### PR TITLE
Inject presentation theme CSS during preview generation to optimize document rendering.

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -1739,7 +1739,16 @@ describe("chat composer templates", () => {
           "Slide two",
         );
       });
+      const createObjectUrlCountBeforeLeave = createObjectURL.mock.calls.length;
       fireEvent.mouseLeave(preview);
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId(`${template.title} card HTML preview`),
+        ).not.toBeInTheDocument();
+      });
+      expect(createObjectURL).toHaveBeenCalledTimes(
+        createObjectUrlCountBeforeLeave,
+      );
 
       await fill(
         screen.getByLabelText("Search templates"),

--- a/turbo/apps/platform/src/views/zero-page/__tests__/presentation-html-edit-protocol.test.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/presentation-html-edit-protocol.test.ts
@@ -95,4 +95,23 @@ describe("previewPresentationHtml", () => {
     expect(injectedCss).toContain("box-shadow: none !important");
     expect(injectedCss).toContain("border-radius: 0 !important");
   });
+
+  it("appends additional head styles to the preview document", () => {
+    const previewHtml = previewPresentationHtml({
+      activeSlideId: "slide-1",
+      additionalHeadStyle: ":root { --accent: #ff6600; }",
+      html: `
+        <!doctype html>
+        <html>
+          <body>
+            <section data-vm0-slide data-slide-id="slide-1">
+              <h1>Slide</h1>
+            </section>
+          </body>
+        </html>
+      `,
+    });
+
+    expect(previewHtml).toContain(":root { --accent: #ff6600; }");
+  });
 });

