### PR TITLE
perf(runner): add pre-spawn phase timing

### DIFF
--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -21,7 +21,7 @@ use super::idle_lifecycle::{
 };
 use super::job_spawn::{JobProfile, SpawnContext, SpawnJobRequest, spawn_job};
 use crate::config::ProfileConfig;
-use crate::executor::validate_resume_session_id;
+use crate::executor::{RunnerPreSpawnTiming, validate_resume_session_id};
 use crate::idle_pool::{IdlePoolSnapshot, IdleUnparkResult, ReusableIdleSandbox};
 use crate::ids::RunId;
 use crate::paths::diagnostic_session_fingerprint;
@@ -117,6 +117,7 @@ pub(super) async fn handle_discovered_job(job: DiscoveredJob, mut ctx: Discovere
         budget_lease: job_lease,
         cancel: job_cancel,
     } = admission;
+    let pre_spawn_timing = RunnerPreSpawnTiming::start_after_claim();
     let resume_session_valid = validate_resume_session_id(claimed.context()).is_ok();
     let active_cli_agent_session_guard = ActiveCliAgentSessionGuard::new(
         ctx.spawn_ctx.active_cli_agent_sessions.clone(),
@@ -180,6 +181,7 @@ pub(super) async fn handle_discovered_job(job: DiscoveredJob, mut ctx: Discovere
             job_profile,
             reuse_entry,
             reuse_result,
+            pre_spawn_timing,
             active_cli_agent_session_guard,
         },
         ctx.spawn_ctx,

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -26,7 +26,7 @@ use super::ownership::{OwnershipTransitions, RunSandbox};
 use super::sandbox_finalization::{FinalizeContext, finalize_sandbox_for_completion};
 #[cfg(test)]
 use super::{OuterJobPanicPoint, StartLoopTestObserver, maybe_panic_outer_job};
-use crate::executor::{self, ExecutionFailureKind, ExecutorConfig};
+use crate::executor::{self, ExecutionFailureKind, ExecutorConfig, RunnerPreSpawnTiming};
 use crate::idle_pool::{ParkingGate, ReusableIdleSandbox};
 use crate::ids::RunId;
 use crate::network_log_drain::NetworkLogDrainCoordinator;
@@ -85,6 +85,7 @@ pub(super) struct SpawnJobRequest {
     pub(super) job_profile: JobProfile,
     pub(super) reuse_entry: Option<ReusableIdleSandbox>,
     pub(super) reuse_result: SandboxReuseResult,
+    pub(super) pre_spawn_timing: RunnerPreSpawnTiming,
     pub(super) active_cli_agent_session_guard: ActiveCliAgentSessionGuard,
 }
 
@@ -97,6 +98,7 @@ struct ExecutorInvocation {
     factory: SharedFactory,
     reuse_entry: Option<ReusableIdleSandbox>,
     reuse_result: SandboxReuseResult,
+    pre_spawn_timing: RunnerPreSpawnTiming,
     cancel: CancellationToken,
     sandbox_token: String,
     sandbox_prepared: Option<executor::SandboxPreparedNotifier>,
@@ -121,6 +123,7 @@ impl ExecutorInvocation {
             factory,
             reuse_entry,
             reuse_result,
+            pre_spawn_timing,
             cancel,
             sandbox_token,
             sandbox_prepared,
@@ -140,6 +143,7 @@ impl ExecutorInvocation {
                     &params,
                     cancel_for_executor,
                     active_input_source,
+                    Some(pre_spawn_timing),
                 )
                 .await
             } else {
@@ -156,6 +160,7 @@ impl ExecutorInvocation {
                     executor::ExecutionHooks {
                         sandbox_prepared,
                         active_input_source,
+                        pre_spawn_timing: Some(pre_spawn_timing),
                     },
                 )
                 .await
@@ -434,6 +439,7 @@ pub(super) fn spawn_job(
         job_profile,
         reuse_entry,
         reuse_result,
+        pre_spawn_timing,
         active_cli_agent_session_guard,
     } = request;
     let (context, completion_auth, active_input_source) = claimed.into_parts();
@@ -522,6 +528,7 @@ pub(super) fn spawn_job(
         factory: Arc::clone(&factory),
         reuse_entry,
         reuse_result,
+        pre_spawn_timing,
         cancel: job_cancel.token(),
         sandbox_token: sandbox_token.clone(),
         sandbox_prepared,

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -19,7 +19,7 @@ use super::env::{build_env_json, build_user_env_json, write_user_env_file};
 use super::guest_state::{restore_guest_state, sync_guest_timezone};
 use super::session_restore::restore_session;
 use super::storage::{apply_storage_fingerprint_reuse, download_storages, guest_download_has_work};
-use super::telemetry::record_api_latency;
+use super::telemetry::{RunnerSpawnTiming, record_api_latency};
 use super::{
     EXIT_SIGKILL, EXIT_SIGNAL_KILL, ExecutionFailure, ExecutorConfig, JOB_TIMEOUT,
     JOB_TIMEOUT_EXIT_CODE, PROCESS_CANCEL_TIMEOUTS, ResourceFailureDiagnostics,
@@ -190,6 +190,7 @@ pub(super) struct RunStart<'a> {
 pub(super) struct RunControls {
     pub(super) cancel: CancellationToken,
     pub(super) active_input_source: Option<ActiveInputSource>,
+    pub(super) spawn_timing: Option<RunnerSpawnTiming>,
 }
 
 impl RunControls {
@@ -200,7 +201,13 @@ impl RunControls {
         Self {
             cancel,
             active_input_source,
+            spawn_timing: None,
         }
+    }
+
+    pub(super) fn with_spawn_timing(mut self, spawn_timing: RunnerSpawnTiming) -> Self {
+        self.spawn_timing = Some(spawn_timing);
+        self
     }
 }
 
@@ -236,6 +243,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
     let RunControls {
         cancel,
         active_input_source,
+        spawn_timing,
     } = controls;
 
     // 1. Fix guest clock and reseed entropy (must happen before HTTPS calls).
@@ -243,10 +251,21 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
     //    When this exec already runs, fold best-effort timezone sync into it
     //    to avoid another pre-spawn guest round trip.
     if start.restore_guest_state {
-        restore_guest_state(sandbox, context).await?;
+        let t = Instant::now();
+        let result = restore_guest_state(sandbox, context).await;
+        let err = result.as_ref().err().map(|e| e.to_string());
+        telemetry.record(
+            "runner_guest_state_restore",
+            t.elapsed(),
+            result.is_ok(),
+            err.as_deref(),
+        );
+        result?;
     } else {
         // 2. Set guest timezone from user preference (best-effort, never fails).
+        let t = Instant::now();
         sync_guest_timezone(sandbox, context).await;
+        telemetry.record("runner_guest_timezone_sync", t.elapsed(), true, None);
     }
 
     // 3. Download storage manifest entries (skipping entries unchanged since the previous turn).
@@ -308,9 +327,42 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
     // 5. Build env vars. The guest-agent bootstrap env is runner-owned only;
     // user-provided env is passed through a private guest file and injected
     // into the CLI child after guest-agent has started.
+    let user_env_started = Instant::now();
     let user_env_map = build_user_env_json(context);
-    let user_env_file = write_user_env_file(sandbox, context.run_id, &user_env_map).await?;
-    let mut env_map = build_env_json(context, &config.api_url, sandbox.id(), start.reuse_result)?;
+    let user_env_file = match write_user_env_file(sandbox, context.run_id, &user_env_map).await {
+        Ok(user_env_file) => {
+            telemetry.record(
+                "runner_user_env_write",
+                user_env_started.elapsed(),
+                true,
+                None,
+            );
+            user_env_file
+        }
+        Err(error) => {
+            telemetry.record(
+                "runner_user_env_write",
+                user_env_started.elapsed(),
+                false,
+                None,
+            );
+            return Err(error);
+        }
+    };
+    let env_build_started = Instant::now();
+    let mut env_map =
+        match build_env_json(context, &config.api_url, sandbox.id(), start.reuse_result) {
+            Ok(env_map) => env_map,
+            Err(error) => {
+                telemetry.record(
+                    "runner_agent_env_build",
+                    env_build_started.elapsed(),
+                    false,
+                    None,
+                );
+                return Err(error);
+            }
+        };
     if let Some(path) = user_env_file {
         env_map.insert(USER_ENV_FILE_ENV_KEY.into(), path);
     }
@@ -320,6 +372,12 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         .iter()
         .map(|(k, v)| (k.as_str(), v.as_str()))
         .collect();
+    telemetry.record(
+        "runner_agent_env_build",
+        env_build_started.elapsed(),
+        true,
+        None,
+    );
     info!(run_id = %context.run_id, count = env_refs.len(), "passing env vars via vsock");
 
     // 6. Spawn agent — stdout streamed to host via vsock, stderr merged into stdout.
@@ -344,8 +402,20 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         .await;
 
     let mut handle = match handle {
-        Ok(h) => h,
+        Ok(h) => {
+            telemetry.record("runner_agent_start_process", t.elapsed(), true, None);
+            if let Some(spawn_timing) = spawn_timing {
+                spawn_timing.record_spawn_success(telemetry);
+            }
+            h
+        }
         Err(e) => {
+            telemetry.record(
+                "runner_agent_start_process",
+                t.elapsed(),
+                false,
+                Some(&e.to_string()),
+            );
             telemetry.record("agent_execute", t.elapsed(), false, Some(&e.to_string()));
             return Err(e.into());
         }

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -403,9 +403,15 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
 
     let mut handle = match handle {
         Ok(h) => {
-            telemetry.record("runner_agent_start_process", t.elapsed(), true, None);
+            let spawned_at = Instant::now();
+            telemetry.record(
+                "runner_agent_start_process",
+                spawned_at.saturating_duration_since(t),
+                true,
+                None,
+            );
             if let Some(spawn_timing) = spawn_timing {
-                spawn_timing.record_spawn_success(telemetry);
+                spawn_timing.record_spawn_success_at(telemetry, spawned_at);
             }
             h
         }

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -44,7 +44,8 @@ pub(crate) use env::validate_resume_session_id;
 use sandbox_run::{
     NewSandboxHooks, execute_new_sandbox_with_prepared_notifier, execute_reused_sandbox,
 };
-use telemetry::{record_api_latency, record_reuse_result};
+pub(crate) use telemetry::RunnerPreSpawnTiming;
+use telemetry::{RunnerSpawnTiming, record_api_latency, record_reuse_result};
 
 use crate::ids::RunId;
 use api_contracts::generated::constants::runners::paths::{
@@ -188,6 +189,7 @@ impl SandboxPreparedNotifier {
 pub(crate) struct ExecutionHooks {
     pub(crate) sandbox_prepared: Option<SandboxPreparedNotifier>,
     pub(crate) active_input_source: Option<ActiveInputSource>,
+    pub(crate) pre_spawn_timing: Option<RunnerPreSpawnTiming>,
 }
 
 impl ExecutionHooks {
@@ -196,6 +198,7 @@ impl ExecutionHooks {
         Self {
             sandbox_prepared: None,
             active_input_source: None,
+            pre_spawn_timing: None,
         }
     }
 }
@@ -417,6 +420,8 @@ pub(crate) async fn execute_job_with_prepared_notifier(
     let run_id = context.run_id;
     let mut telemetry =
         JobTelemetry::new(config.http.clone(), run_id, context.sandbox_token.clone());
+    let spawn_timing = RunnerSpawnTiming::start(hooks.pre_spawn_timing);
+    spawn_timing.record_claim_to_executor_start(&mut telemetry);
 
     record_reuse_result(&mut telemetry, dispatch.reuse_result);
     record_api_latency("api_to_vm_start", &context, &mut telemetry);
@@ -445,7 +450,8 @@ pub(crate) async fn execute_job_with_prepared_notifier(
             params,
             &mut telemetry,
             NewSandboxHooks {
-                controls: RunControls::new(cancel, hooks.active_input_source),
+                controls: RunControls::new(cancel, hooks.active_input_source)
+                    .with_spawn_timing(spawn_timing),
                 sandbox_prepared: hooks.sandbox_prepared.as_ref(),
             },
         )
@@ -481,8 +487,16 @@ pub async fn execute_job_reuse(
     params: &JobParams,
     cancel: CancellationToken,
 ) -> (ExecuteOutcome, JobTelemetry) {
-    execute_job_reuse_with_active_input_source(idle_sandbox, context, config, params, cancel, None)
-        .await
+    execute_job_reuse_with_active_input_source(
+        idle_sandbox,
+        context,
+        config,
+        params,
+        cancel,
+        None,
+        None,
+    )
+    .await
 }
 
 pub(crate) async fn execute_job_reuse_with_active_input_source(
@@ -492,10 +506,13 @@ pub(crate) async fn execute_job_reuse_with_active_input_source(
     params: &JobParams,
     cancel: CancellationToken,
     active_input_source: Option<ActiveInputSource>,
+    pre_spawn_timing: Option<RunnerPreSpawnTiming>,
 ) -> (ExecuteOutcome, JobTelemetry) {
     let run_id = context.run_id;
     let mut telemetry =
         JobTelemetry::new(config.http.clone(), run_id, context.sandbox_token.clone());
+    let spawn_timing = RunnerSpawnTiming::start(pre_spawn_timing);
+    spawn_timing.record_claim_to_executor_start(&mut telemetry);
 
     record_reuse_result(&mut telemetry, SandboxReuseResult::Reused);
     record_api_latency("api_to_vm_start", &context, &mut telemetry);
@@ -699,7 +716,7 @@ pub(crate) async fn execute_job_reuse_with_active_input_source(
             config,
             &prev_storage,
             &mut telemetry,
-            RunControls::new(cancel, active_input_source),
+            RunControls::new(cancel, active_input_source).with_spawn_timing(spawn_timing),
         )
         .await;
         outcome.workspace_image = workspace_image;

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -417,10 +417,10 @@ pub(crate) async fn execute_job_with_prepared_notifier(
     cancel: CancellationToken,
     hooks: ExecutionHooks,
 ) -> (ExecuteOutcome, JobTelemetry) {
+    let spawn_timing = RunnerSpawnTiming::start(hooks.pre_spawn_timing);
     let run_id = context.run_id;
     let mut telemetry =
         JobTelemetry::new(config.http.clone(), run_id, context.sandbox_token.clone());
-    let spawn_timing = RunnerSpawnTiming::start(hooks.pre_spawn_timing);
     spawn_timing.record_claim_to_executor_start(&mut telemetry);
 
     record_reuse_result(&mut telemetry, dispatch.reuse_result);
@@ -508,10 +508,10 @@ pub(crate) async fn execute_job_reuse_with_active_input_source(
     active_input_source: Option<ActiveInputSource>,
     pre_spawn_timing: Option<RunnerPreSpawnTiming>,
 ) -> (ExecuteOutcome, JobTelemetry) {
+    let spawn_timing = RunnerSpawnTiming::start(pre_spawn_timing);
     let run_id = context.run_id;
     let mut telemetry =
         JobTelemetry::new(config.http.clone(), run_id, context.sandbox_token.clone());
-    let spawn_timing = RunnerSpawnTiming::start(pre_spawn_timing);
     spawn_timing.record_claim_to_executor_start(&mut telemetry);
 
     record_reuse_result(&mut telemetry, SandboxReuseResult::Reused);

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -77,6 +77,7 @@ pub(super) async fn execute_new_sandbox_with_prepared_notifier(
         controls,
         sandbox_prepared,
     } = hooks;
+    let prepare_started = Instant::now();
     let mut workspace_image = prepare_workspace_image(
         context,
         sandbox_id,
@@ -121,7 +122,7 @@ pub(super) async fn execute_new_sandbox_with_prepared_notifier(
                 "workspace image cache hit failed during sandbox preparation; retrying with fresh workspace image"
             );
             workspace_image = None;
-            create_started_sandbox(
+            match create_started_sandbox(
                 factory,
                 context,
                 sandbox_id,
@@ -134,10 +135,37 @@ pub(super) async fn execute_new_sandbox_with_prepared_notifier(
                 },
             )
             .await
-            .map_err(|e| e.error)?
+            {
+                Ok(prepared) => prepared,
+                Err(e) => {
+                    let error = e.error;
+                    telemetry.record(
+                        "runner_fresh_sandbox_prepare",
+                        prepare_started.elapsed(),
+                        false,
+                        Some(&error.to_string()),
+                    );
+                    return Err(error);
+                }
+            }
         }
-        Err(e) => return Err(e.error),
+        Err(e) => {
+            let error = e.error;
+            telemetry.record(
+                "runner_fresh_sandbox_prepare",
+                prepare_started.elapsed(),
+                false,
+                Some(&error.to_string()),
+            );
+            return Err(error);
+        }
     };
+    telemetry.record(
+        "runner_fresh_sandbox_prepare",
+        prepare_started.elapsed(),
+        true,
+        None,
+    );
 
     let mut outcome = execute_prepared_sandbox_run(
         prepared,
@@ -391,9 +419,16 @@ pub(super) async fn execute_reused_sandbox(
     );
 
     let source_ip = source_ip.to_string();
+    let prepare_started = Instant::now();
     let network_log_session = match register_proxy(config, context, &source_ip).await {
         Ok(session) => session,
         Err(e) => {
+            telemetry.record(
+                "runner_reused_sandbox_prepare",
+                prepare_started.elapsed(),
+                false,
+                Some(&e.to_string()),
+            );
             return ExecuteOutcome {
                 failure: Some(ExecutionFailure::from_error(e.to_string())),
                 sandbox: Some(sandbox),
@@ -420,6 +455,12 @@ pub(super) async fn execute_reused_sandbox(
                 "failed to unregister VM from proxy after reused sandbox mount failure"
             );
         }
+        telemetry.record(
+            "runner_reused_sandbox_prepare",
+            prepare_started.elapsed(),
+            false,
+            Some(&e.to_string()),
+        );
         return ExecuteOutcome {
             failure: Some(ExecutionFailure::from_error(e.to_string())),
             sandbox: Some(sandbox),
@@ -430,6 +471,12 @@ pub(super) async fn execute_reused_sandbox(
         };
     }
     telemetry.record("workspace_drive_mount", mount_started.elapsed(), true, None);
+    telemetry.record(
+        "runner_reused_sandbox_prepare",
+        prepare_started.elapsed(),
+        true,
+        None,
+    );
 
     execute_prepared_sandbox_run(
         PreparedSandboxRun {
@@ -463,6 +510,7 @@ pub(super) async fn execute_prepared_sandbox_run(
         source_ip,
         network_log_session,
     } = run;
+    let cleanup_cancel = controls.cancel.clone();
 
     let result = run_in_sandbox(
         sandbox.as_ref(),
@@ -470,7 +518,7 @@ pub(super) async fn execute_prepared_sandbox_run(
         config,
         start,
         telemetry,
-        RunControls::new(controls.cancel.clone(), controls.active_input_source),
+        controls,
     )
     .await;
 
@@ -484,7 +532,7 @@ pub(super) async fn execute_prepared_sandbox_run(
         config,
         context,
         &source_ip,
-        controls.cancel.is_cancelled(),
+        cleanup_cancel.is_cancelled(),
         stdout_stream_diagnostics,
     )
     .await;

--- a/crates/runner/src/executor/telemetry.rs
+++ b/crates/runner/src/executor/telemetry.rs
@@ -1,7 +1,7 @@
 //! Executor telemetry marker helpers.
 
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use tracing::warn;
 
@@ -11,6 +11,67 @@ use crate::types::{ExecutionContext, SandboxReuseResult};
 use crate::workspace_image_cache::WorkspaceCacheCheckoutResult;
 
 static INVALID_API_START_TIME_WARNED: AtomicBool = AtomicBool::new(false);
+
+#[derive(Clone, Copy)]
+pub(crate) struct RunnerPreSpawnTiming {
+    claim_returned_at: Instant,
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct RunnerSpawnTiming {
+    executor_started_at: Instant,
+    pre_spawn_timing: Option<RunnerPreSpawnTiming>,
+}
+
+impl RunnerPreSpawnTiming {
+    pub(crate) fn start_after_claim() -> Self {
+        Self {
+            claim_returned_at: Instant::now(),
+        }
+    }
+
+    fn elapsed_at(self, at: Instant) -> Duration {
+        at.saturating_duration_since(self.claim_returned_at)
+    }
+}
+
+impl RunnerSpawnTiming {
+    pub(super) fn start(pre_spawn_timing: Option<RunnerPreSpawnTiming>) -> Self {
+        Self {
+            executor_started_at: Instant::now(),
+            pre_spawn_timing,
+        }
+    }
+
+    pub(super) fn record_claim_to_executor_start(self, telemetry: &mut JobTelemetry) {
+        if let Some(pre_spawn_timing) = self.pre_spawn_timing {
+            telemetry.record(
+                "runner_claim_to_executor_start",
+                pre_spawn_timing.elapsed_at(self.executor_started_at),
+                true,
+                None,
+            );
+        }
+    }
+
+    pub(super) fn record_spawn_success(self, telemetry: &mut JobTelemetry) {
+        let spawned_at = Instant::now();
+        telemetry.record(
+            "runner_executor_start_to_spawn",
+            spawned_at.saturating_duration_since(self.executor_started_at),
+            true,
+            None,
+        );
+        if let Some(pre_spawn_timing) = self.pre_spawn_timing {
+            telemetry.record(
+                "runner_claim_to_spawn",
+                pre_spawn_timing.elapsed_at(spawned_at),
+                true,
+                None,
+            );
+        }
+    }
+}
 
 pub(super) fn record_reuse_result(telemetry: &mut JobTelemetry, result: SandboxReuseResult) {
     let action_type = match result {

--- a/crates/runner/src/executor/telemetry.rs
+++ b/crates/runner/src/executor/telemetry.rs
@@ -54,8 +54,7 @@ impl RunnerSpawnTiming {
         }
     }
 
-    pub(super) fn record_spawn_success(self, telemetry: &mut JobTelemetry) {
-        let spawned_at = Instant::now();
+    pub(super) fn record_spawn_success_at(self, telemetry: &mut JobTelemetry, spawned_at: Instant) {
         telemetry.record(
             "runner_executor_start_to_spawn",
             spawned_at.saturating_duration_since(self.executor_started_at),

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -1,10 +1,14 @@
 use std::time::Duration;
 
 use sandbox::SandboxId;
+use sandbox::{ProcessOutputChunk, ProcessOutputMode};
 use sandbox_mock::MockSandboxFactory;
 
 use super::super::telemetry::{elapsed_since_api_start_ms, record_reuse_result};
-use super::super::{NewSandboxDispatch, execute_job, execute_job_reuse};
+use super::super::{
+    ExecutionHooks, NewSandboxDispatch, RunnerPreSpawnTiming, execute_job, execute_job_reuse,
+    execute_job_reuse_with_active_input_source, execute_job_with_prepared_notifier,
+};
 use super::support::{
     default_params, make_reusable_idle_sandbox, minimal_context, test_executor_config,
 };
@@ -45,6 +49,31 @@ fn new_telemetry() -> JobTelemetry {
     })
     .unwrap();
     JobTelemetry::new(http, RunId::nil(), "tok".to_string())
+}
+
+fn assert_has_action(telemetry: &JobTelemetry, action: &str) {
+    let ops = telemetry.pending_ops_snapshot();
+    assert!(
+        ops.iter().any(|op| op.0 == action),
+        "expected telemetry action {action}, got: {ops:?}"
+    );
+}
+
+fn assert_lacks_action(telemetry: &JobTelemetry, action: &str) {
+    let ops = telemetry.pending_ops_snapshot();
+    assert!(
+        ops.iter().all(|op| op.0 != action),
+        "unexpected telemetry action {action}, got: {ops:?}"
+    );
+}
+
+fn assert_action_success(telemetry: &JobTelemetry, action: &str, success: bool) {
+    let ops = telemetry.pending_ops_snapshot();
+    let op = ops
+        .iter()
+        .find(|op| op.0 == action)
+        .unwrap_or_else(|| panic!("expected telemetry action {action}, got: {ops:?}"));
+    assert_eq!(op.1, success, "{action} success flag");
 }
 
 #[test]
@@ -143,4 +172,142 @@ async fn execute_job_reuse_records_sandbox_reuse_hit_in_telemetry() {
         .collect();
     assert_eq!(reuse_events.len(), 1);
     assert_eq!(reuse_events[0].0, "sandbox_reuse_hit");
+}
+
+#[tokio::test]
+async fn execute_job_records_runner_pre_spawn_and_fresh_path_timing() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let factory = MockSandboxFactory::new();
+
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let (_outcome, telemetry) = execute_job_with_prepared_notifier(
+        &factory,
+        minimal_context(),
+        NewSandboxDispatch {
+            id: SandboxId::new_v4(),
+            reuse_result: SandboxReuseResult::PoolMiss,
+        },
+        &config,
+        &default_params(),
+        cancel,
+        ExecutionHooks {
+            sandbox_prepared: None,
+            active_input_source: None,
+            pre_spawn_timing: Some(RunnerPreSpawnTiming::start_after_claim()),
+        },
+    )
+    .await;
+
+    for action in [
+        "runner_claim_to_executor_start",
+        "runner_executor_start_to_spawn",
+        "runner_claim_to_spawn",
+        "runner_fresh_sandbox_prepare",
+        "runner_guest_timezone_sync",
+        "runner_user_env_write",
+        "runner_agent_env_build",
+        "runner_agent_start_process",
+        "sandbox_reuse_miss",
+        "vm_create",
+        "workspace_drive_mount",
+        "agent_execute",
+    ] {
+        assert_has_action(&telemetry, action);
+    }
+    assert_lacks_action(&telemetry, "runner_reused_sandbox_prepare");
+    assert_lacks_action(&telemetry, "runner_guest_state_restore");
+}
+
+#[tokio::test]
+async fn execute_job_reuse_records_runner_pre_spawn_and_reuse_path_timing() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let factory = MockSandboxFactory::new();
+
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let (outcome, _telemetry) = execute_job(
+        &factory,
+        minimal_context(),
+        NewSandboxDispatch {
+            id: SandboxId::new_v4(),
+            reuse_result: SandboxReuseResult::NoSessionId,
+        },
+        &config,
+        &default_params(),
+        cancel,
+    )
+    .await;
+    let sandbox = outcome.sandbox.expect("sandbox should be alive");
+
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let (idle_sandbox, _lease) =
+        make_reusable_idle_sandbox(sandbox, outcome.source_ip, "test-session").await;
+    let (_outcome, telemetry) = execute_job_reuse_with_active_input_source(
+        idle_sandbox,
+        minimal_context(),
+        &config,
+        &default_params(),
+        cancel,
+        None,
+        Some(RunnerPreSpawnTiming::start_after_claim()),
+    )
+    .await;
+
+    for action in [
+        "runner_claim_to_executor_start",
+        "runner_executor_start_to_spawn",
+        "runner_claim_to_spawn",
+        "runner_reused_sandbox_prepare",
+        "runner_guest_state_restore",
+        "runner_user_env_write",
+        "runner_agent_env_build",
+        "runner_agent_start_process",
+        "sandbox_reuse_hit",
+        "workspace_drive_mount",
+        "agent_execute",
+    ] {
+        assert_has_action(&telemetry, action);
+    }
+    assert_lacks_action(&telemetry, "runner_fresh_sandbox_prepare");
+    assert_lacks_action(&telemetry, "runner_guest_timezone_sync");
+}
+
+#[tokio::test]
+async fn start_process_failure_records_phase_failure_without_spawn_completion() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = std::sync::Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_start_process_stdout_chunks(vec![
+        ProcessOutputChunk {
+            bytes: Vec::new(),
+            truncated: false,
+        };
+        ProcessOutputMode::DEFAULT_QUEUE_CAPACITY + 1
+    ]);
+    let factory = MockSandboxFactory::with_overrides(overrides);
+
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let (_outcome, telemetry) = execute_job_with_prepared_notifier(
+        &factory,
+        minimal_context(),
+        NewSandboxDispatch {
+            id: SandboxId::new_v4(),
+            reuse_result: SandboxReuseResult::PoolMiss,
+        },
+        &config,
+        &default_params(),
+        cancel,
+        ExecutionHooks {
+            sandbox_prepared: None,
+            active_input_source: None,
+            pre_spawn_timing: Some(RunnerPreSpawnTiming::start_after_claim()),
+        },
+    )
+    .await;
+
+    assert_action_success(&telemetry, "runner_agent_start_process", false);
+    assert_action_success(&telemetry, "agent_execute", false);
+    assert_lacks_action(&telemetry, "runner_executor_start_to_spawn");
+    assert_lacks_action(&telemetry, "runner_claim_to_spawn");
 }


### PR DESCRIPTION
## Summary

- add a post-claim runner timing carrier and record claim-to-executor / executor-to-spawn / claim-to-spawn rows through existing JobTelemetry
- add fixed runner pre-spawn phase rows for fresh/reused sandbox preparation, guest restore/timezone, env write/build, and start_process
- keep telemetry ingestion/schema and existing api_to_spawn semantics unchanged

Closes #18994

## Tests

- cargo test --manifest-path crates/Cargo.toml -p runner executor::tests::telemetry_tests
- cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::tests::main_loop::job_flow
- cargo test --manifest-path crates/Cargo.toml -p runner
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- git diff --check

Pre-commit also ran crates cargo-fmt, cargo-doc, and cargo-clippy.