### PR TITLE
perf: move resume history download to runner

### DIFF
--- a/crates/runner/src/cmd/start/tests/idle_reuse.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse.rs
@@ -27,10 +27,10 @@ fn context_with_session_opt(
 ) -> crate::types::ExecutionContext {
     let mut ctx = minimal_context(run_id);
     if let Some(sid) = session_id {
-        ctx.resume_session = Some(crate::types::ResumeSession {
-            cli_agent_session_id: sid.to_string(),
-            session_history: String::new(),
-        });
+        ctx.resume_session = Some(crate::types::ResumeSession::inline(
+            sid.to_string(),
+            String::new(),
+        ));
     }
     ctx
 }

--- a/crates/runner/src/cmd/start/tests/support/jobs.rs
+++ b/crates/runner/src/cmd/start/tests/support/jobs.rs
@@ -45,9 +45,9 @@ pub(in super::super) fn context_with_session(
     session_id: &str,
 ) -> crate::types::ExecutionContext {
     let mut ctx = minimal_context(run_id);
-    ctx.resume_session = Some(crate::types::ResumeSession {
-        cli_agent_session_id: session_id.into(),
-        session_history: String::new(),
-    });
+    ctx.resume_session = Some(crate::types::ResumeSession::inline(
+        session_id.into(),
+        String::new(),
+    ));
     ctx
 }

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -339,9 +339,9 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
 
     // 4. Restore session history. Hash-backed history downloads start before
     // guest prep/storage download, then materialize here right before restore.
