### PR TITLE
test: align stream buffer fixtures with hook contract

### DIFF
--- a/crates/runner/mitm-addon/tests/stream_buffer_helpers.py
+++ b/crates/runner/mitm-addon/tests/stream_buffer_helpers.py
@@ -10,15 +10,24 @@ def set_response_stream_buffer(
     body: bytes,
     *,
     truncated: bool = False,
-    total_bytes: int | None = None,
 ) -> None:
     """Seed response stream metadata with the production hook's normal shape."""
-    observed_total_bytes = total_bytes
-    if observed_total_bytes is None:
-        observed_total_bytes = len(body) + 1 if truncated else len(body)
-
     flow.metadata[metadata_keys.STREAM_BUFFER] = bytearray(body)
     flow.metadata[metadata_keys.STREAM_BUFFER_STATE] = {
         "truncated": truncated,
-        "total_bytes": observed_total_bytes,
+        "total_bytes": len(body) + 1 if truncated else len(body),
+    }
+
+
+def set_request_stream_buffer(
+    flow: http.HTTPFlow,
+    body: bytes,
+    *,
+    truncated: bool = False,
+) -> None:
+    """Seed request stream metadata with the production hook's normal shape."""
+    flow.metadata[metadata_keys.REQUEST_STREAM_BUFFER] = bytearray(body)
+    flow.metadata[metadata_keys.REQUEST_STREAM_BUFFER_STATE] = {
+        "truncated": truncated,
+        "total_bytes": len(body) + 1 if truncated else len(body),
     }

--- a/crates/runner/mitm-addon/tests/stream_buffer_helpers.py
+++ b/crates/runner/mitm-addon/tests/stream_buffer_helpers.py
@@ -1,4 +1,9 @@
-"""Shared stream-buffer metadata helpers for mitm-addon tests."""
+"""Shared stream-buffer metadata helpers for mitm-addon tests.
+
+These helpers seed the hook-owned metadata keys and required state fields for
+tests that consume buffered stream metadata. Tests for byte-limit behavior
+should use the real request/response stream callbacks instead.
+"""
 
 from mitmproxy import http
 
@@ -11,7 +16,7 @@ def set_response_stream_buffer(
     *,
     truncated: bool = False,
 ) -> None:
