### PR TITLE
fix: reject non-ascii authority port digits

### DIFF
--- a/crates/runner/mitm-addon/src/authority_utils.py
+++ b/crates/runner/mitm-addon/src/authority_utils.py
@@ -17,6 +17,7 @@ from url_syntax import ASCII_CONTROL_MAX, ASCII_DELETE
 IPV6_VERSION = 6
 
 _AUTHORITY_PORT_MAX = 65535
+_AUTHORITY_PORT_MAX_TEXT = str(_AUTHORITY_PORT_MAX)
 _PERCENT_ESCAPE_LENGTH = 3
 _HEX_DIGITS = frozenset("0123456789abcdefABCDEF")
 _DEFAULT_SCHEME_PORTS = MappingProxyType({"http": 80, "https": 443})
@@ -90,9 +91,12 @@ def is_default_scheme_port(scheme: str, port: int) -> bool:
 
 
 def parse_authority_port(raw_port: str) -> int:
-    if not raw_port or not raw_port.isdigit():
+    if not raw_port or not all("0" <= char <= "9" for char in raw_port):
         raise ValueError("invalid authority port")
-    port = int(raw_port)
-    if port > _AUTHORITY_PORT_MAX:
+    normalized_port = raw_port.lstrip("0") or "0"
+    if len(normalized_port) > len(_AUTHORITY_PORT_MAX_TEXT) or (
+        len(normalized_port) == len(_AUTHORITY_PORT_MAX_TEXT)
+        and normalized_port > _AUTHORITY_PORT_MAX_TEXT
+    ):
         raise ValueError("authority port out of range")
-    return port
+    return int(normalized_port)

--- a/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
@@ -825,6 +825,25 @@ async def test_rejects_idna_compatibility_host_alias_before_firewall_auth(
         (443, "", "missing_authority", "https://api.github.com/repos"),
         (8443, "", "missing_authority", "https://api.github.com:8443/repos"),
         (443, "api.github.com:bad", "invalid_authority", "https://api.github.com/repos"),
+        (
+            443,
+            "api.github.com:\uff14\uff14\uff13",
+            "invalid_authority",
+            "https://api.github.com/repos",
+        ),
+        (
+            443,
+            "api.github.com:\u0664\u0664\u0663",
+            "invalid_authority",
+            "https://api.github.com/repos",
+        ),
+        (
+            443,
+            "api.github.com:\u0967\u0968\u0969",
+            "invalid_authority",
+            "https://api.github.com/repos",
+        ),
+        (443, "api.github.com:" + ("9" * 128), "invalid_authority", "https://api.github.com/repos"),
         (443, "api.github.com..", "invalid_authority", "https://api.github.com/repos"),
         (443, "api%2egithub.com", "invalid_authority", "https://api.github.com/repos"),
         (443, "b%C3%BCcher.example", "invalid_authority", "https://api.github.com/repos"),
@@ -858,6 +877,12 @@ async def test_rejects_idna_compatibility_host_alias_before_firewall_auth(
         (443, "a\u0663\u0664.example", "invalid_authority", "https://api.github.com/repos"),
         (443, "1\u0663.example", "invalid_authority", "https://api.github.com/repos"),
         (443, "!\u0663!.example", "invalid_authority", "https://api.github.com/repos"),
+        (
+            443,
+            "[2001:db8::1]:\uff14\uff14\uff13",
+            "invalid_authority",
+            "https://api.github.com/repos",
+        ),
         (443, "[::1]junk", "invalid_authority", "https://api.github.com/repos"),
         (443, "[fe80::1%25eth0]", "invalid_authority", "https://api.github.com/repos"),
         (

--- a/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
@@ -934,6 +934,7 @@ async def test_rejects_invalid_host_authority_before_firewall_auth(
     assert flow.metadata["firewall_error"] == expected_error
     assert flow.metadata["original_url"] == expected_original_url
     auth_fetch.assert_not_called()
+    assert "Authorization" not in flow.request.headers
 
 
 @pytest.mark.parametrize(

--- a/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
@@ -292,8 +292,9 @@ async def test_rejects_duplicate_host_authority_before_firewall_auth(
     assert "Authorization" not in flow.request.headers
 
 
+@pytest.mark.parametrize("host_header", ["api.github.com:443", "api.github.com:000443"])
 async def test_accepts_equivalent_host_authority_default_https_port(
-    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers, host_header
 ):
     reg_path = _write_github_firewall_registry(tmp_path)
     flow = real_flow(
@@ -302,7 +303,7 @@ async def test_accepts_equivalent_host_authority_default_https_port(
         host="203.0.113.10",
         sni="api.github.com",
         path="/repos",
-        request_headers=headers(("Host", "api.github.com:443")),
+        request_headers=headers(("Host", host_header)),
     )
 
     with (
@@ -844,6 +845,7 @@ async def test_rejects_idna_compatibility_host_alias_before_firewall_auth(
             "https://api.github.com/repos",
         ),
         (443, "api.github.com:" + ("9" * 128), "invalid_authority", "https://api.github.com/repos"),
+        (443, "api.github.com:00065536", "invalid_authority", "https://api.github.com/repos"),
         (443, "api.github.com..", "invalid_authority", "https://api.github.com/repos"),
         (443, "api%2egithub.com", "invalid_authority", "https://api.github.com/repos"),
         (443, "b%C3%BCcher.example", "invalid_authority", "https://api.github.com/repos"),


### PR DESCRIPTION
## Summary

- restrict MITM authority port parsing to ASCII decimal digits
- avoid converting oversized ASCII digit strings before rejecting out-of-range ports
- add request-hook regression coverage for non-ASCII Host authority port digits

Fixes #18651

## Tests

- `cd crates/runner/mitm-addon && .venv/bin/python -m pytest tests/test_request_handler_authority_validation.py`
- `cd crates/runner/mitm-addon && .venv/bin/ruff check .`
- `cd crates/runner/mitm-addon && .venv/bin/ruff format --check .`
- `cd crates/runner/mitm-addon && .venv/bin/basedpyright -p .`
- `git diff --check`
