### PR TITLE
ci: guard balloon pressure allocation

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1559,8 +1559,10 @@ jobs:
             local output
             local val
             output=$(sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- grep MemAvailable /proc/meminfo 2>/dev/null) || return 1
-            val=$(printf '%s\n' "$output" | tr -s ' ' | cut -d' ' -f2)
-            [ -n "$val" ] || return 1
+            val=$(printf '%s\n' "$output" | awk '/^MemAvailable:/ { print $2; exit }')
+            case "$val" in
+              ''|*[!0-9]*) return 1 ;;
+            esac
             echo "$val"
           }
 

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1483,6 +1483,8 @@ jobs:
           RUNNER_DIR="/var/lib/vm0-runner/runners/${JOB_REF}-balloon"
           SVC="${JOB_REF}-balloon"
           GROUP="vm0/balloon-${JOB_REF}"
+          SUBMIT_PID=""
+          ALLOC_PID=""
 
           fail() {
             echo "FAIL: $1"
@@ -1497,6 +1499,14 @@ jobs:
 
           cleanup() {
             echo "--- Cleanup ---"
+            if [ -n "$ALLOC_PID" ]; then
+              kill "$ALLOC_PID" 2>/dev/null || true
+              wait "$ALLOC_PID" 2>/dev/null || true
+            fi
+            if [ -n "$SUBMIT_PID" ]; then
+              kill "$SUBMIT_PID" 2>/dev/null || true
+              wait "$SUBMIT_PID" 2>/dev/null || true
+            fi
             sudo "$BIN_DIR/runner" service stop --name "$SVC" --force || true
           }
           trap cleanup EXIT
@@ -1653,8 +1663,9 @@ jobs:
           # allocator. The host kill does NOT propagate to the guest process
           # because vsock-guest spawns it independently.
           echo "--- Test 3: balloon re-inflate after pressure release ---"
-          kill $ALLOC_PID 2>/dev/null || true
-          wait $ALLOC_PID 2>/dev/null || true
+          kill "$ALLOC_PID" 2>/dev/null || true
+          wait "$ALLOC_PID" 2>/dev/null || true
+          ALLOC_PID=""
 
           # Verify VM survived the memory pressure test
           vm_alive || fail "VM crashed during memory pressure test"

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1503,11 +1503,11 @@ jobs:
               kill "$ALLOC_PID" 2>/dev/null || true
               wait "$ALLOC_PID" 2>/dev/null || true
             fi
+            sudo "$BIN_DIR/runner" service stop --name "$SVC" --force || true
             if [ -n "$SUBMIT_PID" ]; then
               kill "$SUBMIT_PID" 2>/dev/null || true
               wait "$SUBMIT_PID" 2>/dev/null || true
             fi
-            sudo "$BIN_DIR/runner" service stop --name "$SVC" --force || true
           }
           trap cleanup EXIT
 

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1571,6 +1571,7 @@ jobs:
           ensure_submit_running() {
             if ! kill -0 "$SUBMIT_PID" 2>/dev/null; then
               wait "$SUBMIT_PID" 2>/dev/null || true
+              SUBMIT_PID=""
               fail "keepalive submit exited before balloon test completed"
             fi
           }

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1501,9 +1501,11 @@ jobs:
             echo "--- Cleanup ---"
             if [ -n "$ALLOC_PID" ]; then
               kill "$ALLOC_PID" 2>/dev/null || true
-              wait "$ALLOC_PID" 2>/dev/null || true
             fi
             sudo "$BIN_DIR/runner" service stop --name "$SVC" --force || true
+            if [ -n "$ALLOC_PID" ]; then
+              wait "$ALLOC_PID" 2>/dev/null || true
+            fi
             if [ -n "$SUBMIT_PID" ]; then
               kill "$SUBMIT_PID" 2>/dev/null || true
               wait "$SUBMIT_PID" 2>/dev/null || true

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1522,12 +1522,24 @@ jobs:
           # Start transient runner service
           echo "--- Starting runner ---"
           sudo "$BIN_DIR/runner" service start --name "$SVC" \
