### PR TITLE
Remove the automatic idle prewarm scheduled from the template picker button.

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -343,6 +343,103 @@ function resetPresentationTemplateThumbnailCache(): void {
   Reflect.deleteProperty(globalThis, "vm0PresentationTemplateThumbnailCache");
 }
 
+function resetTemplatePreviewPrewarmCache(): void {
+  Reflect.deleteProperty(globalThis, "vm0TemplatePreviewPrewarmCache");
+  Reflect.deleteProperty(globalThis, "vm0TemplatePreviewIdlePrewarmKeys");
+}
+
+function trackTemplatePreviewImagePreloads(): {
+  readonly srcs: readonly string[];
+  readonly restore: () => void;
+} {
+  const srcs: string[] = [];
+  const originalGlobalImage = Object.getOwnPropertyDescriptor(
+    globalThis,
+    "Image",
+  );
+  const originalWindowImage = Object.getOwnPropertyDescriptor(window, "Image");
+
+  class TestImagePreload {
+    decoding = "";
+    loading = "";
+    fetchPriority = "";
+    #src = "";
+
+    decode(): Promise<void> {
+      return Promise.resolve();
+    }
+
+    get src(): string {
+      return this.#src;
+    }
+
+    set src(value: string) {
+      this.#src = value;
+      srcs.push(value);
+    }
+  }
+
+  const imageConstructor = TestImagePreload as unknown as typeof Image;
+  Object.defineProperty(globalThis, "Image", {
+    configurable: true,
+    value: imageConstructor,
+    writable: true,
+  });
+  Object.defineProperty(window, "Image", {
+    configurable: true,
+    value: imageConstructor,
+    writable: true,
+  });
+
+  return {
+    srcs,
+    restore: () => {
+      if (originalGlobalImage) {
+        Object.defineProperty(globalThis, "Image", originalGlobalImage);
+      } else {
+        Reflect.deleteProperty(globalThis, "Image");
+      }
+      if (originalWindowImage) {
+        Object.defineProperty(window, "Image", originalWindowImage);
+      } else {
+        Reflect.deleteProperty(window, "Image");
+      }
+    },
+  };
+}
+
+function mockImmediateIdleCallback(): () => void {
+  const originalRequestIdleCallback = Object.getOwnPropertyDescriptor(
+    window,
+    "requestIdleCallback",
+  );
+  Object.defineProperty(window, "requestIdleCallback", {
+    configurable: true,
+    value: (callback: IdleRequestCallback): number => {
+      callback({
+        didTimeout: false,
+        timeRemaining: () => {
+          return 50;
+        },
+      });
+      return 1;
+    },
+    writable: true,
+  });
+
+  return () => {
+    if (originalRequestIdleCallback) {
+      Object.defineProperty(
+        window,
+        "requestIdleCallback",
+        originalRequestIdleCallback,
+      );
+    } else {
+      Reflect.deleteProperty(window, "requestIdleCallback");
+    }
+  };
+}
+
 async function expectComposerModel(label: string): Promise<void> {
   await waitFor(() => {
     expect(screen.getByRole("combobox", { name: label })).toBeInTheDocument();
@@ -546,6 +643,7 @@ beforeEach(() => {
   resetPresentationTemplateHtmlPreviewCache();
   resetPresentationCardPreviewImageDecodeCache();
   resetPresentationTemplateThumbnailCache();
+  resetTemplatePreviewPrewarmCache();
 });
 
 describe("chat composer models", () => {
@@ -1517,6 +1615,44 @@ describe("chat composer models", () => {
 });
 
 describe("chat composer templates", () => {
+  it("prewarms template previews only after the template button is used", async () => {
+    const imagePreloads = trackTemplatePreviewImagePreloads();
+    const restoreIdleCallback = mockImmediateIdleCallback();
+    const templatePreviewSrcs = () => {
+      return imagePreloads.srcs.filter((src) => {
+        return src.includes("/cdn-cgi/image/width=480,height=270");
+      });
+    };
+
+    try {
+      mockChatLifecycle(context, { threadId: THREAD_ID });
+
+      detachedSetupPage({
+        context,
+        path: `/chats/${THREAD_ID}`,
+        featureSwitches: {
+          [FeatureSwitchKey.ChatTemplatePicker]: true,
+        },
+      });
+
+      const templateButton = await waitFor(() => {
+        return screen.getByLabelText("Template");
+      });
+
+      expect(templatePreviewSrcs()).toStrictEqual([]);
+
+      click(templateButton);
+
+      await waitFor(() => {
+        expect(templatePreviewSrcs().length).toBeGreaterThan(0);
+      });
+    } finally {
+      restoreIdleCallback();
+      imagePreloads.restore();
+      resetTemplatePreviewPrewarmCache();
+    }
+  });
+
   it("places the template control immediately after attach", async () => {
     mockChatLifecycle(context, { threadId: THREAD_ID });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -381,8 +381,6 @@ const ILLUSTRATION_PREWARM_IMAGE_COUNT = 24;
 const ILLUSTRATION_EAGER_IMAGE_COUNT = 24;
 const ILLUSTRATION_SCROLL_PREWARM_LOOKAHEAD_COUNT = 12;
 const ILLUSTRATION_SCROLL_PREWARM_IMAGE_COUNT = 24;
-const TEMPLATE_IDLE_PREWARM_TIMEOUT_MS = 350;
-const TEMPLATE_IDLE_PREWARM_STAGGER_MS = 500;
 const ILLUSTRATION_CARD_PREVIEW_SIZE = {
   width: 512,
   height: 512,
@@ -1295,125 +1293,6 @@ function prewarmTemplatePreviewImages(
   const uniqueUrls = uniqueTemplatePreviewImageUrls(imageUrls);
   for (const imageUrl of uniqueUrls.slice(0, count)) {
     prewarmTemplatePreviewImage(imageUrl);
-  }
-}
-
-interface TemplatePreviewIdlePrewarmParams {
-  readonly category: string;
-  readonly hasIllustrationTab: boolean;
-  readonly hasPptTab: boolean;
-  readonly hasVideoTab: boolean;
-  readonly presentationThemeIdBySlug?: Readonly<Record<string, string>>;
-}
-
-function templatePreviewIdlePrewarmKeys(): Set<string> {
-  const cacheKey = "vm0TemplatePreviewIdlePrewarmKeys";
-  const existing = Reflect.get(globalThis, cacheKey) as Set<string> | undefined;
-  if (existing !== undefined) {
-    return existing;
-  }
-  const keys = new Set<string>();
-  Reflect.set(globalThis, cacheKey, keys);
-  return keys;
-}
-
-function templatePreviewIdlePrewarmKey({
-  category,
-  hasIllustrationTab,
-  hasPptTab,
-  hasVideoTab,
-}: TemplatePreviewIdlePrewarmParams): string {
-  return [
-    category,
-    hasPptTab ? "ppt" : "",
-    hasIllustrationTab ? "illustration" : "",
-    hasVideoTab ? "video" : "",
-  ].join(":");
-}
-
-function templatePreviewIdlePrewarmCategories({
-  category,
-  hasIllustrationTab,
-  hasPptTab,
-  hasVideoTab,
-}: TemplatePreviewIdlePrewarmParams): string[] {
-  const categories: string[] = [];
-  if (hasPptTab) {
-    categories.push("slides");
-  }
-  if (hasIllustrationTab) {
-    categories.push("illustration");
-  }
-  if (hasVideoTab) {
-    categories.push("video");
-  }
-  const selectedCategory = categories.includes(category)
-    ? category
-    : categories[0];
-  return [
-    ...(selectedCategory !== undefined ? [selectedCategory] : []),
-    ...categories.filter((candidate) => {
-      return candidate !== selectedCategory;
-    }),
-  ];
-}
-
-function scheduleIdleTemplatePreviewPrewarmCategory(
-  node: HTMLElement | null,
-  params: TemplatePreviewIdlePrewarmParams,
-  delayMs: number,
-): void {
-  if (node === null || typeof window === "undefined") {
-    return;
-  }
-
-  const keys = templatePreviewIdlePrewarmKeys();
-  const key = templatePreviewIdlePrewarmKey(params);
-  if (keys.has(key)) {
-    return;
-  }
-  keys.add(key);
-
-  const prewarm = () => {
-    if (!node.isConnected) {
-      keys.delete(key);
-      return;
-    }
-    prewarmTemplatePreviewImages(
-      initialTemplatePreviewImageUrlsForCategory(params),
-      templatePreviewPrewarmImageCountForCategory(params.category),
-    );
-  };
-
-  const requestPrewarm = () => {
-    if (window.requestIdleCallback !== undefined) {
-      window.requestIdleCallback(prewarm, {
-        timeout: TEMPLATE_IDLE_PREWARM_TIMEOUT_MS,
-      });
-      return;
-    }
-
-    window.setTimeout(prewarm, 0);
-  };
-
-  if (delayMs > 0) {
-    window.setTimeout(requestPrewarm, delayMs);
-  } else {
-    requestPrewarm();
-  }
-}
-
-function scheduleIdleTemplatePreviewPrewarm(
-  node: HTMLElement | null,
-  params: TemplatePreviewIdlePrewarmParams,
-): void {
-  const categories = templatePreviewIdlePrewarmCategories(params);
-  for (const [index, category] of categories.entries()) {
-    scheduleIdleTemplatePreviewPrewarmCategory(
-      node,
-      { ...params, category },
-      index * TEMPLATE_IDLE_PREWARM_STAGGER_MS,
-    );
   }
 }
 
@@ -5105,15 +4984,6 @@ function TemplatePickerButton({
         <Tooltip>
           <TooltipTrigger asChild>
             <button
-              ref={(node) => {
-                scheduleIdleTemplatePreviewPrewarm(node, {
-                  category: selectedCategory,
-                  hasIllustrationTab,
-                  hasPptTab,
-                  hasVideoTab,
-                  presentationThemeIdBySlug: cardThemeIdBySlug,
-                });
-              }}
               type="button"
               className={cn(
                 "inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg transition-colors duration-200 hover:bg-accent hover:text-foreground sm:h-9 sm:w-9",


### PR DESCRIPTION
## Summary
- Remove the automatic idle prewarm scheduled from the template picker button
- Keep user-initiated template preview prewarm on hover, focus, pointer down, and click

## Testing
- git diff --check
- pnpm -C turbo -F @vm0/app check-types (fails locally: node_modules missing, tsc not found in this checkout)