### PR TITLE
fix: close artifact sidebar on new chat

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
@@ -22,6 +22,10 @@ import {
 import { detachedNavigateTo$, searchParams$ } from "../route.ts";
 import { loadRightThread$ } from "./chat-thread-panes.ts";
 import {
+  clearArtifactSidebarParams,
+  clearChatAutomationSidebarParams,
+} from "../zero-page/right-sidebar-search-params.ts";
+import {
   talkDraft$,
   type ZeroChatAttachment,
 } from "../zero-page/chat-draft.ts";
@@ -258,6 +262,8 @@ const routeMainOptimisticChatThread$ = command(
     if (next.get(SIDEBAR_PARAM) === pending.threadId) {
       next.delete(SIDEBAR_PARAM);
     }
+    clearArtifactSidebarParams(next);
+    clearChatAutomationSidebarParams(next);
     set(detachedNavigateTo$, "/chats/:threadId", {
       pathParams: { threadId: pending.threadId },
       searchParams: next,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   chatThreadByIdContract,
+  chatThreadArtifactsContract,
   chatThreadPinContract,
   chatThreadRenameContract,
   chatThreadUnpinContract,
@@ -314,6 +315,74 @@ describe("zero sidebar", () => {
     });
 
     createDeferred.resolve();
+  });
+
+  it("closes the artifact sidebar when creating a new main chat", async () => {
+    prepareDefaultAgent();
+    const artifactUrl = encodeURIComponent(
+      "https://cdn.vm7.io/artifacts/test/archive.zip",
+    );
+
+    context.mocks.api(chatThreadsContract.list, ({ respond }) => {
+      return respond(
+        200,
+        splitChatThreadListResponse([
+          {
+            id: EXISTING_THREAD_ID,
+            title: "Existing conversation",
+            agent: { id: AGENT_ID, avatarUrl: null },
+            createdAt: "2026-03-10T00:00:00Z",
+            updatedAt: "2026-03-10T00:00:00Z",
+            running: false,
+          },
+        ]),
+      );
+    });
+    context.mocks.api(chatThreadsContract.create, ({ body, respond }) => {
+      return respond(201, {
+        id: body.clientThreadId ?? "created-thread-id",
+        title: null,
+        createdAt: "2026-03-10T00:00:00Z",
+      });
+    });
+    context.mocks.api(chatThreadArtifactsContract.list, ({ respond }) => {
+      return respond(200, { runs: [] });
+    });
+    context.mocks.api(chatThreadByIdContract.get, ({ params, respond }) => {
+      return respond(200, {
+        id: params.id,
+        title:
+          params.id === EXISTING_THREAD_ID ? "Existing conversation" : null,
+        agentId: AGENT_ID,
+        activeRunIds: [],
+        draftContent: null,
+        draftAttachments: null,
+        createdAt: "2026-03-10T00:00:00Z",
+        updatedAt: "2026-03-10T00:00:00Z",
+      });
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${EXISTING_THREAD_ID}?artifact=${artifactUrl}`,
+    });
+
+    const newChatButton = await waitFor(() => {
+      expect(screen.getByTestId("artifact-sidebar")).toBeInTheDocument();
+      expect(
+        within(sidebar()).getByText("Existing conversation"),
+      ).toBeInTheDocument();
+      const button = screen.getByLabelText("New chat with Zero");
+      expect(button).not.toBeDisabled();
+      return button;
+    });
+
+    click(newChatButton);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("artifact-sidebar")).not.toBeInTheDocument();
+      expect(window.location.search).not.toContain("artifact=");
+    });
   });
 
   it("pins and unpins a chat thread from the sidebar menu", async () => {


### PR DESCRIPTION
## Summary
- clear right-side artifact and automation query params when routing a new main chat
- add regression coverage for creating a new chat while an artifact preview is open

## Tests
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-sidebar.test.tsx
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types