### PR TITLE
perf(mitm-addon): short-circuit connector diagnostics

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -74,6 +74,7 @@ from url_utils import AuthorityValidationError, get_trusted_authority
 # HTTP status boundaries used in response-phase classification.
 _HTTP_STATUS_UNAUTHORIZED = 401
 _HTTP_STATUS_FORBIDDEN = 403
+_HTTP_STATUS_FAILED_DEPENDENCY = 424
 _HTTP_STATUS_BAD_GATEWAY = 502
 _HTTP_STATUS_ERROR_MIN = 400  # inclusive: start of 4xx/5xx error range
 _HTTP_DEFAULT_PORT = 80
@@ -1071,7 +1072,7 @@ def _maybe_make_connector_diagnostic_local_response(
     _set_connector_diagnostic_failure_metadata(flow, candidate)
     flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
     flow.response = http.Response.make(
-        _HTTP_STATUS_BAD_GATEWAY,
+        _HTTP_STATUS_FAILED_DEPENDENCY,
         _connector_diagnostic_response_body(candidate, upstream_status=0),
         {"Content-Type": "application/json"},
     )
@@ -1136,7 +1137,7 @@ def _maybe_make_connector_diagnostic_error_response(
         return
     _set_connector_diagnostic_failure_metadata(flow, candidate)
     flow.response = http.Response.make(
-        _HTTP_STATUS_BAD_GATEWAY,
+        _HTTP_STATUS_FAILED_DEPENDENCY,
         _connector_diagnostic_response_body(candidate, upstream_status=0),
         {"Content-Type": "application/json"},
     )

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1435,18 +1435,8 @@ def requestheaders(flow: http.HTTPFlow) -> None:
         flow.kill()
         return
 
-    if classification.kind == "allow":
-        _maybe_record_allow_connector_diagnostic_context(flow, classification)
-        original_url = flow.metadata.get(metadata_keys.ORIGINAL_URL)
-        if isinstance(original_url, str) and _maybe_make_connector_diagnostic_local_response(
-            flow,
-            original_url=original_url,
-        ):
-            flow.metadata.pop(_REQUEST_CLASSIFICATION, None)
-            flow.metadata[_REQUEST_HEADERS_TERMINATED] = True
-            return
-
     if _should_stream_capture_request(classification):
+        _maybe_record_allow_connector_diagnostic_context(flow, classification)
         flow.metadata[_REQUEST_CLASSIFICATION] = classification
         _start_request_timing(flow)
         request_streaming.configure_request_stream(flow)
@@ -1579,12 +1569,13 @@ async def request(flow: http.HTTPFlow) -> None:
         if vm_info is None:
             return
         _maybe_record_allow_connector_diagnostic_context(flow, classification)
-        original_url = flow.metadata.get(metadata_keys.ORIGINAL_URL)
-        if isinstance(original_url, str) and _maybe_make_connector_diagnostic_local_response(
-            flow,
-            original_url=original_url,
-        ):
-            return
+        if request_streaming.streamed_request_size(flow) is None:
+            original_url = flow.metadata.get(metadata_keys.ORIGINAL_URL)
+            if isinstance(original_url, str) and _maybe_make_connector_diagnostic_local_response(
+                flow,
+                original_url=original_url,
+            ):
+                return
         flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
     except (asyncio.CancelledError, Exception):
         flow.metadata.pop(metadata_keys.HTTP_REQUEST_START_MONOTONIC, None)

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1052,6 +1052,37 @@ def _log_connector_diagnostic_proxy_entry(
     )
 
 
+def _maybe_make_connector_diagnostic_local_response(
+    flow: http.HTTPFlow,
+    *,
+    original_url: str,
+) -> bool:
+    if flow.metadata.get(metadata_keys.BROWSER_USER_AGENT) or _is_browser_passthrough_heuristic(
+        flow
+    ):
+        return False
+    candidate = _resolve_connector_diagnostic_candidate(flow, original_url=original_url)
+    if candidate is None:
+        return False
+    if _request_has_connector_auth_material(flow, candidate, original_url):
+        return False
+
+    _start_request_timing(flow)
+    _set_connector_diagnostic_failure_metadata(flow, candidate)
+    flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+    flow.response = http.Response.make(
+        _HTTP_STATUS_BAD_GATEWAY,
+        _connector_diagnostic_response_body(candidate, upstream_status=0),
+        {"Content-Type": "application/json"},
+    )
+    _log_connector_diagnostic_proxy_entry(
+        flow,
+        original_url=original_url,
+        upstream_status=0,
+    )
+    return True
+
+
 def _maybe_replace_connector_diagnostic_response(
     flow: http.HTTPFlow,
     *,
@@ -1404,8 +1435,18 @@ def requestheaders(flow: http.HTTPFlow) -> None:
         flow.kill()
         return
 
-    if _should_stream_capture_request(classification):
+    if classification.kind == "allow":
         _maybe_record_allow_connector_diagnostic_context(flow, classification)
+        original_url = flow.metadata.get(metadata_keys.ORIGINAL_URL)
+        if isinstance(original_url, str) and _maybe_make_connector_diagnostic_local_response(
+            flow,
+            original_url=original_url,
+        ):
+            flow.metadata.pop(_REQUEST_CLASSIFICATION, None)
+            flow.metadata[_REQUEST_HEADERS_TERMINATED] = True
+            return
+
+    if _should_stream_capture_request(classification):
         flow.metadata[_REQUEST_CLASSIFICATION] = classification
         _start_request_timing(flow)
         request_streaming.configure_request_stream(flow)
@@ -1538,6 +1579,12 @@ async def request(flow: http.HTTPFlow) -> None:
         if vm_info is None:
             return
         _maybe_record_allow_connector_diagnostic_context(flow, classification)
+        original_url = flow.metadata.get(metadata_keys.ORIGINAL_URL)
+        if isinstance(original_url, str) and _maybe_make_connector_diagnostic_local_response(
+            flow,
+            original_url=original_url,
+        ):
+            return
         flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
     except (asyncio.CancelledError, Exception):
         flow.metadata.pop(metadata_keys.HTTP_REQUEST_START_MONOTONIC, None)

--- a/crates/runner/mitm-addon/tests/test_error_handler.py
+++ b/crates/runner/mitm-addon/tests/test_error_handler.py
@@ -21,11 +21,23 @@ from tests.request_handler_helpers import _vm_without_firewalls, _write_registry
 from tests.timestamp_helpers import assert_utc_millisecond_timestamp
 
 
+def _prepare_legacy_connector_diagnostic_flow(tmp_path, flow, *, capture_body: bool = False):
+    flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+    flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = str(tmp_path / "net.jsonl")
+    flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = str(tmp_path / "proxy.jsonl")
+    flow.metadata[metadata_keys.CAPTURE_BODY] = capture_body
+    flow.metadata[metadata_keys.ORIGINAL_URL] = (
+        f"https://{flow.request.pretty_host}{flow.request.path}"
+    )
+    flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+    flow.metadata[mitm_addon._CONNECTOR_DIAGNOSTIC_ELIGIBLE] = True
+    flow.metadata[mitm_addon._CONNECTOR_DIAGNOSTIC_ACTIVE_FIREWALL_NAMES] = ()
+
+
 class TestErrorHandler:
     async def test_connector_candidate_error_gets_local_diagnostic_response(
         self, tmp_path, real_flow, mitm_ctx
     ):
-        reg_path = _write_registry(tmp_path, vm_info=_vm_without_firewalls(tmp_path))
         flow = real_flow(
             with_response=False,
             client_ip="10.200.0.5",
@@ -33,9 +45,9 @@ class TestErrorHandler:
             path="/fal-ai/nano-banana-pro",
             method="POST",
         )
+        _prepare_legacy_connector_diagnostic_flow(tmp_path, flow)
 
-        with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
-            await mitm_addon.request(flow)
+        with mitm_ctx():
             flow.error = Error("connection reset by peer")
             mitm_addon.error(flow)
 
@@ -66,10 +78,6 @@ class TestErrorHandler:
     def test_streamed_connector_candidate_error_before_request_gets_diagnostic(
         self, tmp_path, real_flow, mitm_ctx
     ):
-        reg_path = _write_registry(
-            tmp_path,
-            vm_info=_vm_without_firewalls(tmp_path, vm_fields={"captureNetworkBodies": True}),
-        )
         flow = real_flow(
             with_response=False,
             client_ip="10.200.0.5",
@@ -77,9 +85,10 @@ class TestErrorHandler:
             path="/fal-ai/nano-banana-pro",
             method="POST",
         )
+        _prepare_legacy_connector_diagnostic_flow(tmp_path, flow, capture_body=True)
 
-        with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
-            mitm_addon.requestheaders(flow)
+        with mitm_ctx():
+            request_streaming.configure_request_stream(flow)
             stream = flow.request.stream
             assert callable(stream)
             assert stream(b"partial request") == b"partial request"

--- a/crates/runner/mitm-addon/tests/test_error_handler.py
+++ b/crates/runner/mitm-addon/tests/test_error_handler.py
@@ -52,7 +52,7 @@ class TestErrorHandler:
             mitm_addon.error(flow)
 
         assert flow.response is not None
-        assert flow.response.status_code == 502
+        assert flow.response.status_code == 424
         content = flow.response.content
         assert content is not None
         body = json.loads(content)
@@ -99,7 +99,7 @@ class TestErrorHandler:
             mitm_addon.error(flow)
 
         assert flow.response is not None
-        assert flow.response.status_code == 502
+        assert flow.response.status_code == 424
         content = flow.response.content
         assert content is not None
         body = json.loads(content)

--- a/crates/runner/mitm-addon/tests/test_error_handler.py
+++ b/crates/runner/mitm-addon/tests/test_error_handler.py
@@ -78,6 +78,10 @@ class TestErrorHandler:
     def test_streamed_connector_candidate_error_before_request_gets_diagnostic(
         self, tmp_path, real_flow, mitm_ctx
     ):
+        reg_path = _write_registry(
+            tmp_path,
+            vm_info=_vm_without_firewalls(tmp_path, vm_fields={"captureNetworkBodies": True}),
+        )
         flow = real_flow(
             with_response=False,
             client_ip="10.200.0.5",
@@ -85,10 +89,9 @@ class TestErrorHandler:
             path="/fal-ai/nano-banana-pro",
             method="POST",
         )
-        _prepare_legacy_connector_diagnostic_flow(tmp_path, flow, capture_body=True)
 
-        with mitm_ctx():
-            request_streaming.configure_request_stream(flow)
+        with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+            mitm_addon.requestheaders(flow)
             stream = flow.request.stream
             assert callable(stream)
             assert stream(b"partial request") == b"partial request"

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -28,6 +28,35 @@ _BROWSER_USER_AGENT = (
 )
 
 
+def _assert_fal_local_connector_diagnostic(flow):
+    assert flow.response is not None
+    assert flow.response.status_code == 502
+    content = flow.response.content
+    assert content is not None
+    body = json.loads(content)
+    assert body == {
+        "error": "connector_not_configured_for_run",
+        "connector": "fal",
+        "reason": "not_configured_for_run",
+        "message": (
+            "fal is not configured for this run. FAL_TOKEN is unavailable, "
+            "so credentials cannot be injected."
+        ),
+        "envNames": ["FAL_TOKEN"],
+        "base": "https://fal.run",
+        "upstreamStatus": 0,
+    }
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+    assert flow.metadata[metadata_keys.FIREWALL_BASE] == "https://fal.run"
+    assert flow.metadata[metadata_keys.FIREWALL_NAME] == "fal"
+    assert flow.metadata[metadata_keys.FIREWALL_PERMISSION] == ""
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "connector_not_configured_for_run"
+    assert flow.metadata[metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE] == "fal"
+    assert flow.metadata[metadata_keys.CONNECTOR_DIAGNOSTIC_REASON] == "not_configured_for_run"
+    assert flow.metadata[metadata_keys.CONNECTOR_DIAGNOSTIC_ENV_NAMES] == ["FAL_TOKEN"]
+    assert flow.metadata[metadata_keys.CONNECTOR_DIAGNOSTIC_BASE] == "https://fal.run"
+
+
 def _write_auth_base_firewall_registry(
     tmp_path,
     *,
@@ -77,8 +106,8 @@ async def test_firewall_match_calls_handler(
     assert flow.metadata["firewall_permission"] == "full-access"
 
 
-async def test_inactive_builtin_connector_url_allows_without_diagnostic_lookup(
-    tmp_path, real_flow, mitm_ctx, monkeypatch
+async def test_inactive_builtin_connector_url_without_auth_gets_local_diagnostic(
+    tmp_path, real_flow, mitm_ctx
 ):
     reg_path = _write_registry(tmp_path, vm_info=_vm_without_firewalls(tmp_path))
     flow = real_flow(
@@ -89,13 +118,69 @@ async def test_inactive_builtin_connector_url_allows_without_diagnostic_lookup(
         method="POST",
     )
 
-    def fail_find_candidate(*_args, **_kwargs):
-        raise AssertionError("request hook should not run connector diagnostic lookup")
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        await mitm_addon.request(flow)
+        mitm_addon.response(flow)
 
-    monkeypatch.setattr(
-        mitm_addon.builtin_connector_diagnostics,
-        "find_candidate",
-        fail_find_candidate,
+    _assert_fal_local_connector_diagnostic(flow)
+    [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
+    assert entry["action"] == "ALLOW"
+    assert entry["status"] == 502
+    assert entry["firewall_error"] == "connector_not_configured_for_run"
+    assert entry["connector_diagnostic_type"] == "fal"
+    [proxy_entry, http_error_entry] = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
+    assert proxy_entry["type"] == "connector_diagnostic"
+    assert proxy_entry["connector"] == "fal"
+    assert proxy_entry["upstream_status"] == 0
+    assert http_error_entry["type"] == "http_error"
+    assert http_error_entry["status"] == 502
+
+
+@pytest.mark.parametrize(
+    ("path", "request_header_pairs"),
+    [
+        ("/fal-ai/nano-banana-pro", [("Authorization", "Bearer ")]),
+        ("/fal-ai/nano-banana-pro", [("Authorization", "Key ")]),
+        ("/fal-ai/nano-banana-pro", [("Proxy-Authorization", "Basic proxy-secret")]),
+        ("/fal-ai/nano-banana-pro?api_key=", []),
+    ],
+)
+async def test_inactive_builtin_connector_url_with_empty_auth_gets_local_diagnostic(
+    tmp_path, real_flow, mitm_ctx, headers, path, request_header_pairs
+):
+    reg_path = _write_registry(tmp_path, vm_info=_vm_without_firewalls(tmp_path))
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="fal.run",
+        path=path,
+        method="POST",
+        request_headers=headers(
+            ("Host", "fal.run"),
+            *request_header_pairs,
+        ),
+    )
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        await mitm_addon.request(flow)
+
+    _assert_fal_local_connector_diagnostic(flow)
+
+
+async def test_inactive_builtin_connector_url_with_user_auth_allows_upstream(
+    tmp_path, real_flow, mitm_ctx, headers
+):
+    reg_path = _write_registry(tmp_path, vm_info=_vm_without_firewalls(tmp_path))
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="fal.run",
+        path="/fal-ai/nano-banana-pro",
+        method="POST",
+        request_headers=headers(
+            ("Host", "fal.run"),
+            ("Authorization", "Key user-provided"),
+        ),
     )
 
     with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
@@ -105,9 +190,37 @@ async def test_inactive_builtin_connector_url_allows_without_diagnostic_lookup(
     assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
     assert metadata_keys.FIREWALL_BASE not in flow.metadata
     assert metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE not in flow.metadata
-    assert metadata_keys.CONNECTOR_DIAGNOSTIC_REASON not in flow.metadata
-    assert metadata_keys.CONNECTOR_DIAGNOSTIC_ENV_NAMES not in flow.metadata
-    assert metadata_keys.CONNECTOR_DIAGNOSTIC_BASE not in flow.metadata
+
+
+async def test_inactive_builtin_connector_requestheaders_without_auth_gets_local_diagnostic(
+    tmp_path, real_flow, mitm_ctx
+):
+    reg_path = _write_registry(
+        tmp_path,
+        vm_info=_vm_without_firewalls(tmp_path, vm_fields={"captureNetworkBodies": True}),
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="fal.run",
+        path="/fal-ai/nano-banana-pro",
+        method="POST",
+    )
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        mitm_addon.requestheaders(flow)
+        await mitm_addon.request(flow)
+        mitm_addon.response(flow)
+
+    _assert_fal_local_connector_diagnostic(flow)
+    assert not callable(flow.request.stream)
+    assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
+    assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
+    assert mitm_addon._REQUEST_CLASSIFICATION not in flow.metadata
+    [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
+    assert entry["status"] == 502
+    assert entry["request_size"] == 0
+    assert entry["connector_diagnostic_type"] == "fal"
 
 
 async def test_browser_builtin_connector_url_does_not_record_diagnostic_candidate(

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -31,7 +31,7 @@ _BROWSER_USER_AGENT = (
 
 def _assert_fal_local_connector_diagnostic(flow):
     assert flow.response is not None
-    assert flow.response.status_code == 502
+    assert flow.response.status_code == 424
     content = flow.response.content
     assert content is not None
     body = json.loads(content)
@@ -126,7 +126,7 @@ async def test_inactive_builtin_connector_url_without_auth_gets_local_diagnostic
     _assert_fal_local_connector_diagnostic(flow)
     [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
     assert entry["action"] == "ALLOW"
-    assert entry["status"] == 502
+    assert entry["status"] == 424
     assert entry["firewall_error"] == "connector_not_configured_for_run"
     assert entry["connector_diagnostic_type"] == "fal"
     [proxy_entry, http_error_entry] = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
@@ -134,7 +134,7 @@ async def test_inactive_builtin_connector_url_without_auth_gets_local_diagnostic
     assert proxy_entry["connector"] == "fal"
     assert proxy_entry["upstream_status"] == 0
     assert http_error_entry["type"] == "http_error"
-    assert http_error_entry["status"] == 502
+    assert http_error_entry["status"] == 424
 
 
 @pytest.mark.parametrize(

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -9,6 +9,7 @@ from mitmproxy.flow import Error
 import auth
 import flow_metadata_keys as metadata_keys
 import mitm_addon
+import request_streaming
 import usage
 from tests.jsonl_log_helpers import (
     read_jsonl_entries_after_flush,
@@ -192,7 +193,7 @@ async def test_inactive_builtin_connector_url_with_user_auth_allows_upstream(
     assert metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE not in flow.metadata
 
 
-async def test_inactive_builtin_connector_requestheaders_without_auth_gets_local_diagnostic(
+async def test_streamed_inactive_builtin_connector_request_waits_for_response_fallback(
     tmp_path, real_flow, mitm_ctx
 ):
     reg_path = _write_registry(
@@ -209,18 +210,17 @@ async def test_inactive_builtin_connector_requestheaders_without_auth_gets_local
 
     with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
         mitm_addon.requestheaders(flow)
+        request_stream = flow.request.stream
+        assert callable(request_stream)
+        assert request_stream(b"partial request") == b"partial request"
         await mitm_addon.request(flow)
-        mitm_addon.response(flow)
 
-    _assert_fal_local_connector_diagnostic(flow)
-    assert not callable(flow.request.stream)
-    assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
-    assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
+    assert flow.response is None
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+    assert metadata_keys.FIREWALL_ERROR not in flow.metadata
+    assert metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE not in flow.metadata
+    assert request_streaming.streamed_request_size(flow) == len(b"partial request")
     assert mitm_addon._REQUEST_CLASSIFICATION not in flow.metadata
-    [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
-    assert entry["status"] == 502
-    assert entry["request_size"] == 0
-    assert entry["connector_diagnostic_type"] == "fal"
 
 
 async def test_browser_builtin_connector_url_does_not_record_diagnostic_candidate(

--- a/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
@@ -644,7 +644,7 @@ async def test_registered_vm_null_firewalls_passes_through_without_auth_injectio
     )
     vm_info["firewalls"] = None
     reg_path = _write_registry(tmp_path, client_ip="10.200.0.5", vm_info=vm_info)
-    flow = real_flow(with_response=False, client_ip="10.200.0.5", host="api.github.com")
+    flow = real_flow(with_response=False, client_ip="10.200.0.5", host="unconfigured.example.com")
 
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -229,6 +229,10 @@ class TestResponseHandler:
     def test_streamed_connector_401_before_request_gets_diagnostic(
         self, tmp_path, real_flow, mitm_ctx
     ):
+        reg_path = _write_registry(
+            tmp_path,
+            vm_info=_vm_without_firewalls(tmp_path, vm_fields={"captureNetworkBodies": True}),
+        )
         flow = real_flow(
             with_response=False,
             client_ip="10.200.0.5",
@@ -236,10 +240,9 @@ class TestResponseHandler:
             path="/fal-ai/nano-banana-pro",
             method="POST",
         )
-        _prepare_legacy_connector_diagnostic_flow(tmp_path, flow, capture_body=True)
 
-        with mitm_ctx():
-            request_streaming.configure_request_stream(flow)
+        with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+            mitm_addon.requestheaders(flow)
             request_stream = flow.request.stream
             assert callable(request_stream)
             assert request_stream(b"partial request") == b"partial request"

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -29,9 +29,21 @@ from tests.request_handler_helpers import _vm_without_firewalls, _write_registry
 from tests.timestamp_helpers import assert_utc_millisecond_timestamp
 
 
+def _prepare_legacy_connector_diagnostic_flow(tmp_path, flow, *, capture_body: bool = False):
+    flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
+    flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = str(tmp_path / "net.jsonl")
+    flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = str(tmp_path / "proxy.jsonl")
+    flow.metadata[metadata_keys.CAPTURE_BODY] = capture_body
+    flow.metadata[metadata_keys.ORIGINAL_URL] = (
+        f"https://{flow.request.pretty_host}{flow.request.path}"
+    )
+    flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+    flow.metadata[mitm_addon._CONNECTOR_DIAGNOSTIC_ELIGIBLE] = True
+    flow.metadata[mitm_addon._CONNECTOR_DIAGNOSTIC_ACTIVE_FIREWALL_NAMES] = ()
+
+
 class TestResponseHandler:
     async def test_replaces_unauthenticated_connector_401_body(self, tmp_path, real_flow, mitm_ctx):
-        reg_path = _write_registry(tmp_path, vm_info=_vm_without_firewalls(tmp_path))
         flow = real_flow(
             with_response=False,
             client_ip="10.200.0.5",
@@ -39,9 +51,9 @@ class TestResponseHandler:
             path="/fal-ai/nano-banana-pro",
             method="POST",
         )
+        _prepare_legacy_connector_diagnostic_flow(tmp_path, flow)
 
-        with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
-            await mitm_addon.request(flow)
+        with mitm_ctx():
             flow.response = tutils.tresp(
                 status_code=401,
                 headers=header_map({"content-type": "text/plain", "content-length": "8"}),
@@ -82,7 +94,6 @@ class TestResponseHandler:
     async def test_buffers_unauthenticated_connector_401_before_response_replacement(
         self, tmp_path, real_flow, mitm_ctx
     ):
-        reg_path = _write_registry(tmp_path, vm_info=_vm_without_firewalls(tmp_path))
         flow = real_flow(
             with_response=False,
             client_ip="10.200.0.5",
@@ -90,9 +101,9 @@ class TestResponseHandler:
             path="/fal-ai/nano-banana-pro",
             method="POST",
         )
+        _prepare_legacy_connector_diagnostic_flow(tmp_path, flow)
 
-        with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
-            await mitm_addon.request(flow)
+        with mitm_ctx():
             flow.response = tutils.tresp(
                 status_code=401,
                 headers=header_map({"content-type": "text/plain"}),
@@ -218,10 +229,6 @@ class TestResponseHandler:
     def test_streamed_connector_401_before_request_gets_diagnostic(
         self, tmp_path, real_flow, mitm_ctx
     ):
-        reg_path = _write_registry(
-            tmp_path,
-            vm_info=_vm_without_firewalls(tmp_path, vm_fields={"captureNetworkBodies": True}),
-        )
         flow = real_flow(
             with_response=False,
             client_ip="10.200.0.5",
@@ -229,9 +236,10 @@ class TestResponseHandler:
             path="/fal-ai/nano-banana-pro",
             method="POST",
         )
+        _prepare_legacy_connector_diagnostic_flow(tmp_path, flow, capture_body=True)
 
-        with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
-            mitm_addon.requestheaders(flow)
+        with mitm_ctx():
+            request_streaming.configure_request_stream(flow)
             request_stream = flow.request.stream
             assert callable(request_stream)
             assert request_stream(b"partial request") == b"partial request"
@@ -429,7 +437,6 @@ class TestResponseHandler:
     async def test_replaces_connector_401_body_when_auth_header_has_empty_bearer_token(
         self, tmp_path, real_flow, mitm_ctx, headers
     ):
-        reg_path = _write_registry(tmp_path, vm_info=_vm_without_firewalls(tmp_path))
         flow = real_flow(
             with_response=False,
             client_ip="10.200.0.5",
@@ -441,9 +448,9 @@ class TestResponseHandler:
                 ("Authorization", "Bearer "),
             ),
         )
+        _prepare_legacy_connector_diagnostic_flow(tmp_path, flow)
 
-        with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
-            await mitm_addon.request(flow)
+        with mitm_ctx():
             flow.response = tutils.tresp(
                 status_code=401,
                 headers=header_map({"content-type": "text/plain"}),
@@ -463,7 +470,6 @@ class TestResponseHandler:
     async def test_replaces_connector_401_body_when_only_proxy_authorization_is_present(
         self, tmp_path, real_flow, mitm_ctx, headers
     ):
-        reg_path = _write_registry(tmp_path, vm_info=_vm_without_firewalls(tmp_path))
         flow = real_flow(
             with_response=False,
             client_ip="10.200.0.5",
@@ -475,9 +481,9 @@ class TestResponseHandler:
                 ("Proxy-Authorization", "Basic proxy-secret"),
             ),
         )
+        _prepare_legacy_connector_diagnostic_flow(tmp_path, flow)
 
-        with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
-            await mitm_addon.request(flow)
+        with mitm_ctx():
             flow.response = tutils.tresp(
                 status_code=401,
                 headers=header_map({"content-type": "text/plain"}),
@@ -497,7 +503,6 @@ class TestResponseHandler:
     async def test_replaces_connector_401_body_when_auth_header_has_empty_key_token(
         self, tmp_path, real_flow, mitm_ctx, headers
     ):
-        reg_path = _write_registry(tmp_path, vm_info=_vm_without_firewalls(tmp_path))
         flow = real_flow(
             with_response=False,
             client_ip="10.200.0.5",
@@ -509,9 +514,9 @@ class TestResponseHandler:
                 ("Authorization", "Key "),
             ),
         )
+        _prepare_legacy_connector_diagnostic_flow(tmp_path, flow)
 
-        with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
-            await mitm_addon.request(flow)
+        with mitm_ctx():
             flow.response = tutils.tresp(
                 status_code=401,
                 headers=header_map({"content-type": "text/plain"}),
@@ -531,7 +536,6 @@ class TestResponseHandler:
     async def test_replaces_connector_401_body_when_auth_query_param_is_empty(
         self, tmp_path, real_flow, mitm_ctx
     ):
-        reg_path = _write_registry(tmp_path, vm_info=_vm_without_firewalls(tmp_path))
         flow = real_flow(
             with_response=False,
             client_ip="10.200.0.5",
@@ -539,9 +543,9 @@ class TestResponseHandler:
             path="/fal-ai/nano-banana-pro?api_key=",
             method="POST",
         )
+        _prepare_legacy_connector_diagnostic_flow(tmp_path, flow)
 
-        with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
-            await mitm_addon.request(flow)
+        with mitm_ctx():
             flow.response = tutils.tresp(
                 status_code=401,
                 headers=header_map({"content-type": "text/plain"}),
@@ -684,7 +688,7 @@ class TestResponseHandler:
         assert "firewall_error" not in entry
 
     async def test_preserves_successful_connector_response_body(
-        self, tmp_path, real_flow, mitm_ctx
+        self, tmp_path, real_flow, mitm_ctx, headers
     ):
         reg_path = _write_registry(tmp_path, vm_info=_vm_without_firewalls(tmp_path))
         flow = real_flow(
@@ -693,6 +697,10 @@ class TestResponseHandler:
             host="fal.run",
             path="/fal-ai/nano-banana-pro",
             method="POST",
+            request_headers=headers(
+                ("Host", "fal.run"),
+                ("Authorization", "Key user-provided"),
+            ),
         )
 
         with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):

--- a/e2e/tests/03-runner/t45-vm0-network-logging.bats
+++ b/e2e/tests/03-runner/t45-vm0-network-logging.bats
@@ -134,17 +134,15 @@ EOF
 @test "t45-4: connector diagnostic fields appear in network logs" {
     create_agent
 
-    # Replicate's model list endpoint is read-only and returns 401 when no
-    # token is present. Since this run does not configure the replicate
-    # connector, mitmproxy should replace that response body with the
-    # connector-not-configured diagnostic and persist the diagnostic metadata
-    # to network logs.
+    # Since this run does not configure the replicate connector, mitmproxy
+    # returns a local failed-dependency diagnostic without calling upstream and
+    # persists the diagnostic metadata to network logs.
     run $VM0_CLI run "$AGENT_NAME" \
         --artifact "$ARTIFACT_NAME:/home/user/workspace" \
         "STATUS=\$(curl -sS -o /tmp/replicate-diagnostic.json -w '%{http_code}' https://api.replicate.com/v1/models); cat /tmp/replicate-diagnostic.json; echo; echo REPLICATE_STATUS=\$STATUS"
     assert_success
     assert_output --partial "connector_not_configured_for_run"
-    assert_output --partial "REPLICATE_STATUS=401"
+    assert_output --partial "REPLICATE_STATUS=424"
 
     RUN_ID=$(echo "$output" | grep -oP 'Run ID:\s+\K[a-f0-9-]{36}' | head -1)
     [ -n "$RUN_ID" ] || {


### PR DESCRIPTION
## Summary

- Return connector-not-configured diagnostics locally for inactive built-in connector URLs with no usable user auth material when the request has not already entered request streaming.
- Keep streamed request paths on the existing response/error fallback, because mitmproxy cannot safely combine a requestheaders local response with request streaming without buffering or state-machine issues.
- Preserve active connector, browser passthrough, model-provider, and user-authenticated behavior, and update fallback tests around the new primary path.

Fixes #18908

## Tests

- `pytest tests/test_request_handler_firewall_dispatch.py tests/test_response_handler.py tests/test_error_handler.py tests/test_builtin_connector_diagnostics.py tests/test_request_handler_passthrough.py::test_registered_vm_null_firewalls_passes_through_without_auth_injection`
- `pytest`
- `ruff format .`
- `ruff check .`
- `basedpyright`