### PR TITLE
test: deduplicate auth query rewrite fixtures

### DIFF
--- a/crates/runner/mitm-addon/tests/firewall_auth_helpers.py
+++ b/crates/runner/mitm-addon/tests/firewall_auth_helpers.py
@@ -1,0 +1,15 @@
+"""Shared helpers for firewall auth handler tests."""
+
+import matching
+
+
+def make_allow(
+    api_entry: dict,
+    *,
+    name: str = "test",
+    permission: str | None = "send",
+    params: dict[str, str] | None = None,
+    rule: str | None = "POST /",
+    rel_path: str = "/",
+) -> matching.FirewallAllow:
+    return matching.FirewallAllow(api_entry, name, permission, params or {}, rule, rel_path)

--- a/crates/runner/mitm-addon/tests/firewall_rewrite_helpers.py
+++ b/crates/runner/mitm-addon/tests/firewall_rewrite_helpers.py
@@ -2,19 +2,7 @@
 
 from urllib.parse import urlparse
 
-import matching
-
-
-def make_allow(
-    api_entry: dict,
-    *,
-    name: str = "test",
-    permission: str | None = "send",
-    params: dict[str, str] | None = None,
-    rule: str | None = "POST /",
-    rel_path: str = "/",
-) -> matching.FirewallAllow:
-    return matching.FirewallAllow(api_entry, name, permission, params or {}, rule, rel_path)
+from tests.firewall_auth_helpers import make_allow
 
 
 def _make_rewrite_inputs(
@@ -134,8 +122,10 @@ def make_forwarding_rewrite_inputs(
     method="GET",
     request_body=None,
     request_headers=None,
+    api_base="https://firewall-placeholder.vm3.ai/discord-webhook/hook",
     auth_overrides=None,
     token_overrides=None,
+    match_overrides=None,
 ):
     return _make_rewrite_inputs(
         real_flow,
@@ -146,8 +136,10 @@ def make_forwarding_rewrite_inputs(
         method=method,
         request_body=request_body,
         request_headers=request_headers,
+        api_base=api_base,
         auth_overrides=auth_overrides,
         token_overrides=token_overrides,
+        match_overrides=match_overrides,
     )
 
 

--- a/crates/runner/mitm-addon/tests/test_auth_query_injection.py
+++ b/crates/runner/mitm-addon/tests/test_auth_query_injection.py
@@ -4,19 +4,8 @@ from unittest.mock import AsyncMock, patch
 from urllib.parse import parse_qs, urlparse
 
 import auth
-import matching
-
-
-def _allow(
-    api_entry: dict,
-    *,
-    name: str = "test",
-    permission: str | None = "send",
-    params: dict[str, str] | None = None,
-    rule: str | None = "POST /",
-    rel_path: str = "/",
-) -> matching.FirewallAllow:
-    return matching.FirewallAllow(api_entry, name, permission, params or {}, rule, rel_path)
+from tests.firewall_auth_helpers import make_allow
+from tests.firewall_rewrite_helpers import make_forwarding_rewrite_inputs
 
 
 def make_query_inputs(
@@ -55,7 +44,7 @@ def make_query_inputs(
     }
     if match_overrides:
         allow_kwargs.update(match_overrides)
-    allow = _allow(api_entry, **allow_kwargs)
+    allow = make_allow(api_entry, **allow_kwargs)
     token_meta = {
         "headers": {},
         "resolved_secrets": ["SERPAPI_TOKEN"],
@@ -157,11 +146,13 @@ class TestAuthQueryInjection:
         assert flow.request.headers["Authorization"] == "Bearer real-token"
         assert flow.request.query["key"] == "resolved-query-value"
 
-    async def test_query_params_merged_into_rewrite_url(self, real_flow, mitm_ctx, headers):
+    async def test_query_params_merged_into_rewrite_url(
+        self, real_flow, mitm_ctx, headers, tmp_path
+    ):
         """auth.query params are forwarded without mutating the placeholder request."""
-        flow = real_flow(
-            with_response=False,
-            host="firewall-placeholder.vm3.ai",
+        flow, allow, vm_info, token_meta = make_forwarding_rewrite_inputs(
+            real_flow,
+            tmp_path,
             path="/hook?client=visible",
             request_headers=headers(
                 ("Authorization", "Bearer agent"),
@@ -169,30 +160,14 @@ class TestAuthQueryInjection:
                 ("X-Api-Key", "agent-api-key"),
                 ("X-Keep", "client"),
             ),
-        )
-        flow.metadata["vm_run_id"] = "test-run"
-        api_entry = {
-            "base": "https://firewall-placeholder.vm3.ai/webhook/hook",
-            "auth": {
-                "headers": {},
-                "base": "${{ secrets.WEBHOOK }}",
-                "query": {"api_key": "${{ secrets.KEY }}"},
+            api_base="https://firewall-placeholder.vm3.ai/webhook/hook",
+            resolved_base="https://real-api.com/webhook/secret",
+            auth_overrides={"query": {"api_key": "${{ secrets.KEY }}"}},
+            token_overrides={
+                "resolved_secrets": ["WEBHOOK", "KEY"],
+                "query": {"api_key": "resolved-key-456"},
             },
-        }
-        vm_info = {
-            "runId": "run-1",
-            "sandboxToken": "tok",
-            "encryptedSecrets": "iv:tag:data",
-            "billableFirewalls": [],
-        }
-        allow = _allow(api_entry)
-        token_meta = {
-            "headers": {},
-            "base": "https://real-api.com/webhook/secret",
-            "resolved_secrets": ["WEBHOOK", "KEY"],
-            "cache_hit": False,
-            "query": {"api_key": "resolved-key-456"},
-        }
+        )
         mock_forward = AsyncMock(return_value=(200, b"ok", {}))
         with (
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
@@ -219,44 +194,34 @@ class TestAuthQueryInjection:
         assert flow.request.headers["Authorization"] == "Bearer agent"
         assert flow.request.headers["Cookie"] == "session=agent"
 
-    async def test_query_params_overwrite_existing_rewrite_url_keys(self, real_flow, mitm_ctx):
+    async def test_query_params_overwrite_existing_rewrite_url_keys(
+        self, real_flow, mitm_ctx, tmp_path
+    ):
         """auth.query overwrites duplicate keys while preserving other query values."""
-        flow = real_flow(
-            with_response=False,
-            host="firewall-placeholder.vm3.ai",
+        flow, allow, vm_info, token_meta = make_forwarding_rewrite_inputs(
+            real_flow,
+            tmp_path,
             path="/hook?api_key=agent-key&q=test&empty=&repeat=one&repeat=two",
-        )
-        flow.metadata["vm_run_id"] = "test-run"
-        api_entry = {
-            "base": "https://firewall-placeholder.vm3.ai/webhook/hook",
-            "auth": {
-                "headers": {},
-                "base": "${{ secrets.WEBHOOK }}",
+            api_base="https://firewall-placeholder.vm3.ai/webhook/hook",
+            resolved_base=(
+                "https://real-api.com/webhook/secret?api_key=base-key&mode=fast&base_empty="
+            ),
+            auth_overrides={
                 "query": {
                     "api_key": "${{ secrets.KEY }}",
                     "empty_auth": "${{ vars.EMPTY }}",
                     "space": "${{ vars.SPACE }}",
                 },
             },
-        }
-        vm_info = {
-            "runId": "run-1",
-            "sandboxToken": "tok",
-            "encryptedSecrets": "iv:tag:data",
-            "billableFirewalls": [],
-        }
-        allow = _allow(api_entry)
-        token_meta = {
-            "headers": {},
-            "base": "https://real-api.com/webhook/secret?api_key=base-key&mode=fast&base_empty=",
-            "resolved_secrets": ["WEBHOOK", "KEY"],
-            "cache_hit": False,
-            "query": {
-                "api_key": "resolved-key-456",
-                "empty_auth": "",
-                "space": "a b",
+            token_overrides={
+                "resolved_secrets": ["WEBHOOK", "KEY"],
+                "query": {
+                    "api_key": "resolved-key-456",
+                    "empty_auth": "",
+                    "space": "a b",
+                },
             },
-        }
+        )
         mock_forward = AsyncMock(return_value=(200, b"ok", {}))
         with (
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
@@ -279,36 +244,21 @@ class TestAuthQueryInjection:
         assert query["space"] == ["a b"]
         assert query["repeat"] == ["one", "two"]
 
-    async def test_query_params_preserve_rewrite_path_params(self, real_flow, mitm_ctx):
+    async def test_query_params_preserve_rewrite_path_params(self, real_flow, mitm_ctx, tmp_path):
         """auth.query merging must not strip URL path params from the rewrite target."""
-        flow = real_flow(
-            with_response=False,
-            host="firewall-placeholder.vm3.ai",
+        flow, allow, vm_info, token_meta = make_forwarding_rewrite_inputs(
+            real_flow,
+            tmp_path,
             path="/hook/callback;matrix=1?q=test",
-        )
-        flow.metadata["vm_run_id"] = "test-run"
-        api_entry = {
-            "base": "https://firewall-placeholder.vm3.ai/webhook/hook",
-            "auth": {
-                "headers": {},
-                "base": "${{ secrets.WEBHOOK }}",
-                "query": {"api_key": "${{ secrets.KEY }}"},
+            api_base="https://firewall-placeholder.vm3.ai/webhook/hook",
+            resolved_base="https://real-api.com/webhook/secret;v=1?mode=fast",
+            rel_path="/callback;matrix=1",
+            auth_overrides={"query": {"api_key": "${{ secrets.KEY }}"}},
+            token_overrides={
+                "resolved_secrets": ["WEBHOOK", "KEY"],
+                "query": {"api_key": "resolved-key"},
             },
-        }
-        vm_info = {
-            "runId": "run-1",
-            "sandboxToken": "tok",
-            "encryptedSecrets": "iv:tag:data",
-            "billableFirewalls": [],
-        }
-        allow = _allow(api_entry, rel_path="/callback;matrix=1")
-        token_meta = {
-            "headers": {},
-            "base": "https://real-api.com/webhook/secret;v=1?mode=fast",
-            "resolved_secrets": ["WEBHOOK", "KEY"],
-            "cache_hit": False,
-            "query": {"api_key": "resolved-key"},
-        }
+        )
         mock_forward = AsyncMock(return_value=(200, b"ok", {}))
         with (
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
@@ -341,7 +291,9 @@ class TestAuthQueryInjection:
             "encryptedSecrets": "iv:tag:data",
             "billableFirewalls": [],
         }
-        allow = _allow(api_entry, name="gh", permission="read", rule="GET /repos/{owner}/{repo}")
+        allow = make_allow(
+            api_entry, name="gh", permission="read", rule="GET /repos/{owner}/{repo}"
+        )
         token_meta = {
             "headers": {"Authorization": "Bearer real"},
             "resolved_secrets": ["TOKEN"],


### PR DESCRIPTION
## Summary

- add a neutral firewall auth test helper for constructing `FirewallAllow`
- keep auth.base rewrite fixture setup in `firewall_rewrite_helpers.py` while exposing forwarding `api_base` and `match_overrides` pass-throughs
- update auth.query rewrite tests to reuse the shared rewrite fixture path while preserving query-specific assertions

Fixes #18906

## Tests

- `cd crates/runner/mitm-addon && .venv/bin/ruff check tests/firewall_auth_helpers.py tests/firewall_rewrite_helpers.py tests/test_auth_query_injection.py`
- `cd crates/runner/mitm-addon && .venv/bin/ruff format --check tests/firewall_auth_helpers.py tests/firewall_rewrite_helpers.py tests/test_auth_query_injection.py`
- `cd crates/runner/mitm-addon && .venv/bin/python -m pytest tests/test_auth_query_injection.py tests/test_firewall_rewrite_forwarding.py tests/test_firewall_rewrite_success.py tests/test_firewall_rewrite_safety.py -v`
- `cd crates/runner/mitm-addon && .venv/bin/basedpyright -p .`
