### PR TITLE
refactor(runner): centralize idle pool test builders

### DIFF
--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -198,7 +198,7 @@ mod tests {
     use super::*;
     use crate::config;
     use crate::idle_pool::{
-        IdlePoolConfig, ParkResult, ParkedIdleCandidate, SyntheticParkedIdleCandidateParts,
+        IdlePoolConfig, ParkResult, ParkedIdleCandidate, test_support::ParkedIdleCandidateBuilder,
     };
     use crate::paths::RunnerPaths;
     use crate::provider::mock::MockJobProvider;
@@ -206,8 +206,7 @@ mod tests {
         WorkspaceCacheTerminalStatus, WorkspaceImageLeaseIdentity, WorkspaceImagePrepareRequest,
     };
     use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
-    use sandbox::{SandboxFactory, SandboxId};
-    use sandbox_mock::{MockSandbox, MockSandboxFactory};
+    use sandbox::SandboxId;
     use tracing_subscriber::prelude::*;
     use tracing_test_support::{CapturedEvent, CapturedEvents};
 
@@ -229,17 +228,12 @@ mod tests {
 
     fn make_synthetic_parked_candidate(session_id: &str) -> ParkedIdleCandidate {
         let budget = Arc::new(ResourceBudget::new(1, 1, 1.0, 0));
-        ParkedIdleCandidate::synthetic_for_test(SyntheticParkedIdleCandidateParts {
-            sandbox: Box::new(MockSandbox::new("test")),
-            factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
-            cli_agent_session_id: session_id.into(),
-            sandbox_id: SandboxId::new_v4(),
-            profile_name: "vm0/default".into(),
-            device_rate_limits: None,
-            budget_lease: ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap(),
-            source_ip: "10.0.0.1".into(),
-            storage_fingerprints: crate::storage_fingerprints::StorageFingerprints::default(),
-        })
+        ParkedIdleCandidateBuilder::new(
+            session_id,
+            ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap(),
+        )
+        .with_mock_sandbox_name("test")
+        .build()
     }
 
     async fn seed_workspace_cache_state(

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -920,8 +920,7 @@ mod tests {
         AgentFramework, CliTerminationDiagnostic, CliTerminationReason, CliTerminationSignal,
         FailureClass, FailureDetailSource, PromptMetadata, SessionHistoryStatus,
     };
-    use sandbox::{SandboxFactory, SandboxId};
-    use sandbox_mock::{MockSandbox, MockSandboxFactory};
+    use sandbox::SandboxId;
     use tracing::Level;
     use tracing_subscriber::prelude::*;
     use tracing_test_support::{CapturedEvent, CapturedEvents};
@@ -930,8 +929,7 @@ mod tests {
     use super::super::job_lifecycle::RunCleanupState;
     use super::super::orphan_reap::OrphanedActiveRuns;
     use crate::idle_pool::{
-        IdlePool, IdlePoolConfig, ParkResult, ParkedIdleCandidate,
-        SyntheticParkedIdleCandidateParts,
+        IdlePool, IdlePoolConfig, ParkResult, test_support::ParkedIdleCandidateBuilder,
     };
     use crate::ids::RunId;
     use crate::resource_budget::ResourceBudget;
@@ -1520,18 +1518,10 @@ mod tests {
         let sandbox_id = SandboxId::new_v4();
         let budget = Arc::new(ResourceBudget::new(2, 4096, 1.0, 0));
         let lease = ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap();
-        let candidate =
-            ParkedIdleCandidate::synthetic_for_test(SyntheticParkedIdleCandidateParts {
-                sandbox: Box::new(MockSandbox::new("idle-owned-cleanup")),
-                factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
-                cli_agent_session_id: "sess-idle-owned-cleanup".into(),
-                sandbox_id,
-                profile_name: "vm0/default".into(),
-                device_rate_limits: None,
-                budget_lease: lease,
-                source_ip: "10.0.0.1".into(),
-                storage_fingerprints: crate::storage_fingerprints::StorageFingerprints::default(),
-            });
+        let candidate = ParkedIdleCandidateBuilder::new("sess-idle-owned-cleanup", lease)
+            .with_mock_sandbox_name("idle-owned-cleanup")
+            .with_sandbox_id(sandbox_id)
+            .build();
         assert!(matches!(
             fixture.idle_pool.lock().await.park(candidate),
             ParkResult::Parked

--- a/crates/runner/src/cmd/start/orphan_reap.rs
+++ b/crates/runner/src/cmd/start/orphan_reap.rs
@@ -314,13 +314,9 @@ async fn reap_orphaned_active_runs_with_firecrackers(
 mod tests {
     use super::*;
     use crate::idle_pool::{
-        IdlePool, IdlePoolConfig, ParkResult, ParkedIdleCandidate,
-        SyntheticParkedIdleCandidateParts,
+        IdlePool, IdlePoolConfig, ParkResult, test_support::ParkedIdleCandidateBuilder,
     };
     use crate::resource_budget::ResourceBudget;
-    use crate::storage_fingerprints::StorageFingerprints;
-    use sandbox::SandboxFactory;
-    use sandbox_mock::{MockSandbox, MockSandboxFactory};
     use std::time::Duration;
 
     struct OrphanReapFixture {
@@ -363,20 +359,10 @@ mod tests {
         ) {
             let budget = Arc::new(ResourceBudget::new(2, 4096, 1.0, 0));
             let lease = ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap();
-            let candidate =
-                ParkedIdleCandidate::synthetic_for_test(SyntheticParkedIdleCandidateParts {
-                    sandbox: Box::new(MockSandbox::new(mock_name)),
-                    factory: Arc::new(
-                        Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>
-                    ),
-                    cli_agent_session_id: session_id.into(),
-                    sandbox_id,
-                    profile_name: "vm0/default".into(),
-                    device_rate_limits: None,
-                    budget_lease: lease,
-                    source_ip: "10.0.0.1".into(),
-                    storage_fingerprints: StorageFingerprints::default(),
-                });
+            let candidate = ParkedIdleCandidateBuilder::new(session_id, lease)
+                .with_mock_sandbox_name(mock_name)
+                .with_sandbox_id(sandbox_id)
+                .build();
             let result = {
                 let mut idle_pool = self.idle_pool.lock().await;
                 idle_pool.park(candidate)

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -588,8 +588,8 @@ mod tests {
         ActiveBudgetLease, CompletionPayload, RunCleanupDisposition, RunCleanupState,
     };
     use crate::idle_pool::{
-        IdleParkRequest, IdleParkRequestParts, IdlePool, IdlePoolConfig, ParkResult,
-        ParkedIdleCandidate, ParkingGate, SyntheticParkedIdleCandidateParts,
+        IdleParkRequest, IdleParkRequestParts, IdlePool, IdlePoolConfig, ParkResult, ParkingGate,
+        test_support::ParkedIdleCandidateBuilder,
     };
     use crate::ids::RunId;
     use crate::network_log_drain::NetworkLogDrainCoordinator;
@@ -1250,18 +1250,10 @@ mod tests {
     async fn finalizer_promotes_workspace_cache_when_parked_candidate_is_rejected() {
         let fixture = FinalizeTestFixture::new_with_max_idle(1).await;
         let (_existing_budget, existing_lease) = test_budget_lease();
-        let existing = ParkedIdleCandidate::synthetic_for_test(SyntheticParkedIdleCandidateParts {
-            sandbox: Box::new(MockSandbox::new("existing-idle")),
-            factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
-            cli_agent_session_id: "sess-existing".into(),
-            sandbox_id: SandboxId::new_v4(),
-            profile_name: "vm0/default".into(),
-            device_rate_limits: None,
-            budget_lease: existing_lease,
-            source_ip: "10.0.0.1".into(),
-            storage_fingerprints: crate::storage_fingerprints::StorageFingerprints::default(),
-        })
-        .with_last_completed_at(local_completed_at());
+        let existing = ParkedIdleCandidateBuilder::new("sess-existing", existing_lease)
+            .with_mock_sandbox_name("existing-idle")
+            .with_last_completed_at(local_completed_at())
+            .build();
         assert!(matches!(
             fixture.idle_pool.lock().await.park(existing),
             ParkResult::Parked

--- a/crates/runner/src/cmd/start/tests/support/idle_pool.rs
+++ b/crates/runner/src/cmd/start/tests/support/idle_pool.rs
@@ -1,7 +1,7 @@
 use super::super::super::*;
 use super::TEST_SESSION_LAST_COMPLETED_AT;
 
-use crate::idle_pool::{ParkResult, ParkedIdleCandidate, SyntheticParkedIdleCandidateParts};
+use crate::idle_pool::{ParkResult, ParkedIdleCandidate, test_support::ParkedIdleCandidateBuilder};
 use crate::ids::RunId;
 use crate::paths::RunnerPaths;
 use crate::resource_budget::BudgetLease;
@@ -11,25 +11,16 @@ use crate::workspace_image_cache::{
     WorkspaceImagePrepareRequest, WorkspaceImagePromotionRequest,
 };
 use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
-use sandbox::{SandboxFactory, SandboxId};
-use sandbox_mock::{MockSandbox, MockSandboxFactory};
+use sandbox::SandboxId;
 
 fn make_synthetic_parked_candidate(
     session_id: &str,
     profile_name: &str,
     budget_lease: BudgetLease,
 ) -> ParkedIdleCandidate {
-    ParkedIdleCandidate::synthetic_for_test(SyntheticParkedIdleCandidateParts {
-        sandbox: Box::new(MockSandbox::new("idle-test")),
-        factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
-        cli_agent_session_id: session_id.into(),
-        sandbox_id: SandboxId::new_v4(),
-        profile_name: profile_name.into(),
-        device_rate_limits: None,
-        budget_lease,
-        source_ip: "10.0.0.1".into(),
-        storage_fingerprints: crate::storage_fingerprints::StorageFingerprints::default(),
-    })
+    ParkedIdleCandidateBuilder::new(session_id, budget_lease)
+        .with_profile_name(profile_name)
+        .build()
 }
 
 /// Pre-populate idle pool with an entry and reserve its budget. Returns
@@ -93,18 +84,13 @@ pub(in super::super) async fn seed_idle_pool_with_overrides(
 
     let mut guard = pool.lock().await;
     let result = guard.park(
-        ParkedIdleCandidate::synthetic_for_test(SyntheticParkedIdleCandidateParts {
-            sandbox,
-            factory: factory_arc,
-            cli_agent_session_id: session_id.to_string(),
-            sandbox_id,
-            profile_name: profile_name.into(),
-            device_rate_limits: None,
-            budget_lease,
-            source_ip: "10.0.0.1".into(),
-            storage_fingerprints: crate::storage_fingerprints::StorageFingerprints::default(),
-        })
-        .with_last_completed_at(TEST_SESSION_LAST_COMPLETED_AT.to_string()),
+        ParkedIdleCandidateBuilder::new(session_id, budget_lease)
+            .with_sandbox(sandbox)
+            .with_factory(factory_arc)
+            .with_sandbox_id(sandbox_id)
+            .with_profile_name(profile_name)
+            .with_last_completed_at(TEST_SESSION_LAST_COMPLETED_AT)
+            .build(),
     );
     assert!(matches!(result, ParkResult::Parked));
     sandbox_id
@@ -159,21 +145,13 @@ pub(in super::super) async fn seed_idle_pool_with_workspace_promotion(
         .expect("workspace image should be promotable");
     let budget_lease = ResourceBudget::try_reserve_lease(budget, spec.vcpu, spec.memory_mb)
         .expect("reserve budget");
-    let candidate = ParkedIdleCandidate::synthetic_for_test_with_workspace_promotion(
-        SyntheticParkedIdleCandidateParts {
-            sandbox: Box::new(MockSandbox::new("idle-workspace-promotion-test")),
-            factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
-            cli_agent_session_id: spec.session_id.into(),
-            sandbox_id,
-            profile_name: spec.profile_name.into(),
-            device_rate_limits: None,
-            budget_lease,
-            source_ip: "10.0.0.1".into(),
-            storage_fingerprints: StorageFingerprints::default(),
-        },
-        promotion,
-    )
-    .with_last_completed_at(TEST_SESSION_LAST_COMPLETED_AT.to_string());
+    let candidate = ParkedIdleCandidateBuilder::new(spec.session_id, budget_lease)
+        .with_mock_sandbox_name("idle-workspace-promotion-test")
+        .with_sandbox_id(sandbox_id)
+        .with_profile_name(spec.profile_name)
+        .with_workspace_promotion(promotion)
+        .with_last_completed_at(TEST_SESSION_LAST_COMPLETED_AT)
+        .build();
     let mut guard = pool.lock().await;
     let result = guard.park(candidate);
     assert!(matches!(result, ParkResult::Parked));

--- a/crates/runner/src/executor/tests/sandbox_run_tests/idle_pool.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/idle_pool.rs
@@ -3,8 +3,7 @@ use super::*;
 #[tokio::test]
 async fn idle_pool_park_and_reuse_cycle() {
     use crate::idle_pool::{
-        IdlePool, IdlePoolConfig, ParkResult, ParkedIdleCandidate,
-        SyntheticParkedIdleCandidateParts,
+        IdlePool, IdlePoolConfig, ParkResult, test_support::ParkedIdleCandidateBuilder,
     };
 
     let dir = tempfile::tempdir().unwrap();
@@ -34,17 +33,10 @@ async fn idle_pool_park_and_reuse_cycle() {
         max_idle: 0,
     });
 
-    let entry = ParkedIdleCandidate::synthetic_for_test(SyntheticParkedIdleCandidateParts {
-        sandbox,
-        factory: std::sync::Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
-        cli_agent_session_id: "test-session".into(),
-        sandbox_id: SandboxId::new_v4(),
-        profile_name: "vm0/default".into(),
-        device_rate_limits: None,
-        budget_lease: test_budget_lease(),
-        source_ip: outcome.source_ip,
-        storage_fingerprints: crate::storage_fingerprints::StorageFingerprints::default(),
-    });
+    let entry = ParkedIdleCandidateBuilder::new("test-session", test_budget_lease())
+        .with_sandbox(sandbox)
+        .with_source_ip(outcome.source_ip)
+        .build();
 
     let result = pool.park(entry);
     assert!(matches!(result, ParkResult::Parked));
@@ -80,9 +72,7 @@ async fn idle_pool_park_and_reuse_cycle() {
 
 #[tokio::test]
 async fn idle_pool_profile_mismatch_returns_none() {
-    use crate::idle_pool::{
-        IdlePool, IdlePoolConfig, ParkedIdleCandidate, SyntheticParkedIdleCandidateParts,
-    };
+    use crate::idle_pool::{IdlePool, IdlePoolConfig, test_support::ParkedIdleCandidateBuilder};
 
     let mut pool = IdlePool::new(IdlePoolConfig {
         default_timeout: std::time::Duration::from_secs(300),
@@ -90,19 +80,9 @@ async fn idle_pool_profile_mismatch_returns_none() {
     });
 
     // Park with profile "vm0/default"
-    let entry = ParkedIdleCandidate::synthetic_for_test(SyntheticParkedIdleCandidateParts {
-        sandbox: Box::new(sandbox_mock::MockSandbox::new("test")),
-        factory: std::sync::Arc::new(
-            Box::new(sandbox_mock::MockSandboxFactory::new()) as Box<dyn SandboxFactory>
-        ),
-        cli_agent_session_id: "test-session".into(),
-        sandbox_id: SandboxId::new_v4(),
-        profile_name: "vm0/default".into(),
-        device_rate_limits: None,
-        budget_lease: test_budget_lease(),
-        source_ip: "10.0.0.1".into(),
-        storage_fingerprints: crate::storage_fingerprints::StorageFingerprints::default(),
-    });
+    let entry = ParkedIdleCandidateBuilder::new("test-session", test_budget_lease())
+        .with_mock_sandbox_name("test")
+        .build();
     let _ = pool.park(entry);
 
     // Take and verify profile

--- a/crates/runner/src/executor/tests/support/config.rs
+++ b/crates/runner/src/executor/tests/support/config.rs
@@ -1,8 +1,7 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use sandbox::{Sandbox, SandboxFactory, SandboxId};
-use sandbox_mock::MockSandboxFactory;
+use sandbox::Sandbox;
 
 use super::super::super::{ExecutorConfig, JobParams};
 use crate::http::HttpClientConfig;
@@ -76,25 +75,18 @@ pub(in crate::executor::tests) async fn make_reusable_idle_sandbox(
     session_id: &str,
 ) -> (ReusableIdleSandbox, crate::resource_budget::BudgetLease) {
     use crate::idle_pool::{
-        IdlePool, IdlePoolConfig, IdleUnparkResult, ParkResult, ParkedIdleCandidate,
-        SyntheticParkedIdleCandidateParts,
+        IdlePool, IdlePoolConfig, IdleUnparkResult, ParkResult,
+        test_support::ParkedIdleCandidateBuilder,
     };
 
     let mut pool = IdlePool::new(IdlePoolConfig {
         default_timeout: std::time::Duration::from_secs(300),
         max_idle: 0,
     });
-    let candidate = ParkedIdleCandidate::synthetic_for_test(SyntheticParkedIdleCandidateParts {
-        sandbox,
-        factory: std::sync::Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
-        cli_agent_session_id: session_id.into(),
-        sandbox_id: SandboxId::new_v4(),
-        profile_name: "vm0/default".into(),
-        device_rate_limits: None,
-        budget_lease: test_budget_lease(),
-        source_ip,
-        storage_fingerprints: crate::storage_fingerprints::StorageFingerprints::default(),
-    });
+    let candidate = ParkedIdleCandidateBuilder::new(session_id, test_budget_lease())
+        .with_sandbox(sandbox)
+        .with_source_ip(source_ip)
+        .build();
     assert!(matches!(pool.park(candidate), ParkResult::Parked));
     let entry = pool.take(session_id).expect("idle entry should exist");
     match entry.try_unpark().await {

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -22,6 +22,9 @@ use crate::workspace_promotion::{
     abandon_unpublished_workspace_promotion, promote_workspace_image_from_parked_sandbox,
 };
 
+#[cfg(test)]
+pub(crate) mod test_support;
+
 /// Default idle timeout for kept-alive VMs (30 minutes).
 ///
 /// Re-exported via `SandboxConfig::default()` so the YAML default and
@@ -236,19 +239,6 @@ pub struct ParkedIdleCandidate {
     budget_lease: BudgetLease,
 }
 
-#[cfg(test)]
-pub(crate) struct SyntheticParkedIdleCandidateParts {
-    pub sandbox: Box<dyn Sandbox>,
-    pub factory: Arc<Box<dyn SandboxFactory>>,
-    pub cli_agent_session_id: String,
-    pub sandbox_id: SandboxId,
-    pub profile_name: String,
-    pub device_rate_limits: Option<DeviceRateLimits>,
-    pub budget_lease: BudgetLease,
-    pub source_ip: String,
-    pub storage_fingerprints: StorageFingerprints,
-}
-
 #[must_use = "idle park failures must be explicitly destroyed or otherwise handled"]
 pub(crate) struct IdleParkFailure {
     resources: IdleSandboxResources,
@@ -393,51 +383,6 @@ impl IdleParkFailure {
 }
 
 impl ParkedIdleCandidate {
-    /// Build a synthetic candidate for tests that seed idle-pool state without
-    /// running a real park transition.
-    #[cfg(test)]
-    pub(crate) fn synthetic_for_test(parts: SyntheticParkedIdleCandidateParts) -> Self {
-        Self {
-            resources: IdleSandboxResources {
-                sandbox: parts.sandbox,
-                factory: parts.factory,
-                workspace_promotion: None,
-            },
-            metadata: IdleSandboxMetadata::new(
-                parts.cli_agent_session_id,
-                parts.sandbox_id,
-                parts.profile_name,
-                parts.device_rate_limits,
-                parts.source_ip,
-                parts.storage_fingerprints,
-            ),
-            budget_lease: parts.budget_lease,
-        }
-    }
-
-    #[cfg(test)]
-    pub(crate) fn synthetic_for_test_with_workspace_promotion(
-        parts: SyntheticParkedIdleCandidateParts,
-        workspace_promotion: WorkspaceImagePromotionContext,
-    ) -> Self {
-        Self {
-            resources: IdleSandboxResources {
-                sandbox: parts.sandbox,
-                factory: parts.factory,
-                workspace_promotion: Some(workspace_promotion),
-            },
-            metadata: IdleSandboxMetadata::new(
-                parts.cli_agent_session_id,
-                parts.sandbox_id,
-                parts.profile_name,
-                parts.device_rate_limits,
-                parts.source_ip,
-                parts.storage_fingerprints,
-            ),
-            budget_lease: parts.budget_lease,
-        }
-    }
-
     fn cli_agent_session_id(&self) -> &str {
         self.metadata.cli_agent_session_id()
     }
@@ -1133,8 +1078,9 @@ mod tests {
     use crate::resource_budget::ResourceBudget;
     use crate::storage_fingerprints::StorageFingerprint;
 
+    use super::test_support::ParkedIdleCandidateBuilder;
     use sandbox::{ResourceLimits, SandboxConfig};
-    use sandbox_mock::{MockSandbox, MockSandboxFactory, MockSandboxOverrides};
+    use sandbox_mock::{MockSandboxFactory, MockSandboxOverrides};
 
     fn make_budget_lease(vcpu: u32, memory_mb: u32) -> BudgetLease {
         let budget = Arc::new(ResourceBudget::new(1, 1, 1.0, 0));
@@ -1149,17 +1095,9 @@ mod tests {
         session_id: &str,
         budget_lease: BudgetLease,
     ) -> ParkedIdleCandidate {
-        ParkedIdleCandidate::synthetic_for_test(SyntheticParkedIdleCandidateParts {
-            sandbox: Box::new(MockSandbox::new("test")),
-            factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
-            cli_agent_session_id: session_id.into(),
-            sandbox_id: SandboxId::new_v4(),
-            profile_name: "vm0/default".into(),
-            device_rate_limits: None,
-            budget_lease,
-            source_ip: "10.0.0.1".into(),
-            storage_fingerprints: StorageFingerprints::default(),
-        })
+        ParkedIdleCandidateBuilder::new(session_id, budget_lease)
+            .with_mock_sandbox_name("test")
+            .build()
     }
 
     fn park_at(

--- a/crates/runner/src/idle_pool/test_support.rs
+++ b/crates/runner/src/idle_pool/test_support.rs
@@ -1,0 +1,128 @@
+use std::sync::Arc;
+
+use sandbox::{DeviceRateLimits, Sandbox, SandboxFactory, SandboxId};
+use sandbox_mock::{MockSandbox, MockSandboxFactory};
+
+use crate::resource_budget::BudgetLease;
+use crate::storage_fingerprints::StorageFingerprints;
+use crate::workspace_image_cache::WorkspaceImagePromotionContext;
+
+use super::{IdleSandboxMetadata, IdleSandboxResources, ParkedIdleCandidate};
+
+const DEFAULT_PROFILE_NAME: &str = "vm0/default";
+const DEFAULT_SOURCE_IP: &str = "10.0.0.1";
+const DEFAULT_SANDBOX_NAME: &str = "idle-test";
+
+pub(crate) struct ParkedIdleCandidateBuilder {
+    sandbox: Box<dyn Sandbox>,
+    factory: Arc<Box<dyn SandboxFactory>>,
+    cli_agent_session_id: String,
+    sandbox_id: SandboxId,
+    profile_name: String,
+    device_rate_limits: Option<DeviceRateLimits>,
+    budget_lease: BudgetLease,
+    source_ip: String,
+    storage_fingerprints: StorageFingerprints,
+    last_completed_at: Option<String>,
+    workspace_promotion: Option<WorkspaceImagePromotionContext>,
+}
+
+impl ParkedIdleCandidateBuilder {
+    pub(crate) fn new(
+        session_id: impl Into<String>,
+        budget_lease: BudgetLease,
+    ) -> ParkedIdleCandidateBuilder {
+        Self {
+            sandbox: Box::new(MockSandbox::new(DEFAULT_SANDBOX_NAME)),
+            factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
+            cli_agent_session_id: session_id.into(),
+            sandbox_id: SandboxId::new_v4(),
+            profile_name: DEFAULT_PROFILE_NAME.into(),
+            device_rate_limits: None,
+            budget_lease,
+            source_ip: DEFAULT_SOURCE_IP.into(),
+            storage_fingerprints: StorageFingerprints::default(),
+            last_completed_at: None,
+            workspace_promotion: None,
+        }
+    }
+
+    pub(crate) fn with_sandbox(mut self, sandbox: Box<dyn Sandbox>) -> Self {
+        self.sandbox = sandbox;
+        self
+    }
+
+    pub(crate) fn with_mock_sandbox_name(mut self, name: &str) -> Self {
+        self.sandbox = Box::new(MockSandbox::new(name));
+        self
+    }
+
+    pub(crate) fn with_factory(mut self, factory: Arc<Box<dyn SandboxFactory>>) -> Self {
+        self.factory = factory;
+        self
+    }
+
+    pub(crate) fn with_sandbox_id(mut self, sandbox_id: SandboxId) -> Self {
+        self.sandbox_id = sandbox_id;
+        self
+    }
+
+    pub(crate) fn with_profile_name(mut self, profile_name: impl Into<String>) -> Self {
+        self.profile_name = profile_name.into();
+        self
+    }
+
+    pub(crate) fn with_source_ip(mut self, source_ip: impl Into<String>) -> Self {
+        self.source_ip = source_ip.into();
+        self
+    }
+
+    pub(crate) fn with_last_completed_at(mut self, last_completed_at: impl Into<String>) -> Self {
+        self.last_completed_at = Some(last_completed_at.into());
+        self
+    }
+
+    pub(crate) fn with_workspace_promotion(
+        mut self,
+        workspace_promotion: WorkspaceImagePromotionContext,
+    ) -> Self {
+        self.workspace_promotion = Some(workspace_promotion);
+        self
+    }
+
+    pub(crate) fn build(self) -> ParkedIdleCandidate {
+        let Self {
+            sandbox,
+            factory,
+            cli_agent_session_id,
+            sandbox_id,
+            profile_name,
+            device_rate_limits,
+            budget_lease,
+            source_ip,
+            storage_fingerprints,
+            last_completed_at,
+            workspace_promotion,
+        } = self;
+        let mut metadata = IdleSandboxMetadata::new(
+            cli_agent_session_id,
+            sandbox_id,
+            profile_name,
+            device_rate_limits,
+            source_ip,
+            storage_fingerprints,
+        );
+        if let Some(last_completed_at) = last_completed_at {
+            metadata = metadata.with_last_completed_at(last_completed_at);
+        }
+        ParkedIdleCandidate {
+            resources: IdleSandboxResources {
+                sandbox,
+                factory,
+                workspace_promotion,
+            },
+            metadata,
+            budget_lease,
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add an idle-pool-owned `ParkedIdleCandidateBuilder` test support module.
- Remove the cross-module `SyntheticParkedIdleCandidateParts` and `synthetic_for_test*` APIs from `idle_pool.rs`.
- Migrate idle-pool, executor, and runner-start tests to use the shared builder while preserving explicit sandbox, source IP, budget, timestamp, and workspace-promotion setup.

Closes #18896

## Testing

- `cargo test --manifest-path crates/Cargo.toml -p runner idle_pool`
- `cargo test --manifest-path crates/Cargo.toml -p runner executor::tests`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::start`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
