### PR TITLE
refactor(runner): clarify new sandbox test helpers

### DIFF
--- a/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
@@ -12,7 +12,7 @@ async fn execute_inner_appends_stream_overflow_marker() {
     let ctx = minimal_context();
     let system_stream_log_path = config.log_paths.system_stream_log(ctx.run_id);
 
-    let (exit_code, error_msg) = run_execute_inner(&factory, &ctx, &config, &default_params())
+    let (exit_code, error_msg) = run_new_sandbox_status(&factory, &ctx, &config, &default_params())
         .await
         .unwrap();
 
@@ -35,7 +35,7 @@ async fn execute_inner_appends_stream_limit_marker() {
     let ctx = minimal_context();
     let system_stream_log_path = config.log_paths.system_stream_log(ctx.run_id);
 
-    let (exit_code, error_msg) = run_execute_inner(&factory, &ctx, &config, &default_params())
+    let (exit_code, error_msg) = run_new_sandbox_status(&factory, &ctx, &config, &default_params())
         .await
         .unwrap();
 
@@ -67,21 +67,9 @@ async fn execute_inner_appends_stream_limit_marker_after_oom_rewrite() {
     let ctx = minimal_context();
     let system_stream_log_path = config.log_paths.system_stream_log(ctx.run_id);
 
-    let mut telemetry = test_telemetry(&config, &ctx);
-    let outcome = execute_new_sandbox(
-        &factory,
-        &ctx,
-        NewSandboxDispatch {
-            id: SandboxId::new_v4(),
-            reuse_result: SandboxReuseResult::PoolMiss,
-        },
-        &config,
-        &default_params(),
-        &mut telemetry,
-        tokio_util::sync::CancellationToken::new(),
-    )
-    .await
-    .unwrap();
+    let outcome = run_new_sandbox_outcome(&factory, &ctx, &config, &default_params())
+        .await
+        .unwrap();
 
     let failure = outcome.failure.as_ref().expect("expected OOM failure");
     assert_eq!(outcome.exit_code(), 1);
@@ -118,22 +106,9 @@ async fn execute_inner_ignores_non_exited_dmesg_oom_output() {
     );
     let factory = sandbox_mock::MockSandboxFactory::with_overrides(overrides);
     let ctx = minimal_context();
-    let mut telemetry = test_telemetry(&config, &ctx);
-
-    let outcome = execute_new_sandbox(
-        &factory,
-        &ctx,
-        NewSandboxDispatch {
-            id: SandboxId::new_v4(),
-            reuse_result: SandboxReuseResult::PoolMiss,
-        },
-        &config,
-        &default_params(),
-        &mut telemetry,
-        tokio_util::sync::CancellationToken::new(),
-    )
-    .await
-    .unwrap();
+    let outcome = run_new_sandbox_outcome(&factory, &ctx, &config, &default_params())
+        .await
+        .unwrap();
 
     let failure = outcome.failure.as_ref().expect("expected failure");
     assert_eq!(outcome.exit_code(), EXIT_SIGKILL);
@@ -348,22 +323,9 @@ async fn execute_inner_aborts_drain_task_on_wait_process_error() {
     ));
     let factory = sandbox_mock::MockSandboxFactory::with_overrides(overrides);
     let ctx = minimal_context();
-    let mut telemetry = test_telemetry(&config, &ctx);
-
-    let outcome = execute_new_sandbox(
-        &factory,
-        &ctx,
-        NewSandboxDispatch {
-            id: SandboxId::new_v4(),
-            reuse_result: SandboxReuseResult::PoolMiss,
-        },
-        &config,
-        &default_params(),
-        &mut telemetry,
-        tokio_util::sync::CancellationToken::new(),
-    )
-    .await
-    .unwrap();
+    let outcome = run_new_sandbox_outcome(&factory, &ctx, &config, &default_params())
+        .await
+        .unwrap();
 
     assert_eq!(outcome.exit_code(), 124);
     let failure = outcome.failure.as_ref().expect("expected failure");
@@ -437,7 +399,7 @@ async fn execute_inner_nonzero_without_guest_error_returns_failure_message() {
     let factory = sandbox_mock::MockSandboxFactory::with_overrides(overrides);
 
     let (exit_code, error) =
-        run_execute_inner(&factory, &minimal_context(), &config, &default_params())
+        run_new_sandbox_status(&factory, &minimal_context(), &config, &default_params())
             .await
             .unwrap();
 
@@ -455,22 +417,9 @@ async fn execute_inner_non_exited_zero_code_is_failure() {
     overrides.push_wait_process_exit(exit);
     let factory = sandbox_mock::MockSandboxFactory::with_overrides(Arc::clone(&overrides));
     let ctx = minimal_context();
-    let mut telemetry = test_telemetry(&config, &ctx);
-
-    let outcome = execute_new_sandbox(
-        &factory,
-        &ctx,
-        NewSandboxDispatch {
-            id: SandboxId::new_v4(),
-            reuse_result: SandboxReuseResult::PoolMiss,
-        },
-        &config,
-        &default_params(),
-        &mut telemetry,
-        tokio_util::sync::CancellationToken::new(),
-    )
-    .await
-    .unwrap();
+    let outcome = run_new_sandbox_outcome(&factory, &ctx, &config, &default_params())
+        .await
+        .unwrap();
 
     let failure = outcome.failure.as_ref().expect("expected failure");
     assert_eq!(outcome.exit_code(), 1);
@@ -497,22 +446,9 @@ async fn execute_inner_non_exited_diagnostic_is_user_visible() {
     overrides.push_wait_process_exit(exit);
     let factory = sandbox_mock::MockSandboxFactory::with_overrides(Arc::clone(&overrides));
     let ctx = minimal_context();
-    let mut telemetry = test_telemetry(&config, &ctx);
-
-    let outcome = execute_new_sandbox(
-        &factory,
-        &ctx,
-        NewSandboxDispatch {
-            id: SandboxId::new_v4(),
-            reuse_result: SandboxReuseResult::PoolMiss,
-        },
-        &config,
-        &default_params(),
-        &mut telemetry,
-        tokio_util::sync::CancellationToken::new(),
-    )
-    .await
-    .unwrap();
+    let outcome = run_new_sandbox_outcome(&factory, &ctx, &config, &default_params())
+        .await
+        .unwrap();
 
     let failure = outcome.failure.as_ref().expect("expected failure");
     assert_eq!(outcome.exit_code(), 1);
@@ -537,22 +473,9 @@ async fn execute_inner_guest_process_timeout_marks_failure_kind() {
     overrides.push_wait_process_exit(exit);
     let factory = sandbox_mock::MockSandboxFactory::with_overrides(overrides);
     let ctx = minimal_context();
-    let mut telemetry = test_telemetry(&config, &ctx);
-
-    let outcome = execute_new_sandbox(
-        &factory,
-        &ctx,
-        NewSandboxDispatch {
-            id: SandboxId::new_v4(),
-            reuse_result: SandboxReuseResult::PoolMiss,
-        },
-        &config,
-        &default_params(),
-        &mut telemetry,
-        tokio_util::sync::CancellationToken::new(),
-    )
-    .await
-    .unwrap();
+    let outcome = run_new_sandbox_outcome(&factory, &ctx, &config, &default_params())
+        .await
+        .unwrap();
 
     let failure = outcome.failure.as_ref().expect("expected timeout failure");
     assert_eq!(failure.exit_code, 124);
@@ -581,22 +504,9 @@ async fn execute_inner_guest_process_timeout_waits_for_terminal_grace_and_copies
     overrides.push_wait_process_exit(exit);
     let factory = sandbox_mock::MockSandboxFactory::with_overrides(Arc::clone(&overrides));
     let ctx = minimal_context();
-    let mut telemetry = test_telemetry(&config, &ctx);
-
-    let outcome = execute_new_sandbox(
-        &factory,
-        &ctx,
-        NewSandboxDispatch {
-            id: SandboxId::new_v4(),
-            reuse_result: SandboxReuseResult::PoolMiss,
-        },
-        &config,
-        &default_params(),
-        &mut telemetry,
-        tokio_util::sync::CancellationToken::new(),
-    )
-    .await
-    .unwrap();
+    let outcome = run_new_sandbox_outcome(&factory, &ctx, &config, &default_params())
+        .await
+        .unwrap();
 
     let start_calls = overrides.start_process_calls();
     assert_eq!(start_calls.len(), 1);
@@ -646,22 +556,9 @@ async fn execute_inner_timeout_without_stderr_uses_timeout_message() {
     overrides.push_wait_process_exit(exit);
     let factory = sandbox_mock::MockSandboxFactory::with_overrides(Arc::clone(&overrides));
     let ctx = minimal_context();
-    let mut telemetry = test_telemetry(&config, &ctx);
-
-    let outcome = execute_new_sandbox(
-        &factory,
-        &ctx,
-        NewSandboxDispatch {
-            id: SandboxId::new_v4(),
-            reuse_result: SandboxReuseResult::PoolMiss,
-        },
-        &config,
-        &default_params(),
-        &mut telemetry,
-        tokio_util::sync::CancellationToken::new(),
-    )
-    .await
-    .unwrap();
+    let outcome = run_new_sandbox_outcome(&factory, &ctx, &config, &default_params())
+        .await
+        .unwrap();
 
     let failure = outcome.failure.as_ref().expect("expected timeout failure");
     assert_eq!(outcome.exit_code(), 124);
@@ -694,22 +591,9 @@ async fn execute_inner_ordinary_124_timeout_text_is_generic_failure() {
     overrides.push_wait_process_exit(ProcessExit::new(1, 124, Vec::new(), b"Timeout".to_vec()));
     let factory = sandbox_mock::MockSandboxFactory::with_overrides(overrides);
     let ctx = minimal_context();
-    let mut telemetry = test_telemetry(&config, &ctx);
-
-    let outcome = execute_new_sandbox(
-        &factory,
-        &ctx,
-        NewSandboxDispatch {
-            id: SandboxId::new_v4(),
-            reuse_result: SandboxReuseResult::PoolMiss,
-        },
-        &config,
-        &default_params(),
-        &mut telemetry,
-        tokio_util::sync::CancellationToken::new(),
-    )
-    .await
-    .unwrap();
+    let outcome = run_new_sandbox_outcome(&factory, &ctx, &config, &default_params())
+        .await
+        .unwrap();
 
     let failure = outcome.failure.as_ref().expect("expected failure");
     assert_eq!(failure.exit_code, 124);
@@ -731,22 +615,9 @@ async fn execute_inner_abnormal_exit_collects_guest_diagnostics() {
     });
     let factory = sandbox_mock::MockSandboxFactory::with_overrides(Arc::clone(&overrides));
     let ctx = minimal_context();
-    let mut telemetry = test_telemetry(&config, &ctx);
-
-    let outcome = execute_new_sandbox(
-        &factory,
-        &ctx,
-        NewSandboxDispatch {
-            id: SandboxId::new_v4(),
-            reuse_result: SandboxReuseResult::PoolMiss,
-        },
-        &config,
-        &default_params(),
-        &mut telemetry,
-        tokio_util::sync::CancellationToken::new(),
-    )
-    .await
-    .unwrap();
+    let outcome = run_new_sandbox_outcome(&factory, &ctx, &config, &default_params())
+        .await
+        .unwrap();
 
     let failure = outcome.failure.as_ref().expect("expected failure");
     assert_eq!(failure.exit_code, 126);
@@ -824,22 +695,9 @@ async fn execute_inner_ignores_non_exited_abnormal_exit_diagnostics() {
     );
     let factory = sandbox_mock::MockSandboxFactory::with_overrides(overrides);
     let ctx = minimal_context();
-    let mut telemetry = test_telemetry(&config, &ctx);
-
-    let outcome = execute_new_sandbox(
-        &factory,
-        &ctx,
-        NewSandboxDispatch {
-            id: SandboxId::new_v4(),
-            reuse_result: SandboxReuseResult::PoolMiss,
-        },
-        &config,
-        &default_params(),
-        &mut telemetry,
-        tokio_util::sync::CancellationToken::new(),
-    )
-    .await
-    .unwrap();
+    let outcome = run_new_sandbox_outcome(&factory, &ctx, &config, &default_params())
+        .await
+        .unwrap();
 
     let failure = outcome.failure.as_ref().expect("expected failure");
     assert_eq!(failure.exit_code, 126);
@@ -855,7 +713,7 @@ async fn execute_inner_success_skips_abnormal_exit_diagnostics() {
     let factory = sandbox_mock::MockSandboxFactory::with_overrides(Arc::clone(&overrides));
 
     let (exit_code, error) =
-        run_execute_inner(&factory, &minimal_context(), &config, &default_params())
+        run_new_sandbox_status(&factory, &minimal_context(), &config, &default_params())
             .await
             .unwrap();
 
@@ -878,7 +736,7 @@ async fn execute_inner_nonzero_with_stderr_skips_abnormal_exit_diagnostics() {
     let factory = sandbox_mock::MockSandboxFactory::with_overrides(Arc::clone(&overrides));
 
     let (exit_code, error) =
-        run_execute_inner(&factory, &minimal_context(), &config, &default_params())
+        run_new_sandbox_status(&factory, &minimal_context(), &config, &default_params())
             .await
             .unwrap();
 
@@ -903,7 +761,7 @@ async fn execute_inner_nonzero_with_process_diagnostic_skips_abnormal_exit_diagn
     let factory = sandbox_mock::MockSandboxFactory::with_overrides(Arc::clone(&overrides));
 
     let (exit_code, error) =
-        run_execute_inner(&factory, &minimal_context(), &config, &default_params())
+        run_new_sandbox_status(&factory, &minimal_context(), &config, &default_params())
             .await
             .unwrap();
 
@@ -933,7 +791,7 @@ async fn execute_inner_nonzero_with_failure_diagnostic_skips_abnormal_exit_diagn
     let factory = sandbox_mock::MockSandboxFactory::with_overrides(Arc::clone(&overrides));
 
     let (exit_code, error) =
-        run_execute_inner(&factory, &minimal_context(), &config, &default_params())
+        run_new_sandbox_status(&factory, &minimal_context(), &config, &default_params())
             .await
             .unwrap();
 

--- a/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
@@ -7,7 +7,7 @@ async fn execute_inner_happy_path() {
     let factory = MockSandboxFactory::new();
 
     let (exit_code, error_msg) =
-        run_execute_inner(&factory, &minimal_context(), &config, &default_params())
+        run_new_sandbox_status(&factory, &minimal_context(), &config, &default_params())
             .await
             .unwrap();
     assert_eq!(exit_code, 0);
@@ -210,7 +210,7 @@ async fn execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_
         ("VM0_STUCK_TOOL_TIMEOUT_SECS".into(), "3".into()),
     ]));
 
-    let (exit_code, error_msg) = run_execute_inner(&factory, &ctx, &config, &default_params())
+    let (exit_code, error_msg) = run_new_sandbox_status(&factory, &ctx, &config, &default_params())
         .await
         .unwrap();
 
@@ -284,9 +284,10 @@ async fn execute_inner_passes_device_rate_limits_to_sandbox_create() {
         ..default_params()
     };
 
-    let (exit_code, error_msg) = run_execute_inner(&factory, &minimal_context(), &config, &params)
-        .await
-        .unwrap();
+    let (exit_code, error_msg) =
+        run_new_sandbox_status(&factory, &minimal_context(), &config, &params)
+            .await
+            .unwrap();
 
     assert_eq!(exit_code, 0);
     assert!(error_msg.is_none());
@@ -310,7 +311,7 @@ async fn execute_inner_launches_agent_stream_only_without_guest_log_tee() {
     let factory = sandbox_mock::MockSandboxFactory::with_overrides(overrides.clone());
 
     let (exit_code, error_msg) =
-        run_execute_inner(&factory, &minimal_context(), &config, &default_params())
+        run_new_sandbox_status(&factory, &minimal_context(), &config, &default_params())
             .await
             .unwrap();
     assert_eq!(exit_code, 0);
@@ -332,7 +333,7 @@ async fn execute_inner_with_snapshot_runs_clock_fix_and_reseed() {
         restore_guest_state: true,
         ..default_params()
     };
-    let (exit_code, _) = run_execute_inner(&factory, &minimal_context(), &config, &params)
+    let (exit_code, _) = run_new_sandbox_status(&factory, &minimal_context(), &config, &params)
         .await
         .unwrap();
     assert_eq!(exit_code, 0);
@@ -354,7 +355,7 @@ async fn execute_inner_with_storage_manifest() {
         )],
         artifacts: vec![],
     });
-    let (exit_code, _) = run_execute_inner(&factory, &ctx, &config, &default_params())
+    let (exit_code, _) = run_new_sandbox_status(&factory, &ctx, &config, &default_params())
         .await
         .unwrap();
     assert_eq!(exit_code, 0);
@@ -371,7 +372,7 @@ async fn execute_inner_with_resume_session() {
         cli_agent_session_id: "sess-abc-123".into(),
         session_history: r#"{"type":"init"}"#.into(),
     });
-    let (exit_code, _) = run_execute_inner(&factory, &ctx, &config, &default_params())
+    let (exit_code, _) = run_new_sandbox_status(&factory, &ctx, &config, &default_params())
         .await
         .unwrap();
     assert_eq!(exit_code, 0);
@@ -384,7 +385,7 @@ async fn execute_inner_create_failure_returns_error() {
     let factory = MockSandboxFactory::new();
     factory.push_create_result(Err(sandbox_create_error("no free devices")));
 
-    let err = run_execute_inner(&factory, &minimal_context(), &config, &default_params())
+    let err = run_new_sandbox_status(&factory, &minimal_context(), &config, &default_params())
         .await
         .unwrap_err();
     assert!(err.to_string().contains("no free devices"), "got: {err}");

--- a/crates/runner/src/executor/tests/sandbox_run_tests/mod.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/mod.rs
@@ -30,9 +30,9 @@ use super::super::{
 use super::support::{
     CapturedEvent, CapturedEvents, DestroyPanicFactory, QueuedCopyFileSandbox, api_storage,
     assert_proxy_registry_empty, create_overridden_sandbox, default_params,
-    make_reusable_idle_sandbox, minimal_context, run_execute_inner, sandbox_create_error,
-    sandbox_exec_error, sandbox_write_file_error, seed_workspace_image_cache, test_budget_lease,
-    test_device_rate_limits, test_executor_config, test_telemetry,
+    make_reusable_idle_sandbox, minimal_context, run_new_sandbox_outcome, run_new_sandbox_status,
+    sandbox_create_error, sandbox_exec_error, sandbox_write_file_error, seed_workspace_image_cache,
+    test_budget_lease, test_device_rate_limits, test_executor_config, test_telemetry,
 };
 use crate::ids::RunId;
 use crate::paths::{RunnerPaths, scoped_session_workspace_cache_key};

--- a/crates/runner/src/executor/tests/support/execution.rs
+++ b/crates/runner/src/executor/tests/support/execution.rs
@@ -9,22 +9,24 @@ use super::super::super::agent_run::{
     run_in_sandbox_with_process_cancel_timeouts,
 };
 use super::super::super::sandbox_run::execute_new_sandbox;
-use super::super::super::{ExecutorConfig, JobParams, NewSandboxDispatch, PROCESS_CANCEL_TIMEOUTS};
+use super::super::super::{
+    ExecuteOutcome, ExecutorConfig, JobParams, NewSandboxDispatch, PROCESS_CANCEL_TIMEOUTS,
+};
 use super::config::test_telemetry;
 use crate::error::RunnerResult;
 use crate::types::{ExecutionContext, SandboxReuseResult};
 
 pub(in crate::executor::tests) const RUN_IN_SANDBOX_TEST_TIMEOUT: Duration = Duration::from_secs(5);
 
-pub(in crate::executor::tests) async fn run_execute_inner(
+pub(in crate::executor::tests) async fn run_new_sandbox_outcome(
     factory: &MockSandboxFactory,
     ctx: &ExecutionContext,
     config: &ExecutorConfig,
     params: &JobParams,
-) -> RunnerResult<(i32, Option<String>)> {
+) -> RunnerResult<ExecuteOutcome> {
     let mut telemetry = test_telemetry(config, ctx);
     let cancel = CancellationToken::new();
-    let outcome = execute_new_sandbox(
+    execute_new_sandbox(
         factory,
         ctx,
         NewSandboxDispatch {
@@ -36,7 +38,16 @@ pub(in crate::executor::tests) async fn run_execute_inner(
         &mut telemetry,
         cancel,
     )
-    .await?;
+    .await
+}
+
+pub(in crate::executor::tests) async fn run_new_sandbox_status(
+    factory: &MockSandboxFactory,
+    ctx: &ExecutionContext,
+    config: &ExecutorConfig,
+    params: &JobParams,
+) -> RunnerResult<(i32, Option<String>)> {
+    let outcome = run_new_sandbox_outcome(factory, ctx, config, params).await?;
     Ok((outcome.exit_code(), outcome.error().map(ToOwned::to_owned)))
 }
 

--- a/crates/runner/src/executor/tests/support/mod.rs
+++ b/crates/runner/src/executor/tests/support/mod.rs
@@ -16,8 +16,8 @@ pub(super) use self::env::{
     build_env_for_test, build_env_for_test_result, build_env_for_test_with_host_env,
 };
 pub(super) use self::execution::{
-    RUN_IN_SANDBOX_TEST_TIMEOUT, run_execute_inner, spawn_run_in_sandbox_test,
-    spawn_run_in_sandbox_test_with_timeouts,
+    RUN_IN_SANDBOX_TEST_TIMEOUT, run_new_sandbox_outcome, run_new_sandbox_status,
+    spawn_run_in_sandbox_test, spawn_run_in_sandbox_test_with_timeouts,
 };
 pub(super) use self::manifest::{api_artifact, api_storage};
 pub(super) use self::sandbox::{


### PR DESCRIPTION
## Summary

- add a shared `run_new_sandbox_outcome` helper for default new-sandbox tests that need `ExecuteOutcome`
- replace the old `run_execute_inner` helper with `run_new_sandbox_status`, derived from the outcome helper
- update diagnostics/fresh sandbox tests to use the clearer helpers while keeping telemetry and special execution paths explicit

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p runner executor::tests::sandbox_run_tests`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`

Closes #18677
