### PR TITLE
fix: handle numeric Gmail Pub/Sub history IDs

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-gmail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-gmail.test.ts
@@ -147,7 +147,7 @@ function configureGmailMessageMocks(): void {
 
 function gmailPushBody(args: {
   readonly emailAddress: string;
-  readonly historyId: string;
+  readonly historyId: string | number;
   readonly messageId: string;
 }): string {
   return JSON.stringify({
@@ -320,7 +320,7 @@ describe("POST /api/webhooks/gmail", () => {
 
     const body = gmailPushBody({
       emailAddress: GMAIL_EMAIL,
-      historyId: "101",
+      historyId: 101,
       messageId: "pubsub-1",
     });
     const first = await postGmailWebhook(body);

--- a/turbo/apps/api/src/signals/services/gmail-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/gmail-workflow-event.service.ts
@@ -139,7 +139,9 @@ const pubSubPushSchema = z.object({
 
 const gmailPubSubDataSchema = z.object({
   emailAddress: z.string(),
-  historyId: z.string(),
+  historyId: z
+    .union([z.string(), z.number().int().nonnegative()])
+    .transform(String),
 });
 
 interface GmailAccess {


### PR DESCRIPTION
## Summary
- Accept Gmail Pub/Sub `historyId` values as either strings or non-negative integers.
- Normalize decoded Gmail Pub/Sub `historyId` to a string before downstream processing.
- Update the Gmail webhook integration test fixture to use a numeric `historyId`, matching the production payload captured from Pub/Sub.

## Root cause
Production Gmail Pub/Sub messages decode to payloads like `{"emailAddress":"lancy@vm0.ai","historyId":249961}`. The webhook schema only accepted `historyId` as a string, so `decodePubSubPush()` rejected valid Gmail notifications and returned HTTP 400 before enqueueing workflow triggers.

## Verification
- `pnpm --dir turbo -F api exec prettier --check src/signals/services/gmail-workflow-event.service.ts src/signals/routes/__tests__/webhooks-gmail.test.ts`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --dir turbo -F api check-types`
- `pnpm --dir turbo -F api lint`
- Attempted `pnpm --dir turbo -F api exec vitest run src/signals/routes/__tests__/webhooks-gmail.test.ts`; local run is blocked before assertions because this container has no running PostgreSQL cluster (`ECONNREFUSED 127.0.0.1:5432`, `service postgresql start` reports `No PostgreSQL clusters exist`).