### PR TITLE
fix: reject invalid aws sigv4 header text

### DIFF
--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -20,6 +20,8 @@ from typing import NamedTuple
 
 from mitmproxy import http
 
+from http_header_syntax import has_forbidden_header_value_control, is_http_header_name
+
 HOP_BY_HOP: frozenset[str] = frozenset(
     (
         "connection",
@@ -84,11 +86,6 @@ _AWS_SIGV4_AUTHORIZATION_PREFIXES: tuple[str, ...] = (
     "AWS4-HMAC-SHA256 ",
     "AWS4-ECDSA-P256-SHA256 ",
 )
-_HTTP_TOKEN_CHARS: frozenset[str] = frozenset(
-    "!#$%&'*+-.^_`|~0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-)
-_ASCII_CONTROL_MAX = 0x1F
-_ASCII_DELETE = 0x7F
 DEFAULT_HTTPS_PORT = 443
 MAX_AUTH_BASE_REQUEST_BODY_BYTES = 32 * 1024 * 1024
 MAX_AUTH_BASE_RESPONSE_BODY_BYTES = 32 * 1024 * 1024
@@ -329,17 +326,9 @@ def forwarded_auth_base_client_header_pairs(
 
 
 def _validate_resolved_auth_header_pair(header_name: str, header_value: str) -> None:
-    if (
-        not isinstance(header_name, str)
-        or not header_name
-        or any(char not in _HTTP_TOKEN_CHARS for char in header_name)
-    ):
+    if not isinstance(header_name, str) or not is_http_header_name(header_name):
         raise InvalidResolvedAuthHeaderError("Resolved auth header name is invalid")
-    if (
-        not isinstance(header_value, str)
-        or any(ord(char) <= _ASCII_CONTROL_MAX and char != "\t" for char in header_value)
-        or chr(_ASCII_DELETE) in header_value
-    ):
+    if not isinstance(header_value, str) or has_forbidden_header_value_control(header_value):
         raise InvalidResolvedAuthHeaderError(f"Resolved auth header {header_name} value is invalid")
     try:
         header_value.encode("latin-1")

--- a/crates/runner/mitm-addon/src/aws_sigv4.py
+++ b/crates/runner/mitm-addon/src/aws_sigv4.py
@@ -21,6 +21,8 @@ import urllib.parse
 from dataclasses import dataclass
 from enum import Enum
 
+from http_header_syntax import has_forbidden_header_value_control, is_http_header_name
+
 _AWS4_REQUEST = "aws4_request"
 _HMAC_ALGORITHM = "AWS4-HMAC-SHA256"
 _ASYMMETRIC_ALGORITHM = "AWS4-ECDSA-P256-SHA256"
@@ -28,6 +30,7 @@ _S3_SIGNING_NAMES = frozenset(("s3", "s3-outposts", "s3-object-lambda"))
 _UNSUPPORTED_S3_EXPRESS_SIGNING_NAME = "s3express"
 _STREAMING_PAYLOAD_PREFIX = "STREAMING-"
 _UNSIGNED_PAYLOAD = "UNSIGNED-PAYLOAD"
+_CONTENT_HASH_HEADER = "x-amz-content-sha256"
 _SHA256_HEX_LENGTH = 64
 _CREDENTIAL_SCOPE_PARTS = 5
 _AUTH_HEADER_PARAM_NAMES = frozenset(("Credential", "SignedHeaders", "Signature"))
@@ -48,7 +51,6 @@ _SCOPE_SERVICE_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 _AMZ_DATE_RE = re.compile(r"^\d{8}T\d{6}Z$")
 _PRESIGN_EXPIRES_RE = re.compile(r"^[1-9]\d*$")
 _ACCESS_KEY_ID_RE = re.compile(r"^[A-Za-z0-9]+$")
-_SIGNED_HEADER_NAME_RE = re.compile(r"^[A-Za-z0-9!#$%&'*+.^_`|~-]+$")
 _LOWER_HEX_DIGITS = frozenset("0123456789abcdef")
 _HEX_DIGITS = frozenset("0123456789ABCDEFabcdef")
 _RAW_WHITESPACE_CHARS = frozenset(" \t\n\r\f\v")
@@ -288,7 +290,7 @@ def _parse_signed_headers(value: str) -> frozenset[str]:
     parts = [part.strip().lower() for part in value.split(";")]
     if (
         not parts
-        or any(not part or not _SIGNED_HEADER_NAME_RE.fullmatch(part) for part in parts)
+        or any(not is_http_header_name(part) for part in parts)
         or len(parts) != len(set(parts))
     ):
         raise AwsSigV4SigningError("Malformed AWS signed headers")
@@ -506,7 +508,7 @@ def _query_payload_hash(headers: list[tuple[str, str]], body: bytes | None, is_s
 def _content_hash_header_value(headers: list[tuple[str, str]]) -> str | None:
     header_value = _unique_header_value(
         headers,
-        "x-amz-content-sha256",
+        _CONTENT_HASH_HEADER,
         "AWS content hash header is ambiguous",
     )
     if header_value is None:
@@ -685,6 +687,10 @@ def _validate_headers(headers: list[tuple[str, str]]) -> None:
     for name, value in headers:
         _utf8_encode(name, "AWS request header contains invalid text")
         _utf8_encode(value, "AWS request header contains invalid text")
+        if not is_http_header_name(name) or (
+            name.lower() != _CONTENT_HASH_HEADER and has_forbidden_header_value_control(value)
+        ):
+            raise AwsSigV4SigningError("AWS request header contains invalid text")
 
 
 def _utf8_encode(value: str, message: str) -> bytes:

--- a/crates/runner/mitm-addon/src/http_header_syntax.py
+++ b/crates/runner/mitm-addon/src/http_header_syntax.py
@@ -1,0 +1,22 @@
+"""Shared HTTP header syntax predicates.
+
+These helpers only answer syntax questions. Callers keep ownership of their
+trust-boundary-specific encoding rules, exception types, and error messages.
+"""
+
+_HTTP_TOKEN_CHARS: frozenset[str] = frozenset(
+    "!#$%&'*+-.^_`|~0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+)
+_ASCII_CONTROL_MAX = 0x1F
+_ASCII_DELETE = 0x7F
+
+
+def is_http_header_name(value: str) -> bool:
+    return bool(value) and all(char in _HTTP_TOKEN_CHARS for char in value)
+
+
+def has_forbidden_header_value_control(value: str) -> bool:
+    return any(
+        (ord(char) <= _ASCII_CONTROL_MAX and char != "\t") or ord(char) == _ASCII_DELETE
+        for char in value
+    )

--- a/crates/runner/mitm-addon/tests/test_aws_sigv4.py
+++ b/crates/runner/mitm-addon/tests/test_aws_sigv4.py
@@ -42,6 +42,21 @@ def _header_auth_headers_with_content_hash(value: str) -> list[tuple[str, str]]:
     ]
 
 
+def _header_auth_headers_with_signed_test_header(value: str) -> list[tuple[str, str]]:
+    return [
+        (
+            "Authorization",
+            "AWS4-HMAC-SHA256 "
+            "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
+            "SignedHeaders=host;x-amz-date;x-test, "
+            "Signature=placeholder",
+        ),
+        ("X-Amz-Date", "20260101T000000Z"),
+        ("Host", "sts.amazonaws.com"),
+        ("X-Test", value),
+    ]
+
+
 def _presigned_url(host: str) -> str:
     placeholder_credential = urllib.parse.quote(
         "PLACEHOLDER/20260101/us-east-1/sts/aws4_request",
@@ -243,6 +258,18 @@ def test_signed_header_invalid_unicode_raises_signing_error() -> None:
         )
 
 
+@pytest.mark.parametrize("header_value", ["a\n b", "a\r b"])
+def test_signed_header_control_character_raises_signing_error(header_value: str) -> None:
+    with pytest.raises(AwsSigV4SigningError, match="AWS request header contains invalid text"):
+        sign_request(
+            method="GET",
+            url="https://sts.amazonaws.com/",
+            headers=_header_auth_headers_with_signed_test_header(header_value),
+            body=None,
+            credentials=_credentials(),
+        )
+
+
 @pytest.mark.parametrize(
     "header",
     [
@@ -261,6 +288,44 @@ def test_unsigned_header_invalid_unicode_raises_signing_error(
             body=None,
             credentials=_credentials(),
         )
+
+
+@pytest.mark.parametrize("header_value", ["a\n b", "a\r b"])
+def test_unsigned_header_control_character_raises_signing_error(header_value: str) -> None:
+    with pytest.raises(AwsSigV4SigningError, match="AWS request header contains invalid text"):
+        sign_request(
+            method="GET",
+            url="https://sts.amazonaws.com/",
+            headers=[*_header_auth_headers(), ("x-other", header_value)],
+            body=None,
+            credentials=_credentials(),
+        )
+
+
+@pytest.mark.parametrize("header_name", ["", "x other", "x:other", "x\nother"])
+def test_header_invalid_name_raises_signing_error(header_name: str) -> None:
+    with pytest.raises(AwsSigV4SigningError, match="AWS request header contains invalid text"):
+        sign_request(
+            method="GET",
+            url="https://sts.amazonaws.com/",
+            headers=[*_header_auth_headers(), (header_name, "value")],
+            body=None,
+            credentials=_credentials(),
+        )
+
+
+def test_signed_header_tab_value_signs() -> None:
+    _url, headers = sign_request(
+        method="GET",
+        url="https://sts.amazonaws.com/",
+        headers=_header_auth_headers_with_signed_test_header("a\t b"),
+        body=None,
+        credentials=_credentials(),
+    )
+
+    by_name = {name.lower(): value for name, value in headers}
+    assert by_name["x-test"] == "a\t b"
+    assert "SignedHeaders=host;x-amz-date;x-test" in by_name["authorization"]
 
 
 def test_invalid_unicode_secret_key_raises_signing_error() -> None:

--- a/crates/runner/mitm-addon/tests/test_aws_sigv4.py
+++ b/crates/runner/mitm-addon/tests/test_aws_sigv4.py
@@ -258,7 +258,7 @@ def test_signed_header_invalid_unicode_raises_signing_error() -> None:
         )
 
 
-@pytest.mark.parametrize("header_value", ["a\n b", "a\r b"])
+@pytest.mark.parametrize("header_value", ["a\n b", "a\r b", "a\x00b", "a\x7fb"])
 def test_signed_header_control_character_raises_signing_error(header_value: str) -> None:
     with pytest.raises(AwsSigV4SigningError, match="AWS request header contains invalid text"):
         sign_request(
@@ -290,7 +290,7 @@ def test_unsigned_header_invalid_unicode_raises_signing_error(
         )
 
 
-@pytest.mark.parametrize("header_value", ["a\n b", "a\r b"])
+@pytest.mark.parametrize("header_value", ["a\n b", "a\r b", "a\x00b", "a\x7fb"])
 def test_unsigned_header_control_character_raises_signing_error(header_value: str) -> None:
     with pytest.raises(AwsSigV4SigningError, match="AWS request header contains invalid text"):
         sign_request(
@@ -302,7 +302,18 @@ def test_unsigned_header_control_character_raises_signing_error(header_value: st
         )
 
 
-@pytest.mark.parametrize("header_name", ["", "x other", "x:other", "x\nother"])
+def test_presigned_query_unsigned_header_control_character_raises_signing_error() -> None:
+    with pytest.raises(AwsSigV4SigningError, match="AWS request header contains invalid text"):
+        sign_request(
+            method="GET",
+            url=_presigned_url("sts.amazonaws.com"),
+            headers=[("Host", "sts.amazonaws.com"), ("x-other", "a\n b")],
+            body=None,
+            credentials=_credentials(),
+        )
+
+
+@pytest.mark.parametrize("header_name", ["", "x other", "x:other", "x\nother", "x\x00other"])
 def test_header_invalid_name_raises_signing_error(header_name: str) -> None:
     with pytest.raises(AwsSigV4SigningError, match="AWS request header contains invalid text"):
         sign_request(

--- a/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
@@ -701,6 +701,44 @@ async def test_header_sigv4_with_malformed_scope_fails_closed(
     assert "Malformed AWS credential scope" in flow.response.json()["message"]
 
 
+async def test_header_sigv4_with_control_character_header_fails_closed(
+    real_flow,
+    headers,
+    tmp_path,
+    mitm_ctx,
+):
+    endpoint = FakeAuthEndpoint()
+    endpoint.queue_json_response(_auth_response())
+    flow = real_flow(
+        with_response=False,
+        host="sts.amazonaws.com",
+        path="/",
+        method="POST",
+        request_headers=headers(
+            ("Host", "sts.amazonaws.com"),
+            ("X-Amz-Date", "20260101T000000Z"),
+            ("X-Test", "a\n b"),
+            (
+                "Authorization",
+                "AWS4-HMAC-SHA256 "
+                "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
+                "SignedHeaders=host;x-amz-date;x-test, "
+                "Signature=placeholder",
+            ),
+        ),
+    )
+    _prepare_firewall_request(flow)
+
+    with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
+        result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
+
+    assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
+    assert flow.response is not None
+    assert flow.response.status_code == 502
+    assert flow.response.json()["error"] == "aws_sigv4_auth_failed"
+    assert "AWS request header contains invalid text" in flow.response.json()["message"]
+
+
 async def test_header_sigv4_with_invalid_resolved_access_key_fails_closed(
     real_flow,
     headers,


### PR DESCRIPTION
## Summary

- add shared HTTP header syntax predicates for header token names and forbidden value controls
- reject malformed generic AWS SigV4 request header names and CR/LF-style values before signing
- preserve content-hash-specific validation and resolved-auth Latin-1 behavior
- add signer and firewall auth regressions for invalid SigV4 headers

Closes #18813

## Tests

- pytest tests/test_aws_sigv4.py
- pytest tests/test_firewall_aws_sigv4_auth.py
- pytest tests/test_auth_base_forwarder.py tests/test_firewall_rewrite_forwarding.py
- pytest tests/test_aws_sigv4.py tests/test_firewall_aws_sigv4_auth.py tests/test_auth_base_forwarder.py tests/test_firewall_rewrite_forwarding.py
- ruff check .
- ruff format --check .
- basedpyright -p .