### PR TITLE
refactor: move cli firewall commands off eager registry

### DIFF
--- a/turbo/apps/cli/src/commands/zero/__tests__/firewall-import-boundary.test.ts
+++ b/turbo/apps/cli/src/commands/zero/__tests__/firewall-import-boundary.test.ts
@@ -1,0 +1,56 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, extname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const ZERO_COMMAND_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const IMPORT_SPECIFIER_PATTERN =
+  /\bfrom\s+["']([^"']+)["']|\bimport\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s+["']([^"']+)["']|\brequire\s*\(\s*["']([^"']+)["']\s*\)/g;
+
+function sourceFiles(dir: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    if (entry === "__tests__") continue;
+    const path = join(dir, entry);
+    const stats = statSync(path);
+    if (stats.isDirectory()) {
+      files.push(...sourceFiles(path));
+      continue;
+    }
+    if (stats.isFile() && extname(path) === ".ts") {
+      files.push(path);
+    }
+  }
+  return files;
+}
+
+function importSpecifiers(source: string): string[] {
+  return [...source.matchAll(IMPORT_SPECIFIER_PATTERN)].map((match) => {
+    return match[1] ?? match[2] ?? match[3] ?? match[4] ?? "";
+  });
+}
+
+function forbiddenFirewallImport(specifier: string): boolean {
+  if (specifier === "@vm0/connectors/firewalls") {
+    return true;
+  }
+  if (specifier === "@vm0/connectors/firewalls/runtime") {
+    return false;
+  }
+  return specifier.startsWith("@vm0/connectors/firewalls/");
+}
+
+describe("zero CLI firewall import boundary", () => {
+  it("keeps zero command sources off the default eager firewall registry", () => {
+    const violations = sourceFiles(ZERO_COMMAND_DIR).flatMap((file) => {
+      return importSpecifiers(readFileSync(file, "utf8"))
+        .filter(forbiddenFirewallImport)
+        .map((specifier) => {
+          return `${relative(ZERO_COMMAND_DIR, file)} -> ${specifier}`;
+        });
+    });
+
+    expect(violations).toStrictEqual([]);
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/__tests__/whoami.test.ts
+++ b/turbo/apps/cli/src/commands/zero/__tests__/whoami.test.ts
@@ -519,7 +519,7 @@ describe("zero whoami command", () => {
         }),
         mockUserPermissionGrantsHandler([
           makePermissionGrant({
-            permission: "conversations:read",
+            permission: "admin.conversations:read",
             action: "allow",
           }),
           makePermissionGrant({

--- a/turbo/apps/cli/src/commands/zero/agent/view.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/view.ts
@@ -8,73 +8,14 @@ import {
   listZeroConnectors,
 } from "../../../lib/api";
 import { withErrorHandler } from "../../../lib/command";
-import {
-  isFirewallConnectorType,
-  getConnectorFirewall,
-  permissionGrantsToFirewallPolicies,
-  resolveFirewallPolicies,
-} from "@vm0/connectors/firewalls";
-import type {
-  FirewallPolicies,
-  FirewallPolicyValue,
-} from "@vm0/connectors/firewall-types";
+import { permissionGrantsToFirewallPolicies } from "@vm0/connectors/firewall-metadata";
 import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
 import { policyIcon } from "../../../lib/utils/format-utils";
 import { formatAvatar } from "./avatar";
-
-interface ConnectorPermissionInfo {
-  type: string;
-  hasPermissions: boolean;
-  permissions: Array<{ name: string; description?: string }>;
-  policies: Record<string, FirewallPolicyValue> | null;
-  unknownPolicy: FirewallPolicyValue;
-  allowed: number;
-  total: number;
-}
-
-function getConnectorPermissionInfo(
-  type: string,
-  resolvedPolicies: FirewallPolicies | null,
-): ConnectorPermissionInfo {
-  if (!isFirewallConnectorType(type)) {
-    return {
-      type,
-      hasPermissions: false,
-      permissions: [],
-      policies: null,
-      unknownPolicy: "allow",
-      allowed: 0,
-      total: 0,
-    };
-  }
-
-  const refPolicy = resolvedPolicies?.[type];
-  const policies =
-    refPolicy && Object.keys(refPolicy.policies).length > 0
-      ? refPolicy.policies
-      : null;
-  const config = getConnectorFirewall(type);
-  const permissions = config.apis.flatMap((a) => {
-    return a.permissions ?? [];
-  });
-  const total = permissions.length;
-  const allowed = policies
-    ? permissions.filter((p) => {
-        return policies[p.name] === "allow";
-      }).length
-    : 0;
-
-  const unknownPolicy = refPolicy?.unknownPolicy ?? "allow";
-  return {
-    type,
-    hasPermissions: true,
-    permissions,
-    policies,
-    unknownPolicy,
-    allowed,
-    total,
-  };
-}
+import {
+  loadConnectorPermissionInfos,
+  type ConnectorPermissionInfo,
+} from "../shared/firewall-permissions";
 
 function printDetailedPermissions(info: ConnectorPermissionInfo): void {
   if (!info.policies) {
@@ -183,18 +124,15 @@ Examples:
         console.log();
         console.log(`Agent ID:     ${agent.agentId}`);
 
-        const permissionPolicies = options.permissions
+        const storedPolicies = options.permissions
           ? permissionGrantsToFirewallPolicies(
               await listZeroUserPermissionGrants(agent.agentId),
             )
           : null;
-        const resolvedPolicies = resolveFirewallPolicies(
-          permissionPolicies,
-          connectorTypes,
-        );
-
-        const connectorInfos = connectorTypes.map((type) => {
-          return getConnectorPermissionInfo(type, resolvedPolicies);
+        const connectorInfos = await loadConnectorPermissionInfos({
+          displayTypes: connectorTypes,
+          defaultPolicyTypes: connectorTypes,
+          storedPolicies,
         });
 
         if (connectorInfos.length > 0) {

--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/permission-change.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/permission-change.test.ts
@@ -9,7 +9,7 @@ import { UNKNOWN_PERMISSION_GRANT } from "@vm0/connectors/firewall-types";
 import { permissionChangeCommand } from "../permission-change";
 
 describe("zero doctor permission-change command", () => {
-  const SLACK_READ_PERMISSION = "conversations:read";
+  const SLACK_READ_PERMISSION = "admin.conversations:read";
 
   const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
     throw new Error("process.exit called");
@@ -46,7 +46,9 @@ describe("zero doctor permission-change command", () => {
     expect(logCalls).toContain("[Manage Slack permissions]");
     expect(logCalls).toContain("/agents/agent-abc-123/permissions?");
     expect(logCalls).toContain("ref=slack");
-    expect(logCalls).toContain("permission=conversations%3Aread");
+    expect(logCalls).toContain(
+      `permission=${encodeURIComponent(SLACK_READ_PERMISSION)}`,
+    );
     expect(logCalls).toContain("action=allow");
     expect(logCalls).toContain("expiresIn=1h");
     expect(logCalls).toContain("Requested duration: 1h");

--- a/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
@@ -1,6 +1,5 @@
 import { Command, Option } from "commander";
 import {
-  CONNECTOR_TYPE_KEYS,
   CONNECTOR_TYPES,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
@@ -21,9 +20,10 @@ import {
   type NetworkPolicies,
 } from "@vm0/connectors/firewall-types";
 import {
-  getConnectorFirewall,
-  isFirewallConnectorType,
-} from "@vm0/connectors/firewalls";
+  loadConnectorFirewall,
+  loadConnectorFirewalls,
+  RUNTIME_FIREWALL_CONNECTOR_TYPES,
+} from "@vm0/connectors/firewalls/runtime";
 import type { RunContextResponse } from "@vm0/api-contracts/contracts/zero-runs";
 import { getApiUrl } from "../../../lib/api/config";
 import {
@@ -74,22 +74,35 @@ async function connectorTypeIsAvailable(type: string): Promise<boolean> {
   });
 }
 
+function hasPermissionRules(config: FirewallConfig): boolean {
+  return config.apis.some((api) => {
+    return (
+      api.permissions?.some((permission) => {
+        return permission.rules.length > 0;
+      }) ?? false
+    );
+  });
+}
+
 /**
  * Reverse-lookup a full URL to find which connector handles it.
  * Iterates all connector firewall configs and checks if the URL
  * starts with any registered base URL (scheme + host + optional path prefix).
  */
-function resolveConnectorFromUrl(url: string): UrlLookupResult | null {
-  const allTypes = CONNECTOR_TYPE_KEYS;
-
+async function resolveConnectorFromUrl(
+  url: string,
+): Promise<UrlLookupResult | null> {
   let bestMatch: {
     connectorType: string;
     match: FirewallBaseUrlMatch;
   } | null = null;
 
-  for (const type of allTypes) {
-    if (!isFirewallConnectorType(type)) continue;
-    const config = getConnectorFirewall(type);
+  const firewalls = await loadConnectorFirewalls(
+    RUNTIME_FIREWALL_CONNECTOR_TYPES,
+  );
+  for (const type of RUNTIME_FIREWALL_CONNECTOR_TYPES) {
+    const config = firewalls[type];
+    if (!config) continue;
     for (const api of config.apis) {
       const match = matchFirewallBaseUrl(url, api.base);
       if (match !== null) {
@@ -118,17 +131,15 @@ function resolveConnectorFromUrl(url: string): UrlLookupResult | null {
   };
 }
 
-function runContextFirewallPermissionConfig(
+async function runContextFirewallPermissionConfig(
   firewall: RunContextResponse["firewalls"][number],
-): FirewallConfig | null {
+): Promise<FirewallConfig | null> {
   if (!("apis" in firewall)) {
     if (!isConnectorType(firewall.name)) {
       return null;
     }
-    if (!isFirewallConnectorType(firewall.name)) {
-      return null;
-    }
-    const config = getConnectorFirewall(firewall.name);
+    const config = await loadConnectorFirewall(firewall.name);
+    if (!config) return null;
     return resolveFirewallBaseUrlVars(
       [{ name: config.name, apis: config.apis }],
       firewall.baseUrlVars,
@@ -146,10 +157,10 @@ function runContextFirewallPermissionConfig(
   };
 }
 
-function resolveConnectorFromRunContext(
+async function resolveConnectorFromRunContext(
   url: string,
   runContext: RunContextResponse,
-): UrlLookupResult | null {
+): Promise<UrlLookupResult | null> {
   let bestMatch: {
     connectorType: string;
     match: FirewallBaseUrlMatch;
@@ -158,8 +169,7 @@ function resolveConnectorFromRunContext(
 
   for (const firewall of runContext.firewalls) {
     if (!isConnectorType(firewall.name)) continue;
-    if (!isFirewallConnectorType(firewall.name)) continue;
-    const permissionConfig = runContextFirewallPermissionConfig(firewall);
+    const permissionConfig = await runContextFirewallPermissionConfig(firewall);
     if (!permissionConfig) continue;
     for (const api of permissionConfig.apis) {
       const match = matchFirewallBaseUrl(url, api.base);
@@ -187,7 +197,9 @@ function resolveConnectorFromRunContext(
     envName,
     matchedBase: bestMatch.match.displayBase,
     relativePath: bestMatch.match.relativePath,
-    permissionConfig: bestMatch.permissionConfig,
+    ...(hasPermissionRules(bestMatch.permissionConfig)
+      ? { permissionConfig: bestMatch.permissionConfig }
+      : {}),
   };
 }
 
@@ -333,15 +345,15 @@ async function checkConnectorDomains(
     return null;
   }
 
-  printConnectorDomains(ctx, runContext);
+  await printConnectorDomains(ctx, runContext);
   console.log("");
   return runContext.networkPolicies;
 }
 
-function printConnectorDomains(
+async function printConnectorDomains(
   ctx: DiagContext,
   runContext: RunContextResponse,
-): void {
+): Promise<void> {
   const matchingEntry = runContext.firewalls.find((fw) => {
     return fw.name === ctx.connectorType;
   });
@@ -355,7 +367,8 @@ function printConnectorDomains(
     );
     return;
   }
-  const permissionConfig = runContextFirewallPermissionConfig(matchingEntry);
+  const permissionConfig =
+    await runContextFirewallPermissionConfig(matchingEntry);
   if (!permissionConfig) {
     console.log(
       `No configuration found for the ${ctx.label} connector in this run.`,
@@ -377,8 +390,8 @@ function printConnectorDomains(
     "When the sandbox sends an HTTP request matching one of these URL prefixes, the network boundary intercepts the request and injects real credentials into the auth headers.",
   );
 
-  if (isFirewallConnectorType(ctx.connectorType)) {
-    const firewallConfig = getConnectorFirewall(ctx.connectorType);
+  const firewallConfig = await loadConnectorFirewall(ctx.connectorType);
+  if (firewallConfig) {
     const secretNames = extractSecretNamesFromApis(firewallConfig.apis);
     if (secretNames.length > 0) {
       console.log(`Credentials resolved from: ${secretNames.join(", ")}`);
@@ -456,7 +469,7 @@ function unknownPermissionChangeCommand(connectorRef: string): string {
  * When --url is provided, auto-detect the matching permission by running
  * the URL's relative path against the connector's firewall rules.
  */
-function resolvePermissionFromUrl(
+async function resolvePermissionFromUrl(
   connectorType: string,
   label: string,
   method: string,
@@ -464,7 +477,7 @@ function resolvePermissionFromUrl(
   matchedBase: string,
   permissionConfig: FirewallConfig | undefined,
   networkPolicies: NetworkPolicies | null,
-): void {
+): Promise<void> {
   console.log("## Step 3: Permission policy check (auto-detected from URL)");
   console.log("");
   console.log(
@@ -472,7 +485,9 @@ function resolvePermissionFromUrl(
   );
   console.log("");
 
-  if (!isFirewallConnectorType(connectorType)) {
+  const config =
+    permissionConfig ?? (await loadConnectorFirewall(connectorType));
+  if (!config) {
     console.log(
       `The ${label} connector does not have permission rules defined.`,
     );
@@ -480,7 +495,6 @@ function resolvePermissionFromUrl(
     return;
   }
 
-  const config = permissionConfig ?? getConnectorFirewall(connectorType);
   const matchedPermissions = findMatchingPermissions(
     method,
     relativePath,
@@ -608,12 +622,15 @@ How connectors work:
       let runContext: RunContextResponse | null | undefined;
 
       if (opts.url) {
-        urlLookup = resolveConnectorFromUrl(opts.url);
+        runContext = await getCurrentRunContext();
+        if (runContext) {
+          urlLookup = await resolveConnectorFromRunContext(
+            opts.url,
+            runContext,
+          );
+        }
         if (!urlLookup) {
-          runContext = await getCurrentRunContext();
-          if (runContext) {
-            urlLookup = resolveConnectorFromRunContext(opts.url, runContext);
-          }
+          urlLookup = await resolveConnectorFromUrl(opts.url);
         }
         if (!urlLookup) {
           throw new Error(
@@ -676,7 +693,7 @@ How connectors work:
       // Step 3: Permission policy check
       if (urlLookup) {
         // --url mode: auto-detect permission from URL path
-        resolvePermissionFromUrl(
+        await resolvePermissionFromUrl(
           connectorType,
           label,
           opts.method,

--- a/turbo/apps/cli/src/commands/zero/doctor/permission-change.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/permission-change.ts
@@ -1,10 +1,9 @@
 import { Command, Option } from "commander";
 import type { UserPermissionGrantExpiresIn } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
-import { CONNECTOR_TYPES } from "@vm0/connectors/connectors";
 import {
-  getConnectorFirewall,
-  isFirewallConnectorType,
-} from "@vm0/connectors/firewalls";
+  findFirewallMetadataPermission,
+  loadFirewallPermissionMetadata,
+} from "@vm0/connectors/firewall-metadata";
 import { UNKNOWN_PERMISSION_GRANT } from "@vm0/connectors/firewall-types";
 import { withErrorHandler } from "../../../lib/command";
 import { getPlatformOrigin } from "./platform-url";
@@ -20,19 +19,6 @@ const PERMISSION_GRANT_DURATIONS = [
   "7d",
   "always",
 ] as const satisfies readonly UserPermissionGrantExpiresIn[];
-
-function findPermissionInConfig(ref: string, permissionName: string): boolean {
-  if (!isFirewallConnectorType(ref)) return false;
-  if (permissionName === UNKNOWN_PERMISSION_GRANT) return true;
-  const config = getConnectorFirewall(ref);
-  for (const api of config.apis) {
-    if (!api.permissions) continue;
-    for (const p of api.permissions) {
-      if (p.name === permissionName) return true;
-    }
-  }
-  return false;
-}
 
 type PermissionAction = "enable" | "disable";
 
@@ -103,13 +89,11 @@ function printPermissionActionMessage(args: {
 
 async function outputPermissionChangeMessage(
   connectorRef: string,
+  label: string,
   permission: string,
   action: PermissionAction,
   duration: UserPermissionGrantExpiresIn | undefined,
 ): Promise<void> {
-  const { label } =
-    CONNECTOR_TYPES[connectorRef as keyof typeof CONNECTOR_TYPES];
-
   const platformOrigin = await getPlatformOrigin();
   const agentId = process.env.ZERO_AGENT_ID;
 
@@ -215,11 +199,15 @@ Notes:
           return;
         }
 
-        if (!isFirewallConnectorType(connectorRef)) {
+        const metadata = await loadFirewallPermissionMetadata(connectorRef);
+        if (!metadata) {
           throw new Error(`Unknown connector type: ${connectorRef}`);
         }
 
-        if (!findPermissionInConfig(connectorRef, opts.permission)) {
+        if (
+          opts.permission !== UNKNOWN_PERMISSION_GRANT &&
+          !findFirewallMetadataPermission(metadata, opts.permission)
+        ) {
           throw new Error(
             `Unknown permission "${opts.permission}" for ${connectorRef}`,
           );
@@ -228,6 +216,7 @@ Notes:
         const action = opts.enable ? "enable" : "disable";
         await outputPermissionChangeMessage(
           connectorRef,
+          metadata.label,
           opts.permission,
           action,
           opts.duration,

--- a/turbo/apps/cli/src/commands/zero/doctor/permission-deny.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/permission-deny.ts
@@ -1,10 +1,7 @@
 import { Command, Option } from "commander";
-import { CONNECTOR_TYPES } from "@vm0/connectors/connectors";
 import { findMatchingPermissions } from "@vm0/connectors/firewall-rule-matcher";
-import {
-  getConnectorFirewall,
-  isFirewallConnectorType,
-} from "@vm0/connectors/firewalls";
+import { getFirewallPermissionSummary } from "@vm0/connectors/firewall-metadata";
+import { loadConnectorFirewall } from "@vm0/connectors/firewalls/runtime";
 import { UNKNOWN_PERMISSION_GRANT } from "@vm0/connectors/firewall-types";
 import { withErrorHandler } from "../../../lib/command";
 import {
@@ -52,12 +49,13 @@ Notes:
           return;
         }
 
-        if (!isFirewallConnectorType(connectorRef)) {
+        const config = await loadConnectorFirewall(connectorRef);
+        if (!config) {
           throw new Error(`Unknown connector type: ${connectorRef}`);
         }
 
-        const { label } = CONNECTOR_TYPES[connectorRef];
-        const config = getConnectorFirewall(connectorRef);
+        const label =
+          getFirewallPermissionSummary(connectorRef)?.label ?? connectorRef;
         const permissions = findMatchingPermissions(
           opts.method,
           opts.path,

--- a/turbo/apps/cli/src/commands/zero/shared/firewall-permissions.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/firewall-permissions.ts
@@ -1,0 +1,106 @@
+import {
+  loadFirewallPermissionMetadata,
+  resolveFirewallMetadataPolicies,
+  type FirewallPermissionDetailMetadata,
+} from "@vm0/connectors/firewall-metadata";
+import type {
+  FirewallPolicies,
+  FirewallPolicyValue,
+} from "@vm0/connectors/firewall-types";
+
+export interface ConnectorPermissionInfo {
+  readonly type: string;
+  readonly hasPermissions: boolean;
+  readonly hasPolicyEntry: boolean;
+  readonly permissions: readonly FirewallPermissionDetailMetadata["permissions"][number][];
+  readonly policies: Readonly<Record<string, FirewallPolicyValue>> | null;
+  readonly unknownPolicy: FirewallPolicyValue;
+  readonly allowed: number;
+  readonly total: number;
+}
+
+type PermissionMetadataByType = Map<
+  string,
+  FirewallPermissionDetailMetadata | null
+>;
+
+async function loadPermissionMetadataByType(
+  types: readonly string[],
+): Promise<PermissionMetadataByType> {
+  const uniqueTypes = [...new Set(types)];
+  const entries = await Promise.all(
+    uniqueTypes.map(async (type) => {
+      return [type, await loadFirewallPermissionMetadata(type)] as const;
+    }),
+  );
+  return new Map(entries);
+}
+
+function connectorPermissionInfo(args: {
+  readonly type: string;
+  readonly metadata: FirewallPermissionDetailMetadata | null;
+  readonly resolvedPolicies: FirewallPolicies | null;
+}): ConnectorPermissionInfo {
+  if (!args.metadata) {
+    return {
+      type: args.type,
+      hasPermissions: false,
+      hasPolicyEntry: false,
+      permissions: [],
+      policies: null,
+      unknownPolicy: "allow",
+      allowed: 0,
+      total: 0,
+    };
+  }
+
+  const refPolicy = args.resolvedPolicies?.[args.metadata.type];
+  const policies =
+    refPolicy && Object.keys(refPolicy.policies).length > 0
+      ? refPolicy.policies
+      : null;
+  const total = args.metadata.permissions.length;
+  const allowed = policies
+    ? args.metadata.permissions.filter((permission) => {
+        return policies[permission.name] === "allow";
+      }).length
+    : 0;
+
+  return {
+    type: args.type,
+    hasPermissions: true,
+    hasPolicyEntry: refPolicy !== undefined,
+    permissions: args.metadata.permissions,
+    policies,
+    unknownPolicy: refPolicy?.unknownPolicy ?? "allow",
+    allowed,
+    total,
+  };
+}
+
+export async function loadConnectorPermissionInfos(args: {
+  readonly displayTypes: readonly string[];
+  readonly defaultPolicyTypes: readonly string[];
+  readonly storedPolicies: FirewallPolicies | null;
+}): Promise<ConnectorPermissionInfo[]> {
+  const metadataByType = await loadPermissionMetadataByType([
+    ...args.displayTypes,
+    ...args.defaultPolicyTypes,
+  ]);
+  const defaultPolicyMetadata = args.defaultPolicyTypes.flatMap((type) => {
+    const metadata = metadataByType.get(type);
+    return metadata ? [metadata] : [];
+  });
+  const resolvedPolicies = resolveFirewallMetadataPolicies(
+    args.storedPolicies,
+    defaultPolicyMetadata,
+  );
+
+  return args.displayTypes.map((type) => {
+    return connectorPermissionInfo({
+      type,
+      metadata: metadataByType.get(type) ?? null,
+      resolvedPolicies,
+    });
+  });
+}

--- a/turbo/apps/cli/src/commands/zero/whoami.ts
+++ b/turbo/apps/cli/src/commands/zero/whoami.ts
@@ -12,14 +12,12 @@ import {
   listZeroUserPermissionGrants,
 } from "../../lib/api";
 import { withErrorHandler } from "../../lib/command";
-import {
-  isFirewallConnectorType,
-  getConnectorFirewall,
-  permissionGrantsToFirewallPolicies,
-  resolveFirewallPolicies,
-} from "@vm0/connectors/firewalls";
-import type { FirewallPolicies } from "@vm0/connectors/firewall-types";
+import { permissionGrantsToFirewallPolicies } from "@vm0/connectors/firewall-metadata";
 import { policyIcon } from "../../lib/utils/format-utils";
+import {
+  loadConnectorPermissionInfos,
+  type ConnectorPermissionInfo,
+} from "./shared/firewall-permissions";
 
 /**
  * Detect if running inside a zero sandbox (agent runtime).
@@ -49,47 +47,38 @@ function formatConnectorIdentity(connector: {
   return identity;
 }
 
-function printConnectorPermissions(
-  type: string,
-  resolvedPolicies: FirewallPolicies | null,
-): void {
-  if (!isFirewallConnectorType(type)) return;
+function printConnectorPermissions(info: ConnectorPermissionInfo): void {
+  if (!info.hasPermissions) return;
 
-  const refPolicy = resolvedPolicies?.[type];
-  if (!refPolicy) {
+  if (!info.hasPolicyEntry) {
     console.log(chalk.dim("    full access — no permission rules configured"));
     return;
   }
 
-  const config = getConnectorFirewall(type);
-  const permissions = config.apis.flatMap((a) => {
-    return a.permissions ?? [];
-  });
-
   if (
-    permissions.length === 0 &&
-    Object.keys(refPolicy.policies).length === 0
+    info.permissions.length === 0 &&
+    (!info.policies || Object.keys(info.policies).length === 0)
   ) {
-    const unknownIcon = policyIcon(refPolicy.unknownPolicy ?? "allow");
+    const unknownIcon = policyIcon(info.unknownPolicy);
     console.log(`    ${unknownIcon} unknown endpoints`);
     return;
   }
 
   const nameWidth = Math.max(
     "unknown endpoints".length,
-    ...permissions.map((p) => {
+    ...info.permissions.map((p) => {
       return p.name.length;
     }),
   );
 
-  for (const perm of permissions) {
-    const policy = refPolicy.policies[perm.name] ?? "deny";
+  for (const perm of info.permissions) {
+    const policy = info.policies?.[perm.name] ?? "deny";
     const icon = policyIcon(policy);
     const desc = perm.description ?? "";
     console.log(`    ${icon} ${perm.name.padEnd(nameWidth)}  ${desc}`);
   }
 
-  const unknownIcon = policyIcon(refPolicy.unknownPolicy ?? "allow");
+  const unknownIcon = policyIcon(info.unknownPolicy);
   console.log(
     `    ${unknownIcon} ${"unknown endpoints".padEnd(nameWidth)}  Endpoints not matching any rule`,
   );
@@ -129,14 +118,24 @@ async function showSandboxInfo(showPermissions: boolean): Promise<void> {
 
       if (identities.length === 0) return;
 
-      let resolvedPolicies: FirewallPolicies | null = null;
+      let permissionInfoByType = new Map<string, ConnectorPermissionInfo>();
       const permissionDataAvailable =
         grantsResult.status === "fulfilled" &&
         enabledResult.status === "fulfilled";
       if (permissionDataAvailable) {
-        resolvedPolicies = resolveFirewallPolicies(
-          permissionGrantsToFirewallPolicies(grantsResult.value),
-          enabledResult.value,
+        const permissionInfos = await loadConnectorPermissionInfos({
+          displayTypes: identities.map((connector) => {
+            return connector.type;
+          }),
+          defaultPolicyTypes: enabledResult.value,
+          storedPolicies: permissionGrantsToFirewallPolicies(
+            grantsResult.value,
+          ),
+        });
+        permissionInfoByType = new Map(
+          permissionInfos.map((info) => {
+            return [info.type, info];
+          }),
         );
       }
 
@@ -147,7 +146,10 @@ async function showSandboxInfo(showPermissions: boolean): Promise<void> {
         console.log(`  ${connector.type.padEnd(14)}${identity}`);
 
         if (permissionDataAvailable) {
-          printConnectorPermissions(connector.type, resolvedPolicies);
+          const info = permissionInfoByType.get(connector.type);
+          if (info) {
+            printConnectorPermissions(info);
+          }
         }
       }
     } else {


### PR DESCRIPTION
## Summary
- move CLI permission display flows to generated firewall metadata instead of the eager runtime firewall registry
- switch doctor runtime matching commands to explicit lazy firewall runtime loading
- add a zero CLI import-boundary test to prevent reintroducing the default eager registry import

Closes #18657

## Tests
- pnpm -F @vm0/cli exec vitest run src/commands/zero/__tests__/whoami.test.ts src/commands/zero/agent/__tests__/view.test.ts src/commands/zero/doctor/__tests__/permission-change.test.ts src/commands/zero/doctor/__tests__/permission-deny.test.ts src/commands/zero/doctor/__tests__/check-connector.test.ts src/commands/zero/__tests__/firewall-import-boundary.test.ts
- pnpm -F @vm0/cli check-types
- pnpm -F @vm0/cli lint
- pnpm -F @vm0/cli build
- pnpm format
- pnpm knip
- pre-commit hook: pnpm check-types