-            --config "$RUNNER_DIR/runner.yaml" --local --env USE_MOCK_CLAUDE=true --env USE_MOCK_CODEX=true
+            --config "$RUNNER_DIR/runner.yaml" --local --env USE_MOCK_CLAUDE=true --env USE_MOCK_CODEX=true \
+            || fail "failed to start balloon service"
 
           # Submit a long-running job in background (keeps sandbox alive during tests)
           echo "--- Submitting long-running job ---"
           sudo "$BIN_DIR/runner" local submit --group "$GROUP" --prompt 'sleep 360 && echo done' &
           SUBMIT_PID=$!
+
+          # Helper: fail fast if the keepalive job exits before the balloon
+          # assertions finish. Otherwise a dead sandbox can look like
+          # actual_mib=0 and produce misleading follow-on failures.
+          ensure_submit_running() {
+            if ! kill -0 "$SUBMIT_PID" 2>/dev/null; then
+              wait "$SUBMIT_PID" 2>/dev/null || true
+              SUBMIT_PID=""
+              fail "keepalive submit exited before balloon test completed"
+            fi
+          }
 
           # Wait for sandbox control socket. Socket and api.sock paths use
           # sandbox_id (distinct from run_id after #9552). `runner exec`
@@ -1535,6 +1547,7 @@ jobs:
           # is what we need here.
           echo "--- Waiting for sandbox control socket ---"
           for i in $(seq 1 60); do
+            ensure_submit_running
             SANDBOX_ID=$(sudo jq -r '.active_runs[0].sandbox_id // empty' \
               "$RUNNER_DIR/status.json" 2>/dev/null)
             [ -n "$SANDBOX_ID" ] && [ -S "/run/vm0/sock/$SANDBOX_ID/control.sock" ] && break
@@ -1569,17 +1582,6 @@ jobs:
           # Helper: check if VM is still alive
           vm_alive() {
             sudo curl -sf --unix-socket "$API_SOCK" http://localhost/ >/dev/null 2>&1
-          }
-
-          # Helper: fail fast if the keepalive job exits before the balloon
-          # assertions finish. Otherwise a dead sandbox can look like
-          # actual_mib=0 and produce misleading follow-on failures.
-          ensure_submit_running() {
-            if ! kill -0 "$SUBMIT_PID" 2>/dev/null; then
-              wait "$SUBMIT_PID" 2>/dev/null || true
-              SUBMIT_PID=""
-              fail "keepalive submit exited before balloon test completed"
-            fi
           }
 
           # Test 1: idle inflate — balloon controller gradually reclaims idle guest memory

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1608,21 +1608,26 @@ jobs:
 
           # Test 2: deflate under memory pressure — allocate anonymous memory
           # in the guest to push available below deflate threshold (192 MiB).
-          # Refuse to allocate when the idle balloon state already leaves too
-          # little guest headroom; otherwise the allocator can starve the
+          # Scale the allocator down when the idle balloon state already leaves
+          # limited guest headroom; otherwise the allocator can starve the
           # keepalive job and mask the assertion as "cancelled by user".
           # Trailing `# BALLOON_ALLOC_MARKER` is a unique string pkill can
           # match on to terminate the guest-side allocator below.
           echo "--- Test 2: balloon deflate under memory pressure ---"
-          PRESSURE_ALLOC_MIB=300
-          PRESSURE_SAFETY_MARGIN_MIB=128
-          MIN_PRESSURE_AVAIL_MIB=$(( PRESSURE_ALLOC_MIB + PRESSURE_SAFETY_MARGIN_MIB ))
-          MIN_PRESSURE_AVAIL_KB=$(( MIN_PRESSURE_AVAIL_MIB * 1024 ))
+          MAX_PRESSURE_ALLOC_MIB=300
+          MIN_PRESSURE_REMAINING_MIB=128
+          MIN_PRESSURE_AVAIL_KB=$(( MIN_PRESSURE_REMAINING_MIB * 1024 ))
           ensure_submit_running
           PRE_PRESSURE_AVAIL_KB=$(guest_avail_kb) || fail "failed to read guest MemAvailable before pressure allocation"
