### PR TITLE
refactor: remove obsolete firewall registry helpers

### DIFF
--- a/turbo/packages/connectors/src/__tests__/firewall-categories.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-categories.test.ts
@@ -9,6 +9,23 @@ function compareStrings(a: string, b: string): number {
   return a < b ? -1 : a > b ? 1 : 0;
 }
 
+const EXPECTED_CATEGORIZED_CONNECTORS = [
+  "clerk",
+  "cloudflare",
+  "gmail",
+  "google-analytics",
+  "google-calendar",
+  "google-cloud",
+  "google-drive",
+  "google-meet",
+  "google-search-console",
+  "google-sheets",
+  "slack",
+  "stripe",
+  "vercel",
+  "youtube",
+] as const;
+
 const CATEGORIZED_CONNECTORS = Object.entries(
   FIREWALL_PERMISSION_METADATA_SUMMARIES,
 )
@@ -30,9 +47,9 @@ async function loadDetail(type: string) {
 
 describe("firewall categories", () => {
   it("tracks categorized connectors in generated summaries", () => {
-    expect(CATEGORIZED_CONNECTORS.length).toBeGreaterThan(0);
-    expect(CATEGORIZED_CONNECTORS).toContain("gmail");
-    expect(CATEGORIZED_CONNECTORS).toContain("slack");
+    expect(CATEGORIZED_CONNECTORS).toStrictEqual(
+      [...EXPECTED_CATEGORIZED_CONNECTORS].sort(compareStrings),
+    );
   });
 
   it("does not emit categories for selected uncategorized connectors", async () => {

--- a/turbo/packages/connectors/src/__tests__/firewall-categories.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-categories.test.ts
@@ -1,99 +1,110 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
+
 import {
-  getPermissionCategories,
-  getConnectorFirewall,
-  isFirewallConnectorType,
-} from "../firewalls/index";
+  FIREWALL_PERMISSION_METADATA_SUMMARIES,
+  loadFirewallPermissionMetadata,
+} from "../firewall-metadata";
 
-const CATEGORIZED_CONNECTORS = [
-  "clerk",
-  "cloudflare",
-  "google-analytics",
-  "google-calendar",
-  "google-cloud",
-  "google-drive",
-  "google-meet",
-  "google-search-console",
-  "google-sheets",
-  "slack",
-  "gmail",
-  "stripe",
-  "vercel",
-  "youtube",
-] as const;
+function compareStrings(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
 
-function getFirewallPermissionNames(connectorType: string): Set<string> {
-  if (!isFirewallConnectorType(connectorType)) {
-    return new Set();
-  }
-  const config = getConnectorFirewall(connectorType);
-  const names = new Set<string>();
-  for (const api of config.apis) {
-    if (api.permissions) {
-      for (const p of api.permissions) {
-        names.add(p.name);
-      }
-    }
-  }
-  return names;
+const CATEGORIZED_CONNECTORS = Object.entries(
+  FIREWALL_PERMISSION_METADATA_SUMMARIES,
+)
+  .filter(([, summary]) => {
+    return summary.hasCategories;
+  })
+  .map(([type]) => {
+    return type;
+  })
+  .sort(compareStrings);
+
+const UNCATEGORIZED_CONNECTORS = ["linear", "notion"] as const;
+
+async function loadDetail(type: string) {
+  const detail = await loadFirewallPermissionMetadata(type);
+  expect(detail).not.toBeNull();
+  return detail!;
 }
 
 describe("firewall categories", () => {
-  it("should return categories for all categorized connectors", () => {
-    for (const connector of CATEGORIZED_CONNECTORS) {
-      const data = getPermissionCategories(connector);
-      expect(data).not.toBeNull();
-    }
+  it("tracks categorized connectors in generated summaries", () => {
+    expect(CATEGORIZED_CONNECTORS.length).toBeGreaterThan(0);
+    expect(CATEGORIZED_CONNECTORS).toContain("gmail");
+    expect(CATEGORIZED_CONNECTORS).toContain("slack");
   });
 
-  it("should return null for uncategorized connectors", () => {
-    expect(getPermissionCategories("notion")).toBeNull();
-    expect(getPermissionCategories("linear")).toBeNull();
+  it("does not emit categories for selected uncategorized connectors", async () => {
+    for (const connector of UNCATEGORIZED_CONNECTORS) {
+      const summary = FIREWALL_PERMISSION_METADATA_SUMMARIES[connector];
+      const detail = await loadDetail(connector);
+
+      expect(summary.hasCategories).toBe(false);
+      expect(detail.categories).toBeUndefined();
+    }
   });
 
   for (const connector of CATEGORIZED_CONNECTORS) {
     describe(connector, () => {
-      it("should have a category for every permission in the firewall config", () => {
-        const permNames = getFirewallPermissionNames(connector);
-        const data = getPermissionCategories(connector)!;
-        const categorized = new Set(Object.keys(data.categories));
+      it("has category metadata", async () => {
+        const detail = await loadDetail(connector);
 
-        const missing = [...permNames].filter((name) => {
-          return !categorized.has(name);
-        });
+        expect(detail.categories).toBeDefined();
+      });
+
+      it("has a category for every metadata permission", async () => {
+        const detail = await loadDetail(connector);
+        const categories = detail.categories!;
+        const categorized = new Set(Object.keys(categories.categories));
+
+        const missing = detail.permissions
+          .map((permission) => {
+            return permission.name;
+          })
+          .filter((name) => {
+            return !categorized.has(name);
+          });
         expect(missing).toEqual([]);
       });
 
-      it("should not have orphan keys that are not in the firewall config", () => {
-        const permNames = getFirewallPermissionNames(connector);
-        const data = getPermissionCategories(connector)!;
+      it("does not have orphan category keys", async () => {
+        const detail = await loadDetail(connector);
+        const categories = detail.categories!;
+        const permissionNames = new Set(
+          detail.permissions.map((permission) => {
+            return permission.name;
+          }),
+        );
 
-        const orphans = Object.keys(data.categories).filter((name) => {
-          return !permNames.has(name);
+        const orphans = Object.keys(categories.categories).filter((name) => {
+          return !permissionNames.has(name);
         });
         expect(orphans).toEqual([]);
       });
 
-      it("should have displayOrder covering every category used", () => {
-        const data = getPermissionCategories(connector)!;
-        const usedCategories = new Set(Object.values(data.categories));
-        const orderedCategories = new Set(data.displayOrder);
+      it("has displayOrder covering every category used", async () => {
+        const detail = await loadDetail(connector);
+        const categories = detail.categories!;
+        const usedCategories = new Set(Object.values(categories.categories));
+        const orderedCategories = new Set(categories.displayOrder);
 
-        const missing = [...usedCategories].filter((cat) => {
-          return !orderedCategories.has(cat);
+        const missing = [...usedCategories].filter((category) => {
+          return !orderedCategories.has(category);
         });
         expect(missing).toEqual([]);
       });
 
-      it("should have at least one permission in each displayOrder category", () => {
-        const data = getPermissionCategories(connector)!;
+      it("has at least one permission in each displayOrder category", async () => {
+        const detail = await loadDetail(connector);
+        const categories = detail.categories!;
         const categoryCounts = new Map<string, number>();
-        for (const cat of Object.values(data.categories)) {
-          categoryCounts.set(cat, (categoryCounts.get(cat) ?? 0) + 1);
+        for (const category of Object.values(categories.categories)) {
+          categoryCounts.set(category, (categoryCounts.get(category) ?? 0) + 1);
         }
 
-        for (const cat of data.displayOrder) {
-          expect(categoryCounts.get(cat) ?? 0).toBeGreaterThan(0);
+        for (const category of categories.displayOrder) {
+          expect(categoryCounts.get(category) ?? 0).toBeGreaterThan(0);
         }
       });
     });

--- a/turbo/packages/connectors/src/__tests__/firewall-categories.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-categories.test.ts
@@ -44,10 +44,14 @@ const CATEGORIZED_CONNECTORS = Object.entries(
 
 const UNCATEGORIZED_CONNECTORS = ["linear", "notion"] as const;
 
-async function loadDetail(type: string) {
+async function loadDetail(
+  type: string,
+): Promise<FirewallPermissionDetailMetadata> {
   const detail = await loadFirewallPermissionMetadata(type);
-  expect(detail).not.toBeNull();
-  return detail!;
+  if (detail === null) {
+    throw new Error(`Expected firewall metadata detail for ${type}`);
+  }
+  return detail;
 }
 
 async function loadCategorizedDetail(type: string): Promise<{

--- a/turbo/packages/connectors/src/__tests__/firewall-categories.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-categories.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it } from "vitest";
 
 import {
   FIREWALL_PERMISSION_METADATA_SUMMARIES,
+  getFirewallPermissionSummary,
   loadFirewallPermissionMetadata,
+} from "../firewall-metadata";
+import type {
+  FirewallPermissionCategoryMetadata,
+  FirewallPermissionDetailMetadata,
 } from "../firewall-metadata";
 
 function compareStrings(a: string, b: string): number {
@@ -45,6 +50,17 @@ async function loadDetail(type: string) {
   return detail!;
 }
 
+async function loadCategorizedDetail(type: string): Promise<{
+  detail: FirewallPermissionDetailMetadata;
+  categories: FirewallPermissionCategoryMetadata;
+}> {
+  const detail = await loadDetail(type);
+  if (detail.categories === undefined) {
+    throw new Error(`Expected firewall category metadata for ${type}`);
+  }
+  return { detail, categories: detail.categories };
+}
+
 describe("firewall categories", () => {
   it("tracks categorized connectors in generated summaries", () => {
     expect(CATEGORIZED_CONNECTORS).toStrictEqual(
@@ -54,7 +70,10 @@ describe("firewall categories", () => {
 
   it("does not emit categories for selected uncategorized connectors", async () => {
     for (const connector of UNCATEGORIZED_CONNECTORS) {
-      const summary = FIREWALL_PERMISSION_METADATA_SUMMARIES[connector];
+      const summary = getFirewallPermissionSummary(connector);
+      if (summary === null) {
+        throw new Error(`Expected firewall metadata summary for ${connector}`);
+      }
       const detail = await loadDetail(connector);
 
       expect(summary.hasCategories).toBe(false);
@@ -65,14 +84,13 @@ describe("firewall categories", () => {
   for (const connector of CATEGORIZED_CONNECTORS) {
     describe(connector, () => {
       it("has category metadata", async () => {
-        const detail = await loadDetail(connector);
+        const { categories } = await loadCategorizedDetail(connector);
 
-        expect(detail.categories).toBeDefined();
+        expect(categories).toBeDefined();
       });
 
       it("has a category for every metadata permission", async () => {
-        const detail = await loadDetail(connector);
-        const categories = detail.categories!;
+        const { detail, categories } = await loadCategorizedDetail(connector);
         const categorized = new Set(Object.keys(categories.categories));
 
         const missing = detail.permissions
@@ -86,8 +104,7 @@ describe("firewall categories", () => {
       });
 
       it("does not have orphan category keys", async () => {
-        const detail = await loadDetail(connector);
-        const categories = detail.categories!;
+        const { detail, categories } = await loadCategorizedDetail(connector);
         const permissionNames = new Set(
           detail.permissions.map((permission) => {
             return permission.name;
@@ -101,8 +118,7 @@ describe("firewall categories", () => {
       });
 
       it("has displayOrder covering every category used", async () => {
-        const detail = await loadDetail(connector);
-        const categories = detail.categories!;
+        const { categories } = await loadCategorizedDetail(connector);
         const usedCategories = new Set(Object.values(categories.categories));
         const orderedCategories = new Set(categories.displayOrder);
 
@@ -113,8 +129,7 @@ describe("firewall categories", () => {
       });
 
       it("has at least one permission in each displayOrder category", async () => {
-        const detail = await loadDetail(connector);
-        const categories = detail.categories!;
+        const { categories } = await loadCategorizedDetail(connector);
         const categoryCounts = new Map<string, number>();
         for (const category of Object.values(categories.categories)) {
           categoryCounts.set(category, (categoryCounts.get(category) ?? 0) + 1);

--- a/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
@@ -39,8 +39,6 @@ import {
   BILLABLE_CONNECTORS,
   getAllBuiltinConnectorHosts,
   getDefaultFirewallPolicies,
-  getPermissionCategories,
-  groupPermissionsByCategory,
   resolveFirewallPolicies,
   type FirewallConnectorType,
 } from "../firewalls";
@@ -640,7 +638,6 @@ describe("firewall metadata", () => {
         label: connectorLabel(type),
         hasPermissions: permissions.length > 0,
         permissionCount: permissions.length,
-        hasCategories: getPermissionCategories(type) !== null,
       });
     }
   });
@@ -696,35 +693,44 @@ describe("firewall metadata", () => {
     expect(getFirewallExecutionMetadata("cloudinary")).toBeNull();
   });
 
-  it("keeps category metadata synchronized with runtime categories", async () => {
+  it("keeps category summary flags synchronized with detail metadata", async () => {
     for (const [type] of runtimeEntries()) {
       const detail = await loadFirewallPermissionMetadata(type);
       expect(detail).not.toBeNull();
-      const categories = getPermissionCategories(type);
-      if (!categories) {
-        expect(detail!.categories).toBeUndefined();
-        continue;
-      }
-
-      expect(detail!.categories).toStrictEqual({
-        categories: categories.categories,
-        displayOrder: [...categories.displayOrder],
-      });
+      const summary = getFirewallPermissionSummary(type);
+      expect(summary).not.toBeNull();
+      expect(summary!.hasCategories).toBe(detail!.categories !== undefined);
     }
   });
 
-  it("groups metadata permissions like runtime categories", async () => {
-    for (const [type, firewall] of runtimeEntries()) {
+  it("groups metadata permissions by generated category metadata", async () => {
+    for (const [type] of runtimeEntries()) {
       const detail = await loadFirewallPermissionMetadata(type);
       expect(detail).not.toBeNull();
-      expect(
-        groupFirewallMetadataPermissionsByCategory(
-          detail!.permissions,
-          detail!,
-        ),
-      ).toStrictEqual(
-        groupPermissionsByCategory(collectRuntimePermissions(firewall), type),
+      const grouped = groupFirewallMetadataPermissionsByCategory(
+        detail!.permissions,
+        detail!,
       );
+      const categories = detail!.categories;
+      if (categories === undefined) {
+        expect(grouped).toBeNull();
+        continue;
+      }
+
+      const expected = categories.displayOrder
+        .map((category) => {
+          return {
+            category,
+            permissions: detail!.permissions.filter((permission) => {
+              return categories.categories[permission.name] === category;
+            }),
+          };
+        })
+        .filter((group) => {
+          return group.permissions.length > 0;
+        });
+
+      expect(grouped).toStrictEqual(expected);
     }
   });
 

--- a/turbo/packages/connectors/src/__tests__/firewall-runtime-loader.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-runtime-loader.test.ts
@@ -207,6 +207,18 @@ describe("firewall runtime loader", () => {
     );
   });
 
+  it("keeps metadata category helpers out of the eager runtime entrypoint", () => {
+    expect(defaultFirewallEntrypoint).not.toHaveProperty(
+      "getBuiltinConnectorDisplayName",
+    );
+    expect(defaultFirewallEntrypoint).not.toHaveProperty(
+      "getPermissionCategories",
+    );
+    expect(defaultFirewallEntrypoint).not.toHaveProperty(
+      "groupPermissionsByCategory",
+    );
+  });
+
   it("does not statically import the eager registry or connector runtime modules", () => {
     const runtimeSource = fs.readFileSync(
       path.resolve(import.meta.dirname, "../firewall-runtime.ts"),

--- a/turbo/packages/connectors/src/__tests__/firewall-runtime-loader.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-runtime-loader.test.ts
@@ -199,6 +199,33 @@ function exportedIdentifierNames(source: string): string[] {
   return names;
 }
 
+function exportedIdentifierNamesFromModule(
+  source: string,
+  moduleSpecifier: string,
+): string[] {
+  const names: string[] = [];
+  for (const statement of parseSource(source).statements) {
+    if (!ts.isExportDeclaration(statement)) {
+      continue;
+    }
+
+    if (stringLiteralText(statement.moduleSpecifier) !== moduleSpecifier) {
+      continue;
+    }
+
+    const clause = statement.exportClause;
+    if (clause === undefined || ts.isNamespaceExport(clause)) {
+      names.push("*");
+      continue;
+    }
+
+    for (const element of clause.elements) {
+      names.push(element.name.text);
+    }
+  }
+  return names;
+}
+
 describe("firewall runtime loader", () => {
   it("keeps the runtime loader behind an explicit package subpath", () => {
     const packageJson = JSON.parse(
@@ -277,6 +304,18 @@ describe("firewall runtime loader", () => {
         return removedExports.includes(name);
       }),
     ).toStrictEqual([]);
+    expect(
+      exportedIdentifierNamesFromModule(
+        defaultEntrypointSource,
+        "../firewall-metadata",
+      ).sort(compareStrings),
+    ).toStrictEqual(
+      [
+        "FirewallPermissionGrant",
+        "FirewallPermissionGrantAction",
+        "permissionGrantsToFirewallPolicies",
+      ].sort(compareStrings),
+    );
     expect(defaultFirewallEntrypoint).not.toHaveProperty(
       "getBuiltinConnectorDisplayName",
     );

--- a/turbo/packages/connectors/src/__tests__/firewall-runtime-loader.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-runtime-loader.test.ts
@@ -148,6 +148,57 @@ function moduleSpecifiers(source: string): string[] {
   ];
 }
 
+function hasExportModifier(node: ts.Node): boolean {
+  if (!ts.canHaveModifiers(node)) {
+    return false;
+  }
+  return (
+    ts.getModifiers(node)?.some((modifier) => {
+      return modifier.kind === ts.SyntaxKind.ExportKeyword;
+    }) ?? false
+  );
+}
+
+function exportedIdentifierNames(source: string): string[] {
+  const names: string[] = [];
+  for (const statement of parseSource(source).statements) {
+    if (ts.isExportDeclaration(statement)) {
+      const clause = statement.exportClause;
+      if (clause !== undefined && ts.isNamedExports(clause)) {
+        for (const element of clause.elements) {
+          names.push(element.name.text);
+        }
+      }
+      continue;
+    }
+
+    if (ts.isFunctionDeclaration(statement) && hasExportModifier(statement)) {
+      if (statement.name !== undefined) {
+        names.push(statement.name.text);
+      }
+      continue;
+    }
+
+    if (
+      (ts.isInterfaceDeclaration(statement) ||
+        ts.isTypeAliasDeclaration(statement)) &&
+      hasExportModifier(statement)
+    ) {
+      names.push(statement.name.text);
+      continue;
+    }
+
+    if (ts.isVariableStatement(statement) && hasExportModifier(statement)) {
+      for (const declaration of statement.declarationList.declarations) {
+        if (ts.isIdentifier(declaration.name)) {
+          names.push(declaration.name.text);
+        }
+      }
+    }
+  }
+  return names;
+}
+
 describe("firewall runtime loader", () => {
   it("keeps the runtime loader behind an explicit package subpath", () => {
     const packageJson = JSON.parse(
@@ -208,6 +259,24 @@ describe("firewall runtime loader", () => {
   });
 
   it("keeps metadata category helpers out of the eager runtime entrypoint", () => {
+    const defaultEntrypointSource = fs.readFileSync(
+      path.resolve(import.meta.dirname, "../firewalls/index.ts"),
+      "utf-8",
+    );
+    const removedExports = [
+      "ConnectorCategories",
+      "CONNECTOR_CATEGORIES",
+      "getBuiltinConnectorDisplayName",
+      "getPermissionCategories",
+      "groupPermissionsByCategory",
+      "PermissionGroup",
+    ];
+
+    expect(
+      exportedIdentifierNames(defaultEntrypointSource).filter((name) => {
+        return removedExports.includes(name);
+      }),
+    ).toStrictEqual([]);
     expect(defaultFirewallEntrypoint).not.toHaveProperty(
       "getBuiltinConnectorDisplayName",
     );

--- a/turbo/packages/connectors/src/firewalls/index.ts
+++ b/turbo/packages/connectors/src/firewalls/index.ts
@@ -11,32 +11,15 @@ import {
   type FirewallPolicyValue,
 } from "../firewall-types";
 import type { ConnectorType } from "../connectors";
-import { CONNECTOR_TYPES } from "../connectors";
 import { expandFirewallPlaceholders } from "../firewall-placeholder-expansion";
-import {
-  clerkDefaultAllowed,
-  clerkCategories,
-  clerkCategoryOrder,
-  clerkFirewall,
-} from "./clerk.generated";
+import { clerkDefaultAllowed, clerkFirewall } from "./clerk.generated";
 import {
   gmailDefaultAllowed,
-  gmailCategories,
-  gmailCategoryOrder,
   gmailDefaultUnknownPolicy,
   gmailFirewall,
 } from "./gmail.generated";
-import {
-  slackDefaultAllowed,
-  slackCategories,
-  slackCategoryOrder,
-  slackFirewall,
-} from "./slack.generated";
-import {
-  vercelCategories,
-  vercelCategoryOrder,
-  vercelFirewall,
-} from "./vercel.generated";
+import { slackDefaultAllowed, slackFirewall } from "./slack.generated";
+import { vercelFirewall } from "./vercel.generated";
 import { agentmailFirewall } from "./agentmail.generated";
 import { amplitudeFirewall } from "./amplitude.generated";
 import { amadeusFirewall } from "./amadeus.generated";
@@ -89,8 +72,6 @@ import { clearbitFirewall } from "./clearbit.generated";
 import { clickupFirewall } from "./clickup.generated";
 import { closeFirewall } from "./close.generated";
 import {
-  cloudflareCategories,
-  cloudflareCategoryOrder,
   cloudflareDefaultAllowed,
   cloudflareDefaultUnknownPolicy,
   cloudflareFirewall,
@@ -137,22 +118,16 @@ import { githubFirewall } from "./github.generated";
 import { gitlabFirewall } from "./gitlab.generated";
 import { googleAdsFirewall } from "./google-ads.generated";
 import {
-  googleAnalyticsCategories,
-  googleAnalyticsCategoryOrder,
   googleAnalyticsDefaultAllowed,
   googleAnalyticsDefaultUnknownPolicy,
   googleAnalyticsFirewall,
 } from "./google-analytics.generated";
 import {
-  googleCalendarCategories,
-  googleCalendarCategoryOrder,
   googleCalendarDefaultAllowed,
   googleCalendarDefaultUnknownPolicy,
   googleCalendarFirewall,
 } from "./google-calendar.generated";
 import {
-  googleCloudCategories,
-  googleCloudCategoryOrder,
   googleCloudDefaultAllowed,
   googleCloudDefaultUnknownPolicy,
   googleCloudFirewall,
@@ -164,29 +139,21 @@ import {
   googleDocsFirewall,
 } from "./google-docs.generated";
 import {
-  googleDriveCategories,
-  googleDriveCategoryOrder,
   googleDriveDefaultAllowed,
   googleDriveDefaultUnknownPolicy,
   googleDriveFirewall,
 } from "./google-drive.generated";
 import {
-  googleMeetCategories,
-  googleMeetCategoryOrder,
   googleMeetDefaultAllowed,
   googleMeetDefaultUnknownPolicy,
   googleMeetFirewall,
 } from "./google-meet.generated";
 import {
-  googleSearchConsoleCategories,
-  googleSearchConsoleCategoryOrder,
   googleSearchConsoleDefaultAllowed,
   googleSearchConsoleDefaultUnknownPolicy,
   googleSearchConsoleFirewall,
 } from "./google-search-console.generated";
 import {
-  googleSheetsCategories,
-  googleSheetsCategoryOrder,
   googleSheetsDefaultAllowed,
   googleSheetsDefaultUnknownPolicy,
   googleSheetsFirewall,
@@ -314,12 +281,7 @@ import { spotifyFirewall } from "./spotify.generated";
 import { stravaFirewall } from "./strava.generated";
 import { strapiFirewall } from "./strapi.generated";
 import { streakFirewall } from "./streak.generated";
-import {
-  stripeCategories,
-  stripeCategoryOrder,
-  stripeDefaultAllowed,
-  stripeFirewall,
-} from "./stripe.generated";
+import { stripeDefaultAllowed, stripeFirewall } from "./stripe.generated";
 import { supabaseFirewall } from "./supabase.generated";
 import { supadataFirewall } from "./supadata.generated";
 import { supermemoryFirewall } from "./supermemory.generated";
@@ -344,8 +306,6 @@ import { wrikeFirewall } from "./wrike.generated";
 import { xFirewall } from "./x.generated";
 import { xeroFirewall } from "./xero.generated";
 import {
-  youtubeCategories,
-  youtubeCategoryOrder,
   youtubeDefaultAllowed,
   youtubeDefaultUnknownPolicy,
   youtubeFirewall,
@@ -373,20 +333,6 @@ export {
   type FirewallPermissionGrantAction,
 } from "../firewall-metadata";
 export * from "../firewall-types";
-
-// ── Permission categories ───────────────────────────────────────────────
-
-export interface ConnectorCategories {
-  /** Map of permission name to category label */
-  categories: Record<string, string>;
-  /** Display order of categories (first = top of list) */
-  displayOrder: readonly string[];
-}
-
-export interface PermissionGroup<T extends { name: string }> {
-  category: string;
-  permissions: T[];
-}
 
 function defineConnectorFirewalls<
   const T extends Record<string, FirewallConfig>,
@@ -703,97 +649,6 @@ export type PermissionNamesOf<T extends FirewallConfig> =
       : never
     : never;
 
-const CONNECTOR_CATEGORIES: Partial<
-  Record<FirewallConnectorType, ConnectorCategories>
-> = {
-  clerk: { categories: clerkCategories, displayOrder: clerkCategoryOrder },
-  cloudflare: {
-    categories: cloudflareCategories,
-    displayOrder: cloudflareCategoryOrder,
-  },
-  "google-cloud": {
-    categories: googleCloudCategories,
-    displayOrder: googleCloudCategoryOrder,
-  },
-  "google-analytics": {
-    categories: googleAnalyticsCategories,
-    displayOrder: googleAnalyticsCategoryOrder,
-  },
-  "google-calendar": {
-    categories: googleCalendarCategories,
-    displayOrder: googleCalendarCategoryOrder,
-  },
-  "google-drive": {
-    categories: googleDriveCategories,
-    displayOrder: googleDriveCategoryOrder,
-  },
-  "google-meet": {
-    categories: googleMeetCategories,
-    displayOrder: googleMeetCategoryOrder,
-  },
-  "google-search-console": {
-    categories: googleSearchConsoleCategories,
-    displayOrder: googleSearchConsoleCategoryOrder,
-  },
-  "google-sheets": {
-    categories: googleSheetsCategories,
-    displayOrder: googleSheetsCategoryOrder,
-  },
-  gmail: { categories: gmailCategories, displayOrder: gmailCategoryOrder },
-  slack: { categories: slackCategories, displayOrder: slackCategoryOrder },
-  stripe: { categories: stripeCategories, displayOrder: stripeCategoryOrder },
-  vercel: { categories: vercelCategories, displayOrder: vercelCategoryOrder },
-  youtube: {
-    categories: youtubeCategories,
-    displayOrder: youtubeCategoryOrder,
-  },
-};
-
-/** Get the category data for a connector type (null if uncategorized). */
-export function getPermissionCategories(
-  type: string,
-): ConnectorCategories | null {
-  return CONNECTOR_CATEGORIES[type as FirewallConnectorType] ?? null;
-}
-
-/**
- * Group permissions by their category for a given connector type.
- * Returns null when the connector has no category data (caller should
- * fall back to a flat list).
- */
-export function groupPermissionsByCategory<T extends { name: string }>(
-  permissions: T[],
-  connectorType: string,
-): PermissionGroup<T>[] | null {
-  const categoryData = getPermissionCategories(connectorType);
-  if (!categoryData) {
-    return null;
-  }
-
-  const grouped = new Map<string, T[]>();
-  for (const category of categoryData.displayOrder) {
-    grouped.set(category, []);
-  }
-
-  for (const perm of permissions) {
-    const category = categoryData.categories[perm.name];
-    if (category) {
-      const list = grouped.get(category);
-      if (list) {
-        list.push(perm);
-      }
-    }
-  }
-
-  return [...grouped.entries()]
-    .filter(([, perms]) => {
-      return perms.length > 0;
-    })
-    .map(([category, perms]) => {
-      return { category, permissions: perms };
-    });
-}
-
 /**
  * Connector types that do not have a firewall config.
  *
@@ -1009,15 +864,4 @@ export function getAllBuiltinConnectorHosts(): Map<
     }
   }
   return hosts;
-}
-
-/**
- * Human-readable display name for a built-in connector type
- * (e.g. "GitHub", "Google Drive"). Falls back to the type slug if
- * `CONNECTOR_TYPES` has no entry.
- */
-export function getBuiltinConnectorDisplayName(
-  type: FirewallConnectorType,
-): string {
-  return CONNECTOR_TYPES[type]?.label ?? type;
 }


### PR DESCRIPTION
## Summary

- remove unused metadata-style helper exports from the eager runtime firewall registry
- update category tests to validate generated firewall metadata directly
- add a regression assertion that the eager runtime entrypoint does not re-export the removed metadata helpers

Closes #18656.

## Tests

- pnpm -F @vm0/firewalls-generator generate
- pnpm -F @vm0/connectors exec vitest run src/__tests__/firewall-categories.test.ts src/__tests__/firewall-metadata.test.ts src/__tests__/firewall-runtime-loader.test.ts
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/connectors lint
- git diff --check
- pre-commit hook: pnpm check-types
