### PR TITLE
ci: deploy runner assets by host architecture

### DIFF
--- a/.github/scripts/runner-host-architecture-groups.sh
+++ b/.github/scripts/runner-host-architecture-groups.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 usage() {
   cat <<'USAGE'
-Usage: runner-host-architecture-groups.sh [matrix|has-groups|hosts ID|select-host ID KEY [HOSTS]]
+Usage: runner-host-architecture-groups.sh [matrix|target-matrix|has-groups|hosts ID|select-host ID KEY [HOSTS]]
 
 Emits compact JSON for configured runner host architecture groups.
 Inputs:
@@ -16,6 +16,7 @@ Inputs:
 Commands:
   <none>      Emit the full local contract, including hosts.
   matrix      Emit the cross-job matrix contract, excluding hosts.
+  target-matrix  Emit the deploy/rollback matrix contract: id, label, target.
   has-groups  Emit true when at least one host group is configured.
   hosts ID            Emit comma-separated hosts for the given architecture group.
   select-host ID KEY [HOSTS]  Emit one deterministic host from the given architecture group.
@@ -169,6 +170,16 @@ emit_matrix() {
   })' <<<"$groups"
 }
 
+emit_target_matrix() {
+  local groups
+  groups=$(emit_groups) || return $?
+  jq -c 'map({
+    id,
+    label,
+    target
+  })' <<<"$groups"
+}
+
 emit_has_groups() {
   local groups
   groups=$(emit_groups) || return $?
@@ -245,6 +256,9 @@ case "$cmd" in
     ;;
   matrix)
     emit_matrix
+    ;;
+  target-matrix)
+    emit_target_matrix
     ;;
   has-groups)
     emit_has_groups

--- a/.github/scripts/runner-image-target.sh
+++ b/.github/scripts/runner-image-target.sh
@@ -109,3 +109,21 @@ runner_image_asset_suffix() {
       ;;
   esac
 }
+
+runner_image_elf_machine_hex() {
+  local target="${1:-}"
+
+  runner_image_validate_target "$target" || return $?
+  case "$target" in
+    aarch64-unknown-linux-musl)
+      printf '%s\n' "b700"
+      ;;
+    x86_64-unknown-linux-musl)
+      printf '%s\n' "3e00"
+      ;;
+    *)
+      echo "missing runner image ELF machine metadata for target: ${target}" >&2
+      return 2
+      ;;
+  esac
+}

--- a/.github/scripts/runner-image-target.sh
+++ b/.github/scripts/runner-image-target.sh
@@ -116,6 +116,10 @@ runner_image_release_tag() {
     echo "missing runner release version" >&2
     return 2
   fi
+  if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "unsupported runner release version: ${version} (expected semver like 0.81.0, without leading v)" >&2
+    return 2
+  fi
 
   printf 'runner-rs-v%s\n' "$version"
 }

--- a/.github/scripts/runner-image-target.sh
+++ b/.github/scripts/runner-image-target.sh
@@ -110,6 +110,26 @@ runner_image_asset_suffix() {
   esac
 }
 
