### PR TITLE
fix(guest-agent): bound codex session lookup

### DIFF
--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -1,5 +1,5 @@
 //! Session-history reader — abstracts over Claude (literal jsonl path) and
-//! codex (`CODEX_SEARCH:{dir_len}:{dir}:{id}` marker → recursive scan +
+//! codex (`CODEX_SEARCH:{dir_len}:{dir}:{id}` marker → bounded layout scan +
 //! optional zstd decode).
 //!
 //! The event metadata capture path writes one of two payloads to
@@ -21,10 +21,12 @@
 //! The codex sessions layout is `${CODEX_HOME}/sessions/YYYY/MM/DD/<file>.jsonl[.zst]`.
 //! Filenames are not stably keyed to thread_id in the real codex CLI
 //! (the `rollout-` prefix mangles dashes), so we match by dash-stripped
-//! UUID substring. If no filename matches, we fail fast — silently picking
-//! "the most recent file in the tree" would risk uploading an unrelated
-//! session as the resume context, which is a multi-tenant correctness
-//! hazard. The descriptive `Codex session file not found` error from
+//! UUID substring. Lookup only scans the expected `YYYY/MM/DD` layout and is
+//! budgeted so user-controlled session trees cannot make checkpoint perform an
+//! unbounded filesystem walk. If no filename matches, we fail fast — silently
+//! picking "the most recent file in the tree" would risk uploading an unrelated
+//! session as the resume context, which is a multi-tenant correctness hazard.
+//! The descriptive `Codex session file not found` error from
 //! `read_session_history` surfaces the failure without logging the session id.
 
 use crate::error::AgentError;
@@ -39,6 +41,12 @@ use std::path::{Path, PathBuf};
 use std::{fs::File, io::Read};
 
 const CODEX_MARKER_PREFIX: &str = "CODEX_SEARCH:";
+// Checkpoint must resolve Codex history from user-controlled guest-home state.
+// Keep the budget comfortably above normal date-partitioned histories while
+// preventing layout-shaped trees from turning session lookup into an
+// unbounded synchronous walk.
+const CODEX_SESSION_LOOKUP_SCAN_BUDGET: usize = 16_384;
+const CODEX_SESSION_LOOKUP_SCAN_BUDGET_ERROR: &str = "Codex session lookup exceeded scan budget";
 
 /// Build the persisted Codex session-history marker payload.
 pub(crate) fn codex_marker_payload(sessions_dir: &Path, thread_id: &str) -> String {
@@ -154,49 +162,159 @@ fn read_codex_session_history_impl(
     }
 
     let mut found = None;
-    find_codex_session_file_recursive(sessions_dir, sessions_dir, id_norm, &mut found)?;
+    let mut budget = CodexSessionLookupBudget::new();
+    scan_codex_session_year_dirs(sessions_dir, sessions_dir, id_norm, &mut found, &mut budget)?;
     found
         .map(|session| read_history_bytes(&session.path))
         .transpose()
 }
 
 #[cfg(not(target_os = "linux"))]
