### PR TITLE
test(vsock-guest): assert guest connection thread results

### DIFF
--- a/crates/vsock-guest/tests/connection/exec_cancel_cleanup.rs
+++ b/crates/vsock-guest/tests/connection/exec_cancel_cleanup.rs
@@ -74,7 +74,7 @@ fn exec_operation_stream_disconnect_cancels_child() {
     );
 
     drop(host_stream);
-    let _ = handle.join();
+    join_guest_connection(handle);
     wait_for_pid_exit(pid, "exec operation stream host disconnect");
     child_guard.disarm();
 }
@@ -164,7 +164,7 @@ fn exec_operation_connection_close_cancels_child() {
     );
 
     drop(host_stream);
-    let _ = handle.join();
+    join_guest_connection(handle);
     wait_for_pid_exit(pid, "exec operation host disconnect");
     child_guard.disarm();
 }

--- a/crates/vsock-guest/tests/connection/support/connection.rs
+++ b/crates/vsock-guest/tests/connection/support/connection.rs
@@ -1,3 +1,4 @@
+use std::os::unix::net::UnixStream;
 use std::thread;
 use std::time::Duration;
 
@@ -5,11 +6,11 @@ use vsock_guest::handle_connection;
 
 use super::protocol::read_and_discard_message;
 
-pub(crate) fn start_guest_connection() -> (thread::JoinHandle<()>, std::os::unix::net::UnixStream) {
-    let (guest_stream, mut host_stream) = std::os::unix::net::UnixStream::pair().unwrap();
-    let handle = thread::spawn(move || {
-        let _ = handle_connection(guest_stream);
-    });
+pub(crate) type GuestConnectionHandle = thread::JoinHandle<std::io::Result<()>>;
+
+pub(crate) fn start_guest_connection() -> (GuestConnectionHandle, UnixStream) {
+    let (guest_stream, mut host_stream) = UnixStream::pair().unwrap();
+    let handle = thread::spawn(move || handle_connection(guest_stream));
     read_and_discard_message(&mut host_stream);
     host_stream
         .set_read_timeout(Some(Duration::from_secs(5)))
@@ -17,10 +18,12 @@ pub(crate) fn start_guest_connection() -> (thread::JoinHandle<()>, std::os::unix
     (handle, host_stream)
 }
 
-pub(crate) fn finish_guest_connection(
-    handle: thread::JoinHandle<()>,
-    host_stream: std::os::unix::net::UnixStream,
-) {
+pub(crate) fn finish_guest_connection(handle: GuestConnectionHandle, host_stream: UnixStream) {
     drop(host_stream);
-    let _ = handle.join();
+    join_guest_connection(handle);
+}
+
+pub(crate) fn join_guest_connection(handle: GuestConnectionHandle) {
+    let result = handle.join().expect("guest connection thread panicked");
+    result.expect("guest connection handler returned an error");
 }

--- a/crates/vsock-guest/tests/connection/support/mod.rs
+++ b/crates/vsock-guest/tests/connection/support/mod.rs
@@ -4,7 +4,9 @@ mod process;
 mod protocol;
 mod temp_paths;
 
-pub(crate) use connection::{finish_guest_connection, start_guest_connection};
+pub(crate) use connection::{
+    finish_guest_connection, join_guest_connection, start_guest_connection,
+};
 pub(crate) use exec::{
     DRAIN_DEADLINE_SECS, LARGE_ENV_COMMAND, LONG_RUNNING_EXEC_TIMEOUT_MS, assert_large_env_stdout,
     large_env_entries, large_env_values, read_exec_output_chunk, read_exec_result,


### PR DESCRIPTION
## Summary
- preserve the guest connection test thread's handle_connection result
- add a shared join helper that fails on guest thread panic or handler error
- use the helper in explicit host-disconnect cleanup tests

## Scope
- test harness only
- production connection, reconnect, protocol, and exec worker join behavior are unchanged

Closes #18864

## Tests
- cargo test --manifest-path crates/Cargo.toml -p vsock-guest --test connection
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo clippy --manifest-path crates/Cargo.toml -p vsock-guest --all-targets -- -D warnings