### PR TITLE
perf: write exec stream chunks directly

### DIFF
--- a/crates/vsock-guest/src/exec_operation.rs
+++ b/crates/vsock-guest/src/exec_operation.rs
@@ -1504,7 +1504,7 @@ mod tests {
     use std::net::Shutdown;
     use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
     use std::os::unix::net::UnixStream;
-    use std::time::{Duration, Instant};
+    use std::time::Duration;
 
     fn read_message(stream: &mut UnixStream) -> vsock_proto::RawMessage {
         let mut hdr = [0u8; 4];
@@ -1914,28 +1914,21 @@ mod tests {
             limit_bytes: 64,
             chunk_limit_bytes: 8,
         };
+        let seq = request.seq;
+        let registration = registry.register(request.seq, &request.label).unwrap();
+        let exec_cancel = registration.cancel_token();
 
-        start_exec_operation_with_spawner(
+        run_exec_operation_worker(
             request,
-            operation_guard(),
             writer,
             Arc::new(AtomicBool::new(false)),
-            registry.clone(),
+            exec_cancel.clone(),
+            registration,
+            operation_guard(),
             SystemThreadSpawner,
-        )
-        .unwrap();
+        );
 
-        let started = Instant::now();
-        loop {
-            if let Ok(registration) = registry.register(44, "released") {
-                drop(registration);
-                break;
-            }
-            assert!(
-                started.elapsed() < Duration::from_secs(5),
-                "exec operation registry entry for seq=44 was not released"
-            );
-            std::thread::sleep(Duration::from_millis(10));
-        }
+        assert!(exec_cancel.load(Ordering::Acquire));
+        assert_registry_released(&registry, seq);
     }
 }

--- a/crates/vsock-guest/src/exec_operation.rs
+++ b/crates/vsock-guest/src/exec_operation.rs
@@ -3,7 +3,7 @@ use std::io::{self, Write};
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 use std::process::{Child, ChildStderr, ChildStdin, ChildStdout};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::{self, Receiver, SyncSender};
+use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
@@ -11,7 +11,7 @@ use std::time::{Duration, Instant};
 use vsock_proto::{
     self, ExecCapturedOutput, ExecControlNonce, ExecControlPolicy, ExecLifecyclePolicy,
     ExecOutputPolicy, ExecOutputStream, ExecTermination, ExecTimeoutPolicy, MSG_ERROR,
-    MSG_EXEC_OUTPUT, MSG_EXEC_RESULT, MSG_EXEC_STARTED,
+    MSG_EXEC_RESULT, MSG_EXEC_STARTED,
 };
 
 use crate::drain::{BoundedDrainResult, BoundedStreamConfig, drain_bounded_cancellable};
@@ -38,9 +38,7 @@ const THREAD_EXEC_OPERATION_WORKER: &str = "vsock-exec-operation-worker";
 const THREAD_EXEC_OPERATION_STDIN: &str = "vsock-exec-operation-stdin";
 const THREAD_EXEC_OPERATION_STDOUT: &str = "vsock-exec-operation-stdout";
 const THREAD_EXEC_OPERATION_STDERR: &str = "vsock-exec-operation-stderr";
-const THREAD_EXEC_OPERATION_OUTPUT: &str = "vsock-exec-operation-output";
 const STDIN_WRITE_CANCELLED: &str = "stdin write cancelled";
-const OUTPUT_CHANNEL_CAPACITY: usize = 32;
 const FRAME_BODY_HEADER_LEN: usize = 1 + 4; // message type + sequence
 const EXEC_OUTPUT_PAYLOAD_OVERHEAD: usize = 1 + 4 + 1 + 4;
 const EXEC_RESULT_EXITED_LEN: usize = 1 + 4;
