### PR TITLE
chore: remove redundant no-store fetch options

### DIFF
--- a/turbo/apps/api/src/signals/external/axiom.ts
+++ b/turbo/apps/api/src/signals/external/axiom.ts
@@ -177,7 +177,6 @@ async function queryAxiomDirectWithCursor<T>(
       apl,
       cursor: options.cursor,
     }),
-    cache: "no-store",
     signal: AbortSignal.timeout(AXIOM_QUERY_TIMEOUT_MS),
   });
 

--- a/turbo/apps/platform/src/signals/chat-page/github-pr-tracking.ts
+++ b/turbo/apps/platform/src/signals/chat-page/github-pr-tracking.ts
@@ -201,7 +201,6 @@ function createChatThreadGithubPrsFactory(): (
         const result = await accept(
           client.list({
             params: { threadId },
-            fetchOptions: { cache: "no-store" },
           }),
           [200],
           { toast: false },

--- a/turbo/apps/platform/src/signals/chat-page/header-automation-menu.ts
+++ b/turbo/apps/platform/src/signals/chat-page/header-automation-menu.ts
@@ -41,9 +41,7 @@ export const headerAutomationMenu$ = computed(
     const prefs = await get(userPreferences$);
     const displayTz =
       prefs?.timezone ?? new Intl.DateTimeFormat().resolvedOptions().timeZone;
-    const automations = await listAutomations(get(zeroClient$), {
-      cache: "no-store",
-    });
+    const automations = await listAutomations(get(zeroClient$));
     return automations.map((automation) => {
       return {
         id: automation.id,
@@ -112,11 +110,9 @@ function createHeaderWorkflowTriggersFactory(): (
     const triggers$ = computed(
       async (get): Promise<readonly HeaderWorkflowTriggerEntry[]> => {
         get(headerAutomationMenuReload$);
-        const triggers = await listThreadWorkflowTriggers(
-          get(zeroClient$),
-          { threadId },
-          { cache: "no-store" },
-        );
+        const triggers = await listThreadWorkflowTriggers(get(zeroClient$), {
+          threadId,
+        });
         return triggers.map((trigger) => {
           return {
             id: trigger.id,


### PR DESCRIPTION
## Summary
- remove redundant fetch `cache: no-store` options from platform automation and GitHub PR tracking reads
- remove redundant `cache: no-store` from the server-side Axiom POST request
- leave Next.js Strapi draft-mode no-store fetch options untouched because they control Next fetch caching

## Verification
- `git diff --check`
