### PR TITLE
refactor(mitm-addon): centralize webhook retry handling

### DIFF
--- a/crates/runner/mitm-addon/src/usage/webhook.py
+++ b/crates/runner/mitm-addon/src/usage/webhook.py
@@ -28,6 +28,7 @@ _RETRYABLE_FAILURE: WebhookDeliveryOutcome = "retryable_failure"
 _PERMANENT_FAILURE: WebhookDeliveryOutcome = "permanent_failure"
 _MIN_RETRYABLE_HTTP_STATUS_CODE = 500
 _RETRYABLE_HTTP_STATUS_CODES = {408, 429}
+_WEBHOOK_RETRY_DELAY_SECONDS = 0.5
 
 
 class _NoRedirect(urllib.request.HTTPRedirectHandler):
@@ -129,6 +130,48 @@ def _post_webhook_with_retry(
         decrement_pending_reports()
 
 
+def _handle_retryable_webhook_failure(
+    *,
+    proxy_log_path: str,
+    url: str,
+    log_type: str,
+    payload: dict,
+    payload_bytes: int,
+    attempt: int,
+    max_retries: int,
+    exc: Exception,
+) -> WebhookDeliveryOutcome | None:
+    attempt_number = attempt + 1
+    if attempt < max_retries:
+        _log_webhook_entry(
+            proxy_log_path,
+            "info",
+            f"Webhook POST to {url} attempt {attempt_number} failed, retrying: {exc}",
+            url,
+            log_type,
+            payload,
+            payload_bytes=payload_bytes,
+            attempt=attempt_number,
+            error=str(exc),
+        )
+        time.sleep(_WEBHOOK_RETRY_DELAY_SECONDS)
+        return None
+
+    _log_webhook_entry(
+        proxy_log_path,
+        "info",
+        f"Webhook POST to {url} failed after {attempt_number} attempts: {exc}",
+        url,
+        log_type,
+        payload,
+        payload_bytes=payload_bytes,
+        attempt=attempt_number,
+        error=str(exc),
+        extra_fields={"delivery_outcome": _RETRYABLE_FAILURE},
+    )
+    return _RETRYABLE_FAILURE
+
+
 def _do_post_webhook_attempts(
     url: str,
     sandbox_token: str,
@@ -181,61 +224,31 @@ def _do_post_webhook_attempts(
                     error=str(exc),
                 )
                 return _PERMANENT_FAILURE
-            if attempt < max_retries:
-                _log_webhook_entry(
-                    proxy_log_path,
-                    "info",
-                    f"Webhook POST to {url} attempt {attempt + 1} failed, retrying: {exc}",
-                    url,
-                    log_type,
-                    payload,
-                    payload_bytes=payload_bytes,
-                    attempt=attempt + 1,
-                    error=str(exc),
-                )
-                time.sleep(0.5)
-            else:
-                _log_webhook_entry(
-                    proxy_log_path,
-                    "info",
-                    f"Webhook POST to {url} failed after {attempt + 1} attempts: {exc}",
-                    url,
-                    log_type,
-                    payload,
-                    payload_bytes=payload_bytes,
-                    attempt=attempt + 1,
-                    error=str(exc),
-                    extra_fields={"delivery_outcome": _RETRYABLE_FAILURE},
-                )
-                return _RETRYABLE_FAILURE
+            outcome = _handle_retryable_webhook_failure(
+                proxy_log_path=proxy_log_path,
+                url=url,
+                log_type=log_type,
+                payload=payload,
+                payload_bytes=payload_bytes,
+                attempt=attempt,
+                max_retries=max_retries,
+                exc=exc,
+            )
+            if outcome is not None:
+                return outcome
         except (urllib.error.URLError, OSError, TimeoutError) as exc:
-            if attempt < max_retries:
-                _log_webhook_entry(
-                    proxy_log_path,
-                    "info",
-                    f"Webhook POST to {url} attempt {attempt + 1} failed, retrying: {exc}",
-                    url,
-                    log_type,
-                    payload,
-                    payload_bytes=payload_bytes,
-                    attempt=attempt + 1,
-                    error=str(exc),
-                )
-                time.sleep(0.5)
-            else:
-                _log_webhook_entry(
-                    proxy_log_path,
-                    "info",
-                    f"Webhook POST to {url} failed after {attempt + 1} attempts: {exc}",
-                    url,
-                    log_type,
-                    payload,
-                    payload_bytes=payload_bytes,
-                    attempt=attempt + 1,
-                    error=str(exc),
-                    extra_fields={"delivery_outcome": _RETRYABLE_FAILURE},
-                )
-                return _RETRYABLE_FAILURE
+            outcome = _handle_retryable_webhook_failure(
+                proxy_log_path=proxy_log_path,
+                url=url,
+                log_type=log_type,
+                payload=payload,
+                payload_bytes=payload_bytes,
+                attempt=attempt,
+                max_retries=max_retries,
+                exc=exc,
+            )
+            if outcome is not None:
+                return outcome
         except Exception as exc:
             # Catch-all by design: non-retryable failures (TypeError on
             # non-serializable payload, AttributeError, ValueError, or any

--- a/crates/runner/mitm-addon/tests/test_webhook.py
+++ b/crates/runner/mitm-addon/tests/test_webhook.py
@@ -293,6 +293,43 @@ class TestUsageWebhookDelivery:
         assert [entry["level"] for entry in entries] == ["info", "info"]
         assert entries[-1]["delivery_outcome"] == "retryable_failure"
 
+    def test_url_error_is_retryable(self, tmp_path):
+        proxy_log = tmp_path / "proxy.jsonl"
+        payload = {"runId": "run-1", "events": []}
+        payload_bytes = len(json.dumps(payload).encode())
+
+        with (
+            patch.object(
+                usage.webhook._opener,
+                "open",
+                side_effect=urllib.error.URLError("connection refused"),
+            ) as mock_open,
+            patch.object(usage.webhook.time, "sleep") as mock_sleep,
+        ):
+            outcome = usage.webhook._do_post_webhook_attempts(
+                "https://api.vm0.ai/api/webhooks/agent/usage-event",
+                "tok",
+                payload,
+                str(proxy_log),
+                "usage",
+                max_retries=1,
+            )
+
+        assert outcome == "retryable_failure"
+        assert mock_open.call_count == 2
+        mock_sleep.assert_called_once_with(0.5)
+        entries = read_jsonl_entries_after_flush(proxy_log)
+        assert [entry["level"] for entry in entries] == ["info", "info"]
+        assert [entry["attempt"] for entry in entries] == [1, 2]
+        assert entries[-1]["delivery_outcome"] == "retryable_failure"
+        for entry in entries:
+            _assert_body_free_webhook_entry(
+                entry,
+                run_id="run-1",
+                event_count=0,
+                payload_bytes=payload_bytes,
+            )
+
     def test_http_400_is_permanent(self, tmp_path, usage_webhook_server):
         proxy_log = tmp_path / "proxy.jsonl"
         usage_webhook_server.queue_response(400)


### PR DESCRIPTION
## Summary

- Centralize retryable webhook failure logging, delay, and final outcome handling behind a narrow private helper.
- Keep HTTP retryability classification in the `HTTPError` branch so permanent HTTP failures remain explicit.
- Add focused `URLError` coverage for the transport retry path.

## Behavior

Retry policy is intentionally unchanged: retry count, retry delay, timeout, and retryable HTTP status codes remain the same.

Closes #18862

## Tests

- `python3 -m pytest tests/test_webhook.py`
- `python3 -m ruff check src/usage/webhook.py tests/test_webhook.py`
- `python3 -m ruff format --check src/usage/webhook.py tests/test_webhook.py`
- `git diff --check`
