### PR TITLE
perf: store resume session history references

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -8,6 +8,10 @@ import {
   MODEL_PROVIDER_TYPES,
   type ModelProviderType,
 } from "@vm0/api-contracts/contracts/model-providers";
+import {
+  storedExecutionContextSchema,
+  type StoredExecutionContext,
+} from "@vm0/api-contracts/contracts/runners";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   UNKNOWN_PERMISSION_GRANT,
@@ -16,6 +20,7 @@ import {
 } from "@vm0/connectors/firewall-types";
 import { getFirewallExecutionMetadata } from "@vm0/connectors/firewall-metadata/server";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
+import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
 import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
 import { createStore } from "ccstate";
 import { eq } from "drizzle-orm";
@@ -71,6 +76,7 @@ const CLAIM_ROUTE_TOP_LEVEL_TIMING_ACTION_TYPES = [
   "claim_route_request_prepare",
   "claim_route_lookup_authorization",
   "claim_route_context_parse",
+  "claim_route_resolve_resume_session_history",
   "claim_route_feature_switch_context",
   "claim_route_secret_materialization",
   "claim_route_response_assembly",
@@ -359,11 +365,13 @@ function expectNoApiDispatchActions(
   }
 }
 
-function mockSessionHistoryBlob(hash: string, history: string): void {
+function mockSessionHistoryBlob(hash: string, history: string): () => number {
+  let readCount = 0;
   context.mocks.s3.send.mockImplementation((command: unknown) => {
     const input = (command as { readonly input?: { readonly Key?: string } })
       .input;
     if (input?.Key === `blobs/${hash}.blob`) {
+      readCount += 1;
       return Promise.resolve({
         Body: {
           async *[Symbol.asyncIterator]() {
@@ -374,6 +382,23 @@ function mockSessionHistoryBlob(hash: string, history: string): void {
     }
     return Promise.resolve({});
   });
+  return () => {
+    return readCount;
+  };
+}
+
+async function storedExecutionContextForQueuedRun(
+  runId: string,
+): Promise<StoredExecutionContext> {
+  const [row] = await writeDb
+    .select({ executionContext: runnerJobQueue.executionContext })
+    .from(runnerJobQueue)
+    .where(eq(runnerJobQueue.runId, runId))
+    .limit(1);
+  if (!row) {
+    throw new Error("Expected runner job queue row");
+  }
+  return storedExecutionContextSchema.parse(row.executionContext);
 }
 
 /**
@@ -615,7 +640,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const claim = await api.claimRunnerJob(first.runId);
     const history = `bdd timing session history ${first.runId}`;
     const historyHash = createHash("sha256").update(history).digest("hex");
-    mockSessionHistoryBlob(historyHash, history);
+    const historyBlobReads = mockSessionHistoryBlob(historyHash, history);
 
     await webhooks.requestAgentCheckpoint(
       {
@@ -638,6 +663,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       throw new Error("Expected checkpointed timing run to expose checkpoint");
     }
 
+    const historyBlobReadsBeforeResume = historyBlobReads();
     const resumed = await api.createRun(actor, {
       agentId,
       sessionId: first.sessionId,
@@ -645,14 +671,26 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       modelProvider: "anthropic-api-key",
     });
     expect(resumed.sessionId).toBe(first.sessionId);
+    expect(historyBlobReads()).toBe(historyBlobReadsBeforeResume);
+    const storedSessionContext = await storedExecutionContextForQueuedRun(
+      resumed.runId,
+    );
+    expect(storedSessionContext.resumeSession).toStrictEqual({
+      kind: "history-ref",
+      sessionId: `bdd-timing-cli-${first.runId}`,
+      historyHash,
+    });
+    expect(JSON.stringify(storedSessionContext)).not.toContain(history);
     const sessionTimingEvents = apiDispatchTimingEventsForRun(resumed.runId);
     expectApiDispatchActions(sessionTimingEvents, [
       "api_dispatch_resolve_compose_by_session_id",
       "api_dispatch_resolve_compose_lookup_session",
       "api_dispatch_resolve_compose_lookup_compose",
       "api_dispatch_resolve_compose_load_resume_session",
-      "api_dispatch_resolve_compose_resolve_session_history",
       "api_dispatch_resolve_compose_lookup_session_vars",
+    ]);
+    expectNoApiDispatchActions(sessionTimingEvents, [
+      "api_dispatch_resolve_compose_resolve_session_history",
     ]);
     expectNoApiDispatchActions(
       sessionTimingEvents,
@@ -666,13 +704,30 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       expect(serialized).not.toContain(historyHash);
       expect(serialized).not.toContain(first.sessionId);
     }
+    const resumedClaim = await api.claimRunnerJob(resumed.runId);
+    expect(resumedClaim.resumeSession).toStrictEqual({
+      sessionId: `bdd-timing-cli-${first.runId}`,
+      sessionHistory: history,
+    });
+    expect(historyBlobReads()).toBe(historyBlobReadsBeforeResume + 1);
 
     const checkpointZeroToken = "bdd-checkpoint-zero-token";
+    const historyBlobReadsBeforeCheckpointResume = historyBlobReads();
     const checkpointRun = await api.createDirectRun(actor, {
       checkpointId,
       prompt: "resume checkpoint with timing",
       secrets: { ZERO_TOKEN: checkpointZeroToken },
     });
+    expect(historyBlobReads()).toBe(historyBlobReadsBeforeCheckpointResume);
+    const storedCheckpointContext = await storedExecutionContextForQueuedRun(
+      checkpointRun.runId,
+    );
+    expect(storedCheckpointContext.resumeSession).toStrictEqual({
+      kind: "history-ref",
+      sessionId: `bdd-timing-cli-${first.runId}`,
+      historyHash,
+    });
+    expect(JSON.stringify(storedCheckpointContext)).not.toContain(history);
     const checkpointTimingEvents = apiDispatchTimingEventsForRun(
       checkpointRun.runId,
     );
@@ -681,6 +736,8 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       "api_dispatch_resolve_compose_lookup_checkpoint",
       "api_dispatch_resolve_compose_lookup_version",
       "api_dispatch_resolve_compose_load_resume_session",
+    ]);
+    expectNoApiDispatchActions(checkpointTimingEvents, [
       "api_dispatch_resolve_compose_resolve_session_history",
     ]);
     expectNoApiDispatchActions(
@@ -704,6 +761,73 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
 
     await api.requestCancelRun(actor, resumed.runId, [200]);
     await api.requestCancelRun(actor, checkpointRun.runId, [200]);
+  });
+
+  it("fails claim before running when referenced session history is missing", async () => {
+    const api = createRunsAutomationsApi(context);
+    const webhooks = createWebhookCallbackApi(context);
+    const { actor, agentId } = await entitledRunActor();
+
+    const first = await api.createRun(actor, {
+      agentId,
+      prompt: "start a missing-history session",
+      modelProvider: "anthropic-api-key",
+    });
+    const claim = await api.claimRunnerJob(first.runId);
+    const history = `missing history ${first.runId}`;
+    const historyHash = createHash("sha256").update(history).digest("hex");
+
+    await webhooks.requestAgentCheckpoint(
+      {
+        runId: first.runId,
+        cliAgentType: "claude-code",
+        cliAgentSessionId: `bdd-missing-history-cli-${first.runId}`,
+        cliAgentSessionHistoryHash: historyHash,
+      },
+      { authorization: `Bearer ${claim.sandboxToken}` },
+      [200],
+    );
+    await webhooks.requestAgentComplete(
+      { runId: first.runId, exitCode: 0, lastEventSequence: 0 },
+      { authorization: `Bearer ${claim.sandboxToken}` },
+      [200],
+    );
+
+    context.mocks.s3.send.mockResolvedValue({});
+    const resumed = await api.createRun(actor, {
+      agentId,
+      sessionId: first.sessionId,
+      prompt: "continue missing-history session",
+      modelProvider: "anthropic-api-key",
+    });
+    const storedContext = await storedExecutionContextForQueuedRun(
+      resumed.runId,
+    );
+    expect(storedContext.resumeSession).toStrictEqual({
+      kind: "history-ref",
+      sessionId: `bdd-missing-history-cli-${first.runId}`,
+      historyHash,
+    });
+
+    const rejectedClaim = await api.requestClaimRunnerJob(
+      true,
+      resumed.runId,
+      [400],
+    );
+    expectApiError(rejectedClaim.body);
+    expect(rejectedClaim.body.error.message).toBe(
+      "Job missing resume session history",
+    );
+
+    const failed = await api.readRun(actor, resumed.runId);
+    expect(failed.status).toBe("failed");
+    expect(failed.error).toBe("Runner job missing resume session history");
+    const [remainingJob] = await writeDb
+      .select({ runId: runnerJobQueue.runId })
+      .from(runnerJobQueue)
+      .where(eq(runnerJobQueue.runId, resumed.runId))
+      .limit(1);
+    expect(remainingJob).toBeUndefined();
   });
 
   it("creates, dispatches, claims, reports, and completes a run through public APIs", async () => {

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -7,7 +7,9 @@ import {
   storedExecutionContextSchema,
   type ExecutionContext,
   type HeldSessionState,
+  type ResumeSession,
   type StoredExecutionContext,
+  type StoredResumeSession,
 } from "@vm0/api-contracts/contracts/runners";
 import { runnerRealtimeTokenContract } from "@vm0/api-contracts/contracts/realtime";
 import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
@@ -21,6 +23,7 @@ import { authorization$ } from "../context/hono";
 import { bodyResultOf, pathParamsOf } from "../context/request";
 import { waitUntil } from "../context/wait-until";
 import { writeDb$, type Db } from "../external/db";
+import { downloadS3Buffer } from "../external/s3";
 import {
   createRunnerGroupRealtimeToken,
   publishRunChangedForUserSafely,
@@ -28,13 +31,14 @@ import {
 import { recordSandboxOperations } from "../external/sandbox-op-log";
 import { now, nowDate } from "../external/time";
 import { badRequestMessage, conflict, notFound } from "../../lib/error";
+import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { generateSandboxToken } from "../auth/tokens";
 import { decryptPersistentSecretsMap } from "../services/crypto.utils";
 import { dispatchCompleteSideEffects$ } from "../services/agent-webhook-complete.service";
 import { loadUserFeatureSwitchContext } from "../services/feature-switches.service";
 import type { RouteEntry } from "../route";
-import { tapError } from "../utils";
+import { settle, tapError } from "../utils";
 
 const L = logger("Runners");
 
@@ -45,6 +49,8 @@ type SandboxOperationAttrs = Parameters<
 const STALE_RUNNER_THRESHOLD_MS = 5 * 60 * 1000;
 const INVALID_EXECUTION_CONTEXT_ERROR =
   "Runner job missing valid execution context";
+const MISSING_RESUME_SESSION_HISTORY_ERROR =
+  "Runner job missing resume session history";
 const MAX_VALIDATION_ISSUES_TO_LOG = 10;
 
 type ClaimRouteTimingSpanKind = "top_level" | "nested";
@@ -52,6 +58,7 @@ type ClaimRouteTimingActionType =
   | "claim_route_request_prepare"
   | "claim_route_lookup_authorization"
   | "claim_route_context_parse"
+  | "claim_route_resolve_resume_session_history"
   | "claim_route_feature_switch_context"
   | "claim_route_secret_materialization"
   | "claim_route_response_assembly"
@@ -575,6 +582,10 @@ type ClaimedTransitionResult = Extract<
   ClaimTransitionResult,
   { readonly status: "claimed" }
 >;
+type ClaimTransitionFailureResult = Exclude<
+  ClaimTransitionResult,
+  ClaimedTransitionResult
+>;
 
 interface LockedClaimRunRow extends Record<string, unknown> {
   readonly id: string;
@@ -699,6 +710,18 @@ async function transitionClaimedJobToRunning(
   });
 }
 
+function claimTransitionFailureResponse(
+  result: ClaimTransitionFailureResult,
+): ReturnType<typeof conflict> | ReturnType<typeof notFound> {
+  if (result.status === "conflict") {
+    return conflict("Job was claimed by another runner");
+  }
+  if (result.status === "job-not-found") {
+    return notFound("Job not found in queue");
+  }
+  return notFound("Run not found");
+}
+
 type PoisonJobResult =
   | { readonly status: "failed" }
   | { readonly status: "conflict" }
@@ -754,6 +777,115 @@ async function failPoisonQueuedJob(
   });
 }
 
+type ResumeSessionResolutionResult =
+  | {
+      readonly status: "ok";
+      readonly resumeSession: ResumeSession | null;
+    }
+  | { readonly status: "missing-history" };
+
+type PoisonClaimResponse =
+  | ReturnType<typeof conflict>
+  | ReturnType<typeof notFound>
+  | ReturnType<typeof badRequestMessage>;
+
+function isStoredResumeSessionHistoryRef(
+  resumeSession: StoredResumeSession,
+): resumeSession is Extract<
+  StoredResumeSession,
+  { readonly kind: "history-ref" }
+> {
+  return "kind" in resumeSession && resumeSession.kind === "history-ref";
+}
+
+async function resolveClaimResumeSession(args: {
+  readonly storedResumeSession: StoredResumeSession | null;
+  readonly loadHistory: (historyHash: string) => Promise<Buffer>;
+}): Promise<ResumeSessionResolutionResult> {
+  const storedResumeSession = args.storedResumeSession;
+  if (!storedResumeSession) {
+    return { status: "ok", resumeSession: null };
+  }
+  if (!isStoredResumeSessionHistoryRef(storedResumeSession)) {
+    return { status: "ok", resumeSession: storedResumeSession };
+  }
+
+  const result = await settle(
+    args.loadHistory(storedResumeSession.historyHash),
+  );
+  if (!result.ok) {
+    L.warn(MISSING_RESUME_SESSION_HISTORY_ERROR);
+    return { status: "missing-history" };
+  }
+
+  return {
+    status: "ok",
+    resumeSession: {
+      sessionId: storedResumeSession.sessionId,
+      sessionHistory: result.value.toString("utf8"),
+    },
+  };
+}
+
+async function resolveClaimResumeSessionWithTiming(args: {
+  readonly storedContext: StoredExecutionContext;
+  readonly timing: ClaimRouteTimingCollector;
+  readonly loadHistory: (historyHash: string) => Promise<Buffer>;
+}): Promise<ResumeSessionResolutionResult> {
+  return await args.timing.measure(
+    "claim_route_resolve_resume_session_history",
+    "top_level",
+    async () => {
+      return await resolveClaimResumeSession({
+        storedResumeSession: args.storedContext.resumeSession,
+        loadHistory: args.loadHistory,
+      });
+    },
+  );
+}
+
+function parseStoredExecutionContextForClaim(args: {
+  readonly executionContext: unknown;
+  readonly timing: ClaimRouteTimingCollector;
+}): ReturnType<typeof storedExecutionContextSchema.safeParse> {
+  const startedAt = now();
+  const result = storedExecutionContextSchema.safeParse(args.executionContext);
+  args.timing.recordElapsed(
+    "claim_route_context_parse",
+    "top_level",
+    startedAt,
+  );
+  return result;
+}
+
+async function failClaimWithPoisonedJob(args: {
+  readonly db: Db;
+  readonly runId: string;
+  readonly signal: AbortSignal;
+  readonly errorMessage: string;
+  readonly responseMessage: string;
+  readonly scheduleFailedSideEffects: () => void;
+}): Promise<PoisonClaimResponse> {
+  const poisonResult = await failPoisonQueuedJob(
+    args.db,
+    args.runId,
+    args.errorMessage,
+    args.signal,
+  );
+  if (poisonResult.status === "conflict") {
+    return conflict("Job was claimed by another runner");
+  }
+  if (poisonResult.status === "job-not-found") {
+    return notFound("Job not found in queue");
+  }
+  if (poisonResult.status === "run-not-found") {
+    return notFound("Run not found");
+  }
+
+  args.scheduleFailedSideEffects();
+  return badRequestMessage(args.responseMessage);
+}
+
 async function secretValuesForRunner(
   storedContext: StoredExecutionContext,
   featureSwitchContext: FeatureSwitchContext,
@@ -778,6 +910,7 @@ async function buildClaimResponseBody(args: {
   readonly db: Db;
   readonly run: ClaimedRun;
   readonly storedContext: StoredExecutionContext;
+  readonly resumeSession: ResumeSession | null;
   readonly timing: ClaimRouteTimingCollector;
   readonly signal: AbortSignal;
 }): Promise<ExecutionContext> {
@@ -809,6 +942,7 @@ async function buildClaimResponseBody(args: {
   );
   const responseBody = {
     ...args.storedContext,
+    resumeSession: args.resumeSession,
     runId: args.run.id,
     prompt: args.run.prompt,
     appendSystemPrompt: args.run.appendSystemPrompt,
@@ -1107,48 +1241,63 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 
   const run = jobWithRun.run;
 
-  const contextParseStartedAt = now();
-  const storedContextResult = storedExecutionContextSchema.safeParse(
-    jobWithRun.job.executionContext,
-  );
-  claimRouteTiming.recordElapsed(
-    "claim_route_context_parse",
-    "top_level",
-    contextParseStartedAt,
-  );
+  const storedContextResult = parseStoredExecutionContextForClaim({
+    executionContext: jobWithRun.job.executionContext,
+    timing: claimRouteTiming,
+  });
   signal.throwIfAborted();
   if (!storedContextResult.success) {
     warnInvalidStoredExecutionContext(runId, storedContextResult.error.issues);
-    const poisonResult = await failPoisonQueuedJob(
+    return await failClaimWithPoisonedJob({
       db,
       runId,
-      INVALID_EXECUTION_CONTEXT_ERROR,
       signal,
-    );
-    if (poisonResult.status === "conflict") {
-      return conflict("Job was claimed by another runner");
-    }
-    if (poisonResult.status === "job-not-found") {
-      return notFound("Job not found in queue");
-    }
-    if (poisonResult.status === "run-not-found") {
-      return notFound("Run not found");
-    }
-
-    set(scheduleClaimFailedSideEffects$, {
-      runId,
-      userId: run.userId,
-      orgId: run.orgId,
-      error: INVALID_EXECUTION_CONTEXT_ERROR,
+      errorMessage: INVALID_EXECUTION_CONTEXT_ERROR,
+      responseMessage: "Job missing execution context",
+      scheduleFailedSideEffects: () => {
+        set(scheduleClaimFailedSideEffects$, {
+          runId,
+          userId: run.userId,
+          orgId: run.orgId,
+          error: INVALID_EXECUTION_CONTEXT_ERROR,
+        });
+      },
     });
-    return badRequestMessage("Job missing execution context");
   }
   const storedContext = storedContextResult.data;
+
+  const resumeSessionResult = await resolveClaimResumeSessionWithTiming({
+    storedContext,
+    timing: claimRouteTiming,
+    loadHistory: async (historyHash) => {
+      const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
+      return await get(downloadS3Buffer(bucket, `blobs/${historyHash}.blob`));
+    },
+  });
+  signal.throwIfAborted();
+  if (resumeSessionResult.status === "missing-history") {
+    return await failClaimWithPoisonedJob({
+      db,
+      runId,
+      signal,
+      errorMessage: MISSING_RESUME_SESSION_HISTORY_ERROR,
+      responseMessage: "Job missing resume session history",
+      scheduleFailedSideEffects: () => {
+        set(scheduleClaimFailedSideEffects$, {
+          runId,
+          userId: run.userId,
+          orgId: run.orgId,
+          error: MISSING_RESUME_SESSION_HISTORY_ERROR,
+        });
+      },
+    });
+  }
 
   const responseBody = await buildClaimResponseBody({
     db,
     run,
     storedContext,
+    resumeSession: resumeSessionResult.resumeSession,
     timing: claimRouteTiming,
     signal,
   });
@@ -1167,14 +1316,8 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     },
   );
   signal.throwIfAborted();
-  if (claimResult.status === "conflict") {
-    return conflict("Job was claimed by another runner");
-  }
-  if (claimResult.status === "job-not-found") {
-    return notFound("Job not found in queue");
-  }
-  if (claimResult.status === "run-not-found") {
-    return notFound("Run not found");
+  if (claimResult.status !== "claimed") {
+    return claimTransitionFailureResponse(claimResult);
   }
 
   scheduleSuccessfulClaimSideEffects({

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -114,7 +114,6 @@ import {
   providerUnavailable,
 } from "../../lib/error";
 import { writeDb$, type Db } from "../external/db";
-import { downloadS3Buffer } from "../external/s3";
 import { getDatasetName, ingestToAxiom } from "../external/axiom";
 import {
   publishOrgSignal,
@@ -3059,7 +3058,7 @@ function resolveBySessionId(
               "api_dispatch_resolve_compose_load_resume_session",
               "nested",
               async () => {
-                return await get(loadResumeSession(db, conversationId, timing));
+                return await get(loadResumeSession(db, conversationId));
               },
             );
       const conversationRunId = session.conversationRunId;
@@ -3157,7 +3156,7 @@ function resolveByCheckpointId(
           "api_dispatch_resolve_compose_load_resume_session",
           "nested",
           async () => {
-            return await get(loadResumeSession(db, row.conversationId, timing));
+            return await get(loadResumeSession(db, row.conversationId));
           },
         ),
       };
@@ -3168,12 +3167,9 @@ function resolveByCheckpointId(
 function loadResumeSession(
   db: Db,
   conversationId: string,
-  timing?: ApiDispatchTimingCollector,
 ): Computed<Promise<StoredExecutionContext["resumeSession"] | undefined>> {
   return computed(
-    async (
-      get,
-    ): Promise<StoredExecutionContext["resumeSession"] | undefined> => {
+    async (): Promise<StoredExecutionContext["resumeSession"] | undefined> => {
       const [conversation] = await db
         .select({
           cliAgentSessionId: conversations.cliAgentSessionId,
@@ -3188,61 +3184,21 @@ function loadResumeSession(
         return undefined;
       }
 
-      const sessionHistory = await measureApiDispatchTiming(
-        timing,
-        "api_dispatch_resolve_compose_resolve_session_history",
-        "nested",
-        async () => {
-          return await get(
-            resolveConversationSessionHistory({
-              hash: conversation.cliAgentSessionHistoryHash,
-              legacyText: conversation.cliAgentSessionHistory,
-            }),
-          );
-        },
-      );
+      const cliAgentSessionId = conversation.cliAgentSessionId;
 
-      if (sessionHistory === null) {
-        return undefined;
+      if (conversation.cliAgentSessionHistory) {
+        return {
+          sessionId: cliAgentSessionId,
+          sessionHistory: conversation.cliAgentSessionHistory,
+        };
       }
 
-      const cliAgentSessionId = conversation.cliAgentSessionId;
-      return {
-        sessionId: cliAgentSessionId,
-        sessionHistory,
-      };
+      const historyHash = conversation.cliAgentSessionHistoryHash;
+      return historyHash
+        ? { kind: "history-ref", sessionId: cliAgentSessionId, historyHash }
+        : undefined;
     },
   );
-}
-
-function resolveConversationSessionHistory(args: {
-  readonly hash: string | null;
-  readonly legacyText: string | null;
-}): Computed<Promise<string | null>> {
-  return computed(async (get): Promise<string | null> => {
-    const { hash, legacyText } = args;
-    if (hash) {
-      const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
-      const result = await settle(
-        get(downloadS3Buffer(bucket, `blobs/${hash}.blob`)),
-      );
-      if (result.ok) {
-        return result.value.toString("utf8");
-      }
-      if (legacyText) {
-        L.warn(
-          "session history R2 retrieval failed; falling back to legacy TEXT",
-          { hash, error: result.error },
-        );
-        return legacyText;
-      }
-      throw result.error;
-    }
-    if (legacyText) {
-      return legacyText;
-    }
-    return null;
-  });
 }
 
 function resolveCompose(

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -236,6 +236,41 @@ describe("runner firewall entry contract", () => {
   });
 });
 
+describe("runner resume session contracts", () => {
+  it("accepts legacy inline resume sessions in stored contexts", () => {
+    const resumeSession = {
+      sessionId: "session-1",
+      sessionHistory: '{"type":"init"}\n',
+    };
+
+    expect(
+      storedExecutionContextSchema.shape.resumeSession.safeParse(resumeSession)
+        .success,
+    ).toBe(true);
+    expect(
+      executionContextSchema.shape.resumeSession.safeParse(resumeSession)
+        .success,
+    ).toBe(true);
+  });
+
+  it("accepts hash references only in stored resume sessions", () => {
+    const resumeSession = {
+      kind: "history-ref",
+      sessionId: "session-1",
+      historyHash: "a".repeat(64),
+    };
+
+    expect(
+      storedExecutionContextSchema.shape.resumeSession.safeParse(resumeSession)
+        .success,
+    ).toBe(true);
+    expect(
+      executionContextSchema.shape.resumeSession.safeParse(resumeSession)
+        .success,
+    ).toBe(false);
+  });
+});
+
 describe("runner apiStartTime contract", () => {
   it("accepts Unix epoch millisecond integers", () => {
     const timestamp = 1_700_000_000_000;

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -642,6 +642,7 @@ export {
   artifactEntrySchema,
   storageManifestSchema,
   resumeSessionSchema,
+  storedResumeSessionSchema,
   type RunnersPollContract,
   type RunnersJobClaimContract,
   type RunnersHeartbeatContract,
@@ -653,6 +654,7 @@ export {
   type ArtifactEntry,
   type StorageManifest,
   type ResumeSession,
+  type StoredResumeSession,
 } from "./runners";
 
 export {

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -170,6 +170,15 @@ export const resumeSessionSchema = z.object({
   sessionHistory: z.string(),
 });
 
+export const storedResumeSessionSchema = z.union([
+  resumeSessionSchema,
+  z.object({
+    kind: z.literal("history-ref"),
+    sessionId: z.string(),
+    historyHash: z.string().length(64),
+  }),
+]);
+
 export const secretConnectorMetadataSchema = z.object({
   sourceType: z.enum(["connector", "model-provider"]),
   sourceUserId: z.string().optional(),
@@ -190,7 +199,7 @@ export const secretConnectorMetadataMapSchema = z.record(
 export const storedExecutionContextSchema = z.object({
   storageManifest: storageManifestSchema.nullable(),
   environment: z.record(z.string(), z.string()).nullable(),
-  resumeSession: resumeSessionSchema.nullable(),
+  resumeSession: storedResumeSessionSchema.nullable(),
   // AES-256-GCM encrypted Record<string, string>. Keys are the runtime secret
   // names used by `${{ secrets.NAME }}`; connector/model-provider keys are env
   // aliases, not backing storage secret names.
@@ -386,3 +395,4 @@ export type StorageEntry = z.infer<typeof storageEntrySchema>;
 export type ArtifactEntry = z.infer<typeof artifactEntrySchema>;
 export type StorageManifest = z.infer<typeof storageManifestSchema>;
 export type ResumeSession = z.infer<typeof resumeSessionSchema>;
+export type StoredResumeSession = z.infer<typeof storedResumeSessionSchema>;


### PR DESCRIPTION
Closes #18963

## Summary
- Add an API-internal stored resume-session reference shape while keeping the public runner claim response unchanged.
- Stop downloading hash-backed resume session history during run creation and store `{ kind: "history-ref", sessionId, historyHash }` in queued execution context.
- Expand history references at runner claim time, with a controlled pre-running failure path when the referenced history is unavailable.
- Add claim timing for `claim_route_resolve_resume_session_history` and tests covering compact stored context, public claim expansion, and missing history behavior.

## Validation
- `pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/runners.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-reads.bdd.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm format`
- `git diff --check`

## Production Validation
After deploy, compare these spans and end-to-end timings against the pre-change baseline:
- `api_dispatch_resolve_compose_resolve_session_history`
- `api_dispatch_prepare_context_resolve_compose`
- `api_dispatch_insert_runner_job_queue`
- `claim_route_resolve_resume_session_history`
- `claim_route_context_parse`
- `api_to_runner_queue`
- `api_to_claim`
- `api_to_spawn`