### PR TITLE
fix(guest-agent): preserve non-UTF-8 success checkpoints

### DIFF
--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -415,19 +415,23 @@ async fn create_checkpoint_impl_with_artifacts(
             }
         };
 
-    let session_history = match String::from_utf8(history_bytes) {
-        Ok(s) => s,
+    let session_history_text = match std::str::from_utf8(&history_bytes) {
+        Ok(s) => Some(s),
         Err(e) => {
-            return Err(fail(
-                mode,
-                "session_history_read",
-                history_read_start,
-                format!("Session history is not valid UTF-8: {e}"),
-            ));
+            let msg = format!("Session history is not valid UTF-8: {e}");
+            if mode.validate_history() {
+                return Err(fail(mode, "session_history_read", history_read_start, msg));
+            }
+            log_warn!(LOG_TAG, "{msg}; preserving raw bytes for checkpoint");
+            None
         }
     };
 
-    if session_history.trim().is_empty() {
+    let history_is_empty = session_history_text.map_or_else(
+        || history_bytes.iter().all(|byte| byte.is_ascii_whitespace()),
+        |session_history| session_history.trim().is_empty(),
+    );
+    if history_is_empty {
         return Err(fail(
             mode,
             "session_history_read",
@@ -436,13 +440,21 @@ async fn create_checkpoint_impl_with_artifacts(
         ));
     }
 
-    if mode.validate_history() {
-        validate_recoverable_session_history(&session_history)
-            .map_err(|msg| fail(mode, "session_history_validate", history_read_start, msg))?;
-    }
+    if let Some(session_history) = session_history_text {
+        if mode.validate_history() {
+            validate_recoverable_session_history(session_history)
+                .map_err(|msg| fail(mode, "session_history_validate", history_read_start, msg))?;
+        }
 
-    let line_count = session_history.lines().count();
-    log_info!(LOG_TAG, "Session history loaded ({line_count} lines)");
+        let line_count = session_history.lines().count();
+        log_info!(LOG_TAG, "Session history loaded ({line_count} lines)");
+    } else {
+        log_info!(
+            LOG_TAG,
+            "Session history loaded ({} raw bytes, invalid UTF-8)",
+            history_bytes.len()
+        );
+    }
     record_sandbox_op(
         "session_history_read",
         history_read_start.elapsed(),
@@ -451,8 +463,8 @@ async fn create_checkpoint_impl_with_artifacts(
     );
 
     // Compute SHA-256 hash of session history for presigned URL upload
-    let history_hash = hex::encode(Sha256::digest(session_history.as_bytes()));
-    let history_size = session_history.len() as u64;
+    let history_hash = hex::encode(Sha256::digest(&history_bytes));
+    let history_size = history_bytes.len() as u64;
     log_info!(
         LOG_TAG,
         "Session history hash={}, size={history_size}",
@@ -465,12 +477,7 @@ async fn create_checkpoint_impl_with_artifacts(
     // (prepare + HEAD update). Serial, wall time was dominated by whichever
     // was longer plus the other; concurrent, it's just the longer one.
     let (_, artifact_snapshots) = tokio::try_join!(
-        upload_session_history(
-            http,
-            &history_hash,
-            history_size,
-            session_history.into_bytes()
-        ),
+        upload_session_history(http, &history_hash, history_size, history_bytes),
         snapshot_artifact_entries(http, artifact_entries),
     )?;
 

--- a/crates/guest-agent/tests/integration/checkpoint.rs
+++ b/crates/guest-agent/tests/integration/checkpoint.rs
@@ -267,7 +267,12 @@ async fn recovery_checkpoint_rejects_partial_jsonl_without_error_file() {
 
     let result = guest_agent::checkpoint::create_recovery_checkpoint(&http_client!()).await;
 
-    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("Session history is not valid UTF-8"),
+        "expected recovery checkpoint to fail on invalid UTF-8 history, got: {err}"
+    );
     assert!(
         !std::path::Path::new(guest_agent::paths::checkpoint_error_file()).exists(),
         "recovery checkpoint must not write the success-path checkpoint error file"

--- a/crates/guest-agent/tests/integration/checkpoint.rs
+++ b/crates/guest-agent/tests/integration/checkpoint.rs
@@ -270,8 +270,8 @@ async fn recovery_checkpoint_rejects_partial_jsonl_without_error_file() {
     let err = result.unwrap_err();
     assert!(
         err.to_string()
-            .contains("Session history is not valid UTF-8"),
-        "expected recovery checkpoint to fail on invalid UTF-8 history, got: {err}"
+            .contains("Session history line 2 is not valid JSON"),
+        "expected recovery checkpoint to fail on partial JSONL history, got: {err}"
     );
     assert!(
         !std::path::Path::new(guest_agent::paths::checkpoint_error_file()).exists(),
@@ -305,7 +305,12 @@ async fn recovery_checkpoint_rejects_non_utf8_session_history() {
 
     let result = guest_agent::checkpoint::create_recovery_checkpoint(&http_client!()).await;
 
-    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("Session history is not valid UTF-8"),
+        "expected recovery checkpoint to fail on invalid UTF-8 history, got: {err}"
+    );
     assert!(
         !std::path::Path::new(guest_agent::paths::checkpoint_error_file()).exists(),
         "recovery checkpoint must not write the success-path checkpoint error file"

--- a/crates/guest-agent/tests/integration/checkpoint.rs
+++ b/crates/guest-agent/tests/integration/checkpoint.rs
@@ -338,7 +338,11 @@ async fn recovery_checkpoint_skips_when_session_id_is_missing() {
 
     let result = guest_agent::checkpoint::create_recovery_checkpoint(&http_client!()).await;
 
-    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(
+        err.to_string().contains("No session ID found"),
+        "expected recovery checkpoint to fail on missing session ID, got: {err}"
+    );
     assert!(
         !std::path::Path::new(guest_agent::paths::checkpoint_error_file()).exists(),
         "recovery checkpoint must not write the success-path checkpoint error file"
@@ -368,7 +372,11 @@ async fn recovery_checkpoint_skips_when_derived_history_is_missing() {
 
     let result = guest_agent::checkpoint::create_recovery_checkpoint(&http_client!()).await;
 
-    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(
+        err.to_string().contains("Failed to read session history"),
+        "expected recovery checkpoint to fail on missing derived history, got: {err}"
+    );
     assert!(
         !std::path::Path::new(guest_agent::paths::checkpoint_error_file()).exists(),
         "recovery checkpoint must not write the success-path checkpoint error file"
@@ -398,7 +406,12 @@ async fn recovery_checkpoint_rejects_invalid_session_id_without_marker() {
 
     let result = guest_agent::checkpoint::create_recovery_checkpoint(&http_client!()).await;
 
-    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("Failed to derive session history marker from session ID"),
+        "expected recovery checkpoint to fail on invalid session ID, got: {err}"
+    );
     assert!(
         !std::path::Path::new(guest_agent::paths::checkpoint_error_file()).exists(),
         "recovery checkpoint must not write the success-path checkpoint error file"

--- a/crates/guest-agent/tests/integration/checkpoint.rs
+++ b/crates/guest-agent/tests/integration/checkpoint.rs
@@ -1,6 +1,7 @@
 use crate::support::*;
 use httpmock::prelude::*;
 use serde_json::json;
+use sha2::{Digest, Sha256};
 
 fn write_derived_claude_history(session_id: &str, history: &str) -> Result<(), String> {
     guest_agent::paths::write_private(guest_agent::paths::session_id_file(), session_id)
@@ -22,6 +23,82 @@ fn write_derived_claude_history(session_id: &str, history: &str) -> Result<(), S
     std::fs::write(&history_path, history)
         .map_err(|e| format!("write history {}: {e}", history_path.display()))?;
     Ok(())
+}
+
+fn write_literal_session_history(
+    session_id: &str,
+    history: &[u8],
+) -> Result<tempfile::TempDir, String> {
+    let dir = tempfile::tempdir().map_err(|e| format!("create temp history dir: {e}"))?;
+    let history_path = dir.path().join(format!("{session_id}.jsonl"));
+    std::fs::write(&history_path, history)
+        .map_err(|e| format!("write history {}: {e}", history_path.display()))?;
+    guest_agent::paths::write_private(guest_agent::paths::session_id_file(), session_id)
+        .map_err(|e| format!("write session id: {e}"))?;
+    guest_agent::paths::write_private(
+        guest_agent::paths::session_history_path_file(),
+        history_path.to_string_lossy().as_ref(),
+    )
+    .map_err(|e| format!("write session history marker: {e}"))?;
+    Ok(dir)
+}
+
+// =========================================================================
+// Success checkpoint
+// =========================================================================
+
+#[tokio::test]
+async fn success_checkpoint_uploads_non_utf8_session_history() {
+    let api = SharedApiMock::new().await;
+    let server = api.server();
+
+    let _files_guard = SessionCheckpointFilesGuard::new();
+    let history = b"{\"type\":\"system\"}\nnon-utf8:\xC3(\n".to_vec();
+    let _history_dir = write_literal_session_history("success-non-utf8-session", &history).unwrap();
+
+    let history_hash = hex::encode(Sha256::digest(&history));
+    let history_size = history.len();
+    let prepare_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history")
+            .json_body(json!({
+                "runId": "test-run-001",
+                "hash": history_hash,
+                "size": history_size,
+            }));
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({
+                "presignedUrl": server.url("/test/success-non-utf8-history-upload"),
+                "existing": false
+            }));
+    });
+    let upload_len = history_size.to_string();
+    let upload_body = history.clone();
+    let upload_mock = server.mock(|when, then| {
+        when.method(PUT)
+            .path("/test/success-non-utf8-history-upload")
+            .header("Content-Type", "application/octet-stream");
+        then.respond_with(move |req| upload_validation_response(req, &upload_body, &upload_len));
+    });
+    let checkpoint_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints")
+            .json_body_includes(r#"{"cliAgentSessionId":"success-non-utf8-session"}"#)
+            .json_body_includes(format!(
+                r#"{{"cliAgentSessionHistoryHash":"{history_hash}"}}"#
+            ));
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({"checkpointId": "checkpoint-success-non-utf8"}));
+    });
+
+    let result = guest_agent::checkpoint::create_checkpoint(&http_client!()).await;
+
+    assert!(result.is_ok());
+    prepare_mock.assert_calls_async(1).await;
+    upload_mock.assert_calls_async(1).await;
+    checkpoint_mock.assert_calls_async(1).await;
 }
 
 // =========================================================================
@@ -175,6 +252,39 @@ async fn recovery_checkpoint_rejects_partial_jsonl_without_error_file() {
     guest_agent::paths::write_private(
         guest_agent::paths::session_history_path_file(),
         history_path.to_string_lossy().as_ref(),
+    )
+    .unwrap();
+
+    let prepare_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history");
+        then.status(200);
+    });
+    let checkpoint_mock = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/checkpoints");
+        then.status(200);
+    });
+
+    let result = guest_agent::checkpoint::create_recovery_checkpoint(&http_client!()).await;
+
+    assert!(result.is_err());
+    assert!(
+        !std::path::Path::new(guest_agent::paths::checkpoint_error_file()).exists(),
+        "recovery checkpoint must not write the success-path checkpoint error file"
+    );
+    prepare_mock.assert_calls_async(0).await;
+    checkpoint_mock.assert_calls_async(0).await;
+}
+
+#[tokio::test]
+async fn recovery_checkpoint_rejects_non_utf8_session_history() {
+    let api = SharedApiMock::new().await;
+    let server = api.server();
+
+    let _files_guard = SessionCheckpointFilesGuard::new();
+    let _history_dir = write_literal_session_history(
+        "recovery-non-utf8-session",
+        b"{\"type\":\"system\"}\nnon-utf8:\xC3(\n",
     )
     .unwrap();
 


### PR DESCRIPTION
## Summary

- keep success checkpoint session history as raw bytes for hash, size, and S3 upload
- warn and continue when success checkpoint history is not valid UTF-8
- keep recovery checkpoints strict: invalid UTF-8 still fails before prepare/upload/checkpoint calls
- add integration coverage for both success and recovery non-UTF-8 histories

Closes #18997.

## Tests

- cargo test --manifest-path crates/Cargo.toml -p guest-agent success_checkpoint_uploads_non_utf8_session_history
- cargo test --manifest-path crates/Cargo.toml -p guest-agent recovery_checkpoint_rejects_non_utf8_session_history
- cargo test --manifest-path crates/Cargo.toml -p guest-agent
- cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features -- -D warnings
- cargo fmt --manifest-path crates/Cargo.toml --all --check

## Notes

API resume still decodes checkpoint blobs as UTF-8 text, so invalid byte sequences will be replacement-decoded on a future resume. This PR fixes the production failure mode without changing the API/runner resume contract.