### PR TITLE
fix: select dev runner target from host architecture

### DIFF
--- a/.github/scripts/runner-host-architecture-groups.sh
+++ b/.github/scripts/runner-host-architecture-groups.sh
@@ -129,18 +129,22 @@ emit_groups() {
   require_env METAL_USER
   validate_hosts_csv "$hosts" || return $?
 
-  local host uname_m
+  local host uname_m target
   while IFS= read -r host; do
     uname_m=$(host_uname_m "$host")
-    case "$uname_m" in
-      aarch64)
+    if ! target=$(runner_image_target_for_uname_m "$uname_m" 2>/dev/null); then
+      echo "unsupported runner host architecture for ${host}: ${uname_m}" >&2
+      return 2
+    fi
+    case "$target" in
+      aarch64-unknown-linux-musl)
         arm64_hosts=$(append_csv "$arm64_hosts" "$host")
         ;;
-      x86_64)
+      x86_64-unknown-linux-musl)
         x86_64_hosts=$(append_csv "$x86_64_hosts" "$host")
         ;;
       *)
-        echo "unsupported runner host architecture for ${host}: ${uname_m}" >&2
+        echo "unsupported runner host target for ${host}: ${target}" >&2
         return 2
         ;;
     esac

--- a/.github/scripts/runner-image-target.sh
+++ b/.github/scripts/runner-image-target.sh
@@ -4,6 +4,10 @@ runner_image_supported_targets_text() {
   printf '%s\n' "aarch64-unknown-linux-musl, x86_64-unknown-linux-musl"
 }
 
+runner_image_supported_uname_m_text() {
+  printf '%s\n' "aarch64, x86_64"
+}
+
 runner_image_validate_target() {
   local target="${1:-}"
   if [ -z "$target" ]; then
@@ -17,6 +21,27 @@ runner_image_validate_target() {
       ;;
     *)
       echo "unsupported runner image target: ${target} (expected one of: $(runner_image_supported_targets_text))" >&2
+      return 2
+      ;;
+  esac
+}
+
+runner_image_target_for_uname_m() {
+  local uname_m="${1:-}"
+  if [ -z "$uname_m" ]; then
+    echo "missing runner host architecture" >&2
+    return 2
+  fi
+
+  case "$uname_m" in
+    aarch64)
+      printf '%s\n' "aarch64-unknown-linux-musl"
+      ;;
+    x86_64)
+      printf '%s\n' "x86_64-unknown-linux-musl"
+      ;;
+    *)
+      echo "unsupported runner host architecture: ${uname_m} (expected one of: $(runner_image_supported_uname_m_text))" >&2
       return 2
       ;;
   esac

