### PR TITLE
fix: reap runner child processes on drop cleanup

### DIFF
--- a/crates/runner/src/child_cleanup.rs
+++ b/crates/runner/src/child_cleanup.rs
@@ -71,17 +71,18 @@ pub(crate) fn kill_and_reap_child_on_drop(
 #[cfg(target_os = "linux")]
 mod tests {
     use super::*;
-    use std::path::Path;
     use std::time::Duration;
 
-    fn process_exists(pid: u32) -> bool {
-        Path::new(&format!("/proc/{pid}")).exists()
+    fn process_state(pid: u32) -> Option<char> {
+        let content = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+        let after_comm = content.rsplit_once(')')?.1;
+        after_comm.split_whitespace().next()?.chars().next()
     }
 
     async fn wait_for_process_exit(pid: u32) {
         tokio::time::timeout(Duration::from_secs(2), async {
             loop {
-                if !process_exists(pid) {
+                if process_state(pid).is_none() {
                     break;
                 }
                 tokio::time::sleep(Duration::from_millis(10)).await;
@@ -89,6 +90,21 @@ mod tests {
         })
         .await
         .unwrap_or_else(|_| panic!("timed out waiting for pid {pid} to be reaped"));
+    }
+
+    async fn wait_for_process_state(pid: u32, expected_state: char) {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if process_state(pid) == Some(expected_state) {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .unwrap_or_else(|_| {
+            panic!("timed out waiting for pid {pid} to enter state {expected_state}")
+        });
     }
 
     #[tokio::test]
@@ -112,7 +128,7 @@ mod tests {
         let pid = child.id().unwrap();
         let mut child = Some(child);
 
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        wait_for_process_state(pid, 'Z').await;
         kill_and_reap_child_on_drop("test-exited-child", &mut child);
 
         assert!(child.is_none());

--- a/crates/runner/src/child_cleanup.rs
+++ b/crates/runner/src/child_cleanup.rs
@@ -1,0 +1,121 @@
+use tokio::runtime::Handle;
+use tracing::{debug, warn};
+
+/// Kill a child from a synchronous drop fallback and reap it on the active runtime.
+///
+/// Normal async shutdown paths should still use explicit `wait().await`. This
+/// helper exists for abnormal drop/cancellation fallback paths where awaiting
+/// directly is impossible.
+pub(crate) fn kill_and_reap_child_on_drop(
+    label: &'static str,
+    child: &mut Option<tokio::process::Child>,
+) {
+    let Some(mut child) = child.take() else {
+        return;
+    };
+    let pid = child.id();
+
+    match child.try_wait() {
+        Ok(Some(status)) => {
+            debug!(
+                label,
+                ?pid,
+                code = status.code(),
+                "child already exited during drop cleanup"
+            );
+            return;
+        }
+        Ok(None) => {}
+        Err(error) => {
+            warn!(label, ?pid, error = %error, "failed to check child status during drop cleanup");
+        }
+    }
+
+    if let Err(error) = child.start_kill() {
+        warn!(label, ?pid, error = %error, "failed to kill child during drop cleanup");
+    }
+
+    match child.try_wait() {
+        Ok(Some(status)) => {
+            debug!(
+                label,
+                ?pid,
+                code = status.code(),
+                "child exited during drop cleanup"
+            );
+            return;
+        }
+        Ok(None) => {}
+        Err(error) => {
+            warn!(label, ?pid, error = %error, "failed to recheck child status during drop cleanup");
+        }
+    }
+
+    let Ok(handle) = Handle::try_current() else {
+        warn!(
+            label,
+            ?pid,
+            "cannot spawn child reaper without an active tokio runtime"
+        );
+        return;
+    };
+
+    handle.spawn(async move {
+        if let Err(error) = child.wait().await {
+            warn!(label, ?pid, error = %error, "failed to reap child after drop cleanup");
+        }
+    });
+}
+
+#[cfg(test)]
+#[cfg(target_os = "linux")]
+mod tests {
+    use super::*;
+    use std::path::Path;
+    use std::time::Duration;
+
+    fn process_exists(pid: u32) -> bool {
+        Path::new(&format!("/proc/{pid}")).exists()
+    }
+
+    async fn wait_for_process_exit(pid: u32) {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if !process_exists(pid) {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .unwrap_or_else(|_| panic!("timed out waiting for pid {pid} to be reaped"));
+    }
+
+    #[tokio::test]
+    async fn drop_cleanup_kills_and_reaps_running_child() {
+        let child = tokio::process::Command::new("sleep")
+            .arg("60")
+            .spawn()
+            .unwrap();
+        let pid = child.id().unwrap();
+        let mut child = Some(child);
+
+        kill_and_reap_child_on_drop("test-running-child", &mut child);
+
+        assert!(child.is_none());
+        wait_for_process_exit(pid).await;
+    }
+
+    #[tokio::test]
+    async fn drop_cleanup_reaps_already_exited_child() {
+        let child = tokio::process::Command::new("true").spawn().unwrap();
+        let pid = child.id().unwrap();
+        let mut child = Some(child);
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        kill_and_reap_child_on_drop("test-exited-child", &mut child);
+
+        assert!(child.is_none());
+        wait_for_process_exit(pid).await;
+    }
+}

--- a/crates/runner/src/child_cleanup.rs
+++ b/crates/runner/src/child_cleanup.rs
@@ -71,19 +71,34 @@ pub(crate) fn kill_and_reap_child_on_drop(
 #[cfg(target_os = "linux")]
 mod tests {
     use super::*;
+    use crate::process::read_process_stat;
     use std::time::Duration;
 
-    fn process_state(pid: u32) -> Option<char> {
-        let content = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
-        let after_comm = content.rsplit_once(')')?.1;
-        after_comm.split_whitespace().next()?.chars().next()
+    async fn process_identity(pid: u32) -> Option<(char, u64)> {
+        read_process_stat(pid)
+            .await
+            .map(|stat| (stat.state, stat.starttime))
     }
 
-    async fn wait_for_process_exit(pid: u32) {
+    async fn wait_for_process_starttime(pid: u32) -> u64 {
         tokio::time::timeout(Duration::from_secs(2), async {
             loop {
-                if process_state(pid).is_none() {
-                    break;
+                if let Some((_, starttime)) = process_identity(pid).await {
+                    return starttime;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .unwrap_or_else(|_| panic!("timed out waiting for pid {pid} to appear"))
+    }
+
+    async fn wait_for_process_exit(pid: u32, starttime: u64) {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                match process_identity(pid).await {
+                    Some((_, observed_starttime)) if observed_starttime == starttime => {}
+                    _ => break,
                 }
                 tokio::time::sleep(Duration::from_millis(10)).await;
             }
@@ -92,10 +107,10 @@ mod tests {
         .unwrap_or_else(|_| panic!("timed out waiting for pid {pid} to be reaped"));
     }
 
-    async fn wait_for_process_state(pid: u32, expected_state: char) {
+    async fn wait_for_process_state(pid: u32, starttime: u64, expected_state: char) {
         tokio::time::timeout(Duration::from_secs(2), async {
             loop {
-                if process_state(pid) == Some(expected_state) {
+                if process_identity(pid).await == Some((expected_state, starttime)) {
                     break;
                 }
                 tokio::time::sleep(Duration::from_millis(10)).await;
@@ -114,24 +129,26 @@ mod tests {
             .spawn()
             .unwrap();
         let pid = child.id().unwrap();
+        let starttime = wait_for_process_starttime(pid).await;
         let mut child = Some(child);
 
         kill_and_reap_child_on_drop("test-running-child", &mut child);
 
         assert!(child.is_none());
-        wait_for_process_exit(pid).await;
+        wait_for_process_exit(pid, starttime).await;
     }
 
     #[tokio::test]
     async fn drop_cleanup_reaps_already_exited_child() {
         let child = tokio::process::Command::new("true").spawn().unwrap();
         let pid = child.id().unwrap();
+        let starttime = wait_for_process_starttime(pid).await;
         let mut child = Some(child);
 
-        wait_for_process_state(pid, 'Z').await;
+        wait_for_process_state(pid, starttime, 'Z').await;
         kill_and_reap_child_on_drop("test-exited-child", &mut child);
 
         assert!(child.is_none());
-        wait_for_process_exit(pid).await;
+        wait_for_process_exit(pid, starttime).await;
     }
 }

--- a/crates/runner/src/cmd/build/scripts.rs
+++ b/crates/runner/src/cmd/build/scripts.rs
@@ -91,16 +91,8 @@ pub(super) async fn run_rootfs_script(
         .spawn()
         .map_err(|e| RunnerError::Internal(format!("spawn {label}: {e}")))?;
     let pgid = child.id().map(|pid| nix::unistd::Pid::from_raw(pid as i32));
-    let mut process = RootfsScriptProcess {
-        child: Some(child),
-        pgid,
-    };
-
-    let Some(child) = process.child.as_mut() else {
-        return Err(RunnerError::Internal(
-            "rootfs script child was missing".into(),
-        ));
-    };
+    let mut process = RootfsScriptProcess { child: None, pgid };
+    let child = process.child.insert(child);
     let status = child
         .wait()
         .await

--- a/crates/runner/src/cmd/build/scripts.rs
+++ b/crates/runner/src/cmd/build/scripts.rs
@@ -97,6 +97,7 @@ pub(super) async fn run_rootfs_script(
         .wait()
         .await
         .map_err(|e| RunnerError::Internal(format!("wait for {label}: {e}")))?;
+    process.child = None;
     if status.success() {
         process.pgid = None;
     }

--- a/crates/runner/src/cmd/build/scripts.rs
+++ b/crates/runner/src/cmd/build/scripts.rs
@@ -70,7 +70,7 @@ pub(super) fn rootfs_script_command(script: &Path) -> tokio::process::Command {
 }
 
 struct RootfsScriptProcess {
-    child: tokio::process::Child,
+    child: Option<tokio::process::Child>,
     pgid: Option<nix::unistd::Pid>,
 }
 
@@ -79,6 +79,7 @@ impl Drop for RootfsScriptProcess {
         if let Some(pgid) = self.pgid {
             let _ = nix::sys::signal::killpg(pgid, nix::sys::signal::Signal::SIGKILL);
         }
+        crate::child_cleanup::kill_and_reap_child_on_drop("rootfs script", &mut self.child);
     }
 }
 
@@ -90,10 +91,17 @@ pub(super) async fn run_rootfs_script(
         .spawn()
         .map_err(|e| RunnerError::Internal(format!("spawn {label}: {e}")))?;
     let pgid = child.id().map(|pid| nix::unistd::Pid::from_raw(pid as i32));
-    let mut process = RootfsScriptProcess { child, pgid };
+    let mut process = RootfsScriptProcess {
+        child: Some(child),
+        pgid,
+    };
 
-    let status = process
-        .child
+    let Some(child) = process.child.as_mut() else {
+        return Err(RunnerError::Internal(
+            "rootfs script child was missing".into(),
+        ));
+    };
+    let status = child
         .wait()
         .await
         .map_err(|e| RunnerError::Internal(format!("wait for {label}: {e}")))?;

--- a/crates/runner/src/dns/proxy.rs
+++ b/crates/runner/src/dns/proxy.rs
@@ -6,6 +6,7 @@ use tracing::{info, warn};
 
 use super::log::tail_stderr;
 use super::port::DnsPortReservation;
+use crate::child_cleanup::kill_and_reap_child_on_drop;
 use crate::network_log_drain::NetworkLogDrainProducer;
 use crate::network_log_manager::NetworkLogManager;
 
@@ -22,9 +23,14 @@ impl DnsProxy {
     /// Stop the DNS proxy and wait for cleanup.
     pub async fn stop(mut self) {
         self.cancel.cancel();
-        if let Some(ref mut child) = self.child {
+        let child_reaped = if let Some(ref mut child) = self.child {
             let _ = child.start_kill();
-            let _ = child.wait().await;
+            child.wait().await.is_ok()
+        } else {
+            false
+        };
+        if child_reaped {
+            self.child = None;
         }
         let _ = (&mut self.task).await;
         info!("dns proxy stopped");
@@ -74,13 +80,11 @@ impl DnsProxy {
 impl Drop for DnsProxy {
     /// Kill dnsmasq and abort the log task if `stop()` was never called.
     ///
-    /// Prevents orphaned dnsmasq processes when `run_start()` fails after
-    /// `start_on_reserved_port()` (e.g., live-runner publish error). Harmless
-    /// if `stop()` already ran — `start_kill` on an exited child is a no-op.
+    /// Prevents orphaned dnsmasq processes when shutdown misses the explicit
+    /// async `stop()` path. The cleanup helper also reaps children that already
+    /// exited before drop.
     fn drop(&mut self) {
-        if let Some(ref mut child) = self.child {
-            let _ = child.start_kill();
-        }
+        kill_and_reap_child_on_drop("dnsmasq", &mut self.child);
         self.cancel.cancel();
         self.task.abort();
     }

--- a/crates/runner/src/kmsg_log.rs
+++ b/crates/runner/src/kmsg_log.rs
@@ -82,9 +82,9 @@ impl KmsgHandle {
 impl Drop for KmsgHandle {
     /// Kill dmesg and abort the log task if `stop()` was never called.
     ///
-    /// Prevents a leaked `dmesg -w` process when `run()` returns early
-    /// (e.g., factory creation failure). Harmless if `stop()` already ran —
-    /// `start_kill` on an exited child is a no-op.
+    /// Prevents a leaked `dmesg -w` process when shutdown misses the explicit
+    /// async `stop()` path. The cleanup helper also reaps children that already
+    /// exited before drop.
     fn drop(&mut self) {
         kill_and_reap_child_on_drop("dmesg", &mut self.child);
         self.cancel.cancel();

--- a/crates/runner/src/kmsg_log.rs
+++ b/crates/runner/src/kmsg_log.rs
@@ -36,9 +36,14 @@ impl KmsgHandle {
     /// Stop the kmsg monitor and wait for cleanup.
     pub async fn stop(mut self) {
         self.cancel.cancel();
-        if let Some(ref mut child) = self.child {
+        let child_reaped = if let Some(ref mut child) = self.child {
             let _ = child.start_kill();
-            let _ = child.wait().await;
+            child.wait().await.is_ok()
+        } else {
+            false
+        };
+        if child_reaped {
+            self.child = None;
         }
         let _ = (&mut self.task).await;
         info!("kmsg monitor stopped");

--- a/crates/runner/src/kmsg_log.rs
+++ b/crates/runner/src/kmsg_log.rs
@@ -14,6 +14,7 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
+use crate::child_cleanup::kill_and_reap_child_on_drop;
 use crate::network_log_drain::{
     NetworkLogDrainProducer, NetworkLogDrainRequest, run_drainable_line_reader,
 };
@@ -85,9 +86,7 @@ impl Drop for KmsgHandle {
     /// (e.g., factory creation failure). Harmless if `stop()` already ran —
     /// `start_kill` on an exited child is a no-op.
     fn drop(&mut self) {
-        if let Some(ref mut child) = self.child {
-            let _ = child.start_kill();
-        }
+        kill_and_reap_child_on_drop("dmesg", &mut self.child);
         self.cancel.cancel();
         self.task.abort();
     }

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -1,6 +1,7 @@
 mod active_input;
 mod axiom_layer;
 mod ca;
+mod child_cleanup;
 mod cmd;
 mod config;
 mod deps;

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -1195,10 +1195,7 @@ impl MitmProxy {
 impl Drop for MitmProxy {
     fn drop(&mut self) {
         self.stopping.store(true, Ordering::Release);
-        // Best-effort kill if still running.
-        if let Some(ref mut child) = self.child {
-            let _ = child.start_kill();
-        }
+        crate::child_cleanup::kill_and_reap_child_on_drop("mitmdump", &mut self.child);
     }
 }
 


### PR DESCRIPTION
## Summary

- add a focused runner helper that kills and best-effort reaps `tokio::process::Child` handles from synchronous drop cleanup
- apply the helper to DNS, kmsg, mitmproxy, and rootfs script fallback cleanup paths
- cover the helper with Linux/Tokio process reaping tests while preserving rootfs process-group cancellation behavior

Fixes #18649

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml --all`
- `cargo test --manifest-path crates/Cargo.toml -p runner child_cleanup`
- `cargo test --manifest-path crates/Cargo.toml -p runner run_rootfs_script`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- pre-commit hook: cargo-fmt, cargo-doc, cargo-clippy, commitlint
