### PR TITLE
feat(triggers): resolve trigger runs from isolated unattended policy

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-trigger-scheduler.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-trigger-scheduler.test.ts
@@ -1,13 +1,20 @@
 import { randomUUID } from "node:crypto";
 
+import type { UnattendedTriggerPermissionPolicy } from "@vm0/api-contracts/contracts/zero-workflows";
+import { networkPoliciesSchema } from "@vm0/connectors/firewall-types";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
 import { agentSessions } from "@vm0/db/schema/agent-session";
 import { chatMessages } from "@vm0/db/schema/chat-message";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
+import { connectors } from "@vm0/db/schema/connector";
 import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
 import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
+import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
+import { secrets } from "@vm0/db/schema/secret";
 import { userCache } from "@vm0/db/schema/user-cache";
+import { userConnectors } from "@vm0/db/schema/user-connector";
+import { userPermissionGrants } from "@vm0/db/schema/user-permission-grant";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import {
   zeroWorkflowTriggers,
@@ -16,11 +23,13 @@ import {
 } from "@vm0/db/schema/zero-workflow";
 import { createStore } from "ccstate";
 import { and, eq } from "drizzle-orm";
+import { z } from "zod";
 
 import { testContext } from "../../../__tests__/test-helpers";
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { now } from "../../../lib/time";
 import {
+  encryptStoredSecretValue,
   resetSecretKmsClientForTests,
   setSecretKmsClientForTests,
 } from "../../services/crypto.utils";
@@ -125,6 +134,7 @@ async function seedTrigger(
     readonly enabled?: boolean;
     readonly consecutiveFailures?: number;
     readonly lastRunId?: string;
+    readonly unattendedPermissionPolicy?: UnattendedTriggerPermissionPolicy | null;
   },
 ): Promise<{ triggerId: string; threadId: string }> {
   const db = store.set(writeDb$);
@@ -152,6 +162,7 @@ async function seedTrigger(
       nextRunAt: opts.nextRunAt,
       consecutiveFailures: opts.consecutiveFailures ?? 0,
       lastRunId: opts.lastRunId ?? null,
+      unattendedPermissionPolicy: opts.unattendedPermissionPolicy ?? null,
     })
     .returning({ id: zeroWorkflowTriggers.id });
   return { triggerId: trigger!.id, threadId: thread!.id };
@@ -170,7 +181,99 @@ function pastDate(): Date {
   return new Date(now() - 3_600_000);
 }
 
