### PR TITLE
fix: deduplicate clerk firewall route permissions

### DIFF
--- a/crates/runner/mitm-addon/src/generated/builtin_firewalls/clerk_0.py
+++ b/crates/runner/mitm-addon/src/generated/builtin_firewalls/clerk_0.py
@@ -382,9 +382,7 @@ JSON_PART = r"""{
           "name": "organizations:read",
           "rules": [
             "GET /v1/organizations",
-            "GET /v1/organizations/{organization_id}",
-            "GET /v1/organizations/{organization_id}/billing/credits",
-            "GET /v1/organizations/{organization_id}/billing/subscription"
+            "GET /v1/organizations/{organization_id}"
           ]
         },
         {
@@ -393,7 +391,6 @@ JSON_PART = r"""{
             "POST /v1/organizations",
             "PATCH /v1/organizations/{organization_id}",
             "DELETE /v1/organizations/{organization_id}",
-            "POST /v1/organizations/{organization_id}/billing/credits",
             "PUT /v1/organizations/{organization_id}/logo",
             "DELETE /v1/organizations/{organization_id}/logo",
             "PUT /v1/organizations/{organization_id}/metadata",
@@ -517,8 +514,6 @@ JSON_PART = r"""{
             "GET /v1/users",
             "GET /v1/users/count",
             "GET /v1/users/{user_id}",
-            "GET /v1/users/{user_id}/billing/credits",
-            "GET /v1/users/{user_id}/billing/subscription",
             "GET /v1/users/{user_id}/oauth_access_tokens/{provider}",
             "GET /v1/users/{user_id}/organization_invitations",
             "GET /v1/users/{user_id}/organization_memberships"
@@ -534,7 +529,6 @@ JSON_PART = r"""{
             "DELETE /v1/users/{user_id}",
             "DELETE /v1/users/{user_id}/backup_code",
             "POST /v1/users/{user_id}/ban",
-            "POST /v1/users/{user_id}/billing/credits",
             "DELETE /v1/users/{user_id}/external_accounts/{external_account_id}",
             "POST /v1/users/{user_id}/lock",
             "PUT /v1/users/{user_id}/metadata",

--- a/turbo/packages/connectors/src/__tests__/firewalls/clerk.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewalls/clerk.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+
+import { findMatchingPermissions } from "../../firewall-rule-matcher";
+import {
+  getConnectorFirewall,
+  getDefaultFirewallPolicies,
+} from "../../firewalls";
+
+const RUNTIME_METHODS = [
+  "GET",
+  "POST",
+  "PUT",
+  "PATCH",
+  "DELETE",
+  "HEAD",
+  "OPTIONS",
+] as const;
+
+function clerkMatches(method: string, path: string): string[] {
+  return findMatchingPermissions(method, path, getConnectorFirewall("clerk"));
+}
+
+function expectClerkMatches(
+  method: string,
+  path: string,
+  permissionNames: readonly string[],
+): void {
+  expect([...clerkMatches(method, path)].sort()).toStrictEqual(
+    [...permissionNames].sort(),
+  );
+}
+
+function expandRuntimeRules(rule: string): string[] {
+  const spaceIndex = rule.indexOf(" ");
+  const method = rule.slice(0, spaceIndex);
+  const path = rule.slice(spaceIndex + 1);
+  if (method !== "ANY") return [rule];
+  return RUNTIME_METHODS.map((runtimeMethod) => {
+    return `${runtimeMethod} ${path}`;
+  });
+}
+
+describe("clerk firewall", () => {
+  it("assigns one permission owner to every runtime route", () => {
+    const duplicates: string[] = [];
+    for (const api of getConnectorFirewall("clerk").apis) {
+      const owners = new Map<string, string>();
+      for (const permission of api.permissions ?? []) {
+        for (const rule of permission.rules) {
+          for (const runtimeRule of expandRuntimeRules(rule)) {
+            const key = `${api.base} ${runtimeRule}`;
+            const existing = owners.get(key);
+            if (existing) {
+              duplicates.push(`${key}: ${existing}, ${permission.name}`);
+              continue;
+            }
+            owners.set(key, permission.name);
+          }
+        }
+      }
+    }
+
+    expect(duplicates).toStrictEqual([]);
+  });
+
+  it("maps nested user billing routes to billing permissions", () => {
+    expectClerkMatches("GET", "/v1/users/user_123/billing/credits", [
+      "billing:read",
+    ]);
+    expectClerkMatches("GET", "/v1/users/user_123/billing/subscription", [
+      "billing:read",
+    ]);
+    expectClerkMatches("POST", "/v1/users/user_123/billing/credits", [
+      "billing:write",
+    ]);
+  });
+
+  it("maps nested organization billing routes to billing permissions", () => {
+    expectClerkMatches("GET", "/v1/organizations/org_123/billing/credits", [
+      "billing:read",
+    ]);
+    expectClerkMatches(
+      "GET",
+      "/v1/organizations/org_123/billing/subscription",
+      ["billing:read"],
+    );
+    expectClerkMatches("POST", "/v1/organizations/org_123/billing/credits", [
+      "billing:write",
+    ]);
+  });
+
+  it("keeps billing writes default denied as admin operations", () => {
+    const policies = getDefaultFirewallPolicies("clerk").policies;
+
+    expect(policies["billing:read"]).toBe("allow");
+    expect(policies["billing:write"]).toBe("deny");
+    expect(policies["users:write"]).toBe("deny");
+    expect(policies["organizations:write"]).toBe("deny");
+  });
+});

--- a/turbo/packages/firewalls-generator/src/clerk.ts
+++ b/turbo/packages/firewalls-generator/src/clerk.ts
@@ -45,6 +45,11 @@ interface ClerkOperation {
   tags?: string[];
 }
 
+interface ClerkOwnerOverride {
+  readonly tags: readonly string[];
+  readonly permission: string;
+}
+
 interface ClerkSpec extends OpenApiSpec {
   servers?: Array<{ url: string }>;
 }
@@ -78,9 +83,200 @@ function slugifyTag(tag: string): string {
 // ── Grouping ─────────────────────────────────────────────────────────────
 
 const READ_METHODS = new Set(["get", "head"]);
+const RUNTIME_METHODS = [
+  "GET",
+  "POST",
+  "PUT",
+  "PATCH",
+  "DELETE",
+  "HEAD",
+  "OPTIONS",
+] as const;
+
+// Clerk tags nested billing operations as both Users/Organizations and Billing.
+// Keep these billing-specific routes under Billing while validating the
+// official tag set still matches the override.
+const OWNER_OVERRIDES = new Map<string, ClerkOwnerOverride>([
+  [
+    "GET /organizations/{organization_id}/billing/credits",
+    {
+      tags: ["Organizations", "Billing"],
+      permission: "billing:read",
+    },
+  ],
+  [
+    "GET /organizations/{organization_id}/billing/subscription",
+    {
+      tags: ["Organizations", "Billing"],
+      permission: "billing:read",
+    },
+  ],
+  [
+    "GET /users/{user_id}/billing/credits",
+    {
+      tags: ["Users", "Billing"],
+      permission: "billing:read",
+    },
+  ],
+  [
+    "GET /users/{user_id}/billing/subscription",
+    {
+      tags: ["Users", "Billing"],
+      permission: "billing:read",
+    },
+  ],
+  [
+    "POST /organizations/{organization_id}/billing/credits",
+    {
+      tags: ["Organizations", "Billing"],
+      permission: "billing:write",
+    },
+  ],
+  [
+    "POST /users/{user_id}/billing/credits",
+    {
+      tags: ["Users", "Billing"],
+      permission: "billing:write",
+    },
+  ],
+]);
+
+function uniqueSorted(values: readonly string[]): string[] {
+  return [...new Set(values)].sort((left, right) => {
+    return left.localeCompare(right);
+  });
+}
+
+function formatList(values: readonly string[]): string {
+  return values.join(", ");
+}
+
+function permissionNameForTag(tag: string, access: string): string {
+  return `${slugifyTag(tag)}:${access}`;
+}
+
+function operationKey(methodLower: string, apiPath: string): string {
+  return `${methodLower.toUpperCase()} ${apiPath}`;
+}
+
+function sameValues(
+  left: readonly string[],
+  right: readonly string[],
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((value, index) => {
+      return value === right[index];
+    })
+  );
+}
+
+function resolveOwnerPermissions(
+  apiPath: string,
+  methodLower: string,
+  tags: readonly string[],
+  access: string,
+  usedOwnerOverrides: Set<string>,
+): string[] {
+  const ownerPermissions = uniqueSorted(
+    tags.map((tag) => {
+      return permissionNameForTag(tag, access);
+    }),
+  );
+  const key = operationKey(methodLower, apiPath);
+  const override = OWNER_OVERRIDES.get(key);
+  if (!override) return ownerPermissions;
+
+  usedOwnerOverrides.add(key);
+
+  const expectedOwnerPermissions = uniqueSorted(
+    override.tags.map((tag) => {
+      return permissionNameForTag(tag, access);
+    }),
+  );
+  if (!sameValues(ownerPermissions, expectedOwnerPermissions)) {
+    throw new Error(
+      `Clerk operation "${key}" owner override tags changed: expected [${formatList(
+        expectedOwnerPermissions,
+      )}], got [${formatList(ownerPermissions)}]`,
+    );
+  }
+
+  if (!expectedOwnerPermissions.includes(override.permission)) {
+    throw new Error(
+      `Clerk operation "${key}" owner override permission "${
+        override.permission
+      }" is not one of [${formatList(expectedOwnerPermissions)}]`,
+    );
+  }
+
+  return [override.permission];
+}
+
+function assertAllOwnerOverridesUsed(usedOwnerOverrides: Set<string>): void {
+  const unused = [...OWNER_OVERRIDES.keys()].filter((key) => {
+    return !usedOwnerOverrides.has(key);
+  });
+  if (unused.length === 0) return;
+
+  throw new Error(
+    "Clerk owner overrides no longer match official operations:\n" +
+      unused
+        .sort((left, right) => {
+          return left.localeCompare(right);
+        })
+        .map((key) => {
+          return `  - ${key}`;
+        })
+        .join("\n"),
+  );
+}
+
+function expandRuntimeRule(rule: string): string[] {
+  const spaceIndex = rule.indexOf(" ");
+  const method = rule.slice(0, spaceIndex);
+  const path = rule.slice(spaceIndex + 1);
+  if (method !== "ANY") return [rule];
+  return RUNTIME_METHODS.map((runtimeMethod) => {
+    return `${runtimeMethod} ${path}`;
+  });
+}
+
+function assertUniqueClerkRules(permissions: readonly PermissionGroup[]): void {
+  const owners = new Map<string, string>();
+  const duplicates: string[] = [];
+
+  for (const permission of permissions) {
+    for (const rule of permission.rules) {
+      for (const runtimeRule of expandRuntimeRule(rule)) {
+        const existing = owners.get(runtimeRule);
+        if (existing) {
+          duplicates.push(`${runtimeRule}: ${existing}, ${permission.name}`);
+          continue;
+        }
+        owners.set(runtimeRule, permission.name);
+      }
+    }
+  }
+
+  if (duplicates.length > 0) {
+    throw new Error(
+      "Clerk generated duplicate firewall route owners:\n" +
+        duplicates
+          .sort((left, right) => {
+            return left.localeCompare(right);
+          })
+          .map((duplicate) => {
+            return `  - ${duplicate}`;
+          })
+          .join("\n"),
+    );
+  }
+}
 
 function buildGroups(spec: ClerkSpec): PermissionGroup[] {
   const groups = new Map<string, Set<string>>();
+  const usedOwnerOverrides = new Set<string>();
   if (!spec.paths) {
     throw new Error("OpenAPI spec has no 'paths'");
   }
@@ -101,9 +297,15 @@ function buildGroups(spec: ClerkSpec): PermissionGroup[] {
 
       const access = READ_METHODS.has(methodLower) ? "read" : "write";
       const rule = `${methodLower.toUpperCase()} ${prefix}${apiPath}`;
+      const ownerPermissions = resolveOwnerPermissions(
+        apiPath,
+        methodLower,
+        tags,
+        access,
+        usedOwnerOverrides,
+      );
 
-      for (const tag of tags) {
-        const groupName = `${slugifyTag(tag)}:${access}`;
+      for (const groupName of ownerPermissions) {
         let ruleSet = groups.get(groupName);
         if (!ruleSet) {
           ruleSet = new Set();
@@ -114,13 +316,19 @@ function buildGroups(spec: ClerkSpec): PermissionGroup[] {
     }
   }
 
-  return [...groups.entries()]
+  assertAllOwnerOverridesUsed(usedOwnerOverrides);
+
+  const permissions = [...groups.entries()]
     .filter(([, ruleSet]) => ruleSet.size > 0)
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([name, ruleSet]) => ({
       name,
       rules: sanitizeAndSortRules([...ruleSet]),
     }));
+
+  assertUniqueClerkRules(permissions);
+
+  return permissions;
 }
 
 // ── Category assignment ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- route Clerk nested user/organization billing endpoints to `billing:read` / `billing:write` only
- validate the official Clerk OpenAPI tags for those multi-tag billing operations before applying owner overrides
- fail Clerk generation if duplicate runtime route owners are emitted
- add Clerk connector regression coverage for duplicate ownership, nested billing route matches, and default billing policies
- regenerate the Python built-in firewall catalog for Clerk

Closes #18720

## Testing

- `pnpm -F @vm0/firewalls-generator generate:clerk`
- `pnpm -F @vm0/api-contracts generate:rust`
- `pnpm -F @vm0/connectors exec vitest run src/__tests__/firewalls/clerk.test.ts`
- `pnpm -F @vm0/connectors exec vitest run src/__tests__/firewall-rule-validation.test.ts src/__tests__/firewalls/clerk.test.ts`
- `pnpm -F @vm0/firewalls-generator check-types`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm knip`

Full-suite note:

- `pnpm vitest` failed locally with 13 failed files / 18 failed tests. The failures were outside this change path, primarily `@vm0/app` UI 5s timeouts plus one existing DB migration test (`0443_backfill_claude_fable_5_model_policies`). Clerk/firewall-related tests passed in the same run.
