### PR TITLE
docs: document runner architecture rollout

### DIFF
--- a/crates/README.md
+++ b/crates/README.md
@@ -4,26 +4,26 @@ This workspace contains Rust crates for the vm0 sandbox runtime — VM orchestra
 
 ## Crates
 
-| Crate | Description |
-|-------|-------------|
-| **runner** | Sandbox orchestrator — polls for jobs (API or local queue), manages VM lifecycle, proxy, service install, and bridges to sandbox-fc |
-| **sandbox** | Sandbox trait and shared types — `SandboxFactory`, `Sandbox`, `SandboxConfig`, `ExecRequest`, `ExecResult` |
-| **sandbox-fc** | Firecracker sandbox implementation — VM lifecycle, network namespace pool, NBD COW, snapshot restore |
-| **nbd-cow** | Userspace NBD COW device — block-level copy-on-write via Linux NBD, bitmap tracking, no dm-snapshot/loop devices |
-| **vsock-proto** | Wire protocol encoding/decoding shared by host and guest — length-prefixed binary messages |
-| **vsock-host** | Host-side async vsock client (tokio) — connects to guest via Unix domain sockets |
-| **vsock-guest** | Guest-side vsock library — IPC over vsock/Unix sockets, embedded in guest-init as PID 2 |
-| **vsock-test** | Integration tests for vsock — real host + real guest over Unix sockets |
-| **guest-init** | Init process (PID 1) for Firecracker VMs — virtual filesystem setup, env config, signal handling, forks vsock-guest |
-| **guest-agent** | Guest orchestrator — CLI execution, heartbeat, telemetry upload, and checkpoint creation inside the VM |
-| **guest-contracts** | Runner/guest contracts — bootstrap environment variables, runtime path layout, and private runtime file helpers |
-| **guest-common** | Guest-only shared utilities — logging macros and telemetry recording |
-| **guest-download** | Downloads and extracts storage archives — parallel downloads (4 concurrent), streaming extraction, retry logic |
-| **guest-mock-claude** | Mock Claude CLI for testing — executes bash commands and outputs Claude-compatible JSONL |
-| **guest-mock-codex** | Mock Codex CLI for testing — emits Codex JSONL protocol on stdout and persists JSONL session files |
-| **guest-reseed** | Entropy reseed after snapshot restore — mixes stdin entropy into /dev/urandom and forces CRNG reseed via RNDRESEEDCRNG |
-| **guest-write-file** | Direct file writer for vsock `write_file` — writes stdin to guest files without shell startup overhead |
-| **ably-subscriber** | Ably Pub/Sub subscribe-only realtime client — WebSocket/MessagePack protocol with token auth and automatic reconnection |
+| Crate                 | Description                                                                                                                         |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| **runner**            | Sandbox orchestrator — polls for jobs (API or local queue), manages VM lifecycle, proxy, service install, and bridges to sandbox-fc |
+| **sandbox**           | Sandbox trait and shared types — `SandboxFactory`, `Sandbox`, `SandboxConfig`, `ExecRequest`, `ExecResult`                          |
+| **sandbox-fc**        | Firecracker sandbox implementation — VM lifecycle, network namespace pool, NBD COW, snapshot restore                                |
+| **nbd-cow**           | Userspace NBD COW device — block-level copy-on-write via Linux NBD, bitmap tracking, no dm-snapshot/loop devices                    |
+| **vsock-proto**       | Wire protocol encoding/decoding shared by host and guest — length-prefixed binary messages                                          |
+| **vsock-host**        | Host-side async vsock client (tokio) — connects to guest via Unix domain sockets                                                    |
+| **vsock-guest**       | Guest-side vsock library — IPC over vsock/Unix sockets, embedded in guest-init as PID 2                                             |
+| **vsock-test**        | Integration tests for vsock — real host + real guest over Unix sockets                                                              |
+| **guest-init**        | Init process (PID 1) for Firecracker VMs — virtual filesystem setup, env config, signal handling, forks vsock-guest                 |
+| **guest-agent**       | Guest orchestrator — CLI execution, heartbeat, telemetry upload, and checkpoint creation inside the VM                              |
+| **guest-contracts**   | Runner/guest contracts — bootstrap environment variables, runtime path layout, and private runtime file helpers                     |
+| **guest-common**      | Guest-only shared utilities — logging macros and telemetry recording                                                                |
+| **guest-download**    | Downloads and extracts storage archives — parallel downloads (4 concurrent), streaming extraction, retry logic                      |
+| **guest-mock-claude** | Mock Claude CLI for testing — executes bash commands and outputs Claude-compatible JSONL                                            |
+| **guest-mock-codex**  | Mock Codex CLI for testing — emits Codex JSONL protocol on stdout and persists JSONL session files                                  |
+| **guest-reseed**      | Entropy reseed after snapshot restore — mixes stdin entropy into /dev/urandom and forces CRNG reseed via RNDRESEEDCRNG              |
+| **guest-write-file**  | Direct file writer for vsock `write_file` — writes stdin to guest files without shell startup overhead                              |
+| **ably-subscriber**   | Ably Pub/Sub subscribe-only realtime client — WebSocket/MessagePack protocol with token auth and automatic reconnection             |
 
 ## Architecture
 
