### PR TITLE
feat: add presentation R2 template resources

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/registry-resources-download.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/registry-resources-download.test.ts
@@ -155,6 +155,106 @@ const PRIVATE_ARCHIVE_FIXTURES = [
       "8d3ff7b69bbc1ec197f60688d92ffddf5fd5d3c3186aa69cce35d49ce057514c",
   },
   {
+    id: "design-system:bloom-pitch",
+    versionId:
+      "951db59508b46f5f483f0b8dc4c1488d12b9977cd182644904ebfb7d53f4a795",
+  },
+  {
+    id: "design-system:blueprint-academy",
+    versionId:
+      "519cb8a9866664072e27b380800b4749bd2c2b2bcd2a87c1b6b45771dd4b803c",
+  },
+  {
+    id: "design-system:meridian",
+    versionId:
+      "e4b07b5b5d837481ca3025e4e47d04fc1565cf5cd86dc55471eff387e86c70c1",
+  },
+  {
+    id: "design-system:pixel-glitch",
+    versionId:
+      "9906a37702544ac949dece9b83eb40139a94bceda4fc18eea73828e9a8cc561b",
+  },
+  {
+    id: "design-system:prospectus",
+    versionId:
+      "319f03a0df3a07039c1ef10fbc6663173c3eefcfa3f90b25f8ff08d7dde39870",
+  },
+  {
+    id: "design-system:schoolhouse",
+    versionId:
+      "66ceb17d376190beeb523d406eb645c5e12fd268e005e4d49c7f2b0293a9f2b7",
+  },
+  {
+    id: "design-system:sticker-scrapbook",
+    versionId:
+      "0d0af81dec7322f7826c65734077e2fa5acfc63caf78055b202579bc6f309184",
+  },
+  {
+    id: "design-system:strata",
+    versionId:
+      "4c5fd8631f88b0f5fb68983d6897f7f9a87ee58a5c292e5b09a08dc13a58fb6f",
+  },
+  {
+    id: "design-system:taped-consulting",
+    versionId:
+      "c33b3421a9108798a4626b7aeb9f3a8e48593b7b268ffa300df41f49c41cd9a3",
+  },
+  {
+    id: "design-system:vantage",
+    versionId:
+      "0c153dc7f1106422bac7a217fef107b16f69e8672a51819a8f3d1173b5c22a33",
+  },
+  {
+    id: "template:html-ppt-bloom-pitch",
+    versionId:
+      "381d52c641588675a939612b71a7e4b37dcc2ac2bfa55f7d73c5b3a635a53175",
+  },
+  {
+    id: "template:html-ppt-blueprint-academy",
+    versionId:
+      "551ccd097862ab360d3d9125f2113cf68e1aa91fd1e4748eb64617638433d03c",
+  },
+  {
+    id: "template:html-ppt-meridian",
+    versionId:
+      "f07842290d44056fe0781a21de47528fe67ae32aaf62b5a53a2c590432343a83",
+  },
+  {
+    id: "template:html-ppt-pixel-glitch",
+    versionId:
+      "1c576e8851cdc4b57c4ed1c84415b52137efcd965c981f194c4ee910f7d42ccb",
+  },
+  {
+    id: "template:html-ppt-prospectus",
+    versionId:
+      "e628f268e2c2983e84e21154e4afe0747552cc0457069ff2913e1c360ef7d47a",
+  },
+  {
+    id: "template:html-ppt-schoolhouse",
+    versionId:
+      "6151e85d2e94d26dce77c987765db5a67038c9a1d30dc3ce9e7c74847605eb31",
+  },
+  {
+    id: "template:html-ppt-sticker-scrapbook",
+    versionId:
+      "30c2a72e7f058f3c4fe2e63fa60b8bdc6124565461fbbb11ff6c113a406faf66",
+  },
+  {
+    id: "template:html-ppt-strata",
+    versionId:
+      "ca499dce027b3f063da0980154137ebd6a3ee4aeb9c4ae6eeeb7140303a7c05f",
+  },
+  {
+    id: "template:html-ppt-taped-consulting",
+    versionId:
+      "8323a7a66d1a63c50f8ff81b9b3ce5505225afbc1cafd3d2786642a9dce2b426",
+  },
+  {
+    id: "template:html-ppt-vantage",
+    versionId:
+      "443945f5416488feea43cf0cb8f005046a289fbceb8a2c214ba72bd93f31de32",
+  },
+  {
     id: "color-system:bauhaus-primary",
     versionId:
       "26c34a2a33a5c7b751b6741da5e4013020d5dbe138e60f5b3a444f4a5d3a351b",

--- a/turbo/apps/api/src/signals/routes/registry-resources-download.ts
+++ b/turbo/apps/api/src/signals/routes/registry-resources-download.ts
@@ -72,6 +72,26 @@ const PRIVATE_REGISTRY_RESOURCE_ARCHIVE_VERSION_IDS = {
     "2344d4eeb97b8706148f6fabe7e73973a98a9d9929be31f7a4e531a3136bbb2b",
   "design-system:neo-brutalism":
     "929a4c72074e3fce2b64b16c5f53507707225dc71e5909d86b5f9a1bc43c2da0",
+  "design-system:bloom-pitch":
+    "951db59508b46f5f483f0b8dc4c1488d12b9977cd182644904ebfb7d53f4a795",
+  "design-system:blueprint-academy":
+    "519cb8a9866664072e27b380800b4749bd2c2b2bcd2a87c1b6b45771dd4b803c",
+  "design-system:meridian":
+    "e4b07b5b5d837481ca3025e4e47d04fc1565cf5cd86dc55471eff387e86c70c1",
+  "design-system:pixel-glitch":
+    "9906a37702544ac949dece9b83eb40139a94bceda4fc18eea73828e9a8cc561b",
+  "design-system:prospectus":
+    "319f03a0df3a07039c1ef10fbc6663173c3eefcfa3f90b25f8ff08d7dde39870",
+  "design-system:schoolhouse":
+    "66ceb17d376190beeb523d406eb645c5e12fd268e005e4d49c7f2b0293a9f2b7",
+  "design-system:sticker-scrapbook":
+    "0d0af81dec7322f7826c65734077e2fa5acfc63caf78055b202579bc6f309184",
+  "design-system:strata":
+    "4c5fd8631f88b0f5fb68983d6897f7f9a87ee58a5c292e5b09a08dc13a58fb6f",
+  "design-system:taped-consulting":
+    "c33b3421a9108798a4626b7aeb9f3a8e48593b7b268ffa300df41f49c41cd9a3",
+  "design-system:vantage":
+    "0c153dc7f1106422bac7a217fef107b16f69e8672a51819a8f3d1173b5c22a33",
   "color-system:bauhaus-primary":
     "26c34a2a33a5c7b751b6741da5e4013020d5dbe138e60f5b3a444f4a5d3a351b",
   "color-system:berry-pop":
@@ -136,6 +156,26 @@ const PRIVATE_REGISTRY_RESOURCE_ARCHIVE_VERSION_IDS = {
     "b0bb3ef5e0fcc772ecfa67e27776e3be38fdff33b411b431d053544b5ffa4abc",
   "template:html-ppt-neo-brutalism":
     "8d3ff7b69bbc1ec197f60688d92ffddf5fd5d3c3186aa69cce35d49ce057514c",
+  "template:html-ppt-bloom-pitch":
+    "381d52c641588675a939612b71a7e4b37dcc2ac2bfa55f7d73c5b3a635a53175",
+  "template:html-ppt-blueprint-academy":
+    "551ccd097862ab360d3d9125f2113cf68e1aa91fd1e4748eb64617638433d03c",
+  "template:html-ppt-meridian":
+    "f07842290d44056fe0781a21de47528fe67ae32aaf62b5a53a2c590432343a83",
+  "template:html-ppt-pixel-glitch":
+    "1c576e8851cdc4b57c4ed1c84415b52137efcd965c981f194c4ee910f7d42ccb",
+  "template:html-ppt-prospectus":
+    "e628f268e2c2983e84e21154e4afe0747552cc0457069ff2913e1c360ef7d47a",
+  "template:html-ppt-schoolhouse":
+    "6151e85d2e94d26dce77c987765db5a67038c9a1d30dc3ce9e7c74847605eb31",
+  "template:html-ppt-sticker-scrapbook":
+    "30c2a72e7f058f3c4fe2e63fa60b8bdc6124565461fbbb11ff6c113a406faf66",
+  "template:html-ppt-strata":
+    "ca499dce027b3f063da0980154137ebd6a3ee4aeb9c4ae6eeeb7140303a7c05f",
+  "template:html-ppt-taped-consulting":
+    "8323a7a66d1a63c50f8ff81b9b3ce5505225afbc1cafd3d2786642a9dce2b426",
+  "template:html-ppt-vantage":
+    "443945f5416488feea43cf0cb8f005046a289fbceb8a2c214ba72bd93f31de32",
 } as const satisfies Record<string, string>;
 
 function privateRegistryResourceArchive(

--- a/turbo/packages/core/src/__tests__/presentation-template-items.spec.ts
+++ b/turbo/packages/core/src/__tests__/presentation-template-items.spec.ts
@@ -95,7 +95,11 @@ function expectCdnPreviewHtmls(
   }
 }
 
-function expectR2ArchiveSource(id: string, sourcePath: string): void {
+function expectR2ArchiveSource(
+  id: string,
+  sourcePath: string,
+  archiveSha256?: string,
+): void {
   const entry = id.startsWith("template:")
     ? findTemplate(id)
     : findDesignSystem(id);
@@ -109,7 +113,11 @@ function expectR2ArchiveSource(id: string, sourcePath: string): void {
   expect(entry.source.repo).toBeUndefined();
   expect(entry.source.ref).toBeUndefined();
   expect(entry.source.archive?.type).toBe("tar.gz");
-  expect(entry.source.archive?.sha256).toMatch(/^[a-f0-9]{64}$/);
+  if (archiveSha256) {
+    expect(entry.source.archive?.sha256).toBe(archiveSha256);
+  } else {
+    expect(entry.source.archive?.sha256).toMatch(/^[a-f0-9]{64}$/);
+  }
   expect(entry.source.archive).not.toHaveProperty("url");
 }
 
@@ -516,13 +524,123 @@ describe("presentation template items", () => {
         designSourcePath: "presentation-design-system/neo-brutalism",
         templateSourcePath: "presentation-template/neo-brutalism",
       },
+      {
+        designSystemId: "design-system:bloom-pitch",
+        templateId: "template:html-ppt-bloom-pitch",
+        designSourcePath: "presentation-design-system/bloom-pitch",
+        templateSourcePath: "presentation-template/bloom-pitch",
+        designArchiveSha256:
+          "5b7b8f959cef7a3f5ea4eb86e95152845013425365683e4d7efe6c7c5ecc2b48",
+        templateArchiveSha256:
+          "0176ccac0f36b5921ebfcdc998e2273f57a3d79644213eb01000dc4e0e23dcd5",
+      },
+      {
+        designSystemId: "design-system:blueprint-academy",
+        templateId: "template:html-ppt-blueprint-academy",
+        designSourcePath: "presentation-design-system/blueprint-academy",
+        templateSourcePath: "presentation-template/blueprint-academy",
+        designArchiveSha256:
+          "9a5fdb160ae3691513567279401e9a8766c892e0bb80caae6eef3c08a54c0416",
+        templateArchiveSha256:
+          "00b01b07095965f68971e4593cf563562a32b75f49ff4be186be5c81eb6e8330",
+      },
+      {
+        designSystemId: "design-system:meridian",
+        templateId: "template:html-ppt-meridian",
+        designSourcePath: "presentation-design-system/meridian",
+        templateSourcePath: "presentation-template/meridian",
+        designArchiveSha256:
+          "6a00cba7ddd2fcb74e8c89c0063d33bba5fe2e190c15b4634d4a56b2334f527e",
+        templateArchiveSha256:
+          "571bc5d0a35fe3db2ddb2ddc2b0aa3b11bb52532da3fc2eb76d84af885710302",
+      },
+      {
+        designSystemId: "design-system:pixel-glitch",
+        templateId: "template:html-ppt-pixel-glitch",
+        designSourcePath: "presentation-design-system/pixel-glitch",
+        templateSourcePath: "presentation-template/pixel-glitch",
+        designArchiveSha256:
+          "18ce63a66658c7002d3ebea135dc7274b2dac4033c0e98c6e508c7a249fe93a2",
+        templateArchiveSha256:
+          "d16f2913aed0dba0384795db45aa67e6a697d1ae1c31c6a43ff16b8a975dfc18",
+      },
+      {
+        designSystemId: "design-system:prospectus",
+        templateId: "template:html-ppt-prospectus",
+        designSourcePath: "presentation-design-system/prospectus",
+        templateSourcePath: "presentation-template/prospectus",
+        designArchiveSha256:
+          "01e9e6b1f0ea17e3a65c2af7c76cff317b095005c4020ce20eba22e5d63430b6",
+        templateArchiveSha256:
+          "99430b2bd063eb1c922ef22ca95fbe783ab0646b7bdfbb6b7a8b5c839cad5ba0",
+      },
+      {
+        designSystemId: "design-system:schoolhouse",
+        templateId: "template:html-ppt-schoolhouse",
+        designSourcePath: "presentation-design-system/schoolhouse",
+        templateSourcePath: "presentation-template/schoolhouse",
+        designArchiveSha256:
+          "a4a7be65e2adca9eb5572f92b3f49075e768da305b833d74b703da5f2dd3d271",
+        templateArchiveSha256:
+          "4824967cf53a03098aca8c6ca3ea34938d848ff372a556f47ac66a608f81f5db",
+      },
+      {
+        designSystemId: "design-system:sticker-scrapbook",
+        templateId: "template:html-ppt-sticker-scrapbook",
+        designSourcePath: "presentation-design-system/sticker-scrapbook",
+        templateSourcePath: "presentation-template/sticker-scrapbook",
+        designArchiveSha256:
+          "d50129981c3dc3b51b4c63b2ac36b9b5fe6783953bbea3546e372903c8596cad",
+        templateArchiveSha256:
+          "e289743180d623e6a0966ab85d0737686914445c1b749901cfbbf061958cc334",
+      },
+      {
+        designSystemId: "design-system:strata",
+        templateId: "template:html-ppt-strata",
+        designSourcePath: "presentation-design-system/strata",
+        templateSourcePath: "presentation-template/strata",
+        designArchiveSha256:
+          "91a45f8c3b70d7c43505ca7fe51f55ab36a08312e28867383ef885a7a7e63c28",
+        templateArchiveSha256:
+          "ff9c81d11d866f98bbe9cf5e8584adcb3cb28095b734ca02dd1e750ace6f9e49",
+      },
+      {
+        designSystemId: "design-system:taped-consulting",
+        templateId: "template:html-ppt-taped-consulting",
+        designSourcePath: "presentation-design-system/taped-consulting",
+        templateSourcePath: "presentation-template/taped-consulting",
+        designArchiveSha256:
+          "9fb58db77455a3bc7ccdd106b18c99a3d62bc53981f494577804b496a78a858e",
+        templateArchiveSha256:
+          "df64d3f8d5a63e892eeaf5b7723d7274e4147359eda558e1b34aab27e30c439d",
+      },
+      {
+        designSystemId: "design-system:vantage",
+        templateId: "template:html-ppt-vantage",
+        designSourcePath: "presentation-design-system/vantage",
+        templateSourcePath: "presentation-template/vantage",
+        designArchiveSha256:
+          "8338e31f3aa18538d36ae363d3ac2aa0ec56669c33494fdf2a12286d9b0523a8",
+        templateArchiveSha256:
+          "0d4c276d8dc7710a484d4d7c9bfb05f0a68b378d50e73aea6a6eb92698daa6fe",
+      },
     ] as const;
 
     for (const entry of entries) {
       expect(findDesignSystem(entry.designSystemId)).toBeDefined();
       expect(findTemplate(entry.templateId)?.targets).toContain("presentation");
-      expectR2ArchiveSource(entry.designSystemId, entry.designSourcePath);
-      expectR2ArchiveSource(entry.templateId, entry.templateSourcePath);
+      expectR2ArchiveSource(
+        entry.designSystemId,
+        entry.designSourcePath,
+        "designArchiveSha256" in entry ? entry.designArchiveSha256 : undefined,
+      );
+      expectR2ArchiveSource(
+        entry.templateId,
+        entry.templateSourcePath,
+        "templateArchiveSha256" in entry
+          ? entry.templateArchiveSha256
+          : undefined,
+      );
     }
   });
 

--- a/turbo/packages/core/src/resource-registry.ts
+++ b/turbo/packages/core/src/resource-registry.ts
@@ -139,7 +139,7 @@ const PRESENTATION_RESOURCE_ARCHIVE_SHA256 = {
   businessData:
     "229516a65ebd66d48c789bb626da24f96a8658d313c72229c0d2cabe262248f1",
   presentationDeckTools:
-    "a0674e9238ce0819281fa01f39dd650ccda215b6498578decaaf2042ab8c4531",
+    "8494f73396a76d81b8b252afe0e3cbaf2c6004346b2c9430365cdb0b6ae76d89",
   designSystemCrayon:
     "c2b891a40b672aa8f45bd72d7343309d097dd3aeb6653444fe10c5d4b62bbaca",
   templateCrayon:
@@ -180,6 +180,46 @@ const PRESENTATION_RESOURCE_ARCHIVE_SHA256 = {
     "a9bbb1cfc4a86259b9ad8f33d9eaa433eedd75b26ce0a6d4f65fa965d66a75c9",
   templateNeoBrutalism:
     "cec2dde23a09f38c8a538e5cddcce9853e726cef1ee7bcfde46cd405f7dcd465",
+  designSystemBloomPitch:
+    "5b7b8f959cef7a3f5ea4eb86e95152845013425365683e4d7efe6c7c5ecc2b48",
+  templateBloomPitch:
+    "0176ccac0f36b5921ebfcdc998e2273f57a3d79644213eb01000dc4e0e23dcd5",
+  designSystemBlueprintAcademy:
+    "9a5fdb160ae3691513567279401e9a8766c892e0bb80caae6eef3c08a54c0416",
+  templateBlueprintAcademy:
+    "00b01b07095965f68971e4593cf563562a32b75f49ff4be186be5c81eb6e8330",
+  designSystemMeridian:
+    "6a00cba7ddd2fcb74e8c89c0063d33bba5fe2e190c15b4634d4a56b2334f527e",
+  templateMeridian:
+    "571bc5d0a35fe3db2ddb2ddc2b0aa3b11bb52532da3fc2eb76d84af885710302",
+  designSystemPixelGlitch:
+    "18ce63a66658c7002d3ebea135dc7274b2dac4033c0e98c6e508c7a249fe93a2",
+  templatePixelGlitch:
+    "d16f2913aed0dba0384795db45aa67e6a697d1ae1c31c6a43ff16b8a975dfc18",
+  designSystemProspectus:
+    "01e9e6b1f0ea17e3a65c2af7c76cff317b095005c4020ce20eba22e5d63430b6",
+  templateProspectus:
+    "99430b2bd063eb1c922ef22ca95fbe783ab0646b7bdfbb6b7a8b5c839cad5ba0",
+  designSystemSchoolhouse:
+    "a4a7be65e2adca9eb5572f92b3f49075e768da305b833d74b703da5f2dd3d271",
+  templateSchoolhouse:
+    "4824967cf53a03098aca8c6ca3ea34938d848ff372a556f47ac66a608f81f5db",
+  designSystemStickerScrapbook:
+    "d50129981c3dc3b51b4c63b2ac36b9b5fe6783953bbea3546e372903c8596cad",
+  templateStickerScrapbook:
+    "e289743180d623e6a0966ab85d0737686914445c1b749901cfbbf061958cc334",
+  designSystemStrata:
+    "91a45f8c3b70d7c43505ca7fe51f55ab36a08312e28867383ef885a7a7e63c28",
+  templateStrata:
+    "ff9c81d11d866f98bbe9cf5e8584adcb3cb28095b734ca02dd1e750ace6f9e49",
+  designSystemTapedConsulting:
+    "9fb58db77455a3bc7ccdd106b18c99a3d62bc53981f494577804b496a78a858e",
+  templateTapedConsulting:
+    "df64d3f8d5a63e892eeaf5b7723d7274e4147359eda558e1b34aab27e30c439d",
+  designSystemVantage:
+    "8338e31f3aa18538d36ae363d3ac2aa0ec56669c33494fdf2a12286d9b0523a8",
+  templateVantage:
+    "0d4c276d8dc7710a484d4d7c9bfb05f0a68b378d50e73aea6a6eb92698daa6fe",
   colorSystemBauhausPrimary:
     "f42a1d62462f24b1a411889f8011b07bd3f1bb1db82a339cc59cf5ab5be2f475",
   colorSystemBerryPop:
@@ -1160,6 +1200,126 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     source: privateR2ArchiveSource(
       "presentation-template/neo-brutalism",
       PRESENTATION_RESOURCE_ARCHIVE_SHA256.templateNeoBrutalism,
+    ),
+    targets: ["presentation"],
+  },
+  {
+    id: "template:html-ppt-bloom-pitch",
+    kind: "template",
+    name: "Bloom Pitch Presentation",
+    description:
+      "15-slot playful investor-pitch presentation structure with oversized headlines, colour-field dividers, organic visuals, stat stacks, quote cards, and pricing cards.",
+    source: privateR2ArchiveSource(
+      "presentation-template/bloom-pitch",
+      PRESENTATION_RESOURCE_ARCHIVE_SHA256.templateBloomPitch,
+    ),
+    targets: ["presentation"],
+  },
+  {
+    id: "template:html-ppt-blueprint-academy",
+    kind: "template",
+    name: "Blueprint Academy Presentation",
+    description:
+      "15-slot academic education presentation structure with blueprint grids, wire diagrams, matted photos, goal cards, process spines, stats, testimonials, and contact slides.",
+    source: privateR2ArchiveSource(
+      "presentation-template/blueprint-academy",
+      PRESENTATION_RESOURCE_ARCHIVE_SHA256.templateBlueprintAcademy,
+    ),
+    targets: ["presentation"],
+  },
+  {
+    id: "template:html-ppt-meridian",
+    kind: "template",
+    name: "Meridian Presentation",
+    description:
+      "15-slot professional data-agency presentation structure with flat nav chrome, sharp blocks, index numbers, stat matrices, bar charts, service blocks, and executive close.",
+    source: privateR2ArchiveSource(
+      "presentation-template/meridian",
+      PRESENTATION_RESOURCE_ARCHIVE_SHA256.templateMeridian,
+    ),
+    targets: ["presentation"],
+  },
+  {
+    id: "template:html-ppt-pixel-glitch",
+    kind: "template",
+    name: "Pixel Glitch Presentation",
+    description:
+      "15-slot Y2K creative-studio presentation structure with pixel trails, glitch titles, sharp dividers, image blocks, ring charts, process spines, and bold proof pages.",
+    source: privateR2ArchiveSource(
+      "presentation-template/pixel-glitch",
+      PRESENTATION_RESOURCE_ARCHIVE_SHA256.templatePixelGlitch,
+    ),
+    targets: ["presentation"],
+  },
+  {
+    id: "template:html-ppt-prospectus",
+    kind: "template",
+    name: "Prospectus Presentation",
+    description:
+      "15-slot corporate landing-page business-plan structure with persistent nav, colour-field stages, diagonal arrows, CTA clusters, flat charts, gantt timelines, and pricing tiers.",
+    source: privateR2ArchiveSource(
+      "presentation-template/prospectus",
+      PRESENTATION_RESOURCE_ARCHIVE_SHA256.templateProspectus,
+    ),
+    targets: ["presentation"],
+  },
+  {
+    id: "template:html-ppt-schoolhouse",
+    kind: "template",
+    name: "Schoolhouse Presentation",
+    description:
+      "15-slot retro school-poster presentation structure with paper stages, stamp badges, index cards, ruled rows, stat bands, quote cards, and membership tiers.",
+    source: privateR2ArchiveSource(
+      "presentation-template/schoolhouse",
+      PRESENTATION_RESOURCE_ARCHIVE_SHA256.templateSchoolhouse,
+    ),
+    targets: ["presentation"],
+  },
+  {
+    id: "template:html-ppt-sticker-scrapbook",
+    kind: "template",
+    name: "Sticker Scrapbook Presentation",
+    description:
+      "15-slot vibrant scrapbook presentation structure with sticker seals, spiral pads, agenda cards, doodle dividers, photo grids, stat stickers, quote cards, and pricing cards.",
+    source: privateR2ArchiveSource(
+      "presentation-template/sticker-scrapbook",
+      PRESENTATION_RESOURCE_ARCHIVE_SHA256.templateStickerScrapbook,
+    ),
+    targets: ["presentation"],
+  },
+  {
+    id: "template:html-ppt-strata",
+    kind: "template",
+    name: "Strata Presentation",
+    description:
+      "15-slot Swiss-minimal agency presentation structure with giant caps, asterisk dividers, tile ramps, mono photo grids, frameless stats, quote cards, and pricing cards.",
+    source: privateR2ArchiveSource(
+      "presentation-template/strata",
+      PRESENTATION_RESOURCE_ARCHIVE_SHA256.templateStrata,
+    ),
+    targets: ["presentation"],
+  },
+  {
+    id: "template:html-ppt-taped-consulting",
+    kind: "template",
+    name: "Taped Consulting Presentation",
+    description:
+      "15-slot consulting presentation structure with taped photo clusters, inset frames, feature rows, process spines, big-number proof, quote cards, and pricing cards.",
+    source: privateR2ArchiveSource(
+      "presentation-template/taped-consulting",
+      PRESENTATION_RESOURCE_ARCHIVE_SHA256.templateTapedConsulting,
+    ),
+    targets: ["presentation"],
+  },
+  {
+    id: "template:html-ppt-vantage",
+    kind: "template",
+    name: "Vantage Presentation",
+    description:
+      "15-slot business-proposal presentation structure with two-tone headings, corner indexes, square-pair motifs, split panels, frameless numbers, donut charts, and milestone lines.",
+    source: privateR2ArchiveSource(
+      "presentation-template/vantage",
+      PRESENTATION_RESOURCE_ARCHIVE_SHA256.templateVantage,
     ),
     targets: ["presentation"],
   },
@@ -3035,6 +3195,116 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
     source: privateR2ArchiveSource(
       "presentation-design-system/neo-brutalism",
       PRESENTATION_RESOURCE_ARCHIVE_SHA256.designSystemNeoBrutalism,
+    ),
+  },
+  {
+    id: "design-system:bloom-pitch",
+    kind: "design-system",
+    name: "Bloom Pitch",
+    description:
+      "Playful visual language with carnival colour, Fredoka and Quicksand type, soft geometry, organic blobs, and asterisk bursts.",
+    source: privateR2ArchiveSource(
+      "presentation-design-system/bloom-pitch",
+      PRESENTATION_RESOURCE_ARCHIVE_SHA256.designSystemBloomPitch,
+    ),
+  },
+  {
+    id: "design-system:blueprint-academy",
+    kind: "design-system",
+    name: "Blueprint Academy",
+    description:
+      "Academic visual language with forest-editorial colour, Fraunces and Work Sans type, blueprint texture, wire diagrams, sparkle marks, and matted photo treatment.",
+    source: privateR2ArchiveSource(
+      "presentation-design-system/blueprint-academy",
+      PRESENTATION_RESOURCE_ARCHIVE_SHA256.designSystemBlueprintAcademy,
+    ),
+  },
+  {
+    id: "design-system:meridian",
+    kind: "design-system",
+    name: "Meridian",
+    description:
+      "Professional data-agency visual language with slate-corporate colour, Sora and Inter type, sharp geometry, hairline rules, square tickers, and two-tone data marks.",
+    source: privateR2ArchiveSource(
+      "presentation-design-system/meridian",
+      PRESENTATION_RESOURCE_ARCHIVE_SHA256.designSystemMeridian,
+    ),
+  },
+  {
+    id: "design-system:pixel-glitch",
+    kind: "design-system",
+    name: "Pixel Glitch",
+    description:
+      "Y2K digital visual language with Bauhaus-primary colour, Space Grotesk and Lexend type, sharp pixel geometry, glitch titles, cursor marks, and pixel trails.",
+    source: privateR2ArchiveSource(
+      "presentation-design-system/pixel-glitch",
+      PRESENTATION_RESOURCE_ARCHIVE_SHA256.designSystemPixelGlitch,
+    ),
+  },
+  {
+    id: "design-system:prospectus",
+    kind: "design-system",
+    name: "Prospectus",
+    description:
+      "Corporate landing-page visual language with slate-corporate colour, Archivo and Manrope type, oversized thin titles, diagonal arrows, underline-ring labels, and CTA styling.",
+    source: privateR2ArchiveSource(
+      "presentation-design-system/prospectus",
+      PRESENTATION_RESOURCE_ARCHIVE_SHA256.designSystemProspectus,
+    ),
+  },
+  {
+    id: "design-system:schoolhouse",
+    kind: "design-system",
+    name: "Schoolhouse",
+    description:
+      "Retro school-poster visual language with Bauhaus-primary colour, Archivo and Manrope type, kraft-paper texture, thick outlines, stamp marks, halftone, and hard shadows.",
+    source: privateR2ArchiveSource(
+      "presentation-design-system/schoolhouse",
+      PRESENTATION_RESOURCE_ARCHIVE_SHA256.designSystemSchoolhouse,
+    ),
+  },
+  {
+    id: "design-system:sticker-scrapbook",
+    kind: "design-system",
+    name: "Sticker Scrapbook",
+    description:
+      "Vibrant scrapbook visual language with prism colour, Poppins and Figtree type, pill geometry, sticker seals, spiral pads, doodles, sun rays, and sparkles.",
+    source: privateR2ArchiveSource(
+      "presentation-design-system/sticker-scrapbook",
+      PRESENTATION_RESOURCE_ARCHIVE_SHA256.designSystemStickerScrapbook,
+    ),
+  },
+  {
+    id: "design-system:strata",
+    kind: "design-system",
+    name: "Strata",
+    description:
+      "Swiss-minimal agency visual language with mono-ink colour, Archivo and Manrope type, giant caps, asterisk sparks, tile ramps, mono imagery, and red signal accents.",
+    source: privateR2ArchiveSource(
+      "presentation-design-system/strata",
+      PRESENTATION_RESOURCE_ARCHIVE_SHA256.designSystemStrata,
+    ),
+  },
+  {
+    id: "design-system:taped-consulting",
+    kind: "design-system",
+    name: "Taped Consulting",
+    description:
+      "Elegant consulting visual language with slate-corporate colour, Montserrat and Lora type, taped-photo treatment, two-tone titles, inset frames, lifted shadows, and text links.",
+    source: privateR2ArchiveSource(
+      "presentation-design-system/taped-consulting",
+      PRESENTATION_RESOURCE_ARCHIVE_SHA256.designSystemTapedConsulting,
+    ),
+  },
+  {
+    id: "design-system:vantage",
+    kind: "design-system",
+    name: "Vantage",
+    description:
+      "Business-proposal visual language with slate-corporate colour, Archivo and Manrope type, sharp geometry, two-tone headings, corner indexes, square-pair marks, and hashtag chrome.",
+    source: privateR2ArchiveSource(
+      "presentation-design-system/vantage",
+      PRESENTATION_RESOURCE_ARCHIVE_SHA256.designSystemVantage,
     ),
   },
   {


### PR DESCRIPTION
## Summary

- Upload R2-backed registry archives for 10 new presentation templates and 10 matching design systems:
  `bloom-pitch`, `blueprint-academy`, `meridian`, `pixel-glitch`, `prospectus`, `schoolhouse`, `sticker-scrapbook`, `strata`, `taped-consulting`, `vantage`.
- Register the new `presentation-template/<slug>` and `presentation-design-system/<slug>` private archive sources with pinned SHA-256 values.
- Add the private archive version ids to the registry resource download allowlist and test fixtures.
- Align `tool:presentation-deck-tools` with the currently uploaded runtime archive SHA.

## Verification

- R2 storage download verification: 21/21 uploaded archives downloaded by version id and matched local SHA-256.
- `pnpm exec prettier --check packages/core/src/resource-registry.ts apps/api/src/signals/routes/registry-resources-download.ts apps/api/src/signals/routes/__tests__/registry-resources-download.test.ts packages/core/src/__tests__/presentation-template-items.spec.ts`
- `pnpm exec vitest --run packages/core/src/__tests__/presentation-template-items.spec.ts`

## Not run

- `pnpm exec vitest --run apps/api/src/signals/routes/__tests__/registry-resources-download.test.ts` requires local Postgres; this environment returned `ECONNREFUSED 127.0.0.1:5432`.
