### PR TITLE
fix: silence jsonl writes after shutdown

### DIFF
--- a/crates/runner/mitm-addon/src/jsonl_writer.py
+++ b/crates/runner/mitm-addon/src/jsonl_writer.py
@@ -44,7 +44,6 @@ def write_jsonl_line(log_path: str, line: bytes, log_name: str) -> None:
     dropped = False
     with _condition:
         if _shutdown:
-            _warn(f"Skipping {log_name} log write after JSONL writer shutdown")
             return
         line_size = len(line)
         if _pending_bytes + line_size > MAX_PENDING_JSONL_BYTES:

--- a/crates/runner/mitm-addon/tests/test_logging_utils.py
+++ b/crates/runner/mitm-addon/tests/test_logging_utils.py
@@ -240,19 +240,25 @@ class TestJsonlWriterBehavior:
         assert entry["level"] == "info"
         assert entry["message"] == "before shutdown"
 
-    def test_write_after_shutdown_warns_without_appending(self, tmp_path):
+    def test_write_after_shutdown_is_noop_without_warning(self, tmp_path):
+        network_path = tmp_path / "network.jsonl"
         proxy_path = tmp_path / "proxy.jsonl"
         log = MagicMock()
 
+        logging_utils.log_network_entry(str(network_path), {"action": "ALLOW"})
         logging_utils.log_proxy_entry(str(proxy_path), "info", "before shutdown")
         logging_utils.shutdown_log_writer()
+        before_network_entries = _read_jsonl_entries_without_flush(network_path)
         before_entries = _read_jsonl_entries_without_flush(proxy_path)
 
         with patch.object(logging_utils.ctx, "log", log, create=True):
+            logging_utils.log_network_entry(str(network_path), {"action": "DENY"})
             logging_utils.log_proxy_entry(str(proxy_path), "warn", "after shutdown")
 
-        log.warn.assert_called_once_with("Skipping proxy log write after JSONL writer shutdown")
+        log.warn.assert_not_called()
+        after_network_entries = _read_jsonl_entries_without_flush(network_path)
         after_entries = _read_jsonl_entries_without_flush(proxy_path)
+        assert after_network_entries == before_network_entries
         assert after_entries == before_entries
 
 


### PR DESCRIPTION
## Summary

- Treat mitm addon JSONL writes attempted after writer shutdown as silent best-effort drops.
- Keep accepted pre-shutdown writes drained during `shutdown_writer()`.
- Preserve real warning paths for encoding failures, backlog pressure, and filesystem write failures.

Fixes #19021.

## Tests

```bash
cd crates/runner/mitm-addon
pytest tests/test_logging_utils.py tests/test_jsonl_writer.py
pytest tests/test_done_hook.py tests/test_response_handler.py tests/test_error_handler.py tests/test_tcp_hooks.py
```
