### PR TITLE
fix(runner): stage workspace unmount holder cleanup

### DIFF
--- a/crates/runner/scripts/unmount-workspace-drive.sh
+++ b/crates/runner/scripts/unmount-workspace-drive.sh
@@ -38,9 +38,19 @@ if umount -- "$workspace_dir"; then
 fi
 
 WORKSPACE_HOLDER_DIAGNOSTIC_LIMIT=40
+WORKSPACE_HOLDER_MAPS_LINE_LIMIT=4096
 WORKSPACE_HOLDER_VALUE_LIMIT=240
 WORKSPACE_HOLDER_KILL_GRACE_SECONDS=1
 WORKSPACE_HOLDER_TERM_GRACE_SECONDS=1
+
+holder_record_dir="$(mktemp -d)"
+holder_records="$holder_record_dir/fast"
+remaining_holder_records="$holder_record_dir/fast-remaining"
+maps_holder_records="$holder_record_dir/maps"
+cleanup_workspace_holder_records() {
+  rm -rf -- "$holder_record_dir"
+}
+trap cleanup_workspace_holder_records EXIT
 
 is_workspace_ref() {
   target=$1
@@ -110,7 +120,13 @@ scan_proc_maps() {
   [ -r "$maps_path" ] || return 0
 
   {
+    line_count=0
     while read -r maps_address maps_perms maps_offset maps_dev maps_inode maps_target; do
+      line_count=$((line_count + 1))
+      if [ "$line_count" -gt "$WORKSPACE_HOLDER_MAPS_LINE_LIMIT" ]; then
+        echo "workspace holder maps scan truncated for pid=$pid after $WORKSPACE_HOLDER_MAPS_LINE_LIMIT lines" >&2
+        return 0
+      fi
       [ -n "$maps_target" ] || continue
       if is_workspace_ref "$maps_target"; then
         scan_proc_target "$pid" maps "$maps_target"
@@ -122,14 +138,21 @@ scan_proc_maps() {
   return 0
 }
 
-scan_workspace_holder_refs() {
+scan_workspace_fast_holder_refs() {
   for proc_dir in /proc/[0-9]*; do
     pid=${proc_dir#/proc/}
-    scan_proc_holder_refs "$pid"
+    scan_proc_fast_holder_refs "$pid"
   done
 }
 
-scan_proc_holder_refs() {
+scan_workspace_maps_holder_refs() {
+  for proc_dir in /proc/[0-9]*; do
+    pid=${proc_dir#/proc/}
+    scan_proc_maps_holder_refs "$pid"
+  done
+}
+
+scan_proc_fast_holder_refs() {
   pid=$1
   proc_dir="/proc/$pid"
   [ -d "$proc_dir" ] || return 0
@@ -143,13 +166,22 @@ scan_proc_holder_refs() {
     [ -L "$fd_ref" ] || [ -e "$fd_ref" ] || continue
     scan_proc_ref "$pid" fd "$fd_ref"
   done
+}
+
+scan_proc_maps_holder_refs() {
+  pid=$1
+  proc_dir="/proc/$pid"
+  [ -d "$proc_dir" ] || return 0
+  [ "$pid" != "$$" ] || return 0
+  [ "$pid" != "1" ] || return 0
+
   scan_proc_maps "$pid" "$proc_dir/maps"
 }
 
-workspace_holder_pids() {
+workspace_fast_holder_pids() {
   for proc_dir in /proc/[0-9]*; do
     pid=${proc_dir#/proc/}
-    if pid_has_workspace_ref "$pid"; then
+    if pid_has_fast_workspace_ref "$pid"; then
       printf '%s\n' "$pid"
     fi
   done | sort -u
@@ -166,7 +198,10 @@ proc_maps_has_workspace_ref() {
   [ -r "$maps_path" ] || return 1
 
   {
+    line_count=0
     while read -r maps_address maps_perms maps_offset maps_dev maps_inode maps_target; do
+      line_count=$((line_count + 1))
+      [ "$line_count" -le "$WORKSPACE_HOLDER_MAPS_LINE_LIMIT" ] || return 1
       [ -n "$maps_target" ] || continue
       if is_workspace_ref "$maps_target"; then
         return 0
@@ -177,7 +212,7 @@ proc_maps_has_workspace_ref() {
   return 1
 }
 
-pid_has_workspace_ref() {
+pid_has_fast_workspace_ref() {
   pid=$1
   proc_dir="/proc/$pid"
   [ -d "$proc_dir" ] || return 1
@@ -199,6 +234,17 @@ pid_has_workspace_ref() {
       return 0
     fi
   done
+
+  return 1
+}
+
+pid_has_maps_workspace_ref() {
+  pid=$1
+  proc_dir="/proc/$pid"
+  [ -d "$proc_dir" ] || return 1
+  [ "$pid" != "$$" ] || return 1
+  [ "$pid" != "1" ] || return 1
+
   if proc_maps_has_workspace_ref "$proc_dir/maps"; then
     return 0
   fi
@@ -206,75 +252,137 @@ pid_has_workspace_ref() {
   return 1
 }
 
-log_workspace_holders() {
+collect_and_log_workspace_holders() {
+  records_file=$1
+  label=$2
+  : > "$records_file"
   count=0
   tab="$(printf '\t')"
-  scan_workspace_holder_refs | while IFS="$tab" read -r pid uid comm ref_type target; do
+  while IFS="$tab" read -r pid uid comm ref_type target; do
     count=$((count + 1))
+    printf '%s\n' "$pid" >> "$records_file"
     if [ "$count" -le "$WORKSPACE_HOLDER_DIAGNOSTIC_LIMIT" ]; then
       comm="$(sanitize_log_value "$comm")"
       target="$(sanitize_log_value "$target")"
-      printf 'workspace holder: pid=%s uid=%s comm=%s ref=%s path=%s\n' \
-        "$pid" "$uid" "$comm" "$ref_type" "$target" >&2
+      printf 'workspace holder: phase=%s pid=%s uid=%s comm=%s ref=%s path=%s\n' \
+        "$label" "$pid" "$uid" "$comm" "$ref_type" "$target" >&2
     elif [ "$count" -eq "$((WORKSPACE_HOLDER_DIAGNOSTIC_LIMIT + 1))" ]; then
-      echo "workspace holder diagnostics truncated after $WORKSPACE_HOLDER_DIAGNOSTIC_LIMIT entries" >&2
+      echo "workspace holder $label diagnostics truncated after $WORKSPACE_HOLDER_DIAGNOSTIC_LIMIT entries" >&2
     fi
   done
+  echo "workspace holder cleanup: $label scan completed holder_ref_count=$count" >&2
 }
 
-term_workspace_holder_pids() {
-  pids=$1
-  for pid in $pids; do
+holder_record_pids() {
+  sed -n '/^[0-9][0-9]*$/p' "$1" | sort -u
+}
+
+holder_record_pid_count() {
+  count="$(holder_record_pids "$1" | wc -l | tr -d ' ')"
+  [ -n "$count" ] || count=0
+  printf '%s' "$count"
+}
+
+term_workspace_holder_record_pids() {
+  records_file=$1
+  for pid in $(holder_record_pids "$records_file"); do
     [ "$pid" != "$$" ] || continue
     [ "$pid" != "1" ] || continue
-    pid_has_workspace_ref "$pid" || continue
+    pid_has_fast_workspace_ref "$pid" || continue
     kill -TERM "$pid" 2>/dev/null || true
   done
 }
 
-kill_workspace_holder_pids() {
-  pids=$1
-  for pid in $pids; do
+kill_workspace_holder_record_pids() {
+  records_file=$1
+  ref_mode=$2
+  for pid in $(holder_record_pids "$records_file"); do
     [ "$pid" != "$$" ] || continue
     [ "$pid" != "1" ] || continue
-    pid_has_workspace_ref "$pid" || continue
+    case "$ref_mode" in
+      fast) pid_has_fast_workspace_ref "$pid" || continue ;;
+      maps) pid_has_maps_workspace_ref "$pid" || continue ;;
+      *) continue ;;
+    esac
     kill -KILL "$pid" 2>/dev/null || true
   done
 }
 
-wait_for_workspace_holders_to_clear() {
+wait_for_fast_workspace_holders_to_clear() {
   grace_seconds=$1
   attempts=$((grace_seconds * 10))
   [ "$attempts" -gt 0 ] || attempts=1
 
   while [ "$attempts" -gt 0 ]; do
-    if [ -z "$(workspace_holder_pids)" ]; then
+    if [ -z "$(workspace_fast_holder_pids)" ]; then
       return 0
     fi
     attempts=$((attempts - 1))
     sleep 0.1
   done
 
-  [ -z "$(workspace_holder_pids)" ]
+  [ -z "$(workspace_fast_holder_pids)" ]
+}
+
+retry_workspace_unmount() {
+  stage=$1
+  echo "workspace holder cleanup: retry umount after $stage started" >&2
+  sync -f -- "$workspace_dir" 2>/dev/null || true
+  if umount -- "$workspace_dir"; then
+    echo "workspace holder cleanup: retry umount after $stage succeeded" >&2
+    return 0
+  else
+    status=$?
+    echo "workspace holder cleanup: retry umount after $stage failed exit_code=$status" >&2
+    return "$status"
+  fi
 }
 
 echo "workspace drive unmount failed; diagnosing holders under $workspace_dir" >&2
-holder_pids="$(workspace_holder_pids)"
-if [ -z "$holder_pids" ]; then
-  echo "no workspace holder processes found" >&2
+echo "workspace holder cleanup: fast scan started" >&2
+scan_workspace_fast_holder_refs | collect_and_log_workspace_holders "$holder_records" fast
+holder_pid_count="$(holder_record_pid_count "$holder_records")"
+echo "workspace holder cleanup: fast scan holder_pid_count=$holder_pid_count" >&2
+if [ "$holder_pid_count" -eq 0 ]; then
+  echo "no fast workspace holder processes found" >&2
 else
-  log_workspace_holders
-  term_workspace_holder_pids "$holder_pids"
-  wait_for_workspace_holders_to_clear "$WORKSPACE_HOLDER_TERM_GRACE_SECONDS" || true
-
-  remaining_holder_pids="$(workspace_holder_pids)"
-  if [ -n "$remaining_holder_pids" ]; then
-    echo "workspace holders remain after TERM; sending KILL" >&2
-    log_workspace_holders
-    kill_workspace_holder_pids "$remaining_holder_pids"
-    wait_for_workspace_holders_to_clear "$WORKSPACE_HOLDER_KILL_GRACE_SECONDS" || true
-  fi
+  echo "workspace holder cleanup: TERM started holder_pid_count=$holder_pid_count" >&2
+  term_workspace_holder_record_pids "$holder_records"
+  wait_for_fast_workspace_holders_to_clear "$WORKSPACE_HOLDER_TERM_GRACE_SECONDS" || true
+  echo "workspace holder cleanup: TERM completed" >&2
 fi
 
-sync -f -- "$workspace_dir" 2>/dev/null || true
-umount -- "$workspace_dir"
+if retry_workspace_unmount "fast cleanup"; then
+  exit 0
+fi
+
+echo "workspace holder cleanup: fast rescan started" >&2
+scan_workspace_fast_holder_refs | collect_and_log_workspace_holders "$remaining_holder_records" fast-remaining
+remaining_holder_pid_count="$(holder_record_pid_count "$remaining_holder_records")"
+echo "workspace holder cleanup: fast rescan holder_pid_count=$remaining_holder_pid_count" >&2
+if [ "$remaining_holder_pid_count" -gt 0 ]; then
+  echo "workspace holder cleanup: KILL started holder_pid_count=$remaining_holder_pid_count" >&2
+  kill_workspace_holder_record_pids "$remaining_holder_records" fast
+  wait_for_fast_workspace_holders_to_clear "$WORKSPACE_HOLDER_KILL_GRACE_SECONDS" || true
+  echo "workspace holder cleanup: KILL completed" >&2
+
+  if retry_workspace_unmount "fast KILL cleanup"; then
+    exit 0
+  fi
+else
+  echo "no remaining fast workspace holder processes found" >&2
+fi
+
+echo "workspace holder cleanup: slow maps scan started" >&2
+scan_workspace_maps_holder_refs | collect_and_log_workspace_holders "$maps_holder_records" maps
+maps_holder_pid_count="$(holder_record_pid_count "$maps_holder_records")"
+echo "workspace holder cleanup: slow maps scan holder_pid_count=$maps_holder_pid_count" >&2
+if [ "$maps_holder_pid_count" -gt 0 ]; then
+  echo "workspace holder cleanup: maps KILL started holder_pid_count=$maps_holder_pid_count" >&2
+  kill_workspace_holder_record_pids "$maps_holder_records" maps
+  echo "workspace holder cleanup: maps KILL completed" >&2
+else
+  echo "no workspace maps holder processes found" >&2
+fi
+
+retry_workspace_unmount "slow maps diagnostics"

--- a/crates/runner/scripts/unmount-workspace-drive.sh
+++ b/crates/runner/scripts/unmount-workspace-drive.sh
@@ -324,6 +324,33 @@ wait_for_fast_workspace_holders_to_clear() {
   [ -z "$(workspace_fast_holder_pids)" ]
 }
 
+holder_records_have_maps_workspace_ref() {
+  records_file=$1
+  for pid in $(holder_record_pids "$records_file"); do
+    if pid_has_maps_workspace_ref "$pid"; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+wait_for_maps_workspace_holders_to_clear() {
+  records_file=$1
+  grace_seconds=$2
+  attempts=$((grace_seconds * 10))
+  [ "$attempts" -gt 0 ] || attempts=1
+
+  while [ "$attempts" -gt 0 ]; do
+    if ! holder_records_have_maps_workspace_ref "$records_file"; then
+      return 0
+    fi
+    attempts=$((attempts - 1))
+    sleep 0.1
+  done
+
+  ! holder_records_have_maps_workspace_ref "$records_file"
+}
+
 retry_workspace_unmount() {
   stage=$1
   echo "workspace holder cleanup: retry umount after $stage started" >&2
@@ -380,6 +407,7 @@ echo "workspace holder cleanup: slow maps scan holder_pid_count=$maps_holder_pid
 if [ "$maps_holder_pid_count" -gt 0 ]; then
   echo "workspace holder cleanup: maps KILL started holder_pid_count=$maps_holder_pid_count" >&2
   kill_workspace_holder_record_pids "$maps_holder_records" maps
+  wait_for_maps_workspace_holders_to_clear "$maps_holder_records" "$WORKSPACE_HOLDER_KILL_GRACE_SECONDS" || true
   echo "workspace holder cleanup: maps KILL completed" >&2
 else
   echo "no workspace maps holder processes found" >&2

--- a/crates/runner/scripts/unmount-workspace-drive.sh
+++ b/crates/runner/scripts/unmount-workspace-drive.sh
@@ -119,13 +119,14 @@ scan_proc_maps() {
   maps_path=$2
   [ -r "$maps_path" ] || return 0
 
+  truncated=0
   {
     line_count=0
     while read -r maps_address maps_perms maps_offset maps_dev maps_inode maps_target; do
       line_count=$((line_count + 1))
       if [ "$line_count" -gt "$WORKSPACE_HOLDER_MAPS_LINE_LIMIT" ]; then
-        echo "workspace holder maps scan truncated for pid=$pid after $WORKSPACE_HOLDER_MAPS_LINE_LIMIT lines" >&2
-        return 0
+        truncated=1
+        break
       fi
       [ -n "$maps_target" ] || continue
       if is_workspace_ref "$maps_target"; then
@@ -134,6 +135,9 @@ scan_proc_maps() {
       fi
     done < "$maps_path"
   } 2>/dev/null || return 0
+  if [ "$truncated" -eq 1 ]; then
+    echo "workspace holder maps scan truncated for pid=$pid after $WORKSPACE_HOLDER_MAPS_LINE_LIMIT lines" >&2
+  fi
 
   return 0
 }

--- a/crates/runner/src/workspace_mount.rs
+++ b/crates/runner/src/workspace_mount.rs
@@ -728,6 +728,7 @@ exit 32
         assert!(cmd.contains("WORKSPACE_HOLDER_VALUE_LIMIT=240"));
         assert!(cmd.contains("WORKSPACE_HOLDER_KILL_GRACE_SECONDS=1"));
         assert!(cmd.contains("wait_for_fast_workspace_holders_to_clear()"));
+        assert!(cmd.contains("wait_for_maps_workspace_holders_to_clear()"));
         assert!(cmd.contains("diagnostics truncated after $WORKSPACE_HOLDER_DIAGNOSTIC_LIMIT"));
         assert!(cmd.contains("workspace holder cleanup: fast scan started"));
         assert!(cmd.contains("workspace holder cleanup: TERM started"));
@@ -780,6 +781,21 @@ exit 32
             "scan_workspace_maps_holder_refs | collect_and_log_workspace_holders",
             kill_retry,
         );
+        let maps_kill = find_after(
+            &cmd,
+            "kill_workspace_holder_record_pids \"$maps_holder_records\" maps",
+            maps_scan,
+        );
+        let maps_wait = find_after(
+            &cmd,
+            "wait_for_maps_workspace_holders_to_clear \"$maps_holder_records\" \"$WORKSPACE_HOLDER_KILL_GRACE_SECONDS\"",
+            maps_kill,
+        );
+        let maps_retry = find_after(
+            &cmd,
+            "retry_workspace_unmount \"slow maps diagnostics\"",
+            maps_wait,
+        );
 
         assert!(
             clean_unmount < fast_scan,
@@ -810,6 +826,14 @@ exit 32
         assert!(
             kill_retry < maps_scan,
             "slow maps scan must run after fast TERM/KILL retries"
+        );
+        assert!(
+            maps_kill < maps_wait,
+            "maps KILL must wait for maps refs to clear"
+        );
+        assert!(
+            maps_wait < maps_retry,
+            "maps wait must happen before final retry unmount"
         );
     }
 

--- a/crates/runner/src/workspace_mount.rs
+++ b/crates/runner/src/workspace_mount.rs
@@ -187,6 +187,23 @@ exit 0
     }
 
     fn write_busy_then_successful_fake_umount(fake_bin: &Path, log_path: &Path, count_path: &Path) {
+        write_busy_until_successful_fake_umount(fake_bin, log_path, count_path, 1);
+    }
+
+    fn write_busy_twice_then_successful_fake_umount(
+        fake_bin: &Path,
+        log_path: &Path,
+        count_path: &Path,
+    ) {
+        write_busy_until_successful_fake_umount(fake_bin, log_path, count_path, 2);
+    }
+
+    fn write_busy_until_successful_fake_umount(
+        fake_bin: &Path,
+        log_path: &Path,
+        count_path: &Path,
+        busy_calls: u32,
+    ) {
         let log_path = quote_shell_arg(log_path.to_str().unwrap());
         let count_path = quote_shell_arg(count_path.to_str().unwrap());
         write_executable(
@@ -201,11 +218,33 @@ fi
 count=$((count + 1))
 printf '%s\n' "$count" > {count_path}
 printf 'umount call=%s cwd=%s args=%s\n' "$count" "$(pwd)" "$*" >> {log_path}
-if [ "$count" -eq 1 ]; then
+if [ "$count" -le {busy_calls} ]; then
   echo "target is busy" >&2
   exit 32
 fi
 exit 0
+"#
+            ),
+        );
+    }
+
+    fn write_always_busy_fake_umount(fake_bin: &Path, log_path: &Path, count_path: &Path) {
+        let log_path = quote_shell_arg(log_path.to_str().unwrap());
+        let count_path = quote_shell_arg(count_path.to_str().unwrap());
+        write_executable(
+            &fake_bin.join("umount"),
+            &format!(
+                r#"#!/bin/sh
+set -eu
+count=0
+if [ -f {count_path} ]; then
+  count="$(cat {count_path})"
+fi
+count=$((count + 1))
+printf '%s\n' "$count" > {count_path}
+printf 'umount call=%s cwd=%s args=%s\n' "$count" "$(pwd)" "$*" >> {log_path}
+echo "target is busy" >&2
+exit 32
 "#
             ),
         );
@@ -441,9 +480,13 @@ exit 0
             "holder should be terminated by signal"
         );
         assert!(stderr.contains("workspace drive unmount failed; diagnosing holders"));
-        assert!(stderr.contains("workspace holder:"));
+        assert!(stderr.contains("workspace holder: phase=fast"));
         assert!(stderr.contains(&format!("pid={}", holder.id())));
         assert!(stderr.contains("ref=cwd"));
+        assert!(stderr.contains("workspace holder cleanup: TERM started"));
+        assert!(
+            stderr.contains("workspace holder cleanup: retry umount after fast cleanup succeeded")
+        );
         let log = fs::read_to_string(log_path).unwrap();
         assert_eq!(log.matches("umount call=").count(), 2);
         assert!(log.contains("umount call=1 cwd=/ args=--"));
@@ -488,9 +531,13 @@ exit 0
             !holder_status.success(),
             "holder should be terminated by signal"
         );
-        assert!(stderr.contains("workspace holder:"));
+        assert!(stderr.contains("workspace holder: phase=fast"));
         assert!(stderr.contains(&format!("pid={}", holder.id())));
         assert!(stderr.contains("ref=fd"));
+        assert!(stderr.contains("workspace holder cleanup: TERM started"));
+        assert!(
+            stderr.contains("workspace holder cleanup: retry umount after fast cleanup succeeded")
+        );
         let log = fs::read_to_string(log_path).unwrap();
         assert_eq!(log.matches("umount call=").count(), 2);
         assert!(log.contains("umount call=1 cwd=/ args=--"));
@@ -510,7 +557,7 @@ exit 0
         fs::create_dir(&fake_bin).unwrap();
         write_fake_mountpoint(&fake_bin, &workspace_dir, &workspace_device);
         write_fake_sync(&fake_bin, &log_path);
-        write_busy_then_successful_fake_umount(&fake_bin, &log_path, &count_path);
+        write_busy_twice_then_successful_fake_umount(&fake_bin, &log_path, &count_path);
 
         let mut holder = Command::new("sh")
             .arg("-c")
@@ -533,12 +580,56 @@ exit 0
             !holder_status.success(),
             "holder should be killed after ignoring TERM"
         );
-        assert!(stderr.contains("workspace holders remain after TERM; sending KILL"));
+        assert!(
+            stderr.contains("workspace holder cleanup: retry umount after fast cleanup failed")
+        );
+        assert!(stderr.contains("workspace holder cleanup: KILL started"));
+        assert!(
+            stderr.contains(
+                "workspace holder cleanup: retry umount after fast KILL cleanup succeeded"
+            )
+        );
         assert!(stderr.contains(&format!("pid={}", holder.id())));
         let log = fs::read_to_string(log_path).unwrap();
-        assert_eq!(log.matches("umount call=").count(), 2);
+        assert_eq!(log.matches("umount call=").count(), 3);
         assert!(log.contains("umount call=1 cwd=/ args=--"));
         assert!(log.contains("umount call=2 cwd=/ args=--"));
+        assert!(log.contains("umount call=3 cwd=/ args=--"));
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn unmount_script_reports_no_fast_holders_before_slow_maps_scan() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_dir = temp.path().join("workspace");
+        let workspace_device = temp.path().join("vdb");
+        let fake_bin = temp.path().join("bin");
+        let log_path = temp.path().join("calls.log");
+        let count_path = temp.path().join("umount-count");
+        fs::create_dir(&workspace_dir).unwrap();
+        fs::create_dir(&fake_bin).unwrap();
+        write_fake_mountpoint(&fake_bin, &workspace_dir, &workspace_device);
+        write_fake_sync(&fake_bin, &log_path);
+        write_always_busy_fake_umount(&fake_bin, &log_path, &count_path);
+
+        let output = run_unmount_script(&workspace_dir, &workspace_device, &fake_bin);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        assert!(!output.status.success(), "stderr={stderr}");
+        assert!(stderr.contains("workspace holder cleanup: fast scan started"));
+        assert!(stderr.contains("no fast workspace holder processes found"));
+        assert!(
+            stderr.contains("workspace holder cleanup: retry umount after fast cleanup failed")
+        );
+        assert!(stderr.contains("workspace holder cleanup: slow maps scan started"));
+        assert!(stderr.contains("no workspace maps holder processes found"));
+        assert!(
+            stderr.contains(
+                "workspace holder cleanup: retry umount after slow maps diagnostics failed"
+            )
+        );
+        let log = fs::read_to_string(log_path).unwrap();
+        assert_eq!(log.matches("umount call=").count(), 3);
     }
 
     #[test]
@@ -618,6 +709,8 @@ exit 0
     fn unmount_command_diagnoses_and_cleans_workspace_holders_before_retry() {
         let cmd = workspace_unmount_command();
 
+        assert!(cmd.contains("scan_workspace_fast_holder_refs()"));
+        assert!(cmd.contains("scan_workspace_maps_holder_refs()"));
         assert!(cmd.contains("scan_proc_ref \"$pid\" cwd \"$proc_dir/cwd\""));
         assert!(cmd.contains("scan_proc_ref \"$pid\" root \"$proc_dir/root\""));
         assert!(cmd.contains("scan_proc_ref \"$pid\" exe \"$proc_dir/exe\""));
@@ -627,69 +720,96 @@ exit 0
         assert!(cmd.contains("stripped_target=${target%\"$deleted_suffix\"}"));
         assert!(cmd.contains("proc_path_has_workspace_ref()"));
         assert!(cmd.contains("proc_maps_has_workspace_ref()"));
-        assert!(cmd.contains("if pid_has_workspace_ref \"$pid\"; then"));
+        assert!(cmd.contains("if pid_has_fast_workspace_ref \"$pid\"; then"));
         assert!(cmd.contains("if proc_path_has_workspace_ref \"$proc_dir/exe\"; then"));
         assert!(cmd.contains("if proc_maps_has_workspace_ref \"$proc_dir/maps\"; then"));
         assert!(cmd.contains("WORKSPACE_HOLDER_DIAGNOSTIC_LIMIT=40"));
+        assert!(cmd.contains("WORKSPACE_HOLDER_MAPS_LINE_LIMIT=4096"));
         assert!(cmd.contains("WORKSPACE_HOLDER_VALUE_LIMIT=240"));
         assert!(cmd.contains("WORKSPACE_HOLDER_KILL_GRACE_SECONDS=1"));
-        assert!(cmd.contains("wait_for_workspace_holders_to_clear()"));
-        assert!(cmd.contains("workspace holder diagnostics truncated"));
+        assert!(cmd.contains("wait_for_fast_workspace_holders_to_clear()"));
+        assert!(cmd.contains("diagnostics truncated after $WORKSPACE_HOLDER_DIAGNOSTIC_LIMIT"));
+        assert!(cmd.contains("workspace holder cleanup: fast scan started"));
+        assert!(cmd.contains("workspace holder cleanup: TERM started"));
+        assert!(cmd.contains("workspace holder cleanup: KILL started"));
+        assert!(cmd.contains("workspace holder cleanup: slow maps scan started"));
+        assert!(cmd.contains("workspace holder cleanup: maps KILL started"));
         assert!(cmd.contains("pid=%s uid=%s comm=%s ref=%s path=%s"));
         assert!(cmd.contains("comm=\"$(sanitize_log_value \"$comm\")\""));
         assert!(cmd.contains("target=\"$(sanitize_log_value \"$target\")\""));
-        assert!(cmd.contains("pid_has_workspace_ref \"$pid\" || continue"));
+        assert!(cmd.contains("pid_has_fast_workspace_ref \"$pid\" || continue"));
+        assert!(cmd.contains("pid_has_maps_workspace_ref \"$pid\" || continue"));
         assert!(cmd.contains("[ \"$pid\" != \"$$\" ] || continue"));
         assert!(cmd.contains("[ \"$pid\" != \"1\" ] || continue"));
 
         let clean_unmount = cmd
             .find("if umount -- \"$workspace_dir\"")
             .expect("clean unmount");
-        let diagnose = cmd
-            .find("holder_pids=\"$(workspace_holder_pids)\"")
-            .expect("holder pid collection");
+        let fast_scan = cmd
+            .find("scan_workspace_fast_holder_refs | collect_and_log_workspace_holders")
+            .expect("fast holder scan");
         let term = cmd
-            .find("term_workspace_holder_pids \"$holder_pids\"")
+            .find("term_workspace_holder_record_pids \"$holder_records\"")
             .expect("TERM holders");
         let term_wait = cmd
-            .find("wait_for_workspace_holders_to_clear \"$WORKSPACE_HOLDER_TERM_GRACE_SECONDS\"")
+            .find(
+                "wait_for_fast_workspace_holders_to_clear \"$WORKSPACE_HOLDER_TERM_GRACE_SECONDS\"",
+            )
             .expect("TERM holder wait");
+        let term_retry = cmd
+            .find("retry_workspace_unmount \"fast cleanup\"")
+            .expect("TERM retry unmount");
         let rescan = cmd
-            .find("remaining_holder_pids=\"$(workspace_holder_pids)\"")
+            .find("scan_workspace_fast_holder_refs | collect_and_log_workspace_holders \"$remaining_holder_records\"")
             .expect("holder rescan");
         let kill = cmd
-            .find("kill_workspace_holder_pids \"$remaining_holder_pids\"")
+            .find("kill_workspace_holder_record_pids \"$remaining_holder_records\" fast")
             .expect("KILL remaining holders");
         let kill_wait = find_after(
             &cmd,
-            "wait_for_workspace_holders_to_clear \"$WORKSPACE_HOLDER_KILL_GRACE_SECONDS\"",
+            "wait_for_fast_workspace_holders_to_clear \"$WORKSPACE_HOLDER_KILL_GRACE_SECONDS\"",
             kill,
         );
-        let retry_sync = find_after(&cmd, "sync -f -- \"$workspace_dir\"", kill_wait);
-        let retry_unmount = find_after(&cmd, "umount -- \"$workspace_dir\"", retry_sync);
+        let kill_retry = find_after(
+            &cmd,
+            "retry_workspace_unmount \"fast KILL cleanup\"",
+            kill_wait,
+        );
+        let maps_scan = find_after(
+            &cmd,
+            "scan_workspace_maps_holder_refs | collect_and_log_workspace_holders",
+            kill_retry,
+        );
 
         assert!(
-            clean_unmount < diagnose,
-            "holder diagnosis must only happen after clean unmount fails"
+            clean_unmount < fast_scan,
+            "fast holder diagnosis must only happen after clean unmount fails"
         );
-        assert!(diagnose < term, "holders must be diagnosed before TERM");
+        assert!(fast_scan < term, "holders must be diagnosed before TERM");
         assert!(term < term_wait, "TERM must wait for holder refs to clear");
         assert!(
-            term_wait < rescan,
-            "holders must be rescanned after TERM wait"
+            term_wait < term_retry,
+            "TERM wait must precede retry unmount"
+        );
+        assert!(
+            term_retry < rescan,
+            "holders must be rescanned only after TERM retry fails"
         );
         assert!(
             rescan < kill,
             "KILL must only target holders confirmed by the rescan"
         );
-        assert!(kill < retry_sync, "cleanup must happen before retry sync");
         assert!(
             kill < kill_wait,
             "KILL must wait for holder refs to clear before retry sync"
         );
         assert!(
-            retry_sync < retry_unmount,
-            "retry sync must happen before retry unmount"
+            kill_wait < kill_retry,
+            "KILL wait must happen before KILL retry unmount"
+        );
+        assert!(
+            kill_retry < maps_scan,
+            "slow maps scan must run after fast TERM/KILL retries"
         );
     }
 


### PR DESCRIPTION
## Summary
- split workspace unmount holder diagnostics into fast cwd/root/exe/fd scans and a delayed bounded maps scan
- retry clean umount after TERM cleanup and again after confirmed KILL cleanup before falling back to maps diagnostics
- keep workspace cache promotion fail-closed: promotion still only proceeds after the guest workspace drive unmount succeeds

Fixes #18872

## Tests
- sh -n crates/runner/scripts/unmount-workspace-drive.sh
- cargo fmt --manifest-path crates/Cargo.toml --all -- --check
- git diff --check
- cargo test --manifest-path crates/Cargo.toml -p runner workspace_mount::tests -- --nocapture
- cargo test --manifest-path crates/Cargo.toml -p runner

## Pre-commit
- lefthook check-file-size
- lefthook ensure-connector-firewalls-index-only
- lefthook crates cargo-fmt
- lefthook crates cargo-doc
- lefthook crates cargo-clippy
- commitlint