### PR TITLE
fix: remove agent workflows search

### DIFF
--- a/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
+++ b/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
@@ -52,7 +52,6 @@ const internalWorkflowReload$ = state(0);
 const internalSelectedFilePath$ = state<string | null>(null);
 const internalWorkflowActionDialog$ = state<WorkflowDetailActionDialog>(null);
 const internalWorkflowFileDraft$ = state<WorkflowDetailFileDraft | null>(null);
-const internalWorkflowSearch$ = state("");
 const internalEditingGmailTriggerId$ = state<string | null>(null);
 const internalWorkflowTriggerPermissionsDrawerTriggerId$ = state<string | null>(
   null,
@@ -61,14 +60,6 @@ const internalWorkflowTriggerCreateDialog$ = state<"schedule" | "gmail" | null>(
   null,
 );
 const internalScheduleTriggerType$ = state<ZeroWorkflowScheduleType>("cron");
-
-export const workflowSearch$ = computed((get) => {
-  return get(internalWorkflowSearch$);
-});
-
-export const setWorkflowSearch$ = command(({ set }, value: string) => {
-  set(internalWorkflowSearch$, value);
-});
 
 export const workflowDetailTriggerSidebarOpen$ = computed((get) => {
   return (
@@ -173,25 +164,6 @@ export const setScheduleTriggerType$ = command(
   },
 );
 
-function matchesWorkflowSearch(
-  workflow: ZeroWorkflowSummary,
-  search: string,
-): boolean {
-  if (!search) {
-    return true;
-  }
-  return [
-    workflow.name,
-    workflow.displayName ?? "",
-    workflow.description ?? "",
-    workflow.agentDisplayName ?? "",
-    workflow.agentName ?? "",
-  ]
-    .join(" ")
-    .toLowerCase()
-    .includes(search);
-}
-
 /** The supplementary file selected in the detail viewer, or null. */
 export const selectedWorkflowFilePath$ = computed((get) => {
   return get(internalSelectedFilePath$);
@@ -240,32 +212,7 @@ function createAgentWorkflowsFactory(): (
 }
 
 const agentWorkflows = createAgentWorkflowsFactory();
-
-function createFilteredAgentWorkflowsFactory(): (
-  agentId: string,
-) => Computed<Promise<readonly ZeroWorkflowSummary[]>> {
-  const cache = new Map<
-    string,
-    Computed<Promise<readonly ZeroWorkflowSummary[]>>
-  >();
-  return (agentId: string) => {
-    const existing = cache.get(agentId);
-    if (existing) {
-      return existing;
-    }
-    const atom$ = computed(async (get) => {
-      const workflows = await get(agentWorkflows(agentId));
-      const search = get(internalWorkflowSearch$).trim().toLowerCase();
-      return workflows.filter((workflow) => {
-        return matchesWorkflowSearch(workflow, search);
-      });
-    });
-    cache.set(agentId, atom$);
-    return atom$;
-  };
-}
-
-export const agentVisibleWorkflows$ = createFilteredAgentWorkflowsFactory();
+export const agentVisibleWorkflows$ = agentWorkflows;
 
 /**
  * The current chat agent's visible workflows, used by the slash-workflow

--- a/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
@@ -135,10 +135,7 @@ import type {
   UserPermissionGrantResponse,
 } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import { agentVisibleWorkflows$ } from "../../signals/workflows-page/workflows-signals.ts";
-import {
-  WorkflowListPanel,
-  WorkflowsSearch,
-} from "../workflows-page/workflows-page.tsx";
+import { WorkflowListPanel } from "../workflows-page/workflows-page.tsx";
 
 type ApplyUserPermissionGrants = (
   params: {
@@ -1245,9 +1242,6 @@ function JobWorkflowsTab({ agentId }: { agentId: string }) {
 
   return (
     <div className="mx-auto flex max-w-[900px] flex-col gap-3">
-      <div className="flex justify-end">
-        <WorkflowsSearch />
-      </div>
       <WorkflowListPanel
         workflows={workflows}
         loading={loading}

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -402,13 +402,7 @@ describe("agent workflows tab", () => {
     expect(screen.getByText("Ops Playbook")).toBeInTheDocument();
     expect(screen.queryByText("Support Intake")).not.toBeInTheDocument();
     expect(screen.getByText("private")).toBeInTheDocument();
-
-    const searchInput = screen.getByLabelText("Search workflows");
-    await fill(searchInput, "ops");
-    await waitFor(() => {
-      expect(screen.queryByText("Sales Research")).not.toBeInTheDocument();
-    });
-    expect(screen.getByText("Ops Playbook")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Search workflows")).not.toBeInTheDocument();
 
     const opsLink = screen.getByText("Ops Playbook").closest("a");
     expect(opsLink).toHaveAttribute(

--- a/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
@@ -1,14 +1,9 @@
 // Read-only workflow lists. Rows link into the agent-scoped detail page; there
 // are no write actions here.
-import { useGet, useSet } from "ccstate-react";
 import type { ZeroWorkflowSummary } from "@vm0/api-contracts/contracts/zero-workflows";
-import { IconChevronRight, IconSearch } from "@tabler/icons-react";
+import { IconChevronRight } from "@tabler/icons-react";
 import { cn } from "@vm0/ui";
 
-import {
-  setWorkflowSearch$,
-  workflowSearch$,
-} from "../../signals/workflows-page/workflows-signals.ts";
 import { ROUTES } from "../../signals/route-paths.ts";
 import { Link } from "../router/link.tsx";
 import {
@@ -21,31 +16,6 @@ const WORKFLOW_LIST_GRID_WITH_AGENT =
   "grid grid-cols-[minmax(11rem,1.05fr)_minmax(16rem,1.55fr)_9rem_7rem_2.5rem] gap-x-5 items-center";
 const WORKFLOW_LIST_GRID_AGENT_SCOPED =
   "grid grid-cols-[minmax(11rem,1.05fr)_minmax(16rem,1.65fr)_7rem_2.5rem] gap-x-5 items-center";
-
-export function WorkflowsSearch() {
-  const search = useGet(workflowSearch$);
-  const setSearch = useSet(setWorkflowSearch$);
-
-  return (
-    <div className="relative w-full sm:w-64">
-      <IconSearch
-        size={15}
-        stroke={1.5}
-        className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground/60"
-      />
-      <input
-        aria-label="Search workflows"
-        type="text"
-        value={search}
-        onChange={(event) => {
-          setSearch(event.target.value);
-        }}
-        placeholder="Search workflows"
-        className="h-9 w-full rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-input pl-9 pr-3 text-sm text-foreground outline-none transition-colors placeholder:text-muted-foreground focus:border-primary focus:ring-[3px] focus:ring-primary/10"
-      />
-    </div>
-  );
-}
 
 export function WorkflowListPanel({
   workflows,


### PR DESCRIPTION
## Summary
- remove the workflows search input from the agent workflows tab
- delete the search state and filtering layer for agent workflows
- update the workflows page test to assert the search input is absent

## Verification
- pnpm exec prettier --write apps/platform/src/signals/workflows-page/workflows-signals.ts apps/platform/src/views/team-page/zero-job-detail-page.tsx apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx apps/platform/src/views/workflows-page/workflows-page.tsx
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app exec vitest run src/views/workflows-page/__tests__/workflows-page.test.tsx

Note: did not start a local dev server per vm0 PR verification preference.