### PR TITLE
ci: run runner consumers per architecture group

### DIFF
--- a/.github/scripts/runner-host-architecture-groups.sh
+++ b/.github/scripts/runner-host-architecture-groups.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 usage() {
   cat <<'USAGE'
-Usage: runner-host-architecture-groups.sh [matrix|has-groups|hosts ID]
+Usage: runner-host-architecture-groups.sh [matrix|has-groups|hosts ID|select-host ID KEY [HOSTS]]
 
 Emits compact JSON for configured runner host architecture groups.
 Inputs:
@@ -17,7 +17,8 @@ Commands:
   <none>      Emit the full local contract, including hosts.
   matrix      Emit the cross-job matrix contract, excluding hosts.
   has-groups  Emit true when at least one host group is configured.
-  hosts ID    Emit comma-separated hosts for the given architecture group.
+  hosts ID            Emit comma-separated hosts for the given architecture group.
+  select-host ID KEY [HOSTS]  Emit one deterministic host from the given architecture group.
 USAGE
 }
 
@@ -174,7 +175,7 @@ emit_has_groups() {
   fi
 }
 
-emit_hosts() {
+validate_group_id() {
   local group_id=${1:-}
   if [ -z "$group_id" ]; then
     echo "missing runner host group id" >&2
@@ -188,10 +189,49 @@ emit_hosts() {
       return 2
       ;;
   esac
+}
+
+emit_hosts() {
+  local group_id=${1:-}
+  validate_group_id "$group_id" || return $?
 
   local groups
   groups=$(emit_groups) || return $?
   jq -r --arg id "$group_id" '.[] | select(.id == $id) | .hosts' <<<"$groups"
+}
+
+emit_selected_host() {
+  local group_id=${1:-}
+  local selection_key=${2:-}
+  local hosts=${3:-}
+  validate_group_id "$group_id" || return $?
+  if [ -z "$selection_key" ]; then
+    echo "missing runner host selection key" >&2
+    return 2
+  fi
+
+  if [ -z "$hosts" ]; then
+    hosts=$(emit_hosts "$group_id") || return $?
+  fi
+
+  local -a host_list=()
+  mapfile -t host_list < <(
+    printf '%s\n' "$hosts" \
+      | tr ',' '\n' \
+      | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' \
+      | sed '/^$/d'
+  )
+
+  local host_count=${#host_list[@]}
+  if [ "$host_count" -lt 1 ]; then
+    echo "no runner hosts found for runner host group: ${group_id}" >&2
+    return 2
+  fi
+
+  local hash host_index
+  hash=$(printf '%s-%s' "$selection_key" "$group_id" | md5sum | cut -c1-8)
+  host_index=$(( 0x$hash % host_count ))
+  printf '%s\n' "${host_list[$host_index]}"
 }
 
 cmd="${1:-}"
@@ -207,6 +247,9 @@ case "$cmd" in
     ;;
   hosts)
     emit_hosts "${2:-}"
+    ;;
+  select-host)
+    emit_selected_host "${2:-}" "${3:-}" "${4:-}"
     ;;
   -h|--help|help)
     usage

--- a/.github/scripts/tests/runner-host-architecture-groups-test.sh
+++ b/.github/scripts/tests/runner-host-architecture-groups-test.sh
@@ -81,6 +81,12 @@ out=$(run_clean AWS_METAL_RUNNER_HOSTS='arm-1, arm-2' "$HOST_GROUPS" has-groups)
 out=$(run_clean AWS_METAL_RUNNER_HOSTS='arm-1, arm-2' "$HOST_GROUPS" hosts arm64)
 [ "$out" = "arm-1,arm-2" ] || fail "expected ARM64 hosts, got: ${out}"
 
+out=$(run_clean AWS_METAL_RUNNER_HOSTS='arm-1, arm-2' "$HOST_GROUPS" select-host arm64 pr-123-test)
+case "$out" in
+  arm-1|arm-2) ;;
+  *) fail "expected selected ARM64 host to be one host from the group, got: ${out}" ;;
+esac
+
 HOST_ARCHES='x86-1=x86_64'
 
 out=$(run_clean AWS_METAL_RUNNER_HOSTS='x86-1' "$HOST_GROUPS")
@@ -111,6 +117,19 @@ assert_json_eq "$out" '[{"id":"arm64","label":"ARM64","target":"aarch64-unknown-
 
 out=$(run_clean AWS_METAL_RUNNER_HOSTS='arm-1,x86-1,x86-2' "$HOST_GROUPS" hosts x86_64)
 [ "$out" = "x86-1,x86-2" ] || fail "expected mixed x86_64 hosts, got: ${out}"
