### PR TITLE
perf: add runner queue-to-claim timing

### DIFF
--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -2,7 +2,7 @@
 
 use std::borrow::Cow;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
@@ -36,7 +36,17 @@ struct ClaimRequestTelemetry {
     #[serde(skip_serializing_if = "Option::is_none")]
     local_admission_to_claim_request_ms: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    poll_due_to_job_discovered_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    poll_http_request_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     poll_reason: Option<String>,
+}
+
+#[derive(Debug)]
+struct PollApiResult {
+    job: Option<Job>,
+    http_request_elapsed: Duration,
 }
 
 // ---------------------------------------------------------------------------
@@ -135,6 +145,7 @@ impl JobProvider for ApiProvider {
                 .wait_for_poll_due(&self.cancel, POLL_SLOW, POLL_FAST)
                 .await?;
             let reason = due.reason();
+            let poll_due_started_at = Instant::now();
 
             let held_session_states = self.held_session_states.lock().await.clone();
             let poll_result = tokio::select! {
@@ -142,11 +153,14 @@ impl JobProvider for ApiProvider {
                 () = self.cancel.cancelled() => {
                     return None;
                 }
-                result = self.api.poll(&self.group, &self.profiles, &held_session_states) => result,
+                result = self.api.poll(&self.group, &self.profiles, &held_session_states, reason) => result,
             };
 
             match poll_result {
-                Ok(Some(job)) => {
+                Ok(PollApiResult {
+                    job: Some(job),
+                    http_request_elapsed,
+                }) => {
                     let record = self
                         .poll_wakeups
                         .record_poll_result(due, PollOutcome::JobFound, POLL_WAKEUP_RETRY)
@@ -170,10 +184,11 @@ impl JobProvider for ApiProvider {
                     info!(run_id = %job.run_id, %profile, poll_reason = ?reason, "poll: job found");
                     return Some(
                         JobCandidate::new(job.run_id, profile)
-                            .with_poll_reason(poll_reason_value(reason)),
+                            .with_poll_reason(poll_reason_value(reason))
+                            .with_poll_timing(poll_due_started_at.elapsed(), http_request_elapsed),
                     );
                 }
-                Ok(None) => {
+                Ok(PollApiResult { job: None, .. }) => {
                     self.poll_wakeups
                         .record_poll_result(due, PollOutcome::Empty, POLL_WAKEUP_RETRY)
                         .await;
@@ -300,17 +315,10 @@ impl ApiClient {
         group: &str,
         profiles: &[String],
         held_session_states: &[HeldSessionState],
-    ) -> RunnerResult<Option<Job>> {
-        let mut body = serde_json::json!({ "group": group, "profiles": profiles });
-        let held_session_states = poll_held_session_states(held_session_states);
-        if !held_session_states.is_empty()
-            && let Some(obj) = body.as_object_mut()
-        {
-            obj.insert(
-                "heldSessionStates".to_string(),
-                serde_json::json!(&*held_session_states),
-            );
-        }
+        reason: PollReason,
+    ) -> RunnerResult<PollApiResult> {
+        let body = poll_request_body(group, profiles, held_session_states, reason);
+        let poll_started_at = Instant::now();
         let resp = send_api(
             self.http
                 .request_route(routes::runners::poll::POLL, &self.token)
@@ -322,7 +330,10 @@ impl ApiClient {
         let resp = check_api_status(resp, "poll").await?;
         let poll: PollResponse = decode_api_json(resp, "poll").await?;
 
-        Ok(poll.job)
+        Ok(PollApiResult {
+            job: poll.job,
+            http_request_elapsed: poll_started_at.elapsed(),
+        })
     }
 
     /// Send a heartbeat with runner state. Uses a short timeout (3s) to
@@ -436,9 +447,38 @@ fn claim_request_body(candidate: &JobCandidate) -> ClaimRequestBody {
             local_admission_to_claim_request_ms: candidate
                 .local_admission_elapsed()
                 .map(duration_ms),
+            poll_due_to_job_discovered_ms: candidate
+                .poll_due_to_job_discovered_elapsed()
+                .map(duration_ms),
+            poll_http_request_ms: candidate.poll_http_request_elapsed().map(duration_ms),
             poll_reason: candidate.poll_reason().map(String::from),
         },
     }
+}
+
+fn poll_request_body(
+    group: &str,
+    profiles: &[String],
+    held_session_states: &[HeldSessionState],
+    reason: PollReason,
+) -> serde_json::Value {
+    let mut body = serde_json::json!({
+        "group": group,
+        "profiles": profiles,
+        "telemetry": {
+            "pollReason": poll_reason_value(reason),
+        },
+    });
+    let held_session_states = poll_held_session_states(held_session_states);
+    if !held_session_states.is_empty()
+        && let Some(obj) = body.as_object_mut()
+    {
+        obj.insert(
+            "heldSessionStates".to_string(),
+            serde_json::json!(&*held_session_states),
+        );
+    }
+    body
 }
 
 fn poll_reason_value(reason: PollReason) -> &'static str {
@@ -858,6 +898,17 @@ mod tests {
     }
 
     #[test]
+    fn poll_request_body_serializes_poll_reason_telemetry() {
+        let profiles = vec![crate::profile::DEFAULT_PROFILE.to_string()];
+        let body = poll_request_body("vm0/test", &profiles, &[], PollReason::Immediate);
+
+        assert_eq!(body["group"], "vm0/test");
+        assert_eq!(body["profiles"][0], crate::profile::DEFAULT_PROFILE);
+        assert_eq!(body["telemetry"]["pollReason"], "immediate");
+        assert!(body.get("heldSessionStates").is_none());
+    }
+
+    #[test]
     fn claim_request_body_serializes_runner_timing() {
         let now = std::time::Instant::now();
         let candidate = JobCandidate::new_with_timing_for_test(
@@ -866,7 +917,8 @@ mod tests {
             now.checked_sub(Duration::from_millis(25)).unwrap(),
             Some(now.checked_sub(Duration::from_millis(7)).unwrap()),
         )
-        .with_poll_reason("deferred");
+        .with_poll_reason("deferred")
+        .with_poll_timing(Duration::from_millis(19), Duration::from_millis(11));
 
         let body = serde_json::to_value(claim_request_body(&candidate)).unwrap();
 
@@ -880,6 +932,8 @@ mod tests {
                 .as_u64()
                 .is_some_and(|value| value >= 7)
         );
+        assert_eq!(body["telemetry"]["pollDueToJobDiscoveredMs"], 19);
+        assert_eq!(body["telemetry"]["pollHttpRequestMs"], 11);
         assert_eq!(body["telemetry"]["pollReason"], "deferred");
     }
 
@@ -905,6 +959,8 @@ mod tests {
                 .get("localAdmissionToClaimRequestMs")
                 .is_none()
         );
+        assert!(body["telemetry"].get("pollDueToJobDiscoveredMs").is_none());
+        assert!(body["telemetry"].get("pollHttpRequestMs").is_none());
         assert!(body["telemetry"].get("pollReason").is_none());
     }
 
@@ -989,6 +1045,8 @@ mod tests {
 
         assert_eq!(discovered.run_id(), run_id);
         assert_eq!(discovered.profile_name(), "vm0/default");
+        assert!(discovered.poll_due_to_job_discovered_elapsed().is_some());
+        assert!(discovered.poll_http_request_elapsed().is_some());
         mock.assert_async().await;
     }
 
@@ -1051,7 +1109,10 @@ mod tests {
             .await;
         let api = api_client_for_server(&server);
 
-        let err = api.poll("default", &[], &[]).await.unwrap_err();
+        let err = api
+            .poll("default", &[], &[], PollReason::Immediate)
+            .await
+            .unwrap_err();
 
         assert_api_error(err, "poll 503 Service Unavailable: poll unavailable");
         mock.assert_async().await;
@@ -1068,7 +1129,10 @@ mod tests {
             .await;
         let api = api_client_for_server(&server);
 
-        let err = api.poll("default", &[], &[]).await.unwrap_err();
+        let err = api
+            .poll("default", &[], &[], PollReason::Immediate)
+            .await
+            .unwrap_err();
 
         match err {
             RunnerError::Api(message) => assert!(
@@ -1090,6 +1154,9 @@ mod tests {
                     .json_body(serde_json::json!({
                         "group": "default",
                         "profiles": ["vm0/default"],
+                        "telemetry": {
+                            "pollReason": "deferred"
+                        },
                         "heldSessionStates": [
                             {
                                 "sessionId": "sess-a",
@@ -1108,12 +1175,17 @@ mod tests {
             last_completed_at: "2026-05-28T00:00:00.000Z".to_string(),
         }];
 
-        let job = api
-            .poll("default", &profiles, &held_session_states)
+        let poll = api
+            .poll(
+                "default",
+                &profiles,
+                &held_session_states,
+                PollReason::Deferred,
+            )
             .await
             .unwrap();
 
-        assert!(job.is_none());
+        assert!(poll.job.is_none());
         mock.assert_async().await;
     }
 
@@ -1380,6 +1452,7 @@ mod tests {
                 "default",
                 &[crate::profile::DEFAULT_PROFILE.to_string()],
                 &[],
+                PollReason::Immediate,
             )
             .await
             .unwrap_err();

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -309,7 +309,7 @@ impl ApiClient {
         Self { http, token }
     }
 
-    /// Poll for a pending job. Returns `Ok(None)` when no work is available.
+    /// Poll for a pending job. The response contains `job: None` when no work is available.
     async fn poll(
         &self,
         group: &str,

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -31,6 +31,8 @@ pub struct JobCandidate {
     discovered_at: Instant,
     local_admission_started_at: Option<Instant>,
     poll_reason: Option<String>,
+    poll_due_to_job_discovered_elapsed: Option<Duration>,
+    poll_http_request_elapsed: Option<Duration>,
 }
 
 impl JobCandidate {
@@ -42,6 +44,8 @@ impl JobCandidate {
             discovered_at: Instant::now(),
             local_admission_started_at: None,
             poll_reason: None,
+            poll_due_to_job_discovered_elapsed: None,
+            poll_http_request_elapsed: None,
         }
     }
 
@@ -53,6 +57,8 @@ impl JobCandidate {
             discovered_at: Instant::now(),
             local_admission_started_at: None,
             poll_reason: None,
+            poll_due_to_job_discovered_elapsed: None,
+            poll_http_request_elapsed: None,
         }
     }
 
@@ -85,8 +91,26 @@ impl JobCandidate {
         self.poll_reason.as_deref()
     }
 
+    pub(crate) fn poll_due_to_job_discovered_elapsed(&self) -> Option<Duration> {
+        self.poll_due_to_job_discovered_elapsed
+    }
+
+    pub(crate) fn poll_http_request_elapsed(&self) -> Option<Duration> {
+        self.poll_http_request_elapsed
+    }
+
     pub(crate) fn with_poll_reason(mut self, poll_reason: impl Into<String>) -> Self {
         self.poll_reason = Some(poll_reason.into());
+        self
+    }
+
+    pub(crate) fn with_poll_timing(
+        mut self,
+        poll_due_to_job_discovered_elapsed: Duration,
+        poll_http_request_elapsed: Duration,
+    ) -> Self {
+        self.poll_due_to_job_discovered_elapsed = Some(poll_due_to_job_discovered_elapsed);
+        self.poll_http_request_elapsed = Some(poll_http_request_elapsed);
         self
     }
 
@@ -104,6 +128,8 @@ impl JobCandidate {
             discovered_at,
             local_admission_started_at,
             poll_reason: None,
+            poll_due_to_job_discovered_elapsed: None,
+            poll_http_request_elapsed: None,
         }
     }
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -2305,37 +2305,39 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
       expect(serialized).not.toContain(claimed.body.sandboxToken);
       expect(serialized).not.toContain(apiKey.token);
     }
-    expect(context.mocks.axiom.sdkIngest).toHaveBeenCalledWith(
-      "vm0-sandbox-op-log-dev",
-      [
-        expect.objectContaining({
-          op_type: "job_discovered_to_claim_request",
-          sandbox_type: "runner",
-          run_id: first.runId,
-          duration_ms: 1234,
-          success: true,
-          profile: "vm0/default",
-          auth_type: "user",
-          poll_reason: "deferred",
-        }),
-      ],
-    );
-    expect(context.mocks.axiom.sdkIngest).toHaveBeenCalledWith(
-      "vm0-sandbox-op-log-dev",
-      [
-        expect.objectContaining({
-          op_type: "local_admission_to_claim_request",
-          sandbox_type: "runner",
-          run_id: first.runId,
-          duration_ms: 56,
-          success: true,
-          profile: "vm0/default",
-          auth_type: "user",
-          poll_reason: "deferred",
-        }),
-      ],
-    );
     const timingEvents = sandboxOperationEventsForRun(first.runId);
+    expect(
+      timingEvents.find((event) => {
+        return event.op_type === "job_discovered_to_claim_request";
+      }),
+    ).toStrictEqual(
+      expect.objectContaining({
+        op_type: "job_discovered_to_claim_request",
+        sandbox_type: "runner",
+        run_id: first.runId,
+        duration_ms: 1234,
+        success: true,
+        profile: "vm0/default",
+        auth_type: "user",
+        poll_reason: "deferred",
+      }),
+    );
+    expect(
+      timingEvents.find((event) => {
+        return event.op_type === "local_admission_to_claim_request";
+      }),
+    ).toStrictEqual(
+      expect.objectContaining({
+        op_type: "local_admission_to_claim_request",
+        sandbox_type: "runner",
+        run_id: first.runId,
+        duration_ms: 56,
+        success: true,
+        profile: "vm0/default",
+        auth_type: "user",
+        poll_reason: "deferred",
+      }),
+    );
     for (const actionType of RUNNER_POLL_TIMING_ACTION_TYPES) {
       const events = timingEvents.filter((event) => {
         return event.op_type === actionType;

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -85,6 +85,15 @@ const CLAIM_ROUTE_TIMING_ACTION_TYPES = [
   ...CLAIM_ROUTE_TOP_LEVEL_TIMING_ACTION_TYPES,
   ...CLAIM_ROUTE_TRANSITION_TIMING_ACTION_TYPES,
 ] as const;
+const RUNNER_POLL_TIMING_ACTION_TYPES = [
+  "runner_poll_pending_job_lookup",
+  "runner_poll_request_to_job_response",
+  "runner_queue_to_poll_response",
+] as const;
+const RUNNER_CLAIM_TELEMETRY_ACTION_TYPES = [
+  "runner_poll_due_to_job_discovered",
+  "runner_poll_http_request",
+] as const;
 const API_DISPATCH_TIMING_ACTION_TYPES = [
   "api_dispatch_pre_create_agent_run",
   "api_dispatch_check_org_tier",
@@ -126,6 +135,16 @@ const FORBIDDEN_API_DISPATCH_TIMING_KEYS = [
   "environment",
   "execution_context",
   "presigned_url",
+  "runner_id",
+  "runnerId",
+  "target_runner_id",
+  "targetRunnerId",
+  "cli_agent_session_id",
+  "cliAgentSessionId",
+  "sandbox_token",
+  "sandboxToken",
+  "api_key",
+  "apiKey",
 ] as const;
 const FORBIDDEN_CLAIM_ROUTE_TIMING_KEYS = [
   "org_id",
@@ -257,7 +276,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function apiDispatchTimingEventsForRun(
+function sandboxOperationEventsForRun(
   runId: string,
 ): readonly Record<string, unknown>[] {
   return context.mocks.axiom.sdkIngest.mock.calls.flatMap((call) => {
@@ -267,12 +286,7 @@ function apiDispatchTimingEventsForRun(
       return [];
     }
     return events.filter((event): event is Record<string, unknown> => {
-      return (
-        isRecord(event) &&
-        event.run_id === runId &&
-        typeof event.op_type === "string" &&
-        event.op_type.startsWith("api_dispatch_")
-      );
+      return isRecord(event) && event.run_id === runId;
     });
   });
 }
@@ -280,20 +294,22 @@ function apiDispatchTimingEventsForRun(
 function claimRouteTimingEventsForRun(
   runId: string,
 ): readonly Record<string, unknown>[] {
-  return context.mocks.axiom.sdkIngest.mock.calls.flatMap((call) => {
-    const dataset = call[0];
-    const events = call[1];
-    if (dataset !== "vm0-sandbox-op-log-dev" || !Array.isArray(events)) {
-      return [];
-    }
-    return events.filter((event): event is Record<string, unknown> => {
-      return (
-        isRecord(event) &&
-        event.run_id === runId &&
-        typeof event.op_type === "string" &&
-        event.op_type.startsWith("claim_route_")
-      );
-    });
+  return sandboxOperationEventsForRun(runId).filter((event) => {
+    return (
+      typeof event.op_type === "string" &&
+      event.op_type.startsWith("claim_route_")
+    );
+  });
+}
+
+function apiDispatchTimingEventsForRun(
+  runId: string,
+): readonly Record<string, unknown>[] {
+  return sandboxOperationEventsForRun(runId).filter((event) => {
+    return (
+      typeof event.op_type === "string" &&
+      event.op_type.startsWith("api_dispatch_")
+    );
   });
 }
 
@@ -2200,7 +2216,11 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
     });
     const polled = await api.requestPollRunnerAs(
       bearer,
-      { group: runnerGroup, profiles: ["vm0/default"] },
+      {
+        group: runnerGroup,
+        profiles: ["vm0/default"],
+        telemetry: { pollReason: "deferred" },
+      },
       [200],
     );
     if (polled.status !== 200) {
@@ -2216,6 +2236,8 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
         telemetry: {
           jobDiscoveredToClaimRequestMs: 1234,
           localAdmissionToClaimRequestMs: 56,
+          pollDueToJobDiscoveredMs: 789,
+          pollHttpRequestMs: 321,
           pollReason: "deferred",
         },
       },
@@ -2313,6 +2335,89 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
         }),
       ],
     );
+    const timingEvents = sandboxOperationEventsForRun(first.runId);
+    for (const actionType of RUNNER_POLL_TIMING_ACTION_TYPES) {
+      const events = timingEvents.filter((event) => {
+        return event.op_type === actionType;
+      });
+      expect(events).toHaveLength(1);
+      const event = events[0];
+      if (!event) {
+        throw new Error(`Missing ${actionType} timing event`);
+      }
+      expect(event).toStrictEqual(
+        expect.objectContaining({
+          source: "api",
+          sandbox_type: "runner",
+          run_id: first.runId,
+          success: true,
+          runner_group: runnerGroup,
+          profile: "vm0/default",
+          auth_type: "user",
+          poll_reason: "deferred",
+        }),
+      );
+      expect(event.duration_ms).toStrictEqual(expect.any(Number));
+      expect(Number(event.duration_ms)).toBeGreaterThanOrEqual(0);
+    }
+    for (const actionType of RUNNER_CLAIM_TELEMETRY_ACTION_TYPES) {
+      const events = timingEvents.filter((event) => {
+        return event.op_type === actionType;
+      });
+      expect(events).toHaveLength(1);
+      const event = events[0];
+      if (!event) {
+        throw new Error(`Missing ${actionType} timing event`);
+      }
+      expect(event).toStrictEqual(
+        expect.objectContaining({
+          source: "api",
+          sandbox_type: "runner",
+          run_id: first.runId,
+          success: true,
+          runner_group: runnerGroup,
+          profile: "vm0/default",
+          auth_type: "user",
+          poll_reason: "deferred",
+        }),
+      );
+    }
+    expect(
+      timingEvents.find((event) => {
+        return event.op_type === "runner_poll_due_to_job_discovered";
+      }),
+    ).toStrictEqual(
+      expect.objectContaining({
+        duration_ms: 789,
+      }),
+    );
+    expect(
+      timingEvents.find((event) => {
+        return event.op_type === "runner_poll_http_request";
+      }),
+    ).toStrictEqual(
+      expect.objectContaining({
+        duration_ms: 321,
+      }),
+    );
+    const newRunnerTimingActionTypes = new Set<string>([
+      ...RUNNER_POLL_TIMING_ACTION_TYPES,
+      ...RUNNER_CLAIM_TELEMETRY_ACTION_TYPES,
+    ]);
+    for (const event of timingEvents.filter((timingEvent) => {
+      return (
+        typeof timingEvent.op_type === "string" &&
+        newRunnerTimingActionTypes.has(timingEvent.op_type)
+      );
+    })) {
+      for (const forbiddenKey of FORBIDDEN_API_DISPATCH_TIMING_KEYS) {
+        expect(event).not.toHaveProperty(forbiddenKey);
+      }
+      const serialized = JSON.stringify(event);
+      expect(serialized).not.toContain("user runner job one");
+      expect(serialized).not.toContain(claimed.body.sandboxToken);
+      expect(serialized).not.toContain(apiKey.token);
+    }
     const claimedRun = await api.readRun(actor, first.runId);
     expect(claimedRun.status).toBe("running");
 

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -25,10 +25,7 @@ import {
   createRunnerGroupRealtimeToken,
   publishRunChangedForUserSafely,
 } from "../external/realtime";
-import {
-  recordSandboxOperation,
-  recordSandboxOperations,
-} from "../external/sandbox-op-log";
+import { recordSandboxOperations } from "../external/sandbox-op-log";
 import { now, nowDate } from "../external/time";
 import { badRequestMessage, conflict, notFound } from "../../lib/error";
 import { logger } from "../../lib/log";
@@ -40,6 +37,10 @@ import type { RouteEntry } from "../route";
 import { tapError } from "../utils";
 
 const L = logger("Runners");
+
+type SandboxOperationAttrs = Parameters<
+  typeof recordSandboxOperations
+>[0][number];
 
 const STALE_RUNNER_THRESHOLD_MS = 5 * 60 * 1000;
 const INVALID_EXECUTION_CONTEXT_ERROR =
@@ -938,59 +939,65 @@ async function recordClaimTimingMetrics(args: {
   if (args.pollReason) {
     dimensions.poll_reason = args.pollReason;
   }
-  recordClaimTimingOperation(
-    args.runId,
-    "api_to_runner_queue",
-    args.apiToRunnerQueueMs,
-    dimensions,
-  );
-  recordClaimTimingOperation(
-    args.runId,
-    "runner_queue_to_claim_request",
-    args.runnerQueueToClaimRequestMs,
-    dimensions,
-  );
-  recordClaimTimingOperation(
-    args.runId,
-    "api_to_claim_request",
-    args.apiToClaimRequestMs,
-    dimensions,
-  );
-  recordClaimTimingOperation(
-    args.runId,
-    "api_to_claim",
-    args.apiToClaimMs,
-    dimensions,
-  );
-  recordClaimTimingOperation(
-    args.runId,
-    "claim_request_to_running",
-    args.claimRequestToRunningMs,
-    dimensions,
-  );
-  recordClaimTimingOperation(
-    args.runId,
-    "job_discovered_to_claim_request",
-    args.jobDiscoveredToClaimRequestMs,
-    dimensions,
-  );
-  recordClaimTimingOperation(
-    args.runId,
-    "local_admission_to_claim_request",
-    args.localAdmissionToClaimRequestMs,
-    dimensions,
-  );
-  recordClaimTimingOperation(
-    args.runId,
-    "runner_poll_due_to_job_discovered",
-    args.pollDueToJobDiscoveredMs,
-    dimensions,
-  );
-  recordClaimTimingOperation(
-    args.runId,
-    "runner_poll_http_request",
-    args.pollHttpRequestMs,
-    dimensions,
+  recordSandboxOperations(
+    [
+      claimTimingOperation(
+        args.runId,
+        "api_to_runner_queue",
+        args.apiToRunnerQueueMs,
+        dimensions,
+      ),
+      claimTimingOperation(
+        args.runId,
+        "runner_queue_to_claim_request",
+        args.runnerQueueToClaimRequestMs,
+        dimensions,
+      ),
+      claimTimingOperation(
+        args.runId,
+        "api_to_claim_request",
+        args.apiToClaimRequestMs,
+        dimensions,
+      ),
+      claimTimingOperation(
+        args.runId,
+        "api_to_claim",
+        args.apiToClaimMs,
+        dimensions,
+      ),
+      claimTimingOperation(
+        args.runId,
+        "claim_request_to_running",
+        args.claimRequestToRunningMs,
+        dimensions,
+      ),
+      claimTimingOperation(
+        args.runId,
+        "job_discovered_to_claim_request",
+        args.jobDiscoveredToClaimRequestMs,
+        dimensions,
+      ),
+      claimTimingOperation(
+        args.runId,
+        "local_admission_to_claim_request",
+        args.localAdmissionToClaimRequestMs,
+        dimensions,
+      ),
+      claimTimingOperation(
+        args.runId,
+        "runner_poll_due_to_job_discovered",
+        args.pollDueToJobDiscoveredMs,
+        dimensions,
+      ),
+      claimTimingOperation(
+        args.runId,
+        "runner_poll_http_request",
+        args.pollHttpRequestMs,
+        dimensions,
+      ),
+    ].filter((operation): operation is SandboxOperationAttrs => {
+      return operation !== undefined;
+    }),
   );
   args.claimRouteTiming.flush({
     runId: args.runId,
@@ -1001,23 +1008,23 @@ async function recordClaimTimingMetrics(args: {
   });
 }
 
-function recordClaimTimingOperation(
+function claimTimingOperation(
   runId: string,
   actionType: string,
   durationMs: number | undefined,
   dimensions: Record<string, string>,
-): void {
+): SandboxOperationAttrs | undefined {
   if (durationMs === undefined) {
-    return;
+    return undefined;
   }
-  recordSandboxOperation({
+  return {
     sandboxType: "runner",
     actionType,
     durationMs,
     success: true,
     runId,
     dimensions,
-  });
+  };
 }
 
 const scheduleClaimFailedSideEffects$ = command(

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -304,7 +304,63 @@ function uniqueHeldCliAgentSessionIds(
   ];
 }
 
+function recordPollTimingMetrics(args: {
+  readonly runId: string;
+  readonly runnerGroup: string;
+  readonly profile: string;
+  readonly authType: RunnerAuthContext["type"];
+  readonly pollReason: string | undefined;
+  readonly queueCreatedAtMs: number;
+  readonly pollRequestStartedAtMs: number;
+  readonly pendingJobLookupStartedAtMs: number;
+  readonly pendingJobLookupFinishedAtMs: number;
+  readonly pollResponseAtMs: number;
+}): void {
+  const dimensions: Record<string, string> = {
+    runner_group: args.runnerGroup,
+    profile: args.profile,
+    auth_type: args.authType,
+  };
+  if (args.pollReason) {
+    dimensions.poll_reason = args.pollReason;
+  }
+
+  recordSandboxOperations([
+    {
+      sandboxType: "runner",
+      actionType: "runner_poll_pending_job_lookup",
+      durationMs: Math.max(
+        0,
+        args.pendingJobLookupFinishedAtMs - args.pendingJobLookupStartedAtMs,
+      ),
+      success: true,
+      runId: args.runId,
+      dimensions,
+    },
+    {
+      sandboxType: "runner",
+      actionType: "runner_poll_request_to_job_response",
+      durationMs: Math.max(
+        0,
+        args.pollResponseAtMs - args.pollRequestStartedAtMs,
+      ),
+      success: true,
+      runId: args.runId,
+      dimensions,
+    },
+    {
+      sandboxType: "runner",
+      actionType: "runner_queue_to_poll_response",
+      durationMs: Math.max(0, args.pollResponseAtMs - args.queueCreatedAtMs),
+      success: true,
+      runId: args.runId,
+      dimensions,
+    },
+  ]);
+}
+
 const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const pollRequestStartedAtMs = now();
   const auth = await set(runnerAuth$, get(authorization$), signal);
   signal.throwIfAborted();
   if (!auth) {
@@ -359,6 +415,7 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       : [runnerJobQueue.createdAt];
 
   const db = set(writeDb$);
+  const pendingJobLookupStartedAtMs = now();
   const [pendingJob] = await db
     .select({
       runId: runnerJobQueue.runId,
@@ -368,6 +425,7 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       vars: agentRuns.vars,
       resumedFromCheckpointId: agentRuns.resumedFromCheckpointId,
       profile: runnerJobQueue.profile,
+      createdAt: runnerJobQueue.createdAt,
     })
     .from(runnerJobQueue)
     .innerJoin(agentRuns, eq(runnerJobQueue.runId, agentRuns.id))
@@ -375,10 +433,25 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     .orderBy(...orderClauses)
     .limit(1);
   signal.throwIfAborted();
+  const pendingJobLookupFinishedAtMs = now();
 
   if (!pendingJob) {
     return { status: 200 as const, body: { job: null } };
   }
+
+  const pollResponseAtMs = now();
+  recordPollTimingMetrics({
+    runId: pendingJob.runId,
+    runnerGroup: group,
+    profile: pendingJob.profile,
+    authType: auth.type,
+    pollReason: body.data.telemetry?.pollReason,
+    queueCreatedAtMs: pendingJob.createdAt.getTime(),
+    pollRequestStartedAtMs,
+    pendingJobLookupStartedAtMs,
+    pendingJobLookupFinishedAtMs,
+    pollResponseAtMs,
+  });
 
   return {
     status: 200 as const,
@@ -762,6 +835,8 @@ function scheduleSuccessfulClaimSideEffects(args: {
     | {
         readonly jobDiscoveredToClaimRequestMs?: number;
         readonly localAdmissionToClaimRequestMs?: number;
+        readonly pollDueToJobDiscoveredMs?: number;
+        readonly pollHttpRequestMs?: number;
         readonly pollReason?: string;
       }
     | undefined;
@@ -799,6 +874,8 @@ function scheduleSuccessfulClaimSideEffects(args: {
       args.telemetry?.jobDiscoveredToClaimRequestMs,
     localAdmissionToClaimRequestMs:
       args.telemetry?.localAdmissionToClaimRequestMs,
+    pollDueToJobDiscoveredMs: args.telemetry?.pollDueToJobDiscoveredMs,
+    pollHttpRequestMs: args.telemetry?.pollHttpRequestMs,
     pollReason: args.telemetry?.pollReason,
     claimRouteTiming: args.claimRouteTiming,
   });
@@ -817,6 +894,8 @@ function scheduleClaimSucceededSideEffects(args: {
   readonly claimRequestToRunningMs: number;
   readonly jobDiscoveredToClaimRequestMs: number | undefined;
   readonly localAdmissionToClaimRequestMs: number | undefined;
+  readonly pollDueToJobDiscoveredMs: number | undefined;
+  readonly pollHttpRequestMs: number | undefined;
   readonly pollReason: string | undefined;
   readonly claimRouteTiming: ClaimRouteTimingCollector;
 }): void {
@@ -845,6 +924,8 @@ async function recordClaimTimingMetrics(args: {
   readonly claimRequestToRunningMs: number;
   readonly jobDiscoveredToClaimRequestMs: number | undefined;
   readonly localAdmissionToClaimRequestMs: number | undefined;
+  readonly pollDueToJobDiscoveredMs: number | undefined;
+  readonly pollHttpRequestMs: number | undefined;
   readonly pollReason: string | undefined;
   readonly claimRouteTiming: ClaimRouteTimingCollector;
 }): Promise<void> {
@@ -897,6 +978,18 @@ async function recordClaimTimingMetrics(args: {
     args.runId,
     "local_admission_to_claim_request",
     args.localAdmissionToClaimRequestMs,
+    dimensions,
+  );
+  recordClaimTimingOperation(
+    args.runId,
+    "runner_poll_due_to_job_discovered",
+    args.pollDueToJobDiscoveredMs,
+    dimensions,
+  );
+  recordClaimTimingOperation(
+    args.runId,
+    "runner_poll_http_request",
+    args.pollHttpRequestMs,
     dimensions,
   );
   args.claimRouteTiming.flush({

--- a/turbo/apps/api/src/signals/services/__tests__/runner-dispatch.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/runner-dispatch.service.test.ts
@@ -14,6 +14,26 @@ const context = testContext();
 const store = createStore();
 const SESSION_LAST_COMPLETED_AT = "2026-05-28T00:00:00.000Z";
 const NEWER_SESSION_LAST_COMPLETED_AT = "2026-05-28T00:00:01.000Z";
+const NOTIFICATION_TIMING_ACTION_TYPES = [
+  "runner_notification_target_lookup",
+  "runner_notification_realtime_publish",
+] as const;
+const FORBIDDEN_NOTIFICATION_TIMING_KEYS = [
+  "runner_id",
+  "runnerId",
+  "target_runner_id",
+  "targetRunnerId",
+  "cli_agent_session_id",
+  "cliAgentSessionId",
+  "user_id",
+  "userId",
+  "org_id",
+  "orgId",
+  "prompt",
+  "vars",
+  "secrets",
+  "environment",
+] as const;
 
 interface RunnerStateFixture {
   readonly runnerId: string;
@@ -24,6 +44,58 @@ interface RunnerStateFixture {
   readonly heldSessionStates?: { sessionId: string; lastCompletedAt: string }[];
   readonly mode?: string;
   readonly lastSeenAt?: Date;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function sandboxOperationEventsForRun(
+  runId: string,
+): readonly Record<string, unknown>[] {
+  return context.mocks.axiom.sdkIngest.mock.calls.flatMap((call) => {
+    const dataset = call[0];
+    const events = call[1];
+    if (dataset !== "vm0-sandbox-op-log-dev" || !Array.isArray(events)) {
+      return [];
+    }
+    return events.filter((event): event is Record<string, unknown> => {
+      return isRecord(event) && event.run_id === runId;
+    });
+  });
+}
+
+function expectNotificationTiming(args: {
+  readonly runId: string;
+  readonly notificationTarget: "targeted" | "broadcast";
+}): void {
+  const events = sandboxOperationEventsForRun(args.runId);
+  for (const actionType of NOTIFICATION_TIMING_ACTION_TYPES) {
+    const matching = events.filter((event) => {
+      return event.op_type === actionType;
+    });
+    expect(matching).toHaveLength(1);
+    const event = matching[0];
+    if (!event) {
+      throw new Error(`Missing ${actionType} timing event`);
+    }
+    expect(event).toStrictEqual(
+      expect.objectContaining({
+        source: "api",
+        sandbox_type: "runner",
+        run_id: args.runId,
+        success: true,
+        runner_group: "vm0/test",
+        profile: "vm0/default",
+        notification_target: args.notificationTarget,
+      }),
+    );
+    expect(event.duration_ms).toStrictEqual(expect.any(Number));
+    expect(Number(event.duration_ms)).toBeGreaterThanOrEqual(0);
+    for (const forbiddenKey of FORBIDDEN_NOTIFICATION_TIMING_KEYS) {
+      expect(event).not.toHaveProperty(forbiddenKey);
+    }
+  }
 }
 
 describe("runner dispatch affinity", () => {
@@ -149,6 +221,7 @@ describe("runner dispatch affinity", () => {
       profile: "vm0/default",
       targetRunnerId,
     });
+    expectNotificationTiming({ runId, notificationTarget: "targeted" });
   });
 
   it("publishes targetRunnerId for the newest matching held session", async () => {
@@ -311,5 +384,6 @@ describe("runner dispatch affinity", () => {
       runId,
       profile: "vm0/default",
     });
+    expectNotificationTiming({ runId, notificationTarget: "broadcast" });
   });
 });

--- a/turbo/apps/api/src/signals/services/runner-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/runner-dispatch.service.ts
@@ -6,6 +6,7 @@ import { and, eq, gt } from "drizzle-orm";
 
 import type { ReadonlyDb } from "../external/db";
 import { publishRunnerJobNotification } from "../external/realtime";
+import { recordSandboxOperations } from "../external/sandbox-op-log";
 import { now } from "../external/time";
 import { settle } from "../utils";
 import { logger } from "../../lib/log";
@@ -93,9 +94,11 @@ export async function notifyRunnerJob(
     readonly cliAgentSessionId: string | null;
   },
 ): Promise<boolean> {
+  const targetLookupStartedAt = now();
   const target = await settle(
     findBestRunner(db, args.runnerGroup, args.profile, args.cliAgentSessionId),
   );
+  const targetLookupFinishedAt = now();
   const targetRunnerId = target.ok ? (target.value?.runnerId ?? null) : null;
   if (!target.ok) {
     L.warn("findBestRunner failed for run, using broadcast", {
@@ -104,10 +107,39 @@ export async function notifyRunnerJob(
     });
   }
 
-  return await publishRunnerJobNotification(
+  const notificationTarget = targetRunnerId ? "targeted" : "broadcast";
+  const publishStartedAt = now();
+  const published = await publishRunnerJobNotification(
     args.runnerGroup,
     args.runId,
     args.profile,
     targetRunnerId,
   );
+  const publishFinishedAt = now();
+
+  const dimensions = {
+    runner_group: args.runnerGroup,
+    profile: args.profile,
+    notification_target: notificationTarget,
+  };
+  recordSandboxOperations([
+    {
+      sandboxType: "runner",
+      actionType: "runner_notification_target_lookup",
+      durationMs: Math.max(0, targetLookupFinishedAt - targetLookupStartedAt),
+      success: target.ok,
+      runId: args.runId,
+      dimensions,
+    },
+    {
+      sandboxType: "runner",
+      actionType: "runner_notification_realtime_publish",
+      durationMs: Math.max(0, publishFinishedAt - publishStartedAt),
+      success: published,
+      runId: args.runId,
+      dimensions,
+    },
+  ]);
+
+  return published;
 }

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -46,6 +46,12 @@ export const runnerClaimPollReasonSchema = z.enum([
 const runnerClaimTelemetrySchema = z.object({
   jobDiscoveredToClaimRequestMs: z.number().int().nonnegative().optional(),
   localAdmissionToClaimRequestMs: z.number().int().nonnegative().optional(),
+  pollDueToJobDiscoveredMs: z.number().int().nonnegative().optional(),
+  pollHttpRequestMs: z.number().int().nonnegative().optional(),
+  pollReason: runnerClaimPollReasonSchema.optional(),
+});
+
+const runnerPollTelemetrySchema = z.object({
   pollReason: runnerClaimPollReasonSchema.optional(),
 });
 
@@ -101,6 +107,7 @@ export const runnersPollContract = c.router({
       group: runnerGroupSchema,
       profiles: z.array(z.string()).optional(),
       heldSessionStates: z.array(heldSessionStateSchema).max(1024).optional(),
+      telemetry: runnerPollTelemetrySchema.optional(),
     }),
     responses: {
       200: z.object({


### PR DESCRIPTION
Closes #18918.

## Summary
- add optional runner poll telemetry to identify the poll reason on `/runners/poll`
- record API-side notification and poll timing in sandbox operation logs with safe dimensions only
- send runner-side poll timing in the claim telemetry so queue-to-claim can be split around poll wakeup and HTTP poll phases

## Notes
- No database schema or migration changes.
- All new request fields are optional so old runners and old API deployments remain compatible.

## Tests
- `cargo test --manifest-path crates/Cargo.toml -p runner provider::api::tests`
- `cd turbo && pnpm -F api exec vitest run src/signals/services/__tests__/runner-dispatch.service.test.ts src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `cd turbo && pnpm -F api check-types`
- `cd turbo && pnpm -F @vm0/api-contracts check-types`
- `cd turbo && pnpm -F api lint`
- `cd turbo && pnpm -F @vm0/api-contracts lint`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `git diff --check`
- pre-commit: `knip`, `cargo fmt`, `cargo doc`, `cargo clippy`, full `check-types`