-    """Seed response stream metadata with the production hook's normal shape."""
+    """Seed response stream metadata with the hook-owned key/state shape."""
     flow.metadata[metadata_keys.STREAM_BUFFER] = bytearray(body)
     flow.metadata[metadata_keys.STREAM_BUFFER_STATE] = {
         "truncated": truncated,
@@ -25,7 +30,7 @@ def set_request_stream_buffer(
     *,
     truncated: bool = False,
 ) -> None:
-    """Seed request stream metadata with the production hook's normal shape."""
+    """Seed request stream metadata with the hook-owned key/state shape."""
     flow.metadata[metadata_keys.REQUEST_STREAM_BUFFER] = bytearray(body)
     flow.metadata[metadata_keys.REQUEST_STREAM_BUFFER_STATE] = {
         "truncated": truncated,

--- a/crates/runner/mitm-addon/tests/stream_buffer_helpers.py
+++ b/crates/runner/mitm-addon/tests/stream_buffer_helpers.py
@@ -1,0 +1,19 @@
+"""Shared stream-buffer metadata helpers for mitm-addon tests."""
+
+from mitmproxy import http
+
+import flow_metadata_keys as metadata_keys
+
+
+def set_response_stream_buffer(
+    flow: http.HTTPFlow,
+    body: bytes,
+    *,
+    truncated: bool = False,
+    total_bytes: int | None = None,
+) -> None:
+    flow.metadata[metadata_keys.STREAM_BUFFER] = bytearray(body)
+    flow.metadata[metadata_keys.STREAM_BUFFER_STATE] = {
+        "truncated": truncated,
+        "total_bytes": total_bytes if total_bytes is not None else len(body),
+    }

--- a/crates/runner/mitm-addon/tests/stream_buffer_helpers.py
+++ b/crates/runner/mitm-addon/tests/stream_buffer_helpers.py
@@ -12,8 +12,13 @@ def set_response_stream_buffer(
     truncated: bool = False,
     total_bytes: int | None = None,
 ) -> None:
+    """Seed response stream metadata with the production hook's normal shape."""
+    observed_total_bytes = total_bytes
+    if observed_total_bytes is None:
+        observed_total_bytes = len(body) + 1 if truncated else len(body)
+
     flow.metadata[metadata_keys.STREAM_BUFFER] = bytearray(body)
     flow.metadata[metadata_keys.STREAM_BUFFER_STATE] = {
         "truncated": truncated,
-        "total_bytes": total_bytes if total_bytes is not None else len(body),
+        "total_bytes": observed_total_bytes,
     }

--- a/crates/runner/mitm-addon/tests/test_body_capture_decompression.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture_decompression.py
@@ -11,6 +11,7 @@ from mitmproxy import http
 from body_capture import add_capture_fields
 from body_limits import STREAM_BUFFER_LIMIT
 from tests.body_decode_helpers import pseudo_random_ascii, track_brotli_decompressor
+from tests.stream_buffer_helpers import set_response_stream_buffer
 
 
 class TestDecompression:
@@ -26,8 +27,7 @@ class TestDecompression:
             response_content_type=content_type,
             response_encoding=encoding or None,
         )
-        flow.metadata["stream_buffer"] = bytearray(data)
-        flow.metadata["stream_buffer_state"] = {"truncated": False}
+        set_response_stream_buffer(flow, data)
         return flow
 
     def test_no_encoding_captures_plain_text(self, real_flow):

--- a/crates/runner/mitm-addon/tests/test_body_capture_decompression.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture_decompression.py
@@ -18,7 +18,13 @@ class TestDecompression:
     """Integration tests for decompression through add_capture_fields."""
 
     def _make_flow_with_compressed_buffer(
-        self, real_flow, data: bytes, encoding: str, content_type: str = "application/json"
+        self,
+        real_flow,
+        data: bytes,
+        encoding: str,
+        content_type: str = "application/json",
+        *,
+        truncated: bool = False,
     ) -> http.HTTPFlow:
         flow = real_flow(
             method="POST",
@@ -27,7 +33,7 @@ class TestDecompression:
             response_content_type=content_type,
             response_encoding=encoding or None,
         )
-        set_response_stream_buffer(flow, data)
+        set_response_stream_buffer(flow, data, truncated=truncated)
         return flow
 
     def test_no_encoding_captures_plain_text(self, real_flow):
@@ -180,8 +186,9 @@ class TestDecompression:
         original = b"x" * 100_000
         compressed = gzip.compress(original)
         truncated = compressed[: len(compressed) // 2]
-        flow = self._make_flow_with_compressed_buffer(real_flow, truncated, "gzip", "text/plain")
-        flow.metadata["stream_buffer_state"]["truncated"] = True
+        flow = self._make_flow_with_compressed_buffer(
+            real_flow, truncated, "gzip", "text/plain", truncated=True
+        )
         entry = {}
         add_capture_fields(flow, entry)
         assert "response_body" in entry
@@ -208,8 +215,9 @@ class TestDecompression:
         original = b"hello world " * 1000
         compressed = brotli.compress(original)
         truncated = compressed[: len(compressed) // 2]
-        flow = self._make_flow_with_compressed_buffer(real_flow, truncated, "br", "text/plain")
-        flow.metadata["stream_buffer_state"]["truncated"] = True
+        flow = self._make_flow_with_compressed_buffer(
+            real_flow, truncated, "br", "text/plain", truncated=True
+        )
         entry = {}
         add_capture_fields(flow, entry)
         # Should not crash; body is either partial decompressed or original
@@ -220,8 +228,9 @@ class TestDecompression:
         original = b"hello world " * 1000
         compressed = zstandard.ZstdCompressor().compress(original)
         truncated = compressed[: len(compressed) // 2]
-        flow = self._make_flow_with_compressed_buffer(real_flow, truncated, "zstd", "text/plain")
-        flow.metadata["stream_buffer_state"]["truncated"] = True
+        flow = self._make_flow_with_compressed_buffer(
+            real_flow, truncated, "zstd", "text/plain", truncated=True
+        )
         entry = {}
         add_capture_fields(flow, entry)
         assert entry.get("response_body_truncated") is True or "response_body" not in entry

--- a/crates/runner/mitm-addon/tests/test_body_capture_stream_buffer.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture_stream_buffer.py
@@ -7,6 +7,7 @@ import pytest
 import flow_metadata_keys as metadata_keys
 from body_capture import add_capture_fields
 from body_limits import STREAM_BUFFER_LIMIT
+from tests.stream_buffer_helpers import set_response_stream_buffer
 
 
 class TestBodyCaptureStreamBuffer:
@@ -154,8 +155,7 @@ class TestBodyCaptureStreamBuffer:
             response_body=b"should-be-ignored",
         )
         body = b'{"streamed": true}'
-        flow.metadata["stream_buffer"] = bytearray(body)
-        flow.metadata["stream_buffer_state"] = {"truncated": False}
+        set_response_stream_buffer(flow, body)
         entry = {}
         add_capture_fields(flow, entry)
         assert entry["response_body"] == '{"streamed": true}'
@@ -171,8 +171,7 @@ class TestBodyCaptureStreamBuffer:
             response_content_type="application/json",
             include_request_id=True,
         )
-        flow.metadata["stream_buffer"] = bytearray()
-        flow.metadata["stream_buffer_state"] = {"truncated": False}
+        set_response_stream_buffer(flow, b"")
         entry = {}
         add_capture_fields(flow, entry)
         assert "response_body" not in entry
@@ -329,8 +328,7 @@ class TestBodyCaptureStreamBuffer:
             response_content_type="application/json",
             include_request_id=True,
         )
-        flow.metadata["stream_buffer"] = bytearray(body)
-        flow.metadata["stream_buffer_state"] = {"truncated": True}
+        set_response_stream_buffer(flow, body, truncated=True)
         entry = {}
         add_capture_fields(flow, entry)
         assert entry["response_body_truncated"] is True
@@ -344,8 +342,7 @@ class TestBodyCaptureStreamBuffer:
             response_content_type="application/octet-stream",
             include_request_id=True,
         )
