### PR TITLE
refactor(runner): consolidate storage manifest reuse filtering

### DIFF
--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -18,7 +18,7 @@ use super::diagnostics::{
 use super::env::{build_env_json, build_user_env_json, write_user_env_file};
 use super::guest_state::{fix_guest_clock, reseed_guest_entropy, sync_guest_timezone};
 use super::session_restore::restore_session;
-use super::storage::{download_storages, filter_unchanged_storages, guest_download_has_work};
+use super::storage::{apply_storage_fingerprint_reuse, download_storages, guest_download_has_work};
 use super::telemetry::record_api_latency;
 use super::{
     EXIT_SIGKILL, EXIT_SIGNAL_KILL, ExecutionFailure, ExecutorConfig, JOB_TIMEOUT,
@@ -252,7 +252,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
     if let Some(manifest) = &context.storage_manifest {
         let guest_manifest = GuestDownloadManifest::from(manifest);
         let mut effective: GuestDownloadManifest = match start.prev_storage {
-            Some(prev) => filter_unchanged_storages(&guest_manifest, prev),
+            Some(prev) => apply_storage_fingerprint_reuse(&guest_manifest, prev),
             None => guest_manifest,
         };
         // Short-circuit: skip the vsock exec if no downloads, cleanup, or

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -248,7 +248,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
     // 2. Set guest timezone from user preference (best-effort, never fails).
     sync_guest_timezone(sandbox, context).await;
 
-    // 3. Download storages (skipping entries unchanged since the previous turn)
+    // 3. Download storage manifest entries (skipping entries unchanged since the previous turn).
     if let Some(manifest) = &context.storage_manifest {
         let guest_manifest = GuestDownloadManifest::from(manifest);
         let mut effective: GuestDownloadManifest = match start.prev_storage {
@@ -259,7 +259,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         // guest-side instruction normalization remain.
         let has_work = guest_download_has_work(&effective);
         if !has_work {
-            info!(run_id = %context.run_id, "all storages unchanged, skipping download");
+            info!(run_id = %context.run_id, "storage manifest has no download work, skipping download");
         }
         let t = Instant::now();
         let result = if has_work {

--- a/crates/runner/src/executor/storage.rs
+++ b/crates/runner/src/executor/storage.rs
@@ -1,5 +1,7 @@
 //! Storage manifest filtering and guest download helpers.
 
+use std::collections::{HashMap, HashSet};
+
 use sandbox::{EXEC_OUTPUT_LIMIT_1_MIB, ExecRequest, Sandbox};
 use tracing::info;
 
@@ -11,25 +13,60 @@ use crate::types::{
     ExecutionContext, GuestDownloadArtifactEntry, GuestDownloadManifest, GuestDownloadStorageEntry,
 };
 
-pub(super) fn filter_unchanged_storages(
+#[derive(Default)]
+struct ManifestReuseFilter {
+    skipped: usize,
+    cleanup_paths: Vec<String>,
+}
+
+impl ManifestReuseFilter {
+    fn record_entry(
+        &mut self,
+        previous: Option<&StorageFingerprint>,
+        mount_path: &str,
+        vas_storage_name: &str,
+        vas_version_id: &str,
+    ) -> bool {
+        let unchanged = previous
+            .is_some_and(|fingerprint| fingerprint.matches(vas_storage_name, vas_version_id));
+        if unchanged {
+            self.skipped += 1;
+        } else {
+            self.cleanup_paths.push(mount_path.to_string());
+        }
+        unchanged
+    }
+
+    fn record_removed_paths<'a>(
+        &mut self,
+        previous: &HashMap<String, StorageFingerprint>,
+        current_paths: impl IntoIterator<Item = &'a str>,
+    ) {
+        let current_paths: HashSet<&str> = current_paths.into_iter().collect();
+        for prev_path in previous.keys() {
+            if !current_paths.contains(prev_path.as_str()) {
+                self.cleanup_paths.push(prev_path.clone());
+            }
+        }
+    }
+}
+
+pub(super) fn apply_storage_fingerprint_reuse(
     manifest: &GuestDownloadManifest,
     prev: &StorageFingerprints,
 ) -> GuestDownloadManifest {
-    let mut skipped: usize = 0;
-    let mut cleanup_paths: Vec<String> = Vec::new();
+    let mut filter = ManifestReuseFilter::default();
 
     let storages: Vec<GuestDownloadStorageEntry> = manifest
         .storages
         .iter()
         .map(|s| {
-            let unchanged = prev.storages.get(&s.mount_path).is_some_and(|fingerprint| {
-                fingerprint.matches(&s.vas_storage_name, &s.vas_version_id)
-            });
-            if unchanged {
-                skipped += 1;
-            } else {
-                cleanup_paths.push(s.mount_path.clone());
-            }
+            let unchanged = filter.record_entry(
+                prev.storages.get(&s.mount_path),
+                &s.mount_path,
+                &s.vas_storage_name,
+                &s.vas_version_id,
+            );
             GuestDownloadStorageEntry {
                 archive_url: if unchanged {
                     None
@@ -43,58 +80,42 @@ pub(super) fn filter_unchanged_storages(
         })
         .collect();
 
-    // Detect removed storages: paths in previous fingerprints not in current manifest.
-    let current_paths: std::collections::HashSet<&str> = manifest
-        .storages
-        .iter()
-        .map(|s| s.mount_path.as_str())
-        .collect();
-    for prev_path in prev.storages.keys() {
-        if !current_paths.contains(prev_path.as_str()) {
-            cleanup_paths.push(prev_path.clone());
-        }
-    }
-
-    let filter_artifact = |a: &GuestDownloadArtifactEntry,
-                           prev_ver: Option<&StorageFingerprint>,
-                           skipped: &mut usize,
-                           cleanup: &mut Vec<String>| {
-        let same = prev_ver
-            .is_some_and(|fingerprint| fingerprint.matches(&a.vas_storage_name, &a.vas_version_id));
-        if same {
-            *skipped += 1;
-        } else {
-            cleanup.push(a.mount_path.clone());
-        }
-        GuestDownloadArtifactEntry {
-            archive_url: a.archive_url.clone(),
-            cached: same,
-            ..a.clone()
-        }
-    };
+    filter.record_removed_paths(
+        &prev.storages,
+        manifest.storages.iter().map(|s| s.mount_path.as_str()),
+    );
 
     let artifacts: Vec<GuestDownloadArtifactEntry> = manifest
         .artifacts
         .iter()
         .map(|a| {
-            let prev_ver = prev.artifacts.get(&a.mount_path);
-            filter_artifact(a, prev_ver, &mut skipped, &mut cleanup_paths)
+            let unchanged = filter.record_entry(
+                prev.artifacts.get(&a.mount_path),
+                &a.mount_path,
+                &a.vas_storage_name,
+                &a.vas_version_id,
+            );
+            GuestDownloadArtifactEntry {
+                archive_url: a.archive_url.clone(),
+                cached: unchanged,
+                ..a.clone()
+            }
         })
         .collect();
-    // Detect removed artifacts: previous artifact mount_paths not in current manifest.
-    let current_artifact_paths: std::collections::HashSet<&str> = manifest
-        .artifacts
-        .iter()
-        .map(|a| a.mount_path.as_str())
-        .collect();
-    for prev_path in prev.artifacts.keys() {
-        if !current_artifact_paths.contains(prev_path.as_str()) {
-            cleanup_paths.push(prev_path.clone());
-        }
-    }
+
+    filter.record_removed_paths(
+        &prev.artifacts,
+        manifest.artifacts.iter().map(|a| a.mount_path.as_str()),
+    );
+
+    let ManifestReuseFilter {
+        skipped,
+        cleanup_paths,
+    } = filter;
+
     if skipped > 0 {
         let total = manifest.storages.len() + manifest.artifacts.len();
-        info!(skipped, total, "filtered unchanged storage entries");
+        info!(skipped, total, "filtered unchanged manifest entries");
     }
 
     if !cleanup_paths.is_empty() {

--- a/crates/runner/src/executor/tests/storage_tests.rs
+++ b/crates/runner/src/executor/tests/storage_tests.rs
@@ -6,7 +6,7 @@ use sandbox_mock::MockSandbox;
 
 use super::super::guest_runtime_dir;
 use super::super::storage::{
-    download_storages, filter_unchanged_storages, format_guest_download_failure,
+    apply_storage_fingerprint_reuse, download_storages, format_guest_download_failure,
     guest_download_command, guest_download_env, guest_download_has_work,
 };
 use super::support::{minimal_context, sandbox_write_file_error};
@@ -211,7 +211,7 @@ async fn download_storages_fails_on_write_file_error() {
 }
 
 // -----------------------------------------------------------------------
-// filter_unchanged_storages tests
+// apply_storage_fingerprint_reuse tests
 // -----------------------------------------------------------------------
 
 fn guest_art(name: &str, ver: &str, url: Option<&str>) -> GuestDownloadArtifactEntry {
@@ -331,7 +331,7 @@ fn filter_same_artifact_version_keeps_url_for_mount_repair() {
         storages: HashMap::new(),
         artifacts: art_fp("/workspace", "my-art", "v1"),
     };
-    let result = filter_unchanged_storages(&manifest, &prev);
+    let result = apply_storage_fingerprint_reuse(&manifest, &prev);
     assert_eq!(
         result.artifacts[0].archive_url.as_deref(),
         Some("https://s3/v1")
@@ -351,7 +351,7 @@ fn filter_different_artifact_version_keeps_url() {
         storages: HashMap::new(),
         artifacts: art_fp("/workspace", "my-art", "v1"),
     };
-    let result = filter_unchanged_storages(&manifest, &prev);
+    let result = apply_storage_fingerprint_reuse(&manifest, &prev);
     assert_eq!(
         result.artifacts[0].archive_url.as_deref(),
         Some("https://s3/v2"),
@@ -369,7 +369,7 @@ fn filter_different_artifact_name_keeps_url() {
         storages: HashMap::new(),
         artifacts: art_fp("/workspace", "my-art", "v1"),
     };
-    let result = filter_unchanged_storages(&manifest, &prev);
+    let result = apply_storage_fingerprint_reuse(&manifest, &prev);
     assert!(result.artifacts[0].archive_url.is_some());
 }
 
@@ -381,7 +381,7 @@ fn filter_new_artifact_not_in_prev_keeps_url() {
         cleanup_paths: vec![],
     };
     let prev = StorageFingerprints::default();
-    let result = filter_unchanged_storages(&manifest, &prev);
+    let result = apply_storage_fingerprint_reuse(&manifest, &prev);
     assert!(result.artifacts[0].archive_url.is_some());
 }
 
@@ -398,7 +398,7 @@ fn filter_empty_prev_downloads_everything() {
         cleanup_paths: vec![],
     };
     let prev = StorageFingerprints::default();
-    let result = filter_unchanged_storages(&manifest, &prev);
+    let result = apply_storage_fingerprint_reuse(&manifest, &prev);
     assert!(result.storages[0].archive_url.is_some());
     assert!(result.artifacts[0].archive_url.is_some());
 }
@@ -421,7 +421,7 @@ fn filter_all_unchanged_nulls_storage_urls_and_keeps_artifact_urls() {
         storages,
         artifacts: art_fp("/workspace", "my-art", "v1"),
     };
-    let result = filter_unchanged_storages(&manifest, &prev);
+    let result = apply_storage_fingerprint_reuse(&manifest, &prev);
     assert!(result.storages[0].archive_url.is_none());
     assert!(result.storages[0].cached);
     assert_eq!(
@@ -464,7 +464,7 @@ fn filter_two_artifacts_at_different_mount_paths() {
         storages: HashMap::new(),
         artifacts,
     };
-    let result = filter_unchanged_storages(&manifest, &prev);
+    let result = apply_storage_fingerprint_reuse(&manifest, &prev);
     assert_eq!(result.artifacts.len(), 2);
     // art-a changed → keeps URL, not cached, cleanup path added
     assert!(result.artifacts[0].archive_url.is_some());
@@ -493,9 +493,53 @@ fn filter_detects_removed_artifacts() {
         storages: HashMap::new(),
         artifacts,
     };
-    let result = filter_unchanged_storages(&manifest, &prev);
+    let result = apply_storage_fingerprint_reuse(&manifest, &prev);
     // Removed artifact path must appear in cleanup_paths.
     assert!(result.cleanup_paths.contains(&"/old".to_string()));
+}
+
+#[test]
+fn filter_cleanup_paths_keep_broad_phase_order() {
+    let manifest = GuestDownloadManifest {
+        storages: vec![guest_storage(
+            "/storage-changed",
+            "storage",
+            "v2",
+            Some("https://s3/storage"),
+        )],
+        artifacts: vec![GuestDownloadArtifactEntry {
+            mount_path: "/artifact-changed".into(),
+            archive_url: Some("https://s3/artifact".into()),
+            cached: false,
+            vas_storage_name: "artifact".into(),
+            vas_storage_id: String::new(),
+            vas_version_id: "v2".into(),
+            missing_root_policy: None,
+        }],
+        cleanup_paths: vec![],
+    };
+    let prev = StorageFingerprints {
+        storages: HashMap::from([
+            ("/storage-changed".into(), fp("storage", "v1")),
+            ("/storage-removed".into(), fp("removed-storage", "v1")),
+        ]),
+        artifacts: HashMap::from([
+            ("/artifact-changed".into(), fp("artifact", "v1")),
+            ("/artifact-removed".into(), fp("removed-artifact", "v1")),
+        ]),
+    };
+
+    let result = apply_storage_fingerprint_reuse(&manifest, &prev);
+
+    assert_eq!(
+        result.cleanup_paths,
+        vec![
+            "/storage-changed",
+            "/storage-removed",
+            "/artifact-changed",
+            "/artifact-removed"
+        ]
+    );
 }
 
 #[test]
@@ -528,7 +572,7 @@ fn filter_computes_cleanup_for_changed_storages() {
         storages,
         artifacts: HashMap::new(),
     };
-    let result = filter_unchanged_storages(&manifest, &prev);
+    let result = apply_storage_fingerprint_reuse(&manifest, &prev);
     // Instructions changed (v1→v2), skill-foo unchanged
     assert!(result.storages[0].archive_url.is_some());
     assert!(!result.storages[0].cached);
@@ -560,7 +604,7 @@ fn filter_detects_removed_storages() {
         storages,
         artifacts: HashMap::new(),
     };
-    let result = filter_unchanged_storages(&manifest, &prev);
+    let result = apply_storage_fingerprint_reuse(&manifest, &prev);
     // instructions unchanged, old-skill removed
     assert!(result.storages[0].archive_url.is_none());
     assert!(
@@ -581,7 +625,7 @@ fn filter_changed_artifact_adds_cleanup_path() {
         storages: HashMap::new(),
         artifacts: art_fp("/workspace", "my-art", "v1"),
     };
-    let result = filter_unchanged_storages(&manifest, &prev);
+    let result = apply_storage_fingerprint_reuse(&manifest, &prev);
     assert!(result.artifacts[0].archive_url.is_some());
     assert!(
         result
@@ -601,7 +645,7 @@ fn filter_changed_artifact_with_null_url_adds_cleanup_path() {
         storages: HashMap::new(),
         artifacts: art_fp("/workspace", "my-art", "v1"),
     };
-    let result = filter_unchanged_storages(&manifest, &prev);
+    let result = apply_storage_fingerprint_reuse(&manifest, &prev);
     // Version changed → must be in cleanup_paths even though URL is absent.
     assert!(result.cleanup_paths.contains(&"/workspace".to_string()));
     assert!(!result.artifacts[0].cached);
@@ -624,7 +668,7 @@ fn filter_unchanged_artifact_policy_does_not_force_redownload() {
         artifacts: art_fp("/workspace", "memory", "v1"),
     };
 
-    let result = filter_unchanged_storages(&manifest, &prev);
+    let result = apply_storage_fingerprint_reuse(&manifest, &prev);
 
     assert_eq!(
         result.artifacts[0].archive_url.as_deref(),
@@ -647,7 +691,7 @@ fn filter_changed_storage_with_null_url_adds_cleanup_path() {
         storages,
         artifacts: HashMap::new(),
     };
-    let result = filter_unchanged_storages(&manifest, &prev);
+    let result = apply_storage_fingerprint_reuse(&manifest, &prev);
     // Version changed → must be in cleanup_paths even though URL is absent.
     assert!(result.cleanup_paths.contains(&"/data".to_string()));
     assert!(!result.storages[0].cached);
@@ -671,7 +715,7 @@ fn filter_unchanged_storage_sets_cached_true() {
         storages,
         artifacts: HashMap::new(),
     };
-    let result = filter_unchanged_storages(&manifest, &prev);
+    let result = apply_storage_fingerprint_reuse(&manifest, &prev);
     assert!(result.storages[0].cached);
     assert!(result.storages[0].archive_url.is_none());
 }
@@ -695,7 +739,7 @@ fn filter_unchanged_storage_leaves_instruction_normalization_work() {
         artifacts: HashMap::new(),
     };
 
-    let result = filter_unchanged_storages(&manifest, &prev);
+    let result = apply_storage_fingerprint_reuse(&manifest, &prev);
 
     assert!(result.storages[0].cached);
     assert!(result.storages[0].archive_url.is_none());
@@ -733,7 +777,7 @@ fn filter_tainted_paths_force_download_even_when_versions_match() {
     }
     .tainted_paths();
 
-    let result = filter_unchanged_storages(&manifest, &prev);
+    let result = apply_storage_fingerprint_reuse(&manifest, &prev);
 
     assert_eq!(
         result.storages[0].archive_url.as_deref(),
@@ -770,7 +814,7 @@ fn filter_tainted_removed_paths_are_cleaned() {
     }
     .tainted_paths();
 
-    let result = filter_unchanged_storages(&manifest, &prev);
+    let result = apply_storage_fingerprint_reuse(&manifest, &prev);
 
     assert!(
         result

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -1,6 +1,6 @@
 //! Runner-side content-addressed cache for small storage archives.
 //!
-//! Sits between `filter_unchanged_storages` and `download_storages` in
+//! Sits between `apply_storage_fingerprint_reuse` and `download_storages` in
 //! `run_in_sandbox`. For each eligible manifest entry, checks a host-local
 //! cache keyed by `(vasStorageName, vasVersionId)`. On hit, reads the cached
 //! tarball from disk and pushes it into the guest via vsock; on miss,
@@ -15,7 +15,7 @@
 //!
 //! Entries above [`CACHE_MAX_SIZE`], entries without a content key, and
 //! entries already marked `cached = true` (reuse-in-place from
-//! `filter_unchanged_storages`) pass through untouched.
+//! `apply_storage_fingerprint_reuse`) pass through untouched.
 //! If the probe says an entry is cache-eligible but the full response exceeds
 //! [`CACHE_MAX_SIZE`], the cache fails closed instead of handing the same
 //! inconsistent URL to the guest.
@@ -153,7 +153,7 @@ impl GuestWriteLocks {
 ///
 /// Invariant: only touches entries where `cached == false`, `archive_url.is_some()`,
 /// and both `vas_storage_name` and `vas_version_id` are non-empty. Entries that
-/// `filter_unchanged_storages` marked as reuse-in-place (`archive_url = None`)
+/// `apply_storage_fingerprint_reuse` marked as reuse-in-place (`archive_url = None`)
 /// are left untouched.
 pub async fn populate_cache(
     manifest: &mut GuestDownloadManifest,


### PR DESCRIPTION
## Summary
- consolidate storage/artifact reuse filtering bookkeeping into a focused runner-side filter state
- rename the private filter entry point to `apply_storage_fingerprint_reuse` and update related comments/log text
- add regression coverage for the broad cleanup path phase order

## Testing
- `cargo test --manifest-path crates/Cargo.toml -p runner filter_unchanged`
- `cargo test --manifest-path crates/Cargo.toml -p runner executor::tests::storage_tests`
- `cargo test --manifest-path crates/Cargo.toml -p runner guest_download_has_work`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets`
- pre-commit hook: `cargo-fmt`, `cargo-doc`, `cargo-clippy`, `commitlint`

Closes #18723
