### PR TITLE
fix: add agent exit 126 diagnostics

### DIFF
--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -10,11 +10,11 @@ use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use super::diagnostics::{
-    AgentStdoutStreamDiagnostics, StdoutDrainReport, build_agent_env_diagnostics,
-    build_agent_env_key_diagnostics, check_host_oom, collect_agent_abnormal_exit_diagnostics,
-    dmesg_indicates_oom, drain_stdout_to_file, log_agent_abnormal_exit_env_diagnostics,
-    log_agent_bootstrap_abnormal_exit_diagnostics, log_agent_process_exit_summary,
-    read_guest_error_file, read_guest_failure_diagnostic_file,
+    AgentBootstrapAbnormalExitLogContext, AgentStdoutStreamDiagnostics, StdoutDrainReport,
+    build_agent_env_diagnostics, build_agent_env_key_diagnostics, check_host_oom,
+    collect_agent_abnormal_exit_diagnostics, dmesg_indicates_oom, drain_stdout_to_file,
+    log_agent_abnormal_exit_env_diagnostics, log_agent_bootstrap_abnormal_exit_diagnostics,
+    log_agent_process_exit_summary, read_guest_error_file, read_guest_failure_diagnostic_file,
     should_collect_agent_abnormal_exit_diagnostics,
     should_log_agent_bootstrap_abnormal_exit_diagnostics,
 };
@@ -505,6 +505,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         }
     }
     let stdout_stream_diagnostics_on_wait_error = AgentStdoutStreamDiagnostics {
+        bytes_written: stdout_drain_report.bytes_written,
         chunk_truncated: stdout_drain_report.chunk_truncated,
         stream_overflowed: false,
     };
@@ -546,6 +547,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         warn!(run_id = %context.run_id, "agent stdout stream overflowed before process exit");
     }
     let stdout_stream_diagnostics = AgentStdoutStreamDiagnostics {
+        bytes_written: stdout_drain_report.bytes_written,
         chunk_truncated: stdout_drain_report.chunk_truncated,
         stream_overflowed: exit.stream_overflowed,
     };
@@ -569,6 +571,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         start.reuse_result,
         &exit,
         &env_diagnostics,
+        stdout_stream_diagnostics,
     );
 
     // Check for OOM kill when process was terminated by SIGKILL.
@@ -647,13 +650,16 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
             let env_key_diagnostics = build_agent_env_key_diagnostics(&env_pairs);
             if should_log_bootstrap_diagnostics {
                 log_agent_bootstrap_abnormal_exit_diagnostics(
-                    context.run_id,
-                    sandbox.id(),
-                    start.reuse_result,
-                    &exit,
-                    &env_diagnostics,
-                    &env_key_diagnostics,
-                    session_restore_diagnostics.as_ref(),
+                    AgentBootstrapAbnormalExitLogContext {
+                        run_id: context.run_id,
+                        sandbox_id: sandbox.id(),
+                        reuse_result: start.reuse_result,
+                        exit: &exit,
+                        env_diagnostics: &env_diagnostics,
+                        env_key_diagnostics: &env_key_diagnostics,
+                        stdout_stream_diagnostics,
+                        session_restore_diagnostics: session_restore_diagnostics.as_ref(),
+                    },
                 );
             }
             if should_collect_resource_diagnostics {

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -5,6 +5,7 @@ use sandbox::{
     EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, ExecTermination, ProcessControlMode, ProcessOutputMode,
     Sandbox, StartProcessRequest,
 };
+use shell_quote::quote_shell_arg;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
@@ -35,6 +36,25 @@ use crate::telemetry::JobTelemetry;
 use crate::types::{ExecutionContext, GuestDownloadManifest};
 
 const AGENT_WRAPPER_STDERR_CAPTURE_LIMIT_BYTES: u32 = 64 * 1024;
+
+pub(super) fn build_agent_start_command(run_agent_path: &str) -> String {
+    let run_agent_path = quote_shell_arg(run_agent_path);
+    format!(
+        "if [ ! -e {run_agent_path} ]; then \
+            printf '%s\\n' 'agent bootstrap failed: guest-agent is missing' >&2; \
+            exit 127; \
+        fi; \
+        if [ ! -f {run_agent_path} ]; then \
+            printf '%s\\n' 'agent bootstrap failed: guest-agent is not a regular file' >&2; \
+            exit 126; \
+        fi; \
+        if [ ! -x {run_agent_path} ]; then \
+            printf '%s\\n' 'agent bootstrap failed: guest-agent is not executable' >&2; \
+            exit 126; \
+        fi; \
+        exec {run_agent_path} 2>&1"
+    )
+}
 
 pub(super) struct ProcessCancelTimeouts {
     pub(super) write: Duration,
@@ -330,7 +350,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
     // 6. Spawn agent — stdout streamed to host via vsock. guest-agent stderr is
     //    merged into stdout, while a small stderr capture keeps shell/wrapper
     //    startup failures visible when the process exits before guest logging.
-    let agent_cmd = format!("{} 2>&1", guest::RUN_AGENT);
+    let agent_cmd = build_agent_start_command(guest::RUN_AGENT);
     info!(run_id = %context.run_id, "spawning agent");
 
     // JOB_TIMEOUT remains the guest-side runtime budget. The host waits a

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -601,7 +601,10 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         let failure_exit_code = process_failure_exit_code(&exit);
         let stderr = process_failure_stderr(&exit);
         let failure_diagnostic = read_guest_failure_diagnostic_file(sandbox, context.run_id).await;
-        let guest_error = if stderr.is_empty() {
+        let should_read_guest_error = stderr.is_empty()
+            || (failure_diagnostic.is_none()
+                && matches!(exit.termination, ExecTermination::Exited { exit_code } if exit_code != 0));
+        let guest_error = if should_read_guest_error {
             read_guest_error_file(sandbox, context.run_id).await
         } else {
             None

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -12,8 +12,10 @@ use super::diagnostics::{
     AgentStdoutStreamDiagnostics, StdoutDrainReport, build_agent_env_diagnostics,
     build_agent_env_key_diagnostics, check_host_oom, collect_agent_abnormal_exit_diagnostics,
     dmesg_indicates_oom, drain_stdout_to_file, log_agent_abnormal_exit_env_diagnostics,
-    log_agent_process_exit_summary, read_guest_error_file, read_guest_failure_diagnostic_file,
+    log_agent_bootstrap_abnormal_exit_diagnostics, log_agent_process_exit_summary,
+    read_guest_error_file, read_guest_failure_diagnostic_file,
     should_collect_agent_abnormal_exit_diagnostics,
+    should_log_agent_bootstrap_abnormal_exit_diagnostics,
 };
 use super::env::{build_env_json, build_user_env_json, write_user_env_file};
 use super::guest_state::{restore_guest_state, sync_guest_timezone};
@@ -31,6 +33,8 @@ use crate::helper_exec::{helper_exec_succeeded, helper_exec_termination_label};
 use crate::paths::guest;
 use crate::telemetry::JobTelemetry;
 use crate::types::{ExecutionContext, GuestDownloadManifest};
+
+const AGENT_WRAPPER_STDERR_CAPTURE_LIMIT_BYTES: u32 = 64 * 1024;
 
 pub(super) struct ProcessCancelTimeouts {
     pub(super) write: Duration,
@@ -292,6 +296,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
     }
 
     // 4. Restore session history
+    let mut session_restore_diagnostics = None;
     if let Some(session) = &context.resume_session {
         let t = Instant::now();
         let result = restore_session(sandbox, context, session).await;
@@ -302,7 +307,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
             result.is_ok(),
             err.as_deref(),
         );
-        result?;
+        session_restore_diagnostics = Some(result?);
     }
 
     // 5. Build env vars. The guest-agent bootstrap env is runner-owned only;
@@ -322,9 +327,9 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         .collect();
     info!(run_id = %context.run_id, count = env_refs.len(), "passing env vars via vsock");
 
-    // 6. Spawn agent — stdout streamed to host via vsock, stderr merged into stdout.
-    //    guest-agent owns the guest-side system log for telemetry; the runner
-    //    separately writes streamed chunks to a host stream log in real time.
+    // 6. Spawn agent — stdout streamed to host via vsock. guest-agent stderr is
+    //    merged into stdout, while a small stderr capture keeps shell/wrapper
+    //    startup failures visible when the process exits before guest logging.
     let agent_cmd = format!("{} 2>&1", guest::RUN_AGENT);
     info!(run_id = %context.run_id, "spawning agent");
 
@@ -338,7 +343,9 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
             timeout: JOB_TIMEOUT,
             env: &env_refs,
             sudo: false,
-            output: ProcessOutputMode::stream(),
+            output: ProcessOutputMode::stream_with_stderr_capture(
+                AGENT_WRAPPER_STDERR_CAPTURE_LIMIT_BYTES,
+            ),
             control: ProcessControlMode::Enabled,
         })
         .await;
@@ -599,31 +606,51 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         } else {
             None
         };
