### PR TITLE
Fix SO frontend proxy compression headers

### DIFF
--- a/turbo/apps/web/__tests__/proxy.public-routes.test.ts
+++ b/turbo/apps/web/__tests__/proxy.public-routes.test.ts
@@ -335,6 +335,91 @@ describe("proxy middleware: public routes", () => {
     expect(response.status).toBe(202);
   });
 
+  it("normalizes compression headers for proxied sign-up verification responses", async () => {
+    vi.stubEnv("NEXT_PUBLIC_PAID_ONBOARDING_URL", "https://so.vm0.ai");
+    vi.stubEnv("VERCEL_ENV", "production");
+    reloadEnv();
+    const fetchMock = vi.fn<typeof fetch>(async () => {
+      return new Response("verification proxied", {
+        status: 202,
+        headers: {
+          "content-encoding": "br",
+          "content-length": "123",
+          "content-type": "text/x-component",
+        },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const request = new NextRequest(
+      "https://www.vm0.ai/sign-up/verify-email-address?redirect_url=https%3A%2F%2Fapp.vm0.ai%2Fagents%2F4f189ea8-ada2-416d-83a9-9c25ddb960c9%2Fchat",
+      {
+        method: "POST",
+        headers: {
+          "accept-encoding": "gzip, deflate, br, zstd",
+        },
+      },
+    );
+
+    const response = await middleware(request, createMockEvent());
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [targetUrl, init] = fetchMock.mock.calls[0] ?? [];
+    expect(String(targetUrl)).toBe(
+      "https://so.vm0.ai/sign-up/verify-email-address?redirect_url=https%3A%2F%2Fapp.vm0.ai%2Fagents%2F4f189ea8-ada2-416d-83a9-9c25ddb960c9%2Fchat",
+    );
+    expect((init?.headers as Headers).get("accept-encoding")).toBe("identity");
+    expect(response).toBeDefined();
+    if (!response) {
+      throw new Error("Expected verification proxy response");
+    }
+    expect(response.status).toBe(202);
+    expect(response.headers.get("content-encoding")).toBeNull();
+    expect(response.headers.get("content-length")).toBeNull();
+    expect(response.headers.get("content-type")).toBe("text/x-component");
+    await expect(response.text()).resolves.toBe("verification proxied");
+  });
+
+  it("normalizes compression headers for proxied locale page action responses", async () => {
+    vi.stubEnv("NEXT_PUBLIC_PAID_ONBOARDING_URL", "https://so.vm0.ai");
+    vi.stubEnv("VERCEL_ENV", "production");
+    reloadEnv();
+    const fetchMock = vi.fn<typeof fetch>(async () => {
+      return new Response("locale action proxied", {
+        status: 200,
+        headers: {
+          "content-encoding": "br",
+          "content-length": "123",
+          "content-type": "text/x-component",
+        },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const request = new NextRequest("https://www.vm0.ai/en", {
+      method: "POST",
+      headers: {
+        "accept-encoding": "gzip, deflate, br, zstd",
+      },
+    });
+
+    const response = await middleware(request, createMockEvent());
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [targetUrl, init] = fetchMock.mock.calls[0] ?? [];
+    expect(String(targetUrl)).toBe("https://so.vm0.ai/en");
+    expect((init?.headers as Headers).get("accept-encoding")).toBe("identity");
+    expect(response).toBeDefined();
+    if (!response) {
+      throw new Error("Expected locale page proxy response");
+    }
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-encoding")).toBeNull();
+    expect(response.headers.get("content-length")).toBeNull();
+    expect(response.headers.get("content-type")).toBe("text/x-component");
+    await expect(response.text()).resolves.toBe("locale action proxied");
+  });
+
   it("does not proxy app-only functional routes when so forwarding is enabled", async () => {
     vi.stubEnv("NEXT_PUBLIC_PAID_ONBOARDING_URL", "https://so.vm0.ai");
     reloadEnv();

--- a/turbo/apps/web/__tests__/proxy.public-routes.test.ts
+++ b/turbo/apps/web/__tests__/proxy.public-routes.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeAll, beforeEach } from "vitest";
+import { brotliCompressSync } from "node:zlib";
 import { NextRequest, NextResponse } from "next/server";
 import { HttpResponse, http } from "msw";
 import { server } from "../src/mocks/server";
@@ -92,6 +93,18 @@ function captureForwardedRequests(
     }),
   );
   return requests;
+}
+
+function compressedComponentResponse(body: string, status: number): Response {
+  const encodedBody = brotliCompressSync(Buffer.from(body));
+  return new HttpResponse(encodedBody, {
+    status,
+    headers: {
+      "content-encoding": "br",
+      "content-length": String(encodedBody.byteLength),
+      "content-type": "text/x-component",
+    },
+  });
 }
 
 describe("proxy middleware: public routes", () => {
@@ -339,17 +352,11 @@ describe("proxy middleware: public routes", () => {
     vi.stubEnv("NEXT_PUBLIC_PAID_ONBOARDING_URL", "https://so.vm0.ai");
     vi.stubEnv("VERCEL_ENV", "production");
     reloadEnv();
-    const fetchMock = vi.fn<typeof fetch>(async () => {
-      return new Response("verification proxied", {
-        status: 202,
-        headers: {
-          "content-encoding": "br",
-          "content-length": "123",
-          "content-type": "text/x-component",
-        },
-      });
-    });
-    vi.stubGlobal("fetch", fetchMock);
+    const forwardedRequests = captureForwardedRequests(
+      "post",
+      "https://so.vm0.ai/sign-up/verify-email-address",
+      compressedComponentResponse("verification proxied", 202),
+    );
 
     const request = new NextRequest(
       "https://www.vm0.ai/sign-up/verify-email-address?redirect_url=https%3A%2F%2Fapp.vm0.ai%2Fagents%2F4f189ea8-ada2-416d-83a9-9c25ddb960c9%2Fchat",
@@ -363,12 +370,15 @@ describe("proxy middleware: public routes", () => {
 
     const response = await middleware(request, createMockEvent());
 
-    expect(fetchMock).toHaveBeenCalledOnce();
-    const [targetUrl, init] = fetchMock.mock.calls[0] ?? [];
-    expect(String(targetUrl)).toBe(
+    expect(forwardedRequests).toHaveLength(1);
+    const [forwardedRequest] = forwardedRequests;
+    if (!forwardedRequest) {
+      throw new Error("Expected forwarded verification request");
+    }
+    expect(forwardedRequest.url).toBe(
       "https://so.vm0.ai/sign-up/verify-email-address?redirect_url=https%3A%2F%2Fapp.vm0.ai%2Fagents%2F4f189ea8-ada2-416d-83a9-9c25ddb960c9%2Fchat",
     );
-    expect((init?.headers as Headers).get("accept-encoding")).toBe("identity");
+    expect(forwardedRequest.headers.get("accept-encoding")).toBe("identity");
     expect(response).toBeDefined();
     if (!response) {
       throw new Error("Expected verification proxy response");
@@ -384,17 +394,11 @@ describe("proxy middleware: public routes", () => {
     vi.stubEnv("NEXT_PUBLIC_PAID_ONBOARDING_URL", "https://so.vm0.ai");
     vi.stubEnv("VERCEL_ENV", "production");
     reloadEnv();
-    const fetchMock = vi.fn<typeof fetch>(async () => {
-      return new Response("locale action proxied", {
-        status: 200,
-        headers: {
-          "content-encoding": "br",
-          "content-length": "123",
-          "content-type": "text/x-component",
-        },
-      });
-    });
-    vi.stubGlobal("fetch", fetchMock);
+    const forwardedRequests = captureForwardedRequests(
+      "post",
+      "https://so.vm0.ai/en",
+      compressedComponentResponse("locale action proxied", 200),
+    );
 
     const request = new NextRequest("https://www.vm0.ai/en", {
       method: "POST",
@@ -405,10 +409,13 @@ describe("proxy middleware: public routes", () => {
 
     const response = await middleware(request, createMockEvent());
 
-    expect(fetchMock).toHaveBeenCalledOnce();
-    const [targetUrl, init] = fetchMock.mock.calls[0] ?? [];
-    expect(String(targetUrl)).toBe("https://so.vm0.ai/en");
-    expect((init?.headers as Headers).get("accept-encoding")).toBe("identity");
+    expect(forwardedRequests).toHaveLength(1);
+    const [forwardedRequest] = forwardedRequests;
+    if (!forwardedRequest) {
+      throw new Error("Expected forwarded locale page request");
+    }
+    expect(forwardedRequest.url).toBe("https://so.vm0.ai/en");
+    expect(forwardedRequest.headers.get("accept-encoding")).toBe("identity");
     expect(response).toBeDefined();
     if (!response) {
       throw new Error("Expected locale page proxy response");

--- a/turbo/apps/web/proxy.ts
+++ b/turbo/apps/web/proxy.ts
@@ -201,6 +201,7 @@ async function proxySoFrontendRequest(
       `${targetUrl.origin}${referer.slice(request.nextUrl.origin.length)}`,
     );
   }
+  requestHeaders.set("accept-encoding", "identity");
 
   const proxyRequestInit: RequestInit & { duplex?: "half" } = {
     method: request.method,
@@ -212,7 +213,16 @@ async function proxySoFrontendRequest(
     proxyRequestInit.duplex = "half";
   }
 
-  return fetch(targetUrl, proxyRequestInit);
+  const upstreamResponse = await fetch(targetUrl, proxyRequestInit);
+  const responseHeaders = new Headers(upstreamResponse.headers);
+  responseHeaders.delete("content-encoding");
+  responseHeaders.delete("content-length");
+
+  return new Response(upstreamResponse.body, {
+    headers: responseHeaders,
+    status: upstreamResponse.status,
+    statusText: upstreamResponse.statusText,
+  });
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- request identity encoding from SO frontend for non-GET proxy requests
- strip stale content-encoding/content-length headers before returning proxied responses
- cover sign-up verification and locale page action POST responses

## Test
- pnpm --filter web test -- proxy.public-routes.test.ts