### PR TITLE
fix: prevent lightbox image zoom drift

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -262,6 +262,18 @@ describe("zero attachment chips", () => {
       expect(screen.getByText("100%")).toBeInTheDocument();
     });
 
+    const zoomStage = screen.getByTestId("artifact-dialog-image-stage");
+    const zoomContent = zoomStage.querySelector<HTMLElement>(
+      ".react-transform-component",
+    );
+    if (!zoomContent) {
+      throw new Error("Zoomable image content not found");
+    }
+    expect(zoomContent.style.height).toBe("");
+    expect(zoomContent.style.width).toBe("");
+    expect(zoomContent.style.maxHeight).toBe("100%");
+    expect(zoomContent.style.maxWidth).toBe("100%");
+
     click(screen.getByLabelText("Zoom in"));
     await waitFor(() => {
       expect(screen.getByText("115%")).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/zero-zoomable-image-canvas.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-zoomable-image-canvas.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode, Ref } from "react";
+import type { CSSProperties, ReactNode, Ref } from "react";
 import { useGet, useSet } from "ccstate-react";
 import {
   TransformComponent,
@@ -19,6 +19,18 @@ const IMAGE_ZOOM_STEP = 0.15;
 const IMAGE_ZOOM_ANIMATION_MS = 180;
 const IMAGE_ZOOM_ANIMATION_TYPE = "linear";
 const NATIVE_MEDIA_INTERACTION_CLASS = "zero-native-media-interaction";
+const ZOOMABLE_IMAGE_WRAPPER_STYLE = {
+  height: "100%",
+  width: "100%",
+} satisfies CSSProperties;
+const ZOOMABLE_IMAGE_CONTENT_STYLE = {
+  alignItems: "center",
+  boxSizing: "border-box",
+  display: "flex",
+  justifyContent: "center",
+  maxHeight: "100%",
+  maxWidth: "100%",
+} satisfies CSSProperties;
 
 type ZoomableArtifactImageSurface =
   | "attachment-lightbox"
@@ -152,6 +164,7 @@ export function ZoomableArtifactImageCanvas({
       maxScale={IMAGE_LIGHTBOX_MAX_ZOOM}
       limitToBounds
       centerZoomedOut
+      centerOnInit
       smooth
       wheel={{ step: 0.008, wheelDisabled: true }}
       trackPadPanning={{
@@ -212,15 +225,8 @@ export function ZoomableArtifactImageCanvas({
             {children?.(controls)}
             <TransformComponent
               contentClass={contentClassName}
-              wrapperStyle={{ height: "100%", width: "100%" }}
-              contentStyle={{
-                alignItems: "center",
-                boxSizing: "border-box",
-                display: "flex",
-                height: "100%",
-                justifyContent: "center",
-                width: "100%",
-              }}
+              wrapperStyle={ZOOMABLE_IMAGE_WRAPPER_STYLE}
+              contentStyle={ZOOMABLE_IMAGE_CONTENT_STYLE}
             >
               <img
                 ref={imageRef}


### PR DESCRIPTION
## Summary
- keep the zoom/pan wrapper full-size, but stop sizing the transform content to the full canvas
- let the transform content measure the rendered image box with max bounds, so empty canvas space is not scaled into the pan/zoom boundary math
- center the measured image content on init and reset
- add a regression assertion for the lightbox image zoom content sizing

## Verification
- pnpm exec prettier --write apps/platform/src/views/zero-page/zero-zoomable-image-canvas.tsx apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app lint

Fixes #17671