### PR TITLE
feat: support updating gmail workflow triggers

### DIFF
--- a/turbo/apps/cli/src/commands/zero/workflow/trigger/__tests__/trigger.test.ts
+++ b/turbo/apps/cli/src/commands/zero/workflow/trigger/__tests__/trigger.test.ts
@@ -466,6 +466,106 @@ describe("zero workflow trigger commands", () => {
       );
     });
 
+    it("should update a Gmail new message trigger with text match flags", async () => {
+      const updated = {
+        ...gmailTrigger,
+        eventConfig: {
+          provider: "gmail",
+          event: "new_message",
+          match: {
+            from: { contains: "@example.com" },
+            subject: { doesNotContain: "marketing" },
+          },
+        },
+      };
+      const captured = captureUpdateTrigger(updated);
+
+      await triggerCommand.parseAsync([
+        "node",
+        "cli",
+        "update",
+        TRIGGER_ID,
+        "--from-contains",
+        "@example.com",
+        "--subject-not-contains",
+        "marketing",
+      ]);
+
+      expect(captured.id).toBe(TRIGGER_ID);
+      expect(captured.body).toEqual({
+        eventConfig: {
+          provider: "gmail",
+          event: "new_message",
+          match: {
+            from: { contains: "@example.com" },
+            subject: { doesNotContain: "marketing" },
+          },
+        },
+      });
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain(`Trigger ${TRIGGER_ID} updated`);
+      expect(logCalls).toContain('subject does not contain "marketing"');
+    });
+
+    it("should update a Gmail new message trigger from a config file", async () => {
+      const configPath = writeGmailConfig({
+        match: {
+          body: { containsAny: ["invoice", "receipt"] },
+        },
+      });
+      const captured = captureUpdateTrigger({
+        ...gmailTrigger,
+        eventConfig: {
+          provider: "gmail",
+          event: "new_message",
+          match: {
+            body: { containsAny: ["invoice", "receipt"] },
+          },
+        },
+      });
+
+      await triggerCommand.parseAsync([
+        "node",
+        "cli",
+        "update",
+        TRIGGER_ID,
+        "--config",
+        configPath,
+      ]);
+
+      expect(captured.body).toEqual({
+        eventConfig: {
+          provider: "gmail",
+          event: "new_message",
+          match: {
+            body: { containsAny: ["invoice", "receipt"] },
+          },
+        },
+      });
+    });
+
+    it("should reject mixing schedule and Gmail match options", async () => {
+      await expect(async () => {
+        await triggerCommand.parseAsync([
+          "node",
+          "cli",
+          "update",
+          TRIGGER_ID,
+          "--expr",
+          "0 9 * * *",
+          "--from-contains",
+          "@acme.com",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Use either schedule flags or Gmail match options",
+        ),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
     it("should reject more than one timing flag", async () => {
       await expect(async () => {
         await triggerCommand.parseAsync([

--- a/turbo/apps/cli/src/commands/zero/workflow/trigger/index.ts
+++ b/turbo/apps/cli/src/commands/zero/workflow/trigger/index.ts
@@ -36,7 +36,7 @@ interface AddOptions extends GmailTriggerOptions {
   readonly agent?: string;
 }
 
-interface UpdateOptions {
+interface UpdateOptions extends GmailTriggerOptions {
   readonly expr?: string;
   readonly at?: string;
   readonly every?: string;
@@ -53,7 +53,46 @@ const SCHEDULE_KINDS = ["cron", "once", "loop"] as const;
 const EVENT_KINDS = ["gmail-new-message"] as const;
 const TRIGGER_KINDS = [...SCHEDULE_KINDS, ...EVENT_KINDS] as const;
 const EXACTLY_ONE_FLAG_MESSAGE =
-  "Provide exactly one of --expr (cron), --at (once), --every (loop)";
+  "Provide exactly one of --expr (cron), --at (once), --every (loop), or provide Gmail match options";
+
+function addGmailTriggerOptions(command: Command): Command {
+  return command
+    .option(
+      "--config <path>",
+      "Path to a Gmail new message trigger config JSON",
+    )
+    .option("--from-contains <text>", "Require the From header to contain text")
+    .option(
+      "--from-not-contains <text>",
+      "Require the From header not to contain text",
+    )
+    .option(
+      "--subject-contains <text>",
+      "Require the Subject header to contain text",
+    )
+    .option(
+      "--subject-not-contains <text>",
+      "Require the Subject header not to contain text",
+    )
+    .option(
+      "--body-contains <text>",
+      "Require the message body to contain text",
+    )
+    .option(
+      "--body-not-contains <text>",
+      "Require the message body not to contain text",
+    )
+    .option("--to-contains <text>", "Require the To header to contain text")
+    .option(
+      "--to-not-contains <text>",
+      "Require the To header not to contain text",
+    )
+    .option("--cc-contains <text>", "Require the Cc header to contain text")
+    .option(
+      "--cc-not-contains <text>",
+      "Require the Cc header not to contain text",
+    );
+}
 
 function timezoneOrUtc(timezone: string | undefined): string {
   return timezone ?? "UTC";
@@ -259,6 +298,13 @@ function buildUpdate(options: UpdateOptions): ZeroWorkflowTriggerUpdateRequest {
       return value !== undefined;
     },
   ).length;
+  const hasGmailOptions = hasGmailTriggerOptions(options);
+  if (hasGmailOptions) {
+    if (flagCount > 0 || options.timezone !== undefined) {
+      throw new Error("Use either schedule flags or Gmail match options");
+    }
+    return { eventConfig: buildGmailNewMessageEventConfig(options) };
+  }
   if (flagCount !== 1) {
     throw new Error(EXACTLY_ONE_FLAG_MESSAGE);
   }
@@ -301,44 +347,23 @@ async function resolveWorkflowId(
   return matches[0]!.id;
 }
 
-const addCommand = new Command()
-  .name("add")
-  .description("Add a trigger to a workflow")
-  .argument("<workflow>", "Workflow ID or name")
-  .argument("<kind>", `Trigger type: ${TRIGGER_KINDS.join(" | ")}`)
-  .option("--expr <expression>", 'Cron expression for kind "cron"')
-  .option("--at <iso-time>", 'Fire time for kind "once"')
-  .option("--every <duration>", 'Interval for kind "loop" (e.g. 15m, 1h, 90s)')
-  .option("-z, --timezone <tz>", "IANA timezone for cron/once (default: UTC)")
-  .option("--config <path>", "Path to a Gmail new message trigger config JSON")
-  .option("--from-contains <text>", "Require the From header to contain text")
-  .option(
-    "--from-not-contains <text>",
-    "Require the From header not to contain text",
-  )
-  .option(
-    "--subject-contains <text>",
-    "Require the Subject header to contain text",
-  )
-  .option(
-    "--subject-not-contains <text>",
-    "Require the Subject header not to contain text",
-  )
-  .option("--body-contains <text>", "Require the message body to contain text")
-  .option(
-    "--body-not-contains <text>",
-    "Require the message body not to contain text",
-  )
-  .option("--to-contains <text>", "Require the To header to contain text")
-  .option(
-    "--to-not-contains <text>",
-    "Require the To header not to contain text",
-  )
-  .option("--cc-contains <text>", "Require the Cc header to contain text")
-  .option(
-    "--cc-not-contains <text>",
-    "Require the Cc header not to contain text",
-  )
+const addCommand = addGmailTriggerOptions(
+  new Command()
+    .name("add")
+    .description("Add a trigger to a workflow")
+    .argument("<workflow>", "Workflow ID or name")
+    .argument("<kind>", `Trigger type: ${TRIGGER_KINDS.join(" | ")}`)
+    .option("--expr <expression>", 'Cron expression for kind "cron"')
+    .option("--at <iso-time>", 'Fire time for kind "once"')
+    .option(
+      "--every <duration>",
+      'Interval for kind "loop" (e.g. 15m, 1h, 90s)',
+    )
+    .option(
+      "-z, --timezone <tz>",
+      "IANA timezone for cron/once (default: UTC)",
+    ),
+)
   .option("--agent <id>", "Agent ID for resolving a workflow name")
   .addHelpText(
     "after",
@@ -378,21 +403,25 @@ Notes:
     ),
   );
 
-const updateCommand = new Command()
-  .name("update")
-  .description("Replace a workflow trigger's schedule")
-  .argument("<trigger>", "Workflow trigger ID")
-  .option("--expr <expression>", 'New cron schedule (e.g. "0 9 * * *")')
-  .option("--at <iso-time>", 'New one-time fire (e.g. "2026-06-10T09:00")')
-  .option("--every <duration>", "New loop interval (e.g. 15m, 1h, 90s)")
-  .option("-z, --timezone <tz>", "IANA timezone for --expr / --at")
+const updateCommand = addGmailTriggerOptions(
+  new Command()
+    .name("update")
+    .description("Replace a workflow trigger's schedule or Gmail match config")
+    .argument("<trigger>", "Workflow trigger ID")
+    .option("--expr <expression>", 'New cron schedule (e.g. "0 9 * * *")')
+    .option("--at <iso-time>", 'New one-time fire (e.g. "2026-06-10T09:00")')
+    .option("--every <duration>", "New loop interval (e.g. 15m, 1h, 90s)")
+    .option("-z, --timezone <tz>", "IANA timezone for --expr / --at"),
+)
   .addHelpText(
     "after",
     `
 Examples:
   zero workflow trigger update 22222222-2222-4222-8222-222222222222 --expr "0 9 * * *" -z Asia/Shanghai
   zero workflow trigger update 22222222-2222-4222-8222-222222222222 --at "2026-06-10T09:00" -z UTC
-  zero workflow trigger update 22222222-2222-4222-8222-222222222222 --every 10m`,
+  zero workflow trigger update 22222222-2222-4222-8222-222222222222 --every 10m
+  zero workflow trigger update 22222222-2222-4222-8222-222222222222 --from-contains "@example.com"
+  zero workflow trigger update 22222222-2222-4222-8222-222222222222 --config ./gmail-trigger.json`,
   )
   .action(
     withErrorHandler(async (id: string, options: UpdateOptions) => {

--- a/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
+++ b/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
@@ -33,6 +33,7 @@ const internalWorkflowReload$ = state(0);
 
 const internalSelectedFilePath$ = state<string | null>(null);
 const internalWorkflowSearch$ = state("");
+const internalEditingGmailTriggerId$ = state<string | null>(null);
 
 export const workflowSearch$ = computed((get) => {
   return get(internalWorkflowSearch$);
@@ -41,6 +42,16 @@ export const workflowSearch$ = computed((get) => {
 export const setWorkflowSearch$ = command(({ set }, value: string) => {
   set(internalWorkflowSearch$, value);
 });
+
+export const editingGmailTriggerId$ = computed((get) => {
+  return get(internalEditingGmailTriggerId$);
+});
+
+export const setEditingGmailTriggerId$ = command(
+  ({ set }, triggerId: string | null) => {
+    set(internalEditingGmailTriggerId$, triggerId);
+  },
+);
 
 function matchesWorkflowSearch(
   workflow: ZeroWorkflowSummary,

--- a/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
+++ b/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
@@ -353,6 +353,29 @@ export const createWorkflowGmailNewMessageTrigger$ = command(
   },
 );
 
+export const updateWorkflowGmailNewMessageTrigger$ = command(
+  async (
+    { get, set },
+    input: {
+      readonly triggerId: string;
+      readonly eventConfig: GmailNewMessageEventConfig;
+    },
+    signal: AbortSignal,
+  ) => {
+    const client = get(zeroClient$)(zeroWorkflowTriggersContract);
+    await accept(
+      client.update({
+        params: { id: input.triggerId },
+        body: { eventConfig: input.eventConfig },
+        fetchOptions: { signal },
+      }),
+      [200],
+    );
+    signal.throwIfAborted();
+    set(reloadWorkflows$);
+  },
+);
+
 export const setWorkflowTriggerEnabled$ = command(
   async (
     { get, set },
@@ -375,7 +398,7 @@ export const setWorkflowTriggerEnabled$ = command(
   },
 );
 
-export const deleteWorkflowScheduleTrigger$ = command(
+export const deleteWorkflowTrigger$ = command(
   async ({ get, set }, triggerId: string, signal: AbortSignal) => {
     const client = get(zeroClient$)(zeroWorkflowTriggersContract);
     await accept(
@@ -387,7 +410,7 @@ export const deleteWorkflowScheduleTrigger$ = command(
   },
 );
 
-export const runWorkflowScheduleTrigger$ = command(
+export const runWorkflowTrigger$ = command(
   async ({ get }, triggerId: string, signal: AbortSignal) => {
     const client = get(zeroClient$)(zeroWorkflowTriggersContract);
     await accept(

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -4,6 +4,7 @@ import {
   zeroWorkflowsDetailContract,
   zeroWorkflowTriggersContract,
   type ZeroWorkflowTriggerCreateRequest,
+  type ZeroWorkflowTriggerUpdateRequest,
   type ZeroWorkflowUpdateRequest,
   type ZeroWorkflowDetailResponse,
   type ZeroWorkflowSummary,
@@ -236,6 +237,29 @@ function mockCreateWorkflowTrigger(
   );
 }
 
+function mockUpdateWorkflowTrigger(
+  onUpdate: (triggerId: string, body: ZeroWorkflowTriggerUpdateRequest) => void,
+): void {
+  context.mocks.api(
+    zeroWorkflowTriggersContract.update,
+    ({ params, body, respond }) => {
+      onUpdate(params.id, body);
+      if ("eventConfig" in body) {
+        return respond(200, {
+          ...gmailWorkflowTrigger(),
+          id: params.id,
+          eventConfig: body.eventConfig,
+        });
+      }
+      return respond(200, {
+        ...weekdayWorkflowTrigger(),
+        id: params.id,
+        schedule: body.schedule,
+      });
+    },
+  );
+}
+
 describe("workflows index page", () => {
   it("shows every visible workflow with its agent and links into the detail page", async () => {
     mockWorkflowApis([salesResearch(), opsPlaybook()]);
@@ -353,6 +377,80 @@ describe("workflow detail page", () => {
           match: {
             from: { contains: "@acme.com" },
             subject: { doesNotContain: "newsletter" },
+          },
+        },
+      });
+    });
+  });
+
+  it("updates a Gmail new message trigger with text match rules", async () => {
+    const updateBodies: {
+      readonly triggerId: string;
+      readonly body: ZeroWorkflowTriggerUpdateRequest;
+    }[] = [];
+    const workflow = {
+      ...salesResearch(),
+      triggers: [
+        {
+          ...gmailWorkflowTrigger(),
+          eventConfig: {
+            provider: "gmail",
+            event: "new_message",
+            match: {
+              from: { containsAny: ["@vip.example"] },
+              subject: { doesNotContain: "newsletter" },
+              hasAttachment: true,
+            },
+          },
+        } satisfies WorkflowGmailNewMessageTriggerSummary,
+      ],
+    };
+    mockWorkflowApis([workflow]);
+    mockUpdateWorkflowTrigger((triggerId, body) => {
+      updateBodies.push({ triggerId, body });
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/workflows/${SALES_WORKFLOW_ID}`,
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Gmail new message").length).toBeGreaterThan(
+        0,
+      );
+    });
+    click(screen.getByRole("button", { name: "Edit match" }));
+
+    const updateTriggerForm = screen.getByRole("form", {
+      name: "Update Gmail new message trigger",
+    });
+    await fill(
+      within(updateTriggerForm).getByLabelText("From contains"),
+      "@acme.com",
+    );
+    await fill(
+      within(updateTriggerForm).getByLabelText("Body contains"),
+      "invoice",
+    );
+    fireEvent.submit(updateTriggerForm);
+
+    await waitFor(() => {
+      expect(updateBodies.at(-1)).toStrictEqual({
+        triggerId: GMAIL_TRIGGER_ID,
+        body: {
+          eventConfig: {
+            provider: "gmail",
+            event: "new_message",
+            match: {
+              from: {
+                contains: "@acme.com",
+                containsAny: ["@vip.example"],
+              },
+              subject: { doesNotContain: "newsletter" },
+              body: { contains: "invoice" },
+              hasAttachment: true,
+            },
           },
         },
       });

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -420,7 +420,7 @@ describe("workflow detail page", () => {
         0,
       );
     });
-    click(screen.getByRole("button", { name: "Edit match" }));
+    click(screen.getByText("Edit match"));
 
     const updateTriggerForm = screen.getByRole("form", {
       name: "Update Gmail new message trigger",

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -1,6 +1,7 @@
 // Agent-scoped workflow detail at /agents/:agentId/workflows/:workflowId. Hosts
 // the instruction editor, supplementary file manager (SKILL.md is never shown),
 // triggers, visibility controls, metadata editing, run-once, copy, and delete.
+import { useState } from "react";
 import { useGet, useLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import type {
@@ -38,14 +39,15 @@ import {
   createWorkflowGmailNewMessageTrigger$,
   createWorkflowScheduleTrigger$,
   currentWorkflowId$,
-  deleteWorkflow$,
-  deleteWorkflowScheduleTrigger$,
   copyWorkflow$,
+  deleteWorkflow$,
+  deleteWorkflowTrigger$,
   runWorkflow$,
-  runWorkflowScheduleTrigger$,
+  runWorkflowTrigger$,
   selectedWorkflowFilePath$,
   setSelectedWorkflowFilePath$,
   setWorkflowTriggerEnabled$,
+  updateWorkflowGmailNewMessageTrigger$,
   updateWorkflow$,
   workflowDetail,
 } from "../../signals/workflows-page/workflows-signals.ts";
@@ -668,19 +670,37 @@ function formTextValue(form: FormData, name: string): string | undefined {
 
 function buildGmailNewMessageEventConfig(
   form: FormData,
+  baseConfig?: GmailNewMessageEventConfig,
 ): GmailNewMessageEventConfig {
+  const baseMatch = baseConfig?.match;
   const match: GmailMatchRules = {};
+  if (baseMatch?.snippet) {
+    match.snippet = baseMatch.snippet;
+  }
+  if (baseMatch?.labels) {
+    match.labels = baseMatch.labels;
+  }
+  if (baseMatch?.hasAttachment !== undefined) {
+    match.hasAttachment = baseMatch.hasAttachment;
+  }
   for (const { field } of GMAIL_TEXT_FIELDS) {
+    const existing = baseMatch?.[field];
     const contains = formTextValue(form, `${field}Contains`);
     const doesNotContain = formTextValue(form, `${field}DoesNotContain`);
-    if (contains || doesNotContain) {
-      const matcher: { contains?: string; doesNotContain?: string } = {};
-      if (contains) {
-        matcher.contains = contains;
-      }
-      if (doesNotContain) {
-        matcher.doesNotContain = doesNotContain;
-      }
+    const matcher: GmailTextMatcher = {};
+    if (existing?.containsAny) {
+      matcher.containsAny = existing.containsAny;
+    }
+    if (existing?.doesNotContainAny) {
+      matcher.doesNotContainAny = existing.doesNotContainAny;
+    }
+    if (contains) {
+      matcher.contains = contains;
+    }
+    if (doesNotContain) {
+      matcher.doesNotContain = doesNotContain;
+    }
+    if (Object.keys(matcher).length > 0) {
       match[field] = matcher;
     }
   }
@@ -736,6 +756,14 @@ function formatGmailMatchSummary(config: GmailNewMessageEventConfig): string {
     parts.push("custom match rules");
   }
   return parts.length > 0 ? parts.join("; ") : "all inbound messages";
+}
+
+function gmailMatcherDefaultValue(
+  config: GmailNewMessageEventConfig,
+  field: GmailTextField,
+  key: "contains" | "doesNotContain",
+): string {
+  return config.match?.[field]?.[key] ?? "";
 }
 
 function TriggersSection({
@@ -961,14 +989,15 @@ function TriggerRow({
   readonly trigger: ZeroWorkflowTriggerSummary;
   readonly canManage: boolean;
 }) {
+  const [editingMatch, setEditingMatch] = useState(false);
   const pageSignal = useGet(pageSignal$);
   const [enabledLoadable, setEnabled] = useLoadableSet(
     setWorkflowTriggerEnabled$,
   );
   const [deleteLoadable, deleteTrigger] = useLoadableSet(
-    deleteWorkflowScheduleTrigger$,
+    deleteWorkflowTrigger$,
   );
-  const [runLoadable, runTrigger] = useLoadableSet(runWorkflowScheduleTrigger$);
+  const [runLoadable, runTrigger] = useLoadableSet(runWorkflowTrigger$);
   const busy =
     enabledLoadable.state === "loading" ||
     deleteLoadable.state === "loading" ||
@@ -1019,7 +1048,7 @@ function TriggerRow({
             Open thread
           </Link>
         ) : null}
-        {canManage && trigger.kind === "schedule" ? (
+        {canManage ? (
           <div className="mt-1 flex items-center gap-2">
             <button
               type="button"
@@ -1031,6 +1060,20 @@ function TriggerRow({
             >
               Test run
             </button>
+            {trigger.kind === "event" && !editingMatch ? (
+              <button
+                type="button"
+                disabled={busy}
+                className="text-xs text-muted-foreground transition-colors hover:text-foreground disabled:opacity-60"
+                onClick={() => {
+                  setEditingMatch((value) => {
+                    return !value;
+                  });
+                }}
+              >
+                Edit match
+              </button>
+            ) : null}
             <button
               type="button"
               disabled={busy}
@@ -1062,8 +1105,114 @@ function TriggerRow({
             </button>
           </div>
         ) : null}
+        {canManage && trigger.kind === "event" && editingMatch ? (
+          <UpdateGmailNewMessageTriggerForm
+            trigger={trigger}
+            onCancel={() => {
+              setEditingMatch(false);
+            }}
+          />
+        ) : null}
       </div>
     </div>
+  );
+}
+
+function UpdateGmailNewMessageTriggerForm({
+  trigger,
+  onCancel,
+}: {
+  readonly trigger: Extract<ZeroWorkflowTriggerSummary, { kind: "event" }>;
+  readonly onCancel: () => void;
+}) {
+  const pageSignal = useGet(pageSignal$);
+  const [updateLoadable, updateGmailTrigger] = useLoadableSet(
+    updateWorkflowGmailNewMessageTrigger$,
+  );
+  const saving = updateLoadable.state === "loading";
+
+  return (
+    <form
+      aria-label="Update Gmail new message trigger"
+      className="mt-2 rounded-md border border-border/60 bg-background/70 p-2"
+      onSubmit={(event) => {
+        event.preventDefault();
+        const form = new FormData(event.currentTarget);
+        detach(
+          updateGmailTrigger(
+            {
+              triggerId: trigger.id,
+              eventConfig: buildGmailNewMessageEventConfig(
+                form,
+                trigger.eventConfig,
+              ),
+            },
+            pageSignal,
+          ).then(() => {
+            onCancel();
+          }),
+          Reason.DomCallback,
+        );
+      }}
+    >
+      <div className="grid gap-2 sm:grid-cols-2">
+        {GMAIL_TEXT_FIELDS.map(({ field, label }) => {
+          return (
+            <div key={field} className="grid grid-cols-2 gap-1.5">
+              <input
+                name={`${field}Contains`}
+                aria-label={`${label} contains`}
+                defaultValue={gmailMatcherDefaultValue(
+                  trigger.eventConfig,
+                  field,
+                  "contains",
+                )}
+                disabled={saving}
+                placeholder={`${label} contains`}
+                className={TRIGGER_FIELD_CLASS}
+              />
+              <input
+                name={`${field}DoesNotContain`}
+                aria-label={`${label} does not contain`}
+                defaultValue={gmailMatcherDefaultValue(
+                  trigger.eventConfig,
+                  field,
+                  "doesNotContain",
+                )}
+                disabled={saving}
+                placeholder={`${label} does not contain`}
+                className={TRIGGER_FIELD_CLASS}
+              />
+            </div>
+          );
+        })}
+      </div>
+      <div className="mt-2 flex items-center gap-2">
+        <button
+          type="submit"
+          disabled={saving}
+          className={cn(
+            "zero-btn-morandi inline-flex h-8 shrink-0 items-center justify-center gap-1.5 rounded-md px-2 text-xs",
+            saving ? "cursor-not-allowed opacity-60" : "",
+          )}
+        >
+          {saving ? (
+            <IconLoader2 size={13} className="animate-spin" />
+          ) : (
+            <IconMail size={13} stroke={1.5} />
+          )}
+          <span>Save match</span>
+        </button>
+        <button
+          type="button"
+          disabled={saving}
+          className="text-xs text-muted-foreground transition-colors hover:text-foreground disabled:opacity-60"
+          onClick={onCancel}
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
   );
 }
 

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -1,7 +1,6 @@
 // Agent-scoped workflow detail at /agents/:agentId/workflows/:workflowId. Hosts
 // the instruction editor, supplementary file manager (SKILL.md is never shown),
 // triggers, visibility controls, metadata editing, run-once, copy, and delete.
-import { useState } from "react";
 import { useGet, useLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import type {
@@ -42,9 +41,11 @@ import {
   copyWorkflow$,
   deleteWorkflow$,
   deleteWorkflowTrigger$,
+  editingGmailTriggerId$,
   runWorkflow$,
   runWorkflowTrigger$,
   selectedWorkflowFilePath$,
+  setEditingGmailTriggerId$,
   setSelectedWorkflowFilePath$,
   setWorkflowTriggerEnabled$,
   updateWorkflowGmailNewMessageTrigger$,
@@ -989,19 +990,9 @@ function TriggerRow({
   readonly trigger: ZeroWorkflowTriggerSummary;
   readonly canManage: boolean;
 }) {
-  const [editingMatch, setEditingMatch] = useState(false);
-  const pageSignal = useGet(pageSignal$);
-  const [enabledLoadable, setEnabled] = useLoadableSet(
-    setWorkflowTriggerEnabled$,
-  );
-  const [deleteLoadable, deleteTrigger] = useLoadableSet(
-    deleteWorkflowTrigger$,
-  );
-  const [runLoadable, runTrigger] = useLoadableSet(runWorkflowTrigger$);
-  const busy =
-    enabledLoadable.state === "loading" ||
-    deleteLoadable.state === "loading" ||
-    runLoadable.state === "loading";
+  const editingTriggerId = useGet(editingGmailTriggerId$);
+  const setEditingTriggerId = useSet(setEditingGmailTriggerId$);
+  const editingMatch = editingTriggerId === trigger.id;
   const title =
     trigger.kind === "schedule" ? trigger.scheduleSummary : "Gmail new message";
   const matchSummary =
@@ -1049,71 +1040,92 @@ function TriggerRow({
           </Link>
         ) : null}
         {canManage ? (
-          <div className="mt-1 flex items-center gap-2">
-            <button
-              type="button"
-              disabled={busy}
-              className="text-xs text-muted-foreground transition-colors hover:text-foreground disabled:opacity-60"
-              onClick={() => {
-                detach(runTrigger(trigger.id, pageSignal), Reason.DomCallback);
-              }}
-            >
-              Test run
-            </button>
-            {trigger.kind === "event" && !editingMatch ? (
-              <button
-                type="button"
-                disabled={busy}
-                className="text-xs text-muted-foreground transition-colors hover:text-foreground disabled:opacity-60"
-                onClick={() => {
-                  setEditingMatch((value) => {
-                    return !value;
-                  });
-                }}
-              >
-                Edit match
-              </button>
-            ) : null}
-            <button
-              type="button"
-              disabled={busy}
-              className="text-xs text-muted-foreground transition-colors hover:text-foreground disabled:opacity-60"
-              onClick={() => {
-                detach(
-                  setEnabled(
-                    { triggerId: trigger.id, enabled: !trigger.enabled },
-                    pageSignal,
-                  ),
-                  Reason.DomCallback,
-                );
-              }}
-            >
-              {trigger.enabled ? "Pause" : "Resume"}
-            </button>
-            <button
-              type="button"
-              disabled={busy}
-              className="text-xs text-destructive/80 transition-colors hover:text-destructive disabled:opacity-60"
-              onClick={() => {
-                detach(
-                  deleteTrigger(trigger.id, pageSignal),
-                  Reason.DomCallback,
-                );
-              }}
-            >
-              Delete
-            </button>
-          </div>
+          <TriggerControls trigger={trigger} editingMatch={editingMatch} />
         ) : null}
         {canManage && trigger.kind === "event" && editingMatch ? (
           <UpdateGmailNewMessageTriggerForm
             trigger={trigger}
             onCancel={() => {
-              setEditingMatch(false);
+              setEditingTriggerId(null);
             }}
           />
         ) : null}
       </div>
+    </div>
+  );
+}
+
+function TriggerControls({
+  trigger,
+  editingMatch,
+}: {
+  readonly trigger: ZeroWorkflowTriggerSummary;
+  readonly editingMatch: boolean;
+}) {
+  const pageSignal = useGet(pageSignal$);
+  const setEditingTriggerId = useSet(setEditingGmailTriggerId$);
+  const [enabledLoadable, setEnabled] = useLoadableSet(
+    setWorkflowTriggerEnabled$,
+  );
+  const [deleteLoadable, deleteTrigger] = useLoadableSet(
+    deleteWorkflowTrigger$,
+  );
+  const [runLoadable, runTrigger] = useLoadableSet(runWorkflowTrigger$);
+  const busy =
+    enabledLoadable.state === "loading" ||
+    deleteLoadable.state === "loading" ||
+    runLoadable.state === "loading";
+
+  return (
+    <div className="mt-1 flex items-center gap-2">
+      <button
+        type="button"
+        disabled={busy}
+        className="text-xs text-muted-foreground transition-colors hover:text-foreground disabled:opacity-60"
+        onClick={() => {
+          detach(runTrigger(trigger.id, pageSignal), Reason.DomCallback);
+        }}
+      >
+        Test run
+      </button>
+      {trigger.kind === "event" && !editingMatch ? (
+        <button
+          type="button"
+          disabled={busy}
+          className="text-xs text-muted-foreground transition-colors hover:text-foreground disabled:opacity-60"
+          onClick={() => {
+            setEditingTriggerId(trigger.id);
+          }}
+        >
+          Edit match
+        </button>
+      ) : null}
+      <button
+        type="button"
+        disabled={busy}
+        className="text-xs text-muted-foreground transition-colors hover:text-foreground disabled:opacity-60"
+        onClick={() => {
+          detach(
+            setEnabled(
+              { triggerId: trigger.id, enabled: !trigger.enabled },
+              pageSignal,
+            ),
+            Reason.DomCallback,
+          );
+        }}
+      >
+        {trigger.enabled ? "Pause" : "Resume"}
+      </button>
+      <button
+        type="button"
+        disabled={busy}
+        className="text-xs text-destructive/80 transition-colors hover:text-destructive disabled:opacity-60"
+        onClick={() => {
+          detach(deleteTrigger(trigger.id, pageSignal), Reason.DomCallback);
+        }}
+      >
+        Delete
+      </button>
     </div>
   );
 }
@@ -1139,18 +1151,19 @@ function UpdateGmailNewMessageTriggerForm({
         event.preventDefault();
         const form = new FormData(event.currentTarget);
         detach(
-          updateGmailTrigger(
-            {
-              triggerId: trigger.id,
-              eventConfig: buildGmailNewMessageEventConfig(
-                form,
-                trigger.eventConfig,
-              ),
-            },
-            pageSignal,
-          ).then(() => {
+          (async () => {
+            await updateGmailTrigger(
+              {
+                triggerId: trigger.id,
+                eventConfig: buildGmailNewMessageEventConfig(
+                  form,
+                  trigger.eventConfig,
+                ),
+              },
+              pageSignal,
+            );
             onCancel();
-          }),
+          })(),
           Reason.DomCallback,
         );
       }}

--- a/turbo/packages/api-contracts/src/contracts/zero-workflows.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-workflows.ts
@@ -588,7 +588,7 @@ export const zeroWorkflowTriggersContract = c.router({
       404: apiErrorSchema,
       409: apiErrorSchema,
     },
-    summary: "Create a schedule trigger on a workflow",
+    summary: "Create a trigger on a workflow",
   },
   get: {
     method: "GET",
@@ -601,7 +601,7 @@ export const zeroWorkflowTriggersContract = c.router({
       403: apiErrorSchema,
       404: apiErrorSchema,
     },
-    summary: "Get a workflow schedule trigger",
+    summary: "Get a workflow trigger",
   },
   update: {
     method: "PATCH",
@@ -617,7 +617,7 @@ export const zeroWorkflowTriggersContract = c.router({
       404: apiErrorSchema,
       409: apiErrorSchema,
     },
-    summary: "Update a workflow schedule trigger",
+    summary: "Update a workflow trigger",
   },
   delete: {
     method: "DELETE",
@@ -631,7 +631,7 @@ export const zeroWorkflowTriggersContract = c.router({
       403: apiErrorSchema,
       404: apiErrorSchema,
     },
-    summary: "Delete a workflow schedule trigger",
+    summary: "Delete a workflow trigger",
   },
   enable: {
     method: "POST",
@@ -646,7 +646,7 @@ export const zeroWorkflowTriggersContract = c.router({
       404: apiErrorSchema,
       409: apiErrorSchema,
     },
-    summary: "Enable a workflow schedule trigger",
+    summary: "Enable a workflow trigger",
   },
   disable: {
     method: "POST",
@@ -660,7 +660,7 @@ export const zeroWorkflowTriggersContract = c.router({
       403: apiErrorSchema,
       404: apiErrorSchema,
     },
-    summary: "Disable a workflow schedule trigger",
+    summary: "Disable a workflow trigger",
   },
   run: {
     method: "POST",
@@ -675,7 +675,7 @@ export const zeroWorkflowTriggersContract = c.router({
       404: apiErrorSchema,
       409: apiErrorSchema,
     },
-    summary: "Fire a one-off test run of a workflow schedule trigger",
+    summary: "Fire a one-off test run of a workflow trigger",
   },
 });
 


### PR DESCRIPTION
## Summary

- Add Gmail event trigger match config updates to the `zero workflow trigger update` CLI command
- Add inline Gmail match editing on the workflow detail page while preserving advanced existing match rules
- Generalize workflow trigger API summaries away from schedule-only wording and cover CLI/page update flows with tests

## Verification

- `npx prettier@3.6.2 --write ...`
- `git diff --check`
- Targeted Vitest and package check-types could not run locally because this runtime has no workspace `node_modules` / `vitest` / `tsc` installed; relying on PR pipeline for full validation
