### PR TITLE
perf: split compose resolution timing

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -15,6 +15,7 @@ import {
   type FirewallApi,
 } from "@vm0/connectors/firewall-types";
 import { getFirewallExecutionMetadata } from "@vm0/connectors/firewall-metadata/server";
+import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
 import { createStore } from "ccstate";
 import { eq } from "drizzle-orm";
@@ -121,6 +122,21 @@ const API_DISPATCH_TIMING_ACTION_TYPES = [
   "api_dispatch_insert_run_record",
   "api_dispatch_prepare_storage_manifest",
   "api_dispatch_build_stored_execution_context",
+] as const;
+const API_DISPATCH_RESOLVE_COMPOSE_PATH_ACTION_TYPES = [
+  "api_dispatch_resolve_compose_by_compose_id",
+  "api_dispatch_resolve_compose_by_version_id",
+  "api_dispatch_resolve_compose_by_session_id",
+  "api_dispatch_resolve_compose_by_checkpoint_id",
+] as const;
+const API_DISPATCH_RESOLVE_COMPOSE_SUBSTEP_ACTION_TYPES = [
+  "api_dispatch_resolve_compose_lookup_compose",
+  "api_dispatch_resolve_compose_lookup_version",
+  "api_dispatch_resolve_compose_lookup_session",
+  "api_dispatch_resolve_compose_lookup_checkpoint",
+  "api_dispatch_resolve_compose_load_resume_session",
+  "api_dispatch_resolve_compose_resolve_session_history",
+  "api_dispatch_resolve_compose_lookup_session_vars",
 ] as const;
 const FORBIDDEN_API_DISPATCH_TIMING_KEYS = [
   "org_id",
@@ -313,6 +329,53 @@ function apiDispatchTimingEventsForRun(
   });
 }
 
