### PR TITLE
Support video template onboarding and Pro video gate

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-video-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-video-io-generate.test.ts
@@ -601,8 +601,9 @@ describe("POST /api/zero/video-io/generate", () => {
     expect(response.status).toBe(402);
     await expect(response.json()).resolves.toStrictEqual({
       error: {
-        message: "Upgrade to Pro to generate videos.",
-        code: "INSUFFICIENT_CREDITS",
+        message:
+          "Built-in video generation requires Pro. Return `pro_required` as the assistant error marker so the app can show the Pro upgrade card. Do not retry video generation until the workspace upgrades.",
+        code: "PRO_REQUIRED",
       },
     });
     expect(calledBytePlus).toBeFalsy();

--- a/turbo/apps/api/src/signals/services/run-error-format.service.ts
+++ b/turbo/apps/api/src/signals/services/run-error-format.service.ts
@@ -22,6 +22,7 @@ import { getMemberRoleAndUpdateCache$ } from "./auth.service";
 
 const REPORT_ERROR_STREAK_THRESHOLD = 2;
 const CHAT_RUN_REPORTABLE_ERROR_MESSAGE = "An unexpected error occurred.";
+const PRO_REQUIRED_MARKER = "pro_required";
 
 interface RunErrorProviderContext {
   readonly userId: string;
@@ -67,6 +68,10 @@ function buildClaudeCodeCredentialRecoveryUrl(params: {
     return buildPersonalModelProvidersUrl();
   }
   return buildModelProvidersUrl();
+}
+
+function isProRequiredRunError(message: string): boolean {
+  return message.toLowerCase().includes(PRO_REQUIRED_MARKER);
 }
 
 function formatLatestSessionProviderType(
@@ -160,6 +165,10 @@ function formatRunErrorLikeWebMessage(
 ): Computed<Promise<string>> {
   return computed(async (get): Promise<string> => {
     const errorMessage = params.errorMessage.trim() || "Run failed";
+    if (isProRequiredRunError(errorMessage)) {
+      return PRO_REQUIRED_MARKER;
+    }
+
     const providerContext =
       params.modelProviderType !== undefined &&
       params.modelProviderCredentialScope !== undefined

--- a/turbo/apps/api/src/signals/services/zero-video-io-generate.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-video-io-generate.service.ts
@@ -534,8 +534,8 @@ export function videoRequiresPro() {
   return {
     status: 402 as const,
     body: errorBody(
-      "Upgrade to Pro to generate videos.",
-      "INSUFFICIENT_CREDITS",
+      "Built-in video generation requires Pro. Return `pro_required` as the assistant error marker so the app can show the Pro upgrade card. Do not retry video generation until the workspace upgrades.",
+      "PRO_REQUIRED",
     ),
   };
 }

--- a/turbo/apps/platform/src/signals/prompt-page/prompt-page-setup.ts
+++ b/turbo/apps/platform/src/signals/prompt-page/prompt-page-setup.ts
@@ -1,5 +1,7 @@
 import { command } from "ccstate";
 import { isSupportedRunModel } from "@vm0/api-contracts/contracts/model-providers";
+import type { GenerationTemplateRequest } from "@vm0/api-contracts/contracts/chat-threads";
+import { findVideoTemplateItem } from "@vm0/core";
 import { sendNewThreadOptimistically$ } from "../chat-page/optimistic-chat-thread-page.ts";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { orgModelPolicies$ } from "../external/org-model-policies.ts";
@@ -22,6 +24,23 @@ import {
   resolveModelFirstUserDefaultSelection,
 } from "../zero-page/model-default-selection.ts";
 
+function generationTemplateFromSearchParam(
+  template: string | null,
+): GenerationTemplateRequest | undefined {
+  const id = template?.trim();
+  if (!id) {
+    return undefined;
+  }
+  const videoTemplate = findVideoTemplateItem(id);
+  if (!videoTemplate) {
+    return undefined;
+  }
+  return {
+    type: "video",
+    selection: { stylePresetId: videoTemplate.id },
+  };
+}
+
 /**
  * Lightweight prompt deep-link endpoint.
  *
@@ -37,6 +56,9 @@ export const setupPromptPage$ = command(
     const params = get(searchParams$);
     const prompt = params.get("prompt")?.trim();
     const requestedModel = params.get("model")?.trim();
+    const generationTemplate = generationTemplateFromSearchParam(
+      params.get("template"),
+    );
     if (!prompt) {
       set(detachedNavigateTo$, "/", { replace: true });
       return;
@@ -72,6 +94,7 @@ export const setupPromptPage$ = command(
     const cleaned = new URLSearchParams(params);
     cleaned.delete("prompt");
     cleaned.delete("model");
+    cleaned.delete("template");
     cleaned.delete("connector");
     set(updateSearchParams$, cleaned);
 
@@ -82,7 +105,7 @@ export const setupPromptPage$ = command(
         agentId,
         prompt,
         modelSelection,
-        generationTemplate: undefined,
+        generationTemplate,
         computerUseHostId: null,
       },
       rootSignal,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -4718,6 +4718,36 @@ describe("chat lifecycle", () => {
     });
   });
 
+  it("shows Pro upgrade guidance when built-in video requires Pro", async () => {
+    const threadId = "failed-guidance-video-pro";
+    mockFailedAssistantThread({ threadId, error: "pro_required" });
+    context.mocks.api(
+      zeroBillingCheckoutContract.create,
+      ({ body, respond }) => {
+        return respond(200, {
+          url: `https://checkout.stripe.com/recover?tier=${body.tier}`,
+        });
+      },
+    );
+
+    detachedSetupPage({ context, path: `/chats/${threadId}` });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Upgrade to Pro to run Zero"),
+      ).toBeInTheDocument();
+      expect(buttonByText("Upgrade to Pro")).toBeInTheDocument();
+    });
+
+    click(buttonByText("Upgrade to Pro"));
+
+    await waitFor(() => {
+      expect(window.location.href).toBe(
+        "https://checkout.stripe.com/recover?tier=pro",
+      );
+    });
+  });
+
   it("shows Pro upgrade guidance for limited-free-1 even with credits", async () => {
     const threadId = "failed-guidance-limited-free";
     mockFailedAssistantThread({ threadId, error: "insufficient_credits" });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/prompt-param-injection.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/prompt-param-injection.test.tsx
@@ -1,5 +1,6 @@
 import { screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+import { VIDEO_TEMPLATE_ITEMS } from "@vm0/core";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { mockChatLifecycle, PLACEHOLDER } from "./chat-test-helpers.ts";
@@ -52,6 +53,36 @@ describe("prompt query parameter injection", () => {
       expect(screen.getByText("Build a launch recap")).toBeInTheDocument();
       expect(runPrompt).toBe("Build a launch recap");
       expect(selectedModel).toBe("deepseek-v4-pro");
+    });
+  });
+
+  it("starts an optimistic video template chat from the prompt route", async () => {
+    const videoTemplate = VIDEO_TEMPLATE_ITEMS.find((item) => {
+      return item.id === "video-template:luxury-product";
+    });
+    expect(videoTemplate).toBeDefined();
+
+    let runPrompt: string | undefined;
+    let stylePresetId: string | undefined;
+    mockChatLifecycle(context, {
+      onRunCreate: (body) => {
+        runPrompt = body.prompt;
+        stylePresetId =
+          body.generationTemplate?.type === "video"
+            ? body.generationTemplate.selection.stylePresetId
+            : undefined;
+      },
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/prompt?prompt=Make%20a%20product%20spot&template=video-template%3Aluxury-product",
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Make a product spot")).toBeInTheDocument();
+      expect(runPrompt).toBe("Make a product spot");
+      expect(stylePresetId).toBe(videoTemplate?.id);
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -5627,12 +5627,17 @@ function InsufficientCreditsCard() {
   );
 }
 
+function isBillingRecoveryError(error: string): boolean {
+  const normalized = error.trim().toLowerCase();
+  return normalized === "insufficient_credits" || normalized === "pro_required";
+}
+
 function AssistantErrorContent({ error }: { error: string }) {
   const setOrgManageOpen = useSet(setOrgManageDialogOpen$);
   const setTab = useSet(setActiveOrgManageTab$);
   const pageSignal = useGet(pageSignal$);
 
-  if (error === "insufficient_credits") {
+  if (isBillingRecoveryError(error)) {
     return <InsufficientCreditsCard />;
   }
 

--- a/turbo/apps/web/__tests__/proxy.public-routes.test.ts
+++ b/turbo/apps/web/__tests__/proxy.public-routes.test.ts
@@ -203,6 +203,39 @@ describe("proxy middleware: public routes", () => {
     expect(response?.status).toBe(202);
   });
 
+  it("uses the SO origin as forwarded host for SO frontend server actions", async () => {
+    vi.stubEnv("NEXT_PUBLIC_PAID_ONBOARDING_URL", "https://so.vm0.ai");
+    reloadEnv();
+    const fetchMock = vi.fn<typeof fetch>(async () => {
+      return new Response("proxied", { status: 202 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const request = new NextRequest("https://www.vm0.ai/en", {
+      method: "POST",
+      headers: {
+        "next-action": "abc123",
+        origin: "https://www.vm0.ai",
+        referer: "https://www.vm0.ai/en",
+      },
+    });
+
+    const response = await middleware(request, createMockEvent());
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [, init] = fetchMock.mock.calls[0] ?? [];
+    expect(init).toBeDefined();
+    if (!init) {
+      throw new Error("Expected fetch init");
+    }
+    const proxiedHeaders = init.headers as Headers;
+    expect(proxiedHeaders.get("origin")).toBe("https://so.vm0.ai");
+    expect(proxiedHeaders.get("referer")).toBe("https://so.vm0.ai/en");
+    expect(proxiedHeaders.get("x-forwarded-host")).toBe("so.vm0.ai");
+    expect(proxiedHeaders.get("x-forwarded-proto")).toBe("https");
+    expect(response?.status).toBe(202);
+  });
+
   it("does not proxy non-GET requests when so frontend forwarding is disabled", async () => {
     const request = new NextRequest("https://www.vm0.ai/en", {
       method: "POST",

--- a/turbo/apps/web/__tests__/proxy.public-routes.test.ts
+++ b/turbo/apps/web/__tests__/proxy.public-routes.test.ts
@@ -272,6 +272,36 @@ describe("proxy middleware: public routes", () => {
     expect(response.status).toBe(202);
   });
 
+  it("proxies sign-up verification routes to so while preserving redirect_url", async () => {
+    vi.stubEnv("NEXT_PUBLIC_PAID_ONBOARDING_URL", "https://so.vm0.ai");
+    vi.stubEnv("VERCEL_ENV", "production");
+    reloadEnv();
+    const forwardedRequests = captureForwardedRequests(
+      "post",
+      "https://so.vm0.ai/sign-up/verify-email-address",
+      new HttpResponse("verification proxied", { status: 202 }),
+    );
+
+    const request = new NextRequest(
+      "https://www.vm0.ai/sign-up/verify-email-address?redirect_url=https%3A%2F%2Fapp.vm0.ai%2Fagents%2F4f189ea8-ada2-416d-83a9-9c25ddb960c9%2Fchat",
+      {
+        method: "POST",
+      },
+    );
+
+    const response = await middleware(request, createMockEvent());
+
+    expect(forwardedRequests).toHaveLength(1);
+    expect(forwardedRequests[0]?.url).toBe(
+      "https://so.vm0.ai/sign-up/verify-email-address?redirect_url=https%3A%2F%2Fapp.vm0.ai%2Fagents%2F4f189ea8-ada2-416d-83a9-9c25ddb960c9%2Fchat",
+    );
+    expect(response).toBeDefined();
+    if (!response) {
+      throw new Error("Expected verification proxy response");
+    }
+    expect(response.status).toBe(202);
+  });
+
   it("does not proxy app-only functional routes when so forwarding is enabled", async () => {
     vi.stubEnv("NEXT_PUBLIC_PAID_ONBOARDING_URL", "https://so.vm0.ai");
     reloadEnv();

--- a/turbo/apps/web/__tests__/so-frontend-rewrites.test.ts
+++ b/turbo/apps/web/__tests__/so-frontend-rewrites.test.ts
@@ -113,9 +113,9 @@ describe("so frontend rewrites", () => {
     expect(matchesSoFrontendRewritePath("/assets/vm0-logo.svg")).toBe(true);
 
     expect(matchesSoFrontendRewritePath("/sign-in/sso-callback")).toBe(true);
-    expect(
-      matchesSoFrontendRewritePath("/sign-up/verify-email-address"),
-    ).toBe(true);
+    expect(matchesSoFrontendRewritePath("/sign-up/verify-email-address")).toBe(
+      true,
+    );
     expect(matchesSoFrontendRewritePath("/connector/success")).toBe(false);
     expect(matchesSoFrontendRewritePath("/desktop-auth/start")).toBe(false);
     expect(matchesSoFrontendRewritePath("/api/zero/billing/status")).toBe(
@@ -136,9 +136,9 @@ describe("so frontend rewrites", () => {
     expect(resolveSoFrontendRewritePath("/sign-in/factor-one")).toBe(
       "/sign-in/factor-one",
     );
-    expect(
-      resolveSoFrontendRewritePath("/sign-up/verify-email-address"),
-    ).toBe("/sign-up/verify-email-address");
+    expect(resolveSoFrontendRewritePath("/sign-up/verify-email-address")).toBe(
+      "/sign-up/verify-email-address",
+    );
     expect(resolveSoFrontendRewritePath("/connector/success")).toBeUndefined();
   });
 });

--- a/turbo/apps/web/__tests__/so-frontend-rewrites.test.ts
+++ b/turbo/apps/web/__tests__/so-frontend-rewrites.test.ts
@@ -60,6 +60,10 @@ describe("so frontend rewrites", () => {
       source: "/sign-up",
       destination: "https://pr-123-so.vm6.ai/sign-up",
     });
+    expect(rewrites).toContainEqual({
+      source: "/sign-up/:path*",
+      destination: "https://pr-123-so.vm6.ai/sign-up/:path*",
+    });
   });
 
   it("rewrites sign-in/sign-up when a so frontend target is configured", () => {
@@ -75,6 +79,10 @@ describe("so frontend rewrites", () => {
     expect(rewrites).toContainEqual({
       source: "/sign-up",
       destination: "https://so.vm0.ai/sign-up",
+    });
+    expect(rewrites).toContainEqual({
+      source: "/sign-up/:path*",
+      destination: "https://so.vm0.ai/sign-up/:path*",
     });
   });
 
@@ -105,6 +113,9 @@ describe("so frontend rewrites", () => {
     expect(matchesSoFrontendRewritePath("/assets/vm0-logo.svg")).toBe(true);
 
     expect(matchesSoFrontendRewritePath("/sign-in/sso-callback")).toBe(true);
+    expect(
+      matchesSoFrontendRewritePath("/sign-up/verify-email-address"),
+    ).toBe(true);
     expect(matchesSoFrontendRewritePath("/connector/success")).toBe(false);
     expect(matchesSoFrontendRewritePath("/desktop-auth/start")).toBe(false);
     expect(matchesSoFrontendRewritePath("/api/zero/billing/status")).toBe(
@@ -125,6 +136,9 @@ describe("so frontend rewrites", () => {
     expect(resolveSoFrontendRewritePath("/sign-in/factor-one")).toBe(
       "/sign-in/factor-one",
     );
+    expect(
+      resolveSoFrontendRewritePath("/sign-up/verify-email-address"),
+    ).toBe("/sign-up/verify-email-address");
     expect(resolveSoFrontendRewritePath("/connector/success")).toBeUndefined();
   });
 });

--- a/turbo/apps/web/proxy.ts
+++ b/turbo/apps/web/proxy.ts
@@ -332,8 +332,7 @@ export const config = {
     // - _vercel (Vercel internals)
     // - assets (static assets)
     // - files with extensions (images, fonts, etc.)
-    // - sign-in and sign-up (Clerk auth pages, no i18n)
-    "/((?!_next|_vercel|assets|sign-in|sign-up|.*\\..*).*)",
+    "/((?!_next|_vercel|assets|.*\\..*).*)",
     // Match API routes for CORS handling
     "/(api|v1|trpc)(.*)",
   ],

--- a/turbo/apps/web/proxy.ts
+++ b/turbo/apps/web/proxy.ts
@@ -116,6 +116,10 @@ const HOP_BY_HOP_HEADERS = [
   "upgrade",
 ];
 
+function isServerActionRequest(request: NextRequest): boolean {
+  return request.headers.has("next-action");
+}
+
 function apiBackendProxyPassThrough(request: NextRequest): NextResponse {
   const requestHeaders = new Headers(request.headers);
   requestHeaders.set("x-forwarded-host", request.nextUrl.host);
@@ -172,13 +176,19 @@ async function proxySoFrontendRequest(
   targetUrl: URL,
 ): Promise<Response> {
   const requestHeaders = new Headers(request.headers);
+  const serverActionRequest = isServerActionRequest(request);
   for (const header of HOP_BY_HOP_HEADERS) {
     requestHeaders.delete(header);
   }
-  requestHeaders.set("x-forwarded-host", request.nextUrl.host);
+  requestHeaders.set(
+    "x-forwarded-host",
+    serverActionRequest ? targetUrl.host : request.nextUrl.host,
+  );
   requestHeaders.set(
     "x-forwarded-proto",
-    request.nextUrl.protocol.slice(0, -1),
+    serverActionRequest
+      ? targetUrl.protocol.slice(0, -1)
+      : request.nextUrl.protocol.slice(0, -1),
   );
 
   if (requestHeaders.get("origin") === request.nextUrl.origin) {


### PR DESCRIPTION
## Summary
- Support /prompt video template params by passing a video generation template into optimistic thread creation
- Return a PRO_REQUIRED video gate error with a pro_required marker instruction, and preserve that marker through run error formatting
- Show the existing Pro upgrade UI when chat assistant errors carry the pro_required marker

## Verification
- pnpm --dir turbo -F @vm0/app test -- src/views/zero-page/__tests__/chat-lifecycle.test.tsx src/views/zero-page/__tests__/prompt-param-injection.test.tsx
- pnpm --dir turbo -F @vm0/app check-types
- pnpm --dir turbo -F api check-types
- pnpm --dir turbo exec prettier --check apps/api/src/signals/services/zero-video-io-generate.service.ts apps/api/src/signals/routes/__tests__/zero-video-io-generate.test.ts apps/api/src/signals/services/run-error-format.service.ts apps/platform/src/signals/prompt-page/prompt-page-setup.ts apps/platform/src/views/zero-page/__tests__/prompt-param-injection.test.tsx apps/platform/src/views/zero-page/zero-chat-thread-page.tsx apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
- git diff --check