### PR TITLE
Maintain the original order of the composer connector popover by disabling authorization state sorting.

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -68,6 +68,14 @@ function connectorSearchFixtureTypes(): readonly ConnectorType[] {
   }).slice(0, 21);
 }
 
+function expectTextBefore(firstText: string, secondText: string): void {
+  const first = screen.getByText(firstText);
+  const second = screen.getByText(secondText);
+  expect(
+    first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING,
+  ).toBeTruthy();
+}
+
 function tabByText(text: string): HTMLElement {
   const tab = queryAllByRoleFast("tab").find((candidate) => {
     return candidate.textContent?.replace(/\s+/g, " ").trim() === text;
@@ -1610,6 +1618,34 @@ describe("chat composer models", () => {
       expect(
         screen.queryByText(/Available connectors to connect/u),
       ).not.toBeInTheDocument();
+    });
+  });
+
+  it("keeps composer connector order independent of authorization state", async () => {
+    const user = userEvent.setup({ delay: null });
+    mockOrgModelRoutes("claude-sonnet-4-6");
+    mockAgent();
+    mockManyConnectedConnectors();
+    mockAgentConnectorAuthorizations(["slack"]);
+
+    detachedSetupPage({ context, path: `/agents/${AGENT_ID}/chat` });
+
+    const composer = composerElementFrom(
+      await screen.findByPlaceholderText(PLACEHOLDER),
+    );
+    click(within(composer).getByLabelText("Connectors"));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Add GitHub")).toBeInTheDocument();
+      expect(screen.getByLabelText("Remove Slack")).toBeInTheDocument();
+      expectTextBefore("GitHub", "Slack");
+    });
+
+    await user.click(screen.getByLabelText("Remove Slack"));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Add Slack")).toBeInTheDocument();
+      expectTextBefore("GitHub", "Slack");
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -5286,16 +5286,23 @@ function ConnectorsPopoverButton({
   const setDownloadDialogOpen = useSet(setComputerUseDownloadDialogOpen$);
   const showSearch = agentConnectors.length > 20;
 
-  // Use snapshot order if available, otherwise sort by added status
+  // Use snapshot order if available, otherwise preserve catalog order.
   const sorted = sortOrder
     ? [...agentConnectors].sort((a, b) => {
         const ai = sortOrder.indexOf(a.type);
         const bi = sortOrder.indexOf(b.type);
-        return (ai === -1 ? Infinity : ai) - (bi === -1 ? Infinity : bi);
+        if (ai === -1 && bi === -1) {
+          return 0;
+        }
+        if (ai === -1) {
+          return 1;
+        }
+        if (bi === -1) {
+          return -1;
+        }
+        return ai - bi;
       })
-    : [...agentConnectors].sort((a, b) => {
-        return Number(b.authorized) - Number(a.authorized);
-      });
+    : agentConnectors;
 
   const visibleConnectors =
     showSearch && search.trim()
@@ -5307,13 +5314,9 @@ function ConnectorsPopoverButton({
   const handleOpenChange = (open: boolean) => {
     if (open) {
       // Snapshot the sort order when popover opens
-      const freshSort = [...agentConnectors]
-        .sort((a, b) => {
-          return Number(b.authorized) - Number(a.authorized);
-        })
-        .map((c) => {
-          return c.type;
-        });
+      const freshSort = agentConnectors.map((c) => {
+        return c.type;
+      });
       setSortOrder(freshSort);
     } else {
       setSortOrder(null);


### PR DESCRIPTION
## Summary
- Maintain the original order of the composer connector popover by disabling authorization state sorting.
- Snapshot the existing catalog order while the popover is open so toggles do not reorder rows
- Add a regression test covering an authorized connector that should not move above earlier catalog items

## Tests
- pnpm exec prettier --write --ignore-unknown apps/platform/src/views/zero-page/zero-chat-composer.tsx apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
- pnpm turbo run lint --filter=@vm0/app --log-order grouped
- pnpm turbo run check-types --filter=@vm0/app --log-order grouped
- pnpm exec vitest run apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx