### PR TITLE
fix: render activity thinking blocks

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/log-views/grouped-message-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/grouped-message-card.tsx
@@ -48,6 +48,88 @@ function CollapsibleText({ text }: { text: string }) {
   );
 }
 
+function ThinkingSummary({
+  text,
+  searchTerm,
+  timestamp,
+  showConnector,
+  isDashed,
+}: {
+  text: string;
+  searchTerm?: string;
+  timestamp: string;
+  showConnector: boolean;
+  isDashed: boolean;
+}) {
+  const hasSearchMatch = Boolean(
+    searchTerm &&
+    searchTerm.trim() &&
+    text.toLowerCase().includes(searchTerm.toLowerCase()),
+  );
+
+  return (
+    <div className={`${MESSAGE_SPACING} relative`}>
+      {showConnector && <Connector isDashed={isDashed} />}
+      <details className="group" open={hasSearchMatch}>
+        <summary className="cursor-pointer list-none w-full text-left">
+          <div className="flex items-center gap-2">
+            <StatusDot variant="success" />
+            <span className="font-semibold text-sm text-foreground shrink-0">
+              Thinking
+            </span>
+            <span className="flex-1" />
+            <span className="text-xs text-muted-foreground shrink-0 ml-4 whitespace-nowrap hidden sm:inline">
+              {timestamp}
+            </span>
+          </div>
+          <div className="text-xs text-muted-foreground pl-5 mt-1 sm:hidden">
+            {timestamp}
+          </div>
+        </summary>
+
+        <div className="mt-1 flex items-start gap-1.5 ml-[18px] overflow-hidden">
+          <span className="text-muted-foreground text-xs shrink-0">└</span>
+          <div className="flex-1 min-w-0 text-sm text-foreground">
+            <MarkdownContent text={text} />
+          </div>
+        </div>
+      </details>
+    </div>
+  );
+}
+
+function AssistantSection({
+  children,
+  timestamp,
+  showConnector,
+  isDashed,
+}: {
+  children: React.ReactNode;
+  timestamp?: string;
+  showConnector: boolean;
+  isDashed: boolean;
+}) {
+  return (
+    <div className={`${MESSAGE_SPACING} relative`}>
+      {showConnector && <Connector isDashed={isDashed} />}
+      <div className="flex gap-2 items-start relative">
+        <StatusDot variant="neutral" className="mt-1.5" />
+        <div className="flex-1 min-w-0">{children}</div>
+        {timestamp && (
+          <span className="text-xs text-muted-foreground shrink-0 ml-4 whitespace-nowrap hidden sm:inline">
+            {timestamp}
+          </span>
+        )}
+      </div>
+      {timestamp && (
+        <div className="text-xs text-muted-foreground pl-5 mt-1 sm:hidden">
+          {timestamp}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function GroupedMessageCard({
   message,
   searchTerm,
@@ -471,6 +553,16 @@ function Connector({ isDashed }: { isDashed: boolean }) {
   );
 }
 
+function countMatches(text: string | undefined, searchTerm?: string): number {
+  if (!searchTerm || !text) {
+    return 0;
+  }
+
+  return (
+    text.toLowerCase().match(new RegExp(searchTerm.toLowerCase(), "g")) ?? []
+  ).length;
+}
+
 interface ToolGroup {
   toolName: string;
   operations: ToolOperation[];
@@ -558,6 +650,73 @@ function CollapsedToolGroup({
   );
 }
 
+function renderToolElements(params: {
+  toolOperations: ToolOperation[];
+  textAfter?: string;
+  toolMatchStart: number;
+  currentMatchIndex?: number;
+  searchTerm?: string;
+  showConnector: boolean;
+  timestamp: string;
+}): React.ReactNode[] {
+  const {
+    toolOperations,
+    textAfter,
+    toolMatchStart,
+    currentMatchIndex,
+    searchTerm,
+    showConnector,
+    timestamp,
+  } = params;
+  const elements: React.ReactNode[] = [];
+  const toolGroups = groupConsecutiveTools(toolOperations);
+
+  for (let gi = 0; gi < toolGroups.length; gi++) {
+    const group = toolGroups[gi]!;
+    const isLastGroup = gi === toolGroups.length - 1;
+    const isLastElement = isLastGroup && !textAfter;
+    const { showConnector: showConnectorHere } = shouldShowAssistantConnector({
+      isLastElementInMessage: isLastElement,
+      showConnectorToNextMessage: showConnector,
+    });
+    const nextGroup = toolGroups[gi + 1];
+    const isDashed = nextGroup ? nextGroup.toolName === group.toolName : false;
+
+    if (group.operations.length === 1) {
+      const op = group.operations[0]!;
+      elements.push(
+        <div key={op.toolUseId} className={`${MESSAGE_SPACING} relative`}>
+          {showConnectorHere && <Connector isDashed={isDashed} />}
+          <div className="relative">
+            <ToolSummary
+              operation={op}
+              searchTerm={searchTerm}
+              currentMatchIndex={currentMatchIndex}
+              matchStartIndex={toolMatchStart}
+              timestamp={timestamp}
+            />
+          </div>
+        </div>,
+      );
+    } else {
+      elements.push(
+        <CollapsedToolGroup
+          key={`group-${group.operations[0]!.toolUseId}`}
+          group={group}
+          searchTerm={searchTerm}
+          currentMatchIndex={currentMatchIndex}
+          matchStartIndex={toolMatchStart}
+          timestamp={timestamp}
+          showConnector={showConnectorHere}
+          isDashed={isDashed}
+        />,
+      );
+    }
+  }
+
+  return elements;
+}
+
 function AssistantMessageCard({
   message,
   searchTerm,
@@ -571,27 +730,35 @@ function AssistantMessageCard({
   matchStartIndex?: number;
   showConnector?: boolean;
 }) {
-  const { textBefore, textAfter, toolOperations } = message;
+  const { thinkingBlocks, textBefore, textAfter, toolOperations } = message;
+  const thinkingText = thinkingBlocks?.join("\n\n");
   const hasTools = toolOperations && toolOperations.length > 0;
-
-  // Calculate match offset for text sections
   const currentOffset = matchStartIndex ?? 0;
-
-  // Count matches in textBefore for offset calculation
-  const textBeforeMatches =
-    searchTerm && textBefore
-      ? (
-          textBefore
-            .toLowerCase()
-            .match(new RegExp(searchTerm.toLowerCase(), "g")) ?? []
-        ).length
-      : 0;
-
-  // Build array of elements to render independently
+  const textBeforeMatches = countMatches(textBefore, searchTerm);
+  const thinkingMatches = countMatches(thinkingText, searchTerm);
   const elements: React.ReactNode[] = [];
-
-  // Text before tools with timestamp
   const timestamp = formatEventTime(message.createdAt);
+
+  if (thinkingText) {
+    const isLastElement = !textBefore && !hasTools && !textAfter;
+    const { showConnector: showConnectorHere, isDashed } =
+      shouldShowAssistantConnector({
+        isLastElementInMessage: isLastElement,
+        showConnectorToNextMessage: showConnector,
+      });
+
+    elements.push(
+      <ThinkingSummary
+        key="thinking"
+        text={thinkingText}
+        searchTerm={searchTerm}
+        timestamp={timestamp}
+        showConnector={showConnectorHere}
+        isDashed={isDashed}
+      />,
+    );
+  }
+
   if (textBefore) {
     const isLastElement = !hasTools && !textAfter;
     const { showConnector: showConnectorHere, isDashed } =
@@ -601,83 +768,32 @@ function AssistantMessageCard({
       });
 
     elements.push(
-      <div key="text-before" className={`${MESSAGE_SPACING} relative`}>
-        {showConnectorHere && <Connector isDashed={isDashed} />}
-        <div className="flex gap-2 items-start relative">
-          <StatusDot variant="neutral" className="mt-1.5" />
-          <div className="flex-1 min-w-0">
-            <CollapsibleText text={textBefore} />
-          </div>
-          <span className="text-xs text-muted-foreground shrink-0 ml-4 whitespace-nowrap hidden sm:inline">
-            {timestamp}
-          </span>
-        </div>
-        <div className="text-xs text-muted-foreground pl-5 mt-1 sm:hidden">
-          {timestamp}
-        </div>
-      </div>,
+      <AssistantSection
+        key="text-before"
+        timestamp={timestamp}
+        showConnector={showConnectorHere}
+        isDashed={isDashed}
+      >
+        <CollapsibleText text={textBefore} />
+      </AssistantSection>,
     );
   }
 
-  // Tool operations - group consecutive same-type tools
   if (hasTools) {
-    const toolGroups = groupConsecutiveTools(toolOperations);
-    const toolMatchStart = currentOffset + textBeforeMatches;
-
-    for (let gi = 0; gi < toolGroups.length; gi++) {
-      const group = toolGroups[gi]!;
-      const isLastGroup = gi === toolGroups.length - 1;
-      const isLastElement = isLastGroup && !textAfter;
-
-      const { showConnector: showConnectorHere } = shouldShowAssistantConnector(
-        {
-          isLastElementInMessage: isLastElement,
-          showConnectorToNextMessage: showConnector,
-        },
-      );
-
-      // Dashed line if next group is the same tool type
-      const nextGroup = toolGroups[gi + 1];
-      const isDashed = nextGroup
-        ? nextGroup.toolName === group.toolName
-        : false;
-
-      if (group.operations.length === 1) {
-        // Single operation: render as before
-        const op = group.operations[0]!;
-        elements.push(
-          <div key={op.toolUseId} className={`${MESSAGE_SPACING} relative`}>
-            {showConnectorHere && <Connector isDashed={isDashed} />}
-            <div className="relative">
-              <ToolSummary
-                operation={op}
-                searchTerm={searchTerm}
-                currentMatchIndex={currentMatchIndex}
-                matchStartIndex={toolMatchStart}
-                timestamp={formatEventTime(message.createdAt)}
-              />
-            </div>
-          </div>,
-        );
-      } else {
-        // Multiple consecutive same-type operations: render collapsed group
-        elements.push(
-          <CollapsedToolGroup
-            key={`group-${group.operations[0]!.toolUseId}`}
-            group={group}
-            searchTerm={searchTerm}
-            currentMatchIndex={currentMatchIndex}
-            matchStartIndex={toolMatchStart}
-            timestamp={formatEventTime(message.createdAt)}
-            showConnector={showConnectorHere}
-            isDashed={isDashed}
-          />,
-        );
-      }
-    }
+    const toolMatchStart = currentOffset + thinkingMatches + textBeforeMatches;
+    elements.push(
+      ...renderToolElements({
+        toolOperations,
+        textAfter,
+        toolMatchStart,
+        currentMatchIndex,
+        searchTerm,
+        showConnector,
+        timestamp,
+      }),
+    );
   }
 
-  // Text after tools
   if (textAfter) {
     const isLastElement = true;
     const { showConnector: showConnectorHere, isDashed } =
@@ -687,15 +803,13 @@ function AssistantMessageCard({
       });
 
     elements.push(
-      <div key="text-after" className={`${MESSAGE_SPACING} relative`}>
-        {showConnectorHere && <Connector isDashed={isDashed} />}
-        <div className="flex gap-2 items-start relative w-full">
-          <StatusDot variant="neutral" className="mt-1.5" />
-          <div className="flex-1 min-w-0">
-            <CollapsibleText text={textAfter} />
-          </div>
-        </div>
-      </div>,
+      <AssistantSection
+        key="text-after"
+        showConnector={showConnectorHere}
+        isDashed={isDashed}
+      >
+        <CollapsibleText text={textAfter} />
+      </AssistantSection>,
     );
   }
 

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/grouped-message-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/grouped-message-card.tsx
@@ -558,9 +558,20 @@ function countMatches(text: string | undefined, searchTerm?: string): number {
     return 0;
   }
 
-  return (
-    text.toLowerCase().match(new RegExp(searchTerm.toLowerCase(), "g")) ?? []
-  ).length;
+  const normalizedText = text.toLowerCase();
+  const normalizedSearch = searchTerm.toLowerCase();
+  let count = 0;
+  let index = normalizedText.indexOf(normalizedSearch);
+
+  while (index !== -1) {
+    count++;
+    index = normalizedText.indexOf(
+      normalizedSearch,
+      index + normalizedSearch.length,
+    );
+  }
+
+  return count;
 }
 
 interface ToolGroup {

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.test.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+
+import type { AgentEvent } from "../../../../signals/zero-page/log-types.ts";
+import { groupEventsIntoMessages } from "./log-detail-utils.ts";
+
+describe("groupEventsIntoMessages progress events", () => {
+  it("filters Claude Code thinking token progress events", () => {
+    const events: AgentEvent[] = [
+      {
+        sequenceNumber: 0,
+        eventType: "system",
+        eventData: {
+          type: "system",
+          subtype: "init",
+        },
+        createdAt: "2026-06-26T02:31:20Z",
+      },
+      {
+        sequenceNumber: 1,
+        eventType: "system",
+        eventData: {
+          type: "system",
+          subtype: "thinking_tokens",
+        },
+        createdAt: "2026-06-26T02:31:26Z",
+      },
+      {
+        sequenceNumber: 2,
+        eventType: "assistant",
+        eventData: {
+          message: {
+            content: [{ type: "text", text: "Actual assistant output." }],
+          },
+        },
+        createdAt: "2026-06-26T02:31:28Z",
+      },
+    ];
+
+    const messages = groupEventsIntoMessages(events);
+
+    expect(messages).toHaveLength(2);
+    expect(
+      messages.map((message) => {
+        return message.eventData;
+      }),
+    ).toEqual([
+      { type: "system", subtype: "init" },
+      {
+        message: {
+          content: [{ type: "text", text: "Actual assistant output." }],
+        },
+      },
+    ]);
+  });
+
+  it("keeps Codex reasoning text visible", () => {
+    const messages = groupEventsIntoMessages([
+      {
+        sequenceNumber: 0,
+        eventType: "item.completed",
+        eventData: {
+          type: "item.completed",
+          item: {
+            type: "reasoning",
+            text: "Consider the failing branch before editing.",
+          },
+        },
+        createdAt: "2026-06-26T02:31:20Z",
+      },
+    ]);
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.textBefore).toBe(
+      "[thinking] Consider the failing branch before editing.",
+    );
+  });
+});
+
+describe("groupEventsIntoMessages thinking content", () => {
+  it("keeps Claude Code thinking content blocks visible", () => {
+    const messages = groupEventsIntoMessages([
+      {
+        sequenceNumber: 0,
+        eventType: "assistant",
+        eventData: {
+          message: {
+            content: [
+              {
+                type: "thinking",
+                thinking: "Review the failing logs before responding.",
+              },
+              { type: "text", text: "The failure is in the log renderer." },
+            ],
+          },
+        },
+        createdAt: "2026-06-26T02:31:20Z",
+      },
+    ]);
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.thinkingBlocks).toEqual([
+      "Review the failing logs before responding.",
+    ]);
+    expect(messages[0]?.textBefore).toBe("The failure is in the log renderer.");
+  });
+
+  it("does not drop thinking-only assistant events", () => {
+    const messages = groupEventsIntoMessages([
+      {
+        sequenceNumber: 0,
+        eventType: "assistant",
+        eventData: {
+          message: {
+            content: [
+              {
+                type: "thinking",
+                thinking: "Inspect the previous run output.",
+              },
+            ],
+          },
+        },
+        createdAt: "2026-06-26T02:31:20Z",
+      },
+    ]);
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.thinkingBlocks).toEqual([
+      "Inspect the previous run output.",
+    ]);
+    expect(messages[0]?.textBefore).toBeUndefined();
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/log-detail-utils.ts
@@ -6,6 +6,11 @@ interface TextContent {
   text: string;
 }
 
+interface ThinkingContent {
+  type: "thinking";
+  thinking?: string;
+}
+
 interface ToolUseContent {
   type: "tool_use";
   id?: string;
@@ -32,7 +37,11 @@ function normalizeToolResultContent(content: unknown): string {
   return String(content ?? "");
 }
 
-type MessageContent = TextContent | ToolUseContent | ToolResultContent;
+type MessageContent =
+  | TextContent
+  | ThinkingContent
+  | ToolUseContent
+  | ToolResultContent;
 
 // ============ GROUPED MESSAGE TYPES ============
 
@@ -60,6 +69,7 @@ export interface GroupedMessage {
   type: "system" | "assistant" | "result" | "todo";
   sequenceNumber: number;
   createdAt: string;
+  thinkingBlocks?: string[];
   textBefore?: string;
   textAfter?: string;
   toolOperations?: ToolOperation[];
@@ -687,16 +697,22 @@ function extractKeyParam(
  * Parse assistant event content into text parts and tool operations.
  */
 function parseAssistantContent(contents: MessageContent[]): {
+  thinkingParts: string[];
   textParts: string[];
   toolOperations: ToolOperation[];
   foundToolUse: boolean;
 } {
+  const thinkingParts: string[] = [];
   const textParts: string[] = [];
   const toolOperations: ToolOperation[] = [];
   let foundToolUse = false;
 
   for (const content of contents) {
-    if (content.type === "text") {
+    if (content.type === "thinking") {
+      if (content.thinking) {
+        thinkingParts.push(content.thinking);
+      }
+    } else if (content.type === "text") {
       const textContent = content as TextContent;
       if (textContent.text) {
         textParts.push(textContent.text);
@@ -714,7 +730,7 @@ function parseAssistantContent(contents: MessageContent[]): {
     }
   }
 
-  return { textParts, toolOperations, foundToolUse };
+  return { thinkingParts, textParts, toolOperations, foundToolUse };
 }
 
 /**
@@ -851,6 +867,10 @@ function processSystemEvent(event: AgentEvent, ctx: GroupingContext): void {
   const eventData = event.eventData as GroupingEventData;
   const subtype = eventData.subtype;
 
+  if (subtype === "thinking_tokens") {
+    return;
+  }
+
   if (!isTaskEventData(event.eventData)) {
     ctx.grouped.push({
       type: "system",
@@ -975,11 +995,13 @@ function processChildAssistantEvent(
   ctx: GroupingContext,
 ): void {
   const contents = eventData.message?.content ?? [];
-  const { textParts, toolOperations } = parseAssistantContent(contents);
+  const { thinkingParts, textParts, toolOperations } =
+    parseAssistantContent(contents);
+  const hasThinking = thinkingParts.length > 0;
   const hasText = textParts.length > 0;
   const hasTools = toolOperations.length > 0;
 
-  if (!hasText && !hasTools) {
+  if (!hasThinking && !hasText && !hasTools) {
     return;
   }
 
@@ -996,6 +1018,7 @@ function processChildAssistantEvent(
     type: "assistant",
     sequenceNumber: event.sequenceNumber,
     createdAt: event.createdAt,
+    thinkingBlocks: hasThinking ? thinkingParts : undefined,
     textBefore: hasText ? textParts.join("\n\n") : undefined,
     toolOperations: hasTools ? toolOperations : undefined,
     eventData: event.eventData,
@@ -1019,7 +1042,9 @@ function processAssistantEvent(
   }
 
   const contents = eventData.message?.content ?? [];
-  const { textParts, toolOperations } = parseAssistantContent(contents);
+  const { thinkingParts, textParts, toolOperations } =
+    parseAssistantContent(contents);
+  const hasThinking = thinkingParts.length > 0;
   const hasText = textParts.length > 0;
 
   // Separate TodoWrite from other tools
@@ -1047,11 +1072,12 @@ function processAssistantEvent(
   }
 
   // Create assistant message for text and non-TodoWrite tools
-  if (hasText || hasOtherTools) {
+  if (hasThinking || hasText || hasOtherTools) {
     const message: GroupedMessage = {
       type: "assistant",
       sequenceNumber: event.sequenceNumber,
       createdAt: event.createdAt,
+      thinkingBlocks: hasThinking ? thinkingParts : undefined,
       textBefore: hasText ? textParts.join("\n\n") : undefined,
       toolOperations: hasOtherTools ? otherToolOps : undefined,
       eventData: event.eventData,
@@ -1163,6 +1189,10 @@ function getVisibleGroupedMessageText(message: GroupedMessage): string {
   const parts: string[] = [];
 
   parts.push(message.type);
+
+  if (message.thinkingBlocks) {
+    parts.push(...message.thinkingBlocks);
+  }
 
   if (message.textBefore) {
     parts.push(message.textBefore);

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
@@ -137,7 +137,10 @@ export function isVisibleMessage(
   if (typeof result !== "string" || result.trim().length === 0) {
     return true;
   }
-  return (message.toolOperations?.length ?? 0) > 0;
+  return (
+    (message.thinkingBlocks?.length ?? 0) > 0 ||
+    (message.toolOperations?.length ?? 0) > 0
+  );
 }
 
 function ActivityBreadcrumbLink() {


### PR DESCRIPTION
## Summary
- render Claude Code thinking content blocks in activity logs using the existing tool-style details layout
- hide thinking token progress events from the activity timeline
- keep thinking-only assistant events visible and searchable

## Verification
- pnpm -F @vm0/app exec vitest run src/views/zero-page/components/log-views/log-detail-utils.test.ts
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app lint
- pre-commit: prettier, knip, turbo check-types