+runner_image_release_tag() {
+  local version="${1:-}"
+  if [ -z "$version" ]; then
+    echo "missing runner release version" >&2
+    return 2
+  fi
+
+  printf 'runner-rs-v%s\n' "$version"
+}
+
+runner_image_release_asset_name() {
+  local version="${1:-}"
+  local target="${2:-}"
+  local asset_suffix
+
+  runner_image_release_tag "$version" >/dev/null || return $?
+  asset_suffix=$(runner_image_asset_suffix "$target") || return $?
+  printf 'runner-v%s-%s\n' "$version" "$asset_suffix"
+}
+
 runner_image_elf_machine_hex() {
   local target="${1:-}"
 

--- a/.github/scripts/tests/runner-host-architecture-groups-test.sh
+++ b/.github/scripts/tests/runner-host-architecture-groups-test.sh
@@ -64,6 +64,11 @@ assert_no_hosts_field() {
   jq -e 'all(.[]; has("hosts") | not)' >/dev/null <<<"$output" || fail "expected no hosts field: ${output}"
 }
 
+assert_target_matrix_contract() {
+  local output=$1
+  jq -e 'all(.[]; (keys | sort) == ["id", "label", "target"])' >/dev/null <<<"$output" || fail "expected target matrix fields only: ${output}"
+}
+
 out=$(bash -c '. "$1"; runner_image_target_for_uname_m aarch64' bash "$TARGET")
 [ "$out" = "aarch64-unknown-linux-musl" ] || fail "expected aarch64 target, got: ${out}"
 
@@ -75,6 +80,15 @@ out=$(bash -c '. "$1"; runner_image_elf_machine_hex aarch64-unknown-linux-musl' 
 
 out=$(bash -c '. "$1"; runner_image_elf_machine_hex x86_64-unknown-linux-musl' bash "$TARGET")
 [ "$out" = "3e00" ] || fail "expected x86_64 ELF machine metadata, got: ${out}"
+
+out=$(bash -c '. "$1"; runner_image_release_tag 1.2.3' bash "$TARGET")
+[ "$out" = "runner-rs-v1.2.3" ] || fail "expected runner release tag, got: ${out}"
+
+out=$(bash -c '. "$1"; runner_image_release_asset_name 1.2.3 aarch64-unknown-linux-musl' bash "$TARGET")
+[ "$out" = "runner-v1.2.3-aarch64-linux" ] || fail "expected aarch64 release asset name, got: ${out}"
+
+out=$(bash -c '. "$1"; runner_image_release_asset_name 1.2.3 x86_64-unknown-linux-musl' bash "$TARGET")
+[ "$out" = "runner-v1.2.3-x86_64-linux" ] || fail "expected x86_64 release asset name, got: ${out}"
 
 if bash -c '. "$1"; runner_image_target_for_uname_m ""' bash "$TARGET" >"${TMPDIR}/uname-empty.out" 2>"${TMPDIR}/uname-empty.err"; then
   fail "expected empty uname target lookup to fail"
@@ -96,6 +110,11 @@ out=$(run_clean AWS_METAL_RUNNER_HOSTS='arm-1, arm-2' "$HOST_GROUPS" matrix)
 assert_compact_json "$out"
 assert_no_hosts_field "$out"
 assert_json_eq "$out" '[{"id":"arm64","label":"ARM64","target":"aarch64-unknown-linux-musl","unameM":"aarch64","cacheSuffix":"aarch64-musl","assetSuffix":"aarch64-linux"}]'
+
+out=$(run_clean AWS_METAL_RUNNER_HOSTS='arm-1, arm-2' "$HOST_GROUPS" target-matrix)
+assert_compact_json "$out"
+assert_target_matrix_contract "$out"
+assert_json_eq "$out" '[{"id":"arm64","label":"ARM64","target":"aarch64-unknown-linux-musl"}]'
 
 out=$(run_clean AWS_METAL_RUNNER_HOSTS='arm-1, arm-2' "$HOST_GROUPS" has-groups)
 [ "$out" = "true" ] || fail "expected ARM64 has-groups=true, got: ${out}"
@@ -120,6 +139,11 @@ assert_compact_json "$out"
 assert_no_hosts_field "$out"
 assert_json_eq "$out" '[{"id":"x86_64","label":"x86_64","target":"x86_64-unknown-linux-musl","unameM":"x86_64","cacheSuffix":"x86_64-musl","assetSuffix":"x86_64-linux"}]'
 
+out=$(run_clean AWS_METAL_RUNNER_HOSTS='x86-1' "$HOST_GROUPS" target-matrix)
+assert_compact_json "$out"
+assert_target_matrix_contract "$out"
+assert_json_eq "$out" '[{"id":"x86_64","label":"x86_64","target":"x86_64-unknown-linux-musl"}]'
+
 out=$(run_clean AWS_METAL_RUNNER_HOSTS='x86-1' "$HOST_GROUPS" has-groups)
 [ "$out" = "true" ] || fail "expected x86_64 has-groups=true, got: ${out}"
 
@@ -136,6 +160,11 @@ out=$(run_clean AWS_METAL_RUNNER_HOSTS='arm-1,x86-1,x86-2' "$HOST_GROUPS" matrix
 assert_compact_json "$out"
 assert_no_hosts_field "$out"
 assert_json_eq "$out" '[{"id":"arm64","label":"ARM64","target":"aarch64-unknown-linux-musl","unameM":"aarch64","cacheSuffix":"aarch64-musl","assetSuffix":"aarch64-linux"},{"id":"x86_64","label":"x86_64","target":"x86_64-unknown-linux-musl","unameM":"x86_64","cacheSuffix":"x86_64-musl","assetSuffix":"x86_64-linux"}]'
+
+out=$(run_clean AWS_METAL_RUNNER_HOSTS='arm-1,x86-1,x86-2' "$HOST_GROUPS" target-matrix)
+assert_compact_json "$out"
+assert_target_matrix_contract "$out"
+assert_json_eq "$out" '[{"id":"arm64","label":"ARM64","target":"aarch64-unknown-linux-musl"},{"id":"x86_64","label":"x86_64","target":"x86_64-unknown-linux-musl"}]'
 
 out=$(run_clean AWS_METAL_RUNNER_HOSTS='arm-1,x86-1,x86-2' "$HOST_GROUPS" hosts x86_64)
 [ "$out" = "x86-1,x86-2" ] || fail "expected mixed x86_64 hosts, got: ${out}"
@@ -228,6 +257,10 @@ out=$(run_clean "$HOST_GROUPS" matrix)
 assert_compact_json "$out"
 assert_json_eq "$out" '[]'
 
+out=$(run_clean "$HOST_GROUPS" target-matrix)
+assert_compact_json "$out"
+assert_json_eq "$out" '[]'
+
 out=$(run_clean "$HOST_GROUPS" has-groups)
 [ "$out" = "false" ] || fail "expected empty has-groups=false, got: ${out}"
 
@@ -260,5 +293,20 @@ if bash -c '. "$1"; runner_image_elf_machine_hex powerpc-unknown-linux-musl' bas
   fail "expected unsupported ELF machine target to fail"
 fi
 grep -q "unsupported runner image target: powerpc-unknown-linux-musl" "${TMPDIR}/elf.err" || fail "expected unsupported ELF machine message"
+
+if bash -c '. "$1"; runner_image_release_tag ""' bash "$TARGET" >"${TMPDIR}/tag-empty.out" 2>"${TMPDIR}/tag-empty.err"; then
+  fail "expected empty release tag version to fail"
+fi
+grep -q "missing runner release version" "${TMPDIR}/tag-empty.err" || fail "expected missing release tag version message"
+
+if bash -c '. "$1"; runner_image_release_asset_name "" aarch64-unknown-linux-musl' bash "$TARGET" >"${TMPDIR}/asset-name-version-empty.out" 2>"${TMPDIR}/asset-name-version-empty.err"; then
+  fail "expected empty release asset name version to fail"
+fi
+grep -q "missing runner release version" "${TMPDIR}/asset-name-version-empty.err" || fail "expected missing release asset name version message"
+
+if bash -c '. "$1"; runner_image_release_asset_name 1.2.3 powerpc-unknown-linux-musl' bash "$TARGET" >"${TMPDIR}/asset-name-target.out" 2>"${TMPDIR}/asset-name-target.err"; then
+  fail "expected unsupported release asset name target to fail"
+fi
+grep -q "unsupported runner image target: powerpc-unknown-linux-musl" "${TMPDIR}/asset-name-target.err" || fail "expected unsupported release asset name target message"
 
 echo "runner-host-architecture-groups-test: ok"

--- a/.github/scripts/tests/runner-host-architecture-groups-test.sh
+++ b/.github/scripts/tests/runner-host-architecture-groups-test.sh
@@ -70,6 +70,12 @@ out=$(bash -c '. "$1"; runner_image_target_for_uname_m aarch64' bash "$TARGET")
 out=$(bash -c '. "$1"; runner_image_target_for_uname_m x86_64' bash "$TARGET")
 [ "$out" = "x86_64-unknown-linux-musl" ] || fail "expected x86_64 target, got: ${out}"
 
+out=$(bash -c '. "$1"; runner_image_elf_machine_hex aarch64-unknown-linux-musl' bash "$TARGET")
+[ "$out" = "b700" ] || fail "expected aarch64 ELF machine metadata, got: ${out}"
+
+out=$(bash -c '. "$1"; runner_image_elf_machine_hex x86_64-unknown-linux-musl' bash "$TARGET")
+[ "$out" = "3e00" ] || fail "expected x86_64 ELF machine metadata, got: ${out}"
+
 if bash -c '. "$1"; runner_image_target_for_uname_m ""' bash "$TARGET" >"${TMPDIR}/uname-empty.out" 2>"${TMPDIR}/uname-empty.err"; then
   fail "expected empty uname target lookup to fail"
 fi
@@ -244,5 +250,15 @@ if bash -c '. "$1"; runner_image_asset_suffix powerpc-unknown-linux-musl' bash "
   fail "expected unsupported asset suffix target to fail"
 fi
 grep -q "unsupported runner image target: powerpc-unknown-linux-musl" "${TMPDIR}/asset.err" || fail "expected unsupported asset suffix message"
+
+if bash -c '. "$1"; runner_image_elf_machine_hex ""' bash "$TARGET" >"${TMPDIR}/elf-empty.out" 2>"${TMPDIR}/elf-empty.err"; then
+  fail "expected empty ELF machine target to fail"
+fi
+grep -q "missing runner image target" "${TMPDIR}/elf-empty.err" || fail "expected missing ELF machine target message"
+
+if bash -c '. "$1"; runner_image_elf_machine_hex powerpc-unknown-linux-musl' bash "$TARGET" >"${TMPDIR}/elf.out" 2>"${TMPDIR}/elf.err"; then
+  fail "expected unsupported ELF machine target to fail"
+fi
+grep -q "unsupported runner image target: powerpc-unknown-linux-musl" "${TMPDIR}/elf.err" || fail "expected unsupported ELF machine message"
 
 echo "runner-host-architecture-groups-test: ok"

--- a/.github/scripts/tests/runner-host-architecture-groups-test.sh
+++ b/.github/scripts/tests/runner-host-architecture-groups-test.sh
@@ -299,10 +299,25 @@ if bash -c '. "$1"; runner_image_release_tag ""' bash "$TARGET" >"${TMPDIR}/tag-
 fi
 grep -q "missing runner release version" "${TMPDIR}/tag-empty.err" || fail "expected missing release tag version message"
 
+if bash -c '. "$1"; runner_image_release_tag v1.2.3' bash "$TARGET" >"${TMPDIR}/tag-leading-v.out" 2>"${TMPDIR}/tag-leading-v.err"; then
+  fail "expected leading-v release tag version to fail"
+fi
+grep -q "unsupported runner release version: v1.2.3" "${TMPDIR}/tag-leading-v.err" || fail "expected leading-v release tag version message"
+
+if bash -c '. "$1"; runner_image_release_tag "$2"' bash "$TARGET" "1.2.3/evil" >"${TMPDIR}/tag-path.out" 2>"${TMPDIR}/tag-path.err"; then
+  fail "expected path-like release tag version to fail"
+fi
+grep -q "unsupported runner release version: 1.2.3/evil" "${TMPDIR}/tag-path.err" || fail "expected path-like release tag version message"
+
 if bash -c '. "$1"; runner_image_release_asset_name "" aarch64-unknown-linux-musl' bash "$TARGET" >"${TMPDIR}/asset-name-version-empty.out" 2>"${TMPDIR}/asset-name-version-empty.err"; then
   fail "expected empty release asset name version to fail"
 fi
 grep -q "missing runner release version" "${TMPDIR}/asset-name-version-empty.err" || fail "expected missing release asset name version message"
+
+if bash -c '. "$1"; runner_image_release_asset_name v1.2.3 aarch64-unknown-linux-musl' bash "$TARGET" >"${TMPDIR}/asset-name-version-leading-v.out" 2>"${TMPDIR}/asset-name-version-leading-v.err"; then
+  fail "expected leading-v release asset name version to fail"
+fi
+grep -q "unsupported runner release version: v1.2.3" "${TMPDIR}/asset-name-version-leading-v.err" || fail "expected leading-v release asset name version message"
 
 if bash -c '. "$1"; runner_image_release_asset_name 1.2.3 powerpc-unknown-linux-musl' bash "$TARGET" >"${TMPDIR}/asset-name-target.out" 2>"${TMPDIR}/asset-name-target.err"; then
   fail "expected unsupported release asset name target to fail"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1112,6 +1112,7 @@ jobs:
       - build-api-production
       - build-app-production
       - build-runner-release-assets
+      - runner-production-host-groups
       - build-runner-production
       - build-e2b-template-production
       - sbom
@@ -2058,8 +2059,6 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
   # Publish runner release binaries for every supported host architecture.
-  # Production host staging remains in build-runner-production until #18486
-  # makes deploy/rollback architecture-aware.
   build-runner-release-assets:
     needs: release-please
     if: ${{ needs.release-please.outputs.runner_rs_release_created == 'true' }}
@@ -2253,14 +2252,63 @@ jobs:
                   type: mrkdwn
                   text: "*Runner RS* ❌ Release asset publishing failed\n📦 Version: `${{ needs.release-please.outputs.runner_rs_version }}`\n🏗️ Target: `${{ matrix.target }}`\n⏱️ `${{ steps.duration.outputs.text }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/runner-rs-v${{ needs.release-please.outputs.runner_rs_version }}|View Release>\n🔗 <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Logs>"
 
-  # Build runner: download the published ARM64 release binary and stage it on
-  # metal hosts (provision OS + monitoring + `runner build`
+  runner-production-host-groups:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.runner_rs_release_created == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    environment: production
+    outputs:
+      # Keep cross-job architecture metadata sanitized. Jobs that need hosts
+      # resolve the host subset from matrix.id inside that job.
+      matrix: ${{ steps.groups.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup SSH via Cloudflare Tunnel
+        uses: ./.github/actions/setup-ssh-tunnel
+        with:
+          ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
+          cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+
+      - name: Resolve production runner host architecture groups
+        id: groups
+        env:
+          AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          matrix=$(.github/scripts/runner-host-architecture-groups.sh matrix)
+          group_count=$(jq -r 'length' <<<"$matrix")
+          if [ "$group_count" -lt 1 ]; then
+            echo "::error::No production runner host architecture groups found"
+            exit 1
+          fi
+
+          echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
+          echo "Production runner host architecture groups:"
+          jq . <<<"$matrix"
+
+  # Build runner: download the matching published release binary and stage it
+  # on each architecture group (provision OS + monitoring + `runner build`
   # rootfs/snapshot). This job does not flip traffic — the systemd
   # service is still running the previous version. Runs after release assets
   # have been published so production staging uses the same binary users can
   # download from GitHub Releases.
   build-runner-production:
-    needs: [release-please, resolve-image-cache, build-runner-release-assets]
+    name: Build runner production (${{ matrix.label }})
+    needs:
+      [
+        release-please,
+        resolve-image-cache,
+        build-runner-release-assets,
+        runner-production-host-groups,
+      ]
     if: ${{ needs.release-please.outputs.runner_rs_release_created == 'true' }}
     runs-on: ubuntu-latest
     container:
@@ -2268,6 +2316,10 @@ jobs:
     permissions:
       contents: read
     environment: production
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.runner-production-host-groups.outputs.matrix || '[]') }}
     steps:
       - uses: actions/checkout@v7
 
@@ -2280,28 +2332,68 @@ jobs:
           token: ${{ secrets.CI_SLACK_BOT_TOKEN }}
           payload: |
             channel: ${{ vars.SLACK_RELEASE_CHANNEL_ID }}
-            text: "*Runner RS* building staged production deployment..."
+            text: "*Runner RS* building staged production deployment (${{ matrix.label }})..."
             blocks:
               - type: section
                 text:
                   type: mrkdwn
-                  text: "*Runner RS* building staged production deployment...\n📦 Version: `${{ needs.release-please.outputs.runner_rs_version }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/runner-rs-v${{ needs.release-please.outputs.runner_rs_version }}|View Release>"
+                  text: "*Runner RS* building staged production deployment...\n📦 Version: `${{ needs.release-please.outputs.runner_rs_version }}`\n🏗️ Target: `${{ matrix.target }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/runner-rs-v${{ needs.release-please.outputs.runner_rs_version }}|View Release>"
 
       - name: Record start time
         id: timer
         run: echo "start=$(date +%s)" >> "$GITHUB_OUTPUT"
 
-      - name: Download ARM64 runner binary from GitHub Release
+      - name: Setup SSH via Cloudflare Tunnel
+        uses: ./.github/actions/setup-ssh-tunnel
+        with:
+          ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
+          cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+
+      - name: Resolve metal hosts for architecture
+        id: matrix-hosts
+        env:
+          AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
+          RUNNER_HOST_GROUP_ID: ${{ matrix.id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          hosts=$(.github/scripts/runner-host-architecture-groups.sh hosts "$RUNNER_HOST_GROUP_ID")
+          if [ -z "$hosts" ]; then
+            echo "::error::No metal hosts resolved for ${RUNNER_HOST_GROUP_ID}"
+            exit 1
+          fi
+
+          echo "hosts=${hosts}" >> "$GITHUB_OUTPUT"
+          host_count=$(printf '%s\n' "$hosts" | tr ',' '\n' | sed '/^$/d' | wc -l | tr -d ' ')
+          echo "Resolved ${host_count} metal host(s) for ${RUNNER_HOST_GROUP_ID}"
+
+      - name: Download runner binary from GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ needs.release-please.outputs.runner_rs_version }}
-          TARGET_TRIPLE: aarch64-unknown-linux-musl
+          TARGET_TRIPLE: ${{ matrix.target }}
+          ASSET_SUFFIX: ${{ matrix.assetSuffix }}
+          EXPECTED_RUNNER_UNAME_M: ${{ matrix.unameM }}
         shell: bash
         run: |
           set -euo pipefail
           . .github/scripts/runner-image-target.sh
           runner_image_validate_target "$TARGET_TRIPLE"
-          ASSET_SUFFIX=$(runner_image_asset_suffix "$TARGET_TRIPLE")
+          EXPECTED_ASSET_SUFFIX=$(runner_image_asset_suffix "$TARGET_TRIPLE")
+          EXPECTED_UNAME_M=$(runner_image_expected_uname_m "$TARGET_TRIPLE")
+          EXPECTED_ELF_MACHINE=$(runner_image_elf_machine_hex "$TARGET_TRIPLE")
+          if [ "$ASSET_SUFFIX" != "$EXPECTED_ASSET_SUFFIX" ]; then
+            echo "::error::matrix asset suffix ${ASSET_SUFFIX} does not match target ${TARGET_TRIPLE} (expected ${EXPECTED_ASSET_SUFFIX})"
+            exit 1
+          fi
+          if [ "$EXPECTED_RUNNER_UNAME_M" != "$EXPECTED_UNAME_M" ]; then
+            echo "::error::matrix uname ${EXPECTED_RUNNER_UNAME_M} does not match target ${TARGET_TRIPLE} (expected ${EXPECTED_UNAME_M})"
+            exit 1
+          fi
+
           TAG="runner-rs-v${VERSION}"
           ASSET_NAME="runner-v${VERSION}-${ASSET_SUFFIX}"
           ASSET_PATH="crates/target/${TARGET_TRIPLE}/release/runner"
@@ -2336,17 +2428,10 @@ jobs:
 
           ELF_MAGIC=$(od -An -tx1 -N4 "$ASSET_PATH" | tr -d ' \n')
           ELF_MACHINE=$(dd if="$ASSET_PATH" bs=1 skip=18 count=2 2>/dev/null | od -An -tx1 | tr -d ' \n')
-          if [ "$ELF_MAGIC" != "7f454c46" ] || [ "$ELF_MACHINE" != "b700" ]; then
-            echo "::error::downloaded runner asset is not an AArch64 ELF binary: magic=${ELF_MAGIC} machine=${ELF_MACHINE}"
+          if [ "$ELF_MAGIC" != "7f454c46" ] || [ "$ELF_MACHINE" != "$EXPECTED_ELF_MACHINE" ]; then
+            echo "::error::downloaded runner asset does not match ${TARGET_TRIPLE}: magic=${ELF_MAGIC} machine=${ELF_MACHINE} expected_machine=${EXPECTED_ELF_MACHINE}"
             exit 1
           fi
-
-      - name: Setup SSH via Cloudflare Tunnel
-        uses: ./.github/actions/setup-ssh-tunnel
-        with:
-          ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
-          cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
-          cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
 
       # Decrypt R2 secrets from resolve-image-cache.  The secrets were
       # AES-encrypted with GRAFANA_CLOUD_API_KEY (a repo-level-only
@@ -2381,7 +2466,7 @@ jobs:
       - name: Provision metal hosts
         uses: ./.github/actions/provision
         with:
-          hosts: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          hosts: ${{ steps.matrix-hosts.outputs.hosts }}
           metal-user: ${{ vars.AWS_METAL_RUNNER_USER }}
           grafana-cloud-prometheus-url: ${{ secrets.GRAFANA_CLOUD_PROMETHEUS_URL }}
           grafana-cloud-prometheus-user: ${{ secrets.GRAFANA_CLOUD_PROMETHEUS_USER }}
@@ -2390,10 +2475,13 @@ jobs:
 
       - name: Build rootfs and snapshot on production hosts
         env:
-          AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          RUNNER_HOSTS: ${{ steps.matrix-hosts.outputs.hosts }}
           AWS_METAL_RUNNER_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
           RUNNER_VERSION: ${{ needs.release-please.outputs.runner_rs_version }}
+          RUNNER_TARGET: ${{ matrix.target }}
+          RUNNER_ASSET_SUFFIX: ${{ matrix.assetSuffix }}
+          EXPECTED_RUNNER_UNAME_M: ${{ matrix.unameM }}
           API_URL: ${{ vars.VM0_API_URL }}
           # R2 image cache credentials — from resolve-image-cache job (repo-level,
           # not production-scoped) so the runner uses the same bucket as CI.
@@ -2404,12 +2492,15 @@ jobs:
         run: |
           cd ansible
           ansible-playbook \
-            -i "${AWS_METAL_RUNNER_HOSTS}," \
+            -i "${RUNNER_HOSTS}," \
             playbooks/build-runner.yml \
             -e "ansible_user=${AWS_METAL_RUNNER_USER}" \
             -e "official_runner_secret=${OFFICIAL_RUNNER_SECRET}" \
             -e "api_url=${API_URL}" \
             -e "runner_version=${RUNNER_VERSION}" \
+            -e "runner_target=${RUNNER_TARGET}" \
+            -e "runner_asset_suffix=${RUNNER_ASSET_SUFFIX}" \
+            -e "expected_runner_uname_m=${EXPECTED_RUNNER_UNAME_M}" \
             -e "r2_account_id=${R2_ACCOUNT_ID:-}" \
             -e "r2_access_key_id=${R2_ACCESS_KEY_ID:-}" \
             -e "r2_secret_access_key=${R2_SECRET_ACCESS_KEY:-}" \
@@ -2441,7 +2532,7 @@ jobs:
               - type: section
                 text:
                   type: mrkdwn
-                  text: "*Runner RS* ✅ Staged build ready (not yet serving)\n📦 Version: `${{ needs.release-please.outputs.runner_rs_version }}`\n⏱️ `${{ steps.duration.outputs.text }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/runner-rs-v${{ needs.release-please.outputs.runner_rs_version }}|View Release>"
+                  text: "*Runner RS* ✅ Staged build ready (not yet serving)\n📦 Version: `${{ needs.release-please.outputs.runner_rs_version }}`\n🏗️ Target: `${{ matrix.target }}`\n⏱️ `${{ steps.duration.outputs.text }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/runner-rs-v${{ needs.release-please.outputs.runner_rs_version }}|View Release>"
 
       - name: Notify Slack - Failure
         if: ${{ failure() && steps.slack-start.outputs.ts }}
@@ -2457,7 +2548,7 @@ jobs:
               - type: section
                 text:
                   type: mrkdwn
-                  text: "*Runner RS* ❌ Staged build failed\n📦 Version: `${{ needs.release-please.outputs.runner_rs_version }}`\n⏱️ `${{ steps.duration.outputs.text }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/runner-rs-v${{ needs.release-please.outputs.runner_rs_version }}|View Release>\n🔗 <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Logs>"
+                  text: "*Runner RS* ❌ Staged build failed\n📦 Version: `${{ needs.release-please.outputs.runner_rs_version }}`\n🏗️ Target: `${{ matrix.target }}`\n⏱️ `${{ steps.duration.outputs.text }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/runner-rs-v${{ needs.release-please.outputs.runner_rs_version }}|View Release>\n🔗 <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Logs>"
 
   # Promote runner: install systemd service (traffic cutover), drain
   # old runners, garbage-collect old artifacts, global health check.
@@ -2466,6 +2557,7 @@ jobs:
   # targets is live. Host-level prep (provision-runner, provision-monitoring)
   # already ran in build.
   promote-runner-production:
+    name: Promote runner production (${{ matrix.label }})
     needs:
       [
         release-please,
@@ -2473,6 +2565,7 @@ jobs:
         promote-api-production,
         resolve-image-cache,
         build-runner-production,
+        runner-production-host-groups,
       ]
     if: >-
       always() &&
@@ -2487,6 +2580,10 @@ jobs:
     permissions:
       contents: read
     environment: production
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.runner-production-host-groups.outputs.matrix || '[]') }}
     steps:
       - uses: actions/checkout@v7
 
