### PR TITLE
feat(triggers): add trigger permission editor UI

### DIFF
--- a/turbo/apps/platform/src/signals/agent.ts
+++ b/turbo/apps/platform/src/signals/agent.ts
@@ -84,7 +84,8 @@ export const currentAgentId$ = computed((get) => {
     route !== "agentIdeas" &&
     route !== "agentPermissions" &&
     route !== "agentWorkflows" &&
-    route !== "agentWorkflowDetail"
+    route !== "agentWorkflowDetail" &&
+    route !== "agentWorkflowTriggerPermissions"
   ) {
     return null;
   }

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -52,6 +52,7 @@ import { setupDirectedConnectPage$ } from "./connectors-page/directed-connect-pa
 import { setupDirectedAuthorizePage$ } from "./connectors-page/directed-authorize-page-setup.ts";
 import { setupSignInTokenPage$ } from "./sign-in-token-setup.ts";
 import { setupPermissionAllowPage$ } from "./permission-allow/permission-allow-page-setup.ts";
+import { setupTriggerPermissionsPage$ } from "./trigger-permissions/trigger-permissions-page-setup.ts";
 import { setupReportErrorPage$ } from "./report-error/report-error-page-setup.ts";
 import { setupLabPage$ } from "./lab-page/lab-page-setup.ts";
 import { setupNetworkInsightsPage$ } from "./network-insights/network-insights-page-setup.ts";
@@ -173,6 +174,10 @@ const ROUTE_CONFIG = [
   {
     path: ROUTES.reportError,
     setup: setupAuthPageWrapper(setupReportErrorPage$),
+  },
+  {
+    path: ROUTES.agentWorkflowTriggerPermissions,
+    setup: setupAuthSidebarPageWrapper(setupTriggerPermissionsPage$),
   },
   {
     path: ROUTES.agentWorkflowDetail,

--- a/turbo/apps/platform/src/signals/route-paths.ts
+++ b/turbo/apps/platform/src/signals/route-paths.ts
@@ -9,6 +9,8 @@ export const ROUTES = {
   agentPermissions: "/agents/:agentId/permissions",
   agentWorkflows: "/agents/:agentId/workflows",
   agentWorkflowDetail: "/agents/:agentId/workflows/:workflowId",
+  agentWorkflowTriggerPermissions:
+    "/agents/:agentId/workflows/:workflowId/triggers/:triggerId/permissions",
   activities: "/activities",
   activityInspect: "/activities/inspect",
   activityDetail: "/activities/:activityRunId",

--- a/turbo/apps/platform/src/signals/trigger-permissions/trigger-permissions-page-setup.ts
+++ b/turbo/apps/platform/src/signals/trigger-permissions/trigger-permissions-page-setup.ts
@@ -1,0 +1,18 @@
+import { command } from "ccstate";
+import { createElement } from "react";
+import { TriggerPermissionsPage } from "../../views/trigger-permissions/trigger-permissions-page.tsx";
+import { updateDocumentTitle$ } from "../document-title.ts";
+import { updatePage$ } from "../react-router.ts";
+import { hideAppSkeleton$ } from "../app-skeleton.ts";
+import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
+
+export const setupTriggerPermissionsPage$ = command(
+  async ({ set }, signal: AbortSignal) => {
+    set(updatePage$, createElement(TriggerPermissionsPage), "sidebar");
+    set(updateDocumentTitle$, "Trigger Permissions");
+
+    await set(hideAppSkeleton$, signal);
+
+    await set(onboardGuard$, signal);
+  },
+);

--- a/turbo/apps/platform/src/signals/trigger-permissions/trigger-permissions-signals.ts
+++ b/turbo/apps/platform/src/signals/trigger-permissions/trigger-permissions-signals.ts
@@ -1,0 +1,167 @@
+import { command, computed, state, type Command, type Computed } from "ccstate";
+import type {
+  UnattendedTriggerPermissionAction,
+  UnattendedTriggerPermissionPolicy,
+  ZeroWorkflowTriggerSummary,
+} from "@vm0/api-contracts/contracts/zero-workflows";
+import { pathParams$, searchParams$ } from "../route.ts";
+import { workflowDetail } from "../workflows-page/workflows-signals.ts";
+
+// ---------------------------------------------------------------------------
+// Route params
+// ---------------------------------------------------------------------------
+
+const triggerPermissionsWorkflowId$ = computed((get) => {
+  const workflowId = get(pathParams$)?.workflowId;
+  return typeof workflowId === "string" ? workflowId : null;
+});
+
+export const triggerPermissionsTriggerId$ = computed((get) => {
+  const triggerId = get(pathParams$)?.triggerId;
+  return typeof triggerId === "string" ? triggerId : null;
+});
+
+export const triggerPermissionsRef$ = computed((get) => {
+  return get(searchParams$).get("ref") ?? null;
+});
+
+// ---------------------------------------------------------------------------
+// Trigger data (derived from the workflow detail's trigger list)
+// ---------------------------------------------------------------------------
+
+export const triggerPermissionsTrigger$ = computed(
+  async (get): Promise<ZeroWorkflowTriggerSummary | null> => {
+    const workflowId = get(triggerPermissionsWorkflowId$);
+    const triggerId = get(triggerPermissionsTriggerId$);
+    if (!workflowId || !triggerId) {
+      return null;
+    }
+    const workflow = await get(workflowDetail(workflowId));
+    if (!workflow) {
+      return null;
+    }
+    return (
+      workflow.triggers.find((trigger) => {
+        return trigger.id === triggerId;
+      }) ?? null
+    );
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Policy helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * The unattended default is "deny": a permission absent from the trigger's
+ * policy is treated as denied until explicitly allowed.
+ */
+const UNATTENDED_PERMISSION_DEFAULT: UnattendedTriggerPermissionAction = "deny";
+
+/**
+ * Resolve the current action for a single connector permission from the
+ * trigger's full policy, falling back to the unattended default.
+ */
+export function resolveTriggerPermissionAction(
+  policy: UnattendedTriggerPermissionPolicy | null,
+  connectorRef: string,
+  permission: string,
+): UnattendedTriggerPermissionAction {
+  return (
+    policy?.[connectorRef]?.policies[permission] ??
+    UNATTENDED_PERMISSION_DEFAULT
+  );
+}
+
+/**
+ * Merge an edited connector's permission map into the trigger's full existing
+ * policy, preserving every other connector. Permissions set back to the
+ * unattended default are dropped so the stored policy stays minimal; a
+ * connector left with no explicit permissions is removed entirely, and an empty
+ * overall policy collapses to `null` (which clears the policy server-side).
+ */
+export function mergeConnectorPolicy(
+  policy: UnattendedTriggerPermissionPolicy | null,
+  connectorRef: string,
+  policies: Record<string, UnattendedTriggerPermissionAction>,
+): UnattendedTriggerPermissionPolicy | null {
+  const next: UnattendedTriggerPermissionPolicy = {};
+  for (const [ref, entry] of Object.entries(policy ?? {})) {
+    if (ref !== connectorRef) {
+      next[ref] = entry;
+    }
+  }
+  const nextPolicies: Record<string, UnattendedTriggerPermissionAction> = {};
+  for (const [permission, action] of Object.entries(policies)) {
+    if (action !== UNATTENDED_PERMISSION_DEFAULT) {
+      nextPolicies[permission] = action;
+    }
+  }
+  if (Object.keys(nextPolicies).length > 0) {
+    next[connectorRef] = { policies: nextPolicies };
+  }
+  return Object.keys(next).length > 0 ? next : null;
+}
+
+// ---------------------------------------------------------------------------
+// Editor state (per trigger + connector)
+// ---------------------------------------------------------------------------
+
+/**
+ * Local, unsaved edits the user has toggled, keyed by permission name. Sparse:
+ * only permissions the user actually changed appear here, so the displayed
+ * action falls back to the trigger's saved policy for everything else. This
+ * avoids seeding the full permission list from async data.
+ */
+export interface TriggerPermissionEditorSignals {
+  readonly overrides$: Computed<
+    Record<string, UnattendedTriggerPermissionAction>
+  >;
+  readonly setOverride$: Command<
+    void,
+    [permission: string, action: UnattendedTriggerPermissionAction]
+  >;
+}
+
+function createTriggerPermissionEditorSignals(): TriggerPermissionEditorSignals {
+  const internalOverrides$ = state<
+    Record<string, UnattendedTriggerPermissionAction>
+  >({});
+
+  const overrides$ = computed((get) => {
+    return get(internalOverrides$);
+  });
+
+  const setOverride$ = command(
+    (
+      { set },
+      permission: string,
+      action: UnattendedTriggerPermissionAction,
+    ) => {
+      set(internalOverrides$, (prev) => {
+        return { ...prev, [permission]: action };
+      });
+    },
+  );
+
+  return { overrides$, setOverride$ };
+}
+
+/**
+ * Editor signals for the active trigger + connector. ccstate memoizes the
+ * computed, so the same signal group is reused until the trigger or connector
+ * changes, at which point a fresh group (with empty overrides) is created.
+ */
+export const currentTriggerPermissionEditorSignals$ = computed(
+  (get): TriggerPermissionEditorSignals | null => {
+    const triggerId = get(triggerPermissionsTriggerId$);
+    const ref = get(triggerPermissionsRef$);
+    if (!triggerId || !ref) {
+      return null;
+    }
+    // The factory is created per (triggerId, ref); ccstate's memoization keys
+    // this computed on those route values, so navigating to a different
+    // trigger/connector yields a fresh editor with no carried-over edits.
+    return createTriggerPermissionEditorSignals();
+  },
+);

--- a/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
+++ b/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
@@ -10,6 +10,7 @@ import {
   type ZeroWorkflowSchedule,
   type ZeroWorkflowSummary,
   type ZeroWorkflowUpdateRequest,
+  type UnattendedTriggerPermissionPolicy,
 } from "@vm0/api-contracts/contracts/zero-workflows";
 
 import { accept } from "../../lib/accept.ts";
@@ -404,6 +405,29 @@ export const setWorkflowTriggerEnabled$ = command(
           fetchOptions: { signal },
         });
     await accept(request, [200]);
+    signal.throwIfAborted();
+    set(reloadWorkflows$);
+  },
+);
+
+export const setWorkflowTriggerPermissionPolicy$ = command(
+  async (
+    { get, set },
+    input: {
+      triggerId: string;
+      unattendedPermissionPolicy: UnattendedTriggerPermissionPolicy | null;
+    },
+    signal: AbortSignal,
+  ) => {
+    const client = get(zeroClient$)(zeroWorkflowTriggersContract);
+    await accept(
+      client.setPermissionPolicy({
+        params: { id: input.triggerId },
+        body: { unattendedPermissionPolicy: input.unattendedPermissionPolicy },
+        fetchOptions: { signal },
+      }),
+      [200],
+    );
     signal.throwIfAborted();
     set(reloadWorkflows$);
   },

--- a/turbo/apps/platform/src/views/trigger-permissions/__tests__/trigger-permissions-page.test.tsx
+++ b/turbo/apps/platform/src/views/trigger-permissions/__tests__/trigger-permissions-page.test.tsx
@@ -1,0 +1,182 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  zeroWorkflowsDetailContract,
+  zeroWorkflowTriggersContract,
+  type SetUnattendedTriggerPermissionPolicyRequest,
+  type ZeroWorkflowDetailResponse,
+  type ZeroWorkflowTriggerSummary,
+} from "@vm0/api-contracts/contracts/zero-workflows";
+import { describe, expect, it } from "vitest";
+
+import {
+  detachedSetupPage,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+
+const context = testContext();
+const user = userEvent.setup();
+
+const CURRENT_USER_ID = "test-user-123";
+const AGENT_ID = "c0000000-0000-4000-a000-000000000301";
+const WORKFLOW_ID = "d0000000-0000-4000-a000-000000000401";
+const TRIGGER_ID = "workflow-trigger-perm-editor";
+const PERMISSION_LABEL = "Access workspace analytics data";
+
+function trigger(
+  unattendedPermissionPolicy: ZeroWorkflowTriggerSummary["unattendedPermissionPolicy"],
+): ZeroWorkflowTriggerSummary {
+  return {
+    id: TRIGGER_ID,
+    kind: "schedule",
+    schedule: { type: "cron", cronExpression: "0 9 * * *", timezone: "UTC" },
+    scheduleSummary: "Every day at 9:00 AM",
+    ownerUserId: CURRENT_USER_ID,
+    enabled: true,
+    chatThreadId: "thread_perm_editor",
+    nextRunAt: null,
+    lastRunAt: null,
+    unattendedPermissionPolicy,
+  };
+}
+
+function workflow(
+  triggerSummary: ZeroWorkflowTriggerSummary,
+): ZeroWorkflowDetailResponse {
+  return {
+    id: WORKFLOW_ID,
+    agentId: AGENT_ID,
+    agentName: "research-bot",
+    agentDisplayName: "Research Bot",
+    name: "perm-workflow",
+    displayName: "Perm Workflow",
+    description: null,
+    visibility: "private",
+    requestToPublish: false,
+    ownerUserId: CURRENT_USER_ID,
+    canManage: true,
+    instruction: "Do the thing.",
+    files: [],
+    fileContents: [],
+    triggers: [triggerSummary],
+  };
+}
+
+/**
+ * Mocks the workflow-detail GET and the trigger setPermissionPolicy PUT over a
+ * single shared policy, so the post-save workflow reload reflects the latest
+ * saved policy the way the real backend would. Returns the captured request
+ * bodies.
+ */
+function mockTriggerPolicyApis(
+  initialPolicy: ZeroWorkflowTriggerSummary["unattendedPermissionPolicy"],
+): SetUnattendedTriggerPermissionPolicyRequest[] {
+  const bodies: SetUnattendedTriggerPermissionPolicyRequest[] = [];
+  let currentPolicy = initialPolicy;
+
+  context.mocks.api(zeroWorkflowsDetailContract.get, ({ params, respond }) => {
+    if (params.workflowId !== WORKFLOW_ID) {
+      return respond(404, { error: { code: "NOT_FOUND", message: "missing" } });
+    }
+    return respond(200, workflow(trigger(currentPolicy)));
+  });
+
+  context.mocks.api(
+    zeroWorkflowTriggersContract.setPermissionPolicy,
+    ({ body, respond }) => {
+      bodies.push(body);
+      currentPolicy = body.unattendedPermissionPolicy ?? null;
+      return respond(200, trigger(currentPolicy));
+    },
+  );
+
+  return bodies;
+}
+
+function permissionRow(): HTMLElement {
+  const label = screen.getByText(PERMISSION_LABEL);
+  const row = label.parentElement;
+  if (!row) {
+    throw new Error("Expected a permission row");
+  }
+  return row;
+}
+
+function button(label: string, container?: HTMLElement): HTMLElement {
+  const match = queryAllByRoleFast("button", container).find((el) => {
+    return el.textContent?.trim() === label;
+  });
+  if (!match) {
+    throw new Error(`Expected a "${label}" button`);
+  }
+  return match;
+}
+
+const editorPath = `/agents/${AGENT_ID}/workflows/${WORKFLOW_ID}/triggers/${TRIGGER_ID}/permissions?ref=slack`;
+
+describe("trigger permissions page", () => {
+  it("rejects an unknown connector ref", async () => {
+    mockTriggerPolicyApis(null);
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/workflows/${WORKFLOW_ID}/triggers/${TRIGGER_ID}/permissions?ref=not-a-connector`,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Unknown connector: not-a-connector"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("allows a permission and saves the merged policy", async () => {
+    const bodies = mockTriggerPolicyApis(null);
+
+    detachedSetupPage({ context, path: editorPath });
+
+    await waitFor(() => {
+      expect(screen.getByText(PERMISSION_LABEL)).toBeInTheDocument();
+    });
+
+    // Save is disabled until something changes.
+    expect(button("Save")).toBeDisabled();
+
+    await user.click(button("Allow", permissionRow()));
+    await user.click(button("Save"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Saved")).toBeInTheDocument();
+    });
+
+    expect(bodies).toStrictEqual([
+      {
+        unattendedPermissionPolicy: {
+          slack: { policies: { "admin.analytics:read": "allow" } },
+        },
+      },
+    ]);
+  });
+
+  it("clears the policy to null when the only allowed permission is denied", async () => {
+    const bodies = mockTriggerPolicyApis({
+      slack: { policies: { "admin.analytics:read": "allow" } },
+    });
+
+    detachedSetupPage({ context, path: editorPath });
+
+    await waitFor(() => {
+      expect(screen.getByText(PERMISSION_LABEL)).toBeInTheDocument();
+    });
+
+    await user.click(button("Deny", permissionRow()));
+    await user.click(button("Save"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Saved")).toBeInTheDocument();
+    });
+
+    expect(bodies).toStrictEqual([{ unattendedPermissionPolicy: null }]);
+  });
+});

--- a/turbo/apps/platform/src/views/trigger-permissions/trigger-permissions-page.tsx
+++ b/turbo/apps/platform/src/views/trigger-permissions/trigger-permissions-page.tsx
@@ -1,0 +1,318 @@
+import { useGet, useLastLoadable, useLoadable, useSet } from "ccstate-react";
+import { useLoadableSet } from "ccstate-react/experimental";
+import { Button } from "@vm0/ui";
+import {
+  IconAlertTriangle,
+  IconBan,
+  IconCheck,
+  IconLoader2,
+} from "@tabler/icons-react";
+import type {
+  UnattendedTriggerPermissionAction,
+  UnattendedTriggerPermissionPolicy,
+} from "@vm0/api-contracts/contracts/zero-workflows";
+import { CONNECTOR_TYPES } from "@vm0/connectors/connectors";
+import {
+  isFirewallMetadataConnectorType,
+  type FirewallPermissionDetailMetadata,
+} from "@vm0/connectors/firewall-metadata";
+import { pageSignal$ } from "../../signals/page-signal.ts";
+import { firewallPermissionMetadataByConnector } from "../../signals/firewall-permission-metadata.ts";
+import {
+  currentTriggerPermissionEditorSignals$,
+  mergeConnectorPolicy,
+  resolveTriggerPermissionAction,
+  triggerPermissionsRef$,
+  triggerPermissionsTrigger$,
+  triggerPermissionsTriggerId$,
+  type TriggerPermissionEditorSignals,
+} from "../../signals/trigger-permissions/trigger-permissions-signals.ts";
+import { setWorkflowTriggerPermissionPolicy$ } from "../../signals/workflows-page/workflows-signals.ts";
+import { detach, Reason } from "../../signals/utils.ts";
+import { VM0Logo } from "../components/vm0-logo.tsx";
+import { ConnectorIcon } from "../zero-page/components/settings/connector-icons.tsx";
+
+function LoadingCard() {
+  return (
+    <div className="fixed inset-0 z-10 flex items-center justify-center pointer-events-none">
+      <div className="pointer-events-auto flex w-[500px] max-w-[calc(100vw-96px)] flex-col items-center gap-10 rounded-[20px] border border-border bg-background px-6 py-12">
+        <VM0Logo />
+        <IconLoader2 size={20} className="animate-spin text-muted-foreground" />
+      </div>
+    </div>
+  );
+}
+
+function StatusMessage({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex flex-1 items-center justify-center text-muted-foreground">
+      {children}
+    </div>
+  );
+}
+
+function ErrorMessage({ message }: { message: string }) {
+  return (
+    <StatusMessage>
+      <div className="flex flex-col items-center gap-2">
+        <IconAlertTriangle size={24} />
+        <p className="text-sm">{message}</p>
+      </div>
+    </StatusMessage>
+  );
+}
+
+function PermissionToggle({
+  action,
+  disabled,
+  onChange,
+}: {
+  action: UnattendedTriggerPermissionAction;
+  disabled: boolean;
+  onChange: (action: UnattendedTriggerPermissionAction) => void;
+}) {
+  return (
+    <div className="flex shrink-0 items-center gap-1 rounded-lg border border-border bg-muted/30 p-0.5">
+      <button
+        type="button"
+        disabled={disabled}
+        aria-pressed={action === "allow"}
+        onClick={() => {
+          onChange("allow");
+        }}
+        className={`flex items-center gap-1 rounded-[6px] px-2 py-1 text-xs font-medium transition-colors disabled:opacity-50 ${
+          action === "allow"
+            ? "bg-background text-green-700 shadow-sm dark:text-green-400"
+            : "text-muted-foreground hover:text-foreground"
+        }`}
+      >
+        <IconCheck size={14} />
+        Allow
+      </button>
+      <button
+        type="button"
+        disabled={disabled}
+        aria-pressed={action === "deny"}
+        onClick={() => {
+          onChange("deny");
+        }}
+        className={`flex items-center gap-1 rounded-[6px] px-2 py-1 text-xs font-medium transition-colors disabled:opacity-50 ${
+          action === "deny"
+            ? "bg-background text-destructive shadow-sm"
+            : "text-muted-foreground hover:text-foreground"
+        }`}
+      >
+        <IconBan size={14} />
+        Deny
+      </button>
+    </div>
+  );
+}
+
+function ConnectorPermissionEditorCard({
+  triggerId,
+  connectorRef,
+  metadata,
+  savedPolicy,
+  editor,
+}: {
+  triggerId: string;
+  connectorRef: string;
+  metadata: FirewallPermissionDetailMetadata;
+  savedPolicy: UnattendedTriggerPermissionPolicy | null;
+  editor: TriggerPermissionEditorSignals;
+}) {
+  const pageSignal = useGet(pageSignal$);
+  const overrides = useGet(editor.overrides$);
+  const setOverride = useSet(editor.setOverride$);
+  const [saveLoadable, save] = useLoadableSet(
+    setWorkflowTriggerPermissionPolicy$,
+  );
+  const saving = saveLoadable.state === "loading";
+  const saved = saveLoadable.state === "hasData";
+
+  const connectorConfig = isFirewallMetadataConnectorType(connectorRef)
+    ? CONNECTOR_TYPES[connectorRef]
+    : undefined;
+  const connectorLabel = connectorConfig?.label ?? metadata.label;
+  const connectorHelpText = connectorConfig?.helpText ?? "";
+
+  const actionFor = (permission: string): UnattendedTriggerPermissionAction => {
+    return (
+      overrides[permission] ??
+      resolveTriggerPermissionAction(savedPolicy, connectorRef, permission)
+    );
+  };
+
+  const dirty = metadata.permissions.some((permission) => {
+    const override = overrides[permission.name];
+    if (override === undefined) {
+      return false;
+    }
+    return (
+      override !==
+      resolveTriggerPermissionAction(savedPolicy, connectorRef, permission.name)
+    );
+  });
+
+  const handleSave = () => {
+    const policies: Record<string, UnattendedTriggerPermissionAction> = {};
+    for (const permission of metadata.permissions) {
+      policies[permission.name] = actionFor(permission.name);
+    }
+    const merged = mergeConnectorPolicy(savedPolicy, connectorRef, policies);
+    // After the save, `reloadWorkflows$` refetches the trigger; once its policy
+    // reflects the merge, the local overrides match the saved state and `dirty`
+    // collapses to false on its own — no explicit reset needed.
+    detach(
+      save({ triggerId, unattendedPermissionPolicy: merged }, pageSignal),
+      Reason.DomCallback,
+    );
+  };
+
+  return (
+    <div className="mx-auto flex w-full max-w-[640px] flex-col gap-4 px-6 py-10">
+      <div className="flex items-center gap-3">
+        {isFirewallMetadataConnectorType(connectorRef) && (
+          <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[10px] bg-muted/40">
+            <ConnectorIcon type={connectorRef} size={20} />
+          </span>
+        )}
+        <div className="min-w-0 flex-1 flex flex-col gap-1">
+          <p className="text-base font-medium text-foreground">
+            {connectorLabel}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            Choose which {connectorLabel} permissions this trigger may use when
+            it fires unattended.
+          </p>
+        </div>
+      </div>
+
+      {connectorHelpText && (
+        <p className="text-xs text-muted-foreground">{connectorHelpText}</p>
+      )}
+
+      <div className="flex flex-col divide-y divide-border/70 rounded-lg border border-border">
+        {metadata.permissions.map((permission) => {
+          return (
+            <div
+              key={permission.name}
+              className="flex items-center gap-3 px-4 py-3"
+            >
+              <span className="min-w-0 flex-1 text-sm text-foreground">
+                {permission.description ?? permission.name}
+              </span>
+              <code className="hidden shrink-0 rounded border border-border bg-muted/40 px-1.5 py-0.5 font-mono text-xs text-sky-700 sm:inline">
+                {permission.name}
+              </code>
+              <PermissionToggle
+                action={actionFor(permission.name)}
+                disabled={saving}
+                onChange={(action) => {
+                  setOverride(permission.name, action);
+                }}
+              />
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="flex items-center justify-end gap-3">
+        {saved && !dirty && (
+          <span className="flex items-center gap-1 text-sm text-green-700 dark:text-green-400">
+            <IconCheck size={16} />
+            Saved
+          </span>
+        )}
+        <Button
+          type="button"
+          onClick={handleSave}
+          disabled={saving || !dirty}
+          className="h-9 rounded-[10px]"
+        >
+          {saving ? "Saving..." : "Save"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function TriggerPermissionsEditor({
+  triggerId,
+  connectorRef,
+  editor,
+}: {
+  triggerId: string;
+  connectorRef: string;
+  editor: TriggerPermissionEditorSignals;
+}) {
+  const triggerLoadable = useLastLoadable(triggerPermissionsTrigger$);
+  const metadataLoadable = useLoadable(
+    firewallPermissionMetadataByConnector({ connectorType: connectorRef }),
+  );
+
+  if (
+    triggerLoadable.state === "loading" ||
+    metadataLoadable.state === "loading"
+  ) {
+    return <LoadingCard />;
+  }
+
+  if (triggerLoadable.state === "hasError") {
+    return <ErrorMessage message="Failed to load trigger" />;
+  }
+  if (metadataLoadable.state === "hasError") {
+    return <ErrorMessage message="Failed to load permission metadata" />;
+  }
+
+  const trigger = triggerLoadable.data;
+  if (!trigger) {
+    return <ErrorMessage message="Trigger not found" />;
+  }
+
+  const metadata = metadataLoadable.data;
+  if (!metadata) {
+    return <ErrorMessage message={`Unknown connector: ${connectorRef}`} />;
+  }
+
+  return (
+    <ConnectorPermissionEditorCard
+      triggerId={triggerId}
+      connectorRef={connectorRef}
+      metadata={metadata}
+      savedPolicy={trigger.unattendedPermissionPolicy}
+      editor={editor}
+    />
+  );
+}
+
+export function TriggerPermissionsPage() {
+  const triggerId = useGet(triggerPermissionsTriggerId$);
+  const ref = useGet(triggerPermissionsRef$);
+  const editor = useGet(currentTriggerPermissionEditorSignals$);
+
+  if (!triggerId) {
+    return <ErrorMessage message="Missing trigger ID in URL parameters" />;
+  }
+
+  if (!ref) {
+    return <ErrorMessage message="Missing connector in URL parameters" />;
+  }
+
+  if (!isFirewallMetadataConnectorType(ref)) {
+    return <ErrorMessage message={`Unknown connector: ${ref}`} />;
+  }
+
+  if (!editor) {
+    return <LoadingCard />;
+  }
+
+  return (
+    <TriggerPermissionsEditor
+      triggerId={triggerId}
+      connectorRef={ref}
+      editor={editor}
+    />
+  );
+}


### PR DESCRIPTION
Sub-issue of #18789 (4/5). Closes #18804. Builds on #18806, #18819, #18832.

The human-facing editor for a trigger's unattended permission policy.

## What
- New page + route `agentWorkflowTriggerPermissions` = `/agents/:agentId/workflows/:workflowId/triggers/:triggerId/permissions?ref=<connectorType>`, mirroring the existing single-connector `permission-allow-page`.
- Lists the `ref` connector's permissions (from firewall metadata) with an **allow/deny toggle each — no `ask`** (an unattended run has no approver). Each permission defaults to **deny** until explicitly allowed.
- Saving merges the edited connector into the trigger's full `unattendedPermissionPolicy`, preserving other connectors; permissions left at the deny default are dropped to keep storage minimal, and an empty policy collapses to `null` (clears it). Writes via the new `setWorkflowTriggerPermissionPolicy$` → `PUT /api/zero/workflow-triggers/:id/permission-policy` (session/PAT-gated).

## Deferred
- The OAuth-scope precondition warning (allowing a write when the owner's connection lacks the scope) is **not** included — it needs the owner's connection scope state cross-referenced per permission, which is non-trivial. Tracked as follow-up; no stub left behind.

## Test plan
- `pnpm -F @vm0/app check-types`, `pnpm turbo run lint --filter=@vm0/app`, `pnpm knip --workspace apps/platform` — all green.
- 3 MSW integration tests (no DB): rejects unknown connector; allow → saves the merged policy; denying the only allowed permission → sends `null`. Regression: workflows-page (8/8) and permission-allow (6/6) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)