### PR TITLE
fix: count folded run groups in chat render window

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/__tests__/run-group-folding.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/run-group-folding.test.ts
@@ -3,7 +3,11 @@ import type {
   EnrichedChatMessage,
   GroupedChatMessageGroup,
 } from "../chat-message.ts";
-import { buildRunGroupFolding } from "../run-group-folding.ts";
+import {
+  buildRunGroupFolding,
+  previousRunGroupVisualWindowStartIndex,
+  runGroupVisualWindowStartIndex,
+} from "../run-group-folding.ts";
 
 function userMessage(params: {
   readonly id: string;
@@ -59,6 +63,24 @@ function messageIds(groups: readonly GroupedChatMessageGroup[]): string[] {
     return item.messages.map((message) => {
       return message.id;
     });
+  });
+}
+
+function assistantRunGroups(params: {
+  readonly label: string;
+  readonly count: number;
+  readonly runGroupId?: string;
+}): GroupedChatMessageGroup[] {
+  return Array.from({ length: params.count }, (_, index) => {
+    const itemNumber = index + 1;
+    const id = `${params.label}-${itemNumber}`;
+    return group("assistant", [
+      assistantMessage({
+        id,
+        runId: `${params.label}-run-${itemNumber}`,
+        runGroupId: params.runGroupId,
+      }),
+    ]);
   });
 }
 
@@ -165,5 +187,93 @@ describe("buildRunGroupFolding", () => {
       "a3a",
     ]);
     expect(firstFold?.key).not.toBe(secondFold?.key);
+  });
+});
+
+describe("runGroupVisualWindowStartIndex", () => {
+  it("counts a folded tail run group as one visual item", () => {
+    const groups = [
+      ...assistantRunGroups({
+        label: "A",
+        count: 11,
+        runGroupId: "group-a",
+      }),
+      ...assistantRunGroups({
+        label: "B",
+        count: 1,
+        runGroupId: "group-b",
+      }),
+    ];
+
+    const startIndex = runGroupVisualWindowStartIndex(groups, null, 10);
+    const folding = buildRunGroupFolding(groups.slice(startIndex));
+
+    expect(startIndex).toBe(0);
+    expect(folding?.foldsByNextGroupId.get("A-11")?.[0]?.hiddenRunCount).toBe(
+      10,
+    );
+    expect(messageIds(folding?.visibleGroups ?? [])).toStrictEqual([
+      "A-11",
+      "B-1",
+    ]);
+  });
+
+  it("keeps the item before a folded middle run group in the initial window", () => {
+    const groups = [
+      ...assistantRunGroups({
+        label: "A",
+        count: 1,
+        runGroupId: "group-a",
+      }),
+      ...assistantRunGroups({
+        label: "B",
+        count: 10,
+        runGroupId: "group-b",
+      }),
+      ...assistantRunGroups({
+        label: "C",
+        count: 1,
+        runGroupId: "group-c",
+      }),
+    ];
+
+    const startIndex = runGroupVisualWindowStartIndex(groups, null, 10);
+    const folding = buildRunGroupFolding(groups.slice(startIndex));
+
+    expect(startIndex).toBe(0);
+    expect(folding?.foldsByNextGroupId.get("B-10")?.[0]?.hiddenRunCount).toBe(
+      9,
+    );
+    expect(messageIds(folding?.visibleGroups ?? [])).toStrictEqual([
+      "A-1",
+      "B-10",
+      "C-1",
+    ]);
+  });
+
+  it("moves the cursor by visual items when loading more", () => {
+    const groups = [
+      ...assistantRunGroups({ label: "older", count: 12 }),
+      ...assistantRunGroups({
+        label: "A",
+        count: 11,
+        runGroupId: "group-a",
+      }),
+      ...assistantRunGroups({
+        label: "B",
+        count: 1,
+        runGroupId: "group-b",
+      }),
+    ];
+
+    const initialStartIndex = runGroupVisualWindowStartIndex(groups, null, 10);
+    const previousStartIndex = previousRunGroupVisualWindowStartIndex(
+      groups,
+      initialStartIndex,
+      10,
+    );
+
+    expect(groups[initialStartIndex]?.beginMessageId).toBe("older-5");
+    expect(previousStartIndex).toBe(0);
   });
 });

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -42,11 +42,13 @@ import {
   type ModelSelectionRequest,
   type PagedChatMessage,
 } from "@vm0/api-contracts/contracts/chat-threads";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import type { ModelProviderSelection } from "../../views/zero-page/components/model-provider-picker.tsx";
 import { accept } from "../../lib/accept.ts";
 import { nowDate } from "../../lib/time.ts";
 import { captureTaskCompletedSuccessfully } from "../../lib/posthog.ts";
 import { zeroClient$ } from "../api-client.ts";
