### PR TITLE
fix(desktop): avoid repeated web area ancestry reads

### DIFF
--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
@@ -1950,7 +1950,8 @@ func isSelectableElement(role roleName: String?, subrole: String?, selected: Boo
 func clickCapabilities(
     _ element: AXUIElement,
     actions actionList: [String]? = nil,
-    selected selectedValue: Bool? = nil
+    selected selectedValue: Bool? = nil,
+    webAreaMouseClick webAreaMouseClickOverride: Bool? = nil
 ) -> ElementClickCapabilities {
     let elementRole = role(element)
     let elementSubrole = stringValue(attribute(element, kAXSubroleAttribute as CFString))
@@ -1958,7 +1959,8 @@ func clickCapabilities(
     let elementSelected = selectedValue ?? boolValue(attribute(element, kAXSelectedAttribute as CFString))
     let frame = clickableFrame(element)
     let selectable = isSelectableElement(role: elementRole, subrole: elementSubrole, selected: elementSelected)
-    let webAreaMouseClick = shouldUseMouseClickForElement(element)
+    let webAreaMouseClick = webAreaMouseClickOverride
+        ?? shouldUseMouseClickForElement(element, role: elementRole)
     let mouseClickable = frame != nil && (webAreaMouseClick || selectable)
     return ElementClickCapabilities(
         role: elementRole,
@@ -3310,7 +3312,8 @@ func describe(
     depth: Int,
     nodeCount: inout Int,
     truncationReasons: inout [String],
-    ancestry: Set<CFHashCode> = []
+    ancestry: Set<CFHashCode> = [],
+    insideWebArea: Bool = false
 ) -> [String: Any]? {
     let elementHash = CFHash(element)
     if ancestry.contains(elementHash) {
@@ -3327,8 +3330,10 @@ func describe(
     nodeCount += 1
 
     var node: [String: Any] = ["id": id]
-    if let role = role(element) {
-        node["role"] = role
+    let elementRole = role(element)
+    let elementInsideWebArea = insideWebArea || elementRole == "AXWebArea"
+    if let elementRole {
+        node["role"] = elementRole
     }
     if let roleDescription = stringValue(attribute(element, kAXRoleDescriptionAttribute as CFString)) {
         node["roleDescription"] = roleDescription
@@ -3400,7 +3405,16 @@ func describe(
     if let bounds = bounds(element) {
         node["bounds"] = bounds
     }
-    setClickCapabilityFields(&node, capabilities: clickCapabilities(element, actions: actions, selected: selected))
+    let webAreaMouseClick = elementInsideWebArea && elementRole != "AXMenuBarItem" && elementRole != "AXMenuItem"
+    setClickCapabilityFields(
+        &node,
+        capabilities: clickCapabilities(
+            element,
+            actions: actions,
+            selected: selected,
+            webAreaMouseClick: webAreaMouseClick
+        )
+    )
 
     if depth >= limits.maxDepth {
         markTruncated(&truncationReasons, "max_depth")
@@ -3416,7 +3430,8 @@ func describe(
             depth: depth + 1,
             nodeCount: &nodeCount,
             truncationReasons: &truncationReasons,
-            ancestry: childAncestry
+            ancestry: childAncestry,
+            insideWebArea: elementInsideWebArea
         )
     }
     if !children.isEmpty {
@@ -4108,8 +4123,11 @@ func hasRoleInElementAncestry(_ element: AXUIElement, roleName: String) -> Bool 
     return false
 }
 
-func shouldUseMouseClickForElement(_ element: AXUIElement) -> Bool {
-    let elementRole = role(element)
+func shouldUseMouseClickForElement(
+    _ element: AXUIElement,
+    role elementRoleOverride: String? = nil
+) -> Bool {
+    let elementRole = elementRoleOverride ?? role(element)
     if elementRole == "AXMenuBarItem" || elementRole == "AXMenuItem" {
         return false
     }


### PR DESCRIPTION
## Summary\n- pass WebArea ancestry through the accessibility snapshot recursion\n- avoid re-reading AXParent for every snapshot node when marking web-area mouse-click fallbacks\n- keep element click resolution behavior unchanged outside snapshot construction\n\n## Validation\n- pnpm -F @vm0/desktop exec vitest run src/window-policy.test.ts\n- pnpm -F @vm0/desktop check-types\n- pnpm -F @vm0/desktop test:native (skips on linux)\n- swift test (not run: swift is not installed in this container)