### PR TITLE
fix: align workflow detail skeleton

### DIFF
--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -425,7 +425,13 @@ function DetailHeader({
           </button>
           <WorkflowActionsMenu detail={detail} />
         </div>
-      ) : null}
+      ) : (
+        <div className="flex shrink-0 items-center gap-2" aria-hidden="true">
+          <div className="h-9 w-9 rounded-md bg-muted/50 sm:w-24" />
+          <div className="h-9 w-9 rounded-md bg-muted/50 sm:w-20" />
+          <div className="size-9 rounded-md bg-muted/50" />
+        </div>
+      )}
     </header>
   );
 }
@@ -2064,13 +2070,34 @@ function UpdateGmailNewMessageTriggerForm({
 
 function DetailSkeleton() {
   return (
-    <div className="flex flex-col gap-4" data-testid="workflow-detail-loading">
-      <div className="h-7 w-52 rounded bg-muted/50" />
-      <div className="zero-card h-32 p-4">
-        <div className="h-4 w-40 rounded bg-muted/40" />
-      </div>
-      <div className="zero-card h-64 p-4">
-        <div className="h-4 w-40 rounded bg-muted/40" />
+    <div
+      className="flex min-h-[calc(100vh-8rem)] flex-col"
+      data-testid="workflow-detail-loading"
+    >
+      <div className="flex flex-1 flex-col animate-pulse px-0 py-3">
+        <div className="mb-7 flex items-center justify-between gap-4">
+          <div className="flex min-w-0 items-center gap-2">
+            <div className="size-4 shrink-0 rounded bg-muted/40" />
+            <div className="h-4 w-28 rounded bg-muted/40" />
+          </div>
+          <div className="h-6 w-16 shrink-0 rounded-full bg-muted/40" />
+        </div>
+        <div className="space-y-3">
+          <div className="h-5 w-1/2 rounded bg-muted/50" />
+          <div className="h-4 w-11/12 rounded bg-muted/40" />
+          <div className="h-4 w-3/4 rounded bg-muted/40" />
+          <div className="h-4 w-5/6 rounded bg-muted/40" />
+          <div className="h-4 w-2/5 rounded bg-muted/40" />
+        </div>
+        <div className="my-6 h-px w-full bg-border/60" />
+        <div className="space-y-3">
+          <div className="h-4 w-4/5 rounded bg-muted/40" />
+          <div className="h-4 w-2/3 rounded bg-muted/40" />
+          <div className="flex items-center gap-3">
+            <div className="h-4 w-1/3 rounded bg-muted/40" />
+            <div className="h-5 w-px rounded bg-muted-foreground/30" />
+          </div>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Replace the workflow detail loading body with an editor-canvas skeleton instead of stacked detail cards
- Reserve header action skeletons while workflow detail data loads

## Validation
- pnpm exec prettier --write apps/platform/src/views/workflows-page/workflow-detail-page.tsx
- pnpm -F @vm0/app exec oxlint src/views/workflows-page/workflow-detail-page.tsx
- pnpm -F @vm0/app exec eslint src/views/workflows-page/workflow-detail-page.tsx --max-warnings 0
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app exec vitest run src/views/workflows-page/__tests__/workflows-page.test.tsx