### PR TITLE
perf: reduce guest state restore startup execs

### DIFF
--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -394,7 +394,7 @@ async fn setup_guest(sandbox: &dyn sandbox::Sandbox) -> RunnerResult<()> {
     Ok(())
 }
 
-/// Start sandbox, fix clock, exec command. Returns result + timing.
+/// Start sandbox, restore guest state, exec command. Returns result + timing.
 async fn run_in_sandbox(
     args: &BenchmarkArgs,
     env_pairs: &[(String, String)],

--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -390,8 +390,7 @@ async fn run_sandbox(
 
 /// Images always contain a snapshot — fix guest clock drift and reseed entropy.
 async fn setup_guest(sandbox: &dyn sandbox::Sandbox) -> RunnerResult<()> {
-    executor::fix_guest_clock(sandbox).await?;
-    executor::reseed_guest_entropy(sandbox).await?;
+    executor::restore_guest_state(sandbox).await?;
     Ok(())
 }
 

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -16,7 +16,7 @@ use super::diagnostics::{
     should_collect_agent_abnormal_exit_diagnostics,
 };
 use super::env::{build_env_json, build_user_env_json, write_user_env_file};
-use super::guest_state::{fix_guest_clock, reseed_guest_entropy, sync_guest_timezone};
+use super::guest_state::{restore_guest_state, sync_guest_timezone};
 use super::session_restore::restore_session;
 use super::storage::{download_storages, filter_unchanged_storages, guest_download_has_work};
 use super::telemetry::record_api_latency;
@@ -241,8 +241,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
     // 1. Fix guest clock and reseed entropy (must happen before HTTPS calls).
     //    Needed after snapshot restore (frozen clock) and after idle reuse (drifted clock).
     if start.restore_guest_state {
-        fix_guest_clock(sandbox).await?;
-        reseed_guest_entropy(sandbox).await?;
+        restore_guest_state(sandbox).await?;
     }
 
     // 2. Set guest timezone from user preference (best-effort, never fails).

--- a/crates/runner/src/executor/guest_state.rs
+++ b/crates/runner/src/executor/guest_state.rs
@@ -9,6 +9,8 @@ use crate::helper_exec::{
 };
 use crate::types::ExecutionContext;
 
+const ENTROPY_SIZE: usize = 256;
+
 fn helper_exec_exit_code(result: &sandbox::ExecResult) -> Option<i32> {
     match result.termination {
         ExecTermination::Exited { exit_code } => Some(exit_code),
@@ -19,72 +21,58 @@ fn helper_exec_exit_code(result: &sandbox::ExecResult) -> Option<i32> {
     }
 }
 
-pub(crate) async fn fix_guest_clock(sandbox: &dyn Sandbox) -> RunnerResult<()> {
-    let timestamp = format!(
+fn host_unix_timestamp_secs() -> String {
+    format!(
         "{:.3}",
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs_f64()
-    );
-    let date_cmd = format!("date -s \"@{timestamp}\"");
-    let result = sandbox
-        .exec_with_diagnostic_label(
-            &ExecRequest {
-                cmd: &date_cmd,
-                timeout: DEFAULT_EXEC_TIMEOUT,
-                env: &[],
-                sudo: true,
-                stdin_bytes: None,
-                output_limits: EXEC_OUTPUT_LIMIT_64_KIB,
-            },
-            "guest-clock-sync",
-        )
-        .await?;
-    if !helper_exec_succeeded(&result) {
-        return Err(RunnerError::Internal(format_helper_exec_failure(
-            "guest clock sync",
-            &result,
-        )));
-    }
-    Ok(())
+    )
 }
 
-/// Reseed guest CRNG after snapshot restore.
-///
-/// On ARM64 with kernel 6.1, VMGenID does not work (the driver only supports
-/// ACPI; DeviceTree support requires kernel 6.10+). All VMs restored from the
-/// same snapshot share identical CRNG state, producing identical random output.
-///
-/// This function injects fresh host entropy and forces an immediate CRNG reseed
-/// so each VM produces unique random numbers from the first `getrandom()` call.
-pub(crate) async fn reseed_guest_entropy(sandbox: &dyn Sandbox) -> RunnerResult<()> {
+fn read_host_entropy() -> RunnerResult<Vec<u8>> {
     use std::io::Read;
-
-    const ENTROPY_SIZE: usize = 256;
 
     let mut entropy = vec![0u8; ENTROPY_SIZE];
     std::fs::File::open("/dev/urandom")
         .and_then(|mut f| f.read_exact(&mut entropy))
         .map_err(|e| RunnerError::Internal(format!("read host entropy: {e}")))?;
+    Ok(entropy)
+}
 
+/// Restores snapshot-sensitive guest state in one exec before the agent starts.
+///
+/// On ARM64 with kernel 6.1, VMGenID does not work (the driver only supports
+/// ACPI; DeviceTree support requires kernel 6.10+). All VMs restored from the
+/// same snapshot share identical CRNG state, producing identical random output.
+///
+/// This syncs the frozen guest clock and injects fresh host entropy so each VM
+/// produces unique random numbers from the first `getrandom()` call.
+pub(crate) async fn restore_guest_state(sandbox: &dyn Sandbox) -> RunnerResult<()> {
+    let timestamp = host_unix_timestamp_secs();
+    let entropy = read_host_entropy()?;
+    let cmd = format!(
+        r#"date -s "@{timestamp}" || {{ status=$?; echo "guest clock sync failed" >&2; exit "$status"; }}
+guest-reseed || {{ status=$?; echo "guest-reseed failed" >&2; exit "$status"; }}"#
+    );
     let result = sandbox
         .exec_with_diagnostic_label(
             &ExecRequest {
-                cmd: "guest-reseed",
+                cmd: &cmd,
                 timeout: DEFAULT_EXEC_TIMEOUT,
                 env: &[],
                 sudo: true,
                 stdin_bytes: Some(&entropy),
                 output_limits: EXEC_OUTPUT_LIMIT_64_KIB,
             },
-            "guest-reseed",
+            "guest-state-restore",
         )
         .await?;
 
     if !helper_exec_succeeded(&result) {
         return Err(RunnerError::Internal(format_helper_exec_failure(
-            "guest-reseed",
+            "guest state restore",
             &result,
         )));
     }

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -35,7 +35,7 @@ mod session_restore;
 mod storage;
 mod telemetry;
 
-pub(crate) use guest_state::{fix_guest_clock, reseed_guest_entropy};
+pub(crate) use guest_state::restore_guest_state;
 
 use crate::active_input::ActiveInputSource;
 use agent_run::{ProcessCancelTimeouts, RunControls};

--- a/crates/runner/src/executor/tests/guest_state_tests.rs
+++ b/crates/runner/src/executor/tests/guest_state_tests.rs
@@ -16,8 +16,17 @@ async fn restore_guest_state_combines_clock_sync_and_reseed() {
 
     let calls = sandbox.exec_calls();
     assert_eq!(calls.len(), 1);
-    assert!(calls[0].cmd.contains("date -s \"@"));
-    assert!(calls[0].cmd.contains("guest-reseed"));
+    let clock_sync_index = calls[0]
+        .cmd
+        .find("date -s \"@")
+        .expect("guest state restore should sync the clock first");
+    let reseed_index = calls[0]
+        .cmd
+        .find("guest-reseed")
+        .expect("guest state restore should reseed entropy");
+    assert!(clock_sync_index < reseed_index);
+    assert!(calls[0].cmd.contains("guest clock sync failed"));
+    assert!(calls[0].cmd.contains("guest-reseed failed"));
     assert!(calls[0].sudo);
     let stdin_bytes = calls[0].stdin_bytes.as_ref().unwrap();
     assert_eq!(stdin_bytes.len(), 256);
@@ -31,6 +40,35 @@ async fn restore_guest_state_propagates_exec_error() {
     let result = restore_guest_state(&sandbox);
 
     assert!(result.await.is_err());
+}
+
+#[tokio::test]
+async fn restore_guest_state_fails_on_non_exited_result() {
+    let sandbox = MockSandbox::new("test");
+    sandbox.push_exec_result(Ok(ExecResult {
+        termination: ExecTermination::WaitFailed,
+        stdout: b"restore stdout".to_vec(),
+        stderr: b"wait failed".to_vec(),
+        diagnostic: String::new(),
+        stdout_truncated: false,
+        stderr_truncated: false,
+    }));
+
+    let result = restore_guest_state(&sandbox).await;
+
+    let message = result.unwrap_err().to_string();
+    assert!(
+        message.contains("guest state restore failed (wait failed)"),
+        "got: {message}"
+    );
+    assert!(
+        message.contains("stderr (captured): wait failed"),
+        "got: {message}"
+    );
+    assert!(
+        message.contains("stdout (captured): restore stdout"),
+        "got: {message}"
+    );
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor/tests/guest_state_tests.rs
+++ b/crates/runner/src/executor/tests/guest_state_tests.rs
@@ -3,116 +3,75 @@ use sandbox_mock::MockSandbox;
 use tracing::Level;
 use tracing_subscriber::prelude::*;
 
-use super::super::guest_state::{fix_guest_clock, reseed_guest_entropy, sync_guest_timezone};
+use super::super::guest_state::{restore_guest_state, sync_guest_timezone};
 use super::support::{CapturedEvent, CapturedEvents, minimal_context, sandbox_exec_error};
 use crate::ids::RunId;
 use crate::types::ExecutionContext;
 
 #[tokio::test]
-async fn fix_guest_clock_calls_date_command() {
+async fn restore_guest_state_combines_clock_sync_and_reseed() {
     let sandbox = MockSandbox::new("test");
-    // Default mock returns exit 0 — clock fix should succeed.
-    fix_guest_clock(&sandbox).await.unwrap();
-}
 
-#[tokio::test]
-async fn fix_guest_clock_propagates_exec_error() {
-    let sandbox = MockSandbox::new("test");
-    sandbox.push_exec_result(Err(sandbox_exec_error("timeout")));
-    let result = fix_guest_clock(&sandbox).await;
-    assert!(result.is_err());
-}
-
-#[tokio::test]
-async fn fix_guest_clock_fails_on_nonzero_exit() {
-    let sandbox = MockSandbox::new("test");
-    sandbox.push_exec_result(Ok(ExecResult::new(
-        2,
-        b"date stdout".to_vec(),
-        b"date stderr".to_vec(),
-    )));
-
-    let result = fix_guest_clock(&sandbox).await;
-
-    let message = result.unwrap_err().to_string();
-    assert!(
-        message.contains("guest clock sync failed (exit code 2)"),
-        "got: {message}"
-    );
-    assert!(
-        message.contains("stderr (captured): date stderr"),
-        "got: {message}"
-    );
-    assert!(
-        message.contains("stdout (captured): date stdout"),
-        "got: {message}"
-    );
-}
-
-#[tokio::test]
-async fn fix_guest_clock_fails_on_non_exited_result() {
-    let sandbox = MockSandbox::new("test");
-    sandbox.push_exec_result(Ok(ExecResult {
-        termination: ExecTermination::WaitFailed,
-        stdout: b"date stdout".to_vec(),
-        stderr: b"wait failed".to_vec(),
-        diagnostic: String::new(),
-        stdout_truncated: false,
-        stderr_truncated: false,
-    }));
-
-    let result = fix_guest_clock(&sandbox).await;
-
-    let message = result.unwrap_err().to_string();
-    assert!(
-        message.contains("guest clock sync failed (wait failed)"),
-        "got: {message}"
-    );
-    assert!(
-        message.contains("stderr (captured): wait failed"),
-        "got: {message}"
-    );
-    assert!(
-        message.contains("stdout (captured): date stdout"),
-        "got: {message}"
-    );
-}
-
-#[tokio::test]
-async fn reseed_guest_entropy_succeeds() {
-    let sandbox = MockSandbox::new("test");
-    reseed_guest_entropy(&sandbox).await.unwrap();
+    restore_guest_state(&sandbox).await.unwrap();
 
     let calls = sandbox.exec_calls();
     assert_eq!(calls.len(), 1);
-    assert_eq!(calls[0].cmd, "guest-reseed");
+    assert!(calls[0].cmd.contains("date -s \"@"));
+    assert!(calls[0].cmd.contains("guest-reseed"));
     assert!(calls[0].sudo);
     let stdin_bytes = calls[0].stdin_bytes.as_ref().unwrap();
     assert_eq!(stdin_bytes.len(), 256);
 }
 
 #[tokio::test]
-async fn reseed_guest_entropy_propagates_exec_error() {
+async fn restore_guest_state_propagates_exec_error() {
     let sandbox = MockSandbox::new("test");
-    // Sandbox-level failure (vsock connection issue).
-    sandbox.push_exec_result(Err(sandbox_exec_error("reseed failed")));
-    let result = reseed_guest_entropy(&sandbox).await;
-    assert!(result.is_err());
+    sandbox.push_exec_result(Err(sandbox_exec_error("restore failed")));
+
+    let result = restore_guest_state(&sandbox);
+
+    assert!(result.await.is_err());
 }
 
 #[tokio::test]
-async fn reseed_guest_entropy_fails_on_nonzero_exit() {
+async fn restore_guest_state_reports_clock_failure_marker() {
     let sandbox = MockSandbox::new("test");
-    // guest-reseed exits with code 1 (e.g., ioctl failed).
+    sandbox.push_exec_result(Ok(ExecResult::new(
+        2,
+        b"date stdout".to_vec(),
+        b"guest clock sync failed\ndate stderr".to_vec(),
+    )));
+
+    let result = restore_guest_state(&sandbox).await;
+
+    let message = result.unwrap_err().to_string();
+    assert!(
+        message.contains("guest state restore failed (exit code 2)"),
+        "got: {message}"
+    );
+    assert!(
+        message.contains("guest clock sync failed"),
+        "got: {message}"
+    );
+}
+
+#[tokio::test]
+async fn restore_guest_state_reports_reseed_failure_marker() {
+    let sandbox = MockSandbox::new("test");
     sandbox.push_exec_result(Ok(ExecResult::new(
         1,
         Vec::new(),
-        b"RNDRESEEDCRNG failed: Operation not permitted".to_vec(),
+        b"guest-reseed failed\nRNDRESEEDCRNG failed".to_vec(),
     )));
-    let result = reseed_guest_entropy(&sandbox).await;
-    assert!(result.is_err());
-    let msg = result.unwrap_err().to_string();
-    assert!(msg.contains("guest-reseed failed"), "got: {msg}");
+
+    let result = restore_guest_state(&sandbox).await;
+
+    let message = result.unwrap_err().to_string();
+    assert!(
+        message.contains("guest state restore failed (exit code 1)"),
+        "got: {message}"
+    );
+    assert!(message.contains("guest-reseed failed"), "got: {message}");
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor/tests/sandbox_run_tests/reuse.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/reuse.rs
@@ -222,11 +222,11 @@ async fn execute_job_reuse_with_session_context() {
 }
 
 #[tokio::test]
-async fn execute_job_reuse_clock_fix_failure_returns_sandbox() {
+async fn execute_job_reuse_guest_state_restore_exec_failure_returns_sandbox() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
 
-    // First exec mounts the workspace drive, second exec fixes the clock.
+    // First exec mounts the workspace drive, second exec restores guest state.
     let sandbox = MockSandbox::new("reuse-clock-fail");
     sandbox.push_exec_result(Ok(ExecResult::new(0, Vec::new(), Vec::new())));
     sandbox.push_exec_result(Err(sandbox_exec_error("vsock broken")));
@@ -248,7 +248,7 @@ async fn execute_job_reuse_clock_fix_failure_returns_sandbox() {
     // Critical: sandbox must be returned so caller can stop + destroy it
     assert!(
         outcome.sandbox.is_some(),
-        "sandbox must be returned on clock fix failure"
+        "sandbox must be returned on guest state restore failure"
     );
     assert!(
         outcome.network_log_session.is_some(),
@@ -262,11 +262,15 @@ async fn execute_job_reuse_reseed_failure_returns_sandbox() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
 
-    // Workspace mount and clock fix succeed, then reseed_guest_entropy fails.
+    // Workspace mount succeeds, then the combined guest state restore reports a
+    // guest-reseed failure.
     let sandbox = MockSandbox::new("reuse-reseed-fail");
     sandbox.push_exec_result(Ok(ExecResult::new(0, Vec::new(), Vec::new())));
-    sandbox.push_exec_result(Ok(ExecResult::new(0, Vec::new(), Vec::new())));
-    sandbox.push_exec_result(Err(sandbox_exec_error("reseed timeout")));
+    sandbox.push_exec_result(Ok(ExecResult::new(
+        1,
+        Vec::new(),
+        b"guest-reseed failed\nreseed timeout".to_vec(),
+    )));
 
     let cancel = tokio_util::sync::CancellationToken::new();
     let (idle_sandbox, _lease) =
@@ -281,7 +285,7 @@ async fn execute_job_reuse_reseed_failure_returns_sandbox() {
     .await;
 
     assert_eq!(outcome.exit_code(), 1);
-    assert!(outcome.error().unwrap().contains("reseed timeout"));
+    assert!(outcome.error().unwrap().contains("guest-reseed failed"));
     assert!(
         outcome.sandbox.is_some(),
         "sandbox must be returned on reseed failure"


### PR DESCRIPTION
## Summary
- combine guest clock sync and entropy reseed into one guest exec before agent spawn
- use the combined helper in snapshot/reuse and runner benchmark setup paths
- update guest-state and reuse failure tests for the combined restore path

## Why
`api_to_spawn` includes runner-side guest preparation before the agent PID is available. Snapshot/reuse paths previously paid two guest exec round trips for clock sync and entropy reseed. Combining them removes one guest exec while preserving the same ordering and failure behavior.

## Testing
- `cargo fmt --manifest-path crates/Cargo.toml --all`
- `cargo test --manifest-path crates/Cargo.toml -p runner guest_state`
- `cargo test --manifest-path crates/Cargo.toml -p runner execute_job_reuse`
- `cargo test --manifest-path crates/Cargo.toml -p runner run_in_sandbox`
- `cargo test --manifest-path crates/Cargo.toml -p runner benchmark`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- `git diff --check`