--- a/.github/scripts/tests/dev-runner-test.sh
+++ b/.github/scripts/tests/dev-runner-test.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+DEV_RUNNER="${REPO_ROOT}/scripts/dev-runner.sh"
+TARGET_HELPER="${REPO_ROOT}/.github/scripts/runner-image-target.sh"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+setup_test_root() {
+  local root=$1
+
+  mkdir -p \
+    "${root}/scripts" \
+    "${root}/.github/scripts" \
+    "${root}/.certs" \
+    "${root}/crates" \
+    "${root}/bin"
+
+  ln -s "$DEV_RUNNER" "${root}/scripts/dev-runner.sh"
+  ln -s "$TARGET_HELPER" "${root}/.github/scripts/runner-image-target.sh"
+  touch "${root}/.certs/vm0-metal-local.pem"
+
+  cat >"${root}/scripts/.env.local" <<'ENV'
+RUNNER_LOCAL_HOST=dev-host
+RUNNER_LOCAL_USER=ubuntu
+RUNNER_DEFAULT_GROUP=vm0/local-test
+OFFICIAL_RUNNER_SECRET=test-secret
+ENV
+
+  cat >"${root}/scripts/cf-ssh.sh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+command="${*: -1}"
+printf '%s\n' "$command" >>"${CF_SSH_LOG:?}"
+
+case "$command" in
+  "uname -m")
+    printf '%s\n' "${REMOTE_ARCH:?}"
+    ;;
+  *"service stop"*)
+    printf '%s\n' "$command" >>"${SERVICE_STOP_LOG:?}"
+    ;;
+  "sudo mkdir -p "*)
+    ;;
+  "sudo install -m 755 /dev/stdin "*)
+    cat >/dev/null
+    ;;
+  *" setup")
+    ;;
+  *" gc --keep-latest 3")
+    ;;
+  *" build --profile "*)
+    printf '%s\n' "rootfs_hash=rootfs-test"
+    printf '%s\n' "snapshot_hash=snapshot-test"
+    ;;
+  *" config "*)
+    ;;
+  *" service start "*)
+    ;;
+  *)
+    echo "unexpected cf-ssh command: $command" >&2
+    exit 2
+    ;;
+esac
+SH
+  chmod +x "${root}/scripts/cf-ssh.sh"
+
+  cat >"${root}/bin/cargo" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+target=""
+previous=""
+for arg in "$@"; do
+  if [ "$previous" = "--target" ]; then
+    target="$arg"
+    break
+  fi
+  previous="$arg"
+done
+
+if [ -z "$target" ]; then
+  echo "missing fake cargo target" >&2
+  exit 2
+fi
+
+printf '%s\n' "$*" >>"${CARGO_LOG:?}"
+mkdir -p "target/${target}/ci"
+for bin in guest-agent guest-download guest-init guest-mock-claude guest-mock-codex guest-reseed guest-write-file runner; do
+  printf '%s\n' "$bin" >"target/${target}/ci/${bin}"
+  chmod +x "target/${target}/ci/${bin}"
+done
+SH
+  chmod +x "${root}/bin/cargo"
+}
+
+run_deploy() {
+  local name=$1
+  local remote_arch=$2
+  shift 2
+
+  local root="${TMPDIR}/${name}"
+  setup_test_root "$root"
+
+  REMOTE_ARCH="$remote_arch" \
+    CF_SSH_LOG="${root}/cf-ssh.log" \
+    SERVICE_STOP_LOG="${root}/service-stop.log" \
+    CARGO_LOG="${root}/cargo.log" \
+    PATH="${root}/bin:$PATH" \
+    "$@" "${root}/scripts/dev-runner.sh" deploy
+}
+
+run_deploy arm64-success aarch64 env >"${TMPDIR}/arm64-success.out" 2>"${TMPDIR}/arm64-success.err"
+grep -q -- "--target aarch64-unknown-linux-musl" "${TMPDIR}/arm64-success/cargo.log" || fail "expected ARM64 cargo target"
+grep -q "service stop" "${TMPDIR}/arm64-success/service-stop.log" || fail "expected ARM64 service stop"
+
+run_deploy x86-success x86_64 env >"${TMPDIR}/x86-success.out" 2>"${TMPDIR}/x86-success.err"
+grep -q -- "--target x86_64-unknown-linux-musl" "${TMPDIR}/x86-success/cargo.log" || fail "expected x86_64 cargo target"
+grep -q "service stop" "${TMPDIR}/x86-success/service-stop.log" || fail "expected x86_64 service stop"
+
+run_deploy x86-explicit-success x86_64 env RUNNER_TARGET_TRIPLE=x86_64-unknown-linux-musl >"${TMPDIR}/x86-explicit-success.out" 2>"${TMPDIR}/x86-explicit-success.err"
+grep -q -- "--target x86_64-unknown-linux-musl" "${TMPDIR}/x86-explicit-success/cargo.log" || fail "expected explicit x86_64 cargo target"
+
+if run_deploy mismatch x86_64 env RUNNER_TARGET_TRIPLE=aarch64-unknown-linux-musl >"${TMPDIR}/mismatch.out" 2>"${TMPDIR}/mismatch.err"; then
+  fail "expected target mismatch to fail"
+fi
+[ ! -f "${TMPDIR}/mismatch/cargo.log" ] || fail "target mismatch should fail before cargo"
+[ ! -f "${TMPDIR}/mismatch/service-stop.log" ] || fail "target mismatch should fail before service stop"
+grep -q "expects remote architecture aarch64, but dev-host reported x86_64" "${TMPDIR}/mismatch.err" || fail "expected mismatch error"
+
+if run_deploy invalid-override aarch64 env RUNNER_TARGET_TRIPLE=powerpc-unknown-linux-musl >"${TMPDIR}/invalid-override.out" 2>"${TMPDIR}/invalid-override.err"; then
+  fail "expected invalid target override to fail"
+fi
+[ ! -f "${TMPDIR}/invalid-override/cargo.log" ] || fail "invalid target override should fail before cargo"
+[ ! -f "${TMPDIR}/invalid-override/service-stop.log" ] || fail "invalid target override should fail before service stop"
+[ ! -f "${TMPDIR}/invalid-override/cf-ssh.log" ] || fail "invalid target override should fail before ssh"
+grep -q "unsupported runner image target: powerpc-unknown-linux-musl" "${TMPDIR}/invalid-override.err" || fail "expected invalid target override error"
+
+if run_deploy unsupported ppc64le env >"${TMPDIR}/unsupported.out" 2>"${TMPDIR}/unsupported.err"; then
+  fail "expected unsupported remote architecture to fail"
+fi
+[ ! -f "${TMPDIR}/unsupported/cargo.log" ] || fail "unsupported architecture should fail before cargo"
+[ ! -f "${TMPDIR}/unsupported/service-stop.log" ] || fail "unsupported architecture should fail before service stop"
+grep -q "unsupported remote architecture for dev-host: ppc64le" "${TMPDIR}/unsupported.err" || fail "expected unsupported architecture error"
+
+echo "dev-runner-test: ok"

