### PR TITLE
refactor: restrict eager firewall registry exports

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -10,7 +10,7 @@ import {
   type ExecutionFirewallEntry,
   type FirewallApi,
 } from "@vm0/connectors/firewall-types";
-import { getConnectorFirewall } from "@vm0/connectors/firewalls";
+import { getAllConnectorFirewalls } from "@vm0/connectors/firewalls/all";
 import { HttpResponse, http } from "msw";
 import { describe, expect, it } from "vitest";
 
@@ -50,6 +50,8 @@ const context = testContext();
 // value the chat composer sends when picking a model instead of a provider).
 const MODEL_FIRST_SELECTION_PROVIDER_ID =
   "00000000-0000-4000-8000-000000000000";
+const connectorFirewalls = getAllConnectorFirewalls();
+type ConnectorFirewallType = keyof typeof connectorFirewalls;
 
 function modelProviderPlaceholder(
   type: ModelProviderType,
@@ -64,10 +66,10 @@ function modelProviderPlaceholder(
 }
 
 function connectorPlaceholder(
-  type: Parameters<typeof getConnectorFirewall>[0],
+  type: ConnectorFirewallType,
   secretName: string,
 ): string {
-  const placeholder = getConnectorFirewall(type)?.placeholders?.[secretName];
+  const placeholder = connectorFirewalls[type].placeholders?.[secretName];
   if (!placeholder) {
     throw new Error(`Missing connector placeholder for ${secretName}`);
   }

--- a/turbo/apps/api/src/signals/services/__tests__/firewall-metadata-import-boundary.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/firewall-metadata-import-boundary.test.ts
@@ -54,6 +54,7 @@ describe("firewall metadata import boundary", () => {
       `import { getAllConnectorFirewalls } from "@vm0/connectors/firewalls/all";`,
       `export { getConnectorFirewall } from "@vm0/connectors/firewalls";`,
       `await import("@vm0/connectors/firewalls/github.generated");`,
+      `await import("@vm0/connectors/firewalls/index");`,
       `import "@vm0/connectors/firewalls";`,
       `require("@vm0/connectors/firewalls/github.generated");`,
     ]) {

--- a/turbo/packages/connectors/package.json
+++ b/turbo/packages/connectors/package.json
@@ -48,10 +48,7 @@
       "import": "./src/firewall-metadata/server.ts",
       "types": "./src/firewall-metadata/server.ts"
     },
-    "./firewalls": {
-      "import": "./src/firewalls/index.ts",
-      "types": "./src/firewalls/index.ts"
-    },
+    "./firewalls": null,
     "./firewalls/all": {
       "import": "./src/firewall-runtime-all.ts",
       "types": "./src/firewall-runtime-all.ts"
@@ -64,10 +61,7 @@
       "import": "./src/firewall-selection-resolver.ts",
       "types": "./src/firewall-selection-resolver.ts"
     },
-    "./firewalls/*": {
-      "import": "./src/firewalls/*.ts",
-      "types": "./src/firewalls/*.ts"
-    },
+    "./firewalls/*": null,
     "./auth-providers": {
       "import": "./src/auth-providers/connector-auth.ts",
       "types": "./src/auth-providers/connector-auth.ts"

--- a/turbo/packages/connectors/src/__tests__/firewall-runtime-loader.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-runtime-loader.test.ts
@@ -332,10 +332,12 @@ describe("firewall runtime loader", () => {
       "utf-8",
     );
 
+    expect(packageJson.exports["./firewalls"]).toBeNull();
     expect(packageJson.exports["./firewalls/all"]).toStrictEqual({
       import: "./src/firewall-runtime-all.ts",
       types: "./src/firewall-runtime-all.ts",
     });
+    expect(packageJson.exports["./firewalls/*"]).toBeNull();
     expect(defaultFirewallEntrypoint).not.toHaveProperty(
       "getAllConnectorFirewalls",
     );


### PR DESCRIPTION
## Summary

- deny the ambiguous `@vm0/connectors/firewalls` and wildcard `@vm0/connectors/firewalls/*` public package exports
- keep explicit firewall subpaths for all-catalog, lazy runtime, and selection resolver access
- move the remaining API BDD fixture import to `@vm0/connectors/firewalls/all`
- strengthen boundary coverage for denied package subpaths and the `firewalls/index` bypass form

Closes #18659

## Tests

- `pnpm -F @vm0/connectors exec vitest src/__tests__/firewall-runtime-loader.test.ts`
- `pnpm -F @vm0/connectors exec vitest src/__tests__/firewall-selection-resolver.test.ts`
- `pnpm -F @vm0/connectors exec vitest src/__tests__/firewall-metadata.test.ts`
- `pnpm -F api exec vitest src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `pnpm -F api exec vitest src/signals/services/__tests__/firewall-metadata-import-boundary.test.ts`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api check-types`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F api lint`
- pre-commit: `knip --cache`
- pre-commit: `turbo run check-types --concurrency=1`

Note: the first local metadata/API BDD run exposed stale untracked generated Slack firewall artifacts missing `conversations:read`; refreshing local generated artifacts with `pnpm -F @vm0/firewalls-generator generate:slack && pnpm -F @vm0/firewalls-generator generate:metadata` fixed local verification without adding generated files to the commit.