+
+out=$(run_clean AWS_METAL_RUNNER_HOSTS='arm-1,x86-1,x86-2' "$HOST_GROUPS" select-host x86_64 pr-123-test)
+case "$out" in
+  x86-1|x86-2) ;;
+  *) fail "expected selected x86_64 host to be one host from the group, got: ${out}" ;;
+esac
+
+HOST_ARCHES=''
+out=$(run_clean "$HOST_GROUPS" select-host x86_64 pr-123-test 'x86-1,x86-2')
+case "$out" in
+  x86-1|x86-2) ;;
+  *) fail "expected selected x86_64 host from explicit hosts to be one host, got: ${out}" ;;
+esac
 
 HOST_ARCHES='arm-1=aarch64 arm-2=aarch64'
 
@@ -173,6 +192,11 @@ if run_clean AWS_METAL_RUNNER_HOSTS='arm-1' "$HOST_GROUPS" hosts powerpc >"${TMP
   fail "expected unsupported hosts group id to fail"
 fi
 grep -q "unsupported runner host group id: powerpc" "${TMPDIR}/unsupported-host-group.err" || fail "expected unsupported hosts group id message"
+
+if run_clean AWS_METAL_RUNNER_HOSTS='arm-1' "$HOST_GROUPS" select-host arm64 >"${TMPDIR}/missing-selection-key.out" 2>"${TMPDIR}/missing-selection-key.err"; then
+  fail "expected missing selection key to fail"
+fi
+grep -q "missing runner host selection key" "${TMPDIR}/missing-selection-key.err" || fail "expected missing selection key message"
 
 out=$(run_clean "$HOST_GROUPS")
 assert_compact_json "$out"

--- a/.github/scripts/tests/wait-runner-image-groups-test.sh
+++ b/.github/scripts/tests/wait-runner-image-groups-test.sh
@@ -175,6 +175,7 @@ run_wait_groups() {
     PROFILE="debug" \
     REPO="vm0-ai/vm0" \
     MANIFEST_DIR="$MANIFEST_DIR" \
+    OUTPUT_DIR="$TEST_DIR/output-dir" \
     GITHUB_OUTPUT="$output_file" \
     "$SCRIPT_DIR/wait-runner-image-groups.sh"
 }