@@ -2499,12 +2596,12 @@ jobs:
           token: ${{ secrets.CI_SLACK_BOT_TOKEN }}
           payload: |
             channel: ${{ vars.SLACK_RELEASE_CHANNEL_ID }}
-            text: "*Runner RS* promoting staged deployment to production..."
+            text: "*Runner RS* promoting staged deployment to production (${{ matrix.label }})..."
             blocks:
               - type: section
                 text:
                   type: mrkdwn
-                  text: "*Runner RS* promoting staged deployment to production...\n📦 Version: `${{ needs.release-please.outputs.runner_rs_version }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/runner-rs-v${{ needs.release-please.outputs.runner_rs_version }}|View Release>"
+                  text: "*Runner RS* promoting staged deployment to production...\n📦 Version: `${{ needs.release-please.outputs.runner_rs_version }}`\n🏗️ Target: `${{ matrix.target }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/runner-rs-v${{ needs.release-please.outputs.runner_rs_version }}|View Release>"
 
       - name: Record start time
         id: timer
@@ -2516,6 +2613,26 @@ jobs:
           ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
           cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+
+      - name: Resolve metal hosts for architecture
+        id: matrix-hosts
+        env:
+          AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
+          RUNNER_HOST_GROUP_ID: ${{ matrix.id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          hosts=$(.github/scripts/runner-host-architecture-groups.sh hosts "$RUNNER_HOST_GROUP_ID")
+          if [ -z "$hosts" ]; then
+            echo "::error::No metal hosts resolved for ${RUNNER_HOST_GROUP_ID}"
+            exit 1
+          fi
+
+          echo "hosts=${hosts}" >> "$GITHUB_OUTPUT"
+          host_count=$(printf '%s\n' "$hosts" | tr ',' '\n' | sed '/^$/d' | wc -l | tr -d ' ')
+          echo "Resolved ${host_count} metal host(s) for ${RUNNER_HOST_GROUP_ID}"
 
       # Same decrypt as build; needed here so `runner gc` (inside
       # promote-runner.yml) can sweep stale image cache objects in R2.
@@ -2540,23 +2657,29 @@ jobs:
 
       - name: Promote runner on production hosts with Ansible
         env:
-          AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          RUNNER_HOSTS: ${{ steps.matrix-hosts.outputs.hosts }}
           AWS_METAL_RUNNER_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
           SENTRY_DSN_RUNNER: ${{ secrets.SENTRY_DSN_RUNNER }}
           AXIOM_TOKEN_TELEMETRY: ${{ secrets.AXIOM_TOKEN_TELEMETRY }}
           RUNNER_VERSION: ${{ needs.release-please.outputs.runner_rs_version }}
+          RUNNER_TARGET: ${{ matrix.target }}
+          RUNNER_ASSET_SUFFIX: ${{ matrix.assetSuffix }}
+          EXPECTED_RUNNER_UNAME_M: ${{ matrix.unameM }}
           R2_ACCOUNT_ID: ${{ needs.resolve-image-cache.outputs.r2-account-id }}
           R2_USER_STORAGES_BUCKET_NAME: ${{ needs.resolve-image-cache.outputs.r2-bucket }}
         run: |
           cd ansible
           ansible-playbook \
-            -i "${AWS_METAL_RUNNER_HOSTS}," \
+            -i "${RUNNER_HOSTS}," \
             playbooks/promote-runner.yml \
             -e "ansible_user=${AWS_METAL_RUNNER_USER}" \
             -e "sentry_dsn=${SENTRY_DSN_RUNNER}" \
             -e "axiom_token_telemetry=${AXIOM_TOKEN_TELEMETRY}" \
             -e "axiom_dataset_suffix=prod" \
             -e "runner_version=${RUNNER_VERSION}" \
+            -e "runner_target=${RUNNER_TARGET}" \
+            -e "runner_asset_suffix=${RUNNER_ASSET_SUFFIX}" \
+            -e "expected_runner_uname_m=${EXPECTED_RUNNER_UNAME_M}" \
             -e "r2_account_id=${R2_ACCOUNT_ID:-}" \
             -e "r2_access_key_id=${R2_ACCESS_KEY_ID:-}" \
             -e "r2_secret_access_key=${R2_SECRET_ACCESS_KEY:-}" \
@@ -2567,13 +2690,13 @@ jobs:
         id: global-doctor
         if: ${{ success() }}
         env:
-          AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          RUNNER_HOSTS: ${{ steps.matrix-hosts.outputs.hosts }}
           AWS_METAL_RUNNER_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
           RUNNER_VERSION: ${{ needs.release-please.outputs.runner_rs_version }}
         run: |
           RUNNER_BIN="/var/lib/vm0-runner/bin/v${RUNNER_VERSION}/runner"
           has_warnings=false
-          for host in $(echo "$AWS_METAL_RUNNER_HOSTS" | tr ',' ' '); do
+          for host in $(echo "$RUNNER_HOSTS" | tr ',' ' '); do
             [ -z "$host" ] && continue
             # shellcheck disable=SC2029
             if ! ssh "${AWS_METAL_RUNNER_USER}@${host}" "sudo ${RUNNER_BIN} doctor" 2>&1; then
@@ -2608,7 +2731,7 @@ jobs:
               - type: section
                 text:
                   type: mrkdwn
-                  text: "*Runner RS* ✅ Promoted to production\n📦 Version: `${{ needs.release-please.outputs.runner_rs_version }}`\n⏱️ `${{ steps.duration.outputs.text }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/runner-rs-v${{ needs.release-please.outputs.runner_rs_version }}|View Release>\n🔄 <${{ github.server_url }}/${{ github.repository }}/issues/${{ vars.ROLLBACK_ISSUE_NUMBER }}|Rollback Dashboard>"
+                  text: "*Runner RS* ✅ Promoted to production\n📦 Version: `${{ needs.release-please.outputs.runner_rs_version }}`\n🏗️ Target: `${{ matrix.target }}`\n⏱️ `${{ steps.duration.outputs.text }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/runner-rs-v${{ needs.release-please.outputs.runner_rs_version }}|View Release>\n🔄 <${{ github.server_url }}/${{ github.repository }}/issues/${{ vars.ROLLBACK_ISSUE_NUMBER }}|Rollback Dashboard>"
 
       - name: Notify Slack - Success with warnings
         if: ${{ success() && steps.slack-start.outputs.ts && steps.global-doctor.outputs.has_warnings == 'true' }}
@@ -2624,7 +2747,7 @@ jobs:
               - type: section
                 text:
                   type: mrkdwn
-                  text: "*Runner RS* ⚠️ Promoted with warnings\n📦 Version: `${{ needs.release-please.outputs.runner_rs_version }}`\n⏱️ `${{ steps.duration.outputs.text }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/runner-rs-v${{ needs.release-please.outputs.runner_rs_version }}|View Release>\n🔗 <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Logs>\n🔄 <${{ github.server_url }}/${{ github.repository }}/issues/${{ vars.ROLLBACK_ISSUE_NUMBER }}|Rollback Dashboard>"
+                  text: "*Runner RS* ⚠️ Promoted with warnings\n📦 Version: `${{ needs.release-please.outputs.runner_rs_version }}`\n🏗️ Target: `${{ matrix.target }}`\n⏱️ `${{ steps.duration.outputs.text }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/runner-rs-v${{ needs.release-please.outputs.runner_rs_version }}|View Release>\n🔗 <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Logs>\n🔄 <${{ github.server_url }}/${{ github.repository }}/issues/${{ vars.ROLLBACK_ISSUE_NUMBER }}|Rollback Dashboard>"
 
       - name: Notify Slack - Failure
         if: ${{ failure() && steps.slack-start.outputs.ts }}
@@ -2640,7 +2763,7 @@ jobs:
               - type: section
                 text:
                   type: mrkdwn
-                  text: "*Runner RS* ❌ Promote failed\n📦 Version: `${{ needs.release-please.outputs.runner_rs_version }}`\n⏱️ `${{ steps.duration.outputs.text }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/runner-rs-v${{ needs.release-please.outputs.runner_rs_version }}|View Release>\n🔗 <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Logs>"
+                  text: "*Runner RS* ❌ Promote failed\n📦 Version: `${{ needs.release-please.outputs.runner_rs_version }}`\n🏗️ Target: `${{ matrix.target }}`\n⏱️ `${{ steps.duration.outputs.text }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/runner-rs-v${{ needs.release-please.outputs.runner_rs_version }}|View Release>\n🔗 <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Logs>"
 
   # Build E2B templates to production account
   # Uses production environment E2B_API_KEY secret

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2283,7 +2283,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          matrix=$(.github/scripts/runner-host-architecture-groups.sh matrix)
+          matrix=$(.github/scripts/runner-host-architecture-groups.sh matrix | jq -c 'map({ id, label, target })')
           group_count=$(jq -r 'length' <<<"$matrix")
           if [ "$group_count" -lt 1 ]; then
             echo "::error::No production runner host architecture groups found"
@@ -2375,24 +2375,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ needs.release-please.outputs.runner_rs_version }}
           TARGET_TRIPLE: ${{ matrix.target }}
