### PR TITLE
perf: stream storage manifest through stdin

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1309,6 +1309,7 @@ dependencies = [
  "guest-common",
  "guest-contracts",
  "httpmock",
+ "libc",
  "serde",
  "serde_json",
  "tar",

--- a/crates/guest-download/Cargo.toml
+++ b/crates/guest-download/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 
 [dependencies]
 flate2.workspace = true
+libc.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 tar.workspace = true

--- a/crates/guest-download/src/lib.rs
+++ b/crates/guest-download/src/lib.rs
@@ -36,6 +36,24 @@ pub fn run(manifest_path: &str) -> bool {
         }
     };
 
+    run_manifest(manifest)
+}
+
+/// Run the download process for a manifest supplied as JSON bytes.
+/// Returns `true` if all downloads succeeded, `false` otherwise.
+pub fn run_manifest_bytes(manifest_json: &[u8]) -> bool {
+    let manifest = match Manifest::parse(manifest_json) {
+        Ok(manifest) => manifest,
+        Err(e) => {
+            log_error!(LOG_TAG, "Failed to parse manifest: {e}");
+            return false;
+        }
+    };
+
+    run_manifest(manifest)
+}
+
+fn run_manifest(manifest: Manifest) -> bool {
     let RunPlan {
         cleanup_paths,
         preserved_paths,

--- a/crates/guest-download/src/main.rs
+++ b/crates/guest-download/src/main.rs
@@ -48,9 +48,9 @@ fn manifest_input_from_args() -> Option<ManifestInput> {
 
 fn run(input: ManifestInput) -> bool {
     match input {
-        ManifestInput::Path(manifest_path) => guest_download::run(&manifest_path),
+        ManifestInput::Path(manifest_path) => run_path(&manifest_path),
         ManifestInput::Stdin => {
-            if !remove_legacy_manifest_file(LEGACY_MANIFEST_PATH) {
+            if !remove_manifest_file(LEGACY_MANIFEST_PATH) {
                 return false;
             }
 
@@ -64,12 +64,36 @@ fn run(input: ManifestInput) -> bool {
     }
 }
 
-fn remove_legacy_manifest_file(path: &str) -> bool {
+fn run_path(manifest_path: &str) -> bool {
+    if manifest_path == LEGACY_MANIFEST_PATH {
+        run_manifest_file_and_remove(manifest_path)
+    } else {
+        guest_download::run(manifest_path)
+    }
+}
+
+fn run_manifest_file_and_remove(manifest_path: &str) -> bool {
+    let manifest_json = match std::fs::read(manifest_path) {
+        Ok(manifest_json) => manifest_json,
+        Err(e) => {
+            log_error!(LOG_TAG, "Failed to read manifest: {e}");
+            return false;
+        }
+    };
+
+    if !remove_manifest_file(manifest_path) {
+        return false;
+    }
+
+    guest_download::run_manifest_bytes(&manifest_json)
+}
+
+fn remove_manifest_file(path: &str) -> bool {
     match std::fs::remove_file(path) {
         Ok(()) => true,
         Err(e) if e.kind() == ErrorKind::NotFound => true,
         Err(e) => {
-            log_error!(LOG_TAG, "Failed to remove stale manifest {path}: {e}");
+            log_error!(LOG_TAG, "Failed to remove storage manifest {path}: {e}");
             false
         }
     }
@@ -77,33 +101,55 @@ fn remove_legacy_manifest_file(path: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::remove_legacy_manifest_file;
+    use super::{remove_manifest_file, run_manifest_file_and_remove};
 
     #[test]
-    fn remove_legacy_manifest_file_removes_existing_file() {
+    fn remove_manifest_file_removes_existing_file() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("storage-manifest.json");
         std::fs::write(&path, br#"{"secret":"old"}"#).unwrap();
 
-        assert!(remove_legacy_manifest_file(path.to_str().unwrap()));
+        assert!(remove_manifest_file(path.to_str().unwrap()));
 
         assert!(!path.exists());
     }
 
     #[test]
-    fn remove_legacy_manifest_file_allows_missing_file() {
+    fn remove_manifest_file_allows_missing_file() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("missing-storage-manifest.json");
 
-        assert!(remove_legacy_manifest_file(path.to_str().unwrap()));
+        assert!(remove_manifest_file(path.to_str().unwrap()));
 
         assert!(!path.exists());
     }
 
     #[test]
-    fn remove_legacy_manifest_file_fails_for_non_removable_path() {
+    fn remove_manifest_file_fails_for_non_removable_path() {
         let dir = tempfile::tempdir().unwrap();
 
-        assert!(!remove_legacy_manifest_file(dir.path().to_str().unwrap()));
+        assert!(!remove_manifest_file(dir.path().to_str().unwrap()));
+    }
+
+    #[test]
+    fn run_manifest_file_and_remove_removes_file_on_success() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("storage-manifest.json");
+        std::fs::write(&path, br#"{"storages":[],"artifacts":[]}"#).unwrap();
+
+        assert!(run_manifest_file_and_remove(path.to_str().unwrap()));
+
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn run_manifest_file_and_remove_removes_file_on_parse_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("storage-manifest.json");
+        std::fs::write(&path, br#"{{not valid json secret-body"#).unwrap();
+
+        assert!(!run_manifest_file_and_remove(path.to_str().unwrap()));
+
+        assert!(!path.exists());
     }
 }

--- a/crates/guest-download/src/main.rs
+++ b/crates/guest-download/src/main.rs
@@ -1,5 +1,6 @@
 use guest_common::{log_error, log_info, telemetry::record_sandbox_op};
-use std::io::{ErrorKind, Read as _};
+use std::fs::{File, OpenOptions};
+use std::io::{self, ErrorKind, Read as _};
 use std::time::Instant;
 
 const LOG_TAG: &str = "sandbox:download";
@@ -73,7 +74,7 @@ fn run_path(manifest_path: &str) -> bool {
 }
 
 fn run_manifest_file_and_remove(manifest_path: &str) -> bool {
-    let manifest_json = match std::fs::read(manifest_path) {
+    let manifest_json = match read_manifest_file(manifest_path) {
         Ok(manifest_json) => manifest_json,
         Err(e) => {
             log_error!(LOG_TAG, "Failed to read manifest: {e}");
@@ -87,6 +88,55 @@ fn run_manifest_file_and_remove(manifest_path: &str) -> bool {
     }
 
     guest_download::run_manifest_bytes(&manifest_json)
+}
+
+fn read_manifest_file(path: &str) -> io::Result<Vec<u8>> {
+    let mut file = open_manifest_file(path)?;
+    let mut manifest_json = Vec::new();
+    file.read_to_end(&mut manifest_json)?;
+    Ok(manifest_json)
+}
+
+#[cfg(unix)]
+fn open_manifest_file(path: &str) -> io::Result<File> {
+    use std::os::unix::fs::OpenOptionsExt;
+    use std::os::unix::io::AsRawFd;
+
+    let file = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK)
+        .open(path)?;
+
+    let fd = file.as_raw_fd();
+    let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
+    // SAFETY: `stat` points to valid writable memory and `fd` comes from a live
+    // File. On success, fstat initializes the whole struct.
+    let result = unsafe { libc::fstat(fd, stat.as_mut_ptr()) };
+    if result != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: fstat succeeded and initialized `stat`.
+    let stat = unsafe { stat.assume_init() };
+    if stat.st_mode & libc::S_IFMT != libc::S_IFREG {
+        return Err(io::Error::new(
+            ErrorKind::InvalidInput,
+            "storage manifest is not a regular file",
+        ));
+    }
+
+    Ok(file)
+}
+
+#[cfg(not(unix))]
+fn open_manifest_file(path: &str) -> io::Result<File> {
+    let file = File::open(path)?;
+    if !file.metadata()?.is_file() {
+        return Err(io::Error::new(
+            ErrorKind::InvalidInput,
+            "storage manifest is not a regular file",
+        ));
+    }
+    Ok(file)
 }
 
 fn remove_manifest_file(path: &str) -> bool {
@@ -194,5 +244,40 @@ mod tests {
 
         assert!(!path.exists());
         assert!(target_dir.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_manifest_file_and_remove_rejects_symlink_to_regular_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target-manifest.json");
+        let path = dir.path().join("storage-manifest.json");
+        std::fs::write(&target, br#"{"storages":[],"artifacts":[]}"#).unwrap();
+        std::os::unix::fs::symlink(&target, &path).unwrap();
+
+        assert!(!run_manifest_file_and_remove(path.to_str().unwrap()));
+
+        assert!(!path.exists());
+        assert!(target.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_manifest_file_and_remove_rejects_fifo_without_blocking() {
+        use std::ffi::CString;
+        use std::io;
+        use std::os::unix::ffi::OsStrExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("storage-manifest.json");
+        let c_path = CString::new(path.as_os_str().as_bytes()).unwrap();
+
+        // SAFETY: `c_path` is a valid, NUL-terminated filesystem path.
+        let result = unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) };
+        assert_eq!(result, 0, "mkfifo failed: {}", io::Error::last_os_error());
+
+        assert!(!run_manifest_file_and_remove(path.to_str().unwrap()));
+
+        assert!(!path.exists());
     }
 }

--- a/crates/guest-download/src/main.rs
+++ b/crates/guest-download/src/main.rs
@@ -77,6 +77,7 @@ fn run_manifest_file_and_remove(manifest_path: &str) -> bool {
         Ok(manifest_json) => manifest_json,
         Err(e) => {
             log_error!(LOG_TAG, "Failed to read manifest: {e}");
+            let _ = remove_manifest_file(manifest_path);
             return false;
         }
     };
@@ -151,5 +152,20 @@ mod tests {
         assert!(!run_manifest_file_and_remove(path.to_str().unwrap()));
 
         assert!(!path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_manifest_file_and_remove_removes_symlink_on_read_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let target_dir = dir.path().join("target-dir");
+        let path = dir.path().join("storage-manifest.json");
+        std::fs::create_dir(&target_dir).unwrap();
+        std::os::unix::fs::symlink(&target_dir, &path).unwrap();
+
+        assert!(!run_manifest_file_and_remove(path.to_str().unwrap()));
+
+        assert!(!path.exists());
+        assert!(target_dir.exists());
     }
 }

--- a/crates/guest-download/src/main.rs
+++ b/crates/guest-download/src/main.rs
@@ -1,9 +1,10 @@
-use guest_common::{log_error, log_info, telemetry::record_sandbox_op};
-use std::io::Read as _;
+use guest_common::{log_error, log_info, log_warn, telemetry::record_sandbox_op};
+use std::io::{ErrorKind, Read as _};
 use std::time::Instant;
 
 const LOG_TAG: &str = "sandbox:download";
 const MANIFEST_STDIN_ARG: &str = "--manifest-stdin";
+const LEGACY_MANIFEST_PATH: &str = "/tmp/storage-manifest.json";
 const USAGE: &str = "Usage: guest-download <manifest_path> | --manifest-stdin";
 
 enum ManifestInput {
@@ -49,6 +50,8 @@ fn run(input: ManifestInput) -> bool {
     match input {
         ManifestInput::Path(manifest_path) => guest_download::run(&manifest_path),
         ManifestInput::Stdin => {
+            remove_legacy_manifest_file(LEGACY_MANIFEST_PATH);
+
             let mut manifest_json = Vec::new();
             if let Err(e) = std::io::stdin().read_to_end(&mut manifest_json) {
                 log_error!(LOG_TAG, "Failed to read manifest from stdin: {e}");
@@ -56,5 +59,39 @@ fn run(input: ManifestInput) -> bool {
             }
             guest_download::run_manifest_bytes(&manifest_json)
         }
+    }
+}
+
+fn remove_legacy_manifest_file(path: &str) {
+    match std::fs::remove_file(path) {
+        Ok(()) => {}
+        Err(e) if e.kind() == ErrorKind::NotFound => {}
+        Err(e) => log_warn!(LOG_TAG, "Failed to remove stale manifest {path}: {e}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::remove_legacy_manifest_file;
+
+    #[test]
+    fn remove_legacy_manifest_file_removes_existing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("storage-manifest.json");
+        std::fs::write(&path, br#"{"secret":"old"}"#).unwrap();
+
+        remove_legacy_manifest_file(path.to_str().unwrap());
+
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn remove_legacy_manifest_file_allows_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("missing-storage-manifest.json");
+
+        remove_legacy_manifest_file(path.to_str().unwrap());
+
+        assert!(!path.exists());
     }
 }

--- a/crates/guest-download/src/main.rs
+++ b/crates/guest-download/src/main.rs
@@ -1,4 +1,4 @@
-use guest_common::{log_error, log_info, log_warn, telemetry::record_sandbox_op};
+use guest_common::{log_error, log_info, telemetry::record_sandbox_op};
 use std::io::{ErrorKind, Read as _};
 use std::time::Instant;
 
@@ -50,7 +50,9 @@ fn run(input: ManifestInput) -> bool {
     match input {
         ManifestInput::Path(manifest_path) => guest_download::run(&manifest_path),
         ManifestInput::Stdin => {
-            remove_legacy_manifest_file(LEGACY_MANIFEST_PATH);
+            if !remove_legacy_manifest_file(LEGACY_MANIFEST_PATH) {
+                return false;
+            }
 
             let mut manifest_json = Vec::new();
             if let Err(e) = std::io::stdin().read_to_end(&mut manifest_json) {
@@ -62,11 +64,14 @@ fn run(input: ManifestInput) -> bool {
     }
 }
 
-fn remove_legacy_manifest_file(path: &str) {
+fn remove_legacy_manifest_file(path: &str) -> bool {
     match std::fs::remove_file(path) {
-        Ok(()) => {}
-        Err(e) if e.kind() == ErrorKind::NotFound => {}
-        Err(e) => log_warn!(LOG_TAG, "Failed to remove stale manifest {path}: {e}"),
+        Ok(()) => true,
+        Err(e) if e.kind() == ErrorKind::NotFound => true,
+        Err(e) => {
+            log_error!(LOG_TAG, "Failed to remove stale manifest {path}: {e}");
+            false
+        }
     }
 }
 
@@ -80,7 +85,7 @@ mod tests {
         let path = dir.path().join("storage-manifest.json");
         std::fs::write(&path, br#"{"secret":"old"}"#).unwrap();
 
-        remove_legacy_manifest_file(path.to_str().unwrap());
+        assert!(remove_legacy_manifest_file(path.to_str().unwrap()));
 
         assert!(!path.exists());
     }
@@ -90,8 +95,15 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("missing-storage-manifest.json");
 
-        remove_legacy_manifest_file(path.to_str().unwrap());
+        assert!(remove_legacy_manifest_file(path.to_str().unwrap()));
 
         assert!(!path.exists());
+    }
+
+    #[test]
+    fn remove_legacy_manifest_file_fails_for_non_removable_path() {
+        let dir = tempfile::tempdir().unwrap();
+
+        assert!(!remove_legacy_manifest_file(dir.path().to_str().unwrap()));
     }
 }

--- a/crates/guest-download/src/main.rs
+++ b/crates/guest-download/src/main.rs
@@ -1,5 +1,7 @@
 use guest_common::{log_error, log_info, telemetry::record_sandbox_op};
-use std::fs::{File, OpenOptions};
+use std::fs::File;
+#[cfg(unix)]
+use std::fs::OpenOptions;
 use std::io::{self, ErrorKind, Read as _};
 use std::time::Instant;
 

--- a/crates/guest-download/src/main.rs
+++ b/crates/guest-download/src/main.rs
@@ -50,7 +50,7 @@ fn run(input: ManifestInput) -> bool {
     match input {
         ManifestInput::Path(manifest_path) => run_path(&manifest_path),
         ManifestInput::Stdin => {
-            if !remove_manifest_file(LEGACY_MANIFEST_PATH) {
+            if !remove_stale_manifest_file(LEGACY_MANIFEST_PATH) {
                 return false;
             }
 
@@ -100,9 +100,27 @@ fn remove_manifest_file(path: &str) -> bool {
     }
 }
 
+fn remove_stale_manifest_file(path: &str) -> bool {
+    match std::fs::remove_file(path) {
+        Ok(()) => true,
+        Err(e) if e.kind() == ErrorKind::NotFound => true,
+        Err(e) if e.kind() == ErrorKind::IsADirectory => {
+            log_info!(
+                LOG_TAG,
+                "Skipping stale storage manifest cleanup because {path} is a directory"
+            );
+            true
+        }
+        Err(e) => {
+            log_error!(LOG_TAG, "Failed to remove storage manifest {path}: {e}");
+            false
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{remove_manifest_file, run_manifest_file_and_remove};
+    use super::{remove_manifest_file, remove_stale_manifest_file, run_manifest_file_and_remove};
 
     #[test]
     fn remove_manifest_file_removes_existing_file() {
@@ -130,6 +148,15 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
 
         assert!(!remove_manifest_file(dir.path().to_str().unwrap()));
+    }
+
+    #[test]
+    fn remove_stale_manifest_file_allows_directory_without_removing_it() {
+        let dir = tempfile::tempdir().unwrap();
+
+        assert!(remove_stale_manifest_file(dir.path().to_str().unwrap()));
+
+        assert!(dir.path().is_dir());
     }
 
     #[test]

--- a/crates/guest-download/src/main.rs
+++ b/crates/guest-download/src/main.rs
@@ -35,10 +35,10 @@ fn main() {
 fn manifest_input_from_args() -> Option<ManifestInput> {
     let mut args = std::env::args().skip(1);
     let arg = args.next()?;
-    if args.next().is_some() {
-        return None;
-    }
     if arg == MANIFEST_STDIN_ARG {
+        if args.next().is_some() {
+            return None;
+        }
         Some(ManifestInput::Stdin)
     } else {
         Some(ManifestInput::Path(arg))

--- a/crates/guest-download/src/main.rs
+++ b/crates/guest-download/src/main.rs
@@ -1,18 +1,26 @@
 use guest_common::{log_error, log_info, telemetry::record_sandbox_op};
+use std::io::Read as _;
 use std::time::Instant;
 
 const LOG_TAG: &str = "sandbox:download";
+const MANIFEST_STDIN_ARG: &str = "--manifest-stdin";
+const USAGE: &str = "Usage: guest-download <manifest_path> | --manifest-stdin";
+
+enum ManifestInput {
+    Path(String),
+    Stdin,
+}
 
 fn main() {
     guest_common::log::enable_system_log_file();
 
-    let Some(manifest_path) = std::env::args().nth(1) else {
-        log_error!(LOG_TAG, "Usage: guest-download <manifest_path>");
+    let Some(input) = manifest_input_from_args() else {
+        log_error!(LOG_TAG, "{USAGE}");
         std::process::exit(1);
     };
 
     let start = Instant::now();
-    let success = guest_download::run(&manifest_path);
+    let success = run(input);
     let elapsed = start.elapsed();
 
     record_sandbox_op("download_total", elapsed, success, None);
@@ -21,5 +29,32 @@ fn main() {
     } else {
         log_error!(LOG_TAG, "Download failed");
         std::process::exit(1);
+    }
+}
+
+fn manifest_input_from_args() -> Option<ManifestInput> {
+    let mut args = std::env::args().skip(1);
+    let arg = args.next()?;
+    if args.next().is_some() {
+        return None;
+    }
+    if arg == MANIFEST_STDIN_ARG {
+        Some(ManifestInput::Stdin)
+    } else {
+        Some(ManifestInput::Path(arg))
+    }
+}
+
+fn run(input: ManifestInput) -> bool {
+    match input {
+        ManifestInput::Path(manifest_path) => guest_download::run(&manifest_path),
+        ManifestInput::Stdin => {
+            let mut manifest_json = Vec::new();
+            if let Err(e) = std::io::stdin().read_to_end(&mut manifest_json) {
+                log_error!(LOG_TAG, "Failed to read manifest from stdin: {e}");
+                return false;
+            }
+            guest_download::run_manifest_bytes(&manifest_json)
+        }
     }
 }

--- a/crates/guest-download/src/manifest.rs
+++ b/crates/guest-download/src/manifest.rs
@@ -18,7 +18,11 @@ pub(crate) struct Manifest {
 impl Manifest {
     pub(crate) fn load(manifest_path: &str) -> Result<Self, ManifestLoadError> {
         let manifest_json = fs::read_to_string(manifest_path).map_err(ManifestLoadError::Read)?;
-        serde_json::from_str(&manifest_json).map_err(ManifestLoadError::Parse)
+        Self::parse(manifest_json.as_bytes()).map_err(ManifestLoadError::Parse)
+    }
+
+    pub(crate) fn parse(manifest_json: &[u8]) -> Result<Self, serde_json::Error> {
+        serde_json::from_slice(manifest_json)
     }
 }
 

--- a/crates/guest-download/tests/integration/binary_logging.rs
+++ b/crates/guest-download/tests/integration/binary_logging.rs
@@ -118,6 +118,62 @@ fn binary_reads_manifest_from_stdin() {
 }
 
 #[test]
+fn binary_path_mode_ignores_extra_args_for_compatibility() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest_path = write_manifest(&dir, &[], None).unwrap();
+    let run_id = unique_run_id("path-extra-arg");
+    let logs = RuntimeLogPaths::new(&dir);
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_guest-download"))
+        .arg(&manifest_path)
+        .arg("--ignored")
+        .env("VM0_RUN_ID", &run_id)
+        .env(
+            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+            &logs.runtime_dir,
+        )
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let content = std::fs::read_to_string(&logs.system_log).unwrap();
+    assert!(
+        content.contains("[INFO] [sandbox:download] Download completed"),
+        "unexpected system log: {content:?}"
+    );
+}
+
+#[test]
+fn binary_manifest_stdin_rejects_extra_args_before_telemetry() {
+    let dir = tempfile::tempdir().unwrap();
+    let run_id = unique_run_id("stdin-extra-arg");
+    let logs = RuntimeLogPaths::new(&dir);
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_guest-download"))
+        .arg("--manifest-stdin")
+        .arg("--ignored")
+        .env("VM0_RUN_ID", &run_id)
+        .env(
+            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+            &logs.runtime_dir,
+        )
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let content = std::fs::read_to_string(&logs.system_log).unwrap();
+    assert!(
+        content.contains("[ERROR] [sandbox:download] Usage: guest-download"),
+        "unexpected system log: {content:?}"
+    );
+    assert!(!logs.ops_log.exists());
+}
+
+#[test]
 fn binary_invalid_stdin_manifest_logs_parse_failure_without_body() {
     let dir = tempfile::tempdir().unwrap();
     let run_id = unique_run_id("stdin-invalid");

--- a/crates/guest-download/tests/integration/binary_logging.rs
+++ b/crates/guest-download/tests/integration/binary_logging.rs
@@ -1,6 +1,10 @@
-use crate::support::{assert_does_not_contain_any, create_tar_gz, unique_run_id, write_manifest};
+use crate::support::{
+    assert_does_not_contain_any, create_tar_gz, manifest_json, unique_run_id, write_manifest,
+};
 use httpmock::prelude::*;
+use std::io::{self, Write as _};
 use std::path::PathBuf;
+use std::process::{Output, Stdio};
 use tempfile::TempDir;
 
 struct RuntimeLogPaths {
@@ -18,6 +22,28 @@ impl RuntimeLogPaths {
             runtime_dir,
         }
     }
+}
+
+fn run_binary_with_manifest_stdin(
+    manifest_json: &[u8],
+    run_id: &str,
+    logs: &RuntimeLogPaths,
+) -> io::Result<Output> {
+    let mut child = std::process::Command::new(env!("CARGO_BIN_EXE_guest-download"))
+        .arg("--manifest-stdin")
+        .env("VM0_RUN_ID", run_id)
+        .env(
+            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+            &logs.runtime_dir,
+        )
+        .stdin(Stdio::piped())
+        .spawn()?;
+    child
+        .stdin
+        .as_mut()
+        .ok_or_else(|| io::Error::other("guest-download stdin unavailable"))?
+        .write_all(manifest_json)?;
+    child.wait_with_output()
 }
 
 #[test]
@@ -60,6 +86,63 @@ fn binary_writes_system_log_to_guest_common_default_path() {
         .collect();
     assert_eq!(totals.len(), 1, "unexpected ops log: {ops_content}");
     assert_eq!(totals[0]["success"], true);
+}
+
+#[test]
+fn binary_reads_manifest_from_stdin() {
+    let dir = tempfile::tempdir().unwrap();
+    let run_id = unique_run_id("stdin-success");
+    let logs = RuntimeLogPaths::new(&dir);
+    let json = manifest_json(&[], None).unwrap();
+
+    let output = run_binary_with_manifest_stdin(&json, &run_id, &logs).unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let content = std::fs::read_to_string(&logs.system_log).unwrap();
+    assert!(
+        content.contains("[INFO] [sandbox:download] Download completed"),
+        "unexpected system log: {content:?}"
+    );
+    let ops_content = std::fs::read_to_string(&logs.ops_log).unwrap();
+    let totals: Vec<serde_json::Value> = ops_content
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .filter(|entry: &serde_json::Value| entry["action_type"] == "download_total")
+        .collect();
+    assert_eq!(totals.len(), 1, "unexpected ops log: {ops_content}");
+    assert_eq!(totals[0]["success"], true);
+}
+
+#[test]
+fn binary_invalid_stdin_manifest_logs_parse_failure_without_body() {
+    let dir = tempfile::tempdir().unwrap();
+    let run_id = unique_run_id("stdin-invalid");
+    let logs = RuntimeLogPaths::new(&dir);
+    let body = b"{{not valid json super-secret-body";
+
+    let output = run_binary_with_manifest_stdin(body, &run_id, &logs).unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!stderr.contains("super-secret-body"));
+    let content = std::fs::read_to_string(&logs.system_log).unwrap();
+    assert!(
+        content.contains("[ERROR] [sandbox:download] Failed to parse manifest"),
+        "unexpected system log: {content:?}"
+    );
+    assert!(!content.contains("super-secret-body"));
+    let ops_content = std::fs::read_to_string(&logs.ops_log).unwrap();
+    let totals: Vec<serde_json::Value> = ops_content
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .filter(|entry: &serde_json::Value| entry["action_type"] == "download_total")
+        .collect();
+    assert_eq!(totals.len(), 1, "unexpected ops log: {ops_content}");
+    assert_eq!(totals[0]["success"], false);
 }
 
 #[test]

--- a/crates/guest-download/tests/integration/download.rs
+++ b/crates/guest-download/tests/integration/download.rs
@@ -1,5 +1,6 @@
 use crate::support::{
-    TarEntry, create_tar_gz, create_tar_gz_entries, run_guest_download, write_manifest,
+    TarEntry, create_tar_gz, create_tar_gz_entries, manifest_json, run_guest_download,
+    run_guest_download_manifest_json, write_manifest,
 };
 use httpmock::Mock;
 use httpmock::prelude::*;
@@ -447,6 +448,22 @@ fn manifest_json_invalid() {
     std::fs::write(&manifest_path, "{{not valid json").unwrap();
 
     let result = run_guest_download(manifest_path.to_str().unwrap());
+    assert!(!result);
+}
+
+#[test]
+fn manifest_json_from_stdin_valid() {
+    let json = manifest_json(&[], None).unwrap();
+
+    let result = run_guest_download_manifest_json(&json);
+
+    assert!(result);
+}
+
+#[test]
+fn manifest_json_from_stdin_invalid() {
+    let result = run_guest_download_manifest_json(b"{{not valid json secret-body");
+
     assert!(!result);
 }
 

--- a/crates/guest-download/tests/integration/support.rs
+++ b/crates/guest-download/tests/integration/support.rs
@@ -133,6 +133,16 @@ pub(crate) fn write_manifest(
     storages: &[(&str, Option<&str>)],
     artifact: Option<(&str, Option<&str>)>,
 ) -> std::io::Result<PathBuf> {
+    let json = manifest_json(storages, artifact)?;
+    let manifest_path = dir.path().join("manifest.json");
+    std::fs::write(&manifest_path, json)?;
+    Ok(manifest_path)
+}
+
+pub(crate) fn manifest_json(
+    storages: &[(&str, Option<&str>)],
+    artifact: Option<(&str, Option<&str>)>,
+) -> std::io::Result<Vec<u8>> {
     let mut manifest = Map::new();
     manifest.insert(
         "storages".to_owned(),
@@ -151,11 +161,7 @@ pub(crate) fn write_manifest(
         );
     }
 
-    let json = serde_json::to_vec(&Value::Object(manifest)).map_err(std::io::Error::other)?;
-
-    let manifest_path = dir.path().join("manifest.json");
-    std::fs::write(&manifest_path, json)?;
-    Ok(manifest_path)
+    serde_json::to_vec(&Value::Object(manifest)).map_err(std::io::Error::other)
 }
 
 fn manifest_entry(mount_path: &str, archive_url: Option<&str>) -> Value {
@@ -170,6 +176,11 @@ fn manifest_entry(mount_path: &str, archive_url: Option<&str>) -> Value {
 pub(crate) fn run_guest_download(manifest_path: &str) -> bool {
     guest_common::log::clear_system_log_file();
     guest_download::run(manifest_path)
+}
+
+pub(crate) fn run_guest_download_manifest_json(manifest_json: &[u8]) -> bool {
+    guest_common::log::clear_system_log_file();
+    guest_download::run_manifest_bytes(manifest_json)
 }
 
 pub(crate) fn assert_does_not_contain_any(haystack_name: &str, haystack: &str, forbidden: &[&str]) {

--- a/crates/guest-write-file/src/lib.rs
+++ b/crates/guest-write-file/src/lib.rs
@@ -94,7 +94,7 @@ fn output_options(append: bool) -> OpenOptions {
     {
         use std::os::unix::fs::OpenOptionsExt;
 
-        options.custom_flags(libc::O_NONBLOCK);
+        options.custom_flags(libc::O_NONBLOCK | libc::O_NOFOLLOW);
     }
 
     options

--- a/crates/guest-write-file/tests/integration.rs
+++ b/crates/guest-write-file/tests/integration.rs
@@ -237,6 +237,38 @@ fn create_mode_rejects_character_device_target() {
 
 #[cfg(unix)]
 #[test]
+fn create_mode_rejects_symlink_target_without_truncating_target() {
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("target.txt");
+    let link = dir.path().join("link.txt");
+    std::fs::write(&target, b"keep").unwrap();
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+
+    let output = run_helper(&[link.to_str().unwrap()], b"replace");
+
+    assert!(!output.status.success());
+    assert_eq!(std::fs::read(&target).unwrap(), b"keep");
+    assert!(link.symlink_metadata().unwrap().file_type().is_symlink());
+}
+
+#[cfg(unix)]
+#[test]
+fn append_mode_rejects_symlink_target_without_appending_target() {
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("target.txt");
+    let link = dir.path().join("link.txt");
+    std::fs::write(&target, b"keep").unwrap();
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+
+    let output = run_helper(&["--append", link.to_str().unwrap()], b"append");
+
+    assert!(!output.status.success());
+    assert_eq!(std::fs::read(&target).unwrap(), b"keep");
+    assert!(link.symlink_metadata().unwrap().file_type().is_symlink());
+}
+
+#[cfg(unix)]
+#[test]
 fn create_mode_fails_fast_for_fifo_without_reader() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("fifo");

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -29,6 +29,7 @@ tokio-util = { workspace = true, features = ["io", "io-util"] }
 tracing = { workspace = true }
 tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true }
+vsock-proto = { workspace = true }
 flate2 = { workspace = true }
 futures-util = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -29,7 +29,6 @@ tokio-util = { workspace = true, features = ["io", "io-util"] }
 tracing = { workspace = true }
 tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true }
-vsock-proto = { workspace = true }
 flate2 = { workspace = true }
 futures-util = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/runner/src/executor/storage.rs
+++ b/crates/runner/src/executor/storage.rs
@@ -178,6 +178,9 @@ pub(super) async fn download_storages(
 ) -> RunnerResult<()> {
     let manifest_json = serde_json::to_vec(manifest)
         .map_err(|e| RunnerError::Internal(format!("manifest json: {e}")))?;
+    let run_id = context.run_id.to_string();
+    let runtime_dir = guest_runtime_dir(context.run_id)?;
+    let download_env = guest_download_env(&run_id, &runtime_dir);
     let use_stdin = manifest_json.len() <= vsock_proto::MAX_EXEC_STDIN_BYTES;
     let download_cmd = if use_stdin {
         guest_download_stdin_command()
@@ -194,9 +197,6 @@ pub(super) async fn download_storages(
     };
     let stdin_bytes = use_stdin.then_some(manifest_json.as_slice());
 
-    let run_id = context.run_id.to_string();
-    let runtime_dir = guest_runtime_dir(context.run_id)?;
-    let download_env = guest_download_env(&run_id, &runtime_dir);
     info!(run_id = %context.run_id, "downloading storages");
     let result = match sandbox
         .exec_with_diagnostic_label(

--- a/crates/runner/src/executor/storage.rs
+++ b/crates/runner/src/executor/storage.rs
@@ -182,6 +182,7 @@ pub(super) async fn download_storages(
     let download_cmd = if use_stdin {
         guest_download_stdin_command()
     } else {
+        remove_fallback_storage_manifest(sandbox).await?;
         if let Err(error) = sandbox
             .write_file(guest::STORAGE_MANIFEST, &manifest_json)
             .await
@@ -235,8 +236,21 @@ async fn cleanup_fallback_storage_manifest_after_failure(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,
 ) {
+    match remove_fallback_storage_manifest(sandbox).await {
+        Ok(()) => {}
+        Err(error) => {
+            warn!(
+                run_id = %context.run_id,
+                error = %error,
+                "failed to remove fallback storage manifest after fallback failure"
+            );
+        }
+    }
+}
+
+async fn remove_fallback_storage_manifest(sandbox: &dyn Sandbox) -> RunnerResult<()> {
     let cleanup_cmd = guest_storage_manifest_cleanup_command();
-    let cleanup_result = sandbox
+    let result = sandbox
         .exec_with_diagnostic_label(
             &ExecRequest {
                 cmd: &cleanup_cmd,
@@ -248,25 +262,16 @@ async fn cleanup_fallback_storage_manifest_after_failure(
             },
             "storage-manifest-cleanup",
         )
-        .await;
+        .await?;
 
-    match cleanup_result {
-        Ok(result) if helper_exec_succeeded(&result) => {}
-        Ok(result) => {
-            warn!(
-                run_id = %context.run_id,
-                error = %format_helper_exec_failure("storage manifest cleanup", &result),
-                "failed to remove fallback storage manifest after fallback failure"
-            );
-        }
-        Err(error) => {
-            warn!(
-                run_id = %context.run_id,
-                error = %error,
-                "failed to remove fallback storage manifest after fallback failure"
-            );
-        }
+    if !helper_exec_succeeded(&result) {
+        return Err(RunnerError::Internal(format_helper_exec_failure(
+            "storage manifest cleanup",
+            &result,
+        )));
     }
+
+    Ok(())
 }
 
 pub(super) fn format_guest_download_failure(result: &sandbox::ExecResult) -> String {

--- a/crates/runner/src/executor/storage.rs
+++ b/crates/runner/src/executor/storage.rs
@@ -182,9 +182,13 @@ pub(super) async fn download_storages(
     let download_cmd = if use_stdin {
         guest_download_stdin_command()
     } else {
-        sandbox
+        if let Err(error) = sandbox
             .write_file(guest::STORAGE_MANIFEST, &manifest_json)
-            .await?;
+            .await
+        {
+            cleanup_fallback_storage_manifest_after_failure(sandbox, context).await;
+            return Err(error.into());
+        }
         guest_download_command()
     };
     let stdin_bytes = use_stdin.then_some(manifest_json.as_slice());
@@ -210,7 +214,7 @@ pub(super) async fn download_storages(
         Ok(result) => result,
         Err(e) => {
             if !use_stdin {
-                cleanup_fallback_storage_manifest_after_exec_error(sandbox, context).await;
+                cleanup_fallback_storage_manifest_after_failure(sandbox, context).await;
             }
             return Err(e.into());
         }
@@ -218,7 +222,7 @@ pub(super) async fn download_storages(
 
     if !helper_exec_succeeded(&result) {
         if !use_stdin {
-            cleanup_fallback_storage_manifest_after_exec_error(sandbox, context).await;
+            cleanup_fallback_storage_manifest_after_failure(sandbox, context).await;
         }
         return Err(RunnerError::Internal(format_guest_download_failure(
             &result,
@@ -227,7 +231,7 @@ pub(super) async fn download_storages(
     Ok(())
 }
 
-async fn cleanup_fallback_storage_manifest_after_exec_error(
+async fn cleanup_fallback_storage_manifest_after_failure(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,
 ) {
@@ -252,14 +256,14 @@ async fn cleanup_fallback_storage_manifest_after_exec_error(
             warn!(
                 run_id = %context.run_id,
                 error = %format_helper_exec_failure("storage manifest cleanup", &result),
-                "failed to remove fallback storage manifest after exec error"
+                "failed to remove fallback storage manifest after fallback failure"
             );
         }
         Err(error) => {
             warn!(
                 run_id = %context.run_id,
                 error = %error,
-                "failed to remove fallback storage manifest after exec error"
+                "failed to remove fallback storage manifest after fallback failure"
             );
         }
     }

--- a/crates/runner/src/executor/storage.rs
+++ b/crates/runner/src/executor/storage.rs
@@ -147,6 +147,10 @@ pub(super) fn guest_download_command() -> String {
     format!("{} {}", guest::DOWNLOAD_BIN, guest::STORAGE_MANIFEST)
 }
 
+pub(super) fn guest_download_stdin_command() -> String {
+    format!("{} --manifest-stdin", guest::DOWNLOAD_BIN)
+}
+
 pub(super) fn guest_download_env<'a>(
     run_id: &'a str,
     runtime_dir: &'a str,
@@ -167,11 +171,17 @@ pub(super) async fn download_storages(
 ) -> RunnerResult<()> {
     let manifest_json = serde_json::to_vec(manifest)
         .map_err(|e| RunnerError::Internal(format!("manifest json: {e}")))?;
-    sandbox
-        .write_file(guest::STORAGE_MANIFEST, &manifest_json)
-        .await?;
+    let use_stdin = manifest_json.len() <= vsock_proto::MAX_EXEC_STDIN_BYTES;
+    let download_cmd = if use_stdin {
+        guest_download_stdin_command()
+    } else {
+        sandbox
+            .write_file(guest::STORAGE_MANIFEST, &manifest_json)
+            .await?;
+        guest_download_command()
+    };
+    let stdin_bytes = use_stdin.then_some(manifest_json.as_slice());
 
-    let download_cmd = guest_download_command();
     let run_id = context.run_id.to_string();
     let runtime_dir = guest_runtime_dir(context.run_id)?;
     let download_env = guest_download_env(&run_id, &runtime_dir);
@@ -183,7 +193,7 @@ pub(super) async fn download_storages(
                 timeout: DEFAULT_EXEC_TIMEOUT,
                 env: &download_env,
                 sudo: false,
-                stdin_bytes: None,
+                stdin_bytes,
                 output_limits: EXEC_OUTPUT_LIMIT_1_MIB,
             },
             "storage-download",

--- a/crates/runner/src/executor/storage.rs
+++ b/crates/runner/src/executor/storage.rs
@@ -1,9 +1,10 @@
 //! Storage manifest filtering and guest download helpers.
 
 use std::collections::{HashMap, HashSet};
+use std::time::Duration;
 
-use sandbox::{EXEC_OUTPUT_LIMIT_1_MIB, ExecRequest, Sandbox};
-use tracing::info;
+use sandbox::{EXEC_OUTPUT_LIMIT_1_MIB, EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, Sandbox};
+use tracing::{info, warn};
 
 use super::{DEFAULT_EXEC_TIMEOUT, RunnerError, RunnerResult, guest_runtime_dir};
 use crate::helper_exec::{format_helper_exec_failure, helper_exec_succeeded};
@@ -12,6 +13,8 @@ use crate::storage_fingerprints::{StorageFingerprint, StorageFingerprints};
 use crate::types::{
     ExecutionContext, GuestDownloadArtifactEntry, GuestDownloadManifest, GuestDownloadStorageEntry,
 };
+
+const STORAGE_MANIFEST_CLEANUP_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Default)]
 struct ManifestReuseFilter {
@@ -151,6 +154,10 @@ pub(super) fn guest_download_stdin_command() -> String {
     format!("{} --manifest-stdin", guest::DOWNLOAD_BIN)
 }
 
+pub(super) fn guest_storage_manifest_cleanup_command() -> String {
+    format!("rm -f -- {}", guest::STORAGE_MANIFEST)
+}
+
 pub(super) fn guest_download_env<'a>(
     run_id: &'a str,
     runtime_dir: &'a str,
@@ -186,7 +193,7 @@ pub(super) async fn download_storages(
     let runtime_dir = guest_runtime_dir(context.run_id)?;
     let download_env = guest_download_env(&run_id, &runtime_dir);
     info!(run_id = %context.run_id, "downloading storages");
-    let result = sandbox
+    let result = match sandbox
         .exec_with_diagnostic_label(
             &ExecRequest {
                 cmd: &download_cmd,
@@ -198,7 +205,16 @@ pub(super) async fn download_storages(
             },
             "storage-download",
         )
-        .await?;
+        .await
+    {
+        Ok(result) => result,
+        Err(e) => {
+            if !use_stdin {
+                cleanup_fallback_storage_manifest_after_exec_error(sandbox, context).await;
+            }
+            return Err(e.into());
+        }
+    };
 
     if !helper_exec_succeeded(&result) {
         return Err(RunnerError::Internal(format_guest_download_failure(
@@ -206,6 +222,44 @@ pub(super) async fn download_storages(
         )));
     }
     Ok(())
+}
+
+async fn cleanup_fallback_storage_manifest_after_exec_error(
+    sandbox: &dyn Sandbox,
+    context: &ExecutionContext,
+) {
+    let cleanup_cmd = guest_storage_manifest_cleanup_command();
+    let cleanup_result = sandbox
+        .exec_with_diagnostic_label(
+            &ExecRequest {
+                cmd: &cleanup_cmd,
+                timeout: STORAGE_MANIFEST_CLEANUP_TIMEOUT,
+                env: &[],
+                sudo: false,
+                stdin_bytes: None,
+                output_limits: EXEC_OUTPUT_LIMIT_64_KIB,
+            },
+            "storage-manifest-cleanup",
+        )
+        .await;
+
+    match cleanup_result {
+        Ok(result) if helper_exec_succeeded(&result) => {}
+        Ok(result) => {
+            warn!(
+                run_id = %context.run_id,
+                error = %format_helper_exec_failure("storage manifest cleanup", &result),
+                "failed to remove fallback storage manifest after exec error"
+            );
+        }
+        Err(error) => {
+            warn!(
+                run_id = %context.run_id,
+                error = %error,
+                "failed to remove fallback storage manifest after exec error"
+            );
+        }
+    }
 }
 
 pub(super) fn format_guest_download_failure(result: &sandbox::ExecResult) -> String {

--- a/crates/runner/src/executor/storage.rs
+++ b/crates/runner/src/executor/storage.rs
@@ -217,6 +217,9 @@ pub(super) async fn download_storages(
     };
 
     if !helper_exec_succeeded(&result) {
+        if !use_stdin {
+            cleanup_fallback_storage_manifest_after_exec_error(sandbox, context).await;
+        }
         return Err(RunnerError::Internal(format_guest_download_failure(
             &result,
         )));

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -8,7 +8,7 @@ use sandbox_mock::MockSandboxFactory;
 
 use super::super::agent_run::{ProcessCancelTimeouts, RunControls, RunStart, run_in_sandbox};
 use super::super::diagnostics::AgentStdoutStreamDiagnostics;
-use super::super::storage::guest_download_command;
+use super::super::storage::guest_download_stdin_command;
 use super::super::{EXIT_SIGKILL, PROCESS_CANCEL_WRITE_TIMEOUT};
 use super::support::{
     CancelAfterWaitSandbox, RUN_IN_SANDBOX_TEST_TIMEOUT, api_storage, create_overridden_sandbox,
@@ -120,7 +120,7 @@ async fn run_in_sandbox_runs_guest_download_for_cached_instruction_normalization
     assert!(
         exec_calls
             .iter()
-            .any(|call| call.cmd == guest_download_command()),
+            .any(|call| call.cmd == guest_download_stdin_command()),
         "cached instruction storage should still invoke guest-download; calls: {exec_calls:?}"
     );
 }

--- a/crates/runner/src/executor/tests/storage_tests.rs
+++ b/crates/runner/src/executor/tests/storage_tests.rs
@@ -387,6 +387,30 @@ async fn download_storages_fails_on_write_file_error() {
     assert_eq!(exec_calls[1].cmd, guest_storage_manifest_cleanup_command());
 }
 
+#[tokio::test]
+async fn download_storages_retains_write_file_error_when_failure_cleanup_fails() {
+    let sandbox = MockSandbox::new("test");
+    sandbox.push_exec_result(Ok(ExecResult::new(0, Vec::new(), Vec::new())));
+    sandbox.push_exec_result(Ok(ExecResult::new(
+        1,
+        Vec::new(),
+        b"rm: cannot remove manifest".to_vec(),
+    )));
+    sandbox.push_write_file_result(Err(sandbox_write_file_error("vsock write failed")));
+    let ctx = minimal_context();
+    let manifest = manifest_with_serialized_len(vsock_proto::MAX_EXEC_STDIN_BYTES + 1);
+
+    let err = download_storages(&sandbox, &ctx, &manifest)
+        .await
+        .unwrap_err();
+
+    assert!(err.to_string().contains("vsock write failed"), "got: {err}");
+    let exec_calls = sandbox.exec_calls();
+    assert_eq!(exec_calls.len(), 2);
+    assert_eq!(exec_calls[0].cmd, guest_storage_manifest_cleanup_command());
+    assert_eq!(exec_calls[1].cmd, guest_storage_manifest_cleanup_command());
+}
+
 // -----------------------------------------------------------------------
 // apply_storage_fingerprint_reuse tests
 // -----------------------------------------------------------------------

--- a/crates/runner/src/executor/tests/storage_tests.rs
+++ b/crates/runner/src/executor/tests/storage_tests.rs
@@ -8,9 +8,9 @@ use super::super::guest_runtime_dir;
 use super::super::storage::{
     apply_storage_fingerprint_reuse, download_storages, format_guest_download_failure,
     guest_download_command, guest_download_env, guest_download_has_work,
-    guest_download_stdin_command,
+    guest_download_stdin_command, guest_storage_manifest_cleanup_command,
 };
-use super::support::{minimal_context, sandbox_write_file_error};
+use super::support::{minimal_context, sandbox_exec_error, sandbox_write_file_error};
 use crate::helper_exec::{HELPER_EXEC_OUTPUT_EXCERPT_BYTES, format_command_output_excerpt};
 use crate::paths::guest;
 use crate::storage_fingerprints::{StorageFingerprint, StorageFingerprints};
@@ -120,6 +120,42 @@ async fn download_storages_oversized_manifest_falls_back_to_write_file() {
     assert_eq!(exec_calls.len(), 1);
     assert_eq!(exec_calls[0].cmd, guest_download_command());
     assert!(exec_calls[0].stdin_bytes.is_none());
+}
+
+#[tokio::test]
+async fn download_storages_oversized_manifest_cleans_file_on_exec_error() {
+    let sandbox = MockSandbox::new("test");
+    sandbox.push_exec_result(Err(sandbox_exec_error("vsock exec failed")));
+    let ctx = minimal_context();
+    let manifest = manifest_with_serialized_len(vsock_proto::MAX_EXEC_STDIN_BYTES + 1);
+
+    let err = download_storages(&sandbox, &ctx, &manifest)
+        .await
+        .unwrap_err();
+
+    assert!(err.to_string().contains("vsock exec failed"), "got: {err}");
+    let exec_calls = sandbox.exec_calls();
+    assert_eq!(exec_calls.len(), 2);
+    assert_eq!(exec_calls[0].cmd, guest_download_command());
+    assert_eq!(exec_calls[1].cmd, guest_storage_manifest_cleanup_command());
+    assert_eq!(exec_calls[1].timeout, std::time::Duration::from_secs(5));
+}
+
+#[tokio::test]
+async fn download_storages_stdin_manifest_does_not_cleanup_on_exec_error() {
+    let sandbox = MockSandbox::new("test");
+    sandbox.push_exec_result(Err(sandbox_exec_error("vsock exec failed")));
+    let ctx = minimal_context();
+    let manifest = manifest_with_serialized_len(vsock_proto::MAX_EXEC_STDIN_BYTES);
+
+    let err = download_storages(&sandbox, &ctx, &manifest)
+        .await
+        .unwrap_err();
+
+    assert!(err.to_string().contains("vsock exec failed"), "got: {err}");
+    let exec_calls = sandbox.exec_calls();
+    assert_eq!(exec_calls.len(), 1);
+    assert_eq!(exec_calls[0].cmd, guest_download_stdin_command());
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor/tests/storage_tests.rs
+++ b/crates/runner/src/executor/tests/storage_tests.rs
@@ -8,16 +8,18 @@ use super::super::guest_runtime_dir;
 use super::super::storage::{
     apply_storage_fingerprint_reuse, download_storages, format_guest_download_failure,
     guest_download_command, guest_download_env, guest_download_has_work,
+    guest_download_stdin_command,
 };
 use super::support::{minimal_context, sandbox_write_file_error};
 use crate::helper_exec::{HELPER_EXEC_OUTPUT_EXCERPT_BYTES, format_command_output_excerpt};
+use crate::paths::guest;
 use crate::storage_fingerprints::{StorageFingerprint, StorageFingerprints};
 use crate::types::{GuestDownloadArtifactEntry, GuestDownloadManifest, GuestDownloadStorageEntry};
 
 #[tokio::test]
 async fn download_storages_success() {
     let sandbox = MockSandbox::new("test");
-    // write_file succeeds by default, exec returns exit 0 by default.
+    // exec returns exit 0 by default.
     let ctx = minimal_context();
     let manifest = GuestDownloadManifest {
         storages: vec![guest_storage(
@@ -29,7 +31,17 @@ async fn download_storages_success() {
         artifacts: vec![],
         cleanup_paths: vec![],
     };
+    let manifest_json = serde_json::to_vec(&manifest).unwrap();
     download_storages(&sandbox, &ctx, &manifest).await.unwrap();
+
+    assert!(sandbox.write_file_calls().is_empty());
+    let exec_calls = sandbox.exec_calls();
+    assert_eq!(exec_calls.len(), 1);
+    assert_eq!(exec_calls[0].cmd, guest_download_stdin_command());
+    assert_eq!(
+        exec_calls[0].stdin_bytes.as_deref(),
+        Some(manifest_json.as_slice())
+    );
 }
 
 #[test]
@@ -40,6 +52,16 @@ fn guest_download_command_uses_guest_common_system_log_without_shell_redirect() 
         cmd,
         "/usr/local/bin/guest-download /tmp/storage-manifest.json"
     );
+    assert!(!cmd.contains(">>"));
+    assert!(!cmd.contains("2>&1"));
+    assert!(!cmd.contains("--system-log"));
+}
+
+#[test]
+fn guest_download_stdin_command_uses_explicit_stdin_mode_without_shell_redirect() {
+    let cmd = guest_download_stdin_command();
+
+    assert_eq!(cmd, "/usr/local/bin/guest-download --manifest-stdin");
     assert!(!cmd.contains(">>"));
     assert!(!cmd.contains("2>&1"));
     assert!(!cmd.contains("--system-log"));
@@ -62,9 +84,48 @@ fn guest_download_env_includes_run_id_for_guest_common_logs() {
 }
 
 #[tokio::test]
+async fn download_storages_exact_stdin_limit_uses_fast_path() {
+    let sandbox = MockSandbox::new("test");
+    let ctx = minimal_context();
+    let manifest = manifest_with_serialized_len(vsock_proto::MAX_EXEC_STDIN_BYTES);
+    let manifest_json = serde_json::to_vec(&manifest).unwrap();
+    assert_eq!(manifest_json.len(), vsock_proto::MAX_EXEC_STDIN_BYTES);
+
+    download_storages(&sandbox, &ctx, &manifest).await.unwrap();
+
+    assert!(sandbox.write_file_calls().is_empty());
+    let exec_calls = sandbox.exec_calls();
+    assert_eq!(exec_calls.len(), 1);
+    assert_eq!(exec_calls[0].cmd, guest_download_stdin_command());
+    assert_eq!(
+        exec_calls[0].stdin_bytes.as_deref(),
+        Some(manifest_json.as_slice())
+    );
+}
+
+#[tokio::test]
+async fn download_storages_oversized_manifest_falls_back_to_write_file() {
+    let sandbox = MockSandbox::new("test");
+    let ctx = minimal_context();
+    let manifest = manifest_with_serialized_len(vsock_proto::MAX_EXEC_STDIN_BYTES + 1);
+    let manifest_json = serde_json::to_vec(&manifest).unwrap();
+
+    download_storages(&sandbox, &ctx, &manifest).await.unwrap();
+
+    let writes = sandbox.write_file_calls();
+    assert_eq!(writes.len(), 1);
+    assert_eq!(writes[0].path, guest::STORAGE_MANIFEST);
+    assert_eq!(writes[0].content, manifest_json);
+    let exec_calls = sandbox.exec_calls();
+    assert_eq!(exec_calls.len(), 1);
+    assert_eq!(exec_calls[0].cmd, guest_download_command());
+    assert!(exec_calls[0].stdin_bytes.is_none());
+}
+
+#[tokio::test]
 async fn download_storages_nonzero_exit_code() {
     let sandbox = MockSandbox::new("test");
-    // write_file succeeds, but exec returns non-zero.
+    // Exec returns non-zero so failure formatting includes helper output.
     sandbox.push_exec_result(Ok(ExecResult::new(
             1,
             b"stdout clue".to_vec(),
@@ -199,15 +260,12 @@ async fn download_storages_fails_on_write_file_error() {
     let sandbox = MockSandbox::new("test");
     sandbox.push_write_file_result(Err(sandbox_write_file_error("vsock write failed")));
     let ctx = minimal_context();
-    let manifest = GuestDownloadManifest {
-        storages: vec![],
-        artifacts: vec![],
-        cleanup_paths: vec![],
-    };
+    let manifest = manifest_with_serialized_len(vsock_proto::MAX_EXEC_STDIN_BYTES + 1);
     let err = download_storages(&sandbox, &ctx, &manifest)
         .await
         .unwrap_err();
     assert!(err.to_string().contains("vsock write failed"), "got: {err}");
+    assert!(sandbox.exec_calls().is_empty());
 }
 
 // -----------------------------------------------------------------------
@@ -216,6 +274,19 @@ async fn download_storages_fails_on_write_file_error() {
 
 fn guest_art(name: &str, ver: &str, url: Option<&str>) -> GuestDownloadArtifactEntry {
     guest_art_with_policy(name, ver, url, None)
+}
+
+fn manifest_with_serialized_len(len: usize) -> GuestDownloadManifest {
+    let mut manifest = GuestDownloadManifest {
+        storages: vec![],
+        artifacts: vec![],
+        cleanup_paths: vec![String::new()],
+    };
+    let empty_len = serde_json::to_vec(&manifest).unwrap().len();
+    assert!(len >= empty_len);
+    manifest.cleanup_paths[0] = "x".repeat(len - empty_len);
+    assert_eq!(serde_json::to_vec(&manifest).unwrap().len(), len);
+    manifest
 }
 
 fn guest_art_with_policy(

--- a/crates/runner/src/executor/tests/storage_tests.rs
+++ b/crates/runner/src/executor/tests/storage_tests.rs
@@ -350,7 +350,9 @@ async fn download_storages_fails_on_write_file_error() {
         .await
         .unwrap_err();
     assert!(err.to_string().contains("vsock write failed"), "got: {err}");
-    assert!(sandbox.exec_calls().is_empty());
+    let exec_calls = sandbox.exec_calls();
+    assert_eq!(exec_calls.len(), 1);
+    assert_eq!(exec_calls[0].cmd, guest_storage_manifest_cleanup_command());
 }
 
 // -----------------------------------------------------------------------

--- a/crates/runner/src/executor/tests/storage_tests.rs
+++ b/crates/runner/src/executor/tests/storage_tests.rs
@@ -159,6 +159,55 @@ async fn download_storages_stdin_manifest_does_not_cleanup_on_exec_error() {
 }
 
 #[tokio::test]
+async fn download_storages_oversized_manifest_cleans_file_on_helper_failure() {
+    let sandbox = MockSandbox::new("test");
+    sandbox.push_exec_result(Ok(ExecResult::new(
+        127,
+        Vec::new(),
+        b"/usr/local/bin/guest-download: not found".to_vec(),
+    )));
+    let ctx = minimal_context();
+    let manifest = manifest_with_serialized_len(vsock_proto::MAX_EXEC_STDIN_BYTES + 1);
+
+    let err = download_storages(&sandbox, &ctx, &manifest)
+        .await
+        .unwrap_err();
+
+    assert!(
+        err.to_string().contains("storage download failed"),
+        "got: {err}"
+    );
+    let exec_calls = sandbox.exec_calls();
+    assert_eq!(exec_calls.len(), 2);
+    assert_eq!(exec_calls[0].cmd, guest_download_command());
+    assert_eq!(exec_calls[1].cmd, guest_storage_manifest_cleanup_command());
+}
+
+#[tokio::test]
+async fn download_storages_stdin_manifest_does_not_cleanup_on_helper_failure() {
+    let sandbox = MockSandbox::new("test");
+    sandbox.push_exec_result(Ok(ExecResult::new(
+        127,
+        Vec::new(),
+        b"/usr/local/bin/guest-download: not found".to_vec(),
+    )));
+    let ctx = minimal_context();
+    let manifest = manifest_with_serialized_len(vsock_proto::MAX_EXEC_STDIN_BYTES);
+
+    let err = download_storages(&sandbox, &ctx, &manifest)
+        .await
+        .unwrap_err();
+
+    assert!(
+        err.to_string().contains("storage download failed"),
+        "got: {err}"
+    );
+    let exec_calls = sandbox.exec_calls();
+    assert_eq!(exec_calls.len(), 1);
+    assert_eq!(exec_calls[0].cmd, guest_download_stdin_command());
+}
+
+#[tokio::test]
 async fn download_storages_nonzero_exit_code() {
     let sandbox = MockSandbox::new("test");
     // Exec returns non-zero so failure formatting includes helper output.

--- a/crates/runner/src/executor/tests/storage_tests.rs
+++ b/crates/runner/src/executor/tests/storage_tests.rs
@@ -117,14 +117,42 @@ async fn download_storages_oversized_manifest_falls_back_to_write_file() {
     assert_eq!(writes[0].path, guest::STORAGE_MANIFEST);
     assert_eq!(writes[0].content, manifest_json);
     let exec_calls = sandbox.exec_calls();
-    assert_eq!(exec_calls.len(), 1);
-    assert_eq!(exec_calls[0].cmd, guest_download_command());
+    assert_eq!(exec_calls.len(), 2);
+    assert_eq!(exec_calls[0].cmd, guest_storage_manifest_cleanup_command());
+    assert_eq!(exec_calls[1].cmd, guest_download_command());
     assert!(exec_calls[0].stdin_bytes.is_none());
+    assert!(exec_calls[1].stdin_bytes.is_none());
+}
+
+#[tokio::test]
+async fn download_storages_oversized_manifest_fails_before_write_when_stale_cleanup_fails() {
+    let sandbox = MockSandbox::new("test");
+    sandbox.push_exec_result(Ok(ExecResult::new(
+        1,
+        Vec::new(),
+        b"rm: cannot remove '/tmp/storage-manifest.json': Is a directory".to_vec(),
+    )));
+    let ctx = minimal_context();
+    let manifest = manifest_with_serialized_len(vsock_proto::MAX_EXEC_STDIN_BYTES + 1);
+
+    let err = download_storages(&sandbox, &ctx, &manifest)
+        .await
+        .unwrap_err();
+
+    assert!(
+        err.to_string().contains("storage manifest cleanup failed"),
+        "got: {err}"
+    );
+    assert!(sandbox.write_file_calls().is_empty());
+    let exec_calls = sandbox.exec_calls();
+    assert_eq!(exec_calls.len(), 1);
+    assert_eq!(exec_calls[0].cmd, guest_storage_manifest_cleanup_command());
 }
 
 #[tokio::test]
 async fn download_storages_oversized_manifest_cleans_file_on_exec_error() {
     let sandbox = MockSandbox::new("test");
+    sandbox.push_exec_result(Ok(ExecResult::new(0, Vec::new(), Vec::new())));
     sandbox.push_exec_result(Err(sandbox_exec_error("vsock exec failed")));
     let ctx = minimal_context();
     let manifest = manifest_with_serialized_len(vsock_proto::MAX_EXEC_STDIN_BYTES + 1);
@@ -135,10 +163,11 @@ async fn download_storages_oversized_manifest_cleans_file_on_exec_error() {
 
     assert!(err.to_string().contains("vsock exec failed"), "got: {err}");
     let exec_calls = sandbox.exec_calls();
-    assert_eq!(exec_calls.len(), 2);
-    assert_eq!(exec_calls[0].cmd, guest_download_command());
-    assert_eq!(exec_calls[1].cmd, guest_storage_manifest_cleanup_command());
-    assert_eq!(exec_calls[1].timeout, std::time::Duration::from_secs(5));
+    assert_eq!(exec_calls.len(), 3);
+    assert_eq!(exec_calls[0].cmd, guest_storage_manifest_cleanup_command());
+    assert_eq!(exec_calls[1].cmd, guest_download_command());
+    assert_eq!(exec_calls[2].cmd, guest_storage_manifest_cleanup_command());
+    assert_eq!(exec_calls[2].timeout, std::time::Duration::from_secs(5));
 }
 
 #[tokio::test]
@@ -161,6 +190,7 @@ async fn download_storages_stdin_manifest_does_not_cleanup_on_exec_error() {
 #[tokio::test]
 async fn download_storages_oversized_manifest_cleans_file_on_helper_failure() {
     let sandbox = MockSandbox::new("test");
+    sandbox.push_exec_result(Ok(ExecResult::new(0, Vec::new(), Vec::new())));
     sandbox.push_exec_result(Ok(ExecResult::new(
         127,
         Vec::new(),
@@ -178,9 +208,10 @@ async fn download_storages_oversized_manifest_cleans_file_on_helper_failure() {
         "got: {err}"
     );
     let exec_calls = sandbox.exec_calls();
-    assert_eq!(exec_calls.len(), 2);
-    assert_eq!(exec_calls[0].cmd, guest_download_command());
-    assert_eq!(exec_calls[1].cmd, guest_storage_manifest_cleanup_command());
+    assert_eq!(exec_calls.len(), 3);
+    assert_eq!(exec_calls[0].cmd, guest_storage_manifest_cleanup_command());
+    assert_eq!(exec_calls[1].cmd, guest_download_command());
+    assert_eq!(exec_calls[2].cmd, guest_storage_manifest_cleanup_command());
 }
 
 #[tokio::test]
@@ -351,8 +382,9 @@ async fn download_storages_fails_on_write_file_error() {
         .unwrap_err();
     assert!(err.to_string().contains("vsock write failed"), "got: {err}");
     let exec_calls = sandbox.exec_calls();
-    assert_eq!(exec_calls.len(), 1);
+    assert_eq!(exec_calls.len(), 2);
     assert_eq!(exec_calls[0].cmd, guest_storage_manifest_cleanup_command());
+    assert_eq!(exec_calls[1].cmd, guest_storage_manifest_cleanup_command());
 }
 
 // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add an explicit `guest-download --manifest-stdin` mode while keeping path-based manifest loading
- stream small runner storage manifests through exec stdin instead of a guest file write
- keep the existing `/tmp/storage-manifest.json` fallback for manifests over `MAX_EXEC_STDIN_BYTES`

## Tests
- `cargo fmt --manifest-path crates/Cargo.toml --package runner --package guest-download`
- `cargo test --manifest-path crates/Cargo.toml -p guest-download manifest`
- `cargo test --manifest-path crates/Cargo.toml -p guest-download binary`
- `cargo test --manifest-path crates/Cargo.toml -p runner download_storages`
- `cargo test --manifest-path crates/Cargo.toml -p runner guest_download`
- `cargo test --manifest-path crates/Cargo.toml -p guest-download`
- `cargo test --manifest-path crates/Cargo.toml -p runner executor::tests::storage_tests`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-download --all-targets -- -D warnings`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
- `git diff --check`

Fixes #18749