### PR TITLE
refactor: narrow gmail workflow trigger match fields

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-gmail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-gmail.test.ts
@@ -122,7 +122,6 @@ function configureGmailMessageMocks(): void {
           id: "msg-1",
           threadId: "gmail-thread-1",
           labelIds: ["INBOX", "IMPORTANT"],
-          snippet: "Need help with the invoice",
           payload: {
             mimeType: "multipart/alternative",
             headers: [

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-triggers.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-triggers.test.ts
@@ -20,6 +20,7 @@ import { and, eq } from "drizzle-orm";
 import { HttpResponse, http } from "msw";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { createApp } from "../../../app-factory";
 import { mockOptionalEnv } from "../../../lib/env";
 import { mockNow, now } from "../../../lib/time";
 import { server } from "../../../mocks/server";
@@ -474,6 +475,34 @@ describe("zero workflow triggers", () => {
     expect(rejected.body.error.message).toBe(
       "Connect Gmail before adding a Gmail event trigger",
     );
+  });
+
+  it("rejects removed Gmail event trigger match fields", async () => {
+    const { workflowId } = await setupFixture();
+
+    const response = await createApp({ signal: context.signal }).request(
+      `/api/zero/workflows/${workflowId}/triggers`,
+      {
+        method: "POST",
+        headers: {
+          ...authHeaders(),
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          kind: "event",
+          eventType: "gmail-new-message",
+          eventConfig: {
+            provider: "gmail",
+            event: "new_message",
+            match: { hasAttachment: true },
+          },
+        }),
+      },
+    );
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBe("BAD_REQUEST");
   });
 
   it("creates Gmail event triggers with a watch and agent connector grant", async () => {

--- a/turbo/apps/api/src/signals/services/gmail-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/gmail-workflow-event.service.ts
@@ -125,7 +125,6 @@ const gmailMessageSchema = z.object({
   id: z.string(),
   threadId: z.string().optional(),
   labelIds: z.array(z.string()).optional(),
-  snippet: z.string().optional(),
   payload: gmailMessagePartSchema.optional(),
 });
 
@@ -203,9 +202,7 @@ interface GmailMessageContext {
   readonly to: readonly string[];
   readonly cc: readonly string[];
   readonly subject: string | null;
-  readonly snippet: string | null;
   readonly bodyText: string | null;
-  readonly hasAttachment: boolean;
 }
 
 type GmailHistoryResult =
@@ -735,18 +732,6 @@ function collectBodyText(part: GmailMessagePart | undefined): string {
     .join("\n");
 }
 
-function partHasAttachment(part: GmailMessagePart | undefined): boolean {
-  if (!part) {
-    return false;
-  }
-  if ((part.filename?.length ?? 0) > 0 || part.body?.attachmentId) {
-    return true;
-  }
-  return (part.parts ?? []).some((child) => {
-    return partHasAttachment(child);
-  });
-}
-
 function messageIsInbound(message: GmailMessageContext): boolean {
   const labels = new Set(message.labelIds);
   if (!labels.has("INBOX")) {
@@ -798,9 +783,7 @@ async function fetchGmailMessageContext(args: {
     to: headerValues(headers, "To"),
     cc: headerValues(headers, "Cc"),
     subject: firstHeaderValue(headers, "Subject"),
-    snippet: result.value.snippet ?? null,
     bodyText: bodyText.length > 0 ? bodyText : null,
-    hasAttachment: partHasAttachment(result.value.payload),
   };
 }
 
@@ -837,29 +820,6 @@ function textMatches(value: string | null, matcher: GmailTextMatch): boolean {
   return true;
 }
 
-function labelsMatch(
-  labels: readonly string[],
-  matcher: NonNullable<GmailMatchRules["labels"]>,
-): boolean {
-  const labelSet = new Set(labels);
-  if (
-    matcher.includeAny &&
-    !matcher.includeAny.some((label) => {
-      return labelSet.has(label);
-    })
-  ) {
-    return false;
-  }
-  if (
-    matcher.excludeAny?.some((label) => {
-      return labelSet.has(label);
-    })
-  ) {
-    return false;
-  }
-  return true;
-}
-
 function gmailMessageMatchesConfig(
   message: GmailMessageContext,
   config: GmailNewMessageEventConfig,
@@ -874,9 +834,6 @@ function gmailMessageMatchesConfig(
   if (match.subject && !textMatches(message.subject, match.subject)) {
     return false;
   }
-  if (match.snippet && !textMatches(message.snippet, match.snippet)) {
-    return false;
-  }
   if (match.body && !textMatches(message.bodyText, match.body)) {
     return false;
   }
@@ -884,15 +841,6 @@ function gmailMessageMatchesConfig(
     return false;
   }
   if (match.cc && !textMatches(message.cc.join(", "), match.cc)) {
-    return false;
-  }
-  if (match.labels && !labelsMatch(message.labelIds, match.labels)) {
-    return false;
-  }
-  if (
-    match.hasAttachment !== undefined &&
-    match.hasAttachment !== message.hasAttachment
-  ) {
     return false;
   }
   return true;
@@ -1232,10 +1180,7 @@ function buildGmailWorkflowEventSystemPrompt(args: {
         to: args.message.to,
         cc: args.message.cc,
         subject: args.message.subject,
-        snippet: args.message.snippet,
         bodyText: args.message.bodyText,
-        labelIds: args.message.labelIds,
-        hasAttachment: args.message.hasAttachment,
       },
       null,
       2,

--- a/turbo/apps/cli/src/commands/zero/workflow/trigger/display.ts
+++ b/turbo/apps/cli/src/commands/zero/workflow/trigger/display.ts
@@ -61,9 +61,6 @@ function formatGmailMatchSummary(config: GmailNewMessageEventConfig): string {
       parts.push(...textMatcherParts(field, matcher));
     }
   }
-  if (match.snippet || match.labels || match.hasAttachment !== undefined) {
-    parts.push("custom match rules");
-  }
   return parts.length > 0 ? parts.join("; ") : "all inbound messages";
 }
 

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -399,7 +399,6 @@ describe("workflow detail page", () => {
             match: {
               from: { containsAny: ["@vip.example"] },
               subject: { doesNotContain: "newsletter" },
-              hasAttachment: true,
             },
           },
         } satisfies WorkflowGmailNewMessageTriggerSummary,
@@ -449,7 +448,6 @@ describe("workflow detail page", () => {
               },
               subject: { doesNotContain: "newsletter" },
               body: { contains: "invoice" },
-              hasAttachment: true,
             },
           },
         },

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -675,15 +675,6 @@ function buildGmailNewMessageEventConfig(
 ): GmailNewMessageEventConfig {
   const baseMatch = baseConfig?.match;
   const match: GmailMatchRules = {};
-  if (baseMatch?.snippet) {
-    match.snippet = baseMatch.snippet;
-  }
-  if (baseMatch?.labels) {
-    match.labels = baseMatch.labels;
-  }
-  if (baseMatch?.hasAttachment !== undefined) {
-    match.hasAttachment = baseMatch.hasAttachment;
-  }
   for (const { field } of GMAIL_TEXT_FIELDS) {
     const existing = baseMatch?.[field];
     const contains = formTextValue(form, `${field}Contains`);
@@ -752,9 +743,6 @@ function formatGmailMatchSummary(config: GmailNewMessageEventConfig): string {
     if (matcher) {
       parts.push(...textMatcherParts(field, matcher));
     }
-  }
-  if (match.snippet || match.labels || match.hasAttachment !== undefined) {
-    parts.push("custom match rules");
   }
   return parts.length > 0 ? parts.join("; ") : "all inbound messages";
 }

--- a/turbo/packages/api-contracts/src/contracts/__tests__/zero-workflows.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/zero-workflows.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { gmailNewMessageEventConfigSchema } from "../zero-workflows";
+
+describe("Gmail new message workflow trigger contract", () => {
+  it("accepts only explicit text match fields", () => {
+    const parsed = gmailNewMessageEventConfigSchema.safeParse({
+      provider: "gmail",
+      event: "new_message",
+      match: {
+        from: { contains: "@example.com" },
+        to: { containsAny: ["team@example.com"] },
+        cc: { doesNotContain: "archive@example.com" },
+        subject: { doesNotContainAny: ["newsletter"] },
+        body: { contains: "invoice" },
+      },
+    });
+
+    expect(parsed.success).toBe(true);
+  });
+
+  it("rejects removed match fields", () => {
+    const removedMatchRules = [
+      { snippet: { contains: "preview" } },
+      { labels: { includeAny: ["INBOX"] } },
+      { hasAttachment: true },
+    ];
+
+    for (const match of removedMatchRules) {
+      const parsed = gmailNewMessageEventConfigSchema.safeParse({
+        provider: "gmail",
+        event: "new_message",
+        match,
+      });
+
+      expect(parsed.success).toBe(false);
+    }
+  });
+});

--- a/turbo/packages/api-contracts/src/contracts/zero-workflows.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-workflows.ts
@@ -111,6 +111,7 @@ const gmailTextMatchSchema = z
     doesNotContain: z.string().min(1).optional(),
     doesNotContainAny: z.array(z.string().min(1)).min(1).optional(),
   })
+  .strict()
   .refine(
     (value) => {
       return (
@@ -123,34 +124,22 @@ const gmailTextMatchSchema = z
     { message: "At least one text matcher is required" },
   );
 
-const gmailLabelMatchSchema = z
+export const gmailNewMessageEventConfigSchema = z
   .object({
-    includeAny: z.array(z.string().min(1)).min(1).optional(),
-    excludeAny: z.array(z.string().min(1)).min(1).optional(),
+    provider: z.literal("gmail"),
+    event: z.literal("new_message"),
+    match: z
+      .object({
+        from: gmailTextMatchSchema.optional(),
+        subject: gmailTextMatchSchema.optional(),
+        body: gmailTextMatchSchema.optional(),
+        to: gmailTextMatchSchema.optional(),
+        cc: gmailTextMatchSchema.optional(),
+      })
+      .strict()
+      .optional(),
   })
-  .refine(
-    (value) => {
-      return value.includeAny !== undefined || value.excludeAny !== undefined;
-    },
-    { message: "At least one label matcher is required" },
-  );
-
-export const gmailNewMessageEventConfigSchema = z.object({
-  provider: z.literal("gmail"),
-  event: z.literal("new_message"),
-  match: z
-    .object({
-      from: gmailTextMatchSchema.optional(),
-      subject: gmailTextMatchSchema.optional(),
-      snippet: gmailTextMatchSchema.optional(),
-      body: gmailTextMatchSchema.optional(),
-      to: gmailTextMatchSchema.optional(),
-      cc: gmailTextMatchSchema.optional(),
-      labels: gmailLabelMatchSchema.optional(),
-      hasAttachment: z.boolean().optional(),
-    })
-    .optional(),
-});
+  .strict();
 export type GmailNewMessageEventConfig = z.infer<
   typeof gmailNewMessageEventConfigSchema
 >;


### PR DESCRIPTION
## Summary
- Remove `snippet`, `labels`, and `hasAttachment` from the public Gmail workflow trigger match contract.
- Stop parsing, matching, prompting, and summarizing those removed Gmail fields in API, CLI, and Platform UI.
- Add contract coverage proving only `from`, `to`, `cc`, `subject`, and `body` remain accepted.

## Tests
- `pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/zero-workflows.test.ts`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/cli exec vitest run src/commands/zero/workflow/trigger/__tests__/trigger.test.ts`
- `pnpm -F @vm0/cli check-types`
- `pnpm -F @vm0/app exec vitest run src/views/workflows-page/__tests__/workflows-page.test.tsx`
- `pnpm -F @vm0/app check-types`
- targeted `oxlint` on touched API, CLI, Platform, and contracts files

Attempted API route tests and API typecheck locally, but they could not complete in this runtime: route tests require Postgres on `127.0.0.1:5432`, and `pnpm -F api check-types` was killed with exit 137.

Closes #18777