### PR TITLE
fix: require auth write for Deel magic links

### DIFF
--- a/crates/runner/mitm-addon/src/generated/builtin_firewalls/deel_0.py
+++ b/crates/runner/mitm-addon/src/generated/builtin_firewalls/deel_0.py
@@ -89,6 +89,7 @@ JSON_PART = r"""{
         {
           "name": "auth:write",
           "rules": [
+            "POST /rest/v2/magic-link",
             "POST /rest/v2/managers/magic-links"
           ]
         },
@@ -633,7 +634,6 @@ JSON_PART = r"""{
             "GET /rest/v2/immigration/workers/cases/{case_id}",
             "GET /rest/v2/immigration/workers/{worker_id}/cases/{case_id}/required-document",
             "GET /rest/v2/immigration/workers/{worker_id}/onboarding-case",
-            "POST /rest/v2/magic-link",
             "GET /rest/v2/payouts/auto-withdrawal-setting",
             "GET /rest/v2/payouts/balances",
             "GET /rest/v2/payouts/contractors/methods",

--- a/crates/runner/mitm-addon/tests/test_firewall_network_policy_decisions.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_network_policy_decisions.py
@@ -44,6 +44,25 @@ class TestFirewallNetworkPolicyDecisions:
             }
         }
 
+    def _deel_firewall(self):
+        return [builtin_firewalls.BUILTIN_FIREWALLS["deel"]]
+
+    def _deel_policy_allowing(self, *allowed_permissions: str):
+        firewall = builtin_firewalls.BUILTIN_FIREWALLS["deel"]
+        names = {
+            permission["name"]
+            for api in firewall["apis"]
+            for permission in api.get("permissions", [])
+        }
+        allowed = set(allowed_permissions)
+        return {
+            "deel": {
+                "allow": sorted(allowed),
+                "deny": sorted(names - allowed),
+                "unknownPolicy": "deny",
+            }
+        }
+
     def test_allowed_permission_passes(self):
         policies = {
             "github": {"allow": ["repo-read"], "deny": ["repo-write"], "unknownPolicy": "deny"}
@@ -116,6 +135,34 @@ class TestFirewallNetworkPolicyDecisions:
         assert upload_result.permission == "files.write"
         assert isinstance(resumable_result, matching.FirewallAllow)
         assert resumable_result.permission == "files.write"
+
+    def test_deel_worker_read_does_not_allow_magic_link_creation(self):
+        policies = self._deel_policy_allowing("worker:read")
+
+        result = match_request_with_raw_firewalls(
+            "https://api.letsdeel.com/rest/v2/magic-link",
+            "POST",
+            self._deel_firewall(),
+            network_policies=policies,
+        )
+
+        assert isinstance(result, matching.FirewallBlock)
+        assert result.permissions == ("auth:write",)
+        assert result.reason == "permission_denied"
+
+    def test_deel_auth_write_allows_magic_link_creation(self):
+        policies = self._deel_policy_allowing("auth:write")
+
+        result = match_request_with_raw_firewalls(
+            "https://api.letsdeel.com/rest/v2/magic-link",
+            "POST",
+            self._deel_firewall(),
+            network_policies=policies,
+        )
+
+        assert isinstance(result, matching.FirewallAllow)
+        assert result.permission == "auth:write"
+        assert result.rule == "POST /rest/v2/magic-link"
 
     def test_denied_permission_blocked(self):
         policies = {

--- a/turbo/packages/connectors/src/__tests__/firewalls/deel.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewalls/deel.test.ts
@@ -81,6 +81,11 @@ describe("deel firewall", () => {
     ]);
   });
 
