### PR TITLE
fix: harden guest runtime private file writes

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1359,6 +1359,7 @@ dependencies = [
 name = "guest-write-file"
 version = "0.1.2"
 dependencies = [
+ "guest-contracts",
  "libc",
  "tempfile",
 ]

--- a/crates/guest-contracts/src/runtime_paths.rs
+++ b/crates/guest-contracts/src/runtime_paths.rs
@@ -1,15 +1,27 @@
 //! Shared guest runtime path contract and private runtime file helpers.
 
 use std::env;
-use std::fs::{self, File, OpenOptions};
+use std::fs::File;
+#[cfg(not(unix))]
+use std::fs::{self, OpenOptions};
 use std::io;
+#[cfg(unix)]
+use std::path::Component;
 use std::path::{Path, PathBuf};
 
 #[cfg(unix)]
-use std::os::unix::fs::{DirBuilderExt, OpenOptionsExt, PermissionsExt};
+use std::ffi::{CString, OsStr};
+#[cfg(unix)]
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+#[cfg(unix)]
+use std::os::unix::ffi::OsStrExt;
 
 pub const GUEST_RUNTIME_DIR_ENV: &str = "VM0_GUEST_RUNTIME_DIR";
 const DEFAULT_RUNTIME_PARENT: &str = ".vm0/guest-agent/runs";
+#[cfg(unix)]
+const PRIVATE_DIR_MODE: libc::mode_t = 0o700;
+#[cfg(unix)]
+const PRIVATE_FILE_MODE: libc::mode_t = 0o600;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RuntimePathError {
@@ -143,8 +155,257 @@ pub fn telemetry_sandbox_ops_pos_file(run_dir: impl AsRef<Path>) -> PathBuf {
 }
 
 #[cfg(unix)]
-fn set_dir_private(path: &Path) -> io::Result<()> {
-    fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+fn permission_denied(message: String) -> io::Error {
+    io::Error::new(io::ErrorKind::PermissionDenied, message)
+}
+
+#[cfg(unix)]
+fn wrap_last_os_error(context: String) -> io::Error {
+    let error = io::Error::last_os_error();
+    io::Error::new(error.kind(), format!("{context}: {error}"))
+}
+
+#[cfg(unix)]
+fn wrap_io_error(error: io::Error, context: String) -> io::Error {
+    io::Error::new(error.kind(), format!("{context}: {error}"))
+}
+
+#[cfg(unix)]
+fn component_cstring(name: &OsStr, path: &Path) -> io::Result<CString> {
+    CString::new(name.as_bytes()).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "{} contains a NUL byte in component {}",
+                path.display(),
+                name.to_string_lossy()
+            ),
+        )
+    })
+}
+
+#[cfg(unix)]
+fn open_dir_root(path: &Path) -> io::Result<OwnedFd> {
+    let root = if path.is_absolute() { "/" } else { "." };
+    let root = CString::new(root).map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("invalid runtime directory root: {error}"),
+        )
+    })?;
+    // SAFETY: `root` is NUL-terminated and points to a static path string.
+    let fd = unsafe {
+        libc::open(
+            root.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC,
+        )
+    };
+    if fd < 0 {
+        return Err(wrap_last_os_error(format!(
+            "open runtime directory root for {}",
+            path.display()
+        )));
+    }
+    // SAFETY: `fd` is a fresh descriptor returned by `open`.
+    Ok(unsafe { OwnedFd::from_raw_fd(fd) })
+}
+
+#[cfg(unix)]
+fn dir_open_flags() -> libc::c_int {
+    libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC
+}
+
+#[cfg(unix)]
+fn validate_dir_fd(fd: &OwnedFd, path: &Path) -> io::Result<()> {
+    let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
+    // SAFETY: `stat` points to writable memory and `fd` owns a live descriptor.
+    let result = unsafe { libc::fstat(fd.as_raw_fd(), stat.as_mut_ptr()) };
+    if result != 0 {
+        return Err(wrap_last_os_error(format!(
+            "stat runtime directory {}",
+            path.display()
+        )));
+    }
+    // SAFETY: successful `fstat` initialized the full struct.
+    let stat = unsafe { stat.assume_init() };
+    if stat.st_mode & libc::S_IFMT != libc::S_IFDIR {
+        return Err(permission_denied(format!(
+            "{} is not a runtime directory",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn chmod_dir_fd(fd: &OwnedFd, path: &Path) -> io::Result<()> {
+    // SAFETY: `fd` owns a live directory descriptor.
+    let result = unsafe { libc::fchmod(fd.as_raw_fd(), PRIVATE_DIR_MODE) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(wrap_last_os_error(format!(
+            "chmod runtime directory {}",
+            path.display()
+        )))
+    }
+}
+
+#[cfg(unix)]
+fn dir_component_error(operation: &str, name: &OsStr, full_path: &Path) -> io::Error {
+    let error = io::Error::last_os_error();
+    match error.raw_os_error() {
+        Some(code) if code == libc::ELOOP => permission_denied(format!(
+            "{} contains symlink component {}; refusing to use it as runtime directory",
+            full_path.display(),
+            name.to_string_lossy()
+        )),
+        Some(code) if code == libc::ENOTDIR => permission_denied(format!(
+            "{} is not a directory; refusing to use it as runtime directory",
+            full_path.display()
+        )),
+        _ => io::Error::new(
+            error.kind(),
+            format!(
+                "{operation} runtime directory component {} for {}: {error}",
+                name.to_string_lossy(),
+                full_path.display()
+            ),
+        ),
+    }
+}
+
+#[cfg(unix)]
+fn component_path(parent_path: &Path, name: &OsStr) -> PathBuf {
+    let mut path = parent_path.to_path_buf();
+    path.push(Path::new(name));
+    path
+}
+
+#[cfg(unix)]
+fn open_or_create_dir_component(
+    parent: &OwnedFd,
+    parent_path: &Path,
+    name: &OsStr,
+    full_path: &Path,
+    is_final: bool,
+) -> io::Result<OwnedFd> {
+    let name_c = component_cstring(name, full_path)?;
+    let path = component_path(parent_path, name);
+    // SAFETY: `name_c` is NUL-terminated and `parent` owns a live directory fd.
+    let mut fd = unsafe { libc::openat(parent.as_raw_fd(), name_c.as_ptr(), dir_open_flags()) };
+    if fd < 0 && io::Error::last_os_error().raw_os_error() == Some(libc::ENOENT) {
+        // SAFETY: `name_c` is NUL-terminated and `parent` owns a live directory fd.
+        let mkdir_result =
+            unsafe { libc::mkdirat(parent.as_raw_fd(), name_c.as_ptr(), PRIVATE_DIR_MODE) };
+        if mkdir_result != 0 && io::Error::last_os_error().raw_os_error() != Some(libc::EEXIST) {
+            return Err(wrap_last_os_error(format!(
+                "create runtime directory component {} for {}",
+                name.to_string_lossy(),
+                full_path.display()
+            )));
+        }
+        // SAFETY: `name_c` is NUL-terminated and `parent` owns a live directory fd.
+        fd = unsafe { libc::openat(parent.as_raw_fd(), name_c.as_ptr(), dir_open_flags()) };
+    }
+    if fd < 0 {
+        return Err(dir_component_error("open", name, full_path));
+    }
+
+    // SAFETY: `fd` is a fresh descriptor returned by `openat`.
+    let fd = unsafe { OwnedFd::from_raw_fd(fd) };
+    validate_dir_fd(&fd, &path)?;
+    if is_final {
+        chmod_dir_fd(&fd, &path)?;
+    }
+    Ok(fd)
+}
+
+#[cfg(unix)]
+fn open_or_create_private_dir(path: &Path) -> io::Result<OwnedFd> {
+    if path.as_os_str().is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "runtime directory path is empty",
+        ));
+    }
+    validate_dir_path_components(path)?;
+
+    let mut current = open_dir_root(path)?;
+    let mut current_path = if path.is_absolute() {
+        PathBuf::from("/")
+    } else {
+        PathBuf::from(".")
+    };
+    let mut components = path.components().peekable();
+    let mut saw_normal_component = false;
+
+    while let Some(component) = components.next() {
+        match component {
+            Component::RootDir | Component::CurDir => {}
+            Component::ParentDir => {
+                return Err(permission_denied(format!(
+                    "{} contains a parent directory segment",
+                    path.display()
+                )));
+            }
+            Component::Normal(name) => {
+                saw_normal_component = true;
+                let is_final = components.peek().is_none();
+                current =
+                    open_or_create_dir_component(&current, &current_path, name, path, is_final)?;
+                current_path = component_path(&current_path, name);
+            }
+            Component::Prefix(prefix) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "{} contains unsupported path prefix {}",
+                        path.display(),
+                        prefix.as_os_str().to_string_lossy()
+                    ),
+                ));
+            }
+        }
+    }
+
+    if !saw_normal_component {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "runtime directory path has no components: {}",
+                path.display()
+            ),
+        ));
+    }
+
+    Ok(current)
+}
+
+#[cfg(unix)]
+fn validate_dir_path_components(path: &Path) -> io::Result<()> {
+    for component in path.components() {
+        match component {
+            Component::RootDir | Component::CurDir | Component::Normal(_) => {}
+            Component::ParentDir => {
+                return Err(permission_denied(format!(
+                    "{} contains a parent directory segment",
+                    path.display()
+                )));
+            }
+            Component::Prefix(prefix) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "{} contains unsupported path prefix {}",
+                        path.display(),
+                        prefix.as_os_str().to_string_lossy()
+                    ),
+                ));
+            }
+        }
+    }
+    Ok(())
 }
 
 #[cfg(not(unix))]
@@ -156,15 +417,14 @@ pub fn ensure_dir(path: impl AsRef<Path>) -> io::Result<()> {
     let path = path.as_ref();
     #[cfg(unix)]
     {
-        let mut builder = fs::DirBuilder::new();
-        builder.recursive(true).mode(0o700);
-        builder.create(path)?;
+        open_or_create_private_dir(path)?;
+        Ok(())
     }
     #[cfg(not(unix))]
     {
         fs::create_dir_all(path)?;
+        set_dir_private(path)
     }
-    set_dir_private(path)
 }
 
 pub fn ensure_parent_dir(path: impl AsRef<Path>) -> io::Result<()> {
@@ -178,18 +438,6 @@ pub fn ensure_parent_dir(path: impl AsRef<Path>) -> io::Result<()> {
     ensure_dir(parent)
 }
 
-#[cfg(unix)]
-fn private_file_options() -> OpenOptions {
-    let mut options = OpenOptions::new();
-    options
-        .write(true)
-        .create(true)
-        .truncate(true)
-        .mode(0o600)
-        .custom_flags(libc::O_NOFOLLOW);
-    options
-}
-
 #[cfg(not(unix))]
 fn private_file_options() -> OpenOptions {
     let mut options = OpenOptions::new();
@@ -199,7 +447,13 @@ fn private_file_options() -> OpenOptions {
 
 #[cfg(unix)]
 fn set_file_private(file: &File) -> io::Result<()> {
-    file.set_permissions(fs::Permissions::from_mode(0o600))
+    // SAFETY: `file` owns a live descriptor.
+    let result = unsafe { libc::fchmod(file.as_raw_fd(), PRIVATE_FILE_MODE) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(wrap_last_os_error("chmod runtime file".to_string()))
+    }
 }
 
 #[cfg(not(unix))]
@@ -207,6 +461,100 @@ fn set_file_private(_file: &File) -> io::Result<()> {
     Ok(())
 }
 
+#[cfg(unix)]
+fn file_name(path: &Path) -> io::Result<&OsStr> {
+    path.file_name()
+        .filter(|name| !name.is_empty() && *name != "." && *name != "..")
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("runtime path has no file name: {}", path.display()),
+            )
+        })
+}
+
+#[cfg(unix)]
+fn parent_dir(path: &Path) -> io::Result<&Path> {
+    path.parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("runtime path has no parent: {}", path.display()),
+            )
+        })
+}
+
+#[cfg(unix)]
+fn open_private_file(path: &Path, append: bool) -> io::Result<File> {
+    let parent = parent_dir(path)?;
+    let parent = open_or_create_private_dir(parent)?;
+    let name = file_name(path)?;
+    let name_c = component_cstring(name, path)?;
+    let mut flags =
+        libc::O_WRONLY | libc::O_CREAT | libc::O_NOFOLLOW | libc::O_CLOEXEC | libc::O_NONBLOCK;
+    if append {
+        flags |= libc::O_APPEND;
+    } else {
+        flags |= libc::O_TRUNC;
+    }
+
+    // SAFETY: `name_c` is NUL-terminated and `parent` owns a verified directory fd.
+    let fd = unsafe {
+        libc::openat(
+            parent.as_raw_fd(),
+            name_c.as_ptr(),
+            flags,
+            PRIVATE_FILE_MODE,
+        )
+    };
+    if fd < 0 {
+        let error = io::Error::last_os_error();
+        let error = if error.raw_os_error() == Some(libc::ELOOP) {
+            permission_denied(format!(
+                "{} is a symlink; refusing to use it as runtime file",
+                path.display()
+            ))
+        } else {
+            wrap_io_error(error, format!("open runtime file {}", path.display()))
+        };
+        return Err(error);
+    }
+    // SAFETY: `fd` is a fresh descriptor returned by `openat`.
+    let file = unsafe { File::from_raw_fd(fd) };
+    secure_regular_private_file(&file, path)?;
+    Ok(file)
+}
+
+#[cfg(unix)]
+fn secure_regular_private_file(file: &File, path: &Path) -> io::Result<()> {
+    let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
+    // SAFETY: `stat` points to writable memory and `file` owns a live descriptor.
+    let result = unsafe { libc::fstat(file.as_raw_fd(), stat.as_mut_ptr()) };
+    if result != 0 {
+        return Err(wrap_last_os_error(format!(
+            "stat runtime file {}",
+            path.display()
+        )));
+    }
+    // SAFETY: successful `fstat` initialized the full struct.
+    let stat = unsafe { stat.assume_init() };
+    if stat.st_mode & libc::S_IFMT != libc::S_IFREG {
+        return Err(permission_denied(format!(
+            "{} is not a regular runtime file",
+            path.display()
+        )));
+    }
+    set_file_private(file)?;
+    Ok(())
+}
+
+#[cfg(unix)]
+pub fn create_private(path: impl AsRef<Path>) -> io::Result<File> {
+    open_private_file(path.as_ref(), false)
+}
+
+#[cfg(not(unix))]
 pub fn create_private(path: impl AsRef<Path>) -> io::Result<File> {
     let path = path.as_ref();
     ensure_parent_dir(path)?;
@@ -225,17 +573,6 @@ pub fn write_private(path: impl AsRef<Path>, bytes: impl AsRef<[u8]>) -> io::Res
     std::io::Write::write_all(&mut file, bytes.as_ref())
 }
 
-#[cfg(unix)]
-fn private_append_options() -> OpenOptions {
-    let mut options = OpenOptions::new();
-    options
-        .create(true)
-        .append(true)
-        .mode(0o600)
-        .custom_flags(libc::O_NOFOLLOW);
-    options
-}
-
 #[cfg(not(unix))]
 fn private_append_options() -> OpenOptions {
     let mut options = OpenOptions::new();
@@ -243,6 +580,12 @@ fn private_append_options() -> OpenOptions {
     options
 }
 
+#[cfg(unix)]
+pub fn open_private_append(path: impl AsRef<Path>) -> io::Result<File> {
+    open_private_file(path.as_ref(), true)
+}
+
+#[cfg(not(unix))]
 pub fn open_private_append(path: impl AsRef<Path>) -> io::Result<File> {
     let path = path.as_ref();
     ensure_parent_dir(path)?;
@@ -264,6 +607,8 @@ fn path_is_under(path: &Path, parent: &Path) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
 
     #[test]
     fn canonical_paths_are_not_under_tmp() {
@@ -366,6 +711,80 @@ mod tests {
             std::os::unix::fs::symlink(&target, &link).unwrap();
             assert!(open_private_append(&link).is_err());
             assert_eq!(std::fs::read(&target).unwrap(), b"secret");
+        }
+    }
+
+    #[test]
+    fn write_private_rejects_symlink_parent_without_touching_target() {
+        let temp = tempfile::tempdir().unwrap();
+        let target = temp.path().join("target");
+        let link = temp.path().join("link");
+        std::fs::create_dir(&target).unwrap();
+
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink(&target, &link).unwrap();
+
+            let error = write_private(link.join("system.log"), b"new").unwrap_err();
+
+            assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+            assert!(!target.join("system.log").exists());
+        }
+    }
+
+    #[test]
+    fn create_private_rejects_symlink_parent_without_touching_target() {
+        let temp = tempfile::tempdir().unwrap();
+        let target = temp.path().join("target");
+        let link = temp.path().join("link");
+        std::fs::create_dir(&target).unwrap();
+
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink(&target, &link).unwrap();
+
+            let error = create_private(link.join("agent.jsonl")).unwrap_err();
+
+            assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+            assert!(!target.join("agent.jsonl").exists());
+        }
+    }
+
+    #[test]
+    fn open_private_append_rejects_symlink_parent_without_touching_target() {
+        let temp = tempfile::tempdir().unwrap();
+        let target = temp.path().join("target");
+        let link = temp.path().join("link");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("metrics.jsonl"), b"secret").unwrap();
+
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink(&target, &link).unwrap();
+
+            let error = open_private_append(link.join("metrics.jsonl")).unwrap_err();
+
+            assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+            assert_eq!(
+                std::fs::read(target.join("metrics.jsonl")).unwrap(),
+                b"secret"
+            );
+        }
+    }
+
+    #[test]
+    fn ensure_dir_rejects_parent_segment_before_creating_missing_prefix() {
+        let temp = tempfile::tempdir().unwrap();
+        let base = temp.path().join("base");
+        std::fs::create_dir(&base).unwrap();
+
+        #[cfg(unix)]
+        {
+            let error = ensure_dir(base.join("missing").join("..").join("leaf")).unwrap_err();
+
+            assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+            assert!(!base.join("missing").exists());
+            assert!(!base.join("leaf").exists());
         }
     }
 }

