### PR TITLE
fix: normalize codex cli log rendering

### DIFF
--- a/turbo/apps/api/src/lib/axiom-apl.ts
+++ b/turbo/apps/api/src/lib/axiom-apl.ts
@@ -1,6 +1,12 @@
-// Escape a string literal for safe interpolation into an APL `where` clause.
-// APL string literals are double-quoted; backslash and double-quote must be
-// escaped so user-controlled values cannot break out of the literal.
+// Escape a string literal for safe interpolation into an APL query.
+// APL string literals are double-quoted; control characters that APL treats as
+// escape sequences must be represented with backslash escapes.
 export function escapeAplString(value: string): string {
-  return value.replace(/\\/g, String.raw`\\`).replace(/"/g, String.raw`\"`);
+  return value
+    .replace(/\\/g, String.raw`\\`)
+    .replace(/"/g, String.raw`\"`)
+    .replace(/\t/g, String.raw`\t`)
+    .replace(/\r\n/g, String.raw`\n`)
+    .replace(/\r/g, String.raw`\n`)
+    .replace(/\n/g, String.raw`\n`);
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -1373,6 +1373,9 @@ describe("CHAT-01 chat search", () => {
     expect(emptyResults.results).toStrictEqual([]);
     expect(emptyResults.hasMore).toBeFalsy();
 
+    const blankKeyword = await chat.requestSearchChat(owner, "   ", {}, [400]);
+    expectApiError(blankKeyword.body);
+
     // Peer-user isolation inside one org.
     const peerAgent = await bdd.createAgent(peer, {
       displayName: "Peer search agent",

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-misc.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-misc.ts
@@ -46,6 +46,7 @@ interface AuthHeaders {
 type ZeroLogsSearchQuery = z.input<
   (typeof zeroLogsSearchContract.searchLogs)["query"]
 >;
+type ZeroLogsListQuery = z.input<(typeof logsListContract.list)["query"]>;
 
 interface ClerkOrg {
   readonly imageUrl: string | null;
@@ -127,6 +128,21 @@ async function requestZeroLogsSearch<TStatus extends 200 | 400 | 401 | 403>(
 ) {
   return await accept(
     setupApp({ context })(zeroLogsSearchContract).searchLogs({
+      headers: authenticate(context, actor),
+      query,
+    }),
+    statuses,
+  );
+}
+
+async function requestZeroLogsList<TStatus extends 200 | 400 | 401 | 403>(
+  context: TestContext,
+  actor: ApiTestUser | null,
+  query: ZeroLogsListQuery,
+  statuses: readonly TStatus[],
+) {
+  return await accept(
+    setupApp({ context })(logsListContract).list({
       headers: authenticate(context, actor),
       query,
     }),
@@ -509,13 +525,15 @@ export function createMiscRoutesApi(context: TestContext) {
     },
 
     async listLogs(actor: ApiTestUser) {
-      return await accept(
-        setupApp({ context })(logsListContract).list({
-          headers: authenticate(context, actor),
-          query: {},
-        }),
-        [200],
-      );
+      return await requestZeroLogsList(context, actor, {}, [200]);
+    },
+
+    async requestListLogs<TStatus extends 200 | 400 | 401 | 403>(
+      actor: ApiTestUser | null,
+      query: ZeroLogsListQuery,
+      statuses: readonly TStatus[],
+    ) {
+      return await requestZeroLogsList(context, actor, query, statuses);
     },
 
     async requestSearchLogs<TStatus extends 200 | 400 | 401 | 403>(

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-misc.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-misc.ts
@@ -36,6 +36,7 @@ import {
   setupApp,
   type TestContext,
 } from "../../../../__tests__/test-helpers";
+import { createApp } from "../../../../app-factory";
 import type { ApiTestUser } from "./api-bdd";
 import { createZeroRouteMocks } from "./zero-route-test";
 
@@ -542,6 +543,23 @@ export function createMiscRoutesApi(context: TestContext) {
       statuses: readonly TStatus[],
     ) {
       return await requestZeroLogsSearch(context, actor, query, statuses);
+    },
+
+    async rawSearchLogs(
+      actor: ApiTestUser,
+      queryString: string,
+    ): Promise<{ readonly status: number; readonly body: unknown }> {
+      const { authorization } = authenticate(context, actor);
+      const app = createApp({ signal: context.signal });
+      const response = await app.request(
+        `/api/zero/logs/search${queryString}`,
+        {
+          method: "GET",
+          headers: authorization === undefined ? {} : { authorization },
+        },
+      );
+      const body: unknown = await response.json();
+      return { status: response.status, body };
     },
 
     async searchLogs(actor: ApiTestUser, keyword: string) {

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-misc.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-misc.ts
@@ -2,6 +2,7 @@ import {
   logsByIdContract,
   logsListContract,
 } from "@vm0/api-contracts/contracts/logs";
+import type { z } from "zod";
 import { emailUnsubscribeContract } from "@vm0/api-contracts/contracts/email-unsubscribe";
 import { pushSubscriptionsContract } from "@vm0/api-contracts/contracts/push-subscriptions";
 import { userExportContract } from "@vm0/api-contracts/contracts/user-export";
@@ -41,6 +42,10 @@ import { createZeroRouteMocks } from "./zero-route-test";
 interface AuthHeaders {
   readonly authorization?: string;
 }
+
+type ZeroLogsSearchQuery = z.input<
+  (typeof zeroLogsSearchContract.searchLogs)["query"]
+>;
 
 interface ClerkOrg {
   readonly imageUrl: string | null;
@@ -112,6 +117,21 @@ function asyncIterableOf(buffer: Buffer): AsyncIterable<Uint8Array> {
       yield buffer;
     },
   };
+}
+
+async function requestZeroLogsSearch<TStatus extends 200 | 400 | 401 | 403>(
+  context: TestContext,
+  actor: ApiTestUser | null,
+  query: ZeroLogsSearchQuery,
+  statuses: readonly TStatus[],
+) {
+  return await accept(
+    setupApp({ context })(zeroLogsSearchContract).searchLogs({
+      headers: authenticate(context, actor),
+      query,
+    }),
+    statuses,
+  );
 }
 
 export function createMiscRoutesApi(context: TestContext) {
@@ -498,14 +518,16 @@ export function createMiscRoutesApi(context: TestContext) {
       );
     },
 
+    async requestSearchLogs<TStatus extends 200 | 400 | 401 | 403>(
+      actor: ApiTestUser | null,
+      query: ZeroLogsSearchQuery,
+      statuses: readonly TStatus[],
+    ) {
+      return await requestZeroLogsSearch(context, actor, query, statuses);
+    },
+
     async searchLogs(actor: ApiTestUser, keyword: string) {
-      return await accept(
-        setupApp({ context })(zeroLogsSearchContract).searchLogs({
-          headers: authenticate(context, actor),
-          query: { keyword },
-        }),
-        [200],
-      );
+      return await requestZeroLogsSearch(context, actor, { keyword }, [200]);
     },
 
     async readLog(

--- a/turbo/apps/api/src/signals/routes/__tests__/misc-routes.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/misc-routes.bdd.test.ts
@@ -193,6 +193,12 @@ describe("MISC-02: preferences, push subscription, user export, and empty logs",
       [400],
     );
     expectApiError(invalidSearchAfter.body);
+    const blankSearchContext = await api.rawSearchLogs(
+      admin,
+      "?keyword=nothing-here&before=&after=",
+    );
+    expect(blankSearchContext.status).toBe(400);
+    expectApiError(blankSearchContext.body);
     const invalidSearchRunId = await api.requestSearchLogs(
       admin,
       { keyword: "nothing-here", runId: "not-a-uuid" },

--- a/turbo/apps/api/src/signals/routes/__tests__/misc-routes.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/misc-routes.bdd.test.ts
@@ -169,6 +169,30 @@ describe("MISC-02: preferences, push subscription, user export, and empty logs",
     expect(logs.body.data).toStrictEqual([]);
     const searched = await api.searchLogs(admin, "nothing-here");
     expect(searched.body.results).toStrictEqual([]);
+    const invalidSearchLimit = await api.requestSearchLogs(
+      admin,
+      { keyword: "nothing-here", limit: 1.5 },
+      [400],
+    );
+    expectApiError(invalidSearchLimit.body);
+    const invalidSearchBefore = await api.requestSearchLogs(
+      admin,
+      { keyword: "nothing-here", before: 1.5 },
+      [400],
+    );
+    expectApiError(invalidSearchBefore.body);
+    const invalidSearchAfter = await api.requestSearchLogs(
+      admin,
+      { keyword: "nothing-here", after: 1.5 },
+      [400],
+    );
+    expectApiError(invalidSearchAfter.body);
+    const invalidSearchRunId = await api.requestSearchLogs(
+      admin,
+      { keyword: "nothing-here", runId: "not-a-uuid" },
+      [400],
+    );
+    expectApiError(invalidSearchRunId.body);
     const missingLog = await api.readLog(admin, randomUUID(), [404]);
     expectApiError(missingLog.body);
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/misc-routes.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/misc-routes.bdd.test.ts
@@ -167,6 +167,12 @@ describe("MISC-02: preferences, push subscription, user export, and empty logs",
 
     const logs = await api.listLogs(admin);
     expect(logs.body.data).toStrictEqual([]);
+    const invalidListLimit = await api.requestListLogs(
+      admin,
+      { limit: 1.5 },
+      [400],
+    );
+    expectApiError(invalidListLimit.body);
     const searched = await api.searchLogs(admin, "nothing-here");
     expect(searched.body.results).toStrictEqual([]);
     const invalidSearchLimit = await api.requestSearchLogs(

--- a/turbo/apps/api/src/signals/routes/__tests__/misc-routes.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/misc-routes.bdd.test.ts
@@ -199,6 +199,12 @@ describe("MISC-02: preferences, push subscription, user export, and empty logs",
     );
     expect(blankSearchContext.status).toBe(400);
     expectApiError(blankSearchContext.body);
+    const blankSearchKeyword = await api.rawSearchLogs(
+      admin,
+      "?keyword=%20%20",
+    );
+    expect(blankSearchKeyword.status).toBe(400);
+    expectApiError(blankSearchKeyword.body);
     const invalidSearchRunId = await api.requestSearchLogs(
       admin,
       { keyword: "nothing-here", runId: "not-a-uuid" },

--- a/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
@@ -423,6 +423,10 @@ describe("OPS-01: run log search via /api/logs/search", () => {
     expect(blankContext.status).toBe(400);
     expectApiError(blankContext.body);
 
+    const blankKeyword = await api.rawSearchLogs(actor, "?keyword=%20%20");
+    expect(blankKeyword.status).toBe(400);
+    expectApiError(blankKeyword.body);
+
     const invalidRunId = await api.requestSearchLogs(
       actor,
       { keyword: "OOM", runId: "not-a-uuid" },
@@ -475,7 +479,7 @@ describe("OPS-01: run log search via /api/logs/search", () => {
     context.mocks.axiom.query.mockResolvedValueOnce([]);
     const escapedKeywordSearch = await api.requestSearchLogs(
       actor,
-      { keyword: 'quote" slash\\ tab\t newline\n carriage\r' },
+      { keyword: 'quote" slash\\ tab\t newline\n carriage\r return' },
       [200],
     );
     expect(escapedKeywordSearch.body).toStrictEqual({
@@ -488,7 +492,7 @@ describe("OPS-01: run log search via /api/logs/search", () => {
         return line.includes("| search");
       });
     expect(escapedSearchLine).toBe(
-      String.raw`| search "*quote\" slash\\ tab\t newline\n carriage\n*"`,
+      String.raw`| search "*quote\" slash\\ tab\t newline\n carriage\n return*"`,
     );
 
     context.mocks.axiom.query

--- a/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
@@ -2,6 +2,8 @@ import { createHmac, randomUUID } from "node:crypto";
 
 import { afterEach, describe, expect, it } from "vitest";
 
+import { MAX_EVENT_SEQUENCE_NUMBER } from "@vm0/api-contracts/contracts/runs";
+
 import { env } from "../../../lib/env";
 import { clearMockNow, mockNow } from "../../../lib/time";
 import { testContext } from "../../../__tests__/test-helpers";
@@ -392,6 +394,28 @@ describe("OPS-01: run log search via /api/logs/search", () => {
       [400],
     );
     expectApiError(invalidSince.body);
+
+    const axiomCallsBeforeMalformed =
+      context.mocks.axiom.query.mock.calls.length;
+    context.mocks.axiom.query.mockResolvedValueOnce([
+      { ...axiomEvent(runId, 3, "Error: OOM killed"), sequenceNumber: "bad" },
+      {
+        ...axiomEvent(runId, 4, "Error: OOM killed"),
+        sequenceNumber: MAX_EVENT_SEQUENCE_NUMBER + 1,
+      },
+    ]);
+    const malformedAxiomRow = await api.requestSearchLogs(
+      actor,
+      { keyword: "OOM", before: 1, after: 1 },
+      [200],
+    );
+    expect(malformedAxiomRow.body).toStrictEqual({
+      results: [],
+      hasMore: false,
+    });
+    expect(context.mocks.axiom.query.mock.calls).toHaveLength(
+      axiomCallsBeforeMalformed + 1,
+    );
 
     context.mocks.axiom.query.mockResolvedValueOnce([
       axiomEvent(runId, 3, "Error: OOM killed"),

--- a/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
@@ -472,6 +472,25 @@ describe("OPS-01: run log search via /api/logs/search", () => {
     expect(broadApl).toContain('search "*OOM*"');
     expect(broadApl).toContain(`runId == "${runId}"`);
 
+    context.mocks.axiom.query.mockResolvedValueOnce([]);
+    const escapedKeywordSearch = await api.requestSearchLogs(
+      actor,
+      { keyword: 'quote" slash\\ tab\t newline\n carriage\r' },
+      [200],
+    );
+    expect(escapedKeywordSearch.body).toStrictEqual({
+      results: [],
+      hasMore: false,
+    });
+    const escapedSearchLine = lastAxiomApl()
+      .split("\n")
+      .find((line) => {
+        return line.includes("| search");
+      });
+    expect(escapedSearchLine).toBe(
+      String.raw`| search "*quote\" slash\\ tab\t newline\n carriage\n*"`,
+    );
+
     context.mocks.axiom.query
       .mockResolvedValueOnce([
         axiomEvent(runId, 5, "Error: OOM killed", "2026-01-15T10:30:05Z"),

--- a/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
@@ -404,6 +404,7 @@ describe("OPS-01: run log search via /api/logs/search", () => {
     expect(matched.body.results).toHaveLength(1);
     expect(matched.body.results[0]?.runId).toBe(runId);
     expect(matched.body.results[0]?.agentName).toBe("BDD ops-logs agent");
+    expect(matched.body.results[0]?.framework).toBe("claude-code");
     expect(matched.body.results[0]?.matchedEvent.sequenceNumber).toBe(3);
     expect(matched.body.results[0]?.contextBefore).toStrictEqual([]);
     expect(matched.body.results[0]?.contextAfter).toStrictEqual([]);

--- a/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
@@ -509,6 +509,32 @@ describe("OPS-01: run log search via /api/logs/search", () => {
     expect(byRunId.body.results[0]?.runId).toBe(runId);
     expect(lastAxiomApl()).toContain(`runId == "${runId}"`);
 
+    const axiomCallsBeforeMismatchedRunAgent =
+      context.mocks.axiom.query.mock.calls.length;
+    const mismatchedRunAgent = await api.requestSearchLogs(
+      actor,
+      { keyword: "Found", runId, agentId: randomUUID() },
+      [200],
+    );
+    expect(mismatchedRunAgent.body).toStrictEqual({
+      results: [],
+      hasMore: false,
+    });
+    expect(context.mocks.axiom.query.mock.calls).toHaveLength(
+      axiomCallsBeforeMismatchedRunAgent,
+    );
+
+    context.mocks.axiom.query.mockResolvedValueOnce([
+      axiomEvent(runId, 2, "Found again"),
+    ]);
+    const byRunAndAgent = await api.requestSearchLogs(
+      actor,
+      { keyword: "Found", runId, agentId },
+      [200],
+    );
+    expect(byRunAndAgent.body.results).toHaveLength(1);
+    expect(byRunAndAgent.body.results[0]?.runId).toBe(runId);
+
     context.mocks.axiom.query.mockResolvedValueOnce([
       axiomEvent(runId, 1, "Agent scoped event"),
     ]);

--- a/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
@@ -395,6 +395,27 @@ describe("OPS-01: run log search via /api/logs/search", () => {
     );
     expectApiError(invalidSince.body);
 
+    const invalidLimit = await api.requestSearchLogs(
+      actor,
+      { keyword: "OOM", limit: 1.5 },
+      [400],
+    );
+    expectApiError(invalidLimit.body);
+
+    const invalidBefore = await api.requestSearchLogs(
+      actor,
+      { keyword: "OOM", before: 1.5 },
+      [400],
+    );
+    expectApiError(invalidBefore.body);
+
+    const invalidAfter = await api.requestSearchLogs(
+      actor,
+      { keyword: "OOM", after: 1.5 },
+      [400],
+    );
+    expectApiError(invalidAfter.body);
+
     const axiomCallsBeforeMalformed =
       context.mocks.axiom.query.mock.calls.length;
     context.mocks.axiom.query.mockResolvedValueOnce([
@@ -403,6 +424,7 @@ describe("OPS-01: run log search via /api/logs/search", () => {
         ...axiomEvent(runId, 4, "Error: OOM killed"),
         sequenceNumber: MAX_EVENT_SEQUENCE_NUMBER + 1,
       },
+      { ...axiomEvent(runId, 5, "Error: OOM killed"), _time: "not-a-date" },
     ]);
     const malformedAxiomRow = await api.requestSearchLogs(
       actor,

--- a/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
@@ -416,6 +416,13 @@ describe("OPS-01: run log search via /api/logs/search", () => {
     );
     expectApiError(invalidAfter.body);
 
+    const blankContext = await api.rawSearchLogs(
+      actor,
+      "?keyword=OOM&before=&after=",
+    );
+    expect(blankContext.status).toBe(400);
+    expectApiError(blankContext.body);
+
     const invalidRunId = await api.requestSearchLogs(
       actor,
       { keyword: "OOM", runId: "not-a-uuid" },

--- a/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
@@ -416,6 +416,13 @@ describe("OPS-01: run log search via /api/logs/search", () => {
     );
     expectApiError(invalidAfter.body);
 
+    const invalidRunId = await api.requestSearchLogs(
+      actor,
+      { keyword: "OOM", runId: "not-a-uuid" },
+      [400],
+    );
+    expectApiError(invalidRunId.body);
+
     const axiomCallsBeforeMalformed =
       context.mocks.axiom.query.mock.calls.length;
     context.mocks.axiom.query.mockResolvedValueOnce([

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -1,11 +1,15 @@
 import { createHash, randomUUID } from "node:crypto";
 
 import { CANONICAL_CLAUDE_MEMORY_MOUNT_PATH } from "@vm0/api-contracts/contracts/runners";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 
 import { mockEnv } from "../../../lib/env";
 import { now } from "../../../lib/time";
 import { testContext } from "../../../__tests__/test-helpers";
+import { writeDb$ } from "../../external/db";
 import {
   createBddApi,
   expectApiError,
@@ -41,6 +45,7 @@ import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 const UTF8_ENCODING = ["utf", "8"].join("-");
 
 const context = testContext();
+const store = createStore();
 const bdd = createBddApi(context);
 const api = createRunsAutomationsApi(context);
 const webhooks = createWebhookCallbackApi(context);
@@ -79,6 +84,14 @@ async function createClaudeCompose(
       },
     },
   });
+}
+
+async function setRunCreatedAt(runId: string, createdAt: Date): Promise<void> {
+  await store
+    .set(writeDb$)
+    .update(agentRuns)
+    .set({ createdAt })
+    .where(eq(agentRuns.id, runId));
 }
 
 function sandboxHeaders(token: string): { readonly authorization: string } {
@@ -3475,6 +3488,35 @@ describe("RUN-04/OPS-01: zero run logs", () => {
     expect(tokenDetail.body).toMatchObject({ id: webRun.runId });
 
     await api.requestCancelRun(actor, tokenRun.runId, [200]);
+
+    const sinceBoundaryRun = await api.createRun(actor, {
+      agentId: agentOne.agentId,
+      prompt: "since boundary visible run",
+      modelProvider: "anthropic-api-key",
+    });
+    await api.requestCancelRun(actor, sinceBoundaryRun.runId, [200]);
+    const beforeEpochRun = await api.createRun(actor, {
+      agentId: agentOne.agentId,
+      prompt: "since boundary hidden run",
+      modelProvider: "anthropic-api-key",
+    });
+    await api.requestCancelRun(actor, beforeEpochRun.runId, [200]);
+    await setRunCreatedAt(
+      beforeEpochRun.runId,
+      new Date("1969-12-31T23:59:59.000Z"),
+    );
+
+    const sinceEpoch = await reads.requestListLogs(
+      actor,
+      { since: 0, limit: 100 },
+      [200],
+    );
+    mustOk(sinceEpoch, "the epoch-boundary log list");
+    const sinceEpochIds = sinceEpoch.body.data.map((entry) => {
+      return entry.id;
+    });
+    expect(sinceEpochIds).toContain(sinceBoundaryRun.runId);
+    expect(sinceEpochIds).not.toContain(beforeEpochRun.runId);
   });
 
   it("splits multi-run log searches into a bounded run-id filter", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -3280,10 +3280,18 @@ describe("RUN-04/OPS-01: zero run logs", () => {
       { limit: 1, cursor: "garbage" },
       [200],
     );
-    if (malformedCursor.status !== 200) {
-      throw new Error("Expected the malformed-cursor list to succeed");
-    }
+    mustOk(malformedCursor, "malformed cursor list");
     expect(malformedCursor.body.data[0]?.id).toBe(pageOne.body.data[0]?.id);
+
+    const malformedStructuredCursor = await reads.requestListLogs(
+      actor,
+      { limit: 1, cursor: "not-a-date|not-a-run-id" },
+      [200],
+    );
+    mustOk(malformedStructuredCursor, "malformed structured cursor list");
+    expect(malformedStructuredCursor.body.data[0]?.id).toBe(
+      pageOne.body.data[0]?.id,
+    );
 
     const agentOneRunIds = [webRun.runId, scheduleRun.body.runId].sort();
     const fuzzy = await reads.requestListLogs(

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -3255,9 +3255,7 @@ describe("RUN-04/OPS-01: zero run logs", () => {
     });
 
     const pageOne = await reads.requestListLogs(actor, { limit: 1 }, [200]);
-    if (pageOne.status !== 200) {
-      throw new Error("Expected the first log page to succeed");
-    }
+    mustOk(pageOne, "the first log page");
     expect(pageOne.body.data).toHaveLength(1);
     expect(pageOne.body.pagination.hasMore).toBeTruthy();
     const cursor = pageOne.body.pagination.nextCursor;
@@ -3269,9 +3267,7 @@ describe("RUN-04/OPS-01: zero run logs", () => {
       { limit: 1, cursor },
       [200],
     );
-    if (pageTwo.status !== 200) {
-      throw new Error("Expected the second log page to succeed");
-    }
+    mustOk(pageTwo, "the second log page");
     expect(pageTwo.body.data).toHaveLength(1);
     expect(pageTwo.body.data[0]?.id).not.toBe(pageOne.body.data[0]?.id);
 
@@ -3293,15 +3289,21 @@ describe("RUN-04/OPS-01: zero run logs", () => {
       pageOne.body.data[0]?.id,
     );
 
+    const malformedCursorId = await reads.requestListLogs(
+      actor,
+      { limit: 1, cursor: "2026-01-15T10:30:00.000Z|not-a-run-id" },
+      [200],
+    );
+    mustOk(malformedCursorId, "malformed cursor id list");
+    expect(malformedCursorId.body.data[0]?.id).toBe(pageOne.body.data[0]?.id);
+
     const agentOneRunIds = [webRun.runId, scheduleRun.body.runId].sort();
     const fuzzy = await reads.requestListLogs(
       actor,
       { search: agentOneName.toUpperCase() },
       [200],
     );
-    if (fuzzy.status !== 200) {
-      throw new Error("Expected the fuzzy search list to succeed");
-    }
+    mustOk(fuzzy, "the fuzzy search list");
     expect(
       fuzzy.body.data
         .map((entry) => {
@@ -3315,9 +3317,7 @@ describe("RUN-04/OPS-01: zero run logs", () => {
       { name: agentOneName },
       [200],
     );
-    if (byName.status !== 200) {
-      throw new Error("Expected the name-filtered list to succeed");
-    }
+    mustOk(byName, "the name-filtered list");
     expect(
       byName.body.data
         .map((entry) => {
@@ -3331,9 +3331,7 @@ describe("RUN-04/OPS-01: zero run logs", () => {
       { agentId: agentOne.agentId, search: "zzz-no-such-agent" },
       [200],
     );
-    if (byAgentId.status !== 200) {
-      throw new Error("Expected the agent-id list to succeed");
-    }
+    mustOk(byAgentId, "the agent-id list");
     expect(
       byAgentId.body.data
         .map((entry) => {
@@ -3347,9 +3345,7 @@ describe("RUN-04/OPS-01: zero run logs", () => {
       { status: "cancelled", triggerSource: "web" },
       [200],
     );
-    if (byStatusAndSource.status !== 200) {
-      throw new Error("Expected the status+source list to succeed");
-    }
+    mustOk(byStatusAndSource, "the status+source list");
     expect(
       byStatusAndSource.body.data
         .map((entry) => {
@@ -3375,9 +3371,7 @@ describe("RUN-04/OPS-01: zero run logs", () => {
       { triggerSource: "telegram" },
       [200],
     );
-    if (noSourceMatch.status !== 200) {
-      throw new Error("Expected the empty source list to succeed");
-    }
+    mustOk(noSourceMatch, "the empty source list");
     expect(noSourceMatch.body.data).toStrictEqual([]);
 
     const byAutomationId = await reads.requestListLogs(
@@ -3385,9 +3379,7 @@ describe("RUN-04/OPS-01: zero run logs", () => {
       { automationId: schedule.automation.id, limit: 1 },
       [200],
     );
-    if (byAutomationId.status !== 200) {
-      throw new Error("Expected the automation-filtered list to succeed");
-    }
+    mustOk(byAutomationId, "the automation-filtered list");
     expect(byAutomationId.body.data).toStrictEqual([
       expect.objectContaining({ id: scheduleRun.body.runId }),
     ]);
@@ -3469,9 +3461,7 @@ describe("RUN-04/OPS-01: zero run logs", () => {
       {},
       [200],
     );
-    if (tokenList.status !== 200) {
-      throw new Error("Expected the zero-token log list to succeed");
-    }
+    mustOk(tokenList, "the zero-token log list");
     expect(
       tokenList.body.data.map((entry) => {
         return entry.id;

--- a/turbo/apps/api/src/signals/services/zero-logs.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-logs.service.ts
@@ -855,16 +855,28 @@ export function zeroLogSearch(
     // Determine which run IDs to search (ownership verified via DB)
     let targetRunIds: string[];
     if (runId) {
+      const runConditions = [
+        eq(agentRuns.id, runId),
+        eq(agentRuns.userId, params.userId),
+        eq(agentRuns.orgId, params.orgId),
+      ];
+      if (params.agentId) {
+        runConditions.push(eq(zeroAgents.id, params.agentId));
+      }
+
       const [run] = await db
         .select({ id: agentRuns.id })
         .from(agentRuns)
-        .where(
-          and(
-            eq(agentRuns.id, runId),
-            eq(agentRuns.userId, params.userId),
-            eq(agentRuns.orgId, params.orgId),
-          ),
+        .leftJoin(
+          agentComposeVersions,
+          eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
         )
+        .leftJoin(
+          agentComposes,
+          eq(agentComposeVersions.composeId, agentComposes.id),
+        )
+        .leftJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
+        .where(and(...runConditions))
         .limit(1);
 
       if (!run) {

--- a/turbo/apps/api/src/signals/services/zero-logs.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-logs.service.ts
@@ -87,13 +87,16 @@ function normalizeTriggerSource(
 
 function buildCursorCondition(cursor: string): SQL | null {
   const separatorIndex = cursor.lastIndexOf("|");
-  if (separatorIndex <= 0) {
+  if (separatorIndex <= 0 || separatorIndex >= cursor.length - 1) {
     return null;
   }
 
   const cursorTime = cursor.slice(0, separatorIndex);
   const cursorId = cursor.slice(separatorIndex + 1);
   const cursorDate = new Date(cursorTime);
+  if (!Number.isFinite(cursorDate.getTime())) {
+    return null;
+  }
 
   return or(
     lt(agentRuns.createdAt, cursorDate),

--- a/turbo/apps/api/src/signals/services/zero-logs.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-logs.service.ts
@@ -542,6 +542,9 @@ function parseAxiomAgentEvent(value: unknown): AxiomAgentEvent | null {
   ) {
     return null;
   }
+  if (!Number.isFinite(Date.parse(time))) {
+    return null;
+  }
 
   return {
     _time: time,

--- a/turbo/apps/api/src/signals/services/zero-logs.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-logs.service.ts
@@ -362,16 +362,7 @@ async function getAvailableFilters(
       return r.triggerSource;
     })
     .filter((s): s is TriggerSource => {
-      return [
-        "automation",
-        "web",
-        "slack",
-        "email",
-        "telegram",
-        "github",
-        "cli",
-        "agent",
-      ].includes(s as string);
+      return triggerSourceSchema.safeParse(s).success;
     });
 
   const agents = agentRows

--- a/turbo/apps/api/src/signals/services/zero-logs.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-logs.service.ts
@@ -169,7 +169,7 @@ export function zeroLogsList(
 
     conditions.push(...buildAgentFilterConditions(params));
 
-    if (params.since) {
+    if (params.since !== undefined) {
       conditions.push(gte(agentRuns.createdAt, new Date(params.since)));
     }
     if (params.status) {
@@ -275,7 +275,7 @@ async function getLogsTotalCount(
 
   conditions.push(...buildAgentFilterConditions(params));
 
-  if (params.since) {
+  if (params.since !== undefined) {
     conditions.push(gte(agentRuns.createdAt, new Date(params.since)));
   }
   if (params.status) {

--- a/turbo/apps/api/src/signals/services/zero-logs.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-logs.service.ts
@@ -7,9 +7,10 @@ import {
   type LogsFilters,
   type TriggerSource,
 } from "@vm0/api-contracts/contracts/logs";
-import type {
-  LogsSearchResponse,
-  RunEvent,
+import {
+  MAX_EVENT_SEQUENCE_NUMBER,
+  type LogsSearchResponse,
+  type RunEvent,
 } from "@vm0/api-contracts/contracts/runs";
 import { isSupportedFramework } from "@vm0/core/frameworks";
 import {
@@ -511,6 +512,55 @@ interface AxiomAgentEvent {
   eventData: unknown;
 }
 
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function parseAxiomAgentEvent(value: unknown): AxiomAgentEvent | null {
+  const event = asRecord(value);
+  if (!event) {
+    return null;
+  }
+
+  const time = event._time;
+  const runId = event.runId;
+  const userId = event.userId;
+  const sequenceNumber = event.sequenceNumber;
+  const eventType = event.eventType;
+  if (
+    typeof time !== "string" ||
+    typeof runId !== "string" ||
+    typeof userId !== "string" ||
+    typeof eventType !== "string" ||
+    typeof sequenceNumber !== "number" ||
+    !Number.isSafeInteger(sequenceNumber) ||
+    sequenceNumber < 0 ||
+    sequenceNumber > MAX_EVENT_SEQUENCE_NUMBER
+  ) {
+    return null;
+  }
+
+  return {
+    _time: time,
+    runId,
+    userId,
+    sequenceNumber,
+    eventType,
+    eventData: event.eventData,
+  };
+}
+
+function parseAxiomAgentEvents(values: readonly unknown[]): AxiomAgentEvent[] {
+  return values
+    .map(parseAxiomAgentEvent)
+    .filter((event): event is AxiomAgentEvent => {
+      return event !== null;
+    });
+}
+
 function toRunEvent(event: AxiomAgentEvent): RunEvent {
   return {
     sequenceNumber: event.sequenceNumber,
@@ -646,9 +696,7 @@ function queryMatchingEvents(params: {
             keyword: params.keyword,
             limit: params.limit + 1,
           });
-          return (
-            await get(queryAxiom(searchApl))
-          ).slice() as unknown as AxiomAgentEvent[];
+          return parseAxiomAgentEvents(await get(queryAxiom(searchApl)));
         }),
       );
 
@@ -683,9 +731,9 @@ function getSearchContextMap(params: {
 | where ${contextConditions.join("\n  or ")}
 | order by runId asc, sequenceNumber asc`;
 
-    const contextEvents = (
-      await get(queryAxiom(contextApl))
-    ).slice() as unknown as AxiomAgentEvent[];
+    const contextEvents = parseAxiomAgentEvents(
+      await get(queryAxiom(contextApl)),
+    );
 
     for (const event of contextEvents) {
       contextMap.set(`${event.runId}:${event.sequenceNumber}`, event);

--- a/turbo/apps/api/src/signals/services/zero-logs.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-logs.service.ts
@@ -11,6 +11,7 @@ import type {
   LogsSearchResponse,
   RunEvent,
 } from "@vm0/api-contracts/contracts/runs";
+import { isSupportedFramework } from "@vm0/core/frameworks";
 import {
   agentComposes,
   agentComposeVersions,
@@ -47,16 +48,33 @@ const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
 const AXIOM_RUN_ID_FILTER_CHUNK_SIZE = 500;
 const AXIOM_SEARCH_QUERY_CONCURRENCY = 4;
 
-interface AgentComposeContent {
-  agents: Record<string, { framework: string }>;
-}
-
 function extractFramework(composeContent: unknown): string | null {
-  const content = composeContent as AgentComposeContent | null;
-  const agentNames = content?.agents ? Object.keys(content.agents) : [];
-  const firstAgent =
-    agentNames.length > 0 ? content?.agents[agentNames[0]!] : null;
-  return firstAgent?.framework ?? null;
+  if (
+    !composeContent ||
+    typeof composeContent !== "object" ||
+    Array.isArray(composeContent)
+  ) {
+    return null;
+  }
+
+  const agents = (composeContent as { readonly agents?: unknown }).agents;
+  if (!agents || typeof agents !== "object" || Array.isArray(agents)) {
+    return null;
+  }
+
+  const [firstAgent] = Object.values(agents);
+  if (
+    !firstAgent ||
+    typeof firstAgent !== "object" ||
+    Array.isArray(firstAgent)
+  ) {
+    return null;
+  }
+
+  const framework = (firstAgent as { readonly framework?: unknown }).framework;
+  return typeof framework === "string" && isSupportedFramework(framework)
+    ? framework
+    : null;
 }
 
 function normalizeTriggerSource(
@@ -447,8 +465,7 @@ export function zeroLogDetail(
     } = result;
     const runResult = run.result as RunResult | null;
     const agentSessionId = runResult?.agentSessionId ?? null;
-    const composeContent =
-      composeVersion?.content as AgentComposeContent | null;
+    const composeContent = composeVersion?.content ?? null;
 
     return {
       id: run.id,
@@ -683,11 +700,15 @@ function buildSearchResults(params: {
   readonly before: number;
   readonly after: number;
   readonly contextMap: Map<string, AxiomAgentEvent>;
-  readonly agentNames: Map<string, string>;
+  readonly runMetadata: Map<
+    string,
+    { readonly agentName: string; readonly framework: string | null }
+  >;
 }): LogsSearchResponse["results"] {
   return params.matches.map((match) => {
     const contextBefore: RunEvent[] = [];
     const contextAfter: RunEvent[] = [];
+    const metadata = params.runMetadata.get(match.runId);
 
     for (
       let i = match.sequenceNumber - params.before;
@@ -713,7 +734,8 @@ function buildSearchResults(params: {
 
     return {
       runId: match.runId,
-      agentName: params.agentNames.get(match.runId) || "unknown",
+      agentName: metadata?.agentName ?? "unknown",
+      framework: metadata?.framework ?? null,
       matchedEvent: toRunEvent(match),
       contextBefore,
       contextAfter,
@@ -721,13 +743,18 @@ function buildSearchResults(params: {
   });
 }
 
-async function getAgentNames(
+async function getSearchRunMetadata(
   db: ServiceDb,
   runIds: string[],
   userId: string,
   orgId: string,
-): Promise<Map<string, string>> {
-  const result = new Map<string, string>();
+): Promise<
+  Map<string, { readonly agentName: string; readonly framework: string | null }>
+> {
+  const result = new Map<
+    string,
+    { readonly agentName: string; readonly framework: string | null }
+  >();
   if (runIds.length === 0) {
     return result;
   }
@@ -736,6 +763,7 @@ async function getAgentNames(
     .select({
       runId: agentRuns.id,
       composeId: agentComposes.id,
+      composeContent: agentComposeVersions.content,
       displayName: zeroAgents.displayName,
     })
     .from(agentRuns)
@@ -757,7 +785,10 @@ async function getAgentNames(
     );
 
   for (const row of rows) {
-    result.set(row.runId, row.displayName ?? row.composeId ?? "unknown");
+    result.set(row.runId, {
+      agentName: row.displayName ?? row.composeId ?? "unknown",
+      framework: extractFramework(row.composeContent),
+    });
   }
 
   return result;
@@ -837,7 +868,7 @@ export function zeroLogSearch(
         }),
       ),
     ];
-    const agentNames = await getAgentNames(
+    const runMetadata = await getSearchRunMetadata(
       db,
       matchedRunIds,
       params.userId,
@@ -849,7 +880,7 @@ export function zeroLogSearch(
       before,
       after,
       contextMap,
-      agentNames,
+      runMetadata,
     });
     return { results, hasMore };
   });

--- a/turbo/apps/api/src/signals/services/zero-logs.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-logs.service.ts
@@ -48,6 +48,8 @@ const triggerAgentAlias = alias(zeroAgents, "trigger_agent");
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
 const AXIOM_RUN_ID_FILTER_CHUNK_SIZE = 500;
 const AXIOM_SEARCH_QUERY_CONCURRENCY = 4;
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 function extractFramework(composeContent: unknown): string | null {
   if (
@@ -94,7 +96,7 @@ function buildCursorCondition(cursor: string): SQL | null {
   const cursorTime = cursor.slice(0, separatorIndex);
   const cursorId = cursor.slice(separatorIndex + 1);
   const cursorDate = new Date(cursorTime);
-  if (!Number.isFinite(cursorDate.getTime())) {
+  if (!Number.isFinite(cursorDate.getTime()) || !UUID_PATTERN.test(cursorId)) {
     return null;
   }
 

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -1515,8 +1515,14 @@ describe("logs command", () => {
                   createdAt: "2024-01-15T10:30:01Z",
                   eventData: {
                     type: "turn.failed",
+                    error: "Turn failed.",
                     turn: {
                       id: "turn-1",
+                      duration_ms: 2500,
+                      usage: {
+                        input_tokens: 12,
+                        output_tokens: 3,
+                      },
                       error: {
                         message: "selected model is at capacity",
                         additional_details: "retry later",
@@ -1538,6 +1544,9 @@ describe("logs command", () => {
       expect(logCalls).toContain("Codex Failed");
       expect(logCalls).toContain("selected model is at capacity");
       expect(logCalls).toContain("retry later");
+      expect(logCalls).toContain("Duration:");
+      expect(logCalls).toContain("2.5s");
+      expect(logCalls).toContain("input=12 output=3");
       expect(logCalls).not.toContain("Turn failed");
     });
 
@@ -1609,6 +1618,51 @@ describe("logs command", () => {
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Codex Failed");
+    });
+
+    it("should render top-level error event with nested turn error details", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "error",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "error",
+                    error: "Unknown error",
+                    turn: {
+                      id: "turn-1",
+                      duration_ms: 1200,
+                      usage: {
+                        input_tokens: 9,
+                        output_tokens: 2,
+                      },
+                      error: {
+                        message: "authentication expired",
+                      },
+                    },
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Codex Failed");
+      expect(logCalls).toContain("authentication expired");
+      expect(logCalls).toContain("1.2s");
+      expect(logCalls).toContain("input=9 output=2");
+      expect(logCalls).not.toContain("Unknown error");
     });
 
     it("should collapse paired top-level error and turn.failed into one Codex failure", async () => {
@@ -2682,6 +2736,19 @@ describe("logs command", () => {
                     },
                   },
                 },
+                {
+                  sequenceNumber: 4,
+                  eventType: "item.completed",
+                  createdAt: "2024-01-15T10:30:03Z",
+                  eventData: {
+                    type: "item.completed",
+                    item: {
+                      id: "message-error",
+                      type: "agent_message",
+                      error: { message: "message unavailable" },
+                    },
+                  },
+                },
               ],
               framework: "codex",
               hasMore: false,
@@ -2697,6 +2764,7 @@ describe("logs command", () => {
       expect(logCalls).toContain("read was denied");
       expect(logCalls).toContain("[files]");
       expect(logCalls).toContain("patch rejected");
+      expect(logCalls).toContain("message unavailable");
       expect(countOccurrences(logCalls, "✗")).toBeGreaterThanOrEqual(2);
       expect(logCalls).not.toContain("File read completed");
     });

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -2914,6 +2914,10 @@ describe("logs command", () => {
                         code: "server_error",
                         additional_details: "retry later",
                       },
+                      usage: {
+                        input_tokens: "not-a-number",
+                        output_tokens: "also-not-a-number",
+                      },
                     },
                   },
                 },
@@ -2948,6 +2952,8 @@ describe("logs command", () => {
       expect(mockExit).not.toHaveBeenCalled();
       expect(logCalls).toContain("server_error");
       expect(logCalls).toContain("retry later");
+      expect(logCalls).toContain("input=0 output=0");
+      expect(logCalls).not.toContain("NaN");
       expect(logCalls).toContain("Modified: /workspace/ok.ts");
       expect(logCalls).not.toContain("[object Object]");
     });

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -284,6 +284,70 @@ describe("logs command", () => {
       expect(logCalls).toContain("Codex page output");
     });
 
+    it("should not reuse a codex framework for a later unsupported framework page", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          ({ request }) => {
+            const url = new URL(request.url);
+            const cursor = url.searchParams.get("cursor");
+
+            if (!cursor) {
+              return HttpResponse.json({
+                events: [
+                  {
+                    sequenceNumber: 2,
+                    eventType: "item.completed",
+                    createdAt: "2024-01-15T10:31:00Z",
+                    eventData: {
+                      type: "item.completed",
+                      item: {
+                        id: "msg_1",
+                        type: "agent_message",
+                        text: "Codex page output",
+                      },
+                    },
+                  },
+                ],
+                framework: "codex",
+                hasMore: true,
+                nextCursor: "cursor-page-2",
+              });
+            }
+
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "assistant",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "assistant",
+                    message: {
+                      content: [
+                        {
+                          type: "text",
+                          text: "Future framework legacy output",
+                        },
+                      ],
+                    },
+                  },
+                },
+              ],
+              framework: "future-framework",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--all"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Future framework legacy output");
+      expect(logCalls).toContain("Codex page output");
+    });
+
     it("should stop pagination when target count is reached within single page", async () => {
       let requestCount = 0;
       server.use(

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -2245,6 +2245,62 @@ describe("logs command", () => {
       expect(logCalls).not.toContain("turn.started");
     });
 
+    it("should collapse Codex failures when only the terminal event has a turn id", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "thread.started",
+                  createdAt: "2024-01-15T10:29:59Z",
+                  eventData: {
+                    type: "thread.started",
+                    thread_id: "thread-x",
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "error",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "error",
+                    message: "API connection failed",
+                  },
+                },
+                {
+                  sequenceNumber: 3,
+                  eventType: "turn.completed",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "turn.completed",
+                    turn: {
+                      id: "turn-1",
+                      status: "failed",
+                      error: {
+                        message: "Rate limit exceeded",
+                      },
+                    },
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(countOccurrences(logCalls, "Codex Failed")).toBe(1);
+      expect(logCalls).toContain("API connection failed");
+      expect(logCalls).toContain("Rate limit exceeded");
+    });
+
     it("should keep the more detailed Codex error when one message contains another", async () => {
       server.use(
         http.get(

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -947,6 +947,69 @@ describe("logs command", () => {
       expect(logCalls).toContain("Done");
     });
 
+    it("should bound large TodoWrite todo lists", async () => {
+      const todos = Array.from({ length: 25 }, (_, index) => {
+        return { content: `task-${index}`, status: "pending" };
+      });
+
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "assistant",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "assistant",
+                    message: {
+                      content: [
+                        {
+                          type: "tool_use",
+                          name: "TodoWrite",
+                          id: "todo-large",
+                          input: { todos },
+                        },
+                      ],
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "user",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "user",
+                    message: {
+                      content: [
+                        {
+                          type: "tool_result",
+                          tool_use_id: "todo-large",
+                          content: "ok",
+                        },
+                      ],
+                    },
+                  },
+                },
+              ],
+              framework: "claude-code",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("task-0");
+      expect(logCalls).toContain("task-19");
+      expect(logCalls).toContain("… +5 tasks");
+      expect(logCalls).not.toContain("task-20");
+    });
+
     it("should handle tool_result events", async () => {
       server.use(
         http.get(

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -900,6 +900,70 @@ describe("logs command", () => {
       expect(logCalls).not.toContain("first result");
     });
 
+    it("should not duplicate ambiguous Codex tool headers when result metadata matches", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "item.started",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "item.started",
+                    item: {
+                      id: "duplicate-id",
+                      type: "command_execution",
+                      command: "first command",
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "item.started",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "item.started",
+                    item: {
+                      id: "duplicate-id",
+                      type: "command_execution",
+                      command: "second command",
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 3,
+                  eventType: "item.completed",
+                  createdAt: "2024-01-15T10:30:02Z",
+                  eventData: {
+                    type: "item.completed",
+                    item: {
+                      id: "duplicate-id",
+                      type: "command_execution",
+                      command: "second command",
+                      aggregated_output: "second result",
+                      exit_code: 0,
+                    },
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("first command");
+      expect(logCalls).toContain("second result");
+      expect(countOccurrences(logCalls, "second command")).toBe(1);
+    });
+
     it("should tolerate malformed TodoWrite todo items", async () => {
       server.use(
         http.get(

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -4665,6 +4665,35 @@ describe("logs command", () => {
       expect(capturedQuery?.since).toBeUndefined();
     });
 
+    it("should pass epoch --since values to API", async () => {
+      let capturedQuery: Record<string, unknown> | undefined;
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          ({ request }) => {
+            const url = new URL(request.url);
+            capturedQuery = Object.fromEntries(url.searchParams);
+            return HttpResponse.json({
+              events: [],
+              framework: "claude-code",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        RUN_ID,
+        "--since",
+        "1970-01-01T00:00:00Z",
+      ]);
+
+      expect(capturedQuery?.sinceTime).toBe("0");
+      expect(capturedQuery?.since).toBeUndefined();
+    });
+
     it("should pass --tail option to API with desc order", async () => {
       let capturedQuery: Record<string, unknown> | undefined;
       server.use(

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -48,6 +48,14 @@ function makeWideNestedObject(fieldCount: number): Record<string, unknown> {
   return value;
 }
 
+function makeNestedErrorObject(depth: number): Record<string, unknown> {
+  let value: Record<string, unknown> = { message: "deep failure" };
+  for (let index = 0; index < depth; index += 1) {
+    value = { error: value };
+  }
+  return value;
+}
+
 describe("logs command", () => {
   const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
     throw new Error("process.exit called");
@@ -2014,6 +2022,51 @@ describe("logs command", () => {
       expect(logCalls).toContain("Codex Completed");
       expect(logCalls).not.toContain("Codex Failed");
       expect(logCalls).not.toContain("message=null");
+    });
+
+    it("should bound deeply nested object turn errors when rendering successful turn.completed", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "thread.started",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "thread.started",
+                    thread_id: "thread-x",
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "turn.completed",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "turn.completed",
+                    turn: {
+                      id: "turn-1",
+                      status: "completed",
+                      error: makeNestedErrorObject(20),
+                    },
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Codex Completed");
+      expect(logCalls).not.toContain("Codex Failed");
+      expect(logCalls).not.toContain("deep failure");
     });
 
     it("should collapse same-turn Codex error and failed turn.completed while preserving details", async () => {

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -890,6 +890,63 @@ describe("logs command", () => {
       expect(logCalls).toContain("finished");
     });
 
+    it("should show done for empty TodoWrite todo lists", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "assistant",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "assistant",
+                    message: {
+                      content: [
+                        {
+                          type: "tool_use",
+                          name: "TodoWrite",
+                          id: "todo-empty",
+                          input: { todos: [] },
+                        },
+                      ],
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "user",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "user",
+                    message: {
+                      content: [
+                        {
+                          type: "tool_result",
+                          tool_use_id: "todo-empty",
+                          content: "ok",
+                        },
+                      ],
+                    },
+                  },
+                },
+              ],
+              framework: "claude-code",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("TodoWrite");
+      expect(logCalls).toContain("Done");
+    });
+
     it("should handle tool_result events", async () => {
       server.use(
         http.get(

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -2245,6 +2245,63 @@ describe("logs command", () => {
       expect(logCalls).not.toContain("turn.started");
     });
 
+    it("should keep the more detailed Codex error when one message contains another", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "thread.started",
+                  createdAt: "2024-01-15T10:29:59Z",
+                  eventData: {
+                    type: "thread.started",
+                    thread_id: "thread-x",
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "error",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "error",
+                    turn_id: "turn-1",
+                    message: "API connection failed",
+                  },
+                },
+                {
+                  sequenceNumber: 3,
+                  eventType: "turn.completed",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "turn.completed",
+                    turn: {
+                      id: "turn-1",
+                      status: "failed",
+                      error: {
+                        message: "API connection failed (retry later)",
+                      },
+                    },
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(countOccurrences(logCalls, "Codex Failed")).toBe(1);
+      expect(logCalls).toContain("API connection failed (retry later)");
+      expect(countOccurrences(logCalls, "API connection failed")).toBe(1);
+    });
+
     it("should not collapse Codex failures from different turns", async () => {
       server.use(
         http.get(

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -2648,6 +2648,63 @@ describe("logs command", () => {
       expect(logCalls).not.toContain("[object Object]");
     });
 
+    it("should bound large Codex plan and file-change lists", async () => {
+      const plan = Array.from({ length: 25 }, (_, index) => {
+        return { step: `step-${index}`, status: "pending" };
+      });
+      const changes = Array.from({ length: 25 }, (_, index) => {
+        return { path: `/workspace/file-${index}.ts`, kind: "add" };
+      });
+
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "turn.plan.updated",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "turn.plan.updated",
+                    plan,
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "item.completed",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "item.completed",
+                    item: {
+                      id: "changes-1",
+                      type: "file_change",
+                      changes,
+                    },
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("pending: step-0");
+      expect(logCalls).toContain("pending: step-19");
+      expect(logCalls).toContain("- ... +5 more steps");
+      expect(logCalls).not.toContain("pending: step-20");
+      expect(logCalls).toContain("Created: /workspace/file-0.ts");
+      expect(logCalls).toContain("Created: /workspace/file-19.ts");
+      expect(logCalls).toContain("... +5 more changes");
+      expect(logCalls).not.toContain("Created: /workspace/file-20.ts");
+    });
+
     it("should respect failed and declined statuses and flush pending tools", async () => {
       server.use(
         http.get(

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -1967,6 +1967,55 @@ describe("logs command", () => {
       expect(logCalls).not.toContain("Turn completed");
     });
 
+    it("should ignore empty object turn errors when rendering successful turn.completed", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "thread.started",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "thread.started",
+                    thread_id: "thread-x",
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "turn.completed",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "turn.completed",
+                    turn: {
+                      id: "turn-1",
+                      status: "completed",
+                      error: {
+                        message: null,
+                        error: false,
+                        additional_details: "   ",
+                      },
+                    },
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Codex Completed");
+      expect(logCalls).not.toContain("Codex Failed");
+      expect(logCalls).not.toContain("message=null");
+    });
+
     it("should collapse same-turn Codex error and failed turn.completed while preserving details", async () => {
       server.use(
         http.get(

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -1861,6 +1861,51 @@ describe("logs command", () => {
       expect(logCalls).not.toContain("Error: null");
     });
 
+    it("should ignore false turn errors when rendering successful turn.completed", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "thread.started",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "thread.started",
+                    thread_id: "thread-x",
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "turn.completed",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "turn.completed",
+                    turn: {
+                      id: "turn-1",
+                      status: "completed",
+                      error: false,
+                    },
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Codex Completed");
+      expect(logCalls).not.toContain("Codex Failed");
+      expect(logCalls).not.toContain("Error: false");
+    });
+
     it("should collapse same-turn Codex error and failed turn.completed while preserving details", async () => {
       server.use(
         http.get(

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -32,6 +32,14 @@ function makeAgentEvent(sequenceNumber: number) {
   };
 }
 
+function makeNestedArray(depth: number): unknown[] {
+  let value: unknown[] = ["leaf"];
+  for (let index = 0; index < depth; index += 1) {
+    value = [value];
+  }
+  return value;
+}
+
 describe("logs command", () => {
   const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
     throw new Error("process.exit called");
@@ -2321,6 +2329,46 @@ describe("logs command", () => {
       expect(logCalls).toContain("retry later");
       expect(logCalls).toContain("Modified: /workspace/ok.ts");
       expect(logCalls).not.toContain("[object Object]");
+    });
+
+    it("should bound deeply nested Codex error detail formatting", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "turn.completed",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "turn.completed",
+                    turn: {
+                      id: "turn-1",
+                      status: "failed",
+                      error: {
+                        message: "nested error detail",
+                        connectors: makeNestedArray(20),
+                      },
+                    },
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(mockExit).not.toHaveBeenCalled();
+      expect(logCalls).toContain("nested error detail");
+      expect(logCalls).toContain("...");
+      expect(logCalls).not.toContain("leaf");
     });
   });
 

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -1579,6 +1579,97 @@ describe("logs command", () => {
       expect(logCalls).not.toContain("[object Object]");
     });
 
+    it("should render turn.completed with an error payload as failed when status is missing", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "thread.started",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "thread.started",
+                    thread_id: "thread-x",
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "turn.completed",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "turn.completed",
+                    turn: {
+                      id: "turn-1",
+                      error: {
+                        message: "server overloaded",
+                      },
+                    },
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Codex Failed");
+      expect(logCalls).toContain("server overloaded");
+      expect(logCalls).not.toContain("Codex Completed");
+    });
+
+    it("should render cancelled turn.completed as failed", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "thread.started",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "thread.started",
+                    thread_id: "thread-x",
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "turn.completed",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "turn.completed",
+                    turn: {
+                      id: "turn-1",
+                      status: "cancelled",
+                      error: null,
+                    },
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Codex Failed");
+      expect(logCalls).toContain("Turn cancelled");
+      expect(logCalls).not.toContain("Codex Completed");
+    });
+
     it("should ignore null turn errors when rendering failed turn.completed", async () => {
       server.use(
         http.get(

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -829,10 +829,12 @@ describe("logs command", () => {
                   createdAt: "2024-01-15T10:30:02Z",
                   eventData: {
                     type: "turn.completed",
-                    usage: {
-                      input_tokens: 24763,
-                      cached_input_tokens: 24448,
-                      output_tokens: 122,
+                    turn: {
+                      usage: {
+                        input_tokens: 24763,
+                        cached_input_tokens: 24448,
+                        output_tokens: 122,
+                      },
                     },
                   },
                 },
@@ -851,6 +853,7 @@ describe("logs command", () => {
       expect(logCalls).toContain("0199a213-81c0-7800-8aa1-bbab2a035a53");
       expect(logCalls).toContain("Codex says hello");
       expect(logCalls).toContain("Codex Completed");
+      expect(logCalls).toContain("input=24k output=122");
     });
 
     it("should render command_execution as Bash tool with output", async () => {
@@ -903,6 +906,79 @@ describe("logs command", () => {
       expect(logCalls).toContain("Bash");
       expect(logCalls).toContain("bash -lc ls");
       expect(logCalls).toContain("README.md");
+    });
+
+    it("should render completed-only Codex tool events", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "item.completed",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "item.completed",
+                    item: {
+                      id: "cmd_only",
+                      type: "command_execution",
+                      command: "echo completed-only",
+                      exit_code: 0,
+                      aggregated_output: "completed output\n",
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "item.completed",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "item.completed",
+                    item: {
+                      id: "edit_only",
+                      type: "file_edit",
+                      path: "/workspace/src/edge.ts",
+                      diff: "-before\n+after",
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 3,
+                  eventType: "item.completed",
+                  createdAt: "2024-01-15T10:30:02Z",
+                  eventData: {
+                    type: "item.completed",
+                    item: {
+                      id: "read_only",
+                      type: "file_read",
+                      path: "/workspace/package.json",
+                      status: "completed",
+                    },
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Bash");
+      expect(logCalls).toContain("echo completed-only");
+      expect(logCalls).toContain("completed output");
+      expect(logCalls).toContain("Edit");
+      expect(logCalls).toContain("/workspace/src/edge.ts");
+      expect(logCalls).toContain("-before");
+      expect(logCalls).toContain("+after");
+      expect(logCalls).toContain("Read");
+      expect(logCalls).toContain("/workspace/package.json");
+      expect(logCalls).toContain("File read completed");
     });
 
     it("should mark command_execution with non-zero exit_code as error", async () => {

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -4564,6 +4564,39 @@ describe("logs command", () => {
       expect(logCalls).not.toContain("app.platform.");
     });
 
+    it("should replace api subdomain with app", async () => {
+      vi.stubEnv("VM0_API_URL", "https://api.vm0.ai");
+
+      server.use(
+        http.get(
+          "https://api.vm0.ai/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "assistant",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "assistant",
+                    message: { content: [{ type: "text", text: "Test" }] },
+                  },
+                },
+              ],
+              framework: "claude-code",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", RUN_ID]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain(`https://app.vm0.ai/logs/${RUN_ID}`);
+      expect(logCalls).not.toContain("app.api.");
+    });
+
     it("should transform vm7.ai:8443 to app.vm7.ai:8443", async () => {
       vi.stubEnv("VM0_API_URL", "https://www.vm7.ai:8443");
 

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -1493,6 +1493,54 @@ describe("logs command", () => {
       expect(logCalls).toContain("Codex Failed");
     });
 
+    it("should render turn.failed with nested turn error details", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "thread.started",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "thread.started",
+                    thread_id: "thread-x",
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "turn.failed",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "turn.failed",
+                    turn: {
+                      id: "turn-1",
+                      error: {
+                        message: "selected model is at capacity",
+                        additional_details: "retry later",
+                      },
+                    },
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Codex Failed");
+      expect(logCalls).toContain("selected model is at capacity");
+      expect(logCalls).toContain("retry later");
+      expect(logCalls).not.toContain("Turn failed");
+    });
+
     it("should render truncated Codex result events with the Codex label", async () => {
       server.use(
         http.get(
@@ -2584,6 +2632,73 @@ describe("logs command", () => {
       expect(logCalls).toContain("File read declined");
       expect(logCalls).toContain("sleep 10");
       expect(countOccurrences(logCalls, "✗")).toBeGreaterThanOrEqual(2);
+    });
+
+    it("should render Codex item error payloads without explicit failed status", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "item.completed",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "item.completed",
+                    item: {
+                      id: "cmd-error",
+                      type: "command_execution",
+                      command: "deploy",
+                      error: { message: "permission denied" },
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "item.completed",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "item.completed",
+                    item: {
+                      id: "read-error",
+                      type: "file_read",
+                      path: "/workspace/private.txt",
+                      error: { message: "read was denied" },
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 3,
+                  eventType: "item.completed",
+                  createdAt: "2024-01-15T10:30:02Z",
+                  eventData: {
+                    type: "item.completed",
+                    item: {
+                      id: "files-error",
+                      type: "file_change",
+                      error: { message: "patch rejected" },
+                    },
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("permission denied");
+      expect(logCalls).toContain("read was denied");
+      expect(logCalls).toContain("[files]");
+      expect(logCalls).toContain("patch rejected");
+      expect(countOccurrences(logCalls, "✗")).toBeGreaterThanOrEqual(2);
+      expect(logCalls).not.toContain("File read completed");
     });
 
     it("should keep delayed Codex tool results after intervening text", async () => {

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -242,6 +242,54 @@ describe("logs command", () => {
       expect(requestCount).toBe(2);
     });
 
+    it("should continue agent pagination past empty pages with cursors", async () => {
+      const capturedCursors: (string | null)[] = [];
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          ({ request }) => {
+            const url = new URL(request.url);
+            const cursor = url.searchParams.get("cursor");
+            capturedCursors.push(cursor);
+
+            if (!cursor) {
+              return HttpResponse.json({
+                events: [],
+                framework: "claude-code",
+                hasMore: true,
+                nextCursor: "cursor-page-2",
+              });
+            }
+
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "assistant",
+                  createdAt: "2024-01-15T10:31:00Z",
+                  eventData: {
+                    type: "assistant",
+                    message: {
+                      content: [{ type: "text", text: "After empty page" }],
+                    },
+                  },
+                },
+              ],
+              framework: "claude-code",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--all"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("After empty page");
+      expect(logCalls).not.toContain("No agent events found");
+      expect(capturedCursors).toStrictEqual([null, "cursor-page-2"]);
+    });
+
     it("should preserve per-page framework when a later page omits it", async () => {
       server.use(
         http.get(

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -824,6 +824,82 @@ describe("logs command", () => {
       expect(logCalls).not.toContain("orphan output");
     });
 
+    it("should not pair duplicate tool ids with the wrong tool use", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "assistant",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "assistant",
+                    message: {
+                      content: [
+                        {
+                          type: "tool_use",
+                          name: "Bash",
+                          id: "duplicate-id",
+                          input: { command: "first command" },
+                        },
+                      ],
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "assistant",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "assistant",
+                    message: {
+                      content: [
+                        {
+                          type: "tool_use",
+                          name: "Bash",
+                          id: "duplicate-id",
+                          input: { command: "second command" },
+                        },
+                      ],
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 3,
+                  eventType: "user",
+                  createdAt: "2024-01-15T10:30:02Z",
+                  eventData: {
+                    type: "user",
+                    message: {
+                      content: [
+                        {
+                          type: "tool_result",
+                          tool_use_id: "duplicate-id",
+                          content: "first result",
+                        },
+                      ],
+                    },
+                  },
+                },
+              ],
+              framework: "claude-code",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("first command");
+      expect(logCalls).toContain("second command");
+      expect(logCalls).not.toContain("first result");
+    });
+
     it("should tolerate malformed TodoWrite todo items", async () => {
       server.use(
         http.get(

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -605,6 +605,75 @@ describe("logs command", () => {
       expect(logCalls).toContain("File content here");
     });
 
+    it("should not pair malformed tool results with tool uses that lack ids", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "assistant",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "assistant",
+                    message: {
+                      content: [
+                        {
+                          type: "tool_use",
+                          name: "Bash",
+                          input: { command: "echo no-id" },
+                        },
+                      ],
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "user",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "user",
+                    message: {
+                      content: [
+                        {
+                          type: "tool_result",
+                          content: "orphan output",
+                        },
+                      ],
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 3,
+                  eventType: "assistant",
+                  createdAt: "2024-01-15T10:30:02Z",
+                  eventData: {
+                    type: "assistant",
+                    message: {
+                      content: [
+                        { type: "text", text: "after malformed result" },
+                      ],
+                    },
+                  },
+                },
+              ],
+              framework: "claude-code",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("echo no-id");
+      expect(logCalls).toContain("after malformed result");
+      expect(logCalls).not.toContain("orphan output");
+    });
+
     it("should handle tool_result events", async () => {
       server.use(
         http.get(

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -1240,6 +1240,409 @@ describe("logs command", () => {
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(countOccurrences(logCalls, "Codex Failed")).toBe(1);
     });
+
+    it("should render failed turn.completed with nested error details", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "thread.started",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "thread.started",
+                    thread_id: "thread-x",
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "turn.completed",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "turn.completed",
+                    thread_id: "thread-x",
+                    turn: {
+                      id: "turn-1",
+                      status: "failed",
+                      duration_ms: 1200,
+                      error: {
+                        message: "selected model is at capacity",
+                        additional_details: "retry later",
+                        codex_error_info: "serverOverloaded",
+                      },
+                    },
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Codex Failed");
+      expect(logCalls).toContain("selected model is at capacity");
+      expect(logCalls).toContain("retry later");
+      expect(logCalls).not.toContain("[object Object]");
+    });
+
+    it("should collapse same-turn Codex error and failed turn.completed while preserving details", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "thread.started",
+                  createdAt: "2024-01-15T10:29:59Z",
+                  eventData: {
+                    type: "thread.started",
+                    thread_id: "thread-x",
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "error",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "error",
+                    turn_id: "turn-1",
+                    message: "API connection failed",
+                  },
+                },
+                {
+                  sequenceNumber: 3,
+                  eventType: "turn.completed",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "turn.completed",
+                    turn: {
+                      id: "turn-1",
+                      status: "failed",
+                      error: {
+                        message: "Rate limit exceeded",
+                      },
+                    },
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(countOccurrences(logCalls, "Codex Failed")).toBe(1);
+      expect(logCalls).toContain("API connection failed");
+      expect(logCalls).toContain("Rate limit exceeded");
+    });
+
+    it("should not collapse Codex failures from different turns", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "thread.started",
+                  createdAt: "2024-01-15T10:29:59Z",
+                  eventData: {
+                    type: "thread.started",
+                    thread_id: "thread-x",
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "error",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "error",
+                    turn_id: "turn-1",
+                    message: "First turn failed",
+                  },
+                },
+                {
+                  sequenceNumber: 3,
+                  eventType: "turn.completed",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "turn.completed",
+                    turn: {
+                      id: "turn-2",
+                      status: "failed",
+                      error: {
+                        message: "Second turn failed",
+                      },
+                    },
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(countOccurrences(logCalls, "Codex Failed")).toBe(2);
+      expect(logCalls).toContain("First turn failed");
+      expect(logCalls).toContain("Second turn failed");
+    });
+
+    it("should render warnings, plans, and generic completed items", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "warning",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "warning",
+                    message: "configuration warning",
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "turn.plan.updated",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "turn.plan.updated",
+                    explanation: "working",
+                    plan: [
+                      { step: "read files", status: "completed" },
+                      { step: "write fix", status: "in_progress" },
+                    ],
+                  },
+                },
+                {
+                  sequenceNumber: 3,
+                  eventType: "item.completed",
+                  createdAt: "2024-01-15T10:30:02Z",
+                  eventData: {
+                    type: "item.completed",
+                    item: {
+                      id: "plan-1",
+                      type: "plan",
+                      text: "Review implementation",
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 4,
+                  eventType: "item.completed",
+                  createdAt: "2024-01-15T10:30:03Z",
+                  eventData: {
+                    type: "item.completed",
+                    item: {
+                      id: "mcp-1",
+                      type: "mcp_tool_call",
+                      status: "completed",
+                      server: "github",
+                      tool: "listIssues",
+                      arguments: { owner: "vm0-ai" },
+                    },
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("[warning] configuration warning");
+      expect(logCalls).toContain("[plan]");
+      expect(logCalls).toContain("working");
+      expect(logCalls).toContain("completed: read files");
+      expect(logCalls).toContain("Review implementation");
+      expect(logCalls).toContain("[item] mcp_tool_call");
+      expect(logCalls).toContain("server=github");
+      expect(logCalls).not.toContain("Codex Failed");
+      expect(logCalls).not.toContain("[object Object]");
+    });
+
+    it("should respect failed and declined statuses and flush pending tools", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "item.started",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "item.started",
+                    item: {
+                      id: "cmd-failed",
+                      type: "command_execution",
+                      command: "deploy",
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "item.completed",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "item.completed",
+                    item: {
+                      id: "cmd-failed",
+                      type: "command_execution",
+                      status: "failed",
+                      aggregated_output: "permission denied",
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 3,
+                  eventType: "item.started",
+                  createdAt: "2024-01-15T10:30:02Z",
+                  eventData: {
+                    type: "item.started",
+                    item: {
+                      id: "read-declined",
+                      type: "file_read",
+                      path: "/workspace/private.txt",
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 4,
+                  eventType: "item.completed",
+                  createdAt: "2024-01-15T10:30:03Z",
+                  eventData: {
+                    type: "item.completed",
+                    item: {
+                      id: "read-declined",
+                      type: "file_read",
+                      status: "declined",
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 5,
+                  eventType: "item.started",
+                  createdAt: "2024-01-15T10:30:04Z",
+                  eventData: {
+                    type: "item.started",
+                    item: {
+                      id: "cmd-pending",
+                      type: "command_execution",
+                      command: "sleep 10",
+                    },
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("deploy");
+      expect(logCalls).toContain("permission denied");
+      expect(logCalls).toContain("File read declined");
+      expect(logCalls).toContain("sleep 10");
+      expect(countOccurrences(logCalls, "✗")).toBeGreaterThanOrEqual(2);
+    });
+
+    it("should tolerate malformed optional Codex payload fields", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "malformed",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: 123,
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "turn.completed",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "turn.completed",
+                    turn: {
+                      id: "turn-1",
+                      status: "failed",
+                      error: {
+                        code: "server_error",
+                        additional_details: "retry later",
+                      },
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 3,
+                  eventType: "item.completed",
+                  createdAt: "2024-01-15T10:30:02Z",
+                  eventData: {
+                    type: "item.completed",
+                    item: {
+                      id: "change-1",
+                      type: "file_change",
+                      changes: [
+                        null,
+                        { kind: { type: "modify" }, path: 12 },
+                        { kind: "modify", path: "/workspace/ok.ts" },
+                      ],
+                    },
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(mockExit).not.toHaveBeenCalled();
+      expect(logCalls).toContain("server_error");
+      expect(logCalls).toContain("retry later");
+      expect(logCalls).toContain("Modified: /workspace/ok.ts");
+      expect(logCalls).not.toContain("[object Object]");
+    });
   });
 
   describe("system log", () => {

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -926,7 +926,7 @@ describe("logs command", () => {
                       type: "command_execution",
                       command: "echo completed-only",
                       exit_code: 0,
-                      aggregated_output: "completed output\n",
+                      aggregated_output: "  completed output  \n",
                     },
                   },
                 },
@@ -940,7 +940,7 @@ describe("logs command", () => {
                       id: "edit_only",
                       type: "file_edit",
                       path: "/workspace/src/edge.ts",
-                      diff: "-before\n+after",
+                      diff: "-before  \n+ after",
                     },
                   },
                 },
@@ -955,6 +955,7 @@ describe("logs command", () => {
                       type: "file_read",
                       path: "/workspace/package.json",
                       status: "completed",
+                      output: "  file body  \n",
                     },
                   },
                 },
@@ -971,14 +972,14 @@ describe("logs command", () => {
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Bash");
       expect(logCalls).toContain("echo completed-only");
-      expect(logCalls).toContain("completed output");
+      expect(logCalls).toContain("  completed output  ");
       expect(logCalls).toContain("Edit");
       expect(logCalls).toContain("/workspace/src/edge.ts");
-      expect(logCalls).toContain("-before");
-      expect(logCalls).toContain("+after");
+      expect(logCalls).toContain("-before  ");
+      expect(logCalls).toContain("+ after");
       expect(logCalls).toContain("Read");
       expect(logCalls).toContain("/workspace/package.json");
-      expect(logCalls).toContain("File read completed");
+      expect(logCalls).toContain("  file body  ");
     });
 
     it("should mark command_execution with non-zero exit_code as error", async () => {
@@ -1077,6 +1078,7 @@ describe("logs command", () => {
                       id: "write_1",
                       type: "file_write",
                       path: "/workspace/README.md",
+                      diff: "",
                     },
                   },
                 },
@@ -1103,6 +1105,7 @@ describe("logs command", () => {
                       id: "read_1",
                       type: "file_read",
                       path: "/workspace/package.json",
+                      output: "",
                     },
                   },
                 },
@@ -1139,6 +1142,7 @@ describe("logs command", () => {
       expect(logCalls).toContain("File operation completed");
       expect(logCalls).toContain("Read");
       expect(logCalls).toContain("/workspace/package.json");
+      expect(logCalls).toContain("File read completed");
     });
 
     it("should render reasoning items with [thinking] prefix", async () => {

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -2403,6 +2403,57 @@ describe("logs command", () => {
       expect(logCalls).toContain("Rate limit exceeded");
     });
 
+    it("should not collapse Codex failures when only the pending error has a turn id", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "thread.started",
+                  createdAt: "2024-01-15T10:29:59Z",
+                  eventData: {
+                    type: "thread.started",
+                    thread_id: "thread-x",
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "error",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "error",
+                    turn_id: "turn-1",
+                    message: "First turn failed",
+                  },
+                },
+                {
+                  sequenceNumber: 3,
+                  eventType: "turn.failed",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "turn.failed",
+                    error: "Unattributed terminal failure",
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(countOccurrences(logCalls, "Codex Failed")).toBe(2);
+      expect(logCalls).toContain("First turn failed");
+      expect(logCalls).toContain("Unattributed terminal failure");
+    });
+
     it("should keep the more detailed Codex error when one message contains another", async () => {
       server.use(
         http.get(

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -228,6 +228,62 @@ describe("logs command", () => {
       expect(requestCount).toBe(2);
     });
 
+    it("should preserve per-page framework when a later page omits it", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          ({ request }) => {
+            const url = new URL(request.url);
+            const cursor = url.searchParams.get("cursor");
+
+            if (!cursor) {
+              return HttpResponse.json({
+                events: [
+                  {
+                    sequenceNumber: 2,
+                    eventType: "item.completed",
+                    createdAt: "2024-01-15T10:31:00Z",
+                    eventData: {
+                      type: "item.completed",
+                      item: {
+                        id: "msg_1",
+                        type: "agent_message",
+                        text: "Codex page output",
+                      },
+                    },
+                  },
+                ],
+                framework: "codex",
+                hasMore: true,
+                nextCursor: "cursor-page-2",
+              });
+            }
+
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "thread.started",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "thread.started",
+                    thread_id: "thread-page-1",
+                  },
+                },
+              ],
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--all"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Codex Started");
+      expect(logCalls).toContain("Codex page output");
+    });
+
     it("should stop pagination when target count is reached within single page", async () => {
       let requestCount = 0;
       server.use(

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -85,6 +85,16 @@ describe("logs command", () => {
   });
 
   describe("agent events (default)", () => {
+    it("should reject non-UUID run IDs", async () => {
+      await expect(
+        logsCommand.parseAsync(["node", "cli", "run-123"]),
+      ).rejects.toThrow("process.exit called");
+
+      const errorCalls = mockConsoleError.mock.calls.flat().join("\n");
+      expect(errorCalls).toContain("Invalid run ID");
+      expect(errorCalls).toContain("vm0 run list");
+    });
+
     it("should display agent events with timestamps", async () => {
       server.use(
         http.get(
@@ -111,7 +121,11 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Hello, world!");
@@ -143,7 +157,11 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("[invalid-date]");
@@ -164,7 +182,11 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("No agent events found");
@@ -220,7 +242,12 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--all"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--all",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Page 1");
@@ -277,7 +304,12 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--all"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--all",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Codex Started");
@@ -341,7 +373,12 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--all"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--all",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Future framework legacy output");
@@ -392,7 +429,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--tail", "2"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--tail",
+        "2",
+      ]);
 
       // Should only make 1 request since we got enough events
       expect(requestCount).toBe(1);
@@ -476,7 +519,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--tail", "3"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--tail",
+        "3",
+      ]);
 
       // Should make 2 requests to collect 3 events
       expect(requestCount).toBe(2);
@@ -537,7 +586,12 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--all"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--all",
+      ]);
 
       expect(capturedCursorValues).toHaveLength(2);
       expect(capturedCursorValues[0]).toBeNull();
@@ -578,7 +632,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--tail", "101"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--tail",
+        "101",
+      ]);
 
       expect(capturedCursors).toStrictEqual([null, "sequence:desc:101"]);
       expect(capturedLimits).toStrictEqual(["100", "1"]);
@@ -630,7 +690,12 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--all"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--all",
+      ]);
 
       // Should stop after 2 requests (not infinite loop)
       expect(requestCount).toBe(2);
@@ -674,7 +739,12 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--all"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--all",
+      ]);
 
       expect(requestCount).toBe(2);
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
@@ -721,7 +791,12 @@ describe("logs command", () => {
       );
 
       await expect(async () => {
-        await logsCommand.parseAsync(["node", "cli", "run-123", "--all"]);
+        await logsCommand.parseAsync([
+          "node",
+          "cli",
+          "abc12345-1234-1234-1234-123456789abc",
+          "--all",
+        ]);
       }).rejects.toThrow("process.exit called");
 
       expect(requestCount).toBe(2);
@@ -783,7 +858,11 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Read");
@@ -865,7 +944,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "100",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("printf false");
@@ -936,7 +1021,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "100",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("echo no-id");
@@ -1012,7 +1103,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "100",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("first command");
@@ -1091,7 +1188,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "100",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("first result");
@@ -1157,7 +1260,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "100",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("TodoWrite");
@@ -1216,7 +1325,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "100",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("TodoWrite");
@@ -1277,7 +1392,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "100",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("task-0");
@@ -1311,7 +1432,11 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+      ]);
 
       // Result events are handled without error
       expect(mockExit).not.toHaveBeenCalled();
@@ -1341,7 +1466,11 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+      ]);
 
       // Should not crash on unknown event types
       expect(mockExit).not.toHaveBeenCalled();
@@ -1371,7 +1500,11 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+      ]);
 
       // Should handle empty content gracefully
       expect(mockExit).not.toHaveBeenCalled();
@@ -1398,7 +1531,11 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+      ]);
 
       // Should handle malformed data gracefully
       expect(mockExit).not.toHaveBeenCalled();
@@ -1459,7 +1596,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "100",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Codex Started");
@@ -1513,7 +1656,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "100",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Bash");
@@ -1595,7 +1744,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "100",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Bash");
@@ -1656,7 +1811,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "100",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("ls /nonexistent");
@@ -1760,7 +1921,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "100",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Edit");
@@ -1803,7 +1970,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "100",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("[thinking] Considering the trade-offs");
@@ -1841,7 +2014,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "100",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("[files]");
@@ -1883,7 +2062,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "100",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Codex Failed");
@@ -1934,7 +2119,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "100",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Codex Failed");
@@ -1970,7 +2161,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--tail", "1"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--tail",
+        "1",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Codex Failed");
@@ -2010,7 +2207,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "100",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Codex Failed");
@@ -2051,7 +2254,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "100",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Codex Failed");
@@ -2103,7 +2312,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "100",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(countOccurrences(logCalls, "Codex Failed")).toBe(1);
@@ -2151,7 +2366,11 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(countOccurrences(logCalls, "Codex Failed")).toBe(1);
@@ -2200,7 +2419,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "100",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Codex Failed");
@@ -2247,7 +2472,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "100",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Codex Failed");
@@ -2292,7 +2523,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "100",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Codex Failed");
@@ -2336,7 +2573,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "100",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Codex Failed");
@@ -2383,7 +2626,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "100",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Codex Failed");
@@ -2428,7 +2677,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "100",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Codex Completed");
@@ -2473,7 +2728,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "100",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Codex Completed");
@@ -2523,7 +2784,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "100",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Codex Completed");
@@ -2571,7 +2838,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "100",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Codex Failed");
@@ -2616,7 +2889,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "100",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Codex Completed");
@@ -2673,7 +2952,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "100",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(countOccurrences(logCalls, "Codex Failed")).toBe(1);
@@ -2734,7 +3019,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "100",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(countOccurrences(logCalls, "Codex Failed")).toBe(1);
@@ -2791,7 +3082,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "100",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(countOccurrences(logCalls, "Codex Failed")).toBe(1);
@@ -2842,7 +3139,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "100",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(countOccurrences(logCalls, "Codex Failed")).toBe(2);
@@ -2899,7 +3202,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "100",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(countOccurrences(logCalls, "Codex Failed")).toBe(1);
@@ -2956,7 +3265,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "100",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(countOccurrences(logCalls, "Codex Failed")).toBe(2);
@@ -3030,7 +3345,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "100",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("[warning] configuration warning");
@@ -3088,7 +3409,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "100",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("pending: step-0");
@@ -3182,7 +3509,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "100",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("deploy");
@@ -3261,7 +3594,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "100",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("permission denied");
@@ -3328,7 +3667,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "100",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       const commandIndex = logCalls.indexOf("printf delayed");
@@ -3400,7 +3745,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "100",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(mockExit).not.toHaveBeenCalled();
@@ -3445,7 +3796,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "100",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(mockExit).not.toHaveBeenCalled();
@@ -3483,7 +3840,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "100",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(mockExit).not.toHaveBeenCalled();
@@ -3507,7 +3870,12 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--system"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--system",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("System started");
@@ -3527,7 +3895,12 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--system"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--system",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("No system log found");
@@ -3562,7 +3935,7 @@ describe("logs command", () => {
       await logsCommand.parseAsync([
         "node",
         "cli",
-        "run-123",
+        "abc12345-1234-1234-1234-123456789abc",
         "--system",
         "--all",
       ]);
@@ -3602,7 +3975,7 @@ describe("logs command", () => {
       await logsCommand.parseAsync([
         "node",
         "cli",
-        "run-123",
+        "abc12345-1234-1234-1234-123456789abc",
         "--system",
         "--all",
       ]);
@@ -3639,7 +4012,12 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--system"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--system",
+      ]);
 
       expect(capturedCursors).toStrictEqual([null, "time:desc:1"]);
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
@@ -3671,7 +4049,12 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--metrics"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--metrics",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("CPU:");
@@ -3693,7 +4076,12 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--metrics"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--metrics",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("No metrics found");
@@ -3726,7 +4114,12 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--network"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--network",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("GET");
@@ -3756,7 +4149,12 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--network"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--network",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("DENY");
@@ -3793,7 +4191,12 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--network"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--network",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("BLOCK");
@@ -3828,7 +4231,12 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--network"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--network",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("BLOCK");
@@ -3864,7 +4272,12 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--network"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--network",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("502");
@@ -3903,7 +4316,12 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--network"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--network",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("connector diagnostic");
@@ -3936,7 +4354,12 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--network"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--network",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("TCP");
@@ -3968,7 +4391,12 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--network"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--network",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("TCP");
@@ -3999,7 +4427,12 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--network"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--network",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("DNS");
@@ -4020,7 +4453,12 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--network"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--network",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("No network logs found");
@@ -4033,7 +4471,7 @@ describe("logs command", () => {
         await logsCommand.parseAsync([
           "node",
           "cli",
-          "run-123",
+          "abc12345-1234-1234-1234-123456789abc",
           "--system",
           "--metrics",
         ]);
@@ -4063,7 +4501,7 @@ describe("logs command", () => {
         await logsCommand.parseAsync([
           "node",
           "cli",
-          "run-123",
+          "abc12345-1234-1234-1234-123456789abc",
           "--tail",
           "10",
           "--head",
@@ -4082,7 +4520,7 @@ describe("logs command", () => {
         await logsCommand.parseAsync([
           "node",
           "cli",
-          "run-123",
+          "abc12345-1234-1234-1234-123456789abc",
           "--tail",
           "10",
           "--all",
@@ -4100,7 +4538,7 @@ describe("logs command", () => {
         await logsCommand.parseAsync([
           "node",
           "cli",
-          "run-123",
+          "abc12345-1234-1234-1234-123456789abc",
           "--head",
           "10",
           "--all",
@@ -4118,7 +4556,7 @@ describe("logs command", () => {
         await logsCommand.parseAsync([
           "node",
           "cli",
-          "run-123",
+          "abc12345-1234-1234-1234-123456789abc",
           "--tail",
           "abc",
         ]);
@@ -4136,7 +4574,7 @@ describe("logs command", () => {
         await logsCommand.parseAsync([
           "node",
           "cli",
-          "run-123",
+          "abc12345-1234-1234-1234-123456789abc",
           "--tail",
           "000",
         ]);
@@ -4154,7 +4592,7 @@ describe("logs command", () => {
         await logsCommand.parseAsync([
           "node",
           "cli",
-          "run-123",
+          "abc12345-1234-1234-1234-123456789abc",
           "--tail",
           "1e2",
         ]);
@@ -4168,7 +4606,13 @@ describe("logs command", () => {
 
     it("should exit with error when --head is not a positive integer", async () => {
       await expect(async () => {
-        await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "0"]);
+        await logsCommand.parseAsync([
+          "node",
+          "cli",
+          "abc12345-1234-1234-1234-123456789abc",
+          "--head",
+          "0",
+        ]);
       }).rejects.toThrow("process.exit called");
 
       expect(mockExit).toHaveBeenCalledWith(1);
@@ -4193,7 +4637,11 @@ describe("logs command", () => {
       );
 
       await expect(async () => {
-        await logsCommand.parseAsync(["node", "cli", "run-123"]);
+        await logsCommand.parseAsync([
+          "node",
+          "cli",
+          "abc12345-1234-1234-1234-123456789abc",
+        ]);
       }).rejects.toThrow("process.exit called");
 
       expect(mockExit).toHaveBeenCalledWith(1);
@@ -4216,7 +4664,11 @@ describe("logs command", () => {
       );
 
       await expect(async () => {
-        await logsCommand.parseAsync(["node", "cli", "nonexistent-run"]);
+        await logsCommand.parseAsync([
+          "node",
+          "cli",
+          "ffffffff-ffff-4fff-8fff-ffffffffffff",
+        ]);
       }).rejects.toThrow("process.exit called");
 
       expect(mockExit).toHaveBeenCalledWith(1);
@@ -4243,7 +4695,7 @@ describe("logs command", () => {
         await logsCommand.parseAsync([
           "node",
           "cli",
-          "run-123",
+          "abc12345-1234-1234-1234-123456789abc",
           "--since",
           "invalid-time",
         ]);
@@ -4260,7 +4712,7 @@ describe("logs command", () => {
         await logsCommand.parseAsync([
           "node",
           "cli",
-          "run-123",
+          "abc12345-1234-1234-1234-123456789abc",
           "--since",
           "2024-02-30T00:00:00Z",
         ]);
@@ -4277,7 +4729,7 @@ describe("logs command", () => {
         await logsCommand.parseAsync([
           "node",
           "cli",
-          "run-123",
+          "abc12345-1234-1234-1234-123456789abc",
           "--since",
           "8640000000000001",
         ]);
@@ -4303,7 +4755,11 @@ describe("logs command", () => {
       );
 
       await expect(async () => {
-        await logsCommand.parseAsync(["node", "cli", "run-123"]);
+        await logsCommand.parseAsync([
+          "node",
+          "cli",
+          "abc12345-1234-1234-1234-123456789abc",
+        ]);
       }).rejects.toThrow("process.exit called");
 
       expect(mockExit).toHaveBeenCalledWith(1);
@@ -4340,11 +4796,17 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("View on platform:");
-      expect(logCalls).toContain("http://localhost:3001/logs/run-123");
+      expect(logCalls).toContain(
+        "http://localhost:3001/logs/abc12345-1234-1234-1234-123456789abc",
+      );
     });
 
     it("should NOT display platform URL for system logs", async () => {
@@ -4360,7 +4822,12 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--system"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--system",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).not.toContain("View on platform:");
@@ -4388,7 +4855,12 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--metrics"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--metrics",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).not.toContain("View on platform:");
@@ -4416,7 +4888,12 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--network"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--network",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).not.toContain("View on platform:");
@@ -4448,10 +4925,16 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain("https://app.vm0.ai/logs/run-123");
+      expect(logCalls).toContain(
+        "https://app.vm0.ai/logs/abc12345-1234-1234-1234-123456789abc",
+      );
     });
 
     it("should not double-prefix when input URL already has app subdomain", async () => {
@@ -4480,10 +4963,16 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain("https://app.vm0.ai/logs/run-123");
+      expect(logCalls).toContain(
+        "https://app.vm0.ai/logs/abc12345-1234-1234-1234-123456789abc",
+      );
       expect(logCalls).not.toContain("app.app.");
     });
 
@@ -4513,10 +5002,16 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain("https://app.vm0.ai/logs/run-123");
+      expect(logCalls).toContain(
+        "https://app.vm0.ai/logs/abc12345-1234-1234-1234-123456789abc",
+      );
       expect(logCalls).not.toContain("app.platform.");
     });
 
@@ -4546,10 +5041,16 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain("https://app.vm7.ai:8443/logs/run-123");
+      expect(logCalls).toContain(
+        "https://app.vm7.ai:8443/logs/abc12345-1234-1234-1234-123456789abc",
+      );
     });
   });
 
@@ -4571,7 +5072,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--since", "5m"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--since",
+        "5m",
+      ]);
 
       expect(capturedQuery?.sinceTime).toBeDefined();
       expect(capturedQuery?.since).toBeUndefined();
@@ -4594,7 +5101,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--tail", "020"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--tail",
+        "020",
+      ]);
 
       // Small finite requests only fetch the remaining target count.
       expect(capturedQuery?.limit).toBe("20");
@@ -4618,7 +5131,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "010"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--head",
+        "010",
+      ]);
 
       // Small finite requests only fetch the remaining target count.
       expect(capturedQuery?.limit).toBe("10");
@@ -4642,7 +5161,13 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--tail", "500"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--tail",
+        "500",
+      ]);
 
       // Per-page limit is capped at 100
       expect(capturedQuery?.limit).toBe("100");
@@ -4665,7 +5190,12 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync(["node", "cli", "run-123", "--all"]);
+      await logsCommand.parseAsync([
+        "node",
+        "cli",
+        "abc12345-1234-1234-1234-123456789abc",
+        "--all",
+      ]);
 
       // --all uses page limit of 100 and fetches all pages
       expect(capturedQuery?.limit).toBe("100");
@@ -4692,7 +5222,7 @@ describe("logs command", () => {
       await logsCommand.parseAsync([
         "node",
         "cli",
-        "run-123",
+        "abc12345-1234-1234-1234-123456789abc",
         "--all",
         "--since",
         "5m",

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -1578,6 +1578,72 @@ describe("logs command", () => {
       expect(countOccurrences(logCalls, "✗")).toBeGreaterThanOrEqual(2);
     });
 
+    it("should keep delayed Codex tool results after intervening text", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "item.started",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "item.started",
+                    item: {
+                      id: "cmd-delayed",
+                      type: "command_execution",
+                      command: "printf delayed",
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "item.completed",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "item.completed",
+                    item: {
+                      id: "message-1",
+                      type: "agent_message",
+                      text: "continuing while command runs",
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 3,
+                  eventType: "item.completed",
+                  createdAt: "2024-01-15T10:30:02Z",
+                  eventData: {
+                    type: "item.completed",
+                    item: {
+                      id: "cmd-delayed",
+                      type: "command_execution",
+                      status: "completed",
+                      aggregated_output: "delayed output",
+                    },
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      const commandIndex = logCalls.indexOf("printf delayed");
+      const textIndex = logCalls.indexOf("continuing while command runs");
+      const outputIndex = logCalls.indexOf("delayed output");
+      expect(commandIndex).toBeGreaterThan(-1);
+      expect(textIndex).toBeGreaterThan(commandIndex);
+      expect(outputIndex).toBeGreaterThan(textIndex);
+    });
+
     it("should tolerate malformed optional Codex payload fields", async () => {
       server.use(
         http.get(

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -40,6 +40,14 @@ function makeNestedArray(depth: number): unknown[] {
   return value;
 }
 
+function makeWideNestedObject(fieldCount: number): Record<string, unknown> {
+  const value: Record<string, unknown> = {};
+  for (let index = 0; index < fieldCount; index += 1) {
+    value[`ignored_${index}`] = { nested: { index } };
+  }
+  return value;
+}
+
 describe("logs command", () => {
   const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
     throw new Error("process.exit called");
@@ -2369,6 +2377,44 @@ describe("logs command", () => {
       expect(logCalls).toContain("nested error detail");
       expect(logCalls).toContain("...");
       expect(logCalls).not.toContain("leaf");
+    });
+
+    it("should bound wide Codex fallback object formatting", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "item.completed",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "item.completed",
+                    item: {
+                      id: "wide-1",
+                      type: "mcp_tool_call",
+                      ...makeWideNestedObject(40),
+                      late: "should not be scanned",
+                    },
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(mockExit).not.toHaveBeenCalled();
+      expect(logCalls).toContain("[item] mcp_tool_call");
+      expect(logCalls).toContain("...");
+      expect(logCalls).not.toContain("should not be scanned");
     });
   });
 

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -605,6 +605,91 @@ describe("logs command", () => {
       expect(logCalls).toContain("File content here");
     });
 
+    it("should preserve falsy primitive event values in rendered output", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "assistant",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "assistant",
+                    message: {
+                      content: [
+                        {
+                          type: "tool_use",
+                          name: "Bash",
+                          id: 0,
+                          input: { command: "printf false" },
+                        },
+                      ],
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "user",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "user",
+                    message: {
+                      content: [
+                        {
+                          type: "tool_result",
+                          tool_use_id: 0,
+                          content: false,
+                        },
+                      ],
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 3,
+                  eventType: "assistant",
+                  createdAt: "2024-01-15T10:30:02Z",
+                  eventData: {
+                    type: "assistant",
+                    message: {
+                      content: [{ type: "text", text: 0 }],
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 4,
+                  eventType: "result",
+                  createdAt: "2024-01-15T10:30:03Z",
+                  eventData: {
+                    type: "result",
+                    is_error: true,
+                    result: false,
+                    duration_ms: 0,
+                    num_turns: 1,
+                    total_cost_usd: 0,
+                    usage: {},
+                  },
+                },
+              ],
+              framework: "claude-code",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("printf false");
+      expect(logCalls).toContain("false");
+      expect(logCalls).toContain("● 0");
+      expect(logCalls).toContain("Error: false");
+      expect(logCalls).not.toContain("Done");
+    });
+
     it("should not pair malformed tool results with tool uses that lack ids", async () => {
       server.use(
         http.get(
@@ -959,6 +1044,21 @@ describe("logs command", () => {
                     },
                   },
                 },
+                {
+                  sequenceNumber: 4,
+                  eventType: "item.completed",
+                  createdAt: "2024-01-15T10:30:03Z",
+                  eventData: {
+                    type: "item.completed",
+                    item: {
+                      id: "read_blank",
+                      type: "file_read",
+                      path: "/workspace/blank.txt",
+                      status: "completed",
+                      output: "   ",
+                    },
+                  },
+                },
               ],
               framework: "codex",
               hasMore: false,
@@ -980,6 +1080,8 @@ describe("logs command", () => {
       expect(logCalls).toContain("Read");
       expect(logCalls).toContain("/workspace/package.json");
       expect(logCalls).toContain("  file body  ");
+      expect(logCalls).toContain("/workspace/blank.txt");
+      expect(logCalls).not.toContain("(empty)");
     });
 
     it("should mark command_execution with non-zero exit_code as error", async () => {

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -48,6 +48,14 @@ function makeWideNestedObject(fieldCount: number): Record<string, unknown> {
   return value;
 }
 
+function makeWideEmptyObject(fieldCount: number): Record<string, unknown> {
+  const value: Record<string, unknown> = {};
+  for (let index = 0; index < fieldCount; index += 1) {
+    value[`empty_${index}`] = null;
+  }
+  return value;
+}
+
 function makeNestedErrorObject(depth: number): Record<string, unknown> {
   let value: Record<string, unknown> = { message: "deep failure" };
   for (let index = 0; index < depth; index += 1) {
@@ -2004,6 +2012,7 @@ describe("logs command", () => {
                         message: null,
                         error: false,
                         additional_details: "   ",
+                        connectors: null,
                       },
                     },
                   },
@@ -2022,6 +2031,54 @@ describe("logs command", () => {
       expect(logCalls).toContain("Codex Completed");
       expect(logCalls).not.toContain("Codex Failed");
       expect(logCalls).not.toContain("message=null");
+    });
+
+    it("should read known Codex error fields past bounded fallback fields", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "thread.started",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "thread.started",
+                    thread_id: "thread-x",
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "turn.completed",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "turn.completed",
+                    turn: {
+                      id: "turn-1",
+                      status: "completed",
+                      error: {
+                        ...makeWideEmptyObject(40),
+                        message: "late standard error",
+                      },
+                    },
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Codex Failed");
+      expect(logCalls).toContain("late standard error");
+      expect(logCalls).not.toContain("Codex Completed");
     });
 
     it("should bound deeply nested object turn errors when rendering successful turn.completed", async () => {

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -2183,6 +2183,68 @@ describe("logs command", () => {
       expect(logCalls).toContain("Rate limit exceeded");
     });
 
+    it("should collapse Codex failures across unrendered same-turn events", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "thread.started",
+                  createdAt: "2024-01-15T10:29:59Z",
+                  eventData: {
+                    type: "thread.started",
+                    thread_id: "thread-x",
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "error",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "error",
+                    turn_id: "turn-1",
+                    message: "API connection failed",
+                  },
+                },
+                {
+                  sequenceNumber: 3,
+                  eventType: "turn.started",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "turn.started",
+                    turn_id: "turn-1",
+                  },
+                },
+                {
+                  sequenceNumber: 4,
+                  eventType: "turn.failed",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "turn.failed",
+                    turn_id: "turn-1",
+                    error: "Rate limit exceeded",
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(countOccurrences(logCalls, "Codex Failed")).toBe(1);
+      expect(logCalls).toContain("API connection failed");
+      expect(logCalls).toContain("Rate limit exceeded");
+      expect(logCalls).not.toContain("turn.started");
+    });
+
     it("should not collapse Codex failures from different turns", async () => {
       server.use(
         http.get(

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -85,6 +85,39 @@ describe("logs command", () => {
       expect(logCalls).toContain("Hello, world!");
     });
 
+    it("should not fail when an agent event has an invalid timestamp", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "assistant",
+                  createdAt: "not-a-timestamp",
+                  eventData: {
+                    type: "assistant",
+                    message: {
+                      content: [{ type: "text", text: "Still visible" }],
+                    },
+                  },
+                },
+              ],
+              framework: "claude-code",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("[invalid-date]");
+      expect(logCalls).toContain("Still visible");
+    });
+
     it("should handle empty events", async () => {
       server.use(
         http.get(

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -942,6 +942,21 @@ describe("logs command", () => {
                     item: {
                       id: "duplicate-id",
                       type: "command_execution",
+                      command: "first command",
+                      aggregated_output: "first result",
+                      exit_code: 0,
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 4,
+                  eventType: "item.completed",
+                  createdAt: "2024-01-15T10:30:03Z",
+                  eventData: {
+                    type: "item.completed",
+                    item: {
+                      id: "duplicate-id",
+                      type: "command_execution",
                       command: "second command",
                       aggregated_output: "second result",
                       exit_code: 0,
@@ -959,8 +974,9 @@ describe("logs command", () => {
       await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain("first command");
+      expect(logCalls).toContain("first result");
       expect(logCalls).toContain("second result");
+      expect(countOccurrences(logCalls, "first command")).toBe(1);
       expect(countOccurrences(logCalls, "second command")).toBe(1);
     });
 

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -1361,6 +1361,37 @@ describe("logs command", () => {
       expect(logCalls).toContain("Codex Failed");
     });
 
+    it("should render truncated Codex result events with the Codex label", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 2,
+                  eventType: "turn.failed",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "turn.failed",
+                    error: "Rate limit exceeded",
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--tail", "1"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Codex Failed");
+      expect(logCalls).not.toContain("Agent Failed");
+    });
+
     it("should render top-level error event as a failure result", async () => {
       server.use(
         http.get(
@@ -1546,6 +1577,53 @@ describe("logs command", () => {
       expect(logCalls).toContain("selected model is at capacity");
       expect(logCalls).toContain("retry later");
       expect(logCalls).not.toContain("[object Object]");
+    });
+
+    it("should ignore null turn errors when rendering failed turn.completed", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "thread.started",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "thread.started",
+                    thread_id: "thread-x",
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "turn.completed",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "turn.completed",
+                    thread_id: "thread-x",
+                    message: "request aborted before shutdown",
+                    turn: {
+                      id: "turn-1",
+                      status: "failed",
+                      error: null,
+                    },
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Codex Failed");
+      expect(logCalls).toContain("request aborted before shutdown");
+      expect(logCalls).not.toContain("Error: null");
     });
 
     it("should collapse same-turn Codex error and failed turn.completed while preserving details", async () => {

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -792,6 +792,72 @@ describe("logs command", () => {
       expect(logCalls).not.toContain("orphan output");
     });
 
+    it("should tolerate malformed TodoWrite todo items", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "assistant",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "assistant",
+                    message: {
+                      content: [
+                        {
+                          type: "tool_use",
+                          name: "TodoWrite",
+                          id: "todo-1",
+                          input: {
+                            todos: [
+                              null,
+                              "not-an-object",
+                              { content: 0, status: "in_progress" },
+                              { content: "finished", status: "completed" },
+                            ],
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "user",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "user",
+                    message: {
+                      content: [
+                        {
+                          type: "tool_result",
+                          tool_use_id: "todo-1",
+                          content: "ok",
+                        },
+                      ],
+                    },
+                  },
+                },
+              ],
+              framework: "claude-code",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("TodoWrite");
+      expect(countOccurrences(logCalls, "Unknown task")).toBe(2);
+      expect(logCalls).toContain("0");
+      expect(logCalls).toContain("finished");
+    });
+
     it("should handle tool_result events", async () => {
       server.use(
         http.get(

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -2907,6 +2907,7 @@ describe("logs command", () => {
                   createdAt: "2024-01-15T10:30:01Z",
                   eventData: {
                     type: "turn.completed",
+                    duration_ms: -1000,
                     turn: {
                       id: "turn-1",
                       status: "failed",
@@ -2916,7 +2917,7 @@ describe("logs command", () => {
                       },
                       usage: {
                         input_tokens: "not-a-number",
-                        output_tokens: "also-not-a-number",
+                        output_tokens: -7,
                       },
                     },
                   },
@@ -2952,8 +2953,10 @@ describe("logs command", () => {
       expect(mockExit).not.toHaveBeenCalled();
       expect(logCalls).toContain("server_error");
       expect(logCalls).toContain("retry later");
+      expect(logCalls).toContain("Duration: 0.0s");
       expect(logCalls).toContain("input=0 output=0");
       expect(logCalls).not.toContain("NaN");
+      expect(logCalls).not.toContain("output=-7");
       expect(logCalls).toContain("Modified: /workspace/ok.ts");
       expect(logCalls).not.toContain("[object Object]");
     });

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -915,6 +915,7 @@ describe("logs command", () => {
                   eventData: {
                     type: "turn.completed",
                     turn: {
+                      status: "completed",
                       usage: {
                         input_tokens: 24763,
                         cached_input_tokens: 24448,
@@ -1667,6 +1668,50 @@ describe("logs command", () => {
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Codex Failed");
       expect(logCalls).toContain("Turn cancelled");
+      expect(logCalls).not.toContain("Codex Completed");
+    });
+
+    it("should render non-success turn.completed statuses as failed", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "thread.started",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "thread.started",
+                    thread_id: "thread-x",
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "turn.completed",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "turn.completed",
+                    turn: {
+                      id: "turn-1",
+                      status: "in_progress",
+                    },
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Codex Failed");
+      expect(logCalls).toContain("Turn in_progress");
       expect(logCalls).not.toContain("Codex Completed");
     });
 

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -918,6 +918,7 @@ describe("logs command", () => {
                       id: "edit_1",
                       type: "file_edit",
                       path: "/workspace/src/main.ts",
+                      diff: "-old\n+new",
                     },
                   },
                 },
@@ -986,8 +987,11 @@ describe("logs command", () => {
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Edit");
       expect(logCalls).toContain("/workspace/src/main.ts");
+      expect(logCalls).toContain("-old");
+      expect(logCalls).toContain("+new");
       expect(logCalls).toContain("Write");
       expect(logCalls).toContain("/workspace/README.md");
+      expect(logCalls).toContain("File operation completed");
       expect(logCalls).toContain("Read");
       expect(logCalls).toContain("/workspace/package.json");
     });

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -12,6 +12,10 @@ import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server";
 import { logsCommand } from "../index";
 
+const RUN_ID = "abc12345-1234-1234-1234-123456789abc";
+const MISSING_RUN_ID = "ffffffff-ffff-4fff-8fff-ffffffffffff";
+const INVALID_RUN_ID = "run-123";
+
 function countOccurrences(text: string, pattern: string): number {
   return text.split(pattern).length - 1;
 }
@@ -87,7 +91,7 @@ describe("logs command", () => {
   describe("agent events (default)", () => {
     it("should reject non-UUID run IDs", async () => {
       await expect(
-        logsCommand.parseAsync(["node", "cli", "run-123"]),
+        logsCommand.parseAsync(["node", "cli", INVALID_RUN_ID]),
       ).rejects.toThrow("process.exit called");
 
       const errorCalls = mockConsoleError.mock.calls.flat().join("\n");
@@ -121,11 +125,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Hello, world!");
@@ -157,11 +157,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("[invalid-date]");
@@ -182,11 +178,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("No agent events found");
@@ -242,12 +234,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--all",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--all"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Page 1");
@@ -304,12 +291,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--all",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--all"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Codex Started");
@@ -373,12 +355,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--all",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--all"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Future framework legacy output");
@@ -429,13 +406,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--tail",
-        "2",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--tail", "2"]);
 
       // Should only make 1 request since we got enough events
       expect(requestCount).toBe(1);
@@ -519,13 +490,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--tail",
-        "3",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--tail", "3"]);
 
       // Should make 2 requests to collect 3 events
       expect(requestCount).toBe(2);
@@ -586,12 +551,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--all",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--all"]);
 
       expect(capturedCursorValues).toHaveLength(2);
       expect(capturedCursorValues[0]).toBeNull();
@@ -632,13 +592,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--tail",
-        "101",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--tail", "101"]);
 
       expect(capturedCursors).toStrictEqual([null, "sequence:desc:101"]);
       expect(capturedLimits).toStrictEqual(["100", "1"]);
@@ -690,12 +644,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--all",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--all"]);
 
       // Should stop after 2 requests (not infinite loop)
       expect(requestCount).toBe(2);
@@ -739,12 +688,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--all",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--all"]);
 
       expect(requestCount).toBe(2);
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
@@ -791,12 +735,7 @@ describe("logs command", () => {
       );
 
       await expect(async () => {
-        await logsCommand.parseAsync([
-          "node",
-          "cli",
-          "abc12345-1234-1234-1234-123456789abc",
-          "--all",
-        ]);
+        await logsCommand.parseAsync(["node", "cli", RUN_ID, "--all"]);
       }).rejects.toThrow("process.exit called");
 
       expect(requestCount).toBe(2);
@@ -858,11 +797,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Read");
@@ -944,13 +879,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "100",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("printf false");
@@ -1021,13 +950,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "100",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("echo no-id");
@@ -1103,13 +1026,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "100",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("first command");
@@ -1188,13 +1105,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "100",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("first result");
@@ -1260,13 +1171,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "100",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("TodoWrite");
@@ -1325,13 +1230,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "100",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("TodoWrite");
@@ -1392,13 +1291,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "100",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("task-0");
@@ -1432,11 +1325,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID]);
 
       // Result events are handled without error
       expect(mockExit).not.toHaveBeenCalled();
@@ -1466,11 +1355,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID]);
 
       // Should not crash on unknown event types
       expect(mockExit).not.toHaveBeenCalled();
@@ -1500,11 +1385,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID]);
 
       // Should handle empty content gracefully
       expect(mockExit).not.toHaveBeenCalled();
@@ -1531,11 +1412,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID]);
 
       // Should handle malformed data gracefully
       expect(mockExit).not.toHaveBeenCalled();
@@ -1596,13 +1473,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "100",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Codex Started");
@@ -1656,13 +1527,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "100",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Bash");
@@ -1744,13 +1609,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "100",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Bash");
@@ -1811,13 +1670,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "100",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("ls /nonexistent");
@@ -1921,13 +1774,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "100",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Edit");
@@ -1970,13 +1817,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "100",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("[thinking] Considering the trade-offs");
@@ -2014,13 +1855,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "100",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("[files]");
@@ -2062,13 +1897,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "100",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Codex Failed");
@@ -2119,13 +1948,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "100",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Codex Failed");
@@ -2161,13 +1984,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--tail",
-        "1",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--tail", "1"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Codex Failed");
@@ -2207,13 +2024,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "100",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Codex Failed");
@@ -2254,13 +2065,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "100",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Codex Failed");
@@ -2312,13 +2117,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "100",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(countOccurrences(logCalls, "Codex Failed")).toBe(1);
@@ -2366,11 +2165,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(countOccurrences(logCalls, "Codex Failed")).toBe(1);
@@ -2419,13 +2214,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "100",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Codex Failed");
@@ -2472,13 +2261,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "100",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Codex Failed");
@@ -2523,13 +2306,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "100",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Codex Failed");
@@ -2573,13 +2350,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "100",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Codex Failed");
@@ -2626,13 +2397,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "100",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Codex Failed");
@@ -2677,13 +2442,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "100",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Codex Completed");
@@ -2728,13 +2487,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "100",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Codex Completed");
@@ -2784,13 +2537,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "100",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Codex Completed");
@@ -2838,13 +2585,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "100",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Codex Failed");
@@ -2889,13 +2630,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "100",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Codex Completed");
@@ -2952,13 +2687,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "100",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(countOccurrences(logCalls, "Codex Failed")).toBe(1);
@@ -3019,13 +2748,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "100",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(countOccurrences(logCalls, "Codex Failed")).toBe(1);
@@ -3082,13 +2805,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "100",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(countOccurrences(logCalls, "Codex Failed")).toBe(1);
@@ -3139,13 +2856,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "100",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(countOccurrences(logCalls, "Codex Failed")).toBe(2);
@@ -3202,13 +2913,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "100",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(countOccurrences(logCalls, "Codex Failed")).toBe(1);
@@ -3265,13 +2970,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "100",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(countOccurrences(logCalls, "Codex Failed")).toBe(2);
@@ -3345,13 +3044,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "100",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("[warning] configuration warning");
@@ -3409,13 +3102,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "100",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("pending: step-0");
@@ -3509,13 +3196,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "100",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("deploy");
@@ -3594,13 +3275,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "100",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("permission denied");
@@ -3667,13 +3342,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "100",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       const commandIndex = logCalls.indexOf("printf delayed");
@@ -3745,13 +3414,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "100",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(mockExit).not.toHaveBeenCalled();
@@ -3796,13 +3459,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "100",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(mockExit).not.toHaveBeenCalled();
@@ -3840,13 +3497,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "100",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(mockExit).not.toHaveBeenCalled();
@@ -3870,12 +3521,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--system",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--system"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("System started");
@@ -3895,12 +3541,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--system",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--system"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("No system log found");
@@ -3935,7 +3576,7 @@ describe("logs command", () => {
       await logsCommand.parseAsync([
         "node",
         "cli",
-        "abc12345-1234-1234-1234-123456789abc",
+        RUN_ID,
         "--system",
         "--all",
       ]);
@@ -3975,7 +3616,7 @@ describe("logs command", () => {
       await logsCommand.parseAsync([
         "node",
         "cli",
-        "abc12345-1234-1234-1234-123456789abc",
+        RUN_ID,
         "--system",
         "--all",
       ]);
@@ -4012,12 +3653,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--system",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--system"]);
 
       expect(capturedCursors).toStrictEqual([null, "time:desc:1"]);
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
@@ -4049,12 +3685,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--metrics",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--metrics"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("CPU:");
@@ -4076,12 +3707,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--metrics",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--metrics"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("No metrics found");
@@ -4114,12 +3740,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--network",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--network"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("GET");
@@ -4149,12 +3770,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--network",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--network"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("DENY");
@@ -4191,12 +3807,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--network",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--network"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("BLOCK");
@@ -4231,12 +3842,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--network",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--network"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("BLOCK");
@@ -4272,12 +3878,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--network",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--network"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("502");
@@ -4316,12 +3917,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--network",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--network"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("connector diagnostic");
@@ -4354,12 +3950,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--network",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--network"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("TCP");
@@ -4391,12 +3982,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--network",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--network"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("TCP");
@@ -4427,12 +4013,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--network",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--network"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("DNS");
@@ -4453,12 +4034,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--network",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--network"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("No network logs found");
@@ -4471,7 +4047,7 @@ describe("logs command", () => {
         await logsCommand.parseAsync([
           "node",
           "cli",
-          "abc12345-1234-1234-1234-123456789abc",
+          RUN_ID,
           "--system",
           "--metrics",
         ]);
@@ -4501,7 +4077,7 @@ describe("logs command", () => {
         await logsCommand.parseAsync([
           "node",
           "cli",
-          "abc12345-1234-1234-1234-123456789abc",
+          RUN_ID,
           "--tail",
           "10",
           "--head",
@@ -4520,7 +4096,7 @@ describe("logs command", () => {
         await logsCommand.parseAsync([
           "node",
           "cli",
-          "abc12345-1234-1234-1234-123456789abc",
+          RUN_ID,
           "--tail",
           "10",
           "--all",
@@ -4538,7 +4114,7 @@ describe("logs command", () => {
         await logsCommand.parseAsync([
           "node",
           "cli",
-          "abc12345-1234-1234-1234-123456789abc",
+          RUN_ID,
           "--head",
           "10",
           "--all",
@@ -4553,13 +4129,7 @@ describe("logs command", () => {
 
     it("should exit with error when --tail is not a positive integer", async () => {
       await expect(async () => {
-        await logsCommand.parseAsync([
-          "node",
-          "cli",
-          "abc12345-1234-1234-1234-123456789abc",
-          "--tail",
-          "abc",
-        ]);
+        await logsCommand.parseAsync(["node", "cli", RUN_ID, "--tail", "abc"]);
       }).rejects.toThrow("process.exit called");
 
       expect(mockExit).toHaveBeenCalledWith(1);
@@ -4571,13 +4141,7 @@ describe("logs command", () => {
       mockConsoleError.mockClear();
 
       await expect(async () => {
-        await logsCommand.parseAsync([
-          "node",
-          "cli",
-          "abc12345-1234-1234-1234-123456789abc",
-          "--tail",
-          "000",
-        ]);
+        await logsCommand.parseAsync(["node", "cli", RUN_ID, "--tail", "000"]);
       }).rejects.toThrow("process.exit called");
 
       expect(mockExit).toHaveBeenCalledWith(1);
@@ -4589,13 +4153,7 @@ describe("logs command", () => {
       mockConsoleError.mockClear();
 
       await expect(async () => {
-        await logsCommand.parseAsync([
-          "node",
-          "cli",
-          "abc12345-1234-1234-1234-123456789abc",
-          "--tail",
-          "1e2",
-        ]);
+        await logsCommand.parseAsync(["node", "cli", RUN_ID, "--tail", "1e2"]);
       }).rejects.toThrow("process.exit called");
 
       expect(mockExit).toHaveBeenCalledWith(1);
@@ -4606,13 +4164,7 @@ describe("logs command", () => {
 
     it("should exit with error when --head is not a positive integer", async () => {
       await expect(async () => {
-        await logsCommand.parseAsync([
-          "node",
-          "cli",
-          "abc12345-1234-1234-1234-123456789abc",
-          "--head",
-          "0",
-        ]);
+        await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "0"]);
       }).rejects.toThrow("process.exit called");
 
       expect(mockExit).toHaveBeenCalledWith(1);
@@ -4637,11 +4189,7 @@ describe("logs command", () => {
       );
 
       await expect(async () => {
-        await logsCommand.parseAsync([
-          "node",
-          "cli",
-          "abc12345-1234-1234-1234-123456789abc",
-        ]);
+        await logsCommand.parseAsync(["node", "cli", RUN_ID]);
       }).rejects.toThrow("process.exit called");
 
       expect(mockExit).toHaveBeenCalledWith(1);
@@ -4664,11 +4212,7 @@ describe("logs command", () => {
       );
 
       await expect(async () => {
-        await logsCommand.parseAsync([
-          "node",
-          "cli",
-          "ffffffff-ffff-4fff-8fff-ffffffffffff",
-        ]);
+        await logsCommand.parseAsync(["node", "cli", MISSING_RUN_ID]);
       }).rejects.toThrow("process.exit called");
 
       expect(mockExit).toHaveBeenCalledWith(1);
@@ -4695,7 +4239,7 @@ describe("logs command", () => {
         await logsCommand.parseAsync([
           "node",
           "cli",
-          "abc12345-1234-1234-1234-123456789abc",
+          RUN_ID,
           "--since",
           "invalid-time",
         ]);
@@ -4712,7 +4256,7 @@ describe("logs command", () => {
         await logsCommand.parseAsync([
           "node",
           "cli",
-          "abc12345-1234-1234-1234-123456789abc",
+          RUN_ID,
           "--since",
           "2024-02-30T00:00:00Z",
         ]);
@@ -4729,7 +4273,7 @@ describe("logs command", () => {
         await logsCommand.parseAsync([
           "node",
           "cli",
-          "abc12345-1234-1234-1234-123456789abc",
+          RUN_ID,
           "--since",
           "8640000000000001",
         ]);
@@ -4755,11 +4299,7 @@ describe("logs command", () => {
       );
 
       await expect(async () => {
-        await logsCommand.parseAsync([
-          "node",
-          "cli",
-          "abc12345-1234-1234-1234-123456789abc",
-        ]);
+        await logsCommand.parseAsync(["node", "cli", RUN_ID]);
       }).rejects.toThrow("process.exit called");
 
       expect(mockExit).toHaveBeenCalledWith(1);
@@ -4796,17 +4336,11 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("View on platform:");
-      expect(logCalls).toContain(
-        "http://localhost:3001/logs/abc12345-1234-1234-1234-123456789abc",
-      );
+      expect(logCalls).toContain(`http://localhost:3001/logs/${RUN_ID}`);
     });
 
     it("should NOT display platform URL for system logs", async () => {
@@ -4822,12 +4356,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--system",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--system"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).not.toContain("View on platform:");
@@ -4855,12 +4384,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--metrics",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--metrics"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).not.toContain("View on platform:");
@@ -4888,12 +4412,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--network",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--network"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).not.toContain("View on platform:");
@@ -4925,16 +4444,10 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain(
-        "https://app.vm0.ai/logs/abc12345-1234-1234-1234-123456789abc",
-      );
+      expect(logCalls).toContain(`https://app.vm0.ai/logs/${RUN_ID}`);
     });
 
     it("should not double-prefix when input URL already has app subdomain", async () => {
@@ -4963,16 +4476,10 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain(
-        "https://app.vm0.ai/logs/abc12345-1234-1234-1234-123456789abc",
-      );
+      expect(logCalls).toContain(`https://app.vm0.ai/logs/${RUN_ID}`);
       expect(logCalls).not.toContain("app.app.");
     });
 
@@ -5002,16 +4509,10 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain(
-        "https://app.vm0.ai/logs/abc12345-1234-1234-1234-123456789abc",
-      );
+      expect(logCalls).toContain(`https://app.vm0.ai/logs/${RUN_ID}`);
       expect(logCalls).not.toContain("app.platform.");
     });
 
@@ -5041,16 +4542,10 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain(
-        "https://app.vm7.ai:8443/logs/abc12345-1234-1234-1234-123456789abc",
-      );
+      expect(logCalls).toContain(`https://app.vm7.ai:8443/logs/${RUN_ID}`);
     });
   });
 
@@ -5072,13 +4567,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--since",
-        "5m",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--since", "5m"]);
 
       expect(capturedQuery?.sinceTime).toBeDefined();
       expect(capturedQuery?.since).toBeUndefined();
@@ -5101,13 +4590,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--tail",
-        "020",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--tail", "020"]);
 
       // Small finite requests only fetch the remaining target count.
       expect(capturedQuery?.limit).toBe("20");
@@ -5131,13 +4614,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--head",
-        "010",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "010"]);
 
       // Small finite requests only fetch the remaining target count.
       expect(capturedQuery?.limit).toBe("10");
@@ -5161,13 +4638,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--tail",
-        "500",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--tail", "500"]);
 
       // Per-page limit is capped at 100
       expect(capturedQuery?.limit).toBe("100");
@@ -5190,12 +4661,7 @@ describe("logs command", () => {
         ),
       );
 
-      await logsCommand.parseAsync([
-        "node",
-        "cli",
-        "abc12345-1234-1234-1234-123456789abc",
-        "--all",
-      ]);
+      await logsCommand.parseAsync(["node", "cli", RUN_ID, "--all"]);
 
       // --all uses page limit of 100 and fetches all pages
       expect(capturedQuery?.limit).toBe("100");
@@ -5222,7 +4688,7 @@ describe("logs command", () => {
       await logsCommand.parseAsync([
         "node",
         "cli",
-        "abc12345-1234-1234-1234-123456789abc",
+        RUN_ID,
         "--all",
         "--since",
         "5m",

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -1922,6 +1922,51 @@ describe("logs command", () => {
       expect(logCalls).not.toContain("Error: false");
     });
 
+    it("should ignore blank string turn errors when rendering successful turn.completed", async () => {
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/runs/:id/telemetry/agent",
+          () => {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 1,
+                  eventType: "thread.started",
+                  createdAt: "2024-01-15T10:30:00Z",
+                  eventData: {
+                    type: "thread.started",
+                    thread_id: "thread-x",
+                  },
+                },
+                {
+                  sequenceNumber: 2,
+                  eventType: "turn.completed",
+                  createdAt: "2024-01-15T10:30:01Z",
+                  eventData: {
+                    type: "turn.completed",
+                    turn: {
+                      id: "turn-1",
+                      status: "completed",
+                      error: "   ",
+                    },
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: false,
+            });
+          },
+        ),
+      );
+
+      await logsCommand.parseAsync(["node", "cli", "run-123", "--head", "100"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Codex Completed");
+      expect(logCalls).not.toContain("Codex Failed");
+      expect(logCalls).not.toContain("Turn completed");
+    });
+
     it("should collapse same-turn Codex error and failed turn.completed while preserving details", async () => {
       server.use(
         http.get(

--- a/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/index.test.ts
@@ -12,9 +12,10 @@ import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server";
 import { logsCommand } from "../index";
 
-const RUN_ID = "abc12345-1234-1234-1234-123456789abc";
+const RUN_ID = "550e8400-e29b-41d4-a716-446655440001";
 const MISSING_RUN_ID = "ffffffff-ffff-4fff-8fff-ffffffffffff";
 const INVALID_RUN_ID = "run-123";
+const INVALID_UUID_SHAPED_RUN_ID = "abc12345-1234-1234-1234-123456789abc";
 
 function countOccurrences(text: string, pattern: string): number {
   return text.split(pattern).length - 1;
@@ -92,6 +93,16 @@ describe("logs command", () => {
     it("should reject non-UUID run IDs", async () => {
       await expect(
         logsCommand.parseAsync(["node", "cli", INVALID_RUN_ID]),
+      ).rejects.toThrow("process.exit called");
+
+      const errorCalls = mockConsoleError.mock.calls.flat().join("\n");
+      expect(errorCalls).toContain("Invalid run ID");
+      expect(errorCalls).toContain("vm0 run list");
+    });
+
+    it("should reject UUID-shaped run IDs with invalid variants", async () => {
+      await expect(
+        logsCommand.parseAsync(["node", "cli", INVALID_UUID_SHAPED_RUN_ID]),
       ).rejects.toThrow("process.exit called");
 
       const errorCalls = mockConsoleError.mock.calls.flat().join("\n");

--- a/turbo/apps/cli/src/commands/logs/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/search.test.ts
@@ -288,6 +288,24 @@ describe("logs search command", () => {
 
     errorCalls = mockConsoleError.mock.calls.flat().join("\n");
     expect(errorCalls).toContain("--limit must be between 1 and 50");
+
+    mockConsoleError.mockClear();
+
+    await expect(
+      searchCommand.parseAsync(["node", "cli", "error", "-C", ""]),
+    ).rejects.toThrow("process.exit called");
+
+    errorCalls = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errorCalls).toContain("--context must be between 0 and 10");
+
+    mockConsoleError.mockClear();
+
+    await expect(
+      searchCommand.parseAsync(["node", "cli", "error", "--limit", ""]),
+    ).rejects.toThrow("process.exit called");
+
+    errorCalls = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errorCalls).toContain("--limit must be between 1 and 50");
   });
 
   it("should pass --agent as agentId and --run filters to API", async () => {
@@ -320,7 +338,16 @@ describe("logs search command", () => {
       searchCommand.parseAsync(["node", "cli", "deploy", "--run", "run-123"]),
     ).rejects.toThrow("process.exit called");
 
-    const errorCalls = mockConsoleError.mock.calls.flat().join("\n");
+    let errorCalls = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errorCalls).toContain("Invalid run ID");
+
+    mockConsoleError.mockClear();
+
+    await expect(
+      searchCommand.parseAsync(["node", "cli", "deploy", "--run", ""]),
+    ).rejects.toThrow("process.exit called");
+
+    errorCalls = mockConsoleError.mock.calls.flat().join("\n");
     expect(errorCalls).toContain("Invalid run ID");
   });
 
@@ -335,7 +362,16 @@ describe("logs search command", () => {
       ]),
     ).rejects.toThrow("process.exit called");
 
-    const errorCalls = mockConsoleError.mock.calls.flat().join("\n");
+    let errorCalls = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errorCalls).toContain("Invalid agent ID");
+
+    mockConsoleError.mockClear();
+
+    await expect(
+      searchCommand.parseAsync(["node", "cli", "deploy", "--agent", ""]),
+    ).rejects.toThrow("process.exit called");
+
+    errorCalls = mockConsoleError.mock.calls.flat().join("\n");
     expect(errorCalls).toContain("Invalid agent ID");
   });
 

--- a/turbo/apps/cli/src/commands/logs/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/search.test.ts
@@ -104,6 +104,15 @@ describe("logs search command", () => {
     mockConsoleError.mockClear();
   });
 
+  it("should reject whitespace-only keywords", async () => {
+    await expect(
+      searchCommand.parseAsync(["node", "cli", "   "]),
+    ).rejects.toThrow("process.exit called");
+
+    const errorCalls = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errorCalls).toContain("Keyword cannot be empty");
+  });
+
   it("should display search results grouped by run", async () => {
     server.use(
       http.get("http://localhost:3000/api/logs/search", () => {

--- a/turbo/apps/cli/src/commands/logs/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/search.test.ts
@@ -315,6 +315,15 @@ describe("logs search command", () => {
     expect(capturedUrl?.searchParams.get("runId")).toBe(runId);
   });
 
+  it("should reject non-UUID --run values", async () => {
+    await expect(
+      searchCommand.parseAsync(["node", "cli", "deploy", "--run", "run-123"]),
+    ).rejects.toThrow("process.exit called");
+
+    const errorCalls = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errorCalls).toContain("Invalid run ID");
+  });
+
   it("should parse --since and send as timestamp", async () => {
     let capturedUrl: URL | undefined;
     server.use(

--- a/turbo/apps/cli/src/commands/logs/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/search.test.ts
@@ -30,6 +30,26 @@ function makeEvent(
   };
 }
 
+function makeCodexMessageEvent(
+  sequenceNumber: number,
+  text: string,
+  createdAt = "2024-01-15T10:30:00Z",
+) {
+  return {
+    sequenceNumber,
+    eventType: "item.completed",
+    createdAt,
+    eventData: {
+      type: "item.completed",
+      item: {
+        id: `item-${sequenceNumber}`,
+        type: "agent_message",
+        text,
+      },
+    },
+  };
+}
+
 describe("logs search command", () => {
   const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
     throw new Error("process.exit called");
@@ -99,6 +119,32 @@ describe("logs search command", () => {
     const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
     expect(logCalls).toContain("invalid-date");
     expect(logCalls).toContain("Build failed");
+  });
+
+  it("should render codex search result events with the result framework", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/logs/search", () => {
+        return HttpResponse.json({
+          results: [
+            {
+              runId: "abc12345-1234-1234-1234-123456789abc",
+              agentName: "codex-agent",
+              framework: "codex",
+              matchedEvent: makeCodexMessageEvent(3, "Codex found the issue"),
+              contextBefore: [],
+              contextAfter: [],
+            },
+          ],
+          hasMore: false,
+        });
+      }),
+    );
+
+    await searchCommand.parseAsync(["node", "cli", "Codex"]);
+
+    const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(logCalls).toContain("codex-agent");
+    expect(logCalls).toContain("Codex found the issue");
   });
 
   it("should pass context params to API", async () => {

--- a/turbo/apps/cli/src/commands/logs/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/search.test.ts
@@ -358,6 +358,26 @@ describe("logs search command", () => {
     expect(Math.abs(sinceMs - expectedMs)).toBeLessThan(5000);
   });
 
+  it("should send epoch --since instead of the default search window", async () => {
+    let capturedUrl: URL | undefined;
+    server.use(
+      http.get("http://localhost:3000/api/logs/search", ({ request }) => {
+        capturedUrl = new URL(request.url);
+        return HttpResponse.json({ results: [], hasMore: false });
+      }),
+    );
+
+    await searchCommand.parseAsync([
+      "node",
+      "cli",
+      "error",
+      "--since",
+      "1970-01-01T00:00:00Z",
+    ]);
+
+    expect(capturedUrl?.searchParams.get("since")).toBe("0");
+  });
+
   it("should show guided message for empty results", async () => {
     server.use(
       http.get("http://localhost:3000/api/logs/search", () => {

--- a/turbo/apps/cli/src/commands/logs/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/search.test.ts
@@ -50,6 +50,40 @@ function makeCodexMessageEvent(
   };
 }
 
+function makeCodexErrorEvent(
+  sequenceNumber: number,
+  message: string,
+  createdAt = "2024-01-15T10:30:00Z",
+) {
+  return {
+    sequenceNumber,
+    eventType: "error",
+    createdAt,
+    eventData: {
+      type: "error",
+      turn_id: "turn-1",
+      message,
+    },
+  };
+}
+
+function makeCodexTurnFailedEvent(
+  sequenceNumber: number,
+  message: string,
+  createdAt = "2024-01-15T10:30:01Z",
+) {
+  return {
+    sequenceNumber,
+    eventType: "turn.failed",
+    createdAt,
+    eventData: {
+      type: "turn.failed",
+      turn_id: "turn-1",
+      error: { message },
+    },
+  };
+}
+
 describe("logs search command", () => {
   const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
     throw new Error("process.exit called");
@@ -145,6 +179,32 @@ describe("logs search command", () => {
     const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
     expect(logCalls).toContain("codex-agent");
     expect(logCalls).toContain("Codex found the issue");
+  });
+
+  it("should collapse paired codex error and terminal failure events in search context", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/logs/search", () => {
+        return HttpResponse.json({
+          results: [
+            {
+              runId: "abc12345-1234-1234-1234-123456789abc",
+              agentName: "codex-agent",
+              framework: "codex",
+              matchedEvent: makeCodexTurnFailedEvent(4, "Turn failed"),
+              contextBefore: [makeCodexErrorEvent(3, "Sandbox terminated")],
+              contextAfter: [],
+            },
+          ],
+          hasMore: false,
+        });
+      }),
+    );
+
+    await searchCommand.parseAsync(["node", "cli", "terminated"]);
+
+    const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(logCalls).toContain("Sandbox terminated");
+    expect(logCalls.match(/Codex Failed/g) ?? []).toHaveLength(1);
   });
 
   it("should pass context params to API", async () => {

--- a/turbo/apps/cli/src/commands/logs/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/search.test.ts
@@ -140,6 +140,24 @@ describe("logs search command", () => {
     expect(capturedUrl?.searchParams.get("after")).toBe("5");
   });
 
+  it("should reject partial numeric context and limit values", async () => {
+    await expect(
+      searchCommand.parseAsync(["node", "cli", "error", "-C", "2x"]),
+    ).rejects.toThrow("process.exit called");
+
+    let errorCalls = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errorCalls).toContain("--context must be between 0 and 10");
+
+    mockConsoleError.mockClear();
+
+    await expect(
+      searchCommand.parseAsync(["node", "cli", "error", "--limit", "1abc"]),
+    ).rejects.toThrow("process.exit called");
+
+    errorCalls = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errorCalls).toContain("--limit must be between 1 and 50");
+  });
+
   it("should pass --agent as agentId and --run filters to API", async () => {
     let capturedUrl: URL | undefined;
     const agentId = "550e8400-e29b-41d4-a716-446655440001";

--- a/turbo/apps/cli/src/commands/logs/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/search.test.ts
@@ -324,6 +324,21 @@ describe("logs search command", () => {
     expect(errorCalls).toContain("Invalid run ID");
   });
 
+  it("should reject non-UUID --agent values", async () => {
+    await expect(
+      searchCommand.parseAsync([
+        "node",
+        "cli",
+        "deploy",
+        "--agent",
+        "agent-123",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    const errorCalls = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errorCalls).toContain("Invalid agent ID");
+  });
+
   it("should parse --since and send as timestamp", async () => {
     let capturedUrl: URL | undefined;
     server.use(

--- a/turbo/apps/cli/src/commands/logs/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/search.test.ts
@@ -293,6 +293,7 @@ describe("logs search command", () => {
   it("should pass --agent as agentId and --run filters to API", async () => {
     let capturedUrl: URL | undefined;
     const agentId = "550e8400-e29b-41d4-a716-446655440001";
+    const runId = "550e8400-e29b-41d4-a716-446655440002";
     server.use(
       http.get("http://localhost:3000/api/logs/search", ({ request }) => {
         capturedUrl = new URL(request.url);
@@ -307,11 +308,11 @@ describe("logs search command", () => {
       "--agent",
       agentId,
       "--run",
-      "run-123",
+      runId,
     ]);
 
     expect(capturedUrl?.searchParams.get("agentId")).toBe(agentId);
-    expect(capturedUrl?.searchParams.get("runId")).toBe("run-123");
+    expect(capturedUrl?.searchParams.get("runId")).toBe(runId);
   });
 
   it("should parse --since and send as timestamp", async () => {

--- a/turbo/apps/cli/src/commands/logs/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/search.test.ts
@@ -76,6 +76,31 @@ describe("logs search command", () => {
     expect(logCalls).toContain("OOM killed");
   });
 
+  it("should tolerate invalid search result timestamps", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/logs/search", () => {
+        return HttpResponse.json({
+          results: [
+            {
+              runId: "abc12345-1234-1234-1234-123456789abc",
+              agentName: "my-agent",
+              matchedEvent: makeEvent(3, "Build failed", "not-a-timestamp"),
+              contextBefore: [],
+              contextAfter: [],
+            },
+          ],
+          hasMore: false,
+        });
+      }),
+    );
+
+    await searchCommand.parseAsync(["node", "cli", "Build"]);
+
+    const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(logCalls).toContain("invalid-date");
+    expect(logCalls).toContain("Build failed");
+  });
+
   it("should pass context params to API", async () => {
     let capturedUrl: URL | undefined;
     server.use(

--- a/turbo/apps/cli/src/commands/logs/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/search.test.ts
@@ -110,7 +110,7 @@ describe("logs search command", () => {
         return HttpResponse.json({
           results: [
             {
-              runId: "abc12345-1234-1234-1234-123456789abc",
+              runId: "550e8400-e29b-41d4-a716-446655440001",
               agentName: "my-agent",
               matchedEvent: makeEvent(3, "Build failed: OOM killed"),
               contextBefore: [],
@@ -125,7 +125,7 @@ describe("logs search command", () => {
     await searchCommand.parseAsync(["node", "cli", "OOM"]);
 
     const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-    expect(logCalls).toContain("abc12345");
+    expect(logCalls).toContain("550e8400");
     expect(logCalls).toContain("my-agent");
     expect(logCalls).toContain("OOM killed");
   });
@@ -136,7 +136,7 @@ describe("logs search command", () => {
         return HttpResponse.json({
           results: [
             {
-              runId: "abc12345-1234-1234-1234-123456789abc",
+              runId: "550e8400-e29b-41d4-a716-446655440001",
               agentName: "my-agent",
               matchedEvent: makeEvent(3, "Build failed", "not-a-timestamp"),
               contextBefore: [],
@@ -161,7 +161,7 @@ describe("logs search command", () => {
         return HttpResponse.json({
           results: [
             {
-              runId: "abc12345-1234-1234-1234-123456789abc",
+              runId: "550e8400-e29b-41d4-a716-446655440001",
               agentName: "codex-agent",
               framework: "codex",
               matchedEvent: makeCodexMessageEvent(3, "Codex found the issue"),
@@ -187,7 +187,7 @@ describe("logs search command", () => {
         return HttpResponse.json({
           results: [
             {
-              runId: "abc12345-1234-1234-1234-123456789abc",
+              runId: "550e8400-e29b-41d4-a716-446655440001",
               agentName: "future-agent",
               framework: "future-framework",
               matchedEvent: makeEvent(3, "Legacy parser fallback output"),
@@ -213,7 +213,7 @@ describe("logs search command", () => {
         return HttpResponse.json({
           results: [
             {
-              runId: "abc12345-1234-1234-1234-123456789abc",
+              runId: "550e8400-e29b-41d4-a716-446655440001",
               agentName: "codex-agent",
               framework: "codex",
               matchedEvent: makeCodexTurnFailedEvent(4, "Turn failed"),
@@ -397,7 +397,7 @@ describe("logs search command", () => {
         return HttpResponse.json({
           results: [
             {
-              runId: "abc12345-1234-1234-1234-123456789abc",
+              runId: "550e8400-e29b-41d4-a716-446655440001",
               agentName: "test-agent",
               matchedEvent: makeEvent(
                 5,
@@ -435,7 +435,7 @@ describe("logs search command", () => {
         return HttpResponse.json({
           results: [
             {
-              runId: "abc12345-1234-1234-1234-123456789abc",
+              runId: "550e8400-e29b-41d4-a716-446655440001",
               agentName: "agent",
               matchedEvent: makeEvent(1, "match"),
               contextBefore: [],

--- a/turbo/apps/cli/src/commands/logs/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/logs/__tests__/search.test.ts
@@ -181,6 +181,32 @@ describe("logs search command", () => {
     expect(logCalls).toContain("Codex found the issue");
   });
 
+  it("should tolerate unsupported search result framework values", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/logs/search", () => {
+        return HttpResponse.json({
+          results: [
+            {
+              runId: "abc12345-1234-1234-1234-123456789abc",
+              agentName: "future-agent",
+              framework: "future-framework",
+              matchedEvent: makeEvent(3, "Legacy parser fallback output"),
+              contextBefore: [],
+              contextAfter: [],
+            },
+          ],
+          hasMore: false,
+        });
+      }),
+    );
+
+    await searchCommand.parseAsync(["node", "cli", "fallback"]);
+
+    const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(logCalls).toContain("future-agent");
+    expect(logCalls).toContain("Legacy parser fallback output");
+  });
+
   it("should collapse paired codex error and terminal failure events in search context", async () => {
     server.use(
       http.get("http://localhost:3000/api/logs/search", () => {

--- a/turbo/apps/cli/src/commands/logs/index.ts
+++ b/turbo/apps/cli/src/commands/logs/index.ts
@@ -20,6 +20,7 @@ import {
 } from "../../lib/utils/log-pagination";
 import { searchCommand } from "./search";
 import { withErrorHandler } from "../../lib/command";
+import { isSupportedFramework } from "@vm0/core/frameworks";
 
 /**
  * Maximum entries per API request
@@ -57,6 +58,17 @@ function buildPlatformLogsUrl(apiUrl: string, runId: string): string {
  * Log type for mutually exclusive options
  */
 type LogType = "agent" | "system" | "metrics" | "network";
+
+interface AgentEventWithFramework {
+  readonly event: RunEvent;
+  readonly framework?: string;
+}
+
+function supportedLogFramework(
+  framework: string | undefined,
+): string | undefined {
+  return isSupportedFramework(framework) ? framework : undefined;
+}
 
 /**
  * Format a single metric line
@@ -304,7 +316,7 @@ function renderAgentEvent(
   event: RunEvent,
   renderer: EventRenderer,
   normalizer: EventStreamNormalizer,
-  framework: string,
+  framework: string | undefined,
 ): void {
   const parsedEvents = normalizer.process(
     event.eventData,
@@ -459,13 +471,14 @@ async function showAgentEvents(
   },
   platformUrl: string,
 ): Promise<void> {
-  let framework = "claude-code";
-  const events = await collectLogItems<RunEvent>({
+  const events = await collectLogItems<AgentEventWithFramework>({
     fetchPage: async (request) => {
       const response = await getAgentEvents(runId, request);
-      framework = response.framework;
       return {
-        items: response.events,
+        items: response.events.map((event) => {
+          const framework = supportedLogFramework(response.framework);
+          return framework ? { event, framework } : { event };
+        }),
         hasMore: response.hasMore,
         nextCursor: response.nextCursor,
       };
@@ -482,11 +495,19 @@ async function showAgentEvents(
   }
 
   // Create renderer for log viewing (with timestamps, always verbose)
+  const framework = events.find((item) => {
+    return item.framework !== undefined;
+  })?.framework;
   const renderer = createLogRenderer(true);
   const normalizer = new EventStreamNormalizer();
 
-  for (const event of events) {
-    renderAgentEvent(event, renderer, normalizer, framework);
+  for (const item of events) {
+    renderAgentEvent(
+      item.event,
+      renderer,
+      normalizer,
+      item.framework ?? framework,
+    );
   }
   for (const parsed of normalizer.flush()) {
     renderer.render(parsed);

--- a/turbo/apps/cli/src/commands/logs/index.ts
+++ b/turbo/apps/cli/src/commands/logs/index.ts
@@ -428,7 +428,7 @@ export const logsCommand = new Command()
 
         // Parse since option
         let since: number | undefined;
-        if (options.since) {
+        if (options.since !== undefined) {
           since = parseTime(options.since);
         }
 

--- a/turbo/apps/cli/src/commands/logs/index.ts
+++ b/turbo/apps/cli/src/commands/logs/index.ts
@@ -491,6 +491,7 @@ async function showAgentEvents(
   for (const parsed of normalizer.flush()) {
     renderer.render(parsed);
   }
+  renderer.flush();
 
   console.log(chalk.dim(`View on platform: ${platformUrl}`));
 }

--- a/turbo/apps/cli/src/commands/logs/index.ts
+++ b/turbo/apps/cli/src/commands/logs/index.ts
@@ -62,12 +62,17 @@ type LogType = "agent" | "system" | "metrics" | "network";
 interface AgentEventWithFramework {
   readonly event: RunEvent;
   readonly framework?: string;
+  readonly useDefaultFramework: boolean;
 }
 
 function supportedLogFramework(
   framework: string | undefined,
 ): string | undefined {
   return isSupportedFramework(framework) ? framework : undefined;
+}
+
+function hasLogFramework(framework: string | null | undefined): boolean {
+  return framework !== undefined && framework !== null;
 }
 
 /**
@@ -474,10 +479,17 @@ async function showAgentEvents(
   const events = await collectLogItems<AgentEventWithFramework>({
     fetchPage: async (request) => {
       const response = await getAgentEvents(runId, request);
+      const responseFramework: string | null | undefined = response.framework;
       return {
         items: response.events.map((event) => {
-          const framework = supportedLogFramework(response.framework);
-          return framework ? { event, framework } : { event };
+          const framework = supportedLogFramework(
+            responseFramework ?? undefined,
+          );
+          return {
+            event,
+            ...(framework ? { framework } : {}),
+            useDefaultFramework: !hasLogFramework(responseFramework),
+          };
         }),
         hasMore: response.hasMore,
         nextCursor: response.nextCursor,
@@ -506,7 +518,7 @@ async function showAgentEvents(
       item.event,
       renderer,
       normalizer,
-      item.framework ?? framework,
+      item.framework ?? (item.useDefaultFramework ? framework : undefined),
     );
   }
   for (const parsed of normalizer.flush()) {

--- a/turbo/apps/cli/src/commands/logs/index.ts
+++ b/turbo/apps/cli/src/commands/logs/index.ts
@@ -42,9 +42,15 @@ function buildPlatformLogsUrl(apiUrl: string, runId: string): string {
   }
 
   // Transform: www.vm0.ai → app.vm0.ai
+  //            api.vm0.ai → app.vm0.ai
   //            vm0.ai → app.vm0.ai
   const parts = hostname.split(".");
-  if (parts[0] === "www" || parts[0] === "app" || parts[0] === "platform") {
+  if (
+    parts[0] === "www" ||
+    parts[0] === "app" ||
+    parts[0] === "platform" ||
+    parts[0] === "api"
+  ) {
     parts[0] = "app";
   } else {
     parts.unshift("app");

--- a/turbo/apps/cli/src/commands/logs/index.ts
+++ b/turbo/apps/cli/src/commands/logs/index.ts
@@ -21,6 +21,7 @@ import {
 import { searchCommand } from "./search";
 import { withErrorHandler } from "../../lib/command";
 import { isSupportedFramework } from "@vm0/core/frameworks";
+import { isUUID } from "../run/shared";
 
 /**
  * Maximum entries per API request
@@ -395,6 +396,14 @@ export const logsCommand = new Command()
         if (!runId) {
           logsCommand.help();
           return;
+        }
+
+        if (!isUUID(runId)) {
+          console.error(
+            chalk.red(`✗ Invalid run ID "${runId}" — expected a UUID`),
+          );
+          console.error(chalk.dim("  Run: vm0 run list    to find run IDs"));
+          process.exit(1);
         }
 
         const logType = getLogType(options);

--- a/turbo/apps/cli/src/commands/logs/search.ts
+++ b/turbo/apps/cli/src/commands/logs/search.ts
@@ -11,6 +11,7 @@ import { EventRenderer } from "../../lib/events/event-renderer";
 import { EventStreamNormalizer } from "../../lib/events/event-stream-normalizer";
 import { withErrorHandler } from "../../lib/command";
 import { parseBoundedLogCount } from "../../lib/utils/log-pagination";
+import { isSupportedFramework } from "@vm0/core/frameworks";
 
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
 
@@ -24,6 +25,13 @@ interface SearchOptions {
   limit?: string;
 }
 
+function supportedSearchFramework(
+  framework: string | null | undefined,
+): string | undefined {
+  const normalized = framework ?? undefined;
+  return isSupportedFramework(normalized) ? normalized : undefined;
+}
+
 function renderSearchEvent(
   event: RunEvent,
   framework: string | null | undefined,
@@ -32,7 +40,7 @@ function renderSearchEvent(
 ): void {
   const parsedEvents = normalizer.process(
     event.eventData,
-    framework ?? undefined,
+    supportedSearchFramework(framework),
     new Date(event.createdAt),
   );
   for (const parsed of parsedEvents) {

--- a/turbo/apps/cli/src/commands/logs/search.ts
+++ b/turbo/apps/cli/src/commands/logs/search.ts
@@ -197,9 +197,10 @@ export const searchCommand = new Command()
       }
 
       const { before, after } = parseContextOptions(options);
-      const since = options.since
-        ? parseTime(options.since)
-        : Date.now() - SEVEN_DAYS_MS;
+      const since =
+        options.since !== undefined
+          ? parseTime(options.since)
+          : Date.now() - SEVEN_DAYS_MS;
       const limit = parseLimit(options.limit);
 
       const response = await searchLogs({

--- a/turbo/apps/cli/src/commands/logs/search.ts
+++ b/turbo/apps/cli/src/commands/logs/search.ts
@@ -6,6 +6,7 @@ import {
   type LogsSearchResponse,
 } from "../../lib/api";
 import { parseTime } from "../../lib/utils/time-parser";
+import { formatIsoTimestamp } from "../../lib/utils/time-format";
 import { parseEvent } from "../../lib/events/event-parser-factory";
 import { EventRenderer } from "../../lib/events/event-renderer";
 import { withErrorHandler } from "../../lib/command";
@@ -47,7 +48,7 @@ function formatRunHeader(
   timestamp: string,
 ): string {
   const shortId = runId.slice(0, 8);
-  const time = new Date(timestamp).toISOString().replace(/\.\d{3}Z$/, "Z");
+  const time = formatIsoTimestamp(timestamp);
   return `── Run ${shortId} (${agentName}, ${time}) ──────────`;
 }
 

--- a/turbo/apps/cli/src/commands/logs/search.ts
+++ b/turbo/apps/cli/src/commands/logs/search.ts
@@ -11,6 +11,7 @@ import { EventRenderer } from "../../lib/events/event-renderer";
 import { EventStreamNormalizer } from "../../lib/events/event-stream-normalizer";
 import { withErrorHandler } from "../../lib/command";
 import { parseBoundedLogCount } from "../../lib/utils/log-pagination";
+import { parseSearchQuery } from "../../lib/utils/search-query";
 import { isSupportedFramework } from "@vm0/core/frameworks";
 import { isUUID } from "../run/shared";
 
@@ -183,6 +184,8 @@ export const searchCommand = new Command()
   .option("--limit <n>", "Maximum number of matches (default: 20)")
   .action(
     withErrorHandler(async (keyword: string, options: SearchOptions) => {
+      const searchKeyword = parseSearchQuery(keyword, "Keyword");
+
       if (options.agent !== undefined && !isUUID(options.agent)) {
         console.error(
           chalk.red(`✗ Invalid agent ID "${options.agent}" — expected a UUID`),
@@ -207,7 +210,7 @@ export const searchCommand = new Command()
       const limit = parseLimit(options.limit);
 
       const response = await searchLogs({
-        keyword,
+        keyword: searchKeyword,
         agentId: options.agent,
         runId: options.run,
         since,

--- a/turbo/apps/cli/src/commands/logs/search.ts
+++ b/turbo/apps/cli/src/commands/logs/search.ts
@@ -79,15 +79,18 @@ function parseContextOptions(options: SearchOptions): {
   before: number;
   after: number;
 } {
-  const contextN = options.context
-    ? parseBoundedLogCount(options.context, "--context", 0, 10)
-    : 0;
-  const before = options.beforeContext
-    ? parseBoundedLogCount(options.beforeContext, "--before-context", 0, 10)
-    : contextN;
-  const after = options.afterContext
-    ? parseBoundedLogCount(options.afterContext, "--after-context", 0, 10)
-    : contextN;
+  const contextN =
+    options.context !== undefined
+      ? parseBoundedLogCount(options.context, "--context", 0, 10)
+      : 0;
+  const before =
+    options.beforeContext !== undefined
+      ? parseBoundedLogCount(options.beforeContext, "--before-context", 0, 10)
+      : contextN;
+  const after =
+    options.afterContext !== undefined
+      ? parseBoundedLogCount(options.afterContext, "--after-context", 0, 10)
+      : contextN;
 
   return { before, after };
 }
@@ -96,7 +99,7 @@ function parseContextOptions(options: SearchOptions): {
  * Parse --limit option with validation
  */
 function parseLimit(value: string | undefined): number | undefined {
-  if (!value) return undefined;
+  if (value === undefined) return undefined;
   return parseBoundedLogCount(value, "--limit", 1, 50);
 }
 
@@ -180,7 +183,7 @@ export const searchCommand = new Command()
   .option("--limit <n>", "Maximum number of matches (default: 20)")
   .action(
     withErrorHandler(async (keyword: string, options: SearchOptions) => {
-      if (options.agent && !isUUID(options.agent)) {
+      if (options.agent !== undefined && !isUUID(options.agent)) {
         console.error(
           chalk.red(`✗ Invalid agent ID "${options.agent}" — expected a UUID`),
         );
@@ -188,7 +191,7 @@ export const searchCommand = new Command()
         process.exit(1);
       }
 
-      if (options.run && !isUUID(options.run)) {
+      if (options.run !== undefined && !isUUID(options.run)) {
         console.error(
           chalk.red(`✗ Invalid run ID "${options.run}" — expected a UUID`),
         );

--- a/turbo/apps/cli/src/commands/logs/search.ts
+++ b/turbo/apps/cli/src/commands/logs/search.ts
@@ -24,16 +24,13 @@ interface SearchOptions {
   limit?: string;
 }
 
-/**
- * Render a single agent event using EventRenderer.
- *
- * Search responses do not yet carry a per-result framework, so we let the
- * factory default to claude-code. Codex events in search results render as
- * nothing until the search contract is extended (tracked separately).
- */
-function renderEvent(event: RunEvent, renderer: EventRenderer): void {
+function renderSearchEvent(
+  event: RunEvent,
+  framework: string | null | undefined,
+  renderer: EventRenderer,
+): void {
   const eventData = event.eventData as Record<string, unknown>;
-  const parsed = parseEvent(eventData);
+  const parsed = parseEvent(eventData, framework ?? undefined);
   if (parsed) {
     parsed.timestamp = new Date(event.createdAt);
     renderer.render(parsed);
@@ -123,11 +120,11 @@ function renderResults(response: LogsSearchResponse): void {
       });
 
       for (const event of result.contextBefore) {
-        renderEvent(event, renderer);
+        renderSearchEvent(event, result.framework, renderer);
       }
-      renderEvent(result.matchedEvent, renderer);
+      renderSearchEvent(result.matchedEvent, result.framework, renderer);
       for (const event of result.contextAfter) {
-        renderEvent(event, renderer);
+        renderSearchEvent(event, result.framework, renderer);
       }
     }
   }

--- a/turbo/apps/cli/src/commands/logs/search.ts
+++ b/turbo/apps/cli/src/commands/logs/search.ts
@@ -180,6 +180,14 @@ export const searchCommand = new Command()
   .option("--limit <n>", "Maximum number of matches (default: 20)")
   .action(
     withErrorHandler(async (keyword: string, options: SearchOptions) => {
+      if (options.agent && !isUUID(options.agent)) {
+        console.error(
+          chalk.red(`✗ Invalid agent ID "${options.agent}" — expected a UUID`),
+        );
+        console.error(chalk.dim("  Run: vm0 run list    to find agent IDs"));
+        process.exit(1);
+      }
+
       if (options.run && !isUUID(options.run)) {
         console.error(
           chalk.red(`✗ Invalid run ID "${options.run}" — expected a UUID`),

--- a/turbo/apps/cli/src/commands/logs/search.ts
+++ b/turbo/apps/cli/src/commands/logs/search.ts
@@ -12,6 +12,7 @@ import { EventStreamNormalizer } from "../../lib/events/event-stream-normalizer"
 import { withErrorHandler } from "../../lib/command";
 import { parseBoundedLogCount } from "../../lib/utils/log-pagination";
 import { isSupportedFramework } from "@vm0/core/frameworks";
+import { isUUID } from "../run/shared";
 
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
 
@@ -179,6 +180,14 @@ export const searchCommand = new Command()
   .option("--limit <n>", "Maximum number of matches (default: 20)")
   .action(
     withErrorHandler(async (keyword: string, options: SearchOptions) => {
+      if (options.run && !isUUID(options.run)) {
+        console.error(
+          chalk.red(`✗ Invalid run ID "${options.run}" — expected a UUID`),
+        );
+        console.error(chalk.dim("  Run: vm0 run list    to find run IDs"));
+        process.exit(1);
+      }
+
       const { before, after } = parseContextOptions(options);
       const since = options.since
         ? parseTime(options.since)

--- a/turbo/apps/cli/src/commands/logs/search.ts
+++ b/turbo/apps/cli/src/commands/logs/search.ts
@@ -10,6 +10,7 @@ import { formatIsoTimestamp } from "../../lib/utils/time-format";
 import { parseEvent } from "../../lib/events/event-parser-factory";
 import { EventRenderer } from "../../lib/events/event-renderer";
 import { withErrorHandler } from "../../lib/command";
+import { parseBoundedLogCount } from "../../lib/utils/log-pagination";
 
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
 
@@ -59,20 +60,15 @@ function parseContextOptions(options: SearchOptions): {
   before: number;
   after: number;
 } {
-  const contextN = options.context ? parseInt(options.context, 10) : 0;
+  const contextN = options.context
+    ? parseBoundedLogCount(options.context, "--context", 0, 10)
+    : 0;
   const before = options.beforeContext
-    ? parseInt(options.beforeContext, 10)
+    ? parseBoundedLogCount(options.beforeContext, "--before-context", 0, 10)
     : contextN;
   const after = options.afterContext
-    ? parseInt(options.afterContext, 10)
+    ? parseBoundedLogCount(options.afterContext, "--after-context", 0, 10)
     : contextN;
-
-  if (isNaN(before) || before < 0 || before > 10) {
-    throw new Error("--before-context must be between 0 and 10");
-  }
-  if (isNaN(after) || after < 0 || after > 10) {
-    throw new Error("--after-context must be between 0 and 10");
-  }
 
   return { before, after };
 }
@@ -82,11 +78,7 @@ function parseContextOptions(options: SearchOptions): {
  */
 function parseLimit(value: string | undefined): number | undefined {
   if (!value) return undefined;
-  const limit = parseInt(value, 10);
-  if (isNaN(limit) || limit < 1 || limit > 50) {
-    throw new Error("--limit must be between 1 and 50");
-  }
-  return limit;
+  return parseBoundedLogCount(value, "--limit", 1, 50);
 }
 
 /**

--- a/turbo/apps/cli/src/commands/logs/search.ts
+++ b/turbo/apps/cli/src/commands/logs/search.ts
@@ -7,8 +7,8 @@ import {
 } from "../../lib/api";
 import { parseTime } from "../../lib/utils/time-parser";
 import { formatIsoTimestamp } from "../../lib/utils/time-format";
-import { parseEvent } from "../../lib/events/event-parser-factory";
 import { EventRenderer } from "../../lib/events/event-renderer";
+import { EventStreamNormalizer } from "../../lib/events/event-stream-normalizer";
 import { withErrorHandler } from "../../lib/command";
 import { parseBoundedLogCount } from "../../lib/utils/log-pagination";
 
@@ -28,13 +28,26 @@ function renderSearchEvent(
   event: RunEvent,
   framework: string | null | undefined,
   renderer: EventRenderer,
+  normalizer: EventStreamNormalizer,
 ): void {
-  const eventData = event.eventData as Record<string, unknown>;
-  const parsed = parseEvent(eventData, framework ?? undefined);
-  if (parsed) {
-    parsed.timestamp = new Date(event.createdAt);
+  const parsedEvents = normalizer.process(
+    event.eventData,
+    framework ?? undefined,
+    new Date(event.createdAt),
+  );
+  for (const parsed of parsedEvents) {
     renderer.render(parsed);
   }
+}
+
+function flushSearchRenderer(
+  renderer: EventRenderer,
+  normalizer: EventStreamNormalizer,
+): void {
+  for (const parsed of normalizer.flush()) {
+    renderer.render(parsed);
+  }
+  renderer.flush();
 }
 
 /**
@@ -116,16 +129,22 @@ function renderResults(response: LogsSearchResponse): void {
       const renderer = new EventRenderer({
         showTimestamp: true,
         verbose: false,
-        buffered: false,
       });
+      const normalizer = new EventStreamNormalizer();
 
       for (const event of result.contextBefore) {
-        renderSearchEvent(event, result.framework, renderer);
+        renderSearchEvent(event, result.framework, renderer, normalizer);
       }
-      renderSearchEvent(result.matchedEvent, result.framework, renderer);
+      renderSearchEvent(
+        result.matchedEvent,
+        result.framework,
+        renderer,
+        normalizer,
+      );
       for (const event of result.contextAfter) {
-        renderSearchEvent(event, result.framework, renderer);
+        renderSearchEvent(event, result.framework, renderer, normalizer);
       }
+      flushSearchRenderer(renderer, normalizer);
     }
   }
 

--- a/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
@@ -2346,6 +2346,58 @@ describe("run command", () => {
       expect(logCalls).toContain("Second turn failed");
     });
 
+    it("should not collapse Codex polling failures when only the pending error has a turn id", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/runs/:id/events", () => {
+          return HttpResponse.json({
+            events: [
+              {
+                sequenceNumber: 0,
+                eventType: "thread.started",
+                eventData: {
+                  type: "thread.started",
+                  thread_id: "thread-x",
+                },
+                createdAt: "2025-01-01T00:00:00Z",
+              },
+              {
+                sequenceNumber: 1,
+                eventType: "error",
+                eventData: {
+                  type: "error",
+                  turn_id: "turn-1",
+                  message: "First turn failed",
+                },
+                createdAt: "2025-01-01T00:00:01Z",
+              },
+              {
+                sequenceNumber: 2,
+                eventType: "turn.failed",
+                eventData: {
+                  type: "turn.failed",
+                  error: "Unattributed terminal failure",
+                },
+                createdAt: "2025-01-01T00:00:02Z",
+              },
+            ],
+            hasMore: false,
+            nextSequence: 2,
+            run: { status: "failed", error: "Agent crashed" },
+            framework: "codex",
+          });
+        }),
+      );
+
+      await expect(async () => {
+        await runCommand.parseAsync(["node", "cli", testUuid, "test prompt"]);
+      }).rejects.toThrow("process.exit called");
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(countOccurrences(logCalls, "Codex Failed")).toBe(2);
+      expect(logCalls).toContain("First turn failed");
+      expect(logCalls).toContain("Unattributed terminal failure");
+    });
+
     it("should flush pending Codex tool use before terminal run lifecycle output", async () => {
       server.use(
         http.get("http://localhost:3000/api/agent/runs/:id/events", () => {

--- a/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
@@ -2168,6 +2168,230 @@ describe("run command", () => {
       );
     });
 
+    it("should render failed Codex turn.completed before failed run lifecycle output", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/runs/:id/events", () => {
+          return HttpResponse.json({
+            events: [
+              {
+                sequenceNumber: 0,
+                eventType: "thread.started",
+                eventData: {
+                  type: "thread.started",
+                  thread_id: "thread-x",
+                },
+                createdAt: "2025-01-01T00:00:00Z",
+              },
+              {
+                sequenceNumber: 1,
+                eventType: "turn.completed",
+                eventData: {
+                  type: "turn.completed",
+                  turn: {
+                    id: "turn-1",
+                    status: "failed",
+                    error: {
+                      message: "selected model is at capacity",
+                      additional_details: "retry later",
+                    },
+                  },
+                },
+                createdAt: "2025-01-01T00:00:01Z",
+              },
+            ],
+            hasMore: false,
+            nextSequence: 1,
+            run: { status: "failed", error: "Agent crashed" },
+            framework: "codex",
+          });
+        }),
+      );
+
+      await expect(async () => {
+        await runCommand.parseAsync(["node", "cli", testUuid, "test prompt"]);
+      }).rejects.toThrow("process.exit called");
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Codex Failed");
+      expect(logCalls).toContain("selected model is at capacity");
+      expect(logCalls).toContain("retry later");
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Run failed"),
+      );
+    });
+
+    it("should collapse same-turn Codex error and failed turn.completed across event pages", async () => {
+      let pollCount = 0;
+      server.use(
+        http.get("http://localhost:3000/api/agent/runs/:id/events", () => {
+          pollCount++;
+          if (pollCount === 1) {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 0,
+                  eventType: "thread.started",
+                  eventData: {
+                    type: "thread.started",
+                    thread_id: "thread-x",
+                  },
+                  createdAt: "2025-01-01T00:00:00Z",
+                },
+                {
+                  sequenceNumber: 1,
+                  eventType: "error",
+                  eventData: {
+                    type: "error",
+                    turn_id: "turn-1",
+                    message: "API connection failed",
+                  },
+                  createdAt: "2025-01-01T00:00:01Z",
+                },
+              ],
+              hasMore: true,
+              nextSequence: 1,
+              run: { status: "running" },
+              framework: "codex",
+            });
+          }
+
+          return HttpResponse.json({
+            events: [
+              {
+                sequenceNumber: 2,
+                eventType: "turn.completed",
+                eventData: {
+                  type: "turn.completed",
+                  turn: {
+                    id: "turn-1",
+                    status: "failed",
+                    error: { message: "Rate limit exceeded" },
+                  },
+                },
+                createdAt: "2025-01-01T00:00:02Z",
+              },
+            ],
+            hasMore: false,
+            nextSequence: 2,
+            run: { status: "failed", error: "Agent crashed" },
+            framework: "codex",
+          });
+        }),
+      );
+
+      await expect(async () => {
+        await runCommand.parseAsync(["node", "cli", testUuid, "test prompt"]);
+      }).rejects.toThrow("process.exit called");
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(pollCount).toBe(2);
+      expect(countOccurrences(logCalls, "Codex Failed")).toBe(1);
+      expect(logCalls).toContain("API connection failed");
+      expect(logCalls).toContain("Rate limit exceeded");
+    });
+
+    it("should not collapse Codex terminal failures from different turns while polling", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/runs/:id/events", () => {
+          return HttpResponse.json({
+            events: [
+              {
+                sequenceNumber: 0,
+                eventType: "thread.started",
+                eventData: {
+                  type: "thread.started",
+                  thread_id: "thread-x",
+                },
+                createdAt: "2025-01-01T00:00:00Z",
+              },
+              {
+                sequenceNumber: 1,
+                eventType: "error",
+                eventData: {
+                  type: "error",
+                  turn_id: "turn-1",
+                  message: "First turn failed",
+                },
+                createdAt: "2025-01-01T00:00:01Z",
+              },
+              {
+                sequenceNumber: 2,
+                eventType: "turn.completed",
+                eventData: {
+                  type: "turn.completed",
+                  turn: {
+                    id: "turn-2",
+                    status: "failed",
+                    error: { message: "Second turn failed" },
+                  },
+                },
+                createdAt: "2025-01-01T00:00:02Z",
+              },
+            ],
+            hasMore: false,
+            nextSequence: 2,
+            run: { status: "failed", error: "Agent crashed" },
+            framework: "codex",
+          });
+        }),
+      );
+
+      await expect(async () => {
+        await runCommand.parseAsync(["node", "cli", testUuid, "test prompt"]);
+      }).rejects.toThrow("process.exit called");
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(countOccurrences(logCalls, "Codex Failed")).toBe(2);
+      expect(logCalls).toContain("First turn failed");
+      expect(logCalls).toContain("Second turn failed");
+    });
+
+    it("should flush pending Codex tool use before terminal run lifecycle output", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/runs/:id/events", () => {
+          return HttpResponse.json({
+            events: [
+              {
+                sequenceNumber: 0,
+                eventType: "item.started",
+                eventData: {
+                  type: "item.started",
+                  item: {
+                    id: "cmd-pending",
+                    type: "command_execution",
+                    command: "sleep 10",
+                  },
+                },
+                createdAt: "2025-01-01T00:00:00Z",
+              },
+            ],
+            hasMore: false,
+            nextSequence: 0,
+            run: {
+              status: "completed",
+              lastEventSequence: 0,
+              result: {
+                checkpointId: "cp-1",
+                agentSessionId: "s-1",
+                conversationId: "c-1",
+                artifact: {},
+              },
+            },
+            framework: "codex",
+          });
+        }),
+      );
+
+      await runCommand.parseAsync(["node", "cli", testUuid, "test prompt"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("sleep 10");
+      const pendingIndex = logCalls.indexOf("sleep 10");
+      const completedIndex = logCalls.indexOf("Run completed successfully");
+      expect(pendingIndex).toBeGreaterThan(-1);
+      expect(completedIndex).toBeGreaterThan(pendingIndex);
+    });
+
     it("should not drain additional pages after failed status without watermark", async () => {
       let pollCount = 0;
       server.use(

--- a/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
@@ -1211,7 +1211,7 @@ describe("run command", () => {
         return call[0];
       });
       const resultIndex = logMessages.findIndex((message) => {
-        return String(message).includes("Agent Completed");
+        return String(message).includes("Claude Code Completed");
       });
       const completionIndex = logMessages.findIndex((message) => {
         return String(message).includes("Run completed successfully");
@@ -1274,7 +1274,7 @@ describe("run command", () => {
 
       expect(pollCount).toBe(2);
       expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("Agent Completed"),
+        expect.stringContaining("Claude Code Completed"),
       );
       expect(mockConsoleLog).toHaveBeenCalledWith(
         expect.stringContaining("Run completed successfully"),
@@ -1325,7 +1325,7 @@ describe("run command", () => {
 
       expect(pollCount).toBe(1);
       expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("Agent Completed"),
+        expect.stringContaining("Claude Code Completed"),
       );
       expect(mockConsoleLog).toHaveBeenCalledWith(
         expect.stringContaining("Run completed successfully"),
@@ -1421,7 +1421,7 @@ describe("run command", () => {
 
       expect(pollCount).toBe(2);
       expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("Agent Completed"),
+        expect.stringContaining("Claude Code Completed"),
       );
       expect(mockConsoleLog).toHaveBeenCalledWith(
         expect.stringContaining("terminal watermark"),
@@ -1482,7 +1482,7 @@ describe("run command", () => {
 
       expect(pollCount).toBe(2);
       expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("Agent Completed"),
+        expect.stringContaining("Codex Completed"),
       );
       expect(mockConsoleLog).toHaveBeenCalledWith(
         expect.stringContaining("Run completed successfully"),
@@ -1553,7 +1553,7 @@ describe("run command", () => {
 
       expect(pollCount).toBe(4);
       expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("Agent Completed"),
+        expect.stringContaining("Claude Code Completed"),
       );
       expect(mockConsoleLog).toHaveBeenCalledWith(
         expect.stringContaining("Run completed successfully"),

--- a/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
@@ -2392,6 +2392,67 @@ describe("run command", () => {
       expect(completedIndex).toBeGreaterThan(pendingIndex);
     });
 
+    it("should flush pending Codex tool use before terminal Codex failure output", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/runs/:id/events", () => {
+          return HttpResponse.json({
+            events: [
+              {
+                sequenceNumber: 0,
+                eventType: "thread.started",
+                eventData: {
+                  type: "thread.started",
+                  thread_id: "thread-x",
+                },
+                createdAt: "2025-01-01T00:00:00Z",
+              },
+              {
+                sequenceNumber: 1,
+                eventType: "item.started",
+                eventData: {
+                  type: "item.started",
+                  item: {
+                    id: "cmd-pending",
+                    type: "command_execution",
+                    command: "sleep 10",
+                  },
+                },
+                createdAt: "2025-01-01T00:00:01Z",
+              },
+              {
+                sequenceNumber: 2,
+                eventType: "turn.completed",
+                eventData: {
+                  type: "turn.completed",
+                  turn: {
+                    id: "turn-1",
+                    status: "failed",
+                    error: { message: "model unavailable" },
+                  },
+                },
+                createdAt: "2025-01-01T00:00:02Z",
+              },
+            ],
+            hasMore: false,
+            nextSequence: 2,
+            run: { status: "failed", error: "Agent crashed" },
+            framework: "codex",
+          });
+        }),
+      );
+
+      await expect(async () => {
+        await runCommand.parseAsync(["node", "cli", testUuid, "test prompt"]);
+      }).rejects.toThrow("process.exit called");
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      const pendingIndex = logCalls.indexOf("sleep 10");
+      const codexFailedIndex = logCalls.indexOf("Codex Failed");
+      expect(pendingIndex).toBeGreaterThan(-1);
+      expect(codexFailedIndex).toBeGreaterThan(pendingIndex);
+      expect(logCalls).toContain("model unavailable");
+    });
+
     it("should not drain additional pages after failed status without watermark", async () => {
       let pollCount = 0;
       server.use(

--- a/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
@@ -1937,6 +1937,51 @@ describe("run command", () => {
       );
     });
 
+    it("should not fail when an events response has an unsupported framework", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/agent/runs/:id/events", () => {
+          return HttpResponse.json({
+            events: [
+              {
+                sequenceNumber: 0,
+                eventType: "result",
+                eventData: {
+                  type: "result",
+                  subtype: "success",
+                  is_error: false,
+                  duration_ms: 1000,
+                  num_turns: 1,
+                  result: "Done despite unknown framework",
+                  session_id: "test",
+                  total_cost_usd: 0,
+                  usage: {},
+                },
+                createdAt: "2025-01-01T00:00:00Z",
+              },
+            ],
+            hasMore: false,
+            nextSequence: 0,
+            run: {
+              status: "completed",
+              result: {
+                checkpointId: "cp-1",
+                agentSessionId: "s-1",
+                conversationId: "c-1",
+                artifact: {},
+              },
+            },
+            framework: "future-framework",
+          });
+        }),
+      );
+
+      await runCommand.parseAsync(["node", "cli", testUuid, "test prompt"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Agent Completed");
+      expect(logCalls).toContain("Run completed successfully");
+    });
+
     it("should handle polling errors gracefully", async () => {
       let pollCount = 0;
       server.use(

--- a/turbo/apps/cli/src/commands/run/shared.ts
+++ b/turbo/apps/cli/src/commands/run/shared.ts
@@ -6,6 +6,7 @@ import type { GetEventsResponse } from "../../lib/api/core/types";
 import { EventStreamNormalizer } from "../../lib/events/event-stream-normalizer";
 import { EventRenderer } from "../../lib/events/event-renderer";
 import { extractAndGroupVariables } from "@vm0/core/variable-expander";
+import { isSupportedFramework } from "@vm0/core/frameworks";
 import {
   firewallPoliciesSchema,
   type FirewallPolicies,
@@ -323,6 +324,12 @@ const TERMINAL_DRAIN_POLL_INTERVAL_MS = 500;
 const TERMINAL_DRAIN_IDLE_MS = 1000;
 const TERMINAL_DRAIN_MAX_MS = 3000;
 
+function supportedEventFramework(
+  framework: string | undefined,
+): string | undefined {
+  return isSupportedFramework(framework) ? framework : undefined;
+}
+
 /**
  * Options for polling/streaming events
  */
@@ -515,7 +522,7 @@ export async function pollEvents(
       for (const event of response.events) {
         const parsedEvents = normalizer.process(
           event.eventData,
-          response.framework,
+          supportedEventFramework(response.framework),
         );
         for (const parsed of parsedEvents) {
           renderer.render(parsed);

--- a/turbo/apps/cli/src/commands/run/shared.ts
+++ b/turbo/apps/cli/src/commands/run/shared.ts
@@ -496,6 +496,7 @@ export async function pollEvents(
     for (const parsed of normalizer.flush()) {
       renderer.render(parsed);
     }
+    renderer.flush();
   };
 
   for (;;) {

--- a/turbo/apps/cli/src/commands/run/shared.ts
+++ b/turbo/apps/cli/src/commands/run/shared.ts
@@ -154,10 +154,11 @@ export function parsePermissionPolicies(
   return result.data;
 }
 
+const UUID_PATTERN =
+  /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000)$/i;
+
 export function isUUID(str: string): boolean {
-  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
-    str,
-  );
+  return UUID_PATTERN.test(str);
 }
 
 /**

--- a/turbo/apps/cli/src/commands/run/shared.ts
+++ b/turbo/apps/cli/src/commands/run/shared.ts
@@ -154,7 +154,9 @@ export function parsePermissionPolicies(
 }
 
 export function isUUID(str: string): boolean {
-  return /^[0-9a-f-]{36}$/i.test(str);
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+    str,
+  );
 }
 
 /**

--- a/turbo/apps/cli/src/commands/zero/logs/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/__tests__/list.test.ts
@@ -206,6 +206,15 @@ describe("zero logs list command", () => {
     expect(sinceValue).toBeLessThanOrEqual(Date.now());
   });
 
+  it("should reject partial numeric --limit values", async () => {
+    await expect(
+      listCommand.parseAsync(["node", "cli", "--limit", "1abc"]),
+    ).rejects.toThrow("process.exit called");
+
+    const errorCalls = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errorCalls).toContain("Option --limit must be a positive integer");
+  });
+
   it("should fall back to agentId when displayName is null", async () => {
     server.use(
       http.get("http://localhost:3000/api/zero/logs", () => {

--- a/turbo/apps/cli/src/commands/zero/logs/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/__tests__/list.test.ts
@@ -130,6 +130,15 @@ describe("zero logs list command", () => {
     expect(capturedUrl?.searchParams.get("agentId")).toBe(AGENT_ID);
   });
 
+  it("should reject non-UUID agent filter values", async () => {
+    await expect(
+      listCommand.parseAsync(["node", "cli", "--agent", "agent-123"]),
+    ).rejects.toThrow("process.exit called");
+
+    const errorCalls = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errorCalls).toContain("Invalid agent ID");
+  });
+
   it("should pass status filter to API", async () => {
     let capturedUrl: URL | undefined;
     server.use(

--- a/turbo/apps/cli/src/commands/zero/logs/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/__tests__/list.test.ts
@@ -135,7 +135,16 @@ describe("zero logs list command", () => {
       listCommand.parseAsync(["node", "cli", "--agent", "agent-123"]),
     ).rejects.toThrow("process.exit called");
 
-    const errorCalls = mockConsoleError.mock.calls.flat().join("\n");
+    let errorCalls = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errorCalls).toContain("Invalid agent ID");
+
+    mockConsoleError.mockClear();
+
+    await expect(
+      listCommand.parseAsync(["node", "cli", "--agent", ""]),
+    ).rejects.toThrow("process.exit called");
+
+    errorCalls = mockConsoleError.mock.calls.flat().join("\n");
     expect(errorCalls).toContain("Invalid agent ID");
   });
 
@@ -241,6 +250,15 @@ describe("zero logs list command", () => {
   it("should reject partial numeric --limit values", async () => {
     await expect(
       listCommand.parseAsync(["node", "cli", "--limit", "1abc"]),
+    ).rejects.toThrow("process.exit called");
+
+    const errorCalls = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errorCalls).toContain("--limit must be between 1 and 100");
+  });
+
+  it("should reject empty --limit values", async () => {
+    await expect(
+      listCommand.parseAsync(["node", "cli", "--limit", ""]),
     ).rejects.toThrow("process.exit called");
 
     const errorCalls = mockConsoleError.mock.calls.flat().join("\n");

--- a/turbo/apps/cli/src/commands/zero/logs/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/__tests__/list.test.ts
@@ -212,7 +212,16 @@ describe("zero logs list command", () => {
     ).rejects.toThrow("process.exit called");
 
     const errorCalls = mockConsoleError.mock.calls.flat().join("\n");
-    expect(errorCalls).toContain("Option --limit must be a positive integer");
+    expect(errorCalls).toContain("--limit must be between 1 and 100");
+  });
+
+  it("should reject --limit values above the API maximum", async () => {
+    await expect(
+      listCommand.parseAsync(["node", "cli", "--limit", "101"]),
+    ).rejects.toThrow("process.exit called");
+
+    const errorCalls = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errorCalls).toContain("--limit must be between 1 and 100");
   });
 
   it("should fall back to agentId when displayName is null", async () => {

--- a/turbo/apps/cli/src/commands/zero/logs/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/__tests__/list.test.ts
@@ -215,6 +215,29 @@ describe("zero logs list command", () => {
     expect(sinceValue).toBeLessThanOrEqual(Date.now());
   });
 
+  it("should pass epoch since filter to API", async () => {
+    let capturedUrl: URL | undefined;
+    server.use(
+      http.get("http://localhost:3000/api/zero/logs", ({ request }) => {
+        capturedUrl = new URL(request.url);
+        return HttpResponse.json({
+          data: [],
+          pagination: { hasMore: false, nextCursor: null, totalPages: 0 },
+          filters: emptyFilters,
+        });
+      }),
+    );
+
+    await listCommand.parseAsync([
+      "node",
+      "cli",
+      "--since",
+      "1970-01-01T00:00:00Z",
+    ]);
+
+    expect(capturedUrl?.searchParams.get("since")).toBe("0");
+  });
+
   it("should reject partial numeric --limit values", async () => {
     await expect(
       listCommand.parseAsync(["node", "cli", "--limit", "1abc"]),

--- a/turbo/apps/cli/src/commands/zero/logs/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/__tests__/list.test.ts
@@ -77,6 +77,24 @@ describe("zero logs list command", () => {
     expect(logCalls).toContain("2026-04-01");
   });
 
+  it("should tolerate invalid run creation timestamps", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/zero/logs", () => {
+        return HttpResponse.json({
+          data: [{ ...mockLogEntry, createdAt: "not-a-timestamp" }],
+          pagination: { hasMore: false, nextCursor: null, totalPages: 1 },
+          filters: emptyFilters,
+        });
+      }),
+    );
+
+    await listCommand.parseAsync(["node", "cli"]);
+
+    const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(logCalls).toContain("invalid-date");
+    expect(logCalls).toContain("My Agent");
+  });
+
   it("should handle empty run list", async () => {
     server.use(
       http.get("http://localhost:3000/api/zero/logs", () => {

--- a/turbo/apps/cli/src/commands/zero/logs/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/__tests__/list.test.ts
@@ -16,7 +16,7 @@ import chalk from "chalk";
 const AGENT_ID = "11111111-1111-4111-8111-111111111111";
 
 const mockLogEntry = {
-  id: "abc12345-1234-1234-1234-123456789abc",
+  id: "550e8400-e29b-41d4-a716-446655440001",
   sessionId: null,
   agentId: AGENT_ID,
   displayName: "My Agent",
@@ -71,7 +71,7 @@ describe("zero logs list command", () => {
     await listCommand.parseAsync(["node", "cli"]);
 
     const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-    expect(logCalls).toContain("abc12345-1234-1234-1234-123456789abc");
+    expect(logCalls).toContain("550e8400-e29b-41d4-a716-446655440001");
     expect(logCalls).toContain("My Agent");
     expect(logCalls).toContain("completed");
     expect(logCalls).toContain("2026-04-01");

--- a/turbo/apps/cli/src/commands/zero/logs/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/__tests__/search.test.ts
@@ -112,6 +112,15 @@ describe("zero logs search command", () => {
     mockConsoleError.mockClear();
   });
 
+  it("should reject whitespace-only keywords", async () => {
+    await expect(
+      searchCommand.parseAsync(["node", "cli", "   "]),
+    ).rejects.toThrow("process.exit called");
+
+    const errorCalls = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errorCalls).toContain("Keyword cannot be empty");
+  });
+
   it("should render search results grouped by run", async () => {
     server.use(
       http.get("http://localhost:3000/api/zero/logs/search", () => {

--- a/turbo/apps/cli/src/commands/zero/logs/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/__tests__/search.test.ts
@@ -118,7 +118,7 @@ describe("zero logs search command", () => {
         return HttpResponse.json({
           results: [
             {
-              runId: "abc12345-1234-1234-1234-123456789abc",
+              runId: "550e8400-e29b-41d4-a716-446655440001",
               agentName: "my-agent",
               matchedEvent: makeEvent(3, "Build failed: OOM killed"),
               contextBefore: [],
@@ -133,7 +133,7 @@ describe("zero logs search command", () => {
     await searchCommand.parseAsync(["node", "cli", "OOM"]);
 
     const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-    expect(logCalls).toContain("abc12345-1234-1234-1234-123456789abc");
+    expect(logCalls).toContain("550e8400-e29b-41d4-a716-446655440001");
     expect(logCalls).toContain("my-agent");
     expect(logCalls).toContain("OOM killed");
   });
@@ -144,7 +144,7 @@ describe("zero logs search command", () => {
         return HttpResponse.json({
           results: [
             {
-              runId: "abc12345-1234-1234-1234-123456789abc",
+              runId: "550e8400-e29b-41d4-a716-446655440001",
               agentName: "my-agent",
               matchedEvent: makeEvent(3, "Build failed", "not-a-timestamp"),
               contextBefore: [],
@@ -169,7 +169,7 @@ describe("zero logs search command", () => {
         return HttpResponse.json({
           results: [
             {
-              runId: "abc12345-1234-1234-1234-123456789abc",
+              runId: "550e8400-e29b-41d4-a716-446655440001",
               agentName: "codex-agent",
               framework: "codex",
               matchedEvent: makeCodexMessageEvent(3, "Codex found the issue"),
@@ -195,7 +195,7 @@ describe("zero logs search command", () => {
         return HttpResponse.json({
           results: [
             {
-              runId: "abc12345-1234-1234-1234-123456789abc",
+              runId: "550e8400-e29b-41d4-a716-446655440001",
               agentName: "future-agent",
               framework: "future-framework",
               matchedEvent: makeEvent(3, "Legacy parser fallback output"),
@@ -221,7 +221,7 @@ describe("zero logs search command", () => {
         return HttpResponse.json({
           results: [
             {
-              runId: "abc12345-1234-1234-1234-123456789abc",
+              runId: "550e8400-e29b-41d4-a716-446655440001",
               agentName: "codex-agent",
               framework: "codex",
               matchedEvent: makeCodexCommandCompletedEvent(4),
@@ -328,12 +328,12 @@ describe("zero logs search command", () => {
       "--agent",
       AGENT_ID,
       "--run",
-      "abc12345-1234-1234-1234-123456789abc",
+      "550e8400-e29b-41d4-a716-446655440001",
     ]);
 
     expect(capturedUrl?.searchParams.get("agentId")).toBe(AGENT_ID);
     expect(capturedUrl?.searchParams.get("runId")).toBe(
-      "abc12345-1234-1234-1234-123456789abc",
+      "550e8400-e29b-41d4-a716-446655440001",
     );
   });
 
@@ -343,7 +343,7 @@ describe("zero logs search command", () => {
         return HttpResponse.json({
           results: [
             {
-              runId: "abc12345-1234-1234-1234-123456789abc",
+              runId: "550e8400-e29b-41d4-a716-446655440001",
               agentName: "agent",
               matchedEvent: makeEvent(1, "match"),
               contextBefore: [],
@@ -367,7 +367,7 @@ describe("zero logs search command", () => {
         return HttpResponse.json({
           results: [
             {
-              runId: "abc12345-1234-1234-1234-123456789abc",
+              runId: "550e8400-e29b-41d4-a716-446655440001",
               agentName: "test-agent",
               matchedEvent: makeEvent(
                 5,

--- a/turbo/apps/cli/src/commands/zero/logs/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/__tests__/search.test.ts
@@ -52,6 +52,46 @@ function makeCodexMessageEvent(
   };
 }
 
+function makeCodexCommandStartedEvent(
+  sequenceNumber: number,
+  createdAt = "2024-01-15T10:30:00Z",
+) {
+  return {
+    sequenceNumber,
+    eventType: "item.started",
+    createdAt,
+    eventData: {
+      type: "item.started",
+      item: {
+        id: "cmd-1",
+        type: "command_execution",
+        command: "npm test",
+      },
+    },
+  };
+}
+
+function makeCodexCommandCompletedEvent(
+  sequenceNumber: number,
+  createdAt = "2024-01-15T10:30:01Z",
+) {
+  return {
+    sequenceNumber,
+    eventType: "item.completed",
+    createdAt,
+    eventData: {
+      type: "item.completed",
+      item: {
+        id: "cmd-1",
+        type: "command_execution",
+        command: "npm test",
+        aggregated_output: "tests passed",
+        exit_code: 0,
+      },
+    },
+  };
+}
+
 describe("zero logs search command", () => {
   const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
     throw new Error("process.exit called");
@@ -147,6 +187,32 @@ describe("zero logs search command", () => {
     const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
     expect(logCalls).toContain("codex-agent");
     expect(logCalls).toContain("Codex found the issue");
+  });
+
+  it("should group paired codex tool events in search context", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/zero/logs/search", () => {
+        return HttpResponse.json({
+          results: [
+            {
+              runId: "abc12345-1234-1234-1234-123456789abc",
+              agentName: "codex-agent",
+              framework: "codex",
+              matchedEvent: makeCodexCommandCompletedEvent(4),
+              contextBefore: [makeCodexCommandStartedEvent(3)],
+              contextAfter: [],
+            },
+          ],
+          hasMore: false,
+        });
+      }),
+    );
+
+    await searchCommand.parseAsync(["node", "cli", "tests"]);
+
+    const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(logCalls).toContain("tests passed");
+    expect(logCalls.match(/Bash/g) ?? []).toHaveLength(1);
   });
 
   it("should handle no matches", async () => {

--- a/turbo/apps/cli/src/commands/zero/logs/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/__tests__/search.test.ts
@@ -189,6 +189,32 @@ describe("zero logs search command", () => {
     expect(logCalls).toContain("Codex found the issue");
   });
 
+  it("should tolerate unsupported search result framework values", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/zero/logs/search", () => {
+        return HttpResponse.json({
+          results: [
+            {
+              runId: "abc12345-1234-1234-1234-123456789abc",
+              agentName: "future-agent",
+              framework: "future-framework",
+              matchedEvent: makeEvent(3, "Legacy parser fallback output"),
+              contextBefore: [],
+              contextAfter: [],
+            },
+          ],
+          hasMore: false,
+        });
+      }),
+    );
+
+    await searchCommand.parseAsync(["node", "cli", "fallback"]);
+
+    const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(logCalls).toContain("future-agent");
+    expect(logCalls).toContain("Legacy parser fallback output");
+  });
+
   it("should group paired codex tool events in search context", async () => {
     server.use(
       http.get("http://localhost:3000/api/zero/logs/search", () => {

--- a/turbo/apps/cli/src/commands/zero/logs/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/__tests__/search.test.ts
@@ -409,6 +409,22 @@ describe("zero logs search command", () => {
     expect(errorCalls).toContain("zero logs list");
   });
 
+  it("should reject malformed UUID-like --run value", async () => {
+    await expect(
+      searchCommand.parseAsync([
+        "node",
+        "cli",
+        "error",
+        "--run",
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    const errorCalls = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errorCalls).toContain("Invalid run ID");
+    expect(errorCalls).toContain("zero logs list");
+  });
+
   it("should handle authentication error", async () => {
     server.use(
       http.get("http://localhost:3000/api/zero/logs/search", () => {

--- a/turbo/apps/cli/src/commands/zero/logs/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/__tests__/search.test.ts
@@ -271,6 +271,26 @@ describe("zero logs search command", () => {
     expect(capturedUrl?.searchParams.get("after")).toBe("3");
   });
 
+  it("should send epoch --since instead of the default search window", async () => {
+    let capturedUrl: URL | undefined;
+    server.use(
+      http.get("http://localhost:3000/api/zero/logs/search", ({ request }) => {
+        capturedUrl = new URL(request.url);
+        return HttpResponse.json({ results: [], hasMore: false });
+      }),
+    );
+
+    await searchCommand.parseAsync([
+      "node",
+      "cli",
+      "error",
+      "--since",
+      "1970-01-01T00:00:00Z",
+    ]);
+
+    expect(capturedUrl?.searchParams.get("since")).toBe("0");
+  });
+
   it("should pass -A and -B independently", async () => {
     let capturedUrl: URL | undefined;
     server.use(

--- a/turbo/apps/cli/src/commands/zero/logs/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/__tests__/search.test.ts
@@ -330,6 +330,24 @@ describe("zero logs search command", () => {
 
     errorCalls = mockConsoleError.mock.calls.flat().join("\n");
     expect(errorCalls).toContain("--limit must be between 1 and 50");
+
+    mockConsoleError.mockClear();
+
+    await expect(
+      searchCommand.parseAsync(["node", "cli", "error", "-C", ""]),
+    ).rejects.toThrow("process.exit called");
+
+    errorCalls = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errorCalls).toContain("--context must be between 0 and 10");
+
+    mockConsoleError.mockClear();
+
+    await expect(
+      searchCommand.parseAsync(["node", "cli", "error", "--limit", ""]),
+    ).rejects.toThrow("process.exit called");
+
+    errorCalls = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errorCalls).toContain("--limit must be between 1 and 50");
   });
 
   it("should pass agentId and run filters", async () => {
@@ -424,7 +442,17 @@ describe("zero logs search command", () => {
       searchCommand.parseAsync(["node", "cli", "error", "--run", "6af7eece"]),
     ).rejects.toThrow("process.exit called");
 
-    const errorCalls = mockConsoleError.mock.calls.flat().join("\n");
+    let errorCalls = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errorCalls).toContain("Invalid run ID");
+    expect(errorCalls).toContain("zero logs list");
+
+    mockConsoleError.mockClear();
+
+    await expect(
+      searchCommand.parseAsync(["node", "cli", "error", "--run", ""]),
+    ).rejects.toThrow("process.exit called");
+
+    errorCalls = mockConsoleError.mock.calls.flat().join("\n");
     expect(errorCalls).toContain("Invalid run ID");
     expect(errorCalls).toContain("zero logs list");
   });
@@ -440,7 +468,17 @@ describe("zero logs search command", () => {
       ]),
     ).rejects.toThrow("process.exit called");
 
-    const errorCalls = mockConsoleError.mock.calls.flat().join("\n");
+    let errorCalls = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errorCalls).toContain("Invalid agent ID");
+    expect(errorCalls).toContain("zero logs list");
+
+    mockConsoleError.mockClear();
+
+    await expect(
+      searchCommand.parseAsync(["node", "cli", "error", "--agent", ""]),
+    ).rejects.toThrow("process.exit called");
+
+    errorCalls = mockConsoleError.mock.calls.flat().join("\n");
     expect(errorCalls).toContain("Invalid agent ID");
     expect(errorCalls).toContain("zero logs list");
   });

--- a/turbo/apps/cli/src/commands/zero/logs/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/__tests__/search.test.ts
@@ -78,6 +78,31 @@ describe("zero logs search command", () => {
     expect(logCalls).toContain("OOM killed");
   });
 
+  it("should tolerate invalid search result timestamps", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/zero/logs/search", () => {
+        return HttpResponse.json({
+          results: [
+            {
+              runId: "abc12345-1234-1234-1234-123456789abc",
+              agentName: "my-agent",
+              matchedEvent: makeEvent(3, "Build failed", "not-a-timestamp"),
+              contextBefore: [],
+              contextAfter: [],
+            },
+          ],
+          hasMore: false,
+        });
+      }),
+    );
+
+    await searchCommand.parseAsync(["node", "cli", "Build"]);
+
+    const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(logCalls).toContain("invalid-date");
+    expect(logCalls).toContain("Build failed");
+  });
+
   it("should handle no matches", async () => {
     server.use(
       http.get("http://localhost:3000/api/zero/logs/search", () => {

--- a/turbo/apps/cli/src/commands/zero/logs/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/__tests__/search.test.ts
@@ -32,6 +32,26 @@ function makeEvent(
   };
 }
 
+function makeCodexMessageEvent(
+  sequenceNumber: number,
+  text: string,
+  createdAt = "2024-01-15T10:30:00Z",
+) {
+  return {
+    sequenceNumber,
+    eventType: "item.completed",
+    createdAt,
+    eventData: {
+      type: "item.completed",
+      item: {
+        id: `item-${sequenceNumber}`,
+        type: "agent_message",
+        text,
+      },
+    },
+  };
+}
+
 describe("zero logs search command", () => {
   const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
     throw new Error("process.exit called");
@@ -101,6 +121,32 @@ describe("zero logs search command", () => {
     const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
     expect(logCalls).toContain("invalid-date");
     expect(logCalls).toContain("Build failed");
+  });
+
+  it("should render codex search result events with the result framework", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/zero/logs/search", () => {
+        return HttpResponse.json({
+          results: [
+            {
+              runId: "abc12345-1234-1234-1234-123456789abc",
+              agentName: "codex-agent",
+              framework: "codex",
+              matchedEvent: makeCodexMessageEvent(3, "Codex found the issue"),
+              contextBefore: [],
+              contextAfter: [],
+            },
+          ],
+          hasMore: false,
+        });
+      }),
+    );
+
+    await searchCommand.parseAsync(["node", "cli", "Codex"]);
+
+    const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(logCalls).toContain("codex-agent");
+    expect(logCalls).toContain("Codex found the issue");
   });
 
   it("should handle no matches", async () => {

--- a/turbo/apps/cli/src/commands/zero/logs/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/__tests__/search.test.ts
@@ -156,6 +156,24 @@ describe("zero logs search command", () => {
     expect(capturedUrl?.searchParams.get("after")).toBe("5");
   });
 
+  it("should reject partial numeric context and limit values", async () => {
+    await expect(
+      searchCommand.parseAsync(["node", "cli", "error", "-C", "2x"]),
+    ).rejects.toThrow("process.exit called");
+
+    let errorCalls = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errorCalls).toContain("--context must be between 0 and 10");
+
+    mockConsoleError.mockClear();
+
+    await expect(
+      searchCommand.parseAsync(["node", "cli", "error", "--limit", "1abc"]),
+    ).rejects.toThrow("process.exit called");
+
+    errorCalls = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errorCalls).toContain("--limit must be between 1 and 50");
+  });
+
   it("should pass agentId and run filters", async () => {
     let capturedUrl: URL | undefined;
     server.use(

--- a/turbo/apps/cli/src/commands/zero/logs/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/__tests__/search.test.ts
@@ -409,6 +409,22 @@ describe("zero logs search command", () => {
     expect(errorCalls).toContain("zero logs list");
   });
 
+  it("should reject non-UUID --agent value", async () => {
+    await expect(
+      searchCommand.parseAsync([
+        "node",
+        "cli",
+        "error",
+        "--agent",
+        "agent-123",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    const errorCalls = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errorCalls).toContain("Invalid agent ID");
+    expect(errorCalls).toContain("zero logs list");
+  });
+
   it("should reject malformed UUID-like --run value", async () => {
     await expect(
       searchCommand.parseAsync([

--- a/turbo/apps/cli/src/commands/zero/logs/__tests__/view.test.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/__tests__/view.test.ts
@@ -34,7 +34,7 @@ function countOccurrences(text: string, pattern: string): number {
   return text.split(pattern).length - 1;
 }
 
-const RUN_ID = "abc12345-1234-1234-1234-123456789abc";
+const RUN_ID = "550e8400-e29b-41d4-a716-446655440001";
 
 describe("zero logs view command", () => {
   const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {

--- a/turbo/apps/cli/src/commands/zero/logs/__tests__/view.test.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/__tests__/view.test.ts
@@ -193,6 +193,59 @@ describe("zero logs view command", () => {
     expect(logCalls).toContain("Codex zero page output");
   });
 
+  it("should not reuse a codex framework for a later unsupported framework page", async () => {
+    server.use(
+      http.get(
+        "http://localhost:3000/api/zero/runs/:id/telemetry/agent",
+        ({ request }) => {
+          const url = new URL(request.url);
+          const cursor = url.searchParams.get("cursor");
+
+          if (!cursor) {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 2,
+                  eventType: "item.completed",
+                  createdAt: "2024-01-15T10:31:00Z",
+                  eventData: {
+                    type: "item.completed",
+                    item: {
+                      id: "msg_1",
+                      type: "agent_message",
+                      text: "Codex zero page output",
+                    },
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: true,
+              nextCursor: "sequence:desc:2",
+            });
+          }
+
+          return HttpResponse.json({
+            events: [
+              makeEvent(
+                1,
+                "Future framework legacy output",
+                "2024-01-15T10:30:00Z",
+              ),
+            ],
+            framework: "future-framework",
+            hasMore: false,
+          });
+        },
+      ),
+    );
+
+    await zeroLogsCommand.parseAsync(["node", "cli", RUN_ID, "--all"]);
+
+    const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(logCalls).toContain("Future framework legacy output");
+    expect(logCalls).toContain("Codex zero page output");
+  });
+
   it("should pass --since option to API as sinceTime", async () => {
     let capturedUrl: URL | undefined;
     server.use(

--- a/turbo/apps/cli/src/commands/zero/logs/__tests__/view.test.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/__tests__/view.test.ts
@@ -383,6 +383,145 @@ describe("zero logs view command", () => {
     expect(countOccurrences(logCalls, "Codex Failed")).toBe(1);
   });
 
+  it("should render failed Codex turn.completed with readable details", async () => {
+    server.use(
+      http.get(
+        "http://localhost:3000/api/zero/runs/:id/telemetry/agent",
+        () => {
+          return HttpResponse.json({
+            events: [
+              {
+                sequenceNumber: 1,
+                eventType: "thread.started",
+                createdAt: "2024-01-15T10:29:59Z",
+                eventData: {
+                  type: "thread.started",
+                  thread_id: "thread-zero-1",
+                },
+              },
+              {
+                sequenceNumber: 2,
+                eventType: "turn.completed",
+                createdAt: "2024-01-15T10:30:00Z",
+                eventData: {
+                  type: "turn.completed",
+                  turn: {
+                    id: "turn-zero-1",
+                    status: "failed",
+                    error: {
+                      message: "usage limit exceeded",
+                      additional_details: "upgrade required",
+                    },
+                  },
+                },
+              },
+            ],
+            framework: "codex",
+            hasMore: false,
+          });
+        },
+      ),
+    );
+
+    await zeroLogsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
+
+    const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(logCalls).toContain("Codex Failed");
+    expect(logCalls).toContain("usage limit exceeded");
+    expect(logCalls).toContain("upgrade required");
+    expect(logCalls).not.toContain("[object Object]");
+  });
+
+  it("should collapse same-turn Codex error and failed turn.completed in default tail output", async () => {
+    server.use(
+      http.get(
+        "http://localhost:3000/api/zero/runs/:id/telemetry/agent",
+        () => {
+          return HttpResponse.json({
+            events: [
+              {
+                sequenceNumber: 3,
+                eventType: "turn.completed",
+                createdAt: "2024-01-15T10:30:02Z",
+                eventData: {
+                  type: "turn.completed",
+                  turn: {
+                    id: "turn-zero-1",
+                    status: "failed",
+                    error: { message: "Rate limit exceeded" },
+                  },
+                },
+              },
+              {
+                sequenceNumber: 2,
+                eventType: "error",
+                createdAt: "2024-01-15T10:30:01Z",
+                eventData: {
+                  type: "error",
+                  turn_id: "turn-zero-1",
+                  message: "API connection failed",
+                },
+              },
+              {
+                sequenceNumber: 1,
+                eventType: "thread.started",
+                createdAt: "2024-01-15T10:30:00Z",
+                eventData: {
+                  type: "thread.started",
+                  thread_id: "thread-zero-1",
+                },
+              },
+            ],
+            framework: "codex",
+            hasMore: false,
+          });
+        },
+      ),
+    );
+
+    await zeroLogsCommand.parseAsync(["node", "cli", RUN_ID]);
+
+    const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(countOccurrences(logCalls, "Codex Failed")).toBe(1);
+    expect(logCalls).toContain("API connection failed");
+    expect(logCalls).toContain("Rate limit exceeded");
+  });
+
+  it("should flush pending Codex tool use at command end", async () => {
+    server.use(
+      http.get(
+        "http://localhost:3000/api/zero/runs/:id/telemetry/agent",
+        () => {
+          return HttpResponse.json({
+            events: [
+              {
+                sequenceNumber: 1,
+                eventType: "item.started",
+                createdAt: "2024-01-15T10:30:00Z",
+                eventData: {
+                  type: "item.started",
+                  item: {
+                    id: "cmd-pending",
+                    type: "command_execution",
+                    command: "sleep 10",
+                  },
+                },
+              },
+            ],
+            framework: "codex",
+            hasMore: false,
+          });
+        },
+      ),
+    );
+
+    await zeroLogsCommand.parseAsync(["node", "cli", RUN_ID, "--head", "100"]);
+
+    const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(logCalls).toContain("Bash");
+    expect(logCalls).toContain("sleep 10");
+  });
+
   it("should handle authentication error", async () => {
     server.use(
       http.get(

--- a/turbo/apps/cli/src/commands/zero/logs/__tests__/view.test.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/__tests__/view.test.ts
@@ -281,6 +281,20 @@ describe("zero logs view command", () => {
     expect(errorCalls).toContain("zero logs list");
   });
 
+  it("should reject malformed UUID-like run ID", async () => {
+    await expect(
+      zeroLogsCommand.parseAsync([
+        "node",
+        "cli",
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    const errorCalls = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errorCalls).toContain("Invalid run ID");
+    expect(errorCalls).toContain("zero logs list");
+  });
+
   it("should render codex framework events", async () => {
     server.use(
       http.get(

--- a/turbo/apps/cli/src/commands/zero/logs/__tests__/view.test.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/__tests__/view.test.ts
@@ -268,6 +268,34 @@ describe("zero logs view command", () => {
     expect(capturedUrl?.searchParams.get("since")).toBeNull();
   });
 
+  it("should pass epoch --since values to API", async () => {
+    let capturedUrl: URL | undefined;
+    server.use(
+      http.get(
+        "http://localhost:3000/api/zero/runs/:id/telemetry/agent",
+        ({ request }) => {
+          capturedUrl = new URL(request.url);
+          return HttpResponse.json({
+            events: [],
+            framework: "claude-code",
+            hasMore: false,
+          });
+        },
+      ),
+    );
+
+    await zeroLogsCommand.parseAsync([
+      "node",
+      "cli",
+      RUN_ID,
+      "--since",
+      "1970-01-01T00:00:00Z",
+    ]);
+
+    expect(capturedUrl?.searchParams.get("sinceTime")).toBe("0");
+    expect(capturedUrl?.searchParams.get("since")).toBeNull();
+  });
+
   it("should reject invalid calendar dates for --since", async () => {
     await expect(
       zeroLogsCommand.parseAsync([

--- a/turbo/apps/cli/src/commands/zero/logs/__tests__/view.test.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/__tests__/view.test.ts
@@ -137,6 +137,62 @@ describe("zero logs view command", () => {
     expect(logCalls).toContain("Page 2");
   });
 
+  it("should preserve per-page framework when a later page omits it", async () => {
+    server.use(
+      http.get(
+        "http://localhost:3000/api/zero/runs/:id/telemetry/agent",
+        ({ request }) => {
+          const url = new URL(request.url);
+          const cursor = url.searchParams.get("cursor");
+
+          if (!cursor) {
+            return HttpResponse.json({
+              events: [
+                {
+                  sequenceNumber: 2,
+                  eventType: "item.completed",
+                  createdAt: "2024-01-15T10:31:00Z",
+                  eventData: {
+                    type: "item.completed",
+                    item: {
+                      id: "msg_1",
+                      type: "agent_message",
+                      text: "Codex zero page output",
+                    },
+                  },
+                },
+              ],
+              framework: "codex",
+              hasMore: true,
+              nextCursor: "sequence:desc:2",
+            });
+          }
+
+          return HttpResponse.json({
+            events: [
+              {
+                sequenceNumber: 1,
+                eventType: "thread.started",
+                createdAt: "2024-01-15T10:30:00Z",
+                eventData: {
+                  type: "thread.started",
+                  thread_id: "thread-zero-page-1",
+                },
+              },
+            ],
+            hasMore: false,
+          });
+        },
+      ),
+    );
+
+    await zeroLogsCommand.parseAsync(["node", "cli", RUN_ID, "--all"]);
+
+    const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(logCalls).toContain("Codex Started");
+    expect(logCalls).toContain("Codex zero page output");
+  });
+
   it("should pass --since option to API as sinceTime", async () => {
     let capturedUrl: URL | undefined;
     server.use(

--- a/turbo/apps/cli/src/commands/zero/logs/index.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/index.ts
@@ -168,7 +168,7 @@ Examples:
         }
 
         let since: number | undefined;
-        if (options.since) {
+        if (options.since !== undefined) {
           since = parseTime(options.since);
         }
 

--- a/turbo/apps/cli/src/commands/zero/logs/index.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/index.ts
@@ -19,12 +19,17 @@ const PAGE_LIMIT = 100;
 interface AgentEventWithFramework {
   readonly event: RunEvent;
   readonly framework?: string;
+  readonly useDefaultFramework: boolean;
 }
 
 function supportedLogFramework(
   framework: string | undefined,
 ): string | undefined {
   return isSupportedFramework(framework) ? framework : undefined;
+}
+
+function hasLogFramework(framework: string | null | undefined): boolean {
+  return framework !== undefined && framework !== null;
 }
 
 function renderAgentEvent(
@@ -54,10 +59,17 @@ async function showAgentEvents(
   const events = await collectLogItems<AgentEventWithFramework>({
     fetchPage: async (request) => {
       const response = await getZeroRunAgentEvents(runId, request);
+      const responseFramework: string | null | undefined = response.framework;
       return {
         items: response.events.map((event) => {
-          const framework = supportedLogFramework(response.framework);
-          return framework ? { event, framework } : { event };
+          const framework = supportedLogFramework(
+            responseFramework ?? undefined,
+          );
+          return {
+            event,
+            ...(framework ? { framework } : {}),
+            useDefaultFramework: !hasLogFramework(responseFramework),
+          };
         }),
         hasMore: response.hasMore,
         nextCursor: response.nextCursor,
@@ -88,7 +100,7 @@ async function showAgentEvents(
       item.event,
       renderer,
       normalizer,
-      item.framework ?? framework,
+      item.framework ?? (item.useDefaultFramework ? framework : undefined),
     );
   }
   for (const parsed of normalizer.flush()) {

--- a/turbo/apps/cli/src/commands/zero/logs/index.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/index.ts
@@ -73,6 +73,7 @@ async function showAgentEvents(
   for (const parsed of normalizer.flush()) {
     renderer.render(parsed);
   }
+  renderer.flush();
 }
 
 export const zeroLogsCommand = new Command()

--- a/turbo/apps/cli/src/commands/zero/logs/index.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/index.ts
@@ -12,14 +12,26 @@ import { withErrorHandler } from "../../../lib/command";
 import { isUUID } from "../../run/shared";
 import { listCommand } from "./list";
 import { searchCommand } from "./search";
+import { isSupportedFramework } from "@vm0/core/frameworks";
 
 const PAGE_LIMIT = 100;
+
+interface AgentEventWithFramework {
+  readonly event: RunEvent;
+  readonly framework?: string;
+}
+
+function supportedLogFramework(
+  framework: string | undefined,
+): string | undefined {
+  return isSupportedFramework(framework) ? framework : undefined;
+}
 
 function renderAgentEvent(
   event: RunEvent,
   renderer: EventRenderer,
   normalizer: EventStreamNormalizer,
-  framework: string,
+  framework: string | undefined,
 ): void {
   const parsedEvents = normalizer.process(
     event.eventData,
@@ -39,13 +51,14 @@ async function showAgentEvents(
     order: "asc" | "desc";
   },
 ): Promise<void> {
-  let framework = "claude-code";
-  const events = await collectLogItems<RunEvent>({
+  const events = await collectLogItems<AgentEventWithFramework>({
     fetchPage: async (request) => {
       const response = await getZeroRunAgentEvents(runId, request);
-      framework = response.framework;
       return {
-        items: response.events,
+        items: response.events.map((event) => {
+          const framework = supportedLogFramework(response.framework);
+          return framework ? { event, framework } : { event };
+        }),
         hasMore: response.hasMore,
         nextCursor: response.nextCursor,
       };
@@ -65,10 +78,18 @@ async function showAgentEvents(
     showTimestamp: true,
     verbose: true,
   });
+  const framework = events.find((item) => {
+    return item.framework !== undefined;
+  })?.framework;
   const normalizer = new EventStreamNormalizer();
 
-  for (const event of events) {
-    renderAgentEvent(event, renderer, normalizer, framework);
+  for (const item of events) {
+    renderAgentEvent(
+      item.event,
+      renderer,
+      normalizer,
+      item.framework ?? framework,
+    );
   }
   for (const parsed of normalizer.flush()) {
     renderer.render(parsed);

--- a/turbo/apps/cli/src/commands/zero/logs/list.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/list.ts
@@ -3,6 +3,7 @@ import chalk from "chalk";
 import { listZeroLogs } from "../../../lib/api";
 import { parseTime } from "../../../lib/utils/time-parser";
 import { formatIsoTimestamp } from "../../../lib/utils/time-format";
+import { parsePositiveLogCount } from "../../../lib/utils/log-pagination";
 import { withErrorHandler } from "../../../lib/command";
 
 function formatStatus(status: string): string {
@@ -59,7 +60,9 @@ Examples:
         since?: string;
         limit?: string;
       }) => {
-        const limit = options.limit ? parseInt(options.limit, 10) : undefined;
+        const limit = options.limit
+          ? parsePositiveLogCount(options.limit, "--limit")
+          : undefined;
         const since = options.since ? parseTime(options.since) : undefined;
 
         const result = await listZeroLogs({

--- a/turbo/apps/cli/src/commands/zero/logs/list.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/list.ts
@@ -61,12 +61,13 @@ Examples:
         since?: string;
         limit?: string;
       }) => {
-        const limit = options.limit
-          ? parseBoundedLogCount(options.limit, "--limit", 1, 100)
-          : undefined;
+        const limit =
+          options.limit !== undefined
+            ? parseBoundedLogCount(options.limit, "--limit", 1, 100)
+            : undefined;
         const since =
           options.since !== undefined ? parseTime(options.since) : undefined;
-        if (options.agent && !isUUID(options.agent)) {
+        if (options.agent !== undefined && !isUUID(options.agent)) {
           console.error(
             chalk.red(
               `✗ Invalid agent ID "${options.agent}" — expected a UUID`,

--- a/turbo/apps/cli/src/commands/zero/logs/list.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/list.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { listZeroLogs } from "../../../lib/api";
 import { parseTime } from "../../../lib/utils/time-parser";
+import { formatIsoTimestamp } from "../../../lib/utils/time-format";
 import { withErrorHandler } from "../../../lib/command";
 
 function formatStatus(status: string): string {
@@ -23,7 +24,7 @@ function formatStatus(status: string): string {
 }
 
 function formatTime(iso: string): string {
-  return new Date(iso).toISOString().replace(/\.\d{3}Z$/, "Z");
+  return formatIsoTimestamp(iso);
 }
 
 export const listCommand = new Command()

--- a/turbo/apps/cli/src/commands/zero/logs/list.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/list.ts
@@ -64,7 +64,8 @@ Examples:
         const limit = options.limit
           ? parseBoundedLogCount(options.limit, "--limit", 1, 100)
           : undefined;
-        const since = options.since ? parseTime(options.since) : undefined;
+        const since =
+          options.since !== undefined ? parseTime(options.since) : undefined;
         if (options.agent && !isUUID(options.agent)) {
           console.error(
             chalk.red(

--- a/turbo/apps/cli/src/commands/zero/logs/list.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/list.ts
@@ -5,6 +5,7 @@ import { parseTime } from "../../../lib/utils/time-parser";
 import { formatIsoTimestamp } from "../../../lib/utils/time-format";
 import { parseBoundedLogCount } from "../../../lib/utils/log-pagination";
 import { withErrorHandler } from "../../../lib/command";
+import { isUUID } from "../../run/shared";
 
 function formatStatus(status: string): string {
   switch (status) {
@@ -64,6 +65,17 @@ Examples:
           ? parseBoundedLogCount(options.limit, "--limit", 1, 100)
           : undefined;
         const since = options.since ? parseTime(options.since) : undefined;
+        if (options.agent && !isUUID(options.agent)) {
+          console.error(
+            chalk.red(
+              `✗ Invalid agent ID "${options.agent}" — expected a UUID`,
+            ),
+          );
+          console.error(
+            chalk.dim("  Run: zero logs list    to find agent IDs"),
+          );
+          process.exit(1);
+        }
 
         const result = await listZeroLogs({
           agentId: options.agent,

--- a/turbo/apps/cli/src/commands/zero/logs/list.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/list.ts
@@ -3,7 +3,7 @@ import chalk from "chalk";
 import { listZeroLogs } from "../../../lib/api";
 import { parseTime } from "../../../lib/utils/time-parser";
 import { formatIsoTimestamp } from "../../../lib/utils/time-format";
-import { parsePositiveLogCount } from "../../../lib/utils/log-pagination";
+import { parseBoundedLogCount } from "../../../lib/utils/log-pagination";
 import { withErrorHandler } from "../../../lib/command";
 
 function formatStatus(status: string): string {
@@ -61,7 +61,7 @@ Examples:
         limit?: string;
       }) => {
         const limit = options.limit
-          ? parsePositiveLogCount(options.limit, "--limit")
+          ? parseBoundedLogCount(options.limit, "--limit", 1, 100)
           : undefined;
         const since = options.since ? parseTime(options.since) : undefined;
 

--- a/turbo/apps/cli/src/commands/zero/logs/search.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/search.ts
@@ -32,9 +32,13 @@ interface LogsSearchCommandOptions extends Omit<
   agent?: string;
 }
 
-function renderEvent(event: RunEvent, renderer: EventRenderer): void {
+function renderSearchEvent(
+  event: RunEvent,
+  framework: string | null | undefined,
+  renderer: EventRenderer,
+): void {
   const eventData = event.eventData as Record<string, unknown>;
-  const parsed = parseEvent(eventData);
+  const parsed = parseEvent(eventData, framework ?? undefined);
   if (parsed) {
     parsed.timestamp = new Date(event.createdAt);
     renderer.render(parsed);
@@ -109,11 +113,11 @@ function renderResults(response: LogsSearchResponse): void {
       });
 
       for (const event of result.contextBefore) {
-        renderEvent(event, renderer);
+        renderSearchEvent(event, result.framework, renderer);
       }
-      renderEvent(result.matchedEvent, renderer);
+      renderSearchEvent(result.matchedEvent, result.framework, renderer);
       for (const event of result.contextAfter) {
-        renderEvent(event, renderer);
+        renderSearchEvent(event, result.framework, renderer);
       }
     }
   }

--- a/turbo/apps/cli/src/commands/zero/logs/search.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/search.ts
@@ -165,6 +165,14 @@ export async function runLogsSearch(
 ): Promise<void> {
   const { before, after } = parseContextOptions(options);
 
+  if (options.agentId && !isUUID(options.agentId)) {
+    console.error(
+      chalk.red(`✗ Invalid agent ID "${options.agentId}" — expected a UUID`),
+    );
+    console.error(chalk.dim("  Run: zero logs list    to find agent IDs"));
+    process.exit(1);
+  }
+
   if (options.run && !isUUID(options.run)) {
     console.error(
       chalk.red(`✗ Invalid run ID "${options.run}" — expected a UUID`),

--- a/turbo/apps/cli/src/commands/zero/logs/search.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/search.ts
@@ -12,6 +12,7 @@ import { EventStreamNormalizer } from "../../../lib/events/event-stream-normaliz
 import { withErrorHandler } from "../../../lib/command";
 import { isUUID } from "../../run/shared";
 import { parseBoundedLogCount } from "../../../lib/utils/log-pagination";
+import { parseSearchQuery } from "../../../lib/utils/search-query";
 import { isSupportedFramework } from "@vm0/core/frameworks";
 
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
@@ -166,6 +167,7 @@ export async function runLogsSearch(
   keyword: string,
   options: LogsSearchCliOptions,
 ): Promise<void> {
+  const searchKeyword = parseSearchQuery(keyword, "Keyword");
   const { before, after } = parseContextOptions(options);
 
   if (options.agentId !== undefined && !isUUID(options.agentId)) {
@@ -191,7 +193,7 @@ export async function runLogsSearch(
   const limit = parseLimit(options.limit);
 
   const response = await searchZeroLogs({
-    keyword,
+    keyword: searchKeyword,
     agentId: options.agentId,
     runId: options.run,
     since,

--- a/turbo/apps/cli/src/commands/zero/logs/search.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/search.ts
@@ -7,8 +7,8 @@ import {
 } from "../../../lib/api";
 import { parseTime } from "../../../lib/utils/time-parser";
 import { formatIsoTimestamp } from "../../../lib/utils/time-format";
-import { parseEvent } from "../../../lib/events/event-parser-factory";
 import { EventRenderer } from "../../../lib/events/event-renderer";
+import { EventStreamNormalizer } from "../../../lib/events/event-stream-normalizer";
 import { withErrorHandler } from "../../../lib/command";
 import { isUUID } from "../../run/shared";
 import { parseBoundedLogCount } from "../../../lib/utils/log-pagination";
@@ -36,13 +36,26 @@ function renderSearchEvent(
   event: RunEvent,
   framework: string | null | undefined,
   renderer: EventRenderer,
+  normalizer: EventStreamNormalizer,
 ): void {
-  const eventData = event.eventData as Record<string, unknown>;
-  const parsed = parseEvent(eventData, framework ?? undefined);
-  if (parsed) {
-    parsed.timestamp = new Date(event.createdAt);
+  const parsedEvents = normalizer.process(
+    event.eventData,
+    framework ?? undefined,
+    new Date(event.createdAt),
+  );
+  for (const parsed of parsedEvents) {
     renderer.render(parsed);
   }
+}
+
+function flushSearchRenderer(
+  renderer: EventRenderer,
+  normalizer: EventStreamNormalizer,
+): void {
+  for (const parsed of normalizer.flush()) {
+    renderer.render(parsed);
+  }
+  renderer.flush();
 }
 
 function formatRunHeader(
@@ -109,16 +122,22 @@ function renderResults(response: LogsSearchResponse): void {
       const renderer = new EventRenderer({
         showTimestamp: true,
         verbose: false,
-        buffered: false,
       });
+      const normalizer = new EventStreamNormalizer();
 
       for (const event of result.contextBefore) {
-        renderSearchEvent(event, result.framework, renderer);
+        renderSearchEvent(event, result.framework, renderer, normalizer);
       }
-      renderSearchEvent(result.matchedEvent, result.framework, renderer);
+      renderSearchEvent(
+        result.matchedEvent,
+        result.framework,
+        renderer,
+        normalizer,
+      );
       for (const event of result.contextAfter) {
-        renderSearchEvent(event, result.framework, renderer);
+        renderSearchEvent(event, result.framework, renderer, normalizer);
       }
+      flushSearchRenderer(renderer, normalizer);
     }
   }
 

--- a/turbo/apps/cli/src/commands/zero/logs/search.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/search.ts
@@ -79,21 +79,24 @@ function parseContextOptions(options: LogsSearchCliOptions): {
   before: number;
   after: number;
 } {
-  const contextN = options.context
-    ? parseBoundedLogCount(options.context, "--context", 0, 10)
-    : 0;
-  const before = options.beforeContext
-    ? parseBoundedLogCount(options.beforeContext, "--before-context", 0, 10)
-    : contextN;
-  const after = options.afterContext
-    ? parseBoundedLogCount(options.afterContext, "--after-context", 0, 10)
-    : contextN;
+  const contextN =
+    options.context !== undefined
+      ? parseBoundedLogCount(options.context, "--context", 0, 10)
+      : 0;
+  const before =
+    options.beforeContext !== undefined
+      ? parseBoundedLogCount(options.beforeContext, "--before-context", 0, 10)
+      : contextN;
+  const after =
+    options.afterContext !== undefined
+      ? parseBoundedLogCount(options.afterContext, "--after-context", 0, 10)
+      : contextN;
 
   return { before, after };
 }
 
 function parseLimit(value: string | undefined): number | undefined {
-  if (!value) return undefined;
+  if (value === undefined) return undefined;
   return parseBoundedLogCount(value, "--limit", 1, 50);
 }
 
@@ -165,7 +168,7 @@ export async function runLogsSearch(
 ): Promise<void> {
   const { before, after } = parseContextOptions(options);
 
-  if (options.agentId && !isUUID(options.agentId)) {
+  if (options.agentId !== undefined && !isUUID(options.agentId)) {
     console.error(
       chalk.red(`✗ Invalid agent ID "${options.agentId}" — expected a UUID`),
     );
@@ -173,7 +176,7 @@ export async function runLogsSearch(
     process.exit(1);
   }
 
-  if (options.run && !isUUID(options.run)) {
+  if (options.run !== undefined && !isUUID(options.run)) {
     console.error(
       chalk.red(`✗ Invalid run ID "${options.run}" — expected a UUID`),
     );

--- a/turbo/apps/cli/src/commands/zero/logs/search.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/search.ts
@@ -181,9 +181,10 @@ export async function runLogsSearch(
     process.exit(1);
   }
 
-  const since = options.since
-    ? parseTime(options.since)
-    : Date.now() - SEVEN_DAYS_MS;
+  const since =
+    options.since !== undefined
+      ? parseTime(options.since)
+      : Date.now() - SEVEN_DAYS_MS;
   const limit = parseLimit(options.limit);
 
   const response = await searchZeroLogs({

--- a/turbo/apps/cli/src/commands/zero/logs/search.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/search.ts
@@ -12,6 +12,7 @@ import { EventStreamNormalizer } from "../../../lib/events/event-stream-normaliz
 import { withErrorHandler } from "../../../lib/command";
 import { isUUID } from "../../run/shared";
 import { parseBoundedLogCount } from "../../../lib/utils/log-pagination";
+import { isSupportedFramework } from "@vm0/core/frameworks";
 
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
 
@@ -32,6 +33,13 @@ interface LogsSearchCommandOptions extends Omit<
   agent?: string;
 }
 
+function supportedSearchFramework(
+  framework: string | null | undefined,
+): string | undefined {
+  const normalized = framework ?? undefined;
+  return isSupportedFramework(normalized) ? normalized : undefined;
+}
+
 function renderSearchEvent(
   event: RunEvent,
   framework: string | null | undefined,
@@ -40,7 +48,7 @@ function renderSearchEvent(
 ): void {
   const parsedEvents = normalizer.process(
     event.eventData,
-    framework ?? undefined,
+    supportedSearchFramework(framework),
     new Date(event.createdAt),
   );
   for (const parsed of parsedEvents) {

--- a/turbo/apps/cli/src/commands/zero/logs/search.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/search.ts
@@ -11,6 +11,7 @@ import { parseEvent } from "../../../lib/events/event-parser-factory";
 import { EventRenderer } from "../../../lib/events/event-renderer";
 import { withErrorHandler } from "../../../lib/command";
 import { isUUID } from "../../run/shared";
+import { parseBoundedLogCount } from "../../../lib/utils/log-pagination";
 
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
 
@@ -53,31 +54,22 @@ function parseContextOptions(options: LogsSearchCliOptions): {
   before: number;
   after: number;
 } {
-  const contextN = options.context ? parseInt(options.context, 10) : 0;
+  const contextN = options.context
+    ? parseBoundedLogCount(options.context, "--context", 0, 10)
+    : 0;
   const before = options.beforeContext
-    ? parseInt(options.beforeContext, 10)
+    ? parseBoundedLogCount(options.beforeContext, "--before-context", 0, 10)
     : contextN;
   const after = options.afterContext
-    ? parseInt(options.afterContext, 10)
+    ? parseBoundedLogCount(options.afterContext, "--after-context", 0, 10)
     : contextN;
-
-  if (isNaN(before) || before < 0 || before > 10) {
-    throw new Error("--before-context must be between 0 and 10");
-  }
-  if (isNaN(after) || after < 0 || after > 10) {
-    throw new Error("--after-context must be between 0 and 10");
-  }
 
   return { before, after };
 }
 
 function parseLimit(value: string | undefined): number | undefined {
   if (!value) return undefined;
-  const limit = parseInt(value, 10);
-  if (isNaN(limit) || limit < 1 || limit > 50) {
-    throw new Error("--limit must be between 1 and 50");
-  }
-  return limit;
+  return parseBoundedLogCount(value, "--limit", 1, 50);
 }
 
 function renderResults(response: LogsSearchResponse): void {

--- a/turbo/apps/cli/src/commands/zero/logs/search.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/search.ts
@@ -6,6 +6,7 @@ import {
   type LogsSearchResponse,
 } from "../../../lib/api";
 import { parseTime } from "../../../lib/utils/time-parser";
+import { formatIsoTimestamp } from "../../../lib/utils/time-format";
 import { parseEvent } from "../../../lib/events/event-parser-factory";
 import { EventRenderer } from "../../../lib/events/event-renderer";
 import { withErrorHandler } from "../../../lib/command";
@@ -44,7 +45,7 @@ function formatRunHeader(
   agentName: string,
   timestamp: string,
 ): string {
-  const time = new Date(timestamp).toISOString().replace(/\.\d{3}Z$/, "Z");
+  const time = formatIsoTimestamp(timestamp);
   return `── Run ${runId} (${agentName}, ${time}) ──────────`;
 }
 

--- a/turbo/apps/cli/src/commands/zero/search/__tests__/chat-source.test.ts
+++ b/turbo/apps/cli/src/commands/zero/search/__tests__/chat-source.test.ts
@@ -53,6 +53,15 @@ describe("zero search --source chat", () => {
     vi.unstubAllEnvs();
   });
 
+  it("rejects whitespace-only queries", async () => {
+    await expect(
+      zeroSearchCommand.parseAsync(["node", "cli", "   ", "--source", "chat"]),
+    ).rejects.toThrow("process.exit called");
+
+    const errors = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errors).toContain("Query cannot be empty");
+  });
+
   it("renders chat search results grouped by thread", async () => {
     server.use(
       http.get("http://localhost:3000/api/zero/chat/search", () => {

--- a/turbo/apps/cli/src/commands/zero/search/__tests__/chat-source.test.ts
+++ b/turbo/apps/cli/src/commands/zero/search/__tests__/chat-source.test.ts
@@ -239,7 +239,7 @@ describe("zero search --source chat", () => {
         "--source",
         "chat",
         "--run",
-        "abc12345-1234-1234-1234-123456789abc",
+        "550e8400-e29b-41d4-a716-446655440001",
       ]),
     ).rejects.toThrow("process.exit called");
 

--- a/turbo/apps/cli/src/commands/zero/search/__tests__/chat-source.test.ts
+++ b/turbo/apps/cli/src/commands/zero/search/__tests__/chat-source.test.ts
@@ -213,6 +213,23 @@ describe("zero search --source chat", () => {
     expect(capturedUrl?.searchParams.get("agentId")).toBe(agentId);
   });
 
+  it("rejects non-UUID --agent values", async () => {
+    await expect(
+      zeroSearchCommand.parseAsync([
+        "node",
+        "cli",
+        "hello",
+        "--source",
+        "chat",
+        "--agent",
+        "agent-123",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    const errors = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errors).toContain("Invalid agent ID");
+  });
+
   it("rejects --run flag for chat source with clear error", async () => {
     await expect(
       zeroSearchCommand.parseAsync([

--- a/turbo/apps/cli/src/commands/zero/search/__tests__/chat-source.test.ts
+++ b/turbo/apps/cli/src/commands/zero/search/__tests__/chat-source.test.ts
@@ -87,6 +87,40 @@ describe("zero search --source chat", () => {
     expect(logs).toContain("OOM killed the build");
   });
 
+  it("tolerates invalid chat message timestamps", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/zero/chat/search", () => {
+        return HttpResponse.json({
+          results: [
+            {
+              chatThreadId: "thread-abc",
+              agentName: "my-agent",
+              matchedMessage: makeMessage({
+                content: "OOM killed the build",
+                createdAt: "not-a-timestamp",
+              }),
+              contextBefore: [],
+              contextAfter: [],
+            },
+          ],
+          hasMore: false,
+        });
+      }),
+    );
+
+    await zeroSearchCommand.parseAsync([
+      "node",
+      "cli",
+      "OOM",
+      "--source",
+      "chat",
+    ]);
+
+    const logs = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(logs).toContain("invalid-date");
+    expect(logs).toContain("OOM killed the build");
+  });
+
   it("handles no matches", async () => {
     server.use(
       http.get("http://localhost:3000/api/zero/chat/search", () => {

--- a/turbo/apps/cli/src/commands/zero/search/__tests__/chat-source.test.ts
+++ b/turbo/apps/cli/src/commands/zero/search/__tests__/chat-source.test.ts
@@ -248,7 +248,25 @@ describe("zero search --source chat", () => {
       ]),
     ).rejects.toThrow("process.exit called");
 
-    const errors = mockConsoleError.mock.calls.flat().join("\n");
+    let errors = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errors).toContain("Invalid agent ID");
+
+    mockConsoleError.mockClear();
+    zeroSearchCommand.setOptionValue("source", []);
+
+    await expect(
+      zeroSearchCommand.parseAsync([
+        "node",
+        "cli",
+        "hello",
+        "--source",
+        "chat",
+        "--agent",
+        "",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    errors = mockConsoleError.mock.calls.flat().join("\n");
     expect(errors).toContain("Invalid agent ID");
   });
 
@@ -265,7 +283,25 @@ describe("zero search --source chat", () => {
       ]),
     ).rejects.toThrow("process.exit called");
 
-    const errors = mockConsoleError.mock.calls.flat().join("\n");
+    let errors = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errors).toContain("--run is not supported with --source chat");
+
+    mockConsoleError.mockClear();
+    zeroSearchCommand.setOptionValue("source", []);
+
+    await expect(
+      zeroSearchCommand.parseAsync([
+        "node",
+        "cli",
+        "hello",
+        "--source",
+        "chat",
+        "--run",
+        "",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    errors = mockConsoleError.mock.calls.flat().join("\n");
     expect(errors).toContain("--run is not supported with --source chat");
   });
 
@@ -331,6 +367,42 @@ describe("zero search --source chat", () => {
         "chat",
         "--limit",
         "1abc",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    errors = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errors).toContain("--limit must be between 1 and 50");
+
+    mockConsoleError.mockClear();
+    zeroSearchCommand.setOptionValue("source", []);
+
+    await expect(
+      zeroSearchCommand.parseAsync([
+        "node",
+        "cli",
+        "hello",
+        "--source",
+        "chat",
+        "-C",
+        "",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    errors = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errors).toContain("--context must be between 0 and 10");
+
+    mockConsoleError.mockClear();
+    zeroSearchCommand.setOptionValue("source", []);
+
+    await expect(
+      zeroSearchCommand.parseAsync([
+        "node",
+        "cli",
+        "hello",
+        "--source",
+        "chat",
+        "--limit",
+        "",
       ]),
     ).rejects.toThrow("process.exit called");
 

--- a/turbo/apps/cli/src/commands/zero/search/__tests__/chat-source.test.ts
+++ b/turbo/apps/cli/src/commands/zero/search/__tests__/chat-source.test.ts
@@ -264,6 +264,41 @@ describe("zero search --source chat", () => {
     expect(errors).toContain("--before-context must be between 0 and 10");
   });
 
+  it("rejects partial numeric context and limit values", async () => {
+    await expect(
+      zeroSearchCommand.parseAsync([
+        "node",
+        "cli",
+        "hello",
+        "--source",
+        "chat",
+        "-C",
+        "2x",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    let errors = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errors).toContain("--context must be between 0 and 10");
+
+    mockConsoleError.mockClear();
+    zeroSearchCommand.setOptionValue("source", []);
+
+    await expect(
+      zeroSearchCommand.parseAsync([
+        "node",
+        "cli",
+        "hello",
+        "--source",
+        "chat",
+        "--limit",
+        "1abc",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    errors = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errors).toContain("--limit must be between 1 and 50");
+  });
+
   it("shows the hasMore hint when the API reports more results", async () => {
     server.use(
       http.get("http://localhost:3000/api/zero/chat/search", () => {

--- a/turbo/apps/cli/src/commands/zero/search/__tests__/chat-source.test.ts
+++ b/turbo/apps/cli/src/commands/zero/search/__tests__/chat-source.test.ts
@@ -165,6 +165,28 @@ describe("zero search --source chat", () => {
     expect(capturedUrl?.searchParams.get("after")).toBe("3");
   });
 
+  it("passes epoch --since to API instead of the default search window", async () => {
+    let capturedUrl: URL | undefined;
+    server.use(
+      http.get("http://localhost:3000/api/zero/chat/search", ({ request }) => {
+        capturedUrl = new URL(request.url);
+        return HttpResponse.json({ results: [], hasMore: false });
+      }),
+    );
+
+    await zeroSearchCommand.parseAsync([
+      "node",
+      "cli",
+      "error",
+      "--source",
+      "chat",
+      "--since",
+      "1970-01-01T00:00:00Z",
+    ]);
+
+    expect(capturedUrl?.searchParams.get("since")).toBe("0");
+  });
+
   it("passes -A and -B independently", async () => {
     let capturedUrl: URL | undefined;
     server.use(

--- a/turbo/apps/cli/src/commands/zero/search/__tests__/logs-source.test.ts
+++ b/turbo/apps/cli/src/commands/zero/search/__tests__/logs-source.test.ts
@@ -18,7 +18,7 @@ function stubResponse() {
   return HttpResponse.json({
     results: [
       {
-        runId: "abc12345-1234-1234-1234-123456789abc",
+        runId: "550e8400-e29b-41d4-a716-446655440001",
         agentName: "my-agent",
         matchedEvent: {
           sequenceNumber: 3,
@@ -134,7 +134,7 @@ describe("zero search --source logs parity with zero logs search", () => {
       "--agent",
       AGENT_ID,
       "--run",
-      "abc12345-1234-1234-1234-123456789abc",
+      "550e8400-e29b-41d4-a716-446655440001",
       "--since",
       "3d",
       "--limit",
@@ -150,7 +150,7 @@ describe("zero search --source logs parity with zero logs search", () => {
     expect(url.searchParams.get("keyword")).toBe("error");
     expect(url.searchParams.get("agentId")).toBe(AGENT_ID);
     expect(url.searchParams.get("runId")).toBe(
-      "abc12345-1234-1234-1234-123456789abc",
+      "550e8400-e29b-41d4-a716-446655440001",
     );
     expect(url.searchParams.get("limit")).toBe("10");
     expect(url.searchParams.get("before")).toBe("1");

--- a/turbo/apps/cli/src/commands/zero/search/__tests__/logs-source.test.ts
+++ b/turbo/apps/cli/src/commands/zero/search/__tests__/logs-source.test.ts
@@ -79,6 +79,15 @@ describe("zero search --source logs parity with zero logs search", () => {
     vi.unstubAllEnvs();
   });
 
+  it("rejects whitespace-only queries", async () => {
+    await expect(
+      zeroSearchCommand.parseAsync(["node", "cli", "   ", "--source", "logs"]),
+    ).rejects.toThrow("process.exit called");
+
+    const errors = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errors).toContain("Query cannot be empty");
+  });
+
   it("produces identical output for the same query and flags", async () => {
     server.use(
       http.get("http://localhost:3000/api/zero/logs/search", stubResponse),

--- a/turbo/apps/cli/src/commands/zero/search/__tests__/logs-source.test.ts
+++ b/turbo/apps/cli/src/commands/zero/search/__tests__/logs-source.test.ts
@@ -136,7 +136,7 @@ describe("zero search --source logs parity with zero logs search", () => {
       "--run",
       "550e8400-e29b-41d4-a716-446655440001",
       "--since",
-      "3d",
+      "1970-01-01T00:00:00Z",
       "--limit",
       "10",
       "-A",
@@ -155,6 +155,7 @@ describe("zero search --source logs parity with zero logs search", () => {
     expect(url.searchParams.get("limit")).toBe("10");
     expect(url.searchParams.get("before")).toBe("1");
     expect(url.searchParams.get("after")).toBe("2");
+    expect(url.searchParams.get("since")).toBe("0");
   });
 
   it("rejects non-UUID --agent values", async () => {

--- a/turbo/apps/cli/src/commands/zero/search/__tests__/logs-source.test.ts
+++ b/turbo/apps/cli/src/commands/zero/search/__tests__/logs-source.test.ts
@@ -58,14 +58,25 @@ async function capture(
 }
 
 describe("zero search --source logs parity with zero logs search", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
   beforeEach(() => {
+    mockExit.mockClear();
+    mockConsoleError.mockClear();
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");
     zeroSearchCommand.setOptionValue("source", []);
   });
 
   afterEach(() => {
-    vi.restoreAllMocks();
+    mockExit.mockClear();
+    mockConsoleError.mockClear();
+    vi.unstubAllEnvs();
   });
 
   it("produces identical output for the same query and flags", async () => {
@@ -144,5 +155,22 @@ describe("zero search --source logs parity with zero logs search", () => {
     expect(url.searchParams.get("limit")).toBe("10");
     expect(url.searchParams.get("before")).toBe("1");
     expect(url.searchParams.get("after")).toBe("2");
+  });
+
+  it("rejects non-UUID --agent values", async () => {
+    await expect(
+      zeroSearchCommand.parseAsync([
+        "node",
+        "cli",
+        "error",
+        "--source",
+        "logs",
+        "--agent",
+        "agent-123",
+      ]),
+    ).rejects.toThrow("process.exit called");
+
+    const errors = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errors).toContain("Invalid agent ID");
   });
 });

--- a/turbo/apps/cli/src/commands/zero/search/__tests__/slack-source.test.ts
+++ b/turbo/apps/cli/src/commands/zero/search/__tests__/slack-source.test.ts
@@ -33,6 +33,21 @@ describe("zero search --source slack", () => {
   });
 
   describe("zero outbound HTTP", () => {
+    it("rejects whitespace-only queries", async () => {
+      await expect(
+        zeroSearchCommand.parseAsync([
+          "node",
+          "cli",
+          "   ",
+          "--source",
+          "slack",
+        ]),
+      ).rejects.toThrow("process.exit called");
+
+      const errors = mockConsoleError.mock.calls.flat().join("\n");
+      expect(errors).toContain("Query cannot be empty");
+    });
+
     it("makes no network call (MSW would error on any unhandled request)", async () => {
       await zeroSearchCommand.parseAsync([
         "node",

--- a/turbo/apps/cli/src/commands/zero/search/index.ts
+++ b/turbo/apps/cli/src/commands/zero/search/index.ts
@@ -158,9 +158,10 @@ async function runChatSource(
 
   const { before, after } = parseContextOptions(options);
   const limit = parseLimit(options.limit);
-  const since = options.since
-    ? parseTime(options.since)
-    : Date.now() - SEVEN_DAYS_MS;
+  const since =
+    options.since !== undefined
+      ? parseTime(options.since)
+      : Date.now() - SEVEN_DAYS_MS;
 
   const response = await searchZeroChat({
     keyword: query,

--- a/turbo/apps/cli/src/commands/zero/search/index.ts
+++ b/turbo/apps/cli/src/commands/zero/search/index.ts
@@ -8,6 +8,7 @@ import type {
   ChatSearchResponse,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import { parseTime } from "../../../lib/utils/time-parser";
+import { formatIsoTimestamp } from "../../../lib/utils/time-format";
 
 const SUPPORTED_SOURCES = ["logs", "chat", "slack"] as const;
 type Source = (typeof SUPPORTED_SOURCES)[number];
@@ -107,7 +108,7 @@ async function runLogsSource(
 }
 
 function formatTimestamp(iso: string): string {
-  return new Date(iso).toISOString().replace(/\.\d{3}Z$/, "Z");
+  return formatIsoTimestamp(iso);
 }
 
 function renderChatMessage(msg: ChatSearchMessage, isMatch: boolean): void {

--- a/turbo/apps/cli/src/commands/zero/search/index.ts
+++ b/turbo/apps/cli/src/commands/zero/search/index.ts
@@ -10,6 +10,7 @@ import type {
 import { parseTime } from "../../../lib/utils/time-parser";
 import { formatIsoTimestamp } from "../../../lib/utils/time-format";
 import { parseBoundedLogCount } from "../../../lib/utils/log-pagination";
+import { isUUID } from "../../run/shared";
 
 const SUPPORTED_SOURCES = ["logs", "chat", "slack"] as const;
 type Source = (typeof SUPPORTED_SOURCES)[number];
@@ -146,6 +147,13 @@ async function runChatSource(
 ): Promise<void> {
   if (options.run) {
     throw new Error("--run is not supported with --source chat");
+  }
+  if (options.agent && !isUUID(options.agent)) {
+    console.error(
+      chalk.red(`✗ Invalid agent ID "${options.agent}" — expected a UUID`),
+    );
+    console.error(chalk.dim("  Run: zero logs list    to find agent IDs"));
+    process.exit(1);
   }
 
   const { before, after } = parseContextOptions(options);

--- a/turbo/apps/cli/src/commands/zero/search/index.ts
+++ b/turbo/apps/cli/src/commands/zero/search/index.ts
@@ -66,21 +66,24 @@ function parseContextOptions(options: SearchOptions): {
   before: number;
   after: number;
 } {
-  const contextN = options.context
-    ? parseBoundedLogCount(options.context, "--context", 0, 10)
-    : 0;
-  const before = options.beforeContext
-    ? parseBoundedLogCount(options.beforeContext, "--before-context", 0, 10)
-    : contextN;
-  const after = options.afterContext
-    ? parseBoundedLogCount(options.afterContext, "--after-context", 0, 10)
-    : contextN;
+  const contextN =
+    options.context !== undefined
+      ? parseBoundedLogCount(options.context, "--context", 0, 10)
+      : 0;
+  const before =
+    options.beforeContext !== undefined
+      ? parseBoundedLogCount(options.beforeContext, "--before-context", 0, 10)
+      : contextN;
+  const after =
+    options.afterContext !== undefined
+      ? parseBoundedLogCount(options.afterContext, "--after-context", 0, 10)
+      : contextN;
 
   return { before, after };
 }
 
 function parseLimit(value: string | undefined): number | undefined {
-  if (!value) return undefined;
+  if (value === undefined) return undefined;
   return parseBoundedLogCount(value, "--limit", 1, 50);
 }
 
@@ -145,10 +148,10 @@ async function runChatSource(
   query: string,
   options: SearchOptions,
 ): Promise<void> {
-  if (options.run) {
+  if (options.run !== undefined) {
     throw new Error("--run is not supported with --source chat");
   }
-  if (options.agent && !isUUID(options.agent)) {
+  if (options.agent !== undefined && !isUUID(options.agent)) {
     console.error(
       chalk.red(`✗ Invalid agent ID "${options.agent}" — expected a UUID`),
     );

--- a/turbo/apps/cli/src/commands/zero/search/index.ts
+++ b/turbo/apps/cli/src/commands/zero/search/index.ts
@@ -10,6 +10,7 @@ import type {
 import { parseTime } from "../../../lib/utils/time-parser";
 import { formatIsoTimestamp } from "../../../lib/utils/time-format";
 import { parseBoundedLogCount } from "../../../lib/utils/log-pagination";
+import { parseSearchQuery } from "../../../lib/utils/search-query";
 import { isUUID } from "../../run/shared";
 
 const SUPPORTED_SOURCES = ["logs", "chat", "slack"] as const;
@@ -215,6 +216,7 @@ export const zeroSearchCommand = new Command()
   .addHelpText("after", SEARCH_EXPLAINER)
   .action(
     withErrorHandler(async (query: string, options: SearchOptions) => {
+      const searchQuery = parseSearchQuery(query, "Query");
       const sources = options.source;
 
       if (sources.length === 0) {
@@ -235,13 +237,13 @@ export const zeroSearchCommand = new Command()
 
       switch (source as Source) {
         case "logs":
-          await runLogsSource(query, options);
+          await runLogsSource(searchQuery, options);
           return;
         case "chat":
-          await runChatSource(query, options);
+          await runChatSource(searchQuery, options);
           return;
         case "slack":
-          await runSlackSource(query, options);
+          await runSlackSource(searchQuery, options);
           return;
       }
     }),

--- a/turbo/apps/cli/src/commands/zero/search/index.ts
+++ b/turbo/apps/cli/src/commands/zero/search/index.ts
@@ -9,6 +9,7 @@ import type {
 } from "@vm0/api-contracts/contracts/chat-threads";
 import { parseTime } from "../../../lib/utils/time-parser";
 import { formatIsoTimestamp } from "../../../lib/utils/time-format";
+import { parseBoundedLogCount } from "../../../lib/utils/log-pagination";
 
 const SUPPORTED_SOURCES = ["logs", "chat", "slack"] as const;
 type Source = (typeof SUPPORTED_SOURCES)[number];
@@ -64,31 +65,22 @@ function parseContextOptions(options: SearchOptions): {
   before: number;
   after: number;
 } {
-  const contextN = options.context ? parseInt(options.context, 10) : 0;
+  const contextN = options.context
+    ? parseBoundedLogCount(options.context, "--context", 0, 10)
+    : 0;
   const before = options.beforeContext
-    ? parseInt(options.beforeContext, 10)
+    ? parseBoundedLogCount(options.beforeContext, "--before-context", 0, 10)
     : contextN;
   const after = options.afterContext
-    ? parseInt(options.afterContext, 10)
+    ? parseBoundedLogCount(options.afterContext, "--after-context", 0, 10)
     : contextN;
-
-  if (isNaN(before) || before < 0 || before > 10) {
-    throw new Error("--before-context must be between 0 and 10");
-  }
-  if (isNaN(after) || after < 0 || after > 10) {
-    throw new Error("--after-context must be between 0 and 10");
-  }
 
   return { before, after };
 }
 
 function parseLimit(value: string | undefined): number | undefined {
   if (!value) return undefined;
-  const limit = parseInt(value, 10);
-  if (isNaN(limit) || limit < 1 || limit > 50) {
-    throw new Error("--limit must be between 1 and 50");
-  }
-  return limit;
+  return parseBoundedLogCount(value, "--limit", 1, 50);
 }
 
 async function runLogsSource(

--- a/turbo/apps/cli/src/lib/events/codex-event-parser.ts
+++ b/turbo/apps/cli/src/lib/events/codex-event-parser.ts
@@ -157,7 +157,7 @@ function formatDetailSuffix(details: readonly string[]): string {
 }
 
 function extractErrorMessage(value: unknown): string | undefined {
-  if (value === null || value === undefined) {
+  if (value === null || value === undefined || value === false) {
     return undefined;
   }
 

--- a/turbo/apps/cli/src/lib/events/codex-event-parser.ts
+++ b/turbo/apps/cli/src/lib/events/codex-event-parser.ts
@@ -250,6 +250,20 @@ function combineDistinctMessages(
   return messages.length > 0 ? messages.join("\n") : undefined;
 }
 
+function isGenericFailureMessage(message: string): boolean {
+  const normalized = message
+    .trim()
+    .toLowerCase()
+    .replace(/[\s.:!?]+$/u, "");
+  return (
+    normalized === "error" ||
+    normalized === "turn failed" ||
+    normalized === "turn interrupted" ||
+    normalized === "unknown error" ||
+    normalized === "codex error"
+  );
+}
+
 function combineResultWithError(
   result: string | undefined,
   errorMessage: string | undefined,
@@ -405,15 +419,26 @@ function getTurnErrorMessage(
   event: JsonRecord,
   turn: JsonRecord | null,
 ): string | undefined {
-  return combineDistinctMessages(
-    turn !== null ? extractErrorMessage(turn.error) : undefined,
-    extractEventErrorMessage(event),
-  );
+  const turnMessage =
+    turn !== null ? extractErrorMessage(turn.error) : undefined;
+  const eventMessage = extractEventErrorMessage(event);
+  if (turnMessage && eventMessage && isGenericFailureMessage(eventMessage)) {
+    return turnMessage;
+  }
+  return combineDistinctMessages(turnMessage, eventMessage);
 }
 
 function getUsage(event: JsonRecord): JsonRecord {
   const turn = getTurnRecord(event);
   return asRecord(event.usage) ?? (turn ? asRecord(turn.usage) : null) ?? {};
+}
+
+function getTurnDurationMs(event: JsonRecord, turn: JsonRecord | null): number {
+  return (
+    (turn ? getFirstNumber(turn, ["duration_ms", "durationMs"]) : undefined) ??
+    getFirstNumber(event, ["duration_ms", "durationMs"]) ??
+    0
+  );
 }
 
 function getItem(event: JsonRecord): JsonRecord | null {
@@ -434,6 +459,17 @@ function getItemStatus(item: JsonRecord): string | undefined {
 
 function getItemErrorMessage(item: JsonRecord): string | undefined {
   return extractErrorMessage(item.error);
+}
+
+function shouldRenderGenericItemFailure(
+  eventType: string,
+  item: JsonRecord,
+): boolean {
+  return (
+    eventType === "item.completed" &&
+    (isFailedStatus(getItemStatus(item)) ||
+      getItemErrorMessage(item) !== undefined)
+  );
 }
 
 function formatPlanStatus(status: string | undefined): string {
@@ -582,12 +618,7 @@ export class CodexEventParser {
     const status = getTurnStatus(event);
     const turn = getTurnRecord(event);
     const turnId = getTurnId(event);
-    const durationMs =
-      (turn
-        ? getFirstNumber(turn, ["duration_ms", "durationMs"])
-        : undefined) ??
-      getFirstNumber(event, ["duration_ms", "durationMs"]) ??
-      0;
+    const durationMs = getTurnDurationMs(event, turn);
 
     if (
       isUnsuccessfulTurnCompletionStatus(status) ||
@@ -635,10 +666,10 @@ export class CodexEventParser {
       data: {
         success: false,
         result: getTurnErrorMessage(event, turn) ?? "Turn failed",
-        durationMs: 0,
+        durationMs: getTurnDurationMs(event, turn),
         numTurns: 1,
         cost: 0,
-        usage: {},
+        usage: getUsage(event),
         ...(turnId ? { turnId } : {}),
       },
     };
@@ -692,10 +723,9 @@ export class CodexEventParser {
     }
 
     if (itemType === "agent_message") {
-      const text = trimmedStringValue(item.text);
-      return text
-        ? { type: "text", timestamp: new Date(), data: { text } }
-        : null;
+      return this.parseTextItem(eventType, item, (text) => {
+        return text;
+      });
     }
     if (itemType === "command_execution") {
       return this.parseCommandExecution(eventType, item);
@@ -710,34 +740,49 @@ export class CodexEventParser {
       return this.parseFileChange(item);
     }
     if (itemType === "reasoning") {
-      const text = trimmedStringValue(item.text);
-      return text
-        ? {
-            type: "text",
-            timestamp: new Date(),
-            data: { text: `[thinking] ${text}` },
-          }
-        : null;
+      return this.parseTextItem(eventType, item, (text) => {
+        return `[thinking] ${text}`;
+      });
     }
     if (itemType === "plan") {
-      const text = trimmedStringValue(item.text);
-      return text
-        ? {
-            type: "text",
-            timestamp: new Date(),
-            data: { text: `[plan]\n${text}` },
-          }
-        : null;
+      return this.parseTextItem(eventType, item, (text) => {
+        return `[plan]\n${text}`;
+      });
     }
 
     if (eventType === "item.completed") {
-      const text = formatGenericItem(item);
-      return text
-        ? { type: "text", timestamp: new Date(), data: { text } }
-        : null;
+      return this.parseGenericCompletedItem(item);
     }
 
     return null;
+  }
+
+  private static parseTextItem(
+    eventType: string,
+    item: JsonRecord,
+    formatText: (text: string) => string,
+  ): ParsedEvent | null {
+    const text = trimmedStringValue(item.text);
+    if (text) {
+      return {
+        type: "text",
+        timestamp: new Date(),
+        data: { text: formatText(text) },
+      };
+    }
+
+    return shouldRenderGenericItemFailure(eventType, item)
+      ? this.parseGenericCompletedItem(item)
+      : null;
+  }
+
+  private static parseGenericCompletedItem(
+    item: JsonRecord,
+  ): ParsedEvent | null {
+    const text = formatGenericItem(item);
+    return text
+      ? { type: "text", timestamp: new Date(), data: { text } }
+      : null;
   }
 
   private static parseCommandExecution(
@@ -931,17 +976,19 @@ export class CodexEventParser {
   }
 
   private static parseErrorEvent(event: JsonRecord): ParsedEvent | null {
+    const turn = getTurnRecord(event);
     const turnId = getTurnId(event);
+    const hasTurnContext = turn !== null || turnId !== undefined;
     return {
       type: "result",
       timestamp: new Date(),
       data: {
         success: false,
-        result: extractEventErrorMessage(event) ?? "Unknown error",
-        durationMs: 0,
-        numTurns: 0,
+        result: getTurnErrorMessage(event, turn) ?? "Unknown error",
+        durationMs: getTurnDurationMs(event, turn),
+        numTurns: hasTurnContext ? 1 : 0,
         cost: 0,
-        usage: {},
+        usage: getUsage(event),
         ...(turnId ? { turnId } : {}),
       },
     };

--- a/turbo/apps/cli/src/lib/events/codex-event-parser.ts
+++ b/turbo/apps/cli/src/lib/events/codex-event-parser.ts
@@ -230,13 +230,21 @@ function combineDistinctMessages(
     if (!trimmed) {
       continue;
     }
-    if (
-      messages.some((existing) => {
-        return existing === trimmed || existing.includes(trimmed);
-      })
-    ) {
+    const containingIndex = messages.findIndex((existing) => {
+      return existing === trimmed || existing.includes(trimmed);
+    });
+    if (containingIndex !== -1) {
       continue;
     }
+
+    const containedIndex = messages.findIndex((existing) => {
+      return trimmed.includes(existing);
+    });
+    if (containedIndex !== -1) {
+      messages[containedIndex] = trimmed;
+      continue;
+    }
+
     messages.push(trimmed);
   }
   return messages.length > 0 ? messages.join("\n") : undefined;

--- a/turbo/apps/cli/src/lib/events/codex-event-parser.ts
+++ b/turbo/apps/cli/src/lib/events/codex-event-parser.ts
@@ -1,228 +1,578 @@
 /**
- * Event parser for OpenAI Codex CLI JSONL events
- * Converts raw JSONL events into simplified, user-friendly format
+ * Event parser for OpenAI Codex CLI JSONL events.
  *
- * Codex event types:
- * - thread.started: Session initialization
- * - turn.started/turn.completed/turn.failed: Turn lifecycle
- * - item.started/item.updated/item.completed: Individual items (messages, commands, etc.)
- * - error: Unrecoverable errors
+ * The parser accepts both legacy `codex exec --json` events and the
+ * Codex-style compatibility events produced by the vm0 guest-agent app-server
+ * adapter. It deliberately does not consume raw app-server JSON-RPC
+ * notifications.
  */
 
 import type { ParsedEvent } from "./claude-event-parser";
 
-interface ThreadStartedEvent {
-  type: "thread.started";
-  thread_id: string;
+type JsonRecord = Record<string, unknown>;
+
+const MAX_FORMATTED_ARRAY_ITEMS = 6;
+const MAX_FORMATTED_OBJECT_FIELDS = 8;
+const MAX_FORMATTED_TEXT_LENGTH = 240;
+
+function asRecord(value: unknown): JsonRecord | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as JsonRecord;
 }
 
-interface TurnStartedEvent {
-  type: "turn.started";
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
 }
 
-interface TurnCompletedEvent {
-  type: "turn.completed";
-  usage?: {
-    input_tokens?: number;
-    cached_input_tokens?: number;
-    output_tokens?: number;
-  };
+function trimmedStringValue(value: unknown): string | undefined {
+  const valueString = stringValue(value)?.trim();
+  return valueString && valueString.length > 0 ? valueString : undefined;
 }
 
-interface TurnFailedEvent {
-  type: "turn.failed";
-  error?: string;
+function numberValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
 }
 
-interface FileChange {
-  kind: "add" | "modify" | "delete";
-  path: string;
+function getFirstString(
+  record: JsonRecord,
+  keys: readonly string[],
+): string | undefined {
+  for (const key of keys) {
+    const value = trimmedStringValue(record[key]);
+    if (value) {
+      return value;
+    }
+  }
+  return undefined;
 }
 
-interface CodexItem {
-  id: string;
-  type: string;
-  status?: string;
-  // For command_execution
-  command?: string;
-  exit_code?: number;
-  output?: string;
-  aggregated_output?: string;
-  // For agent_message
-  text?: string;
-  // For file operations
-  path?: string;
-  diff?: string;
-  // For file_change
-  changes?: FileChange[];
-  // For reasoning (text field is used)
+function getFirstNumber(
+  record: JsonRecord,
+  keys: readonly string[],
+): number | undefined {
+  for (const key of keys) {
+    const value = numberValue(record[key]);
+    if (value !== undefined) {
+      return value;
+    }
+  }
+  return undefined;
 }
 
-interface ItemEvent {
-  type: "item.started" | "item.updated" | "item.completed";
-  item: CodexItem;
+function truncate(text: string): string {
+  if (text.length <= MAX_FORMATTED_TEXT_LENGTH) {
+    return text;
+  }
+  return `${text.slice(0, MAX_FORMATTED_TEXT_LENGTH - 3)}...`;
 }
 
-interface ErrorEvent {
-  type: "error";
-  message?: string;
-  error?: string;
+function formatScalar(value: unknown): string | undefined {
+  if (value === null) {
+    return "null";
+  }
+  if (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return truncate(String(value));
+  }
+  return undefined;
 }
 
-type RawCodexEvent =
-  | ThreadStartedEvent
-  | TurnStartedEvent
-  | TurnCompletedEvent
-  | TurnFailedEvent
-  | ItemEvent
-  | ErrorEvent
-  | Record<string, unknown>;
+function formatUnknownValue(value: unknown, depth = 0): string | undefined {
+  const scalar = formatScalar(value);
+  if (scalar !== undefined) {
+    return scalar;
+  }
+
+  if (Array.isArray(value)) {
+    const items = value
+      .slice(0, MAX_FORMATTED_ARRAY_ITEMS)
+      .map((item) => {
+        return formatUnknownValue(item, depth + 1);
+      })
+      .filter((item): item is string => {
+        return item !== undefined && item.length > 0;
+      });
+    if (items.length === 0) {
+      return undefined;
+    }
+    const suffix = value.length > MAX_FORMATTED_ARRAY_ITEMS ? ", ..." : "";
+    return `[${items.join(", ")}${suffix}]`;
+  }
+
+  const record = asRecord(value);
+  if (!record || depth > 0) {
+    return undefined;
+  }
+
+  const fields: string[] = [];
+  for (const [key, fieldValue] of Object.entries(record)) {
+    if (fields.length >= MAX_FORMATTED_OBJECT_FIELDS) {
+      fields.push("...");
+      break;
+    }
+    const formatted = formatUnknownValue(fieldValue, depth + 1);
+    if (formatted !== undefined) {
+      fields.push(`${key}=${formatted}`);
+    }
+  }
+  return fields.length > 0 ? `{${fields.join(", ")}}` : undefined;
+}
+
+function combineDistinctMessages(
+  first: string | undefined,
+  second: string | undefined,
+): string | undefined {
+  const messages: string[] = [];
+  for (const message of [first, second]) {
+    const trimmed = message?.trim();
+    if (!trimmed) {
+      continue;
+    }
+    if (
+      messages.some((existing) => {
+        return existing === trimmed || existing.includes(trimmed);
+      })
+    ) {
+      continue;
+    }
+    messages.push(trimmed);
+  }
+  return messages.length > 0 ? messages.join("\n") : undefined;
+}
+
+function formatDetailSuffix(details: readonly string[]): string {
+  return details.length > 0 ? ` (${details.join("; ")})` : "";
+}
+
+function extractErrorMessage(value: unknown): string | undefined {
+  const direct = trimmedStringValue(value);
+  if (direct) {
+    return direct;
+  }
+
+  const record = asRecord(value);
+  if (!record) {
+    return formatUnknownValue(value);
+  }
+
+  const message =
+    getFirstString(record, ["message"]) ??
+    getFirstString(record, ["error", "code", "failureReason"]);
+  const details = [
+    getFirstString(record, ["additional_details", "additionalDetails"]),
+    getFirstString(record, ["codex_error_info", "codexErrorInfo"]),
+    formatUnknownValue(record.connectors),
+  ].filter((detail): detail is string => {
+    return detail !== undefined && detail.length > 0;
+  });
+
+  if (message) {
+    const uniqueDetails = details.filter((detail) => {
+      return !message.includes(detail);
+    });
+    return `${message}${formatDetailSuffix(uniqueDetails)}`;
+  }
+
+  const nested = extractErrorMessage(record.error);
+  if (nested) {
+    return nested;
+  }
+
+  return formatUnknownValue(record);
+}
+
+function extractEventErrorMessage(event: JsonRecord): string | undefined {
+  return combineDistinctMessages(
+    trimmedStringValue(event.message),
+    extractErrorMessage(event.error),
+  );
+}
+
+function getTurnRecord(event: JsonRecord): JsonRecord | null {
+  return asRecord(event.turn);
+}
+
+function getTurnId(event: JsonRecord): string | undefined {
+  const topLevelId = getFirstString(event, ["turn_id", "turnId"]);
+  if (topLevelId) {
+    return topLevelId;
+  }
+  const turn = getTurnRecord(event);
+  return turn ? getFirstString(turn, ["id"]) : undefined;
+}
+
+function getTurnStatus(event: JsonRecord): string | undefined {
+  const turn = getTurnRecord(event);
+  return (
+    (turn ? getFirstString(turn, ["status"]) : undefined) ??
+    getFirstString(event, ["status"])
+  );
+}
+
+function isFailedStatus(status: string | undefined): boolean {
+  return status === "failed" || status === "declined";
+}
+
+function isTerminalFailedTurnStatus(status: string | undefined): boolean {
+  return status === "failed" || status === "interrupted";
+}
+
+function getUsage(event: JsonRecord): JsonRecord {
+  return asRecord(event.usage) ?? {};
+}
+
+function getItem(event: JsonRecord): JsonRecord | null {
+  return asRecord(event.item);
+}
+
+function getItemId(item: JsonRecord): string | undefined {
+  return getFirstString(item, ["id"]);
+}
+
+function getItemType(item: JsonRecord): string | undefined {
+  return getFirstString(item, ["type"]);
+}
+
+function getItemStatus(item: JsonRecord): string | undefined {
+  return getFirstString(item, ["status"]);
+}
+
+function formatPlanStatus(status: string | undefined): string {
+  if (status === "completed") return "completed";
+  if (status === "in_progress") return "in progress";
+  if (status === "pending") return "pending";
+  return status ?? "step";
+}
+
+function formatPlanLines(plan: unknown): string[] {
+  if (!Array.isArray(plan)) {
+    return [];
+  }
+  return plan
+    .map((step) => {
+      const stepRecord = asRecord(step);
+      if (!stepRecord) {
+        return undefined;
+      }
+      const text = trimmedStringValue(stepRecord.step);
+      if (!text) {
+        return undefined;
+      }
+      const status = formatPlanStatus(trimmedStringValue(stepRecord.status));
+      return `- ${status}: ${text}`;
+    })
+    .filter((line): line is string => {
+      return line !== undefined;
+    });
+}
+
+function formatGenericItem(item: JsonRecord): string | undefined {
+  const itemType = getItemType(item);
+  if (!itemType) {
+    return undefined;
+  }
+
+  const fields: string[] = [itemType];
+  const id = getItemId(item);
+  if (id) {
+    fields.push(`id=${id}`);
+  }
+  const status = getItemStatus(item);
+  if (status) {
+    fields.push(`status=${status}`);
+  }
+
+  for (const [key, value] of Object.entries(item)) {
+    if (key === "id" || key === "type" || key === "status") {
+      continue;
+    }
+    if (fields.length >= MAX_FORMATTED_OBJECT_FIELDS + 3) {
+      fields.push("...");
+      break;
+    }
+    const formatted = formatUnknownValue(value);
+    if (formatted !== undefined) {
+      fields.push(`${key}=${formatted}`);
+    }
+  }
+
+  return `[item] ${fields.join(" ")}`;
+}
+
+function formatFileChangeAction(kind: string | undefined): string {
+  if (kind === "add") return "Created";
+  if (kind === "modify") return "Modified";
+  if (kind === "delete") return "Deleted";
+  return "Changed";
+}
 
 export class CodexEventParser {
   /**
-   * Parse a raw Codex CLI JSONL event into a simplified format
-   * Returns null if the event type is unknown or malformed
+   * Parse a raw Codex JSONL event into the shared CLI parsed-event format.
+   * Returns null if the event type is unknown or too malformed to display.
    */
-  static parse(rawEvent: RawCodexEvent): ParsedEvent | null {
-    if (!rawEvent || typeof rawEvent !== "object" || !("type" in rawEvent)) {
+  static parse(rawEvent: unknown): ParsedEvent | null {
+    const event = asRecord(rawEvent);
+    if (!event) {
       return null;
     }
 
-    const eventType = rawEvent.type as string;
+    const eventType = stringValue(event.type);
+    if (!eventType) {
+      return null;
+    }
 
-    // Thread started = init event
     if (eventType === "thread.started") {
-      return this.parseThreadStarted(rawEvent as ThreadStartedEvent);
+      return this.parseThreadStarted(event);
     }
 
-    // Turn completed = result event
     if (eventType === "turn.completed") {
-      return this.parseTurnCompleted(rawEvent as TurnCompletedEvent);
+      return this.parseTurnCompleted(event);
     }
 
-    // Turn failed = result event with error
     if (eventType === "turn.failed") {
-      return this.parseTurnFailed(rawEvent as TurnFailedEvent);
+      return this.parseTurnFailed(event);
     }
 
-    // Item events (started, updated, completed)
+    if (eventType === "turn.plan.updated") {
+      return this.parseTurnPlanUpdated(event);
+    }
+
+    if (eventType === "warning") {
+      return this.parseWarning(event);
+    }
+
     if (eventType.startsWith("item.")) {
-      return this.parseItemEvent(rawEvent as ItemEvent);
+      return this.parseItemEvent(event, eventType);
     }
 
-    // Error event
     if (eventType === "error") {
-      return this.parseErrorEvent(rawEvent as ErrorEvent);
+      return this.parseErrorEvent(event);
     }
 
-    // Turn started - we skip this, not useful for display
     return null;
   }
 
-  private static parseThreadStarted(
-    event: ThreadStartedEvent,
-  ): ParsedEvent | null {
+  private static parseThreadStarted(event: JsonRecord): ParsedEvent | null {
+    const threadId = getFirstString(event, ["thread_id", "threadId"]);
+    if (!threadId) {
+      return null;
+    }
+
     return {
       type: "init",
       timestamp: new Date(),
       data: {
         framework: "codex",
-        sessionId: event.thread_id,
+        sessionId: threadId,
         tools: [],
       },
     };
   }
 
-  private static parseTurnCompleted(
-    event: TurnCompletedEvent,
-  ): ParsedEvent | null {
+  private static parseTurnCompleted(event: JsonRecord): ParsedEvent | null {
+    const status = getTurnStatus(event);
+    const turn = getTurnRecord(event);
+    const turnId = getTurnId(event);
+    const durationMs =
+      (turn
+        ? getFirstNumber(turn, ["duration_ms", "durationMs"])
+        : undefined) ??
+      getFirstNumber(event, ["duration_ms", "durationMs"]) ??
+      0;
+
+    if (isTerminalFailedTurnStatus(status)) {
+      const result =
+        (turn ? extractErrorMessage(turn.error) : undefined) ??
+        extractEventErrorMessage(event) ??
+        `Turn ${status}`;
+      return {
+        type: "result",
+        timestamp: new Date(),
+        data: {
+          success: false,
+          result,
+          durationMs,
+          numTurns: 1,
+          cost: 0,
+          usage: getUsage(event),
+          ...(turnId ? { turnId } : {}),
+        },
+      };
+    }
+
     return {
       type: "result",
       timestamp: new Date(),
       data: {
         success: true,
         result: "",
-        durationMs: 0,
+        durationMs,
         numTurns: 1,
         cost: 0,
-        usage: event.usage || {},
+        usage: getUsage(event),
+        ...(turnId ? { turnId } : {}),
       },
     };
   }
 
-  private static parseTurnFailed(event: TurnFailedEvent): ParsedEvent | null {
+  private static parseTurnFailed(event: JsonRecord): ParsedEvent | null {
+    const turnId = getTurnId(event);
     return {
       type: "result",
       timestamp: new Date(),
       data: {
         success: false,
-        result: event.error || "Turn failed",
+        result: extractEventErrorMessage(event) ?? "Turn failed",
         durationMs: 0,
         numTurns: 1,
         cost: 0,
         usage: {},
+        ...(turnId ? { turnId } : {}),
       },
     };
   }
 
-  private static parseItemEvent(event: ItemEvent): ParsedEvent | null {
-    const item = event.item;
+  private static parseTurnPlanUpdated(event: JsonRecord): ParsedEvent | null {
+    const lines = formatPlanLines(event.plan);
+    const explanation = trimmedStringValue(event.explanation);
+    if (lines.length === 0 && !explanation) {
+      return null;
+    }
+
+    return {
+      type: "text",
+      timestamp: new Date(),
+      data: {
+        text: ["[plan]", explanation, ...lines]
+          .filter((line): line is string => {
+            return line !== undefined && line.length > 0;
+          })
+          .join("\n"),
+      },
+    };
+  }
+
+  private static parseWarning(event: JsonRecord): ParsedEvent | null {
+    const message = extractEventErrorMessage(event);
+    if (!message) {
+      return null;
+    }
+
+    return {
+      type: "text",
+      timestamp: new Date(),
+      data: { text: `[warning] ${message}` },
+    };
+  }
+
+  private static parseItemEvent(
+    event: JsonRecord,
+    eventType: string,
+  ): ParsedEvent | null {
+    const item = getItem(event);
     if (!item) {
       return null;
     }
 
-    const itemType = item.type;
+    const itemType = getItemType(item);
+    if (!itemType) {
+      return null;
+    }
 
-    if (itemType === "agent_message" && item.text) {
-      return { type: "text", timestamp: new Date(), data: { text: item.text } };
+    if (itemType === "agent_message") {
+      const text = trimmedStringValue(item.text);
+      return text
+        ? { type: "text", timestamp: new Date(), data: { text } }
+        : null;
     }
     if (itemType === "command_execution") {
-      return this.parseCommandExecution(event);
+      return this.parseCommandExecution(eventType, item);
     }
     if (itemType === "file_edit" || itemType === "file_write") {
-      return this.parseFileEditOrWrite(event);
+      return this.parseFileEditOrWrite(eventType, item);
     }
     if (itemType === "file_read") {
-      return this.parseFileRead(event);
+      return this.parseFileRead(eventType, item);
     }
     if (itemType === "file_change") {
       return this.parseFileChange(item);
     }
-    if (itemType === "reasoning" && item.text) {
-      return {
-        type: "text",
-        timestamp: new Date(),
-        data: { text: `[thinking] ${item.text}` },
-      };
+    if (itemType === "reasoning") {
+      const text = trimmedStringValue(item.text);
+      return text
+        ? {
+            type: "text",
+            timestamp: new Date(),
+            data: { text: `[thinking] ${text}` },
+          }
+        : null;
+    }
+    if (itemType === "plan") {
+      const text = trimmedStringValue(item.text);
+      return text
+        ? {
+            type: "text",
+            timestamp: new Date(),
+            data: { text: `[plan]\n${text}` },
+          }
+        : null;
+    }
+
+    if (eventType === "item.completed") {
+      const text = formatGenericItem(item);
+      return text
+        ? { type: "text", timestamp: new Date(), data: { text } }
+        : null;
     }
 
     return null;
   }
 
-  private static parseCommandExecution(event: ItemEvent): ParsedEvent | null {
-    const item = event.item;
+  private static parseCommandExecution(
+    eventType: string,
+    item: JsonRecord,
+  ): ParsedEvent | null {
+    const itemId = getItemId(item);
+    const command = trimmedStringValue(item.command);
+    if (!itemId) {
+      return null;
+    }
 
-    if (event.type === "item.started" && item.command) {
+    if (eventType === "item.started" && command) {
       return {
         type: "tool_use",
         timestamp: new Date(),
         data: {
           tool: "Bash",
-          toolUseId: item.id,
-          input: { command: item.command },
+          toolUseId: itemId,
+          input: { command },
         },
       };
     }
 
-    if (event.type === "item.completed") {
-      const output = item.aggregated_output ?? item.output ?? "";
+    if (eventType === "item.completed") {
+      const output =
+        trimmedStringValue(item.aggregated_output) ??
+        trimmedStringValue(item.output) ??
+        "";
+      const status = getItemStatus(item);
+      const exitCode = numberValue(item.exit_code);
+      const isError = exitCode !== undefined ? exitCode !== 0 : false;
       return {
         type: "tool_result",
         timestamp: new Date(),
         data: {
-          toolUseId: item.id,
-          result: output,
-          isError: item.exit_code !== 0,
+          toolUseId: itemId,
+          result: output || (isFailedStatus(status) ? `Command ${status}` : ""),
+          isError: isError || isFailedStatus(status),
         },
       };
     }
@@ -230,29 +580,41 @@ export class CodexEventParser {
     return null;
   }
 
-  private static parseFileEditOrWrite(event: ItemEvent): ParsedEvent | null {
-    const item = event.item;
+  private static parseFileEditOrWrite(
+    eventType: string,
+    item: JsonRecord,
+  ): ParsedEvent | null {
+    const itemId = getItemId(item);
+    const path = trimmedStringValue(item.path);
+    if (!itemId) {
+      return null;
+    }
 
-    if (event.type === "item.started" && item.path) {
+    if (eventType === "item.started" && path) {
       return {
         type: "tool_use",
         timestamp: new Date(),
         data: {
-          tool: item.type === "file_edit" ? "Edit" : "Write",
-          toolUseId: item.id,
-          input: { file_path: item.path },
+          tool: getItemType(item) === "file_edit" ? "Edit" : "Write",
+          toolUseId: itemId,
+          input: { file_path: path },
         },
       };
     }
 
-    if (event.type === "item.completed") {
+    if (eventType === "item.completed") {
+      const status = getItemStatus(item);
       return {
         type: "tool_result",
         timestamp: new Date(),
         data: {
-          toolUseId: item.id,
-          result: item.diff || "File operation completed",
-          isError: false,
+          toolUseId: itemId,
+          result:
+            trimmedStringValue(item.diff) ??
+            (isFailedStatus(status)
+              ? `File operation ${status}`
+              : "File operation completed"),
+          isError: isFailedStatus(status),
         },
       };
     }
@@ -260,29 +622,39 @@ export class CodexEventParser {
     return null;
   }
 
-  private static parseFileRead(event: ItemEvent): ParsedEvent | null {
-    const item = event.item;
+  private static parseFileRead(
+    eventType: string,
+    item: JsonRecord,
+  ): ParsedEvent | null {
+    const itemId = getItemId(item);
+    const path = trimmedStringValue(item.path);
+    if (!itemId) {
+      return null;
+    }
 
-    if (event.type === "item.started" && item.path) {
+    if (eventType === "item.started" && path) {
       return {
         type: "tool_use",
         timestamp: new Date(),
         data: {
           tool: "Read",
-          toolUseId: item.id,
-          input: { file_path: item.path },
+          toolUseId: itemId,
+          input: { file_path: path },
         },
       };
     }
 
-    if (event.type === "item.completed") {
+    if (eventType === "item.completed") {
+      const status = getItemStatus(item);
       return {
         type: "tool_result",
         timestamp: new Date(),
         data: {
-          toolUseId: item.id,
-          result: "File read completed",
-          isError: false,
+          toolUseId: itemId,
+          result: isFailedStatus(status)
+            ? `File read ${status}`
+            : "File read completed",
+          isError: isFailedStatus(status),
         },
       };
     }
@@ -290,41 +662,60 @@ export class CodexEventParser {
     return null;
   }
 
-  private static parseFileChange(item: CodexItem): ParsedEvent | null {
-    if (!item.changes || item.changes.length === 0) {
+  private static parseFileChange(item: JsonRecord): ParsedEvent | null {
+    const status = getItemStatus(item);
+    const lines = Array.isArray(item.changes)
+      ? item.changes
+          .map((change) => {
+            const changeRecord = asRecord(change);
+            if (!changeRecord) {
+              return undefined;
+            }
+            const path = trimmedStringValue(changeRecord.path);
+            if (!path) {
+              return undefined;
+            }
+            const action = formatFileChangeAction(
+              trimmedStringValue(changeRecord.kind),
+            );
+            return `${action}: ${path}`;
+          })
+          .filter((line): line is string => {
+            return line !== undefined;
+          })
+      : [];
+
+    if (lines.length === 0 && !isFailedStatus(status)) {
       return null;
     }
 
-    const changes = item.changes
-      .map((c) => {
-        const action =
-          c.kind === "add"
-            ? "Created"
-            : c.kind === "modify"
-              ? "Modified"
-              : "Deleted";
-        return `${action}: ${c.path}`;
-      })
-      .join("\n");
-
+    const statusLine = isFailedStatus(status) ? `Status: ${status}` : undefined;
     return {
       type: "text",
       timestamp: new Date(),
-      data: { text: `[files]\n${changes}` },
+      data: {
+        text: ["[files]", statusLine, ...lines]
+          .filter((line): line is string => {
+            return line !== undefined && line.length > 0;
+          })
+          .join("\n"),
+      },
     };
   }
 
-  private static parseErrorEvent(event: ErrorEvent): ParsedEvent | null {
+  private static parseErrorEvent(event: JsonRecord): ParsedEvent | null {
+    const turnId = getTurnId(event);
     return {
       type: "result",
       timestamp: new Date(),
       data: {
         success: false,
-        result: event.message || event.error || "Unknown error",
+        result: extractEventErrorMessage(event) ?? "Unknown error",
         durationMs: 0,
         numTurns: 0,
         cost: 0,
         usage: {},
+        ...(turnId ? { turnId } : {}),
       },
     };
   }

--- a/turbo/apps/cli/src/lib/events/codex-event-parser.ts
+++ b/turbo/apps/cli/src/lib/events/codex-event-parser.ts
@@ -12,6 +12,7 @@ import type { ParsedEvent } from "./claude-event-parser";
 type JsonRecord = Record<string, unknown>;
 
 const MAX_FORMATTED_ARRAY_ITEMS = 6;
+const MAX_FORMATTED_ARRAY_DEPTH = 4;
 const MAX_FORMATTED_OBJECT_FIELDS = 8;
 const MAX_FORMATTED_TEXT_LENGTH = 240;
 
@@ -96,6 +97,10 @@ function formatUnknownValue(value: unknown, depth = 0): string | undefined {
   }
 
   if (Array.isArray(value)) {
+    if (depth >= MAX_FORMATTED_ARRAY_DEPTH) {
+      return "...";
+    }
+
     const items = value
       .slice(0, MAX_FORMATTED_ARRAY_ITEMS)
       .map((item) => {

--- a/turbo/apps/cli/src/lib/events/codex-event-parser.ts
+++ b/turbo/apps/cli/src/lib/events/codex-event-parser.ts
@@ -26,6 +26,11 @@ function stringValue(value: unknown): string | undefined {
   return typeof value === "string" ? value : undefined;
 }
 
+function nonEmptyStringValue(value: unknown): string | undefined {
+  const valueString = stringValue(value);
+  return valueString && valueString.length > 0 ? valueString : undefined;
+}
+
 function trimmedStringValue(value: unknown): string | undefined {
   const valueString = stringValue(value)?.trim();
   return valueString && valueString.length > 0 ? valueString : undefined;
@@ -561,8 +566,8 @@ export class CodexEventParser {
 
     if (eventType === "item.completed") {
       const output =
-        trimmedStringValue(item.aggregated_output) ??
-        trimmedStringValue(item.output) ??
+        nonEmptyStringValue(item.aggregated_output) ??
+        nonEmptyStringValue(item.output) ??
         "";
       const status = getItemStatus(item);
       const exitCode = numberValue(item.exit_code);
@@ -616,7 +621,7 @@ export class CodexEventParser {
           toolUseId: itemId,
           input: path ? { file_path: path } : {},
           result:
-            trimmedStringValue(item.diff) ??
+            nonEmptyStringValue(item.diff) ??
             (isFailedStatus(status)
               ? `File operation ${status}`
               : "File operation completed"),
@@ -652,6 +657,7 @@ export class CodexEventParser {
 
     if (eventType === "item.completed") {
       const status = getItemStatus(item);
+      const output = nonEmptyStringValue(item.output);
       return {
         type: "tool_result",
         timestamp: new Date(),
@@ -659,9 +665,11 @@ export class CodexEventParser {
           tool: "Read",
           toolUseId: itemId,
           input: path ? { file_path: path } : {},
-          result: isFailedStatus(status)
-            ? `File read ${status}`
-            : "File read completed",
+          result:
+            output ??
+            (isFailedStatus(status)
+              ? `File read ${status}`
+              : "File read completed"),
           isError: isFailedStatus(status),
         },
       };

--- a/turbo/apps/cli/src/lib/events/codex-event-parser.ts
+++ b/turbo/apps/cli/src/lib/events/codex-event-parser.ts
@@ -85,11 +85,10 @@ function formatScalar(value: unknown): string | undefined {
   if (value === null) {
     return "null";
   }
-  if (
-    typeof value === "string" ||
-    typeof value === "number" ||
-    typeof value === "boolean"
-  ) {
+  if (typeof value === "string") {
+    return value.trim().length > 0 ? truncate(value) : undefined;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
     return truncate(String(value));
   }
   return undefined;

--- a/turbo/apps/cli/src/lib/events/codex-event-parser.ts
+++ b/turbo/apps/cli/src/lib/events/codex-event-parser.ts
@@ -225,7 +225,8 @@ function isTerminalFailedTurnStatus(status: string | undefined): boolean {
 }
 
 function getUsage(event: JsonRecord): JsonRecord {
-  return asRecord(event.usage) ?? {};
+  const turn = getTurnRecord(event);
+  return asRecord(event.usage) ?? (turn ? asRecord(turn.usage) : null) ?? {};
 }
 
 function getItem(event: JsonRecord): JsonRecord | null {
@@ -570,7 +571,9 @@ export class CodexEventParser {
         type: "tool_result",
         timestamp: new Date(),
         data: {
+          tool: "Bash",
           toolUseId: itemId,
+          input: command ? { command } : {},
           result: output || (isFailedStatus(status) ? `Command ${status}` : ""),
           isError: isError || isFailedStatus(status),
         },
@@ -604,11 +607,14 @@ export class CodexEventParser {
 
     if (eventType === "item.completed") {
       const status = getItemStatus(item);
+      const tool = getItemType(item) === "file_edit" ? "Edit" : "Write";
       return {
         type: "tool_result",
         timestamp: new Date(),
         data: {
+          tool,
           toolUseId: itemId,
+          input: path ? { file_path: path } : {},
           result:
             trimmedStringValue(item.diff) ??
             (isFailedStatus(status)
@@ -650,7 +656,9 @@ export class CodexEventParser {
         type: "tool_result",
         timestamp: new Date(),
         data: {
+          tool: "Read",
           toolUseId: itemId,
+          input: path ? { file_path: path } : {},
           result: isFailedStatus(status)
             ? `File read ${status}`
             : "File read completed",

--- a/turbo/apps/cli/src/lib/events/codex-event-parser.ts
+++ b/turbo/apps/cli/src/lib/events/codex-event-parser.ts
@@ -94,6 +94,54 @@ function formatScalar(value: unknown): string | undefined {
   return undefined;
 }
 
+function hasSignalValue(value: unknown, depth = 0): boolean {
+  if (value === null || value === undefined || value === false) {
+    return false;
+  }
+
+  if (typeof value === "string") {
+    return value.trim().length > 0;
+  }
+
+  if (typeof value === "number") {
+    return Number.isFinite(value);
+  }
+
+  if (typeof value === "boolean") {
+    return true;
+  }
+
+  if (Array.isArray(value)) {
+    if (depth >= MAX_FORMATTED_ARRAY_DEPTH) {
+      return false;
+    }
+
+    return value.slice(0, MAX_FORMATTED_ARRAY_ITEMS).some((item) => {
+      return hasSignalValue(item, depth + 1);
+    });
+  }
+
+  const record = asRecord(value);
+  if (!record) {
+    return false;
+  }
+
+  let inspectedFields = 0;
+  for (const key in record) {
+    if (!hasOwnKey(record, key)) {
+      continue;
+    }
+    if (inspectedFields >= MAX_FORMATTED_OBJECT_INSPECTED_FIELDS) {
+      return false;
+    }
+    inspectedFields += 1;
+    if (hasSignalValue(record[key], depth + 1)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function formatUnknownValue(value: unknown, depth = 0): string | undefined {
   const scalar = formatScalar(value);
   if (scalar !== undefined) {
@@ -175,7 +223,7 @@ function formatDetailSuffix(details: readonly string[]): string {
 }
 
 function extractErrorMessage(value: unknown): string | undefined {
-  if (value === null || value === undefined || value === false) {
+  if (!hasSignalValue(value)) {
     return undefined;
   }
 

--- a/turbo/apps/cli/src/lib/events/codex-event-parser.ts
+++ b/turbo/apps/cli/src/lib/events/codex-event-parser.ts
@@ -237,8 +237,23 @@ const FAILED_STATUSES = new Set([
   "timeout",
 ]);
 
+const SUCCESSFUL_TURN_COMPLETION_STATUSES = new Set([
+  "completed",
+  "success",
+  "succeeded",
+]);
+
 function isFailedStatus(status: string | undefined): boolean {
   return status !== undefined && FAILED_STATUSES.has(status.toLowerCase());
+}
+
+function isUnsuccessfulTurnCompletionStatus(
+  status: string | undefined,
+): boolean {
+  return (
+    status !== undefined &&
+    !SUCCESSFUL_TURN_COMPLETION_STATUSES.has(status.toLowerCase())
+  );
 }
 
 function hasExtractableError(value: unknown): boolean {
@@ -430,7 +445,10 @@ export class CodexEventParser {
       getFirstNumber(event, ["duration_ms", "durationMs"]) ??
       0;
 
-    if (isFailedStatus(status) || hasTurnCompletionError(event, turn)) {
+    if (
+      isUnsuccessfulTurnCompletionStatus(status) ||
+      hasTurnCompletionError(event, turn)
+    ) {
       const result =
         getTurnCompletionErrorMessage(event, turn) ??
         (status ? `Turn ${status}` : "Turn failed");

--- a/turbo/apps/cli/src/lib/events/codex-event-parser.ts
+++ b/turbo/apps/cli/src/lib/events/codex-event-parser.ts
@@ -14,6 +14,7 @@ type JsonRecord = Record<string, unknown>;
 const MAX_FORMATTED_ARRAY_ITEMS = 6;
 const MAX_FORMATTED_ARRAY_DEPTH = 4;
 const MAX_FORMATTED_OBJECT_FIELDS = 8;
+const MAX_FORMATTED_OBJECT_INSPECTED_FIELDS = 16;
 const MAX_FORMATTED_TEXT_LENGTH = 240;
 
 function asRecord(value: unknown): JsonRecord | null {
@@ -21,6 +22,10 @@ function asRecord(value: unknown): JsonRecord | null {
     return null;
   }
   return value as JsonRecord;
+}
+
+function hasOwnKey(record: JsonRecord, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(record, key);
 }
 
 function stringValue(value: unknown): string | undefined {
@@ -122,11 +127,20 @@ function formatUnknownValue(value: unknown, depth = 0): string | undefined {
   }
 
   const fields: string[] = [];
-  for (const [key, fieldValue] of Object.entries(record)) {
-    if (fields.length >= MAX_FORMATTED_OBJECT_FIELDS) {
+  let inspectedFields = 0;
+  for (const key in record) {
+    if (!hasOwnKey(record, key)) {
+      continue;
+    }
+    if (
+      fields.length >= MAX_FORMATTED_OBJECT_FIELDS ||
+      inspectedFields >= MAX_FORMATTED_OBJECT_INSPECTED_FIELDS
+    ) {
       fields.push("...");
       break;
     }
+    inspectedFields += 1;
+    const fieldValue = record[key];
     const formatted = formatUnknownValue(fieldValue, depth + 1);
     if (formatted !== undefined) {
       fields.push(`${key}=${formatted}`);
@@ -351,14 +365,23 @@ function formatGenericItem(item: JsonRecord): string | undefined {
     fields.push(`status=${status}`);
   }
 
-  for (const [key, value] of Object.entries(item)) {
+  let inspectedFields = 0;
+  for (const key in item) {
+    if (!hasOwnKey(item, key)) {
+      continue;
+    }
     if (key === "id" || key === "type" || key === "status") {
       continue;
     }
-    if (fields.length >= MAX_FORMATTED_OBJECT_FIELDS + 3) {
+    if (
+      fields.length >= MAX_FORMATTED_OBJECT_FIELDS + 3 ||
+      inspectedFields >= MAX_FORMATTED_OBJECT_INSPECTED_FIELDS
+    ) {
       fields.push("...");
       break;
     }
+    inspectedFields += 1;
+    const value = item[key];
     const formatted = formatUnknownValue(value);
     if (formatted !== undefined) {
       fields.push(`${key}=${formatted}`);

--- a/turbo/apps/cli/src/lib/events/codex-event-parser.ts
+++ b/turbo/apps/cli/src/lib/events/codex-event-parser.ts
@@ -201,6 +201,25 @@ function formatUnknownValue(value: unknown, depth = 0): string | undefined {
   return fields.length > 0 ? `{${fields.join(", ")}}` : undefined;
 }
 
+function formatSignalValue(
+  value: unknown,
+  includeBoundedPlaceholder = false,
+): string | undefined {
+  if (value === null || value === undefined || value === false) {
+    return undefined;
+  }
+  const formatted = formatUnknownValue(value);
+  if (!formatted) {
+    return undefined;
+  }
+  if (hasSignalValue(value)) {
+    return formatted;
+  }
+  return includeBoundedPlaceholder && formatted.includes("...")
+    ? formatted
+    : undefined;
+}
+
 function combineDistinctMessages(
   first: string | undefined,
   second: string | undefined,
@@ -228,7 +247,7 @@ function formatDetailSuffix(details: readonly string[]): string {
 }
 
 function extractErrorMessage(value: unknown, depth = 0): string | undefined {
-  if (!hasSignalValue(value, depth)) {
+  if (value === null || value === undefined || value === false) {
     return undefined;
   }
 
@@ -239,7 +258,7 @@ function extractErrorMessage(value: unknown, depth = 0): string | undefined {
 
   const record = asRecord(value);
   if (!record) {
-    return formatUnknownValue(value);
+    return hasSignalValue(value, depth) ? formatUnknownValue(value) : undefined;
   }
 
   const message =
@@ -248,7 +267,7 @@ function extractErrorMessage(value: unknown, depth = 0): string | undefined {
   const details = [
     getFirstString(record, ["additional_details", "additionalDetails"]),
     getFirstString(record, ["codex_error_info", "codexErrorInfo"]),
-    formatUnknownValue(record.connectors),
+    formatSignalValue(record.connectors, message !== undefined),
   ].filter((detail): detail is string => {
     return detail !== undefined && detail.length > 0;
   });
@@ -260,8 +279,12 @@ function extractErrorMessage(value: unknown, depth = 0): string | undefined {
     return `${message}${formatDetailSuffix(uniqueDetails)}`;
   }
 
+  if (details.length > 0) {
+    return details.join("; ");
+  }
+
   if (depth >= MAX_ERROR_SIGNAL_DEPTH) {
-    return formatUnknownValue(record);
+    return undefined;
   }
 
   const nested = extractErrorMessage(record.error, depth + 1);
@@ -269,7 +292,7 @@ function extractErrorMessage(value: unknown, depth = 0): string | undefined {
     return nested;
   }
 
-  return formatUnknownValue(record);
+  return hasSignalValue(record, depth) ? formatUnknownValue(record) : undefined;
 }
 
 function extractEventErrorMessage(event: JsonRecord): string | undefined {

--- a/turbo/apps/cli/src/lib/events/codex-event-parser.ts
+++ b/turbo/apps/cli/src/lib/events/codex-event-parser.ts
@@ -250,6 +250,31 @@ function combineDistinctMessages(
   return messages.length > 0 ? messages.join("\n") : undefined;
 }
 
+function combineResultWithError(
+  result: string | undefined,
+  errorMessage: string | undefined,
+): string | undefined {
+  if (result === undefined || result.length === 0) {
+    return errorMessage;
+  }
+  if (!errorMessage) {
+    return result;
+  }
+
+  const trimmedResult = result.trim();
+  if (!trimmedResult) {
+    return errorMessage;
+  }
+  if (trimmedResult === errorMessage || trimmedResult.includes(errorMessage)) {
+    return result;
+  }
+  if (errorMessage.includes(trimmedResult)) {
+    return errorMessage;
+  }
+
+  return `${result}\n${errorMessage}`;
+}
+
 function formatDetailSuffix(details: readonly string[]): string {
   return details.length > 0 ? ` (${details.join("; ")})` : "";
 }
@@ -376,7 +401,7 @@ function hasTurnCompletionError(
   );
 }
 
-function getTurnCompletionErrorMessage(
+function getTurnErrorMessage(
   event: JsonRecord,
   turn: JsonRecord | null,
 ): string | undefined {
@@ -405,6 +430,10 @@ function getItemType(item: JsonRecord): string | undefined {
 
 function getItemStatus(item: JsonRecord): string | undefined {
   return getFirstString(item, ["status"]);
+}
+
+function getItemErrorMessage(item: JsonRecord): string | undefined {
+  return extractErrorMessage(item.error);
 }
 
 function formatPlanStatus(status: string | undefined): string {
@@ -565,7 +594,7 @@ export class CodexEventParser {
       hasTurnCompletionError(event, turn)
     ) {
       const result =
-        getTurnCompletionErrorMessage(event, turn) ??
+        getTurnErrorMessage(event, turn) ??
         (status ? `Turn ${status}` : "Turn failed");
       return {
         type: "result",
@@ -598,13 +627,14 @@ export class CodexEventParser {
   }
 
   private static parseTurnFailed(event: JsonRecord): ParsedEvent | null {
+    const turn = getTurnRecord(event);
     const turnId = getTurnId(event);
     return {
       type: "result",
       timestamp: new Date(),
       data: {
         success: false,
-        result: extractEventErrorMessage(event) ?? "Turn failed",
+        result: getTurnErrorMessage(event, turn) ?? "Turn failed",
         durationMs: 0,
         numTurns: 1,
         cost: 0,
@@ -739,7 +769,11 @@ export class CodexEventParser {
         "";
       const status = getItemStatus(item);
       const exitCode = numberValue(item.exit_code);
-      const isError = exitCode !== undefined ? exitCode !== 0 : false;
+      const errorMessage = getItemErrorMessage(item);
+      const isError =
+        (exitCode !== undefined ? exitCode !== 0 : false) ||
+        isFailedStatus(status) ||
+        errorMessage !== undefined;
       return {
         type: "tool_result",
         timestamp: new Date(),
@@ -747,8 +781,10 @@ export class CodexEventParser {
           tool: "Bash",
           toolUseId: itemId,
           input: command ? { command } : {},
-          result: output || (isFailedStatus(status) ? `Command ${status}` : ""),
-          isError: isError || isFailedStatus(status),
+          result:
+            combineResultWithError(output, errorMessage) ??
+            (isFailedStatus(status) ? `Command ${status}` : ""),
+          isError,
         },
       };
     }
@@ -781,6 +817,7 @@ export class CodexEventParser {
     if (eventType === "item.completed") {
       const status = getItemStatus(item);
       const tool = getItemType(item) === "file_edit" ? "Edit" : "Write";
+      const errorMessage = getItemErrorMessage(item);
       return {
         type: "tool_result",
         timestamp: new Date(),
@@ -789,11 +826,14 @@ export class CodexEventParser {
           toolUseId: itemId,
           input: path ? { file_path: path } : {},
           result:
-            nonEmptyStringValue(item.diff) ??
+            combineResultWithError(
+              nonEmptyStringValue(item.diff),
+              errorMessage,
+            ) ??
             (isFailedStatus(status)
               ? `File operation ${status}`
               : "File operation completed"),
-          isError: isFailedStatus(status),
+          isError: isFailedStatus(status) || errorMessage !== undefined,
         },
       };
     }
@@ -826,6 +866,7 @@ export class CodexEventParser {
     if (eventType === "item.completed") {
       const status = getItemStatus(item);
       const output = nonEmptyStringValue(item.output);
+      const errorMessage = getItemErrorMessage(item);
       return {
         type: "tool_result",
         timestamp: new Date(),
@@ -834,11 +875,11 @@ export class CodexEventParser {
           toolUseId: itemId,
           input: path ? { file_path: path } : {},
           result:
-            output ??
+            combineResultWithError(output, errorMessage) ??
             (isFailedStatus(status)
               ? `File read ${status}`
               : "File read completed"),
-          isError: isFailedStatus(status),
+          isError: isFailedStatus(status) || errorMessage !== undefined,
         },
       };
     }
@@ -848,6 +889,7 @@ export class CodexEventParser {
 
   private static parseFileChange(item: JsonRecord): ParsedEvent | null {
     const status = getItemStatus(item);
+    const errorMessage = getItemErrorMessage(item);
     const lines = Array.isArray(item.changes)
       ? item.changes
           .map((change) => {
@@ -869,16 +911,17 @@ export class CodexEventParser {
           })
       : [];
 
-    if (lines.length === 0 && !isFailedStatus(status)) {
+    if (lines.length === 0 && !isFailedStatus(status) && !errorMessage) {
       return null;
     }
 
     const statusLine = isFailedStatus(status) ? `Status: ${status}` : undefined;
+    const errorLine = errorMessage ? `Error: ${errorMessage}` : undefined;
     return {
       type: "text",
       timestamp: new Date(),
       data: {
-        text: ["[files]", statusLine, ...lines]
+        text: ["[files]", statusLine, errorLine, ...lines]
           .filter((line): line is string => {
             return line !== undefined && line.length > 0;
           })

--- a/turbo/apps/cli/src/lib/events/codex-event-parser.ts
+++ b/turbo/apps/cli/src/lib/events/codex-event-parser.ts
@@ -16,6 +16,7 @@ const MAX_FORMATTED_ARRAY_DEPTH = 4;
 const MAX_FORMATTED_OBJECT_FIELDS = 8;
 const MAX_FORMATTED_OBJECT_INSPECTED_FIELDS = 16;
 const MAX_FORMATTED_TEXT_LENGTH = 240;
+const MAX_ERROR_SIGNAL_DEPTH = 8;
 
 function asRecord(value: unknown): JsonRecord | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -109,6 +110,10 @@ function hasSignalValue(value: unknown, depth = 0): boolean {
 
   if (typeof value === "boolean") {
     return true;
+  }
+
+  if (depth >= MAX_ERROR_SIGNAL_DEPTH) {
+    return false;
   }
 
   if (Array.isArray(value)) {
@@ -222,8 +227,8 @@ function formatDetailSuffix(details: readonly string[]): string {
   return details.length > 0 ? ` (${details.join("; ")})` : "";
 }
 
-function extractErrorMessage(value: unknown): string | undefined {
-  if (!hasSignalValue(value)) {
+function extractErrorMessage(value: unknown, depth = 0): string | undefined {
+  if (!hasSignalValue(value, depth)) {
     return undefined;
   }
 
@@ -255,7 +260,11 @@ function extractErrorMessage(value: unknown): string | undefined {
     return `${message}${formatDetailSuffix(uniqueDetails)}`;
   }
 
-  const nested = extractErrorMessage(record.error);
+  if (depth >= MAX_ERROR_SIGNAL_DEPTH) {
+    return formatUnknownValue(record);
+  }
+
+  const nested = extractErrorMessage(record.error, depth + 1);
   if (nested) {
     return nested;
   }

--- a/turbo/apps/cli/src/lib/events/codex-event-parser.ts
+++ b/turbo/apps/cli/src/lib/events/codex-event-parser.ts
@@ -157,6 +157,10 @@ function formatDetailSuffix(details: readonly string[]): string {
 }
 
 function extractErrorMessage(value: unknown): string | undefined {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+
   const direct = trimmedStringValue(value);
   if (direct) {
     return direct;

--- a/turbo/apps/cli/src/lib/events/codex-event-parser.ts
+++ b/turbo/apps/cli/src/lib/events/codex-event-parser.ts
@@ -225,12 +225,44 @@ function getTurnStatus(event: JsonRecord): string | undefined {
   );
 }
 
+const FAILED_STATUSES = new Set([
+  "aborted",
+  "cancelled",
+  "canceled",
+  "declined",
+  "error",
+  "failed",
+  "interrupted",
+  "timed_out",
+  "timeout",
+]);
+
 function isFailedStatus(status: string | undefined): boolean {
-  return status === "failed" || status === "declined";
+  return status !== undefined && FAILED_STATUSES.has(status.toLowerCase());
 }
 
-function isTerminalFailedTurnStatus(status: string | undefined): boolean {
-  return status === "failed" || status === "interrupted";
+function hasExtractableError(value: unknown): boolean {
+  return extractErrorMessage(value) !== undefined;
+}
+
+function hasTurnCompletionError(
+  event: JsonRecord,
+  turn: JsonRecord | null,
+): boolean {
+  return (
+    (turn !== null && hasExtractableError(turn.error)) ||
+    hasExtractableError(event.error)
+  );
+}
+
+function getTurnCompletionErrorMessage(
+  event: JsonRecord,
+  turn: JsonRecord | null,
+): string | undefined {
+  return combineDistinctMessages(
+    turn !== null ? extractErrorMessage(turn.error) : undefined,
+    extractEventErrorMessage(event),
+  );
 }
 
 function getUsage(event: JsonRecord): JsonRecord {
@@ -398,11 +430,10 @@ export class CodexEventParser {
       getFirstNumber(event, ["duration_ms", "durationMs"]) ??
       0;
 
-    if (isTerminalFailedTurnStatus(status)) {
+    if (isFailedStatus(status) || hasTurnCompletionError(event, turn)) {
       const result =
-        (turn ? extractErrorMessage(turn.error) : undefined) ??
-        extractEventErrorMessage(event) ??
-        `Turn ${status}`;
+        getTurnCompletionErrorMessage(event, turn) ??
+        (status ? `Turn ${status}` : "Turn failed");
       return {
         type: "result",
         timestamp: new Date(),

--- a/turbo/apps/cli/src/lib/events/codex-event-parser.ts
+++ b/turbo/apps/cli/src/lib/events/codex-event-parser.ts
@@ -17,6 +17,8 @@ const MAX_FORMATTED_OBJECT_FIELDS = 8;
 const MAX_FORMATTED_OBJECT_INSPECTED_FIELDS = 16;
 const MAX_FORMATTED_TEXT_LENGTH = 240;
 const MAX_ERROR_SIGNAL_DEPTH = 8;
+const MAX_FORMATTED_PLAN_STEPS = 20;
+const MAX_FORMATTED_FILE_CHANGES = 20;
 
 function asRecord(value: unknown): JsonRecord | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -483,7 +485,8 @@ function formatPlanLines(plan: unknown): string[] {
   if (!Array.isArray(plan)) {
     return [];
   }
-  return plan
+  const lines = plan
+    .slice(0, MAX_FORMATTED_PLAN_STEPS)
     .map((step) => {
       const stepRecord = asRecord(step);
       if (!stepRecord) {
@@ -499,6 +502,11 @@ function formatPlanLines(plan: unknown): string[] {
     .filter((line): line is string => {
       return line !== undefined;
     });
+  const remaining = plan.length - MAX_FORMATTED_PLAN_STEPS;
+  if (remaining > 0) {
+    lines.push(`- ... +${remaining} more steps`);
+  }
+  return lines;
 }
 
 function formatGenericItem(item: JsonRecord): string | undefined {
@@ -937,6 +945,7 @@ export class CodexEventParser {
     const errorMessage = getItemErrorMessage(item);
     const lines = Array.isArray(item.changes)
       ? item.changes
+          .slice(0, MAX_FORMATTED_FILE_CHANGES)
           .map((change) => {
             const changeRecord = asRecord(change);
             if (!changeRecord) {
@@ -955,6 +964,14 @@ export class CodexEventParser {
             return line !== undefined;
           })
       : [];
+    if (
+      Array.isArray(item.changes) &&
+      item.changes.length > MAX_FORMATTED_FILE_CHANGES
+    ) {
+      lines.push(
+        `... +${item.changes.length - MAX_FORMATTED_FILE_CHANGES} more changes`,
+      );
+    }
 
     if (lines.length === 0 && !isFailedStatus(status) && !errorMessage) {
       return null;

--- a/turbo/apps/cli/src/lib/events/event-renderer.ts
+++ b/turbo/apps/cli/src/lib/events/event-renderer.ts
@@ -88,6 +88,9 @@ export class EventRenderer {
    * Format timestamp for display (without milliseconds, matching metrics format)
    */
   static formatTimestamp(timestamp: Date): string {
+    if (!Number.isFinite(timestamp.getTime())) {
+      return "invalid-date";
+    }
     return timestamp.toISOString().replace(/\.\d{3}Z$/, "Z");
   }
 

--- a/turbo/apps/cli/src/lib/events/event-renderer.ts
+++ b/turbo/apps/cli/src/lib/events/event-renderer.ts
@@ -75,6 +75,7 @@ export class EventRenderer {
     string,
     { toolUse: ToolUseData; prefix: string; rendered: boolean }
   >();
+  private ambiguousToolUseIds = new Set<string>();
   private options: EventRendererOptions;
   private lastEventType: string | null = null;
   private frameworkDisplayName: string = "Agent";
@@ -140,6 +141,7 @@ export class EventRenderer {
   flush(): void {
     this.renderPendingToolUses();
     this.pendingToolUse.clear();
+    this.ambiguousToolUseIds.clear();
   }
 
   private renderPendingToolUses(): void {
@@ -230,8 +232,14 @@ export class EventRenderer {
     // When not buffered, render immediately
     if (this.options.buffered !== false && toolUseId.length > 0) {
       const existing = this.pendingToolUse.get(toolUseId);
-      if (existing && !existing.rendered) {
-        this.renderToolUseOnly(existing.toolUse, existing.prefix);
+      if (existing || this.ambiguousToolUseIds.has(toolUseId)) {
+        if (existing && !existing.rendered) {
+          this.renderToolUseOnly(existing.toolUse, existing.prefix);
+        }
+        this.pendingToolUse.delete(toolUseId);
+        this.ambiguousToolUseIds.add(toolUseId);
+        this.renderToolUseOnly(toolUseData, prefix);
+        return;
       }
       this.pendingToolUse.set(toolUseId, {
         toolUse: toolUseData,
@@ -275,6 +283,14 @@ export class EventRenderer {
     const toolUseId = displayString(event.data.toolUseId);
     const result = displayString(event.data.result);
     const isError = Boolean(event.data.isError);
+
+    if (toolUseId.length > 0 && this.ambiguousToolUseIds.has(toolUseId)) {
+      const orphanToolUse = this.getToolUseFromResultEvent(event);
+      if (orphanToolUse) {
+        this.renderGroupedTool(orphanToolUse, { result, isError }, prefix);
+      }
+      return;
+    }
 
     const pending = this.pendingToolUse.get(toolUseId);
 

--- a/turbo/apps/cli/src/lib/events/event-renderer.ts
+++ b/turbo/apps/cli/src/lib/events/event-renderer.ts
@@ -42,6 +42,13 @@ interface EventRendererOptions {
   buffered?: boolean;
 }
 
+function recordData(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+  return value as Record<string, unknown>;
+}
+
 /**
  * Stateful event renderer that buffers tool_use events
  * and displays them grouped with their tool_result
@@ -199,7 +206,7 @@ export class EventRenderer {
   private handleToolUse(event: ParsedEvent, prefix: string): void {
     const toolUseId = String(event.data.toolUseId || "");
     const tool = String(event.data.tool || "");
-    const input = (event.data.input as Record<string, unknown>) || {};
+    const input = recordData(event.data.input);
     const toolUseData: ToolUseData = { tool, input };
 
     // When buffered (default), store for later grouping
@@ -262,8 +269,26 @@ export class EventRenderer {
         this.renderGroupedTool(pending.toolUse, { result, isError }, prefix);
       }
       this.pendingToolUse.delete(toolUseId);
+      return;
     }
-    // Skip orphan tool_results (no matching tool_use in buffer)
+
+    const orphanToolUse = this.getToolUseFromResultEvent(event);
+    if (orphanToolUse) {
+      this.renderGroupedTool(orphanToolUse, { result, isError }, prefix);
+    }
+    // Skip orphan tool_results without enough tool metadata to render.
+  }
+
+  private getToolUseFromResultEvent(event: ParsedEvent): ToolUseData | null {
+    const tool = event.data.tool;
+    if (typeof tool !== "string" || tool.length === 0) {
+      return null;
+    }
+
+    return {
+      tool,
+      input: recordData(event.data.input),
+    };
   }
 
   /**

--- a/turbo/apps/cli/src/lib/events/event-renderer.ts
+++ b/turbo/apps/cli/src/lib/events/event-renderer.ts
@@ -49,6 +49,10 @@ function recordData(value: unknown): Record<string, unknown> {
   return value as Record<string, unknown>;
 }
 
+function displayString(value: unknown): string {
+  return value === null || value === undefined ? "" : String(value);
+}
+
 /**
  * Stateful event renderer that buffers tool_use events
  * and displays them grouped with their tool_result
@@ -204,8 +208,8 @@ export class EventRenderer {
    * or render immediately (when not buffered, e.g., historical log viewing)
    */
   private handleToolUse(event: ParsedEvent, prefix: string): void {
-    const toolUseId = String(event.data.toolUseId || "");
-    const tool = String(event.data.tool || "");
+    const toolUseId = displayString(event.data.toolUseId);
+    const tool = displayString(event.data.tool);
     const input = recordData(event.data.input);
     const toolUseData: ToolUseData = { tool, input };
 
@@ -255,8 +259,8 @@ export class EventRenderer {
    * Handle tool_result event - lookup buffered tool_use and render grouped
    */
   private handleToolResult(event: ParsedEvent, prefix: string): void {
-    const toolUseId = String(event.data.toolUseId || "");
-    const result = String(event.data.result || "");
+    const toolUseId = displayString(event.data.toolUseId);
+    const result = displayString(event.data.result);
     const isError = Boolean(event.data.isError);
 
     const pending = this.pendingToolUse.get(toolUseId);
@@ -358,13 +362,13 @@ export class EventRenderer {
   }
 
   private renderInit(event: ParsedEvent, prefix: string): void {
-    const frameworkStr = String(event.data.framework || "claude-code");
+    const frameworkStr = displayString(event.data.framework) || "claude-code";
     const displayName = isSupportedFramework(frameworkStr)
       ? getFrameworkDisplayName(frameworkStr)
       : frameworkStr;
     this.frameworkDisplayName = displayName;
     console.log(prefix + chalk.bold(`▷ ${displayName} Started`));
-    console.log(`  Session: ${chalk.dim(String(event.data.sessionId || ""))}`);
+    console.log(`  Session: ${chalk.dim(displayString(event.data.sessionId))}`);
     if (event.data.model) {
       console.log(`  Model: ${chalk.dim(String(event.data.model))}`);
     }
@@ -380,7 +384,7 @@ export class EventRenderer {
   }
 
   private renderText(event: ParsedEvent, prefix: string): void {
-    const text = String(event.data.text || "");
+    const text = displayString(event.data.text);
     // Text events get a bullet prefix
     console.log(prefix + "● " + text);
     this.lastEventType = "text";
@@ -396,7 +400,7 @@ export class EventRenderer {
       );
     } else {
       console.log(prefix + chalk.bold(`◆ ${this.frameworkDisplayName} Failed`));
-      const result = String(event.data.result || "").trim();
+      const result = displayString(event.data.result).trim();
       if (result.length > 0) {
         const [firstLine, ...restLines] = result.split("\n");
         console.log(`  Error: ${chalk.red(firstLine)}`);

--- a/turbo/apps/cli/src/lib/events/event-renderer.ts
+++ b/turbo/apps/cli/src/lib/events/event-renderer.ts
@@ -108,6 +108,17 @@ export class EventRenderer {
   }
 
   /**
+   * Render any buffered display state that cannot wait for a future event.
+   */
+  flush(): void {
+    const pending = Array.from(this.pendingToolUse.values());
+    this.pendingToolUse.clear();
+    for (const { toolUse, prefix } of pending) {
+      this.renderToolUseOnly(toolUse, prefix);
+    }
+  }
+
+  /**
    * Render run completed state
    * Note: This is run lifecycle status, not an event
    */
@@ -183,6 +194,10 @@ export class EventRenderer {
     // When buffered (default), store for later grouping
     // When not buffered, render immediately
     if (this.options.buffered !== false) {
+      const existing = this.pendingToolUse.get(toolUseId);
+      if (existing) {
+        this.renderToolUseOnly(existing.toolUse, existing.prefix);
+      }
       this.pendingToolUse.set(toolUseId, { toolUse: toolUseData, prefix });
     } else {
       // Non-buffered: render tool_use header immediately
@@ -312,6 +327,14 @@ export class EventRenderer {
       );
     } else {
       console.log(prefix + chalk.bold(`◆ ${this.frameworkDisplayName} Failed`));
+      const result = String(event.data.result || "").trim();
+      if (result.length > 0) {
+        const [firstLine, ...restLines] = result.split("\n");
+        console.log(`  Error: ${chalk.red(firstLine)}`);
+        for (const line of restLines) {
+          console.log(`         ${chalk.red(line)}`);
+        }
+      }
     }
 
     const durationMs = Number(event.data.durationMs || 0);

--- a/turbo/apps/cli/src/lib/events/event-renderer.ts
+++ b/turbo/apps/cli/src/lib/events/event-renderer.ts
@@ -393,13 +393,17 @@ export class EventRenderer {
   private renderResult(event: ParsedEvent, prefix: string): void {
     console.log(); // Spacing before result
     const success = Boolean(event.data.success);
+    const eventFramework = displayString(event.data.framework);
+    const displayName =
+      eventFramework && isSupportedFramework(eventFramework)
+        ? getFrameworkDisplayName(eventFramework)
+        : eventFramework || this.frameworkDisplayName;
+    this.frameworkDisplayName = displayName;
 
     if (success) {
-      console.log(
-        prefix + chalk.bold(`◆ ${this.frameworkDisplayName} Completed`),
-      );
+      console.log(prefix + chalk.bold(`◆ ${displayName} Completed`));
     } else {
-      console.log(prefix + chalk.bold(`◆ ${this.frameworkDisplayName} Failed`));
+      console.log(prefix + chalk.bold(`◆ ${displayName} Failed`));
       const result = displayString(event.data.result).trim();
       if (result.length > 0) {
         const [firstLine, ...restLines] = result.split("\n");

--- a/turbo/apps/cli/src/lib/events/event-renderer.ts
+++ b/turbo/apps/cli/src/lib/events/event-renderer.ts
@@ -54,6 +54,11 @@ function displayString(value: unknown): string {
   return value === null || value === undefined ? "" : String(value);
 }
 
+function displayNumber(value: unknown): number {
+  const number = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(number) ? number : 0;
+}
+
 /**
  * Stateful event renderer that buffers tool_use events
  * and displays them grouped with their tool_result
@@ -415,17 +420,17 @@ export class EventRenderer {
       }
     }
 
-    const durationMs = Number(event.data.durationMs || 0);
+    const durationMs = displayNumber(event.data.durationMs);
     const durationSec = (durationMs / 1000).toFixed(1);
     console.log(`  Duration: ${chalk.dim(durationSec + "s")}`);
 
-    const numTurns = Number(event.data.numTurns || 0);
+    const numTurns = displayNumber(event.data.numTurns);
     console.log(`  Turns: ${chalk.dim(String(numTurns))}`);
 
     const usage = event.data.usage as Record<string, unknown>;
     if (usage && typeof usage === "object") {
-      const inputTokens = Number(usage.input_tokens || 0);
-      const outputTokens = Number(usage.output_tokens || 0);
+      const inputTokens = displayNumber(usage.input_tokens);
+      const outputTokens = displayNumber(usage.output_tokens);
 
       const formatTokens = (count: number): string => {
         if (count >= 1000) {

--- a/turbo/apps/cli/src/lib/events/event-renderer.ts
+++ b/turbo/apps/cli/src/lib/events/event-renderer.ts
@@ -76,6 +76,7 @@ export class EventRenderer {
     { toolUse: ToolUseData; prefix: string; rendered: boolean }
   >();
   private ambiguousToolUseIds = new Set<string>();
+  private ambiguousRenderedToolUse = new Map<string, ToolUseData>();
   private options: EventRendererOptions;
   private lastEventType: string | null = null;
   private frameworkDisplayName: string = "Agent";
@@ -142,6 +143,7 @@ export class EventRenderer {
     this.renderPendingToolUses();
     this.pendingToolUse.clear();
     this.ambiguousToolUseIds.clear();
+    this.ambiguousRenderedToolUse.clear();
   }
 
   private renderPendingToolUses(): void {
@@ -239,6 +241,7 @@ export class EventRenderer {
         this.pendingToolUse.delete(toolUseId);
         this.ambiguousToolUseIds.add(toolUseId);
         this.renderToolUseOnly(toolUseData, prefix);
+        this.ambiguousRenderedToolUse.set(toolUseId, toolUseData);
         return;
       }
       this.pendingToolUse.set(toolUseId, {
@@ -286,6 +289,15 @@ export class EventRenderer {
 
     if (toolUseId.length > 0 && this.ambiguousToolUseIds.has(toolUseId)) {
       const orphanToolUse = this.getToolUseFromResultEvent(event);
+      const renderedToolUse = this.ambiguousRenderedToolUse.get(toolUseId);
+      if (
+        renderedToolUse &&
+        orphanToolUse &&
+        this.hasSameToolHeader(renderedToolUse, orphanToolUse)
+      ) {
+        this.renderToolResultOnly(renderedToolUse, { result, isError }, prefix);
+        return;
+      }
       if (orphanToolUse) {
         this.renderGroupedTool(orphanToolUse, { result, isError }, prefix);
       }
@@ -322,6 +334,12 @@ export class EventRenderer {
       tool,
       input: recordData(event.data.input),
     };
+  }
+
+  private hasSameToolHeader(first: ToolUseData, second: ToolUseData): boolean {
+    return (
+      formatToolHeader(first).join("\n") === formatToolHeader(second).join("\n")
+    );
   }
 
   /**

--- a/turbo/apps/cli/src/lib/events/event-renderer.ts
+++ b/turbo/apps/cli/src/lib/events/event-renderer.ts
@@ -204,7 +204,7 @@ export class EventRenderer {
 
     // When buffered (default), store for later grouping
     // When not buffered, render immediately
-    if (this.options.buffered !== false) {
+    if (this.options.buffered !== false && toolUseId.length > 0) {
       const existing = this.pendingToolUse.get(toolUseId);
       if (existing && !existing.rendered) {
         this.renderToolUseOnly(existing.toolUse, existing.prefix);
@@ -215,7 +215,7 @@ export class EventRenderer {
         rendered: false,
       });
     } else {
-      // Non-buffered: render tool_use header immediately
+      // Non-buffered, or malformed tool_use without a stable id: render immediately.
       this.renderToolUseOnly(toolUseData, prefix);
     }
   }

--- a/turbo/apps/cli/src/lib/events/event-renderer.ts
+++ b/turbo/apps/cli/src/lib/events/event-renderer.ts
@@ -90,9 +90,11 @@ export class EventRenderer {
 
     switch (event.type) {
       case "init":
+        this.flushPendingToolUses();
         this.renderInit(event, timestampPrefix);
         break;
       case "text":
+        this.flushPendingToolUses();
         this.renderText(event, timestampPrefix);
         break;
       case "tool_use":
@@ -102,6 +104,7 @@ export class EventRenderer {
         this.handleToolResult(event, timestampPrefix);
         break;
       case "result":
+        this.flushPendingToolUses();
         this.renderResult(event, timestampPrefix);
         break;
     }
@@ -111,6 +114,10 @@ export class EventRenderer {
    * Render any buffered display state that cannot wait for a future event.
    */
   flush(): void {
+    this.flushPendingToolUses();
+  }
+
+  private flushPendingToolUses(): void {
     const pending = Array.from(this.pendingToolUse.values());
     this.pendingToolUse.clear();
     for (const { toolUse, prefix } of pending) {

--- a/turbo/apps/cli/src/lib/events/event-renderer.ts
+++ b/turbo/apps/cli/src/lib/events/event-renderer.ts
@@ -76,7 +76,7 @@ export class EventRenderer {
     { toolUse: ToolUseData; prefix: string; rendered: boolean }
   >();
   private ambiguousToolUseIds = new Set<string>();
-  private ambiguousRenderedToolUse = new Map<string, ToolUseData>();
+  private ambiguousRenderedToolUses = new Map<string, ToolUseData[]>();
   private options: EventRendererOptions;
   private lastEventType: string | null = null;
   private frameworkDisplayName: string = "Agent";
@@ -143,7 +143,7 @@ export class EventRenderer {
     this.renderPendingToolUses();
     this.pendingToolUse.clear();
     this.ambiguousToolUseIds.clear();
-    this.ambiguousRenderedToolUse.clear();
+    this.ambiguousRenderedToolUses.clear();
   }
 
   private renderPendingToolUses(): void {
@@ -235,13 +235,16 @@ export class EventRenderer {
     if (this.options.buffered !== false && toolUseId.length > 0) {
       const existing = this.pendingToolUse.get(toolUseId);
       if (existing || this.ambiguousToolUseIds.has(toolUseId)) {
-        if (existing && !existing.rendered) {
-          this.renderToolUseOnly(existing.toolUse, existing.prefix);
+        if (existing) {
+          if (!existing.rendered) {
+            this.renderToolUseOnly(existing.toolUse, existing.prefix);
+          }
+          this.rememberAmbiguousRenderedToolUse(toolUseId, existing.toolUse);
         }
         this.pendingToolUse.delete(toolUseId);
         this.ambiguousToolUseIds.add(toolUseId);
         this.renderToolUseOnly(toolUseData, prefix);
-        this.ambiguousRenderedToolUse.set(toolUseId, toolUseData);
+        this.rememberAmbiguousRenderedToolUse(toolUseId, toolUseData);
         return;
       }
       this.pendingToolUse.set(toolUseId, {
@@ -289,12 +292,10 @@ export class EventRenderer {
 
     if (toolUseId.length > 0 && this.ambiguousToolUseIds.has(toolUseId)) {
       const orphanToolUse = this.getToolUseFromResultEvent(event);
-      const renderedToolUse = this.ambiguousRenderedToolUse.get(toolUseId);
-      if (
-        renderedToolUse &&
-        orphanToolUse &&
-        this.hasSameToolHeader(renderedToolUse, orphanToolUse)
-      ) {
+      const renderedToolUse = orphanToolUse
+        ? this.getMatchingAmbiguousRenderedToolUse(toolUseId, orphanToolUse)
+        : undefined;
+      if (renderedToolUse) {
         this.renderToolResultOnly(renderedToolUse, { result, isError }, prefix);
         return;
       }
@@ -334,6 +335,39 @@ export class EventRenderer {
       tool,
       input: recordData(event.data.input),
     };
+  }
+
+  private rememberAmbiguousRenderedToolUse(
+    toolUseId: string,
+    toolUse: ToolUseData,
+  ): void {
+    const renderedToolUses = this.ambiguousRenderedToolUses.get(toolUseId);
+    if (renderedToolUses) {
+      renderedToolUses.push(toolUse);
+      return;
+    }
+    this.ambiguousRenderedToolUses.set(toolUseId, [toolUse]);
+  }
+
+  private getMatchingAmbiguousRenderedToolUse(
+    toolUseId: string,
+    toolUse: ToolUseData,
+  ): ToolUseData | undefined {
+    const renderedToolUses = this.ambiguousRenderedToolUses.get(toolUseId);
+    if (!renderedToolUses) {
+      return undefined;
+    }
+
+    for (let index = renderedToolUses.length - 1; index >= 0; index -= 1) {
+      const renderedToolUse = renderedToolUses[index];
+      if (
+        renderedToolUse !== undefined &&
+        this.hasSameToolHeader(renderedToolUse, toolUse)
+      ) {
+        return renderedToolUse;
+      }
+    }
+    return undefined;
   }
 
   private hasSameToolHeader(first: ToolUseData, second: ToolUseData): boolean {

--- a/turbo/apps/cli/src/lib/events/event-renderer.ts
+++ b/turbo/apps/cli/src/lib/events/event-renderer.ts
@@ -49,7 +49,7 @@ interface EventRendererOptions {
 export class EventRenderer {
   private pendingToolUse = new Map<
     string,
-    { toolUse: ToolUseData; prefix: string }
+    { toolUse: ToolUseData; prefix: string; rendered: boolean }
   >();
   private options: EventRendererOptions;
   private lastEventType: string | null = null;
@@ -90,11 +90,11 @@ export class EventRenderer {
 
     switch (event.type) {
       case "init":
-        this.flushPendingToolUses();
+        this.renderPendingToolUses();
         this.renderInit(event, timestampPrefix);
         break;
       case "text":
-        this.flushPendingToolUses();
+        this.renderPendingToolUses();
         this.renderText(event, timestampPrefix);
         break;
       case "tool_use":
@@ -104,7 +104,7 @@ export class EventRenderer {
         this.handleToolResult(event, timestampPrefix);
         break;
       case "result":
-        this.flushPendingToolUses();
+        this.renderPendingToolUses();
         this.renderResult(event, timestampPrefix);
         break;
     }
@@ -114,14 +114,18 @@ export class EventRenderer {
    * Render any buffered display state that cannot wait for a future event.
    */
   flush(): void {
-    this.flushPendingToolUses();
+    this.renderPendingToolUses();
+    this.pendingToolUse.clear();
   }
 
-  private flushPendingToolUses(): void {
-    const pending = Array.from(this.pendingToolUse.values());
-    this.pendingToolUse.clear();
-    for (const { toolUse, prefix } of pending) {
+  private renderPendingToolUses(): void {
+    for (const pending of this.pendingToolUse.values()) {
+      if (pending.rendered) {
+        continue;
+      }
+      const { toolUse, prefix } = pending;
       this.renderToolUseOnly(toolUse, prefix);
+      pending.rendered = true;
     }
   }
 
@@ -202,10 +206,14 @@ export class EventRenderer {
     // When not buffered, render immediately
     if (this.options.buffered !== false) {
       const existing = this.pendingToolUse.get(toolUseId);
-      if (existing) {
+      if (existing && !existing.rendered) {
         this.renderToolUseOnly(existing.toolUse, existing.prefix);
       }
-      this.pendingToolUse.set(toolUseId, { toolUse: toolUseData, prefix });
+      this.pendingToolUse.set(toolUseId, {
+        toolUse: toolUseData,
+        prefix,
+        rendered: false,
+      });
     } else {
       // Non-buffered: render tool_use header immediately
       this.renderToolUseOnly(toolUseData, prefix);
@@ -247,8 +255,12 @@ export class EventRenderer {
     const pending = this.pendingToolUse.get(toolUseId);
 
     if (pending) {
-      // Render grouped output
-      this.renderGroupedTool(pending.toolUse, { result, isError }, prefix);
+      if (pending.rendered) {
+        this.renderToolResultOnly(pending.toolUse, { result, isError }, prefix);
+      } else {
+        // Render grouped output
+        this.renderGroupedTool(pending.toolUse, { result, isError }, prefix);
+      }
       this.pendingToolUse.delete(toolUseId);
     }
     // Skip orphan tool_results (no matching tool_use in buffer)
@@ -292,6 +304,31 @@ export class EventRenderer {
       console.log(cont + line);
     }
     console.log(); // Empty line after each group
+    this.lastEventType = "tool";
+  }
+
+  private renderToolResultOnly(
+    toolUse: ToolUseData,
+    result: ToolResultData,
+    prefix: string,
+  ): void {
+    if (this.lastEventType === "text") {
+      console.log();
+    }
+
+    const verbose = this.options.verbose ?? false;
+    const cont = this.getContinuationPrefix();
+    const resultLines = formatToolResult(toolUse, result, verbose);
+
+    for (let i = 0; i < resultLines.length; i++) {
+      const line = resultLines[i];
+      if (i === 0) {
+        console.log(prefix + cont + line);
+      } else {
+        console.log(cont + line);
+      }
+    }
+    console.log();
     this.lastEventType = "tool";
   }
 

--- a/turbo/apps/cli/src/lib/events/event-renderer.ts
+++ b/turbo/apps/cli/src/lib/events/event-renderer.ts
@@ -15,6 +15,7 @@ import {
   getFrameworkDisplayName,
   isSupportedFramework,
 } from "@vm0/core/frameworks";
+import { formatIsoTimestamp } from "../utils/time-format";
 import {
   formatToolHeader,
   formatToolResult,
@@ -88,10 +89,7 @@ export class EventRenderer {
    * Format timestamp for display (without milliseconds, matching metrics format)
    */
   static formatTimestamp(timestamp: Date): string {
-    if (!Number.isFinite(timestamp.getTime())) {
-      return "invalid-date";
-    }
-    return timestamp.toISOString().replace(/\.\d{3}Z$/, "Z");
+    return formatIsoTimestamp(timestamp);
   }
 
   /**

--- a/turbo/apps/cli/src/lib/events/event-renderer.ts
+++ b/turbo/apps/cli/src/lib/events/event-renderer.ts
@@ -54,9 +54,16 @@ function displayString(value: unknown): string {
   return value === null || value === undefined ? "" : String(value);
 }
 
-function displayNumber(value: unknown): number {
-  const number = typeof value === "number" ? value : Number(value);
-  return Number.isFinite(number) ? number : 0;
+function displayNonNegativeNumber(value: unknown): number {
+  const number =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && value.trim().length > 0
+        ? Number(value)
+        : undefined;
+  return number !== undefined && Number.isFinite(number) && number >= 0
+    ? number
+    : 0;
 }
 
 /**
@@ -420,17 +427,17 @@ export class EventRenderer {
       }
     }
 
-    const durationMs = displayNumber(event.data.durationMs);
+    const durationMs = displayNonNegativeNumber(event.data.durationMs);
     const durationSec = (durationMs / 1000).toFixed(1);
     console.log(`  Duration: ${chalk.dim(durationSec + "s")}`);
 
-    const numTurns = displayNumber(event.data.numTurns);
+    const numTurns = displayNonNegativeNumber(event.data.numTurns);
     console.log(`  Turns: ${chalk.dim(String(numTurns))}`);
 
     const usage = event.data.usage as Record<string, unknown>;
     if (usage && typeof usage === "object") {
-      const inputTokens = displayNumber(usage.input_tokens);
-      const outputTokens = displayNumber(usage.output_tokens);
+      const inputTokens = displayNonNegativeNumber(usage.input_tokens);
+      const outputTokens = displayNonNegativeNumber(usage.output_tokens);
 
       const formatTokens = (count: number): string => {
         if (count >= 1000) {

--- a/turbo/apps/cli/src/lib/events/event-stream-normalizer.ts
+++ b/turbo/apps/cli/src/lib/events/event-stream-normalizer.ts
@@ -71,6 +71,22 @@ function combineDistinctMessages(
   return messages.length > 0 ? messages.join("\n") : undefined;
 }
 
+function attachFramework(
+  parsed: ParsedEvent | null,
+  framework: string | undefined,
+): ParsedEvent | null {
+  if (!parsed || !framework || parsed.data.framework !== undefined) {
+    return parsed;
+  }
+  return {
+    ...parsed,
+    data: {
+      ...parsed.data,
+      framework,
+    },
+  };
+}
+
 /**
  * Preserves single-event parser behavior while applying stream-aware
  * presentation fixes that require one-event lookahead.
@@ -86,7 +102,10 @@ export class EventStreamNormalizer {
     const isCodex = framework === "codex";
     const rawRecord = asRecord(rawEvent);
     const eventType = getEventType(rawRecord);
-    const parsed = rawRecord ? parseEvent(rawRecord, framework) : null;
+    const parsed = attachFramework(
+      rawRecord ? parseEvent(rawRecord, framework) : null,
+      framework,
+    );
     if (parsed && timestamp) {
       parsed.timestamp = timestamp;
     }

--- a/turbo/apps/cli/src/lib/events/event-stream-normalizer.ts
+++ b/turbo/apps/cli/src/lib/events/event-stream-normalizer.ts
@@ -59,13 +59,21 @@ function combineDistinctMessages(
     if (!message) {
       continue;
     }
-    if (
-      messages.some((existing) => {
-        return existing === message || existing.includes(message);
-      })
-    ) {
+    const containingIndex = messages.findIndex((existing) => {
+      return existing === message || existing.includes(message);
+    });
+    if (containingIndex !== -1) {
       continue;
     }
+
+    const containedIndex = messages.findIndex((existing) => {
+      return message.includes(existing);
+    });
+    if (containedIndex !== -1) {
+      messages[containedIndex] = message;
+      continue;
+    }
+
     messages.push(message);
   }
   return messages.length > 0 ? messages.join("\n") : undefined;

--- a/turbo/apps/cli/src/lib/events/event-stream-normalizer.ts
+++ b/turbo/apps/cli/src/lib/events/event-stream-normalizer.ts
@@ -137,7 +137,8 @@ export class EventStreamNormalizer {
         const pendingTurnId = getParsedTurnId(this.pendingCodexError);
         const terminalTurnId = getParsedTurnId(parsed);
         const shouldCollapse =
-          !pendingTurnId || !terminalTurnId || pendingTurnId === terminalTurnId;
+          !pendingTurnId ||
+          (terminalTurnId !== undefined && pendingTurnId === terminalTurnId);
 
         if (shouldCollapse) {
           const mergedResult = combineDistinctMessages(

--- a/turbo/apps/cli/src/lib/events/event-stream-normalizer.ts
+++ b/turbo/apps/cli/src/lib/events/event-stream-normalizer.ts
@@ -15,6 +15,62 @@ function getEventType(
   return typeof eventType === "string" ? eventType : undefined;
 }
 
+function stringData(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}
+
+function isFailureResult(event: ParsedEvent | null): event is ParsedEvent {
+  return event?.type === "result" && event.data.success === false;
+}
+
+function isTopLevelCodexError(
+  eventType: string | undefined,
+  parsed: ParsedEvent | null,
+): boolean {
+  return eventType === "error" && isFailureResult(parsed);
+}
+
+function isTerminalCodexFailure(
+  eventType: string | undefined,
+  parsed: ParsedEvent | null,
+): parsed is ParsedEvent {
+  if (!isFailureResult(parsed)) {
+    return false;
+  }
+  return eventType === "turn.failed" || eventType === "turn.completed";
+}
+
+function getParsedTurnId(event: ParsedEvent): string | undefined {
+  return stringData(event.data.turnId);
+}
+
+function getResultText(event: ParsedEvent): string | undefined {
+  return stringData(event.data.result);
+}
+
+function combineDistinctMessages(
+  first: string | undefined,
+  second: string | undefined,
+): string | undefined {
+  const messages: string[] = [];
+  for (const message of [first, second]) {
+    if (!message) {
+      continue;
+    }
+    if (
+      messages.some((existing) => {
+        return existing === message || existing.includes(message);
+      })
+    ) {
+      continue;
+    }
+    messages.push(message);
+  }
+  return messages.length > 0 ? messages.join("\n") : undefined;
+}
+
 /**
  * Preserves single-event parser behavior while applying stream-aware
  * presentation fixes that require one-event lookahead.
@@ -43,15 +99,45 @@ export class EventStreamNormalizer {
       return output;
     }
 
-    if (eventType === "error" && parsed?.type === "result") {
+    if (isTopLevelCodexError(eventType, parsed)) {
       const output = this.flush();
       this.pendingCodexError = parsed;
       return output;
     }
 
-    if (eventType === "turn.failed") {
+    if (isTerminalCodexFailure(eventType, parsed)) {
+      if (this.pendingCodexError) {
+        const pendingTurnId = getParsedTurnId(this.pendingCodexError);
+        const terminalTurnId = getParsedTurnId(parsed);
+        const shouldCollapse =
+          pendingTurnId && terminalTurnId
+            ? pendingTurnId === terminalTurnId
+            : !pendingTurnId && !terminalTurnId;
+
+        if (shouldCollapse) {
+          const mergedResult = combineDistinctMessages(
+            getResultText(this.pendingCodexError),
+            getResultText(parsed),
+          );
+          this.pendingCodexError = null;
+          return [
+            {
+              ...parsed,
+              data: {
+                ...parsed.data,
+                ...(mergedResult ? { result: mergedResult } : {}),
+              },
+            },
+          ];
+        }
+
+        const output = this.flush();
+        output.push(parsed);
+        return output;
+      }
+
       this.pendingCodexError = null;
-      return parsed ? [parsed] : [];
+      return [parsed];
     }
 
     const output = this.flush();

--- a/turbo/apps/cli/src/lib/events/event-stream-normalizer.ts
+++ b/turbo/apps/cli/src/lib/events/event-stream-normalizer.ts
@@ -137,9 +137,7 @@ export class EventStreamNormalizer {
         const pendingTurnId = getParsedTurnId(this.pendingCodexError);
         const terminalTurnId = getParsedTurnId(parsed);
         const shouldCollapse =
-          pendingTurnId && terminalTurnId
-            ? pendingTurnId === terminalTurnId
-            : !pendingTurnId && !terminalTurnId;
+          !pendingTurnId || !terminalTurnId || pendingTurnId === terminalTurnId;
 
         if (shouldCollapse) {
           const mergedResult = combineDistinctMessages(

--- a/turbo/apps/cli/src/lib/events/event-stream-normalizer.ts
+++ b/turbo/apps/cli/src/lib/events/event-stream-normalizer.ts
@@ -159,10 +159,12 @@ export class EventStreamNormalizer {
       return [parsed];
     }
 
-    const output = this.flush();
-    if (parsed) {
-      output.push(parsed);
+    if (!parsed) {
+      return [];
     }
+
+    const output = this.flush();
+    output.push(parsed);
     return output;
   }
 

--- a/turbo/apps/cli/src/lib/events/tool-formatters.ts
+++ b/turbo/apps/cli/src/lib/events/tool-formatters.ts
@@ -5,6 +5,8 @@
 
 import chalk from "chalk";
 
+const MAX_FORMATTED_TODOS = 20;
+
 export interface ToolUseData {
   tool: string;
   input: Record<string, unknown>;
@@ -369,14 +371,22 @@ function formatTodoList(input: Record<string, unknown>): string[] {
     return lines;
   }
 
-  for (let i = 0; i < todos.length; i++) {
-    const todo = recordValue(todos[i]);
+  const displayedTodos = todos.slice(0, MAX_FORMATTED_TODOS);
+  for (let i = 0; i < displayedTodos.length; i++) {
+    const todo = recordValue(displayedTodos[i]);
     const content = nonEmptyDisplayValue(todo?.content) ?? "Unknown task";
     const status = nonEmptyDisplayValue(todo?.status) ?? "pending";
     const icon = getTodoStatusIcon(status);
     const styledContent = formatTodoContent(content, status);
     const prefix = i === 0 ? "└ " : "  ";
     lines.push(`${prefix}${icon} ${styledContent}`);
+  }
+
+  const remaining = todos.length - MAX_FORMATTED_TODOS;
+  if (remaining > 0) {
+    lines.push(
+      `  ${chalk.dim(`… +${remaining} ${pluralize(remaining, "task", "tasks")} (vm0 logs <runId> to see all)`)}`,
+    );
   }
 
   return lines;

--- a/turbo/apps/cli/src/lib/events/tool-formatters.ts
+++ b/turbo/apps/cli/src/lib/events/tool-formatters.ts
@@ -30,6 +30,22 @@ function truncate(text: string, maxLength: number): string {
   return text.slice(0, maxLength - 3) + "...";
 }
 
+function displayValue(value: unknown): string {
+  return value === null || value === undefined ? "" : String(value);
+}
+
+function nonEmptyDisplayValue(value: unknown): string | undefined {
+  const display = displayValue(value);
+  return display.length > 0 ? display : undefined;
+}
+
+function recordValue(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
 /**
  * Format the header line for a tool (e.g., "Read src/lib/api.ts")
  */
@@ -49,31 +65,31 @@ const toolHeadlineFormatters: Record<
   (input: Record<string, unknown>) => string
 > = {
   Read: (input) => {
-    return `Read${chalk.dim(`(${String(input.file_path || "")})`)}`;
+    return `Read${chalk.dim(`(${displayValue(input.file_path)})`)}`;
   },
   Edit: (input) => {
-    return `Edit${chalk.dim(`(${String(input.file_path || "")})`)}`;
+    return `Edit${chalk.dim(`(${displayValue(input.file_path)})`)}`;
   },
   Write: (input) => {
-    return `Write${chalk.dim(`(${String(input.file_path || "")})`)}`;
+    return `Write${chalk.dim(`(${displayValue(input.file_path)})`)}`;
   },
   Bash: (input) => {
-    return `Bash${chalk.dim(`(${truncate(String(input.command || ""), 60)})`)}`;
+    return `Bash${chalk.dim(`(${truncate(displayValue(input.command), 60)})`)}`;
   },
   Glob: (input) => {
-    return `Glob${chalk.dim(`(${String(input.pattern || "")})`)}`;
+    return `Glob${chalk.dim(`(${displayValue(input.pattern)})`)}`;
   },
   Grep: (input) => {
-    return `Grep${chalk.dim(`(${String(input.pattern || "")})`)}`;
+    return `Grep${chalk.dim(`(${displayValue(input.pattern)})`)}`;
   },
   Task: (input) => {
-    return `Task${chalk.dim(`(${truncate(String(input.description || ""), 60)})`)}`;
+    return `Task${chalk.dim(`(${truncate(displayValue(input.description), 60)})`)}`;
   },
   WebFetch: (input) => {
-    return `WebFetch${chalk.dim(`(${truncate(String(input.url || ""), 60)})`)}`;
+    return `WebFetch${chalk.dim(`(${truncate(displayValue(input.url), 60)})`)}`;
   },
   WebSearch: (input) => {
-    return `WebSearch${chalk.dim(`(${truncate(String(input.query || ""), 60)})`)}`;
+    return `WebSearch${chalk.dim(`(${truncate(displayValue(input.query), 60)})`)}`;
   },
   TodoWrite: () => {
     return "TodoWrite";
@@ -246,7 +262,7 @@ function formatWritePreview(
   verbose: boolean,
 ): string[] {
   const lines: string[] = [];
-  const content = String(input.content || "");
+  const content = displayValue(input.content);
   const contentLines = content.split("\n");
   const totalLines = contentLines.length;
 
@@ -282,8 +298,8 @@ function formatEditDiff(
   verbose: boolean,
 ): string[] {
   const lines: string[] = [];
-  const oldString = String(input.old_string || "");
-  const newString = String(input.new_string || "");
+  const oldString = displayValue(input.old_string);
+  const newString = displayValue(input.new_string);
 
   const oldLines = oldString.split("\n");
   const newLines = newString.split("\n");
@@ -341,23 +357,17 @@ function formatEditDiff(
  */
 function formatTodoList(input: Record<string, unknown>): string[] {
   const lines: string[] = [];
-  const todos = input.todos as
-    | Array<{
-        id?: string;
-        content?: string;
-        status?: string;
-      }>
-    | undefined;
+  const todos = input.todos;
 
-  if (!todos || !Array.isArray(todos)) {
+  if (!Array.isArray(todos)) {
     lines.push("└ ✓ Done");
     return lines;
   }
 
   for (let i = 0; i < todos.length; i++) {
-    const todo = todos[i]!;
-    const content = todo.content || "Unknown task";
-    const status = todo.status || "pending";
+    const todo = recordValue(todos[i]);
+    const content = nonEmptyDisplayValue(todo?.content) ?? "Unknown task";
+    const status = nonEmptyDisplayValue(todo?.status) ?? "pending";
     const icon = getTodoStatusIcon(status);
     const styledContent = formatTodoContent(content, status);
     const prefix = i === 0 ? "└ " : "  ";

--- a/turbo/apps/cli/src/lib/events/tool-formatters.ts
+++ b/turbo/apps/cli/src/lib/events/tool-formatters.ts
@@ -364,6 +364,11 @@ function formatTodoList(input: Record<string, unknown>): string[] {
     return lines;
   }
 
+  if (todos.length === 0) {
+    lines.push("└ ✓ Done");
+    return lines;
+  }
+
   for (let i = 0; i < todos.length; i++) {
     const todo = recordValue(todos[i]);
     const content = nonEmptyDisplayValue(todo?.content) ?? "Unknown task";

--- a/turbo/apps/cli/src/lib/events/tool-formatters.ts
+++ b/turbo/apps/cli/src/lib/events/tool-formatters.ts
@@ -205,13 +205,9 @@ function formatReadContent(resultText: string, verbose: boolean): string[] {
     }
   }
 
-  // If no line numbers found, use raw content (fallback for plain text results)
-  const displayLines =
-    contentLines.length > 0
-      ? contentLines
-      : rawLines.filter((line) => {
-          return line.trim().length > 0;
-        });
+  // If no line numbers found, use raw content so whitespace-only files are not
+  // misreported as empty.
+  const displayLines = contentLines.length > 0 ? contentLines : rawLines;
   const totalLines = displayLines.length;
 
   if (totalLines === 0) {

--- a/turbo/apps/cli/src/lib/events/tool-formatters.ts
+++ b/turbo/apps/cli/src/lib/events/tool-formatters.ts
@@ -100,32 +100,15 @@ export function formatToolResult(
   const { result: resultText, isError } = result;
   const lines: string[] = [];
 
-  // Special handling for Read - strip line numbers and filter system content
-  if (tool === "Read" && !isError && resultText) {
-    const readLines = formatReadContent(resultText, verbose);
-    lines.push(...readLines);
-    return lines;
-  }
-
-  // Special handling for TodoWrite - show the task list
-  if (tool === "TodoWrite" && !isError) {
-    const todoLines = formatTodoList(input);
-    lines.push(...todoLines);
-    return lines;
-  }
-
-  // Special handling for Edit - show diff format
-  if (tool === "Edit" && !isError) {
-    const editLines = formatEditDiff(input, verbose);
-    lines.push(...editLines);
-    return lines;
-  }
-
-  // Special handling for Write - show content preview
-  if (tool === "Write" && !isError) {
-    const writeLines = formatWritePreview(input, verbose);
-    lines.push(...writeLines);
-    return lines;
+  const specialLines = formatSpecialToolResult(
+    tool,
+    input,
+    resultText,
+    isError,
+    verbose,
+  );
+  if (specialLines) {
+    return specialLines;
   }
 
   // Error case: show error message
@@ -164,6 +147,42 @@ export function formatToolResult(
   }
 
   return lines;
+}
+
+function formatSpecialToolResult(
+  tool: string,
+  input: Record<string, unknown>,
+  resultText: string,
+  isError: boolean,
+  verbose: boolean,
+): string[] | null {
+  if (isError) {
+    return null;
+  }
+
+  if (tool === "Read" && resultText) {
+    return formatReadContent(resultText, verbose);
+  }
+  if (tool === "TodoWrite") {
+    return formatTodoList(input);
+  }
+  if (tool === "Edit" && hasClaudeEditInput(input)) {
+    return formatEditDiff(input, verbose);
+  }
+  if (tool === "Write" && hasClaudeWriteInput(input)) {
+    return formatWritePreview(input, verbose);
+  }
+  return null;
+}
+
+function hasClaudeEditInput(input: Record<string, unknown>): boolean {
+  return (
+    typeof input.old_string === "string" || typeof input.new_string === "string"
+  );
+}
+
+function hasClaudeWriteInput(input: Record<string, unknown>): boolean {
+  return typeof input.content === "string";
 }
 
 /**

--- a/turbo/apps/cli/src/lib/utils/log-pagination.ts
+++ b/turbo/apps/cli/src/lib/utils/log-pagination.ts
@@ -81,10 +81,6 @@ export async function collectLogItems<T>(
 
     collected.push(...page.items);
 
-    if (page.items.length === 0) {
-      break;
-    }
-
     if (
       options.targetCount !== "all" &&
       collected.length >= options.targetCount

--- a/turbo/apps/cli/src/lib/utils/log-pagination.ts
+++ b/turbo/apps/cli/src/lib/utils/log-pagination.ts
@@ -40,6 +40,25 @@ export function parsePositiveLogCount(
   return count;
 }
 
+export function parseBoundedLogCount(
+  value: string,
+  optionName: string,
+  min: number,
+  max: number,
+): number {
+  const trimmed = value.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    throw new Error(`${optionName} must be between ${min} and ${max}`);
+  }
+
+  const count = Number(trimmed);
+  if (!Number.isSafeInteger(count) || count < min || count > max) {
+    throw new Error(`${optionName} must be between ${min} and ${max}`);
+  }
+
+  return count;
+}
+
 export async function collectLogItems<T>(
   options: CollectLogItemsOptions<T>,
 ): Promise<T[]> {

--- a/turbo/apps/cli/src/lib/utils/search-query.ts
+++ b/turbo/apps/cli/src/lib/utils/search-query.ts
@@ -1,0 +1,7 @@
+export function parseSearchQuery(value: string, label: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error(`${label} cannot be empty.`);
+  }
+  return trimmed;
+}

--- a/turbo/apps/cli/src/lib/utils/time-format.ts
+++ b/turbo/apps/cli/src/lib/utils/time-format.ts
@@ -1,0 +1,7 @@
+export function formatIsoTimestamp(value: Date | string): string {
+  const timestamp = value instanceof Date ? value : new Date(value);
+  if (!Number.isFinite(timestamp.getTime())) {
+    return "invalid-date";
+  }
+  return timestamp.toISOString().replace(/\.\d{3}Z$/, "Z");
+}

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -799,7 +799,7 @@ export const chatSearchContract = c.router({
     path: "/api/zero/chat/search",
     headers: authHeadersSchema,
     query: z.object({
-      keyword: z.string().min(1),
+      keyword: z.string().trim().min(1),
       agentId: z.string().uuid().optional(),
       since: z.coerce.number().optional(),
       limit: z.coerce.number().min(1).max(50).default(20),

--- a/turbo/packages/api-contracts/src/contracts/logs.ts
+++ b/turbo/packages/api-contracts/src/contracts/logs.ts
@@ -22,7 +22,7 @@ export type Pagination = z.infer<typeof paginationSchema>;
  */
 const listQuerySchema = z.object({
   cursor: z.string().optional(),
-  limit: z.coerce.number().min(1).max(100).default(20),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
 });
 
 const c = initContract();

--- a/turbo/packages/api-contracts/src/contracts/runs.ts
+++ b/turbo/packages/api-contracts/src/contracts/runs.ts
@@ -956,9 +956,9 @@ export const logsSearchContract = c.router({
       agentId: z.string().uuid().optional(),
       runId: z.string().optional(),
       since: timestampQueryNumberSchema.optional(),
-      limit: z.coerce.number().min(1).max(50).default(20),
-      before: z.coerce.number().min(0).max(10).default(0),
-      after: z.coerce.number().min(0).max(10).default(0),
+      limit: z.coerce.number().int().min(1).max(50).default(20),
+      before: z.coerce.number().int().min(0).max(10).default(0),
+      after: z.coerce.number().int().min(0).max(10).default(0),
     }),
     responses: {
       200: logsSearchResponseSchema,

--- a/turbo/packages/api-contracts/src/contracts/runs.ts
+++ b/turbo/packages/api-contracts/src/contracts/runs.ts
@@ -954,7 +954,7 @@ export const logsSearchContract = c.router({
     query: z.object({
       keyword: z.string().min(1),
       agentId: z.string().uuid().optional(),
-      runId: z.string().optional(),
+      runId: z.string().uuid().optional(),
       since: timestampQueryNumberSchema.optional(),
       limit: z.coerce.number().int().min(1).max(50).default(20),
       before: z.coerce.number().int().min(0).max(10).default(0),

--- a/turbo/packages/api-contracts/src/contracts/runs.ts
+++ b/turbo/packages/api-contracts/src/contracts/runs.ts
@@ -946,7 +946,7 @@ const logsSearchResponseSchema = z.object({
 });
 
 const logsSearchQuerySchema = z.object({
-  keyword: z.string().min(1),
+  keyword: z.string().trim().min(1),
   agentId: z.string().uuid().optional(),
   runId: z.string().uuid().optional(),
   since: timestampQueryNumberSchema.optional(),

--- a/turbo/packages/api-contracts/src/contracts/runs.ts
+++ b/turbo/packages/api-contracts/src/contracts/runs.ts
@@ -924,6 +924,7 @@ export type RunNetworkLogsContract = typeof runNetworkLogsContract;
 const searchResultSchema = z.object({
   runId: z.string(),
   agentName: z.string(),
+  framework: z.string().nullable().optional(),
   matchedEvent: runEventSchema,
   contextBefore: z.array(runEventSchema),
   contextAfter: z.array(runEventSchema),

--- a/turbo/packages/api-contracts/src/contracts/runs.ts
+++ b/turbo/packages/api-contracts/src/contracts/runs.ts
@@ -463,6 +463,13 @@ const sequenceQueryNumberSchema = safeIntegerQueryNumberSchema
     { message: "Sequence cursor is out of range" },
   );
 
+function boundedIntegerQueryNumberSchema(min: number, max: number) {
+  return z.preprocess(
+    rejectBlankQueryNumber,
+    z.coerce.number().int().min(min).max(max),
+  );
+}
+
 function logSinceQuerySchema(cursorKind: LogPaginationCursorKind) {
   return cursorKind === "time"
     ? timestampQueryNumberSchema
@@ -938,6 +945,16 @@ const logsSearchResponseSchema = z.object({
   hasMore: z.boolean(),
 });
 
+const logsSearchQuerySchema = z.object({
+  keyword: z.string().min(1),
+  agentId: z.string().uuid().optional(),
+  runId: z.string().uuid().optional(),
+  since: timestampQueryNumberSchema.optional(),
+  limit: boundedIntegerQueryNumberSchema(1, 50).default(20),
+  before: boundedIntegerQueryNumberSchema(0, 10).default(0),
+  after: boundedIntegerQueryNumberSchema(0, 10).default(0),
+});
+
 /**
  * Logs search route contract (/api/logs/search)
  * Search agent events across runs
@@ -951,15 +968,7 @@ export const logsSearchContract = c.router({
     method: "GET",
     path: "/api/logs/search",
     headers: authHeadersSchema,
-    query: z.object({
-      keyword: z.string().min(1),
-      agentId: z.string().uuid().optional(),
-      runId: z.string().uuid().optional(),
-      since: timestampQueryNumberSchema.optional(),
-      limit: z.coerce.number().int().min(1).max(50).default(20),
-      before: z.coerce.number().int().min(0).max(10).default(0),
-      after: z.coerce.number().int().min(0).max(10).default(0),
-    }),
+    query: logsSearchQuerySchema,
     responses: {
       200: logsSearchResponseSchema,
       400: apiErrorSchema,
@@ -1067,6 +1076,7 @@ export {
   networkLogEntrySchema,
   networkLogsResponseSchema,
   searchResultSchema,
+  logsSearchQuerySchema,
   logsSearchResponseSchema,
   queueEntrySchema,
   runningTaskSchema,

--- a/turbo/packages/api-contracts/src/contracts/zero-runs.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-runs.ts
@@ -1,9 +1,5 @@
 import { z } from "zod";
-import {
-  authHeadersSchema,
-  initContract,
-  timestampQueryNumberSchema,
-} from "./base";
+import { authHeadersSchema, initContract } from "./base";
 import { apiErrorSchema } from "./errors";
 import {
   executionFirewallBuiltinEntrySchema,
@@ -17,6 +13,7 @@ import {
   queueResponseSchema,
   unifiedRunRequestSchema,
   networkLogsResponseSchema,
+  logsSearchQuerySchema,
   logsSearchResponseSchema,
   createLogPaginationQuerySchema,
 } from "./runs";
@@ -315,15 +312,7 @@ export const zeroLogsSearchContract = c.router({
     method: "GET",
     path: "/api/zero/logs/search",
     headers: authHeadersSchema,
-    query: z.object({
-      keyword: z.string().min(1),
-      agentId: z.string().uuid().optional(),
-      runId: z.string().uuid().optional(),
-      since: timestampQueryNumberSchema.optional(),
-      limit: z.coerce.number().int().min(1).max(50).default(20),
-      before: z.coerce.number().int().min(0).max(10).default(0),
-      after: z.coerce.number().int().min(0).max(10).default(0),
-    }),
+    query: logsSearchQuerySchema,
     responses: {
       200: logsSearchResponseSchema,
       400: apiErrorSchema,

--- a/turbo/packages/api-contracts/src/contracts/zero-runs.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-runs.ts
@@ -318,11 +318,11 @@ export const zeroLogsSearchContract = c.router({
     query: z.object({
       keyword: z.string().min(1),
       agentId: z.string().uuid().optional(),
-      runId: z.string().optional(),
+      runId: z.string().uuid().optional(),
       since: timestampQueryNumberSchema.optional(),
-      limit: z.coerce.number().min(1).max(50).default(20),
-      before: z.coerce.number().min(0).max(10).default(0),
-      after: z.coerce.number().min(0).max(10).default(0),
+      limit: z.coerce.number().int().min(1).max(50).default(20),
+      before: z.coerce.number().int().min(0).max(10).default(0),
+      after: z.coerce.number().int().min(0).max(10).default(0),
     }),
     responses: {
       200: logsSearchResponseSchema,


### PR DESCRIPTION
## Summary
- normalize Codex CLI event parsing for failed turn.completed, warnings, plans, generic completed items, and malformed optional payloads
- collapse paired same-turn Codex error + terminal failure events while preserving distinct error details
- flush pending buffered tool uses before CLI log/run output terminates

Closes #18665

## Tests
- pnpm -F @vm0/cli exec vitest src/commands/logs/__tests__/index.test.ts src/commands/zero/logs/__tests__/view.test.ts src/commands/run/__tests__/index.test.ts --run
- pnpm check-types
- pnpm turbo run lint
- pnpm knip --workspace @vm0/cli