### PR TITLE
fix(mitm-addon): bound JSONL shutdown control waits

### DIFF
--- a/crates/runner/mitm-addon/src/jsonl_writer.py
+++ b/crates/runner/mitm-addon/src/jsonl_writer.py
@@ -3,6 +3,7 @@
 import os
 import queue
 import threading
+import time
 from collections import defaultdict
 from contextlib import suppress
 from dataclasses import dataclass
@@ -11,6 +12,8 @@ from mitmproxy import ctx
 
 MAX_PENDING_JSONL_WRITES = 4096
 MAX_PENDING_JSONL_BYTES = 32 * 1024 * 1024
+JSONL_CONTROL_QUEUE_SLOTS = 1
+SHUTDOWN_JOIN_TIMEOUT_SECONDS = 1.0
 
 
 @dataclass(frozen=True)
@@ -24,19 +27,23 @@ class _WriteItem:
 _STOP = object()
 _lock = threading.Lock()
 _condition = threading.Condition(_lock)
-_queue: queue.Queue[_WriteItem | object] = queue.Queue(maxsize=MAX_PENDING_JSONL_WRITES)
+_queue: queue.Queue[_WriteItem | object] = queue.Queue(
+    maxsize=MAX_PENDING_JSONL_WRITES + JSONL_CONTROL_QUEUE_SLOTS
+)
 _worker: threading.Thread | None = None
 _shutdown = False
+_stop_enqueued = False
 _accepted_by_path: defaultdict[str, int] = defaultdict(int)
 _completed_by_path: defaultdict[str, int] = defaultdict(int)
 _flush_waiters_by_path: defaultdict[str, int] = defaultdict(int)
 _pending_bytes = 0
+_queued_writes = 0
 _drop_warning_logged = False
 
 
 def write_jsonl_line(log_path: str, line: bytes, log_name: str) -> None:
     """Queue a JSONL line for best-effort append without blocking hook latency."""
-    global _pending_bytes
+    global _pending_bytes, _queued_writes
 
     if not log_path:
         return
@@ -47,7 +54,10 @@ def write_jsonl_line(log_path: str, line: bytes, log_name: str) -> None:
             _warn(f"Skipping {log_name} log write after JSONL writer shutdown")
             return
         line_size = len(line)
-        if _pending_bytes + line_size > MAX_PENDING_JSONL_BYTES:
+        if (
+            _queued_writes >= MAX_PENDING_JSONL_WRITES
+            or _pending_bytes + line_size > MAX_PENDING_JSONL_BYTES
+        ):
             dropped = True
         elif not _ensure_worker_locked():
             _warn(f"Failed to start JSONL writer for {log_name} log")
@@ -67,22 +77,32 @@ def write_jsonl_line(log_path: str, line: bytes, log_name: str) -> None:
             else:
                 _accepted_by_path[log_path] = sequence
                 _pending_bytes += line_size
+                _queued_writes += 1
 
     if dropped:
         _warn_drop_once(log_name)
 
 
-def flush_log_path(log_path: str) -> None:
+def flush_log_path(log_path: str, *, timeout: float | None = None) -> bool:
     """Wait until all writes accepted so far for ``log_path`` are completed."""
     if not log_path:
-        return
+        return True
 
     with _condition:
         target = _accepted_by_path.get(log_path, 0)
+        deadline = None if timeout is None else time.monotonic() + timeout
         _increment_flush_waiter_locked(log_path)
         try:
             while _completed_by_path.get(log_path, 0) < target:
-                _condition.wait()
+                if deadline is None:
+                    _condition.wait()
+                    continue
+
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return False
+                _condition.wait(remaining)
+            return True
         finally:
             _decrement_flush_waiter_locked(log_path)
             _prune_completed_path_locked(log_path, target)
@@ -104,43 +124,58 @@ def flush_all_logs() -> None:
                 _prune_completed_path_locked(path, target)
 
 
-def shutdown_writer() -> None:
+def shutdown_writer(*, timeout: float | None = SHUTDOWN_JOIN_TIMEOUT_SECONDS) -> bool:
     """Drain accepted writes and stop the background writer."""
-    global _worker, _shutdown
+    global _worker, _shutdown, _stop_enqueued
 
+    failed_to_signal_stop = False
     with _condition:
         worker = _worker
         if worker is None:
             _shutdown = True
-            return
-        should_signal_stop = not _shutdown
+            return True
         _shutdown = True
+        should_signal_stop = not _stop_enqueued
+        if should_signal_stop:
+            try:
+                _queue.put_nowait(_STOP)
+            except queue.Full:
+                failed_to_signal_stop = True
+            else:
+                _stop_enqueued = True
 
