### PR TITLE
fix: require model usage provider for model observations

### DIFF
--- a/crates/runner/mitm-addon/src/flow_metadata_keys.py
+++ b/crates/runner/mitm-addon/src/flow_metadata_keys.py
@@ -62,8 +62,8 @@ Firewall and auth context
   network-log firewall metadata when it has the expected shape.
 - ``FIREWALL_BILLABLE``: ``bool`` computed from runner VM billable firewall
   context for matched auth flows, or forced ``False`` for browser passthrough.
-  Gates connector billing and connector response parser setup; model usage
-  reporting still checks model-provider-specific gates.
+  Gates connector billing, model-provider billing, and connector response parser
+  setup; model usage observation still checks model-provider-specific gates.
 - ``FIREWALL_ACTION``: ``str`` firewall decision such as ``ALLOW``, ``DENY``,
   or ``BLOCK``. Read by response/error network logging.
 - ``FIREWALL_ERROR``: optional ``str`` error code for auth, forwarding, or
@@ -125,10 +125,10 @@ Model-provider usage
   usage extraction and read by model usage-event and observation reporters.
   Entries may be removed before ``websocket_end()`` once a terminal WebSocket
   usage frame is accepted into the source-preserving usage buffer or the source
-  has no future reporting path. Zero-only entries that only preserve model hints
-  for a later same-response-id frame are retained with a small per-flow bound.
-- ``MODEL_USAGE_PROVIDER``: optional ``str`` model id from registry VM info.
-  Read by model-provider usage observability and reported-model selection.
+  has no future reporting path. Zero-only entries are released immediately
+  because observable model-provider flows already carry ``MODEL_USAGE_PROVIDER``.
+- ``MODEL_USAGE_PROVIDER``: optional ``str`` canonical model id from registry VM
+  info. Read by model-provider usage observability and reported-model selection.
 - ``MODEL_JSON_USAGE_FINALIZED``: ``bool`` written when JSON usage finalization
   ran. Read by ``response()`` to skip legacy fallback JSON extraction.
 

--- a/crates/runner/mitm-addon/src/flow_metadata_keys.py
+++ b/crates/runner/mitm-addon/src/flow_metadata_keys.py
@@ -123,10 +123,9 @@ Model-provider usage
 - ``MODEL_PROVIDER_USAGE_SOURCES``: ``dict`` keyed by WebSocket response id,
   with normalized token usage dict values. Written by WebSocket model-provider
   usage extraction and read by model usage-event and observation reporters.
-  Entries may be removed before ``websocket_end()`` once a terminal WebSocket
-  usage frame is accepted into the source-preserving usage buffer or the source
-  has no future reporting path. Zero-only entries are released immediately
-  because observable model-provider flows already carry ``MODEL_USAGE_PROVIDER``.
+  Entries are released before ``websocket_end()`` after each source-preserving
+  report attempt. Zero-only entries are also released immediately because
+  observable model-provider flows already carry ``MODEL_USAGE_PROVIDER``.
 - ``MODEL_USAGE_PROVIDER``: optional ``str`` canonical model id from registry VM
   info. Read by model-provider usage observability and reported-model selection.
 - ``MODEL_JSON_USAGE_FINALIZED``: ``bool`` written when JSON usage finalization

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1549,7 +1549,12 @@ async def request(flow: http.HTTPFlow) -> None:
 
 def _is_model_provider_usage_observable(firewall_name: str, vm_info: dict) -> bool:
     """Return whether a firewall can produce model usage observations."""
