### PR TITLE
fix: preserve presentation template picker scroll

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
@@ -166,6 +166,18 @@ export const setTemplatePickerPreviewSlug$ = command(
   },
 );
 
+const internalTemplatePickerPresentationScrollTop$ = state(0);
+export const setTemplatePickerPresentationScrollTop$ = command(
+  ({ set }, scrollTop: number) => {
+    set(internalTemplatePickerPresentationScrollTop$, scrollTop);
+  },
+);
+export const restoreTemplatePickerPresentationScroll$ = command(
+  ({ get }, node: HTMLElement) => {
+    node.scrollTop = get(internalTemplatePickerPresentationScrollTop$);
+  },
+);
+
 // Inline illustration cards show a hero image plus a variant thumbnail strip.
 // Several cards are visible at once, so the active variant index is tracked per
 // illustration style slug rather than as a single shared value.

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -96,6 +96,16 @@ function linkByText(text: string): HTMLElement {
   return link;
 }
 
+function presentationTemplateGridScrollContainer(): HTMLElement {
+  const scrollContainer = screen
+    .getByRole("dialog")
+    .querySelector<HTMLElement>("[data-presentation-template-grid-scroll]");
+  if (!scrollContainer) {
+    throw new Error("Presentation template grid scroll container not found");
+  }
+  return scrollContainer;
+}
+
 function mockNavigatorUserAgent(userAgent: string): () => void {
   const original = Object.getOwnPropertyDescriptor(navigator, "userAgent");
   Object.defineProperty(navigator, "userAgent", {
@@ -2325,6 +2335,72 @@ describe("chat composer templates", () => {
     expect(
       screen.queryByText(`${String(lastSlideNumber)} of 15`),
     ).not.toBeInTheDocument();
+  });
+
+  it("preserves presentation template grid scroll when returning from detail preview", async () => {
+    const template = PRESENTATION_TEMPLATE_PICKER_ITEMS[0]!;
+    mockChatLifecycle(context, { threadId: THREAD_ID });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ChatTemplatePicker]: true,
+      },
+    });
+
+    click(
+      await waitFor(() => {
+        return screen.getByLabelText("Template");
+      }),
+    );
+
+    const initialScrollContainer = presentationTemplateGridScrollContainer();
+    initialScrollContainer.scrollTop = 360;
+    fireEvent.scroll(initialScrollContainer);
+    click(screen.getByLabelText(`Preview ${template.title} at current slide`));
+
+    const templateDialog = screen.getByRole("dialog");
+    await waitFor(() => {
+      expect(
+        within(templateDialog).getByRole("heading", {
+          name: `Template / ${template.title}`,
+        }),
+      ).toBeInTheDocument();
+    });
+
+    click(within(templateDialog).getByLabelText("Close"));
+    await waitFor(() => {
+      expect(presentationTemplateGridScrollContainer().scrollTop).toBe(360);
+    });
+
+    const restoredAfterClose = presentationTemplateGridScrollContainer();
+    restoredAfterClose.scrollTop = 520;
+    fireEvent.scroll(restoredAfterClose);
+    click(screen.getByLabelText(`Preview ${template.title} at current slide`));
+    await waitFor(() => {
+      expect(
+        within(templateDialog).getByRole("heading", {
+          name: `Template / ${template.title}`,
+        }),
+      ).toBeInTheDocument();
+    });
+
+    const templateButton = queryAllByRoleFast("button", templateDialog).find(
+      (candidate) => {
+        return (
+          candidate.textContent?.replace(/\s+/g, " ").trim() === "Template"
+        );
+      },
+    );
+    if (!templateButton) {
+      throw new Error("Template button not found");
+    }
+    click(templateButton);
+
+    await waitFor(() => {
+      expect(presentationTemplateGridScrollContainer().scrollTop).toBe(520);
+    });
   });
 
   it("resumes presentation template detail preview loading after reopening the same slide", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -172,6 +172,8 @@ import {
   setTemplatePickerSearch$,
   templatePickerPreviewSlug$,
   setTemplatePickerPreviewSlug$,
+  restoreTemplatePickerPresentationScroll$,
+  setTemplatePickerPresentationScrollTop$,
   setComputerUseDownloadDialogOpen$,
   illustrationVariantIndex$,
   setIllustrationVariantIndex$,
@@ -4272,6 +4274,12 @@ function TemplatePickerDialog({
   const setSearch = useSet(setTemplatePickerSearch$);
   const previewSlug = useGet(templatePickerPreviewSlug$);
   const setPreviewSlug = useSet(setTemplatePickerPreviewSlug$);
+  const restorePresentationGridScroll = useSet(
+    restoreTemplatePickerPresentationScroll$,
+  );
+  const setPresentationGridScrollTop = useSet(
+    setTemplatePickerPresentationScrollTop$,
+  );
   const detailPreview = useGet(templateDetailHtmlPreview$);
   const setDetailPreview = useSet(setTemplateDetailHtmlPreview$);
   const detailThemeIdBySlug = useGet(templateDetailThemeIdBySlug$);
@@ -4365,22 +4373,27 @@ function TemplatePickerDialog({
     );
   };
 
+  const closeTemplatePicker = () => {
+    setPresentationGridScrollTop(0);
+    onClose();
+  };
+
   const handleSelectPresentation = (
     item: PresentationTemplateItem,
     colorSystemId?: string,
   ) => {
     onChange(toPresentationGenerationTemplate(item, colorSystemId));
-    onClose();
+    closeTemplatePicker();
   };
 
   const handleSelectVideo = (item: VideoTemplateItem) => {
     onChange(toVideoGenerationTemplate(item));
-    onClose();
+    closeTemplatePicker();
   };
 
   const handleSelectIllustration = (item: IllustrationTemplateItem) => {
     onChange(toIllustrationGenerationTemplate(item));
-    onClose();
+    closeTemplatePicker();
   };
 
   const handlePreview = (item: PresentationTemplateItem, slideIndex = 0) => {
@@ -4475,6 +4488,13 @@ function TemplatePickerDialog({
     }
   };
 
+  const restorePresentationGridScrollNode = (node: HTMLDivElement | null) => {
+    if (node === null) {
+      return;
+    }
+    restorePresentationGridScroll(node);
+  };
+
   return (
     <Dialog
       open
@@ -4484,7 +4504,7 @@ function TemplatePickerDialog({
             setPreviewSlug(null);
             return;
           }
-          onClose();
+          closeTemplatePicker();
         }
       }}
     >
@@ -4544,7 +4564,11 @@ function TemplatePickerDialog({
             {selectedCategory === "slides" && hasPptTab && (
               <div
                 data-presentation-template-grid-scroll=""
+                ref={restorePresentationGridScrollNode}
                 className="relative flex min-h-0 flex-1 transform-gpu flex-col overflow-y-auto px-5 py-4"
+                onScroll={(event) => {
+                  setPresentationGridScrollTop(event.currentTarget.scrollTop);
+                }}
               >
                 {filteredPptItems.length > 0 ? (
                   <PptTemplateGrid


### PR DESCRIPTION
## Summary

- Preserve the presentation template picker scroll position while users open and return from a template detail preview.
- Store the presentation grid scroll offset in composer ccstate commands so returning from detail restores the first-level picker without causing scroll-driven rerenders.
- Add regression coverage for returning via both the detail close button and the Template breadcrumb.

## Root Cause

The first-level presentation template grid unmounts when the picker switches into the second-level detail preview. When the user closes the detail view or navigates back, the grid remounts with the browser default `scrollTop` of `0`.

## Validation

- `pnpm format`
- `pnpm lint`
- `pnpm check-types`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx`

## Notes

- `pnpm test` was attempted but the local environment is not ready for the full suite: API tests fail with Postgres connection errors to `127.0.0.1:5432` / `::1:5432`, and `scripts/prepare.sh` also fails because `DATABASE_URL` is invalid or unset and local Postgres is not reachable.
- Some web tests in the full run also failed because `localStorage` was unavailable in the full-root Vitest process.