-          ASSET_SUFFIX: ${{ matrix.assetSuffix }}
-          EXPECTED_RUNNER_UNAME_M: ${{ matrix.unameM }}
         shell: bash
         run: |
           set -euo pipefail
           . .github/scripts/runner-image-target.sh
           runner_image_validate_target "$TARGET_TRIPLE"
-          EXPECTED_ASSET_SUFFIX=$(runner_image_asset_suffix "$TARGET_TRIPLE")
-          EXPECTED_UNAME_M=$(runner_image_expected_uname_m "$TARGET_TRIPLE")
+          ASSET_SUFFIX=$(runner_image_asset_suffix "$TARGET_TRIPLE")
           EXPECTED_ELF_MACHINE=$(runner_image_elf_machine_hex "$TARGET_TRIPLE")
-          if [ "$ASSET_SUFFIX" != "$EXPECTED_ASSET_SUFFIX" ]; then
-            echo "::error::matrix asset suffix ${ASSET_SUFFIX} does not match target ${TARGET_TRIPLE} (expected ${EXPECTED_ASSET_SUFFIX})"
-            exit 1
-          fi
-          if [ "$EXPECTED_RUNNER_UNAME_M" != "$EXPECTED_UNAME_M" ]; then
-            echo "::error::matrix uname ${EXPECTED_RUNNER_UNAME_M} does not match target ${TARGET_TRIPLE} (expected ${EXPECTED_UNAME_M})"
-            exit 1
-          fi
 
           TAG="runner-rs-v${VERSION}"
           ASSET_NAME="runner-v${VERSION}-${ASSET_SUFFIX}"
@@ -2480,8 +2469,6 @@ jobs:
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
           RUNNER_VERSION: ${{ needs.release-please.outputs.runner_rs_version }}
           RUNNER_TARGET: ${{ matrix.target }}
-          RUNNER_ASSET_SUFFIX: ${{ matrix.assetSuffix }}
-          EXPECTED_RUNNER_UNAME_M: ${{ matrix.unameM }}
           API_URL: ${{ vars.VM0_API_URL }}
           # R2 image cache credentials — from resolve-image-cache job (repo-level,
           # not production-scoped) so the runner uses the same bucket as CI.
@@ -2499,8 +2486,6 @@ jobs:
             -e "api_url=${API_URL}" \
             -e "runner_version=${RUNNER_VERSION}" \
             -e "runner_target=${RUNNER_TARGET}" \
-            -e "runner_asset_suffix=${RUNNER_ASSET_SUFFIX}" \
-            -e "expected_runner_uname_m=${EXPECTED_RUNNER_UNAME_M}" \
             -e "r2_account_id=${R2_ACCOUNT_ID:-}" \
             -e "r2_access_key_id=${R2_ACCESS_KEY_ID:-}" \
             -e "r2_secret_access_key=${R2_SECRET_ACCESS_KEY:-}" \
@@ -2663,8 +2648,6 @@ jobs:
           AXIOM_TOKEN_TELEMETRY: ${{ secrets.AXIOM_TOKEN_TELEMETRY }}
           RUNNER_VERSION: ${{ needs.release-please.outputs.runner_rs_version }}
           RUNNER_TARGET: ${{ matrix.target }}
-          RUNNER_ASSET_SUFFIX: ${{ matrix.assetSuffix }}
-          EXPECTED_RUNNER_UNAME_M: ${{ matrix.unameM }}
           R2_ACCOUNT_ID: ${{ needs.resolve-image-cache.outputs.r2-account-id }}
           R2_USER_STORAGES_BUCKET_NAME: ${{ needs.resolve-image-cache.outputs.r2-bucket }}
         run: |
@@ -2678,8 +2661,6 @@ jobs:
             -e "axiom_dataset_suffix=prod" \
             -e "runner_version=${RUNNER_VERSION}" \
             -e "runner_target=${RUNNER_TARGET}" \
-            -e "runner_asset_suffix=${RUNNER_ASSET_SUFFIX}" \
-            -e "expected_runner_uname_m=${EXPECTED_RUNNER_UNAME_M}" \
             -e "r2_account_id=${R2_ACCOUNT_ID:-}" \
             -e "r2_access_key_id=${R2_ACCESS_KEY_ID:-}" \
             -e "r2_secret_access_key=${R2_SECRET_ACCESS_KEY:-}" \

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2086,11 +2086,7 @@ jobs:
           . .github/scripts/runner-image-target.sh
           runner_image_validate_target "$TARGET_TRIPLE"
           cache_suffix=$(runner_image_cache_suffix "$TARGET_TRIPLE")
-          asset_suffix=$(runner_image_asset_suffix "$TARGET_TRIPLE")
-          {
-            echo "cache_suffix=$cache_suffix"
-            echo "asset_suffix=$asset_suffix"
-          } >> "$GITHUB_OUTPUT"
+          echo "cache_suffix=$cache_suffix" >> "$GITHUB_OUTPUT"
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -2148,12 +2144,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ needs.release-please.outputs.runner_rs_version }}
           TARGET_TRIPLE: ${{ matrix.target }}
-          ASSET_SUFFIX: ${{ steps.target-metadata.outputs.asset_suffix }}
         shell: bash
         run: |
           set -euo pipefail
-          TAG="runner-rs-v${VERSION}"
-          ASSET_NAME="runner-v${VERSION}-${ASSET_SUFFIX}"
+          . .github/scripts/runner-image-target.sh
+          TAG=$(runner_image_release_tag "$VERSION")
+          ASSET_NAME=$(runner_image_release_asset_name "$VERSION" "$TARGET_TRIPLE")
           ASSET_NAME_ENCODED=$(jq -rn --arg value "$ASSET_NAME" '$value|@uri')
           ASSET_PATH="crates/target/${TARGET_TRIPLE}/release/runner"
 
@@ -2283,7 +2279,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          matrix=$(.github/scripts/runner-host-architecture-groups.sh matrix | jq -c 'map({ id, label, target })')
+          matrix=$(.github/scripts/runner-host-architecture-groups.sh target-matrix)
           group_count=$(jq -r 'length' <<<"$matrix")
           if [ "$group_count" -lt 1 ]; then
             echo "::error::No production runner host architecture groups found"
@@ -2379,12 +2375,10 @@ jobs:
         run: |
           set -euo pipefail
           . .github/scripts/runner-image-target.sh
-          runner_image_validate_target "$TARGET_TRIPLE"
-          ASSET_SUFFIX=$(runner_image_asset_suffix "$TARGET_TRIPLE")
+          TAG=$(runner_image_release_tag "$VERSION")
+          ASSET_NAME=$(runner_image_release_asset_name "$VERSION" "$TARGET_TRIPLE")
           EXPECTED_ELF_MACHINE=$(runner_image_elf_machine_hex "$TARGET_TRIPLE")
 
-          TAG="runner-rs-v${VERSION}"
-          ASSET_NAME="runner-v${VERSION}-${ASSET_SUFFIX}"
           ASSET_PATH="crates/target/${TARGET_TRIPLE}/release/runner"
 
           ASSET_ID=$(curl -sfL \

--- a/.github/workflows/rollback-runner.yml
+++ b/.github/workflows/rollback-runner.yml
@@ -106,7 +106,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          matrix=$(.github/scripts/runner-host-architecture-groups.sh matrix | jq -c 'map({ id, label, target })')
+          matrix=$(.github/scripts/runner-host-architecture-groups.sh target-matrix)
           group_count=$(jq -r 'length' <<<"$matrix")
           if [ "$group_count" -lt 1 ]; then
             echo "::error::No production runner host architecture groups found"
@@ -169,11 +169,9 @@ jobs:
         run: |
           set -euo pipefail
           . .github/scripts/runner-image-target.sh
-          runner_image_validate_target "$TARGET_TRIPLE"
-          ASSET_SUFFIX=$(runner_image_asset_suffix "$TARGET_TRIPLE")
+          TAG=$(runner_image_release_tag "$VERSION")
+          ASSET_NAME=$(runner_image_release_asset_name "$VERSION" "$TARGET_TRIPLE")
 
-          TAG="runner-rs-v${VERSION}"
-          ASSET_NAME="runner-v${VERSION}-${ASSET_SUFFIX}"
           # curl + jq instead of `gh` — the toolchain-rust image doesn't
           # ship `gh` (it's in stage 3 `development`, not stage 2). Same
           # REST endpoint and auth as the upload step in release-please.yml.

--- a/.github/workflows/rollback-runner.yml
+++ b/.github/workflows/rollback-runner.yml
@@ -106,7 +106,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          matrix=$(.github/scripts/runner-host-architecture-groups.sh matrix)
+          matrix=$(.github/scripts/runner-host-architecture-groups.sh matrix | jq -c 'map({ id, label, target })')
           group_count=$(jq -r 'length' <<<"$matrix")
           if [ "$group_count" -lt 1 ]; then
             echo "::error::No production runner host architecture groups found"
@@ -165,23 +165,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ inputs.target_version }}
           TARGET_TRIPLE: ${{ matrix.target }}
-          ASSET_SUFFIX: ${{ matrix.assetSuffix }}
-          EXPECTED_RUNNER_UNAME_M: ${{ matrix.unameM }}
         shell: bash
         run: |
           set -euo pipefail
           . .github/scripts/runner-image-target.sh
           runner_image_validate_target "$TARGET_TRIPLE"
-          EXPECTED_ASSET_SUFFIX=$(runner_image_asset_suffix "$TARGET_TRIPLE")
-          EXPECTED_UNAME_M=$(runner_image_expected_uname_m "$TARGET_TRIPLE")
-          if [ "$ASSET_SUFFIX" != "$EXPECTED_ASSET_SUFFIX" ]; then
-            echo "::error::matrix asset suffix ${ASSET_SUFFIX} does not match target ${TARGET_TRIPLE} (expected ${EXPECTED_ASSET_SUFFIX})"
-            exit 1
-          fi
-          if [ "$EXPECTED_RUNNER_UNAME_M" != "$EXPECTED_UNAME_M" ]; then
-            echo "::error::matrix uname ${EXPECTED_RUNNER_UNAME_M} does not match target ${TARGET_TRIPLE} (expected ${EXPECTED_UNAME_M})"
-            exit 1
-          fi
+          ASSET_SUFFIX=$(runner_image_asset_suffix "$TARGET_TRIPLE")
 
           TAG="runner-rs-v${VERSION}"
           ASSET_NAME="runner-v${VERSION}-${ASSET_SUFFIX}"
@@ -253,8 +242,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUNNER_VERSION: ${{ inputs.target_version }}
           RUNNER_TARGET: ${{ matrix.target }}
-          RUNNER_ASSET_SUFFIX: ${{ matrix.assetSuffix }}
-          EXPECTED_RUNNER_UNAME_M: ${{ matrix.unameM }}
           ROLLBACK_MODE: ${{ inputs.rollback_mode }}
           API_URL: ${{ vars.VM0_API_URL }}
         run: |
@@ -265,8 +252,6 @@ jobs:
             -e "ansible_user=${AWS_METAL_RUNNER_USER}" \
             -e "runner_version=${RUNNER_VERSION}" \
             -e "runner_target=${RUNNER_TARGET}" \
