### PR TITLE
fix: cap connectors popover list height so it scrolls

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -5404,7 +5404,7 @@ function ConnectorsPopoverButton({
                 })}
               </div>
             ) : (
-              <div className="flex min-h-0 flex-col overflow-y-auto">
+              <div className="flex max-h-64 min-h-0 flex-col overflow-y-auto">
                 {visibleConnectors.map((item) => {
                   return (
                     <label


### PR DESCRIPTION
## Problem

The connectors dropdown (`ConnectorsPopoverButton`) list had no explicit max-height. The popover was only bounded by the viewport (`--radix-popover-content-available-height`), so on a tall screen the connector list grew to fill the screen and pushed the **Add connectors** button and the **Your computer** section to the bottom edge before any scrolling kicked in.

## Fix

Add `max-h-64` (256px ≈ 7 rows) to the scrollable connector list. The list now caps and scrolls earlier, keeping **Add connectors** and **Your computer** always visible.

```diff
- <div className="flex min-h-0 flex-col overflow-y-auto">
+ <div className="flex max-h-64 min-h-0 flex-col overflow-y-auto">
```

Single-line className change. The separate `AddConnectorsDialog` already has its own `max-h-[80vh]`, so no change there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)