### PR TITLE
test(mitm-addon): enforce shared flow metadata keys

### DIFF
--- a/crates/runner/mitm-addon/src/usage/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/__init__.py
@@ -7,7 +7,7 @@ Two paths:
   upload to billing and/or observation endpoints through a background thread pool — see
   :mod:`usage.providers.model_provider`.
 - Billable connector responses (flagged by the web layer via
-  ``billableFirewalls`` → ``flow.metadata["firewall_billable"]``): compute
+  ``billableFirewalls`` → ``metadata_keys.FIREWALL_BILLABLE``): compute
   per-permission billable resource counts and buffer them for aggregate
   platform upload via ``/api/webhooks/agent/usage-event`` — see
   :mod:`usage.providers.connectors`.

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x_billing.py
@@ -237,8 +237,8 @@ def classify_bucket(permission: str, method: str, path: str) -> str | None:
     """Return the X billing bucket for a matched firewall request.
 
     ``permission`` is the firewall permission name set on
-    ``flow.metadata["firewall_permission"]``.  ``method`` and ``path``
-    come from ``flow.request``.
+    ``metadata_keys.FIREWALL_PERMISSION``.  ``method`` and ``path`` come from
+    ``flow.request``.
 
     Returns ``None`` for permissions that are not billable (e.g. the
     ``"app-only"`` scope).  The caller should skip emission in that

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -299,8 +299,8 @@ def fake_firewall_headers():
     Dispatcher tests that want to verify ``mitm_addon.request`` routed to
     ``handle_firewall_request`` should not patch the handler itself (that was
     the Phase-3-forbidden pattern). Instead they patch the auth-service
-    boundary behind ``get_firewall_headers`` and assert on
-    ``flow.metadata["firewall_*"]`` populated by
+    boundary behind ``get_firewall_headers`` and assert on shared firewall
+    metadata keys populated by
     ``_prepare_firewall_metadata`` at the start of the real handler, before
     auth resolution begins.
 

--- a/crates/runner/mitm-addon/tests/firewall_rewrite_helpers.py
+++ b/crates/runner/mitm-addon/tests/firewall_rewrite_helpers.py
@@ -2,6 +2,7 @@
 
 from urllib.parse import urlparse
 
+import flow_metadata_keys as metadata_keys
 from tests.firewall_auth_helpers import make_allow
 
 
@@ -46,7 +47,7 @@ def _make_rewrite_inputs(
             request_body=request_body,
             request_headers=request_headers,
         )
-    flow.metadata["vm_run_id"] = "test-run"
+    flow.metadata[metadata_keys.VM_RUN_ID] = "test-run"
 
     auth_config = {"headers": {}, "base": "${{ secrets.WEBHOOK }}"}
     if auth_overrides:

--- a/crates/runner/mitm-addon/tests/test_auth_query_injection.py
+++ b/crates/runner/mitm-addon/tests/test_auth_query_injection.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, patch
 from urllib.parse import parse_qs, urlparse
 
 import auth
+import flow_metadata_keys as metadata_keys
 from tests.firewall_auth_helpers import make_allow
 from tests.firewall_rewrite_helpers import make_forwarding_rewrite_inputs
 
@@ -19,7 +20,7 @@ def make_query_inputs(
     match_overrides=None,
 ):
     flow = real_flow(with_response=False, host=host, path=path)
-    flow.metadata["vm_run_id"] = "test-run"
+    flow.metadata[metadata_keys.VM_RUN_ID] = "test-run"
     auth_config = {
         "headers": {},
         "query": {"api_key": "${{ secrets.SERPAPI_TOKEN }}"},
@@ -91,7 +92,7 @@ class TestAuthQueryInjection:
         ):
             result = await auth.handle_firewall_request(flow, allow, vm_info)
         assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
-        assert "auth_url_rewrite" not in flow.metadata
+        assert metadata_keys.AUTH_URL_REWRITE not in flow.metadata
         assert flow.request.query["api_key"] == "resolved-key-123"
         assert flow.request.query["empty_auth"] == ""
         assert flow.request.query["space"] == "a b"
@@ -175,7 +176,7 @@ class TestAuthQueryInjection:
             mitm_ctx(),
         ):
             await auth.handle_firewall_request(flow, allow, vm_info)
-        assert flow.metadata["auth_url_rewrite"] is True
+        assert flow.metadata[metadata_keys.AUTH_URL_REWRITE] is True
         # Verify the forwarded URL contains the auth.query params
         call_args = mock_forward.call_args
         forwarded_url = call_args[0][0]
@@ -280,7 +281,7 @@ class TestAuthQueryInjection:
     async def test_no_query_injection_when_absent(self, real_flow, mitm_ctx):
         """No query modification when auth.query is not present."""
         flow = real_flow(with_response=False, host="api.github.com", path="/repos")
-        flow.metadata["vm_run_id"] = "test-run"
+        flow.metadata[metadata_keys.VM_RUN_ID] = "test-run"
         api_entry = {
             "base": "https://api.github.com",
             "auth": {"headers": {"Authorization": "Bearer ${{ secrets.TOKEN }}"}},

--- a/crates/runner/mitm-addon/tests/test_body_capture_stream_buffer.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture_stream_buffer.py
@@ -211,8 +211,8 @@ class TestBodyCaptureStreamBuffer:
             response_content_type="application/json",
             include_request_id=True,
         )
-        flow.metadata["stream_buffer"] = bytearray()
-        flow.metadata["stream_buffer_state"] = {"total_bytes": 0}
+        flow.metadata[metadata_keys.STREAM_BUFFER] = bytearray()
+        flow.metadata[metadata_keys.STREAM_BUFFER_STATE] = {"total_bytes": 0}
         entry = {}
         add_capture_fields(flow, entry)
         assert "response_body" not in entry
@@ -227,8 +227,8 @@ class TestBodyCaptureStreamBuffer:
             response_content_type="application/json",
             include_request_id=True,
         )
-        flow.metadata["stream_buffer"] = bytearray()
-        flow.metadata["stream_buffer_state"] = ["truncated"]
+        flow.metadata[metadata_keys.STREAM_BUFFER] = bytearray()
+        flow.metadata[metadata_keys.STREAM_BUFFER_STATE] = ["truncated"]
         entry = {}
         with pytest.raises(
             RuntimeError,
@@ -245,7 +245,7 @@ class TestBodyCaptureStreamBuffer:
             response_content_type="application/json",
             include_request_id=True,
         )
-        flow.metadata["stream_buffer"] = bytearray(body)
+        flow.metadata[metadata_keys.STREAM_BUFFER] = bytearray(body)
         entry = {}
         with pytest.raises(
             RuntimeError,
@@ -262,8 +262,8 @@ class TestBodyCaptureStreamBuffer:
             response_content_type="application/json",
             include_request_id=True,
         )
-        flow.metadata["stream_buffer"] = bytearray(body)
-        flow.metadata["stream_buffer_state"] = {}
+        flow.metadata[metadata_keys.STREAM_BUFFER] = bytearray(body)
+        flow.metadata[metadata_keys.STREAM_BUFFER_STATE] = {}
         entry = {}
         with pytest.raises(
             RuntimeError,
@@ -280,8 +280,8 @@ class TestBodyCaptureStreamBuffer:
             response_content_type="application/json",
             include_request_id=True,
         )
-        flow.metadata["stream_buffer"] = bytearray(body)
-        flow.metadata["stream_buffer_state"] = ["truncated"]
+        flow.metadata[metadata_keys.STREAM_BUFFER] = bytearray(body)
+        flow.metadata[metadata_keys.STREAM_BUFFER_STATE] = ["truncated"]
         entry = {}
         with pytest.raises(
             RuntimeError,
@@ -298,7 +298,7 @@ class TestBodyCaptureStreamBuffer:
             response_encoding="gzip",
             include_request_id=True,
         )
-        flow.metadata["stream_buffer"] = bytearray(gzip.compress(b""))
+        flow.metadata[metadata_keys.STREAM_BUFFER] = bytearray(gzip.compress(b""))
         entry = {}
         with pytest.raises(
             RuntimeError,
@@ -316,8 +316,8 @@ class TestBodyCaptureStreamBuffer:
             response_encoding="gzip",
             include_request_id=True,
         )
-        flow.metadata["stream_buffer"] = bytearray(compressed)
-        flow.metadata["stream_buffer_state"] = {"total_bytes": len(compressed)}
+        flow.metadata[metadata_keys.STREAM_BUFFER] = bytearray(compressed)
+        flow.metadata[metadata_keys.STREAM_BUFFER_STATE] = {"total_bytes": len(compressed)}
         entry = {}
         with pytest.raises(
             RuntimeError,
@@ -334,8 +334,8 @@ class TestBodyCaptureStreamBuffer:
             response_content_type="application/json",
             include_request_id=True,
         )
-        flow.metadata["stream_buffer"] = bytearray(body)
-        flow.metadata["stream_buffer_state"] = {"total_bytes": len(body)}
+        flow.metadata[metadata_keys.STREAM_BUFFER] = bytearray(body)
+        flow.metadata[metadata_keys.STREAM_BUFFER_STATE] = {"total_bytes": len(body)}
         entry = {}
         with pytest.raises(
             RuntimeError,

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+import flow_metadata_keys as metadata_keys
 import mitm_addon
 from body_limits import STREAM_BUFFER_LIMIT
 from tests.flow_helpers import header_map, response_stream
@@ -29,7 +30,7 @@ class TestXStreamPathRouting:
 
         mitm_addon.responseheaders(flow)
 
-        assert "x_ndjson_state" in flow.metadata
+        assert metadata_keys.X_NDJSON_STATE in flow.metadata
         assert "connector_response_finish" in flow.metadata
 
     def test_absolute_form_request_target_registers_ndjson_parser_from_original_url(
@@ -43,12 +44,12 @@ class TestXStreamPathRouting:
 
         mitm_addon.responseheaders(flow)
 
-        assert "x_ndjson_state" in flow.metadata
+        assert metadata_keys.X_NDJSON_STATE in flow.metadata
         assert "connector_response_finish" in flow.metadata
 
     def test_stream_parser_requires_original_url(self, real_flow):
         flow = self._make_x_response_flow(real_flow, "/2/tweets/search/stream")
-        flow.metadata.pop("original_url")
+        flow.metadata.pop(metadata_keys.ORIGINAL_URL)
 
         with pytest.raises(ValueError, match="original_url"):
             mitm_addon.responseheaders(flow)
@@ -69,7 +70,7 @@ class TestXStreamPathRouting:
 
         mitm_addon.responseheaders(flow)
 
-        assert "x_ndjson_state" not in flow.metadata
+        assert metadata_keys.X_NDJSON_STATE not in flow.metadata
         assert "connector_response_finish" in flow.metadata
 
     def test_stream_error_response_uses_bounded_forensic_buffer_only(self, real_flow):
@@ -81,12 +82,12 @@ class TestXStreamPathRouting:
 
         mitm_addon.responseheaders(flow)
 
-        assert "x_ndjson_state" not in flow.metadata
+        assert metadata_keys.X_NDJSON_STATE not in flow.metadata
         assert "connector_response_finish" not in flow.metadata
         callback = response_stream(flow)
         callback(b'{"title":"Unauthorized","detail":"' + b"x" * (200 * 1024) + b'"}')
-        assert len(flow.metadata["stream_buffer"]) == STREAM_BUFFER_LIMIT
-        assert flow.metadata["stream_buffer_state"]["truncated"] is True
+        assert len(flow.metadata[metadata_keys.STREAM_BUFFER]) == STREAM_BUFFER_LIMIT
+        assert flow.metadata[metadata_keys.STREAM_BUFFER_STATE]["truncated"] is True
 
     @pytest.mark.parametrize("path", ["/2/tweets", "/2/tweets/search/stream"])
     @pytest.mark.parametrize("firewall_billable", [False, None])
@@ -98,16 +99,16 @@ class TestXStreamPathRouting:
     ):
         flow = make_x_response_flow(real_flow, path=path, firewall_billable=firewall_billable)
         if firewall_billable is None:
-            flow.metadata.pop("firewall_billable")
+            flow.metadata.pop(metadata_keys.FIREWALL_BILLABLE)
 
         mitm_addon.responseheaders(flow)
 
         response_stream(flow)(b"x" * (STREAM_BUFFER_LIMIT + 1000))
 
         assert "connector_response_finish" not in flow.metadata
-        assert "x_ndjson_state" not in flow.metadata
-        assert len(flow.metadata["stream_buffer"]) == STREAM_BUFFER_LIMIT
-        assert flow.metadata["stream_buffer_state"]["truncated"] is True
+        assert metadata_keys.X_NDJSON_STATE not in flow.metadata
+        assert len(flow.metadata[metadata_keys.STREAM_BUFFER]) == STREAM_BUFFER_LIMIT
+        assert flow.metadata[metadata_keys.STREAM_BUFFER_STATE]["truncated"] is True
 
     def test_brotli_stream_path_skips_response_body_parser(self, real_flow, mitm_ctx):
         flow = self._make_x_response_flow(real_flow, "/2/tweets/search/stream")
@@ -120,17 +121,17 @@ class TestXStreamPathRouting:
             mitm_addon.responseheaders(flow)
 
         assert callable(response_stream(flow))
-        assert "x_ndjson_state" not in flow.metadata
+        assert metadata_keys.X_NDJSON_STATE not in flow.metadata
         assert "connector_response_finish" not in flow.metadata
         assert log.debug.call_count == 1
         assert "Streaming decompression skipped (br)" in log.debug.call_args[0][0]
 
     def test_unregistered_parser_factory_does_not_require_original_url(self, real_flow):
         flow = self._make_x_response_flow(real_flow, "/2/tweets/search/stream")
-        flow.metadata["firewall_name"] = "github"
-        flow.metadata.pop("original_url")
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "github"
+        flow.metadata.pop(metadata_keys.ORIGINAL_URL)
 
         mitm_addon.responseheaders(flow)
 
-        assert "x_ndjson_state" not in flow.metadata
+        assert metadata_keys.X_NDJSON_STATE not in flow.metadata
         assert "connector_response_finish" not in flow.metadata

--- a/crates/runner/mitm-addon/tests/test_connector_usage_dispatcher.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage_dispatcher.py
@@ -60,7 +60,7 @@ class TestConnectorUsageDispatcher:
         it early-returns and never reaches the X parser even when
         firewall_billable=True."""
         flow = self._make_x_flow(real_flow, tmp_path)
-        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
         assert self._call_and_get_billing(flow) == []
         proxy_log = tmp_path / "proxy.jsonl"
         if jsonl_exists_after_flush(proxy_log):
@@ -74,7 +74,7 @@ class TestConnectorUsageDispatcher:
         flow = self._make_x_flow(
             real_flow, tmp_path, path="/2/tweets/1", body=body, rule="GET /2/tweets/{id}"
         )
-        flow.metadata["firewall_name"] = firewall_name
+        flow.metadata[metadata_keys.FIREWALL_NAME] = firewall_name
 
         assert self._call_and_get_billing(flow) == []
 
@@ -89,13 +89,13 @@ class TestConnectorUsageDispatcher:
         which prevents bogus billing records if someone marks a connector
         billable without also registering a handler in ``_HANDLERS``."""
         flow = self._make_x_flow(real_flow, tmp_path)
-        flow.metadata["firewall_name"] = "github"
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "github"
         assert self._call_and_get_billing(flow) == []
 
     def test_unregistered_handler_does_not_require_original_url(self, tmp_path, real_flow):
         flow = self._make_x_flow(real_flow, tmp_path)
-        flow.metadata["firewall_name"] = "github"
-        flow.metadata.pop("original_url")
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "github"
+        flow.metadata.pop(metadata_keys.ORIGINAL_URL)
 
         assert self._call_and_get_billing(flow) == []
 
@@ -105,7 +105,7 @@ class TestConnectorUsageDispatcher:
         proxy_log = tmp_path / "proxy.jsonl"
         for _ in range(3):
             flow = self._make_x_flow(real_flow, tmp_path)
-            flow.metadata["firewall_name"] = "github"
+            flow.metadata[metadata_keys.FIREWALL_NAME] = "github"
             assert self._call_and_get_billing(flow) == []
 
         lines = [
@@ -127,7 +127,7 @@ class TestConnectorUsageDispatcher:
         proxy_log = tmp_path / "proxy.jsonl"
         for name in ("github", "slack", "github"):  # github repeats; slack new
             flow = self._make_x_flow(real_flow, tmp_path)
-            flow.metadata["firewall_name"] = name
+            flow.metadata[metadata_keys.FIREWALL_NAME] = name
             assert self._call_and_get_billing(flow) == []
 
         warned_names = [
@@ -142,7 +142,7 @@ class TestConnectorUsageDispatcher:
         violation) already logged elsewhere; don't double-warn here."""
         proxy_log = tmp_path / "proxy.jsonl"
         flow = self._make_x_flow(real_flow, tmp_path)
-        flow.metadata["firewall_name"] = ""
+        flow.metadata[metadata_keys.FIREWALL_NAME] = ""
         assert self._call_and_get_billing(flow) == []
 
         if jsonl_exists_after_flush(proxy_log):
@@ -150,7 +150,7 @@ class TestConnectorUsageDispatcher:
 
     def test_registered_x_usage_requires_original_url(self, tmp_path, real_flow, mitm_ctx):
         flow = self._make_x_flow(real_flow, tmp_path)
-        flow.metadata.pop("original_url")
+        flow.metadata.pop(metadata_keys.ORIGINAL_URL)
 
         with (
             mitm_ctx(api_url="https://api.vm0.ai"),

--- a/crates/runner/mitm-addon/tests/test_counters.py
+++ b/crates/runner/mitm-addon/tests/test_counters.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+import flow_metadata_keys as metadata_keys
 import usage
 from tests.pending_helpers import assert_current_pending, assert_pending
 from tests.usage_buffer_helpers import RecordingEnqueue, event
@@ -119,11 +120,11 @@ class TestUsagePendingCounter:
         usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
 
         flow = real_flow(with_response=False, host="api.anthropic.com")
-        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
-        flow.metadata["firewall_billable"] = True
-        flow.metadata["vm_sandbox_token"] = "tok"
-        flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
-        flow.metadata["model_provider_usage"] = {"tokens.input": 1}
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
+        flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = "tok"
+        flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = str(tmp_path / "proxy.jsonl")
+        flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {"tokens.input": 1}
 
         with mitm_ctx(api_url="https://api.test"):
             usage.report_model_provider_usage(flow, "run-1")

--- a/crates/runner/mitm-addon/tests/test_error_handler.py
+++ b/crates/runner/mitm-addon/tests/test_error_handler.py
@@ -205,11 +205,11 @@ class TestErrorHandler:
 
     def test_cleans_up_start_time(self, tmp_path, real_flow, mitm_ctx):
         flow = real_flow(with_response=False)
-        flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_network_log_path"] = str(tmp_path / "net.jsonl")
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = str(tmp_path / "net.jsonl")
         # Matches the request handler's invariant: original_url is set
         # alongside vm_run_id.
-        flow.metadata["original_url"] = "https://example.com/"
+        flow.metadata[metadata_keys.ORIGINAL_URL] = "https://example.com/"
         flow.error = Error("connection reset")
         flow.metadata[metadata_keys.HTTP_REQUEST_START_MONOTONIC] = time.monotonic()
 
@@ -221,13 +221,13 @@ class TestErrorHandler:
     def test_error_releases_unfinished_json_streaming_state(self, tmp_path, real_flow, mitm_ctx):
         """Connection errors should drop unfinished JSON parser closures."""
         flow = real_flow(with_response=False, host="api.anthropic.com")
-        flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_network_log_path"] = str(tmp_path / "net.jsonl")
-        flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
-        flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["original_url"] = "https://api.anthropic.com/v1/messages"
-        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
-        flow.metadata["firewall_billable"] = True
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = str(tmp_path / "net.jsonl")
+        flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = str(tmp_path / "proxy.jsonl")
+        flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+        flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.anthropic.com/v1/messages"
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
         flow.response = tutils.tresp(
             status_code=200,
             headers=header_map({"content-type": "application/json"}),
@@ -241,17 +241,17 @@ class TestErrorHandler:
             mitm_addon.error(flow)
 
         assert flow.response.stream is False
-        assert "stream_buffer" not in flow.metadata
-        assert "stream_buffer_state" not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
         assert "model_json_usage_finish" not in flow.metadata
-        assert "model_provider_usage" not in flow.metadata
+        assert metadata_keys.MODEL_PROVIDER_USAGE not in flow.metadata
 
     def test_error_without_run_id_releases_streaming_state(self, real_flow, mitm_ctx):
         """Early-returning error flows should still drop response parser closures."""
         flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets")
-        flow.metadata["firewall_name"] = "x"
-        flow.metadata["firewall_billable"] = True
-        flow.metadata["original_url"] = "https://api.x.com/2/tweets"
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "x"
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
+        flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.x.com/2/tweets"
         flow.response = tutils.tresp(
             status_code=200,
             headers=header_map({"content-type": "application/json"}),
@@ -266,8 +266,8 @@ class TestErrorHandler:
             mitm_addon.error(flow)
 
         assert flow.response.stream is False
-        assert "stream_buffer" not in flow.metadata
-        assert "stream_buffer_state" not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
         assert "connector_response_finish" not in flow.metadata
 
     def test_error_without_run_id_releases_request_stream_state(self, real_flow, mitm_ctx):
@@ -291,16 +291,16 @@ class TestErrorHandler:
     ):
         """Interrupted non-stream JSON must not be billed via request-hint fallback."""
         flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets?ids=1,2,3")
-        flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_network_log_path"] = str(tmp_path / "net.jsonl")
-        flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
-        flow.metadata["vm_sandbox_token"] = "test-token"
-        flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["original_url"] = "https://api.x.com/2/tweets?ids=1,2,3"
-        flow.metadata["firewall_name"] = "x"
-        flow.metadata["firewall_billable"] = True
-        flow.metadata["firewall_permission"] = "tweet.read"
-        flow.metadata["firewall_rule_match"] = "GET /2/tweets"
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = str(tmp_path / "net.jsonl")
+        flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = str(tmp_path / "proxy.jsonl")
+        flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = "test-token"
+        flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+        flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.x.com/2/tweets?ids=1,2,3"
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "x"
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
+        flow.metadata[metadata_keys.FIREWALL_PERMISSION] = "tweet.read"
+        flow.metadata[metadata_keys.FIREWALL_RULE_MATCH] = "GET /2/tweets"
         flow.response = tutils.tresp(
             status_code=200,
             headers=header_map({"content-type": "application/json"}),
@@ -315,7 +315,7 @@ class TestErrorHandler:
 
         assert webhook.request_count == 0
         assert flow.response.stream is False
-        assert "stream_buffer" not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
         assert "connector_response_finish" not in flow.metadata
 
     def test_skips_log_when_no_metadata(self, real_flow, mitm_ctx):
@@ -330,10 +330,10 @@ class TestErrorHandler:
         flow.request.method = "POST"
         log_path = str(tmp_path / "network.jsonl")
         raw_url = "https://slack.com/api/chat.postMessage?token=secret#frag"
-        flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_network_log_path"] = log_path
-        flow.metadata["original_url"] = raw_url
-        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
+        flow.metadata[metadata_keys.ORIGINAL_URL] = raw_url
+        flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
         flow.error = Error("connection reset by peer")
         flow.metadata[metadata_keys.HTTP_REQUEST_START_MONOTONIC] = time.monotonic() - 1.5
 
@@ -353,7 +353,7 @@ class TestErrorHandler:
         assert entry["error"] == "connection reset by peer"
         assert entry["latency_ms"] > 0
         assert_utc_millisecond_timestamp(entry["timestamp"])
-        assert flow.metadata["original_url"] == raw_url
+        assert flow.metadata[metadata_keys.ORIGINAL_URL] == raw_url
 
     async def test_request_classified_error_logs_network_target(
         self, registry_file, real_flow, mitm_ctx, headers
@@ -388,10 +388,10 @@ class TestErrorHandler:
     ):
         flow = real_flow(with_response=False, host="fallback.example.com", port=9443)
         log_path = str(tmp_path / "network.jsonl")
-        flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_network_log_path"] = log_path
-        flow.metadata["original_url"] = "https://invalid.example.com:bad/path"
-        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
+        flow.metadata[metadata_keys.ORIGINAL_URL] = "https://invalid.example.com:bad/path"
+        flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
         flow.error = Error("connection reset by peer")
 
         with mitm_ctx():
@@ -415,10 +415,10 @@ class TestErrorHandler:
         log_path = str(tmp_path / "network.jsonl")
         body = b"abcdef"
 
-        flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_network_log_path"] = log_path
-        flow.metadata["original_url"] = "https://api.example.com/"
-        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
+        flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.example.com/"
+        flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
         flow.error = Error("connection reset by peer")
 
         request_streaming.configure_request_stream(flow)
@@ -440,14 +440,14 @@ class TestErrorHandler:
     def test_error_includes_firewall_context(self, tmp_path, real_flow, mitm_ctx):
         flow = real_flow(with_response=False, host="slack.com")
         log_path = str(tmp_path / "network.jsonl")
-        flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_network_log_path"] = log_path
-        flow.metadata["original_url"] = "https://slack.com/api/chat.postMessage"
-        flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["firewall_base"] = "https://slack.com/api"
-        flow.metadata["firewall_name"] = "slack"
-        flow.metadata["firewall_permission"] = "chat:write"
-        flow.metadata["firewall_rule_match"] = "POST /chat.postMessage"
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
+        flow.metadata[metadata_keys.ORIGINAL_URL] = "https://slack.com/api/chat.postMessage"
+        flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+        flow.metadata[metadata_keys.FIREWALL_BASE] = "https://slack.com/api"
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "slack"
+        flow.metadata[metadata_keys.FIREWALL_PERMISSION] = "chat:write"
+        flow.metadata[metadata_keys.FIREWALL_RULE_MATCH] = "POST /chat.postMessage"
         flow.error = Error("timed out")
 
         with mitm_ctx():
@@ -465,10 +465,10 @@ class TestErrorHandler:
         flow = real_flow(with_response=False, host="slack.com")
         log_path = str(tmp_path / "network.jsonl")
         proxy_log = tmp_path / "proxy-run-abc-123.jsonl"
-        flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_network_log_path"] = log_path
-        flow.metadata["vm_proxy_log_path"] = str(proxy_log)
-        flow.metadata["original_url"] = "https://slack.com/api/test?api_key=secret#frag"
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
+        flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = str(proxy_log)
+        flow.metadata[metadata_keys.ORIGINAL_URL] = "https://slack.com/api/test?api_key=secret#frag"
         flow.error = Error("connection reset by peer")
 
         mitm_addon.error(flow)
@@ -488,15 +488,15 @@ class TestErrorHandler:
         """
         flow = real_flow(with_response=False, host="api.anthropic.com")
         log_path = str(tmp_path / "network.jsonl")
-        flow.metadata["vm_run_id"] = "run-int-002"
-        flow.metadata["vm_network_log_path"] = log_path
-        flow.metadata["original_url"] = "https://api.anthropic.com/v1/messages"
-        flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
-        flow.metadata["firewall_billable"] = True
-        flow.metadata["model_usage_provider"] = "claude-sonnet-4-6"
-        flow.metadata["vm_sandbox_token"] = "tok-xyz"
-        flow.metadata["model_provider_usage"] = {
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-int-002"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
+        flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.anthropic.com/v1/messages"
+        flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
+        flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "claude-sonnet-4-6"
+        flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = "tok-xyz"
+        flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {
             "model": "claude-sonnet-4-6",
             "tokens.input": 80,
         }

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -13,6 +13,7 @@ import pytest
 import auth
 import firewall_auth_cache as auth_cache
 import firewall_auth_client as auth_client
+import flow_metadata_keys as metadata_keys
 import matching
 import platform_api
 from aws_sigv4 import AwsSigV4Credentials
@@ -117,7 +118,7 @@ def _firewall_flow(
     run_id: str = "test-run",
 ):
     flow = real_flow(with_response=False, host=host, path=path)
-    flow.metadata["vm_run_id"] = run_id
+    flow.metadata[metadata_keys.VM_RUN_ID] = run_id
     return flow
 
 
@@ -727,7 +728,7 @@ class TestHandleFirewallRequest:
     ):
         flow = _firewall_flow(real_flow)
         proxy_log_path = tmp_path / "proxy.jsonl"
-        flow.metadata["vm_proxy_log_path"] = str(proxy_log_path)
+        flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = str(proxy_log_path)
         api_entry = _api_entry(
             api_id="run-1:0",
             auth_config={"headers": {"Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"}},
@@ -752,21 +753,21 @@ class TestHandleFirewallRequest:
         assert flow.request.headers["X-Custom"] == "value"
 
         # Token replacement metadata
-        assert flow.metadata["auth_resolved_secrets"] == ["GITHUB_TOKEN"]
-        assert flow.metadata["auth_refreshed_connectors"] == []
-        assert flow.metadata["auth_refreshed_secrets"] == []
-        assert flow.metadata["auth_cache_hit"] is False
+        assert flow.metadata[metadata_keys.AUTH_RESOLVED_SECRETS] == ["GITHUB_TOKEN"]
+        assert flow.metadata[metadata_keys.AUTH_REFRESHED_CONNECTORS] == []
+        assert flow.metadata[metadata_keys.AUTH_REFRESHED_SECRETS] == []
+        assert flow.metadata[metadata_keys.AUTH_CACHE_HIT] is False
 
         # Core metadata
-        assert flow.metadata["firewall_action"] == "ALLOW"
-        assert flow.metadata["firewall_base"] == "https://api.github.com"
-        assert flow.metadata["firewall_api_id"] == "run-1:0"
+        assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+        assert flow.metadata[metadata_keys.FIREWALL_BASE] == "https://api.github.com"
+        assert flow.metadata[metadata_keys.FIREWALL_API_ID] == "run-1:0"
 
         # Audit metadata
-        assert flow.metadata["firewall_name"] == "github"
-        assert flow.metadata["firewall_permission"] == "repo-read"
-        assert flow.metadata["firewall_rule_match"] == "GET /repos/{owner}/{repo}"
-        assert flow.metadata["firewall_params"] == {"owner": "octocat", "repo": "hello"}
+        assert flow.metadata[metadata_keys.FIREWALL_NAME] == "github"
+        assert flow.metadata[metadata_keys.FIREWALL_PERMISSION] == "repo-read"
+        assert flow.metadata[metadata_keys.FIREWALL_RULE_MATCH] == "GET /repos/{owner}/{repo}"
+        assert flow.metadata[metadata_keys.FIREWALL_PARAMS] == {"owner": "octocat", "repo": "hello"}
         log_text = await asyncio.to_thread(read_jsonl_text_after_flush, proxy_log_path)
         assert "Firewall https://api.github.com: api.github.com" in log_text
 
@@ -847,8 +848,8 @@ class TestHandleFirewallRequest:
                 ("Authorization", placeholder_authorization),
             ),
         )
-        flow.metadata["vm_run_id"] = "test-run"
-        flow.metadata["original_url"] = get_original_url(flow)
+        flow.metadata[metadata_keys.VM_RUN_ID] = "test-run"
+        flow.metadata[metadata_keys.ORIGINAL_URL] = get_original_url(flow)
         api_entry = _api_entry(
             base="https://sts.amazonaws.com",
             auth_config={
@@ -932,8 +933,8 @@ class TestHandleFirewallRequest:
         assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
         assert flow.response is not None
         assert flow.response.status_code == 502
-        assert flow.metadata["firewall_action"] == "ALLOW"
-        assert flow.metadata["firewall_error"] == "invalid_resolved_auth_header"
+        assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+        assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "invalid_resolved_auth_header"
         assert "Authorization" not in flow.request.headers
         assert "api_key" not in flow.request.query
         assert flow.request.query["existing"] == "1"
@@ -959,7 +960,7 @@ class TestHandleFirewallRequest:
         ):
             await auth.handle_firewall_request(flow, allow, vm_info)
 
-        assert flow.metadata["firewall_billable"] is False
+        assert flow.metadata[metadata_keys.FIREWALL_BILLABLE] is False
 
     async def test_failure_returns_502(self, real_flow, headers, mitm_ctx, tmp_path):
         flow = _firewall_flow(real_flow)
@@ -981,8 +982,8 @@ class TestHandleFirewallRequest:
         assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
         assert flow.response is not None
         assert flow.response.status_code == 502
-        assert flow.metadata["firewall_action"] == "ALLOW"
-        assert flow.metadata["firewall_error"] == "auth_failed"
+        assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+        assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "auth_failed"
         body = json.loads(flow.response.content)
         assert body["error"] == "auth_failed"
         assert "API unreachable" in body["message"]
@@ -1029,8 +1030,8 @@ class TestHandleFirewallRequest:
 
         assert flow.response is not None
         assert flow.response.status_code == 502
-        assert flow.metadata["firewall_action"] == "ALLOW"
-        assert flow.metadata["firewall_error"] == "auth_failed"
+        assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+        assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "auth_failed"
         assert "Authorization" not in flow.request.headers
         body = json.loads(flow.response.content)
         assert body["error"] == "auth_failed"
@@ -1067,8 +1068,8 @@ class TestHandleFirewallRequest:
 
         assert flow.response is not None
         assert flow.response.status_code == 502
-        assert flow.metadata["firewall_action"] == "ALLOW"
-        assert flow.metadata["firewall_error"] == "auth_failed"
+        assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+        assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "auth_failed"
         assert "Authorization" not in flow.request.headers
         assert "api_key" not in flow.request.query
         assert flow.request.query["existing"] == "1"
@@ -1111,8 +1112,8 @@ class TestHandleFirewallRequest:
 
         assert flow.response is not None
         assert flow.response.status_code == 502
-        assert flow.metadata["firewall_action"] == "ALLOW"
-        assert flow.metadata["firewall_error"] == "auth_failed"
+        assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+        assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "auth_failed"
         assert "Authorization" not in flow.request.headers
         assert "api_key" not in flow.request.query
         assert flow.request.query["existing"] == "1"
@@ -1150,8 +1151,8 @@ class TestHandleFirewallRequest:
 
         assert flow.response is not None
         assert flow.response.status_code == 502
-        assert flow.metadata["firewall_action"] == "ALLOW"
-        assert flow.metadata["firewall_error"] == "auth_failed"
+        assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+        assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "auth_failed"
         assert "Authorization" not in flow.request.headers
         assert "api_key" not in flow.request.query
         assert flow.request.query["existing"] == "1"
@@ -1191,8 +1192,8 @@ class TestHandleFirewallRequest:
         assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
         assert flow.response is not None
         assert flow.response.status_code == 502
-        assert flow.metadata["firewall_action"] == "ALLOW"
-        assert flow.metadata["firewall_error"] == "TOKEN_REFRESH_FAILED"
+        assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+        assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "TOKEN_REFRESH_FAILED"
         body = json.loads(flow.response.content)
         assert body["error"] == "TOKEN_REFRESH_FAILED"
         assert body["message"] == "Access token expired and refresh failed for: codex-oauth-token."
@@ -1231,8 +1232,8 @@ class TestHandleFirewallRequest:
         assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
         assert flow.response is not None
         assert flow.response.status_code == 403
-        assert flow.metadata["firewall_action"] == "BLOCK"
-        assert flow.metadata["firewall_error"] == "FORBIDDEN"
+        assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "BLOCK"
+        assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "FORBIDDEN"
         assert "Authorization" not in flow.request.headers
         assert "api_key" not in flow.request.query
         assert flow.request.query["existing"] == "1"
@@ -1246,7 +1247,7 @@ class TestHandleFirewallRequest:
     async def test_invalid_billable_auth_expiry_returns_502(self, real_flow, mitm_ctx, tmp_path):
         flow = _firewall_flow(real_flow)
         proxy_log_path = tmp_path / "proxy.jsonl"
-        flow.metadata["vm_proxy_log_path"] = str(proxy_log_path)
+        flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = str(proxy_log_path)
         api_entry = _api_entry()
         vm_info = _vm_info(tmp_path, billable_firewalls=["github"])
         allow = _allow(api_entry)
@@ -1271,10 +1272,10 @@ class TestHandleFirewallRequest:
         assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
         assert flow.response is not None
         assert flow.response.status_code == 502
-        assert flow.metadata["firewall_action"] == "ALLOW"
-        assert flow.metadata["firewall_error"] == "invalid_auth_expiry"
+        assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+        assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "invalid_auth_expiry"
         assert "Authorization" not in flow.request.headers
-        assert "auth_url_rewrite" not in flow.metadata
+        assert metadata_keys.AUTH_URL_REWRITE not in flow.metadata
         assert "api_key" not in flow.request.query
         assert cached_headers(("test-run", "https://api.github.com")) is None
         body = json.loads(flow.response.content)
@@ -1340,8 +1341,8 @@ class TestHandleFirewallRequest:
         assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
         assert flow.response is not None
         assert flow.response.status_code == 424
-        assert flow.metadata["firewall_action"] == "BLOCK"
-        assert flow.metadata["firewall_error"] == "connector_not_configured"
+        assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "BLOCK"
+        assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "connector_not_configured"
         body = json.loads(flow.response.content)
         assert body["error"] == "connector_not_configured"
         assert body["message"] == "Connector not configured"
@@ -1370,8 +1371,8 @@ class TestHandleFirewallRequest:
         assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
         assert flow.response is not None
         assert flow.response.status_code == 402
-        assert flow.metadata["firewall_action"] == "BLOCK"
-        assert flow.metadata["firewall_error"] == "insufficient_credits"
+        assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "BLOCK"
+        assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "insufficient_credits"
         body = json.loads(flow.response.content)
         assert body["error"] == "insufficient_credits"
         assert body["message"] == "Insufficient credits"
@@ -1405,8 +1406,8 @@ class TestHandleFirewallRequest:
 
         assert flow.response is not None
         assert flow.response.status_code == 424
-        assert flow.metadata["firewall_action"] == "BLOCK"
-        assert flow.metadata["firewall_error"] == "connector_not_configured"
+        assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "BLOCK"
+        assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "connector_not_configured"
         body = json.loads(flow.response.content)
         assert body["error"] == "connector_not_configured"
         assert body["message"] == "Connector not configured"
@@ -1456,8 +1457,8 @@ class TestHandleFirewallRequest:
         assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
         assert flow.response is not None
         assert flow.response.status_code == 502
-        assert flow.metadata["firewall_action"] == "ALLOW"
-        assert flow.metadata["firewall_error"] == "auth_unavailable"
+        assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+        assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "auth_unavailable"
         body = json.loads(flow.response.content)
         assert body["error"] == "auth_unavailable"
         assert body["message"] == "Auth secrets not configured"

--- a/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
@@ -109,7 +109,7 @@ async def test_re_signs_header_sigv4_request(real_flow, headers, tmp_path, mitm_
     assert "PLACEHOLDER" not in authorization
     assert "Signature=placeholder" not in authorization
     assert flow.request.headers["x-amz-security-token"] == "real-session-token"
-    assert flow.metadata["auth_resolved_secrets"] == [
+    assert flow.metadata[metadata_keys.AUTH_RESOLVED_SECRETS] == [
         "AWS_ACCESS_KEY_ID",
         "AWS_SECRET_ACCESS_KEY",
         "AWS_SESSION_TOKEN",

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite_forwarding.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite_forwarding.py
@@ -7,6 +7,7 @@ from urllib.parse import parse_qs, urlparse
 
 import auth
 import auth_base_forwarder as forwarder
+import flow_metadata_keys as metadata_keys
 from aws_sigv4 import AwsSigV4Credentials
 from generated.builtin_firewalls import BUILTIN_FIREWALLS
 from tests.auth_base_forwarder_helpers import fake_forwarder_upstream
@@ -70,7 +71,7 @@ class TestAuthBaseUrlRewriteForwarding:
             },
         )
         proxy_log_path = tmp_path / "proxy.jsonl"
-        flow.metadata["vm_proxy_log_path"] = str(proxy_log_path)
+        flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = str(proxy_log_path)
 
         with (
             fake_forwarder_upstream(
@@ -124,12 +125,12 @@ class TestAuthBaseUrlRewriteForwarding:
         assert ("Content-Type", "application/json") in response_pairs
         assert ("X-Upstream", "real") in response_pairs
 
-        assert flow.metadata["auth_url_rewrite"] is True
-        assert flow.metadata["auth_resolved_secrets"] == ["WEBHOOK", "API_KEY"]
-        assert flow.metadata["auth_refreshed_connectors"] == ["discord"]
-        assert flow.metadata["auth_refreshed_secrets"] == ["WEBHOOK"]
-        assert flow.metadata["auth_cache_hit"] is False
-        assert "firewall_error" not in flow.metadata
+        assert flow.metadata[metadata_keys.AUTH_URL_REWRITE] is True
+        assert flow.metadata[metadata_keys.AUTH_RESOLVED_SECRETS] == ["WEBHOOK", "API_KEY"]
+        assert flow.metadata[metadata_keys.AUTH_REFRESHED_CONNECTORS] == ["discord"]
+        assert flow.metadata[metadata_keys.AUTH_REFRESHED_SECRETS] == ["WEBHOOK"]
+        assert flow.metadata[metadata_keys.AUTH_CACHE_HIT] is False
+        assert metadata_keys.FIREWALL_ERROR not in flow.metadata
 
         assert flow.request.path == "/hook?client=visible"
         assert flow.request.headers["Authorization"] == "Bearer agent"
@@ -169,7 +170,7 @@ class TestAuthBaseUrlRewriteForwarding:
             mitm_ctx(),
         ):
             await auth.handle_firewall_request(flow, allow, vm_info)
-        assert flow.metadata["auth_url_rewrite"] is True
+        assert flow.metadata[metadata_keys.AUTH_URL_REWRITE] is True
         assert upstream.socket.request_header_values("Authorization") == ["Bearer real-token"]
         assert upstream.socket.request_header_values("X-Api-Key") == ["real-api-key"]
         assert upstream.socket.request_header_values("X-Custom") == ["injected-value"]
@@ -391,8 +392,8 @@ class TestAuthBaseUrlRewriteForwarding:
         mock_forward.assert_not_called()
         assert flow.response is not None
         assert flow.response.status_code == 502
-        assert flow.metadata["firewall_action"] == "ALLOW"
-        assert flow.metadata["firewall_error"] == "invalid_resolved_auth_header"
+        assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+        assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "invalid_resolved_auth_header"
         body = json.loads(flow.response.content)
         assert body["error"] == "invalid_resolved_auth_header"
 
@@ -659,10 +660,10 @@ class TestAuthBaseUrlRewriteForwarding:
             "permission": allow.name,
             "base": allow.api_entry["base"],
         }
-        assert flow.metadata["firewall_action"] == "ALLOW"
-        assert flow.metadata["firewall_error"] == "auth_base_request_body_too_large"
-        assert "auth_url_rewrite" not in flow.metadata
-        assert "auth_resolved_secrets" not in flow.metadata
+        assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+        assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "auth_base_request_body_too_large"
+        assert metadata_keys.AUTH_URL_REWRITE not in flow.metadata
+        assert metadata_keys.AUTH_RESOLVED_SECRETS not in flow.metadata
         response_text = flow.response.text
         assert "super-secret-body" not in response_text
         assert "super-secret-token" not in response_text
@@ -709,9 +710,9 @@ class TestAuthBaseUrlRewriteForwarding:
         assert flow.response.status_code == 413
         body = json.loads(flow.response.content)
         assert body["error"] == "auth_base_request_body_too_large"
-        assert flow.metadata["firewall_action"] == "ALLOW"
-        assert flow.metadata["firewall_error"] == "auth_base_request_body_too_large"
-        assert "auth_url_rewrite" not in flow.metadata
+        assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+        assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "auth_base_request_body_too_large"
+        assert metadata_keys.AUTH_URL_REWRITE not in flow.metadata
         assert "url_rewrite_forward_failed" not in flow.response.text
         assert "super-secret-token" not in flow.response.text
         assert "Bearer real-token" not in flow.response.text
@@ -750,9 +751,9 @@ class TestAuthBaseUrlRewriteForwarding:
         assert get_headers.await_count == 1
         assert flow.response is None
         assert flow.request.headers["Authorization"] == "Bearer real-token"
-        assert flow.metadata["firewall_action"] == "ALLOW"
-        assert "firewall_error" not in flow.metadata
-        assert "auth_url_rewrite" not in flow.metadata
+        assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+        assert metadata_keys.FIREWALL_ERROR not in flow.metadata
+        assert metadata_keys.AUTH_URL_REWRITE not in flow.metadata
 
     async def test_forward_failure_returns_502(self, headers, real_flow, mitm_ctx, tmp_path):
         """forward_request exception produces a 502 error response and marks
@@ -784,7 +785,7 @@ class TestAuthBaseUrlRewriteForwarding:
             },
         )
         proxy_log_path = tmp_path / "proxy.jsonl"
-        flow.metadata["vm_proxy_log_path"] = str(proxy_log_path)
+        flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = str(proxy_log_path)
         mock_forward = AsyncMock(side_effect=Exception("connection refused"))
         with (
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
@@ -811,13 +812,13 @@ class TestAuthBaseUrlRewriteForwarding:
         assert body["base"] == allow.api_entry["base"]
         assert "connectors" not in body
         # Failure must not masquerade as a successful rewrite.
-        assert "auth_url_rewrite" not in flow.metadata
-        assert flow.metadata["firewall_action"] == "ALLOW"
-        assert flow.metadata["firewall_error"] == "url_rewrite_forward_failed"
-        assert "auth_resolved_secrets" not in flow.metadata
-        assert "auth_refreshed_connectors" not in flow.metadata
-        assert "auth_refreshed_secrets" not in flow.metadata
-        assert "auth_cache_hit" not in flow.metadata
+        assert metadata_keys.AUTH_URL_REWRITE not in flow.metadata
+        assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+        assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "url_rewrite_forward_failed"
+        assert metadata_keys.AUTH_RESOLVED_SECRETS not in flow.metadata
+        assert metadata_keys.AUTH_REFRESHED_CONNECTORS not in flow.metadata
+        assert metadata_keys.AUTH_REFRESHED_SECRETS not in flow.metadata
+        assert metadata_keys.AUTH_CACHE_HIT not in flow.metadata
         assert flow.request.headers["Authorization"] == "Bearer agent"
         assert "X-Custom" not in flow.request.headers
         assert "api_key" not in flow.request.query

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite_safety.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite_safety.py
@@ -9,6 +9,7 @@ import pytest
 
 import auth
 import auth_base_forwarder as forwarder
+import flow_metadata_keys as metadata_keys
 from tests.auth_base_forwarder_helpers import fake_forwarder_upstream
 from tests.firewall_rewrite_helpers import make_safety_rewrite_inputs
 from tests.jsonl_log_helpers import read_jsonl_text_after_flush
@@ -83,8 +84,8 @@ class TestAuthBaseUrlRewriteSafety:
         assert mock_forward.call_count == 1
         assert flow.response is not None
         assert flow.response.status_code == 502
-        assert flow.metadata["firewall_error"] == "url_rewrite_forward_failed"
-        assert "auth_url_rewrite" not in flow.metadata
+        assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "url_rewrite_forward_failed"
+        assert metadata_keys.AUTH_URL_REWRITE not in flow.metadata
         assert flow.request.headers["Authorization"] == "Bearer agent"
         assert "X-Custom" not in flow.request.headers
         assert "api_key" not in flow.request.query
@@ -120,7 +121,7 @@ class TestAuthBaseUrlRewriteSafety:
             },
         )
         proxy_log_path = tmp_path / "proxy.jsonl"
-        flow.metadata["vm_proxy_log_path"] = str(proxy_log_path)
+        flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = str(proxy_log_path)
 
         with (
             fake_forwarder_upstream(addresses=("127.0.0.1",)) as upstream,
@@ -142,13 +143,13 @@ class TestAuthBaseUrlRewriteSafety:
         assert body["base"] == allow.api_entry["base"]
         assert "connectors" not in body
 
-        assert flow.metadata["firewall_action"] == "ALLOW"
-        assert flow.metadata["firewall_error"] == "url_rewrite_forward_failed"
-        assert "auth_url_rewrite" not in flow.metadata
-        assert "auth_resolved_secrets" not in flow.metadata
-        assert "auth_refreshed_connectors" not in flow.metadata
-        assert "auth_refreshed_secrets" not in flow.metadata
-        assert "auth_cache_hit" not in flow.metadata
+        assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+        assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "url_rewrite_forward_failed"
+        assert metadata_keys.AUTH_URL_REWRITE not in flow.metadata
+        assert metadata_keys.AUTH_RESOLVED_SECRETS not in flow.metadata
+        assert metadata_keys.AUTH_REFRESHED_CONNECTORS not in flow.metadata
+        assert metadata_keys.AUTH_REFRESHED_SECRETS not in flow.metadata
+        assert metadata_keys.AUTH_CACHE_HIT not in flow.metadata
 
         assert flow.request.headers["Authorization"] == "Bearer agent"
         assert flow.request.path == "/hook?client=visible"
@@ -197,7 +198,7 @@ class TestAuthBaseUrlRewriteSafety:
         assert mock_forward.call_count == 0
         assert flow.response is not None
         assert flow.response.status_code == 502
-        assert flow.metadata["firewall_error"] == "url_rewrite_forward_failed"
+        assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "url_rewrite_forward_failed"
         assert "super-secret-token" not in flow.response.text
         assert flow.request.headers["Authorization"] == "Bearer agent"
         assert "X-Custom" not in flow.request.headers
@@ -230,7 +231,7 @@ class TestAuthBaseUrlRewriteSafety:
         assert flow.response is not None
         assert flow.response.status_code == 502
         assert "super-secret-token" not in flow.response.text
-        assert flow.metadata["firewall_error"] == "url_rewrite_forward_failed"
+        assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "url_rewrite_forward_failed"
         for log_call in mock_log.call_args_list:
             assert "super-secret-token" not in json.dumps(log_call.args)
             assert "super-secret-token" not in json.dumps(log_call.kwargs)
@@ -265,8 +266,8 @@ class TestAuthBaseUrlRewriteSafety:
         assert mock_forward.call_count == 0
         assert flow.response is not None
         assert flow.response.status_code == 502
-        assert flow.metadata["firewall_error"] == "url_rewrite_forward_failed"
-        assert "auth_url_rewrite" not in flow.metadata
+        assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "url_rewrite_forward_failed"
+        assert metadata_keys.AUTH_URL_REWRITE not in flow.metadata
         assert "super-secret-token" not in flow.response.text
         for log_call in mock_log.call_args_list:
             assert "super-secret-token" not in json.dumps(log_call.args)
@@ -313,7 +314,7 @@ class TestAuthBaseUrlRewriteSafety:
         assert mock_forward.call_count == 0
         assert flow.response is not None
         assert flow.response.status_code == 502
-        assert flow.metadata["firewall_error"] == "url_rewrite_forward_failed"
+        assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "url_rewrite_forward_failed"
         for log_call in mock_log.call_args_list:
             assert "super-secret-token" not in json.dumps(log_call.args)
             assert "super-secret-token" not in json.dumps(log_call.kwargs)
@@ -344,7 +345,7 @@ class TestAuthBaseUrlRewriteSafety:
         assert updated_url.scheme == original_url.scheme
         assert updated_url.netloc == original_url.netloc
         assert updated_url.path == original_url.path
-        assert "auth_url_rewrite" not in flow.metadata
+        assert metadata_keys.AUTH_URL_REWRITE not in flow.metadata
         assert flow.request.headers["Authorization"] == "Bearer real-token"
         assert flow.request.query["api_key"] == "resolved-key"
-        assert flow.metadata["auth_resolved_secrets"] == ["TOKEN", "API_KEY"]
+        assert flow.metadata[metadata_keys.AUTH_RESOLVED_SECRETS] == ["TOKEN", "API_KEY"]

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite_success.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite_success.py
@@ -4,6 +4,7 @@ import asyncio
 from unittest.mock import AsyncMock, patch
 
 import auth
+import flow_metadata_keys as metadata_keys
 from tests.auth_base_forwarder_helpers import fake_forwarder_upstream
 from tests.firewall_rewrite_helpers import make_allow, make_success_rewrite_inputs
 from tests.jsonl_log_helpers import read_jsonl_text_after_flush
@@ -15,7 +16,7 @@ class TestAuthBaseUrlRewriteSuccess:
     async def test_no_url_rewrite_when_auth_base_absent(self, real_flow, mitm_ctx, tmp_path):
         """Without auth.base, no URL rewriting happens (existing behavior)."""
         flow = real_flow(with_response=False, host="api.github.com", path="/repos")
-        flow.metadata["vm_run_id"] = "test-run"
+        flow.metadata[metadata_keys.VM_RUN_ID] = "test-run"
         original_url = flow.request.url
         api_entry = {
             "base": "https://api.github.com",
@@ -63,7 +64,7 @@ class TestAuthBaseUrlRewriteSuccess:
             },
         )
         proxy_log_path = tmp_path / "proxy.jsonl"
-        flow.metadata["vm_proxy_log_path"] = str(proxy_log_path)
+        flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = str(proxy_log_path)
         with (
             fake_forwarder_upstream(
                 body=b'{"ok":true}', headers=[("Content-Type", "application/json")]
@@ -73,12 +74,12 @@ class TestAuthBaseUrlRewriteSuccess:
         ):
             result = await auth.handle_firewall_request(flow, allow, vm_info)
         assert result is auth.FirewallAuthHandlingResult.INLINE_PROVIDER_RESPONSE
-        assert flow.metadata["auth_url_rewrite"] is True
-        assert flow.metadata["firewall_action"] == "ALLOW"
-        assert flow.metadata["auth_resolved_secrets"] == ["WEBHOOK"]
-        assert flow.metadata["auth_refreshed_connectors"] == ["discord"]
-        assert flow.metadata["auth_refreshed_secrets"] == ["WEBHOOK"]
-        assert flow.metadata["auth_cache_hit"] is False
+        assert flow.metadata[metadata_keys.AUTH_URL_REWRITE] is True
+        assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+        assert flow.metadata[metadata_keys.AUTH_RESOLVED_SECRETS] == ["WEBHOOK"]
+        assert flow.metadata[metadata_keys.AUTH_REFRESHED_CONNECTORS] == ["discord"]
+        assert flow.metadata[metadata_keys.AUTH_REFRESHED_SECRETS] == ["WEBHOOK"]
+        assert flow.metadata[metadata_keys.AUTH_CACHE_HIT] is False
         assert flow.response is not None
         assert flow.response.status_code == 200
         log_text = await asyncio.to_thread(read_jsonl_text_after_flush, proxy_log_path)
@@ -103,14 +104,14 @@ class TestAuthBaseUrlRewriteSuccess:
         assert flow.response is not None
         assert flow.response.status_code == 500
         assert flow.response.content == b'{"error":"upstream"}'
-        assert flow.metadata["auth_url_rewrite"] is True
-        assert flow.metadata["firewall_action"] == "ALLOW"
-        assert "firewall_error" not in flow.metadata
+        assert flow.metadata[metadata_keys.AUTH_URL_REWRITE] is True
+        assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+        assert metadata_keys.FIREWALL_ERROR not in flow.metadata
 
     async def test_no_auth_url_rewrite_metadata_when_no_base(self, real_flow, mitm_ctx, tmp_path):
         """auth_url_rewrite metadata is absent when no URL rewrite happens."""
         flow = real_flow(with_response=False, host="api.github.com", path="/repos")
-        flow.metadata["vm_run_id"] = "test-run"
+        flow.metadata[metadata_keys.VM_RUN_ID] = "test-run"
         api_entry = {
             "base": "https://api.github.com",
             "auth": {"headers": {"Authorization": "Bearer ${{ secrets.TOKEN }}"}},
@@ -135,6 +136,6 @@ class TestAuthBaseUrlRewriteSuccess:
             mitm_ctx(),
         ):
             await auth.handle_firewall_request(flow, allow, vm_info)
-        assert "auth_url_rewrite" not in flow.metadata
+        assert metadata_keys.AUTH_URL_REWRITE not in flow.metadata
         # Standard header injection happened
         assert flow.request.headers["Authorization"] == "Bearer real"

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -69,6 +69,37 @@ def _argument_names(args: ast.arguments) -> set[str]:
     return names
 
 
+def _pattern_names(pattern: ast.pattern) -> set[str]:
+    if isinstance(pattern, ast.MatchAs):
+        names = set() if pattern.name is None else {pattern.name}
+        if pattern.pattern is not None:
+            names.update(_pattern_names(pattern.pattern))
+        return names
+    if isinstance(pattern, ast.MatchStar):
+        return set() if pattern.name is None else {pattern.name}
+    if isinstance(pattern, ast.MatchMapping):
+        mapping_names: set[str] = set() if pattern.rest is None else {pattern.rest}
+        for child_pattern in pattern.patterns:
+            mapping_names.update(_pattern_names(child_pattern))
+        return mapping_names
+    if isinstance(pattern, ast.MatchSequence):
+        sequence_names: set[str] = set()
+        for child_pattern in pattern.patterns:
+            sequence_names.update(_pattern_names(child_pattern))
+        return sequence_names
+    if isinstance(pattern, ast.MatchClass):
+        class_names: set[str] = set()
+        for child_pattern in [*pattern.patterns, *pattern.kwd_patterns]:
+            class_names.update(_pattern_names(child_pattern))
+        return class_names
+    if isinstance(pattern, ast.MatchOr):
+        or_names: set[str] = set()
+        for child_pattern in pattern.patterns:
+            or_names.update(_pattern_names(child_pattern))
+        return or_names
+    return set()
+
+
 class _MetadataKeyVisitor(ast.NodeVisitor):
     def __init__(self, path: Path) -> None:
         self.path = path
@@ -92,6 +123,34 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
             or (isinstance(node, ast.Name) and node.id in self._metadata_aliases)
             or (isinstance(node, ast.NamedExpr) and self._is_metadata_reference(node.value))
         )
+
+    def _contains_metadata_reference(self, node: ast.AST) -> bool:
+        return self._is_metadata_reference(node) or any(
+            self._contains_metadata_reference(child) for child in ast.iter_child_nodes(node)
+        )
+
+    def _is_metadata_merge_value(self, node: ast.AST) -> bool:
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+            left_contains_metadata = self._contains_metadata_reference(node.left)
+            right_contains_metadata = self._contains_metadata_reference(node.right)
+            return left_contains_metadata or right_contains_metadata
+        if isinstance(node, ast.Dict) and any(
+            key is None and self._contains_metadata_reference(value)
+            for key, value in zip(node.keys, node.values, strict=True)
+        ):
+            return True
+        return (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "dict"
+            and len(node.args) > 0
+            and self._contains_metadata_reference(node.args[0])
+        )
+
+    def _metadata_merge_key_violations(self, node: ast.AST) -> list[str]:
+        if self._is_metadata_merge_value(node):
+            return _metadata_dict_key_violations(self.path, node)
+        return []
 
     def _visit_scoped_body(self, body: list[ast.stmt], shadowed: set[str] | None = None) -> None:
         aliases = set(self._metadata_aliases)
@@ -155,18 +214,27 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
     def visit_Assign(self, node: ast.Assign) -> None:
         if any(_is_metadata_attribute(target) for target in node.targets):
             self.violations.extend(_metadata_dict_key_violations(self.path, node.value))
+        else:
+            self.violations.extend(self._metadata_merge_key_violations(node.value))
+        self.visit(node.value)
+        for target in node.targets:
+            self.visit(target)
         self._update_aliases_from_assign(node)
-        self.generic_visit(node)
 
     def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
         if _is_metadata_attribute(node.target):
             self.violations.extend(_metadata_dict_key_violations(self.path, node.value))
+        elif node.value is not None:
+            self.violations.extend(self._metadata_merge_key_violations(node.value))
+        if node.value is not None:
+            self.visit(node.value)
+        self.visit(node.annotation)
+        self.visit(node.target)
         if node.value is not None and isinstance(node.target, ast.Name):
-            if self._is_metadata_reference(node.value):
+            if self._is_metadata_reference(node.value) or self._is_metadata_merge_value(node.value):
                 self._metadata_aliases.add(node.target.id)
             else:
                 self._metadata_aliases.discard(node.target.id)
-        self.generic_visit(node)
 
     def visit_AugAssign(self, node: ast.AugAssign) -> None:
         if self._is_metadata_reference(node.target):
@@ -175,13 +243,19 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
 
     def visit_NamedExpr(self, node: ast.NamedExpr) -> None:
         if isinstance(node.target, ast.Name):
+            is_metadata_alias = self._is_metadata_reference(
+                node.value
+            ) or self._is_metadata_merge_value(node.value)
+            self.violations.extend(self._metadata_merge_key_violations(node.value))
+            self.visit(node.value)
             target_aliases = self._named_expr_target_aliases
-            if self._is_metadata_reference(node.value):
+            if is_metadata_alias:
                 target_aliases.add(node.target.id)
                 self._metadata_aliases.add(node.target.id)
             else:
                 target_aliases.discard(node.target.id)
                 self._metadata_aliases.discard(node.target.id)
+            return
         self.visit(node.value)
 
     def visit_Subscript(self, node: ast.Subscript) -> None:
@@ -258,6 +332,22 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         if node.name is not None:
             self._metadata_aliases.discard(node.name)
 
+    def visit_Match(self, node: ast.Match) -> None:
+        self.visit(node.subject)
+        matched_names: set[str] = set()
+        for case in node.cases:
+            names = _pattern_names(case.pattern)
+            matched_names.update(names)
+            aliases = set(self._metadata_aliases)
+            aliases.difference_update(names)
+            self._metadata_alias_scopes.append(aliases)
+            if case.guard is not None:
+                self.visit(case.guard)
+            for statement in case.body:
+                self.visit(statement)
+            self._metadata_alias_scopes.pop()
+        self._metadata_aliases.difference_update(matched_names)
+
     def visit_ListComp(self, node: ast.ListComp) -> None:
         self._visit_comprehension(node.generators, [node.elt])
 
@@ -282,7 +372,9 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
                 self._metadata_aliases.discard(alias.asname or alias.name)
 
     def _update_aliases_from_assign(self, node: ast.Assign) -> None:
-        is_metadata_alias = self._is_metadata_reference(node.value)
+        is_metadata_alias = self._is_metadata_reference(
+            node.value
+        ) or self._is_metadata_merge_value(node.value)
         for target in node.targets:
             if is_metadata_alias and isinstance(target, ast.Name):
                 self._metadata_aliases.add(target.id)
@@ -436,6 +528,15 @@ def nested_alias():
 annotated_meta = flow.metadata
 annotated_meta: dict[str, object]
 annotated_meta["auth_url_rewrite"] = True
+annotated_meta: str = annotated_meta["auth_url_rewrite"]
+reassigned_meta = flow.metadata
+reassigned_meta = reassigned_meta["connector_diagnostic_env_names"]
+(named_expr_reassigned_meta := flow.metadata)
+(named_expr_reassigned_meta := named_expr_reassigned_meta["firewall_error"])
+merged_meta = flow.metadata | {"firewall_base": "https://api.example.com"}
+merged_meta = {**merged_meta, "firewall_api_id": "run-1:0"}
+merged_meta = dict(merged_meta, firewall_action="ALLOW")
+(merged_named_expr_meta := flow.metadata | {"firewall_name": "github"})
 (inline_meta := flow.metadata)["connector_diagnostic_type"] = "github"
 (call_meta := flow.metadata).get("connector_diagnostic_reason")
 if conditional_meta := flow.metadata:
@@ -456,12 +557,15 @@ values = [
     for row in rows
     for item in (generator_body_meta := flow.metadata)
 ]
+match payload:
+    case {"payload": payload}:
+        outer_meta["_model_json_usage_finalized"] = True
 """
     )
 
     violations = _metadata_key_violations(source_path)
 
-    assert len(violations) == 34
+    assert len(violations) == 42
     assert all("use metadata_keys." in violation for violation in violations)
 
 
@@ -475,6 +579,8 @@ entry["firewall_name"] = "github"
 payload = {"vm_run_id": "run-1"}
 assert "connector_response_finish" in flow.metadata
 flow.metadata["_local_marker"] = "private"
+external_meta_value = flow.metadata
+payload = {"vm_run_id": "external", "metadata": external_meta_value}
 meta = flow.metadata
 meta = {"vm_run_id": "external payload"}
 def accepts_external_metadata(meta):
@@ -504,6 +610,17 @@ values = tuple(meta["vm_run_id"] for meta in [{"vm_run_id": "external"}])
 value = lambda_local_meta["vm_run_id"]
 values = [(meta := {"vm_run_id": "external"}) for item in rows]
 value = meta["vm_run_id"]
+match payload:
+    case {"meta": match_meta, **match_rest} if match_rest["vm_run_id"]:
+        value = match_meta["vm_run_id"]
+    case Item(meta=class_meta):
+        value = class_meta["vm_run_id"]
+    case [sequence_meta, *sequence_tail]:
+        value = sequence_meta["vm_run_id"]
+        value = sequence_tail["vm_run_id"]
+    case meta:
+        value = meta["vm_run_id"]
+value = match_meta["vm_run_id"]
 try:
     pass
 except Exception as meta:

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -80,8 +80,10 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         return self._metadata_alias_scopes[-1]
 
     def _is_metadata_reference(self, node: ast.AST) -> bool:
-        return _is_metadata_attribute(node) or (
-            isinstance(node, ast.Name) and node.id in self._metadata_aliases
+        return (
+            _is_metadata_attribute(node)
+            or (isinstance(node, ast.Name) and node.id in self._metadata_aliases)
+            or (isinstance(node, ast.NamedExpr) and self._is_metadata_reference(node.value))
         )
 
     def _visit_scoped_body(self, body: list[ast.stmt], shadowed: set[str] | None = None) -> None:
@@ -91,6 +93,16 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self._metadata_alias_scopes.append(aliases)
         for statement in body:
             self.visit(statement)
+        self._metadata_alias_scopes.pop()
+
+    def _visit_scoped_expression(
+        self, expression: ast.AST, shadowed: set[str] | None = None
+    ) -> None:
+        aliases = set(self._metadata_aliases)
+        if shadowed is not None:
+            aliases.difference_update(shadowed)
+        self._metadata_alias_scopes.append(aliases)
+        self.visit(expression)
         self._metadata_alias_scopes.pop()
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
@@ -110,6 +122,12 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
                 self.visit(default)
         self._visit_scoped_body(node.body, _argument_names(node.args) | {node.name})
         self._metadata_aliases.discard(node.name)
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        for default in [*node.args.defaults, *node.args.kw_defaults]:
+            if default is not None:
+                self.visit(default)
+        self._visit_scoped_expression(node.body, _argument_names(node.args))
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
         for decorator in node.decorator_list:
@@ -141,6 +159,14 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         if self._is_metadata_reference(node.target):
             self.violations.extend(_metadata_dict_key_violations(self.path, node.value))
         self.generic_visit(node)
+
+    def visit_NamedExpr(self, node: ast.NamedExpr) -> None:
+        if isinstance(node.target, ast.Name):
+            if self._is_metadata_reference(node.value):
+                self._metadata_aliases.add(node.target.id)
+            else:
+                self._metadata_aliases.discard(node.target.id)
+        self.visit(node.value)
 
     def visit_Subscript(self, node: ast.Subscript) -> None:
         if self._is_metadata_reference(node.value):
@@ -206,6 +232,28 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         for statement in node.body:
             self.visit(statement)
 
+    def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
+        if node.type is not None:
+            self.visit(node.type)
+        if node.name is not None:
+            self._metadata_aliases.discard(node.name)
+        for statement in node.body:
+            self.visit(statement)
+        if node.name is not None:
+            self._metadata_aliases.discard(node.name)
+
+    def visit_ListComp(self, node: ast.ListComp) -> None:
+        self._visit_comprehension(node.generators, [node.elt])
+
+    def visit_SetComp(self, node: ast.SetComp) -> None:
+        self._visit_comprehension(node.generators, [node.elt])
+
+    def visit_GeneratorExp(self, node: ast.GeneratorExp) -> None:
+        self._visit_comprehension(node.generators, [node.elt])
+
+    def visit_DictComp(self, node: ast.DictComp) -> None:
+        self._visit_comprehension(node.generators, [node.key, node.value])
+
     def visit_Import(self, node: ast.Import) -> None:
         for alias in node.names:
             self._metadata_aliases.discard(alias.asname or alias.name.split(".", maxsplit=1)[0])
@@ -229,6 +277,30 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
     def _discard_alias_target(self, target: ast.AST | None) -> None:
         for name in _target_names(target):
             self._metadata_aliases.discard(name)
+
+    def _visit_comprehension(
+        self, generators: list[ast.comprehension], body_expressions: list[ast.AST]
+    ) -> None:
+        if not generators:
+            for expression in body_expressions:
+                self.visit(expression)
+            return
+
+        first_generator, *remaining_generators = generators
+        self.visit(first_generator.iter)
+
+        self._metadata_alias_scopes.append(set(self._metadata_aliases))
+        self._discard_alias_target(first_generator.target)
+        for condition in first_generator.ifs:
+            self.visit(condition)
+        for generator in remaining_generators:
+            self.visit(generator.iter)
+            self._discard_alias_target(generator.target)
+            for condition in generator.ifs:
+                self.visit(condition)
+        for expression in body_expressions:
+            self.visit(expression)
+        self._metadata_alias_scopes.pop()
 
 
 def _metadata_key_violations(path: Path) -> list[str]:
@@ -341,12 +413,18 @@ def nested_alias():
 annotated_meta = flow.metadata
 annotated_meta: dict[str, object]
 annotated_meta["auth_url_rewrite"] = True
+(inline_meta := flow.metadata)["connector_diagnostic_type"] = "github"
+(call_meta := flow.metadata).get("connector_diagnostic_reason")
+if conditional_meta := flow.metadata:
+    conditional_meta["connector_diagnostic_base"] = "https://api.example.com"
+outer_meta = flow.metadata
+values = [outer_meta["auth_refreshed_connectors"] for item in rows]
 """
     )
 
     violations = _metadata_key_violations(source_path)
 
-    assert len(violations) == 26
+    assert len(violations) == 30
     assert all("use metadata_keys." in violation for violation in violations)
 
 
@@ -380,6 +458,15 @@ from json import dumps as meta
 value = meta["vm_run_id"]
 meta, other = flow.metadata
 value = meta["vm_run_id"]
+fn = lambda meta: meta["vm_run_id"]
+values = [meta["vm_run_id"] for meta in [{"vm_run_id": "external"}]]
+values = {meta["vm_run_id"] for meta in [{"vm_run_id": "external"}]}
+values = {meta["vm_run_id"]: 1 for meta in [{"vm_run_id": "external"}]}
+values = tuple(meta["vm_run_id"] for meta in [{"vm_run_id": "external"}])
+try:
+    pass
+except Exception as meta:
+    value = meta["vm_run_id"]
 """
     )
 

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -99,7 +99,8 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         for default in [*node.args.defaults, *node.args.kw_defaults]:
             if default is not None:
                 self.visit(default)
-        self._visit_scoped_body(node.body, _argument_names(node.args))
+        self._visit_scoped_body(node.body, _argument_names(node.args) | {node.name})
+        self._metadata_aliases.discard(node.name)
 
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
         for decorator in node.decorator_list:
@@ -107,7 +108,8 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         for default in [*node.args.defaults, *node.args.kw_defaults]:
             if default is not None:
                 self.visit(default)
-        self._visit_scoped_body(node.body, _argument_names(node.args))
+        self._visit_scoped_body(node.body, _argument_names(node.args) | {node.name})
+        self._metadata_aliases.discard(node.name)
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
         for decorator in node.decorator_list:
@@ -117,6 +119,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         for keyword in node.keywords:
             self.visit(keyword)
         self._visit_scoped_body(node.body)
+        self._metadata_aliases.discard(node.name)
 
     def visit_Assign(self, node: ast.Assign) -> None:
         if any(_is_metadata_attribute(target) for target in node.targets):
@@ -127,8 +130,8 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
     def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
         if _is_metadata_attribute(node.target):
             self.violations.extend(_metadata_dict_key_violations(self.path, node.value))
-        if isinstance(node.target, ast.Name):
-            if node.value is not None and self._is_metadata_reference(node.value):
+        if node.value is not None and isinstance(node.target, ast.Name):
+            if self._is_metadata_reference(node.value):
                 self._metadata_aliases.add(node.target.id)
             else:
                 self._metadata_aliases.discard(node.target.id)
@@ -203,14 +206,25 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         for statement in node.body:
             self.visit(statement)
 
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            self._metadata_aliases.discard(alias.asname or alias.name.split(".", maxsplit=1)[0])
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        for alias in node.names:
+            if alias.name == "*":
+                self._metadata_aliases.clear()
+            else:
+                self._metadata_aliases.discard(alias.asname or alias.name)
+
     def _update_aliases_from_assign(self, node: ast.Assign) -> None:
         is_metadata_alias = self._is_metadata_reference(node.value)
         for target in node.targets:
+            if is_metadata_alias and isinstance(target, ast.Name):
+                self._metadata_aliases.add(target.id)
+                continue
             for name in _target_names(target):
-                if is_metadata_alias:
-                    self._metadata_aliases.add(name)
-                else:
-                    self._metadata_aliases.discard(name)
+                self._metadata_aliases.discard(name)
 
     def _discard_alias_target(self, target: ast.AST | None) -> None:
         for name in _target_names(target):
@@ -324,12 +338,15 @@ def nested_alias():
     inner_meta = flow.metadata
     def uses_outer_alias():
         inner_meta["auth_cache_hit"] = False
+annotated_meta = flow.metadata
+annotated_meta: dict[str, object]
+annotated_meta["auth_url_rewrite"] = True
 """
     )
 
     violations = _metadata_key_violations(source_path)
 
-    assert len(violations) == 25
+    assert len(violations) == 26
     assert all("use metadata_keys." in violation for violation in violations)
 
 
@@ -351,6 +368,18 @@ for meta in [{"firewall_name": "external"}]:
     value = meta["firewall_name"]
 with context() as meta:
     value = meta["firewall_action"]
+def meta():
+    return None
+value = meta["vm_run_id"]
+class meta:
+    pass
+value = meta["vm_run_id"]
+import json as meta
+value = meta["vm_run_id"]
+from json import dumps as meta
+value = meta["vm_run_id"]
+meta, other = flow.metadata
+value = meta["vm_run_id"]
 """
     )
 

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -33,13 +33,8 @@ def _python_files() -> list[Path]:
     return sorted(files)
 
 
-def _is_flow_metadata_attribute(node: ast.AST) -> bool:
-    return (
-        isinstance(node, ast.Attribute)
-        and isinstance(node.value, ast.Name)
-        and node.value.id == "flow"
-        and node.attr == "metadata"
-    )
+def _is_metadata_attribute(node: ast.AST) -> bool:
+    return isinstance(node, ast.Attribute) and node.attr == "metadata"
 
 
 def _registered_key_name(node: ast.AST) -> str | None:
@@ -59,7 +54,7 @@ def _metadata_key_violations(path: Path) -> list[str]:
     violations: list[str] = []
 
     for node in ast.walk(tree):
-        if isinstance(node, ast.Subscript) and _is_flow_metadata_attribute(node.value):
+        if isinstance(node, ast.Subscript) and _is_metadata_attribute(node.value):
             key_name = _registered_key_name(node.slice)
             if key_name is not None:
                 violations.append(_violation(path, node, key_name))
@@ -67,7 +62,7 @@ def _metadata_key_violations(path: Path) -> list[str]:
         if (
             isinstance(node, ast.Call)
             and isinstance(node.func, ast.Attribute)
-            and _is_flow_metadata_attribute(node.func.value)
+            and _is_metadata_attribute(node.func.value)
         ):
             if node.func.attr in _METADATA_METHODS_WITH_KEY_ARGUMENTS and node.args:
                 key_name = _registered_key_name(node.args[0])
@@ -76,21 +71,21 @@ def _metadata_key_violations(path: Path) -> list[str]:
             if node.func.attr in _METADATA_METHODS_WITH_DICT_ARGUMENTS:
                 violations.extend(_metadata_update_violations(path, node))
 
-        if isinstance(node, ast.AugAssign) and _is_flow_metadata_attribute(node.target):
+        if isinstance(node, ast.AugAssign) and _is_metadata_attribute(node.target):
             violations.extend(_metadata_dict_key_violations(path, node.value))
 
         if isinstance(node, ast.Assign) and any(
-            _is_flow_metadata_attribute(target) for target in node.targets
+            _is_metadata_attribute(target) for target in node.targets
         ):
             violations.extend(_metadata_dict_key_violations(path, node.value))
 
-        if isinstance(node, ast.AnnAssign) and _is_flow_metadata_attribute(node.target):
+        if isinstance(node, ast.AnnAssign) and _is_metadata_attribute(node.target):
             violations.extend(_metadata_dict_key_violations(path, node.value))
 
         if isinstance(node, ast.Compare) and len(node.comparators) == 1:
             if not isinstance(node.ops[0], (ast.In, ast.NotIn)):
                 continue
-            if not _is_flow_metadata_attribute(node.comparators[0]):
+            if not _is_metadata_attribute(node.comparators[0]):
                 continue
             key_name = _registered_key_name(node.left)
             if key_name is not None:
@@ -188,12 +183,13 @@ flow.metadata.__setitem__("firewall_api_id", "run-1:0")
 flow.metadata.__delitem__("network_log_target")
 flow.metadata.__contains__("browser_user_agent")
 flow.metadata.__ior__({"suppress_request_body_capture": True})
+http_flow.metadata["vm_run_id"] = "run-2"
 """
     )
 
     violations = _metadata_key_violations(source_path)
 
-    assert len(violations) == 18
+    assert len(violations) == 19
     assert all("use metadata_keys." in violation for violation in violations)
 
 
@@ -205,7 +201,6 @@ def test_registered_flow_metadata_guard_ignores_external_schema_and_private_mark
         """
 entry["firewall_name"] = "github"
 payload = {"vm_run_id": "run-1"}
-record.metadata["vm_run_id"] = "external id"
 assert "connector_response_finish" in flow.metadata
 flow.metadata["firewall_rule"] = "domain:*.example.com"
 """

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -1365,13 +1365,12 @@ def _metadata_key_sequence_violations(path: Path, node: ast.AST | None) -> list[
         and not node.keywords
     ):
         return _metadata_key_sequence_violations(path, node.func.value)
-    if (
-        isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Name)
-        and node.func.id in _PAIR_SEQUENCE_WRAPPER_CALLS
-    ):
-        keys_arg = None if not node.args else node.args[0]
-        return _metadata_key_sequence_violations(path, keys_arg)
+    if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+        if node.func.id == "dict":
+            return _metadata_dict_key_violations(path, node)
+        if node.func.id in _PAIR_SEQUENCE_WRAPPER_CALLS:
+            keys_arg = None if not node.args else node.args[0]
+            return _metadata_key_sequence_violations(path, keys_arg)
     if not isinstance(node, ast.List | ast.Tuple | ast.Set):
         return []
     violations: list[str] = []
@@ -1429,6 +1428,9 @@ flow.metadata = dict.fromkeys(["auth_refreshed_connectors"], [])
 flow.metadata.update(dict.fromkeys(("auth_refreshed_secrets",), []))
 flow.metadata.update(dict.fromkeys({"auth_resolved_secrets": []}, []))
 flow.metadata.update(dict.fromkeys({"model_usage_provider": "gpt-5.5"}.keys(), "gpt-5.5"))
+flow.metadata.update(dict.fromkeys(dict(vm_run_id="run-1"), "run-1"))
+flow.metadata.update(dict.fromkeys(dict([("firewall_action", "ALLOW")]).keys(), "ALLOW"))
+flow.metadata.update(dict.fromkeys(tuple(dict(firewall_billable=True)), False))
 flow.metadata.update(dict([("stream_buffer", bytearray())]))
 flow.metadata.update({**{"capture_body": True}})
 flow.metadata = {"request_stream_buffer": bytearray()} | {"request_stream_buffer_state": {}}
@@ -1728,7 +1730,7 @@ match flow.metadata:
 
     violations = _metadata_key_violations(source_path)
 
-    assert len(violations) == 159
+    assert len(violations) == 162
     assert all("use metadata_keys." in violation for violation in violations)
 
 
@@ -1770,6 +1772,9 @@ value = external_items_meta["vm_run_id"]
 flow.metadata.update({metadata_keys.VM_RUN_ID: "run-1"}.items())
 flow.metadata.update(dict.fromkeys([metadata_keys.VM_RUN_ID], "run-1"))
 flow.metadata.update(dict.fromkeys({metadata_keys.VM_RUN_ID: "run-1"}, "run-1"))
+flow.metadata.update(dict.fromkeys(dict({metadata_keys.VM_RUN_ID: "run-1"}), "run-1"))
+flow.metadata.update(dict.fromkeys(dict({metadata_keys.FIREWALL_ACTION: "ALLOW"}).keys(), "ALLOW"))
+flow.metadata.update(dict.fromkeys(tuple(dict({metadata_keys.FIREWALL_BILLABLE: True})), False))
 external_conditional_meta = {"vm_run_id": "external"} if condition else {}
 value = external_conditional_meta["vm_run_id"]
 external_bool_meta = fallback_meta or {"vm_run_id": "external"}

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -414,6 +414,8 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
             return any(self._is_metadata_alias_value(value) for value in node.values)
         if isinstance(node, ast.Await):
             return self._is_metadata_alias_value(node.value)
+        if isinstance(node, ast.UnaryOp) and not isinstance(node.op, ast.Not):
+            return self._is_metadata_alias_value(node.operand)
         return (
             isinstance(node, ast.Call)
             and isinstance(node.func, ast.Attribute)
@@ -1468,6 +1470,9 @@ async def await_metadata_merge():
     return await (flow.metadata | {"vm_proxy_log_path": "proxy.jsonl"})
 async def await_metadata_precedence_merge():
     await flow.metadata | {"vm_run_id": "run-1"}
+value = +flow.metadata | {"firewall_base": "https://api.example.com"}
+value = -flow.metadata | {"firewall_action": "ALLOW"}
+value = ~flow.metadata | {"firewall_error": "auth_failed"}
 value = not (flow.metadata | {"auth_cache_hit": False})
 value = other == (flow.metadata | {"firewall_name": "github"})
 value = (flow.metadata | {"firewall_api_id": "run-1:0"}).items
@@ -1571,7 +1576,7 @@ match match_payload:
 
     violations = _metadata_key_violations(source_path)
 
-    assert len(violations) == 140
+    assert len(violations) == 143
     assert all("use metadata_keys." in violation for violation in violations)
 
 

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -53,6 +53,8 @@ def _violation(path: Path, node: ast.AST, key_name: str) -> str:
 def _target_names(node: ast.AST | None) -> set[str]:
     if isinstance(node, ast.Name):
         return {node.id}
+    if isinstance(node, ast.Starred):
+        return _target_names(node.value)
     if isinstance(node, ast.List | ast.Tuple):
         names: set[str] = set()
         for element in node.elts:
@@ -102,8 +104,8 @@ def _pattern_names(pattern: ast.pattern) -> set[str]:
 
 
 def _pattern_is_exhaustive(pattern: ast.pattern) -> bool:
-    if isinstance(pattern, ast.MatchAs) and pattern.pattern is None:
-        return True
+    if isinstance(pattern, ast.MatchAs):
+        return pattern.pattern is None or _pattern_is_exhaustive(pattern.pattern)
     if isinstance(pattern, ast.MatchOr):
         return any(_pattern_is_exhaustive(child_pattern) for child_pattern in pattern.patterns)
     return False
@@ -118,7 +120,7 @@ def _is_try_statement(statement: ast.stmt) -> TypeGuard[ast.Try]:
 
 
 def _statement_can_fall_through(statement: ast.stmt) -> bool:
-    if isinstance(statement, (ast.Return, ast.Raise)):
+    if isinstance(statement, (ast.Return, ast.Raise, ast.Break, ast.Continue)):
         return False
     if isinstance(statement, ast.If):
         if not statement.orelse:
@@ -160,12 +162,28 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         return (
             _is_metadata_attribute(node)
             or (isinstance(node, ast.Name) and node.id in self._metadata_aliases)
-            or (isinstance(node, ast.NamedExpr) and self._is_metadata_reference(node.value))
+            or (isinstance(node, ast.NamedExpr) and self._is_metadata_alias_value(node.value))
         )
 
     def _contains_metadata_reference(self, node: ast.AST) -> bool:
         return self._is_metadata_reference(node) or any(
             self._contains_metadata_reference(child) for child in ast.iter_child_nodes(node)
+        )
+
+    def _is_metadata_alias_value(self, node: ast.AST) -> bool:
+        if self._is_metadata_reference(node) or self._is_metadata_merge_value(node):
+            return True
+        if isinstance(node, ast.IfExp):
+            return self._is_metadata_alias_value(node.body) or self._is_metadata_alias_value(
+                node.orelse
+            )
+        if isinstance(node, ast.BoolOp):
+            return any(self._is_metadata_alias_value(value) for value in node.values)
+        return (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "copy"
+            and self._is_metadata_alias_value(node.func.value)
         )
 
     def _is_metadata_merge_value(self, node: ast.AST) -> bool:
@@ -178,17 +196,34 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
             for key, value in zip(node.keys, node.values, strict=True)
         ):
             return True
-        return (
+        if (
             isinstance(node, ast.Call)
             and isinstance(node.func, ast.Name)
             and node.func.id == "dict"
-            and len(node.args) > 0
-            and self._contains_metadata_reference(node.args[0])
-        )
+        ):
+            positional_metadata = any(
+                self._contains_metadata_reference(argument) for argument in node.args
+            )
+            unpacked_keyword_metadata = any(
+                keyword.arg is None and self._contains_metadata_reference(keyword.value)
+                for keyword in node.keywords
+            )
+            return positional_metadata or unpacked_keyword_metadata
+        return False
 
     def _metadata_merge_key_violations(self, node: ast.AST) -> list[str]:
         if self._is_metadata_merge_value(node):
             return _metadata_dict_key_violations(self.path, node)
+        if isinstance(node, ast.IfExp):
+            return [
+                *self._metadata_merge_key_violations(node.body),
+                *self._metadata_merge_key_violations(node.orelse),
+            ]
+        if isinstance(node, ast.BoolOp):
+            violations: list[str] = []
+            for value in node.values:
+                violations.extend(self._metadata_merge_key_violations(value))
+            return violations
         return []
 
     def _metadata_default_argument_names(self, args: ast.arguments) -> set[str]:
@@ -196,12 +231,10 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         positional_args = [*args.posonlyargs, *args.args]
         default_offset = len(positional_args) - len(args.defaults)
         for arg, default in zip(positional_args[default_offset:], args.defaults, strict=True):
-            if self._is_metadata_reference(default) or self._is_metadata_merge_value(default):
+            if self._is_metadata_alias_value(default):
                 metadata_defaults.add(arg.arg)
         for arg, default in zip(args.kwonlyargs, args.kw_defaults, strict=True):
-            if default is not None and (
-                self._is_metadata_reference(default) or self._is_metadata_merge_value(default)
-            ):
+            if default is not None and self._is_metadata_alias_value(default):
                 metadata_defaults.add(arg.arg)
         return metadata_defaults
 
@@ -345,7 +378,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self.visit(node.annotation)
         self.visit(node.target)
         if node.value is not None and isinstance(node.target, ast.Name):
-            if self._is_metadata_reference(node.value) or self._is_metadata_merge_value(node.value):
+            if self._is_metadata_alias_value(node.value):
                 self._metadata_aliases.add(node.target.id)
             else:
                 self._metadata_aliases.discard(node.target.id)
@@ -368,9 +401,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
 
     def visit_NamedExpr(self, node: ast.NamedExpr) -> None:
         if isinstance(node.target, ast.Name):
-            is_metadata_alias = self._is_metadata_reference(
-                node.value
-            ) or self._is_metadata_merge_value(node.value)
+            is_metadata_alias = self._is_metadata_alias_value(node.value)
             self.violations.extend(self._metadata_merge_key_violations(node.value))
             self.visit(node.value)
             target_aliases = self._named_expr_target_aliases
@@ -384,14 +415,14 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self.visit(node.value)
 
     def visit_Subscript(self, node: ast.Subscript) -> None:
-        if self._is_metadata_reference(node.value):
+        if self._is_metadata_alias_value(node.value):
             key_name = _registered_key_name(node.slice)
             if key_name is not None:
                 self.violations.append(_violation(self.path, node, key_name))
         self.generic_visit(node)
 
     def visit_Call(self, node: ast.Call) -> None:
-        if isinstance(node.func, ast.Attribute) and self._is_metadata_reference(node.func.value):
+        if isinstance(node.func, ast.Attribute) and self._is_metadata_alias_value(node.func.value):
             if node.func.attr in _METADATA_METHODS_WITH_KEY_ARGUMENTS and node.args:
                 key_name = _registered_key_name(node.args[0])
                 if key_name is not None:
@@ -404,7 +435,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         if (
             len(node.comparators) == 1
             and isinstance(node.ops[0], (ast.In, ast.NotIn))
-            and self._is_metadata_reference(node.comparators[0])
+            and self._is_metadata_alias_value(node.comparators[0])
         ):
             key_name = _registered_key_name(node.left)
             if key_name is not None:
@@ -480,28 +511,26 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
     def visit_With(self, node: ast.With) -> None:
         for item in node.items:
             self.visit(item.context_expr)
-        base_aliases = set(self._metadata_aliases)
         body_aliases = set(self._metadata_aliases)
         self._metadata_alias_scopes.append(body_aliases)
         for item in node.items:
             self._discard_alias_target(item.optional_vars)
-        self._visit_current_scope_body(node.body)
+        body_falls_through = self._visit_current_scope_body(node.body)
         body_result_aliases = set(self._metadata_aliases)
         self._metadata_alias_scopes.pop()
-        self._replace_current_aliases(base_aliases | body_result_aliases)
+        self._replace_current_aliases(body_result_aliases if body_falls_through else set())
 
     def visit_AsyncWith(self, node: ast.AsyncWith) -> None:
         for item in node.items:
             self.visit(item.context_expr)
-        base_aliases = set(self._metadata_aliases)
         body_aliases = set(self._metadata_aliases)
         self._metadata_alias_scopes.append(body_aliases)
         for item in node.items:
             self._discard_alias_target(item.optional_vars)
-        self._visit_current_scope_body(node.body)
+        body_falls_through = self._visit_current_scope_body(node.body)
         body_result_aliases = set(self._metadata_aliases)
         self._metadata_alias_scopes.pop()
-        self._replace_current_aliases(base_aliases | body_result_aliases)
+        self._replace_current_aliases(body_result_aliases if body_falls_through else set())
 
     def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
         if node.type is not None:
@@ -563,25 +592,32 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
 
     def visit_Match(self, node: ast.Match) -> None:
         self.visit(node.subject)
-        base_aliases = set(self._metadata_aliases)
+        continuing_aliases = set(self._metadata_aliases)
         exit_aliases: set[str] = set()
         has_unmatched_path = True
         for case in node.cases:
             names = _pattern_names(case.pattern)
-            aliases = set(base_aliases)
+            pattern_is_exhaustive = _pattern_is_exhaustive(case.pattern)
+            aliases = set(continuing_aliases)
             aliases.difference_update(names)
             self._metadata_alias_scopes.append(aliases)
             if case.guard is not None:
                 self.visit(case.guard)
+            guard_aliases = set(self._metadata_aliases)
             falls_through = self._visit_current_scope_body(case.body)
             if falls_through:
                 exit_aliases.update(self._metadata_aliases)
             self._metadata_alias_scopes.pop()
-            if case.guard is None and _pattern_is_exhaustive(case.pattern):
+            if case.guard is not None:
+                if pattern_is_exhaustive:
+                    continuing_aliases = guard_aliases
+                else:
+                    continuing_aliases.update(guard_aliases)
+            if case.guard is None and pattern_is_exhaustive:
                 has_unmatched_path = False
                 break
         if has_unmatched_path:
-            exit_aliases.update(base_aliases)
+            exit_aliases.update(continuing_aliases)
         self._replace_current_aliases(exit_aliases)
 
     def visit_ListComp(self, node: ast.ListComp) -> None:
@@ -608,9 +644,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
                 self._metadata_aliases.discard(alias.asname or alias.name)
 
     def _update_aliases_from_assign(self, node: ast.Assign) -> None:
-        is_metadata_alias = self._is_metadata_reference(
-            node.value
-        ) or self._is_metadata_merge_value(node.value)
+        is_metadata_alias = self._is_metadata_alias_value(node.value)
         for target in node.targets:
             if is_metadata_alias and isinstance(target, ast.Name):
                 self._metadata_aliases.add(target.id)
@@ -772,7 +806,21 @@ reassigned_meta = reassigned_meta["connector_diagnostic_env_names"]
 merged_meta = flow.metadata | {"firewall_base": "https://api.example.com"}
 merged_meta = {**merged_meta, "firewall_api_id": "run-1:0"}
 merged_meta = dict(merged_meta, firewall_action="ALLOW")
+kwargs_merged_meta = dict(**flow.metadata, vm_run_id="run-1")
+kwargs_alias_meta = dict(**flow.metadata)
+kwargs_alias_meta["vm_run_id"] = "run-1"
+conditional_expr_meta = flow.metadata if condition else {}
+conditional_expr_meta["vm_run_id"] = "run-1"
+bool_expr_meta = fallback_meta or flow.metadata
+bool_expr_meta["firewall_name"] = "github"
+conditional_merge_meta = (flow.metadata | {"firewall_action": "ALLOW"}) if condition else {}
+copy_meta = flow.metadata.copy()
+copy_meta["vm_run_id"] = "run-1"
+(flow.metadata if condition else {})["firewall_base"] = "https://api.example.com"
+(flow.metadata if condition else {}).get("firewall_action")
+"firewall_name" in (flow.metadata if condition else {})
 (merged_named_expr_meta := flow.metadata | {"firewall_name": "github"})
+(inline_conditional_meta := flow.metadata if condition else {})["vm_run_id"] = "run-1"
 (inline_meta := flow.metadata)["connector_diagnostic_type"] = "github"
 (call_meta := flow.metadata).get("connector_diagnostic_reason")
 def function_default_meta(default_meta=flow.metadata):
@@ -810,16 +858,17 @@ try:
 except* Exception as except_star_meta:
     pass
 except_star_meta["firewall_error"] = "auth_failed"
+break_exit_meta = {}
+for item in rows:
+    break_exit_meta = flow.metadata
+    break
+break_exit_meta["vm_run_id"] = "run-1"
 def finalbody_alias_after_return():
     finalbody_meta = flow.metadata
     try:
         return None
     finally:
         finalbody_meta["vm_run_id"] = "run-1"
-with_meta = flow.metadata
-with context() as with_meta:
-    pass
-with_meta["network_log_target"] = {}
 aug_merged_meta = {}
 aug_merged_meta |= flow.metadata | {"firewall_action": "ALLOW"}
 aug_merged_meta["firewall_name"] = "github"
@@ -849,12 +898,17 @@ match match_payload:
     case _:
         pass
 match_alias_after_case["vm_run_id"] = "run-1"
+match match_payload:
+    case _ if (guard_case_meta := flow.metadata) and False:
+        pass
+    case _:
+        guard_case_meta["vm_run_id"] = "run-1"
 """
     )
 
     violations = _metadata_key_violations(source_path)
 
-    assert len(violations) == 55
+    assert len(violations) == 66
     assert all("use metadata_keys." in violation for violation in violations)
 
 
@@ -881,6 +935,16 @@ value = both_branch_meta["vm_run_id"]
 external_aug_meta = {}
 external_aug_meta |= {"vm_run_id": "external"}
 value = external_aug_meta["vm_run_id"]
+external_keyword_meta = dict(metadata=flow.metadata, vm_run_id="external")
+value = external_keyword_meta["vm_run_id"]
+external_conditional_meta = {"vm_run_id": "external"} if condition else {}
+value = external_conditional_meta["vm_run_id"]
+external_bool_meta = fallback_meta or {"vm_run_id": "external"}
+value = external_bool_meta["vm_run_id"]
+external_copy_meta = {"vm_run_id": "external"}.copy()
+value = external_copy_meta["vm_run_id"]
+value = ({"vm_run_id": "external"} if condition else {}).get("vm_run_id")
+value = "vm_run_id" in ({"vm_run_id": "external"} if condition else {})
 def terminal_if_rebinds_to_external(condition):
     terminal_if_meta = flow.metadata
     if condition:
@@ -918,6 +982,38 @@ def terminal_match_rebinds_to_external(match_payload):
         case _:
             terminal_match_meta = {}
     return terminal_match_meta["vm_run_id"]
+def guarded_capture_rebinds_to_external(match_payload):
+    guarded_capture_meta = flow.metadata
+    match match_payload:
+        case guarded_capture_meta if False:
+            pass
+    return guarded_capture_meta["vm_run_id"]
+def guarded_as_capture_rebinds_to_external(match_payload):
+    guarded_as_meta = flow.metadata
+    match match_payload:
+        case _ as guarded_as_meta if False:
+            pass
+    return guarded_as_meta["vm_run_id"]
+def with_target_rebinds_to_external():
+    with_target_meta = flow.metadata
+    with context() as with_target_meta:
+        pass
+    return with_target_meta["vm_run_id"]
+async def async_with_target_rebinds_to_external():
+    async_with_target_meta = flow.metadata
+    async with context() as async_with_target_meta:
+        pass
+    return async_with_target_meta["vm_run_id"]
+def break_skips_unreachable_metadata_access():
+    for item in rows:
+        unreachable_break_meta = flow.metadata
+        break
+        unreachable_break_meta["vm_run_id"]
+def continue_skips_unreachable_metadata_access():
+    for item in rows:
+        unreachable_continue_meta = flow.metadata
+        continue
+        unreachable_continue_meta["vm_run_id"]
 def accepts_external_metadata(meta):
     return meta["vm_proxy_log_path"]
 for meta in [{"firewall_name": "external"}]:
@@ -936,6 +1032,8 @@ from json import dumps as meta
 value = meta["vm_run_id"]
 meta, other = flow.metadata
 value = meta["vm_run_id"]
+*starred_meta, = flow.metadata
+value = starred_meta["vm_run_id"]
 fn = lambda meta: meta["vm_run_id"]
 values = [meta["vm_run_id"] for meta in [{"vm_run_id": "external"}]]
 values = {meta["vm_run_id"] for meta in [{"vm_run_id": "external"}]}

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -1310,6 +1310,8 @@ def _metadata_dict_key_violations(path: Path, node: ast.AST | None) -> list[str]
                 dict_call_violations.extend(_metadata_dict_key_violations(path, update_arg))
                 dict_call_violations.extend(_metadata_keyword_violations(path, node.keywords))
                 return dict_call_violations
+            if node.func.id == "zip":
+                return _metadata_zip_key_violations(path, node)
             if node.func.id in _SEQUENCE_WRAPPER_CALLS:
                 update_arg = None if not node.args else node.args[0]
                 return _metadata_dict_key_violations(path, update_arg)
@@ -1331,12 +1333,56 @@ def _metadata_pair_sequence_violations(
 ) -> list[str]:
     violations: list[str] = []
     for item in node.elts:
+        if isinstance(item, ast.Starred):
+            violations.extend(_metadata_pair_iterable_violations(path, item.value))
+            continue
         if not isinstance(item, ast.List | ast.Tuple) or len(item.elts) != 2:
             continue
         key_name = _registered_key_name(item.elts[0])
         if key_name is not None:
             violations.append(_violation(path, item.elts[0], key_name))
     return violations
+
+
+def _metadata_pair_iterable_violations(path: Path, node: ast.AST) -> list[str]:
+    if isinstance(node, ast.NamedExpr):
+        return _metadata_pair_iterable_violations(path, node.value)
+    if isinstance(node, ast.IfExp):
+        return [
+            *_metadata_pair_iterable_violations(path, node.body),
+            *_metadata_pair_iterable_violations(path, node.orelse),
+        ]
+    if isinstance(node, ast.BoolOp):
+        violations: list[str] = []
+        for value in node.values:
+            violations.extend(_metadata_pair_iterable_violations(path, value))
+        return violations
+    if isinstance(node, ast.List | ast.Tuple | ast.Set):
+        return _metadata_pair_sequence_violations(path, node)
+    if isinstance(node, ast.Call):
+        if (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr == "items"
+            and not node.args
+            and not node.keywords
+        ):
+            return _metadata_dict_key_violations(path, node.func.value)
+        if (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr == "copy"
+            and not node.args
+            and not node.keywords
+        ):
+            return _metadata_pair_iterable_violations(path, node.func.value)
+        if isinstance(node.func, ast.Name):
+            if node.func.id == "zip":
+                return _metadata_zip_key_violations(path, node)
+            if node.func.id in _SEQUENCE_WRAPPER_CALLS:
+                update_arg = None if not node.args else node.args[0]
+                if update_arg is None:
+                    return []
+                return _metadata_pair_iterable_violations(path, update_arg)
+    return []
 
 
 def _metadata_key_sequence_violations(path: Path, node: ast.AST | None) -> list[str]:
@@ -1395,10 +1441,18 @@ def _metadata_key_sequence_violations(path: Path, node: ast.AST | None) -> list[
         return []
     violations: list[str] = []
     for element in node.elts:
+        if isinstance(element, ast.Starred):
+            violations.extend(_metadata_key_sequence_violations(path, element.value))
+            continue
         key_name = _registered_key_name(element)
         if key_name is not None:
             violations.append(_violation(path, element, key_name))
     return violations
+
+
+def _metadata_zip_key_violations(path: Path, node: ast.Call) -> list[str]:
+    keys_arg = None if not node.args else node.args[0]
+    return _metadata_key_sequence_violations(path, keys_arg)
 
 
 def _metadata_keyword_violations(path: Path, keywords: list[ast.keyword]) -> list[str]:
@@ -1464,6 +1518,17 @@ flow.metadata.update(dict.fromkeys(reversed(["auth_refreshed_secrets"]), []))
 flow.metadata.update(dict.fromkeys({"firewall_base": "https://api.example.com"} | {}, "base"))
 flow.metadata.update(dict.fromkeys(({"firewall_action": "ALLOW"} | {}).keys(), "ALLOW"))
 flow.metadata.update(dict.fromkeys({"firewall_error": "auth_failed"}.copy(), "auth_failed"))
+flow.metadata.update(zip(["vm_run_id"], ["run-1"]))
+flow.metadata = dict(zip(["firewall_name"], ["github"]))
+flow.metadata.update(dict(zip(("firewall_action",), ("ALLOW",))))
+flow.metadata.update([*[("firewall_permission", "read")]])
+flow.metadata.update((*[("firewall_base", "https://api.example.com")],))
+flow.metadata.update([*{"auth_url_rewrite": True}.items()])
+flow.metadata.update([*zip(["network_log_target"], [{}])])
+flow.metadata.update([*sorted([("vm_network_log_path", "network.jsonl")])])
+flow.metadata.update([*[("vm_proxy_log_path", "proxy.jsonl")].copy()])
+flow.metadata.update(dict.fromkeys([*["firewall_error"]], "auth_failed"))
+flow.metadata.update(dict.fromkeys((*["auth_cache_hit"],), False))
 flow.metadata.update(dict([("stream_buffer", bytearray())]))
 flow.metadata.update({**{"capture_body": True}})
 flow.metadata = {"request_stream_buffer": bytearray()} | {"request_stream_buffer_state": {}}
@@ -1763,7 +1828,7 @@ match flow.metadata:
 
     violations = _metadata_key_violations(source_path)
 
-    assert len(violations) == 175
+    assert len(violations) == 186
     assert all("use metadata_keys." in violation for violation in violations)
 
 
@@ -1825,6 +1890,17 @@ flow.metadata.update(dict.fromkeys(({metadata_keys.FIREWALL_ACTION: "ALLOW"} | {
 flow.metadata.update(
     dict.fromkeys({metadata_keys.FIREWALL_ERROR: "auth_failed"}.copy(), "auth_failed")
 )
+flow.metadata.update(zip([metadata_keys.VM_RUN_ID], ["run-1"]))
+flow.metadata = dict(zip([metadata_keys.FIREWALL_NAME], ["github"]))
+flow.metadata.update(dict(zip((metadata_keys.FIREWALL_ACTION,), ("ALLOW",))))
+flow.metadata.update([*[(metadata_keys.FIREWALL_PERMISSION, "read")]])
+flow.metadata.update((*[(metadata_keys.FIREWALL_BASE, "base")],))
+flow.metadata.update([*{metadata_keys.AUTH_URL_REWRITE: True}.items()])
+flow.metadata.update([*zip([metadata_keys.NETWORK_LOG_TARGET], [{}])])
+flow.metadata.update([*sorted([(metadata_keys.VM_NETWORK_LOG_PATH, "network.jsonl")])])
+flow.metadata.update([*[(metadata_keys.VM_PROXY_LOG_PATH, "proxy.jsonl")].copy()])
+flow.metadata.update(dict.fromkeys([*[metadata_keys.FIREWALL_ERROR]], "auth_failed"))
+flow.metadata.update(dict.fromkeys((*[metadata_keys.AUTH_CACHE_HIT],), False))
 external_conditional_meta = {"vm_run_id": "external"} if condition else {}
 value = external_conditional_meta["vm_run_id"]
 external_bool_meta = fallback_meta or {"vm_run_id": "external"}

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -873,6 +873,14 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
                     key_name = _REGISTERED_METADATA_KEYS.get(keyword.arg)
                     if key_name is not None:
                         self.violations.append(_violation(self.path, keyword, key_name))
+        self.visit(node.func)
+        for argument in node.args:
+            self.visit(argument)
+        for keyword in node.keywords:
+            self.visit(keyword.value)
+
+    def visit_keyword(self, node: ast.keyword) -> None:
+        self._record_metadata_merge_key_violations(node.value)
         self.generic_visit(node)
 
     def visit_Expr(self, node: ast.Expr) -> None:
@@ -1397,6 +1405,8 @@ class ClassTypeParamMeta[T: flow.metadata["firewall_name"]]:
     pass
 class ClassTypeParamMergeMeta[T: flow.metadata | {"firewall_name": "github"}]:
     pass
+class ClassKeywordMergeMeta(Base, option=flow.metadata | {"vm_run_id": "run-1"}):
+    pass
 type TypeAliasParamMeta[T: flow.metadata["firewall_base"]] = int
 type TypeAliasParamMergeMeta[T: flow.metadata | {"firewall_base": "https://api.example.com"}] = int
 type TypeAliasValueMeta = flow.metadata["vm_run_id"]
@@ -1540,7 +1550,7 @@ match match_payload:
 
     violations = _metadata_key_violations(source_path)
 
-    assert len(violations) == 138
+    assert len(violations) == 139
     assert all("use metadata_keys." in violation for violation in violations)
 
 

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -14,7 +14,16 @@ _REGISTERED_METADATA_KEYS = {
     for name, value in vars(metadata_keys).items()
     if name.isupper() and isinstance(value, str)
 }
-_METADATA_METHODS_WITH_KEY_ARGUMENTS = {"get", "pop", "setdefault"}
+_METADATA_METHODS_WITH_KEY_ARGUMENTS = {
+    "__contains__",
+    "__delitem__",
+    "__getitem__",
+    "__setitem__",
+    "get",
+    "pop",
+    "setdefault",
+}
+_METADATA_METHODS_WITH_DICT_ARGUMENTS = {"__ior__", "update"}
 
 
 def _python_files() -> list[Path]:
@@ -59,7 +68,7 @@ def _metadata_key_violations(path: Path) -> list[str]:
                 key_name = _registered_key_name(node.args[0])
                 if key_name is not None:
                     violations.append(_violation(path, node, key_name))
-            if node.func.attr == "update":
+            if node.func.attr in _METADATA_METHODS_WITH_DICT_ARGUMENTS:
                 violations.extend(_metadata_update_violations(path, node))
 
         if isinstance(node, ast.AugAssign) and _is_metadata_attribute(node.target):
@@ -169,12 +178,17 @@ flow.metadata.update({**{"capture_body": True}})
 flow.metadata = {"request_stream_buffer": bytearray()} | {"request_stream_buffer_state": {}}
 flow.metadata.update(**{"trusted_authority_host": "api.example.com"})
 flow.metadata.update([("http_request_start_monotonic", 1.0)])
+flow.metadata.__getitem__("vm_sandbox_token")
+flow.metadata.__setitem__("firewall_api_id", "run-1:0")
+flow.metadata.__delitem__("network_log_target")
+flow.metadata.__contains__("browser_user_agent")
+flow.metadata.__ior__({"suppress_request_body_capture": True})
 """
     )
 
     violations = _metadata_key_violations(source_path)
 
-    assert len(violations) == 13
+    assert len(violations) == 18
     assert all("use metadata_keys." in violation for violation in violations)
 
 

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -528,8 +528,10 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self, body: list[ast.stmt], aliases: set[str]
     ) -> tuple[set[str], bool]:
         violation_count = len(self.violations)
+        checked_node_ids = set(self._metadata_key_checked_node_ids)
         result = self._visit_branch_body(body, aliases)
         del self.violations[violation_count:]
+        self._metadata_key_checked_node_ids = checked_node_ids
         return result
 
     def _visit_except_handler_branch(
@@ -798,9 +800,10 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self._visit_sequence_expression(node)
 
     def visit_Dict(self, node: ast.Dict) -> None:
-        if not self._is_metadata_merge_value(node):
-            for key, value in zip(node.keys, node.values, strict=True):
-                self._record_metadata_merge_key_violations(key)
+        node_is_metadata_merge = self._is_metadata_merge_value(node)
+        for key, value in zip(node.keys, node.values, strict=True):
+            self._record_metadata_merge_key_violations(key)
+            if key is not None or not node_is_metadata_merge:
                 self._record_metadata_merge_key_violations(value)
         self.generic_visit(node)
 
@@ -849,8 +852,8 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         node_is_metadata_merge = self._is_metadata_merge_value(node)
         self._record_metadata_merge_key_violations(node)
         self._record_metadata_merge_key_violations(node.func)
-        for argument in node.args:
-            if not node_is_metadata_merge:
+        for index, argument in enumerate(node.args):
+            if not node_is_metadata_merge or index > 0:
                 self._record_metadata_merge_key_violations(argument)
         for keyword in node.keywords:
             if not (node_is_metadata_merge and keyword.arg is None):
@@ -1343,6 +1346,7 @@ merged_meta = dict(merged_meta, firewall_action="ALLOW")
 kwargs_merged_meta = dict(**flow.metadata, vm_run_id="run-1")
 dict_inner_union_meta = dict(flow.metadata | {"vm_run_id": "run-1"})
 dict_unpack_union_meta = dict(**(flow.metadata | {"firewall_name": "github"}))
+dict_second_positional_meta = dict(flow.metadata, flow.metadata | {"firewall_action": "ALLOW"})
 kwargs_alias_meta = dict(**flow.metadata)
 kwargs_alias_meta["vm_run_id"] = "run-1"
 conditional_expr_meta = flow.metadata if condition else {}
@@ -1439,6 +1443,7 @@ value = (flow.metadata | {"firewall_api_id": "run-1:0"}).items
 values = [*(flow.metadata | {"suppress_request_body_capture": True})]
 value = rows[:(flow.metadata | {"capture_body": True})]
 values = [{**(flow.metadata | {"connector_diagnostic_base": "https://api.example.com"})}]
+values = {**flow.metadata, "payload": flow.metadata | {"vm_run_id": "run-1"}}
 values = [flow.metadata | {"firewall_permission": "read"} for item in rows]
 for item in flow.metadata | {"firewall_rule_match": "GET /items"}:
     pass
@@ -1535,7 +1540,7 @@ match match_payload:
 
     violations = _metadata_key_violations(source_path)
 
-    assert len(violations) == 136
+    assert len(violations) == 138
     assert all("use metadata_keys." in violation for violation in violations)
 
 

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -1,6 +1,7 @@
 """Tests for the shared flow metadata key registry contract."""
 
 import ast
+import sys
 from pathlib import Path
 from typing import TypeGuard
 
@@ -26,6 +27,11 @@ _METADATA_METHODS_WITH_KEY_ARGUMENTS = {
 }
 _METADATA_METHODS_WITH_DICT_ARGUMENTS = {"__ior__", "update"}
 _SEQUENCE_WRAPPER_CALLS = {"frozenset", "iter", "list", "reversed", "set", "sorted", "tuple"}
+_SUPPORTS_PEP695_SYNTAX = sys.version_info >= (3, 12)
+
+
+def _write_python_source(path: Path, source: str, *, pep695_source: str = "") -> None:
+    path.write_text(source + (pep695_source if _SUPPORTS_PEP695_SYNTAX else ""))
 
 
 def _python_files() -> list[Path]:
@@ -1592,7 +1598,8 @@ def test_registered_flow_metadata_keys_use_registry_constants():
 
 def test_registered_flow_metadata_guard_flags_direct_literals(tmp_path):
     source_path = tmp_path / "violations.py"
-    source_path.write_text(
+    _write_python_source(
+        source_path,
         """
 flow.metadata["vm_run_id"] = "run-1"
 flow.metadata[f"vm_run_id"] = "run-1"
@@ -1791,31 +1798,6 @@ def vararg_annotation_alias_order(
     kw: vararg_annotation_meta["vm_run_id"],
 ):
     pass
-def function_type_param_meta[T: flow.metadata["vm_run_id"]]():
-    pass
-def function_type_param_merge_meta[T: flow.metadata | {"vm_run_id": "run-1"}]():
-    pass
-async def async_function_type_param_meta[T: flow.metadata["firewall_action"]]():
-    pass
-class ClassTypeParamMeta[T: flow.metadata["firewall_name"]]:
-    pass
-class ClassTypeParamMergeMeta[T: flow.metadata | {"firewall_name": "github"}]:
-    pass
-class ClassKeywordMergeMeta(Base, option=flow.metadata | {"vm_run_id": "run-1"}):
-    pass
-type TypeAliasParamMeta[T: flow.metadata["firewall_base"]] = int
-type TypeAliasParamMergeMeta[T: flow.metadata | {"firewall_base": "https://api.example.com"}] = int
-type TypeAliasValueMeta = flow.metadata["vm_run_id"]
-type TypeAliasMergeMeta = flow.metadata | {"firewall_action": "ALLOW"}
-default_type_param_shadow_meta = flow.metadata
-def default_type_param_reads_outer[default_type_param_shadow_meta](
-    arg=default_type_param_shadow_meta["vm_run_id"],
-):
-    pass
-type_param_restored_meta = flow.metadata
-def type_param_scope_restores_alias[type_param_restored_meta]():
-    pass
-type_param_restored_meta["firewall_name"] = "github"
 def call_argument_metadata_merge():
     send(flow.metadata | {"vm_run_id": "run-1"})
 def return_metadata_merge():
@@ -1865,10 +1847,6 @@ def nested_function_global_reads_module_metadata():
     def inner():
         global function_global_meta
         function_global_meta["vm_run_id"] = "run-1"
-function_type_param_global_meta = flow.metadata
-def function_type_param_global_reads_module[function_type_param_global_meta]():
-    global function_type_param_global_meta
-    function_type_param_global_meta["firewall_action"] = "ALLOW"
 if conditional_meta := flow.metadata:
     conditional_meta["connector_diagnostic_base"] = "https://api.example.com"
 branch_meta = flow.metadata
@@ -1971,12 +1949,44 @@ match flow.metadata:
 match flow.metadata:
     case guarded_match_meta if guarded_match_meta["vm_run_id"]:
         pass
-"""
+""",
+        pep695_source="""
+def function_type_param_meta[T: flow.metadata["vm_run_id"]]():
+    pass
+def function_type_param_merge_meta[T: flow.metadata | {"vm_run_id": "run-1"}]():
+    pass
+async def async_function_type_param_meta[T: flow.metadata["firewall_action"]]():
+    pass
+class ClassTypeParamMeta[T: flow.metadata["firewall_name"]]:
+    pass
+class ClassTypeParamMergeMeta[T: flow.metadata | {"firewall_name": "github"}]:
+    pass
+class ClassKeywordMergeMeta(Base, option=flow.metadata | {"vm_run_id": "run-1"}):
+    pass
+type TypeAliasParamMeta[T: flow.metadata["firewall_base"]] = int
+type TypeAliasParamMergeMeta[T: flow.metadata | {"firewall_base": "https://api.example.com"}] = int
+type TypeAliasValueMeta = flow.metadata["vm_run_id"]
+type TypeAliasMergeMeta = flow.metadata | {"firewall_action": "ALLOW"}
+default_type_param_shadow_meta = flow.metadata
+def default_type_param_reads_outer[default_type_param_shadow_meta](
+    arg=default_type_param_shadow_meta["vm_run_id"],
+):
+    pass
+type_param_restored_meta = flow.metadata
+def type_param_scope_restores_alias[type_param_restored_meta]():
+    pass
+type_param_restored_meta["firewall_name"] = "github"
+function_type_param_global_meta = flow.metadata
+def function_type_param_global_reads_module[function_type_param_global_meta]():
+    global function_type_param_global_meta
+    function_type_param_global_meta["firewall_action"] = "ALLOW"
+""",
     )
 
     violations = _metadata_key_violations(source_path)
 
-    assert len(violations) == 223
+    expected_violation_count = 223 if _SUPPORTS_PEP695_SYNTAX else 210
+    assert len(violations) == expected_violation_count
     assert all("use metadata_keys." in violation for violation in violations)
 
 
@@ -1984,7 +1994,8 @@ def test_registered_flow_metadata_guard_ignores_external_schema_and_private_mark
     tmp_path,
 ):
     source_path = tmp_path / "allowed.py"
-    source_path.write_text(
+    _write_python_source(
+        source_path,
         """
 entry["firewall_name"] = "github"
 payload = {"vm_run_id": "run-1"}
@@ -2190,31 +2201,6 @@ def annotation_walrus_local_shadow():
     value = annotation_shadow_meta["vm_run_id"]
     def inner(arg: (annotation_shadow_meta := {})):
         pass
-type_alias_shadow_meta = flow.metadata
-type type_alias_shadow_meta = int
-value = type_alias_shadow_meta["vm_run_id"]
-type_alias_value_shadow_meta = flow.metadata
-type type_alias_value_shadow_meta = type_alias_value_shadow_meta["vm_run_id"]
-function_type_alias_shadow_meta = flow.metadata
-def function_type_alias_local_shadow():
-    value = function_type_alias_shadow_meta["vm_run_id"]
-    type function_type_alias_shadow_meta = int
-class TypeAliasDoesNotSeeClassAlias:
-    class_type_alias_meta = flow.metadata
-    type class_type_alias_meta = int
-    value = class_type_alias_meta["vm_run_id"]
-type_param_shadow_meta = flow.metadata
-def function_type_param_shadows_outer[type_param_shadow_meta](
-    arg: type_param_shadow_meta["vm_run_id"],
-) -> type_param_shadow_meta["firewall_name"]:
-    type_param_shadow_meta["firewall_base"]
-class ClassTypeParamShadowsOuter[type_param_shadow_meta](type_param_shadow_meta):
-    value = type_param_shadow_meta["vm_run_id"]
-    def method(self):
-        type_param_shadow_meta["firewall_name"]
-type TypeAliasTypeParamShadowsOuter[type_param_shadow_meta] = type_param_shadow_meta[
-    "vm_run_id"
-]
 def nested_function_global_reads_external():
     function_global_external_meta = {}
     def inner():
@@ -2306,7 +2292,34 @@ try:
     pass
 except Exception as meta:
     value = meta["vm_run_id"]
-"""
+""",
+        pep695_source="""
+type_alias_shadow_meta = flow.metadata
+type type_alias_shadow_meta = int
+value = type_alias_shadow_meta["vm_run_id"]
+type_alias_value_shadow_meta = flow.metadata
+type type_alias_value_shadow_meta = type_alias_value_shadow_meta["vm_run_id"]
+function_type_alias_shadow_meta = flow.metadata
+def function_type_alias_local_shadow():
+    value = function_type_alias_shadow_meta["vm_run_id"]
+    type function_type_alias_shadow_meta = int
+class TypeAliasDoesNotSeeClassAlias:
+    class_type_alias_meta = flow.metadata
+    type class_type_alias_meta = int
+    value = class_type_alias_meta["vm_run_id"]
+type_param_shadow_meta = flow.metadata
+def function_type_param_shadows_outer[type_param_shadow_meta](
+    arg: type_param_shadow_meta["vm_run_id"],
+) -> type_param_shadow_meta["firewall_name"]:
+    type_param_shadow_meta["firewall_base"]
+class ClassTypeParamShadowsOuter[type_param_shadow_meta](type_param_shadow_meta):
+    value = type_param_shadow_meta["vm_run_id"]
+    def method(self):
+        type_param_shadow_meta["firewall_name"]
+type TypeAliasTypeParamShadowsOuter[type_param_shadow_meta] = type_param_shadow_meta[
+    "vm_run_id"
+]
+""",
     )
 
     assert _metadata_key_violations(source_path) == []

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -98,6 +98,11 @@ def _metadata_dict_key_violations(path: Path, node: ast.AST | None) -> list[str]
         return []
     if isinstance(node, ast.List | ast.Tuple):
         return _metadata_pair_sequence_violations(path, node)
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+        return [
+            *_metadata_dict_key_violations(path, node.left),
+            *_metadata_dict_key_violations(path, node.right),
+        ]
     if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "dict":
         dict_call_violations: list[str] = []
         update_arg = None if not node.args else node.args[0]
@@ -107,8 +112,9 @@ def _metadata_dict_key_violations(path: Path, node: ast.AST | None) -> list[str]
     if not isinstance(node, ast.Dict):
         return []
     violations: list[str] = []
-    for key in node.keys:
+    for key, value in zip(node.keys, node.values, strict=True):
         if key is None:
+            violations.extend(_metadata_dict_key_violations(path, value))
             continue
         key_name = _registered_key_name(key)
         if key_name is not None:
@@ -159,12 +165,14 @@ flow.metadata.update(firewall_permission="read")
 flow.metadata |= {"vm_network_log_path": "network.jsonl"}
 flow.metadata = dict(vm_proxy_log_path="proxy.jsonl")
 flow.metadata.update(dict([("stream_buffer", bytearray())]))
+flow.metadata.update({**{"capture_body": True}})
+flow.metadata = {"request_stream_buffer": bytearray()} | {"request_stream_buffer_state": {}}
 """
     )
 
     violations = _metadata_key_violations(source_path)
 
-    assert len(violations) == 8
+    assert len(violations) == 11
     assert all("use metadata_keys." in violation for violation in violations)
 
 

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -127,18 +127,17 @@ def _static_call_argument_nodes(args: list[ast.expr], index: int) -> list[ast.AS
     for argument in args:
         next_consumed_counts: list[int] = []
         if isinstance(argument, ast.Starred):
-            expansions = _static_starred_argument_expansions(argument.value)
-            if expansions is None:
+            expansions, has_unknown_expansion = _static_starred_argument_expansions(argument.value)
+            for consumed in consumed_counts:
+                for expansion in expansions:
+                    for offset, expanded_argument in enumerate(expansion):
+                        if consumed + offset == index:
+                            result.append(expanded_argument)
+                    next_consumed_counts.append(consumed + len(expansion))
+            if has_unknown_expansion:
                 next_consumed_counts.extend(
                     consumed for consumed in consumed_counts if consumed <= index
                 )
-            else:
-                for consumed in consumed_counts:
-                    for expansion in expansions:
-                        for offset, expanded_argument in enumerate(expansion):
-                            if consumed + offset == index:
-                                result.append(expanded_argument)
-                        next_consumed_counts.append(consumed + len(expansion))
         else:
             for consumed in consumed_counts:
                 if consumed == index:
@@ -148,35 +147,49 @@ def _static_call_argument_nodes(args: list[ast.expr], index: int) -> list[ast.AS
     return result
 
 
-def _static_starred_argument_expansions(node: ast.AST) -> list[list[ast.AST]] | None:
+def _static_starred_argument_expansions(node: ast.AST) -> tuple[list[list[ast.AST]], bool]:
     if isinstance(node, ast.NamedExpr):
         return _static_starred_argument_expansions(node.value)
     if isinstance(node, ast.IfExp):
+        body_expansions, body_has_unknown_expansion = _static_starred_argument_expansions(node.body)
+        orelse_expansions, orelse_has_unknown_expansion = _static_starred_argument_expansions(
+            node.orelse
+        )
         return [
-            *(_static_starred_argument_expansions(node.body) or []),
-            *(_static_starred_argument_expansions(node.orelse) or []),
-        ]
+            *body_expansions,
+            *orelse_expansions,
+        ], body_has_unknown_expansion or orelse_has_unknown_expansion
     if isinstance(node, ast.BoolOp):
         expansions: list[list[ast.AST]] = []
+        has_unknown_expansion = False
         for value in node.values:
-            value_expansions = _static_starred_argument_expansions(value)
-            if value_expansions is not None:
-                expansions.extend(value_expansions)
-        return expansions
+            value_expansions, value_has_unknown_expansion = _static_starred_argument_expansions(
+                value
+            )
+            expansions.extend(value_expansions)
+            has_unknown_expansion = has_unknown_expansion or value_has_unknown_expansion
+        return expansions, has_unknown_expansion
     if not isinstance(node, ast.List | ast.Tuple):
-        return None
+        return [], True
     expansions = [[]]
+    has_unknown_expansion = False
     for element in node.elts:
         if isinstance(element, ast.Starred):
-            nested_expansions = _static_starred_argument_expansions(element.value)
-            if nested_expansions is None:
-                return None
-            expansions = [
-                [*prefix, *nested] for prefix in expansions for nested in nested_expansions
-            ]
+            nested_expansions, nested_has_unknown_expansion = _static_starred_argument_expansions(
+                element.value
+            )
+            next_expansions: list[list[ast.AST]] = []
+            if nested_expansions:
+                next_expansions.extend(
+                    [*prefix, *nested] for prefix in expansions for nested in nested_expansions
+                )
+            if nested_has_unknown_expansion:
+                next_expansions.extend(expansions)
+            expansions = next_expansions
+            has_unknown_expansion = has_unknown_expansion or nested_has_unknown_expansion
         else:
             expansions = [[*prefix, element] for prefix in expansions]
-    return expansions
+    return expansions, has_unknown_expansion
 
 
 def _type_params(node: ast.AST) -> list[ast.AST]:
@@ -2015,17 +2028,26 @@ def test_registered_flow_metadata_guard_flags_literals_after_dynamic_star_args(t
 flow.metadata.get(*args, "vm_run_id")
 flow.metadata.update(*args, {"firewall_name": "github"})
 flow.metadata.update(dict.fromkeys(*args, ["firewall_action"], "ALLOW"))
+flow.metadata.get(*(args if condition else other_args), "auth_cache_hit")
+flow.metadata.get(*(args if condition else ["firewall_error"]))
+flow.metadata.update(*([[("firewall_permission", "read")]] if condition else args))
+flow.metadata.get(*[*([prefix] if condition else args), "vm_network_log_path"])
 flow.metadata.get(*args, metadata_keys.VM_RUN_ID)
 flow.metadata.update(*args, {metadata_keys.FIREWALL_NAME: "github"})
+flow.metadata.get(*(args if condition else [metadata_keys.AUTH_CACHE_HIT]))
 """,
     )
 
     violations = _metadata_key_violations(source_path)
 
-    assert len(violations) == 3
+    assert len(violations) == 7
     assert any("metadata_keys.VM_RUN_ID" in violation for violation in violations)
     assert any("metadata_keys.FIREWALL_NAME" in violation for violation in violations)
     assert any("metadata_keys.FIREWALL_ACTION" in violation for violation in violations)
+    assert any("metadata_keys.AUTH_CACHE_HIT" in violation for violation in violations)
+    assert any("metadata_keys.FIREWALL_ERROR" in violation for violation in violations)
+    assert any("metadata_keys.FIREWALL_PERMISSION" in violation for violation in violations)
+    assert any("metadata_keys.VM_NETWORK_LOG_PATH" in violation for violation in violations)
 
 
 def test_registered_flow_metadata_guard_ignores_external_schema_and_private_markers(

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -366,6 +366,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
     def __init__(self, path: Path) -> None:
         self.path = path
         self.violations: list[str] = []
+        self._violation_messages: set[str] = set()
         self._metadata_alias_scopes: list[set[str]] = [set()]
         self._class_nested_scope_alias_scopes: list[set[str]] = []
         self._metadata_key_checked_node_ids: set[int] = set()
@@ -380,6 +381,20 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         if not self._named_expr_target_scope_indexes:
             return self._metadata_aliases
         return self._metadata_alias_scopes[self._named_expr_target_scope_indexes[-1]]
+
+    def _add_violation(self, violation: str) -> None:
+        if violation in self._violation_messages:
+            return
+        self._violation_messages.add(violation)
+        self.violations.append(violation)
+
+    def _add_violations(self, violations: list[str]) -> None:
+        for violation in violations:
+            self._add_violation(violation)
+
+    def visit(self, node: ast.AST) -> None:
+        self._record_metadata_merge_key_violations(node)
+        super().visit(node)
 
     def _is_metadata_reference(self, node: ast.AST) -> bool:
         return (
@@ -454,7 +469,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         if not violations:
             return
         self._metadata_key_checked_node_ids.add(node_id)
-        self.violations.extend(violations)
+        self._add_violations(violations)
 
     def _record_metadata_dict_key_violations(self, node: ast.AST | None) -> None:
         if node is None:
@@ -466,7 +481,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         if not violations:
             return
         self._metadata_key_checked_node_ids.add(node_id)
-        self.violations.extend(violations)
+        self._add_violations(violations)
 
     def _metadata_default_argument_names(self, args: ast.arguments) -> set[str]:
         metadata_defaults: set[str] = set()
@@ -528,9 +543,11 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self, body: list[ast.stmt], aliases: set[str]
     ) -> tuple[set[str], bool]:
         violation_count = len(self.violations)
+        violation_messages = set(self._violation_messages)
         checked_node_ids = set(self._metadata_key_checked_node_ids)
         result = self._visit_branch_body(body, aliases)
         del self.violations[violation_count:]
+        self._violation_messages = violation_messages
         self._metadata_key_checked_node_ids = checked_node_ids
         return result
 
@@ -845,7 +862,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         if self._is_metadata_alias_value(node.value):
             key_name = _registered_key_name(node.slice)
             if key_name is not None:
-                self.violations.append(_violation(self.path, node, key_name))
+                self._add_violation(_violation(self.path, node, key_name))
         self.generic_visit(node)
 
     def visit_Call(self, node: ast.Call) -> None:
@@ -862,7 +879,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
             if node.func.attr in _METADATA_METHODS_WITH_KEY_ARGUMENTS and node.args:
                 key_name = _registered_key_name(node.args[0])
                 if key_name is not None:
-                    self.violations.append(_violation(self.path, node, key_name))
+                    self._add_violation(_violation(self.path, node, key_name))
             if node.func.attr in _METADATA_METHODS_WITH_DICT_ARGUMENTS:
                 update_arg = None if not node.args else node.args[0]
                 self._record_metadata_dict_key_violations(update_arg)
@@ -872,7 +889,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
                         continue
                     key_name = _REGISTERED_METADATA_KEYS.get(keyword.arg)
                     if key_name is not None:
-                        self.violations.append(_violation(self.path, keyword, key_name))
+                        self._add_violation(_violation(self.path, keyword, key_name))
         self.visit(node.func)
         for argument in node.args:
             self.visit(argument)
@@ -920,7 +937,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         ):
             key_name = _registered_key_name(node.left)
             if key_name is not None:
-                self.violations.append(_violation(self.path, node, key_name))
+                self._add_violation(_violation(self.path, node, key_name))
         self.generic_visit(node)
 
     def visit_Delete(self, node: ast.Delete) -> None:

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -152,10 +152,61 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
             return _metadata_dict_key_violations(self.path, node)
         return []
 
-    def _visit_scoped_body(self, body: list[ast.stmt], shadowed: set[str] | None = None) -> None:
+    def _metadata_default_argument_names(self, args: ast.arguments) -> set[str]:
+        metadata_defaults: set[str] = set()
+        positional_args = [*args.posonlyargs, *args.args]
+        default_offset = len(positional_args) - len(args.defaults)
+        for arg, default in zip(positional_args[default_offset:], args.defaults, strict=True):
+            if self._is_metadata_reference(default) or self._is_metadata_merge_value(default):
+                metadata_defaults.add(arg.arg)
+        for arg, default in zip(args.kwonlyargs, args.kw_defaults, strict=True):
+            if default is not None and (
+                self._is_metadata_reference(default) or self._is_metadata_merge_value(default)
+            ):
+                metadata_defaults.add(arg.arg)
+        return metadata_defaults
+
+    def _visit_default_value(self, node: ast.AST) -> None:
+        self.violations.extend(self._metadata_merge_key_violations(node))
+        self.visit(node)
+
+    def _replace_current_aliases(self, aliases: set[str]) -> None:
+        self._metadata_aliases.clear()
+        self._metadata_aliases.update(aliases)
+
+    def _visit_branch_body(self, body: list[ast.stmt], aliases: set[str]) -> set[str]:
+        self._metadata_alias_scopes.append(set(aliases))
+        for statement in body:
+            self.visit(statement)
+        result = set(self._metadata_aliases)
+        self._metadata_alias_scopes.pop()
+        return result
+
+    def _visit_except_handler_branch(
+        self, handler: ast.ExceptHandler, aliases: set[str]
+    ) -> set[str]:
+        self._metadata_alias_scopes.append(set(aliases))
+        if handler.type is not None:
+            self.visit(handler.type)
+        if handler.name is not None:
+            self._metadata_aliases.discard(handler.name)
+        for statement in handler.body:
+            self.visit(statement)
+        result = set(self._metadata_aliases)
+        self._metadata_alias_scopes.pop()
+        return result
+
+    def _visit_scoped_body(
+        self,
+        body: list[ast.stmt],
+        shadowed: set[str] | None = None,
+        added: set[str] | None = None,
+    ) -> None:
         aliases = set(self._metadata_aliases)
         if shadowed is not None:
             aliases.difference_update(shadowed)
+        if added is not None:
+            aliases.update(added)
         self._metadata_alias_scopes.append(aliases)
         previous_named_expr_target_scope_indexes = self._named_expr_target_scope_indexes
         self._named_expr_target_scope_indexes = []
@@ -165,11 +216,16 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self._metadata_alias_scopes.pop()
 
     def _visit_scoped_expression(
-        self, expression: ast.AST, shadowed: set[str] | None = None
+        self,
+        expression: ast.AST,
+        shadowed: set[str] | None = None,
+        added: set[str] | None = None,
     ) -> None:
         aliases = set(self._metadata_aliases)
         if shadowed is not None:
             aliases.difference_update(shadowed)
+        if added is not None:
+            aliases.update(added)
         self._metadata_alias_scopes.append(aliases)
         previous_named_expr_target_scope_indexes = self._named_expr_target_scope_indexes
         self._named_expr_target_scope_indexes = []
@@ -180,26 +236,33 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
         for decorator in node.decorator_list:
             self.visit(decorator)
+        metadata_defaults = self._metadata_default_argument_names(node.args)
         for default in [*node.args.defaults, *node.args.kw_defaults]:
             if default is not None:
-                self.visit(default)
-        self._visit_scoped_body(node.body, _argument_names(node.args) | {node.name})
+                self._visit_default_value(default)
+        shadowed_names = (_argument_names(node.args) - metadata_defaults) | {node.name}
+        self._visit_scoped_body(node.body, shadowed_names, metadata_defaults)
         self._metadata_aliases.discard(node.name)
 
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
         for decorator in node.decorator_list:
             self.visit(decorator)
+        metadata_defaults = self._metadata_default_argument_names(node.args)
         for default in [*node.args.defaults, *node.args.kw_defaults]:
             if default is not None:
-                self.visit(default)
-        self._visit_scoped_body(node.body, _argument_names(node.args) | {node.name})
+                self._visit_default_value(default)
+        shadowed_names = (_argument_names(node.args) - metadata_defaults) | {node.name}
+        self._visit_scoped_body(node.body, shadowed_names, metadata_defaults)
         self._metadata_aliases.discard(node.name)
 
     def visit_Lambda(self, node: ast.Lambda) -> None:
+        metadata_defaults = self._metadata_default_argument_names(node.args)
         for default in [*node.args.defaults, *node.args.kw_defaults]:
             if default is not None:
-                self.visit(default)
-        self._visit_scoped_expression(node.body, _argument_names(node.args))
+                self._visit_default_value(default)
+        self._visit_scoped_expression(
+            node.body, _argument_names(node.args) - metadata_defaults, metadata_defaults
+        )
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
         for decorator in node.decorator_list:
@@ -237,9 +300,20 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
                 self._metadata_aliases.discard(node.target.id)
 
     def visit_AugAssign(self, node: ast.AugAssign) -> None:
-        if self._is_metadata_reference(node.target):
+        target_is_metadata = self._is_metadata_reference(node.target)
+        value_is_metadata_merge = self._is_metadata_merge_value(node.value)
+        if target_is_metadata:
             self.violations.extend(_metadata_dict_key_violations(self.path, node.value))
-        self.generic_visit(node)
+        elif value_is_metadata_merge:
+            self.violations.extend(self._metadata_merge_key_violations(node.value))
+        self.visit(node.target)
+        self.visit(node.value)
+        if (
+            isinstance(node.op, ast.BitOr)
+            and isinstance(node.target, ast.Name)
+            and (target_is_metadata or value_is_metadata_merge)
+        ):
+            self._metadata_aliases.add(node.target.id)
 
     def visit_NamedExpr(self, node: ast.NamedExpr) -> None:
         if isinstance(node.target, ast.Name):
@@ -292,45 +366,117 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
                 self._metadata_aliases.discard(name)
         self.generic_visit(node)
 
+    def visit_If(self, node: ast.If) -> None:
+        self.visit(node.test)
+        base_aliases = set(self._metadata_aliases)
+        body_aliases = self._visit_branch_body(node.body, base_aliases)
+        orelse_aliases = (
+            self._visit_branch_body(node.orelse, base_aliases) if node.orelse else base_aliases
+        )
+        self._replace_current_aliases(body_aliases | orelse_aliases)
+
     def visit_For(self, node: ast.For) -> None:
         self.visit(node.iter)
+        base_aliases = set(self._metadata_aliases)
         self._discard_alias_target(node.target)
-        for statement in node.body:
-            self.visit(statement)
-        for statement in node.orelse:
-            self.visit(statement)
+        body_aliases = self._visit_branch_body(node.body, set(self._metadata_aliases))
+        loop_exit_aliases = base_aliases | body_aliases
+        orelse_aliases = (
+            self._visit_branch_body(node.orelse, loop_exit_aliases)
+            if node.orelse
+            else loop_exit_aliases
+        )
+        self._replace_current_aliases(loop_exit_aliases | orelse_aliases)
 
     def visit_AsyncFor(self, node: ast.AsyncFor) -> None:
         self.visit(node.iter)
+        base_aliases = set(self._metadata_aliases)
         self._discard_alias_target(node.target)
-        for statement in node.body:
-            self.visit(statement)
-        for statement in node.orelse:
-            self.visit(statement)
+        body_aliases = self._visit_branch_body(node.body, set(self._metadata_aliases))
+        loop_exit_aliases = base_aliases | body_aliases
+        orelse_aliases = (
+            self._visit_branch_body(node.orelse, loop_exit_aliases)
+            if node.orelse
+            else loop_exit_aliases
+        )
+        self._replace_current_aliases(loop_exit_aliases | orelse_aliases)
+
+    def visit_While(self, node: ast.While) -> None:
+        self.visit(node.test)
+        base_aliases = set(self._metadata_aliases)
+        body_aliases = self._visit_branch_body(node.body, base_aliases)
+        loop_exit_aliases = base_aliases | body_aliases
+        orelse_aliases = (
+            self._visit_branch_body(node.orelse, loop_exit_aliases)
+            if node.orelse
+            else loop_exit_aliases
+        )
+        self._replace_current_aliases(loop_exit_aliases | orelse_aliases)
 
     def visit_With(self, node: ast.With) -> None:
         for item in node.items:
             self.visit(item.context_expr)
+        base_aliases = set(self._metadata_aliases)
+        body_aliases = set(self._metadata_aliases)
+        self._metadata_alias_scopes.append(body_aliases)
+        for item in node.items:
             self._discard_alias_target(item.optional_vars)
         for statement in node.body:
             self.visit(statement)
+        body_result_aliases = set(self._metadata_aliases)
+        self._metadata_alias_scopes.pop()
+        self._replace_current_aliases(base_aliases | body_result_aliases)
 
     def visit_AsyncWith(self, node: ast.AsyncWith) -> None:
         for item in node.items:
             self.visit(item.context_expr)
+        base_aliases = set(self._metadata_aliases)
+        body_aliases = set(self._metadata_aliases)
+        self._metadata_alias_scopes.append(body_aliases)
+        for item in node.items:
             self._discard_alias_target(item.optional_vars)
         for statement in node.body:
             self.visit(statement)
+        body_result_aliases = set(self._metadata_aliases)
+        self._metadata_alias_scopes.pop()
+        self._replace_current_aliases(base_aliases | body_result_aliases)
 
     def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
         if node.type is not None:
             self.visit(node.type)
+        base_aliases = set(self._metadata_aliases)
+        self._metadata_alias_scopes.append(base_aliases)
         if node.name is not None:
             self._metadata_aliases.discard(node.name)
         for statement in node.body:
             self.visit(statement)
-        if node.name is not None:
-            self._metadata_aliases.discard(node.name)
+        result_aliases = set(self._metadata_aliases)
+        self._metadata_alias_scopes.pop()
+        self._replace_current_aliases(base_aliases | result_aliases)
+
+    def _visit_try_statement(self, node: ast.Try) -> None:
+        base_aliases = set(self._metadata_aliases)
+        body_aliases = self._visit_branch_body(node.body, base_aliases)
+        handler_start_aliases = base_aliases | body_aliases
+        handler_aliases = [
+            self._visit_except_handler_branch(handler, handler_start_aliases)
+            for handler in node.handlers
+        ]
+        orelse_aliases = (
+            self._visit_branch_body(node.orelse, body_aliases) if node.orelse else body_aliases
+        )
+        exit_aliases = base_aliases | body_aliases | orelse_aliases
+        for aliases in handler_aliases:
+            exit_aliases.update(aliases)
+        if node.finalbody:
+            exit_aliases = self._visit_branch_body(node.finalbody, exit_aliases)
+        self._replace_current_aliases(exit_aliases)
+
+    def visit_Try(self, node: ast.Try) -> None:
+        self._visit_try_statement(node)
+
+    def visit_TryStar(self, node: ast.Try) -> None:
+        self._visit_try_statement(node)
 
     def visit_Match(self, node: ast.Match) -> None:
         self.visit(node.subject)
@@ -539,8 +685,48 @@ merged_meta = dict(merged_meta, firewall_action="ALLOW")
 (merged_named_expr_meta := flow.metadata | {"firewall_name": "github"})
 (inline_meta := flow.metadata)["connector_diagnostic_type"] = "github"
 (call_meta := flow.metadata).get("connector_diagnostic_reason")
+def function_default_meta(default_meta=flow.metadata):
+    default_meta["vm_run_id"] = "run-1"
+lambda_default_meta = lambda default_meta=flow.metadata: default_meta["vm_network_log_path"]
 if conditional_meta := flow.metadata:
     conditional_meta["connector_diagnostic_base"] = "https://api.example.com"
+branch_meta = flow.metadata
+if condition:
+    branch_meta = {}
+branch_meta["vm_proxy_log_path"] = "proxy.jsonl"
+while_meta = flow.metadata
+while condition:
+    while_meta = {}
+while_meta["capture_body"] = True
+loop_meta = flow.metadata
+for loop_meta in rows:
+    pass
+loop_meta["vm_sandbox_token"] = "sandbox"
+try_meta = flow.metadata
+try:
+    try_meta = {}
+except Exception:
+    pass
+try_meta["original_url"] = "https://api.example.com"
+except_meta = flow.metadata
+try:
+    pass
+except Exception as except_meta:
+    pass
+except_meta["suppress_request_body_capture"] = True
+except_star_meta = flow.metadata
+try:
+    pass
+except* Exception as except_star_meta:
+    pass
+except_star_meta["firewall_error"] = "auth_failed"
+with_meta = flow.metadata
+with context() as with_meta:
+    pass
+with_meta["network_log_target"] = {}
+aug_merged_meta = {}
+aug_merged_meta |= flow.metadata | {"firewall_action": "ALLOW"}
+aug_merged_meta["firewall_name"] = "github"
 outer_meta = flow.metadata
 values = [outer_meta["auth_refreshed_connectors"] for item in rows]
 values = [(leaked_meta := flow.metadata) for item in rows]
@@ -565,7 +751,7 @@ match payload:
 
     violations = _metadata_key_violations(source_path)
 
-    assert len(violations) == 42
+    assert len(violations) == 53
     assert all("use metadata_keys." in violation for violation in violations)
 
 
@@ -583,6 +769,15 @@ external_meta_value = flow.metadata
 payload = {"vm_run_id": "external", "metadata": external_meta_value}
 meta = flow.metadata
 meta = {"vm_run_id": "external payload"}
+both_branch_meta = flow.metadata
+if condition:
+    both_branch_meta = {}
+else:
+    both_branch_meta = {}
+value = both_branch_meta["vm_run_id"]
+external_aug_meta = {}
+external_aug_meta |= {"vm_run_id": "external"}
+value = external_aug_meta["vm_run_id"]
 def accepts_external_metadata(meta):
     return meta["vm_proxy_log_path"]
 for meta in [{"firewall_name": "external"}]:

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -324,6 +324,22 @@ def _pattern_names(pattern: ast.pattern) -> set[str]:
     return set()
 
 
+def _metadata_match_pattern_alias_names(pattern: ast.pattern) -> set[str]:
+    if isinstance(pattern, ast.MatchAs):
+        names = set() if pattern.name is None else {pattern.name}
+        if pattern.pattern is not None:
+            names.update(_metadata_match_pattern_alias_names(pattern.pattern))
+        return names
+    if isinstance(pattern, ast.MatchMapping):
+        return set() if pattern.rest is None else {pattern.rest}
+    if isinstance(pattern, ast.MatchOr):
+        names: set[str] = set()
+        for child_pattern in pattern.patterns:
+            names.update(_metadata_match_pattern_alias_names(child_pattern))
+        return names
+    return set()
+
+
 def _pattern_is_exhaustive(pattern: ast.pattern) -> bool:
     if isinstance(pattern, ast.MatchAs):
         return pattern.pattern is None or _pattern_is_exhaustive(pattern.pattern)
@@ -1113,6 +1129,8 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
             pattern_is_exhaustive = _pattern_is_exhaustive(case.pattern)
             aliases = set(continuing_aliases)
             aliases.difference_update(names)
+            if subject_is_metadata:
+                aliases.update(_metadata_match_pattern_alias_names(case.pattern))
             self._metadata_alias_scopes.append(aliases)
             if case.guard is not None:
                 self._record_metadata_merge_key_violations(case.guard)
@@ -1595,12 +1613,30 @@ meta = flow.metadata
 match meta:
     case {"firewall_name": firewall_name}:
         pass
+match flow.metadata:
+    case captured_match_meta:
+        captured_match_meta["vm_run_id"] = "run-1"
+match flow.metadata:
+    case _ as as_match_meta:
+        as_match_meta.get("firewall_name")
+match flow.metadata:
+    case {"payload": payload, **rest_match_meta}:
+        rest_match_meta["firewall_action"] = "ALLOW"
+match flow.metadata:
+    case {**only_rest_match_meta}:
+        only_rest_match_meta["firewall_permission"] = "read"
+match flow.metadata:
+    case {"payload": payload} as matched_meta:
+        matched_meta["firewall_base"] = "https://api.example.com"
+match flow.metadata:
+    case guarded_match_meta if guarded_match_meta["vm_run_id"]:
+        pass
 """
     )
 
     violations = _metadata_key_violations(source_path)
 
-    assert len(violations) == 145
+    assert len(violations) == 151
     assert all("use metadata_keys." in violation for violation in violations)
 
 
@@ -1852,6 +1888,9 @@ match payload:
         pass
 match flow.metadata:
     case {"payload": {"vm_run_id": external_run_id}}:
+        pass
+match flow.metadata:
+    case {metadata_keys.VM_RUN_ID: run_id}:
         pass
 try:
     pass

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -49,6 +49,26 @@ def _violation(path: Path, node: ast.AST, key_name: str) -> str:
     return f"{location}:{line_number}: use metadata_keys.{key_name} for flow.metadata access"
 
 
+def _target_names(node: ast.AST | None) -> set[str]:
+    if isinstance(node, ast.Name):
+        return {node.id}
+    if isinstance(node, ast.List | ast.Tuple):
+        names: set[str] = set()
+        for element in node.elts:
+            names.update(_target_names(element))
+        return names
+    return set()
+
+
+def _argument_names(args: ast.arguments) -> set[str]:
+    names = {arg.arg for arg in [*args.posonlyargs, *args.args, *args.kwonlyargs]}
+    if args.vararg is not None:
+        names.add(args.vararg.arg)
+    if args.kwarg is not None:
+        names.add(args.kwarg.arg)
+    return names
+
+
 class _MetadataKeyVisitor(ast.NodeVisitor):
     def __init__(self, path: Path) -> None:
         self.path = path
@@ -64,19 +84,38 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
             isinstance(node, ast.Name) and node.id in self._metadata_aliases
         )
 
-    def _visit_scoped_body(self, body: list[ast.stmt]) -> None:
-        self._metadata_alias_scopes.append(set(self._metadata_aliases))
+    def _visit_scoped_body(self, body: list[ast.stmt], shadowed: set[str] | None = None) -> None:
+        aliases = set(self._metadata_aliases)
+        if shadowed is not None:
+            aliases.difference_update(shadowed)
+        self._metadata_alias_scopes.append(aliases)
         for statement in body:
             self.visit(statement)
         self._metadata_alias_scopes.pop()
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
-        self._visit_scoped_body(node.body)
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        for default in [*node.args.defaults, *node.args.kw_defaults]:
+            if default is not None:
+                self.visit(default)
+        self._visit_scoped_body(node.body, _argument_names(node.args))
 
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
-        self._visit_scoped_body(node.body)
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        for default in [*node.args.defaults, *node.args.kw_defaults]:
+            if default is not None:
+                self.visit(default)
+        self._visit_scoped_body(node.body, _argument_names(node.args))
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        for base in node.bases:
+            self.visit(base)
+        for keyword in node.keywords:
+            self.visit(keyword)
         self._visit_scoped_body(node.body)
 
     def visit_Assign(self, node: ast.Assign) -> None:
@@ -130,19 +169,52 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
 
     def visit_Delete(self, node: ast.Delete) -> None:
         for target in node.targets:
-            if isinstance(target, ast.Name):
-                self._metadata_aliases.discard(target.id)
+            for name in _target_names(target):
+                self._metadata_aliases.discard(name)
         self.generic_visit(node)
+
+    def visit_For(self, node: ast.For) -> None:
+        self.visit(node.iter)
+        self._discard_alias_target(node.target)
+        for statement in node.body:
+            self.visit(statement)
+        for statement in node.orelse:
+            self.visit(statement)
+
+    def visit_AsyncFor(self, node: ast.AsyncFor) -> None:
+        self.visit(node.iter)
+        self._discard_alias_target(node.target)
+        for statement in node.body:
+            self.visit(statement)
+        for statement in node.orelse:
+            self.visit(statement)
+
+    def visit_With(self, node: ast.With) -> None:
+        for item in node.items:
+            self.visit(item.context_expr)
+            self._discard_alias_target(item.optional_vars)
+        for statement in node.body:
+            self.visit(statement)
+
+    def visit_AsyncWith(self, node: ast.AsyncWith) -> None:
+        for item in node.items:
+            self.visit(item.context_expr)
+            self._discard_alias_target(item.optional_vars)
+        for statement in node.body:
+            self.visit(statement)
 
     def _update_aliases_from_assign(self, node: ast.Assign) -> None:
         is_metadata_alias = self._is_metadata_reference(node.value)
         for target in node.targets:
-            if not isinstance(target, ast.Name):
-                continue
-            if is_metadata_alias:
-                self._metadata_aliases.add(target.id)
-            else:
-                self._metadata_aliases.discard(target.id)
+            for name in _target_names(target):
+                if is_metadata_alias:
+                    self._metadata_aliases.add(name)
+                else:
+                    self._metadata_aliases.discard(name)
+
+    def _discard_alias_target(self, target: ast.AST | None) -> None:
+        for name in _target_names(target):
+            self._metadata_aliases.discard(name)
 
 
 def _metadata_key_violations(path: Path) -> list[str]:
@@ -248,12 +320,16 @@ meta.get("vm_network_log_path")
 "firewall_name" in meta
 meta.update({"firewall_permission": "read"})
 meta |= {"firewall_rule_match": "GET /items"}
+def nested_alias():
+    inner_meta = flow.metadata
+    def uses_outer_alias():
+        inner_meta["auth_cache_hit"] = False
 """
     )
 
     violations = _metadata_key_violations(source_path)
 
-    assert len(violations) == 24
+    assert len(violations) == 25
     assert all("use metadata_keys." in violation for violation in violations)
 
 
@@ -269,6 +345,12 @@ assert "connector_response_finish" in flow.metadata
 flow.metadata["_local_marker"] = "private"
 meta = flow.metadata
 meta = {"vm_run_id": "external payload"}
+def accepts_external_metadata(meta):
+    return meta["vm_proxy_log_path"]
+for meta in [{"firewall_name": "external"}]:
+    value = meta["firewall_name"]
+with context() as meta:
+    value = meta["firewall_action"]
 """
     )
 

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -25,6 +25,7 @@ _METADATA_METHODS_WITH_KEY_ARGUMENTS = {
     "setdefault",
 }
 _METADATA_METHODS_WITH_DICT_ARGUMENTS = {"__ior__", "update"}
+_PAIR_SEQUENCE_WRAPPER_CALLS = {"iter", "list", "tuple"}
 
 
 def _python_files() -> list[Path]:
@@ -1272,19 +1273,39 @@ def _metadata_dict_key_violations(path: Path, node: ast.AST | None) -> list[str]
         for value in node.values:
             boolop_violations.extend(_metadata_dict_key_violations(path, value))
         return boolop_violations
-    if isinstance(node, ast.List | ast.Tuple):
+    if isinstance(node, ast.List | ast.Tuple | ast.Set):
         return _metadata_pair_sequence_violations(path, node)
     if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
         return [
             *_metadata_dict_key_violations(path, node.left),
             *_metadata_dict_key_violations(path, node.right),
         ]
-    if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "dict":
-        dict_call_violations: list[str] = []
-        update_arg = None if not node.args else node.args[0]
-        dict_call_violations.extend(_metadata_dict_key_violations(path, update_arg))
-        dict_call_violations.extend(_metadata_keyword_violations(path, node.keywords))
-        return dict_call_violations
+    if isinstance(node, ast.Call):
+        if (
+            isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "dict"
+            and node.func.attr == "fromkeys"
+        ):
+            keys_arg = None if not node.args else node.args[0]
+            return _metadata_key_sequence_violations(path, keys_arg)
+        if (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr == "items"
+            and not node.args
+            and not node.keywords
+        ):
+            return _metadata_dict_key_violations(path, node.func.value)
+        if isinstance(node.func, ast.Name):
+            if node.func.id == "dict":
+                dict_call_violations: list[str] = []
+                update_arg = None if not node.args else node.args[0]
+                dict_call_violations.extend(_metadata_dict_key_violations(path, update_arg))
+                dict_call_violations.extend(_metadata_keyword_violations(path, node.keywords))
+                return dict_call_violations
+            if node.func.id in _PAIR_SEQUENCE_WRAPPER_CALLS:
+                update_arg = None if not node.args else node.args[0]
+                return _metadata_dict_key_violations(path, update_arg)
     if not isinstance(node, ast.Dict):
         return []
     violations: list[str] = []
@@ -1298,7 +1319,9 @@ def _metadata_dict_key_violations(path: Path, node: ast.AST | None) -> list[str]
     return violations
 
 
-def _metadata_pair_sequence_violations(path: Path, node: ast.List | ast.Tuple) -> list[str]:
+def _metadata_pair_sequence_violations(
+    path: Path, node: ast.List | ast.Tuple | ast.Set
+) -> list[str]:
     violations: list[str] = []
     for item in node.elts:
         if not isinstance(item, ast.List | ast.Tuple) or len(item.elts) != 2:
@@ -1306,6 +1329,56 @@ def _metadata_pair_sequence_violations(path: Path, node: ast.List | ast.Tuple) -
         key_name = _registered_key_name(item.elts[0])
         if key_name is not None:
             violations.append(_violation(path, item.elts[0], key_name))
+    return violations
+
+
+def _metadata_key_sequence_violations(path: Path, node: ast.AST | None) -> list[str]:
+    if node is None:
+        return []
+    if isinstance(node, ast.NamedExpr):
+        return _metadata_key_sequence_violations(path, node.value)
+    if isinstance(node, ast.IfExp):
+        return [
+            *_metadata_key_sequence_violations(path, node.body),
+            *_metadata_key_sequence_violations(path, node.orelse),
+        ]
+    if isinstance(node, ast.BoolOp):
+        sequence_violations: list[str] = []
+        for value in node.values:
+            sequence_violations.extend(_metadata_key_sequence_violations(path, value))
+        return sequence_violations
+    if isinstance(node, ast.Dict):
+        dict_key_violations: list[str] = []
+        for key, value in zip(node.keys, node.values, strict=True):
+            if key is None:
+                dict_key_violations.extend(_metadata_key_sequence_violations(path, value))
+                continue
+            key_name = _registered_key_name(key)
+            if key_name is not None:
+                dict_key_violations.append(_violation(path, key, key_name))
+        return dict_key_violations
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "keys"
+        and not node.args
+        and not node.keywords
+    ):
+        return _metadata_key_sequence_violations(path, node.func.value)
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id in _PAIR_SEQUENCE_WRAPPER_CALLS
+    ):
+        keys_arg = None if not node.args else node.args[0]
+        return _metadata_key_sequence_violations(path, keys_arg)
+    if not isinstance(node, ast.List | ast.Tuple | ast.Set):
+        return []
+    violations: list[str] = []
+    for element in node.elts:
+        key_name = _registered_key_name(element)
+        if key_name is not None:
+            violations.append(_violation(path, element, key_name))
     return violations
 
 
@@ -1347,7 +1420,15 @@ flow.metadata.update(fallback_update or {"vm_run_id": "run-1"})
 flow.metadata.update([("vm_run_id", "run-1")] if condition else [])
 flow.metadata.update((named_update := {"vm_run_id": "run-1"}))
 flow.metadata.update(flow.metadata | {"auth_cache_hit": False})
+flow.metadata.update({"firewall_params": {}}.items())
+flow.metadata.update({("firewall_billable", True)})
+flow.metadata.update(tuple([("trusted_authority_host", "api.example.com")]))
 flow.metadata = {**({"vm_run_id": "run-1"} if condition else {})}
+flow.metadata = dict({"auth_url_rewrite": True}.items())
+flow.metadata = dict.fromkeys(["auth_refreshed_connectors"], [])
+flow.metadata.update(dict.fromkeys(("auth_refreshed_secrets",), []))
+flow.metadata.update(dict.fromkeys({"auth_resolved_secrets": []}, []))
+flow.metadata.update(dict.fromkeys({"model_usage_provider": "gpt-5.5"}.keys(), "gpt-5.5"))
 flow.metadata.update(dict([("stream_buffer", bytearray())]))
 flow.metadata.update({**{"capture_body": True}})
 flow.metadata = {"request_stream_buffer": bytearray()} | {"request_stream_buffer_state": {}}
@@ -1647,7 +1728,7 @@ match flow.metadata:
 
     violations = _metadata_key_violations(source_path)
 
-    assert len(violations) == 151
+    assert len(violations) == 159
     assert all("use metadata_keys." in violation for violation in violations)
 
 
@@ -1684,6 +1765,11 @@ external_positional_dict_meta = dict({"metadata": flow.metadata, "vm_run_id": "e
 value = external_positional_dict_meta["vm_run_id"]
 external_unpack_dict_meta = dict(**{"metadata": flow.metadata, "vm_run_id": "external"})
 value = external_unpack_dict_meta["vm_run_id"]
+external_items_meta = dict({"metadata": flow.metadata, "vm_run_id": "external"}.items())
+value = external_items_meta["vm_run_id"]
+flow.metadata.update({metadata_keys.VM_RUN_ID: "run-1"}.items())
+flow.metadata.update(dict.fromkeys([metadata_keys.VM_RUN_ID], "run-1"))
+flow.metadata.update(dict.fromkeys({metadata_keys.VM_RUN_ID: "run-1"}, "run-1"))
 external_conditional_meta = {"vm_run_id": "external"} if condition else {}
 value = external_conditional_meta["vm_run_id"]
 external_bool_meta = fallback_meta or {"vm_run_id": "external"}

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -74,10 +74,17 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self.path = path
         self.violations: list[str] = []
         self._metadata_alias_scopes: list[set[str]] = [set()]
+        self._named_expr_target_scope_indexes: list[int] = []
 
     @property
     def _metadata_aliases(self) -> set[str]:
         return self._metadata_alias_scopes[-1]
+
+    @property
+    def _named_expr_target_aliases(self) -> set[str]:
+        if not self._named_expr_target_scope_indexes:
+            return self._metadata_aliases
+        return self._metadata_alias_scopes[self._named_expr_target_scope_indexes[-1]]
 
     def _is_metadata_reference(self, node: ast.AST) -> bool:
         return (
@@ -91,8 +98,11 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         if shadowed is not None:
             aliases.difference_update(shadowed)
         self._metadata_alias_scopes.append(aliases)
+        previous_named_expr_target_scope_indexes = self._named_expr_target_scope_indexes
+        self._named_expr_target_scope_indexes = []
         for statement in body:
             self.visit(statement)
+        self._named_expr_target_scope_indexes = previous_named_expr_target_scope_indexes
         self._metadata_alias_scopes.pop()
 
     def _visit_scoped_expression(
@@ -102,7 +112,10 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         if shadowed is not None:
             aliases.difference_update(shadowed)
         self._metadata_alias_scopes.append(aliases)
+        previous_named_expr_target_scope_indexes = self._named_expr_target_scope_indexes
+        self._named_expr_target_scope_indexes = []
         self.visit(expression)
+        self._named_expr_target_scope_indexes = previous_named_expr_target_scope_indexes
         self._metadata_alias_scopes.pop()
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
@@ -162,9 +175,12 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
 
     def visit_NamedExpr(self, node: ast.NamedExpr) -> None:
         if isinstance(node.target, ast.Name):
+            target_aliases = self._named_expr_target_aliases
             if self._is_metadata_reference(node.value):
+                target_aliases.add(node.target.id)
                 self._metadata_aliases.add(node.target.id)
             else:
+                target_aliases.discard(node.target.id)
                 self._metadata_aliases.discard(node.target.id)
         self.visit(node.value)
 
@@ -289,7 +305,13 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         first_generator, *remaining_generators = generators
         self.visit(first_generator.iter)
 
+        named_expr_target_scope_index = (
+            self._named_expr_target_scope_indexes[-1]
+            if self._named_expr_target_scope_indexes
+            else len(self._metadata_alias_scopes) - 1
+        )
         self._metadata_alias_scopes.append(set(self._metadata_aliases))
+        self._named_expr_target_scope_indexes.append(named_expr_target_scope_index)
         self._discard_alias_target(first_generator.target)
         for condition in first_generator.ifs:
             self.visit(condition)
@@ -300,6 +322,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
                 self.visit(condition)
         for expression in body_expressions:
             self.visit(expression)
+        self._named_expr_target_scope_indexes.pop()
         self._metadata_alias_scopes.pop()
 
 
@@ -419,12 +442,26 @@ if conditional_meta := flow.metadata:
     conditional_meta["connector_diagnostic_base"] = "https://api.example.com"
 outer_meta = flow.metadata
 values = [outer_meta["auth_refreshed_connectors"] for item in rows]
+values = [(leaked_meta := flow.metadata) for item in rows]
+leaked_meta["auth_refreshed_secrets"] = []
+values = [[(nested_leaked_meta := flow.metadata) for item in row] for row in rows]
+nested_leaked_meta["auth_resolved_secrets"] = []
+values = [
+    conditional_body_meta["model_provider_usage"]
+    for item in rows
+    if (conditional_body_meta := flow.metadata)
+]
+values = [
+    generator_body_meta["model_provider_usage_sources"]
+    for row in rows
+    for item in (generator_body_meta := flow.metadata)
+]
 """
     )
 
     violations = _metadata_key_violations(source_path)
 
-    assert len(violations) == 30
+    assert len(violations) == 34
     assert all("use metadata_keys." in violation for violation in violations)
 
 
@@ -463,6 +500,10 @@ values = [meta["vm_run_id"] for meta in [{"vm_run_id": "external"}]]
 values = {meta["vm_run_id"] for meta in [{"vm_run_id": "external"}]}
 values = {meta["vm_run_id"]: 1 for meta in [{"vm_run_id": "external"}]}
 values = tuple(meta["vm_run_id"] for meta in [{"vm_run_id": "external"}])
+[(lambda: (lambda_local_meta := flow.metadata))() for item in rows]
+value = lambda_local_meta["vm_run_id"]
+values = [(meta := {"vm_run_id": "external"}) for item in rows]
+value = meta["vm_run_id"]
 try:
     pass
 except Exception as meta:

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -130,7 +130,7 @@ def _static_call_argument_nodes(args: list[ast.expr], index: int) -> list[ast.AS
             expansions = _static_starred_argument_expansions(argument.value)
             if expansions is None:
                 next_consumed_counts.extend(
-                    consumed for consumed in consumed_counts if consumed > index
+                    consumed for consumed in consumed_counts if consumed <= index
                 )
             else:
                 for consumed in consumed_counts:
@@ -2005,6 +2005,27 @@ def function_type_param_global_reads_module[function_type_param_global_meta]():
         expected_violation_count += 13
     assert len(violations) == expected_violation_count
     assert all("use metadata_keys." in violation for violation in violations)
+
+
+def test_registered_flow_metadata_guard_flags_literals_after_dynamic_star_args(tmp_path):
+    source_path = tmp_path / "dynamic_star_args.py"
+    _write_python_source(
+        source_path,
+        """
+flow.metadata.get(*args, "vm_run_id")
+flow.metadata.update(*args, {"firewall_name": "github"})
+flow.metadata.update(dict.fromkeys(*args, ["firewall_action"], "ALLOW"))
+flow.metadata.get(*args, metadata_keys.VM_RUN_ID)
+flow.metadata.update(*args, {metadata_keys.FIREWALL_NAME: "github"})
+""",
+    )
+
+    violations = _metadata_key_violations(source_path)
+
+    assert len(violations) == 3
+    assert any("metadata_keys.VM_RUN_ID" in violation for violation in violations)
+    assert any("metadata_keys.FIREWALL_NAME" in violation for violation in violations)
+    assert any("metadata_keys.FIREWALL_ACTION" in violation for violation in violations)
 
 
 def test_registered_flow_metadata_guard_ignores_external_schema_and_private_markers(

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -101,6 +101,14 @@ def _pattern_names(pattern: ast.pattern) -> set[str]:
     return set()
 
 
+def _pattern_is_exhaustive(pattern: ast.pattern) -> bool:
+    if isinstance(pattern, ast.MatchAs) and pattern.pattern is None:
+        return True
+    if isinstance(pattern, ast.MatchOr):
+        return any(_pattern_is_exhaustive(child_pattern) for child_pattern in pattern.patterns)
+    return False
+
+
 def _body_can_fall_through(body: list[ast.stmt]) -> bool:
     return all(_statement_can_fall_through(statement) for statement in body)
 
@@ -555,19 +563,26 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
 
     def visit_Match(self, node: ast.Match) -> None:
         self.visit(node.subject)
-        matched_names: set[str] = set()
+        base_aliases = set(self._metadata_aliases)
+        exit_aliases: set[str] = set()
+        has_unmatched_path = True
         for case in node.cases:
             names = _pattern_names(case.pattern)
-            matched_names.update(names)
-            aliases = set(self._metadata_aliases)
+            aliases = set(base_aliases)
             aliases.difference_update(names)
             self._metadata_alias_scopes.append(aliases)
             if case.guard is not None:
                 self.visit(case.guard)
-            for statement in case.body:
-                self.visit(statement)
+            falls_through = self._visit_current_scope_body(case.body)
+            if falls_through:
+                exit_aliases.update(self._metadata_aliases)
             self._metadata_alias_scopes.pop()
-        self._metadata_aliases.difference_update(matched_names)
+            if case.guard is None and _pattern_is_exhaustive(case.pattern):
+                has_unmatched_path = False
+                break
+        if has_unmatched_path:
+            exit_aliases.update(base_aliases)
+        self._replace_current_aliases(exit_aliases)
 
     def visit_ListComp(self, node: ast.ListComp) -> None:
         self._visit_comprehension(node.generators, [node.elt])
@@ -827,12 +842,19 @@ values = [
 match payload:
     case {"payload": payload}:
         outer_meta["_model_json_usage_finalized"] = True
+match_alias_after_case = {}
+match match_payload:
+    case {"metadata": raw_match_metadata}:
+        match_alias_after_case = flow.metadata
+    case _:
+        pass
+match_alias_after_case["vm_run_id"] = "run-1"
 """
     )
 
     violations = _metadata_key_violations(source_path)
 
-    assert len(violations) == 54
+    assert len(violations) == 55
     assert all("use metadata_keys." in violation for violation in violations)
 
 
@@ -888,6 +910,14 @@ def partial_return_finalbody_rebinds_to_external(condition):
     finally:
         partial_finalbody_meta = {}
     return partial_finalbody_meta["vm_run_id"]
+def terminal_match_rebinds_to_external(match_payload):
+    terminal_match_meta = flow.metadata
+    match match_payload:
+        case {"return": True}:
+            return None
+        case _:
+            terminal_match_meta = {}
+    return terminal_match_meta["vm_run_id"]
 def accepts_external_metadata(meta):
     return meta["vm_proxy_log_path"]
 for meta in [{"firewall_name": "external"}]:

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -36,7 +36,8 @@ def _registered_key_name(node: ast.AST) -> str | None:
 
 def _violation(path: Path, node: ast.AST, key_name: str) -> str:
     location = path.relative_to(_ADDON_ROOT) if path.is_relative_to(_ADDON_ROOT) else path
-    return f"{location}:{node.lineno}: use metadata_keys.{key_name} for flow.metadata access"
+    line_number = getattr(node, "lineno", 0)
+    return f"{location}:{line_number}: use metadata_keys.{key_name} for flow.metadata access"
 
 
 def _metadata_key_violations(path: Path) -> list[str]:
@@ -98,11 +99,11 @@ def _metadata_dict_key_violations(path: Path, node: ast.AST | None) -> list[str]
     if isinstance(node, ast.List | ast.Tuple):
         return _metadata_pair_sequence_violations(path, node)
     if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "dict":
-        violations: list[str] = []
+        dict_call_violations: list[str] = []
         update_arg = None if not node.args else node.args[0]
-        violations.extend(_metadata_dict_key_violations(path, update_arg))
-        violations.extend(_metadata_keyword_violations(path, node.keywords))
-        return violations
+        dict_call_violations.extend(_metadata_dict_key_violations(path, update_arg))
+        dict_call_violations.extend(_metadata_keyword_violations(path, node.keywords))
+        return dict_call_violations
     if not isinstance(node, ast.Dict):
         return []
     violations: list[str] = []

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -49,49 +49,107 @@ def _violation(path: Path, node: ast.AST, key_name: str) -> str:
     return f"{location}:{line_number}: use metadata_keys.{key_name} for flow.metadata access"
 
 
-def _metadata_key_violations(path: Path) -> list[str]:
-    tree = ast.parse(path.read_text(), filename=str(path))
-    violations: list[str] = []
+class _MetadataKeyVisitor(ast.NodeVisitor):
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.violations: list[str] = []
+        self._metadata_alias_scopes: list[set[str]] = [set()]
 
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Subscript) and _is_metadata_attribute(node.value):
+    @property
+    def _metadata_aliases(self) -> set[str]:
+        return self._metadata_alias_scopes[-1]
+
+    def _is_metadata_reference(self, node: ast.AST) -> bool:
+        return _is_metadata_attribute(node) or (
+            isinstance(node, ast.Name) and node.id in self._metadata_aliases
+        )
+
+    def _visit_scoped_body(self, body: list[ast.stmt]) -> None:
+        self._metadata_alias_scopes.append(set(self._metadata_aliases))
+        for statement in body:
+            self.visit(statement)
+        self._metadata_alias_scopes.pop()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_scoped_body(node.body)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_scoped_body(node.body)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self._visit_scoped_body(node.body)
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        if any(_is_metadata_attribute(target) for target in node.targets):
+            self.violations.extend(_metadata_dict_key_violations(self.path, node.value))
+        self._update_aliases_from_assign(node)
+        self.generic_visit(node)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        if _is_metadata_attribute(node.target):
+            self.violations.extend(_metadata_dict_key_violations(self.path, node.value))
+        if isinstance(node.target, ast.Name):
+            if node.value is not None and self._is_metadata_reference(node.value):
+                self._metadata_aliases.add(node.target.id)
+            else:
+                self._metadata_aliases.discard(node.target.id)
+        self.generic_visit(node)
+
+    def visit_AugAssign(self, node: ast.AugAssign) -> None:
+        if self._is_metadata_reference(node.target):
+            self.violations.extend(_metadata_dict_key_violations(self.path, node.value))
+        self.generic_visit(node)
+
+    def visit_Subscript(self, node: ast.Subscript) -> None:
+        if self._is_metadata_reference(node.value):
             key_name = _registered_key_name(node.slice)
             if key_name is not None:
-                violations.append(_violation(path, node, key_name))
+                self.violations.append(_violation(self.path, node, key_name))
+        self.generic_visit(node)
 
-        if (
-            isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Attribute)
-            and _is_metadata_attribute(node.func.value)
-        ):
+    def visit_Call(self, node: ast.Call) -> None:
+        if isinstance(node.func, ast.Attribute) and self._is_metadata_reference(node.func.value):
             if node.func.attr in _METADATA_METHODS_WITH_KEY_ARGUMENTS and node.args:
                 key_name = _registered_key_name(node.args[0])
                 if key_name is not None:
-                    violations.append(_violation(path, node, key_name))
+                    self.violations.append(_violation(self.path, node, key_name))
             if node.func.attr in _METADATA_METHODS_WITH_DICT_ARGUMENTS:
-                violations.extend(_metadata_update_violations(path, node))
+                self.violations.extend(_metadata_update_violations(self.path, node))
+        self.generic_visit(node)
 
-        if isinstance(node, ast.AugAssign) and _is_metadata_attribute(node.target):
-            violations.extend(_metadata_dict_key_violations(path, node.value))
-
-        if isinstance(node, ast.Assign) and any(
-            _is_metadata_attribute(target) for target in node.targets
+    def visit_Compare(self, node: ast.Compare) -> None:
+        if (
+            len(node.comparators) == 1
+            and isinstance(node.ops[0], (ast.In, ast.NotIn))
+            and self._is_metadata_reference(node.comparators[0])
         ):
-            violations.extend(_metadata_dict_key_violations(path, node.value))
-
-        if isinstance(node, ast.AnnAssign) and _is_metadata_attribute(node.target):
-            violations.extend(_metadata_dict_key_violations(path, node.value))
-
-        if isinstance(node, ast.Compare) and len(node.comparators) == 1:
-            if not isinstance(node.ops[0], (ast.In, ast.NotIn)):
-                continue
-            if not _is_metadata_attribute(node.comparators[0]):
-                continue
             key_name = _registered_key_name(node.left)
             if key_name is not None:
-                violations.append(_violation(path, node, key_name))
+                self.violations.append(_violation(self.path, node, key_name))
+        self.generic_visit(node)
 
-    return violations
+    def visit_Delete(self, node: ast.Delete) -> None:
+        for target in node.targets:
+            if isinstance(target, ast.Name):
+                self._metadata_aliases.discard(target.id)
+        self.generic_visit(node)
+
+    def _update_aliases_from_assign(self, node: ast.Assign) -> None:
+        is_metadata_alias = self._is_metadata_reference(node.value)
+        for target in node.targets:
+            if not isinstance(target, ast.Name):
+                continue
+            if is_metadata_alias:
+                self._metadata_aliases.add(target.id)
+            else:
+                self._metadata_aliases.discard(target.id)
+
+
+def _metadata_key_violations(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(), filename=str(path))
+    visitor = _MetadataKeyVisitor(path)
+    visitor.visit(tree)
+    return visitor.violations
 
 
 def _metadata_update_violations(path: Path, node: ast.Call) -> list[str]:
@@ -184,12 +242,18 @@ flow.metadata.__delitem__("network_log_target")
 flow.metadata.__contains__("browser_user_agent")
 flow.metadata.__ior__({"suppress_request_body_capture": True})
 http_flow.metadata["vm_run_id"] = "run-2"
+meta = flow.metadata
+meta["vm_proxy_log_path"] = "proxy.jsonl"
+meta.get("vm_network_log_path")
+"firewall_name" in meta
+meta.update({"firewall_permission": "read"})
+meta |= {"firewall_rule_match": "GET /items"}
 """
     )
 
     violations = _metadata_key_violations(source_path)
 
-    assert len(violations) == 19
+    assert len(violations) == 24
     assert all("use metadata_keys." in violation for violation in violations)
 
 
@@ -203,6 +267,8 @@ entry["firewall_name"] = "github"
 payload = {"vm_run_id": "run-1"}
 assert "connector_response_finish" in flow.metadata
 flow.metadata["_local_marker"] = "private"
+meta = flow.metadata
+meta = {"vm_run_id": "external payload"}
 """
     )
 

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -33,8 +33,13 @@ def _python_files() -> list[Path]:
     return sorted(files)
 
 
-def _is_metadata_attribute(node: ast.AST) -> bool:
-    return isinstance(node, ast.Attribute) and node.attr == "metadata"
+def _is_flow_metadata_attribute(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "flow"
+        and node.attr == "metadata"
+    )
 
 
 def _registered_key_name(node: ast.AST) -> str | None:
@@ -54,7 +59,7 @@ def _metadata_key_violations(path: Path) -> list[str]:
     violations: list[str] = []
 
     for node in ast.walk(tree):
-        if isinstance(node, ast.Subscript) and _is_metadata_attribute(node.value):
+        if isinstance(node, ast.Subscript) and _is_flow_metadata_attribute(node.value):
             key_name = _registered_key_name(node.slice)
             if key_name is not None:
                 violations.append(_violation(path, node, key_name))
@@ -62,7 +67,7 @@ def _metadata_key_violations(path: Path) -> list[str]:
         if (
             isinstance(node, ast.Call)
             and isinstance(node.func, ast.Attribute)
-            and _is_metadata_attribute(node.func.value)
+            and _is_flow_metadata_attribute(node.func.value)
         ):
             if node.func.attr in _METADATA_METHODS_WITH_KEY_ARGUMENTS and node.args:
                 key_name = _registered_key_name(node.args[0])
@@ -71,21 +76,21 @@ def _metadata_key_violations(path: Path) -> list[str]:
             if node.func.attr in _METADATA_METHODS_WITH_DICT_ARGUMENTS:
                 violations.extend(_metadata_update_violations(path, node))
 
-        if isinstance(node, ast.AugAssign) and _is_metadata_attribute(node.target):
+        if isinstance(node, ast.AugAssign) and _is_flow_metadata_attribute(node.target):
             violations.extend(_metadata_dict_key_violations(path, node.value))
 
         if isinstance(node, ast.Assign) and any(
-            _is_metadata_attribute(target) for target in node.targets
+            _is_flow_metadata_attribute(target) for target in node.targets
         ):
             violations.extend(_metadata_dict_key_violations(path, node.value))
 
-        if isinstance(node, ast.AnnAssign) and _is_metadata_attribute(node.target):
+        if isinstance(node, ast.AnnAssign) and _is_flow_metadata_attribute(node.target):
             violations.extend(_metadata_dict_key_violations(path, node.value))
 
         if isinstance(node, ast.Compare) and len(node.comparators) == 1:
             if not isinstance(node.ops[0], (ast.In, ast.NotIn)):
                 continue
-            if not _is_metadata_attribute(node.comparators[0]):
+            if not _is_flow_metadata_attribute(node.comparators[0]):
                 continue
             key_name = _registered_key_name(node.left)
             if key_name is not None:
@@ -200,6 +205,7 @@ def test_registered_flow_metadata_guard_ignores_external_schema_and_private_mark
         """
 entry["firewall_name"] = "github"
 payload = {"vm_run_id": "run-1"}
+record.metadata["vm_run_id"] = "external id"
 assert "connector_response_finish" in flow.metadata
 flow.metadata["firewall_rule"] = "domain:*.example.com"
 """

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -72,6 +72,48 @@ def _argument_names(args: ast.arguments) -> set[str]:
     return names
 
 
+def _argument_annotations(args: ast.arguments) -> list[ast.expr]:
+    annotations = [
+        arg.annotation for arg in [*args.posonlyargs, *args.args] if arg.annotation is not None
+    ]
+    if args.vararg is not None and args.vararg.annotation is not None:
+        annotations.append(args.vararg.annotation)
+    annotations.extend(arg.annotation for arg in args.kwonlyargs if arg.annotation is not None)
+    if args.kwarg is not None and args.kwarg.annotation is not None:
+        annotations.append(args.kwarg.annotation)
+    return annotations
+
+
+def _type_params(node: ast.AST) -> list[ast.AST]:
+    for field_name, value in ast.iter_fields(node):
+        if field_name == "type_params" and isinstance(value, list):
+            return [item for item in value if isinstance(item, ast.AST)]
+    return []
+
+
+def _type_param_names(node: ast.AST) -> set[str]:
+    names: set[str] = set()
+    for type_param in _type_params(node):
+        for field_name, value in ast.iter_fields(type_param):
+            if field_name == "name" and isinstance(value, str):
+                names.add(value)
+    return names
+
+
+def _type_alias_target_names(node: ast.AST) -> set[str]:
+    for field_name, value in ast.iter_fields(node):
+        if field_name == "name" and isinstance(value, ast.AST):
+            return _target_names(value)
+    return set()
+
+
+def _type_alias_value(node: ast.AST) -> ast.AST | None:
+    for field_name, value in ast.iter_fields(node):
+        if field_name == "value" and isinstance(value, ast.AST):
+            return value
+    return None
+
+
 class _ScopeBoundNameVisitor(ast.NodeVisitor):
     def __init__(self) -> None:
         self.bound_names: set[str] = set()
@@ -100,10 +142,15 @@ class _ScopeBoundNameVisitor(ast.NodeVisitor):
         self.bound_names.add(node.name)
         for decorator in node.decorator_list:
             self.visit(decorator)
+        for type_param in _type_params(node):
+            self.visit(type_param)
         for base in node.bases:
             self.visit(base)
         for keyword in node.keywords:
             self.visit(keyword)
+
+    def visit_TypeAlias(self, node: ast.AST) -> None:
+        self.bound_names.update(_type_alias_target_names(node))
 
     def visit_Lambda(self, node: ast.Lambda) -> None:
         for default in [*node.args.defaults, *node.args.kw_defaults]:
@@ -208,9 +255,13 @@ class _ScopeBoundNameVisitor(ast.NodeVisitor):
     ) -> None:
         for decorator in node.decorator_list:
             self.visit(decorator)
+        for type_param in _type_params(node):
+            self.visit(type_param)
         for default in [*node.args.defaults, *node.args.kw_defaults]:
             if default is not None:
                 self.visit(default)
+        for annotation in _argument_annotations(node.args):
+            self.visit(annotation)
         if node.returns is not None:
             self.visit(node.returns)
 
@@ -412,6 +463,23 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self._metadata_aliases.clear()
         self._metadata_aliases.update(aliases)
 
+    def _visit_definition_expression(
+        self,
+        node: ast.AST,
+        shadowed_names: set[str],
+        *,
+        check_metadata_merge: bool = False,
+    ) -> None:
+        outer_aliases = set(self._metadata_aliases)
+        self._metadata_aliases.difference_update(shadowed_names)
+        if check_metadata_merge:
+            self.violations.extend(self._metadata_merge_key_violations(node))
+        self.visit(node)
+        expression_aliases = set(self._metadata_aliases)
+        self._replace_current_aliases(
+            (expression_aliases - shadowed_names) | (outer_aliases & shadowed_names)
+        )
+
     def _nested_function_base_aliases(self) -> set[str]:
         if self._class_nested_scope_alias_scopes:
             return set(self._class_nested_scope_alias_scopes[-1])
@@ -492,13 +560,27 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
         for decorator in node.decorator_list:
-            self.visit(decorator)
+            self._visit_definition_expression(decorator, set(), check_metadata_merge=True)
+        type_param_names = _type_param_names(node)
+        for type_param in _type_params(node):
+            self._visit_definition_expression(
+                type_param, type_param_names, check_metadata_merge=True
+            )
         metadata_defaults = self._metadata_default_argument_names(node.args)
         for default in [*node.args.defaults, *node.args.kw_defaults]:
             if default is not None:
                 self._visit_default_value(default)
+        for annotation in _argument_annotations(node.args):
+            self._visit_definition_expression(
+                annotation, type_param_names, check_metadata_merge=True
+            )
+        if node.returns is not None:
+            self._visit_definition_expression(
+                node.returns, type_param_names, check_metadata_merge=True
+            )
         shadowed_names = (
-            (_argument_names(node.args) | _scope_bound_names(node.body)) - metadata_defaults
+            (_argument_names(node.args) | _scope_bound_names(node.body) | type_param_names)
+            - metadata_defaults
         ) | {node.name}
         self._visit_scoped_body(
             node.body, shadowed_names, metadata_defaults, self._nested_function_base_aliases()
@@ -507,13 +589,27 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
 
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
         for decorator in node.decorator_list:
-            self.visit(decorator)
+            self._visit_definition_expression(decorator, set(), check_metadata_merge=True)
+        type_param_names = _type_param_names(node)
+        for type_param in _type_params(node):
+            self._visit_definition_expression(
+                type_param, type_param_names, check_metadata_merge=True
+            )
         metadata_defaults = self._metadata_default_argument_names(node.args)
         for default in [*node.args.defaults, *node.args.kw_defaults]:
             if default is not None:
                 self._visit_default_value(default)
+        for annotation in _argument_annotations(node.args):
+            self._visit_definition_expression(
+                annotation, type_param_names, check_metadata_merge=True
+            )
+        if node.returns is not None:
+            self._visit_definition_expression(
+                node.returns, type_param_names, check_metadata_merge=True
+            )
         shadowed_names = (
-            (_argument_names(node.args) | _scope_bound_names(node.body)) - metadata_defaults
+            (_argument_names(node.args) | _scope_bound_names(node.body) | type_param_names)
+            - metadata_defaults
         ) | {node.name}
         self._visit_scoped_body(
             node.body, shadowed_names, metadata_defaults, self._nested_function_base_aliases()
@@ -534,12 +630,17 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
         for decorator in node.decorator_list:
-            self.visit(decorator)
+            self._visit_definition_expression(decorator, set(), check_metadata_merge=True)
+        type_param_names = _type_param_names(node)
+        for type_param in _type_params(node):
+            self._visit_definition_expression(
+                type_param, type_param_names, check_metadata_merge=True
+            )
         for base in node.bases:
-            self.visit(base)
+            self._visit_definition_expression(base, type_param_names, check_metadata_merge=True)
         for keyword in node.keywords:
-            self.visit(keyword)
-        outer_aliases = self._nested_function_base_aliases()
+            self._visit_definition_expression(keyword, type_param_names, check_metadata_merge=True)
+        outer_aliases = self._nested_function_base_aliases() - type_param_names
         class_scope_bindings = _scope_bound_name_visitor(node.body)
         class_body_bound_names = class_scope_bindings.local_names
         class_body_global_names = class_scope_bindings.global_names
@@ -551,6 +652,18 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self._visit_scoped_body(node.body, base_aliases=class_body_aliases)
         self._class_nested_scope_alias_scopes.pop()
         self._metadata_aliases.discard(node.name)
+
+    def visit_TypeAlias(self, node: ast.AST) -> None:
+        type_param_names = _type_param_names(node)
+        target_names = _type_alias_target_names(node)
+        shadowed_names = type_param_names | target_names
+        for type_param in _type_params(node):
+            self._visit_definition_expression(type_param, shadowed_names, check_metadata_merge=True)
+        value = _type_alias_value(node)
+        if value is not None:
+            self._visit_definition_expression(value, shadowed_names, check_metadata_merge=True)
+        for name in target_names:
+            self._metadata_aliases.discard(name)
 
     def visit_Assign(self, node: ast.Assign) -> None:
         if any(_is_metadata_attribute(target) for target in node.targets):
@@ -1077,6 +1190,42 @@ copy_meta["vm_run_id"] = "run-1"
 def function_default_meta(default_meta=flow.metadata):
     default_meta["vm_run_id"] = "run-1"
 lambda_default_meta = lambda default_meta=flow.metadata: default_meta["vm_network_log_path"]
+def function_annotation_meta(
+    arg: flow.metadata["vm_run_id"],
+    *args: flow.metadata["vm_network_log_path"],
+    kw: flow.metadata["firewall_action"],
+    **kwargs: flow.metadata["firewall_name"],
+) -> flow.metadata["firewall_base"]:
+    pass
+async def async_function_annotation_meta(arg: flow.metadata["firewall_error"]):
+    pass
+def function_annotation_alias_leaks():
+    def inner(arg: (annotation_alias_meta := flow.metadata)):
+        pass
+    annotation_alias_meta["vm_run_id"] = "run-1"
+def vararg_annotation_alias_order(
+    *args: (vararg_annotation_meta := flow.metadata),
+    kw: vararg_annotation_meta["vm_run_id"],
+):
+    pass
+def function_type_param_meta[T: flow.metadata["vm_run_id"]]():
+    pass
+async def async_function_type_param_meta[T: flow.metadata["firewall_action"]]():
+    pass
+class ClassTypeParamMeta[T: flow.metadata["firewall_name"]]:
+    pass
+type TypeAliasParamMeta[T: flow.metadata["firewall_base"]] = int
+type TypeAliasValueMeta = flow.metadata["vm_run_id"]
+type TypeAliasMergeMeta = flow.metadata | {"firewall_action": "ALLOW"}
+default_type_param_shadow_meta = flow.metadata
+def default_type_param_reads_outer[default_type_param_shadow_meta](
+    arg=default_type_param_shadow_meta["vm_run_id"],
+):
+    pass
+type_param_restored_meta = flow.metadata
+def type_param_scope_restores_alias[type_param_restored_meta]():
+    pass
+type_param_restored_meta["firewall_name"] = "github"
 if conditional_meta := flow.metadata:
     conditional_meta["connector_diagnostic_base"] = "https://api.example.com"
 branch_meta = flow.metadata
@@ -1159,7 +1308,7 @@ match match_payload:
 
     violations = _metadata_key_violations(source_path)
 
-    assert len(violations) == 81
+    assert len(violations) == 97
     assert all("use metadata_keys." in violation for violation in violations)
 
 
@@ -1298,6 +1447,36 @@ def late_match_local_shadow(match_payload):
             pass
 lambda_shadow_meta = flow.metadata
 fn = lambda: lambda_shadow_meta["vm_run_id"] if (lambda_shadow_meta := {}) else None
+annotation_shadow_meta = flow.metadata
+def annotation_walrus_local_shadow():
+    value = annotation_shadow_meta["vm_run_id"]
+    def inner(arg: (annotation_shadow_meta := {})):
+        pass
+type_alias_shadow_meta = flow.metadata
+type type_alias_shadow_meta = int
+value = type_alias_shadow_meta["vm_run_id"]
+type_alias_value_shadow_meta = flow.metadata
+type type_alias_value_shadow_meta = type_alias_value_shadow_meta["vm_run_id"]
+function_type_alias_shadow_meta = flow.metadata
+def function_type_alias_local_shadow():
+    value = function_type_alias_shadow_meta["vm_run_id"]
+    type function_type_alias_shadow_meta = int
+class TypeAliasDoesNotSeeClassAlias:
+    class_type_alias_meta = flow.metadata
+    type class_type_alias_meta = int
+    value = class_type_alias_meta["vm_run_id"]
+type_param_shadow_meta = flow.metadata
+def function_type_param_shadows_outer[type_param_shadow_meta](
+    arg: type_param_shadow_meta["vm_run_id"],
+) -> type_param_shadow_meta["firewall_name"]:
+    type_param_shadow_meta["firewall_base"]
+class ClassTypeParamShadowsOuter[type_param_shadow_meta](type_param_shadow_meta):
+    value = type_param_shadow_meta["vm_run_id"]
+    def method(self):
+        type_param_shadow_meta["firewall_name"]
+type TypeAliasTypeParamShadowsOuter[type_param_shadow_meta] = type_param_shadow_meta[
+    "vm_run_id"
+]
 def class_body_late_binding_shadow():
     class_shadow_meta = flow.metadata
     class ShadowsClosure:

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -86,33 +86,61 @@ def _argument_annotations(args: ast.arguments) -> list[ast.expr]:
 
 
 def _static_call_argument_nodes(args: list[ast.expr], index: int) -> list[ast.AST]:
-    if index >= len(args):
-        return []
-    argument = args[index]
-    if isinstance(argument, ast.Starred):
-        return _static_starred_argument_nodes(argument.value)
-    return [argument]
+    result: list[ast.AST] = []
+    consumed_counts = [0]
+    for argument in args:
+        next_consumed_counts: list[int] = []
+        if isinstance(argument, ast.Starred):
+            expansions = _static_starred_argument_expansions(argument.value)
+            if expansions is None:
+                next_consumed_counts.extend(
+                    consumed for consumed in consumed_counts if consumed > index
+                )
+            else:
+                for consumed in consumed_counts:
+                    for expansion in expansions:
+                        for offset, expanded_argument in enumerate(expansion):
+                            if consumed + offset == index:
+                                result.append(expanded_argument)
+                        next_consumed_counts.append(consumed + len(expansion))
+        else:
+            for consumed in consumed_counts:
+                if consumed == index:
+                    result.append(argument)
+                next_consumed_counts.append(consumed + 1)
+        consumed_counts = next_consumed_counts
+    return result
 
 
-def _static_starred_argument_nodes(node: ast.AST) -> list[ast.AST]:
+def _static_starred_argument_expansions(node: ast.AST) -> list[list[ast.AST]] | None:
     if isinstance(node, ast.NamedExpr):
-        return _static_starred_argument_nodes(node.value)
+        return _static_starred_argument_expansions(node.value)
     if isinstance(node, ast.IfExp):
         return [
-            *_static_starred_argument_nodes(node.body),
-            *_static_starred_argument_nodes(node.orelse),
+            *(_static_starred_argument_expansions(node.body) or []),
+            *(_static_starred_argument_expansions(node.orelse) or []),
         ]
     if isinstance(node, ast.BoolOp):
-        nodes: list[ast.AST] = []
+        expansions: list[list[ast.AST]] = []
         for value in node.values:
-            nodes.extend(_static_starred_argument_nodes(value))
-        return nodes
-    if not isinstance(node, ast.List | ast.Tuple) or not node.elts:
-        return []
-    first_arg = node.elts[0]
-    if isinstance(first_arg, ast.Starred):
-        return _static_starred_argument_nodes(first_arg.value)
-    return [first_arg]
+            value_expansions = _static_starred_argument_expansions(value)
+            if value_expansions is not None:
+                expansions.extend(value_expansions)
+        return expansions
+    if not isinstance(node, ast.List | ast.Tuple):
+        return None
+    expansions = [[]]
+    for element in node.elts:
+        if isinstance(element, ast.Starred):
+            nested_expansions = _static_starred_argument_expansions(element.value)
+            if nested_expansions is None:
+                return None
+            expansions = [
+                [*prefix, *nested] for prefix in expansions for nested in nested_expansions
+            ]
+        else:
+            expansions = [[*prefix, element] for prefix in expansions]
+    return expansions
 
 
 def _type_params(node: ast.AST) -> list[ast.AST]:
@@ -1610,6 +1638,11 @@ flow.metadata = dict(*[{"firewall_permission": "read"}])
 flow.metadata.get(*["firewall_base"])
 flow.metadata.update(dict.fromkeys(*[["firewall_error"], "auth_failed"]))
 flow.metadata.update(dict.fromkeys(*[["auth_cache_hit"]], False))
+flow.metadata.update(*[], {"vm_run_id": "run-1"})
+flow.metadata.update(*[], [("firewall_name", "github")])
+flow.metadata = dict(*[], {"firewall_action": "ALLOW"})
+flow.metadata.get(*[], "firewall_permission")
+flow.metadata.update(dict.fromkeys(*[], ["firewall_base"], "base"))
 flow.metadata.update((("firewall_action", value) for value in rows))
 flow.metadata.update([("firewall_permission", value) for value in rows])
 flow.metadata.update({("firewall_base", value) for value in rows})
@@ -1917,7 +1950,7 @@ match flow.metadata:
 
     violations = _metadata_key_violations(source_path)
 
-    assert len(violations) == 211
+    assert len(violations) == 216
     assert all("use metadata_keys." in violation for violation in violations)
 
 
@@ -2007,6 +2040,11 @@ flow.metadata = dict(*[{metadata_keys.FIREWALL_PERMISSION: "read"}])
 flow.metadata.get(*[metadata_keys.FIREWALL_BASE])
 flow.metadata.update(dict.fromkeys(*[[metadata_keys.FIREWALL_ERROR], "auth_failed"]))
 flow.metadata.update(dict.fromkeys(*[[metadata_keys.AUTH_CACHE_HIT]], False))
+flow.metadata.update(*[], {metadata_keys.VM_RUN_ID: "run-1"})
+flow.metadata.update(*[], [(metadata_keys.FIREWALL_NAME, "github")])
+flow.metadata = dict(*[], {metadata_keys.FIREWALL_ACTION: "ALLOW"})
+flow.metadata.get(*[], metadata_keys.FIREWALL_PERMISSION)
+flow.metadata.update(dict.fromkeys(*[], [metadata_keys.FIREWALL_BASE], "base"))
 flow.metadata.update(((metadata_keys.FIREWALL_ACTION, value) for value in rows))
 flow.metadata.update([(metadata_keys.FIREWALL_PERMISSION, value) for value in rows])
 flow.metadata.update({(metadata_keys.FIREWALL_BASE, value) for value in rows})

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -35,7 +35,7 @@ def _registered_key_name(node: ast.AST) -> str | None:
 
 
 def _violation(path: Path, node: ast.AST, key_name: str) -> str:
-    location = path.relative_to(_ADDON_ROOT)
+    location = path.relative_to(_ADDON_ROOT) if path.is_relative_to(_ADDON_ROOT) else path
     return f"{location}:{node.lineno}: use metadata_keys.{key_name} for flow.metadata access"
 
 
@@ -98,7 +98,11 @@ def _metadata_dict_key_violations(path: Path, node: ast.AST | None) -> list[str]
     if isinstance(node, ast.List | ast.Tuple):
         return _metadata_pair_sequence_violations(path, node)
     if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "dict":
-        return _metadata_keyword_violations(path, node.keywords)
+        violations: list[str] = []
+        update_arg = None if not node.args else node.args[0]
+        violations.extend(_metadata_dict_key_violations(path, update_arg))
+        violations.extend(_metadata_keyword_violations(path, node.keywords))
+        return violations
     if not isinstance(node, ast.Dict):
         return []
     violations: list[str] = []
@@ -140,3 +144,40 @@ def test_registered_flow_metadata_keys_use_registry_constants():
     ]
 
     assert violations == []
+
+
+def test_registered_flow_metadata_guard_flags_direct_literals(tmp_path):
+    source_path = tmp_path / "violations.py"
+    source_path.write_text(
+        """
+flow.metadata["vm_run_id"] = "run-1"
+flow.metadata.get("firewall_action")
+"original_url" in flow.metadata
+flow.metadata.update({"firewall_base": "https://api.example.com"})
+flow.metadata.update(firewall_permission="read")
+flow.metadata |= {"vm_network_log_path": "network.jsonl"}
+flow.metadata = dict(vm_proxy_log_path="proxy.jsonl")
+flow.metadata.update(dict([("stream_buffer", bytearray())]))
+"""
+    )
+
+    violations = _metadata_key_violations(source_path)
+
+    assert len(violations) == 8
+    assert all("use metadata_keys." in violation for violation in violations)
+
+
+def test_registered_flow_metadata_guard_ignores_external_schema_and_private_markers(
+    tmp_path,
+):
+    source_path = tmp_path / "allowed.py"
+    source_path.write_text(
+        """
+entry["firewall_name"] = "github"
+payload = {"vm_run_id": "run-1"}
+assert "connector_response_finish" in flow.metadata
+flow.metadata["firewall_rule"] = "domain:*.example.com"
+"""
+    )
+
+    assert _metadata_key_violations(source_path) == []

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -762,7 +762,61 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
             return
         self.visit(node.value)
 
+    def _visit_sequence_expression(self, node: ast.List | ast.Tuple | ast.Set) -> None:
+        for element in node.elts:
+            self._record_metadata_merge_key_violations(element)
+        self.generic_visit(node)
+
+    def visit_List(self, node: ast.List) -> None:
+        self._visit_sequence_expression(node)
+
+    def visit_Tuple(self, node: ast.Tuple) -> None:
+        self._visit_sequence_expression(node)
+
+    def visit_Set(self, node: ast.Set) -> None:
+        self._visit_sequence_expression(node)
+
+    def visit_Dict(self, node: ast.Dict) -> None:
+        for key, value in zip(node.keys, node.values, strict=True):
+            self._record_metadata_merge_key_violations(key)
+            self._record_metadata_merge_key_violations(value)
+        self.generic_visit(node)
+
+    def visit_BinOp(self, node: ast.BinOp) -> None:
+        if not self._is_metadata_merge_value(node):
+            self._record_metadata_merge_key_violations(node.left)
+            self._record_metadata_merge_key_violations(node.right)
+        self.generic_visit(node)
+
+    def visit_UnaryOp(self, node: ast.UnaryOp) -> None:
+        self._record_metadata_merge_key_violations(node.operand)
+        self.generic_visit(node)
+
+    def visit_Await(self, node: ast.Await) -> None:
+        self._record_metadata_merge_key_violations(node.value)
+        self.generic_visit(node)
+
+    def visit_Attribute(self, node: ast.Attribute) -> None:
+        self._record_metadata_merge_key_violations(node.value)
+        self.generic_visit(node)
+
+    def visit_Starred(self, node: ast.Starred) -> None:
+        self._record_metadata_merge_key_violations(node.value)
+        self.generic_visit(node)
+
+    def visit_FormattedValue(self, node: ast.FormattedValue) -> None:
+        self._record_metadata_merge_key_violations(node.value)
+        self.generic_visit(node)
+
+    def visit_Slice(self, node: ast.Slice) -> None:
+        self._record_metadata_merge_key_violations(node.lower)
+        self._record_metadata_merge_key_violations(node.upper)
+        self._record_metadata_merge_key_violations(node.step)
+        self.generic_visit(node)
+
     def visit_Subscript(self, node: ast.Subscript) -> None:
+        self._record_metadata_merge_key_violations(node.value)
+        self._record_metadata_merge_key_violations(node.slice)
         if self._is_metadata_alias_value(node.value):
             key_name = _registered_key_name(node.slice)
             if key_name is not None:
@@ -813,6 +867,9 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self.generic_visit(node)
 
     def visit_Compare(self, node: ast.Compare) -> None:
+        self._record_metadata_merge_key_violations(node.left)
+        for comparator in node.comparators:
+            self._record_metadata_merge_key_violations(comparator)
         if (
             len(node.comparators) == 1
             and isinstance(node.ops[0], (ast.In, ast.NotIn))
@@ -1259,6 +1316,7 @@ bool_expr_meta = fallback_meta or flow.metadata
 bool_expr_meta["firewall_name"] = "github"
 conditional_merge_meta = (flow.metadata | {"firewall_action": "ALLOW"}) if condition else {}
 conditional_rhs_merge_meta = flow.metadata | ({"firewall_action": "ALLOW"} if condition else {})
+chained_merge_meta = flow.metadata | {"vm_run_id": "run-1"} | {}
 copy_meta = flow.metadata.copy()
 copy_meta["vm_run_id"] = "run-1"
 (flow.metadata if condition else {})["firewall_base"] = "https://api.example.com"
@@ -1317,6 +1375,21 @@ def assert_metadata_merge():
 (flow.metadata | {"firewall_action": "ALLOW"})
 def yield_metadata_merge():
     yield flow.metadata | {"firewall_error": "auth_failed"}
+values = [flow.metadata | {"vm_run_id": "run-1"}]
+values = (flow.metadata | {"firewall_action": "ALLOW"},)
+values = {flow.metadata | {"firewall_error": "auth_failed"}}
+payload = {"metadata": flow.metadata | {"firewall_base": "https://api.example.com"}}
+value = (flow.metadata | {"firewall_permission": "read"})["x"]
+value = rows[flow.metadata | {"firewall_rule_match": "GET /items"}]
+message = f"{flow.metadata | {'network_log_target': {}}}"
+value = (flow.metadata | {"vm_network_log_path": "network.jsonl"}) + other
+async def await_metadata_merge():
+    return await (flow.metadata | {"vm_proxy_log_path": "proxy.jsonl"})
+value = not (flow.metadata | {"auth_cache_hit": False})
+value = other == (flow.metadata | {"firewall_name": "github"})
+value = (flow.metadata | {"firewall_api_id": "run-1:0"}).items
+values = [*(flow.metadata | {"suppress_request_body_capture": True})]
+value = rows[:(flow.metadata | {"capture_body": True})]
 values = [flow.metadata | {"firewall_permission": "read"} for item in rows]
 for item in flow.metadata | {"firewall_rule_match": "GET /items"}:
     pass
@@ -1413,7 +1486,7 @@ match match_payload:
 
     violations = _metadata_key_violations(source_path)
 
-    assert len(violations) == 110
+    assert len(violations) == 125
     assert all("use metadata_keys." in violation for violation in violations)
 
 

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -165,11 +165,6 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
             or (isinstance(node, ast.NamedExpr) and self._is_metadata_alias_value(node.value))
         )
 
-    def _contains_metadata_reference(self, node: ast.AST) -> bool:
-        return self._is_metadata_reference(node) or any(
-            self._contains_metadata_reference(child) for child in ast.iter_child_nodes(node)
-        )
-
     def _is_metadata_alias_value(self, node: ast.AST) -> bool:
         if self._is_metadata_reference(node) or self._is_metadata_merge_value(node):
             return True
@@ -188,11 +183,11 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
 
     def _is_metadata_merge_value(self, node: ast.AST) -> bool:
         if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
-            left_contains_metadata = self._contains_metadata_reference(node.left)
-            right_contains_metadata = self._contains_metadata_reference(node.right)
-            return left_contains_metadata or right_contains_metadata
+            left_is_metadata = self._is_metadata_alias_value(node.left)
+            right_is_metadata = self._is_metadata_alias_value(node.right)
+            return left_is_metadata or right_is_metadata
         if isinstance(node, ast.Dict) and any(
-            key is None and self._contains_metadata_reference(value)
+            key is None and self._is_metadata_alias_value(value)
             for key, value in zip(node.keys, node.values, strict=True)
         ):
             return True
@@ -202,10 +197,10 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
             and node.func.id == "dict"
         ):
             positional_metadata = any(
-                self._contains_metadata_reference(argument) for argument in node.args
+                self._is_metadata_alias_value(argument) for argument in node.args
             )
             unpacked_keyword_metadata = any(
-                keyword.arg is None and self._contains_metadata_reference(keyword.value)
+                keyword.arg is None and self._is_metadata_alias_value(keyword.value)
                 for keyword in node.keywords
             )
             return positional_metadata or unpacked_keyword_metadata
@@ -706,6 +701,18 @@ def _metadata_update_violations(path: Path, node: ast.Call) -> list[str]:
 def _metadata_dict_key_violations(path: Path, node: ast.AST | None) -> list[str]:
     if node is None:
         return []
+    if isinstance(node, ast.NamedExpr):
+        return _metadata_dict_key_violations(path, node.value)
+    if isinstance(node, ast.IfExp):
+        return [
+            *_metadata_dict_key_violations(path, node.body),
+            *_metadata_dict_key_violations(path, node.orelse),
+        ]
+    if isinstance(node, ast.BoolOp):
+        boolop_violations: list[str] = []
+        for value in node.values:
+            boolop_violations.extend(_metadata_dict_key_violations(path, value))
+        return boolop_violations
     if isinstance(node, ast.List | ast.Tuple):
         return _metadata_pair_sequence_violations(path, node)
     if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
@@ -774,6 +781,12 @@ flow.metadata.update({"firewall_base": "https://api.example.com"})
 flow.metadata.update(firewall_permission="read")
 flow.metadata |= {"vm_network_log_path": "network.jsonl"}
 flow.metadata = dict(vm_proxy_log_path="proxy.jsonl")
+flow.metadata = {"vm_run_id": "run-1"} if condition else {}
+flow.metadata.update({"vm_run_id": "run-1"} if condition else {})
+flow.metadata.update(fallback_update or {"vm_run_id": "run-1"})
+flow.metadata.update([("vm_run_id", "run-1")] if condition else [])
+flow.metadata.update((named_update := {"vm_run_id": "run-1"}))
+flow.metadata = {**({"vm_run_id": "run-1"} if condition else {})}
 flow.metadata.update(dict([("stream_buffer", bytearray())]))
 flow.metadata.update({**{"capture_body": True}})
 flow.metadata = {"request_stream_buffer": bytearray()} | {"request_stream_buffer_state": {}}
@@ -814,6 +827,7 @@ conditional_expr_meta["vm_run_id"] = "run-1"
 bool_expr_meta = fallback_meta or flow.metadata
 bool_expr_meta["firewall_name"] = "github"
 conditional_merge_meta = (flow.metadata | {"firewall_action": "ALLOW"}) if condition else {}
+conditional_rhs_merge_meta = flow.metadata | ({"firewall_action": "ALLOW"} if condition else {})
 copy_meta = flow.metadata.copy()
 copy_meta["vm_run_id"] = "run-1"
 (flow.metadata if condition else {})["firewall_base"] = "https://api.example.com"
@@ -908,7 +922,7 @@ match match_payload:
 
     violations = _metadata_key_violations(source_path)
 
-    assert len(violations) == 66
+    assert len(violations) == 73
     assert all("use metadata_keys." in violation for violation in violations)
 
 
@@ -937,6 +951,14 @@ external_aug_meta |= {"vm_run_id": "external"}
 value = external_aug_meta["vm_run_id"]
 external_keyword_meta = dict(metadata=flow.metadata, vm_run_id="external")
 value = external_keyword_meta["vm_run_id"]
+external_union_meta = {"metadata": flow.metadata} | {"vm_run_id": "external"}
+value = external_union_meta["vm_run_id"]
+external_unpack_meta = {**{"metadata": flow.metadata}, "vm_run_id": "external"}
+value = external_unpack_meta["vm_run_id"]
+external_positional_dict_meta = dict({"metadata": flow.metadata, "vm_run_id": "external"})
+value = external_positional_dict_meta["vm_run_id"]
+external_unpack_dict_meta = dict(**{"metadata": flow.metadata, "vm_run_id": "external"})
+value = external_unpack_dict_meta["vm_run_id"]
 external_conditional_meta = {"vm_run_id": "external"} if condition else {}
 value = external_conditional_meta["vm_run_id"]
 external_bool_meta = fallback_meta or {"vm_run_id": "external"}

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -1100,12 +1100,15 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self._visit_try_statement(node)
 
     def visit_Match(self, node: ast.Match) -> None:
+        subject_is_metadata = self._is_metadata_alias_value(node.subject)
         self._record_metadata_merge_key_violations(node.subject)
         self.visit(node.subject)
         continuing_aliases = set(self._metadata_aliases)
         exit_aliases: set[str] = set()
         has_unmatched_path = True
         for case in node.cases:
+            if subject_is_metadata:
+                self._record_metadata_match_pattern_key_violations(case.pattern)
             names = _pattern_names(case.pattern)
             pattern_is_exhaustive = _pattern_is_exhaustive(case.pattern)
             aliases = set(continuing_aliases)
@@ -1130,6 +1133,20 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         if has_unmatched_path:
             exit_aliases.update(continuing_aliases)
         self._replace_current_aliases(exit_aliases)
+
+    def _record_metadata_match_pattern_key_violations(self, pattern: ast.pattern) -> None:
+        if isinstance(pattern, ast.MatchMapping):
+            for key in pattern.keys:
+                key_name = _registered_key_name(key)
+                if key_name is not None:
+                    self._add_violation(_violation(self.path, key, key_name))
+            return
+        if isinstance(pattern, ast.MatchAs) and pattern.pattern is not None:
+            self._record_metadata_match_pattern_key_violations(pattern.pattern)
+            return
+        if isinstance(pattern, ast.MatchOr):
+            for child_pattern in pattern.patterns:
+                self._record_metadata_match_pattern_key_violations(child_pattern)
 
     def visit_ListComp(self, node: ast.ListComp) -> None:
         self._visit_comprehension(node.generators, [node.elt])
@@ -1571,12 +1588,19 @@ match match_payload:
         pass
     case _:
         guard_case_meta["vm_run_id"] = "run-1"
+match flow.metadata:
+    case {"vm_run_id": run_id}:
+        pass
+meta = flow.metadata
+match meta:
+    case {"firewall_name": firewall_name}:
+        pass
 """
     )
 
     violations = _metadata_key_violations(source_path)
 
-    assert len(violations) == 143
+    assert len(violations) == 145
     assert all("use metadata_keys." in violation for violation in violations)
 
 
@@ -1823,6 +1847,12 @@ match payload:
     case meta:
         value = meta["vm_run_id"]
 value = match_meta["vm_run_id"]
+match payload:
+    case {"vm_run_id": external_run_id}:
+        pass
+match flow.metadata:
+    case {"payload": {"vm_run_id": external_run_id}}:
+        pass
 try:
     pass
 except Exception as meta:

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -61,6 +61,17 @@ def _metadata_key_violations(path: Path) -> list[str]:
             if node.func.attr == "update":
                 violations.extend(_metadata_update_violations(path, node))
 
+        if isinstance(node, ast.AugAssign) and _is_metadata_attribute(node.target):
+            violations.extend(_metadata_dict_key_violations(path, node.value))
+
+        if isinstance(node, ast.Assign) and any(
+            _is_metadata_attribute(target) for target in node.targets
+        ):
+            violations.extend(_metadata_dict_key_violations(path, node.value))
+
+        if isinstance(node, ast.AnnAssign) and _is_metadata_attribute(node.target):
+            violations.extend(_metadata_dict_key_violations(path, node.value))
+
         if isinstance(node, ast.Compare) and len(node.comparators) == 1:
             if not isinstance(node.ops[0], (ast.In, ast.NotIn)):
                 continue
@@ -74,18 +85,52 @@ def _metadata_key_violations(path: Path) -> list[str]:
 
 
 def _metadata_update_violations(path: Path, node: ast.Call) -> list[str]:
-    if not node.args:
+    violations: list[str] = []
+    update_arg = None if not node.args else node.args[0]
+    violations.extend(_metadata_dict_key_violations(path, update_arg))
+    violations.extend(_metadata_keyword_violations(path, node.keywords))
+    return violations
+
+
+def _metadata_dict_key_violations(path: Path, node: ast.AST | None) -> list[str]:
+    if node is None:
         return []
-    update_arg = node.args[0]
-    if not isinstance(update_arg, ast.Dict):
+    if isinstance(node, ast.List | ast.Tuple):
+        return _metadata_pair_sequence_violations(path, node)
+    if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "dict":
+        return _metadata_keyword_violations(path, node.keywords)
+    if not isinstance(node, ast.Dict):
         return []
     violations: list[str] = []
-    for key in update_arg.keys:
+    for key in node.keys:
         if key is None:
             continue
         key_name = _registered_key_name(key)
         if key_name is not None:
             violations.append(_violation(path, key, key_name))
+    return violations
+
+
+def _metadata_pair_sequence_violations(path: Path, node: ast.List | ast.Tuple) -> list[str]:
+    violations: list[str] = []
+    for item in node.elts:
+        if not isinstance(item, ast.List | ast.Tuple) or len(item.elts) != 2:
+            continue
+        key_name = _registered_key_name(item.elts[0])
+        if key_name is not None:
+            violations.append(_violation(path, item.elts[0], key_name))
+    return violations
+
+
+def _metadata_keyword_violations(path: Path, keywords: list[ast.keyword]) -> list[str]:
+    violations: list[str] = []
+    for keyword in keywords:
+        if keyword.arg is None:
+            violations.extend(_metadata_dict_key_violations(path, keyword.value))
+            continue
+        key_name = _REGISTERED_METADATA_KEYS.get(keyword.arg)
+        if key_name is not None:
+            violations.append(_violation(path, keyword, key_name))
     return violations
 
 

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -1246,6 +1246,17 @@ def _metadata_key_violations(path: Path) -> list[str]:
     return visitor.violations
 
 
+def test_registered_flow_metadata_keys_are_unique():
+    names_by_value: dict[str, list[str]] = {}
+    for name, value in vars(metadata_keys).items():
+        if name.isupper() and isinstance(value, str):
+            names_by_value.setdefault(value, []).append(name)
+
+    duplicates = {value: names for value, names in sorted(names_by_value.items()) if len(names) > 1}
+
+    assert duplicates == {}
+
+
 def _metadata_dict_key_violations(path: Path, node: ast.AST | None) -> list[str]:
     if node is None:
         return []

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -72,6 +72,172 @@ def _argument_names(args: ast.arguments) -> set[str]:
     return names
 
 
+class _ScopeBoundNameVisitor(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.bound_names: set[str] = set()
+        self.global_names: set[str] = set()
+        self.nonlocal_names: set[str] = set()
+
+    @property
+    def local_names(self) -> set[str]:
+        return self.bound_names - self.global_names - self.nonlocal_names
+
+    def visit_Global(self, node: ast.Global) -> None:
+        self.global_names.update(node.names)
+
+    def visit_Nonlocal(self, node: ast.Nonlocal) -> None:
+        self.nonlocal_names.update(node.names)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self.bound_names.add(node.name)
+        self._visit_function_definition_expressions(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self.bound_names.add(node.name)
+        self._visit_function_definition_expressions(node)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self.bound_names.add(node.name)
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        for base in node.bases:
+            self.visit(base)
+        for keyword in node.keywords:
+            self.visit(keyword)
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        for default in [*node.args.defaults, *node.args.kw_defaults]:
+            if default is not None:
+                self.visit(default)
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        self.visit(node.value)
+        for target in node.targets:
+            self.bound_names.update(_target_names(target))
+            self.visit(target)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        if node.value is not None:
+            self.visit(node.value)
+        self.visit(node.annotation)
+        self.bound_names.update(_target_names(node.target))
+        self.visit(node.target)
+
+    def visit_AugAssign(self, node: ast.AugAssign) -> None:
+        self.bound_names.update(_target_names(node.target))
+        self.visit(node.target)
+        self.visit(node.value)
+
+    def _visit_for_statement(self, node: ast.For | ast.AsyncFor) -> None:
+        self.visit(node.iter)
+        self.bound_names.update(_target_names(node.target))
+        self.visit(node.target)
+        for statement in [*node.body, *node.orelse]:
+            self.visit(statement)
+
+    def visit_For(self, node: ast.For) -> None:
+        self._visit_for_statement(node)
+
+    def visit_AsyncFor(self, node: ast.AsyncFor) -> None:
+        self._visit_for_statement(node)
+
+    def _visit_with_statement(self, node: ast.With | ast.AsyncWith) -> None:
+        for item in node.items:
+            self.visit(item.context_expr)
+            self.bound_names.update(_target_names(item.optional_vars))
+            if item.optional_vars is not None:
+                self.visit(item.optional_vars)
+        for statement in node.body:
+            self.visit(statement)
+
+    def visit_With(self, node: ast.With) -> None:
+        self._visit_with_statement(node)
+
+    def visit_AsyncWith(self, node: ast.AsyncWith) -> None:
+        self._visit_with_statement(node)
+
+    def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
+        if node.type is not None:
+            self.visit(node.type)
+        if node.name is not None:
+            self.bound_names.add(node.name)
+        for statement in node.body:
+            self.visit(statement)
+
+    def visit_Delete(self, node: ast.Delete) -> None:
+        for target in node.targets:
+            self.bound_names.update(_target_names(target))
+            self.visit(target)
+
+    def visit_NamedExpr(self, node: ast.NamedExpr) -> None:
+        self.bound_names.update(_target_names(node.target))
+        self.visit(node.value)
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            self.bound_names.add(alias.asname or alias.name.split(".", maxsplit=1)[0])
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        for alias in node.names:
+            if alias.name != "*":
+                self.bound_names.add(alias.asname or alias.name)
+
+    def visit_Match(self, node: ast.Match) -> None:
+        self.visit(node.subject)
+        for case in node.cases:
+            self.bound_names.update(_pattern_names(case.pattern))
+            if case.guard is not None:
+                self.visit(case.guard)
+            for statement in case.body:
+                self.visit(statement)
+
+    def visit_ListComp(self, node: ast.ListComp) -> None:
+        self._visit_comprehension_expressions(node.generators, [node.elt])
+
+    def visit_SetComp(self, node: ast.SetComp) -> None:
+        self._visit_comprehension_expressions(node.generators, [node.elt])
+
+    def visit_GeneratorExp(self, node: ast.GeneratorExp) -> None:
+        self._visit_comprehension_expressions(node.generators, [node.elt])
+
+    def visit_DictComp(self, node: ast.DictComp) -> None:
+        self._visit_comprehension_expressions(node.generators, [node.key, node.value])
+
+    def _visit_function_definition_expressions(
+        self, node: ast.FunctionDef | ast.AsyncFunctionDef
+    ) -> None:
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        for default in [*node.args.defaults, *node.args.kw_defaults]:
+            if default is not None:
+                self.visit(default)
+        if node.returns is not None:
+            self.visit(node.returns)
+
+    def _visit_comprehension_expressions(
+        self, generators: list[ast.comprehension], body_expressions: list[ast.AST]
+    ) -> None:
+        for generator in generators:
+            self.visit(generator.iter)
+            for condition in generator.ifs:
+                self.visit(condition)
+        for expression in body_expressions:
+            self.visit(expression)
+
+
+def _scope_bound_names(body: list[ast.stmt]) -> set[str]:
+    visitor = _ScopeBoundNameVisitor()
+    for statement in body:
+        visitor.visit(statement)
+    return visitor.local_names
+
+
+def _expression_bound_names(expression: ast.AST) -> set[str]:
+    visitor = _ScopeBoundNameVisitor()
+    visitor.visit(expression)
+    return visitor.local_names
+
+
 def _pattern_names(pattern: ast.pattern) -> set[str]:
     if isinstance(pattern, ast.MatchAs):
         names = set() if pattern.name is None else {pattern.name}
@@ -146,6 +312,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self.path = path
         self.violations: list[str] = []
         self._metadata_alias_scopes: list[set[str]] = [set()]
+        self._class_nested_scope_alias_scopes: list[set[str]] = []
         self._named_expr_target_scope_indexes: list[int] = []
 
     @property
@@ -241,6 +408,11 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self._metadata_aliases.clear()
         self._metadata_aliases.update(aliases)
 
+    def _nested_function_base_aliases(self) -> set[str]:
+        if self._class_nested_scope_alias_scopes:
+            return set(self._class_nested_scope_alias_scopes[-1])
+        return set(self._metadata_aliases)
+
     def _visit_current_scope_body(self, body: list[ast.stmt]) -> bool:
         for statement in body:
             self.visit(statement)
@@ -281,8 +453,9 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         body: list[ast.stmt],
         shadowed: set[str] | None = None,
         added: set[str] | None = None,
+        base_aliases: set[str] | None = None,
     ) -> None:
-        aliases = set(self._metadata_aliases)
+        aliases = set(self._metadata_aliases if base_aliases is None else base_aliases)
         if shadowed is not None:
             aliases.difference_update(shadowed)
         if added is not None:
@@ -299,8 +472,9 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         expression: ast.AST,
         shadowed: set[str] | None = None,
         added: set[str] | None = None,
+        base_aliases: set[str] | None = None,
     ) -> None:
-        aliases = set(self._metadata_aliases)
+        aliases = set(self._metadata_aliases if base_aliases is None else base_aliases)
         if shadowed is not None:
             aliases.difference_update(shadowed)
         if added is not None:
@@ -319,8 +493,12 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         for default in [*node.args.defaults, *node.args.kw_defaults]:
             if default is not None:
                 self._visit_default_value(default)
-        shadowed_names = (_argument_names(node.args) - metadata_defaults) | {node.name}
-        self._visit_scoped_body(node.body, shadowed_names, metadata_defaults)
+        shadowed_names = (
+            (_argument_names(node.args) | _scope_bound_names(node.body)) - metadata_defaults
+        ) | {node.name}
+        self._visit_scoped_body(
+            node.body, shadowed_names, metadata_defaults, self._nested_function_base_aliases()
+        )
         self._metadata_aliases.discard(node.name)
 
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
@@ -330,8 +508,12 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         for default in [*node.args.defaults, *node.args.kw_defaults]:
             if default is not None:
                 self._visit_default_value(default)
-        shadowed_names = (_argument_names(node.args) - metadata_defaults) | {node.name}
-        self._visit_scoped_body(node.body, shadowed_names, metadata_defaults)
+        shadowed_names = (
+            (_argument_names(node.args) | _scope_bound_names(node.body)) - metadata_defaults
+        ) | {node.name}
+        self._visit_scoped_body(
+            node.body, shadowed_names, metadata_defaults, self._nested_function_base_aliases()
+        )
         self._metadata_aliases.discard(node.name)
 
     def visit_Lambda(self, node: ast.Lambda) -> None:
@@ -340,7 +522,10 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
             if default is not None:
                 self._visit_default_value(default)
         self._visit_scoped_expression(
-            node.body, _argument_names(node.args) - metadata_defaults, metadata_defaults
+            node.body,
+            (_argument_names(node.args) | _expression_bound_names(node.body)) - metadata_defaults,
+            metadata_defaults,
+            self._nested_function_base_aliases(),
         )
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
@@ -350,7 +535,13 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
             self.visit(base)
         for keyword in node.keywords:
             self.visit(keyword)
-        self._visit_scoped_body(node.body)
+        outer_aliases = set(self._metadata_aliases)
+        class_body_aliases = set(outer_aliases)
+        class_body_aliases.difference_update(_scope_bound_names(node.body))
+        class_body_aliases.update(self._metadata_alias_scopes[0])
+        self._class_nested_scope_alias_scopes.append(outer_aliases)
+        self._visit_scoped_body(node.body, base_aliases=class_body_aliases)
+        self._class_nested_scope_alias_scopes.pop()
         self._metadata_aliases.discard(node.name)
 
     def visit_Assign(self, node: ast.Assign) -> None:
@@ -667,7 +858,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
             if self._named_expr_target_scope_indexes
             else len(self._metadata_alias_scopes) - 1
         )
-        self._metadata_alias_scopes.append(set(self._metadata_aliases))
+        self._metadata_alias_scopes.append(self._nested_function_base_aliases())
         self._named_expr_target_scope_indexes.append(named_expr_target_scope_index)
         self._discard_alias_target(first_generator.target)
         for condition in first_generator.ifs:
@@ -808,6 +999,22 @@ def nested_alias():
     inner_meta = flow.metadata
     def uses_outer_alias():
         inner_meta["auth_cache_hit"] = False
+def local_function_assigns_metadata():
+    local_function_meta = flow.metadata
+    local_function_meta["vm_run_id"] = "run-1"
+class ClassBodyAssignsMetadata:
+    class_body_meta = flow.metadata
+    class_body_meta["vm_run_id"] = "run-1"
+def class_body_reads_closure_metadata():
+    class_closure_meta = flow.metadata
+    class ReadsClosure:
+        class_closure_meta["vm_run_id"] = "run-1"
+def class_method_reads_outer_metadata():
+    method_outer_meta = flow.metadata
+    class MethodReadsOuter:
+        method_outer_meta = {}
+        def method(self):
+            method_outer_meta["vm_run_id"] = "run-1"
 annotated_meta = flow.metadata
 annotated_meta: dict[str, object]
 annotated_meta["auth_url_rewrite"] = True
@@ -922,7 +1129,7 @@ match match_payload:
 
     violations = _metadata_key_violations(source_path)
 
-    assert len(violations) == 73
+    assert len(violations) == 77
     assert all("use metadata_keys." in violation for violation in violations)
 
 
@@ -1036,6 +1243,43 @@ def continue_skips_unreachable_metadata_access():
         unreachable_continue_meta = flow.metadata
         continue
         unreachable_continue_meta["vm_run_id"]
+late_assignment_meta = flow.metadata
+def late_assignment_local_shadow():
+    value = late_assignment_meta["vm_run_id"]
+    late_assignment_meta = {}
+late_import_meta = flow.metadata
+def late_import_local_shadow():
+    value = late_import_meta["vm_run_id"]
+    import json as late_import_meta
+late_loop_meta = flow.metadata
+def late_loop_local_shadow():
+    value = late_loop_meta["vm_run_id"]
+    for late_loop_meta in rows:
+        pass
+late_delete_meta = flow.metadata
+def late_delete_local_shadow():
+    value = late_delete_meta["vm_run_id"]
+    del late_delete_meta
+late_match_meta = flow.metadata
+def late_match_local_shadow(match_payload):
+    value = late_match_meta["vm_run_id"]
+    match match_payload:
+        case late_match_meta:
+            pass
+lambda_shadow_meta = flow.metadata
+fn = lambda: lambda_shadow_meta["vm_run_id"] if (lambda_shadow_meta := {}) else None
+def class_body_late_binding_shadow():
+    class_shadow_meta = flow.metadata
+    class ShadowsClosure:
+        value = class_shadow_meta["vm_run_id"]
+        class_shadow_meta = {}
+class MethodDoesNotSeeClassAlias:
+    method_class_meta = flow.metadata
+    def method(self):
+        method_class_meta["vm_run_id"]
+class ComprehensionDoesNotSeeClassAlias:
+    comp_class_meta = flow.metadata
+    values = [comp_class_meta["vm_run_id"] for item in rows]
 def accepts_external_metadata(meta):
     return meta["vm_proxy_log_path"]
 for meta in [{"firewall_name": "external"}]:

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -368,6 +368,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self.violations: list[str] = []
         self._metadata_alias_scopes: list[set[str]] = [set()]
         self._class_nested_scope_alias_scopes: list[set[str]] = []
+        self._metadata_key_checked_node_ids: set[int] = set()
         self._named_expr_target_scope_indexes: list[int] = []
 
     @property
@@ -443,6 +444,30 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
             return violations
         return []
 
+    def _record_metadata_merge_key_violations(self, node: ast.AST | None) -> None:
+        if node is None:
+            return
+        node_id = id(node)
+        if node_id in self._metadata_key_checked_node_ids:
+            return
+        violations = self._metadata_merge_key_violations(node)
+        if not violations:
+            return
+        self._metadata_key_checked_node_ids.add(node_id)
+        self.violations.extend(violations)
+
+    def _record_metadata_dict_key_violations(self, node: ast.AST | None) -> None:
+        if node is None:
+            return
+        node_id = id(node)
+        if node_id in self._metadata_key_checked_node_ids:
+            return
+        violations = _metadata_dict_key_violations(self.path, node)
+        if not violations:
+            return
+        self._metadata_key_checked_node_ids.add(node_id)
+        self.violations.extend(violations)
+
     def _metadata_default_argument_names(self, args: ast.arguments) -> set[str]:
         metadata_defaults: set[str] = set()
         positional_args = [*args.posonlyargs, *args.args]
@@ -456,7 +481,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         return metadata_defaults
 
     def _visit_default_value(self, node: ast.AST) -> None:
-        self.violations.extend(self._metadata_merge_key_violations(node))
+        self._record_metadata_merge_key_violations(node)
         self.visit(node)
 
     def _replace_current_aliases(self, aliases: set[str]) -> None:
@@ -473,7 +498,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         outer_aliases = set(self._metadata_aliases)
         self._metadata_aliases.difference_update(shadowed_names)
         if check_metadata_merge:
-            self.violations.extend(self._metadata_merge_key_violations(node))
+            self._record_metadata_merge_key_violations(node)
         self.visit(node)
         expression_aliases = set(self._metadata_aliases)
         self._replace_current_aliases(
@@ -554,6 +579,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self._metadata_alias_scopes.append(aliases)
         previous_named_expr_target_scope_indexes = self._named_expr_target_scope_indexes
         self._named_expr_target_scope_indexes = []
+        self._record_metadata_merge_key_violations(expression)
         self.visit(expression)
         self._named_expr_target_scope_indexes = previous_named_expr_target_scope_indexes
         self._metadata_alias_scopes.pop()
@@ -578,13 +604,20 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
             self._visit_definition_expression(
                 node.returns, type_param_names, check_metadata_merge=True
             )
+        body_scope_bindings = _scope_bound_name_visitor(node.body)
+        body_global_names = body_scope_bindings.global_names
         shadowed_names = (
-            (_argument_names(node.args) | _scope_bound_names(node.body) | type_param_names)
+            (
+                _argument_names(node.args)
+                | body_scope_bindings.local_names
+                | (type_param_names - body_global_names)
+            )
             - metadata_defaults
         ) | {node.name}
-        self._visit_scoped_body(
-            node.body, shadowed_names, metadata_defaults, self._nested_function_base_aliases()
-        )
+        body_base_aliases = self._nested_function_base_aliases()
+        body_base_aliases.difference_update(body_global_names)
+        body_base_aliases.update(self._metadata_alias_scopes[0] & body_global_names)
+        self._visit_scoped_body(node.body, shadowed_names, metadata_defaults, body_base_aliases)
         self._metadata_aliases.discard(node.name)
 
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
@@ -607,13 +640,20 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
             self._visit_definition_expression(
                 node.returns, type_param_names, check_metadata_merge=True
             )
+        body_scope_bindings = _scope_bound_name_visitor(node.body)
+        body_global_names = body_scope_bindings.global_names
         shadowed_names = (
-            (_argument_names(node.args) | _scope_bound_names(node.body) | type_param_names)
+            (
+                _argument_names(node.args)
+                | body_scope_bindings.local_names
+                | (type_param_names - body_global_names)
+            )
             - metadata_defaults
         ) | {node.name}
-        self._visit_scoped_body(
-            node.body, shadowed_names, metadata_defaults, self._nested_function_base_aliases()
-        )
+        body_base_aliases = self._nested_function_base_aliases()
+        body_base_aliases.difference_update(body_global_names)
+        body_base_aliases.update(self._metadata_alias_scopes[0] & body_global_names)
+        self._visit_scoped_body(node.body, shadowed_names, metadata_defaults, body_base_aliases)
         self._metadata_aliases.discard(node.name)
 
     def visit_Lambda(self, node: ast.Lambda) -> None:
@@ -667,9 +707,9 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
 
     def visit_Assign(self, node: ast.Assign) -> None:
         if any(_is_metadata_attribute(target) for target in node.targets):
-            self.violations.extend(_metadata_dict_key_violations(self.path, node.value))
+            self._record_metadata_dict_key_violations(node.value)
         else:
-            self.violations.extend(self._metadata_merge_key_violations(node.value))
+            self._record_metadata_merge_key_violations(node.value)
         self.visit(node.value)
         for target in node.targets:
             self.visit(target)
@@ -677,11 +717,12 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
 
     def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
         if _is_metadata_attribute(node.target):
-            self.violations.extend(_metadata_dict_key_violations(self.path, node.value))
+            self._record_metadata_dict_key_violations(node.value)
         elif node.value is not None:
-            self.violations.extend(self._metadata_merge_key_violations(node.value))
+            self._record_metadata_merge_key_violations(node.value)
         if node.value is not None:
             self.visit(node.value)
+        self._record_metadata_merge_key_violations(node.annotation)
         self.visit(node.annotation)
         self.visit(node.target)
         if node.value is not None and isinstance(node.target, ast.Name):
@@ -694,9 +735,9 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         target_is_metadata = self._is_metadata_reference(node.target)
         value_is_metadata_merge = self._is_metadata_merge_value(node.value)
         if target_is_metadata:
-            self.violations.extend(_metadata_dict_key_violations(self.path, node.value))
+            self._record_metadata_dict_key_violations(node.value)
         elif value_is_metadata_merge:
-            self.violations.extend(self._metadata_merge_key_violations(node.value))
+            self._record_metadata_merge_key_violations(node.value)
         self.visit(node.target)
         self.visit(node.value)
         if (
@@ -709,7 +750,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
     def visit_NamedExpr(self, node: ast.NamedExpr) -> None:
         if isinstance(node.target, ast.Name):
             is_metadata_alias = self._is_metadata_alias_value(node.value)
-            self.violations.extend(self._metadata_merge_key_violations(node.value))
+            self._record_metadata_merge_key_violations(node.value)
             self.visit(node.value)
             target_aliases = self._named_expr_target_aliases
             if is_metadata_alias:
@@ -729,13 +770,46 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self.generic_visit(node)
 
     def visit_Call(self, node: ast.Call) -> None:
+        self._record_metadata_merge_key_violations(node)
+        for argument in node.args:
+            self._record_metadata_merge_key_violations(argument)
+        for keyword in node.keywords:
+            self._record_metadata_merge_key_violations(keyword.value)
         if isinstance(node.func, ast.Attribute) and self._is_metadata_alias_value(node.func.value):
             if node.func.attr in _METADATA_METHODS_WITH_KEY_ARGUMENTS and node.args:
                 key_name = _registered_key_name(node.args[0])
                 if key_name is not None:
                     self.violations.append(_violation(self.path, node, key_name))
             if node.func.attr in _METADATA_METHODS_WITH_DICT_ARGUMENTS:
-                self.violations.extend(_metadata_update_violations(self.path, node))
+                update_arg = None if not node.args else node.args[0]
+                self._record_metadata_dict_key_violations(update_arg)
+                for keyword in node.keywords:
+                    if keyword.arg is None:
+                        self._record_metadata_dict_key_violations(keyword.value)
+                        continue
+                    key_name = _REGISTERED_METADATA_KEYS.get(keyword.arg)
+                    if key_name is not None:
+                        self.violations.append(_violation(self.path, keyword, key_name))
+        self.generic_visit(node)
+
+    def visit_Expr(self, node: ast.Expr) -> None:
+        self._record_metadata_merge_key_violations(node.value)
+        self.generic_visit(node)
+
+    def visit_Return(self, node: ast.Return) -> None:
+        self._record_metadata_merge_key_violations(node.value)
+        self.generic_visit(node)
+
+    def visit_Assert(self, node: ast.Assert) -> None:
+        self._record_metadata_merge_key_violations(node.test)
+        self.generic_visit(node)
+
+    def visit_Yield(self, node: ast.Yield) -> None:
+        self._record_metadata_merge_key_violations(node.value)
+        self.generic_visit(node)
+
+    def visit_YieldFrom(self, node: ast.YieldFrom) -> None:
+        self._record_metadata_merge_key_violations(node.value)
         self.generic_visit(node)
 
     def visit_Compare(self, node: ast.Compare) -> None:
@@ -756,6 +830,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self.generic_visit(node)
 
     def visit_If(self, node: ast.If) -> None:
+        self._record_metadata_merge_key_violations(node.test)
         self.visit(node.test)
         base_aliases = set(self._metadata_aliases)
         body_aliases, body_falls_through = self._visit_branch_body(node.body, base_aliases)
@@ -774,6 +849,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self._replace_current_aliases(exit_aliases)
 
     def visit_For(self, node: ast.For) -> None:
+        self._record_metadata_merge_key_violations(node.iter)
         self.visit(node.iter)
         base_aliases = set(self._metadata_aliases)
         self._discard_alias_target(node.target)
@@ -789,6 +865,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self._replace_current_aliases(loop_exit_aliases | orelse_aliases)
 
     def visit_AsyncFor(self, node: ast.AsyncFor) -> None:
+        self._record_metadata_merge_key_violations(node.iter)
         self.visit(node.iter)
         base_aliases = set(self._metadata_aliases)
         self._discard_alias_target(node.target)
@@ -804,6 +881,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self._replace_current_aliases(loop_exit_aliases | orelse_aliases)
 
     def visit_While(self, node: ast.While) -> None:
+        self._record_metadata_merge_key_violations(node.test)
         self.visit(node.test)
         base_aliases = set(self._metadata_aliases)
         body_aliases, _body_falls_through = self._visit_branch_body(node.body, base_aliases)
@@ -817,6 +895,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
 
     def visit_With(self, node: ast.With) -> None:
         for item in node.items:
+            self._record_metadata_merge_key_violations(item.context_expr)
             self.visit(item.context_expr)
         body_aliases = set(self._metadata_aliases)
         self._metadata_alias_scopes.append(body_aliases)
@@ -829,6 +908,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
 
     def visit_AsyncWith(self, node: ast.AsyncWith) -> None:
         for item in node.items:
+            self._record_metadata_merge_key_violations(item.context_expr)
             self.visit(item.context_expr)
         body_aliases = set(self._metadata_aliases)
         self._metadata_alias_scopes.append(body_aliases)
@@ -898,6 +978,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self._visit_try_statement(node)
 
     def visit_Match(self, node: ast.Match) -> None:
+        self._record_metadata_merge_key_violations(node.subject)
         self.visit(node.subject)
         continuing_aliases = set(self._metadata_aliases)
         exit_aliases: set[str] = set()
@@ -909,6 +990,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
             aliases.difference_update(names)
             self._metadata_alias_scopes.append(aliases)
             if case.guard is not None:
+                self._record_metadata_merge_key_violations(case.guard)
                 self.visit(case.guard)
             guard_aliases = set(self._metadata_aliases)
             falls_through = self._visit_current_scope_body(case.body)
@@ -972,6 +1054,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
             return
 
         first_generator, *remaining_generators = generators
+        self._record_metadata_merge_key_violations(first_generator.iter)
         self.visit(first_generator.iter)
 
         named_expr_target_scope_index = (
@@ -983,13 +1066,17 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self._named_expr_target_scope_indexes.append(named_expr_target_scope_index)
         self._discard_alias_target(first_generator.target)
         for condition in first_generator.ifs:
+            self._record_metadata_merge_key_violations(condition)
             self.visit(condition)
         for generator in remaining_generators:
+            self._record_metadata_merge_key_violations(generator.iter)
             self.visit(generator.iter)
             self._discard_alias_target(generator.target)
             for condition in generator.ifs:
+                self._record_metadata_merge_key_violations(condition)
                 self.visit(condition)
         for expression in body_expressions:
+            self._record_metadata_merge_key_violations(expression)
             self.visit(expression)
         self._named_expr_target_scope_indexes.pop()
         self._metadata_alias_scopes.pop()
@@ -1000,14 +1087,6 @@ def _metadata_key_violations(path: Path) -> list[str]:
     visitor = _MetadataKeyVisitor(path)
     visitor.visit(tree)
     return visitor.violations
-
-
-def _metadata_update_violations(path: Path, node: ast.Call) -> list[str]:
-    violations: list[str] = []
-    update_arg = None if not node.args else node.args[0]
-    violations.extend(_metadata_dict_key_violations(path, update_arg))
-    violations.extend(_metadata_keyword_violations(path, node.keywords))
-    return violations
 
 
 def _metadata_dict_key_violations(path: Path, node: ast.AST | None) -> list[str]:
@@ -1093,11 +1172,13 @@ flow.metadata.update({"firewall_base": "https://api.example.com"})
 flow.metadata.update(firewall_permission="read")
 flow.metadata |= {"vm_network_log_path": "network.jsonl"}
 flow.metadata = dict(vm_proxy_log_path="proxy.jsonl")
+flow.metadata = dict(flow.metadata, vm_run_id="run-1")
 flow.metadata = {"vm_run_id": "run-1"} if condition else {}
 flow.metadata.update({"vm_run_id": "run-1"} if condition else {})
 flow.metadata.update(fallback_update or {"vm_run_id": "run-1"})
 flow.metadata.update([("vm_run_id", "run-1")] if condition else [])
 flow.metadata.update((named_update := {"vm_run_id": "run-1"}))
+flow.metadata.update(flow.metadata | {"auth_cache_hit": False})
 flow.metadata = {**({"vm_run_id": "run-1"} if condition else {})}
 flow.metadata.update(dict([("stream_buffer", bytearray())]))
 flow.metadata.update({**{"capture_body": True}})
@@ -1190,6 +1271,7 @@ copy_meta["vm_run_id"] = "run-1"
 def function_default_meta(default_meta=flow.metadata):
     default_meta["vm_run_id"] = "run-1"
 lambda_default_meta = lambda default_meta=flow.metadata: default_meta["vm_network_log_path"]
+lambda_metadata_merge = lambda: flow.metadata | {"vm_run_id": "run-1"}
 def function_annotation_meta(
     arg: flow.metadata["vm_run_id"],
     *args: flow.metadata["vm_network_log_path"],
@@ -1226,6 +1308,29 @@ type_param_restored_meta = flow.metadata
 def type_param_scope_restores_alias[type_param_restored_meta]():
     pass
 type_param_restored_meta["firewall_name"] = "github"
+def call_argument_metadata_merge():
+    send(flow.metadata | {"vm_run_id": "run-1"})
+def return_metadata_merge():
+    return dict(flow.metadata, firewall_name="github")
+def assert_metadata_merge():
+    assert flow.metadata | {"firewall_base": "https://api.example.com"}
+(flow.metadata | {"firewall_action": "ALLOW"})
+def yield_metadata_merge():
+    yield flow.metadata | {"firewall_error": "auth_failed"}
+values = [flow.metadata | {"firewall_permission": "read"} for item in rows]
+for item in flow.metadata | {"firewall_rule_match": "GET /items"}:
+    pass
+annotated_merge_meta: flow.metadata | {"network_log_target": {}}
+function_global_meta = flow.metadata
+def nested_function_global_reads_module_metadata():
+    function_global_meta = {}
+    def inner():
+        global function_global_meta
+        function_global_meta["vm_run_id"] = "run-1"
+function_type_param_global_meta = flow.metadata
+def function_type_param_global_reads_module[function_type_param_global_meta]():
+    global function_type_param_global_meta
+    function_type_param_global_meta["firewall_action"] = "ALLOW"
 if conditional_meta := flow.metadata:
     conditional_meta["connector_diagnostic_base"] = "https://api.example.com"
 branch_meta = flow.metadata
@@ -1308,7 +1413,7 @@ match match_payload:
 
     violations = _metadata_key_violations(source_path)
 
-    assert len(violations) == 97
+    assert len(violations) == 110
     assert all("use metadata_keys." in violation for violation in violations)
 
 
@@ -1477,6 +1582,18 @@ class ClassTypeParamShadowsOuter[type_param_shadow_meta](type_param_shadow_meta)
 type TypeAliasTypeParamShadowsOuter[type_param_shadow_meta] = type_param_shadow_meta[
     "vm_run_id"
 ]
+def nested_function_global_reads_external():
+    function_global_external_meta = {}
+    def inner():
+        global function_global_external_meta
+        function_global_external_meta["vm_run_id"]
+send({"vm_run_id": "external"})
+def return_external_dict():
+    return {"vm_run_id": "external"}
+assert {"vm_run_id": "external"}
+lambda_external_dict = lambda: {"vm_run_id": "external"}
+values = [{"vm_run_id": "external"} for item in rows]
+external_annotation: {"vm_run_id": "external"}
 def class_body_late_binding_shadow():
     class_shadow_meta = flow.metadata
     class ShadowsClosure:

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -225,11 +225,15 @@ class _ScopeBoundNameVisitor(ast.NodeVisitor):
             self.visit(expression)
 
 
-def _scope_bound_names(body: list[ast.stmt]) -> set[str]:
+def _scope_bound_name_visitor(body: list[ast.stmt]) -> _ScopeBoundNameVisitor:
     visitor = _ScopeBoundNameVisitor()
     for statement in body:
         visitor.visit(statement)
-    return visitor.local_names
+    return visitor
+
+
+def _scope_bound_names(body: list[ast.stmt]) -> set[str]:
+    return _scope_bound_name_visitor(body).local_names
 
 
 def _expression_bound_names(expression: ast.AST) -> set[str]:
@@ -535,10 +539,14 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
             self.visit(base)
         for keyword in node.keywords:
             self.visit(keyword)
-        outer_aliases = set(self._metadata_aliases)
-        class_body_aliases = set(outer_aliases)
-        class_body_aliases.difference_update(_scope_bound_names(node.body))
-        class_body_aliases.update(self._metadata_alias_scopes[0])
+        outer_aliases = self._nested_function_base_aliases()
+        class_scope_bindings = _scope_bound_name_visitor(node.body)
+        class_body_bound_names = class_scope_bindings.local_names
+        class_body_global_names = class_scope_bindings.global_names
+        class_body_aliases = outer_aliases - class_body_bound_names - class_body_global_names
+        class_body_aliases.update(
+            self._metadata_alias_scopes[0] & (class_body_bound_names | class_body_global_names)
+        )
         self._class_nested_scope_alias_scopes.append(outer_aliases)
         self._visit_scoped_body(node.body, base_aliases=class_body_aliases)
         self._class_nested_scope_alias_scopes.pop()
@@ -1009,6 +1017,28 @@ def class_body_reads_closure_metadata():
     class_closure_meta = flow.metadata
     class ReadsClosure:
         class_closure_meta["vm_run_id"] = "run-1"
+class_module_fallback_meta = flow.metadata
+def class_body_binding_reads_module_metadata():
+    class_module_fallback_meta = {}
+    class ReadsModuleFallback:
+        class_module_fallback_meta["vm_run_id"] = "run-1"
+        class_module_fallback_meta = {}
+class_global_meta = flow.metadata
+def class_body_global_reads_module_metadata():
+    class_global_meta = {}
+    class ReadsGlobal:
+        global class_global_meta
+        class_global_meta["vm_run_id"] = "run-1"
+def nested_class_reads_closure_metadata():
+    nested_class_closure_meta = flow.metadata
+    class Outer:
+        class Inner:
+            nested_class_closure_meta["vm_run_id"] = "run-1"
+nested_class_module_meta = flow.metadata
+class NestedClassReadsModuleFallback:
+    nested_class_module_meta = {}
+    class Inner:
+        nested_class_module_meta["vm_run_id"] = "run-1"
 def class_method_reads_outer_metadata():
     method_outer_meta = flow.metadata
     class MethodReadsOuter:
@@ -1129,7 +1159,7 @@ match match_payload:
 
     violations = _metadata_key_violations(source_path)
 
-    assert len(violations) == 77
+    assert len(violations) == 81
     assert all("use metadata_keys." in violation for violation in violations)
 
 
@@ -1273,6 +1303,20 @@ def class_body_late_binding_shadow():
     class ShadowsClosure:
         value = class_shadow_meta["vm_run_id"]
         class_shadow_meta = {}
+module_shadowed_in_class_meta = flow.metadata
+def class_body_outer_external_shadows_module_alias():
+    module_shadowed_in_class_meta = {}
+    class ReadsOuterExternal:
+        value = module_shadowed_in_class_meta["vm_run_id"]
+def class_body_nonlocal_reads_outer_external():
+    class_nonlocal_meta = {}
+    class ReadsNonlocal:
+        nonlocal class_nonlocal_meta
+        value = class_nonlocal_meta["vm_run_id"]
+class NestedClassDoesNotSeeOuterClassAlias:
+    nested_class_shadow_meta = flow.metadata
+    class Inner:
+        nested_class_shadow_meta["vm_run_id"]
 class MethodDoesNotSeeClassAlias:
     method_class_meta = flow.metadata
     def method(self):

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -537,6 +537,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
     ) -> tuple[set[str], bool]:
         self._metadata_alias_scopes.append(set(aliases))
         if handler.type is not None:
+            self._record_metadata_merge_key_violations(handler.type)
             self.visit(handler.type)
         if handler.name is not None:
             self._metadata_aliases.discard(handler.name)
@@ -705,6 +706,26 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         for name in target_names:
             self._metadata_aliases.discard(name)
 
+    def _visit_type_parameter(self, node: ast.AST) -> None:
+        for _field_name, value in ast.iter_fields(node):
+            if isinstance(value, ast.AST):
+                self._record_metadata_merge_key_violations(value)
+                self.visit(value)
+            elif isinstance(value, list):
+                for item in value:
+                    if isinstance(item, ast.AST):
+                        self._record_metadata_merge_key_violations(item)
+                        self.visit(item)
+
+    def visit_TypeVar(self, node: ast.AST) -> None:
+        self._visit_type_parameter(node)
+
+    def visit_ParamSpec(self, node: ast.AST) -> None:
+        self._visit_type_parameter(node)
+
+    def visit_TypeVarTuple(self, node: ast.AST) -> None:
+        self._visit_type_parameter(node)
+
     def visit_Assign(self, node: ast.Assign) -> None:
         if any(_is_metadata_attribute(target) for target in node.targets):
             self._record_metadata_dict_key_violations(node.value)
@@ -777,9 +798,10 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self._visit_sequence_expression(node)
 
     def visit_Dict(self, node: ast.Dict) -> None:
-        for key, value in zip(node.keys, node.values, strict=True):
-            self._record_metadata_merge_key_violations(key)
-            self._record_metadata_merge_key_violations(value)
+        if not self._is_metadata_merge_value(node):
+            for key, value in zip(node.keys, node.values, strict=True):
+                self._record_metadata_merge_key_violations(key)
+                self._record_metadata_merge_key_violations(value)
         self.generic_visit(node)
 
     def visit_BinOp(self, node: ast.BinOp) -> None:
@@ -824,11 +846,15 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self.generic_visit(node)
 
     def visit_Call(self, node: ast.Call) -> None:
+        node_is_metadata_merge = self._is_metadata_merge_value(node)
         self._record_metadata_merge_key_violations(node)
+        self._record_metadata_merge_key_violations(node.func)
         for argument in node.args:
-            self._record_metadata_merge_key_violations(argument)
+            if not node_is_metadata_merge:
+                self._record_metadata_merge_key_violations(argument)
         for keyword in node.keywords:
-            self._record_metadata_merge_key_violations(keyword.value)
+            if not (node_is_metadata_merge and keyword.arg is None):
+                self._record_metadata_merge_key_violations(keyword.value)
         if isinstance(node.func, ast.Attribute) and self._is_metadata_alias_value(node.func.value):
             if node.func.attr in _METADATA_METHODS_WITH_KEY_ARGUMENTS and node.args:
                 key_name = _registered_key_name(node.args[0])
@@ -856,6 +882,12 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
 
     def visit_Assert(self, node: ast.Assert) -> None:
         self._record_metadata_merge_key_violations(node.test)
+        self._record_metadata_merge_key_violations(node.msg)
+        self.generic_visit(node)
+
+    def visit_Raise(self, node: ast.Raise) -> None:
+        self._record_metadata_merge_key_violations(node.exc)
+        self._record_metadata_merge_key_violations(node.cause)
         self.generic_visit(node)
 
     def visit_Yield(self, node: ast.Yield) -> None:
@@ -978,6 +1010,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
 
     def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
         if node.type is not None:
+            self._record_metadata_merge_key_violations(node.type)
             self.visit(node.type)
         base_aliases = set(self._metadata_aliases)
         self._metadata_alias_scopes.append(base_aliases)
@@ -1308,6 +1341,8 @@ merged_meta = flow.metadata | {"firewall_base": "https://api.example.com"}
 merged_meta = {**merged_meta, "firewall_api_id": "run-1:0"}
 merged_meta = dict(merged_meta, firewall_action="ALLOW")
 kwargs_merged_meta = dict(**flow.metadata, vm_run_id="run-1")
+dict_inner_union_meta = dict(flow.metadata | {"vm_run_id": "run-1"})
+dict_unpack_union_meta = dict(**(flow.metadata | {"firewall_name": "github"}))
 kwargs_alias_meta = dict(**flow.metadata)
 kwargs_alias_meta["vm_run_id"] = "run-1"
 conditional_expr_meta = flow.metadata if condition else {}
@@ -1350,11 +1385,16 @@ def vararg_annotation_alias_order(
     pass
 def function_type_param_meta[T: flow.metadata["vm_run_id"]]():
     pass
+def function_type_param_merge_meta[T: flow.metadata | {"vm_run_id": "run-1"}]():
+    pass
 async def async_function_type_param_meta[T: flow.metadata["firewall_action"]]():
     pass
 class ClassTypeParamMeta[T: flow.metadata["firewall_name"]]:
     pass
+class ClassTypeParamMergeMeta[T: flow.metadata | {"firewall_name": "github"}]:
+    pass
 type TypeAliasParamMeta[T: flow.metadata["firewall_base"]] = int
+type TypeAliasParamMergeMeta[T: flow.metadata | {"firewall_base": "https://api.example.com"}] = int
 type TypeAliasValueMeta = flow.metadata["vm_run_id"]
 type TypeAliasMergeMeta = flow.metadata | {"firewall_action": "ALLOW"}
 default_type_param_shadow_meta = flow.metadata
@@ -1372,7 +1412,15 @@ def return_metadata_merge():
     return dict(flow.metadata, firewall_name="github")
 def assert_metadata_merge():
     assert flow.metadata | {"firewall_base": "https://api.example.com"}
+assert condition, flow.metadata | {"vm_run_id": "run-1"}
 (flow.metadata | {"firewall_action": "ALLOW"})
+(flow.metadata | {"vm_run_id": "run-1"})()
+try:
+    pass
+except flow.metadata | {"firewall_name": "github"}:
+    pass
+raise RuntimeError from (flow.metadata | {"firewall_error": "auth_failed"})
+raise flow.metadata | {"firewall_permission": "read"}
 def yield_metadata_merge():
     yield flow.metadata | {"firewall_error": "auth_failed"}
 values = [flow.metadata | {"vm_run_id": "run-1"}]
@@ -1390,6 +1438,7 @@ value = other == (flow.metadata | {"firewall_name": "github"})
 value = (flow.metadata | {"firewall_api_id": "run-1:0"}).items
 values = [*(flow.metadata | {"suppress_request_body_capture": True})]
 value = rows[:(flow.metadata | {"capture_body": True})]
+values = [{**(flow.metadata | {"connector_diagnostic_base": "https://api.example.com"})}]
 values = [flow.metadata | {"firewall_permission": "read"} for item in rows]
 for item in flow.metadata | {"firewall_rule_match": "GET /items"}:
     pass
@@ -1486,7 +1535,7 @@ match match_payload:
 
     violations = _metadata_key_violations(source_path)
 
-    assert len(violations) == 125
+    assert len(violations) == 136
     assert all("use metadata_keys." in violation for violation in violations)
 
 

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -85,6 +85,36 @@ def _argument_annotations(args: ast.arguments) -> list[ast.expr]:
     return annotations
 
 
+def _static_call_argument_nodes(args: list[ast.expr], index: int) -> list[ast.AST]:
+    if index >= len(args):
+        return []
+    argument = args[index]
+    if isinstance(argument, ast.Starred):
+        return _static_starred_argument_nodes(argument.value)
+    return [argument]
+
+
+def _static_starred_argument_nodes(node: ast.AST) -> list[ast.AST]:
+    if isinstance(node, ast.NamedExpr):
+        return _static_starred_argument_nodes(node.value)
+    if isinstance(node, ast.IfExp):
+        return [
+            *_static_starred_argument_nodes(node.body),
+            *_static_starred_argument_nodes(node.orelse),
+        ]
+    if isinstance(node, ast.BoolOp):
+        nodes: list[ast.AST] = []
+        for value in node.values:
+            nodes.extend(_static_starred_argument_nodes(value))
+        return nodes
+    if not isinstance(node, ast.List | ast.Tuple) or not node.elts:
+        return []
+    first_arg = node.elts[0]
+    if isinstance(first_arg, ast.Starred):
+        return _static_starred_argument_nodes(first_arg.value)
+    return [first_arg]
+
+
 def _type_params(node: ast.AST) -> list[ast.AST]:
     for field_name, value in ast.iter_fields(node):
         if field_name == "type_params" and isinstance(value, list):
@@ -881,9 +911,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self._record_metadata_merge_key_violations(node.value)
         self._record_metadata_merge_key_violations(node.slice)
         if self._is_metadata_alias_value(node.value):
-            key_name = _registered_key_name(node.slice)
-            if key_name is not None:
-                self._add_violation(_violation(self.path, node, key_name))
+            self._add_violations(_metadata_key_expression_violations(self.path, node.slice))
         self.generic_visit(node)
 
     def visit_Call(self, node: ast.Call) -> None:
@@ -891,19 +919,18 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self._record_metadata_merge_key_violations(node)
         self._record_metadata_merge_key_violations(node.func)
         for index, argument in enumerate(node.args):
-            if not node_is_metadata_merge or index > 0:
+            if not node_is_metadata_merge or index > 0 or isinstance(argument, ast.Starred):
                 self._record_metadata_merge_key_violations(argument)
         for keyword in node.keywords:
             if not (node_is_metadata_merge and keyword.arg is None):
                 self._record_metadata_merge_key_violations(keyword.value)
         if isinstance(node.func, ast.Attribute) and self._is_metadata_alias_value(node.func.value):
             if node.func.attr in _METADATA_METHODS_WITH_KEY_ARGUMENTS and node.args:
-                key_name = _registered_key_name(node.args[0])
-                if key_name is not None:
-                    self._add_violation(_violation(self.path, node, key_name))
+                for key_arg in _static_call_argument_nodes(node.args, 0):
+                    self._add_violations(_metadata_key_expression_violations(self.path, key_arg))
             if node.func.attr in _METADATA_METHODS_WITH_DICT_ARGUMENTS:
-                update_arg = None if not node.args else node.args[0]
-                self._record_metadata_dict_key_violations(update_arg)
+                for update_arg in _static_call_argument_nodes(node.args, 0):
+                    self._record_metadata_dict_key_violations(update_arg)
                 for keyword in node.keywords:
                     if keyword.arg is None:
                         self._record_metadata_dict_key_violations(keyword.value)
@@ -956,9 +983,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
             and isinstance(node.ops[0], (ast.In, ast.NotIn))
             and self._is_metadata_alias_value(node.comparators[0])
         ):
-            key_name = _registered_key_name(node.left)
-            if key_name is not None:
-                self._add_violation(_violation(self.path, node, key_name))
+            self._add_violations(_metadata_key_expression_violations(self.path, node.left))
         self.generic_visit(node)
 
     def visit_Delete(self, node: ast.Delete) -> None:
@@ -1156,9 +1181,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
     def _record_metadata_match_pattern_key_violations(self, pattern: ast.pattern) -> None:
         if isinstance(pattern, ast.MatchMapping):
             for key in pattern.keys:
-                key_name = _registered_key_name(key)
-                if key_name is not None:
-                    self._add_violation(_violation(self.path, key, key_name))
+                self._add_violations(_metadata_key_expression_violations(self.path, key))
             return
         if isinstance(pattern, ast.MatchAs) and pattern.pattern is not None:
             self._record_metadata_match_pattern_key_violations(pattern.pattern)
@@ -1273,8 +1296,12 @@ def _metadata_dict_key_violations(path: Path, node: ast.AST | None) -> list[str]
         for value in node.values:
             boolop_violations.extend(_metadata_dict_key_violations(path, value))
         return boolop_violations
+    if isinstance(node, ast.DictComp):
+        return _metadata_key_expression_violations(path, node.key)
     if isinstance(node, ast.List | ast.Tuple | ast.Set):
         return _metadata_pair_sequence_violations(path, node)
+    if isinstance(node, ast.ListComp | ast.SetComp | ast.GeneratorExp):
+        return _metadata_pair_element_violations(path, node.elt)
     if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
         return [
             *_metadata_dict_key_violations(path, node.left),
@@ -1287,8 +1314,10 @@ def _metadata_dict_key_violations(path: Path, node: ast.AST | None) -> list[str]
             and node.func.value.id == "dict"
             and node.func.attr == "fromkeys"
         ):
-            keys_arg = None if not node.args else node.args[0]
-            return _metadata_key_sequence_violations(path, keys_arg)
+            fromkeys_violations: list[str] = []
+            for keys_arg in _static_call_argument_nodes(node.args, 0):
+                fromkeys_violations.extend(_metadata_key_sequence_violations(path, keys_arg))
+            return fromkeys_violations
         if (
             isinstance(node.func, ast.Attribute)
             and node.func.attr == "items"
@@ -1306,15 +1335,17 @@ def _metadata_dict_key_violations(path: Path, node: ast.AST | None) -> list[str]
         if isinstance(node.func, ast.Name):
             if node.func.id == "dict":
                 dict_call_violations: list[str] = []
-                update_arg = None if not node.args else node.args[0]
-                dict_call_violations.extend(_metadata_dict_key_violations(path, update_arg))
+                for update_arg in _static_call_argument_nodes(node.args, 0):
+                    dict_call_violations.extend(_metadata_dict_key_violations(path, update_arg))
                 dict_call_violations.extend(_metadata_keyword_violations(path, node.keywords))
                 return dict_call_violations
             if node.func.id == "zip":
                 return _metadata_zip_key_violations(path, node)
             if node.func.id in _SEQUENCE_WRAPPER_CALLS:
-                update_arg = None if not node.args else node.args[0]
-                return _metadata_dict_key_violations(path, update_arg)
+                wrapper_violations: list[str] = []
+                for update_arg in _static_call_argument_nodes(node.args, 0):
+                    wrapper_violations.extend(_metadata_dict_key_violations(path, update_arg))
+                return wrapper_violations
     if not isinstance(node, ast.Dict):
         return []
     violations: list[str] = []
@@ -1322,9 +1353,7 @@ def _metadata_dict_key_violations(path: Path, node: ast.AST | None) -> list[str]
         if key is None:
             violations.extend(_metadata_dict_key_violations(path, value))
             continue
-        key_name = _registered_key_name(key)
-        if key_name is not None:
-            violations.append(_violation(path, key, key_name))
+        violations.extend(_metadata_key_expression_violations(path, key))
     return violations
 
 
@@ -1336,12 +1365,26 @@ def _metadata_pair_sequence_violations(
         if isinstance(item, ast.Starred):
             violations.extend(_metadata_pair_iterable_violations(path, item.value))
             continue
-        if not isinstance(item, ast.List | ast.Tuple) or len(item.elts) != 2:
-            continue
-        key_name = _registered_key_name(item.elts[0])
-        if key_name is not None:
-            violations.append(_violation(path, item.elts[0], key_name))
+        violations.extend(_metadata_pair_element_violations(path, item))
     return violations
+
+
+def _metadata_pair_element_violations(path: Path, node: ast.AST) -> list[str]:
+    if isinstance(node, ast.NamedExpr):
+        return _metadata_pair_element_violations(path, node.value)
+    if isinstance(node, ast.IfExp):
+        return [
+            *_metadata_pair_element_violations(path, node.body),
+            *_metadata_pair_element_violations(path, node.orelse),
+        ]
+    if isinstance(node, ast.BoolOp):
+        violations: list[str] = []
+        for value in node.values:
+            violations.extend(_metadata_pair_element_violations(path, value))
+        return violations
+    if not isinstance(node, ast.List | ast.Tuple) or len(node.elts) != 2:
+        return []
+    return _metadata_key_expression_violations(path, node.elts[0])
 
 
 def _metadata_pair_iterable_violations(path: Path, node: ast.AST) -> list[str]:
@@ -1353,12 +1396,14 @@ def _metadata_pair_iterable_violations(path: Path, node: ast.AST) -> list[str]:
             *_metadata_pair_iterable_violations(path, node.orelse),
         ]
     if isinstance(node, ast.BoolOp):
-        violations: list[str] = []
+        boolop_violations: list[str] = []
         for value in node.values:
-            violations.extend(_metadata_pair_iterable_violations(path, value))
-        return violations
+            boolop_violations.extend(_metadata_pair_iterable_violations(path, value))
+        return boolop_violations
     if isinstance(node, ast.List | ast.Tuple | ast.Set):
         return _metadata_pair_sequence_violations(path, node)
+    if isinstance(node, ast.ListComp | ast.SetComp | ast.GeneratorExp):
+        return _metadata_pair_element_violations(path, node.elt)
     if isinstance(node, ast.Call):
         if (
             isinstance(node.func, ast.Attribute)
@@ -1378,10 +1423,10 @@ def _metadata_pair_iterable_violations(path: Path, node: ast.AST) -> list[str]:
             if node.func.id == "zip":
                 return _metadata_zip_key_violations(path, node)
             if node.func.id in _SEQUENCE_WRAPPER_CALLS:
-                update_arg = None if not node.args else node.args[0]
-                if update_arg is None:
-                    return []
-                return _metadata_pair_iterable_violations(path, update_arg)
+                violations: list[str] = []
+                for update_arg in _static_call_argument_nodes(node.args, 0):
+                    violations.extend(_metadata_pair_iterable_violations(path, update_arg))
+                return violations
     return []
 
 
@@ -1405,15 +1450,17 @@ def _metadata_key_sequence_violations(path: Path, node: ast.AST | None) -> list[
             *_metadata_key_sequence_violations(path, node.left),
             *_metadata_key_sequence_violations(path, node.right),
         ]
+    if isinstance(node, ast.ListComp | ast.SetComp | ast.GeneratorExp):
+        return _metadata_key_expression_violations(path, node.elt)
+    if isinstance(node, ast.DictComp):
+        return _metadata_key_expression_violations(path, node.key)
     if isinstance(node, ast.Dict):
         dict_key_violations: list[str] = []
         for key, value in zip(node.keys, node.values, strict=True):
             if key is None:
                 dict_key_violations.extend(_metadata_key_sequence_violations(path, value))
                 continue
-            key_name = _registered_key_name(key)
-            if key_name is not None:
-                dict_key_violations.append(_violation(path, key, key_name))
+            dict_key_violations.extend(_metadata_key_expression_violations(path, key))
         return dict_key_violations
     if (
         isinstance(node, ast.Call)
@@ -1435,8 +1482,10 @@ def _metadata_key_sequence_violations(path: Path, node: ast.AST | None) -> list[
         if node.func.id == "dict":
             return _metadata_dict_key_violations(path, node)
         if node.func.id in _SEQUENCE_WRAPPER_CALLS:
-            keys_arg = None if not node.args else node.args[0]
-            return _metadata_key_sequence_violations(path, keys_arg)
+            wrapper_violations: list[str] = []
+            for keys_arg in _static_call_argument_nodes(node.args, 0):
+                wrapper_violations.extend(_metadata_key_sequence_violations(path, keys_arg))
+            return wrapper_violations
     if not isinstance(node, ast.List | ast.Tuple | ast.Set):
         return []
     violations: list[str] = []
@@ -1444,15 +1493,34 @@ def _metadata_key_sequence_violations(path: Path, node: ast.AST | None) -> list[
         if isinstance(element, ast.Starred):
             violations.extend(_metadata_key_sequence_violations(path, element.value))
             continue
-        key_name = _registered_key_name(element)
-        if key_name is not None:
-            violations.append(_violation(path, element, key_name))
+        violations.extend(_metadata_key_expression_violations(path, element))
     return violations
 
 
 def _metadata_zip_key_violations(path: Path, node: ast.Call) -> list[str]:
-    keys_arg = None if not node.args else node.args[0]
-    return _metadata_key_sequence_violations(path, keys_arg)
+    violations: list[str] = []
+    for keys_arg in _static_call_argument_nodes(node.args, 0):
+        violations.extend(_metadata_key_sequence_violations(path, keys_arg))
+    return violations
+
+
+def _metadata_key_expression_violations(path: Path, node: ast.AST) -> list[str]:
+    if isinstance(node, ast.NamedExpr):
+        return _metadata_key_expression_violations(path, node.value)
+    if isinstance(node, ast.IfExp):
+        return [
+            *_metadata_key_expression_violations(path, node.body),
+            *_metadata_key_expression_violations(path, node.orelse),
+        ]
+    if isinstance(node, ast.BoolOp):
+        violations: list[str] = []
+        for value in node.values:
+            violations.extend(_metadata_key_expression_violations(path, value))
+        return violations
+    key_name = _registered_key_name(node)
+    if key_name is None:
+        return []
+    return [_violation(path, node, key_name)]
 
 
 def _metadata_keyword_violations(path: Path, keywords: list[ast.keyword]) -> list[str]:
@@ -1480,9 +1548,13 @@ def test_registered_flow_metadata_guard_flags_direct_literals(tmp_path):
     source_path.write_text(
         """
 flow.metadata["vm_run_id"] = "run-1"
+flow.metadata["vm_run_id" if condition else "firewall_name"] = "run-1"
 flow.metadata.get("firewall_action")
+flow.metadata.get("firewall_action" if condition else "firewall_error")
 "original_url" in flow.metadata
+("firewall_base" if condition else "firewall_permission") in flow.metadata
 flow.metadata.update({"firewall_base": "https://api.example.com"})
+flow.metadata.update({("auth_cache_hit" if condition else "auth_url_rewrite"): True})
 flow.metadata.update(firewall_permission="read")
 flow.metadata |= {"vm_network_log_path": "network.jsonl"}
 flow.metadata = dict(vm_proxy_log_path="proxy.jsonl")
@@ -1529,6 +1601,23 @@ flow.metadata.update([*sorted([("vm_network_log_path", "network.jsonl")])])
 flow.metadata.update([*[("vm_proxy_log_path", "proxy.jsonl")].copy()])
 flow.metadata.update(dict.fromkeys([*["firewall_error"]], "auth_failed"))
 flow.metadata.update(dict.fromkeys((*["auth_cache_hit"],), False))
+flow.metadata.update({"vm_run_id": value for value in rows})
+flow.metadata = {"firewall_name": value for value in rows}
+flow.metadata.update(*[{"vm_run_id": "run-1"}])
+flow.metadata.update(*[dict(firewall_name="github")])
+flow.metadata.update(*[[("firewall_action", "ALLOW")]])
+flow.metadata = dict(*[{"firewall_permission": "read"}])
+flow.metadata.get(*["firewall_base"])
+flow.metadata.update(dict.fromkeys(*[["firewall_error"], "auth_failed"]))
+flow.metadata.update(dict.fromkeys(*[["auth_cache_hit"]], False))
+flow.metadata.update((("firewall_action", value) for value in rows))
+flow.metadata.update([("firewall_permission", value) for value in rows])
+flow.metadata.update({("firewall_base", value) for value in rows})
+flow.metadata = dict((("auth_url_rewrite", value) for value in rows))
+flow.metadata.update(dict.fromkeys(("firewall_error" for value in rows), "auth_failed"))
+flow.metadata.update(dict.fromkeys(["auth_cache_hit" for value in rows], False))
+flow.metadata.update(dict.fromkeys({"network_log_target" for value in rows}, {}))
+flow.metadata.update(dict.fromkeys({"vm_network_log_path": value for value in rows}, "path"))
 flow.metadata.update(dict([("stream_buffer", bytearray())]))
 flow.metadata.update({**{"capture_body": True}})
 flow.metadata = {"request_stream_buffer": bytearray()} | {"request_stream_buffer_state": {}}
@@ -1828,7 +1917,7 @@ match flow.metadata:
 
     violations = _metadata_key_violations(source_path)
 
-    assert len(violations) == 186
+    assert len(violations) == 211
     assert all("use metadata_keys." in violation for violation in violations)
 
 
@@ -1842,6 +1931,14 @@ entry["firewall_name"] = "github"
 payload = {"vm_run_id": "run-1"}
 assert "connector_response_finish" in flow.metadata
 flow.metadata["_local_marker"] = "private"
+flow.metadata[metadata_keys.VM_RUN_ID if condition else metadata_keys.FIREWALL_NAME] = "run-1"
+flow.metadata.get(
+    metadata_keys.FIREWALL_ACTION if condition else metadata_keys.FIREWALL_ERROR
+)
+(metadata_keys.FIREWALL_BASE if condition else metadata_keys.FIREWALL_PERMISSION) in flow.metadata
+flow.metadata.update(
+    {(metadata_keys.AUTH_CACHE_HIT if condition else metadata_keys.AUTH_URL_REWRITE): True}
+)
 external_meta_value = flow.metadata
 payload = {"vm_run_id": "external", "metadata": external_meta_value}
 meta = flow.metadata
@@ -1901,6 +1998,25 @@ flow.metadata.update([*sorted([(metadata_keys.VM_NETWORK_LOG_PATH, "network.json
 flow.metadata.update([*[(metadata_keys.VM_PROXY_LOG_PATH, "proxy.jsonl")].copy()])
 flow.metadata.update(dict.fromkeys([*[metadata_keys.FIREWALL_ERROR]], "auth_failed"))
 flow.metadata.update(dict.fromkeys((*[metadata_keys.AUTH_CACHE_HIT],), False))
+flow.metadata.update({metadata_keys.VM_RUN_ID: value for value in rows})
+flow.metadata = {metadata_keys.FIREWALL_NAME: value for value in rows}
+flow.metadata.update(*[{metadata_keys.VM_RUN_ID: "run-1"}])
+flow.metadata.update(*[dict({metadata_keys.FIREWALL_NAME: "github"})])
+flow.metadata.update(*[[(metadata_keys.FIREWALL_ACTION, "ALLOW")]])
+flow.metadata = dict(*[{metadata_keys.FIREWALL_PERMISSION: "read"}])
+flow.metadata.get(*[metadata_keys.FIREWALL_BASE])
+flow.metadata.update(dict.fromkeys(*[[metadata_keys.FIREWALL_ERROR], "auth_failed"]))
+flow.metadata.update(dict.fromkeys(*[[metadata_keys.AUTH_CACHE_HIT]], False))
+flow.metadata.update(((metadata_keys.FIREWALL_ACTION, value) for value in rows))
+flow.metadata.update([(metadata_keys.FIREWALL_PERMISSION, value) for value in rows])
+flow.metadata.update({(metadata_keys.FIREWALL_BASE, value) for value in rows})
+flow.metadata = dict(((metadata_keys.AUTH_URL_REWRITE, value) for value in rows))
+flow.metadata.update(dict.fromkeys((metadata_keys.FIREWALL_ERROR for value in rows), "error"))
+flow.metadata.update(dict.fromkeys([metadata_keys.AUTH_CACHE_HIT for value in rows], False))
+flow.metadata.update(dict.fromkeys({metadata_keys.NETWORK_LOG_TARGET for value in rows}, {}))
+flow.metadata.update(
+    dict.fromkeys({metadata_keys.VM_NETWORK_LOG_PATH: value for value in rows}, "path")
+)
 external_conditional_meta = {"vm_run_id": "external"} if condition else {}
 value = external_conditional_meta["vm_run_id"]
 external_bool_meta = fallback_meta or {"vm_run_id": "external"}

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -56,6 +56,11 @@ def _static_string_value(node: ast.AST) -> str | None:
                 return None
             parts.append(value.value)
         return "".join(parts)
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        left = _static_string_value(node.left)
+        right = _static_string_value(node.right)
+        if left is not None and right is not None:
+            return left + right
     return None
 
 
@@ -1591,6 +1596,7 @@ def test_registered_flow_metadata_guard_flags_direct_literals(tmp_path):
         """
 flow.metadata["vm_run_id"] = "run-1"
 flow.metadata[f"vm_run_id"] = "run-1"
+flow.metadata["vm_" + "run_id"] = "run-1"
 flow.metadata["vm_run_id" if condition else "firewall_name"] = "run-1"
 flow.metadata.get("firewall_action")
 flow.metadata.get(f"firewall_action")
@@ -1970,7 +1976,7 @@ match flow.metadata:
 
     violations = _metadata_key_violations(source_path)
 
-    assert len(violations) == 222
+    assert len(violations) == 223
     assert all("use metadata_keys." in violation for violation in violations)
 
 
@@ -1985,6 +1991,7 @@ payload = {"vm_run_id": "run-1"}
 assert "connector_response_finish" in flow.metadata
 flow.metadata["_local_marker"] = "private"
 flow.metadata[f"vm_{dynamic_suffix}"] = "run-1"
+flow.metadata[metadata_keys.VM_RUN_ID + ""] = "run-1"
 flow.metadata[metadata_keys.VM_RUN_ID if condition else metadata_keys.FIREWALL_NAME] = "run-1"
 flow.metadata.get(
     metadata_keys.FIREWALL_ACTION if condition else metadata_keys.FIREWALL_ERROR

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -412,6 +412,8 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
             )
         if isinstance(node, ast.BoolOp):
             return any(self._is_metadata_alias_value(value) for value in node.values)
+        if isinstance(node, ast.Await):
+            return self._is_metadata_alias_value(node.value)
         return (
             isinstance(node, ast.Call)
             and isinstance(node.func, ast.Attribute)
@@ -1464,6 +1466,8 @@ message = f"{flow.metadata | {'network_log_target': {}}}"
 value = (flow.metadata | {"vm_network_log_path": "network.jsonl"}) + other
 async def await_metadata_merge():
     return await (flow.metadata | {"vm_proxy_log_path": "proxy.jsonl"})
+async def await_metadata_precedence_merge():
+    await flow.metadata | {"vm_run_id": "run-1"}
 value = not (flow.metadata | {"auth_cache_hit": False})
 value = other == (flow.metadata | {"firewall_name": "github"})
 value = (flow.metadata | {"firewall_api_id": "run-1:0"}).items
@@ -1567,7 +1571,7 @@ match match_payload:
 
     violations = _metadata_key_violations(source_path)
 
-    assert len(violations) == 139
+    assert len(violations) == 140
     assert all("use metadata_keys." in violation for violation in violations)
 
 

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -27,11 +27,22 @@ _METADATA_METHODS_WITH_KEY_ARGUMENTS = {
 }
 _METADATA_METHODS_WITH_DICT_ARGUMENTS = {"__ior__", "update"}
 _SEQUENCE_WRAPPER_CALLS = {"frozenset", "iter", "list", "reversed", "set", "sorted", "tuple"}
+_SUPPORTS_EXCEPT_STAR_SYNTAX = sys.version_info >= (3, 11)
 _SUPPORTS_PEP695_SYNTAX = sys.version_info >= (3, 12)
 
 
-def _write_python_source(path: Path, source: str, *, pep695_source: str = "") -> None:
-    path.write_text(source + (pep695_source if _SUPPORTS_PEP695_SYNTAX else ""))
+def _write_python_source(
+    path: Path,
+    source: str,
+    *,
+    python311_source: str = "",
+    python312_source: str = "",
+) -> None:
+    path.write_text(
+        source
+        + (python311_source if _SUPPORTS_EXCEPT_STAR_SYNTAX else "")
+        + (python312_source if _SUPPORTS_PEP695_SYNTAX else "")
+    )
 
 
 def _python_files() -> list[Path]:
@@ -1873,12 +1884,6 @@ try:
 except Exception as except_meta:
     pass
 except_meta["suppress_request_body_capture"] = True
-except_star_meta = flow.metadata
-try:
-    pass
-except* Exception as except_star_meta:
-    pass
-except_star_meta["firewall_error"] = "auth_failed"
 break_exit_meta = {}
 for item in rows:
     break_exit_meta = flow.metadata
@@ -1950,7 +1955,15 @@ match flow.metadata:
     case guarded_match_meta if guarded_match_meta["vm_run_id"]:
         pass
 """,
-        pep695_source="""
+        python311_source="""
+except_star_meta = flow.metadata
+try:
+    pass
+except* Exception as except_star_meta:
+    pass
+except_star_meta["firewall_error"] = "auth_failed"
+""",
+        python312_source="""
 def function_type_param_meta[T: flow.metadata["vm_run_id"]]():
     pass
 def function_type_param_merge_meta[T: flow.metadata | {"vm_run_id": "run-1"}]():
@@ -1985,7 +1998,11 @@ def function_type_param_global_reads_module[function_type_param_global_meta]():
 
     violations = _metadata_key_violations(source_path)
 
-    expected_violation_count = 223 if _SUPPORTS_PEP695_SYNTAX else 210
+    expected_violation_count = 209
+    if _SUPPORTS_EXCEPT_STAR_SYNTAX:
+        expected_violation_count += 1
+    if _SUPPORTS_PEP695_SYNTAX:
+        expected_violation_count += 13
     assert len(violations) == expected_violation_count
     assert all("use metadata_keys." in violation for violation in violations)
 
@@ -2293,7 +2310,7 @@ try:
 except Exception as meta:
     value = meta["vm_run_id"]
 """,
-        pep695_source="""
+        python312_source="""
 type_alias_shadow_meta = flow.metadata
 type type_alias_shadow_meta = int
 value = type_alias_shadow_meta["vm_run_id"]

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -25,7 +25,7 @@ _METADATA_METHODS_WITH_KEY_ARGUMENTS = {
     "setdefault",
 }
 _METADATA_METHODS_WITH_DICT_ARGUMENTS = {"__ior__", "update"}
-_PAIR_SEQUENCE_WRAPPER_CALLS = {"iter", "list", "tuple"}
+_SEQUENCE_WRAPPER_CALLS = {"frozenset", "iter", "list", "reversed", "set", "sorted", "tuple"}
 
 
 def _python_files() -> list[Path]:
@@ -1296,6 +1296,13 @@ def _metadata_dict_key_violations(path: Path, node: ast.AST | None) -> list[str]
             and not node.keywords
         ):
             return _metadata_dict_key_violations(path, node.func.value)
+        if (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr == "copy"
+            and not node.args
+            and not node.keywords
+        ):
+            return _metadata_dict_key_violations(path, node.func.value)
         if isinstance(node.func, ast.Name):
             if node.func.id == "dict":
                 dict_call_violations: list[str] = []
@@ -1303,7 +1310,7 @@ def _metadata_dict_key_violations(path: Path, node: ast.AST | None) -> list[str]
                 dict_call_violations.extend(_metadata_dict_key_violations(path, update_arg))
                 dict_call_violations.extend(_metadata_keyword_violations(path, node.keywords))
                 return dict_call_violations
-            if node.func.id in _PAIR_SEQUENCE_WRAPPER_CALLS:
+            if node.func.id in _SEQUENCE_WRAPPER_CALLS:
                 update_arg = None if not node.args else node.args[0]
                 return _metadata_dict_key_violations(path, update_arg)
     if not isinstance(node, ast.Dict):
@@ -1347,6 +1354,11 @@ def _metadata_key_sequence_violations(path: Path, node: ast.AST | None) -> list[
         for value in node.values:
             sequence_violations.extend(_metadata_key_sequence_violations(path, value))
         return sequence_violations
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+        return [
+            *_metadata_key_sequence_violations(path, node.left),
+            *_metadata_key_sequence_violations(path, node.right),
+        ]
     if isinstance(node, ast.Dict):
         dict_key_violations: list[str] = []
         for key, value in zip(node.keys, node.values, strict=True):
@@ -1365,10 +1377,18 @@ def _metadata_key_sequence_violations(path: Path, node: ast.AST | None) -> list[
         and not node.keywords
     ):
         return _metadata_key_sequence_violations(path, node.func.value)
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "copy"
+        and not node.args
+        and not node.keywords
+    ):
+        return _metadata_key_sequence_violations(path, node.func.value)
     if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
         if node.func.id == "dict":
             return _metadata_dict_key_violations(path, node)
-        if node.func.id in _PAIR_SEQUENCE_WRAPPER_CALLS:
+        if node.func.id in _SEQUENCE_WRAPPER_CALLS:
             keys_arg = None if not node.args else node.args[0]
             return _metadata_key_sequence_violations(path, keys_arg)
     if not isinstance(node, ast.List | ast.Tuple | ast.Set):
@@ -1422,8 +1442,14 @@ flow.metadata.update(flow.metadata | {"auth_cache_hit": False})
 flow.metadata.update({"firewall_params": {}}.items())
 flow.metadata.update({("firewall_billable", True)})
 flow.metadata.update(tuple([("trusted_authority_host", "api.example.com")]))
+flow.metadata.update(set([("firewall_permission", "read")]))
+flow.metadata.update(frozenset([("connector_diagnostic_type", "github")]))
+flow.metadata.update(sorted([("connector_diagnostic_reason", "missing")]))
+flow.metadata.update(reversed([("connector_diagnostic_base", "https://api.example.com")]))
 flow.metadata = {**({"vm_run_id": "run-1"} if condition else {})}
 flow.metadata = dict({"auth_url_rewrite": True}.items())
+flow.metadata = {"vm_run_id": "run-1"}.copy()
+flow.metadata.update([("firewall_name", "github")].copy())
 flow.metadata = dict.fromkeys(["auth_refreshed_connectors"], [])
 flow.metadata.update(dict.fromkeys(("auth_refreshed_secrets",), []))
 flow.metadata.update(dict.fromkeys({"auth_resolved_secrets": []}, []))
@@ -1431,6 +1457,13 @@ flow.metadata.update(dict.fromkeys({"model_usage_provider": "gpt-5.5"}.keys(), "
 flow.metadata.update(dict.fromkeys(dict(vm_run_id="run-1"), "run-1"))
 flow.metadata.update(dict.fromkeys(dict([("firewall_action", "ALLOW")]).keys(), "ALLOW"))
 flow.metadata.update(dict.fromkeys(tuple(dict(firewall_billable=True)), False))
+flow.metadata.update(dict.fromkeys(set(["auth_cache_hit"]), False))
+flow.metadata.update(dict.fromkeys(frozenset(["connector_diagnostic_env_names"]), []))
+flow.metadata.update(dict.fromkeys(sorted(["auth_refreshed_connectors"]), []))
+flow.metadata.update(dict.fromkeys(reversed(["auth_refreshed_secrets"]), []))
+flow.metadata.update(dict.fromkeys({"firewall_base": "https://api.example.com"} | {}, "base"))
+flow.metadata.update(dict.fromkeys(({"firewall_action": "ALLOW"} | {}).keys(), "ALLOW"))
+flow.metadata.update(dict.fromkeys({"firewall_error": "auth_failed"}.copy(), "auth_failed"))
 flow.metadata.update(dict([("stream_buffer", bytearray())]))
 flow.metadata.update({**{"capture_body": True}})
 flow.metadata = {"request_stream_buffer": bytearray()} | {"request_stream_buffer_state": {}}
@@ -1730,7 +1763,7 @@ match flow.metadata:
 
     violations = _metadata_key_violations(source_path)
 
-    assert len(violations) == 162
+    assert len(violations) == 175
     assert all("use metadata_keys." in violation for violation in violations)
 
 
@@ -1775,6 +1808,23 @@ flow.metadata.update(dict.fromkeys({metadata_keys.VM_RUN_ID: "run-1"}, "run-1"))
 flow.metadata.update(dict.fromkeys(dict({metadata_keys.VM_RUN_ID: "run-1"}), "run-1"))
 flow.metadata.update(dict.fromkeys(dict({metadata_keys.FIREWALL_ACTION: "ALLOW"}).keys(), "ALLOW"))
 flow.metadata.update(dict.fromkeys(tuple(dict({metadata_keys.FIREWALL_BILLABLE: True})), False))
+flow.metadata.update(set([(metadata_keys.FIREWALL_PERMISSION, "read")]))
+flow.metadata.update(frozenset([(metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE, "github")]))
+flow.metadata.update(sorted([(metadata_keys.CONNECTOR_DIAGNOSTIC_REASON, "missing")]))
+flow.metadata.update(reversed([(metadata_keys.CONNECTOR_DIAGNOSTIC_BASE, "https://api.example.com")]))
+flow.metadata.update({metadata_keys.VM_RUN_ID: "run-1"}.copy())
+flow.metadata.update([(metadata_keys.FIREWALL_NAME, "github")].copy())
+flow.metadata.update(dict.fromkeys(set([metadata_keys.AUTH_CACHE_HIT]), False))
+flow.metadata.update(dict.fromkeys(frozenset([metadata_keys.CONNECTOR_DIAGNOSTIC_ENV_NAMES]), []))
+flow.metadata.update(dict.fromkeys(sorted([metadata_keys.AUTH_REFRESHED_CONNECTORS]), []))
+flow.metadata.update(dict.fromkeys(reversed([metadata_keys.AUTH_REFRESHED_SECRETS]), []))
+flow.metadata.update(
+    dict.fromkeys({metadata_keys.FIREWALL_BASE: "https://api.example.com"} | {}, "base")
+)
+flow.metadata.update(dict.fromkeys(({metadata_keys.FIREWALL_ACTION: "ALLOW"} | {}).keys(), "ALLOW"))
+flow.metadata.update(
+    dict.fromkeys({metadata_keys.FIREWALL_ERROR: "auth_failed"}.copy(), "auth_failed")
+)
 external_conditional_meta = {"vm_run_id": "external"} if condition else {}
 value = external_conditional_meta["vm_run_id"]
 external_bool_meta = fallback_meta or {"vm_run_id": "external"}

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -40,9 +40,23 @@ def _is_metadata_attribute(node: ast.AST) -> bool:
 
 
 def _registered_key_name(node: ast.AST) -> str | None:
-    if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
+    value = _static_string_value(node)
+    if value is None:
         return None
-    return _REGISTERED_METADATA_KEYS.get(node.value)
+    return _REGISTERED_METADATA_KEYS.get(value)
+
+
+def _static_string_value(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.JoinedStr):
+        parts: list[str] = []
+        for value in node.values:
+            if not isinstance(value, ast.Constant) or not isinstance(value.value, str):
+                return None
+            parts.append(value.value)
+        return "".join(parts)
+    return None
 
 
 def _violation(path: Path, node: ast.AST, key_name: str) -> str:
@@ -1576,12 +1590,16 @@ def test_registered_flow_metadata_guard_flags_direct_literals(tmp_path):
     source_path.write_text(
         """
 flow.metadata["vm_run_id"] = "run-1"
+flow.metadata[f"vm_run_id"] = "run-1"
 flow.metadata["vm_run_id" if condition else "firewall_name"] = "run-1"
 flow.metadata.get("firewall_action")
+flow.metadata.get(f"firewall_action")
 flow.metadata.get("firewall_action" if condition else "firewall_error")
 "original_url" in flow.metadata
+f"firewall_name" in flow.metadata
 ("firewall_base" if condition else "firewall_permission") in flow.metadata
 flow.metadata.update({"firewall_base": "https://api.example.com"})
+flow.metadata.update({f"firewall_base": "https://api.example.com"})
 flow.metadata.update({("auth_cache_hit" if condition else "auth_url_rewrite"): True})
 flow.metadata.update(firewall_permission="read")
 flow.metadata |= {"vm_network_log_path": "network.jsonl"}
@@ -1628,7 +1646,9 @@ flow.metadata.update([*zip(["network_log_target"], [{}])])
 flow.metadata.update([*sorted([("vm_network_log_path", "network.jsonl")])])
 flow.metadata.update([*[("vm_proxy_log_path", "proxy.jsonl")].copy()])
 flow.metadata.update(dict.fromkeys([*["firewall_error"]], "auth_failed"))
+flow.metadata.update(dict.fromkeys([f"firewall_error"], "auth_failed"))
 flow.metadata.update(dict.fromkeys((*["auth_cache_hit"],), False))
+flow.metadata.update([(f"firewall_permission", "read")])
 flow.metadata.update({"vm_run_id": value for value in rows})
 flow.metadata = {"firewall_name": value for value in rows}
 flow.metadata.update(*[{"vm_run_id": "run-1"}])
@@ -1950,7 +1970,7 @@ match flow.metadata:
 
     violations = _metadata_key_violations(source_path)
 
-    assert len(violations) == 216
+    assert len(violations) == 222
     assert all("use metadata_keys." in violation for violation in violations)
 
 
@@ -1964,6 +1984,7 @@ entry["firewall_name"] = "github"
 payload = {"vm_run_id": "run-1"}
 assert "connector_response_finish" in flow.metadata
 flow.metadata["_local_marker"] = "private"
+flow.metadata[f"vm_{dynamic_suffix}"] = "run-1"
 flow.metadata[metadata_keys.VM_RUN_ID if condition else metadata_keys.FIREWALL_NAME] = "run-1"
 flow.metadata.get(
     metadata_keys.FIREWALL_ACTION if condition else metadata_keys.FIREWALL_ERROR

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -202,7 +202,7 @@ def test_registered_flow_metadata_guard_ignores_external_schema_and_private_mark
 entry["firewall_name"] = "github"
 payload = {"vm_run_id": "run-1"}
 assert "connector_response_finish" in flow.metadata
-flow.metadata["firewall_rule"] = "domain:*.example.com"
+flow.metadata["_local_marker"] = "private"
 """
     )
 

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -167,12 +167,14 @@ flow.metadata = dict(vm_proxy_log_path="proxy.jsonl")
 flow.metadata.update(dict([("stream_buffer", bytearray())]))
 flow.metadata.update({**{"capture_body": True}})
 flow.metadata = {"request_stream_buffer": bytearray()} | {"request_stream_buffer_state": {}}
+flow.metadata.update(**{"trusted_authority_host": "api.example.com"})
+flow.metadata.update([("http_request_start_monotonic", 1.0)])
 """
     )
 
     violations = _metadata_key_violations(source_path)
 
-    assert len(violations) == 11
+    assert len(violations) == 13
     assert all("use metadata_keys." in violation for violation in violations)
 
 

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -2,6 +2,7 @@
 
 import ast
 from pathlib import Path
+from typing import TypeGuard
 
 import flow_metadata_keys as metadata_keys
 
@@ -100,6 +101,36 @@ def _pattern_names(pattern: ast.pattern) -> set[str]:
     return set()
 
 
+def _body_can_fall_through(body: list[ast.stmt]) -> bool:
+    return all(_statement_can_fall_through(statement) for statement in body)
+
+
+def _is_try_statement(statement: ast.stmt) -> TypeGuard[ast.Try]:
+    return isinstance(statement, ast.Try) or statement.__class__.__name__ == "TryStar"
+
+
+def _statement_can_fall_through(statement: ast.stmt) -> bool:
+    if isinstance(statement, (ast.Return, ast.Raise)):
+        return False
+    if isinstance(statement, ast.If):
+        if not statement.orelse:
+            return True
+        return _body_can_fall_through(statement.body) or _body_can_fall_through(statement.orelse)
+    if isinstance(statement, (ast.With, ast.AsyncWith)):
+        return _body_can_fall_through(statement.body)
+    if _is_try_statement(statement):
+        if statement.finalbody and not _body_can_fall_through(statement.finalbody):
+            return False
+        normal_path_falls_through = _body_can_fall_through(statement.body)
+        if normal_path_falls_through and statement.orelse:
+            normal_path_falls_through = _body_can_fall_through(statement.orelse)
+        handler_path_falls_through = any(
+            _body_can_fall_through(handler.body) for handler in statement.handlers
+        )
+        return normal_path_falls_through or handler_path_falls_through
+    return True
+
+
 class _MetadataKeyVisitor(ast.NodeVisitor):
     def __init__(self, path: Path) -> None:
         self.path = path
@@ -174,27 +205,40 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self._metadata_aliases.clear()
         self._metadata_aliases.update(aliases)
 
-    def _visit_branch_body(self, body: list[ast.stmt], aliases: set[str]) -> set[str]:
-        self._metadata_alias_scopes.append(set(aliases))
+    def _visit_current_scope_body(self, body: list[ast.stmt]) -> bool:
         for statement in body:
             self.visit(statement)
+            if not _statement_can_fall_through(statement):
+                return False
+        return True
+
+    def _visit_branch_body(self, body: list[ast.stmt], aliases: set[str]) -> tuple[set[str], bool]:
+        self._metadata_alias_scopes.append(set(aliases))
+        falls_through = self._visit_current_scope_body(body)
         result = set(self._metadata_aliases)
         self._metadata_alias_scopes.pop()
+        return result, falls_through
+
+    def _visit_branch_body_state_only(
+        self, body: list[ast.stmt], aliases: set[str]
+    ) -> tuple[set[str], bool]:
+        violation_count = len(self.violations)
+        result = self._visit_branch_body(body, aliases)
+        del self.violations[violation_count:]
         return result
 
     def _visit_except_handler_branch(
         self, handler: ast.ExceptHandler, aliases: set[str]
-    ) -> set[str]:
+    ) -> tuple[set[str], bool]:
         self._metadata_alias_scopes.append(set(aliases))
         if handler.type is not None:
             self.visit(handler.type)
         if handler.name is not None:
             self._metadata_aliases.discard(handler.name)
-        for statement in handler.body:
-            self.visit(statement)
+        falls_through = self._visit_current_scope_body(handler.body)
         result = set(self._metadata_aliases)
         self._metadata_alias_scopes.pop()
-        return result
+        return result, falls_through
 
     def _visit_scoped_body(
         self,
@@ -210,8 +254,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self._metadata_alias_scopes.append(aliases)
         previous_named_expr_target_scope_indexes = self._named_expr_target_scope_indexes
         self._named_expr_target_scope_indexes = []
-        for statement in body:
-            self.visit(statement)
+        self._visit_current_scope_body(body)
         self._named_expr_target_scope_indexes = previous_named_expr_target_scope_indexes
         self._metadata_alias_scopes.pop()
 
@@ -369,20 +412,31 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
     def visit_If(self, node: ast.If) -> None:
         self.visit(node.test)
         base_aliases = set(self._metadata_aliases)
-        body_aliases = self._visit_branch_body(node.body, base_aliases)
-        orelse_aliases = (
-            self._visit_branch_body(node.orelse, base_aliases) if node.orelse else base_aliases
-        )
-        self._replace_current_aliases(body_aliases | orelse_aliases)
+        body_aliases, body_falls_through = self._visit_branch_body(node.body, base_aliases)
+        if node.orelse:
+            orelse_aliases, orelse_falls_through = self._visit_branch_body(
+                node.orelse, base_aliases
+            )
+        else:
+            orelse_aliases = base_aliases
+            orelse_falls_through = True
+        exit_aliases: set[str] = set()
+        if body_falls_through:
+            exit_aliases.update(body_aliases)
+        if orelse_falls_through:
+            exit_aliases.update(orelse_aliases)
+        self._replace_current_aliases(exit_aliases)
 
     def visit_For(self, node: ast.For) -> None:
         self.visit(node.iter)
         base_aliases = set(self._metadata_aliases)
         self._discard_alias_target(node.target)
-        body_aliases = self._visit_branch_body(node.body, set(self._metadata_aliases))
+        body_aliases, _body_falls_through = self._visit_branch_body(
+            node.body, set(self._metadata_aliases)
+        )
         loop_exit_aliases = base_aliases | body_aliases
         orelse_aliases = (
-            self._visit_branch_body(node.orelse, loop_exit_aliases)
+            self._visit_branch_body(node.orelse, loop_exit_aliases)[0]
             if node.orelse
             else loop_exit_aliases
         )
@@ -392,10 +446,12 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self.visit(node.iter)
         base_aliases = set(self._metadata_aliases)
         self._discard_alias_target(node.target)
-        body_aliases = self._visit_branch_body(node.body, set(self._metadata_aliases))
+        body_aliases, _body_falls_through = self._visit_branch_body(
+            node.body, set(self._metadata_aliases)
+        )
         loop_exit_aliases = base_aliases | body_aliases
         orelse_aliases = (
-            self._visit_branch_body(node.orelse, loop_exit_aliases)
+            self._visit_branch_body(node.orelse, loop_exit_aliases)[0]
             if node.orelse
             else loop_exit_aliases
         )
@@ -404,10 +460,10 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
     def visit_While(self, node: ast.While) -> None:
         self.visit(node.test)
         base_aliases = set(self._metadata_aliases)
-        body_aliases = self._visit_branch_body(node.body, base_aliases)
+        body_aliases, _body_falls_through = self._visit_branch_body(node.body, base_aliases)
         loop_exit_aliases = base_aliases | body_aliases
         orelse_aliases = (
-            self._visit_branch_body(node.orelse, loop_exit_aliases)
+            self._visit_branch_body(node.orelse, loop_exit_aliases)[0]
             if node.orelse
             else loop_exit_aliases
         )
@@ -421,8 +477,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self._metadata_alias_scopes.append(body_aliases)
         for item in node.items:
             self._discard_alias_target(item.optional_vars)
-        for statement in node.body:
-            self.visit(statement)
+        self._visit_current_scope_body(node.body)
         body_result_aliases = set(self._metadata_aliases)
         self._metadata_alias_scopes.pop()
         self._replace_current_aliases(base_aliases | body_result_aliases)
@@ -435,8 +490,7 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self._metadata_alias_scopes.append(body_aliases)
         for item in node.items:
             self._discard_alias_target(item.optional_vars)
-        for statement in node.body:
-            self.visit(statement)
+        self._visit_current_scope_body(node.body)
         body_result_aliases = set(self._metadata_aliases)
         self._metadata_alias_scopes.pop()
         self._replace_current_aliases(base_aliases | body_result_aliases)
@@ -448,28 +502,49 @@ class _MetadataKeyVisitor(ast.NodeVisitor):
         self._metadata_alias_scopes.append(base_aliases)
         if node.name is not None:
             self._metadata_aliases.discard(node.name)
-        for statement in node.body:
-            self.visit(statement)
+        self._visit_current_scope_body(node.body)
         result_aliases = set(self._metadata_aliases)
         self._metadata_alias_scopes.pop()
         self._replace_current_aliases(base_aliases | result_aliases)
 
     def _visit_try_statement(self, node: ast.Try) -> None:
         base_aliases = set(self._metadata_aliases)
-        body_aliases = self._visit_branch_body(node.body, base_aliases)
+        body_aliases, body_falls_through = self._visit_branch_body(node.body, base_aliases)
         handler_start_aliases = base_aliases | body_aliases
-        handler_aliases = [
+        handler_results = [
             self._visit_except_handler_branch(handler, handler_start_aliases)
             for handler in node.handlers
         ]
-        orelse_aliases = (
-            self._visit_branch_body(node.orelse, body_aliases) if node.orelse else body_aliases
-        )
-        exit_aliases = base_aliases | body_aliases | orelse_aliases
-        for aliases in handler_aliases:
-            exit_aliases.update(aliases)
+        exit_aliases: set[str] = set()
+        if body_falls_through:
+            if node.orelse:
+                orelse_aliases, orelse_falls_through = self._visit_branch_body(
+                    node.orelse, body_aliases
+                )
+                if orelse_falls_through:
+                    exit_aliases.update(orelse_aliases)
+            else:
+                exit_aliases.update(body_aliases)
+        for aliases, falls_through in handler_results:
+            if falls_through:
+                exit_aliases.update(aliases)
         if node.finalbody:
-            exit_aliases = self._visit_branch_body(node.finalbody, exit_aliases)
+            finalbody_scan_aliases = base_aliases | body_aliases
+            for aliases, _falls_through in handler_results:
+                finalbody_scan_aliases.update(aliases)
+            if finalbody_scan_aliases == exit_aliases:
+                exit_aliases, finalbody_falls_through = self._visit_branch_body(
+                    node.finalbody, exit_aliases
+                )
+            else:
+                self._visit_branch_body(node.finalbody, finalbody_scan_aliases)
+                exit_aliases, finalbody_falls_through = (
+                    self._visit_branch_body_state_only(node.finalbody, exit_aliases)
+                    if exit_aliases
+                    else (set(), True)
+                )
+            if not finalbody_falls_through:
+                exit_aliases = set()
         self._replace_current_aliases(exit_aliases)
 
     def visit_Try(self, node: ast.Try) -> None:
@@ -720,6 +795,12 @@ try:
 except* Exception as except_star_meta:
     pass
 except_star_meta["firewall_error"] = "auth_failed"
+def finalbody_alias_after_return():
+    finalbody_meta = flow.metadata
+    try:
+        return None
+    finally:
+        finalbody_meta["vm_run_id"] = "run-1"
 with_meta = flow.metadata
 with context() as with_meta:
     pass
@@ -751,7 +832,7 @@ match payload:
 
     violations = _metadata_key_violations(source_path)
 
-    assert len(violations) == 53
+    assert len(violations) == 54
     assert all("use metadata_keys." in violation for violation in violations)
 
 
@@ -778,6 +859,35 @@ value = both_branch_meta["vm_run_id"]
 external_aug_meta = {}
 external_aug_meta |= {"vm_run_id": "external"}
 value = external_aug_meta["vm_run_id"]
+def terminal_if_rebinds_to_external(condition):
+    terminal_if_meta = flow.metadata
+    if condition:
+        return None
+    else:
+        terminal_if_meta = {}
+    return terminal_if_meta["vm_run_id"]
+def terminal_raise_rebinds_to_external(condition):
+    terminal_raise_meta = flow.metadata
+    if condition:
+        raise RuntimeError
+    else:
+        terminal_raise_meta = {}
+    return terminal_raise_meta["vm_run_id"]
+def terminal_try_handler_rebinds_to_external():
+    terminal_try_meta = flow.metadata
+    try:
+        return None
+    except Exception:
+        terminal_try_meta = {}
+    return terminal_try_meta["vm_run_id"]
+def partial_return_finalbody_rebinds_to_external(condition):
+    partial_finalbody_meta = flow.metadata
+    try:
+        if condition:
+            return None
+    finally:
+        partial_finalbody_meta = {}
+    return partial_finalbody_meta["vm_run_id"]
 def accepts_external_metadata(meta):
     return meta["vm_proxy_log_path"]
 for meta in [{"firewall_name": "external"}]:

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -1,0 +1,97 @@
+"""Tests for the shared flow metadata key registry contract."""
+
+import ast
+from pathlib import Path
+
+import flow_metadata_keys as metadata_keys
+
+_ADDON_ROOT = Path(__file__).resolve().parents[1]
+_SRC_ROOT = _ADDON_ROOT / "src"
+_TESTS_ROOT = _ADDON_ROOT / "tests"
+_METADATA_KEYS_FILE = _SRC_ROOT / "flow_metadata_keys.py"
+_REGISTERED_METADATA_KEYS = {
+    value: name
+    for name, value in vars(metadata_keys).items()
+    if name.isupper() and isinstance(value, str)
+}
+_METADATA_METHODS_WITH_KEY_ARGUMENTS = {"get", "pop", "setdefault"}
+
+
+def _python_files() -> list[Path]:
+    files: list[Path] = []
+    for root in (_SRC_ROOT, _TESTS_ROOT):
+        files.extend(path for path in root.rglob("*.py") if path != _METADATA_KEYS_FILE)
+    return sorted(files)
+
+
+def _is_metadata_attribute(node: ast.AST) -> bool:
+    return isinstance(node, ast.Attribute) and node.attr == "metadata"
+
+
+def _registered_key_name(node: ast.AST) -> str | None:
+    if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
+        return None
+    return _REGISTERED_METADATA_KEYS.get(node.value)
+
+
+def _violation(path: Path, node: ast.AST, key_name: str) -> str:
+    location = path.relative_to(_ADDON_ROOT)
+    return f"{location}:{node.lineno}: use metadata_keys.{key_name} for flow.metadata access"
+
+
+def _metadata_key_violations(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(), filename=str(path))
+    violations: list[str] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Subscript) and _is_metadata_attribute(node.value):
+            key_name = _registered_key_name(node.slice)
+            if key_name is not None:
+                violations.append(_violation(path, node, key_name))
+
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and _is_metadata_attribute(node.func.value)
+        ):
+            if node.func.attr in _METADATA_METHODS_WITH_KEY_ARGUMENTS and node.args:
+                key_name = _registered_key_name(node.args[0])
+                if key_name is not None:
+                    violations.append(_violation(path, node, key_name))
+            if node.func.attr == "update":
+                violations.extend(_metadata_update_violations(path, node))
+
+        if isinstance(node, ast.Compare) and len(node.comparators) == 1:
+            if not isinstance(node.ops[0], (ast.In, ast.NotIn)):
+                continue
+            if not _is_metadata_attribute(node.comparators[0]):
+                continue
+            key_name = _registered_key_name(node.left)
+            if key_name is not None:
+                violations.append(_violation(path, node, key_name))
+
+    return violations
+
+
+def _metadata_update_violations(path: Path, node: ast.Call) -> list[str]:
+    if not node.args:
+        return []
+    update_arg = node.args[0]
+    if not isinstance(update_arg, ast.Dict):
+        return []
+    violations: list[str] = []
+    for key in update_arg.keys:
+        if key is None:
+            continue
+        key_name = _registered_key_name(key)
+        if key_name is not None:
+            violations.append(_violation(path, key, key_name))
+    return violations
+
+
+def test_registered_flow_metadata_keys_use_registry_constants():
+    violations = [
+        violation for path in _python_files() for violation in _metadata_key_violations(path)
+    ]
+
+    assert violations == []

--- a/crates/runner/mitm-addon/tests/test_model_provider_response_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_response_usage.py
@@ -922,8 +922,8 @@ class TestModelProviderResponseUsage:
 
         assert "model_json_usage_finish" not in flow.metadata
         assert metadata_keys.MODEL_PROVIDER_USAGE not in flow.metadata
-        assert len(flow.metadata["stream_buffer"]) == STREAM_BUFFER_LIMIT
-        assert flow.metadata["stream_buffer_state"]["truncated"] is True
+        assert len(flow.metadata[metadata_keys.STREAM_BUFFER]) == STREAM_BUFFER_LIMIT
+        assert flow.metadata[metadata_keys.STREAM_BUFFER_STATE]["truncated"] is True
 
     def test_non_observable_json_fallback_parse_error_stays_quiet(self, tmp_path, real_flow):
         """Model-provider fallback without MODEL_USAGE_PROVIDER must not emit warnings."""
@@ -968,8 +968,8 @@ class TestModelProviderResponseUsage:
         callback(b'{"id":"msg_1","model":"claude-sonnet-4-6","content":[{"text":"')
         callback(b"x" * (STREAM_BUFFER_LIMIT + 4096))
         callback(b'"}],"usage":{"input_tokens":50,"output_tokens":200}}')
-        assert len(flow.metadata["stream_buffer"]) == STREAM_BUFFER_LIMIT
-        assert flow.metadata["stream_buffer_state"]["truncated"] is True
+        assert len(flow.metadata[metadata_keys.STREAM_BUFFER]) == STREAM_BUFFER_LIMIT
+        assert flow.metadata[metadata_keys.STREAM_BUFFER_STATE]["truncated"] is True
 
         webhook = self._run_response(flow)
 
@@ -1241,7 +1241,7 @@ class TestModelProviderResponseUsage:
 
         assert webhook.request_count == 0
         assert metadata_keys.MODEL_PROVIDER_USAGE not in flow.metadata
-        assert "stream_buffer" not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
 
     def test_full_pipeline_model_json_ignores_usage_array_shape(self, tmp_path, real_flow):
         """usage fields inside array elements must not be treated as usage object fields."""

--- a/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
@@ -52,9 +52,9 @@ async def test_rejects_spoofed_host_before_firewall_auth(
     assert flow.response.status_code == 403
     body = json.loads(flow.response.content)
     assert body["error"] == "authority_mismatch"
-    assert flow.metadata["firewall_action"] == "DENY"
-    assert flow.metadata["firewall_error"] == "authority_mismatch"
-    assert flow.metadata["original_url"] == expected_original_url
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "DENY"
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "authority_mismatch"
+    assert flow.metadata[metadata_keys.ORIGINAL_URL] == expected_original_url
     assert flow.metadata[metadata_keys.NETWORK_LOG_TARGET] == {
         "url": expected_original_url,
         "host": "attacker.example.com",
@@ -88,7 +88,7 @@ async def test_authority_validation_deny_response_logs_network_target(
     assert flow.response is not None
     assert flow.response.status_code == 403
     auth_fetch.assert_not_called()
-    assert flow.metadata["original_url"] == raw_url
+    assert flow.metadata[metadata_keys.ORIGINAL_URL] == raw_url
     assert flow.metadata[metadata_keys.NETWORK_LOG_TARGET]["url"] == raw_url
 
     with mitm_ctx():
@@ -161,11 +161,11 @@ async def test_matching_sni_and_host_allows_firewall_auth(
         await mitm_addon.request(flow)
 
     assert flow.response is None
-    assert flow.metadata["firewall_base"] == "https://api.github.com"
-    assert flow.metadata["firewall_name"] == "github"
-    assert flow.metadata["firewall_permission"] == "full-access"
+    assert flow.metadata[metadata_keys.FIREWALL_BASE] == "https://api.github.com"
+    assert flow.metadata[metadata_keys.FIREWALL_NAME] == "github"
+    assert flow.metadata[metadata_keys.FIREWALL_PERMISSION] == "full-access"
     assert flow.request.headers["Authorization"] == "Bearer x"
-    assert flow.metadata["original_url"] == "https://api.github.com/repos"
+    assert flow.metadata[metadata_keys.ORIGINAL_URL] == "https://api.github.com/repos"
     assert flow.metadata[metadata_keys.NETWORK_LOG_TARGET] == {
         "url": "https://api.github.com/repos",
         "host": "api.github.com",
@@ -196,8 +196,8 @@ async def test_pseudo_authority_without_host_allows_firewall_auth(
         await mitm_addon.request(flow)
 
     assert flow.response is None
-    assert flow.metadata["firewall_base"] == "https://api.github.com"
-    assert flow.metadata["original_url"] == "https://api.github.com/repos"
+    assert flow.metadata[metadata_keys.FIREWALL_BASE] == "https://api.github.com"
+    assert flow.metadata[metadata_keys.ORIGINAL_URL] == "https://api.github.com/repos"
     assert flow.request.headers["Authorization"] == "Bearer x"
 
 
@@ -229,9 +229,9 @@ async def test_pseudo_authority_takes_precedence_over_host_header(
     assert body["error"] == "authority_mismatch"
     assert body["sni"] == "api.github.com"
     assert body["host_header"] == "attacker.example.com"
-    assert flow.metadata["firewall_action"] == "DENY"
-    assert flow.metadata["firewall_error"] == "authority_mismatch"
-    assert flow.metadata["original_url"] == "https://api.github.com/repos"
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "DENY"
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "authority_mismatch"
+    assert flow.metadata[metadata_keys.ORIGINAL_URL] == "https://api.github.com/repos"
     auth_fetch.assert_not_called()
     assert "Authorization" not in flow.request.headers
 
@@ -254,7 +254,7 @@ async def test_rejects_spoofed_host_before_vm0_api_auto_allow(
     assert flow.response.status_code == 403
     body = json.loads(flow.response.content)
     assert body["error"] == "authority_mismatch"
-    assert flow.metadata["firewall_action"] == "DENY"
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "DENY"
 
 
 async def test_rejects_duplicate_host_authority_before_firewall_auth(
@@ -285,9 +285,9 @@ async def test_rejects_duplicate_host_authority_before_firewall_auth(
     assert body["error"] == "invalid_authority"
     assert body["sni"] == "api.github.com"
     assert body["host_header"] == "api.github.com, attacker.example.com"
-    assert flow.metadata["firewall_action"] == "DENY"
-    assert flow.metadata["firewall_error"] == "invalid_authority"
-    assert flow.metadata["original_url"] == "https://api.github.com/repos"
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "DENY"
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "invalid_authority"
+    assert flow.metadata[metadata_keys.ORIGINAL_URL] == "https://api.github.com/repos"
     auth_fetch.assert_not_called()
     assert "Authorization" not in flow.request.headers
 
@@ -313,7 +313,7 @@ async def test_accepts_equivalent_host_authority_default_https_port(
         await mitm_addon.request(flow)
 
     assert flow.response is None
-    assert flow.metadata["firewall_base"] == "https://api.github.com"
+    assert flow.metadata[metadata_keys.FIREWALL_BASE] == "https://api.github.com"
     assert flow.request.headers["Authorization"] == "Bearer x"
 
 
@@ -351,9 +351,9 @@ async def test_rejects_noncanonical_ipv4_host_authority_before_firewall_auth(
     assert body["error"] == "invalid_authority"
     assert body["sni"] == "127.0.0.1"
     assert body["host_header"] == host_header
-    assert flow.metadata["firewall_action"] == "DENY"
-    assert flow.metadata["firewall_error"] == "invalid_authority"
-    assert flow.metadata["original_url"] == "https://127.0.0.1/repos"
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "DENY"
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "invalid_authority"
+    assert flow.metadata[metadata_keys.ORIGINAL_URL] == "https://127.0.0.1/repos"
     auth_fetch.assert_not_called()
     assert "Authorization" not in flow.request.headers
 
@@ -388,8 +388,8 @@ async def test_accepts_matching_non_default_host_authority_port(
         await mitm_addon.request(flow)
 
     assert flow.response is None
-    assert flow.metadata["firewall_base"] == "https://api.github.com:8443"
-    assert flow.metadata["original_url"] == "https://api.github.com:8443/repos"
+    assert flow.metadata[metadata_keys.FIREWALL_BASE] == "https://api.github.com:8443"
+    assert flow.metadata[metadata_keys.ORIGINAL_URL] == "https://api.github.com:8443/repos"
     assert flow.request.headers["Authorization"] == "Bearer x"
 
 
@@ -418,8 +418,8 @@ async def test_accepts_matching_ipv6_host_authority(
         await mitm_addon.request(flow)
 
     assert flow.response is None
-    assert flow.metadata["firewall_base"] == "https://[2001:db8::1]:8443"
-    assert flow.metadata["original_url"] == "https://[2001:db8::1]:8443/repos"
+    assert flow.metadata[metadata_keys.FIREWALL_BASE] == "https://[2001:db8::1]:8443"
+    assert flow.metadata[metadata_keys.ORIGINAL_URL] == "https://[2001:db8::1]:8443/repos"
     assert flow.request.headers["Authorization"] == "Bearer x"
 
 
@@ -447,8 +447,8 @@ async def test_accepts_canonical_ipv6_host_authority(
         await mitm_addon.request(flow)
 
     assert flow.response is None
-    assert flow.metadata["firewall_base"] == "https://[2001:db8::1]:8443"
-    assert flow.metadata["original_url"] == "https://[2001:db8::1]:8443/repos"
+    assert flow.metadata[metadata_keys.FIREWALL_BASE] == "https://[2001:db8::1]:8443"
+    assert flow.metadata[metadata_keys.ORIGINAL_URL] == "https://[2001:db8::1]:8443/repos"
     assert flow.request.headers["Authorization"] == "Bearer x"
 
 
@@ -483,9 +483,9 @@ async def test_rejects_unbracketed_ipv6_host_authority(
     assert body["request_host"] == "2001:db8::1"
     assert body["host_header"] == "2001:db8::1"
     assert body["request_port"] == 8443
-    assert flow.metadata["firewall_action"] == "DENY"
-    assert flow.metadata["firewall_error"] == "invalid_authority"
-    assert flow.metadata["original_url"] == "https://[2001:db8::1]:8443/repos"
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "DENY"
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "invalid_authority"
+    assert flow.metadata[metadata_keys.ORIGINAL_URL] == "https://[2001:db8::1]:8443/repos"
     auth_fetch.assert_not_called()
     assert "Authorization" not in flow.request.headers
 
@@ -528,9 +528,9 @@ async def test_rejects_host_authority_port_mismatch(
     assert flow.response.status_code == 403
     body = json.loads(flow.response.content)
     assert body["error"] == "authority_port_mismatch"
-    assert flow.metadata["firewall_action"] == "DENY"
-    assert flow.metadata["firewall_error"] == "authority_port_mismatch"
-    assert flow.metadata["original_url"] == expected_original_url
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "DENY"
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "authority_port_mismatch"
+    assert flow.metadata[metadata_keys.ORIGINAL_URL] == expected_original_url
     auth_fetch.assert_not_called()
 
 
@@ -708,8 +708,8 @@ async def test_accepts_authority_host_normalization_equivalence(
         await mitm_addon.request(flow)
 
     assert flow.response is None
-    assert flow.metadata["firewall_base"] == expected_firewall_base
-    assert flow.metadata["original_url"] == expected_original_url
+    assert flow.metadata[metadata_keys.FIREWALL_BASE] == expected_firewall_base
+    assert flow.metadata[metadata_keys.ORIGINAL_URL] == expected_original_url
     assert flow.request.headers["Authorization"] == "Bearer x"
 
 
@@ -741,9 +741,9 @@ async def test_rejects_idna_compatibility_sni_alias_before_firewall_auth(
     body = json.loads(flow.response.content)
     assert body["error"] == "invalid_sni"
     assert body["sni"] == "\uff21.example"
-    assert flow.metadata["firewall_action"] == "DENY"
-    assert flow.metadata["firewall_error"] == "invalid_sni"
-    assert flow.metadata["original_url"] == "https://203.0.113.10/repos"
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "DENY"
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "invalid_sni"
+    assert flow.metadata[metadata_keys.ORIGINAL_URL] == "https://203.0.113.10/repos"
     auth_fetch.assert_not_called()
     assert "Authorization" not in flow.request.headers
 
@@ -776,9 +776,9 @@ async def test_rejects_multiple_trailing_dot_sni_before_firewall_auth(
     body = json.loads(flow.response.content)
     assert body["error"] == "invalid_sni"
     assert body["sni"] == "api.github.com.."
-    assert flow.metadata["firewall_action"] == "DENY"
-    assert flow.metadata["firewall_error"] == "invalid_sni"
-    assert flow.metadata["original_url"] == "https://203.0.113.10/repos"
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "DENY"
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "invalid_sni"
+    assert flow.metadata[metadata_keys.ORIGINAL_URL] == "https://203.0.113.10/repos"
     auth_fetch.assert_not_called()
     assert "Authorization" not in flow.request.headers
 
@@ -812,9 +812,9 @@ async def test_rejects_idna_compatibility_host_alias_before_firewall_auth(
     assert body["error"] == "invalid_authority"
     assert body["sni"] == "a.example"
     assert body["host_header"] == "\uff21.example"
-    assert flow.metadata["firewall_action"] == "DENY"
-    assert flow.metadata["firewall_error"] == "invalid_authority"
-    assert flow.metadata["original_url"] == "https://a.example/repos"
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "DENY"
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "invalid_authority"
+    assert flow.metadata[metadata_keys.ORIGINAL_URL] == "https://a.example/repos"
     auth_fetch.assert_not_called()
     assert "Authorization" not in flow.request.headers
 
@@ -932,9 +932,9 @@ async def test_rejects_invalid_host_authority_before_firewall_auth(
     assert body["request_host"] == "203.0.113.10"
     assert body["host_header"] == host_header
     assert body["request_port"] == request_port
-    assert flow.metadata["firewall_action"] == "DENY"
-    assert flow.metadata["firewall_error"] == expected_error
-    assert flow.metadata["original_url"] == expected_original_url
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "DENY"
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == expected_error
+    assert flow.metadata[metadata_keys.ORIGINAL_URL] == expected_original_url
     auth_fetch.assert_not_called()
     assert "Authorization" not in flow.request.headers
 
@@ -982,9 +982,9 @@ async def test_rejects_missing_https_sni_before_firewall_auth(
     body = json.loads(flow.response.content)
     assert body["error"] == "missing_sni"
     assert body["sni"] == expected_sni
-    assert flow.metadata["firewall_action"] == "DENY"
-    assert flow.metadata["firewall_error"] == "missing_sni"
-    assert flow.metadata["original_url"] == expected_original_url
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "DENY"
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "missing_sni"
+    assert flow.metadata[metadata_keys.ORIGINAL_URL] == expected_original_url
     auth_fetch.assert_not_called()
 
 
@@ -1158,9 +1158,9 @@ async def test_rejects_invalid_https_sni_before_firewall_auth(
     assert body["request_host"] == request_host
     assert body["host_header"] == "api.github.com"
     assert body["request_port"] == request_port
-    assert flow.metadata["firewall_action"] == "DENY"
-    assert flow.metadata["firewall_error"] == "invalid_sni"
-    assert flow.metadata["original_url"] == expected_original_url
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "DENY"
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "invalid_sni"
+    assert flow.metadata[metadata_keys.ORIGINAL_URL] == expected_original_url
     proxy_log_entry = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")[0]
     assert proxy_log_entry["type"] == "authority_validation"
     assert proxy_log_entry["reason"] == "invalid_sni"
@@ -1193,9 +1193,9 @@ async def test_http_host_spoof_does_not_match_domain_firewall(
         await mitm_addon.request(flow)
 
     assert flow.response is None
-    assert flow.metadata["firewall_action"] == "ALLOW"
-    assert flow.metadata["original_url"] == "http://203.0.113.10/repos"
-    assert "firewall_base" not in flow.metadata
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+    assert flow.metadata[metadata_keys.ORIGINAL_URL] == "http://203.0.113.10/repos"
+    assert metadata_keys.FIREWALL_BASE not in flow.metadata
     auth_fetch.assert_not_called()
     assert "Authorization" not in flow.request.headers
 
@@ -1226,10 +1226,10 @@ async def test_http_host_spoof_does_not_trigger_vm0_api_auto_allow(
     auth_fetch.assert_not_called()
     assert flow.response is not None
     assert flow.response.status_code == 403
-    assert flow.metadata["firewall_base"] == "http://203.0.113.10/api/runs"
-    assert flow.metadata["firewall_action"] == "BLOCK"
-    assert flow.metadata["firewall_error"] == "insecure_transport"
-    assert flow.metadata["original_url"] == "http://203.0.113.10/api/runs/heartbeat"
+    assert flow.metadata[metadata_keys.FIREWALL_BASE] == "http://203.0.113.10/api/runs"
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "BLOCK"
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "insecure_transport"
+    assert flow.metadata[metadata_keys.ORIGINAL_URL] == "http://203.0.113.10/api/runs/heartbeat"
     assert "Authorization" not in flow.request.headers
     body = json.loads(flow.response.content)
     assert body["error"] == "insecure_transport"

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -72,9 +72,9 @@ async def test_firewall_match_calls_handler(
 
     # Dispatcher routed to the real handle_firewall_request, which writes
     # firewall allow metadata into flow.metadata up front.
-    assert flow.metadata["firewall_base"] == "https://api.github.com"
-    assert flow.metadata["firewall_name"] == "github"
-    assert flow.metadata["firewall_permission"] == "full-access"
+    assert flow.metadata[metadata_keys.FIREWALL_BASE] == "https://api.github.com"
+    assert flow.metadata[metadata_keys.FIREWALL_NAME] == "github"
+    assert flow.metadata[metadata_keys.FIREWALL_PERMISSION] == "full-access"
 
 
 async def test_inactive_builtin_connector_url_allows_without_diagnostic_lookup(
@@ -205,8 +205,8 @@ async def test_firewall_permission_blocks_unmatched(tmp_path, real_flow, mitm_ct
     # handle_firewall_request is reached.
     assert flow.response is not None
     assert flow.response.status_code == 403
-    assert flow.metadata["firewall_action"] == "DENY"
-    assert flow.metadata["firewall_base"] == "https://api.github.com"
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "DENY"
+    assert flow.metadata[metadata_keys.FIREWALL_BASE] == "https://api.github.com"
     body = json.loads(flow.response.content)
     assert body["error"] == "permission_denied"
     assert body["method"] == "GET"
@@ -355,7 +355,7 @@ async def test_firewall_malformed_network_policy_block_reports_reason(
 
     assert flow.response is not None
     assert flow.response.status_code == 403
-    assert flow.metadata["firewall_action"] == "DENY"
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "DENY"
     body = json.loads(flow.response.content)
     assert body["permissions"] == []
     assert body["message"] == "Request blocked: malformed network policy"
@@ -404,7 +404,7 @@ async def test_firewall_top_level_malformed_network_policy_block_reports_reason(
 
     assert flow.response is not None
     assert flow.response.status_code == 403
-    assert flow.metadata["firewall_action"] == "DENY"
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "DENY"
     body = json.loads(flow.response.content)
     assert body["permissions"] == []
     assert body["message"] == "Request blocked: malformed network policy"
@@ -504,11 +504,11 @@ async def test_firewall_permission_allows_matched(
 
     # Dispatcher routed to the real handle_firewall_request, which writes
     # firewall allow metadata into flow.metadata up front.
-    assert flow.metadata["firewall_base"] == "https://api.github.com"
-    assert flow.metadata["firewall_name"] == "github"
-    assert flow.metadata["firewall_permission"] == "read-repos"
-    assert flow.metadata["firewall_rule_match"] == "GET /repos/{owner}/{repo}"
-    assert flow.metadata["firewall_params"] == {"owner": "octocat", "repo": "hello"}
+    assert flow.metadata[metadata_keys.FIREWALL_BASE] == "https://api.github.com"
+    assert flow.metadata[metadata_keys.FIREWALL_NAME] == "github"
+    assert flow.metadata[metadata_keys.FIREWALL_PERMISSION] == "read-repos"
+    assert flow.metadata[metadata_keys.FIREWALL_RULE_MATCH] == "GET /repos/{owner}/{repo}"
+    assert flow.metadata[metadata_keys.FIREWALL_PARAMS] == {"owner": "octocat", "repo": "hello"}
 
 
 @pytest.mark.parametrize(
@@ -1039,12 +1039,12 @@ async def test_firewall_unknown_policy_allow_writes_empty_permission_metadata(
         await mitm_addon.request(flow)
 
     assert flow.response is None
-    assert flow.metadata["firewall_action"] == "ALLOW"
-    assert flow.metadata["firewall_base"] == "https://api-{region}.example.com/v1"
-    assert flow.metadata["firewall_name"] == "example"
-    assert flow.metadata["firewall_permission"] == ""
-    assert flow.metadata["firewall_rule_match"] == ""
-    assert flow.metadata["firewall_params"] == {"region": "us"}
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+    assert flow.metadata[metadata_keys.FIREWALL_BASE] == "https://api-{region}.example.com/v1"
+    assert flow.metadata[metadata_keys.FIREWALL_NAME] == "example"
+    assert flow.metadata[metadata_keys.FIREWALL_PERMISSION] == ""
+    assert flow.metadata[metadata_keys.FIREWALL_RULE_MATCH] == ""
+    assert flow.metadata[metadata_keys.FIREWALL_PARAMS] == {"region": "us"}
     assert flow.request.headers["Authorization"] == "Bearer x"
 
 
@@ -1095,18 +1095,18 @@ async def test_browser_passthrough_skips_firewall_auth_injection(
     mock_headers.assert_not_called()
     assert flow.response is None
     assert "Authorization" not in flow.request.headers
-    assert flow.metadata["firewall_action"] == "ALLOW"
-    assert flow.metadata["firewall_billable"] is False
-    assert flow.metadata["browser_user_agent"] is True
-    assert "firewall_base" not in flow.metadata
-    assert "firewall_name" not in flow.metadata
-    assert "firewall_permission" not in flow.metadata
-    assert "firewall_rule_match" not in flow.metadata
-    assert "firewall_params" not in flow.metadata
-    assert "firewall_api_id" not in flow.metadata
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+    assert flow.metadata[metadata_keys.FIREWALL_BILLABLE] is False
+    assert flow.metadata[metadata_keys.BROWSER_USER_AGENT] is True
+    assert metadata_keys.FIREWALL_BASE not in flow.metadata
+    assert metadata_keys.FIREWALL_NAME not in flow.metadata
+    assert metadata_keys.FIREWALL_PERMISSION not in flow.metadata
+    assert metadata_keys.FIREWALL_RULE_MATCH not in flow.metadata
+    assert metadata_keys.FIREWALL_PARAMS not in flow.metadata
+    assert metadata_keys.FIREWALL_API_ID not in flow.metadata
     assert metadata_keys.MODEL_USAGE_PROVIDER not in flow.metadata
-    assert "auth_resolved_secrets" not in flow.metadata
-    assert "auth_url_rewrite" not in flow.metadata
+    assert metadata_keys.AUTH_RESOLVED_SECRETS not in flow.metadata
+    assert metadata_keys.AUTH_URL_REWRITE not in flow.metadata
     usage.write_pending_snapshot(flush_request_id="browser-passthrough")
     assert_pending(
         pending_path,
@@ -1167,9 +1167,9 @@ async def test_non_browser_firewall_match_still_injects_auth(
     mock_headers.assert_awaited_once()
     assert flow.response is None
     assert flow.request.headers["Authorization"] == "Bearer x"
-    assert flow.metadata["firewall_action"] == "ALLOW"
-    assert flow.metadata["firewall_base"] == "https://api.stripe.com"
-    assert flow.metadata["firewall_name"] == "stripe"
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+    assert flow.metadata[metadata_keys.FIREWALL_BASE] == "https://api.stripe.com"
+    assert flow.metadata[metadata_keys.FIREWALL_NAME] == "stripe"
 
 
 async def test_browser_passthrough_skips_denied_unknown_policy_match(
@@ -1216,11 +1216,11 @@ async def test_browser_passthrough_skips_denied_unknown_policy_match(
     mock_headers.assert_not_called()
     assert flow.response is None
     assert "Authorization" not in flow.request.headers
-    assert flow.metadata["firewall_action"] == "ALLOW"
-    assert flow.metadata["firewall_billable"] is False
-    assert flow.metadata["browser_user_agent"] is True
-    assert "firewall_base" not in flow.metadata
-    assert "firewall_name" not in flow.metadata
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+    assert flow.metadata[metadata_keys.FIREWALL_BILLABLE] is False
+    assert flow.metadata[metadata_keys.BROWSER_USER_AGENT] is True
+    assert metadata_keys.FIREWALL_BASE not in flow.metadata
+    assert metadata_keys.FIREWALL_NAME not in flow.metadata
 
 
 async def test_browser_passthrough_skips_denied_permission_match(
@@ -1273,12 +1273,12 @@ async def test_browser_passthrough_skips_denied_permission_match(
     mock_headers.assert_not_called()
     assert flow.response is None
     assert "Authorization" not in flow.request.headers
-    assert flow.metadata["firewall_action"] == "ALLOW"
-    assert flow.metadata["firewall_billable"] is False
-    assert flow.metadata["browser_user_agent"] is True
-    assert "firewall_base" not in flow.metadata
-    assert "firewall_name" not in flow.metadata
-    assert "firewall_api_id" not in flow.metadata
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+    assert flow.metadata[metadata_keys.FIREWALL_BILLABLE] is False
+    assert flow.metadata[metadata_keys.BROWSER_USER_AGENT] is True
+    assert metadata_keys.FIREWALL_BASE not in flow.metadata
+    assert metadata_keys.FIREWALL_NAME not in flow.metadata
+    assert metadata_keys.FIREWALL_API_ID not in flow.metadata
 
     flow.response = mitm_addon.http.Response.make(200)
     mitm_addon.response(flow)
@@ -1356,9 +1356,9 @@ async def test_firewall_unsafe_path_blocks_before_auth_injection(
     mock_headers.assert_not_called()
     assert flow.response is not None
     assert flow.response.status_code == 403
-    assert flow.metadata["firewall_action"] == "DENY"
-    assert flow.metadata["firewall_base"] == "https://api.github.com"
-    assert flow.metadata["firewall_name"] == "github"
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "DENY"
+    assert flow.metadata[metadata_keys.FIREWALL_BASE] == "https://api.github.com"
+    assert flow.metadata[metadata_keys.FIREWALL_NAME] == "github"
     assert "Authorization" not in flow.request.headers
     body = json.loads(flow.response.content)
     assert body["error"] == "permission_denied"
@@ -1421,9 +1421,9 @@ async def test_browser_passthrough_skips_unsafe_path_firewall_match(
 
     mock_headers.assert_not_called()
     assert flow.response is None
-    assert flow.metadata["browser_user_agent"] is True
-    assert flow.metadata["firewall_action"] == "ALLOW"
-    assert flow.metadata["firewall_billable"] is False
-    assert "firewall_base" not in flow.metadata
-    assert "firewall_name" not in flow.metadata
+    assert flow.metadata[metadata_keys.BROWSER_USER_AGENT] is True
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+    assert flow.metadata[metadata_keys.FIREWALL_BILLABLE] is False
+    assert metadata_keys.FIREWALL_BASE not in flow.metadata
+    assert metadata_keys.FIREWALL_NAME not in flow.metadata
     assert "Authorization" not in flow.request.headers

--- a/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
@@ -39,11 +39,11 @@ def _assert_stale_tls_admission_block(flow, *, reason: str) -> None:
         ),
         "reason": reason,
     }
-    assert flow.metadata["firewall_action"] == "BLOCK"
-    assert flow.metadata["firewall_error"] == "stale_tls_admission"
-    assert "vm_run_id" not in flow.metadata
-    assert "vm_network_log_path" not in flow.metadata
-    assert "firewall_base" not in flow.metadata
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "BLOCK"
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "stale_tls_admission"
+    assert metadata_keys.VM_RUN_ID not in flow.metadata
+    assert metadata_keys.VM_NETWORK_LOG_PATH not in flow.metadata
+    assert metadata_keys.FIREWALL_BASE not in flow.metadata
     assert metadata_keys.HTTP_REQUEST_START_MONOTONIC not in flow.metadata
 
 
@@ -55,7 +55,7 @@ async def test_allowed_domain_passes_through(registry_file, real_flow, mitm_ctx)
     ):
         await mitm_addon.request(flow)
 
-    assert flow.metadata["firewall_action"] == "ALLOW"
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
 
 
 async def test_vm0_api_auto_allowed(registry_file, real_flow, mitm_ctx):
@@ -66,7 +66,7 @@ async def test_vm0_api_auto_allowed(registry_file, real_flow, mitm_ctx):
     ):
         await mitm_addon.request(flow)
 
-    assert flow.metadata["firewall_action"] == "ALLOW"
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
 
 
 async def test_registry_unavailable_blocks_vm0_api_auto_allow(registry_file, real_flow, mitm_ctx):
@@ -84,9 +84,9 @@ async def test_registry_unavailable_blocks_vm0_api_auto_allow(registry_file, rea
         "message": "Proxy registry is unavailable",
         "reason": "parse_failed",
     }
-    assert flow.metadata["firewall_action"] == "BLOCK"
-    assert flow.metadata["firewall_error"] == "registry_unavailable"
-    assert "vm_run_id" not in flow.metadata
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "BLOCK"
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "registry_unavailable"
+    assert metadata_keys.VM_RUN_ID not in flow.metadata
 
 
 async def test_vm0_api_test_paths_skip_auto_allow(tmp_path, real_flow, mitm_ctx, headers):
@@ -124,7 +124,9 @@ async def test_vm0_api_test_paths_skip_auto_allow(tmp_path, real_flow, mitm_ctx,
     # Carve-out took effect: Step 3 ran and the real handle_firewall_request
     # entered (firewall_base is written at auth.py:327 up-front).  Step 2's
     # auto-allow would have returned without writing firewall_base.
-    assert flow.metadata["firewall_base"] == "https://api.vm0.ai/api/test/oauth-provider"
+    assert (
+        flow.metadata[metadata_keys.FIREWALL_BASE] == "https://api.vm0.ai/api/test/oauth-provider"
+    )
 
 
 async def test_registry_unavailable_blocks_before_auth_injection(tmp_path, real_flow, mitm_ctx):
@@ -156,9 +158,9 @@ async def test_registry_unavailable_blocks_before_auth_injection(tmp_path, real_
     assert flow.response is not None
     assert flow.response.status_code == 503
     assert flow.request.headers.get("Authorization") is None
-    assert flow.metadata["firewall_action"] == "BLOCK"
-    assert flow.metadata["firewall_error"] == "registry_unavailable"
-    assert "firewall_base" not in flow.metadata
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "BLOCK"
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "registry_unavailable"
+    assert metadata_keys.FIREWALL_BASE not in flow.metadata
 
 
 async def test_valid_tls_admission_blocks_when_registry_entry_disappears(
@@ -391,7 +393,7 @@ async def test_missing_registry_entry_without_tls_admission_passes_through(
         await mitm_addon.request(flow)
 
     assert flow.response is None
-    assert "firewall_action" not in flow.metadata
+    assert metadata_keys.FIREWALL_ACTION not in flow.metadata
 
 
 async def test_tls_admission_keeps_guarding_multiple_requests(
@@ -475,7 +477,7 @@ async def test_client_disconnected_removes_tls_admission(
 
     assert tls_data.ignore_connection is False
     assert flow.response is None
-    assert "firewall_action" not in flow.metadata
+    assert metadata_keys.FIREWALL_ACTION not in flow.metadata
 
 
 @pytest.mark.parametrize(
@@ -537,10 +539,10 @@ async def test_invalid_registered_vm_blocks_before_auth_injection(
     }
     auth_fetch.assert_not_called()
     assert not has_auth_state(("", "https://api.github.com"))
-    assert "vm_run_id" not in flow.metadata
-    assert "firewall_base" not in flow.metadata
-    assert flow.metadata["firewall_action"] == "BLOCK"
-    assert flow.metadata["firewall_error"] == "invalid_registry_vm"
+    assert metadata_keys.VM_RUN_ID not in flow.metadata
+    assert metadata_keys.FIREWALL_BASE not in flow.metadata
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "BLOCK"
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "invalid_registry_vm"
 
 
 async def test_invalid_registered_vm_non_object_blocks_before_auth_injection(
@@ -567,10 +569,10 @@ async def test_invalid_registered_vm_non_object_blocks_before_auth_injection(
         "reason": "invalid_vm_entry",
     }
     auth_fetch.assert_not_called()
-    assert "vm_run_id" not in flow.metadata
-    assert "firewall_base" not in flow.metadata
-    assert flow.metadata["firewall_action"] == "BLOCK"
-    assert flow.metadata["firewall_error"] == "invalid_registry_vm"
+    assert metadata_keys.VM_RUN_ID not in flow.metadata
+    assert metadata_keys.FIREWALL_BASE not in flow.metadata
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "BLOCK"
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "invalid_registry_vm"
 
 
 @pytest.mark.parametrize(
@@ -616,10 +618,10 @@ async def test_invalid_registered_vm_firewalls_shape_blocks_before_auth_injectio
         "reason": "invalid_firewalls",
     }
     auth_fetch.assert_not_called()
-    assert "vm_run_id" not in flow.metadata
-    assert "firewall_base" not in flow.metadata
-    assert flow.metadata["firewall_action"] == "BLOCK"
-    assert flow.metadata["firewall_error"] == "invalid_registry_vm"
+    assert metadata_keys.VM_RUN_ID not in flow.metadata
+    assert metadata_keys.FIREWALL_BASE not in flow.metadata
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "BLOCK"
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "invalid_registry_vm"
 
 
 async def test_registered_vm_null_firewalls_passes_through_without_auth_injection(
@@ -654,9 +656,9 @@ async def test_registered_vm_null_firewalls_passes_through_without_auth_injectio
 
     assert flow.response is None
     auth_fetch.assert_not_called()
-    assert flow.metadata["vm_run_id"] == vm_info["runId"]
-    assert "firewall_base" not in flow.metadata
-    assert flow.metadata["firewall_action"] == "ALLOW"
+    assert flow.metadata[metadata_keys.VM_RUN_ID] == vm_info["runId"]
+    assert metadata_keys.FIREWALL_BASE not in flow.metadata
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
 
 
 async def test_tracks_start_time(registry_file, real_flow, mitm_ctx):
@@ -680,7 +682,7 @@ async def test_unregistered_vm_passes_through(registry_file, real_flow, mitm_ctx
 
     # No 403, no metadata set
     assert flow.response is None
-    assert "firewall_action" not in flow.metadata
+    assert metadata_keys.FIREWALL_ACTION not in flow.metadata
 
 
 async def test_mitm_allowed_passes_through(registry_file, real_flow, mitm_ctx):
@@ -694,8 +696,8 @@ async def test_mitm_allowed_passes_through(registry_file, real_flow, mitm_ctx):
 
     # Request should pass through without rewrite
     assert flow.response is None
-    assert flow.metadata["firewall_action"] == "ALLOW"
-    assert flow.metadata.get("original_url") == "https://api.anthropic.com/v1/messages"
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+    assert flow.metadata.get(metadata_keys.ORIGINAL_URL) == "https://api.anthropic.com/v1/messages"
 
 
 async def test_firewall_no_base_match_passes_through(tmp_path, real_flow, mitm_ctx, headers):
@@ -730,5 +732,5 @@ async def test_firewall_no_base_match_passes_through(tmp_path, real_flow, mitm_c
     # fall-through sets firewall_action=ALLOW; handler never reached so
     # firewall_base is absent).
     assert flow.response is None
-    assert flow.metadata["firewall_action"] == "ALLOW"
-    assert "firewall_base" not in flow.metadata
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+    assert metadata_keys.FIREWALL_BASE not in flow.metadata

--- a/crates/runner/mitm-addon/tests/test_request_handler_usage_tracking.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_usage_tracking.py
@@ -459,7 +459,7 @@ async def test_untracked_terminal_hook_does_not_decrement_other_usage_flow(
         fake_firewall_headers(),
     ):
         await mitm_addon.request(untracked_flow)
-        assert untracked_flow.metadata["firewall_billable"] is False
+        assert untracked_flow.metadata[metadata_keys.FIREWALL_BILLABLE] is False
         usage.write_pending_snapshot(flush_request_id="after-untracked-request")
         assert_pending(
             usage_pending_path,
@@ -509,7 +509,7 @@ async def test_local_firewall_error_leaves_usage_flows_drained(
 
     assert flow.response is not None
     assert flow.response.status_code == 502
-    assert flow.metadata["firewall_error"] == "auth_unavailable"
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "auth_unavailable"
     usage.write_pending_snapshot(flush_request_id="request-1")
     assert_pending(
         usage_pending_path,
@@ -614,9 +614,9 @@ async def test_non_billable_model_provider_is_not_tracked_before_responseheaders
     ):
         await mitm_addon.request(flow)
 
-    assert flow.metadata["firewall_name"] == _MODEL_PROVIDER_FIREWALL_NAME
-    assert flow.metadata["cli_agent_type"] == "claude-code"
-    assert flow.metadata["firewall_billable"] is False
+    assert flow.metadata[metadata_keys.FIREWALL_NAME] == _MODEL_PROVIDER_FIREWALL_NAME
+    assert flow.metadata[metadata_keys.CLI_AGENT_TYPE] == "claude-code"
+    assert flow.metadata[metadata_keys.FIREWALL_BILLABLE] is False
     usage.write_pending_snapshot(flush_request_id="request-1")
     assert_pending(
         usage_pending_path,
@@ -645,8 +645,8 @@ async def test_non_billable_model_provider_with_invalid_model_usage_provider_is_
     ):
         await mitm_addon.request(flow)
 
-    assert flow.metadata["firewall_name"] == _MODEL_PROVIDER_FIREWALL_NAME
-    assert flow.metadata["firewall_billable"] is False
+    assert flow.metadata[metadata_keys.FIREWALL_NAME] == _MODEL_PROVIDER_FIREWALL_NAME
+    assert flow.metadata[metadata_keys.FIREWALL_BILLABLE] is False
     assert flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] == 123
     usage.write_pending_snapshot(flush_request_id="request-1")
     assert_pending(
@@ -676,9 +676,9 @@ async def test_non_billable_observable_model_provider_is_tracked_before_response
     ):
         await mitm_addon.request(flow)
 
-    assert flow.metadata["firewall_name"] == _MODEL_PROVIDER_FIREWALL_NAME
-    assert flow.metadata["firewall_billable"] is False
-    assert flow.metadata["model_usage_provider"] == "claude-sonnet-4-6"
+    assert flow.metadata[metadata_keys.FIREWALL_NAME] == _MODEL_PROVIDER_FIREWALL_NAME
+    assert flow.metadata[metadata_keys.FIREWALL_BILLABLE] is False
+    assert flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] == "claude-sonnet-4-6"
     usage.write_pending_snapshot(flush_request_id="request-1")
     assert_pending(
         usage_pending_path,
@@ -711,10 +711,10 @@ async def test_billable_model_provider_records_model_usage_provider(
     ):
         await mitm_addon.request(flow)
 
-    assert flow.metadata["firewall_name"] == _MODEL_PROVIDER_FIREWALL_NAME
-    assert flow.metadata["cli_agent_type"] == "codex"
-    assert flow.metadata["firewall_billable"] is True
-    assert flow.metadata["model_usage_provider"] == "claude-opus-4-6"
+    assert flow.metadata[metadata_keys.FIREWALL_NAME] == _MODEL_PROVIDER_FIREWALL_NAME
+    assert flow.metadata[metadata_keys.CLI_AGENT_TYPE] == "codex"
+    assert flow.metadata[metadata_keys.FIREWALL_BILLABLE] is True
+    assert flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] == "claude-opus-4-6"
     usage.write_pending_snapshot(flush_request_id="request-1")
     assert_pending(
         usage_pending_path,
@@ -780,7 +780,7 @@ async def test_billable_auth_url_rewrite_flow_drains_after_response(
         assert flow.response is not None
         assert flow.response.status_code == 200
         assert flow.response.content == b'{"delivered":true}'
-        assert flow.metadata["auth_url_rewrite"] is True
+        assert flow.metadata[metadata_keys.AUTH_URL_REWRITE] is True
         usage.write_pending_snapshot(flush_request_id="request-1")
         assert_pending(
             usage_pending_path,
@@ -827,8 +827,8 @@ async def test_billable_auth_url_rewrite_forward_failure_releases_tracking(
     assert upstream.create_connection_calls == [(("93.184.216.34", 443), 30, None)]
     assert flow.response is not None
     assert flow.response.status_code == 502
-    assert flow.metadata["firewall_error"] == "url_rewrite_forward_failed"
-    assert "auth_url_rewrite" not in flow.metadata
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "url_rewrite_forward_failed"
+    assert metadata_keys.AUTH_URL_REWRITE not in flow.metadata
     usage.write_pending_snapshot(flush_request_id="request-1")
     assert_pending(
         usage_pending_path,
@@ -895,7 +895,7 @@ async def test_billable_auth_url_rewrite_forward_cancellation_releases_tracking(
             await _drain_request_task(request_task)
 
     assert flow.response is None
-    assert "auth_url_rewrite" not in flow.metadata
+    assert metadata_keys.AUTH_URL_REWRITE not in flow.metadata
     assert metadata_keys.HTTP_REQUEST_START_MONOTONIC not in flow.metadata
     assert "_usage_flow_tracked" not in flow.metadata
     usage.write_pending_snapshot(flush_request_id="request-1")

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -754,11 +754,11 @@ class TestResponseHandler:
         log_path = str(tmp_path / "network.jsonl")
 
         # Simulate request handler setting metadata
-        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
 
-        flow.metadata["vm_network_log_path"] = log_path
-        flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["original_url"] = "https://api.anthropic.com/"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
+        flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+        flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.anthropic.com/"
 
         # Add response
         flow.response = tutils.tresp(
@@ -796,10 +796,10 @@ class TestResponseHandler:
         flow = real_flow(with_response=False, host="request.example.com")
         log_path = str(tmp_path / "network.jsonl")
 
-        flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_network_log_path"] = log_path
-        flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["original_url"] = "https://original.example.com/"
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
+        flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+        flow.metadata[metadata_keys.ORIGINAL_URL] = "https://original.example.com/"
         flow.metadata[metadata_keys.NETWORK_LOG_TARGET] = {
             "url": "https://target.example.com:9443/path",
             "host": "target.example.com",
@@ -882,10 +882,10 @@ class TestResponseHandler:
         flow = real_flow(with_response=False, host="request.example.com")
         log_path = str(tmp_path / "network.jsonl")
 
-        flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_network_log_path"] = log_path
-        flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["original_url"] = raw_url
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
+        flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+        flow.metadata[metadata_keys.ORIGINAL_URL] = raw_url
         flow.metadata[metadata_keys.NETWORK_LOG_TARGET] = {
             "url": raw_url,
             "host": "target.example.com",
@@ -900,7 +900,7 @@ class TestResponseHandler:
         assert entry["host"] == "target.example.com"
         assert entry["port"] == 9443
         assert entry["url"] == expected_url
-        assert flow.metadata["original_url"] == raw_url
+        assert flow.metadata[metadata_keys.ORIGINAL_URL] == raw_url
         assert flow.metadata[metadata_keys.NETWORK_LOG_TARGET]["url"] == raw_url
 
     def test_logs_legacy_target_when_original_url_port_is_invalid(
@@ -909,10 +909,12 @@ class TestResponseHandler:
         flow = real_flow(with_response=False, host="fallback.example.com", port=9443)
         log_path = str(tmp_path / "network.jsonl")
 
-        flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_network_log_path"] = log_path
-        flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["original_url"] = "https://invalid.example.com:bad/path?secret=value#frag"
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
+        flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+        flow.metadata[metadata_keys.ORIGINAL_URL] = (
+            "https://invalid.example.com:bad/path?secret=value#frag"
+        )
         flow.response = tutils.tresp(status_code=200, headers=header_map({"content-length": "0"}))
 
         with mitm_ctx():
@@ -928,10 +930,10 @@ class TestResponseHandler:
         flow = real_flow(with_response=False, host="api.example.com")
         log_path = str(tmp_path / "network.jsonl")
 
-        flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_network_log_path"] = log_path
-        flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["original_url"] = "https://api.example.com/"
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
+        flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+        flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.example.com/"
         flow.response = tutils.tresp(
             status_code=200,
             headers=header_map({"content-length": "999", "content-type": "application/json"}),
@@ -955,10 +957,10 @@ class TestResponseHandler:
         log_path = str(tmp_path / "network.jsonl")
         body = b"x" * (STREAM_BUFFER_LIMIT + 4096)
 
-        flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_network_log_path"] = log_path
-        flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["original_url"] = "https://api.example.com/"
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
+        flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+        flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.example.com/"
         flow.response = tutils.tresp(
             status_code=200,
             headers=header_map({"content-length": "12", "content-type": "application/json"}),
@@ -967,8 +969,8 @@ class TestResponseHandler:
         mitm_addon.responseheaders(flow)
         response_stream(flow)(body[:123])
         response_stream(flow)(body[123:])
-        assert flow.metadata["stream_buffer_state"]["truncated"] is True
-        assert len(flow.metadata["stream_buffer"]) == STREAM_BUFFER_LIMIT
+        assert flow.metadata[metadata_keys.STREAM_BUFFER_STATE]["truncated"] is True
+        assert len(flow.metadata[metadata_keys.STREAM_BUFFER]) == STREAM_BUFFER_LIMIT
 
         with mitm_ctx():
             mitm_addon.response(flow)
@@ -989,10 +991,10 @@ class TestResponseHandler:
         log_path = str(tmp_path / "network.jsonl")
         body = b"x" * (STREAM_BUFFER_LIMIT + 17)
 
-        flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_network_log_path"] = log_path
-        flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["original_url"] = "https://api.example.com/"
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
+        flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+        flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.example.com/"
         flow.metadata[metadata_keys.CAPTURE_BODY] = True
         flow.response = tutils.tresp(
             status_code=200,
@@ -1273,10 +1275,10 @@ class TestResponseHandler:
         flow = real_flow(with_response=False, host="api.example.com")
         log_path = str(tmp_path / "network.jsonl")
 
-        flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_network_log_path"] = log_path
-        flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["original_url"] = "https://api.example.com/"
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
+        flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+        flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.example.com/"
         flow.response = tutils.tresp(
             status_code=200, headers=header_map({"content-length": content_length})
         )
@@ -1292,10 +1294,10 @@ class TestResponseHandler:
         flow = real_flow(with_response=False, host="api.example.com")
         log_path = str(tmp_path / "network.jsonl")
 
-        flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_network_log_path"] = log_path
-        flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["original_url"] = "https://api.example.com/"
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
+        flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+        flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.example.com/"
         flow.response = tutils.tresp(
             status_code=200, headers=header_map({"content-length": "9007199254740991"})
         )
@@ -1313,10 +1315,10 @@ class TestResponseHandler:
         flow = real_flow(with_response=False, host="api.example.com")
         log_path = str(tmp_path / "network.jsonl")
 
-        flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_network_log_path"] = log_path
-        flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["original_url"] = "https://api.example.com/"
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
+        flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+        flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.example.com/"
         flow.response = tutils.tresp(
             status_code=200, headers=header_map({"content-type": "application/json"})
         )
@@ -1357,10 +1359,10 @@ class TestResponseHandler:
         flow = real_flow(with_response=False, host="api.example.com")
         log_path = str(tmp_path / "network.jsonl")
 
-        flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_network_log_path"] = log_path
-        flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["original_url"] = "https://api.example.com/"
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
+        flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+        flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.example.com/"
         flow.response = tutils.tresp(
             status_code=200, headers=header_map({"content-length": content_length})
         )
@@ -1378,10 +1380,10 @@ class TestResponseHandler:
         flow = real_flow(with_response=False, host="api.example.com")
         log_path = str(tmp_path / "network.jsonl")
 
-        flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_network_log_path"] = log_path
-        flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["original_url"] = "https://api.example.com/"
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
+        flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+        flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.example.com/"
         flow.response = tutils.tresp(
             status_code=200,
             headers=http.Headers([(b"content-length", b"50000"), (b"content-length", b"50000")]),
@@ -1400,10 +1402,10 @@ class TestResponseHandler:
         flow = real_flow(with_response=False, host="api.example.com")
         log_path = str(tmp_path / "network.jsonl")
 
-        flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_network_log_path"] = log_path
-        flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["original_url"] = "https://api.example.com/"
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
+        flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+        flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.example.com/"
         flow.response = tutils.tresp(
             status_code=200,
             headers=http.Headers([(b"content-length", b"50000"), (b"content-length", b"50001")]),
@@ -1420,10 +1422,10 @@ class TestResponseHandler:
         flow = real_flow(with_response=False, host="api.example.com")
         log_path = str(tmp_path / "network.jsonl")
 
-        flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_network_log_path"] = log_path
-        flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["original_url"] = "https://api.example.com/"
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
+        flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+        flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.example.com/"
         flow.response = tutils.tresp(
             status_code=200,
             headers=header_map({"content-length": "50000", "content-type": "application/json"}),
@@ -1445,10 +1447,10 @@ class TestResponseHandler:
         log_path = str(tmp_path / "network.jsonl")
         body = b"x" * (STREAM_BUFFER_LIMIT + 4096)
 
-        flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_network_log_path"] = log_path
-        flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["original_url"] = "https://api.example.com/"
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
+        flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+        flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.example.com/"
         flow.response = tutils.tresp(
             status_code=200,
             headers=header_map({"content-type": "application/json"}),
@@ -1467,13 +1469,13 @@ class TestResponseHandler:
     def test_401_firewall_cache_invalidation(self, real_flow, mitm_ctx, headers):
         """401 response with firewall_base pops the cache entry and marks force-refresh (#9860)."""
         flow = real_flow(with_response=False, host="api.github.com")
-        flow.metadata["vm_run_id"] = "run-conn-1"
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-conn-1"
 
-        flow.metadata["vm_network_log_path"] = ""
-        flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["firewall_base"] = "https://api.github.com"
-        flow.metadata["firewall_api_id"] = "run-conn-1:0"
-        flow.metadata["original_url"] = "https://api.github.com/repos"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = ""
+        flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+        flow.metadata[metadata_keys.FIREWALL_BASE] = "https://api.github.com"
+        flow.metadata[metadata_keys.FIREWALL_API_ID] = "run-conn-1:0"
+        flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.github.com/repos"
 
         flow.response = tutils.tresp(status_code=401, headers=http.Headers())
 
@@ -1495,13 +1497,13 @@ class TestResponseHandler:
     ):
         """Malformed log-only response size metadata must not block 401 auth recovery."""
         flow = real_flow(with_response=False, host="api.github.com")
-        flow.metadata["vm_run_id"] = "run-conn-invalid-length"
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-conn-invalid-length"
 
-        flow.metadata["vm_network_log_path"] = ""
-        flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["firewall_base"] = "https://api.github.com"
-        flow.metadata["firewall_api_id"] = "run-conn-invalid-length:0"
-        flow.metadata["original_url"] = "https://api.github.com/repos"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = ""
+        flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+        flow.metadata[metadata_keys.FIREWALL_BASE] = "https://api.github.com"
+        flow.metadata[metadata_keys.FIREWALL_API_ID] = "run-conn-invalid-length:0"
+        flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.github.com/repos"
 
         flow.response = tutils.tresp(
             status_code=401,
@@ -1523,13 +1525,13 @@ class TestResponseHandler:
         """Malformed network-log response size metadata must not block 401 auth recovery."""
         flow = real_flow(with_response=False, host="api.github.com")
         log_path = str(tmp_path / "network.jsonl")
-        flow.metadata["vm_run_id"] = "run-conn-invalid-length-log"
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-conn-invalid-length-log"
 
-        flow.metadata["vm_network_log_path"] = log_path
-        flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["firewall_base"] = "https://api.github.com"
-        flow.metadata["firewall_api_id"] = "run-conn-invalid-length-log:0"
-        flow.metadata["original_url"] = "https://api.github.com/repos"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
+        flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+        flow.metadata[metadata_keys.FIREWALL_BASE] = "https://api.github.com"
+        flow.metadata[metadata_keys.FIREWALL_API_ID] = "run-conn-invalid-length-log:0"
+        flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.github.com/repos"
 
         flow.response = tutils.tresp(
             status_code=401,
@@ -1550,12 +1552,12 @@ class TestResponseHandler:
     def test_401_without_existing_state_marks_force_refresh(self, real_flow, mitm_ctx, headers):
         """401 should request a forced refresh even if no cache entry exists yet."""
         flow = real_flow(with_response=False, host="api.github.com")
-        flow.metadata["vm_run_id"] = "run-conn-new"
-        flow.metadata["vm_network_log_path"] = ""
-        flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["firewall_base"] = "https://api.github.com"
-        flow.metadata["firewall_api_id"] = "run-conn-new:0"
-        flow.metadata["original_url"] = "https://api.github.com/repos"
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-conn-new"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = ""
+        flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+        flow.metadata[metadata_keys.FIREWALL_BASE] = "https://api.github.com"
+        flow.metadata[metadata_keys.FIREWALL_API_ID] = "run-conn-new:0"
+        flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.github.com/repos"
         flow.response = tutils.tresp(status_code=401, headers=http.Headers())
 
         cache_key = ("run-conn-new", "run-conn-new:0")
@@ -1573,12 +1575,12 @@ class TestResponseHandler:
         level reject) would amplify into a loop of OAuth refresh calls and
         hit the provider's rate limits (#9860)."""
         flow = real_flow(with_response=False, host="api.github.com")
-        flow.metadata["vm_run_id"] = "run-conn-cd"
-        flow.metadata["vm_network_log_path"] = ""
-        flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["firewall_base"] = "https://api.github.com"
-        flow.metadata["firewall_api_id"] = "run-conn-cd:0"
-        flow.metadata["original_url"] = "https://api.github.com/repos"
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-conn-cd"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = ""
+        flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+        flow.metadata[metadata_keys.FIREWALL_BASE] = "https://api.github.com"
+        flow.metadata[metadata_keys.FIREWALL_API_ID] = "run-conn-cd:0"
+        flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.github.com/repos"
         flow.response = tutils.tresp(status_code=401, headers=http.Headers())
 
         cache_key = ("run-conn-cd", "run-conn-cd:0")
@@ -1600,12 +1602,12 @@ class TestResponseHandler:
         rate limit only throttles, it doesn't permanently lock out real
         token-invalidation recovery (#9860)."""
         flow = real_flow(with_response=False, host="api.github.com")
-        flow.metadata["vm_run_id"] = "run-conn-re"
-        flow.metadata["vm_network_log_path"] = ""
-        flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["firewall_base"] = "https://api.github.com"
-        flow.metadata["firewall_api_id"] = "run-conn-re:0"
-        flow.metadata["original_url"] = "https://api.github.com/repos"
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-conn-re"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = ""
+        flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+        flow.metadata[metadata_keys.FIREWALL_BASE] = "https://api.github.com"
+        flow.metadata[metadata_keys.FIREWALL_API_ID] = "run-conn-re:0"
+        flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.github.com/repos"
         flow.response = tutils.tresp(status_code=401, headers=http.Headers())
 
         cache_key = ("run-conn-re", "run-conn-re:0")
@@ -1624,14 +1626,16 @@ class TestResponseHandler:
     def test_error_status_logs_warning(self, tmp_path, real_flow, headers):
         """Response with status >= 400 writes to per-job proxy log."""
         flow = real_flow(with_response=False, host="api.example.com")
-        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
 
         proxy_log = tmp_path / "proxy-run-abc-123.jsonl"
-        flow.metadata["vm_network_log_path"] = ""
-        flow.metadata["vm_proxy_log_path"] = str(proxy_log)
-        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = ""
+        flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = str(proxy_log)
+        flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
         flow.metadata["firewall_rule"] = "domain:*.example.com"
-        flow.metadata["original_url"] = "https://api.example.com/fail?api_key=secret#frag"
+        flow.metadata[metadata_keys.ORIGINAL_URL] = (
+            "https://api.example.com/fail?api_key=secret#frag"
+        )
 
         flow.response = tutils.tresp(status_code=500, headers=http.Headers())
 
@@ -1657,13 +1661,13 @@ class TestResponseHandler:
     def test_response_releases_streaming_state(self, tmp_path, real_flow, mitm_ctx):
         """The completed response hook must not retain parser/buffer closures."""
         flow = real_flow(with_response=False, host="api.anthropic.com")
-        flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
-        flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
-        flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["original_url"] = "https://api.anthropic.com/v1/messages"
-        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
-        flow.metadata["firewall_billable"] = True
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = str(tmp_path / "network.jsonl")
+        flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = str(tmp_path / "proxy.jsonl")
+        flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+        flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.anthropic.com/v1/messages"
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
         flow.response = tutils.tresp(
             status_code=200,
             headers=header_map({"content-type": "application/json"}),
@@ -1676,16 +1680,16 @@ class TestResponseHandler:
             mitm_addon.response(flow)
 
         assert flow.response.stream is False
-        assert "stream_buffer" not in flow.metadata
-        assert "stream_buffer_state" not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
         assert "model_json_usage_finish" not in flow.metadata
 
     def test_response_without_run_id_releases_x_json_streaming_state(self, real_flow):
         """Even early-returning flows should not retain response parser closures."""
         flow = real_flow(with_response=False, host="api.x.com", path="/2/tweets")
-        flow.metadata["firewall_name"] = "x"
-        flow.metadata["firewall_billable"] = True
-        flow.metadata["original_url"] = "https://api.x.com/2/tweets"
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "x"
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
+        flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.x.com/2/tweets"
         flow.response = tutils.tresp(
             status_code=200,
             headers=header_map({"content-type": "application/json"}),
@@ -1698,8 +1702,8 @@ class TestResponseHandler:
         mitm_addon.response(flow)
 
         assert flow.response.stream is False
-        assert "stream_buffer" not in flow.metadata
-        assert "stream_buffer_state" not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
         assert "connector_response_finish" not in flow.metadata
 
     def test_response_without_run_id_releases_request_stream_state(self, real_flow):
@@ -1738,10 +1742,10 @@ class TestResponseHandler:
     def test_response_without_run_id_releases_sse_streaming_state(self, real_flow):
         """Early-returning SSE flows should not retain parser closures."""
         flow = real_flow(with_response=False, host="api.openai.com")
-        flow.metadata["firewall_name"] = "model-provider:openai-api-key"
-        flow.metadata["cli_agent_type"] = "codex"
-        flow.metadata["firewall_billable"] = True
-        flow.metadata["model_usage_provider"] = "gpt-5.5"
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:openai-api-key"
+        flow.metadata[metadata_keys.CLI_AGENT_TYPE] = "codex"
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
+        flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "gpt-5.5"
         flow.response = tutils.tresp(
             status_code=200,
             headers=header_map({"content-type": "text/event-stream"}),
@@ -1757,8 +1761,8 @@ class TestResponseHandler:
         mitm_addon.response(flow)
 
         assert flow.response.stream is False
-        assert "stream_buffer" not in flow.metadata
-        assert "stream_buffer_state" not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
         assert "model_sse_usage_finish" not in flow.metadata
 
     def test_response_does_not_clear_external_stream_callback(self, tmp_path, real_flow, mitm_ctx):
@@ -1769,10 +1773,10 @@ class TestResponseHandler:
         def external_stream(chunk):
             return chunk
 
-        flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_network_log_path"] = log_path
-        flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["original_url"] = "https://api.example.com/"
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
+        flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+        flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.example.com/"
         flow.response = tutils.tresp(status_code=200)
         flow.response.stream = external_stream
 
@@ -1788,13 +1792,13 @@ class TestResponseHandler:
         def external_stream(chunk):
             return chunk
 
-        flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
-        flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
-        flow.metadata["firewall_action"] = "ALLOW"
-        flow.metadata["original_url"] = "https://api.anthropic.com/v1/messages"
-        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
-        flow.metadata["firewall_billable"] = True
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = str(tmp_path / "network.jsonl")
+        flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = str(tmp_path / "proxy.jsonl")
+        flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+        flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.anthropic.com/v1/messages"
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
         flow.response = tutils.tresp(
             status_code=200,
             headers=header_map({"content-type": "application/json"}),
@@ -1809,5 +1813,5 @@ class TestResponseHandler:
             mitm_addon.response(flow)
 
         assert flow.response.stream is external_stream
-        assert "stream_buffer" not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
         assert "model_json_usage_finish" not in flow.metadata

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -1632,7 +1632,6 @@ class TestResponseHandler:
         flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = ""
         flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = str(proxy_log)
         flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
-        flow.metadata["firewall_rule"] = "domain:*.example.com"
         flow.metadata[metadata_keys.ORIGINAL_URL] = (
             "https://api.example.com/fail?api_key=secret#frag"
         )

--- a/crates/runner/mitm-addon/tests/test_response_headers_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_headers_handler.py
@@ -2,6 +2,7 @@
 
 from mitmproxy.test import tutils
 
+import flow_metadata_keys as metadata_keys
 import mitm_addon
 from tests.flow_helpers import header_map, response_stream
 
@@ -19,9 +20,9 @@ class TestResponseHeadersHandler:
         mitm_addon.responseheaders(flow)
 
         assert callable(response_stream(flow))
-        assert "stream_buffer" in flow.metadata
-        assert isinstance(flow.metadata["stream_buffer"], bytearray)
-        assert "stream_buffer_state" in flow.metadata
+        assert metadata_keys.STREAM_BUFFER in flow.metadata
+        assert isinstance(flow.metadata[metadata_keys.STREAM_BUFFER], bytearray)
+        assert metadata_keys.STREAM_BUFFER_STATE in flow.metadata
 
     def test_capture_body_also_streams(self, real_flow):
         """When capture_body is set, streaming should still be enabled."""
@@ -29,13 +30,13 @@ class TestResponseHeadersHandler:
         flow.response = tutils.tresp(
             status_code=200, headers=header_map({"content-type": "application/json"})
         )
-        flow.metadata["capture_body"] = True
+        flow.metadata[metadata_keys.CAPTURE_BODY] = True
 
         mitm_addon.responseheaders(flow)
 
         assert callable(response_stream(flow))
-        assert "stream_buffer" in flow.metadata
-        assert "stream_buffer_state" in flow.metadata
+        assert metadata_keys.STREAM_BUFFER in flow.metadata
+        assert metadata_keys.STREAM_BUFFER_STATE in flow.metadata
 
     def test_no_response_is_noop(self, real_flow):
         """Flow without response should not raise."""

--- a/crates/runner/mitm-addon/tests/test_response_streaming.py
+++ b/crates/runner/mitm-addon/tests/test_response_streaming.py
@@ -7,6 +7,7 @@ import pytest
 from mitmproxy import http
 from mitmproxy.test import tutils
 
+import flow_metadata_keys as metadata_keys
 import mitm_addon
 import response_streaming
 from body_limits import LARGE_RESPONSE_DECOMPRESS_LIMIT, STREAM_BUFFER_LIMIT
@@ -34,8 +35,8 @@ class TestResponseStreamBuffer:
         callback = response_stream(flow)
         assert callback(b"hello ") == b"hello "
         assert callback(b"world") == b"world"
-        assert bytes(flow.metadata["stream_buffer"]) == b"hello world"
-        assert flow.metadata["stream_buffer_state"]["truncated"] is False
+        assert bytes(flow.metadata[metadata_keys.STREAM_BUFFER]) == b"hello world"
+        assert flow.metadata[metadata_keys.STREAM_BUFFER_STATE]["truncated"] is False
 
     def test_stream_callback_stops_buffering_at_limit(self, real_flow):
         flow = self._json_response_flow(real_flow)
@@ -45,12 +46,12 @@ class TestResponseStreamBuffer:
         callback = response_stream(flow)
         chunk = b"x" * STREAM_BUFFER_LIMIT
         assert callback(chunk) == chunk
-        assert len(flow.metadata["stream_buffer"]) == STREAM_BUFFER_LIMIT
-        assert flow.metadata["stream_buffer_state"]["truncated"] is False
+        assert len(flow.metadata[metadata_keys.STREAM_BUFFER]) == STREAM_BUFFER_LIMIT
+        assert flow.metadata[metadata_keys.STREAM_BUFFER_STATE]["truncated"] is False
 
         assert callback(b"overflow") == b"overflow"
-        assert len(flow.metadata["stream_buffer"]) == STREAM_BUFFER_LIMIT
-        assert flow.metadata["stream_buffer_state"]["truncated"] is True
+        assert len(flow.metadata[metadata_keys.STREAM_BUFFER]) == STREAM_BUFFER_LIMIT
+        assert flow.metadata[metadata_keys.STREAM_BUFFER_STATE]["truncated"] is True
 
     def test_stream_callback_large_single_chunk(self, real_flow):
         flow = self._json_response_flow(real_flow)
@@ -60,8 +61,8 @@ class TestResponseStreamBuffer:
         callback = response_stream(flow)
         big_chunk = b"A" * (STREAM_BUFFER_LIMIT + 1000)
         assert callback(big_chunk) == big_chunk
-        assert len(flow.metadata["stream_buffer"]) == STREAM_BUFFER_LIMIT
-        assert flow.metadata["stream_buffer_state"]["truncated"] is True
+        assert len(flow.metadata[metadata_keys.STREAM_BUFFER]) == STREAM_BUFFER_LIMIT
+        assert flow.metadata[metadata_keys.STREAM_BUFFER_STATE]["truncated"] is True
 
     def test_stream_callback_partial_fill_then_overflow(self, real_flow):
         flow = self._json_response_flow(real_flow)
@@ -71,14 +72,14 @@ class TestResponseStreamBuffer:
         callback = response_stream(flow)
         half = STREAM_BUFFER_LIMIT // 2
         callback(b"A" * half)
-        assert flow.metadata["stream_buffer_state"]["truncated"] is False
+        assert flow.metadata[metadata_keys.STREAM_BUFFER_STATE]["truncated"] is False
 
         callback(b"B" * STREAM_BUFFER_LIMIT)
         remaining = STREAM_BUFFER_LIMIT - half
-        assert len(flow.metadata["stream_buffer"]) == STREAM_BUFFER_LIMIT
-        assert flow.metadata["stream_buffer"][:half] == bytearray(b"A" * half)
-        assert flow.metadata["stream_buffer"][half:] == bytearray(b"B" * remaining)
-        assert flow.metadata["stream_buffer_state"]["truncated"] is True
+        assert len(flow.metadata[metadata_keys.STREAM_BUFFER]) == STREAM_BUFFER_LIMIT
+        assert flow.metadata[metadata_keys.STREAM_BUFFER][:half] == bytearray(b"A" * half)
+        assert flow.metadata[metadata_keys.STREAM_BUFFER][half:] == bytearray(b"B" * remaining)
+        assert flow.metadata[metadata_keys.STREAM_BUFFER_STATE]["truncated"] is True
 
     def test_stream_callback_empty_chunk(self, real_flow):
         flow = self._json_response_flow(real_flow)
@@ -87,11 +88,11 @@ class TestResponseStreamBuffer:
 
         callback = response_stream(flow)
         assert callback(b"") == b""
-        assert len(flow.metadata["stream_buffer"]) == 0
-        assert flow.metadata["stream_buffer_state"]["truncated"] is False
+        assert len(flow.metadata[metadata_keys.STREAM_BUFFER]) == 0
+        assert flow.metadata[metadata_keys.STREAM_BUFFER_STATE]["truncated"] is False
 
         callback(b"hello")
-        assert bytes(flow.metadata["stream_buffer"]) == b"hello"
+        assert bytes(flow.metadata[metadata_keys.STREAM_BUFFER]) == b"hello"
 
     def test_non_model_provider_buffer_truncated(self, real_flow):
         flow = self._json_response_flow(real_flow, host="api.github.com")
@@ -100,21 +101,21 @@ class TestResponseStreamBuffer:
 
         response_stream(flow)(b"x" * (STREAM_BUFFER_LIMIT + 1000))
 
-        assert len(flow.metadata["stream_buffer"]) == STREAM_BUFFER_LIMIT
-        assert flow.metadata["stream_buffer_state"]["truncated"] is True
+        assert len(flow.metadata[metadata_keys.STREAM_BUFFER]) == STREAM_BUFFER_LIMIT
+        assert flow.metadata[metadata_keys.STREAM_BUFFER_STATE]["truncated"] is True
 
     def test_non_x_billable_connector_uses_bounded_forensic_buffer(self, real_flow):
         flow = self._json_response_flow(real_flow, host="api.gamma.example")
-        flow.metadata["firewall_name"] = "gamma"
-        flow.metadata["firewall_billable"] = True
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "gamma"
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
 
         mitm_addon.responseheaders(flow)
 
         response_stream(flow)(b"g" * (STREAM_BUFFER_LIMIT + 1000))
 
-        assert len(flow.metadata["stream_buffer"]) == STREAM_BUFFER_LIMIT
-        assert flow.metadata["stream_buffer_state"]["truncated"] is True
-        assert "x_ndjson_state" not in flow.metadata
+        assert len(flow.metadata[metadata_keys.STREAM_BUFFER]) == STREAM_BUFFER_LIMIT
+        assert flow.metadata[metadata_keys.STREAM_BUFFER_STATE]["truncated"] is True
+        assert metadata_keys.X_NDJSON_STATE not in flow.metadata
         assert "connector_response_finish" not in flow.metadata
 
 
@@ -128,7 +129,7 @@ class TestNdjsonExtractor:
 
     def _stream_parser(self, real_flow):
         flow = self._stream_flow(real_flow)
-        return response_stream(flow), flow.metadata["x_ndjson_state"]
+        return response_stream(flow), flow.metadata[metadata_keys.X_NDJSON_STATE]
 
     def test_single_line(self, real_flow):
         parse, state = self._stream_parser(real_flow)
@@ -149,12 +150,12 @@ class TestNdjsonExtractor:
     def test_forensic_buffer_truncation_does_not_stop_parser(self, real_flow):
         flow = self._stream_flow(real_flow)
         parse = response_stream(flow)
-        state = flow.metadata["x_ndjson_state"]
+        state = flow.metadata[metadata_keys.X_NDJSON_STATE]
 
         parse(b'{"data":{"id":"1"}}\n' + b"x" * (200 * 1024))
 
-        assert len(flow.metadata["stream_buffer"]) == STREAM_BUFFER_LIMIT
-        assert flow.metadata["stream_buffer_state"]["truncated"] is True
+        assert len(flow.metadata[metadata_keys.STREAM_BUFFER]) == STREAM_BUFFER_LIMIT
+        assert flow.metadata[metadata_keys.STREAM_BUFFER_STATE]["truncated"] is True
         assert state["data_count"] == 1
         assert "connector_response_finish" in flow.metadata
 
@@ -176,7 +177,7 @@ class TestNdjsonExtractor:
         mid = len(compressed) // 2
         response_stream(flow)(compressed[:mid])
         response_stream(flow)(compressed[mid:])
-        state = flow.metadata["x_ndjson_state"]
+        state = flow.metadata[metadata_keys.X_NDJSON_STATE]
         assert state["data_count"] == 3
         assert state["includes"] == {"users": 3}
         assert "connector_response_finish" in flow.metadata
@@ -239,7 +240,7 @@ class TestNdjsonExtractor:
     def test_complete_trailing_line_without_newline_counted_on_finish(self, real_flow):
         flow = self._stream_flow(real_flow)
         parse = response_stream(flow)
-        state = flow.metadata["x_ndjson_state"]
+        state = flow.metadata[metadata_keys.X_NDJSON_STATE]
 
         parse(b'{"data":{"id":"1"},"includes":{"users":[{"id":"u1"}]}}')
         response_streaming.finalize_connector_response_state(flow)
@@ -252,7 +253,7 @@ class TestNdjsonExtractor:
     def test_incomplete_trailing_line_without_newline_fails_on_finish(self, real_flow):
         flow = self._stream_flow(real_flow)
         parse = response_stream(flow)
-        state = flow.metadata["x_ndjson_state"]
+        state = flow.metadata[metadata_keys.X_NDJSON_STATE]
 
         parse(b'{"data":{"id":"1"}}\n{"data":{"id":"2"}')
         response_streaming.finalize_connector_response_state(flow)
@@ -265,7 +266,7 @@ class TestNdjsonExtractor:
     def test_blank_trailing_line_ignored_on_finish(self, real_flow, tail):
         flow = self._stream_flow(real_flow)
         parse = response_stream(flow)
-        state = flow.metadata["x_ndjson_state"]
+        state = flow.metadata[metadata_keys.X_NDJSON_STATE]
 
         parse(b'{"data":{"id":"1"}}\n' + tail)
         response_streaming.finalize_connector_response_state(flow)
@@ -277,7 +278,7 @@ class TestNdjsonExtractor:
     def test_trailing_line_finish_is_idempotent(self, real_flow):
         flow = self._stream_flow(real_flow)
         parse = response_stream(flow)
-        state = flow.metadata["x_ndjson_state"]
+        state = flow.metadata[metadata_keys.X_NDJSON_STATE]
 
         parse(b'{"data":{"id":"1"}}')
         response_streaming.finalize_connector_response_state(flow)
@@ -290,7 +291,7 @@ class TestNdjsonExtractor:
     def test_oversized_line_tail_not_counted_on_finish(self, real_flow):
         flow = self._stream_flow(real_flow)
         parse = response_stream(flow)
-        state = flow.metadata["x_ndjson_state"]
+        state = flow.metadata[metadata_keys.X_NDJSON_STATE]
         big = b"x" * _OVERSIZED_NDJSON_LINE_BYTES
 
         parse(big)
@@ -414,7 +415,7 @@ class TestXJsonFinalize:
 
         response_streaming.finalize_connector_response_state(flow)
 
-        assert "x_json_state" not in flow.metadata
+        assert metadata_keys.X_JSON_STATE not in flow.metadata
 
     def test_finalizes_successful_x_json_state(self, real_flow):
         flow = self._billable_x_json_flow(real_flow)
@@ -424,14 +425,14 @@ class TestXJsonFinalize:
         response_stream(flow)(b'{"data":[{"id":"1"}]}')
         response_streaming.finalize_connector_response_state(flow)
 
-        state = dict(flow.metadata["x_json_state"])
+        state = dict(flow.metadata[metadata_keys.X_JSON_STATE])
         assert "connector_response_finish" not in flow.metadata
         assert state["body_parsed"] is True
         assert state["response_data_count"] == 1
         assert "parse_error" not in state
 
         response_streaming.finalize_connector_response_state(flow)
-        assert flow.metadata["x_json_state"] == state
+        assert flow.metadata[metadata_keys.X_JSON_STATE] == state
 
     def test_forensic_buffer_truncation_does_not_stop_x_json_parser(self, real_flow):
         flow = make_x_response_flow(
@@ -450,10 +451,10 @@ class TestXJsonFinalize:
         )
         response_streaming.finalize_connector_response_state(flow)
 
-        assert len(flow.metadata["stream_buffer"]) == STREAM_BUFFER_LIMIT
-        assert flow.metadata["stream_buffer_state"]["truncated"] is True
-        assert "x_ndjson_state" not in flow.metadata
-        state = flow.metadata["x_json_state"]
+        assert len(flow.metadata[metadata_keys.STREAM_BUFFER]) == STREAM_BUFFER_LIMIT
+        assert flow.metadata[metadata_keys.STREAM_BUFFER_STATE]["truncated"] is True
+        assert metadata_keys.X_NDJSON_STATE not in flow.metadata
+        state = flow.metadata[metadata_keys.X_JSON_STATE]
         assert state["body_parsed"] is True
         assert state["response_data_count"] == 1
         assert state["response_includes"] == {"users": 1}
@@ -472,7 +473,7 @@ class TestXJsonFinalize:
 
         response_stream(flow)(gzip.compress(body))
         response_streaming.finalize_connector_response_state(flow)
-        state = flow.metadata["x_json_state"]
+        state = flow.metadata[metadata_keys.X_JSON_STATE]
         assert state["response_data_count"] == 2
         assert state["response_includes"] == {"users": 1}
         assert state["response_result_count"] == 2
@@ -495,7 +496,7 @@ class TestXJsonFinalize:
         response_stream(flow)(compressed)
         response_streaming.finalize_connector_response_state(flow)
 
-        state = flow.metadata["x_json_state"]
+        state = flow.metadata[metadata_keys.X_JSON_STATE]
         assert state["body_parsed"] is True
         assert state["response_data_count"] == 2
         assert state["response_includes"] == {"users": 1}
@@ -510,14 +511,14 @@ class TestXJsonFinalize:
         response_stream(flow)(b'{"data":[1')
         response_streaming.finalize_connector_response_state(flow)
 
-        state = dict(flow.metadata["x_json_state"])
+        state = dict(flow.metadata[metadata_keys.X_JSON_STATE])
         assert "connector_response_finish" not in flow.metadata
         assert state["body_parsed"] is False
         assert isinstance(state["parse_error"], str)
         assert state["parse_error"]
 
         response_streaming.finalize_connector_response_state(flow)
-        assert flow.metadata["x_json_state"] == state
+        assert flow.metadata[metadata_keys.X_JSON_STATE] == state
 
     def test_finalizes_non_object_x_json_without_parse_error(self, real_flow):
         flow = self._billable_x_json_flow(real_flow)
@@ -527,7 +528,7 @@ class TestXJsonFinalize:
         response_stream(flow)(b"[1,2,3]")
         response_streaming.finalize_connector_response_state(flow)
 
-        state = flow.metadata["x_json_state"]
+        state = flow.metadata[metadata_keys.X_JSON_STATE]
         assert "connector_response_finish" not in flow.metadata
         assert state["body_parsed"] is False
         assert "parse_error" not in state
@@ -542,16 +543,16 @@ class TestResponseHeadersModelJsonParser:
             status_code=200,
             headers=header_map({"content-type": "application/json", "content-encoding": "br"}),
         )
-        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
-        flow.metadata["firewall_billable"] = True
-        flow.metadata["model_usage_provider"] = "claude-sonnet-4-6"
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
+        flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "claude-sonnet-4-6"
 
         with mitm_ctx() as log:
             mitm_addon.responseheaders(flow)
 
         assert callable(response_stream(flow))
         assert "model_json_usage_finish" not in flow.metadata
-        assert "model_provider_usage" not in flow.metadata
+        assert metadata_keys.MODEL_PROVIDER_USAGE not in flow.metadata
         assert any(
             "Streaming decompression skipped (br)" in call.args[0]
             for call in log.debug.call_args_list
@@ -566,14 +567,14 @@ class TestResponseHeadersSseParser:
         flow.response = tutils.tresp(
             status_code=200, headers=header_map({"content-type": "text/event-stream"})
         )
-        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
-        flow.metadata["firewall_billable"] = True
-        flow.metadata["model_usage_provider"] = "claude-sonnet-4-6"
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
+        flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "claude-sonnet-4-6"
 
         mitm_addon.responseheaders(flow)
 
-        assert "model_provider_usage" in flow.metadata
-        assert isinstance(flow.metadata["model_provider_usage"], dict)
+        assert metadata_keys.MODEL_PROVIDER_USAGE in flow.metadata
+        assert isinstance(flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE], dict)
         assert "model_sse_usage_finish" in flow.metadata
         assert "model_json_usage_finish" not in flow.metadata
         # Feed SSE data through the callback
@@ -584,8 +585,8 @@ class TestResponseHeadersSseParser:
             b'{"model":"claude-sonnet-4-6",'
             b'"usage":{"input_tokens":42}}}\n\n'
         )
-        assert flow.metadata["model_provider_usage"]["model"] == "claude-sonnet-4-6"
-        assert flow.metadata["model_provider_usage"]["tokens.input"] == 42
+        assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]["model"] == "claude-sonnet-4-6"
+        assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]["tokens.input"] == 42
 
     def test_sets_up_sse_parser_with_case_insensitive_content_type(self, real_flow):
         flow = real_flow(with_response=False, host="api.openai.com")
@@ -593,22 +594,22 @@ class TestResponseHeadersSseParser:
             status_code=200,
             headers=header_map({"content-type": "Text/Event-Stream"}),
         )
-        flow.metadata["firewall_name"] = "model-provider:openai-api-key"
-        flow.metadata["cli_agent_type"] = "codex"
-        flow.metadata["firewall_billable"] = True
-        flow.metadata["model_usage_provider"] = "gpt-5.5"
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:openai-api-key"
+        flow.metadata[metadata_keys.CLI_AGENT_TYPE] = "codex"
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
+        flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "gpt-5.5"
 
         mitm_addon.responseheaders(flow)
 
-        assert "model_provider_usage" in flow.metadata
+        assert metadata_keys.MODEL_PROVIDER_USAGE in flow.metadata
         callback = response_stream(flow)
         callback(
             b"event: response.completed\n"
             b'data: {"response":{"model":"gpt-5.5",'
             b'"usage":{"output_tokens":5}}}\n\n'
         )
-        assert flow.metadata["model_provider_usage"]["model"] == "gpt-5.5"
-        assert flow.metadata["model_provider_usage"]["tokens.output"] == 5
+        assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]["model"] == "gpt-5.5"
+        assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]["tokens.output"] == 5
 
     def test_finalizes_sse_parser_for_trailing_event_without_blank_line(self, real_flow):
         flow = real_flow(with_response=False, host="api.openai.com")
@@ -616,10 +617,10 @@ class TestResponseHeadersSseParser:
             status_code=200,
             headers=header_map({"content-type": "text/event-stream"}),
         )
-        flow.metadata["firewall_name"] = "model-provider:openai-api-key"
-        flow.metadata["cli_agent_type"] = "codex"
-        flow.metadata["firewall_billable"] = True
-        flow.metadata["model_usage_provider"] = "gpt-5.5"
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:openai-api-key"
+        flow.metadata[metadata_keys.CLI_AGENT_TYPE] = "codex"
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
+        flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "gpt-5.5"
 
         mitm_addon.responseheaders(flow)
 
@@ -629,12 +630,12 @@ class TestResponseHeadersSseParser:
             b'data: {"response":{"model":"gpt-5.5",'
             b'"usage":{"output_tokens":7}}}\n'
         )
-        assert flow.metadata["model_provider_usage"] == {}
+        assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == {}
 
         response_streaming.finalize_model_sse_usage(flow)
 
-        assert flow.metadata["model_provider_usage"]["model"] == "gpt-5.5"
-        assert flow.metadata["model_provider_usage"]["tokens.output"] == 7
+        assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]["model"] == "gpt-5.5"
+        assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]["tokens.output"] == 7
 
     def test_sets_up_openai_sse_parser_for_openai_model_provider(self, real_flow, headers):
         flow = real_flow(with_response=False, host="api.openai.com")
@@ -642,14 +643,14 @@ class TestResponseHeadersSseParser:
             status_code=200,
             headers=header_map({"content-type": "text/event-stream"}),
         )
-        flow.metadata["firewall_name"] = "model-provider:openai-api-key"
-        flow.metadata["cli_agent_type"] = "codex"
-        flow.metadata["firewall_billable"] = True
-        flow.metadata["model_usage_provider"] = "gpt-5.5"
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:openai-api-key"
+        flow.metadata[metadata_keys.CLI_AGENT_TYPE] = "codex"
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
+        flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "gpt-5.5"
 
         mitm_addon.responseheaders(flow)
 
-        assert "model_provider_usage" in flow.metadata
+        assert metadata_keys.MODEL_PROVIDER_USAGE in flow.metadata
         callback = response_stream(flow)
         callback(
             b"event: response.completed\n"
@@ -657,9 +658,9 @@ class TestResponseHeadersSseParser:
             b'"usage":{"input_tokens":42,'
             b'"input_tokens_details":{"cached_tokens":12}}}}\n\n'
         )
-        assert flow.metadata["model_provider_usage"]["model"] == "gpt-5.5"
-        assert flow.metadata["model_provider_usage"]["tokens.input"] == 30
-        assert flow.metadata["model_provider_usage"]["tokens.cache_read"] == 12
+        assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]["model"] == "gpt-5.5"
+        assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]["tokens.input"] == 30
+        assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]["tokens.cache_read"] == 12
 
     def test_codex_oauth_model_provider_uses_openai_sse_parser(self, real_flow):
         flow = real_flow(with_response=False, host="chatgpt.com")
@@ -667,14 +668,14 @@ class TestResponseHeadersSseParser:
             status_code=200,
             headers=header_map({"content-type": "text/event-stream"}),
         )
-        flow.metadata["firewall_name"] = "model-provider:codex-oauth-token"
-        flow.metadata["cli_agent_type"] = "codex"
-        flow.metadata["firewall_billable"] = True
-        flow.metadata["model_usage_provider"] = "gpt-5.5"
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:codex-oauth-token"
+        flow.metadata[metadata_keys.CLI_AGENT_TYPE] = "codex"
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
+        flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "gpt-5.5"
 
         mitm_addon.responseheaders(flow)
 
-        assert "model_provider_usage" in flow.metadata
+        assert metadata_keys.MODEL_PROVIDER_USAGE in flow.metadata
         callback = response_stream(flow)
         callback(
             b"event: response.completed\n"
@@ -682,9 +683,9 @@ class TestResponseHeadersSseParser:
             b'"usage":{"input_tokens":42,'
             b'"input_tokens_details":{"cached_tokens":12}}}}\n\n'
         )
-        assert flow.metadata["model_provider_usage"]["model"] == "gpt-5.5"
-        assert flow.metadata["model_provider_usage"]["tokens.input"] == 30
-        assert flow.metadata["model_provider_usage"]["tokens.cache_read"] == 12
+        assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]["model"] == "gpt-5.5"
+        assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]["tokens.input"] == 30
+        assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]["tokens.cache_read"] == 12
 
     @pytest.mark.parametrize("cli_agent_type", [None, ""])
     def test_default_cli_agent_type_uses_anthropic_sse_parser(self, real_flow, cli_agent_type):
@@ -693,11 +694,11 @@ class TestResponseHeadersSseParser:
             status_code=200,
             headers=header_map({"content-type": "text/event-stream"}),
         )
-        flow.metadata["firewall_name"] = "model-provider:codex-oauth-token"
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:codex-oauth-token"
         if cli_agent_type is not None:
-            flow.metadata["cli_agent_type"] = cli_agent_type
-        flow.metadata["firewall_billable"] = True
-        flow.metadata["model_usage_provider"] = "claude-sonnet-4-6"
+            flow.metadata[metadata_keys.CLI_AGENT_TYPE] = cli_agent_type
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
+        flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "claude-sonnet-4-6"
 
         mitm_addon.responseheaders(flow)
 
@@ -708,8 +709,8 @@ class TestResponseHeadersSseParser:
             b'{"model":"claude-sonnet-4-6",'
             b'"usage":{"input_tokens":42}}}\n\n'
         )
-        assert flow.metadata["model_provider_usage"]["model"] == "claude-sonnet-4-6"
-        assert flow.metadata["model_provider_usage"]["tokens.input"] == 42
+        assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]["model"] == "claude-sonnet-4-6"
+        assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]["tokens.input"] == 42
 
     def test_decompresses_gzip_sse_before_parsing(self, real_flow, headers):
         """Compressed SSE streams must be decompressed before usage extraction."""
@@ -723,13 +724,13 @@ class TestResponseHeadersSseParser:
                 }
             ),
         )
-        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
-        flow.metadata["firewall_billable"] = True
-        flow.metadata["model_usage_provider"] = "claude-sonnet-4-6"
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
+        flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "claude-sonnet-4-6"
 
         mitm_addon.responseheaders(flow)
 
-        assert "model_provider_usage" in flow.metadata
+        assert metadata_keys.MODEL_PROVIDER_USAGE in flow.metadata
         callback = response_stream(flow)
         plaintext = (
             b"event: message_start\n"
@@ -742,42 +743,42 @@ class TestResponseHeadersSseParser:
         result = callback(compressed)
         assert result == compressed
         # But parser receives decompressed data
-        assert flow.metadata["model_provider_usage"]["model"] == "claude-sonnet-4-6"
-        assert flow.metadata["model_provider_usage"]["tokens.input"] == 99
+        assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]["model"] == "claude-sonnet-4-6"
+        assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]["tokens.input"] == 99
 
     def test_no_sse_parser_for_non_model_provider(self, real_flow, headers):
         flow = real_flow(with_response=False, host="api.github.com")
         flow.response = tutils.tresp(
             status_code=200, headers=header_map({"content-type": "text/event-stream"})
         )
-        flow.metadata["firewall_name"] = "github"
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "github"
 
         mitm_addon.responseheaders(flow)
 
-        assert "model_provider_usage" not in flow.metadata
+        assert metadata_keys.MODEL_PROVIDER_USAGE not in flow.metadata
 
     def test_no_sse_parser_for_non_sse_response(self, real_flow, headers):
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.response = tutils.tresp(
             status_code=200, headers=header_map({"content-type": "application/json"})
         )
-        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
 
         mitm_addon.responseheaders(flow)
 
-        assert "model_provider_usage" not in flow.metadata
+        assert metadata_keys.MODEL_PROVIDER_USAGE not in flow.metadata
 
     def test_no_sse_parser_without_model_usage_provider(self, real_flow, headers):
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.response = tutils.tresp(
             status_code=200, headers=header_map({"content-type": "text/event-stream"})
         )
-        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
-        flow.metadata["firewall_billable"] = True
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
 
         mitm_addon.responseheaders(flow)
 
-        assert "model_provider_usage" not in flow.metadata
+        assert metadata_keys.MODEL_PROVIDER_USAGE not in flow.metadata
 
     def test_sets_up_sse_parser_for_non_billable_observable_model_provider(
         self, real_flow, headers
@@ -786,14 +787,14 @@ class TestResponseHeadersSseParser:
         flow.response = tutils.tresp(
             status_code=200, headers=header_map({"content-type": "text/event-stream"})
         )
-        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
-        flow.metadata["firewall_billable"] = False
-        flow.metadata["model_usage_provider"] = "claude-sonnet-4-6"
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = False
+        flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "claude-sonnet-4-6"
 
         mitm_addon.responseheaders(flow)
 
-        assert "model_provider_usage" in flow.metadata
-        assert isinstance(flow.metadata["model_provider_usage"], dict)
+        assert metadata_keys.MODEL_PROVIDER_USAGE in flow.metadata
+        assert isinstance(flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE], dict)
         assert "model_sse_usage_finish" in flow.metadata
 
     def test_no_sse_parser_without_firewall_name(self, real_flow, headers):
@@ -805,7 +806,7 @@ class TestResponseHeadersSseParser:
 
         mitm_addon.responseheaders(flow)
 
-        assert "model_provider_usage" not in flow.metadata
+        assert metadata_keys.MODEL_PROVIDER_USAGE not in flow.metadata
 
     @pytest.mark.parametrize("firewall_name", [None, 42])
     def test_malformed_firewall_name_skips_usage_parsers(self, real_flow, firewall_name):
@@ -817,11 +818,11 @@ class TestResponseHeadersSseParser:
 
         mitm_addon.responseheaders(flow)
 
-        assert "model_provider_usage" not in flow.metadata
+        assert metadata_keys.MODEL_PROVIDER_USAGE not in flow.metadata
         assert "model_json_usage_finish" not in flow.metadata
         assert "model_sse_usage_finish" not in flow.metadata
         assert "connector_response_finish" not in flow.metadata
-        assert "x_ndjson_state" not in flow.metadata
+        assert metadata_keys.X_NDJSON_STATE not in flow.metadata
 
 
 class TestReleaseResponseStreamState:
@@ -845,8 +846,8 @@ class TestReleaseResponseStreamState:
 
         assert flow.response.stream is external_stream
         assert "_vm0_response_stream_callback" not in flow.metadata
-        assert "stream_buffer" not in flow.metadata
-        assert "stream_buffer_state" not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
 
     @pytest.mark.parametrize(
         ("host", "path", "response_content_type", "metadata", "finish_key"),
@@ -856,9 +857,9 @@ class TestReleaseResponseStreamState:
                 "/v1/messages",
                 "application/json",
                 {
-                    "firewall_name": "model-provider:anthropic-api-key",
-                    "firewall_billable": True,
-                    "model_usage_provider": "claude-sonnet-4-6",
+                    metadata_keys.FIREWALL_NAME: "model-provider:anthropic-api-key",
+                    metadata_keys.FIREWALL_BILLABLE: True,
+                    metadata_keys.MODEL_USAGE_PROVIDER: "claude-sonnet-4-6",
                 },
                 "model_json_usage_finish",
                 id="model-json",
@@ -868,10 +869,10 @@ class TestReleaseResponseStreamState:
                 "/v1/responses",
                 "text/event-stream",
                 {
-                    "firewall_name": "model-provider:openai-api-key",
-                    "cli_agent_type": "codex",
-                    "firewall_billable": True,
-                    "model_usage_provider": "gpt-5.5",
+                    metadata_keys.FIREWALL_NAME: "model-provider:openai-api-key",
+                    metadata_keys.CLI_AGENT_TYPE: "codex",
+                    metadata_keys.FIREWALL_BILLABLE: True,
+                    metadata_keys.MODEL_USAGE_PROVIDER: "gpt-5.5",
                 },
                 "model_sse_usage_finish",
                 id="model-sse",
@@ -881,9 +882,9 @@ class TestReleaseResponseStreamState:
                 "/2/tweets",
                 "application/json",
                 {
-                    "firewall_name": "x",
-                    "firewall_billable": True,
-                    "original_url": "https://api.x.com/2/tweets",
+                    metadata_keys.FIREWALL_NAME: "x",
+                    metadata_keys.FIREWALL_BILLABLE: True,
+                    metadata_keys.ORIGINAL_URL: "https://api.x.com/2/tweets",
                 },
                 "connector_response_finish",
                 id="x-json",
@@ -893,9 +894,9 @@ class TestReleaseResponseStreamState:
                 "/2/tweets/search/stream",
                 "application/json",
                 {
-                    "firewall_name": "x",
-                    "firewall_billable": True,
-                    "original_url": "https://api.x.com/2/tweets/search/stream",
+                    metadata_keys.FIREWALL_NAME: "x",
+                    metadata_keys.FIREWALL_BILLABLE: True,
+                    metadata_keys.ORIGINAL_URL: "https://api.x.com/2/tweets/search/stream",
                 },
                 "connector_response_finish",
                 id="x-ndjson",
@@ -924,8 +925,8 @@ class TestReleaseResponseStreamState:
         response_streaming.release_response_stream_state(flow)
 
         assert finish_key not in flow.metadata
-        assert "stream_buffer" not in flow.metadata
-        assert "stream_buffer_state" not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
         assert flow.response.stream is False
 
     def test_unconfigured_flow_is_noop(self, real_flow):
@@ -955,14 +956,14 @@ class TestReleaseResponseStreamState:
 
         assert flow.response.stream is False
         assert "_vm0_response_stream_callback" not in flow.metadata
-        assert "stream_buffer" not in flow.metadata
-        assert "stream_buffer_state" not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
 
     def test_release_after_response_is_removed_still_drops_metadata(self, real_flow):
         flow = real_flow(with_response=False, host="api.anthropic.com")
-        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
-        flow.metadata["firewall_billable"] = True
-        flow.metadata["model_usage_provider"] = "claude-sonnet-4-6"
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
+        flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "claude-sonnet-4-6"
         flow.response = tutils.tresp(
             status_code=200, headers=header_map({"content-type": "application/json"})
         )
@@ -977,6 +978,6 @@ class TestReleaseResponseStreamState:
 
         assert flow.response is None
         assert "_vm0_response_stream_callback" not in flow.metadata
-        assert "stream_buffer" not in flow.metadata
-        assert "stream_buffer_state" not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
         assert "model_json_usage_finish" not in flow.metadata

--- a/crates/runner/mitm-addon/tests/test_tcp_hooks.py
+++ b/crates/runner/mitm-addon/tests/test_tcp_hooks.py
@@ -45,8 +45,8 @@ class TestTcpStart:
         ):
             mitm_addon.tcp_start(flow)
 
-        assert flow.metadata["vm_run_id"] == "run-abc-123"
-        assert "vm_network_log_path" in flow.metadata
+        assert flow.metadata[metadata_keys.VM_RUN_ID] == "run-abc-123"
+        assert metadata_keys.VM_NETWORK_LOG_PATH in flow.metadata
         assert metadata_keys.TCP_START_MONOTONIC in flow.metadata
 
     def test_skips_when_no_client_ip(self, registry_file, mitm_ctx, real_tcp_flow):
@@ -58,7 +58,7 @@ class TestTcpStart:
         ):
             mitm_addon.tcp_start(flow)
 
-        assert "vm_run_id" not in flow.metadata
+        assert metadata_keys.VM_RUN_ID not in flow.metadata
 
     def test_skips_when_vm_not_registered(self, registry_file, mitm_ctx, real_tcp_flow):
         flow = real_tcp_flow(client_ip="192.168.99.99")
@@ -68,7 +68,7 @@ class TestTcpStart:
         ):
             mitm_addon.tcp_start(flow)
 
-        assert "vm_run_id" not in flow.metadata
+        assert metadata_keys.VM_RUN_ID not in flow.metadata
 
     def test_registry_unavailable_kills_flow(self, registry_file, mitm_ctx, real_tcp_flow):
         registry.load_registry(str(registry_file))
@@ -81,7 +81,7 @@ class TestTcpStart:
         assert flow.error is not None
         assert flow.error.msg == Error.KILLED_MESSAGE
         assert not flow.live
-        assert "vm_run_id" not in flow.metadata
+        assert metadata_keys.VM_RUN_ID not in flow.metadata
 
     def test_invalid_registered_vm_kills_flow(self, tmp_path, mitm_ctx, real_tcp_flow):
         registry_file = tmp_path / "registry.json"
@@ -94,15 +94,15 @@ class TestTcpStart:
         assert flow.error is not None
         assert flow.error.msg == Error.KILLED_MESSAGE
         assert not flow.live
-        assert "vm_run_id" not in flow.metadata
+        assert metadata_keys.VM_RUN_ID not in flow.metadata
 
 
 class TestTcpLog:
     def test_logs_tcp_connection(self, registry_file, tmp_path, mitm_ctx, real_tcp_flow):
         flow = real_tcp_flow(client_ip="10.200.0.1")
         log_path = str(tmp_path / "network.jsonl")
-        flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_network_log_path"] = log_path
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
         flow.metadata[metadata_keys.TCP_START_MONOTONIC] = time.monotonic() - 0.05
 
         with mitm_ctx():
@@ -123,8 +123,8 @@ class TestTcpLog:
     def test_logs_tcp_error(self, registry_file, tmp_path, mitm_ctx, real_tcp_flow):
         flow = real_tcp_flow(client_ip="10.200.0.1")
         log_path = str(tmp_path / "network.jsonl")
-        flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_network_log_path"] = log_path
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
         flow.metadata[metadata_keys.TCP_START_MONOTONIC] = time.monotonic()
         flow.error = Error("connection reset by peer")
 
@@ -138,7 +138,7 @@ class TestTcpLog:
     def test_skips_when_no_run_id(self, tmp_path, mitm_ctx, real_tcp_flow):
         flow = real_tcp_flow()
         log_path = str(tmp_path / "network.jsonl")
-        flow.metadata["vm_network_log_path"] = log_path
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
 
         with mitm_ctx():
             mitm_addon.tcp_end(flow)
@@ -149,8 +149,8 @@ class TestTcpLog:
     def test_handles_missing_server_addr(self, tmp_path, mitm_ctx, real_tcp_flow):
         flow = real_tcp_flow()
         log_path = str(tmp_path / "network.jsonl")
-        flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_network_log_path"] = log_path
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
         flow.metadata[metadata_keys.TCP_START_MONOTONIC] = time.monotonic()
         flow.server_conn = None
 
@@ -164,8 +164,8 @@ class TestTcpLog:
     def test_handles_missing_start_time(self, tmp_path, mitm_ctx, real_tcp_flow):
         flow = real_tcp_flow()
         log_path = str(tmp_path / "network.jsonl")
-        flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_network_log_path"] = log_path
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
 
         with mitm_ctx():
             mitm_addon.tcp_end(flow)
@@ -183,8 +183,8 @@ class TestTcpLog:
         ]
         flow = real_tcp_flow(messages=messages)
         log_path = str(tmp_path / "network.jsonl")
-        flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_network_log_path"] = log_path
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
         scheduled = _capture_tcp_drains(monkeypatch)
 
         with mitm_ctx():
@@ -214,8 +214,8 @@ class TestTcpLog:
         ]
         flow = real_tcp_flow(messages=messages)
         log_path = str(tmp_path / "network.jsonl")
-        flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_network_log_path"] = log_path
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
         scheduled = _capture_tcp_drains(monkeypatch)
 
         with mitm_ctx():
@@ -237,8 +237,8 @@ class TestTcpLog:
         first_server = tcp.TCPMessage(False, b"first-server")
         flow = real_tcp_flow(messages=[first_client, first_server])
         log_path = str(tmp_path / "network.jsonl")
-        flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_network_log_path"] = log_path
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
         scheduled = _capture_tcp_drains(monkeypatch)
 
         with mitm_ctx():
@@ -282,8 +282,8 @@ class TestTcpLog:
     def test_tcp_size_counter_saturates_at_network_log_max(self, tmp_path, mitm_ctx, real_tcp_flow):
         flow = real_tcp_flow(messages=[tcp.TCPMessage(True, b"overflow")])
         log_path = str(tmp_path / "network.jsonl")
-        flow.metadata["vm_run_id"] = "run-abc-123"
-        flow.metadata["vm_network_log_path"] = log_path
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = log_path
         flow.metadata[mitm_addon._TCP_REQUEST_SIZE] = mitm_addon._MAX_SAFE_NETWORK_LOG_SIZE - 1
 
         with mitm_ctx():

--- a/crates/runner/mitm-addon/tests/test_webhook.py
+++ b/crates/runner/mitm-addon/tests/test_webhook.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 
 import pytest
 
+import flow_metadata_keys as metadata_keys
 import platform_api
 import usage
 from tests.jsonl_log_helpers import (
@@ -53,11 +54,11 @@ class TestUsageWebhookDelivery:
     @staticmethod
     def _model_flow(real_flow, tmp_path):
         flow = real_flow(with_response=False, host="api.anthropic.com")
-        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
-        flow.metadata["firewall_billable"] = True
-        flow.metadata["vm_sandbox_token"] = "tok"
-        flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
-        flow.metadata["model_provider_usage"] = {"tokens.input": 100}
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
+        flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = "tok"
+        flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = str(tmp_path / "proxy.jsonl")
+        flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {"tokens.input": 100}
         return flow
 
     def test_post_webhook_does_not_follow_redirects(self, usage_webhook_server):
@@ -93,7 +94,10 @@ class TestUsageWebhookDelivery:
         self, tmp_path, real_flow, fresh_usage_executor, usage_webhook_api
     ):
         flow = self._model_flow(real_flow, tmp_path)
-        flow.metadata["model_provider_usage"] = {"model": "claude-sonnet-4-6", "tokens.input": 100}
+        flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {
+            "model": "claude-sonnet-4-6",
+            "tokens.input": 100,
+        }
 
         with usage_webhook_api() as webhook:
             usage.report_model_provider_usage(flow, "run-1")
@@ -123,7 +127,8 @@ class TestUsageWebhookDelivery:
         ]
         uuid.UUID(body["events"][0]["idempotencyKey"])
         payload_bytes = len(json.dumps(body).encode())
-        log_entries = read_jsonl_entries_after_flush(Path(flow.metadata["vm_proxy_log_path"]))
+        log_path = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
+        log_entries = read_jsonl_entries_after_flush(log_path)
         webhook_entries = [entry for entry in log_entries if entry["type"] == "usage_event"]
         assert len(webhook_entries) == 2
         assert {entry["level"] for entry in webhook_entries} == {"info"}
@@ -223,7 +228,7 @@ class TestUsageWebhookDelivery:
     ):
         """Default max_retries=1 -> 2 total attempts before giving up."""
         flow = self._model_flow(real_flow, tmp_path)
-        proxy_log = Path(flow.metadata["vm_proxy_log_path"])
+        proxy_log = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
 
         with (
             usage_webhook_api() as webhook,
@@ -550,7 +555,7 @@ class TestUsageWebhookDelivery:
         pending_path = tmp_path / "usage-pending"
         usage.set_pending_path(str(pending_path))
         flow = self._model_flow(real_flow, tmp_path)
-        flow.metadata["model_provider_usage"] = {"tokens.input": 42}
+        flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {"tokens.input": 42}
         usage.flush_usage_events(trigger="test")
         usage.webhook.usage_executor.shutdown(wait=True)
 

--- a/crates/runner/mitm-addon/tests/test_x_connector_pipeline.py
+++ b/crates/runner/mitm-addon/tests/test_x_connector_pipeline.py
@@ -9,6 +9,7 @@ import brotli
 import pytest
 from mitmproxy.flow import Error
 
+import flow_metadata_keys as metadata_keys
 import mitm_addon
 import usage
 from body_limits import STREAM_BUFFER_LIMIT
@@ -62,8 +63,8 @@ class TestXConnectorResponsePipeline:
         callback(b'{"data":[{"id":"1","text":"')
         callback(b"x" * (STREAM_BUFFER_LIMIT + 4096))
         callback(b'"}],"includes":{"users":[{"id":"u1"}]},"meta":{"result_count":1}}')
-        assert len(flow.metadata["stream_buffer"]) == STREAM_BUFFER_LIMIT
-        assert flow.metadata["stream_buffer_state"]["truncated"] is True
+        assert len(flow.metadata[metadata_keys.STREAM_BUFFER]) == STREAM_BUFFER_LIMIT
+        assert flow.metadata[metadata_keys.STREAM_BUFFER_STATE]["truncated"] is True
 
         with self._usage_webhook_api() as webhook:
             mitm_addon.response(flow)
@@ -90,7 +91,7 @@ class TestXConnectorResponsePipeline:
         by_category = {event["category"]: event["quantity"] for event in payloads}
         assert by_category == {"posts.read": 1, "user.read": 1}
         assert "connector_response_finish" not in flow.metadata
-        assert "x_ndjson_state" not in flow.metadata
+        assert metadata_keys.X_NDJSON_STATE not in flow.metadata
         assert log.debug.call_count == 1
         assert "Streaming decompression skipped (br)" in log.debug.call_args[0][0]
 
@@ -105,7 +106,7 @@ class TestXConnectorResponsePipeline:
             mitm_addon.responseheaders(flow)
 
         assert "connector_response_finish" not in flow.metadata
-        assert "x_ndjson_state" not in flow.metadata
+        assert metadata_keys.X_NDJSON_STATE not in flow.metadata
         assert log.debug.call_count == 1
         assert "Streaming decompression skipped (br)" in log.debug.call_args[0][0]
 
@@ -138,7 +139,7 @@ class TestXConnectorResponsePipeline:
             usage.flush_usage_events(trigger="test")
 
         assert webhook.request_count == 0
-        proxy_log = Path(flow.metadata["vm_proxy_log_path"])
+        proxy_log = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
         entries = read_jsonl_entries_after_flush(proxy_log)
         lost_visibility_entries = [
             entry for entry in entries if "unparseable" in entry["message"].lower()
@@ -226,7 +227,7 @@ class TestXConnectorResponsePipeline:
         # 1. responseheaders - registers NDJSON parser
         mitm_addon.responseheaders(flow)
         callback = response_stream(flow)
-        assert "x_ndjson_state" in flow.metadata
+        assert metadata_keys.X_NDJSON_STATE in flow.metadata
         assert "connector_response_finish" in flow.metadata
 
         # 2. Stream chunks (including keep-alives and a mid-line split)
@@ -289,7 +290,7 @@ class TestXConnectorResponsePipeline:
                 b'{"data":{"id":"1"},"includes":{"users":[{"id":"u1"}]}}\n{"data":{"id":"2"}}\n'
             )[:-1]
         )
-        assert flow.metadata["x_ndjson_state"]["data_count"] == 2
+        assert flow.metadata[metadata_keys.X_NDJSON_STATE]["data_count"] == 2
         flow.error = Error("connection reset by peer")
 
         with usage_webhook_api() as webhook:
@@ -298,8 +299,8 @@ class TestXConnectorResponsePipeline:
             usage.webhook.usage_executor.shutdown(wait=True)
 
         assert webhook.request_count == 0
-        assert "x_ndjson_state" not in flow.metadata
-        proxy_log = Path(flow.metadata["vm_proxy_log_path"])
+        assert metadata_keys.X_NDJSON_STATE not in flow.metadata
+        proxy_log = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
         entries = read_jsonl_entries_after_flush(proxy_log)
         lost_visibility_entries = [
             entry for entry in entries if "unparseable" in entry["message"].lower()
@@ -315,7 +316,7 @@ class TestXConnectorResponsePipeline:
 
         mitm_addon.responseheaders(flow)
         callback = response_stream(flow)
-        assert "x_ndjson_state" in flow.metadata
+        assert metadata_keys.X_NDJSON_STATE in flow.metadata
         assert "connector_response_finish" in flow.metadata
 
         callback(
@@ -324,7 +325,7 @@ class TestXConnectorResponsePipeline:
             b'"tweets":{"id":"t1"},'
             b'"media":[{"media_key":"m1"}]}}\n'
         )
-        state = flow.metadata["x_ndjson_state"]
+        state = flow.metadata[metadata_keys.X_NDJSON_STATE]
         assert state["data_count"] == 1
         assert state["includes"] == {"media": 1}
         assert state["lines_parsed"] == 1
@@ -357,7 +358,7 @@ class TestXConnectorResponsePipeline:
 
         callback(failed_line + b'\n{"data":{"id":"1"},"includes":{"users":[{"id":"u1"}]}}\n')
 
-        state = flow.metadata["x_ndjson_state"]
+        state = flow.metadata[metadata_keys.X_NDJSON_STATE]
         assert state["lines_failed"] == 1
         assert state["lines_parsed"] == 1
         assert state["data_count"] == 1
@@ -389,7 +390,7 @@ class TestXConnectorResponsePipeline:
                 + b'":[{"id":"u"}]}}\n'
             )
         callback(b'{"data":{"id":"known"},"includes":{"users":[{"id":"user"}]}}\n')
-        state = flow.metadata["x_ndjson_state"]
+        state = flow.metadata[metadata_keys.X_NDJSON_STATE]
         assert state["unknown_includes_overflow_count"] == 6
         assert state["includes"]["users"] == 1
 
@@ -430,7 +431,7 @@ class TestXConnectorResponsePipeline:
             mitm_addon.response(flow)
 
         assert webhook.request_count == 0
-        proxy_log = Path(flow.metadata["vm_proxy_log_path"])
+        proxy_log = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
         entries = read_jsonl_entries_after_flush(proxy_log)
         lost_visibility_entries = [
             entry for entry in entries if "unparseable" in entry["message"].lower()
@@ -458,13 +459,13 @@ class TestXConnectorResponsePipeline:
 
         mitm_addon.responseheaders(flow)
         response_stream(flow)(b'{"data":[{"id":"1"},' + b" " * STREAM_BUFFER_LIMIT)
-        assert flow.metadata["stream_buffer_state"]["truncated"] is True
+        assert flow.metadata[metadata_keys.STREAM_BUFFER_STATE]["truncated"] is True
 
         with self._usage_webhook_api() as webhook:
             mitm_addon.response(flow)
 
         assert webhook.request_count == 0
-        proxy_log = Path(flow.metadata["vm_proxy_log_path"])
+        proxy_log = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
         entries = read_jsonl_entries_after_flush(proxy_log)
         lost_visibility_entries = [
             entry for entry in entries if "unparseable" in entry["message"].lower()
@@ -499,7 +500,7 @@ class TestXConnectorResponsePipeline:
         assert len(events) == 1
         assert events[0]["category"] == "posts.read"
         assert events[0]["quantity"] == 3
-        proxy_log = Path(flow.metadata["vm_proxy_log_path"])
+        proxy_log = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
         entries = read_jsonl_entries_after_flush(proxy_log)
         assert all(entry["level"] != "error" for entry in entries)
         assert all("unparseable" not in entry["message"].lower() for entry in entries)
@@ -515,7 +516,7 @@ class TestXConnectorErrorPipeline:
     ):
         """Mid-flight stream crash: partial counts still reported (issue #9534)."""
         flow = make_x_stream_pipeline_flow(real_flow, tmp_path)
-        flow.metadata["x_ndjson_state"] = {
+        flow.metadata[metadata_keys.X_NDJSON_STATE] = {
             "data_count": 23,
             "includes": {"users": 5},
             "lines_parsed": 23,
@@ -549,7 +550,7 @@ class TestXConnectorErrorPipeline:
         # 1. Register parser
         mitm_addon.responseheaders(flow)
         callback = response_stream(flow)
-        assert "x_ndjson_state" in flow.metadata
+        assert metadata_keys.X_NDJSON_STATE in flow.metadata
 
         # 2. Receive two complete tweets, then a partial third (cut off)
         callback(b'{"data":{"id":"1"},"includes":{"users":[{"id":"u1"}]}}\n')

--- a/crates/runner/mitm-addon/tests/x_connector_usage/test_guards.py
+++ b/crates/runner/mitm-addon/tests/x_connector_usage/test_guards.py
@@ -2,6 +2,7 @@
 
 import json
 
+import flow_metadata_keys as metadata_keys
 from tests.jsonl_log_helpers import jsonl_exists_after_flush, read_jsonl_entries_after_flush
 
 
@@ -29,7 +30,7 @@ def test_skips_on_empty_run_id(x_usage, tmp_path, real_flow):
 def test_skips_when_not_billable(x_usage, tmp_path, real_flow):
     """Firewalls with firewall_billable=False are not reported."""
     flow = x_usage.make_flow(real_flow, tmp_path)
-    flow.metadata["firewall_billable"] = False
+    flow.metadata[metadata_keys.FIREWALL_BILLABLE] = False
     assert x_usage.call_and_get_billing(flow) == []
 
 
@@ -45,7 +46,7 @@ def test_skips_webhook_without_sandbox_token(x_usage, tmp_path, real_flow):
     flow = x_usage.make_flow(
         real_flow, tmp_path, path="/2/tweets/1", body=body, rule="GET /2/tweets/{id}"
     )
-    flow.metadata["vm_sandbox_token"] = ""
+    flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = ""
     assert x_usage.call_and_get_billing(flow) == []
 
     proxy_log = tmp_path / "proxy.jsonl"
@@ -74,7 +75,7 @@ def test_zero_count_without_sandbox_token_does_not_log_underbilling(x_usage, tmp
         body=body,
         rule="GET /2/tweets/search/recent",
     )
-    flow.metadata["vm_sandbox_token"] = ""
+    flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = ""
 
     assert x_usage.call_and_get_billing(flow) == []
     assert not jsonl_exists_after_flush(tmp_path / "proxy.jsonl")
@@ -91,7 +92,7 @@ def test_unparseable_no_hints_without_sandbox_token_logs_only_visibility_loss(
         body=b"not json",
         rule="GET /2/tweets/search/recent",
     )
-    flow.metadata["vm_sandbox_token"] = ""
+    flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = ""
 
     assert x_usage.call_and_get_billing(flow) == []
 

--- a/crates/runner/mitm-addon/tests/x_connector_usage/test_reads.py
+++ b/crates/runner/mitm-addon/tests/x_connector_usage/test_reads.py
@@ -5,6 +5,7 @@ import json
 
 import pytest
 
+import flow_metadata_keys as metadata_keys
 import usage
 from tests.jsonl_log_helpers import (
     jsonl_exists_after_flush,
@@ -535,7 +536,9 @@ def test_query_string_does_not_break_literal_suffix_override(x_usage, tmp_path, 
     )
     # The ?max_results metadata goes into original_url for
     # req-meta parsing to consume.
-    flow.metadata["original_url"] = "https://api.x.com/2/tweets/123/retweeted_by?max_results=10"
+    flow.metadata[metadata_keys.ORIGINAL_URL] = (
+        "https://api.x.com/2/tweets/123/retweeted_by?max_results=10"
+    )
     p = x_usage.call_and_get_single_billing(flow)
     assert p["category"] == "user.read"
     assert p["quantity"] == 2

--- a/crates/runner/mitm-addon/tests/x_connector_usage/test_unparseable.py
+++ b/crates/runner/mitm-addon/tests/x_connector_usage/test_unparseable.py
@@ -4,6 +4,7 @@ import json
 
 import pytest
 
+import flow_metadata_keys as metadata_keys
 import usage
 from tests.jsonl_log_helpers import (
     jsonl_exists_after_flush,
@@ -23,7 +24,7 @@ def test_logs_x_stream_with_ndjson_state(x_usage, tmp_path, real_flow):
         body=b"",
         rule="GET /2/tweets/search/stream",
     )
-    flow.metadata["x_ndjson_state"] = {
+    flow.metadata[metadata_keys.X_NDJSON_STATE] = {
         "data_count": 50,
         "includes": {"users": 47, "tweets": 12},
         "lines_parsed": 50,
@@ -46,7 +47,7 @@ def test_x_stream_empty_emits_no_billing(x_usage, tmp_path, real_flow):
         body=b"",
         rule="GET /2/tweets/search/stream",
     )
-    flow.metadata["x_ndjson_state"] = {
+    flow.metadata[metadata_keys.X_NDJSON_STATE] = {
         "data_count": 0,
         "includes": {},
         "lines_parsed": 0,
@@ -145,7 +146,7 @@ def test_unparseable_no_hints_writes_error_to_proxy_log(x_usage, tmp_path, real_
         body=b"not json",
         rule="GET /2/tweets/search/recent",
     )
-    flow.metadata["original_url"] = (
+    flow.metadata[metadata_keys.ORIGINAL_URL] = (
         f"https://api.x.com:8443/2/tweets/search/recent?query={sensitive_query}"
     )
     proxy_log = tmp_path / "proxy.jsonl"
@@ -178,7 +179,7 @@ def test_unparseable_no_hints_without_proxy_log_path_logs_stderr(
         body=b"not json",
         rule="GET /2/tweets/search/recent",
     )
-    flow.metadata["vm_proxy_log_path"] = ""
+    flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = ""
 
     with mitm_ctx(api_url="https://api.vm0.ai") as log:
         usage.report_connector_usage(flow, "run-abc-123")
@@ -201,7 +202,7 @@ def test_unparseable_x_json_state_logs_parse_error(x_usage, tmp_path, real_flow)
         path="/2/tweets/search/recent",
         rule="GET /2/tweets/search/recent",
     )
-    flow.metadata["x_json_state"] = {
+    flow.metadata[metadata_keys.X_JSON_STATE] = {
         "body_parsed": False,
         "body_truncated": False,
         "parse_error": "incomplete json",
@@ -230,7 +231,7 @@ def test_unparseable_x_json_state_omits_invalid_parse_error(
         path="/2/tweets/search/recent",
         rule="GET /2/tweets/search/recent",
     )
-    flow.metadata["x_json_state"] = {
+    flow.metadata[metadata_keys.X_JSON_STATE] = {
         "body_parsed": False,
         "body_truncated": False,
         "parse_error": parse_error,
@@ -528,7 +529,7 @@ def test_x_json_parse_error_with_request_hints_uses_fallback_without_error_log(
         permission=permission,
         rule=rule,
     )
-    flow.metadata["x_json_state"] = {
+    flow.metadata[metadata_keys.X_JSON_STATE] = {
         "body_parsed": False,
         "body_truncated": False,
         "parse_error": "incomplete json",
@@ -555,7 +556,7 @@ def test_x_json_parse_error_with_zero_max_results_is_no_reliable_hint(x_usage, t
         query="query=hello&max_results=0",
         rule="GET /2/tweets/search/recent",
     )
-    flow.metadata["x_json_state"] = {
+    flow.metadata[metadata_keys.X_JSON_STATE] = {
         "body_parsed": False,
         "body_truncated": False,
         "parse_error": "incomplete json",

--- a/crates/runner/mitm-addon/tests/x_connector_usage/test_writes.py
+++ b/crates/runner/mitm-addon/tests/x_connector_usage/test_writes.py
@@ -57,7 +57,7 @@ def test_x_json_parse_error_on_write_does_not_emit_lost_visibility_log(
         rule="POST /2/tweets",
     )
     flow.request.method = "POST"
-    flow.metadata["x_json_state"] = {
+    flow.metadata[metadata_keys.X_JSON_STATE] = {
         "body_parsed": False,
         "body_truncated": False,
         "parse_error": "incomplete json",
@@ -354,7 +354,9 @@ def test_non_refinement_flow_does_not_decode_request_body(x_usage, tmp_path, rea
         request_body=b"not gzip request content",
         request_encoding="gzip",
     )
-    flow.metadata["original_url"] = "https://api.x.com/2/tweets/123/retweeted_by?max_results=10"
+    flow.metadata[metadata_keys.ORIGINAL_URL] = (
+        "https://api.x.com/2/tweets/123/retweeted_by?max_results=10"
+    )
 
     # The billing payload cannot prove this negative side effect: the decoder
     # fails closed, so a regression that decodes non-refinement request bodies

--- a/crates/runner/mitm-addon/tests/x_flow_helpers.py
+++ b/crates/runner/mitm-addon/tests/x_flow_helpers.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from mitmproxy import http
 from mitmproxy.test import tutils
 
+import flow_metadata_keys as metadata_keys
 from tests.flow_helpers import header_map
 from tests.stream_buffer_helpers import set_response_stream_buffer
 
@@ -52,9 +53,9 @@ def make_x_response_flow(
         request_body=request_body,
         request_encoding=request_encoding,
     )
-    flow.metadata["firewall_name"] = firewall_name
-    flow.metadata["firewall_billable"] = firewall_billable
-    flow.metadata["original_url"] = (
+    flow.metadata[metadata_keys.FIREWALL_NAME] = firewall_name
+    flow.metadata[metadata_keys.FIREWALL_BILLABLE] = firewall_billable
+    flow.metadata[metadata_keys.ORIGINAL_URL] = (
         original_url if original_url is not None else x_original_url(path)
     )
     response_headers = {"content-type": content_type}
@@ -90,10 +91,10 @@ def make_x_usage_flow(
         request_body=request_body,
         request_encoding=request_encoding,
     )
-    flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
-    flow.metadata["vm_sandbox_token"] = "test-token"
-    flow.metadata["firewall_permission"] = permission
-    flow.metadata["firewall_rule_match"] = rule
+    flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = str(tmp_path / "proxy.jsonl")
+    flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = "test-token"
+    flow.metadata[metadata_keys.FIREWALL_PERMISSION] = permission
+    flow.metadata[metadata_keys.FIREWALL_RULE_MATCH] = rule
     set_response_stream_buffer(flow, body)
     return flow
 
@@ -122,13 +123,13 @@ def make_x_pipeline_flow(
         content_type=content_type,
         content_encoding=content_encoding,
     )
-    flow.metadata["vm_run_id"] = vm_run_id
-    flow.metadata["vm_network_log_path"] = str(tmp_path / "network.jsonl")
-    flow.metadata["vm_proxy_log_path"] = str(tmp_path / "proxy.jsonl")
-    flow.metadata["vm_sandbox_token"] = sandbox_value
-    flow.metadata["firewall_action"] = firewall_action
-    flow.metadata["firewall_permission"] = permission
-    flow.metadata["firewall_rule_match"] = rule
+    flow.metadata[metadata_keys.VM_RUN_ID] = vm_run_id
+    flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = str(tmp_path / "network.jsonl")
+    flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = str(tmp_path / "proxy.jsonl")
+    flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = sandbox_value
+    flow.metadata[metadata_keys.FIREWALL_ACTION] = firewall_action
+    flow.metadata[metadata_keys.FIREWALL_PERMISSION] = permission
+    flow.metadata[metadata_keys.FIREWALL_RULE_MATCH] = rule
     return flow
 
 

--- a/docs/testing/mitm-addon-testing.md
+++ b/docs/testing/mitm-addon-testing.md
@@ -136,14 +136,17 @@ metadata semantics, while still letting the test seed metadata for later hook
 phases:
 
 ```python
+import flow_metadata_keys as metadata_keys
+
+
 def test_firewall_response_logs_context(tmp_path, real_flow, mitm_ctx):
     flow = real_flow(with_response=True, host="api.github.com", path="/repos")
     flow.metadata.update(
         {
-            "vm_run_id": "run-abc-123",
-            "vm_network_log_path": str(tmp_path / "network.jsonl"),
-            "original_url": "https://api.github.com/repos",
-            "firewall_action": "ALLOW",
+            metadata_keys.VM_RUN_ID: "run-abc-123",
+            metadata_keys.VM_NETWORK_LOG_PATH: str(tmp_path / "network.jsonl"),
+            metadata_keys.ORIGINAL_URL: "https://api.github.com/repos",
+            metadata_keys.FIREWALL_ACTION: "ALLOW",
         }
     )
 
@@ -177,6 +180,9 @@ shared `fake_firewall_headers` fixture to stub the auth-service boundary while
 still running the real dispatcher and firewall handler:
 
 ```python
+import flow_metadata_keys as metadata_keys
+
+
 async def test_firewall_request_injects_auth(
     tmp_path, real_flow, mitm_ctx, fake_firewall_headers
 ):
@@ -190,7 +196,7 @@ async def test_firewall_request_injects_auth(
         await mitm_addon.request(flow)
 
     assert flow.request.headers["Authorization"] == "Bearer real-token"
-    assert flow.metadata["firewall_action"] == "ALLOW"
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
 ```
 
 Avoid patching internal handlers only to prove they were called. Assert the flow
@@ -202,10 +208,13 @@ hook path.
 Check flow metadata and response after handler execution:
 
 ```python
+import flow_metadata_keys as metadata_keys
+
+
 # Service auth injected
 assert flow.request.headers["Authorization"] == "Bearer real-token"
-assert flow.metadata["firewall_action"] == "ALLOW"
-assert flow.metadata["firewall_base"] == "https://api.github.com"
+assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+assert flow.metadata[metadata_keys.FIREWALL_BASE] == "https://api.github.com"
 ```
 
 ### Shared Flow Metadata Keys


### PR DESCRIPTION
## Summary
- replace registered mitm-addon flow.metadata key literals in tests with flow_metadata_keys constants
- add an AST guard that rejects direct registered key literals on .metadata access
- update mitm-addon testing docs and developer comments to avoid teaching raw shared metadata key access

## Boundary
- external log, webhook, fixture, and payload schema fields remain string literals
- hook-local private metadata markers that are not registered shared keys remain local/raw

Closes #18811

## Tests
- cd crates/runner/mitm-addon && ruff check .
- cd crates/runner/mitm-addon && ruff format --check .
- cd crates/runner/mitm-addon && npx --yes basedpyright -p .
- cd crates/runner/mitm-addon && pytest tests/test_flow_metadata_key_contract.py
- cd crates/runner/mitm-addon && pytest tests/test_flow_metadata_key_contract.py tests/test_tcp_hooks.py tests/x_connector_usage/ tests/test_x_connector_pipeline.py tests/test_response_handler.py tests/test_error_handler.py tests/test_request_handler_firewall_dispatch.py tests/test_request_handler_passthrough.py tests/test_firewall_auth.py
- cd crates/runner/mitm-addon && pytest tests/