-    if should_signal_stop:
-        _queue.put(_STOP)
+    if failed_to_signal_stop:
+        _warn("Failed to signal JSONL writer shutdown because the control queue is full")
     if worker is not threading.current_thread():
-        worker.join()
+        worker.join(timeout=timeout)
+        if worker.is_alive():
+            _warn("JSONL writer shutdown timed out")
+            return False
 
     with _condition:
         if _worker is worker:
             _worker = None
+            _stop_enqueued = False
         _condition.notify_all()
+    return True
 
 
 def reset_for_tests() -> None:
     """Reset writer state between tests."""
-    global _queue, _worker, _shutdown, _accepted_by_path, _completed_by_path, _flush_waiters_by_path
-    global _pending_bytes, _drop_warning_logged
+    global _queue, _worker, _shutdown, _stop_enqueued, _accepted_by_path, _completed_by_path
+    global _flush_waiters_by_path, _pending_bytes, _queued_writes, _drop_warning_logged
 
-    shutdown_writer()
+    shutdown_writer(timeout=None)
     with _condition:
-        _queue = queue.Queue(maxsize=MAX_PENDING_JSONL_WRITES)
+        _queue = queue.Queue(maxsize=MAX_PENDING_JSONL_WRITES + JSONL_CONTROL_QUEUE_SLOTS)
         _worker = None
         _shutdown = False
+        _stop_enqueued = False
         _accepted_by_path = defaultdict(int)
         _completed_by_path = defaultdict(int)
         _flush_waiters_by_path = defaultdict(int)
         _pending_bytes = 0
+        _queued_writes = 0
         _drop_warning_logged = False
         _condition.notify_all()
 
@@ -224,7 +259,7 @@ def _append_lines(log_path: str, content: bytes) -> None:
 
 
 def _complete_item(item: _WriteItem) -> None:
-    global _pending_bytes
+    global _pending_bytes, _queued_writes
 
     with _condition:
         _completed_by_path[item.log_path] = max(
@@ -232,6 +267,7 @@ def _complete_item(item: _WriteItem) -> None:
             item.sequence,
         )
         _pending_bytes = max(0, _pending_bytes - len(item.line))
+        _queued_writes = max(0, _queued_writes - 1)
         _prune_completed_path_locked(item.log_path, item.sequence)
         _condition.notify_all()
 

--- a/crates/runner/mitm-addon/src/logging_utils.py
+++ b/crates/runner/mitm-addon/src/logging_utils.py
@@ -34,9 +34,9 @@ def _write_jsonl_entry(log_path: str, entry: dict, log_name: str) -> None:
     jsonl_writer.write_jsonl_line(log_path, line, log_name)
 
 
-def flush_log_path(log_path: str) -> None:
+def flush_log_path(log_path: str, *, timeout: float | None = None) -> bool:
     """Flush accepted JSONL writes for a path."""
-    jsonl_writer.flush_log_path(log_path)
+    return jsonl_writer.flush_log_path(log_path, timeout=timeout)
 
 
 def flush_all_logs() -> None:

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -231,6 +231,7 @@ _jsonl_flush_state_write_lock = threading.Lock()
 _last_jsonl_flush_request_id: str | None = None
 _JSONL_FLUSH_REQUEST_FILE = "jsonl-flush-request"
 _JSONL_FLUSH_STATE_FILE = "jsonl-flush-state"
+RUNNER_JSONL_FLUSH_TIMEOUT_SECONDS = 4.0
 
 # ============================================================================
 # Addon Configuration
@@ -391,14 +392,18 @@ def _flush_jsonl_for_runner_request() -> None:
 
     log_path, flush_request_id = request
     pending = 0
+    timed_out = False
     try:
-        flush_log_path(log_path)
+        if not flush_log_path(log_path, timeout=RUNNER_JSONL_FLUSH_TIMEOUT_SECONDS):
+            pending = 1
+            timed_out = True
+            ctx.log.warn("JSONL flush did not complete before timeout")
     except Exception as exc:
         pending = 1
         ctx.log.warn(f"Failed to flush JSONL logs after runner request ({type(exc).__name__})")
     finally:
         state_written = _write_jsonl_flush_state(log_path, flush_request_id, pending=pending)
-        if pending == 0 and state_written:
+        if state_written and (pending == 0 or timed_out):
             _last_jsonl_flush_request_id = flush_request_id
 
 

--- a/crates/runner/mitm-addon/tests/test_jsonl_writer.py
+++ b/crates/runner/mitm-addon/tests/test_jsonl_writer.py
@@ -36,13 +36,16 @@ def test_flush_prunes_completed_path_state(tmp_path):
         release_append.wait()
         original_append_lines(path, content)
 
