### PR TITLE
fix: align so action proxy origin

### DIFF
--- a/turbo/apps/web/__tests__/proxy.public-routes.test.ts
+++ b/turbo/apps/web/__tests__/proxy.public-routes.test.ts
@@ -249,6 +249,75 @@ describe("proxy middleware: public routes", () => {
     expect(response?.status).toBe(202);
   });
 
+  it("uses the final staging SO origin for local SO alias server actions", async () => {
+    vi.stubEnv("NEXT_PUBLIC_PAID_ONBOARDING_URL", "https://so.vm7.ai:8443");
+    reloadEnv();
+    const fetchMock = vi.fn<typeof fetch>(async () => {
+      return new Response("proxied", { status: 202 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const request = new NextRequest("http://localhost:3000/en", {
+      method: "POST",
+      headers: {
+        "next-action": "abc123",
+        origin: "https://www.vm7.ai:8443",
+        referer: "https://www.vm7.ai:8443/en",
+        "x-forwarded-host": "www.vm7.ai:8443",
+        "x-forwarded-proto": "https",
+      },
+    });
+
+    const response = await middleware(request, createMockEvent());
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [, init] = fetchMock.mock.calls[0] ?? [];
+    expect(init).toBeDefined();
+    if (!init) {
+      throw new Error("Expected fetch init");
+    }
+    const proxiedHeaders = init.headers as Headers;
+    expect(proxiedHeaders.get("origin")).toBe("https://staging-so.vm6.ai");
+    expect(proxiedHeaders.get("referer")).toBe("https://staging-so.vm6.ai/en");
+    expect(proxiedHeaders.get("x-forwarded-host")).toBe("staging-so.vm6.ai");
+    expect(proxiedHeaders.get("x-forwarded-proto")).toBe("https");
+    expect(response?.status).toBe(202);
+  });
+
+  it("treats SO frontend form POSTs as server actions", async () => {
+    vi.stubEnv("NEXT_PUBLIC_PAID_ONBOARDING_URL", "https://so.vm0.ai");
+    reloadEnv();
+    const fetchMock = vi.fn<typeof fetch>(async () => {
+      return new Response("proxied", { status: 202 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const request = new NextRequest("https://www.vm0.ai/en", {
+      method: "POST",
+      headers: {
+        "content-type": "multipart/form-data; boundary=boundary",
+        origin: "https://www.vm0.ai",
+        referer: "https://www.vm0.ai/en",
+      },
+      body: "--boundary--",
+    });
+
+    const response = await middleware(request, createMockEvent());
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [, init] = fetchMock.mock.calls[0] ?? [];
+    expect(init).toBeDefined();
+    if (!init) {
+      throw new Error("Expected fetch init");
+    }
+    const proxiedHeaders = init.headers as Headers;
+    expect(proxiedHeaders.get("origin")).toBe("https://so.vm0.ai");
+    expect(proxiedHeaders.get("referer")).toBe("https://so.vm0.ai/en");
+    expect(proxiedHeaders.get("x-forwarded-host")).toBe("so.vm0.ai");
+    expect(proxiedHeaders.get("x-forwarded-proto")).toBe("https");
+    expect(response?.status).toBe(202);
+  });
+
   it("does not proxy non-GET requests when so frontend forwarding is disabled", async () => {
     const request = new NextRequest("https://www.vm0.ai/en", {
       method: "POST",

--- a/turbo/apps/web/proxy.ts
+++ b/turbo/apps/web/proxy.ts
@@ -117,7 +117,40 @@ const HOP_BY_HOP_HEADERS = [
 ];
 
 function isServerActionRequest(request: NextRequest): boolean {
-  return request.headers.has("next-action");
+  if (request.method !== "POST") {
+    return false;
+  }
+
+  const contentType = request.headers.get("content-type");
+  return (
+    request.headers.has("next-action") ||
+    contentType === "application/x-www-form-urlencoded" ||
+    contentType?.startsWith("multipart/form-data") === true
+  );
+}
+
+function soFrontendActionOrigin(targetUrl: URL): string {
+  if (targetUrl.hostname === "so.vm7.ai") {
+    return "https://staging-so.vm6.ai";
+  }
+
+  return targetUrl.origin;
+}
+
+function firstForwardedHeaderValue(value: string | null): string | undefined {
+  return value?.split(",")[0]?.trim() || undefined;
+}
+
+function requestPublicOrigin(request: NextRequest): string {
+  const host =
+    firstForwardedHeaderValue(request.headers.get("x-forwarded-host")) ??
+    request.headers.get("host") ??
+    request.nextUrl.host;
+  const proto =
+    firstForwardedHeaderValue(request.headers.get("x-forwarded-proto")) ??
+    request.nextUrl.protocol.slice(0, -1);
+
+  return `${proto}://${host}`;
 }
 
 function apiBackendProxyPassThrough(request: NextRequest): NextResponse {
@@ -180,25 +213,32 @@ async function proxySoFrontendRequest(
   for (const header of HOP_BY_HOP_HEADERS) {
     requestHeaders.delete(header);
   }
+  const publicOrigin = requestPublicOrigin(request);
+  const publicOriginUrl = new URL(publicOrigin);
+  const actionOrigin = serverActionRequest
+    ? soFrontendActionOrigin(targetUrl)
+    : undefined;
+  const actionOriginUrl = actionOrigin ? new URL(actionOrigin) : undefined;
   requestHeaders.set(
     "x-forwarded-host",
-    serverActionRequest ? targetUrl.host : request.nextUrl.host,
+    actionOriginUrl?.host ?? publicOriginUrl.host,
   );
   requestHeaders.set(
     "x-forwarded-proto",
-    serverActionRequest
-      ? targetUrl.protocol.slice(0, -1)
-      : request.nextUrl.protocol.slice(0, -1),
+    actionOriginUrl?.protocol.slice(0, -1) ??
+      publicOriginUrl.protocol.slice(0, -1),
   );
 
-  if (requestHeaders.get("origin") === request.nextUrl.origin) {
-    requestHeaders.set("origin", targetUrl.origin);
+  if (requestHeaders.get("origin") === publicOrigin) {
+    requestHeaders.set("origin", actionOrigin ?? targetUrl.origin);
   }
   const referer = requestHeaders.get("referer");
-  if (referer?.startsWith(request.nextUrl.origin)) {
+  if (referer?.startsWith(publicOrigin)) {
     requestHeaders.set(
       "referer",
-      `${targetUrl.origin}${referer.slice(request.nextUrl.origin.length)}`,
+      `${actionOrigin ?? targetUrl.origin}${referer.slice(
+        publicOrigin.length,
+      )}`,
     );
   }
   requestHeaders.set("accept-encoding", "identity");


### PR DESCRIPTION
## Summary
- align proxied SO Server Action origin/forwarded host for local vm7 alias traffic
- detect form and multipart SO POSTs as possible Server Actions
- add coverage for local SO alias and form-action proxy headers

## Testing
- pnpm -F web exec vitest run __tests__/proxy.public-routes.test.ts __tests__/so-frontend-rewrites.test.ts
- pnpm -F web lint
- pnpm -F web check-types
- git diff --check
- curl POST https://www.vm7.ai:8443/en with a fake next-action now returns x-nextjs-action-not-found instead of E80

## Note
- A normal pre-commit run was blocked by unrelated ignored/generated connector firewall artifacts in the local worktree during full check-types. The committed diff only touches apps/web proxy code and tests.