### PR TITLE
ci: use larger runner for release asset builds

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2062,7 +2062,7 @@ jobs:
   build-runner-release-assets:
     needs: release-please
     if: ${{ needs.release-please.outputs.runner_rs_release_created == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8-cores
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260622
     permissions:


### PR DESCRIPTION
## Summary

- move `release-please` `build-runner-release-assets` to `ubuntu-latest-8-cores`
- keep the release profile, target matrix, toolchain container, and release asset upload flow unchanged

Closes #18827

## Verification

- `git diff --check`
- pre-commit hook via `git commit`
