### PR TITLE
refactor(nbd-cow): hide protocol internals

### DIFF
--- a/crates/nbd-cow/src/error.rs
+++ b/crates/nbd-cow/src/error.rs
@@ -3,7 +3,7 @@
 //! [`NbdCowError`] wraps protocol, I/O, netlink, device allocation, and bounds
 //! errors surfaced by the public APIs.
 
-pub use crate::protocol::ProtocolError;
+pub use crate::protocol_impl::ProtocolError;
 
 /// Error type returned by `nbd-cow` operations.
 #[derive(Debug, thiserror::Error)]

--- a/crates/nbd-cow/src/error.rs
+++ b/crates/nbd-cow/src/error.rs
@@ -3,7 +3,7 @@
 //! [`NbdCowError`] wraps protocol, I/O, netlink, device allocation, and bounds
 //! errors surfaced by the public APIs.
 
-use crate::protocol::ProtocolError;
+pub use crate::protocol::ProtocolError;
 
 /// Error type returned by `nbd-cow` operations.
 #[derive(Debug, thiserror::Error)]

--- a/crates/nbd-cow/src/lib.rs
+++ b/crates/nbd-cow/src/lib.rs
@@ -15,7 +15,7 @@
 //! - [`pool`] for host-locked `/dev/nbdN` device claim allocation.
 //! - [`netlink`] for Linux NBD generic netlink setup and disconnect.
 //! - [`server`] for the in-process NBD dispatch loop.
-//! - [`protocol`] for NBD transmission protocol parsing and serialization.
+//! - an internal NBD transmission protocol parser and serializer.
 //! - [`error`] for crate error and result types.
 //!
 //! Call pooled-device finalizers when the device should be shut down cleanly.
@@ -28,7 +28,7 @@ pub mod device_lock;
 pub mod error;
 pub mod netlink;
 pub mod pool;