-          if [ "$PRE_PRESSURE_AVAIL_KB" -lt "$MIN_PRESSURE_AVAIL_KB" ]; then
-            fail "guest MemAvailable too low before pressure allocation: ${PRE_PRESSURE_AVAIL_KB}kB (need >= ${MIN_PRESSURE_AVAIL_KB}kB; allocation=${PRESSURE_ALLOC_MIB}MiB, margin=${PRESSURE_SAFETY_MARGIN_MIB}MiB)"
+          if [ "$PRE_PRESSURE_AVAIL_KB" -le "$MIN_PRESSURE_AVAIL_KB" ]; then
+            fail "guest MemAvailable too low before pressure allocation: ${PRE_PRESSURE_AVAIL_KB}kB (need > ${MIN_PRESSURE_AVAIL_KB}kB)"
           fi
+          PRE_PRESSURE_AVAIL_MIB=$(( PRE_PRESSURE_AVAIL_KB / 1024 ))
+          PRESSURE_ALLOC_MIB=$(( PRE_PRESSURE_AVAIL_MIB - MIN_PRESSURE_REMAINING_MIB ))
+          if [ "$PRESSURE_ALLOC_MIB" -gt "$MAX_PRESSURE_ALLOC_MIB" ]; then
+            PRESSURE_ALLOC_MIB=$MAX_PRESSURE_ALLOC_MIB
+          fi
+          [ "$PRESSURE_ALLOC_MIB" -gt 0 ] || fail "pressure allocation would be zero: ${PRE_PRESSURE_AVAIL_KB}kB available"
           echo "Pre-pressure guest MemAvailable: ${PRE_PRESSURE_AVAIL_KB}kB; allocating ${PRESSURE_ALLOC_MIB}MiB"
           sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- python3 -c "import ctypes,time; b=bytearray(${PRESSURE_ALLOC_MIB}*1024*1024); ctypes.memset((ctypes.c_char*len(b)).from_buffer(b),1,len(b)); time.sleep(120)  # BALLOON_ALLOC_MARKER" &
           ALLOC_PID=$!
@@ -1654,8 +1659,8 @@ jobs:
           # Verify VM survived the memory pressure test
           vm_alive || fail "VM crashed during memory pressure test"
 
-          # Kill guest-side allocator — balloon has already deflated (Test 2
-          # passed), so guest has ~250 MiB available, enough for pkill exec.
+          # Kill guest-side allocator — Test 2 passing means the controller has
+          # already returned memory to the guest, enough for pkill exec.
           sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- pkill -f BALLOON_ALLOC_MARKER 2>/dev/null || true
 
           # Wait for balloon to re-inflate past midpoint between deflate and original inflate

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1606,14 +1606,25 @@ jobs:
           [ "$AVAIL" -lt 1536000 ] || fail "MemAvailable too high after balloon: ${AVAIL}kB (expected < 1536000kB)"
           echo "PASS: guest MemAvailable reduced (${AVAIL}kB)"
 
-          # Test 2: deflate under memory pressure — allocate 300 MiB anonymous memory
+          # Test 2: deflate under memory pressure — allocate anonymous memory
           # in the guest to push available below deflate threshold (192 MiB).
-          # After inflate stabilizes (~1438 MiB), guest has ~476 MiB available.
-          # 300 MiB alloc drops available to ~176 MiB < 192 MiB threshold.
+          # Refuse to allocate when the idle balloon state already leaves too
+          # little guest headroom; otherwise the allocator can starve the
+          # keepalive job and mask the assertion as "cancelled by user".
           # Trailing `# BALLOON_ALLOC_MARKER` is a unique string pkill can
           # match on to terminate the guest-side allocator below.
           echo "--- Test 2: balloon deflate under memory pressure ---"
