### PR TITLE
refactor(runner): deduplicate idle-pool expiration eviction

### DIFF
--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -958,31 +958,9 @@ impl IdlePool {
 
     /// Remove expired entries and return the post-eviction idle status snapshot.
     pub fn evict_expired_with_snapshot(&mut self) -> (Vec<IdleDestroyJob>, IdlePoolSnapshot) {
-        let now = Instant::now();
-        let mut idle_vms = Vec::with_capacity(self.entries.len());
-        let expired: Vec<IdleDestroyJob> = self
-            .entries
-            .extract_if(|session_id, entry| {
-                if entry.is_expired_at(now) {
-                    true
-                } else {
-                    idle_vms.push(idle_vm_for_entry(session_id, entry));
-                    false
-                }
-            })
-            .map(|(_, entry)| entry.into_destroy_job())
-            .collect();
-        if !expired.is_empty() {
-            self.bump_revision();
-        }
-        idle_vms.sort_unstable_by(|a, b| a.session_id.cmp(&b.session_id));
-        (
-            expired,
-            IdlePoolSnapshot {
-                revision: self.revision,
-                idle_vms,
-            },
-        )
+        let expired = self.evict_expired();
+        let snapshot = self.status_snapshot();
+        (expired, snapshot)
     }
 
     /// Evict the oldest idle entry (by park time). Used for resource


### PR DESCRIPTION
## Summary

- make `evict_expired_with_snapshot()` reuse `evict_expired()` for expiration mutation
- reuse `status_snapshot()` for post-eviction snapshot construction
- preserve existing lifecycle caller behavior for budget pressure and periodic cleanup

Fixes #18897

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p runner idle_pool::tests::evict_expired`
- `cargo test --manifest-path crates/Cargo.toml -p runner idle_pool::tests::evict_expired_with_snapshot`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`