@@ -73,22 +73,31 @@ Both HTTP clients in the workspace use `rustls-platform-verifier` to read from t
 cargo build
 cargo build --release
 
-# Cross-compile for aarch64 with the faster CI/dev profile
+# Cross-compile with the faster CI/dev profile.
+# Supported targets:
+#   aarch64-unknown-linux-musl
+#   x86_64-unknown-linux-musl
+TARGET_TRIPLE=aarch64-unknown-linux-musl
+
 # Step 1: build guest binaries
-cargo build --target aarch64-unknown-linux-musl \
+cargo build --target "$TARGET_TRIPLE" \
   -p guest-agent -p guest-download -p guest-init -p guest-mock-claude -p guest-mock-codex -p guest-reseed -p guest-write-file \
   --profile ci
 
 # Step 2: build runner with embedded guests
-GUEST_AGENT_PATH=target/aarch64-unknown-linux-musl/ci/guest-agent \
-GUEST_DOWNLOAD_PATH=target/aarch64-unknown-linux-musl/ci/guest-download \
-GUEST_INIT_PATH=target/aarch64-unknown-linux-musl/ci/guest-init \
-GUEST_MOCK_CLAUDE_PATH=target/aarch64-unknown-linux-musl/ci/guest-mock-claude \
-GUEST_MOCK_CODEX_PATH=target/aarch64-unknown-linux-musl/ci/guest-mock-codex \
-GUEST_RESEED_PATH=target/aarch64-unknown-linux-musl/ci/guest-reseed \
-GUEST_WRITE_FILE_PATH=target/aarch64-unknown-linux-musl/ci/guest-write-file \
-cargo build --target aarch64-unknown-linux-musl -p runner --profile ci
+GUEST_AGENT_PATH="target/$TARGET_TRIPLE/ci/guest-agent" \
+GUEST_DOWNLOAD_PATH="target/$TARGET_TRIPLE/ci/guest-download" \
+GUEST_INIT_PATH="target/$TARGET_TRIPLE/ci/guest-init" \
+GUEST_MOCK_CLAUDE_PATH="target/$TARGET_TRIPLE/ci/guest-mock-claude" \
+GUEST_MOCK_CODEX_PATH="target/$TARGET_TRIPLE/ci/guest-mock-codex" \
+GUEST_RESEED_PATH="target/$TARGET_TRIPLE/ci/guest-reseed" \
+GUEST_WRITE_FILE_PATH="target/$TARGET_TRIPLE/ci/guest-write-file" \
+cargo build --target "$TARGET_TRIPLE" -p runner --profile ci
 ```
+
+See [`../docs/runner-multi-architecture.md`](../docs/runner-multi-architecture.md)
+for runner deployment, release asset naming, and host-architecture target
+selection.
 
 ## Testing
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,6 +25,7 @@ VM0 is a platform for running AI agent workflows in isolated sandbox environment
 ### High-Level Architecture
 
 **Execution Flow**:
+
 ```
 User CLI/API Request
   ↓
@@ -66,10 +67,12 @@ The storage layer persists user data (volumes, artifacts, session state) in Clou
 #### Storage Types
 
 **Volumes**: Read-only data mounted at specified paths
