### PR TITLE
fix: add default hosted site robots

### DIFF
--- a/turbo/apps/cli/src/commands/zero/host/__tests__/publish.test.ts
+++ b/turbo/apps/cli/src/commands/zero/host/__tests__/publish.test.ts
@@ -1,0 +1,142 @@
+import { createHash } from "node:crypto";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { hostedSitePrepareRequestSchema } from "@vm0/api-contracts/contracts/zero-host";
+import chalk from "chalk";
+import { http, HttpResponse } from "msw";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DEFAULT_HOSTED_SITE_ROBOTS_TXT } from "../../../../lib/host/static-site";
+import { server } from "../../../../mocks/server";
+import { zeroHostCommand } from "../index";
+
+const PREPARE_URL = "http://localhost:3000/api/zero/host/deployments/prepare";
+const COMPLETE_URL =
+  "http://localhost:3000/api/zero/host/deployments/:deploymentId/complete";
+const INDEX_UPLOAD_URL = "https://uploads.example.com/index";
+const ROBOTS_UPLOAD_URL = "https://uploads.example.com/robots";
+
+function sha256(bytes: string): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+describe("zero host publish command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  let tempDir: string;
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("ZERO_TOKEN", "test-token");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+    tempDir = join(tmpdir(), `zero-host-publish-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+    vi.unstubAllEnvs();
+  });
+
+  it("uploads a default robots.txt when the site does not include one", async () => {
+    const index = "<!doctype html><main>Hosted site</main>";
+    let uploadedRobots = false;
+
+    writeFileSync(join(tempDir, "index.html"), index);
+
+    server.use(
+      http.post(PREPARE_URL, async ({ request }) => {
+        expect(request.headers.get("authorization")).toBe("Bearer test-token");
+        const body = hostedSitePrepareRequestSchema.parse(await request.json());
+        expect(body).toMatchObject({
+          site: "demo-site",
+          artifactKind: "hosted-site",
+          spaFallback: true,
+        });
+
+        const filesByPath = new Map(
+          body.files.map((file) => {
+            return [file.path, file];
+          }),
+        );
+
+        expect(filesByPath.get("/index.html")).toMatchObject({
+          size: Buffer.byteLength(index),
+          sha256: sha256(index),
+          contentType: "text/html; charset=utf-8",
+        });
+        expect(filesByPath.get("/robots.txt")).toMatchObject({
+          size: Buffer.byteLength(DEFAULT_HOSTED_SITE_ROBOTS_TXT),
+          sha256: sha256(DEFAULT_HOSTED_SITE_ROBOTS_TXT),
+          contentType: "text/plain; charset=utf-8",
+        });
+
+        return HttpResponse.json({
+          siteId: "00000000-0000-4000-8000-000000000001",
+          deploymentId: "00000000-0000-4000-8000-000000000002",
+          publicSlug: "demo-site-a1b2c3d4-release-01",
+          url: "https://demo-site-a1b2c3d4-release-01.sites.example.com",
+          uploads: [
+            { path: "/index.html", uploadUrl: INDEX_UPLOAD_URL },
+            { path: "/robots.txt", uploadUrl: ROBOTS_UPLOAD_URL },
+          ],
+        });
+      }),
+      http.put(INDEX_UPLOAD_URL, async ({ request }) => {
+        expect(await request.text()).toBe(index);
+        return new HttpResponse(null, { status: 200 });
+      }),
+      http.put(ROBOTS_UPLOAD_URL, async ({ request }) => {
+        uploadedRobots = true;
+        expect(await request.text()).toBe(DEFAULT_HOSTED_SITE_ROBOTS_TXT);
+        return new HttpResponse(null, { status: 200 });
+      }),
+      http.post(COMPLETE_URL, ({ params }) => {
+        expect(params.deploymentId).toBe(
+          "00000000-0000-4000-8000-000000000002",
+        );
+        return HttpResponse.json({
+          siteId: "00000000-0000-4000-8000-000000000001",
+          deploymentId: "00000000-0000-4000-8000-000000000002",
+          publicSlug: "demo-site-a1b2c3d4-release-01",
+          url: "https://demo-site-a1b2c3d4-release-01.sites.example.com",
+          status: "ready",
+        });
+      }),
+    );
+
+    await zeroHostCommand.parseAsync([
+      "node",
+      "cli",
+      tempDir,
+      "--site",
+      "demo-site",
+      "--spa",
+      "--json",
+    ]);
+
+    expect(uploadedRobots).toBe(true);
+
+    const stdout = mockConsoleLog.mock.calls.flat().join("\n");
+    const parsed = JSON.parse(stdout) as Record<string, unknown>;
+    expect(parsed).toMatchObject({
+      publicSlug: "demo-site-a1b2c3d4-release-01",
+      fileCount: 2,
+      size:
+        Buffer.byteLength(index) +
+        Buffer.byteLength(DEFAULT_HOSTED_SITE_ROBOTS_TXT),
+    });
+  });
+});

--- a/turbo/apps/cli/src/lib/host/__tests__/static-site.test.ts
+++ b/turbo/apps/cli/src/lib/host/__tests__/static-site.test.ts
@@ -4,7 +4,11 @@ import { tmpdir } from "node:os";
 
 import { afterEach, describe, expect, it } from "vitest";
 
-import { scanStaticSite } from "../static-site";
+import {
+  DEFAULT_HOSTED_SITE_ROBOTS_TXT,
+  readStaticSiteFile,
+  scanStaticSite,
+} from "../static-site";
 
 const roots: string[] = [];
 
@@ -59,6 +63,54 @@ describe("scanStaticSite", () => {
 
     await expect(scanStaticSite(root)).rejects.toThrow(
       "Missing asset referenced by /index.html",
+    );
+  });
+
+  it("adds a default robots.txt when requested and missing", async () => {
+    const root = await tempRoot();
+    await writeFile(join(root, "index.html"), "<main>Hosted site</main>");
+
+    const result = await scanStaticSite(root, {
+      defaultRobots: "disallow-all",
+    });
+
+    const robots = result.files.find((file) => {
+      return file.path === "/robots.txt";
+    });
+
+    expect(robots).toMatchObject({
+      path: "/robots.txt",
+      contentType: "text/plain; charset=utf-8",
+      size: Buffer.byteLength(DEFAULT_HOSTED_SITE_ROBOTS_TXT),
+    });
+    if (!robots) {
+      throw new Error("Expected generated robots.txt");
+    }
+    expect(new TextDecoder().decode(await readStaticSiteFile(robots))).toBe(
+      DEFAULT_HOSTED_SITE_ROBOTS_TXT,
+    );
+  });
+
+  it("keeps an existing robots.txt when present", async () => {
+    const root = await tempRoot();
+    const customRobots = "User-agent: *\nAllow: /\n";
+    await writeFile(join(root, "index.html"), "<main>Hosted site</main>");
+    await writeFile(join(root, "robots.txt"), customRobots);
+
+    const result = await scanStaticSite(root, {
+      defaultRobots: "disallow-all",
+    });
+    const robotsFiles = result.files.filter((file) => {
+      return file.path === "/robots.txt";
+    });
+
+    expect(robotsFiles).toHaveLength(1);
+    const robots = robotsFiles[0];
+    if (!robots) {
+      throw new Error("Expected existing robots.txt");
+    }
+    expect(new TextDecoder().decode(await readStaticSiteFile(robots))).toBe(
+      customRobots,
     );
   });
 });

--- a/turbo/apps/cli/src/lib/host/publish-static-site.ts
+++ b/turbo/apps/cli/src/lib/host/publish-static-site.ts
@@ -1,8 +1,6 @@
-import { readFile } from "node:fs/promises";
-
 import type { HostedArtifactKind } from "@vm0/api-contracts/contracts/zero-host";
 import { completeHostedSite, prepareHostedSite } from "../api";
-import { scanStaticSite } from "./static-site";
+import { readStaticSiteFile, scanStaticSite } from "./static-site";
 
 interface PublishStaticSiteProgress {
   readonly phase: "preparing" | "uploading";
@@ -31,7 +29,11 @@ interface PublishStaticSiteOptions {
 export async function publishStaticSite(
   options: PublishStaticSiteOptions,
 ): Promise<PublishStaticSiteResult> {
-  const scan = await scanStaticSite(options.dir);
+  const artifactKind = options.artifactKind ?? "hosted-site";
+  const scan = await scanStaticSite(
+    options.dir,
+    artifactKind === "hosted-site" ? { defaultRobots: "disallow-all" } : {},
+  );
   const totalSize = scan.files.reduce((sum, file) => {
     return sum + file.size;
   }, 0);
@@ -44,7 +46,7 @@ export async function publishStaticSite(
   const prepared = await prepareHostedSite({
     site: options.site,
     ...(options.slugSuffix !== undefined && { slugSuffix: options.slugSuffix }),
-    artifactKind: options.artifactKind ?? "hosted-site",
+    artifactKind,
     spaFallback: Boolean(options.spaFallback),
     files: scan.files.map((file) => {
       return {
@@ -69,7 +71,7 @@ export async function publishStaticSite(
       throw new Error(`Missing upload URL for ${file.path}`);
     }
     options.onProgress?.({ phase: "uploading", path: file.path });
-    const bytes = await readFile(file.absolutePath);
+    const bytes = await readStaticSiteFile(file);
     const response = await fetch(uploadUrl, {
       method: "PUT",
       headers: { "Content-Type": file.contentType },

--- a/turbo/apps/cli/src/lib/host/static-site.ts
+++ b/turbo/apps/cli/src/lib/host/static-site.ts
@@ -3,7 +3,8 @@ import { readdir, readFile, stat } from "node:fs/promises";
 import { extname, relative, resolve, sep, dirname, posix } from "node:path";
 
 interface StaticSiteFile {
-  readonly absolutePath: string;
+  readonly absolutePath?: string;
+  readonly content?: Uint8Array;
   readonly path: string;
   readonly size: number;
   readonly sha256: string;
@@ -11,10 +12,16 @@ interface StaticSiteFile {
   readonly immutable?: boolean;
 }
 
+interface StaticSiteScanOptions {
+  readonly defaultRobots?: "disallow-all";
+}
+
 interface StaticSiteScanResult {
   readonly root: string;
   readonly files: readonly StaticSiteFile[];
 }
+
+export const DEFAULT_HOSTED_SITE_ROBOTS_TXT = "User-agent: *\nDisallow: /\n";
 
 const MIME_BY_EXTENSION: Record<string, string> = {
   ".html": "text/html; charset=utf-8",
@@ -168,6 +175,33 @@ async function hashFile(path: string): Promise<string> {
   return createHash("sha256").update(bytes).digest("hex");
 }
 
+function textFile(path: string, content: string): StaticSiteFile {
+  const bytes = new TextEncoder().encode(content);
+  return {
+    content: bytes,
+    path,
+    size: bytes.byteLength,
+    sha256: createHash("sha256").update(bytes).digest("hex"),
+    contentType: inferContentType(path),
+  };
+}
+
+function ensureDefaultRobots(
+  files: readonly StaticSiteFile[],
+  options: StaticSiteScanOptions,
+): readonly StaticSiteFile[] {
+  if (
+    options.defaultRobots !== "disallow-all" ||
+    files.some((file) => {
+      return file.path === "/robots.txt";
+    })
+  ) {
+    return files;
+  }
+
+  return [...files, textFile("/robots.txt", DEFAULT_HOSTED_SITE_ROBOTS_TXT)];
+}
+
 async function walk(
   root: string,
   dir: string,
@@ -214,6 +248,9 @@ async function assertReferencesExist(
     if (!shouldValidateReferences(ext)) {
       continue;
     }
+    if (!file.absolutePath) {
+      throw new Error(`Hosted-site file has no source: ${file.path}`);
+    }
     const text = await readFile(file.absolutePath, "utf8");
     const references = collectReferences(ext, text);
 
@@ -236,6 +273,7 @@ async function assertReferencesExist(
 
 export async function scanStaticSite(
   rootPath: string,
+  options: StaticSiteScanOptions = {},
 ): Promise<StaticSiteScanResult> {
   const root = resolve(rootPath);
   const rootStat = await stat(root);
@@ -255,11 +293,25 @@ export async function scanStaticSite(
   }
 
   await assertReferencesExist(files);
+  const publishFiles = [...ensureDefaultRobots(files, options)];
 
   return {
     root,
-    files: files.sort((a, b) => {
+    files: publishFiles.sort((a, b) => {
       return a.path.localeCompare(b.path);
     }),
   };
+}
+
+export async function readStaticSiteFile(
+  file: StaticSiteFile,
+): Promise<Uint8Array> {
+  if (file.content) {
+    return file.content;
+  }
+  if (!file.absolutePath) {
+    throw new Error(`Hosted-site file has no source: ${file.path}`);
+  }
+  const bytes = await readFile(file.absolutePath);
+  return new Uint8Array(bytes);
 }

--- a/turbo/apps/host-worker/src/index.test.ts
+++ b/turbo/apps/host-worker/src/index.test.ts
@@ -7,6 +7,17 @@ type R2Object = NonNullable<
   Awaited<ReturnType<WorkerEnv["HOSTED_SITES_BUCKET"]["get"]>>
 >;
 
+interface TestFile {
+  readonly body: string;
+  readonly contentType: string;
+}
+
+interface TestEnvOptions {
+  readonly files?: Record<string, TestFile>;
+}
+
+const DEFAULT_ROBOTS_TXT = "User-agent: *\nDisallow: /\n";
+
 function textStream(value: string): ReadableStream<Uint8Array> {
   return new ReadableStream({
     start(controller) {
@@ -26,11 +37,40 @@ function objectBody(body: string, contentType = "application/json"): R2Object {
   };
 }
 
-function env(): WorkerEnv {
+function byteLength(value: string): number {
+  return new TextEncoder().encode(value).byteLength;
+}
+
+function env(options: TestEnvOptions = {}): WorkerEnv {
   const publicSlug = "demo";
   const deploymentId = "00000000-0000-4000-8000-000000000001";
   const prefix = `sites/${publicSlug}/deployments/${deploymentId}`;
   const manifestKey = `${prefix}/manifest.json`;
+  const files: Record<string, TestFile> = {
+    "/index.html": {
+      body: "<!doctype html>ok",
+      contentType: "text/html; charset=utf-8",
+    },
+    ...(options.files ?? {}),
+  };
+  const manifestFiles = Object.fromEntries(
+    Object.entries(files).map(([path, file]) => {
+      return [
+        path,
+        {
+          path,
+          size: byteLength(file.body),
+          sha256: "a".repeat(64),
+          contentType: file.contentType,
+        },
+      ];
+    }),
+  );
+  const fileObjects: [string, R2Object][] = Object.entries(files).map(
+    ([path, file]) => {
+      return [`${prefix}${path}`, objectBody(file.body, file.contentType)];
+    },
+  );
   const objects = new Map<string, R2Object>([
     [
       `sites/${publicSlug}/active.json`,
@@ -57,21 +97,11 @@ function env(): WorkerEnv {
           publicSlug,
           createdAt: "2026-01-01T00:00:00.000Z",
           spaFallback: false,
-          files: {
-            "/index.html": {
-              path: "/index.html",
-              size: 18,
-              sha256: "a".repeat(64),
-              contentType: "text/html; charset=utf-8",
-            },
-          },
+          files: manifestFiles,
         }),
       ),
     ],
-    [
-      `${prefix}/index.html`,
-      objectBody("<!doctype html>ok", "text/html; charset=utf-8"),
-    ],
+    ...fileObjects,
   ]);
 
   return {
@@ -84,7 +114,7 @@ function env(): WorkerEnv {
   };
 }
 
-describe("hosted site CORS", () => {
+describe("hosted site worker", () => {
   it("allows the vm0 apex origin on preflight responses", async () => {
     const response = await worker.fetch(
       new Request("https://demo.sites.vm0.io/", {
@@ -131,5 +161,38 @@ describe("hosted site CORS", () => {
     expect(response.status).toBe(200);
     expect(response.headers.get("Access-Control-Allow-Origin")).toBeNull();
     expect(response.headers.get("Vary")).toBe("Origin");
+  });
+
+  it("serves default robots.txt when the active deployment omits it", async () => {
+    const response = await worker.fetch(
+      new Request("https://demo.sites.vm0.io/robots.txt"),
+      env(),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe(
+      "text/plain; charset=utf-8",
+    );
+    expect(response.headers.get("Cache-Control")).toBe("public, max-age=3600");
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(await response.text()).toBe(DEFAULT_ROBOTS_TXT);
+  });
+
+  it("serves an uploaded robots.txt when present", async () => {
+    const customRobots = "User-agent: *\nAllow: /\n";
+    const response = await worker.fetch(
+      new Request("https://demo.sites.vm0.io/robots.txt"),
+      env({
+        files: {
+          "/robots.txt": {
+            body: customRobots,
+            contentType: "text/plain; charset=utf-8",
+          },
+        },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe(customRobots);
   });
 });

--- a/turbo/apps/host-worker/src/index.ts
+++ b/turbo/apps/host-worker/src/index.ts
@@ -52,6 +52,7 @@ const STATIC_ALLOWED_ORIGINS = new Set([
   "https://vm0.ai",
   "https://app.vm7.ai:8443",
 ]);
+const DEFAULT_ROBOTS_TXT = "User-agent: *\nDisallow: /\n";
 
 function isSubdomainOf(hostname: string, domain: string): boolean {
   return hostname.endsWith(`.${domain}`) && hostname.length > domain.length + 1;
@@ -130,6 +131,17 @@ function notFoundResponse(): Response {
   return new Response("Not found", {
     status: 404,
     headers: { "Cache-Control": "public, max-age=60" },
+  });
+}
+
+function defaultRobotsResponse(request: Request): Response {
+  return new Response(request.method === "HEAD" ? null : DEFAULT_ROBOTS_TXT, {
+    status: 200,
+    headers: {
+      "Cache-Control": "public, max-age=3600",
+      "Content-Type": "text/plain; charset=utf-8",
+      "X-Content-Type-Options": "nosniff",
+    },
   });
 }
 
@@ -258,6 +270,10 @@ async function serveHostedSite(request: Request, env: Env): Promise<Response> {
   );
   if (!manifest || manifest.deploymentId !== pointer.deploymentId) {
     return notFoundResponse();
+  }
+
+  if (pathname === "/robots.txt" && !manifest.files["/robots.txt"]) {
+    return defaultRobotsResponse(request);
   }
 
   const filePath = resolveFilePath(request, pathname, pointer, manifest);


### PR DESCRIPTION
## Summary
- generate a default disallow-all `/robots.txt` for hosted-site publishes when the source directory omits one
- preserve uploaded `robots.txt` files and keep `presentation-html` publishes unchanged
- serve a generated disallow-all `robots.txt` from the host worker for existing deployments that do not have one

## Tests
- `pnpm -C turbo -F @vm0/cli exec vitest run src/lib/host/__tests__/static-site.test.ts src/commands/zero/host/__tests__/publish.test.ts`
- `pnpm -C turbo exec vitest run apps/host-worker/src/index.test.ts`
- `pnpm -C turbo -F @vm0/cli lint`
- `pnpm -C turbo -F @vm0/cli check-types`
- `pnpm -C turbo -F @vm0/host-worker lint`
- `pnpm -C turbo -F @vm0/host-worker check-types`
- `pnpm -C turbo knip --workspace @vm0/cli`
- `pnpm -C turbo knip --workspace @vm0/host-worker`
- pre-commit: `pnpm -C turbo check-types`