### PR TITLE
fix(desktop): raise helper app hang threshold

### DIFF
--- a/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
+++ b/turbo/apps/desktop/native/computer-use-helper/Sources/ComputerUseHelper/main.swift
@@ -57,6 +57,7 @@ func startSentry() {
         options.tracesSampleRate = NSNumber(value: 0)
         options.enableAutoPerformanceTracing = false
         options.enableUncaughtNSExceptionReporting = true
+        options.appHangTimeoutInterval = 5
         options.initialScope = { scope in
             scope.setTag(value: "desktop", key: "app")
             scope.setTag(value: "computer-use-helper", key: "component")


### PR DESCRIPTION
## Summary
- raise the native computer-use helper Sentry AppHang threshold from the SDK default 2s to 5s
- keep runtime request and Sentry flush timeouts unchanged

## Testing
- git diff --check
- pnpm -F @vm0/desktop check-types

## Notes
- Swift is not installed in this Linux container, so native Swift compilation is covered by macOS CI.