### PR TITLE
fix(runner): classify Claude provider server errors

### DIFF
--- a/crates/agent-diagnostics/src/lib.rs
+++ b/crates/agent-diagnostics/src/lib.rs
@@ -1,6 +1,6 @@
 //! Structured diagnostics shared by guest agents and runners.
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 pub const FAILURE_DIAGNOSTIC_SCHEMA_VERSION: u8 = 1;
 
@@ -14,6 +14,7 @@ pub struct FailureDiagnostic {
     pub cli_termination: Option<CliTerminationDiagnostic>,
     pub claude_num_turns: Option<u64>,
     pub failure_detail_source: Option<FailureDetailSource>,
+    #[serde(default, deserialize_with = "deserialize_optional_failure_reason")]
     pub failure_reason: Option<FailureReason>,
     pub session_history_status: SessionHistoryStatus,
     pub prompt_shape: PromptShape,
@@ -240,6 +241,7 @@ pub enum FailureReason {
     InvalidCredentials,
     OutputTokenLimit,
     ProviderOverloaded,
+    ProviderServerError,
     ReconnectRequired,
     UsageLimit,
 }
@@ -253,10 +255,35 @@ impl FailureReason {
             Self::InvalidCredentials => "invalid_credentials",
             Self::OutputTokenLimit => "output_token_limit",
             Self::ProviderOverloaded => "provider_overloaded",
+            Self::ProviderServerError => "provider_server_error",
             Self::ReconnectRequired => "reconnect_required",
             Self::UsageLimit => "usage_limit",
         }
     }
+
+    fn from_serialized(value: &str) -> Option<Self> {
+        match value {
+            "insufficient_credits" => Some(Self::InsufficientCredits),
+            "invalid_api_key" => Some(Self::InvalidApiKey),
+            "invalid_credentials" => Some(Self::InvalidCredentials),
+            "output_token_limit" => Some(Self::OutputTokenLimit),
+            "provider_overloaded" => Some(Self::ProviderOverloaded),
+            "provider_server_error" => Some(Self::ProviderServerError),
+            "reconnect_required" => Some(Self::ReconnectRequired),
+            "usage_limit" => Some(Self::UsageLimit),
+            _ => None,
+        }
+    }
+}
+
+fn deserialize_optional_failure_reason<'de, D>(
+    deserializer: D,
+) -> Result<Option<FailureReason>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw = Option::<String>::deserialize(deserializer)?;
+    Ok(raw.and_then(|value| FailureReason::from_serialized(&value)))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -627,6 +654,28 @@ mod tests {
     }
 
     #[test]
