### PR TITLE
fix: classify claude stream idle timeout failures

### DIFF
--- a/crates/agent-diagnostics/src/lib.rs
+++ b/crates/agent-diagnostics/src/lib.rs
@@ -240,6 +240,7 @@ pub enum FailureReason {
     InvalidCredentials,
     OutputTokenLimit,
     ProviderOverloaded,
+    ProviderStreamTimeout,
     ProviderServerError,
     ReconnectRequired,
     UsageLimit,
@@ -254,6 +255,7 @@ impl FailureReason {
             Self::InvalidCredentials => "invalid_credentials",
             Self::OutputTokenLimit => "output_token_limit",
             Self::ProviderOverloaded => "provider_overloaded",
+            Self::ProviderStreamTimeout => "provider_stream_timeout",
             Self::ProviderServerError => "provider_server_error",
             Self::ReconnectRequired => "reconnect_required",
             Self::UsageLimit => "usage_limit",
@@ -623,6 +625,28 @@ mod tests {
 
         let json = serde_json::to_value(&diagnostic).unwrap();
         assert_eq!(json["failureReason"], "provider_overloaded");
+
+        let round_trip: FailureDiagnostic = serde_json::from_value(json).unwrap();
+        assert_eq!(round_trip, diagnostic);
+    }
+
+    #[test]
+    fn failure_diagnostic_serializes_provider_stream_timeout_reason() {
+        assert_eq!(
+            FailureReason::ProviderStreamTimeout.as_str(),
+            "provider_stream_timeout"
+        );
+
+        let diagnostic = FailureDiagnostic::new(
+            FailureClass::CliNonzero,
+            AgentFramework::ClaudeCode,
+            PromptMetadata::from_prompt("debug failure"),
+        )
+        .with_cli_exit_code(1)
+        .with_failure_reason(FailureReason::ProviderStreamTimeout);
+
+        let json = serde_json::to_value(&diagnostic).unwrap();
+        assert_eq!(json["failureReason"], "provider_stream_timeout");
 
         let round_trip: FailureDiagnostic = serde_json::from_value(json).unwrap();
         assert_eq!(round_trip, diagnostic);

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -436,6 +436,11 @@ fn classify_cli_failure_reason(
         return Some(FailureReason::ProviderOverloaded);
     }
     if matches!(framework, AgentFramework::ClaudeCode)
+        && is_claude_result_provider_stream_timeout(source, &normalized)
+    {
+        return Some(FailureReason::ProviderStreamTimeout);
+    }
+    if matches!(framework, AgentFramework::ClaudeCode)
         && is_claude_provider_server_error(source, &normalized)
     {
         return Some(FailureReason::ProviderServerError);
@@ -504,6 +509,12 @@ fn is_claude_result_simple_provider_overloaded_error(
     normalized: &str,
 ) -> bool {
     source == FailureDetailSource::ClaudeResult && normalized.trim() == "api error: overloaded"
+}
+
+fn is_claude_result_provider_stream_timeout(source: FailureDetailSource, normalized: &str) -> bool {
+    source == FailureDetailSource::ClaudeResult
+        && normalized.contains("api error: stream idle timeout")
+        && normalized.contains("partial response received")
 }
 
 fn is_claude_provider_server_error(source: FailureDetailSource, normalized: &str) -> bool {
@@ -1604,11 +1615,44 @@ mod tests {
     }
 
     #[test]
-    fn cli_failure_reason_ignores_claude_result_stream_idle_timeout() {
+    fn cli_failure_reason_classifies_claude_result_stream_idle_timeout() {
         let reason = super::classify_cli_failure_reason(
             AgentFramework::ClaudeCode,
             FailureDetailSource::ClaudeResult,
             "API Error: Stream idle timeout - partial response received",
+        );
+
+        assert_eq!(reason, Some(FailureReason::ProviderStreamTimeout));
+    }
+
+    #[test]
+    fn cli_failure_reason_ignores_stream_idle_timeout_from_stderr() {
+        let reason = super::classify_cli_failure_reason(
+            AgentFramework::ClaudeCode,
+            FailureDetailSource::Stderr,
+            "API Error: Stream idle timeout - partial response received",
+        );
+
+        assert_eq!(reason, None);
+    }
+
+    #[test]
+    fn cli_failure_reason_ignores_codex_stream_idle_timeout() {
+        let reason = super::classify_cli_failure_reason(
+            AgentFramework::Codex,
+            FailureDetailSource::ClaudeResult,
+            "API Error: Stream idle timeout - partial response received",
+        );
+
+        assert_eq!(reason, None);
+    }
+
+    #[test]
+    fn cli_failure_reason_ignores_generic_claude_timeout() {
+        let reason = super::classify_cli_failure_reason(
+            AgentFramework::ClaudeCode,
+            FailureDetailSource::ClaudeResult,
+            "API Error: request timed out",
         );
 
         assert_eq!(reason, None);

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -512,9 +512,10 @@ fn is_claude_result_simple_provider_overloaded_error(
 }
 
 fn is_claude_result_provider_stream_timeout(source: FailureDetailSource, normalized: &str) -> bool {
+    let trimmed = normalized.trim();
     source == FailureDetailSource::ClaudeResult
-        && normalized.contains("api error: stream idle timeout")
-        && normalized.contains("partial response received")
+        && trimmed.starts_with("api error: stream idle timeout")
+        && trimmed.contains("partial response received")
 }
 
 fn is_claude_provider_server_error(source: FailureDetailSource, normalized: &str) -> bool {
@@ -1653,6 +1654,17 @@ mod tests {
             AgentFramework::ClaudeCode,
             FailureDetailSource::ClaudeResult,
             "API Error: request timed out",
+        );
+
+        assert_eq!(reason, None);
+    }
+
+    #[test]
+    fn cli_failure_reason_ignores_explanatory_stream_idle_timeout_text() {
+        let reason = super::classify_cli_failure_reason(
+            AgentFramework::ClaudeCode,
+            FailureDetailSource::ClaudeResult,
+            "Observed API Error: Stream idle timeout - partial response received in an earlier run",
         );
 
         assert_eq!(reason, None);

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -850,6 +850,7 @@ fn is_info_level_job_failure(diagnostic: &FailureDiagnostic) -> bool {
                     | FailureReason::InvalidCredentials
                     | FailureReason::OutputTokenLimit
                     | FailureReason::ProviderOverloaded
+                    | FailureReason::ProviderStreamTimeout
                     | FailureReason::ProviderServerError
                     | FailureReason::ReconnectRequired
                     | FailureReason::UsageLimit
@@ -1021,6 +1022,7 @@ mod tests {
             FailureReason::InvalidCredentials,
             FailureReason::OutputTokenLimit,
             FailureReason::ProviderOverloaded,
+            FailureReason::ProviderStreamTimeout,
             FailureReason::ProviderServerError,
             FailureReason::ReconnectRequired,
             FailureReason::UsageLimit,
@@ -1075,6 +1077,41 @@ mod tests {
     }
 
     #[test]
+    fn claude_result_provider_stream_timeout_logs_job_execution_failed_at_info() {
+        let diagnostic = FailureDiagnostic::new(
+            FailureClass::CliNonzero,
+            AgentFramework::ClaudeCode,
+            PromptMetadata::from_prompt("plain prompt"),
+        )
+        .with_cli_exit_code(1)
+        .with_failure_detail_source(FailureDetailSource::ClaudeResult)
+        .with_session_history_status(SessionHistoryStatus::Present)
+        .with_failure_reason(FailureReason::ProviderStreamTimeout);
+        let failure = executor::ExecutionFailure::new(
+            1,
+            "API Error: Stream idle timeout - partial response received",
+            Some(diagnostic),
+        );
+
+        let event = capture_job_failure_log(&failure);
+
+        assert_eq!(event.level, Level::INFO);
+        assert_eq!(
+            event.fields.get("message").map(String::as_str),
+            Some("job execution failed")
+        );
+        assert_field_eq(
+            &event,
+            "error",
+            "API Error: Stream idle timeout - partial response received",
+        );
+        assert_field_eq(&event, "failure_reason", "provider_stream_timeout");
+        assert_field_eq(&event, "failure_class", "cli_nonzero");
+        assert_field_eq(&event, "failure_framework", "claude_code");
+        assert_field_eq(&event, "failure_detail_source", "claude_result");
+    }
+
+    #[test]
     fn claude_zero_turn_no_history_logs_job_execution_failed_at_info() {
         let diagnostic = FailureDiagnostic::new(
             FailureClass::ClaudeZeroTurnNoHistory,
@@ -1108,6 +1145,7 @@ mod tests {
             FailureReason::InvalidCredentials,
             FailureReason::OutputTokenLimit,
             FailureReason::ProviderOverloaded,
+            FailureReason::ProviderStreamTimeout,
             FailureReason::ProviderServerError,
             FailureReason::ReconnectRequired,
             FailureReason::UsageLimit,


### PR DESCRIPTION
## Summary

- Add `provider_stream_timeout` as a structured failure reason.
- Classify only Claude Code `ClaudeResult` stream idle timeout failures with partial responses.
- Log `CliNonzero + provider_stream_timeout` job failures at info while keeping non-CLI failures at error.

Closes #18877

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p agent-diagnostics provider_stream_timeout`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent cli_failure_reason`
- `cargo test --manifest-path crates/Cargo.toml -p runner job_execution_failed`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo check --manifest-path crates/Cargo.toml -p runner -p guest-agent -p agent-diagnostics`