-            -e "runner_asset_suffix=${RUNNER_ASSET_SUFFIX}" \
-            -e "expected_runner_uname_m=${EXPECTED_RUNNER_UNAME_M}" \
             -e "rollback_mode=${ROLLBACK_MODE}" \
             -e "sentry_dsn=${SENTRY_DSN_RUNNER}" \
             -e "official_runner_secret=${OFFICIAL_RUNNER_SECRET}" \

--- a/.github/workflows/rollback-runner.yml
+++ b/.github/workflows/rollback-runner.yml
@@ -47,13 +47,17 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  rollback:
+  prepare:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260622
     permissions:
       contents: read
     environment: production
+    outputs:
+      # Keep cross-job architecture metadata sanitized. The rollback job
+      # resolves the concrete host subset from matrix.id inside the job.
+      matrix: ${{ steps.groups.outputs.matrix }}
 
     steps:
       # Hard gate — refuse to proceed unless the operator explicitly
@@ -79,6 +83,57 @@ jobs:
             exit 1
           fi
 
+      # Use main's rollback-runner.yml — this playbook did not exist in
+      # older tags. The playbook only calls stable runner CLI surfaces
+      # (`service install` / `service drain` / `service stop` / `service
+      # resume` / `doctor` / `gc` / `setup` / `build` / `config`), so it
+      # works against any target binary the runner CLI contract supports.
+      - uses: actions/checkout@v7
+
+      - name: Setup SSH via Cloudflare Tunnel
+        uses: ./.github/actions/setup-ssh-tunnel
+        with:
+          ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
+          cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+
+      - name: Resolve production runner host architecture groups
+        id: groups
+        env:
+          AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          matrix=$(.github/scripts/runner-host-architecture-groups.sh matrix)
+          group_count=$(jq -r 'length' <<<"$matrix")
+          if [ "$group_count" -lt 1 ]; then
+            echo "::error::No production runner host architecture groups found"
+            exit 1
+          fi
+
+          echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
+          echo "Production runner host architecture groups:"
+          jq . <<<"$matrix"
+
+  rollback:
+    name: Roll back runner (${{ matrix.label }})
+    needs: prepare
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260622
+    permissions:
+      contents: read
+    environment: production
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.prepare.outputs.matrix || '[]') }}
+
+    steps:
+      - uses: actions/checkout@v7
+
       - name: Notify Slack - Starting
         id: slack-start
         if: ${{ vars.SLACK_RELEASE_CHANNEL_ID != '' }}
@@ -88,38 +143,48 @@ jobs:
           token: ${{ secrets.CI_SLACK_BOT_TOKEN }}
           payload: |
             channel: ${{ vars.SLACK_RELEASE_CHANNEL_ID }}
-            text: "*Runner RS* ⏪ rolling back to v${{ inputs.target_version }} (${{ inputs.rollback_mode }})..."
+            text: "*Runner RS* ⏪ rolling back to v${{ inputs.target_version }} (${{ matrix.label }})..."
             blocks:
               - type: section
                 text:
                   type: mrkdwn
-                  text: "*Runner RS* ⏪ rolling back to v${{ inputs.target_version }}...\n📦 Mode: `${{ inputs.rollback_mode }}`\n👤 Triggered by: `${{ github.actor }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/runner-rs-v${{ inputs.target_version }}|View Release>\n🔗 <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Logs>"
+                  text: "*Runner RS* ⏪ rolling back to v${{ inputs.target_version }}...\n📦 Mode: `${{ inputs.rollback_mode }}`\n🏗️ Target: `${{ matrix.target }}`\n👤 Triggered by: `${{ github.actor }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/runner-rs-v${{ inputs.target_version }}|View Release>\n🔗 <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Logs>"
 
       - name: Record start time
         id: timer
         run: echo "start=$(date +%s)" >> "$GITHUB_OUTPUT"
 
-      # Use main's rollback-runner.yml — this playbook did not exist in
-      # older tags. The playbook only calls stable runner CLI surfaces
-      # (`service install` / `service drain` / `service stop` / `service
-      # resume` / `doctor` / `gc` / `setup` / `build` / `config`), so it
-      # works against any target binary the runner CLI contract supports.
-      - uses: actions/checkout@v7
-
-      # Preflight: confirm the release asset is downloadable before we go
-      # SSH-tinkering with production hosts. gc typically keeps the last
-      # 6 versions on-host so this is a fallback check, but if a host
-      # recently replaced its disk the playbook's binary-download branch
-      # will need the asset — fail fast rather than mid-rollout.
+      # Preflight: confirm the exact architecture-specific release asset is
+      # downloadable before we go SSH-tinkering with production hosts. gc
+      # typically keeps the last 6 versions on-host so this is a fallback
+      # check, but if a host recently replaced its disk the playbook's
+      # binary-download branch will need the asset — fail fast rather than
+      # mid-rollout.
       - name: Verify target release asset exists
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ inputs.target_version }}
+          TARGET_TRIPLE: ${{ matrix.target }}
+          ASSET_SUFFIX: ${{ matrix.assetSuffix }}
+          EXPECTED_RUNNER_UNAME_M: ${{ matrix.unameM }}
         shell: bash
         run: |
           set -euo pipefail
+          . .github/scripts/runner-image-target.sh
+          runner_image_validate_target "$TARGET_TRIPLE"
+          EXPECTED_ASSET_SUFFIX=$(runner_image_asset_suffix "$TARGET_TRIPLE")
+          EXPECTED_UNAME_M=$(runner_image_expected_uname_m "$TARGET_TRIPLE")
+          if [ "$ASSET_SUFFIX" != "$EXPECTED_ASSET_SUFFIX" ]; then
+            echo "::error::matrix asset suffix ${ASSET_SUFFIX} does not match target ${TARGET_TRIPLE} (expected ${EXPECTED_ASSET_SUFFIX})"
+            exit 1
+          fi
+          if [ "$EXPECTED_RUNNER_UNAME_M" != "$EXPECTED_UNAME_M" ]; then
+            echo "::error::matrix uname ${EXPECTED_RUNNER_UNAME_M} does not match target ${TARGET_TRIPLE} (expected ${EXPECTED_UNAME_M})"
+            exit 1
+          fi
+
           TAG="runner-rs-v${VERSION}"
-          ASSET_NAME="runner-v${VERSION}-aarch64-linux"
+          ASSET_NAME="runner-v${VERSION}-${ASSET_SUFFIX}"
           # curl + jq instead of `gh` — the toolchain-rust image doesn't
           # ship `gh` (it's in stage 3 `development`, not stage 2). Same
           # REST endpoint and auth as the upload step in release-please.yml.
@@ -146,11 +211,31 @@ jobs:
           cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
 