+
 - Examples: Code repositories, dependencies, reference data
 - Defined in `vm0.yaml`
 
 **Artifacts**: Read-write working directory
+
 - Agent output, modified files, generated assets
 - Versioned after each run
 - Used for checkpoints and resume
@@ -77,12 +80,14 @@ The storage layer persists user data (volumes, artifacts, session state) in Clou
 #### Data Flow
 
 **Upload**:
+
 ```
 CLI → tar.gz archive → presigned PUT URL → R2
 Database records: storage_id, version_id, s3_key
 ```
 
 **Download**:
+
 ```
 Server → presigned GET URL (1h expiration)
   ↓
@@ -100,10 +105,12 @@ Extracts to mount paths
 The orchestration layer coordinates job execution between web API and runners.
 
 **Job Notification**:
+
 - **Wakeup**: Ably realtime notifications wake runners for instant HTTP polling (~100-200ms)
 - **Fallback**: HTTP polling every 30s catches missed notifications
 
 **Runner Behavior**:
+
 1. Subscribe to Ably channel `runner-group:{org}/{name}`
 2. Receive job notification and wake HTTP poll
 3. Select the next job via `/api/runners/poll`
@@ -115,10 +122,12 @@ The orchestration layer coordinates job execution between web API and runners.
 #### Runner Groups
 
 **Format**: `{org}/{name}`
+
 - Official: `vm0/*` (e.g., `vm0/production`) - VM0-managed runners
 - User: `{org-slug}/*` (e.g., `my-team/private`) - Self-hosted runners
 
 **Authentication**:
+
 - Official runners: HMAC signature using `OFFICIAL_RUNNER_SECRET`
 - User runners: JWT bearer token with userId claim
 
@@ -130,14 +139,19 @@ The orchestration layer coordinates job execution between web API and runners.
 
 Firecracker is an open-source VMM (Virtual Machine Monitor) developed by AWS that creates lightweight microVMs using Linux KVM.
 
+For host-architecture-driven runner deployment, release assets, and validation
+checklists, see [Runner Multi-Architecture Rollout](runner-multi-architecture.md).
+
 #### Infrastructure Requirements
 
 **Hardware**:
+
 - Bare metal Linux server
 - KVM support: `/dev/kvm` device
 - Cannot run on cloud VMs (nested virtualization limitations)
 
 **Software**:
+
 - Firecracker v1.15.1 binary
 - Linux kernel v6.1.155 (for microVM)
 - Node.js 24.x, pnpm, pm2
@@ -150,6 +164,7 @@ Firecracker is an open-source VMM (Virtual Machine Monitor) developed by AWS tha
 **Runner Application**: Rust application in `crates/runner/`
 
 **VM Configuration**:
+
 ```yaml
 # runner.yaml
 name: prod-1
@@ -175,6 +190,7 @@ profiles:
 ```
 
 **Host-local runner overrides**:
+
 - Host-specific capacity belongs in `/etc/vm0-runner/host.env`, not
   `runner.yaml`. The file is parsed with an allowlist so accidental secrets or
   unrelated environment values fail visibly.
@@ -198,6 +214,7 @@ profiles:
 #### Storage Architecture
 
 **Shared Read-Only Base**:
+
 - ext4 rootfs (~500MB-1GB)
 - Content-addressed: `/var/lib/vm0-runner/images/{rootfs_hash}/rootfs.ext4`
 - Shared across all VMs via nbd-cow
@@ -205,12 +222,14 @@ profiles:
   guest binaries and host-specific settings in `customize-rootfs.sh`
 
 **Per-VM Copy-on-Write (nbd-cow)**:
+
 - Userspace NBD-based COW backed by sparse file
 - Device: `/dev/nbdN` (writable block device)
 - Reads of unmodified blocks go to base image, writes captured in COW file
 - Enables instant boot without rootfs copy
 
 **Per-VM Workspace Drive**:
+
 - Sparse ext4 image: `{base_dir}/workspaces/{sandbox_id}/workspace.ext4`
 - Exposed to the guest as `/dev/vdb`
 - Mounted by the runner at `/home/user/workspace`
@@ -221,16 +240,19 @@ profiles:
 **Isolation**: Each VM in separate network namespace via pre-warmed namespace pool
 
 **Namespace Pool**: Pre-allocated network namespaces for fast VM startup
+
 - Each namespace gets a unique veth pair
 - Namespace side: `veth0` (e.g., `10.200.0.2`)
 - Host side: `vm0-ve-{pool}-{index}` (e.g., `vm0-ve-00-00`)
 - Pool supports up to 64 pools × 256 namespaces
 
 **IP Allocation**: 10.200.0.0/16 subnets
+
 - Guest fixed IP: `192.168.241.2` (same across VMs, isolated by namespace)
 - NAT/MASQUERADE: Guest traffic routed through namespace to external network
 
 **HTTP Proxy**: mitmproxy (dynamically allocated port)
+
 - Intercepts all HTTP/HTTPS traffic
 - Logs requests/responses to per-run JSONL files
 - CA certificate injected into VM trust store
@@ -270,6 +292,7 @@ Cloudflare R2 is S3-compatible object storage with zero egress fees.
 #### Direct Download
 
 Sandboxes download directly from R2 (no proxy through VM0 API):
+
 1. VM0 API generates presigned GET URLs
 2. Storage manifest JSON uploaded to sandbox
 3. Sandbox's `download.mjs` script fetches from R2

--- a/docs/runner-multi-architecture.md
+++ b/docs/runner-multi-architecture.md
@@ -1,0 +1,154 @@
+# Runner Multi-Architecture Rollout
+
+This document describes the operational contract for running vm0 runners on
+more than one host CPU architecture.
+
+## Core Invariant
+
+Runner host architecture determines every architecture-specific runner output:
+
+- Rust target triple
+- Runner image manifest target
+- Release asset name
+- Deploy, promote, and rollback asset
+- Host-bound test target
+
+Do not choose these values independently in workflows. Use the shared helper
+scripts so CI, release, deploy, rollback, and local development keep the same
+mapping.
+
+## Supported Targets
+
+`.github/scripts/runner-image-target.sh` is the implementation source of truth
+for supported runner targets and derived metadata.
+
+| Host `uname -m` | Rust target triple           | Cache suffix   | Release asset suffix | Release asset                      |
+| --------------- | ---------------------------- | -------------- | -------------------- | ---------------------------------- |
+| `aarch64`       | `aarch64-unknown-linux-musl` | `aarch64-musl` | `aarch64-linux`      | `runner-v${VERSION}-aarch64-linux` |
+| `x86_64`        | `x86_64-unknown-linux-musl`  | `x86_64-musl`  | `x86_64-linux`       | `runner-v${VERSION}-x86_64-linux`  |
+
+Runner release tags use `runner-rs-v${VERSION}`. Runner release assets use
+`runner-v${VERSION}-${assetSuffix}`.
+
+## Host Inventory
+
+`AWS_METAL_RUNNER_HOSTS` is the single metal runner inventory for this rollout.
+There is no separate architecture-specific host secret.
+
+`.github/scripts/runner-host-architecture-groups.sh` derives architecture
+groups by probing each host with SSH:
+
+```bash
+ssh "${METAL_USER}@${host}" uname -m
+```
+
+The helper accepts the configured host inventory and emits architecture groups
+for the supported target triples. Unsupported host architectures fail early.
+
+The full local contract includes host lists and is intended for same-job use:
+
+- `id`
+- `label`
+- `hosts`
+- `target`
+- `unameM`
+- `cacheSuffix`
+- `assetSuffix`
+
+The cross-job matrix contract is sanitized and excludes host lists:
+
+- `id`
+- `label`
+- `target`
+- `unameM`
+- `cacheSuffix`
+- `assetSuffix`
+
+The deploy and rollback target matrix contains only:
+
+- `id`
+- `label`
+- `target`
+
+Host lists must not be passed through GitHub Actions job outputs or matrix JSON.
+Jobs that need concrete hosts resolve them locally for the selected group:
+
+```bash
+.github/scripts/runner-host-architecture-groups.sh hosts "$RUNNER_HOST_GROUP_ID"
+```
+
+Jobs that need one representative host use the deterministic selector:
+
+```bash
+.github/scripts/runner-host-architecture-groups.sh select-host "$RUNNER_HOST_GROUP_ID" "$JOB_REF" "$HOSTS"
+```
+
+## Workflow Consumers
+
+Runner image production resolves architecture groups, builds one runner image per
+configured group, and validates the manifest under that group's target triple.
+
+Crates host-bound tests resolve the same sanitized matrix and run architecture
+specific checks, including NBD COW tests, on matching metal. Jobs that need an
+actual host resolve the host subset inside the job instead of reading hosts from
+the matrix.
+
+Turbo runner consumers use the same metal inventory for runner bootstrap and
+runner E2E jobs. These jobs validate behavior against the configured runner
+fleet, but heavy behavior suites do not need to be duplicated per architecture
+unless they assert architecture-specific behavior.
+
+Release publishing builds runner assets for all supported target triples. The
+asset names come from `.github/scripts/runner-image-target.sh`.
+
+Production build, promote, and rollback resolve the deploy/rollback target
+matrix from the configured inventory. Each matrix leg downloads or uses the
+runner binary matching that group's target and passes `runner_target` to Ansible.
+
+Ansible deploy and rollback validate the remote host architecture before
+installing, promoting, or rolling back a runner binary. A target and remote
+architecture mismatch should fail before mutating the runner service.
+
+## Local Development
+
+`scripts/dev-runner.sh` derives the runner target from the remote host
+architecture by default.
+
+Set `RUNNER_TARGET_TRIPLE` only when you need to force a supported target. The
+script validates that the forced target matches the remote host `uname -m` before
+building and uploading the runner.
+
+## Dispatch Boundary
+
+Current runner dispatch is not architecture-aware. The mixed-architecture rollout
+selects the correct binary and image artifacts for each runner host, but it does
+not guarantee that a profile or run always lands on a fixed CPU architecture.
+
+Workspace and sandbox reuse are runner-local, so a local workspace is not shared
+across different runner machines. If the product needs fixed-architecture
+scheduling semantics later, that should be handled as a separate control-plane
+design.
+
+## Validation Checklist
+
+Record dated validation evidence in the rollout issue or PR, grouped by
+architecture group. Do not mark an architecture as runtime-validated solely
+because cross-compilation or release asset publication succeeded.
+
+For each configured architecture group, record evidence for:
+
+| Area                      | Evidence to record                                                                               |
+| ------------------------- | ------------------------------------------------------------------------------------------------ |
+| Runner image production   | The matrix leg built the image and uploaded a target-specific manifest.                          |
+| Runner image consumption  | Consumers resolved the matching target-specific manifest.                                        |
+| NBD COW tests             | Host-bound NBD COW tests ran on matching metal.                                                  |
+| Runner setup              | `runner setup` downloaded and verified Firecracker, kernel, and mitmdump artifacts.              |
+| Rootfs and snapshot       | `runner build --profile vm0/default` built the template, rootfs, and snapshot on matching metal. |
+| Snapshot restore          | A sandbox restored from the snapshot successfully.                                               |
+| Local runner smoke        | A local runner claimed and completed a smoke job.                                                |
+| Guest CLIs                | Chromium, Claude Code, Codex, Node global packages, PostgreSQL, Go, and Rust work in the rootfs. |
+| Release asset             | The expected `runner-v${VERSION}-${assetSuffix}` asset exists.                                   |
+| Deploy, promote, rollback | The host used the matching asset and passed architecture preflight.                              |
+
+If a host architecture is not configured in `AWS_METAL_RUNNER_HOSTS`, record that
+state explicitly instead of marking the architecture complete.


### PR DESCRIPTION
## Summary
- add a canonical runner multi-architecture rollout document
- update the Rust crates README build example to use a supported `TARGET_TRIPLE`
- link the rollout doc from the main architecture doc
- document the single-inventory host grouping model, release asset naming, local dev target selection, and validation checklist

## Validation
- `git diff --check`
- `pnpm exec prettier --check ../docs/runner-multi-architecture.md ../crates/README.md ../docs/architecture.md`
- pre-commit hooks during commit: file size check, connector firewall index check, commitlint

## Notes
- Closes #18488
- Parent #18460 should still treat real x86_64 metal runtime validation as pending unless x86_64 hosts are configured and have run the checklist.