### PR TITLE
fix(mitm-addon): ignore invalid UTF-8 flush markers

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -399,8 +399,8 @@ def _flush_jsonl_for_runner_request() -> None:
 def _read_jsonl_flush_request() -> tuple[str, str] | None:
     marker_path = Path(__file__).resolve().parent / _JSONL_FLUSH_REQUEST_FILE
     try:
-        marker = json.loads(marker_path.read_text())
-    except (OSError, json.JSONDecodeError):
+        marker = json.loads(marker_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
         return None
 
     if not isinstance(marker, dict):

--- a/crates/runner/mitm-addon/src/usage/counters.py
+++ b/crates/runner/mitm-addon/src/usage/counters.py
@@ -99,8 +99,8 @@ def read_usage_flush_request_id() -> str | None:
 
     marker_path = Path(pending_path).with_name(_FLUSH_REQUEST_FILE)
     try:
-        marker = json.loads(marker_path.read_text())
-    except (OSError, json.JSONDecodeError):
+        marker = json.loads(marker_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
         return None
 
     if not isinstance(marker, dict):

--- a/crates/runner/mitm-addon/tests/test_counters.py
+++ b/crates/runner/mitm-addon/tests/test_counters.py
@@ -218,6 +218,13 @@ class TestUsagePendingCounter:
 
         assert usage.read_usage_flush_request_id() is None
 
+    def test_read_usage_flush_request_id_ignores_invalid_utf8_marker(self, tmp_path):
+        pending_path = tmp_path / "usage-pending"
+        usage.set_pending_path(str(pending_path), usage_state_id="runner-state")
+        (tmp_path / "usage-flush-request").write_bytes(b"\xff")
+
+        assert usage.read_usage_flush_request_id() is None
+
     @pytest.mark.parametrize(
         "marker",
         [

--- a/crates/runner/mitm-addon/tests/test_runner_usage_flush_signal.py
+++ b/crates/runner/mitm-addon/tests/test_runner_usage_flush_signal.py
@@ -232,6 +232,20 @@ class TestRunnerUsageFlushSignal:
         flush_log_path.assert_not_called()
         assert not runner_usage_flush_files.jsonl_flush_state_path.exists()
 
+    def test_jsonl_flush_request_ignores_invalid_utf8_marker(
+        self, runner_usage_flush_files: RunnerUsageFlushFiles
+    ):
+        runner_usage_flush_files.jsonl_flush_request_path.write_bytes(b"\xff")
+
+        with (
+            patch.object(mitm_addon, "__file__", str(runner_usage_flush_files.addon_file)),
+            patch.object(mitm_addon, "flush_log_path") as flush_log_path,
+        ):
+            mitm_addon._flush_jsonl_for_runner_request()
+
+        flush_log_path.assert_not_called()
+        assert not runner_usage_flush_files.jsonl_flush_state_path.exists()
+
     def test_jsonl_flush_failure_writes_pending_state(
         self, runner_usage_flush_files: RunnerUsageFlushFiles
     ):


### PR DESCRIPTION
## Summary

- Treat invalid UTF-8 `usage-flush-request` markers as malformed usage flush markers.
- Treat invalid UTF-8 `jsonl-flush-request` markers the same way in the runner-triggered JSONL flush path.
- Add real-file regressions for both marker files.

The normal Rust writer serializes these markers as JSON bytes and writes them atomically, so this is not about normal partial writes. It keeps malformed cross-process marker handling consistent with the existing missing/invalid JSON/stale marker behavior.

Closes #18680

## Tests

- `.venv/bin/python -m pytest tests/test_counters.py::TestUsagePendingCounter::test_read_usage_flush_request_id_ignores_invalid_utf8_marker tests/test_runner_usage_flush_signal.py::TestRunnerUsageFlushSignal::test_jsonl_flush_request_ignores_invalid_utf8_marker -q`
- `.venv/bin/python -m pytest tests/test_counters.py tests/test_runner_usage_flush_signal.py -q`
- `.venv/bin/python -m ruff check src/usage/counters.py src/mitm_addon.py tests/test_counters.py tests/test_runner_usage_flush_signal.py`
- `.venv/bin/python -m ruff format --check src/usage/counters.py src/mitm_addon.py tests/test_counters.py tests/test_runner_usage_flush_signal.py`
- `.venv/bin/python -m pytest tests/ -q`