### PR TITLE
test: stabilize clerk user deletion webhook test

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -3733,14 +3733,13 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
 
     // User storage cleanup is best-effort: a failing S3 listing must not
     // stop the rest of the teardown.
-    context.mocks.s3.send.mockRejectedValue(new Error("R2 unavailable"));
+    context.mocks.s3.send.mockRejectedValueOnce(new Error("R2 unavailable"));
     api.verifyNextClerkWebhook({
       type: "user.deleted",
       data: { id: doomed.userId },
     });
     const response = await api.requestClerkWebhook("{}", {}, [200]);
     expect(response.body).toBe("OK");
-    context.mocks.s3.send.mockResolvedValue({});
 
     await waitForExpectation(() => {
       expect(context.mocks.telegram.deleteWebhook).toHaveBeenCalledWith(

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -3742,16 +3742,12 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
     const response = await api.requestClerkWebhook("{}", {}, [200]);
     expect(response.body).toBe("OK");
     await flushWaitUntilForTest();
+    const firstCleanupS3Prefix = commandInput(
+      context.mocks.s3.send.mock.calls[s3CallCountBeforeCleanup]?.[0],
+    ).Prefix;
     expect(
-      context.mocks.s3.send.mock.calls
-        .slice(s3CallCountBeforeCleanup)
-        .some(([command]) => {
-          const prefix = commandInput(command).Prefix;
-          return (
-            typeof prefix === "string" &&
-            prefix.startsWith(`${orgOf(doomed)}/artifact/`)
-          );
-        }),
+      typeof firstCleanupS3Prefix === "string" &&
+        firstCleanupS3Prefix.startsWith(`${orgOf(doomed)}/artifact/`),
     ).toBeTruthy();
 
     await waitForExpectation(() => {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -3741,6 +3741,15 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
     const response = await api.requestClerkWebhook("{}", {}, [200]);
     expect(response.body).toBe("OK");
     await flushWaitUntilForTest();
+    expect(
+      context.mocks.s3.send.mock.calls.some(([command]) => {
+        const prefix = commandInput(command).Prefix;
+        return (
+          typeof prefix === "string" &&
+          prefix.startsWith(`${orgOf(doomed)}/artifact/`)
+        );
+      }),
+    ).toBeTruthy();
 
     await waitForExpectation(() => {
       expect(context.mocks.telegram.deleteWebhook).toHaveBeenCalledWith(

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -3783,14 +3783,16 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
     expect(context.mocks.stripe.subscriptions.list).not.toHaveBeenCalled();
     expect(context.mocks.stripe.subscriptions.update).not.toHaveBeenCalled();
     expect(context.mocks.stripe.subscriptions.cancel).not.toHaveBeenCalled();
-    const rows = await readOrgCleanupRows(orgOf(doomed));
-    expect(rows.metadata).toStrictEqual([
-      {
-        stripeCustomerId: granted.customerId,
-        stripeSubscriptionId: granted.subscriptionId,
-      },
-    ]);
-    expect(rows.members).toStrictEqual([{ userId: peer.userId }]);
+    await waitForExpectation(async () => {
+      const rows = await readOrgCleanupRows(orgOf(doomed));
+      expect(rows.metadata).toStrictEqual([
+        {
+          stripeCustomerId: granted.customerId,
+          stripeSubscriptionId: granted.subscriptionId,
+        },
+      ]);
+      expect(rows.members).toStrictEqual([{ userId: peer.userId }]);
+    });
   });
 
   it("suspends user-owned runs and automations after a verified user.banned event", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -3740,6 +3740,7 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
     });
     const response = await api.requestClerkWebhook("{}", {}, [200]);
     expect(response.body).toBe("OK");
+    await flushWaitUntilForTest();
 
     await waitForExpectation(() => {
       expect(context.mocks.telegram.deleteWebhook).toHaveBeenCalledWith(
@@ -3782,16 +3783,14 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
     expect(context.mocks.stripe.subscriptions.list).not.toHaveBeenCalled();
     expect(context.mocks.stripe.subscriptions.update).not.toHaveBeenCalled();
     expect(context.mocks.stripe.subscriptions.cancel).not.toHaveBeenCalled();
-    await waitForExpectation(async () => {
-      const rows = await readOrgCleanupRows(orgOf(doomed));
-      expect(rows.metadata).toStrictEqual([
-        {
-          stripeCustomerId: granted.customerId,
-          stripeSubscriptionId: granted.subscriptionId,
-        },
-      ]);
-      expect(rows.members).toStrictEqual([{ userId: peer.userId }]);
-    });
+    const rows = await readOrgCleanupRows(orgOf(doomed));
+    expect(rows.metadata).toStrictEqual([
+      {
+        stripeCustomerId: granted.customerId,
+        stripeSubscriptionId: granted.subscriptionId,
+      },
+    ]);
+    expect(rows.members).toStrictEqual([{ userId: peer.userId }]);
   });
 
   it("suspends user-owned runs and automations after a verified user.banned event", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -3733,6 +3733,7 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
 
     // User storage cleanup is best-effort: a failing S3 listing must not
     // stop the rest of the teardown.
+    const s3CallCountBeforeCleanup = context.mocks.s3.send.mock.calls.length;
     context.mocks.s3.send.mockRejectedValueOnce(new Error("R2 unavailable"));
     api.verifyNextClerkWebhook({
       type: "user.deleted",
@@ -3742,13 +3743,15 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
     expect(response.body).toBe("OK");
     await flushWaitUntilForTest();
     expect(
-      context.mocks.s3.send.mock.calls.some(([command]) => {
-        const prefix = commandInput(command).Prefix;
-        return (
-          typeof prefix === "string" &&
-          prefix.startsWith(`${orgOf(doomed)}/artifact/`)
-        );
-      }),
+      context.mocks.s3.send.mock.calls
+        .slice(s3CallCountBeforeCleanup)
+        .some(([command]) => {
+          const prefix = commandInput(command).Prefix;
+          return (
+            typeof prefix === "string" &&
+            prefix.startsWith(`${orgOf(doomed)}/artifact/`)
+          );
+        }),
     ).toBeTruthy();
 
     await waitForExpectation(() => {


### PR DESCRIPTION
## Summary
- wait for the final org cleanup rows before asserting Clerk user deletion cleanup state
- avoid racing the asynchronous waitUntil cleanup between user permission grant deletion and org member cache deletion

## Testing
- pnpm i
- env DATABASE_URL=postgresql://postgres:postgres@localhost:5432/vm0_test_webhooks_pr_20260623_1936 pnpm -F @vm0/db db:migrate
- env DATABASE_URL=postgresql://postgres:postgres@localhost:5432/vm0_test_webhooks_pr_20260623_1936 pnpm -F api db:dev-seed
- env DATABASE_URL=postgresql://postgres:postgres@localhost:5432/vm0_test_webhooks_pr_20260623_1936 pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts -t "cleans up user state after a verified user.deleted event"
- env DATABASE_URL=postgresql://postgres:postgres@localhost:5432/vm0_test_webhooks_pr_20260623_1936 pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
- git diff --check
- pnpm exec prettier --check apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
- pnpm -F api lint
- pnpm -F api check-types
- pre-commit hook: pnpm check-types