### PR TITLE
perf: avoid ably protocol json decode round trip

### DIFF
--- a/crates/ably-subscriber/src/protocol.rs
+++ b/crates/ably-subscriber/src/protocol.rs
@@ -324,7 +324,8 @@ fn decode_ably_message(map: MsgpackMap) -> Result<AblyMessage, Error> {
 
 fn optional_messages(value: Option<rmpv::Value>) -> Result<Option<Vec<AblyMessage>>, Error> {
     match value {
-        None | Some(rmpv::Value::Nil) => Ok(None),
+        None => Ok(None),
+        Some(value) if is_json_null_equivalent(&value) => Ok(None),
         Some(rmpv::Value::Array(messages)) => messages
             .into_iter()
             .map(|message| match message {
@@ -339,7 +340,8 @@ fn optional_messages(value: Option<rmpv::Value>) -> Result<Option<Vec<AblyMessag
 
 fn optional_params(value: Option<rmpv::Value>) -> Result<Option<HashMap<String, String>>, Error> {
     match value {
-        None | Some(rmpv::Value::Nil) => Ok(None),
+        None => Ok(None),
+        Some(value) if is_json_null_equivalent(&value) => Ok(None),
         Some(rmpv::Value::Map(map)) => {
             let mut raw_values = HashMap::new();
             for (key, value) in map {
@@ -364,7 +366,8 @@ fn optional_map<T>(
     decode: fn(MsgpackMap) -> Result<T, Error>,
 ) -> Result<Option<T>, Error> {
     match value {
-        None | Some(rmpv::Value::Nil) => Ok(None),
+        None => Ok(None),
+        Some(value) if is_json_null_equivalent(&value) => Ok(None),
         Some(rmpv::Value::Map(map)) => decode(map).map(Some),
         Some(other) => Err(type_error(field, "map", &other)),
     }
@@ -372,7 +375,8 @@ fn optional_map<T>(
 
 fn optional_json(value: Option<rmpv::Value>) -> Option<serde_json::Value> {
     match value {
-        None | Some(rmpv::Value::Nil) => None,
+        None => None,
+        Some(value) if is_json_null_equivalent(&value) => None,
         Some(value) => Some(rmpv_to_json(value)),
     }
 }
@@ -382,7 +386,8 @@ fn optional_string(
     value: Option<rmpv::Value>,
 ) -> Result<Option<String>, Error> {
     match value {
-        None | Some(rmpv::Value::Nil) => Ok(None),
+        None => Ok(None),
+        Some(value) if is_json_null_equivalent(&value) => Ok(None),
         Some(value) => required_string(field, value).map(Some),
     }
 }
@@ -415,7 +420,8 @@ fn required_string(field: &'static str, value: rmpv::Value) -> Result<String, Er
 
 fn optional_i32(field: &'static str, value: Option<rmpv::Value>) -> Result<Option<i32>, Error> {
     match value {
-        None | Some(rmpv::Value::Nil) => Ok(None),
+        None => Ok(None),
+        Some(value) if is_json_null_equivalent(&value) => Ok(None),
         Some(value) => required_i32(field, value).map(Some),
     }
 }
@@ -444,7 +450,8 @@ fn required_i32(field: &'static str, value: rmpv::Value) -> Result<i32, Error> {
 
 fn optional_i64(field: &'static str, value: Option<rmpv::Value>) -> Result<Option<i64>, Error> {
     match value {
-        None | Some(rmpv::Value::Nil) => Ok(None),
+        None => Ok(None),
+        Some(value) if is_json_null_equivalent(&value) => Ok(None),
         Some(value) => required_i64(field, value).map(Some),
     }
 }
@@ -481,6 +488,15 @@ fn json_map_key(key: rmpv::Value) -> String {
             }
         },
         other => format!("{other}"),
+    }
+}
+
+fn is_json_null_equivalent(value: &rmpv::Value) -> bool {
+    match value {
+        rmpv::Value::Nil => true,
+        rmpv::Value::F32(value) => !value.is_finite(),
+        rmpv::Value::F64(value) => !value.is_finite(),
+        _ => false,
     }
 }
 

--- a/crates/ably-subscriber/src/protocol.rs
+++ b/crates/ably-subscriber/src/protocol.rs
@@ -144,6 +144,15 @@ pub fn decode_msg(data: &[u8]) -> Result<ProtocolMessage, Error> {
     decode_protocol_message(map)
 }
 
+// Inbound decoding intentionally does not use direct rmp_serde struct
+// deserialization. Ably can send duplicate MessagePack map keys, and serde
+// rejects duplicate struct fields. The old decoder used a full
+// MessagePack -> JSON -> ProtocolMessage round trip because serde_json object
+// collection gave us last-wins duplicate-key behavior while rmpv handled
+// MessagePack binary/ext values. This decoder keeps those compatibility
+// semantics without materializing a JSON tree for the whole protocol message:
+// known protocol fields are collected in wire order, and only AblyMessage.data
+// is converted to JSON because that field is exposed as serde_json::Value.
 fn decode_protocol_message(map: MsgpackMap) -> Result<ProtocolMessage, Error> {
     let mut action = None;
     let mut id = None;

--- a/crates/ably-subscriber/src/protocol.rs
+++ b/crates/ably-subscriber/src/protocol.rs
@@ -112,17 +112,13 @@ pub struct AblyMessage {
 // Encode / decode helpers
 // ---------------------------------------------------------------------------
 
+type MsgpackMap = Vec<(rmpv::Value, rmpv::Value)>;
+
 pub fn encode_msg(msg: &ProtocolMessage) -> Result<Vec<u8>, Error> {
     Ok(rmp_serde::to_vec_named(msg)?)
 }
 
 pub fn decode_msg(data: &[u8]) -> Result<ProtocolMessage, Error> {
-    // Three-step decode: msgpack → rmpv::Value → serde_json::Value → ProtocolMessage.
-    //
-    // 1. rmpv::Value handles msgpack binary data (which serde_json::Value cannot).
-    // 2. serde_json::Value deduplicates map keys (Ably may send "messages" twice,
-    //    which rmp_serde's struct deserializer rejects).
-    // This adds allocation overhead compared to direct struct deserialization.
     let mut cursor = std::io::Cursor::new(data);
     let value = rmpv::decode::read_value(&mut cursor).map_err(|e| Error::Protocol {
         code: error_code::BAD_REQUEST,
@@ -145,24 +141,365 @@ pub fn decode_msg(data: &[u8]) -> Result<ProtocolMessage, Error> {
         }
     };
 
-    if !map
-        .iter()
-        .any(|(key, _)| matches!(key, rmpv::Value::String(key) if key.as_str() == Some("action")))
-    {
+    decode_protocol_message(map)
+}
+
+fn decode_protocol_message(map: MsgpackMap) -> Result<ProtocolMessage, Error> {
+    let mut action = None;
+    let mut id = None;
+    let mut channel = None;
+    let mut channel_serial = None;
+    let mut connection_id = None;
+    let mut connection_key = None;
+    let mut connection_details = None;
+    let mut connection_serial = None;
+    let mut msg_serial = None;
+    let mut flags = None;
+    let mut error = None;
+    let mut auth = None;
+    let mut messages = None;
+    let mut timestamp = None;
+    let mut params = None;
+
+    for (key, value) in map {
+        match msgpack_key_name(&key) {
+            Some("action") => action = Some(value),
+            Some("id") => id = Some(value),
+            Some("channel") => channel = Some(value),
+            Some("channelSerial") => channel_serial = Some(value),
+            Some("connectionId") => connection_id = Some(value),
+            Some("connectionKey") => connection_key = Some(value),
+            Some("connectionDetails") => connection_details = Some(value),
+            Some("connectionSerial") => connection_serial = Some(value),
+            Some("msgSerial") => msg_serial = Some(value),
+            Some("flags") => flags = Some(value),
+            Some("error") => error = Some(value),
+            Some("auth") => auth = Some(value),
+            Some("messages") => messages = Some(value),
+            Some("timestamp") => timestamp = Some(value),
+            Some("params") => params = Some(value),
+            _ => {}
+        }
+    }
+
+    let Some(action) = action else {
         return Err(Error::Protocol {
             code: error_code::BAD_REQUEST,
             message: "protocol message missing action".to_string(),
         });
-    }
+    };
 
-    let json = rmpv_to_json(rmpv::Value::Map(map));
-    serde_json::from_value(json).map_err(|e| Error::Protocol {
-        code: error_code::BAD_REQUEST,
-        message: format!("message decode error: {e}"),
+    Ok(ProtocolMessage {
+        action: required_i32("action", action)?,
+        id: optional_string("id", id)?,
+        channel: optional_string("channel", channel)?,
+        channel_serial: optional_string("channelSerial", channel_serial)?,
+        connection_id: optional_string("connectionId", connection_id)?,
+        connection_key: optional_string("connectionKey", connection_key)?,
+        connection_details: optional_map(
+            "connectionDetails",
+            connection_details,
+            decode_connection_details,
+        )?,
+        connection_serial: optional_i64("connectionSerial", connection_serial)?,
+        msg_serial: optional_i64("msgSerial", msg_serial)?,
+        flags: optional_i32("flags", flags)?,
+        error: optional_map("error", error, decode_error_info)?,
+        auth: optional_map("auth", auth, decode_auth_details)?,
+        messages: optional_messages(messages)?,
+        timestamp: optional_i64("timestamp", timestamp)?,
+        params: optional_params(params)?,
     })
 }
 
-/// Convert an rmpv::Value to serde_json::Value, encoding binary data as base64 strings.
+fn decode_connection_details(map: MsgpackMap) -> Result<ConnectionDetails, Error> {
+    let mut client_id = None;
+    let mut connection_key = None;
+    let mut connection_state_ttl = None;
+    let mut max_idle_interval = None;
+    let mut max_message_size = None;
+    let mut max_frame_size = None;
+    let mut server_id = None;
+
+    for (key, value) in map {
+        match msgpack_key_name(&key) {
+            Some("clientId") => client_id = Some(value),
+            Some("connectionKey") => connection_key = Some(value),
+            Some("connectionStateTtl") => connection_state_ttl = Some(value),
+            Some("maxIdleInterval") => max_idle_interval = Some(value),
+            Some("maxMessageSize") => max_message_size = Some(value),
+            Some("maxFrameSize") => max_frame_size = Some(value),
+            Some("serverId") => server_id = Some(value),
+            _ => {}
+        }
+    }
+
+    Ok(ConnectionDetails {
+        client_id: optional_string("connectionDetails.clientId", client_id)?,
+        connection_key: optional_string("connectionDetails.connectionKey", connection_key)?,
+        connection_state_ttl: optional_i64(
+            "connectionDetails.connectionStateTtl",
+            connection_state_ttl,
+        )?,
+        max_idle_interval: optional_i64("connectionDetails.maxIdleInterval", max_idle_interval)?,
+        max_message_size: optional_i64("connectionDetails.maxMessageSize", max_message_size)?,
+        max_frame_size: optional_i64("connectionDetails.maxFrameSize", max_frame_size)?,
+        server_id: optional_string("connectionDetails.serverId", server_id)?,
+    })
+}
+
+fn decode_error_info(map: MsgpackMap) -> Result<ErrorInfo, Error> {
+    let mut code = None;
+    let mut status_code = None;
+    let mut message = None;
+
+    for (key, value) in map {
+        match msgpack_key_name(&key) {
+            Some("code") => code = Some(value),
+            Some("statusCode") => status_code = Some(value),
+            Some("message") => message = Some(value),
+            _ => {}
+        }
+    }
+
+    Ok(ErrorInfo {
+        code: required_i32_or_default("error.code", code)?,
+        status_code: optional_i32("error.statusCode", status_code)?,
+        message: required_string_or_default("error.message", message)?,
+    })
+}
+
+fn decode_auth_details(map: MsgpackMap) -> Result<AuthDetails, Error> {
+    let mut access_token = None;
+
+    for (key, value) in map {
+        if msgpack_key_name(&key) == Some("accessToken") {
+            access_token = Some(value);
+        }
+    }
+
+    Ok(AuthDetails {
+        access_token: required_string_or_default("auth.accessToken", access_token)?,
+    })
+}
+
+fn decode_ably_message(map: MsgpackMap) -> Result<AblyMessage, Error> {
+    let mut id = None;
+    let mut name = None;
+    let mut data = None;
+    let mut client_id = None;
+    let mut timestamp = None;
+    let mut encoding = None;
+
+    for (key, value) in map {
+        match msgpack_key_name(&key) {
+            Some("id") => id = Some(value),
+            Some("name") => name = Some(value),
+            Some("data") => data = Some(value),
+            Some("clientId") => client_id = Some(value),
+            Some("timestamp") => timestamp = Some(value),
+            Some("encoding") => encoding = Some(value),
+            _ => {}
+        }
+    }
+
+    Ok(AblyMessage {
+        id: optional_string("messages[].id", id)?,
+        name: optional_string("messages[].name", name)?,
+        data: optional_json(data),
+        client_id: optional_string("messages[].clientId", client_id)?,
+        timestamp: optional_i64("messages[].timestamp", timestamp)?,
+        encoding: optional_string("messages[].encoding", encoding)?,
+    })
+}
+
+fn optional_messages(value: Option<rmpv::Value>) -> Result<Option<Vec<AblyMessage>>, Error> {
+    match value {
+        None | Some(rmpv::Value::Nil) => Ok(None),
+        Some(rmpv::Value::Array(messages)) => messages
+            .into_iter()
+            .map(|message| match message {
+                rmpv::Value::Map(map) => decode_ably_message(map),
+                other => Err(type_error("messages[]", "map", &other)),
+            })
+            .collect::<Result<Vec<_>, _>>()
+            .map(Some),
+        Some(other) => Err(type_error("messages", "array", &other)),
+    }
+}
+
+fn optional_params(value: Option<rmpv::Value>) -> Result<Option<HashMap<String, String>>, Error> {
+    match value {
+        None | Some(rmpv::Value::Nil) => Ok(None),
+        Some(rmpv::Value::Map(map)) => {
+            let mut raw_values = HashMap::new();
+            for (key, value) in map {
+                raw_values.insert(json_map_key(key), value);
+            }
+
+            raw_values
+                .into_iter()
+                .map(|(key, value)| {
+                    required_string("params value", value).map(|value| (key, value))
+                })
+                .collect::<Result<HashMap<_, _>, _>>()
+                .map(Some)
+        }
+        Some(other) => Err(type_error("params", "map", &other)),
+    }
+}
+
+fn optional_map<T>(
+    field: &'static str,
+    value: Option<rmpv::Value>,
+    decode: fn(MsgpackMap) -> Result<T, Error>,
+) -> Result<Option<T>, Error> {
+    match value {
+        None | Some(rmpv::Value::Nil) => Ok(None),
+        Some(rmpv::Value::Map(map)) => decode(map).map(Some),
+        Some(other) => Err(type_error(field, "map", &other)),
+    }
+}
+
+fn optional_json(value: Option<rmpv::Value>) -> Option<serde_json::Value> {
+    match value {
+        None | Some(rmpv::Value::Nil) => None,
+        Some(value) => Some(rmpv_to_json(value)),
+    }
+}
+
+fn optional_string(
+    field: &'static str,
+    value: Option<rmpv::Value>,
+) -> Result<Option<String>, Error> {
+    match value {
+        None | Some(rmpv::Value::Nil) => Ok(None),
+        Some(value) => required_string(field, value).map(Some),
+    }
+}
+
+fn required_string_or_default(
+    field: &'static str,
+    value: Option<rmpv::Value>,
+) -> Result<String, Error> {
+    match value {
+        None => Ok(String::new()),
+        Some(value) => required_string(field, value),
+    }
+}
+
+fn required_string(field: &'static str, value: rmpv::Value) -> Result<String, Error> {
+    match value {
+        rmpv::Value::String(s) => match s.into_str() {
+            Some(s) => Ok(s),
+            None => {
+                tracing::warn!("msgpack string contains invalid UTF-8, substituting empty string");
+                Ok(String::new())
+            }
+        },
+        rmpv::Value::Binary(bytes) | rmpv::Value::Ext(_, bytes) => {
+            Ok(base64::engine::general_purpose::STANDARD.encode(&bytes))
+        }
+        other => Err(type_error(field, "string", &other)),
+    }
+}
+
+fn optional_i32(field: &'static str, value: Option<rmpv::Value>) -> Result<Option<i32>, Error> {
+    match value {
+        None | Some(rmpv::Value::Nil) => Ok(None),
+        Some(value) => required_i32(field, value).map(Some),
+    }
+}
+
+fn required_i32_or_default(field: &'static str, value: Option<rmpv::Value>) -> Result<i32, Error> {
+    match value {
+        None => Ok(0),
+        Some(value) => required_i32(field, value),
+    }
+}
+
+fn required_i32(field: &'static str, value: rmpv::Value) -> Result<i32, Error> {
+    match value {
+        rmpv::Value::Integer(i) => {
+            if let Some(n) = i.as_i64() {
+                i32::try_from(n).map_err(|_| type_error(field, "i32", &rmpv::Value::Integer(i)))
+            } else if let Some(n) = i.as_u64() {
+                i32::try_from(n).map_err(|_| type_error(field, "i32", &rmpv::Value::Integer(i)))
+            } else {
+                Err(type_error(field, "i32", &rmpv::Value::Integer(i)))
+            }
+        }
+        other => Err(type_error(field, "i32", &other)),
+    }
+}
+
+fn optional_i64(field: &'static str, value: Option<rmpv::Value>) -> Result<Option<i64>, Error> {
+    match value {
+        None | Some(rmpv::Value::Nil) => Ok(None),
+        Some(value) => required_i64(field, value).map(Some),
+    }
+}
+
+fn required_i64(field: &'static str, value: rmpv::Value) -> Result<i64, Error> {
+    match value {
+        rmpv::Value::Integer(i) => {
+            if let Some(n) = i.as_i64() {
+                Ok(n)
+            } else if let Some(n) = i.as_u64() {
+                i64::try_from(n).map_err(|_| type_error(field, "i64", &rmpv::Value::Integer(i)))
+            } else {
+                Err(type_error(field, "i64", &rmpv::Value::Integer(i)))
+            }
+        }
+        other => Err(type_error(field, "i64", &other)),
+    }
+}
+
+fn msgpack_key_name(key: &rmpv::Value) -> Option<&str> {
+    match key {
+        rmpv::Value::String(key) => key.as_str(),
+        _ => None,
+    }
+}
+
+fn json_map_key(key: rmpv::Value) -> String {
+    match key {
+        rmpv::Value::String(s) => match s.into_str() {
+            Some(s) => s,
+            None => {
+                tracing::warn!("msgpack map key contains invalid UTF-8, substituting empty string");
+                String::new()
+            }
+        },
+        other => format!("{other}"),
+    }
+}
+
+fn type_error(field: &'static str, expected: &'static str, actual: &rmpv::Value) -> Error {
+    Error::Protocol {
+        code: error_code::BAD_REQUEST,
+        message: format!(
+            "message decode error: field {field} expected {expected}, got {}",
+            value_kind(actual)
+        ),
+    }
+}
+
+fn value_kind(value: &rmpv::Value) -> &'static str {
+    match value {
+        rmpv::Value::Nil => "nil",
+        rmpv::Value::Boolean(_) => "boolean",
+        rmpv::Value::Integer(_) => "integer",
+        rmpv::Value::F32(_) | rmpv::Value::F64(_) => "float",
+        rmpv::Value::String(_) => "string",
+        rmpv::Value::Binary(_) => "binary",
+        rmpv::Value::Array(_) => "array",
+        rmpv::Value::Map(_) => "map",
+        rmpv::Value::Ext(_, _) => "ext",
+    }
+}
+
+/// Convert a MessagePack value to JSON, encoding binary data as base64 strings.
 fn rmpv_to_json(value: rmpv::Value) -> serde_json::Value {
     match value {
         rmpv::Value::Nil => serde_json::Value::Null,

--- a/crates/ably-subscriber/tests/protocol_decode.rs
+++ b/crates/ably-subscriber/tests/protocol_decode.rs
@@ -263,6 +263,30 @@ fn decode_msg_accepts_duplicate_message_fields_from_msgpack() -> TestResult {
 }
 
 #[test]
+fn decode_msg_accepts_duplicate_nested_field_when_later_value_is_valid() -> TestResult {
+    let payload = rmpv::Value::Map(vec![
+        field("action", rmpv::Value::from(action::MESSAGE)),
+        field(
+            "messages",
+            rmpv::Value::Array(vec![rmpv::Value::Map(vec![
+                field("name", rmpv::Value::Array(Vec::new())),
+                field("name", str_value("job")),
+                field("timestamp", str_value("not-a-number")),
+                field("timestamp", rmpv::Value::from(2)),
+            ])]),
+        ),
+    ]);
+
+    let encoded = encode_value(payload)?;
+    let decoded = decode_msg(&encoded)?;
+
+    let message = single_message(&decoded)?;
+    assert_eq!(message.name.as_deref(), Some("job"));
+    assert_eq!(message.timestamp, Some(2));
+    Ok(())
+}
+
+#[test]
 fn decode_msg_ignores_unknown_fields() -> TestResult {
     let payload = rmpv::Value::Map(vec![
         field("action", rmpv::Value::from(action::MESSAGE)),

--- a/crates/ably-subscriber/tests/protocol_decode.rs
+++ b/crates/ably-subscriber/tests/protocol_decode.rs
@@ -113,6 +113,51 @@ fn decode_msg_rejects_field_type_mismatches() -> TestResult {
 }
 
 #[test]
+fn decode_msg_rejects_nil_required_fields() -> TestResult {
+    let action_as_nil = rmpv::Value::Map(vec![field("action", rmpv::Value::Nil)]);
+    let encoded = encode_value(action_as_nil)?;
+    expect_bad_request(&encoded)?;
+
+    let error_code_as_nil = rmpv::Value::Map(vec![
+        field("action", rmpv::Value::from(action::ERROR)),
+        field(
+            "error",
+            rmpv::Value::Map(vec![field("code", rmpv::Value::Nil)]),
+        ),
+    ]);
+    let encoded = encode_value(error_code_as_nil)?;
+    expect_bad_request(&encoded)?;
+
+    let auth_token_as_nil = rmpv::Value::Map(vec![
+        field("action", rmpv::Value::from(action::AUTH)),
+        field(
+            "auth",
+            rmpv::Value::Map(vec![field("accessToken", rmpv::Value::Nil)]),
+        ),
+    ]);
+    let encoded = encode_value(auth_token_as_nil)?;
+    expect_bad_request(&encoded)?;
+
+    Ok(())
+}
+
+#[test]
+fn decode_msg_rejects_integer_fields_outside_target_range() -> TestResult {
+    let action_outside_i32 = rmpv::Value::Map(vec![field("action", rmpv::Value::from(i64::MAX))]);
+    let encoded = encode_value(action_outside_i32)?;
+    expect_bad_request(&encoded)?;
+
+    let timestamp_outside_i64 = rmpv::Value::Map(vec![
+        field("action", rmpv::Value::from(action::MESSAGE)),
+        field("timestamp", rmpv::Value::from(u64::MAX)),
+    ]);
+    let encoded = encode_value(timestamp_outside_i64)?;
+    expect_bad_request(&encoded)?;
+
+    Ok(())
+}
+
+#[test]
 fn decode_msg_rejects_nested_field_type_mismatches() -> TestResult {
     let message_name_as_array = rmpv::Value::Map(vec![
         field("action", rmpv::Value::from(action::MESSAGE)),
@@ -170,6 +215,44 @@ fn decode_msg_accepts_unknown_numeric_action() -> TestResult {
     let decoded = decode_msg(&encoded)?;
 
     assert_eq!(decoded.action, 123_456);
+
+    Ok(())
+}
+
+#[test]
+fn decode_msg_preserves_nil_optional_fields_and_empty_nested_defaults() -> TestResult {
+    let payload = rmpv::Value::Map(vec![
+        field("action", rmpv::Value::from(action::CONNECTED)),
+        field("channel", rmpv::Value::Nil),
+        field("messages", rmpv::Value::Nil),
+        field("params", rmpv::Value::Nil),
+        field("connectionDetails", rmpv::Value::Map(Vec::new())),
+        field("error", rmpv::Value::Map(Vec::new())),
+        field("auth", rmpv::Value::Map(Vec::new())),
+    ]);
+
+    let encoded = encode_value(payload)?;
+    let decoded = decode_msg(&encoded)?;
+
+    assert!(decoded.channel.is_none());
+    assert!(decoded.messages.is_none());
+    assert!(decoded.params.is_none());
+    let connection_details = decoded
+        .connection_details
+        .as_ref()
+        .ok_or_else(|| io::Error::other("connection details are missing"))?;
+    assert!(connection_details.connection_key.is_none());
+    let error = decoded
+        .error
+        .as_ref()
+        .ok_or_else(|| io::Error::other("error info is missing"))?;
+    assert_eq!(error.code, 0);
+    assert_eq!(error.message, "");
+    let auth = decoded
+        .auth
+        .as_ref()
+        .ok_or_else(|| io::Error::other("auth details are missing"))?;
+    assert_eq!(auth.access_token, "");
 
     Ok(())
 }

--- a/crates/ably-subscriber/tests/protocol_decode.rs
+++ b/crates/ably-subscriber/tests/protocol_decode.rs
@@ -109,6 +109,13 @@ fn decode_msg_rejects_field_type_mismatches() -> TestResult {
     let encoded = encode_value(messages_as_string)?;
     expect_bad_request(&encoded)?;
 
+    let message_item_as_string = rmpv::Value::Map(vec![
+        field("action", rmpv::Value::from(action::MESSAGE)),
+        field("messages", rmpv::Value::Array(vec![str_value("not-map")])),
+    ]);
+    let encoded = encode_value(message_item_as_string)?;
+    expect_bad_request(&encoded)?;
+
     Ok(())
 }
 

--- a/crates/ably-subscriber/tests/protocol_decode.rs
+++ b/crates/ably-subscriber/tests/protocol_decode.rs
@@ -113,6 +113,46 @@ fn decode_msg_rejects_field_type_mismatches() -> TestResult {
 }
 
 #[test]
+fn decode_msg_rejects_nested_field_type_mismatches() -> TestResult {
+    let message_name_as_array = rmpv::Value::Map(vec![
+        field("action", rmpv::Value::from(action::MESSAGE)),
+        field(
+            "messages",
+            rmpv::Value::Array(vec![rmpv::Value::Map(vec![field(
+                "name",
+                rmpv::Value::Array(Vec::new()),
+            )])]),
+        ),
+    ]);
+    let encoded = encode_value(message_name_as_array)?;
+    expect_bad_request(&encoded)?;
+
+    Ok(())
+}
+
+#[test]
+fn decode_msg_type_errors_do_not_include_field_values() -> TestResult {
+    let secret = "secret-access-token";
+    let auth_as_string = rmpv::Value::Map(vec![
+        field("action", rmpv::Value::from(action::AUTH)),
+        field("auth", str_value(secret)),
+    ]);
+    let encoded = encode_value(auth_as_string)?;
+
+    match decode_msg(&encoded) {
+        Err(AblyError::Protocol { message, .. }) => {
+            assert!(message.contains("field auth expected map, got string"));
+            assert!(!message.contains(secret));
+            Ok(())
+        }
+        Err(err) => {
+            Err(io::Error::other(format!("expected BAD_REQUEST protocol error, got {err}")).into())
+        }
+        Ok(_) => Err(io::Error::other("expected BAD_REQUEST protocol error").into()),
+    }
+}
+
+#[test]
 fn decode_msg_rejects_trailing_bytes() -> TestResult {
     let payload = rmpv::Value::Map(vec![field("action", rmpv::Value::from(action::HEARTBEAT))]);
     let mut encoded = encode_value(payload)?;
@@ -131,6 +171,42 @@ fn decode_msg_accepts_unknown_numeric_action() -> TestResult {
 
     assert_eq!(decoded.action, 123_456);
 
+    Ok(())
+}
+
+#[test]
+fn decode_msg_accepts_duplicate_scalar_keys_from_msgpack() -> TestResult {
+    let payload = rmpv::Value::Map(vec![
+        field("action", rmpv::Value::from(action::ATTACHED)),
+        field("channel", str_value("first")),
+        field("channel", str_value("second")),
+        field("flags", rmpv::Value::from(1)),
+        field("flags", rmpv::Value::from(2)),
+    ]);
+
+    let encoded = encode_value(payload)?;
+    let decoded = decode_msg(&encoded)?;
+
+    assert_eq!(decoded.action, action::ATTACHED);
+    assert_eq!(decoded.channel.as_deref(), Some("second"));
+    assert_eq!(decoded.flags, Some(2));
+    Ok(())
+}
+
+#[test]
+fn decode_msg_accepts_duplicate_field_when_later_value_is_valid() -> TestResult {
+    let payload = rmpv::Value::Map(vec![
+        field("action", str_value("not-a-number")),
+        field("action", rmpv::Value::from(action::ATTACHED)),
+        field("channel", rmpv::Value::Array(Vec::new())),
+        field("channel", str_value("channel")),
+    ]);
+
+    let encoded = encode_value(payload)?;
+    let decoded = decode_msg(&encoded)?;
+
+    assert_eq!(decoded.action, action::ATTACHED);
+    assert_eq!(decoded.channel.as_deref(), Some("channel"));
     Ok(())
 }
 
@@ -163,6 +239,93 @@ fn decode_msg_accepts_duplicate_messages_key_from_msgpack() -> TestResult {
 }
 
 #[test]
+fn decode_msg_accepts_duplicate_message_fields_from_msgpack() -> TestResult {
+    let payload = rmpv::Value::Map(vec![
+        field("action", rmpv::Value::from(action::MESSAGE)),
+        field(
+            "messages",
+            rmpv::Value::Array(vec![rmpv::Value::Map(vec![
+                field("name", str_value("first")),
+                field("name", str_value("second")),
+                field("timestamp", rmpv::Value::from(1)),
+                field("timestamp", rmpv::Value::from(2)),
+            ])]),
+        ),
+    ]);
+
+    let encoded = encode_value(payload)?;
+    let decoded = decode_msg(&encoded)?;
+
+    let message = single_message(&decoded)?;
+    assert_eq!(message.name.as_deref(), Some("second"));
+    assert_eq!(message.timestamp, Some(2));
+    Ok(())
+}
+
+#[test]
+fn decode_msg_ignores_unknown_fields() -> TestResult {
+    let payload = rmpv::Value::Map(vec![
+        field("action", rmpv::Value::from(action::MESSAGE)),
+        field("unknownTopLevel", str_value("ignored")),
+        field(
+            "messages",
+            rmpv::Value::Array(vec![rmpv::Value::Map(vec![
+                field("name", str_value("job")),
+                field("unknownMessageField", rmpv::Value::Boolean(true)),
+            ])]),
+        ),
+    ]);
+
+    let encoded = encode_value(payload)?;
+    let decoded = decode_msg(&encoded)?;
+
+    assert_eq!(decoded.action, action::MESSAGE);
+    let message = single_message(&decoded)?;
+    assert_eq!(message.name.as_deref(), Some("job"));
+    Ok(())
+}
+
+#[test]
+fn decode_msg_preserves_nested_data_maps_and_arrays() -> TestResult {
+    let payload = rmpv::Value::Map(vec![
+        field("action", rmpv::Value::from(action::MESSAGE)),
+        field(
+            "messages",
+            rmpv::Value::Array(vec![rmpv::Value::Map(vec![field(
+                "data",
+                rmpv::Value::Map(vec![
+                    field(
+                        "items",
+                        rmpv::Value::Array(vec![
+                            rmpv::Value::from(1),
+                            rmpv::Value::Boolean(true),
+                            str_value("three"),
+                        ]),
+                    ),
+                    field(
+                        "nested",
+                        rmpv::Value::Map(vec![field("ok", str_value("yes"))]),
+                    ),
+                ]),
+            )])]),
+        ),
+    ]);
+
+    let encoded = encode_value(payload)?;
+    let decoded = decode_msg(&encoded)?;
+
+    let message = single_message(&decoded)?;
+    assert_eq!(
+        message.data.as_ref(),
+        Some(&serde_json::json!({
+            "items": [1, true, "three"],
+            "nested": {"ok": "yes"}
+        }))
+    );
+    Ok(())
+}
+
+#[test]
 fn decode_msg_converts_msgpack_binary_data_to_base64_string() -> TestResult {
     let payload = rmpv::Value::Map(vec![
         field("action", rmpv::Value::from(action::MESSAGE)),
@@ -184,5 +347,60 @@ fn decode_msg_converts_msgpack_binary_data_to_base64_string() -> TestResult {
         message.data.as_ref().and_then(|data| data.as_str()),
         Some("AAH+/w==")
     );
+    Ok(())
+}
+
+#[test]
+fn decode_msg_converts_msgpack_ext_data_to_base64_string() -> TestResult {
+    let payload = rmpv::Value::Map(vec![
+        field("action", rmpv::Value::from(action::MESSAGE)),
+        field(
+            "messages",
+            rmpv::Value::Array(vec![rmpv::Value::Map(vec![field(
+                "data",
+                rmpv::Value::Ext(1, vec![0xde, 0xad]),
+            )])]),
+        ),
+    ]);
+
+    let encoded = encode_value(payload)?;
+    let decoded = decode_msg(&encoded)?;
+
+    let message = single_message(&decoded)?;
+    assert_eq!(
+        message.data.as_ref().and_then(|data| data.as_str()),
+        Some("3q0=")
+    );
+    Ok(())
+}
+
+#[test]
+fn decode_msg_replaces_invalid_utf8_string_with_empty_string() -> TestResult {
+    let data = [
+        0x82,
+        b'\xa6',
+        b'a',
+        b'c',
+        b't',
+        b'i',
+        b'o',
+        b'n',
+        action::MESSAGE as u8,
+        b'\xa7',
+        b'c',
+        b'h',
+        b'a',
+        b'n',
+        b'n',
+        b'e',
+        b'l',
+        b'\xa1',
+        b'\xff',
+    ];
+
+    let decoded = decode_msg(&data)?;
+
+    assert_eq!(decoded.action, action::MESSAGE);
+    assert_eq!(decoded.channel.as_deref(), Some(""));
     Ok(())
 }

--- a/crates/ably-subscriber/tests/protocol_decode.rs
+++ b/crates/ably-subscriber/tests/protocol_decode.rs
@@ -258,6 +258,59 @@ fn decode_msg_preserves_nil_optional_fields_and_empty_nested_defaults() -> TestR
 }
 
 #[test]
+fn decode_msg_treats_non_finite_optional_fields_as_null() -> TestResult {
+    let payload = rmpv::Value::Map(vec![
+        field("action", rmpv::Value::from(action::MESSAGE)),
+        field("channel", rmpv::Value::F64(f64::NAN)),
+        field("timestamp", rmpv::Value::F64(f64::INFINITY)),
+        field("params", rmpv::Value::F32(f32::NEG_INFINITY)),
+        field("connectionDetails", rmpv::Value::F64(f64::NAN)),
+        field("auth", rmpv::Value::F32(f32::INFINITY)),
+        field("error", rmpv::Value::F64(f64::NEG_INFINITY)),
+        field(
+            "messages",
+            rmpv::Value::Array(vec![rmpv::Value::Map(vec![
+                field("name", str_value("job")),
+                field("data", rmpv::Value::F64(f64::NAN)),
+                field("timestamp", rmpv::Value::F64(f64::INFINITY)),
+                field("encoding", rmpv::Value::F32(f32::NAN)),
+            ])]),
+        ),
+    ]);
+
+    let encoded = encode_value(payload)?;
+    let decoded = decode_msg(&encoded)?;
+
+    assert!(decoded.channel.is_none());
+    assert!(decoded.timestamp.is_none());
+    assert!(decoded.params.is_none());
+    assert!(decoded.connection_details.is_none());
+    assert!(decoded.auth.is_none());
+    assert!(decoded.error.is_none());
+    let message = single_message(&decoded)?;
+    assert_eq!(message.name.as_deref(), Some("job"));
+    assert!(message.data.is_none());
+    assert!(message.timestamp.is_none());
+    assert!(message.encoding.is_none());
+
+    Ok(())
+}
+
+#[test]
+fn decode_msg_treats_non_finite_messages_field_as_null() -> TestResult {
+    let payload = rmpv::Value::Map(vec![
+        field("action", rmpv::Value::from(action::MESSAGE)),
+        field("messages", rmpv::Value::F64(f64::NAN)),
+    ]);
+
+    let encoded = encode_value(payload)?;
+    let decoded = decode_msg(&encoded)?;
+
+    assert!(decoded.messages.is_none());
+    Ok(())
+}
+
+#[test]
 fn decode_msg_accepts_duplicate_scalar_keys_from_msgpack() -> TestResult {
     let payload = rmpv::Value::Map(vec![
         field("action", rmpv::Value::from(action::ATTACHED)),

--- a/crates/ably-subscriber/tests/protocol_decode.rs
+++ b/crates/ably-subscriber/tests/protocol_decode.rs
@@ -211,6 +211,33 @@ fn decode_msg_accepts_duplicate_field_when_later_value_is_valid() -> TestResult 
 }
 
 #[test]
+fn decode_msg_accepts_duplicate_params_field_when_later_value_is_valid() -> TestResult {
+    let payload = rmpv::Value::Map(vec![
+        field("action", rmpv::Value::from(action::ATTACH)),
+        field(
+            "params",
+            rmpv::Value::Map(vec![
+                field("rewind", rmpv::Value::Array(Vec::new())),
+                field("rewind", str_value("2m")),
+            ]),
+        ),
+    ]);
+
+    let encoded = encode_value(payload)?;
+    let decoded = decode_msg(&encoded)?;
+
+    assert_eq!(
+        decoded
+            .params
+            .as_ref()
+            .and_then(|params| params.get("rewind"))
+            .map(String::as_str),
+        Some("2m")
+    );
+    Ok(())
+}
+
+#[test]
 fn decode_msg_accepts_duplicate_messages_key_from_msgpack() -> TestResult {
     let payload = rmpv::Value::Map(vec![
         field("action", rmpv::Value::from(action::MESSAGE)),


### PR DESCRIPTION
## Summary

- Replace inbound Ably protocol decoding's full `rmpv::Value -> serde_json::Value -> ProtocolMessage` round trip with direct protocol struct materialization from the decoded MessagePack map.
- Keep JSON conversion only for `AblyMessage.data`, where the public API already exposes `serde_json::Value`.
- Preserve duplicate-key last-wins behavior, binary/ext base64 data handling, invalid UTF-8 substitution, and malformed-frame `BAD_REQUEST` mapping.
- Add focused protocol decode regression coverage for duplicate fields, unknown fields, nested data, ext data, invalid UTF-8, and non-leaking type errors.

Closes #18856

## Testing

- `cargo test --manifest-path crates/Cargo.toml -p ably-subscriber --test protocol_decode`
- `cargo test --manifest-path crates/Cargo.toml -p ably-subscriber`
- `cargo clippy --manifest-path crates/Cargo.toml -p ably-subscriber --all-targets -- -D warnings`
- `cargo fmt --manifest-path crates/Cargo.toml -p ably-subscriber --check`
- `git diff --check`
