### PR TITLE
test(sandbox-fc): assert balloon deflate targets

### DIFF
--- a/crates/sandbox-fc/src/balloon.rs
+++ b/crates/sandbox-fc/src/balloon.rs
@@ -347,6 +347,14 @@ mod tests {
         server.await.unwrap()
     }
 
+    fn patch_amount_mib(body: &str) -> u64 {
+        let parsed: serde_json::Value =
+            serde_json::from_str(body).unwrap_or_else(|e| panic!("parse PATCH body {body:?}: {e}"));
+        parsed["amount_mib"]
+            .as_u64()
+            .unwrap_or_else(|| panic!("PATCH body missing numeric amount_mib: {body}"))
+    }
+
     #[tokio::test]
     async fn controller_handle_drop_aborts_task() {
         let (started_tx, started_rx) = tokio::sync::oneshot::channel();
@@ -464,8 +472,7 @@ mod tests {
         let patch = run_tick_with_mock(stats, 1536).await;
         assert!(patch.is_some(), "expected PATCH call for inflate");
         let body = patch.unwrap();
-        let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
-        let amount = parsed["amount_mib"].as_u64().unwrap();
+        let amount = patch_amount_mib(&body);
         assert_eq!(
             amount, 256,
             "expected per-tick cap of {MAX_INFLATE_PER_TICK_MIB}, got {amount}"
@@ -493,7 +500,26 @@ mod tests {
         let patch = run_tick_with_mock(stats, 1536).await;
         assert!(patch.is_some(), "expected PATCH call for deflate");
         let body = patch.unwrap();
-        assert!(body.contains("amount_mib"), "body: {body}");
+        let amount = patch_amount_mib(&body);
+        assert_eq!(
+            amount, 384,
+            "expected deflate target for 128 MiB available memory, got {amount}"
+        );
+    }
+
+    #[tokio::test]
+    async fn tick_deflate_saturates_when_deficit_exceeds_current() {
+        // available_memory = 0 MiB, so deficit is 256 MiB.
+        // current balloon is only 100 MiB, so target should saturate at 0.
+        let stats = r#"{"target_mib":100,"actual_mib":100,"target_pages":25600,"actual_pages":25600,"free_memory":0,"available_memory":0}"#;
+        let patch = run_tick_with_mock(stats, 1536).await;
+        assert!(patch.is_some(), "expected PATCH call for deflate");
+        let body = patch.unwrap();
+        let amount = patch_amount_mib(&body);
+        assert_eq!(
+            amount, 0,
+            "expected saturated deflate target of 0, got {amount}"
+        );
     }
 
     #[tokio::test]
@@ -514,8 +540,7 @@ mod tests {
         let patch = run_tick_with_mock(stats, 512).await;
         assert!(patch.is_some(), "expected PATCH call");
         let body = patch.unwrap();
-        let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
-        let amount = parsed["amount_mib"].as_u64().unwrap();
+        let amount = patch_amount_mib(&body);
         assert_eq!(
             amount, 256,
             "expected per-tick cap of {MAX_INFLATE_PER_TICK_MIB}, got {amount}"
@@ -531,8 +556,7 @@ mod tests {
         let patch = run_tick_with_mock(stats, 1536).await;
         assert!(patch.is_some(), "expected PATCH call");
         let body = patch.unwrap();
-        let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
-        let amount = parsed["amount_mib"].as_u64().unwrap();
+        let amount = patch_amount_mib(&body);
         assert_eq!(
             amount, 1536,
             "expected clamped to max_inflate, got {amount}"

--- a/crates/sandbox-fc/src/balloon.rs
+++ b/crates/sandbox-fc/src/balloon.rs
@@ -244,7 +244,7 @@ fn parse_meminfo(content: &str) -> Option<(u64, u64)> {
 mod tests {
     use super::*;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
-    use tokio::net::UnixListener;
+    use tokio::net::{UnixListener, UnixStream};
 
     const LIFECYCLE_TIMEOUT: Duration = Duration::from_secs(1);
 
@@ -293,6 +293,45 @@ mod tests {
         run_tick_with_mock_at(stats_json, max_inflate, 0).await
     }
 
+    async fn read_mock_request_body(stream: &mut UnixStream) -> String {
+        let mut buf = Vec::with_capacity(4096);
+
+        let header_end = loop {
+            let n = stream.read_buf(&mut buf).await.expect("read mock request");
+            assert!(n != 0, "mock request closed before headers completed");
+            if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                break pos;
+            }
+        };
+
+        let headers = String::from_utf8_lossy(&buf[..header_end]);
+        let content_length = headers
+            .lines()
+            .find_map(|line| {
+                let (key, value) = line.split_once(':')?;
+                if key.trim().eq_ignore_ascii_case("content-length") {
+                    value.trim().parse::<usize>().ok()
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(0);
+
+        let body_start = header_end + 4;
+        let already_read = buf.len().saturating_sub(body_start);
+        if already_read < content_length {
+            let mut tail = vec![0u8; content_length - already_read];
+            stream
+                .read_exact(&mut tail)
+                .await
+                .expect("read mock request body");
+            buf.extend_from_slice(&tail);
+        }
+
+        let body_end = body_start + content_length;
+        String::from_utf8_lossy(&buf[body_start..body_end]).to_string()
+    }
+
     async fn run_tick_with_mock_at(
         stats_json: &str,
         max_inflate: u32,
@@ -311,8 +350,7 @@ mod tests {
 
             // First request: GET /balloon/statistics
             let (mut stream, _) = listener.accept().await.unwrap();
-            let mut buf = vec![0u8; 4096];
-            let _ = stream.read(&mut buf).await;
+            let _ = read_mock_request_body(&mut stream).await;
             let response = format!(
                 "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{stats_body}",
                 stats_body.len()
@@ -325,14 +363,7 @@ mod tests {
                 tokio::time::timeout(Duration::from_millis(100), listener.accept()).await
             {
                 let (mut stream, _) = result.unwrap();
-                let mut buf = vec![0u8; 4096];
-                let n = stream.read(&mut buf).await.unwrap();
-                let req = String::from_utf8_lossy(&buf[..n]).to_string();
-
-                // Extract body from HTTP request.
-                if let Some(pos) = req.find("\r\n\r\n") {
-                    patch_body = Some(req[pos + 4..].to_string());
-                }
+                patch_body = Some(read_mock_request_body(&mut stream).await);
 
                 let response = "HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n";
                 let _ = stream.write_all(response.as_bytes()).await;


### PR DESCRIPTION
## Summary

- add a test helper for parsing balloon PATCH `amount_mib` values
- assert the exact low-available-memory deflate target of `384`
- add a deflate saturation test for deficits larger than the current balloon size

Closes #18729

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc balloon::tests::tick_`
- `cargo fmt --manifest-path crates/sandbox-fc/Cargo.toml --check`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc`
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox-fc --all-targets -- -D warnings`
