### PR TITLE
perf(api): split runner job queue persistence timing

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -61,6 +61,11 @@ const TEST_VM0_MANAGED_API_KEY = "vm0-key-run-lifecycle-bdd-default-model";
 // value the chat composer sends when picking a model instead of a provider).
 const MODEL_FIRST_SELECTION_PROVIDER_ID =
   "00000000-0000-4000-8000-000000000000";
+const API_DISPATCH_QUEUE_PERSISTENCE_ACTION_TYPES = [
+  "api_dispatch_lock_run_for_queue_persistence",
+  "api_dispatch_insert_runner_job_queue",
+  "api_dispatch_update_run_runner_group",
+] as const;
 const API_DISPATCH_TIMING_ACTION_TYPES = [
   "api_dispatch_pre_create_agent_run",
   "api_dispatch_check_org_tier",
@@ -82,6 +87,7 @@ const API_DISPATCH_TIMING_ACTION_TYPES = [
   "api_dispatch_mark_pending_heartbeat",
   "api_dispatch_build_runner_job_payload",
   "api_dispatch_persist_runner_job_queue",
+  ...API_DISPATCH_QUEUE_PERSISTENCE_ACTION_TYPES,
   "api_dispatch_admission_lock_wait",
   "api_dispatch_check_concurrency_limit",
   "api_dispatch_insert_run_record",
@@ -359,6 +365,18 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     );
     expect(observedActionTypes).not.toContain("api_dispatch_check_vm0_credits");
     expect(observedActionTypes).not.toContain("api_dispatch_notify_runner_job");
+
+    for (const actionType of API_DISPATCH_QUEUE_PERSISTENCE_ACTION_TYPES) {
+      const events = timingEvents.filter((event) => {
+        return event.op_type === actionType;
+      });
+      expect(events).toHaveLength(1);
+      expect(events[0]).toStrictEqual(
+        expect.objectContaining({
+          span_kind: "nested",
+        }),
+      );
+    }
 
     for (const event of timingEvents) {
       expect(event).toStrictEqual(

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -199,6 +199,9 @@ type ApiDispatchTimingActionType =
   | "api_dispatch_mark_pending_heartbeat"
   | "api_dispatch_build_runner_job_payload"
   | "api_dispatch_persist_runner_job_queue"
+  | "api_dispatch_lock_run_for_queue_persistence"
+  | "api_dispatch_insert_runner_job_queue"
+  | "api_dispatch_update_run_runner_group"
   | "api_dispatch_admission_lock_wait"
   | "api_dispatch_check_concurrency_limit"
   | "api_dispatch_insert_run_record"
@@ -4113,9 +4116,13 @@ function dispatchRun(
       "top_level",
       async () => {
         return await db.transaction(async (tx) => {
-          const currentRun = await lockRunForDerivedPersistence(
-            tx,
-            args.run.id,
+          const currentRun = await measureApiDispatchTiming(
+            args.timing,
+            "api_dispatch_lock_run_for_queue_persistence",
+            "nested",
+            async () => {
+              return await lockRunForDerivedPersistence(tx, args.run.id);
+            },
           );
           if (!currentRun) {
             throw new Error("Run disappeared before runner job persistence");
@@ -4124,24 +4131,38 @@ function dispatchRun(
             return currentRun;
           }
 
-          await tx.insert(runnerJobQueue).values({
-            runId: args.run.id,
-            runnerGroup: payload.runnerGroup,
-            profile: payload.profile,
-            cliAgentSessionId: payload.cliAgentSessionId,
-            executionContext: payload.executionContext,
-            expiresAt: new Date(now() + 2 * 60 * 60 * 1000),
-          });
+          await measureApiDispatchTiming(
+            args.timing,
+            "api_dispatch_insert_runner_job_queue",
+            "nested",
+            async () => {
+              await tx.insert(runnerJobQueue).values({
+                runId: args.run.id,
+                runnerGroup: payload.runnerGroup,
+                profile: payload.profile,
+                cliAgentSessionId: payload.cliAgentSessionId,
+                executionContext: payload.executionContext,
+                expiresAt: new Date(now() + 2 * 60 * 60 * 1000),
+              });
+            },
+          );
 
-          await tx
-            .update(agentRuns)
-            .set({ runnerGroup: payload.runnerGroup })
-            .where(
-              and(
-                eq(agentRuns.id, args.run.id),
-                eq(agentRuns.status, "pending"),
-              ),
-            );
+          await measureApiDispatchTiming(
+            args.timing,
+            "api_dispatch_update_run_runner_group",
+            "nested",
+            async () => {
+              await tx
+                .update(agentRuns)
+                .set({ runnerGroup: payload.runnerGroup })
+                .where(
+                  and(
+                    eq(agentRuns.id, args.run.id),
+                    eq(agentRuns.status, "pending"),
+                  ),
+                );
+            },
+          );
 
           return { status: "pending" as const };
         });


### PR DESCRIPTION
## Summary

- Add nested API dispatch timing for the direct-dispatch runner job queue persistence transaction.
- Split the existing `api_dispatch_persist_runner_job_queue` span into lock, queue insert, and runner-group update sub-spans.
- Extend the route integration telemetry test to assert the new nested rows and safe dimensions.

## Notes

This is diagnostic instrumentation only. It keeps the existing outer span, transaction boundary, lock behavior, pending-status checks, queue insert, runner-group update, and runner notification behavior unchanged.

Closes #18849

## Tests

- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- pre-commit: prettier, knip, full `pnpm check-types`
