### PR TITLE
perf: bound firewalled request body capture

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -5,6 +5,7 @@ auth.base forwarding, local failure responses, and AWS SigV4 signing together.
 Cache state and platform API calls live in dedicated owner modules.
 """
 
+import asyncio
 import json
 import urllib.parse
 from dataclasses import dataclass
@@ -875,6 +876,14 @@ async def try_apply_stream_safe_firewall_auth_for_requestheaders(
             context.api_id,
             context.auth_request,
         )
+    except asyncio.CancelledError:
+        _restore_header_phase_probe_state(
+            flow,
+            metadata_snapshot=metadata_snapshot,
+            request_headers_snapshot=request_headers_snapshot,
+            request_path_snapshot=request_path_snapshot,
+        )
+        raise
     except Exception:
         _restore_header_phase_probe_state(
             flow,
@@ -910,7 +919,7 @@ async def try_apply_stream_safe_firewall_auth_for_requestheaders(
             headers=headers,
             resolved_query=resolved_query,
         )
-    except (InvalidResolvedAuthHeaderError, KeyError, TypeError):
+    except Exception:
         _restore_header_phase_probe_state(
             flow,
             metadata_snapshot=metadata_snapshot,

--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -45,6 +45,13 @@ class FirewallAuthHandlingResult(Enum):
     LOCAL_RESPONSE = "local_response"
 
 
+class FirewallHeaderPhaseAuthResult(Enum):
+    """Firewall auth result for requestheaders() stream-capture probing."""
+
+    APPLIED = "applied"
+    FALLBACK = "fallback"
+
+
 _HTTP_STATUS_CLIENT_ERROR_MIN = 400
 _HTTP_STATUS_SERVER_ERROR_MIN = 500
 
@@ -210,6 +217,29 @@ def _record_firewall_auth_success_metadata(flow: http.HTTPFlow, token_meta: dict
     )
     flow.metadata[metadata_keys.AUTH_REFRESHED_SECRETS] = token_meta.get("refreshed_secrets", [])
     flow.metadata[metadata_keys.AUTH_CACHE_HIT] = token_meta.get("cache_hit", False)
+
+
+def _auth_config_uses_body_dependent_auth(auth_config: object) -> bool:
+    if not isinstance(auth_config, dict):
+        return False
+    auth_base = auth_config.get("base")
+    if isinstance(auth_base, str) and auth_base:
+        return True
+    auth_aws_sigv4 = auth_config.get("awsSigv4")
+    return isinstance(auth_aws_sigv4, dict) and bool(auth_aws_sigv4)
+
+
+def _restore_header_phase_probe_state(
+    flow: http.HTTPFlow,
+    *,
+    metadata_snapshot: dict,
+    request_headers_snapshot: http.Headers,
+    request_path_snapshot: str,
+) -> None:
+    flow.metadata.clear()
+    flow.metadata.update(metadata_snapshot)
+    flow.request.headers = http.Headers(request_headers_snapshot.fields)
+    flow.request.path = request_path_snapshot
 
 
 def _apply_header_query_injection(
@@ -808,3 +838,86 @@ async def handle_firewall_request(
 
     _finalize_firewall_auth_success(flow, context, token_meta)
     return auth_result
+
+
+async def try_apply_stream_safe_firewall_auth_for_requestheaders(
+    flow: http.HTTPFlow,
+    allow: matching.FirewallAllow,
+    vm_info: dict,
+) -> FirewallHeaderPhaseAuthResult:
+    """Apply successful header/query firewall auth before request streaming.
+
+    This helper intentionally falls back instead of creating local responses.
+    The request hook owns auth failure semantics; requestheaders() only keeps a
+    success that is safe before mitmproxy sends upstream request headers.
+    """
+    auth_config = allow.api_entry.get("auth", {})
+    if _auth_config_uses_body_dependent_auth(auth_config):
+        return FirewallHeaderPhaseAuthResult.FALLBACK
+
+    request_scheme = flow.request.scheme.lower()
+    if request_scheme != "https" and auth_config_injects_credentials(auth_config):
+        return FirewallHeaderPhaseAuthResult.FALLBACK
+
+    if not vm_info.get("encryptedSecrets"):
+        return FirewallHeaderPhaseAuthResult.FALLBACK
+
+    metadata_snapshot = dict(flow.metadata)
+    request_headers_snapshot = http.Headers(flow.request.headers.fields)
+    request_path_snapshot = flow.request.path
+
+    _prepare_firewall_metadata(flow, allow, vm_info)
+    context = _build_firewall_auth_context(flow, allow, vm_info)
+
+    try:
+        token_meta = await get_firewall_headers(
+            context.run_id,
+            context.api_id,
+            context.auth_request,
+        )
+    except Exception:
+        _restore_header_phase_probe_state(
+            flow,
+            metadata_snapshot=metadata_snapshot,
+            request_headers_snapshot=request_headers_snapshot,
+            request_path_snapshot=request_path_snapshot,
+        )
+        return FirewallHeaderPhaseAuthResult.FALLBACK
+
+    if not isinstance(token_meta, dict):
+        _restore_header_phase_probe_state(
+            flow,
+            metadata_snapshot=metadata_snapshot,
+            request_headers_snapshot=request_headers_snapshot,
+            request_path_snapshot=request_path_snapshot,
+        )
+        return FirewallHeaderPhaseAuthResult.FALLBACK
+
+    if token_meta.get("base") or token_meta.get("aws_sigv4") is not None:
+        _restore_header_phase_probe_state(
+            flow,
+            metadata_snapshot=metadata_snapshot,
+            request_headers_snapshot=request_headers_snapshot,
+            request_path_snapshot=request_path_snapshot,
+        )
+        return FirewallHeaderPhaseAuthResult.FALLBACK
+
+    try:
+        headers = token_meta["headers"]
+        resolved_query = token_meta.get("query")
+        _apply_header_query_injection(
+            flow,
+            headers=headers,
+            resolved_query=resolved_query,
+        )
+    except (InvalidResolvedAuthHeaderError, KeyError, TypeError):
+        _restore_header_phase_probe_state(
+            flow,
+            metadata_snapshot=metadata_snapshot,
+            request_headers_snapshot=request_headers_snapshot,
+            request_path_snapshot=request_path_snapshot,
+        )
+        return FirewallHeaderPhaseAuthResult.FALLBACK
+
+    _finalize_firewall_auth_success(flow, context, token_meta)
+    return FirewallHeaderPhaseAuthResult.APPLIED

--- a/crates/runner/mitm-addon/src/body_capture.py
+++ b/crates/runner/mitm-addon/src/body_capture.py
@@ -310,8 +310,7 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
         request_stream_body = request_streaming.captured_request_stream_body(flow)
         if request_stream_body is not None:
             request_stream_incomplete = (
-                bool(request_stream_body.buffer)
-                and flow.metadata.get(metadata_keys.REQUEST_STREAM_COMPLETE) is not True
+                flow.metadata.get(metadata_keys.REQUEST_STREAM_COMPLETE) is not True
             )
             req_ct = flow.request.headers.get("content-type", "")
             request_body = body_decoding.decode_body_bounded(

--- a/crates/runner/mitm-addon/src/body_capture.py
+++ b/crates/runner/mitm-addon/src/body_capture.py
@@ -309,6 +309,10 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
     else:
         request_stream_body = request_streaming.captured_request_stream_body(flow)
         if request_stream_body is not None:
+            request_stream_incomplete = (
+                bool(request_stream_body.buffer)
+                and flow.metadata.get(metadata_keys.REQUEST_STREAM_COMPLETE) is not True
+            )
             req_ct = flow.request.headers.get("content-type", "")
             request_body = body_decoding.decode_body_bounded(
                 bytes(request_stream_body.buffer),
@@ -317,7 +321,7 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
                 fail_on_unsupported_encoding=True,
             )
             if request_body.failed:
-                if request_stream_body.truncated:
+                if request_stream_body.truncated or request_stream_incomplete:
                     log_entry["request_body_truncated"] = True
                 log_entry["request_body_encoding"] = "binary"
             else:
@@ -326,7 +330,7 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
                     "request",
                     request_body.body,
                     req_ct,
-                    already_truncated=request_stream_body.truncated,
+                    already_truncated=request_stream_body.truncated or request_stream_incomplete,
                 )
         elif flow.request.raw_content:
             req_ct = flow.request.headers.get("content-type", "")

--- a/crates/runner/mitm-addon/src/flow_metadata_keys.py
+++ b/crates/runner/mitm-addon/src/flow_metadata_keys.py
@@ -113,6 +113,10 @@ Request streaming
 - ``REQUEST_STREAM_BUFFER_STATE``: ``dict`` with at least ``truncated`` and
   ``total_bytes``. Written with ``REQUEST_STREAM_BUFFER`` and read for request
   size and capture truncation. Removed by stream cleanup.
+- ``REQUEST_STREAM_COMPLETE``: ``bool`` written by ``request()`` after
+  mitmproxy has delivered the full streamed request body to the addon. Read by
+  connector billing before treating a non-truncated request stream buffer as a
+  complete request body. Removed by stream cleanup.
 
 Model-provider usage
 --------------------
@@ -189,5 +193,6 @@ STREAM_BUFFER: Final = "stream_buffer"
 STREAM_BUFFER_STATE: Final = "stream_buffer_state"
 REQUEST_STREAM_BUFFER: Final = "request_stream_buffer"
 REQUEST_STREAM_BUFFER_STATE: Final = "request_stream_buffer_state"
+REQUEST_STREAM_COMPLETE: Final = "request_stream_complete"
 X_NDJSON_STATE: Final = "x_ndjson_state"
 X_JSON_STATE: Final = "x_json_state"

--- a/crates/runner/mitm-addon/src/flow_metadata_keys.py
+++ b/crates/runner/mitm-addon/src/flow_metadata_keys.py
@@ -108,11 +108,12 @@ Request streaming
 -----------------
 - ``REQUEST_STREAM_BUFFER``: capped ``bytearray`` written by
   ``requestheaders()`` via request streaming setup for stream-safe body
-  capture paths. Read by request body capture. Removed by stream cleanup after
-  terminal hooks.
+  capture paths. Read by request body capture and connector billing refinement.
+  Removed by stream cleanup after terminal hooks.
 - ``REQUEST_STREAM_BUFFER_STATE``: ``dict`` with at least ``truncated`` and
   ``total_bytes``. Written with ``REQUEST_STREAM_BUFFER`` and read for request
-  size and capture truncation. Removed by stream cleanup.
+  size, capture truncation, and connector billing refinement. Removed by stream
+  cleanup.
 - ``REQUEST_STREAM_COMPLETE``: ``bool`` written by ``request()`` after
   mitmproxy has delivered the full streamed request body to the addon. Read by
   connector billing before treating a non-truncated request stream buffer as a

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -20,7 +20,7 @@ import tempfile
 import threading
 import time
 import urllib.parse
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
@@ -54,11 +54,13 @@ import response_streaming
 import usage
 from auth import (
     FirewallAuthHandlingResult,
+    FirewallHeaderPhaseAuthResult,
     handle_firewall_request,
     is_billable_firewall,
     mark_auth_base_request_length_required,
     mark_auth_base_request_too_large,
     prepare_firewall_metadata,
+    try_apply_stream_safe_firewall_auth_for_requestheaders,
 )
 from body_limits import STREAM_BUFFER_LIMIT
 from firewall_auth_cache import clear_cached_firewall_headers, request_force_refresh
@@ -163,6 +165,7 @@ _RequestClassificationKind = Literal[
 _AuthBaseBodyCheckKind = Literal["ok", "too_large", "length_required"]
 _REQUEST_HEADERS_TERMINATED = "_request_headers_terminated"
 _REQUEST_CLASSIFICATION = "_request_classification"
+_FIREWALL_AUTH_APPLIED_IN_REQUESTHEADERS = "_firewall_auth_applied_in_requestheaders"
 _REQUEST_HEADERS_PROBE_METADATA_KEYS = (
     metadata_keys.VM_RUN_ID,
     metadata_keys.VM_NETWORK_LOG_PATH,
@@ -174,6 +177,7 @@ _REQUEST_HEADERS_PROBE_METADATA_KEYS = (
     metadata_keys.ORIGINAL_URL,
     metadata_keys.TRUSTED_AUTHORITY_HOST,
     metadata_keys.NETWORK_LOG_TARGET,
+    metadata_keys.HTTP_REQUEST_START_MONOTONIC,
 )
 
 
@@ -692,6 +696,13 @@ def _classification_needs_request_timing(classification: _RequestClassification)
 
 def _should_stream_capture_request(classification: _RequestClassification) -> bool:
     if classification.kind not in ("api_allow", "browser_allow", "allow"):
+        return False
+    vm_info = classification.vm_info
+    return isinstance(vm_info, dict) and bool(vm_info.get("captureNetworkBodies", False))
+
+
+def _should_try_firewall_stream_capture_request(classification: _RequestClassification) -> bool:
+    if classification.kind != "firewall_allow":
         return False
     vm_info = classification.vm_info
     return isinstance(vm_info, dict) and bool(vm_info.get("captureNetworkBodies", False))
@@ -1360,11 +1371,11 @@ def client_disconnected(client: connection.Client) -> None:
 # ============================================================================
 
 
-def requestheaders(flow: http.HTTPFlow) -> None:
+def requestheaders(flow: http.HTTPFlow) -> Awaitable[None] | None:
     """Handle request-header-only decisions before mitmproxy buffers bodies."""
     body_check = _auth_base_body_header_check(flow)
     if body_check.kind == "ok" and _request_body_fits_stream_buffer(flow):
-        return
+        return None
 
     metadata_snapshot = {
         key: flow.metadata[key]
@@ -1402,16 +1413,56 @@ def requestheaders(flow: http.HTTPFlow) -> None:
         flow.metadata.pop(_REQUEST_CLASSIFICATION, None)
         flow.metadata[_REQUEST_HEADERS_TERMINATED] = True
         flow.kill()
-        return
+        return None
 
     if _should_stream_capture_request(classification):
         _maybe_record_allow_connector_diagnostic_context(flow, classification)
         flow.metadata[_REQUEST_CLASSIFICATION] = classification
         _start_request_timing(flow)
         request_streaming.configure_request_stream(flow)
-        return
+        return None
+
+    if _should_try_firewall_stream_capture_request(classification):
+        return _try_firewall_request_stream_capture_from_headers(
+            flow,
+            classification=classification,
+            metadata_snapshot=metadata_snapshot,
+        )
 
     _restore_request_headers_probe_metadata(flow, metadata_snapshot)
+    return None
+
+
+async def _try_firewall_request_stream_capture_from_headers(
+    flow: http.HTTPFlow,
+    *,
+    classification: _RequestClassification,
+    metadata_snapshot: dict[str, object],
+) -> None:
+    allow = classification.firewall_allow
+    vm_info = classification.vm_info
+    if allow is None or vm_info is None:
+        _restore_request_headers_probe_metadata(flow, metadata_snapshot)
+        return
+
+    _start_request_timing(flow)
+    try:
+        result = await try_apply_stream_safe_firewall_auth_for_requestheaders(flow, allow, vm_info)
+    except (asyncio.CancelledError, Exception):
+        _restore_request_headers_probe_metadata(flow, metadata_snapshot)
+        raise
+    if result is not FirewallHeaderPhaseAuthResult.APPLIED:
+        _restore_request_headers_probe_metadata(flow, metadata_snapshot)
+        return
+
+    _maybe_track_usage_flow(
+        flow,
+        is_billable_firewall(allow.name, vm_info),
+        _is_model_provider_usage_observable(allow.name, vm_info),
+    )
+    flow.metadata[_REQUEST_CLASSIFICATION] = classification
+    flow.metadata[_FIREWALL_AUTH_APPLIED_IN_REQUESTHEADERS] = True
+    request_streaming.configure_request_stream(flow)
 
 
 def _set_firewall_block_response(flow: http.HTTPFlow, result: matching.FirewallBlock) -> None:
@@ -1472,6 +1523,9 @@ async def request(flow: http.HTTPFlow) -> None:
         flow.metadata.pop(_REQUEST_CLASSIFICATION, None)
         return
 
+    if request_streaming.streamed_request_size(flow) is not None:
+        flow.metadata[metadata_keys.REQUEST_STREAM_COMPLETE] = True
+
     try:
         classification = _request_classification(flow)
 
@@ -1520,6 +1574,8 @@ async def request(flow: http.HTTPFlow) -> None:
             allow = classification.firewall_allow
             vm_info = classification.vm_info
             if allow is None or vm_info is None:
+                return
+            if flow.metadata.get(_FIREWALL_AUTH_APPLIED_IN_REQUESTHEADERS):
                 return
             _maybe_track_usage_flow(
                 flow,
@@ -1730,6 +1786,7 @@ def _release_usage_hook_state(
         if response_streaming.is_model_websocket_usage_enabled(flow):
             flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE_SOURCES] = {}
     flow.metadata.pop(_REQUEST_CLASSIFICATION, None)
+    flow.metadata.pop(_FIREWALL_AUTH_APPLIED_IN_REQUESTHEADERS, None)
     request_streaming.release_request_stream_state(flow)
     response_streaming.release_response_stream_state(flow)
     if release_tracking:

--- a/crates/runner/mitm-addon/src/request_streaming.py
+++ b/crates/runner/mitm-addon/src/request_streaming.py
@@ -85,16 +85,6 @@ def captured_request_stream_body(flow: http.HTTPFlow) -> CapturedRequestStreamBo
     return CapturedRequestStreamBody(stream_buf, stream_truncated)
 
 
-def complete_captured_request_stream_body(flow: http.HTTPFlow) -> bytes | None:
-    """Return complete captured request stream bytes, or None if truncated/missing."""
-    if flow.metadata.get(metadata_keys.REQUEST_STREAM_COMPLETE) is not True:
-        return None
-    captured = captured_request_stream_body(flow)
-    if captured is None or captured.truncated:
-        return None
-    return bytes(captured.buffer)
-
-
 def release_request_stream_state(flow: http.HTTPFlow) -> None:
     """Release request stream callback and buffered capture metadata."""
     stream_callback = flow.metadata.pop(_REQUEST_STREAM_CALLBACK, None)

--- a/crates/runner/mitm-addon/src/request_streaming.py
+++ b/crates/runner/mitm-addon/src/request_streaming.py
@@ -85,10 +85,21 @@ def captured_request_stream_body(flow: http.HTTPFlow) -> CapturedRequestStreamBo
     return CapturedRequestStreamBody(stream_buf, stream_truncated)
 
 
+def complete_captured_request_stream_body(flow: http.HTTPFlow) -> bytes | None:
+    """Return complete captured request stream bytes, or None if truncated/missing."""
+    if flow.metadata.get(metadata_keys.REQUEST_STREAM_COMPLETE) is not True:
+        return None
+    captured = captured_request_stream_body(flow)
+    if captured is None or captured.truncated:
+        return None
+    return bytes(captured.buffer)
+
+
 def release_request_stream_state(flow: http.HTTPFlow) -> None:
     """Release request stream callback and buffered capture metadata."""
     stream_callback = flow.metadata.pop(_REQUEST_STREAM_CALLBACK, None)
     flow.metadata.pop(metadata_keys.REQUEST_STREAM_BUFFER, None)
     flow.metadata.pop(metadata_keys.REQUEST_STREAM_BUFFER_STATE, None)
+    flow.metadata.pop(metadata_keys.REQUEST_STREAM_COMPLETE, None)
     if stream_callback is not None and flow.request.stream is stream_callback:
         flow.request.stream = False

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -16,6 +16,7 @@ import billing_body
 import body_decoding
 import flow_metadata_keys as metadata_keys
 import matching
+import request_streaming
 from body_limits import LARGE_RESPONSE_DECOMPRESS_LIMIT, STREAM_BUFFER_LIMIT
 from logging_utils import log_proxy_entry
 from platform_api import get_api_url
@@ -780,6 +781,13 @@ def _parse_response_metadata(flow: http.HTTPFlow) -> dict:
     return result
 
 
+def _request_body_for_billing_refinement(flow: http.HTTPFlow) -> bytes | None:
+    raw_content = flow.request.raw_content
+    if raw_content is not None:
+        return raw_content
+    return request_streaming.complete_captured_request_stream_body(flow)
+
+
 def _compute_billable_counts(
     method: str,
     req_meta: dict,
@@ -943,7 +951,7 @@ def report_usage(flow: http.HTTPFlow, run_id: str, original_url: str) -> None:
         return
     if bucket_needs_body_refinement(endpoint_bucket, flow.request.method, request_path):
         request_body = billing_body.decode_request_body_for_billing(
-            flow.request.raw_content,
+            _request_body_for_billing_refinement(flow),
             flow.request.headers,
             max_raw=_REQUEST_BODY_REFINEMENT_LIMIT,
             max_decoded=_REQUEST_BODY_REFINEMENT_LIMIT,

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -782,13 +782,15 @@ def _parse_response_metadata(flow: http.HTTPFlow) -> dict:
 
 
 def _request_body_for_billing_refinement(flow: http.HTTPFlow) -> bytes | None:
-    raw_content = flow.request.raw_content
-    if raw_content:
-        return raw_content
-    streamed_content = request_streaming.complete_captured_request_stream_body(flow)
-    if streamed_content:
-        return streamed_content
-    return raw_content
+    captured = request_streaming.captured_request_stream_body(flow)
+    if captured is not None:
+        if (
+            flow.metadata.get(metadata_keys.REQUEST_STREAM_COMPLETE) is True
+            and not captured.truncated
+        ):
+            return bytes(captured.buffer)
+        return None
+    return flow.request.raw_content
 
 
 def _compute_billable_counts(

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -783,9 +783,12 @@ def _parse_response_metadata(flow: http.HTTPFlow) -> dict:
 
 def _request_body_for_billing_refinement(flow: http.HTTPFlow) -> bytes | None:
     raw_content = flow.request.raw_content
-    if raw_content is not None:
+    if raw_content:
         return raw_content
-    return request_streaming.complete_captured_request_stream_body(flow)
+    streamed_content = request_streaming.complete_captured_request_stream_body(flow)
+    if streamed_content:
+        return streamed_content
+    return raw_content
 
 
 def _compute_billable_counts(

--- a/crates/runner/mitm-addon/tests/requestheaders_helpers.py
+++ b/crates/runner/mitm-addon/tests/requestheaders_helpers.py
@@ -1,0 +1,12 @@
+"""Shared helpers for requestheaders() hook tests."""
+
+import inspect
+from collections.abc import Awaitable
+from typing import cast
+
+
+async def await_requestheaders_result(result: object) -> None:
+    """Await the async requestheaders() path, failing if the hook stayed sync."""
+    if not inspect.isawaitable(result):
+        raise AssertionError("expected requestheaders() to return an awaitable")
+    return await cast(Awaitable[None], result)

--- a/crates/runner/mitm-addon/tests/stream_buffer_helpers.py
+++ b/crates/runner/mitm-addon/tests/stream_buffer_helpers.py
@@ -28,6 +28,7 @@ def set_request_stream_buffer(
     flow: http.HTTPFlow,
     body: bytes,
     *,
+    complete: bool = True,
     truncated: bool = False,
 ) -> None:
     """Seed request stream metadata with the hook-owned key/state shape."""
@@ -36,3 +37,7 @@ def set_request_stream_buffer(
         "truncated": truncated,
         "total_bytes": len(body) + 1 if truncated else len(body),
     }
+    if complete:
+        flow.metadata[metadata_keys.REQUEST_STREAM_COMPLETE] = True
+    else:
+        flow.metadata.pop(metadata_keys.REQUEST_STREAM_COMPLETE, None)

--- a/crates/runner/mitm-addon/tests/test_body_capture_stream_buffer.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture_stream_buffer.py
@@ -44,6 +44,21 @@ class TestBodyCaptureStreamBuffer:
         assert entry["request_body_encoding"] == "utf-8"
         assert entry["request_body_truncated"] is True
 
+    def test_incomplete_request_stream_buffer_marks_truncation(self, real_flow):
+        body = b'{"partial": true}'
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="application/json",
+            include_request_id=True,
+        )
+        set_request_stream_buffer(flow, body, complete=False)
+        entry = {}
+        add_capture_fields(flow, entry)
+        assert entry["request_body"] == '{"partial": true}'
+        assert entry["request_body_encoding"] == "utf-8"
+        assert entry["request_body_truncated"] is True
+
     def test_binary_request_stream_buffer_truncated_marks_truncation(self, real_flow):
         body = b"\x00" * STREAM_BUFFER_LIMIT
         flow = real_flow(

--- a/crates/runner/mitm-addon/tests/test_body_capture_stream_buffer.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture_stream_buffer.py
@@ -59,6 +59,20 @@ class TestBodyCaptureStreamBuffer:
         assert entry["request_body_encoding"] == "utf-8"
         assert entry["request_body_truncated"] is True
 
+    def test_empty_incomplete_request_stream_buffer_marks_truncation(self, real_flow):
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="application/json",
+            include_request_id=True,
+        )
+        set_request_stream_buffer(flow, b"", complete=False)
+        entry = {}
+        add_capture_fields(flow, entry)
+        assert "request_body" not in entry
+        assert "request_body_encoding" not in entry
+        assert entry["request_body_truncated"] is True
+
     def test_binary_request_stream_buffer_truncated_marks_truncation(self, real_flow):
         body = b"\x00" * STREAM_BUFFER_LIMIT
         flow = real_flow(

--- a/crates/runner/mitm-addon/tests/test_request_handler_usage_tracking.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_usage_tracking.py
@@ -20,6 +20,7 @@ from tests.auth_base_forwarder_helpers import (
 )
 from tests.pending_helpers import assert_pending
 from tests.request_handler_helpers import _single_firewall_vm, _write_registry
+from tests.requestheaders_helpers import await_requestheaders_result
 
 _X_FIREWALL_NAME = "x"
 _X_TRACKING_PATH = "/2/users/by"
@@ -334,8 +335,7 @@ async def test_header_phase_streamed_billable_flow_error_releases_tracking(
         fake_firewall_headers(),
     ):
         requestheaders_result = mitm_addon.requestheaders(flow)
-        assert requestheaders_result is not None
-        await requestheaders_result
+        await await_requestheaders_result(requestheaders_result)
 
         usage.write_pending_snapshot(flush_request_id="request-headers")
         assert_pending(

--- a/crates/runner/mitm-addon/tests/test_request_handler_usage_tracking.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_usage_tracking.py
@@ -123,6 +123,7 @@ def _write_billable_x_tracking_registry(
     tmp_path: Path,
     *,
     include_encrypted_secrets: bool = True,
+    vm_fields: dict[str, object] | None = None,
 ) -> Path:
     return _write_registry(
         tmp_path,
@@ -142,6 +143,7 @@ def _write_billable_x_tracking_registry(
             },
             billable_firewalls=[_X_FIREWALL_NAME],
             include_encrypted_secrets=include_encrypted_secrets,
+            vm_fields=vm_fields,
         ),
     )
 
@@ -312,6 +314,51 @@ async def test_billable_flow_error_releases_tracking_after_request(
         reports=0,
         flush_request_id="request-1",
     )
+
+
+async def test_header_phase_streamed_billable_flow_error_releases_tracking(
+    tmp_path,
+    usage_pending_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+):
+    reg_path = _write_billable_x_tracking_registry(
+        tmp_path,
+        vm_fields={"captureNetworkBodies": True},
+    )
+    flow = _x_tracking_flow(real_flow)
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers(),
+    ):
+        requestheaders_result = mitm_addon.requestheaders(flow)
+        assert requestheaders_result is not None
+        await requestheaders_result
+
+        usage.write_pending_snapshot(flush_request_id="request-headers")
+        assert_pending(
+            usage_pending_path,
+            flows=1,
+            buffered=0,
+            reports=0,
+            flush_request_id="request-headers",
+        )
+
+        flow.error = Error("connection reset")
+        mitm_addon.error(flow)
+
+    usage.write_pending_snapshot(flush_request_id="after-error")
+    assert_pending(
+        usage_pending_path,
+        flows=0,
+        buffered=0,
+        reports=0,
+        flush_request_id="after-error",
+    )
+    assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
+    assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
 
 
 async def test_duplicate_terminal_hooks_do_not_double_decrement_usage_flow(

--- a/crates/runner/mitm-addon/tests/test_request_headers_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_headers_handler.py
@@ -1,5 +1,6 @@
 """Tests for requestheaders() request-stream setup."""
 
+import asyncio
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -485,6 +486,61 @@ async def test_firewall_allow_header_auth_failure_falls_back_to_request_hook(
     assert flow.response is not None
     assert flow.response.status_code == 424
     assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "connector_not_configured"
+
+
+async def test_firewall_allow_header_auth_cancellation_restores_probe_state(
+    tmp_path, real_flow, mitm_ctx, headers
+):
+    reg_path = _write_registry(
+        tmp_path,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            api_entry={
+                "base": "https://api.github.com",
+                "auth": {"headers": {"Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"}},
+                "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+            },
+            network_policy={
+                "allow": ["full-access"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "allow",
+            },
+            vm_fields={"captureNetworkBodies": True},
+        ),
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="api.github.com",
+        method="POST",
+        path="/repos/octocat/hello",
+        request_headers=headers(
+            ("Host", "api.github.com"),
+            ("X-Client", "original"),
+            ("Content-Length", str(STREAM_BUFFER_LIMIT + 1)),
+        ),
+    )
+    get_headers = AsyncMock(side_effect=asyncio.CancelledError)
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        patch.object(auth, "get_firewall_headers", get_headers),
+    ):
+        requestheaders_result = mitm_addon.requestheaders(flow)
+        assert requestheaders_result is not None
+        with pytest.raises(asyncio.CancelledError):
+            await requestheaders_result
+
+    get_headers.assert_awaited_once()
+    _assert_no_request_stream(flow)
+    assert flow.request.headers["X-Client"] == "original"
+    assert "Authorization" not in flow.request.headers
+    assert metadata_keys.VM_RUN_ID not in flow.metadata
+    assert metadata_keys.ORIGINAL_URL not in flow.metadata
+    assert metadata_keys.HTTP_REQUEST_START_MONOTONIC not in flow.metadata
+    assert metadata_keys.FIREWALL_BASE not in flow.metadata
+    assert metadata_keys.FIREWALL_API_ID not in flow.metadata
 
 
 @pytest.mark.parametrize(

--- a/crates/runner/mitm-addon/tests/test_request_headers_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_headers_handler.py
@@ -9,13 +9,13 @@ import auth
 import firewall_auth_client as auth_client
 import flow_metadata_keys as metadata_keys
 import mitm_addon
-from auth import MAX_AUTH_BASE_REQUEST_BODY_BYTES
 from body_limits import STREAM_BUFFER_LIMIT
 from tests.request_handler_helpers import (
     _single_firewall_vm,
     _vm_without_firewalls,
     _write_registry,
 )
+from tests.requestheaders_helpers import await_requestheaders_result
 
 _BROWSER_USER_AGENT = (
     "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
@@ -375,8 +375,7 @@ async def test_capture_enabled_firewall_allow_header_auth_installs_request_strea
         fake_firewall_headers(headers={"Authorization": "Bearer resolved"}) as auth_fetch,
     ):
         requestheaders_result = mitm_addon.requestheaders(flow)
-        assert requestheaders_result is not None
-        await requestheaders_result
+        await await_requestheaders_result(requestheaders_result)
 
         assert callable(flow.request.stream)
         assert metadata_keys.REQUEST_STREAM_BUFFER in flow.metadata
@@ -473,8 +472,7 @@ async def test_firewall_allow_header_auth_failure_falls_back_to_request_hook(
         patch.object(auth, "get_firewall_headers", get_headers),
     ):
         requestheaders_result = mitm_addon.requestheaders(flow)
-        assert requestheaders_result is not None
-        await requestheaders_result
+        await await_requestheaders_result(requestheaders_result)
 
         _assert_no_request_stream(flow)
         assert flow.response is None
@@ -528,9 +526,8 @@ async def test_firewall_allow_header_auth_cancellation_restores_probe_state(
         patch.object(auth, "get_firewall_headers", get_headers),
     ):
         requestheaders_result = mitm_addon.requestheaders(flow)
-        assert requestheaders_result is not None
         with pytest.raises(asyncio.CancelledError):
-            await requestheaders_result
+            await await_requestheaders_result(requestheaders_result)
 
     get_headers.assert_awaited_once()
     _assert_no_request_stream(flow)
@@ -595,8 +592,7 @@ async def test_capture_enabled_body_dependent_firewall_auth_does_not_install_req
         patch.object(auth, "get_firewall_headers", get_headers),
     ):
         requestheaders_result = mitm_addon.requestheaders(flow)
-        assert requestheaders_result is not None
-        await requestheaders_result
+        await await_requestheaders_result(requestheaders_result)
 
     get_headers.assert_not_called()
     _assert_no_request_stream(flow)
@@ -670,7 +666,7 @@ def test_auth_base_requestheaders_rejection_does_not_install_request_stream(
         path="/",
         request_headers=headers(
             ("Host", "placeholder.example.com"),
-            ("Content-Length", str(MAX_AUTH_BASE_REQUEST_BODY_BYTES + 1)),
+            ("Content-Length", str(auth.MAX_AUTH_BASE_REQUEST_BODY_BYTES + 1)),
         ),
     )
 

--- a/crates/runner/mitm-addon/tests/test_request_headers_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_headers_handler.py
@@ -1,5 +1,11 @@
 """Tests for requestheaders() request-stream setup."""
 
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import auth
+import firewall_auth_client as auth_client
 import flow_metadata_keys as metadata_keys
 import mitm_addon
 from auth import MAX_AUTH_BASE_REQUEST_BODY_BYTES
@@ -324,8 +330,17 @@ def test_non_stream_requestheaders_probe_restores_request_metadata(tmp_path, rea
     assert metadata_keys.CAPTURE_BODY not in flow.metadata
 
 
-def test_capture_enabled_firewall_allow_does_not_install_request_stream(
-    tmp_path, real_flow, mitm_ctx
+@pytest.mark.parametrize(
+    "request_header_pairs",
+    [
+        [("Content-Length", str(STREAM_BUFFER_LIMIT + 1))],
+        [("Transfer-Encoding", "chunked")],
+        [],
+    ],
+    ids=["large-content-length", "chunked", "unknown-length"],
+)
+async def test_capture_enabled_firewall_allow_header_auth_installs_request_stream(
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers, request_header_pairs
 ):
     reg_path = _write_registry(
         tmp_path,
@@ -349,12 +364,185 @@ def test_capture_enabled_firewall_allow_does_not_install_request_stream(
         with_response=False,
         client_ip="10.200.0.5",
         host="api.github.com",
+        method="POST",
         path="/repos/octocat/hello",
+        request_headers=headers(("Host", "api.github.com"), *request_header_pairs),
     )
 
-    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
-        mitm_addon.requestheaders(flow)
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers(headers={"Authorization": "Bearer resolved"}) as auth_fetch,
+    ):
+        requestheaders_result = mitm_addon.requestheaders(flow)
+        assert requestheaders_result is not None
+        await requestheaders_result
 
+        assert callable(flow.request.stream)
+        assert metadata_keys.REQUEST_STREAM_BUFFER in flow.metadata
+        assert flow.request.headers["Authorization"] == "Bearer resolved"
+        assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+        assert flow.metadata[metadata_keys.FIREWALL_BASE] == "https://api.github.com"
+        assert flow.metadata[metadata_keys.FIREWALL_NAME] == "github"
+
+        await mitm_addon.request(flow)
+
+    auth_fetch.assert_awaited_once()
+    assert mitm_addon._REQUEST_CLASSIFICATION not in flow.metadata
+    assert flow.metadata[metadata_keys.REQUEST_STREAM_COMPLETE] is True
+
+
+def test_capture_enabled_firewall_allow_small_bounded_body_does_not_install_request_stream(
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+):
+    reg_path = _write_registry(
+        tmp_path,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            api_entry={
+                "base": "https://api.github.com",
+                "auth": {"headers": {"Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"}},
+                "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+            },
+            network_policy={
+                "allow": ["full-access"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "allow",
+            },
+            vm_fields={"captureNetworkBodies": True},
+        ),
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="api.github.com",
+        method="POST",
+        path="/repos/octocat/hello",
+        request_headers=headers(("Host", "api.github.com"), ("Content-Length", "4")),
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as auth_fetch,
+    ):
+        assert mitm_addon.requestheaders(flow) is None
+
+    auth_fetch.assert_not_called()
+    _assert_no_request_stream(flow)
+    assert metadata_keys.VM_RUN_ID not in flow.metadata
+    assert metadata_keys.ORIGINAL_URL not in flow.metadata
+
+
+async def test_firewall_allow_header_auth_failure_falls_back_to_request_hook(
+    tmp_path, real_flow, mitm_ctx, headers
+):
+    reg_path = _write_registry(
+        tmp_path,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            api_entry={
+                "base": "https://api.github.com",
+                "auth": {"headers": {"Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"}},
+                "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+            },
+            network_policy={
+                "allow": ["full-access"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "allow",
+            },
+            vm_fields={"captureNetworkBodies": True},
+        ),
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="api.github.com",
+        method="POST",
+        path="/repos/octocat/hello",
+        request_headers=headers(
+            ("Host", "api.github.com"),
+            ("Content-Length", str(STREAM_BUFFER_LIMIT + 1)),
+        ),
+    )
+    get_headers = AsyncMock(side_effect=auth_client.ConnectorNotConfiguredError("not linked"))
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        patch.object(auth, "get_firewall_headers", get_headers),
+    ):
+        requestheaders_result = mitm_addon.requestheaders(flow)
+        assert requestheaders_result is not None
+        await requestheaders_result
+
+        _assert_no_request_stream(flow)
+        assert flow.response is None
+        assert metadata_keys.FIREWALL_BASE not in flow.metadata
+
+        await mitm_addon.request(flow)
+
+    assert get_headers.await_count == 2
+    assert flow.response is not None
+    assert flow.response.status_code == 424
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "connector_not_configured"
+
+
+@pytest.mark.parametrize(
+    "auth_config",
+    [
+        {"headers": {}, "base": "${{ secrets.WEBHOOK_URL }}"},
+        {
+            "awsSigv4": {
+                "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
+                "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
+            }
+        },
+    ],
+    ids=["auth-base", "aws-sigv4"],
+)
+async def test_capture_enabled_body_dependent_firewall_auth_does_not_install_request_stream(
+    tmp_path, real_flow, mitm_ctx, headers, auth_config
+):
+    reg_path = _write_registry(
+        tmp_path,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            api_entry={
+                "base": "https://api.github.com",
+                "auth": auth_config,
+                "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+            },
+            network_policy={
+                "allow": ["full-access"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "allow",
+            },
+            vm_fields={"captureNetworkBodies": True},
+        ),
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="api.github.com",
+        method="POST",
+        path="/repos/octocat/hello",
+        request_headers=headers(
+            ("Host", "api.github.com"),
+            ("Content-Length", str(STREAM_BUFFER_LIMIT + 1)),
+        ),
+    )
+    get_headers = AsyncMock()
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        patch.object(auth, "get_firewall_headers", get_headers),
+    ):
+        requestheaders_result = mitm_addon.requestheaders(flow)
+        assert requestheaders_result is not None
+        await requestheaders_result
+
+    get_headers.assert_not_called()
     _assert_no_request_stream(flow)
     assert metadata_keys.VM_RUN_ID not in flow.metadata
     assert metadata_keys.ORIGINAL_URL not in flow.metadata

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -25,7 +25,11 @@ from tests.jsonl_log_helpers import (
     jsonl_exists_after_flush,
     read_jsonl_entries_after_flush,
 )
-from tests.request_handler_helpers import _vm_without_firewalls, _write_registry
+from tests.request_handler_helpers import (
+    _single_firewall_vm,
+    _vm_without_firewalls,
+    _write_registry,
+)
 from tests.timestamp_helpers import assert_utc_millisecond_timestamp
 
 
@@ -1004,6 +1008,68 @@ class TestResponseHandler:
             mitm_addon.response(flow)
 
         entry = read_jsonl_entries_after_flush(Path(log_path))[0]
+        assert entry["request_size"] == len(body)
+        assert entry["request_body"] == "x" * STREAM_BUFFER_LIMIT
+        assert entry["request_body_encoding"] == "utf-8"
+        assert entry["request_body_truncated"] is True
+        assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
+        assert flow.request.stream is False
+
+    async def test_firewalled_streamed_request_logs_size_and_capture_body(
+        self, tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+    ):
+        reg_path = _write_registry(
+            tmp_path,
+            vm_info=_single_firewall_vm(
+                tmp_path,
+                api_entry={
+                    "base": "https://api.github.com",
+                    "auth": {"headers": {"Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"}},
+                    "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+                },
+                network_policy={
+                    "allow": ["full-access"],
+                    "deny": [],
+                    "ask": [],
+                    "unknownPolicy": "allow",
+                },
+                vm_fields={"captureNetworkBodies": True},
+            ),
+        )
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="api.github.com",
+            method="POST",
+            path="/repos/octocat/hello",
+            request_headers=headers(
+                ("Host", "api.github.com"),
+                ("Content-Type", "text/plain"),
+                ("Content-Length", str(STREAM_BUFFER_LIMIT + 17)),
+            ),
+        )
+        body = b"x" * (STREAM_BUFFER_LIMIT + 17)
+
+        with (
+            mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+            fake_firewall_headers(headers={"Authorization": "Bearer resolved"}) as auth_fetch,
+        ):
+            requestheaders_result = mitm_addon.requestheaders(flow)
+            assert requestheaders_result is not None
+            await requestheaders_result
+            stream = flow.request.stream
+            assert callable(stream)
+            assert stream(body[:123]) == body[:123]
+            assert stream(body[123:]) == body[123:]
+            flow.response = tutils.tresp(
+                status_code=200,
+                headers=header_map({"content-length": "0", "content-type": "application/json"}),
+            )
+            mitm_addon.response(flow)
+
+        auth_fetch.assert_awaited_once()
+        entry = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")[0]
         assert entry["request_size"] == len(body)
         assert entry["request_body"] == "x" * STREAM_BUFFER_LIMIT
         assert entry["request_body_encoding"] == "utf-8"

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -1133,6 +1133,62 @@ class TestResponseHandler:
         assert entry["request_body_encoding"] == "utf-8"
         assert entry["request_body_truncated"] is True
 
+    async def test_firewalled_empty_incomplete_streamed_request_marks_capture_truncated(
+        self, tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+    ):
+        reg_path = _write_registry(
+            tmp_path,
+            vm_info=_single_firewall_vm(
+                tmp_path,
+                api_entry={
+                    "base": "https://api.github.com",
+                    "auth": {"headers": {"Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"}},
+                    "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+                },
+                network_policy={
+                    "allow": ["full-access"],
+                    "deny": [],
+                    "ask": [],
+                    "unknownPolicy": "allow",
+                },
+                vm_fields={"captureNetworkBodies": True},
+            ),
+        )
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="api.github.com",
+            method="POST",
+            path="/repos/octocat/hello",
+            request_headers=headers(
+                ("Host", "api.github.com"),
+                ("Content-Type", "application/json"),
+                ("Content-Length", str(STREAM_BUFFER_LIMIT + 1)),
+            ),
+        )
+
+        with (
+            mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+            fake_firewall_headers(headers={"Authorization": "Bearer resolved"}),
+        ):
+            requestheaders_result = mitm_addon.requestheaders(flow)
+            await await_requestheaders_result(requestheaders_result)
+            assert callable(flow.request.stream)
+            flow.response = tutils.tresp(
+                status_code=200,
+                headers=header_map({"content-length": "0", "content-type": "application/json"}),
+            )
+            mitm_addon.response(flow)
+
+        entry = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")[0]
+        assert entry["request_size"] == 0
+        assert "request_body" not in entry
+        assert "request_body_encoding" not in entry
+        assert entry["request_body_truncated"] is True
+        assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
+        assert flow.request.stream is False
+
     async def test_unknown_length_get_without_body_logs_zero_request_size(
         self, tmp_path, real_flow, mitm_ctx
     ):

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -1078,6 +1078,62 @@ class TestResponseHandler:
         assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
         assert flow.request.stream is False
 
+    async def test_firewalled_partial_streamed_request_marks_capture_truncated(
+        self, tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+    ):
+        reg_path = _write_registry(
+            tmp_path,
+            vm_info=_single_firewall_vm(
+                tmp_path,
+                api_entry={
+                    "base": "https://api.github.com",
+                    "auth": {"headers": {"Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"}},
+                    "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+                },
+                network_policy={
+                    "allow": ["full-access"],
+                    "deny": [],
+                    "ask": [],
+                    "unknownPolicy": "allow",
+                },
+                vm_fields={"captureNetworkBodies": True},
+            ),
+        )
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="api.github.com",
+            method="POST",
+            path="/repos/octocat/hello",
+            request_headers=headers(
+                ("Host", "api.github.com"),
+                ("Content-Type", "application/json"),
+                ("Content-Length", str(STREAM_BUFFER_LIMIT + 1)),
+            ),
+        )
+
+        with (
+            mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+            fake_firewall_headers(headers={"Authorization": "Bearer resolved"}),
+        ):
+            requestheaders_result = mitm_addon.requestheaders(flow)
+            assert requestheaders_result is not None
+            await requestheaders_result
+            stream = flow.request.stream
+            assert callable(stream)
+            assert stream(b'{"partial":true') == b'{"partial":true'
+            flow.response = tutils.tresp(
+                status_code=200,
+                headers=header_map({"content-length": "0", "content-type": "application/json"}),
+            )
+            mitm_addon.response(flow)
+
+        entry = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")[0]
+        assert entry["request_size"] == len(b'{"partial":true')
+        assert entry["request_body"] == '{"partial":true'
+        assert entry["request_body_encoding"] == "utf-8"
+        assert entry["request_body_truncated"] is True
+
     async def test_unknown_length_get_without_body_logs_zero_request_size(
         self, tmp_path, real_flow, mitm_ctx
     ):

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -30,6 +30,7 @@ from tests.request_handler_helpers import (
     _vm_without_firewalls,
     _write_registry,
 )
+from tests.requestheaders_helpers import await_requestheaders_result
 from tests.timestamp_helpers import assert_utc_millisecond_timestamp
 
 
@@ -1056,8 +1057,7 @@ class TestResponseHandler:
             fake_firewall_headers(headers={"Authorization": "Bearer resolved"}) as auth_fetch,
         ):
             requestheaders_result = mitm_addon.requestheaders(flow)
-            assert requestheaders_result is not None
-            await requestheaders_result
+            await await_requestheaders_result(requestheaders_result)
             stream = flow.request.stream
             assert callable(stream)
             assert stream(body[:123]) == body[:123]
@@ -1117,8 +1117,7 @@ class TestResponseHandler:
             fake_firewall_headers(headers={"Authorization": "Bearer resolved"}),
         ):
             requestheaders_result = mitm_addon.requestheaders(flow)
-            assert requestheaders_result is not None
-            await requestheaders_result
+            await await_requestheaders_result(requestheaders_result)
             stream = flow.request.stream
             assert callable(stream)
             assert stream(b'{"partial":true') == b'{"partial":true'

--- a/crates/runner/mitm-addon/tests/x_connector_usage/test_writes.py
+++ b/crates/runner/mitm-addon/tests/x_connector_usage/test_writes.py
@@ -198,6 +198,31 @@ def test_tweet_create_refines_from_complete_stream_capture(x_usage, tmp_path, re
     assert p["quantity"] == 1
 
 
+def test_tweet_create_refines_from_complete_stream_capture_when_raw_content_is_empty(
+    x_usage, tmp_path, real_flow
+):
+    flow = x_usage.make_flow(
+        real_flow,
+        tmp_path,
+        path="/2/tweets",
+        body=json.dumps({"data": {"id": "1"}}).encode(),
+        status=201,
+        permission="tweet.write",
+        rule="POST /2/tweets",
+    )
+    flow.request.method = "POST"
+    flow.request.raw_content = b""
+    request_streaming.configure_request_stream(flow)
+    stream = flow.request.stream
+    assert callable(stream)
+    assert stream(b'{"text":"hello world"}') == b'{"text":"hello world"}'
+    flow.metadata[metadata_keys.REQUEST_STREAM_COMPLETE] = True
+
+    p = x_usage.call_and_get_single_billing(flow)
+    assert p["category"] == "content.create"
+    assert p["quantity"] == 1
+
+
 def test_tweet_create_incomplete_stream_capture_stays_conservative(x_usage, tmp_path, real_flow):
     flow = x_usage.make_flow(
         real_flow,

--- a/crates/runner/mitm-addon/tests/x_connector_usage/test_writes.py
+++ b/crates/runner/mitm-addon/tests/x_connector_usage/test_writes.py
@@ -7,6 +7,8 @@ from unittest.mock import patch
 
 import pytest
 
+import flow_metadata_keys as metadata_keys
+import request_streaming
 from body_limits import STREAM_BUFFER_LIMIT
 from tests.jsonl_log_helpers import (
     jsonl_exists_after_flush,
@@ -168,6 +170,75 @@ def test_tweet_create_raw_body_over_cap_stays_conservative(x_usage, tmp_path, re
         request_body=request_body,
     )
     flow.request.method = "POST"
+    p = x_usage.call_and_get_single_billing(flow)
+    assert p["category"] == "content.create_with_url"
+    assert p["quantity"] == 1
+
+
+def test_tweet_create_refines_from_complete_stream_capture(x_usage, tmp_path, real_flow):
+    flow = x_usage.make_flow(
+        real_flow,
+        tmp_path,
+        path="/2/tweets",
+        body=json.dumps({"data": {"id": "1"}}).encode(),
+        status=201,
+        permission="tweet.write",
+        rule="POST /2/tweets",
+    )
+    flow.request.method = "POST"
+    flow.request.raw_content = None
+    request_streaming.configure_request_stream(flow)
+    stream = flow.request.stream
+    assert callable(stream)
+    assert stream(b'{"text":"hello world"}') == b'{"text":"hello world"}'
+    flow.metadata[metadata_keys.REQUEST_STREAM_COMPLETE] = True
+
+    p = x_usage.call_and_get_single_billing(flow)
+    assert p["category"] == "content.create"
+    assert p["quantity"] == 1
+
+
+def test_tweet_create_incomplete_stream_capture_stays_conservative(x_usage, tmp_path, real_flow):
+    flow = x_usage.make_flow(
+        real_flow,
+        tmp_path,
+        path="/2/tweets",
+        body=json.dumps({"data": {"id": "1"}}).encode(),
+        status=201,
+        permission="tweet.write",
+        rule="POST /2/tweets",
+    )
+    flow.request.method = "POST"
+    flow.request.raw_content = None
+    request_streaming.configure_request_stream(flow)
+    stream = flow.request.stream
+    assert callable(stream)
+    assert stream(b'{"text":"hello world"}') == b'{"text":"hello world"}'
+
+    p = x_usage.call_and_get_single_billing(flow)
+    assert p["category"] == "content.create_with_url"
+    assert p["quantity"] == 1
+
+
+def test_tweet_create_truncated_stream_capture_stays_conservative(x_usage, tmp_path, real_flow):
+    flow = x_usage.make_flow(
+        real_flow,
+        tmp_path,
+        path="/2/tweets",
+        body=json.dumps({"data": {"id": "1"}}).encode(),
+        status=201,
+        permission="tweet.write",
+        rule="POST /2/tweets",
+    )
+    flow.request.method = "POST"
+    flow.request.raw_content = None
+    request_streaming.configure_request_stream(flow)
+    stream = flow.request.stream
+    assert callable(stream)
+    request_body = b"{" + b'"text":"' + b"x" * STREAM_BUFFER_LIMIT + b'"}'
+    assert stream(request_body) == request_body
+    flow.metadata[metadata_keys.REQUEST_STREAM_COMPLETE] = True
+
     p = x_usage.call_and_get_single_billing(flow)
     assert p["category"] == "content.create_with_url"
     assert p["quantity"] == 1

--- a/crates/runner/mitm-addon/tests/x_connector_usage/test_writes.py
+++ b/crates/runner/mitm-addon/tests/x_connector_usage/test_writes.py
@@ -223,6 +223,57 @@ def test_tweet_create_refines_from_complete_stream_capture_when_raw_content_is_e
     assert p["quantity"] == 1
 
 
+def test_tweet_create_complete_stream_capture_overrides_stale_raw_content(
+    x_usage, tmp_path, real_flow
+):
+    flow = x_usage.make_flow(
+        real_flow,
+        tmp_path,
+        path="/2/tweets",
+        body=json.dumps({"data": {"id": "1"}}).encode(),
+        status=201,
+        permission="tweet.write",
+        rule="POST /2/tweets",
+        request_body=b'{"text":"https://example.com"}',
+    )
+    flow.request.method = "POST"
+    request_streaming.configure_request_stream(flow)
+    stream = flow.request.stream
+    assert callable(stream)
+    assert stream(b'{"text":"hello world"}') == b'{"text":"hello world"}'
+    flow.metadata[metadata_keys.REQUEST_STREAM_COMPLETE] = True
+
+    p = x_usage.call_and_get_single_billing(flow)
+    assert p["category"] == "content.create"
+    assert p["quantity"] == 1
+
+
+def test_tweet_create_truncated_stream_capture_ignores_stale_raw_content(
+    x_usage, tmp_path, real_flow
+):
+    flow = x_usage.make_flow(
+        real_flow,
+        tmp_path,
+        path="/2/tweets",
+        body=json.dumps({"data": {"id": "1"}}).encode(),
+        status=201,
+        permission="tweet.write",
+        rule="POST /2/tweets",
+        request_body=b'{"text":"hello world"}',
+    )
+    flow.request.method = "POST"
+    request_streaming.configure_request_stream(flow)
+    stream = flow.request.stream
+    assert callable(stream)
+    request_body = b"{" + b'"text":"' + b"x" * STREAM_BUFFER_LIMIT + b'"}'
+    assert stream(request_body) == request_body
+    flow.metadata[metadata_keys.REQUEST_STREAM_COMPLETE] = True
+
+    p = x_usage.call_and_get_single_billing(flow)
+    assert p["category"] == "content.create_with_url"
+    assert p["quantity"] == 1
+
+
 def test_tweet_create_incomplete_stream_capture_stays_conservative(x_usage, tmp_path, real_flow):
     flow = x_usage.make_flow(
         real_flow,


### PR DESCRIPTION
## Summary
- enable bounded request stream capture for large or unknown-size `firewall_allow` requests after successful header/query auth in `requestheaders()`
- keep auth.base, AWS SigV4, auth failures, and other body-dependent paths on the existing buffered request hook path
- expose complete request stream bodies to X billing only after the request hook confirms the streamed body is complete

Closes #18907

## Tests
- `python3 -m py_compile crates/runner/mitm-addon/src/auth.py crates/runner/mitm-addon/src/mitm_addon.py crates/runner/mitm-addon/src/request_streaming.py crates/runner/mitm-addon/src/flow_metadata_keys.py crates/runner/mitm-addon/src/usage/providers/connectors/x.py crates/runner/mitm-addon/tests/test_request_headers_handler.py crates/runner/mitm-addon/tests/test_response_handler.py crates/runner/mitm-addon/tests/test_request_handler_usage_tracking.py crates/runner/mitm-addon/tests/x_connector_usage/test_writes.py`
- `ruff check src tests`
- `basedpyright`
- `pytest tests/test_request_headers_handler.py`
- `pytest tests/test_request_headers_handler.py tests/x_connector_usage/test_writes.py`
- `pytest tests/test_request_handler_firewall_dispatch.py tests/test_request_handler_usage_tracking.py tests/test_response_handler.py`
- `pytest tests/`