### PR TITLE
docs: clarify storage cache file url contract

### DIFF
--- a/crates/guest-download/src/source.rs
+++ b/crates/guest-download/src/source.rs
@@ -26,9 +26,9 @@ static HTTP_AGENT: LazyLock<ureq::Agent> = LazyLock::new(|| {
         .new_agent()
 });
 
-/// Open the archive byte stream. HTTP is the production path today; `file://`
-/// is used by the runner-side storage cache to feed host-staged tarballs that
-/// were pushed into the guest over vsock.
+/// Open the archive byte stream. HTTP/HTTPS URLs use the direct remote-fetch
+/// path; `file://` URLs are the runner storage-cache path for guest-local
+/// tarballs staged over vsock.
 pub(crate) fn open_archive(url: &str) -> Result<ArchiveSource, DownloadError> {
     if let Some(path) = url.strip_prefix("file://") {
         log_info!(LOG_TAG, "Reading local archive");

--- a/crates/guest-download/tests/integration/file_scheme.rs
+++ b/crates/guest-download/tests/integration/file_scheme.rs
@@ -3,7 +3,7 @@ use crate::support::{
 };
 
 // ---------------------------------------------------------------------------
-// file:// scheme — host-staged tarballs (epic #10800)
+// file:// scheme — runner-staged local archives (epic #10800)
 // ---------------------------------------------------------------------------
 
 // Successful file:// extraction: the local tarball is read and its contents are

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -4,10 +4,11 @@
 //! `run_in_sandbox`. For each eligible manifest entry, checks a host-local
 //! cache keyed by `(vasStorageName, vasVersionId)`. On hit, reads the cached
 //! tarball from disk and pushes it into the guest via vsock; on miss,
-//! downloads the archive from R2 into the cache first. Either way, the
-//! entry's `archive_url` is rewritten to
+//! downloads the archive from R2 into the cache first. Once guest staging
+//! succeeds, the entry's `archive_url` is rewritten to
 //! `file:///tmp/vm0-storage-cache/<hash(name)>-<hash(version)>.tar.gz`
-//! so `guest-download` reads from the local stage instead of re-fetching.
+//! so `guest-download` reads the guest-local staged archive instead of
+//! re-fetching.
 //! Keying on both name and version gives same-version entries with different
 //! storage names separate collision-resistant staged filenames in normal
 //! operation, so they do not clobber each other on the guest tmpfs.
@@ -19,9 +20,9 @@
 //! [`CACHE_MAX_SIZE`], the cache fails closed instead of handing the same
 //! inconsistent URL to the guest.
 //!
-//! Merge-order contract: this module produces `file://` URLs, which only
-//! `guest-download` understands after #10805. The PR adding this module
-//! must not merge before #10805 is on `main`.
+//! Runtime contract: `file://` URLs produced here point to guest-local archives
+//! staged under [`GUEST_STAGE_DIR`]. `guest-download` supports that scheme and
+//! treats missing local archives as a broken staging contract.
 
 use std::collections::HashMap;
 use std::io;
@@ -147,8 +148,8 @@ impl GuestWriteLocks {
 /// Populate the runner-side cache for eligible entries in `manifest`.
 ///
 /// Mutates `manifest.storages[i].archive_url` / `manifest.artifacts[i].archive_url`
-/// in place, rewriting them to `file://` URLs pointing at host-staged tarballs
-/// pushed into the guest over vsock.
+/// in place, rewriting them to `file://` URLs pointing at guest-local tarballs
+/// staged over vsock.
 ///
 /// Invariant: only touches entries where `cached == false`, `archive_url.is_some()`,
 /// and both `vas_storage_name` and `vas_version_id` are non-empty. Entries that


### PR DESCRIPTION
## Summary

- replace the stale storage-cache merge-order warning with the current runner/guest `file://` runtime contract
- clarify that `guest-download` treats HTTP/HTTPS as the direct remote-fetch path and `file://` as the runner-staged guest-local archive path
- update the file-scheme integration-test heading to avoid implying guest-download reads host paths

Closes #18650

## Tests

- `rg -n "Merge-order|#10805|production path today|host-staged" crates/runner/src crates/guest-download/src crates/guest-download/tests/integration/file_scheme.rs`
- `rg -n "Merge-order|#10805|production path today" crates/runner crates/guest-download -g '!**/CHANGELOG.md'`
- `git diff --check`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo test --manifest-path crates/Cargo.toml -p guest-download file_scheme`
- pre-commit: `cargo-fmt`, `cargo-clippy`, `cargo-doc`
