### PR TITLE
fix: restore presentation deck QA flow

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/generation-template-prompt.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/generation-template-prompt.test.ts
@@ -43,6 +43,12 @@ describe("buildGenerationTemplatePrompt", () => {
     expect(result.prompt).toContain(
       `zero generate presentation --design-system ${item.designSystemId} --template ${item.templateId}`,
     );
+    expect(result.prompt).toContain(
+      "After generating the final HTML deck, from the workspace root run",
+    );
+    expect(result.prompt).toContain(
+      "npm install --no-save --no-package-lock playwright && node ./generated/resources/presentation-runtime/html-ppt-deck-tools/qa-deck.mjs <output-dir>/index.html",
+    );
   });
 
   it("builds presentation template guidance for the switched picker catalog", () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/registry-resources-download.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/registry-resources-download.test.ts
@@ -27,7 +27,7 @@ const PRIVATE_ARCHIVE_FIXTURES = [
   {
     id: "tool:presentation-deck-tools",
     versionId:
-      "82cf61753b7e7d81cf2c457ea1ac970b266dcbec8b2d253d462b7dd035843e87",
+      "3c4f3323dcf5d8a03a9780c3a46906706efbdc9f845d50c0d882e05d5ff1828f",
   },
   {
     id: "design-system:business-data",

--- a/turbo/apps/api/src/signals/routes/generation-template-prompt.ts
+++ b/turbo/apps/api/src/signals/routes/generation-template-prompt.ts
@@ -151,6 +151,7 @@ function buildPresentationGenerationTemplatePrompt(
             `- Apply the selected color system (${colorSystem.id}) when authoring the deck.`,
           ]
         : []),
+      "- After generating the final HTML deck, from the workspace root run: `npm install --no-save --no-package-lock playwright && node ./generated/resources/presentation-runtime/html-ppt-deck-tools/qa-deck.mjs <output-dir>/index.html`. Fix failures before hosting.",
       "- Follow the returned authoring packet. For a static HTML presentation, publish it with `zero host <dir> --site <slug> --artifact-kind presentation-html`.",
       "- If a flag above no longer applies, run `zero generate presentation -h` to discover the current options.",
     ].join("\n"),

--- a/turbo/apps/api/src/signals/routes/registry-resources-download.ts
+++ b/turbo/apps/api/src/signals/routes/registry-resources-download.ts
@@ -45,7 +45,7 @@ function storageServiceNotConfigured() {
 
 const PRIVATE_REGISTRY_RESOURCE_ARCHIVE_VERSION_IDS = {
   "tool:presentation-deck-tools":
-    "82cf61753b7e7d81cf2c457ea1ac970b266dcbec8b2d253d462b7dd035843e87",
+    "3c4f3323dcf5d8a03a9780c3a46906706efbdc9f845d50c0d882e05d5ff1828f",
   "design-system:business-data":
     "c9f7a6246c31da8a50f8e0bedee769416af83fdea4047ec59ccf926b78f18fe9",
   "design-system:botane-organic":

--- a/turbo/packages/core/src/resource-registry.ts
+++ b/turbo/packages/core/src/resource-registry.ts
@@ -139,7 +139,7 @@ const PRESENTATION_RESOURCE_ARCHIVE_SHA256 = {
   businessData:
     "47b08d200c334d669ca3595906218797d75f2a1b8ec12abee3372163f8f7d4e7",
   presentationDeckTools:
-    "5d31cb02f1beb2533a13161222a6a24e1fa07621755970623ab2b44a9380fda2",
+    "00897f9278c014d2d7fcb95f3d03ee954c3d9c281cdef280fb92597be6609b38",
   designSystemCrayon:
     "c2b891a40b672aa8f45bd72d7343309d097dd3aeb6653444fe10c5d4b62bbaca",
   templateCrayon:


### PR DESCRIPTION
## Summary
- Update the R2 `tool:presentation-deck-tools` archive with a `qa-deck.mjs` fix for decks without `#swPal`.
- When no palette switcher exists, QA now runs contrast checks once against the deck's current/default palette instead of crashing on `.value`.
- Restore the presentation generation template prompt that runs deck QA after final HTML generation and before publishing.
- Update the registry archive sha and private storage version pin for the new runtime archive.

## Generation prompt
Added to `buildPresentationGenerationTemplatePrompt`:

```text
- After generating the final HTML deck, from the workspace root run: `npm install --no-save --no-package-lock playwright && node ./generated/resources/presentation-runtime/html-ppt-deck-tools/qa-deck.mjs <output-dir>/index.html`. Fix failures before hosting.
```

## R2 update
- Resource: `tool:presentation-deck-tools`
- Storage version: `3c4f3323dcf5d8a03a9780c3a46906706efbdc9f845d50c0d882e05d5ff1828f`
- Archive sha256: `00897f9278c014d2d7fcb95f3d03ee954c3d9c281cdef280fb92597be6609b38`

## QA regression
- `https://top-news-x-hn-2026-06-26-715f6d07-9f9a3d3a.sites.vm0.io`: PASS, 0 violations.
- `https://html-artifact-715f6d07-4aea9c68.sites.vm0.io/`: no longer crashes when `#swPal` is missing; reports the deck's existing contrast/density/body-presence violations under `[palette default]`.

## Validation
- Downloaded the uploaded archive and verified sha256 matches `00897f9278c014d2d7fcb95f3d03ee954c3d9c281cdef280fb92597be6609b38`.
- `node --check qa-deck.mjs` against the downloaded archive.
- `pnpm -C turbo exec prettier --check apps/api/src/signals/routes/generation-template-prompt.ts apps/api/src/signals/routes/__tests__/generation-template-prompt.test.ts`
- `pnpm -C turbo exec vitest run apps/api/src/signals/routes/__tests__/generation-template-prompt.test.ts`
- `pnpm -C turbo exec prettier --check packages/core/src/resource-registry.ts apps/api/src/signals/routes/registry-resources-download.ts apps/api/src/signals/routes/__tests__/registry-resources-download.test.ts`
- `pnpm -C turbo exec vitest run apps/cli/src/commands/zero/resource/__tests__/index.test.ts`
- `pnpm -C turbo exec vitest run packages/core/src/__tests__/presentation-template-items.spec.ts`
- `DATABASE_URL=postgresql://postgres@127.0.0.1:5432/vm0_test pnpm -C turbo exec vitest run apps/api/src/signals/routes/__tests__/registry-resources-download.test.ts`
- `git diff --check`