### PR TITLE
fix: preserve mobile chat safe area

### DIFF
--- a/turbo/apps/platform/src/lib/__tests__/visual-viewport-keyboard.test.ts
+++ b/turbo/apps/platform/src/lib/__tests__/visual-viewport-keyboard.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { setupVisualViewportKeyboardState } from "../visual-viewport-keyboard.ts";
+
+class MockVisualViewport extends EventTarget {
+  height: number;
+  offsetTop = 0;
+
+  constructor(height: number) {
+    super();
+    this.height = height;
+  }
+
+  resizeTo(height: number): void {
+    this.height = height;
+    this.dispatchEvent(new Event("resize"));
+  }
+}
+
+function installVisualViewport(viewport: MockVisualViewport): void {
+  Object.defineProperty(window, "visualViewport", {
+    configurable: true,
+    value: viewport,
+  });
+}
+
+function setInnerHeight(height: number): void {
+  Object.defineProperty(window, "innerHeight", {
+    configurable: true,
+    value: height,
+  });
+}
+
+function focusTextEntry(): HTMLTextAreaElement {
+  const textarea = document.createElement("textarea");
+  document.body.append(textarea);
+  textarea.focus();
+  return textarea;
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+  delete document.documentElement.dataset.keyboardOpen;
+  Object.defineProperty(window, "visualViewport", {
+    configurable: true,
+    value: undefined,
+  });
+});
+
+describe("visual viewport keyboard state", () => {
+  it("keeps the safe-area state when text entry is focused without viewport shrink", () => {
+    const viewport = new MockVisualViewport(844);
+    setInnerHeight(844);
+    installVisualViewport(viewport);
+
+    const cleanup = setupVisualViewportKeyboardState();
+    focusTextEntry();
+    viewport.resizeTo(844);
+
+    expect(document.documentElement.dataset.keyboardOpen).toBeUndefined();
+
+    cleanup();
+  });
+
+  it("marks the keyboard open only while a focused text entry occludes the viewport", () => {
+    const viewport = new MockVisualViewport(844);
+    setInnerHeight(844);
+    installVisualViewport(viewport);
+
+    const cleanup = setupVisualViewportKeyboardState();
+    focusTextEntry();
+
+    viewport.resizeTo(520);
+    expect(document.documentElement.dataset.keyboardOpen).toBe("true");
+
+    viewport.resizeTo(844);
+    expect(document.documentElement.dataset.keyboardOpen).toBeUndefined();
+
+    cleanup();
+  });
+
+  it("clears the keyboard state when focus leaves the text entry", () => {
+    const viewport = new MockVisualViewport(844);
+    setInnerHeight(844);
+    installVisualViewport(viewport);
+
+    const cleanup = setupVisualViewportKeyboardState();
+    const textarea = focusTextEntry();
+    viewport.resizeTo(520);
+
+    textarea.blur();
+    expect(document.documentElement.dataset.keyboardOpen).toBeUndefined();
+
+    cleanup();
+  });
+
+  it("does not mark keyboard state without visualViewport support", () => {
+    setInnerHeight(844);
+
+    const cleanup = setupVisualViewportKeyboardState();
+    focusTextEntry();
+
+    expect(document.documentElement.dataset.keyboardOpen).toBeUndefined();
+
+    cleanup();
+  });
+});

--- a/turbo/apps/platform/src/lib/visual-viewport-keyboard.ts
+++ b/turbo/apps/platform/src/lib/visual-viewport-keyboard.ts
@@ -1,0 +1,122 @@
+const KEYBOARD_SHRINK_RATIO = 0.15;
+const MIN_KEYBOARD_SHRINK_PX = 120;
+
+const TEXT_ENTRY_SELECTOR =
+  "textarea, select, [contenteditable]:not([contenteditable='false'])";
+
+function isNonTextInputType(type: string): boolean {
+  switch (type) {
+    case "button":
+    case "checkbox":
+    case "color":
+    case "file":
+    case "hidden":
+    case "image":
+    case "radio":
+    case "range":
+    case "reset":
+    case "submit": {
+      return true;
+    }
+    default: {
+      return false;
+    }
+  }
+}
+
+function isTextEntryElement(element: Element | null): boolean {
+  if (!(element instanceof HTMLElement)) {
+    return false;
+  }
+
+  if (element instanceof HTMLInputElement) {
+    return !isNonTextInputType(element.type);
+  }
+
+  return element.matches(TEXT_ENTRY_SELECTOR);
+}
+
+function readLayoutViewportHeight(viewport: VisualViewport): number {
+  return Math.max(
+    window.innerHeight,
+    document.documentElement.clientHeight,
+    viewport.height + viewport.offsetTop,
+  );
+}
+
+function viewportHasKeyboardOcclusion(
+  baselineHeight: number,
+  viewport: VisualViewport,
+): boolean {
+  const visibleBottom = viewport.height + viewport.offsetTop;
+  const occludedHeight = baselineHeight - visibleBottom;
+  const threshold = Math.max(
+    MIN_KEYBOARD_SHRINK_PX,
+    baselineHeight * KEYBOARD_SHRINK_RATIO,
+  );
+
+  return occludedHeight > threshold;
+}
+
+function setKeyboardOpen(open: boolean): void {
+  if (open) {
+    document.documentElement.dataset.keyboardOpen = "true";
+  } else {
+    delete document.documentElement.dataset.keyboardOpen;
+  }
+}
+
+export function setupVisualViewportKeyboardState(): () => void {
+  const viewport = window.visualViewport;
+
+  if (!viewport) {
+    return () => {
+      setKeyboardOpen(false);
+    };
+  }
+
+  let baselineHeight = readLayoutViewportHeight(viewport);
+  let keyboardOpen = false;
+
+  const update = () => {
+    const activeTextEntry = isTextEntryElement(document.activeElement);
+
+    if (!activeTextEntry) {
+      keyboardOpen = false;
+      baselineHeight = readLayoutViewportHeight(viewport);
+      setKeyboardOpen(false);
+      return;
+    }
+
+    if (!keyboardOpen) {
+      baselineHeight = Math.max(
+        baselineHeight,
+        readLayoutViewportHeight(viewport),
+      );
+    }
+
+    keyboardOpen = viewportHasKeyboardOcclusion(baselineHeight, viewport);
+    setKeyboardOpen(keyboardOpen);
+  };
+
+  const resetBaseline = () => {
+    baselineHeight = readLayoutViewportHeight(viewport);
+    update();
+  };
+
+  viewport.addEventListener("resize", update);
+  viewport.addEventListener("scroll", update);
+  window.addEventListener("orientationchange", resetBaseline);
+  document.addEventListener("focusin", update);
+  document.addEventListener("focusout", update);
+  update();
+
+  return () => {
+    viewport.removeEventListener("resize", update);
+    viewport.removeEventListener("scroll", update);
+    window.removeEventListener("orientationchange", resetBaseline);
+    document.removeEventListener("focusin", update);
+    document.removeEventListener("focusout", update);
+    setKeyboardOpen(false);
+  };
+}