--- a/.github/scripts/tests/wait-runner-image-groups-test.sh
+++ b/.github/scripts/tests/wait-runner-image-groups-test.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEST_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+FAKE_BIN="$TEST_DIR/bin"
+MANIFEST_DIR="$TEST_DIR/manifests"
+mkdir -p "$FAKE_BIN" "$MANIFEST_DIR"
+
+cat >"$FAKE_BIN/ssh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+target="${1#*@}"
+case "$target" in
+  arm-1|arm-2)
+    echo "aarch64"
+    ;;
+  x86-1)
+    echo "x86_64"
+    ;;
+  *)
+    echo "unexpected host: $target" >&2
+    exit 1
+    ;;
+esac
+SH
+chmod +x "$FAKE_BIN/ssh"
+
+cat >"$FAKE_BIN/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$1" = "api" ]; then
+  request="$2"
+  artifact_name="${request#*name=}"
+  artifact_name="${artifact_name%%&*}"
+  cat <<JSON
+{
+  "artifacts": [
+    {
+      "name": "$artifact_name",
+      "expired": false,
+      "workflow_run": {
+        "id": 42,
+        "head_sha": "$HEAD_SHA"
+      }
+    }
+  ]
+}
+JSON
+  exit 0
+fi
+
+if [ "$1" = "run" ] && [ "$2" = "view" ]; then
+  echo "https://github.com/vm0-ai/vm0/actions/runs/42"
+  exit 0
+fi
+
+if [ "$1" = "run" ] && [ "$2" = "download" ]; then
+  artifact_name=""
+  output_dir=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      -n)
+        artifact_name="$2"
+        shift 2
+        ;;
+      -D)
+        output_dir="$2"
+        shift 2
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+
+  mkdir -p "$output_dir"
+  case "$artifact_name" in
+    *aarch64-unknown-linux-musl*)
+      cp "$MANIFEST_DIR/arm64.json" "$output_dir/manifest.json"
+      ;;
+    *x86_64-unknown-linux-musl*)
+      if [ "${FAKE_X86_MISMATCH:-}" = "1" ]; then
+        cp "$MANIFEST_DIR/x86_64-mismatch.json" "$output_dir/manifest.json"
+      else
+        cp "$MANIFEST_DIR/x86_64.json" "$output_dir/manifest.json"
+      fi
+      ;;
+    *)
+      echo "unexpected artifact: $artifact_name" >&2
+      exit 1
+      ;;
+  esac
+  exit 0
+fi
+
+echo "unexpected gh command: $*" >&2
+exit 1
+SH
+chmod +x "$FAKE_BIN/gh"
+
+make_manifest() {
+  local file="$1"
+  local target="$2"
+  local bin_dir="$3"
+  local runner_dir="$4"
+  local hosts_json="$5"
+
+  jq -n \
+    --arg head_sha "head-sha" \
+    --arg job_ref "job-ref" \
+    --arg profile "debug" \
+    --arg target "$target" \
+    --arg bin_dir "$bin_dir" \
+    --arg runner_dir "$runner_dir" \
+    --argjson hosts "$hosts_json" \
+    '{
+      schemaVersion: 1,
+      headSha: $head_sha,
+      jobRef: $job_ref,
+      profile: $profile,
+      target: $target,
+      binDir: $bin_dir,
+      runnerDir: $runner_dir,
+      runnerSha256: "runner-sha",
+      guestSha256: {
+        "guest-agent": "guest-agent-sha",
+        "guest-download": "guest-download-sha",
+        "guest-init": "guest-init-sha",
+        "guest-mock-claude": "guest-mock-claude-sha",
+        "guest-mock-codex": "guest-mock-codex-sha",
+        "guest-reseed": "guest-reseed-sha",
+        "guest-write-file": "guest-write-file-sha"
+      },
+      hosts: $hosts
+    }' >"$file"
+}
+
+make_manifest \
+  "$MANIFEST_DIR/arm64.json" \
+  "aarch64-unknown-linux-musl" \
+  "/var/lib/vm0-runner/bin/job-ref" \
+  "/var/lib/vm0-runner/runners/job-ref" \
+  '{
+    "arm-1": {"rootfsHash": "rootfs-arm-1", "snapshotHash": "snapshot-arm-1"},
+    "arm-2": {"rootfsHash": "rootfs-arm-2", "snapshotHash": "snapshot-arm-2"}
+  }'
+
+make_manifest \
+  "$MANIFEST_DIR/x86_64.json" \
+  "x86_64-unknown-linux-musl" \
+  "/var/lib/vm0-runner/bin/job-ref" \
+  "/var/lib/vm0-runner/runners/job-ref" \
+  '{"x86-1": {"rootfsHash": "rootfs-x86-1", "snapshotHash": "snapshot-x86-1"}}'
+
+make_manifest \
+  "$MANIFEST_DIR/x86_64-mismatch.json" \
+  "x86_64-unknown-linux-musl" \
+  "/var/lib/vm0-runner/bin/other-job-ref" \
+  "/var/lib/vm0-runner/runners/job-ref" \
+  '{"x86-1": {"rootfsHash": "rootfs-x86-1", "snapshotHash": "snapshot-x86-1"}}'
+
+run_wait_groups() {
+  local output_file="$1"
+
+  PATH="$FAKE_BIN:$PATH" \
+    AWS_METAL_RUNNER_HOSTS="arm-1,arm-2,x86-1" \
+    METAL_USER="ci" \
+    HEAD_SHA="head-sha" \
+    JOB_REF="job-ref" \
+    LOOKUP_SHA="head-sha" \
+    PROFILE="debug" \
+    REPO="vm0-ai/vm0" \
+    MANIFEST_DIR="$MANIFEST_DIR" \
+    GITHUB_OUTPUT="$output_file" \
+    "$SCRIPT_DIR/wait-runner-image-groups.sh"
+}
+
+assert_output_contains() {
+  local file="$1"
+  local pattern="$2"
+  if ! grep -Fq "$pattern" "$file"; then
+    echo "expected output to contain $pattern" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+output_file="$TEST_DIR/output"
+run_wait_groups "$output_file"
+
+assert_output_contains "$output_file" 'bin-dir=/var/lib/vm0-runner/bin/job-ref'
+assert_output_contains "$output_file" 'runner-dir=/var/lib/vm0-runner/runners/job-ref'
+assert_output_contains "$output_file" '"arm-1":"rootfs-arm-1"'
+assert_output_contains "$output_file" '"arm-2":"rootfs-arm-2"'
+assert_output_contains "$output_file" '"x86-1":"rootfs-x86-1"'
+assert_output_contains "$output_file" '"arm-1":"snapshot-arm-1"'
+assert_output_contains "$output_file" '"x86-1":"snapshot-x86-1"'
+
+mismatch_output="$TEST_DIR/mismatch-output"
+if FAKE_X86_MISMATCH=1 run_wait_groups "$mismatch_output" 2>"$TEST_DIR/mismatch.err"; then
+  echo "expected mismatched bin-dir to fail" >&2
+  exit 1
+fi
+
+if ! grep -Fq "manifests disagree on bin-dir" "$TEST_DIR/mismatch.err"; then
+  echo "expected bin-dir mismatch error" >&2
+  cat "$TEST_DIR/mismatch.err" >&2
+  exit 1
+fi
+
+echo "wait-runner-image-groups-test: ok"

--- a/.github/scripts/wait-runner-image-groups.sh
+++ b/.github/scripts/wait-runner-image-groups.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+require_env() {
+  local name="$1"
+  if [ -z "${!name:-}" ]; then
+    echo "error: $name is required" >&2
+    exit 1
+  fi
+}
+
+emit() {
+  local key="$1"
+  local value="$2"
+  echo "$key=$value" >>"$GITHUB_OUTPUT"
+}
+
+output_value() {
+  local key="$1"
+  local file="$2"
+  sed -n "s/^${key}=//p" "$file" | tail -n 1
+}
+
+merge_json_map() {
+  local lhs="$1"
+  local rhs="$2"
+  jq -c --argjson rhs "$rhs" '. + $rhs' <<<"$lhs"
+}
+
+require_env HEAD_SHA
+require_env JOB_REF
+require_env AWS_METAL_RUNNER_HOSTS
+require_env METAL_USER
+require_env PROFILE
+require_env GITHUB_OUTPUT
+
+base_output_dir="${OUTPUT_DIR:-/tmp/runner-image-manifests}"
+groups_json="$("$SCRIPT_DIR/runner-host-architecture-groups.sh")"
+group_count="$(jq -r 'length' <<<"$groups_json")"
+
+if [ "$group_count" = "0" ]; then
+  echo "error: no runner host architecture groups found" >&2
+  exit 1
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+bin_dir=""
+runner_dir=""
+rootfs_hash_map="{}"
+snapshot_hash_map="{}"
+
+while IFS= read -r group; do
+  group_id="$(jq -r '.id' <<<"$group")"
+  target="$(jq -r '.target' <<<"$group")"
+  hosts="$(jq -r '.hosts' <<<"$group")"
+
+  if [ -z "$hosts" ]; then
+    echo "error: runner host group $group_id has no hosts" >&2
+    exit 1
+  fi
+
+  group_output="$tmp_dir/${group_id}.out"
+  group_output_dir="$base_output_dir/$group_id"
+
+  echo "Waiting for runner image manifest for $group_id ($target)"
+  GITHUB_OUTPUT="$group_output" \
+    OUTPUT_DIR="$group_output_dir" \
+    TARGET="$target" \
+    METAL_HOSTS="$hosts" \
+    "$SCRIPT_DIR/wait-runner-image.sh"
+
+  group_bin_dir="$(output_value bin-dir "$group_output")"
+  group_runner_dir="$(output_value runner-dir "$group_output")"
+  group_rootfs_hash_map="$(output_value rootfs-hash-map "$group_output")"
+  group_snapshot_hash_map="$(output_value snapshot-hash-map "$group_output")"
+
+  if [ -z "$group_bin_dir" ] || [ -z "$group_runner_dir" ]; then
+    echo "error: runner image manifest for $group_id did not emit bin-dir and runner-dir" >&2
+    exit 1
+  fi
+
+  if [ -n "$bin_dir" ] && [ "$bin_dir" != "$group_bin_dir" ]; then
+    echo "error: runner image manifests disagree on bin-dir: $bin_dir != $group_bin_dir" >&2
+    exit 1
+  fi
+  if [ -n "$runner_dir" ] && [ "$runner_dir" != "$group_runner_dir" ]; then
+    echo "error: runner image manifests disagree on runner-dir: $runner_dir != $group_runner_dir" >&2
+    exit 1
+  fi
+
+  bin_dir="$group_bin_dir"
+  runner_dir="$group_runner_dir"
+  rootfs_hash_map="$(merge_json_map "$rootfs_hash_map" "$group_rootfs_hash_map")"
+  snapshot_hash_map="$(merge_json_map "$snapshot_hash_map" "$group_snapshot_hash_map")"
+done < <(jq -c '.[]' <<<"$groups_json")
+
+emit "bin-dir" "$bin_dir"
+emit "runner-dir" "$runner_dir"
+emit "rootfs-hash-map" "$rootfs_hash_map"
+emit "snapshot-hash-map" "$snapshot_hash_map"

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -472,16 +472,14 @@ jobs:
           JOB_REF: ${{ needs.detect.outputs.metal-job-ref }}
         run: |
           HOSTS=$(.github/scripts/runner-host-architecture-groups.sh hosts "$RUNNER_HOST_GROUP_ID")
-          NUM_HOSTS=$(printf '%s\n' "$HOSTS" | grep -c . || true)
+          NUM_HOSTS=$(printf '%s\n' "$HOSTS" | tr ',' '\n' | grep -c . || true)
           if [ "$NUM_HOSTS" -lt 1 ]; then
             echo "::error::No metal hosts found for runner host group $RUNNER_HOST_GROUP_ID"
             exit 1
           fi
-          HASH=$(printf '%s-%s' "$JOB_REF" "$RUNNER_HOST_GROUP_ID" | md5sum | cut -c1-8)
-          HOST_INDEX=$(( 0x$HASH % NUM_HOSTS ))
-          HOST=$(printf '%s\n' "$HOSTS" | sed -n "$((HOST_INDEX + 1))p")
+          HOST=$(.github/scripts/runner-host-architecture-groups.sh select-host "$RUNNER_HOST_GROUP_ID" "$JOB_REF" "$HOSTS")
           echo "host=${HOST}" >> "$GITHUB_OUTPUT"
-          echo "Selected $RUNNER_HOST_GROUP_ID metal host: ${HOST} (index ${HOST_INDEX}/${NUM_HOSTS})"
+          echo "Selected $RUNNER_HOST_GROUP_ID metal host: ${HOST} (${NUM_HOSTS} host(s) in group)"
 
       - name: Run nbd-cow integration tests on metal
         env:
@@ -532,21 +530,19 @@ jobs:
           JOB_REF: ${{ needs.detect.outputs.metal-job-ref }}
         run: |
           HOSTS=$(.github/scripts/runner-host-architecture-groups.sh hosts "$RUNNER_HOST_GROUP_ID")
-          NUM_HOSTS=$(printf '%s\n' "$HOSTS" | grep -c . || true)
+          NUM_HOSTS=$(printf '%s\n' "$HOSTS" | tr ',' '\n' | grep -c . || true)
           if [ "$NUM_HOSTS" -lt 1 ]; then
             echo "::error::No metal hosts found for runner host group $RUNNER_HOST_GROUP_ID"
             exit 1
           fi
-          HASH=$(printf '%s-%s' "$JOB_REF" "$RUNNER_HOST_GROUP_ID" | md5sum | cut -c1-8)
-          HOST_INDEX=$(( 0x$HASH % NUM_HOSTS ))
-          HOST=$(printf '%s\n' "$HOSTS" | sed -n "$((HOST_INDEX + 1))p")
+          HOST=$(.github/scripts/runner-host-architecture-groups.sh select-host "$RUNNER_HOST_GROUP_ID" "$JOB_REF" "$HOSTS")
           {
             echo "host=${HOST}"
             echo "hosts<<HOSTS"
             echo "$HOSTS"
             echo "HOSTS"
           } >> "$GITHUB_OUTPUT"
-          echo "Selected representative metal host: ${HOST} (group ${RUNNER_HOST_GROUP_ID}, index ${HOST_INDEX}/${NUM_HOSTS})"
+          echo "Selected representative metal host: ${HOST} (group ${RUNNER_HOST_GROUP_ID}, ${NUM_HOSTS} host(s) in group)"
 
       - name: Wait for runner image manifest
         id: manifest

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -79,9 +79,8 @@ jobs:
       nbd-cow-changed: ${{ steps.detect.outputs.nbd-cow-changed }}
       vsock-test-changed: ${{ steps.detect.outputs.vsock-test-changed }}
       crates-runner-consumer-needed: ${{ steps.runner-tests.outputs.crates-runner-consumer-needed }}
-      metal-host: ${{ steps.host.outputs.host }}
-      metal-job-ref: ${{ steps.host.outputs.job-ref }}
-      runner-image-job-ref: ${{ steps.host.outputs.image-job-ref }}
+      metal-job-ref: ${{ steps.runner-job-ref.outputs.job-ref }}
+      runner-image-job-ref: ${{ steps.runner-job-ref.outputs.image-job-ref }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -206,8 +205,8 @@ jobs:
           GUEST_WRITE_FILE_CHANGED: ${{ steps.detect.outputs.guest-write-file-changed }}
         run: .github/scripts/runner-image-context.sh crates-consumer
 
-      - name: Select metal host
-        id: host
+      - name: Select runner job refs
+        id: runner-job-ref
         env:
           METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
           EVENT_NAME: ${{ github.event_name }}
@@ -259,18 +258,65 @@ jobs:
           HOSTS=$(echo "$METAL_HOSTS" | tr ',' '\n' | grep . || true)
           NUM_HOSTS=$(echo "$HOSTS" | grep -c . || true)
           if [ "$NUM_HOSTS" -lt 1 ]; then
-            echo "No metal hosts configured, skipping host selection"
+            echo "No metal hosts configured, skipping runner job refs"
             exit 0
           fi
-          HASH=$(printf '%s' "$JOB_REF" | md5sum | cut -c1-8)
-          HOST_INDEX=$(( 0x$HASH % NUM_HOSTS ))
-          HOST=$(echo "$HOSTS" | sed -n "$((HOST_INDEX + 1))p")
           {
-            echo "host=${HOST}"
             echo "job-ref=${JOB_REF}"
             echo "image-job-ref=${IMAGE_JOB_REF}"
           } >> "$GITHUB_OUTPUT"
-          echo "Selected metal host: ${HOST} (index ${HOST_INDEX}/${NUM_HOSTS}, job-ref: ${JOB_REF}, image-job-ref: ${IMAGE_JOB_REF})"
+          echo "Selected runner job refs: job-ref=${JOB_REF}, image-job-ref=${IMAGE_JOB_REF}"
+
+  runner-host-groups:
+    runs-on: ubuntu-latest
+    needs: [detect]
+    if: |
+      needs.detect.outputs.metal-job-ref != '' && (
+        needs.detect.outputs.crates-runner-consumer-needed == 'true' ||
+        needs.detect.outputs.ci-changed == 'true' ||
+        needs.detect.outputs.nbd-cow-changed == 'true'
+      )
+    timeout-minutes: 5
+    outputs:
+      # Keep cross-job architecture metadata sanitized. Jobs that need hosts
+      # resolve the host subset from matrix.id inside that job.
+      matrix: ${{ steps.groups.outputs.matrix }}
+      representative-group-id: ${{ steps.groups.outputs.representative-group-id }}
+      representative-target: ${{ steps.groups.outputs.representative-target }}
+      representative-cache-suffix: ${{ steps.groups.outputs.representative-cache-suffix }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup SSH via Cloudflare Tunnel
+        uses: ./.github/actions/setup-ssh-tunnel
+        with:
+          ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
+          cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+
+      - name: Resolve runner host architecture groups
+        id: groups
+        env:
+          AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
+        run: |
+          MATRIX=$(.github/scripts/runner-host-architecture-groups.sh matrix)
+          GROUP_COUNT=$(jq -r 'length' <<<"$MATRIX")
+          if [ "$GROUP_COUNT" -lt 1 ]; then
+            echo "::error::No runner host architecture groups found"
+            exit 1
+          fi
+
+          REPRESENTATIVE=$(jq -c '.[0]' <<<"$MATRIX")
+          {
+            echo "matrix=${MATRIX}"
+            echo "representative-group-id=$(jq -r '.id' <<<"$REPRESENTATIVE")"
+            echo "representative-target=$(jq -r '.target' <<<"$REPRESENTATIVE")"
+            echo "representative-cache-suffix=$(jq -r '.cacheSuffix' <<<"$REPRESENTATIVE")"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Runner host architecture groups:"
+          jq . <<<"$MATRIX"
 
   check:
     runs-on: ubuntu-latest
@@ -379,15 +425,19 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260622
-    needs: [detect]
+    needs: [detect, runner-host-groups]
     if: |
       needs.detect.outputs.metal-job-ref != '' && (
         needs.detect.outputs.ci-changed == 'true' ||
         needs.detect.outputs.nbd-cow-changed == 'true'
       )
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.runner-host-groups.outputs.matrix || '[]') }}
     timeout-minutes: 5
     env:
-      TARGET_TRIPLE: aarch64-unknown-linux-musl
+      TARGET_TRIPLE: ${{ matrix.target }}
     steps:
       - uses: actions/checkout@v7
 
@@ -395,10 +445,10 @@ jobs:
         with:
           workspaces: crates -> target
           # Separate key from runner-build to avoid cache reservation race (#9447)
-          shared-key: aarch64-musl-nbd
+          shared-key: ${{ matrix.cacheSuffix }}-nbd
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
-      - name: Cross-compile nbd-cow tests for ARM64
+      - name: Cross-compile nbd-cow tests for ${{ matrix.label }}
         run: |
           cd crates
           cargo test --no-run --release --target "$TARGET_TRIPLE" -p nbd-cow
@@ -413,14 +463,35 @@ jobs:
           cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
 
+      - name: Select metal host
+        id: selected-host
+        env:
+          AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
+          RUNNER_HOST_GROUP_ID: ${{ matrix.id }}
+          JOB_REF: ${{ needs.detect.outputs.metal-job-ref }}
+        run: |
+          HOSTS=$(.github/scripts/runner-host-architecture-groups.sh hosts "$RUNNER_HOST_GROUP_ID")
+          NUM_HOSTS=$(printf '%s\n' "$HOSTS" | grep -c . || true)
+          if [ "$NUM_HOSTS" -lt 1 ]; then
+            echo "::error::No metal hosts found for runner host group $RUNNER_HOST_GROUP_ID"
+            exit 1
+          fi
+          HASH=$(printf '%s-%s' "$JOB_REF" "$RUNNER_HOST_GROUP_ID" | md5sum | cut -c1-8)
+          HOST_INDEX=$(( 0x$HASH % NUM_HOSTS ))
+          HOST=$(printf '%s\n' "$HOSTS" | sed -n "$((HOST_INDEX + 1))p")
+          echo "host=${HOST}" >> "$GITHUB_OUTPUT"
+          echo "Selected $RUNNER_HOST_GROUP_ID metal host: ${HOST} (index ${HOST_INDEX}/${NUM_HOSTS})"
+
       - name: Run nbd-cow integration tests on metal
         env:
           METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
-          HOST: ${{ needs.detect.outputs.metal-host }}
+          HOST: ${{ steps.selected-host.outputs.host }}
           JOB_REF: ${{ needs.detect.outputs.metal-job-ref }}
+          RUNNER_HOST_GROUP_ID: ${{ matrix.id }}
         run: |
           REMOTE="${METAL_USER}@${HOST}"
-          REMOTE_BIN="/tmp/nbd-cow-test-${JOB_REF}"
+          REMOTE_BIN="/tmp/nbd-cow-test-${JOB_REF}-${RUNNER_HOST_GROUP_ID}"
           scp "$TEST_BIN" "${REMOTE}:${REMOTE_BIN}"
           # shellcheck disable=SC2029
           ssh "$REMOTE" "trap 'rm -f ${REMOTE_BIN}' EXIT && sudo modprobe nbd nbds_max=4096 && sudo ${REMOTE_BIN} --ignored --test-threads=1"
@@ -430,13 +501,13 @@ jobs:
     permissions:
       actions: read
       contents: read
-    needs: [detect]
+    needs: [detect, runner-host-groups]
     if: |
       needs.detect.outputs.metal-job-ref != '' &&
       needs.detect.outputs.crates-runner-consumer-needed == 'true'
     timeout-minutes: 20
     outputs:
-      host: ${{ needs.detect.outputs.metal-host }}
+      host: ${{ steps.selected-host.outputs.host }}
       job-ref: ${{ needs.detect.outputs.metal-job-ref }}
       image-job-ref: ${{ needs.detect.outputs.runner-image-job-ref }}
       bin-dir: ${{ steps.manifest.outputs.bin-dir }}
@@ -445,6 +516,38 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Setup SSH via Cloudflare Tunnel
+        uses: ./.github/actions/setup-ssh-tunnel
+        with:
+          ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
+          cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+
+      - name: Select representative metal host
+        id: selected-host
+        env:
+          AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
+          RUNNER_HOST_GROUP_ID: ${{ needs.runner-host-groups.outputs.representative-group-id }}
+          JOB_REF: ${{ needs.detect.outputs.metal-job-ref }}
+        run: |
+          HOSTS=$(.github/scripts/runner-host-architecture-groups.sh hosts "$RUNNER_HOST_GROUP_ID")
+          NUM_HOSTS=$(printf '%s\n' "$HOSTS" | grep -c . || true)
+          if [ "$NUM_HOSTS" -lt 1 ]; then
+            echo "::error::No metal hosts found for runner host group $RUNNER_HOST_GROUP_ID"
+            exit 1
+          fi
+          HASH=$(printf '%s-%s' "$JOB_REF" "$RUNNER_HOST_GROUP_ID" | md5sum | cut -c1-8)
+          HOST_INDEX=$(( 0x$HASH % NUM_HOSTS ))
+          HOST=$(printf '%s\n' "$HOSTS" | sed -n "$((HOST_INDEX + 1))p")
+          {
+            echo "host=${HOST}"
+            echo "hosts<<HOSTS"
+            echo "$HOSTS"
+            echo "HOSTS"
+          } >> "$GITHUB_OUTPUT"
+          echo "Selected representative metal host: ${HOST} (group ${RUNNER_HOST_GROUP_ID}, index ${HOST_INDEX}/${NUM_HOSTS})"
+
       - name: Wait for runner image manifest
         id: manifest
         env:
@@ -452,9 +555,63 @@ jobs:
           HEAD_SHA: ${{ github.sha }}
           LOOKUP_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           JOB_REF: ${{ needs.detect.outputs.runner-image-job-ref }}
-          METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
-          SELECTED_HOST: ${{ needs.detect.outputs.metal-host }}
-          TARGET: aarch64-unknown-linux-musl
+          # Target-specific manifests only contain hosts for that architecture group.
+          METAL_HOSTS: ${{ steps.selected-host.outputs.hosts }}
+          SELECTED_HOST: ${{ steps.selected-host.outputs.host }}
+          TARGET: ${{ needs.runner-host-groups.outputs.representative-target }}
+          PROFILE: vm0/default
+        run: .github/scripts/wait-runner-image.sh
+
+  runner-image-architecture-manifest:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    needs: [detect, runner-host-groups]
+    if: |
+      needs.detect.outputs.metal-job-ref != '' &&
+      needs.detect.outputs.crates-runner-consumer-needed == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.runner-host-groups.outputs.matrix || '[]') }}
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup SSH via Cloudflare Tunnel
+        uses: ./.github/actions/setup-ssh-tunnel
+        with:
+          ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
+          cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+
+      - name: Resolve metal hosts
+        id: hosts
+        env:
+          AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
+          RUNNER_HOST_GROUP_ID: ${{ matrix.id }}
+        run: |
+          HOSTS=$(.github/scripts/runner-host-architecture-groups.sh hosts "$RUNNER_HOST_GROUP_ID")
+          if ! printf '%s\n' "$HOSTS" | grep -q .; then
+            echo "::error::No metal hosts found for runner host group $RUNNER_HOST_GROUP_ID"
+            exit 1
+          fi
+          {
+            echo "hosts<<HOSTS"
+            echo "$HOSTS"
+            echo "HOSTS"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Wait for runner image manifest for ${{ matrix.label }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.sha }}
+          LOOKUP_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          JOB_REF: ${{ needs.detect.outputs.runner-image-job-ref }}
+          METAL_HOSTS: ${{ steps.hosts.outputs.hosts }}
+          TARGET: ${{ matrix.target }}
           PROFILE: vm0/default
         run: .github/scripts/wait-runner-image.sh
 
