### PR TITLE
fix: use figma api token header in builtin firewall

### DIFF
--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -66,6 +66,7 @@ _CLIENT_CREDENTIAL_HEADER_NAMES: frozenset[str] = frozenset(
         "x-cg-demo-api-key",
         "x-cg-pro-api-key",
         "x-faire-access-token",
+        "x-figma-token",
         "x-goog-api-key",
         "x-hume-api-key",
         "x-key",

--- a/crates/runner/mitm-addon/src/generated/builtin_firewalls/diagnostics.py
+++ b/crates/runner/mitm-addon/src/generated/builtin_firewalls/diagnostics.py
@@ -1447,7 +1447,7 @@ CONNECTOR_DIAGNOSTIC_FIREWALLS = json.loads(r"""[
     "apis": [
       {
         "authHeaderNames": [
-          "Authorization"
+          "X-Figma-Token"
         ],
         "authQueryParamNames": [],
         "base": "https://api.figma.com",

--- a/crates/runner/mitm-addon/src/generated/builtin_firewalls/figma_0.py
+++ b/crates/runner/mitm-addon/src/generated/builtin_firewalls/figma_0.py
@@ -8,7 +8,7 @@ JSON_PART = r"""{
     {
       "auth": {
         "headers": {
-          "Authorization": "Bearer ${{ secrets.FIGMA_TOKEN }}"
+          "X-Figma-Token": "${{ secrets.FIGMA_TOKEN }}"
         }
       },
       "base": "https://api.figma.com",

--- a/crates/runner/mitm-addon/tests/test_builtin_firewalls_catalog.py
+++ b/crates/runner/mitm-addon/tests/test_builtin_firewalls_catalog.py
@@ -131,6 +131,12 @@ def test_figma_firewall_uses_granular_permissions():
     assert "files:read" not in permissions
 
 
+def test_figma_builtin_firewall_uses_personal_access_token_header():
+    firewall = builtin_firewalls.BUILTIN_FIREWALLS["figma"]
+
+    assert firewall["apis"][0]["auth"]["headers"] == {"X-Figma-Token": "${{ secrets.FIGMA_TOKEN }}"}
+
+
 def test_figma_firewall_has_one_owner_per_route():
     firewall = builtin_firewalls.BUILTIN_FIREWALLS["figma"]
     route_owners: dict[tuple[str, str], str] = {}

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1261,7 +1261,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     expect(drained.body.concurrency.active).toBe(0);
   });
 
-  it("uses Figma personal access tokens in the X-Figma-Token firewall header", async () => {
+  it("uses the builtin Figma firewall for personal access tokens", async () => {
     const api = createRunsAutomationsApi(context);
     const connectors = createConnectorBddApi(context);
     const fw = createFirewallApi(context);
@@ -1294,12 +1294,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     expect(claim.secretConnectorMap).toMatchObject({ FIGMA_TOKEN: "figma" });
 
     const figmaEntry = findFirewallEntry(claim.firewalls, "figma");
-    expect(figmaEntry?.kind).toBe("inline");
-    expect(
-      inlineFirewallApis(claim.firewalls, "figma")[0]?.auth.headers,
-    ).toStrictEqual({
-      "X-Figma-Token": figmaTokenTemplate,
-    });
+    expect(figmaEntry).toStrictEqual({ kind: "builtin", name: "figma" });
 
     if (!claim.encryptedSecrets) {
       throw new Error("Expected the figma claim to carry encrypted secrets");

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -43,7 +43,6 @@ import {
   type FirewallExecutionMetadataConnectorType,
   type FirewallPermissionIndex,
 } from "@vm0/connectors/firewall-metadata/server";
-import { loadConnectorFirewall } from "@vm0/connectors/firewalls/runtime";
 import { getModelProviderRefreshMetadata } from "@vm0/connectors/auth-providers/model-provider-auth";
 import {
   extractSecretNamesFromApis,
@@ -547,7 +546,6 @@ interface ConnectorRuntimeContext {
   readonly vars: Record<string, string> | undefined;
   readonly secretConnectorMap: Record<string, string> | undefined;
   readonly connectorTypes: readonly ConnectorType[];
-  readonly connectorAuthMethods: Partial<Record<ConnectorType, string>>;
   readonly storedEnvironment: Record<string, string> | undefined;
 }
 
@@ -1923,7 +1921,6 @@ function emptyConnectorRuntimeContext(): ConnectorRuntimeContext {
     vars: undefined,
     secretConnectorMap: undefined,
     connectorTypes: [],
-    connectorAuthMethods: {},
     storedEnvironment: undefined,
   };
 }
@@ -2221,11 +2218,6 @@ async function loadStoredConnectorContext(
       connectorTypes: allowedConnectorRows.map((row) => {
         return row.connectorType;
       }),
-      connectorAuthMethods: Object.fromEntries(
-        allowedConnectorRows.map((row) => {
-          return [row.connectorType, row.authMethod];
-        }),
-      ),
       storedEnvironment: compactRecord(resolved.environment),
     };
   });
@@ -2523,36 +2515,6 @@ function inlineFirewallEntry(
   return { kind: "inline", firewall: runtimeFirewall(firewall) };
 }
 
-const FIGMA_API_TOKEN_TEMPLATE = ["$", "{{ secrets.FIGMA_TOKEN }}"].join("");
-const FIGMA_API_TOKEN_AUTH_HEADERS = Object.freeze({
-  "X-Figma-Token": FIGMA_API_TOKEN_TEMPLATE,
-});
-
-function figmaApiTokenFirewall(
-  firewall: ExpandedFirewallConfig,
-): ExpandedFirewallConfig {
-  return {
-    ...firewall,
-    apis: firewall.apis.map((api) => {
-      return {
-        ...api,
-        auth: {
-          ...api.auth,
-          headers: FIGMA_API_TOKEN_AUTH_HEADERS,
-        },
-      };
-    }),
-  };
-}
-
-async function loadFigmaApiTokenFirewall(): Promise<ExpandedFirewallConfig> {
-  const firewall = await loadConnectorFirewall("figma");
-  if (!firewall) {
-    throw new Error("Missing figma runtime firewall");
-  }
-  return figmaApiTokenFirewall(firewall);
-}
-
 function applyConnectorPolicies(
   connectorFirewalls: readonly ExpandedFirewallConfig[],
   policies: FirewallPolicies | undefined,
@@ -2689,7 +2651,6 @@ async function buildPermissionManifest(args: {
   readonly vars: Record<string, string> | undefined;
   readonly connectorVars?: Record<string, string>;
   readonly connectorTypes?: readonly ConnectorType[];
-  readonly connectorAuthMethods?: Partial<Record<ConnectorType, string>>;
   readonly customConnectorFirewalls?: readonly ExpandedFirewallConfig[];
 }): Promise<PermissionManifest | undefined> {
   const connectorTypes =
@@ -2702,62 +2663,18 @@ async function buildPermissionManifest(args: {
     isFirewallExecutionMetadataConnectorType,
   );
 
-  const builtinSources: BuiltinConnectorManifestSource[] = [];
-  const inlineConnectorFirewalls: ExpandedFirewallConfig[] = [];
-  const inlineConnectorDefaultPolicies = new Map<string, FirewallPolicy>();
-  const inlineConnectorBillableFirewalls: string[] = [];
-
-  const loadedConnectorSources = await Promise.all(
+  const builtinSources = await Promise.all(
     builtinConnectorTypes.map(async (type) => {
       const metadata = getRequiredFirewallExecutionMetadata(type);
       const permissionIndex = await loadRequiredFirewallPermissionIndex(type);
-      if (
-        type === "figma" &&
-        args.connectorAuthMethods?.[type] === "api-token"
-      ) {
-        return {
-          type,
-          metadata,
-          permissionIndex,
-          inlineFirewall: await loadFigmaApiTokenFirewall(),
-        };
-      }
-      return { type, metadata, permissionIndex, inlineFirewall: null };
+      return { metadata, permissionIndex };
     }),
   );
-  for (const source of loadedConnectorSources) {
-    if (source.inlineFirewall) {
-      inlineConnectorFirewalls.push(source.inlineFirewall);
-      inlineConnectorDefaultPolicies.set(
-        source.type,
-        defaultPolicyForPermissionIndex(source.permissionIndex),
-      );
-      if (source.metadata.billable) {
-        inlineConnectorBillableFirewalls.push(source.type);
-      }
-      continue;
-    }
-    builtinSources.push({
-      metadata: source.metadata,
-      permissionIndex: source.permissionIndex,
-    });
-  }
 
   const connectorManifest = applyBuiltinConnectorMetadataPolicies(
     builtinSources,
     args.permissionPolicies,
     connectorBaseUrlVars,
-  );
-  const inlineConnectorManifest = applyConnectorPolicies(
-    inlineConnectorFirewalls,
-    args.permissionPolicies,
-    inlineFirewallEntry,
-    (firewall, permissionNames) => {
-      return (
-        inlineConnectorDefaultPolicies.get(firewall.name) ??
-        allAllowPolicyForPermissions(permissionNames)
-      );
-    },
   );
   const resolvedCustomConnectorFirewalls = resolveFirewallBaseUrlVars(
     (args.customConnectorFirewalls ?? []).map(runtimeFirewall),
@@ -2778,7 +2695,6 @@ async function buildPermissionManifest(args: {
   const firewalls = [
     ...(providerManifest?.firewalls ?? []),
     ...connectorManifest.firewalls,
-    ...inlineConnectorManifest.firewalls,
     ...customConnectorManifest.firewalls,
   ];
 
@@ -2791,18 +2707,15 @@ async function buildPermissionManifest(args: {
     environmentSecretPlaceholders: mergeRecords(
       providerManifest?.environmentSecretPlaceholders,
       connectorManifest.environmentSecretPlaceholders,
-      firewallSecretPlaceholdersFromFirewalls(inlineConnectorFirewalls),
       firewallSecretPlaceholdersFromFirewalls(args.customConnectorFirewalls),
     ),
     billableFirewalls: [
       ...(providerManifest?.billableFirewalls ?? []),
       ...connectorManifest.billableFirewalls,
-      ...inlineConnectorBillableFirewalls,
     ],
     networkPolicies: {
       ...providerManifest?.networkPolicies,
       ...connectorManifest.networkPolicies,
-      ...inlineConnectorManifest.networkPolicies,
       ...customConnectorManifest.networkPolicies,
     },
   };
@@ -4533,7 +4446,6 @@ async function buildPreparedPermissionManifest(args: {
     vars: args.body.vars,
     connectorVars: args.connectorContext.vars,
     connectorTypes: args.connectorContext.connectorTypes,
-    connectorAuthMethods: args.connectorContext.connectorAuthMethods,
     customConnectorFirewalls: args.customConnectorContext.firewalls,
   });
 }

--- a/turbo/packages/firewalls-generator/src/figma.ts
+++ b/turbo/packages/firewalls-generator/src/figma.ts
@@ -216,7 +216,7 @@ function generateTypeScript(permissions: PermissionGroup[]): string {
     '      base: "https://api.figma.com",',
     "      auth: {",
     "        headers: {",
-    '          Authorization: "Bearer ${{ secrets.FIGMA_TOKEN }}",',
+    '          "X-Figma-Token": "${{ secrets.FIGMA_TOKEN }}",',
     "        },",
     "      },",
     "      permissions: [",


### PR DESCRIPTION
## Summary
- make the generated Figma firewall use the PAT `X-Figma-Token` auth header
- remove the run-creation Figma api-token inline firewall special case
- add runner builtin catalog coverage for the Figma auth header

## Testing
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "uses the builtin Figma firewall for personal access tokens"`
- `pnpm -F api exec vitest run src/signals/services/__tests__/firewall-metadata-import-boundary.test.ts`
- `pnpm -F @vm0/firewalls-generator exec vitest run src/__tests__/figma.test.ts`
- `python3 -m pytest tests/test_builtin_firewalls_catalog.py -q`
- `pnpm -F api check-types`
- `pnpm -F @vm0/firewalls-generator check-types`
- `pnpm -F api lint`
- pre-commit `pnpm check-types`