### PR TITLE
perf: add pre-create dispatch timing

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -62,6 +62,7 @@ const TEST_VM0_MANAGED_API_KEY = "vm0-key-run-lifecycle-bdd-default-model";
 const MODEL_FIRST_SELECTION_PROVIDER_ID =
   "00000000-0000-4000-8000-000000000000";
 const API_DISPATCH_TIMING_ACTION_TYPES = [
+  "api_dispatch_pre_create_agent_run",
   "api_dispatch_check_org_tier",
   "api_dispatch_prepare_run_context",
   "api_dispatch_prepare_context_feature_switches",
@@ -347,6 +348,15 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     for (const actionType of API_DISPATCH_TIMING_ACTION_TYPES) {
       expect(observedActionTypes).toContain(actionType);
     }
+    const preCreateEvents = timingEvents.filter((event) => {
+      return event.op_type === "api_dispatch_pre_create_agent_run";
+    });
+    expect(preCreateEvents).toHaveLength(1);
+    expect(preCreateEvents[0]).toStrictEqual(
+      expect.objectContaining({
+        span_kind: "top_level",
+      }),
+    );
     expect(observedActionTypes).not.toContain("api_dispatch_check_vm0_credits");
     expect(observedActionTypes).not.toContain("api_dispatch_notify_runner_job");
 

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -178,6 +178,7 @@ const AUTO_MEMORY_MISSING_ROOT_POLICY: ArtifactMissingRootPolicy =
 
 type ApiDispatchTimingSpanKind = "top_level" | "nested";
 type ApiDispatchTimingActionType =
+  | "api_dispatch_pre_create_agent_run"
   | "api_dispatch_check_org_tier"
   | "api_dispatch_prepare_run_context"
   | "api_dispatch_prepare_context_feature_switches"
@@ -214,22 +215,29 @@ interface ApiDispatchTimingRecord {
 class ApiDispatchTimingCollector {
   private readonly records: ApiDispatchTimingRecord[] = [];
 
+  recordElapsed(
+    actionType: ApiDispatchTimingActionType,
+    spanKind: ApiDispatchTimingSpanKind,
+    startedAt: number,
+    finishedAt: number = now(),
+  ): void {
+    this.records.push({
+      actionType,
+      spanKind,
+      durationMs: Math.max(0, finishedAt - startedAt),
+      timestamp: new Date(finishedAt).toISOString(),
+    });
+  }
+
   measure<T>(
     actionType: ApiDispatchTimingActionType,
     spanKind: ApiDispatchTimingSpanKind,
     operation: () => Promise<T>,
   ): Promise<T> {
     const startedAt = now();
-    const record = (): void => {
-      const finishedAt = now();
-      this.records.push({
-        actionType,
-        spanKind,
-        durationMs: Math.max(0, finishedAt - startedAt),
-        timestamp: new Date(finishedAt).toISOString(),
-      });
-    };
-    return operation().finally(record);
+    return operation().finally(() => {
+      this.recordElapsed(actionType, spanKind, startedAt);
+    });
   }
 
   flush(args: {
@@ -5038,6 +5046,11 @@ export const createAgentRun$ = command(
   ): Promise<CreateRunRouteResult> => {
     const db = set(writeDb$);
     const timing = new ApiDispatchTimingCollector();
+    timing.recordElapsed(
+      "api_dispatch_pre_create_agent_run",
+      "top_level",
+      args.apiStartTime,
+    );
     const tierGate = await timing.measure(
       "api_dispatch_check_org_tier",
       "top_level",


### PR DESCRIPTION
## Summary

- Add `api_dispatch_pre_create_agent_run` to measure the elapsed span from the existing `apiStartTime` to the start of `createAgentRun$` dispatch timing.
- Reuse the existing API dispatch timing collector and safe sandbox operation dimensions.
- Update the run lifecycle route integration test to require the new top-level timing row and keep the existing safety checks.

## Boundary Notes

- `apiStartTime` remains set inside authenticated create-run handlers.
- Auth wrapper work remains outside this interval.
- The new row measures `apiStartTime -> createAgentRun$ collector start`.
- Existing top-level rows still measure work inside `createAgentRun$`.
- Nested `prepare_context` rows remain children of `api_dispatch_prepare_run_context`.
- Queued runs remain outside the current direct-dispatch collector flush behavior.

Closes #18848

## Tests

- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "api dispatch timing"`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `git diff --check`
- pre-commit hook: prettier, knip, full `pnpm check-types`