--- a/.github/scripts/tests/runner-host-architecture-groups-test.sh
+++ b/.github/scripts/tests/runner-host-architecture-groups-test.sh
@@ -64,6 +64,22 @@ assert_no_hosts_field() {
   jq -e 'all(.[]; has("hosts") | not)' >/dev/null <<<"$output" || fail "expected no hosts field: ${output}"
 }
 
+out=$(bash -c '. "$1"; runner_image_target_for_uname_m aarch64' bash "$TARGET")
+[ "$out" = "aarch64-unknown-linux-musl" ] || fail "expected aarch64 target, got: ${out}"
+
+out=$(bash -c '. "$1"; runner_image_target_for_uname_m x86_64' bash "$TARGET")
+[ "$out" = "x86_64-unknown-linux-musl" ] || fail "expected x86_64 target, got: ${out}"
+
+if bash -c '. "$1"; runner_image_target_for_uname_m ""' bash "$TARGET" >"${TMPDIR}/uname-empty.out" 2>"${TMPDIR}/uname-empty.err"; then
+  fail "expected empty uname target lookup to fail"
+fi
+grep -q "missing runner host architecture" "${TMPDIR}/uname-empty.err" || fail "expected empty uname message"
+
+if bash -c '. "$1"; runner_image_target_for_uname_m powerpc' bash "$TARGET" >"${TMPDIR}/uname-unsupported.out" 2>"${TMPDIR}/uname-unsupported.err"; then
+  fail "expected unsupported uname target lookup to fail"
+fi
+grep -q "unsupported runner host architecture: powerpc" "${TMPDIR}/uname-unsupported.err" || fail "expected unsupported uname message"
+
 HOST_ARCHES='arm-1=aarch64 arm-2=aarch64'
 
 out=$(run_clean AWS_METAL_RUNNER_HOSTS='arm-1, arm-2' "$HOST_GROUPS")