--- a/turbo/apps/platform/src/views/zero-page/presentation-html-edit-protocol.ts
+++ b/turbo/apps/platform/src/views/zero-page/presentation-html-edit-protocol.ts
@@ -699,42 +699,7 @@ export function applyPresentationSpeakerNotesPatch(params: {
   return { appliedCount, slides };
 }
 
-export function previewPresentationHtml(params: {
-  readonly activeSlideId: string;
-  readonly html: string;
-}): string {
-  const doc = new DOMParser().parseFromString(params.html, "text/html");
-  materializePresentationThemeSwitcherDefaults(doc);
-  sanitizePreviewTree(doc);
-  const previewDoc = document.implementation.createHTMLDocument(
-    doc.title || "Presentation preview",
-  );
-  for (const node of Array.from(doc.head.childNodes)) {
-    previewDoc.head.append(node.cloneNode(true));
-  }
-  const stage = previewDoc.createElement("div");
-  stage.dataset.vm0EditorStage = "true";
-  previewDoc.body.append(stage);
-  for (const [index, slide] of selectSlideElements(doc).entries()) {
-    if (slideIdForElement(slide, index) === params.activeSlideId) {
-      const slideId = slideIdForElement(slide, index);
-      for (const [editableIndex, editable] of selectEditableElements(
-        slide,
-      ).entries()) {
-        if (editable instanceof HTMLElement) {
-          editable.dataset.vm0EditorSlideId = slideId;
-          editable.dataset.vm0EditorEditId =
-            editIdForElement(editable, editableIndex) ?? "";
-        }
-      }
-      const slideClone = slide.cloneNode(true);
-      if (slideClone instanceof Element) {
-        sanitizePreviewTree(slideClone);
-      }
-      stage.append(slideClone);
-      break;
-    }
-  }
+function appendPresentationPreviewStyle(previewDoc: Document): void {
   const style = previewDoc.createElement("style");
   style.textContent = `
     html, body {
@@ -824,6 +789,59 @@ export function previewPresentationHtml(params: {
     }
   `;
   previewDoc.head.append(style);
+}
+
+function appendAdditionalHeadStyle(
+  previewDoc: Document,
+  styleText: string | undefined,
+): void {
+  if (styleText === undefined) {
+    return;
+  }
+  const style = previewDoc.createElement("style");
+  style.textContent = styleText;
+  previewDoc.head.append(style);
+}
+
+export function previewPresentationHtml(params: {
+  readonly activeSlideId: string;
+  readonly additionalHeadStyle?: string;
+  readonly html: string;
+}): string {
+  const doc = new DOMParser().parseFromString(params.html, "text/html");
+  materializePresentationThemeSwitcherDefaults(doc);
+  sanitizePreviewTree(doc);
+  const previewDoc = document.implementation.createHTMLDocument(
+    doc.title || "Presentation preview",
+  );
+  for (const node of Array.from(doc.head.childNodes)) {
+    previewDoc.head.append(node.cloneNode(true));
+  }
+  const stage = previewDoc.createElement("div");
+  stage.dataset.vm0EditorStage = "true";
+  previewDoc.body.append(stage);
+  for (const [index, slide] of selectSlideElements(doc).entries()) {
+    if (slideIdForElement(slide, index) === params.activeSlideId) {
+      const slideId = slideIdForElement(slide, index);
+      for (const [editableIndex, editable] of selectEditableElements(
+        slide,
+      ).entries()) {
+        if (editable instanceof HTMLElement) {
+          editable.dataset.vm0EditorSlideId = slideId;
+          editable.dataset.vm0EditorEditId =
+            editIdForElement(editable, editableIndex) ?? "";
+        }
+      }
+      const slideClone = slide.cloneNode(true);
+      if (slideClone instanceof Element) {
+        sanitizePreviewTree(slideClone);
+      }
+      stage.append(slideClone);
+      break;
+    }
+  }
+  appendPresentationPreviewStyle(previewDoc);
+  appendAdditionalHeadStyle(previewDoc, params.additionalHeadStyle);
   sanitizePreviewDocument(previewDoc);
   return serializeDoc(previewDoc);
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -2074,15 +2074,11 @@ function themedPreviewPresentationHtml(params: {
   readonly draft: PresentationEditDraft;
   readonly theme: PresentationTemplateThemeOption;
 }): string {
-  const html = previewPresentationHtml({
+  return previewPresentationHtml({
     activeSlideId: params.activeSlideId,
+    additionalHeadStyle: presentationTemplateThemeCss(params.theme),
     html: params.draft.html,
   });
-  const doc = new DOMParser().parseFromString(html, "text/html");
-  const style = doc.createElement("style");
-  style.textContent = presentationTemplateThemeCss(params.theme);
-  doc.head.append(style);
-  return `<!doctype html>\n${doc.documentElement.outerHTML}`;
 }
 
 async function loadPresentationTemplateHtmlPreview(params: {
@@ -2911,17 +2907,10 @@ function TemplatePreview({
         cache.activeIndexes.delete(item.embedUrl);
         cache.activeTokens.delete(item.embedUrl);
         setHover(null);
-        const cachedDraft = cache.drafts.get(item.embedUrl);
-        if (cachedDraft !== undefined) {
-          const previewState = createPresentationTemplateHtmlPreviewState({
-            draft: cachedDraft,
-            index: 0,
-            item,
-            previousFrameUrl: previousActiveFrameUrlForImmediateRevocation,
-            theme: previewTheme,
-          });
-          setHtmlPreview(previewState);
-        }
+        revokePresentationTemplateHtmlPreviewUrl(
+          previousActiveFrameUrlForImmediateRevocation,
+        );
+        setHtmlPreview(null);
       }}
     >
       <TemplatePreviewFrames


### PR DESCRIPTION
## Summary
Inject presentation theme CSS during preview generation to optimize document rendering.

- hide the card HTML iframe on mouseleave instead of rebuilding slide 0 synchronously
- add coverage for additional preview head styles and mouseleave not creating a new Blob URL

## Verification
- pnpm exec prettier --write apps/platform/src/views/zero-page/zero-chat-composer.tsx apps/platform/src/views/zero-page/presentation-html-edit-protocol.ts apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx apps/platform/src/views/zero-page/__tests__/presentation-html-edit-protocol.test.ts
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/presentation-html-edit-protocol.test.ts src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app lint

Note: did not start a local dev server per vm0 PR verification preference.