--- a/turbo/apps/platform/src/main.ts
+++ b/turbo/apps/platform/src/main.ts
@@ -1,5 +1,6 @@
 import { initSentry, Sentry } from "./lib/sentry.ts";
 import { initPostHog } from "./lib/posthog.ts";
+import { setupVisualViewportKeyboardState } from "./lib/visual-viewport-keyboard.ts";
 import "./polyfill.ts";
 import { createRoot } from "react-dom/client";
 import { createStore } from "ccstate";
@@ -11,6 +12,7 @@ import { setupRouter } from "./views/main.tsx";
 // Initialize Sentry before bootstrap so errors during startup are captured
 initSentry();
 initPostHog();
+setupVisualViewportKeyboardState();
 
 setLogErrorHandler((loggerName, args) => {
   const error = args.find((a): a is Error => {

--- a/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
+++ b/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
@@ -44,7 +44,7 @@ describe("platform entrypoint safe area behavior", () => {
     );
   });
 
-  it("suppresses the bottom safe-area inset while text entry is focused", () => {
+  it("suppresses the bottom safe-area inset only while the keyboard is open", () => {
     const globalCss = readGlobalCss();
 
     expect(globalCss).toMatch(
@@ -52,7 +52,7 @@ describe("platform entrypoint safe area behavior", () => {
     );
     expect(globalCss).toMatch(/--sab:\s*var\(--sab-raw\);/);
     expect(globalCss).toMatch(
-      /:root:has\([\s\S]*:focus-visible[\s\S]*\)\s*{\s*--sab:\s*0px;\s*}/,
+      /:root\[data-keyboard-open="true"\]\s*{\s*--sab:\s*0px;\s*}/,
     );
     expect(globalCss).toMatch(/bottom:\s*calc\(-1\s*\*\s*var\(--sab\)\);/);
   });
@@ -63,7 +63,7 @@ describe("platform entrypoint safe area behavior", () => {
     expect(globalCss).toMatch(/--zero-viewport-height:\s*100dvh;/);
     expect(globalCss).toMatch(/--zero-viewport-height:\s*100lvh;/);
     expect(globalCss).toMatch(
-      /:root:has\([\s\S]*:focus-visible[\s\S]*\)\s*{\s*--zero-viewport-height:\s*100dvh;\s*}/,
+      /:root\[data-keyboard-open="true"\]\s*{\s*--zero-viewport-height:\s*100dvh;\s*}/,
     );
     expect(globalCss).toMatch(
       /html,\s*body,\s*#root\s*{[\s\S]*overflow:\s*hidden;[\s\S]*overscroll-behavior:\s*none;/,

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -64,27 +64,13 @@
   }
 }
 
-:root:has(
-  :is(
-    input,
-    textarea,
-    select,
-    [contenteditable]:not([contenteditable="false"])
-  ):focus-visible
-) {
+:root[data-keyboard-open="true"] {
   --sab: 0px;
 }
 
 @supports (height: 100lvh) {
   @media (display-mode: standalone) {
-    :root:has(
-      :is(
-        input,
-        textarea,
-        select,
-        [contenteditable]:not([contenteditable="false"])
-      ):focus-visible
-    ) {
+    :root[data-keyboard-open="true"] {
       --zero-viewport-height: 100dvh;
     }
   }


### PR DESCRIPTION
## Summary
- track actual visual viewport keyboard occlusion before entering the mobile keyboard layout state
- keep bottom safe-area padding when a text entry remains focused but the keyboard is closed
- update safe-area CSS assertions and add visualViewport keyboard-state coverage

## Validation
- pnpm exec prettier --write apps/platform/src/main.ts apps/platform/src/lib/visual-viewport-keyboard.ts apps/platform/src/lib/__tests__/visual-viewport-keyboard.test.ts apps/platform/src/views/css/index.css apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app exec vitest run src/lib/__tests__/visual-viewport-keyboard.test.ts
- pnpm -F @vm0/app exec vitest run src/views/css/__tests__/entrypoint-safe-area.test.ts

Did not start a local dev server or run full vitest per vm0 PR verification preference.