### PR TITLE
refactor: share firewall lazy loader rendering

### DIFF
--- a/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
@@ -692,10 +692,17 @@ describe("firewall metadata", () => {
       assertNoForbiddenMetadataKeys(detail, type);
     }
 
-    expect(isFirewallMetadataConnectorType("cloudinary")).toBe(false);
-    await expect(
-      loadFirewallPermissionMetadata("cloudinary"),
-    ).resolves.toBeNull();
+    for (const unknownType of [
+      "cloudinary",
+      "__proto__",
+      "constructor",
+      "toString",
+    ]) {
+      expect(isFirewallMetadataConnectorType(unknownType)).toBe(false);
+      await expect(
+        loadFirewallPermissionMetadata(unknownType),
+      ).resolves.toBeNull();
+    }
   });
 
   it("keeps execution metadata synchronized with runtime construction data", async () => {

--- a/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
@@ -14,7 +14,6 @@ import {
   permissionGrantsToFirewallPolicies,
   resolveFirewallMetadataPolicies,
 } from "../firewall-metadata";
-import { loadGeneratedFirewallPermissionMetadata } from "../firewall-metadata/loader.generated";
 import type {
   FirewallPermissionDetailMetadata,
   FirewallPermissionMetadataPermission,
@@ -702,9 +701,6 @@ describe("firewall metadata", () => {
       expect(isFirewallMetadataConnectorType(unknownType)).toBe(false);
       await expect(
         loadFirewallPermissionMetadata(unknownType),
-      ).resolves.toBeNull();
-      await expect(
-        loadGeneratedFirewallPermissionMetadata(unknownType),
       ).resolves.toBeNull();
     }
   });

--- a/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
@@ -14,6 +14,7 @@ import {
   permissionGrantsToFirewallPolicies,
   resolveFirewallMetadataPolicies,
 } from "../firewall-metadata";
+import { loadGeneratedFirewallPermissionMetadata } from "../firewall-metadata/loader.generated";
 import type {
   FirewallPermissionDetailMetadata,
   FirewallPermissionMetadataPermission,
@@ -701,6 +702,9 @@ describe("firewall metadata", () => {
       expect(isFirewallMetadataConnectorType(unknownType)).toBe(false);
       await expect(
         loadFirewallPermissionMetadata(unknownType),
+      ).resolves.toBeNull();
+      await expect(
+        loadGeneratedFirewallPermissionMetadata(unknownType),
       ).resolves.toBeNull();
     }
   });

--- a/turbo/packages/connectors/src/__tests__/firewall-runtime-loader.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-runtime-loader.test.ts
@@ -484,8 +484,15 @@ describe("firewall runtime loader", () => {
 
   it("loads and caches expanded connector firewalls", async () => {
     expect(isRuntimeFirewallConnectorType("slack")).toBe(true);
-    expect(isRuntimeFirewallConnectorType("cloudinary")).toBe(false);
-    await expect(loadConnectorFirewall("cloudinary")).resolves.toBeNull();
+    for (const unknownType of [
+      "cloudinary",
+      "__proto__",
+      "constructor",
+      "toString",
+    ]) {
+      expect(isRuntimeFirewallConnectorType(unknownType)).toBe(false);
+      await expect(loadConnectorFirewall(unknownType)).resolves.toBeNull();
+    }
 
     const [firstSlack, secondSlack] = await Promise.all([
       loadConnectorFirewall("slack"),

--- a/turbo/packages/firewalls-generator/src/__tests__/metadata.test.ts
+++ b/turbo/packages/firewalls-generator/src/__tests__/metadata.test.ts
@@ -268,6 +268,7 @@ describe("firewall metadata generator", () => {
     expect(loaderSource).toContain(
       "const FIREWALL_PERMISSION_METADATA_LOADERS",
     );
+    expect(loaderSource).toContain("Object.create(null)");
     expect(loaderSource).toContain(
       "export async function loadGeneratedFirewallPermissionMetadata",
     );
@@ -309,6 +310,7 @@ describe("firewall metadata generator", () => {
     expect(loaderSource).toContain(
       "export async function loadGeneratedRuntimeFirewall",
     );
+    expect(loaderSource).toContain("Object.create(null)");
     expect(new Set(dynamicSpecifiers).size).toBe(dynamicSpecifiers.length);
     expect(dynamicSpecifiers.length).toBe(
       runtimeLoaderConnectorTypes(loaderSource).length,

--- a/turbo/packages/firewalls-generator/src/__tests__/metadata.test.ts
+++ b/turbo/packages/firewalls-generator/src/__tests__/metadata.test.ts
@@ -93,7 +93,7 @@ function runtimeLoaderExportNames(source: string): Map<string, string> {
   return new Map(
     [
       ...source.matchAll(
-        /^\s*"([^"]+)": async \(\) => \{\n\s+return \(await import\("[^"]+"\)\)\.([a-zA-Z_$][\w$]*);\n\s+\},$/gm,
+        /^\s*"([^"]+)": async \(\) => \{\n\s+return \(await import\("[^"]+"\)\)\["([^"]+)"\];\n\s+\},$/gm,
       ),
     ].map((match) => {
       return [match[1]!, match[2]!] as const;
@@ -317,6 +317,6 @@ describe("firewall metadata generator", () => {
       expect(specifier).toMatch(/^\.\/[a-z0-9][a-z0-9-]*\.generated$/);
     }
     expect(loaderSource).toContain('"slack": async () =>');
-    expect(loaderSource).toContain(")).slackFirewall");
+    expect(loaderSource).toContain('))["slackFirewall"]');
   });
 });

--- a/turbo/packages/firewalls-generator/src/__tests__/metadata.test.ts
+++ b/turbo/packages/firewalls-generator/src/__tests__/metadata.test.ts
@@ -93,7 +93,7 @@ function runtimeLoaderExportNames(source: string): Map<string, string> {
   return new Map(
     [
       ...source.matchAll(
-        /^\s*"([^"]+)": async \(\) => \{\n\s+return \(await import\("[^"]+"\)\)\["([^"]+)"\];\n\s+\},$/gm,
+        /^\s+\["([^"]+)"\]: async \(\) => \{\n\s+return \(await import\("[^"]+"\)\)\["([^"]+)"\];\n\s+\},$/gm,
       ),
     ].map((match) => {
       return [match[1]!, match[2]!] as const;
@@ -318,7 +318,7 @@ describe("firewall metadata generator", () => {
     for (const specifier of dynamicSpecifiers) {
       expect(specifier).toMatch(/^\.\/[a-z0-9][a-z0-9-]*\.generated$/);
     }
-    expect(loaderSource).toContain('"slack": async () =>');
+    expect(loaderSource).toContain('["slack"]: async () =>');
     expect(loaderSource).toContain('))["slackFirewall"]');
   });
 });

--- a/turbo/packages/firewalls-generator/src/__tests__/metadata.test.ts
+++ b/turbo/packages/firewalls-generator/src/__tests__/metadata.test.ts
@@ -23,6 +23,7 @@ const CONNECTORS_DIR = path.resolve(
 const UNREGISTERED_GENERATED_FIREWALL_TYPES = ["daytona", "modal"] as const;
 const GENERATOR_SOURCE_BOUNDARY_FILES = [
   "../metadata.ts",
+  "../lazy-loader-renderer.ts",
   "../connector-firewall-manifest.ts",
   "../connector-firewall-sources.ts",
   "../python-builtin-firewall-catalog-composition.ts",
@@ -250,6 +251,35 @@ describe("firewall metadata generator", () => {
     expect(source).not.toContain('"rules"');
   });
 
+  it("keeps the generated metadata loader literal and nullable", () => {
+    const loaderSource = fs.readFileSync(
+      path.resolve(
+        import.meta.dirname,
+        "../../../connectors/src/firewall-metadata/loader.generated.ts",
+      ),
+      "utf-8",
+    );
+    const dynamicSpecifiers = dynamicImportSpecifiers(loaderSource);
+
+    expect(staticValueModuleSpecifiers(loaderSource)).toStrictEqual([]);
+    expect(dynamicSpecifiers).toContain("./details/slack.generated");
+    expect(dynamicSpecifiers).toContain("./details/github.generated");
+    expect(loaderSource).toContain("/firewall-metadata/v1/");
+    expect(loaderSource).toContain(
+      "const FIREWALL_PERMISSION_METADATA_LOADERS",
+    );
+    expect(loaderSource).toContain(
+      "export async function loadGeneratedFirewallPermissionMetadata",
+    );
+    expect(loaderSource).toContain("return null;");
+    expect(loaderSource).toContain("return await load();");
+    expect(new Set(dynamicSpecifiers).size).toBe(dynamicSpecifiers.length);
+    expect(dynamicSpecifiers.length).toBe(FIREWALL_CONNECTOR_TYPES.length);
+    for (const specifier of dynamicSpecifiers) {
+      expect(specifier).toMatch(/^\.\/details\/[a-z0-9][a-z0-9-]*\.generated$/);
+    }
+  });
+
   it("keeps the generated runtime loader literal and registry-shaped", () => {
     const loaderSource = fs.readFileSync(
       path.resolve(
@@ -270,6 +300,15 @@ describe("firewall metadata generator", () => {
     expect(dynamicSpecifiers).toContain("./slack.generated");
     expect(dynamicSpecifiers).toContain("./github.generated");
     expect(loaderSource).toContain("/firewall-runtime/v1/");
+    expect(loaderSource).toContain(
+      "export const RUNTIME_FIREWALL_CONNECTOR_TYPES",
+    );
+    expect(loaderSource).toContain(
+      "export function hasGeneratedRuntimeFirewall",
+    );
+    expect(loaderSource).toContain(
+      "export async function loadGeneratedRuntimeFirewall",
+    );
     expect(new Set(dynamicSpecifiers).size).toBe(dynamicSpecifiers.length);
     expect(dynamicSpecifiers.length).toBe(
       runtimeLoaderConnectorTypes(loaderSource).length,

--- a/turbo/packages/firewalls-generator/src/lazy-loader-renderer.ts
+++ b/turbo/packages/firewalls-generator/src/lazy-loader-renderer.ts
@@ -15,9 +15,19 @@ function compareEntryKeys(a: LazyLoaderEntry, b: LazyLoaderEntry): number {
 }
 
 function renderLazyLoaderEntry(entry: LazyLoaderEntry): string {
-  return `  ${JSON.stringify(entry.key)}: async () => {
+  return `  [${JSON.stringify(entry.key)}]: async () => {
     return (await import(${JSON.stringify(entry.moduleSpecifier)}))[${JSON.stringify(entry.exportName)}];
   },`;
+}
+
+function validateUniqueEntryKeys(entries: readonly LazyLoaderEntry[]): void {
+  const keys = new Set<string>();
+  for (const entry of entries) {
+    if (keys.has(entry.key)) {
+      throw new Error(`Duplicate lazy loader key: ${entry.key}`);
+    }
+    keys.add(entry.key);
+  }
 }
 
 export function renderLazyLoaderRecord({
@@ -25,6 +35,8 @@ export function renderLazyLoaderRecord({
   recordType,
   entries,
 }: LazyLoaderRecordOptions): string {
+  validateUniqueEntryKeys(entries);
+
   const renderedEntries = [...entries]
     .sort(compareEntryKeys)
     .map(renderLazyLoaderEntry)

--- a/turbo/packages/firewalls-generator/src/lazy-loader-renderer.ts
+++ b/turbo/packages/firewalls-generator/src/lazy-loader-renderer.ts
@@ -32,7 +32,9 @@ export function renderLazyLoaderRecord({
 
   return `const ${constName}: Readonly<
   ${recordType}
-> = {
+> = Object.assign(Object.create(null), {
 ${renderedEntries}
-};`;
+} satisfies Readonly<
+  ${recordType}
+>);`;
 }

--- a/turbo/packages/firewalls-generator/src/lazy-loader-renderer.ts
+++ b/turbo/packages/firewalls-generator/src/lazy-loader-renderer.ts
@@ -1,0 +1,38 @@
+export interface LazyLoaderEntry {
+  readonly key: string;
+  readonly moduleSpecifier: string;
+  readonly exportName: string;
+}
+
+interface LazyLoaderRecordOptions {
+  readonly constName: string;
+  readonly recordType: string;
+  readonly entries: readonly LazyLoaderEntry[];
+}
+
+function compareEntryKeys(a: LazyLoaderEntry, b: LazyLoaderEntry): number {
+  return a.key < b.key ? -1 : a.key > b.key ? 1 : 0;
+}
+
+function renderLazyLoaderEntry(entry: LazyLoaderEntry): string {
+  return `  ${JSON.stringify(entry.key)}: async () => {
+    return (await import(${JSON.stringify(entry.moduleSpecifier)})).${entry.exportName};
+  },`;
+}
+
+export function renderLazyLoaderRecord({
+  constName,
+  recordType,
+  entries,
+}: LazyLoaderRecordOptions): string {
+  const renderedEntries = [...entries]
+    .sort(compareEntryKeys)
+    .map(renderLazyLoaderEntry)
+    .join("\n");
+
+  return `const ${constName}: Readonly<
+  ${recordType}
+> = {
+${renderedEntries}
+};`;
+}

--- a/turbo/packages/firewalls-generator/src/lazy-loader-renderer.ts
+++ b/turbo/packages/firewalls-generator/src/lazy-loader-renderer.ts
@@ -16,7 +16,7 @@ function compareEntryKeys(a: LazyLoaderEntry, b: LazyLoaderEntry): number {
 
 function renderLazyLoaderEntry(entry: LazyLoaderEntry): string {
   return `  ${JSON.stringify(entry.key)}: async () => {
-    return (await import(${JSON.stringify(entry.moduleSpecifier)})).${entry.exportName};
+    return (await import(${JSON.stringify(entry.moduleSpecifier)}))[${JSON.stringify(entry.exportName)}];
   },`;
 }
 

--- a/turbo/packages/firewalls-generator/src/metadata.ts
+++ b/turbo/packages/firewalls-generator/src/metadata.ts
@@ -21,6 +21,10 @@ import {
   type ConnectorEnvBindingEntry,
   type ConnectorFirewallSource,
 } from "./connector-firewall-sources";
+import {
+  renderLazyLoaderRecord,
+  type LazyLoaderEntry,
+} from "./lazy-loader-renderer";
 
 const POLICY_VALUES = ["allow", "deny", "ask"] as const;
 const DEFAULT_FIREWALL_SECRET_PLACEHOLDER =
@@ -507,25 +511,23 @@ export const BUILTIN_FIREWALL_FIXED_HOST_OWNERS = ${stableJson(fixedHostOwners)}
 }
 
 function renderLoaderFile(types: readonly FirewallConnectorType[]): string {
-  const loaders = types
-    .map((type) => {
-      const key = JSON.stringify(type);
-      const specifier = JSON.stringify(generatedDetailModuleSpecifier(type));
-      return `  ${key}: async () => {
-    return (await import(${specifier})).firewallPermissionMetadata;
-  },`;
-    })
-    .join("\n");
+  const loaderEntries = types.map((type): LazyLoaderEntry => {
+    return {
+      key: type,
+      moduleSpecifier: generatedDetailModuleSpecifier(type),
+      exportName: "firewallPermissionMetadata",
+    };
+  });
 
   return `${generatedHeader()}// The platform build serves these dynamic imports from /firewall-metadata/v1/.
 // Bump that URL version before shipping an incompatible metadata module shape or import contract change.
 import type { FirewallPermissionDetailMetadata } from "./types";
 
-const FIREWALL_PERMISSION_METADATA_LOADERS: Readonly<
-  Record<string, () => Promise<FirewallPermissionDetailMetadata>>
-> = {
-${loaders}
-};
+${renderLazyLoaderRecord({
+  constName: "FIREWALL_PERMISSION_METADATA_LOADERS",
+  recordType: "Record<string, () => Promise<FirewallPermissionDetailMetadata>>",
+  entries: loaderEntries,
+})}
 
 export async function loadGeneratedFirewallPermissionMetadata(
   type: string,
@@ -547,17 +549,13 @@ function renderRuntimeLoaderFile(
       return `  ${JSON.stringify(source.type)},`;
     })
     .join("\n");
-  const loaders = sources
-    .map((source) => {
-      const key = JSON.stringify(source.type);
-      const specifier = JSON.stringify(
-        generatedRuntimeModuleSpecifier(source.type),
-      );
-      return `  ${key}: async () => {
-    return (await import(${specifier})).${source.firewallExportName};
-  },`;
-    })
-    .join("\n");
+  const loaderEntries = sources.map((source): LazyLoaderEntry => {
+    return {
+      key: source.type,
+      moduleSpecifier: generatedRuntimeModuleSpecifier(source.type),
+      exportName: source.firewallExportName,
+    };
+  });
 
   return `${generatedHeader()}// The platform build serves these dynamic imports from /firewall-runtime/v1/.
 // Bump that URL version before shipping an incompatible runtime firewall module shape or import contract change.
@@ -570,11 +568,12 @@ ${connectorTypes}
 export type GeneratedRuntimeFirewallConnectorType =
   (typeof RUNTIME_FIREWALL_CONNECTOR_TYPES)[number];
 
-const GENERATED_RUNTIME_FIREWALL_LOADERS: Readonly<
-  Record<GeneratedRuntimeFirewallConnectorType, () => Promise<FirewallConfig>>
-> = {
-${loaders}
-};
+${renderLazyLoaderRecord({
+  constName: "GENERATED_RUNTIME_FIREWALL_LOADERS",
+  recordType:
+    "Record<GeneratedRuntimeFirewallConnectorType, () => Promise<FirewallConfig>>",
+  entries: loaderEntries,
+})}
 
 export function hasGeneratedRuntimeFirewall(
   type: string,


### PR DESCRIPTION
## Summary

- add a shared internal renderer for generated literal dynamic-import loader records
- refactor metadata and runtime firewall loader generation to reuse that renderer while keeping their generated APIs unchanged
- strengthen generator tests for metadata nullable loading, runtime exports, literal imports, and chunk comments

## Verification

- `pnpm -F @vm0/firewalls-generator generate`
- `pnpm -F @vm0/firewalls-generator exec vitest run src/__tests__/metadata.test.ts`
- `pnpm -F @vm0/connectors exec vitest run src/__tests__/firewall-runtime-loader.test.ts src/__tests__/firewall-metadata.test.ts`
- `pnpm -F @vm0/firewalls-generator check-types`
- `pnpm -F @vm0/connectors check-types`
- `pnpm format`
- `pnpm lint`
- `pnpm check-types`
- `pnpm knip`
- `git diff --check`
- `pnpm test` after `pnpm -F @vm0/db db:migrate` synced the local DB schema; final run passed 598 files / 7089 tests

No persisted data, package exports, runtime consumers, or firewall semantics changed.

Closes #18966