-    let materialized_resume_session = match session_history_materializer.finish(&cancel).await {
+    let downloaded_resume_session = match session_history_materializer.finish(&cancel).await {
         SessionHistoryMaterialization::Missing => None,
-        SessionHistoryMaterialization::Ready(session) => Some(session),
+        SessionHistoryMaterialization::Ready => None,
         SessionHistoryMaterialization::Downloaded { session, elapsed } => {
             telemetry.record("session_history_download", elapsed, true, None);
             Some(session)
@@ -357,8 +357,11 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
             return Err(error);
         }
     };
+    let resume_session = downloaded_resume_session
+        .as_ref()
+        .or(context.resume_session.as_ref());
     let mut session_restore_diagnostics = None;
-    if let Some(session) = &materialized_resume_session {
+    if let Some(session) = resume_session {
         let t = Instant::now();
         let result = restore_session(sandbox, context, session).await;
         let err = result.as_ref().err().map(|e| e.to_string());

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -20,6 +20,7 @@ use super::diagnostics::{
 };
 use super::env::{build_env_json, build_user_env_json, write_user_env_file};
 use super::guest_state::{restore_guest_state, sync_guest_timezone};
+use super::session_history_download::{SessionHistoryMaterialization, SessionHistoryMaterializer};
 use super::session_restore::restore_session;
 use super::storage::{apply_storage_fingerprint_reuse, download_storages, guest_download_has_work};
 use super::telemetry::{RunnerSpawnTiming, record_api_latency};
@@ -269,6 +270,8 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         active_input_source,
         spawn_timing,
     } = controls;
+    let session_history_materializer =
+        SessionHistoryMaterializer::start(&config.http, context.resume_session.as_ref());
 
     // 1. Fix guest clock and reseed entropy (must happen before HTTPS calls).
     //    Needed after snapshot restore (frozen clock) and after idle reuse (drifted clock).
@@ -334,9 +337,28 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         result?;
     }
 
-    // 4. Restore session history
+    // 4. Restore session history. Hash-backed history downloads start before
+    // guest prep/storage download, then materialize here right before restore.
+    let materialized_resume_session = match session_history_materializer.finish(&cancel).await {
+        SessionHistoryMaterialization::Missing => None,
+        SessionHistoryMaterialization::Ready(session) => Some(session),
+        SessionHistoryMaterialization::Downloaded { session, elapsed } => {
+            telemetry.record("session_history_download", elapsed, true, None);
+            Some(session)
+        }
+        SessionHistoryMaterialization::Failed { elapsed, error } => {
+            let error_message = error.to_string();
+            telemetry.record(
+                "session_history_download",
+                elapsed,
+                false,
+                Some(&error_message),
+            );
+            return Err(error);
+        }
+    };
     let mut session_restore_diagnostics = None;
-    if let Some(session) = &context.resume_session {
+    if let Some(session) = &materialized_resume_session {
         let t = Instant::now();
         let result = restore_session(sandbox, context, session).await;
         let err = result.as_ref().err().map(|e| e.to_string());

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -30,6 +30,7 @@ mod diagnostics;
 mod env;
 mod guest_state;
 mod sandbox_run;
+mod session_history_download;
 mod session_id;
 mod session_restore;
 mod storage;

--- a/crates/runner/src/executor/session_history_download.rs
+++ b/crates/runner/src/executor/session_history_download.rs
@@ -1,0 +1,419 @@
+use std::time::{Duration, Instant};
+
+use sha2::{Digest, Sha256};
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use crate::error::{RunnerError, RunnerResult};
+use crate::http::HttpClient;
+use crate::types::{ResumeSession, ResumeSessionHistoryRefKind};
+
+const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(30);
+const MAX_SESSION_HISTORY_BYTES: u64 = 128 * 1024 * 1024;
+
+pub(super) enum SessionHistoryMaterializer {
+    Missing,
+    Ready(Option<ResumeSession>),
+    Downloading {
+        started_at: Instant,
+        task: Option<JoinHandle<RunnerResult<ResumeSession>>>,
+    },
+}
+
+pub(super) enum SessionHistoryMaterialization {
+    Missing,
+    Ready(ResumeSession),
+    Downloaded {
+        session: ResumeSession,
+        elapsed: Duration,
+    },
+    Failed {
+        elapsed: Duration,
+        error: RunnerError,
+    },
+}
+
+impl SessionHistoryMaterializer {
+    pub(super) fn start(http: &HttpClient, session: Option<&ResumeSession>) -> Self {
+        let Some(session) = session else {
+            return Self::Missing;
+        };
+        if session.history_ref().is_none() {
+            return Self::Ready(Some(session.clone()));
+        }
+
+        let http = http.clone();
+        let session = session.clone();
+        Self::Downloading {
+            started_at: Instant::now(),
+            task: Some(tokio::spawn(async move {
+                download_resume_session_history(http, session).await
+            })),
+        }
+    }
+
+    pub(super) async fn finish(
+        mut self,
+        cancel: &CancellationToken,
+    ) -> SessionHistoryMaterialization {
+        match &mut self {
+            Self::Missing => SessionHistoryMaterialization::Missing,
+            Self::Ready(session) => {
+                let Some(session) = session.take() else {
+                    return SessionHistoryMaterialization::Failed {
+                        elapsed: Duration::ZERO,
+                        error: RunnerError::Internal(
+                            "session history materializer lost ready session".into(),
+                        ),
+                    };
+                };
+                SessionHistoryMaterialization::Ready(session)
+            }
+            Self::Downloading { started_at, task } => {
+                let started_at = *started_at;
+                let Some(mut task) = task.take() else {
+                    return SessionHistoryMaterialization::Failed {
+                        elapsed: Duration::ZERO,
+                        error: RunnerError::Internal(
+                            "session history materializer lost download task".into(),
+                        ),
+                    };
+                };
+                let result = tokio::select! {
+                    _ = cancel.cancelled() => {
+                        task.abort();
+                        let _ = task.await;
+                        Err(RunnerError::Internal("session history download cancelled".into()))
+                    }
+                    joined = &mut task => {
+                        joined.unwrap_or_else(|error| {
+                            Err(RunnerError::Internal(format!(
+                                "session history download task failed: {error}"
+                            )))
+                        })
+                    }
+                };
+                let elapsed = started_at.elapsed();
+                match result {
+                    Ok(session) => SessionHistoryMaterialization::Downloaded { session, elapsed },
+                    Err(error) => SessionHistoryMaterialization::Failed { elapsed, error },
+                }
+            }
+        }
+    }
+}
+
+impl Drop for SessionHistoryMaterializer {
+    fn drop(&mut self) {
+        if let Self::Downloading {
+            task: Some(task), ..
+        } = self
+        {
+            task.abort();
+        }
+    }
+}
+
+async fn download_resume_session_history(
+    http: HttpClient,
+    session: ResumeSession,
+) -> RunnerResult<ResumeSession> {
+    let history_ref = session
+        .history_ref()
+        .ok_or_else(|| RunnerError::Internal("resume session history ref is missing".into()))?
+        .clone();
+    match history_ref.kind {
+        ResumeSessionHistoryRefKind::Blob => {}
+    }
+    if let Some(expected_size) = history_ref.size
+        && expected_size > MAX_SESSION_HISTORY_BYTES
+    {
+        return Err(RunnerError::Internal(format!(
+            "session history is too large: {expected_size} bytes exceeds {MAX_SESSION_HISTORY_BYTES} bytes"
+        )));
+    }
+
+    let bytes = download_body(&http, &history_ref.url, history_ref.size).await?;
+    if let Some(expected_size) = history_ref.size
+        && bytes.len() as u64 != expected_size
+    {
+        return Err(RunnerError::Internal(format!(
+            "session history size mismatch: expected {expected_size} bytes, got {} bytes",
+            bytes.len()
+        )));
+    }
+
+    let actual_hash = hex::encode(Sha256::digest(&bytes));
+    if actual_hash != history_ref.hash {
+        return Err(RunnerError::Internal(format!(
+            "session history hash mismatch: expected {}, got {actual_hash}",
+            history_ref.hash
+        )));
+    }
+
+    let session_history = String::from_utf8(bytes)
+        .map_err(|error| RunnerError::Internal(format!("session history is not utf-8: {error}")))?;
+    Ok(ResumeSession::inline(
+        session.cli_agent_session_id,
+        session_history,
+    ))
+}
+
+async fn download_body(
+    http: &HttpClient,
+    url: &str,
+    expected_size: Option<u64>,
+) -> RunnerResult<Vec<u8>> {
+    let mut response = http
+        .get(url)
+        .timeout(DOWNLOAD_TIMEOUT)
+        .send()
+        .await
+        .map_err(|error| {
+            RunnerError::Internal(format!(
+                "GET {}: {}",
+                redact_url_query(url),
+                error.without_url()
+            ))
+        })?
+        .error_for_status()
+        .map_err(|error| {
+            RunnerError::Internal(format!(
+                "GET status {}: {}",
+                redact_url_query(url),
+                error.without_url()
+            ))
+        })?;
+
+    if let Some(content_length) = response.content_length() {
+        if content_length > MAX_SESSION_HISTORY_BYTES {
+            return Err(RunnerError::Internal(format!(
+                "session history is too large: {content_length} bytes exceeds {MAX_SESSION_HISTORY_BYTES} bytes"
+            )));
+        }
+        if let Some(expected_size) = expected_size
+            && content_length != expected_size
+        {
+            return Err(RunnerError::Internal(format!(
+                "session history content-length mismatch: expected {expected_size} bytes, got {content_length} bytes"
+            )));
+        }
+    }
+
+    let capacity = expected_size
+        .unwrap_or(64 * 1024)
+        .min(MAX_SESSION_HISTORY_BYTES)
+        .min(usize::MAX as u64) as usize;
+    let mut body = Vec::with_capacity(capacity);
+    let mut downloaded = 0u64;
+    while let Some(chunk) = response.chunk().await.map_err(|error| {
+        RunnerError::Internal(format!(
+            "read {}: {}",
+            redact_url_query(url),
+            error.without_url()
+        ))
+    })? {
+        downloaded += chunk.len() as u64;
+        if downloaded > MAX_SESSION_HISTORY_BYTES {
+            return Err(RunnerError::Internal(format!(
+                "session history is too large: {downloaded} bytes exceeds {MAX_SESSION_HISTORY_BYTES} bytes"
+            )));
+        }
+        body.extend_from_slice(&chunk);
+    }
+
+    Ok(body)
+}
+
+fn redact_url_query(url: &str) -> String {
+    let Some(query_start) = url.find('?') else {
+        return url.to_string();
+    };
+    let fragment = url[query_start + 1..].find('#').map(|index| {
+        let fragment_start = query_start + 1 + index;
+        &url[fragment_start..]
+    });
+    match fragment {
+        Some(fragment) => format!("{}?<redacted>{fragment}", &url[..query_start]),
+        None => format!("{}?<redacted>", &url[..query_start]),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    use super::*;
+    use crate::http::{HttpClient, HttpClientConfig};
+    use crate::types::{
+        ResumeSessionHistory, ResumeSessionHistoryRef, ResumeSessionHistoryRefKind,
+    };
+
+    fn http_client() -> HttpClient {
+        HttpClient::new(HttpClientConfig {
+            api_url: "http://api.test".to_string(),
+            vercel_bypass: None,
+        })
+        .unwrap()
+    }
+
+    fn ref_session(url: String, hash: String, size: Option<u64>) -> ResumeSession {
+        ResumeSession {
+            cli_agent_session_id: "sess-123".to_string(),
+            history: ResumeSessionHistory::Ref {
+                history_ref: ResumeSessionHistoryRef {
+                    kind: ResumeSessionHistoryRefKind::Blob,
+                    hash,
+                    url,
+                    size,
+                },
+            },
+        }
+    }
+
+    async fn serve_once(
+        status: &'static str,
+        body: &'static [u8],
+        content_length: Option<u64>,
+    ) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = [0u8; 1024];
+            let _ = stream.read(&mut request).await;
+            let content_length = content_length.unwrap_or(body.len() as u64);
+            let response = format!(
+                "HTTP/1.1 {status}\r\nContent-Length: {content_length}\r\nConnection: close\r\n\r\n"
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+            stream.write_all(body).await.unwrap();
+        });
+        format!("http://{address}/history.blob?token=secret")
+    }
+
+    #[tokio::test]
+    async fn materializer_downloads_and_verifies_hash() {
+        let body = br#"{"type":"init"}"#;
+        let hash = hex::encode(Sha256::digest(body));
+        let session = ref_session(
+            serve_once("200 OK", body, Some(body.len() as u64)).await,
+            hash,
+            Some(body.len() as u64),
+        );
+
+        let materializer = SessionHistoryMaterializer::start(&http_client(), Some(&session));
+        let result = materializer.finish(&CancellationToken::new()).await;
+
+        match result {
+            SessionHistoryMaterialization::Downloaded { session, .. } => {
+                assert_eq!(session.cli_agent_session_id, "sess-123");
+                assert_eq!(session.session_history(), Some(r#"{"type":"init"}"#));
+            }
+            _ => panic!("expected downloaded session"),
+        }
+    }
+
+    #[tokio::test]
+    async fn materializer_rejects_hash_mismatch_and_redacts_url_query() {
+        let session = ref_session(
+            serve_once("200 OK", b"actual", Some(6)).await,
+            hex::encode(Sha256::digest(b"expected")),
+            Some(6),
+        );
+
+        let result = SessionHistoryMaterializer::start(&http_client(), Some(&session))
+            .finish(&CancellationToken::new())
+            .await;
+
+        match result {
+            SessionHistoryMaterialization::Failed { error, .. } => {
+                let message = error.to_string();
+                assert!(message.contains("hash mismatch"));
+                assert!(!message.contains("token=secret"));
+            }
+            _ => panic!("expected failed download"),
+        }
+    }
+
+    #[tokio::test]
+    async fn materializer_redacts_url_query_from_http_status_error() {
+        let session = ref_session(
+            serve_once("403 Forbidden", b"no", Some(2)).await,
+            hex::encode(Sha256::digest(b"no")),
+            Some(2),
+        );
+
+        let result = SessionHistoryMaterializer::start(&http_client(), Some(&session))
+            .finish(&CancellationToken::new())
+            .await;
+
+        match result {
+            SessionHistoryMaterialization::Failed { error, .. } => {
+                let message = error.to_string();
+                assert!(message.contains("history.blob?<redacted>"));
+                assert!(!message.contains("token=secret"));
+            }
+            _ => panic!("expected failed download"),
+        }
+    }
+
+    #[tokio::test]
+    async fn materializer_rejects_oversized_content_length() {
+        let session = ref_session(
+            serve_once("200 OK", b"", Some(MAX_SESSION_HISTORY_BYTES + 1)).await,
+            hex::encode(Sha256::digest(b"")),
+            None,
+        );
+
+        let result = SessionHistoryMaterializer::start(&http_client(), Some(&session))
+            .finish(&CancellationToken::new())
+            .await;
+
+        match result {
+            SessionHistoryMaterialization::Failed { error, .. } => {
+                assert!(error.to_string().contains("too large"));
+            }
+            _ => panic!("expected failed download"),
+        }
+    }
+
+    #[test]
+    fn redact_url_query_preserves_fragment() {
+        assert_eq!(
+            redact_url_query("https://r2.example.com/blob?sig=secret#frag"),
+            "https://r2.example.com/blob?<redacted>#frag"
+        );
+    }
+
+    #[tokio::test]
+    async fn materializer_reports_cancelled_download() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (_stream, _) = listener.accept().await.unwrap();
+            futures_util::future::pending::<io::Result<()>>().await
+        });
+        let session = ref_session(
+            format!("http://{address}/history.blob?token=secret"),
+            hex::encode(Sha256::digest(b"")),
+            None,
+        );
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+
+        let result = SessionHistoryMaterializer::start(&http_client(), Some(&session))
+            .finish(&cancel)
+            .await;
+
+        match result {
+            SessionHistoryMaterialization::Failed { error, .. } => {
+                assert!(error.to_string().contains("cancelled"));
+            }
+            _ => panic!("expected cancelled download"),
+        }
+    }
+}

--- a/crates/runner/src/executor/session_history_download.rs
+++ b/crates/runner/src/executor/session_history_download.rs
@@ -9,6 +9,7 @@ use crate::http::HttpClient;
 use crate::types::{ResumeSession, ResumeSessionHistoryRefKind};
 
 const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(30);
+// Must stay in sync with RESUME_SESSION_HISTORY_MAX_BYTES in the API contracts.
 const MAX_SESSION_HISTORY_BYTES: u64 = 128 * 1024 * 1024;
 
 pub(super) enum SessionHistoryMaterializer {

--- a/crates/runner/src/executor/session_history_download.rs
+++ b/crates/runner/src/executor/session_history_download.rs
@@ -16,7 +16,7 @@ pub(super) enum SessionHistoryMaterializer {
     Ready(Option<ResumeSession>),
     Downloading {
         started_at: Instant,
-        task: Option<JoinHandle<RunnerResult<ResumeSession>>>,
+        task: Option<JoinHandle<SessionHistoryDownloadTaskResult>>,
     },
 }
 
@@ -33,6 +33,11 @@ pub(super) enum SessionHistoryMaterialization {
     },
 }
 
+pub(super) struct SessionHistoryDownloadTaskResult {
+    elapsed: Duration,
+    result: RunnerResult<ResumeSession>,
+}
+
 impl SessionHistoryMaterializer {
     pub(super) fn start(http: &HttpClient, session: Option<&ResumeSession>) -> Self {
         let Some(session) = session else {
@@ -47,7 +52,7 @@ impl SessionHistoryMaterializer {
         Self::Downloading {
             started_at: Instant::now(),
             task: Some(tokio::spawn(async move {
-                download_resume_session_history(http, session).await
+                download_resume_session_history_timed(http, session).await
             })),
         }
     }
@@ -83,20 +88,33 @@ impl SessionHistoryMaterializer {
                     _ = cancel.cancelled() => {
                         task.abort();
                         let _ = task.await;
-                        Err(RunnerError::Internal("session history download cancelled".into()))
+                        SessionHistoryDownloadTaskResult {
+                            elapsed: started_at.elapsed(),
+                            result: Err(RunnerError::Internal(
+                                "session history download cancelled".into(),
+                            )),
+                        }
                     }
                     joined = &mut task => {
                         joined.unwrap_or_else(|error| {
-                            Err(RunnerError::Internal(format!(
-                                "session history download task failed: {error}"
-                            )))
+                            SessionHistoryDownloadTaskResult {
+                                elapsed: started_at.elapsed(),
+                                result: Err(RunnerError::Internal(format!(
+                                    "session history download task failed: {error}"
+                                ))),
+                            }
                         })
                     }
                 };
-                let elapsed = started_at.elapsed();
-                match result {
-                    Ok(session) => SessionHistoryMaterialization::Downloaded { session, elapsed },
-                    Err(error) => SessionHistoryMaterialization::Failed { elapsed, error },
+                match result.result {
+                    Ok(session) => SessionHistoryMaterialization::Downloaded {
+                        session,
+                        elapsed: result.elapsed,
+                    },
+                    Err(error) => SessionHistoryMaterialization::Failed {
+                        elapsed: result.elapsed,
+                        error,
+                    },
                 }
             }
         }
@@ -111,6 +129,18 @@ impl Drop for SessionHistoryMaterializer {
         {
             task.abort();
         }
+    }
+}
+
+async fn download_resume_session_history_timed(
+    http: HttpClient,
+    session: ResumeSession,
+) -> SessionHistoryDownloadTaskResult {
+    let started_at = Instant::now();
+    let result = download_resume_session_history(http, session).await;
+    SessionHistoryDownloadTaskResult {
+        elapsed: started_at.elapsed(),
+        result,
     }
 }
 

--- a/crates/runner/src/executor/session_history_download.rs
+++ b/crates/runner/src/executor/session_history_download.rs
@@ -13,7 +13,7 @@ const MAX_SESSION_HISTORY_BYTES: u64 = 128 * 1024 * 1024;
 
 pub(super) enum SessionHistoryMaterializer {
     Missing,
-    Ready(Option<ResumeSession>),
+    Ready,
     Downloading {
         started_at: Instant,
         task: Option<JoinHandle<SessionHistoryDownloadTaskResult>>,
@@ -22,7 +22,7 @@ pub(super) enum SessionHistoryMaterializer {
 
 pub(super) enum SessionHistoryMaterialization {
     Missing,
-    Ready(ResumeSession),
+    Ready,
     Downloaded {
         session: ResumeSession,
         elapsed: Duration,
@@ -44,7 +44,7 @@ impl SessionHistoryMaterializer {
             return Self::Missing;
         };
         if session.history_ref().is_none() {
-            return Self::Ready(Some(session.clone()));
+            return Self::Ready;
         }
 
         let http = http.clone();
@@ -63,17 +63,7 @@ impl SessionHistoryMaterializer {
     ) -> SessionHistoryMaterialization {
         match &mut self {
             Self::Missing => SessionHistoryMaterialization::Missing,
-            Self::Ready(session) => {
-                let Some(session) = session.take() else {
-                    return SessionHistoryMaterialization::Failed {
-                        elapsed: Duration::ZERO,
-                        error: RunnerError::Internal(
-                            "session history materializer lost ready session".into(),
-                        ),
-                    };
-                };
-                SessionHistoryMaterialization::Ready(session)
-            }
+            Self::Ready => SessionHistoryMaterialization::Ready,
             Self::Downloading { started_at, task } => {
                 let started_at = *started_at;
                 let Some(mut task) = task.take() else {

--- a/crates/runner/src/executor/session_restore.rs
+++ b/crates/runner/src/executor/session_restore.rs
@@ -38,6 +38,12 @@ pub(super) async fn restore_session(
         return Err(RunnerError::Internal("invalid session_id".into()));
     }
 
+    if session.session_history().is_none() {
+        return Err(RunnerError::Internal(
+            "resume session history was not materialized".into(),
+        ));
+    }
+
     match effective_cli_framework(&context.cli_agent_type) {
         EffectiveCliFramework::ClaudeCode => {
             if !matches!(context.cli_agent_type.as_str(), "" | "claude-code") {
@@ -61,6 +67,9 @@ pub(super) async fn restore_claude_session(
     context: &ExecutionContext,
     session: &ResumeSession,
 ) -> RunnerResult<SessionRestoreDiagnostics> {
+    let session_history = session.session_history().ok_or_else(|| {
+        RunnerError::Internal("resume session history was not materialized".into())
+    })?;
     let project_name = CANONICAL_WORKING_DIR
         .trim_start_matches('/')
         .replace('/', "-");
@@ -71,13 +80,13 @@ pub(super) async fn restore_claude_session(
         sandbox,
         &session_path,
         &[&session.cli_agent_session_id],
-        &session.session_history,
+        session_history,
     )
     .await?;
     let diagnostics = SessionRestoreDiagnostics {
         framework: "claude-code",
         session_fingerprint: diagnostic_session_fingerprint(&session.cli_agent_session_id),
-        bytes_in: session.session_history.len(),
+        bytes_in: session_history.len(),
     };
     info!(
         run_id = %context.run_id,

--- a/crates/runner/src/executor/session_restore/codex.rs
+++ b/crates/runner/src/executor/session_restore/codex.rs
@@ -92,13 +92,15 @@ pub(super) async fn restore_codex_session(
     context: &ExecutionContext,
     session: &ResumeSession,
 ) -> RunnerResult<SessionRestoreDiagnostics> {
+    let session_history = session.session_history().ok_or_else(|| {
+        RunnerError::Internal("resume session history was not materialized".into())
+    })?;
     let thread_id = CodexThreadId::parse(&session.cli_agent_session_id)
         .ok_or_else(|| RunnerError::Internal("invalid codex session_id".into()))?;
     let session_id = thread_id.as_str();
     let session_filename_key = thread_id.filename_key();
 
-    let session_path =
-        codex_restore_rollout_path(session_id, &session.session_history, chrono::Utc::now());
+    let session_path = codex_restore_rollout_path(session_id, session_history, chrono::Utc::now());
 
     cleanup_existing_codex_session_files(
         sandbox,
@@ -113,14 +115,14 @@ pub(super) async fn restore_codex_session(
         sandbox,
         &session_path,
         &[session_id, &session.cli_agent_session_id],
-        &session.session_history,
+        session_history,
     )
     .await?;
 
     let diagnostics = SessionRestoreDiagnostics {
         framework: "codex",
         session_fingerprint: diagnostic_session_fingerprint(session_id),
-        bytes_in: session.session_history.len(),
+        bytes_in: session_history.len(),
     };
     info!(
         run_id = %context.run_id,

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -8,6 +8,9 @@ use std::time::Duration;
 use api_contracts::generated::types::runners::storage::StorageManifest;
 use sandbox::{ProcessExit, ProcessOutputChunk, SandboxConfig, SandboxFactory, SandboxId};
 use sandbox_mock::MockSandboxFactory;
+use sha2::{Digest, Sha256};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
 
 use super::super::agent_run::{
     ProcessCancelTimeouts, RunControls, RunStart, build_agent_start_command, run_in_sandbox,
@@ -23,7 +26,27 @@ use super::support::{
 use crate::active_input::ActiveInputSource;
 use crate::local_queue::{ActiveInputEntry, LocalQueue};
 use crate::storage_fingerprints::{StorageFingerprint, StorageFingerprints};
-use crate::types::SandboxReuseResult;
+use crate::types::{
+    ResumeSession, ResumeSessionHistory, ResumeSessionHistoryRef, ResumeSessionHistoryRefKind,
+    SandboxReuseResult,
+};
+
+async fn serve_history_once(body: &'static [u8]) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let mut request = [0u8; 1024];
+        let _ = stream.read(&mut request).await;
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            body.len()
+        );
+        stream.write_all(response.as_bytes()).await.unwrap();
+        stream.write_all(body).await.unwrap();
+    });
+    format!("http://{address}/history.blob?token=secret")
+}
 
 #[test]
 fn agent_start_command_reports_missing_agent_on_stderr() {
@@ -214,6 +237,51 @@ async fn run_in_sandbox_runs_guest_download_for_cached_instruction_normalization
             .any(|call| call.cmd == guest_download_stdin_command()),
         "cached instruction storage should still invoke guest-download; calls: {exec_calls:?}"
     );
+}
+
+#[tokio::test]
+async fn run_in_sandbox_materializes_resume_session_history_ref_before_restore() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let sandbox = sandbox_mock::MockSandbox::new("test");
+    let history = br#"{"type":"init"}"#;
+    let mut ctx = minimal_context();
+    ctx.resume_session = Some(ResumeSession {
+        cli_agent_session_id: "sess-ref-123".into(),
+        history: ResumeSessionHistory::Ref {
+            history_ref: ResumeSessionHistoryRef {
+                kind: ResumeSessionHistoryRefKind::Blob,
+                hash: hex::encode(Sha256::digest(history)),
+                url: serve_history_once(history).await,
+                size: Some(history.len() as u64),
+            },
+        },
+    });
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let result = run_in_sandbox(
+        &sandbox,
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::PoolMiss,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None),
+    )
+    .await
+    .unwrap();
+
+    assert!(result.failure.is_none());
+    let writes = sandbox.write_file_calls();
+    assert_eq!(writes.len(), 1);
+    assert_eq!(
+        writes[0].path,
+        "/home/user/.claude/projects/-home-user-workspace/sess-ref-123.jsonl"
+    );
+    assert_eq!(writes[0].content, history);
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -195,10 +195,7 @@ fn execution_context_validation_rejects_bootstrap_env_nul_before_sandbox() {
 fn execution_context_validation_rejects_invalid_codex_resume_before_sandbox() {
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "codex".into();
-    ctx.resume_session = Some(ResumeSession {
-        cli_agent_session_id: "not-a-thread-id".into(),
-        session_history: "{}".into(),
-    });
+    ctx.resume_session = Some(ResumeSession::inline("not-a-thread-id".into(), "{}".into()));
 
     let error = validate_context_for_test(&ctx).unwrap_err();
 
@@ -590,10 +587,7 @@ fn emitted_bootstrap_env_keys_classify_as_runner_owned() {
         ),
     ]));
     ctx.append_system_prompt = Some("Use terse answers.".into());
-    ctx.resume_session = Some(ResumeSession {
-        cli_agent_session_id: "sess-123".into(),
-        session_history: "{}".into(),
-    });
+    ctx.resume_session = Some(ResumeSession::inline("sess-123".into(), "{}".into()));
     ctx.disallowed_tools = Some(vec!["CronCreate".into()]);
     ctx.tools = Some(vec!["Bash".into()]);
     ctx.settings = Some(r#"{"hooks":{}}"#.into());
@@ -661,10 +655,10 @@ fn build_env_json_codex_keeps_shared_runner_env() {
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "codex".into();
     ctx.append_system_prompt = Some("Use terse answers.".into());
-    ctx.resume_session = Some(ResumeSession {
-        cli_agent_session_id: "019E9154C30470F0ADDE36EFB1BE1701".into(),
-        session_history: "{}".into(),
-    });
+    ctx.resume_session = Some(ResumeSession::inline(
+        "019E9154C30470F0ADDE36EFB1BE1701".into(),
+        "{}".into(),
+    ));
 
     let env = build_env_for_test(&ctx, "http://localhost");
 
@@ -684,10 +678,7 @@ fn build_env_json_rejects_invalid_codex_resume_session_id() {
     for session_id in ["abc", "urn:uuid:019e9154-c304-70f0-adde-36efb1be1701"] {
         let mut ctx = minimal_context();
         ctx.cli_agent_type = "codex".into();
-        ctx.resume_session = Some(ResumeSession {
-            cli_agent_session_id: session_id.into(),
-            session_history: "{}".into(),
-        });
+        ctx.resume_session = Some(ResumeSession::inline(session_id.into(), "{}".into()));
 
         let error = build_env_for_test_result(&ctx, "http://localhost").unwrap_err();
         let message = error.to_string();
@@ -841,10 +832,7 @@ fn build_env_json_with_secrets() {
 #[test]
 fn build_env_json_with_resume_session() {
     let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession {
-        cli_agent_session_id: "sess-123".into(),
-        session_history: "{}".into(),
-    });
+    ctx.resume_session = Some(ResumeSession::inline("sess-123".into(), "{}".into()));
 
     let env = build_env_for_test(&ctx, "http://localhost");
     assert_eq!(env.get("VM0_RESUME_SESSION_ID").unwrap(), "sess-123");

--- a/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
@@ -359,10 +359,10 @@ async fn execute_inner_with_resume_session() {
     let factory = MockSandboxFactory::new();
 
     let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession {
-        cli_agent_session_id: "sess-abc-123".into(),
-        session_history: r#"{"type":"init"}"#.into(),
-    });
+    ctx.resume_session = Some(ResumeSession::inline(
+        "sess-abc-123".into(),
+        r#"{"type":"init"}"#.into(),
+    ));
     let (exit_code, _) = run_new_sandbox_status(&factory, &ctx, &config, &default_params())
         .await
         .unwrap();

--- a/crates/runner/src/executor/tests/sandbox_run_tests/reuse.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/reuse.rs
@@ -118,10 +118,7 @@ async fn execute_job_reuse_invalid_resume_session_does_not_lease_workspace_image
         make_reusable_idle_sandbox(sandbox, source_ip, "bad-session").await;
     let raw_session_id = "../bad-session";
     let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession {
-        cli_agent_session_id: raw_session_id.into(),
-        session_history: "{}".into(),
-    });
+    ctx.resume_session = Some(ResumeSession::inline(raw_session_id.into(), "{}".into()));
 
     let cancel = tokio_util::sync::CancellationToken::new();
     let (reuse_outcome, _telemetry) =
@@ -179,10 +176,10 @@ async fn execute_job_reuse_with_session_context() {
 
     // First turn: execute with resume_session
     let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession {
-        cli_agent_session_id: "test-session-abc".into(),
-        session_history: r#"{"type":"human","text":"hello"}"#.into(),
-    });
+    ctx.resume_session = Some(ResumeSession::inline(
+        "test-session-abc".into(),
+        r#"{"type":"human","text":"hello"}"#.into(),
+    ));
     assert_eq!(ctx.cli_agent_session_id(), Some("test-session-abc"));
 
     let cancel = tokio_util::sync::CancellationToken::new();
@@ -203,13 +200,13 @@ async fn execute_job_reuse_with_session_context() {
 
     // Second turn: reuse with new session history
     let mut ctx2 = minimal_context();
-    ctx2.resume_session = Some(ResumeSession {
-        cli_agent_session_id: "test-session-abc".into(),
-        session_history: r#"{"type":"human","text":"hello"}
+    ctx2.resume_session = Some(ResumeSession::inline(
+        "test-session-abc".into(),
+        r#"{"type":"human","text":"hello"}
 {"type":"assistant","text":"hi"}
 {"type":"human","text":"do something"}"#
             .into(),
-    });
+    ));
 
     let cancel = tokio_util::sync::CancellationToken::new();
     let (idle_sandbox, _lease) =
@@ -345,10 +342,10 @@ async fn execute_job_reuse_session_restore_failure_returns_sandbox() {
     sandbox.push_write_file_result(Err(sandbox_write_file_error("disk full")));
 
     let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession {
-        cli_agent_session_id: "sess-abc".into(),
-        session_history: r#"{"type":"init"}"#.into(),
-    });
+    ctx.resume_session = Some(ResumeSession::inline(
+        "sess-abc".into(),
+        r#"{"type":"init"}"#.into(),
+    ));
 
     let cancel = tokio_util::sync::CancellationToken::new();
     let (idle_sandbox, _lease) =

--- a/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
@@ -11,10 +11,10 @@ async fn execute_inner_retries_fresh_after_workspace_cache_hit_create_failure() 
     overrides.push_create_result(Err(sandbox_create_error("bad seed image")));
     let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
     let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession {
-        cli_agent_session_id: "sess-cache-hit".into(),
-        session_history: r#"{"type":"init"}"#.into(),
-    });
+    ctx.resume_session = Some(ResumeSession::inline(
+        "sess-cache-hit".into(),
+        r#"{"type":"init"}"#.into(),
+    ));
     let params = JobParams {
         workspace_disk_mb: 16,
         ..default_params()
@@ -74,10 +74,10 @@ async fn execute_inner_uses_workspace_cache_when_configured() {
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
     let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession {
-        cli_agent_session_id: "sess-cache-default".into(),
-        session_history: r#"{"type":"init"}"#.into(),
-    });
+    ctx.resume_session = Some(ResumeSession::inline(
+        "sess-cache-default".into(),
+        r#"{"type":"init"}"#.into(),
+    ));
     let params = JobParams {
         workspace_disk_mb: 16,
         ..default_params()
@@ -127,10 +127,10 @@ async fn execute_inner_does_not_retry_workspace_cache_hit_after_proxy_register_f
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
     let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession {
-        cli_agent_session_id: "sess-register-fail".into(),
-        session_history: r#"{"type":"init"}"#.into(),
-    });
+    ctx.resume_session = Some(ResumeSession::inline(
+        "sess-register-fail".into(),
+        r#"{"type":"init"}"#.into(),
+    ));
     let params = JobParams {
         workspace_disk_mb: 16,
         ..default_params()
@@ -207,10 +207,10 @@ async fn execute_job_reuse_uses_workspace_cache_when_configured() {
     let (idle_sandbox, _lease) = make_reusable_idle_sandbox(sandbox, source_ip, session_id).await;
 
     let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession {
-        cli_agent_session_id: session_id.into(),
-        session_history: r#"{"type":"init"}"#.into(),
-    });
+    ctx.resume_session = Some(ResumeSession::inline(
+        session_id.into(),
+        r#"{"type":"init"}"#.into(),
+    ));
 
     let cancel = tokio_util::sync::CancellationToken::new();
     let (reuse_outcome, _telemetry) =
@@ -260,10 +260,10 @@ async fn cached_reuse_workspace_promotion_identity_mismatch_stops_before_agent()
     .await;
 
     let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession {
-        cli_agent_session_id: session_id.into(),
-        session_history: r#"{"type":"init"}"#.into(),
-    });
+    ctx.resume_session = Some(ResumeSession::inline(
+        session_id.into(),
+        r#"{"type":"init"}"#.into(),
+    ));
 
     let cancel = tokio_util::sync::CancellationToken::new();
     let (reuse_outcome, _telemetry) =
@@ -315,10 +315,10 @@ async fn execute_job_reuse_without_workspace_cache_config_invalidates_held_cache
             .await;
 
     let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession {
-        cli_agent_session_id: session_id.into(),
-        session_history: r#"{"type":"init"}"#.into(),
-    });
+    ctx.resume_session = Some(ResumeSession::inline(
+        session_id.into(),
+        r#"{"type":"init"}"#.into(),
+    ));
 
     let cancel = tokio_util::sync::CancellationToken::new();
     let (reuse_outcome, _telemetry) =
@@ -373,10 +373,10 @@ async fn unconfigured_cache_reuse_stops_when_cache_invalidation_fails() {
     tokio::fs::create_dir(&current_image).await.unwrap();
 
     let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession {
-        cli_agent_session_id: session_id.into(),
-        session_history: r#"{"type":"init"}"#.into(),
-    });
+    ctx.resume_session = Some(ResumeSession::inline(
+        session_id.into(),
+        r#"{"type":"init"}"#.into(),
+    ));
 
     let cancel = tokio_util::sync::CancellationToken::new();
     let (reuse_outcome, _telemetry) =
@@ -432,10 +432,10 @@ async fn unconfigured_cache_reuse_stops_when_required_cache_invalidation_lock_is
     .unwrap();
 
     let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession {
-        cli_agent_session_id: session_id.into(),
-        session_history: r#"{"type":"init"}"#.into(),
-    });
+    ctx.resume_session = Some(ResumeSession::inline(
+        session_id.into(),
+        r#"{"type":"init"}"#.into(),
+    ));
 
     let cancel = tokio_util::sync::CancellationToken::new();
     let (reuse_outcome, _telemetry) =
@@ -480,10 +480,10 @@ async fn cached_reuse_validation_failure_keeps_workspace_cache_hidden() {
             .await;
 
     let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession {
-        cli_agent_session_id: session_id.into(),
-        session_history: r#"{"type":"init"}"#.into(),
-    });
+    ctx.resume_session = Some(ResumeSession::inline(
+        session_id.into(),
+        r#"{"type":"init"}"#.into(),
+    ));
     ctx.environment = Some(HashMap::from([(
         "OPENAI_API_KEY".into(),
         "sk-proj-real-openai-secret".into(),
@@ -539,10 +539,10 @@ async fn cached_reuse_invalid_resume_session_keeps_existing_workspace_cache_hidd
 
     let raw_session_id = "../invalid-resume";
     let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession {
-        cli_agent_session_id: raw_session_id.into(),
-        session_history: r#"{"type":"init"}"#.into(),
-    });
+    ctx.resume_session = Some(ResumeSession::inline(
+        raw_session_id.into(),
+        r#"{"type":"init"}"#.into(),
+    ));
 
     let cancel = tokio_util::sync::CancellationToken::new();
     let (reuse_outcome, _telemetry) =

--- a/crates/runner/src/executor/tests/session_restore_tests.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests.rs
@@ -102,7 +102,10 @@ fn restore_session_logs_fingerprint_without_raw_claude_session_id() {
         diagnostics.session_fingerprint,
         diagnostic_session_fingerprint(raw_session_id)
     );
-    assert_eq!(diagnostics.bytes_in, session.session_history.len());
+    assert_eq!(
+        diagnostics.bytes_in,
+        session.session_history().unwrap().len()
+    );
     assert_captured_events_do_not_contain(&events, raw_session_id);
     let event = captured_event(&events, "restored session history");
     assert_eq!(
@@ -208,7 +211,10 @@ fn restore_session_logs_fingerprint_without_raw_codex_session_id() {
         diagnostics.session_fingerprint,
         diagnostic_session_fingerprint(raw_session_id)
     );
-    assert_eq!(diagnostics.bytes_in, session.session_history.len());
+    assert_eq!(
+        diagnostics.bytes_in,
+        session.session_history().unwrap().len()
+    );
     assert_captured_events_do_not_contain(&events, raw_session_id);
     let restore_event = captured_event(&events, "restored session history");
     assert_eq!(

--- a/crates/runner/src/executor/tests/session_restore_tests.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests.rs
@@ -67,10 +67,7 @@ fn restore_session_writes_history() {
     let sandbox = MockSandbox::new("test");
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "claude-code".into();
-    let session = ResumeSession {
-        cli_agent_session_id: "sess-abc-123".into(),
-        session_history: r#"{"type":"init"}"#.into(),
-    };
+    let session = ResumeSession::inline("sess-abc-123".into(), r#"{"type":"init"}"#.into());
     run_restore_session(restore_session(&sandbox, &ctx, &session)).unwrap();
 }
 
@@ -79,10 +76,7 @@ async fn restore_session_rejects_invalid_session_id() {
     let sandbox = MockSandbox::new("test");
     let ctx = minimal_context();
     let raw_session_id = "../../etc/passwd";
-    let session = ResumeSession {
-        cli_agent_session_id: raw_session_id.into(),
-        session_history: "data".into(),
-    };
+    let session = ResumeSession::inline(raw_session_id.into(), "data".into());
     let err = restore_session(&sandbox, &ctx, &session).await.unwrap_err();
     let message = err.to_string();
     assert!(message.contains("invalid session_id"));
@@ -98,10 +92,7 @@ fn restore_session_logs_fingerprint_without_raw_claude_session_id() {
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "claude-code".into();
     let raw_session_id = "sess-sensitive-restore-17975";
-    let session = ResumeSession {
-        cli_agent_session_id: raw_session_id.into(),
-        session_history: r#"{"type":"init"}"#.into(),
-    };
+    let session = ResumeSession::inline(raw_session_id.into(), r#"{"type":"init"}"#.into());
 
     let (result, events) = capture_restore_events(restore_session(&sandbox, &ctx, &session));
 
@@ -133,10 +124,7 @@ fn restore_session_unknown_framework_uses_claude_fallback() {
     let sandbox = MockSandbox::new("test");
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "custom-agent".into();
-    let session = ResumeSession {
-        cli_agent_session_id: "sess-1".into(),
-        session_history: "data".into(),
-    };
+    let session = ResumeSession::inline("sess-1".into(), "data".into());
 
     run_restore_session(restore_session(&sandbox, &ctx, &session)).unwrap();
 
@@ -154,10 +142,7 @@ fn restore_session_allows_empty_agent_type() {
     let sandbox = MockSandbox::new("test");
     let mut ctx = minimal_context();
     ctx.cli_agent_type = String::new(); // empty defaults to claude-code
-    let session = ResumeSession {
-        cli_agent_session_id: "sess-1".into(),
-        session_history: "{}".into(),
-    };
+    let session = ResumeSession::inline("sess-1".into(), "{}".into());
     // Should proceed (empty agent type treated as claude-code).
     run_restore_session(restore_session(&sandbox, &ctx, &session)).unwrap();
 }
@@ -168,9 +153,9 @@ fn restore_session_writes_codex_session() {
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "codex".into();
     let session_id = "019e9154-c304-70f0-adde-36efb1be1701";
-    let session = ResumeSession {
-        cli_agent_session_id: session_id.into(),
-        session_history: format!(
+    let session = ResumeSession::inline(
+        session_id.into(),
+        format!(
             "{}\n",
             serde_json::json!({
                 "timestamp": "2026-06-04T07:18:08.001Z",
@@ -187,7 +172,7 @@ fn restore_session_writes_codex_session() {
                 },
             }),
         ),
-    };
+    );
     run_restore_session(restore_session(&sandbox, &ctx, &session)).unwrap();
 
     assert_codex_cleanup_call(&sandbox);
@@ -201,7 +186,10 @@ fn restore_session_writes_codex_session() {
         "codex resume history must be restored as a canonical rollout jsonl, got {}",
         writes[0].path
     );
-    assert_eq!(writes[0].content, session.session_history.as_bytes());
+    assert_eq!(
+        writes[0].content,
+        session.session_history().unwrap().as_bytes()
+    );
 }
 
 #[test]
@@ -210,10 +198,7 @@ fn restore_session_logs_fingerprint_without_raw_codex_session_id() {
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "codex".into();
     let raw_session_id = "019e9154-c304-70f0-adde-36efb1be1701";
-    let session = ResumeSession {
-        cli_agent_session_id: raw_session_id.into(),
-        session_history: "{}\n".into(),
-    };
+    let session = ResumeSession::inline(raw_session_id.into(), "{}\n".into());
 
     let (result, events) = capture_restore_events(restore_session(&sandbox, &ctx, &session));
 
@@ -248,10 +233,10 @@ fn restore_session_writes_codex_session_with_canonical_fallback_filename() {
     let sandbox = MockSandbox::new("test");
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "codex".into();
-    let session = ResumeSession {
-        cli_agent_session_id: "019e9154-c304-70f0-adde-36efb1be1701".into(),
-        session_history: "{\"type\":\"thread.started\"}\n{not-json}\n".into(),
-    };
+    let session = ResumeSession::inline(
+        "019e9154-c304-70f0-adde-36efb1be1701".into(),
+        "{\"type\":\"thread.started\"}\n{not-json}\n".into(),
+    );
 
     run_restore_session(restore_session(&sandbox, &ctx, &session)).unwrap();
 
@@ -277,7 +262,10 @@ fn restore_session_writes_codex_session_with_canonical_fallback_filename() {
         filename.ends_with("-019e9154-c304-70f0-adde-36efb1be1701.jsonl"),
         "codex resume history filename must include the thread id, got {filename}"
     );
-    assert_eq!(writes[0].content, session.session_history.as_bytes());
+    assert_eq!(
+        writes[0].content,
+        session.session_history().unwrap().as_bytes()
+    );
 }
 
 #[test]
@@ -285,10 +273,7 @@ fn restore_session_canonicalizes_codex_session_id() {
     let sandbox = MockSandbox::new("test");
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "codex".into();
-    let session = ResumeSession {
-        cli_agent_session_id: "019E9154C30470F0ADDE36EFB1BE1701".into(),
-        session_history: "{}\n".into(),
-    };
+    let session = ResumeSession::inline("019E9154C30470F0ADDE36EFB1BE1701".into(), "{}\n".into());
 
     run_restore_session(restore_session(&sandbox, &ctx, &session)).unwrap();
 
@@ -312,10 +297,7 @@ async fn restore_session_rejects_invalid_codex_session_id() {
     let sandbox = MockSandbox::new("test");
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "codex".into();
-    let session = ResumeSession {
-        cli_agent_session_id: "../../etc/passwd".into(),
-        session_history: "{}".into(),
-    };
+    let session = ResumeSession::inline("../../etc/passwd".into(), "{}".into());
     let err = restore_session(&sandbox, &ctx, &session).await.unwrap_err();
     assert!(err.to_string().contains("invalid session_id"));
 }
@@ -325,10 +307,7 @@ async fn restore_session_rejects_short_codex_session_id_without_cleanup() {
     let sandbox = MockSandbox::new("test");
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "codex".into();
-    let session = ResumeSession {
-        cli_agent_session_id: "abc".into(),
-        session_history: "{}".into(),
-    };
+    let session = ResumeSession::inline("abc".into(), "{}".into());
 
     let err = restore_session(&sandbox, &ctx, &session).await.unwrap_err();
 
@@ -351,10 +330,7 @@ async fn restore_session_rejects_decorated_codex_session_id_without_cleanup() {
         let sandbox = MockSandbox::new("test");
         let mut ctx = minimal_context();
         ctx.cli_agent_type = "codex".into();
-        let session = ResumeSession {
-            cli_agent_session_id: raw_session_id.into(),
-            session_history: "{}".into(),
-        };
+        let session = ResumeSession::inline(raw_session_id.into(), "{}".into());
 
         let err = restore_session(&sandbox, &ctx, &session).await.unwrap_err();
 
@@ -374,10 +350,8 @@ async fn restore_session_fails_when_codex_cleanup_fails() {
     let sandbox = MockSandbox::new("test");
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "codex".into();
-    let session = ResumeSession {
-        cli_agent_session_id: "019e9154-c304-70f0-adde-36efb1be1701".into(),
-        session_history: "{}\n".into(),
-    };
+    let session =
+        ResumeSession::inline("019e9154-c304-70f0-adde-36efb1be1701".into(), "{}\n".into());
     sandbox.push_exec_result(Ok(ExecResult::new(
         1,
         b"cleanup stdout".to_vec(),
@@ -403,9 +377,9 @@ async fn restore_session_redacts_codex_cleanup_failure_output() {
     let session_id = "019e9154-c304-70f0-adde-36efb1be1701";
     let session_id_no_dashes = session_id.replace('-', "");
     let session_path = "/home/user/.codex/sessions/2026/06/04/rollout-2026-06-04T07-18-08-019e9154-c304-70f0-adde-36efb1be1701.jsonl";
-    let session = ResumeSession {
-        cli_agent_session_id: session_id.into(),
-        session_history: format!(
+    let session = ResumeSession::inline(
+        session_id.into(),
+        format!(
             "{}\n",
             serde_json::json!({
                 "timestamp": "2026-06-04T07:18:08.001Z",
@@ -416,7 +390,7 @@ async fn restore_session_redacts_codex_cleanup_failure_output() {
                 },
             }),
         ),
-    };
+    );
     sandbox.push_exec_result(Ok(ExecResult::new(
         1,
         format!("stdout includes {session_id_no_dashes}").into_bytes(),
@@ -452,9 +426,9 @@ async fn restore_session_redacts_non_exited_codex_cleanup_failure_output() {
     let session_id = "019e9154-c304-70f0-adde-36efb1be1701";
     let session_id_no_dashes = session_id.replace('-', "");
     let session_path = "/home/user/.codex/sessions/2026/06/04/rollout-2026-06-04T07-18-08-019e9154-c304-70f0-adde-36efb1be1701.jsonl";
-    let session = ResumeSession {
-        cli_agent_session_id: session_id.into(),
-        session_history: format!(
+    let session = ResumeSession::inline(
+        session_id.into(),
+        format!(
             "{}\n",
             serde_json::json!({
                 "timestamp": "2026-06-04T07:18:08.001Z",
@@ -465,7 +439,7 @@ async fn restore_session_redacts_non_exited_codex_cleanup_failure_output() {
                 },
             }),
         ),
-    };
+    );
     sandbox.push_exec_result(Ok(ExecResult {
         termination: sandbox::ExecTermination::WaitFailed,
         stdout: format!("stdout includes {session_id_no_dashes}").into_bytes(),
@@ -494,10 +468,7 @@ async fn restore_session_redacts_claude_write_file_error() {
     let session_id = "sess-sensitive-write-17975";
     let session_path =
         "/home/user/.claude/projects/-home-user-workspace/sess-sensitive-write-17975.jsonl";
-    let session = ResumeSession {
-        cli_agent_session_id: session_id.into(),
-        session_history: r#"{"type":"init"}"#.into(),
-    };
+    let session = ResumeSession::inline(session_id.into(), r#"{"type":"init"}"#.into());
     sandbox.push_write_file_result(Err(sandbox_write_file_error(format!(
         "failed to write {session_path} for {session_id}"
     ))));
@@ -525,9 +496,9 @@ async fn restore_session_redacts_codex_write_file_error() {
     let session_id = "019e9154-c304-70f0-adde-36efb1be1701";
     let session_id_no_dashes = session_id.replace('-', "");
     let session_path = "/home/user/.codex/sessions/2026/06/04/rollout-2026-06-04T07-18-08-019e9154-c304-70f0-adde-36efb1be1701.jsonl";
-    let session = ResumeSession {
-        cli_agent_session_id: session_id.into(),
-        session_history: format!(
+    let session = ResumeSession::inline(
+        session_id.into(),
+        format!(
             "{}\n",
             serde_json::json!({
                 "timestamp": "2026-06-04T07:18:08.001Z",
@@ -538,7 +509,7 @@ async fn restore_session_redacts_codex_write_file_error() {
                 },
             }),
         ),
-    };
+    );
     sandbox.push_write_file_result(Err(sandbox_write_file_error(format!(
         "failed to rename temp file to {session_path}: thread {session_id_no_dashes}"
     ))));
@@ -570,9 +541,9 @@ async fn restore_session_redacts_codex_original_no_dash_write_file_error() {
     let raw_session_id = "019E9154C30470F0ADDE36EFB1BE1701";
     let canonical_session_id = "019e9154-c304-70f0-adde-36efb1be1701";
     let session_path = "/home/user/.codex/sessions/2026/06/04/rollout-2026-06-04T07-18-08-019e9154-c304-70f0-adde-36efb1be1701.jsonl";
-    let session = ResumeSession {
-        cli_agent_session_id: raw_session_id.into(),
-        session_history: format!(
+    let session = ResumeSession::inline(
+        raw_session_id.into(),
+        format!(
             "{}\n",
             serde_json::json!({
                 "timestamp": "2026-06-04T07:18:08.001Z",
@@ -583,7 +554,7 @@ async fn restore_session_redacts_codex_original_no_dash_write_file_error() {
                 },
             }),
         ),
-    };
+    );
     sandbox.push_write_file_result(Err(sandbox_write_file_error(format!(
         "failed to write original thread {raw_session_id} at {session_path}"
     ))));
@@ -614,9 +585,9 @@ async fn restore_session_redacts_codex_mixed_case_original_write_file_error() {
     ctx.cli_agent_type = "codex".into();
     let raw_session_id = "019e9154C30470f0ADDE36efB1be1701";
     let canonical_session_id = "019e9154-c304-70f0-adde-36efb1be1701";
-    let session = ResumeSession {
-        cli_agent_session_id: raw_session_id.into(),
-        session_history: format!(
+    let session = ResumeSession::inline(
+        raw_session_id.into(),
+        format!(
             "{}\n",
             serde_json::json!({
                 "timestamp": "2026-06-04T07:18:08.001Z",
@@ -627,7 +598,7 @@ async fn restore_session_redacts_codex_mixed_case_original_write_file_error() {
                 },
             }),
         ),
-    };
+    );
     sandbox.push_write_file_result(Err(sandbox_write_file_error(format!(
         "failed to write original thread {raw_session_id} with canonical {canonical_session_id}"
     ))));
@@ -654,10 +625,7 @@ async fn restore_session_redacts_write_file_invalid_state() {
     let session_id = "sess-invalid-state-17975";
     let session_path =
         "/home/user/.claude/projects/-home-user-workspace/sess-invalid-state-17975.jsonl";
-    let session = ResumeSession {
-        cli_agent_session_id: session_id.into(),
-        session_history: r#"{"type":"init"}"#.into(),
-    };
+    let session = ResumeSession::inline(session_id.into(), r#"{"type":"init"}"#.into());
     sandbox.push_write_file_result(Err(SandboxError::InvalidState {
         context: SandboxInvalidStateContext::Operation(SandboxOperation::WriteFile),
         state: format!("blocked for {session_path}"),
@@ -686,10 +654,7 @@ async fn restore_session_redaction_does_not_rewrite_markers() {
     ctx.cli_agent_type = "claude-code".into();
     let session_id = "session";
     let session_path = "/home/user/.claude/projects/-home-user-workspace/session.jsonl";
-    let session = ResumeSession {
-        cli_agent_session_id: session_id.into(),
-        session_history: r#"{"type":"init"}"#.into(),
-    };
+    let session = ResumeSession::inline(session_id.into(), r#"{"type":"init"}"#.into());
     sandbox.push_write_file_result(Err(sandbox_write_file_error(format!(
         "failed to write {session_path} for {session_id}"
     ))));
@@ -718,10 +683,7 @@ async fn restore_session_redaction_preserves_words_for_short_ids() {
     ctx.cli_agent_type = "claude-code".into();
     let session_id = "a";
     let session_path = "/home/user/.claude/projects/-home-user-workspace/a.jsonl";
-    let session = ResumeSession {
-        cli_agent_session_id: session_id.into(),
-        session_history: r#"{"type":"init"}"#.into(),
-    };
+    let session = ResumeSession::inline(session_id.into(), r#"{"type":"init"}"#.into());
     sandbox.push_write_file_result(Err(sandbox_write_file_error(format!(
         "failed to write {session_path} for {session_id}"
     ))));
@@ -747,10 +709,7 @@ async fn restore_session_redaction_preserves_words_for_short_ids() {
 async fn restore_session_fails_on_write_file_error() {
     let sandbox = MockSandbox::new("test");
     let ctx = minimal_context();
-    let session = ResumeSession {
-        cli_agent_session_id: "sess-abc".into(),
-        session_history: r#"{"type":"init"}"#.into(),
-    };
+    let session = ResumeSession::inline("sess-abc".into(), r#"{"type":"init"}"#.into());
     sandbox.push_write_file_result(Err(sandbox_write_file_error("disk full")));
     let err = restore_session(&sandbox, &ctx, &session).await.unwrap_err();
     assert!(err.to_string().contains("disk full"), "got: {err}");

--- a/crates/runner/src/http.rs
+++ b/crates/runner/src/http.rs
@@ -86,6 +86,10 @@ impl HttpClient {
         )
     }
 
+    pub fn get(&self, url: &str) -> reqwest::RequestBuilder {
+        self.inner.client.get(url)
+    }
+
     fn authenticated_request(
         &self,
         method: reqwest::Method,

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -33,6 +33,13 @@ use sandbox::SandboxId;
 #[serde(rename_all = "camelCase")]
 struct ClaimRequestBody {
     telemetry: ClaimRequestTelemetry,
+    capabilities: [ClaimCapability; 1],
+}
+
+#[derive(Serialize)]
+enum ClaimCapability {
+    #[serde(rename = "resumeSessionHistoryRef")]
+    ResumeSessionHistoryRef,
 }
 
 #[derive(Serialize)]
@@ -586,6 +593,7 @@ fn claim_request_body(candidate: &JobCandidate) -> ClaimRequestBody {
             poll_http_request_ms: candidate.poll_http_request_elapsed().map(duration_ms),
             poll_reason: candidate.poll_reason().map(String::from),
         },
+        capabilities: [ClaimCapability::ResumeSessionHistoryRef],
     }
 }
 
@@ -771,6 +779,8 @@ fn is_static_json_field(field: &str) -> bool {
             | "firewall"
             | "firewalls"
             | "headers"
+            | "hash"
+            | "historyRef"
             | "issued"
             | "job"
             | "keyName"
@@ -797,6 +807,7 @@ fn is_static_json_field(field: &str) -> bool {
             | "sessionHistory"
             | "sessionId"
             | "settings"
+            | "size"
             | "sourceType"
             | "sourceUserId"
             | "storageManifest"
@@ -806,6 +817,7 @@ fn is_static_json_field(field: &str) -> bool {
             | "tools"
             | "ttl"
             | "unknownPolicy"
+            | "url"
             | "userTimezone"
             | "vars"
             | "vasStorageId"
@@ -1078,6 +1090,10 @@ mod tests {
         assert_eq!(body["telemetry"]["pollDueToJobDiscoveredMs"], 19);
         assert_eq!(body["telemetry"]["pollHttpRequestMs"], 11);
         assert_eq!(body["telemetry"]["pollReason"], "deferred");
+        assert_eq!(
+            body["capabilities"],
+            serde_json::json!(["resumeSessionHistoryRef"])
+        );
     }
 
     #[test]

--- a/crates/runner/src/provider/local.rs
+++ b/crates/runner/src/provider/local.rs
@@ -206,10 +206,7 @@ impl JobProvider for LocalProvider {
             resume_session: req
                 .session_id
                 .as_ref()
-                .map(|id| crate::types::ResumeSession {
-                    cli_agent_session_id: id.clone(),
-                    session_history: String::new(),
-                }),
+                .map(|id| crate::types::ResumeSession::inline(id.clone(), String::new())),
             secret_values: environment_merge.secret_values,
             local_secret_env_keys: environment_merge.local_secret_env_keys,
             encrypted_secrets: None,

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -280,12 +280,65 @@ impl From<&StorageManifest> for GuestDownloadManifest {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ResumeSession {
     #[serde(rename = "sessionId")]
     pub cli_agent_session_id: String,
-    pub session_history: String,
+    #[serde(flatten)]
+    pub history: ResumeSessionHistory,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(untagged)]
+pub enum ResumeSessionHistory {
+    Inline {
+        #[serde(rename = "sessionHistory")]
+        session_history: String,
+    },
+    Ref {
+        #[serde(rename = "historyRef")]
+        history_ref: ResumeSessionHistoryRef,
+    },
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResumeSessionHistoryRef {
+    pub kind: ResumeSessionHistoryRefKind,
+    pub hash: String,
+    pub url: String,
+    #[serde(default)]
+    pub size: Option<u64>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
+pub enum ResumeSessionHistoryRefKind {
+    #[serde(rename = "blob")]
+    Blob,
+}
+
+impl ResumeSession {
+    pub fn inline(cli_agent_session_id: String, session_history: String) -> Self {
+        Self {
+            cli_agent_session_id,
+            history: ResumeSessionHistory::Inline { session_history },
+        }
+    }
+
+    pub fn session_history(&self) -> Option<&str> {
+        match &self.history {
+            ResumeSessionHistory::Inline { session_history } => Some(session_history),
+            ResumeSessionHistory::Ref { .. } => None,
+        }
+    }
+
+    pub fn history_ref(&self) -> Option<&ResumeSessionHistoryRef> {
+        match &self.history {
+            ResumeSessionHistory::Inline { .. } => None,
+            ResumeSessionHistory::Ref { history_ref } => Some(history_ref),
+        }
+    }
 }
 
 impl ExecutionContext {
@@ -753,6 +806,37 @@ mod tests {
         });
         let ctx: ExecutionContext = serde_json::from_value(json).unwrap();
         assert_eq!(ctx.cli_agent_session_id(), Some("sess-abc-123"));
+        assert_eq!(
+            ctx.resume_session.as_ref().unwrap().session_history(),
+            Some("{}")
+        );
+    }
+
+    #[test]
+    fn cli_agent_session_id_returns_id_from_resume_session_history_ref() {
+        let json = json!({
+            "runId": "550e8400-e29b-41d4-a716-446655440000",
+            "prompt": "hello",
+            "sandboxToken": "tok",
+            "cliAgentType": "claude_code",
+            "resumeSession": {
+                "sessionId": "sess-ref-123",
+                "historyRef": {
+                    "kind": "blob",
+                    "hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "url": "https://r2.example.com/blobs/a.blob?sig=secret",
+                    "size": 42
+                }
+            },
+            "billableFirewalls": []
+        });
+        let ctx: ExecutionContext = serde_json::from_value(json).unwrap();
+        let session = ctx.resume_session.as_ref().unwrap();
+        let history_ref = session.history_ref().unwrap();
+        assert_eq!(ctx.cli_agent_session_id(), Some("sess-ref-123"));
+        assert!(session.session_history().is_none());
+        assert_eq!(history_ref.kind, ResumeSessionHistoryRefKind::Blob);
+        assert_eq!(history_ref.size, Some(42));
     }
 
     #[test]

--- a/turbo/apps/api/src/__tests__/test-helpers.ts
+++ b/turbo/apps/api/src/__tests__/test-helpers.ts
@@ -19,6 +19,7 @@ import { getApiTestMocks, type ApiTestMocks } from "./mocks";
 export interface TestContext {
   readonly signal: AbortSignal;
   readonly mocks: ApiTestMocks;
+  readonly sessionHistoryBlobs: Map<string, Uint8Array>;
 }
 
 interface SetupAppOptions {
@@ -124,6 +125,7 @@ export function testContext(): TestContext {
       return controller.signal;
     },
     mocks: getApiTestMocks(),
+    sessionHistoryBlobs: new Map<string, Uint8Array>(),
   };
 
   afterEach(async () => {
@@ -133,6 +135,7 @@ export function testContext(): TestContext {
     controller = new AbortController();
 
     await clearAllDetached();
+    context.sessionHistoryBlobs.clear();
     clearMockedEnv();
     clearMockListStripeInvoices();
   });

--- a/turbo/apps/api/src/signals/external/s3.ts
+++ b/turbo/apps/api/src/signals/external/s3.ts
@@ -38,6 +38,21 @@ interface S3Credentials {
   readonly secretAccessKey: string;
 }
 
+interface DownloadS3BufferOptions {
+  readonly maxBytes?: number;
+}
+
+export class S3ObjectSizeLimitError extends Error {
+  constructor(
+    readonly key: string,
+    readonly size: number,
+    readonly maxBytes: number,
+  ) {
+    super(`S3 object is too large: ${size} bytes exceeds ${maxBytes} bytes`);
+    this.name = "S3ObjectSizeLimitError";
+  }
+}
+
 function createS3Client(
   endpoint: string,
   credentials: S3Credentials,
@@ -208,10 +223,21 @@ export function downloadS3Buffer(
   return downloadS3BufferWithClient(s3ClientForBucket(bucket), bucket, key);
 }
 
+export function downloadS3BufferWithMaxBytes(
+  bucket: string,
+  key: string,
+  maxBytes: number,
+): Computed<Promise<Buffer>> {
+  return downloadS3BufferWithClient(s3ClientForBucket(bucket), bucket, key, {
+    maxBytes,
+  });
+}
+
 function downloadS3BufferWithClient(
   client$: Computed<S3Client>,
   bucket: string,
   key: string,
+  options: DownloadS3BufferOptions = {},
 ): Computed<Promise<Buffer>> {
   return computed(async (get): Promise<Buffer> => {
     const client = get(client$);
@@ -221,14 +247,27 @@ function downloadS3BufferWithClient(
     if (!response.Body) {
       throw new Error("S3 object body is empty");
     }
+    if (
+      options.maxBytes !== undefined &&
+      response.ContentLength !== undefined &&
+      response.ContentLength > options.maxBytes
+    ) {
+      throw new S3ObjectSizeLimitError(
+        key,
+        response.ContentLength,
+        options.maxBytes,
+      );
+    }
     const chunks: Uint8Array[] = [];
     const stream = response.Body as unknown as AsyncIterable<Uint8Array>;
+    let totalLength = 0;
     for await (const chunk of stream) {
+      totalLength += chunk.length;
+      if (options.maxBytes !== undefined && totalLength > options.maxBytes) {
+        throw new S3ObjectSizeLimitError(key, totalLength, options.maxBytes);
+      }
       chunks.push(chunk);
     }
-    const totalLength = chunks.reduce((acc, c) => {
-      return acc + c.length;
-    }, 0);
     return Buffer.concat(
       chunks.map((c) => {
         return Buffer.from(c);

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-agentphone.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-agentphone.ts
@@ -27,6 +27,7 @@ import {
   agentPhoneBddWebhookSecret,
   createBddIntegrationApi,
 } from "./api-bdd-integrations";
+import { sessionHistoryBlobBodyForKey } from "./api-bdd-session-history";
 import { createZeroRouteMocks } from "./zero-route-test";
 
 export const AGENTPHONE_BDD_AGENT_ID = "agt-bdd-agentphone";
@@ -402,10 +403,13 @@ export function createAgentPhoneBddApi(context: TestContext) {
         const input = commandInput(args[0]);
         const key = typeof input.Key === "string" ? input.Key : "";
         if (key.startsWith("blobs/") && key.endsWith(".blob")) {
+          const body = sessionHistoryBlobBodyForKey(context, key);
           return Promise.resolve({
             Body: {
               async *[Symbol.asyncIterator](): AsyncGenerator<Uint8Array> {
-                yield Buffer.from(`bdd agentphone history ${key}`, "utf8");
+                if (body) {
+                  yield body;
+                }
               },
             },
           });

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-callbacks.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-callbacks.ts
@@ -13,6 +13,7 @@ import {
   setupApp,
   type TestContext,
 } from "../../../../__tests__/test-helpers";
+import { sessionHistoryBlobBodyForKey } from "./api-bdd-session-history";
 import type { ApiTestUser } from "./api-bdd";
 import { createZeroRouteMocks } from "./zero-route-test";
 
@@ -227,10 +228,13 @@ export function createChatCallbacksApi(context: TestContext) {
         const input = commandInput(args[0]);
         const key = typeof input.Key === "string" ? input.Key : "";
         if (key.startsWith("blobs/") && key.endsWith(".blob")) {
+          const body = sessionHistoryBlobBodyForKey(context, key);
           return Promise.resolve({
             Body: {
               async *[Symbol.asyncIterator](): AsyncGenerator<Uint8Array> {
-                yield Buffer.from(`bdd session history ${key}`, "utf8");
+                if (body) {
+                  yield body;
+                }
               },
             },
           });

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-github.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-github.ts
@@ -42,6 +42,7 @@ import {
 import { signSandboxJwtForTests } from "../../../auth/tokens";
 import { signGithubConnectParams } from "../../../services/github-oauth.service";
 import type { ApiTestUser } from "./api-bdd";
+import { sessionHistoryBlobBodyForKey } from "./api-bdd-session-history";
 import { createZeroRouteMocks } from "./zero-route-test";
 
 export const GITHUB_APP_SLUG = "vm0-test";
@@ -166,10 +167,13 @@ export function acceptGithubRunObjectStorage(context: TestContext): void {
     const input = commandInput(command);
     const key = typeof input.Key === "string" ? input.Key : "";
     if (key.startsWith("blobs/") && key.endsWith(".blob")) {
+      const body = sessionHistoryBlobBodyForKey(context, key);
       return Promise.resolve({
         Body: {
           async *[Symbol.asyncIterator](): AsyncGenerator<Uint8Array> {
-            yield Buffer.from(`bdd github session history ${key}`, "utf8");
+            if (body) {
+              yield body;
+            }
           },
         },
       });

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
@@ -71,6 +71,7 @@ import {
   type TestContext,
 } from "../../../../__tests__/test-helpers";
 import type { ApiTestUser, ApiTestUserOptions } from "./api-bdd";
+import { sessionHistoryBlobBodyForKey } from "./api-bdd-session-history";
 import { createZeroRouteMocks } from "./zero-route-test";
 
 interface AuthHeaders {
@@ -866,9 +867,12 @@ export function createBddIntegrationApi(context: TestContext) {
     acceptSlackSessionHistoryDownloads(): void {
       context.mocks.s3.send.mockImplementation((command: unknown) => {
         if (command instanceof GetObjectCommand) {
+          const key =
+            typeof command.input.Key === "string" ? command.input.Key : "";
+          const historyBody = sessionHistoryBlobBodyForKey(context, key);
           return Promise.resolve({
             Body: (async function* () {
-              yield new TextEncoder().encode("[]");
+              yield historyBody ?? new TextEncoder().encode("[]");
             })(),
           });
         }

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs-automations.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs-automations.ts
@@ -69,6 +69,9 @@ import { createZeroRouteMocks } from "./zero-route-test";
 type AuthHeaders = { readonly authorization?: string };
 type ZeroRunRequest = z.infer<(typeof zeroRunsMainContract.create)["body"]>;
 type DirectRunRequest = z.infer<(typeof runsMainContract.create)["body"]>;
+type RunnerJobClaimRequest = z.infer<
+  (typeof runnersJobClaimContract.claim)["body"]
+>;
 type ComposeContent = z.infer<
   (typeof composesMainContract.create)["body"]
 >["content"];
@@ -495,12 +498,12 @@ export function createRunsAutomationsApi(context: TestContext) {
       return response.body;
     },
 
-    async claimRunnerJob(runId: string) {
+    async claimRunnerJob(runId: string, body: RunnerJobClaimRequest = {}) {
       const response = await accept(
         setupApp({ context })(runnersJobClaimContract).claim({
           headers: runnerHeaders(true),
           params: { id: runId },
-          body: {},
+          body,
         }),
         [200],
       );

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-session-history.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-session-history.ts
@@ -1,0 +1,51 @@
+import { Buffer } from "node:buffer";
+import { createHash } from "node:crypto";
+
+import type { TestContext } from "../../../../__tests__/test-helpers";
+
+function knownSessionHistoryBodies(runId: string): readonly string[] {
+  return [
+    `bdd agentphone history ${runId}`,
+    `bdd chat session history ${runId}`,
+    `bdd chat thread history ${runId}`,
+    `bdd github session history ${runId}`,
+    `bdd run reads history ${runId}`,
+    `bdd schedule history ${runId}`,
+    `bdd session history ${runId}`,
+    `bdd slack history ${runId}`,
+    `bdd snapshot history ${runId}`,
+    `bdd cleanup-first session history ${runId}`,
+  ];
+}
+
+function hashText(text: string): string {
+  return createHash("sha256").update(text).digest("hex");
+}
+
+export function registerKnownSessionHistoryBlob(
+  context: TestContext,
+  runId: string,
+  hash: string,
+): void {
+  for (const body of knownSessionHistoryBodies(runId)) {
+    if (hashText(body) === hash) {
+      context.sessionHistoryBlobs.set(hash, Buffer.from(body, "utf8"));
+      return;
+    }
+  }
+}
+
+export function sessionHistoryBlobBodyForKey(
+  context: TestContext,
+  key: string,
+): Uint8Array | undefined {
+  const match = /^blobs\/([a-f0-9]{64})\.blob$/.exec(key);
+  if (!match) {
+    return undefined;
+  }
+  const hash = match[1];
+  if (!hash) {
+    return undefined;
+  }
+  return context.sessionHistoryBlobs.get(hash);
+}

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-webhooks.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-webhooks.ts
@@ -36,6 +36,7 @@ import {
   setupApp,
   type TestContext,
 } from "../../../../__tests__/test-helpers";
+import { registerKnownSessionHistoryBlob } from "./api-bdd-session-history";
 
 type AgentEventsBody = z.infer<(typeof webhookEventsContract.send)["body"]>;
 type AgentCompleteBody = z.infer<
@@ -580,6 +581,11 @@ export function createWebhookCallbackApi(context: TestContext) {
       headers: SandboxWebhookHeaders,
       statuses: readonly (200 | 400 | 401 | 404 | 500)[],
     ) {
+      registerKnownSessionHistoryBlob(
+        context,
+        body.runId,
+        body.cliAgentSessionHistoryHash,
+      );
       return await accept(
         setupApp({ context })(webhookCheckpointsContract).create({
           headers,

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -1277,16 +1277,9 @@ describe("RUN-01/RUN-02: checkpoint resume, memory policies, and volume pinning"
       "Runner job missing resume session history",
     );
 
-    const [failedRun] = await store
-      .set(writeDb$)
-      .select({ status: agentRuns.status, error: agentRuns.error })
-      .from(agentRuns)
-      .where(eq(agentRuns.id, resumed.runId))
-      .limit(1);
-    expect(failedRun).toStrictEqual({
-      status: "failed",
-      error: "Runner job missing resume session history",
-    });
+    const failedRun = await api.readRun(actor, resumed.runId);
+    expect(failedRun.status).toBe("failed");
+    expect(failedRun.error).toBe("Runner job missing resume session history");
     await api.requestClaimRunnerJob(true, resumed.runId, [404]);
   });
 
@@ -1312,16 +1305,9 @@ describe("RUN-01/RUN-02: checkpoint resume, memory policies, and volume pinning"
     );
     await api.requestClaimRunnerJob(true, resumed.runId, [500]);
 
-    const [pendingRun] = await store
-      .set(writeDb$)
-      .select({ status: agentRuns.status, error: agentRuns.error })
-      .from(agentRuns)
-      .where(eq(agentRuns.id, resumed.runId))
-      .limit(1);
-    expect(pendingRun).toStrictEqual({
-      status: "pending",
-      error: null,
-    });
+    const pendingRun = await api.readRun(actor, resumed.runId);
+    expect(pendingRun.status).toBe("pending");
+    expect(pendingRun.error).toBeUndefined();
     await api.requestCancelRun(actor, resumed.runId, [200]);
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -98,6 +98,17 @@ function sandboxHeaders(token: string): { readonly authorization: string } {
   return { authorization: `Bearer ${token}` };
 }
 
+function s3CommandKey(command: unknown): string | undefined {
+  return (command as { readonly input?: { readonly Key?: string } }).input?.Key;
+}
+
+function countSessionHistoryBlobReads(hash: string): number {
+  const blobKey = `blobs/${hash}.blob`;
+  return context.mocks.s3.send.mock.calls.filter(([command]) => {
+    return s3CommandKey(command) === blobKey;
+  }).length;
+}
+
 /**
  * Marks a claimed run completed through the sandbox webhooks. Successful
  * completion requires a checkpoint, so one is always posted first.
@@ -1007,11 +1018,44 @@ describe("RUN-01/RUN-02: checkpoint resume, memory policies, and volume pinning"
       [200],
     );
 
+    const readsBeforeRefResumeCreate =
+      countSessionHistoryBlobReads(historyHash);
+    const refResumed = await api.createDirectRun(actor, {
+      checkpointId,
+      prompt: "resume from the checkpoint with history ref",
+    });
+    expect(countSessionHistoryBlobReads(historyHash)).toBe(
+      readsBeforeRefResumeCreate,
+    );
+    const refClaim = await api.claimRunnerJob(refResumed.runId, {
+      capabilities: ["resumeSessionHistoryRef"],
+    });
+    expect(countSessionHistoryBlobReads(historyHash)).toBe(
+      readsBeforeRefResumeCreate,
+    );
+    expect(refClaim.resumeSession).toStrictEqual({
+      sessionId: `bdd-cli-${r1.runId}`,
+      historyRef: {
+        kind: "blob",
+        hash: historyHash,
+        url: "https://r2.example.com/storages/presigned?sig=bdd",
+      },
+    });
+    await api.requestCancelRun(actor, refResumed.runId, [200]);
+
+    const readsBeforeInlineResumeCreate =
+      countSessionHistoryBlobReads(historyHash);
     const resumed = await api.createDirectRun(actor, {
       checkpointId,
       prompt: "resume from the checkpoint",
     });
+    expect(countSessionHistoryBlobReads(historyHash)).toBe(
+      readsBeforeInlineResumeCreate,
+    );
     const claim2 = await api.claimRunnerJob(resumed.runId);
+    expect(countSessionHistoryBlobReads(historyHash)).toBe(
+      readsBeforeInlineResumeCreate + 1,
+    );
     expect(claim2.checkpointId).toBe(checkpointId);
     expect(claim2.vars).toStrictEqual({ VOL_VERSION: versionPrefix });
     expect(claim2.resumeSession).toStrictEqual({

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -102,11 +102,58 @@ function s3CommandKey(command: unknown): string | undefined {
   return (command as { readonly input?: { readonly Key?: string } }).input?.Key;
 }
 
+interface S3NotFoundError extends Error {
+  Code: string;
+  $metadata: { httpStatusCode: number };
+}
+
+function s3ObjectNotFoundError(): S3NotFoundError {
+  const error = new Error("NotFound") as S3NotFoundError;
+  error.name = "NotFound";
+  error.Code = "NoSuchKey";
+  error.$metadata = { httpStatusCode: 404 };
+  return error;
+}
+
 function countSessionHistoryBlobReads(hash: string): number {
   const blobKey = `blobs/${hash}.blob`;
   return context.mocks.s3.send.mock.calls.filter(([command]) => {
     return s3CommandKey(command) === blobKey;
   }).length;
+}
+
+async function createHashBackedResumeRun(
+  actor: ApiTestUser,
+  composeId: string,
+  historyHash: string,
+  prefix: string,
+): Promise<{ readonly runId: string }> {
+  const first = await api.createDirectRun(actor, {
+    agentComposeId: composeId,
+    prompt: `${prefix} first run`,
+  });
+  const firstClaim = await api.claimRunnerJob(first.runId);
+  const checkpoint = await webhooks.requestAgentCheckpoint(
+    {
+      runId: first.runId,
+      cliAgentType: "claude-code",
+      cliAgentSessionId: `bdd-cli-${first.runId}`,
+      cliAgentSessionHistoryHash: historyHash,
+    },
+    sandboxHeaders(firstClaim.sandboxToken),
+    [200],
+  );
+  mustOk(checkpoint, "checkpoint webhook");
+  await webhooks.requestAgentComplete(
+    { runId: first.runId, exitCode: 0 },
+    sandboxHeaders(firstClaim.sandboxToken),
+    [200],
+  );
+
+  return await api.createDirectRun(actor, {
+    checkpointId: checkpoint.body.checkpointId,
+    prompt: `${prefix} resume run`,
+  });
 }
 
 /**
@@ -1198,6 +1245,84 @@ describe("RUN-01/RUN-02: checkpoint resume, memory policies, and volume pinning"
       missingRootPolicy: "preserveParentVersion",
     });
     await api.requestCancelRun(actor, continued.runId, [200]);
+  });
+
+  it("fails a hash-backed resume run instead of leaving old runner claims pending when history is missing", async () => {
+    const actor = await entitledActor();
+    const compose = await createClaudeCompose(actor, "bdd-missing-history");
+    const missingHistoryHash = createHash("sha256")
+      .update(`missing resume history ${randomUUID()}`)
+      .digest("hex");
+
+    context.mocks.s3.send.mockImplementation((command: unknown) => {
+      if (s3CommandKey(command) === `blobs/${missingHistoryHash}.blob`) {
+        return Promise.reject(s3ObjectNotFoundError());
+      }
+      return Promise.resolve({});
+    });
+
+    const resumed = await createHashBackedResumeRun(
+      actor,
+      compose.composeId,
+      missingHistoryHash,
+      "missing history",
+    );
+    const failedClaim = await api.requestClaimRunnerJob(
+      true,
+      resumed.runId,
+      [400],
+    );
+    expectApiError(failedClaim.body);
+    expect(failedClaim.body.error.message).toBe(
+      "Runner job missing resume session history",
+    );
+
+    const [failedRun] = await store
+      .set(writeDb$)
+      .select({ status: agentRuns.status, error: agentRuns.error })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, resumed.runId))
+      .limit(1);
+    expect(failedRun).toStrictEqual({
+      status: "failed",
+      error: "Runner job missing resume session history",
+    });
+    await api.requestClaimRunnerJob(true, resumed.runId, [404]);
+  });
+
+  it("keeps a hash-backed resume run pending when old runner history read fails transiently", async () => {
+    const actor = await entitledActor();
+    const compose = await createClaudeCompose(actor, "bdd-transient-history");
+    const historyHash = createHash("sha256")
+      .update(`transient resume history ${randomUUID()}`)
+      .digest("hex");
+
+    context.mocks.s3.send.mockImplementation((command: unknown) => {
+      if (s3CommandKey(command) === `blobs/${historyHash}.blob`) {
+        return Promise.reject(new Error("transient S3 timeout"));
+      }
+      return Promise.resolve({});
+    });
+
+    const resumed = await createHashBackedResumeRun(
+      actor,
+      compose.composeId,
+      historyHash,
+      "transient history",
+    );
+    await api.requestClaimRunnerJob(true, resumed.runId, [500]);
+
+    const [pendingRun] = await store
+      .set(writeDb$)
+      .select({ status: agentRuns.status, error: agentRuns.error })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, resumed.runId))
+      .limit(1);
+    expect(pendingRun).toStrictEqual({
+      status: "pending",
+      error: null,
+    });
+    await api.requestCancelRun(actor, resumed.runId, [200]);
   });
 });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -1,6 +1,9 @@
 import { createHash, randomUUID } from "node:crypto";
 
-import { CANONICAL_CLAUDE_MEMORY_MOUNT_PATH } from "@vm0/api-contracts/contracts/runners";
+import {
+  CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
+  RESUME_SESSION_HISTORY_MAX_BYTES,
+} from "@vm0/api-contracts/contracts/runners";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { createStore } from "ccstate";
 import { eq } from "drizzle-orm";
@@ -120,6 +123,14 @@ function countSessionHistoryBlobReads(hash: string): number {
   return context.mocks.s3.send.mock.calls.filter(([command]) => {
     return s3CommandKey(command) === blobKey;
   }).length;
+}
+
+function s3TextBody(text: string): AsyncIterable<Buffer> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield Buffer.from(text, "utf8");
+    },
+  };
 }
 
 async function createHashBackedResumeRun(
@@ -1309,6 +1320,87 @@ describe("RUN-01/RUN-02: checkpoint resume, memory policies, and volume pinning"
     expect(pendingRun.status).toBe("pending");
     expect(pendingRun.error).toBeUndefined();
     await api.requestCancelRun(actor, resumed.runId, [200]);
+  });
+
+  it("fails a hash-backed resume run when old runner history hash validation fails", async () => {
+    const actor = await entitledActor();
+    const compose = await createClaudeCompose(actor, "bdd-bad-history-hash");
+    const historyHash = createHash("sha256")
+      .update(`expected resume history ${randomUUID()}`)
+      .digest("hex");
+
+    context.mocks.s3.send.mockImplementation((command: unknown) => {
+      if (s3CommandKey(command) === `blobs/${historyHash}.blob`) {
+        return Promise.resolve({
+          Body: s3TextBody(`corrupt resume history ${randomUUID()}`),
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    const resumed = await createHashBackedResumeRun(
+      actor,
+      compose.composeId,
+      historyHash,
+      "bad history hash",
+    );
+    const failedClaim = await api.requestClaimRunnerJob(
+      true,
+      resumed.runId,
+      [400],
+    );
+    expectApiError(failedClaim.body);
+    expect(failedClaim.body.error.message).toBe(
+      "Runner job has invalid resume session history",
+    );
+
+    const failedRun = await api.readRun(actor, resumed.runId);
+    expect(failedRun.status).toBe("failed");
+    expect(failedRun.error).toBe(
+      "Runner job has invalid resume session history",
+    );
+    await api.requestClaimRunnerJob(true, resumed.runId, [404]);
+  });
+
+  it("fails a hash-backed resume run when old runner history is oversized", async () => {
+    const actor = await entitledActor();
+    const compose = await createClaudeCompose(actor, "bdd-oversized-history");
+    const historyHash = createHash("sha256")
+      .update(`oversized resume history ${randomUUID()}`)
+      .digest("hex");
+
+    context.mocks.s3.send.mockImplementation((command: unknown) => {
+      if (s3CommandKey(command) === `blobs/${historyHash}.blob`) {
+        return Promise.resolve({
+          ContentLength: RESUME_SESSION_HISTORY_MAX_BYTES + 1,
+          Body: s3TextBody(""),
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    const resumed = await createHashBackedResumeRun(
+      actor,
+      compose.composeId,
+      historyHash,
+      "oversized history",
+    );
+    const failedClaim = await api.requestClaimRunnerJob(
+      true,
+      resumed.runId,
+      [400],
+    );
+    expectApiError(failedClaim.body);
+    expect(failedClaim.body.error.message).toBe(
+      "Runner job has invalid resume session history",
+    );
+
+    const failedRun = await api.readRun(actor, resumed.runId);
+    expect(failedRun.status).toBe("failed");
+    expect(failedRun.error).toBe(
+      "Runner job has invalid resume session history",
+    );
+    await api.requestClaimRunnerJob(true, resumed.runId, [404]);
   });
 });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -1350,6 +1350,19 @@ describe("WHCB-06: sandbox agent artifact webhook boundaries", () => {
     expectApiError(malformedCheckpoint.body);
     expect(malformedCheckpoint.body.error.code).toBe("BAD_REQUEST");
 
+    const uppercaseCheckpointHash = await api.requestAgentCheckpointUnchecked(
+      {
+        runId,
+        cliAgentType: "claude-code",
+        cliAgentSessionId: "session-bdd",
+        cliAgentSessionHistoryHash: "A".repeat(64),
+      },
+      headers,
+      [400],
+    );
+    expectApiError(uppercaseCheckpointHash.body);
+    expect(uppercaseCheckpointHash.body.error.code).toBe("BAD_REQUEST");
+
     const missingCheckpointRun = await api.requestAgentCheckpoint(
       {
         runId,
@@ -1393,6 +1406,15 @@ describe("WHCB-06: sandbox agent artifact webhook boundaries", () => {
       );
     expectApiError(malformedHistoryPrepare.body);
     expect(malformedHistoryPrepare.body.error.code).toBe("BAD_REQUEST");
+
+    const uppercaseHistoryPrepare =
+      await api.requestAgentCheckpointPrepareHistoryUnchecked(
+        { runId, hash: "A".repeat(64), size: 128 },
+        headers,
+        [400],
+      );
+    expectApiError(uppercaseHistoryPrepare.body);
+    expect(uppercaseHistoryPrepare.body.error.code).toBe("BAD_REQUEST");
 
     const mismatchedStoragePrepare = await api.requestAgentStoragePrepare(
       {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -1,5 +1,6 @@
 import { createHash, randomInt, randomUUID } from "node:crypto";
 
+import { RESUME_SESSION_HISTORY_MAX_BYTES } from "@vm0/api-contracts/contracts/runners";
 import { MAX_FILE_SIZE_BYTES } from "@vm0/api-contracts/contracts/storages";
 import { automations, automationTriggers } from "@vm0/db/schema/automation";
 import { orgConcurrencyEntitlements } from "@vm0/db/schema/org-concurrency-entitlement";
@@ -1415,6 +1416,15 @@ describe("WHCB-06: sandbox agent artifact webhook boundaries", () => {
       );
     expectApiError(uppercaseHistoryPrepare.body);
     expect(uppercaseHistoryPrepare.body.error.code).toBe("BAD_REQUEST");
+
+    const oversizedHistoryPrepare =
+      await api.requestAgentCheckpointPrepareHistoryUnchecked(
+        { runId, hash, size: RESUME_SESSION_HISTORY_MAX_BYTES + 1 },
+        headers,
+        [400],
+      );
+    expectApiError(oversizedHistoryPrepare.body);
+    expect(oversizedHistoryPrepare.body.error.code).toBe("BAD_REQUEST");
 
     const mismatchedStoragePrepare = await api.requestAgentStoragePrepare(
       {

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -7,11 +7,13 @@ import {
   storedExecutionContextSchema,
   type ExecutionContext,
   type HeldSessionState,
+  type RunnerClaimCapability,
   type StoredExecutionContext,
 } from "@vm0/api-contracts/contracts/runners";
 import { runnerRealtimeTokenContract } from "@vm0/api-contracts/contracts/realtime";
 import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
 import { agentRuns } from "@vm0/db/schema/agent-run";
+import { blobs } from "@vm0/db/schema/blob";
 import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
 import { runnerState } from "@vm0/db/schema/runner-state";
 import { and, eq, gt, inArray, isNull, lt, sql, type SQL } from "drizzle-orm";
@@ -21,12 +23,14 @@ import { authorization$ } from "../context/hono";
 import { bodyResultOf, pathParamsOf } from "../context/request";
 import { waitUntil } from "../context/wait-until";
 import { writeDb$, type Db } from "../external/db";
+import { downloadS3Buffer, generatePresignedGetUrl } from "../external/s3";
 import {
   createRunnerGroupRealtimeToken,
   publishRunChangedForUserSafely,
 } from "../external/realtime";
 import { recordSandboxOperations } from "../external/sandbox-op-log";
 import { now, nowDate } from "../external/time";
+import { env } from "../../lib/env";
 import { badRequestMessage, conflict, notFound } from "../../lib/error";
 import { logger } from "../../lib/log";
 import { generateSandboxToken } from "../auth/tokens";
@@ -46,6 +50,9 @@ const STALE_RUNNER_THRESHOLD_MS = 5 * 60 * 1000;
 const INVALID_EXECUTION_CONTEXT_ERROR =
   "Runner job missing valid execution context";
 const MAX_VALIDATION_ISSUES_TO_LOG = 10;
+const RESUME_SESSION_HISTORY_URL_TTL_SECONDS = 60 * 60;
+const RESUME_SESSION_HISTORY_REF_CAPABILITY =
+  "resumeSessionHistoryRef" satisfies RunnerClaimCapability;
 
 type ClaimRouteTimingSpanKind = "top_level" | "nested";
 type ClaimRouteTimingActionType =
@@ -579,10 +586,24 @@ type ClaimedTransitionResult = Extract<
   ClaimTransitionResult,
   { readonly status: "claimed" }
 >;
+type FailedClaimTransitionResult = Exclude<
+  ClaimTransitionResult,
+  { readonly status: "claimed" }
+>;
 
 interface LockedClaimRunRow extends Record<string, unknown> {
   readonly id: string;
   readonly status: string;
+}
+
+function claimTransitionErrorResponse(result: FailedClaimTransitionResult) {
+  if (result.status === "conflict") {
+    return conflict("Job was claimed by another runner");
+  }
+  if (result.status === "job-not-found") {
+    return notFound("Job not found in queue");
+  }
+  return notFound("Run not found");
 }
 
 interface LockedRunnerJobRow extends Record<string, unknown> {
@@ -708,6 +729,20 @@ type PoisonJobResult =
   | { readonly status: "conflict" }
   | { readonly status: "job-not-found" }
   | { readonly status: "run-not-found" };
+type FailedPoisonJobResult = Exclude<
+  PoisonJobResult,
+  { readonly status: "failed" }
+>;
+
+function poisonJobErrorResponse(result: FailedPoisonJobResult) {
+  if (result.status === "conflict") {
+    return conflict("Job was claimed by another runner");
+  }
+  if (result.status === "job-not-found") {
+    return notFound("Job not found in queue");
+  }
+  return notFound("Run not found");
+}
 
 async function failPoisonQueuedJob(
   db: Db,
@@ -778,12 +813,98 @@ async function secretValuesForRunner(
   });
 }
 
+type StoredResumeSessionWithHistoryRef = Extract<
+  NonNullable<StoredExecutionContext["resumeSession"]>,
+  { historyRef: { kind: "blob"; hash: string } }
+>;
+
+function hasResumeSessionHistoryRef(
+  resumeSession: StoredExecutionContext["resumeSession"],
+): resumeSession is StoredResumeSessionWithHistoryRef {
+  return resumeSession !== null && "historyRef" in resumeSession;
+}
+
+function runnerSupportsResumeSessionHistoryRef(
+  capabilities: readonly RunnerClaimCapability[] | undefined,
+): boolean {
+  return capabilities?.includes(RESUME_SESSION_HISTORY_REF_CAPABILITY) ?? false;
+}
+
+function resumeSessionHistoryBlobKey(hash: string): string {
+  return `blobs/${hash}.blob`;
+}
+
+const generateResumeSessionHistoryUrl$ = command(
+  async ({ get }, hash: string): Promise<string> => {
+    return await get(
+      generatePresignedGetUrl(
+        env("R2_USER_STORAGES_BUCKET_NAME"),
+        resumeSessionHistoryBlobKey(hash),
+        RESUME_SESSION_HISTORY_URL_TTL_SECONDS,
+        undefined,
+        true,
+      ),
+    );
+  },
+);
+
+const loadResumeSessionHistory$ = command(
+  async ({ get }, hash: string): Promise<string> => {
+    const buffer = await get(
+      downloadS3Buffer(
+        env("R2_USER_STORAGES_BUCKET_NAME"),
+        resumeSessionHistoryBlobKey(hash),
+      ),
+    );
+    return buffer.toString("utf8");
+  },
+);
+
+async function resolveResumeSessionForClaim(args: {
+  readonly db: Db;
+  readonly resumeSession: StoredExecutionContext["resumeSession"];
+  readonly supportsResumeSessionHistoryRef: boolean;
+  readonly generateResumeSessionHistoryUrl: (hash: string) => Promise<string>;
+  readonly loadResumeSessionHistory: (hash: string) => Promise<string>;
+}): Promise<ExecutionContext["resumeSession"]> {
+  const resumeSession = args.resumeSession;
+  if (!hasResumeSessionHistoryRef(resumeSession)) {
+    return resumeSession;
+  }
+
+  const { sessionId, historyRef } = resumeSession;
+  if (!args.supportsResumeSessionHistoryRef) {
+    return {
+      sessionId,
+      sessionHistory: await args.loadResumeSessionHistory(historyRef.hash),
+    };
+  }
+
+  const [blob] = await args.db
+    .select({ size: blobs.size })
+    .from(blobs)
+    .where(eq(blobs.hash, historyRef.hash))
+    .limit(1);
+  const url = await args.generateResumeSessionHistoryUrl(historyRef.hash);
+  return {
+    sessionId,
+    historyRef: {
+      ...historyRef,
+      url,
+      ...(blob && blob.size > 0 ? { size: blob.size } : {}),
+    },
+  };
+}
+
 async function buildClaimResponseBody(args: {
   readonly db: Db;
   readonly run: ClaimedRun;
   readonly storedContext: StoredExecutionContext;
   readonly timing: ClaimRouteTimingCollector;
   readonly signal: AbortSignal;
+  readonly supportsResumeSessionHistoryRef: boolean;
+  readonly generateResumeSessionHistoryUrl: (hash: string) => Promise<string>;
+  readonly loadResumeSessionHistory: (hash: string) => Promise<string>;
 }): Promise<ExecutionContext> {
   const featureSwitchContext = await args.timing.measure(
     "claim_route_feature_switch_context",
@@ -805,29 +926,37 @@ async function buildClaimResponseBody(args: {
     },
   );
   args.signal.throwIfAborted();
-  const responseAssemblyStartedAt = now();
-  const sandboxToken = generateSandboxToken(
-    args.run.userId,
-    args.run.id,
-    args.run.orgId,
-  );
-  const responseBody = {
-    ...args.storedContext,
-    runId: args.run.id,
-    prompt: args.run.prompt,
-    appendSystemPrompt: args.run.appendSystemPrompt,
-    agentComposeVersionId: args.run.agentComposeVersionId,
-    vars: (args.run.vars as Record<string, string>) ?? null,
-    checkpointId: args.run.resumedFromCheckpointId ?? null,
-    sandboxToken,
-    secretValues,
-  };
-  args.timing.recordElapsed(
+  return await args.timing.measure(
     "claim_route_response_assembly",
     "top_level",
-    responseAssemblyStartedAt,
+    async () => {
+      const resumeSession = await resolveResumeSessionForClaim({
+        db: args.db,
+        resumeSession: args.storedContext.resumeSession,
+        supportsResumeSessionHistoryRef: args.supportsResumeSessionHistoryRef,
+        generateResumeSessionHistoryUrl: args.generateResumeSessionHistoryUrl,
+        loadResumeSessionHistory: args.loadResumeSessionHistory,
+      });
+      args.signal.throwIfAborted();
+      const sandboxToken = generateSandboxToken(
+        args.run.userId,
+        args.run.id,
+        args.run.orgId,
+      );
+      return {
+        ...args.storedContext,
+        runId: args.run.id,
+        prompt: args.run.prompt,
+        appendSystemPrompt: args.run.appendSystemPrompt,
+        agentComposeVersionId: args.run.agentComposeVersionId,
+        vars: (args.run.vars as Record<string, string>) ?? null,
+        checkpointId: args.run.resumedFromCheckpointId ?? null,
+        resumeSession,
+        sandboxToken,
+        secretValues,
+      };
+    },
   );
-  return responseBody;
 }
 
 function scheduleSuccessfulClaimSideEffects(args: {
@@ -1137,14 +1266,8 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       INVALID_EXECUTION_CONTEXT_ERROR,
       signal,
     );
-    if (poisonResult.status === "conflict") {
-      return conflict("Job was claimed by another runner");
-    }
-    if (poisonResult.status === "job-not-found") {
-      return notFound("Job not found in queue");
-    }
-    if (poisonResult.status === "run-not-found") {
-      return notFound("Run not found");
+    if (poisonResult.status !== "failed") {
+      return poisonJobErrorResponse(poisonResult);
     }
 
     set(scheduleClaimFailedSideEffects$, {
@@ -1163,6 +1286,15 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     storedContext,
     timing: claimRouteTiming,
     signal,
+    supportsResumeSessionHistoryRef: runnerSupportsResumeSessionHistoryRef(
+      body.data.capabilities,
+    ),
+    generateResumeSessionHistoryUrl(hash: string) {
+      return set(generateResumeSessionHistoryUrl$, hash);
+    },
+    loadResumeSessionHistory(hash: string) {
+      return set(loadResumeSessionHistory$, hash);
+    },
   });
   signal.throwIfAborted();
 
@@ -1179,14 +1311,8 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     },
   );
   signal.throwIfAborted();
-  if (claimResult.status === "conflict") {
-    return conflict("Job was claimed by another runner");
-  }
-  if (claimResult.status === "job-not-found") {
-    return notFound("Job not found in queue");
-  }
-  if (claimResult.status === "run-not-found") {
-    return notFound("Run not found");
+  if (claimResult.status !== "claimed") {
+    return claimTransitionErrorResponse(claimResult);
   }
 
   scheduleSuccessfulClaimSideEffects({

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -37,7 +37,7 @@ import { decryptPersistentSecretsMap } from "../services/crypto.utils";
 import { dispatchCompleteSideEffects$ } from "../services/agent-webhook-complete.service";
 import { loadUserFeatureSwitchContext } from "../services/feature-switches.service";
 import type { RouteEntry } from "../route";
-import { tapError } from "../utils";
+import { settle, tapError } from "../utils";
 
 const L = logger("Runners");
 
@@ -52,6 +52,62 @@ const MAX_VALIDATION_ISSUES_TO_LOG = 10;
 const RESUME_SESSION_HISTORY_URL_TTL_SECONDS = 60 * 60;
 const RESUME_SESSION_HISTORY_REF_CAPABILITY =
   "resumeSessionHistoryRef" satisfies RunnerClaimCapability;
+const RESUME_SESSION_HISTORY_LOAD_ERROR =
+  "Runner job missing resume session history";
+const EMPTY_S3_BODY_MESSAGE = "S3 object body is empty";
+
+interface ClaimFailedSideEffectArgs {
+  readonly runId: string;
+  readonly userId: string;
+  readonly orgId: string;
+  readonly error: string;
+}
+
+class ResumeSessionHistoryLoadError extends Error {
+  constructor(
+    readonly hash: string,
+    readonly cause: unknown,
+  ) {
+    super(RESUME_SESSION_HISTORY_LOAD_ERROR);
+    this.name = "ResumeSessionHistoryLoadError";
+  }
+}
+
+function isResumeSessionHistoryLoadError(
+  error: unknown,
+): error is ResumeSessionHistoryLoadError {
+  return error instanceof ResumeSessionHistoryLoadError;
+}
+
+function errorField(error: unknown, field: string): unknown {
+  if (typeof error !== "object" || error === null) {
+    return undefined;
+  }
+  return Reflect.get(error, field);
+}
+
+function errorStringField(error: unknown, field: string): string | undefined {
+  const value = errorField(error, field);
+  return typeof value === "string" ? value : undefined;
+}
+
+function isMissingResumeSessionHistoryError(error: unknown): boolean {
+  const code =
+    errorStringField(error, "Code") ??
+    errorStringField(error, "code") ??
+    errorStringField(error, "name");
+  const metadata = errorField(error, "$metadata");
+  const status =
+    typeof metadata === "object" && metadata !== null
+      ? errorField(metadata, "httpStatusCode")
+      : undefined;
+  return (
+    code === "NoSuchKey" ||
+    code === "NotFound" ||
+    status === 404 ||
+    errorStringField(error, "message") === EMPTY_S3_BODY_MESSAGE
+  );
+}
 
 type ClaimRouteTimingSpanKind = "top_level" | "nested";
 type ClaimRouteTimingActionType =
@@ -872,9 +928,21 @@ async function resolveResumeSessionForClaim(args: {
 
   const { sessionId, historyRef } = resumeSession;
   if (!args.supportsResumeSessionHistoryRef) {
+    const sessionHistoryResult = await settle(
+      args.loadResumeSessionHistory(historyRef.hash),
+    );
+    if (!sessionHistoryResult.ok) {
+      if (!isMissingResumeSessionHistoryError(sessionHistoryResult.error)) {
+        throw sessionHistoryResult.error;
+      }
+      throw new ResumeSessionHistoryLoadError(
+        historyRef.hash,
+        sessionHistoryResult.error,
+      );
+    }
     return {
       sessionId,
-      sessionHistory: await args.loadResumeSessionHistory(historyRef.hash),
+      sessionHistory: sessionHistoryResult.value,
     };
   }
 
@@ -1160,15 +1228,7 @@ function claimTimingOperation(
 }
 
 const scheduleClaimFailedSideEffects$ = command(
-  (
-    { set },
-    args: {
-      readonly runId: string;
-      readonly userId: string;
-      readonly orgId: string;
-      readonly error: string;
-    },
-  ): void => {
+  ({ set }, args: ClaimFailedSideEffectArgs): void => {
     const backgroundSignal = new AbortController().signal;
     waitUntil(
       publishRunChangedForUserSafely(args.userId, args.runId, {
@@ -1198,6 +1258,65 @@ const scheduleClaimFailedSideEffects$ = command(
   },
 );
 
+async function failClaimForResumeSessionHistoryLoad(args: {
+  readonly db: Db;
+  readonly runId: string;
+  readonly userId: string;
+  readonly orgId: string;
+  readonly hash: string;
+  readonly cause: unknown;
+  readonly signal: AbortSignal;
+  readonly scheduleFailedSideEffects: (args: ClaimFailedSideEffectArgs) => void;
+}) {
+  L.warn("session history R2 object is missing during claim", {
+    runId: args.runId,
+    hash: args.hash,
+    error: args.cause,
+  });
+  const poisonResult = await failPoisonQueuedJob(
+    args.db,
+    args.runId,
+    RESUME_SESSION_HISTORY_LOAD_ERROR,
+    args.signal,
+  );
+  if (poisonResult.status !== "failed") {
+    return poisonJobErrorResponse(poisonResult);
+  }
+  args.scheduleFailedSideEffects({
+    runId: args.runId,
+    userId: args.userId,
+    orgId: args.orgId,
+    error: RESUME_SESSION_HISTORY_LOAD_ERROR,
+  });
+  return badRequestMessage(RESUME_SESSION_HISTORY_LOAD_ERROR);
+}
+
+async function failClaimForInvalidStoredExecutionContext(args: {
+  readonly db: Db;
+  readonly runId: string;
+  readonly userId: string;
+  readonly orgId: string;
+  readonly signal: AbortSignal;
+  readonly scheduleFailedSideEffects: (args: ClaimFailedSideEffectArgs) => void;
+}) {
+  const poisonResult = await failPoisonQueuedJob(
+    args.db,
+    args.runId,
+    INVALID_EXECUTION_CONTEXT_ERROR,
+    args.signal,
+  );
+  if (poisonResult.status !== "failed") {
+    return poisonJobErrorResponse(poisonResult);
+  }
+  args.scheduleFailedSideEffects({
+    runId: args.runId,
+    userId: args.userId,
+    orgId: args.orgId,
+    error: INVALID_EXECUTION_CONTEXT_ERROR,
+  });
+  return badRequestMessage("Job missing execution context");
+}
+
 const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const claimRequestStartedAtMs = now();
   const claimRouteTiming = new ClaimRouteTimingCollector();
@@ -1213,8 +1332,7 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     return body.response;
   }
 
-  const params = get(pathParamsOf(runnersJobClaimContract.claim));
-  const runId = params.id;
+  const runId = get(pathParamsOf(runnersJobClaimContract.claim)).id;
   const db = set(writeDb$);
   claimRouteTiming.recordElapsed(
     "claim_route_request_prepare",
@@ -1251,42 +1369,57 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   signal.throwIfAborted();
   if (!storedContextResult.success) {
     warnInvalidStoredExecutionContext(runId, storedContextResult.error.issues);
-    const poisonResult = await failPoisonQueuedJob(
+    return await failClaimForInvalidStoredExecutionContext({
       db,
-      runId,
-      INVALID_EXECUTION_CONTEXT_ERROR,
-      signal,
-    );
-    if (poisonResult.status !== "failed") {
-      return poisonJobErrorResponse(poisonResult);
-    }
-
-    set(scheduleClaimFailedSideEffects$, {
       runId,
       userId: run.userId,
       orgId: run.orgId,
-      error: INVALID_EXECUTION_CONTEXT_ERROR,
+      signal,
+      scheduleFailedSideEffects(args) {
+        set(scheduleClaimFailedSideEffects$, args);
+      },
     });
-    return badRequestMessage("Job missing execution context");
   }
   const storedContext = storedContextResult.data;
 
-  const responseBody = await buildClaimResponseBody({
-    db,
-    run,
-    storedContext,
-    timing: claimRouteTiming,
+  const responseBodyResult = await settle(
+    buildClaimResponseBody({
+      db,
+      run,
+      storedContext,
+      timing: claimRouteTiming,
+      signal,
+      supportsResumeSessionHistoryRef: runnerSupportsResumeSessionHistoryRef(
+        body.data.capabilities,
+      ),
+      generateResumeSessionHistoryUrl(hash: string) {
+        return set(generateResumeSessionHistoryUrl$, hash);
+      },
+      loadResumeSessionHistory(hash: string) {
+        return set(loadResumeSessionHistory$, hash);
+      },
+    }),
     signal,
-    supportsResumeSessionHistoryRef: runnerSupportsResumeSessionHistoryRef(
-      body.data.capabilities,
-    ),
-    generateResumeSessionHistoryUrl(hash: string) {
-      return set(generateResumeSessionHistoryUrl$, hash);
-    },
-    loadResumeSessionHistory(hash: string) {
-      return set(loadResumeSessionHistory$, hash);
-    },
-  });
+  );
+  if (!responseBodyResult.ok) {
+    const error = responseBodyResult.error;
+    if (!isResumeSessionHistoryLoadError(error)) {
+      throw error;
+    }
+    return await failClaimForResumeSessionHistoryLoad({
+      db,
+      runId,
+      hash: error.hash,
+      userId: run.userId,
+      orgId: run.orgId,
+      cause: error.cause,
+      signal,
+      scheduleFailedSideEffects(args) {
+        set(scheduleClaimFailedSideEffects$, args);
+      },
+    });
+  }
+  const responseBody = responseBodyResult.value;
   signal.throwIfAborted();
 
   const claimResult = await claimRouteTiming.measure(

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -13,7 +13,6 @@ import {
 import { runnerRealtimeTokenContract } from "@vm0/api-contracts/contracts/realtime";
 import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
 import { agentRuns } from "@vm0/db/schema/agent-run";
-import { blobs } from "@vm0/db/schema/blob";
 import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
 import { runnerState } from "@vm0/db/schema/runner-state";
 import { and, eq, gt, inArray, isNull, lt, sql, type SQL } from "drizzle-orm";
@@ -861,7 +860,6 @@ const loadResumeSessionHistory$ = command(
 );
 
 async function resolveResumeSessionForClaim(args: {
-  readonly db: Db;
   readonly resumeSession: StoredExecutionContext["resumeSession"];
   readonly supportsResumeSessionHistoryRef: boolean;
   readonly generateResumeSessionHistoryUrl: (hash: string) => Promise<string>;
@@ -880,18 +878,12 @@ async function resolveResumeSessionForClaim(args: {
     };
   }
 
-  const [blob] = await args.db
-    .select({ size: blobs.size })
-    .from(blobs)
-    .where(eq(blobs.hash, historyRef.hash))
-    .limit(1);
   const url = await args.generateResumeSessionHistoryUrl(historyRef.hash);
   return {
     sessionId,
     historyRef: {
       ...historyRef,
       url,
-      ...(blob && blob.size > 0 ? { size: blob.size } : {}),
     },
   };
 }
@@ -931,7 +923,6 @@ async function buildClaimResponseBody(args: {
     "top_level",
     async () => {
       const resumeSession = await resolveResumeSessionForClaim({
-        db: args.db,
         resumeSession: args.storedContext.resumeSession,
         supportsResumeSessionHistoryRef: args.supportsResumeSessionHistoryRef,
         generateResumeSessionHistoryUrl: args.generateResumeSessionHistoryUrl,

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -1,6 +1,10 @@
+import { isUtf8 } from "node:buffer";
+import { createHash } from "node:crypto";
+
 import { command } from "ccstate";
 import {
   elapsedSinceApiStartMs,
+  RESUME_SESSION_HISTORY_MAX_BYTES,
   runnersHeartbeatContract,
   runnersJobClaimContract,
   runnersPollContract,
@@ -22,7 +26,11 @@ import { authorization$ } from "../context/hono";
 import { bodyResultOf, pathParamsOf } from "../context/request";
 import { waitUntil } from "../context/wait-until";
 import { writeDb$, type Db } from "../external/db";
-import { downloadS3Buffer, generatePresignedGetUrl } from "../external/s3";
+import {
+  downloadS3BufferWithMaxBytes,
+  generatePresignedGetUrl,
+  S3ObjectSizeLimitError,
+} from "../external/s3";
 import {
   createRunnerGroupRealtimeToken,
   publishRunChangedForUserSafely,
@@ -54,6 +62,8 @@ const RESUME_SESSION_HISTORY_REF_CAPABILITY =
   "resumeSessionHistoryRef" satisfies RunnerClaimCapability;
 const RESUME_SESSION_HISTORY_LOAD_ERROR =
   "Runner job missing resume session history";
+const RESUME_SESSION_HISTORY_INVALID_ERROR =
+  "Runner job has invalid resume session history";
 const EMPTY_S3_BODY_MESSAGE = "S3 object body is empty";
 
 interface ClaimFailedSideEffectArgs {
@@ -66,9 +76,10 @@ interface ClaimFailedSideEffectArgs {
 class ResumeSessionHistoryLoadError extends Error {
   constructor(
     readonly hash: string,
+    message: string,
     readonly cause: unknown,
   ) {
-    super(RESUME_SESSION_HISTORY_LOAD_ERROR);
+    super(message);
     this.name = "ResumeSessionHistoryLoadError";
   }
 }
@@ -889,6 +900,37 @@ function resumeSessionHistoryBlobKey(hash: string): string {
   return `blobs/${hash}.blob`;
 }
 
+function invalidResumeSessionHistoryError(
+  hash: string,
+  cause: unknown,
+): ResumeSessionHistoryLoadError {
+  return new ResumeSessionHistoryLoadError(
+    hash,
+    RESUME_SESSION_HISTORY_INVALID_ERROR,
+    cause,
+  );
+}
+
+function decodeVerifiedResumeSessionHistory(
+  hash: string,
+  buffer: Buffer,
+): string {
+  const actualHash = createHash("sha256").update(buffer).digest("hex");
+  if (actualHash !== hash) {
+    throw invalidResumeSessionHistoryError(
+      hash,
+      new Error(`hash mismatch: expected ${hash}, got ${actualHash}`),
+    );
+  }
+  if (!isUtf8(buffer)) {
+    throw invalidResumeSessionHistoryError(
+      hash,
+      new Error("session history is not utf-8"),
+    );
+  }
+  return buffer.toString("utf8");
+}
+
 const generateResumeSessionHistoryUrl$ = command(
   async ({ get }, hash: string): Promise<string> => {
     return await get(
@@ -906,12 +948,13 @@ const generateResumeSessionHistoryUrl$ = command(
 const loadResumeSessionHistory$ = command(
   async ({ get }, hash: string): Promise<string> => {
     const buffer = await get(
-      downloadS3Buffer(
+      downloadS3BufferWithMaxBytes(
         env("R2_USER_STORAGES_BUCKET_NAME"),
         resumeSessionHistoryBlobKey(hash),
+        RESUME_SESSION_HISTORY_MAX_BYTES,
       ),
     );
-    return buffer.toString("utf8");
+    return decodeVerifiedResumeSessionHistory(hash, buffer);
   },
 );
 
@@ -932,11 +975,21 @@ async function resolveResumeSessionForClaim(args: {
       args.loadResumeSessionHistory(historyRef.hash),
     );
     if (!sessionHistoryResult.ok) {
+      if (isResumeSessionHistoryLoadError(sessionHistoryResult.error)) {
+        throw sessionHistoryResult.error;
+      }
+      if (sessionHistoryResult.error instanceof S3ObjectSizeLimitError) {
+        throw invalidResumeSessionHistoryError(
+          historyRef.hash,
+          sessionHistoryResult.error,
+        );
+      }
       if (!isMissingResumeSessionHistoryError(sessionHistoryResult.error)) {
         throw sessionHistoryResult.error;
       }
       throw new ResumeSessionHistoryLoadError(
         historyRef.hash,
+        RESUME_SESSION_HISTORY_LOAD_ERROR,
         sessionHistoryResult.error,
       );
     }
@@ -1264,19 +1317,21 @@ async function failClaimForResumeSessionHistoryLoad(args: {
   readonly userId: string;
   readonly orgId: string;
   readonly hash: string;
+  readonly errorMessage: string;
   readonly cause: unknown;
   readonly signal: AbortSignal;
   readonly scheduleFailedSideEffects: (args: ClaimFailedSideEffectArgs) => void;
 }) {
-  L.warn("session history R2 object is missing during claim", {
+  L.warn("session history R2 object could not be loaded during claim", {
     runId: args.runId,
     hash: args.hash,
+    errorMessage: args.errorMessage,
     error: args.cause,
   });
   const poisonResult = await failPoisonQueuedJob(
     args.db,
     args.runId,
-    RESUME_SESSION_HISTORY_LOAD_ERROR,
+    args.errorMessage,
     args.signal,
   );
   if (poisonResult.status !== "failed") {
@@ -1286,9 +1341,9 @@ async function failClaimForResumeSessionHistoryLoad(args: {
     runId: args.runId,
     userId: args.userId,
     orgId: args.orgId,
-    error: RESUME_SESSION_HISTORY_LOAD_ERROR,
+    error: args.errorMessage,
   });
-  return badRequestMessage(RESUME_SESSION_HISTORY_LOAD_ERROR);
+  return badRequestMessage(args.errorMessage);
 }
 
 async function failClaimForInvalidStoredExecutionContext(args: {
@@ -1315,6 +1370,30 @@ async function failClaimForInvalidStoredExecutionContext(args: {
     error: INVALID_EXECUTION_CONTEXT_ERROR,
   });
   return badRequestMessage("Job missing execution context");
+}
+
+async function claimResponseBuildErrorResponse(args: {
+  readonly db: Db;
+  readonly run: ClaimedRun;
+  readonly runId: string;
+  readonly error: unknown;
+  readonly signal: AbortSignal;
+  readonly scheduleFailedSideEffects: (args: ClaimFailedSideEffectArgs) => void;
+}) {
+  if (!isResumeSessionHistoryLoadError(args.error)) {
+    throw args.error;
+  }
+  return await failClaimForResumeSessionHistoryLoad({
+    db: args.db,
+    runId: args.runId,
+    hash: args.error.hash,
+    userId: args.run.userId,
+    orgId: args.run.orgId,
+    errorMessage: args.error.message,
+    cause: args.error.cause,
+    signal: args.signal,
+    scheduleFailedSideEffects: args.scheduleFailedSideEffects,
+  });
 }
 
 const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
@@ -1402,17 +1481,11 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     signal,
   );
   if (!responseBodyResult.ok) {
-    const error = responseBodyResult.error;
-    if (!isResumeSessionHistoryLoadError(error)) {
-      throw error;
-    }
-    return await failClaimForResumeSessionHistoryLoad({
+    return await claimResponseBuildErrorResponse({
       db,
+      run,
       runId,
-      hash: error.hash,
-      userId: run.userId,
-      orgId: run.orgId,
-      cause: error.cause,
+      error: responseBodyResult.error,
       signal,
       scheduleFailedSideEffects(args) {
         set(scheduleClaimFailedSideEffects$, args);

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -880,7 +880,7 @@ function hasResumeSessionHistoryRef(
 }
 
 function runnerSupportsResumeSessionHistoryRef(
-  capabilities: readonly RunnerClaimCapability[] | undefined,
+  capabilities: readonly string[] | undefined,
 ): boolean {
   return capabilities?.includes(RESUME_SESSION_HISTORY_REF_CAPABILITY) ?? false;
 }

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -114,7 +114,6 @@ import {
   providerUnavailable,
 } from "../../lib/error";
 import { writeDb$, type Db } from "../external/db";
-import { downloadS3Buffer } from "../external/s3";
 import { getDatasetName, ingestToAxiom } from "../external/axiom";
 import {
   publishOrgSignal,
@@ -3171,9 +3170,7 @@ function loadResumeSession(
   timing?: ApiDispatchTimingCollector,
 ): Computed<Promise<StoredExecutionContext["resumeSession"] | undefined>> {
   return computed(
-    async (
-      get,
-    ): Promise<StoredExecutionContext["resumeSession"] | undefined> => {
+    async (): Promise<StoredExecutionContext["resumeSession"] | undefined> => {
       const [conversation] = await db
         .select({
           cliAgentSessionId: conversations.cliAgentSessionId,
@@ -3188,61 +3185,40 @@ function loadResumeSession(
         return undefined;
       }
 
-      const sessionHistory = await measureApiDispatchTiming(
+      const resumeSession = await measureApiDispatchTiming(
         timing,
         "api_dispatch_resolve_compose_resolve_session_history",
         "nested",
-        async () => {
-          return await get(
-            resolveConversationSessionHistory({
-              hash: conversation.cliAgentSessionHistoryHash,
-              legacyText: conversation.cliAgentSessionHistory,
-            }),
-          );
+        (): Promise<StoredExecutionContext["resumeSession"] | null> => {
+          const cliAgentSessionId = conversation.cliAgentSessionId;
+          const hash = conversation.cliAgentSessionHistoryHash;
+          if (hash) {
+            return Promise.resolve({
+              sessionId: cliAgentSessionId,
+              historyRef: {
+                kind: "blob",
+                hash,
+              },
+            });
+          }
+          const sessionHistory = conversation.cliAgentSessionHistory;
+          if (sessionHistory) {
+            return Promise.resolve({
+              sessionId: cliAgentSessionId,
+              sessionHistory,
+            });
+          }
+          return Promise.resolve(null);
         },
       );
 
-      if (sessionHistory === null) {
+      if (resumeSession === null) {
         return undefined;
       }
 
-      const cliAgentSessionId = conversation.cliAgentSessionId;
-      return {
-        sessionId: cliAgentSessionId,
-        sessionHistory,
-      };
+      return resumeSession;
     },
   );
-}
-
-function resolveConversationSessionHistory(args: {
-  readonly hash: string | null;
-  readonly legacyText: string | null;
-}): Computed<Promise<string | null>> {
-  return computed(async (get): Promise<string | null> => {
-    const { hash, legacyText } = args;
-    if (hash) {
-      const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
-      const result = await settle(
-        get(downloadS3Buffer(bucket, `blobs/${hash}.blob`)),
-      );
-      if (result.ok) {
-        return result.value.toString("utf8");
-      }
-      if (legacyText) {
-        L.warn(
-          "session history R2 retrieval failed; falling back to legacy TEXT",
-          { hash, error: result.error },
-        );
-        return legacyText;
-      }
-      throw result.error;
-    }
-    if (legacyText) {
-      return legacyText;
-    }
-    return null;
-  });
 }
 
 function resolveCompose(

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -3,8 +3,11 @@ import { describe, expect, it } from "vitest";
 import {
   elapsedSinceApiStartMs,
   executionContextSchema,
+  resumeSessionSchema,
+  runnersJobClaimContract,
   storageManifestSchema,
   storedExecutionContextSchema,
+  storedResumeSessionSchema,
 } from "../runners";
 
 describe("runner storage manifest contract", () => {
@@ -156,6 +159,86 @@ describe("runner storage manifest contract", () => {
       ],
       artifacts: [],
     });
+  });
+});
+
+describe("runner resume session contract", () => {
+  const historyHash =
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+  it("accepts inline stored and claim resume sessions", () => {
+    const resumeSession = {
+      sessionId: "sess-123",
+      sessionHistory: '{"type":"init"}\n',
+    };
+
+    expect(storedResumeSessionSchema.safeParse(resumeSession).success).toBe(
+      true,
+    );
+    expect(resumeSessionSchema.safeParse(resumeSession).success).toBe(true);
+  });
+
+  it("accepts hash-backed stored resume sessions without URLs", () => {
+    const resumeSession = {
+      sessionId: "sess-123",
+      historyRef: { kind: "blob", hash: historyHash },
+    };
+
+    expect(storedResumeSessionSchema.parse(resumeSession)).toEqual(
+      resumeSession,
+    );
+    expect(
+      storedExecutionContextSchema.shape.resumeSession.safeParse(resumeSession)
+        .success,
+    ).toBe(true);
+  });
+
+  it("requires a URL for hash-backed claim resume sessions", () => {
+    const storedResumeSession = {
+      sessionId: "sess-123",
+      historyRef: { kind: "blob", hash: historyHash },
+    };
+    const claimResumeSession = {
+      sessionId: "sess-123",
+      historyRef: {
+        kind: "blob",
+        hash: historyHash,
+        url: "https://r2.example.com/blobs/history.blob?sig=secret",
+      },
+    };
+
+    expect(resumeSessionSchema.safeParse(storedResumeSession).success).toBe(
+      false,
+    );
+    expect(resumeSessionSchema.parse(claimResumeSession)).toEqual(
+      claimResumeSession,
+    );
+    expect(
+      executionContextSchema.shape.resumeSession.safeParse(claimResumeSession)
+        .success,
+    ).toBe(true);
+  });
+
+  it("rejects non-lowercase session history hashes", () => {
+    const resumeSession = {
+      sessionId: "sess-123",
+      historyRef: { kind: "blob", hash: "A".repeat(64) },
+    };
+
+    expect(storedResumeSessionSchema.safeParse(resumeSession).success).toBe(
+      false,
+    );
+    expect(resumeSessionSchema.safeParse(resumeSession).success).toBe(false);
+  });
+});
+
+describe("runner claim capability contract", () => {
+  it("accepts unknown capabilities for forward compatibility", () => {
+    const result = runnersJobClaimContract.claim.body.safeParse({
+      capabilities: ["resumeSessionHistoryRef", "futureCapability"],
+    });
+
+    expect(result.success).toBe(true);
   });
 });
 

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   elapsedSinceApiStartMs,
   executionContextSchema,
+  RESUME_SESSION_HISTORY_MAX_BYTES,
   resumeSessionSchema,
   runnersJobClaimContract,
   storageManifestSchema,
@@ -228,6 +229,20 @@ describe("runner resume session contract", () => {
     expect(storedResumeSessionSchema.safeParse(resumeSession).success).toBe(
       false,
     );
+    expect(resumeSessionSchema.safeParse(resumeSession).success).toBe(false);
+  });
+
+  it("rejects oversized hash-backed claim resume sessions", () => {
+    const resumeSession = {
+      sessionId: "sess-123",
+      historyRef: {
+        kind: "blob",
+        hash: historyHash,
+        url: "https://r2.example.com/blobs/history.blob?sig=secret",
+        size: RESUME_SESSION_HISTORY_MAX_BYTES + 1,
+      },
+    };
+
     expect(resumeSessionSchema.safeParse(resumeSession).success).toBe(false);
   });
 });

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -19,6 +19,9 @@ const CANONICAL_CLAUDE_PROJECT_NAME = CANONICAL_WORKING_DIR.replace(
 ).replace(/\//g, "-");
 export const CANONICAL_CLAUDE_MEMORY_MOUNT_PATH = `${CANONICAL_GUEST_HOME_DIR}/.claude/projects/-${CANONICAL_CLAUDE_PROJECT_NAME}/memory`;
 export const CANONICAL_CODEX_MEMORY_MOUNT_PATH = `${CANONICAL_GUEST_HOME_DIR}/.codex/memories`;
+// Must stay in sync with the runner download cap:
+// crates/runner/src/executor/session_history_download.rs.
+export const RESUME_SESSION_HISTORY_MAX_BYTES = 128 * 1024 * 1024;
 
 export function elapsedSinceApiStartMs(
   apiStartTimeMs: number | undefined,
@@ -187,7 +190,12 @@ const resumeSessionRefSchema = z.object({
   sessionId: z.string(),
   historyRef: resumeSessionHistoryBlobRefSchema.extend({
     url: z.string().url(),
-    size: z.number().int().nonnegative().optional(),
+    size: z
+      .number()
+      .int()
+      .nonnegative()
+      .max(RESUME_SESSION_HISTORY_MAX_BYTES)
+      .optional(),
   }),
 });
 

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -201,7 +201,9 @@ export const resumeSessionSchema = z.union([
   resumeSessionRefSchema,
 ]);
 
-export const runnerClaimCapabilitySchema = z.enum(["resumeSessionHistoryRef"]);
+// Capability names are intentionally open-ended so a newer runner can claim
+// jobs through an older API; the API ignores capabilities it does not know.
+export const runnerClaimCapabilitySchema = z.string().min(1);
 
 export const secretConnectorMetadataSchema = z.object({
   sourceType: z.enum(["connector", "model-provider"]),
@@ -421,4 +423,4 @@ export type ArtifactEntry = z.infer<typeof artifactEntrySchema>;
 export type StorageManifest = z.infer<typeof storageManifestSchema>;
 export type StoredResumeSession = z.infer<typeof storedResumeSessionSchema>;
 export type ResumeSession = z.infer<typeof resumeSessionSchema>;
-export type RunnerClaimCapability = z.infer<typeof runnerClaimCapabilitySchema>;
+export type RunnerClaimCapability = "resumeSessionHistoryRef";

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -168,10 +168,40 @@ export const storageManifestSchema = z.object({
  * Resume session information. The compatibility wire field is `sessionId`, but
  * its semantic name in API/runner code is `cliAgentSessionId`.
  */
-export const resumeSessionSchema = z.object({
+const inlineResumeSessionSchema = z.object({
   sessionId: z.string(),
   sessionHistory: z.string(),
 });
+
+const resumeSessionHistoryBlobRefSchema = z.object({
+  kind: z.literal("blob"),
+  hash: z.string().regex(/^[a-f0-9]{64}$/),
+});
+
+const storedResumeSessionRefSchema = z.object({
+  sessionId: z.string(),
+  historyRef: resumeSessionHistoryBlobRefSchema,
+});
+
+const resumeSessionRefSchema = z.object({
+  sessionId: z.string(),
+  historyRef: resumeSessionHistoryBlobRefSchema.extend({
+    url: z.string().url(),
+    size: z.number().int().nonnegative().optional(),
+  }),
+});
+
+export const storedResumeSessionSchema = z.union([
+  inlineResumeSessionSchema,
+  storedResumeSessionRefSchema,
+]);
+
+export const resumeSessionSchema = z.union([
+  inlineResumeSessionSchema,
+  resumeSessionRefSchema,
+]);
+
+export const runnerClaimCapabilitySchema = z.enum(["resumeSessionHistoryRef"]);
 
 export const secretConnectorMetadataSchema = z.object({
   sourceType: z.enum(["connector", "model-provider"]),
@@ -193,7 +223,7 @@ export const secretConnectorMetadataMapSchema = z.record(
 export const storedExecutionContextSchema = z.object({
   storageManifest: storageManifestSchema.nullable(),
   environment: z.record(z.string(), z.string()).nullable(),
-  resumeSession: resumeSessionSchema.nullable(),
+  resumeSession: storedResumeSessionSchema.nullable(),
   // AES-256-GCM encrypted Record<string, string>. Keys are the runtime secret
   // names used by `${{ secrets.NAME }}`; connector/model-provider keys are env
   // aliases, not backing storage secret names.
@@ -321,6 +351,7 @@ export const runnersJobClaimContract = c.router({
     }),
     body: z.object({
       telemetry: runnerClaimTelemetrySchema.optional(),
+      capabilities: z.array(runnerClaimCapabilitySchema).optional(),
     }),
     responses: {
       200: executionContextSchema,
@@ -388,4 +419,6 @@ export type SecretConnectorMetadata = z.infer<
 export type StorageEntry = z.infer<typeof storageEntrySchema>;
 export type ArtifactEntry = z.infer<typeof artifactEntrySchema>;
 export type StorageManifest = z.infer<typeof storageManifestSchema>;
+export type StoredResumeSession = z.infer<typeof storedResumeSessionSchema>;
 export type ResumeSession = z.infer<typeof resumeSessionSchema>;
+export type RunnerClaimCapability = z.infer<typeof runnerClaimCapabilitySchema>;

--- a/turbo/packages/api-contracts/src/contracts/webhooks.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhooks.ts
@@ -15,6 +15,15 @@ import {
 
 const c = initContract();
 
+// Hash-backed resume history is keyed and verified as lowercase SHA-256 hex.
+// Accepting other 64-character strings would defer bad input until runner claim.
+const sha256HexSchema = z
+  .string()
+  .regex(
+    /^[a-f0-9]{64}$/,
+    "hash must be a lowercase 64-character SHA-256 hex string",
+  );
+
 const thirdPartyWebhookErrorSchema = z.object({ error: z.string() });
 const thirdPartyWebhookOkSchema = z.union([
   z.string(),
@@ -364,12 +373,7 @@ export const webhookCheckpointsContract = c.router({
         runId: z.string().min(1, "runId is required"),
         cliAgentType: z.string().min(1, "cliAgentType is required"),
         cliAgentSessionId: z.string().min(1, "cliAgentSessionId is required"),
-        cliAgentSessionHistoryHash: z
-          .string()
-          .length(
-            64,
-            "cliAgentSessionHistoryHash must be a 64-character SHA-256 hex string",
-          ),
+        cliAgentSessionHistoryHash: sha256HexSchema,
         // Multi-artifact snapshot payload. Canonical
         // `Array<{name, version, mountPath}>` form persisted verbatim to
         // checkpoints.artifact_snapshots.
@@ -406,9 +410,7 @@ export const webhookCheckpointsPrepareHistoryContract = c.router({
     headers: authHeadersSchema,
     body: z.object({
       runId: z.string().min(1, "runId is required"),
-      hash: z
-        .string()
-        .length(64, "hash must be a 64-character SHA-256 hex string"),
+      hash: sha256HexSchema,
       size: z.number().int().positive("size must be a positive integer"),
     }),
     responses: {

--- a/turbo/packages/api-contracts/src/contracts/webhooks.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhooks.ts
@@ -3,6 +3,7 @@ import { authHeadersSchema, initContract } from "./base";
 import { apiErrorSchema } from "./errors";
 import {
   artifactMissingRootPolicySchema,
+  RESUME_SESSION_HISTORY_MAX_BYTES,
   secretConnectorMetadataMapSchema,
 } from "./runners";
 import { eventSequenceNumberSchema, networkLogEntrySchema } from "./runs";
@@ -411,7 +412,11 @@ export const webhookCheckpointsPrepareHistoryContract = c.router({
     body: z.object({
       runId: z.string().min(1, "runId is required"),
       hash: sha256HexSchema,
-      size: z.number().int().positive("size must be a positive integer"),
+      size: z
+        .number()
+        .int()
+        .positive("size must be a positive integer")
+        .max(RESUME_SESSION_HISTORY_MAX_BYTES),
     }),
     responses: {
       200: z.object({

--- a/turbo/packages/db/src/schema/agent-run-session-conversation.ts
+++ b/turbo/packages/db/src/schema/agent-run-session-conversation.ts
@@ -156,7 +156,8 @@ export const agentSessions = pgTable(
  * Session history storage strategy:
  * - New records use cliAgentSessionHistoryHash (R2 blob reference)
  * - Legacy records use cliAgentSessionHistory (TEXT field)
- * - Read logic: prioritize hash, fallback to TEXT
+ * - Read logic: use the hash-backed path when present; use TEXT only for
+ *   legacy rows that do not have a hash
  */
 export const conversations = pgTable("conversations", {
   id: uuid("id").defaultRandom().primaryKey(),


### PR DESCRIPTION
## Summary
- store hash-backed resume history as a queued historyRef instead of downloading it during create-run
- return presigned history refs to capable runners, with claim-time inline fallback for old runners
- download and verify history on the runner with SHA-256, size limits, URL-query redaction, cancellation, and session_history_download telemetry

## Tests
- pnpm -F api exec vitest run src/signals/routes/__tests__/run-reads.bdd.test.ts
- pnpm -F api check-types
- pnpm -F api lint
- pnpm -F @vm0/api-contracts check-types
- pnpm -F @vm0/api-contracts lint
- cargo test --manifest-path crates/Cargo.toml -p runner
- cargo fmt --manifest-path crates/Cargo.toml --package runner --check
- pre-commit: prettier, knip, check-types, cargo-clippy, cargo-doc

Closes #19015