@@ -1784,7 +1941,9 @@ jobs:
       - check
       - api-contracts-rust-bindings
       - mitm-addon-test
+      - runner-host-groups
       - runner-build
+      - runner-image-architecture-manifest
       - runner-local-active-input-smoke
       - runner-benchmark
       - runner-exec
@@ -1834,7 +1993,9 @@ jobs:
           check_result "check" "${{ needs.check.result }}" "true"
           check_result "api-contracts-rust-bindings" "${{ needs.api-contracts-rust-bindings.result }}" "true"
           check_result "mitm-addon-test" "${{ needs.mitm-addon-test.result }}" "true"
+          check_result "runner-host-groups" "${{ needs.runner-host-groups.result }}" "true"
           check_result "runner-build" "${{ needs.runner-build.result }}" "true"
+          check_result "runner-image-architecture-manifest" "${{ needs.runner-image-architecture-manifest.result }}" "true"
           check_result "runner-local-active-input-smoke" "${{ needs.runner-local-active-input-smoke.result }}" "true"
           check_result "runner-benchmark" "${{ needs.runner-benchmark.result }}" "true"
           check_result "runner-exec" "${{ needs.runner-exec.result }}" "true"

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1789,6 +1789,13 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Setup SSH via Cloudflare Tunnel
+        uses: ./.github/actions/setup-ssh-tunnel
+        with:
+          ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
+          cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+
       - name: Generate runner E2E test matrix
         id: runner-matrix
         shell: bash