-        let mut resource_diagnostics = None;
-        if should_collect_agent_abnormal_exit_diagnostics(
+        let should_log_bootstrap_diagnostics = should_log_agent_bootstrap_abnormal_exit_diagnostics(
+            wait_cancelled,
+            &exit,
+            failure_diagnostic.as_ref(),
+            guest_error.as_deref(),
+        );
+        let should_collect_resource_diagnostics = should_collect_agent_abnormal_exit_diagnostics(
             wait_cancelled,
             &exit,
             &stderr,
             failure_diagnostic.as_ref(),
             guest_error.as_deref(),
-        ) {
+        );
+        let mut resource_diagnostics = None;
+        if should_log_bootstrap_diagnostics || should_collect_resource_diagnostics {
             let env_key_diagnostics = build_agent_env_key_diagnostics(&env_pairs);
-            log_agent_abnormal_exit_env_diagnostics(
-                context.run_id,
-                sandbox.id(),
-                start.reuse_result,
-                &exit,
-                &env_diagnostics,
-                &env_key_diagnostics,
-            );
-            resource_diagnostics = collect_agent_abnormal_exit_diagnostics(
-                sandbox,
-                context.run_id,
-                sandbox.id(),
-                start.reuse_result,
-                failure_exit_code,
-            )
-            .await;
+            if should_log_bootstrap_diagnostics {
+                log_agent_bootstrap_abnormal_exit_diagnostics(
+                    context.run_id,
+                    sandbox.id(),
+                    start.reuse_result,
+                    &exit,
+                    &env_diagnostics,
+                    &env_key_diagnostics,
+                    session_restore_diagnostics.as_ref(),
+                );
+            }
+            if should_collect_resource_diagnostics {
+                log_agent_abnormal_exit_env_diagnostics(
+                    context.run_id,
+                    sandbox.id(),
+                    start.reuse_result,
+                    &exit,
+                    &env_diagnostics,
+                    &env_key_diagnostics,
+                );
+                resource_diagnostics = collect_agent_abnormal_exit_diagnostics(
+                    sandbox,
+                    context.run_id,
+                    sandbox.id(),
+                    start.reuse_result,
+                    failure_exit_code,
+                )
+                .await;
+            }
         }
         let error = if !stderr.is_empty() {
             stderr

--- a/crates/runner/src/executor/diagnostics.rs
+++ b/crates/runner/src/executor/diagnostics.rs
@@ -6,9 +6,10 @@
 //! truncation and overflow markers, and post-job guest log copies.
 //!
 //! Environment diagnostics are deliberately key-only. They may record counts,
-//! sanitized key names, omitted-key counts, and suspicious key names, but they
-//! must not log environment values. This keeps operator debugging signals
-//! separate from secret-bearing user, model, or connector environment data.
+//! byte totals, sanitized key names, omitted-key counts, value lengths, and
+//! suspicious key names, but they must not log environment values. This keeps
+//! operator debugging signals separate from secret-bearing user, model, or
+//! connector environment data.
 //!
 //! Diagnostic collection should not mask the original run result. Failed reads,
 //! failed probes, and failed log copies are reported to operator logs when useful
@@ -35,6 +36,7 @@ use tracing::{info, warn};
 
 use super::env::is_runner_owned_env_key;
 use super::session_id::is_valid_session_id;
+use super::session_restore::SessionRestoreDiagnostics;
 use super::{
     AGENT_ABNORMAL_EXIT_DIAGNOSTIC_SCRIPT, AGENT_ABNORMAL_EXIT_DIAGNOSTIC_TIMEOUT,
     AGENT_ENV_KEY_DIAGNOSTIC_LIMIT, AGENT_ENV_KEY_MAX_CHARS, BOOTSTRAP_SENSITIVE_ENV_KEYS,
@@ -46,6 +48,8 @@ use crate::helper_exec::{helper_exec_succeeded, helper_exec_termination_label};
 use crate::ids::RunId;
 use crate::paths::{LogPaths, diagnostic_session_fingerprint};
 use crate::types::ExecutionContext;
+
+const AGENT_ENV_VALUE_SIZE_DIAGNOSTIC_LIMIT: usize = 5;
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub(super) struct AgentStdoutStreamDiagnostics {
@@ -62,15 +66,31 @@ impl AgentStdoutStreamDiagnostics {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(super) struct AgentEnvDiagnostics {
     pub(super) env_count: usize,
+    pub(super) env_bytes: usize,
     pub(super) runner_owned_count: usize,
     pub(super) external_count: usize,
     pub(super) suspicious_keys: Vec<String>,
+    pub(super) largest_entries: Vec<AgentEnvValueSizeDiagnostics>,
 }
 
 impl AgentEnvDiagnostics {
     pub(super) fn suspicious_keys_csv(&self) -> String {
         self.suspicious_keys.join(",")
     }
+
+    pub(super) fn largest_entries_csv(&self) -> String {
+        self.largest_entries
+            .iter()
+            .map(|entry| format!("{}:{}", entry.key, entry.value_len))
+            .collect::<Vec<_>>()
+            .join(",")
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct AgentEnvValueSizeDiagnostics {
+    pub(super) key: String,
+    pub(super) value_len: usize,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -101,12 +121,29 @@ pub(super) fn build_agent_env_diagnostics(
         .keys()
         .filter(|key| is_runner_owned_env_key(key))
         .count();
+    let env_bytes = env.iter().map(|(key, value)| key.len() + value.len()).sum();
+    let mut largest_entries: Vec<AgentEnvValueSizeDiagnostics> = env
+        .iter()
+        .map(|(key, value)| AgentEnvValueSizeDiagnostics {
+            key: sanitize_env_key_for_diagnostic(key),
+            value_len: value.len(),
+        })
+        .collect();
+    largest_entries.sort_by(|left, right| {
+        right
+            .value_len
+            .cmp(&left.value_len)
+            .then_with(|| left.key.cmp(&right.key))
+    });
+    largest_entries.truncate(AGENT_ENV_VALUE_SIZE_DIAGNOSTIC_LIMIT);
 
     AgentEnvDiagnostics {
         env_count: env.len(),
+        env_bytes,
         runner_owned_count,
         external_count: env.len().saturating_sub(runner_owned_count),
         suspicious_keys,
+        largest_entries,
     }
 }
 
@@ -160,8 +197,24 @@ pub(super) fn should_collect_agent_abnormal_exit_diagnostics(
         && guest_error.is_none()
 }
 
+pub(super) fn should_log_agent_bootstrap_abnormal_exit_diagnostics(
+    wait_cancelled: bool,
+    exit: &sandbox::ProcessExit,
+    failure_diagnostic: Option<&FailureDiagnostic>,
+    guest_error: Option<&str>,
+) -> bool {
+    !wait_cancelled
+        && process_exited_nonzero(exit)
+        && failure_diagnostic.is_none()
+        && guest_error.is_none()
+}
+
 fn process_failed(exit: &sandbox::ProcessExit) -> bool {
     !matches!(exit.termination, ExecTermination::Exited { exit_code: 0 })
+}
+
+fn process_exited_nonzero(exit: &sandbox::ProcessExit) -> bool {
+    matches!(exit.termination, ExecTermination::Exited { exit_code } if exit_code != 0)
 }
 
 fn process_exit_code(exit: &sandbox::ProcessExit) -> Option<i32> {
@@ -303,6 +356,8 @@ pub(super) fn log_agent_process_exit_summary(
         diagnostic_present = !exit.diagnostic.is_empty(),
         stream_overflowed = exit.stream_overflowed,
         env_count = env_diagnostics.env_count,
+        env_bytes = env_diagnostics.env_bytes,
+        largest_env_value_lengths = %env_diagnostics.largest_entries_csv(),
         suspicious_env_keys = %env_diagnostics.suspicious_keys_csv(),
         "agent process exit summary"
     );
@@ -323,12 +378,61 @@ pub(super) fn log_agent_abnormal_exit_env_diagnostics(
         termination = ?exit.termination,
         exit_code = ?process_exit_code(exit),
         env_count = env_diagnostics.env_count,
+        env_bytes = env_diagnostics.env_bytes,
         runner_owned_env_count = env_diagnostics.runner_owned_count,
         external_env_count = env_diagnostics.external_count,
+        largest_env_value_lengths = %env_diagnostics.largest_entries_csv(),
         suspicious_env_keys = %env_diagnostics.suspicious_keys_csv(),
         env_keys = %env_key_diagnostics.logged_keys_csv(),
         omitted_env_key_count = env_key_diagnostics.omitted_key_count,
         "agent abnormal exit env diagnostics"
+    );
+}
+
+pub(super) fn log_agent_bootstrap_abnormal_exit_diagnostics(
+    run_id: RunId,
+    sandbox_id: &str,
+    reuse_result: SandboxReuseResult,
+    exit: &sandbox::ProcessExit,
+    env_diagnostics: &AgentEnvDiagnostics,
+    env_key_diagnostics: &AgentEnvKeyDiagnostics,
+    session_restore_diagnostics: Option<&SessionRestoreDiagnostics>,
+) {
+    let resume_session_framework = session_restore_diagnostics
+        .map(|diagnostics| diagnostics.framework)
+        .unwrap_or("none");
+    let resume_session_fingerprint = session_restore_diagnostics
+        .map(|diagnostics| diagnostics.session_fingerprint.as_str())
+        .unwrap_or("");
+    let resume_session_bytes_in =
+        session_restore_diagnostics.map(|diagnostics| diagnostics.bytes_in);
+
+    warn!(
+        run_id = %run_id,
+        sandbox_id = %sandbox_id,
+        sandbox_reuse_result = reuse_result.as_wire(),
+        termination = ?exit.termination,
+        exit_code = ?process_exit_code(exit),
+        stdout_len = exit.stdout.len(),
+        stderr_len = exit.stderr.len(),
+        stdout_truncated = exit.stdout_truncated,
+        stderr_truncated = exit.stderr_truncated,
+        captured_stderr_present = !exit.stderr.is_empty(),
+        captured_stderr_truncated = exit.stderr_truncated,
+        diagnostic_present = !exit.diagnostic.is_empty(),
+        stream_overflowed = exit.stream_overflowed,
+        env_count = env_diagnostics.env_count,
+        env_bytes = env_diagnostics.env_bytes,
+        runner_owned_env_count = env_diagnostics.runner_owned_count,
+        external_env_count = env_diagnostics.external_count,
+        largest_env_value_lengths = %env_diagnostics.largest_entries_csv(),
+        suspicious_env_keys = %env_diagnostics.suspicious_keys_csv(),
+        env_keys = %env_key_diagnostics.logged_keys_csv(),
+        omitted_env_key_count = env_key_diagnostics.omitted_key_count,
+        resume_session_framework = %resume_session_framework,
+        resume_session_fingerprint = %resume_session_fingerprint,
+        resume_session_bytes_in = ?resume_session_bytes_in,
+        "agent bootstrap abnormal exit diagnostics"
     );
 }
 

--- a/crates/runner/src/executor/diagnostics.rs
+++ b/crates/runner/src/executor/diagnostics.rs
@@ -53,6 +53,7 @@ const AGENT_ENV_VALUE_SIZE_DIAGNOSTIC_LIMIT: usize = 5;
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub(super) struct AgentStdoutStreamDiagnostics {
+    pub(super) bytes_written: u64,
     pub(super) chunk_truncated: bool,
     pub(super) stream_overflowed: bool,
 }
@@ -342,6 +343,7 @@ pub(super) fn log_agent_process_exit_summary(
     reuse_result: SandboxReuseResult,
     exit: &sandbox::ProcessExit,
     env_diagnostics: &AgentEnvDiagnostics,
+    stdout_stream_diagnostics: AgentStdoutStreamDiagnostics,
 ) {
     info!(
         run_id = %run_id,
@@ -353,6 +355,7 @@ pub(super) fn log_agent_process_exit_summary(
         stderr_len = exit.stderr.len(),
         stdout_truncated = exit.stdout_truncated,
         stderr_truncated = exit.stderr_truncated,
+        stdout_stream_bytes = stdout_stream_diagnostics.bytes_written,
         diagnostic_present = !exit.diagnostic.is_empty(),
         stream_overflowed = exit.stream_overflowed,
         env_count = env_diagnostics.env_count,
@@ -389,46 +392,55 @@ pub(super) fn log_agent_abnormal_exit_env_diagnostics(
     );
 }
 
+pub(super) struct AgentBootstrapAbnormalExitLogContext<'a> {
+    pub(super) run_id: RunId,
+    pub(super) sandbox_id: &'a str,
+    pub(super) reuse_result: SandboxReuseResult,
+    pub(super) exit: &'a sandbox::ProcessExit,
+    pub(super) env_diagnostics: &'a AgentEnvDiagnostics,
+    pub(super) env_key_diagnostics: &'a AgentEnvKeyDiagnostics,
+    pub(super) stdout_stream_diagnostics: AgentStdoutStreamDiagnostics,
+    pub(super) session_restore_diagnostics: Option<&'a SessionRestoreDiagnostics>,
+}
+
 pub(super) fn log_agent_bootstrap_abnormal_exit_diagnostics(
-    run_id: RunId,
-    sandbox_id: &str,
-    reuse_result: SandboxReuseResult,
-    exit: &sandbox::ProcessExit,
-    env_diagnostics: &AgentEnvDiagnostics,
-    env_key_diagnostics: &AgentEnvKeyDiagnostics,
-    session_restore_diagnostics: Option<&SessionRestoreDiagnostics>,
+    context: AgentBootstrapAbnormalExitLogContext<'_>,
 ) {
-    let resume_session_framework = session_restore_diagnostics
+    let resume_session_framework = context
+        .session_restore_diagnostics
         .map(|diagnostics| diagnostics.framework)
         .unwrap_or("none");
-    let resume_session_fingerprint = session_restore_diagnostics
+    let resume_session_fingerprint = context
+        .session_restore_diagnostics
         .map(|diagnostics| diagnostics.session_fingerprint.as_str())
         .unwrap_or("");
-    let resume_session_bytes_in =
-        session_restore_diagnostics.map(|diagnostics| diagnostics.bytes_in);
+    let resume_session_bytes_in = context
+        .session_restore_diagnostics
+        .map(|diagnostics| diagnostics.bytes_in);
 
     warn!(
-        run_id = %run_id,
-        sandbox_id = %sandbox_id,
-        sandbox_reuse_result = reuse_result.as_wire(),
-        termination = ?exit.termination,
-        exit_code = ?process_exit_code(exit),
-        stdout_len = exit.stdout.len(),
-        stderr_len = exit.stderr.len(),
-        stdout_truncated = exit.stdout_truncated,
-        stderr_truncated = exit.stderr_truncated,
-        captured_stderr_present = !exit.stderr.is_empty(),
-        captured_stderr_truncated = exit.stderr_truncated,
-        diagnostic_present = !exit.diagnostic.is_empty(),
-        stream_overflowed = exit.stream_overflowed,
-        env_count = env_diagnostics.env_count,
-        env_bytes = env_diagnostics.env_bytes,
-        runner_owned_env_count = env_diagnostics.runner_owned_count,
-        external_env_count = env_diagnostics.external_count,
-        largest_env_value_lengths = %env_diagnostics.largest_entries_csv(),
-        suspicious_env_keys = %env_diagnostics.suspicious_keys_csv(),
-        env_keys = %env_key_diagnostics.logged_keys_csv(),
-        omitted_env_key_count = env_key_diagnostics.omitted_key_count,
+        run_id = %context.run_id,
+        sandbox_id = %context.sandbox_id,
+        sandbox_reuse_result = context.reuse_result.as_wire(),
+        termination = ?context.exit.termination,
+        exit_code = ?process_exit_code(context.exit),
+        stdout_len = context.exit.stdout.len(),
+        stderr_len = context.exit.stderr.len(),
+        stdout_truncated = context.exit.stdout_truncated,
+        stderr_truncated = context.exit.stderr_truncated,
+        stdout_stream_bytes = context.stdout_stream_diagnostics.bytes_written,
+        captured_stderr_present = !context.exit.stderr.is_empty(),
+        captured_stderr_truncated = context.exit.stderr_truncated,
+        diagnostic_present = !context.exit.diagnostic.is_empty(),
+        stream_overflowed = context.exit.stream_overflowed,
+        env_count = context.env_diagnostics.env_count,
+        env_bytes = context.env_diagnostics.env_bytes,
+        runner_owned_env_count = context.env_diagnostics.runner_owned_count,
+        external_env_count = context.env_diagnostics.external_count,
+        largest_env_value_lengths = %context.env_diagnostics.largest_entries_csv(),
+        suspicious_env_keys = %context.env_diagnostics.suspicious_keys_csv(),
+        env_keys = %context.env_key_diagnostics.logged_keys_csv(),
+        omitted_env_key_count = context.env_key_diagnostics.omitted_key_count,
         resume_session_framework = %resume_session_framework,
         resume_session_fingerprint = %resume_session_fingerprint,
         resume_session_bytes_in = ?resume_session_bytes_in,
@@ -687,6 +699,7 @@ pub(super) enum StdoutDrainError {
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub(super) struct StdoutDrainReport {
+    pub(super) bytes_written: u64,
     pub(super) chunk_truncated: bool,
 }
 
@@ -704,6 +717,9 @@ pub(super) async fn drain_stdout_to_file(
     };
     let mut report = StdoutDrainReport::default();
     while let Some(chunk) = rx.recv().await {
+        report.bytes_written = report
+            .bytes_written
+            .saturating_add(u64::try_from(chunk.bytes.len()).unwrap_or(u64::MAX));
         if chunk.truncated {
             report.chunk_truncated = true;
             warn!(path = %path.display(), "stdout stream chunk was truncated before host log write");

--- a/crates/runner/src/executor/session_restore.rs
+++ b/crates/runner/src/executor/session_restore.rs
@@ -17,11 +17,19 @@ const SESSION_ID_SENTINEL: &str = "\u{0}\u{2}";
 const REDACTED_SESSION_PATH: &str = "[redacted-session-path]";
 const REDACTED_SESSION_ID: &str = "[redacted-session-id]";
 const SUBSTRING_SESSION_ID_REDACTION_MIN_LEN: usize = 8;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct SessionRestoreDiagnostics {
+    pub(super) framework: &'static str,
+    pub(super) session_fingerprint: String,
+    pub(super) bytes_in: usize,
+}
+
 pub(super) async fn restore_session(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,
     session: &ResumeSession,
-) -> RunnerResult<()> {
+) -> RunnerResult<SessionRestoreDiagnostics> {
     // Validate the CLI agent session id to prevent path traversal.
     // Only allow alnum, dash, and underscore.
     // Applied up-front so unknown frameworks still reject malformed IDs in case the
@@ -52,7 +60,7 @@ pub(super) async fn restore_claude_session(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,
     session: &ResumeSession,
-) -> RunnerResult<()> {
+) -> RunnerResult<SessionRestoreDiagnostics> {
     let project_name = CANONICAL_WORKING_DIR
         .trim_start_matches('/')
         .replace('/', "-");
@@ -66,14 +74,19 @@ pub(super) async fn restore_claude_session(
         &session.session_history,
     )
     .await?;
+    let diagnostics = SessionRestoreDiagnostics {
+        framework: "claude-code",
+        session_fingerprint: diagnostic_session_fingerprint(&session.cli_agent_session_id),
+        bytes_in: session.session_history.len(),
+    };
     info!(
         run_id = %context.run_id,
-        framework = "claude-code",
-        session_fingerprint = %diagnostic_session_fingerprint(&session.cli_agent_session_id),
-        bytes_in = session.session_history.len(),
+        framework = diagnostics.framework,
+        session_fingerprint = %diagnostics.session_fingerprint,
+        bytes_in = diagnostics.bytes_in,
         "restored session history"
     );
-    Ok(())
+    Ok(diagnostics)
 }
 
 async fn write_session_history_file(

--- a/crates/runner/src/executor/session_restore/codex.rs
+++ b/crates/runner/src/executor/session_restore/codex.rs
@@ -2,7 +2,9 @@ use sandbox::{EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, Sandbox};
 use shell_quote::quote_shell_arg;
 use tracing::info;
 
-use super::{redact_session_restore_diagnostic, write_session_history_file};
+use super::{
+    SessionRestoreDiagnostics, redact_session_restore_diagnostic, write_session_history_file,
+};
 use crate::helper_exec::{format_helper_exec_failure, helper_exec_succeeded};
 use crate::paths::diagnostic_session_fingerprint;
 use crate::types::{ExecutionContext, ResumeSession};
@@ -89,7 +91,7 @@ pub(super) async fn restore_codex_session(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,
     session: &ResumeSession,
-) -> RunnerResult<()> {
+) -> RunnerResult<SessionRestoreDiagnostics> {
     let thread_id = CodexThreadId::parse(&session.cli_agent_session_id)
         .ok_or_else(|| RunnerError::Internal("invalid codex session_id".into()))?;
     let session_id = thread_id.as_str();
@@ -115,14 +117,19 @@ pub(super) async fn restore_codex_session(
     )
     .await?;
 
+    let diagnostics = SessionRestoreDiagnostics {
+        framework: "codex",
+        session_fingerprint: diagnostic_session_fingerprint(session_id),
+        bytes_in: session.session_history.len(),
+    };
     info!(
         run_id = %context.run_id,
-        framework = "codex",
-        session_fingerprint = %diagnostic_session_fingerprint(session_id),
-        bytes_in = session.session_history.len(),
+        framework = diagnostics.framework,
+        session_fingerprint = %diagnostics.session_fingerprint,
+        bytes_in = diagnostics.bytes_in,
         "restored session history",
     );
-    Ok(())
+    Ok(diagnostics)
 }
 
 async fn cleanup_existing_codex_session_files(

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -1,4 +1,7 @@
 use std::collections::HashMap;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::process::Command;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -6,7 +9,9 @@ use api_contracts::generated::types::runners::storage::StorageManifest;
 use sandbox::{ProcessExit, ProcessOutputChunk, SandboxConfig, SandboxFactory, SandboxId};
 use sandbox_mock::MockSandboxFactory;
 
-use super::super::agent_run::{ProcessCancelTimeouts, RunControls, RunStart, run_in_sandbox};
+use super::super::agent_run::{
+    ProcessCancelTimeouts, RunControls, RunStart, build_agent_start_command, run_in_sandbox,
+};
 use super::super::diagnostics::AgentStdoutStreamDiagnostics;
 use super::super::storage::guest_download_stdin_command;
 use super::super::{EXIT_SIGKILL, PROCESS_CANCEL_WRITE_TIMEOUT};
@@ -19,6 +24,91 @@ use crate::active_input::ActiveInputSource;
 use crate::local_queue::{ActiveInputEntry, LocalQueue};
 use crate::storage_fingerprints::{StorageFingerprint, StorageFingerprints};
 use crate::types::SandboxReuseResult;
+
+#[test]
+fn agent_start_command_reports_missing_agent_on_stderr() {
+    let dir = tempfile::tempdir().unwrap();
+    let agent_path = dir.path().join("missing-agent");
+
+    let output = Command::new("sh")
+        .arg("-c")
+        .arg(build_agent_start_command(agent_path.to_str().unwrap()))
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(127));
+    assert!(output.stdout.is_empty());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        "agent bootstrap failed: guest-agent is missing\n"
+    );
+}
+
+#[test]
+fn agent_start_command_reports_non_executable_agent_on_stderr() {
+    let dir = tempfile::tempdir().unwrap();
+    let agent_path = dir.path().join("guest-agent");
+    fs::write(&agent_path, "#!/bin/sh\nexit 0\n").unwrap();
+    fs::set_permissions(&agent_path, fs::Permissions::from_mode(0o644)).unwrap();
+
+    let output = Command::new("sh")
+        .arg("-c")
+        .arg(build_agent_start_command(agent_path.to_str().unwrap()))
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(126));
+    assert!(output.stdout.is_empty());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        "agent bootstrap failed: guest-agent is not executable\n"
+    );
+}
+
+#[test]
+fn agent_start_command_reports_non_file_agent_on_stderr() {
+    let dir = tempfile::tempdir().unwrap();
+    let agent_path = dir.path().join("guest-agent");
+    fs::create_dir(&agent_path).unwrap();
+
+    let output = Command::new("sh")
+        .arg("-c")
+        .arg(build_agent_start_command(agent_path.to_str().unwrap()))
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(126));
+    assert!(output.stdout.is_empty());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        "agent bootstrap failed: guest-agent is not a regular file\n"
+    );
+}
+
+#[test]
+fn agent_start_command_keeps_agent_stderr_merged_into_stdout() {
+    let dir = tempfile::tempdir().unwrap();
+    let agent_path = dir.path().join("guest-agent");
+    fs::write(
+        &agent_path,
+        "#!/bin/sh\nprintf 'agent stdout\\n'\nprintf 'agent stderr\\n' >&2\n",
+    )
+    .unwrap();
+    fs::set_permissions(&agent_path, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let output = Command::new("sh")
+        .arg("-c")
+        .arg(build_agent_start_command(agent_path.to_str().unwrap()))
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "agent stdout\nagent stderr\n"
+    );
+    assert!(output.stderr.is_empty());
+}
 
 #[tokio::test]
 async fn run_in_sandbox_preserves_wait_result_when_cancel_arrives_after_wait() {

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -159,6 +159,7 @@ async fn run_in_sandbox_preserves_wait_result_when_cancel_arrives_after_wait() {
     assert_eq!(
         result.stdout_stream_diagnostics,
         AgentStdoutStreamDiagnostics {
+            bytes_written: 14,
             chunk_truncated: true,
             stream_overflowed: false,
         }
@@ -520,6 +521,7 @@ async fn run_in_sandbox_cancels_guest_process_and_waits_for_terminal_status() {
     assert_eq!(
         result.stdout_stream_diagnostics,
         AgentStdoutStreamDiagnostics {
+            bytes_written: 14,
             chunk_truncated: true,
             stream_overflowed: true,
         }

--- a/crates/runner/src/executor/tests/diagnostics_tests.rs
+++ b/crates/runner/src/executor/tests/diagnostics_tests.rs
@@ -712,6 +712,7 @@ async fn post_job_cleanup_appends_stream_markers_after_guest_log_copy() {
         "10.0.0.1",
         false,
         AgentStdoutStreamDiagnostics {
+            bytes_written: 0,
             chunk_truncated: true,
             stream_overflowed: true,
         },
@@ -756,6 +757,7 @@ async fn drain_stdout_writes_chunks_to_file() {
 
     let content = tokio::fs::read_to_string(&path).await.unwrap();
     assert_eq!(content, "chunk 1\nchunk 2\n");
+    assert_eq!(report.bytes_written, 16);
     assert!(!report.chunk_truncated);
     assert_eq!(mode(&path), 0o600);
 }
@@ -778,6 +780,7 @@ async fn drain_stdout_reports_truncated_chunk_without_changing_bytes() {
 
     let content = tokio::fs::read(&path).await.unwrap();
     assert_eq!(content, b"partial chunk");
+    assert_eq!(report.bytes_written, 13);
     assert!(report.chunk_truncated);
 }
 
@@ -793,6 +796,7 @@ async fn drain_stdout_empty_channel() {
 
     let content = tokio::fs::read_to_string(&path).await.unwrap();
     assert!(content.is_empty());
+    assert_eq!(report.bytes_written, 0);
     assert!(!report.chunk_truncated);
 }
 
@@ -829,6 +833,7 @@ async fn append_stdout_stream_diagnostics_writes_markers() {
     append_stdout_stream_diagnostics(
         &path,
         AgentStdoutStreamDiagnostics {
+            bytes_written: 0,
             chunk_truncated: true,
             stream_overflowed: true,
         },

--- a/crates/runner/src/executor/tests/diagnostics_tests.rs
+++ b/crates/runner/src/executor/tests/diagnostics_tests.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use agent_diagnostics::{FAILURE_DIAGNOSTIC_SCHEMA_VERSION, FailureDiagnostic};
-use sandbox::ProcessOutputChunk;
+use sandbox::{ExecTermination, ProcessExit, ProcessOutputChunk};
 use sandbox_mock::MockSandbox;
 
 use super::super::diagnostics::{
@@ -13,6 +13,8 @@ use super::super::diagnostics::{
     copy_guest_logs, dmesg_indicates_oom, drain_stdout_to_file, guest_log_copy_failure_kind,
     host_dmesg_indicates_oom, parse_agent_abnormal_exit_resource_diagnostics,
     read_guest_cli_agent_session_id, read_guest_error_file, read_guest_failure_diagnostic_file,
+    should_collect_agent_abnormal_exit_diagnostics,
+    should_log_agent_bootstrap_abnormal_exit_diagnostics,
 };
 use super::super::sandbox_run::post_job_cleanup;
 use super::super::{
@@ -39,6 +41,9 @@ fn agent_env_diagnostics_sort_bounds_and_never_include_values() {
             "stored-secret-value".to_string(),
         ),
     ]);
+    let big_value = "largest-secret-value".repeat(20);
+    let big_value_len = big_value.len();
+    bootstrap_env.insert("BIG_VALUE".to_string(), big_value);
     for index in 0..AGENT_ENV_KEY_DIAGNOSTIC_LIMIT {
         bootstrap_env.insert(format!("ZZZ_{index:03}"), format!("value-{index}"));
     }
@@ -50,20 +55,23 @@ fn agent_env_diagnostics_sort_bounds_and_never_include_values() {
 
     let diagnostics = build_agent_env_diagnostics(&bootstrap_env, &user_env);
 
-    assert_eq!(diagnostics.env_count, AGENT_ENV_KEY_DIAGNOSTIC_LIMIT + 5);
+    assert_eq!(diagnostics.env_count, AGENT_ENV_KEY_DIAGNOSTIC_LIMIT + 6);
+    assert!(diagnostics.env_bytes >= big_value_len);
     assert_eq!(diagnostics.runner_owned_count, 2);
     assert_eq!(
         diagnostics.external_count,
-        AGENT_ENV_KEY_DIAGNOSTIC_LIMIT + 3
+        AGENT_ENV_KEY_DIAGNOSTIC_LIMIT + 4
     );
     assert_eq!(diagnostics.suspicious_keys, vec!["BASH_ENV".to_string()]);
+    assert_eq!(diagnostics.largest_entries[0].key, "BIG_VALUE");
+    assert_eq!(diagnostics.largest_entries[0].value_len, big_value_len);
     let env_pairs: Vec<(String, String)> = bootstrap_env.into_iter().collect();
     let key_diagnostics = build_agent_env_key_diagnostics(&env_pairs);
     assert_eq!(
         key_diagnostics.logged_keys.len(),
         AGENT_ENV_KEY_DIAGNOSTIC_LIMIT
     );
-    assert_eq!(key_diagnostics.omitted_key_count, 5);
+    assert_eq!(key_diagnostics.omitted_key_count, 6);
     let mut sorted_logged_keys = key_diagnostics.logged_keys.clone();
     sorted_logged_keys.sort();
     assert_eq!(key_diagnostics.logged_keys, sorted_logged_keys);
@@ -75,18 +83,70 @@ fn agent_env_diagnostics_sort_bounds_and_never_include_values() {
     assert_eq!(long_key.chars().count(), AGENT_ENV_KEY_MAX_CHARS + 3);
     assert!(long_key.ends_with("..."));
     let rendered = format!(
-        "{} {}",
+        "{} {} {}",
         diagnostics.suspicious_keys_csv(),
-        key_diagnostics.logged_keys_csv()
+        key_diagnostics.logged_keys_csv(),
+        diagnostics.largest_entries_csv()
     );
     assert!(rendered.contains("BASH_ENV"));
+    assert!(rendered.contains("BIG_VALUE"));
     assert!(rendered.contains("VM0_RUN_ID"));
     assert!(!rendered.contains("super-secret-bash-env"));
     assert!(!rendered.contains("user-secret-bash-env"));
+    assert!(!rendered.contains("largest-secret-value"));
     assert!(!rendered.contains("normal-secret-value"));
     assert!(!rendered.contains("runner-secret-value"));
     assert!(!rendered.contains("stored-secret-value"));
     assert!(!rendered.contains("long-secret-value"));
+}
+
+#[test]
+fn bootstrap_abnormal_exit_diagnostics_allow_captured_stderr_without_resource_probe() {
+    let exit = ProcessExit::new(1, 126, Vec::new(), b"permission denied".to_vec());
+    let stderr = "permission denied";
+
+    assert!(should_log_agent_bootstrap_abnormal_exit_diagnostics(
+        false, &exit, None, None
+    ));
+    assert!(!should_collect_agent_abnormal_exit_diagnostics(
+        false, &exit, stderr, None, None
+    ));
+
+    let diagnostic = FailureDiagnostic::new(
+        agent_diagnostics::FailureClass::CliNonzero,
+        agent_diagnostics::AgentFramework::ClaudeCode,
+        agent_diagnostics::PromptMetadata::from_prompt("/help"),
+    );
+    assert!(!should_log_agent_bootstrap_abnormal_exit_diagnostics(
+        false,
+        &exit,
+        Some(&diagnostic),
+        None
+    ));
+    assert!(!should_log_agent_bootstrap_abnormal_exit_diagnostics(
+        false,
+        &exit,
+        None,
+        Some("guest error")
+    ));
+
+    let successful_exit = ProcessExit::new(1, 0, Vec::new(), Vec::new());
+    assert!(!should_log_agent_bootstrap_abnormal_exit_diagnostics(
+        false,
+        &successful_exit,
+        None,
+        None
+    ));
+    let timed_out_exit = ProcessExit {
+        termination: ExecTermination::TimedOut,
+        ..ProcessExit::new(1, 0, Vec::new(), Vec::new())
+    };
+    assert!(!should_log_agent_bootstrap_abnormal_exit_diagnostics(
+        false,
+        &timed_out_exit,
+        None,
+        None
+    ));
 }
 
 #[test]

--- a/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
@@ -751,6 +751,42 @@ async fn execute_inner_nonzero_with_stderr_skips_abnormal_exit_diagnostics() {
 }
 
 #[tokio::test]
+async fn execute_inner_nonzero_with_stderr_and_guest_error_skips_bootstrap_diagnostics() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_wait_process_exit(ProcessExit::new(1, 7, Vec::new(), b"guest stderr".to_vec()));
+    overrides.push_read_file_result(Ok(None));
+    overrides.push_read_file_result(Ok(Some(b"guest checkpoint error".to_vec())));
+    let factory = sandbox_mock::MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+
+    let (result, events) = capture_async_events(run_new_sandbox_status(
+        &factory,
+        &minimal_context(),
+        &config,
+        &default_params(),
+    ))
+    .await;
+    let (exit_code, error) = result.unwrap();
+
+    assert_eq!(exit_code, 7);
+    assert_eq!(error.as_deref(), Some("guest stderr"));
+    assert!(
+        events.iter().all(|event| {
+            event.fields.get("message").map(String::as_str)
+                != Some("agent bootstrap abnormal exit diagnostics")
+        }),
+        "guest error file should suppress bootstrap diagnostics: {events:#?}"
+    );
+    assert!(
+        overrides
+            .exec_calls()
+            .iter()
+            .all(|call| !call.cmd.contains("guest-agent-binary"))
+    );
+}
+
+#[tokio::test]
 async fn execute_inner_nonzero_with_process_diagnostic_skips_abnormal_exit_diagnostics() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;

--- a/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
@@ -138,7 +138,7 @@ async fn execute_inner_preserves_system_stream_log_after_nonzero_exit_guest_copy
     let system_stream_log_path = config.log_paths.system_stream_log(ctx.run_id);
     let mut telemetry = test_telemetry(&config, &ctx);
 
-    let outcome = execute_prepared_sandbox_run(
+    let (outcome, events) = capture_async_events(execute_prepared_sandbox_run(
         PreparedSandboxRun {
             sandbox,
             source_ip,
@@ -153,7 +153,7 @@ async fn execute_inner_preserves_system_stream_log_after_nonzero_exit_guest_copy
         },
         &mut telemetry,
         RunControls::new(tokio_util::sync::CancellationToken::new(), None),
-    )
+    ))
     .await;
 
     assert_eq!(outcome.exit_code(), 126);
@@ -164,6 +164,14 @@ async fn execute_inner_preserves_system_stream_log_after_nonzero_exit_guest_copy
     assert_eq!(system_log, b"guest system log\n");
     let system_stream_log = tokio::fs::read(&system_stream_log_path).await.unwrap();
     assert_eq!(system_stream_log, b"bootstrap diagnostic\n");
+    let bootstrap_event = captured_event(&events, "agent bootstrap abnormal exit diagnostics");
+    assert_eq!(
+        bootstrap_event
+            .fields
+            .get("stdout_stream_bytes")
+            .map(String::as_str),
+        Some("21")
+    );
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
@@ -307,7 +307,10 @@ async fn execute_inner_launches_agent_stream_only_without_guest_log_tee() {
 
     let calls = overrides.start_process_calls();
     assert_eq!(calls.len(), 1);
-    assert_eq!(calls[0].output, ProcessOutputMode::stream());
+    assert_eq!(
+        calls[0].output,
+        ProcessOutputMode::stream_with_stderr_capture(64 * 1024)
+    );
     assert_eq!(calls[0].control, ProcessControlMode::Enabled);
 }
 

--- a/crates/runner/src/executor/tests/session_restore_tests.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests.rs
@@ -105,7 +105,13 @@ fn restore_session_logs_fingerprint_without_raw_claude_session_id() {
 
     let (result, events) = capture_restore_events(restore_session(&sandbox, &ctx, &session));
 
-    result.unwrap();
+    let diagnostics = result.unwrap();
+    assert_eq!(diagnostics.framework, "claude-code");
+    assert_eq!(
+        diagnostics.session_fingerprint,
+        diagnostic_session_fingerprint(raw_session_id)
+    );
+    assert_eq!(diagnostics.bytes_in, session.session_history.len());
     assert_captured_events_do_not_contain(&events, raw_session_id);
     let event = captured_event(&events, "restored session history");
     assert_eq!(
@@ -211,7 +217,13 @@ fn restore_session_logs_fingerprint_without_raw_codex_session_id() {
 
     let (result, events) = capture_restore_events(restore_session(&sandbox, &ctx, &session));
 
-    result.unwrap();
+    let diagnostics = result.unwrap();
+    assert_eq!(diagnostics.framework, "codex");
+    assert_eq!(
+        diagnostics.session_fingerprint,
+        diagnostic_session_fingerprint(raw_session_id)
+    );
+    assert_eq!(diagnostics.bytes_in, session.session_history.len());
     assert_captured_events_do_not_contain(&events, raw_session_id);
     let restore_event = captured_event(&events, "restored session history");
     assert_eq!(

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -1605,7 +1605,14 @@ fn process_stderr_policy(output: ProcessOutputMode) -> ExecOutputPolicy {
         ProcessOutputMode::Buffered { output_limits } => ExecOutputPolicy::Capture {
             limit_bytes: output_limits.stderr_limit_bytes,
         },
-        ProcessOutputMode::Stream { .. } => ExecOutputPolicy::Discard,
+        ProcessOutputMode::Stream {
+            stderr_capture_limit_bytes: Some(limit_bytes),
+            ..
+        } => ExecOutputPolicy::Capture { limit_bytes },
+        ProcessOutputMode::Stream {
+            stderr_capture_limit_bytes: None,
+            ..
+        } => ExecOutputPolicy::Discard,
     }
 }
 
@@ -5203,6 +5210,7 @@ mod tests {
             stream_limit_bytes: 123,
             chunk_limit_bytes: 45,
             queue_capacity: 7,
+            stderr_capture_limit_bytes: None,
         };
 
         assert_eq!(
@@ -5214,6 +5222,21 @@ mod tests {
         );
         assert_eq!(process_stderr_policy(output), ExecOutputPolicy::Discard);
         assert_eq!(process_stream_queue_capacity(output), Some(7));
+    }
+
+    #[test]
+    fn process_output_stream_can_capture_stderr() {
+        let output = ProcessOutputMode::Stream {
+            stream_limit_bytes: 123,
+            chunk_limit_bytes: 45,
+            queue_capacity: 7,
+            stderr_capture_limit_bytes: Some(4096),
+        };
+
+        assert_eq!(
+            process_stderr_policy(output),
+            ExecOutputPolicy::Capture { limit_bytes: 4096 }
+        );
     }
 
     #[test]

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -3503,11 +3503,13 @@ mod tests {
                 stream_limit_bytes: 1024,
                 chunk_limit_bytes: 0,
                 queue_capacity: 1,
+                stderr_capture_limit_bytes: None,
             },
             ProcessOutputMode::Stream {
                 stream_limit_bytes: 1024,
                 chunk_limit_bytes: 16,
                 queue_capacity: 0,
+                stderr_capture_limit_bytes: None,
             },
         ] {
             match sandbox

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -560,9 +560,9 @@ pub enum ProcessOutputMode {
     },
     /// Request real-time stdout delivery through a bounded host receiver.
     ///
-    /// This mode requests stdout streaming only. Provider-specific stderr
-    /// handling may differ; the current Firecracker-backed provider discards
-    /// stderr in stream mode instead of streaming or capturing it.
+    /// By default this mode requests stdout streaming only. Callers that need
+    /// startup diagnostics can request a small captured stderr tail without
+    /// changing stdout streaming behavior.
     Stream {
         /// Maximum stdout bytes the guest should emit as stream chunks.
         ///
@@ -577,6 +577,10 @@ pub enum ProcessOutputMode {
         /// guarantee that a slow caller applies backpressure to the guest; host
         /// delivery overflow is reported through [`ProcessExit::stream_overflowed`].
         queue_capacity: usize,
+        /// Optional captured stderr byte limit retained in [`ProcessExit`].
+        ///
+        /// When unset, providers may discard stderr in stream mode.
+        stderr_capture_limit_bytes: Option<u32>,
     },
 }
 
@@ -617,6 +621,17 @@ impl ProcessOutputMode {
             stream_limit_bytes: Self::DEFAULT_STREAM_LIMIT_BYTES,
             chunk_limit_bytes: Self::DEFAULT_CHUNK_LIMIT_BYTES,
             queue_capacity: Self::DEFAULT_QUEUE_CAPACITY,
+            stderr_capture_limit_bytes: None,
+        }
+    }
+
+    /// Return stdout stream mode with bounded defaults and captured stderr.
+    pub const fn stream_with_stderr_capture(stderr_capture_limit_bytes: u32) -> Self {
+        Self::Stream {
+            stream_limit_bytes: Self::DEFAULT_STREAM_LIMIT_BYTES,
+            chunk_limit_bytes: Self::DEFAULT_CHUNK_LIMIT_BYTES,
+            queue_capacity: Self::DEFAULT_QUEUE_CAPACITY,
+            stderr_capture_limit_bytes: Some(stderr_capture_limit_bytes),
         }
     }
 
@@ -786,6 +801,20 @@ mod tests {
                 stream_limit_bytes: ProcessOutputMode::DEFAULT_STREAM_LIMIT_BYTES,
                 chunk_limit_bytes: ProcessOutputMode::DEFAULT_CHUNK_LIMIT_BYTES,
                 queue_capacity: ProcessOutputMode::DEFAULT_QUEUE_CAPACITY,
+                stderr_capture_limit_bytes: None,
+            }
+        );
+    }
+
+    #[test]
+    fn process_output_mode_stream_with_stderr_capture_uses_bounded_defaults() {
+        assert_eq!(
+            ProcessOutputMode::stream_with_stderr_capture(4096),
+            ProcessOutputMode::Stream {
+                stream_limit_bytes: ProcessOutputMode::DEFAULT_STREAM_LIMIT_BYTES,
+                chunk_limit_bytes: ProcessOutputMode::DEFAULT_CHUNK_LIMIT_BYTES,
+                queue_capacity: ProcessOutputMode::DEFAULT_QUEUE_CAPACITY,
+                stderr_capture_limit_bytes: Some(4096),
             }
         );
     }


### PR DESCRIPTION
## Summary
- capture a bounded stderr tail for streamed agent startup while keeping default stream stderr behavior unchanged
- log bootstrap abnormal-exit diagnostics for exited nonzero agent starts with no guest diagnostic/error file
- include env byte/value-length diagnostics and resume-session framework/fingerprint/byte metadata without logging env values or raw session ids

Closes #18999

## Tests
- cargo test -p runner diagnostics_tests
- cargo test -p runner execution_diagnostics
- cargo test -p runner
- cargo test -p sandbox -p sandbox-fc -p sandbox-mock process_output
- pre-commit: cargo-fmt, cargo-doc, cargo-clippy