### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1246,7 +1246,7 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "guest-agent"
-version = "0.41.4"
+version = "0.41.3"
 dependencies = [
  "agent-diagnostics",
  "aho-corasick",
@@ -1320,7 +1320,7 @@ dependencies = [
 
 [[package]]
 name = "guest-init"
-version = "0.16.87"
+version = "0.16.86"
 dependencies = [
  "libc",
  "nix",
@@ -1915,9 +1915,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2528,7 +2528,7 @@ dependencies = [
 
 [[package]]
 name = "runner"
-version = "0.129.16"
+version = "0.129.15"
 dependencies = [
  "ably-subscriber",
  "agent-diagnostics",
@@ -2749,7 +2749,7 @@ dependencies = [
 
 [[package]]
 name = "sandbox-fc"
-version = "0.37.61"
+version = "0.37.60"
 dependencies = [
  "async-trait",
  "base64",
@@ -3028,7 +3028,7 @@ dependencies = [
 
 [[package]]
 name = "shell-quote"
-version = "0.1.1"
+version = "0.1.0"
 
 [[package]]
 name = "shlex"
@@ -3641,9 +3641,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.3"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -3672,7 +3672,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vsock-guest"
-version = "0.19.7"
+version = "0.19.6"
 dependencies = [
  "guest-contracts",
  "libc",
@@ -3683,7 +3683,7 @@ dependencies = [
 
 [[package]]
 name = "vsock-host"
-version = "0.17.43"
+version = "0.17.42"
 dependencies = [
  "nix",
  "shell-quote",
@@ -3701,7 +3701,7 @@ version = "0.18.17"
 
 [[package]]
 name = "vsock-test"
-version = "0.9.112"
+version = "0.9.111"
 dependencies = [
  "guest-write-file",
  "libc",
@@ -3750,9 +3750,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3763,9 +3763,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.75"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3773,9 +3773,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3783,9 +3783,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3796,18 +3796,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",


### PR DESCRIPTION
## Summary
- Ran `cargo update --verbose` in the `crates/` Rust workspace.
- Updated 8 lockfile dependencies:
  - `js-sys` 0.3.102 -> 0.3.103
  - `uuid` 1.23.3 -> 1.23.4
  - `wasm-bindgen` 0.2.125 -> 0.2.126
  - `wasm-bindgen-futures` 0.4.75 -> 0.4.76
  - `wasm-bindgen-macro` 0.2.125 -> 0.2.126
  - `wasm-bindgen-macro-support` 0.2.125 -> 0.2.126
  - `wasm-bindgen-shared` 0.2.125 -> 0.2.126
  - `web-sys` 0.3.102 -> 0.3.103
- Checked direct workspace dependencies against crates.io for safe same-major minor/patch updates; none required a `Cargo.toml` version-specifier bump.

## Dependencies not updated
- `generic-array` stayed at 0.14.7 while 0.14.9 is available. It is transitive and pinned by `crypto-common v0.1.7`, which requires `generic-array = "=0.14.7"`; there is no local `Cargo.toml` constraint to safely adjust.

## Manual version bumps
- None.

## Tests
- `cargo fmt --all --check`: passed.
- `cargo test --workspace`: first attempt failed because `/tmp` ran out of disk space while compiling.
- `CARGO_TARGET_DIR=/home/user/workspace/vm0-rust-deps-target cargo test --workspace -j 1`: built and ran the workspace; non-`runner` crates passed, but the `runner` binary failed under this runtime's default `umask=0002` because temporary directories were created as mode `775` and runner security checks reject group/other-writable temp directories without the sticky bit.
- Re-ran the already-linked `runner` test binary with `umask 077` and a private `TMPDIR`: passed (`2080 passed, 0 failed, 2 ignored`). No dependency-related test failures were observed.