### PR TITLE
fix: classify deel custom field patch as write

### DIFF
--- a/crates/runner/mitm-addon/src/generated/builtin_firewalls/deel_0.py
+++ b/crates/runner/mitm-addon/src/generated/builtin_firewalls/deel_0.py
@@ -376,7 +376,6 @@ JSON_PART = r"""{
             "GET /rest/v2/departments",
             "GET /rest/v2/eor/job-scopes",
             "GET /rest/v2/hris/organization-structures/teams/{team_id}/custom-fields",
-            "PATCH /rest/v2/hris/organization-structures/teams/{team_id}/custom-fields",
             "GET /rest/v2/hris/organization_structures",
             "GET /rest/v2/hris/organization_structures/external/{external_id}",
             "GET /rest/v2/hris/organization_structures/{hrisOrgStr_id}",
@@ -393,6 +392,7 @@ JSON_PART = r"""{
         {
           "name": "organizations:write",
           "rules": [
+            "PATCH /rest/v2/hris/organization-structures/teams/{team_id}/custom-fields",
             "POST /rest/v2/hris/organization_structures",
             "PATCH /rest/v2/hris/organization_structures/external/{external_id}",
             "DELETE /rest/v2/hris/organization_structures/external/{external_id}",

--- a/crates/runner/mitm-addon/tests/test_builtin_firewalls_catalog.py
+++ b/crates/runner/mitm-addon/tests/test_builtin_firewalls_catalog.py
@@ -2,6 +2,14 @@
 
 import generated.builtin_firewalls as builtin_firewalls
 
+READ_LIKE_PERMISSION_NAMES = {"read", "readonly"}
+READ_LIKE_PERMISSION_SUFFIXES = (":read", ".read")
+READ_LIKE_MUTATION_METHODS = {"DELETE", "PATCH", "PUT"}
+
+
+def _is_read_like_permission(name: str) -> bool:
+    return name in READ_LIKE_PERMISSION_NAMES or name.endswith(READ_LIKE_PERMISSION_SUFFIXES)
+
 
 def test_get_existing_builtin_firewall():
     firewall = builtin_firewalls.BUILTIN_FIREWALLS.get("github")
@@ -46,6 +54,23 @@ def test_builtin_firewalls_cache_loaded_values():
 
 def test_builtin_firewalls_mapping_is_read_only():
     assert not hasattr(builtin_firewalls.BUILTIN_FIREWALLS, "__setitem__")
+
+
+def test_read_like_builtin_permissions_do_not_own_mutation_methods():
+    violations: list[str] = []
+
+    for firewall_name, firewall in builtin_firewalls.BUILTIN_FIREWALLS.items():
+        for api in firewall["apis"]:
+            for permission in api.get("permissions", []):
+                permission_name = permission["name"]
+                if not _is_read_like_permission(permission_name):
+                    continue
+                for rule in permission.get("rules", []):
+                    method = rule.split(" ", 1)[0]
+                    if method in READ_LIKE_MUTATION_METHODS:
+                        violations.append(f"{firewall_name}: {permission_name}: {rule}")
+
+    assert violations == []
 
 
 def test_google_drive_builtin_uses_vm0_permissions():

--- a/crates/runner/mitm-addon/tests/test_firewall_network_policy_decisions.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_network_policy_decisions.py
@@ -164,6 +164,46 @@ class TestFirewallNetworkPolicyDecisions:
         assert result.permission == "auth:write"
         assert result.rule == "POST /rest/v2/magic-link"
 
+    def test_deel_organizations_read_does_not_allow_team_custom_field_mutations(self):
+        policies = self._deel_policy_allowing("organizations:read")
+        url = (
+            "https://api.letsdeel.com/rest/v2/hris/organization-structures/"
+            "teams/team_123/custom-fields"
+        )
+
+        read_result = match_request_with_raw_firewalls(
+            url,
+            "GET",
+            self._deel_firewall(),
+            network_policies=policies,
+        )
+        mutation_result = match_request_with_raw_firewalls(
+            url,
+            "PATCH",
+            self._deel_firewall(),
+            network_policies=policies,
+        )
+
+        assert isinstance(read_result, matching.FirewallAllow)
+        assert read_result.permission == "organizations:read"
+        assert isinstance(mutation_result, matching.FirewallBlock)
+        assert mutation_result.reason == "permission_denied"
+        assert mutation_result.permissions == ("organizations:write",)
+
+    def test_deel_organizations_write_allows_team_custom_field_mutations(self):
+        policies = self._deel_policy_allowing("organizations:write")
+
+        result = match_request_with_raw_firewalls(
+            "https://api.letsdeel.com/rest/v2/hris/organization-structures/"
+            "teams/team_123/custom-fields",
+            "PATCH",
+            self._deel_firewall(),
+            network_policies=policies,
+        )
+
+        assert isinstance(result, matching.FirewallAllow)
+        assert result.permission == "organizations:write"
+
     def test_denied_permission_blocked(self):
         policies = {
             "github": {"allow": ["repo-read"], "deny": ["repo-write"], "unknownPolicy": "deny"}

--- a/turbo/packages/firewalls-generator/src/deel.ts
+++ b/turbo/packages/firewalls-generator/src/deel.ts
@@ -328,6 +328,10 @@ const DOCUMENTED_SCOPE_REMAPS: Record<string, DeelDocumentedScopeRemap> = {
     expectedScopes: ["worker:read"],
     targetScope: "auth:write",
   },
+  "PATCH /rest/v2/hris/organization-structures/teams/{team_id}/custom-fields": {
+    expectedScopes: ["organizations:read"],
+    targetScope: "organizations:write",
+  },
 };
 
 // ── Scopeless endpoints ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- add a Deel documented-scope correction for the team custom-fields PATCH route
- move the generated builtin firewall rule from `organizations:read` to `organizations:write`
- add runtime matcher coverage for Deel read/write policy behavior
- add a builtin catalog guard so read-like permissions cannot own `PATCH`, `PUT`, or `DELETE` rules

Closes #18770

## Tests

- `cd turbo && pnpm -F @vm0/firewalls-generator generate:deel`
- `cd turbo && pnpm -F @vm0/api-contracts generate:rust`
- `cd crates/runner/mitm-addon && python3 -m pytest tests/test_firewall_network_policy_decisions.py tests/test_builtin_firewalls_catalog.py`
- `cd turbo && pnpm -F @vm0/firewalls-generator check-types`
- `cd turbo && pnpm -F @vm0/api-contracts check-types`
- `cd crates/runner/mitm-addon && python3 -m ruff check tests/test_firewall_network_policy_decisions.py tests/test_builtin_firewalls_catalog.py`
- `cd crates/runner/mitm-addon && python3 -m ruff format --check tests/test_firewall_network_policy_decisions.py tests/test_builtin_firewalls_catalog.py`
- pre-commit hook: ruff, prettier, knip, and `pnpm check-types`