-        flow.metadata["stream_buffer"] = bytearray(body)
-        flow.metadata["stream_buffer_state"] = {"truncated": False}
+        set_response_stream_buffer(flow, body)
         entry = {}
         add_capture_fields(flow, entry)
         assert "response_body" not in entry
@@ -361,8 +358,7 @@ class TestBodyCaptureStreamBuffer:
             response_content_type="application/octet-stream",
             include_request_id=True,
         )
-        flow.metadata["stream_buffer"] = bytearray(body)
-        flow.metadata["stream_buffer_state"] = {"truncated": True}
+        set_response_stream_buffer(flow, body, truncated=True)
         entry = {}
         add_capture_fields(flow, entry)
         assert "response_body" not in entry
@@ -381,8 +377,7 @@ class TestBodyCaptureStreamBuffer:
             response_content_type="application/json",
             response_encoding="gzip",
         )
-        flow.metadata["stream_buffer"] = bytearray(compressed)
-        flow.metadata["stream_buffer_state"] = {"truncated": False}
+        set_response_stream_buffer(flow, compressed)
         entry = {}
         add_capture_fields(flow, entry)
         assert entry["response_body"] == '{"result": "ok"}'
@@ -400,8 +395,7 @@ class TestBodyCaptureStreamBuffer:
             response_content_type="application/json",
             response_encoding="gzip",
         )
-        flow.metadata["stream_buffer"] = bytearray(compressed)
-        flow.metadata["stream_buffer_state"] = {"truncated": False}
+        set_response_stream_buffer(flow, compressed)
         entry = {}
         add_capture_fields(flow, entry)
         assert "response_body" not in entry
@@ -418,8 +412,7 @@ class TestBodyCaptureStreamBuffer:
             response_content_type="application/json",
             response_encoding="gzip",
         )
-        flow.metadata["stream_buffer"] = bytearray(compressed)
-        flow.metadata["stream_buffer_state"] = {"truncated": True}
+        set_response_stream_buffer(flow, compressed, truncated=True)
         entry = {}
         add_capture_fields(flow, entry)
         assert "response_body" not in entry

--- a/crates/runner/mitm-addon/tests/test_body_capture_stream_buffer.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture_stream_buffer.py
@@ -1,4 +1,4 @@
-"""Tests for body capture response stream-buffer contracts."""
+"""Tests for body capture request and response stream-buffer contracts."""
 
 import gzip
 
@@ -7,7 +7,7 @@ import pytest
 import flow_metadata_keys as metadata_keys
 from body_capture import add_capture_fields
 from body_limits import STREAM_BUFFER_LIMIT
