### PR TITLE
fix: improve Computer Use authorization host selection

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/computer-use.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/computer-use.bdd.test.ts
@@ -283,6 +283,89 @@ describe("FILE-03 desktop computer-use runtime", () => {
     expect(completed.completedAt).not.toBeNull();
   });
 
+  it("only exposes online hosts for delegated authorization requests", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const actor = bdd.user({ orgId });
+    await enableComputerUseDelegatedAuthorization(actor);
+    const run = await seedZeroRun({ actor, triggerSource: "web" });
+    if (!run.threadId) {
+      throw new Error("Expected web run fixture to create a chat thread");
+    }
+
+    const base = now();
+    mockNow(base);
+    const staleHost = await api.startComputerUseHost(actor, {
+      hostName: "Stale Mac",
+    });
+    const stoppedHost = await api.startComputerUseHost(actor, {
+      installationId: randomUUID(),
+      hostName: "Closed Mac",
+    });
+    await api.stopComputerUseHost(stoppedHost.hostToken);
+
+    mockNow(base + 120_000);
+    const onlineHost = await api.startComputerUseHost(actor, {
+      hostName: "Studio Mac",
+    });
+    mockClerkMembership(context, actor, "org:admin");
+    const token = zeroComputerUseToken({
+      userId: actor.userId,
+      orgId,
+      runId: run.runId,
+      capabilities: ["connector:read"],
+    }).token;
+
+    const created = await api.createComputerUseAuthorizationRequest({
+      bearer: token,
+    });
+    const requestToken = requestTokenFromUrl(created.authorizationUrl);
+    const readable = await api.readComputerUseAuthorizationRequest(
+      actor,
+      requestToken,
+    );
+    expect(
+      readable.hosts.map((host) => {
+        return host.id;
+      }),
+    ).toStrictEqual([onlineHost.hostId]);
+
+    const staleApply = await api.requestApplyComputerUseAuthorizationRequest(
+      actor,
+      requestToken,
+      staleHost.hostId,
+      [404],
+    );
+    expectApiError(staleApply.body);
+    expect(staleApply.body.error.message).toBe("Computer-use host not found");
+
+    const stoppedApply = await api.requestApplyComputerUseAuthorizationRequest(
+      actor,
+      requestToken,
+      stoppedHost.hostId,
+      [404],
+    );
+    expectApiError(stoppedApply.body);
+    expect(stoppedApply.body.error.message).toBe("Computer-use host not found");
+
+    const applied = await api.applyComputerUseAuthorizationRequest(
+      actor,
+      requestToken,
+      onlineHost.hostId,
+    );
+    expect(applied).toStrictEqual({
+      ok: true,
+      source: "chat",
+      computerUseHostId: onlineHost.hostId,
+    });
+
+    const writeDb = store.set(writeDb$);
+    const [thread] = await writeDb
+      .select({ computerUseHostId: chatThreads.computerUseHostId })
+      .from(chatThreads)
+      .where(eq(chatThreads.id, run.threadId));
+    expect(thread).toStrictEqual({ computerUseHostId: onlineHost.hostId });
+  });
+
   it("creates a delegated authorization link and applies the selected host to the Slack thread", async () => {
     const orgId = `org_${randomUUID()}`;
     const actor = bdd.user({ orgId });

--- a/turbo/apps/api/src/signals/services/zero-computer-use-authorization.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-computer-use-authorization.service.ts
@@ -22,7 +22,10 @@ import { env } from "../../lib/env";
 import { nowDate } from "../../lib/time";
 import { writeDb$, type Db } from "../external/db";
 import { slackOrgCallbackPayloadSchema } from "./slack-org-callback-payload";
-import { listComputerUseHosts$ } from "./zero-computer-use.service";
+import {
+  computerUseHostIsOnline,
+  listComputerUseHosts$,
+} from "./zero-computer-use.service";
 
 const COMPUTER_USE_AUTHORIZATION_REQUEST_TTL_MS = 60 * 60 * 1000;
 const COMPUTER_USE_AUTHORIZATION_URL_PREFIX =
@@ -204,14 +207,19 @@ async function loadRequestByToken(args: {
   return { status: "found", request };
 }
 
-async function hostExists(args: {
+async function onlineHostExists(args: {
   readonly db: Db;
   readonly orgId: string;
   readonly userId: string;
   readonly hostId: string;
+  readonly now: Date;
 }): Promise<boolean> {
   const [host] = await args.db
-    .select({ id: computerUseHosts.id })
+    .select({
+      lastSeenAt: computerUseHosts.lastSeenAt,
+      revokedAt: computerUseHosts.revokedAt,
+      status: computerUseHosts.status,
+    })
     .from(computerUseHosts)
     .where(
       and(
@@ -222,7 +230,7 @@ async function hostExists(args: {
       ),
     )
     .limit(1);
-  return host !== undefined;
+  return host !== undefined && computerUseHostIsOnline(host, args.now);
 }
 
 async function slackScopeExists(args: {
@@ -341,7 +349,9 @@ export const readComputerUseAuthorizationRequest$ = command(
       source: loaded.request.source as ComputerUseAuthorizationSource,
       expiresAt: loaded.request.expiresAt.toISOString(),
       completedAt: loaded.request.completedAt?.toISOString() ?? null,
-      hosts: hosts.hosts,
+      hosts: hosts.hosts.filter((host) => {
+        return host.status === "online";
+      }),
     };
   },
 );
@@ -373,11 +383,12 @@ export const applyComputerUseAuthorizationRequest$ = command(
     }
 
     if (
-      !(await hostExists({
+      !(await onlineHostExists({
         db,
         orgId: args.orgId,
         userId: args.userId,
         hostId: args.computerUseHostId,
+        now,
       }))
     ) {
       return { status: "host_not_found" };

--- a/turbo/apps/api/src/signals/services/zero-computer-use.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-computer-use.service.ts
@@ -231,7 +231,14 @@ function normalizeHostPermissions(
   };
 }
 
-function hostIsOnline(host: ComputerUseHostRow, now: Date): boolean {
+export function computerUseHostIsOnline(
+  host: {
+    readonly status: string;
+    readonly revokedAt: Date | null;
+    readonly lastSeenAt: Date;
+  },
+  now: Date,
+): boolean {
   return (
     host.status === "online" &&
     host.revokedAt === null &&
@@ -581,7 +588,9 @@ function serializeHost(row: ComputerUseHostRow, now: Date) {
     osVersion: row.osVersion,
     supportedCapabilities: row.supportedCapabilities,
     permissions: normalizeHostPermissions(row.permissions),
-    status: hostIsOnline(row, now) ? ("online" as const) : ("offline" as const),
+    status: computerUseHostIsOnline(row, now)
+      ? ("online" as const)
+      : ("offline" as const),
     lastSeenAt: row.lastSeenAt.toISOString(),
     createdAt: row.createdAt.toISOString(),
   };
@@ -873,7 +882,7 @@ export const heartbeatComputerUseHost$ = command(
           params.supportedCapabilities,
         );
         const publishChanged =
-          !hostIsOnline(lockedHost, now) ||
+          !computerUseHostIsOnline(lockedHost, now) ||
           lockedHost.displayName !== displayName ||
           lockedHost.appVersion !== appVersion ||
           lockedHost.osVersion !== osVersion ||
@@ -1079,7 +1088,7 @@ export const createComputerUseCommand$ = command(
     }
 
     const onlineHosts = hosts.filter((host) => {
-      return hostIsOnline(host, now);
+      return computerUseHostIsOnline(host, now);
     });
     const target = resolveComputerUseCommandTargets({
       onlineHosts,

--- a/turbo/apps/platform/src/signals/computer-use-authorization/computer-use-authorization-page-setup.ts
+++ b/turbo/apps/platform/src/signals/computer-use-authorization/computer-use-authorization-page-setup.ts
@@ -9,7 +9,7 @@ import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
 export const setupComputerUseAuthorizationPage$ = command(
   async ({ set }, signal: AbortSignal) => {
     set(updatePage$, createElement(ComputerUseAuthorizationPage), "minimal");
-    set(updateDocumentTitle$, "Authorize Computer Use");
+    set(updateDocumentTitle$, "Authorize computer use");
     await set(hideAppSkeleton$, signal);
 
     if (await set(onboardGuard$, signal)) {

--- a/turbo/apps/platform/src/signals/zero-page/computer-use-hosts.ts
+++ b/turbo/apps/platform/src/signals/zero-page/computer-use-hosts.ts
@@ -52,6 +52,8 @@ interface ListedComputerUseHost extends Pick<
   readonly hostName: string;
 }
 
+type SelectableComputerUseHost = Pick<ComputerUseHost, "id" | "status">;
+
 export function selectedComputerUseHostId(
   hosts: readonly { readonly id: string }[],
   selectedHostId: string | null | undefined,
@@ -66,10 +68,10 @@ export function selectedComputerUseHostId(
     : null;
 }
 
-export function visibleComputerUseHosts(
-  hosts: readonly ListedComputerUseHost[],
+export function visibleComputerUseHosts<Host extends SelectableComputerUseHost>(
+  hosts: readonly Host[],
   selectedHostId: string | null | undefined,
-): ListedComputerUseHost[] {
+): Host[] {
   const selected = selectedComputerUseHostId(hosts, selectedHostId);
   const selectedHost = selected
     ? hosts.find((host) => {

--- a/turbo/apps/platform/src/views/computer-use-authorization/__tests__/computer-use-authorization-page.test.tsx
+++ b/turbo/apps/platform/src/views/computer-use-authorization/__tests__/computer-use-authorization-page.test.tsx
@@ -1,0 +1,141 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { zeroComputerUseAuthorizationRequestsContract } from "@vm0/api-contracts/contracts/zero-computer-use";
+
+import {
+  detachedSetupPage,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+
+const context = testContext();
+
+function computerUseHost(args: {
+  readonly id: string;
+  readonly displayName: string;
+  readonly status: "online" | "offline";
+}) {
+  return {
+    id: args.id,
+    displayName: args.displayName,
+    appVersion: "1.0.0",
+    osVersion: "macOS 15.0",
+    supportedCapabilities: ["app.open"],
+    permissions: { accessibility: true, screenRecording: true },
+    status: args.status,
+    lastSeenAt: "2026-06-10T12:00:00Z",
+    createdAt: "2026-06-10T11:00:00Z",
+  };
+}
+
+describe("computer use authorization page", () => {
+  it("shows only online hosts and applies the selected host", async () => {
+    const user = userEvent.setup({ delay: null });
+    let appliedHostId: string | null = null;
+
+    context.mocks.api(
+      zeroComputerUseAuthorizationRequestsContract.get,
+      ({ respond }) => {
+        return respond(200, {
+          source: "chat",
+          expiresAt: "2026-06-25T12:00:00Z",
+          completedAt: null,
+          hosts: [
+            computerUseHost({
+              id: "00000000-0000-4000-a000-000000000001",
+              displayName: "Studio Mac",
+              status: "online",
+            }),
+            computerUseHost({
+              id: "00000000-0000-4000-a000-000000000002",
+              displayName: "Offline Desktop",
+              status: "offline",
+            }),
+          ],
+        });
+      },
+    );
+    context.mocks.api(
+      zeroComputerUseAuthorizationRequestsContract.apply,
+      ({ body, respond }) => {
+        appliedHostId = body.computerUseHostId;
+        return respond(200, {
+          ok: true,
+          source: "chat",
+          computerUseHostId: body.computerUseHostId,
+        });
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/computer-use/authorize/vm0_computer_use_authorization_request_test",
+    });
+
+    await expect(
+      screen.findByRole("heading", { name: "Authorize computer use" }),
+    ).resolves.toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Choose an online computer for Zero to use in this chat thread.",
+      ),
+    ).toBeInTheDocument();
+    await expect(screen.findByText("Studio Mac")).resolves.toBeInTheDocument();
+    expect(screen.queryByText("Offline Desktop")).not.toBeInTheDocument();
+
+    const authorizeButton = queryAllByRoleFast("button").find((button) => {
+      return button.textContent === "Authorize";
+    });
+    expect(authorizeButton).toBeDefined();
+    await user.click(authorizeButton!);
+
+    await waitFor(() => {
+      expect(appliedHostId).toBe("00000000-0000-4000-a000-000000000001");
+    });
+  });
+
+  it("shows desktop guidance when there are no online hosts", async () => {
+    context.mocks.api(
+      zeroComputerUseAuthorizationRequestsContract.get,
+      ({ respond }) => {
+        return respond(200, {
+          source: "slack",
+          expiresAt: "2026-06-25T12:00:00Z",
+          completedAt: null,
+          hosts: [
+            computerUseHost({
+              id: "00000000-0000-4000-a000-000000000003",
+              displayName: "Offline Desktop",
+              status: "offline",
+            }),
+          ],
+        });
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/computer-use/authorize/vm0_computer_use_authorization_request_empty",
+    });
+
+    await expect(
+      screen.findByText("No online computers"),
+    ).resolves.toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Open Zero Computer Use on your Mac and refresh this page when it comes online.",
+      ),
+    ).toBeInTheDocument();
+    const downloadLink = queryAllByRoleFast("link").find((link) => {
+      return link.textContent === "Download for macOS";
+    });
+    expect(downloadLink).toHaveAttribute(
+      "href",
+      expect.stringContaining(
+        "/api/zero/desktop/updates/stable/darwin/arm64/dmg",
+      ),
+    );
+    expect(screen.queryByText("Offline Desktop")).not.toBeInTheDocument();
+  });
+});

--- a/turbo/apps/platform/src/views/computer-use-authorization/computer-use-authorization-page.tsx
+++ b/turbo/apps/platform/src/views/computer-use-authorization/computer-use-authorization-page.tsx
@@ -12,9 +12,13 @@ import {
   applyComputerUseAuthorizationRequest$,
   computerUseAuthorizationRequest$,
 } from "../../signals/computer-use-authorization/computer-use-authorization.ts";
-import { ZERO_DESKTOP_DOWNLOAD_URL } from "../../signals/zero-page/computer-use-hosts.ts";
+import {
+  visibleComputerUseHosts,
+  ZERO_DESKTOP_DOWNLOAD_URL,
+} from "../../signals/zero-page/computer-use-hosts.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
+import computerUseIllustration from "../zero-page/assets/computer-use-illustration.png";
 import { Vm0LogoLink } from "../zero-page/zero-directed-shared.tsx";
 
 function formatTime(value: string): string {
@@ -52,8 +56,7 @@ function HostOption({
             {host.displayName}
           </div>
           <div className="mt-0.5 text-xs text-muted-foreground">
-            {host.status === "online" ? "Online" : "Offline"} · Last seen{" "}
-            {formatTime(host.lastSeenAt)}
+            Last seen {formatTime(host.lastSeenAt)}
           </div>
         </div>
       </div>
@@ -81,24 +84,30 @@ function HostOption({
 function EmptyHosts() {
   return (
     <div className="flex flex-col items-center gap-4 rounded-lg border border-border bg-muted/30 px-4 py-6 text-center">
-      <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-background">
-        <IconDeviceDesktop size={20} />
+      <div className="flex h-24 w-24 items-center justify-center">
+        <img
+          src={computerUseIllustration}
+          alt=""
+          className="h-24 w-24 object-contain"
+        />
       </div>
       <div className="flex max-w-sm flex-col gap-1">
         <h2 className="text-sm font-medium text-foreground">
-          No Desktop host found
+          No online computers
         </h2>
         <p className="text-sm leading-5 text-muted-foreground">
-          Install or open Zero Desktop, sign in, and enable Computer Use before
-          authorizing a host.
+          Open Zero Computer Use on your Mac and refresh this page when it comes
+          online.
         </p>
       </div>
       <a
         href={ZERO_DESKTOP_DOWNLOAD_URL}
+        target="_blank"
+        rel="noreferrer"
         className="inline-flex h-9 items-center justify-center gap-2 rounded-lg border border-border bg-background px-3 text-sm font-medium text-foreground transition-colors hover:bg-accent"
       >
         <IconDownload size={16} />
-        Download Zero Desktop
+        Download for macOS
       </a>
     </div>
   );
@@ -132,6 +141,7 @@ export function ComputerUseAuthorizationPage() {
   const request =
     requestLoadable.state === "hasData" ? requestLoadable.data : null;
   const hosts = request?.hosts;
+  const visibleHosts = visibleComputerUseHosts(hosts ?? [], null);
 
   if (requestLoadable.state === "loading") {
     return (
@@ -159,21 +169,20 @@ export function ComputerUseAuthorizationPage() {
           </div>
           <div className="flex flex-col gap-2">
             <h1 className="text-lg font-medium text-foreground">
-              Authorize Computer Use
+              Authorize computer use
             </h1>
             <p className="mx-auto max-w-md text-sm leading-5 text-muted-foreground">
-              Select a Desktop host for future runs in{" "}
-              {sourceLabel(request.source)}. The current run token will not
-              change.
+              Choose an online computer for Zero to use in{" "}
+              {sourceLabel(request.source)}.
             </p>
           </div>
         </div>
 
-        {!hosts || hosts.length === 0 ? (
+        {visibleHosts.length === 0 ? (
           <EmptyHosts />
         ) : (
           <div className="flex flex-col gap-3">
-            {hosts.map((host) => {
+            {visibleHosts.map((host) => {
               return (
                 <HostOption
                   key={host.id}


### PR DESCRIPTION
## Summary
- show only online Computer Use hosts on delegated authorization pages
- add desktop guidance empty state matching the chat composer download path
- reject offline or stale hosts when applying delegated authorization

Fixes #18873

## Testing
- pnpm --filter @vm0/app exec vitest run src/views/computer-use-authorization/__tests__/computer-use-authorization-page.test.tsx
- pnpm --filter @vm0/app exec oxlint src/signals/zero-page/computer-use-hosts.ts src/signals/computer-use-authorization/computer-use-authorization-page-setup.ts src/views/computer-use-authorization/computer-use-authorization-page.tsx src/views/computer-use-authorization/__tests__/computer-use-authorization-page.test.tsx
- pnpm --filter api exec oxlint src/signals/services/zero-computer-use.service.ts src/signals/services/zero-computer-use-authorization.service.ts src/signals/routes/__tests__/computer-use.bdd.test.ts
- pnpm exec prettier --check apps/platform/src/signals/computer-use-authorization/computer-use-authorization-page-setup.ts apps/platform/src/signals/zero-page/computer-use-hosts.ts apps/platform/src/views/computer-use-authorization/computer-use-authorization-page.tsx apps/platform/src/views/computer-use-authorization/__tests__/computer-use-authorization-page.test.tsx apps/api/src/signals/services/zero-computer-use.service.ts apps/api/src/signals/services/zero-computer-use-authorization.service.ts apps/api/src/signals/routes/__tests__/computer-use.bdd.test.ts
- git diff --check

## Notes
- Local API BDD run requires Postgres on :5432; this environment does not have it running.