### PR TITLE
perf: bound auth base forwarding admission

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -24,6 +24,7 @@ from auth_base_forwarder import (
     forward_request,
     forwarded_auth_base_client_header_pairs,
     header_pairs,
+    release_forward_request_admission,
     resolved_auth_header_pairs,
 )
 from aws_sigv4 import AwsSigV4Credentials, AwsSigV4SigningError, sign_request
@@ -700,6 +701,12 @@ def _take_auth_base_forward_admission(
     return admission if isinstance(admission, AuthBaseForwardingAdmission) else None
 
 
+def _release_auth_base_forward_admission(flow: http.HTTPFlow) -> None:
+    admission = _take_auth_base_forward_admission(flow)
+    if admission is not None:
+        release_forward_request_admission(admission)
+
+
 async def _apply_url_rewrite(
     flow: http.HTTPFlow,
     *,
@@ -831,6 +838,7 @@ async def _apply_resolved_firewall_auth(
                 proxy_log_path=proxy_log_path,
             )
 
+        _release_auth_base_forward_admission(flow)
         _apply_header_query_injection(
             flow,
             headers=headers,

--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -17,6 +17,8 @@ import flow_metadata_keys as metadata_keys
 import matching
 from auth_base_forwarder import (
     MAX_AUTH_BASE_REQUEST_BODY_BYTES,
+    AuthBaseForwardingAdmission,
+    AuthBaseForwardingSaturatedError,
     ForwardedRequestTooLargeError,
     InvalidResolvedAuthHeaderError,
     forward_request,
@@ -55,6 +57,7 @@ class FirewallHeaderPhaseAuthResult(Enum):
 
 _HTTP_STATUS_CLIENT_ERROR_MIN = 400
 _HTTP_STATUS_SERVER_ERROR_MIN = 500
+AUTH_BASE_FORWARDING_SATURATED_ERROR = "auth_base_forwarding_saturated"
 
 
 @dataclass(frozen=True)
@@ -347,6 +350,63 @@ def _set_url_rewrite_forward_failed(
     )
 
 
+def _log_auth_base_forwarding_saturated(
+    flow: http.HTTPFlow,
+    *,
+    proxy_log_path: str,
+    firewall_base: str,
+) -> None:
+    flow.metadata[metadata_keys.SUPPRESS_REQUEST_BODY_CAPTURE] = True
+    log_proxy_entry(
+        proxy_log_path,
+        "warn",
+        "auth.base forwarding admission saturated",
+        type="firewall",
+        firewall_base=firewall_base,
+    )
+
+
+def _set_auth_base_forwarding_saturated(
+    flow: http.HTTPFlow,
+    *,
+    allow: matching.FirewallAllow,
+    proxy_log_path: str,
+    firewall_base: str,
+) -> None:
+    _log_auth_base_forwarding_saturated(
+        flow,
+        proxy_log_path=proxy_log_path,
+        firewall_base=firewall_base,
+    )
+    _set_matched_firewall_failure_response(
+        flow,
+        status=503,
+        action="ALLOW",
+        error_code=AUTH_BASE_FORWARDING_SATURATED_ERROR,
+        message="auth.base forwarding is temporarily saturated",
+        permission=allow.name,
+    )
+
+
+def mark_auth_base_forwarding_saturated(
+    flow: http.HTTPFlow,
+    *,
+    proxy_log_path: str,
+    firewall_base: str,
+) -> None:
+    """Record auth.base forwarding saturation before killing the flow."""
+    _log_auth_base_forwarding_saturated(
+        flow,
+        proxy_log_path=proxy_log_path,
+        firewall_base=firewall_base,
+    )
+    _mark_matched_firewall_failure(
+        flow,
+        action="ALLOW",
+        error_code=AUTH_BASE_FORWARDING_SATURATED_ERROR,
+    )
+
+
 def _request_body_exceeds_auth_base_limit(flow: http.HTTPFlow) -> bool:
     body = flow.request.raw_content
     return body is not None and len(body) > MAX_AUTH_BASE_REQUEST_BODY_BYTES
@@ -633,6 +693,13 @@ def _set_invalid_resolved_auth_header_response(
     )
 
 
+def _take_auth_base_forward_admission(
+    flow: http.HTTPFlow,
+) -> AuthBaseForwardingAdmission | None:
+    admission = flow.metadata.pop(metadata_keys.AUTH_BASE_FORWARD_ADMISSION, None)
+    return admission if isinstance(admission, AuthBaseForwardingAdmission) else None
+
+
 async def _apply_url_rewrite(
     flow: http.HTTPFlow,
     *,
@@ -691,15 +758,25 @@ async def _apply_url_rewrite(
             return FirewallAuthHandlingResult.LOCAL_RESPONSE
 
     try:
+        admission = _take_auth_base_forward_admission(flow)
         status, resp_body, resp_headers = await forward_request(
             new_url,
             flow.request.method,
             req_headers,
             req_body,
+            admission=admission,
         )
         flow.response = http.Response.make(status, resp_body, resp_headers)
     except ForwardedRequestTooLargeError:
         _set_auth_base_request_too_large(
+            flow,
+            allow=allow,
+            proxy_log_path=proxy_log_path,
+            firewall_base=firewall_base,
+        )
+        return FirewallAuthHandlingResult.LOCAL_RESPONSE
+    except AuthBaseForwardingSaturatedError:
+        _set_auth_base_forwarding_saturated(
             flow,
             allow=allow,
             proxy_log_path=proxy_log_path,

--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -904,37 +904,41 @@ async def handle_firewall_request(
     flow: http.HTTPFlow, allow: matching.FirewallAllow, vm_info: dict
 ) -> FirewallAuthHandlingResult:
     """Handle firewall auth and return who owns the next response lifecycle."""
-    _prepare_firewall_metadata(flow, allow, vm_info)
-    context = _build_firewall_auth_context(flow, allow, vm_info)
-
-    preflight_result = _preflight_firewall_auth(flow, context)
-    if preflight_result is not None:
-        return _finish_firewall_auth_result(flow, preflight_result)
-
     try:
-        token_meta = await get_firewall_headers(
-            context.run_id,
-            context.api_id,
-            context.auth_request,
-        )
-    except Exception as exc:
-        return _finish_firewall_auth_result(
+        _prepare_firewall_metadata(flow, allow, vm_info)
+        context = _build_firewall_auth_context(flow, allow, vm_info)
+
+        preflight_result = _preflight_firewall_auth(flow, context)
+        if preflight_result is not None:
+            return _finish_firewall_auth_result(flow, preflight_result)
+
+        try:
+            token_meta = await get_firewall_headers(
+                context.run_id,
+                context.api_id,
+                context.auth_request,
+            )
+        except Exception as exc:
+            return _finish_firewall_auth_result(
+                flow,
+                _set_firewall_auth_resolution_failure(flow, context, exc),
+            )
+
+        auth_result = await _apply_resolved_firewall_auth(
             flow,
-            _set_firewall_auth_resolution_failure(flow, context, exc),
+            allow=context.allow,
+            token_meta=token_meta,
+            firewall_base=context.firewall_base,
+            proxy_log_path=context.proxy_log_path,
         )
+        if auth_result is FirewallAuthHandlingResult.LOCAL_RESPONSE:
+            return _finish_firewall_auth_result(flow, auth_result)
 
-    auth_result = await _apply_resolved_firewall_auth(
-        flow,
-        allow=context.allow,
-        token_meta=token_meta,
-        firewall_base=context.firewall_base,
-        proxy_log_path=context.proxy_log_path,
-    )
-    if auth_result is FirewallAuthHandlingResult.LOCAL_RESPONSE:
-        return _finish_firewall_auth_result(flow, auth_result)
-
-    _finalize_firewall_auth_success(flow, context, token_meta)
-    return auth_result
+        _finalize_firewall_auth_success(flow, context, token_meta)
+        return auth_result
+    except BaseException:
+        _release_auth_base_forward_admission(flow)
+        raise
 
 
 async def try_apply_stream_safe_firewall_auth_for_requestheaders(

--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -892,6 +892,14 @@ def _finalize_firewall_auth_success(
     )
 
 
+def _finish_firewall_auth_result(
+    flow: http.HTTPFlow, result: FirewallAuthHandlingResult
+) -> FirewallAuthHandlingResult:
+    if result is FirewallAuthHandlingResult.LOCAL_RESPONSE:
+        _release_auth_base_forward_admission(flow)
+    return result
+
+
 async def handle_firewall_request(
     flow: http.HTTPFlow, allow: matching.FirewallAllow, vm_info: dict
 ) -> FirewallAuthHandlingResult:
@@ -901,7 +909,7 @@ async def handle_firewall_request(
 
     preflight_result = _preflight_firewall_auth(flow, context)
     if preflight_result is not None:
-        return preflight_result
+        return _finish_firewall_auth_result(flow, preflight_result)
 
     try:
         token_meta = await get_firewall_headers(
@@ -910,7 +918,10 @@ async def handle_firewall_request(
             context.auth_request,
         )
     except Exception as exc:
-        return _set_firewall_auth_resolution_failure(flow, context, exc)
+        return _finish_firewall_auth_result(
+            flow,
+            _set_firewall_auth_resolution_failure(flow, context, exc),
+        )
 
     auth_result = await _apply_resolved_firewall_auth(
         flow,
@@ -920,7 +931,7 @@ async def handle_firewall_request(
         proxy_log_path=context.proxy_log_path,
     )
     if auth_result is FirewallAuthHandlingResult.LOCAL_RESPONSE:
-        return auth_result
+        return _finish_firewall_auth_result(flow, auth_result)
 
     _finalize_firewall_auth_success(flow, context, token_meta)
     return auth_result

--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -91,6 +91,8 @@ DEFAULT_HTTPS_PORT = 443
 MAX_AUTH_BASE_REQUEST_BODY_BYTES = 32 * 1024 * 1024
 MAX_AUTH_BASE_RESPONSE_BODY_BYTES = 32 * 1024 * 1024
 MAX_CONCURRENT_AUTH_BASE_FORWARDS = 4
+MAX_ADMITTED_AUTH_BASE_FORWARDS = 16
+MAX_ADMITTED_AUTH_BASE_REQUEST_BODY_BYTES = 128 * 1024 * 1024
 NAT64_WELL_KNOWN_PREFIX = ipaddress.IPv6Network("64:ff9b::/96")
 
 _forward_request_executor_state: tuple[int, ThreadPoolExecutor] | None = None
@@ -98,6 +100,9 @@ _forward_request_admission_state: (
     tuple[asyncio.AbstractEventLoop, int, asyncio.Semaphore] | None
 ) = None
 _forward_request_accepting = True
+_forward_request_budget_lock = threading.Lock()
+_forward_request_admitted_count = 0
+_forward_request_admitted_body_bytes = 0
 _https_context: ssl.SSLContext | None = None
 _https_context_lock = threading.Lock()
 
@@ -105,9 +110,14 @@ _https_context_lock = threading.Lock()
 def reset_forward_request_state_for_tests() -> None:
     """Reset forwarder worker state between tests."""
     global _forward_request_accepting
+    global _forward_request_admitted_body_bytes
+    global _forward_request_admitted_count
     global _https_context
 
     shutdown_forward_request_executor(wait=True)
+    with _forward_request_budget_lock:
+        _forward_request_admitted_count = 0
+        _forward_request_admitted_body_bytes = 0
     with _https_context_lock:
         _https_context = None
     _forward_request_accepting = True
@@ -135,12 +145,26 @@ class ForwardedRequestTooLargeError(Exception):
     """Raised when an auth.base forwarded request body exceeds the local cap."""
 
 
+class AuthBaseForwardingSaturatedError(Exception):
+    """Raised when auth.base forwarding admission is saturated."""
+
+
 class UnsafeAuthBaseDestinationError(Exception):
     """Raised when an auth.base upstream destination is not public internet."""
 
 
 class InvalidResolvedAuthHeaderError(Exception):
     """Raised when resolved auth data contains an invalid HTTP header."""
+
+
+class AuthBaseForwardingAdmission:
+    """Opaque reservation for one admitted auth.base forward."""
+
+    __slots__ = ("_body_bytes", "_released")
+
+    def __init__(self, body_bytes: int) -> None:
+        self._body_bytes = body_bytes
+        self._released = False
 
 
 class _ValidatedAddress(NamedTuple):
@@ -437,6 +461,74 @@ def _validate_request_body_size(body: bytes | None) -> None:
         raise ForwardedRequestTooLargeError("Forwarded auth.base request body too large")
 
 
+def _request_body_size(body: bytes | None) -> int:
+    return len(body) if body is not None else 0
+
+
+def reserve_forward_request_admission(body_bytes: int) -> AuthBaseForwardingAdmission:
+    """Reserve aggregate auth.base forwarding capacity before body buffering."""
+    global _forward_request_admitted_body_bytes
+    global _forward_request_admitted_count
+
+    if body_bytes < 0:
+        raise ValueError("auth.base forwarding body size cannot be negative")
+    if not _forward_request_accepting:
+        raise RuntimeError("auth.base forwarding executor is shut down")
+
+    with _forward_request_budget_lock:
+        if _forward_request_admitted_count + 1 > MAX_ADMITTED_AUTH_BASE_FORWARDS:
+            raise AuthBaseForwardingSaturatedError("auth.base forwarding admission is full")
+        if (
+            _forward_request_admitted_body_bytes + body_bytes
+            > MAX_ADMITTED_AUTH_BASE_REQUEST_BODY_BYTES
+        ):
+            raise AuthBaseForwardingSaturatedError("auth.base forwarding body budget is full")
+
+        _forward_request_admitted_count += 1
+        _forward_request_admitted_body_bytes += body_bytes
+        return AuthBaseForwardingAdmission(body_bytes)
+
+
+def adjust_forward_request_admission(
+    admission: AuthBaseForwardingAdmission, body_bytes: int
+) -> None:
+    """Resize an existing reservation when actual body size differs."""
+    global _forward_request_admitted_body_bytes
+
+    if body_bytes < 0:
+        raise ValueError("auth.base forwarding body size cannot be negative")
+
+    with _forward_request_budget_lock:
+        if admission._released:
+            raise RuntimeError("auth.base forwarding admission is already released")
+        delta = body_bytes - admission._body_bytes
+        if delta > 0 and (
+            _forward_request_admitted_body_bytes + delta > MAX_ADMITTED_AUTH_BASE_REQUEST_BODY_BYTES
+        ):
+            raise AuthBaseForwardingSaturatedError("auth.base forwarding body budget is full")
+        _forward_request_admitted_body_bytes += delta
+        admission._body_bytes = body_bytes
+
+
+def release_forward_request_admission(admission: AuthBaseForwardingAdmission) -> None:
+    """Release aggregate auth.base forwarding capacity exactly once."""
+    global _forward_request_admitted_body_bytes
+    global _forward_request_admitted_count
+
+    with _forward_request_budget_lock:
+        if admission._released:
+            return
+        admission._released = True
+        _forward_request_admitted_count -= 1
+        _forward_request_admitted_body_bytes -= admission._body_bytes
+
+
+def forward_request_admission_state_for_tests() -> tuple[int, int]:
+    """Return current admitted count and body bytes for tests."""
+    with _forward_request_budget_lock:
+        return _forward_request_admitted_count, _forward_request_admitted_body_bytes
+
+
 def _is_public_unicast_address(address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
     if isinstance(address, ipaddress.IPv6Address) and (
         address.ipv4_mapped is not None
@@ -563,11 +655,13 @@ def _can_submit_forward_request(semaphore: asyncio.Semaphore) -> bool:
     )
 
 
-def _release_forward_request_slot(
+def _release_forward_request_resources(
     loop: asyncio.AbstractEventLoop,
     semaphore: asyncio.Semaphore,
+    admission: AuthBaseForwardingAdmission,
     _future: Future[tuple[int, bytes, http.Headers]],
 ) -> None:
+    release_forward_request_admission(admission)
     with suppress(RuntimeError):
         loop.call_soon_threadsafe(semaphore.release)
 
@@ -587,37 +681,61 @@ async def forward_request(
     method: str,
     headers: list[tuple[str, str]],
     body: bytes | None,
+    *,
+    admission: AuthBaseForwardingAdmission | None = None,
 ) -> tuple[int, bytes, http.Headers]:
     """Async wrapper for _forward_request_sync."""
-    _validate_request_body_size(body)
-    loop = asyncio.get_running_loop()
-    semaphore = _get_forward_request_admission_semaphore()
-    context = contextvars.copy_context()
-    await semaphore.acquire()
-    if not _can_submit_forward_request(semaphore):
-        semaphore.release()
-        raise RuntimeError("auth.base forwarding executor is shut down")
+    body_bytes = _request_body_size(body)
     try:
-        future = _get_forward_request_executor().submit(
-            _forward_request_sync_in_context,
-            context,
-            url,
-            method,
-            headers,
-            body,
-        )
-    except Exception:
-        semaphore.release()
+        _validate_request_body_size(body)
+    except BaseException:
+        if admission is not None:
+            release_forward_request_admission(admission)
         raise
-    future.add_done_callback(
-        lambda completed_future: _release_forward_request_slot(
-            loop,
-            semaphore,
-            completed_future,
-        )
-    )
+    if admission is None:
+        admission = reserve_forward_request_admission(body_bytes)
+    else:
+        try:
+            adjust_forward_request_admission(admission, body_bytes)
+        except BaseException:
+            release_forward_request_admission(admission)
+            raise
+
+    submitted = False
     try:
-        return await asyncio.wrap_future(future, loop=loop)
-    except asyncio.CancelledError:
-        future.cancel()
-        raise
+        loop = asyncio.get_running_loop()
+        semaphore = _get_forward_request_admission_semaphore()
+        context = contextvars.copy_context()
+        await semaphore.acquire()
+        if not _can_submit_forward_request(semaphore):
+            semaphore.release()
+            raise RuntimeError("auth.base forwarding executor is shut down")
+        try:
+            future = _get_forward_request_executor().submit(
+                _forward_request_sync_in_context,
+                context,
+                url,
+                method,
+                headers,
+                body,
+            )
+        except BaseException:
+            semaphore.release()
+            raise
+        future.add_done_callback(
+            lambda completed_future: _release_forward_request_resources(
+                loop,
+                semaphore,
+                admission,
+                completed_future,
+            )
+        )
+        submitted = True
+        try:
+            return await asyncio.wrap_future(future, loop=loop)
+        except asyncio.CancelledError:
+            future.cancel()
+            raise
+    finally:
+        if not submitted:
+            release_forward_request_admission(admission)

--- a/crates/runner/mitm-addon/src/flow_metadata_keys.py
+++ b/crates/runner/mitm-addon/src/flow_metadata_keys.py
@@ -91,6 +91,10 @@ Firewall and auth context
 - ``AUTH_URL_REWRITE``: ``bool`` written only after inline auth.base forwarding
   succeeds and sets the provider response on the flow. Read by network-log
   firewall metadata.
+- ``AUTH_BASE_FORWARD_ADMISSION``: opaque auth.base forwarding admission
+  reservation written by header-phase auth.base admission and consumed by the
+  request auth.base forwarder path. Released by request/terminal cleanup if it
+  is not transferred to the forwarder.
 - ``TRUSTED_AUTHORITY_HOST``: ``str`` host from authority validation. Read by
   auth-base URL rewrite logic when reconstructing trusted request authority.
 
@@ -183,6 +187,7 @@ AUTH_REFRESHED_CONNECTORS: Final = "auth_refreshed_connectors"
 AUTH_REFRESHED_SECRETS: Final = "auth_refreshed_secrets"
 AUTH_CACHE_HIT: Final = "auth_cache_hit"
 AUTH_URL_REWRITE: Final = "auth_url_rewrite"
+AUTH_BASE_FORWARD_ADMISSION: Final = "auth_base_forward_admission"
 TRUSTED_AUTHORITY_HOST: Final = "trusted_authority_host"
 
 # Usage and streaming metadata

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -57,6 +57,7 @@ from auth import (
     FirewallHeaderPhaseAuthResult,
     handle_firewall_request,
     is_billable_firewall,
+    mark_auth_base_forwarding_saturated,
     mark_auth_base_request_length_required,
     mark_auth_base_request_too_large,
     prepare_firewall_metadata,
@@ -1385,12 +1386,13 @@ def requestheaders(flow: http.HTTPFlow) -> Awaitable[None] | None:
     classification = _classify_request(flow)
     allow = classification.firewall_allow
     vm_info = classification.vm_info
+    auth_base = _firewall_allow_auth_base(allow) if allow is not None else None
     if (
         classification.kind == "firewall_allow"
         and allow is not None
         and vm_info is not None
         and body_check.kind != "ok"
-        and _firewall_allow_auth_base(allow)
+        and auth_base
     ):
         _start_request_timing(flow)
         prepare_firewall_metadata(flow, allow, vm_info)
@@ -1414,6 +1416,38 @@ def requestheaders(flow: http.HTTPFlow) -> Awaitable[None] | None:
         flow.metadata[_REQUEST_HEADERS_TERMINATED] = True
         flow.kill()
         return None
+
+    if (
+        classification.kind == "firewall_allow"
+        and allow is not None
+        and vm_info is not None
+        and auth_base
+        and body_check.kind == "ok"
+    ):
+        try:
+            admission = auth_base_forwarder.reserve_forward_request_admission(
+                body_check.observed_size
+            )
+        except (
+            auth_base_forwarder.AuthBaseForwardingSaturatedError,
+            RuntimeError,
+        ):
+            _start_request_timing(flow)
+            prepare_firewall_metadata(flow, allow, vm_info)
+            proxy_log_path = flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, "")
+            firewall_base = flow.metadata[metadata_keys.FIREWALL_BASE]
+            mark_auth_base_forwarding_saturated(
+                flow,
+                proxy_log_path=proxy_log_path,
+                firewall_base=firewall_base,
+            )
+            flow.metadata.pop(_REQUEST_CLASSIFICATION, None)
+            flow.metadata[_REQUEST_HEADERS_TERMINATED] = True
+            flow.kill()
+            return
+        flow.metadata[metadata_keys.AUTH_BASE_FORWARD_ADMISSION] = admission
+        flow.metadata[_REQUEST_CLASSIFICATION] = classification
+        return
 
     if _should_stream_capture_request(classification):
         _maybe_record_allow_connector_diagnostic_context(flow, classification)
@@ -1587,6 +1621,7 @@ async def request(flow: http.HTTPFlow) -> None:
                 # Local firewall/auth errors never reach a provider. They only
                 # need pre-tracking to keep shutdown from racing while auth is
                 # resolving, so release as soon as the local response exists.
+                _release_auth_base_forward_admission(flow)
                 _release_tracked_usage_flow(flow)
             return
 
@@ -1597,6 +1632,7 @@ async def request(flow: http.HTTPFlow) -> None:
         flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
     except (asyncio.CancelledError, Exception):
         flow.metadata.pop(metadata_keys.HTTP_REQUEST_START_MONOTONIC, None)
+        _release_auth_base_forward_admission(flow)
         _release_tracked_usage_flow(flow)
         raise
     finally:
@@ -1634,6 +1670,12 @@ def _maybe_track_usage_flow(
 def _release_tracked_usage_flow(flow: http.HTTPFlow) -> None:
     if flow.metadata.pop(_USAGE_FLOW_TRACKED, False):
         usage.decrement_in_flight_flows()
+
+
+def _release_auth_base_forward_admission(flow: http.HTTPFlow) -> None:
+    admission = flow.metadata.pop(metadata_keys.AUTH_BASE_FORWARD_ADMISSION, None)
+    if isinstance(admission, auth_base_forwarder.AuthBaseForwardingAdmission):
+        auth_base_forwarder.release_forward_request_admission(admission)
 
 
 def _report_model_provider_usage_once(flow: http.HTTPFlow, run_id: str) -> None:
@@ -1789,6 +1831,7 @@ def _release_usage_hook_state(
     flow.metadata.pop(_FIREWALL_AUTH_APPLIED_IN_REQUESTHEADERS, None)
     request_streaming.release_request_stream_state(flow)
     response_streaming.release_response_stream_state(flow)
+    _release_auth_base_forward_admission(flow)
     if release_tracking:
         _release_tracked_usage_flow(flow)
 

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1444,10 +1444,10 @@ def requestheaders(flow: http.HTTPFlow) -> Awaitable[None] | None:
             flow.metadata.pop(_REQUEST_CLASSIFICATION, None)
             flow.metadata[_REQUEST_HEADERS_TERMINATED] = True
             flow.kill()
-            return
+            return None
         flow.metadata[metadata_keys.AUTH_BASE_FORWARD_ADMISSION] = admission
         flow.metadata[_REQUEST_CLASSIFICATION] = classification
-        return
+        return None
 
     if _should_stream_capture_request(classification):
         _maybe_record_allow_connector_diagnostic_context(flow, classification)

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -728,7 +728,10 @@ def _auth_base_body_header_check(flow: http.HTTPFlow) -> _AuthBaseBodyCheck:
     if not raw_content_lengths:
         if flow.request.method.upper() not in _AUTH_BASE_BODYLESS_METHODS:
             return _AuthBaseBodyCheck(kind="length_required", reason="missing_content_length")
-        return _AuthBaseBodyCheck(kind="ok")
+        return _AuthBaseBodyCheck(
+            kind="ok",
+            observed_size=auth_base_forwarder.MAX_AUTH_BASE_REQUEST_BODY_BYTES,
+        )
 
     parsed_length: int | None = None
     for raw_content_length in raw_content_lengths:

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1553,10 +1553,12 @@ async def request(flow: http.HTTPFlow) -> None:
     3. Firewall match (inject auth headers for allowed requests)
     """
     if flow.metadata.get(_REQUEST_HEADERS_TERMINATED):
+        _release_auth_base_forward_admission(flow)
         flow.metadata.pop(_REQUEST_CLASSIFICATION, None)
         return
 
     if flow.response is not None or flow.error is not None:
+        _release_auth_base_forward_admission(flow)
         flow.metadata.pop(_REQUEST_CLASSIFICATION, None)
         return
 

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -728,10 +728,7 @@ def _auth_base_body_header_check(flow: http.HTTPFlow) -> _AuthBaseBodyCheck:
     if not raw_content_lengths:
         if flow.request.method.upper() not in _AUTH_BASE_BODYLESS_METHODS:
             return _AuthBaseBodyCheck(kind="length_required", reason="missing_content_length")
-        return _AuthBaseBodyCheck(
-            kind="ok",
-            observed_size=auth_base_forwarder.MAX_AUTH_BASE_REQUEST_BODY_BYTES,
-        )
+        return _AuthBaseBodyCheck(kind="ok")
 
     parsed_length: int | None = None
     for raw_content_length in raw_content_lengths:

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
@@ -31,13 +31,6 @@ class _SubmitRecordingThreadPoolExecutor(ThreadPoolExecutor):
         with self._submit_condition:
             return self._submit_count
 
-    def wait_for_submit_count(self, count: int, timeout: float) -> bool:
-        with self._submit_condition:
-            return self._submit_condition.wait_for(
-                lambda: self._submit_count >= count,
-                timeout=timeout,
-            )
-
 
 async def _run_ready_tasks() -> None:
     ready = asyncio.Event()

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
@@ -16,19 +16,18 @@ from tests.auth_base_forwarder_helpers import FakeSocket, fake_forwarder_upstrea
 class _SubmitRecordingThreadPoolExecutor(ThreadPoolExecutor):
     def __init__(self, *args, **kwargs) -> None:
         self._submit_count = 0
-        self._submit_condition = threading.Condition()
+        self._submit_lock = threading.Lock()
         super().__init__(*args, **kwargs)
 
     def submit(self, fn, /, *args, **kwargs):
         future = super().submit(fn, *args, **kwargs)
-        with self._submit_condition:
+        with self._submit_lock:
             self._submit_count += 1
-            self._submit_condition.notify_all()
         return future
 
     @property
     def submit_count(self) -> int:
-        with self._submit_condition:
+        with self._submit_lock:
             return self._submit_count
 
 

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
@@ -39,6 +39,12 @@ class _SubmitRecordingThreadPoolExecutor(ThreadPoolExecutor):
             )
 
 
+async def _run_ready_tasks() -> None:
+    ready = asyncio.Event()
+    asyncio.get_running_loop().call_soon(ready.set)
+    await ready.wait()
+
+
 class TestAuthBaseForwarderSecurity:
     @pytest.mark.parametrize(
         ("url", "resolved_address"),
@@ -977,9 +983,17 @@ class TestForwardRequestAsyncWrapper:
                     active -= 1
 
         third_task = None
+        executors: list[_SubmitRecordingThreadPoolExecutor] = []
+
+        def create_executor(*args, **kwargs):
+            executor = _SubmitRecordingThreadPoolExecutor(*args, **kwargs)
+            executors.append(executor)
+            return executor
+
         with (
             patch.object(forwarder, "MAX_CONCURRENT_AUTH_BASE_FORWARDS", 1),
             patch.object(forwarder, "MAX_ADMITTED_AUTH_BASE_FORWARDS", 2),
+            patch.object(forwarder, "ThreadPoolExecutor", new=create_executor),
             fake_forwarder_upstream(create_connection=create_connection),
         ):
             first_task = asyncio.create_task(
@@ -991,6 +1005,9 @@ class TestForwardRequestAsyncWrapper:
             try:
                 first_started = await asyncio.to_thread(first_entered.wait, 2)
                 assert first_started
+                assert len(executors) == 1
+                executor = executors[0]
+                assert executor.submit_count == 1
 
                 waiting_task.cancel()
                 with pytest.raises(asyncio.CancelledError):
@@ -999,11 +1016,9 @@ class TestForwardRequestAsyncWrapper:
                 third_task = asyncio.create_task(
                     forwarder.forward_request("https://example.com", "GET", [], None)
                 )
-                second_started_before_release = await asyncio.to_thread(
-                    second_entered.wait,
-                    0.2,
-                )
-                assert not second_started_before_release
+                await _run_ready_tasks()
+                assert executor.submit_count == 1
+                assert not second_entered.is_set()
 
                 release_first.set()
                 second_started_after_release = await asyncio.to_thread(second_entered.wait, 2)

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
@@ -727,6 +727,65 @@ class TestForwardRequestAsyncWrapper:
 
         getaddrinfo.assert_not_called()
 
+    async def test_rejects_when_admitted_forward_count_is_saturated(self):
+        first_entered = threading.Event()
+        release_first = threading.Event()
+
+        def create_connection(_address, _timeout, _source_address):
+            first_entered.set()
+            if not release_first.wait(timeout=5):
+                raise TimeoutError("test did not release first forward")
+            return FakeSocket(http_response())
+
+        with (
+            patch.object(forwarder, "MAX_ADMITTED_AUTH_BASE_FORWARDS", 1),
+            fake_forwarder_upstream(create_connection=create_connection) as upstream,
+        ):
+            first_task = asyncio.create_task(
+                forwarder.forward_request("https://example.com", "GET", [], None)
+            )
+            try:
+                first_started = await asyncio.to_thread(first_entered.wait, 2)
+                assert first_started
+                with pytest.raises(forwarder.AuthBaseForwardingSaturatedError):
+                    await forwarder.forward_request("https://example.com", "GET", [], None)
+            finally:
+                release_first.set()
+                await asyncio.gather(first_task, return_exceptions=True)
+
+        assert upstream.getaddrinfo_calls == [("example.com", 443)]
+        assert upstream.create_connection_calls == [(("93.184.216.34", 443), 30, None)]
+
+    async def test_rejects_when_admitted_forward_body_bytes_are_saturated(self):
+        first_entered = threading.Event()
+        release_first = threading.Event()
+
+        def create_connection(_address, _timeout, _source_address):
+            first_entered.set()
+            if not release_first.wait(timeout=5):
+                raise TimeoutError("test did not release first forward")
+            return FakeSocket(http_response())
+
+        with (
+            patch.object(forwarder, "MAX_ADMITTED_AUTH_BASE_FORWARDS", 2),
+            patch.object(forwarder, "MAX_ADMITTED_AUTH_BASE_REQUEST_BODY_BYTES", 4),
+            fake_forwarder_upstream(create_connection=create_connection) as upstream,
+        ):
+            first_task = asyncio.create_task(
+                forwarder.forward_request("https://example.com", "POST", [], b"1234")
+            )
+            try:
+                first_started = await asyncio.to_thread(first_entered.wait, 2)
+                assert first_started
+                with pytest.raises(forwarder.AuthBaseForwardingSaturatedError):
+                    await forwarder.forward_request("https://example.com", "POST", [], b"x")
+            finally:
+                release_first.set()
+                await asyncio.gather(first_task, return_exceptions=True)
+
+        assert upstream.getaddrinfo_calls == [("example.com", 443)]
+        assert upstream.create_connection_calls == [(("93.184.216.34", 443), 30, None)]
+
     async def test_releases_forward_slot_when_forwarding_raises(self):
         first = True
 
@@ -852,6 +911,7 @@ class TestForwardRequestAsyncWrapper:
 
         with (
             patch.object(forwarder, "MAX_CONCURRENT_AUTH_BASE_FORWARDS", 1),
+            patch.object(forwarder, "MAX_ADMITTED_AUTH_BASE_FORWARDS", 1),
             patch.object(forwarder, "ThreadPoolExecutor", new=create_executor),
             fake_forwarder_upstream(create_connection=create_connection),
         ):
@@ -871,32 +931,18 @@ class TestForwardRequestAsyncWrapper:
                 with lock:
                     assert active == 1
 
-                second_task = asyncio.create_task(
-                    forwarder.forward_request("https://example.com", "GET", [], None)
-                )
-                await asyncio.sleep(0)
+                with pytest.raises(forwarder.AuthBaseForwardingSaturatedError):
+                    await forwarder.forward_request("https://example.com", "GET", [], None)
                 assert executor.submit_count == 1
 
                 release_first.set()
-                second_submitted_after_release = await asyncio.to_thread(
-                    executor.wait_for_submit_count,
-                    2,
-                    2,
-                )
-                assert second_submitted_after_release
-                second_started_after_release = await asyncio.to_thread(second_entered.wait, 2)
-                assert second_started_after_release
-
-                status, body, headers = await asyncio.wait_for(second_task, timeout=2)
             finally:
                 release_first.set()
                 await asyncio.gather(first_task, return_exceptions=True)
                 if second_task is not None:
                     await asyncio.gather(second_task, return_exceptions=True)
 
-        assert status == 200
-        assert body == b"ok"
-        assert list(headers.items(multi=True)) == []
+        assert not second_entered.is_set()
         assert max_active == 1
 
     async def test_cancelled_waiting_forward_does_not_leak_forward_slot(self):
@@ -933,6 +979,7 @@ class TestForwardRequestAsyncWrapper:
         third_task = None
         with (
             patch.object(forwarder, "MAX_CONCURRENT_AUTH_BASE_FORWARDS", 1),
+            patch.object(forwarder, "MAX_ADMITTED_AUTH_BASE_FORWARDS", 2),
             fake_forwarder_upstream(create_connection=create_connection),
         ):
             first_task = asyncio.create_task(

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
@@ -899,7 +899,6 @@ class TestForwardRequestAsyncWrapper:
                 with lock:
                     active -= 1
 
-        second_task = None
         executors: list[_SubmitRecordingThreadPoolExecutor] = []
 
         def create_executor(*args, **kwargs):
@@ -937,8 +936,6 @@ class TestForwardRequestAsyncWrapper:
             finally:
                 release_first.set()
                 await asyncio.gather(first_task, return_exceptions=True)
-                if second_task is not None:
-                    await asyncio.gather(second_task, return_exceptions=True)
 
         assert not second_entered.is_set()
         assert max_active == 1

--- a/crates/runner/mitm-addon/tests/test_error_handler.py
+++ b/crates/runner/mitm-addon/tests/test_error_handler.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from mitmproxy.flow import Error
 from mitmproxy.test import tutils
 
+import auth_base_forwarder
 import flow_metadata_keys as metadata_keys
 import mitm_addon
 import request_streaming
@@ -17,11 +18,61 @@ from tests.jsonl_log_helpers import (
     jsonl_exists_after_flush,
     read_jsonl_entries_after_flush,
 )
-from tests.request_handler_helpers import _vm_without_firewalls, _write_registry
+from tests.request_handler_helpers import (
+    _single_firewall_vm,
+    _vm_without_firewalls,
+    _write_registry,
+)
 from tests.timestamp_helpers import assert_utc_millisecond_timestamp
 
 
 class TestErrorHandler:
+    def test_error_releases_header_phase_auth_base_admission(
+        self, tmp_path, real_flow, mitm_ctx, headers
+    ):
+        reg_path = _write_registry(
+            tmp_path,
+            vm_info=_single_firewall_vm(
+                tmp_path,
+                firewall_name="webhook",
+                api_entry={
+                    "base": "https://placeholder.example.com",
+                    "auth": {"headers": {}, "base": "${{ secrets.WEBHOOK_URL }}"},
+                    "permissions": [{"name": "send", "rules": ["POST /"]}],
+                },
+                network_policy={
+                    "allow": ["send"],
+                    "deny": [],
+                    "ask": [],
+                    "unknownPolicy": "deny",
+                },
+            ),
+        )
+        declared_size = mitm_addon.STREAM_BUFFER_LIMIT + 1
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="placeholder.example.com",
+            method="POST",
+            path="/",
+            request_headers=headers(
+                ("Host", "placeholder.example.com"),
+                ("Content-Length", str(declared_size)),
+            ),
+        )
+
+        with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+            mitm_addon.requestheaders(flow)
+            assert auth_base_forwarder.forward_request_admission_state_for_tests() == (
+                1,
+                declared_size,
+            )
+            flow.error = Error("connection reset by peer")
+            mitm_addon.error(flow)
+
+        assert auth_base_forwarder.forward_request_admission_state_for_tests() == (0, 0)
+        assert metadata_keys.AUTH_BASE_FORWARD_ADMISSION not in flow.metadata
+
     async def test_connector_candidate_error_gets_local_diagnostic_response(
         self, tmp_path, real_flow, mitm_ctx
     ):

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 import auth
+import auth_base_forwarder
 import firewall_auth_cache as auth_cache
 import firewall_auth_client as auth_client
 import flow_metadata_keys as metadata_keys
@@ -1450,6 +1451,8 @@ class TestHandleFirewallRequest:
         api_entry = _api_entry()
         vm_info = _vm_info(network_log_path="", include_encrypted_secrets=False)
         allow = _allow(api_entry)
+        admission = auth_base_forwarder.reserve_forward_request_admission(42)
+        flow.metadata[metadata_keys.AUTH_BASE_FORWARD_ADMISSION] = admission
 
         with mitm_ctx():
             result = await auth.handle_firewall_request(flow, allow, vm_info)
@@ -1465,6 +1468,8 @@ class TestHandleFirewallRequest:
         assert body["permission"] == "github"
         assert body["base"] == "https://api.github.com"
         assert "connectors" not in body
+        assert metadata_keys.AUTH_BASE_FORWARD_ADMISSION not in flow.metadata
+        assert auth_base_forwarder.forward_request_admission_state_for_tests() == (0, 0)
 
 
 # =========================================================================

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -1500,7 +1500,7 @@ class TestHandleFirewallRequest:
                 await asyncio.wait_for(auth_resolution_entered.wait(), timeout=1)
                 task.cancel()
                 with pytest.raises(asyncio.CancelledError):
-                    await task
+                    _ = await task
             finally:
                 release_auth_resolution.set()
                 await cancel_pending_task(task)

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -1471,6 +1471,43 @@ class TestHandleFirewallRequest:
         assert metadata_keys.AUTH_BASE_FORWARD_ADMISSION not in flow.metadata
         assert auth_base_forwarder.forward_request_admission_state_for_tests() == (0, 0)
 
+    async def test_cancelled_auth_resolution_releases_forward_admission(
+        self, real_flow, mitm_ctx, tmp_path
+    ):
+        flow = _firewall_flow(real_flow)
+        api_entry = _api_entry()
+        vm_info = _vm_info(tmp_path)
+        allow = _allow(api_entry)
+        admission = auth_base_forwarder.reserve_forward_request_admission(42)
+        flow.metadata[metadata_keys.AUTH_BASE_FORWARD_ADMISSION] = admission
+        auth_resolution_entered = asyncio.Event()
+        release_auth_resolution = asyncio.Event()
+
+        async def wait_for_auth_resolution(*_args, **_kwargs):
+            auth_resolution_entered.set()
+            await release_auth_resolution.wait()
+
+        with (
+            mitm_ctx(),
+            patch.object(
+                auth,
+                "get_firewall_headers",
+                AsyncMock(side_effect=wait_for_auth_resolution),
+            ),
+        ):
+            task = asyncio.create_task(auth.handle_firewall_request(flow, allow, vm_info))
+            try:
+                await asyncio.wait_for(auth_resolution_entered.wait(), timeout=1)
+                task.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await task
+            finally:
+                release_auth_resolution.set()
+                await cancel_pending_task(task)
+
+        assert metadata_keys.AUTH_BASE_FORWARD_ADMISSION not in flow.metadata
+        assert auth_base_forwarder.forward_request_admission_state_for_tests() == (0, 0)
+
 
 # =========================================================================
 # fetch_firewall_headers

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite_forwarding.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite_forwarding.py
@@ -846,7 +846,7 @@ class TestAuthBaseUrlRewriteForwarding:
             },
         )
         proxy_log_path = tmp_path / "proxy.jsonl"
-        flow.metadata["vm_proxy_log_path"] = str(proxy_log_path)
+        flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = str(proxy_log_path)
         mock_forward = AsyncMock(side_effect=forwarder.AuthBaseForwardingSaturatedError())
         with (
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
@@ -863,10 +863,12 @@ class TestAuthBaseUrlRewriteForwarding:
         assert body["message"] == "auth.base forwarding is temporarily saturated"
         assert body["permission"] == allow.name
         assert body["base"] == allow.api_entry["base"]
-        assert "auth_url_rewrite" not in flow.metadata
-        assert flow.metadata["firewall_action"] == "ALLOW"
-        assert flow.metadata["firewall_error"] == auth.AUTH_BASE_FORWARDING_SATURATED_ERROR
-        assert flow.metadata["suppress_request_body_capture"] is True
+        assert metadata_keys.AUTH_URL_REWRITE not in flow.metadata
+        assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+        assert (
+            flow.metadata[metadata_keys.FIREWALL_ERROR] == auth.AUTH_BASE_FORWARDING_SATURATED_ERROR
+        )
+        assert flow.metadata[metadata_keys.SUPPRESS_REQUEST_BODY_CAPTURE] is True
 
         log_text = await asyncio.to_thread(read_jsonl_text_after_flush, proxy_log_path)
         assert "auth.base forwarding admission saturated" in log_text

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite_forwarding.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite_forwarding.py
@@ -828,3 +828,47 @@ class TestAuthBaseUrlRewriteForwarding:
         assert "URL rewrite forward failed" in log_text
         assert "Firewall URL rewrite:" not in log_text
         assert f"Firewall {allow.api_entry['base']}:" not in log_text
+
+    async def test_forward_saturation_returns_dedicated_local_error(
+        self, headers, real_flow, mitm_ctx, tmp_path
+    ):
+        flow, allow, vm_info, token_meta = make_forwarding_rewrite_inputs(
+            real_flow,
+            tmp_path,
+            path="/hook",
+            request_headers=headers(("Host", "firewall-placeholder.vm3.ai")),
+            token_overrides={
+                "headers": {},
+                "resolved_secrets": ["WEBHOOK"],
+                "refreshed_connectors": [],
+                "refreshed_secrets": [],
+                "cache_hit": False,
+            },
+        )
+        proxy_log_path = tmp_path / "proxy.jsonl"
+        flow.metadata["vm_proxy_log_path"] = str(proxy_log_path)
+        mock_forward = AsyncMock(side_effect=forwarder.AuthBaseForwardingSaturatedError())
+        with (
+            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+            patch.object(auth, "forward_request", mock_forward),
+            mitm_ctx(),
+        ):
+            result = await auth.handle_firewall_request(flow, allow, vm_info)
+
+        assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
+        assert flow.response is not None
+        assert flow.response.status_code == 503
+        body = json.loads(flow.response.content)
+        assert body["error"] == auth.AUTH_BASE_FORWARDING_SATURATED_ERROR
+        assert body["message"] == "auth.base forwarding is temporarily saturated"
+        assert body["permission"] == allow.name
+        assert body["base"] == allow.api_entry["base"]
+        assert "auth_url_rewrite" not in flow.metadata
+        assert flow.metadata["firewall_action"] == "ALLOW"
+        assert flow.metadata["firewall_error"] == auth.AUTH_BASE_FORWARDING_SATURATED_ERROR
+        assert flow.metadata["suppress_request_body_capture"] is True
+
+        log_text = await asyncio.to_thread(read_jsonl_text_after_flush, proxy_log_path)
+        assert "auth.base forwarding admission saturated" in log_text
+        assert "URL rewrite forward failed" not in log_text
+        assert "Firewall URL rewrite:" not in log_text

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -7,9 +7,11 @@ import pytest
 from mitmproxy.flow import Error
 
 import auth
+import auth_base_forwarder
 import flow_metadata_keys as metadata_keys
 import mitm_addon
 import usage
+from tests.auth_base_forwarder_helpers import fake_forwarder_upstream
 from tests.jsonl_log_helpers import (
     read_jsonl_entries_after_flush,
     read_jsonl_text_after_flush,
@@ -740,6 +742,59 @@ async def test_auth_base_requestheaders_rejects_oversized_content_length_before_
     assert "auth.base request body too large" in proxy_log_text
 
 
+async def test_auth_base_requestheaders_rejects_saturated_admission_before_auth(
+    tmp_path, real_flow, mitm_ctx, headers
+):
+    reg_path = _write_auth_base_firewall_registry(
+        tmp_path,
+        vm_fields={"captureNetworkBodies": True},
+    )
+    declared_size = mitm_addon.STREAM_BUFFER_LIMIT + 1
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="placeholder.example.com",
+        method="POST",
+        path="/",
+        request_headers=headers(
+            ("Host", "placeholder.example.com"),
+            ("Content-Type", "application/json"),
+            ("Content-Length", str(declared_size)),
+        ),
+    )
+    get_headers = AsyncMock()
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        patch.object(
+            auth_base_forwarder,
+            "MAX_ADMITTED_AUTH_BASE_REQUEST_BODY_BYTES",
+            declared_size - 1,
+        ),
+        patch.object(auth, "get_firewall_headers", get_headers),
+    ):
+        mitm_addon.requestheaders(flow)
+        await mitm_addon.request(flow)
+        mitm_addon.error(flow)
+
+    get_headers.assert_not_called()
+    assert flow.response is None
+    assert flow.error is not None
+    assert flow.error.msg == Error.KILLED_MESSAGE
+    assert flow.live is False
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == auth.AUTH_BASE_FORWARDING_SATURATED_ERROR
+    assert flow.metadata[metadata_keys.SUPPRESS_REQUEST_BODY_CAPTURE] is True
+    assert metadata_keys.AUTH_BASE_FORWARD_ADMISSION not in flow.metadata
+    assert auth_base_forwarder.forward_request_admission_state_for_tests() == (0, 0)
+
+    network_log_text = read_jsonl_text_after_flush(tmp_path / "net.jsonl")
+    network_log_entry = json.loads(network_log_text)
+    assert network_log_entry["error"] == Error.KILLED_MESSAGE
+    assert network_log_entry["request_size"] == 0
+    assert "request_body" not in network_log_entry
+    assert network_log_entry["firewall_error"] == auth.AUTH_BASE_FORWARDING_SATURATED_ERROR
+
+
 @pytest.mark.parametrize(
     ("method", "request_header_pairs"),
     [
@@ -960,6 +1015,89 @@ async def test_auth_base_requestheaders_accepts_body_at_limit(
     assert flow.response.status_code == 200
     assert mock_forward.call_args is not None
     assert mock_forward.call_args[0][3] == b"ok"
+
+
+async def test_auth_base_requestheaders_admission_released_after_success(
+    tmp_path, real_flow, mitm_ctx, headers
+):
+    reg_path = _write_auth_base_firewall_registry(tmp_path)
+    request_body = b"x" * (mitm_addon.STREAM_BUFFER_LIMIT + 1)
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="placeholder.example.com",
+        method="POST",
+        path="/",
+        request_headers=headers(
+            ("Host", "placeholder.example.com"),
+            ("Content-Length", str(len(request_body))),
+        ),
+        request_body=request_body,
+    )
+    token_meta = {
+        "headers": {},
+        "base": "https://real.example.com/webhook",
+        "resolved_secrets": ["WEBHOOK_URL"],
+        "refreshed_connectors": [],
+        "refreshed_secrets": [],
+        "cache_hit": False,
+    }
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+        fake_forwarder_upstream(status=202, body=b"accepted"),
+    ):
+        mitm_addon.requestheaders(flow)
+        assert auth_base_forwarder.forward_request_admission_state_for_tests() == (
+            1,
+            len(request_body),
+        )
+        await mitm_addon.request(flow)
+
+    assert flow.response is not None
+    assert flow.response.status_code == 202
+    assert flow.response.content == b"accepted"
+    assert auth_base_forwarder.forward_request_admission_state_for_tests() == (0, 0)
+
+
+async def test_auth_base_requestheaders_admission_released_on_auth_failure(
+    tmp_path, real_flow, mitm_ctx, headers
+):
+    reg_path = _write_auth_base_firewall_registry(tmp_path)
+    declared_size = mitm_addon.STREAM_BUFFER_LIMIT + 1
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="placeholder.example.com",
+        method="POST",
+        path="/",
+        request_headers=headers(
+            ("Host", "placeholder.example.com"),
+            ("Content-Length", str(declared_size)),
+        ),
+        request_body=b"ok",
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        patch.object(
+            auth,
+            "get_firewall_headers",
+            AsyncMock(side_effect=RuntimeError("auth service unavailable")),
+        ),
+    ):
+        mitm_addon.requestheaders(flow)
+        assert auth_base_forwarder.forward_request_admission_state_for_tests() == (
+            1,
+            declared_size,
+        )
+        await mitm_addon.request(flow)
+
+    assert flow.response is not None
+    assert flow.response.status_code == 502
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "auth_failed"
+    assert auth_base_forwarder.forward_request_admission_state_for_tests() == (0, 0)
 
 
 @pytest.mark.parametrize(

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -4,6 +4,7 @@ import json
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from mitmproxy import http
 from mitmproxy.flow import Error
 
 import auth
@@ -1157,6 +1158,39 @@ async def test_auth_base_requestheaders_admission_released_when_resolved_base_mi
 
     assert flow.response is None
     assert flow.request.headers["Authorization"] == "Bearer resolved"
+    assert metadata_keys.AUTH_BASE_FORWARD_ADMISSION not in flow.metadata
+    assert auth_base_forwarder.forward_request_admission_state_for_tests() == (0, 0)
+
+
+async def test_auth_base_requestheaders_admission_released_when_request_already_has_response(
+    tmp_path, real_flow, mitm_ctx, headers
+):
+    reg_path = _write_auth_base_firewall_registry(tmp_path)
+    declared_size = mitm_addon.STREAM_BUFFER_LIMIT + 1
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="placeholder.example.com",
+        method="POST",
+        path="/",
+        request_headers=headers(
+            ("Host", "placeholder.example.com"),
+            ("Content-Length", str(declared_size)),
+        ),
+        request_body=b"ok",
+    )
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        mitm_addon.requestheaders(flow)
+        assert auth_base_forwarder.forward_request_admission_state_for_tests() == (
+            1,
+            declared_size,
+        )
+        flow.response = http.Response.make(204)
+        await mitm_addon.request(flow)
+
+    assert flow.response is not None
+    assert flow.response.status_code == 204
     assert metadata_keys.AUTH_BASE_FORWARD_ADMISSION not in flow.metadata
     assert auth_base_forwarder.forward_request_admission_state_for_tests() == (0, 0)
 

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -1100,6 +1100,48 @@ async def test_auth_base_requestheaders_admission_released_on_auth_failure(
     assert auth_base_forwarder.forward_request_admission_state_for_tests() == (0, 0)
 
 
+async def test_auth_base_requestheaders_admission_released_when_resolved_base_missing(
+    tmp_path, real_flow, mitm_ctx, headers
+):
+    reg_path = _write_auth_base_firewall_registry(tmp_path)
+    declared_size = mitm_addon.STREAM_BUFFER_LIMIT + 1
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="placeholder.example.com",
+        method="POST",
+        path="/",
+        request_headers=headers(
+            ("Host", "placeholder.example.com"),
+            ("Content-Length", str(declared_size)),
+        ),
+        request_body=b"ok",
+    )
+    token_meta = {
+        "headers": {"Authorization": "Bearer resolved"},
+        "resolved_secrets": ["WEBHOOK_URL"],
+        "refreshed_connectors": [],
+        "refreshed_secrets": [],
+        "cache_hit": False,
+    }
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+    ):
+        mitm_addon.requestheaders(flow)
+        assert auth_base_forwarder.forward_request_admission_state_for_tests() == (
+            1,
+            declared_size,
+        )
+        await mitm_addon.request(flow)
+
+    assert flow.response is None
+    assert flow.request.headers["Authorization"] == "Bearer resolved"
+    assert metadata_keys.AUTH_BASE_FORWARD_ADMISSION not in flow.metadata
+    assert auth_base_forwarder.forward_request_admission_state_for_tests() == (0, 0)
+
+
 @pytest.mark.parametrize(
     "request_header_pairs",
     [

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -949,11 +949,30 @@ async def test_auth_base_requestheaders_accepts_no_body_framing(
         path="/",
         request_headers=headers(("Host", "placeholder.example.com")),
     )
+    token_meta = {
+        "headers": {},
+        "base": "https://real.example.com/webhook",
+        "resolved_secrets": ["WEBHOOK_URL"],
+        "refreshed_connectors": [],
+        "refreshed_secrets": [],
+        "cache_hit": False,
+    }
 
-    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+        fake_forwarder_upstream(status=200, body=b"ok"),
+    ):
         mitm_addon.requestheaders(flow)
+        assert auth_base_forwarder.forward_request_admission_state_for_tests() == (
+            1,
+            auth.MAX_AUTH_BASE_REQUEST_BODY_BYTES,
+        )
+        await mitm_addon.request(flow)
 
-    assert flow.response is None
+    assert flow.response is not None
+    assert flow.response.status_code == 200
+    assert auth_base_forwarder.forward_request_admission_state_for_tests() == (0, 0)
 
 
 async def test_requestheaders_skips_registry_for_bounded_body_headers(real_flow, headers):

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -967,13 +967,40 @@ async def test_auth_base_requestheaders_accepts_no_body_framing(
         mitm_addon.requestheaders(flow)
         assert auth_base_forwarder.forward_request_admission_state_for_tests() == (
             1,
-            auth.MAX_AUTH_BASE_REQUEST_BODY_BYTES,
+            0,
         )
         await mitm_addon.request(flow)
 
     assert flow.response is not None
     assert flow.response.status_code == 200
     assert auth_base_forwarder.forward_request_admission_state_for_tests() == (0, 0)
+
+
+async def test_auth_base_bodyless_requests_do_not_spend_body_budget(
+    tmp_path, real_flow, mitm_ctx, headers
+):
+    reg_path = _write_auth_base_firewall_registry(tmp_path)
+    flows = [
+        real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="placeholder.example.com",
+            method="GET",
+            path="/",
+            request_headers=headers(("Host", "placeholder.example.com")),
+        )
+        for _ in range(2)
+    ]
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        patch.object(auth_base_forwarder, "MAX_ADMITTED_AUTH_BASE_REQUEST_BODY_BYTES", 1),
+    ):
+        for flow in flows:
+            mitm_addon.requestheaders(flow)
+
+    assert all(flow.response is None for flow in flows)
+    assert auth_base_forwarder.forward_request_admission_state_for_tests() == (2, 0)
 
 
 async def test_requestheaders_skips_registry_for_bounded_body_headers(real_flow, headers):

--- a/crates/runner/mitm-addon/tests/test_request_headers_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_headers_handler.py
@@ -586,18 +586,30 @@ async def test_capture_enabled_body_dependent_firewall_auth_does_not_install_req
         ),
     )
     get_headers = AsyncMock()
+    used_auth_base_header_admission = False
 
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
         patch.object(auth, "get_firewall_headers", get_headers),
     ):
         requestheaders_result = mitm_addon.requestheaders(flow)
-        await await_requestheaders_result(requestheaders_result)
+        if "base" in auth_config:
+            used_auth_base_header_admission = True
+            assert requestheaders_result is None
+            assert metadata_keys.AUTH_BASE_FORWARD_ADMISSION in flow.metadata
+            mitm_addon.error(flow)
+        else:
+            await await_requestheaders_result(requestheaders_result)
 
     get_headers.assert_not_called()
     _assert_no_request_stream(flow)
-    assert metadata_keys.VM_RUN_ID not in flow.metadata
-    assert metadata_keys.ORIGINAL_URL not in flow.metadata
+    assert metadata_keys.AUTH_BASE_FORWARD_ADMISSION not in flow.metadata
+    if used_auth_base_header_admission:
+        assert metadata_keys.VM_RUN_ID in flow.metadata
+        assert metadata_keys.ORIGINAL_URL in flow.metadata
+    else:
+        assert metadata_keys.VM_RUN_ID not in flow.metadata
+        assert metadata_keys.ORIGINAL_URL not in flow.metadata
 
 
 def test_capture_enabled_firewall_block_does_not_install_request_stream(


### PR DESCRIPTION
## Summary

- add aggregate auth.base forwarding admission limits by request count and request body bytes
- reserve header-phase capacity for large auth.base requests before body buffering, with forwarder-level final admission as a backstop
- return a dedicated `auth_base_forwarding_saturated` failure for saturated forwarding and release reservations across success, local failure, cancellation, and error cleanup paths

Closes #18921

## Tests

- `ruff format src/auth.py src/auth_base_forwarder.py src/flow_metadata_keys.py src/mitm_addon.py tests/test_auth_base_forwarder.py tests/test_error_handler.py tests/test_firewall_rewrite_forwarding.py tests/test_request_handler_firewall_dispatch.py`
- `ruff check src/auth.py src/auth_base_forwarder.py src/flow_metadata_keys.py src/mitm_addon.py tests/test_auth_base_forwarder.py tests/test_error_handler.py tests/test_firewall_rewrite_forwarding.py tests/test_request_handler_firewall_dispatch.py`
- `pytest tests/test_auth_base_forwarder.py tests/test_firewall_rewrite_forwarding.py tests/test_request_handler_firewall_dispatch.py tests/test_request_handler_usage_tracking.py tests/test_error_handler.py`
- `pytest tests/`
