### PR TITLE
perf(runner): fold timezone sync into guest restore

### DIFF
--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -390,7 +390,7 @@ async fn run_sandbox(
 
 /// Images always contain a snapshot — fix guest clock drift and reseed entropy.
 async fn setup_guest(sandbox: &dyn sandbox::Sandbox) -> RunnerResult<()> {
-    executor::restore_guest_state(sandbox).await?;
+    executor::restore_guest_state_without_timezone(sandbox).await?;
     Ok(())
 }
 

--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -24,7 +24,7 @@ use crate::workspace_mount::ensure_workspace_drive_mounted;
 struct Timing {
     boot_ms: Option<u128>,
     workspace_mount_ms: Option<u128>,
-    clock_ms: Option<u128>,
+    guest_restore_ms: Option<u128>,
     exec_ms: Option<u128>,
 }
 
@@ -233,7 +233,7 @@ pub async fn run_benchmark(
     let Timing {
         boot_ms,
         workspace_mount_ms,
-        clock_ms,
+        guest_restore_ms,
         exec_ms,
     } = timing;
     match &result {
@@ -244,7 +244,7 @@ pub async fn run_benchmark(
                 factory_ms,
                 boot_ms = ?boot_ms,
                 workspace_mount_ms = ?workspace_mount_ms,
-                clock_ms = ?clock_ms,
+                guest_restore_ms = ?guest_restore_ms,
                 exec_ms = ?exec_ms,
                 total_ms,
                 termination = ?exec_result.termination,
@@ -253,7 +253,7 @@ pub async fn run_benchmark(
             );
         }
         Err(e) => {
-            info!(proxy_ms, factory_ms, boot_ms = ?boot_ms, workspace_mount_ms = ?workspace_mount_ms, clock_ms = ?clock_ms, exec_ms = ?exec_ms, total_ms, error = %e, "benchmark failed");
+            info!(proxy_ms, factory_ms, boot_ms = ?boot_ms, workspace_mount_ms = ?workspace_mount_ms, guest_restore_ms = ?guest_restore_ms, exec_ms = ?exec_ms, total_ms, error = %e, "benchmark failed");
         }
     }
 
@@ -431,10 +431,10 @@ async fn run_in_sandbox(
         return (Err(e), timing);
     }
 
-    let t_clock = Instant::now();
-    let clock_result = setup_guest(sandbox, &args.timezone).await;
-    timing.clock_ms = Some(t_clock.elapsed().as_millis());
-    if let Err(e) = clock_result {
+    let t_guest_restore = Instant::now();
+    let guest_restore_result = setup_guest(sandbox, &args.timezone).await;
+    timing.guest_restore_ms = Some(t_guest_restore.elapsed().as_millis());
+    if let Err(e) = guest_restore_result {
         return (Err(e), timing);
     }
 

--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -403,7 +403,7 @@ async fn run_sandbox(
     (result, timing)
 }
 
-/// Images always contain a snapshot — fix guest clock drift and reseed entropy.
+/// Images always contain a snapshot — restore guest state before the benchmark command.
 async fn setup_guest(sandbox: &dyn sandbox::Sandbox, timezone: &str) -> RunnerResult<()> {
     executor::restore_guest_state_with_timezone(sandbox, timezone).await?;
     Ok(())

--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -28,6 +28,8 @@ struct Timing {
     exec_ms: Option<u128>,
 }
 
+const DEFAULT_BENCHMARK_TIMEZONE: &str = "UTC";
+
 /// Reject malformed entries so typos fail loud before benchmark startup.
 fn parse_env_args(env: &[String]) -> RunnerResult<Vec<(String, String)>> {
     env.iter()
@@ -50,6 +52,15 @@ fn parse_env_args(env: &[String]) -> RunnerResult<Vec<(String, String)>> {
         .collect()
 }
 
+fn validate_timezone_arg(timezone: &str) -> RunnerResult<()> {
+    if !timezone.is_empty() && executor::is_valid_guest_timezone_name(timezone) {
+        return Ok(());
+    }
+    Err(RunnerError::Config(format!(
+        "invalid --timezone {timezone:?}: expected a non-empty IANA timezone name"
+    )))
+}
+
 #[derive(Args)]
 pub struct BenchmarkArgs {
     /// The bash command to execute in the VM
@@ -63,6 +74,9 @@ pub struct BenchmarkArgs {
     /// Environment variables to pass (KEY=VALUE), can be repeated
     #[arg(long, short)]
     env: Vec<String>,
+    /// System timezone to configure in the VM before running the command
+    #[arg(long, default_value = DEFAULT_BENCHMARK_TIMEZONE)]
+    timezone: String,
     /// Run the command as root (sudo)
     #[arg(long)]
     sudo: bool,
@@ -79,6 +93,7 @@ pub async fn run_benchmark(
 
     // Validate --env up front so typos fail before proxy/sandbox startup.
     let env_pairs = parse_env_args(&args.env)?;
+    validate_timezone_arg(&args.timezone)?;
 
     // 1. Load config, force concurrency=1
     let mut runner_config = config::load(&args.config).await?;
@@ -389,8 +404,8 @@ async fn run_sandbox(
 }
 
 /// Images always contain a snapshot — fix guest clock drift and reseed entropy.
-async fn setup_guest(sandbox: &dyn sandbox::Sandbox) -> RunnerResult<()> {
-    executor::restore_guest_state_without_timezone(sandbox).await?;
+async fn setup_guest(sandbox: &dyn sandbox::Sandbox, timezone: &str) -> RunnerResult<()> {
+    executor::restore_guest_state_with_timezone(sandbox, timezone).await?;
     Ok(())
 }
 
@@ -417,7 +432,7 @@ async fn run_in_sandbox(
     }
 
     let t_clock = Instant::now();
-    let clock_result = setup_guest(sandbox).await;
+    let clock_result = setup_guest(sandbox, &args.timezone).await;
     timing.clock_ms = Some(t_clock.elapsed().as_millis());
     if let Err(e) = clock_result {
         return (Err(e), timing);
@@ -530,6 +545,29 @@ mod tests {
             );
             assert!(!err.to_string().contains("secret-value"), "got: {err}");
             assert!(!err.to_string().contains(value), "got: {err}");
+        }
+    }
+
+    #[test]
+    fn validate_timezone_arg_accepts_default_and_common_names() {
+        for timezone in [
+            DEFAULT_BENCHMARK_TIMEZONE,
+            "Asia/Shanghai",
+            "Etc/GMT+1",
+            "America/Argentina/Buenos_Aires",
+        ] {
+            validate_timezone_arg(timezone).unwrap();
+        }
+    }
+
+    #[test]
+    fn validate_timezone_arg_rejects_empty_and_shell_metacharacters() {
+        for timezone in ["", "UTC;id", "America/New York", "UTC'", "$(date)"] {
+            let err = validate_timezone_arg(timezone).unwrap_err();
+            assert!(
+                err.to_string().contains("invalid --timezone"),
+                "timezone {timezone:?} produced unexpected error: {err}"
+            );
         }
     }
 

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -240,12 +240,14 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
 
     // 1. Fix guest clock and reseed entropy (must happen before HTTPS calls).
     //    Needed after snapshot restore (frozen clock) and after idle reuse (drifted clock).
+    //    When this exec already runs, fold best-effort timezone sync into it
+    //    to avoid another pre-spawn guest round trip.
     if start.restore_guest_state {
-        restore_guest_state(sandbox).await?;
+        restore_guest_state(sandbox, context).await?;
+    } else {
+        // 2. Set guest timezone from user preference (best-effort, never fails).
+        sync_guest_timezone(sandbox, context).await;
     }
-
-    // 2. Set guest timezone from user preference (best-effort, never fails).
-    sync_guest_timezone(sandbox, context).await;
 
     // 3. Download storage manifest entries (skipping entries unchanged since the previous turn).
     if let Some(manifest) = &context.storage_manifest {

--- a/crates/runner/src/executor/guest_state.rs
+++ b/crates/runner/src/executor/guest_state.rs
@@ -10,6 +10,13 @@ use crate::helper_exec::{
 use crate::types::ExecutionContext;
 
 const ENTROPY_SIZE: usize = 256;
+const TIMEZONE_SYNC_FAILED_MARKER: &str = "guest timezone sync failed";
+
+#[derive(Clone, Copy)]
+struct GuestTimezone<'a> {
+    name: &'a str,
+    context: &'a ExecutionContext,
+}
 
 fn helper_exec_exit_code(result: &sandbox::ExecResult) -> Option<i32> {
     match result.termination {
@@ -41,6 +48,74 @@ fn read_host_entropy() -> RunnerResult<Vec<u8>> {
     Ok(entropy)
 }
 
+fn valid_timezone_name(tz: &str) -> bool {
+    tz.bytes()
+        .all(|b| b.is_ascii_alphanumeric() || b == b'/' || b == b'_' || b == b'-' || b == b'+')
+}
+
+fn user_timezone(context: &ExecutionContext) -> Option<&str> {
+    let tz = match context.user_timezone.as_deref() {
+        Some(tz) if !tz.is_empty() => tz,
+        _ => return None,
+    };
+    // Strict validation: timezone names are like "Asia/Shanghai" or "UTC".
+    // Only allow alphanumeric, '/', '_', '-', '+'.  This prevents shell
+    // injection since the value is interpolated into a sudo shell command.
+    if !valid_timezone_name(tz) {
+        tracing::warn!(tz = %tz, "rejected invalid timezone name");
+        return None;
+    }
+    Some(tz)
+}
+
+fn timezone_sync_body(tz: &str) -> String {
+    format!(
+        "echo '{tz}' > /etc/timezone && \
+         ln -sf /usr/share/zoneinfo/{tz} /etc/localtime && \
+         sed -i '/^TZ=/d' /etc/environment && \
+         echo 'TZ={tz}' >> /etc/environment"
+    )
+}
+
+fn timezone_sync_command(tz: &str) -> String {
+    let body = timezone_sync_body(tz);
+    format!("if test -f /usr/share/zoneinfo/{tz}; then {body}; fi")
+}
+
+fn timezone_sync_best_effort_command(tz: &str) -> String {
+    let body = timezone_sync_body(tz);
+    format!(
+        "if test -f /usr/share/zoneinfo/{tz}; then {{ {body}; }} || echo \"{TIMEZONE_SYNC_FAILED_MARKER}\" >&2; fi"
+    )
+}
+
+fn log_embedded_timezone_failure(
+    context: &ExecutionContext,
+    tz: &str,
+    result: &sandbox::ExecResult,
+) {
+    if !result
+        .stderr
+        .windows(TIMEZONE_SYNC_FAILED_MARKER.len())
+        .any(|window| window == TIMEZONE_SYNC_FAILED_MARKER.as_bytes())
+    {
+        return;
+    }
+
+    let stderr_excerpt =
+        format_command_output_excerpt("stderr", &result.stderr, result.stderr_truncated);
+    let stdout_excerpt =
+        format_command_output_excerpt("stdout", &result.stdout, result.stdout_truncated);
+    tracing::warn!(
+        run_id = %context.run_id,
+        tz = %tz,
+        termination = helper_exec_termination_label(result),
+        stderr_excerpt = %stderr_excerpt.as_deref().unwrap_or(""),
+        stdout_excerpt = %stdout_excerpt.as_deref().unwrap_or(""),
+        "failed to set guest timezone"
+    );
+}
+
 /// Restores snapshot-sensitive guest state in one exec before the agent starts.
 ///
 /// On ARM64 with kernel 6.1, VMGenID does not work (the driver only supports
@@ -49,13 +124,34 @@ fn read_host_entropy() -> RunnerResult<Vec<u8>> {
 ///
 /// This syncs the frozen guest clock and injects fresh host entropy so each VM
 /// produces unique random numbers from the first `getrandom()` call.
-pub(crate) async fn restore_guest_state(sandbox: &dyn Sandbox) -> RunnerResult<()> {
+pub(crate) async fn restore_guest_state(
+    sandbox: &dyn Sandbox,
+    context: &ExecutionContext,
+) -> RunnerResult<()> {
+    let timezone = user_timezone(context).map(|name| GuestTimezone { name, context });
+    restore_guest_state_inner(sandbox, timezone).await
+}
+
+pub(crate) async fn restore_guest_state_without_timezone(
+    sandbox: &dyn Sandbox,
+) -> RunnerResult<()> {
+    restore_guest_state_inner(sandbox, None).await
+}
+
+async fn restore_guest_state_inner(
+    sandbox: &dyn Sandbox,
+    timezone: Option<GuestTimezone<'_>>,
+) -> RunnerResult<()> {
     let timestamp = host_unix_timestamp_secs();
     let entropy = read_host_entropy()?;
-    let cmd = format!(
+    let mut cmd = format!(
         r#"date -s "@{timestamp}" || {{ status=$?; echo "guest clock sync failed" >&2; exit "$status"; }}
 guest-reseed || {{ status=$?; echo "guest-reseed failed" >&2; exit "$status"; }}"#
     );
+    if let Some(timezone) = timezone {
+        cmd.push('\n');
+        cmd.push_str(&timezone_sync_best_effort_command(timezone.name));
+    }
     let result = sandbox
         .exec_with_diagnostic_label(
             &ExecRequest {
@@ -76,6 +172,9 @@ guest-reseed || {{ status=$?; echo "guest-reseed failed" >&2; exit "$status"; }}
             &result,
         )));
     }
+    if let Some(timezone) = timezone {
+        log_embedded_timezone_failure(timezone.context, timezone.name, &result);
+    }
 
     Ok(())
 }
@@ -90,28 +189,10 @@ guest-reseed || {{ status=$?; echo "guest-reseed failed" >&2; exit "$status"; }}
 /// The agent process also receives `TZ` via the env vars in step 6.
 /// Skipped when no user timezone is configured (falls back to image default UTC).
 pub(super) async fn sync_guest_timezone(sandbox: &dyn Sandbox, context: &ExecutionContext) {
-    let tz = match &context.user_timezone {
-        Some(tz) if !tz.is_empty() => tz,
-        _ => return,
-    };
-    // Strict validation: timezone names are like "Asia/Shanghai" or "UTC".
-    // Only allow alphanumeric, '/', '_', '-', '+'.  This prevents shell
-    // injection since the value is interpolated into a sudo shell command.
-    if !tz
-        .bytes()
-        .all(|b| b.is_ascii_alphanumeric() || b == b'/' || b == b'_' || b == b'-' || b == b'+')
-    {
-        tracing::warn!(tz = %tz, "rejected invalid timezone name");
+    let Some(tz) = user_timezone(context) else {
         return;
-    }
-    let cmd = format!(
-        "if test -f /usr/share/zoneinfo/{tz}; then \
-         echo '{tz}' > /etc/timezone && \
-         ln -sf /usr/share/zoneinfo/{tz} /etc/localtime && \
-         sed -i '/^TZ=/d' /etc/environment && \
-         echo 'TZ={tz}' >> /etc/environment; \
-         fi"
-    );
+    };
+    let cmd = timezone_sync_command(tz);
     // Best-effort: don't fail the run if timezone setup fails.
     match sandbox
         .exec_with_diagnostic_label(

--- a/crates/runner/src/executor/guest_state.rs
+++ b/crates/runner/src/executor/guest_state.rs
@@ -129,8 +129,10 @@ fn log_embedded_timezone_failure(run_id: Option<RunId>, tz: &str, result: &sandb
 /// ACPI; DeviceTree support requires kernel 6.10+). All VMs restored from the
 /// same snapshot share identical CRNG state, producing identical random output.
 ///
-/// This syncs the frozen guest clock and injects fresh host entropy so each VM
-/// produces unique random numbers from the first `getrandom()` call.
+/// This syncs the frozen guest clock, injects fresh host entropy, and folds in
+/// best-effort system timezone sync when a user timezone is configured. The
+/// entropy step ensures each VM produces unique random numbers from the first
+/// `getrandom()` call.
 pub(crate) async fn restore_guest_state(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,

--- a/crates/runner/src/executor/guest_state.rs
+++ b/crates/runner/src/executor/guest_state.rs
@@ -7,6 +7,7 @@ use crate::helper_exec::{
     format_command_output_excerpt, format_helper_exec_failure, helper_exec_succeeded,
     helper_exec_termination_label,
 };
+use crate::ids::RunId;
 use crate::types::ExecutionContext;
 
 const ENTROPY_SIZE: usize = 256;
@@ -15,7 +16,7 @@ const TIMEZONE_SYNC_FAILED_MARKER: &str = "guest timezone sync failed";
 #[derive(Clone, Copy)]
 struct GuestTimezone<'a> {
     name: &'a str,
-    context: &'a ExecutionContext,
+    run_id: Option<RunId>,
 }
 
 fn helper_exec_exit_code(result: &sandbox::ExecResult) -> Option<i32> {
@@ -48,7 +49,7 @@ fn read_host_entropy() -> RunnerResult<Vec<u8>> {
     Ok(entropy)
 }
 
-fn valid_timezone_name(tz: &str) -> bool {
+pub(crate) fn is_valid_guest_timezone_name(tz: &str) -> bool {
     tz.bytes()
         .all(|b| b.is_ascii_alphanumeric() || b == b'/' || b == b'_' || b == b'-' || b == b'+')
 }
@@ -61,7 +62,7 @@ fn user_timezone(context: &ExecutionContext) -> Option<&str> {
     // Strict validation: timezone names are like "Asia/Shanghai" or "UTC".
     // Only allow alphanumeric, '/', '_', '-', '+'.  This prevents shell
     // injection since the value is interpolated into a sudo shell command.
-    if !valid_timezone_name(tz) {
+    if !is_valid_guest_timezone_name(tz) {
         tracing::warn!(tz = %tz, "rejected invalid timezone name");
         return None;
     }
@@ -89,11 +90,7 @@ fn timezone_sync_best_effort_command(tz: &str) -> String {
     )
 }
 
-fn log_embedded_timezone_failure(
-    context: &ExecutionContext,
-    tz: &str,
-    result: &sandbox::ExecResult,
-) {
+fn log_embedded_timezone_failure(run_id: Option<RunId>, tz: &str, result: &sandbox::ExecResult) {
     if !result
         .stderr
         .windows(TIMEZONE_SYNC_FAILED_MARKER.len())
@@ -106,14 +103,24 @@ fn log_embedded_timezone_failure(
         format_command_output_excerpt("stderr", &result.stderr, result.stderr_truncated);
     let stdout_excerpt =
         format_command_output_excerpt("stdout", &result.stdout, result.stdout_truncated);
-    tracing::warn!(
-        run_id = %context.run_id,
-        tz = %tz,
-        termination = helper_exec_termination_label(result),
-        stderr_excerpt = %stderr_excerpt.as_deref().unwrap_or(""),
-        stdout_excerpt = %stdout_excerpt.as_deref().unwrap_or(""),
-        "failed to set guest timezone"
-    );
+    if let Some(run_id) = run_id {
+        tracing::warn!(
+            run_id = %run_id,
+            tz = %tz,
+            termination = helper_exec_termination_label(result),
+            stderr_excerpt = %stderr_excerpt.as_deref().unwrap_or(""),
+            stdout_excerpt = %stdout_excerpt.as_deref().unwrap_or(""),
+            "failed to set guest timezone"
+        );
+    } else {
+        tracing::warn!(
+            tz = %tz,
+            termination = helper_exec_termination_label(result),
+            stderr_excerpt = %stderr_excerpt.as_deref().unwrap_or(""),
+            stdout_excerpt = %stdout_excerpt.as_deref().unwrap_or(""),
+            "failed to set guest timezone"
+        );
+    }
 }
 
 /// Restores snapshot-sensitive guest state in one exec before the agent starts.
@@ -128,14 +135,30 @@ pub(crate) async fn restore_guest_state(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,
 ) -> RunnerResult<()> {
-    let timezone = user_timezone(context).map(|name| GuestTimezone { name, context });
+    let timezone = user_timezone(context).map(|name| GuestTimezone {
+        name,
+        run_id: Some(context.run_id),
+    });
     restore_guest_state_inner(sandbox, timezone).await
 }
 
-pub(crate) async fn restore_guest_state_without_timezone(
+pub(crate) async fn restore_guest_state_with_timezone(
     sandbox: &dyn Sandbox,
+    timezone: &str,
 ) -> RunnerResult<()> {
-    restore_guest_state_inner(sandbox, None).await
+    if timezone.is_empty() || !is_valid_guest_timezone_name(timezone) {
+        return Err(RunnerError::Config(format!(
+            "invalid timezone {timezone:?}: expected a non-empty IANA timezone name"
+        )));
+    }
+    restore_guest_state_inner(
+        sandbox,
+        Some(GuestTimezone {
+            name: timezone,
+            run_id: None,
+        }),
+    )
+    .await
 }
 
 async fn restore_guest_state_inner(
@@ -173,7 +196,7 @@ guest-reseed || {{ status=$?; echo "guest-reseed failed" >&2; exit "$status"; }}
         )));
     }
     if let Some(timezone) = timezone {
-        log_embedded_timezone_failure(timezone.context, timezone.name, &result);
+        log_embedded_timezone_failure(timezone.run_id, timezone.name, &result);
     }
 
     Ok(())

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -35,7 +35,7 @@ mod session_restore;
 mod storage;
 mod telemetry;
 
-pub(crate) use guest_state::restore_guest_state_without_timezone;
+pub(crate) use guest_state::{is_valid_guest_timezone_name, restore_guest_state_with_timezone};
 
 use crate::active_input::ActiveInputSource;
 use agent_run::{ProcessCancelTimeouts, RunControls};

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -35,7 +35,7 @@ mod session_restore;
 mod storage;
 mod telemetry;
 
-pub(crate) use guest_state::restore_guest_state;
+pub(crate) use guest_state::restore_guest_state_without_timezone;
 
 use crate::active_input::ActiveInputSource;
 use agent_run::{ProcessCancelTimeouts, RunControls};

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -126,6 +126,109 @@ async fn run_in_sandbox_runs_guest_download_for_cached_instruction_normalization
 }
 
 #[tokio::test]
+async fn run_in_sandbox_folds_timezone_sync_into_restore_exec() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let sandbox = sandbox_mock::MockSandbox::new("test");
+    let mut ctx = minimal_context();
+    ctx.user_timezone = Some("Asia/Shanghai".into());
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    run_in_sandbox(
+        &sandbox,
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: true,
+            reuse_result: SandboxReuseResult::Reused,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None),
+    )
+    .await
+    .unwrap();
+
+    let exec_calls = sandbox.exec_calls();
+    let restore_calls = exec_calls
+        .iter()
+        .filter(|call| call.cmd.contains("guest-reseed"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        restore_calls.len(),
+        1,
+        "restore should run once; calls: {exec_calls:?}"
+    );
+    let restore_command = &restore_calls[0].cmd;
+    assert!(
+        restore_command.contains("if test -f /usr/share/zoneinfo/Asia/Shanghai"),
+        "restore should include timezone sync; command: {restore_command}"
+    );
+    assert!(
+        restore_command.contains("guest timezone sync failed"),
+        "timezone sync should remain best-effort; command: {restore_command}"
+    );
+    let standalone_timezone_calls = exec_calls
+        .iter()
+        .filter(|call| {
+            call.cmd
+                .starts_with("if test -f /usr/share/zoneinfo/Asia/Shanghai")
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        standalone_timezone_calls.is_empty(),
+        "restore path should not run a separate timezone exec; calls: {exec_calls:?}"
+    );
+    assert_eq!(
+        exec_calls
+            .iter()
+            .filter(|call| call.cmd.contains("/usr/share/zoneinfo/Asia/Shanghai"))
+            .count(),
+        1,
+        "timezone sync should appear in exactly one exec; calls: {exec_calls:?}"
+    );
+}
+
+#[tokio::test]
+async fn run_in_sandbox_runs_standalone_timezone_sync_without_restore_exec() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let sandbox = sandbox_mock::MockSandbox::new("test");
+    let mut ctx = minimal_context();
+    ctx.user_timezone = Some("Asia/Shanghai".into());
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    run_in_sandbox(
+        &sandbox,
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::PoolMiss,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None),
+    )
+    .await
+    .unwrap();
+
+    let exec_calls = sandbox.exec_calls();
+    assert!(
+        exec_calls.iter().any(|call| call
+            .cmd
+            .starts_with("if test -f /usr/share/zoneinfo/Asia/Shanghai")),
+        "fresh path should keep standalone timezone sync; calls: {exec_calls:?}"
+    );
+    assert!(
+        exec_calls
+            .iter()
+            .all(|call| !call.cmd.contains("guest-reseed")),
+        "fresh path should not run guest state restore; calls: {exec_calls:?}"
+    );
+}
+
+#[tokio::test]
 async fn run_in_sandbox_forwards_local_active_inputs_in_order_and_dedupes() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;

--- a/crates/runner/src/executor/tests/guest_state_tests.rs
+++ b/crates/runner/src/executor/tests/guest_state_tests.rs
@@ -11,8 +11,9 @@ use crate::types::ExecutionContext;
 #[tokio::test]
 async fn restore_guest_state_combines_clock_sync_and_reseed() {
     let sandbox = MockSandbox::new("test");
+    let ctx = minimal_context();
 
-    restore_guest_state(&sandbox).await.unwrap();
+    restore_guest_state(&sandbox, &ctx).await.unwrap();
 
     let calls = sandbox.exec_calls();
     assert_eq!(calls.len(), 1);
@@ -33,11 +34,112 @@ async fn restore_guest_state_combines_clock_sync_and_reseed() {
 }
 
 #[tokio::test]
+async fn restore_guest_state_folds_timezone_sync_into_restore_exec() {
+    let sandbox = MockSandbox::new("test");
+    let mut ctx = minimal_context();
+    ctx.user_timezone = Some("Asia/Shanghai".into());
+
+    restore_guest_state(&sandbox, &ctx).await.unwrap();
+
+    let calls = sandbox.exec_calls();
+    assert_eq!(calls.len(), 1);
+    let command = &calls[0].cmd;
+    let clock_sync_index = command
+        .find("date -s \"@")
+        .expect("guest state restore should sync the clock first");
+    let reseed_index = command
+        .find("guest-reseed")
+        .expect("guest state restore should reseed entropy");
+    let timezone_index = command
+        .find("echo 'Asia/Shanghai' > /etc/timezone")
+        .expect("guest state restore should include timezone sync");
+    assert!(clock_sync_index < reseed_index);
+    assert!(reseed_index < timezone_index);
+    assert!(command.contains("guest clock sync failed"));
+    assert!(command.contains("guest-reseed failed"));
+    assert!(command.contains("guest timezone sync failed"));
+    assert!(
+        command.contains(
+            "if test -f /usr/share/zoneinfo/Asia/Shanghai; then { echo 'Asia/Shanghai' > /etc/timezone"
+        ),
+        "unexpected command: {command}"
+    );
+    assert!(calls[0].sudo);
+    let stdin_bytes = calls[0].stdin_bytes.as_ref().unwrap();
+    assert_eq!(stdin_bytes.len(), 256);
+}
+
+#[tokio::test]
+async fn restore_guest_state_rejects_invalid_timezone_without_extra_exec() {
+    let sandbox = MockSandbox::new("test");
+    let mut ctx = minimal_context();
+    ctx.user_timezone = Some("UTC;id".into());
+
+    restore_guest_state(&sandbox, &ctx).await.unwrap();
+
+    let calls = sandbox.exec_calls();
+    assert_eq!(calls.len(), 1);
+    assert!(calls[0].cmd.contains("date -s \"@"));
+    assert!(calls[0].cmd.contains("guest-reseed"));
+    assert!(!calls[0].cmd.contains("UTC;id"));
+    assert!(!calls[0].cmd.contains("guest timezone sync failed"));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn restore_guest_state_logs_embedded_timezone_failure_without_failing_restore() {
+    let sandbox = MockSandbox::new("test");
+    sandbox.push_exec_result(Ok(ExecResult::new(
+        0,
+        b"timezone stdout".to_vec(),
+        b"ln failed\nguest timezone sync failed".to_vec(),
+    )));
+    let mut ctx = minimal_context();
+    ctx.user_timezone = Some("America/New_York".into());
+    let captured = CapturedEvents::default();
+    let subscriber = tracing_subscriber::registry().with(captured.clone());
+    let _guard = tracing::subscriber::set_default(subscriber);
+    tracing::callsite::rebuild_interest_cache();
+
+    restore_guest_state(&sandbox, &ctx).await.unwrap();
+
+    let events = captured.entries();
+    let event = events
+        .iter()
+        .find(|event| {
+            event.level == Level::WARN
+                && event.fields.get("message").map(String::as_str)
+                    == Some("failed to set guest timezone")
+        })
+        .unwrap_or_else(|| panic!("missing timezone warning; events={events:#?}"));
+    let run_id = RunId::nil().to_string();
+    assert_eq!(
+        event.fields.get("run_id").map(String::as_str),
+        Some(run_id.as_str())
+    );
+    assert_eq!(
+        event.fields.get("tz").map(String::as_str),
+        Some("America/New_York")
+    );
+    assert_eq!(
+        event.fields.get("termination").map(String::as_str),
+        Some("exited")
+    );
+    assert!(
+        event
+            .fields
+            .get("stderr_excerpt")
+            .is_some_and(|value| value.contains("guest timezone sync failed")),
+        "event={event:#?}"
+    );
+}
+
+#[tokio::test]
 async fn restore_guest_state_propagates_exec_error() {
     let sandbox = MockSandbox::new("test");
     sandbox.push_exec_result(Err(sandbox_exec_error("restore failed")));
+    let ctx = minimal_context();
 
-    let result = restore_guest_state(&sandbox);
+    let result = restore_guest_state(&sandbox, &ctx);
 
     assert!(result.await.is_err());
 }
@@ -53,8 +155,9 @@ async fn restore_guest_state_fails_on_non_exited_result() {
         stdout_truncated: false,
         stderr_truncated: false,
     }));
+    let ctx = minimal_context();
 
-    let result = restore_guest_state(&sandbox).await;
+    let result = restore_guest_state(&sandbox, &ctx).await;
 
     let message = result.unwrap_err().to_string();
     assert!(
@@ -79,8 +182,9 @@ async fn restore_guest_state_reports_clock_failure_marker() {
         b"date stdout".to_vec(),
         b"guest clock sync failed\ndate stderr".to_vec(),
     )));
+    let ctx = minimal_context();
 
-    let result = restore_guest_state(&sandbox).await;
+    let result = restore_guest_state(&sandbox, &ctx).await;
 
     let message = result.unwrap_err().to_string();
     assert!(
@@ -101,8 +205,9 @@ async fn restore_guest_state_reports_reseed_failure_marker() {
         Vec::new(),
         b"guest-reseed failed\nRNDRESEEDCRNG failed".to_vec(),
     )));
+    let ctx = minimal_context();
 
-    let result = restore_guest_state(&sandbox).await;
+    let result = restore_guest_state(&sandbox, &ctx).await;
 
     let message = result.unwrap_err().to_string();
     assert!(

--- a/crates/runner/src/executor/tests/guest_state_tests.rs
+++ b/crates/runner/src/executor/tests/guest_state_tests.rs
@@ -3,7 +3,9 @@ use sandbox_mock::MockSandbox;
 use tracing::Level;
 use tracing_subscriber::prelude::*;
 
-use super::super::guest_state::{restore_guest_state, sync_guest_timezone};
+use super::super::guest_state::{
+    restore_guest_state, restore_guest_state_with_timezone, sync_guest_timezone,
+};
 use super::support::{CapturedEvent, CapturedEvents, minimal_context, sandbox_exec_error};
 use crate::ids::RunId;
 use crate::types::ExecutionContext;
@@ -67,6 +69,41 @@ async fn restore_guest_state_folds_timezone_sync_into_restore_exec() {
     assert!(calls[0].sudo);
     let stdin_bytes = calls[0].stdin_bytes.as_ref().unwrap();
     assert_eq!(stdin_bytes.len(), 256);
+}
+
+#[tokio::test]
+async fn restore_guest_state_with_explicit_timezone_folds_sync_into_restore_exec() {
+    let sandbox = MockSandbox::new("test");
+
+    restore_guest_state_with_timezone(&sandbox, "UTC")
+        .await
+        .unwrap();
+
+    let calls = sandbox.exec_calls();
+    assert_eq!(calls.len(), 1);
+    let command = &calls[0].cmd;
+    assert!(command.contains("date -s \"@"));
+    assert!(command.contains("guest-reseed"));
+    assert!(
+        command.contains("if test -f /usr/share/zoneinfo/UTC; then { echo 'UTC' > /etc/timezone"),
+        "unexpected command: {command}"
+    );
+    assert!(command.contains("echo 'TZ=UTC' >> /etc/environment"));
+    assert!(command.contains("guest timezone sync failed"));
+}
+
+#[tokio::test]
+async fn restore_guest_state_with_explicit_timezone_rejects_invalid_timezone_before_exec() {
+    let sandbox = MockSandbox::new("test");
+
+    let result = restore_guest_state_with_timezone(&sandbox, "UTC;id").await;
+
+    let message = result.unwrap_err().to_string();
+    assert!(
+        message.contains("invalid timezone"),
+        "unexpected error: {message}"
+    );
+    assert!(sandbox.exec_calls().is_empty());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Closes #18751.

- Fold user timezone sync into the existing guest state restore sudo exec when `restore_guest_state` is enabled.
- Keep standalone timezone sync for fresh/no-restore runs so those paths keep the previous behavior.
- Make `restore_guest_state` take `ExecutionContext` by default so production callers include timezone automatically.
- Add benchmark `--timezone` with default `UTC`, so benchmark restore measures the same embedded timezone sync path while remaining deterministic.
- Preserve hard failure semantics for clock sync and entropy reseed, while keeping timezone best-effort and warning when the embedded timezone step reports failure.

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::benchmark::tests`
- `cargo test --manifest-path crates/Cargo.toml -p runner executor::tests::guest_state_tests`
- `cargo test --manifest-path crates/Cargo.toml -p runner executor::tests::agent_run_tests`
- `cargo test --manifest-path crates/Cargo.toml -p runner executor::tests::sandbox_run_tests::fresh_sandbox::execute_inner_with_snapshot_runs_clock_fix_and_reseed`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- pre-commit: cargo fmt, cargo doc, cargo clippy
