### PR TITLE
refactor(runner): centralize workspace promotion eligibility

### DIFF
--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -280,7 +280,6 @@ mod tests {
                 .await
                 .unwrap()
         );
-        drop(lease);
     }
 
     async fn capture_heartbeat_events<F>(future: F) -> (F::Output, Vec<CapturedEvent>)

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -193,7 +193,6 @@ impl ExecutorInvocation {
                         source_ip: String::new(),
                         network_log_session: None,
                         workspace_image: None,
-                        workspace_promotable: false,
                         discovered_cli_agent_session_id: None,
                     },
                     exit_code,
@@ -273,7 +272,6 @@ impl FinalizationPhase {
             source_ip,
             network_log_session,
             workspace_image,
-            workspace_promotable,
             discovered_cli_agent_session_id,
         } = outcome;
 
@@ -302,7 +300,6 @@ impl FinalizationPhase {
                 network_log_session,
                 workspace_image,
                 workspace_image_size_bytes: u64::from(workspace_disk_mb) * 1024 * 1024,
-                workspace_promotable,
                 storage_fingerprints,
                 device_rate_limits,
                 factory,

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -1182,6 +1182,71 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn finalizer_promotes_workspace_cache_from_lease_session_without_resolved_session() {
+        let (_budget, lease) = test_budget_lease();
+        let fixture = FinalizeTestFixture::new().await;
+        let network_log_session = fixture.network_log_session().await;
+        let dir = tempfile::tempdir().unwrap();
+        let paths = RunnerPaths::new(dir.path().join("runner"));
+        tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
+        let cache = SessionWorkspaceCache::new(paths.clone());
+        let run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+        let session_id = "sess-lease-only";
+        let workspace_image = cache
+            .prepare(WorkspaceImagePrepareRequest {
+                identity: WorkspaceImageLeaseIdentity {
+                    run_id,
+                    sandbox_id,
+                    profile_name: "vm0/default",
+                    cli_agent_session_id: Some(session_id),
+                    working_dir: CANONICAL_WORKING_DIR,
+                    image_size_bytes: b"image".len() as u64,
+                },
+                workspace_drive_required: true,
+            })
+            .await;
+        tokio::fs::create_dir_all(paths.workspace_dir(&sandbox_id))
+            .await
+            .unwrap();
+        tokio::fs::write(paths.active_workspace_image(&sandbox_id), b"image")
+            .await
+            .unwrap();
+        let mut context = fixture.finalize_context(
+            run_id,
+            sandbox_id,
+            "unused-context-session",
+            network_log_session,
+            RunCancellationHandle::new(),
+        );
+        context.cli_agent_session_id = None;
+        context.discovered_cli_agent_session_id = None;
+        context.exit_code = 1;
+        context.workspace_image = Some(workspace_image);
+        context.workspace_image_size_bytes = b"image".len() as u64;
+
+        let _completion_ready = finalize_sandbox_for_completion(
+            Some(Box::new(MockSandbox::new("lease-session-promotion"))),
+            ActiveBudgetLease::new(lease),
+            CompletionPayload::new(
+                run_id,
+                1,
+                Some("invalid resume session".into()),
+                sandbox_id,
+                SandboxReuseResult::Reused,
+                CompletionAuth::local(),
+            ),
+            context,
+        )
+        .await;
+
+        assert_eq!(fixture.idle_pool.lock().await.len(), 0);
+        let cache_states = cache.held_session_states().await;
+        assert_eq!(cache_states.len(), 1);
+        assert_eq!(cache_states[0].session_id, session_id);
+    }
+
+    #[tokio::test]
     async fn finalizer_promotes_workspace_cache_when_parked_candidate_is_rejected() {
         let fixture = FinalizeTestFixture::new_with_max_idle(1).await;
         let (_existing_budget, existing_lease) = test_budget_lease();

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -68,7 +68,6 @@ pub(super) struct FinalizeContext {
     pub(super) network_log_session: Option<NetworkLogSession>,
     pub(super) workspace_image: Option<WorkspaceImageLease>,
     pub(super) workspace_image_size_bytes: u64,
-    pub(super) workspace_promotable: bool,
     pub(super) storage_fingerprints: StorageFingerprints,
     pub(super) device_rate_limits: Option<sandbox::DeviceRateLimits>,
     pub(super) factory: Arc<Box<dyn SandboxFactory>>,
@@ -106,7 +105,6 @@ pub(super) async fn finalize_sandbox_for_completion(
         mut network_log_session,
         workspace_image,
         workspace_image_size_bytes,
-        workspace_promotable,
         storage_fingerprints,
         device_rate_limits,
         factory,
@@ -150,7 +148,6 @@ pub(super) async fn finalize_sandbox_for_completion(
             terminal_status,
             completed_at: completed_at.clone(),
             storage_fingerprints: storage_fingerprints.clone(),
-            promotable: workspace_promotable,
         })
     });
 
@@ -679,7 +676,6 @@ mod tests {
                 network_log_session: Some(network_log_session),
                 workspace_image: None,
                 workspace_image_size_bytes: 0,
-                workspace_promotable: false,
                 storage_fingerprints: crate::storage_fingerprints::StorageFingerprints::default(),
                 device_rate_limits: None,
                 factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
@@ -742,7 +738,6 @@ mod tests {
                 terminal_status,
                 completed_at: local_completed_at(),
                 storage_fingerprints,
-                promotable: true,
             })
             .expect("test workspace image should be promotable")
     }
