### PR TITLE
fix: fix first slide presentation hover preview

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -1856,16 +1856,9 @@ describe("chat composer templates", () => {
       fireEvent.mouseEnter(preview);
       await waitFor(() => {
         expect(
-          screen.getByTestId(`${template.title} card HTML preview`),
-        ).toHaveAttribute("src", expect.stringMatching(/^blob:/));
+          screen.queryByTestId(`${template.title} card HTML preview`),
+        ).not.toBeInTheDocument();
       });
-      expect(currentPreviewFrame()).toHaveAttribute("tabindex", "-1");
-      const firstPreviewHtml = await htmlForFrame(currentPreviewFrame());
-      expect(firstPreviewHtml).toContain("Slide one");
-      expect(firstPreviewHtml).toContain("--accent:#FF7A1A");
-      expect(firstPreviewHtml).toContain("--s2:#F5B73E");
-      expect(firstPreviewHtml).not.toContain("--fd:");
-      expect(firstPreviewHtml).not.toContain("--fb:");
 
       fireEvent.mouseEnter(preview);
       fireEvent.mouseMove(preview, { clientX: 300, clientY: 80 });
@@ -1875,6 +1868,12 @@ describe("chat composer templates", () => {
           "Slide two",
         );
       });
+      expect(currentPreviewFrame()).toHaveAttribute("tabindex", "-1");
+      const secondPreviewHtml = await htmlForFrame(currentPreviewFrame());
+      expect(secondPreviewHtml).toContain("--accent:#FF7A1A");
+      expect(secondPreviewHtml).toContain("--s2:#F5B73E");
+      expect(secondPreviewHtml).not.toContain("--fd:");
+      expect(secondPreviewHtml).not.toContain("--fb:");
       const createObjectUrlCountBeforeLeave = createObjectURL.mock.calls.length;
       fireEvent.mouseLeave(preview);
       await waitFor(() => {
@@ -1910,6 +1909,12 @@ describe("chat composer templates", () => {
       });
 
       fireEvent.mouseEnter(prismPreview);
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId(`${prismTemplate.title} card HTML preview`),
+        ).not.toBeInTheDocument();
+      });
+      fireEvent.mouseMove(prismPreview, { clientX: 300, clientY: 80 });
       await waitFor(() => {
         expect(
           screen.getByTestId(`${prismTemplate.title} card HTML preview`),
@@ -2259,8 +2264,8 @@ describe("chat composer templates", () => {
     fireEvent.mouseEnter(preview);
     await waitFor(() => {
       expect(
-        screen.getByTestId(`${template.title} card HTML preview`),
-      ).toHaveAttribute("src", expect.stringMatching(/^blob:/));
+        screen.queryByTestId(`${template.title} card HTML preview`),
+      ).not.toBeInTheDocument();
     });
     fireEvent.mouseMove(preview, { clientX: 300, clientY: 80 });
     const animationFrame = createDeferredPromise<void>(AbortSignal.any([]));

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -2417,6 +2417,20 @@ function createPresentationTemplateHtmlPreviewState(params: {
   };
 }
 
+function createPresentationTemplateCardHtmlPreviewState(params: {
+  readonly draft: PresentationEditDraft;
+  readonly index: number;
+  readonly item: PresentationTemplateItem;
+  readonly previousFrameUrl: string | null;
+  readonly theme: PresentationTemplateThemeOption;
+}): TemplateCardHtmlPreviewState | null {
+  if (params.index === 0) {
+    revokePresentationTemplateHtmlPreviewUrl(params.previousFrameUrl);
+    return null;
+  }
+  return createPresentationTemplateHtmlPreviewState(params);
+}
+
 function presentationTemplateCardFrameUrls(params: {
   readonly currentFrameUrl: string | null;
   readonly loadedFrameUrl: string | null;
@@ -2596,16 +2610,10 @@ function TemplatePreview({
       ? htmlPreview
       : null;
   const loadedHtmlFrameKey = `card:${item.embedUrl}:${previewTheme.id}:loaded`;
-  const currentFrameUrl = activeHtmlPreview?.frameUrl ?? null;
   const loadedFrameUrl = loadedHtmlFrameUrls[loadedHtmlFrameKey] ?? null;
   const previousActiveFrameUrlForImmediateRevocation =
     presentationTemplateCardActiveFrameUrlForImmediateRevocation({
       activeFrameUrl: activeHtmlPreview?.frameUrl ?? null,
-      loadedFrameUrl,
-    });
-  const { overlayFrameUrl, primaryFrameUrl } =
-    presentationTemplateCardFrameUrls({
-      currentFrameUrl,
       loadedFrameUrl,
     });
   const scrubSlideCount = activeHtmlPreview?.slideCount ?? fallbackSlideCount;
@@ -2617,6 +2625,15 @@ function TemplatePreview({
       hoverSlideIndex;
     return Math.max(0, Math.min(index, scrubSlideCount - 1));
   };
+  const currentFrameUrl =
+    currentPreviewSlideIndex() === 0
+      ? null
+      : (activeHtmlPreview?.frameUrl ?? null);
+  const { overlayFrameUrl, primaryFrameUrl } =
+    presentationTemplateCardFrameUrls({
+      currentFrameUrl,
+      loadedFrameUrl,
+    });
   const openPreview = () => {
     onPreview(item, currentPreviewSlideIndex());
   };
@@ -2633,7 +2650,7 @@ function TemplatePreview({
     const activeIndex = cache.activeIndexes.get(item.embedUrl) ?? 0;
     const cachedDraft = cache.drafts.get(item.embedUrl);
     if (cachedDraft !== undefined) {
-      const previewState = createPresentationTemplateHtmlPreviewState({
+      const previewState = createPresentationTemplateCardHtmlPreviewState({
         draft: cachedDraft,
         index: activeIndex,
         item,
@@ -2700,7 +2717,7 @@ function TemplatePreview({
         cache.drafts.set(item.embedUrl, result.value);
         if (cache.activeTokens.get(item.embedUrl) === activeToken) {
           setHtmlPreview(
-            createPresentationTemplateHtmlPreviewState({
+            createPresentationTemplateCardHtmlPreviewState({
               draft: result.value,
               index: cache.activeIndexes.get(item.embedUrl) ?? 0,
               item,
@@ -2721,7 +2738,7 @@ function TemplatePreview({
     setHover({ slug: item.slug, index });
     if (cachedDraft !== undefined) {
       setHtmlPreview(
-        createPresentationTemplateHtmlPreviewState({
+        createPresentationTemplateCardHtmlPreviewState({
           draft: cachedDraft,
           index,
           item,


### PR DESCRIPTION
## Summary
- keep the first presentation template card slide on the static preview image in the picker
- render HTML iframe previews only after hovering/scrubbing to later slides
- update composer template tests for the first-slide preview behavior

## Why
The themed iframe card preview and the static first slide image can diverge, which made the picker feel mismatched when hovering back to slide 1. Showing the static image for slide 1 keeps the card aligned with the expected first preview.

## Validation
- pnpm format
- pnpm lint
- pnpm check-types
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
- pnpm knip

## Notes
- Full `pnpm test` was attempted, but local environment setup is missing a usable PostgreSQL (`ECONNREFUSED :5432` / invalid `DATABASE_URL`) and web tests also reported unavailable `localStorage` under this root Vitest invocation. `scripts/prepare.sh` was run and confirmed the DB setup blocker.