### PR TITLE
refactor: split firewall selection resolver from expander

### DIFF
--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -763,7 +763,6 @@ export {
 } from "@vm0/connectors/firewall-types";
 
 export {
-  resolveFirewallSelections,
   collectAndValidatePermissions,
   validateRule,
   type FirewallSelection,

--- a/turbo/packages/connectors/package.json
+++ b/turbo/packages/connectors/package.json
@@ -60,6 +60,10 @@
       "import": "./src/firewall-runtime.ts",
       "types": "./src/firewall-runtime.ts"
     },
+    "./firewalls/selection-resolver": {
+      "import": "./src/firewall-selection-resolver.ts",
+      "types": "./src/firewall-selection-resolver.ts"
+    },
     "./firewalls/*": {
       "import": "./src/firewalls/*.ts",
       "types": "./src/firewalls/*.ts"

--- a/turbo/packages/connectors/src/__tests__/firewall-expander.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-expander.test.ts
@@ -8,126 +8,112 @@ import {
 } from "../firewall-types";
 import {
   collectAndValidatePermissions,
-  resolveFirewallSelections,
+  resolveFirewallConfigSelection,
   validateRule,
 } from "../firewall-expander";
 import type { FirewallConfig } from "../firewall-types";
 
-describe("resolveFirewallSelections", () => {
-  it("should resolve builtin firewall with permissions: all", async () => {
-    const expanded = await resolveFirewallSelections({
-      slack: { permissions: "all" },
-    });
-
-    expect(expanded).toHaveLength(1);
-    expect(expanded[0]!.name).toBe("slack");
-    expect(expanded[0]!.apis.length).toBeGreaterThan(0);
-    const permNames = expanded[0]!.apis[0]!.permissions!.map((p) => {
-      return p.name;
-    });
-    expect(permNames).toContain("admin");
-    expect(permNames).toContain("admin.analytics:read");
-  });
-
-  it("should resolve firewall with specific permissions", async () => {
-    const expanded = await resolveFirewallSelections({
-      slack: { permissions: ["admin", "admin.analytics:read"] },
-    });
-
-    expect(expanded).toHaveLength(1);
-    expect(expanded[0]!.apis[0]!.permissions).toHaveLength(2);
-    const permNames = expanded[0]!.apis[0]!.permissions!.map((p) => {
-      return p.name;
-    });
-    expect(permNames).toContain("admin");
-    expect(permNames).toContain("admin.analytics:read");
-  });
-
-  it("should include placeholders and description when config has them", async () => {
-    const expanded = await resolveFirewallSelections({
-      slack: { permissions: "all" },
-    });
-
-    expect(expanded[0]!.placeholders).toMatchObject({
-      SLACK_TOKEN: "xoxb-100100100100-1001001001001-CoffeeSafeLocalCoffeeSaf",
-    });
-    expect(expanded[0]!.description).toBe("Slack API");
-  });
-
-  it("should resolve multiple builtin firewalls", async () => {
-    const expanded = await resolveFirewallSelections({
-      slack: { permissions: "all" },
-      "slack-webhook": { permissions: "all" },
-    });
-
-    expect(expanded).toHaveLength(2);
-    const names = expanded.map((s) => {
-      return s.name;
-    });
-    expect(names).toContain("slack");
-    expect(names).toContain("slack-webhook");
-  });
-
-  it("should return empty array for empty selections", async () => {
-    const expanded = await resolveFirewallSelections({});
-    expect(expanded).toEqual([]);
-  });
-
-  it("should throw for non-existent permission name", async () => {
-    await expect(
-      resolveFirewallSelections({
-        slack: { permissions: ["does-not-exist"] },
-      }),
-    ).rejects.toThrow(
-      'Permission "does-not-exist" does not exist in firewall "slack"',
-    );
-  });
-
-  it("should reject non-builtin firewall names", async () => {
-    await expect(
-      resolveFirewallSelections({
-        "custom-git": { permissions: "all" },
-      }),
-    ).rejects.toThrow(
-      'Unsupported firewall "custom-git": only built-in connector firewalls are supported',
-    );
-  });
-
-  it("should reject GitHub URL firewall refs", async () => {
-    await expect(
-      resolveFirewallSelections({
-        "https://github.com/acme/firewalls/tree/main/my-firewall": {
-          permissions: "all",
+describe("firewall expander helpers", () => {
+  it("resolveFirewallConfigSelection filters selected permissions", () => {
+    const config: FirewallConfig = {
+      name: "mixed",
+      apis: [
+        {
+          base: "https://api.example.com",
+          auth: { headers: {} },
+          permissions: [
+            { name: "read", rules: ["GET /files"] },
+            { name: "write", rules: ["POST /files"] },
+          ],
         },
-      }),
-    ).rejects.toThrow(
-      'Unsupported firewall "https://github.com/acme/firewalls/tree/main/my-firewall": only built-in connector firewalls are supported',
+        {
+          base: "https://uploads.example.com",
+          auth: { headers: {} },
+          permissions: [],
+        },
+      ],
+    };
+
+    const resolved = resolveFirewallConfigSelection(config, {
+      permissions: ["read"],
+    });
+
+    expect(resolved).toStrictEqual({
+      name: "mixed",
+      apis: [
+        {
+          base: "https://api.example.com",
+          auth: { headers: {} },
+          permissions: [{ name: "read", rules: ["GET /files"] }],
+        },
+      ],
+    });
+  });
+
+  it("resolveFirewallConfigSelection keeps all api entries and metadata", () => {
+    const config: FirewallConfig = {
+      name: "metadata",
+      description: "Metadata test",
+      placeholders: { TOKEN: "secret" },
+      apis: [
+        {
+          base: "https://api.example.com",
+          auth: { headers: {} },
+          permissions: [{ name: "read", rules: ["GET /files"] }],
+        },
+        {
+          base: "https://uploads.example.com",
+          auth: { headers: {} },
+          permissions: [],
+        },
+      ],
+    };
+
+    const resolved = resolveFirewallConfigSelection(config, {
+      permissions: "all",
+    });
+
+    expect(resolved).toStrictEqual(config);
+  });
+
+  it("resolveFirewallConfigSelection returns null when no api entries remain", () => {
+    const config: FirewallConfig = {
+      name: "empty-selection",
+      apis: [
+        {
+          base: "https://api.example.com",
+          auth: { headers: {} },
+          permissions: [{ name: "read", rules: ["GET /files"] }],
+        },
+      ],
+    };
+
+    const resolved = resolveFirewallConfigSelection(config, {
+      permissions: [],
+    });
+
+    expect(resolved).toBeNull();
+  });
+
+  it("resolveFirewallConfigSelection rejects missing permission names", () => {
+    const config: FirewallConfig = {
+      name: "missing-permission",
+      apis: [
+        {
+          base: "https://api.example.com",
+          auth: { headers: {} },
+          permissions: [{ name: "read", rules: ["GET /files"] }],
+        },
+      ],
+    };
+
+    expect(() => {
+      return resolveFirewallConfigSelection(config, {
+        permissions: ["write"],
+      });
+    }).toThrow(
+      'Permission "write" does not exist in firewall "missing-permission". Available: read',
     );
-  });
-
-  it("should filter permissions and keep only selected ones", async () => {
-    const expanded = await resolveFirewallSelections({
-      slack: { permissions: ["admin"] },
-    });
-
-    expect(expanded[0]!.apis[0]!.permissions).toHaveLength(1);
-    expect(expanded[0]!.apis[0]!.permissions![0]!.name).toBe("admin");
-  });
-
-  it("should keep all api_entries when shared permission is selected", async () => {
-    const expanded = await resolveFirewallSelections({
-      gmail: { permissions: ["messages.send"] },
-    });
-
-    expect(expanded).toHaveLength(1);
-    expect(expanded[0]!.apis.length).toBeGreaterThan(1);
-    for (const api of expanded[0]!.apis) {
-      expect(
-        api.permissions?.map((p) => {
-          return p.name;
-        }),
-      ).toEqual(["messages.send"]);
-    }
   });
 
   it("collectAndValidatePermissions accepts mixed empty and non-empty apis", () => {
@@ -311,22 +297,6 @@ describe("resolveFirewallSelections", () => {
       expect(() => {
         return collectAndValidatePermissions(config);
       }).not.toThrow();
-    }
-  });
-
-  it("should retain api entries with empty permissions when user picks all", async () => {
-    // Regression for the filter bug: api entries configured as
-    // `permissions: []` rely on base URL match + unknownPolicy fallback.
-    // Dropping them would make the firewall inject no auth headers.
-    const expanded = await resolveFirewallSelections({
-      "slack-webhook": { permissions: "all" },
-    });
-
-    expect(expanded).toHaveLength(1);
-    expect(expanded[0]!.name).toBe("slack-webhook");
-    expect(expanded[0]!.apis).toHaveLength(1);
-    for (const api of expanded[0]!.apis) {
-      expect(api.permissions ?? []).toEqual([]);
     }
   });
 });

--- a/turbo/packages/connectors/src/__tests__/firewall-runtime-loader.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-runtime-loader.test.ts
@@ -226,6 +226,14 @@ function exportedIdentifierNamesFromModule(
   return names;
 }
 
+function expectNoGeneratedRuntimeImports(source: string): void {
+  for (const specifier of moduleSpecifiers(source)) {
+    expect(specifier).not.toMatch(
+      /^\.{1,2}\/(?:[^/]+\/)*[a-z0-9][a-z0-9-]*\.generated$/,
+    );
+  }
+}
+
 describe("firewall runtime loader", () => {
   it("keeps the runtime loader behind an explicit package subpath", () => {
     const packageJson = JSON.parse(
@@ -246,6 +254,29 @@ describe("firewall runtime loader", () => {
     expect(rootEntrypoint).not.toContain("firewalls/runtime");
   });
 
+  it("keeps selection resolution behind an explicit runtime package subpath", () => {
+    const packageJson = JSON.parse(
+      fs.readFileSync(
+        path.resolve(import.meta.dirname, "../../package.json"),
+        "utf-8",
+      ),
+    ) as { exports: Record<string, unknown> };
+    const rootEntrypoint = fs.readFileSync(
+      path.resolve(import.meta.dirname, "../index.ts"),
+      "utf-8",
+    );
+
+    expect(packageJson.exports["./firewalls/selection-resolver"]).toStrictEqual(
+      {
+        import: "./src/firewall-selection-resolver.ts",
+        types: "./src/firewall-selection-resolver.ts",
+      },
+    );
+    expect(moduleSpecifiers(rootEntrypoint)).not.toContain(
+      "./firewalls/selection-resolver",
+    );
+  });
+
   it("keeps runtime firewalls out of the package root entrypoint", () => {
     const rootEntrypoint = fs.readFileSync(
       path.resolve(import.meta.dirname, "../index.ts"),
@@ -256,6 +287,37 @@ describe("firewall runtime loader", () => {
     for (const specifier of rootSpecifiers) {
       expect(specifier).not.toMatch(/^\.\/firewalls(?:\/|$)/);
     }
+  });
+
+  it("keeps firewall expander independent from runtime catalog loaders", () => {
+    const expanderSource = fs.readFileSync(
+      path.resolve(import.meta.dirname, "../firewall-expander.ts"),
+      "utf-8",
+    );
+
+    expect(dynamicImportSpecifiers(expanderSource)).toStrictEqual([]);
+    for (const specifier of moduleSpecifiers(expanderSource)) {
+      expect(specifier).not.toMatch(/^\.{1,2}\/firewalls(?:\/|$)/);
+      expect(specifier).not.toBe("./firewall-runtime");
+    }
+    expectNoGeneratedRuntimeImports(expanderSource);
+  });
+
+  it("keeps root contract entrypoints from exporting runtime selection resolution", () => {
+    const apiContractsRoot = fs.readFileSync(
+      path.resolve(
+        import.meta.dirname,
+        "../../../api-contracts/src/contracts/index.ts",
+      ),
+      "utf-8",
+    );
+    const coreRoot = fs.readFileSync(
+      path.resolve(import.meta.dirname, "../../../core/src/index.ts"),
+      "utf-8",
+    );
+
+    expect(apiContractsRoot).not.toContain("resolveFirewallSelections");
+    expect(coreRoot).not.toContain("resolveFirewallSelections");
   });
 
   it("keeps all-catalog access behind an explicit package subpath", () => {
@@ -350,10 +412,28 @@ describe("firewall runtime loader", () => {
     for (const source of [runtimeSource, helperSource]) {
       expect(source).not.toContain("./index");
       expect(source).not.toContain("@vm0/connectors/firewalls");
-      for (const specifier of staticValueModuleSpecifiers(source)) {
-        expect(specifier).not.toMatch(/^\.\/[a-z0-9][a-z0-9-]*\.generated$/);
-      }
     }
+    expectNoGeneratedRuntimeImports(helperSource);
+  });
+
+  it("keeps selection resolver on the lazy runtime boundary", () => {
+    const resolverSource = fs.readFileSync(
+      path.resolve(import.meta.dirname, "../firewall-selection-resolver.ts"),
+      "utf-8",
+    );
+
+    expect(
+      staticValueModuleSpecifiers(resolverSource).sort(compareStrings),
+    ).toStrictEqual(["./firewall-expander", "./firewall-runtime"]);
+    expect(dynamicImportSpecifiers(resolverSource)).toStrictEqual([]);
+    for (const specifier of moduleSpecifiers(resolverSource)) {
+      expect(specifier).not.toBe(".");
+      expect(specifier).not.toBe("./index");
+      expect(specifier).not.toMatch(/^\.{1,2}\/firewalls(?:\/|$)/);
+      expect(specifier).not.toBe("@vm0/connectors/firewalls");
+      expect(specifier).not.toBe("@vm0/connectors/firewalls/all");
+    }
+    expectNoGeneratedRuntimeImports(resolverSource);
   });
 
   it("uses literal dynamic imports in the generated runtime loader", () => {

--- a/turbo/packages/connectors/src/__tests__/firewall-selection-resolver.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-selection-resolver.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { resolveFirewallSelections } from "../firewall-selection-resolver";
+import { resolveFirewallSelections } from "@vm0/connectors/firewalls/selection-resolver";
 
 describe("resolveFirewallSelections", () => {
   it("should resolve builtin firewall with permissions: all", async () => {
@@ -30,6 +30,15 @@ describe("resolveFirewallSelections", () => {
     });
     expect(permNames).toContain("read");
     expect(permNames).toContain("write");
+  });
+
+  it("should trim builtin firewall names before resolution", async () => {
+    const expanded = await resolveFirewallSelections({
+      " brex ": { permissions: ["read"] },
+    });
+
+    expect(expanded).toHaveLength(1);
+    expect(expanded[0]!.name).toBe("brex");
   });
 
   it("should include placeholders and description when config has them", async () => {

--- a/turbo/packages/connectors/src/__tests__/firewall-selection-resolver.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-selection-resolver.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveFirewallSelections } from "../firewall-selection-resolver";
+
+describe("resolveFirewallSelections", () => {
+  it("should resolve builtin firewall with permissions: all", async () => {
+    const expanded = await resolveFirewallSelections({
+      brex: { permissions: "all" },
+    });
+
+    expect(expanded).toHaveLength(1);
+    expect(expanded[0]!.name).toBe("brex");
+    expect(expanded[0]!.apis.length).toBeGreaterThan(0);
+    const permNames = expanded[0]!.apis[0]!.permissions!.map((p) => {
+      return p.name;
+    });
+    expect(permNames).toContain("read");
+    expect(permNames).toContain("write");
+  });
+
+  it("should resolve firewall with specific permissions", async () => {
+    const expanded = await resolveFirewallSelections({
+      brex: { permissions: ["read", "write"] },
+    });
+
+    expect(expanded).toHaveLength(1);
+    expect(expanded[0]!.apis[0]!.permissions).toHaveLength(2);
+    const permNames = expanded[0]!.apis[0]!.permissions!.map((p) => {
+      return p.name;
+    });
+    expect(permNames).toContain("read");
+    expect(permNames).toContain("write");
+  });
+
+  it("should include placeholders and description when config has them", async () => {
+    const expanded = await resolveFirewallSelections({
+      brex: { permissions: "all" },
+    });
+
+    expect(expanded[0]!.placeholders).toMatchObject({
+      BREX_TOKEN: "CoffeeSafeLocalCoffeeSafeLocalCoffeeSafeLocal",
+    });
+    expect(expanded[0]!.description).toBe("Brex API");
+  });
+
+  it("should resolve multiple builtin firewalls", async () => {
+    const expanded = await resolveFirewallSelections({
+      brex: { permissions: "all" },
+      "slack-webhook": { permissions: "all" },
+    });
+
+    expect(expanded).toHaveLength(2);
+    const names = expanded.map((s) => {
+      return s.name;
+    });
+    expect(names).toContain("brex");
+    expect(names).toContain("slack-webhook");
+  });
+
+  it("should return empty array for empty selections", async () => {
+    const expanded = await resolveFirewallSelections({});
+    expect(expanded).toEqual([]);
+  });
+
+  it("should throw for non-existent permission name", async () => {
+    await expect(
+      resolveFirewallSelections({
+        brex: { permissions: ["does-not-exist"] },
+      }),
+    ).rejects.toThrow(
+      'Permission "does-not-exist" does not exist in firewall "brex"',
+    );
+  });
+
+  it("should reject non-builtin firewall names", async () => {
+    await expect(
+      resolveFirewallSelections({
+        "custom-git": { permissions: "all" },
+      }),
+    ).rejects.toThrow(
+      'Unsupported firewall "custom-git": only built-in connector firewalls are supported',
+    );
+  });
+
+  it("should reject GitHub URL firewall refs", async () => {
+    await expect(
+      resolveFirewallSelections({
+        "https://github.com/acme/firewalls/tree/main/my-firewall": {
+          permissions: "all",
+        },
+      }),
+    ).rejects.toThrow(
+      'Unsupported firewall "https://github.com/acme/firewalls/tree/main/my-firewall": only built-in connector firewalls are supported',
+    );
+  });
+
+  it("should validate unsupported firewall refs before permission names", async () => {
+    await expect(
+      resolveFirewallSelections({
+        brex: { permissions: ["does-not-exist"] },
+        "custom-git": { permissions: "all" },
+      }),
+    ).rejects.toThrow(
+      'Unsupported firewall "custom-git": only built-in connector firewalls are supported',
+    );
+  });
+
+  it("should filter permissions and keep only selected ones", async () => {
+    const expanded = await resolveFirewallSelections({
+      brex: { permissions: ["read"] },
+    });
+
+    expect(expanded[0]!.apis[0]!.permissions).toHaveLength(1);
+    expect(expanded[0]!.apis[0]!.permissions![0]!.name).toBe("read");
+  });
+
+  it("should keep all api_entries when shared permission is selected", async () => {
+    const expanded = await resolveFirewallSelections({
+      gmail: { permissions: ["messages.send"] },
+    });
+
+    expect(expanded).toHaveLength(1);
+    expect(expanded[0]!.apis.length).toBeGreaterThan(1);
+    for (const api of expanded[0]!.apis) {
+      expect(
+        api.permissions?.map((p) => {
+          return p.name;
+        }),
+      ).toEqual(["messages.send"]);
+    }
+  });
+
+  it("should retain api entries with empty permissions when user picks all", async () => {
+    const expanded = await resolveFirewallSelections({
+      "slack-webhook": { permissions: "all" },
+    });
+
+    expect(expanded).toHaveLength(1);
+    expect(expanded[0]!.name).toBe("slack-webhook");
+    expect(expanded[0]!.apis).toHaveLength(1);
+    for (const api of expanded[0]!.apis) {
+      expect(api.permissions ?? []).toEqual([]);
+    }
+  });
+});

--- a/turbo/packages/connectors/src/__tests__/firewall-selection-resolver.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-selection-resolver.test.ts
@@ -59,11 +59,52 @@ describe("resolveFirewallSelections", () => {
     });
 
     expect(expanded).toHaveLength(2);
-    const names = expanded.map((s) => {
-      return s.name;
+    expect(
+      expanded.map((s) => {
+        return s.name;
+      }),
+    ).toEqual(["brex", "slack-webhook"]);
+  });
+
+  it("should drop configs with no selected api entries", async () => {
+    const expanded = await resolveFirewallSelections({
+      brex: { permissions: [] },
     });
-    expect(names).toContain("brex");
-    expect(names).toContain("slack-webhook");
+
+    expect(expanded).toEqual([]);
+  });
+
+  it("should reject blank firewall names after trimming", async () => {
+    await expect(
+      resolveFirewallSelections({
+        "   ": { permissions: "all" },
+      }),
+    ).rejects.toThrow(
+      'Unsupported firewall "   ": only built-in connector firewalls are supported',
+    );
+  });
+
+  it("should reject names that contain slashes after trimming", async () => {
+    await expect(
+      resolveFirewallSelections({
+        " brex/foo ": { permissions: "all" },
+      }),
+    ).rejects.toThrow(
+      'Unsupported firewall " brex/foo ": only built-in connector firewalls are supported',
+    );
+  });
+
+  it("should keep permission-filtered output in selection order", async () => {
+    const expanded = await resolveFirewallSelections({
+      "slack-webhook": { permissions: "all" },
+      brex: { permissions: ["read"] },
+    });
+
+    expect(
+      expanded.map((s) => {
+        return s.name;
+      }),
+    ).toEqual(["slack-webhook", "brex"]);
   });
 
   it("should return empty array for empty selections", async () => {

--- a/turbo/packages/connectors/src/firewall-expander.ts
+++ b/turbo/packages/connectors/src/firewall-expander.ts
@@ -7,20 +7,9 @@ import {
 } from "./firewall-types";
 import { hasRawWhitespace, hasUnsafeUrlCodepoint } from "./firewall-url-utils";
 import { parseSegment, splitPathSegments } from "./segment-parser";
-import { getConnectorFirewall, isFirewallConnectorType } from "./firewalls";
 
 export interface FirewallSelection {
   permissions: string[] | "all";
-}
-
-function resolveBuiltinFirewallConfig(name: string): FirewallConfig {
-  const trimmed = name.trim();
-  if (trimmed.includes("/") || !isFirewallConnectorType(trimmed)) {
-    throw new Error(
-      `Unsupported firewall "${name}": only built-in connector firewalls are supported`,
-    );
-  }
-  return getConnectorFirewall(trimmed);
 }
 
 const VALID_RULE_METHODS = new Set([
@@ -181,83 +170,56 @@ export function collectAndValidatePermissions(
 }
 
 /**
- * Resolve a firewall selections map to expanded configs.
- * Pure function: takes a map of firewall names → permission selections and returns
- * fully resolved ExpandedFirewallConfig[].
- *
- * Input:  Record<name, { permissions: string[] | "all" }>
- * Output: ExpandedFirewallConfig[]
- *
+ * Resolve one already-loaded firewall config against a permission selection.
  * Validates permission names, filters api_entries to only include selected permissions,
- * and drops entries with no remaining APIs.
- *
- * @param selections - Map of firewall names to permission selections
+ * and returns null when no api_entries remain.
  */
-export async function resolveFirewallSelections(
-  selections: Record<string, FirewallSelection>,
-): Promise<ExpandedFirewallConfig[]> {
-  const expanded: ExpandedFirewallConfig[] = [];
+export function resolveFirewallConfigSelection(
+  serviceConfig: FirewallConfig,
+  selection: FirewallSelection,
+): ExpandedFirewallConfig | null {
+  const availablePermissions = collectAndValidatePermissions(serviceConfig);
 
-  const entries = Object.entries(selections);
-  if (entries.length === 0) return expanded;
-
-  const resolvedConfigs = entries.map(([name]) => {
-    return resolveBuiltinFirewallConfig(name);
-  });
-
-  for (let i = 0; i < entries.length; i++) {
-    const [, selection] = entries[i]!;
-    const serviceConfig = resolvedConfigs[i]!;
-    const availablePermissions = collectAndValidatePermissions(serviceConfig);
-
-    // Validate selected permissions exist
-    if (selection.permissions !== "all") {
-      for (const name of selection.permissions) {
-        if (!availablePermissions.has(name)) {
-          const available = [...availablePermissions].join(", ");
-          throw new Error(
-            `Permission "${name}" does not exist in firewall "${serviceConfig.name}". Available: ${available}`,
-          );
-        }
+  if (selection.permissions !== "all") {
+    for (const name of selection.permissions) {
+      if (!availablePermissions.has(name)) {
+        const available = [...availablePermissions].join(", ");
+        throw new Error(
+          `Permission "${name}" does not exist in firewall "${serviceConfig.name}". Available: ${available}`,
+        );
       }
     }
-
-    // Filter api_entries: keep only selected permissions, drop empty entries
-    const selectedSet =
-      selection.permissions === "all" ? null : new Set(selection.permissions);
-
-    const filteredApis = serviceConfig.apis
-      .map((api) => {
-        return {
-          ...api,
-          permissions: selectedSet
-            ? (api.permissions ?? []).filter((p) => {
-                return selectedSet.has(p.name);
-              })
-            : api.permissions,
-        };
-      })
-      .filter((api) => {
-        // When user picked "all", keep every api — including
-        // empty-permissions ones where auth-only injection plus
-        // unknownPolicy fallback is the intended semantics.
-        if (selectedSet === null) return true;
-        return (api.permissions ?? []).length > 0;
-      });
-
-    // Drop firewall config entirely if no api_entries remain
-    if (filteredApis.length === 0) continue;
-
-    const entry: ExpandedFirewallConfig = {
-      name: serviceConfig.name,
-      apis: filteredApis,
-    };
-    if (serviceConfig.description !== undefined)
-      entry.description = serviceConfig.description;
-    if (serviceConfig.placeholders !== undefined)
-      entry.placeholders = serviceConfig.placeholders;
-    expanded.push(entry);
   }
 
-  return expanded;
+  const selectedSet =
+    selection.permissions === "all" ? null : new Set(selection.permissions);
+
+  const filteredApis = serviceConfig.apis
+    .map((api) => {
+      return {
+        ...api,
+        permissions: selectedSet
+          ? (api.permissions ?? []).filter((p) => {
+              return selectedSet.has(p.name);
+            })
+          : api.permissions,
+      };
+    })
+    .filter((api) => {
+      // When user picked "all", keep every api, including auth-only entries.
+      if (selectedSet === null) return true;
+      return (api.permissions ?? []).length > 0;
+    });
+
+  if (filteredApis.length === 0) return null;
+
+  const entry: ExpandedFirewallConfig = {
+    name: serviceConfig.name,
+    apis: filteredApis,
+  };
+  if (serviceConfig.description !== undefined)
+    entry.description = serviceConfig.description;
+  if (serviceConfig.placeholders !== undefined)
+    entry.placeholders = serviceConfig.placeholders;
+  return entry;
 }

--- a/turbo/packages/connectors/src/firewall-selection-resolver.ts
+++ b/turbo/packages/connectors/src/firewall-selection-resolver.ts
@@ -1,0 +1,50 @@
+import {
+  type FirewallSelection,
+  resolveFirewallConfigSelection,
+} from "./firewall-expander";
+import {
+  isRuntimeFirewallConnectorType,
+  loadConnectorFirewall,
+  type RuntimeFirewallConnectorType,
+} from "./firewall-runtime";
+import type { ExpandedFirewallConfig } from "./firewall-types";
+
+function resolveRuntimeFirewallType(
+  name: string,
+): RuntimeFirewallConnectorType {
+  const trimmed = name.trim();
+  if (trimmed.includes("/") || !isRuntimeFirewallConnectorType(trimmed)) {
+    throw new Error(
+      `Unsupported firewall "${name}": only built-in connector firewalls are supported`,
+    );
+  }
+  return trimmed;
+}
+
+export async function resolveFirewallSelections(
+  selections: Record<string, FirewallSelection>,
+): Promise<ExpandedFirewallConfig[]> {
+  const entries = Object.entries(selections);
+  if (entries.length === 0) return [];
+
+  const runtimeTypes = entries.map(([name]) => {
+    return resolveRuntimeFirewallType(name);
+  });
+  const configs = await Promise.all(
+    runtimeTypes.map((type) => {
+      return loadConnectorFirewall(type);
+    }),
+  );
+
+  const expanded: ExpandedFirewallConfig[] = [];
+  for (let i = 0; i < entries.length; i++) {
+    const [, selection] = entries[i]!;
+    const config = configs[i]!;
+    const resolved = resolveFirewallConfigSelection(config, selection);
+    if (resolved !== null) {
+      expanded.push(resolved);
+    }
+  }
+
+  return expanded;
+}

--- a/turbo/packages/core/src/index.ts
+++ b/turbo/packages/core/src/index.ts
@@ -274,7 +274,6 @@ export {
   type FirewallTemplateReferences,
   type BasicAuthTemplateArg,
   type BasicAuthTemplateMatch,
-  resolveFirewallSelections,
   collectAndValidatePermissions,
   validateRule,
   matchFirewallPath,


### PR DESCRIPTION
## Summary
- Keep `firewall-expander` pure by moving built-in firewall selection resolution behind an explicit runtime subpath.
- Add `@vm0/connectors/firewalls/selection-resolver`, backed by the lazy runtime firewall loader.
- Stop re-exporting runtime selection resolution from `api-contracts` and `core` roots, and add boundary coverage to prevent eager generated firewall imports from leaking back in.

Closes #18658

## Tests
- `pnpm -F @vm0/connectors exec vitest run src/__tests__/firewall-runtime-loader.test.ts src/__tests__/firewall-selection-resolver.test.ts src/__tests__/firewall-expander.test.ts`
- `pnpm -F @vm0/connectors exec vitest run`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/core lint`
- `pnpm -F @vm0/core check-types`
- `pnpm check-types`
- `pnpm format`
- `git diff --check`
- Pre-commit hook: prettier, knip, `pnpm check-types`
