### PR TITLE
fix: reject malformed AWS SigV4 content hash headers

### DIFF
--- a/crates/runner/mitm-addon/src/aws_sigv4.py
+++ b/crates/runner/mitm-addon/src/aws_sigv4.py
@@ -511,7 +511,7 @@ def _content_hash_header_value(headers: list[tuple[str, str]]) -> str | None:
     )
     if header_value is None:
         return None
-    if _has_content_hash_forbidden_control(header_value):
+    if _has_content_hash_invalid_text(header_value):
         raise AwsSigV4SigningError("AWS content hash header contains invalid text")
 
     normalized = _normalize_header_value(header_value)
@@ -530,9 +530,11 @@ def _is_sha256_hex_digest(value: str) -> bool:
     return len(value) == _SHA256_HEX_LENGTH and all(char in _LOWER_HEX_DIGITS for char in value)
 
 
-def _has_content_hash_forbidden_control(value: str) -> bool:
+def _has_content_hash_invalid_text(value: str) -> bool:
     return any(
-        (ord(char) <= _ASCII_CONTROL_MAX and char != "\t") or ord(char) == _ASCII_DELETE
+        ord(char) > _ASCII_DELETE
+        or (ord(char) <= _ASCII_CONTROL_MAX and char != "\t")
+        or ord(char) == _ASCII_DELETE
         for char in value
     )
 

--- a/crates/runner/mitm-addon/src/aws_sigv4.py
+++ b/crates/runner/mitm-addon/src/aws_sigv4.py
@@ -511,6 +511,8 @@ def _content_hash_header_value(headers: list[tuple[str, str]]) -> str | None:
     )
     if header_value is None:
         return None
+    if _has_content_hash_forbidden_control(header_value):
+        raise AwsSigV4SigningError("AWS content hash header contains invalid text")
 
     normalized = _normalize_header_value(header_value)
     if not normalized:
@@ -526,6 +528,13 @@ def _content_hash_header_value(headers: list[tuple[str, str]]) -> str | None:
 
 def _is_sha256_hex_digest(value: str) -> bool:
     return len(value) == _SHA256_HEX_LENGTH and all(char in _LOWER_HEX_DIGITS for char in value)
