### PR TITLE
perf: add claim route timing telemetry

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -66,6 +66,25 @@ const API_DISPATCH_QUEUE_PERSISTENCE_ACTION_TYPES = [
   "api_dispatch_insert_runner_job_queue",
   "api_dispatch_update_run_runner_group",
 ] as const;
+const CLAIM_ROUTE_TOP_LEVEL_TIMING_ACTION_TYPES = [
+  "claim_route_request_prepare",
+  "claim_route_lookup_authorization",
+  "claim_route_context_parse",
+  "claim_route_feature_switch_context",
+  "claim_route_secret_materialization",
+  "claim_route_response_assembly",
+  "claim_route_transition_running",
+] as const;
+const CLAIM_ROUTE_TRANSITION_TIMING_ACTION_TYPES = [
+  "claim_route_transition_lock_run",
+  "claim_route_transition_lock_queue_job",
+  "claim_route_transition_update_run",
+  "claim_route_transition_delete_queue_job",
+] as const;
+const CLAIM_ROUTE_TIMING_ACTION_TYPES = [
+  ...CLAIM_ROUTE_TOP_LEVEL_TIMING_ACTION_TYPES,
+  ...CLAIM_ROUTE_TRANSITION_TIMING_ACTION_TYPES,
+] as const;
 const API_DISPATCH_TIMING_ACTION_TYPES = [
   "api_dispatch_pre_create_agent_run",
   "api_dispatch_check_org_tier",
@@ -107,6 +126,24 @@ const FORBIDDEN_API_DISPATCH_TIMING_KEYS = [
   "environment",
   "execution_context",
   "presigned_url",
+] as const;
+const FORBIDDEN_CLAIM_ROUTE_TIMING_KEYS = [
+  "org_id",
+  "user_id",
+  "connector",
+  "connector_name",
+  "agent_id",
+  "prompt",
+  "vars",
+  "secrets",
+  "secret_names",
+  "environment",
+  "execution_context",
+  "stored_context",
+  "sandbox_token",
+  "sandboxToken",
+  "presigned_url",
+  "response_body",
 ] as const;
 
 function modelProviderPlaceholder(
@@ -235,6 +272,26 @@ function apiDispatchTimingEventsForRun(
         event.run_id === runId &&
         typeof event.op_type === "string" &&
         event.op_type.startsWith("api_dispatch_")
+      );
+    });
+  });
+}
+
+function claimRouteTimingEventsForRun(
+  runId: string,
+): readonly Record<string, unknown>[] {
+  return context.mocks.axiom.sdkIngest.mock.calls.flatMap((call) => {
+    const dataset = call[0];
+    const events = call[1];
+    if (dataset !== "vm0-sandbox-op-log-dev" || !Array.isArray(events)) {
+      return [];
+    }
+    return events.filter((event): event is Record<string, unknown> => {
+      return (
+        isRecord(event) &&
+        event.run_id === runId &&
+        typeof event.op_type === "string" &&
+        event.op_type.startsWith("claim_route_")
       );
     });
   });
@@ -2134,10 +2191,11 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
     const { actor, agentId, runnerGroup } = await entitledRunActor();
     const apiKey = await api.createApiKey(actor);
     const bearer = `Bearer ${apiKey.token}`;
+    const firstPrompt = "user runner job one";
 
     const first = await api.createRun(actor, {
       agentId,
-      prompt: "user runner job one",
+      prompt: firstPrompt,
       modelProvider: "anthropic-api-key",
     });
     const polled = await api.requestPollRunnerAs(
@@ -2167,6 +2225,61 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
     }
     expect(claimed.body.prompt).toBe("user runner job one");
     expect(claimed.body.sandboxToken).not.toBe("");
+    const claimRouteTimingEvents = claimRouteTimingEventsForRun(first.runId);
+    const observedClaimRouteActionTypes = new Set(
+      claimRouteTimingEvents.map((event) => {
+        return event.op_type;
+      }),
+    );
+    for (const actionType of CLAIM_ROUTE_TIMING_ACTION_TYPES) {
+      expect(observedClaimRouteActionTypes).toContain(actionType);
+    }
+    for (const actionType of CLAIM_ROUTE_TOP_LEVEL_TIMING_ACTION_TYPES) {
+      const events = claimRouteTimingEvents.filter((event) => {
+        return event.op_type === actionType;
+      });
+      expect(events).toHaveLength(1);
+      expect(events[0]).toStrictEqual(
+        expect.objectContaining({
+          span_kind: "top_level",
+        }),
+      );
+    }
+    for (const actionType of CLAIM_ROUTE_TRANSITION_TIMING_ACTION_TYPES) {
+      const events = claimRouteTimingEvents.filter((event) => {
+        return event.op_type === actionType;
+      });
+      expect(events).toHaveLength(1);
+      expect(events[0]).toStrictEqual(
+        expect.objectContaining({
+          span_kind: "nested",
+        }),
+      );
+    }
+    for (const event of claimRouteTimingEvents) {
+      expect(event).toStrictEqual(
+        expect.objectContaining({
+          source: "api",
+          sandbox_type: "runner",
+          success: true,
+          run_id: first.runId,
+          runner_group: runnerGroup,
+          profile: "vm0/default",
+          auth_type: "user",
+          poll_reason: "deferred",
+        }),
+      );
+      expect(event.duration_ms).toStrictEqual(expect.any(Number));
+      expect(Number(event.duration_ms)).toBeGreaterThanOrEqual(0);
+      expect(["top_level", "nested"]).toContain(event.span_kind);
+      for (const forbiddenKey of FORBIDDEN_CLAIM_ROUTE_TIMING_KEYS) {
+        expect(event).not.toHaveProperty(forbiddenKey);
+      }
+      const serialized = JSON.stringify(event);
+      expect(serialized).not.toContain(firstPrompt);
+      expect(serialized).not.toContain(claimed.body.sandboxToken);
+      expect(serialized).not.toContain(apiKey.token);
+    }
     expect(context.mocks.axiom.sdkIngest).toHaveBeenCalledWith(
       "vm0-sandbox-op-log-dev",
       [

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -2226,6 +2226,9 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
     expect(claimed.body.prompt).toBe("user runner job one");
     expect(claimed.body.sandboxToken).not.toBe("");
     const claimRouteTimingEvents = claimRouteTimingEventsForRun(first.runId);
+    expect(claimRouteTimingEvents).toHaveLength(
+      CLAIM_ROUTE_TIMING_ACTION_TYPES.length,
+    );
     const observedClaimRouteActionTypes = new Set(
       claimRouteTimingEvents.map((event) => {
         return event.op_type;

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -5,6 +5,7 @@ import {
   runnersJobClaimContract,
   runnersPollContract,
   storedExecutionContextSchema,
+  type ExecutionContext,
   type HeldSessionState,
   type StoredExecutionContext,
 } from "@vm0/api-contracts/contracts/runners";
@@ -24,7 +25,10 @@ import {
   createRunnerGroupRealtimeToken,
   publishRunChangedForUserSafely,
 } from "../external/realtime";
-import { recordSandboxOperation } from "../external/sandbox-op-log";
+import {
+  recordSandboxOperation,
+  recordSandboxOperations,
+} from "../external/sandbox-op-log";
 import { now, nowDate } from "../external/time";
 import { badRequestMessage, conflict, notFound } from "../../lib/error";
 import { logger } from "../../lib/log";
@@ -41,6 +45,91 @@ const STALE_RUNNER_THRESHOLD_MS = 5 * 60 * 1000;
 const INVALID_EXECUTION_CONTEXT_ERROR =
   "Runner job missing valid execution context";
 const MAX_VALIDATION_ISSUES_TO_LOG = 10;
+
+type ClaimRouteTimingSpanKind = "top_level" | "nested";
+type ClaimRouteTimingActionType =
+  | "claim_route_request_prepare"
+  | "claim_route_lookup_authorization"
+  | "claim_route_context_parse"
+  | "claim_route_feature_switch_context"
+  | "claim_route_secret_materialization"
+  | "claim_route_response_assembly"
+  | "claim_route_transition_running"
+  | "claim_route_transition_lock_run"
+  | "claim_route_transition_lock_queue_job"
+  | "claim_route_transition_update_run"
+  | "claim_route_transition_delete_queue_job";
+
+interface ClaimRouteTimingRecord {
+  readonly actionType: ClaimRouteTimingActionType;
+  readonly spanKind: ClaimRouteTimingSpanKind;
+  readonly durationMs: number;
+  readonly timestamp: string;
+}
+
+class ClaimRouteTimingCollector {
+  private readonly records: ClaimRouteTimingRecord[] = [];
+
+  recordElapsed(
+    actionType: ClaimRouteTimingActionType,
+    spanKind: ClaimRouteTimingSpanKind,
+    startedAt: number,
+    finishedAt: number = now(),
+  ): void {
+    this.records.push({
+      actionType,
+      spanKind,
+      durationMs: Math.max(0, finishedAt - startedAt),
+      timestamp: new Date(finishedAt).toISOString(),
+    });
+  }
+
+  measure<T>(
+    actionType: ClaimRouteTimingActionType,
+    spanKind: ClaimRouteTimingSpanKind,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    const startedAt = now();
+    return operation().finally(() => {
+      this.recordElapsed(actionType, spanKind, startedAt);
+    });
+  }
+
+  flush(args: {
+    readonly runId: string;
+    readonly runnerGroup: string;
+    readonly profile: string;
+    readonly authType: RunnerAuthContext["type"];
+    readonly pollReason: string | undefined;
+  }): void {
+    const records = this.records.splice(0);
+    const dimensions: Record<string, string> = {
+      runner_group: args.runnerGroup,
+      profile: args.profile,
+      auth_type: args.authType,
+    };
+    if (args.pollReason) {
+      dimensions.poll_reason = args.pollReason;
+    }
+
+    recordSandboxOperations(
+      records.map((record) => {
+        return {
+          sandboxType: "runner",
+          actionType: record.actionType,
+          durationMs: record.durationMs,
+          success: true,
+          runId: args.runId,
+          timestamp: record.timestamp,
+          dimensions: {
+            ...dimensions,
+            span_kind: record.spanKind,
+          },
+        };
+      }),
+    );
+  }
+}
 
 interface ValidationIssueLike {
   readonly path: readonly PropertyKey[];
@@ -408,6 +497,10 @@ type ClaimTransitionResult =
   | { readonly status: "conflict" }
   | { readonly status: "job-not-found" }
   | { readonly status: "run-not-found" };
+type ClaimedTransitionResult = Extract<
+  ClaimTransitionResult,
+  { readonly status: "claimed" }
+>;
 
 interface LockedClaimRunRow extends Record<string, unknown> {
   readonly id: string;
@@ -455,20 +548,41 @@ async function transitionClaimedJobToRunning(
   db: Db,
   runId: string,
   signal: AbortSignal,
+  timing: ClaimRouteTimingCollector,
 ): Promise<ClaimTransitionResult> {
   return await db.transaction(async (tx) => {
-    const run = await lockClaimRun(tx, runId);
+    const run = await timing.measure(
+      "claim_route_transition_lock_run",
+      "nested",
+      async () => {
+        return await lockClaimRun(tx, runId);
+      },
+    );
     signal.throwIfAborted();
     if (!run) {
       return { status: "run-not-found" };
     }
     if (run.status !== "pending") {
-      await tx.delete(runnerJobQueue).where(eq(runnerJobQueue.runId, runId));
+      await timing.measure(
+        "claim_route_transition_delete_queue_job",
+        "nested",
+        async () => {
+          await tx
+            .delete(runnerJobQueue)
+            .where(eq(runnerJobQueue.runId, runId));
+        },
+      );
       signal.throwIfAborted();
       return { status: "run-not-found" };
     }
 
-    const job = await lockRunnerJob(tx, runId);
+    const job = await timing.measure(
+      "claim_route_transition_lock_queue_job",
+      "nested",
+      async () => {
+        return await lockRunnerJob(tx, runId);
+      },
+    );
     signal.throwIfAborted();
     if (!job || job.isExpired) {
       return { status: "job-not-found" };
@@ -478,21 +592,33 @@ async function transitionClaimedJobToRunning(
     }
 
     const claimedAt = nowDate();
-    const [updatedRun] = await tx
-      .update(agentRuns)
-      .set({
-        status: "running",
-        startedAt: claimedAt,
-        lastHeartbeatAt: claimedAt,
-      })
-      .where(and(eq(agentRuns.id, runId), eq(agentRuns.status, "pending")))
-      .returning({ id: agentRuns.id });
+    const [updatedRun] = await timing.measure(
+      "claim_route_transition_update_run",
+      "nested",
+      async () => {
+        return await tx
+          .update(agentRuns)
+          .set({
+            status: "running",
+            startedAt: claimedAt,
+            lastHeartbeatAt: claimedAt,
+          })
+          .where(and(eq(agentRuns.id, runId), eq(agentRuns.status, "pending")))
+          .returning({ id: agentRuns.id });
+      },
+    );
     signal.throwIfAborted();
     if (!updatedRun) {
       throw new Error("Locked pending run was not claimed");
     }
 
-    await tx.delete(runnerJobQueue).where(eq(runnerJobQueue.runId, runId));
+    await timing.measure(
+      "claim_route_transition_delete_queue_job",
+      "nested",
+      async () => {
+        await tx.delete(runnerJobQueue).where(eq(runnerJobQueue.runId, runId));
+      },
+    );
     signal.throwIfAborted();
 
     return { status: "claimed" as const, claimedAt };
@@ -574,6 +700,110 @@ async function secretValuesForRunner(
   });
 }
 
+async function buildClaimResponseBody(args: {
+  readonly db: Db;
+  readonly run: ClaimedRun;
+  readonly storedContext: StoredExecutionContext;
+  readonly timing: ClaimRouteTimingCollector;
+  readonly signal: AbortSignal;
+}): Promise<ExecutionContext> {
+  const featureSwitchContext = await args.timing.measure(
+    "claim_route_feature_switch_context",
+    "top_level",
+    () => {
+      return loadUserFeatureSwitchContext(
+        args.db,
+        args.run.orgId,
+        args.run.userId,
+      );
+    },
+  );
+  args.signal.throwIfAborted();
+  const secretValues = await args.timing.measure(
+    "claim_route_secret_materialization",
+    "top_level",
+    () => {
+      return secretValuesForRunner(args.storedContext, featureSwitchContext);
+    },
+  );
+  args.signal.throwIfAborted();
+  const responseAssemblyStartedAt = now();
+  const sandboxToken = generateSandboxToken(
+    args.run.userId,
+    args.run.id,
+    args.run.orgId,
+  );
+  const responseBody = {
+    ...args.storedContext,
+    runId: args.run.id,
+    prompt: args.run.prompt,
+    appendSystemPrompt: args.run.appendSystemPrompt,
+    agentComposeVersionId: args.run.agentComposeVersionId,
+    vars: (args.run.vars as Record<string, string>) ?? null,
+    checkpointId: args.run.resumedFromCheckpointId ?? null,
+    sandboxToken,
+    secretValues,
+  };
+  args.timing.recordElapsed(
+    "claim_route_response_assembly",
+    "top_level",
+    responseAssemblyStartedAt,
+  );
+  return responseBody;
+}
+
+function scheduleSuccessfulClaimSideEffects(args: {
+  readonly jobWithRun: ClaimableJob;
+  readonly authType: RunnerAuthContext["type"];
+  readonly storedContext: StoredExecutionContext;
+  readonly claimRequestStartedAtMs: number;
+  readonly claimResult: ClaimedTransitionResult;
+  readonly telemetry:
+    | {
+        readonly jobDiscoveredToClaimRequestMs?: number;
+        readonly localAdmissionToClaimRequestMs?: number;
+        readonly pollReason?: string;
+      }
+    | undefined;
+  readonly claimRouteTiming: ClaimRouteTimingCollector;
+}): void {
+  const { job, run } = args.jobWithRun;
+  const queueCreatedAtMs = job.createdAt.getTime();
+  scheduleClaimSucceededSideEffects({
+    runId: run.id,
+    userId: run.userId,
+    runnerGroup: job.runnerGroup,
+    profile: job.profile,
+    authType: args.authType,
+    apiToRunnerQueueMs: elapsedSinceApiStartMs(
+      args.storedContext.apiStartTime,
+      queueCreatedAtMs,
+    ),
+    runnerQueueToClaimRequestMs: Math.max(
+      0,
+      args.claimRequestStartedAtMs - queueCreatedAtMs,
+    ),
+    apiToClaimRequestMs: elapsedSinceApiStartMs(
+      args.storedContext.apiStartTime,
+      args.claimRequestStartedAtMs,
+    ),
+    apiToClaimMs: elapsedSinceApiStartMs(
+      args.storedContext.apiStartTime,
+      args.claimResult.claimedAt.getTime(),
+    ),
+    claimRequestToRunningMs: Math.max(
+      0,
+      args.claimResult.claimedAt.getTime() - args.claimRequestStartedAtMs,
+    ),
+    jobDiscoveredToClaimRequestMs:
+      args.telemetry?.jobDiscoveredToClaimRequestMs,
+    localAdmissionToClaimRequestMs:
+      args.telemetry?.localAdmissionToClaimRequestMs,
+    pollReason: args.telemetry?.pollReason,
+    claimRouteTiming: args.claimRouteTiming,
+  });
+}
+
 function scheduleClaimSucceededSideEffects(args: {
   readonly runId: string;
   readonly userId: string;
@@ -588,6 +818,7 @@ function scheduleClaimSucceededSideEffects(args: {
   readonly jobDiscoveredToClaimRequestMs: number | undefined;
   readonly localAdmissionToClaimRequestMs: number | undefined;
   readonly pollReason: string | undefined;
+  readonly claimRouteTiming: ClaimRouteTimingCollector;
 }): void {
   waitUntil(
     publishRunChangedForUserSafely(args.userId, args.runId, {
@@ -615,6 +846,7 @@ async function recordClaimTimingMetrics(args: {
   readonly jobDiscoveredToClaimRequestMs: number | undefined;
   readonly localAdmissionToClaimRequestMs: number | undefined;
   readonly pollReason: string | undefined;
+  readonly claimRouteTiming: ClaimRouteTimingCollector;
 }): Promise<void> {
   await Promise.resolve();
   const dimensions: Record<string, string> = {
@@ -667,6 +899,13 @@ async function recordClaimTimingMetrics(args: {
     args.localAdmissionToClaimRequestMs,
     dimensions,
   );
+  args.claimRouteTiming.flush({
+    runId: args.runId,
+    runnerGroup: args.runnerGroup,
+    profile: args.profile,
+    authType: args.authType,
+    pollReason: args.pollReason,
+  });
 }
 
 function recordClaimTimingOperation(
@@ -729,6 +968,7 @@ const scheduleClaimFailedSideEffects$ = command(
 
 const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const claimRequestStartedAtMs = now();
+  const claimRouteTiming = new ClaimRouteTimingCollector();
   const auth = await set(runnerAuth$, get(authorization$), signal);
   signal.throwIfAborted();
   if (!auth) {
@@ -744,21 +984,39 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const params = get(pathParamsOf(runnersJobClaimContract.claim));
   const runId = params.id;
   const db = set(writeDb$);
+  claimRouteTiming.recordElapsed(
+    "claim_route_request_prepare",
+    "top_level",
+    claimRequestStartedAtMs,
+  );
 
+  const lookupAuthorizationStartedAt = now();
   const jobWithRun = await getClaimableJob(db, runId, signal);
   if (!isClaimableJob(jobWithRun)) {
     return jobWithRun;
   }
   const authError = claimAuthorizationError(auth, jobWithRun);
+  claimRouteTiming.recordElapsed(
+    "claim_route_lookup_authorization",
+    "top_level",
+    lookupAuthorizationStartedAt,
+  );
   if (authError) {
     return authError;
   }
 
   const run = jobWithRun.run;
 
+  const contextParseStartedAt = now();
   const storedContextResult = storedExecutionContextSchema.safeParse(
     jobWithRun.job.executionContext,
   );
+  claimRouteTiming.recordElapsed(
+    "claim_route_context_parse",
+    "top_level",
+    contextParseStartedAt,
+  );
+  signal.throwIfAborted();
   if (!storedContextResult.success) {
     warnInvalidStoredExecutionContext(runId, storedContextResult.error.issues);
     const poisonResult = await failPoisonQueuedJob(
@@ -787,31 +1045,28 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   }
   const storedContext = storedContextResult.data;
 
-  const featureSwitchContext = await loadUserFeatureSwitchContext(
+  const responseBody = await buildClaimResponseBody({
     db,
-    run.orgId,
-    run.userId,
-  );
-  signal.throwIfAborted();
-  const secretValues = await secretValuesForRunner(
+    run,
     storedContext,
-    featureSwitchContext,
+    timing: claimRouteTiming,
+    signal,
+  });
+  signal.throwIfAborted();
+
+  const claimResult = await claimRouteTiming.measure(
+    "claim_route_transition_running",
+    "top_level",
+    async () => {
+      return await transitionClaimedJobToRunning(
+        db,
+        runId,
+        signal,
+        claimRouteTiming,
+      );
+    },
   );
   signal.throwIfAborted();
-  const sandboxToken = generateSandboxToken(run.userId, run.id, run.orgId);
-  const responseBody = {
-    ...storedContext,
-    runId: run.id,
-    prompt: run.prompt,
-    appendSystemPrompt: run.appendSystemPrompt,
-    agentComposeVersionId: run.agentComposeVersionId,
-    vars: (run.vars as Record<string, string>) ?? null,
-    checkpointId: run.resumedFromCheckpointId ?? null,
-    sandboxToken,
-    secretValues,
-  };
-
-  const claimResult = await transitionClaimedJobToRunning(db, runId, signal);
   if (claimResult.status === "conflict") {
     return conflict("Job was claimed by another runner");
   }
@@ -822,38 +1077,14 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     return notFound("Run not found");
   }
 
-  const queueCreatedAtMs = jobWithRun.job.createdAt.getTime();
-  scheduleClaimSucceededSideEffects({
-    runId,
-    userId: run.userId,
-    runnerGroup: jobWithRun.job.runnerGroup,
-    profile: jobWithRun.job.profile,
+  scheduleSuccessfulClaimSideEffects({
+    jobWithRun,
     authType: auth.type,
-    apiToRunnerQueueMs: elapsedSinceApiStartMs(
-      storedContext.apiStartTime,
-      queueCreatedAtMs,
-    ),
-    runnerQueueToClaimRequestMs: Math.max(
-      0,
-      claimRequestStartedAtMs - queueCreatedAtMs,
-    ),
-    apiToClaimRequestMs: elapsedSinceApiStartMs(
-      storedContext.apiStartTime,
-      claimRequestStartedAtMs,
-    ),
-    apiToClaimMs: elapsedSinceApiStartMs(
-      storedContext.apiStartTime,
-      claimResult.claimedAt.getTime(),
-    ),
-    claimRequestToRunningMs: Math.max(
-      0,
-      claimResult.claimedAt.getTime() - claimRequestStartedAtMs,
-    ),
-    jobDiscoveredToClaimRequestMs:
-      body.data.telemetry?.jobDiscoveredToClaimRequestMs,
-    localAdmissionToClaimRequestMs:
-      body.data.telemetry?.localAdmissionToClaimRequestMs,
-    pollReason: body.data.telemetry?.pollReason,
+    storedContext,
+    claimRequestStartedAtMs,
+    claimResult,
+    telemetry: body.data.telemetry,
+    claimRouteTiming,
   });
 
   return {


### PR DESCRIPTION
## Summary
- add successful-claim internal phase timing rows for the runner claim route
- emit top-level and nested transition spans through the existing sandbox operation telemetry path
- cover the new event shape and sensitive-field exclusions in the run lifecycle route integration test

Closes #18750

## Tests
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- pre-commit: `pnpm knip`, `pnpm check-types`
