### PR TITLE
fix: deepen computer-use menu hover color

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -5232,7 +5232,9 @@ function ComputerUseConnectorMenuSection({
                 key={host.id}
                 className={cn(
                   "flex items-center gap-2 rounded-md px-2 py-2 transition-colors",
-                  checked ? "bg-primary/5" : "hover:bg-background/70",
+                  checked
+                    ? "bg-primary/5"
+                    : "hover:bg-gray-100 dark:hover:bg-gray-200",
                 )}
               >
                 <span className="flex h-4 w-4 shrink-0 items-center justify-center text-muted-foreground">
@@ -5274,7 +5276,7 @@ function ComputerUseConnectorMenuSection({
       <PopoverClose asChild>
         <button
           type="button"
-          className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-sm text-foreground transition-colors hover:bg-background/70"
+          className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-sm text-foreground transition-colors hover:bg-gray-100 dark:hover:bg-gray-200"
           onClick={onOpenDownloadDialog}
         >
           <IconPlug


### PR DESCRIPTION
## Problem

In the chat composer's **Your computer** menu (Computer Use connector), the hovered row used `hover:bg-background/70` — white at 70% opacity. Because the section surface is `bg-gray-50`, the white overlay made the hovered row *lighter* than its surroundings instead of highlighting it, giving a washed-out, near-invisible hover.

## Fix

Both hover targets (the device row and the **Connect my computer** button) now use `hover:bg-gray-100 dark:hover:bg-gray-200` — one shade deeper than the section surface (`bg-gray-50 dark:bg-gray-100`) in each theme, so hover reads as a clear highlight.

File: `turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)