### PR TITLE
feat(web): add video gallery page

### DIFF
--- a/turbo/apps/web/__tests__/proxy.public-routes.test.ts
+++ b/turbo/apps/web/__tests__/proxy.public-routes.test.ts
@@ -272,6 +272,22 @@ describe("proxy middleware: public routes", () => {
     expect(clerkState.protectedPaths).toEqual([]);
   });
 
+  it("keeps locale-prefixed video gallery public", async () => {
+    const request = new NextRequest("https://www.vm0.ai/en/video");
+
+    await middleware(request, createMockEvent());
+
+    expect(clerkState.protectedPaths).toEqual([]);
+  });
+
+  it("keeps locale-less video gallery public", async () => {
+    const request = new NextRequest("https://www.vm0.ai/video");
+
+    await middleware(request, createMockEvent());
+
+    expect(clerkState.protectedPaths).toEqual([]);
+  });
+
   it("keeps locale-prefixed report gallery public", async () => {
     const request = new NextRequest("https://www.vm0.ai/en/report");
 

--- a/turbo/apps/web/__tests__/so-frontend-rewrites.test.ts
+++ b/turbo/apps/web/__tests__/so-frontend-rewrites.test.ts
@@ -37,6 +37,10 @@ describe("so frontend rewrites", () => {
       destination: "https://pr-123-so.vm6.ai/en/report",
     });
     expect(rewrites).toContainEqual({
+      source: "/video",
+      destination: "https://pr-123-so.vm6.ai/video",
+    });
+    expect(rewrites).toContainEqual({
       source: "/docs",
       destination: "https://pr-123-so.vm6.ai/en/docs",
     });
@@ -94,6 +98,8 @@ describe("so frontend rewrites", () => {
   it("matches configured so frontend rewrite paths", () => {
     expect(matchesSoFrontendRewritePath("/pricing")).toBe(true);
     expect(matchesSoFrontendRewritePath("/en/pricing")).toBe(true);
+    expect(matchesSoFrontendRewritePath("/video")).toBe(true);
+    expect(matchesSoFrontendRewritePath("/en/video")).toBe(true);
     expect(matchesSoFrontendRewritePath("/en/blog/posts/example")).toBe(true);
     expect(matchesSoFrontendRewritePath("/docs/getting-started")).toBe(true);
     expect(matchesSoFrontendRewritePath("/assets/vm0-logo.svg")).toBe(true);
@@ -114,6 +120,7 @@ describe("so frontend rewrites", () => {
   it("resolves the matching so frontend destination path", () => {
     expect(resolveSoFrontendRewritePath("/")).toBe("/en");
     expect(resolveSoFrontendRewritePath("/report")).toBe("/en/report");
+    expect(resolveSoFrontendRewritePath("/video")).toBe("/video");
     expect(resolveSoFrontendRewritePath("/docs/reference/api")).toBe(
       "/en/docs/reference/api",
     );

--- a/turbo/apps/web/app/[locale]/video/VideoClient.tsx
+++ b/turbo/apps/web/app/[locale]/video/VideoClient.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import Image from "next/image";
+import { IconPlayerPlay, IconSparkles } from "@tabler/icons-react";
+import { CopyablePrompt } from "../../components/CopyablePrompt";
+import { Footer } from "../../components/Footer";
+import { Particles } from "../../components/Particles";
+import { getAppUrl } from "../../../src/lib/zero/url";
+import { VIDEO_ITEMS, buildVideoRemixHref, type VideoItem } from "./data";
+
+const MAX_WIDTH = 880;
+const PAGE_PADDING = 24;
+
+function VideoPreview({ item }: { item: VideoItem }) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+
+  const playPreview = useCallback(() => {
+    const video = videoRef.current;
+    if (!video) {
+      return;
+    }
+
+    video.muted = true;
+    video.playsInline = true;
+    setIsPlaying(true);
+    void video.play().catch(() => {
+      setIsPlaying(false);
+    });
+  }, []);
+
+  const resetPreview = useCallback(() => {
+    const video = videoRef.current;
+    if (!video) {
+      return;
+    }
+
+    video.pause();
+    video.currentTime = 0;
+    setIsPlaying(false);
+  }, []);
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      aria-label={`Play ${item.title} preview`}
+      className="group relative aspect-video w-full cursor-pointer overflow-hidden bg-[hsl(var(--gray-1))]"
+      onClick={playPreview}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          playPreview();
+        }
+      }}
+      onMouseEnter={playPreview}
+      onMouseLeave={resetPreview}
+      onPointerEnter={playPreview}
+      onPointerLeave={resetPreview}
+      onTouchStart={playPreview}
+    >
+      <Image
+        src={item.previewImage}
+        alt={item.title}
+        fill
+        sizes="(min-width: 880px) 832px, calc(100vw - 48px)"
+        className="pointer-events-none object-cover"
+      />
+      <video
+        ref={videoRef}
+        className={`pointer-events-none absolute inset-0 h-full w-full bg-black object-contain transition-opacity duration-300 ${
+          isPlaying ? "opacity-100" : "opacity-0"
+        }`}
+        poster={item.previewImage}
+        muted
+        loop
+        playsInline
+        preload="auto"
+        src={item.previewVideo}
+      />
+      <div
+        className={`pointer-events-none absolute inset-0 flex items-center justify-center transition-opacity duration-200 ${
+          isPlaying ? "opacity-0" : "opacity-100"
+        }`}
+      >
+        <div className="inline-flex size-14 items-center justify-center rounded-full bg-white/90 text-[hsl(var(--foreground))] shadow-[0_10px_30px_rgba(0,0,0,0.24)] backdrop-blur-sm">
+          <IconPlayerPlay size={24} stroke={2} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function VideoCard({
+  item,
+  appUrl,
+  landingSearch,
+}: {
+  item: VideoItem;
+  appUrl: string;
+  landingSearch: string;
+}) {
+  const remixHref = buildVideoRemixHref(item, appUrl, landingSearch);
+
+  return (
+    <article
+      id={item.slug}
+      className="overflow-hidden rounded-[14px] bg-white shadow-[0_1px_2px_rgba(0,0,0,0.06)]"
+    >
+      <VideoPreview item={item} />
+      <div className="flex flex-col gap-3 px-4 py-3">
+        <div className="flex flex-col gap-1">
+          <h2 className="text-[17px] font-semibold leading-tight text-[hsl(var(--foreground))]">
+            {item.title}
+          </h2>
+          <p className="text-sm leading-6 text-[hsl(var(--muted-foreground))]">
+            {item.description}
+          </p>
+        </div>
+        <CopyablePrompt prompt={item.prompt} />
+        <a
+          href={remixHref}
+          className="inline-flex h-9 shrink-0 items-center justify-center gap-1.5 rounded-[8px] bg-[#ed4e01] px-3.5 text-sm font-medium text-white transition-colors hover:bg-[#d94600]"
+        >
+          <IconSparkles size={15} stroke={2} />
+          Try it
+        </a>
+      </div>
+    </article>
+  );
+}
+
+export function VideoClient() {
+  const appUrl = getAppUrl();
+  const [landingSearch, setLandingSearch] = useState("");
+
+  useEffect(() => {
+    setLandingSearch(window.location.search);
+  }, []);
+
+  return (
+    <div className="landing-page min-h-screen bg-[hsl(var(--gray-0))] text-[hsl(var(--foreground))]">
+      <Particles />
+
+      <section className="hero-section" style={{ paddingBottom: 32 }}>
+        <div
+          style={{
+            maxWidth: MAX_WIDTH,
+            margin: "0 auto",
+            padding: `0 ${PAGE_PADDING}px`,
+          }}
+        >
+          <h1 className="hero-title">Video</h1>
+          <p className="hero-description">
+            Generate short videos from templates. Pick a style, remix the
+            prompt, and let VM0 handle the motion, pacing, and polish.
+          </p>
+        </div>
+      </section>
+
+      <section style={{ paddingBottom: 120 }}>
+        <div
+          style={{
+            maxWidth: MAX_WIDTH,
+            margin: "0 auto",
+            padding: `0 ${PAGE_PADDING}px`,
+          }}
+          className="flex flex-col items-stretch gap-6"
+        >
+          {VIDEO_ITEMS.map((item) => {
+            return (
+              <VideoCard
+                key={item.slug}
+                item={item}
+                appUrl={appUrl}
+                landingSearch={landingSearch}
+              />
+            );
+          })}
+        </div>
+      </section>
+
+      <Footer />
+    </div>
+  );
+}

--- a/turbo/apps/web/app/[locale]/video/__tests__/data.test.ts
+++ b/turbo/apps/web/app/[locale]/video/__tests__/data.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { reloadEnv } from "../../../../src/env";
+import { buildVideoRemixHref, type VideoItem } from "../data";
+
+const item: VideoItem = {
+  id: "video-template:test",
+  slug: "test-video",
+  title: "Test video",
+  description: "Test video description",
+  prompt: "/gen video",
+  previewImage: "https://example.com/preview.jpg",
+  cardPreviewImage: "https://example.com/card.jpg",
+  previewVideo: "https://example.com/preview.mp4",
+  previewWebm: "https://example.com/preview.webm",
+  sourcePath: "video-template/test",
+};
+
+describe("video remix links", () => {
+  it("marks video try-it links with source attribution", () => {
+    const href = buildVideoRemixHref(item, "https://app.vm0.ai");
+    const url = new URL(href);
+
+    expect(url.origin).toBe("https://so.vm0.ai");
+    expect(url.pathname).toBe("/onboarding/2afcf6");
+    expect(url.searchParams.get("prompt")).toBe(item.prompt);
+    expect(url.searchParams.get("showcase")).toBe(item.previewVideo);
+    expect(url.searchParams.get("vm0_source")).toBe("video");
+  });
+
+  it("uses the configured paid onboarding origin", () => {
+    vi.stubEnv("NEXT_PUBLIC_PAID_ONBOARDING_URL", "https://staging-so.vm6.ai/");
+    reloadEnv();
+
+    const href = buildVideoRemixHref(item, "https://app.vm0.ai");
+
+    expect(new URL(href).origin).toBe("https://staging-so.vm6.ai");
+  });
+
+  it("carries paid search attribution to onboarding", () => {
+    const href = buildVideoRemixHref(
+      item,
+      "https://app.vm0.ai",
+      "?gclid=test-click&utm_source=google&utm_medium=cpc&utm_campaign=video_search_en&utm_content=hero&vm0_experiment=video_lp&vm0_variant=a&unused=value",
+    );
+    const params = new URL(href).searchParams;
+
+    expect(params.get("gclid")).toBe("test-click");
+    expect(params.get("utm_source")).toBe("google");
+    expect(params.get("utm_medium")).toBe("cpc");
+    expect(params.get("utm_campaign")).toBe("video_search_en");
+    expect(params.get("utm_content")).toBe("hero");
+    expect(params.get("vm0_experiment")).toBe("video_lp");
+    expect(params.get("vm0_variant")).toBe("a");
+    expect(params.get("unused")).toBeNull();
+  });
+});

--- a/turbo/apps/web/app/[locale]/video/data.ts
+++ b/turbo/apps/web/app/[locale]/video/data.ts
@@ -1,0 +1,86 @@
+import { VIDEO_TEMPLATE_ITEMS, type VideoTemplateItem } from "@vm0/core";
+import { buildVm0OnboardingEntryUrl } from "../../../src/lib/zero/onboardingEntryUrl";
+
+export interface VideoItem extends VideoTemplateItem {
+  readonly prompt: string;
+}
+
+const VIDEO_ATTRIBUTION_PARAM = "vm0_source";
+const VIDEO_ATTRIBUTION_VALUE = "video";
+
+const AD_ATTRIBUTION_PARAMS = [
+  "gclid",
+  "gbraid",
+  "wbraid",
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_content",
+  "utm_term",
+  "vm0_experiment",
+  "vm0_variant",
+  "lp_variant",
+] as const;
+
+const VIDEO_PROMPTS: Readonly<Record<string, string>> = {
+  "epic-grandeur":
+    "/gen video with video template `epic-grandeur`, create a 12-second cinematic launch teaser for Aster Ridge, a mountain observatory opening at sunrise. Use sweeping aerial scale, golden backlight, slow camera movement, and a final title card.",
+  "gourmet-documentary":
+    "/gen video with video template `gourmet-documentary`, create a 12-second documentary spot for Hearth & Grain, an artisan bakery introducing its morning sourdough ritual. Focus on macro crust texture, steam, warm backlight, and hands at work.",
+  "luxury-product":
+    "/gen video with video template `luxury-product`, create a 10-second product reveal for a black ceramic chronograph watch. Use a dark studio, pinpoint highlights, premium material detail, slow macro movement, and a refined final lockup.",
+  "shortform-viral":
+    "/gen video with video template `shortform-viral`, create a 9:16 creator-style teaser for a desk setup upgrade. Start with a fast visual hook, use handheld energy, bright color, quick cuts, and end with a simple call to action.",
+  "fashion-editorial":
+    "/gen video with video template `fashion-editorial`, create a 12-second editorial film for a winter capsule collection in a concrete gallery. Use cold desaturated color, strong silhouettes, luxury fabric texture, and deliberate pose changes.",
+  "sports-performance-ad":
+    "/gen video with video template `sports-performance-ad`, create a 12-second performance ad for a carbon-plate running shoe. Show athlete effort, gear close-ups, impact rhythm, dramatic rim light, and a confident product end frame.",
+  "japanese-wabi-sabi":
+    "/gen video with video template `japanese-wabi-sabi`, create a 12-second quiet lifestyle film for a ceramic tea set in a morning kitchen. Use warm soft light, natural imperfection, negative space, and slow, calm motion.",
+  "hand-drawn-fantasy-anime":
+    "/gen video with video template `hand-drawn-fantasy-anime`, create a 12-second fantasy animation moment where a young mapmaker discovers a floating lantern forest. Use painterly 2D backgrounds, expressive character motion, and gentle wonder.",
+  "cyberpunk-anime":
+    "/gen video with video template `cyberpunk-anime`, create a 12-second 2D anime scene of a courier crossing a neon megacity at night. Use rain-slick streets, cel shading, glowing signage, and a melancholic final beat.",
+  "chinese-ink-art":
+    "/gen video with video template `chinese-ink-art`, create a 12-second ink-wash scene of cranes crossing misty mountains at dawn. Use monochrome brush texture, white space, drifting mist, and a calm classical-poetry mood.",
+};
+
+export const VIDEO_ITEMS: readonly VideoItem[] = VIDEO_TEMPLATE_ITEMS.map(
+  (item) => {
+    return {
+      ...item,
+      prompt: videoPrompt(item),
+    };
+  },
+);
+
+function videoPrompt(item: VideoTemplateItem): string {
+  const prompt = VIDEO_PROMPTS[item.slug];
+  if (!prompt) {
+    throw new Error(`Missing video prompt: ${item.slug}`);
+  }
+
+  return prompt;
+}
+
+export function buildVideoRemixHref(
+  item: VideoItem,
+  appUrl: string,
+  landingSearch = "",
+): string {
+  void appUrl;
+
+  const params = new URLSearchParams();
+  params.set("prompt", item.prompt);
+  params.set("showcase", item.previewVideo);
+  params.set(VIDEO_ATTRIBUTION_PARAM, VIDEO_ATTRIBUTION_VALUE);
+
+  const landingParams = new URLSearchParams(landingSearch);
+  for (const param of AD_ATTRIBUTION_PARAMS) {
+    for (const value of landingParams.getAll(param)) {
+      params.append(param, value);
+    }
+  }
+
+  return buildVm0OnboardingEntryUrl(params);
+}

--- a/turbo/apps/web/app/[locale]/video/page.tsx
+++ b/turbo/apps/web/app/[locale]/video/page.tsx
@@ -1,0 +1,79 @@
+import { webStaticAssetUrl } from "../../lib/static-assets";
+import type { Metadata } from "next";
+import type { Locale } from "../../../i18n";
+import { buildLocaleAlternates } from "../../lib/seo/alternates";
+import { VideoClient } from "./VideoClient";
+import { VIDEO_ITEMS } from "./data";
+
+const BASE_URL = "https://www.vm0.ai";
+
+interface PageProps {
+  params: Promise<{ locale: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const { locale } = await params;
+  const url = `${BASE_URL}/${locale}/video`;
+
+  return {
+    title: "Video Gallery - Remix Zero Prompts",
+    description:
+      "A gallery of video template examples for remixing Zero generation.",
+    alternates: buildLocaleAlternates("/video", locale as Locale),
+    robots: {
+      index: false,
+      follow: false,
+    },
+    openGraph: {
+      title: "VM0 Video Gallery",
+      description: "Video template examples for remixing Zero generation.",
+      url,
+      type: "website",
+      images: [
+        {
+          url: webStaticAssetUrl("og-image.png"),
+          width: 1200,
+          height: 630,
+          alt: "VM0 Video Gallery",
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: "VM0 Video Gallery",
+      description: "Video template examples for remixing Zero generation.",
+      images: [webStaticAssetUrl("og-image.png")],
+      creator: "@vm0_ai",
+      site: "@vm0_ai",
+    },
+  };
+}
+
+export default async function VideoGalleryPage({ params }: PageProps) {
+  const { locale } = await params;
+  const itemListJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: "VM0 Video Gallery",
+    description: "Video template examples for remixing Zero generation.",
+    itemListElement: VIDEO_ITEMS.map((item, i) => {
+      return {
+        "@type": "ListItem",
+        position: i + 1,
+        url: `${BASE_URL}/${locale}/video#${item.slug}`,
+        name: item.title,
+      };
+    }),
+  };
+
+  return (
+    <>
+      <script type="application/ld+json" suppressHydrationWarning>
+        {JSON.stringify(itemListJsonLd)}
+      </script>
+      <VideoClient />
+    </>
+  );
+}

--- a/turbo/apps/web/proxy.ts
+++ b/turbo/apps/web/proxy.ts
@@ -47,6 +47,8 @@ const isPublicRoute = createRouteMatcher([
   "/:locale/web-design",
   "/presentation",
   "/:locale/presentation",
+  "/video",
+  "/:locale/video",
   "/report",
   "/:locale/report",
   "/sprite",

--- a/turbo/apps/web/so-frontend-rewrites.js
+++ b/turbo/apps/web/so-frontend-rewrites.js
@@ -8,6 +8,7 @@ const SO_FRONTEND_EXACT_PATHS = [
   "/illustration",
   "/web-design",
   "/presentation",
+  "/video",
   "/report",
   "/sprite",
   "/terms-of-use",

--- a/turbo/apps/web/src/lib/zero/onboardingEntryUrl.ts
+++ b/turbo/apps/web/src/lib/zero/onboardingEntryUrl.ts
@@ -1,0 +1,22 @@
+import { env } from "../../env";
+
+const VM0_ONBOARDING_PATH = "/onboarding/2afcf6";
+const DEFAULT_PAID_ONBOARDING_URL = "https://so.vm0.ai";
+
+function paidOnboardingBaseUrl(): string {
+  return (
+    env().NEXT_PUBLIC_PAID_ONBOARDING_URL || DEFAULT_PAID_ONBOARDING_URL
+  ).replace(/\/+$/u, "");
+}
+
+export function buildVm0OnboardingEntryUrl(
+  paramsInit?: URLSearchParams | string,
+): string {
+  const params =
+    paramsInit instanceof URLSearchParams
+      ? new URLSearchParams(paramsInit)
+      : new URLSearchParams(paramsInit ?? "");
+  const query = params.toString();
+
+  return `${paidOnboardingBaseUrl()}${VM0_ONBOARDING_PATH}${query ? `?${query}` : ""}`;
+}


### PR DESCRIPTION
## Summary
- add the localized web /video gallery page using the same template content and preview behavior as so.vm0.ai/video
- share video template data from @vm0/core and add the so onboarding entry URL helper
- expose /video as a public route and include it in so frontend rewrites

## Testing
- pnpm -F web test app/[locale]/video/__tests__/data.test.ts __tests__/so-frontend-rewrites.test.ts __tests__/proxy.public-routes.test.ts
- pnpm -F web exec prettier --check app/[locale]/video src/lib/zero/onboardingEntryUrl.ts proxy.ts so-frontend-rewrites.js __tests__/so-frontend-rewrites.test.ts __tests__/proxy.public-routes.test.ts
- pnpm -F web exec oxlint app/[locale]/video src/lib/zero/onboardingEntryUrl.ts proxy.ts so-frontend-rewrites.js __tests__/so-frontend-rewrites.test.ts __tests__/proxy.public-routes.test.ts
- pnpm -F web exec eslint app/[locale]/video src/lib/zero/onboardingEntryUrl.ts proxy.ts so-frontend-rewrites.js __tests__/so-frontend-rewrites.test.ts __tests__/proxy.public-routes.test.ts --max-warnings 0
- pnpm -F web check-types