### PR TITLE
fix(runner): treat duplicate drain signals as idempotent

### DIFF
--- a/crates/runner/src/cmd/start/signals.rs
+++ b/crates/runner/src/cmd/start/signals.rs
@@ -63,6 +63,13 @@ pub(crate) struct LifecycleController {
     parking_gate: ParkingGate,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DrainSignalOutcome {
+    EnteredDraining,
+    AlreadyDraining,
+    Ignored(RunnerMode),
+}
+
 impl LifecycleController {
     pub(crate) fn new(
         mode_tx: tokio::sync::watch::Sender<RunnerMode>,
@@ -83,19 +90,30 @@ impl LifecycleController {
         &self.mode_tx
     }
 
-    pub(crate) fn enter_soft_drain(&self) -> bool {
+    fn enter_soft_drain(&self) -> DrainSignalOutcome {
         let gate = self.parking_gate.clone();
-        let mut transitioned = false;
-        let _ = self.mode_tx.send_if_modified(|mode| {
-            if *mode == RunnerMode::Running && gate.soft_drain() {
-                *mode = RunnerMode::Draining;
-                transitioned = true;
-                true
-            } else {
+        let mut outcome = DrainSignalOutcome::Ignored(self.current_mode());
+        let _ = self.mode_tx.send_if_modified(|mode| match *mode {
+            RunnerMode::Running => {
+                if gate.soft_drain() {
+                    *mode = RunnerMode::Draining;
+                    outcome = DrainSignalOutcome::EnteredDraining;
+                    true
+                } else {
+                    outcome = DrainSignalOutcome::Ignored(RunnerMode::Running);
+                    false
+                }
+            }
+            RunnerMode::Draining => {
+                outcome = DrainSignalOutcome::AlreadyDraining;
+                false
+            }
+            mode => {
+                outcome = DrainSignalOutcome::Ignored(mode);
                 false
             }
         });
-        transitioned
+        outcome
     }
 
     pub(crate) fn resume_from_soft_drain(&self) -> bool {
@@ -203,7 +221,8 @@ impl SignalController {
     ///
     /// Signal semantics:
     /// - **SIGUSR1** (drain): from `Running`, close parking for soft drain,
-    ///   then send `Draining`. Ignored from any other state.
+    ///   then send `Draining`. From `Draining`, treat as an idempotent no-op.
+    ///   Ignored from `Stopping` / `Stopped`.
     /// - **SIGUSR2** (resume): from `Draining`, reopen parking, then send
     ///   `Running` (resume normal discovery). Ignored from `Running` /
     ///   `Stopping` / `Stopped`.
@@ -285,12 +304,17 @@ pub(super) async fn recv_handler_task(
 }
 
 pub(super) fn handle_drain_signal(lifecycle: &LifecycleController) {
-    let current = lifecycle.current_mode();
-    if !lifecycle.enter_soft_drain() {
-        warn!(mode = ?current, "SIGUSR1 ignored — only valid from Running");
-        return;
+    match lifecycle.enter_soft_drain() {
+        DrainSignalOutcome::EnteredDraining => {
+            info!("received SIGUSR1, entering Draining (soft drain)");
+        }
+        DrainSignalOutcome::AlreadyDraining => {
+            info!("received SIGUSR1 while already Draining");
+        }
+        DrainSignalOutcome::Ignored(mode) => {
+            warn!(mode = ?mode, "SIGUSR1 ignored — soft drain is no longer actionable");
+        }
     }
-    info!("received SIGUSR1, entering Draining (soft drain)");
 }
 
 pub(super) fn handle_resume_signal(lifecycle: &LifecycleController) {
@@ -450,8 +474,9 @@ mod tests {
             .expect("dropping signal handler task should abort the task");
     }
 
-    /// `handle_drain_signal` state guard: SIGUSR1 is honored only from
-    /// Running. Mirrors `handle_resume_signal`'s Draining-only guard.
+    /// `enter_soft_drain` state guard: SIGUSR1 transitions only from Running;
+    /// repeated SIGUSR1 in Draining is an idempotent no-op, while teardown modes
+    /// stay ignored.
     #[test]
     fn drain_signal_state_guards() {
         use crate::idle_pool::ParkingState;
@@ -460,16 +485,22 @@ mod tests {
         let gate = ParkingGate::new_open();
         let (tx, _rx) = tokio::sync::watch::channel(RunnerMode::Running);
         let lifecycle = LifecycleController::new(tx, gate.clone());
-        handle_drain_signal(&lifecycle);
+        assert_eq!(
+            lifecycle.enter_soft_drain(),
+            DrainSignalOutcome::EnteredDraining
+        );
         assert_eq!(lifecycle.current_mode(), RunnerMode::Draining);
         assert_eq!(gate.state(), ParkingState::SoftDraining);
 
-        // Draining → ignored (no self-transition).
+        // Draining → idempotent no-op (no warning-worthy self-transition).
         let gate = ParkingGate::new_open();
         gate.soft_drain();
         let (tx, _rx) = tokio::sync::watch::channel(RunnerMode::Draining);
         let lifecycle = LifecycleController::new(tx, gate.clone());
-        handle_drain_signal(&lifecycle);
+        assert_eq!(
+            lifecycle.enter_soft_drain(),
+            DrainSignalOutcome::AlreadyDraining
+        );
         assert_eq!(lifecycle.current_mode(), RunnerMode::Draining);
         assert_eq!(gate.state(), ParkingState::SoftDraining);
 
@@ -478,7 +509,10 @@ mod tests {
         gate.close();
         let (tx, _rx) = tokio::sync::watch::channel(RunnerMode::Stopping);
         let lifecycle = LifecycleController::new(tx, gate.clone());
-        handle_drain_signal(&lifecycle);
+        assert_eq!(
+            lifecycle.enter_soft_drain(),
+            DrainSignalOutcome::Ignored(RunnerMode::Stopping)
+        );
         assert_eq!(lifecycle.current_mode(), RunnerMode::Stopping);
         assert_eq!(gate.state(), ParkingState::Closed);
 
@@ -487,7 +521,10 @@ mod tests {
         gate.close();
         let (tx, _rx) = tokio::sync::watch::channel(RunnerMode::Stopped);
         let lifecycle = LifecycleController::new(tx, gate.clone());
-        handle_drain_signal(&lifecycle);
+        assert_eq!(
+            lifecycle.enter_soft_drain(),
+            DrainSignalOutcome::Ignored(RunnerMode::Stopped)
+        );
         assert_eq!(lifecycle.current_mode(), RunnerMode::Stopped);
         assert_eq!(gate.state(), ParkingState::Closed);
     }

--- a/crates/runner/src/cmd/start/tests/main_loop/drain_resume.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/drain_resume.rs
@@ -165,10 +165,9 @@ async fn drain_without_active_jobs_exits_promptly() {
 /// it must not downgrade to a hard stop or disturb the in-flight job.
 #[tokio::test]
 async fn repeated_drain_while_draining_keeps_active_job_running() {
-    let gate = Arc::new(tokio::sync::Notify::new());
-    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
-        Arc::clone(&gate),
-    ));
+    let wait_gate = sandbox_mock::MockLifecycleGate::new();
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
     let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, overrides);
     let status_path = env._temp_dir.path().join("status.json");
     let run_handle = tokio::spawn(run(config));
@@ -176,6 +175,10 @@ async fn repeated_drain_while_draining_keeps_active_job_running() {
     let run_id = RunId::new_v4();
     push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
     let token = wait_cancel_token(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
+    wait_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .expect("wait_process should enter the lifecycle gate");
 
     env.drain();
     wait_status_mode(&status_path, "draining", Duration::from_secs(5)).await;
@@ -188,7 +191,7 @@ async fn repeated_drain_while_draining_keeps_active_job_running() {
         "repeat drain must not cancel the active job"
     );
 
-    gate.notify_one();
+    wait_gate.release_one();
     let completion = env
         .handle
         .wait_completion(run_id, Duration::from_secs(5))

--- a/crates/runner/src/cmd/start/tests/main_loop/drain_resume.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/drain_resume.rs
@@ -161,6 +161,50 @@ async fn drain_without_active_jobs_exits_promptly() {
     .await;
 }
 
+/// A repeat SIGUSR1 while already Draining is an idempotent no-op:
+/// it must not downgrade to a hard stop or disturb the in-flight job.
+#[tokio::test]
+async fn repeated_drain_while_draining_keeps_active_job_running() {
+    let gate = Arc::new(tokio::sync::Notify::new());
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
+        Arc::clone(&gate),
+    ));
+    let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, overrides);
+    let status_path = env._temp_dir.path().join("status.json");
+    let run_handle = tokio::spawn(run(config));
+
+    let run_id = RunId::new_v4();
+    push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
+    let token = wait_cancel_token(&env.cancel_tokens, run_id, Duration::from_secs(5)).await;
+
+    env.drain();
+    wait_status_mode(&status_path, "draining", Duration::from_secs(5)).await;
+
+    env.drain();
+    assert_eq!(*env.mode_tx.borrow(), RunnerMode::Draining);
+    assert_eq!(env.parking_gate.state(), ParkingState::SoftDraining);
+    assert!(
+        !token.is_cancelled(),
+        "repeat drain must not cancel the active job"
+    );
+
+    gate.notify_one();
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("job should complete after the gate is released");
+    assert_eq!(completion.exit_code, 0, "job ran to normal completion");
+    assert!(completion.error.is_none(), "no cancellation error");
+
+    assert_run_exits_within(
+        run_handle,
+        Duration::from_secs(5),
+        "run should exit after repeated drain and natural job completion",
+    )
+    .await;
+}
+
 /// SIGUSR2 on an already-Running runner is a no-op: it does not disturb
 /// normal discovery.
 #[tokio::test(start_paused = true)]

--- a/crates/runner/src/cmd/start/tests/support/env.rs
+++ b/crates/runner/src/cmd/start/tests/support/env.rs
@@ -41,8 +41,8 @@ pub(in super::super) struct MockRunEnv {
 
 impl MockRunEnv {
     /// Simulate SIGUSR1 by driving the real `handle_drain_signal` so
-    /// tests exercise the same state-guard path production does
-    /// (ignored unless current mode is Running).
+    /// tests exercise the same state-guard path production does:
+    /// Running enters Draining, Draining is idempotent, teardown modes ignore it.
     pub(in super::super) fn drain(&self) {
         handle_drain_signal(&self.lifecycle);
     }


### PR DESCRIPTION
## Summary

- Distinguish SIGUSR1 drain outcomes in the runner lifecycle controller.
- Treat SIGUSR1 while already `Draining` as an idempotent info-level no-op.
- Keep SIGUSR1 after teardown has started visible as a warning.

Closes #19020.

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::signals::tests::drain_signal_state_guards`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::tests::main_loop::drain_resume`
- `cargo test --manifest-path crates/Cargo.toml -p runner`

Pre-commit also ran cargo fmt, cargo clippy, and cargo doc through lefthook.
