### PR TITLE
fix: sharpen artifact template thumbnails

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -2563,16 +2563,8 @@ describe("chat composer templates", () => {
 
     const heroAlt = `${illustrationTemplate.title} illustration preview`;
     const heroSrc = (index: number) => {
-      if (index === 0 && illustrationTemplate.cardPreviewImage) {
-        return r2ImageTransformUrl(illustrationTemplate.cardPreviewImage, {
-          width: 512,
-          height: 512,
-          quality: 72,
-        });
-      }
       return r2ImageTransformUrl(illustrationTemplate.previewImages[index]!, {
-        width: 512,
-        height: 512,
+        width: 1024,
         quality: 72,
       });
     };
@@ -2750,16 +2742,8 @@ describe("chat composer templates", () => {
 
     const heroAlt = `${illustrationTemplate.title} illustration preview`;
     const heroSrc = (index: number) => {
-      if (index === 0 && illustrationTemplate.cardPreviewImage) {
-        return r2ImageTransformUrl(illustrationTemplate.cardPreviewImage, {
-          width: 512,
-          height: 512,
-          quality: 72,
-        });
-      }
       return r2ImageTransformUrl(illustrationTemplate.previewImages[index]!, {
-        width: 512,
-        height: 512,
+        width: 1024,
         quality: 72,
       });
     };

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -384,16 +384,20 @@ const ILLUSTRATION_SCROLL_PREWARM_IMAGE_COUNT = 24;
 const TEMPLATE_IDLE_PREWARM_TIMEOUT_MS = 350;
 const TEMPLATE_IDLE_PREWARM_STAGGER_MS = 500;
 const ILLUSTRATION_CARD_PREVIEW_SIZE = {
-  width: 512,
-  height: 512,
+  width: 1024,
   quality: 72,
 } as const;
 const ILLUSTRATION_VARIANT_THUMB_SIZE = {
   width: 96,
   height: 96,
+  fit: "cover",
   quality: 65,
 } as const;
-const SELECTED_TEMPLATE_CHIP_PREVIEW_SIZE = { width: 40, height: 40 } as const;
+const SELECTED_TEMPLATE_CHIP_PREVIEW_SIZE = {
+  width: 40,
+  height: 40,
+  fit: "cover",
+} as const;
 type TemplatePreviewImageSize = Parameters<typeof r2ImageTransformUrl>[1];
 
 // ---------------------------------------------------------------------------
@@ -1442,10 +1446,7 @@ function illustrationPreviewImageUrlsForItems({
       0,
       Math.min(variantIndexBySlug[item.slug] ?? 0, images.length - 1),
     );
-    return illustrationHeroImageUrlForItem(
-      item,
-      images[activeIndex] ?? item.previewImage,
-    );
+    return illustrationHeroImageUrl(images[activeIndex] ?? item.previewImage);
   });
 }
 
@@ -3632,14 +3633,14 @@ function IllustrationTemplateHero({
   source: string;
   onVariantChange: (slug: string, index: number) => void;
 }) {
-  const heroImage = illustrationHeroImageUrlForItem(item, source);
+  const heroImage = illustrationHeroImageUrl(source);
   const navigable = images.length > 1;
   const variantAt = (direction: -1 | 1): number => {
     return (activeIndex + direction + images.length) % images.length;
   };
   const preloadNeighbors = (): void => {
-    preloadIllustrationVariant(item, images, variantAt(1));
-    preloadIllustrationVariant(item, images, variantAt(-1));
+    preloadIllustrationVariant(images, variantAt(1));
+    preloadIllustrationVariant(images, variantAt(-1));
   };
 
   return (
@@ -3728,19 +3729,6 @@ function illustrationPreviewImageCache(): IllustrationPreviewImageCache {
 
 function illustrationHeroImageUrl(source: string): string {
   return r2ImageTransformUrl(source, ILLUSTRATION_CARD_PREVIEW_SIZE);
-}
-
-function illustrationHeroImageUrlForItem(
-  item: IllustrationTemplateItem,
-  source: string,
-): string {
-  if (
-    item.cardPreviewImage !== undefined &&
-    source === (item.previewImages[0] ?? item.previewImage)
-  ) {
-    return illustrationHeroImageUrl(item.cardPreviewImage);
-  }
-  return illustrationHeroImageUrl(source);
 }
 
 function preloadIllustrationPreviewImage(
@@ -3870,7 +3858,7 @@ function selectIllustrationVariant({
     return;
   }
 
-  const imageUrl = illustrationHeroImageUrlForItem(item, image);
+  const imageUrl = illustrationHeroImageUrl(image);
   // Swap immediately only when the target hero is already decoded; otherwise
   // decode it off-screen first so the hero never flashes a blank/loading frame.
   if (card === null || illustrationPreviewImageDecoded(imageUrl)) {
@@ -3892,7 +3880,6 @@ function selectIllustrationVariant({
 }
 
 function preloadIllustrationVariant(
-  item: IllustrationTemplateItem,
   images: readonly string[],
   index: number,
 ): void {
@@ -3902,9 +3889,7 @@ function preloadIllustrationVariant(
   }
 
   detach(
-    decodeIllustrationPreviewImage(
-      illustrationHeroImageUrlForItem(item, image),
-    ),
+    decodeIllustrationPreviewImage(illustrationHeroImageUrl(image)),
     Reason.DomCallback,
   );
 }
@@ -4105,12 +4090,12 @@ function IllustrationTemplateCard({
                 )}
                 onFocus={() => {
                   preloadIllustrationPreviewImage(
-                    illustrationHeroImageUrlForItem(item, image),
+                    illustrationHeroImageUrl(image),
                   );
                 }}
                 onMouseEnter={() => {
                   preloadIllustrationPreviewImage(
-                    illustrationHeroImageUrlForItem(item, image),
+                    illustrationHeroImageUrl(image),
                   );
                 }}
                 onClick={(event) => {

--- a/turbo/packages/core/src/__tests__/r2-image-transform.spec.ts
+++ b/turbo/packages/core/src/__tests__/r2-image-transform.spec.ts
@@ -47,6 +47,19 @@ describe("r2ImageTransformUrl", () => {
     );
   });
 
+  it("allows callers to crop cover thumbnails", () => {
+    expect(
+      r2ImageTransformUrl("https://cdn.vm0.io/artifacts/user/id/image.jpg", {
+        width: 96,
+        height: 96,
+        fit: "cover",
+        quality: 65,
+      }),
+    ).toBe(
+      "https://cdn.vm0.io/cdn-cgi/image/width=96,height=96,fit=cover,format=auto,quality=65,metadata=none/artifacts/user/id/image.jpg",
+    );
+  });
+
   it("leaves already transformed URLs untouched", () => {
     const url =
       "https://cdn.vm0.io/cdn-cgi/image/width=100,height=100,fit=scale-down/artifacts/user/id/image.png";

--- a/turbo/packages/core/src/r2-image-transform.ts
+++ b/turbo/packages/core/src/r2-image-transform.ts
@@ -8,7 +8,7 @@ const R2_IMAGE_TRANSFORM_QUALITY = 85;
 export interface R2ImageTransformOptions {
   readonly width?: number;
   readonly height?: number;
-  readonly fit?: "scale-down";
+  readonly fit?: "cover" | "scale-down";
   readonly quality?: number;
 }
 


### PR DESCRIPTION
## Summary
- use original illustration variant images for the template picker hero instead of the 512px card-preview assets
- request high-DPI illustration hero images by width, so tall assets are not squeezed into a square resize box
- support `fit=cover` for R2 image transforms and use it for square template thumbnails/chips

Fixes #18701

## Verification
- `pnpm -F @vm0/core test -- src/__tests__/r2-image-transform.spec.ts`
- `pnpm -F @vm0/core check-types`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app exec eslint src/views/zero-page/zero-chat-composer.tsx src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx --max-warnings 0`
- `pnpm -F @vm0/app exec oxlint src/views/zero-page/zero-chat-composer.tsx src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx`
- `pnpm -F @vm0/core exec eslint src/r2-image-transform.ts src/__tests__/r2-image-transform.spec.ts --max-warnings 0`
- `pnpm -F @vm0/core exec oxlint src/r2-image-transform.ts src/__tests__/r2-image-transform.spec.ts`

## Notes
- I did not complete the full platform composer vitest file locally; both the full file and the narrowed illustration test produced no progress output for over 90s, so I interrupted them and relied on targeted static checks plus the core transform test.