### PR TITLE
feat(triggers): add session-gated route to set unattended permission policy

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-triggers.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-triggers.test.ts
@@ -25,6 +25,11 @@ import { signSandboxJwtForTests } from "../../auth/tokens";
 import { writeDb$ } from "../../external/db";
 import { encryptStoredSecretValue } from "../../services/crypto.utils";
 import {
+  deleteOrgMembership$,
+  seedOrgMembership$,
+  type OrgMembershipFixture,
+} from "./helpers/zero-org-membership";
+import {
   deleteWorkflowsForFixture$,
   seedAgentForInstructions$,
   seedWorkflowsFixture$,
@@ -169,6 +174,12 @@ describe("zero workflow triggers", () => {
     await store.set(deleteWorkflowsForFixture$, fixture, context.signal);
   });
 
+  const trackMembership = createFixtureTracker<OrgMembershipFixture>(
+    async (fixture) => {
+      await store.set(deleteOrgMembership$, fixture, context.signal);
+    },
+  );
+
   async function setupFixture(): Promise<{
     fixture: WorkflowsFixture;
     agentId: string;
@@ -285,11 +296,24 @@ describe("zero workflow triggers", () => {
     const { workflowId } = await setupFixture();
     const triggerId = await createScheduleTrigger(workflowId);
 
+    // Seed the in-run token's org membership so role resolution hits the cache
+    // instead of Clerk; the request then reaches the token-type gate, which is
+    // what this test asserts.
+    const runUserId = `user_${randomUUID()}`;
+    const runOrgId = `org_${randomUUID()}`;
+    await trackMembership(
+      store.set(
+        seedOrgMembership$,
+        { orgId: runOrgId, userId: runUserId },
+        context.signal,
+      ),
+    );
+
     const seconds = Math.floor(now() / 1000);
     const token = signSandboxJwtForTests({
       scope: "zero",
-      userId: `user_${randomUUID()}`,
-      orgId: `org_${randomUUID()}`,
+      userId: runUserId,
+      orgId: runOrgId,
       runId: `run_${randomUUID()}`,
       capabilities: ["agent:write"],
       iat: seconds,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-triggers.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-triggers.test.ts
@@ -21,6 +21,7 @@ import { createApp } from "../../../app-factory";
 import { mockOptionalEnv } from "../../../lib/env";
 import { mockNow, now } from "../../../lib/time";
 import { server } from "../../../mocks/server";
+import { signSandboxJwtForTests } from "../../auth/tokens";
 import { writeDb$ } from "../../external/db";
 import { encryptStoredSecretValue } from "../../services/crypto.utils";
 import {
@@ -216,6 +217,97 @@ describe("zero workflow triggers", () => {
       throw new Error("Expected a schedule trigger");
     }
     expect(created.body.scheduleSummary.length).toBeGreaterThan(0);
+  });
+
+  async function createScheduleTrigger(workflowId: string): Promise<string> {
+    const created = await accept(
+      triggersClient().create({
+        headers: authHeaders(),
+        params: { workflowId },
+        body: { schedule: { type: "loop", intervalSeconds: 60 } },
+      }),
+      [201],
+    );
+    expect(created.body.unattendedPermissionPolicy).toBeNull();
+    return created.body.id;
+  }
+
+  it("sets and clears the unattended permission policy from a session", async () => {
+    const { workflowId } = await setupFixture();
+    const triggerId = await createScheduleTrigger(workflowId);
+
+    const set = await accept(
+      triggersClient().setPermissionPolicy({
+        headers: authHeaders(),
+        params: { id: triggerId },
+        body: {
+          unattendedPermissionPolicy: {
+            gmail: { policies: { "messages.write": "allow" } },
+          },
+        },
+      }),
+      [200],
+    );
+    expect(set.body.unattendedPermissionPolicy).toStrictEqual({
+      gmail: { policies: { "messages.write": "allow" } },
+    });
+
+    const cleared = await accept(
+      triggersClient().setPermissionPolicy({
+        headers: authHeaders(),
+        params: { id: triggerId },
+        body: { unattendedPermissionPolicy: null },
+      }),
+      [200],
+    );
+    expect(cleared.body.unattendedPermissionPolicy).toBeNull();
+  });
+
+  it("rejects a permission policy with an unknown permission name", async () => {
+    const { workflowId } = await setupFixture();
+    const triggerId = await createScheduleTrigger(workflowId);
+
+    await accept(
+      triggersClient().setPermissionPolicy({
+        headers: authHeaders(),
+        params: { id: triggerId },
+        body: {
+          unattendedPermissionPolicy: {
+            gmail: { policies: { "messages.not-a-real-permission": "allow" } },
+          },
+        },
+      }),
+      [400],
+    );
+  });
+
+  it("rejects setting the policy from an in-run token even with agent:write", async () => {
+    const { workflowId } = await setupFixture();
+    const triggerId = await createScheduleTrigger(workflowId);
+
+    const seconds = Math.floor(now() / 1000);
+    const token = signSandboxJwtForTests({
+      scope: "zero",
+      userId: `user_${randomUUID()}`,
+      orgId: `org_${randomUUID()}`,
+      runId: `run_${randomUUID()}`,
+      capabilities: ["agent:write"],
+      iat: seconds,
+      exp: seconds + 60,
+    });
+
+    await accept(
+      triggersClient().setPermissionPolicy({
+        headers: { authorization: `Bearer ${token}` },
+        params: { id: triggerId },
+        body: {
+          unattendedPermissionPolicy: {
+            gmail: { policies: { "messages.write": "allow" } },
+          },
+        },
+      }),
+      [403],
+    );
   });
 
   it("lists thread-bound workflow triggers", async () => {

--- a/turbo/apps/api/src/signals/routes/zero-workflow-triggers.ts
+++ b/turbo/apps/api/src/signals/routes/zero-workflow-triggers.ts
@@ -18,6 +18,7 @@ import {
   getWorkflowTrigger,
   listThreadBoundWorkflowTriggers,
   loadWorkflowTriggers,
+  setWorkflowTriggerPermissionPolicy$,
   testRunWorkflowTrigger$,
   updateWorkflowTrigger$,
   type TriggerResult,
@@ -34,6 +35,15 @@ const workflowWriteAuth = {
   requireOrganization: true,
   missingOrganizationStatus: 401,
   requiredCapability: "agent:write",
+} as const;
+
+// The unattended permission policy is set only from a browser session or PAT,
+// never from an in-run agent token (sandbox/zero). This prevents an unattended
+// run from self-escalating the permissions of the trigger it runs under. See
+// issue #18789.
+const workflowPermissionPolicyWriteAuth = {
+  ...workflowWriteAuth,
+  accept: ["session", "pat"],
 } as const;
 
 function memberFromAuth(auth: {
@@ -75,6 +85,9 @@ function triggerErrorResponse(
 
 const createTriggerBody$ = bodyResultOf(zeroWorkflowTriggersContract.create);
 const updateTriggerBody$ = bodyResultOf(zeroWorkflowTriggersContract.update);
+const setTriggerPermissionPolicyBody$ = bodyResultOf(
+  zeroWorkflowTriggersContract.setPermissionPolicy,
+);
 
 const listChatThreadTriggersInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
@@ -191,6 +204,35 @@ const updateTriggerInner$ = command(
             triggerId: params.id,
             eventConfig: bodyResult.data.eventConfig,
           },
+      signal,
+    );
+    signal.throwIfAborted();
+    if (result.kind === "ok") {
+      return { status: 200 as const, body: result.summary };
+    }
+    return triggerErrorResponse(result);
+  },
+);
+
+const setTriggerPermissionPolicyInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    const params = get(
+      pathParamsOf(zeroWorkflowTriggersContract.setPermissionPolicy),
+    );
+    const bodyResult = await get(setTriggerPermissionPolicyBody$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+    const result = await set(
+      setWorkflowTriggerPermissionPolicy$,
+      {
+        orgId: auth.orgId,
+        member: memberFromAuth(auth),
+        triggerId: params.id,
+        policy: bodyResult.data.unattendedPermissionPolicy,
+      },
       signal,
     );
     signal.throwIfAborted();
@@ -328,5 +370,12 @@ export const zeroWorkflowTriggersRoutes: readonly RouteEntry[] = [
   {
     route: zeroWorkflowTriggersContract.run,
     handler: authRoute(workflowWriteAuth, runTriggerInner$),
+  },
+  {
+    route: zeroWorkflowTriggersContract.setPermissionPolicy,
+    handler: authRoute(
+      workflowPermissionPolicyWriteAuth,
+      setTriggerPermissionPolicyInner$,
+    ),
   },
 ];

--- a/turbo/apps/api/src/signals/services/zero-workflow-trigger.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-trigger.service.ts
@@ -3,9 +3,11 @@ import {
   gmailNewMessageEventConfigSchema,
   type ChatThreadWorkflowTrigger,
   type GmailNewMessageEventConfig,
+  type UnattendedTriggerPermissionPolicy,
   type ZeroWorkflowSchedule,
   type ZeroWorkflowTriggerSummary,
 } from "@vm0/api-contracts/contracts/zero-workflows";
+import { loadFirewallPermissionIndex } from "@vm0/connectors/firewall-metadata/server";
 import { parseScheduledAtTime } from "@vm0/core/timezone";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { userConnectors } from "@vm0/db/schema/user-connector";
@@ -795,6 +797,79 @@ export const updateWorkflowTrigger$ = command(
     signal.throwIfAborted();
     if (!row) {
       throw new Error("Failed to update workflow trigger");
+    }
+    return { kind: "ok", summary: rowToSummary(row) };
+  },
+);
+
+interface SetTriggerPermissionPolicyInput {
+  readonly orgId: string;
+  readonly member: WorkflowMember;
+  readonly triggerId: string;
+  readonly policy: UnattendedTriggerPermissionPolicy | null;
+}
+
+/**
+ * Validates connector refs and permission names against the generated firewall
+ * metadata (the same source the user-permission-grants apply path validates
+ * against). `ask` is already rejected by the contract schema, and the unknown
+ * pseudo-permission is intentionally not accepted: a trigger's unknown-endpoint
+ * policy is not configurable and always resolves to `deny`.
+ */
+async function validateUnattendedPermissionPolicy(
+  policy: UnattendedTriggerPermissionPolicy,
+): Promise<{ readonly kind: "bad-request"; readonly message: string } | null> {
+  for (const [connectorRef, entry] of Object.entries(policy)) {
+    const index = await loadFirewallPermissionIndex(connectorRef);
+    if (!index) {
+      return {
+        kind: "bad-request",
+        message: `Unknown connector ref: ${connectorRef}`,
+      };
+    }
+    for (const permission of Object.keys(entry.policies)) {
+      if (!index.hasPermission(permission)) {
+        return {
+          kind: "bad-request",
+          message: `Unknown permission "${permission}" for connector "${connectorRef}"`,
+        };
+      }
+    }
+  }
+  return null;
+}
+
+export const setWorkflowTriggerPermissionPolicy$ = command(
+  async (
+    { set },
+    args: SetTriggerPermissionPolicyInput,
+    signal: AbortSignal,
+  ): Promise<TriggerResult> => {
+    if (args.policy !== null) {
+      const policyError = await validateUnattendedPermissionPolicy(args.policy);
+      signal.throwIfAborted();
+      if (policyError) {
+        return policyError;
+      }
+    }
+    const writeDb = set(writeDb$);
+    const owned = await loadOwnedTrigger(writeDb, {
+      orgId: args.orgId,
+      member: args.member,
+      triggerId: args.triggerId,
+    });
+    signal.throwIfAborted();
+    if ("kind" in owned) {
+      return owned;
+    }
+    const [row] = await writeDb
+      .update(zeroWorkflowTriggers)
+      .set({ unattendedPermissionPolicy: args.policy, updatedAt: nowDate() })
+      .where(eq(zeroWorkflowTriggers.id, owned.trigger.id))
+      .returning();
+    signal.throwIfAborted();
+    if (!row) {
+      throw new Error("Failed to update workflow trigger permission policy");
     }
     return { kind: "ok", summary: rowToSummary(row) };
   },

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -136,6 +136,10 @@ const ZERO_WORKFLOW_TRIGGER_RUN_REWRITE_SOURCE = `/api/zero/workflow-triggers/:i
 const ZERO_WORKFLOW_TRIGGER_RUN_PATH_RE = new RegExp(
   `^/api/zero/workflow-triggers/${UUID_PATH_SEGMENT_PATTERN}/run$`,
 );
+const ZERO_WORKFLOW_TRIGGER_PERMISSION_POLICY_REWRITE_SOURCE = `/api/zero/workflow-triggers/:id(${UUID_PATH_SEGMENT_PATTERN})/permission-policy`;
+const ZERO_WORKFLOW_TRIGGER_PERMISSION_POLICY_PATH_RE = new RegExp(
+  `^/api/zero/workflow-triggers/${UUID_PATH_SEGMENT_PATTERN}/permission-policy$`,
+);
 const ZERO_ME_MODEL_PROVIDERS_REWRITE_SOURCE = "/api/zero/me/model-providers";
 const ZERO_VARIABLE_BY_NAME_REWRITE_SOURCE = "/api/zero/variables/:name";
 const ZERO_VARIABLE_BY_NAME_PATH_RE = /^\/api\/zero\/variables\/[^/]+$/;
@@ -1388,6 +1392,11 @@ export const API_BACKEND_REWRITES = [
     ZERO_WORKFLOW_TRIGGER_RUN_REWRITE_SOURCE,
     "/api/zero/workflow-triggers/:id/run",
     ZERO_WORKFLOW_TRIGGER_RUN_PATH_RE,
+  ],
+  [
+    ZERO_WORKFLOW_TRIGGER_PERMISSION_POLICY_REWRITE_SOURCE,
+    "/api/zero/workflow-triggers/:id/permission-policy",
+    ZERO_WORKFLOW_TRIGGER_PERMISSION_POLICY_PATH_RE,
   ],
   [
     ZERO_WORKFLOW_TRIGGER_BY_ID_REWRITE_SOURCE,

--- a/turbo/packages/api-contracts/src/contracts/zero-workflows.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-workflows.ts
@@ -207,6 +207,17 @@ export type UnattendedTriggerPermissionPolicy = z.infer<
 >;
 
 /**
+ * Full-replace request for a trigger's unattended permission policy. `null`
+ * clears the policy back to connector metadata defaults.
+ */
+export const setUnattendedTriggerPermissionPolicyRequestSchema = z.object({
+  unattendedPermissionPolicy: unattendedTriggerPermissionPolicySchema.nullable(),
+});
+export type SetUnattendedTriggerPermissionPolicyRequest = z.infer<
+  typeof setUnattendedTriggerPermissionPolicyRequestSchema
+>;
+
+/**
  * Trigger summary. Under 1:N the agent is derived from the workflow, so triggers
  * no longer carry an agentId. Detail responses only ever list the caller's own
  * triggers.
@@ -707,6 +718,22 @@ export const zeroWorkflowTriggersContract = c.router({
       409: apiErrorSchema,
     },
     summary: "Fire a one-off test run of a workflow trigger",
+  },
+  setPermissionPolicy: {
+    method: "PUT",
+    path: "/api/zero/workflow-triggers/:id/permission-policy",
+    headers: authHeadersSchema,
+    pathParams: triggerIdParams,
+    body: setUnattendedTriggerPermissionPolicyRequestSchema,
+    responses: {
+      200: zeroWorkflowTriggerSummarySchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary:
+      "Set a workflow trigger unattended permission policy (session/PAT only)",
   },
 });
 

--- a/turbo/packages/api-contracts/src/contracts/zero-workflows.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-workflows.ts
@@ -211,7 +211,8 @@ export type UnattendedTriggerPermissionPolicy = z.infer<
  * clears the policy back to connector metadata defaults.
  */
 export const setUnattendedTriggerPermissionPolicyRequestSchema = z.object({
-  unattendedPermissionPolicy: unattendedTriggerPermissionPolicySchema.nullable(),
+  unattendedPermissionPolicy:
+    unattendedTriggerPermissionPolicySchema.nullable(),
 });
 export type SetUnattendedTriggerPermissionPolicyRequest = z.infer<
   typeof setUnattendedTriggerPermissionPolicyRequestSchema


### PR DESCRIPTION
Sub-issue of #18789 (2/5). Closes #18802. Builds on #18806.

Adds the write path for a trigger's isolated unattended permission policy.

## What
- New endpoint `PUT /api/zero/workflow-triggers/:id/permission-policy` (full replace; `null` clears back to metadata defaults).
- Gated with `accept: ["session", "pat"]` so in-run agent tokens (`sandbox`/`zero`) are rejected with 403 — even when they carry `agent:write`. This prevents an unattended run from self-escalating the permissions of the trigger it runs under.
- Service validates connector refs + permission names against the generated firewall metadata (same source the user-permission-grants apply path uses) and rejects unknown names; `ask` is already rejected by the contract type.
- Authorization reuses the existing owned-trigger check (caller must be able to manage the workflow's agent).

## Why
The policy must be settable by a human (UI/CLI) but never by the in-run agent. Keeping it off the normal trigger create/update body and on a session/PAT-only route is the self-escalation guard. See #18789.

## Test plan
- `pnpm check-types` + `pnpm turbo run lint` — green.
- Integration tests added: session sets/clears the policy; unknown permission → 400; an in-run `zero` token with `agent:write` → 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)