### PR TITLE
perf(mitm-addon): share builtin firewall static payloads

### DIFF
--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -631,6 +631,30 @@ def _validate_credentialed_builtin_base(
         )
 
 
+def _copy_builtin_firewall_shell(
+    *,
+    firewall_name: str,
+    catalog_firewall: dict,
+) -> tuple[dict, list[dict]]:
+    raw_apis = catalog_firewall.get("apis")
+    if not isinstance(raw_apis, list):
+        raise _FirewallEntryResolutionError(
+            f'builtin firewall "{firewall_name}" apis must be a list'
+        )
+
+    copied_apis: list[dict] = []
+    for api in raw_apis:
+        if not isinstance(api, dict):
+            raise _FirewallEntryResolutionError(
+                f'builtin firewall "{firewall_name}" api entries must be objects'
+            )
+        copied_apis.append(dict(api))
+
+    firewall = dict(catalog_firewall)
+    firewall["apis"] = copied_apis
+    return firewall, copied_apis
+
+
 def _resolve_builtin_firewall_entry(entry: dict) -> _ResolvedBuiltinFirewallEntry:
     raw_name = entry.get("name")
     if not isinstance(raw_name, str) or raw_name == "":
@@ -642,18 +666,14 @@ def _resolve_builtin_firewall_entry(entry: dict) -> _ResolvedBuiltinFirewallEntr
     if catalog_firewall is None:
         raise _FirewallEntryResolutionError(f'unknown builtin firewall "{raw_name}"')
 
-    firewall = copy.deepcopy(catalog_firewall)
-    raw_apis = firewall.get("apis")
-    if not isinstance(raw_apis, list):
-        raise _FirewallEntryResolutionError(f'builtin firewall "{raw_name}" apis must be a list')
+    firewall, raw_apis = _copy_builtin_firewall_shell(
+        firewall_name=raw_name,
+        catalog_firewall=catalog_firewall,
+    )
 
     vars_map = _base_url_vars_for_entry(entry)
     resolved_bases: list[str] = []
     for api in raw_apis:
-        if not isinstance(api, dict):
-            raise _FirewallEntryResolutionError(
-                f'builtin firewall "{raw_name}" api entries must be objects'
-            )
         raw_base = api.get("base")
         if not isinstance(raw_base, str):
             raise _FirewallEntryResolutionError(

--- a/crates/runner/mitm-addon/tests/test_registry_context.py
+++ b/crates/runner/mitm-addon/tests/test_registry_context.py
@@ -249,6 +249,85 @@ class TestGetVmContext:
         assert first_result.api_entry["id"] == "run-github-a:0"
         assert second_result.api_entry["id"] == "run-github-b:0"
 
+    def test_builtin_firewall_refs_share_static_payload_but_keep_vm_api_shells(
+        self, tmp_path, monkeypatch
+    ):
+        auth = {"headers": {"Authorization": "Bearer ${{ secrets.API_TOKEN }}"}}
+        permissions = [{"name": "read-items", "rules": ["GET /items"]}]
+        monkeypatch.setattr(
+            registry,
+            "BUILTIN_FIREWALLS",
+            {
+                "large": {
+                    "name": "large",
+                    "apis": [
+                        {
+                            "base": "https://api.example.com",
+                            "auth": auth,
+                            "permissions": permissions,
+                        },
+                        {
+                            "base": "https://upload.example.com",
+                            "auth": auth,
+                            "permissions": permissions,
+                        },
+                    ],
+                }
+            },
+        )
+        path = tmp_path / "registry.json"
+        _write_multi_vm_registry(
+            path,
+            {
+                "10.200.0.1": _builtin_vm("run-large-a", "large"),
+                "10.200.0.2": _builtin_vm("run-large-b", "large"),
+            },
+        )
+
+        first_context = registry.get_vm_context("10.200.0.1", str(path))
+        second_context = registry.get_vm_context("10.200.0.2", str(path))
+
+        assert first_context is not None
+        assert second_context is not None
+        first_vm_info, first_compiled, first_policies = first_context
+        second_vm_info, second_compiled, second_policies = second_context
+        assert first_compiled is not None
+        assert second_compiled is not None
+        assert _first_firewall_core(first_compiled) is _first_firewall_core(second_compiled)
+
+        first_firewall = first_vm_info["firewalls"][0]
+        second_firewall = second_vm_info["firewalls"][0]
+        assert first_firewall is not second_firewall
+        assert first_firewall["apis"] is not second_firewall["apis"]
+
+        first_api = first_firewall["apis"][0]
+        second_api = second_firewall["apis"][0]
+        assert first_api is not second_api
+        assert first_api["id"] == "run-large-a:0"
+        assert second_api["id"] == "run-large-b:0"
+        assert first_api["permissions"] is permissions
+        assert second_api["permissions"] is permissions
+        assert first_api["auth"] is auth
+        assert second_api["auth"] is auth
+
+        first_result = matching.match_compiled_firewall_request(
+            "https://api.example.com/items",
+            "GET",
+            first_compiled,
+            first_policies,
+        )
+        second_result = matching.match_compiled_firewall_request(
+            "https://api.example.com/items",
+            "GET",
+            second_compiled,
+            second_policies,
+        )
+
+        assert isinstance(first_result, matching.FirewallAllow)
+        assert isinstance(second_result, matching.FirewallAllow)
+        assert first_result.api_entry is first_api
+        assert second_result.api_entry is second_api
+
     def test_builtin_firewall_entry_resolves_dynamic_base_url_vars(self, tmp_path):
         path = tmp_path / "registry.json"
         path.write_text(


### PR DESCRIPTION
## Summary

- avoid deep-copying generated builtin firewall nested payloads during mitm registry resolution
- copy only the VM-specific firewall/API shell so resolved bases and run-scoped API ids stay isolated
- add a registry regression test covering shared static payloads, per-VM API shells, and compiled core reuse

Fixes #18771

## Testing

- `cd crates/runner/mitm-addon && .venv/bin/pytest tests/test_registry_context.py`
- `cd crates/runner/mitm-addon && .venv/bin/ruff check .`
- `cd crates/runner/mitm-addon && .venv/bin/ruff format --check .`
- `cd crates/runner/mitm-addon && .venv/bin/basedpyright -p .`
- `cd crates/runner/mitm-addon && .venv/bin/pytest tests/`