@@ -258,16 +256,58 @@ impl ExecOperationWorkerRequest {
 struct DrainWorker {
     stream: ExecOutputStream,
     policy: OutputSettings,
-    output_tx: Option<SyncSender<StreamEvent>>,
+    stream_writer: Option<SharedExecStreamWriter>,
     drain_cancel: Arc<AtomicBool>,
     exec_cancel: Arc<AtomicBool>,
     drain_done_tx: mpsc::Sender<()>,
 }
 
-struct StreamEvent {
-    stream: ExecOutputStream,
-    chunk: Vec<u8>,
-    truncated: bool,
+type SharedExecStreamWriter = Arc<Mutex<ExecStreamWriter>>;
+
+struct ExecStreamWriter {
+    seq: u32,
+    label_preview: String,
+    writer: GuestWriter,
+    output_seq: u32,
+    frame: Vec<u8>,
+}
+
+impl ExecStreamWriter {
+    fn new(seq: u32, label_preview: String, writer: GuestWriter) -> Self {
+        Self {
+            seq,
+            label_preview,
+            writer,
+            output_seq: 0,
+            frame: Vec::new(),
+        }
+    }
+
+    fn write_output(
+        &mut self,
+        stream: ExecOutputStream,
+        chunk: &[u8],
+        truncated: bool,
+    ) -> Result<(), ExecStreamWriteError> {
+        vsock_proto::encode_exec_output_frame_into(
+            &mut self.frame,
+            self.seq,
+            stream,
+            self.output_seq,
+            chunk,
+            truncated,
+        )
+        .map_err(ExecStreamWriteError::Encode)?;
+        self.output_seq = self.output_seq.wrapping_add(1);
+        self.writer
+            .write_frame(&self.frame)
+            .map_err(ExecStreamWriteError::Write)
+    }
+}
+
+enum ExecStreamWriteError {
+    Encode(vsock_proto::ProtocolError),
+    Write(io::Error),
 }
 
 struct StdinWriter {
@@ -356,8 +396,6 @@ struct ExecSetup {
     child: Child,
     kill_target: ProcessTreeKillTarget,
     stdin_writer: Option<StdinWriter>,
-    output_tx: Option<SyncSender<StreamEvent>>,
-    output_handle: Option<JoinHandle<()>>,
     drain_cancel: Arc<AtomicBool>,
     drain_done_tx: mpsc::Sender<()>,
     drain_done_rx: mpsc::Receiver<()>,
@@ -372,8 +410,6 @@ impl ExecSetup {
             child,
             kill_target,
             stdin_writer: None,
-            output_tx: None,
-            output_handle: None,
             drain_cancel,
             drain_done_tx,
             drain_done_rx,
@@ -394,15 +430,6 @@ impl ExecSetup {
 
     fn set_stdin_writer(&mut self, writer: StdinWriter) {
         self.stdin_writer = Some(writer);
-    }
-
-    fn set_output_writer(&mut self, tx: SyncSender<StreamEvent>, handle: JoinHandle<()>) {
-        self.output_tx = Some(tx);
-        self.output_handle = Some(handle);
-    }
-
-    fn output_tx(&self) -> Option<SyncSender<StreamEvent>> {
-        self.output_tx.clone()
     }
 
     fn drain_cancel(&self) -> Arc<AtomicBool> {
@@ -435,31 +462,23 @@ impl ExecSetup {
             child,
             kill_target,
             stdin_writer,
-            output_tx,
-            output_handle,
             drain_cancel,
             drain_done_tx: _,
             drain_done_rx: _,
         } = self;
         exec_cancel.store(true, Ordering::Release);
         drain_cancel.store(true, Ordering::Release);
-        drop(output_tx);
         kill_and_reap_child_with_target(child, kill_target);
         join_stdin_writer_after_kill(stdin_writer);
-        join_output_writer(output_handle);
         completion.wait_failed(diagnostic);
     }
 
     fn abort_exec_started_send_failed(self, completion: &ExecCompletion<'_>) {
         debug_assert!(self.stdin_writer.is_none());
-        debug_assert!(self.output_tx.is_none());
-        debug_assert!(self.output_handle.is_none());
         let ExecSetup {
             child,
             kill_target,
             stdin_writer: _,
-            output_tx: _,
-            output_handle: _,
             drain_cancel: _,
             drain_done_tx: _,
             drain_done_rx: _,
@@ -476,10 +495,6 @@ struct ExecSetupWithStdout {
 }
 
 impl ExecSetupWithStdout {
-    fn output_tx(&self) -> Option<SyncSender<StreamEvent>> {
-        self.setup.output_tx()
-    }
-
     fn drain_cancel(&self) -> Arc<AtomicBool> {
         self.setup.drain_cancel()
     }
@@ -503,28 +518,23 @@ impl ExecSetupWithStdout {
             child,
             kill_target,
             stdin_writer,
-            output_tx,
-            output_handle,
             drain_cancel,
             drain_done_tx: _,
             drain_done_rx: _,
         } = setup;
         exec_cancel.store(true, Ordering::Release);
         drain_cancel.store(true, Ordering::Release);
-        drop(output_tx);
         kill_and_reap_child_with_target(child, kill_target);
         join_stdin_writer_after_kill(stdin_writer);
         let _ = stdout_handle.join();
-        join_output_writer(output_handle);
         completion.wait_failed(diagnostic);
     }
 
     fn into_running(
-        mut self,
+        self,
         stderr_handle: JoinHandle<()>,
         stderr_result_rx: mpsc::Receiver<BoundedDrainResult>,
     ) -> RunningExec {
-        drop(self.setup.output_tx.take());
         let ExecSetupWithStdout {
             setup,
             stdout_handle,
@@ -534,8 +544,6 @@ impl ExecSetupWithStdout {
             child,
             kill_target,
             stdin_writer,
-            output_tx: _,
-            output_handle,
             drain_cancel,
             drain_done_tx,
             drain_done_rx,
@@ -546,7 +554,6 @@ impl ExecSetupWithStdout {
             child,
             kill_target,
             stdin_writer,
-            output_handle,
             stdout_handle,
             stdout_result_rx,
             stderr_handle,
@@ -561,7 +568,6 @@ struct RunningExec {
     child: Child,
     kill_target: ProcessTreeKillTarget,
     stdin_writer: Option<StdinWriter>,
-    output_handle: Option<JoinHandle<()>>,
     stdout_handle: JoinHandle<()>,
     stdout_result_rx: mpsc::Receiver<BoundedDrainResult>,
     stderr_handle: JoinHandle<()>,
@@ -582,7 +588,6 @@ impl RunningExec {
             child,
             mut kill_target,
             stdin_writer,
-            output_handle,
             stdout_handle,
             stdout_result_rx,
             stderr_handle,
@@ -622,7 +627,6 @@ impl RunningExec {
 
         let _ = stdout_handle.join();
         let _ = stderr_handle.join();
-        join_output_writer(output_handle);
         let stdout_result = stdout_result_rx.recv().unwrap_or_default();
         let stderr_result = stderr_result_rx.recv().unwrap_or_default();
 
@@ -862,37 +866,20 @@ fn run_exec_operation_worker<S>(
     let stdout_settings = output_settings(request.stdout);
     let stderr_settings = output_settings(request.stderr);
     let needs_stream = stdout_settings.stream.is_some() || stderr_settings.stream.is_some();
-
-    if needs_stream {
-        let (tx, rx) = mpsc::sync_channel(OUTPUT_CHANNEL_CAPACITY);
-        let label_preview = truncate_command_preview(&request.label);
-        match spawn_output_writer(
+    let stream_writer = needs_stream.then(|| {
+        Arc::new(Mutex::new(ExecStreamWriter::new(
             request.seq,
-            label_preview,
-            rx,
+            truncate_command_preview(&request.label),
             writer.clone(),
-            exec_cancel.clone(),
-            setup.drain_cancel(),
-            spawner.clone(),
-        ) {
-            Ok(handle) => setup.set_output_writer(tx, handle),
-            Err(e) => {
-                setup.abort_wait_failed(
-                    &exec_cancel,
-                    &completion,
-                    &format!("failed to spawn exec output writer thread: {e}"),
-                );
-                return;
-            }
-        }
-    }
+        )))
+    });
 
     let stdout_spawn = spawn_exec_operation_drain(
         stdout,
         DrainWorker {
             stream: ExecOutputStream::Stdout,
             policy: stdout_settings,
-            output_tx: setup.output_tx(),
+            stream_writer: stream_writer.clone(),
             drain_cancel: setup.drain_cancel(),
             exec_cancel: exec_cancel.clone(),
             drain_done_tx: setup.drain_done_tx(),
@@ -918,7 +905,7 @@ fn run_exec_operation_worker<S>(
         DrainWorker {
             stream: ExecOutputStream::Stderr,
             policy: stderr_settings,
-            output_tx: setup.output_tx(),
+            stream_writer,
             drain_cancel: setup.drain_cancel(),
             exec_cancel: exec_cancel.clone(),
             drain_done_tx: setup.drain_done_tx(),
@@ -1031,76 +1018,6 @@ fn stream_config(policy: ExecOutputPolicy) -> Option<BoundedStreamConfig> {
     }
 }
 
-fn spawn_output_writer<S>(
-    seq: u32,
-    label_preview: String,
-    rx: Receiver<StreamEvent>,
-    writer: GuestWriter,
-    exec_cancel: Arc<AtomicBool>,
-    drain_cancel: Arc<AtomicBool>,
-    spawner: S,
-) -> io::Result<JoinHandle<()>>
-where
-    S: ThreadSpawner,
-{
-    spawner.spawn_unit(
-        THREAD_EXEC_OPERATION_OUTPUT,
-        Box::new(move || {
-            let mut output_seq = 0u32;
-            for event in rx {
-                if exec_cancel.load(Ordering::Acquire) {
-                    break;
-                }
-                let payload = match vsock_proto::encode_exec_output(
-                    event.stream,
-                    output_seq,
-                    &event.chunk,
-                    event.truncated,
-                ) {
-                    Ok(payload) => payload,
-                    Err(e) => {
-                        log(
-                            "ERROR",
-                            &format!(
-                                "exec operation: failed to encode output seq={seq} label={label_preview}: {e}"
-                            ),
-                        );
-                        exec_cancel.store(true, Ordering::Release);
-                        drain_cancel.store(true, Ordering::Release);
-                        break;
-                    }
-                };
-                output_seq = output_seq.wrapping_add(1);
-                let frame = match vsock_proto::encode(MSG_EXEC_OUTPUT, seq, &payload) {
-                    Ok(frame) => frame,
-                    Err(e) => {
-                        log(
-                            "ERROR",
-                            &format!(
-                                "exec operation: failed to encode output frame seq={seq} label={label_preview}: {e}"
-                            ),
-                        );
-                        exec_cancel.store(true, Ordering::Release);
-                        drain_cancel.store(true, Ordering::Release);
-                        break;
-                    }
-                };
-                if let Err(e) = writer.write_frame(&frame) {
-                    log(
-                        "WARN",
-                        &format!(
-                            "exec operation: failed to send output chunk seq={seq} label={label_preview}: {e}"
-                        ),
-                    );
-                    exec_cancel.store(true, Ordering::Release);
-                    drain_cancel.store(true, Ordering::Release);
-                    break;
-                }
-            }
-        }),
-    )
-}
-
 fn spawn_exec_operation_drain<R, S>(
     pipe: R,
     worker: DrainWorker,
@@ -1113,7 +1030,7 @@ where
     let DrainWorker {
         stream,
         policy,
-        output_tx,
+        stream_writer,
         drain_cancel,
         exec_cancel,
         drain_done_tx,
@@ -1132,19 +1049,38 @@ where
                 policy.capture_limit_bytes,
                 policy.stream,
                 |chunk, truncated| {
-                    let Some(tx) = &output_tx else {
+                    let Some(stream_writer) = &stream_writer else {
                         return true;
                     };
                     if exec_cancel.load(Ordering::Acquire) || drain_cancel.load(Ordering::Acquire) {
                         return false;
                     }
-                    match tx.send(StreamEvent {
-                        stream,
-                        chunk: chunk.to_vec(),
-                        truncated,
-                    }) {
+                    let mut writer = stream_writer.lock().unwrap_or_else(|e| e.into_inner());
+                    if exec_cancel.load(Ordering::Acquire) || drain_cancel.load(Ordering::Acquire) {
+                        return false;
+                    }
+                    match writer.write_output(stream, chunk, truncated) {
                         Ok(()) => true,
-                        Err(_) => {
+                        Err(ExecStreamWriteError::Encode(e)) => {
+                            log(
+                                "ERROR",
+                                &format!(
+                                    "exec operation: failed to encode output seq={} label={}: {e}",
+                                    writer.seq, writer.label_preview
+                                ),
+                            );
+                            exec_cancel.store(true, Ordering::Release);
+                            drain_cancel.store(true, Ordering::Release);
+                            false
+                        }
+                        Err(ExecStreamWriteError::Write(e)) => {
+                            log(
+                                "WARN",
+                                &format!(
+                                    "exec operation: failed to send output chunk seq={} label={}: {e}",
+                                    writer.seq, writer.label_preview
+                                ),
+                            );
                             exec_cancel.store(true, Ordering::Release);
                             drain_cancel.store(true, Ordering::Release);
                             false
@@ -1559,12 +1495,6 @@ fn log_exec_terminal_if_notable(
     }
 }
 
-fn join_output_writer(handle: Option<JoinHandle<()>>) {
-    if let Some(handle) = handle {
-        let _ = handle.join();
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1574,7 +1504,7 @@ mod tests {
     use std::net::Shutdown;
     use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
     use std::os::unix::net::UnixStream;
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
 
     fn read_message(stream: &mut UnixStream) -> vsock_proto::RawMessage {
         let mut hdr = [0u8; 4];
@@ -1974,12 +1904,12 @@ mod tests {
     }
 
     #[test]
-    fn output_writer_spawn_failure_returns_wait_failed_and_cleans_registry() {
-        let (guest, mut host) = UnixStream::pair().unwrap();
-        host.set_read_timeout(Some(Duration::from_secs(3))).unwrap();
+    fn stream_write_failure_cleans_registry() {
+        let (guest, host) = UnixStream::pair().unwrap();
+        drop(host);
         let writer = GuestWriter::new(guest);
         let registry = ExecOperationRegistry::default();
-        let mut request = request(44, "sleep 60");
+        let mut request = request(44, "printf output");
         request.stdout = ExecOutputPolicy::Stream {
             limit_bytes: 64,
             chunk_limit_bytes: 8,
@@ -1991,16 +1921,21 @@ mod tests {
             writer,
             Arc::new(AtomicBool::new(false)),
             registry.clone(),
-            FailingThreadSpawner::fail_once(THREAD_EXEC_OPERATION_OUTPUT),
+            SystemThreadSpawner,
         )
         .unwrap();
 
-        let msg = read_message(&mut host);
-        assert_eq!(msg.msg_type, MSG_EXEC_RESULT);
-        assert_eq!(msg.seq, 44);
-        let result = vsock_proto::decode_exec_result(&msg.payload).unwrap();
-        assert_eq!(result.termination, ExecTermination::WaitFailed);
-        assert!(result.diagnostic.contains("output writer thread"));
-        assert_registry_released(&registry, 44);
+        let started = Instant::now();
+        loop {
+            if let Ok(registration) = registry.register(44, "released") {
+                drop(registration);
+                break;
+            }
+            assert!(
+                started.elapsed() < Duration::from_secs(5),
+                "exec operation registry entry for seq=44 was not released"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
     }
 }

--- a/crates/vsock-guest/src/exec_operation.rs
+++ b/crates/vsock-guest/src/exec_operation.rs
@@ -1055,7 +1055,15 @@ where
                     if exec_cancel.load(Ordering::Acquire) || drain_cancel.load(Ordering::Acquire) {
                         return false;
                     }
-                    let mut writer = stream_writer.lock().unwrap_or_else(|e| e.into_inner());
+                    let mut writer = match stream_writer.lock() {
+                        Ok(writer) => writer,
+                        Err(_) => {
+                            log("ERROR", "exec operation: stream writer mutex poisoned");
+                            exec_cancel.store(true, Ordering::Release);
+                            drain_cancel.store(true, Ordering::Release);
+                            return false;
+                        }
+                    };
                     if exec_cancel.load(Ordering::Acquire) || drain_cancel.load(Ordering::Acquire) {
                         return false;
                     }

--- a/crates/vsock-guest/tests/connection/exec_output.rs
+++ b/crates/vsock-guest/tests/connection/exec_output.rs
@@ -71,7 +71,7 @@ fn exec_operation_stream_only_stdout_stderr_success() {
 }
 
 #[test]
-fn exec_operation_stream_handles_more_chunks_than_output_queue_capacity() {
+fn exec_operation_stream_handles_many_small_chunks() {
     let (handle, mut host_stream) = start_guest_connection();
     let expected = "x".repeat(96);
     let command = format!("printf {expected}");

--- a/crates/vsock-guest/tests/connection/exec_output.rs
+++ b/crates/vsock-guest/tests/connection/exec_output.rs
@@ -109,7 +109,7 @@ fn exec_operation_stream_sequences_many_stdout_stderr_chunks() {
     send_exec_start(
         &mut host_stream,
         124,
-        "for i in $(seq 1 64); do printf o; printf e >&2; done",
+        "i=0; while [ \"$i\" -lt 64 ]; do printf o; printf e >&2; i=$((i + 1)); done",
         5000,
         ExecOutputPolicy::Stream {
             limit_bytes: expected_stdout.len() as u32,

--- a/crates/vsock-guest/tests/connection/exec_output.rs
+++ b/crates/vsock-guest/tests/connection/exec_output.rs
@@ -101,6 +101,39 @@ fn exec_operation_stream_handles_many_small_chunks() {
 }
 
 #[test]
+fn exec_operation_stream_sequences_many_stdout_stderr_chunks() {
+    let (handle, mut host_stream) = start_guest_connection();
+    let expected_stdout = "o".repeat(64);
+    let expected_stderr = "e".repeat(64);
+
+    send_exec_start(
+        &mut host_stream,
+        124,
+        "for i in $(seq 1 64); do printf o; printf e >&2; done",
+        5000,
+        ExecOutputPolicy::Stream {
+            limit_bytes: expected_stdout.len() as u32,
+            chunk_limit_bytes: 1,
+        },
+        ExecOutputPolicy::Stream {
+            limit_bytes: expected_stderr.len() as u32,
+            chunk_limit_bytes: 1,
+        },
+    );
+    let (chunks, result) = read_exec_result(&mut host_stream, 124);
+
+    assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
+    assert_eq!(stdout_data(&chunks), expected_stdout.as_bytes());
+    assert_eq!(stderr_data(&chunks), expected_stderr.as_bytes());
+    assert_eq!(chunks.len(), expected_stdout.len() + expected_stderr.len());
+    for (expected_seq, chunk) in chunks.iter().enumerate() {
+        assert_eq!(chunk.output_seq, expected_seq as u32);
+    }
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
 fn exec_operation_capture_and_stream_success() {
     let (handle, mut host_stream) = start_guest_connection();
 

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -166,8 +166,9 @@ pub use payloads::exec_operation::{
     ExecTermination, ExecTimeoutPolicy, MAX_EXEC_STDIN_BYTES, decode_exec_cancel,
     decode_exec_control, decode_exec_control_result, decode_exec_output, decode_exec_result,
     decode_exec_start, decode_exec_started, encode_exec_cancel, encode_exec_control,
-    encode_exec_control_result, encode_exec_output, encode_exec_result, encode_exec_start,
-    encode_exec_start_with_expected_exit_codes, encode_exec_started,
+    encode_exec_control_result, encode_exec_output, encode_exec_output_frame_into,
+    encode_exec_result, encode_exec_start, encode_exec_start_with_expected_exit_codes,
+    encode_exec_started,
 };
 pub use payloads::write_file::{
     decode_write_file, decode_write_file_result, encode_private_write_file, encode_write_file,

--- a/crates/vsock-proto/src/payloads/exec_operation.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation.rs
@@ -8,7 +8,10 @@ pub use control::{
     DecodedExecControl, DecodedExecControlResult, decode_exec_control, decode_exec_control_result,
     encode_exec_control, encode_exec_control_result,
 };
-pub use output::{DecodedExecOutput, ExecOutputStream, decode_exec_output, encode_exec_output};
+pub use output::{
+    DecodedExecOutput, ExecOutputStream, decode_exec_output, encode_exec_output,
+    encode_exec_output_frame_into,
+};
 pub use result::{
     DecodedExecResult, ExecCapturedOutput, ExecTermination, decode_exec_result, encode_exec_result,
 };

--- a/crates/vsock-proto/src/payloads/exec_operation/output.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/output.rs
@@ -3,7 +3,7 @@ use crate::read::{
     checked_payload_len_add, ensure_payload_fits_message, ensure_u32_len, expect_consumed,
     read_slice, read_u8, read_u32,
 };
-use crate::wire::EXEC_OUTPUT_FLAG_TRUNCATED;
+use crate::wire::{EXEC_OUTPUT_FLAG_TRUNCATED, HEADER_SIZE, MIN_BODY_SIZE, MSG_EXEC_OUTPUT};
 
 const EXEC_OUTPUT_STREAM_STDOUT: u8 = 0x00;
 const EXEC_OUTPUT_STREAM_STDERR: u8 = 0x01;
@@ -43,11 +43,53 @@ pub fn encode_exec_output(
     chunk: &[u8],
     truncated: bool,
 ) -> Result<Vec<u8>, ProtocolError> {
+    let (chunk_len, payload_len) = validate_exec_output_payload(chunk)?;
+
+    let mut p = Vec::with_capacity(payload_len);
+    append_exec_output_payload(&mut p, stream, output_seq, chunk, chunk_len, truncated);
+    Ok(p)
+}
+
+/// Encode a full exec_output frame into `frame`.
+///
+/// The resulting frame uses the same bytes as
+/// `encode(MSG_EXEC_OUTPUT, seq, &encode_exec_output(...))` without allocating
+/// separate payload and frame vectors.
+pub fn encode_exec_output_frame_into(
+    frame: &mut Vec<u8>,
+    seq: u32,
+    stream: ExecOutputStream,
+    output_seq: u32,
+    chunk: &[u8],
+    truncated: bool,
+) -> Result<(), ProtocolError> {
+    frame.clear();
+    let (chunk_len, payload_len) = validate_exec_output_payload(chunk)?;
+    let body_len = MIN_BODY_SIZE + payload_len;
+
+    frame.reserve(HEADER_SIZE + body_len);
+    frame.extend_from_slice(&(body_len as u32).to_be_bytes());
+    frame.push(MSG_EXEC_OUTPUT);
+    frame.extend_from_slice(&seq.to_be_bytes());
+    append_exec_output_payload(frame, stream, output_seq, chunk, chunk_len, truncated);
+    Ok(())
+}
+
+fn validate_exec_output_payload(chunk: &[u8]) -> Result<(u32, usize), ProtocolError> {
     let chunk_len = ensure_u32_len("chunk", chunk.len())?;
     let payload_len = checked_payload_len_add(1 + 4 + 1 + 4, chunk.len())?;
     ensure_payload_fits_message(payload_len)?;
+    Ok((chunk_len, payload_len))
+}
 
-    let mut p = Vec::with_capacity(payload_len);
+fn append_exec_output_payload(
+    p: &mut Vec<u8>,
+    stream: ExecOutputStream,
+    output_seq: u32,
+    chunk: &[u8],
+    chunk_len: u32,
+    truncated: bool,
+) {
     p.push(match stream {
         ExecOutputStream::Stdout => EXEC_OUTPUT_STREAM_STDOUT,
         ExecOutputStream::Stderr => EXEC_OUTPUT_STREAM_STDERR,
@@ -60,7 +102,6 @@ pub fn encode_exec_output(
     });
     p.extend_from_slice(&chunk_len.to_be_bytes());
     p.extend_from_slice(chunk);
-    Ok(p)
 }
 
 /// Decode exec_output payload into a [`DecodedExecOutput`] struct.

--- a/crates/vsock-proto/src/payloads/exec_operation/tests/exec_output.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/tests/exec_output.rs
@@ -1,5 +1,7 @@
 use super::super::*;
 use super::shared::{ExecOutputLayout, set_byte_at};
+use crate::wire::MAX_PAYLOAD_SIZE;
+use crate::{MSG_EXEC_OUTPUT, encode};
 
 #[test]
 fn exec_output_roundtrip_stdout() {
@@ -24,6 +26,31 @@ fn exec_output_roundtrip_stderr_truncated() {
     assert_eq!(decoded.chunk, b"warn");
     assert!(decoded.truncated);
 }
+
+#[test]
+fn exec_output_frame_into_matches_composed_encoding() {
+    let payload = encode_exec_output(ExecOutputStream::Stderr, 8, b"warn", true).unwrap();
+    let expected = encode(MSG_EXEC_OUTPUT, 42, &payload).unwrap();
+    let mut frame = b"stale frame bytes".to_vec();
+
+    encode_exec_output_frame_into(&mut frame, 42, ExecOutputStream::Stderr, 8, b"warn", true)
+        .unwrap();
+
+    assert_eq!(frame, expected);
+}
+
+#[test]
+fn exec_output_frame_into_rejects_oversized_chunk() {
+    let chunk = vec![0u8; MAX_PAYLOAD_SIZE - 9];
+    let mut frame = b"stale frame bytes".to_vec();
+    let err =
+        encode_exec_output_frame_into(&mut frame, 42, ExecOutputStream::Stdout, 1, &chunk, false)
+            .unwrap_err();
+
+    assert!(matches!(err, ProtocolError::MessageTooLarge(_)));
+    assert!(frame.is_empty());
+}
+
 #[test]
 fn exec_output_rejects_invalid_stream_flags_and_trailing_bytes() {
     let payload = encode_exec_output(ExecOutputStream::Stdout, 1, b"chunk", false).unwrap();


### PR DESCRIPTION
## Summary
- add a reusable exec-output frame encoder that writes directly into a caller-owned buffer
- replace the guest exec output writer thread/channel with a shared per-exec stream writer used from stdout/stderr drain callbacks
- keep stream ordering with a combined output sequence, preserve cancellation on stream write failures, and update stream tests for the queue-free path

Closes #19006

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo test --manifest-path crates/Cargo.toml -p vsock-proto -p vsock-guest -p vsock-host
- cargo test --manifest-path crates/Cargo.toml -p vsock-guest exec_operation_stream
- cargo clippy --manifest-path crates/Cargo.toml -p vsock-proto -p vsock-guest -p vsock-host --all-targets --all-features -- -D warnings
- pre-commit hook: crates cargo-fmt, crates cargo-clippy, crates cargo-doc, commitlint