-from tests.stream_buffer_helpers import set_response_stream_buffer
+from tests.stream_buffer_helpers import set_request_stream_buffer, set_response_stream_buffer
 
 
 class TestBodyCaptureStreamBuffer:
@@ -22,8 +22,7 @@ class TestBodyCaptureStreamBuffer:
             include_request_id=True,
         )
         body = b'{"streamed": true}'
-        flow.metadata[metadata_keys.REQUEST_STREAM_BUFFER] = bytearray(body)
-        flow.metadata[metadata_keys.REQUEST_STREAM_BUFFER_STATE] = {"truncated": False}
+        set_request_stream_buffer(flow, body)
         entry = {}
         add_capture_fields(flow, entry)
         assert entry["request_body"] == '{"streamed": true}'
@@ -38,8 +37,7 @@ class TestBodyCaptureStreamBuffer:
             request_content_type="text/plain",
             include_request_id=True,
         )
-        flow.metadata[metadata_keys.REQUEST_STREAM_BUFFER] = bytearray(body)
-        flow.metadata[metadata_keys.REQUEST_STREAM_BUFFER_STATE] = {"truncated": True}
+        set_request_stream_buffer(flow, body, truncated=True)
         entry = {}
         add_capture_fields(flow, entry)
         assert entry["request_body"] == "x" * STREAM_BUFFER_LIMIT
@@ -54,8 +52,7 @@ class TestBodyCaptureStreamBuffer:
             request_content_type="application/octet-stream",
             include_request_id=True,
         )
-        flow.metadata[metadata_keys.REQUEST_STREAM_BUFFER] = bytearray(body)
-        flow.metadata[metadata_keys.REQUEST_STREAM_BUFFER_STATE] = {"truncated": True}
+        set_request_stream_buffer(flow, body, truncated=True)
         entry = {}
         add_capture_fields(flow, entry)
         assert "request_body" not in entry
@@ -87,8 +84,7 @@ class TestBodyCaptureStreamBuffer:
             response_content_type="application/json",
             include_request_id=True,
         )
-        flow.metadata[metadata_keys.REQUEST_STREAM_BUFFER] = bytearray()
-        flow.metadata[metadata_keys.REQUEST_STREAM_BUFFER_STATE] = {"truncated": False}
+        set_request_stream_buffer(flow, b"")
         entry = {}
         add_capture_fields(flow, entry)
         assert "request_body" not in entry

--- a/crates/runner/mitm-addon/tests/test_connector_usage_dispatcher.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage_dispatcher.py
@@ -50,10 +50,9 @@ class TestConnectorUsageDispatcher:
         flow = self._make_x_flow(real_flow, tmp_path, body=body)
 
         assert flow.metadata[metadata_keys.STREAM_BUFFER] == bytearray(body)
-        assert flow.metadata[metadata_keys.STREAM_BUFFER_STATE] == {
-            "truncated": False,
-            "total_bytes": len(body),
-        }
+        stream_state = flow.metadata[metadata_keys.STREAM_BUFFER_STATE]
+        assert stream_state["truncated"] is False
+        assert stream_state["total_bytes"] == len(body)
 
     def test_skips_for_model_provider(self, tmp_path, real_flow):
         """Model-provider flows go through report_model_provider_usage instead.

--- a/crates/runner/mitm-addon/tests/test_connector_usage_dispatcher.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage_dispatcher.py
@@ -4,6 +4,7 @@ import json
 
 import pytest
 
+import flow_metadata_keys as metadata_keys
 import usage
 from tests.jsonl_log_helpers import (
     jsonl_exists_after_flush,
@@ -43,6 +44,16 @@ class TestConnectorUsageDispatcher:
             for body in [request.json_body()]
             for event in body["events"]
         ]
+
+    def test_x_usage_flow_stream_state_matches_response_stream_contract(self, tmp_path, real_flow):
+        body = b'{"data":[{"id":"1","text":"hi"}]}'
+        flow = self._make_x_flow(real_flow, tmp_path, body=body)
+
+        assert flow.metadata[metadata_keys.STREAM_BUFFER] == bytearray(body)
+        assert flow.metadata[metadata_keys.STREAM_BUFFER_STATE] == {
+            "truncated": False,
+            "total_bytes": len(body),
+        }
 
     def test_skips_for_model_provider(self, tmp_path, real_flow):
         """Model-provider flows go through report_model_provider_usage instead.

