### PR TITLE
fix: stabilize pdf preview frame height

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -1633,10 +1633,17 @@ ${openFencedHostedSiteUrl}`,
     await backToArtifactInbox();
 
     await openArtifactFromInbox("rollout-plan.pdf");
-    expect(screen.getByTestId("artifact-sidebar-body-pdf")).toHaveAttribute(
-      "title",
-      "rollout-plan.pdf preview",
+    const pdfFrame = screen.getByTestId("artifact-sidebar-body-pdf");
+    const pdfFrameWrapper = pdfFrame.parentElement;
+    if (!pdfFrameWrapper) {
+      throw new Error("PDF frame wrapper not found");
+    }
+    expect(screen.getByTestId("artifact-sidebar-stage")).toHaveClass(
+      "overflow-hidden",
     );
+    expect(pdfFrame).toHaveAttribute("title", "rollout-plan.pdf preview");
+    expect(pdfFrame).toHaveClass("h-full", "min-h-0", "border-0");
+    expect(pdfFrameWrapper).toHaveClass("h-full", "min-h-0");
     await backToArtifactInbox();
 
     click(getArtifactTab(screen.getByTestId("artifact-inbox"), "All"));

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -515,6 +515,14 @@ describe("zero attachment chips", () => {
         screen.getByTestId("artifact-dialog-document-frame"),
       ).toBeInTheDocument();
     });
+    const documentFrame = screen.getByTestId("artifact-dialog-document-frame");
+    const iframe = screen.getByTitle("launch-plan.pdf preview");
+    expect(screen.getByTestId("artifact-dialog-stage")).toHaveClass(
+      "overflow-hidden",
+    );
+    expect(documentFrame).toHaveClass("h-full", "min-h-0");
+    expect(iframe).toHaveAttribute("src", `${pdfUrl}#navpanes=0`);
+    expect(iframe).toHaveClass("h-full", "min-h-0", "border-0");
 
     click(screen.getByLabelText("Close"));
 

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -1026,12 +1026,12 @@ function ArtifactIframeBody({
   }
 
   return (
-    <ArtifactStageShell>
-      <div className="flex min-h-[420px] w-full flex-1 overflow-hidden rounded-xl border border-border/70 bg-background shadow-sm">
+    <ArtifactStageShell scrollable={false}>
+      <div className="flex h-full min-h-0 w-full flex-1 overflow-hidden rounded-xl border border-border/70 bg-background shadow-sm">
         <iframe
           src={src}
           title={`${filename} preview`}
-          className="h-full w-full bg-background"
+          className="h-full min-h-0 w-full border-0 bg-background"
           data-testid={`artifact-sidebar-body-${kind}`}
         />
       </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -711,19 +711,20 @@ function ArtifactDialogBody({
     return <ArtifactDialogHtmlBody filename={filename} preview={preview} />;
   }
 
+  const publicUrl = publicAttachmentUrl(preview.url);
+  const src = preview.kind === "pdf" ? `${publicUrl}#navpanes=0` : publicUrl;
+
   return (
-    <ArtifactDialogStage>
+    <ArtifactDialogStage scrollable={false}>
       <div
-        className="flex min-h-[420px] w-full flex-1 overflow-hidden rounded-xl border border-border/70 bg-background shadow-sm"
+        className="flex h-full min-h-0 w-full flex-1 overflow-hidden rounded-xl border border-border/70 bg-background shadow-sm"
         data-testid="artifact-dialog-document-frame"
       >
         <iframe
-          src={
-            preview.kind === "pdf" ? `${preview.url}#navpanes=0` : preview.url
-          }
+          src={src}
           title={`${filename} preview`}
           scrolling="yes"
-          className="block h-full w-full bg-background"
+          className="block h-full min-h-0 w-full border-0 bg-background"
         />
       </div>
     </ArtifactDialogStage>


### PR DESCRIPTION
## Summary
- Fix PDF previews so the iframe owns the available lightbox/sidebar height instead of relying on an outer scroll container.
- Apply the same definite height chain to the artifact sidebar PDF path.
- Normalize dialog document iframe URLs through publicAttachmentUrl before appending PDF open parameters.

## Root cause
The PDF lightbox used a scrollable stage whose inner wrapper provided min-height rather than a definite height, while the document frame used min-h-[420px] and the iframe used h-full. Native browser PDF viewers need a definite iframe height; otherwise the iframe/PDF viewport can resolve to only the upper part of the visible frame, leaving the rest blank.

## Verification
- git diff --check
- pnpm -F @vm0/app exec prettier --check src/views/zero-page/zero-attachment-chips.tsx src/views/zero-page/zero-artifact-sidebar.tsx src/views/zero-page/__tests__/zero-attachment-chips.test.tsx src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-attachment-chips.test.tsx src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx