### PR TITLE
fix: remove presentation QA prompt

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/generation-template-prompt.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/generation-template-prompt.test.ts
@@ -43,9 +43,6 @@ describe("buildGenerationTemplatePrompt", () => {
     expect(result.prompt).toContain(
       `zero generate presentation --design-system ${item.designSystemId} --template ${item.templateId}`,
     );
-    expect(result.prompt).toContain(
-      "node ./generated/resources/presentation-runtime/html-ppt-deck-tools/qa-deck.mjs <output-dir>/index.html",
-    );
   });
 
   it("builds presentation template guidance for the switched picker catalog", () => {

--- a/turbo/apps/api/src/signals/routes/generation-template-prompt.ts
+++ b/turbo/apps/api/src/signals/routes/generation-template-prompt.ts
@@ -151,7 +151,6 @@ function buildPresentationGenerationTemplatePrompt(
             `- Apply the selected color system (${colorSystem.id}) when authoring the deck.`,
           ]
         : []),
-      "- After generating the final HTML deck, run: `node ./generated/resources/presentation-runtime/html-ppt-deck-tools/qa-deck.mjs <output-dir>/index.html`. Fix failures before hosting.",
       "- Follow the returned authoring packet. For a static HTML presentation, publish it with `zero host <dir> --site <slug> --artifact-kind presentation-html`.",
       "- If a flag above no longer applies, run `zero generate presentation -h` to discover the current options.",
     ].join("\n"),


### PR DESCRIPTION
## Summary
- Remove the `qa-deck.mjs` instruction from presentation template context.
- Keep the selected-template prompt focused on applying the template and following the returned authoring packet.
- Remove the now-obsolete test assertion for the QA command.

## Why
`qa-deck.mjs` currently assumes runtime controls such as `#swPal` exist. Decks that do not include those controls can crash the QA script before it reports useful layout or contrast results. Until the QA flow is made robust for all generated presentation HTML, the template context should not require agents to run it.

## Validation
- `pnpm -C turbo exec prettier --check apps/api/src/signals/routes/generation-template-prompt.ts apps/api/src/signals/routes/__tests__/generation-template-prompt.test.ts`
- `pnpm -C turbo exec vitest run apps/api/src/signals/routes/__tests__/generation-template-prompt.test.ts`
- `git diff --check`
