### PR TITLE
fix: make presentation QA dependency explicit

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/generation-template-prompt.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/generation-template-prompt.test.ts
@@ -44,7 +44,7 @@ describe("buildGenerationTemplatePrompt", () => {
       `zero generate presentation --design-system ${item.designSystemId} --template ${item.templateId}`,
     );
     expect(result.prompt).toContain(
-      "node ./generated/resources/presentation-runtime/html-ppt-deck-tools/qa-deck.mjs <output-dir>/index.html",
+      "npm install --no-save --no-package-lock playwright && node ./generated/resources/presentation-runtime/html-ppt-deck-tools/qa-deck.mjs <output-dir>/index.html",
     );
   });
 

--- a/turbo/apps/api/src/signals/routes/generation-template-prompt.ts
+++ b/turbo/apps/api/src/signals/routes/generation-template-prompt.ts
@@ -151,7 +151,7 @@ function buildPresentationGenerationTemplatePrompt(
             `- Apply the selected color system (${colorSystem.id}) when authoring the deck.`,
           ]
         : []),
-      "- After generating the final HTML deck, run: `node ./generated/resources/presentation-runtime/html-ppt-deck-tools/qa-deck.mjs <output-dir>/index.html`. Fix failures before hosting.",
+      "- After generating the final HTML deck, run QA from the workspace root: `npm install --no-save --no-package-lock playwright && node ./generated/resources/presentation-runtime/html-ppt-deck-tools/qa-deck.mjs <output-dir>/index.html`. Fix failures before hosting.",
       "- Follow the returned authoring packet. For a static HTML presentation, publish it with `zero host <dir> --site <slug> --artifact-kind presentation-html`.",
       "- If a flag above no longer applies, run `zero generate presentation -h` to discover the current options.",
     ].join("\n"),


### PR DESCRIPTION
## Summary\n- Update presentation template context guidance to install Playwright into the workspace before running qa-deck.mjs\n- Keep the QA command scoped to buildPresentationGenerationTemplatePrompt\n- Tighten the prompt test to assert the install + node command\n\n## Why\nRunning qa-deck.mjs through `npx -p playwright node ...` does not make the `playwright` package importable to the ESM script, so qa-deck.mjs fails with ERR_MODULE_NOT_FOUND. Installing with `npm install --no-save --no-package-lock playwright` in the workspace lets Node resolve the import from the generated resource path.\n\n## Validation\n- `pnpm -C turbo exec prettier --check apps/api/src/signals/routes/generation-template-prompt.ts apps/api/src/signals/routes/__tests__/generation-template-prompt.test.ts`\n- `pnpm -C turbo exec vitest run apps/api/src/signals/routes/__tests__/generation-template-prompt.test.ts`\n- `git diff --check`