### PR TITLE
fix: bound zero-usage websocket sources

### DIFF
--- a/crates/runner/mitm-addon/src/flow_metadata_keys.py
+++ b/crates/runner/mitm-addon/src/flow_metadata_keys.py
@@ -125,7 +125,8 @@ Model-provider usage
   usage extraction and read by model usage-event and observation reporters.
   Entries may be removed before ``websocket_end()`` once a terminal WebSocket
   usage frame is accepted into the source-preserving usage buffer or the source
-  has no future reporting path.
+  has no future reporting path. Zero-only entries that only preserve model hints
+  for a later same-response-id frame are retained with a small per-flow bound.
 - ``MODEL_USAGE_PROVIDER``: optional ``str`` model id from registry VM info.
   Read by model-provider usage observability and reported-model selection.
 - ``MODEL_JSON_USAGE_FINALIZED``: ``bool`` written when JSON usage finalization

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -32,6 +32,7 @@ _HTTP_STATUS_SWITCHING_PROTOCOLS = 101
 _MODEL_JSON_USAGE_FINISH = "model_json_usage_finish"
 _MODEL_SSE_USAGE_FINISH = "model_sse_usage_finish"
 _MODEL_WEBSOCKET_USAGE_ENABLED = "model_websocket_usage_enabled"
+_MODEL_WEBSOCKET_ZERO_USAGE_SOURCE_LIMIT = 64
 _CONNECTOR_RESPONSE_FINISH = "connector_response_finish"
 _RESPONSE_STREAM_CALLBACK = "_vm0_response_stream_callback"
 
@@ -373,6 +374,8 @@ def feed_model_websocket_usage(flow: http.HTTPFlow, content: bytes | str) -> Non
         # do not need to stay in per-flow metadata until websocket_end/error.
         if source_disposition == "release":
             usage_sources.pop(message_id, None)
+        else:
+            _retain_zero_usage_websocket_source(flow, usage_sources, message_id, usage_target)
         return
 
     usage_target = flow.metadata.get(metadata_keys.MODEL_PROVIDER_USAGE)
@@ -380,6 +383,44 @@ def feed_model_websocket_usage(flow: http.HTTPFlow, content: bytes | str) -> Non
         usage_target = {}
         flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = usage_target
     usage.merge_openai_responses_usage_result(usage_target, usage_result)
+
+
+def _retain_zero_usage_websocket_source(
+    flow: http.HTTPFlow,
+    usage_sources: dict,
+    message_id: str,
+    source_usage: dict,
+) -> None:
+    if usage.has_positive_model_provider_usage(source_usage):
+        return
+    if _string_or_none(source_usage.get("model")) is None:
+        usage_sources.pop(message_id, None)
+        return
+    if _string_or_none(flow.metadata.get(metadata_keys.MODEL_USAGE_PROVIDER)) is not None:
+        usage_sources.pop(message_id, None)
+        return
+
+    zero_usage_source_ids = [
+        source_message_id
+        for source_message_id, retained_source_usage in usage_sources.items()
+        if (
+            isinstance(source_message_id, str)
+            and isinstance(retained_source_usage, dict)
+            and not usage.has_positive_model_provider_usage(retained_source_usage)
+            and _string_or_none(retained_source_usage.get("model")) is not None
+        )
+    ]
+    over_limit = len(zero_usage_source_ids) - _MODEL_WEBSOCKET_ZERO_USAGE_SOURCE_LIMIT
+    if over_limit <= 0:
+        return
+    for source_message_id in zero_usage_source_ids[:over_limit]:
+        usage_sources.pop(source_message_id, None)
+
+
+def _string_or_none(value: object) -> str | None:
+    if not isinstance(value, str) or not value:
+        return None
+    return value
 
 
 def finalize_connector_response_state(flow: http.HTTPFlow) -> None:

