### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2834,9 +2834,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "sentry"
-version = "0.48.2"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "931a20b0da02350676e3d6d3c9028d58eaa448cf42a866712eec5845a505421e"
+checksum = "1975064d9f3d9d87a7c8f0371f7fac10d876906ca3e39faad72e61c263ff9b87"
 dependencies = [
  "cfg_aliases",
  "sentry-core",
@@ -2845,9 +2845,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.48.2"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911ee36abf5b7fa335fccd5f54361ba9c16baea5f0c3bb361a687b6c195c21cf"
+checksum = "134f552b6b147f77aeee46ece875d67a8bfc1d56fe3860d78446ed4c25bb5f9f"
 dependencies = [
  "backtrace",
  "regex",
@@ -2856,9 +2856,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.48.2"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "545dc562b6758d646ac19e1407f4ebc26d452111386743e03323464bc48bb2e0"
+checksum = "7cff96247f4dc36867511d108709e703eb354143e7893319d763d2dd1edb4f48"
 dependencies = [
  "rand",
  "sentry-types",
@@ -2869,9 +2869,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-panic"
-version = "0.48.2"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "772d9de150c8ca910c835353c85f434457348fdd21208f9b3da3574202b1dc5d"
+checksum = "61de3f4a1fc77d4c57e8bacd8ef064c26aaa88ea5b2541a761d37c7c3703b9a9"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -2879,9 +2879,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.48.2"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "041359745a44dd2e14fe21b7510fe7ca8b5beffce6636a0b52e5bc7d5f736887"
+checksum = "8d7e78132ccfb4a1c777b959fb2944d1f6d5145bffe6be2a98ee6b25d244f72c"
 dependencies = [
  "debugid",
  "hex",


### PR DESCRIPTION
## Summary
- Updated the Rust workspace lockfile under `crates/` with `cargo update --verbose`.
- Updated 5 locked packages in the Sentry family:
  - `sentry` `0.48.2` -> `0.48.3`
  - `sentry-backtrace` `0.48.2` -> `0.48.3`
  - `sentry-core` `0.48.2` -> `0.48.3`
  - `sentry-panic` `0.48.2` -> `0.48.3`
  - `sentry-types` `0.48.2` -> `0.48.3`

## Dependencies not updated
- `generic-array` remains at `0.14.7` even though `0.14.9` is available.
- Reason: it is transitive and held by `crypto-common v0.1.7`, which requires `generic-array = "=0.14.7"`. It is not pinned by this repository's `Cargo.toml` files.

## Manual version bumps
- None.
- A direct workspace dependency audit found the workspace-level external dependencies already at the latest non-yanked versions within their current non-major lines, so no safe `Cargo.toml` version specifier changes were needed.

## Test status
- `cargo update --verbose`: passed on current `main`.
- `cargo test --workspace`: initial run failed before tests completed because the `runner` test binary compile was killed by SIGKILL in the local 3.8 GiB RAM environment.
- `cargo test --workspace -j 1`: compiled and ran the workspace; non-`runner` test binaries passed, but `runner` tests failed under the default `umask 0002` because temporary test directories were group-writable and rejected by trusted-path checks.
- Follow-up verification: reran the already-built `runner` test binary with `umask 077`; result was `2089 passed; 0 failed; 2 ignored`.
- The Rust source tree under `crates/` did not change between the original shallow clone base and the current `main` base used for this PR.