--- a/scripts/dev-runner.sh
+++ b/scripts/dev-runner.sh
@@ -9,10 +9,14 @@ set -euo pipefail
 # Usage:
 #   scripts/dev-runner.sh deploy   Build, upload, and start the runner
 #   scripts/dev-runner.sh remove   Stop and uninstall the runner
+#
+# Set RUNNER_TARGET_TRIPLE to force a supported runner target. When unset,
+# deploy derives the target from the remote host architecture.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 CRATES_DIR="$PROJECT_ROOT/crates"
+. "$PROJECT_ROOT/.github/scripts/runner-image-target.sh"
 
 log() { echo "[runner] $1" >&2; }
 
@@ -63,11 +67,46 @@ if [[ ! -f "$SSH_KEY" ]]; then
 fi
 ssh_cmd() { "$CF_SSH" "$HOST" -l "$SSH_USER" -i "$SSH_KEY" "$@"; }
 
+remote_uname_m() {
+  local remote_arch
+  remote_arch=$(ssh_cmd "uname -m")
+  printf '%s\n' "$remote_arch" | tail -n1 | tr -d '\r'
+}
+
+select_runner_target() {
+  local remote_arch derived_target selected_target expected_arch
+
+  if [[ -n "${RUNNER_TARGET_TRIPLE:-}" ]]; then
+    runner_image_validate_target "$RUNNER_TARGET_TRIPLE" || return $?
+    expected_arch=$(runner_image_expected_uname_m "$RUNNER_TARGET_TRIPLE") || return $?
+  fi
+
+  remote_arch=$(remote_uname_m)
+  if ! derived_target=$(runner_image_target_for_uname_m "$remote_arch" 2>/dev/null); then
+    log "Error: unsupported remote architecture for $HOST: $remote_arch"
+    return 2
+  fi
+
+  if [[ -n "${RUNNER_TARGET_TRIPLE:-}" ]]; then
+    if [[ "$expected_arch" != "$remote_arch" ]]; then
+      log "Error: RUNNER_TARGET_TRIPLE=$RUNNER_TARGET_TRIPLE expects remote architecture $expected_arch, but $HOST reported $remote_arch"
+      return 2
+    fi
+    selected_target="$RUNNER_TARGET_TRIPLE"
+  else
+    selected_target="$derived_target"
+  fi
+
+  log "Remote architecture: $remote_arch"
+  log "Runner target: $selected_target"
+  printf '%s\n' "$selected_target"
+}
+
 # --- Commands ---
 
 cmd_deploy() {
   RUNNER_SECRET="${OFFICIAL_RUNNER_SECRET:?OFFICIAL_RUNNER_SECRET not set in $ENV_FILE}"
-  TARGET="aarch64-unknown-linux-musl"
+  TARGET=$(select_runner_target)
   # alice-macbook -> https://tunnel-alice-macbook-www.vm7.ai
   API_URL="https://tunnel-${RUNNER_NAME#local-}-www.vm7.ai"
   log "Runner: $RUNNER_NAME (group: $RUNNER_GROUP, api: $API_URL)"


### PR DESCRIPTION
## Summary
- derive `scripts/dev-runner.sh deploy` target from the remote host `uname -m`
- keep `RUNNER_TARGET_TRIPLE` as an explicit override, but fail early when it does not match the remote architecture
- share architecture-to-target mapping with the runner host grouping script and cover it with shell tests

Closes #18575

## Tests
- `bash .github/scripts/tests/dev-runner-test.sh`
- `bash .github/scripts/tests/runner-host-architecture-groups-test.sh`
- `for test_script in .github/scripts/tests/*.sh; do bash "$test_script"; done`
- `git diff --check HEAD~1..HEAD`
- `pnpm format`
- `pnpm lint`
- `pnpm check-types`
- `pnpm knip`

`pnpm test` was also run after `pnpm -F @vm0/db db:migrate`; it still failed locally on unrelated app/API/connectors tests and generated firewall metadata state (for example Slack `conversations:read` validation and multiple 5s UI timeouts). The targeted script coverage for this PR passes.