-/// DFS walk of `dir`, recording a single matching real file. Symlinks
-/// are skipped because the Codex sessions tree is user-controlled
-/// filesystem state and checkpoint lookup must not follow it outside the
-/// expected history directory.
-fn find_codex_session_file_recursive(
-    root: &Path,
-    dir: &Path,
+fn scan_codex_session_year_dirs(
+    root_path: &Path,
+    sessions_dir: &Path,
     id_norm: &str,
     found: &mut Option<ResolvedCodexSession>,
+    budget: &mut CodexSessionLookupBudget,
 ) -> Result<(), AgentError> {
-    let entries = match std::fs::read_dir(dir) {
+    let entries = match std::fs::read_dir(sessions_dir) {
         Ok(entries) => entries,
         Err(err) if should_skip_unusable_codex_entry(&err) => return Ok(()),
-        Err(err) => return Err(read_history_error(dir, err)),
+        Err(err) => return Err(read_history_error(sessions_dir, err)),
     };
+
     for entry in entries {
         let entry = match entry {
             Ok(entry) => entry,
             Err(err) if should_skip_unusable_codex_entry(&err) => continue,
-            Err(err) => return Err(read_history_error(dir, err)),
+            Err(err) => return Err(read_history_error(sessions_dir, err)),
         };
+        budget.inspect_entry()?;
+
+        let name = entry.file_name();
         let path = entry.path();
         let file_type = match entry.file_type() {
             Ok(file_type) => file_type,
             Err(err) if should_skip_unusable_codex_entry(&err) => continue,
             Err(err) => return Err(read_history_error(&path, err)),
         };
-        if file_type.is_dir() {
-            find_codex_session_file_recursive(root, &path, id_norm, found)?;
-        } else if file_type.is_file()
+        if file_type.is_dir() && is_codex_session_year_dir_name(&name) {
+            scan_codex_session_month_dirs(root_path, &path, id_norm, found, budget)?;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn scan_codex_session_month_dirs(
+    root_path: &Path,
+    year_dir: &Path,
+    id_norm: &str,
+    found: &mut Option<ResolvedCodexSession>,
+    budget: &mut CodexSessionLookupBudget,
+) -> Result<(), AgentError> {
+    let entries = match std::fs::read_dir(year_dir) {
+        Ok(entries) => entries,
+        Err(err) if should_skip_unusable_codex_entry(&err) => return Ok(()),
+        Err(err) => return Err(read_history_error(year_dir, err)),
+    };
+
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(err) if should_skip_unusable_codex_entry(&err) => continue,
+            Err(err) => return Err(read_history_error(year_dir, err)),
+        };
+        budget.inspect_entry()?;
+
+        let name = entry.file_name();
+        let path = entry.path();
+        let file_type = match entry.file_type() {
+            Ok(file_type) => file_type,
+            Err(err) if should_skip_unusable_codex_entry(&err) => continue,
+            Err(err) => return Err(read_history_error(&path, err)),
+        };
+        if file_type.is_dir() && is_codex_session_month_dir_name(&name) {
+            scan_codex_session_day_dirs(root_path, &path, id_norm, found, budget)?;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn scan_codex_session_day_dirs(
+    root_path: &Path,
+    month_dir: &Path,
+    id_norm: &str,
+    found: &mut Option<ResolvedCodexSession>,
+    budget: &mut CodexSessionLookupBudget,
+) -> Result<(), AgentError> {
+    let entries = match std::fs::read_dir(month_dir) {
+        Ok(entries) => entries,
+        Err(err) if should_skip_unusable_codex_entry(&err) => return Ok(()),
+        Err(err) => return Err(read_history_error(month_dir, err)),
+    };
+
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(err) if should_skip_unusable_codex_entry(&err) => continue,
+            Err(err) => return Err(read_history_error(month_dir, err)),
+        };
+        budget.inspect_entry()?;
+
+        let name = entry.file_name();
+        let path = entry.path();
+        let file_type = match entry.file_type() {
+            Ok(file_type) => file_type,
+            Err(err) if should_skip_unusable_codex_entry(&err) => continue,
+            Err(err) => return Err(read_history_error(&path, err)),
+        };
+        if file_type.is_dir() && is_codex_session_day_dir_name(&name) {
+            scan_codex_session_leaf_files(root_path, &path, id_norm, found, budget)?;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn scan_codex_session_leaf_files(
+    root_path: &Path,
+    day_dir: &Path,
+    id_norm: &str,
+    found: &mut Option<ResolvedCodexSession>,
+    budget: &mut CodexSessionLookupBudget,
+) -> Result<(), AgentError> {
+    let entries = match std::fs::read_dir(day_dir) {
+        Ok(entries) => entries,
+        Err(err) if should_skip_unusable_codex_entry(&err) => return Ok(()),
+        Err(err) => return Err(read_history_error(day_dir, err)),
+    };
+
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(err) if should_skip_unusable_codex_entry(&err) => continue,
+            Err(err) => return Err(read_history_error(day_dir, err)),
+        };
+        budget.inspect_entry()?;
+
+        let path = entry.path();
+        let file_type = match entry.file_type() {
+            Ok(file_type) => file_type,
+            Err(err) if should_skip_unusable_codex_entry(&err) => continue,
+            Err(err) => return Err(read_history_error(&path, err)),
+        };
+        if file_type.is_file()
             && path
                 .file_name()
                 .is_some_and(|name| codex_session_filename_matches(name, id_norm))
         {
             if found.is_some() {
-                return Err(duplicate_codex_session_error(root));
+                return Err(duplicate_codex_session_error(root_path));
             }
             *found = Some(ResolvedCodexSession { path });
         }
@@ -216,12 +334,14 @@ fn read_codex_session_history_impl(
         Err(err) => return Err(read_history_error(sessions_dir, err)),
     };
     let mut found = None;
-    find_and_read_codex_session_file_recursive(
+    let mut budget = CodexSessionLookupBudget::new();
+    scan_codex_session_year_dirs(
         &root,
         sessions_dir,
         sessions_dir,
         id_norm,
         &mut found,
+        &mut budget,
     )?;
     found
         .map(|session| read_history_bytes_from_file(&session.path, session.file))
@@ -229,12 +349,13 @@ fn read_codex_session_history_impl(
 }
 
 #[cfg(target_os = "linux")]
-fn find_and_read_codex_session_file_recursive(
+fn scan_codex_session_year_dirs(
     dir: &Dir,
     root_path: &Path,
     dir_path: &Path,
     id_norm: &str,
     found: &mut Option<ResolvedCodexSession>,
+    budget: &mut CodexSessionLookupBudget,
 ) -> Result<(), AgentError> {
     let entries = match dir.read_dir() {
         Ok(entries) => entries,
@@ -248,6 +369,8 @@ fn find_and_read_codex_session_file_recursive(
             Err(err) if should_skip_unusable_codex_entry(&err) => continue,
             Err(err) => return Err(read_history_error(dir_path, err)),
         };
+        budget.inspect_entry()?;
+
         let name = entry.file_name();
         let path = dir_path.join(&name);
         let file_type = match entry.file_type() {
@@ -255,14 +378,136 @@ fn find_and_read_codex_session_file_recursive(
             Err(err) if should_skip_unusable_codex_entry(&err) => continue,
             Err(err) => return Err(read_history_error(&path, err)),
         };
-        if file_type.is_dir() {
+        if file_type.is_dir() && is_codex_session_year_dir_name(&name) {
             let child = match dir.open_child_dir(&name) {
                 Ok(child) => child,
                 Err(err) if should_skip_unusable_codex_entry(&err) => continue,
                 Err(err) => return Err(read_history_error(&path, err)),
             };
-            find_and_read_codex_session_file_recursive(&child, root_path, &path, id_norm, found)?;
-        } else if file_type.is_file() && codex_session_filename_matches(&name, id_norm) {
+            scan_codex_session_month_dirs(&child, root_path, &path, id_norm, found, budget)?;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn scan_codex_session_month_dirs(
+    dir: &Dir,
+    root_path: &Path,
+    dir_path: &Path,
+    id_norm: &str,
+    found: &mut Option<ResolvedCodexSession>,
+    budget: &mut CodexSessionLookupBudget,
+) -> Result<(), AgentError> {
+    let entries = match dir.read_dir() {
+        Ok(entries) => entries,
+        Err(err) if should_skip_unusable_codex_entry(&err) => return Ok(()),
+        Err(err) => return Err(read_history_error(dir_path, err)),
+    };
+
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(err) if should_skip_unusable_codex_entry(&err) => continue,
+            Err(err) => return Err(read_history_error(dir_path, err)),
+        };
+        budget.inspect_entry()?;
+
+        let name = entry.file_name();
+        let path = dir_path.join(&name);
+        let file_type = match entry.file_type() {
+            Ok(file_type) => file_type,
+            Err(err) if should_skip_unusable_codex_entry(&err) => continue,
+            Err(err) => return Err(read_history_error(&path, err)),
+        };
+        if file_type.is_dir() && is_codex_session_month_dir_name(&name) {
+            let child = match dir.open_child_dir(&name) {
+                Ok(child) => child,
+                Err(err) if should_skip_unusable_codex_entry(&err) => continue,
+                Err(err) => return Err(read_history_error(&path, err)),
+            };
+            scan_codex_session_day_dirs(&child, root_path, &path, id_norm, found, budget)?;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn scan_codex_session_day_dirs(
+    dir: &Dir,
+    root_path: &Path,
+    dir_path: &Path,
+    id_norm: &str,
+    found: &mut Option<ResolvedCodexSession>,
+    budget: &mut CodexSessionLookupBudget,
+) -> Result<(), AgentError> {
+    let entries = match dir.read_dir() {
+        Ok(entries) => entries,
+        Err(err) if should_skip_unusable_codex_entry(&err) => return Ok(()),
+        Err(err) => return Err(read_history_error(dir_path, err)),
+    };
+
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(err) if should_skip_unusable_codex_entry(&err) => continue,
+            Err(err) => return Err(read_history_error(dir_path, err)),
+        };
+        budget.inspect_entry()?;
+
+        let name = entry.file_name();
+        let path = dir_path.join(&name);
+        let file_type = match entry.file_type() {
+            Ok(file_type) => file_type,
+            Err(err) if should_skip_unusable_codex_entry(&err) => continue,
+            Err(err) => return Err(read_history_error(&path, err)),
+        };
+        if file_type.is_dir() && is_codex_session_day_dir_name(&name) {
+            let child = match dir.open_child_dir(&name) {
+                Ok(child) => child,
+                Err(err) if should_skip_unusable_codex_entry(&err) => continue,
+                Err(err) => return Err(read_history_error(&path, err)),
+            };
+            scan_codex_session_leaf_files(&child, root_path, &path, id_norm, found, budget)?;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn scan_codex_session_leaf_files(
+    dir: &Dir,
+    root_path: &Path,
+    dir_path: &Path,
+    id_norm: &str,
+    found: &mut Option<ResolvedCodexSession>,
+    budget: &mut CodexSessionLookupBudget,
+) -> Result<(), AgentError> {
+    let entries = match dir.read_dir() {
+        Ok(entries) => entries,
+        Err(err) if should_skip_unusable_codex_entry(&err) => return Ok(()),
+        Err(err) => return Err(read_history_error(dir_path, err)),
+    };
+
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(err) if should_skip_unusable_codex_entry(&err) => continue,
+            Err(err) => return Err(read_history_error(dir_path, err)),
+        };
+        budget.inspect_entry()?;
+
+        let name = entry.file_name();
+        let path = dir_path.join(&name);
+        let file_type = match entry.file_type() {
+            Ok(file_type) => file_type,
+            Err(err) if should_skip_unusable_codex_entry(&err) => continue,
+            Err(err) => return Err(read_history_error(&path, err)),
+        };
+        if file_type.is_file() && codex_session_filename_matches(&name, id_norm) {
             let file = match dir.open_child_file(&name) {
                 Ok(file) => file,
                 Err(e) if should_skip_unusable_codex_entry(&e) => continue,
@@ -290,6 +535,28 @@ struct ResolvedCodexSession {
     file: File,
 }
 
+struct CodexSessionLookupBudget {
+    inspected_entries: usize,
+}
+
+impl CodexSessionLookupBudget {
+    fn new() -> Self {
+        Self {
+            inspected_entries: 0,
+        }
+    }
+
+    fn inspect_entry(&mut self) -> Result<(), AgentError> {
+        self.inspected_entries += 1;
+        if self.inspected_entries > CODEX_SESSION_LOOKUP_SCAN_BUDGET {
+            return Err(AgentError::Checkpoint(
+                CODEX_SESSION_LOOKUP_SCAN_BUDGET_ERROR.to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
 fn duplicate_codex_session_error(root: &Path) -> AgentError {
     AgentError::Checkpoint(format!(
         "Multiple Codex session files found under {}",
@@ -305,6 +572,34 @@ fn codex_session_filename_matches(name: &OsStr, id_norm: &str) -> bool {
 
     let name_norm = name.replace('-', "").to_ascii_lowercase();
     name_norm.contains(id_norm)
+}
+
+fn is_codex_session_year_dir_name(name: &OsStr) -> bool {
+    let Some(name) = name.to_str() else {
+        return false;
+    };
+    name.len() == 4 && name.bytes().all(|byte| byte.is_ascii_digit())
+}
+
+fn is_codex_session_month_dir_name(name: &OsStr) -> bool {
+    is_numeric_codex_session_date_component(name, 2, 1, 12)
+}
+
+fn is_codex_session_day_dir_name(name: &OsStr) -> bool {
+    is_numeric_codex_session_date_component(name, 2, 1, 31)
+}
+
+fn is_numeric_codex_session_date_component(name: &OsStr, len: usize, min: u8, max: u8) -> bool {
+    let Some(name) = name.to_str() else {
+        return false;
+    };
+    if name.len() != len || !name.bytes().all(|byte| byte.is_ascii_digit()) {
+        return false;
+    }
+    let Ok(value) = name.parse::<u8>() else {
+        return false;
+    };
+    (min..=max).contains(&value)
 }
 
 fn should_skip_unusable_codex_entry(err: &io::Error) -> bool {
@@ -356,7 +651,7 @@ fn decode_history_bytes(path: &Path, raw: Vec<u8>) -> Result<Vec<u8>, AgentError
 }
 
 // Note: integration coverage for the public `read_session_history` entry
-// (both Claude literal-path and codex marker -> recursive scan + zstd
+// (both Claude literal-path and codex marker -> bounded layout scan + zstd
 // decode) lives in `crates/guest-agent/tests/session_history_read.rs`.
 // The internal helpers
 // (`read_codex_session_history`, `codex_session_filename_matches`,

--- a/crates/guest-agent/tests/session_history_read.rs
+++ b/crates/guest-agent/tests/session_history_read.rs
@@ -8,6 +8,7 @@ use std::path::{Path, PathBuf};
 
 const VALID_CODEX_THREAD_ID: &str = "0193abcd-ef01-7234-89ab-cdef01234567";
 const UNKNOWN_CODEX_THREAD_ID: &str = "ffffffff-ffff-7fff-bfff-ffffffffffff";
+const CODEX_SESSION_LOOKUP_BUDGET_TEST_FILES: usize = 17_000;
 
 /// Build a `YYYY/MM/DD/` style nested path under `root` and write a file.
 ///
@@ -323,6 +324,92 @@ fn read_session_history_codex_marker_with_no_match_fails_fast() {
 }
 
 #[test]
+fn read_session_history_codex_marker_ignores_deep_non_layout_tree() {
+    let tmp = tempfile::tempdir().unwrap();
+    let sessions_dir = tmp.path().join("sessions");
+    let mut deep_dir = sessions_dir.join("not-a-year");
+    for index in 0..80 {
+        deep_dir.push(format!("level-{index}"));
+    }
+    std::fs::create_dir_all(&deep_dir).unwrap();
+    std::fs::write(
+        deep_dir.join(format!("{VALID_CODEX_THREAD_ID}.jsonl")),
+        b"deep-history\n",
+    )
+    .unwrap();
+
+    let path_file =
+        write_codex_marker_path_file(tmp.path(), &sessions_dir, VALID_CODEX_THREAD_ID).unwrap();
+
+    let err = guest_agent::session_history::read_session_history(path_file.to_str().unwrap())
+        .expect_err("codex lookup must not recurse into non-layout directories");
+    assert_error_contains_without_secret(
+        err,
+        "Codex session file not found",
+        VALID_CODEX_THREAD_ID,
+    );
+}
+
+#[test]
+fn read_session_history_codex_marker_ignores_non_layout_date_components() {
+    let tmp = tempfile::tempdir().unwrap();
+    let sessions_dir = tmp.path().join("sessions");
+    for sub in [
+        ["abcd", "06", "09"],
+        ["2026", "xx", "09"],
+        ["2026", "13", "09"],
+        ["2026", "06", "99"],
+        ["2026", "06", "00"],
+    ] {
+        write_session_file(
+            &sessions_dir,
+            &sub,
+            &format!("{VALID_CODEX_THREAD_ID}.jsonl"),
+            b"invalid-layout-history\n",
+        )
+        .unwrap();
+    }
+
+    let path_file =
+        write_codex_marker_path_file(tmp.path(), &sessions_dir, VALID_CODEX_THREAD_ID).unwrap();
+
+    let err = guest_agent::session_history::read_session_history(path_file.to_str().unwrap())
+        .expect_err("codex lookup must ignore non-layout date components");
+    assert_error_contains_without_secret(
+        err,
+        "Codex session file not found",
+        VALID_CODEX_THREAD_ID,
+    );
+}
+
+#[test]
+fn read_session_history_codex_marker_scan_budget_fails_closed_with_candidate_present() {
+    let tmp = tempfile::tempdir().unwrap();
+    let sessions_dir = tmp.path().join("sessions");
+    let day_dir = sessions_dir.join("2026/04/28");
+    std::fs::create_dir_all(&day_dir).unwrap();
+    std::fs::write(
+        day_dir.join(format!("{VALID_CODEX_THREAD_ID}.jsonl")),
+        b"history that must not be returned after budget exhaustion\n",
+    )
+    .unwrap();
+    for index in 0..CODEX_SESSION_LOOKUP_BUDGET_TEST_FILES {
+        std::fs::write(day_dir.join(format!("noise-{index:05}.txt")), b"").unwrap();
+    }
+
+    let path_file =
+        write_codex_marker_path_file(tmp.path(), &sessions_dir, VALID_CODEX_THREAD_ID).unwrap();
+
+    let err = guest_agent::session_history::read_session_history(path_file.to_str().unwrap())
+        .expect_err("budget exhaustion must fail even when a candidate exists");
+    assert_error_contains_without_secret(
+        err,
+        "Codex session lookup exceeded scan budget",
+        VALID_CODEX_THREAD_ID,
+    );
+}
+
+#[test]
 fn read_session_history_codex_marker_rejects_dash_only_thread_id() {
     let tmp = tempfile::tempdir().unwrap();
     let sessions_dir = tmp.path().join("sessions");
@@ -573,7 +660,7 @@ fn read_session_history_codex_marker_reports_unreadable_directory() {
 
     let tmp = tempfile::tempdir().unwrap();
     let sessions_dir = tmp.path().join("sessions");
-    let blocked_dir = sessions_dir.join("blocked");
+    let blocked_dir = sessions_dir.join("2026/04/28");
     std::fs::create_dir_all(&blocked_dir).unwrap();
     std::fs::set_permissions(&blocked_dir, std::fs::Permissions::from_mode(0o000)).unwrap();
 

--- a/crates/guest-agent/tests/session_history_read.rs
+++ b/crates/guest-agent/tests/session_history_read.rs
@@ -530,22 +530,34 @@ fn read_session_history_codex_marker_skips_symlinks() {
 
     let tmp = tempfile::tempdir().unwrap();
     let sessions_dir = tmp.path().join("sessions");
-    let outside_dir = tmp.path().join("outside");
+    let outside_year_dir = tmp.path().join("outside-year");
+    let outside_day_dir = outside_year_dir.join("04/28");
     std::fs::create_dir_all(&sessions_dir).unwrap();
-    std::fs::create_dir_all(&outside_dir).unwrap();
+    std::fs::create_dir_all(&outside_day_dir).unwrap();
 
-    let outside_history = outside_dir.join(format!("{VALID_CODEX_THREAD_ID}.jsonl"));
+    let outside_history = outside_day_dir.join(format!("{VALID_CODEX_THREAD_ID}.jsonl"));
     std::fs::write(&outside_history, b"outside-history\n").unwrap();
 
-    symlink(&outside_dir, sessions_dir.join("linked-outside")).unwrap();
+    symlink(&outside_year_dir, sessions_dir.join("2026")).unwrap();
+
+    let real_year_dir = sessions_dir.join("2027");
+    std::fs::create_dir_all(&real_year_dir).unwrap();
+    symlink(outside_day_dir.parent().unwrap(), real_year_dir.join("04")).unwrap();
+
+    let real_month_dir = sessions_dir.join("2028/04");
+    std::fs::create_dir_all(&real_month_dir).unwrap();
+    symlink(&outside_day_dir, real_month_dir.join("28")).unwrap();
+
+    let real_leaf_day_dir = sessions_dir.join("2029/04/28");
+    std::fs::create_dir_all(&real_leaf_day_dir).unwrap();
     symlink(
         &outside_history,
-        sessions_dir.join(format!("{VALID_CODEX_THREAD_ID}.jsonl")),
+        real_leaf_day_dir.join(format!("{VALID_CODEX_THREAD_ID}.jsonl")),
     )
     .unwrap();
     symlink(
         "/definitely/missing/codex-history.jsonl",
-        sessions_dir.join("dangling.jsonl"),
+        real_leaf_day_dir.join("dangling.jsonl"),
     )
     .unwrap();
 
@@ -569,10 +581,10 @@ fn read_session_history_codex_marker_rejects_symlinked_sessions_root() {
     let tmp = tempfile::tempdir().unwrap();
     let real_sessions_dir = tmp.path().join("real-sessions");
     let sessions_link = tmp.path().join("sessions-link");
-    std::fs::create_dir_all(&real_sessions_dir).unwrap();
-
-    std::fs::write(
-        real_sessions_dir.join(format!("{VALID_CODEX_THREAD_ID}.jsonl")),
+    write_session_file(
+        &real_sessions_dir,
+        &["2026", "04", "28"],
+        &format!("{VALID_CODEX_THREAD_ID}.jsonl"),
         b"outside-root-history\n",
     )
     .unwrap();
@@ -599,10 +611,10 @@ fn read_session_history_codex_marker_rejects_symlinked_codex_home_parent() {
     let real_codex_home = tmp.path().join("real-codex-home");
     let codex_home_link = tmp.path().join(".codex");
     let real_sessions_dir = real_codex_home.join("sessions");
-    std::fs::create_dir_all(&real_sessions_dir).unwrap();
-
-    std::fs::write(
-        real_sessions_dir.join(format!("{VALID_CODEX_THREAD_ID}.jsonl")),
+    write_session_file(
+        &real_sessions_dir,
+        &["2026", "04", "28"],
+        &format!("{VALID_CODEX_THREAD_ID}.jsonl"),
         b"outside-parent-history\n",
     )
     .unwrap();
@@ -631,10 +643,11 @@ fn read_session_history_codex_marker_skips_special_files() {
 
     let tmp = tempfile::tempdir().unwrap();
     let sessions_dir = tmp.path().join("sessions");
-    std::fs::create_dir_all(&sessions_dir).unwrap();
+    let day_dir = sessions_dir.join("2026/04/28");
+    std::fs::create_dir_all(&day_dir).unwrap();
 
     let _socket =
-        UnixListener::bind(sessions_dir.join(format!("{VALID_CODEX_THREAD_ID}.jsonl"))).unwrap();
+        UnixListener::bind(day_dir.join(format!("{VALID_CODEX_THREAD_ID}.jsonl"))).unwrap();
 
     let path_file =
         write_codex_marker_path_file(tmp.path(), &sessions_dir, VALID_CODEX_THREAD_ID).unwrap();


### PR DESCRIPTION
## Summary

- Replace recursive Codex session-history lookup with fixed `sessions/YYYY/MM/DD` scanning.
- Add a fail-closed scan budget so layout-shaped breadth cannot turn checkpoint into an unbounded filesystem walk.
- Preserve no-follow semantics, duplicate detection before reading/decompression, dash-stripped UUID filename matching, and zstd handling.

Fixes #18758.

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test session_history_read`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets -- -D warnings`
- pre-commit hook: `cargo-fmt`, `cargo-clippy`, `cargo-doc`