--- a/crates/runner/mitm-addon/tests/test_model_provider_response_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_response_usage.py
@@ -23,7 +23,7 @@ from tests.jsonl_log_helpers import (
     read_jsonl_entries_after_flush,
     read_jsonl_text_after_flush,
 )
-from tests.usage_helpers import set_stream_buffer
+from tests.stream_buffer_helpers import set_response_stream_buffer
 
 
 @dataclass(frozen=True)
@@ -386,7 +386,7 @@ class TestModelProviderResponseUsage:
         flow = self._model_provider_flow(real_flow, tmp_path, provider_case)
         # No model_provider_usage set (no SSE parser) — JSON body in buffer
         body = _standard_success_payload(provider_case)
-        flow.metadata["stream_buffer"] = bytearray(body)
+        set_response_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200,
             headers=header_map(
@@ -408,7 +408,7 @@ class TestModelProviderResponseUsage:
         provider_case = OPENAI_RESPONSES_CASE
         flow = self._model_provider_flow(real_flow, tmp_path, provider_case)
         body = _standard_success_payload(provider_case)
-        flow.metadata["stream_buffer"] = bytearray(body)
+        set_response_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200,
             headers=header_map(
@@ -439,7 +439,7 @@ class TestModelProviderResponseUsage:
             proxy_log_path=proxy_log_path,
         )
         body = b'{"id":"msg_1","model":"claude-sonnet-4-6","usage":{"input_tokens":50'
-        set_stream_buffer(flow, body)
+        set_response_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200,
             headers=header_map({"content-type": "application/json"}),
@@ -473,7 +473,7 @@ class TestModelProviderResponseUsage:
                 "usage": {"input_tokens": 50},
             }
         ).encode()
-        set_stream_buffer(flow, body)
+        set_response_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200,
             headers=header_map({"content-type": "application/json"}),
@@ -501,7 +501,7 @@ class TestModelProviderResponseUsage:
             proxy_log_path=proxy_log_path,
         )
         body = b'{"id":"resp_1","model":"gpt-5.5","usage":{"input_tokens":50'
-        set_stream_buffer(flow, body)
+        set_response_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200,
             headers=header_map({"content-type": "application/json"}),
@@ -546,7 +546,7 @@ class TestModelProviderResponseUsage:
         payload = _standard_success_payload(provider_case)
         body = encoding_case.make_body(payload)
 
-        set_stream_buffer(flow, body)
+        set_response_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200,
             headers=header_map(
@@ -594,7 +594,7 @@ class TestModelProviderResponseUsage:
             body = gzip.compress(b"") + gzip.compress(payload)
         else:
             body = zlib.compress(b"") + zlib.compress(payload)
-        set_stream_buffer(flow, body)
+        set_response_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200,
             headers=header_map(
@@ -649,7 +649,7 @@ class TestModelProviderResponseUsage:
         else:
             body = zstandard.ZstdCompressor().compress(payload)
 
-        set_stream_buffer(flow, body)
+        set_response_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200,
             headers=header_map(
@@ -689,7 +689,7 @@ class TestModelProviderResponseUsage:
             proxy_log_path=proxy_log_path,
         )
         body = b'{"id":"msg_1"}'
-        set_stream_buffer(flow, body)
+        set_response_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200,
             headers=header_map({"content-type": "application/json"}),
@@ -712,7 +712,7 @@ class TestModelProviderResponseUsage:
             proxy_log_path=proxy_log_path,
         )
         body = b'{"id":"resp_1","model":"gpt-5.5"}'
-        set_stream_buffer(flow, body)
+        set_response_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200,
             headers=header_map({"content-type": "application/json"}),
@@ -768,7 +768,7 @@ class TestModelProviderResponseUsage:
             response_headers["content-encoding"] = (
                 "zstd" if encoding_case == "zstd-no-size" else encoding_case
             )
-        set_stream_buffer(flow, body)
+        set_response_stream_buffer(flow, body)
         flow.response = tutils.tresp(status_code=200, headers=header_map(response_headers))
 
         webhook = self._run_response(flow)
@@ -788,7 +788,7 @@ class TestModelProviderResponseUsage:
             proxy_log_path=proxy_log_path,
         )
         body = b'{"id":"msg_1","model":"claude-sonnet-4-6"}'
-        set_stream_buffer(flow, body)
+        set_response_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200,
             headers=header_map({"content-type": "application/json"}),
@@ -831,7 +831,7 @@ class TestModelProviderResponseUsage:
             cached_tokens=0,
         )
 
