### PR TITLE
fix: select cloudflared package for remote architecture

### DIFF
--- a/scripts/cloudflared-ssh.sh
+++ b/scripts/cloudflared-ssh.sh
@@ -184,9 +184,17 @@ do_provision() {
   ssh "$remote" bash -s -- "$version" <<'INSTALL_SCRIPT'
 set -euo pipefail
 VERSION="$1"
+ARCH="$(dpkg --print-architecture)"
+case "$ARCH" in
+  amd64|arm64) ;;
+  *)
+    echo "Unsupported cloudflared Debian architecture: ${ARCH}" >&2
+    exit 1
+    ;;
+esac
 if ! cloudflared --version 2>/dev/null | grep -q "$VERSION"; then
   echo "Downloading cloudflared ${VERSION}..."
-  curl -sfL "https://github.com/cloudflare/cloudflared/releases/download/${VERSION}/cloudflared-linux-arm64.deb" \
+  curl -sfL "https://github.com/cloudflare/cloudflared/releases/download/${VERSION}/cloudflared-linux-${ARCH}.deb" \
     -o "/tmp/cloudflared-${VERSION}.deb"
   sudo dpkg -i "/tmp/cloudflared-${VERSION}.deb"
 else


### PR DESCRIPTION
## Summary

- Detect the remote Debian architecture before installing `cloudflared` through `scripts/cloudflared-ssh.sh`.
- Install the matching `cloudflared-linux-amd64.deb` or `cloudflared-linux-arm64.deb` package.
- Fail fast for unsupported remote Debian architectures.

## Context

The SSH tunnel provision script was hardcoded to install the ARM64 Cloudflare package. That works for existing ARM64 hosts, but fails after creating the Cloudflare tunnel and DNS record for an x86_64 GCP runner canary host.

## Testing

- `bash -n scripts/cloudflared-ssh.sh`
- Provisioned `dev-11.gcp.vm3.ai` successfully on x86_64 with the updated script.