+import { featureSwitch$ } from "../external/feature-switch.ts";
 import { agentById } from "../agent.ts";
 import { orgModelPolicies$ } from "../external/org-model-policies.ts";
 import { userModelPreference$ } from "../external/user-model-preference.ts";
@@ -2100,11 +2102,40 @@ const renderWindowStateByThreadId$ = state(
 function renderWindowStartIndex(
   groups: readonly GroupedChatMessageGroup[],
   cursorGroupId: string | null,
+  runGroupFoldingEnabled: boolean,
 ): number {
+  if (!runGroupFoldingEnabled) {
+    if (cursorGroupId === null) {
+      return Math.max(0, groups.length - INITIAL_RENDER_GROUP_COUNT);
+    }
+    const cursorIndex = groups.findIndex((group) => {
+      return group.beginMessageId === cursorGroupId;
+    });
+    return cursorIndex !== -1
+      ? cursorIndex
+      : Math.max(0, groups.length - INITIAL_RENDER_GROUP_COUNT);
+  }
+
   return runGroupVisualWindowStartIndex(
     groups,
     cursorGroupId,
     INITIAL_RENDER_GROUP_COUNT,
+  );
+}
+
+function previousRenderWindowStartIndex(
+  groups: readonly GroupedChatMessageGroup[],
+  currentStartGroupIndex: number,
+  runGroupFoldingEnabled: boolean,
+): number {
+  if (!runGroupFoldingEnabled) {
+    return Math.max(0, currentStartGroupIndex - RENDER_GROUP_LOAD_INCREMENT);
+  }
+
+  return previousRunGroupVisualWindowStartIndex(
+    groups,
+    currentStartGroupIndex,
+    RENDER_GROUP_LOAD_INCREMENT,
   );
 }
 
@@ -2141,7 +2172,11 @@ function createChatRenderWindow({
         get(renderWindowStateByThreadId$),
         threadId,
       );
-      return groups.slice(renderWindowStartIndex(groups, cursorGroupId));
+      const runGroupFoldingEnabled =
+        get(featureSwitch$)[FeatureSwitchKey.ChatRunGroupFolding] ?? false;
+      return groups.slice(
+        renderWindowStartIndex(groups, cursorGroupId, runGroupFoldingEnabled),
+      );
     },
   );
 
