### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -111,11 +111,11 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.4"
-CLAUDE_CODE_VERSION="2.1.187"
-CODEX_CLI_VERSION="0.142.0"
+CLAUDE_CODE_VERSION="2.1.191"
+CODEX_CLI_VERSION="0.142.1"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"
-AGENT_BROWSER_VERSION="0.29.1"
+AGENT_BROWSER_VERSION="0.30.1"
 PNPM_VERSION="11.9.0"
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Updates rootfs build template package pins:

- Claude Code CLI: 2.1.187 -> 2.1.191
- OpenAI Codex CLI: 0.142.0 -> 0.142.1
- agent-browser: 0.29.1 -> 0.30.1

Checked and left unchanged:

- Go: 1.26.4 is the latest stable release (1.27 is still release candidate)
- Node.js: already uses the NodeSource 24.x active LTS track
- PostgreSQL: already uses the PostgreSQL 18 package track
- @googleworkspace/cli: 0.22.5 is current
- @xdevplatform/xurl: 1.0.3 is current
- pnpm: 11.9.0 is current

Validation:

- bash -n crates/runner/scripts/build-template.sh
- git diff --check