### PR TITLE
fix: scope mobile single-line composer to chat threads

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -553,6 +553,80 @@ beforeEach(() => {
 });
 
 describe("chat composer models", () => {
+  it("keeps the agent chat composer at three-line height when the mobile single-line switch is on", async () => {
+    mockOrgModelRoutes("kimi-k2.7-code");
+    mockAgent();
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      featureSwitches: { [FeatureSwitchKey.MobileSingleLineComposer]: true },
+    });
+
+    const textarea = await screen.findByPlaceholderText(PLACEHOLDER);
+    expect(textarea).toHaveAttribute("rows", "3");
+    expect(textarea).toHaveClass("min-h-[96px]");
+    expect(textarea).not.toHaveClass("min-h-[44px]");
+  });
+
+  it("uses the mobile single-line height in chat thread composers when the switch is on", async () => {
+    mockOrgModelRoutes("kimi-k2.7-code");
+    mockAgent();
+    mockThread();
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+      featureSwitches: { [FeatureSwitchKey.MobileSingleLineComposer]: true },
+    });
+
+    const textarea = await screen.findByPlaceholderText(PLACEHOLDER);
+    expect(textarea).toHaveAttribute("rows", "1");
+    expect(textarea).toHaveClass("min-h-[44px]", "md:min-h-[96px]");
+  });
+
+  it("keeps the agent chat slash composer at three-line height when the mobile single-line switch is on", async () => {
+    mockOrgModelRoutes("kimi-k2.7-code");
+    mockAgent();
+    context.mocks.api(zeroWorkflowsCollectionContract.list, ({ respond }) => {
+      return respond(200, []);
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      featureSwitches: {
+        [FeatureSwitchKey.ChatSlashWorkflowCommands]: true,
+        [FeatureSwitchKey.MobileSingleLineComposer]: true,
+      },
+    });
+
+    const editor = await findComposerEditor();
+    expect(editor).toHaveClass("min-h-[96px]");
+    expect(editor).not.toHaveClass("min-h-[44px]");
+  });
+
+  it("uses the mobile single-line height in chat thread slash composers when the switch is on", async () => {
+    mockOrgModelRoutes("kimi-k2.7-code");
+    mockAgent();
+    mockThread();
+    context.mocks.api(zeroWorkflowsCollectionContract.list, ({ respond }) => {
+      return respond(200, []);
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ChatSlashWorkflowCommands]: true,
+        [FeatureSwitchKey.MobileSingleLineComposer]: true,
+      },
+    });
+
+    const editor = await findComposerEditor();
+    expect(editor).toHaveClass("min-h-[44px]", "md:min-h-[96px]");
+  });
+
   it("suggests current agent workflows from slash input and highlights inserted workflow tokens", async () => {
     const user = userEvent.setup({ delay: null });
     mockOrgModelRoutes("kimi-k2.7-code");

--- a/turbo/apps/platform/src/views/zero-page/tiptap-workflow-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/tiptap-workflow-composer.tsx
@@ -482,6 +482,7 @@ interface TiptapWorkflowComposerProps {
   readonly setInputRef: ((el: HTMLElement | null) => void) | undefined;
   readonly onKeyDown: (event: KeyboardEventLike) => void;
   readonly onPaste: (event: ComposerPasteEvent) => void;
+  readonly singleLineOnMobile: boolean;
 }
 
 export function TiptapWorkflowComposer({
@@ -493,6 +494,7 @@ export function TiptapWorkflowComposer({
   setInputRef,
   onKeyDown,
   onPaste,
+  singleLineOnMobile,
 }: TiptapWorkflowComposerProps) {
   const caretIndex = useGet(slashWorkflowCaretIndex$);
   const setCaretIndex = useSet(setSlashWorkflowCaretIndex$);
@@ -500,8 +502,6 @@ export function TiptapWorkflowComposer({
   const setSelectedWorkflowIndex = useSet(setSelectedSlashWorkflowIndex$);
   const currentAgentId = useLastResolved(currentChatAgentRecordId$);
   const features = useLastResolved(featureSwitch$);
-  const singleLineOnMobile =
-    features?.[FeatureSwitchKey.MobileSingleLineComposer] ?? false;
   const composerWorkflowsLoadable = useLastLoadable(composerWorkflows$);
   const composerWorkflowsData =
     composerWorkflowsLoadable.state === "hasData"

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -267,6 +267,8 @@ interface ZeroChatComposerProps {
   className?: string;
   /** Auto-focus the textarea when mounted. */
   autoFocus?: boolean;
+  /** Allows the MobileSingleLineComposer switch to reduce this instance on mobile. */
+  enableMobileSingleLine?: boolean;
   /** Per-instance draft signals (from ChatThreadSignals factory). When omitted, falls back to singleton signals. */
   draft?: DraftSignals;
   /** Composer file input element reference. When omitted, falls back to singleton. */
@@ -6245,6 +6247,7 @@ function ComposerInputSlot({
   onDraftChange,
   sending,
   autoFocus,
+  enableMobileSingleLine,
   setInputRef,
   onKeyDown,
   onPaste,
@@ -6254,6 +6257,7 @@ function ComposerInputSlot({
   readonly onDraftChange: (() => void) | undefined;
   readonly sending: boolean | undefined;
   readonly autoFocus: boolean | undefined;
+  readonly enableMobileSingleLine: boolean;
   readonly setInputRef: ((el: HTMLElement | null) => void) | undefined;
   readonly onKeyDown: (e: KeyboardEventLike) => void;
   readonly onPaste: (e: ComposerPasteEvent) => void;
@@ -6262,7 +6266,8 @@ function ComposerInputSlot({
   const slashWorkflowCommandsEnabled =
     features?.[FeatureSwitchKey.ChatSlashWorkflowCommands] ?? false;
   const singleLineOnMobile =
-    features?.[FeatureSwitchKey.MobileSingleLineComposer] ?? false;
+    enableMobileSingleLine &&
+    (features?.[FeatureSwitchKey.MobileSingleLineComposer] ?? false);
 
   if (slashWorkflowCommandsEnabled) {
     return (
@@ -6275,6 +6280,7 @@ function ComposerInputSlot({
         setInputRef={setInputRef}
         onKeyDown={onKeyDown}
         onPaste={onPaste}
+        singleLineOnMobile={singleLineOnMobile}
       />
     );
   }
@@ -6479,6 +6485,7 @@ export function ZeroChatComposer({
   displayName,
   className,
   autoFocus,
+  enableMobileSingleLine = false,
   draft,
   composerFileInput$: composerFileInputProp$,
   setComposerFileInput$: setComposerFileInputProp$,
@@ -6905,6 +6912,7 @@ export function ZeroChatComposer({
                     onDraftChange={onDraftChange}
                     sending={sending}
                     autoFocus={autoFocus}
+                    enableMobileSingleLine={enableMobileSingleLine}
                     setInputRef={setInputRef}
                     onKeyDown={handleKeyDown}
                     onPaste={handlePaste}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -3924,6 +3924,7 @@ function ChatThreadComposer({
               autoFocus: autoFocusProp,
               hasMessages,
             })}
+            enableMobileSingleLine
             onDraftChange={handleDraftChange}
             draft={thread.draft}
             composerFileInput$={thread.composerFileInput$}


### PR DESCRIPTION
## Summary
- Gate the mobile single-line composer height by composer instance as well as the existing `MobileSingleLineComposer` feature switch
- Enable the compact mobile resting height only for `/chats/:threadId` thread composers
- Keep `/agents/:agentId/chat` composers at the existing three-line resting height, including the slash/TipTap composer path

## Verification
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx`
- `pnpm -F @vm0/app check-types`
- `pnpm exec prettier --check apps/platform/src/views/zero-page/zero-chat-composer.tsx apps/platform/src/views/zero-page/tiptap-workflow-composer.tsx apps/platform/src/views/zero-page/zero-chat-thread-page.tsx apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx`
- `git diff --check`
- `pnpm -F @vm0/app lint`