-        set_stream_buffer(flow, body)
+        set_response_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200,
             headers=header_map({"content-type": "application/json"}),
@@ -849,7 +849,7 @@ class TestModelProviderResponseUsage:
         provider_case = CODEX_OAUTH_RESPONSES_CASE
         flow = self._model_provider_flow(real_flow, tmp_path, provider_case)
         body = _standard_success_payload(provider_case)
-        flow.metadata["stream_buffer"] = bytearray(body)
+        set_response_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200,
             headers=header_map(
@@ -878,7 +878,7 @@ class TestModelProviderResponseUsage:
             billable=False,
         )
         body = _standard_success_payload(OPENAI_RESPONSES_CASE)
-        flow.metadata["stream_buffer"] = bytearray(body)
+        set_response_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200,
             headers=header_map({"content-type": "application/json"}),
@@ -925,7 +925,7 @@ class TestModelProviderResponseUsage:
             proxy_log_path=proxy_log_path,
         )
         body = b'{"id":"resp_1","model":"gpt-5.5","usage":{"input_tokens":50'
-        set_stream_buffer(flow, body)
+        set_response_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200,
             headers=header_map({"content-type": "application/json"}),
@@ -1269,7 +1269,7 @@ class TestModelProviderResponseUsage:
         flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.github.com/repos"
         flow.metadata[metadata_keys.FIREWALL_NAME] = "github"
         body = b'{"incomplete":'
-        set_stream_buffer(flow, body)
+        set_response_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200, headers=header_map({"content-type": "application/json"})
         )
@@ -1288,7 +1288,7 @@ class TestModelProviderResponseUsage:
         flow.metadata[metadata_keys.ORIGINAL_URL] = ANTHROPIC_JSON_CASE.original_url
         flow.metadata[metadata_keys.FIREWALL_NAME] = firewall_name
         body = _standard_success_payload(ANTHROPIC_JSON_CASE)
-        set_stream_buffer(flow, body)
+        set_response_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200, headers=header_map({"content-type": "application/json"})
         )

--- a/crates/runner/mitm-addon/tests/test_usage_reporting_idempotency.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting_idempotency.py
@@ -16,7 +16,7 @@ from tests.jsonl_log_helpers import (
     read_jsonl_entries_after_flush,
 )
 from tests.model_provider_flow_helpers import make_model_provider_flow
-from tests.usage_helpers import set_stream_buffer
+from tests.stream_buffer_helpers import set_response_stream_buffer
 
 
 class TestUsageReportingIdempotency:
@@ -39,7 +39,7 @@ class TestUsageReportingIdempotency:
             "tokens.output": 20,
         }
         body = b'{"id":"resp_1","usage":{"input_tokens":'
-        set_stream_buffer(flow, body)
+        set_response_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200,
             headers=header_map({"content-type": "application/json"}),

--- a/crates/runner/mitm-addon/tests/test_x_connector_pipeline.py
+++ b/crates/runner/mitm-addon/tests/test_x_connector_pipeline.py
@@ -14,6 +14,7 @@ import usage
 from body_limits import STREAM_BUFFER_LIMIT
 from tests.flow_helpers import response_stream
 from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
+from tests.stream_buffer_helpers import set_response_stream_buffer
 from tests.x_flow_helpers import (
     json_body_that_exceeds_decoder_recursion,
     json_body_that_exceeds_integer_digit_limit,
@@ -520,8 +521,7 @@ class TestXConnectorErrorPipeline:
             "lines_parsed": 23,
             "lines_failed": 0,
         }
-        flow.metadata["stream_buffer"] = bytearray()
-        flow.metadata["stream_buffer_state"] = {"truncated": False}
+        set_response_stream_buffer(flow, b"")
         flow.error = Error("connection reset by peer")
 
         with usage_webhook_api() as webhook:

--- a/crates/runner/mitm-addon/tests/usage_helpers.py
+++ b/crates/runner/mitm-addon/tests/usage_helpers.py
@@ -237,11 +237,3 @@ class UsageWebhookServer:
         handler.end_headers()
         if response.body:
             handler.wfile.write(response.body)
-
-
-def set_stream_buffer(flow, body: bytes) -> None:
-    flow.metadata["stream_buffer"] = bytearray(body)
-    flow.metadata["stream_buffer_state"] = {
-        "truncated": False,
-        "total_bytes": len(body),
-    }

