### PR TITLE
perf: optimize stored connector allowlist loading

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1161,6 +1161,37 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
 });
 
 describe("RUN-02: stored connector injection into claimed runs", () => {
+  it("omits connected stored connectors when the Zero run allowlist is empty", async () => {
+    const api = createRunsAutomationsApi(context);
+    const fw = createFirewallApi(context);
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+
+    await fw.seedTestConnector(actor, {
+      connectorName: "x",
+      authMethod: "oauth",
+      accessToken: "x-bdd-unallowed-access",
+      refreshToken: "x-bdd-unallowed-refresh",
+    });
+
+    const run = await api.createRun(actor, {
+      agentId,
+      prompt: "run without enabled stored connectors",
+      modelProvider: "anthropic-api-key",
+    });
+    await api.heartbeatRunner(runnerGroup);
+    const claim = await api.claimRunnerJob(run.runId);
+
+    expect(claim.environment ?? {}).not.toHaveProperty("X_TOKEN");
+    expect(claim.secretConnectorMap ?? {}).not.toHaveProperty("X_TOKEN");
+    expect(findFirewallEntry(claim.firewalls, "x")).toBeUndefined();
+    expect(claim.billableFirewalls).not.toContain("x");
+    expect(claim.networkPolicies ?? {}).not.toHaveProperty("x");
+
+    await api.requestCancelRun(actor, run.runId, [200]);
+    const cancelled = await api.readRun(actor, run.runId);
+    expect(cancelled.status).toBe("cancelled");
+  });
+
   it("injects oauth connector tokens with billable firewalls and resolvable secrets", async () => {
     const api = createRunsAutomationsApi(context);
     const fw = createFirewallApi(context);
@@ -1171,6 +1202,11 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
       authMethod: "oauth",
       accessToken: "x-bdd-access",
       refreshToken: "x-bdd-refresh",
+    });
+    await fw.seedTestConnector(actor, {
+      connectorName: "slack",
+      authMethod: "oauth",
+      accessToken: "xoxb-bdd-unenabled-access",
     });
     const enabled = await api.enableAgentConnectors(actor, agentId, ["x"]);
     expect(enabled).toContain("x");
@@ -1203,6 +1239,11 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     });
     expect(claim.billableFirewalls).toContain("x");
     expect(claim.networkPolicies?.x?.unknownPolicy).toBe("allow");
+    expect(claim.environment).not.toHaveProperty("SLACK_TOKEN");
+    expect(claim.secretConnectorMap).not.toHaveProperty("SLACK_TOKEN");
+    expect(findFirewallEntry(claim.firewalls, "slack")).toBeUndefined();
+    expect(claim.billableFirewalls).not.toContain("slack");
+    expect(claim.networkPolicies ?? {}).not.toHaveProperty("slack");
 
     // The stored access token is only readable through the firewall-auth
     // webhook with the claimed run's sandbox token.
@@ -1224,6 +1265,57 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     expect(resolved.body.headers).toStrictEqual({
       Authorization: "Bearer x-bdd-access",
     });
+
+    await api.requestCancelRun(actor, run.runId, [200]);
+    const cancelled = await api.readRun(actor, run.runId);
+    expect(cancelled.status).toBe("cancelled");
+  });
+
+  it("keeps direct runs without connector allowlists loading stored connectors", async () => {
+    const bdd = createBddApi(context);
+    const api = createRunsAutomationsApi(context);
+    const fw = createFirewallApi(context);
+    const actor = bdd.user();
+    bdd.acceptAgentStorageWrites();
+    api.acceptStorageDownloads();
+    api.acceptTelemetryIngest();
+    const runnerGroup = api.configureRunnerGroup();
+    await api.grantProEntitlement(actor);
+
+    await fw.seedTestConnector(actor, {
+      connectorName: "x",
+      authMethod: "oauth",
+      accessToken: "x-bdd-direct-access",
+      refreshToken: "x-bdd-direct-refresh",
+    });
+    const composeName = `bdd-direct-x-${randomUUID().slice(0, 8)}`;
+    const compose = await api.createCompose(actor, {
+      version: "1",
+      agents: {
+        [composeName]: {
+          framework: "claude-code",
+          environment: { ANTHROPIC_API_KEY: "bdd-inline-key" },
+        },
+      },
+    });
+
+    const run = await api.createDirectRun(actor, {
+      agentComposeId: compose.composeId,
+      prompt: "direct run should load connected stored connectors",
+    });
+    await api.heartbeatRunner(runnerGroup);
+    const claim = await api.claimRunnerJob(run.runId);
+
+    expect(claim.environment?.X_TOKEN).toBe(
+      connectorPlaceholder("x", "X_TOKEN"),
+    );
+    expect(claim.secretConnectorMap).toMatchObject({ X_TOKEN: "x" });
+    expect(findFirewallEntry(claim.firewalls, "x")).toStrictEqual({
+      kind: "builtin",
+      name: "x",
+    });
+    expect(claim.billableFirewalls).toContain("x");
+    expect(claim.networkPolicies?.x?.unknownPolicy).toBe("allow");
 
     await api.requestCancelRun(actor, run.runId, [200]);
     const cancelled = await api.readRun(actor, run.runId);

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1271,57 +1271,6 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     expect(cancelled.status).toBe("cancelled");
   });
 