-          sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- python3 -c 'import ctypes,time; b=bytearray(300*1024*1024); ctypes.memset((ctypes.c_char*len(b)).from_buffer(b),1,len(b)); time.sleep(120)  # BALLOON_ALLOC_MARKER' &
+          PRESSURE_ALLOC_MIB=300
+          PRESSURE_SAFETY_MARGIN_MIB=128
+          MIN_PRESSURE_AVAIL_MIB=$(( PRESSURE_ALLOC_MIB + PRESSURE_SAFETY_MARGIN_MIB ))
+          MIN_PRESSURE_AVAIL_KB=$(( MIN_PRESSURE_AVAIL_MIB * 1024 ))
+          ensure_submit_running
+          PRE_PRESSURE_AVAIL_KB=$(guest_avail_kb) || fail "failed to read guest MemAvailable before pressure allocation"
+          if [ "$PRE_PRESSURE_AVAIL_KB" -lt "$MIN_PRESSURE_AVAIL_KB" ]; then
+            fail "guest MemAvailable too low before pressure allocation: ${PRE_PRESSURE_AVAIL_KB}kB (need >= ${MIN_PRESSURE_AVAIL_KB}kB; allocation=${PRESSURE_ALLOC_MIB}MiB, margin=${PRESSURE_SAFETY_MARGIN_MIB}MiB)"
+          fi
+          echo "Pre-pressure guest MemAvailable: ${PRE_PRESSURE_AVAIL_KB}kB; allocating ${PRESSURE_ALLOC_MIB}MiB"
+          sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- python3 -c "import ctypes,time; b=bytearray(${PRESSURE_ALLOC_MIB}*1024*1024); ctypes.memset((ctypes.c_char*len(b)).from_buffer(b),1,len(b)); time.sleep(120)  # BALLOON_ALLOC_MARKER" &
           ALLOC_PID=$!
 
           # Wait for balloon to deflate (actual_mib decreases)

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1514,8 +1514,10 @@ jobs:
           trap cleanup EXIT
 
           # Clean up any residual transient unit from a previous CI run.
-          # stop() returns Ok when no service exists, so no need for || true.
-          sudo "$BIN_DIR/runner" service stop --name "$SVC" --force
+          # stop() returns Ok when no service exists, so any non-zero exit is
+          # a real cleanup failure.
+          sudo "$BIN_DIR/runner" service stop --name "$SVC" --force \
+            || fail "failed to stop residual balloon service"
 
           # Start transient runner service
           echo "--- Starting runner ---"
@@ -1694,7 +1696,8 @@ jobs:
           echo "PASS: balloon re-inflated from ${DEFLATE_MIB} to ${ACTUAL} MiB (midpoint=${MIDPOINT})"
 
           # Stop transient service
-          sudo "$BIN_DIR/runner" service stop --name "$SVC" --force
+          sudo "$BIN_DIR/runner" service stop --name "$SVC" --force \
+            || fail "failed to stop balloon service"
           kill "$SUBMIT_PID" 2>/dev/null || true
           wait "$SUBMIT_PID" 2>/dev/null || true
           trap - EXIT


### PR DESCRIPTION
## Summary
- add a guest MemAvailable check before the runner balloon pressure allocation
- parse guest MemAvailable from the exact meminfo field and reject non-numeric output before arithmetic
- fail immediately if the balloon service cannot start or the keepalive submit exits while waiting for the sandbox socket
- keep the existing 300MiB pressure allocation when there is enough guest headroom
- scale the pressure allocation down when idle balloon state already leaves limited guest headroom, while preserving a 128MiB safety floor
- fail with explicit diagnostics only when guest MemAvailable is already too low to allocate safely
- clean up balloon test child processes on early failure, stopping the transient runner service before waiting for keepalive submit or allocator cleanup
- clear the keepalive submit PID after it is reaped to avoid cleanup acting on a reused PID
- fail the balloon test if required service stop calls fail instead of disabling cleanup and reporting success

## Testing
- git diff --check
- extracted runner-balloon remote script body with bash -n
- extracted full runner-balloon heredoc script with bash -n
- verified MemAvailable parser accepts the expected meminfo line
- verified bash child exit detection with kill -0/wait