### PR TITLE
docs(mitm-addon): clarify browser passthrough tradeoff

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -507,7 +507,8 @@ def _is_browser_user_agent(user_agent: str | None) -> bool:
 def _is_browser_passthrough_heuristic(flow: http.HTTPFlow) -> bool:
     # Short-term business passthrough heuristic for browser-originated traffic.
     # This is not trusted browser provenance: any sandbox client can set this
-    # header. Issue #18024 tracks replacing it with a runner-owned signal.
+    # header. The spoofable User-Agent heuristic is currently accepted as a
+    # known tradeoff until runner-owned browser provenance is prioritized again.
     return _is_browser_user_agent(flow.request.headers.get("User-Agent"))
 
 


### PR DESCRIPTION
## Summary

- remove the stale #18024 active-tracker reference from the browser passthrough heuristic comment
- clarify that the spoofable User-Agent heuristic is currently accepted as a known tradeoff
- keep the existing warning that User-Agent is not trusted browser provenance

Closes #18727

## Tests

- `/tmp/ruff-target/bin/ruff check src/mitm_addon.py` from `crates/runner/mitm-addon`
- `/tmp/ruff-target/bin/ruff format --check src/mitm_addon.py` from `crates/runner/mitm-addon`
- `git diff --check`

Note: the first commit attempt failed because the local environment had no `ruff` on `PATH`; I installed Ruff into `/tmp/ruff-target` and reran the commit hook with that temporary path. The hook then passed.