-    return firewall_name.startswith("model-provider:") and bool(vm_info.get("modelUsageProvider"))
+    model_usage_provider = vm_info.get("modelUsageProvider")
+    return (
+        firewall_name.startswith("model-provider:")
+        and isinstance(model_usage_provider, str)
+        and bool(model_usage_provider)
+    )
 
 
 def _maybe_track_usage_flow(

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -32,7 +32,6 @@ _HTTP_STATUS_SWITCHING_PROTOCOLS = 101
 _MODEL_JSON_USAGE_FINISH = "model_json_usage_finish"
 _MODEL_SSE_USAGE_FINISH = "model_sse_usage_finish"
 _MODEL_WEBSOCKET_USAGE_ENABLED = "model_websocket_usage_enabled"
-_MODEL_WEBSOCKET_ZERO_USAGE_SOURCE_LIMIT = 64
 _CONNECTOR_RESPONSE_FINISH = "connector_response_finish"
 _RESPONSE_STREAM_CALLBACK = "_vm0_response_stream_callback"
 
@@ -375,7 +374,7 @@ def feed_model_websocket_usage(flow: http.HTTPFlow, content: bytes | str) -> Non
         if source_disposition == "release":
             usage_sources.pop(message_id, None)
         else:
-            _retain_zero_usage_websocket_source(flow, usage_sources, message_id, usage_target)
+            _retain_zero_usage_websocket_source(usage_sources, message_id, usage_target)
         return
 
     usage_target = flow.metadata.get(metadata_keys.MODEL_PROVIDER_USAGE)
@@ -386,41 +385,13 @@ def feed_model_websocket_usage(flow: http.HTTPFlow, content: bytes | str) -> Non
 
 
 def _retain_zero_usage_websocket_source(
-    flow: http.HTTPFlow,
     usage_sources: dict,
     message_id: str,
     source_usage: dict,
 ) -> None:
     if usage.has_positive_model_provider_usage(source_usage):
         return
-    if _string_or_none(source_usage.get("model")) is None:
-        usage_sources.pop(message_id, None)
-        return
-    if _string_or_none(flow.metadata.get(metadata_keys.MODEL_USAGE_PROVIDER)) is not None:
-        usage_sources.pop(message_id, None)
-        return
-
-    zero_usage_source_ids = [
-        source_message_id
-        for source_message_id, retained_source_usage in usage_sources.items()
-        if (
-            isinstance(source_message_id, str)
-            and isinstance(retained_source_usage, dict)
-            and not usage.has_positive_model_provider_usage(retained_source_usage)
-            and _string_or_none(retained_source_usage.get("model")) is not None
-        )
-    ]
-    over_limit = len(zero_usage_source_ids) - _MODEL_WEBSOCKET_ZERO_USAGE_SOURCE_LIMIT
-    if over_limit <= 0:
-        return
-    for source_message_id in zero_usage_source_ids[:over_limit]:
-        usage_sources.pop(source_message_id, None)
-
-
-def _string_or_none(value: object) -> str | None:
-    if not isinstance(value, str) or not value:
-        return None
-    return value
+    usage_sources.pop(message_id, None)
 
 
 def finalize_connector_response_state(flow: http.HTTPFlow) -> None:

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -362,19 +362,13 @@ def feed_model_websocket_usage(flow: http.HTTPFlow, content: bytes | str) -> Non
             usage_sources[message_id] = usage_target
         usage.merge_openai_responses_usage_result(usage_target, usage_result)
         run_id = flow.metadata.get(metadata_keys.VM_RUN_ID, "")
-        source_disposition = usage.report_model_provider_usage_source(
+        usage.report_model_provider_usage_source(
             flow,
             run_id,
             message_id,
             usage_target,
         )
-        # Retain only sources that may still become reportable on a later
-        # same-response-id frame. Buffered or permanently unreportable sources
-        # do not need to stay in per-flow metadata until websocket_end/error.
-        if source_disposition == "release":
-            usage_sources.pop(message_id, None)
-        else:
-            _retain_zero_usage_websocket_source(usage_sources, message_id, usage_target)
+        usage_sources.pop(message_id, None)
         return
 
     usage_target = flow.metadata.get(metadata_keys.MODEL_PROVIDER_USAGE)
@@ -382,16 +376,6 @@ def feed_model_websocket_usage(flow: http.HTTPFlow, content: bytes | str) -> Non
         usage_target = {}
         flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = usage_target
     usage.merge_openai_responses_usage_result(usage_target, usage_result)
-
-
-def _retain_zero_usage_websocket_source(
-    usage_sources: dict,
-    message_id: str,
-    source_usage: dict,
-) -> None:
-    if usage.has_positive_model_provider_usage(source_usage):
-        return
-    usage_sources.pop(message_id, None)
 
 
 def finalize_connector_response_state(flow: http.HTTPFlow) -> None:

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -339,10 +339,11 @@ def feed_model_websocket_usage(flow: http.HTTPFlow, content: bytes | str) -> Non
     Called from ``websocket_message()`` only for server-originated frames. Reads
     ``_MODEL_WEBSOCKET_USAGE_ENABLED`` via ``is_model_websocket_usage_enabled()``
     and temporarily writes per-response sources to
-    ``metadata_keys.MODEL_PROVIDER_USAGE_SOURCES`` until they are accepted into
-    the source-preserving usage buffer. Frames without a response id fall back
-    to ``metadata_keys.MODEL_PROVIDER_USAGE``. This helper is not idempotent for
-    the same frame; callers must feed each server frame once.
+    ``metadata_keys.MODEL_PROVIDER_USAGE_SOURCES`` while attempting a
+    source-preserving report, then releases them from flow metadata. Frames
+    without a response id fall back to ``metadata_keys.MODEL_PROVIDER_USAGE``.
+    This helper is not idempotent for the same frame; callers must feed each
+    server frame once.
     """
     if not is_model_websocket_usage_enabled(flow):
         return

--- a/crates/runner/mitm-addon/src/usage/providers/model_provider.py
+++ b/crates/runner/mitm-addon/src/usage/providers/model_provider.py
@@ -16,7 +16,7 @@ id the proxy should report for model token usage. Billable rows go to
 
 import uuid
 from collections.abc import Iterator
-from typing import Literal, TypeGuard
+from typing import TypeGuard
 
 from mitmproxy import http
 
@@ -41,7 +41,6 @@ from ..model_tokens import MODEL_USAGE_CATEGORIES
 from ..underbilling import log_usage_underbilling
 
 MODEL_USAGE_KIND = "model"
-ModelProviderUsageSourceDisposition = Literal["release", "keep"]
 
 
 def is_model_provider_usage_observable(flow: http.HTTPFlow) -> bool:
@@ -173,14 +172,15 @@ def report_model_provider_usage_source(
     run_id: str,
     message_id: str,
     source_usage: dict,
-) -> ModelProviderUsageSourceDisposition:
+) -> None:
     """Buffer one finalized WebSocket response usage source.
 
     Unlike flow-terminal reporting, this preserves the source idempotency keys
     in the webhook payload so the platform can dedupe one response source even
-    when a later lifecycle hook sees the same source again. Returns ``release``
-    when the caller can drop the source from flow metadata and ``keep`` only
-    when a later same-response-id frame may still make the source reportable.
+    when a later lifecycle hook sees the same source again. Callers can drop the
+    source from flow metadata after this returns: observable flows carry the
+    canonical ``MODEL_USAGE_PROVIDER``, so zero-usage source model hints do not
+    need to be retained for later same-response-id frames.
     """
     usage_events: list[UsageEvent] = []
     observation_events: list[UsageEvent] = []
@@ -209,11 +209,7 @@ def report_model_provider_usage_source(
     api_url = get_api_url() if sandbox_token else ""
     proxy_log_path = flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, "")
     if not usage_events and not observation_events:
-        if not (can_report_usage or can_report_observation):
-            return "release"
-        if not sandbox_token or not api_url:
-            return "release"
-        return "keep"
+        return
 
     if not sandbox_token or not api_url:
         if usage_events:
@@ -235,7 +231,7 @@ def report_model_provider_usage_source(
                 "Cannot report model usage observation: missing sandbox_token or api_url",
                 type="model_usage_observation",
             )
-        return "release"
+        return
 
     if usage_events:
         buffer_source_usage_events(
@@ -253,7 +249,6 @@ def report_model_provider_usage_source(
             observation_events,
             proxy_log_path,
         )
-    return "release"
 
 
 def _build_model_provider_usage_events(

--- a/crates/runner/mitm-addon/src/usage/providers/model_provider.py
+++ b/crates/runner/mitm-addon/src/usage/providers/model_provider.py
@@ -7,13 +7,11 @@ Flow-terminal reporters aggregate usage stored in
 response-id sources can also be buffered incrementally with their source
 idempotency keys preserved.
 
-Model-provider usage reporting is separate from platform billing. New run
-contexts set ``flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER]`` to the
-canonical model id the proxy should report for model token usage. Billable rows
-go to ``/api/webhooks/agent/usage-event``; model usage statistics go to
-``/api/webhooks/agent/model-usage-observation``. ``FIREWALL_BILLABLE`` remains
-as a legacy/billing signal so in-flight Built-in runs created before the context
-field existed can still report usage.
+Model-provider usage reporting is separate from platform billing. Run contexts
+set ``flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER]`` to the canonical model
+id the proxy should report for model token usage. Billable rows go to
+``/api/webhooks/agent/usage-event``; model usage statistics go to
+``/api/webhooks/agent/model-usage-observation``.
 """
 
 import uuid
@@ -53,16 +51,11 @@ def is_model_provider_usage_observable(flow: http.HTTPFlow) -> bool:
     reporting. It is not a billing gate: BYOK/non-billable model providers can
     be observable when the run context supplies a non-empty
     ``MODEL_USAGE_PROVIDER``.
-    ``FIREWALL_BILLABLE`` is also accepted as a legacy model-provider
-    observability signal for older billable contexts.
     """
     firewall_name = flow_metadata.get_firewall_name_metadata(flow.metadata)
     if not firewall_name.startswith("model-provider:"):
         return False
-    return bool(
-        _string_or_none(flow.metadata.get(metadata_keys.MODEL_USAGE_PROVIDER))
-        or flow.metadata.get(metadata_keys.FIREWALL_BILLABLE, False)
-    )
+    return bool(_string_or_none(flow.metadata.get(metadata_keys.MODEL_USAGE_PROVIDER)))
 
 
 def has_positive_model_provider_usage(source_usage: dict) -> bool:
@@ -134,7 +127,7 @@ def report_model_provider_usage_observation(flow: http.HTTPFlow, run_id: str) ->
     - ``run_id`` is non-empty.
     - ``firewall_name`` starts with ``model-provider:``.
     - The flow is model-provider observable: ``MODEL_USAGE_PROVIDER`` is a
-      non-empty string, or legacy ``FIREWALL_BILLABLE`` is truthy.
+      non-empty string.
     - At least one model-provider usage source is available.
     - At least one ``MODEL_USAGE_CATEGORIES`` value has a positive integer
       quantity.

--- a/crates/runner/mitm-addon/tests/model_provider_flow_helpers.py
+++ b/crates/runner/mitm-addon/tests/model_provider_flow_helpers.py
@@ -63,6 +63,7 @@ def make_openai_responses_websocket_flow(
         original_url="https://api.openai.com/v1/responses",
         firewall_name="model-provider:openai-api-key",
         cli_agent_type="codex",
+        model_usage_provider="gpt-5.5",
     )
     flow.response = tutils.tresp(
         status_code=101,
@@ -79,6 +80,7 @@ def make_model_provider_sse_flow(
     original_url: str,
     firewall_name: str,
     cli_agent_type: str | None = None,
+    model_usage_provider: str | None = "claude-sonnet-4-6",
 ) -> http.HTTPFlow:
     flow = make_model_provider_flow(
         real_flow,
@@ -87,6 +89,7 @@ def make_model_provider_sse_flow(
         original_url=original_url,
         firewall_name=firewall_name,
         cli_agent_type=cli_agent_type,
+        model_usage_provider=model_usage_provider,
     )
     flow.response = tutils.tresp(
         status_code=200,

--- a/crates/runner/mitm-addon/tests/test_error_handler.py
+++ b/crates/runner/mitm-addon/tests/test_error_handler.py
@@ -494,6 +494,7 @@ class TestErrorHandler:
         flow.metadata["firewall_action"] = "ALLOW"
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
         flow.metadata["firewall_billable"] = True
+        flow.metadata["model_usage_provider"] = "claude-sonnet-4-6"
         flow.metadata["vm_sandbox_token"] = "tok-xyz"
         flow.metadata["model_provider_usage"] = {
             "model": "claude-sonnet-4-6",

--- a/crates/runner/mitm-addon/tests/test_model_provider_response_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_response_usage.py
@@ -344,6 +344,7 @@ class TestModelProviderResponseUsage:
         provider_case: ModelProviderJsonCase,
         *,
         billable: bool = True,
+        observable: bool = True,
         proxy_log_path: Path | None = None,
         run_id: str = "run-abc-123",
     ) -> None:
@@ -356,6 +357,8 @@ class TestModelProviderResponseUsage:
         )
         flow.metadata[metadata_keys.ORIGINAL_URL] = provider_case.original_url
         flow.metadata[metadata_keys.FIREWALL_NAME] = provider_case.firewall_name
+        if observable:
+            flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = provider_case.model
         if provider_case.cli_agent_type is not None:
             flow.metadata[metadata_keys.CLI_AGENT_TYPE] = provider_case.cli_agent_type
 
@@ -366,6 +369,7 @@ class TestModelProviderResponseUsage:
         provider_case: ModelProviderJsonCase,
         *,
         billable: bool = True,
+        observable: bool = True,
         proxy_log_path: Path | None = None,
         run_id: str = "run-abc-123",
     ):
@@ -375,6 +379,7 @@ class TestModelProviderResponseUsage:
             tmp_path,
             provider_case,
             billable=billable,
+            observable=observable,
             proxy_log_path=proxy_log_path,
             run_id=run_id,
         )
@@ -870,7 +875,9 @@ class TestModelProviderResponseUsage:
         by_category = {event["category"]: event["quantity"] for event in events}
         assert by_category == _expected_event_quantities(provider_case)
 
-    def test_non_billable_openai_json_does_not_report_usage(self, tmp_path, real_flow):
+    def test_non_billable_openai_json_reports_observation_without_billing(
+        self, tmp_path, real_flow
+    ):
         flow = self._model_provider_flow(
             real_flow,
             tmp_path,
@@ -886,10 +893,13 @@ class TestModelProviderResponseUsage:
 
         webhook = self._run_response(flow)
 
-        assert webhook.request_count == 0
-        assert metadata_keys.MODEL_PROVIDER_USAGE not in flow.metadata
+        assert webhook.usage_events() == []
+        observations = webhook.model_usage_observation_events()
+        by_category = {event["category"]: event["quantity"] for event in observations}
+        assert by_category == _expected_event_quantities(OPENAI_RESPONSES_CASE)
+        assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]["model"] == "gpt-5.5"
 
-    def test_non_billable_json_response_does_not_register_incremental_parser(
+    def test_non_observable_json_response_does_not_register_incremental_parser(
         self,
         tmp_path,
         real_flow,
@@ -899,6 +909,7 @@ class TestModelProviderResponseUsage:
             tmp_path,
             ANTHROPIC_JSON_CASE,
             billable=False,
+            observable=False,
         )
         flow.response = tutils.tresp(
             status_code=200,
@@ -914,14 +925,15 @@ class TestModelProviderResponseUsage:
         assert len(flow.metadata["stream_buffer"]) == STREAM_BUFFER_LIMIT
         assert flow.metadata["stream_buffer_state"]["truncated"] is True
 
-    def test_non_billable_json_fallback_parse_error_stays_quiet(self, tmp_path, real_flow):
-        """Non-billable model-provider fallback must not emit usage warnings."""
+    def test_non_observable_json_fallback_parse_error_stays_quiet(self, tmp_path, real_flow):
+        """Model-provider fallback without MODEL_USAGE_PROVIDER must not emit warnings."""
         proxy_log_path = tmp_path / "proxy.jsonl"
         flow = self._model_provider_flow(
             real_flow,
             tmp_path,
             OPENAI_RESPONSES_CASE,
             billable=False,
+            observable=False,
             proxy_log_path=proxy_log_path,
         )
         body = b'{"id":"resp_1","model":"gpt-5.5","usage":{"input_tokens":50'
@@ -1318,6 +1330,7 @@ class TestModelProviderResponseUsageWebhookDelivery:
         flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
         flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
         flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = "tok-xyz"
+        flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "claude-sonnet-4-6"
         flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {
             "model": "claude-sonnet-4-6",
             "tokens.input": 100,

--- a/crates/runner/mitm-addon/tests/test_model_provider_sse_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_sse_usage.py
@@ -28,6 +28,7 @@ def _model_provider_sse_flow(
     original_url: str,
     firewall_name: str,
     cli_agent_type: str | None = None,
+    model_usage_provider: str | None = "claude-sonnet-4-6",
 ) -> http.HTTPFlow:
     return make_model_provider_sse_flow(
         real_flow,
@@ -36,6 +37,7 @@ def _model_provider_sse_flow(
         original_url=original_url,
         firewall_name=firewall_name,
         cli_agent_type=cli_agent_type,
+        model_usage_provider=model_usage_provider,
     )
 
 
@@ -49,6 +51,7 @@ def _openai_responses_sse_flow(
         original_url="https://api.openai.com/v1/responses",
         firewall_name="model-provider:openai-api-key",
         cli_agent_type="codex",
+        model_usage_provider="gpt-5.5",
     )
 
 

--- a/crates/runner/mitm-addon/tests/test_model_provider_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_usage.py
@@ -226,6 +226,27 @@ class TestReportModelProviderUsage:
             != observation_body["events"][0]["idempotencyKey"]
         )
 
+    def test_billable_model_provider_without_model_usage_provider_skips_observation(
+        self, real_flow, fresh_usage_executor, usage_webhook_api
+    ):
+        flow = real_flow(with_response=False, host="api.anthropic.com")
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:vm0"
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
+        flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = "tok-xyz"
+        flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {
+            "model": "claude-sonnet-4-6",
+            "message_id": "msg-built-in-usage-1",
+            "tokens.input": 100,
+        }
+
+        with usage_webhook_api() as webhook:
+            observed = usage.report_model_provider_usage_observation(flow, "run-abc-123")
+            usage.flush_usage_events(trigger="test")
+            usage.webhook.usage_executor.shutdown(wait=True)
+
+        assert observed is False
+        assert webhook.request_count == 0
+
     def test_skips_non_model_provider(self, real_flow, fresh_usage_executor, usage_webhook_api):
         """Should NOT reach the webhook boundary for non-model-provider requests."""
         flow = real_flow(with_response=False, host="api.github.com")
@@ -394,6 +415,7 @@ class TestReportModelProviderUsage:
         flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:openai-api-key"
         flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
         flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = "tok-xyz"
+        flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "gpt-5.5"
         flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE_SOURCES] = {
             "resp_ws_1": {
                 "model": "gpt-5.5",
@@ -448,7 +470,7 @@ class TestReportModelProviderUsage:
         uuid.UUID(usage_body["events"][0]["idempotencyKey"])
         uuid.UUID(observation_body["events"][0]["idempotencyKey"])
 
-    def test_source_dedupe_separates_model_provider_usage_sources_by_model(
+    def test_source_dedupe_separates_billing_sources_by_response_model_without_context_model(
         self, real_flow, fresh_usage_executor, usage_webhook_api
     ):
         flow = real_flow(with_response=False, host="api.openai.com")
@@ -471,25 +493,15 @@ class TestReportModelProviderUsage:
 
         with usage_webhook_api() as webhook:
             usage.report_model_provider_usage(flow, "run-websocket")
-            usage.report_model_provider_usage_observation(flow, "run-websocket")
             usage.flush_usage_events(trigger="test")
             usage.webhook.usage_executor.shutdown(wait=True)
 
-        requests_by_path = {request.path: request for request in webhook.requests}
-        usage_body = requests_by_path["/api/webhooks/agent/usage-event"].json_body()
-        observation_body = requests_by_path[
-            "/api/webhooks/agent/model-usage-observation"
-        ].json_body()
+        assert webhook.request_count == 1
+        assert webhook.requests[0].path == "/api/webhooks/agent/usage-event"
+        usage_body = webhook.requests[0].json_body()
         assert {
             (event["provider"], event["category"]): event["quantity"]
             for event in usage_body["events"]
-        } == {
-            ("gpt-5.5", "tokens.input"): 10,
-            ("gpt-5.4", "tokens.input"): 3,
-        }
-        assert {
-            (event["model"], event["category"]): event["quantity"]
-            for event in observation_body["events"]
         } == {
             ("gpt-5.5", "tokens.input"): 10,
             ("gpt-5.4", "tokens.input"): 3,

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
@@ -12,7 +12,6 @@ from mitmproxy.test import tutils
 
 import flow_metadata_keys as metadata_keys
 import mitm_addon
-import response_streaming
 import usage
 from tests.jsonl_log_helpers import jsonl_exists_after_flush, read_jsonl_entries_after_flush
 from tests.model_provider_websocket_helpers import (
@@ -59,7 +58,10 @@ def _write_openai_model_websocket_registry(tmp_path: Path) -> Path:
                 "unknownPolicy": "deny",
             },
             billable_firewalls=[firewall_name],
-            vm_fields={"cliAgentType": "codex"},
+            vm_fields={
+                "cliAgentType": "codex",
+                "modelUsageProvider": "gpt-5.5",
+            },
         ),
     )
 
@@ -81,6 +83,16 @@ def _sum_quantities_by_category(events: list[dict]) -> dict[str, int]:
     for event in events:
         category = event["category"]
         quantities[category] = quantities.get(category, 0) + event["quantity"]
+    return quantities
+
+
+def _sum_quantities_by_field_and_category(
+    events: list[dict], field: str
+) -> dict[tuple[str, str], int]:
+    quantities: dict[tuple[str, str], int] = {}
+    for event in events:
+        key = (event[field], event["category"])
+        quantities[key] = quantities.get(key, 0) + event["quantity"]
     return quantities
 
 
@@ -461,11 +473,9 @@ class TestModelProviderWebSocketUsage:
 
         assert webhook.request_count == 0
         usage_sources = _model_websocket_usage_sources(flow)
-        assert len(usage_sources) <= response_streaming._MODEL_WEBSOCKET_ZERO_USAGE_SOURCE_LIMIT
-        assert "resp_ws_zero_0" not in usage_sources
-        assert "resp_ws_zero_69" in usage_sources
+        assert usage_sources == {}
 
-    def test_model_websocket_evicted_zero_hint_still_reports_later_positive_usage(
+    def test_model_websocket_flow_model_reports_later_positive_usage_without_zero_hint(
         self, tmp_path, real_flow
     ):
         flow = _openai_model_websocket_flow(tmp_path, real_flow)
@@ -498,20 +508,20 @@ class TestModelProviderWebSocketUsage:
 
         usage_sources = _model_websocket_usage_sources(flow)
         assert "resp_ws_zero_0" not in usage_sources
-        assert len(usage_sources) <= response_streaming._MODEL_WEBSOCKET_ZERO_USAGE_SOURCE_LIMIT
+        assert usage_sources == {}
         assert {
             (event["provider"], event["category"]): event["quantity"]
             for event in webhook.usage_events()
         } == {
-            ("unknown", "tokens.input"): 20,
-            ("unknown", "tokens.output"): 12,
+            ("gpt-5.5", "tokens.input"): 20,
+            ("gpt-5.5", "tokens.output"): 12,
         }
         assert {
             (event["model"], event["category"]): event["quantity"]
             for event in webhook.model_usage_observation_events()
         } == {
-            ("unknown", "tokens.input"): 20,
-            ("unknown", "tokens.output"): 12,
+            ("gpt-5.5", "tokens.input"): 20,
+            ("gpt-5.5", "tokens.output"): 12,
         }
 
     def test_model_websocket_text_frame_reports_usage(self, tmp_path, real_flow):
@@ -539,15 +549,15 @@ class TestModelProviderWebSocketUsage:
             (event["provider"], event["category"]): event["quantity"]
             for event in webhook.usage_events()
         } == {
-            ("gpt-5.4", "tokens.input"): 3,
-            ("gpt-5.4", "tokens.output"): 2,
+            ("gpt-5.5", "tokens.input"): 3,
+            ("gpt-5.5", "tokens.output"): 2,
         }
         assert {
             (event["model"], event["category"]): event["quantity"]
             for event in webhook.model_usage_observation_events()
         } == {
-            ("gpt-5.4", "tokens.input"): 3,
-            ("gpt-5.4", "tokens.output"): 2,
+            ("gpt-5.5", "tokens.input"): 3,
+            ("gpt-5.5", "tokens.output"): 2,
         }
 
     def test_model_websocket_valid_frame_replaces_invalid_usage_sources_metadata(
@@ -609,7 +619,9 @@ class TestModelProviderWebSocketUsage:
             "tokens.output": 12,
         }
 
-    def test_full_pipeline_model_websocket_separates_response_id_models(self, tmp_path, real_flow):
+    def test_full_pipeline_model_websocket_uses_context_model_for_response_ids(
+        self, tmp_path, real_flow
+    ):
         flow = _openai_model_websocket_flow(tmp_path, real_flow)
         mitm_addon.responseheaders(flow)
 
@@ -630,23 +642,15 @@ class TestModelProviderWebSocketUsage:
         )
 
         assert _model_websocket_usage_sources(flow) == {}
-        assert {
-            (event["provider"], event["category"]): event["quantity"]
-            for event in webhook.usage_events()
-        } == {
-            ("gpt-5.5", "tokens.input"): 10,
-            ("gpt-5.5", "tokens.output"): 4,
-            ("gpt-5.4", "tokens.input"): 3,
-            ("gpt-5.4", "tokens.output"): 2,
+        assert _sum_quantities_by_field_and_category(webhook.usage_events(), "provider") == {
+            ("gpt-5.5", "tokens.input"): 13,
+            ("gpt-5.5", "tokens.output"): 6,
         }
-        assert {
-            (event["model"], event["category"]): event["quantity"]
-            for event in webhook.model_usage_observation_events()
-        } == {
-            ("gpt-5.5", "tokens.input"): 10,
-            ("gpt-5.5", "tokens.output"): 4,
-            ("gpt-5.4", "tokens.input"): 3,
-            ("gpt-5.4", "tokens.output"): 2,
+        assert _sum_quantities_by_field_and_category(
+            webhook.model_usage_observation_events(), "model"
+        ) == {
+            ("gpt-5.5", "tokens.input"): 13,
+            ("gpt-5.5", "tokens.output"): 6,
         }
 
     def test_full_pipeline_model_websocket_reports_id_and_missing_id_usage(

--- a/crates/runner/mitm-addon/tests/test_request_handler_usage_tracking.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_usage_tracking.py
@@ -580,6 +580,37 @@ async def test_non_billable_model_provider_is_not_tracked_before_responseheaders
     )
 
 
+async def test_non_billable_model_provider_with_invalid_model_usage_provider_is_not_tracked(
+    tmp_path, usage_pending_path, real_flow, mitm_ctx, fake_firewall_headers
+):
+    """Only non-empty string modelUsageProvider values make model providers observable."""
+    reg_path = _write_model_provider_tracking_registry(
+        tmp_path,
+        run_id=_MODEL_PROVIDER_RUN_ID,
+        sandbox_marker=_MODEL_PROVIDER_SANDBOX_MARKER,
+        vm_fields={"modelUsageProvider": 123},
+    )
+    flow = _model_provider_tracking_flow(real_flow)
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers(),
+    ):
+        await mitm_addon.request(flow)
+
+    assert flow.metadata["firewall_name"] == _MODEL_PROVIDER_FIREWALL_NAME
+    assert flow.metadata["firewall_billable"] is False
+    assert flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] == 123
+    usage.write_pending_snapshot(flush_request_id="request-1")
+    assert_pending(
+        usage_pending_path,
+        flows=0,
+        buffered=0,
+        reports=0,
+        flush_request_id="request-1",
+    )
+
+
 async def test_non_billable_observable_model_provider_is_tracked_before_responseheaders(
     tmp_path, usage_pending_path, real_flow, mitm_ctx, fake_firewall_headers
 ):

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -1564,6 +1564,7 @@ class TestResponseHandler:
         flow.metadata["firewall_name"] = "model-provider:openai-api-key"
         flow.metadata["cli_agent_type"] = "codex"
         flow.metadata["firewall_billable"] = True
+        flow.metadata["model_usage_provider"] = "gpt-5.5"
         flow.response = tutils.tresp(
             status_code=200,
             headers=header_map({"content-type": "text/event-stream"}),

--- a/crates/runner/mitm-addon/tests/test_response_streaming.py
+++ b/crates/runner/mitm-addon/tests/test_response_streaming.py
@@ -544,6 +544,7 @@ class TestResponseHeadersModelJsonParser:
         )
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
         flow.metadata["firewall_billable"] = True
+        flow.metadata["model_usage_provider"] = "claude-sonnet-4-6"
 
         with mitm_ctx() as log:
             mitm_addon.responseheaders(flow)
@@ -567,6 +568,7 @@ class TestResponseHeadersSseParser:
         )
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
         flow.metadata["firewall_billable"] = True
+        flow.metadata["model_usage_provider"] = "claude-sonnet-4-6"
 
         mitm_addon.responseheaders(flow)
 
@@ -594,6 +596,7 @@ class TestResponseHeadersSseParser:
         flow.metadata["firewall_name"] = "model-provider:openai-api-key"
         flow.metadata["cli_agent_type"] = "codex"
         flow.metadata["firewall_billable"] = True
+        flow.metadata["model_usage_provider"] = "gpt-5.5"
 
         mitm_addon.responseheaders(flow)
 
@@ -616,6 +619,7 @@ class TestResponseHeadersSseParser:
         flow.metadata["firewall_name"] = "model-provider:openai-api-key"
         flow.metadata["cli_agent_type"] = "codex"
         flow.metadata["firewall_billable"] = True
+        flow.metadata["model_usage_provider"] = "gpt-5.5"
 
         mitm_addon.responseheaders(flow)
 
@@ -641,6 +645,7 @@ class TestResponseHeadersSseParser:
         flow.metadata["firewall_name"] = "model-provider:openai-api-key"
         flow.metadata["cli_agent_type"] = "codex"
         flow.metadata["firewall_billable"] = True
+        flow.metadata["model_usage_provider"] = "gpt-5.5"
 
         mitm_addon.responseheaders(flow)
 
@@ -665,6 +670,7 @@ class TestResponseHeadersSseParser:
         flow.metadata["firewall_name"] = "model-provider:codex-oauth-token"
         flow.metadata["cli_agent_type"] = "codex"
         flow.metadata["firewall_billable"] = True
+        flow.metadata["model_usage_provider"] = "gpt-5.5"
 
         mitm_addon.responseheaders(flow)
 
@@ -691,6 +697,7 @@ class TestResponseHeadersSseParser:
         if cli_agent_type is not None:
             flow.metadata["cli_agent_type"] = cli_agent_type
         flow.metadata["firewall_billable"] = True
+        flow.metadata["model_usage_provider"] = "claude-sonnet-4-6"
 
         mitm_addon.responseheaders(flow)
 
@@ -718,6 +725,7 @@ class TestResponseHeadersSseParser:
         )
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
         flow.metadata["firewall_billable"] = True
+        flow.metadata["model_usage_provider"] = "claude-sonnet-4-6"
 
         mitm_addon.responseheaders(flow)
 
@@ -759,13 +767,13 @@ class TestResponseHeadersSseParser:
 
         assert "model_provider_usage" not in flow.metadata
 
-    def test_no_sse_parser_for_non_billable_model_provider(self, real_flow, headers):
+    def test_no_sse_parser_without_model_usage_provider(self, real_flow, headers):
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.response = tutils.tresp(
             status_code=200, headers=header_map({"content-type": "text/event-stream"})
         )
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
-        flow.metadata["firewall_billable"] = False
+        flow.metadata["firewall_billable"] = True
 
         mitm_addon.responseheaders(flow)
 
@@ -850,6 +858,7 @@ class TestReleaseResponseStreamState:
                 {
                     "firewall_name": "model-provider:anthropic-api-key",
                     "firewall_billable": True,
+                    "model_usage_provider": "claude-sonnet-4-6",
                 },
                 "model_json_usage_finish",
                 id="model-json",
@@ -862,6 +871,7 @@ class TestReleaseResponseStreamState:
                     "firewall_name": "model-provider:openai-api-key",
                     "cli_agent_type": "codex",
                     "firewall_billable": True,
+                    "model_usage_provider": "gpt-5.5",
                 },
                 "model_sse_usage_finish",
                 id="model-sse",
@@ -952,6 +962,7 @@ class TestReleaseResponseStreamState:
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
         flow.metadata["firewall_billable"] = True
+        flow.metadata["model_usage_provider"] = "claude-sonnet-4-6"
         flow.response = tutils.tresp(
             status_code=200, headers=header_map({"content-type": "application/json"})
         )

--- a/crates/runner/mitm-addon/tests/test_usage_reporting_idempotency.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting_idempotency.py
@@ -113,6 +113,7 @@ class TestUsageReportingIdempotency:
             firewall_name="model-provider:anthropic-api-key",
             run_id="run-fallback",
             network_log_path=log_path,
+            model_usage_provider="claude-sonnet-4-6",
         )
         flow.id = "flow-uuid-xyz-123"
         flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {
@@ -162,6 +163,7 @@ class TestUsageReportingIdempotency:
             firewall_name="model-provider:anthropic-api-key",
             run_id="run-preserved",
             network_log_path=log_path,
+            model_usage_provider="claude-sonnet-4-6",
         )
         flow.id = "flow-should-not-win"
         flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1,7 +1,11 @@
 import { createHash, randomUUID } from "node:crypto";
 
 import {
+  getProviderRuntimeModel,
   getModelProviderFirewall,
+  getVm0ConcreteProviderType,
+  getVm0Vendor,
+  MODEL_PROVIDER_TYPES,
   type ModelProviderType,
 } from "@vm0/api-contracts/contracts/model-providers";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
@@ -11,13 +15,17 @@ import {
   type FirewallApi,
 } from "@vm0/connectors/firewall-types";
 import { getAllConnectorFirewalls } from "@vm0/connectors/firewalls/all";
+import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
 import { HttpResponse, http } from "msw";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, onTestFinished } from "vitest";
 
 import { mockOptionalEnv } from "../../../lib/env";
 import { mockNow, now, nowDate } from "../../../lib/time";
 import { testContext } from "../../../__tests__/test-helpers";
 import { server } from "../../../mocks/server";
+import { writeDb$ } from "../../external/db";
 import { assistantMessageIdForRunEvent } from "../../services/assistant-message-id";
 import {
   createBddApi,
@@ -45,6 +53,9 @@ import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
  */
 
 const context = testContext();
+const store = createStore();
+const writeDb = store.set(writeDb$);
+const TEST_VM0_MANAGED_API_KEY = "vm0-key-run-lifecycle-bdd-default-model";
 
 // Sentinel provider id for model-first thread selections (the wire-protocol
 // value the chat composer sends when picking a model instead of a provider).
@@ -87,6 +98,28 @@ function findFirewallEntry(
   return entries?.find((entry) => {
     return firewallEntryName(entry) === name;
   });
+}
+
+async function seedVm0ManagedDefaultModelKey(): Promise<string> {
+  const selectedModel = MODEL_PROVIDER_TYPES.vm0.defaultModel;
+  if (!selectedModel) {
+    throw new Error("Expected vm0 to define a default model");
+  }
+  await writeDb
+    .delete(vm0ApiKeys)
+    .where(eq(vm0ApiKeys.apiKey, TEST_VM0_MANAGED_API_KEY));
+  onTestFinished(async () => {
+    await writeDb
+      .delete(vm0ApiKeys)
+      .where(eq(vm0ApiKeys.apiKey, TEST_VM0_MANAGED_API_KEY));
+  });
+  await writeDb.insert(vm0ApiKeys).values({
+    vendor: getVm0Vendor(selectedModel),
+    model: getProviderRuntimeModel("vm0", selectedModel),
+    apiKey: TEST_VM0_MANAGED_API_KEY,
+    label: "run-lifecycle-bdd",
+  });
+  return selectedModel;
 }
 
 function inlineFirewallApis(
@@ -663,6 +696,37 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
     );
     expectApiError(rejected.body);
     expect(rejected.body.error.code).toBe("INSUFFICIENT_CREDITS");
+  });
+
+  it("claims vm0 runs with billable model firewall and usage provider", async () => {
+    const api = createRunsAutomationsApi(context);
+    const selectedModel = await seedVm0ManagedDefaultModelKey();
+    const concreteProvider = getVm0ConcreteProviderType(selectedModel);
+    const expectedFirewall = getModelProviderFirewall(concreteProvider)?.name;
+    if (!expectedFirewall) {
+      throw new Error(
+        `Missing model-provider firewall for ${concreteProvider}`,
+      );
+    }
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+
+    const run = await api.createRun(actor, {
+      agentId,
+      prompt: "vm0 built-in model provider",
+      modelProvider: "vm0",
+    });
+    await api.heartbeatRunner(runnerGroup);
+    const claim = await api.claimRunnerJob(run.runId);
+
+    expect(
+      claim.firewalls?.map((firewall) => {
+        return firewallEntryName(firewall);
+      }),
+    ).toContain(expectedFirewall);
+    expect(claim.billableFirewalls).toContain(expectedFirewall);
+    expect(claim.modelUsageProvider).toBe(selectedModel);
+
+    await api.requestCancelRun(actor, run.runId, [200]);
   });
 
   it("injects codex multi-auth provider credentials and proves them via firewall auth", async () => {

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -345,6 +345,11 @@ interface PermissionManifest {
   readonly billableFirewalls: readonly string[];
 }
 
+interface ModelUsageContext {
+  readonly billableFirewalls: readonly string[];
+  readonly modelUsageProvider: string | undefined;
+}
+
 interface StoredExecutionSecrets {
   // Runtime secret namespace encrypted into executionContext.encryptedSecrets.
   // Keys are the `NAME` in `${{ secrets.NAME }}`; connector/model-provider
@@ -3181,6 +3186,18 @@ async function enforceCaptureNetworkBodiesGate(
   return null;
 }
 
+function loadPersistedRunEnvironmentSnapshotForRun(
+  db: Db,
+  args: CreateAgentRunArgs,
+  content: AgentComposeContent,
+): Promise<PersistedRunEnvironmentSnapshot> {
+  return loadPersistedRunEnvironmentSnapshot(db, {
+    orgId: args.orgId,
+    userId: args.userId,
+    content,
+  });
+}
+
 function validateCompose(
   content: AgentComposeContent,
   vars: Record<string, string> | undefined,
@@ -3218,6 +3235,21 @@ function validateCompose(
   }
 
   return { framework };
+}
+
+function validateRunFramework(
+  content: AgentComposeContent,
+  body: CreateRunBody,
+): { readonly framework: SupportedFramework } | CreateRunErrorResult {
+  return validateCompose(content, body.vars, body.secrets, {
+    validateEnvironmentReferences: false,
+  });
+}
+
+function initialRunBody(args: CreateAgentRunArgs): CreateRunBody {
+  return args.includeZeroTokenSecret
+    ? withPendingZeroTokenSecret(args.body)
+    : args.body;
 }
 
 function zeroRunModelProviderValues(
@@ -3465,6 +3497,8 @@ async function buildStoredExecutionContext(args: {
   readonly connectorContext: ConnectorRuntimeContext;
   readonly customConnectorContext: CustomConnectorRuntimeContext;
   readonly permissionManifest: PermissionManifest | undefined;
+  readonly billableFirewalls: readonly string[];
+  readonly modelUsageProvider: string | undefined;
   readonly apiStartTime: number;
   readonly storageManifest: StorageManifest;
   readonly additionalVolumes: readonly AdditionalVolume[] | undefined;
@@ -3528,11 +3562,8 @@ async function buildStoredExecutionContext(args: {
       settings: args.body.settings,
       experimentalProfile: runnerProfile(args.resolved.content),
       featureFlags: getAllFeatureStates(args.featureSwitchContext),
-      billableFirewalls: billableFirewallsForPermissions({
-        modelProvider: args.modelProvider,
-        permissions,
-      }),
-      modelUsageProvider: modelUsageProviderForContext(args.modelProvider),
+      billableFirewalls: [...args.billableFirewalls],
+      modelUsageProvider: args.modelUsageProvider,
     },
     secretNames,
     secretValues,
@@ -3692,13 +3723,52 @@ function billableFirewallsForPermissions(args: {
   });
   const modelFirewalls =
     args.modelProvider?.type === "vm0"
-      ? firewallNames.filter((name) => {
-          return name.startsWith("model-provider:");
-        })
+      ? firewallNames.filter(isModelProviderFirewallName)
       : [];
   const connectorFirewalls = args.permissions?.billableFirewalls ?? [];
 
   return [...modelFirewalls, ...connectorFirewalls];
+}
+
+function isModelProviderFirewallName(name: string): boolean {
+  return name.startsWith("model-provider:");
+}
+
+function validateModelUsageProviderInvariant(args: {
+  readonly modelProvider: ResolvedModelProviderEnvironment | null;
+  readonly billableFirewalls: readonly string[];
+  readonly modelUsageProvider: string | undefined;
+}): CreateRunErrorResult | null {
+  if (args.modelProvider?.type !== "vm0") {
+    return null;
+  }
+  if (!args.billableFirewalls.some(isModelProviderFirewallName)) {
+    return null;
+  }
+  if (args.modelUsageProvider) {
+    return null;
+  }
+  return providerUnavailable(
+    "Built-in model provider did not resolve a supported model for usage reporting",
+  );
+}
+
+function prepareModelUsageContext(args: {
+  readonly modelProvider: ResolvedModelProviderEnvironment | null;
+  readonly permissionManifest: PermissionManifest | undefined;
+}): ModelUsageContext | CreateRunErrorResult {
+  const billableFirewalls = billableFirewallsForPermissions({
+    modelProvider: args.modelProvider,
+    permissions: args.permissionManifest,
+  });
+  const modelUsageProvider = modelUsageProviderForContext(args.modelProvider);
+  const validation = validateModelUsageProviderInvariant({
+    modelProvider: args.modelProvider,
+    billableFirewalls,
+    modelUsageProvider,
+  });
+
+  return validation ?? { billableFirewalls, modelUsageProvider };
 }
 
 function modelUsageProviderForContext(
@@ -3768,6 +3838,8 @@ function buildRunnerJobPayload(
     readonly connectorContext: ConnectorRuntimeContext;
     readonly customConnectorContext: CustomConnectorRuntimeContext;
     readonly permissionManifest: PermissionManifest | undefined;
+    readonly billableFirewalls: readonly string[];
+    readonly modelUsageProvider: string | undefined;
     readonly apiStartTime: number;
     readonly additionalVolumes: readonly AdditionalVolume[] | undefined;
     readonly includeZeroTokenSecret: boolean | undefined;
@@ -3888,6 +3960,8 @@ function dispatchRun(
     readonly connectorContext: ConnectorRuntimeContext;
     readonly customConnectorContext: CustomConnectorRuntimeContext;
     readonly permissionManifest: PermissionManifest | undefined;
+    readonly billableFirewalls: readonly string[];
+    readonly modelUsageProvider: string | undefined;
     readonly apiStartTime: number;
     readonly additionalVolumes: readonly AdditionalVolume[] | undefined;
     readonly includeZeroTokenSecret: boolean | undefined;
@@ -3963,6 +4037,8 @@ function enqueueRunForConcurrency(
     readonly connectorContext: ConnectorRuntimeContext;
     readonly customConnectorContext: CustomConnectorRuntimeContext;
     readonly permissionManifest: PermissionManifest | undefined;
+    readonly billableFirewalls: readonly string[];
+    readonly modelUsageProvider: string | undefined;
     readonly apiStartTime: number;
     readonly additionalVolumes: readonly AdditionalVolume[] | undefined;
     readonly includeZeroTokenSecret: boolean | undefined;
@@ -4069,6 +4145,8 @@ interface PreparedRunContext {
   readonly connectorContext: ConnectorRuntimeContext;
   readonly customConnectorContext: CustomConnectorRuntimeContext;
   readonly permissionManifest: PermissionManifest | undefined;
+  readonly billableFirewalls: readonly string[];
+  readonly modelUsageProvider: string | undefined;
   readonly artifacts: readonly ContextArtifact[];
   readonly additionalVolumes: readonly AdditionalVolume[] | undefined;
   readonly userTimezone: string | undefined;
@@ -4307,9 +4385,7 @@ function prepareRunContext(
 ): Computed<Promise<PreparedRunContext | CreateRunErrorResult>> {
   return computed(
     async (get): Promise<PreparedRunContext | CreateRunErrorResult> => {
-      const initialBody = args.includeZeroTokenSecret
-        ? withPendingZeroTokenSecret(args.body)
-        : args.body;
+      const initialBody = initialRunBody(args);
 
       const captureGate = await enforceCaptureNetworkBodiesGate(
         db,
@@ -4337,14 +4413,12 @@ function prepareRunContext(
         return notFound("Resource not found");
       }
 
-      const persistedEnvironment = await loadPersistedRunEnvironmentSnapshot(
-        db,
-        {
-          orgId: args.orgId,
-          userId: args.userId,
-          content: resolved.content,
-        },
-      );
+      const persistedEnvironment =
+        await loadPersistedRunEnvironmentSnapshotForRun(
+          db,
+          args,
+          resolved.content,
+        );
       signal.throwIfAborted();
 
       const body = await buildResolvedRunBody({
@@ -4355,12 +4429,7 @@ function prepareRunContext(
         signal,
       });
 
-      const frameworkValidation = validateCompose(
-        resolved.content,
-        body.vars,
-        body.secrets,
-        { validateEnvironmentReferences: false },
-      );
+      const frameworkValidation = validateRunFramework(resolved.content, body);
       if (isRouteError(frameworkValidation)) {
         return frameworkValidation;
       }
@@ -4396,6 +4465,14 @@ function prepareRunContext(
         customConnectorContext,
       });
       signal.throwIfAborted();
+
+      const modelUsageContext = prepareModelUsageContext({
+        modelProvider,
+        permissionManifest,
+      });
+      if (isRouteError(modelUsageContext)) {
+        return modelUsageContext;
+      }
 
       const validation = validateRunEnvironmentReferences({
         resolved,
@@ -4434,6 +4511,8 @@ function prepareRunContext(
         connectorContext,
         customConnectorContext,
         permissionManifest,
+        billableFirewalls: modelUsageContext.billableFirewalls,
+        modelUsageProvider: modelUsageContext.modelUsageProvider,
         artifacts: runArtifacts.artifacts,
         additionalVolumes,
         userTimezone,
@@ -4512,6 +4591,8 @@ function completeQueuedRun(input: {
             connectorContext: input.context.connectorContext,
             customConnectorContext: input.context.customConnectorContext,
             permissionManifest: input.context.permissionManifest,
+            billableFirewalls: input.context.billableFirewalls,
+            modelUsageProvider: input.context.modelUsageProvider,
             apiStartTime: input.args.apiStartTime,
             additionalVolumes: input.context.additionalVolumes,
             includeZeroTokenSecret: input.args.includeZeroTokenSecret,
@@ -4565,6 +4646,8 @@ function completePendingRun(input: {
             connectorContext: input.context.connectorContext,
             customConnectorContext: input.context.customConnectorContext,
             permissionManifest: input.context.permissionManifest,
+            billableFirewalls: input.context.billableFirewalls,
+            modelUsageProvider: input.context.modelUsageProvider,
             apiStartTime: input.args.apiStartTime,
             additionalVolumes: input.context.additionalVolumes,
             includeZeroTokenSecret: input.args.includeZeroTokenSecret,

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -4480,11 +4480,6 @@ function prepareRunContext(
       const userTimezone = await loadUserTimezone(db, args);
       signal.throwIfAborted();
 
-      const runArtifacts = artifactsForRun({
-        resolved,
-        framework,
-        bodyArtifacts: body.artifacts,
-      });
       const additionalVolumes = preparedRunAdditionalVolumes({
         createArgs: args,
         framework,
@@ -4503,7 +4498,11 @@ function prepareRunContext(
         permissionManifest,
         billableFirewalls: modelUsageContext.billableFirewalls,
         modelUsageProvider: modelUsageContext.modelUsageProvider,
-        artifacts: runArtifacts.artifacts,
+        artifacts: artifactsForRun({
+          resolved,
+          framework,
+          bodyArtifacts: body.artifacts,
+        }).artifacts,
         additionalVolumes,
         userTimezone,
         featureSwitchContext,

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -3186,18 +3186,6 @@ async function enforceCaptureNetworkBodiesGate(
   return null;
 }
 
-function loadPersistedRunEnvironmentSnapshotForRun(
-  db: Db,
-  args: CreateAgentRunArgs,
-  content: AgentComposeContent,
-): Promise<PersistedRunEnvironmentSnapshot> {
-  return loadPersistedRunEnvironmentSnapshot(db, {
-    orgId: args.orgId,
-    userId: args.userId,
-    content,
-  });
-}
-
 function validateCompose(
   content: AgentComposeContent,
   vars: Record<string, string> | undefined,
@@ -4413,12 +4401,14 @@ function prepareRunContext(
         return notFound("Resource not found");
       }
 
-      const persistedEnvironment =
-        await loadPersistedRunEnvironmentSnapshotForRun(
-          db,
-          args,
-          resolved.content,
-        );
+      const persistedEnvironment = await loadPersistedRunEnvironmentSnapshot(
+        db,
+        {
+          orgId: args.orgId,
+          userId: args.userId,
+          content: resolved.content,
+        },
+      );
       signal.throwIfAborted();
 
       const body = await buildResolvedRunBody({


### PR DESCRIPTION
## Summary
- compute `billableFirewalls` and `modelUsageProvider` once during API run-context preparation, and reject vm0 billable model-provider contexts that cannot resolve a supported usage model
- make mitm model-provider parsers and observation reporting depend on non-empty `MODEL_USAGE_PROVIDER` instead of `FIREWALL_BILLABLE`
- keep `FIREWALL_BILLABLE` as the model billing gate, remove zero-usage WebSocket model-hint retention, and update coverage for BYOK/non-billable observations

Closes #18769

## Tests
- `cd crates/runner/mitm-addon && .venv/bin/ruff format ... && .venv/bin/ruff check ...`
- `cd crates/runner/mitm-addon && .venv/bin/pytest tests/test_model_provider_usage.py tests/test_response_streaming.py tests/test_model_provider_response_usage.py tests/test_model_provider_sse_usage.py tests/test_model_provider_websocket_usage.py`
- `cd crates/runner/mitm-addon && .venv/bin/pytest tests/test_request_handler_usage_tracking.py tests/test_request_handler_firewall_dispatch.py`
- `cd crates/runner/mitm-addon && .venv/bin/basedpyright -p .`
- `cd turbo && pnpm -F api lint`
- `cd turbo && pnpm -F api check-types`
- `cd turbo && pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "claims vm0 runs with billable model firewall and usage provider"`
- pre-commit: `ruff`, `prettier`, `knip`, `turbo run check-types --concurrency=1`

Note: after syncing the local DB with `pnpm -F @vm0/db db:migrate`, the full local `run-lifecycle.bdd.test.ts` still has an unrelated existing Slack permission assertion failure caused by ignored local generated Slack firewall artifacts; the new vm0 model-usage claim case passes independently.