### PR TITLE
perf: reduce user env pre-spawn round trips

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2573,6 +2573,7 @@ dependencies = [
  "tracing-test-support",
  "url",
  "uuid",
+ "vsock-proto",
  "which",
  "zstd",
 ]

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -42,6 +42,7 @@ uuid = { workspace = true, features = ["v4", "serde"] }
 sentry = { workspace = true, features = ["panic"] }
 which = { workspace = true }
 zstd = { workspace = true, features = ["zstdmt"] }
+vsock-proto = { workspace = true }
 
 # These dev-dependencies exist solely for release-please version tracking:
 # cargo-workspace plugin includes dev-dependencies in its dependency graph,

--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -249,20 +249,68 @@ pub(super) fn guest_user_env_file_path(run_id: RunId) -> RunnerResult<String> {
     })
 }
 
-pub(super) async fn write_user_env_file(
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn user_env_dir_command(runtime_dir: &str, dir_path: &str) -> String {
+    let runtime_dir = shell_quote(runtime_dir);
+    let dir_path = shell_quote(dir_path);
+    format!("mkdir -p -m 700 -- {runtime_dir} {dir_path} && chmod 700 -- {runtime_dir} {dir_path}")
+}
+
+fn user_env_write_command(runtime_dir: &str, dir_path: &str, file_path: &str) -> String {
+    let runtime_dir = shell_quote(runtime_dir);
+    let dir_path = shell_quote(dir_path);
+    let file_path = shell_quote(file_path);
+    format!(
+        "umask 077 && \
+         mkdir -p -m 700 -- {runtime_dir} {dir_path} && \
+         chmod 700 -- {runtime_dir} {dir_path} && \
+         cat > {file_path} && \
+         chmod 600 -- {file_path}"
+    )
+}
+
+async fn write_user_env_file_fast_path(
     sandbox: &dyn Sandbox,
-    run_id: RunId,
-    user_env: &HashMap<String, String>,
-) -> RunnerResult<Option<String>> {
-    if user_env.is_empty() {
-        return Ok(None);
+    runtime_dir: &str,
+    dir_path: &str,
+    file_path: &str,
+    payload: &[u8],
+) -> RunnerResult<()> {
+    let write_cmd = user_env_write_command(runtime_dir, dir_path, file_path);
+    let write_result = sandbox
+        .exec_with_diagnostic_label(
+            &ExecRequest {
+                cmd: &write_cmd,
+                timeout: DEFAULT_EXEC_TIMEOUT,
+                env: &[],
+                sudo: false,
+                stdin_bytes: Some(payload),
+                output_limits: EXEC_OUTPUT_LIMIT_64_KIB,
+            },
+            "user-env-write",
+        )
+        .await?;
+    if !helper_exec_succeeded(&write_result) {
+        return Err(RunnerError::Internal(format_helper_exec_failure(
+            "user env file write",
+            &write_result,
+        )));
     }
 
-    let runtime_dir = guest_runtime_dir(run_id)?;
-    let dir_path = guest_user_env_dir_path(run_id)?;
-    let file_path = guest_user_env_file_path(run_id)?;
-    let mkdir_cmd =
-        format!("mkdir -p -m 700 {runtime_dir} {dir_path} && chmod 700 {runtime_dir} {dir_path}");
+    Ok(())
+}
+
+async fn write_user_env_file_fallback(
+    sandbox: &dyn Sandbox,
+    runtime_dir: &str,
+    dir_path: &str,
+    file_path: &str,
+    payload: &[u8],
+) -> RunnerResult<()> {
+    let mkdir_cmd = user_env_dir_command(runtime_dir, dir_path);
     let mkdir_result = sandbox
         .exec_with_diagnostic_label(
             &ExecRequest {
@@ -283,10 +331,8 @@ pub(super) async fn write_user_env_file(
         )));
     }
 
-    let payload = serde_json::to_vec(user_env)
-        .map_err(|e| RunnerError::Internal(format!("serialize user env: {e}")))?;
-    sandbox.write_file(&file_path, &payload).await?;
-    let chmod_cmd = format!("chmod 600 {file_path}");
+    sandbox.write_file(file_path, payload).await?;
+    let chmod_cmd = format!("chmod 600 -- {}", shell_quote(file_path));
     let chmod_result = sandbox
         .exec_with_diagnostic_label(
             &ExecRequest {
@@ -305,6 +351,32 @@ pub(super) async fn write_user_env_file(
             "user env file permission update",
             &chmod_result,
         )));
+    }
+
+    Ok(())
+}
+
+pub(super) async fn write_user_env_file(
+    sandbox: &dyn Sandbox,
+    run_id: RunId,
+    user_env: &HashMap<String, String>,
+) -> RunnerResult<Option<String>> {
+    if user_env.is_empty() {
+        return Ok(None);
+    }
+
+    let runtime_dir = guest_runtime_dir(run_id)?;
+    let dir_path = guest_user_env_dir_path(run_id)?;
+    let file_path = guest_user_env_file_path(run_id)?;
+    let payload = serde_json::to_vec(user_env)
+        .map_err(|e| RunnerError::Internal(format!("serialize user env: {e}")))?;
+
+    if payload.len() <= vsock_proto::MAX_EXEC_STDIN_BYTES {
+        write_user_env_file_fast_path(sandbox, &runtime_dir, &dir_path, &file_path, &payload)
+            .await?;
+    } else {
+        write_user_env_file_fallback(sandbox, &runtime_dir, &dir_path, &file_path, &payload)
+            .await?;
     }
 
     Ok(Some(file_path))

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -915,6 +915,36 @@ async fn write_user_env_file_uses_single_stdin_exec_for_small_env() {
 }
 
 #[tokio::test]
+async fn write_user_env_file_uses_stdin_exec_at_protocol_limit() {
+    let sandbox = MockSandbox::new("test");
+    sandbox.push_exec_result(Ok(ExecResult::new(0, Vec::new(), Vec::new())));
+    let run_id = RunId::nil();
+    let empty_payload_len = serde_json::to_vec(&HashMap::from([("A".to_string(), String::new())]))
+        .unwrap()
+        .len();
+    let user_env = HashMap::from([(
+        "A".to_string(),
+        "x".repeat(vsock_proto::MAX_EXEC_STDIN_BYTES - empty_payload_len),
+    )]);
+    let payload = serde_json::to_vec(&user_env).unwrap();
+    assert_eq!(payload.len(), vsock_proto::MAX_EXEC_STDIN_BYTES);
+
+    let path = write_user_env_file(&sandbox, run_id, &user_env)
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(path, guest_user_env_file_path(run_id).unwrap());
+    let exec_calls = sandbox.exec_calls();
+    assert_eq!(exec_calls.len(), 1);
+    assert_eq!(
+        exec_calls[0].stdin_bytes.as_ref().unwrap().len(),
+        vsock_proto::MAX_EXEC_STDIN_BYTES
+    );
+    assert!(sandbox.write_file_calls().is_empty());
+}
+
+#[tokio::test]
 async fn write_user_env_file_fails_on_non_exited_fast_path_result() {
     let sandbox = MockSandbox::new("test");
     sandbox.push_exec_result(Ok(ExecResult {
@@ -997,6 +1027,36 @@ async fn write_user_env_file_fallback_fails_on_non_exited_mkdir_result() {
         "got: {message}"
     );
     assert!(sandbox.write_file_calls().is_empty());
+}
+
+#[tokio::test]
+async fn write_user_env_file_fallback_fails_on_non_exited_chmod_result() {
+    let sandbox = MockSandbox::new("test");
+    sandbox.push_exec_result(Ok(ExecResult::new(0, Vec::new(), Vec::new())));
+    sandbox.push_exec_result(Ok(ExecResult {
+        termination: ExecTermination::Cancelled,
+        stdout: Vec::new(),
+        stderr: b"cancelled".to_vec(),
+        diagnostic: String::new(),
+        stdout_truncated: false,
+        stderr_truncated: false,
+    }));
+    let run_id = RunId::nil();
+    let user_env = HashMap::from([(
+        "CUSTOM_ENV".to_string(),
+        "x".repeat(vsock_proto::MAX_EXEC_STDIN_BYTES),
+    )]);
+
+    let err = write_user_env_file(&sandbox, run_id, &user_env)
+        .await
+        .unwrap_err();
+    let message = err.to_string();
+
+    assert!(
+        message.contains("user env file permission update failed (cancelled)"),
+        "got: {message}"
+    );
+    assert_eq!(sandbox.write_file_calls().len(), 1);
 }
 
 #[test]

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -11,9 +11,9 @@ use super::super::cli_framework::{
     EffectiveCliFramework, effective_cli_framework, normalized_cli_agent_type,
 };
 use super::super::env::{
-    HostEnv, build_env_json_with_host_env, build_user_env_json, is_runner_owned_env_key,
-    validate_execution_context_before_sandbox, validate_model_provider_env_placeholders,
-    write_user_env_file,
+    HostEnv, build_env_json_with_host_env, build_user_env_json, guest_user_env_file_path,
+    is_runner_owned_env_key, validate_execution_context_before_sandbox,
+    validate_model_provider_env_placeholders, write_user_env_file,
 };
 use super::super::{USER_ENV_FILE_ENV_KEY, guest_runtime_dir};
 use super::support::{
@@ -869,7 +869,53 @@ fn build_env_json_user_vars_cannot_override_system() {
 }
 
 #[tokio::test]
-async fn write_user_env_file_fails_on_non_exited_mkdir_result() {
+async fn write_user_env_file_skips_empty_env() {
+    let sandbox = MockSandbox::new("test");
+    let run_id = RunId::nil();
+
+    let path = write_user_env_file(&sandbox, run_id, &HashMap::new())
+        .await
+        .unwrap();
+
+    assert!(path.is_none());
+    assert!(sandbox.exec_calls().is_empty());
+    assert!(sandbox.write_file_calls().is_empty());
+}
+
+#[tokio::test]
+async fn write_user_env_file_uses_single_stdin_exec_for_small_env() {
+    let sandbox = MockSandbox::new("test");
+    sandbox.push_exec_result(Ok(ExecResult::new(0, Vec::new(), Vec::new())));
+    let run_id = RunId::nil();
+    let user_env = HashMap::from([
+        ("CUSTOM_ENV".to_string(), "value".to_string()),
+        ("TZ".to_string(), "Asia/Shanghai".to_string()),
+    ]);
+
+    let path = write_user_env_file(&sandbox, run_id, &user_env)
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(path, guest_user_env_file_path(run_id).unwrap());
+    let exec_calls = sandbox.exec_calls();
+    assert_eq!(exec_calls.len(), 1);
+    let call = &exec_calls[0];
+    assert!(!call.sudo);
+    assert!(call.env_keys.is_empty());
+    assert!(call.cmd.contains("umask 077"));
+    assert!(call.cmd.contains("mkdir -p -m 700 --"));
+    assert!(call.cmd.contains("chmod 700 --"));
+    assert!(call.cmd.contains("cat >"));
+    assert!(call.cmd.contains("chmod 600 --"));
+    let stdin_bytes = call.stdin_bytes.as_ref().unwrap();
+    let decoded: HashMap<String, String> = serde_json::from_slice(stdin_bytes).unwrap();
+    assert_eq!(decoded, user_env);
+    assert!(sandbox.write_file_calls().is_empty());
+}
+
+#[tokio::test]
+async fn write_user_env_file_fails_on_non_exited_fast_path_result() {
     let sandbox = MockSandbox::new("test");
     sandbox.push_exec_result(Ok(ExecResult {
         termination: ExecTermination::Cancelled,
@@ -881,6 +927,65 @@ async fn write_user_env_file_fails_on_non_exited_mkdir_result() {
     }));
     let run_id = RunId::nil();
     let user_env = HashMap::from([("CUSTOM_ENV".to_string(), "value".to_string())]);
+
+    let err = write_user_env_file(&sandbox, run_id, &user_env)
+        .await
+        .unwrap_err();
+    let message = err.to_string();
+
+    assert!(
+        message.contains("user env file write failed (cancelled)"),
+        "got: {message}"
+    );
+    assert!(sandbox.write_file_calls().is_empty());
+}
+
+#[tokio::test]
+async fn write_user_env_file_falls_back_for_oversized_env() {
+    let sandbox = MockSandbox::new("test");
+    sandbox.push_exec_result(Ok(ExecResult::new(0, Vec::new(), Vec::new())));
+    sandbox.push_exec_result(Ok(ExecResult::new(0, Vec::new(), Vec::new())));
+    let run_id = RunId::nil();
+    let user_env = HashMap::from([(
+        "CUSTOM_ENV".to_string(),
+        "x".repeat(vsock_proto::MAX_EXEC_STDIN_BYTES),
+    )]);
+
+    let path = write_user_env_file(&sandbox, run_id, &user_env)
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(path, guest_user_env_file_path(run_id).unwrap());
+    let exec_calls = sandbox.exec_calls();
+    assert_eq!(exec_calls.len(), 2);
+    assert!(exec_calls[0].cmd.contains("mkdir -p -m 700 --"));
+    assert!(exec_calls[0].stdin_bytes.is_none());
+    assert!(exec_calls[1].cmd.contains("chmod 600 --"));
+    assert!(exec_calls[1].stdin_bytes.is_none());
+    let writes = sandbox.write_file_calls();
+    assert_eq!(writes.len(), 1);
+    assert_eq!(writes[0].path, path);
+    let decoded: HashMap<String, String> = serde_json::from_slice(&writes[0].content).unwrap();
+    assert_eq!(decoded, user_env);
+}
+
+#[tokio::test]
+async fn write_user_env_file_fallback_fails_on_non_exited_mkdir_result() {
+    let sandbox = MockSandbox::new("test");
+    sandbox.push_exec_result(Ok(ExecResult {
+        termination: ExecTermination::Cancelled,
+        stdout: Vec::new(),
+        stderr: b"cancelled".to_vec(),
+        diagnostic: String::new(),
+        stdout_truncated: false,
+        stderr_truncated: false,
+    }));
+    let run_id = RunId::nil();
+    let user_env = HashMap::from([(
+        "CUSTOM_ENV".to_string(),
+        "x".repeat(vsock_proto::MAX_EXEC_STDIN_BYTES),
+    )]);
 
     let err = write_user_env_file(&sandbox, run_id, &user_env)
         .await

--- a/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
@@ -235,30 +235,21 @@ async fn execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_
         );
     }
 
-    let mkdir_call = overrides
+    let write_call = overrides
         .exec_calls()
         .into_iter()
         .find(|call| call.cmd.contains(&expected_user_env_dir))
-        .expect("user env directory should be created before agent start");
-    assert!(mkdir_call.cmd.starts_with("mkdir -p -m 700 "));
-    assert!(mkdir_call.cmd.contains(" && chmod 700 "));
-    assert!(mkdir_call.env_keys.is_empty());
-    assert!(!mkdir_call.sudo);
-    let chmod_call = overrides
-        .exec_calls()
-        .into_iter()
-        .find(|call| call.cmd == format!("chmod 600 {expected_user_env_file}"))
-        .expect("user env file mode should be tightened after write");
-    assert!(chmod_call.env_keys.is_empty());
-    assert!(!chmod_call.sudo);
-
-    let writes = overrides.write_file_calls();
-    let user_env_write = writes
-        .iter()
-        .find(|call| call.path == expected_user_env_file)
-        .expect("user env JSON should be written");
-    let user_env: HashMap<String, String> =
-        serde_json::from_slice(&user_env_write.content).unwrap();
+        .expect("user env file should be written before agent start");
+    assert!(write_call.cmd.contains("umask 077"));
+    assert!(write_call.cmd.contains("mkdir -p -m 700 --"));
+    assert!(write_call.cmd.contains("chmod 700 --"));
+    assert!(write_call.cmd.contains("cat >"));
+    assert!(write_call.cmd.contains("chmod 600 --"));
+    assert!(write_call.cmd.contains(&expected_user_env_file));
+    assert!(write_call.env_keys.is_empty());
+    assert!(!write_call.sudo);
+    let stdin_bytes = write_call.stdin_bytes.as_ref().unwrap();
+    let user_env: HashMap<String, String> = serde_json::from_slice(stdin_bytes).unwrap();
     assert_eq!(user_env.get("CUSTOM_USER_ENV").unwrap(), "visible-to-cli");
     assert_eq!(user_env.get("BASH_ENV").unwrap(), "/tmp/user-bash-env");
     assert_eq!(
@@ -269,6 +260,7 @@ async fn execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_
     assert!(!user_env.contains_key("VM0_API_TOKEN"));
     assert!(!user_env.contains_key(USER_ENV_FILE_ENV_KEY));
     assert!(!user_env.contains_key("VM0_STUCK_TOOL_TIMEOUT_SECS"));
+    assert!(overrides.write_file_calls().is_empty());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- add a small user-env fast path that writes the private env JSON through one helper exec with stdin
- keep the existing `Sandbox::write_file` path for payloads larger than `vsock_proto::MAX_EXEC_STDIN_BYTES`
- update runner env tests and sandbox-run coverage for fast path, fallback, and bootstrap env isolation

## Why

`api_to_spawn` includes runner-side preparation before the guest agent process has a PID. Runs with non-empty user env currently pay directory setup exec + write_file + chmod exec before spawn. Small env payloads can safely use one bounded stdin exec, while oversized payloads still need the existing write-file path to preserve large-payload behavior.

Closes #18748

## Testing

- `cargo fmt --manifest-path crates/Cargo.toml --package runner`
- `cargo test --manifest-path crates/Cargo.toml -p runner write_user_env_file`
- `cargo test --manifest-path crates/Cargo.toml -p runner execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_only`
- `cargo test --manifest-path crates/Cargo.toml -p runner executor::tests::env_tests`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
- `git diff --check`
