### PR TITLE
feat: add workflow trigger permission entry

### DIFF
--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -10,6 +10,7 @@ import {
   setupAuthPageWrapper,
   pathParams$,
   pathname$,
+  type RouterPathParams,
 } from "./route.ts";
 import { registerServiceWorker$ } from "../lib/push-notifications.ts";
 import { onDomEventFn } from "./utils.ts";
@@ -92,10 +93,7 @@ function redirectWithId(target: RoutePath, targetParam: string) {
   return command(({ get, set }) => {
     const params = get(pathParams$) ?? {};
     set(detachedNavigateTo$, target, {
-      pathParams: { [targetParam]: String(params.id) } as Record<
-        string,
-        string
-      >,
+      pathParams: { [targetParam]: String(params.id) } as RouterPathParams,
       replace: true,
     });
   });

--- a/turbo/apps/platform/src/signals/route.ts
+++ b/turbo/apps/platform/src/signals/route.ts
@@ -227,12 +227,23 @@ export const detachedNavigateTo$ = command(
   },
 );
 
-type ExtractParams<T extends string> =
-  T extends `${string}/:${infer Param}/${infer Rest}`
-    ? Record<Param, string> & ExtractParams<`/${Rest}`>
-    : T extends `${string}/:${infer Param}`
-      ? Record<Param, string>
-      : undefined;
+type ExtractParamSegment<T extends string> = T extends `:${infer Param}`
+  ? Record<Param, string>
+  : Record<never, never>;
+
+type ExtractParamSegments<T extends string> =
+  T extends `${infer Segment}/${infer Rest}`
+    ? ExtractParamSegment<Segment> & ExtractParamSegments<Rest>
+    : ExtractParamSegment<T>;
+
+type ExtractParams<T extends string> = T extends string
+  ? keyof ExtractParamSegments<T> extends never
+    ? undefined
+    : ExtractParamSegments<T>
+  : never;
+
+export type RouterPathParams<T extends RoutePath = RoutePath> =
+  ExtractParams<T>;
 
 export const generateRouterPath = <T extends RoutePath>(
   path: T,

--- a/turbo/apps/platform/src/signals/trigger-permissions/trigger-permissions-signals.ts
+++ b/turbo/apps/platform/src/signals/trigger-permissions/trigger-permissions-signals.ts
@@ -11,7 +11,12 @@ import { workflowDetail } from "../workflows-page/workflows-signals.ts";
 // Route params
 // ---------------------------------------------------------------------------
 
-const triggerPermissionsWorkflowId$ = computed((get) => {
+export const triggerPermissionsAgentId$ = computed((get) => {
+  const agentId = get(pathParams$)?.agentId;
+  return typeof agentId === "string" ? agentId : null;
+});
+
+export const triggerPermissionsWorkflowId$ = computed((get) => {
   const workflowId = get(pathParams$)?.workflowId;
   return typeof workflowId === "string" ? workflowId : null;
 });
@@ -24,6 +29,18 @@ export const triggerPermissionsTriggerId$ = computed((get) => {
 export const triggerPermissionsRef$ = computed((get) => {
   return get(searchParams$).get("ref") ?? null;
 });
+
+const internalTriggerPermissionsConnectorSearch$ = state("");
+
+export const triggerPermissionsConnectorSearch$ = computed((get) => {
+  return get(internalTriggerPermissionsConnectorSearch$);
+});
+
+export const setTriggerPermissionsConnectorSearch$ = command(
+  ({ set }, value: string) => {
+    set(internalTriggerPermissionsConnectorSearch$, value);
+  },
+);
 
 // ---------------------------------------------------------------------------
 // Trigger data (derived from the workflow detail's trigger list)

--- a/turbo/apps/platform/src/views/trigger-permissions/__tests__/trigger-permissions-page.test.tsx
+++ b/turbo/apps/platform/src/views/trigger-permissions/__tests__/trigger-permissions-page.test.tsx
@@ -116,6 +116,25 @@ function button(label: string, container?: HTMLElement): HTMLElement {
 const editorPath = `/agents/${AGENT_ID}/workflows/${WORKFLOW_ID}/triggers/${TRIGGER_ID}/permissions?ref=slack`;
 
 describe("trigger permissions page", () => {
+  it("shows a connector picker when no connector ref is selected", async () => {
+    mockTriggerPolicyApis(null);
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/workflows/${WORKFLOW_ID}/triggers/${TRIGGER_ID}/permissions`,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Trigger permissions")).toBeInTheDocument();
+    });
+
+    const slackLink = screen.getByText("Slack").closest("a");
+    expect(slackLink).toHaveAttribute(
+      "href",
+      `/agents/${AGENT_ID}/workflows/${WORKFLOW_ID}/triggers/${TRIGGER_ID}/permissions?ref=slack`,
+    );
+  });
+
   it("rejects an unknown connector ref", async () => {
     mockTriggerPolicyApis(null);
 

--- a/turbo/apps/platform/src/views/trigger-permissions/trigger-permissions-page.tsx
+++ b/turbo/apps/platform/src/views/trigger-permissions/trigger-permissions-page.tsx
@@ -4,6 +4,7 @@ import { Button } from "@vm0/ui";
 import {
   IconAlertTriangle,
   IconBan,
+  IconChevronRight,
   IconCheck,
   IconLoader2,
 } from "@tabler/icons-react";
@@ -11,7 +12,11 @@ import type {
   UnattendedTriggerPermissionAction,
   UnattendedTriggerPermissionPolicy,
 } from "@vm0/api-contracts/contracts/zero-workflows";
-import { CONNECTOR_TYPES } from "@vm0/connectors/connectors";
+import {
+  CONNECTOR_TYPE_KEYS,
+  CONNECTOR_TYPES,
+  type ConnectorType,
+} from "@vm0/connectors/connectors";
 import {
   isFirewallMetadataConnectorType,
   type FirewallPermissionDetailMetadata,
@@ -22,15 +27,64 @@ import {
   currentTriggerPermissionEditorSignals$,
   mergeConnectorPolicy,
   resolveTriggerPermissionAction,
+  setTriggerPermissionsConnectorSearch$,
+  triggerPermissionsAgentId$,
+  triggerPermissionsConnectorSearch$,
   triggerPermissionsRef$,
   triggerPermissionsTrigger$,
   triggerPermissionsTriggerId$,
+  triggerPermissionsWorkflowId$,
   type TriggerPermissionEditorSignals,
 } from "../../signals/trigger-permissions/trigger-permissions-signals.ts";
 import { setWorkflowTriggerPermissionPolicy$ } from "../../signals/workflows-page/workflows-signals.ts";
+import { ROUTES } from "../../signals/route-paths.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { VM0Logo } from "../components/vm0-logo.tsx";
+import { Link } from "../router/link.tsx";
 import { ConnectorIcon } from "../zero-page/components/settings/connector-icons.tsx";
+
+const TRIGGER_PERMISSION_CONNECTORS = [...CONNECTOR_TYPE_KEYS]
+  .filter((type) => {
+    return isFirewallMetadataConnectorType(type);
+  })
+  .sort((left, right) => {
+    return CONNECTOR_TYPES[left].label.localeCompare(
+      CONNECTOR_TYPES[right].label,
+    );
+  });
+const COMMON_TRIGGER_PERMISSION_CONNECTORS: readonly ConnectorType[] = [
+  "gmail",
+  "google-drive",
+  "github",
+  "slack",
+  "notion",
+  "google-calendar",
+  "google-sheets",
+  "google-docs",
+  "google-cloud",
+  "cloudflare",
+  "stripe",
+  "maskdb",
+] as const;
+const TRIGGER_PERMISSION_CONNECTOR_LIMIT = 24;
+
+function visibleTriggerPermissionConnectors(query: string): readonly string[] {
+  const normalizedQuery = query.trim().toLowerCase();
+  const matches = normalizedQuery
+    ? TRIGGER_PERMISSION_CONNECTORS.filter((type) => {
+        const config = CONNECTOR_TYPES[type as ConnectorType];
+        const haystack = [type, config.label, config.helpText ?? ""]
+          .join("\n")
+          .toLowerCase();
+        return haystack.includes(normalizedQuery);
+      })
+    : TRIGGER_PERMISSION_CONNECTORS.filter((type) => {
+        return COMMON_TRIGGER_PERMISSION_CONNECTORS.includes(
+          type as ConnectorType,
+        );
+      });
+  return matches.slice(0, TRIGGER_PERMISSION_CONNECTOR_LIMIT);
+}
 
 function LoadingCard() {
   return (
@@ -59,6 +113,81 @@ function ErrorMessage({ message }: { message: string }) {
         <p className="text-sm">{message}</p>
       </div>
     </StatusMessage>
+  );
+}
+
+function ConnectorPicker({
+  agentId,
+  workflowId,
+  triggerId,
+}: {
+  readonly agentId: string;
+  readonly workflowId: string;
+  readonly triggerId: string;
+}) {
+  const query = useGet(triggerPermissionsConnectorSearch$);
+  const setQuery = useSet(setTriggerPermissionsConnectorSearch$);
+  const visibleConnectors = visibleTriggerPermissionConnectors(query);
+
+  return (
+    <div className="mx-auto flex w-full max-w-[640px] flex-col gap-4 px-6 py-10">
+      <div className="flex flex-col gap-1">
+        <p className="text-base font-medium text-foreground">
+          Trigger permissions
+        </p>
+        <p className="text-xs text-muted-foreground">
+          Choose the connector this trigger may use when it fires unattended.
+        </p>
+      </div>
+      <input
+        value={query}
+        onChange={(event) => {
+          setQuery(event.currentTarget.value);
+        }}
+        placeholder="Search connectors"
+        className="h-9 w-full rounded-md border border-border/60 bg-background px-2.5 text-sm outline-none focus:border-primary"
+      />
+      <div className="flex flex-col divide-y divide-border/70 rounded-lg border border-border">
+        {visibleConnectors.map((type) => {
+          const config = CONNECTOR_TYPES[type as ConnectorType];
+          return (
+            <Link
+              key={type}
+              pathname={ROUTES.agentWorkflowTriggerPermissions}
+              options={{
+                pathParams: { agentId, workflowId, triggerId },
+                searchParams: new URLSearchParams({ ref: type }),
+              }}
+              className="flex items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-muted/40"
+            >
+              <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[10px] bg-muted/40">
+                <ConnectorIcon type={type as ConnectorType} size={20} />
+              </span>
+              <span className="min-w-0 flex-1 flex flex-col gap-1">
+                <span className="text-sm font-medium text-foreground">
+                  {config.label}
+                </span>
+                {config.helpText && (
+                  <span className="line-clamp-1 text-xs text-muted-foreground">
+                    {config.helpText}
+                  </span>
+                )}
+              </span>
+              <IconChevronRight
+                size={16}
+                stroke={1.5}
+                className="shrink-0 text-muted-foreground"
+              />
+            </Link>
+          );
+        })}
+        {visibleConnectors.length === 0 ? (
+          <p className="px-4 py-3 text-sm text-muted-foreground">
+            No connectors found
+          </p>
+        ) : null}
+      </div>
+    </div>
   );
 }
 
@@ -288,16 +417,32 @@ function TriggerPermissionsEditor({
 }
 
 export function TriggerPermissionsPage() {
+  const agentId = useGet(triggerPermissionsAgentId$);
+  const workflowId = useGet(triggerPermissionsWorkflowId$);
   const triggerId = useGet(triggerPermissionsTriggerId$);
   const ref = useGet(triggerPermissionsRef$);
   const editor = useGet(currentTriggerPermissionEditorSignals$);
+
+  if (!agentId) {
+    return <ErrorMessage message="Missing agent ID in URL parameters" />;
+  }
+
+  if (!workflowId) {
+    return <ErrorMessage message="Missing workflow ID in URL parameters" />;
+  }
 
   if (!triggerId) {
     return <ErrorMessage message="Missing trigger ID in URL parameters" />;
   }
 
   if (!ref) {
-    return <ErrorMessage message="Missing connector in URL parameters" />;
+    return (
+      <ConnectorPicker
+        agentId={agentId}
+        workflowId={workflowId}
+        triggerId={triggerId}
+      />
+    );
   }
 
   if (!isFirewallMetadataConnectorType(ref)) {

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -16,6 +16,7 @@ import {
   click,
   detachedSetupPage,
   fill,
+  queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 
@@ -309,6 +310,13 @@ describe("workflow detail page", () => {
     expect(screen.getByText("Weekdays at 9:00 AM")).toBeInTheDocument();
     expect(screen.getByText("Enabled")).toBeInTheDocument();
     expect(screen.getByText("Open thread")).toBeInTheDocument();
+    const permissionsLink = queryAllByRoleFast("link").find((link) => {
+      return link.textContent?.trim() === "Permissions";
+    });
+    expect(permissionsLink).toHaveAttribute(
+      "href",
+      `/agents/${AGENT_ID}/workflows/${SALES_WORKFLOW_ID}/triggers/workflow-trigger-weekday-brief/permissions`,
+    );
 
     click(screen.getByLabelText("Open config/settings.json"));
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -19,6 +19,7 @@ import {
   IconLoader2,
   IconMail,
   IconPlus,
+  IconShieldLock,
   IconTrash,
   IconUpload,
 } from "@tabler/icons-react";
@@ -779,6 +780,7 @@ function TriggersSection({
               return (
                 <TriggerRow
                   key={trigger.id}
+                  workflowId={detail.id}
                   trigger={trigger}
                   canManage={trigger.ownerUserId === currentUserId}
                 />
@@ -972,9 +974,11 @@ function CreateGmailNewMessageTriggerForm({
 }
 
 function TriggerRow({
+  workflowId,
   trigger,
   canManage,
 }: {
+  readonly workflowId: string;
   readonly trigger: ZeroWorkflowTriggerSummary;
   readonly canManage: boolean;
 }) {
@@ -1028,7 +1032,11 @@ function TriggerRow({
           </Link>
         ) : null}
         {canManage ? (
-          <TriggerControls trigger={trigger} editingMatch={editingMatch} />
+          <TriggerControls
+            workflowId={workflowId}
+            trigger={trigger}
+            editingMatch={editingMatch}
+          />
         ) : null}
         {canManage && trigger.kind === "event" && editingMatch ? (
           <UpdateGmailNewMessageTriggerForm
@@ -1044,12 +1052,15 @@ function TriggerRow({
 }
 
 function TriggerControls({
+  workflowId,
   trigger,
   editingMatch,
 }: {
+  readonly workflowId: string;
   readonly trigger: ZeroWorkflowTriggerSummary;
   readonly editingMatch: boolean;
 }) {
+  const agentId = useGet(currentAgentId$);
   const pageSignal = useGet(pageSignal$);
   const setEditingTriggerId = useSet(setEditingGmailTriggerId$);
   const [enabledLoadable, setEnabled] = useLoadableSet(
@@ -1076,6 +1087,22 @@ function TriggerControls({
       >
         Test run
       </button>
+      {agentId ? (
+        <Link
+          pathname={ROUTES.agentWorkflowTriggerPermissions}
+          options={{
+            pathParams: {
+              agentId,
+              workflowId,
+              triggerId: trigger.id,
+            },
+          }}
+          className="inline-flex items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <IconShieldLock size={13} stroke={1.5} />
+          <span>Permissions</span>
+        </Link>
+      ) : null}
       {trigger.kind === "event" && !editingMatch ? (
         <button
           type="button"


### PR DESCRIPTION
## Summary
- Add a visible Permissions entry from each workflow trigger row.
- Show a connector picker on the trigger permissions page when no connector ref is selected.
- Update route param typing to support the trigger permissions route shape.

## Tests
- pnpm exec vitest run src/views/workflows-page/__tests__/workflows-page.test.tsx src/views/trigger-permissions/__tests__/trigger-permissions-page.test.tsx
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app lint