### PR TITLE
fix: align trigger permissions with metadata defaults

### DIFF
--- a/turbo/apps/platform/src/signals/trigger-permissions/trigger-permissions-signals.ts
+++ b/turbo/apps/platform/src/signals/trigger-permissions/trigger-permissions-signals.ts
@@ -4,6 +4,11 @@ import type {
   UnattendedTriggerPermissionPolicy,
   ZeroWorkflowTriggerSummary,
 } from "@vm0/api-contracts/contracts/zero-workflows";
+import {
+  createFirewallMetadataPolicyResolver,
+  type FirewallPermissionDetailMetadata,
+} from "@vm0/connectors/firewall-metadata";
+import type { FirewallPolicyValue } from "@vm0/connectors/firewall-types";
 import { pathParams$, searchParams$ } from "../route.ts";
 import { workflowDetail } from "../workflows-page/workflows-signals.ts";
 
@@ -69,37 +74,42 @@ export const triggerPermissionsTrigger$ = computed(
 // Policy helpers
 // ---------------------------------------------------------------------------
 
-/**
- * The unattended default is "deny": a permission absent from the trigger's
- * policy is treated as denied until explicitly allowed.
- */
-const UNATTENDED_PERMISSION_DEFAULT: UnattendedTriggerPermissionAction = "deny";
+function toUnattendedPermissionAction(
+  value: FirewallPolicyValue,
+): UnattendedTriggerPermissionAction {
+  return value === "allow" ? "allow" : "deny";
+}
 
 /**
  * Resolve the current action for a single connector permission from the
- * trigger's full policy, falling back to the unattended default.
+ * trigger's sparse policy overlaid on connector metadata defaults.
  */
 export function resolveTriggerPermissionAction(
   policy: UnattendedTriggerPermissionPolicy | null,
   connectorRef: string,
+  metadata: FirewallPermissionDetailMetadata,
   permission: string,
 ): UnattendedTriggerPermissionAction {
-  return (
-    policy?.[connectorRef]?.policies[permission] ??
-    UNATTENDED_PERMISSION_DEFAULT
+  const resolver = createFirewallMetadataPolicyResolver(
+    metadata,
+    policy?.[connectorRef]
+      ? { permissionOverrides: policy[connectorRef].policies }
+      : undefined,
   );
+  return toUnattendedPermissionAction(resolver.permission(permission));
 }
 
 /**
  * Merge an edited connector's permission map into the trigger's full existing
  * policy, preserving every other connector. Permissions set back to the
- * unattended default are dropped so the stored policy stays minimal; a
+ * connector metadata default are dropped so the stored policy stays minimal; a
  * connector left with no explicit permissions is removed entirely, and an empty
  * overall policy collapses to `null` (which clears the policy server-side).
  */
 export function mergeConnectorPolicy(
   policy: UnattendedTriggerPermissionPolicy | null,
   connectorRef: string,
+  metadata: FirewallPermissionDetailMetadata,
   policies: Record<string, UnattendedTriggerPermissionAction>,
 ): UnattendedTriggerPermissionPolicy | null {
   const next: UnattendedTriggerPermissionPolicy = {};
@@ -108,9 +118,13 @@ export function mergeConnectorPolicy(
       next[ref] = entry;
     }
   }
+  const defaultResolver = createFirewallMetadataPolicyResolver(metadata);
   const nextPolicies: Record<string, UnattendedTriggerPermissionAction> = {};
   for (const [permission, action] of Object.entries(policies)) {
-    if (action !== UNATTENDED_PERMISSION_DEFAULT) {
+    const defaultAction = toUnattendedPermissionAction(
+      defaultResolver.permission(permission),
+    );
+    if (action !== defaultAction) {
       nextPolicies[permission] = action;
     }
   }

--- a/turbo/apps/platform/src/views/trigger-permissions/__tests__/trigger-permissions-page.test.tsx
+++ b/turbo/apps/platform/src/views/trigger-permissions/__tests__/trigger-permissions-page.test.tsx
@@ -22,7 +22,9 @@ const CURRENT_USER_ID = "test-user-123";
 const AGENT_ID = "c0000000-0000-4000-a000-000000000301";
 const WORKFLOW_ID = "d0000000-0000-4000-a000-000000000401";
 const TRIGGER_ID = "workflow-trigger-perm-editor";
-const PERMISSION_LABEL = "Access workspace analytics data";
+const SLACK_PERMISSION_LABEL = "Access workspace analytics data";
+const GMAIL_DRAFTS_WRITE_LABEL = "Create, update, and delete Gmail drafts.";
+const GMAIL_MESSAGES_SEND_LABEL = "Send Gmail messages directly.";
 
 function trigger(
   unattendedPermissionPolicy: ZeroWorkflowTriggerSummary["unattendedPermissionPolicy"],
@@ -94,8 +96,8 @@ function mockTriggerPolicyApis(
   return bodies;
 }
 
-function permissionRow(): HTMLElement {
-  const label = screen.getByText(PERMISSION_LABEL);
+function permissionRow(labelText: string): HTMLElement {
+  const label = screen.getByText(labelText);
   const row = label.parentElement;
   if (!row) {
     throw new Error("Expected a permission row");
@@ -113,7 +115,9 @@ function button(label: string, container?: HTMLElement): HTMLElement {
   return match;
 }
 
-const editorPath = `/agents/${AGENT_ID}/workflows/${WORKFLOW_ID}/triggers/${TRIGGER_ID}/permissions?ref=slack`;
+function editorPath(connectorRef: string): string {
+  return `/agents/${AGENT_ID}/workflows/${WORKFLOW_ID}/triggers/${TRIGGER_ID}/permissions?ref=${connectorRef}`;
+}
 
 describe("trigger permissions page", () => {
   it("shows a connector picker when no connector ref is selected", async () => {
@@ -153,16 +157,16 @@ describe("trigger permissions page", () => {
   it("allows a permission and saves the merged policy", async () => {
     const bodies = mockTriggerPolicyApis(null);
 
-    detachedSetupPage({ context, path: editorPath });
+    detachedSetupPage({ context, path: editorPath("slack") });
 
     await waitFor(() => {
-      expect(screen.getByText(PERMISSION_LABEL)).toBeInTheDocument();
+      expect(screen.getByText(SLACK_PERMISSION_LABEL)).toBeInTheDocument();
     });
 
     // Save is disabled until something changes.
     expect(button("Save")).toBeDisabled();
 
-    await user.click(button("Allow", permissionRow()));
+    await user.click(button("Allow", permissionRow(SLACK_PERMISSION_LABEL)));
     await user.click(button("Save"));
 
     await waitFor(() => {
@@ -183,13 +187,77 @@ describe("trigger permissions page", () => {
       slack: { policies: { "admin.analytics:read": "allow" } },
     });
 
-    detachedSetupPage({ context, path: editorPath });
+    detachedSetupPage({ context, path: editorPath("slack") });
 
     await waitFor(() => {
-      expect(screen.getByText(PERMISSION_LABEL)).toBeInTheDocument();
+      expect(screen.getByText(SLACK_PERMISSION_LABEL)).toBeInTheDocument();
     });
 
-    await user.click(button("Deny", permissionRow()));
+    await user.click(button("Deny", permissionRow(SLACK_PERMISSION_LABEL)));
+    await user.click(button("Save"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Saved")).toBeInTheDocument();
+    });
+
+    expect(bodies).toStrictEqual([{ unattendedPermissionPolicy: null }]);
+  });
+
+  it("shows Gmail connector metadata defaults when no trigger policy is saved", async () => {
+    mockTriggerPolicyApis(null);
+
+    detachedSetupPage({ context, path: editorPath("gmail") });
+
+    await waitFor(() => {
+      expect(screen.getByText(GMAIL_DRAFTS_WRITE_LABEL)).toBeInTheDocument();
+    });
+
+    expect(
+      button("Allow", permissionRow(GMAIL_DRAFTS_WRITE_LABEL)),
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(
+      button("Deny", permissionRow(GMAIL_MESSAGES_SEND_LABEL)),
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(button("Save")).toBeDisabled();
+  });
+
+  it("preserves an explicit Gmail deny override for metadata-default allowed permissions", async () => {
+    const bodies = mockTriggerPolicyApis(null);
+
+    detachedSetupPage({ context, path: editorPath("gmail") });
+
+    await waitFor(() => {
+      expect(screen.getByText(GMAIL_DRAFTS_WRITE_LABEL)).toBeInTheDocument();
+    });
+
+    await user.click(button("Deny", permissionRow(GMAIL_DRAFTS_WRITE_LABEL)));
+    await user.click(button("Save"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Saved")).toBeInTheDocument();
+    });
+
+    expect(bodies).toStrictEqual([
+      {
+        unattendedPermissionPolicy: {
+          gmail: { policies: { "drafts.write": "deny" } },
+        },
+      },
+    ]);
+  });
+
+  it("clears a Gmail override when restored to the metadata default", async () => {
+    const bodies = mockTriggerPolicyApis({
+      gmail: { policies: { "drafts.write": "deny" } },
+    });
+
+    detachedSetupPage({ context, path: editorPath("gmail") });
+
+    await waitFor(() => {
+      expect(screen.getByText(GMAIL_DRAFTS_WRITE_LABEL)).toBeInTheDocument();
+    });
+
+    await user.click(button("Allow", permissionRow(GMAIL_DRAFTS_WRITE_LABEL)));
     await user.click(button("Save"));
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/trigger-permissions/trigger-permissions-page.tsx
+++ b/turbo/apps/platform/src/views/trigger-permissions/trigger-permissions-page.tsx
@@ -238,6 +238,45 @@ function PermissionToggle({
   );
 }
 
+function hasDirtyTriggerPermissionOverride({
+  overrides,
+  savedPolicy,
+  connectorRef,
+  metadata,
+}: {
+  readonly overrides: Record<string, UnattendedTriggerPermissionAction>;
+  readonly savedPolicy: UnattendedTriggerPermissionPolicy | null;
+  readonly connectorRef: string;
+  readonly metadata: FirewallPermissionDetailMetadata;
+}): boolean {
+  return metadata.permissions.some((permission) => {
+    const override = overrides[permission.name];
+    if (override === undefined) {
+      return false;
+    }
+    return (
+      override !==
+      resolveTriggerPermissionAction(
+        savedPolicy,
+        connectorRef,
+        metadata,
+        permission.name,
+      )
+    );
+  });
+}
+
+function materializeTriggerPermissionPolicies(
+  metadata: FirewallPermissionDetailMetadata,
+  actionFor: (permission: string) => UnattendedTriggerPermissionAction,
+): Record<string, UnattendedTriggerPermissionAction> {
+  const policies: Record<string, UnattendedTriggerPermissionAction> = {};
+  for (const permission of metadata.permissions) {
+    policies[permission.name] = actionFor(permission.name);
+  }
+  return policies;
+}
+
 function ConnectorPermissionEditorCard({
   triggerId,
   connectorRef,
@@ -269,27 +308,29 @@ function ConnectorPermissionEditorCard({
   const actionFor = (permission: string): UnattendedTriggerPermissionAction => {
     return (
       overrides[permission] ??
-      resolveTriggerPermissionAction(savedPolicy, connectorRef, permission)
+      resolveTriggerPermissionAction(
+        savedPolicy,
+        connectorRef,
+        metadata,
+        permission,
+      )
     );
   };
 
-  const dirty = metadata.permissions.some((permission) => {
-    const override = overrides[permission.name];
-    if (override === undefined) {
-      return false;
-    }
-    return (
-      override !==
-      resolveTriggerPermissionAction(savedPolicy, connectorRef, permission.name)
-    );
+  const dirty = hasDirtyTriggerPermissionOverride({
+    overrides,
+    savedPolicy,
+    connectorRef,
+    metadata,
   });
 
   const handleSave = () => {
-    const policies: Record<string, UnattendedTriggerPermissionAction> = {};
-    for (const permission of metadata.permissions) {
-      policies[permission.name] = actionFor(permission.name);
-    }
-    const merged = mergeConnectorPolicy(savedPolicy, connectorRef, policies);
+    const merged = mergeConnectorPolicy(
+      savedPolicy,
+      connectorRef,
+      metadata,
+      materializeTriggerPermissionPolicies(metadata, actionFor),
+    );
     // After the save, `reloadWorkflows$` refetches the trigger; once its policy
     // reflects the merge, the local overrides match the saved state and `dirty`
     // collapses to false on its own — no explicit reset needed.


### PR DESCRIPTION
## Summary

- resolve trigger permission rows from connector metadata defaults plus saved trigger overrides
- save trigger policies as sparse overlays relative to metadata defaults instead of hard-coded deny
- cover Gmail default allow / explicit deny behavior in trigger permissions page tests

Fixes #18927

## Test plan

- pnpm -F @vm0/app exec vitest run src/views/trigger-permissions/__tests__/trigger-permissions-page.test.tsx
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types