### PR TITLE
fix: cap connectors popover height to viewport and scroll

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -5203,7 +5203,7 @@ function ComputerUseConnectorMenuSection({
   onOpenDownloadDialog: () => void;
 }) {
   return (
-    <div className="border-t border-border/50 bg-gray-50 p-1 dark:bg-gray-100">
+    <div className="shrink-0 border-t border-border/50 bg-gray-50 p-1 dark:bg-gray-100">
       <div className="px-2 pb-1 pt-1 text-xs text-muted-foreground">
         Your computer
       </div>
@@ -5376,10 +5376,10 @@ function ConnectorsPopoverButton({
       <PopoverContent
         side="top"
         align="start"
-        className="w-72 overflow-hidden rounded-lg p-0"
+        className="flex max-h-[var(--radix-popover-content-available-height)] w-72 flex-col overflow-hidden rounded-lg p-0"
       >
         {(agentConnectors.length > 0 || connectorsLoading) && (
-          <div className="py-1">
+          <div className="flex min-h-0 flex-col py-1">
             {showSearch && (
               <div className="px-3 py-1 border-b border-border/50">
                 <input
@@ -5406,7 +5406,7 @@ function ConnectorsPopoverButton({
                 })}
               </div>
             ) : (
-              <div className="flex flex-col max-h-72 overflow-y-auto">
+              <div className="flex min-h-0 flex-col overflow-y-auto">
                 {visibleConnectors.map((item) => {
                   return (
                     <label
@@ -5435,7 +5435,7 @@ function ConnectorsPopoverButton({
             )}
           </div>
         )}
-        <div className="flex flex-col p-1">
+        <div className="flex shrink-0 flex-col p-1">
           {(agentConnectors.length > 0 || connectorsLoading) && (
             <div className="mx-2 mb-1 border-t border-border/50" />
           )}


### PR DESCRIPTION
## Problem

The chat composer **connectors** dropdown opens upward (`side="top"`). It stacks three sections with no overall height cap:

1. the connector list (Gmail, Notion, X, Google Drive, Slack, Google Sheets, Google Calendar…)
2. the **Add connectors** button
3. the **Your computer** section

With enough connectors the menu grows taller than the space above the composer, so the **top of the menu gets clipped off the top of the screen** — the first connectors become unreachable.

## Fix

`turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx`

- Constrain `PopoverContent` to `max-h-[var(--radix-popover-content-available-height)]` and make it a `flex` column (Radix already computes the available height between the trigger and the viewport edge).
- Make the connector list the flexible scroll region (`min-h-0`, drop the fixed `max-h-72`) so it shrinks and scrolls when space is tight.
- Pin **Add connectors** and **Your computer** as `shrink-0` footers so they stay visible while the list scrolls.

Pure Tailwind className changes, no logic. Prettier + oxlint pass on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)