+async function runNetworkPolicies(db: Db, runId: string) {
+  const [job] = await db
+    .select({ ctx: runnerJobQueue.executionContext })
+    .from(runnerJobQueue)
+    .where(eq(runnerJobQueue.runId, runId))
+    .limit(1);
+  if (!job) {
+    throw new Error("Expected a runner job for the trigger run");
+  }
+  return z
+    .object({ networkPolicies: networkPoliciesSchema.optional() })
+    .parse(job.ctx).networkPolicies;
+}
+
+async function runIdForTrigger(db: Db, triggerId: string): Promise<string> {
+  const [run] = await db
+    .select({ id: zeroRuns.id })
+    .from(zeroRuns)
+    .where(eq(zeroRuns.workflowTriggerId, triggerId))
+    .limit(1);
+  if (!run) {
+    throw new Error("Expected a run for the trigger");
+  }
+  return run.id;
+}
+
 describe("zero workflow trigger scheduler", () => {
+  it("isolates trigger-run permissions: uses the trigger policy, never agent grants", async () => {
+    const scenario = await setup();
+    const db = store.set(writeDb$);
+
+    // A real Gmail connection so the gmail firewall is built into the manifest.
+    await db.insert(connectors).values({
+      orgId: scenario.fixture.orgId,
+      userId: scenario.fixture.userId,
+      type: "gmail",
+      authMethod: "oauth",
+      externalEmail: "trigger-user@example.com",
+      tokenExpiresAt: new Date(now() + 60 * 60 * 1000),
+      oauthScopes: JSON.stringify([
+        "https://www.googleapis.com/auth/gmail.modify",
+      ]),
+    });
+    await db.insert(secrets).values({
+      orgId: scenario.fixture.orgId,
+      userId: scenario.fixture.userId,
+      name: "GMAIL_ACCESS_TOKEN",
+      encryptedValue: await encryptStoredSecretValue("gmail-access-token"),
+      type: "connector",
+    });
+    // Enable Gmail for the agent so it surfaces in the resolved network policies.
+    await db.insert(userConnectors).values({
+      orgId: scenario.fixture.orgId,
+      userId: scenario.fixture.userId,
+      agentId: scenario.agentId,
+      connectorType: "gmail",
+    });
+    // An agent/user grant that an isolated trigger run must NOT inherit.
+    await db.insert(userPermissionGrants).values({
+      orgId: scenario.fixture.orgId,
+      userId: scenario.fixture.userId,
+      agentId: scenario.agentId,
+      connectorRef: "gmail",
+      permission: "messages.write",
+      action: "allow",
+    });
+
+    // The trigger grants a different permission than the agent grant above.
+    const trigger = await seedTrigger(scenario, {
+      scheduleType: "loop",
+      intervalSeconds: 60,
+      nextRunAt: pastDate(),
+      unattendedPermissionPolicy: {
+        gmail: { policies: { "labels.write": "allow" } },
+      },
+    });
+
+    const result = await store.set(executeDueWorkflowTriggers$, context.signal);
+    expect(result.executed).toBe(1);
+
+    const policies = await runNetworkPolicies(
+      db,
+      await runIdForTrigger(db, trigger.triggerId),
+    );
+    // The trigger's own policy is honored.
+    expect(policies?.gmail?.allow ?? []).toContain("labels.write");
+    // The agent grant is NOT inherited by the unattended run.
+    expect(policies?.gmail?.allow ?? []).not.toContain("messages.write");
+    // It resolves to deny, and no permission is left as ask in an unattended run.
+    expect(policies?.gmail?.deny ?? []).toContain("messages.write");
+    expect(policies?.gmail?.ask ?? []).toHaveLength(0);
+  });
+
   it("fires a due cron trigger: creates a run, posts to the thread, sets last_run_id", async () => {
     const scenario = await setup();
     const { triggerId, threadId } = await seedTrigger(scenario, {

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -7,9 +7,13 @@ import {
   type ConnectorType,
 } from "@vm0/connectors/connectors";
 import type { ModelProviderCredentialScope } from "@vm0/api-contracts/contracts/model-providers";
+import type { UnattendedTriggerPermissionPolicy } from "@vm0/api-contracts/contracts/zero-workflows";
 import { permissionGrantsToFirewallPolicies } from "@vm0/connectors/firewall-metadata";
 import { resolveFirewallServerMetadataPolicies } from "@vm0/connectors/firewall-metadata/server";
-import type { FirewallPolicies } from "@vm0/connectors/firewall-types";
+import type {
+  FirewallPolicies,
+  FirewallPolicyValue,
+} from "@vm0/connectors/firewall-types";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
 import {
@@ -21,6 +25,7 @@ import { userCache } from "@vm0/db/schema/user-cache";
 import { userCustomConnectors } from "@vm0/db/schema/user-custom-connector";
 import { userConnectors } from "@vm0/db/schema/user-connector";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { zeroWorkflowTriggers } from "@vm0/db/schema/zero-workflow";
 import { command } from "ccstate";
 import { and, eq } from "drizzle-orm";
 import type { z } from "zod";
@@ -431,6 +436,62 @@ async function loadAllowedCustomConnectorIds(
   });
 }
 
+/**
+ * For an unattended trigger run, `ask` has no approver, so any resolved `ask`
+ * (always a connector metadata default, never a stored trigger value) is
+ * enforced as `deny`. Unknown-endpoint handling stays at the connector metadata
+ * default, which is `deny` for every connector.
+ */
+function coerceUnattendedPolicyAsks(
+  policies: FirewallPolicies | null,
+): FirewallPolicies | null {
+  if (!policies) {
+    return policies;
+  }
+  const askToDeny = (value: FirewallPolicyValue): FirewallPolicyValue => {
+    return value === "ask" ? "deny" : value;
+  };
+  const result: FirewallPolicies = {};
+  for (const [connector, policy] of Object.entries(policies)) {
+    const coerced: Record<string, FirewallPolicyValue> = {};
+    for (const [permission, value] of Object.entries(policy.policies)) {
+      coerced[permission] = askToDeny(value);
+    }
+    result[connector] = {
+      policies: coerced,
+      ...(policy.unknownPolicy !== undefined
+        ? { unknownPolicy: askToDeny(policy.unknownPolicy) }
+        : {}),
+    };
+  }
+  return result;
+}
+
+async function loadTriggerUnattendedPolicy(
+  db: Db,
+  args: { readonly orgId: string; readonly triggerId: string },
+): Promise<UnattendedTriggerPermissionPolicy | null> {
+  const [row] = await db
+    .select({ policy: zeroWorkflowTriggers.unattendedPermissionPolicy })
+    .from(zeroWorkflowTriggers)
+    .where(
+      and(
+        eq(zeroWorkflowTriggers.id, args.triggerId),
+        eq(zeroWorkflowTriggers.orgId, args.orgId),
+      ),
+    )
+    .limit(1);
+  return row?.policy ?? null;
+}
+
+/**
+ * Resolves the firewall policies for a run.
+ *
+ * Interactive (chat/agent) runs resolve from the caller's user permission
+ * grants. Trigger-fired runs (`args.unattended` present) are isolated: they
+ * resolve from the trigger's own policy overlaid on connector metadata
+ * defaults, never inherit agent/user grants, and have `ask` coerced to `deny`.
+ */
 async function resolveZeroRunPermissionPolicies(
   db: Db,
   args: {
@@ -439,9 +500,21 @@ async function resolveZeroRunPermissionPolicies(
     readonly agent: ZeroAgentRunRecord;
     readonly allowedConnectorTypes: readonly ConnectorType[];
     readonly checkedAt: Date;
+    readonly unattended?: {
+      readonly policy: UnattendedTriggerPermissionPolicy | null;
+    };
   },
   signal: AbortSignal,
 ): Promise<FirewallPolicies | null> {
+  if (args.unattended) {
+    const stored: FirewallPolicies = args.unattended.policy ?? {};
+    const resolved = await resolveFirewallServerMetadataPolicies(stored, [
+      ...args.allowedConnectorTypes,
+    ]);
+    signal.throwIfAborted();
+    return coerceUnattendedPolicyAsks(resolved);
+  }
+
   const grants = await loadActiveUserPermissionGrants(
     db,
     {
@@ -759,6 +832,18 @@ export const createZeroRun$ = command(
       agentId: agent.id,
     });
     signal.throwIfAborted();
+    // Trigger-fired runs carry a workflowTriggerId; they resolve from the
+    // trigger's own isolated unattended policy instead of the caller's grants.
+    const workflowTriggerId = args.zeroRunMetadata?.workflowTriggerId;
+    const unattended = workflowTriggerId
+      ? {
+          policy: await loadTriggerUnattendedPolicy(db, {
+            orgId: args.auth.orgId,
+            triggerId: workflowTriggerId,
+          }),
+        }
+      : undefined;
+    signal.throwIfAborted();
     const runPermissionPolicies = await resolveZeroRunPermissionPolicies(
       db,
       {
@@ -767,6 +852,7 @@ export const createZeroRun$ = command(
         agent,
         allowedConnectorTypes,
         checkedAt: new Date(args.apiStartTime),
+        unattended,
       },
       signal,
     );


### PR DESCRIPTION
Sub-issue of #18789 (3/5). Closes #18803. Builds on #18806, #18819.

Wires the isolated unattended policy into run permission resolution — the core behavior change.

## What
- A trigger-fired run (one carrying a `workflowTriggerId`) now resolves permissions from the trigger's own `unattendedPermissionPolicy` overlaid on connector metadata defaults, and **never inherits agent/user grants**. `ask` is coerced to `deny` (no approver exists for an unattended run; the unknown-endpoint policy stays at the metadata default, which is `deny` for every connector).
- Interactive chat/agent runs are unchanged (still resolve from user permission grants).
- Detection is centralized in `createZeroRun$` via the existing `zeroRunMetadata.workflowTriggerId`, so every `runWorkflowTriggerNow$` caller (schedule cron/loop/once, gmail-new-message, and manual test runs) is covered without threading args through each call site.

## Scope note
Goal / thread-idle continuation runs use a separate code path (`zero-goal-continuation`, keyed by `goalId` not `workflowTriggerId`) and are intentionally left on the existing resolution in this PR — no regression. Extending isolation there is a follow-up.

## Test plan
- `pnpm check-types` + `pnpm turbo run lint` — green.
- Integration test (scheduler): with a Gmail connection enabled and an agent-level `messages.write` grant, a trigger whose policy allows `labels.write` produces a run whose resolved `networkPolicies.gmail` **allows `labels.write`** (trigger policy honored), **does not allow `messages.write`** (agent grant not inherited), has it in `deny`, and leaves `ask` empty (coercion). Run locally against Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)