+    def flush_log_path() -> None:
+        jsonl_writer.flush_log_path(log_path)
+
     with patch.object(jsonl_writer, "_append_lines", side_effect=append_lines):
         try:
             jsonl_writer.write_jsonl_line(log_path, b'{"action":"ALLOW"}\n', "network")
             assert append_started.wait(timeout=1)
 
             flush_thread = ThreadUnderTest(
-                target=lambda: jsonl_writer.flush_log_path(log_path),
+                target=flush_log_path,
                 daemon=True,
             )
             flush_thread.start()
@@ -82,14 +85,17 @@ def test_concurrent_flushes_prune_after_all_waiters_complete(tmp_path):
         release_append.wait()
         original_append_lines(path, content)
 
+    def flush_log_path() -> None:
+        jsonl_writer.flush_log_path(log_path)
+
     with patch.object(jsonl_writer, "_append_lines", side_effect=append_lines):
         try:
             jsonl_writer.write_jsonl_line(log_path, b'{"action":"ALLOW"}\n', "network")
             assert append_started.wait(timeout=1)
 
             flush_threads = [
-                ThreadUnderTest(target=lambda: jsonl_writer.flush_log_path(log_path), daemon=True),
-                ThreadUnderTest(target=lambda: jsonl_writer.flush_log_path(log_path), daemon=True),
+                ThreadUnderTest(target=flush_log_path, daemon=True),
+                ThreadUnderTest(target=flush_log_path, daemon=True),
             ]
             for thread in flush_threads:
                 thread.start()
@@ -116,3 +122,67 @@ def test_concurrent_flushes_prune_after_all_waiters_complete(tmp_path):
     assert log_path not in jsonl_writer._completed_by_path
     assert log_path not in jsonl_writer._flush_waiters_by_path
     assert jsonl_writer._pending_bytes == 0
+
+
+def test_shutdown_writer_returns_when_normal_write_backlog_is_full(tmp_path):
+    log_path = str(tmp_path / "net.jsonl")
+    append_started = threading.Event()
+    release_append = threading.Event()
+    shutdown_thread: ThreadUnderTest | None = None
+    original_append_lines = jsonl_writer._append_lines
+
+    def append_lines(path: str, content: bytes) -> None:
+        append_started.set()
+        release_append.wait()
+        original_append_lines(path, content)
+
+    def shutdown_writer() -> None:
+        jsonl_writer.shutdown_writer(timeout=0.01)
+
+    with (
+        patch.object(jsonl_writer, "_append_lines", side_effect=append_lines),
+    ):
+        try:
+            jsonl_writer.write_jsonl_line(log_path, b'{"action":"ALLOW"}\n', "network")
+            assert append_started.wait(timeout=1)
+
+            for _ in range(jsonl_writer.MAX_PENDING_JSONL_WRITES):
+                jsonl_writer.write_jsonl_line(log_path, b'{"action":"ALLOW"}\n', "network")
+
+            shutdown_thread = ThreadUnderTest(
+                target=shutdown_writer,
+                daemon=True,
+            )
+            shutdown_thread.start()
+            shutdown_thread.join(timeout=0.5)
+            shutdown_thread.raise_if_failed()
+            assert not shutdown_thread.is_alive()
+        finally:
+            release_append.set()
+            if shutdown_thread is not None:
+                shutdown_thread.join(timeout=2)
+            jsonl_writer.reset_for_tests()
+
+
+def test_flush_log_path_timeout_returns_false_and_cleans_waiter(tmp_path):
+    log_path = str(tmp_path / "net.jsonl")
+    append_started = threading.Event()
+    release_append = threading.Event()
+    original_append_lines = jsonl_writer._append_lines
+
+    def append_lines(path: str, content: bytes) -> None:
+        append_started.set()
+        release_append.wait()
+        original_append_lines(path, content)
+
+    with patch.object(jsonl_writer, "_append_lines", side_effect=append_lines):
+        try:
+            jsonl_writer.write_jsonl_line(log_path, b'{"action":"ALLOW"}\n', "network")
+            assert append_started.wait(timeout=1)
+
+            assert jsonl_writer.flush_log_path(log_path, timeout=0.01) is False
+            assert jsonl_writer._flush_waiters_by_path.get(log_path, 0) == 0
+            assert jsonl_writer._completed_by_path.get(log_path, 0) == 0
+        finally:
+            release_append.set()
+            jsonl_writer.reset_for_tests()

--- a/crates/runner/mitm-addon/tests/test_runner_usage_flush_signal.py
+++ b/crates/runner/mitm-addon/tests/test_runner_usage_flush_signal.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+import jsonl_writer
 import logging_utils
 import mitm_addon
 import usage
@@ -274,6 +275,59 @@ class TestRunnerUsageFlushSignal:
         assert "RuntimeError" in warning
         assert "secret" not in warning
 