@@ -1844,10 +1851,12 @@ jobs:
           HEAD_SHA: ${{ github.sha }}
           LOOKUP_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
-          METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
-          TARGET: aarch64-unknown-linux-musl
+          # The helper resolves per-architecture host subsets locally and emits
+          # merged hash maps for deploy-runner-start.
+          AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
           PROFILE: vm0/default
-        run: .github/scripts/wait-runner-image.sh
+        run: .github/scripts/wait-runner-image-groups.sh
 
   # Deploy runner start: generate config with real API preview URL and start service
   # Waits for both deploy-runner-prepare (binaries + image) and deploy-api (preview URL)


### PR DESCRIPTION
## Summary
- resolve runner host architecture groups from the single `AWS_METAL_RUNNER_HOSTS` inventory in Crates consumers
- run NBD COW once per configured architecture group and keep heavy runner smoke jobs representative
- aggregate per-architecture runner image manifests in Turbo prepare before starting the full runner fleet

## Tests
- `bash -lc 'shopt -s nullglob; script_files=(.github/scripts/*.sh .github/scripts/tests/*.sh); bash -n "${script_files[@]}"; for test_script in .github/scripts/tests/*.sh; do bash "$test_script"; done'`
- `/tmp/actionlint-vm0/actionlint /workspaces/vm7/.github/workflows/crates.yml /workspaces/vm7/.github/workflows/turbo.yml`
- `git diff --check`

Closes #18573