-  it("keeps direct runs without connector allowlists loading stored connectors", async () => {
-    const bdd = createBddApi(context);
-    const api = createRunsAutomationsApi(context);
-    const fw = createFirewallApi(context);
-    const actor = bdd.user();
-    bdd.acceptAgentStorageWrites();
-    api.acceptStorageDownloads();
-    api.acceptTelemetryIngest();
-    const runnerGroup = api.configureRunnerGroup();
-    await api.grantProEntitlement(actor);
-
-    await fw.seedTestConnector(actor, {
-      connectorName: "x",
-      authMethod: "oauth",
-      accessToken: "x-bdd-direct-access",
-      refreshToken: "x-bdd-direct-refresh",
-    });
-    const composeName = `bdd-direct-x-${randomUUID().slice(0, 8)}`;
-    const compose = await api.createCompose(actor, {
-      version: "1",
-      agents: {
-        [composeName]: {
-          framework: "claude-code",
-          environment: { ANTHROPIC_API_KEY: "bdd-inline-key" },
-        },
-      },
-    });
-
-    const run = await api.createDirectRun(actor, {
-      agentComposeId: compose.composeId,
-      prompt: "direct run should load connected stored connectors",
-    });
-    await api.heartbeatRunner(runnerGroup);
-    const claim = await api.claimRunnerJob(run.runId);
-
-    expect(claim.environment?.X_TOKEN).toBe(
-      connectorPlaceholder("x", "X_TOKEN"),
-    );
-    expect(claim.secretConnectorMap).toMatchObject({ X_TOKEN: "x" });
-    expect(findFirewallEntry(claim.firewalls, "x")).toStrictEqual({
-      kind: "builtin",
-      name: "x",
-    });
-    expect(claim.billableFirewalls).toContain("x");
-    expect(claim.networkPolicies?.x?.unknownPolicy).toBe("allow");
-
-    await api.requestCancelRun(actor, run.runId, [200]);
-    const cancelled = await api.readRun(actor, run.runId);
-    expect(cancelled.status).toBe("cancelled");
-  });
-
   it("injects manual-grant api-token connectors and their optional variables", async () => {
     const api = createRunsAutomationsApi(context);
     const connectors = createConnectorBddApi(context);
@@ -2007,7 +1956,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     expect(overridden.unknownPolicy).toBe("allow");
   });
 
-  it("applies connector default named policies to direct runs without explicit policies", async () => {
+  it("loads stored connectors and applies default named policies to direct runs without explicit policies", async () => {
     const bdd = createBddApi(context);
     const api = createRunsAutomationsApi(context);
     const fw = createFirewallApi(context);
@@ -2040,6 +1989,17 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     });
     await api.heartbeatRunner(runnerGroup);
     const claim = await api.claimRunnerJob(run.runId);
+    expect(claim.environment?.CLOUDFLARE_TOKEN).toBe(
+      connectorPlaceholder("cloudflare", "CLOUDFLARE_TOKEN"),
+    );
+    expect(claim.secretConnectorMap).toMatchObject({
+      CLOUDFLARE_TOKEN: "cloudflare",
+    });
+    expect(findFirewallEntry(claim.firewalls, "cloudflare")).toStrictEqual({
+      kind: "builtin",
+      name: "cloudflare",
+    });
+
     const policy = claim.networkPolicies?.cloudflare;
     if (!policy) {
       throw new Error("Expected a cloudflare network policy on the claim");

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -2163,6 +2163,14 @@ async function loadStoredConnectorContext(
     readonly featureSwitchContext: FeatureSwitchContext;
   },
 ): Promise<ConnectorRuntimeContext> {
+  if (args.allowedConnectorTypes?.length === 0) {
+    return emptyConnectorRuntimeContext();
+  }
+
+  const allowedConnectorTypes = args.allowedConnectorTypes
+    ? [...new Set(args.allowedConnectorTypes)]
+    : undefined;
+
   return await db.transaction(async (tx) => {
     await tx.execute(
       sql`SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY`,
@@ -2179,6 +2187,9 @@ async function loadStoredConnectorContext(
         and(
           eq(connectors.orgId, args.orgId),
           eq(connectors.userId, args.userId),
+          allowedConnectorTypes
+            ? inArray(connectors.type, allowedConnectorTypes)
+            : undefined,
         ),
       );
     if (connectorRows.length === 0) {
@@ -2187,7 +2198,7 @@ async function loadStoredConnectorContext(
 
     const allowedConnectorRows = allowedStoredConnectorRows(
       connectorRows,
-      args.allowedConnectorTypes,
+      allowedConnectorTypes,
       nowDate(),
     );
     if (allowedConnectorRows.length === 0) {


### PR DESCRIPTION
## Summary
- skip stored connector loading entirely for explicit empty connector allowlists
- push explicit non-empty stored connector allowlists into the connector DB query
- add route integration coverage for Zero empty/narrow allowlists and direct-run undefined allowlist behavior

## Tests
- pnpm -F @vm0/db db:migrate
- pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
- pnpm -F api lint
- pnpm -F api check-types
- pre-commit: pnpm check-types

Fixes #18962