### PR TITLE
fix: deduplicate vercel firewall route permissions

### DIFF
--- a/crates/runner/mitm-addon/src/generated/builtin_firewalls/vercel_0.py
+++ b/crates/runner/mitm-addon/src/generated/builtin_firewalls/vercel_0.py
@@ -192,7 +192,6 @@ JSON_PART = r"""{
         {
           "name": "deployments:write",
           "rules": [
-            "PATCH /v1/deployments/{deploymentId}/integrations/{integrationConfigurationId}/resources/{resourceId}/actions/{action}",
             "PATCH /v12/deployments/{id}/cancel",
             "POST /v13/deployments",
             "DELETE /v13/deployments/{id}",
@@ -465,8 +464,7 @@ JSON_PART = r"""{
           "rules": [
             "POST /v1/connect/networks",
             "PATCH /v1/connect/networks/{networkId}",
-            "DELETE /v1/connect/networks/{networkId}",
-            "PATCH /v1/projects/{idOrName}/shared-connect-links"
+            "DELETE /v1/connect/networks/{networkId}"
           ]
         },
         {

--- a/turbo/packages/connectors/src/__tests__/firewalls/vercel.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewalls/vercel.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import { findMatchingPermissions } from "../../firewall-rule-matcher";
+import { getConnectorFirewall } from "../../firewalls";
+
+const RUNTIME_METHODS = [
+  "GET",
+  "POST",
+  "PUT",
+  "PATCH",
+  "DELETE",
+  "HEAD",
+  "OPTIONS",
+] as const;
+
+function vercelMatches(method: string, path: string): string[] {
+  return findMatchingPermissions(method, path, getConnectorFirewall("vercel"));
+}
+
+function expectVercelMatches(
+  method: string,
+  path: string,
+  permissionNames: readonly string[],
+): void {
+  expect([...vercelMatches(method, path)].sort()).toStrictEqual(
+    [...permissionNames].sort(),
+  );
+}
+
+function expandRuntimeRules(rule: string): string[] {
+  const spaceIndex = rule.indexOf(" ");
+  const method = rule.slice(0, spaceIndex);
+  const path = rule.slice(spaceIndex + 1);
+  if (method !== "ANY") return [rule];
+  return RUNTIME_METHODS.map((runtimeMethod) => {
+    return `${runtimeMethod} ${path}`;
+  });
+}
+
+describe("vercel firewall", () => {
+  it("assigns one permission owner to every runtime route", () => {
+    const duplicates: string[] = [];
+    for (const api of getConnectorFirewall("vercel").apis) {
+      const owners = new Map<string, string>();
+      for (const permission of api.permissions ?? []) {
+        for (const rule of permission.rules) {
+          for (const runtimeRule of expandRuntimeRules(rule)) {
+            const key = `${api.base} ${runtimeRule}`;
+            const existing = owners.get(key);
+            if (existing) {
+              duplicates.push(`${key}: ${existing}, ${permission.name}`);
+              continue;
+            }
+            owners.set(key, permission.name);
+          }
+        }
+      }
+    }
+
+    expect(duplicates).toStrictEqual([]);
+  });
+
+  it("maps deployment integration actions to integrations write", () => {
+    expectVercelMatches(
+      "PATCH",
+      "/v1/deployments/dpl_123/integrations/icfg_123/resources/res_123/actions/restart",
+      ["integrations:write"],
+    );
+  });
+
+  it("maps shared connect links to static IPs write", () => {
+    expectVercelMatches(
+      "PATCH",
+      "/v1/projects/project-a/shared-connect-links",
+      ["static-ips:write"],
+    );
+  });
+});

--- a/turbo/packages/firewalls-generator/src/vercel.ts
+++ b/turbo/packages/firewalls-generator/src/vercel.ts
@@ -69,12 +69,182 @@ interface VercelOperation {
   security?: Array<Record<string, string[]>>;
 }
 
+interface VercelOwnerOverride {
+  readonly tags: readonly string[];
+  readonly permission: string;
+}
+
 // ── Grouping ─────────────────────────────────────────────────────────────
 
 const READ_METHODS = new Set(["get", "head"]);
+const RUNTIME_METHODS = [
+  "GET",
+  "POST",
+  "PUT",
+  "PATCH",
+  "DELETE",
+  "HEAD",
+  "OPTIONS",
+] as const;
+
+// Vercel tags a few operations with both a broad area and the specific
+// resource being changed. Keep each runtime route under one owner while
+// validating the official tag set still matches the override.
+const OWNER_OVERRIDES = new Map<string, VercelOwnerOverride>([
+  [
+    "PATCH /v1/deployments/{deploymentId}/integrations/{integrationConfigurationId}/resources/{resourceId}/actions/{action}",
+    {
+      tags: ["deployments", "integrations"],
+      permission: "integrations:write",
+    },
+  ],
+  [
+    "PATCH /v1/projects/{idOrName}/shared-connect-links",
+    {
+      tags: ["networking", "static-ips"],
+      permission: "static-ips:write",
+    },
+  ],
+]);
+
+function uniqueSorted(values: readonly string[]): string[] {
+  return [...new Set(values)].sort((left, right) => {
+    return left.localeCompare(right);
+  });
+}
+
+function formatList(values: readonly string[]): string {
+  return values.join(", ");
+}
+
+function permissionNameForTag(tag: string, access: string): string {
+  return `${tag}:${access}`;
+}
+
+function operationKey(methodLower: string, apiPath: string): string {
+  return `${methodLower.toUpperCase()} ${apiPath}`;
+}
+
+function sameValues(
+  left: readonly string[],
+  right: readonly string[],
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((value, index) => {
+      return value === right[index];
+    })
+  );
+}
+
+function resolveOwnerPermissions(
+  apiPath: string,
+  methodLower: string,
+  tags: readonly string[],
+  access: string,
+  usedOwnerOverrides: Set<string>,
+): string[] {
+  const ownerPermissions = uniqueSorted(
+    tags.map((tag) => {
+      return permissionNameForTag(tag, access);
+    }),
+  );
+  const key = operationKey(methodLower, apiPath);
+  const override = OWNER_OVERRIDES.get(key);
+  if (!override) return ownerPermissions;
+
+  usedOwnerOverrides.add(key);
+
+  const expectedOwnerPermissions = uniqueSorted(
+    override.tags.map((tag) => {
+      return permissionNameForTag(tag, access);
+    }),
+  );
+  if (!sameValues(ownerPermissions, expectedOwnerPermissions)) {
+    throw new Error(
+      `Vercel operation "${key}" owner override tags changed: expected [${formatList(
+        expectedOwnerPermissions,
+      )}], got [${formatList(ownerPermissions)}]`,
+    );
+  }
+
+  if (!expectedOwnerPermissions.includes(override.permission)) {
+    throw new Error(
+      `Vercel operation "${key}" owner override permission "${
+        override.permission
+      }" is not one of [${formatList(expectedOwnerPermissions)}]`,
+    );
+  }
+
+  return [override.permission];
+}
+
+function assertAllOwnerOverridesUsed(usedOwnerOverrides: Set<string>): void {
+  const unused = [...OWNER_OVERRIDES.keys()].filter((key) => {
+    return !usedOwnerOverrides.has(key);
+  });
+  if (unused.length === 0) return;
+
+  throw new Error(
+    "Vercel owner overrides no longer match official operations:\n" +
+      unused
+        .sort((left, right) => {
+          return left.localeCompare(right);
+        })
+        .map((key) => {
+          return `  - ${key}`;
+        })
+        .join("\n"),
+  );
+}
+
+function expandRuntimeRule(rule: string): string[] {
+  const spaceIndex = rule.indexOf(" ");
+  const method = rule.slice(0, spaceIndex);
+  const path = rule.slice(spaceIndex + 1);
+  if (method !== "ANY") return [rule];
+  return RUNTIME_METHODS.map((runtimeMethod) => {
+    return `${runtimeMethod} ${path}`;
+  });
+}
+
+function assertUniqueVercelRules(
+  permissions: readonly PermissionGroup[],
+): void {
+  const owners = new Map<string, string>();
+  const duplicates: string[] = [];
+
+  for (const permission of permissions) {
+    for (const rule of permission.rules) {
+      for (const runtimeRule of expandRuntimeRule(rule)) {
+        const existing = owners.get(runtimeRule);
+        if (existing) {
+          duplicates.push(`${runtimeRule}: ${existing}, ${permission.name}`);
+          continue;
+        }
+        owners.set(runtimeRule, permission.name);
+      }
+    }
+  }
+
+  if (duplicates.length > 0) {
+    throw new Error(
+      "Vercel generated duplicate firewall route owners:\n" +
+        duplicates
+          .sort((left, right) => {
+            return left.localeCompare(right);
+          })
+          .map((duplicate) => {
+            return `  - ${duplicate}`;
+          })
+          .join("\n"),
+    );
+  }
+}
 
 function buildGroups(spec: OpenApiSpec): PermissionGroup[] {
   const groups = new Map<string, Set<string>>();
+  const usedOwnerOverrides = new Set<string>();
   if (!spec.paths) {
     throw new Error("OpenAPI spec has no 'paths'");
   }
@@ -101,9 +271,15 @@ function buildGroups(spec: OpenApiSpec): PermissionGroup[] {
 
       const access = READ_METHODS.has(methodLower) ? "read" : "write";
       const rule = `${methodLower.toUpperCase()} ${apiPath}`;
+      const ownerPermissions = resolveOwnerPermissions(
+        apiPath,
+        methodLower,
+        tags,
+        access,
+        usedOwnerOverrides,
+      );
 
-      for (const tag of tags) {
-        const groupName = `${tag}:${access}`;
+      for (const groupName of ownerPermissions) {
         let ruleSet = groups.get(groupName);
         if (!ruleSet) {
           ruleSet = new Set();
@@ -114,13 +290,19 @@ function buildGroups(spec: OpenApiSpec): PermissionGroup[] {
     }
   }
 
-  return [...groups.entries()]
+  assertAllOwnerOverridesUsed(usedOwnerOverrides);
+
+  const permissions = [...groups.entries()]
     .filter(([, ruleSet]) => ruleSet.size > 0)
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([name, ruleSet]) => ({
       name,
       rules: sanitizeAndSortRules([...ruleSet]),
     }));
+
+  assertUniqueVercelRules(permissions);
+
+  return permissions;
 }
 
 // ── TypeScript generation ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- route Vercel multi-tag duplicate operations to a single owner permission
- validate the official Vercel OpenAPI tag set before applying owner overrides
- fail Vercel generation if duplicate runtime route owners are emitted
- add Vercel connector regression coverage for duplicate ownership and the two remapped routes
- regenerate the Python built-in firewall catalog for Vercel

Closes #18738

## Testing

- `pnpm -F @vm0/firewalls-generator generate:vercel`
- `pnpm -F @vm0/connectors exec vitest run src/__tests__/firewalls/vercel.test.ts`
- `pnpm -F @vm0/api-contracts generate:rust`
- `pnpm -F @vm0/connectors exec vitest run src/__tests__/firewall-rule-validation.test.ts src/__tests__/firewalls/vercel.test.ts`
- `pnpm -F @vm0/firewalls-generator check-types`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/connectors lint`
- `pnpm format`
- `pnpm knip`
- pre-commit: `pnpm check-types`