--- a/crates/runner/mitm-addon/src/usage/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/__init__.py
@@ -53,6 +53,7 @@ from .openai_responses import (
 )
 from .providers.connectors import create_connector_response_parser, report_connector_usage
 from .providers.model_provider import (
+    has_positive_model_provider_usage,
     is_model_provider_usage_observable,
     report_model_provider_usage,
     report_model_provider_usage_observation,
@@ -79,6 +80,7 @@ __all__ = [
     "extract_openai_responses_usage_from_json",
     "extract_openai_responses_usage_with_error_from_json",
     "flush_usage_events",
+    "has_positive_model_provider_usage",
     "increment_in_flight_flows",
     "is_model_provider_usage_observable",
     "merge_openai_responses_usage_result",

--- a/crates/runner/mitm-addon/src/usage/providers/model_provider.py
+++ b/crates/runner/mitm-addon/src/usage/providers/model_provider.py
@@ -65,6 +65,11 @@ def is_model_provider_usage_observable(flow: http.HTTPFlow) -> bool:
     )
 
 
+def has_positive_model_provider_usage(source_usage: dict) -> bool:
+    """Return whether normalized model-provider usage contains billable quantity."""
+    return any(_is_positive_int(source_usage.get(category)) for category in MODEL_USAGE_CATEGORIES)
+
+
 def report_model_provider_usage(flow: http.HTTPFlow, run_id: str) -> bool:
     """Buffer billable token usage for model-provider responses if available.
 

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
@@ -12,6 +12,7 @@ from mitmproxy.test import tutils
 
 import flow_metadata_keys as metadata_keys
 import mitm_addon
+import response_streaming
 import usage
 from tests.jsonl_log_helpers import jsonl_exists_after_flush, read_jsonl_entries_after_flush
 from tests.model_provider_websocket_helpers import (
@@ -81,6 +82,21 @@ def _sum_quantities_by_category(events: list[dict]) -> dict[str, int]:
         category = event["category"]
         quantities[category] = quantities.get(category, 0) + event["quantity"]
     return quantities
+
+
+def _openai_websocket_zero_usage_frame(response_id: str, *, model: str | None = "gpt-5.5") -> bytes:
+    response: dict = {
+        "id": response_id,
+        "usage": {"input_tokens": 0, "output_tokens": 0},
+    }
+    if model is not None:
+        response["model"] = model
+    return json.dumps(
+        {
+            "type": "response.completed",
+            "response": response,
+        }
+    ).encode()
 
 
 class TestModelProviderWebSocketUsage:
@@ -396,6 +412,106 @@ class TestModelProviderWebSocketUsage:
         } == {
             ("gpt-5.5", "tokens.input"): 20,
             ("gpt-5.5", "tokens.output"): 12,
+        }
+
+    def test_model_websocket_zero_frame_without_model_releases_source(self, tmp_path, real_flow):
+        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        mitm_addon.responseheaders(flow)
+
+        with self._usage_webhook_api() as webhook:
+            _feed_websocket_server_message(
+                flow,
+                _openai_websocket_zero_usage_frame("resp_ws_zero_no_model", model=None),
+            )
+            usage.flush_usage_events(trigger="test")
+
+        assert webhook.request_count == 0
+        assert _model_websocket_usage_sources(flow) == {}
+
+    def test_model_websocket_zero_frame_with_flow_model_releases_source(self, tmp_path, real_flow):
+        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "gpt-flow-model"
+        mitm_addon.responseheaders(flow)
+
+        with self._usage_webhook_api() as webhook:
+            _feed_websocket_server_message(
+                flow,
+                _openai_websocket_zero_usage_frame(
+                    "resp_ws_zero_flow_model", model="gpt-frame-model"
+                ),
+            )
+            usage.flush_usage_events(trigger="test")
+
+        assert webhook.request_count == 0
+        assert _model_websocket_usage_sources(flow) == {}
+
+    def test_model_websocket_zero_frames_are_bounded(self, tmp_path, real_flow):
+        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        mitm_addon.responseheaders(flow)
+
+        with self._usage_webhook_api() as webhook:
+            for index in range(70):
+                _feed_websocket_server_message(
+                    flow,
+                    _openai_websocket_zero_usage_frame(
+                        f"resp_ws_zero_{index}", model=f"gpt-zero-{index}"
+                    ),
+                )
+            usage.flush_usage_events(trigger="test")
+
+        assert webhook.request_count == 0
+        usage_sources = _model_websocket_usage_sources(flow)
+        assert len(usage_sources) <= response_streaming._MODEL_WEBSOCKET_ZERO_USAGE_SOURCE_LIMIT
+        assert "resp_ws_zero_0" not in usage_sources
+        assert "resp_ws_zero_69" in usage_sources
+
+    def test_model_websocket_evicted_zero_hint_still_reports_later_positive_usage(
+        self, tmp_path, real_flow
+    ):
+        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        mitm_addon.responseheaders(flow)
+
+        with self._usage_webhook_api() as webhook:
+            for index in range(70):
+                _feed_websocket_server_message(
+                    flow,
+                    _openai_websocket_zero_usage_frame(
+                        f"resp_ws_zero_{index}", model=f"gpt-zero-{index}"
+                    ),
+                )
+
+            assert "resp_ws_zero_0" not in _model_websocket_usage_sources(flow)
+
+            _feed_websocket_server_message(
+                flow,
+                json.dumps(
+                    {
+                        "type": "response.done",
+                        "response": {
+                            "id": "resp_ws_zero_0",
+                            "usage": {"input_tokens": 20, "output_tokens": 12},
+                        },
+                    }
+                ).encode(),
+            )
+            usage.flush_usage_events(trigger="test")
+
+        usage_sources = _model_websocket_usage_sources(flow)
+        assert "resp_ws_zero_0" not in usage_sources
+        assert len(usage_sources) <= response_streaming._MODEL_WEBSOCKET_ZERO_USAGE_SOURCE_LIMIT
+        assert {
+            (event["provider"], event["category"]): event["quantity"]
+            for event in webhook.usage_events()
+        } == {
+            ("unknown", "tokens.input"): 20,
+            ("unknown", "tokens.output"): 12,
+        }
+        assert {
+            (event["model"], event["category"]): event["quantity"]
+            for event in webhook.model_usage_observation_events()
+        } == {
+            ("unknown", "tokens.input"): 20,
+            ("unknown", "tokens.output"): 12,
         }
 
     def test_model_websocket_text_frame_reports_usage(self, tmp_path, real_flow):


### PR DESCRIPTION
## Summary
- release zero-only WebSocket usage sources that cannot improve later model selection
- bound retained zero-only response-id model hints in `MODEL_PROVIDER_USAGE_SOURCES`
- cover zero-only retention, eviction, and later positive usage reporting

Closes #18726

## Tests
- `cd crates/runner/mitm-addon && .venv/bin/python -m pytest tests/test_model_provider_websocket_usage.py tests/test_model_provider_usage.py`
- `cd crates/runner/mitm-addon && .venv/bin/python -m pytest tests/test_model_provider_websocket_metadata.py tests/test_openai_responses_event_json.py`
- `cd crates/runner/mitm-addon && .venv/bin/ruff check . && .venv/bin/ruff format --check . && .venv/bin/basedpyright -p .`
- `cd crates/runner/mitm-addon && .venv/bin/python -m pytest`