### PR TITLE
feat: enable MobileSingleLineComposer and CustomConnectorProposals for all users

### DIFF
--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -315,15 +315,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "ethan@vm0.ai",
     description:
       "Default the chat composer to a single-line resting height on mobile (below the md breakpoint) instead of the three-line desktop height.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
   [FeatureSwitchKey.CustomConnectorProposals]: {
     maintainer: "ethan@vm0.ai",
     description:
       "Enable custom connector proposal cards, multi-field custom connector definitions, and agent-driven custom connector setup.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
   [FeatureSwitchKey.ComputerUseDelegatedAuthorization]: {
     maintainer: "lancy@vm0.ai",


### PR DESCRIPTION
## Summary

Flip two feature switches from staff-org gated (`enabled: false` + `STAFF_ORG_ID_HASHES`) to fully enabled (`enabled: true`), exposing both features to all users:

- `MobileSingleLineComposer` — defaults the chat composer to a single-line resting height on mobile (below the md breakpoint) instead of the three-line desktop height.
- `CustomConnectorProposals` — enables custom connector proposal cards, multi-field custom connector definitions, and agent-driven custom connector setup.

## Changes

- `turbo/packages/core/src/feature-switch.ts`: set both switches to `enabled: true` and removed the now-redundant `enabledOrgIdHashes: STAFF_ORG_ID_HASHES` lines.

## Notes

- Registry-level default change; existing individual/org overrides in the DB still take precedence.
- Feature switches are not an authorization boundary (per the registry header); the `CustomConnectorProposals` route handler still enforces its own identity checks.
- No test updates needed: existing tests seed these switches as `true` (still valid, just now redundant) and the core feature-switch tests do not reference either key.

Relies on PR CI for lint/typecheck/test validation.