+
+
+def _has_content_hash_forbidden_control(value: str) -> bool:
+    return any(
+        (ord(char) <= _ASCII_CONTROL_MAX and char != "\t") or ord(char) == _ASCII_DELETE
+        for char in value
+    )
 
 
 def _signature(

--- a/crates/runner/mitm-addon/src/aws_sigv4.py
+++ b/crates/runner/mitm-addon/src/aws_sigv4.py
@@ -27,6 +27,8 @@ _ASYMMETRIC_ALGORITHM = "AWS4-ECDSA-P256-SHA256"
 _S3_SIGNING_NAMES = frozenset(("s3", "s3-outposts", "s3-object-lambda"))
 _UNSUPPORTED_S3_EXPRESS_SIGNING_NAME = "s3express"
 _STREAMING_PAYLOAD_PREFIX = "STREAMING-"
+_UNSIGNED_PAYLOAD = "UNSIGNED-PAYLOAD"
+_SHA256_HEX_LENGTH = 64
 _CREDENTIAL_SCOPE_PARTS = 5
 _AUTH_HEADER_PARAM_NAMES = frozenset(("Credential", "SignedHeaders", "Signature"))
 _QUERY_SIGNING_PARAM_NAMES = frozenset(
@@ -47,6 +49,7 @@ _AMZ_DATE_RE = re.compile(r"^\d{8}T\d{6}Z$")
 _PRESIGN_EXPIRES_RE = re.compile(r"^[1-9]\d*$")
 _ACCESS_KEY_ID_RE = re.compile(r"^[A-Za-z0-9]+$")
 _SIGNED_HEADER_NAME_RE = re.compile(r"^[A-Za-z0-9!#$%&'*+.^_`|~-]+$")
+_LOWER_HEX_DIGITS = frozenset("0123456789abcdef")
 _HEX_DIGITS = frozenset("0123456789ABCDEFabcdef")
 _RAW_WHITESPACE_CHARS = frozenset(" \t\n\r\f\v")
 _ASCII_CONTROL_MAX = 0x1F
@@ -485,31 +488,44 @@ def _normalize_header_value(value: str) -> str:
 
 
 def _payload_hash(headers: list[tuple[str, str]], body: bytes | None) -> str:
-    header_value = _unique_header_value(
-        headers,
-        "x-amz-content-sha256",
-        "AWS content hash header is ambiguous",
-    )
-    if header_value:
-        if header_value.startswith(_STREAMING_PAYLOAD_PREFIX):
-            raise AwsSigV4SigningError("AWS streaming payload signing is not supported")
+    header_value = _content_hash_header_value(headers)
+    if header_value is not None:
         return header_value
     return hashlib.sha256(body or b"").hexdigest()
 
 
 def _query_payload_hash(headers: list[tuple[str, str]], body: bytes | None, is_s3: bool) -> str:
+    header_value = _content_hash_header_value(headers)
+    if header_value is not None:
+        return header_value
+    if is_s3:
+        return _UNSIGNED_PAYLOAD
+    return hashlib.sha256(body or b"").hexdigest()
+
+
+def _content_hash_header_value(headers: list[tuple[str, str]]) -> str | None:
     header_value = _unique_header_value(
         headers,
         "x-amz-content-sha256",
         "AWS content hash header is ambiguous",
     )
-    if header_value:
-        if header_value.startswith(_STREAMING_PAYLOAD_PREFIX):
-            raise AwsSigV4SigningError("AWS streaming payload signing is not supported")
-        return header_value
-    if is_s3:
-        return "UNSIGNED-PAYLOAD"
-    return hashlib.sha256(body or b"").hexdigest()
+    if header_value is None:
+        return None
+
+    normalized = _normalize_header_value(header_value)
+    if not normalized:
+        raise AwsSigV4SigningError("AWS content hash header is empty")
+    if normalized.startswith(_STREAMING_PAYLOAD_PREFIX):
+        raise AwsSigV4SigningError("AWS streaming payload signing is not supported")
+    if normalized == _UNSIGNED_PAYLOAD:
+        return normalized
+    if _is_sha256_hex_digest(normalized):
+        return normalized
+    raise AwsSigV4SigningError("Unsupported AWS content hash header")
+
+
+def _is_sha256_hex_digest(value: str) -> bool:
+    return len(value) == _SHA256_HEX_LENGTH and all(char in _LOWER_HEX_DIGITS for char in value)
 
 
 def _signature(

--- a/crates/runner/mitm-addon/tests/test_aws_sigv4.py
+++ b/crates/runner/mitm-addon/tests/test_aws_sigv4.py
@@ -381,3 +381,17 @@ def test_presigned_query_invalid_content_hash_header_raises_signing_error() -> N
             body=None,
             credentials=_credentials(),
         )
+
+
+def test_presigned_query_empty_content_hash_header_raises_signing_error() -> None:
+    with pytest.raises(AwsSigV4SigningError, match="AWS content hash header is empty"):
+        sign_request(
+            method="GET",
+            url=_presigned_url("sts.amazonaws.com"),
+            headers=[
+                ("Host", "sts.amazonaws.com"),
+                ("X-Amz-Content-Sha256", ""),
+            ],
+            body=None,
+            credentials=_credentials(),
+        )

--- a/crates/runner/mitm-addon/tests/test_aws_sigv4.py
+++ b/crates/runner/mitm-addon/tests/test_aws_sigv4.py
@@ -313,6 +313,23 @@ def test_header_auth_invalid_content_hash_header_raises_signing_error(
         )
 
 
+@pytest.mark.parametrize("header_value", ["a" * 64 + "\n", "UNSIGNED-PAYLOAD\r"])
+def test_header_auth_control_content_hash_header_raises_signing_error(
+    header_value: str,
+) -> None:
+    with pytest.raises(
+        AwsSigV4SigningError,
+        match="AWS content hash header contains invalid text",
+    ):
+        sign_request(
+            method="POST",
+            url="https://sts.amazonaws.com/",
+            headers=_header_auth_headers_with_content_hash(header_value),
+            body=b"hello",
+            credentials=_credentials(),
+        )
+
+
 def test_header_auth_streaming_content_hash_header_raises_signing_error() -> None:
     with pytest.raises(
         AwsSigV4SigningError,
@@ -329,7 +346,7 @@ def test_header_auth_streaming_content_hash_header_raises_signing_error() -> Non
         )
 
 
-@pytest.mark.parametrize("header_value", ["a" * 64, "UNSIGNED-PAYLOAD"])
+@pytest.mark.parametrize("header_value", ["a" * 64, "UNSIGNED-PAYLOAD", " \t" + "a" * 64 + "\t "])
 def test_header_auth_supported_content_hash_header_signs(header_value: str) -> None:
     _url, headers = sign_request(
         method="POST",

--- a/crates/runner/mitm-addon/tests/test_aws_sigv4.py
+++ b/crates/runner/mitm-addon/tests/test_aws_sigv4.py
@@ -27,6 +27,21 @@ def _header_auth_headers() -> list[tuple[str, str]]:
     ]
 
 
+def _header_auth_headers_with_content_hash(value: str) -> list[tuple[str, str]]:
+    return [
+        (
+            "Authorization",
+            "AWS4-HMAC-SHA256 "
+            "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
+            "SignedHeaders=host;x-amz-content-sha256;x-amz-date, "
+            "Signature=placeholder",
+        ),
+        ("X-Amz-Date", "20260101T000000Z"),
+        ("X-Amz-Content-Sha256", value),
+        ("Host", "sts.amazonaws.com"),
+    ]
+
+
 def _presigned_url(host: str) -> str:
     placeholder_credential = urllib.parse.quote(
         "PLACEHOLDER/20260101/us-east-1/sts/aws4_request",
@@ -265,6 +280,79 @@ def test_invalid_port_keeps_specific_signing_error() -> None:
             method="GET",
             url="https://sts.amazonaws.com:bad/",
             headers=_header_auth_headers(),
+            body=None,
+            credentials=_credentials(),
+        )
+
+
+@pytest.mark.parametrize("header_value", ["", " \t  "])
+def test_header_auth_empty_content_hash_header_raises_signing_error(
+    header_value: str,
+) -> None:
+    with pytest.raises(AwsSigV4SigningError, match="AWS content hash header is empty"):
+        sign_request(
+            method="POST",
+            url="https://sts.amazonaws.com/",
+            headers=_header_auth_headers_with_content_hash(header_value),
+            body=b"hello",
+            credentials=_credentials(),
+        )
+
+
+@pytest.mark.parametrize("header_value", ["placeholder-hash", "A" * 64])
+def test_header_auth_invalid_content_hash_header_raises_signing_error(
+    header_value: str,
+) -> None:
+    with pytest.raises(AwsSigV4SigningError, match="Unsupported AWS content hash header"):
+        sign_request(
+            method="POST",
+            url="https://sts.amazonaws.com/",
+            headers=_header_auth_headers_with_content_hash(header_value),
+            body=b"hello",
+            credentials=_credentials(),
+        )
+
+
+def test_header_auth_streaming_content_hash_header_raises_signing_error() -> None:
+    with pytest.raises(
+        AwsSigV4SigningError,
+        match="AWS streaming payload signing is not supported",
+    ):
+        sign_request(
+            method="POST",
+            url="https://sts.amazonaws.com/",
+            headers=_header_auth_headers_with_content_hash(
+                "STREAMING-AWS4-HMAC-SHA256-PAYLOAD",
+            ),
+            body=b"hello",
+            credentials=_credentials(),
+        )
+
+
+@pytest.mark.parametrize("header_value", ["a" * 64, "UNSIGNED-PAYLOAD"])
+def test_header_auth_supported_content_hash_header_signs(header_value: str) -> None:
+    _url, headers = sign_request(
+        method="POST",
+        url="https://sts.amazonaws.com/",
+        headers=_header_auth_headers_with_content_hash(header_value),
+        body=b"hello",
+        credentials=_credentials(),
+    )
+
+    authorization = {name.lower(): value for name, value in headers}["authorization"]
+    assert "Credential=AKIDEXAMPLE/" in authorization
+    assert "x-amz-content-sha256" in authorization
+
+
+def test_presigned_query_invalid_content_hash_header_raises_signing_error() -> None:
+    with pytest.raises(AwsSigV4SigningError, match="Unsupported AWS content hash header"):
+        sign_request(
+            method="GET",
+            url=_presigned_url("sts.amazonaws.com"),
+            headers=[
+                ("Host", "sts.amazonaws.com"),
+                ("X-Amz-Content-Sha256", "placeholder-hash"),
+            ],
             body=None,
             credentials=_credentials(),
         )

--- a/crates/runner/mitm-addon/tests/test_aws_sigv4.py
+++ b/crates/runner/mitm-addon/tests/test_aws_sigv4.py
@@ -313,8 +313,16 @@ def test_header_auth_invalid_content_hash_header_raises_signing_error(
         )
 
 
-@pytest.mark.parametrize("header_value", ["a" * 64 + "\n", "UNSIGNED-PAYLOAD\r"])
-def test_header_auth_control_content_hash_header_raises_signing_error(
+@pytest.mark.parametrize(
+    "header_value",
+    [
+        "a" * 64 + "\n",
+        "UNSIGNED-PAYLOAD\r",
+        "a" * 64 + "\u00a0",
+        "\uff41" * 64,
+    ],
+)
+def test_header_auth_non_ascii_or_control_content_hash_header_raises_signing_error(
     header_value: str,
 ) -> None:
     with pytest.raises(

--- a/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
@@ -1333,6 +1333,45 @@ async def test_header_sigv4_with_duplicate_content_hash_fails_closed(
     assert "AWS content hash header is ambiguous" in flow.response.json()["message"]
 
 
+async def test_header_sigv4_with_empty_content_hash_fails_closed(
+    real_flow,
+    headers,
+    tmp_path,
+    mitm_ctx,
+):
+    endpoint = FakeAuthEndpoint()
+    endpoint.queue_json_response(_auth_response())
+    flow = real_flow(
+        with_response=False,
+        host="sts.amazonaws.com",
+        path="/",
+        method="POST",
+        request_body=b"Action=GetCallerIdentity&Version=2011-06-15",
+        request_headers=headers(
+            ("Host", "sts.amazonaws.com"),
+            ("X-Amz-Date", "20260101T000000Z"),
+            ("X-Amz-Content-Sha256", ""),
+            (
+                "Authorization",
+                "AWS4-HMAC-SHA256 "
+                "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
+                "SignedHeaders=host;x-amz-content-sha256;x-amz-date, "
+                "Signature=placeholder",
+            ),
+        ),
+    )
+    _prepare_firewall_request(flow)
+
+    with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
+        result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
+
+    assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
+    assert flow.response is not None
+    assert flow.response.status_code == 502
+    assert flow.response.json()["error"] == "aws_sigv4_auth_failed"
+    assert "AWS content hash header is empty" in flow.response.json()["message"]
+
+
 async def test_query_sigv4_without_signature_fails_closed(real_flow, tmp_path, mitm_ctx):
     endpoint = FakeAuthEndpoint()
     endpoint.queue_json_response(_auth_response())


### PR DESCRIPTION
## Summary

- add a shared `x-amz-content-sha256` parser for AWS SigV4 re-signing
- fail closed for empty, whitespace-only, unsupported, and streaming content-hash values
- keep absent-header fallback behavior unchanged for header auth and presigned query auth
- add direct signer and firewall auth-path regression coverage

Closes #18681

## Tests

- `python3 -m ruff check src/aws_sigv4.py tests/test_aws_sigv4.py tests/test_firewall_aws_sigv4_auth.py`
- `python3 -m pytest tests/test_aws_sigv4.py tests/test_firewall_aws_sigv4_auth.py`