@@ -1072,7 +1067,6 @@ mod tests {
                 workspace_drive_required: true,
             })
             .await;
-        assert!(workspace_image.can_attempt_promotion(Some("sess-guest")));
         tokio::fs::create_dir_all(paths.workspace_dir(&sandbox_id))
             .await
             .unwrap();
@@ -1090,7 +1084,6 @@ mod tests {
         context.discovered_cli_agent_session_id = Some("sess-guest".into());
         context.workspace_image = Some(workspace_image);
         context.workspace_image_size_bytes = b"image".len() as u64;
-        context.workspace_promotable = true;
 
         let _completion_ready = finalize_sandbox_for_completion(
             Some(Box::new(MockSandbox::new("guest-session-promotion"))),
@@ -1159,7 +1152,6 @@ mod tests {
         context.factory = factory;
         context.workspace_image = Some(workspace_image);
         context.workspace_image_size_bytes = b"image".len() as u64 + 1;
-        context.workspace_promotable = true;
 
         let _completion_ready = finalize_sandbox_for_completion(
             Some(sandbox),
@@ -1246,7 +1238,6 @@ mod tests {
         );
         context.workspace_image = Some(workspace_image);
         context.workspace_image_size_bytes = b"image".len() as u64;
-        context.workspace_promotable = true;
 
         let _completion_ready = finalize_sandbox_for_completion(
             Some(Box::new(MockSandbox::new("rejected-workspace-promotion"))),

--- a/crates/runner/src/cmd/start/tests/support/idle_pool.rs
+++ b/crates/runner/src/cmd/start/tests/support/idle_pool.rs
@@ -155,7 +155,6 @@ pub(in super::super) async fn seed_idle_pool_with_workspace_promotion(
             terminal_status: WorkspaceCacheTerminalStatus::Success,
             completed_at: TEST_SESSION_LAST_COMPLETED_AT.into(),
             storage_fingerprints: StorageFingerprints::default(),
-            promotable: true,
         })
         .expect("workspace image should be promotable");
     let budget_lease = ResourceBudget::try_reserve_lease(budget, spec.vcpu, spec.memory_mb)

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -43,7 +43,6 @@ use env::validate_execution_context_before_sandbox;
 pub(crate) use env::validate_resume_session_id;
 use sandbox_run::{
     NewSandboxHooks, execute_new_sandbox_with_prepared_notifier, execute_reused_sandbox,
-    workspace_image_promotable,
 };
 use telemetry::{record_api_latency, record_reuse_result};
 
@@ -211,7 +210,6 @@ pub struct ExecuteOutcome {
     pub source_ip: String,
     pub network_log_session: Option<NetworkLogSession>,
     pub workspace_image: Option<WorkspaceImageLease>,
-    pub workspace_promotable: bool,
     /// CLI-generated session ID read from the guest after execution.
     /// Used for first-run VM parking when `resume_session` is absent.
     pub discovered_cli_agent_session_id: Option<String>,
@@ -436,7 +434,6 @@ pub(crate) async fn execute_job_with_prepared_notifier(
             source_ip: String::new(),
             network_log_session: None,
             workspace_image: None,
-            workspace_promotable: false,
             discovered_cli_agent_session_id: None,
         }
     } else {
@@ -461,7 +458,6 @@ pub(crate) async fn execute_job_with_prepared_notifier(
                 source_ip: String::new(),
                 network_log_session: None,
                 workspace_image: None,
-                workspace_promotable: false,
                 discovered_cli_agent_session_id: None,
             },
         }
@@ -547,7 +543,6 @@ pub(crate) async fn execute_job_reuse_with_active_input_source(
                                 source_ip,
                                 network_log_session: None,
                                 workspace_image: None,
-                                workspace_promotable: false,
                                 discovered_cli_agent_session_id: None,
                             },
                             telemetry,
@@ -572,7 +567,6 @@ pub(crate) async fn execute_job_reuse_with_active_input_source(
                             source_ip,
                             network_log_session: None,
                             workspace_image: None,
-                            workspace_promotable: false,
                             discovered_cli_agent_session_id: None,
                         },
                         telemetry,
@@ -581,9 +575,6 @@ pub(crate) async fn execute_job_reuse_with_active_input_source(
                 None
             }
         };
-        let workspace_promotable = workspace_image.as_ref().is_some_and(|image| {
-            image.can_attempt_promotion(Some(idle_cli_agent_session_id.as_str()))
-        });
         return (
             ExecuteOutcome {
                 failure: Some(ExecutionFailure::from_error(error)),
@@ -591,7 +582,6 @@ pub(crate) async fn execute_job_reuse_with_active_input_source(
                 source_ip,
                 network_log_session: None,
                 workspace_image,
-                workspace_promotable,
                 discovered_cli_agent_session_id: None,
             },
             telemetry,
@@ -636,7 +626,6 @@ pub(crate) async fn execute_job_reuse_with_active_input_source(
                                 source_ip,
                                 network_log_session: None,
                                 workspace_image: None,
-                                workspace_promotable: false,
                                 discovered_cli_agent_session_id: None,
                             },
                             telemetry,
@@ -676,7 +665,6 @@ pub(crate) async fn execute_job_reuse_with_active_input_source(
                         source_ip,
                         network_log_session: None,
                         workspace_image: None,
-                        workspace_promotable: false,
                         discovered_cli_agent_session_id: None,
                     },
                     telemetry,
@@ -700,11 +688,6 @@ pub(crate) async fn execute_job_reuse_with_active_input_source(
             sandbox: Some(sandbox),
             source_ip,
             network_log_session: None,
-            workspace_promotable: workspace_image_promotable(
-                workspace_image.as_ref(),
-                &context,
-                None,
-            ),
             workspace_image,
             discovered_cli_agent_session_id: None,
         }
@@ -719,11 +702,6 @@ pub(crate) async fn execute_job_reuse_with_active_input_source(
             RunControls::new(cancel, active_input_source),
         )
         .await;
-        outcome.workspace_promotable = workspace_image_promotable(
-            workspace_image.as_ref(),
-            &context,
-            outcome.discovered_cli_agent_session_id.as_deref(),
-        );
         outcome.workspace_image = workspace_image;
         outcome
     };

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -154,11 +154,6 @@ pub(super) async fn execute_new_sandbox_with_prepared_notifier(
         controls,
     )
     .await;
-    outcome.workspace_promotable = workspace_image_promotable(
-        workspace_image.as_ref(),
-        context,
-        outcome.discovered_cli_agent_session_id.as_deref(),
-    );
     outcome.workspace_image = workspace_image;
     Ok(outcome)
 }
@@ -224,20 +219,6 @@ pub(super) async fn prepare_workspace_image(
         .await;
     record_workspace_cache_result(telemetry, lease.result());
     Some(lease)
-}
-
-pub(super) fn workspace_image_promotable(
-    workspace_image: Option<&WorkspaceImageLease>,
-    context: &ExecutionContext,
-    discovered_cli_agent_session_id: Option<&str>,
-) -> bool {
-    workspace_image.is_some_and(|image| {
-        image.can_attempt_promotion(
-            context
-                .cli_agent_session_id()
-                .or(discovered_cli_agent_session_id),
-        )
-    })
 }
 
 async fn create_started_sandbox(
@@ -419,7 +400,6 @@ pub(super) async fn execute_reused_sandbox(
                 source_ip,
                 network_log_session: None,
                 workspace_image: None,
-                workspace_promotable: false,
                 discovered_cli_agent_session_id: None,
             };
         }
@@ -446,7 +426,6 @@ pub(super) async fn execute_reused_sandbox(
             source_ip,
             network_log_session: Some(network_log_session),
             workspace_image: None,
-            workspace_promotable: false,
             discovered_cli_agent_session_id: None,
         };
     }
@@ -551,7 +530,6 @@ pub(super) async fn execute_prepared_sandbox_run(
         source_ip,
         network_log_session: Some(network_log_session),
         workspace_image: None,
-        workspace_promotable: false,
         discovered_cli_agent_session_id,
     }
 }

--- a/crates/runner/src/executor/tests/sandbox_run_tests/reuse.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/reuse.rs
@@ -134,7 +134,6 @@ async fn execute_job_reuse_invalid_resume_session_does_not_lease_workspace_image
     assert!(reuse_outcome.sandbox.is_some());
     assert!(reuse_outcome.network_log_session.is_none());
     assert!(reuse_outcome.workspace_image.is_none());
-    assert!(!reuse_outcome.workspace_promotable);
     assert!(
         overrides.start_process_calls().is_empty(),
         "reused sandbox must not start a process after resume session validation failure"

--- a/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
@@ -40,7 +40,6 @@ async fn execute_inner_retries_fresh_after_workspace_cache_hit_create_failure() 
 
     assert_eq!(outcome.exit_code(), 0);
     assert!(outcome.workspace_image.is_none());
-    assert!(!outcome.workspace_promotable);
     let configs = overrides.create_configs();
     assert_eq!(configs.len(), 2);
     assert_eq!(
@@ -104,7 +103,6 @@ async fn execute_inner_uses_workspace_cache_when_configured() {
 
     assert_eq!(outcome.exit_code(), 0);
     assert!(outcome.workspace_image.is_some());
-    assert!(outcome.workspace_promotable);
     let configs = overrides.create_configs();
     assert_eq!(configs.len(), 1);
     assert_eq!(
@@ -220,7 +218,6 @@ async fn execute_job_reuse_uses_workspace_cache_when_configured() {
 
     assert_eq!(reuse_outcome.exit_code(), 0);
     assert!(reuse_outcome.workspace_image.is_some());
-    assert!(reuse_outcome.workspace_promotable);
 
     let checkout = cache
         .prepare(WorkspaceImagePrepareRequest {
@@ -275,7 +272,6 @@ async fn cached_reuse_workspace_promotion_identity_mismatch_stops_before_agent()
     assert_eq!(reuse_outcome.exit_code(), 1);
     assert!(reuse_outcome.sandbox.is_some());
     assert!(reuse_outcome.workspace_image.is_none());
-    assert!(!reuse_outcome.workspace_promotable);
     let error = reuse_outcome.error().expect("error should be set");
     assert!(error.contains("workspace promotion identity mismatch"));
     assert!(!error.contains(session_id));
@@ -499,7 +495,6 @@ async fn cached_reuse_validation_failure_keeps_workspace_cache_hidden() {
 
     assert_eq!(reuse_outcome.exit_code(), 1);
     assert!(reuse_outcome.sandbox.is_some());
-    assert!(reuse_outcome.workspace_promotable);
     assert!(reuse_outcome.workspace_image.is_some());
     assert!(
         overrides.start_process_calls().is_empty(),
@@ -558,7 +553,6 @@ async fn cached_reuse_invalid_resume_session_keeps_existing_workspace_cache_hidd
     assert!(error.contains("invalid session_id"));
     assert!(!error.contains(raw_session_id));
     assert!(reuse_outcome.sandbox.is_some());
-    assert!(reuse_outcome.workspace_promotable);
     assert!(reuse_outcome.workspace_image.is_some());
     assert!(
         overrides.start_process_calls().is_empty(),
@@ -629,7 +623,6 @@ async fn reusable_idle_sandbox_with_workspace_promotion(
                 terminal_status: WorkspaceCacheTerminalStatus::Success,
                 completed_at: "2026-06-01T00:00:01.000Z".into(),
                 storage_fingerprints: StorageFingerprints::default(),
-                promotable: true,
             },
         )
         .unwrap();
@@ -735,7 +728,6 @@ async fn reusable_idle_sandbox_with_unlocked_workspace_promotion(
                 terminal_status: WorkspaceCacheTerminalStatus::Success,
                 completed_at: "2026-06-01T00:00:01.000Z".into(),
                 storage_fingerprints: StorageFingerprints::default(),
-                promotable: true,
             },
         )
         .unwrap();

--- a/crates/runner/src/executor/tests/support/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/support/workspace_cache.rs
@@ -55,7 +55,6 @@ pub(in crate::executor::tests) async fn seed_workspace_image_cache(
             .await
             .unwrap()
     );
-    drop(lease);
 
     let cache_key = scoped_session_workspace_cache_key(
         "",

--- a/crates/runner/src/workspace_image_cache/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/lifecycle.rs
@@ -93,6 +93,11 @@ struct WorkspaceImagePromotionInput<'a> {
     storage_fingerprints: &'a StorageFingerprints,
 }
 
+struct WorkspaceImagePromotionTarget {
+    cache_key: String,
+    cli_agent_session_id: String,
+}
+
 struct WorkspaceImageLeaseCommon<'a> {
     run_id: RunId,
     profile_name: &'a str,
@@ -933,28 +938,6 @@ impl WorkspaceImageLease {
             })
     }
 
-    pub(crate) fn can_attempt_promotion(
-        &self,
-        cli_agent_session_id_override: Option<&str>,
-    ) -> bool {
-        if !self.workspace_drive_enabled || !is_safe_guest_working_dir(&self.working_dir) {
-            return false;
-        }
-
-        match self.result {
-            WorkspaceCacheCheckoutResult::Hit | WorkspaceCacheCheckoutResult::Miss => {
-                self.cache_key.is_some() && self.cli_agent_session_id.is_some()
-            }
-            WorkspaceCacheCheckoutResult::NoSession => {
-                self.cli_agent_session_id.is_none() && cli_agent_session_id_override.is_some()
-            }
-            WorkspaceCacheCheckoutResult::InvalidWorkingDir
-            | WorkspaceCacheCheckoutResult::LockBusy
-            | WorkspaceCacheCheckoutResult::InvalidMetadata
-            | WorkspaceCacheCheckoutResult::DiskPressure => false,
-        }
-    }
-
     pub(crate) async fn invalidate(&self, run_id: RunId, reason: &str) -> RunnerResult<bool> {
         let Some(cache_key) = self.cache_key.as_deref() else {
             return Ok(false);
@@ -973,150 +956,83 @@ impl WorkspaceImageLease {
 
     #[cfg(test)]
     pub(crate) async fn promote(
-        &self,
+        self,
         run_id: RunId,
         cli_agent_session_id_override: Option<&str>,
         terminal_status: WorkspaceCacheTerminalStatus,
         completed_at: String,
         storage_fingerprints: &StorageFingerprints,
     ) -> RunnerResult<bool> {
-        if !self.workspace_drive_enabled {
+        let Some(promotion) = self.into_promotion_context(WorkspaceImagePromotionRequest {
+            run_id,
+            sandbox_id: sandbox::SandboxId::new_v4(),
+            cli_agent_session_id_override,
+            terminal_status,
+            completed_at,
+            storage_fingerprints: storage_fingerprints.clone(),
+        }) else {
             debug!(
                 run_id = %run_id,
-                "workspace image cache promotion skipped: workspace drive unavailable"
-            );
-            return Ok(false);
-        }
-        if !is_safe_guest_working_dir(&self.working_dir) {
-            debug!(
-                run_id = %run_id,
-                working_dir = %self.working_dir,
-                "workspace image cache promotion skipped: unsafe working directory"
-            );
-            return Ok(false);
-        }
-        if !self.can_attempt_promotion(cli_agent_session_id_override) {
-            debug!(
-                run_id = %run_id,
-                checkout_result = ?self.result,
                 "workspace image cache promotion skipped: checkout result is not promotable"
             );
             return Ok(false);
+        };
+        let outcome = promotion.promote().await?;
+        Ok(matches!(outcome, WorkspaceImagePromotionOutcome::Promoted))
+    }
+
+    fn promotion_target(
+        &self,
+        cli_agent_session_id_override: Option<&str>,
+    ) -> Option<WorkspaceImagePromotionTarget> {
+        if !self.workspace_drive_enabled || !is_safe_guest_working_dir(&self.working_dir) {
+            return None;
         }
 
-        let mut _late_entry_lock_guard = None;
-        let late_cache_key;
-        let (cache_key, cli_agent_session_id) = if let Some(cache_key) = self.cache_key.as_deref() {
-            let Some(cli_agent_session_id) = self.cli_agent_session_id.as_deref() else {
-                debug!(run_id = %run_id, "workspace image cache promotion skipped: no session id");
-                return Ok(false);
-            };
-            if self.entry_lock.is_none() {
-                debug!(
-                    run_id = %run_id,
-                    cache_key,
-                    "workspace image cache promotion skipped: entry lock not held"
-                );
-                return Ok(false);
+        match self.result {
+            WorkspaceCacheCheckoutResult::Hit | WorkspaceCacheCheckoutResult::Miss => {
+                Some(WorkspaceImagePromotionTarget {
+                    cache_key: self.cache_key.clone()?,
+                    cli_agent_session_id: self.cli_agent_session_id.clone()?,
+                })
             }
-            (cache_key, cli_agent_session_id)
-        } else if self.cli_agent_session_id.is_none() {
-            let Some(cli_agent_session_id) = cli_agent_session_id_override else {
-                debug!(run_id = %run_id, "workspace image cache promotion skipped: no session id");
-                return Ok(false);
-            };
-            late_cache_key = self.cache.scoped_cache_key(
-                &self.profile_name,
-                cli_agent_session_id,
-                &self.working_dir,
-                self.image_size_bytes,
-            );
-            _late_entry_lock_guard = Some(
-                match crate::lock::try_acquire(self.cache.entry_lock_path(&late_cache_key)).await {
-                    Ok(lock) => lock,
-                    Err(e) => {
-                        info!(
-                            run_id = %run_id,
-                            cache_key = late_cache_key,
-                            error = %e,
-                            "workspace image cache promotion skipped: late entry lock unavailable"
-                        );
-                        return Ok(false);
-                    }
-                },
-            );
-            (late_cache_key.as_str(), cli_agent_session_id)
-        } else {
-            debug!(run_id = %run_id, "workspace image cache promotion skipped: no cache key");
-            return Ok(false);
-        };
-
-        let outcome = self
-            .cache
-            .promote_locked(WorkspaceImagePromotionInput {
-                run_id,
-                cache_key,
-                profile_name: &self.profile_name,
-                cli_agent_session_id,
-                working_dir: &self.working_dir,
-                active_image: &self.active_image,
-                image_size_bytes: self.image_size_bytes,
-                terminal_status,
-                completed_at: &completed_at,
-                storage_fingerprints,
-            })
-            .await?;
-        Ok(matches!(outcome, WorkspaceImagePromotionOutcome::Promoted))
+            WorkspaceCacheCheckoutResult::NoSession => {
+                if self.cli_agent_session_id.is_some() {
+                    return None;
+                }
+                let cli_agent_session_id = cli_agent_session_id_override?.to_owned();
+                let cache_key = self.cache.scoped_cache_key(
+                    &self.profile_name,
+                    &cli_agent_session_id,
+                    &self.working_dir,
+                    self.image_size_bytes,
+                );
+                Some(WorkspaceImagePromotionTarget {
+                    cache_key,
+                    cli_agent_session_id,
+                })
+            }
+            WorkspaceCacheCheckoutResult::InvalidWorkingDir
+            | WorkspaceCacheCheckoutResult::LockBusy
+            | WorkspaceCacheCheckoutResult::InvalidMetadata
+            | WorkspaceCacheCheckoutResult::DiskPressure => None,
+        }
     }
 
     pub(crate) fn into_promotion_context(
         mut self,
         request: WorkspaceImagePromotionRequest<'_>,
     ) -> Option<WorkspaceImagePromotionContext> {
-        if !request.promotable {
-            return None;
-        }
-        if !self.workspace_drive_enabled || !is_safe_guest_working_dir(&self.working_dir) {
-            return None;
-        }
-
-        let cli_agent_session_id = match self.result {
-            WorkspaceCacheCheckoutResult::Hit | WorkspaceCacheCheckoutResult::Miss => {
-                self.cli_agent_session_id.clone()?
-            }
-            WorkspaceCacheCheckoutResult::NoSession => {
-                request.cli_agent_session_id_override?.to_owned()
-            }
-            WorkspaceCacheCheckoutResult::InvalidWorkingDir
-            | WorkspaceCacheCheckoutResult::LockBusy
-            | WorkspaceCacheCheckoutResult::InvalidMetadata
-            | WorkspaceCacheCheckoutResult::DiskPressure => return None,
-        };
-
-        let cache_key = match self.result {
-            WorkspaceCacheCheckoutResult::Hit | WorkspaceCacheCheckoutResult::Miss => {
-                self.cache_key.clone()?
-            }
-            WorkspaceCacheCheckoutResult::NoSession => self.cache.scoped_cache_key(
-                &self.profile_name,
-                &cli_agent_session_id,
-                &self.working_dir,
-                self.image_size_bytes,
-            ),
-            WorkspaceCacheCheckoutResult::InvalidWorkingDir
-            | WorkspaceCacheCheckoutResult::LockBusy
-            | WorkspaceCacheCheckoutResult::InvalidMetadata
-            | WorkspaceCacheCheckoutResult::DiskPressure => return None,
-        };
+        let target = self.promotion_target(request.cli_agent_session_id_override)?;
 
         Some(WorkspaceImagePromotionContext {
             cache: self.cache.clone(),
-            cache_key,
+            cache_key: target.cache_key,
             entry_lock: self.entry_lock.take(),
             run_id: request.run_id,
             sandbox_id: request.sandbox_id,
             profile_name: self.profile_name.clone(),
-            cli_agent_session_id,
+            cli_agent_session_id: target.cli_agent_session_id,
             working_dir: self.working_dir.clone(),
             active_image: self.active_image.clone(),
             image_size_bytes: self.image_size_bytes,

--- a/crates/runner/src/workspace_image_cache/tests/mod.rs
+++ b/crates/runner/src/workspace_image_cache/tests/mod.rs
@@ -4162,6 +4162,44 @@ async fn promote_skips_when_capacity_lock_is_busy() {
 }
 
 #[tokio::test]
+async fn no_session_checkout_without_late_cli_agent_session_id_has_no_promotion_context() {
+    let dir = tempfile::tempdir().unwrap();
+    let paths = RunnerPaths::new(dir.path().join("runner"));
+    tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
+    let cache = SessionWorkspaceCache::new(paths);
+    let run_id = RunId::new_v4();
+    let sandbox_id = sandbox::SandboxId::new_v4();
+    let lease = cache
+        .prepare(WorkspaceImagePrepareRequest {
+            identity: WorkspaceImageLeaseIdentity {
+                run_id,
+                sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: None,
+                working_dir: "/workspace",
+                image_size_bytes: 5,
+            },
+            workspace_drive_required: false,
+        })
+        .await;
+
+    assert_eq!(lease.result(), WorkspaceCacheCheckoutResult::NoSession);
+    assert!(
+        lease
+            .into_promotion_context(WorkspaceImagePromotionRequest {
+                run_id,
+                sandbox_id,
+                cli_agent_session_id_override: None,
+                terminal_status: WorkspaceCacheTerminalStatus::Success,
+                completed_at: "2026-05-01T00:00:00.000Z".into(),
+                storage_fingerprints: StorageFingerprints::default(),
+            })
+            .is_none(),
+        "workspace image promotion must wait until a CLI agent session id is available"
+    );
+}
+
+#[tokio::test]
 async fn no_session_checkout_can_promote_with_late_discovered_cli_agent_session_id() {
     let dir = tempfile::tempdir().unwrap();
     let paths = RunnerPaths::new(dir.path().join("runner"));

--- a/crates/runner/src/workspace_image_cache/tests/mod.rs
+++ b/crates/runner/src/workspace_image_cache/tests/mod.rs
@@ -130,7 +130,6 @@ async fn promote_current_cache_entry(
             .await
             .unwrap()
     );
-    drop(lease);
     cache.scoped_cache_key(
         TEST_PROFILE_NAME,
         session_id,
@@ -193,7 +192,6 @@ async fn promotion_does_not_overwrite_newer_cache_entry() {
         .unwrap();
 
     assert!(!promoted);
-    drop(stale_lease);
     let metadata = cache
         .read_metadata_file(&paths.session_workspace_cache_metadata(&key))
         .await
@@ -260,7 +258,6 @@ async fn promotion_does_not_overwrite_same_completed_at_cache_entry() {
         .unwrap();
 
     assert!(!promoted);
-    drop(competing_lease);
     let metadata = cache
         .read_metadata_file(&paths.session_workspace_cache_metadata(&key))
         .await
@@ -324,7 +321,6 @@ async fn promotion_overwrites_older_cache_entry() {
         .unwrap();
 
     assert!(promoted);
-    drop(newer_lease);
     let metadata = cache
         .read_metadata_file(&paths.session_workspace_cache_metadata(&key))
         .await
@@ -1254,7 +1250,6 @@ async fn shared_cache_is_reusable_across_runner_base_dirs() {
             .await
             .unwrap()
     );
-    drop(lease);
 
     let checkout = cache_b
         .prepare(WorkspaceImagePrepareRequest {
@@ -1391,7 +1386,6 @@ async fn abandoned_cache_hit_promotion_context_invalidates_consumed_entry() {
             terminal_status: WorkspaceCacheTerminalStatus::Success,
             completed_at: "2026-05-02T00:00:00.000Z".into(),
             storage_fingerprints: StorageFingerprints::default(),
-            promotable: true,
         })
         .unwrap();
 
@@ -1464,7 +1458,6 @@ async fn promotion_context_preserves_existing_newer_cache_entry() {
             terminal_status: WorkspaceCacheTerminalStatus::Success,
             completed_at: "2026-05-01T00:00:00.000Z".into(),
             storage_fingerprints: StorageFingerprints::default(),
-            promotable: true,
         })
         .unwrap();
 
@@ -1525,7 +1518,6 @@ async fn no_lock_promotion_context_abandonment_preserves_existing_entry() {
             terminal_status: WorkspaceCacheTerminalStatus::Success,
             completed_at: "2026-05-01T00:00:00.000Z".into(),
             storage_fingerprints: StorageFingerprints::default(),
-            promotable: true,
         })
         .unwrap();
 
@@ -1830,7 +1822,6 @@ async fn shared_cache_is_scoped_by_runner_group() {
             .await
             .unwrap()
     );
-    drop(lease);
 
     let checkout = cache_b
         .prepare(WorkspaceImagePrepareRequest {
@@ -1904,7 +1895,6 @@ async fn global_gc_preserves_other_group_cache_entries_when_under_budget() {
             .await
             .unwrap()
     );
-    drop(lease);
 
     cache_b.gc(false).await.unwrap();
 
@@ -2353,7 +2343,6 @@ async fn prepare_removes_invalid_metadata_entry_and_allows_repromotion() {
         .await
         .unwrap();
     assert_eq!(metadata.session_id, "sess-1");
-    drop(lease);
     assert_eq!(cache.held_session_states().await.len(), 1);
 }
 
@@ -2751,7 +2740,6 @@ async fn cache_hit_checkout_does_not_require_copy_headroom() {
         .await;
 
     assert_eq!(lease.result(), WorkspaceCacheCheckoutResult::Hit);
-    assert!(lease.can_attempt_promotion(Some("sess-1")));
     assert_eq!(
         lease
             .workspace_drive_config()
@@ -2821,7 +2809,6 @@ async fn lock_busy_checkout_cannot_promote_without_entry_lock() {
         .await;
 
     assert_eq!(lease.result(), WorkspaceCacheCheckoutResult::LockBusy);
-    assert!(!lease.can_attempt_promotion(Some("sess-1")));
     assert!(
         !lease
             .promote(
@@ -2936,7 +2923,6 @@ async fn promotion_context_keeps_entry_locked_until_reused_active_lease_drops() 
             terminal_status: WorkspaceCacheTerminalStatus::Success,
             completed_at: local_timestamp(),
             storage_fingerprints: StorageFingerprints::default(),
-            promotable: true,
         })
         .unwrap();
 
@@ -3036,7 +3022,6 @@ async fn promotion_context_validates_expected_identity() {
             terminal_status: WorkspaceCacheTerminalStatus::Success,
             completed_at: local_timestamp(),
             storage_fingerprints: StorageFingerprints::default(),
-            promotable: true,
         })
         .unwrap();
 
@@ -4205,8 +4190,6 @@ async fn no_session_checkout_can_promote_with_late_discovered_cli_agent_session_
         .unwrap();
 
     assert_eq!(lease.result(), WorkspaceCacheCheckoutResult::NoSession);
-    assert!(!lease.can_attempt_promotion(None));
-    assert!(lease.can_attempt_promotion(Some("sess-1")));
     assert!(
         lease
             .promote(
@@ -4271,7 +4254,6 @@ async fn late_session_promotion_skips_when_entry_lock_is_busy() {
             terminal_status: WorkspaceCacheTerminalStatus::Success,
             completed_at: "2026-05-01T00:00:00.000Z".into(),
             storage_fingerprints: StorageFingerprints::default(),
-            promotable: true,
         })
         .unwrap();
     let cache_key = session_workspace_cache_key(session_id, "/workspace");
@@ -4322,7 +4304,6 @@ async fn no_lock_promotion_context_survives_reuse_active_lease() {
             terminal_status: WorkspaceCacheTerminalStatus::Success,
             completed_at: "2026-05-01T00:00:00.000Z".into(),
             storage_fingerprints: StorageFingerprints::default(),
-            promotable: true,
         })
         .unwrap();
 
@@ -4338,7 +4319,6 @@ async fn no_lock_promotion_context_survives_reuse_active_lease() {
     let active_lease = promotion.try_into_active_lease(&expected, true).unwrap();
 
     assert_eq!(active_lease.working_dir(), "/workspace/repo");
-    assert!(active_lease.can_attempt_promotion(Some(session_id)));
     assert!(
         active_lease
             .into_promotion_context(WorkspaceImagePromotionRequest {
@@ -4348,7 +4328,6 @@ async fn no_lock_promotion_context_survives_reuse_active_lease() {
                 terminal_status: WorkspaceCacheTerminalStatus::Success,
                 completed_at: "2026-05-01T00:00:01.000Z".into(),
                 storage_fingerprints: StorageFingerprints::default(),
-                promotable: true,
             })
             .is_some(),
         "reusing an idle sandbox created before the CLI reported a session id must not lose the future cache promotion"

--- a/crates/runner/src/workspace_image_cache/types.rs
+++ b/crates/runner/src/workspace_image_cache/types.rs
@@ -108,7 +108,6 @@ pub(crate) struct WorkspaceImagePromotionRequest<'a> {
     pub(crate) terminal_status: WorkspaceCacheTerminalStatus,
     pub(crate) completed_at: String,
     pub(crate) storage_fingerprints: StorageFingerprints,
-    pub(crate) promotable: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]

--- a/crates/runner/src/workspace_promotion/test_support.rs
+++ b/crates/runner/src/workspace_promotion/test_support.rs
@@ -59,7 +59,6 @@ impl WorkspacePromotionFixture {
                 terminal_status: WorkspaceCacheTerminalStatus::Success,
                 completed_at: TEST_COMPLETED_AT.into(),
                 storage_fingerprints: StorageFingerprints::default(),
-                promotable: true,
             })
             .expect("workspace image should be promotable");
 
@@ -111,7 +110,6 @@ impl WorkspacePromotionFixture {
                 terminal_status: WorkspaceCacheTerminalStatus::Success,
                 completed_at: "2026-06-04T00:00:00.000Z".into(),
                 storage_fingerprints: StorageFingerprints::default(),
-                promotable: true,
             })
             .expect("workspace image cache hit should be promotable");
 


### PR DESCRIPTION
## Summary
- Remove `workspace_promotable` from the executor/finalization data flow.
- Resolve workspace image promotion targets inside `WorkspaceImageLease` before building promotion contexts.
- Route the test-only promotion helper through the same promotion context path.

Closes #18761

## Tests
- `cargo test --manifest-path crates/Cargo.toml -p runner workspace_image_cache`
- `cargo test --manifest-path crates/Cargo.toml -p runner sandbox_finalization`
- `cargo test --manifest-path crates/Cargo.toml -p runner sandbox_run_tests::workspace_cache`
- `cargo test --manifest-path crates/Cargo.toml -p runner executor::tests::sandbox_run_tests::reuse`
- `cargo test --manifest-path crates/Cargo.toml -p runner heartbeat`
- `cargo test --manifest-path crates/Cargo.toml -p runner`