--- a/crates/runner/mitm-addon/tests/x_connector_usage/test_unparseable.py
+++ b/crates/runner/mitm-addon/tests/x_connector_usage/test_unparseable.py
@@ -4,6 +4,7 @@ import json
 
 import pytest
 
+import flow_metadata_keys as metadata_keys
 import usage
 from tests.jsonl_log_helpers import (
     jsonl_exists_after_flush,
@@ -96,7 +97,7 @@ def test_truncated_buffer_with_no_hints_skips_billing(x_usage, tmp_path, real_fl
     error.  The previous blind fallback of 100 units was removed;
     ops audits via the proxy error log instead."""
     flow = x_usage.make_flow(real_flow, tmp_path, body=b"{")
-    flow.metadata["stream_buffer_state"] = {"truncated": True}
+    flow.metadata[metadata_keys.STREAM_BUFFER_STATE]["truncated"] = True
     proxy_log = tmp_path / "proxy.jsonl"
 
     assert x_usage.call_and_get_billing(flow) == []

--- a/crates/runner/mitm-addon/tests/x_connector_usage/test_unparseable.py
+++ b/crates/runner/mitm-addon/tests/x_connector_usage/test_unparseable.py
@@ -4,13 +4,13 @@ import json
 
 import pytest
 
-import flow_metadata_keys as metadata_keys
 import usage
 from tests.jsonl_log_helpers import (
     jsonl_exists_after_flush,
     read_jsonl_entries_after_flush,
     read_jsonl_text_after_flush,
 )
+from tests.stream_buffer_helpers import set_response_stream_buffer
 from tests.x_connector_usage.helpers import assert_lost_visibility_error
 
 
@@ -97,7 +97,7 @@ def test_truncated_buffer_with_no_hints_skips_billing(x_usage, tmp_path, real_fl
     error.  The previous blind fallback of 100 units was removed;
     ops audits via the proxy error log instead."""
     flow = x_usage.make_flow(real_flow, tmp_path, body=b"{")
-    flow.metadata[metadata_keys.STREAM_BUFFER_STATE]["truncated"] = True
+    set_response_stream_buffer(flow, b"{", truncated=True)
     proxy_log = tmp_path / "proxy.jsonl"
 
     assert x_usage.call_and_get_billing(flow) == []

--- a/crates/runner/mitm-addon/tests/x_flow_helpers.py
+++ b/crates/runner/mitm-addon/tests/x_flow_helpers.py
@@ -7,6 +7,7 @@ from mitmproxy import http
 from mitmproxy.test import tutils
 
 from tests.flow_helpers import header_map
+from tests.stream_buffer_helpers import set_response_stream_buffer
 
 RealFlowFactory = Callable[..., http.HTTPFlow]
 _JSON_RECURSION_FAILURE_DEPTH = 10_000
@@ -93,8 +94,7 @@ def make_x_usage_flow(
     flow.metadata["vm_sandbox_token"] = "test-token"
     flow.metadata["firewall_permission"] = permission
     flow.metadata["firewall_rule_match"] = rule
-    flow.metadata["stream_buffer"] = bytearray(body)
-    flow.metadata["stream_buffer_state"] = {"truncated": False}
+    set_response_stream_buffer(flow, body)
     return flow
 
 


### PR DESCRIPTION
## Summary

- Add dedicated request/response stream-buffer test helpers that write the metadata key shape produced by the mitm-addon stream hooks.
- Update normal mitm-addon stream-buffer fixtures, including X direct usage, model-provider fallback, body capture, and X error pipeline tests, to use the helpers.
- Keep malformed metadata tests explicit while preserving `total_bytes` when tests need to mark a stream buffer as truncated.

Closes #18678

## Tests

- `cd crates/runner/mitm-addon && .venv/bin/python -m pytest tests/test_connector_usage_dispatcher.py tests/x_connector_usage tests/test_model_provider_response_usage.py tests/test_usage_reporting_idempotency.py tests/test_body_capture_stream_buffer.py tests/test_body_capture_decompression.py tests/test_x_connector_pipeline.py`
- `cd crates/runner/mitm-addon && .venv/bin/ruff check .`
- `cd crates/runner/mitm-addon && .venv/bin/ruff format --check .`
- `cd crates/runner/mitm-addon && .venv/bin/basedpyright -p .`
- `git diff --check`
