### PR TITLE
ci: test metal runner canary hosts

### DIFF
--- a/.github/workflows/cleanup-stale.yml
+++ b/.github/workflows/cleanup-stale.yml
@@ -220,7 +220,7 @@ jobs:
       - name: Check if cleanup needed
         id: check
         env:
-          METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS_CANARY }}
           SSH_KEY: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
         run: |
           if [ -z "$SSH_KEY" ] || [ -z "$METAL_HOSTS" ]; then
@@ -269,7 +269,7 @@ jobs:
         if: steps.check.outputs.should-cleanup == 'true' && steps.prs.outputs.has-prs == 'true'
         env:
           METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
-          METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS_CANARY }}
           PR_NUMBERS: ${{ steps.prs.outputs.numbers }}
           DRY_RUN: ${{ env.DRY_RUN }}
         run: |

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Check if cleanup needed
         id: check
         env:
-          METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS_CANARY }}
           SSH_KEY: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
         run: |
           if [ -z "$SSH_KEY" ] || [ -z "$METAL_HOSTS" ]; then
@@ -46,7 +46,7 @@ jobs:
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
-          METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS_CANARY }}
         run: |
           cd ansible
           JOB_REF="pr-${PR_NUMBER}"
@@ -64,7 +64,7 @@ jobs:
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
-          METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS_CANARY }}
         run: |
           cd ansible
           JOB_REF="pr-${PR_NUMBER}"
@@ -82,7 +82,7 @@ jobs:
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
-          METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS_CANARY }}
         run: |
           cd ansible
           JOB_REF="pr-${PR_NUMBER}-test"

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -225,7 +225,7 @@ jobs:
       - name: Select runner job refs
         id: runner-job-ref
         env:
-          METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS_CANARY }}
           EVENT_NAME: ${{ github.event_name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           MQ_HEAD_REF: ${{ github.event.merge_group.head_ref }}
@@ -314,7 +314,7 @@ jobs:
       - name: Resolve runner host architecture groups
         id: groups
         env:
-          AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS_CANARY }}
           METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
         run: |
           MATRIX=$(.github/scripts/runner-host-architecture-groups.sh matrix)
@@ -501,7 +501,7 @@ jobs:
       - name: Select metal host
         id: selected-host
         env:
-          AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS_CANARY }}
           METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
           RUNNER_HOST_GROUP_ID: ${{ matrix.id }}
           JOB_REF: ${{ needs.detect.outputs.metal-job-ref }}
@@ -559,7 +559,7 @@ jobs:
       - name: Select representative metal host
         id: selected-host
         env:
-          AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS_CANARY }}
           METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
           RUNNER_HOST_GROUP_ID: ${{ needs.runner-host-groups.outputs.representative-group-id }}
           JOB_REF: ${{ needs.detect.outputs.metal-job-ref }}
@@ -620,7 +620,7 @@ jobs:
       - name: Resolve metal hosts
         id: hosts
         env:
-          AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS_CANARY }}
           METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
           RUNNER_HOST_GROUP_ID: ${{ matrix.id }}
         run: |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2273,7 +2273,7 @@ jobs:
       - name: Resolve production runner host architecture groups
         id: groups
         env:
-          AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS_CANARY }}
           METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
         shell: bash
         run: |
@@ -2349,7 +2349,7 @@ jobs:
       - name: Resolve metal hosts for architecture
         id: matrix-hosts
         env:
-          AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS_CANARY }}
           METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
           RUNNER_HOST_GROUP_ID: ${{ matrix.id }}
         shell: bash
@@ -2596,7 +2596,7 @@ jobs:
       - name: Resolve metal hosts for architecture
         id: matrix-hosts
         env:
-          AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS_CANARY }}
           METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
           RUNNER_HOST_GROUP_ID: ${{ matrix.id }}
         shell: bash

--- a/.github/workflows/rollback-runner.yml
+++ b/.github/workflows/rollback-runner.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Resolve production runner host architecture groups
         id: groups
         env:
-          AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS_CANARY }}
           METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
         shell: bash
         run: |
@@ -198,7 +198,7 @@ jobs:
       - name: Resolve metal hosts for architecture
         id: matrix-hosts
         env:
-          AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS_CANARY }}
           METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
           RUNNER_HOST_GROUP_ID: ${{ matrix.id }}
         shell: bash

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -183,7 +183,7 @@ jobs:
         id: host-group-presence
         env:
           RELEASE_SKIP: ${{ steps.identity.outputs.release-skip }}
-          AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS_CANARY }}
         run: |
           set -euo pipefail
           if [ "$RELEASE_SKIP" = "true" ]; then
@@ -222,7 +222,7 @@ jobs:
         id: host-groups
         env:
           CURRENT_RUNNER_IMAGE_NEEDED: ${{ steps.needed.outputs.current-runner-image-needed }}
-          AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS_CANARY }}
           METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
         run: |
           set -euo pipefail
@@ -296,7 +296,7 @@ jobs:
         id: matrix-hosts
         shell: bash
         env:
-          AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS_CANARY }}
           METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
           RUNNER_HOST_GROUP_ID: ${{ matrix.id }}
         run: |

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1417,7 +1417,7 @@ jobs:
       - name: Start Stripe CLI listener on one metal host
         env:
           METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
-          METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS_CANARY }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
           API_PREVIEW_URL: ${{ needs.prepare.outputs.api-preview-url }}
           STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
@@ -1853,7 +1853,7 @@ jobs:
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
           # The helper resolves per-architecture host subsets locally and emits
           # merged hash maps for deploy-runner-start.
-          AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          AWS_METAL_RUNNER_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS_CANARY }}
           METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
           PROFILE: vm0/default
         run: .github/scripts/wait-runner-image-groups.sh
@@ -1888,7 +1888,7 @@ jobs:
         env:
           METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
-          METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
+          METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS_CANARY }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
           BIN_DIR: ${{ needs.deploy-runner-prepare.outputs.bin-dir }}
           RUNNER_DIR: ${{ needs.deploy-runner-prepare.outputs.runner-dir }}


### PR DESCRIPTION
DO NOT MERGE.

This PR only switches workflow references from `secrets.AWS_METAL_RUNNER_HOSTS` to `secrets.AWS_METAL_RUNNER_HOSTS_CANARY` so CI can validate the canary metal host set.

Expected use:
- Let CI run against the canary host secret.
- Do not merge this PR.
- Close it after the canary validation is done.