+  it("requires auth write for magic link creation", () => {
+    expectDeelMatches("POST", "/rest/v2/magic-link", ["auth:write"]);
+    expectDeelMatches("POST", "/rest/v2/managers/magic-links", ["auth:write"]);
+  });
+
   it("maps cross-resource alternatives to the route resource owner", () => {
     expectDeelMatches("GET", "/rest/v2/legal-entities", ["organizations:read"]);
     expectDeelMatches("GET", "/rest/v2/people/me", ["people:read"]);

--- a/turbo/packages/firewalls-generator/src/deel.ts
+++ b/turbo/packages/firewalls-generator/src/deel.ts
@@ -53,6 +53,11 @@ interface DeelScope {
   readonly action: string;
 }
 
+interface DeelDocumentedScopeRemap {
+  readonly expectedScopes: readonly string[];
+  readonly targetScope: string;
+}
+
 const RUNTIME_METHODS = [
   "GET",
   "POST",
@@ -120,6 +125,24 @@ function parseScope(scope: string): DeelScope {
 
 function uniqueValues(values: readonly string[]): string[] {
   return [...new Set(values)];
+}
+
+function sortedUniqueValues(values: readonly string[]): string[] {
+  return uniqueValues(values).sort((left, right) => {
+    return left.localeCompare(right);
+  });
+}
+
+function scopeSetsEqual(
+  left: readonly string[],
+  right: readonly string[],
+): boolean {
+  const sortedLeft = sortedUniqueValues(left);
+  const sortedRight = sortedUniqueValues(right);
+  if (sortedLeft.length !== sortedRight.length) return false;
+  return sortedLeft.every((scope, index) => {
+    return scope === sortedRight[index];
+  });
 }
 
 function scopeActionRank(method: string, scope: DeelScope): number {
@@ -298,6 +321,15 @@ const SCOPE_OVERRIDES: Record<string, string> = {
   "GET /rest/v2/hris/positions/profile/{hrisProfileId}": "profile:read",
 };
 
+// Documented-scope remaps preserve vm0 permission semantics when Deel's
+// official token scope label is too broad for an agent-facing permission.
+const DOCUMENTED_SCOPE_REMAPS: Record<string, DeelDocumentedScopeRemap> = {
+  "POST /rest/v2/magic-link": {
+    expectedScopes: ["worker:read"],
+    targetScope: "auth:write",
+  },
+};
+
 // ── Scopeless endpoints ──────────────────────────────────────────────────
 // Endpoints that are intentionally denied (different auth or sensitive).
 // Unknown scopeless endpoints cause a build error.
@@ -329,6 +361,7 @@ function buildGroups(spec: DeelSpec): {
 } {
   const groups = new Map<string, Set<string>>();
   const unknownScopeless: string[] = [];
+  const seenDocumentedScopeRemaps = new Set<string>();
 
   for (const [path, methods] of Object.entries(spec.paths ?? {})) {
     for (const [method, op] of Object.entries(methods)) {
@@ -337,7 +370,27 @@ function buildGroups(spec: DeelSpec): {
       const httpMethod = method.toUpperCase();
       const rule = `${httpMethod} /rest/v2${path}`;
       const description = op.description ?? "";
-      const scopes = extractScopes(description);
+      let scopes = extractScopes(description);
+
+      const documentedScopeRemap = DOCUMENTED_SCOPE_REMAPS[rule];
+      if (documentedScopeRemap) {
+        seenDocumentedScopeRemaps.add(rule);
+        if (scopes.length === 0) {
+          throw new Error(
+            `Stale Deel documented scope remap for ${rule}: endpoint no longer has official scopes`,
+          );
+        }
+        if (!scopeSetsEqual(scopes, documentedScopeRemap.expectedScopes)) {
+          throw new Error(
+            `Stale Deel documented scope remap for ${rule}: official scopes are ${sortedUniqueValues(
+              scopes,
+            ).join(", ")}, expected ${sortedUniqueValues(
+              documentedScopeRemap.expectedScopes,
+            ).join(", ")}`,
+          );
+        }
+        scopes = [documentedScopeRemap.targetScope];
+      }
 
       // Apply manual overrides for endpoints missing scopes in spec
       const override = SCOPE_OVERRIDES[rule];
@@ -376,6 +429,14 @@ function buildGroups(spec: DeelSpec): {
         groups.set(primaryScope, ruleSet);
       }
       ruleSet.add(rule);
+    }
+  }
+
+  for (const rule of Object.keys(DOCUMENTED_SCOPE_REMAPS).sort()) {
+    if (!seenDocumentedScopeRemaps.has(rule)) {
+      throw new Error(
+        `Stale Deel documented scope remap for ${rule}: endpoint was not found in cached specs`,
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
- remap Deel's documented `POST /rest/v2/magic-link` scope from the broad `worker:read` label to the existing agent-facing `auth:write` permission
- fail generation if Deel changes or removes that documented scope so the remap cannot silently go stale
- update generated runner builtin firewall data and add TypeScript plus MITM policy regressions

Closes #18772

## Tests
- `cd turbo && pnpm -F @vm0/firewalls-generator generate:deel`
- `cd turbo && pnpm -F @vm0/api-contracts generate:rust`
- `cd turbo && pnpm -F @vm0/connectors exec vitest src/__tests__/firewalls/deel.test.ts --run`
- `cd turbo && pnpm -F @vm0/api-contracts exec vitest src/rust-bindings/__tests__/builtin-firewall-catalog.test.ts --run`
- `cd turbo && pnpm -F @vm0/firewalls-generator check-types`
- `cd turbo && pnpm -F @vm0/connectors check-types`
- `cd turbo && pnpm -F @vm0/connectors lint`
- `cd turbo && pnpm -F @vm0/api-contracts check-types`
- `cd turbo && pnpm format`
- `cd crates/runner/mitm-addon && python3 -m pytest tests/test_firewall_network_policy_decisions.py -v`
- `cd crates/runner/mitm-addon && python3 -m ruff check .`
- `cd crates/runner/mitm-addon && python3 -m ruff format --check .`
- `cd crates/runner/mitm-addon && python3 -m basedpyright -p .`
- pre-commit hook: `pnpm knip`, `pnpm check-types`, ruff/prettier checks