### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1320,7 +1320,7 @@ dependencies = [
 
 [[package]]
 name = "guest-init"
-version = "0.16.86"
+version = "0.16.87"
 dependencies = [
  "libc",
  "nix",
@@ -2749,7 +2749,7 @@ dependencies = [
 
 [[package]]
 name = "sandbox-fc"
-version = "0.37.60"
+version = "0.37.61"
 dependencies = [
  "async-trait",
  "base64",
@@ -3028,7 +3028,7 @@ dependencies = [
 
 [[package]]
 name = "shell-quote"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "shlex"
@@ -3672,7 +3672,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vsock-guest"
-version = "0.19.6"
+version = "0.19.7"
 dependencies = [
  "guest-contracts",
  "libc",
@@ -3683,7 +3683,7 @@ dependencies = [
 
 [[package]]
 name = "vsock-host"
-version = "0.17.42"
+version = "0.17.43"
 dependencies = [
  "nix",
  "shell-quote",
@@ -3701,7 +3701,7 @@ version = "0.18.17"
 
 [[package]]
 name = "vsock-test"
-version = "0.9.111"
+version = "0.9.112"
 dependencies = [
  "guest-write-file",
  "libc",


### PR DESCRIPTION
## Summary
- Ran `cargo update --verbose` in the Rust workspace at `crates`.
- Updated `crates/Cargo.lock` for 6 workspace package entries:
  - `guest-init` `0.16.86` -> `0.16.87`
  - `sandbox-fc` `0.37.60` -> `0.37.61`
  - `shell-quote` `0.1.0` -> `0.1.1`
  - `vsock-guest` `0.19.6` -> `0.19.7`
  - `vsock-host` `0.17.42` -> `0.17.43`
  - `vsock-test` `0.9.111` -> `0.9.112`
- No external registry packages changed; the resolver is up to date within current manifest constraints.

## Dependencies not updated
- `generic-array` stayed at `0.14.7` although `0.14.9` is available. `cargo update -p generic-array --precise 0.14.9` fails because `crypto-common v0.1.7` requires `generic-array = "=0.14.7"` transitively through `digest v0.10.7`. There is no direct repo `Cargo.toml` constraint to safely adjust.

## Manual version bumps
- None.

## Tests
- Pass: `umask 022; CARGO_TARGET_DIR=/home/user/workspace/vm0-rust-deps-target cargo test --workspace -j 1`
- Notes: the first full run hit `/tmp` disk exhaustion; after relocating `CARGO_TARGET_DIR`, the default `umask 0002` caused environment-specific secure-temp-dir failures in `runner`. The final run used `umask 022` and passed.