### PR TITLE
fix: remove presentation card theme picker

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
@@ -297,52 +297,6 @@ export const setTemplateCardThemeId$ = command(
   },
 );
 
-export type TemplateCardThemePopoverSide = "bottom" | "left" | "right";
-export type TemplateCardThemePopoverAlign = "end" | "start";
-export interface TemplateCardThemePopoverPlacement {
-  readonly align: TemplateCardThemePopoverAlign;
-  readonly alignOffset: number;
-  readonly side: TemplateCardThemePopoverSide;
-}
-
-const internalTemplateCardThemePopoverPlacementBySlug$ = state<
-  Readonly<Record<string, TemplateCardThemePopoverPlacement>>
->({});
-export const templateCardThemePopoverPlacementBySlug$ = computed((get) => {
-  return get(internalTemplateCardThemePopoverPlacementBySlug$);
-});
-export const setTemplateCardThemePopoverPlacement$ = command(
-  (
-    { get, set },
-    slug: string,
-    placement: TemplateCardThemePopoverPlacement,
-  ) => {
-    const current = get(internalTemplateCardThemePopoverPlacementBySlug$);
-    const previous = current[slug];
-    if (
-      previous?.align === placement.align &&
-      previous.alignOffset === placement.alignOffset &&
-      previous.side === placement.side
-    ) {
-      return;
-    }
-    set(internalTemplateCardThemePopoverPlacementBySlug$, {
-      ...current,
-      [slug]: placement,
-    });
-  },
-);
-
-const internalTemplateCardThemePopoverOpenSlug$ = state<string | null>(null);
-export const templateCardThemePopoverOpenSlug$ = computed((get) => {
-  return get(internalTemplateCardThemePopoverOpenSlug$);
-});
-export const setTemplateCardThemePopoverOpenSlug$ = command(
-  ({ set }, slug: string | null) => {
-    set(internalTemplateCardThemePopoverOpenSlug$, slug);
-  },
-);
-
 interface TemplateDetailHtmlPreviewState {
   readonly slug: string;
   readonly embedUrl: string;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -33,8 +33,8 @@ import { zeroClaudeCodeDeviceAuthContract } from "@vm0/api-contracts/contracts/z
 import { zeroCodexDeviceAuthContract } from "@vm0/api-contracts/contracts/zero-codex-device-auth";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { createDeferredPromise, jsonParseOr } from "../../../signals/utils.ts";
-import { localStorageSignals } from "../../../signals/external/local-storage.ts";
+import { createDeferredPromise } from "../../../signals/utils.ts";
+import { templateCardThemeIdBySlug$ } from "../../../signals/zero-page/zero-chat-composer.ts";
 import {
   click,
   detachedSetupPage,
@@ -48,10 +48,6 @@ import {
 } from "./chat-test-helpers.ts";
 
 const context = testContext();
-const { get$: presentationTemplateThemeIdBySlugRaw$ } = localStorageSignals(
-  "presentationTemplateThemeIdBySlug",
-);
-
 const AGENT_ID = "e0000000-0000-4000-a000-000000000010";
 const OTHER_AGENT_ID = "e0000000-0000-4000-a000-000000000011";
 const THREAD_ID = "thread-model-template-1";
@@ -1724,7 +1720,7 @@ describe("chat composer templates", () => {
     }
   });
 
-  it("uses the presentation card theme picker for template selection", async () => {
+  it("uses the presentation detail theme for template selection", async () => {
     const user = userEvent.setup({ delay: null });
     const template = PRESENTATION_TEMPLATE_PICKER_ITEMS.find((item) => {
       return item.slug !== PRESENTATION_TEMPLATE_PICKER_ITEMS[0]?.slug;
@@ -1757,35 +1753,9 @@ describe("chat composer templates", () => {
       }),
     );
     await fill(screen.getByLabelText("Search templates"), template.title);
-    await user.click(
-      screen.getByLabelText(`Change theme for ${template.title}`),
-    );
-    await user.click(
-      await screen.findByLabelText(
-        `Select card theme Prism for ${template.title}`,
-      ),
-    );
     expect(
-      screen.getByLabelText(`Select card theme Prism for ${template.title}`),
-    ).toHaveAttribute("aria-pressed", "true");
-    const prismCardPreview = template.cardPreviewImagesByTheme?.prism;
-    if (!prismCardPreview) {
-      throw new Error("Prism card preview not found");
-    }
-    await waitFor(() => {
-      expect(
-        screen.getByTestId(`${template.title} card image preview`),
-      ).toHaveAttribute(
-        "src",
-        r2ImageTransformUrl(prismCardPreview, { width: 480, height: 270 }),
-      );
-    });
-    expect(
-      jsonParseOr<Record<string, string>>(
-        context.store.get(presentationTemplateThemeIdBySlugRaw$) ?? "{}",
-        {},
-      ),
-    ).toMatchObject({ [template.slug]: "prism" });
+      screen.queryByLabelText(`Change theme for ${template.title}`),
+    ).not.toBeInTheDocument();
 
     await user.click(
       screen.getByLabelText(`Preview ${template.title} at current slide`),
@@ -1798,9 +1768,20 @@ describe("chat composer templates", () => {
         }),
       ).toBeInTheDocument();
     });
+    await user.click(
+      within(templateDialog).getByLabelText("Select style Prism"),
+    );
     expect(
       within(templateDialog).getByLabelText("Select style Prism"),
     ).toHaveAttribute("aria-pressed", "true");
+    expect(
+      context.store.get(templateCardThemeIdBySlug$)[template.slug],
+    ).toBeUndefined();
+
+    const prismCardPreview = template.cardPreviewImagesByTheme?.prism;
+    if (!prismCardPreview) {
+      throw new Error("Prism card preview not found");
+    }
     expect(
       within(templateDialog).getByTestId(
         `${template.title} detail image preview`,
@@ -1810,33 +1791,38 @@ describe("chat composer templates", () => {
       r2ImageTransformUrl(prismCardPreview, { width: 480, height: 270 }),
     );
 
-    const templateButton = queryAllByRoleFast("button", templateDialog).find(
-      (candidate) => {
-        return (
-          candidate.textContent?.replace(/\s+/g, " ").trim() === "Template"
-        );
-      },
-    );
-    if (!templateButton) {
-      throw new Error("Template button not found");
-    }
-    await user.click(templateButton);
-
     await user.click(
-      screen.getByLabelText(`Change theme for ${template.title}`),
-    );
-    expect(
-      screen.getByLabelText(`Select card theme Prism for ${template.title}`),
-    ).toHaveAttribute("aria-pressed", "true");
-
-    await user.click(
-      screen.getByLabelText(`Select template ${template.title}`),
+      within(templateDialog).getByLabelText(
+        `Select template ${template.title}`,
+      ),
     );
     await waitFor(() => {
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
       expect(
         screen.getByLabelText(`Remove template ${template.title}`),
       ).toBeInTheDocument();
+    });
+    expect(context.store.get(templateCardThemeIdBySlug$)).toMatchObject({
+      [template.slug]: "prism",
+    });
+
+    await user.click(
+      screen.getByLabelText(`Preview template ${template.title}`),
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${template.title} card image preview`),
+      ).toHaveAttribute(
+        "src",
+        r2ImageTransformUrl(prismCardPreview, { width: 480, height: 270 }),
+      );
+    });
+    expect(
+      screen.queryByLabelText(`Change theme for ${template.title}`),
+    ).not.toBeInTheDocument();
+    await user.click(screen.getByLabelText("Close"));
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     });
 
     await sendMessageInUI(
@@ -1847,50 +1833,6 @@ describe("chat composer templates", () => {
     await waitFor(() => {
       expect(selectedColorSystemId).toBe("color-system:prism");
     });
-  });
-
-  it("opens the presentation theme page from the card theme trigger on mobile", async () => {
-    context.mocks.browser.matchMedia((query) => {
-      return query === "(max-width: 639px)";
-    });
-    const user = userEvent.setup({ delay: null });
-    const template = PRESENTATION_TEMPLATE_PICKER_ITEMS.find((item) => {
-      return item.slug !== PRESENTATION_TEMPLATE_PICKER_ITEMS[0]?.slug;
-    });
-    if (template === undefined) {
-      throw new Error("Second presentation template not found");
-    }
-    mockChatLifecycle(context, { threadId: THREAD_ID });
-
-    detachedSetupPage({
-      context,
-      path: `/chats/${THREAD_ID}`,
-      featureSwitches: {
-        [FeatureSwitchKey.ChatTemplatePicker]: true,
-      },
-    });
-
-    click(
-      await waitFor(() => {
-        return screen.getByLabelText("Template");
-      }),
-    );
-    await fill(screen.getByLabelText("Search templates"), template.title);
-    await user.click(
-      screen.getByLabelText(`Change theme for ${template.title}`),
-    );
-
-    const templateDialog = screen.getByRole("dialog");
-    await waitFor(() => {
-      expect(
-        within(templateDialog).getByRole("heading", {
-          name: `Template / ${template.title}`,
-        }),
-      ).toBeInTheDocument();
-    });
-    expect(
-      screen.queryByLabelText(`Select card theme Prism for ${template.title}`),
-    ).not.toBeInTheDocument();
   });
 
   it("selects presentation templates with the default card theme", async () => {
@@ -1917,10 +1859,7 @@ describe("chat composer templates", () => {
     );
     await fill(screen.getByLabelText("Search templates"), template.title);
     expect(
-      screen.getByLabelText(`Change theme for ${template.title}`),
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByLabelText(`Select card theme Prism for ${template.title}`),
+      screen.queryByLabelText(`Change theme for ${template.title}`),
     ).not.toBeInTheDocument();
 
     click(screen.getByLabelText(`Preview ${template.title} at current slide`));
@@ -1956,8 +1895,8 @@ describe("chat composer templates", () => {
     click(templateButton);
 
     expect(
-      screen.getByLabelText(`Change theme for ${template.title}`),
-    ).toBeInTheDocument();
+      screen.queryByLabelText(`Change theme for ${template.title}`),
+    ).not.toBeInTheDocument();
 
     click(screen.getByLabelText(`Select template ${template.title}`));
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -18,7 +18,6 @@ import { ensurePushSubscription$ } from "../../lib/push-notifications.ts";
 import {
   IconAlertTriangle,
   IconArrowUp,
-  IconChevronDown,
   IconColorSwatch,
   IconDeviceDesktop,
   IconDownload,
@@ -181,15 +180,10 @@ import {
   setTemplateCardLoadedHtmlFrameUrl$,
   templateCardThemeIdBySlug$,
   setTemplateCardThemeId$,
-  templateCardThemePopoverPlacementBySlug$,
-  setTemplateCardThemePopoverPlacement$,
-  templateCardThemePopoverOpenSlug$,
-  setTemplateCardThemePopoverOpenSlug$,
   templateCardHtmlPreview$,
   setTemplateCardHtmlPreview$,
   templateCardDefaultHtmlPreviews$,
   setTemplateCardDefaultHtmlPreview$,
-  type TemplateCardThemePopoverPlacement,
   type TemplateCardHtmlPreviewState,
   templateDetailHtmlPreview$,
   setTemplateDetailHtmlPreview$,
@@ -3101,6 +3095,7 @@ function TemplatePreviewPage({
   const setDetailPreview = useSet(setTemplateDetailHtmlPreview$);
   const themeIdBySlug = useGet(templateDetailThemeIdBySlug$);
   const setThemeId = useSet(setTemplateDetailThemeId$);
+  const setCardThemeId = useSet(setTemplateCardThemeId$);
   const slideIndexBySlug = useGet(templateDetailSlideIndexBySlug$);
   const setSlideIndex = useSet(setTemplateDetailSlideIndex$);
   const selectedThemeId =
@@ -3540,6 +3535,7 @@ function TemplatePreviewPage({
               aria-label={`Select template ${item.title}`}
               className="mt-4 h-12 w-full rounded-lg bg-primary px-4 text-sm font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
               onClick={() => {
+                setCardThemeId(item.slug, selectedTheme.id);
                 onSelect(
                   item,
                   presentationTemplateColorSystemId(selectedTheme.id),
@@ -3552,307 +3548,6 @@ function TemplatePreviewPage({
         </div>
       </div>
     </>
-  );
-}
-
-function presentationTemplateCardThemeSwatches(
-  item: PresentationTemplateItem,
-  theme: PresentationTemplateThemeOption,
-): readonly { readonly color: string; readonly id: string }[] {
-  if (theme.group === "single-accent") {
-    return presentationTemplateThemeAccentSwatches(item, theme);
-  }
-  return presentationTemplateThemePreviewSwatches(theme);
-}
-
-const PRESENTATION_TEMPLATE_CARD_THEME_POPOVER_GAP = 4;
-const PRESENTATION_TEMPLATE_CARD_THEME_POPOVER_HEIGHT = 228;
-const PRESENTATION_TEMPLATE_CARD_THEME_POPOVER_WIDTH = 232;
-const PRESENTATION_TEMPLATE_CARD_THEME_POPOVER_MARGIN = 12;
-const PRESENTATION_TEMPLATE_GRID_SCROLL_SELECTOR =
-  "[data-presentation-template-grid-scroll]";
-
-function presentationTemplateGridScrollElement(
-  slug: string,
-): HTMLElement | undefined {
-  if (typeof document === "undefined") {
-    return undefined;
-  }
-  for (const candidate of document.querySelectorAll(
-    "[data-template-theme-trigger-slug]",
-  )) {
-    if (
-      candidate instanceof HTMLButtonElement &&
-      candidate.dataset.templateThemeTriggerSlug === slug
-    ) {
-      const scrollContainer = candidate.closest(
-        PRESENTATION_TEMPLATE_GRID_SCROLL_SELECTOR,
-      );
-      return scrollContainer instanceof HTMLElement
-        ? scrollContainer
-        : undefined;
-    }
-  }
-  return undefined;
-}
-
-function resolvePresentationTemplateCardThemePopoverPlacement(
-  trigger: HTMLButtonElement,
-): TemplateCardThemePopoverPlacement {
-  const triggerRect = trigger.getBoundingClientRect();
-  const scrollContainer = trigger.closest(
-    PRESENTATION_TEMPLATE_GRID_SCROLL_SELECTOR,
-  );
-  const boundaryRect =
-    scrollContainer instanceof HTMLElement
-      ? scrollContainer.getBoundingClientRect()
-      : null;
-  const boundaryBottom = boundaryRect?.bottom ?? window.innerHeight;
-  const boundaryLeft = boundaryRect?.left ?? 0;
-  const boundaryRight = boundaryRect?.right ?? window.innerWidth;
-  const availableBottomSpace = boundaryBottom - triggerRect.bottom;
-  if (
-    availableBottomSpace >=
-    PRESENTATION_TEMPLATE_CARD_THEME_POPOVER_HEIGHT +
-      PRESENTATION_TEMPLATE_CARD_THEME_POPOVER_GAP +
-      PRESENTATION_TEMPLATE_CARD_THEME_POPOVER_MARGIN
-  ) {
-    const startOverflowsRight =
-      triggerRect.left +
-        PRESENTATION_TEMPLATE_CARD_THEME_POPOVER_WIDTH +
-        PRESENTATION_TEMPLATE_CARD_THEME_POPOVER_MARGIN >
-      boundaryRight;
-    const endOverflowsLeft =
-      triggerRect.right -
-        PRESENTATION_TEMPLATE_CARD_THEME_POPOVER_WIDTH -
-        PRESENTATION_TEMPLATE_CARD_THEME_POPOVER_MARGIN <
-      boundaryLeft;
-    return {
-      align: startOverflowsRight && !endOverflowsLeft ? "end" : "start",
-      alignOffset: 0,
-      side: "bottom",
-    };
-  }
-  const availableRightSpace = boundaryRight - triggerRect.right;
-  if (
-    availableRightSpace >=
-    PRESENTATION_TEMPLATE_CARD_THEME_POPOVER_WIDTH +
-      PRESENTATION_TEMPLATE_CARD_THEME_POPOVER_GAP +
-      PRESENTATION_TEMPLATE_CARD_THEME_POPOVER_MARGIN
-  ) {
-    return { align: "end", alignOffset: 0, side: "right" };
-  }
-  return {
-    align: "start",
-    alignOffset:
-      triggerRect.height + PRESENTATION_TEMPLATE_CARD_THEME_POPOVER_GAP,
-    side: "left",
-  };
-}
-
-function shouldOpenPresentationTemplateThemePage(): boolean {
-  return (
-    typeof window !== "undefined" &&
-    window.matchMedia("(max-width: 639px)").matches
-  );
-}
-
-function PresentationTemplateCardThemePicker({
-  item,
-  onOpenThemePage,
-  selectedTheme,
-  triggerClassName,
-  onThemeChange,
-}: {
-  item: PresentationTemplateItem;
-  onOpenThemePage: () => void;
-  selectedTheme: PresentationTemplateThemeOption;
-  triggerClassName?: string;
-  onThemeChange: (theme: PresentationTemplateThemeOption) => void;
-}) {
-  const selectedSwatches = presentationTemplateCardThemeSwatches(
-    item,
-    selectedTheme,
-  );
-  const openSlug = useGet(templateCardThemePopoverOpenSlug$);
-  const setOpenSlug = useSet(setTemplateCardThemePopoverOpenSlug$);
-  const placementBySlug = useGet(templateCardThemePopoverPlacementBySlug$);
-  const setPlacement = useSet(setTemplateCardThemePopoverPlacement$);
-  const open = openSlug === item.slug;
-  const placement = placementBySlug[item.slug] ?? {
-    align: "start",
-    alignOffset: 0,
-    side: "bottom",
-  };
-  const multiAccentThemes = PRESENTATION_TEMPLATE_THEME_OPTIONS.filter(
-    (theme) => {
-      return theme.group === "multi-accent";
-    },
-  );
-  const singleAccentThemes = PRESENTATION_TEMPLATE_THEME_OPTIONS.filter(
-    (theme) => {
-      return theme.group === "single-accent";
-    },
-  );
-
-  const updatePopoverPlacement = (trigger: HTMLButtonElement) => {
-    setPlacement(
-      item.slug,
-      resolvePresentationTemplateCardThemePopoverPlacement(trigger),
-    );
-  };
-  const openThemePageOnMobile = () => {
-    if (!shouldOpenPresentationTemplateThemePage()) {
-      return false;
-    }
-    setOpenSlug(null);
-    onOpenThemePage();
-    return true;
-  };
-
-  return (
-    <Popover
-      open={open}
-      onOpenChange={(nextOpen) => {
-        setOpenSlug(nextOpen ? item.slug : null);
-      }}
-    >
-      <PopoverTrigger asChild>
-        <button
-          type="button"
-          aria-label={`Change theme for ${item.title}`}
-          data-template-theme-trigger-slug={item.slug}
-          onPointerDown={(event) => {
-            if (openThemePageOnMobile()) {
-              event.preventDefault();
-              return;
-            }
-            updatePopoverPlacement(event.currentTarget);
-          }}
-          onKeyDown={(event) => {
-            if (event.key === "Enter" || event.key === " ") {
-              if (openThemePageOnMobile()) {
-                event.preventDefault();
-                return;
-              }
-              updatePopoverPlacement(event.currentTarget);
-            }
-          }}
-          className={cn(
-            "inline-flex h-8 max-w-full items-center gap-1.5 rounded-md border border-border bg-background px-2.5 text-xs font-medium text-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-            triggerClassName,
-          )}
-        >
-          <IconPalette
-            size={13}
-            stroke={1.8}
-            className="shrink-0 text-muted-foreground"
-          />
-          <span className="flex shrink-0 items-center gap-0.5">
-            {selectedSwatches.map((swatch) => {
-              return (
-                <span
-                  key={`${selectedTheme.id}-${swatch.id}`}
-                  className="h-2.5 w-2.5 rounded-full border border-border"
-                  style={{ backgroundColor: swatch.color }}
-                />
-              );
-            })}
-          </span>
-          <IconChevronDown
-            size={12}
-            stroke={1.8}
-            className="shrink-0 text-muted-foreground"
-          />
-        </button>
-      </PopoverTrigger>
-      <PopoverContent
-        align={placement.align}
-        alignOffset={placement.alignOffset}
-        avoidCollisions={false}
-        className="z-[90] w-[232px] p-2"
-        portalContainer={presentationTemplateGridScrollElement(item.slug)}
-        side={placement.side}
-        sideOffset={PRESENTATION_TEMPLATE_CARD_THEME_POPOVER_GAP}
-      >
-        <p className="px-1 text-[11px] font-medium text-muted-foreground">
-          Multi-accent
-        </p>
-        <div className="mt-1 flex flex-wrap gap-1.5">
-          {multiAccentThemes.map((theme) => {
-            const active = theme.id === selectedTheme.id;
-            const swatches = presentationTemplateCardThemeSwatches(item, theme);
-            return (
-              <button
-                key={theme.id}
-                type="button"
-                aria-label={`Select card theme ${theme.name} for ${item.title}`}
-                aria-pressed={active}
-                onClick={() => {
-                  onThemeChange(theme);
-                }}
-                className={cn(
-                  "relative h-7 w-12 overflow-hidden rounded-md border transition-colors hover:-translate-y-px focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                  active
-                    ? "border-ring ring-1 ring-ring"
-                    : "border-border hover:border-muted-foreground/60",
-                )}
-              >
-                <span className="flex h-full">
-                  {swatches.map((swatch) => {
-                    return (
-                      <span
-                        key={`${theme.id}-${swatch.id}`}
-                        className="flex-1"
-                        style={{ backgroundColor: swatch.color }}
-                      />
-                    );
-                  })}
-                </span>
-              </button>
-            );
-          })}
-        </div>
-        <p className="mt-3 px-1 text-[11px] font-medium text-muted-foreground">
-          Single-accent
-        </p>
-        <div className="mt-1 grid grid-cols-4 gap-1.5">
-          {singleAccentThemes.map((theme) => {
-            const active = theme.id === selectedTheme.id;
-            const swatches = presentationTemplateCardThemeSwatches(item, theme);
-            return (
-              <button
-                key={theme.id}
-                type="button"
-                aria-label={`Select card theme ${theme.name} for ${item.title}`}
-                aria-pressed={active}
-                onClick={() => {
-                  onThemeChange(theme);
-                }}
-                className={cn(
-                  "relative h-7 w-12 overflow-hidden rounded-md border transition-colors hover:-translate-y-px focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                  active
-                    ? "border-ring ring-1 ring-ring"
-                    : "border-border hover:border-muted-foreground/60",
-                )}
-              >
-                <span className="flex h-full">
-                  {swatches.map((swatch) => {
-                    return (
-                      <span
-                        key={`${theme.id}-${swatch.id}`}
-                        className="flex-1"
-                        style={{ backgroundColor: swatch.color }}
-                      />
-                    );
-                  })}
-                </span>
-              </button>
-            );
-          })}
-        </div>
-      </PopoverContent>
-    </Popover>
   );
 }
 
@@ -3869,42 +3564,9 @@ function PptCard({
   priority?: boolean;
 }) {
   const themeIdBySlug = useGet(templateCardThemeIdBySlug$);
-  const setThemeId = useSet(setTemplateCardThemeId$);
-  const hover = useGet(templateCardHover$);
-  const htmlPreview = useGet(templateCardHtmlPreview$);
-  const setHtmlPreview = useSet(setTemplateCardHtmlPreview$);
   const selectedTheme = findPresentationTemplateTheme(
     themeIdBySlug[item.slug] ?? defaultPresentationTemplateThemeId(item),
   );
-  const refreshCardHtmlPreviewTheme = (
-    theme: PresentationTemplateThemeOption,
-  ) => {
-    const cachedDraft = presentationTemplateHtmlPreviewCache().drafts.get(
-      item.embedUrl,
-    );
-    if (cachedDraft === undefined) {
-      return;
-    }
-    const index =
-      hover?.slug === item.slug
-        ? hover.index
-        : (presentationTemplateHtmlPreviewCache().activeIndexes.get(
-            item.embedUrl,
-          ) ?? 0);
-    setHtmlPreview(
-      createPresentationTemplateHtmlPreviewState({
-        draft: cachedDraft,
-        index,
-        item,
-        previousFrameUrl:
-          htmlPreview?.slug === item.slug &&
-          htmlPreview.embedUrl === item.embedUrl
-            ? htmlPreview.frameUrl
-            : null,
-        theme,
-      }),
-    );
-  };
 
   return (
     <div
@@ -3932,41 +3594,22 @@ function PptCard({
             </Tooltip>
           </TooltipProvider>
         </div>
-        <div className="inline-flex h-8 max-w-full shrink-0 overflow-hidden rounded-md border border-border bg-background text-foreground">
-          <button
-            type="button"
-            aria-label={`Select template ${item.title}`}
-            aria-pressed={selected}
-            onClick={() => {
-              onSelect(
-                item,
-                presentationTemplateColorSystemId(selectedTheme.id),
-              );
-            }}
-            className={cn(
-              "h-full shrink-0 px-3 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
-              selected
-                ? "bg-primary/10 text-primary"
-                : "bg-background text-foreground hover:bg-muted",
-            )}
-          >
-            Use
-          </button>
-          <div className="min-w-0 border-l border-border">
-            <PresentationTemplateCardThemePicker
-              item={item}
-              onOpenThemePage={() => {
-                onPreview(item);
-              }}
-              selectedTheme={selectedTheme}
-              triggerClassName="rounded-none border-0 shadow-none focus-visible:ring-inset"
-              onThemeChange={(theme) => {
-                setThemeId(item.slug, theme.id);
-                refreshCardHtmlPreviewTheme(theme);
-              }}
-            />
-          </div>
-        </div>
+        <button
+          type="button"
+          aria-label={`Select template ${item.title}`}
+          aria-pressed={selected}
+          onClick={() => {
+            onSelect(item, presentationTemplateColorSystemId(selectedTheme.id));
+          }}
+          className={cn(
+            "h-8 shrink-0 rounded-md border border-border px-3 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            selected
+              ? "bg-primary/10 text-primary"
+              : "bg-background text-foreground hover:bg-muted",
+          )}
+        >
+          Use
+        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- remove the first-level presentation template card theme picker button and popover state
- keep reading `presentationTemplateThemeIdBySlug` for first-level card previews
- persist the selected theme only when the detail page Use button is clicked
- update presentation template picker tests for the new persistence behavior

## Checks
- `pnpm format`
- `pnpm lint`
- `pnpm check-types`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx -t "presentation detail theme|default card theme|navigates presentation template detail"`
- `pnpm knip`

## Notes
- Full `pnpm vitest` was attempted locally but failed on unrelated environment/existing failures: PostgreSQL connection refused for API tests, `localStorage` undefined in existing web tests, and existing Figma firewall assertion failures.