### PR TITLE
refactor: move CLI firewall diagnostics to routing metadata

### DIFF
--- a/turbo/apps/cli/src/commands/zero/__tests__/firewall-import-boundary.test.ts
+++ b/turbo/apps/cli/src/commands/zero/__tests__/firewall-import-boundary.test.ts
@@ -35,9 +35,6 @@ function forbiddenFirewallImport(specifier: string): boolean {
   if (specifier === "@vm0/connectors/firewalls") {
     return true;
   }
-  if (specifier === "@vm0/connectors/firewalls/runtime") {
-    return false;
-  }
   return specifier.startsWith("@vm0/connectors/firewalls/");
 }
 

--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
@@ -4,7 +4,7 @@
  * Tests command-level behavior via parseAsync() following CLI testing principles:
  * - Entry point: command.parseAsync()
  * - Mock (external): Web API via MSW
- * - Real (internal): All CLI code, connector mappings from @vm0/core
+ * - Real (internal): All CLI code, connector metadata from @vm0/connectors
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";

--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/permission-deny.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/permission-deny.test.ts
@@ -3,7 +3,7 @@
  *
  * Tests command-level behavior via parseAsync() following CLI testing principles:
  * - Entry point: command.parseAsync()
- * - Real (internal): All CLI code, firewall configs from @vm0/core
+ * - Real (internal): All CLI code, routing metadata from @vm0/connectors
  *
  * permission-deny is a pure diagnostic command — it identifies which permission
  * or unknown endpoint policy covers a denied request and tells the agent to run permission-change.