--- a/crates/guest-contracts/src/runtime_paths.rs
+++ b/crates/guest-contracts/src/runtime_paths.rs
@@ -252,6 +252,29 @@ fn chmod_dir_fd(fd: &OwnedFd, path: &Path) -> io::Result<()> {
 }
 
 #[cfg(target_os = "linux")]
+fn chmod_proc_fd_path(fd: &OwnedFd, name: &OsStr, full_path: &Path) -> io::Result<()> {
+    let proc_fd_path =
+        CString::new(format!("/proc/self/fd/{}", fd.as_raw_fd())).map_err(|error| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("invalid proc fd path while chmodding runtime directory: {error}"),
+            )
+        })?;
+    // SAFETY: `proc_fd_path` is NUL-terminated and points to this process's
+    // still-open O_PATH fd, so chmod applies to the pinned directory.
+    let result = unsafe { libc::chmod(proc_fd_path.as_ptr(), PRIVATE_DIR_MODE) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(wrap_last_os_error(format!(
+            "chmod newly-created runtime directory component {} for {} through proc fd",
+            name.to_string_lossy(),
+            full_path.display()
+        )))
+    }
+}
+
+#[cfg(target_os = "linux")]
 fn chmod_created_dir_component(
     parent: &OwnedFd,
     name: &OsStr,
@@ -293,10 +316,10 @@ fn chmod_created_dir_component(
         error.raw_os_error(),
         Some(libc::EINVAL | libc::ENOSYS | libc::EOPNOTSUPP)
     ) {
-        // Older kernels may not support fchmodat(AT_EMPTY_PATH). The regular
-        // openat + fchmod path below still fixes modes when the umask left owner
-        // access intact, which is the common guest case.
-        return Ok(());
+        // Older kernels may not support fchmodat(AT_EMPTY_PATH). The O_PATH fd
+        // still pins the directory, so chmod through /proc/self/fd instead of
+        // falling back to the original path.
+        return chmod_proc_fd_path(&fd, name, full_path);
     }
 
     Err(io::Error::new(
@@ -683,6 +706,10 @@ fn path_is_under(path: &Path, parent: &Path) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(target_os = "linux")]
+    use std::os::fd::FromRawFd;
+    #[cfg(target_os = "linux")]
+    use std::os::unix::ffi::OsStrExt;
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
 
@@ -752,6 +779,30 @@ mod tests {
             assert_eq!(mode(temp.path().join("run/logs")), 0o700);
             assert_eq!(mode(&path), 0o600);
         }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn chmod_proc_fd_path_updates_o_path_directory() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("run");
+        std::fs::create_dir(&path).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o000)).unwrap();
+        let path_c = CString::new(path.as_os_str().as_bytes()).unwrap();
+        // SAFETY: `path_c` is NUL-terminated and points to the test directory.
+        let raw_fd = unsafe {
+            libc::open(
+                path_c.as_ptr(),
+                libc::O_PATH | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+            )
+        };
+        assert!(raw_fd >= 0, "open O_PATH: {}", io::Error::last_os_error());
+        // SAFETY: `raw_fd` is a fresh descriptor returned by `open`.
+        let fd = unsafe { OwnedFd::from_raw_fd(raw_fd) };
+
+        chmod_proc_fd_path(&fd, OsStr::new("run"), &path).unwrap();
+
+        assert_eq!(mode(&path), 0o700);
     }
 
     #[test]

--- a/crates/guest-contracts/src/runtime_paths.rs
+++ b/crates/guest-contracts/src/runtime_paths.rs
@@ -251,6 +251,63 @@ fn chmod_dir_fd(fd: &OwnedFd, path: &Path) -> io::Result<()> {
     }
 }
 
