### PR TITLE
fix: roll up run group usage

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/__tests__/run-group-folding.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/run-group-folding.test.ts
@@ -50,12 +50,17 @@ function assistantMessage(params: {
 function group(
   role: "user" | "assistant",
   messages: EnrichedChatMessage[],
+  usage?: GroupedChatMessageGroup["usage"],
 ): GroupedChatMessageGroup {
-  return {
+  const result: GroupedChatMessageGroup = {
     beginMessageId: messages[0]!.id,
     role,
     messages,
   };
+  if (usage !== undefined) {
+    result.usage = usage;
+  }
+  return result;
 }
 
 function messageIds(groups: readonly GroupedChatMessageGroup[]): string[] {
@@ -64,6 +69,28 @@ function messageIds(groups: readonly GroupedChatMessageGroup[]): string[] {
       return message.id;
     });
   });
+}
+
+function usagePayload(params: {
+  readonly totalCredits: number;
+  readonly settledAt: string;
+  readonly kind: string;
+  readonly provider: string;
+}): NonNullable<GroupedChatMessageGroup["usage"]> {
+  return {
+    version: 1,
+    totalCredits: params.totalCredits,
+    settledAt: params.settledAt,
+    breakdown: [
+      {
+        kind: params.kind,
+        credits: params.totalCredits,
+        providers: [
+          { provider: params.provider, credits: params.totalCredits },
+        ],
+      },
+    ],
+  };
 }
 
 function assistantRunGroups(params: {
@@ -113,6 +140,64 @@ describe("buildRunGroupFolding", () => {
       "u2",
       "a2",
     ]);
+  });
+
+  it("rolls up usage from folded runs onto the latest assistant group", () => {
+    const groups: GroupedChatMessageGroup[] = [
+      group("user", [userMessage({ id: "u1", runId: "r1", runGroupId: "g1" })]),
+      group(
+        "assistant",
+        [assistantMessage({ id: "a1", runId: "r1", runGroupId: "g1" })],
+        usagePayload({
+          totalCredits: 10,
+          settledAt: "2026-06-24T00:00:01.000Z",
+          kind: "connector",
+          provider: "github",
+        }),
+      ),
+      group("user", [userMessage({ id: "u2", runId: "r2", runGroupId: "g1" })]),
+      group(
+        "assistant",
+        [assistantMessage({ id: "a2", runId: "r2", runGroupId: "g1" })],
+        usagePayload({
+          totalCredits: 20,
+          settledAt: "2026-06-24T00:00:02.000Z",
+          kind: "connector",
+          provider: "github",
+        }),
+      ),
+      group("user", [userMessage({ id: "u3", runId: "r3", runGroupId: "g1" })]),
+      group(
+        "assistant",
+        [assistantMessage({ id: "a3", runId: "r3", runGroupId: "g1" })],
+        usagePayload({
+          totalCredits: 30,
+          settledAt: "2026-06-24T00:00:03.000Z",
+          kind: "connector",
+          provider: "github",
+        }),
+      ),
+    ];
+
+    const folding = buildRunGroupFolding(groups);
+
+    expect(folding).not.toBeNull();
+    expect(messageIds(folding!.visibleGroups)).toStrictEqual(["u3", "a3"]);
+    const latestAssistantGroup = folding!.visibleGroups.find((item) => {
+      return item.beginMessageId === "a3";
+    });
+    expect(latestAssistantGroup?.usage).toStrictEqual({
+      version: 1,
+      totalCredits: 60,
+      settledAt: "2026-06-24T00:00:03.000Z",
+      breakdown: [
+        {
+          kind: "connector",
+          credits: 60,
+          providers: [{ provider: "github", credits: 60 }],
+        },
+      ],
+    });
   });
 
   it("does not fold runs separated by a normal message", () => {

--- a/turbo/apps/platform/src/signals/chat-page/run-group-folding.ts
+++ b/turbo/apps/platform/src/signals/chat-page/run-group-folding.ts
@@ -99,6 +99,82 @@ function usageByRunIdFromGroups(
   return usageByRunId;
 }
 
+interface UsageBreakdownAccumulator {
+  readonly kind: string;
+  credits: number;
+  readonly providers: Map<string, number>;
+}
+
+function mergeUsagePayloads(
+  usages: readonly ChatMessageUsagePayload[],
+): ChatMessageUsagePayload | undefined {
+  if (usages.length === 0) {
+    return undefined;
+  }
+
+  let totalCredits = 0;
+  let settledAt = "";
+  const breakdownByKind = new Map<string, UsageBreakdownAccumulator>();
+
+  for (const usage of usages) {
+    totalCredits += usage.totalCredits;
+    settledAt = usage.settledAt;
+
+    for (const kindBreakdown of usage.breakdown) {
+      let accumulator = breakdownByKind.get(kindBreakdown.kind);
+      if (accumulator === undefined) {
+        accumulator = {
+          kind: kindBreakdown.kind,
+          credits: 0,
+          providers: new Map(),
+        };
+        breakdownByKind.set(kindBreakdown.kind, accumulator);
+      }
+
+      accumulator.credits += kindBreakdown.credits;
+
+      for (const providerBreakdown of kindBreakdown.providers) {
+        accumulator.providers.set(
+          providerBreakdown.provider,
+          (accumulator.providers.get(providerBreakdown.provider) ?? 0) +
+            providerBreakdown.credits,
+        );
+      }
+    }
+  }
+
+  return {
+    version: 1,
+    totalCredits,
+    settledAt,
+    breakdown: Array.from(breakdownByKind.values()).map((accumulator) => {
+      return {
+        kind: accumulator.kind,
+        credits: accumulator.credits,
+        providers: Array.from(accumulator.providers.entries()).map(
+          ([provider, credits]) => {
+            return { provider, credits };
+          },
+        ),
+      };
+    }),
+  };
+}
+
+function mergedUsageForRunSegments(
+  runSegments: readonly GroupedRunSegment[],
+  usageByRunId: ReadonlyMap<string, ChatMessageUsagePayload>,
+): ChatMessageUsagePayload | undefined {
+  const usages: ChatMessageUsagePayload[] = [];
+  for (const segment of runSegments) {
+    const usage = usageByRunId.get(segment.runId);
+    if (usage !== undefined) {
+      usages.push(usage);
+    }
+  }
+  return mergeUsagePayloads(usages);
+}
+
 function attachUsageToGroups(
   groups: readonly GroupedChatMessageGroup[],
   usageByRunId: ReadonlyMap<string, ChatMessageUsagePayload>,
@@ -399,7 +475,12 @@ function buildFoldSection(
   const hiddenGroups = hiddenSegments.flatMap((item) => {
     return segmentGroups(item, usageByRunId);
   });
-  const collapsedGroups = segmentGroups(latestSegment, usageByRunId);
+  const collapsedUsageByRunId = new Map(usageByRunId);
+  const collapsedUsage = mergedUsageForRunSegments(runSegments, usageByRunId);
+  if (collapsedUsage !== undefined) {
+    collapsedUsageByRunId.set(latestSegment.runId, collapsedUsage);
+  }
+  const collapsedGroups = segmentGroups(latestSegment, collapsedUsageByRunId);
   const expandedGroups = runSegments.flatMap((item) => {
     return segmentGroups(item, usageByRunId);
   });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -3294,6 +3294,25 @@ describe("chat lifecycle", () => {
           createdAt: "2026-06-09T10:00:01Z",
         },
         {
+          id: "msg-run-group-usage-1",
+          role: "assistant",
+          content: null,
+          runId: "f0000001-0000-4000-a000-000000000724",
+          usage: {
+            version: 1,
+            totalCredits: 10,
+            settledAt: "2026-06-09T10:00:02Z",
+            breakdown: [
+              {
+                kind: "connector",
+                credits: 10,
+                providers: [{ provider: "github", credits: 10 }],
+              },
+            ],
+          },
+          createdAt: "2026-06-09T10:00:02Z",
+        },
+        {
           id: "msg-run-group-user-2",
           role: "user",
           content: "Run the daily check",
@@ -3312,6 +3331,25 @@ describe("chat lifecycle", () => {
           createdAt: "2026-06-09T10:01:01Z",
         },
         {
+          id: "msg-run-group-usage-2",
+          role: "assistant",
+          content: null,
+          runId: "f0000001-0000-4000-a000-000000000725",
+          usage: {
+            version: 1,
+            totalCredits: 20,
+            settledAt: "2026-06-09T10:01:02Z",
+            breakdown: [
+              {
+                kind: "connector",
+                credits: 20,
+                providers: [{ provider: "github", credits: 20 }],
+              },
+            ],
+          },
+          createdAt: "2026-06-09T10:01:02Z",
+        },
+        {
           id: "msg-run-group-user-3",
           role: "user",
           content: "Run the daily check",
@@ -3328,6 +3366,25 @@ describe("chat lifecycle", () => {
           runId: "f0000001-0000-4000-a000-000000000726",
           runGroupId,
           createdAt: "2026-06-09T10:02:01Z",
+        },
+        {
+          id: "msg-run-group-usage-3",
+          role: "assistant",
+          content: null,
+          runId: "f0000001-0000-4000-a000-000000000726",
+          usage: {
+            version: 1,
+            totalCredits: 30,
+            settledAt: "2026-06-09T10:02:02Z",
+            breakdown: [
+              {
+                kind: "connector",
+                credits: 30,
+                providers: [{ provider: "github", credits: 30 }],
+              },
+            ],
+          },
+          createdAt: "2026-06-09T10:02:02Z",
         },
       ],
     });
@@ -3354,6 +3411,16 @@ describe("chat lifecycle", () => {
       expect(
         screen.queryByText("Second daily check result"),
       ).not.toBeInTheDocument();
+    });
+
+    const credit = await screen.findByLabelText("Credit usage 60");
+    expect(screen.queryByLabelText("Credit usage 30")).not.toBeInTheDocument();
+
+    click(credit);
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Github").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText("60").length).toBeGreaterThanOrEqual(1);
     });
 
     fireEvent.click(buttonByLabel("Expand grouped run history"));


### PR DESCRIPTION
## Summary
- roll up usage from every run in a folded run group onto the latest visible assistant message
- keep expanded run groups using each run's original usage payload
- cover the behavior with run-group folding and chat lifecycle tests

## Tests
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm exec vitest run apps/platform/src/signals/chat-page/__tests__/run-group-folding.test.ts apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx