### PR TITLE
perf: cache guest artifact content hash sort keys

### DIFF
--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -248,9 +248,16 @@ async fn snapshot_artifact_entries(
         // locally-recomputed hash is sufficient — no extra metadata needed.
         // See #10967 for the ~3.9s-per-checkpoint motivation.
         let skip_check_start = std::time::Instant::now();
+        let content_hash_start = std::time::Instant::now();
         let local_hash = content_hash::compute_content_hash(
             &entry.storage_id,
             files.iter().map(|f| (f.path.as_str(), f.hash.as_str())),
+        );
+        record_sandbox_op(
+            "artifact_content_hash_compute",
+            content_hash_start.elapsed(),
+            true,
+            None,
         );
         if local_hash == entry.version_id {
             log_info!(

--- a/crates/guest-agent/src/content_hash.rs
+++ b/crates/guest-agent/src/content_hash.rs
@@ -45,31 +45,32 @@ pub(crate) fn compute_content_hash<'a, I>(storage_id: &str, files: I) -> String
 where
     I: IntoIterator<Item = (&'a str, &'a str)>,
 {
-    let entries: Vec<ContentHashEntry<'a>> = files
-        .into_iter()
-        .map(|(path, hash)| ContentHashEntry { path, hash })
-        .collect();
-
     let mut hasher = Sha256::new();
     hasher.update(b"storage:");
     hasher.update(storage_id.as_bytes());
     hasher.update(b"\n");
 
-    if entries.len() > 1 {
-        let mut sortable_entries: Vec<SortableContentHashEntry<'a>> = entries
-            .into_iter()
-            .map(SortableContentHashEntry::new)
-            .collect();
-        // Equal sort keys are identical formatted `path:hash` lines, so
-        // stability cannot affect the final hash byte stream.
-        sortable_entries.sort_unstable_by(|left, right| left.sort_key.cmp(&right.sort_key));
-        for (index, entry) in sortable_entries.iter().enumerate() {
-            update_hash_for_entry(&mut hasher, index, entry.entry);
-        }
-    } else {
-        for (index, entry) in entries.iter().enumerate() {
-            update_hash_for_entry(&mut hasher, index, *entry);
-        }
+    let mut entries = files
+        .into_iter()
+        .map(|(path, hash)| ContentHashEntry { path, hash });
+    let Some(first_entry) = entries.next() else {
+        return hex::encode(hasher.finalize());
+    };
+    let Some(second_entry) = entries.next() else {
+        update_hash_for_entry(&mut hasher, 0, first_entry);
+        return hex::encode(hasher.finalize());
+    };
+
+    let (remaining_lower_bound, _) = entries.size_hint();
+    let mut sortable_entries = Vec::with_capacity(remaining_lower_bound.saturating_add(2));
+    sortable_entries.push(SortableContentHashEntry::new(first_entry));
+    sortable_entries.push(SortableContentHashEntry::new(second_entry));
+    sortable_entries.extend(entries.map(SortableContentHashEntry::new));
+    // Equal sort keys are identical formatted `path:hash` lines, so stability
+    // cannot affect the final hash byte stream.
+    sortable_entries.sort_unstable_by(|left, right| left.sort_key.cmp(&right.sort_key));
+    for (index, entry) in sortable_entries.iter().enumerate() {
+        update_hash_for_entry(&mut hasher, index, entry.entry);
     }
 
     hex::encode(hasher.finalize())

--- a/crates/guest-agent/src/content_hash.rs
+++ b/crates/guest-agent/src/content_hash.rs
@@ -60,7 +60,7 @@ where
             .into_iter()
             .map(SortableContentHashEntry::new)
             .collect();
-        sortable_entries.sort_by(|left, right| left.sort_key.cmp(&right.sort_key));
+        sortable_entries.sort_unstable_by(|left, right| left.sort_key.cmp(&right.sort_key));
         for (index, entry) in sortable_entries.iter().enumerate() {
             update_hash_for_entry(&mut hasher, index, entry.entry);
         }
@@ -175,6 +175,16 @@ mod tests {
 
         assert_eq!(got, sha256_hex(&format!("storage:{STORAGE_A}\na::0\na:z")));
         assert_ne!(got, sha256_hex(&format!("storage:{STORAGE_A}\na:z\na::0")));
+    }
+
+    #[test]
+    fn equal_formatted_entries_do_not_depend_on_stable_sorting() {
+        let got = compute_content_hash(STORAGE_A, [("a", "b:c"), ("a:b", "c")]);
+
+        assert_eq!(
+            got,
+            sha256_hex(&format!("storage:{STORAGE_A}\na:b:c\na:b:c"))
+        );
     }
 
     #[test]

--- a/crates/guest-agent/src/content_hash.rs
+++ b/crates/guest-agent/src/content_hash.rs
@@ -11,12 +11,25 @@
 //! be checked against TS `computeContentHashFromHashes`.
 
 use sha2::{Digest, Sha256};
-use std::cmp::Ordering;
 
 #[derive(Clone, Copy)]
 struct ContentHashEntry<'a> {
     path: &'a str,
     hash: &'a str,
+}
+
+struct SortableContentHashEntry<'a> {
+    entry: ContentHashEntry<'a>,
+    sort_key: Vec<u16>,
+}
+
+impl<'a> SortableContentHashEntry<'a> {
+    fn new(entry: ContentHashEntry<'a>) -> Self {
+        Self {
+            entry,
+            sort_key: formatted_entry_sort_key(entry),
+        }
+    }
 }
 
 /// Compute the content hash for a storage version.
@@ -32,7 +45,7 @@ pub(crate) fn compute_content_hash<'a, I>(storage_id: &str, files: I) -> String
 where
     I: IntoIterator<Item = (&'a str, &'a str)>,
 {
-    let mut entries: Vec<ContentHashEntry<'a>> = files
+    let entries: Vec<ContentHashEntry<'a>> = files
         .into_iter()
         .map(|(path, hash)| ContentHashEntry { path, hash })
         .collect();
@@ -42,44 +55,40 @@ where
     hasher.update(storage_id.as_bytes());
     hasher.update(b"\n");
 
-    if !entries.is_empty() {
-        entries.sort_by(|left, right| compare_formatted_entries(*left, *right));
+    if entries.len() > 1 {
+        let mut sortable_entries: Vec<SortableContentHashEntry<'a>> = entries
+            .into_iter()
+            .map(SortableContentHashEntry::new)
+            .collect();
+        sortable_entries.sort_by(|left, right| left.sort_key.cmp(&right.sort_key));
+        for (index, entry) in sortable_entries.iter().enumerate() {
+            update_hash_for_entry(&mut hasher, index, entry.entry);
+        }
+    } else {
         for (index, entry) in entries.iter().enumerate() {
-            if index > 0 {
-                hasher.update(b"\n");
-            }
-            hasher.update(entry.path.as_bytes());
-            hasher.update(b":");
-            hasher.update(entry.hash.as_bytes());
+            update_hash_for_entry(&mut hasher, index, *entry);
         }
     }
 
     hex::encode(hasher.finalize())
 }
 
-fn compare_formatted_entries(left: ContentHashEntry<'_>, right: ContentHashEntry<'_>) -> Ordering {
-    let mut left_code_units = formatted_entry_code_units(left);
-    let mut right_code_units = formatted_entry_code_units(right);
-
-    loop {
-        match (left_code_units.next(), right_code_units.next()) {
-            (Some(left), Some(right)) => match left.cmp(&right) {
-                Ordering::Equal => {}
-                ordering => return ordering,
-            },
-            (Some(_), None) => return Ordering::Greater,
-            (None, Some(_)) => return Ordering::Less,
-            (None, None) => return Ordering::Equal,
-        }
+fn update_hash_for_entry(hasher: &mut Sha256, index: usize, entry: ContentHashEntry<'_>) {
+    if index > 0 {
+        hasher.update(b"\n");
     }
+    hasher.update(entry.path.as_bytes());
+    hasher.update(b":");
+    hasher.update(entry.hash.as_bytes());
 }
 
-fn formatted_entry_code_units<'a>(entry: ContentHashEntry<'a>) -> impl Iterator<Item = u16> + 'a {
+fn formatted_entry_sort_key(entry: ContentHashEntry<'_>) -> Vec<u16> {
     entry
         .path
         .encode_utf16()
         .chain(std::iter::once(u16::from(b':')))
         .chain(entry.hash.encode_utf16())
+        .collect()
 }
 
 #[cfg(test)]
@@ -158,6 +167,14 @@ mod tests {
             got,
             sha256_hex(&format!("storage:{STORAGE_A}\na:b:1\na:b:0"))
         );
+    }
+
+    #[test]
+    fn path_prefix_with_colon_sorts_like_formatted_entries() {
+        let got = compute_content_hash(STORAGE_A, [("a", "z"), ("a:", "0")]);
+
+        assert_eq!(got, sha256_hex(&format!("storage:{STORAGE_A}\na::0\na:z")));
+        assert_ne!(got, sha256_hex(&format!("storage:{STORAGE_A}\na:z\na::0")));
     }
 
     #[test]

--- a/crates/guest-agent/src/content_hash.rs
+++ b/crates/guest-agent/src/content_hash.rs
@@ -60,6 +60,8 @@ where
             .into_iter()
             .map(SortableContentHashEntry::new)
             .collect();
+        // Equal sort keys are identical formatted `path:hash` lines, so
+        // stability cannot affect the final hash byte stream.
         sortable_entries.sort_unstable_by(|left, right| left.sort_key.cmp(&right.sort_key));
         for (index, entry) in sortable_entries.iter().enumerate() {
             update_hash_for_entry(&mut hasher, index, entry.entry);
@@ -83,12 +85,11 @@ fn update_hash_for_entry(hasher: &mut Sha256, index: usize, entry: ContentHashEn
 }
 
 fn formatted_entry_sort_key(entry: ContentHashEntry<'_>) -> Vec<u16> {
-    entry
-        .path
-        .encode_utf16()
-        .chain(std::iter::once(u16::from(b':')))
-        .chain(entry.hash.encode_utf16())
-        .collect()
+    let mut sort_key = Vec::with_capacity(entry.path.len() + 1 + entry.hash.len());
+    sort_key.extend(entry.path.encode_utf16());
+    sort_key.push(u16::from(b':'));
+    sort_key.extend(entry.hash.encode_utf16());
+    sort_key
 }
 
 #[cfg(test)]

--- a/crates/guest-agent/tests/artifact_checkpoint_content_hash.rs
+++ b/crates/guest-agent/tests/artifact_checkpoint_content_hash.rs
@@ -1,0 +1,118 @@
+//! Artifact checkpoint telemetry lives in its own test binary because
+//! guest-agent environment and runtime paths are captured in process-wide
+//! `LazyLock`s on first access.
+
+use httpmock::prelude::*;
+use serde_json::json;
+use sha2::{Digest, Sha256};
+use std::path::Path;
+use std::time::Duration;
+
+const RUN_ID: &str = "artifact-checkpoint-content-hash";
+const STORAGE_ID: &str = "01234567-89ab-cdef-0123-456789abcdef";
+
+fn sha256_hex(bytes: impl AsRef<[u8]>) -> String {
+    hex::encode(Sha256::digest(bytes.as_ref()))
+}
+
+fn content_hash_for_single_file(storage_id: &str, path: &str, content: &str) -> String {
+    let file_hash = sha256_hex(content.as_bytes());
+    sha256_hex(format!("storage:{storage_id}\n{path}:{file_hash}"))
+}
+
+unsafe fn setup_env(temp_dir: &Path, server: &MockServer, mount_path: &Path, version_id: &str) {
+    unsafe {
+        std::env::set_var("CLI_AGENT_TYPE", "claude-code");
+        std::env::set_var("VM0_RUN_ID", RUN_ID);
+        std::env::set_var("VM0_API_URL", server.base_url());
+        std::env::set_var("VM0_API_TOKEN", "test-token");
+        std::env::set_var(
+            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+            temp_dir.join("runtime"),
+        );
+        std::env::set_var("HOME", temp_dir.join("home"));
+        std::env::set_var(
+            guest_contracts::env::ARTIFACTS_ENV,
+            json!([
+                {
+                    "name": "workspace",
+                    "mountPath": mount_path.to_string_lossy(),
+                    "storageId": STORAGE_ID,
+                    "versionId": version_id,
+                }
+            ])
+            .to_string(),
+        );
+    }
+}
+
+#[tokio::test]
+async fn unchanged_artifact_checkpoint_records_content_hash_timing()
+-> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = tempfile::tempdir()?;
+    let server = MockServer::start();
+    let mount_path = temp_dir.path().join("workspace");
+    std::fs::create_dir(&mount_path)?;
+    std::fs::write(mount_path.join("a.txt"), "hello")?;
+    let version_id = content_hash_for_single_file(STORAGE_ID, "a.txt", "hello");
+
+    unsafe {
+        setup_env(temp_dir.path(), &server, &mount_path, &version_id);
+    }
+
+    let history_path = temp_dir.path().join("history.jsonl");
+    std::fs::write(&history_path, r#"{"type":"system"}"#)?;
+    guest_agent::paths::write_private(guest_agent::paths::session_id_file(), "session-abc")?;
+    guest_agent::paths::write_private(
+        guest_agent::paths::session_history_path_file(),
+        history_path.to_string_lossy().as_ref(),
+    )?;
+
+    let history_prepare = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history")
+            .body_includes(format!(r#""runId":"{RUN_ID}""#));
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({"existing": true}));
+    });
+    let storage_prepare = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/storages/prepare");
+        then.status(200).json_body(json!({"unreachable": true}));
+    });
+    let storage_commit = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/storages/commit");
+        then.status(200).json_body(json!({"unreachable": true}));
+    });
+    let checkpoint = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints")
+            .body_includes(r#""artifactSnapshots":[{"mountPath":"#)
+            .body_includes(format!(r#""version":"{version_id}""#));
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({"checkpointId": "checkpoint-with-unchanged-artifact"}));
+    });
+
+    let http = guest_agent::http::HttpClient::with_api_config(
+        server.base_url(),
+        "test-token",
+        "",
+        Duration::ZERO,
+    )?;
+
+    guest_agent::checkpoint::create_checkpoint(&http).await?;
+
+    history_prepare.assert_calls_async(1).await;
+    storage_prepare.assert_calls_async(0).await;
+    storage_commit.assert_calls_async(0).await;
+    checkpoint.assert_calls_async(1).await;
+
+    let sandbox_ops = std::fs::read_to_string(guest_common::telemetry::sandbox_ops_log())?;
+    assert!(sandbox_ops.contains(r#""action_type":"artifact_content_hash_compute""#));
+    assert!(sandbox_ops.contains(r#""action_type":"artifact_snapshot_skipped""#));
+
+    Ok(())
+}

--- a/crates/guest-agent/tests/artifact_checkpoint_content_hash.rs
+++ b/crates/guest-agent/tests/artifact_checkpoint_content_hash.rs
@@ -20,6 +20,29 @@ fn content_hash_for_single_file(storage_id: &str, path: &str, content: &str) -> 
     sha256_hex(format!("storage:{storage_id}\n{path}:{file_hash}"))
 }
 
+fn checkpoint_request_has_artifact_snapshot(
+    req: &HttpMockRequest,
+    expected_version: &str,
+    expected_mount_path: &str,
+) -> bool {
+    let Ok(body) = serde_json::from_slice::<serde_json::Value>(req.body_ref()) else {
+        return false;
+    };
+    let Some(snapshots) = body
+        .get("artifactSnapshots")
+        .and_then(|value| value.as_array())
+    else {
+        return false;
+    };
+
+    snapshots.iter().any(|snapshot| {
+        snapshot.get("name").and_then(|value| value.as_str()) == Some("workspace")
+            && snapshot.get("version").and_then(|value| value.as_str()) == Some(expected_version)
+            && snapshot.get("mountPath").and_then(|value| value.as_str())
+                == Some(expected_mount_path)
+    })
+}
+
 unsafe fn setup_env(temp_dir: &Path, server: &MockServer, mount_path: &Path, version_id: &str) {
     unsafe {
         std::env::set_var("CLI_AGENT_TYPE", "claude-code");
@@ -71,7 +94,7 @@ async fn unchanged_artifact_checkpoint_records_content_hash_timing()
     let history_prepare = server.mock(|when, then| {
         when.method(POST)
             .path("/api/webhooks/agent/checkpoints/prepare-history")
-            .body_includes(format!(r#""runId":"{RUN_ID}""#));
+            .json_body_includes(format!(r#"{{"runId":"{RUN_ID}"}}"#));
         then.status(200)
             .header("Content-Type", "application/json")
             .json_body(json!({"existing": true}));
@@ -86,11 +109,18 @@ async fn unchanged_artifact_checkpoint_records_content_hash_timing()
             .path("/api/webhooks/agent/storages/commit");
         then.status(200).json_body(json!({"unreachable": true}));
     });
+    let expected_version = version_id.clone();
+    let expected_mount_path = mount_path.to_string_lossy().into_owned();
     let checkpoint = server.mock(|when, then| {
         when.method(POST)
             .path("/api/webhooks/agent/checkpoints")
-            .body_includes(r#""artifactSnapshots":[{"mountPath":"#)
-            .body_includes(format!(r#""version":"{version_id}""#));
+            .is_true(move |req| {
+                checkpoint_request_has_artifact_snapshot(
+                    req,
+                    &expected_version,
+                    &expected_mount_path,
+                )
+            });
         then.status(200)
             .header("Content-Type", "application/json")
             .json_body(json!({"checkpointId": "checkpoint-with-unchanged-artifact"}));

--- a/crates/guest-agent/tests/artifact_checkpoint_content_hash.rs
+++ b/crates/guest-agent/tests/artifact_checkpoint_content_hash.rs
@@ -43,12 +43,10 @@ fn checkpoint_request_has_artifact_snapshot(
     })
 }
 
-unsafe fn setup_env(temp_dir: &Path, server: &MockServer, mount_path: &Path, version_id: &str) {
+unsafe fn setup_env(temp_dir: &Path, mount_path: &Path, version_id: &str) {
     unsafe {
         std::env::set_var("CLI_AGENT_TYPE", "claude-code");
         std::env::set_var("VM0_RUN_ID", RUN_ID);
-        std::env::set_var("VM0_API_URL", server.base_url());
-        std::env::set_var("VM0_API_TOKEN", "test-token");
         std::env::set_var(
             guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
             temp_dir.join("runtime"),
@@ -69,19 +67,20 @@ unsafe fn setup_env(temp_dir: &Path, server: &MockServer, mount_path: &Path, ver
     }
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn unchanged_artifact_checkpoint_records_content_hash_timing()
 -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = tempfile::tempdir()?;
-    let server = MockServer::start();
     let mount_path = temp_dir.path().join("workspace");
     std::fs::create_dir(&mount_path)?;
     std::fs::write(mount_path.join("a.txt"), "hello")?;
     let version_id = content_hash_for_single_file(STORAGE_ID, "a.txt", "hello");
 
     unsafe {
-        setup_env(temp_dir.path(), &server, &mount_path, &version_id);
+        setup_env(temp_dir.path(), &mount_path, &version_id);
     }
+
+    let server = MockServer::start();
 
     let history_path = temp_dir.path().join("history.jsonl");
     std::fs::write(&history_path, r#"{"type":"system"}"#)?;


### PR DESCRIPTION
## Summary
- cache JavaScript-compatible UTF-16 sort keys when recomputing guest artifact content hashes
- avoid duplicate entry vectors, preallocate sort key buffers, and use unstable sorting where equal keys are hash-equivalent
- add artifact_content_hash_compute sandbox op timing around checkpoint skip checks
- cover formatted path:hash sort edge cases and unchanged artifact telemetry

Fixes #18808

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo test --manifest-path crates/Cargo.toml -p guest-agent --lib content_hash
- cargo test --manifest-path crates/Cargo.toml -p guest-agent --test artifact_checkpoint_content_hash
- cargo test --manifest-path crates/Cargo.toml -p guest-agent checkpoint
- cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features
- pre-commit: crates cargo-fmt, cargo-doc, cargo-clippy