### PR TITLE
perf(runner): restore ably direct candidates

### DIFF
--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -13,8 +13,8 @@ use reqwest::{RequestBuilder, Response, StatusCode};
 use serde::{Serialize, de::DeserializeOwned};
 
 use super::api_ably_supervisor::{
-    AblySupervisor, AblySupervisorConfig, DirectJobCandidate, PollDue, PollOutcome, PollReason,
-    PollWakeups,
+    AblySupervisor, AblySupervisorConfig, DirectCandidateSenders, DirectJobCandidate, PollDue,
+    PollOutcome, PollReason, PollWakeups,
 };
 use super::{
     ClaimedJob, CompletionAuth, CompletionAuthError, JobCandidate, JobDiscoverySource, JobProvider,
@@ -109,9 +109,12 @@ pub struct ApiProvider {
     profiles: Vec<String>,
     /// Coalesced poll wakeup state updated by the Ably supervisor.
     poll_wakeups: Arc<PollWakeups>,
-    /// Direct job candidates delivered by Ably notifications.
-    _direct_candidate_tx: mpsc::Sender<DirectJobCandidate>,
-    direct_candidate_rx: tokio::sync::Mutex<mpsc::Receiver<DirectJobCandidate>>,
+    /// Matching targeted direct job candidates delivered by Ably notifications.
+    _targeted_direct_candidate_tx: mpsc::Sender<DirectJobCandidate>,
+    targeted_direct_candidate_rx: tokio::sync::Mutex<mpsc::Receiver<DirectJobCandidate>>,
+    /// Supported broadcast direct job candidates delivered by Ably notifications.
+    _broadcast_direct_candidate_tx: mpsc::Sender<DirectJobCandidate>,
+    broadcast_direct_candidate_rx: tokio::sync::Mutex<mpsc::Receiver<DirectJobCandidate>>,
     /// Background Ably control-plane task.
     ably_supervisor: AblySupervisor,
     /// Session generations held in the idle pool, sent in poll requests for affinity ordering.
@@ -133,7 +136,9 @@ impl ApiProvider {
     ) -> Arc<Self> {
         let api = ApiClient::new(http, token);
         let poll_wakeups = Arc::new(PollWakeups::new(false));
-        let (direct_candidate_tx, direct_candidate_rx) =
+        let (targeted_direct_candidate_tx, targeted_direct_candidate_rx) =
+            mpsc::channel(DIRECT_CANDIDATE_QUEUE_CAPACITY);
+        let (broadcast_direct_candidate_tx, broadcast_direct_candidate_rx) =
             mpsc::channel(DIRECT_CANDIDATE_QUEUE_CAPACITY);
         let ably_supervisor = AblySupervisor::spawn(AblySupervisorConfig {
             api: api.clone(),
@@ -141,7 +146,10 @@ impl ApiProvider {
             runner_id,
             profiles: profiles.clone(),
             poll_wakeups: Arc::clone(&poll_wakeups),
-            direct_candidate_tx: direct_candidate_tx.clone(),
+            direct_candidate_senders: DirectCandidateSenders::new(
+                targeted_direct_candidate_tx.clone(),
+                broadcast_direct_candidate_tx.clone(),
+            ),
             cancel_tokens,
             provider_cancel: cancel.clone(),
         });
@@ -151,8 +159,10 @@ impl ApiProvider {
             group,
             profiles,
             poll_wakeups,
-            _direct_candidate_tx: direct_candidate_tx,
-            direct_candidate_rx: tokio::sync::Mutex::new(direct_candidate_rx),
+            _targeted_direct_candidate_tx: targeted_direct_candidate_tx,
+            targeted_direct_candidate_rx: tokio::sync::Mutex::new(targeted_direct_candidate_rx),
+            _broadcast_direct_candidate_tx: broadcast_direct_candidate_tx,
+            broadcast_direct_candidate_rx: tokio::sync::Mutex::new(broadcast_direct_candidate_rx),
             ably_supervisor,
             held_session_states: tokio::sync::Mutex::new(Vec::new()),
             cancel,
@@ -161,8 +171,15 @@ impl ApiProvider {
 
     async fn wait_for_discovery_wakeup(&self) -> Option<DiscoveryWakeup> {
         loop {
-            let mut direct_candidate_rx = self.direct_candidate_rx.lock().await;
-            match direct_candidate_rx.try_recv() {
+            let mut targeted_direct_candidate_rx = self.targeted_direct_candidate_rx.lock().await;
+            match targeted_direct_candidate_rx.try_recv() {
+                Ok(candidate) => return Some(DiscoveryWakeup::Direct(candidate)),
+                Err(mpsc::error::TryRecvError::Empty) => {}
+                Err(mpsc::error::TryRecvError::Disconnected) => {}
+            }
+
+            let mut broadcast_direct_candidate_rx = self.broadcast_direct_candidate_rx.lock().await;
+            match broadcast_direct_candidate_rx.try_recv() {
                 Ok(candidate) => return Some(DiscoveryWakeup::Direct(candidate)),
                 Err(mpsc::error::TryRecvError::Empty) => {}
                 Err(mpsc::error::TryRecvError::Disconnected) => {}
@@ -173,7 +190,12 @@ impl ApiProvider {
                 () = self.cancel.cancelled() => {
                     return None;
                 }
-                candidate = direct_candidate_rx.recv() => {
+                candidate = targeted_direct_candidate_rx.recv() => {
+                    if let Some(candidate) = candidate {
+                        return Some(DiscoveryWakeup::Direct(candidate));
+                    }
+                }
+                candidate = broadcast_direct_candidate_rx.recv() => {
                     if let Some(candidate) = candidate {
                         return Some(DiscoveryWakeup::Direct(candidate));
                     }
@@ -847,7 +869,9 @@ mod tests {
         cancel: CancellationToken,
         poll_wakeups: Arc<PollWakeups>,
     ) -> Arc<ApiProvider> {
-        let (direct_candidate_tx, direct_candidate_rx) =
+        let (targeted_direct_candidate_tx, targeted_direct_candidate_rx) =
+            mpsc::channel(DIRECT_CANDIDATE_QUEUE_CAPACITY);
+        let (broadcast_direct_candidate_tx, broadcast_direct_candidate_rx) =
             mpsc::channel(DIRECT_CANDIDATE_QUEUE_CAPACITY);
         Arc::new(ApiProvider {
             api: ApiClient::new(
@@ -861,8 +885,10 @@ mod tests {
             group: "default".to_string(),
             profiles: Vec::new(),
             poll_wakeups,
-            _direct_candidate_tx: direct_candidate_tx,
-            direct_candidate_rx: tokio::sync::Mutex::new(direct_candidate_rx),
+            _targeted_direct_candidate_tx: targeted_direct_candidate_tx,
+            targeted_direct_candidate_rx: tokio::sync::Mutex::new(targeted_direct_candidate_rx),
+            _broadcast_direct_candidate_tx: broadcast_direct_candidate_tx,
+            broadcast_direct_candidate_rx: tokio::sync::Mutex::new(broadcast_direct_candidate_rx),
             ably_supervisor: AblySupervisor::disabled(),
             held_session_states: tokio::sync::Mutex::new(Vec::new()),
             cancel,
@@ -1158,7 +1184,7 @@ mod tests {
             .checked_sub(Duration::from_millis(25))
             .unwrap();
         provider
-            ._direct_candidate_tx
+            ._broadcast_direct_candidate_tx
             .try_send(DirectJobCandidate::new_with_discovered_at(
                 run_id,
                 crate::profile::DEFAULT_PROFILE.to_string(),
@@ -1181,6 +1207,53 @@ mod tests {
         assert!(discovered.job_discovered_elapsed() >= Duration::from_millis(25));
         assert!(discovered.poll_due_to_job_discovered_elapsed().is_none());
         assert!(discovered.poll_http_request_elapsed().is_none());
+        poll_mock.assert_calls_async(0).await;
+    }
+
+    #[tokio::test]
+    async fn discover_prioritizes_targeted_direct_candidate_over_broadcast_backlog() {
+        let server = MockServer::start_async().await;
+        let broadcast_run_id: RunId = "00000000-0000-0000-0000-000000000007".parse().unwrap();
+        let targeted_run_id: RunId = "00000000-0000-0000-0000-000000000008".parse().unwrap();
+        let poll_mock = server
+            .mock_async(|when, then| {
+                when.method(POST).path(routes::runners::poll::POLL.path);
+                then.status(200)
+                    .json_body(serde_json::json!({ "job": null }));
+            })
+            .await;
+        let provider = api_provider_for_test(
+            server.base_url(),
+            CancellationToken::new(),
+            Arc::new(PollWakeups::new(false)),
+        );
+        provider
+            ._broadcast_direct_candidate_tx
+            .try_send(DirectJobCandidate::new(
+                broadcast_run_id,
+                crate::profile::DEFAULT_PROFILE.to_string(),
+                false,
+            ))
+            .unwrap();
+        provider
+            ._targeted_direct_candidate_tx
+            .try_send(DirectJobCandidate::new(
+                targeted_run_id,
+                crate::profile::DEFAULT_PROFILE.to_string(),
+                true,
+            ))
+            .unwrap();
+
+        let discovered = tokio::time::timeout(Duration::from_secs(1), provider.discover())
+            .await
+            .expect("discover should receive direct candidate")
+            .unwrap();
+
+        assert_eq!(discovered.run_id(), targeted_run_id);
+        assert_eq!(
+            discovered.discovery_source(),
+            Some(JobDiscoverySource::Ably)
+        );
         poll_mock.assert_calls_async(0).await;
     }
 

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -169,21 +169,30 @@ impl ApiProvider {
         })
     }
 
-    async fn wait_for_discovery_wakeup(&self) -> Option<DiscoveryWakeup> {
+    async fn try_recv_direct_candidate(&self) -> Option<DirectJobCandidate> {
+        let mut targeted_direct_candidate_rx = self.targeted_direct_candidate_rx.lock().await;
+        match targeted_direct_candidate_rx.try_recv() {
+            Ok(candidate) => return Some(candidate),
+            Err(mpsc::error::TryRecvError::Empty) => {}
+            Err(mpsc::error::TryRecvError::Disconnected) => {}
+        }
+
+        let mut broadcast_direct_candidate_rx = self.broadcast_direct_candidate_rx.lock().await;
+        match broadcast_direct_candidate_rx.try_recv() {
+            Ok(candidate) => Some(candidate),
+            Err(mpsc::error::TryRecvError::Empty) => None,
+            Err(mpsc::error::TryRecvError::Disconnected) => None,
+        }
+    }
+
+    async fn wait_for_direct_candidate(&self) -> Option<DirectJobCandidate> {
         loop {
-            let mut targeted_direct_candidate_rx = self.targeted_direct_candidate_rx.lock().await;
-            match targeted_direct_candidate_rx.try_recv() {
-                Ok(candidate) => return Some(DiscoveryWakeup::Direct(candidate)),
-                Err(mpsc::error::TryRecvError::Empty) => {}
-                Err(mpsc::error::TryRecvError::Disconnected) => {}
+            if let Some(candidate) = self.try_recv_direct_candidate().await {
+                return Some(candidate);
             }
 
+            let mut targeted_direct_candidate_rx = self.targeted_direct_candidate_rx.lock().await;
             let mut broadcast_direct_candidate_rx = self.broadcast_direct_candidate_rx.lock().await;
-            match broadcast_direct_candidate_rx.try_recv() {
-                Ok(candidate) => return Some(DiscoveryWakeup::Direct(candidate)),
-                Err(mpsc::error::TryRecvError::Empty) => {}
-                Err(mpsc::error::TryRecvError::Disconnected) => {}
-            }
 
             tokio::select! {
                 biased;
@@ -192,10 +201,30 @@ impl ApiProvider {
                 }
                 candidate = targeted_direct_candidate_rx.recv() => {
                     if let Some(candidate) = candidate {
-                        return Some(DiscoveryWakeup::Direct(candidate));
+                        return Some(candidate);
                     }
                 }
                 candidate = broadcast_direct_candidate_rx.recv() => {
+                    if let Some(candidate) = candidate {
+                        return Some(candidate);
+                    }
+                }
+            }
+        }
+    }
+
+    async fn wait_for_discovery_wakeup(&self) -> Option<DiscoveryWakeup> {
+        loop {
+            if let Some(candidate) = self.try_recv_direct_candidate().await {
+                return Some(DiscoveryWakeup::Direct(candidate));
+            }
+
+            tokio::select! {
+                biased;
+                () = self.cancel.cancelled() => {
+                    return None;
+                }
+                candidate = self.wait_for_direct_candidate() => {
                     if let Some(candidate) = candidate {
                         return Some(DiscoveryWakeup::Direct(candidate));
                     }
@@ -235,6 +264,23 @@ impl JobProvider for ApiProvider {
             let poll_result = tokio::select! {
                 biased;
                 () = self.cancel.cancelled() => {
+                    return None;
+                }
+                direct = self.wait_for_direct_candidate() => {
+                    if let Some(direct) = direct {
+                        self.poll_wakeups.request_immediate_poll().await;
+                        let run_id = direct.run_id();
+                        let profile = direct.profile_name().to_owned();
+                        let targeted = direct.targeted();
+                        info!(
+                            run_id = %run_id,
+                            profile = %profile,
+                            targeted,
+                            poll_reason = ?reason,
+                            "ably: direct job candidate interrupted poll"
+                        );
+                        return Some(direct.into_job_candidate());
+                    }
                     return None;
                 }
                 result = self.api.poll(&self.group, &self.profiles, &held_session_states, reason) => result,
@@ -1328,6 +1374,70 @@ mod tests {
         );
         claim_mock.assert_async().await;
         poll_mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn discover_returns_direct_candidate_that_arrives_during_poll() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let api_url = format!("http://{}", listener.local_addr().unwrap());
+        let direct_run_id: RunId = "00000000-0000-0000-0000-00000000000a".parse().unwrap();
+        let poll_run_id: RunId = "00000000-0000-0000-0000-00000000000b".parse().unwrap();
+        let (poll_accepted_tx, poll_accepted_rx) = tokio::sync::oneshot::channel();
+        let (release_first_poll_tx, release_first_poll_rx) = tokio::sync::oneshot::channel();
+        let server_task = tokio::spawn(async move {
+            let (mut first_socket, _) = listener.accept().await.unwrap();
+            read_http_request(&mut first_socket).await;
+            let _ = poll_accepted_tx.send(());
+            release_first_poll_rx.await.unwrap();
+            drop(first_socket);
+
+            let (mut second_socket, _) = listener.accept().await.unwrap();
+            read_http_request(&mut second_socket).await;
+            write_poll_job_response(&mut second_socket, poll_run_id).await;
+        });
+        let provider = api_provider_for_test(
+            api_url,
+            CancellationToken::new(),
+            Arc::new(PollWakeups::new(false)),
+        );
+        let provider_for_discover = Arc::clone(&provider);
+        let discover_task = tokio::spawn(async move { provider_for_discover.discover().await });
+
+        tokio::time::timeout(Duration::from_secs(1), poll_accepted_rx)
+            .await
+            .expect("poll should reach the server")
+            .unwrap();
+        provider
+            ._targeted_direct_candidate_tx
+            .try_send(DirectJobCandidate::new(
+                direct_run_id,
+                crate::profile::DEFAULT_PROFILE.to_string(),
+                true,
+            ))
+            .unwrap();
+
+        let discovered = tokio::time::timeout(Duration::from_secs(1), discover_task)
+            .await
+            .expect("direct candidate should interrupt poll")
+            .unwrap()
+            .unwrap();
+        assert_eq!(discovered.run_id(), direct_run_id);
+        assert_eq!(
+            discovered.discovery_source(),
+            Some(JobDiscoverySource::Ably)
+        );
+
+        release_first_poll_tx.send(()).unwrap();
+        let rediscovered = tokio::time::timeout(Duration::from_secs(1), provider.discover())
+            .await
+            .expect("interrupted poll should be rearmed")
+            .unwrap();
+        assert_eq!(rediscovered.run_id(), poll_run_id);
+        assert_eq!(
+            rediscovered.discovery_source(),
+            Some(JobDiscoverySource::Poll)
+        );
+        server_task.await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -1288,12 +1288,10 @@ mod tests {
             .expect("first poll should reach the server")
             .unwrap();
         wakeups
-            .request_deferred_poll_after_for_test(Duration::from_millis(10))
+            .request_deferred_poll_after_for_test(Duration::ZERO)
             .await;
         release_first_tx.send(()).unwrap();
-        tokio::task::yield_now().await;
 
-        tokio::time::sleep(Duration::from_millis(10)).await;
         let discovered = tokio::time::timeout(Duration::from_secs(1), discover_task)
             .await
             .expect("discover should retry after target-other defer")

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -312,6 +312,7 @@ impl JobProvider for ApiProvider {
             }
             Err(e) => {
                 error!(run_id = %run_id, error = %e, "claim failed");
+                self.poll_wakeups.request_immediate_poll().await;
                 None
             }
         }
@@ -1255,6 +1256,78 @@ mod tests {
             Some(JobDiscoverySource::Ably)
         );
         poll_mock.assert_calls_async(0).await;
+    }
+
+    #[tokio::test]
+    async fn claim_failure_after_ably_direct_candidate_wakes_poll_fallback() {
+        let server = MockServer::start_async().await;
+        let run_id: RunId = "00000000-0000-0000-0000-000000000009".parse().unwrap();
+        let claim_path = format!("/api/runners/jobs/{run_id}/claim");
+        let claim_mock = server
+            .mock_async(|when, then| {
+                when.method(POST).path(claim_path.as_str());
+                then.status(503).body("claim unavailable");
+            })
+            .await;
+        let poll_mock = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path(routes::runners::poll::POLL.path)
+                    .json_body(serde_json::json!({
+                        "group": "default",
+                        "profiles": [],
+                        "telemetry": {
+                            "pollReason": "immediate"
+                        }
+                    }));
+                then.status(200).json_body(serde_json::json!({
+                    "job": {
+                        "runId": run_id,
+                        "experimentalProfile": crate::profile::DEFAULT_PROFILE
+                    }
+                }));
+            })
+            .await;
+        let wakeups = Arc::new(PollWakeups::new(true));
+        let initial_poll = wakeups
+            .wait_for_poll_due(&CancellationToken::new(), POLL_SLOW, POLL_FAST)
+            .await
+            .unwrap();
+        wakeups
+            .record_poll_result(initial_poll, PollOutcome::Empty, POLL_WAKEUP_RETRY)
+            .await;
+        let provider = api_provider_for_test(
+            server.base_url(),
+            CancellationToken::new(),
+            Arc::clone(&wakeups),
+        );
+        provider
+            ._broadcast_direct_candidate_tx
+            .try_send(DirectJobCandidate::new(
+                run_id,
+                crate::profile::DEFAULT_PROFILE.to_string(),
+                false,
+            ))
+            .unwrap();
+
+        let direct = tokio::time::timeout(Duration::from_secs(1), provider.discover())
+            .await
+            .expect("discover should receive direct candidate")
+            .unwrap();
+        assert_eq!(direct.discovery_source(), Some(JobDiscoverySource::Ably));
+        assert!(provider.claim(direct).await.is_none());
+        let rediscovered = tokio::time::timeout(Duration::from_secs(1), provider.discover())
+            .await
+            .expect("claim failure should wake immediate poll")
+            .unwrap();
+
+        assert_eq!(rediscovered.run_id(), run_id);
+        assert_eq!(
+            rediscovered.discovery_source(),
+            Some(JobDiscoverySource::Poll)
+        );
+        claim_mock.assert_async().await;
+        poll_mock.assert_async().await;
     }
 
     #[tokio::test]

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -1154,12 +1154,16 @@ mod tests {
             CancellationToken::new(),
             Arc::new(PollWakeups::new(false)),
         );
+        let discovered_at = Instant::now()
+            .checked_sub(Duration::from_millis(25))
+            .unwrap();
         provider
             ._direct_candidate_tx
-            .try_send(DirectJobCandidate::new(
+            .try_send(DirectJobCandidate::new_with_discovered_at(
                 run_id,
                 crate::profile::DEFAULT_PROFILE.to_string(),
                 true,
+                discovered_at,
             ))
             .unwrap();
 
@@ -1174,6 +1178,7 @@ mod tests {
             discovered.discovery_source(),
             Some(JobDiscoverySource::Ably)
         );
+        assert!(discovered.job_discovered_elapsed() >= Duration::from_millis(25));
         assert!(discovered.poll_due_to_job_discovered_elapsed().is_none());
         assert!(discovered.poll_http_request_elapsed().is_none());
         poll_mock.assert_calls_async(0).await;

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -4,6 +4,7 @@ use std::borrow::Cow;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
@@ -11,8 +12,13 @@ use api_contracts::generated::routes;
 use reqwest::{RequestBuilder, Response, StatusCode};
 use serde::{Serialize, de::DeserializeOwned};
 
-use super::api_ably_supervisor::{AblySupervisor, PollOutcome, PollReason, PollWakeups};
-use super::{ClaimedJob, CompletionAuth, CompletionAuthError, JobCandidate, JobProvider};
+use super::api_ably_supervisor::{
+    AblySupervisor, AblySupervisorConfig, DirectJobCandidate, PollDue, PollOutcome, PollReason,
+    PollWakeups,
+};
+use super::{
+    ClaimedJob, CompletionAuth, CompletionAuthError, JobCandidate, JobDiscoverySource, JobProvider,
+};
 use crate::error::{RunnerError, RunnerResult};
 use crate::http::HttpClient;
 use crate::ids::RunId;
@@ -32,6 +38,8 @@ struct ClaimRequestBody {
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct ClaimRequestTelemetry {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    discovery_source: Option<&'static str>,
     job_discovered_to_claim_request_ms: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     local_admission_to_claim_request_ms: Option<u64>,
@@ -59,6 +67,13 @@ const POLL_SLOW: Duration = Duration::from_secs(30);
 const POLL_FAST: Duration = Duration::from_secs(5);
 /// Retry delay after a job-notification wakeup reaches poll but poll fails.
 const POLL_WAKEUP_RETRY: Duration = POLL_FAST;
+const DIRECT_CANDIDATE_QUEUE_CAPACITY: usize = 128;
+
+enum DiscoveryWakeup {
+    Direct(DirectJobCandidate),
+    Poll(PollDue),
+}
+
 fn poll_held_session_states(states: &[HeldSessionState]) -> Cow<'_, [HeldSessionState]> {
     if states.len() <= MAX_HELD_SESSION_STATES {
         return Cow::Borrowed(states);
@@ -94,6 +109,9 @@ pub struct ApiProvider {
     profiles: Vec<String>,
     /// Coalesced poll wakeup state updated by the Ably supervisor.
     poll_wakeups: Arc<PollWakeups>,
+    /// Direct job candidates delivered by Ably notifications.
+    _direct_candidate_tx: mpsc::Sender<DirectJobCandidate>,
+    direct_candidate_rx: tokio::sync::Mutex<mpsc::Receiver<DirectJobCandidate>>,
     /// Background Ably control-plane task.
     ably_supervisor: AblySupervisor,
     /// Session generations held in the idle pool, sent in poll requests for affinity ordering.
@@ -115,24 +133,56 @@ impl ApiProvider {
     ) -> Arc<Self> {
         let api = ApiClient::new(http, token);
         let poll_wakeups = Arc::new(PollWakeups::new(false));
-        let ably_supervisor = AblySupervisor::spawn(
-            api.clone(),
-            group.clone(),
+        let (direct_candidate_tx, direct_candidate_rx) =
+            mpsc::channel(DIRECT_CANDIDATE_QUEUE_CAPACITY);
+        let ably_supervisor = AblySupervisor::spawn(AblySupervisorConfig {
+            api: api.clone(),
+            group: group.clone(),
             runner_id,
-            Arc::clone(&poll_wakeups),
+            profiles: profiles.clone(),
+            poll_wakeups: Arc::clone(&poll_wakeups),
+            direct_candidate_tx: direct_candidate_tx.clone(),
             cancel_tokens,
-            cancel.clone(),
-        );
+            provider_cancel: cancel.clone(),
+        });
 
         Arc::new(Self {
             api,
             group,
             profiles,
             poll_wakeups,
+            _direct_candidate_tx: direct_candidate_tx,
+            direct_candidate_rx: tokio::sync::Mutex::new(direct_candidate_rx),
             ably_supervisor,
             held_session_states: tokio::sync::Mutex::new(Vec::new()),
             cancel,
         })
+    }
+
+    async fn wait_for_discovery_wakeup(&self) -> Option<DiscoveryWakeup> {
+        loop {
+            let mut direct_candidate_rx = self.direct_candidate_rx.lock().await;
+            match direct_candidate_rx.try_recv() {
+                Ok(candidate) => return Some(DiscoveryWakeup::Direct(candidate)),
+                Err(mpsc::error::TryRecvError::Empty) => {}
+                Err(mpsc::error::TryRecvError::Disconnected) => {}
+            }
+
+            tokio::select! {
+                biased;
+                () = self.cancel.cancelled() => {
+                    return None;
+                }
+                candidate = direct_candidate_rx.recv() => {
+                    if let Some(candidate) = candidate {
+                        return Some(DiscoveryWakeup::Direct(candidate));
+                    }
+                }
+                due = self.poll_wakeups.wait_for_poll_due(&self.cancel, POLL_SLOW, POLL_FAST) => {
+                    return due.map(DiscoveryWakeup::Poll);
+                }
+            }
+        }
     }
 }
 
@@ -140,10 +190,22 @@ impl ApiProvider {
 impl JobProvider for ApiProvider {
     async fn discover(&self) -> Option<JobCandidate> {
         loop {
-            let due = self
-                .poll_wakeups
-                .wait_for_poll_due(&self.cancel, POLL_SLOW, POLL_FAST)
-                .await?;
+            let due = match self.wait_for_discovery_wakeup().await? {
+                DiscoveryWakeup::Direct(direct) => {
+                    let run_id = direct.run_id();
+                    let profile = direct.profile_name().to_owned();
+                    let targeted = direct.targeted();
+                    let candidate = direct.into_job_candidate();
+                    info!(
+                        run_id = %run_id,
+                        profile = %profile,
+                        targeted,
+                        "ably: direct job candidate discovered"
+                    );
+                    return Some(candidate);
+                }
+                DiscoveryWakeup::Poll(due) => due,
+            };
             let reason = due.reason();
             let poll_due_started_at = Instant::now();
 
@@ -184,6 +246,7 @@ impl JobProvider for ApiProvider {
                     info!(run_id = %job.run_id, %profile, poll_reason = ?reason, "poll: job found");
                     return Some(
                         JobCandidate::new(job.run_id, profile)
+                            .with_discovery_source(JobDiscoverySource::Poll)
                             .with_poll_reason(poll_reason_value(reason))
                             .with_poll_timing(poll_due_started_at.elapsed(), http_request_elapsed),
                     );
@@ -443,6 +506,7 @@ impl ApiClient {
 fn claim_request_body(candidate: &JobCandidate) -> ClaimRequestBody {
     ClaimRequestBody {
         telemetry: ClaimRequestTelemetry {
+            discovery_source: candidate.discovery_source().map(JobDiscoverySource::as_str),
             job_discovered_to_claim_request_ms: duration_ms(candidate.job_discovered_elapsed()),
             local_admission_to_claim_request_ms: candidate
                 .local_admission_elapsed()
@@ -783,6 +847,8 @@ mod tests {
         cancel: CancellationToken,
         poll_wakeups: Arc<PollWakeups>,
     ) -> Arc<ApiProvider> {
+        let (direct_candidate_tx, direct_candidate_rx) =
+            mpsc::channel(DIRECT_CANDIDATE_QUEUE_CAPACITY);
         Arc::new(ApiProvider {
             api: ApiClient::new(
                 HttpClient::new(HttpClientConfig {
@@ -795,6 +861,8 @@ mod tests {
             group: "default".to_string(),
             profiles: Vec::new(),
             poll_wakeups,
+            _direct_candidate_tx: direct_candidate_tx,
+            direct_candidate_rx: tokio::sync::Mutex::new(direct_candidate_rx),
             ably_supervisor: AblySupervisor::disabled(),
             held_session_states: tokio::sync::Mutex::new(Vec::new()),
             cancel,
@@ -917,11 +985,13 @@ mod tests {
             now.checked_sub(Duration::from_millis(25)).unwrap(),
             Some(now.checked_sub(Duration::from_millis(7)).unwrap()),
         )
+        .with_discovery_source(JobDiscoverySource::Poll)
         .with_poll_reason("deferred")
         .with_poll_timing(Duration::from_millis(19), Duration::from_millis(11));
 
         let body = serde_json::to_value(claim_request_body(&candidate)).unwrap();
 
+        assert_eq!(body["telemetry"]["discoverySource"], "poll");
         assert!(
             body["telemetry"]["jobDiscoveredToClaimRequestMs"]
                 .as_u64()
@@ -959,6 +1029,20 @@ mod tests {
                 .get("localAdmissionToClaimRequestMs")
                 .is_none()
         );
+        assert!(body["telemetry"].get("pollDueToJobDiscoveredMs").is_none());
+        assert!(body["telemetry"].get("pollHttpRequestMs").is_none());
+        assert!(body["telemetry"].get("pollReason").is_none());
+    }
+
+    #[test]
+    fn claim_request_body_serializes_ably_discovery_source_without_poll_timing() {
+        let candidate =
+            JobCandidate::new(RunId::nil(), crate::profile::DEFAULT_PROFILE.to_string())
+                .with_discovery_source(JobDiscoverySource::Ably);
+
+        let body = serde_json::to_value(claim_request_body(&candidate)).unwrap();
+
+        assert_eq!(body["telemetry"]["discoverySource"], "ably");
         assert!(body["telemetry"].get("pollDueToJobDiscoveredMs").is_none());
         assert!(body["telemetry"].get("pollHttpRequestMs").is_none());
         assert!(body["telemetry"].get("pollReason").is_none());
@@ -1045,9 +1129,54 @@ mod tests {
 
         assert_eq!(discovered.run_id(), run_id);
         assert_eq!(discovered.profile_name(), "vm0/default");
+        assert_eq!(
+            discovered.discovery_source(),
+            Some(JobDiscoverySource::Poll)
+        );
         assert!(discovered.poll_due_to_job_discovered_elapsed().is_some());
         assert!(discovered.poll_http_request_elapsed().is_some());
         mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn discover_returns_ably_direct_candidate_without_polling() {
+        let server = MockServer::start_async().await;
+        let run_id: RunId = "00000000-0000-0000-0000-000000000006".parse().unwrap();
+        let poll_mock = server
+            .mock_async(|when, then| {
+                when.method(POST).path(routes::runners::poll::POLL.path);
+                then.status(200)
+                    .json_body(serde_json::json!({ "job": null }));
+            })
+            .await;
+        let provider = api_provider_for_test(
+            server.base_url(),
+            CancellationToken::new(),
+            Arc::new(PollWakeups::new(false)),
+        );
+        provider
+            ._direct_candidate_tx
+            .try_send(DirectJobCandidate::new(
+                run_id,
+                crate::profile::DEFAULT_PROFILE.to_string(),
+                true,
+            ))
+            .unwrap();
+
+        let discovered = tokio::time::timeout(Duration::from_secs(1), provider.discover())
+            .await
+            .expect("discover should receive direct candidate")
+            .unwrap();
+
+        assert_eq!(discovered.run_id(), run_id);
+        assert_eq!(discovered.profile_name(), crate::profile::DEFAULT_PROFILE);
+        assert_eq!(
+            discovered.discovery_source(),
+            Some(JobDiscoverySource::Ably)
+        );
+        assert!(discovered.poll_due_to_job_discovered_elapsed().is_none());
+        assert!(discovered.poll_http_request_elapsed().is_none());
+        poll_mock.assert_calls_async(0).await;
     }
 
     #[tokio::test]

--- a/crates/runner/src/provider/api_ably_supervisor.rs
+++ b/crates/runner/src/provider/api_ably_supervisor.rs
@@ -27,14 +27,25 @@ pub(super) struct DirectJobCandidate {
     run_id: RunId,
     profile_name: String,
     targeted: bool,
+    discovered_at: StdInstant,
 }
 
 impl DirectJobCandidate {
     pub(super) fn new(run_id: RunId, profile_name: String, targeted: bool) -> Self {
+        Self::new_with_discovered_at(run_id, profile_name, targeted, StdInstant::now())
+    }
+
+    pub(super) fn new_with_discovered_at(
+        run_id: RunId,
+        profile_name: String,
+        targeted: bool,
+        discovered_at: StdInstant,
+    ) -> Self {
         Self {
             run_id,
             profile_name,
             targeted,
+            discovered_at,
         }
     }
 
@@ -51,7 +62,7 @@ impl DirectJobCandidate {
     }
 
     pub(super) fn into_job_candidate(self) -> JobCandidate {
-        JobCandidate::new(self.run_id, self.profile_name)
+        JobCandidate::new_with_discovered_at(self.run_id, self.profile_name, self.discovered_at)
             .with_discovery_source(JobDiscoverySource::Ably)
     }
 }
@@ -739,8 +750,16 @@ fn parse_job_notification(msg: &ably_subscriber::Message) -> Option<JobNotificat
             return None;
         }
     };
-    let profile = msg.data.get("profile").and_then(|v| v.as_str());
-    let target_runner_id = msg.data.get("targetRunnerId").and_then(|v| v.as_str());
+    let profile = msg
+        .data
+        .get("profile")
+        .and_then(|v| v.as_str())
+        .filter(|value| !value.is_empty());
+    let target_runner_id = msg
+        .data
+        .get("targetRunnerId")
+        .and_then(|v| v.as_str())
+        .filter(|value| !value.is_empty());
     Some(JobNotification {
         run_id,
         profile,
@@ -1557,6 +1576,33 @@ mod tests {
             Some("job"),
             serde_json::json!({
                 "runId": "00000000-0000-0000-0000-000000000001"
+            }),
+        );
+
+        handle_ably_message(&msg, "runner-1", &profiles, &wakeups, &direct_tx, &tokens).await;
+
+        assert!(direct_rx.try_recv().is_err());
+        assert!(wakeups.snapshot().await.poll_now);
+    }
+
+    #[tokio::test]
+    async fn empty_profile_job_notification_wakes_poll() {
+        let tokens = Mutex::new(HashMap::new());
+        let wakeups = PollWakeups::new(true);
+        let (direct_tx, mut direct_rx) = direct_candidate_channel();
+        let profiles = default_profiles();
+        let _ = wakeups
+            .wait_for_poll_due(
+                &CancellationToken::new(),
+                Duration::from_secs(30),
+                Duration::from_secs(5),
+            )
+            .await;
+        let msg = make_message(
+            Some("job"),
+            serde_json::json!({
+                "runId": "00000000-0000-0000-0000-000000000001",
+                "profile": ""
             }),
         );
 

--- a/crates/runner/src/provider/api_ably_supervisor.rs
+++ b/crates/runner/src/provider/api_ably_supervisor.rs
@@ -2,11 +2,12 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant as StdInstant};
 
-use tokio::sync::{Mutex, Notify};
+use tokio::sync::{Mutex, Notify, mpsc};
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
 use super::api::ApiClient;
+use super::{JobCandidate, JobDiscoverySource};
 use crate::ids::RunId;
 use crate::retry::{RetryState, recv_retry, sleep_until_retry};
 use crate::run_cancellation::{RunCancellationHandle, SharedRunCancellationMap};
@@ -20,6 +21,40 @@ const TARGETED_RUNNER_DEFER_MAX: Duration = Duration::from_secs(10);
 
 type AblyConnectHandle =
     tokio::task::JoinHandle<Result<ably_subscriber::Subscription, ably_subscriber::Error>>;
+
+#[derive(Debug)]
+pub(super) struct DirectJobCandidate {
+    run_id: RunId,
+    profile_name: String,
+    targeted: bool,
+}
+
+impl DirectJobCandidate {
+    pub(super) fn new(run_id: RunId, profile_name: String, targeted: bool) -> Self {
+        Self {
+            run_id,
+            profile_name,
+            targeted,
+        }
+    }
+
+    pub(super) fn run_id(&self) -> RunId {
+        self.run_id
+    }
+
+    pub(super) fn profile_name(&self) -> &str {
+        &self.profile_name
+    }
+
+    pub(super) fn targeted(&self) -> bool {
+        self.targeted
+    }
+
+    pub(super) fn into_job_candidate(self) -> JobCandidate {
+        JobCandidate::new(self.run_id, self.profile_name)
+            .with_discovery_source(JobDiscoverySource::Ably)
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum PollReason {
@@ -373,28 +408,46 @@ pub(super) struct AblySupervisor {
     task: Mutex<Option<tokio::task::JoinHandle<()>>>,
 }
 
+pub(super) struct AblySupervisorConfig {
+    pub(super) api: ApiClient,
+    pub(super) group: String,
+    pub(super) runner_id: String,
+    pub(super) profiles: Vec<String>,
+    pub(super) poll_wakeups: Arc<PollWakeups>,
+    pub(super) direct_candidate_tx: mpsc::Sender<DirectJobCandidate>,
+    pub(super) cancel_tokens: SharedRunCancellationMap,
+    pub(super) provider_cancel: CancellationToken,
+}
+
+struct SupervisorTaskConfig {
+    api: ApiClient,
+    group: String,
+    runner_id: String,
+    profiles: Vec<String>,
+    poll_wakeups: Arc<PollWakeups>,
+    direct_candidate_tx: mpsc::Sender<DirectJobCandidate>,
+    cancel_tokens: SharedRunCancellationMap,
+    provider_cancel: CancellationToken,
+    shutdown: CancellationToken,
+}
+
 impl AblySupervisor {
-    pub(super) fn spawn(
-        api: ApiClient,
-        group: String,
-        runner_id: String,
-        poll_wakeups: Arc<PollWakeups>,
-        cancel_tokens: SharedRunCancellationMap,
-        provider_cancel: CancellationToken,
-    ) -> Self {
+    pub(super) fn spawn(config: AblySupervisorConfig) -> Self {
         let shutdown = CancellationToken::new();
         let task_shutdown = shutdown.clone();
+        let task_config = SupervisorTaskConfig {
+            api: config.api,
+            group: config.group,
+            runner_id: config.runner_id,
+            profiles: config.profiles,
+            poll_wakeups: config.poll_wakeups,
+            direct_candidate_tx: config.direct_candidate_tx,
+            cancel_tokens: config.cancel_tokens,
+            provider_cancel: config.provider_cancel,
+            shutdown: task_shutdown,
+        };
         let task = tokio::spawn(async move {
-            run_supervisor(
-                api,
-                group,
-                runner_id,
-                poll_wakeups,
-                cancel_tokens,
-                provider_cancel,
-                task_shutdown,
-            )
-            .await;
+            run_supervisor(task_config).await;
         });
         Self {
             shutdown,
@@ -434,15 +487,7 @@ impl AblySupervisor {
     }
 }
 
-async fn run_supervisor(
-    api: ApiClient,
-    group: String,
-    runner_id: String,
-    poll_wakeups: Arc<PollWakeups>,
-    cancel_tokens: SharedRunCancellationMap,
-    provider_cancel: CancellationToken,
-    shutdown: CancellationToken,
-) {
+async fn run_supervisor(config: SupervisorTaskConfig) {
     let mut ably: Option<ably_subscriber::Subscription> = None;
     let mut ably_retry: RetryState<AblyConnectHandle> =
         RetryState::new(ABLY_BACKOFF_INITIAL, ABLY_BACKOFF_MAX, None);
@@ -450,45 +495,53 @@ async fn run_supervisor(
     let mut disconnect = AblyDisconnectState::disconnected("connecting".to_string());
 
     loop {
-        maybe_spawn_ably_connect(&mut ably, &api, &group, &mut ably_retry);
+        maybe_spawn_ably_connect(&mut ably, &config.api, &config.group, &mut ably_retry);
         let disconnect_error_at = disconnect.error_deadline();
 
         tokio::select! {
-            () = shutdown.cancelled() => {
+            () = config.shutdown.cancelled() => {
                 break;
             }
-            () = provider_cancel.cancelled() => {
+            () = config.provider_cancel.cancelled() => {
                 break;
             }
             event = recv_ably(&mut ably) => {
                 match event {
                     Some(ably_subscriber::Event::Message(msg)) => {
-                        handle_ably_message(&msg, &runner_id, &poll_wakeups, &cancel_tokens).await;
+                        handle_ably_message(
+                            &msg,
+                            &config.runner_id,
+                            &config.profiles,
+                            &config.poll_wakeups,
+                            &config.direct_candidate_tx,
+                            &config.cancel_tokens,
+                        )
+                        .await;
                     }
                     Some(ably_subscriber::Event::Connected) => {
                         if !disconnect.is_connected() {
                             info!("ably reconnected");
                         }
                         disconnect.mark_connected();
-                        poll_wakeups.mark_ably_connected().await;
+                        config.poll_wakeups.mark_ably_connected().await;
                     }
                     Some(ably_subscriber::Event::Disconnected { reason }) => {
                         let reason = reason.unwrap_or_else(|| "unknown".to_string());
                         disconnect.record_disconnected(reason.clone());
-                        poll_wakeups.mark_ably_disconnected().await;
+                        config.poll_wakeups.mark_ably_disconnected().await;
                         info!(reason = %reason, "ably disconnected, switching to fast poll");
                     }
                     Some(ably_subscriber::Event::Error { code, message }) => {
                         error!(code, message = %message, "ably fatal error, will reconnect");
                         disconnect.record_disconnected(message.clone());
-                        poll_wakeups.mark_ably_disconnected().await;
+                        config.poll_wakeups.mark_ably_disconnected().await;
                         ably = None;
                         ably_retry.schedule();
                     }
                     None => {
                         warn!("ably subscription closed, will reconnect");
                         disconnect.record_disconnected("subscription closed".to_string());
-                        poll_wakeups.mark_ably_disconnected().await;
+                        config.poll_wakeups.mark_ably_disconnected().await;
                         ably = None;
                         ably_retry.schedule();
                     }
@@ -498,11 +551,11 @@ async fn run_supervisor(
                 match handle_ably_connect_result(result, &mut ably, &mut ably_retry) {
                     Ok(()) => {
                         disconnect.mark_connected();
-                        poll_wakeups.mark_ably_connected().await;
+                        config.poll_wakeups.mark_ably_connected().await;
                     }
                     Err(reason) => {
                         disconnect.record_disconnected(reason);
-                        poll_wakeups.mark_ably_disconnected().await;
+                        config.poll_wakeups.mark_ably_disconnected().await;
                     }
                 }
             }
@@ -530,7 +583,9 @@ async fn run_supervisor(
 async fn handle_ably_message(
     msg: &ably_subscriber::Message,
     runner_id: &str,
+    profiles: &[String],
     poll_wakeups: &PollWakeups,
+    direct_candidate_tx: &mpsc::Sender<DirectJobCandidate>,
     cancel_tokens: &Mutex<HashMap<RunId, RunCancellationHandle>>,
 ) {
     if let Some(run_id) = parse_cancel_notification(msg) {
@@ -556,15 +611,38 @@ async fn handle_ably_message(
                 "ably: job targeted to another runner, deferring poll"
             );
             JobNotificationAction::Defer
+        } else if let Some(profile) = notif.profile {
+            if supports_profile(profiles, profile) {
+                let targeted = notif
+                    .target_runner_id
+                    .is_some_and(|target| target == runner_id);
+                info!(
+                    run_id = %notif.run_id,
+                    profile = %profile,
+                    targeted,
+                    "ably: job notification, queueing direct candidate"
+                );
+                JobNotificationAction::Direct(DirectJobCandidate::new(
+                    notif.run_id,
+                    profile.to_owned(),
+                    targeted,
+                ))
+            } else {
+                info!(
+                    run_id = %notif.run_id,
+                    profile = %profile,
+                    "ably: job profile unsupported, ignoring direct notification"
+                );
+                JobNotificationAction::Ignore
+            }
         } else {
             let targeted = notif
                 .target_runner_id
                 .is_some_and(|target| target == runner_id);
             info!(
                 run_id = %notif.run_id,
-                profile = notif.profile.unwrap_or(""),
                 targeted,
-                "ably: job notification, waking poll"
+                "ably: job notification missing profile, waking poll"
             );
             JobNotificationAction::WakeNow
         }
@@ -579,11 +657,17 @@ async fn handle_ably_message(
         JobNotificationAction::WakeNow => {
             poll_wakeups.request_immediate_poll().await;
         }
+        JobNotificationAction::Direct(candidate) => {
+            enqueue_direct_candidate(candidate, direct_candidate_tx, poll_wakeups).await;
+        }
+        JobNotificationAction::Ignore => {}
     }
 }
 
 enum JobNotificationAction {
     Defer,
+    Direct(DirectJobCandidate),
+    Ignore,
     WakeNow,
 }
 
@@ -591,6 +675,36 @@ struct JobNotification<'a> {
     run_id: RunId,
     profile: Option<&'a str>,
     target_runner_id: Option<&'a str>,
+}
+
+fn supports_profile(profiles: &[String], profile: &str) -> bool {
+    profiles.is_empty() || profiles.iter().any(|candidate| candidate == profile)
+}
+
+async fn enqueue_direct_candidate(
+    candidate: DirectJobCandidate,
+    direct_candidate_tx: &mpsc::Sender<DirectJobCandidate>,
+    poll_wakeups: &PollWakeups,
+) {
+    match direct_candidate_tx.try_send(candidate) {
+        Ok(()) => {}
+        Err(mpsc::error::TrySendError::Full(candidate)) => {
+            warn!(
+                run_id = %candidate.run_id(),
+                profile = %candidate.profile_name(),
+                "ably: direct candidate queue full, waking poll"
+            );
+            poll_wakeups.request_immediate_poll().await;
+        }
+        Err(mpsc::error::TrySendError::Closed(candidate)) => {
+            warn!(
+                run_id = %candidate.run_id(),
+                profile = %candidate.profile_name(),
+                "ably: direct candidate queue closed, waking poll"
+            );
+            poll_wakeups.request_immediate_poll().await;
+        }
+    }
 }
 
 fn parse_cancel_notification(msg: &ably_subscriber::Message) -> Option<RunId> {
@@ -791,6 +905,17 @@ mod tests {
 
     fn poll_reason(due: Option<PollDue>) -> Option<PollReason> {
         due.map(PollDue::reason)
+    }
+
+    fn direct_candidate_channel() -> (
+        mpsc::Sender<DirectJobCandidate>,
+        mpsc::Receiver<DirectJobCandidate>,
+    ) {
+        mpsc::channel(4)
+    }
+
+    fn default_profiles() -> Vec<String> {
+        vec![crate::profile::DEFAULT_PROFILE.to_string()]
     }
 
     #[tokio::test(start_paused = true)]
@@ -1313,17 +1438,22 @@ mod tests {
         let token = handle.token();
         let tokens = Mutex::new(HashMap::from([(run_id, handle)]));
         let wakeups = PollWakeups::new(true);
+        let (direct_tx, mut direct_rx) = direct_candidate_channel();
+        let profiles = default_profiles();
         let msg = make_message(Some("cancel"), serde_json::json!({ "runId": run_id }));
 
-        handle_ably_message(&msg, "runner-1", &wakeups, &tokens).await;
+        handle_ably_message(&msg, "runner-1", &profiles, &wakeups, &direct_tx, &tokens).await;
 
         assert!(token.is_cancelled());
+        assert!(direct_rx.try_recv().is_err());
     }
 
     #[tokio::test]
-    async fn job_notifications_coalesce_into_poll_wakeup() {
+    async fn broadcast_supported_job_notification_enqueues_direct_candidate() {
         let tokens = Mutex::new(HashMap::new());
         let wakeups = PollWakeups::new(true);
+        let (direct_tx, mut direct_rx) = direct_candidate_channel();
+        let profiles = default_profiles();
         let _ = wakeups
             .wait_for_poll_due(
                 &CancellationToken::new(),
@@ -1339,25 +1469,24 @@ mod tests {
             }),
         );
 
-        handle_ably_message(&msg, "runner-1", &wakeups, &tokens).await;
-        handle_ably_message(&msg, "runner-1", &wakeups, &tokens).await;
+        handle_ably_message(&msg, "runner-1", &profiles, &wakeups, &direct_tx, &tokens).await;
 
-        assert!(wakeups.snapshot().await.poll_now);
-        let reason = wakeups
-            .wait_for_poll_due(
-                &CancellationToken::new(),
-                Duration::from_secs(30),
-                Duration::from_secs(5),
-            )
-            .await;
-        assert_eq!(poll_reason(reason), Some(PollReason::Immediate));
+        let candidate = direct_rx.try_recv().expect("direct candidate");
+        assert_eq!(
+            candidate.run_id().to_string(),
+            "00000000-0000-0000-0000-000000000001"
+        );
+        assert_eq!(candidate.profile_name(), "vm0/default");
+        assert!(!candidate.targeted());
         assert!(!wakeups.snapshot().await.poll_now);
     }
 
     #[tokio::test]
-    async fn target_other_runner_job_notification_defers_poll() {
+    async fn matching_targeted_job_notification_enqueues_direct_candidate() {
         let tokens = Mutex::new(HashMap::new());
         let wakeups = PollWakeups::new(true);
+        let (direct_tx, mut direct_rx) = direct_candidate_channel();
+        let profiles = default_profiles();
         let _ = wakeups
             .wait_for_poll_due(
                 &CancellationToken::new(),
@@ -1369,13 +1498,129 @@ mod tests {
             Some("job"),
             serde_json::json!({
                 "runId": "00000000-0000-0000-0000-000000000001",
+                "profile": "vm0/default",
+                "targetRunnerId": "runner-1"
+            }),
+        );
+
+        handle_ably_message(&msg, "runner-1", &profiles, &wakeups, &direct_tx, &tokens).await;
+
+        let candidate = direct_rx.try_recv().expect("direct candidate");
+        assert_eq!(candidate.profile_name(), "vm0/default");
+        assert!(candidate.targeted());
+        assert!(!wakeups.snapshot().await.poll_now);
+    }
+
+    #[tokio::test]
+    async fn unsupported_profile_job_notification_is_ignored() {
+        let tokens = Mutex::new(HashMap::new());
+        let wakeups = PollWakeups::new(true);
+        let (direct_tx, mut direct_rx) = direct_candidate_channel();
+        let profiles = default_profiles();
+        let _ = wakeups
+            .wait_for_poll_due(
+                &CancellationToken::new(),
+                Duration::from_secs(30),
+                Duration::from_secs(5),
+            )
+            .await;
+        let msg = make_message(
+            Some("job"),
+            serde_json::json!({
+                "runId": "00000000-0000-0000-0000-000000000001",
+                "profile": "vm0/large"
+            }),
+        );
+
+        handle_ably_message(&msg, "runner-1", &profiles, &wakeups, &direct_tx, &tokens).await;
+
+        assert!(direct_rx.try_recv().is_err());
+        let snapshot = wakeups.snapshot().await;
+        assert!(!snapshot.poll_now);
+        assert!(snapshot.deferred_poll_at.is_none());
+    }
+
+    #[tokio::test]
+    async fn missing_profile_job_notification_wakes_poll() {
+        let tokens = Mutex::new(HashMap::new());
+        let wakeups = PollWakeups::new(true);
+        let (direct_tx, mut direct_rx) = direct_candidate_channel();
+        let profiles = default_profiles();
+        let _ = wakeups
+            .wait_for_poll_due(
+                &CancellationToken::new(),
+                Duration::from_secs(30),
+                Duration::from_secs(5),
+            )
+            .await;
+        let msg = make_message(
+            Some("job"),
+            serde_json::json!({
+                "runId": "00000000-0000-0000-0000-000000000001"
+            }),
+        );
+
+        handle_ably_message(&msg, "runner-1", &profiles, &wakeups, &direct_tx, &tokens).await;
+
+        assert!(direct_rx.try_recv().is_err());
+        assert!(wakeups.snapshot().await.poll_now);
+    }
+
+    #[tokio::test]
+    async fn full_direct_candidate_queue_wakes_poll_fallback() {
+        let tokens = Mutex::new(HashMap::new());
+        let wakeups = PollWakeups::new(true);
+        let (direct_tx, mut direct_rx) = mpsc::channel(1);
+        let profiles = default_profiles();
+        let _ = wakeups
+            .wait_for_poll_due(
+                &CancellationToken::new(),
+                Duration::from_secs(30),
+                Duration::from_secs(5),
+            )
+            .await;
+        let msg = make_message(
+            Some("job"),
+            serde_json::json!({
+                "runId": "00000000-0000-0000-0000-000000000001",
+                "profile": "vm0/default"
+            }),
+        );
+
+        handle_ably_message(&msg, "runner-1", &profiles, &wakeups, &direct_tx, &tokens).await;
+        handle_ably_message(&msg, "runner-1", &profiles, &wakeups, &direct_tx, &tokens).await;
+
+        let candidate = direct_rx.try_recv().expect("first direct candidate");
+        assert_eq!(candidate.profile_name(), "vm0/default");
+        assert!(wakeups.snapshot().await.poll_now);
+    }
+
+    #[tokio::test]
+    async fn target_other_runner_job_notification_defers_poll() {
+        let tokens = Mutex::new(HashMap::new());
+        let wakeups = PollWakeups::new(true);
+        let (direct_tx, mut direct_rx) = direct_candidate_channel();
+        let profiles = default_profiles();
+        let _ = wakeups
+            .wait_for_poll_due(
+                &CancellationToken::new(),
+                Duration::from_secs(30),
+                Duration::from_secs(5),
+            )
+            .await;
+        let msg = make_message(
+            Some("job"),
+            serde_json::json!({
+                "runId": "00000000-0000-0000-0000-000000000001",
+                "profile": "vm0/default",
                 "targetRunnerId": "runner-2"
             }),
         );
 
-        handle_ably_message(&msg, "runner-1", &wakeups, &tokens).await;
+        handle_ably_message(&msg, "runner-1", &profiles, &wakeups, &direct_tx, &tokens).await;
 
         let snapshot = wakeups.snapshot().await;
+        assert!(direct_rx.try_recv().is_err());
         assert!(!snapshot.poll_now);
         assert!(snapshot.deferred_poll_at.is_some());
     }
@@ -1384,6 +1629,8 @@ mod tests {
     async fn invalid_job_notification_does_not_mutate_wakeup_state() {
         let tokens = Mutex::new(HashMap::new());
         let wakeups = PollWakeups::new(true);
+        let (direct_tx, mut direct_rx) = direct_candidate_channel();
+        let profiles = default_profiles();
         let _ = wakeups
             .wait_for_poll_due(
                 &CancellationToken::new(),
@@ -1393,9 +1640,10 @@ mod tests {
             .await;
         let msg = make_message(Some("job"), serde_json::json!({ "runId": "not-a-uuid" }));
 
-        handle_ably_message(&msg, "runner-1", &wakeups, &tokens).await;
+        handle_ably_message(&msg, "runner-1", &profiles, &wakeups, &direct_tx, &tokens).await;
 
         let snapshot = wakeups.snapshot().await;
+        assert!(direct_rx.try_recv().is_err());
         assert!(!snapshot.poll_now);
         assert!(snapshot.deferred_poll_at.is_none());
     }

--- a/crates/runner/src/provider/api_ably_supervisor.rs
+++ b/crates/runner/src/provider/api_ably_supervisor.rs
@@ -67,6 +67,24 @@ impl DirectJobCandidate {
     }
 }
 
+#[derive(Clone)]
+pub(super) struct DirectCandidateSenders {
+    targeted: mpsc::Sender<DirectJobCandidate>,
+    broadcast: mpsc::Sender<DirectJobCandidate>,
+}
+
+impl DirectCandidateSenders {
+    pub(super) fn new(
+        targeted: mpsc::Sender<DirectJobCandidate>,
+        broadcast: mpsc::Sender<DirectJobCandidate>,
+    ) -> Self {
+        Self {
+            targeted,
+            broadcast,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum PollReason {
     Immediate,
@@ -425,7 +443,7 @@ pub(super) struct AblySupervisorConfig {
     pub(super) runner_id: String,
     pub(super) profiles: Vec<String>,
     pub(super) poll_wakeups: Arc<PollWakeups>,
-    pub(super) direct_candidate_tx: mpsc::Sender<DirectJobCandidate>,
+    pub(super) direct_candidate_senders: DirectCandidateSenders,
     pub(super) cancel_tokens: SharedRunCancellationMap,
     pub(super) provider_cancel: CancellationToken,
 }
@@ -436,7 +454,7 @@ struct SupervisorTaskConfig {
     runner_id: String,
     profiles: Vec<String>,
     poll_wakeups: Arc<PollWakeups>,
-    direct_candidate_tx: mpsc::Sender<DirectJobCandidate>,
+    direct_candidate_senders: DirectCandidateSenders,
     cancel_tokens: SharedRunCancellationMap,
     provider_cancel: CancellationToken,
     shutdown: CancellationToken,
@@ -452,7 +470,7 @@ impl AblySupervisor {
             runner_id: config.runner_id,
             profiles: config.profiles,
             poll_wakeups: config.poll_wakeups,
-            direct_candidate_tx: config.direct_candidate_tx,
+            direct_candidate_senders: config.direct_candidate_senders,
             cancel_tokens: config.cancel_tokens,
             provider_cancel: config.provider_cancel,
             shutdown: task_shutdown,
@@ -524,7 +542,7 @@ async fn run_supervisor(config: SupervisorTaskConfig) {
                             &config.runner_id,
                             &config.profiles,
                             &config.poll_wakeups,
-                            &config.direct_candidate_tx,
+                            &config.direct_candidate_senders,
                             &config.cancel_tokens,
                         )
                         .await;
@@ -596,7 +614,7 @@ async fn handle_ably_message(
     runner_id: &str,
     profiles: &[String],
     poll_wakeups: &PollWakeups,
-    direct_candidate_tx: &mpsc::Sender<DirectJobCandidate>,
+    direct_candidate_senders: &DirectCandidateSenders,
     cancel_tokens: &Mutex<HashMap<RunId, RunCancellationHandle>>,
 ) {
     if let Some(run_id) = parse_cancel_notification(msg) {
@@ -669,7 +687,7 @@ async fn handle_ably_message(
             poll_wakeups.request_immediate_poll().await;
         }
         JobNotificationAction::Direct(candidate) => {
-            enqueue_direct_candidate(candidate, direct_candidate_tx, poll_wakeups).await;
+            enqueue_direct_candidate(candidate, direct_candidate_senders, poll_wakeups).await;
         }
         JobNotificationAction::Ignore => {}
     }
@@ -694,15 +712,21 @@ fn supports_profile(profiles: &[String], profile: &str) -> bool {
 
 async fn enqueue_direct_candidate(
     candidate: DirectJobCandidate,
-    direct_candidate_tx: &mpsc::Sender<DirectJobCandidate>,
+    direct_candidate_senders: &DirectCandidateSenders,
     poll_wakeups: &PollWakeups,
 ) {
+    let (queue, direct_candidate_tx) = if candidate.targeted() {
+        ("targeted", &direct_candidate_senders.targeted)
+    } else {
+        ("broadcast", &direct_candidate_senders.broadcast)
+    };
     match direct_candidate_tx.try_send(candidate) {
         Ok(()) => {}
         Err(mpsc::error::TrySendError::Full(candidate)) => {
             warn!(
                 run_id = %candidate.run_id(),
                 profile = %candidate.profile_name(),
+                queue,
                 "ably: direct candidate queue full, waking poll"
             );
             poll_wakeups.request_immediate_poll().await;
@@ -711,6 +735,7 @@ async fn enqueue_direct_candidate(
             warn!(
                 run_id = %candidate.run_id(),
                 profile = %candidate.profile_name(),
+                queue,
                 "ably: direct candidate queue closed, waking poll"
             );
             poll_wakeups.request_immediate_poll().await;
@@ -926,11 +951,28 @@ mod tests {
         due.map(PollDue::reason)
     }
 
-    fn direct_candidate_channel() -> (
-        mpsc::Sender<DirectJobCandidate>,
-        mpsc::Receiver<DirectJobCandidate>,
-    ) {
-        mpsc::channel(4)
+    struct DirectCandidateReceivers {
+        targeted: mpsc::Receiver<DirectJobCandidate>,
+        broadcast: mpsc::Receiver<DirectJobCandidate>,
+    }
+
+    fn direct_candidate_channels() -> (DirectCandidateSenders, DirectCandidateReceivers) {
+        direct_candidate_channels_with_capacity(4, 4)
+    }
+
+    fn direct_candidate_channels_with_capacity(
+        targeted_capacity: usize,
+        broadcast_capacity: usize,
+    ) -> (DirectCandidateSenders, DirectCandidateReceivers) {
+        let (targeted_tx, targeted_rx) = mpsc::channel(targeted_capacity);
+        let (broadcast_tx, broadcast_rx) = mpsc::channel(broadcast_capacity);
+        (
+            DirectCandidateSenders::new(targeted_tx, broadcast_tx),
+            DirectCandidateReceivers {
+                targeted: targeted_rx,
+                broadcast: broadcast_rx,
+            },
+        )
     }
 
     fn default_profiles() -> Vec<String> {
@@ -1457,21 +1499,30 @@ mod tests {
         let token = handle.token();
         let tokens = Mutex::new(HashMap::from([(run_id, handle)]));
         let wakeups = PollWakeups::new(true);
-        let (direct_tx, mut direct_rx) = direct_candidate_channel();
+        let (direct_senders, mut direct_rx) = direct_candidate_channels();
         let profiles = default_profiles();
         let msg = make_message(Some("cancel"), serde_json::json!({ "runId": run_id }));
 
-        handle_ably_message(&msg, "runner-1", &profiles, &wakeups, &direct_tx, &tokens).await;
+        handle_ably_message(
+            &msg,
+            "runner-1",
+            &profiles,
+            &wakeups,
+            &direct_senders,
+            &tokens,
+        )
+        .await;
 
         assert!(token.is_cancelled());
-        assert!(direct_rx.try_recv().is_err());
+        assert!(direct_rx.targeted.try_recv().is_err());
+        assert!(direct_rx.broadcast.try_recv().is_err());
     }
 
     #[tokio::test]
     async fn broadcast_supported_job_notification_enqueues_direct_candidate() {
         let tokens = Mutex::new(HashMap::new());
         let wakeups = PollWakeups::new(true);
-        let (direct_tx, mut direct_rx) = direct_candidate_channel();
+        let (direct_senders, mut direct_rx) = direct_candidate_channels();
         let profiles = default_profiles();
         let _ = wakeups
             .wait_for_poll_due(
@@ -1488,15 +1539,24 @@ mod tests {
             }),
         );
 
-        handle_ably_message(&msg, "runner-1", &profiles, &wakeups, &direct_tx, &tokens).await;
+        handle_ably_message(
+            &msg,
+            "runner-1",
+            &profiles,
+            &wakeups,
+            &direct_senders,
+            &tokens,
+        )
+        .await;
 
-        let candidate = direct_rx.try_recv().expect("direct candidate");
+        let candidate = direct_rx.broadcast.try_recv().expect("direct candidate");
         assert_eq!(
             candidate.run_id().to_string(),
             "00000000-0000-0000-0000-000000000001"
         );
         assert_eq!(candidate.profile_name(), "vm0/default");
         assert!(!candidate.targeted());
+        assert!(direct_rx.targeted.try_recv().is_err());
         assert!(!wakeups.snapshot().await.poll_now);
     }
 
@@ -1504,7 +1564,7 @@ mod tests {
     async fn matching_targeted_job_notification_enqueues_direct_candidate() {
         let tokens = Mutex::new(HashMap::new());
         let wakeups = PollWakeups::new(true);
-        let (direct_tx, mut direct_rx) = direct_candidate_channel();
+        let (direct_senders, mut direct_rx) = direct_candidate_channels();
         let profiles = default_profiles();
         let _ = wakeups
             .wait_for_poll_due(
@@ -1522,11 +1582,20 @@ mod tests {
             }),
         );
 
-        handle_ably_message(&msg, "runner-1", &profiles, &wakeups, &direct_tx, &tokens).await;
+        handle_ably_message(
+            &msg,
+            "runner-1",
+            &profiles,
+            &wakeups,
+            &direct_senders,
+            &tokens,
+        )
+        .await;
 
-        let candidate = direct_rx.try_recv().expect("direct candidate");
+        let candidate = direct_rx.targeted.try_recv().expect("direct candidate");
         assert_eq!(candidate.profile_name(), "vm0/default");
         assert!(candidate.targeted());
+        assert!(direct_rx.broadcast.try_recv().is_err());
         assert!(!wakeups.snapshot().await.poll_now);
     }
 
@@ -1534,7 +1603,7 @@ mod tests {
     async fn unsupported_profile_job_notification_is_ignored() {
         let tokens = Mutex::new(HashMap::new());
         let wakeups = PollWakeups::new(true);
-        let (direct_tx, mut direct_rx) = direct_candidate_channel();
+        let (direct_senders, mut direct_rx) = direct_candidate_channels();
         let profiles = default_profiles();
         let _ = wakeups
             .wait_for_poll_due(
@@ -1551,9 +1620,18 @@ mod tests {
             }),
         );
 
-        handle_ably_message(&msg, "runner-1", &profiles, &wakeups, &direct_tx, &tokens).await;
+        handle_ably_message(
+            &msg,
+            "runner-1",
+            &profiles,
+            &wakeups,
+            &direct_senders,
+            &tokens,
+        )
+        .await;
 
-        assert!(direct_rx.try_recv().is_err());
+        assert!(direct_rx.targeted.try_recv().is_err());
+        assert!(direct_rx.broadcast.try_recv().is_err());
         let snapshot = wakeups.snapshot().await;
         assert!(!snapshot.poll_now);
         assert!(snapshot.deferred_poll_at.is_none());
@@ -1563,7 +1641,7 @@ mod tests {
     async fn missing_profile_job_notification_wakes_poll() {
         let tokens = Mutex::new(HashMap::new());
         let wakeups = PollWakeups::new(true);
-        let (direct_tx, mut direct_rx) = direct_candidate_channel();
+        let (direct_senders, mut direct_rx) = direct_candidate_channels();
         let profiles = default_profiles();
         let _ = wakeups
             .wait_for_poll_due(
@@ -1579,9 +1657,18 @@ mod tests {
             }),
         );
 
-        handle_ably_message(&msg, "runner-1", &profiles, &wakeups, &direct_tx, &tokens).await;
+        handle_ably_message(
+            &msg,
+            "runner-1",
+            &profiles,
+            &wakeups,
+            &direct_senders,
+            &tokens,
+        )
+        .await;
 
-        assert!(direct_rx.try_recv().is_err());
+        assert!(direct_rx.targeted.try_recv().is_err());
+        assert!(direct_rx.broadcast.try_recv().is_err());
         assert!(wakeups.snapshot().await.poll_now);
     }
 
@@ -1589,7 +1676,7 @@ mod tests {
     async fn empty_profile_job_notification_wakes_poll() {
         let tokens = Mutex::new(HashMap::new());
         let wakeups = PollWakeups::new(true);
-        let (direct_tx, mut direct_rx) = direct_candidate_channel();
+        let (direct_senders, mut direct_rx) = direct_candidate_channels();
         let profiles = default_profiles();
         let _ = wakeups
             .wait_for_poll_due(
@@ -1606,9 +1693,18 @@ mod tests {
             }),
         );
 
-        handle_ably_message(&msg, "runner-1", &profiles, &wakeups, &direct_tx, &tokens).await;
+        handle_ably_message(
+            &msg,
+            "runner-1",
+            &profiles,
+            &wakeups,
+            &direct_senders,
+            &tokens,
+        )
+        .await;
 
-        assert!(direct_rx.try_recv().is_err());
+        assert!(direct_rx.targeted.try_recv().is_err());
+        assert!(direct_rx.broadcast.try_recv().is_err());
         assert!(wakeups.snapshot().await.poll_now);
     }
 
@@ -1616,7 +1712,7 @@ mod tests {
     async fn full_direct_candidate_queue_wakes_poll_fallback() {
         let tokens = Mutex::new(HashMap::new());
         let wakeups = PollWakeups::new(true);
-        let (direct_tx, mut direct_rx) = mpsc::channel(1);
+        let (direct_senders, mut direct_rx) = direct_candidate_channels_with_capacity(1, 1);
         let profiles = default_profiles();
         let _ = wakeups
             .wait_for_poll_due(
@@ -1633,10 +1729,29 @@ mod tests {
             }),
         );
 
-        handle_ably_message(&msg, "runner-1", &profiles, &wakeups, &direct_tx, &tokens).await;
-        handle_ably_message(&msg, "runner-1", &profiles, &wakeups, &direct_tx, &tokens).await;
+        handle_ably_message(
+            &msg,
+            "runner-1",
+            &profiles,
+            &wakeups,
+            &direct_senders,
+            &tokens,
+        )
+        .await;
+        handle_ably_message(
+            &msg,
+            "runner-1",
+            &profiles,
+            &wakeups,
+            &direct_senders,
+            &tokens,
+        )
+        .await;
 
-        let candidate = direct_rx.try_recv().expect("first direct candidate");
+        let candidate = direct_rx
+            .broadcast
+            .try_recv()
+            .expect("first direct candidate");
         assert_eq!(candidate.profile_name(), "vm0/default");
         assert!(wakeups.snapshot().await.poll_now);
     }
@@ -1645,7 +1760,7 @@ mod tests {
     async fn target_other_runner_job_notification_defers_poll() {
         let tokens = Mutex::new(HashMap::new());
         let wakeups = PollWakeups::new(true);
-        let (direct_tx, mut direct_rx) = direct_candidate_channel();
+        let (direct_senders, mut direct_rx) = direct_candidate_channels();
         let profiles = default_profiles();
         let _ = wakeups
             .wait_for_poll_due(
@@ -1663,10 +1778,19 @@ mod tests {
             }),
         );
 
-        handle_ably_message(&msg, "runner-1", &profiles, &wakeups, &direct_tx, &tokens).await;
+        handle_ably_message(
+            &msg,
+            "runner-1",
+            &profiles,
+            &wakeups,
+            &direct_senders,
+            &tokens,
+        )
+        .await;
 
         let snapshot = wakeups.snapshot().await;
-        assert!(direct_rx.try_recv().is_err());
+        assert!(direct_rx.targeted.try_recv().is_err());
+        assert!(direct_rx.broadcast.try_recv().is_err());
         assert!(!snapshot.poll_now);
         assert!(snapshot.deferred_poll_at.is_some());
     }
@@ -1675,7 +1799,7 @@ mod tests {
     async fn invalid_job_notification_does_not_mutate_wakeup_state() {
         let tokens = Mutex::new(HashMap::new());
         let wakeups = PollWakeups::new(true);
-        let (direct_tx, mut direct_rx) = direct_candidate_channel();
+        let (direct_senders, mut direct_rx) = direct_candidate_channels();
         let profiles = default_profiles();
         let _ = wakeups
             .wait_for_poll_due(
@@ -1686,10 +1810,19 @@ mod tests {
             .await;
         let msg = make_message(Some("job"), serde_json::json!({ "runId": "not-a-uuid" }));
 
-        handle_ably_message(&msg, "runner-1", &profiles, &wakeups, &direct_tx, &tokens).await;
+        handle_ably_message(
+            &msg,
+            "runner-1",
+            &profiles,
+            &wakeups,
+            &direct_senders,
+            &tokens,
+        )
+        .await;
 
         let snapshot = wakeups.snapshot().await;
-        assert!(direct_rx.try_recv().is_err());
+        assert!(direct_rx.targeted.try_recv().is_err());
+        assert!(direct_rx.broadcast.try_recv().is_err());
         assert!(!snapshot.poll_now);
         assert!(snapshot.deferred_poll_at.is_none());
     }

--- a/crates/runner/src/provider/api_ably_supervisor.rs
+++ b/crates/runner/src/provider/api_ably_supervisor.rs
@@ -186,7 +186,7 @@ impl PollWakeups {
         self.notify.notify_waiters();
     }
 
-    async fn request_immediate_poll(&self) {
+    pub(super) async fn request_immediate_poll(&self) {
         let mut inner = self.inner.lock().await;
         inner.poll_now = true;
         inner.bump_generation();

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -22,6 +22,22 @@ use crate::active_input::ActiveInputSource;
 use crate::ids::RunId;
 use crate::types::{ExecutionContext, HeartbeatState, SandboxReuseResult};
 
+/// Low-cardinality source that first discovered a job candidate.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum JobDiscoverySource {
+    Ably,
+    Poll,
+}
+
+impl JobDiscoverySource {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Ably => "ably",
+            Self::Poll => "poll",
+        }
+    }
+}
+
 /// Discovered work item ready for the non-cancellable claim phase.
 #[derive(Clone, Debug)]
 pub struct JobCandidate {
@@ -30,6 +46,7 @@ pub struct JobCandidate {
     local_job_path: Option<PathBuf>,
     discovered_at: Instant,
     local_admission_started_at: Option<Instant>,
+    discovery_source: Option<JobDiscoverySource>,
     poll_reason: Option<String>,
     poll_due_to_job_discovered_elapsed: Option<Duration>,
     poll_http_request_elapsed: Option<Duration>,
@@ -43,6 +60,7 @@ impl JobCandidate {
             local_job_path: None,
             discovered_at: Instant::now(),
             local_admission_started_at: None,
+            discovery_source: None,
             poll_reason: None,
             poll_due_to_job_discovered_elapsed: None,
             poll_http_request_elapsed: None,
@@ -56,6 +74,7 @@ impl JobCandidate {
             local_job_path: Some(job_path),
             discovered_at: Instant::now(),
             local_admission_started_at: None,
+            discovery_source: None,
             poll_reason: None,
             poll_due_to_job_discovered_elapsed: None,
             poll_http_request_elapsed: None,
@@ -87,6 +106,10 @@ impl JobCandidate {
             .map(|started| started.elapsed())
     }
 
+    pub(crate) fn discovery_source(&self) -> Option<JobDiscoverySource> {
+        self.discovery_source
+    }
+
     pub(crate) fn poll_reason(&self) -> Option<&str> {
         self.poll_reason.as_deref()
     }
@@ -97,6 +120,11 @@ impl JobCandidate {
 
     pub(crate) fn poll_http_request_elapsed(&self) -> Option<Duration> {
         self.poll_http_request_elapsed
+    }
+
+    pub(crate) fn with_discovery_source(mut self, source: JobDiscoverySource) -> Self {
+        self.discovery_source = Some(source);
+        self
     }
 
     pub(crate) fn with_poll_reason(mut self, poll_reason: impl Into<String>) -> Self {
@@ -127,6 +155,7 @@ impl JobCandidate {
             local_job_path: None,
             discovered_at,
             local_admission_started_at,
+            discovery_source: None,
             poll_reason: None,
             poll_due_to_job_discovered_elapsed: None,
             poll_http_request_elapsed: None,

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -54,11 +54,19 @@ pub struct JobCandidate {
 
 impl JobCandidate {
     pub fn new(run_id: RunId, profile_name: String) -> Self {
+        Self::new_with_discovered_at(run_id, profile_name, Instant::now())
+    }
+
+    pub(crate) fn new_with_discovered_at(
+        run_id: RunId,
+        profile_name: String,
+        discovered_at: Instant,
+    ) -> Self {
         Self {
             run_id,
             profile_name,
             local_job_path: None,
-            discovered_at: Instant::now(),
+            discovered_at,
             local_admission_started_at: None,
             discovery_source: None,
             poll_reason: None,

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -2512,6 +2512,7 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
       [200],
       {
         telemetry: {
+          discoverySource: "poll",
           jobDiscoveredToClaimRequestMs: 1234,
           localAdmissionToClaimRequestMs: 56,
           pollDueToJobDiscoveredMs: 789,
@@ -2569,6 +2570,7 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
           runner_group: runnerGroup,
           profile: "vm0/default",
           auth_type: "user",
+          discovery_source: "poll",
           poll_reason: "deferred",
         }),
       );
@@ -2597,6 +2599,7 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
         success: true,
         profile: "vm0/default",
         auth_type: "user",
+        discovery_source: "poll",
         poll_reason: "deferred",
       }),
     );
@@ -2613,6 +2616,7 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
         success: true,
         profile: "vm0/default",
         auth_type: "user",
+        discovery_source: "poll",
         poll_reason: "deferred",
       }),
     );
@@ -2658,6 +2662,7 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
           runner_group: runnerGroup,
           profile: "vm0/default",
           auth_type: "user",
+          discovery_source: "poll",
           poll_reason: "deferred",
         }),
       );

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -101,6 +101,7 @@ class ClaimRouteTimingCollector {
     readonly runnerGroup: string;
     readonly profile: string;
     readonly authType: RunnerAuthContext["type"];
+    readonly discoverySource: string | undefined;
     readonly pollReason: string | undefined;
   }): void {
     const records = this.records.splice(0);
@@ -109,6 +110,9 @@ class ClaimRouteTimingCollector {
       profile: args.profile,
       auth_type: args.authType,
     };
+    if (args.discoverySource) {
+      dimensions.discovery_source = args.discoverySource;
+    }
     if (args.pollReason) {
       dimensions.poll_reason = args.pollReason;
     }
@@ -834,6 +838,7 @@ function scheduleSuccessfulClaimSideEffects(args: {
   readonly claimResult: ClaimedTransitionResult;
   readonly telemetry:
     | {
+        readonly discoverySource?: string;
         readonly jobDiscoveredToClaimRequestMs?: number;
         readonly localAdmissionToClaimRequestMs?: number;
         readonly pollDueToJobDiscoveredMs?: number;
@@ -875,6 +880,7 @@ function scheduleSuccessfulClaimSideEffects(args: {
       args.telemetry?.jobDiscoveredToClaimRequestMs,
     localAdmissionToClaimRequestMs:
       args.telemetry?.localAdmissionToClaimRequestMs,
+    discoverySource: args.telemetry?.discoverySource,
     pollDueToJobDiscoveredMs: args.telemetry?.pollDueToJobDiscoveredMs,
     pollHttpRequestMs: args.telemetry?.pollHttpRequestMs,
     pollReason: args.telemetry?.pollReason,
@@ -895,6 +901,7 @@ function scheduleClaimSucceededSideEffects(args: {
   readonly claimRequestToRunningMs: number;
   readonly jobDiscoveredToClaimRequestMs: number | undefined;
   readonly localAdmissionToClaimRequestMs: number | undefined;
+  readonly discoverySource: string | undefined;
   readonly pollDueToJobDiscoveredMs: number | undefined;
   readonly pollHttpRequestMs: number | undefined;
   readonly pollReason: string | undefined;
@@ -925,6 +932,7 @@ async function recordClaimTimingMetrics(args: {
   readonly claimRequestToRunningMs: number;
   readonly jobDiscoveredToClaimRequestMs: number | undefined;
   readonly localAdmissionToClaimRequestMs: number | undefined;
+  readonly discoverySource: string | undefined;
   readonly pollDueToJobDiscoveredMs: number | undefined;
   readonly pollHttpRequestMs: number | undefined;
   readonly pollReason: string | undefined;
@@ -936,6 +944,9 @@ async function recordClaimTimingMetrics(args: {
     profile: args.profile,
     auth_type: args.authType,
   };
+  if (args.discoverySource) {
+    dimensions.discovery_source = args.discoverySource;
+  }
   if (args.pollReason) {
     dimensions.poll_reason = args.pollReason;
   }
@@ -1004,6 +1015,7 @@ async function recordClaimTimingMetrics(args: {
     runnerGroup: args.runnerGroup,
     profile: args.profile,
     authType: args.authType,
+    discoverySource: args.discoverySource,
     pollReason: args.pollReason,
   });
 }

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -43,7 +43,10 @@ export const runnerClaimPollReasonSchema = z.enum([
   "fast",
 ]);
 
+const runnerClaimDiscoverySourceSchema = z.enum(["ably", "poll"]);
+
 const runnerClaimTelemetrySchema = z.object({
+  discoverySource: runnerClaimDiscoverySourceSchema.optional(),
   jobDiscoveredToClaimRequestMs: z.number().int().nonnegative().optional(),
   localAdmissionToClaimRequestMs: z.number().int().nonnegative().optional(),
   pollDueToJobDiscoveredMs: z.number().int().nonnegative().optional(),


### PR DESCRIPTION
## Summary
- restore a direct Ably job-candidate path for matching targeted jobs and supported broadcast profiles
- keep target-other defer behavior and poll fallback for legacy/missing-profile notifications or queue backpressure
- add low-cardinality claim telemetry for discoverySource so Ably and poll discovery can be separated

Closes #19016

## Tests
- cargo test --manifest-path crates/Cargo.toml -p runner provider::api
- cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings
- cd turbo && pnpm check-types
- cd turbo && pnpm -F api exec vitest src/signals/routes/__tests__/run-lifecycle.bdd.test.ts

## Notes
- Local generated connector firewall files were incomplete initially; cd turbo && pnpm install restored workspace links and regenerated ignored firewall metadata before checks.