+    fn failure_diagnostic_serializes_provider_server_error_reason() {
+        assert_eq!(
+            FailureReason::ProviderServerError.as_str(),
+            "provider_server_error"
+        );
+
+        let diagnostic = FailureDiagnostic::new(
+            FailureClass::CliNonzero,
+            AgentFramework::ClaudeCode,
+            PromptMetadata::from_prompt("debug failure"),
+        )
+        .with_cli_exit_code(1)
+        .with_failure_reason(FailureReason::ProviderServerError);
+
+        let json = serde_json::to_value(&diagnostic).unwrap();
+        assert_eq!(json["failureReason"], "provider_server_error");
+
+        let round_trip: FailureDiagnostic = serde_json::from_value(json).unwrap();
+        assert_eq!(round_trip, diagnostic);
+    }
+
+    #[test]
     fn failure_diagnostic_serializes_reconnect_required_reason() {
         let diagnostic = FailureDiagnostic::new(
             FailureClass::CliNonzero,
@@ -662,5 +711,37 @@ mod tests {
         assert_eq!(diagnostic.failure_detail_source, None);
         assert_eq!(diagnostic.failure_reason, None);
         assert_eq!(diagnostic.cli_termination, None);
+    }
+
+    #[test]
+    fn failure_diagnostic_deserializes_unknown_failure_reason_as_none() {
+        let json = serde_json::json!({
+            "schemaVersion": 1,
+            "failureClass": "cli_nonzero",
+            "framework": "claude_code",
+            "cliExitCode": 1,
+            "claudeNumTurns": 1,
+            "failureDetailSource": "claude_result",
+            "failureReason": "future_provider_reason",
+            "sessionHistoryStatus": "present",
+            "promptShape": "plain",
+            "promptBytes": 13,
+            "firstLineBytes": 13
+        });
+
+        let diagnostic: FailureDiagnostic = serde_json::from_value(json).unwrap();
+
+        assert_eq!(diagnostic.failure_class, FailureClass::CliNonzero);
+        assert_eq!(diagnostic.framework, AgentFramework::ClaudeCode);
+        assert_eq!(diagnostic.cli_exit_code, Some(1));
+        assert_eq!(
+            diagnostic.failure_detail_source,
+            Some(FailureDetailSource::ClaudeResult)
+        );
+        assert_eq!(diagnostic.failure_reason, None);
+        assert_eq!(
+            diagnostic.session_history_status,
+            SessionHistoryStatus::Present
+        );
     }
 }

--- a/crates/agent-diagnostics/src/lib.rs
+++ b/crates/agent-diagnostics/src/lib.rs
@@ -1,6 +1,6 @@
 //! Structured diagnostics shared by guest agents and runners.
 
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 
 pub const FAILURE_DIAGNOSTIC_SCHEMA_VERSION: u8 = 1;
 
@@ -14,7 +14,6 @@ pub struct FailureDiagnostic {
     pub cli_termination: Option<CliTerminationDiagnostic>,
     pub claude_num_turns: Option<u64>,
     pub failure_detail_source: Option<FailureDetailSource>,
-    #[serde(default, deserialize_with = "deserialize_optional_failure_reason")]
     pub failure_reason: Option<FailureReason>,
     pub session_history_status: SessionHistoryStatus,
     pub prompt_shape: PromptShape,
@@ -260,30 +259,6 @@ impl FailureReason {
             Self::UsageLimit => "usage_limit",
         }
     }
-
-    fn from_serialized(value: &str) -> Option<Self> {
-        match value {
-            "insufficient_credits" => Some(Self::InsufficientCredits),
-            "invalid_api_key" => Some(Self::InvalidApiKey),
-            "invalid_credentials" => Some(Self::InvalidCredentials),
-            "output_token_limit" => Some(Self::OutputTokenLimit),
-            "provider_overloaded" => Some(Self::ProviderOverloaded),
-            "provider_server_error" => Some(Self::ProviderServerError),
-            "reconnect_required" => Some(Self::ReconnectRequired),
-            "usage_limit" => Some(Self::UsageLimit),
-            _ => None,
-        }
-    }
-}
-
-fn deserialize_optional_failure_reason<'de, D>(
-    deserializer: D,
-) -> Result<Option<FailureReason>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let raw = Option::<String>::deserialize(deserializer)?;
-    Ok(raw.and_then(|value| FailureReason::from_serialized(&value)))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -711,37 +686,5 @@ mod tests {
         assert_eq!(diagnostic.failure_detail_source, None);
         assert_eq!(diagnostic.failure_reason, None);
         assert_eq!(diagnostic.cli_termination, None);
-    }
-
-    #[test]
-    fn failure_diagnostic_deserializes_unknown_failure_reason_as_none() {
-        let json = serde_json::json!({
-            "schemaVersion": 1,
-            "failureClass": "cli_nonzero",
-            "framework": "claude_code",
-            "cliExitCode": 1,
-            "claudeNumTurns": 1,
-            "failureDetailSource": "claude_result",
-            "failureReason": "future_provider_reason",
-            "sessionHistoryStatus": "present",
-            "promptShape": "plain",
-            "promptBytes": 13,
-            "firstLineBytes": 13
-        });
-
-        let diagnostic: FailureDiagnostic = serde_json::from_value(json).unwrap();
-
-        assert_eq!(diagnostic.failure_class, FailureClass::CliNonzero);
-        assert_eq!(diagnostic.framework, AgentFramework::ClaudeCode);
-        assert_eq!(diagnostic.cli_exit_code, Some(1));
-        assert_eq!(
-            diagnostic.failure_detail_source,
-            Some(FailureDetailSource::ClaudeResult)
-        );
-        assert_eq!(diagnostic.failure_reason, None);
-        assert_eq!(
-            diagnostic.session_history_status,
-            SessionHistoryStatus::Present
-        );
     }
 }

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -500,7 +500,7 @@ fn is_claude_provider_overloaded_error(normalized: &str) -> bool {
 
 fn is_claude_provider_server_error(source: FailureDetailSource, normalized: &str) -> bool {
     source == FailureDetailSource::ClaudeResult
-        && normalized.contains("api error: 500")
+        && has_claude_api_status(normalized, "500")
         && normalized.contains("internal server error")
         && normalized.contains("server-side issue")
 }
@@ -529,6 +529,17 @@ fn claude_529_error_detail(detail: &str) -> Option<&str> {
         return None;
     }
     Some(trim_error_detail_start(detail))
+}
+
+fn has_claude_api_status(normalized: &str, status: &str) -> bool {
+    const MARKER: &str = "api error:";
+    normalized.match_indices(MARKER).any(|(index, _)| {
+        let detail = trim_error_detail_start(&normalized[index + MARKER.len()..]);
+        let Some(remaining) = detail.strip_prefix(status) else {
+            return false;
+        };
+        !remaining.chars().next().is_some_and(is_error_type_char)
+    })
 }
 
 fn trim_error_detail_start(detail: &str) -> &str {
@@ -1551,6 +1562,17 @@ mod tests {
             AgentFramework::ClaudeCode,
             FailureDetailSource::Stderr,
             CLAUDE_PROVIDER_SERVER_ERROR_MESSAGE,
+        );
+
+        assert_eq!(reason, None);
+    }
+
+    #[test]
+    fn cli_failure_reason_ignores_claude_provider_server_error_status_prefix() {
+        let reason = super::classify_cli_failure_reason(
+            AgentFramework::ClaudeCode,
+            FailureDetailSource::ClaudeResult,
+            "API Error: 5000 Internal server error. This is a server-side issue, usually temporary - try again in a moment.",
         );
 
         assert_eq!(reason, None);

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -245,11 +245,7 @@ async fn execute(
                 )
                 .with_failure_detail_source(failure_message.source);
                 let diagnostic = with_cli_termination(diagnostic, cli_result.cli_termination);
-                let diagnostic = with_cli_failure_reason(
-                    diagnostic,
-                    failure_message.message.as_str(),
-                    failure_message.failure_reason,
-                );
+                let diagnostic = with_cli_failure_reason(diagnostic, &failure_message);
                 (
                     cli_exit_code,
                     cli_exit_code,
@@ -404,11 +400,14 @@ fn diagnostic_framework() -> AgentFramework {
 
 fn with_cli_failure_reason(
     diagnostic: FailureDiagnostic,
-    failure_message: &str,
-    failure_reason: Option<FailureReason>,
+    failure_message: &CliFailureMessage,
 ) -> FailureDiagnostic {
-    if let Some(reason) =
-        classify_cli_failure_reason(diagnostic.framework, failure_message).or(failure_reason)
+    if let Some(reason) = classify_cli_failure_reason(
+        diagnostic.framework,
+        failure_message.source,
+        failure_message.message.as_str(),
+    )
+    .or(failure_message.failure_reason)
     {
         diagnostic.with_failure_reason(reason)
     } else {
@@ -418,6 +417,7 @@ fn with_cli_failure_reason(
 
 fn classify_cli_failure_reason(
     framework: AgentFramework,
+    source: FailureDetailSource,
     failure_message: &str,
 ) -> Option<FailureReason> {
     let normalized = failure_message.to_ascii_lowercase();
@@ -433,6 +433,11 @@ fn classify_cli_failure_reason(
         && is_claude_provider_overloaded_error(&normalized)
     {
         return Some(FailureReason::ProviderOverloaded);
+    }
+    if matches!(framework, AgentFramework::ClaudeCode)
+        && is_claude_provider_server_error(source, &normalized)
+    {
+        return Some(FailureReason::ProviderServerError);
     }
     if matches!(framework, AgentFramework::ClaudeCode)
         && is_claude_output_token_limit_error(&normalized)
@@ -491,6 +496,13 @@ fn is_claude_provider_overloaded_error(normalized: &str) -> bool {
             starts_with_overloaded_word(detail) || contains_overloaded_error_type(detail)
         })
     })
+}
+
+fn is_claude_provider_server_error(source: FailureDetailSource, normalized: &str) -> bool {
+    source == FailureDetailSource::ClaudeResult
+        && normalized.contains("api error: 500")
+        && normalized.contains("internal server error")
+        && normalized.contains("server-side issue")
 }
 
 fn is_claude_output_token_limit_error(normalized: &str) -> bool {
@@ -1073,6 +1085,28 @@ mod tests {
         }
     }
 
+    fn selected_failure_message(
+        message: &str,
+        source: FailureDetailSource,
+        failure_reason: Option<FailureReason>,
+    ) -> CliFailureMessage {
+        CliFailureMessage {
+            message: message.to_string(),
+            source,
+            failure_reason,
+        }
+    }
+
+    fn classify_cli_failure_reason(
+        framework: AgentFramework,
+        failure_message: &str,
+    ) -> Option<FailureReason> {
+        // Existing direct classifier tests model messages selected from stderr.
+        super::classify_cli_failure_reason(framework, FailureDetailSource::Stderr, failure_message)
+    }
+
+    const CLAUDE_PROVIDER_SERVER_ERROR_MESSAGE: &str = "API Error: 500 Internal server error. This is a server-side issue, usually temporary - try again in a moment. If it persists, check https://status.claude.com.";
+
     #[test]
     fn cli_failure_message_logs_stderr_to_system_log() {
         let _test_state_guard = lock_test_state();
@@ -1286,8 +1320,7 @@ mod tests {
         )
         .with_cli_exit_code(1)
         .with_failure_detail_source(msg.source);
-        let diagnostic =
-            with_cli_failure_reason(diagnostic, msg.message.as_str(), msg.failure_reason);
+        let diagnostic = with_cli_failure_reason(diagnostic, &msg);
 
         assert_eq!(msg.source, FailureDetailSource::Stderr);
         assert_eq!(
@@ -1385,8 +1418,7 @@ mod tests {
         )
         .with_cli_exit_code(1)
         .with_failure_detail_source(msg.source);
-        let diagnostic =
-            with_cli_failure_reason(diagnostic, msg.message.as_str(), msg.failure_reason);
+        let diagnostic = with_cli_failure_reason(diagnostic, &msg);
 
         assert_eq!(msg.source, FailureDetailSource::ClaudeResult);
         assert_eq!(
@@ -1461,8 +1493,7 @@ mod tests {
         )
         .with_cli_exit_code(1)
         .with_failure_detail_source(msg.source);
-        let diagnostic =
-            with_cli_failure_reason(diagnostic, msg.message.as_str(), msg.failure_reason);
+        let diagnostic = with_cli_failure_reason(diagnostic, &msg);
 
         assert_eq!(msg.source, FailureDetailSource::ClaudeResult);
         assert_eq!(
@@ -1490,13 +1521,64 @@ mod tests {
         )
         .with_cli_exit_code(1)
         .with_failure_detail_source(msg.source);
-        let diagnostic =
-            with_cli_failure_reason(diagnostic, msg.message.as_str(), msg.failure_reason);
+        let diagnostic = with_cli_failure_reason(diagnostic, &msg);
 
         assert_eq!(msg.source, FailureDetailSource::ClaudeResult);
         assert_eq!(
             diagnostic.failure_reason,
             Some(FailureReason::ProviderOverloaded)
+        );
+        assert_eq!(
+            diagnostic.failure_detail_source,
+            Some(FailureDetailSource::ClaudeResult)
+        );
+    }
+
+    #[test]
+    fn cli_failure_reason_classifies_claude_result_provider_server_error() {
+        let reason = super::classify_cli_failure_reason(
+            AgentFramework::ClaudeCode,
+            FailureDetailSource::ClaudeResult,
+            CLAUDE_PROVIDER_SERVER_ERROR_MESSAGE,
+        );
+
+        assert_eq!(reason, Some(FailureReason::ProviderServerError));
+    }
+
+    #[test]
+    fn cli_failure_reason_ignores_claude_provider_server_error_from_stderr() {
+        let reason = super::classify_cli_failure_reason(
+            AgentFramework::ClaudeCode,
+            FailureDetailSource::Stderr,
+            CLAUDE_PROVIDER_SERVER_ERROR_MESSAGE,
+        );
+
+        assert_eq!(reason, None);
+    }
+
+    #[test]
+    fn cli_failure_reason_classifies_claude_result_provider_server_error_diagnostic() {
+        let msg = cli_failure_message(
+            1,
+            &["background stderr noise".to_string()],
+            Some(&cli_diagnostic(
+                CLAUDE_PROVIDER_SERVER_ERROR_MESSAGE,
+                FailureDetailSource::ClaudeResult,
+            )),
+        );
+        let diagnostic = FailureDiagnostic::new(
+            FailureClass::CliNonzero,
+            AgentFramework::ClaudeCode,
+            PromptMetadata::from_prompt("plain prompt"),
+        )
+        .with_cli_exit_code(1)
+        .with_failure_detail_source(msg.source);
+        let diagnostic = with_cli_failure_reason(diagnostic, &msg);
+
+        assert_eq!(msg.source, FailureDetailSource::ClaudeResult);
+        assert_eq!(
+            diagnostic.failure_reason,
+            Some(FailureReason::ProviderServerError)
         );
         assert_eq!(
             diagnostic.failure_detail_source,
@@ -1539,8 +1621,7 @@ mod tests {
         )
         .with_cli_exit_code(1)
         .with_failure_detail_source(msg.source);
-        let diagnostic =
-            with_cli_failure_reason(diagnostic, msg.message.as_str(), msg.failure_reason);
+        let diagnostic = with_cli_failure_reason(diagnostic, &msg);
 
         assert_eq!(msg.source, FailureDetailSource::ClaudeResult);
         assert_eq!(
@@ -1847,11 +1928,12 @@ mod tests {
             PromptMetadata::from_prompt("debug failure"),
         )
         .with_cli_exit_code(1);
-        let diagnostic = with_cli_failure_reason(
-            diagnostic,
+        let failure_message = selected_failure_message(
             "You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage.",
+            FailureDetailSource::Stderr,
             Some(FailureReason::InvalidApiKey),
         );
+        let diagnostic = with_cli_failure_reason(diagnostic, &failure_message);
 
         assert_eq!(diagnostic.failure_reason, Some(FailureReason::UsageLimit));
     }
@@ -1945,11 +2027,12 @@ mod tests {
         )
         .with_cli_exit_code(2)
         .with_failure_detail_source(FailureDetailSource::Stderr);
-        let unchanged = with_cli_failure_reason(
-            diagnostic.clone(),
+        let failure_message = selected_failure_message(
             "permission denied while running command",
+            FailureDetailSource::Stderr,
             None,
         );
+        let unchanged = with_cli_failure_reason(diagnostic.clone(), &failure_message);
 
         assert_eq!(unchanged, diagnostic);
     }
@@ -1963,11 +2046,12 @@ mod tests {
         )
         .with_cli_exit_code(1)
         .with_failure_detail_source(FailureDetailSource::CodexJsonl);
-        let diagnostic = with_cli_failure_reason(
-            diagnostic,
+        let failure_message = selected_failure_message(
             "You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage.",
+            FailureDetailSource::CodexJsonl,
             None,
         );
+        let diagnostic = with_cli_failure_reason(diagnostic, &failure_message);
 
         assert_eq!(diagnostic.failure_class, FailureClass::CliNonzero);
         assert_eq!(diagnostic.failure_reason, Some(FailureReason::UsageLimit));

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -853,6 +853,7 @@ fn is_info_level_job_failure(diagnostic: &FailureDiagnostic) -> bool {
                     | FailureReason::InvalidCredentials
                     | FailureReason::OutputTokenLimit
                     | FailureReason::ProviderOverloaded
+                    | FailureReason::ProviderServerError
                     | FailureReason::ReconnectRequired
                     | FailureReason::UsageLimit
             )
@@ -1025,6 +1026,7 @@ mod tests {
             FailureReason::InvalidCredentials,
             FailureReason::OutputTokenLimit,
             FailureReason::ProviderOverloaded,
+            FailureReason::ProviderServerError,
             FailureReason::ReconnectRequired,
             FailureReason::UsageLimit,
         ] {
@@ -1041,8 +1043,11 @@ mod tests {
                 Some("job execution failed")
             );
             assert_field_eq(&event, "error", &failure_error);
+            assert_field_eq(&event, "run_id", &RunId::nil().to_string());
+            assert_field_eq(&event, "exit_code", "1");
             assert_field_eq(&event, "failure_reason", reason.as_str());
             assert_field_eq(&event, "failure_class", "cli_nonzero");
+            assert_field_eq(&event, "failure_framework", "codex");
             assert_field_eq(&event, "failure_detail_source", "codex_jsonl");
         }
     }
@@ -1081,6 +1086,7 @@ mod tests {
             FailureReason::InvalidCredentials,
             FailureReason::OutputTokenLimit,
             FailureReason::ProviderOverloaded,
+            FailureReason::ProviderServerError,
             FailureReason::ReconnectRequired,
             FailureReason::UsageLimit,
         ] {

--- a/crates/runner/src/executor/tests/diagnostics_tests.rs
+++ b/crates/runner/src/executor/tests/diagnostics_tests.rs
@@ -387,6 +387,47 @@ async fn read_guest_failure_diagnostic_file_returns_valid_diagnostic() {
 }
 
 #[tokio::test]
+async fn read_guest_failure_diagnostic_file_tolerates_unknown_failure_reason() {
+    let sandbox = MockSandbox::new("test");
+    let diagnostic = serde_json::json!({
+        "schemaVersion": 1,
+        "failureClass": "cli_nonzero",
+        "framework": "claude_code",
+        "cliExitCode": 1,
+        "claudeNumTurns": 1,
+        "failureDetailSource": "claude_result",
+        "failureReason": "future_provider_reason",
+        "sessionHistoryStatus": "present",
+        "promptShape": "slash_like",
+        "promptBytes": 5,
+        "firstLineBytes": 5
+    });
+    sandbox.push_read_file_result(Ok(Some(serde_json::to_vec(&diagnostic).unwrap())));
+
+    let read = read_guest_failure_diagnostic_file(&sandbox, RunId::nil()).await;
+    let diagnostic = read.expect("unknown optional failure reason should not drop diagnostic");
+
+    assert_eq!(
+        diagnostic.failure_class,
+        agent_diagnostics::FailureClass::CliNonzero
+    );
+    assert_eq!(
+        diagnostic.framework,
+        agent_diagnostics::AgentFramework::ClaudeCode
+    );
+    assert_eq!(diagnostic.cli_exit_code, Some(1));
+    assert_eq!(
+        diagnostic.failure_detail_source,
+        Some(agent_diagnostics::FailureDetailSource::ClaudeResult)
+    );
+    assert_eq!(diagnostic.failure_reason, None);
+    assert_eq!(
+        diagnostic.session_history_status,
+        agent_diagnostics::SessionHistoryStatus::Present
+    );
+}
+
+#[tokio::test]
 async fn read_guest_failure_diagnostic_file_returns_none_on_missing_file() {
     let sandbox = MockSandbox::new("test");
     sandbox.push_read_file_result(Ok(None));

--- a/crates/runner/src/executor/tests/diagnostics_tests.rs
+++ b/crates/runner/src/executor/tests/diagnostics_tests.rs
@@ -387,47 +387,6 @@ async fn read_guest_failure_diagnostic_file_returns_valid_diagnostic() {
 }
 
 #[tokio::test]
-async fn read_guest_failure_diagnostic_file_tolerates_unknown_failure_reason() {
-    let sandbox = MockSandbox::new("test");
-    let diagnostic = serde_json::json!({
-        "schemaVersion": 1,
-        "failureClass": "cli_nonzero",
-        "framework": "claude_code",
-        "cliExitCode": 1,
-        "claudeNumTurns": 1,
-        "failureDetailSource": "claude_result",
-        "failureReason": "future_provider_reason",
-        "sessionHistoryStatus": "present",
-        "promptShape": "slash_like",
-        "promptBytes": 5,
-        "firstLineBytes": 5
-    });
-    sandbox.push_read_file_result(Ok(Some(serde_json::to_vec(&diagnostic).unwrap())));
-
-    let read = read_guest_failure_diagnostic_file(&sandbox, RunId::nil()).await;
-    let diagnostic = read.expect("unknown optional failure reason should not drop diagnostic");
-
-    assert_eq!(
-        diagnostic.failure_class,
-        agent_diagnostics::FailureClass::CliNonzero
-    );
-    assert_eq!(
-        diagnostic.framework,
-        agent_diagnostics::AgentFramework::ClaudeCode
-    );
-    assert_eq!(diagnostic.cli_exit_code, Some(1));
-    assert_eq!(
-        diagnostic.failure_detail_source,
-        Some(agent_diagnostics::FailureDetailSource::ClaudeResult)
-    );
-    assert_eq!(diagnostic.failure_reason, None);
-    assert_eq!(
-        diagnostic.session_history_status,
-        agent_diagnostics::SessionHistoryStatus::Present
-    );
-}
-
-#[tokio::test]
 async fn read_guest_failure_diagnostic_file_returns_none_on_missing_file() {
     let sandbox = MockSandbox::new("test");
     sandbox.push_read_file_result(Ok(None));


### PR DESCRIPTION
## Summary

- add `provider_server_error` to runner failure diagnostics
- classify Claude Code 500 server-side failures only when the selected detail comes from `ClaudeResult`
- avoid status-prefix false positives such as `API Error: 5000`
- log `CliNonzero + provider_server_error` runner failures at info while keeping non-CLI failures at error

## Testing

- `cargo test --manifest-path crates/Cargo.toml -p agent-diagnostics`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent cli_failure_reason`
- `cargo test --manifest-path crates/Cargo.toml -p runner expected_cli_failure_reasons_log_job_execution_failed_at_info`
- `cargo test --manifest-path crates/Cargo.toml -p runner info_level_reason_on_non_cli_failure_logs_job_execution_failed_at_error`
- `cargo test --manifest-path crates/Cargo.toml -p runner read_guest_failure_diagnostic_file`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`

Closes #18718