+    def test_jsonl_flush_timeout_writes_pending_state_and_does_not_reprocess_request(
+        self, runner_usage_flush_files: RunnerUsageFlushFiles
+    ):
+        log_path = runner_usage_flush_files.write_jsonl_flush_request()
+        append_started = threading.Event()
+        release_append = threading.Event()
+        original_append_lines = jsonl_writer._append_lines
+        log = MagicMock()
+
+        def append_lines(path: str, content: bytes) -> None:
+            append_started.set()
+            release_append.wait()
+            original_append_lines(path, content)
+
+        with (
+            patch.object(mitm_addon, "__file__", str(runner_usage_flush_files.addon_file)),
+            patch.object(jsonl_writer, "_append_lines", side_effect=append_lines),
+            patch.object(
+                mitm_addon,
+                "RUNNER_JSONL_FLUSH_TIMEOUT_SECONDS",
+                0.01,
+                create=True,
+            ),
+            patch.object(mitm_addon.ctx, "log", log, create=True),
+        ):
+            try:
+                logging_utils.log_network_entry(str(log_path), {"action": "ALLOW"})
+                assert append_started.wait(timeout=1)
+
+                mitm_addon._handle_runner_usage_flush_signal(0, None)
+                wait_for_usage_flush_worker_to_stop()
+
+                state = json.loads(runner_usage_flush_files.jsonl_flush_state_path.read_text())
+                assert state == {
+                    "pid": state["pid"],
+                    "usageStateId": "runner-state",
+                    "updatedAtMs": state["updatedAtMs"],
+                    "flushRequestId": "jsonl-request-1",
+                    "path": str(log_path),
+                    "pending": 1,
+                }
+
+                with patch.object(mitm_addon, "flush_log_path") as retry_flush:
+                    mitm_addon._handle_runner_usage_flush_signal(0, None)
+                    wait_for_usage_flush_worker_to_stop()
+
+                retry_flush.assert_not_called()
+            finally:
+                release_append.set()
+                jsonl_writer.reset_for_tests()
+
+        log.warn.assert_called_once_with("JSONL flush did not complete before timeout")
+
     def test_signal_handler_does_not_reprocess_acknowledged_jsonl_flush_request(
         self, runner_usage_flush_files: RunnerUsageFlushFiles
     ):
@@ -289,7 +343,10 @@ class TestRunnerUsageFlushSignal:
             mitm_addon._handle_runner_usage_flush_signal(0, None)
             wait_for_usage_flush_worker_to_stop()
 
-        flush_log_path.assert_called_once_with(str(log_path))
+        flush_log_path.assert_called_once_with(
+            str(log_path),
+            timeout=mitm_addon.RUNNER_JSONL_FLUSH_TIMEOUT_SECONDS,
+        )
 
     def test_jsonl_flush_failure_is_retryable(
         self, runner_usage_flush_files: RunnerUsageFlushFiles
@@ -312,8 +369,14 @@ class TestRunnerUsageFlushSignal:
                 mitm_addon._handle_runner_usage_flush_signal(0, None)
                 wait_for_usage_flush_worker_to_stop()
 
-        failed_flush.assert_called_once_with(str(log_path))
-        retry_flush.assert_called_once_with(str(log_path))
+        failed_flush.assert_called_once_with(
+            str(log_path),
+            timeout=mitm_addon.RUNNER_JSONL_FLUSH_TIMEOUT_SECONDS,
+        )
+        retry_flush.assert_called_once_with(
+            str(log_path),
+            timeout=mitm_addon.RUNNER_JSONL_FLUSH_TIMEOUT_SECONDS,
+        )
         state = json.loads(runner_usage_flush_files.jsonl_flush_state_path.read_text())
         assert state["pending"] == 0
 


### PR DESCRIPTION
## Summary

Fixes #19007.

This keeps the existing `queue.Queue` JSONL writer model, but separates normal best-effort data backlog from shutdown control capacity:

- reserves one extra queue slot for the `_STOP` control sentinel
- tracks normal accepted writes separately with `_queued_writes`
- adds a bounded shutdown join so stalled filesystem I/O cannot hang `done()` forever
- adds optional `flush_log_path(..., timeout=...)`
- bounds runner-triggered JSONL flushes and writes `pending=1` when the Python-side flush times out

Healthy shutdown still drains accepted writes. If filesystem I/O is stalled, JSONL network/proxy logs remain best-effort and the control path now warns and returns instead of blocking indefinitely.

## Tests

- `.venv/bin/pytest tests/test_jsonl_writer.py tests/test_runner_usage_flush_signal.py tests/test_logging_utils.py`
- `.venv/bin/pytest tests/`
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/basedpyright -p .`
