### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -111,11 +111,11 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.4"
-CLAUDE_CODE_VERSION="2.1.191"
-CODEX_CLI_VERSION="0.142.1"
+CLAUDE_CODE_VERSION="2.1.193"
+CODEX_CLI_VERSION="0.142.2"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"
-AGENT_BROWSER_VERSION="0.30.1"
+AGENT_BROWSER_VERSION="0.31.0"
 PNPM_VERSION="11.9.0"
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Updates pinned rootfs dependency versions in `crates/runner/scripts/build-template.sh`:

- Claude Code CLI: `2.1.191` -> `2.1.193`
- OpenAI Codex CLI: `0.142.1` -> `0.142.2`
- agent-browser: `0.30.1` -> `0.31.0`

Checked and left unchanged because they are already current or on the current stable/LTS track:

- Go: `1.26.4`
- Google Workspace CLI: `0.22.5`
- xurl: `1.0.3`
- pnpm: `11.9.0`
- Node.js: `24.x` LTS track
- PostgreSQL: `18` stable track

## Validation

- `bash -n crates/runner/scripts/build-template.sh`
- `shellcheck` was not installed in the local runtime, so it was skipped.
