### PR TITLE
fix: render presentation detail thumbnails from html

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -2132,7 +2132,10 @@ describe("chat composer templates", () => {
       ),
     ).toHaveAttribute(
       "src",
-      r2ImageTransformUrl(prismCardPreview, { width: 480, height: 270 }),
+      r2ImageTransformUrl(template.previewImages[0]!, {
+        width: 480,
+        height: 270,
+      }),
     );
 
     await user.click(
@@ -2617,6 +2620,10 @@ describe("chat composer templates", () => {
       `${template.title} detail HTML preview`,
     );
     expect(detailPreviewFrame).toHaveAttribute("tabindex", "-1");
+    expect(detailPreviewFrame).toHaveAttribute(
+      "src",
+      expect.stringMatching(/^blob:/),
+    );
     expect(screen.queryByText("1 of 15")).not.toBeInTheDocument();
     const firstSlidePreviewButton =
       within(templateDialog).getByLabelText("Preview slide 1");
@@ -2638,13 +2645,7 @@ describe("chat composer templates", () => {
     fireEvent.keyDown(firstSlidePreviewButton, { key: "Tab" });
     expect(document.activeElement).toBe(secondSlidePreviewButton);
     expect(firstSlidePreviewButton.querySelector("iframe")).toBeNull();
-    expect(firstSlidePreviewButton.querySelector("img")).toHaveAttribute(
-      "src",
-      r2ImageTransformUrl(template.previewImages[0]!, {
-        width: 480,
-        height: 270,
-      }),
-    );
+    expect(firstSlidePreviewButton.querySelector("img")).toBeNull();
     expect(
       firstSlidePreviewButton.querySelector(
         `[aria-label="${template.title} slide 1 preview"]`,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -1990,7 +1990,7 @@ describe("chat composer templates", () => {
     }
   });
 
-  it("keeps the pending presentation card slide while the hover preview is loading", async () => {
+  it("scrubs presentation card slides by slide count after the hover preview loads", async () => {
     const template = PRESENTATION_TEMPLATE_PICKER_ITEMS.find((item) => {
       return item.slug === "bloom-pitch";
     });
@@ -2069,11 +2069,6 @@ describe("chat composer templates", () => {
     });
 
     try {
-      fireEvent.mouseEnter(preview);
-      await waitFor(() => {
-        expect(previewFetchCount).toBe(1);
-      });
-      fireEvent.mouseMove(preview, { clientX: 300, clientY: 80 });
       previewFetch.resolve(
         new Response(
           `<!doctype html><html><body>${Array.from(
@@ -2086,8 +2081,13 @@ describe("chat composer templates", () => {
           { headers: { "Content-Type": "text/html" } },
         ),
       );
+      fireEvent.mouseEnter(preview);
+      await waitFor(() => {
+        expect(previewFetchCount).toBe(1);
+      });
 
       await waitFor(async () => {
+        fireEvent.mouseMove(preview, { clientX: 300, clientY: 80 });
         await expect(
           htmlForFrame(
             screen.getByTestId(`${template.title} card HTML preview`),

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -1990,14 +1990,50 @@ describe("chat composer templates", () => {
     }
   });
 
-  it("keeps the presentation card image stable while the hover preview is loading", async () => {
+  it("keeps the pending presentation card slide while the hover preview is loading", async () => {
     const template = PRESENTATION_TEMPLATE_PICKER_ITEMS.find((item) => {
-      return item.previewImages.length > 1;
+      return item.slug === "bloom-pitch";
     });
     if (template === undefined) {
-      throw new Error("Presentation template with multiple slides not found");
+      throw new Error("Bloom pitch presentation template not found");
     }
+    const slideCount = template.slideCount;
+    if (slideCount === undefined) {
+      throw new Error("Bloom pitch presentation slide count not found");
+    }
+    expect(template.previewImages).toHaveLength(1);
+    expect(slideCount).toBe(15);
     const previewFetch = createDeferredPromise<Response>(AbortSignal.any([]));
+    const blobHtml: Promise<string>[] = [];
+    const originalCreateObjectURL = URL.createObjectURL;
+    const originalRevokeObjectURL = URL.revokeObjectURL;
+    const createObjectURL = vi.fn((blob: Blob) => {
+      blobHtml.push(blob.text());
+      return `blob:template-preview-late-${String(blobHtml.length)}`;
+    });
+    const htmlForFrame = (frame: HTMLElement): Promise<string> => {
+      const src = frame.getAttribute("src");
+      if (src === null) {
+        throw new Error("Preview frame src not set");
+      }
+      const match = /^blob:template-preview-late-(\d+)$/.exec(src);
+      if (match === null) {
+        throw new Error(`Unexpected preview frame src: ${src}`);
+      }
+      const html = blobHtml[Number(match[1]) - 1];
+      if (html === undefined) {
+        throw new Error(`Preview blob not found for ${src}`);
+      }
+      return html;
+    };
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: createObjectURL,
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: vi.fn(),
+    });
     let previewFetchCount = 0;
     context.mocks.http.get("*/__vm0-dev-artifact-fetch", () => {
       previewFetchCount += 1;
@@ -2019,10 +2055,6 @@ describe("chat composer templates", () => {
       }),
     );
     await fill(screen.getByLabelText("Search templates"), template.title);
-    const previewImage = screen.getByTestId(
-      `${template.title} card image preview`,
-    );
-    const initialPreviewSrc = previewImage.getAttribute("src");
     const preview = screen.getByLabelText(
       `Preview ${template.title} at current slide`,
     ).parentElement;
@@ -2042,24 +2074,45 @@ describe("chat composer templates", () => {
         expect(previewFetchCount).toBe(1);
       });
       fireEvent.mouseMove(preview, { clientX: 300, clientY: 80 });
-      const animationFrame = createDeferredPromise<void>(AbortSignal.any([]));
-      window.requestAnimationFrame(() => {
-        animationFrame.resolve();
-      });
-      try {
-        await animationFrame.promise;
-      } finally {
-        if (!animationFrame.settled()) {
-          animationFrame.reject(new Error("Animation frame cancelled"));
-        }
-      }
+      previewFetch.resolve(
+        new Response(
+          `<!doctype html><html><body>${Array.from(
+            { length: slideCount },
+            (_, index) => {
+              const slideNumber = index + 1;
+              return `<section data-vm0-slide data-slide-id="slide-${slideNumber}"><h1>Slide ${slideNumber}</h1></section>`;
+            },
+          ).join("")}</body></html>`,
+          { headers: { "Content-Type": "text/html" } },
+        ),
+      );
 
-      expect(
-        screen.getByTestId(`${template.title} card image preview`),
-      ).toHaveAttribute("src", initialPreviewSrc);
+      await waitFor(async () => {
+        await expect(
+          htmlForFrame(
+            screen.getByTestId(`${template.title} card HTML preview`),
+          ),
+        ).resolves.toContain("Slide 15");
+      });
     } finally {
       if (!previewFetch.settled()) {
         previewFetch.reject(new Error("Preview fetch intentionally cancelled"));
+      }
+      if (originalCreateObjectURL) {
+        Object.defineProperty(URL, "createObjectURL", {
+          configurable: true,
+          value: originalCreateObjectURL,
+        });
+      } else {
+        delete (URL as { createObjectURL?: unknown }).createObjectURL;
+      }
+      if (originalRevokeObjectURL) {
+        Object.defineProperty(URL, "revokeObjectURL", {
+          configurable: true,
+          value: originalRevokeObjectURL,
+        });
+      } else {
+        delete (URL as { revokeObjectURL?: unknown }).revokeObjectURL;
       }
     }
   });
@@ -2260,20 +2313,21 @@ describe("chat composer templates", () => {
 
   it("opens presentation template detail at the scrubbed card slide", async () => {
     const template = PRESENTATION_TEMPLATE_PICKER_ITEMS[0]!;
-    const lastSlideNumber = template.previewImages.length;
+    const lastSlideNumber = template.slideCount;
+    if (lastSlideNumber === undefined) {
+      throw new Error("Presentation template slide count not found");
+    }
     context.mocks.http.get("*/__vm0-dev-artifact-fetch", () => {
       return new Response(
         `
           <!doctype html>
           <html>
             <body>
-              ${template.previewImages
-                .map((_, index) => {
-                  return `<section data-vm0-slide data-slide-id="slide-${String(
-                    index + 1,
-                  )}"><h1>Slide ${String(index + 1)}</h1></section>`;
-                })
-                .join("")}
+              ${Array.from({ length: lastSlideNumber }, (_, index) => {
+                return `<section data-vm0-slide data-slide-id="slide-${String(
+                  index + 1,
+                )}"><h1>Slide ${String(index + 1)}</h1></section>`;
+              }).join("")}
             </body>
           </html>
         `,

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -1195,6 +1195,12 @@ function presentationTemplateSlideImages(
   return item.previewImages;
 }
 
+function presentationTemplateSlideCount(
+  item: PresentationTemplateItem,
+): number {
+  return Math.max(item.slideCount ?? item.previewImages.length, 1);
+}
+
 function presentationTemplateThemedCardPreviewSource(
   item: PresentationTemplateItem,
   theme: PresentationTemplateThemeOption | undefined,
@@ -2544,8 +2550,7 @@ function TemplatePreview({
   const setHtmlPreview = useSet(setTemplateCardHtmlPreview$);
   const loadedHtmlFrameUrls = useGet(templateCardLoadedHtmlFrameUrls$);
   const setLoadedHtmlFrameUrl = useSet(setTemplateCardLoadedHtmlFrameUrl$);
-  const slideImages = presentationTemplateSlideImages(item);
-  const fallbackSlideCount = Math.max(slideImages.length, 1);
+  const fallbackSlideCount = presentationTemplateSlideCount(item);
   const hoverSlideIndex = Math.max(
     0,
     Math.min(
@@ -2674,10 +2679,14 @@ function TemplatePreview({
 
         cache.drafts.set(item.embedUrl, result.value);
         if (cache.activeTokens.get(item.embedUrl) === activeToken) {
+          const nextIndex =
+            cache.pendingSlideIndexes.get(item.embedUrl) ??
+            cache.activeIndexes.get(item.embedUrl) ??
+            0;
           setHtmlPreview(
             createPresentationTemplateCardHtmlPreviewState({
               draft: result.value,
-              index: cache.activeIndexes.get(item.embedUrl) ?? 0,
+              index: nextIndex,
               item,
               previousFrameUrl: previousActiveFrameUrlForImmediateRevocation,
               theme: previewTheme,
@@ -2709,9 +2718,6 @@ function TemplatePreview({
 
   const handleMouseMove = (event: ReactMouseEvent<HTMLDivElement>) => {
     const cache = presentationTemplateHtmlPreviewCache();
-    if (!cache.drafts.has(item.embedUrl)) {
-      return;
-    }
     if (scrubSlideCount < 2) {
       return;
     }
@@ -2935,7 +2941,6 @@ function TemplatePreviewPage({
   onBack: () => void;
   onSelect: (item: PresentationTemplateItem, colorSystemId?: string) => void;
 }) {
-  const slideImages = presentationTemplateSlideImages(item);
   const detailPreview = useGet(templateDetailHtmlPreview$);
   const setDetailPreview = useSet(setTemplateDetailHtmlPreview$);
   const themeIdBySlug = useGet(templateDetailThemeIdBySlug$);
@@ -2954,7 +2959,7 @@ function TemplatePreviewPage({
     detailPreview.index === activeSlideIndex
       ? detailPreview
       : null;
-  const fallbackSlideCount = Math.max(slideImages.length, 1);
+  const fallbackSlideCount = presentationTemplateSlideCount(item);
   const detailSlideCount =
     visibleDetailPreview?.slideCount ?? fallbackSlideCount;
   const cachedDetailDraft = presentationTemplateHtmlPreviewCache().drafts.get(

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -2131,7 +2131,6 @@ function presentationTemplateThemeVariables(
 
 interface PresentationTemplateThumbnailCache {
   readonly htmlByHost: WeakMap<HTMLDivElement, string>;
-  readonly pendingRenderKeysByHost: WeakMap<HTMLDivElement, string>;
   readonly previewHtmlsByDraft: WeakMap<
     PresentationEditDraft,
     Map<string, string>
@@ -2153,7 +2152,6 @@ function presentationTemplateThumbnailCache(): PresentationTemplateThumbnailCach
 
   const cache: PresentationTemplateThumbnailCache = {
     htmlByHost: new WeakMap<HTMLDivElement, string>(),
-    pendingRenderKeysByHost: new WeakMap<HTMLDivElement, string>(),
     previewHtmlsByDraft: new WeakMap<
       PresentationEditDraft,
       Map<string, string>
@@ -2295,51 +2293,6 @@ function renderPresentationTemplateShadowThumbnail(
   applyPresentationTemplateThumbnailTheme(host, themeVariables);
 }
 
-function schedulePresentationTemplateShadowThumbnailRender({
-  draft,
-  host,
-  slideId,
-  themeVariables,
-}: {
-  readonly draft: PresentationEditDraft;
-  readonly host: HTMLDivElement;
-  readonly slideId: string;
-  readonly themeVariables: PresentationTemplateThemeVariables;
-}): void {
-  const cache = presentationTemplateThumbnailCache();
-  const render = () => {
-    renderPresentationTemplateShadowThumbnail(
-      host,
-      getPresentationTemplateThumbnailPreviewHtml(draft, slideId),
-      themeVariables,
-    );
-  };
-  if (cache.htmlByHost.has(host)) {
-    render();
-    return;
-  }
-
-  const renderKey = `${slideId}:${Object.values(themeVariables).join("|")}`;
-  cache.pendingRenderKeysByHost.set(host, renderKey);
-  const renderWhenCurrent = () => {
-    if (
-      !host.isConnected ||
-      cache.pendingRenderKeysByHost.get(host) !== renderKey
-    ) {
-      return;
-    }
-    cache.pendingRenderKeysByHost.delete(host);
-    render();
-  };
-
-  if (window.requestIdleCallback !== undefined) {
-    window.requestIdleCallback(renderWhenCurrent, { timeout: 250 });
-    return;
-  }
-
-  window.setTimeout(renderWhenCurrent, 0);
-}
-
 function PresentationTemplateShadowThumbnail({
   draft,
   fallbackImage,
@@ -2353,24 +2306,26 @@ function PresentationTemplateShadowThumbnail({
   readonly themeVariables: PresentationTemplateThemeVariables;
   readonly title: string;
 }) {
+  const hasHtmlThumbnail = draft !== undefined && slideId !== null;
   return (
     <>
-      <img
-        src={fallbackImage}
-        alt=""
-        loading="lazy"
-        className="absolute inset-0 h-full w-full object-cover"
-      />
-      {draft !== undefined && slideId !== null ? (
+      {hasHtmlThumbnail ? null : (
+        <img
+          src={fallbackImage}
+          alt=""
+          loading="lazy"
+          className="absolute inset-0 h-full w-full object-cover"
+        />
+      )}
+      {hasHtmlThumbnail ? (
         <div
           ref={(node) => {
             if (node !== null) {
-              schedulePresentationTemplateShadowThumbnailRender({
-                draft,
-                host: node,
-                slideId,
+              renderPresentationTemplateShadowThumbnail(
+                node,
+                getPresentationTemplateThumbnailPreviewHtml(draft, slideId),
                 themeVariables,
-              });
+              );
             }
           }}
           aria-label={title}
@@ -3007,10 +2962,9 @@ function TemplatePreviewPage({
   );
   const thumbnailThemeVariables =
     getPresentationTemplateThumbnailThemeVariables(selectedTheme);
-  const detailFallbackImage = presentationTemplateCardSlideImage(
+  const detailFallbackImage = presentationTemplateFallbackSlideImage(
     item,
     activeSlideIndex,
-    selectedTheme,
   );
 
   const setLoadedDetailPreview = (params: {
@@ -4397,11 +4351,25 @@ function TemplatePickerDialog({
   };
 
   const handlePreview = (item: PresentationTemplateItem, slideIndex = 0) => {
-    setDetailThemeId(
-      item.slug,
+    const selectedTheme = findPresentationTemplateTheme(
       cardThemeIdBySlug[item.slug] ?? defaultPresentationTemplateThemeId(item),
     );
-    setDetailSlideIndex(item.slug, Math.max(0, Math.floor(slideIndex)));
+    const selectedSlideIndex = Math.max(0, Math.floor(slideIndex));
+    setDetailThemeId(item.slug, selectedTheme.id);
+    setDetailSlideIndex(item.slug, selectedSlideIndex);
+    const cachedDraft = presentationTemplateHtmlPreviewCache().drafts.get(
+      item.embedUrl,
+    );
+    if (cachedDraft !== undefined) {
+      setLoadedPresentationTemplateDetailPreview({
+        draft: cachedDraft,
+        index: selectedSlideIndex,
+        item,
+        previousFrameUrl: detailPreview?.frameUrl ?? null,
+        selectedTheme,
+        setDetailPreview,
+      });
+    }
     setPreviewSlug(item.slug);
   };
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -2679,14 +2679,10 @@ function TemplatePreview({
 
         cache.drafts.set(item.embedUrl, result.value);
         if (cache.activeTokens.get(item.embedUrl) === activeToken) {
-          const nextIndex =
-            cache.pendingSlideIndexes.get(item.embedUrl) ??
-            cache.activeIndexes.get(item.embedUrl) ??
-            0;
           setHtmlPreview(
             createPresentationTemplateCardHtmlPreviewState({
               draft: result.value,
-              index: nextIndex,
+              index: cache.activeIndexes.get(item.embedUrl) ?? 0,
               item,
               previousFrameUrl: previousActiveFrameUrlForImmediateRevocation,
               theme: previewTheme,
@@ -2718,6 +2714,9 @@ function TemplatePreview({
 
   const handleMouseMove = (event: ReactMouseEvent<HTMLDivElement>) => {
     const cache = presentationTemplateHtmlPreviewCache();
+    if (!cache.drafts.has(item.embedUrl)) {
+      return;
+    }
     if (scrubSlideCount < 2) {
       return;
     }

--- a/turbo/packages/core/src/__tests__/presentation-template-items.spec.ts
+++ b/turbo/packages/core/src/__tests__/presentation-template-items.spec.ts
@@ -433,6 +433,12 @@ describe("presentation template items", () => {
     }
   });
 
+  it("defines slide counts for picker presentation scrub previews", () => {
+    for (const item of PRESENTATION_TEMPLATE_PICKER_ITEMS) {
+      expect(item.slideCount, item.slug).toBe(15);
+    }
+  });
+
   it("resolve every design system and template against the resource registry", () => {
     for (const item of allPresentationItems) {
       const designSystem = findDesignSystem(item.designSystemId);
@@ -542,6 +548,7 @@ describe("presentation template items", () => {
     expect(item.designSystemId).toBe("design-system:playful-editorial");
     expect(item.templateId).toBe("template:html-ppt-playful-launch");
     expectColorSystem(item.colorSystemId, "color-system:carnival");
+    expect(item.slideCount).toBe(15);
     expect(item.previewImages.length).toBe(15);
     expect(item.previewImage).toBe(item.previewImages[0]);
     expect(item.embedUrl).toMatch(
@@ -576,6 +583,7 @@ describe("presentation template items", () => {
     expect(item.designSystemId).toBe("design-system:business-data");
     expect(item.templateId).toBe("template:html-ppt-business-data");
     expectColorSystem(item.colorSystemId, "color-system:berry-pop");
+    expect(item.slideCount).toBe(15);
     expect(item.previewImages.length).toBe(15);
     expect(item.embedUrl).toMatch(
       /^https:\/\/cdn\.vm0\.io\/artifacts\/.+\/business-data-presentation\.html$/,
@@ -607,6 +615,7 @@ describe("presentation template items", () => {
       expect(item.designSystemId).toBe(expected.designSystemId);
       expect(item.templateId).toBe(expected.templateId);
       expectColorSystem(item.colorSystemId, expected.colorSystemId);
+      expect(item.slideCount).toBe(15);
       expect(item.previewImages.length).toBe(15);
       expect(item.previewImage).toBe(item.previewImages[0]);
       expect(item.embedUrl).toMatch(
@@ -635,6 +644,7 @@ describe("presentation template items", () => {
       expect(item.designSystemId).toBe(expected.designSystemId);
       expect(item.templateId).toBe(expected.templateId);
       expectColorSystem(item.colorSystemId, expected.colorSystemId);
+      expect(item.slideCount).toBe(15);
       expect(item.previewImages.length).toBe(1);
       expect(item.previewImage).toBe(item.previewImages[0]);
       expect(item.previewHtmls).toBeUndefined();

--- a/turbo/packages/core/src/presentation-template-items.ts
+++ b/turbo/packages/core/src/presentation-template-items.ts
@@ -5,6 +5,7 @@ export interface PresentationTemplateItem {
   readonly embedUrl: string;
   readonly previewImage: string;
   readonly previewImages: readonly string[];
+  readonly slideCount?: number;
   readonly cardPreviewImage?: string;
   readonly cardPreviewImagesByTheme?: Readonly<Record<string, string>>;
   readonly previewHtmls?: readonly string[];
@@ -3134,6 +3135,7 @@ export const PRESENTATION_TEMPLATE_PICKER_ITEMS: readonly PresentationTemplateIt
           "playful-launch-presentation"
         ]["carnival"],
       previewImages: PLAYFUL_LAUNCH_CDN_PREVIEW_IMAGES,
+      slideCount: 15,
       colorSystemId: "color-system:carnival",
       designSystemId: "design-system:playful-editorial",
       templateId: "template:html-ppt-playful-launch",
@@ -3153,6 +3155,7 @@ export const PRESENTATION_TEMPLATE_PICKER_ITEMS: readonly PresentationTemplateIt
           "mauve-dusk"
         ],
       previewImages: BOTANE_ORGANIC_PREVIEW_IMAGES,
+      slideCount: 15,
       colorSystemId: "color-system:mauve-dusk",
       designSystemId: "design-system:botane-organic",
       templateId: "template:html-ppt-botane-organic",
@@ -3174,6 +3177,7 @@ export const PRESENTATION_TEMPLATE_PICKER_ITEMS: readonly PresentationTemplateIt
           "business-data-presentation"
         ]["berry-pop"],
       previewImages: BUSINESS_DATA_CDN_PREVIEW_IMAGES,
+      slideCount: 15,
       colorSystemId: "color-system:berry-pop",
       designSystemId: "design-system:business-data",
       templateId: "template:html-ppt-business-data",
@@ -3195,6 +3199,7 @@ export const PRESENTATION_TEMPLATE_PICKER_ITEMS: readonly PresentationTemplateIt
           "crayon-learning-deck"
         ]["prism"],
       previewImages: CRAYON_PREVIEW_IMAGES,
+      slideCount: 15,
       previewHtmls: CRAYON_PREVIEW_HTMLS,
       colorSystemId: "color-system:prism",
       designSystemId: "design-system:crayon",
@@ -3217,6 +3222,7 @@ export const PRESENTATION_TEMPLATE_PICKER_ITEMS: readonly PresentationTemplateIt
           "creative-agency-presentation"
         ]["coral-studio"],
       previewImages: CREATIVE_AGENCY_PREVIEW_IMAGES,
+      slideCount: 15,
       previewHtmls: CREATIVE_AGENCY_PREVIEW_HTMLS,
       colorSystemId: "color-system:coral-studio",
       designSystemId: "design-system:creative-agency",
@@ -3239,6 +3245,7 @@ export const PRESENTATION_TEMPLATE_PICKER_ITEMS: readonly PresentationTemplateIt
           "data-report-presentation"
         ]["prism"],
       previewImages: DATA_REPORT_PREVIEW_IMAGES,
+      slideCount: 15,
       previewHtmls: DATA_REPORT_PREVIEW_HTMLS,
       colorSystemId: "color-system:prism",
       designSystemId: "design-system:data-report",
@@ -3261,6 +3268,7 @@ export const PRESENTATION_TEMPLATE_PICKER_ITEMS: readonly PresentationTemplateIt
           "editorial-magazine-deck"
         ]["warm-sand"],
       previewImages: EDITORIAL_MAGAZINE_PREVIEW_IMAGES,
+      slideCount: 15,
       previewHtmls: EDITORIAL_MAGAZINE_PREVIEW_HTMLS,
       colorSystemId: "color-system:warm-sand",
       designSystemId: "design-system:editorial-magazine",
@@ -3283,6 +3291,7 @@ export const PRESENTATION_TEMPLATE_PICKER_ITEMS: readonly PresentationTemplateIt
           "landing-consulting-deck"
         ]["pop-art"],
       previewImages: LANDING_CONSULTING_PREVIEW_IMAGES,
+      slideCount: 15,
       previewHtmls: LANDING_CONSULTING_PREVIEW_HTMLS,
       colorSystemId: "color-system:pop-art",
       designSystemId: "design-system:landing-consulting",
@@ -3305,6 +3314,7 @@ export const PRESENTATION_TEMPLATE_PICKER_ITEMS: readonly PresentationTemplateIt
           "lumina-creative-studio"
         ]["prism"],
       previewImages: LUMINA_PREVIEW_IMAGES,
+      slideCount: 15,
       previewHtmls: LUMINA_PREVIEW_HTMLS,
       colorSystemId: "color-system:prism",
       designSystemId: "design-system:lumina",
@@ -3327,6 +3337,7 @@ export const PRESENTATION_TEMPLATE_PICKER_ITEMS: readonly PresentationTemplateIt
           "mosaic-geometric-pitch"
         ]["carnival"],
       previewImages: MOSAIC_GEOMETRIC_PREVIEW_IMAGES,
+      slideCount: 15,
       previewHtmls: MOSAIC_GEOMETRIC_PREVIEW_HTMLS,
       colorSystemId: "color-system:carnival",
       designSystemId: "design-system:mosaic-geometric",
@@ -3347,6 +3358,7 @@ export const PRESENTATION_TEMPLATE_PICKER_ITEMS: readonly PresentationTemplateIt
           "pop-art"
         ],
       previewImages: PLAYFUL_POP_PREVIEW_IMAGES,
+      slideCount: 15,
       previewHtmls: PLAYFUL_POP_PREVIEW_HTMLS,
       colorSystemId: "color-system:pop-art",
       designSystemId: "design-system:playful-pop",
@@ -3370,6 +3382,7 @@ export const PRESENTATION_TEMPLATE_PICKER_ITEMS: readonly PresentationTemplateIt
         ],
       previewImages:
         PRESENTATION_TEMPLATE_REFERENCE_PREVIEW_IMAGES["bloom-pitch"],
+      slideCount: 15,
       colorSystemId: "color-system:carnival",
       designSystemId: "design-system:bloom-pitch",
       templateId: "template:html-ppt-bloom-pitch",
@@ -3391,6 +3404,7 @@ export const PRESENTATION_TEMPLATE_PICKER_ITEMS: readonly PresentationTemplateIt
         ],
       previewImages:
         PRESENTATION_TEMPLATE_REFERENCE_PREVIEW_IMAGES["blueprint-academy"],
+      slideCount: 15,
       colorSystemId: "color-system:forest-editorial",
       designSystemId: "design-system:blueprint-academy",
       templateId: "template:html-ppt-blueprint-academy",
@@ -3411,6 +3425,7 @@ export const PRESENTATION_TEMPLATE_PICKER_ITEMS: readonly PresentationTemplateIt
           "slate-corporate"
         ],
       previewImages: PRESENTATION_TEMPLATE_REFERENCE_PREVIEW_IMAGES["meridian"],
+      slideCount: 15,
       colorSystemId: "color-system:slate-corporate",
       designSystemId: "design-system:meridian",
       templateId: "template:html-ppt-meridian",
@@ -3432,6 +3447,7 @@ export const PRESENTATION_TEMPLATE_PICKER_ITEMS: readonly PresentationTemplateIt
         ],
       previewImages:
         PRESENTATION_TEMPLATE_REFERENCE_PREVIEW_IMAGES["neo-brutalism"],
+      slideCount: 15,
       colorSystemId: "color-system:mono-ink",
       designSystemId: "design-system:neo-brutalism",
       templateId: "template:html-ppt-neo-brutalism",
@@ -3452,6 +3468,7 @@ export const PRESENTATION_TEMPLATE_PICKER_ITEMS: readonly PresentationTemplateIt
           "midnight-mono"
         ],
       previewImages: PRESENTATION_TEMPLATE_REFERENCE_PREVIEW_IMAGES["nocturne"],
+      slideCount: 15,
       colorSystemId: "color-system:midnight-mono",
       designSystemId: "design-system:nocturne",
       templateId: "template:html-ppt-nocturne",
@@ -3473,6 +3490,7 @@ export const PRESENTATION_TEMPLATE_PICKER_ITEMS: readonly PresentationTemplateIt
         ],
       previewImages:
         PRESENTATION_TEMPLATE_REFERENCE_PREVIEW_IMAGES["pixel-glitch"],
+      slideCount: 15,
       colorSystemId: "color-system:bauhaus-primary",
       designSystemId: "design-system:pixel-glitch",
       templateId: "template:html-ppt-pixel-glitch",
@@ -3494,6 +3512,7 @@ export const PRESENTATION_TEMPLATE_PICKER_ITEMS: readonly PresentationTemplateIt
         ],
       previewImages:
         PRESENTATION_TEMPLATE_REFERENCE_PREVIEW_IMAGES["prospectus"],
+      slideCount: 15,
       colorSystemId: "color-system:slate-corporate",
       designSystemId: "design-system:prospectus",
       templateId: "template:html-ppt-prospectus",
@@ -3515,6 +3534,7 @@ export const PRESENTATION_TEMPLATE_PICKER_ITEMS: readonly PresentationTemplateIt
         ],
       previewImages:
         PRESENTATION_TEMPLATE_REFERENCE_PREVIEW_IMAGES["schoolhouse"],
+      slideCount: 15,
       colorSystemId: "color-system:bauhaus-primary",
       designSystemId: "design-system:schoolhouse",
       templateId: "template:html-ppt-schoolhouse",
@@ -3536,6 +3556,7 @@ export const PRESENTATION_TEMPLATE_PICKER_ITEMS: readonly PresentationTemplateIt
         ],
       previewImages:
         PRESENTATION_TEMPLATE_REFERENCE_PREVIEW_IMAGES["sticker-scrapbook"],
+      slideCount: 15,
       colorSystemId: "color-system:prism",
       designSystemId: "design-system:sticker-scrapbook",
       templateId: "template:html-ppt-sticker-scrapbook",
@@ -3553,6 +3574,7 @@ export const PRESENTATION_TEMPLATE_PICKER_ITEMS: readonly PresentationTemplateIt
       cardPreviewImage:
         PRESENTATION_TEMPLATE_PICKER_CARD_PREVIEW_IMAGES["strata"]["mono-ink"],
       previewImages: PRESENTATION_TEMPLATE_REFERENCE_PREVIEW_IMAGES["strata"],
+      slideCount: 15,
       colorSystemId: "color-system:mono-ink",
       designSystemId: "design-system:strata",
       templateId: "template:html-ppt-strata",
@@ -3574,6 +3596,7 @@ export const PRESENTATION_TEMPLATE_PICKER_ITEMS: readonly PresentationTemplateIt
         ],
       previewImages:
         PRESENTATION_TEMPLATE_REFERENCE_PREVIEW_IMAGES["taped-consulting"],
+      slideCount: 15,
       colorSystemId: "color-system:slate-corporate",
       designSystemId: "design-system:taped-consulting",
       templateId: "template:html-ppt-taped-consulting",
@@ -3594,6 +3617,7 @@ export const PRESENTATION_TEMPLATE_PICKER_ITEMS: readonly PresentationTemplateIt
           "slate-corporate"
         ],
       previewImages: PRESENTATION_TEMPLATE_REFERENCE_PREVIEW_IMAGES["vantage"],
+      slideCount: 15,
       colorSystemId: "color-system:slate-corporate",
       designSystemId: "design-system:vantage",
       templateId: "template:html-ppt-vantage",


### PR DESCRIPTION
## Summary

- Stop applying the first-level card preview slide0 image fallback inside the second-level presentation template detail preview.
- Render detail thumbnails from the cached HTML preview synchronously when a draft is available, so the bottom thumbnails do not flash from fallback images to HTML thumbnails.
- Keep the first-level card hover optimization intact: card hover still uses a static image for slide0 instead of an iframe/blob.

## Validation

- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