-      # Invokes rollback-runner.yml against every production host. The
-      # playbook is idempotent and per-host state-machine-driven, so one
-      # invocation converges heterogeneous fleet states (some hosts with
-      # target inactive, some with target still draining, some with target
-      # already running, etc.) to "target is the sole live version".
+      - name: Resolve metal hosts for architecture
+        id: matrix-hosts
+        env:
+          AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
+          RUNNER_HOST_GROUP_ID: ${{ matrix.id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          hosts=$(.github/scripts/runner-host-architecture-groups.sh hosts "$RUNNER_HOST_GROUP_ID")
+          if [ -z "$hosts" ]; then
+            echo "::error::No metal hosts resolved for ${RUNNER_HOST_GROUP_ID}"
+            exit 1
+          fi
+
+          echo "hosts=${hosts}" >> "$GITHUB_OUTPUT"
+          host_count=$(printf '%s\n' "$hosts" | tr ',' '\n' | sed '/^$/d' | wc -l | tr -d ' ')
+          echo "Resolved ${host_count} metal host(s) for ${RUNNER_HOST_GROUP_ID}"
+
+      # Invokes rollback-runner.yml against one architecture group. The
+      # playbook is idempotent and per-host state-machine-driven, so the
+      # matrix invocation converges heterogeneous fleet states (some hosts
+      # with target inactive, some with target still draining, some with
+      # target already running, etc.) to "target is the sole live version".
       #
       # R2 credentials are NOT passed: on the happy path (target artifacts
       # still on disk thanks to gc --keep-latest 6), the playbook only
@@ -161,21 +246,27 @@ jobs:
       # have, not required for correctness.
       - name: Roll back runner on production hosts with Ansible
         env:
-          AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          RUNNER_HOSTS: ${{ steps.matrix-hosts.outputs.hosts }}
           AWS_METAL_RUNNER_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
           SENTRY_DSN_RUNNER: ${{ secrets.SENTRY_DSN_RUNNER }}
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUNNER_VERSION: ${{ inputs.target_version }}
+          RUNNER_TARGET: ${{ matrix.target }}
+          RUNNER_ASSET_SUFFIX: ${{ matrix.assetSuffix }}
+          EXPECTED_RUNNER_UNAME_M: ${{ matrix.unameM }}
           ROLLBACK_MODE: ${{ inputs.rollback_mode }}
           API_URL: ${{ vars.VM0_API_URL }}
         run: |
           cd ansible
           ansible-playbook \
-            -i "${AWS_METAL_RUNNER_HOSTS}," \
+            -i "${RUNNER_HOSTS}," \
             playbooks/rollback-runner.yml \
             -e "ansible_user=${AWS_METAL_RUNNER_USER}" \
             -e "runner_version=${RUNNER_VERSION}" \
+            -e "runner_target=${RUNNER_TARGET}" \
+            -e "runner_asset_suffix=${RUNNER_ASSET_SUFFIX}" \
+            -e "expected_runner_uname_m=${EXPECTED_RUNNER_UNAME_M}" \
             -e "rollback_mode=${ROLLBACK_MODE}" \
             -e "sentry_dsn=${SENTRY_DSN_RUNNER}" \
             -e "official_runner_secret=${OFFICIAL_RUNNER_SECRET}" \
@@ -208,7 +299,7 @@ jobs:
               - type: section
                 text:
                   type: mrkdwn
-                  text: "*Runner RS* ✅ Rolled back to v${{ inputs.target_version }} (${{ inputs.rollback_mode }})\n⏱️ `${{ steps.duration.outputs.text }}`\n👤 Triggered by: `${{ github.actor }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/runner-rs-v${{ inputs.target_version }}|View Release>"
+                  text: "*Runner RS* ✅ Rolled back to v${{ inputs.target_version }} (${{ inputs.rollback_mode }})\n🏗️ Target: `${{ matrix.target }}`\n⏱️ `${{ steps.duration.outputs.text }}`\n👤 Triggered by: `${{ github.actor }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/runner-rs-v${{ inputs.target_version }}|View Release>"
 
       - name: Notify Slack - Failure
         if: ${{ failure() && steps.slack-start.outputs.ts }}
@@ -224,4 +315,4 @@ jobs:
               - type: section
                 text:
                   type: mrkdwn
-                  text: "*Runner RS* ❌ Rollback to v${{ inputs.target_version }} FAILED\n📦 Mode: `${{ inputs.rollback_mode }}`\n⏱️ `${{ steps.duration.outputs.text }}`\n👤 Triggered by: `${{ github.actor }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Logs>\n\n⚠️ Fleet may be in a split-version state. Inspect per-host and decide whether to re-run or SSH manually."
+                  text: "*Runner RS* ❌ Rollback to v${{ inputs.target_version }} FAILED\n📦 Mode: `${{ inputs.rollback_mode }}`\n🏗️ Target: `${{ matrix.target }}`\n⏱️ `${{ steps.duration.outputs.text }}`\n👤 Triggered by: `${{ github.actor }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Logs>\n\n⚠️ Fleet may be in a split-version state. Inspect per-host and decide whether to re-run or SSH manually."

--- a/.github/workflows/rollback-runner.yml
+++ b/.github/workflows/rollback-runner.yml
@@ -69,26 +69,23 @@ jobs:
           echo "::error::'confirmed_compatible' must be 'yes'. Operator must vet the target version for API / guest ABI / on-disk state compatibility before rolling back."
           exit 1
 
-      # Reject shell-unsafe / semver-ish injection in target_version. This
-      # string flows into systemd unit names, file paths, URLs, and --name
-      # flags; keep it strictly numeric + dots to match `validate_name` in
-      # crates/runner/src/runner_dirname.rs.
-      - name: Validate target_version format
-        env:
-          VERSION: ${{ inputs.target_version }}
-        shell: bash
-        run: |
-          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::target_version='$VERSION' is not semver (e.g. 0.81.0). Reject."
-            exit 1
-          fi
-
       # Use main's rollback-runner.yml — this playbook did not exist in
       # older tags. The playbook only calls stable runner CLI surfaces
       # (`service install` / `service drain` / `service stop` / `service
       # resume` / `doctor` / `gc` / `setup` / `build` / `config`), so it
       # works against any target binary the runner CLI contract supports.
       - uses: actions/checkout@v7
+
+      # Reject shell-unsafe / semver-ish injection in target_version using
+      # the same helper that derives release tag and asset names elsewhere.
+      - name: Validate target_version format
+        env:
+          VERSION: ${{ inputs.target_version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          . .github/scripts/runner-image-target.sh
+          runner_image_release_tag "$VERSION" >/dev/null
 
       - name: Setup SSH via Cloudflare Tunnel
         uses: ./.github/actions/setup-ssh-tunnel

--- a/ansible/playbooks/build-runner.yml
+++ b/ansible/playbooks/build-runner.yml
@@ -45,45 +45,8 @@
     runner_dir: "{{ data_dir }}/runners/{{ runner_name }}"
 
   tasks:
-    - name: Validate architecture inputs
-      assert:
-        that:
-          - (runner_target | default('')) in ["aarch64-unknown-linux-musl", "x86_64-unknown-linux-musl"]
-          - (runner_asset_suffix | default('')) in ["aarch64-linux", "x86_64-linux"]
-          - (expected_runner_uname_m | default('')) in ["aarch64", "x86_64"]
-          - >-
-            (
-              runner_target == "aarch64-unknown-linux-musl" and
-              runner_asset_suffix == "aarch64-linux" and
-              expected_runner_uname_m == "aarch64"
-            ) or (
-              runner_target == "x86_64-unknown-linux-musl" and
-              runner_asset_suffix == "x86_64-linux" and
-              expected_runner_uname_m == "x86_64"
-            )
-        fail_msg: >-
-          Missing or invalid architecture inputs. Required:
-          `runner_target` (aarch64-unknown-linux-musl |
-          x86_64-unknown-linux-musl), `runner_asset_suffix`
-          (aarch64-linux | x86_64-linux), and `expected_runner_uname_m`
-          (aarch64 | x86_64), all matching the same architecture. Got
-          runner_target='{{ runner_target | default('<undefined>') }}',
-          runner_asset_suffix='{{ runner_asset_suffix | default('<undefined>') }}',
-          expected_runner_uname_m='{{ expected_runner_uname_m | default('<undefined>') }}'.
-
-    - name: Probe remote architecture
-      command: uname -m
-      register: remote_uname_m
-      changed_when: false
-
-    - name: Assert remote architecture matches runner target
-      assert:
-        that:
-          - (remote_uname_m.stdout | trim) == expected_runner_uname_m
-        fail_msg: >-
-          Refusing to stage runner target '{{ runner_target }}' on remote
-          architecture '{{ remote_uname_m.stdout | trim }}' (expected
-          '{{ expected_runner_uname_m }}').
+    - name: Validate runner architecture
+      include_tasks: ../tasks/validate-runner-architecture.yml
 
     # ========================================
     # Phase 1: Deploy binaries

--- a/ansible/playbooks/build-runner.yml
+++ b/ansible/playbooks/build-runner.yml
@@ -24,8 +24,6 @@
 # Required Variables:
 #   - runner_version: Semantic version of the runner being built
 #   - runner_target: Rust target triple for the copied runner binary
-#   - runner_asset_suffix: Release asset suffix selected for this target
-#   - expected_runner_uname_m: Expected remote `uname -m` for this target
 #   - official_runner_secret: Runner authentication secret (baked into config)
 #   - api_url: vm0 API URL (baked into config)
 #   - r2_account_id / r2_access_key_id / r2_secret_access_key / r2_bucket:

--- a/ansible/playbooks/build-runner.yml
+++ b/ansible/playbooks/build-runner.yml
@@ -51,12 +51,22 @@
           - (runner_target | default('')) in ["aarch64-unknown-linux-musl", "x86_64-unknown-linux-musl"]
           - (runner_asset_suffix | default('')) in ["aarch64-linux", "x86_64-linux"]
           - (expected_runner_uname_m | default('')) in ["aarch64", "x86_64"]
+          - >-
+            (
+              runner_target == "aarch64-unknown-linux-musl" and
+              runner_asset_suffix == "aarch64-linux" and
+              expected_runner_uname_m == "aarch64"
+            ) or (
+              runner_target == "x86_64-unknown-linux-musl" and
+              runner_asset_suffix == "x86_64-linux" and
+              expected_runner_uname_m == "x86_64"
+            )
         fail_msg: >-
           Missing or invalid architecture inputs. Required:
           `runner_target` (aarch64-unknown-linux-musl |
           x86_64-unknown-linux-musl), `runner_asset_suffix`
           (aarch64-linux | x86_64-linux), and `expected_runner_uname_m`
-          (aarch64 | x86_64). Got
+          (aarch64 | x86_64), all matching the same architecture. Got
           runner_target='{{ runner_target | default('<undefined>') }}',
           runner_asset_suffix='{{ runner_asset_suffix | default('<undefined>') }}',
           expected_runner_uname_m='{{ expected_runner_uname_m | default('<undefined>') }}'.

--- a/ansible/playbooks/build-runner.yml
+++ b/ansible/playbooks/build-runner.yml
@@ -23,6 +23,9 @@
 #
 # Required Variables:
 #   - runner_version: Semantic version of the runner being built
+#   - runner_target: Rust target triple for the copied runner binary
+#   - runner_asset_suffix: Release asset suffix selected for this target
+#   - expected_runner_uname_m: Expected remote `uname -m` for this target
 #   - official_runner_secret: Runner authentication secret (baked into config)
 #   - api_url: vm0 API URL (baked into config)
 #   - r2_account_id / r2_access_key_id / r2_secret_access_key / r2_bucket:
@@ -42,6 +45,36 @@
     runner_dir: "{{ data_dir }}/runners/{{ runner_name }}"
 
   tasks:
+    - name: Validate architecture inputs
+      assert:
+        that:
+          - (runner_target | default('')) in ["aarch64-unknown-linux-musl", "x86_64-unknown-linux-musl"]
+          - (runner_asset_suffix | default('')) in ["aarch64-linux", "x86_64-linux"]
+          - (expected_runner_uname_m | default('')) in ["aarch64", "x86_64"]
+        fail_msg: >-
+          Missing or invalid architecture inputs. Required:
+          `runner_target` (aarch64-unknown-linux-musl |
+          x86_64-unknown-linux-musl), `runner_asset_suffix`
+          (aarch64-linux | x86_64-linux), and `expected_runner_uname_m`
+          (aarch64 | x86_64). Got
+          runner_target='{{ runner_target | default('<undefined>') }}',
+          runner_asset_suffix='{{ runner_asset_suffix | default('<undefined>') }}',
+          expected_runner_uname_m='{{ expected_runner_uname_m | default('<undefined>') }}'.
+
+    - name: Probe remote architecture
+      command: uname -m
+      register: remote_uname_m
+      changed_when: false
+
+    - name: Assert remote architecture matches runner target
+      assert:
+        that:
+          - (remote_uname_m.stdout | trim) == expected_runner_uname_m
+        fail_msg: >-
+          Refusing to stage runner target '{{ runner_target }}' on remote
+          architecture '{{ remote_uname_m.stdout | trim }}' (expected
+          '{{ expected_runner_uname_m }}').
+
     # ========================================
     # Phase 1: Deploy binaries
     # ========================================
@@ -53,7 +86,7 @@
 
     - name: Copy runner binary (guest binaries are embedded)
       copy:
-        src: "{{ playbook_dir }}/../../crates/target/aarch64-unknown-linux-musl/release/runner"
+        src: "{{ playbook_dir }}/../../crates/target/{{ runner_target }}/release/runner"
         dest: "{{ bin_dir }}/"
         mode: '0755'
 

--- a/ansible/playbooks/build-runner.yml
+++ b/ansible/playbooks/build-runner.yml
@@ -22,7 +22,7 @@
 #     -e "r2_bucket=xxx"
 #
 # Required Variables:
-#   - runner_version: Semantic version of the runner being built
+#   - runner_version: Semantic version of the runner being built, without leading v
 #   - runner_target: Rust target triple for the copied runner binary
 #   - official_runner_secret: Runner authentication secret (baked into config)
 #   - api_url: vm0 API URL (baked into config)

--- a/ansible/playbooks/promote-runner.yml
+++ b/ansible/playbooks/promote-runner.yml
@@ -16,6 +16,9 @@
 #
 # Required Variables:
 #   - runner_version: Semantic version of the runner being promoted
+#   - runner_target: Rust target triple for the staged runner binary
+#   - runner_asset_suffix: Release asset suffix selected for this target
+#   - expected_runner_uname_m: Expected remote `uname -m` for this target
 #
 # Optional Variables:
 #   - sentry_dsn: Forwarded to the systemd unit as SENTRY_DSN
@@ -36,6 +39,36 @@
     runner_dir: "{{ data_dir }}/runners/{{ runner_name }}"
 
   tasks:
+    - name: Validate architecture inputs
+      assert:
+        that:
+          - (runner_target | default('')) in ["aarch64-unknown-linux-musl", "x86_64-unknown-linux-musl"]
+          - (runner_asset_suffix | default('')) in ["aarch64-linux", "x86_64-linux"]
+          - (expected_runner_uname_m | default('')) in ["aarch64", "x86_64"]
+        fail_msg: >-
+          Missing or invalid architecture inputs. Required:
+          `runner_target` (aarch64-unknown-linux-musl |
+          x86_64-unknown-linux-musl), `runner_asset_suffix`
+          (aarch64-linux | x86_64-linux), and `expected_runner_uname_m`
+          (aarch64 | x86_64). Got
+          runner_target='{{ runner_target | default('<undefined>') }}',
+          runner_asset_suffix='{{ runner_asset_suffix | default('<undefined>') }}',
+          expected_runner_uname_m='{{ expected_runner_uname_m | default('<undefined>') }}'.
+
+    - name: Probe remote architecture
+      command: uname -m
+      register: remote_uname_m
+      changed_when: false
+
+    - name: Assert remote architecture matches runner target
+      assert:
+        that:
+          - (remote_uname_m.stdout | trim) == expected_runner_uname_m
+        fail_msg: >-
+          Refusing to promote runner target '{{ runner_target }}' on remote
+          architecture '{{ remote_uname_m.stdout | trim }}' (expected
+          '{{ expected_runner_uname_m }}').
+
     # ========================================
     # Phase 3b: Install systemd service (traffic cutover point)
     # ========================================

--- a/ansible/playbooks/promote-runner.yml
+++ b/ansible/playbooks/promote-runner.yml
@@ -17,8 +17,6 @@
 # Required Variables:
 #   - runner_version: Semantic version of the runner being promoted
 #   - runner_target: Rust target triple for the staged runner binary
-#   - runner_asset_suffix: Release asset suffix selected for this target
-#   - expected_runner_uname_m: Expected remote `uname -m` for this target
 #
 # Optional Variables:
 #   - sentry_dsn: Forwarded to the systemd unit as SENTRY_DSN

--- a/ansible/playbooks/promote-runner.yml
+++ b/ansible/playbooks/promote-runner.yml
@@ -45,12 +45,22 @@
           - (runner_target | default('')) in ["aarch64-unknown-linux-musl", "x86_64-unknown-linux-musl"]
           - (runner_asset_suffix | default('')) in ["aarch64-linux", "x86_64-linux"]
           - (expected_runner_uname_m | default('')) in ["aarch64", "x86_64"]
+          - >-
+            (
+              runner_target == "aarch64-unknown-linux-musl" and
+              runner_asset_suffix == "aarch64-linux" and
+              expected_runner_uname_m == "aarch64"
+            ) or (
+              runner_target == "x86_64-unknown-linux-musl" and
+              runner_asset_suffix == "x86_64-linux" and
+              expected_runner_uname_m == "x86_64"
+            )
         fail_msg: >-
           Missing or invalid architecture inputs. Required:
           `runner_target` (aarch64-unknown-linux-musl |
           x86_64-unknown-linux-musl), `runner_asset_suffix`
           (aarch64-linux | x86_64-linux), and `expected_runner_uname_m`
-          (aarch64 | x86_64). Got
+          (aarch64 | x86_64), all matching the same architecture. Got
           runner_target='{{ runner_target | default('<undefined>') }}',
           runner_asset_suffix='{{ runner_asset_suffix | default('<undefined>') }}',
           expected_runner_uname_m='{{ expected_runner_uname_m | default('<undefined>') }}'.

--- a/ansible/playbooks/promote-runner.yml
+++ b/ansible/playbooks/promote-runner.yml
@@ -15,7 +15,7 @@
 #     -e "runner_version=0.3.0"
 #
 # Required Variables:
-#   - runner_version: Semantic version of the runner being promoted
+#   - runner_version: Semantic version of the runner being promoted, without leading v
 #   - runner_target: Rust target triple for the staged runner binary
 #
 # Optional Variables:

--- a/ansible/playbooks/promote-runner.yml
+++ b/ansible/playbooks/promote-runner.yml
@@ -39,45 +39,8 @@
     runner_dir: "{{ data_dir }}/runners/{{ runner_name }}"
 
   tasks:
-    - name: Validate architecture inputs
-      assert:
-        that:
-          - (runner_target | default('')) in ["aarch64-unknown-linux-musl", "x86_64-unknown-linux-musl"]
-          - (runner_asset_suffix | default('')) in ["aarch64-linux", "x86_64-linux"]
-          - (expected_runner_uname_m | default('')) in ["aarch64", "x86_64"]
-          - >-
-            (
-              runner_target == "aarch64-unknown-linux-musl" and
-              runner_asset_suffix == "aarch64-linux" and
-              expected_runner_uname_m == "aarch64"
-            ) or (
-              runner_target == "x86_64-unknown-linux-musl" and
-              runner_asset_suffix == "x86_64-linux" and
-              expected_runner_uname_m == "x86_64"
-            )
-        fail_msg: >-
-          Missing or invalid architecture inputs. Required:
-          `runner_target` (aarch64-unknown-linux-musl |
-          x86_64-unknown-linux-musl), `runner_asset_suffix`
-          (aarch64-linux | x86_64-linux), and `expected_runner_uname_m`
-          (aarch64 | x86_64), all matching the same architecture. Got
-          runner_target='{{ runner_target | default('<undefined>') }}',
-          runner_asset_suffix='{{ runner_asset_suffix | default('<undefined>') }}',
-          expected_runner_uname_m='{{ expected_runner_uname_m | default('<undefined>') }}'.
-
-    - name: Probe remote architecture
-      command: uname -m
-      register: remote_uname_m
-      changed_when: false
-
-    - name: Assert remote architecture matches runner target
-      assert:
-        that:
-          - (remote_uname_m.stdout | trim) == expected_runner_uname_m
-        fail_msg: >-
-          Refusing to promote runner target '{{ runner_target }}' on remote
-          architecture '{{ remote_uname_m.stdout | trim }}' (expected
-          '{{ expected_runner_uname_m }}').
+    - name: Validate runner architecture
+      include_tasks: ../tasks/validate-runner-architecture.yml
 
     # ========================================
     # Phase 3b: Install systemd service (traffic cutover point)

--- a/ansible/playbooks/rollback-runner.yml
+++ b/ansible/playbooks/rollback-runner.yml
@@ -101,13 +101,23 @@
           - (runner_target | default('')) in ["aarch64-unknown-linux-musl", "x86_64-unknown-linux-musl"]
           - (runner_asset_suffix | default('')) in ["aarch64-linux", "x86_64-linux"]
           - (expected_runner_uname_m | default('')) in ["aarch64", "x86_64"]
+          - >-
+            (
+              runner_target == "aarch64-unknown-linux-musl" and
+              runner_asset_suffix == "aarch64-linux" and
+              expected_runner_uname_m == "aarch64"
+            ) or (
+              runner_target == "x86_64-unknown-linux-musl" and
+              runner_asset_suffix == "x86_64-linux" and
+              expected_runner_uname_m == "x86_64"
+            )
         fail_msg: >-
           Missing or invalid inputs. Required: `runner_version` in semver
           form (e.g. 0.81.0, no leading v), `rollback_mode` (graceful |
           emergency), `runner_target` (aarch64-unknown-linux-musl |
           x86_64-unknown-linux-musl), `runner_asset_suffix` (aarch64-linux |
-          x86_64-linux), and `expected_runner_uname_m` (aarch64 | x86_64).
-          Got
+          x86_64-linux), and `expected_runner_uname_m` (aarch64 | x86_64),
+          all matching the same architecture. Got
           runner_version='{{ runner_version | default('<undefined>') }}',
           rollback_mode='{{ rollback_mode | default('<undefined>') }}',
           runner_target='{{ runner_target | default('<undefined>') }}',

--- a/ansible/playbooks/rollback-runner.yml
+++ b/ansible/playbooks/rollback-runner.yml
@@ -32,6 +32,9 @@
 #
 # Required Variables:
 #   - runner_version: Semantic version to roll back TO (e.g. 0.81.0)
+#   - runner_target: Rust target triple for the rollback runner binary
+#   - runner_asset_suffix: Release asset suffix selected for this target
+#   - expected_runner_uname_m: Expected remote `uname -m` for this target
 #   - rollback_mode: graceful | emergency
 #       graceful  — `runner service drain` (SIGUSR1). Active jobs finish
 #                   naturally (bounded by JOB_TIMEOUT=2h).
@@ -95,12 +98,35 @@
           - runner_version is defined and runner_version | length > 0
           - runner_version is match('^[0-9]+\.[0-9]+\.[0-9]+$')
           - rollback_mode is defined and rollback_mode in ["graceful", "emergency"]
+          - (runner_target | default('')) in ["aarch64-unknown-linux-musl", "x86_64-unknown-linux-musl"]
+          - (runner_asset_suffix | default('')) in ["aarch64-linux", "x86_64-linux"]
+          - (expected_runner_uname_m | default('')) in ["aarch64", "x86_64"]
         fail_msg: >-
           Missing or invalid inputs. Required: `runner_version` in semver
-          form (e.g. 0.81.0, no leading v) and `rollback_mode` (graceful |
-          emergency). Got
+          form (e.g. 0.81.0, no leading v), `rollback_mode` (graceful |
+          emergency), `runner_target` (aarch64-unknown-linux-musl |
+          x86_64-unknown-linux-musl), `runner_asset_suffix` (aarch64-linux |
+          x86_64-linux), and `expected_runner_uname_m` (aarch64 | x86_64).
+          Got
           runner_version='{{ runner_version | default('<undefined>') }}',
-          rollback_mode='{{ rollback_mode | default('<undefined>') }}'.
+          rollback_mode='{{ rollback_mode | default('<undefined>') }}',
+          runner_target='{{ runner_target | default('<undefined>') }}',
+          runner_asset_suffix='{{ runner_asset_suffix | default('<undefined>') }}',
+          expected_runner_uname_m='{{ expected_runner_uname_m | default('<undefined>') }}'.
+
+    - name: Probe remote architecture
+      command: uname -m
+      register: remote_uname_m
+      changed_when: false
+
+    - name: Assert remote architecture matches runner target
+      assert:
+        that:
+          - (remote_uname_m.stdout | trim) == expected_runner_uname_m
+        fail_msg: >-
+          Refusing to roll back runner target '{{ runner_target }}' on remote
+          architecture '{{ remote_uname_m.stdout | trim }}' (expected
+          '{{ expected_runner_uname_m }}').
 
     # ========================================
     # Phase 1: Probe target service state
@@ -312,10 +338,10 @@
             download_headers: "{{ {'Authorization': 'token ' + github_token} if (github_token is defined and github_token | length > 0) else {} }}"
 
         # Release asset naming matches release-please.yml's upload step
-        # (runner-rs-v{version} tag, runner-v{version}-aarch64-linux asset).
+        # (runner-rs-v{version} tag, runner-v{version}-{asset suffix} asset).
         - name: Download runner binary from GitHub Release
           get_url:
-            url: "https://github.com/vm0-ai/vm0/releases/download/runner-rs-{{ runner_name }}/runner-{{ runner_name }}-aarch64-linux"
+            url: "https://github.com/vm0-ai/vm0/releases/download/runner-rs-{{ runner_name }}/runner-{{ runner_name }}-{{ runner_asset_suffix }}"
             dest: "{{ bin_dir }}/runner"
             mode: "0755"
             headers: "{{ download_headers }}"

--- a/ansible/playbooks/rollback-runner.yml
+++ b/ansible/playbooks/rollback-runner.yml
@@ -33,8 +33,6 @@
 # Required Variables:
 #   - runner_version: Semantic version to roll back TO (e.g. 0.81.0)
 #   - runner_target: Rust target triple for the rollback runner binary
-#   - runner_asset_suffix: Release asset suffix selected for this target
-#   - expected_runner_uname_m: Expected remote `uname -m` for this target
 #   - rollback_mode: graceful | emergency
 #       graceful  — `runner service drain` (SIGUSR1). Active jobs finish
 #                   naturally (bounded by JOB_TIMEOUT=2h).
@@ -321,7 +319,7 @@
         # (runner-rs-v{version} tag, runner-v{version}-{asset suffix} asset).
         - name: Download runner binary from GitHub Release
           get_url:
-            url: "https://github.com/vm0-ai/vm0/releases/download/runner-rs-{{ runner_name }}/runner-{{ runner_name }}-{{ runner_asset_suffix }}"
+            url: "https://github.com/vm0-ai/vm0/releases/download/runner-rs-{{ runner_name }}/runner-{{ runner_name }}-{{ derived_runner_asset_suffix }}"
             dest: "{{ bin_dir }}/runner"
             mode: "0755"
             headers: "{{ download_headers }}"

--- a/ansible/playbooks/rollback-runner.yml
+++ b/ansible/playbooks/rollback-runner.yml
@@ -315,11 +315,11 @@
           set_fact:
             download_headers: "{{ {'Authorization': 'token ' + github_token} if (github_token is defined and github_token | length > 0) else {} }}"
 
-        # Release asset naming matches release-please.yml's upload step
-        # (runner-rs-v{version} tag, runner-v{version}-{asset suffix} asset).
+        # Release asset naming comes from runner-image-target.sh, the same
+        # helper used by release-please.yml when uploading assets.
         - name: Download runner binary from GitHub Release
           get_url:
-            url: "https://github.com/vm0-ai/vm0/releases/download/runner-rs-{{ runner_name }}/runner-{{ runner_name }}-{{ derived_runner_asset_suffix }}"
+            url: "https://github.com/vm0-ai/vm0/releases/download/{{ derived_runner_release_tag }}/{{ derived_runner_release_asset_name }}"
             dest: "{{ bin_dir }}/runner"
             mode: "0755"
             headers: "{{ download_headers }}"

--- a/ansible/playbooks/rollback-runner.yml
+++ b/ansible/playbooks/rollback-runner.yml
@@ -31,7 +31,7 @@
 #     -e "rollback_mode=graceful"
 #
 # Required Variables:
-#   - runner_version: Semantic version to roll back TO (e.g. 0.81.0)
+#   - runner_version: Semantic version to roll back TO (e.g. 0.81.0, no leading v)
 #   - runner_target: Rust target triple for the rollback runner binary
 #   - rollback_mode: graceful | emergency
 #       graceful  — `runner service drain` (SIGUSR1). Active jobs finish
@@ -84,23 +84,12 @@
     # Typos like rollback_mode=greaceful silently no-op both Phase 7 drain
     # branches, leaving the fleet in a mixed-version state while the play
     # reports success. Catch that upfront.
-    # Semver regex is enforced at the workflow layer too (rollback-runner.yml
-    # Validate target_version format), but we re-check here as defense in
-    # depth for direct `ansible-playbook` invocations: `runner_version`
-    # flows into systemd unit names and `command:` tasks (Ansible splits
-    # on whitespace), so a malformed value containing spaces or shell
-    # metachars could inject extra CLI flags.
-    - name: Validate required inputs
+    - name: Validate rollback mode
       assert:
         that:
-          - runner_version is defined and runner_version | length > 0
-          - runner_version is match('^[0-9]+\.[0-9]+\.[0-9]+$')
           - rollback_mode is defined and rollback_mode in ["graceful", "emergency"]
         fail_msg: >-
-          Missing or invalid inputs. Required: `runner_version` in semver
-          form (e.g. 0.81.0, no leading v) and `rollback_mode` (graceful |
-          emergency). Got
-          runner_version='{{ runner_version | default('<undefined>') }}',
+          Missing or invalid `rollback_mode` (graceful | emergency). Got
           rollback_mode='{{ rollback_mode | default('<undefined>') }}'.
 
     - name: Validate runner architecture

--- a/ansible/playbooks/rollback-runner.yml
+++ b/ansible/playbooks/rollback-runner.yml
@@ -98,45 +98,15 @@
           - runner_version is defined and runner_version | length > 0
           - runner_version is match('^[0-9]+\.[0-9]+\.[0-9]+$')
           - rollback_mode is defined and rollback_mode in ["graceful", "emergency"]
-          - (runner_target | default('')) in ["aarch64-unknown-linux-musl", "x86_64-unknown-linux-musl"]
-          - (runner_asset_suffix | default('')) in ["aarch64-linux", "x86_64-linux"]
-          - (expected_runner_uname_m | default('')) in ["aarch64", "x86_64"]
-          - >-
-            (
-              runner_target == "aarch64-unknown-linux-musl" and
-              runner_asset_suffix == "aarch64-linux" and
-              expected_runner_uname_m == "aarch64"
-            ) or (
-              runner_target == "x86_64-unknown-linux-musl" and
-              runner_asset_suffix == "x86_64-linux" and
-              expected_runner_uname_m == "x86_64"
-            )
         fail_msg: >-
           Missing or invalid inputs. Required: `runner_version` in semver
-          form (e.g. 0.81.0, no leading v), `rollback_mode` (graceful |
-          emergency), `runner_target` (aarch64-unknown-linux-musl |
-          x86_64-unknown-linux-musl), `runner_asset_suffix` (aarch64-linux |
-          x86_64-linux), and `expected_runner_uname_m` (aarch64 | x86_64),
-          all matching the same architecture. Got
+          form (e.g. 0.81.0, no leading v) and `rollback_mode` (graceful |
+          emergency). Got
           runner_version='{{ runner_version | default('<undefined>') }}',
-          rollback_mode='{{ rollback_mode | default('<undefined>') }}',
-          runner_target='{{ runner_target | default('<undefined>') }}',
-          runner_asset_suffix='{{ runner_asset_suffix | default('<undefined>') }}',
-          expected_runner_uname_m='{{ expected_runner_uname_m | default('<undefined>') }}'.
+          rollback_mode='{{ rollback_mode | default('<undefined>') }}'.
 
-    - name: Probe remote architecture
-      command: uname -m
-      register: remote_uname_m
-      changed_when: false
-
-    - name: Assert remote architecture matches runner target
-      assert:
-        that:
-          - (remote_uname_m.stdout | trim) == expected_runner_uname_m
-        fail_msg: >-
-          Refusing to roll back runner target '{{ runner_target }}' on remote
-          architecture '{{ remote_uname_m.stdout | trim }}' (expected
-          '{{ expected_runner_uname_m }}').
+    - name: Validate runner architecture
+      include_tasks: ../tasks/validate-runner-architecture.yml
 
     # ========================================
     # Phase 1: Probe target service state

--- a/ansible/tasks/validate-runner-architecture.yml
+++ b/ansible/tasks/validate-runner-architecture.yml
@@ -1,0 +1,38 @@
+- name: Validate architecture inputs
+  assert:
+    that:
+      - (runner_target | default('')) in ["aarch64-unknown-linux-musl", "x86_64-unknown-linux-musl"]
+      - (runner_asset_suffix | default('')) in ["aarch64-linux", "x86_64-linux"]
+      - (expected_runner_uname_m | default('')) in ["aarch64", "x86_64"]
+      - >-
+        (
+          runner_target == "aarch64-unknown-linux-musl" and
+          runner_asset_suffix == "aarch64-linux" and
+          expected_runner_uname_m == "aarch64"
+        ) or (
+          runner_target == "x86_64-unknown-linux-musl" and
+          runner_asset_suffix == "x86_64-linux" and
+          expected_runner_uname_m == "x86_64"
+        )
+    fail_msg: >-
+      Missing or invalid architecture inputs. Required: `runner_target`
+      (aarch64-unknown-linux-musl | x86_64-unknown-linux-musl),
+      `runner_asset_suffix` (aarch64-linux | x86_64-linux), and
+      `expected_runner_uname_m` (aarch64 | x86_64), all matching the same
+      architecture. Got runner_target='{{ runner_target | default('<undefined>') }}',
+      runner_asset_suffix='{{ runner_asset_suffix | default('<undefined>') }}',
+      expected_runner_uname_m='{{ expected_runner_uname_m | default('<undefined>') }}'.
+
+- name: Probe remote architecture
+  command: uname -m
+  register: remote_uname_m
+  changed_when: false
+
+- name: Assert remote architecture matches runner target
+  assert:
+    that:
+      - (remote_uname_m.stdout | trim) == expected_runner_uname_m
+    fail_msg: >-
+      Refusing to use runner target '{{ runner_target }}' on remote
+      architecture '{{ remote_uname_m.stdout | trim }}' (expected
+      '{{ expected_runner_uname_m }}').

--- a/ansible/tasks/validate-runner-architecture.yml
+++ b/ansible/tasks/validate-runner-architecture.yml
@@ -1,20 +1,31 @@
-- name: Validate runner target
-  assert:
-    that:
-      - (runner_target | default('')) in ["aarch64-unknown-linux-musl", "x86_64-unknown-linux-musl"]
-    fail_msg: >-
-      Missing or invalid runner target. Required: `runner_target`
-      (aarch64-unknown-linux-musl | x86_64-unknown-linux-musl). Got
-      runner_target='{{ runner_target | default('<undefined>') }}'.
-
 - name: Derive runner architecture metadata
+  command:
+    argv:
+      - bash
+      - -c
+      - |
+        set -euo pipefail
+        . "$1"
+        runner_image_asset_suffix "$2"
+        runner_image_expected_uname_m "$2"
+      - bash
+      - "{{ playbook_dir }}/../../.github/scripts/runner-image-target.sh"
+      - "{{ runner_target | default('') }}"
+  delegate_to: localhost
+  become: false
+  check_mode: false
+  changed_when: false
+  register: runner_architecture_metadata
+
+- name: Store runner architecture metadata
   set_fact:
-    derived_runner_asset_suffix: "{{ 'aarch64-linux' if runner_target == 'aarch64-unknown-linux-musl' else 'x86_64-linux' }}"
-    derived_expected_runner_uname_m: "{{ 'aarch64' if runner_target == 'aarch64-unknown-linux-musl' else 'x86_64' }}"
+    derived_runner_asset_suffix: "{{ runner_architecture_metadata.stdout_lines[0] }}"
+    derived_expected_runner_uname_m: "{{ runner_architecture_metadata.stdout_lines[1] }}"
 
 - name: Probe remote architecture
   command: uname -m
   register: remote_uname_m
+  check_mode: false
   changed_when: false
 
 - name: Assert remote architecture matches runner target

--- a/ansible/tasks/validate-runner-architecture.yml
+++ b/ansible/tasks/validate-runner-architecture.yml
@@ -6,7 +6,6 @@
       - |
         set -euo pipefail
         . "$1"
-        runner_image_asset_suffix "$2"
         runner_image_expected_uname_m "$2"
         runner_image_release_tag "$3"
         runner_image_release_asset_name "$3" "$2"
@@ -22,10 +21,9 @@
 
 - name: Store runner architecture metadata
   set_fact:
-    derived_runner_asset_suffix: "{{ runner_architecture_metadata.stdout_lines[0] }}"
-    derived_expected_runner_uname_m: "{{ runner_architecture_metadata.stdout_lines[1] }}"
-    derived_runner_release_tag: "{{ runner_architecture_metadata.stdout_lines[2] }}"
-    derived_runner_release_asset_name: "{{ runner_architecture_metadata.stdout_lines[3] }}"
+    derived_expected_runner_uname_m: "{{ runner_architecture_metadata.stdout_lines[0] }}"
+    derived_runner_release_tag: "{{ runner_architecture_metadata.stdout_lines[1] }}"
+    derived_runner_release_asset_name: "{{ runner_architecture_metadata.stdout_lines[2] }}"
 
 - name: Probe remote architecture
   command: uname -m

--- a/ansible/tasks/validate-runner-architecture.yml
+++ b/ansible/tasks/validate-runner-architecture.yml
@@ -1,27 +1,16 @@
-- name: Validate architecture inputs
+- name: Validate runner target
   assert:
     that:
       - (runner_target | default('')) in ["aarch64-unknown-linux-musl", "x86_64-unknown-linux-musl"]
-      - (runner_asset_suffix | default('')) in ["aarch64-linux", "x86_64-linux"]
-      - (expected_runner_uname_m | default('')) in ["aarch64", "x86_64"]
-      - >-
-        (
-          runner_target == "aarch64-unknown-linux-musl" and
-          runner_asset_suffix == "aarch64-linux" and
-          expected_runner_uname_m == "aarch64"
-        ) or (
-          runner_target == "x86_64-unknown-linux-musl" and
-          runner_asset_suffix == "x86_64-linux" and
-          expected_runner_uname_m == "x86_64"
-        )
     fail_msg: >-
-      Missing or invalid architecture inputs. Required: `runner_target`
-      (aarch64-unknown-linux-musl | x86_64-unknown-linux-musl),
-      `runner_asset_suffix` (aarch64-linux | x86_64-linux), and
-      `expected_runner_uname_m` (aarch64 | x86_64), all matching the same
-      architecture. Got runner_target='{{ runner_target | default('<undefined>') }}',
-      runner_asset_suffix='{{ runner_asset_suffix | default('<undefined>') }}',
-      expected_runner_uname_m='{{ expected_runner_uname_m | default('<undefined>') }}'.
+      Missing or invalid runner target. Required: `runner_target`
+      (aarch64-unknown-linux-musl | x86_64-unknown-linux-musl). Got
+      runner_target='{{ runner_target | default('<undefined>') }}'.
+
+- name: Derive runner architecture metadata
+  set_fact:
+    derived_runner_asset_suffix: "{{ 'aarch64-linux' if runner_target == 'aarch64-unknown-linux-musl' else 'x86_64-linux' }}"
+    derived_expected_runner_uname_m: "{{ 'aarch64' if runner_target == 'aarch64-unknown-linux-musl' else 'x86_64' }}"
 
 - name: Probe remote architecture
   command: uname -m
@@ -31,8 +20,8 @@
 - name: Assert remote architecture matches runner target
   assert:
     that:
-      - (remote_uname_m.stdout | trim) == expected_runner_uname_m
+      - (remote_uname_m.stdout | trim) == derived_expected_runner_uname_m
     fail_msg: >-
       Refusing to use runner target '{{ runner_target }}' on remote
       architecture '{{ remote_uname_m.stdout | trim }}' (expected
-      '{{ expected_runner_uname_m }}').
+      '{{ derived_expected_runner_uname_m }}').

--- a/ansible/tasks/validate-runner-architecture.yml
+++ b/ansible/tasks/validate-runner-architecture.yml
@@ -8,9 +8,12 @@
         . "$1"
         runner_image_asset_suffix "$2"
         runner_image_expected_uname_m "$2"
+        runner_image_release_tag "$3"
+        runner_image_release_asset_name "$3" "$2"
       - bash
       - "{{ playbook_dir }}/../../.github/scripts/runner-image-target.sh"
       - "{{ runner_target | default('') }}"
+      - "{{ runner_version | default('') }}"
   delegate_to: localhost
   become: false
   check_mode: false
@@ -21,6 +24,8 @@
   set_fact:
     derived_runner_asset_suffix: "{{ runner_architecture_metadata.stdout_lines[0] }}"
     derived_expected_runner_uname_m: "{{ runner_architecture_metadata.stdout_lines[1] }}"
+    derived_runner_release_tag: "{{ runner_architecture_metadata.stdout_lines[2] }}"
+    derived_runner_release_asset_name: "{{ runner_architecture_metadata.stdout_lines[3] }}"
 
 - name: Probe remote architecture
   command: uname -m


### PR DESCRIPTION
## Summary

- Derive production runner host architecture groups from the single `AWS_METAL_RUNNER_HOSTS` inventory and pass only sanitized deploy metadata (`id`, `label`, `target`) across jobs.
- Stage, promote, and roll back runner releases per architecture group, resolving concrete host subsets inside each job.
- Centralize runner target metadata in `.github/scripts/runner-image-target.sh`, including cache suffix, release tag, release asset name, ELF machine type, expected remote `uname -m`, and no-leading-v semver validation.
- Validate downloaded ELF machine type and remote host architecture before copying, downloading, installing, or starting runner binaries.

Closes #18486

## Tests

- `.github/scripts/tests/runner-host-architecture-groups-test.sh`
- `actionlint .github/workflows/release-please.yml .github/workflows/rollback-runner.yml`
- `git diff --check`
- `ansible-playbook --syntax-check` for `build-runner.yml`, `promote-runner.yml`, and `rollback-runner.yml`
- `ansible-playbook --check` negative coverage for unsupported `runner_target`, invalid `runner_version`, and invalid `rollback_mode`