+#[cfg(target_os = "linux")]
+fn chmod_created_dir_component(
+    parent: &OwnedFd,
+    name: &OsStr,
+    name_c: &CString,
+    full_path: &Path,
+) -> io::Result<()> {
+    // `mkdirat` applies the process umask. Open the directory with O_PATH first
+    // so a restrictive umask cannot prevent us from correcting the mode.
+    // SAFETY: `name_c` is NUL-terminated and `parent` owns a live directory fd.
+    let fd = unsafe {
+        libc::openat(
+            parent.as_raw_fd(),
+            name_c.as_ptr(),
+            libc::O_PATH | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    if fd < 0 {
+        return Err(dir_component_error("open newly-created", name, full_path));
+    }
+    // SAFETY: `fd` is a fresh descriptor returned by `openat`.
+    let fd = unsafe { OwnedFd::from_raw_fd(fd) };
+    let empty_path = b"\0";
+    // SAFETY: `fd` owns a live O_PATH directory descriptor and empty_path is
+    // NUL-terminated for AT_EMPTY_PATH.
+    let result = unsafe {
+        libc::fchmodat(
+            fd.as_raw_fd(),
+            empty_path.as_ptr().cast(),
+            PRIVATE_DIR_MODE,
+            libc::AT_EMPTY_PATH,
+        )
+    };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(wrap_last_os_error(format!(
+            "chmod newly-created runtime directory component {} for {}",
+            name.to_string_lossy(),
+            full_path.display()
+        )))
+    }
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+fn chmod_created_dir_component(
+    _parent: &OwnedFd,
+    _name: &OsStr,
+    _name_c: &CString,
+    _full_path: &Path,
+) -> io::Result<()> {
+    // Non-Linux Unix targets do not have Linux's O_PATH + AT_EMPTY_PATH fd-only
+    // chmod flow. Keep the secure fd validation path below instead of adding a
+    // path-based chmod race for non-guest development targets.
+    Ok(())
+}
+
 #[cfg(unix)]
 fn dir_component_error(operation: &str, name: &OsStr, full_path: &Path) -> io::Error {
     let error = io::Error::last_os_error();
@@ -294,6 +351,7 @@ fn open_or_create_dir_component(
     let path = component_path(parent_path, name);
     // SAFETY: `name_c` is NUL-terminated and `parent` owns a live directory fd.
     let mut fd = unsafe { libc::openat(parent.as_raw_fd(), name_c.as_ptr(), dir_open_flags()) };
+    let mut created = false;
     if fd < 0 && io::Error::last_os_error().raw_os_error() == Some(libc::ENOENT) {
         // SAFETY: `name_c` is NUL-terminated and `parent` owns a live directory fd.
         let mkdir_result =
@@ -305,6 +363,10 @@ fn open_or_create_dir_component(
                 full_path.display()
             )));
         }
+        if mkdir_result == 0 {
+            created = true;
+            chmod_created_dir_component(parent, name, &name_c, full_path)?;
+        }
         // SAFETY: `name_c` is NUL-terminated and `parent` owns a live directory fd.
         fd = unsafe { libc::openat(parent.as_raw_fd(), name_c.as_ptr(), dir_open_flags()) };
     }
@@ -315,7 +377,7 @@ fn open_or_create_dir_component(
     // SAFETY: `fd` is a fresh descriptor returned by `openat`.
     let fd = unsafe { OwnedFd::from_raw_fd(fd) };
     validate_dir_fd(&fd, &path)?;
-    if is_final {
+    if is_final || created {
         chmod_dir_fd(&fd, &path)?;
     }
     Ok(fd)
@@ -610,6 +672,11 @@ mod tests {
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
 
+    #[cfg(unix)]
+    fn mode(path: impl AsRef<Path>) -> u32 {
+        std::fs::metadata(path).unwrap().permissions().mode() & 0o777
+    }
+
     #[test]
     fn canonical_paths_are_not_under_tmp() {
         let run_dir =
@@ -667,20 +734,9 @@ mod tests {
         assert_eq!(std::fs::read(&path).unwrap(), b"hello");
         #[cfg(unix)]
         {
-            let run_mode = std::fs::metadata(temp.path().join("run"))
-                .unwrap()
-                .permissions()
-                .mode()
-                & 0o777;
-            let logs_mode = std::fs::metadata(temp.path().join("run/logs"))
-                .unwrap()
-                .permissions()
-                .mode()
-                & 0o777;
-            let file_mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
-            assert_eq!(run_mode, 0o700);
-            assert_eq!(logs_mode, 0o700);
-            assert_eq!(file_mode, 0o600);
+            assert_eq!(mode(temp.path().join("run")), 0o700);
+            assert_eq!(mode(temp.path().join("run/logs")), 0o700);
+            assert_eq!(mode(&path), 0o600);
         }
     }
 

--- a/crates/guest-contracts/src/runtime_paths.rs
+++ b/crates/guest-contracts/src/runtime_paths.rs
@@ -238,28 +238,6 @@ fn validate_dir_fd(fd: &OwnedFd, path: &Path) -> io::Result<()> {
 }
 
 #[cfg(unix)]
-fn validate_private_dir_mode(fd: &OwnedFd, path: &Path) -> io::Result<()> {
-    let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
-    // SAFETY: `stat` points to writable memory and `fd` owns a live descriptor.
-    let result = unsafe { libc::fstat(fd.as_raw_fd(), stat.as_mut_ptr()) };
-    if result != 0 {
-        return Err(wrap_last_os_error(format!(
-            "stat runtime directory {}",
-            path.display()
-        )));
-    }
-    // SAFETY: successful `fstat` initialized the full struct.
-    let stat = unsafe { stat.assume_init() };
-    if stat.st_mode & 0o777 != PRIVATE_DIR_MODE {
-        return Err(permission_denied(format!(
-            "{} is not a private runtime directory",
-            path.display()
-        )));
-    }
-    Ok(())
-}
-
-#[cfg(unix)]
 fn chmod_dir_fd(fd: &OwnedFd, path: &Path) -> io::Result<()> {
     // SAFETY: `fd` owns a live directory descriptor.
     let result = unsafe { libc::fchmod(fd.as_raw_fd(), PRIVATE_DIR_MODE) };
@@ -314,7 +292,13 @@ fn chmod_created_dir_component(
         )
     };
     if fd < 0 {
-        return Err(dir_component_error("open newly-created", name, full_path));
+        return Err(dir_component_error(
+            "open newly-created",
+            parent,
+            name,
+            name_c,
+            full_path,
+        ));
     }
     // SAFETY: `fd` is a fresh descriptor returned by `openat`.
     let fd = unsafe { OwnedFd::from_raw_fd(fd) };
@@ -368,7 +352,34 @@ fn chmod_created_dir_component(
 }
 
 #[cfg(unix)]
-fn dir_component_error(operation: &str, name: &OsStr, full_path: &Path) -> io::Error {
+fn component_is_symlink(parent: &OwnedFd, name_c: &CString) -> io::Result<bool> {
+    let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
+    // SAFETY: `name_c` is NUL-terminated, `parent` owns a live directory fd,
+    // and `stat` points to writable memory.
+    let result = unsafe {
+        libc::fstatat(
+            parent.as_raw_fd(),
+            name_c.as_ptr(),
+            stat.as_mut_ptr(),
+            libc::AT_SYMLINK_NOFOLLOW,
+        )
+    };
+    if result != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: successful `fstatat` initialized the full struct.
+    let stat = unsafe { stat.assume_init() };
+    Ok(stat.st_mode & libc::S_IFMT == libc::S_IFLNK)
+}
+
+#[cfg(unix)]
+fn dir_component_error(
+    operation: &str,
+    parent: &OwnedFd,
+    name: &OsStr,
+    name_c: &CString,
+    full_path: &Path,
+) -> io::Error {
     let error = io::Error::last_os_error();
     match error.raw_os_error() {
         Some(code) if code == libc::ELOOP => permission_denied(format!(
@@ -376,10 +387,28 @@ fn dir_component_error(operation: &str, name: &OsStr, full_path: &Path) -> io::E
             full_path.display(),
             name.to_string_lossy()
         )),
-        Some(code) if code == libc::ENOTDIR => permission_denied(format!(
-            "{} is not a directory; refusing to use it as runtime directory",
-            full_path.display()
-        )),
+        Some(code) if code == libc::ENOTDIR => match component_is_symlink(parent, name_c) {
+            Ok(true) => permission_denied(format!(
+                "{} contains symlink component {}; refusing to use it as runtime directory",
+                full_path.display(),
+                name.to_string_lossy()
+            )),
+            Ok(false) => io::Error::new(
+                io::ErrorKind::NotADirectory,
+                format!(
+                    "{} is not a directory; refusing to use it as runtime directory",
+                    full_path.display()
+                ),
+            ),
+            Err(stat_error) => io::Error::new(
+                error.kind(),
+                format!(
+                    "{operation} runtime directory component {} for {}: {error}; failed to inspect component after ENOTDIR: {stat_error}",
+                    name.to_string_lossy(),
+                    full_path.display()
+                ),
+            ),
+        },
         _ => io::Error::new(
             error.kind(),
             format!(
@@ -405,7 +434,6 @@ fn open_or_create_dir_component(
     name: &OsStr,
     full_path: &Path,
     is_final: bool,
-    chmod_existing_final: bool,
 ) -> io::Result<OwnedFd> {
     let name_c = component_cstring(name, full_path)?;
     let path = component_path(parent_path, name);
@@ -431,25 +459,22 @@ fn open_or_create_dir_component(
         fd = unsafe { libc::openat(parent.as_raw_fd(), name_c.as_ptr(), dir_open_flags()) };
     }
     if fd < 0 {
-        return Err(dir_component_error("open", name, full_path));
+        return Err(dir_component_error(
+            "open", parent, name, &name_c, full_path,
+        ));
     }
 
     // SAFETY: `fd` is a fresh descriptor returned by `openat`.
     let fd = unsafe { OwnedFd::from_raw_fd(fd) };
     validate_dir_fd(&fd, &path)?;
-    if created || (is_final && chmod_existing_final) {
+    if is_final || created {
         chmod_dir_fd(&fd, &path)?;
-    } else if is_final {
-        validate_private_dir_mode(&fd, &path)?;
     }
     Ok(fd)
 }
 
 #[cfg(unix)]
-fn open_or_create_private_dir_with_options(
-    path: &Path,
-    chmod_existing_final: bool,
-) -> io::Result<OwnedFd> {
+fn open_or_create_private_dir(path: &Path) -> io::Result<OwnedFd> {
     if path.as_os_str().is_empty() {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -479,14 +504,8 @@ fn open_or_create_private_dir_with_options(
             Component::Normal(name) => {
                 saw_normal_component = true;
                 let is_final = components.peek().is_none();
-                current = open_or_create_dir_component(
-                    &current,
-                    &current_path,
-                    name,
-                    path,
-                    is_final,
-                    chmod_existing_final,
-                )?;
+                current =
+                    open_or_create_dir_component(&current, &current_path, name, path, is_final)?;
                 current_path = component_path(&current_path, name);
             }
             Component::Prefix(prefix) => {
@@ -513,16 +532,6 @@ fn open_or_create_private_dir_with_options(
     }
 
     Ok(current)
-}
-
-#[cfg(unix)]
-fn open_or_create_private_dir(path: &Path) -> io::Result<OwnedFd> {
-    open_or_create_private_dir_with_options(path, true)
-}
-
-#[cfg(unix)]
-fn open_private_file_parent_dir(path: &Path) -> io::Result<OwnedFd> {
-    open_or_create_private_dir_with_options(path, false)
 }
 
 #[cfg(unix)]
@@ -642,7 +651,7 @@ fn parent_dir(path: &Path) -> io::Result<&Path> {
 fn open_private_file(path: &Path, append: bool) -> io::Result<File> {
     let name = file_name(path)?;
     let parent = parent_dir(path)?;
-    let parent = open_private_file_parent_dir(parent)?;
+    let parent = open_or_create_private_dir(parent)?;
     let name_c = component_cstring(name, path)?;
     let mut flags =
         libc::O_WRONLY | libc::O_CREAT | libc::O_NOFOLLOW | libc::O_CLOEXEC | libc::O_NONBLOCK;
@@ -706,8 +715,8 @@ fn secure_regular_private_file(file: &File, path: &Path) -> io::Result<()> {
 /// Create or truncate a runtime-private file.
 ///
 /// On Unix, missing parent directories are created with private permissions,
-/// symlinked parent components are rejected, and an existing final parent
-/// directory must already be private.
+/// symlinked parent components are rejected, and private permissions are
+/// enforced on the final parent directory.
 pub fn create_private(path: impl AsRef<Path>) -> io::Result<File> {
     open_private_file(path.as_ref(), false)
 }
@@ -729,9 +738,8 @@ pub fn create_private(path: impl AsRef<Path>) -> io::Result<File> {
 /// Write bytes to a runtime-private file.
 ///
 /// On Unix, missing parent directories are created with private permissions,
-/// symlinked parent components are rejected, and an existing final parent
-/// directory must already be private. This avoids chmodding arbitrary existing
-/// directories when a caller passes a non-runtime path by mistake.
+/// symlinked parent components are rejected, and private permissions are
+/// enforced on the final parent directory.
 pub fn write_private(path: impl AsRef<Path>, bytes: impl AsRef<[u8]>) -> io::Result<()> {
     let mut file = create_private(path)?;
     std::io::Write::write_all(&mut file, bytes.as_ref())
@@ -748,8 +756,8 @@ fn private_append_options() -> OpenOptions {
 /// Open a runtime-private file for append.
 ///
 /// On Unix, missing parent directories are created with private permissions,
-/// symlinked parent components are rejected, and an existing final parent
-/// directory must already be private.
+/// symlinked parent components are rejected, and private permissions are
+/// enforced on the final parent directory.
 pub fn open_private_append(path: impl AsRef<Path>) -> io::Result<File> {
     open_private_file(path.as_ref(), true)
 }
@@ -852,44 +860,6 @@ mod tests {
     }
 
     #[test]
-    fn create_private_rejects_non_private_existing_parent_without_chmod() {
-        let temp = tempfile::tempdir().unwrap();
-        let parent = temp.path().join("public");
-        std::fs::create_dir(&parent).unwrap();
-
-        #[cfg(unix)]
-        {
-            std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o777)).unwrap();
-            let path = parent.join("session-id");
-
-            let error = create_private(&path).unwrap_err();
-
-            assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
-            assert_eq!(mode(&parent), 0o777);
-            assert!(!path.exists());
-        }
-    }
-
-    #[test]
-    fn open_private_append_rejects_non_private_existing_parent_without_chmod() {
-        let temp = tempfile::tempdir().unwrap();
-        let parent = temp.path().join("public");
-        std::fs::create_dir(&parent).unwrap();
-
-        #[cfg(unix)]
-        {
-            std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o777)).unwrap();
-            let path = parent.join("metrics.jsonl");
-
-            let error = open_private_append(&path).unwrap_err();
-
-            assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
-            assert_eq!(mode(&parent), 0o777);
-            assert!(!path.exists());
-        }
-    }
-
-    #[test]
     fn ensure_dir_chmods_existing_target_dir() {
         let temp = tempfile::tempdir().unwrap();
         let path = temp.path().join("run");
@@ -902,6 +872,25 @@ mod tests {
             ensure_dir(&path).unwrap();
 
             assert_eq!(mode(&path), 0o700);
+        }
+    }
+
+    #[test]
+    fn write_private_chmods_existing_final_parent_dir() {
+        let temp = tempfile::tempdir().unwrap();
+        let parent = temp.path().join("run");
+        std::fs::create_dir(&parent).unwrap();
+        let path = parent.join("system.log");
+
+        #[cfg(unix)]
+        {
+            std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o777)).unwrap();
+
+            write_private(&path, b"hello").unwrap();
+
+            assert_eq!(std::fs::read(&path).unwrap(), b"hello");
+            assert_eq!(mode(&parent), 0o700);
+            assert_eq!(mode(&path), 0o600);
         }
     }
 
@@ -1014,6 +1003,23 @@ mod tests {
                 std::fs::read(target.join("metrics.jsonl")).unwrap(),
                 b"secret"
             );
+        }
+    }
+
+    #[test]
+    fn write_private_rejects_file_parent_as_not_a_directory() {
+        let temp = tempfile::tempdir().unwrap();
+        let parent = temp.path().join("not-a-dir");
+        std::fs::write(&parent, b"file").unwrap();
+        let path = parent.join("system.log");
+
+        #[cfg(unix)]
+        {
+            let error = write_private(&path, b"new").unwrap_err();
+
+            assert_eq!(error.kind(), io::ErrorKind::NotADirectory);
+            assert!(parent.is_file());
+            assert!(!path.exists());
         }
     }
 

--- a/crates/guest-contracts/src/runtime_paths.rs
+++ b/crates/guest-contracts/src/runtime_paths.rs
@@ -285,14 +285,28 @@ fn chmod_created_dir_component(
         )
     };
     if result == 0 {
-        Ok(())
-    } else {
-        Err(wrap_last_os_error(format!(
-            "chmod newly-created runtime directory component {} for {}",
+        return Ok(());
+    }
+
+    let error = io::Error::last_os_error();
+    if matches!(
+        error.raw_os_error(),
+        Some(libc::EINVAL | libc::ENOSYS | libc::EOPNOTSUPP)
+    ) {
+        // Older kernels may not support fchmodat(AT_EMPTY_PATH). The regular
+        // openat + fchmod path below still fixes modes when the umask left owner
+        // access intact, which is the common guest case.
+        return Ok(());
+    }
+
+    Err(io::Error::new(
+        error.kind(),
+        format!(
+            "chmod newly-created runtime directory component {} for {}: {error}",
             name.to_string_lossy(),
             full_path.display()
-        )))
-    }
+        ),
+    ))
 }
 
 #[cfg(all(unix, not(target_os = "linux")))]

--- a/crates/guest-contracts/src/runtime_paths.rs
+++ b/crates/guest-contracts/src/runtime_paths.rs
@@ -538,7 +538,10 @@ fn open_or_create_private_dir(path: &Path) -> io::Result<OwnedFd> {
 fn validate_dir_path_components(path: &Path) -> io::Result<()> {
     for component in path.components() {
         match component {
-            Component::RootDir | Component::CurDir | Component::Normal(_) => {}
+            Component::RootDir | Component::CurDir => {}
+            Component::Normal(name) => {
+                component_cstring(name, path)?;
+            }
             Component::ParentDir => {
                 return Err(permission_denied(format!(
                     "{} contains a parent directory segment",
@@ -615,13 +618,22 @@ fn set_file_private(_file: &File) -> io::Result<()> {
 
 #[cfg(unix)]
 fn file_name(path: &Path) -> io::Result<&OsStr> {
-    if path.as_os_str().as_bytes().last() == Some(&b'/') {
+    let bytes = path.as_os_str().as_bytes();
+    if bytes.last() == Some(&b'/') {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
             format!(
                 "runtime path must not end with a directory separator: {}",
                 path.display()
             ),
+        ));
+    }
+
+    let last_raw_component = bytes.rsplit(|byte| *byte == b'/').next().unwrap_or(bytes);
+    if matches!(last_raw_component, b"." | b"..") {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("runtime path has no file name: {}", path.display()),
         ));
     }
 
@@ -650,9 +662,9 @@ fn parent_dir(path: &Path) -> io::Result<&Path> {
 #[cfg(unix)]
 fn open_private_file(path: &Path, append: bool) -> io::Result<File> {
     let name = file_name(path)?;
+    let name_c = component_cstring(name, path)?;
     let parent = parent_dir(path)?;
     let parent = open_or_create_private_dir(parent)?;
-    let name_c = component_cstring(name, path)?;
     let mut flags =
         libc::O_WRONLY | libc::O_CREAT | libc::O_NOFOLLOW | libc::O_CLOEXEC | libc::O_NONBLOCK;
     if append {
@@ -786,7 +798,7 @@ mod tests {
     use super::*;
     #[cfg(target_os = "linux")]
     use std::os::fd::FromRawFd;
-    #[cfg(target_os = "linux")]
+    #[cfg(unix)]
     use std::os::unix::ffi::OsStrExt;
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
@@ -1052,6 +1064,40 @@ mod tests {
             assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
             assert!(!temp.path().join("run").exists());
             assert!(!path.exists());
+        }
+    }
+
+    #[test]
+    fn create_private_rejects_trailing_current_dir_without_touching_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("run").join("session-id");
+        let path_with_trailing_current_dir = path.join(".");
+
+        #[cfg(unix)]
+        {
+            let error = create_private(&path_with_trailing_current_dir).unwrap_err();
+
+            assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+            assert!(!temp.path().join("run").exists());
+            assert!(!path.exists());
+        }
+    }
+
+    #[test]
+    fn create_private_rejects_nul_file_name_without_creating_parent() {
+        let temp = tempfile::tempdir().unwrap();
+
+        #[cfg(unix)]
+        {
+            let path = temp
+                .path()
+                .join("run")
+                .join(Path::new(OsStr::from_bytes(b"bad\0name")));
+
+            let error = create_private(&path).unwrap_err();
+
+            assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+            assert!(!temp.path().join("run").exists());
         }
     }
 

--- a/crates/guest-contracts/src/runtime_paths.rs
+++ b/crates/guest-contracts/src/runtime_paths.rs
@@ -238,6 +238,28 @@ fn validate_dir_fd(fd: &OwnedFd, path: &Path) -> io::Result<()> {
 }
 
 #[cfg(unix)]
+fn validate_private_dir_mode(fd: &OwnedFd, path: &Path) -> io::Result<()> {
+    let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
+    // SAFETY: `stat` points to writable memory and `fd` owns a live descriptor.
+    let result = unsafe { libc::fstat(fd.as_raw_fd(), stat.as_mut_ptr()) };
+    if result != 0 {
+        return Err(wrap_last_os_error(format!(
+            "stat runtime directory {}",
+            path.display()
+        )));
+    }
+    // SAFETY: successful `fstat` initialized the full struct.
+    let stat = unsafe { stat.assume_init() };
+    if stat.st_mode & 0o777 != PRIVATE_DIR_MODE {
+        return Err(permission_denied(format!(
+            "{} is not a private runtime directory",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
 fn chmod_dir_fd(fd: &OwnedFd, path: &Path) -> io::Result<()> {
     // SAFETY: `fd` owns a live directory descriptor.
     let result = unsafe { libc::fchmod(fd.as_raw_fd(), PRIVATE_DIR_MODE) };
@@ -383,6 +405,7 @@ fn open_or_create_dir_component(
     name: &OsStr,
     full_path: &Path,
     is_final: bool,
+    chmod_existing_final: bool,
 ) -> io::Result<OwnedFd> {
     let name_c = component_cstring(name, full_path)?;
     let path = component_path(parent_path, name);
@@ -414,14 +437,19 @@ fn open_or_create_dir_component(
     // SAFETY: `fd` is a fresh descriptor returned by `openat`.
     let fd = unsafe { OwnedFd::from_raw_fd(fd) };
     validate_dir_fd(&fd, &path)?;
-    if is_final || created {
+    if created || (is_final && chmod_existing_final) {
         chmod_dir_fd(&fd, &path)?;
+    } else if is_final {
+        validate_private_dir_mode(&fd, &path)?;
     }
     Ok(fd)
 }
 
 #[cfg(unix)]
-fn open_or_create_private_dir(path: &Path) -> io::Result<OwnedFd> {
+fn open_or_create_private_dir_with_options(
+    path: &Path,
+    chmod_existing_final: bool,
+) -> io::Result<OwnedFd> {
     if path.as_os_str().is_empty() {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -451,8 +479,14 @@ fn open_or_create_private_dir(path: &Path) -> io::Result<OwnedFd> {
             Component::Normal(name) => {
                 saw_normal_component = true;
                 let is_final = components.peek().is_none();
-                current =
-                    open_or_create_dir_component(&current, &current_path, name, path, is_final)?;
+                current = open_or_create_dir_component(
+                    &current,
+                    &current_path,
+                    name,
+                    path,
+                    is_final,
+                    chmod_existing_final,
+                )?;
                 current_path = component_path(&current_path, name);
             }
             Component::Prefix(prefix) => {
@@ -479,6 +513,16 @@ fn open_or_create_private_dir(path: &Path) -> io::Result<OwnedFd> {
     }
 
     Ok(current)
+}
+
+#[cfg(unix)]
+fn open_or_create_private_dir(path: &Path) -> io::Result<OwnedFd> {
+    open_or_create_private_dir_with_options(path, true)
+}
+
+#[cfg(unix)]
+fn open_private_file_parent_dir(path: &Path) -> io::Result<OwnedFd> {
+    open_or_create_private_dir_with_options(path, false)
 }
 
 #[cfg(unix)]
@@ -562,6 +606,16 @@ fn set_file_private(_file: &File) -> io::Result<()> {
 
 #[cfg(unix)]
 fn file_name(path: &Path) -> io::Result<&OsStr> {
+    if path.as_os_str().as_bytes().last() == Some(&b'/') {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "runtime path must not end with a directory separator: {}",
+                path.display()
+            ),
+        ));
+    }
+
     path.file_name()
         .filter(|name| !name.is_empty() && *name != "." && *name != "..")
         .ok_or_else(|| {
@@ -586,9 +640,9 @@ fn parent_dir(path: &Path) -> io::Result<&Path> {
 
 #[cfg(unix)]
 fn open_private_file(path: &Path, append: bool) -> io::Result<File> {
-    let parent = parent_dir(path)?;
-    let parent = open_or_create_private_dir(parent)?;
     let name = file_name(path)?;
+    let parent = parent_dir(path)?;
+    let parent = open_private_file_parent_dir(parent)?;
     let name_c = component_cstring(name, path)?;
     let mut flags =
         libc::O_WRONLY | libc::O_CREAT | libc::O_NOFOLLOW | libc::O_CLOEXEC | libc::O_NONBLOCK;
@@ -649,6 +703,11 @@ fn secure_regular_private_file(file: &File, path: &Path) -> io::Result<()> {
 }
 
 #[cfg(unix)]
+/// Create or truncate a runtime-private file.
+///
+/// On Unix, missing parent directories are created with private permissions,
+/// symlinked parent components are rejected, and an existing final parent
+/// directory must already be private.
 pub fn create_private(path: impl AsRef<Path>) -> io::Result<File> {
     open_private_file(path.as_ref(), false)
 }
@@ -667,6 +726,12 @@ pub fn create_private(path: impl AsRef<Path>) -> io::Result<File> {
     Ok(file)
 }
 
+/// Write bytes to a runtime-private file.
+///
+/// On Unix, missing parent directories are created with private permissions,
+/// symlinked parent components are rejected, and an existing final parent
+/// directory must already be private. This avoids chmodding arbitrary existing
+/// directories when a caller passes a non-runtime path by mistake.
 pub fn write_private(path: impl AsRef<Path>, bytes: impl AsRef<[u8]>) -> io::Result<()> {
     let mut file = create_private(path)?;
     std::io::Write::write_all(&mut file, bytes.as_ref())
@@ -680,6 +745,11 @@ fn private_append_options() -> OpenOptions {
 }
 
 #[cfg(unix)]
+/// Open a runtime-private file for append.
+///
+/// On Unix, missing parent directories are created with private permissions,
+/// symlinked parent components are rejected, and an existing final parent
+/// directory must already be private.
 pub fn open_private_append(path: impl AsRef<Path>) -> io::Result<File> {
     open_private_file(path.as_ref(), true)
 }
@@ -778,6 +848,60 @@ mod tests {
             assert_eq!(mode(temp.path().join("run")), 0o700);
             assert_eq!(mode(temp.path().join("run/logs")), 0o700);
             assert_eq!(mode(&path), 0o600);
+        }
+    }
+
+    #[test]
+    fn create_private_rejects_non_private_existing_parent_without_chmod() {
+        let temp = tempfile::tempdir().unwrap();
+        let parent = temp.path().join("public");
+        std::fs::create_dir(&parent).unwrap();
+
+        #[cfg(unix)]
+        {
+            std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o777)).unwrap();
+            let path = parent.join("session-id");
+
+            let error = create_private(&path).unwrap_err();
+
+            assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+            assert_eq!(mode(&parent), 0o777);
+            assert!(!path.exists());
+        }
+    }
+
+    #[test]
+    fn open_private_append_rejects_non_private_existing_parent_without_chmod() {
+        let temp = tempfile::tempdir().unwrap();
+        let parent = temp.path().join("public");
+        std::fs::create_dir(&parent).unwrap();
+
+        #[cfg(unix)]
+        {
+            std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o777)).unwrap();
+            let path = parent.join("metrics.jsonl");
+
+            let error = open_private_append(&path).unwrap_err();
+
+            assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+            assert_eq!(mode(&parent), 0o777);
+            assert!(!path.exists());
+        }
+    }
+
+    #[test]
+    fn ensure_dir_chmods_existing_target_dir() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("run");
+        std::fs::create_dir(&path).unwrap();
+
+        #[cfg(unix)]
+        {
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o777)).unwrap();
+
+            ensure_dir(&path).unwrap();
+
+            assert_eq!(mode(&path), 0o700);
         }
     }
 
@@ -906,6 +1030,38 @@ mod tests {
             assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
             assert!(!base.join("missing").exists());
             assert!(!base.join("leaf").exists());
+        }
+    }
+
+    #[test]
+    fn create_private_rejects_trailing_separator_without_touching_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("run").join("session-id");
+        let path_with_trailing_separator = PathBuf::from(format!("{}/", path.display()));
+
+        #[cfg(unix)]
+        {
+            let error = create_private(&path_with_trailing_separator).unwrap_err();
+
+            assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+            assert!(!temp.path().join("run").exists());
+            assert!(!path.exists());
+        }
+    }
+
+    #[test]
+    fn open_private_append_rejects_trailing_separator_without_touching_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("run").join("metrics.jsonl");
+        let path_with_trailing_separator = PathBuf::from(format!("{}/", path.display()));
+
+        #[cfg(unix)]
+        {
+            let error = open_private_append(&path_with_trailing_separator).unwrap_err();
+
+            assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+            assert!(!temp.path().join("run").exists());
+            assert!(!path.exists());
         }
     }
 }

--- a/crates/guest-write-file/Cargo.toml
+++ b/crates/guest-write-file/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 description = "Write guest files from stdin without shell startup overhead"
 
 [dependencies]
+guest-contracts.workspace = true
 libc.workspace = true
 
 [dev-dependencies]

--- a/crates/guest-write-file/src/lib.rs
+++ b/crates/guest-write-file/src/lib.rs
@@ -11,8 +11,11 @@ use std::path::{Path, PathBuf};
 struct Args {
     append: bool,
     create_parents: bool,
+    private: bool,
     path: PathBuf,
 }
+
+const USAGE: &str = "usage: guest-write-file [--private] [--append | --create-parents] [--] <path>";
 
 fn parse_args<I>(args: I) -> Result<Args, String>
 where
@@ -20,6 +23,7 @@ where
 {
     let mut append = false;
     let mut create_parents = false;
+    let mut private = false;
     let mut path = None;
     let mut positional_only = false;
 
@@ -32,6 +36,10 @@ where
                 }
                 "--create-parents" => {
                     create_parents = true;
+                    continue;
+                }
+                "--private" => {
+                    private = true;
                     continue;
                 }
                 "--" => {
@@ -54,26 +62,41 @@ where
     if append && create_parents {
         return Err("--append and --create-parents cannot be used together".to_string());
     }
+    if private && create_parents {
+        return Err("--private and --create-parents cannot be used together".to_string());
+    }
 
     Ok(Args {
         append,
         create_parents,
+        private,
         path,
     })
 }
 
 fn run(args: Args, mut stdin: impl Read) -> io::Result<()> {
-    if args.create_parents
-        && let Some(parent) = args.path.parent()
-        && !parent.as_os_str().is_empty()
-    {
-        fs::create_dir_all(parent)?;
-    }
-
-    let mut file = open_output_file(&args.path, args.append)?;
+    let mut file = if args.private {
+        open_private_output_file(&args.path, args.append)?
+    } else {
+        if args.create_parents
+            && let Some(parent) = args.path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            fs::create_dir_all(parent)?;
+        }
+        open_output_file(&args.path, args.append)?
+    };
 
     io::copy(&mut stdin, &mut file)?;
     file.flush()
+}
+
+fn open_private_output_file(path: &Path, append: bool) -> io::Result<File> {
+    if append {
+        guest_contracts::runtime_paths::open_private_append(path)
+    } else {
+        guest_contracts::runtime_paths::create_private(path)
+    }
 }
 
 fn open_output_file(path: &Path, append: bool) -> io::Result<File> {
@@ -152,7 +175,7 @@ fn prepare_output_file(_file: &File) -> io::Result<()> {
 /// matching `std::env::args().skip(1)`. The accepted syntax is:
 ///
 /// ```text
-/// guest-write-file [--append | --create-parents] [--] <path>
+/// guest-write-file [--private] [--append | --create-parents] [--] <path>
 /// ```
 ///
 /// Use `--` before `<path>` when the literal path begins with `-`. `stdin`
@@ -161,7 +184,9 @@ fn prepare_output_file(_file: &File) -> io::Result<()> {
 /// By default, the target file is created or truncated before writing.
 /// `--append` appends to the target file and creates it only when the parent
 /// directory already exists. `--create-parents` creates missing parent
-/// directories before writing.
+/// directories before writing. `--private` writes through the guest runtime
+/// private file helpers, creating private parents and rejecting symlinked
+/// parent components.
 ///
 /// Returns process-style exit codes: `0` for success, `1` for runtime or write
 /// failures, and `2` for usage or argument errors.
@@ -173,10 +198,7 @@ where
         Ok(args) => args,
         Err(e) => {
             let _ = writeln!(stderr, "guest-write-file: {e}");
-            let _ = writeln!(
-                stderr,
-                "usage: guest-write-file [--append | --create-parents] [--] <path>"
-            );
+            let _ = writeln!(stderr, "{USAGE}");
             return 2;
         }
     };
@@ -203,6 +225,7 @@ mod tests {
             Args {
                 append: false,
                 create_parents: true,
+                private: false,
                 path: PathBuf::from("/tmp/out.txt"),
             }
         );
@@ -222,6 +245,7 @@ mod tests {
             Args {
                 append: true,
                 create_parents: false,
+                private: false,
                 path: PathBuf::from("-literal"),
             }
         );
@@ -245,6 +269,38 @@ mod tests {
     fn rejects_append_with_create_parents() {
         let err = parse_args([
             "--append".to_string(),
+            "--create-parents".to_string(),
+            "/tmp/a".to_string(),
+        ])
+        .unwrap_err();
+
+        assert!(err.contains("cannot be used together"));
+    }
+
+    #[test]
+    fn parse_private_append() {
+        let args = parse_args([
+            "--private".to_string(),
+            "--append".to_string(),
+            "/tmp/out.txt".to_string(),
+        ])
+        .unwrap();
+
+        assert_eq!(
+            args,
+            Args {
+                append: true,
+                create_parents: false,
+                private: true,
+                path: PathBuf::from("/tmp/out.txt"),
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_private_with_create_parents() {
+        let err = parse_args([
+            "--private".to_string(),
             "--create-parents".to_string(),
             "/tmp/a".to_string(),
         ])

--- a/crates/guest-write-file/src/lib.rs
+++ b/crates/guest-write-file/src/lib.rs
@@ -185,8 +185,9 @@ fn prepare_output_file(_file: &File) -> io::Result<()> {
 /// `--append` appends to the target file and creates it only when the parent
 /// directory already exists. `--create-parents` creates missing parent
 /// directories before writing. `--private` writes through the guest runtime
-/// private file helpers, ensuring parent directories are private and rejecting
-/// symlinked parent components.
+/// private file helpers, ensuring parent directories are private, creating
+/// missing parent directories even with `--append`, and rejecting symlinked
+/// parent components.
 ///
 /// Returns process-style exit codes: `0` for success, `1` for runtime or write
 /// failures, and `2` for usage or argument errors.

--- a/crates/guest-write-file/src/lib.rs
+++ b/crates/guest-write-file/src/lib.rs
@@ -185,9 +185,8 @@ fn prepare_output_file(_file: &File) -> io::Result<()> {
 /// `--append` appends to the target file and creates it only when the parent
 /// directory already exists. `--create-parents` creates missing parent
 /// directories before writing. `--private` writes through the guest runtime
-/// private file helpers, creating missing private parents, rejecting symlinked
-/// parent components, and rejecting existing final parent directories that are
-/// not already private.
+/// private file helpers, ensuring parent directories are private and rejecting
+/// symlinked parent components.
 ///
 /// Returns process-style exit codes: `0` for success, `1` for runtime or write
 /// failures, and `2` for usage or argument errors.

--- a/crates/guest-write-file/src/lib.rs
+++ b/crates/guest-write-file/src/lib.rs
@@ -185,8 +185,9 @@ fn prepare_output_file(_file: &File) -> io::Result<()> {
 /// `--append` appends to the target file and creates it only when the parent
 /// directory already exists. `--create-parents` creates missing parent
 /// directories before writing. `--private` writes through the guest runtime
-/// private file helpers, creating private parents and rejecting symlinked
-/// parent components.
+/// private file helpers, creating missing private parents, rejecting symlinked
+/// parent components, and rejecting existing final parent directories that are
+/// not already private.
 ///
 /// Returns process-style exit codes: `0` for success, `1` for runtime or write
 /// failures, and `2` for usage or argument errors.

--- a/crates/guest-write-file/tests/integration.rs
+++ b/crates/guest-write-file/tests/integration.rs
@@ -338,6 +338,22 @@ fn private_append_mode_appends_with_private_mode() {
 
 #[cfg(unix)]
 #[test]
+fn private_append_mode_creates_missing_private_parent_dirs() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("run/logs/system.log");
+    let path_str = path.to_str().unwrap();
+
+    let output = run_helper(&["--private", "--append", path_str], b"hello");
+
+    assert!(output.status.success(), "stderr={:?}", output.stderr);
+    assert_eq!(std::fs::read(&path).unwrap(), b"hello");
+    assert_eq!(mode(&dir.path().join("run")), 0o700);
+    assert_eq!(mode(&dir.path().join("run/logs")), 0o700);
+    assert_eq!(mode(&path), 0o600);
+}
+
+#[cfg(unix)]
+#[test]
 fn private_mode_rejects_symlink_parent_without_touching_target() {
     let dir = tempfile::tempdir().unwrap();
     let target = dir.path().join("target");

--- a/crates/guest-write-file/tests/integration.rs
+++ b/crates/guest-write-file/tests/integration.rs
@@ -7,6 +7,7 @@ use std::sync::mpsc;
 use std::time::Duration;
 
 const BIN: &str = env!("CARGO_BIN_EXE_guest-write-file");
+const USAGE: &str = "usage: guest-write-file [--private] [--append | --create-parents] [--] <path>";
 
 fn run_helper(args: &[&str], stdin: &[u8]) -> std::process::Output {
     run_helper_with_current_dir(args, stdin, None)
@@ -164,7 +165,22 @@ fn append_mode_rejects_create_parents() {
     assert_eq!(output.status.code(), Some(2));
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("cannot be used together"));
-    assert!(stderr.contains("usage: guest-write-file [--append | --create-parents] [--] <path>"));
+    assert!(stderr.contains(USAGE));
+    assert!(!path.exists());
+}
+
+#[test]
+fn private_mode_rejects_create_parents() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("missing/out.txt");
+    let path_str = path.to_str().unwrap();
+
+    let output = run_helper(&["--private", "--create-parents", path_str], b"hello");
+
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("cannot be used together"));
+    assert!(stderr.contains(USAGE));
     assert!(!path.exists());
 }
 
@@ -228,6 +244,90 @@ fn create_mode_rejects_directory_target() {
 
 #[cfg(unix)]
 #[test]
+fn private_mode_creates_private_parent_dirs_and_writes_content() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("run/user-env/env.json");
+    let path_str = path.to_str().unwrap();
+
+    let output = run_helper(&["--private", path_str], b"hello");
+
+    assert!(output.status.success(), "stderr={:?}", output.stderr);
+    assert_eq!(std::fs::read(&path).unwrap(), b"hello");
+    assert_eq!(mode(&dir.path().join("run")), 0o700);
+    assert_eq!(mode(&dir.path().join("run/user-env")), 0o700);
+    assert_eq!(mode(&path), 0o600);
+}
+
+#[cfg(unix)]
+#[test]
+fn private_append_mode_appends_with_private_mode() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("run/logs/system.log");
+    let path_str = path.to_str().unwrap();
+
+    let first = run_helper(&["--private", path_str], b"first");
+    assert!(first.status.success(), "stderr={:?}", first.stderr);
+    let second = run_helper(&["--private", "--append", path_str], b"second");
+
+    assert!(second.status.success(), "stderr={:?}", second.stderr);
+    assert_eq!(std::fs::read(&path).unwrap(), b"firstsecond");
+    assert_eq!(mode(&path), 0o600);
+}
+
+#[cfg(unix)]
+#[test]
+fn private_mode_rejects_symlink_parent_without_touching_target() {
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("target");
+    let link = dir.path().join("link");
+    std::fs::create_dir(&target).unwrap();
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+    let path = link.join("env.json");
+    let path_str = path.to_str().unwrap();
+
+    let output = run_helper(&["--private", path_str], b"hello");
+
+    assert!(!output.status.success());
+    assert!(!target.join("env.json").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn private_mode_rejects_directory_target() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("target");
+    std::fs::create_dir(&path).unwrap();
+    let path_str = path.to_str().unwrap();
+
+    let output = run_helper(&["--private", path_str], b"hello");
+
+    assert!(!output.status.success());
+    assert!(path.is_dir());
+}
+
+#[cfg(unix)]
+#[test]
+fn private_mode_rejects_fifo_with_reader() {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("fifo");
+    mkfifo(&path);
+    let _reader = std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NONBLOCK)
+        .open(&path)
+        .unwrap();
+    let path_str = path.to_str().unwrap();
+
+    let output = run_helper(&["--private", path_str], b"");
+
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("not a regular"));
+}
+
+#[cfg(unix)]
+#[test]
 fn create_mode_rejects_character_device_target() {
     let output = run_helper(&["/dev/null"], b"hello");
 
@@ -283,4 +383,11 @@ fn mkfifo(path: &std::path::Path) {
         "mkfifo failed: {}",
         std::io::Error::last_os_error()
     );
+}
+
+#[cfg(unix)]
+fn mode(path: &Path) -> u32 {
+    use std::os::unix::fs::PermissionsExt;
+
+    std::fs::metadata(path).unwrap().permissions().mode() & 0o777
 }

--- a/crates/guest-write-file/tests/integration.rs
+++ b/crates/guest-write-file/tests/integration.rs
@@ -286,6 +286,25 @@ fn private_mode_creates_private_parent_dirs_and_writes_content() {
 
 #[cfg(unix)]
 #[test]
+fn private_mode_rejects_non_private_existing_parent_without_chmod() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    let parent = dir.path().join("public");
+    std::fs::create_dir(&parent).unwrap();
+    std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o777)).unwrap();
+    let path = parent.join("env.json");
+    let path_str = path.to_str().unwrap();
+
+    let output = run_helper(&["--private", path_str], b"hello");
+
+    assert!(!output.status.success());
+    assert_eq!(mode(&parent), 0o777);
+    assert!(!path.exists());
+}
+
+#[cfg(unix)]
+#[test]
 fn private_mode_forces_parent_modes_with_restrictive_umask() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("run/logs/system.log");
@@ -336,7 +355,10 @@ fn private_mode_rejects_symlink_parent_without_touching_target() {
 #[cfg(unix)]
 #[test]
 fn private_mode_rejects_directory_target() {
+    use std::os::unix::fs::PermissionsExt;
+
     let dir = tempfile::tempdir().unwrap();
+    std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
     let path = dir.path().join("target");
     std::fs::create_dir(&path).unwrap();
     let path_str = path.to_str().unwrap();
@@ -349,10 +371,26 @@ fn private_mode_rejects_directory_target() {
 
 #[cfg(unix)]
 #[test]
+fn private_mode_rejects_trailing_separator_without_creating_target() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("run/session-id");
+    let path_with_trailing_separator = format!("{}/", path.display());
+
+    let output = run_helper(&["--private", &path_with_trailing_separator], b"hello");
+
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("directory separator"));
+    assert!(!dir.path().join("run").exists());
+    assert!(!path.exists());
+}
+
+#[cfg(unix)]
+#[test]
 fn private_mode_rejects_fifo_with_reader() {
-    use std::os::unix::fs::OpenOptionsExt;
+    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 
     let dir = tempfile::tempdir().unwrap();
+    std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
     let path = dir.path().join("fifo");
     mkfifo(&path);
     let _reader = std::fs::OpenOptions::new()
@@ -365,7 +403,8 @@ fn private_mode_rejects_fifo_with_reader() {
     let output = run_helper(&["--private", path_str], b"");
 
     assert!(!output.status.success());
-    assert!(String::from_utf8_lossy(&output.stderr).contains("not a regular"));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("not a regular"), "stderr={stderr}");
 }
 
 #[cfg(unix)]

--- a/crates/guest-write-file/tests/integration.rs
+++ b/crates/guest-write-file/tests/integration.rs
@@ -387,6 +387,22 @@ fn private_mode_rejects_trailing_separator_without_creating_target() {
 
 #[cfg(unix)]
 #[test]
+fn private_mode_rejects_trailing_current_dir_without_creating_target() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("run/session-id");
+    let path_with_trailing_current_dir = path.join(".");
+    let path_str = path_with_trailing_current_dir.to_str().unwrap();
+
+    let output = run_helper(&["--private", path_str], b"hello");
+
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("no file name"));
+    assert!(!dir.path().join("run").exists());
+    assert!(!path.exists());
+}
+
+#[cfg(unix)]
+#[test]
 fn private_mode_rejects_fifo_with_reader() {
     use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 

--- a/crates/guest-write-file/tests/integration.rs
+++ b/crates/guest-write-file/tests/integration.rs
@@ -286,11 +286,11 @@ fn private_mode_creates_private_parent_dirs_and_writes_content() {
 
 #[cfg(unix)]
 #[test]
-fn private_mode_rejects_non_private_existing_parent_without_chmod() {
+fn private_mode_chmods_existing_parent_and_writes_content() {
     use std::os::unix::fs::PermissionsExt;
 
     let dir = tempfile::tempdir().unwrap();
-    let parent = dir.path().join("public");
+    let parent = dir.path().join("run");
     std::fs::create_dir(&parent).unwrap();
     std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o777)).unwrap();
     let path = parent.join("env.json");
@@ -298,9 +298,10 @@ fn private_mode_rejects_non_private_existing_parent_without_chmod() {
 
     let output = run_helper(&["--private", path_str], b"hello");
 
-    assert!(!output.status.success());
-    assert_eq!(mode(&parent), 0o777);
-    assert!(!path.exists());
+    assert!(output.status.success(), "stderr={:?}", output.stderr);
+    assert_eq!(std::fs::read(&path).unwrap(), b"hello");
+    assert_eq!(mode(&parent), 0o700);
+    assert_eq!(mode(&path), 0o600);
 }
 
 #[cfg(unix)]

--- a/crates/guest-write-file/tests/integration.rs
+++ b/crates/guest-write-file/tests/integration.rs
@@ -17,21 +17,47 @@ fn run_helper_in_dir(args: &[&str], stdin: &[u8], current_dir: &Path) -> std::pr
     run_helper_with_current_dir(args, stdin, Some(current_dir))
 }
 
-fn run_helper_with_current_dir(
-    args: &[&str],
-    stdin: &[u8],
-    current_dir: Option<&Path>,
-) -> std::process::Output {
+fn helper_command(args: &[&str]) -> Command {
     let mut command = Command::new(BIN);
     command
         .args(args)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
+    command
+}
+
+fn run_helper_with_current_dir(
+    args: &[&str],
+    stdin: &[u8],
+    current_dir: Option<&Path>,
+) -> std::process::Output {
+    let mut command = helper_command(args);
     if let Some(current_dir) = current_dir {
         command.current_dir(current_dir);
     }
 
+    run_helper_command(command, stdin)
+}
+
+#[cfg(unix)]
+fn run_helper_with_umask(args: &[&str], stdin: &[u8], umask: libc::mode_t) -> std::process::Output {
+    use std::os::unix::process::CommandExt;
+
+    let mut command = helper_command(args);
+    // SAFETY: `pre_exec` runs in the child process after fork and before exec.
+    // It only changes that child's umask, leaving the test process unaffected.
+    unsafe {
+        command.pre_exec(move || {
+            libc::umask(umask);
+            Ok(())
+        });
+    }
+
+    run_helper_command(command, stdin)
+}
+
+fn run_helper_command(mut command: Command, stdin: &[u8]) -> std::process::Output {
     let mut child = command.spawn().expect("spawn guest-write-file");
     child
         .stdin
@@ -255,6 +281,22 @@ fn private_mode_creates_private_parent_dirs_and_writes_content() {
     assert_eq!(std::fs::read(&path).unwrap(), b"hello");
     assert_eq!(mode(&dir.path().join("run")), 0o700);
     assert_eq!(mode(&dir.path().join("run/user-env")), 0o700);
+    assert_eq!(mode(&path), 0o600);
+}
+
+#[cfg(unix)]
+#[test]
+fn private_mode_forces_parent_modes_with_restrictive_umask() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("run/logs/system.log");
+    let path_str = path.to_str().unwrap();
+
+    let output = run_helper_with_umask(&["--private", path_str], b"hello", 0o777);
+
+    assert!(output.status.success(), "stderr={:?}", output.stderr);
+    assert_eq!(std::fs::read(&path).unwrap(), b"hello");
+    assert_eq!(mode(&dir.path().join("run")), 0o700);
+    assert_eq!(mode(&dir.path().join("run/logs")), 0o700);
     assert_eq!(mode(&path), 0o600);
 }
 

--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -1,17 +1,16 @@
 use std::collections::HashMap;
 
 use api_contracts::generated::constants::model_provider_env::placeholders as model_provider_placeholders;
-use sandbox::{EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, Sandbox};
+use sandbox::Sandbox;
 
 use super::cli_framework::{
     EffectiveCliFramework, effective_cli_framework, normalized_cli_agent_type,
 };
 use super::session_id::{canonical_codex_thread_id, is_valid_session_id};
 use super::{
-    DEFAULT_EXEC_TIMEOUT, GUEST_USER_ENV_DIR_NAME, GUEST_USER_ENV_FILENAME, RunnerError,
-    RunnerResult, guest_runtime_dir, guest_runtime_path,
+    GUEST_USER_ENV_DIR_NAME, GUEST_USER_ENV_FILENAME, RunnerError, RunnerResult, guest_runtime_dir,
+    guest_runtime_path,
 };
-use crate::helper_exec::{format_helper_exec_failure, helper_exec_succeeded};
 use crate::ids::RunId;
 use crate::types::{ExecutionContext, SandboxReuseResult};
 
@@ -238,122 +237,11 @@ pub(super) fn build_user_env_json(context: &ExecutionContext) -> HashMap<String,
     env
 }
 
-pub(super) fn guest_user_env_dir_path(run_id: RunId) -> RunnerResult<String> {
-    guest_runtime_path(run_id, |dir| dir.join(GUEST_USER_ENV_DIR_NAME))
-}
-
 pub(super) fn guest_user_env_file_path(run_id: RunId) -> RunnerResult<String> {
     guest_runtime_path(run_id, |dir| {
         dir.join(GUEST_USER_ENV_DIR_NAME)
             .join(GUEST_USER_ENV_FILENAME)
     })
-}
-
-fn shell_quote(value: &str) -> String {
-    format!("'{}'", value.replace('\'', "'\\''"))
-}
-
-fn user_env_dir_command(runtime_dir: &str, dir_path: &str) -> String {
-    let runtime_dir = shell_quote(runtime_dir);
-    let dir_path = shell_quote(dir_path);
-    format!("mkdir -p -m 700 -- {runtime_dir} {dir_path} && chmod 700 -- {runtime_dir} {dir_path}")
-}
-
-fn user_env_write_command(runtime_dir: &str, dir_path: &str, file_path: &str) -> String {
-    let runtime_dir = shell_quote(runtime_dir);
-    let dir_path = shell_quote(dir_path);
-    let file_path = shell_quote(file_path);
-    format!(
-        "umask 077 && \
-         mkdir -p -m 700 -- {runtime_dir} {dir_path} && \
-         chmod 700 -- {runtime_dir} {dir_path} && \
-         cat > {file_path} && \
-         chmod 600 -- {file_path}"
-    )
-}
-
-async fn write_user_env_file_fast_path(
-    sandbox: &dyn Sandbox,
-    runtime_dir: &str,
-    dir_path: &str,
-    file_path: &str,
-    payload: &[u8],
-) -> RunnerResult<()> {
-    let write_cmd = user_env_write_command(runtime_dir, dir_path, file_path);
-    let write_result = sandbox
-        .exec_with_diagnostic_label(
-            &ExecRequest {
-                cmd: &write_cmd,
-                timeout: DEFAULT_EXEC_TIMEOUT,
-                env: &[],
-                sudo: false,
-                stdin_bytes: Some(payload),
-                output_limits: EXEC_OUTPUT_LIMIT_64_KIB,
-            },
-            "user-env-write",
-        )
-        .await?;
-    if !helper_exec_succeeded(&write_result) {
-        return Err(RunnerError::Internal(format_helper_exec_failure(
-            "user env file write",
-            &write_result,
-        )));
-    }
-
-    Ok(())
-}
-
-async fn write_user_env_file_fallback(
-    sandbox: &dyn Sandbox,
-    runtime_dir: &str,
-    dir_path: &str,
-    file_path: &str,
-    payload: &[u8],
-) -> RunnerResult<()> {
-    let mkdir_cmd = user_env_dir_command(runtime_dir, dir_path);
-    let mkdir_result = sandbox
-        .exec_with_diagnostic_label(
-            &ExecRequest {
-                cmd: &mkdir_cmd,
-                timeout: DEFAULT_EXEC_TIMEOUT,
-                env: &[],
-                sudo: false,
-                stdin_bytes: None,
-                output_limits: EXEC_OUTPUT_LIMIT_64_KIB,
-            },
-            "user-env-dir",
-        )
-        .await?;
-    if !helper_exec_succeeded(&mkdir_result) {
-        return Err(RunnerError::Internal(format_helper_exec_failure(
-            "user env directory creation",
-            &mkdir_result,
-        )));
-    }
-
-    sandbox.write_file(file_path, payload).await?;
-    let chmod_cmd = format!("chmod 600 -- {}", shell_quote(file_path));
-    let chmod_result = sandbox
-        .exec_with_diagnostic_label(
-            &ExecRequest {
-                cmd: &chmod_cmd,
-                timeout: DEFAULT_EXEC_TIMEOUT,
-                env: &[],
-                sudo: false,
-                stdin_bytes: None,
-                output_limits: EXEC_OUTPUT_LIMIT_64_KIB,
-            },
-            "user-env-chmod",
-        )
-        .await?;
-    if !helper_exec_succeeded(&chmod_result) {
-        return Err(RunnerError::Internal(format_helper_exec_failure(
-            "user env file permission update",
-            &chmod_result,
-        )));
-    }
-
-    Ok(())
 }
 
 pub(super) async fn write_user_env_file(
@@ -365,19 +253,10 @@ pub(super) async fn write_user_env_file(
         return Ok(None);
     }
 
-    let runtime_dir = guest_runtime_dir(run_id)?;
-    let dir_path = guest_user_env_dir_path(run_id)?;
     let file_path = guest_user_env_file_path(run_id)?;
     let payload = serde_json::to_vec(user_env)
         .map_err(|e| RunnerError::Internal(format!("serialize user env: {e}")))?;
-
-    if payload.len() <= vsock_proto::MAX_EXEC_STDIN_BYTES {
-        write_user_env_file_fast_path(sandbox, &runtime_dir, &dir_path, &file_path, &payload)
-            .await?;
-    } else {
-        write_user_env_file_fallback(sandbox, &runtime_dir, &dir_path, &file_path, &payload)
-            .await?;
-    }
+    sandbox.write_private_file(&file_path, &payload).await?;
 
     Ok(Some(file_path))
 }

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -4,7 +4,7 @@ use api_contracts::generated::constants::model_provider_env::placeholders as mod
 use api_contracts::generated::types::runners::storage::{
     ArtifactEntryMissingRootPolicy, StorageManifest,
 };
-use sandbox::{ExecResult, ExecTermination, SandboxId};
+use sandbox::SandboxId;
 use sandbox_mock::MockSandbox;
 
 use super::super::cli_framework::{
@@ -18,7 +18,7 @@ use super::super::env::{
 use super::super::{USER_ENV_FILE_ENV_KEY, guest_runtime_dir};
 use super::support::{
     api_artifact, api_storage, build_env_for_test, build_env_for_test_result,
-    build_env_for_test_with_host_env, context_with_env, minimal_context,
+    build_env_for_test_with_host_env, context_with_env, minimal_context, sandbox_write_file_error,
 };
 use crate::error::{RunnerError, RunnerResult};
 use crate::host_env::{
@@ -880,12 +880,12 @@ async fn write_user_env_file_skips_empty_env() {
     assert!(path.is_none());
     assert!(sandbox.exec_calls().is_empty());
     assert!(sandbox.write_file_calls().is_empty());
+    assert!(sandbox.private_write_file_calls().is_empty());
 }
 
 #[tokio::test]
-async fn write_user_env_file_uses_single_stdin_exec_for_small_env() {
+async fn write_user_env_file_uses_private_write_for_small_env() {
     let sandbox = MockSandbox::new("test");
-    sandbox.push_exec_result(Ok(ExecResult::new(0, Vec::new(), Vec::new())));
     let run_id = RunId::nil();
     let user_env = HashMap::from([
         ("CUSTOM_ENV".to_string(), "value".to_string()),
@@ -898,36 +898,25 @@ async fn write_user_env_file_uses_single_stdin_exec_for_small_env() {
         .unwrap();
 
     assert_eq!(path, guest_user_env_file_path(run_id).unwrap());
-    let exec_calls = sandbox.exec_calls();
-    assert_eq!(exec_calls.len(), 1);
-    let call = &exec_calls[0];
-    assert!(!call.sudo);
-    assert!(call.env_keys.is_empty());
-    assert!(call.cmd.contains("umask 077"));
-    assert!(call.cmd.contains("mkdir -p -m 700 --"));
-    assert!(call.cmd.contains("chmod 700 --"));
-    assert!(call.cmd.contains("cat >"));
-    assert!(call.cmd.contains("chmod 600 --"));
-    let stdin_bytes = call.stdin_bytes.as_ref().unwrap();
-    let decoded: HashMap<String, String> = serde_json::from_slice(stdin_bytes).unwrap();
-    assert_eq!(decoded, user_env);
+    assert!(sandbox.exec_calls().is_empty());
     assert!(sandbox.write_file_calls().is_empty());
+    let writes = sandbox.private_write_file_calls();
+    assert_eq!(writes.len(), 1);
+    assert_eq!(writes[0].path, path);
+    let decoded: HashMap<String, String> = serde_json::from_slice(&writes[0].content).unwrap();
+    assert_eq!(decoded, user_env);
 }
 
 #[tokio::test]
-async fn write_user_env_file_uses_stdin_exec_at_protocol_limit() {
+async fn write_user_env_file_uses_private_write_for_large_env() {
     let sandbox = MockSandbox::new("test");
-    sandbox.push_exec_result(Ok(ExecResult::new(0, Vec::new(), Vec::new())));
     let run_id = RunId::nil();
-    let empty_payload_len = serde_json::to_vec(&HashMap::from([("A".to_string(), String::new())]))
-        .unwrap()
-        .len();
     let user_env = HashMap::from([(
-        "A".to_string(),
-        "x".repeat(vsock_proto::MAX_EXEC_STDIN_BYTES - empty_payload_len),
+        "CUSTOM_ENV".to_string(),
+        "x".repeat(vsock_proto::MAX_EXEC_STDIN_BYTES),
     )]);
     let payload = serde_json::to_vec(&user_env).unwrap();
-    assert_eq!(payload.len(), vsock_proto::MAX_EXEC_STDIN_BYTES);
+    assert!(payload.len() > vsock_proto::MAX_EXEC_STDIN_BYTES);
 
     let path = write_user_env_file(&sandbox, run_id, &user_env)
         .await
@@ -935,26 +924,18 @@ async fn write_user_env_file_uses_stdin_exec_at_protocol_limit() {
         .unwrap();
 
     assert_eq!(path, guest_user_env_file_path(run_id).unwrap());
-    let exec_calls = sandbox.exec_calls();
-    assert_eq!(exec_calls.len(), 1);
-    assert_eq!(
-        exec_calls[0].stdin_bytes.as_ref().unwrap().len(),
-        vsock_proto::MAX_EXEC_STDIN_BYTES
-    );
+    assert!(sandbox.exec_calls().is_empty());
     assert!(sandbox.write_file_calls().is_empty());
+    let writes = sandbox.private_write_file_calls();
+    assert_eq!(writes.len(), 1);
+    assert_eq!(writes[0].path, path);
+    assert_eq!(writes[0].content, payload);
 }
 
 #[tokio::test]
-async fn write_user_env_file_fails_on_non_exited_fast_path_result() {
+async fn write_user_env_file_returns_private_write_error() {
     let sandbox = MockSandbox::new("test");
-    sandbox.push_exec_result(Ok(ExecResult {
-        termination: ExecTermination::Cancelled,
-        stdout: Vec::new(),
-        stderr: b"cancelled".to_vec(),
-        diagnostic: String::new(),
-        stdout_truncated: false,
-        stderr_truncated: false,
-    }));
+    sandbox.push_private_write_file_result(Err(sandbox_write_file_error("private write failed")));
     let run_id = RunId::nil();
     let user_env = HashMap::from([("CUSTOM_ENV".to_string(), "value".to_string())]);
 
@@ -963,100 +944,11 @@ async fn write_user_env_file_fails_on_non_exited_fast_path_result() {
         .unwrap_err();
     let message = err.to_string();
 
-    assert!(
-        message.contains("user env file write failed (cancelled)"),
-        "got: {message}"
-    );
+    assert!(message.contains("private write failed"), "got: {message}");
+    assert!(sandbox.exec_calls().is_empty());
     assert!(sandbox.write_file_calls().is_empty());
-}
-
-#[tokio::test]
-async fn write_user_env_file_falls_back_for_oversized_env() {
-    let sandbox = MockSandbox::new("test");
-    sandbox.push_exec_result(Ok(ExecResult::new(0, Vec::new(), Vec::new())));
-    sandbox.push_exec_result(Ok(ExecResult::new(0, Vec::new(), Vec::new())));
-    let run_id = RunId::nil();
-    let user_env = HashMap::from([(
-        "CUSTOM_ENV".to_string(),
-        "x".repeat(vsock_proto::MAX_EXEC_STDIN_BYTES),
-    )]);
-
-    let path = write_user_env_file(&sandbox, run_id, &user_env)
-        .await
-        .unwrap()
-        .unwrap();
-
-    assert_eq!(path, guest_user_env_file_path(run_id).unwrap());
-    let exec_calls = sandbox.exec_calls();
-    assert_eq!(exec_calls.len(), 2);
-    assert!(exec_calls[0].cmd.contains("mkdir -p -m 700 --"));
-    assert!(exec_calls[0].stdin_bytes.is_none());
-    assert!(exec_calls[1].cmd.contains("chmod 600 --"));
-    assert!(exec_calls[1].stdin_bytes.is_none());
-    let writes = sandbox.write_file_calls();
+    let writes = sandbox.private_write_file_calls();
     assert_eq!(writes.len(), 1);
-    assert_eq!(writes[0].path, path);
-    let decoded: HashMap<String, String> = serde_json::from_slice(&writes[0].content).unwrap();
-    assert_eq!(decoded, user_env);
-}
-
-#[tokio::test]
-async fn write_user_env_file_fallback_fails_on_non_exited_mkdir_result() {
-    let sandbox = MockSandbox::new("test");
-    sandbox.push_exec_result(Ok(ExecResult {
-        termination: ExecTermination::Cancelled,
-        stdout: Vec::new(),
-        stderr: b"cancelled".to_vec(),
-        diagnostic: String::new(),
-        stdout_truncated: false,
-        stderr_truncated: false,
-    }));
-    let run_id = RunId::nil();
-    let user_env = HashMap::from([(
-        "CUSTOM_ENV".to_string(),
-        "x".repeat(vsock_proto::MAX_EXEC_STDIN_BYTES),
-    )]);
-
-    let err = write_user_env_file(&sandbox, run_id, &user_env)
-        .await
-        .unwrap_err();
-    let message = err.to_string();
-
-    assert!(
-        message.contains("user env directory creation failed (cancelled)"),
-        "got: {message}"
-    );
-    assert!(sandbox.write_file_calls().is_empty());
-}
-
-#[tokio::test]
-async fn write_user_env_file_fallback_fails_on_non_exited_chmod_result() {
-    let sandbox = MockSandbox::new("test");
-    sandbox.push_exec_result(Ok(ExecResult::new(0, Vec::new(), Vec::new())));
-    sandbox.push_exec_result(Ok(ExecResult {
-        termination: ExecTermination::Cancelled,
-        stdout: Vec::new(),
-        stderr: b"cancelled".to_vec(),
-        diagnostic: String::new(),
-        stdout_truncated: false,
-        stderr_truncated: false,
-    }));
-    let run_id = RunId::nil();
-    let user_env = HashMap::from([(
-        "CUSTOM_ENV".to_string(),
-        "x".repeat(vsock_proto::MAX_EXEC_STDIN_BYTES),
-    )]);
-
-    let err = write_user_env_file(&sandbox, run_id, &user_env)
-        .await
-        .unwrap_err();
-    let message = err.to_string();
-
-    assert!(
-        message.contains("user env file permission update failed (cancelled)"),
-        "got: {message}"
-    );
-    assert_eq!(sandbox.write_file_calls().len(), 1);
 }
 
 #[test]

--- a/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
@@ -220,7 +220,6 @@ async fn execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_
     let start_calls = overrides.start_process_calls();
     assert_eq!(start_calls.len(), 1);
     let start_env: BTreeMap<String, String> = start_calls[0].env.iter().cloned().collect();
-    let expected_user_env_dir = guest_user_env_dir_path(ctx.run_id).unwrap();
     let expected_user_env_file = guest_user_env_file_path(ctx.run_id).unwrap();
     assert_eq!(start_env.get("VM0_API_TOKEN").unwrap(), "tok");
     assert_eq!(start_env.get("VM0_STUCK_TOOL_TIMEOUT_SECS").unwrap(), "3");
@@ -235,21 +234,19 @@ async fn execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_
         );
     }
 
-    let write_call = overrides
-        .exec_calls()
-        .into_iter()
-        .find(|call| call.cmd.contains(&expected_user_env_dir))
-        .expect("user env file should be written before agent start");
-    assert!(write_call.cmd.contains("umask 077"));
-    assert!(write_call.cmd.contains("mkdir -p -m 700 --"));
-    assert!(write_call.cmd.contains("chmod 700 --"));
-    assert!(write_call.cmd.contains("cat >"));
-    assert!(write_call.cmd.contains("chmod 600 --"));
-    assert!(write_call.cmd.contains(&expected_user_env_file));
-    assert!(write_call.env_keys.is_empty());
-    assert!(!write_call.sudo);
-    let stdin_bytes = write_call.stdin_bytes.as_ref().unwrap();
-    let user_env: HashMap<String, String> = serde_json::from_slice(stdin_bytes).unwrap();
+    assert!(overrides.write_file_calls().is_empty());
+    assert!(
+        overrides
+            .exec_calls()
+            .iter()
+            .all(|call| !call.cmd.contains(&expected_user_env_file)),
+        "user env file should not be written through shell exec"
+    );
+    let private_writes = overrides.private_write_file_calls();
+    assert_eq!(private_writes.len(), 1);
+    assert_eq!(private_writes[0].path, expected_user_env_file);
+    let user_env: HashMap<String, String> =
+        serde_json::from_slice(&private_writes[0].content).unwrap();
     assert_eq!(user_env.get("CUSTOM_USER_ENV").unwrap(), "visible-to-cli");
     assert_eq!(user_env.get("BASH_ENV").unwrap(), "/tmp/user-bash-env");
     assert_eq!(
@@ -260,7 +257,6 @@ async fn execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_
     assert!(!user_env.contains_key("VM0_API_TOKEN"));
     assert!(!user_env.contains_key(USER_ENV_FILE_ENV_KEY));
     assert!(!user_env.contains_key("VM0_STUCK_TOOL_TIMEOUT_SECS"));
-    assert!(overrides.write_file_calls().is_empty());
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor/tests/sandbox_run_tests/mod.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/mod.rs
@@ -15,7 +15,7 @@ use sandbox::{
 use sandbox_mock::{MockSandbox, MockSandboxFactory};
 
 use super::super::agent_run::{RunControls, RunStart};
-use super::super::env::{guest_user_env_dir_path, guest_user_env_file_path};
+use super::super::env::guest_user_env_file_path;
 use super::super::sandbox_run::{
     NewSandboxHooks, PreparedSandboxRun, execute_new_sandbox,
     execute_new_sandbox_with_prepared_notifier, execute_prepared_sandbox_run,

--- a/crates/runner/src/executor/tests/support/sandbox.rs
+++ b/crates/runner/src/executor/tests/support/sandbox.rs
@@ -201,6 +201,10 @@ impl Sandbox for CancelAfterWaitSandbox {
         self.inner.write_file(path, content).await
     }
 
+    async fn write_private_file(&self, path: &str, content: &[u8]) -> sandbox::Result<()> {
+        self.inner.write_private_file(path, content).await
+    }
+
     async fn start_process(
         &self,
         request: &StartProcessRequest<'_>,
@@ -335,6 +339,10 @@ impl Sandbox for QueuedCopyFileSandbox {
 
     async fn write_file(&self, path: &str, content: &[u8]) -> sandbox::Result<()> {
         self.inner.write_file(path, content).await
+    }
+
+    async fn write_private_file(&self, path: &str, content: &[u8]) -> sandbox::Result<()> {
+        self.inner.write_private_file(path, content).await
     }
 
     async fn start_process(

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -1146,6 +1146,10 @@ mod tests {
             result
         }
 
+        async fn write_private_file(&self, path: &str, content: &[u8]) -> sandbox::Result<()> {
+            self.inner.write_private_file(path, content).await
+        }
+
         async fn start_process(
             &self,
             request: &sandbox::StartProcessRequest<'_>,

--- a/crates/runner/src/workspace_promotion/tests.rs
+++ b/crates/runner/src/workspace_promotion/tests.rs
@@ -95,6 +95,10 @@ impl Sandbox for PanicExecSandbox {
         Ok(())
     }
 
+    async fn write_private_file(&self, _path: &str, _content: &[u8]) -> sandbox::Result<()> {
+        panic!("unused write_private_file");
+    }
+
     async fn start_process(
         &self,
         _request: &StartProcessRequest<'_>,

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -2164,6 +2164,15 @@ impl Sandbox for FirecrackerSandbox {
         .await
     }
 
+    async fn write_private_file(&self, path: &str, content: &[u8]) -> sandbox::Result<()> {
+        let operation = SandboxOperation::WriteFile;
+
+        self.run_bounded_guest_operation(operation, |guest| async move {
+            guest.write_private_file(path, content).await
+        })
+        .await
+    }
+
     async fn start_process(
         &self,
         request: &StartProcessRequest<'_>,

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! All mocks succeed by default with ordinary exit code 0 and empty output.
 //! Use [`MockSandbox::push_exec_result`], [`MockSandbox::push_write_file_result`],
+//! [`MockSandbox::push_private_write_file_result`],
 //! [`MockSandboxControl::push_exec_remote_result`], or
 //! [`MockSandboxControl::push_kill_remote_result`] to queue custom responses
 //! consumed in FIFO order.
@@ -471,6 +472,8 @@ pub struct MockSandboxOverrides {
     exec_calls: Mutex<Vec<ExecCall>>,
     /// Recorded write_file calls across all sandboxes built from this override set.
     write_file_calls: Mutex<Vec<WriteFileCall>>,
+    /// Recorded write_private_file calls across all sandboxes built from this override set.
+    private_write_file_calls: Mutex<Vec<WriteFileCall>>,
     /// FIFO queue of read_file results consumed by factory-created sandboxes.
     read_file_results: Mutex<VecDeque<Result<Option<Vec<u8>>>>>,
     /// When `Some`, `wait_process` returns this exit code instead of 0.
@@ -565,6 +568,7 @@ impl MockSandboxOverrides {
             exec_matchers: Mutex::new(Vec::new()),
             exec_calls: Mutex::new(Vec::new()),
             write_file_calls: Mutex::new(Vec::new()),
+            private_write_file_calls: Mutex::new(Vec::new()),
             read_file_results: Mutex::new(VecDeque::new()),
             wait_process_code: None,
             wait_process_gate: None,
@@ -698,6 +702,12 @@ impl MockSandboxOverrides {
     /// result queue.
     pub fn write_file_calls(&self) -> Vec<WriteFileCall> {
         self.write_file_calls.lock_ignoring_poison().clone()
+    }
+
+    /// Return recorded private write-file calls across all sandboxes built
+    /// from this override set.
+    pub fn private_write_file_calls(&self) -> Vec<WriteFileCall> {
+        self.private_write_file_calls.lock_ignoring_poison().clone()
     }
 
     /// Queue a read_file result applied to the next read made through any
@@ -1028,6 +1038,8 @@ pub struct MockSandbox {
     copy_file_calls: Mutex<Vec<CopyFileCall>>,
     write_file_results: Mutex<VecDeque<Result<()>>>,
     write_file_calls: Mutex<Vec<WriteFileCall>>,
+    private_write_file_results: Mutex<VecDeque<Result<()>>>,
+    private_write_file_calls: Mutex<Vec<WriteFileCall>>,
     write_file_gate: Mutex<Option<MockLifecycleGate>>,
     overrides: Option<Arc<MockSandboxOverrides>>,
     /// Holds the stdout channel sender alive when simulating a non-closing
@@ -1061,6 +1073,8 @@ impl MockSandbox {
             copy_file_calls: Mutex::new(Vec::new()),
             write_file_results: Mutex::new(VecDeque::new()),
             write_file_calls: Mutex::new(Vec::new()),
+            private_write_file_results: Mutex::new(VecDeque::new()),
+            private_write_file_calls: Mutex::new(Vec::new()),
             write_file_gate: Mutex::new(None),
             overrides,
             stdout_tx: Mutex::new(None),
@@ -1141,6 +1155,23 @@ impl MockSandbox {
     /// recorded in [`MockSandboxOverrides::write_file_calls`].
     pub fn write_file_calls(&self) -> Vec<WriteFileCall> {
         self.write_file_calls.lock_ignoring_poison().clone()
+    }
+
+    /// Queue a write_private_file result. Results are consumed in FIFO order.
+    /// When the queue is empty, write_private_file returns `Ok(())`.
+    pub fn push_private_write_file_result(&self, result: Result<()>) {
+        self.private_write_file_results
+            .lock_ignoring_poison()
+            .push_back(result);
+    }
+
+    /// Return this sandbox's recorded private write-file calls.
+    ///
+    /// The returned vector is a cloned snapshot in recorded order. When this
+    /// sandbox was built with shared overrides, private write-file calls are
+    /// also recorded in [`MockSandboxOverrides::private_write_file_calls`].
+    pub fn private_write_file_calls(&self) -> Vec<WriteFileCall> {
+        self.private_write_file_calls.lock_ignoring_poison().clone()
     }
 
     /// Block every write_file call with a durable lifecycle gate.
@@ -1431,6 +1462,26 @@ impl Sandbox for MockSandbox {
             gate.enter_and_wait().await;
         }
         self.write_file_results
+            .lock_ignoring_poison()
+            .pop_front()
+            .unwrap_or(Ok(()))
+    }
+
+    async fn write_private_file(&self, path: &str, content: &[u8]) -> Result<()> {
+        let call = WriteFileCall {
+            path: path.to_string(),
+            content: content.to_vec(),
+        };
+        self.private_write_file_calls
+            .lock_ignoring_poison()
+            .push(call.clone());
+        if let Some(overrides) = &self.overrides {
+            overrides
+                .private_write_file_calls
+                .lock_ignoring_poison()
+                .push(call);
+        }
+        self.private_write_file_results
             .lock_ignoring_poison()
             .pop_front()
             .unwrap_or(Ok(()))
@@ -3832,6 +3883,31 @@ mod tests {
 
         // Falls back to default Ok.
         sandbox.write_file("/tmp/test.txt", b"data").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn sandbox_write_private_file_queued_error_and_records_calls() {
+        let sandbox = MockSandbox::new("test-1");
+        sandbox.push_private_write_file_result(Err(SandboxError::Operation {
+            operation: SandboxOperation::WriteFile,
+            reason: SandboxOperationReason::Guest,
+            message: "permission denied".into(),
+        }));
+
+        let result = sandbox
+            .write_private_file("/tmp/private.env", b"secret")
+            .await;
+        assert!(result.is_err());
+        sandbox
+            .write_private_file("/tmp/private.env", b"secret")
+            .await
+            .unwrap();
+
+        assert!(sandbox.write_file_calls().is_empty());
+        let calls = sandbox.private_write_file_calls();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].path, "/tmp/private.env");
+        assert_eq!(calls[0].content, b"secret");
     }
 
     #[tokio::test]

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -246,6 +246,15 @@ pub trait Sandbox: Send + Sync + Any {
     /// directories and truncating the file as needed. Returns an error if
     /// the sandbox is not running or if the backing process crashes.
     async fn write_file(&self, path: &str, content: &[u8]) -> Result<()>;
+
+    /// Write `content` to a private runtime file inside the guest.
+    ///
+    /// Implementations should use guest runtime-private semantics: create
+    /// private parent directories, reject symlinked parent components, and
+    /// write the file with private permissions. Generic workspace file writes
+    /// should continue to use [`write_file`](Self::write_file).
+    async fn write_private_file(&self, path: &str, content: &[u8]) -> Result<()>;
+
     /// Start `request.cmd` in the guest and return a handle for later
     /// supervision via [`wait_process`](Self::wait_process).
     ///

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -250,9 +250,10 @@ pub trait Sandbox: Send + Sync + Any {
     /// Write `content` to a private runtime file inside the guest.
     ///
     /// Implementations should use guest runtime-private semantics: create
-    /// private parent directories, reject symlinked parent components, and
-    /// write the file with private permissions. Generic workspace file writes
-    /// should continue to use [`write_file`](Self::write_file).
+    /// missing private parent directories, reject symlinked parent components,
+    /// reject non-private existing final parent directories, and write the file
+    /// with private permissions. Generic workspace file writes should continue
+    /// to use [`write_file`](Self::write_file).
     async fn write_private_file(&self, path: &str, content: &[u8]) -> Result<()>;
 
     /// Start `request.cmd` in the guest and return a handle for later

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -249,11 +249,10 @@ pub trait Sandbox: Send + Sync + Any {
 
     /// Write `content` to a private runtime file inside the guest.
     ///
-    /// Implementations should use guest runtime-private semantics: create
-    /// missing private parent directories, reject symlinked parent components,
-    /// reject non-private existing final parent directories, and write the file
-    /// with private permissions. Generic workspace file writes should continue
-    /// to use [`write_file`](Self::write_file).
+    /// Implementations should use guest runtime-private semantics: ensure
+    /// parent directories are private, reject symlinked parent components, and
+    /// write the file with private permissions. Generic workspace file writes
+    /// should continue to use [`write_file`](Self::write_file).
     async fn write_private_file(&self, path: &str, content: &[u8]) -> Result<()>;
 
     /// Start `request.cmd` in the guest and return a handle for later

--- a/crates/vsock-guest/src/handlers.rs
+++ b/crates/vsock-guest/src/handlers.rs
@@ -38,22 +38,30 @@ pub(crate) struct DecodedWriteFileMessage<'a> {
     content: &'a [u8],
     use_sudo: bool,
     append: bool,
+    private: bool,
 }
 
 /// Handle write_file message
-fn handle_write_file(path: &str, content: &[u8], use_sudo: bool, append: bool) -> (bool, String) {
+fn handle_write_file(
+    path: &str,
+    content: &[u8],
+    use_sudo: bool,
+    append: bool,
+    private: bool,
+) -> (bool, String) {
     log(
         "INFO",
         &format!(
-            "write_file: path={} size={} sudo={} append={}",
+            "write_file: path={} size={} sudo={} append={} private={}",
             path,
             content.len(),
             use_sudo,
             append,
+            private,
         ),
     );
 
-    let child = match spawn_write_file_command(path, use_sudo, append) {
+    let child = match spawn_write_file_command(path, use_sudo, append, private) {
         Ok(c) => c,
         Err(e) => return (false, format!("Failed to spawn write command: {e}")),
     };
@@ -181,12 +189,39 @@ where
     })
 }
 
-fn spawn_write_file_command(path: &str, use_sudo: bool, append: bool) -> io::Result<Child> {
-    let mut command = Command::new(guest_write_file_path());
+fn write_file_command_args(
+    use_sudo: bool,
+    append: bool,
+    private: bool,
+) -> io::Result<Vec<&'static str>> {
+    if private && use_sudo {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "private write_file cannot use sudo",
+        ));
+    }
+
+    let mut args = Vec::new();
+    if private {
+        args.push("--private");
+    }
     if append {
-        command.arg("--append");
-    } else if !use_sudo {
-        command.arg("--create-parents");
+        args.push("--append");
+    } else if !use_sudo && !private {
+        args.push("--create-parents");
+    }
+    Ok(args)
+}
+
+fn spawn_write_file_command(
+    path: &str,
+    use_sudo: bool,
+    append: bool,
+    private: bool,
+) -> io::Result<Child> {
+    let mut command = Command::new(guest_write_file_path());
+    for arg in write_file_command_args(use_sudo, append, private)? {
+        command.arg(arg);
     }
     command
         .arg("--")
@@ -224,12 +259,13 @@ pub(crate) fn set_debug_guest_write_file_path(path: PathBuf) {
 pub(crate) fn decode_write_file_message(
     msg: &RawMessage,
 ) -> Result<DecodedWriteFileMessage<'_>, vsock_proto::ProtocolError> {
-    let (path, content, use_sudo, append) = vsock_proto::decode_write_file(&msg.payload)?;
+    let (path, content, use_sudo, append, private) = vsock_proto::decode_write_file(&msg.payload)?;
     Ok(DecodedWriteFileMessage {
         path,
         content,
         use_sudo,
         append,
+        private,
     })
 }
 
@@ -242,6 +278,7 @@ pub(crate) fn handle_decoded_write_file_message(
         decoded.content,
         decoded.use_sudo,
         decoded.append,
+        decoded.private,
     );
     let payload = vsock_proto::encode_write_file_result(success, &error);
     vsock_proto::encode(MSG_WRITE_FILE_RESULT, seq, &payload).map_err(to_io_error)
@@ -339,6 +376,27 @@ mod tests {
         assert!(!success);
         assert!(error.contains("stderr drain thread"));
         assert!(!pid_alive(pid), "child pid {pid} should have been reaped");
+    }
+
+    #[test]
+    fn write_file_command_args_use_private_mode_without_create_parents() {
+        let args = write_file_command_args(false, false, true).unwrap();
+
+        assert_eq!(args, vec!["--private"]);
+    }
+
+    #[test]
+    fn write_file_command_args_use_private_append_mode() {
+        let args = write_file_command_args(false, true, true).unwrap();
+
+        assert_eq!(args, vec!["--private", "--append"]);
+    }
+
+    #[test]
+    fn write_file_command_args_reject_private_sudo() {
+        let error = write_file_command_args(true, false, true).unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
     }
 
     #[test]

--- a/crates/vsock-host/src/file/write.rs
+++ b/crates/vsock-host/src/file/write.rs
@@ -32,6 +32,36 @@ enum WriteFileChunkTracking<'a> {
     Composite(&'a mut CompositeNormalOperation),
 }
 
+struct WriteFileChunkRequest<'a> {
+    path: &'a str,
+    content: &'a [u8],
+    sudo: bool,
+    append: bool,
+    private: bool,
+}
+
+impl<'a> WriteFileChunkRequest<'a> {
+    fn standard(path: &'a str, content: &'a [u8], sudo: bool, append: bool) -> Self {
+        Self {
+            path,
+            content,
+            sudo,
+            append,
+            private: false,
+        }
+    }
+
+    fn private(path: &'a str, content: &'a [u8], append: bool) -> Self {
+        Self {
+            path,
+            content,
+            sudo: false,
+            append,
+            private: true,
+        }
+    }
+}
+
 #[derive(Debug)]
 struct WriteFileGuestError(String);
 
@@ -355,6 +385,60 @@ impl VsockHost {
             .await
     }
 
+    /// Write a private runtime file on the guest.
+    ///
+    /// Content larger than 15 MB is split into multiple messages. The first
+    /// chunk creates or truncates the final file through private runtime-file
+    /// semantics; later chunks append to the same file. A failed chunk leaves
+    /// the run failed and may leave a partial private runtime file behind.
+    pub async fn write_private_file(&self, path: &str, content: &[u8]) -> io::Result<()> {
+        self.write_private_file_with_write_observer(path, content, FrameWriteObserver::default())
+            .await
+    }
+
+    /// Write a private runtime file on the guest and report before each
+    /// helper frame is written to the guest.
+    pub async fn write_private_file_with_write_observer(
+        &self,
+        path: &str,
+        content: &[u8],
+        write_observer: FrameWriteObserver,
+    ) -> io::Result<()> {
+        validate_guest_file_path(path)?;
+        if content.len() <= WRITE_FILE_CHUNK_LIMIT {
+            return self
+                .write_file_chunk(
+                    WriteFileChunkRequest::private(path, content, false),
+                    WriteFileChunkTracking::Tracked,
+                    write_observer,
+                )
+                .await;
+        }
+
+        let mut normal_operation = CompositeNormalOperation::reserve(&self.shared)?;
+        let result = async {
+            for (i, chunk) in content.chunks(WRITE_FILE_CHUNK_LIMIT).enumerate() {
+                self.write_file_chunk(
+                    WriteFileChunkRequest::private(path, chunk, i > 0),
+                    WriteFileChunkTracking::Composite(&mut normal_operation),
+                    write_observer.clone(),
+                )
+                .await?;
+            }
+            io::Result::Ok(())
+        }
+        .await;
+
+        if let Err(error) = result {
+            if error_is_write_file_guest_error(&error) {
+                normal_operation.complete()?;
+            }
+            return Err(error);
+        }
+
+        normal_operation.complete()
+    }
+
     /// Write a file on the guest and report before each helper frame is
     /// written to the guest.
     pub async fn write_file_with_write_observer(
@@ -368,10 +452,7 @@ impl VsockHost {
         if content.len() <= WRITE_FILE_CHUNK_LIMIT {
             return self
                 .write_file_chunk(
-                    path,
-                    content,
-                    sudo,
-                    false,
+                    WriteFileChunkRequest::standard(path, content, sudo, false),
                     WriteFileChunkTracking::Tracked,
                     write_observer,
                 )
@@ -400,10 +481,7 @@ impl VsockHost {
         let result = async {
             for (i, chunk) in content.chunks(WRITE_FILE_CHUNK_LIMIT).enumerate() {
                 self.write_file_chunk(
-                    &tmp,
-                    chunk,
-                    sudo,
-                    i > 0,
+                    WriteFileChunkRequest::standard(&tmp, chunk, sudo, i > 0),
                     WriteFileChunkTracking::Composite(&mut normal_operation),
                     write_observer.clone(),
                 )
@@ -467,15 +545,21 @@ impl VsockHost {
     /// Send a single write_file message and validate the response.
     async fn write_file_chunk(
         &self,
-        path: &str,
-        content: &[u8],
-        sudo: bool,
-        append: bool,
+        request: WriteFileChunkRequest<'_>,
         tracking: WriteFileChunkTracking<'_>,
         write_observer: FrameWriteObserver,
     ) -> io::Result<()> {
-        let payload = vsock_proto::encode_write_file(path, content, sudo, append)
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
+        let payload = if request.private {
+            vsock_proto::encode_private_write_file(request.path, request.content, request.append)
+        } else {
+            vsock_proto::encode_write_file(
+                request.path,
+                request.content,
+                request.sudo,
+                request.append,
+            )
+        }
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
         let timeout = Duration::from_secs(300);
         let resp = match tracking {
             WriteFileChunkTracking::Tracked => {

--- a/crates/vsock-host/src/tests/file/support.rs
+++ b/crates/vsock-host/src/tests/file/support.rs
@@ -119,6 +119,14 @@ pub(super) fn spawn_write_file(
     tokio::spawn(async move { host.write_file(path, &content, sudo).await })
 }
 
+pub(super) fn spawn_write_private_file(
+    host: Arc<VsockHost>,
+    path: &'static str,
+    content: Vec<u8>,
+) -> JoinHandle<io::Result<()>> {
+    tokio::spawn(async move { host.write_private_file(path, &content).await })
+}
+
 pub(super) struct ExecStartFrame {
     pub(super) msg: RawMessage,
     pub(super) command: String,
@@ -179,6 +187,7 @@ pub(super) struct WriteFileFrame {
     pub(super) content: Vec<u8>,
     pub(super) sudo: bool,
     pub(super) append: bool,
+    pub(super) private: bool,
 }
 
 impl WriteFileFrame {
@@ -190,9 +199,10 @@ impl WriteFileFrame {
 pub(super) async fn expect_write_file(guest: &mut UnixStream) -> WriteFileFrame {
     let msg = read_guest_message(guest).await;
     assert_eq!(msg.msg_type, MSG_WRITE_FILE);
-    let (path, content, sudo, append) = {
-        let (path, content, sudo, append) = vsock_proto::decode_write_file(&msg.payload).unwrap();
-        (path.to_string(), content.to_vec(), sudo, append)
+    let (path, content, sudo, append, private) = {
+        let (path, content, sudo, append, private) =
+            vsock_proto::decode_write_file(&msg.payload).unwrap();
+        (path.to_string(), content.to_vec(), sudo, append, private)
     };
     WriteFileFrame {
         msg,
@@ -200,6 +210,7 @@ pub(super) async fn expect_write_file(guest: &mut UnixStream) -> WriteFileFrame 
         content,
         sudo,
         append,
+        private,
     }
 }
 

--- a/crates/vsock-host/src/tests/file/write_chunked.rs
+++ b/crates/vsock-host/src/tests/file/write_chunked.rs
@@ -431,6 +431,123 @@ async fn write_private_file_chunked_guest_failure_releases_tracker() {
 }
 
 #[tokio::test]
+async fn write_private_file_chunked_cancelled_before_first_frame_write_releases_tracker() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let write_start_count = Arc::new(AtomicUsize::new(0));
+    let writer_guard = host.shared.writer.lock().await;
+    let content = ChunkedWriteFixture::two_chunk_content();
+    let write_task = {
+        let host = Arc::clone(&host);
+        let write_start_count = Arc::clone(&write_start_count);
+        tokio::spawn(async move {
+            host.write_private_file_with_write_observer(
+                "/tmp/private-blocked.env",
+                &content,
+                FrameWriteObserver::new(move || {
+                    write_start_count.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                }),
+            )
+            .await
+        })
+    };
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while pending_request_count(&host) != 1 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+    write_task.abort();
+    let _ = write_task.await;
+
+    assert_eq!(write_start_count.load(Ordering::SeqCst), 0);
+    assert_eq!(pending_request_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+
+    drop(writer_guard);
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
+}
+
+#[tokio::test]
+async fn write_private_file_chunked_chunk_observer_error_keeps_tracker_fail_closed() {
+    let (host, guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let write_start_count = Arc::new(AtomicUsize::new(0));
+    let content = ChunkedWriteFixture::two_chunk_content();
+
+    let err = host
+        .write_private_file_with_write_observer(
+            "/tmp/private-observer.env",
+            &content,
+            FrameWriteObserver::new({
+                let write_start_count = Arc::clone(&write_start_count);
+                move || {
+                    write_start_count.fetch_add(1, Ordering::SeqCst);
+                    Err(io::Error::other("private chunk observer failed"))
+                }
+            }),
+        )
+        .await
+        .unwrap_err();
+
+    assert!(err.to_string().contains("private chunk observer failed"));
+    assert_eq!(write_start_count.load(Ordering::SeqCst), 1);
+    match guest.try_read(&mut [0u8; 1]) {
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+        Ok(n) => panic!("observer error must not send private write_file frame; read {n} bytes"),
+        Err(err) => panic!("unexpected read error after observer error: {err}"),
+    }
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+}
+
+#[tokio::test]
+async fn write_private_file_chunked_unexpected_response_keeps_tracker_fail_closed() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let content = ChunkedWriteFixture::two_chunk_content();
+    let write_task =
+        spawn_write_private_file(Arc::clone(&host), "/tmp/private-unexpected.env", content);
+
+    let first = expect_write_file(&mut guest).await;
+    assert_eq!(first.path, "/tmp/private-unexpected.env");
+    assert!(!first.append);
+    assert!(first.private);
+    send_write_file_success(&mut guest, first.seq()).await;
+
+    let second = expect_write_file(&mut guest).await;
+    assert_eq!(second.path, "/tmp/private-unexpected.env");
+    assert!(second.append);
+    assert!(second.private);
+    guest
+        .write_all(&vsock_proto::encode(MSG_EXEC_START, second.seq(), &[]).unwrap())
+        .await
+        .unwrap();
+
+    let err = write_task.await.unwrap().unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::NotParkable
+    );
+    match guest.try_read(&mut [0u8; 1]) {
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+        Ok(n) => {
+            panic!("private write must not send cleanup after unexpected response; read {n} bytes")
+        }
+        Err(err) => panic!("unexpected read error after unexpected response: {err}"),
+    }
+}
+
+#[tokio::test]
 async fn write_file_chunked_quotes_target_path_with_single_quote() {
     let mut fixture = ChunkedWriteFixture::new("/tmp/big'quote.bin").await;
     let write_task = fixture.spawn_write(ChunkedWriteFixture::two_chunk_content(), false);

--- a/crates/vsock-host/src/tests/file/write_chunked.rs
+++ b/crates/vsock-host/src/tests/file/write_chunked.rs
@@ -393,6 +393,44 @@ async fn write_private_file_chunked_writes_final_path_without_rename() {
 }
 
 #[tokio::test]
+async fn write_private_file_chunked_guest_failure_releases_tracker() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let chunk_limit = ChunkedWriteFixture::chunk_limit();
+    let content = vec![0xCD; chunk_limit + 100];
+    let write_task = spawn_write_private_file(Arc::clone(&host), "/tmp/private-fail.env", content);
+
+    let first = expect_write_file(&mut guest).await;
+    assert_eq!(first.path, "/tmp/private-fail.env");
+    assert!(!first.sudo);
+    assert!(!first.append);
+    assert!(first.private);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Busy
+    );
+    send_write_file_success(&mut guest, first.seq()).await;
+
+    let second = expect_write_file(&mut guest).await;
+    assert_eq!(second.path, "/tmp/private-fail.env");
+    assert!(!second.sudo);
+    assert!(second.append);
+    assert!(second.private);
+    send_write_file_failure(&mut guest, second.seq(), "disk full").await;
+
+    let err = tokio::time::timeout(Duration::from_secs(1), write_task)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap_err();
+    assert!(err.to_string().contains("disk full"));
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+}
+
+#[tokio::test]
 async fn write_file_chunked_quotes_target_path_with_single_quote() {
     let mut fixture = ChunkedWriteFixture::new("/tmp/big'quote.bin").await;
     let write_task = fixture.spawn_write(ChunkedWriteFixture::two_chunk_content(), false);

--- a/crates/vsock-host/src/tests/file/write_chunked.rs
+++ b/crates/vsock-host/src/tests/file/write_chunked.rs
@@ -17,7 +17,7 @@ use super::super::support::{
 };
 use super::support::{
     ExecStartFrame, WriteFileFrame, expect_exec_start, expect_write_file, send_guest_error,
-    send_write_file_failure, send_write_file_success, spawn_write_file,
+    send_write_file_failure, send_write_file_success, spawn_write_file, spawn_write_private_file,
 };
 use crate::{FrameWriteObserver, VsockHost, operation_tracker::NormalOperationReadiness};
 use crate::{exec_operation, file as file_impl};
@@ -66,6 +66,7 @@ impl ChunkedWriteFixture {
     async fn expect_chunk(&mut self) -> WriteFileFrame {
         let frame = expect_write_file(&mut self.guest).await;
         assert_eq!(frame.sudo, self.sudo);
+        assert!(!frame.private);
         if let Some(temp_path) = &self.temp_path {
             assert_eq!(frame.path.as_str(), temp_path);
             assert!(frame.append);
@@ -343,6 +344,55 @@ async fn test_write_file_chunked() {
 }
 
 #[tokio::test]
+async fn write_private_file_single_chunk_sets_private_flag() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let write_task =
+        spawn_write_private_file(Arc::clone(&host), "/tmp/private.env", b"secret".to_vec());
+
+    let frame = expect_write_file(&mut guest).await;
+    assert_eq!(frame.path, "/tmp/private.env");
+    assert_eq!(frame.content, b"secret");
+    assert!(!frame.sudo);
+    assert!(!frame.append);
+    assert!(frame.private);
+    send_write_file_success(&mut guest, frame.seq()).await;
+
+    write_task.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn write_private_file_chunked_writes_final_path_without_rename() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let chunk_limit = ChunkedWriteFixture::chunk_limit();
+    let content = vec![0xCD; chunk_limit + 100];
+    let write_task = spawn_write_private_file(Arc::clone(&host), "/tmp/private-big.env", content);
+
+    let first = expect_write_file(&mut guest).await;
+    assert_eq!(first.path, "/tmp/private-big.env");
+    assert_eq!(first.content.len(), chunk_limit);
+    assert!(!first.sudo);
+    assert!(!first.append);
+    assert!(first.private);
+    send_write_file_success(&mut guest, first.seq()).await;
+
+    let second = expect_write_file(&mut guest).await;
+    assert_eq!(second.path, "/tmp/private-big.env");
+    assert_eq!(second.content.len(), 100);
+    assert!(!second.sudo);
+    assert!(second.append);
+    assert!(second.private);
+    send_write_file_success(&mut guest, second.seq()).await;
+
+    tokio::time::timeout(Duration::from_secs(1), write_task)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+}
+
+#[tokio::test]
 async fn write_file_chunked_quotes_target_path_with_single_quote() {
     let mut fixture = ChunkedWriteFixture::new("/tmp/big'quote.bin").await;
     let write_task = fixture.spawn_write(ChunkedWriteFixture::two_chunk_content(), false);
@@ -411,9 +461,10 @@ async fn write_file_chunked_concurrent_writes_to_same_target_use_distinct_temp_p
         let msg = read_guest_message(&mut guest).await;
         match msg.msg_type {
             MSG_WRITE_FILE => {
-                let (path, content, sudo, append) =
+                let (path, content, sudo, append, private) =
                     vsock_proto::decode_write_file(&msg.payload).unwrap();
                 assert!(!sudo);
+                assert!(!private);
                 assert!(path.starts_with(&format!("{target_path}.vm0tmp-")));
                 let marker = *content.first().expect("chunk content");
                 assert!(matches!(marker, 0xAA | 0xBB));
@@ -502,8 +553,10 @@ async fn write_file_chunked_concurrent_failure_cleans_only_failed_temp_path() {
     while first_chunks.len() < 2 {
         let msg = read_guest_message(&mut guest).await;
         assert_eq!(msg.msg_type, MSG_WRITE_FILE);
-        let (path, content, sudo, append) = vsock_proto::decode_write_file(&msg.payload).unwrap();
+        let (path, content, sudo, append, private) =
+            vsock_proto::decode_write_file(&msg.payload).unwrap();
         assert!(!sudo);
+        assert!(!private);
         assert!(!append);
         assert!(path.starts_with(&format!("{target_path}.vm0tmp-")));
         assert_eq!(content.len(), chunk_limit);
@@ -522,8 +575,10 @@ async fn write_file_chunked_concurrent_failure_cleans_only_failed_temp_path() {
     while second_chunks.len() < 2 {
         let msg = read_guest_message(&mut guest).await;
         assert_eq!(msg.msg_type, MSG_WRITE_FILE);
-        let (path, content, sudo, append) = vsock_proto::decode_write_file(&msg.payload).unwrap();
+        let (path, content, sudo, append, private) =
+            vsock_proto::decode_write_file(&msg.payload).unwrap();
         assert!(!sudo);
+        assert!(!private);
         assert!(append);
         assert_eq!(content.len(), 1);
         let marker = *content.first().expect("chunk content");
@@ -1275,9 +1330,10 @@ async fn test_write_file_chunked_cleans_up_when_cancelled() {
             let msg = guest.read_message().await;
             match msg.msg_type {
                 MSG_WRITE_FILE => {
-                    let (path, _chunk, sudo, append) =
+                    let (path, _chunk, sudo, append, private) =
                         vsock_proto::decode_write_file(&msg.payload).unwrap();
                     assert!(!sudo);
+                    assert!(!private);
                     if let Some(temp_path) = &temp_path {
                         assert_eq!(path, temp_path);
                         assert!(append);

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -35,7 +35,7 @@
 //! | 0x06 | G→H       | operations_quiesced    | (empty) |
 //! | 0x07 | H→G       | resume_operations | (empty) |
 //! | 0x08 | G→H       | operations_resumed | (empty) |
-//! | 0x09 | H→G       | write_file        | `[2B path_len][path][1B flags][4B content_len][content]` (flags: `SUDO=0x01`, `APPEND=0x02`) |
+//! | 0x09 | H→G       | write_file        | `[2B path_len][path][1B flags][4B content_len][content]` (flags: `SUDO=0x01`, `APPEND=0x02`, `PRIVATE=0x04`; `PRIVATE` and `SUDO` are mutually exclusive) |
 //! | 0x0A | G→H       | write_file_result | `[1B success][2B error_len][error]` |
 //! | 0x0B | H→G       | exec_start     | see payload schema below |
 //! | 0x0C | G→H       | exec_started | `[4B pid]` |

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -170,7 +170,8 @@ pub use payloads::exec_operation::{
     encode_exec_start_with_expected_exit_codes, encode_exec_started,
 };
 pub use payloads::write_file::{
-    decode_write_file, decode_write_file_result, encode_write_file, encode_write_file_result,
+    decode_write_file, decode_write_file_result, encode_private_write_file, encode_write_file,
+    encode_write_file_result,
 };
 pub use wire::{
     EXEC_CAPTURED_OUTPUT_FLAG_TRUNCATED, EXEC_FLAG_SUDO, EXEC_OUTPUT_FLAG_TRUNCATED, HEADER_SIZE,
@@ -178,5 +179,6 @@ pub use wire::{
     MSG_EXEC_CONTROL_RESULT, MSG_EXEC_OUTPUT, MSG_EXEC_RESULT, MSG_EXEC_START, MSG_EXEC_STARTED,
     MSG_OPERATIONS_QUIESCED, MSG_OPERATIONS_RESUMED, MSG_PING, MSG_PONG, MSG_QUIESCE_OPERATIONS,
     MSG_READY, MSG_RESUME_OPERATIONS, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_WRITE_FILE,
-    MSG_WRITE_FILE_RESULT, VSOCK_PORT, WRITE_FILE_FLAG_APPEND, WRITE_FILE_FLAG_SUDO,
+    MSG_WRITE_FILE_RESULT, VSOCK_PORT, WRITE_FILE_FLAG_APPEND, WRITE_FILE_FLAG_PRIVATE,
+    WRITE_FILE_FLAG_SUDO,
 };

--- a/crates/vsock-proto/src/payloads/write_file.rs
+++ b/crates/vsock-proto/src/payloads/write_file.rs
@@ -4,7 +4,7 @@ use crate::read::{
     checked_payload_len_add, ensure_payload_fits_message, ensure_u16_len, ensure_u32_len,
     expect_consumed, read_slice, read_str, read_u8, read_u16, read_u32,
 };
-use crate::wire::{WRITE_FILE_FLAG_APPEND, WRITE_FILE_FLAG_SUDO};
+use crate::wire::{WRITE_FILE_FLAG_APPEND, WRITE_FILE_FLAG_PRIVATE, WRITE_FILE_FLAG_SUDO};
 
 /// Encode write_file payload: `[2B path_len][path][1B flags][4B content_len][content]`.
 ///
@@ -15,6 +15,25 @@ pub fn encode_write_file(
     content: &[u8],
     sudo: bool,
     append: bool,
+) -> Result<Vec<u8>, ProtocolError> {
+    encode_write_file_flags(path, content, sudo, append, false)
+}
+
+/// Encode a private write_file payload.
+pub fn encode_private_write_file(
+    path: &str,
+    content: &[u8],
+    append: bool,
+) -> Result<Vec<u8>, ProtocolError> {
+    encode_write_file_flags(path, content, false, append, true)
+}
+
+fn encode_write_file_flags(
+    path: &str,
+    content: &[u8],
+    sudo: bool,
+    append: bool,
+    private: bool,
 ) -> Result<Vec<u8>, ProtocolError> {
     let path_bytes = path.as_bytes();
     let path_len = ensure_u16_len("path", path_bytes.len())?;
@@ -30,6 +49,9 @@ pub fn encode_write_file(
     }
     if append {
         flags |= WRITE_FILE_FLAG_APPEND;
+    }
+    if private {
+        flags |= WRITE_FILE_FLAG_PRIVATE;
     }
     let mut p = Vec::with_capacity(payload_len);
     p.extend_from_slice(&path_len.to_be_bytes());
@@ -53,8 +75,8 @@ pub fn encode_write_file_result(success: bool, error: &str) -> Vec<u8> {
     p
 }
 
-/// Decode write_file payload. Returns `(path, content, sudo, append)`.
-pub fn decode_write_file(payload: &[u8]) -> Result<(&str, &[u8], bool, bool), ProtocolError> {
+/// Decode write_file payload. Returns `(path, content, sudo, append, private)`.
+pub fn decode_write_file(payload: &[u8]) -> Result<(&str, &[u8], bool, bool, bool), ProtocolError> {
     let mut offset = 0;
     let path_len = read_u16(payload, &mut offset, "write_file too short")? as usize;
     let path = read_str(
@@ -65,9 +87,14 @@ pub fn decode_write_file(payload: &[u8]) -> Result<(&str, &[u8], bool, bool), Pr
         "invalid UTF-8 in path",
     )?;
     let flags = read_u8(payload, &mut offset, "write_file too short")?;
-    let known_flags = WRITE_FILE_FLAG_SUDO | WRITE_FILE_FLAG_APPEND;
+    let known_flags = WRITE_FILE_FLAG_SUDO | WRITE_FILE_FLAG_APPEND | WRITE_FILE_FLAG_PRIVATE;
     if flags & !known_flags != 0 {
         return Err(ProtocolError::InvalidPayload("write_file unknown flags"));
+    }
+    if flags & WRITE_FILE_FLAG_PRIVATE != 0 && flags & WRITE_FILE_FLAG_SUDO != 0 {
+        return Err(ProtocolError::InvalidPayload(
+            "write_file private flag cannot be combined with sudo",
+        ));
     }
     let content_len = read_u32(payload, &mut offset, "write_file too short")? as usize;
     let content = read_slice(
@@ -83,6 +110,7 @@ pub fn decode_write_file(payload: &[u8]) -> Result<(&str, &[u8], bool, bool), Pr
         content,
         (flags & WRITE_FILE_FLAG_SUDO) != 0,
         (flags & WRITE_FILE_FLAG_APPEND) != 0,
+        (flags & WRITE_FILE_FLAG_PRIVATE) != 0,
     ))
 }
 
@@ -123,39 +151,54 @@ mod tests {
     #[test]
     fn write_file_payload_roundtrip() {
         let payload = encode_write_file("/tmp/test.txt", b"content", false, false).unwrap();
-        let (path, content, sudo, append) = decode_write_file(&payload).unwrap();
+        let (path, content, sudo, append, private) = decode_write_file(&payload).unwrap();
         assert_eq!(path, "/tmp/test.txt");
         assert_eq!(content, b"content");
         assert!(!sudo);
         assert!(!append);
+        assert!(!private);
     }
 
     #[test]
     fn write_file_with_sudo() {
         let payload = encode_write_file("/etc/hosts", b"127.0.0.1", true, false).unwrap();
-        let (path, content, sudo, append) = decode_write_file(&payload).unwrap();
+        let (path, content, sudo, append, private) = decode_write_file(&payload).unwrap();
         assert_eq!(path, "/etc/hosts");
         assert_eq!(content, b"127.0.0.1");
         assert!(sudo);
         assert!(!append);
+        assert!(!private);
     }
 
     #[test]
     fn write_file_with_append() {
         let payload = encode_write_file("/tmp/out.log", b"more data", false, true).unwrap();
-        let (path, content, sudo, append) = decode_write_file(&payload).unwrap();
+        let (path, content, sudo, append, private) = decode_write_file(&payload).unwrap();
         assert_eq!(path, "/tmp/out.log");
         assert_eq!(content, b"more data");
         assert!(!sudo);
         assert!(append);
+        assert!(!private);
     }
 
     #[test]
     fn write_file_with_sudo_and_append() {
         let payload = encode_write_file("/etc/conf", b"line", true, true).unwrap();
-        let (_, _, sudo, append) = decode_write_file(&payload).unwrap();
+        let (_, _, sudo, append, private) = decode_write_file(&payload).unwrap();
         assert!(sudo);
         assert!(append);
+        assert!(!private);
+    }
+
+    #[test]
+    fn write_file_with_private() {
+        let payload = encode_private_write_file("/tmp/private", b"secret", true).unwrap();
+        let (path, content, sudo, append, private) = decode_write_file(&payload).unwrap();
+        assert_eq!(path, "/tmp/private");
+        assert_eq!(content, b"secret");
+        assert!(!sudo);
+        assert!(append);
+        assert!(private);
     }
 
     #[test]
@@ -184,11 +227,13 @@ mod tests {
         let payload = encode_write_file(path, &content, false, false).unwrap();
 
         assert_eq!(payload.len(), MAX_PAYLOAD_SIZE);
-        let (decoded_path, decoded_content, sudo, append) = decode_write_file(&payload).unwrap();
+        let (decoded_path, decoded_content, sudo, append, private) =
+            decode_write_file(&payload).unwrap();
         assert_eq!(decoded_path, path);
         assert_eq!(decoded_content, content.as_slice());
         assert!(!sudo);
         assert!(!append);
+        assert!(!private);
     }
 
     #[test]
@@ -257,6 +302,23 @@ mod tests {
         let err = decode_write_file(&payload).unwrap_err();
 
         assert_invalid_payload(err, "write_file unknown flags");
+    }
+
+    #[test]
+    fn decode_write_file_rejects_private_with_sudo() {
+        let payload = [
+            0,
+            0,
+            WRITE_FILE_FLAG_PRIVATE | WRITE_FILE_FLAG_SUDO,
+            0,
+            0,
+            0,
+            0,
+        ];
+
+        let err = decode_write_file(&payload).unwrap_err();
+
+        assert_invalid_payload(err, "write_file private flag cannot be combined with sudo");
     }
 
     #[test]

--- a/crates/vsock-proto/src/wire.rs
+++ b/crates/vsock-proto/src/wire.rs
@@ -90,6 +90,9 @@ pub const WRITE_FILE_FLAG_SUDO: u8 = 0x01;
 /// Write-file payload flag requesting append instead of overwrite.
 pub const WRITE_FILE_FLAG_APPEND: u8 = 0x02;
 
+/// Write-file payload flag requesting private runtime-file semantics.
+pub const WRITE_FILE_FLAG_PRIVATE: u8 = 0x04;
+
 pub(crate) const MAX_PAYLOAD_SIZE: usize = MAX_MESSAGE_SIZE - MIN_BODY_SIZE;
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Harden `guest-contracts::runtime_paths` on Unix with fd-based, non-following parent traversal and final-file opens relative to verified parent directories.
- Add explicit private write-file support through `guest-write-file --private`, the vsock write-file flag, and `Sandbox::write_private_file`.
- Move runner-authored user env transfer from shell/generic writes to the private write path while leaving ordinary `write_file` semantics unchanged.

## Notes

This does not claim to protect runtime files from same-UID guest processes under the user home. It specifically fails closed for symlink-parent redirection and final-path replacement hazards on private runtime writes.

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p runner write_user_env_file`
- `cargo test --manifest-path crates/Cargo.toml -p runner execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_only`
- `cargo test --manifest-path crates/Cargo.toml -p guest-contracts runtime_paths`
- `cargo test --manifest-path crates/Cargo.toml -p guest-write-file`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-proto write_file`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-guest write_file`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host write_file`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host write_private_file`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-mock`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc write_private_file`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-contracts -p guest-write-file -p vsock-proto -p vsock-guest -p vsock-host -p sandbox -p sandbox-mock -p sandbox-fc -p runner --tests -- -D warnings`

Closes #18762