### PR TITLE
fix: pan image lightbox on ordinary wheel

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -377,7 +377,7 @@ describe("zero attachment chips", () => {
     });
   });
 
-  it("keeps ordinary wheel events bubbling through an uploaded image preview", async () => {
+  it("pans an uploaded image preview with ordinary wheel events", async () => {
     await setupUploadedImagePreview();
 
     click(screen.getByLabelText("Open image preview for photo.png"));
@@ -389,24 +389,42 @@ describe("zero attachment chips", () => {
     });
 
     const zoomStage = screen.getByTestId("artifact-dialog-image-stage");
+    const zoomContent = screen.getByTestId(
+      "artifact-dialog-image-stage-content",
+    );
+    const transformContent = zoomContent.parentElement as HTMLElement;
+    const transformWrapper = transformContent.parentElement as HTMLElement;
     const lightboxImage = screen.getByTestId("attachment-lightbox-image");
     mockElementBox(zoomStage, { height: 600, width: 800 });
+    mockElementBox(transformWrapper, { height: 600, width: 800 });
+    mockElementBox(transformContent, { height: 1200, width: 1600 });
+    Object.defineProperty(lightboxImage, "naturalWidth", {
+      configurable: true,
+      value: 1200,
+    });
+    fireEvent.load(lightboxImage);
 
-    let wheelReachedStage = false;
-    const markWheelReachedStage = () => {
-      wheelReachedStage = true;
-    };
-    zoomStage.addEventListener("wheel", markWheelReachedStage);
+    await waitFor(() => {
+      expect(lightboxImage).toHaveStyle({ width: "800px" });
+    });
 
-    const trackpadPanEvent = createEvent.wheel(lightboxImage, {
+    click(screen.getByLabelText("Zoom in"));
+
+    await waitFor(() => {
+      expect(screen.getByText("115%")).toBeInTheDocument();
+      expect(transformContent.style.transform).toContain("scale(1.15)");
+    });
+
+    const transformBeforePan = transformContent.style.transform;
+    const trackpadPanEvent = createEvent.wheel(transformWrapper, {
       deltaX: 12,
       deltaY: 24,
     });
-    fireEvent(lightboxImage, trackpadPanEvent);
-    zoomStage.removeEventListener("wheel", markWheelReachedStage);
+    fireEvent(transformWrapper, trackpadPanEvent);
 
-    expect(wheelReachedStage).toBeTruthy();
-    expect(trackpadPanEvent.defaultPrevented).toBeFalsy();
+    expect(trackpadPanEvent.defaultPrevented).toBeTruthy();
+    expect(transformContent.style.transform).not.toBe(transformBeforePan);
+    expect(transformContent.style.transform).toContain("scale(1.15)");
 
     click(screen.getByLabelText("Close"));
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/zero-zoomable-image-canvas.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-zoomable-image-canvas.tsx
@@ -171,7 +171,11 @@ export function ZoomableArtifactImageCanvas({
       }}
       pinch={{ allowPanning: false }}
       smooth={false}
-      wheel={{ activationKeys: ["Control"] }}
+      trackPadPanning={{ disabled: false }}
+      wheel={{
+        activationKeys: ["Control"],
+        wheelDisabled: true,
+      }}
     >
       {({ resetTransform, zoomIn, zoomOut }) => {
         const controls = controlsFromTransformState({


### PR DESCRIPTION
## Summary
- make ordinary wheel input pan the zoomable image canvas instead of bubbling without handling
- keep Control-activated wheel zoom for mouse wheel and trackpad pinch gestures
- update image lightbox regression coverage for ordinary wheel panning

## Context
The desired interaction is:
- trackpad pinch zooms
- trackpad two-finger scroll pans
- Control + mouse wheel zooms
- mouse wheel pans

`react-zoom-pan-pinch` supports this split by disabling ordinary wheel zoom and enabling wheel-based panning.

## Verification
- `pnpm format`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-attachment-chips.test.tsx src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