+function apiDispatchActionTypes(
+  events: readonly Record<string, unknown>[],
+): Set<unknown> {
+  return new Set(
+    events.map((event) => {
+      return event.op_type;
+    }),
+  );
+}
+
+function expectApiDispatchActions(
+  events: readonly Record<string, unknown>[],
+  expectedActionTypes: readonly string[],
+): void {
+  const observedActionTypes = apiDispatchActionTypes(events);
+  for (const actionType of expectedActionTypes) {
+    expect(observedActionTypes).toContain(actionType);
+  }
+}
+
+function expectNoApiDispatchActions(
+  events: readonly Record<string, unknown>[],
+  unexpectedActionTypes: readonly string[],
+): void {
+  const observedActionTypes = apiDispatchActionTypes(events);
+  for (const actionType of unexpectedActionTypes) {
+    expect(observedActionTypes).not.toContain(actionType);
+  }
+}
+
+function mockSessionHistoryBlob(hash: string, history: string): void {
+  context.mocks.s3.send.mockImplementation((command: unknown) => {
+    const input = (command as { readonly input?: { readonly Key?: string } })
+      .input;
+    if (input?.Key === `blobs/${hash}.blob`) {
+      return Promise.resolve({
+        Body: {
+          async *[Symbol.asyncIterator]() {
+            yield Buffer.from(history, "utf8");
+          },
+        },
+      });
+    }
+    return Promise.resolve({});
+  });
+}
+
 /**
  * Wire-shape `~/.codex/auth.json` paste payload for the personal
  * codex-oauth-token provider upsert (the server parses and never stores it).
@@ -419,14 +482,24 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     });
 
     const timingEvents = apiDispatchTimingEventsForRun(created.runId);
-    const observedActionTypes = new Set(
-      timingEvents.map((event) => {
-        return event.op_type;
+    expectApiDispatchActions(timingEvents, API_DISPATCH_TIMING_ACTION_TYPES);
+    expectApiDispatchActions(timingEvents, [
+      "api_dispatch_resolve_compose_by_compose_id",
+      "api_dispatch_resolve_compose_lookup_compose",
+    ]);
+    expectNoApiDispatchActions(
+      timingEvents,
+      API_DISPATCH_RESOLVE_COMPOSE_PATH_ACTION_TYPES.filter((actionType) => {
+        return actionType !== "api_dispatch_resolve_compose_by_compose_id";
       }),
     );
-    for (const actionType of API_DISPATCH_TIMING_ACTION_TYPES) {
-      expect(observedActionTypes).toContain(actionType);
-    }
+    expectNoApiDispatchActions(
+      timingEvents,
+      API_DISPATCH_RESOLVE_COMPOSE_SUBSTEP_ACTION_TYPES.filter((actionType) => {
+        return actionType !== "api_dispatch_resolve_compose_lookup_compose";
+      }),
+    );
+    const observedActionTypes = apiDispatchActionTypes(timingEvents);
     const preCreateEvents = timingEvents.filter((event) => {
       return event.op_type === "api_dispatch_pre_create_agent_run";
     });
@@ -473,6 +546,164 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       expect(serialized).not.toContain(prompt);
       expect(serialized).not.toContain(agentId);
     }
+  });
+
+  it("emits compose resolution timing for direct compose version runs", async () => {
+    const api = createRunsAutomationsApi(context);
+    const { actor } = await entitledRunActor();
+    const prompt = "version timing should not leak prompt";
+    const composeName = `bdd-version-timing-${randomUUID().slice(0, 8)}`;
+    const compose = await api.createCompose(actor, {
+      version: "1",
+      agents: {
+        [composeName]: {
+          framework: "claude-code",
+          environment: { ANTHROPIC_API_KEY: "bdd-inline-key" },
+        },
+      },
+    });
+    const [composeRow] = await writeDb
+      .select({ headVersionId: agentComposes.headVersionId })
+      .from(agentComposes)
+      .where(eq(agentComposes.id, compose.composeId))
+      .limit(1);
+    const headVersionId = composeRow?.headVersionId;
+    if (!headVersionId) {
+      throw new Error("Expected created compose to have a head version id");
+    }
+
+    const created = await api.createDirectRun(actor, {
+      agentComposeVersionId: headVersionId,
+      prompt,
+    });
+
+    const timingEvents = apiDispatchTimingEventsForRun(created.runId);
+    expectApiDispatchActions(timingEvents, [
+      "api_dispatch_resolve_compose_by_version_id",
+      "api_dispatch_resolve_compose_lookup_version",
+    ]);
+    expectNoApiDispatchActions(
+      timingEvents,
+      API_DISPATCH_RESOLVE_COMPOSE_PATH_ACTION_TYPES.filter((actionType) => {
+        return actionType !== "api_dispatch_resolve_compose_by_version_id";
+      }),
+    );
+    expectNoApiDispatchActions(
+      timingEvents,
+      API_DISPATCH_RESOLVE_COMPOSE_SUBSTEP_ACTION_TYPES.filter((actionType) => {
+        return actionType !== "api_dispatch_resolve_compose_lookup_version";
+      }),
+    );
+    for (const event of timingEvents) {
+      expect(JSON.stringify(event)).not.toContain(prompt);
+      expect(JSON.stringify(event)).not.toContain(headVersionId);
+    }
+
+    await api.requestCancelRun(actor, created.runId, [200]);
+  });
+
+  it("emits compose resolution timing for session and checkpoint resume runs", async () => {
+    const api = createRunsAutomationsApi(context);
+    const webhooks = createWebhookCallbackApi(context);
+    const { actor, agentId } = await entitledRunActor();
+
+    const first = await api.createRun(actor, {
+      agentId,
+      prompt: "start a checkpointed timing session",
+      modelProvider: "anthropic-api-key",
+    });
+    const claim = await api.claimRunnerJob(first.runId);
+    const history = `bdd timing session history ${first.runId}`;
+    const historyHash = createHash("sha256").update(history).digest("hex");
+    mockSessionHistoryBlob(historyHash, history);
+
+    await webhooks.requestAgentCheckpoint(
+      {
+        runId: first.runId,
+        cliAgentType: "claude-code",
+        cliAgentSessionId: `bdd-timing-cli-${first.runId}`,
+        cliAgentSessionHistoryHash: historyHash,
+      },
+      { authorization: `Bearer ${claim.sandboxToken}` },
+      [200],
+    );
+    await webhooks.requestAgentComplete(
+      { runId: first.runId, exitCode: 0, lastEventSequence: 0 },
+      { authorization: `Bearer ${claim.sandboxToken}` },
+      [200],
+    );
+    const completed = await api.readRun(actor, first.runId);
+    const checkpointId = completed.result?.checkpointId;
+    if (!checkpointId) {
+      throw new Error("Expected checkpointed timing run to expose checkpoint");
+    }
+
+    const resumed = await api.createRun(actor, {
+      agentId,
+      sessionId: first.sessionId,
+      prompt: "continue checkpointed timing session",
+      modelProvider: "anthropic-api-key",
+    });
+    expect(resumed.sessionId).toBe(first.sessionId);
+    const sessionTimingEvents = apiDispatchTimingEventsForRun(resumed.runId);
+    expectApiDispatchActions(sessionTimingEvents, [
+      "api_dispatch_resolve_compose_by_session_id",
+      "api_dispatch_resolve_compose_lookup_session",
+      "api_dispatch_resolve_compose_lookup_compose",
+      "api_dispatch_resolve_compose_load_resume_session",
+      "api_dispatch_resolve_compose_resolve_session_history",
+      "api_dispatch_resolve_compose_lookup_session_vars",
+    ]);
+    expectNoApiDispatchActions(
+      sessionTimingEvents,
+      API_DISPATCH_RESOLVE_COMPOSE_PATH_ACTION_TYPES.filter((actionType) => {
+        return actionType !== "api_dispatch_resolve_compose_by_session_id";
+      }),
+    );
+    for (const event of sessionTimingEvents) {
+      const serialized = JSON.stringify(event);
+      expect(serialized).not.toContain(history);
+      expect(serialized).not.toContain(historyHash);
+      expect(serialized).not.toContain(first.sessionId);
+    }
+
+    const checkpointZeroToken = "bdd-checkpoint-zero-token";
+    const checkpointRun = await api.createDirectRun(actor, {
+      checkpointId,
+      prompt: "resume checkpoint with timing",
+      secrets: { ZERO_TOKEN: checkpointZeroToken },
+    });
+    const checkpointTimingEvents = apiDispatchTimingEventsForRun(
+      checkpointRun.runId,
+    );
+    expectApiDispatchActions(checkpointTimingEvents, [
+      "api_dispatch_resolve_compose_by_checkpoint_id",
+      "api_dispatch_resolve_compose_lookup_checkpoint",
+      "api_dispatch_resolve_compose_lookup_version",
+      "api_dispatch_resolve_compose_load_resume_session",
+      "api_dispatch_resolve_compose_resolve_session_history",
+    ]);
+    expectNoApiDispatchActions(
+      checkpointTimingEvents,
+      API_DISPATCH_RESOLVE_COMPOSE_PATH_ACTION_TYPES.filter((actionType) => {
+        return actionType !== "api_dispatch_resolve_compose_by_checkpoint_id";
+      }),
+    );
+    expectNoApiDispatchActions(checkpointTimingEvents, [
+      "api_dispatch_resolve_compose_lookup_session",
+      "api_dispatch_resolve_compose_lookup_compose",
+      "api_dispatch_resolve_compose_lookup_session_vars",
+    ]);
+    for (const event of checkpointTimingEvents) {
+      const serialized = JSON.stringify(event);
+      expect(serialized).not.toContain(history);
+      expect(serialized).not.toContain(historyHash);
+      expect(serialized).not.toContain(checkpointId);
+      expect(serialized).not.toContain(checkpointZeroToken);
+    }
+
+    await api.requestCancelRun(actor, resumed.runId, [200]);
+    await api.requestCancelRun(actor, checkpointRun.runId, [200]);
   });
 
   it("creates, dispatches, claims, reports, and completes a run through public APIs", async () => {

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -194,6 +194,17 @@ type ApiDispatchTimingActionType =
   | "api_dispatch_prepare_context_validate_environment"
   | "api_dispatch_prepare_context_load_user_timezone"
   | "api_dispatch_prepare_context_prepare_output_metadata"
+  | "api_dispatch_resolve_compose_by_compose_id"
+  | "api_dispatch_resolve_compose_by_version_id"
+  | "api_dispatch_resolve_compose_by_session_id"
+  | "api_dispatch_resolve_compose_by_checkpoint_id"
+  | "api_dispatch_resolve_compose_lookup_compose"
+  | "api_dispatch_resolve_compose_lookup_version"
+  | "api_dispatch_resolve_compose_lookup_session"
+  | "api_dispatch_resolve_compose_lookup_checkpoint"
+  | "api_dispatch_resolve_compose_load_resume_session"
+  | "api_dispatch_resolve_compose_resolve_session_history"
+  | "api_dispatch_resolve_compose_lookup_session_vars"
   | "api_dispatch_check_vm0_credits"
   | "api_dispatch_insert_run_with_concurrency"
   | "api_dispatch_mark_pending_heartbeat"
@@ -2898,22 +2909,30 @@ async function checkOrgRunTier(
 async function lookupComposeByVersion(
   db: Db,
   versionId: string,
+  timing?: ApiDispatchTimingCollector,
 ): Promise<ResolvedCompose | CreateRunErrorResult> {
-  const [row] = await db
-    .select({
-      versionContent: agentComposeVersions.content,
-      composeName: agentComposes.name,
-      composeOrgId: agentComposes.orgId,
-      composeId: agentComposes.id,
-      composeUserId: agentComposes.userId,
-    })
-    .from(agentComposeVersions)
-    .leftJoin(
-      agentComposes,
-      eq(agentComposeVersions.composeId, agentComposes.id),
-    )
-    .where(eq(agentComposeVersions.id, versionId))
-    .limit(1);
+  const [row] = await measureApiDispatchTiming(
+    timing,
+    "api_dispatch_resolve_compose_lookup_version",
+    "nested",
+    async () => {
+      return await db
+        .select({
+          versionContent: agentComposeVersions.content,
+          composeName: agentComposes.name,
+          composeOrgId: agentComposes.orgId,
+          composeId: agentComposes.id,
+          composeUserId: agentComposes.userId,
+        })
+        .from(agentComposeVersions)
+        .leftJoin(
+          agentComposes,
+          eq(agentComposeVersions.composeId, agentComposes.id),
+        )
+        .where(eq(agentComposeVersions.id, versionId))
+        .limit(1);
+    },
+  );
 
   if (!row?.composeId || !row.composeOrgId || !row.composeUserId) {
     return notFound("Agent compose version not found");
@@ -2933,24 +2952,32 @@ async function lookupComposeByVersion(
 async function resolveByComposeId(
   db: Db,
   composeId: string,
+  timing?: ApiDispatchTimingCollector,
 ): Promise<ResolvedCompose | CreateRunErrorResult> {
-  const [row] = await db
-    .select({
-      composeId: agentComposes.id,
-      composeName: agentComposes.name,
-      composeOrgId: agentComposes.orgId,
-      composeUserId: agentComposes.userId,
-      headVersionId: agentComposes.headVersionId,
-      versionId: agentComposeVersions.id,
-      versionContent: agentComposeVersions.content,
-    })
-    .from(agentComposes)
-    .leftJoin(
-      agentComposeVersions,
-      eq(agentComposeVersions.id, agentComposes.headVersionId),
-    )
-    .where(eq(agentComposes.id, composeId))
-    .limit(1);
+  const [row] = await measureApiDispatchTiming(
+    timing,
+    "api_dispatch_resolve_compose_lookup_compose",
+    "nested",
+    async () => {
+      return await db
+        .select({
+          composeId: agentComposes.id,
+          composeName: agentComposes.name,
+          composeOrgId: agentComposes.orgId,
+          composeUserId: agentComposes.userId,
+          headVersionId: agentComposes.headVersionId,
+          versionId: agentComposeVersions.id,
+          versionContent: agentComposeVersions.content,
+        })
+        .from(agentComposes)
+        .leftJoin(
+          agentComposeVersions,
+          eq(agentComposeVersions.id, agentComposes.headVersionId),
+        )
+        .where(eq(agentComposes.id, composeId))
+        .limit(1);
+    },
+  );
 
   if (!row) {
     return notFound("Agent compose not found");
@@ -2977,50 +3004,78 @@ function resolveBySessionId(
   agentSessionId: string,
   userId: string,
   orgId: string,
+  timing?: ApiDispatchTimingCollector,
 ): Computed<Promise<ResolvedCompose | CreateRunErrorResult>> {
   return computed(
     async (get): Promise<ResolvedCompose | CreateRunErrorResult> => {
-      const [session] = await db
-        .select({
-          id: agentSessions.id,
-          agentComposeId: agentSessions.agentComposeId,
-          conversationId: agentSessions.conversationId,
-          artifacts: agentSessions.artifacts,
-          conversationRunId: conversations.runId,
-        })
-        .from(agentSessions)
-        .leftJoin(
-          conversations,
-          eq(agentSessions.conversationId, conversations.id),
-        )
-        .where(
-          and(
-            eq(agentSessions.id, agentSessionId),
-            eq(agentSessions.userId, userId),
-            eq(agentSessions.orgId, orgId),
-          ),
-        )
-        .limit(1);
+      const [session] = await measureApiDispatchTiming(
+        timing,
+        "api_dispatch_resolve_compose_lookup_session",
+        "nested",
+        async () => {
+          return await db
+            .select({
+              id: agentSessions.id,
+              agentComposeId: agentSessions.agentComposeId,
+              conversationId: agentSessions.conversationId,
+              artifacts: agentSessions.artifacts,
+              conversationRunId: conversations.runId,
+            })
+            .from(agentSessions)
+            .leftJoin(
+              conversations,
+              eq(agentSessions.conversationId, conversations.id),
+            )
+            .where(
+              and(
+                eq(agentSessions.id, agentSessionId),
+                eq(agentSessions.userId, userId),
+                eq(agentSessions.orgId, orgId),
+              ),
+            )
+            .limit(1);
+        },
+      );
 
       if (!session) {
         return notFound("Agent session not found");
       }
 
-      const resolved = await resolveByComposeId(db, session.agentComposeId);
+      const resolved = await resolveByComposeId(
+        db,
+        session.agentComposeId,
+        timing,
+      );
       if (isRouteError(resolved)) {
         return resolved;
       }
 
+      const conversationId = session.conversationId;
       const resumeSession =
-        session.conversationId === null
+        conversationId === null
           ? undefined
-          : await get(loadResumeSession(db, session.conversationId));
-      const [lastRun] = session.conversationRunId
-        ? await db
-            .select({ vars: agentRuns.vars })
-            .from(agentRuns)
-            .where(eq(agentRuns.id, session.conversationRunId))
-            .limit(1)
+          : await measureApiDispatchTiming(
+              timing,
+              "api_dispatch_resolve_compose_load_resume_session",
+              "nested",
+              async () => {
+                return await get(loadResumeSession(db, conversationId, timing));
+              },
+            );
+      const conversationRunId = session.conversationRunId;
+      const [lastRun] = conversationRunId
+        ? await measureApiDispatchTiming(
+            timing,
+            "api_dispatch_resolve_compose_lookup_session_vars",
+            "nested",
+            async () => {
+              return await db
+                .select({ vars: agentRuns.vars })
+                .from(agentRuns)
+                .where(eq(agentRuns.id, conversationRunId))
+                .limit(1);
+            },
+          )
         : [];
 
       return {
@@ -3040,22 +3095,30 @@ function resolveByCheckpointId(
   checkpointId: string,
   userId: string,
   orgId: string,
+  timing?: ApiDispatchTimingCollector,
 ): Computed<Promise<ResolvedCompose | CreateRunErrorResult>> {
   return computed(
     async (get): Promise<ResolvedCompose | CreateRunErrorResult> => {
-      const [row] = await db
-        .select({
-          snapshot: checkpoints.agentComposeSnapshot,
-          artifacts: checkpoints.artifactSnapshots,
-          volumeVersionsSnapshot: checkpoints.volumeVersionsSnapshot,
-          conversationId: checkpoints.conversationId,
-          runUserId: agentRuns.userId,
-          runOrgId: agentRuns.orgId,
-        })
-        .from(checkpoints)
-        .leftJoin(agentRuns, eq(checkpoints.runId, agentRuns.id))
-        .where(eq(checkpoints.id, checkpointId))
-        .limit(1);
+      const [row] = await measureApiDispatchTiming(
+        timing,
+        "api_dispatch_resolve_compose_lookup_checkpoint",
+        "nested",
+        async () => {
+          return await db
+            .select({
+              snapshot: checkpoints.agentComposeSnapshot,
+              artifacts: checkpoints.artifactSnapshots,
+              volumeVersionsSnapshot: checkpoints.volumeVersionsSnapshot,
+              conversationId: checkpoints.conversationId,
+              runUserId: agentRuns.userId,
+              runOrgId: agentRuns.orgId,
+            })
+            .from(checkpoints)
+            .leftJoin(agentRuns, eq(checkpoints.runId, agentRuns.id))
+            .where(eq(checkpoints.id, checkpointId))
+            .limit(1);
+        },
+      );
 
       if (!row || row.runUserId !== userId || row.runOrgId !== orgId) {
         return notFound("Checkpoint not found");
@@ -3074,6 +3137,7 @@ function resolveByCheckpointId(
       const resolved = await lookupComposeByVersion(
         db,
         snapshot.agentComposeVersionId,
+        timing,
       );
       if (isRouteError(resolved)) {
         return resolved;
@@ -3088,7 +3152,14 @@ function resolveByCheckpointId(
           row.volumeVersionsSnapshot,
         ),
         resumedFromCheckpointId: checkpointId,
-        resumeSession: await get(loadResumeSession(db, row.conversationId)),
+        resumeSession: await measureApiDispatchTiming(
+          timing,
+          "api_dispatch_resolve_compose_load_resume_session",
+          "nested",
+          async () => {
+            return await get(loadResumeSession(db, row.conversationId, timing));
+          },
+        ),
       };
     },
   );
@@ -3097,6 +3168,7 @@ function resolveByCheckpointId(
 function loadResumeSession(
   db: Db,
   conversationId: string,
+  timing?: ApiDispatchTimingCollector,
 ): Computed<Promise<StoredExecutionContext["resumeSession"] | undefined>> {
   return computed(
     async (
@@ -3116,11 +3188,18 @@ function loadResumeSession(
         return undefined;
       }
 
-      const sessionHistory = await get(
-        resolveConversationSessionHistory({
-          hash: conversation.cliAgentSessionHistoryHash,
-          legacyText: conversation.cliAgentSessionHistory,
-        }),
+      const sessionHistory = await measureApiDispatchTiming(
+        timing,
+        "api_dispatch_resolve_compose_resolve_session_history",
+        "nested",
+        async () => {
+          return await get(
+            resolveConversationSessionHistory({
+              hash: conversation.cliAgentSessionHistoryHash,
+              legacyText: conversation.cliAgentSessionHistory,
+            }),
+          );
+        },
       );
 
       if (sessionHistory === null) {
@@ -3171,6 +3250,7 @@ function resolveCompose(
   body: CreateRunBody,
   userId: string,
   orgId: string,
+  timing?: ApiDispatchTimingCollector,
 ): Computed<Promise<ResolvedCompose | CreateRunErrorResult>> {
   return computed(
     async (get): Promise<ResolvedCompose | CreateRunErrorResult> => {
@@ -3181,22 +3261,60 @@ function resolveCompose(
       }
 
       if (body.checkpointId) {
-        return await get(
-          resolveByCheckpointId(db, body.checkpointId, userId, orgId),
+        const checkpointId = body.checkpointId;
+        return await measureApiDispatchTiming(
+          timing,
+          "api_dispatch_resolve_compose_by_checkpoint_id",
+          "nested",
+          async () => {
+            return await get(
+              resolveByCheckpointId(db, checkpointId, userId, orgId, timing),
+            );
+          },
         );
       }
       if (body.sessionId) {
-        return await get(resolveBySessionId(db, body.sessionId, userId, orgId));
+        const sessionId = body.sessionId;
+        return await measureApiDispatchTiming(
+          timing,
+          "api_dispatch_resolve_compose_by_session_id",
+          "nested",
+          async () => {
+            return await get(
+              resolveBySessionId(db, sessionId, userId, orgId, timing),
+            );
+          },
+        );
       }
       if (body.agentComposeVersionId) {
-        return await lookupComposeByVersion(db, body.agentComposeVersionId);
+        const agentComposeVersionId = body.agentComposeVersionId;
+        return await measureApiDispatchTiming(
+          timing,
+          "api_dispatch_resolve_compose_by_version_id",
+          "nested",
+          async () => {
+            return await lookupComposeByVersion(
+              db,
+              agentComposeVersionId,
+              timing,
+            );
+          },
+        );
       }
       if (!body.agentComposeId) {
         return badRequestMessage(
           "Missing agentComposeId or agentComposeVersionId. Provide composeId, agentComposeVersionId, checkpointId, or sessionId.",
         );
       }
-      return await resolveByComposeId(db, body.agentComposeId);
+      const agentComposeId = body.agentComposeId;
+      return await measureApiDispatchTiming(
+        timing,
+        "api_dispatch_resolve_compose_by_compose_id",
+        "nested",
+        async () => {
+          return await resolveByComposeId(db, agentComposeId, timing);
+        },
+      );
     },
   );
 }
@@ -4529,6 +4647,7 @@ async function prepareRunBodyContext(args: {
           args.initialBody,
           args.createArgs.userId,
           args.createArgs.orgId,
+          args.timing,
         ),
       );
     },


### PR DESCRIPTION
## Summary

- add low-cardinality API dispatch timing for `resolveCompose` path selection and critical sub-steps
- thread the existing timing collector through compose resolution without adding telemetry dimensions
- cover compose id, compose version, session continue, and checkpoint resume timing through route integration tests

## Tests

- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- pre-commit: `pnpm check-types`

Closes #18961