-pub mod protocol;
+mod protocol;
 pub mod server;
 
 pub use device::{

--- a/crates/nbd-cow/src/lib.rs
+++ b/crates/nbd-cow/src/lib.rs
@@ -28,7 +28,12 @@ pub mod device_lock;
 pub mod error;
 pub mod netlink;
 pub mod pool;
-mod protocol;
+#[path = "protocol.rs"]
+mod protocol_impl;
+/// Compatibility exports for protocol-related public error types.
+pub mod protocol {
+    pub use crate::error::ProtocolError;
+}
 pub mod server;
 
 pub use device::{

--- a/crates/nbd-cow/src/protocol.rs
+++ b/crates/nbd-cow/src/protocol.rs
@@ -16,6 +16,7 @@ pub const REQUEST_HEADER_SIZE: usize = 28;
 pub const REPLY_HEADER_SIZE: usize = 16;
 
 const REQUEST_MAGIC_OFFSET: usize = 0;
+#[cfg(test)]
 const REQUEST_FLAGS_OFFSET: usize = 4;
 const REQUEST_COMMAND_OFFSET: usize = 6;
 const REQUEST_HANDLE_OFFSET: usize = 8;
@@ -53,8 +54,6 @@ impl Command {
 /// NBD request header (28 bytes, client -> server).
 #[derive(Debug, Clone)]
 pub struct NbdRequest {
-    /// Per-command flags bitmask (e.g. `NBD_CMD_FLAG_FUA = 0x0001`).
-    pub flags: u16,
     /// Decoded command type. The wire encoding is `u16`; see [`Command`].
     pub command: Command,
     /// Opaque request identifier echoed back in [`NbdReply::handle`]. The
@@ -80,14 +79,27 @@ pub struct NbdReply {
     pub handle: u64,
 }
 
+/// Errors returned while decoding fixed-size NBD transmission headers.
 #[derive(Debug, thiserror::Error)]
 pub enum ProtocolError {
+    /// The request header magic field did not match the NBD request magic.
+    ///
+    /// The payload is the invalid big-endian `u32` value read from the first
+    /// four bytes of the request header.
     #[error("invalid request magic: expected {REQUEST_MAGIC:#x}, got {0:#x}")]
     InvalidRequestMagic(u32),
 
+    /// The request command field contained an unsupported NBD command value.
+    ///
+    /// The payload is the raw big-endian `u16` command value from the request
+    /// header. Supported values are `0` through `4`.
     #[error("unknown NBD command: {0}")]
     UnknownCommand(u16),
 
+    /// The input buffer was too short to contain a complete request header.
+    ///
+    /// `expected` is the fixed NBD request header size and `actual` is the
+    /// number of bytes provided by the caller.
     #[error("buffer too short: need {expected} bytes, got {actual}")]
     BufferTooShort { expected: usize, actual: usize },
 }
@@ -156,7 +168,6 @@ pub fn parse_request(buf: &[u8]) -> Result<NbdRequest, ProtocolError> {
         return Err(ProtocolError::InvalidRequestMagic(magic));
     }
 
-    let flags = read_u16(header, REQUEST_FLAGS_OFFSET);
     let cmd_type = read_u16(header, REQUEST_COMMAND_OFFSET);
     let command = Command::from_u16(cmd_type)?;
     let handle = read_u64(header, REQUEST_HANDLE_OFFSET);
@@ -164,7 +175,6 @@ pub fn parse_request(buf: &[u8]) -> Result<NbdRequest, ProtocolError> {
     let length = read_u32(header, REQUEST_LENGTH_OFFSET);
 
     Ok(NbdRequest {
-        flags,
         command,
         handle,
         offset,
@@ -186,7 +196,6 @@ pub fn serialize_reply(reply: &NbdReply) -> [u8; REPLY_HEADER_SIZE] {
 pub(crate) fn serialize_request(req: &NbdRequest) -> [u8; REQUEST_HEADER_SIZE] {
     let mut buf = [0u8; REQUEST_HEADER_SIZE];
     write_u32(&mut buf, REQUEST_MAGIC_OFFSET, REQUEST_MAGIC);
-    write_u16(&mut buf, REQUEST_FLAGS_OFFSET, req.flags);
     write_u16(&mut buf, REQUEST_COMMAND_OFFSET, req.command as u16);
     write_u64(&mut buf, REQUEST_HANDLE_OFFSET, req.handle);
     write_u64(&mut buf, REQUEST_OFFSET_FIELD_OFFSET, req.offset);
@@ -201,7 +210,6 @@ mod tests {
     #[test]
     fn round_trip_request() {
         let req = NbdRequest {
-            flags: 0,
             command: Command::Write,
             handle: 0xDEAD_BEEF_CAFE_BABE,
             offset: 4096,
@@ -210,8 +218,6 @@ mod tests {
 
         let buf = serialize_request(&req);
         let parsed = parse_request(&buf).unwrap();
-
-        assert_eq!(parsed.flags, req.flags);
         assert_eq!(parsed.command, req.command);
         assert_eq!(parsed.handle, req.handle);
         assert_eq!(parsed.offset, req.offset);
@@ -221,7 +227,6 @@ mod tests {
     #[test]
     fn parse_request_ignores_trailing_bytes() {
         let req = NbdRequest {
-            flags: 0x0001,
             command: Command::Trim,
             handle: 0xCAFE_BABE_DEAD_BEEF,
             offset: 16_384,
@@ -232,8 +237,6 @@ mod tests {
         buf.extend_from_slice(&[0xAA, 0xBB, 0xCC, 0xDD]);
 
         let parsed = parse_request(&buf).unwrap();
-
-        assert_eq!(parsed.flags, req.flags);
         assert_eq!(parsed.command, req.command);
         assert_eq!(parsed.handle, req.handle);
         assert_eq!(parsed.offset, req.offset);
@@ -272,7 +275,6 @@ mod tests {
             (Command::Trim, 4),
         ] {
             let req = NbdRequest {
-                flags: 0,
                 command: cmd,
                 handle: 1,
                 offset: 0,
@@ -297,7 +299,6 @@ mod tests {
     #[test]
     fn unknown_command() {
         let req = NbdRequest {
-            flags: 0,
             command: Command::Read,
             handle: 0,
             offset: 0,
@@ -382,17 +383,17 @@ mod tests {
     }
 
     #[test]
-    fn round_trip_request_with_flags() {
+    fn parse_request_ignores_flags() {
         let req = NbdRequest {
-            flags: 0x0001, // FUA
             command: Command::Write,
             handle: 42,
             offset: 8192,
             length: 1024,
         };
-        let buf = serialize_request(&req);
+        let mut buf = serialize_request(&req);
+        write_u16(&mut buf, REQUEST_FLAGS_OFFSET, 0x0001);
+
         let parsed = parse_request(&buf).unwrap();
-        assert_eq!(parsed.flags, 0x0001);
         assert_eq!(parsed.command, Command::Write);
         assert_eq!(parsed.handle, 42);
         assert_eq!(parsed.offset, 8192);

--- a/crates/nbd-cow/src/protocol.rs
+++ b/crates/nbd-cow/src/protocol.rs
@@ -4,16 +4,16 @@
 //! The kernel NBD client communicates directly using the transmission protocol.
 
 /// Magic number in every NBD request (client -> server).
-pub const REQUEST_MAGIC: u32 = 0x2560_9513;
+pub(crate) const REQUEST_MAGIC: u32 = 0x2560_9513;
 
 /// Magic number in every NBD reply (server -> client).
-pub const REPLY_MAGIC: u32 = 0x6744_6698;
+pub(crate) const REPLY_MAGIC: u32 = 0x6744_6698;
 
 /// Size of the request header in bytes (excluding payload).
-pub const REQUEST_HEADER_SIZE: usize = 28;
+pub(crate) const REQUEST_HEADER_SIZE: usize = 28;
 
 /// Size of the reply header in bytes (excluding payload).
-pub const REPLY_HEADER_SIZE: usize = 16;
+pub(crate) const REPLY_HEADER_SIZE: usize = 16;
 
 const REQUEST_MAGIC_OFFSET: usize = 0;
 #[cfg(test)]
@@ -30,7 +30,7 @@ const REPLY_HANDLE_OFFSET: usize = 8;
 /// NBD command types.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
-pub enum Command {
+pub(crate) enum Command {
     Read = 0,
     Write = 1,
     Disconnect = 2,
@@ -39,7 +39,7 @@ pub enum Command {
 }
 
 impl Command {
-    pub fn from_u16(val: u16) -> Result<Self, ProtocolError> {
+    pub(crate) fn from_u16(val: u16) -> Result<Self, ProtocolError> {
         match val {
             0 => Ok(Self::Read),
             1 => Ok(Self::Write),
@@ -53,30 +53,30 @@ impl Command {
 
 /// NBD request header (28 bytes, client -> server).
 #[derive(Debug, Clone)]
-pub struct NbdRequest {
+pub(crate) struct NbdRequest {
     /// Decoded command type. The wire encoding is `u16`; see [`Command`].
-    pub command: Command,
+    pub(crate) command: Command,
     /// Opaque request identifier echoed back in [`NbdReply::handle`]. The
     /// dispatcher uses this to correlate replies with in-flight requests;
     /// the server does not interpret the value.
-    pub handle: u64,
+    pub(crate) handle: u64,
     /// Byte offset into the device where the operation applies (Read /
     /// Write / Trim). Ignored for Flush and Disconnect.
-    pub offset: u64,
+    pub(crate) offset: u64,
     /// Payload length in bytes. Requests exceeding the server's
     /// `MAX_REQUEST_LENGTH` (see `server.rs`) are rejected with `EIO`.
-    pub length: u32,
+    pub(crate) length: u32,
 }
 
 /// NBD reply header (16 bytes, server -> client).
 #[derive(Debug, Clone)]
-pub struct NbdReply {
+pub(crate) struct NbdReply {
     /// NBD error code: `0` means success; a non-zero value is an errno
     /// the kernel maps back to the originating I/O (e.g. `libc::EIO`).
-    pub error: u32,
+    pub(crate) error: u32,
     /// Echoes [`NbdRequest::handle`] from the originating request so the
     /// client can match this reply to the pending operation.
-    pub handle: u64,
+    pub(crate) handle: u64,
 }
 
 /// Errors returned while decoding fixed-size NBD transmission headers.
@@ -155,7 +155,7 @@ fn write_bytes<const N: usize>(buf: &mut [u8], offset: usize, bytes: [u8; N]) {
 }
 
 /// Parse a 28-byte NBD request header.
-pub fn parse_request(buf: &[u8]) -> Result<NbdRequest, ProtocolError> {
+pub(crate) fn parse_request(buf: &[u8]) -> Result<NbdRequest, ProtocolError> {
     let header = buf
         .get(..REQUEST_HEADER_SIZE)
         .ok_or(ProtocolError::BufferTooShort {
@@ -183,7 +183,7 @@ pub fn parse_request(buf: &[u8]) -> Result<NbdRequest, ProtocolError> {
 }
 
 /// Serialize a 16-byte NBD reply header.
-pub fn serialize_reply(reply: &NbdReply) -> [u8; REPLY_HEADER_SIZE] {
+pub(crate) fn serialize_reply(reply: &NbdReply) -> [u8; REPLY_HEADER_SIZE] {
     let mut buf = [0u8; REPLY_HEADER_SIZE];
     write_u32(&mut buf, REPLY_MAGIC_OFFSET, REPLY_MAGIC);
     write_u32(&mut buf, REPLY_ERROR_OFFSET, reply.error);

--- a/crates/nbd-cow/src/server.rs
+++ b/crates/nbd-cow/src/server.rs
@@ -1,8 +1,8 @@
 //! In-process NBD request dispatch.
 //!
 //! [`dispatch`] owns one Unix socket connection passed to the kernel NBD device,
-//! decodes requests with [`crate::protocol`], applies them to
-//! [`crate::cow::CowLayer`], and writes NBD replies back to the kernel.
+//! decodes NBD requests, applies them to [`crate::cow::CowLayer`], and writes
+//! NBD replies back to the kernel.
 
 use std::os::unix::io::{FromRawFd, IntoRawFd, OwnedFd};
 use std::sync::Arc;

--- a/crates/nbd-cow/src/server.rs
+++ b/crates/nbd-cow/src/server.rs
@@ -14,7 +14,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::cow::CowLayer;
 use crate::error::{NbdCowError, Result};
-use crate::protocol::{self, Command, NbdReply, NbdRequest, REQUEST_HEADER_SIZE};
+use crate::protocol_impl::{self as protocol, Command, NbdReply, NbdRequest, REQUEST_HEADER_SIZE};
 
 /// Maximum allowed request length (32 MB). Requests exceeding this are rejected
 /// with an I/O error to prevent OOM from malformed requests.

--- a/crates/nbd-cow/src/server/tests.rs
+++ b/crates/nbd-cow/src/server/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::cow::CowLayer;
-use crate::protocol::{Command, NbdReply, NbdRequest, REPLY_MAGIC, serialize_request};
+use crate::protocol_impl::{Command, NbdReply, NbdRequest, REPLY_MAGIC, serialize_request};
 use std::io::Write as _;
 use std::os::unix::io::{FromRawFd, IntoRawFd, OwnedFd};
 use std::time::Duration;

--- a/crates/nbd-cow/src/server/tests.rs
+++ b/crates/nbd-cow/src/server/tests.rs
@@ -166,7 +166,6 @@ async fn dispatch_large_then_small_requests_keep_stream_aligned() {
     let (mut reader, mut writer, task, _shutdown) = setup_dispatch(cow).await;
 
     let large_write = NbdRequest {
-        flags: 0,
         command: Command::Write,
         handle: 1,
         offset: 0,
@@ -178,7 +177,6 @@ async fn dispatch_large_then_small_requests_keep_stream_aligned() {
     assert_eq!(error, 0, "large write should succeed");
 
     let small_write = NbdRequest {
-        flags: 0,
         command: Command::Write,
         handle: 2,
         offset: small_offset,
@@ -190,7 +188,6 @@ async fn dispatch_large_then_small_requests_keep_stream_aligned() {
     assert_eq!(error, 0, "small write after large write should succeed");
 
     let large_read = NbdRequest {
-        flags: 0,
         command: Command::Read,
         handle: 3,
         offset: 0,
@@ -202,7 +199,6 @@ async fn dispatch_large_then_small_requests_keep_stream_aligned() {
     assert!(large_read_data.iter().all(|&byte| byte == 0x44));
 
     let small_read = NbdRequest {
-        flags: 0,
         command: Command::Read,
         handle: 4,
         offset: small_offset,
@@ -214,7 +210,6 @@ async fn dispatch_large_then_small_requests_keep_stream_aligned() {
     assert_eq!(small_read_data, small_write_data);
 
     let max_reusable_read = NbdRequest {
-        flags: 0,
         command: Command::Read,
         handle: 5,
         offset: 0,
@@ -226,7 +221,6 @@ async fn dispatch_large_then_small_requests_keep_stream_aligned() {
     assert!(max_reusable_data.iter().all(|&byte| byte == 0x44));
 
     let alignment_read = NbdRequest {
-        flags: 0,
         command: Command::Read,
         handle: 6,
         offset: alignment_offset,
@@ -238,7 +232,6 @@ async fn dispatch_large_then_small_requests_keep_stream_aligned() {
     assert!(alignment_data.iter().all(|&byte| byte == 0x33));
 
     let disc = NbdRequest {
-        flags: 0,
         command: Command::Disconnect,
         handle: 7,
         offset: 0,
@@ -260,7 +253,6 @@ async fn dispatch_shutdown_flushes_data() {
     let (mut reader, mut writer, task, shutdown) = setup_dispatch(cow.clone()).await;
 
     let write_req = NbdRequest {
-        flags: 0,
         command: Command::Write,
         handle: 1,
         offset: 0,
@@ -297,7 +289,6 @@ async fn dispatch_shutdown_while_write_payload_pending_exits() {
     let (_reader, mut writer, task, shutdown) = setup_dispatch(cow).await;
 
     let write_req = NbdRequest {
-        flags: 0,
         command: Command::Write,
         handle: 1,
         offset: 0,
@@ -327,7 +318,6 @@ async fn dispatch_shutdown_while_oversized_write_discard_pending_exits() {
     let (_reader, mut writer, task, shutdown) = setup_dispatch(cow).await;
 
     let write_req = NbdRequest {
-        flags: 0,
         command: Command::Write,
         handle: 1,
         offset: 0,
@@ -357,7 +347,6 @@ async fn dispatch_shutdown_during_partial_write_flushes_accepted_data() {
     let (mut reader, mut writer, task, shutdown) = setup_dispatch(cow.clone()).await;
 
     let accepted_write = NbdRequest {
-        flags: 0,
         command: Command::Write,
         handle: 1,
         offset: 0,
@@ -373,7 +362,6 @@ async fn dispatch_shutdown_during_partial_write_flushes_accepted_data() {
     }
 
     let partial_write = NbdRequest {
-        flags: 0,
         command: Command::Write,
         handle: 2,
         offset: crate::BLOCK_SIZE as u64,

--- a/crates/nbd-cow/tests/dispatch.rs
+++ b/crates/nbd-cow/tests/dispatch.rs
@@ -93,8 +93,8 @@ async fn dispatch_trim_succeeds() -> TestResult<()> {
 }
 
 #[tokio::test]
-async fn dispatch_accepts_request_flags() -> TestResult<()> {
-    const NBD_CMD_FLAG_FUA: u32 = 1 << 16;
+async fn dispatch_masks_request_type_flags_from_command() -> TestResult<()> {
+    const REQUEST_TYPE_HIGH_FLAG: u32 = 1 << 16;
 
     let base_data = vec![0xAA; 2 * BLOCK_SIZE];
     let (_base, _cow_file, cow) = create_test_cow(&base_data)?;
@@ -108,7 +108,7 @@ async fn dispatch_accepts_request_flags() -> TestResult<()> {
         1,
         0,
         write_data.len() as u32,
-        NBD_CMD_FLAG_FUA,
+        REQUEST_TYPE_HIGH_FLAG,
     );
     client.send_request(&flagged_write).await?;
     client.write_payload(&write_data).await?;

--- a/crates/nbd-cow/tests/dispatch.rs
+++ b/crates/nbd-cow/tests/dispatch.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use nbd_cow::BLOCK_SIZE;
 use support::dispatch_client::{
     Command, TestResult, assert_error, assert_error_code, assert_success, create_base_file,
-    create_cow_with_full_device, create_test_cow, request, spawn_dispatch,
+    create_cow_with_full_device, create_test_cow, request, request_with_flags, spawn_dispatch,
     spawn_dispatch_with_shutdown, wait_for_dispatch,
 };
 use tokio::sync::RwLock;
@@ -88,6 +88,37 @@ async fn dispatch_trim_succeeds() -> TestResult<()> {
     assert_success(&reply, 1);
 
     client.disconnect(2).await?;
+    wait_for_dispatch(task).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn dispatch_accepts_request_flags() -> TestResult<()> {
+    const NBD_CMD_FLAG_FUA: u16 = 0x0001;
+
+    let base_data = vec![0xAA; 2 * BLOCK_SIZE];
+    let (_base, _cow_file, cow) = create_test_cow(&base_data)?;
+    let cow = Arc::new(RwLock::new(cow));
+
+    let (mut client, task, _shutdown) = spawn_dispatch(cow).await?;
+
+    let write_data = vec![0xBC; BLOCK_SIZE];
+    let flagged_write = request_with_flags(
+        Command::Write,
+        1,
+        0,
+        write_data.len() as u32,
+        NBD_CMD_FLAG_FUA,
+    );
+    client.send_request(&flagged_write).await?;
+    client.write_payload(&write_data).await?;
+    let reply = client.read_reply().await?;
+    assert_success(&reply, 1);
+
+    let data = client.read(2, 0, BLOCK_SIZE as u32).await?;
+    assert_eq!(data, write_data);
+
+    client.disconnect(3).await?;
     wait_for_dispatch(task).await?;
     Ok(())
 }

--- a/crates/nbd-cow/tests/dispatch.rs
+++ b/crates/nbd-cow/tests/dispatch.rs
@@ -4,9 +4,8 @@ use std::os::unix::fs::MetadataExt as _;
 use std::sync::Arc;
 
 use nbd_cow::BLOCK_SIZE;
-use nbd_cow::protocol::Command;
 use support::dispatch_client::{
-    TestResult, assert_error, assert_error_code, assert_success, create_base_file,
+    Command, TestResult, assert_error, assert_error_code, assert_success, create_base_file,
     create_cow_with_full_device, create_test_cow, request, spawn_dispatch,
     spawn_dispatch_with_shutdown, wait_for_dispatch,
 };

--- a/crates/nbd-cow/tests/dispatch.rs
+++ b/crates/nbd-cow/tests/dispatch.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use nbd_cow::BLOCK_SIZE;
 use support::dispatch_client::{
     Command, TestResult, assert_error, assert_error_code, assert_success, create_base_file,
-    create_cow_with_full_device, create_test_cow, request, request_with_flags, spawn_dispatch,
+    create_cow_with_full_device, create_test_cow, request, request_with_type_flags, spawn_dispatch,
     spawn_dispatch_with_shutdown, wait_for_dispatch,
 };
 use tokio::sync::RwLock;
@@ -94,7 +94,7 @@ async fn dispatch_trim_succeeds() -> TestResult<()> {
 
 #[tokio::test]
 async fn dispatch_accepts_request_flags() -> TestResult<()> {
-    const NBD_CMD_FLAG_FUA: u16 = 0x0001;
+    const NBD_CMD_FLAG_FUA: u32 = 1 << 16;
 
     let base_data = vec![0xAA; 2 * BLOCK_SIZE];
     let (_base, _cow_file, cow) = create_test_cow(&base_data)?;
@@ -103,7 +103,7 @@ async fn dispatch_accepts_request_flags() -> TestResult<()> {
     let (mut client, task, _shutdown) = spawn_dispatch(cow).await?;
 
     let write_data = vec![0xBC; BLOCK_SIZE];
-    let flagged_write = request_with_flags(
+    let flagged_write = request_with_type_flags(
         Command::Write,
         1,
         0,

--- a/crates/nbd-cow/tests/public_api.rs
+++ b/crates/nbd-cow/tests/public_api.rs
@@ -1,0 +1,11 @@
+use nbd_cow::error::{NbdCowError, ProtocolError};
+
+#[test]
+fn protocol_error_is_available_from_public_error_module() {
+    let error = NbdCowError::from(ProtocolError::UnknownCommand(99));
+
+    assert!(matches!(
+        error,
+        NbdCowError::Protocol(ProtocolError::UnknownCommand(99))
+    ));
+}

--- a/crates/nbd-cow/tests/public_api.rs
+++ b/crates/nbd-cow/tests/public_api.rs
@@ -1,8 +1,19 @@
 use nbd_cow::error::{NbdCowError, ProtocolError};
+use nbd_cow::protocol::ProtocolError as ProtocolModuleError;
 
 #[test]
 fn protocol_error_is_available_from_public_error_module() {
     let error = NbdCowError::from(ProtocolError::UnknownCommand(99));
+
+    assert!(matches!(
+        error,
+        NbdCowError::Protocol(ProtocolError::UnknownCommand(99))
+    ));
+}
+
+#[test]
+fn protocol_error_is_available_from_public_protocol_module() {
+    let error = NbdCowError::from(ProtocolModuleError::UnknownCommand(99));
 
     assert!(matches!(
         error,

--- a/crates/nbd-cow/tests/support/dispatch_client.rs
+++ b/crates/nbd-cow/tests/support/dispatch_client.rs
@@ -7,10 +7,6 @@ use std::time::Duration;
 
 use nbd_cow::cow::CowLayer;
 use nbd_cow::error::Result as NbdResult;
-use nbd_cow::protocol::{
-    Command, NbdReply, NbdRequest, REPLY_HEADER_SIZE, REPLY_MAGIC, REQUEST_HEADER_SIZE,
-    REQUEST_MAGIC,
-};
 use nbd_cow::server::dispatch;
 use nbd_cow::{BLOCK_SIZE, DEFAULT_FLUSH_THRESHOLD};
 use tempfile::NamedTempFile;
@@ -22,6 +18,36 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
 pub type TestResult<T> = std::result::Result<T, Box<dyn Error + Send + Sync>>;
+
+const REQUEST_MAGIC: u32 = 0x2560_9513;
+const REPLY_MAGIC: u32 = 0x6744_6698;
+const REQUEST_HEADER_SIZE: usize = 28;
+const REPLY_HEADER_SIZE: usize = 16;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u16)]
+pub enum Command {
+    Read = 0,
+    Write = 1,
+    Disconnect = 2,
+    Flush = 3,
+    Trim = 4,
+}
+
+#[derive(Debug, Clone)]
+pub struct NbdRequest {
+    flags: u16,
+    command: Command,
+    handle: u64,
+    offset: u64,
+    length: u32,
+}
+
+#[derive(Debug, Clone)]
+pub struct NbdReply {
+    error: u32,
+    handle: u64,
+}
 
 pub struct DispatchClient {
     reader: OwnedReadHalf,

--- a/crates/nbd-cow/tests/support/dispatch_client.rs
+++ b/crates/nbd-cow/tests/support/dispatch_client.rs
@@ -36,7 +36,7 @@ pub enum Command {
 
 #[derive(Debug, Clone)]
 pub struct NbdRequest {
-    flags: u16,
+    request_type_flags: u32,
     command: Command,
     handle: u64,
     offset: u64,
@@ -169,18 +169,18 @@ impl DispatchClient {
 }
 
 pub fn request(command: Command, handle: u64, offset: u64, length: u32) -> NbdRequest {
-    request_with_flags(command, handle, offset, length, 0)
+    request_with_type_flags(command, handle, offset, length, 0)
 }
 
-pub fn request_with_flags(
+pub fn request_with_type_flags(
     command: Command,
     handle: u64,
     offset: u64,
     length: u32,
-    flags: u16,
+    request_type_flags: u32,
 ) -> NbdRequest {
     NbdRequest {
-        flags,
+        request_type_flags,
         command,
         handle,
         offset,
@@ -292,8 +292,8 @@ fn socketpair() -> std::io::Result<(OwnedFd, OwnedFd)> {
 
 fn serialize_request(request: &NbdRequest) -> [u8; REQUEST_HEADER_SIZE] {
     let [magic_0, magic_1, magic_2, magic_3] = REQUEST_MAGIC.to_be_bytes();
-    let [flags_0, flags_1] = request.flags.to_be_bytes();
-    let [command_0, command_1] = (request.command as u16).to_be_bytes();
+    let request_type = request.request_type_flags | request.command as u32;
+    let [type_0, type_1, type_2, type_3] = request_type.to_be_bytes();
     let [
         handle_0,
         handle_1,
@@ -317,9 +317,8 @@ fn serialize_request(request: &NbdRequest) -> [u8; REQUEST_HEADER_SIZE] {
     let [length_0, length_1, length_2, length_3] = request.length.to_be_bytes();
 
     [
-        magic_0, magic_1, magic_2, magic_3, flags_0, flags_1, command_0, command_1, handle_0,
-        handle_1, handle_2, handle_3, handle_4, handle_5, handle_6, handle_7, offset_0, offset_1,
-        offset_2, offset_3, offset_4, offset_5, offset_6, offset_7, length_0, length_1, length_2,
-        length_3,
+        magic_0, magic_1, magic_2, magic_3, type_0, type_1, type_2, type_3, handle_0, handle_1,
+        handle_2, handle_3, handle_4, handle_5, handle_6, handle_7, offset_0, offset_1, offset_2,
+        offset_3, offset_4, offset_5, offset_6, offset_7, length_0, length_1, length_2, length_3,
     ]
 }

--- a/crates/nbd-cow/tests/support/dispatch_client.rs
+++ b/crates/nbd-cow/tests/support/dispatch_client.rs
@@ -169,8 +169,18 @@ impl DispatchClient {
 }
 
 pub fn request(command: Command, handle: u64, offset: u64, length: u32) -> NbdRequest {
+    request_with_flags(command, handle, offset, length, 0)
+}
+
+pub fn request_with_flags(
+    command: Command,
+    handle: u64,
+    offset: u64,
+    length: u32,
+    flags: u16,
+) -> NbdRequest {
     NbdRequest {
-        flags: 0,
+        flags,
         command,
         handle,
         offset,

--- a/crates/nbd-cow/tests/support/dispatch_client.rs
+++ b/crates/nbd-cow/tests/support/dispatch_client.rs
@@ -23,6 +23,7 @@ const REQUEST_MAGIC: u32 = 0x2560_9513;
 const REPLY_MAGIC: u32 = 0x6744_6698;
 const REQUEST_HEADER_SIZE: usize = 28;
 const REPLY_HEADER_SIZE: usize = 16;
+const REQUEST_TYPE_COMMAND_MASK: u32 = 0x0000_FFFF;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
@@ -179,6 +180,12 @@ pub fn request_with_type_flags(
     length: u32,
     request_type_flags: u32,
 ) -> NbdRequest {
+    assert_eq!(
+        request_type_flags & REQUEST_TYPE_COMMAND_MASK,
+        0,
+        "request type flags must not overlap command bits"
+    );
+
     NbdRequest {
         request_type_flags,
         command,


### PR DESCRIPTION
## Summary

- Make `nbd_cow::protocol` crate-private so parser/codec internals are not exposed as public API.
- Re-export `ProtocolError` from `nbd_cow::error` because `NbdCowError::Protocol` remains public.
- Move nbd-cow dispatch integration tests to test-local NBD wire structs/constants while preserving parser and dispatch behavior.

Closes #18900

## Tests

- `cargo check --manifest-path crates/Cargo.toml -p nbd-cow`
- `cargo fmt --manifest-path crates/Cargo.toml --all`
- `cargo clippy --manifest-path crates/Cargo.toml -p nbd-cow --all-targets -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p nbd-cow`
- `cargo doc --manifest-path crates/Cargo.toml -p nbd-cow --no-deps`
- pre-commit hooks: cargo-fmt, cargo-doc, cargo-clippy, commitlint