### PR TITLE
docs: document guest-agent active input contract

### DIFF
--- a/crates/guest-agent/src/active_input.rs
+++ b/crates/guest-agent/src/active_input.rs
@@ -12,26 +12,40 @@ const ACTIVE_INPUT_TYPE: &str = "active-input";
 const ACTIVE_INPUT_QUEUE_CAPACITY: usize = 8;
 const ACTIVE_INPUT_SEEN_MESSAGE_ID_CAPACITY: usize = 1024;
 
+/// Accepted follow-up user input waiting to be written to Claude stream-json stdin.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ActiveInputFrame {
+    /// Control-plane message id used for duplicate detection and diagnostics.
     pub message_id: String,
+    /// Deterministic Claude user-frame UUID assigned to this active input.
     pub uuid: String,
+    /// User text to replay into the running CLI process.
     pub text: String,
 }
 
+/// Result returned to the process-control caller for an active-input payload.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ActiveInputControlOutcome {
+    /// The payload was accepted and queued for the CLI stdin writer.
     Accepted,
+    /// The payload was rejected without being queued.
     Rejected { diagnostic: &'static str },
+    /// The payload could not be queued because the active-input backlog is full.
     QueueFull { diagnostic: &'static str },
+    /// The payload failed with a control-path error.
     Error { diagnostic: &'static str },
 }
 
+/// Classification of a CLI stdout user event during active-input replay filtering.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReplayUserEventAction {
+    /// A normal external user event that should continue through event delivery.
     External,
+    /// The CLI replayed the run's initial prompt frame.
     InternalInitialPrompt,
+    /// The CLI replayed an accepted active-input follow-up frame.
     InternalActiveInput,
+    /// A prompt-like user event could not be attributed to known run input.
     UnknownPromptUser,
 }
 
@@ -232,11 +246,22 @@ struct ActiveInputInner {
     state: Mutex<ActiveInputState>,
 }
 
+/// Cloneable control-plane side of active input for one guest-agent run.
+///
+/// The process-control task uses this handle to accept or reject follow-up user
+/// input while CLI execution uses the paired [`ActiveInputWriter`] to consume
+/// accepted frames. The controller also classifies CLI stdout user events so
+/// internally replayed input can be kept out of outbound event delivery.
 #[derive(Debug, Clone)]
 pub struct ActiveInputController {
     inner: Arc<ActiveInputInner>,
 }
 
+/// Single-consumer CLI stdin side of active input for one guest-agent run.
+///
+/// `execute_cli_with_active_input` consumes this writer for the lifetime of one
+/// CLI execution. It yields accepted follow-up input frames and observes the
+/// same terminal close signal as the paired [`ActiveInputController`].
 #[derive(Debug)]
 pub struct ActiveInputWriter {
     controller: ActiveInputController,
@@ -244,6 +269,12 @@ pub struct ActiveInputWriter {
     close_rx: watch::Receiver<bool>,
 }
 
+/// Paired active-input state for one guest-agent run.
+///
+/// The runtime creates a cloneable [`ActiveInputController`] for control-plane
+/// requests and a single [`ActiveInputWriter`] for CLI stdin replay. Consuming
+/// the runtime with [`ActiveInputRuntime::into_writer`] transfers the writer to
+/// the CLI execution path.
 pub struct ActiveInputRuntime {
     controller: ActiveInputController,
     writer: ActiveInputWriter,

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -227,11 +227,32 @@ pub struct CliExecutionResult {
 /// stop it before final telemetry. `execute_cli` only needs this one-shot
 /// status while the CLI process is running.
 pub enum HeartbeatStatus {
+    /// The heartbeat loop returned an error while CLI execution was running.
+    ///
+    /// `execute_cli` treats this as a guest-agent control-path failure and may
+    /// terminate the CLI process group so final diagnostics can report the
+    /// heartbeat failure.
     Failed(AgentError),
+
+    /// The heartbeat loop stopped cleanly.
+    ///
+    /// During CLI execution this is a non-error completion signal for the
+    /// heartbeat race.
     Stopped,
+
+    /// The heartbeat task itself failed, such as a task panic or join error.
+    ///
+    /// `execute_cli` surfaces this as a guest-agent execution error and may
+    /// terminate the CLI process group if no earlier control-path termination
+    /// is already in progress.
     TaskFailed(String),
 }
 
+/// Optional heartbeat completion receiver for a CLI execution.
+///
+/// `Some(receiver)` races CLI execution against heartbeat completion. `None`
+/// disables heartbeat monitoring for that run, which is useful for tests and
+/// callers that do not own a heartbeat task.
 pub type HeartbeatMonitor = Option<oneshot::Receiver<HeartbeatStatus>>;
 
 /// Execute the CLI process, streaming JSONL events and racing against heartbeat.
@@ -253,6 +274,24 @@ pub async fn execute_cli(
     .await
 }
 
+/// Execute the CLI process with caller-owned active-input state.
+///
+/// This is the active-input variant of [`execute_cli`]. Use it when the caller
+/// has already created an active-input runtime for the run and needs the
+/// process-control side to feed accepted follow-up user input into CLI stdin.
+/// The provided [`ActiveInputWriter`] is consumed for this single CLI
+/// execution.
+///
+/// For Claude stream-json stdin, the initial prompt frame is written first. If
+/// active input is enabled, accepted follow-up user frames are written after the
+/// initial prompt until the active-input terminal closes. If active input is
+/// disabled, the writer closes after the initial prompt. When active input is
+/// enabled, internally replayed initial-prompt and follow-up user events are
+/// filtered from outbound API event delivery.
+///
+/// Result collection, event-drain watermarking, heartbeat handling, shutdown,
+/// process-group termination, and error semantics otherwise match
+/// [`execute_cli`].
 pub async fn execute_cli_with_active_input(
     masker: &SecretMasker,
     heartbeat_monitor: HeartbeatMonitor,


### PR DESCRIPTION
## Summary

- Document the guest-agent CLI heartbeat monitor/status contract.
- Document the active-input variant of CLI execution and its writer ownership semantics.
- Document the public active-input runtime/controller/writer roles used by that execution contract.

## Testing

- `cd crates && cargo doc -p guest-agent --no-deps`
- pre-commit hook also ran `cargo-fmt`, `cargo-clippy`, and workspace `cargo-doc`

Fixes #18760