--- a/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
@@ -9,21 +9,21 @@ import {
 } from "@vm0/connectors/connector-utils";
 import {
   type FirewallBaseUrlMatch,
-  findMatchingPermissions,
+  findMatchingRoutingPermissions,
   matchFirewallBaseUrl,
+  type FirewallRoutingPermissionApi,
 } from "@vm0/connectors/firewall-rule-matcher";
 import {
-  extractSecretNamesFromApis,
-  resolveFirewallBaseUrlVars,
+  resolveFirewallBaseUrlTemplate,
   UNKNOWN_PERMISSION_GRANT,
-  type FirewallConfig,
   type NetworkPolicies,
 } from "@vm0/connectors/firewall-types";
 import {
-  loadConnectorFirewall,
-  loadConnectorFirewalls,
-  RUNTIME_FIREWALL_CONNECTOR_TYPES,
-} from "@vm0/connectors/firewalls/runtime";
+  FIREWALL_ROUTING_METADATA_INDEX,
+  loadFirewallRoutingMetadata,
+  type FirewallRoutingMetadata,
+} from "@vm0/connectors/firewall-metadata/routing";
+import { getFirewallExecutionMetadata } from "@vm0/connectors/firewall-metadata/server";
 import type { RunContextResponse } from "@vm0/api-contracts/contracts/zero-runs";
 import { getApiUrl } from "../../../lib/api/config";
 import {
@@ -45,70 +45,143 @@ interface CheckConnectorOptions {
 
 interface DiagContext {
   envName: string;
-  connectorType: string;
+  connectorType: ConnectorType;
   label: string;
   connectorAvailable: boolean;
   platformOrigin: string;
   agentId: string | undefined;
 }
 
+interface DiagnosticRoutingConfig {
+  type: ConnectorType;
+  label: string;
+  apis: readonly FirewallRoutingPermissionApi[];
+}
+
 interface UrlLookupResult {
-  connectorType: string;
+  connectorType: ConnectorType;
   envName: string;
   matchedBase: string;
   relativePath: string;
-  permissionConfig?: FirewallConfig;
+  routingConfig?: DiagnosticRoutingConfig;
 }
+
+type RunContextFirewall = RunContextResponse["firewalls"][number];
+type RunContextInlineFirewall = Extract<RunContextFirewall, { apis: unknown }>;
+type RunContextInlinePermission =
+  RunContextInlineFirewall["apis"][number]["permissions"] extends
+    | readonly (infer Permission)[]
+    | undefined
+    ? Permission
+    : never;
 
 function isConnectorType(type: string): type is ConnectorType {
   return type in CONNECTOR_TYPES;
 }
 
-async function connectorTypeIsAvailable(type: string): Promise<boolean> {
-  if (!isConnectorType(type)) {
-    return false;
-  }
+async function connectorTypeIsAvailable(type: ConnectorType): Promise<boolean> {
   const catalog = await searchZeroConnectors();
   return catalog.connectors.some((connector) => {
     return connector.id === type;
   });
 }
 
-function hasPermissionRules(config: FirewallConfig): boolean {
+function connectorEnvName(type: ConnectorType): string | null {
+  return getConnectorEnvBindingEntries(type)[0]?.envName ?? null;
+}
+
+function hasRoutingPermissionRules(config: DiagnosticRoutingConfig): boolean {
   return config.apis.some((api) => {
-    return (
-      api.permissions?.some((permission) => {
-        return permission.rules.length > 0;
-      }) ?? false
-    );
+    return api.routes.length > 0;
   });
+}
+
+function routingBaseIsCredentialed(type: ConnectorType, base: string): boolean {
+  const executionMetadata = getFirewallExecutionMetadata(type);
+  const template = executionMetadata?.baseUrlTemplates.find((entry) => {
+    return entry.base === base;
+  });
+  return template?.credentialed ?? true;
+}
+
+function routingConfigFromMetadata(
+  metadata: FirewallRoutingMetadata,
+  baseUrlVars: Record<string, string> | undefined,
+  resolveBaseUrlVars: boolean,
+): DiagnosticRoutingConfig {
+  return {
+    type: metadata.type,
+    label: metadata.label,
+    apis: metadata.apis.map((api) => {
+      return {
+        base: resolveBaseUrlVars
+          ? resolveFirewallBaseUrlTemplate({
+              serviceName: metadata.type,
+              base: api.base,
+              vars: baseUrlVars,
+              credentialed: routingBaseIsCredentialed(metadata.type, api.base),
+            })
+          : api.base,
+        routes: api.routes,
+      };
+    }),
+  };
+}
+
+function runContextPermissionRoutes(
+  permissions: readonly RunContextInlinePermission[] | undefined,
+): FirewallRoutingPermissionApi["routes"] {
+  const routes: { permissionName: string; rule: string }[] = [];
+  const seenPermissionNames = new Set<string>();
+  for (const permission of permissions ?? []) {
+    if (seenPermissionNames.has(permission.name)) continue;
+    seenPermissionNames.add(permission.name);
+    for (const rule of permission.rules) {
+      routes.push({
+        permissionName: permission.name,
+        rule,
+      });
+    }
+  }
+  return routes;
+}
+
+function routingConfigFromInlineRunContext(
+  firewall: RunContextInlineFirewall,
+): DiagnosticRoutingConfig | null {
+  if (!isConnectorType(firewall.name)) {
+    return null;
+  }
+  return {
+    type: firewall.name,
+    label: CONNECTOR_TYPES[firewall.name].label,
+    apis: firewall.apis.map((api) => {
+      return {
+        base: api.base,
+        routes: runContextPermissionRoutes(api.permissions),
+      };
+    }),
+  };
 }
 
 /**
  * Reverse-lookup a full URL to find which connector handles it.
- * Iterates all connector firewall configs and checks if the URL
+ * Iterates routing index base URLs and checks if the URL
  * starts with any registered base URL (scheme + host + optional path prefix).
  */
-async function resolveConnectorFromUrl(
-  url: string,
-): Promise<UrlLookupResult | null> {
+function resolveConnectorFromUrl(url: string): UrlLookupResult | null {
   let bestMatch: {
-    connectorType: string;
+    connectorType: ConnectorType;
     match: FirewallBaseUrlMatch;
   } | null = null;
 
-  const firewalls = await loadConnectorFirewalls(
-    RUNTIME_FIREWALL_CONNECTOR_TYPES,
-  );
-  for (const type of RUNTIME_FIREWALL_CONNECTOR_TYPES) {
-    const config = firewalls[type];
-    if (!config) continue;
-    for (const api of config.apis) {
+  for (const metadata of Object.values(FIREWALL_ROUTING_METADATA_INDEX)) {
+    for (const api of metadata.apis) {
       const match = matchFirewallBaseUrl(url, api.base);
       if (match !== null) {
         // Pick the longest (most specific) base URL match
         if (!bestMatch || match.score > bestMatch.match.score) {
-          bestMatch = { connectorType: type, match };
+          bestMatch = { connectorType: metadata.type, match };
         }
       }
     }
@@ -117,10 +190,7 @@ async function resolveConnectorFromUrl(
   if (!bestMatch) return null;
 
   // Derive the environment name from the connector's configured env bindings.
-  const envBindingEntries = getConnectorEnvBindingEntries(
-    bestMatch.connectorType as ConnectorType,
-  );
-  const envName = envBindingEntries[0]?.envName;
+  const envName = connectorEnvName(bestMatch.connectorType);
   if (!envName) return null;
 
   return {
@@ -131,30 +201,18 @@ async function resolveConnectorFromUrl(
   };
 }
 
-async function runContextFirewallPermissionConfig(
-  firewall: RunContextResponse["firewalls"][number],
-): Promise<FirewallConfig | null> {
-  if (!("apis" in firewall)) {
-    if (!isConnectorType(firewall.name)) {
-      return null;
-    }
-    const config = await loadConnectorFirewall(firewall.name);
-    if (!config) return null;
-    return resolveFirewallBaseUrlVars(
-      [{ name: config.name, apis: config.apis }],
-      firewall.baseUrlVars,
-    )[0]!;
+async function runContextFirewallRoutingConfig(
+  firewall: RunContextFirewall,
+): Promise<DiagnosticRoutingConfig | null> {
+  if ("apis" in firewall) {
+    return routingConfigFromInlineRunContext(firewall);
   }
-  return {
-    name: firewall.name,
-    apis: firewall.apis.map((api) => {
-      return {
-        base: api.base,
-        auth: {},
-        permissions: api.permissions,
-      };
-    }),
-  };
+  if (!isConnectorType(firewall.name)) {
+    return null;
+  }
+  const metadata = await loadFirewallRoutingMetadata(firewall.name);
+  if (!metadata) return null;
+  return routingConfigFromMetadata(metadata, firewall.baseUrlVars, true);
 }
 
 async function resolveConnectorFromRunContext(
@@ -162,23 +220,23 @@ async function resolveConnectorFromRunContext(
   runContext: RunContextResponse,
 ): Promise<UrlLookupResult | null> {
   let bestMatch: {
-    connectorType: string;
+    connectorType: ConnectorType;
     match: FirewallBaseUrlMatch;
-    permissionConfig: FirewallConfig;
+    routingConfig: DiagnosticRoutingConfig;
   } | null = null;
 
   for (const firewall of runContext.firewalls) {
     if (!isConnectorType(firewall.name)) continue;
-    const permissionConfig = await runContextFirewallPermissionConfig(firewall);
-    if (!permissionConfig) continue;
-    for (const api of permissionConfig.apis) {
+    const routingConfig = await runContextFirewallRoutingConfig(firewall);
+    if (!routingConfig) continue;
+    for (const api of routingConfig.apis) {
       const match = matchFirewallBaseUrl(url, api.base);
       if (match === null) continue;
       if (!bestMatch || match.score > bestMatch.match.score) {
         bestMatch = {
           connectorType: firewall.name,
           match,
-          permissionConfig,
+          routingConfig,
         };
       }
     }
@@ -186,10 +244,7 @@ async function resolveConnectorFromRunContext(
 
   if (!bestMatch) return null;
 
-  const envBindingEntries = getConnectorEnvBindingEntries(
-    bestMatch.connectorType as ConnectorType,
-  );
-  const envName = envBindingEntries[0]?.envName;
+  const envName = connectorEnvName(bestMatch.connectorType);
   if (!envName) return null;
 
   return {
@@ -197,8 +252,8 @@ async function resolveConnectorFromRunContext(
     envName,
     matchedBase: bestMatch.match.displayBase,
     relativePath: bestMatch.match.relativePath,
-    ...(hasPermissionRules(bestMatch.permissionConfig)
-      ? { permissionConfig: bestMatch.permissionConfig }
+    ...(hasRoutingPermissionRules(bestMatch.routingConfig)
+      ? { routingConfig: bestMatch.routingConfig }
       : {}),
   };
 }
@@ -243,7 +298,7 @@ async function checkConnectorStatus(ctx: DiagContext): Promise<{
   console.log("");
 
   const [connector, enabledTypes] = await Promise.all([
-    getZeroConnector(ctx.connectorType as ConnectorType),
+    getZeroConnector(ctx.connectorType),
     ctx.agentId
       ? getZeroAgentUserConnectors(ctx.agentId)
       : Promise.resolve(null),
@@ -367,9 +422,8 @@ async function printConnectorDomains(
     );
     return;
   }
-  const permissionConfig =
-    await runContextFirewallPermissionConfig(matchingEntry);
-  if (!permissionConfig) {
+  const routingConfig = await runContextFirewallRoutingConfig(matchingEntry);
+  if (!routingConfig) {
     console.log(
       `No configuration found for the ${ctx.label} connector in this run.`,
     );
@@ -382,7 +436,7 @@ async function printConnectorDomains(
   console.log(
     `The ${ctx.label} connector is configured for this run with the following base URLs:`,
   );
-  for (const api of permissionConfig.apis) {
+  for (const api of routingConfig.apis) {
     console.log(`  - ${api.base}`);
   }
   console.log("");
@@ -390,17 +444,16 @@ async function printConnectorDomains(
     "When the sandbox sends an HTTP request matching one of these URL prefixes, the network boundary intercepts the request and injects real credentials into the auth headers.",
   );
 
-  const firewallConfig = await loadConnectorFirewall(ctx.connectorType);
-  if (firewallConfig) {
-    const secretNames = extractSecretNamesFromApis(firewallConfig.apis);
-    if (secretNames.length > 0) {
-      console.log(`Credentials resolved from: ${secretNames.join(", ")}`);
-    }
+  const secretNames =
+    getFirewallExecutionMetadata(ctx.connectorType)?.secretPlaceholderNames ??
+    [];
+  if (secretNames.length > 0) {
+    console.log(`Credentials resolved from: ${secretNames.join(", ")}`);
   }
 }
 
 function checkPermissionPolicy(
-  connectorType: string,
+  connectorType: ConnectorType,
   label: string,
   permissionName: string,
   networkPolicies: NetworkPolicies | null,
@@ -470,12 +523,12 @@ function unknownPermissionChangeCommand(connectorRef: string): string {
  * the URL's relative path against the connector's firewall rules.
  */
 async function resolvePermissionFromUrl(
-  connectorType: string,
+  connectorType: ConnectorType,
   label: string,
   method: string,
   relativePath: string,
   matchedBase: string,
-  permissionConfig: FirewallConfig | undefined,
+  routingConfig: DiagnosticRoutingConfig | undefined,
   networkPolicies: NetworkPolicies | null,
 ): Promise<void> {
   console.log("## Step 3: Permission policy check (auto-detected from URL)");
@@ -485,8 +538,13 @@ async function resolvePermissionFromUrl(
   );
   console.log("");
 
-  const config =
-    permissionConfig ?? (await loadConnectorFirewall(connectorType));
+  let config = routingConfig;
+  if (!config) {
+    const metadata = await loadFirewallRoutingMetadata(connectorType);
+    config = metadata
+      ? routingConfigFromMetadata(metadata, undefined, false)
+      : undefined;
+  }
   if (!config) {
     console.log(
       `The ${label} connector does not have permission rules defined.`,
@@ -495,10 +553,10 @@ async function resolvePermissionFromUrl(
     return;
   }
 
-  const matchedPermissions = findMatchingPermissions(
+  const matchedPermissions = findMatchingRoutingPermissions(
     method,
     relativePath,
-    config,
+    config.apis,
     { apiBase: matchedBase },
   );
 
@@ -617,7 +675,7 @@ How connectors work:
       }
 
       let envName: string;
-      let connectorType: string;
+      let connectorType: ConnectorType;
       let urlLookup: UrlLookupResult | null = null;
       let runContext: RunContextResponse | null | undefined;
 
@@ -640,7 +698,7 @@ How connectors work:
         connectorType = urlLookup.connectorType;
         envName = opts.envName ?? urlLookup.envName;
         console.log(
-          `URL ${opts.url} matches the ${CONNECTOR_TYPES[connectorType as ConnectorType].label} connector (type: ${connectorType}).`,
+          `URL ${opts.url} matches the ${CONNECTOR_TYPES[connectorType].label} connector (type: ${connectorType}).`,
         );
         console.log(`  Matched base URL: ${urlLookup.matchedBase}`);
         console.log(`  Relative path:    ${urlLookup.relativePath}`);
@@ -656,12 +714,12 @@ How connectors work:
         }
         connectorType = resolvedConnectorType;
         console.log(
-          `${envName} is managed by the ${CONNECTOR_TYPES[connectorType as ConnectorType].label} connector (type: ${connectorType}).`,
+          `${envName} is managed by the ${CONNECTOR_TYPES[connectorType].label} connector (type: ${connectorType}).`,
         );
       }
       console.log("");
 
-      const { label } = CONNECTOR_TYPES[connectorType as ConnectorType];
+      const { label } = CONNECTOR_TYPES[connectorType];
       const [apiUrl, connectorAvailable] = await Promise.all([
         getApiUrl(),
         connectorTypeIsAvailable(connectorType),
@@ -699,7 +757,7 @@ How connectors work:
           opts.method,
           urlLookup.relativePath,
           urlLookup.matchedBase,
-          urlLookup.permissionConfig,
+          urlLookup.routingConfig,
           networkPolicies,
         );
       } else if (opts.checkPermission) {

--- a/turbo/apps/cli/src/commands/zero/doctor/permission-deny.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/permission-deny.ts
@@ -1,7 +1,7 @@
 import { Command, Option } from "commander";
-import { findMatchingPermissions } from "@vm0/connectors/firewall-rule-matcher";
+import { findMatchingRoutingPermissions } from "@vm0/connectors/firewall-rule-matcher";
 import { getFirewallPermissionSummary } from "@vm0/connectors/firewall-metadata";
-import { loadConnectorFirewall } from "@vm0/connectors/firewalls/runtime";
+import { loadFirewallRoutingMetadata } from "@vm0/connectors/firewall-metadata/routing";
 import { UNKNOWN_PERMISSION_GRANT } from "@vm0/connectors/firewall-types";
 import { withErrorHandler } from "../../../lib/command";
 import {
@@ -49,17 +49,18 @@ Notes:
           return;
         }
 
-        const config = await loadConnectorFirewall(connectorRef);
-        if (!config) {
+        const metadata = await loadFirewallRoutingMetadata(connectorRef);
+        if (!metadata) {
           throw new Error(`Unknown connector type: ${connectorRef}`);
         }
 
         const label =
           getFirewallPermissionSummary(connectorRef)?.label ?? connectorRef;
-        const permissions = findMatchingPermissions(
+        const permissions = findMatchingRoutingPermissions(
           opts.method,
           opts.path,
-          config,
+          metadata.apis,
+          { serviceName: connectorRef },
         );
 
         console.log(
@@ -79,12 +80,11 @@ Notes:
 
         // Count total rules per permission name across all APIs
         const ruleCount = new Map<string, number>();
-        for (const api of config.apis) {
-          if (!api.permissions) continue;
-          for (const perm of api.permissions) {
+        for (const api of metadata.apis) {
+          for (const route of api.routes) {
             ruleCount.set(
-              perm.name,
-              (ruleCount.get(perm.name) ?? 0) + perm.rules.length,
+              route.permissionName,
+              (ruleCount.get(route.permissionName) ?? 0) + 1,
             );
           }
         }

--- a/turbo/packages/connectors/src/__tests__/firewall-expander.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-expander.test.ts
@@ -4,6 +4,7 @@ import {
   validateBaseUrl,
   hasBaseUrlParams,
   hasBaseUrlVars,
+  resolveFirewallBaseUrlTemplate,
   resolveFirewallBaseUrlVars,
 } from "../firewall-types";
 import {
@@ -1098,6 +1099,51 @@ describe("hasBaseUrlVars", () => {
     expect(
       hasBaseUrlVars("https://${{ vars.A }}.${{ vars.B }}.example.com"),
     ).toBe(true);
+  });
+});
+
+describe("resolveFirewallBaseUrlTemplate", () => {
+  it("resolves host template variables without requiring a firewall API auth object", () => {
+    expect(
+      resolveFirewallBaseUrlTemplate({
+        serviceName: "zendesk",
+        base: "https://${{ vars.ZENDESK_SUBDOMAIN }}.zendesk.com",
+        vars: { ZENDESK_SUBDOMAIN: "acme" },
+        credentialed: true,
+      }),
+    ).toBe("https://acme.zendesk.com");
+  });
+
+  it("throws when required template variables are missing", () => {
+    expect(() => {
+      return resolveFirewallBaseUrlTemplate({
+        serviceName: "zendesk",
+        base: "https://${{ vars.ZENDESK_SUBDOMAIN }}.zendesk.com",
+        vars: {},
+        credentialed: true,
+      });
+    }).toThrow('requires variable "ZENDESK_SUBDOMAIN"');
+  });
+
+  it("enforces https for credentialed resolved template bases", () => {
+    expect(() => {
+      return resolveFirewallBaseUrlTemplate({
+        serviceName: "strapi",
+        base: "${{ vars.STRAPI_BASE_URL }}",
+        vars: { STRAPI_BASE_URL: "http://strapi.example.test" },
+        credentialed: true,
+      });
+    }).toThrow("credentialed base URL must use https");
+  });
+
+  it("keeps non-credentialed http template bases valid", () => {
+    expect(
+      resolveFirewallBaseUrlTemplate({
+        serviceName: "diagnostic",
+        base: "${{ vars.DIAGNOSTIC_BASE_URL }}",
+        vars: { DIAGNOSTIC_BASE_URL: "http://diagnostic.example.test" },
+      }),
+    ).toBe("http://diagnostic.example.test");
   });
 });
 

--- a/turbo/packages/connectors/src/__tests__/firewall-rule-matcher.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-rule-matcher.test.ts
@@ -5,6 +5,7 @@ import {
   matchFirewallPathPrefix,
   matchFirewallBaseUrl,
   findMatchingPermissions,
+  findMatchingRoutingPermissions,
 } from "../firewall-rule-matcher";
 import type { FirewallConfig } from "../firewall-types";
 
@@ -1831,5 +1832,118 @@ describe("findMatchingPermissions", () => {
     expect(findMatchingPermissions("GET", "/data", multiApi)).toEqual([
       "shared-perm",
     ]);
+  });
+});
+
+describe("findMatchingRoutingPermissions", () => {
+  it("matches routing rules without requiring full firewall config auth", () => {
+    expect(
+      findMatchingRoutingPermissions("get", "/repos/acme/demo/issues", [
+        {
+          base: "https://api.example.com",
+          routes: [
+            {
+              permissionName: "repos.read",
+              rule: "GET /repos/{owner}/{repo}/issues",
+            },
+          ],
+        },
+      ]),
+    ).toEqual(["repos.read"]);
+  });
+
+  it("matches ANY rules and keeps the most-specific route per API", () => {
+    expect(
+      findMatchingRoutingPermissions("POST", "/api/users", [
+        {
+          base: "https://api.example.com",
+          routes: [
+            { permissionName: "catchall", rule: "ANY /{path*}" },
+            { permissionName: "users.write", rule: "POST /api/users" },
+          ],
+        },
+      ]),
+    ).toEqual(["users.write"]);
+  });
+
+  it("can restrict matching to one routing API base", () => {
+    const apis = [
+      {
+        base: "https://api1.example.com",
+        routes: [{ permissionName: "api1.read", rule: "GET /data" }],
+      },
+      {
+        base: "https://api2.example.com/",
+        routes: [{ permissionName: "api2.read", rule: "GET /data" }],
+      },
+    ];
+
+    expect(
+      findMatchingRoutingPermissions("GET", "/data", apis, {
+        apiBase: "https://api1.example.com",
+      }),
+    ).toEqual(["api1.read"]);
+    expect(
+      findMatchingRoutingPermissions("GET", "/data", apis, {
+        apiBase: "https://api2.example.com",
+      }),
+    ).toEqual(["api2.read"]);
+  });
+
+  it("deduplicates duplicate routing permission names inside and across APIs", () => {
+    expect(
+      findMatchingRoutingPermissions("GET", "/data", [
+        {
+          base: "https://api1.example.com",
+          routes: [
+            { permissionName: "shared", rule: "GET /data" },
+            { permissionName: "shared", rule: "ANY /data" },
+          ],
+        },
+        {
+          base: "https://api2.example.com",
+          routes: [{ permissionName: "shared", rule: "GET /data" }],
+        },
+      ]),
+    ).toEqual(["shared"]);
+  });
+
+  it("ignores malformed routing APIs and routes while keeping valid routes", () => {
+    const apis = [
+      "not-an-api",
+      { base: "https://bad.example.com?token=1", routes: [] },
+      { base: "https://missing-routes.example.com" },
+      {
+        base: "https://api.example.com",
+        routes: [
+          { permissionName: "", rule: "GET /empty" },
+          { permissionName: "all", rule: "GET /all" },
+          { permissionName: "lowercase-method", rule: "get /data" },
+          { permissionName: "query-path", rule: "GET /data?debug=1" },
+          { permissionName: "non-string-rule", rule: 123 },
+          { permissionName: 123, rule: "GET /data" },
+          { permissionName: "valid", rule: "GET /data" },
+        ],
+      },
+    ] as unknown as Parameters<typeof findMatchingRoutingPermissions>[2];
+
+    expect(findMatchingRoutingPermissions("GET", "/data", apis)).toEqual([
+      "valid",
+    ]);
+  });
+
+  it("returns multiple routing permissions when best-specificity routes tie", () => {
+    expect(
+      findMatchingRoutingPermissions("GET", "/api/users", [
+        {
+          base: "https://api.example.com",
+          routes: [
+            { permissionName: "users.read", rule: "GET /api/users" },
+            { permissionName: "users.audit", rule: "ANY /api/users" },
+            { permissionName: "catchall", rule: "ANY /{path*}" },
+          ],
+        },
+      ]),
+    ).toEqual(["users.read", "users.audit"]);
   });
 });

--- a/turbo/packages/connectors/src/firewall-rule-matcher.ts
+++ b/turbo/packages/connectors/src/firewall-rule-matcher.ts
@@ -21,15 +21,38 @@ export interface FindMatchingPermissionsOptions {
   apiBase?: string;
 }
 
+export interface FindMatchingRoutingPermissionsOptions extends FindMatchingPermissionsOptions {
+  serviceName?: string;
+}
+
 export interface FirewallBaseUrlMatch {
   displayBase: string;
   relativePath: string;
   score: number;
 }
 
+export interface FirewallRoutingPermissionRoute {
+  readonly permissionName: string;
+  readonly rule: string;
+}
+
+export interface FirewallRoutingPermissionApi {
+  readonly base: string;
+  readonly routes: readonly FirewallRoutingPermissionRoute[];
+}
+
 interface ApiMatchState {
   bestSpecificity: PathSpecificity | null;
   matched: string[];
+}
+
+interface PermissionRuleSet {
+  readonly name: string;
+  readonly rules: readonly string[];
+}
+
+interface PermissionMatchApi {
+  readonly permissionRuleSets: readonly PermissionRuleSet[];
 }
 
 const VALID_RULE_METHODS = new Set([
@@ -316,16 +339,64 @@ function getPermissionRules(permission: unknown): string[] {
   return rules;
 }
 
-function getApiPermissionsForMatch(
+function getApiPermissionRuleSetsForMatch(
   api: FirewallConfig["apis"][number],
   serviceName: string,
   apiBase: string | null,
-): unknown[] | null {
+): PermissionRuleSet[] | null {
   if (!isValidApiEntry(api, serviceName)) return null;
   if (apiBase !== null && stripTrailingSlash(api.base) !== apiBase) return null;
   if (api.permissions === undefined) return null;
   if (!Array.isArray(api.permissions)) return null;
-  return api.permissions;
+
+  const permissionRuleSets: PermissionRuleSet[] = [];
+  const seenPermissionNames = new Set<string>();
+  for (const rawPermission of api.permissions) {
+    const permissionName = getPermissionName(rawPermission);
+    if (permissionName === null) continue;
+    if (seenPermissionNames.has(permissionName)) continue;
+    seenPermissionNames.add(permissionName);
+    permissionRuleSets.push({
+      name: permissionName,
+      rules: getPermissionRules(rawPermission),
+    });
+  }
+  return permissionRuleSets;
+}
+
+function getRoutingApiPermissionRuleSetsForMatch(
+  api: FirewallRoutingPermissionApi,
+  serviceName: string,
+  apiBase: string | null,
+): PermissionRuleSet[] | null {
+  if (!isObjectRecord(api)) return null;
+  if (typeof api.base !== "string") return null;
+  try {
+    validateBaseUrl(api.base, serviceName);
+  } catch {
+    return null;
+  }
+  if (apiBase !== null && stripTrailingSlash(api.base) !== apiBase) return null;
+  if (!Array.isArray(api.routes)) return null;
+
+  const rulesByPermission = new Map<string, string[]>();
+  for (const route of api.routes) {
+    if (!isObjectRecord(route)) continue;
+    if (typeof route.permissionName !== "string") continue;
+    if (!isValidPermissionName(route.permissionName)) continue;
+    if (typeof route.rule !== "string") continue;
+
+    const rules = rulesByPermission.get(route.permissionName);
+    if (rules) {
+      rules.push(route.rule);
+    } else {
+      rulesByPermission.set(route.permissionName, [route.rule]);
+    }
+  }
+
+  return [...rulesByPermission.entries()].map(([name, rules]) => {
+    return { name, rules };
+  });
 }
 
 function recordPermissionMatch(
@@ -896,30 +967,71 @@ export function findMatchingPermissions(
   if (typeof config.name !== "string" || config.name === "") return [];
   if (!Array.isArray(config.apis)) return [];
 
-  const upperMethod = method.toUpperCase();
   const apiBase =
     options.apiBase === undefined ? null : stripTrailingSlash(options.apiBase);
-  const matched: string[] = [];
+  const matchApis: PermissionMatchApi[] = [];
 
   for (const api of config.apis) {
-    const permissions = getApiPermissionsForMatch(api, config.name, apiBase);
-    if (permissions === null) continue;
-    const state: ApiMatchState = { bestSpecificity: null, matched: [] };
-    const seenPermissionNames = new Set<string>();
+    const permissionRuleSets = getApiPermissionRuleSetsForMatch(
+      api,
+      config.name,
+      apiBase,
+    );
+    if (permissionRuleSets !== null) {
+      matchApis.push({ permissionRuleSets });
+    }
+  }
 
-    for (const rawPermission of permissions) {
-      const permissionName = getPermissionName(rawPermission);
-      if (permissionName === null) continue;
-      if (seenPermissionNames.has(permissionName)) continue;
-      seenPermissionNames.add(permissionName);
-      for (const rule of getPermissionRules(rawPermission)) {
+  return findMatchingPermissionRuleSets(method, path, matchApis);
+}
+
+export function findMatchingRoutingPermissions(
+  method: string,
+  path: string,
+  apis: readonly FirewallRoutingPermissionApi[],
+  options: FindMatchingRoutingPermissionsOptions = {},
+): string[] {
+  if (!Array.isArray(apis)) return [];
+
+  const serviceName = options.serviceName ?? "routing";
+  const apiBase =
+    options.apiBase === undefined ? null : stripTrailingSlash(options.apiBase);
+  const matchApis: PermissionMatchApi[] = [];
+
+  for (const api of apis) {
+    const permissionRuleSets = getRoutingApiPermissionRuleSetsForMatch(
+      api,
+      serviceName,
+      apiBase,
+    );
+    if (permissionRuleSets !== null) {
+      matchApis.push({ permissionRuleSets });
+    }
+  }
+
+  return findMatchingPermissionRuleSets(method, path, matchApis);
+}
+
+function findMatchingPermissionRuleSets(
+  method: string,
+  path: string,
+  apis: readonly PermissionMatchApi[],
+): string[] {
+  const upperMethod = method.toUpperCase();
+  const matched: string[] = [];
+
+  for (const api of apis) {
+    const state: ApiMatchState = { bestSpecificity: null, matched: [] };
+
+    for (const permission of api.permissionRuleSets) {
+      for (const rule of permission.rules) {
         const rest = matchingRulePath(rule, upperMethod);
         if (rest === null) continue;
 
         if (matchFirewallPath(path, rest) !== null) {
           const specificity = pathSpecificity(rest);
           if (specificity === null) continue;
-          recordPermissionMatch(state, permissionName, specificity);
+          recordPermissionMatch(state, permission.name, specificity);
         }
       }
     }

--- a/turbo/packages/connectors/src/firewall-types.ts
+++ b/turbo/packages/connectors/src/firewall-types.ts
@@ -1242,16 +1242,65 @@ function baseUrlScheme(base: string): string {
   return base.slice(0, schemeEnd).toLowerCase();
 }
 
-function validateCredentialedBaseUrlTransport(
+function validateCredentialedBaseUrlTransportValue(
   base: string,
   serviceName: string,
-  auth: FirewallApi["auth"],
+  credentialed: boolean,
 ): void {
-  if (!firewallAuthInjectsCredentials(auth)) return;
+  if (!credentialed) return;
   if (baseUrlScheme(base) === REQUIRED_AUTH_BASE_URL_SCHEME) return;
   throw new Error(
     `Invalid base URL "${base}" in firewall "${serviceName}": credentialed base URL must use https`,
   );
+}
+
+export interface ResolveFirewallBaseUrlTemplateOptions {
+  readonly serviceName: string;
+  readonly base: string;
+  readonly vars: Record<string, string> | undefined;
+  readonly credentialed?: boolean;
+}
+
+export function resolveFirewallBaseUrlTemplate({
+  serviceName,
+  base,
+  vars,
+  credentialed = false,
+}: ResolveFirewallBaseUrlTemplateOptions): string {
+  if (!hasBaseUrlVars(base)) return base;
+
+  let resolved = "";
+  let lastIndex = 0;
+  for (const match of base.matchAll(BASE_URL_VARS_PATTERN_G)) {
+    const fullMatch = match[0];
+    const name = match[1]!;
+    const matchIndex = match.index!;
+    const value = vars?.[name];
+    if (!value) {
+      throw new Error(
+        `Firewall "${serviceName}" base URL requires variable "${name}" but it was not provided`,
+      );
+    }
+    validateBaseUrlTemplateVariable({
+      base,
+      serviceName,
+      name,
+      value,
+      prefix: base.slice(0, matchIndex),
+      suffix: base.slice(matchIndex + fullMatch.length),
+    });
+    resolved += base.slice(lastIndex, matchIndex) + value;
+    lastIndex = matchIndex + fullMatch.length;
+  }
+  resolved += base.slice(lastIndex);
+  validateResolvedBaseUrlPathSafety(base, serviceName, resolved);
+  validateBaseUrl(resolved, serviceName);
+  validateCredentialedBaseUrlTransportValue(
+    resolved,
+    serviceName,
+    credentialed,
+  );
+  return resolved;
 }
 
 /**
@@ -1268,33 +1317,12 @@ export function resolveFirewallBaseUrlVars(
       ...fw,
       apis: fw.apis.map((api) => {
         if (!hasBaseUrlVars(api.base)) return api;
-        let resolved = "";
-        let lastIndex = 0;
-        for (const match of api.base.matchAll(BASE_URL_VARS_PATTERN_G)) {
-          const fullMatch = match[0];
-          const name = match[1]!;
-          const matchIndex = match.index!;
-          const value = vars?.[name];
-          if (!value) {
-            throw new Error(
-              `Firewall "${fw.name}" base URL requires variable "${name}" but it was not provided`,
-            );
-          }
-          validateBaseUrlTemplateVariable({
-            base: api.base,
-            serviceName: fw.name,
-            name,
-            value,
-            prefix: api.base.slice(0, matchIndex),
-            suffix: api.base.slice(matchIndex + fullMatch.length),
-          });
-          resolved += api.base.slice(lastIndex, matchIndex) + value;
-          lastIndex = matchIndex + fullMatch.length;
-        }
-        resolved += api.base.slice(lastIndex);
-        validateResolvedBaseUrlPathSafety(api.base, fw.name, resolved);
-        validateBaseUrl(resolved, fw.name);
-        validateCredentialedBaseUrlTransport(resolved, fw.name, api.auth);
+        const resolved = resolveFirewallBaseUrlTemplate({
+          serviceName: fw.name,
+          base: api.base,
+          vars,
+          credentialed: firewallAuthInjectsCredentials(api.auth),
+        });
         return { ...api, base: resolved };
       }),
     };


### PR DESCRIPTION
## Summary

- Move `zero doctor check-connector` off `@vm0/connectors/firewalls/runtime` and onto routing metadata plus execution metadata.
- Add routing-native permission matching and a narrow base URL template resolver for compact builtin run-context firewalls.
- Move `zero doctor permission-deny` to routing metadata while preserving narrowest-permission selection by route count.
- Tighten the zero command import boundary so future command sources cannot import connector firewall runtime loaders.

Closes #18968

## Verification

- `pnpm -F @vm0/connectors exec vitest run src/__tests__/firewall-rule-matcher.test.ts src/__tests__/firewall-expander.test.ts`
- `pnpm -F @vm0/cli exec vitest run src/commands/zero/doctor/__tests__/check-connector.test.ts src/commands/zero/doctor/__tests__/permission-deny.test.ts src/commands/zero/__tests__/firewall-import-boundary.test.ts`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/cli check-types`
- `pnpm format`
- `git diff --check`
- `pnpm turbo run lint --filter=@vm0/connectors --filter=@vm0/cli`
- pre-commit: `pnpm check-types` via lefthook after `pnpm install --frozen-lockfile` restored a missing local `react-zoom-pan-pinch` install