@@ -2153,11 +2188,17 @@ function createChatRenderWindow({
       );
       const groups = await get(groupedChatMessages$);
       signal.throwIfAborted();
-      const startIndex = renderWindowStartIndex(groups, current.cursorGroupId);
-      const nextStartIndex = previousRunGroupVisualWindowStartIndex(
+      const runGroupFoldingEnabled =
+        get(featureSwitch$)[FeatureSwitchKey.ChatRunGroupFolding] ?? false;
+      const startIndex = renderWindowStartIndex(
+        groups,
+        current.cursorGroupId,
+        runGroupFoldingEnabled,
+      );
+      const nextStartIndex = previousRenderWindowStartIndex(
         groups,
         startIndex,
-        RENDER_GROUP_LOAD_INCREMENT,
+        runGroupFoldingEnabled,
       );
       if (nextStartIndex === startIndex) {
         return false;

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -73,6 +73,10 @@ import {
   enrichBlocksWithTextPreviews,
   parseBodyRenderBlocks,
 } from "./parse-body-blocks.ts";
+import {
+  previousRunGroupVisualWindowStartIndex,
+  runGroupVisualWindowStartIndex,
+} from "./run-group-folding.ts";
 import { clerk$ } from "../auth.ts";
 import {
   patchThreadMeta$,
@@ -2097,15 +2101,11 @@ function renderWindowStartIndex(
   groups: readonly GroupedChatMessageGroup[],
   cursorGroupId: string | null,
 ): number {
-  if (cursorGroupId === null) {
-    return Math.max(0, groups.length - INITIAL_RENDER_GROUP_COUNT);
-  }
-  const cursorIndex = groups.findIndex((group) => {
-    return group.beginMessageId === cursorGroupId;
-  });
-  return cursorIndex !== -1
-    ? cursorIndex
-    : Math.max(0, groups.length - INITIAL_RENDER_GROUP_COUNT);
+  return runGroupVisualWindowStartIndex(
+    groups,
+    cursorGroupId,
+    INITIAL_RENDER_GROUP_COUNT,
+  );
 }
 
 function renderWindowStateForThread(
@@ -2154,9 +2154,10 @@ function createChatRenderWindow({
       const groups = await get(groupedChatMessages$);
       signal.throwIfAborted();
       const startIndex = renderWindowStartIndex(groups, current.cursorGroupId);
-      const nextStartIndex = Math.max(
-        0,
-        startIndex - RENDER_GROUP_LOAD_INCREMENT,
+      const nextStartIndex = previousRunGroupVisualWindowStartIndex(
+        groups,
+        startIndex,
+        RENDER_GROUP_LOAD_INCREMENT,
       );
       if (nextStartIndex === startIndex) {
         return false;

--- a/turbo/apps/platform/src/signals/chat-page/run-group-folding.ts
+++ b/turbo/apps/platform/src/signals/chat-page/run-group-folding.ts
@@ -9,12 +9,16 @@ interface RunSegment {
   readonly runId: string;
   runGroupId: string | undefined;
   readonly messages: EnrichedChatMessage[];
+  readonly startGroupIndex: number;
+  endGroupIndex: number;
 }
 
 interface LooseSegment {
   readonly runId: undefined;
   readonly runGroupId: undefined;
   readonly messages: EnrichedChatMessage[];
+  readonly startGroupIndex: number;
+  endGroupIndex: number;
 }
 
 type MessageSegment = RunSegment | LooseSegment;
@@ -124,7 +128,7 @@ function messageSegmentsFromGroups(
 ): MessageSegment[] {
   const segments: MessageSegment[] = [];
 
-  for (const group of groups) {
+  for (const [groupIndex, group] of groups.entries()) {
     for (const message of group.messages) {
       const runId = message.runId;
       if (runId === undefined) {
@@ -132,6 +136,8 @@ function messageSegmentsFromGroups(
           runId: undefined,
           runGroupId: undefined,
           messages: [message],
+          startGroupIndex: groupIndex,
+          endGroupIndex: groupIndex + 1,
         });
         continue;
       }
@@ -139,6 +145,7 @@ function messageSegmentsFromGroups(
       const last = segments[segments.length - 1];
       if (last?.runId === runId) {
         last.messages.push(message);
+        last.endGroupIndex = groupIndex + 1;
         if (last.runGroupId === undefined) {
           last.runGroupId = message.runGroupId;
         }
@@ -149,6 +156,8 @@ function messageSegmentsFromGroups(
         runId,
         runGroupId: message.runGroupId,
         messages: [message],
+        startGroupIndex: groupIndex,
+        endGroupIndex: groupIndex + 1,
       });
     }
   }
@@ -200,6 +209,175 @@ function runGroupStreakEndIndex(
     endIndex++;
   }
   return endIndex;
+}
+
+interface RunGroupVisualWindowItem {
+  readonly startGroupIndex: number;
+  readonly endGroupIndex: number;
+}
+
+function appendIndividualGroupWindowItems(
+  items: RunGroupVisualWindowItem[],
+  startGroupIndex: number,
+  endGroupIndex: number,
+  coveredGroupIndex: number,
+): number {
+  const start = Math.max(startGroupIndex, coveredGroupIndex);
+  for (let groupIndex = start; groupIndex < endGroupIndex; groupIndex++) {
+    items.push({
+      startGroupIndex: groupIndex,
+      endGroupIndex: groupIndex + 1,
+    });
+  }
+  return Math.max(coveredGroupIndex, endGroupIndex);
+}
+
+function runGroupVisualWindowItems(
+  groups: readonly GroupedChatMessageGroup[],
+): RunGroupVisualWindowItem[] {
+  const segments = messageSegmentsFromGroups(groups);
+  const items: RunGroupVisualWindowItem[] = [];
+  let coveredGroupIndex = 0;
+
+  for (let index = 0; index < segments.length; ) {
+    const segment = segments[index]!;
+    if (segment.endGroupIndex <= coveredGroupIndex) {
+      index++;
+      continue;
+    }
+
+    if (coveredGroupIndex < segment.startGroupIndex) {
+      coveredGroupIndex = appendIndividualGroupWindowItems(
+        items,
+        coveredGroupIndex,
+        segment.startGroupIndex,
+        coveredGroupIndex,
+      );
+    }
+
+    if (isGroupedRunSegment(segment)) {
+      const endIndex = runGroupStreakEndIndex(
+        segments,
+        index,
+        segment.runGroupId,
+      );
+      if (endIndex - index >= 2) {
+        const finalSegment = segments[endIndex - 1]!;
+        const startGroupIndex = Math.max(
+          segment.startGroupIndex,
+          coveredGroupIndex,
+        );
+        if (startGroupIndex < finalSegment.endGroupIndex) {
+          items.push({
+            startGroupIndex,
+            endGroupIndex: finalSegment.endGroupIndex,
+          });
+          coveredGroupIndex = finalSegment.endGroupIndex;
+        }
+        index = endIndex;
+        continue;
+      }
+    }
+
+    coveredGroupIndex = appendIndividualGroupWindowItems(
+      items,
+      segment.startGroupIndex,
+      segment.endGroupIndex,
+      coveredGroupIndex,
+    );
+    index++;
+  }
+
+  appendIndividualGroupWindowItems(
+    items,
+    coveredGroupIndex,
+    groups.length,
+    coveredGroupIndex,
+  );
+  return items;
+}
+
+function visualWindowItemIndexForGroupIndex(
+  items: readonly RunGroupVisualWindowItem[],
+  groupIndex: number,
+): number {
+  return items.findIndex((item) => {
+    return (
+      groupIndex >= item.startGroupIndex && groupIndex < item.endGroupIndex
+    );
+  });
+}
+
+function trailingRunGroupVisualWindowStartIndex(
+  items: readonly RunGroupVisualWindowItem[],
+  visibleItemCount: number,
+): number {
+  if (items.length === 0) {
+    return 0;
+  }
+  const startItemIndex = Math.max(0, items.length - visibleItemCount);
+  return items[startItemIndex]?.startGroupIndex ?? 0;
+}
+
+export function runGroupVisualWindowStartIndex(
+  groups: readonly GroupedChatMessageGroup[],
+  cursorGroupId: string | null,
+  visibleItemCount: number,
+): number {
+  if (groups.length === 0) {
+    return 0;
+  }
+  if (visibleItemCount <= 0) {
+    return groups.length;
+  }
+
+  const items = runGroupVisualWindowItems(groups);
+  if (cursorGroupId === null) {
+    return trailingRunGroupVisualWindowStartIndex(items, visibleItemCount);
+  }
+
+  const cursorGroupIndex = groups.findIndex((group) => {
+    return group.beginMessageId === cursorGroupId;
+  });
+  if (cursorGroupIndex === -1) {
+    return trailingRunGroupVisualWindowStartIndex(items, visibleItemCount);
+  }
+
+  const cursorItemIndex = visualWindowItemIndexForGroupIndex(
+    items,
+    cursorGroupIndex,
+  );
+  return cursorItemIndex === -1
+    ? trailingRunGroupVisualWindowStartIndex(items, visibleItemCount)
+    : (items[cursorItemIndex]?.startGroupIndex ?? 0);
+}
+
+export function previousRunGroupVisualWindowStartIndex(
+  groups: readonly GroupedChatMessageGroup[],
+  currentStartGroupIndex: number,
+  visibleItemCount: number,
+): number {
+  if (groups.length === 0) {
+    return 0;
+  }
+  if (visibleItemCount <= 0) {
+    return currentStartGroupIndex;
+  }
+
+  const items = runGroupVisualWindowItems(groups);
+  const currentItemIndex = visualWindowItemIndexForGroupIndex(
+    items,
+    currentStartGroupIndex,
+  );
+  const normalizedCurrentItemIndex =
+    currentItemIndex === -1
+      ? Math.max(0, items.length - visibleItemCount)
+      : currentItemIndex;
+  const previousItemIndex = Math.max(
+    0,
+    normalizedCurrentItemIndex - visibleItemCount,
+  );
+  return items[previousItemIndex]?.startGroupIndex ?? 0;
 }
 
 function buildFoldSection(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -215,6 +215,42 @@ function mockPushBrowserSupport(): PushBrowserMock {
   return { register };
 }
 
+function makeRunGroupMessages(params: {
+  readonly label: string;
+  readonly count: number;
+  readonly runGroupId: string;
+  readonly startMinute: number;
+}): PagedChatMessage[] {
+  return Array.from({ length: params.count }, (_, index) => {
+    const itemNumber = index + 1;
+    const runId = `${params.runGroupId}-run-${itemNumber}`;
+    const createdAt = new Date(
+      Date.UTC(2026, 5, 9, 10, params.startMinute + index, 0),
+    ).toISOString();
+    const assistantCreatedAt = new Date(
+      Date.UTC(2026, 5, 9, 10, params.startMinute + index, 30),
+    ).toISOString();
+    return [
+      {
+        id: `msg-${params.label.toLowerCase()}-${itemNumber}-user`,
+        role: "user" as const,
+        content: params.label,
+        runId,
+        runGroupId: params.runGroupId,
+        createdAt,
+      },
+      {
+        id: `msg-${params.label.toLowerCase()}-${itemNumber}-assistant`,
+        role: "assistant" as const,
+        content: `${params.label} reply ${itemNumber}`,
+        runId,
+        runGroupId: params.runGroupId,
+        createdAt: assistantCreatedAt,
+      },
+    ];
+  }).flat();
+}
+
 function activeRunTextarea(): Promise<HTMLTextAreaElement> {
   return waitFor(() => {
     return screen.getByPlaceholderText(
@@ -2925,6 +2961,89 @@ describe("chat lifecycle", () => {
     await Promise.resolve();
     await Promise.resolve();
     expect(screen.getByText("Render window reply 3")).toBeInTheDocument();
+  });
+
+  it("counts a folded tail run group as one item in the initial chat window", async () => {
+    const threadId = "render-window-tail-run-group";
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Tail run group window",
+      chatMessages: [
+        ...makeRunGroupMessages({
+          label: "A",
+          count: 11,
+          runGroupId: "tail-group-a",
+          startMinute: 0,
+        }),
+        ...makeRunGroupMessages({
+          label: "B",
+          count: 1,
+          runGroupId: "tail-group-b",
+          startMinute: 30,
+        }),
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: { [FeatureSwitchKey.ChatRunGroupFolding]: true },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Tail run group window")).toBeInTheDocument();
+      expect(buttonByLabel("Expand grouped run history")).toHaveTextContent(
+        "10 runs",
+      );
+      expect(screen.getByText("A reply 11")).toBeInTheDocument();
+      expect(screen.getByText("B reply 1")).toBeInTheDocument();
+      expect(screen.queryByText("A reply 10")).not.toBeInTheDocument();
+    });
+  });
+
+  it("keeps the item before a folded middle run group in the initial chat window", async () => {
+    const threadId = "render-window-middle-run-group";
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Middle run group window",
+      chatMessages: [
+        ...makeRunGroupMessages({
+          label: "A",
+          count: 1,
+          runGroupId: "middle-group-a",
+          startMinute: 0,
+        }),
+        ...makeRunGroupMessages({
+          label: "B",
+          count: 10,
+          runGroupId: "middle-group-b",
+          startMinute: 10,
+        }),
+        ...makeRunGroupMessages({
+          label: "C",
+          count: 1,
+          runGroupId: "middle-group-c",
+          startMinute: 30,
+        }),
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: { [FeatureSwitchKey.ChatRunGroupFolding]: true },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Middle run group window")).toBeInTheDocument();
+      expect(screen.getByText("A reply 1")).toBeInTheDocument();
+      expect(buttonByLabel("Expand grouped run history")).toHaveTextContent(
+        "9 runs",
+      );
+      expect(screen.getByText("B reply 10")).toBeInTheDocument();
+      expect(screen.getByText("C reply 1")).toBeInTheDocument();
+      expect(screen.queryByText("B reply 9")).not.toBeInTheDocument();
+    });
   });
 
   it("moves between chat threads with keyboard shortcuts", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -3001,6 +3001,46 @@ describe("chat lifecycle", () => {
     });
   });
 
+  it("uses physical groups for the initial window when run group folding is disabled", async () => {
+    const threadId = "render-window-run-group-folding-disabled";
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Run group render window without folding",
+      chatMessages: [
+        ...makeRunGroupMessages({
+          label: "A",
+          count: 11,
+          runGroupId: "disabled-group-a",
+          startMinute: 0,
+        }),
+        ...makeRunGroupMessages({
+          label: "B",
+          count: 1,
+          runGroupId: "disabled-group-b",
+          startMinute: 30,
+        }),
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: { [FeatureSwitchKey.ChatRunGroupFolding]: false },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Run group render window without folding"),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByLabelText("Expand grouped run history"),
+      ).not.toBeInTheDocument();
+      expect(screen.getByText("A reply 8")).toBeInTheDocument();
+      expect(screen.getByText("B reply 1")).toBeInTheDocument();
+      expect(screen.queryByText("A reply 7")).not.toBeInTheDocument();
+    });
+  });
+
   it("keeps the item before a folded middle run group in the initial chat window", async () => {
     const threadId = "render-window-middle-run-group";
     mockChatLifecycle(context, {


### PR DESCRIPTION
## Summary
- Count consecutive folded run groups as one visual item when choosing the initial chat render window.
- Use the same visual-item cursor math for upward load-more.
- Add run-group folding and page lifecycle coverage for tail and middle folded-group windows.

## Validation
- pnpm format
- pnpm turbo run lint
- NODE_OPTIONS=--max-old-space-size=4096 pnpm check-types
- pnpm vitest
- pnpm knip
- git diff --check