### PR TITLE
fix: preserve codex app-server failure diagnostics

### DIFF
--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -1395,15 +1395,67 @@ mod tests {
 
     #[test]
     fn specific_codex_failure_diagnostic_survives_later_generic_event() {
+        for generic_message in [
+            "turn failed",
+            "Turn failed.",
+            "Unknown error",
+            "codex error",
+        ] {
+            assert_eq!(
+                select_failure_diagnostic(
+                    Some(&CliFailureDiagnostic {
+                        message: "You've hit your usage limit.".to_string(),
+                        source: FailureDetailSource::CodexJsonl,
+                        failure_reason: None,
+                    }),
+                    CliFailureDiagnostic {
+                        message: generic_message.to_string(),
+                        source: FailureDetailSource::CodexJsonl,
+                        failure_reason: None,
+                    },
+                ),
+                None,
+                "generic message should not replace specific diagnostic: {generic_message}"
+            );
+        }
+    }
+
+    #[test]
+    fn generic_codex_failure_diagnostic_replaces_prior_generic_event() {
+        let selected = select_failure_diagnostic(
+            Some(&CliFailureDiagnostic {
+                message: "error".to_string(),
+                source: FailureDetailSource::CodexJsonl,
+                failure_reason: None,
+            }),
+            CliFailureDiagnostic {
+                message: "Unknown error".to_string(),
+                source: FailureDetailSource::CodexJsonl,
+                failure_reason: None,
+            },
+        );
+
+        assert_eq!(
+            selected,
+            Some(CliFailureDiagnostic {
+                message: "Unknown error".to_string(),
+                source: FailureDetailSource::CodexJsonl,
+                failure_reason: None,
+            })
+        );
+    }
+
+    #[test]
+    fn generic_codex_failure_diagnostic_does_not_replace_specific_claude_result() {
         assert_eq!(
             select_failure_diagnostic(
                 Some(&CliFailureDiagnostic {
-                    message: "You've hit your usage limit.".to_string(),
-                    source: FailureDetailSource::CodexJsonl,
+                    message: "Claude result failure".to_string(),
+                    source: FailureDetailSource::ClaudeResult,
                     failure_reason: None,
                 }),
                 CliFailureDiagnostic {
-                    message: "turn failed".to_string(),
+                    message: "Unknown error".to_string(),
                     source: FailureDetailSource::CodexJsonl,
                     failure_reason: None,
                 },

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -155,7 +155,7 @@ fn extract_codex_failure_diagnostic(event: &Value) -> Option<CodexFailureDiagnos
             let error = event.get("error");
             Some(CodexFailureDiagnostic {
                 event_type: "turn.completed",
-                message: codex_first_error_message([turn_error, error])
+                message: codex_best_error_message([turn_error, error])
                     .unwrap_or_else(|| format!("turn {status}")),
                 failure_reason: codex_event_failure_reason_from_errors(event, [turn_error, error]),
             })
@@ -225,8 +225,20 @@ fn codex_turn_failed_message(error: Option<&Value>, turn_error: Option<&Value>) 
     }
 }
 
-fn codex_first_error_message<const N: usize>(errors: [Option<&Value>; N]) -> Option<String> {
-    errors.into_iter().find_map(codex_error_message)
+fn codex_best_error_message<const N: usize>(errors: [Option<&Value>; N]) -> Option<String> {
+    let mut first_generic_message = None;
+    for error in errors {
+        let Some(message) = codex_error_message(error) else {
+            continue;
+        };
+        if !is_generic_codex_failure_diagnostic(&message) {
+            return Some(message);
+        }
+        if first_generic_message.is_none() {
+            first_generic_message = Some(message);
+        }
+    }
+    first_generic_message
 }
 
 fn codex_error_message(error: Option<&Value>) -> Option<String> {
@@ -1450,6 +1462,27 @@ mod tests {
             "turn": {
                 "status": "failed",
                 "error": {}
+            }
+        });
+
+        assert_eq!(
+            masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(CodexFailureDiagnostic {
+                event_type: "turn.completed",
+                message: "top-level completed failure".to_string(),
+                failure_reason: None,
+            })
+        );
+    }
+
+    #[test]
+    fn codex_failed_turn_completed_generic_nested_error_uses_specific_top_level_error() {
+        let event = serde_json::json!({
+            "type": "turn.completed",
+            "error": {"message": "top-level completed failure"},
+            "turn": {
+                "status": "failed",
+                "error": {"message": "turn failed"}
             }
         });
 

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -206,14 +206,15 @@ fn codex_structured_turn_error(event: &Value) -> Option<&Value> {
 
 fn codex_turn_failed_message(error: Option<&Value>, turn_error: Option<&Value>) -> String {
     let top_level_message = codex_error_message(error);
+    let top_level_primary_message = codex_error_primary_message(error);
+    let top_level_is_generic = top_level_primary_message
+        .as_deref()
+        .or(top_level_message.as_deref())
+        .is_some_and(is_generic_codex_failure_diagnostic);
     let turn_error_message = codex_error_message(turn_error);
 
     match (top_level_message, turn_error_message) {
-        (Some(message), Some(turn_error_message))
-            if is_generic_codex_failure_diagnostic(&message) =>
-        {
-            turn_error_message
-        }
+        (Some(_), Some(turn_error_message)) if top_level_is_generic => turn_error_message,
         (Some(message), _) => message,
         (None, Some(turn_error_message)) => turn_error_message,
         (None, None) => "turn failed".into(),
@@ -236,6 +237,16 @@ fn codex_error_message(error: Option<&Value>) -> Option<String> {
         .or_else(|| error.get("additionalDetails"))
         .and_then(Value::as_str);
     combined_message_and_details(message, details)
+}
+
+fn codex_error_primary_message(error: Option<&Value>) -> Option<String> {
+    let error = error?;
+    raw_message_from_field(Some(error)).or_else(|| {
+        error
+            .get("message")
+            .and_then(Value::as_str)
+            .and_then(trimmed_message)
+    })
 }
 
 fn codex_error_failure_reason(error: Option<&Value>) -> Option<FailureReason> {
@@ -1016,6 +1027,32 @@ mod tests {
                 "top-level error: {top_level_error}"
             );
         }
+    }
+
+    #[test]
+    fn codex_turn_failed_uses_nested_message_when_top_level_object_message_is_generic() {
+        let event = serde_json::json!({
+            "type": "turn.failed",
+            "error": {
+                "message": "turn failed",
+                "additionalDetails": "wrapper-level detail"
+            },
+            "turn": {
+                "error": {
+                    "message": "nested turn failure",
+                    "additionalDetails": "quota exhausted"
+                }
+            }
+        });
+
+        assert_eq!(
+            masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(CodexFailureDiagnostic {
+                event_type: "turn.failed",
+                message: "nested turn failure (quota exhausted)".to_string(),
+                failure_reason: None,
+            })
+        );
     }
 
     #[test]

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -114,8 +114,12 @@ pub(crate) fn masked_claude_failure_diagnostic(
     })
 }
 
-pub(crate) fn is_generic_codex_failure_diagnostic(message: &str) -> bool {
-    matches!(message.trim(), "error" | "turn failed" | "turn interrupted")
+pub fn is_generic_codex_failure_diagnostic(message: &str) -> bool {
+    let message = message.trim().to_ascii_lowercase();
+    matches!(
+        message.as_str(),
+        "error" | "turn failed" | "turn interrupted" | "unknown error" | "codex error"
+    )
 }
 
 pub fn is_codex_model_capacity_message(message: &str) -> bool {
@@ -138,19 +142,22 @@ fn extract_codex_failure_diagnostic(event: &Value) -> Option<CodexFailureDiagnos
         }
         "turn.failed" => {
             let error = event.get("error");
+            let turn_error = codex_structured_turn_error(event);
             Some(CodexFailureDiagnostic {
                 event_type: "turn.failed",
-                message: codex_error_message(error).unwrap_or_else(|| "turn failed".into()),
-                failure_reason: codex_event_failure_reason(event, error),
+                message: codex_turn_failed_message(error, turn_error),
+                failure_reason: codex_event_failure_reason_from_errors(event, [turn_error, error]),
             })
         }
         "turn.completed" => {
             let status = codex_turn_completed_failure_status(event)?;
-            let error = event.pointer("/turn/error").or_else(|| event.get("error"));
+            let turn_error = codex_structured_turn_error(event);
+            let error = event.get("error");
             Some(CodexFailureDiagnostic {
                 event_type: "turn.completed",
-                message: codex_error_message(error).unwrap_or_else(|| format!("turn {status}")),
-                failure_reason: codex_event_failure_reason(event, error),
+                message: codex_first_error_message([turn_error, error])
+                    .unwrap_or_else(|| format!("turn {status}")),
+                failure_reason: codex_event_failure_reason_from_errors(event, [turn_error, error]),
             })
         }
         _ => None,
@@ -191,6 +198,32 @@ fn codex_turn_completed_failure_status(event: &Value) -> Option<&'static str> {
     }
 }
 
+fn codex_structured_turn_error(event: &Value) -> Option<&Value> {
+    event
+        .pointer("/turn/error")
+        .filter(|error| !error.is_null())
+}
+
+fn codex_turn_failed_message(error: Option<&Value>, turn_error: Option<&Value>) -> String {
+    let top_level_message = codex_error_message(error);
+    let turn_error_message = codex_error_message(turn_error);
+
+    match (top_level_message, turn_error_message) {
+        (Some(message), Some(turn_error_message))
+            if is_generic_codex_failure_diagnostic(&message) =>
+        {
+            turn_error_message
+        }
+        (Some(message), _) => message,
+        (None, Some(turn_error_message)) => turn_error_message,
+        (None, None) => "turn failed".into(),
+    }
+}
+
+fn codex_first_error_message<const N: usize>(errors: [Option<&Value>; N]) -> Option<String> {
+    errors.into_iter().find_map(codex_error_message)
+}
+
 fn codex_error_message(error: Option<&Value>) -> Option<String> {
     let error = error?;
     if let Some(message) = raw_message_from_field(Some(error)) {
@@ -198,7 +231,10 @@ fn codex_error_message(error: Option<&Value>) -> Option<String> {
     }
 
     let message = error.get("message").and_then(Value::as_str);
-    let details = error.get("additional_details").and_then(Value::as_str);
+    let details = error
+        .get("additional_details")
+        .or_else(|| error.get("additionalDetails"))
+        .and_then(Value::as_str);
     combined_message_and_details(message, details)
 }
 
@@ -213,6 +249,9 @@ fn codex_error_failure_reason(error: Option<&Value>) -> Option<FailureReason> {
     {
         return Some(FailureReason::ReconnectRequired);
     }
+    if let Some(failure_reason) = codex_error_info_failure_reason(error) {
+        return Some(failure_reason);
+    }
     if codex_error_message(Some(error))
         .as_deref()
         .is_some_and(is_codex_model_capacity_message)
@@ -223,7 +262,40 @@ fn codex_error_failure_reason(error: Option<&Value>) -> Option<FailureReason> {
 }
 
 fn codex_event_failure_reason(event: &Value, error: Option<&Value>) -> Option<FailureReason> {
-    codex_error_failure_reason(error).or_else(|| codex_error_failure_reason(Some(event)))
+    codex_event_failure_reason_from_errors(event, [error])
+}
+
+fn codex_event_failure_reason_from_errors<const N: usize>(
+    event: &Value,
+    errors: [Option<&Value>; N],
+) -> Option<FailureReason> {
+    for error in errors.into_iter().flatten() {
+        if let Some(failure_reason) = codex_error_failure_reason(Some(error)) {
+            return Some(failure_reason);
+        }
+    }
+
+    codex_error_failure_reason(Some(event))
+}
+
+fn codex_error_info_failure_reason(error: &Value) -> Option<FailureReason> {
+    match codex_error_info_variant(error)? {
+        "serverOverloaded" => Some(FailureReason::ProviderOverloaded),
+        "usageLimitExceeded" => Some(FailureReason::UsageLimit),
+        _ => None,
+    }
+}
+
+fn codex_error_info_variant(error: &Value) -> Option<&str> {
+    let error_info = error
+        .get("codex_error_info")
+        .or_else(|| error.get("codexErrorInfo"))?;
+
+    match error_info {
+        Value::String(variant) => Some(variant.as_str()),
+        Value::Object(object) if object.len() == 1 => object.keys().next().map(String::as_str),
+        _ => None,
+    }
 }
 
 fn codex_refresh_error_code(value: &Value) -> Option<&str> {
@@ -855,6 +927,141 @@ mod tests {
     }
 
     #[test]
+    fn codex_generic_failure_diagnostic_matcher_is_case_insensitive() {
+        for message in [
+            "error",
+            "Turn failed",
+            " turn interrupted ",
+            "UNKNOWN ERROR",
+            "codex error",
+        ] {
+            assert!(
+                is_generic_codex_failure_diagnostic(message),
+                "message should be generic: {message}"
+            );
+        }
+
+        assert!(!is_generic_codex_failure_diagnostic(
+            "Selected model is at capacity. Please try a different model."
+        ));
+    }
+
+    #[test]
+    fn codex_turn_failed_uses_nested_turn_error_for_failure_reason() {
+        let event = serde_json::json!({
+            "type": "turn.failed",
+            "error": "turn failed",
+            "turn": {
+                "error": {
+                    "code": "invalid_api_key",
+                    "message": "Incorrect API key provided"
+                }
+            }
+        });
+
+        assert_eq!(
+            masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(CodexFailureDiagnostic {
+                event_type: "turn.failed",
+                message: "Incorrect API key provided".to_string(),
+                failure_reason: Some(FailureReason::InvalidApiKey),
+            })
+        );
+    }
+
+    #[test]
+    fn codex_turn_failed_keeps_specific_top_level_message_with_nested_reason() {
+        let event = serde_json::json!({
+            "type": "turn.failed",
+            "error": "request failed before shutdown",
+            "turn": {
+                "error": {
+                    "code": "invalid_api_key",
+                    "message": "Incorrect API key provided"
+                }
+            }
+        });
+
+        assert_eq!(
+            masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(CodexFailureDiagnostic {
+                event_type: "turn.failed",
+                message: "request failed before shutdown".to_string(),
+                failure_reason: Some(FailureReason::InvalidApiKey),
+            })
+        );
+    }
+
+    #[test]
+    fn codex_turn_failed_uses_nested_message_when_top_level_is_generic() {
+        for top_level_error in ["turn failed", "Unknown error", "codex error"] {
+            let event = serde_json::json!({
+                "type": "turn.failed",
+                "error": top_level_error,
+                "turn": {
+                    "error": {
+                        "message": "nested turn failure",
+                        "additionalDetails": "quota exhausted"
+                    }
+                }
+            });
+
+            assert_eq!(
+                masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+                Some(CodexFailureDiagnostic {
+                    event_type: "turn.failed",
+                    message: "nested turn failure (quota exhausted)".to_string(),
+                    failure_reason: None,
+                }),
+                "top-level error: {top_level_error}"
+            );
+        }
+    }
+
+    #[test]
+    fn codex_turn_failed_uses_nested_message_when_top_level_is_missing() {
+        let event = serde_json::json!({
+            "type": "turn.failed",
+            "turn": {
+                "error": {
+                    "message": "nested turn failure",
+                    "additionalDetails": "quota exhausted"
+                }
+            }
+        });
+
+        assert_eq!(
+            masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(CodexFailureDiagnostic {
+                event_type: "turn.failed",
+                message: "nested turn failure (quota exhausted)".to_string(),
+                failure_reason: None,
+            })
+        );
+    }
+
+    #[test]
+    fn codex_turn_failed_null_nested_turn_error_uses_top_level_error() {
+        let event = serde_json::json!({
+            "type": "turn.failed",
+            "error": {
+                "code": "invalid_api_key",
+                "message": "Incorrect API key provided"
+            },
+            "turn": {"error": null}
+        });
+
+        assert_eq!(
+            masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(CodexFailureDiagnostic {
+                event_type: "turn.failed",
+                message: "Incorrect API key provided".to_string(),
+                failure_reason: Some(FailureReason::InvalidApiKey),
+            })
+        );
+    }
+
+    #[test]
     fn codex_turn_failed_model_capacity_yields_failure_reason() {
         let event = serde_json::json!({
             "type": "turn.failed",
@@ -869,6 +1076,90 @@ mod tests {
                 event_type: "turn.failed",
                 message: "Selected model is at capacity. Please try a different model.".to_string(),
                 failure_reason: Some(FailureReason::ProviderOverloaded),
+            })
+        );
+    }
+
+    #[test]
+    fn codex_error_info_server_overloaded_yields_failure_reason() {
+        let event = serde_json::json!({
+            "type": "turn.failed",
+            "error": {
+                "message": "turn failed from server",
+                "codex_error_info": "serverOverloaded"
+            }
+        });
+
+        assert_eq!(
+            masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(CodexFailureDiagnostic {
+                event_type: "turn.failed",
+                message: "turn failed from server".to_string(),
+                failure_reason: Some(FailureReason::ProviderOverloaded),
+            })
+        );
+    }
+
+    #[test]
+    fn codex_error_info_usage_limit_yields_failure_reason() {
+        let event = serde_json::json!({
+            "type": "turn.failed",
+            "error": {
+                "message": "turn failed from server",
+                "codexErrorInfo": "usageLimitExceeded"
+            }
+        });
+
+        assert_eq!(
+            masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(CodexFailureDiagnostic {
+                event_type: "turn.failed",
+                message: "turn failed from server".to_string(),
+                failure_reason: Some(FailureReason::UsageLimit),
+            })
+        );
+    }
+
+    #[test]
+    fn codex_error_info_object_variant_yields_failure_reason() {
+        let event = serde_json::json!({
+            "type": "turn.failed",
+            "error": {
+                "message": "turn failed from server",
+                "codexErrorInfo": {
+                    "serverOverloaded": {
+                        "httpStatusCode": 529
+                    }
+                }
+            }
+        });
+
+        assert_eq!(
+            masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(CodexFailureDiagnostic {
+                event_type: "turn.failed",
+                message: "turn failed from server".to_string(),
+                failure_reason: Some(FailureReason::ProviderOverloaded),
+            })
+        );
+    }
+
+    #[test]
+    fn codex_error_info_unknown_object_variant_remains_unclassified() {
+        let event = serde_json::json!({
+            "type": "turn.failed",
+            "error": {
+                "message": "turn failed from server",
+                "codexErrorInfo": {"badRequest": {}}
+            }
+        });
+
+        assert_eq!(
+            masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(CodexFailureDiagnostic {
+                event_type: "turn.failed",
+                message: "turn failed from server".to_string(),
+                failure_reason: None,
             })
         );
     }
@@ -951,6 +1242,26 @@ mod tests {
     }
 
     #[test]
+    fn codex_turn_failed_appends_camel_case_additional_details() {
+        let event = serde_json::json!({
+            "type": "turn.failed",
+            "error": {
+                "message": "turn failed from server",
+                "additionalDetails": "rate limit exceeded"
+            }
+        });
+
+        assert_eq!(
+            masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(CodexFailureDiagnostic {
+                event_type: "turn.failed",
+                message: "turn failed from server (rate limit exceeded)".to_string(),
+                failure_reason: None,
+            })
+        );
+    }
+
+    #[test]
     fn codex_turn_failed_legacy_string_error_yields_failure_diagnostic() {
         let event = serde_json::json!({
             "type": "turn.failed",
@@ -962,6 +1273,23 @@ mod tests {
             Some(CodexFailureDiagnostic {
                 event_type: "turn.failed",
                 message: "legacy turn failure".to_string(),
+                failure_reason: None,
+            })
+        );
+    }
+
+    #[test]
+    fn codex_turn_failed_error_string_invalid_api_key_remains_unclassified() {
+        let event = serde_json::json!({
+            "type": "turn.failed",
+            "error": "invalid_api_key"
+        });
+
+        assert_eq!(
+            masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(CodexFailureDiagnostic {
+                event_type: "turn.failed",
+                message: "invalid_api_key".to_string(),
                 failure_reason: None,
             })
         );
@@ -1019,6 +1347,27 @@ mod tests {
             Some(CodexFailureDiagnostic {
                 event_type: "turn.completed",
                 message: "failed TurnCompleted reason".to_string(),
+                failure_reason: None,
+            })
+        );
+    }
+
+    #[test]
+    fn codex_failed_turn_completed_empty_nested_error_uses_top_level_error() {
+        let event = serde_json::json!({
+            "type": "turn.completed",
+            "error": {"message": "top-level completed failure"},
+            "turn": {
+                "status": "failed",
+                "error": {}
+            }
+        });
+
+        assert_eq!(
+            masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(CodexFailureDiagnostic {
+                event_type: "turn.completed",
+                message: "top-level completed failure".to_string(),
                 failure_reason: None,
             })
         );

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -207,14 +207,14 @@ fn codex_structured_turn_error(event: &Value) -> Option<&Value> {
 fn codex_turn_failed_message(error: Option<&Value>, turn_error: Option<&Value>) -> String {
     let top_level_message = codex_error_message(error);
     let top_level_primary_message = codex_error_primary_message(error);
-    let top_level_is_generic = top_level_primary_message
+    let top_level_should_yield = top_level_primary_message
         .as_deref()
-        .or(top_level_message.as_deref())
-        .is_some_and(is_generic_codex_failure_diagnostic);
+        .map(is_generic_codex_failure_diagnostic)
+        .unwrap_or(true);
     let turn_error_message = codex_error_message(turn_error);
 
     match (top_level_message, turn_error_message) {
-        (Some(_), Some(turn_error_message)) if top_level_is_generic => turn_error_message,
+        (Some(_), Some(turn_error_message)) if top_level_should_yield => turn_error_message,
         (Some(message), _) => message,
         (None, Some(turn_error_message)) => turn_error_message,
         (None, None) => "turn failed".into(),
@@ -1035,6 +1035,31 @@ mod tests {
             "type": "turn.failed",
             "error": {
                 "message": "turn failed",
+                "additionalDetails": "wrapper-level detail"
+            },
+            "turn": {
+                "error": {
+                    "message": "nested turn failure",
+                    "additionalDetails": "quota exhausted"
+                }
+            }
+        });
+
+        assert_eq!(
+            masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(CodexFailureDiagnostic {
+                event_type: "turn.failed",
+                message: "nested turn failure (quota exhausted)".to_string(),
+                failure_reason: None,
+            })
+        );
+    }
+
+    #[test]
+    fn codex_turn_failed_uses_nested_message_when_top_level_object_message_is_absent() {
+        let event = serde_json::json!({
+            "type": "turn.failed",
+            "error": {
                 "additionalDetails": "wrapper-level detail"
             },
             "turn": {

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -116,7 +116,7 @@ pub(crate) fn masked_claude_failure_diagnostic(
 
 pub fn is_generic_codex_failure_diagnostic(message: &str) -> bool {
     let message = message.trim().to_ascii_lowercase();
-    let message = message.trim_end_matches(['.', ':', '!', '?']);
+    let message = message.trim_end_matches(['.', ':', '!', '?']).trim_end();
     matches!(
         message,
         "error" | "turn failed" | "turn interrupted" | "unknown error" | "codex error"
@@ -959,8 +959,10 @@ mod tests {
         for message in [
             "error",
             "error:",
+            "error :",
             "Turn failed",
             "Turn failed.",
+            "Turn failed .",
             " turn interrupted ",
             "UNKNOWN ERROR",
             "unknown error!",

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -116,8 +116,9 @@ pub(crate) fn masked_claude_failure_diagnostic(
 
 pub fn is_generic_codex_failure_diagnostic(message: &str) -> bool {
     let message = message.trim().to_ascii_lowercase();
+    let message = message.trim_end_matches(['.', ':', '!', '?']);
     matches!(
-        message.as_str(),
+        message,
         "error" | "turn failed" | "turn interrupted" | "unknown error" | "codex error"
     )
 }
@@ -957,10 +958,14 @@ mod tests {
     fn codex_generic_failure_diagnostic_matcher_is_case_insensitive() {
         for message in [
             "error",
+            "error:",
             "Turn failed",
+            "Turn failed.",
             " turn interrupted ",
             "UNKNOWN ERROR",
+            "unknown error!",
             "codex error",
+            "codex error?",
         ] {
             assert!(
                 is_generic_codex_failure_diagnostic(message),
@@ -1021,7 +1026,12 @@ mod tests {
 
     #[test]
     fn codex_turn_failed_uses_nested_message_when_top_level_is_generic() {
-        for top_level_error in ["turn failed", "Unknown error", "codex error"] {
+        for top_level_error in [
+            "turn failed",
+            "Turn failed.",
+            "Unknown error",
+            "codex error",
+        ] {
             let event = serde_json::json!({
                 "type": "turn.failed",
                 "error": top_level_error,

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -207,11 +207,15 @@ fn codex_structured_turn_error(event: &Value) -> Option<&Value> {
 fn codex_turn_failed_message(error: Option<&Value>, turn_error: Option<&Value>) -> String {
     let top_level_message = codex_error_message(error);
     let top_level_primary_message = codex_error_primary_message(error);
+    let turn_error_message = codex_error_message(turn_error);
+    let turn_error_is_specific = turn_error_message
+        .as_deref()
+        .is_some_and(|message| !is_generic_codex_failure_diagnostic(message));
     let top_level_should_yield = top_level_primary_message
         .as_deref()
         .map(is_generic_codex_failure_diagnostic)
-        .unwrap_or(true);
-    let turn_error_message = codex_error_message(turn_error);
+        .unwrap_or(true)
+        && turn_error_is_specific;
 
     match (top_level_message, turn_error_message) {
         (Some(_), Some(turn_error_message)) if top_level_should_yield => turn_error_message,
@@ -1075,6 +1079,30 @@ mod tests {
             Some(CodexFailureDiagnostic {
                 event_type: "turn.failed",
                 message: "nested turn failure (quota exhausted)".to_string(),
+                failure_reason: None,
+            })
+        );
+    }
+
+    #[test]
+    fn codex_turn_failed_keeps_top_level_details_when_nested_message_is_generic() {
+        let event = serde_json::json!({
+            "type": "turn.failed",
+            "error": {
+                "additionalDetails": "wrapper-level detail"
+            },
+            "turn": {
+                "error": {
+                    "message": "turn failed"
+                }
+            }
+        });
+
+        assert_eq!(
+            masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(CodexFailureDiagnostic {
+                event_type: "turn.failed",
+                message: "wrapper-level detail".to_string(),
                 failure_reason: None,
             })
         );

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -6,6 +6,7 @@ use guest_agent::cli;
 use guest_agent::complete;
 use guest_agent::control;
 use guest_agent::env;
+use guest_agent::events;
 use guest_agent::heartbeat;
 use guest_agent::http::HttpClient;
 use guest_agent::masker;
@@ -754,7 +755,7 @@ fn cli_failure_message(
 }
 
 fn is_generic_stdout_failure_diagnostic(message: &str) -> bool {
-    matches!(message.trim(), "error" | "turn failed" | "turn interrupted")
+    events::is_generic_codex_failure_diagnostic(message)
 }
 
 fn truncate_cli_stderr_line(line: &str) -> std::borrow::Cow<'_, str> {
@@ -1229,11 +1230,17 @@ mod tests {
     #[test]
     fn cli_failure_message_uses_stderr_over_generic_codex_failure_diagnostic() {
         let stderr_lines = vec!["specific stderr failure".to_string()];
-        let diagnostic = cli_diagnostic("turn failed", FailureDetailSource::CodexJsonl);
-        let msg = cli_failure_message(1, &stderr_lines, Some(&diagnostic));
+        for diagnostic_message in ["turn failed", "Unknown error", "codex error"] {
+            let diagnostic = cli_diagnostic(diagnostic_message, FailureDetailSource::CodexJsonl);
+            let msg = cli_failure_message(1, &stderr_lines, Some(&diagnostic));
 
-        assert_eq!(msg.source, FailureDetailSource::Stderr);
-        assert_eq!(msg.message, "specific stderr failure");
+            assert_eq!(
+                msg.source,
+                FailureDetailSource::Stderr,
+                "diagnostic message: {diagnostic_message}"
+            );
+            assert_eq!(msg.message, "specific stderr failure");
+        }
     }
 
     #[test]

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -708,7 +708,7 @@ fn cli_failure_message(
         } else {
             Some((message, diagnostic.source, diagnostic.failure_reason))
         }
-    }) && (!is_generic_stdout_failure_diagnostic(message) || stderr_lines.is_empty())
+    }) && (!is_generic_stdout_failure_diagnostic(source, message) || stderr_lines.is_empty())
     {
         return CliFailureMessage {
             message: message.to_string(),
@@ -754,8 +754,12 @@ fn cli_failure_message(
     }
 }
 
-fn is_generic_stdout_failure_diagnostic(message: &str) -> bool {
-    events::is_generic_codex_failure_diagnostic(message)
+fn is_generic_stdout_failure_diagnostic(source: FailureDetailSource, message: &str) -> bool {
+    if source == FailureDetailSource::CodexJsonl {
+        return events::is_generic_codex_failure_diagnostic(message);
+    }
+
+    matches!(message.trim(), "error" | "turn failed" | "turn interrupted")
 }
 
 fn truncate_cli_stderr_line(line: &str) -> std::borrow::Cow<'_, str> {
@@ -1321,6 +1325,16 @@ mod tests {
 
         assert_eq!(msg.source, FailureDetailSource::Stderr);
         assert_eq!(msg.message, "specific stderr failure");
+    }
+
+    #[test]
+    fn cli_failure_message_does_not_apply_codex_generic_messages_to_claude_result() {
+        let stderr_lines = vec!["background task noise".to_string()];
+        let diagnostic = cli_diagnostic("Unknown error", FailureDetailSource::ClaudeResult);
+        let msg = cli_failure_message(1, &stderr_lines, Some(&diagnostic));
+
+        assert_eq!(msg.source, FailureDetailSource::ClaudeResult);
+        assert_eq!(msg.message, "Unknown error");
     }
 
     #[test]

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -1234,7 +1234,12 @@ mod tests {
     #[test]
     fn cli_failure_message_uses_stderr_over_generic_codex_failure_diagnostic() {
         let stderr_lines = vec!["specific stderr failure".to_string()];
-        for diagnostic_message in ["turn failed", "Unknown error", "codex error"] {
+        for diagnostic_message in [
+            "turn failed",
+            "Turn failed.",
+            "Unknown error",
+            "codex error",
+        ] {
             let diagnostic = cli_diagnostic(diagnostic_message, FailureDetailSource::CodexJsonl);
             let msg = cli_failure_message(1, &stderr_lines, Some(&diagnostic));
 


### PR DESCRIPTION
## Summary

- preserve nested Codex `turn.error` diagnostics for `turn.failed` and failed `turn.completed` events
- support `additionalDetails` and `codexErrorInfo` alongside existing snake_case fields
- map known Codex error info variants to existing vm0 failure reasons while leaving unknown variants unclassified
- reuse the Codex generic failure diagnostic matcher for CLI failure message selection

Closes #18663.

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent codex`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent cli_failure`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets -- -D warnings`
