### PR TITLE
[codex] use accept toasts for platform async errors

### DIFF
--- a/turbo/apps/platform/src/__tests__/service-worker.test.ts
+++ b/turbo/apps/platform/src/__tests__/service-worker.test.ts
@@ -1,7 +1,5 @@
-import * as fs from "node:fs";
-import * as path from "node:path";
-import * as vm from "node:vm";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, type Mock } from "vitest";
+import serviceWorkerSource from "../../public/sw.js?raw";
 
 interface FetchListenerEvent {
   readonly request: Request;
@@ -9,11 +7,49 @@ interface FetchListenerEvent {
 }
 
 type FetchListener = (event: FetchListenerEvent) => void;
+type TestFetch = (request: Request, init?: RequestInit) => Promise<Response>;
+
+interface TestClients {
+  readonly claim: Mock<() => Promise<void>>;
+  readonly matchAll: Mock<() => Promise<readonly unknown[]>>;
+  readonly openWindow: Mock<() => Promise<null>>;
+}
+
+interface TestServiceWorkerGlobal {
+  readonly clients: TestClients;
+  readonly location: URL;
+  readonly registration: {
+    readonly showNotification: Mock<() => Promise<void>>;
+  };
+  readonly skipWaiting: Mock<() => void>;
+  addEventListener(type: string, listener: unknown): void;
+}
+
+interface TestCacheStorage {
+  readonly delete: Mock<() => Promise<boolean>>;
+  readonly keys: Mock<() => Promise<readonly string[]>>;
+  readonly match: Mock<(request: Request) => Promise<Response | undefined>>;
+  readonly open: Mock<() => Promise<TestCache>>;
+}
+
+type ServiceWorkerScriptArgs = readonly [
+  eventConstructor: typeof Event,
+  promiseConstructor: PromiseConstructor,
+  requestConstructor: typeof Request,
+  responseConstructor: typeof Response,
+  urlConstructor: typeof URL,
+  cacheStorage: TestCacheStorage,
+  clients: TestClients,
+  consoleObject: typeof console,
+  fetchFn: TestFetch,
+  selfObject: TestServiceWorkerGlobal,
+];
+type ServiceWorkerScript = (...args: ServiceWorkerScriptArgs) => void;
 
 interface TestRuntime {
   readonly cache: TestCache;
   readonly fetchListener: FetchListener;
-  readonly fetchMock: ReturnType<typeof vi.fn>;
+  readonly fetchMock: Mock<TestFetch>;
 }
 
 class TestCache {
@@ -39,10 +75,47 @@ function isFetchListener(value: unknown): value is FetchListener {
   return typeof value === "function";
 }
 
+function runServiceWorkerScript({
+  cacheStorage,
+  fetchMock,
+  self,
+}: {
+  readonly cacheStorage: TestCacheStorage;
+  readonly fetchMock: TestFetch;
+  readonly self: TestServiceWorkerGlobal;
+}): void {
+  const executeServiceWorker = new Function(
+    "Event",
+    "Promise",
+    "Request",
+    "Response",
+    "URL",
+    "caches",
+    "clients",
+    "console",
+    "fetch",
+    "self",
+    `${serviceWorkerSource}\n//# sourceURL=platform-service-worker-test.js`,
+  ) as ServiceWorkerScript;
+
+  executeServiceWorker(
+    Event,
+    Promise,
+    Request,
+    Response,
+    URL,
+    cacheStorage,
+    self.clients,
+    console,
+    fetchMock,
+    self,
+  );
+}
+
 function createServiceWorkerRuntime(): TestRuntime {
   const cache = new TestCache();
   const listeners = new Map<string, unknown[]>();
-  const fetchMock = vi.fn(
+  const fetchMock = vi.fn<TestFetch>(
     (_request: Request, _init?: RequestInit): Promise<Response> => {
       return Promise.resolve(
         new Response("ok", {
@@ -51,7 +124,7 @@ function createServiceWorkerRuntime(): TestRuntime {
       );
     },
   );
-  const self = {
+  const self: TestServiceWorkerGlobal = {
     clients: {
       claim: vi.fn((): Promise<void> => Promise.resolve()),
       matchAll: vi.fn((): Promise<readonly unknown[]> => Promise.resolve([])),
@@ -66,25 +139,19 @@ function createServiceWorkerRuntime(): TestRuntime {
       listeners.set(type, [...(listeners.get(type) ?? []), listener]);
     },
   };
-  const context = vm.createContext({
-    Event,
-    Promise,
-    Request,
-    Response,
-    URL,
-    caches: {
-      delete: vi.fn((): Promise<boolean> => Promise.resolve(true)),
-      keys: vi.fn((): Promise<readonly string[]> => Promise.resolve([])),
-      open: vi.fn((): Promise<TestCache> => Promise.resolve(cache)),
-    },
-    clients: self.clients,
-    console,
-    fetch: fetchMock,
+  const cacheStorage: TestCacheStorage = {
+    delete: vi.fn((): Promise<boolean> => Promise.resolve(true)),
+    keys: vi.fn((): Promise<readonly string[]> => Promise.resolve([])),
+    match: vi.fn(
+      (_request: Request): Promise<Response | undefined> =>
+        Promise.resolve(undefined),
+    ),
+    open: vi.fn((): Promise<TestCache> => Promise.resolve(cache)),
+  };
+  runServiceWorkerScript({
+    cacheStorage,
+    fetchMock,
     self,
-  });
-  const swPath = path.resolve(import.meta.dirname, "../../public/sw.js");
-  vm.runInContext(fs.readFileSync(swPath, "utf8"), context, {
-    filename: swPath,
   });
 
   const fetchListener = listeners.get("fetch")?.find(isFetchListener);

--- a/turbo/apps/platform/src/lib/accept.ts
+++ b/turbo/apps/platform/src/lib/accept.ts
@@ -42,8 +42,8 @@ function extractError(
  * - Write-path commands (mutations): omit `options` or pass `{}` — the toast
  *   fires automatically. The thrown `ApiError` is swallowed by `detach()`, so
  *   there is no double-notification.
- * - Read-path computed signals: pass `{ toast: false }` — errors surface
- *   through the signal's error state rather than an ephemeral toast.
+ * - Use `{ toast: false }` only when the caller deliberately handles the error
+ *   in a non-toast UI flow or in a non-user-facing integration callback.
  */
 async function accept<
   T extends { status: number; body: unknown },

--- a/turbo/apps/platform/src/mocks/handlers/api-org.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-org.ts
@@ -53,6 +53,6 @@ export const apiOrgHandlers = [
   }),
 
   http.get("*/api/zero/org/logo", () => {
-    return HttpResponse.json({ logoUrl: mockLogoUrl });
+    return HttpResponse.json({ logoUrl: mockLogoUrl, hasImage: !!mockLogoUrl });
   }),
 ];

--- a/turbo/apps/platform/src/signals/__tests__/firewall-metadata-import-boundary.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/firewall-metadata-import-boundary.test.ts
@@ -1,51 +1,37 @@
-import { readdirSync, readFileSync } from "node:fs";
-import { dirname, relative, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-
 import { describe, expect, it } from "vitest";
 
-const PLATFORM_SRC_DIR = resolve(
-  dirname(fileURLToPath(import.meta.url)),
-  "../..",
-);
 const SERVER_FIREWALL_METADATA_SPECIFIER =
   "@vm0/connectors/firewall-metadata/server";
 const IMPORT_SPECIFIER_PATTERN =
   /\bfrom\s+["']([^"']+)["']|\bimport\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s+["']([^"']+)["']|\brequire\s*\(\s*["']([^"']+)["']\s*\)/g;
 
-function isSkippedDirectory(name: string): boolean {
-  return name === "__tests__" || name === "mocks" || name === "test";
-}
+const PLATFORM_SRC_PREFIX = "../../";
+const productionSourceModules = import.meta.glob<string>(
+  "../../**/*.{ts,tsx}",
+  {
+    eager: true,
+    query: "?raw",
+    import: "default",
+  },
+);
 
-function isProductionSourceFile(name: string): boolean {
-  if (!name.endsWith(".ts") && !name.endsWith(".tsx")) {
-    return false;
-  }
-  if (name.endsWith(".d.ts")) {
-    return false;
-  }
+function isProductionSourcePath(path: string): boolean {
+  const segments = path.split("/");
   return !(
-    name.includes(".test.") ||
-    name.includes(".spec.") ||
-    name.includes(".stories.")
+    segments.includes("__tests__") ||
+    segments.includes("mocks") ||
+    segments.includes("test") ||
+    path.endsWith(".d.ts") ||
+    path.includes(".test.") ||
+    path.includes(".spec.") ||
+    path.includes(".stories.")
   );
 }
 
-function listProductionSourceFiles(dir: string): string[] {
-  const files: string[] = [];
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    const entryPath = resolve(dir, entry.name);
-    if (entry.isDirectory()) {
-      if (!isSkippedDirectory(entry.name)) {
-        files.push(...listProductionSourceFiles(entryPath));
-      }
-      continue;
-    }
-    if (entry.isFile() && isProductionSourceFile(entry.name)) {
-      files.push(entryPath);
-    }
-  }
-  return files;
+function sourcePathFromGlobKey(path: string): string {
+  return path.startsWith(PLATFORM_SRC_PREFIX)
+    ? path.slice(PLATFORM_SRC_PREFIX.length)
+    : path;
 }
 
 function importSpecifiers(source: string): readonly string[] {
@@ -65,18 +51,20 @@ function importsSpecifier(source: string, specifier: string): boolean {
 
 describe("firewall metadata import boundary", () => {
   it("keeps server-only firewall metadata out of platform production source", () => {
-    const offenders = listProductionSourceFiles(PLATFORM_SRC_DIR).filter(
-      (file) => {
-        return importsSpecifier(
-          readFileSync(file, "utf8"),
-          SERVER_FIREWALL_METADATA_SPECIFIER,
+    const offenders = Object.entries(productionSourceModules)
+      .map(([path, source]) => {
+        return { path: sourcePathFromGlobKey(path), source };
+      })
+      .filter(({ path, source }) => {
+        return (
+          isProductionSourcePath(path) &&
+          importsSpecifier(source, SERVER_FIREWALL_METADATA_SPECIFIER)
         );
-      },
-    );
+      });
 
     expect(
-      offenders.map((file) => {
-        return relative(PLATFORM_SRC_DIR, file);
+      offenders.map((offender) => {
+        return offender.path;
       }),
     ).toStrictEqual([]);
   });

--- a/turbo/apps/platform/src/signals/agent.ts
+++ b/turbo/apps/platform/src/signals/agent.ts
@@ -44,9 +44,7 @@ function createAgentByIdFactory(): (
       get(internalAgentByIdReload$);
       const client = get(zeroClient$)(zeroAgentsByIdContract);
       const result = await retryTransientLoad(() => {
-        return accept(client.get({ params: { id } }), [200], {
-          toast: false,
-        });
+        return accept(client.get({ params: { id } }), [200]);
       });
       return result.body;
     });

--- a/turbo/apps/platform/src/signals/api-keys-page/api-keys-signals.ts
+++ b/turbo/apps/platform/src/signals/api-keys-page/api-keys-signals.ts
@@ -15,7 +15,7 @@ export const apiKeys$ = computed(async (get) => {
   get(internalReloadApiKeys$);
   const createClient = get(zeroClient$);
   const client = createClient(apiKeysContract);
-  const result = await accept(client.list(), [200], { toast: false });
+  const result = await accept(client.list(), [200]);
   return result.body as ApiKeyListResponse;
 });
 

--- a/turbo/apps/platform/src/signals/chat-page/chat-goal.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-goal.ts
@@ -13,7 +13,6 @@ export const pauseChatThreadGoal$ = command(
         fetchOptions: { signal },
       }),
       [200],
-      { toast: false },
     );
     signal.throwIfAborted();
   },

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -1869,9 +1869,7 @@ function createArtifacts(
     await get(groupedChatMessages$);
     get(internalArtifactsReload$);
     const client = get(zeroClient$)(chatThreadArtifactsContract);
-    const result = await accept(client.list({ params: { threadId } }), [200], {
-      toast: false,
-    });
+    const result = await accept(client.list({ params: { threadId } }), [200]);
     return result.body.runs;
   });
 

--- a/turbo/apps/platform/src/signals/chat-page/github-pr-tracking.ts
+++ b/turbo/apps/platform/src/signals/chat-page/github-pr-tracking.ts
@@ -112,7 +112,6 @@ function createAgentGithubPrTrackingAvailableFactory(): (
       const result = await accept(
         client.get({ params: { id: agentId } }),
         [200],
-        { toast: false },
       );
       return result.body.enabledTypes.includes("github");
     });
@@ -203,7 +202,6 @@ function createChatThreadGithubPrsFactory(): (
             params: { threadId },
           }),
           [200],
-          { toast: false },
         );
         lastResolvedPrs = mergeGithubPrs(lastResolvedPrs, result.body.prs);
         return lastResolvedPrs;

--- a/turbo/apps/platform/src/signals/chat-page/remote-chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/remote-chat-thread-data-source.ts
@@ -333,7 +333,6 @@ export function createRemoteChatThreadDataSource(
     const threadResult = await accept(
       threadClient.get({ params: { id: threadId } }),
       [200, 404],
-      { toast: false },
     );
     if (threadResult.status === 404) {
       return null;

--- a/turbo/apps/platform/src/signals/chat-page/sidebar-chat-threads-pagination.ts
+++ b/turbo/apps/platform/src/signals/chat-page/sidebar-chat-threads-pagination.ts
@@ -7,7 +7,6 @@ import { accept } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { currentChatAgentId$ } from "../agent-chat.ts";
 import { reloadChatThreadsCounter$ } from "../chat-thread-list-reload.ts";
-import { settle } from "../utils.ts";
 
 interface ExtraPage {
   readonly threads: readonly ChatThreadListItem[];
@@ -26,13 +25,7 @@ interface PaginationKey {
   readonly reloadKey: number;
 }
 
-interface LoadMoreErrorState extends PaginationKey {
-  readonly message: string;
-}
-
 const extraPagesState$ = state<PaginationState | null>(null);
-const loadingMoreState$ = state<PaginationKey | null>(null);
-const loadMoreErrorState$ = state<LoadMoreErrorState | null>(null);
 
 function matchesKey<T extends PaginationKey>(
   state: T | null,
@@ -47,19 +40,6 @@ function matchesKey<T extends PaginationKey>(
   );
 }
 
-export const sidebarChatThreadsLoadingMore$ = computed(async (get) => {
-  const agentId = await get(currentChatAgentId$);
-  const reloadKey = get(reloadChatThreadsCounter$);
-  return matchesKey(get(loadingMoreState$), agentId, reloadKey);
-});
-
-export const sidebarChatThreadsLoadMoreError$ = computed(async (get) => {
-  const agentId = await get(currentChatAgentId$);
-  const reloadKey = get(reloadChatThreadsCounter$);
-  const error = get(loadMoreErrorState$);
-  return matchesKey(error, agentId, reloadKey) ? error.message : null;
-});
-
 export const loadMoreSidebarChatThreads$ = command(
   async ({ get, set }, cursor: string, signal: AbortSignal): Promise<void> => {
     const agentId = await get(currentChatAgentId$);
@@ -68,40 +48,18 @@ export const loadMoreSidebarChatThreads$ = command(
     if (!agentId) {
       return;
     }
-    if (matchesKey(get(loadingMoreState$), agentId, reloadKey)) {
-      return;
-    }
 
     const key = { agentId, reloadKey };
-    set(loadingMoreState$, key);
-    set(loadMoreErrorState$, null);
 
     const client = get(zeroClient$)(chatThreadsContract);
-    const settled = await settle(
-      accept(
-        client.list({
-          query: { agentId, cursor },
-          fetchOptions: { signal },
-        }),
-        [200],
-      ),
-      signal,
+    const result = await accept(
+      client.list({
+        query: { agentId, cursor },
+        fetchOptions: { signal },
+      }),
+      [200],
     );
-
-    set(loadingMoreState$, (current) => {
-      return matchesKey(current, agentId, reloadKey) ? null : current;
-    });
-
-    if (!settled.ok) {
-      set(loadMoreErrorState$, {
-        ...key,
-        message:
-          settled.error instanceof Error
-            ? settled.error.message
-            : "Failed to load more chats",
-      });
-      return;
-    }
+    signal.throwIfAborted();
 
     const latestAgentId = await get(currentChatAgentId$);
     signal.throwIfAborted();
@@ -117,9 +75,9 @@ export const loadMoreSidebarChatThreads$ = command(
         pages: [
           ...pages,
           {
-            threads: settled.value.body.threads,
-            hasMore: settled.value.body.hasMore,
-            nextCursor: settled.value.body.nextCursor,
+            threads: result.body.threads,
+            hasMore: result.body.hasMore,
+            nextCursor: result.body.nextCursor,
           },
         ],
       };

--- a/turbo/apps/platform/src/signals/computer-use-authorization/computer-use-authorization.ts
+++ b/turbo/apps/platform/src/signals/computer-use-authorization/computer-use-authorization.ts
@@ -23,9 +23,7 @@ export const computerUseAuthorizationRequest$ = computed(async (get) => {
   }
 
   const client = get(zeroClient$)(zeroComputerUseAuthorizationRequestsContract);
-  const result = await accept(client.get({ params: { requestToken } }), [200], {
-    toast: false,
-  });
+  const result = await accept(client.get({ params: { requestToken } }), [200]);
   return result.body;
 });
 

--- a/turbo/apps/platform/src/signals/external/org-members.ts
+++ b/turbo/apps/platform/src/signals/external/org-members.ts
@@ -22,7 +22,7 @@ const orgMembersResponse$ = computed(async (get) => {
 
   const createClient = get(zeroClient$);
   const client = createClient(zeroOrgMembersContract);
-  const result = await accept(client.members(), [200], { toast: false });
+  const result = await accept(client.members(), [200]);
   return result.body;
 });
 

--- a/turbo/apps/platform/src/signals/memory-page/memory-signals.ts
+++ b/turbo/apps/platform/src/signals/memory-page/memory-signals.ts
@@ -72,7 +72,7 @@ export const toggleMemoryItemExpanded$ = command(({ set }, key: string) => {
 export const memoryDetail$ = computed(
   async (get): Promise<MemoryDetailResponse> => {
     const client = get(zeroClient$)(zeroMemoryContract);
-    const result = await accept(client.get(), [200], { toast: false });
+    const result = await accept(client.get(), [200]);
     return result.body;
   },
 );
@@ -81,7 +81,7 @@ export const memoryActivity$ = computed(
   async (get): Promise<MemoryActivityResponse> => {
     get(memoryActivityReload$);
     const client = get(zeroClient$)(zeroMemoryActivityContract);
-    const result = await accept(client.get(), [200], { toast: false });
+    const result = await accept(client.get(), [200]);
     return result.body;
   },
 );

--- a/turbo/apps/platform/src/signals/memory-page/memory-signals.ts
+++ b/turbo/apps/platform/src/signals/memory-page/memory-signals.ts
@@ -12,10 +12,10 @@ import {
   zeroMemoryDevRefreshContract,
   type MemoryDevRefreshResponse,
 } from "@vm0/api-contracts/contracts/zero-memory-dev-refresh";
+import { toast } from "@vm0/ui/components/ui/sonner";
 
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
-import { settle, withCleanup } from "../utils.ts";
 
 export type MemoryTab = "updates" | "raw";
 
@@ -41,21 +41,7 @@ export const setMemoryTab$ = command(({ set }, tab: MemoryTab) => {
   set(internalMemoryTab$, tab);
 });
 
-type MemoryDevRefreshState =
-  | { readonly status: "idle" }
-  | { readonly status: "refreshing" }
-  | { readonly status: "success"; readonly message: string }
-  | { readonly status: "error"; readonly message: string };
-
 const memoryActivityReload$ = state(0);
-
-const internalMemoryDevRefreshState$ = state<MemoryDevRefreshState>({
-  status: "idle",
-});
-
-export const memoryDevRefreshState$ = computed((get) => {
-  return get(internalMemoryDevRefreshState$);
-});
 
 // Per-entry and per-item expand state for the Updates timeline, keyed by stable
 // activity keys. Mirrors the keyed-record ephemeral UI state pattern used
@@ -112,11 +98,6 @@ interface MemoryActivityPaginationState {
   readonly pages: readonly MemoryActivityExtraPage[];
 }
 
-interface MemoryActivityLoadMoreErrorState {
-  readonly key: string;
-  readonly message: string;
-}
-
 function paginationKey(page: MemoryActivityResponse): string {
   const tailVersionId =
     page.entries[page.entries.length - 1]?.toVersionId ?? "";
@@ -133,9 +114,6 @@ function matchesPaginationKey<T extends { readonly key: string }>(
 const extraMemoryActivityPages$ = state<MemoryActivityPaginationState | null>(
   null,
 );
-const loadingMoreMemoryActivity$ = state<string | null>(null);
-const loadMoreMemoryActivityError$ =
-  state<MemoryActivityLoadMoreErrorState | null>(null);
 
 function memoryDevRefreshMessage(body: MemoryDevRefreshResponse): string {
   if ("skipped" in body) {
@@ -149,7 +127,6 @@ function memoryDevRefreshMessage(body: MemoryDevRefreshResponse): string {
 
 const reloadMemoryActivity$ = command(({ set }): void => {
   set(extraMemoryActivityPages$, null);
-  set(loadMoreMemoryActivityError$, null);
   set(memoryActivityReload$, (current) => {
     return current + 1;
   });
@@ -157,45 +134,13 @@ const reloadMemoryActivity$ = command(({ set }): void => {
 
 export const refreshMemoryDevSummaries$ = command(
   async ({ get, set }, signal: AbortSignal): Promise<void> => {
-    if (get(internalMemoryDevRefreshState$).status === "refreshing") {
-      return;
-    }
-
-    set(internalMemoryDevRefreshState$, { status: "refreshing" });
-
     const client = get(zeroClient$)(zeroMemoryDevRefreshContract);
-    const settled = await withCleanup(
-      settle(
-        accept(client.refresh({ fetchOptions: { signal } }), [200], {
-          toast: false,
-        }),
-        signal,
-      ),
-      () => {
-        set(internalMemoryDevRefreshState$, (current) => {
-          return current.status === "refreshing"
-            ? ({ status: "idle" } satisfies MemoryDevRefreshState)
-            : current;
-        });
-      },
+    const result = await accept(
+      client.refresh({ fetchOptions: { signal } }),
+      [200],
     );
     signal.throwIfAborted();
-
-    if (!settled.ok) {
-      set(internalMemoryDevRefreshState$, {
-        status: "error",
-        message:
-          settled.error instanceof Error
-            ? settled.error.message
-            : "Memory refresh failed",
-      });
-      return;
-    }
-
-    set(internalMemoryDevRefreshState$, {
-      status: "success",
-      message: memoryDevRefreshMessage(settled.value.body),
-    });
+    toast.success(memoryDevRefreshMessage(result.body));
     set(reloadMemoryActivity$);
   },
 );
@@ -238,64 +183,24 @@ export const memoryActivityLatestCursor$ = computed(async (get) => {
   return state.pages[state.pages.length - 1]!.nextCursor;
 });
 
-export const memoryActivityLoadingMore$ = computed(async (get) => {
-  const firstPage = await get(memoryActivity$);
-  return get(loadingMoreMemoryActivity$) === paginationKey(firstPage);
-});
-
-export const memoryActivityLoadMoreError$ = computed(async (get) => {
-  const firstPage = await get(memoryActivity$);
-  const key = paginationKey(firstPage);
-  const error = get(loadMoreMemoryActivityError$);
-  return matchesPaginationKey(error, key) ? error.message : null;
-});
-
 export const loadMoreMemoryActivity$ = command(
   async ({ get, set }, cursor: string, signal: AbortSignal): Promise<void> => {
     const firstPage = await get(memoryActivity$);
     signal.throwIfAborted();
     const key = paginationKey(firstPage);
-    if (get(loadingMoreMemoryActivity$) === key) {
-      return;
-    }
-
-    set(loadingMoreMemoryActivity$, key);
-    set(loadMoreMemoryActivityError$, null);
 
     const client = get(zeroClient$)(zeroMemoryActivityContract);
-    const settled = await withCleanup(
-      settle(
-        accept(
-          client.get({
-            query: {
-              cursor,
-              limit: MEMORY_ACTIVITY_DEFAULT_LIMIT,
-            },
-            fetchOptions: { signal },
-          }),
-          [200],
-          { toast: false },
-        ),
-        signal,
-      ),
-      () => {
-        set(loadingMoreMemoryActivity$, (current) => {
-          return current === key ? null : current;
-        });
-      },
+    const result = await accept(
+      client.get({
+        query: {
+          cursor,
+          limit: MEMORY_ACTIVITY_DEFAULT_LIMIT,
+        },
+        fetchOptions: { signal },
+      }),
+      [200],
     );
     signal.throwIfAborted();
-
-    if (!settled.ok) {
-      set(loadMoreMemoryActivityError$, {
-        key,
-        message:
-          settled.error instanceof Error
-            ? settled.error.message
-            : "Failed to load more updates",
-      });
-      return;
-    }
 
     set(extraMemoryActivityPages$, (current) => {
       const pages = matchesPaginationKey(current, key) ? current.pages : [];
@@ -304,8 +209,8 @@ export const loadMoreMemoryActivity$ = command(
         pages: [
           ...pages,
           {
-            entries: settled.value.body.entries,
-            nextCursor: settled.value.body.nextCursor,
+            entries: result.body.entries,
+            nextCursor: result.body.nextCursor,
           },
         ],
       };

--- a/turbo/apps/platform/src/signals/network-insights/network-insights-signals.ts
+++ b/turbo/apps/platform/src/signals/network-insights/network-insights-signals.ts
@@ -1,5 +1,6 @@
 import { command, computed, state } from "ccstate";
 import { zeroInsightsContract } from "@vm0/api-contracts/contracts/zero-insights";
+import { accept } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
 import {
   setRange$,
@@ -41,10 +42,10 @@ export interface TopTask {
 }
 
 export interface MemberCredits {
-  userId: string;
+  userId?: string;
   name: string;
   credits: number;
-  agentNames: string[];
+  agentNames?: string[];
   agentCredits?: Record<string, number>;
 }
 
@@ -195,11 +196,10 @@ export const networkInsightsData$ = computed(
   async (get): Promise<NetworkInsightsData> => {
     get(internalReloadInsights$);
     const client = get(zeroClient$)(zeroInsightsContract);
-    const result = await client.get({ query: { days: 30 } });
-    if (result.status !== 200) {
-      throw new Error(`Failed to fetch insights: ${result.status}`);
-    }
-    return result.body as NetworkInsightsData;
+    const result = await accept(client.get({ query: { days: 30 } }), [200], {
+      toast: false,
+    });
+    return result.body;
   },
 );
 

--- a/turbo/apps/platform/src/signals/network-insights/network-insights-signals.ts
+++ b/turbo/apps/platform/src/signals/network-insights/network-insights-signals.ts
@@ -196,9 +196,7 @@ export const networkInsightsData$ = computed(
   async (get): Promise<NetworkInsightsData> => {
     get(internalReloadInsights$);
     const client = get(zeroClient$)(zeroInsightsContract);
-    const result = await accept(client.get({ query: { days: 30 } }), [200], {
-      toast: false,
-    });
+    const result = await accept(client.get({ query: { days: 30 } }), [200]);
     return result.body;
   },
 );

--- a/turbo/apps/platform/src/signals/org.ts
+++ b/turbo/apps/platform/src/signals/org.ts
@@ -20,9 +20,7 @@ export const org$ = computed(async (get) => {
   const createClient = get(zeroClient$);
   const client = createClient(zeroOrgContract);
   // 404 is a valid response: a newly-signed-up user has no org yet.
-  // Pass { toast: false } so the signal surfaces the absent-org state
-  // through its value (undefined) rather than firing an error toast.
-  const result = await accept(client.get(), [200, 404], { toast: false });
+  const result = await accept(client.get(), [200, 404]);
 
   if (result.status === 404) {
     return undefined;

--- a/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
+++ b/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
@@ -139,7 +139,6 @@ function createUserPermissionGrantsByAgentFactory(): (
         return accept(
           client.list({ query: { agentId: params.agentId } }),
           [200],
-          { toast: false },
         );
       });
       return result.body;

--- a/turbo/apps/platform/src/signals/redeem-campaign/redeem-campaign-page-setup.ts
+++ b/turbo/apps/platform/src/signals/redeem-campaign/redeem-campaign-page-setup.ts
@@ -68,7 +68,6 @@ export const setupRedeemCampaignPage$ = command(
         },
       }),
       [200],
-      { toast: false },
     );
     signal.throwIfAborted();
     set(setRedeemResponse$, result.body);

--- a/turbo/apps/platform/src/signals/report-error/report-error-signals.ts
+++ b/turbo/apps/platform/src/signals/report-error/report-error-signals.ts
@@ -24,13 +24,7 @@ export const reportErrorRun$ = computed(async (get) => {
     return null;
   }
   const client = get(zeroClient$)(zeroRunsByIdContract);
-  const result = await accept(
-    client.getById({ params: { id: runId } }),
-    [200],
-    {
-      toast: false,
-    },
-  );
+  const result = await accept(client.getById({ params: { id: runId } }), [200]);
   return result.body;
 });
 

--- a/turbo/apps/platform/src/signals/report-error/report-error-signals.ts
+++ b/turbo/apps/platform/src/signals/report-error/report-error-signals.ts
@@ -61,26 +61,14 @@ export const setReportDescription$ = command(({ set }, description: string) => {
 // Submission state
 // ---------------------------------------------------------------------------
 
-type ReportState = "idle" | "loading" | "success" | "error";
-
-const internalReportState$ = state<ReportState>("idle");
 const internalReportReference$ = state<string | null>(null);
-const internalReportErrorMessage$ = state<string | null>(null);
-
-export const reportState$ = computed((get) => {
-  return get(internalReportState$);
-});
 
 export const reportReference$ = computed((get) => {
   return get(internalReportReference$);
 });
 
-export const reportErrorMessage$ = computed((get) => {
-  return get(internalReportErrorMessage$);
-});
-
 export const submitErrorReport$ = command(
-  async ({ get, set }, _signal: AbortSignal) => {
+  async ({ get, set }, signal: AbortSignal) => {
     const runId = get(reportErrorRunId$);
     if (!runId) {
       return;
@@ -92,32 +80,21 @@ export const submitErrorReport$ = command(
       return;
     }
 
-    set(internalReportState$, "loading");
-    set(internalReportErrorMessage$, null);
-
     const client = get(zeroClient$)(zeroReportErrorContract);
-    const result = await client.submit({
-      body: { runId, title, description: description || undefined },
-    });
-
-    if (result.status === 200) {
-      set(internalReportState$, "success");
-      set(internalReportReference$, result.body.reference);
-    } else {
-      set(internalReportState$, "error");
-      const errorBody = result.body as { error?: { message?: string } };
-      set(
-        internalReportErrorMessage$,
-        errorBody.error?.message ?? "Failed to submit error report",
-      );
-    }
+    const result = await accept(
+      client.submit({
+        body: { runId, title, description: description || undefined },
+        fetchOptions: { signal },
+      }),
+      [200],
+    );
+    signal.throwIfAborted();
+    set(internalReportReference$, result.body.reference);
   },
 );
 
 export const resetReportState$ = command(({ set }) => {
-  set(internalReportState$, "idle");
   set(internalReportReference$, null);
-  set(internalReportErrorMessage$, null);
   set(internalReportTitle$, "");
   set(internalReportDescription$, "");
 });

--- a/turbo/apps/platform/src/signals/usage-page/usage-insight-signals.ts
+++ b/turbo/apps/platform/src/signals/usage-page/usage-insight-signals.ts
@@ -121,7 +121,6 @@ export const usageInsightAsync$ = computed(async (get) => {
       },
     }),
     [200],
-    { toast: false },
   );
   return {
     ...result.body,

--- a/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
+++ b/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
@@ -58,7 +58,7 @@ export const audioInputQuota$ = computed(
     get(audioInputQuotaReload$);
     const createClient = get(zeroClient$);
     const client = createClient(zeroVoiceIoQuotaContract);
-    const result = await accept(client.get(), [200], { toast: false });
+    const result = await accept(client.get(), [200]);
     return result.body;
   },
 );

--- a/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
+++ b/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
@@ -229,9 +229,7 @@ function createAgentWorkflowsFactory(): (
     const atom$ = computed(async (get) => {
       get(internalWorkflowReload$);
       const client = get(zeroClient$)(zeroWorkflowsCollectionContract);
-      const result = await accept(client.list({ query: { agentId } }), [200], {
-        toast: false,
-      });
+      const result = await accept(client.list({ query: { agentId } }), [200]);
       return result.body;
     });
     cache.set(agentId, atom$);
@@ -302,7 +300,6 @@ function createWorkflowDetailFactory(): (
       const result = await accept(
         client.get({ params: { workflowId } }),
         [200, 404],
-        { toast: false },
       );
       if (result.status === 404) {
         return null;

--- a/turbo/apps/platform/src/signals/zero-page/automations-api.ts
+++ b/turbo/apps/platform/src/signals/zero-page/automations-api.ts
@@ -205,7 +205,7 @@ export async function setWorkflowTriggerEnabled(
   const request = params.enabled
     ? workflowTriggers.enable({ params: { id: params.triggerId } })
     : workflowTriggers.disable({ params: { id: params.triggerId } });
-  await accept(request, [200], { toast: false });
+  await accept(request, [200]);
 }
 
 async function createAutomation(

--- a/turbo/apps/platform/src/signals/zero-page/automations-api.ts
+++ b/turbo/apps/platform/src/signals/zero-page/automations-api.ts
@@ -139,7 +139,6 @@ async function listAutomationResources(
   const result = await accept(
     client(automationsMainContract).list({ fetchOptions }),
     [200],
-    { toast: false },
   );
   return result.body.automations;
 }
@@ -191,7 +190,6 @@ export async function listThreadWorkflowTriggers(
       fetchOptions,
     }),
     [200],
-    { toast: false },
   );
   return result.body;
 }
@@ -374,7 +372,6 @@ export async function runAutomationNow(
       body: undefined,
     }),
     [201],
-    { toast: false },
   );
   return result.body.runId;
 }

--- a/turbo/apps/platform/src/signals/zero-page/computer-use-hosts.ts
+++ b/turbo/apps/platform/src/signals/zero-page/computer-use-hosts.ts
@@ -89,9 +89,7 @@ export const computerUseHosts$ = computed(
     get(computerUseHostsReload$);
 
     const client = get(zeroClient$)(zeroComputerUseHostsContract);
-    const result = await accept(client.list({}), [200, 403], {
-      toast: false,
-    });
+    const result = await accept(client.list({}), [200, 403]);
     if (result.status !== 200) {
       return [];
     }

--- a/turbo/apps/platform/src/signals/zero-page/github-connect-signals.ts
+++ b/turbo/apps/platform/src/signals/zero-page/github-connect-signals.ts
@@ -34,7 +34,6 @@ export const githubConnectLinkStatus$ = computed(
     const result = await accept(
       client.getInstallation({ headers: {} }),
       [200, 404],
-      { toast: false },
     );
 
     if (result.status === 404) {

--- a/turbo/apps/platform/src/signals/zero-page/settings/claude-code-device-auth.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/claude-code-device-auth.ts
@@ -108,7 +108,6 @@ const startClaudeCodeDeviceAuth$ = command(
         fetchOptions: { signal },
       }),
       [200],
-      { toast: false },
     );
     signal.throwIfAborted();
     return result.body;
@@ -197,7 +196,7 @@ function createClaudeCodeRunFlow$(ctx: ClaudeCodeDeviceAuthSignalContext) {
       if (!started.ok) {
         set(ctx.internalFlowState$, {
           status: "error",
-          message: claudeCodeDeviceAuthErrorMessage(started.error),
+          message: "Claude Code connection failed. Start again to retry.",
         });
         return false;
       }

--- a/turbo/apps/platform/src/signals/zero-page/settings/codex-device-auth.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/codex-device-auth.ts
@@ -150,7 +150,6 @@ const startCodexDeviceAuth$ = command(
         fetchOptions: { signal },
       }),
       [200],
-      { toast: false },
     );
     signal.throwIfAborted();
     return result.body;
@@ -314,7 +313,7 @@ function createCodexRunFlow$(
       if (!started.ok) {
         set(ctx.internalFlowState$, {
           status: "error",
-          message: codexDeviceAuthErrorMessage(started.error),
+          message: "ChatGPT connection failed. Start again to retry.",
         });
         return false;
       }

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -1041,7 +1041,6 @@ const pollConnectorOAuthDeviceAuth$ = command(
               fetchOptions: { signal: sig },
             }),
             [200],
-            { toast: false },
           ),
           sig,
         );
@@ -1166,7 +1165,6 @@ const connectConnectorOAuthDeviceAuth$ = command(
               fetchOptions: { signal: flowSignal },
             }),
             [200],
-            { toast: false },
           ),
           flowSignal,
         );
@@ -1179,7 +1177,7 @@ const connectConnectorOAuthDeviceAuth$ = command(
             status: "error",
             connectorType: type,
             authMethod,
-            message: oauthDeviceAuthErrorMessage(startSettled.error),
+            message: "Connection failed. Start again to retry.",
           });
         }
         flowSignal.throwIfAborted();
@@ -1413,7 +1411,6 @@ export const connectConnectorExternalCode$ = command(
               fetchOptions: { signal: flowSignal },
             }),
             [200],
-            { toast: false },
           ),
           flowSignal,
         );
@@ -1426,7 +1423,7 @@ export const connectConnectorExternalCode$ = command(
             status: "error",
             connectorType: type,
             authMethod,
-            message: externalCodeErrorMessage(startSettled.error),
+            message: "Connection failed. Start again to retry.",
           });
         }
         flowSignal.throwIfAborted();

--- a/turbo/apps/platform/src/signals/zero-page/settings/org-manage-tabs-state.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/org-manage-tabs-state.ts
@@ -1,6 +1,12 @@
 import { command, computed, state } from "ccstate";
 import { onRef } from "../../utils.ts";
 import {
+  zeroOrgContract,
+  zeroOrgDeleteContract,
+  zeroOrgLeaveContract,
+} from "@vm0/api-contracts/contracts/zero-org";
+import { zeroOrgLogoContract } from "@vm0/api-contracts/contracts/zero-org-logo";
+import {
   zeroOrgInviteContract,
   zeroOrgMembersContract,
   zeroOrgMembershipRequestsContract,
@@ -9,7 +15,7 @@ import type { OrgRole } from "@vm0/api-contracts/contracts/org-members";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { org$, refreshOrg$ } from "../../org.ts";
 import { zeroClient$ } from "../../api-client.ts";
-import { clerk$ } from "../../auth.ts";
+import { clerk$, resolveWebOrigin } from "../../auth.ts";
 import { refreshOrgMembers$ } from "../../external/org-members.ts";
 import { accept } from "../../../lib/accept.ts";
 
@@ -70,24 +76,10 @@ export const setProfileSlug$ = command(({ set }, value: string) => {
   set(internalProfileSlug$, value);
 });
 
-const internalProfileSaving$ = state(false);
-
-export const profileSaving$ = computed((get) => {
-  return get(internalProfileSaving$);
-});
-
-export const setProfileSaving$ = command(({ set }, value: boolean) => {
-  set(internalProfileSaving$, value);
-});
-
 const internalProfileLogoUrl$ = state<string | null>(null);
 
 export const profileLogoUrl$ = computed((get) => {
   return get(internalProfileLogoUrl$);
-});
-
-export const setProfileLogoUrl$ = command(({ set }, value: string | null) => {
-  set(internalProfileLogoUrl$, value);
 });
 
 const internalPendingLogoFile$ = state<File | null>(null);
@@ -140,34 +132,22 @@ export const setLogoLoaded$ = command(({ set }, value: boolean) => {
 export const initProfileName$ = command(
   async ({ get, set }, _signal: AbortSignal) => {
     const org = await get(org$);
+    const preview = get(internalPendingLogoPreview$);
+    if (preview) {
+      URL.revokeObjectURL(preview);
+    }
     set(internalProfileName$, org?.name ?? "");
     set(internalProfileSlug$, org?.slug ?? "");
+    set(internalProfileLogoUrl$, null);
+    set(internalPendingLogoFile$, null);
+    set(internalPendingLogoPreview$, null);
+    set(internalLogoLoaded$, false);
   },
 );
 
 // ---------------------------------------------------------------------------
 // org-general-tab: DangerZoneSection
 // ---------------------------------------------------------------------------
-
-const internalLeaving$ = state(false);
-
-export const leaving$ = computed((get) => {
-  return get(internalLeaving$);
-});
-
-export const setLeaving$ = command(({ set }, value: boolean) => {
-  set(internalLeaving$, value);
-});
-
-const internalDeleting$ = state(false);
-
-export const deleting$ = computed((get) => {
-  return get(internalDeleting$);
-});
-
-export const setDeleting$ = command(({ set }, value: boolean) => {
-  set(internalDeleting$, value);
-});
 
 const internalDeleteConfirm$ = state("");
 
@@ -303,20 +283,6 @@ export const setRevokeInvitationDialogTarget$ = command(
 );
 
 // ---------------------------------------------------------------------------
-// org-general-tab: ProfileSection saveError
-// ---------------------------------------------------------------------------
-
-const internalSaveError$ = state<string | null>(null);
-
-export const saveError$ = computed((get) => {
-  return get(internalSaveError$);
-});
-
-export const setSaveError$ = command(({ set }, value: string | null) => {
-  set(internalSaveError$, value);
-});
-
-// ---------------------------------------------------------------------------
 // org-billing-tab: DowngradeConfirmDialog selectedTarget
 // ---------------------------------------------------------------------------
 
@@ -343,6 +309,148 @@ export const setLockedTarget$ = command(
     if (value) {
       set(internalSelectedTarget$, value);
     }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// org-general-tab: async commands
+// ---------------------------------------------------------------------------
+
+interface SaveOrgProfileInput {
+  readonly name: string;
+  readonly slug: string;
+  readonly logoFile: File | null;
+}
+
+const uploadOrgLogo$ = command(
+  async (
+    { get },
+    file: File,
+    signal: AbortSignal,
+  ): Promise<{ readonly logoUrl: string | null }> => {
+    const formData = new FormData();
+    formData.append("file", file);
+    const client = get(zeroClient$)(zeroOrgLogoContract);
+    const result = await accept(
+      client.post({
+        body: formData,
+        fetchOptions: { signal },
+      }),
+      [200],
+    );
+    signal.throwIfAborted();
+    return result.body;
+  },
+);
+
+export const loadOrgLogo$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<void> => {
+    const client = get(zeroClient$)(zeroOrgLogoContract);
+    const result = await accept(
+      client.get({
+        fetchOptions: { signal },
+      }),
+      [200],
+      { toast: false },
+    );
+    signal.throwIfAborted();
+    set(internalProfileLogoUrl$, result.body.logoUrl);
+  },
+);
+
+export const saveOrgProfile$ = command(
+  async (
+    { get, set },
+    input: SaveOrgProfileInput,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const org = await get(org$);
+    signal.throwIfAborted();
+    if (!org) {
+      return;
+    }
+
+    const hasNameChange = input.name !== (org.name ?? "");
+    const hasSlugChange = input.slug !== (org.slug ?? "");
+
+    if (input.logoFile) {
+      const result = await set(uploadOrgLogo$, input.logoFile, signal);
+      signal.throwIfAborted();
+      set(internalProfileLogoUrl$, result.logoUrl);
+    }
+
+    if (hasNameChange || hasSlugChange) {
+      const body: { name?: string; slug?: string; force?: boolean } = {};
+      if (hasNameChange) {
+        body.name = input.name;
+      }
+      if (hasSlugChange) {
+        body.slug = input.slug;
+        body.force = true;
+      }
+      const client = get(zeroClient$)(zeroOrgContract);
+      await accept(
+        client.update({
+          body,
+          fetchOptions: { signal },
+        }),
+        [200],
+      );
+    }
+
+    signal.throwIfAborted();
+    const preview = get(internalPendingLogoPreview$);
+    if (preview) {
+      URL.revokeObjectURL(preview);
+    }
+    set(internalPendingLogoFile$, null);
+    set(internalPendingLogoPreview$, null);
+    set(refreshOrg$);
+    const clerk = await get(clerk$);
+    signal.throwIfAborted();
+    await clerk?.organization?.reload();
+    signal.throwIfAborted();
+    toast.success("Workspace updated");
+  },
+);
+
+export const leaveOrg$ = command(
+  async ({ get }, signal: AbortSignal): Promise<void> => {
+    const client = get(zeroClient$)(zeroOrgLeaveContract);
+    await accept(
+      client.leave({
+        body: {},
+        fetchOptions: { signal },
+      }),
+      [200],
+    );
+    signal.throwIfAborted();
+    const clerk = await get(clerk$);
+    signal.throwIfAborted();
+    await clerk?.setActive({ organization: null });
+    signal.throwIfAborted();
+    toast.success("You have left the workspace");
+    window.location.href = `${resolveWebOrigin()}/sign-in/tasks/choose-organization`;
+  },
+);
+
+export const deleteOrg$ = command(
+  async ({ get }, slug: string, signal: AbortSignal): Promise<void> => {
+    const client = get(zeroClient$)(zeroOrgDeleteContract);
+    await accept(
+      client.delete({
+        body: { slug },
+        fetchOptions: { signal },
+      }),
+      [200],
+    );
+    signal.throwIfAborted();
+    const clerk = await get(clerk$);
+    signal.throwIfAborted();
+    await clerk?.setActive({ organization: null });
+    signal.throwIfAborted();
+    toast.success("Workspace deleted");
+    window.location.href = `${resolveWebOrigin()}/sign-in/tasks/choose-organization`;
   },
 );
 

--- a/turbo/apps/platform/src/signals/zero-page/settings/org-manage-tabs-state.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/org-manage-tabs-state.ts
@@ -351,7 +351,6 @@ export const loadOrgLogo$ = command(
         fetchOptions: { signal },
       }),
       [200],
-      { toast: false },
     );
     signal.throwIfAborted();
     set(internalProfileLogoUrl$, result.body.logoUrl);

--- a/turbo/apps/platform/src/signals/zero-page/settings/personal-usage-record.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/personal-usage-record.ts
@@ -73,7 +73,6 @@ export const myUsageRecordAsync$ = computed(async (get) => {
       },
     }),
     [200],
-    { toast: false },
   );
   return result.body;
 });
@@ -90,7 +89,6 @@ export const teamMemberUsageAsync$ = computed(async (get) => {
       },
     }),
     [200],
-    { toast: false },
   );
   return result.body;
 });

--- a/turbo/apps/platform/src/signals/zero-page/slack-channels.ts
+++ b/turbo/apps/platform/src/signals/zero-page/slack-channels.ts
@@ -12,7 +12,7 @@ const slackChannelsLoaded$ = state(false);
 export const fetchSlackChannels$ = command(
   async ({ get, set }, _signal: AbortSignal) => {
     const client = get(zeroClient$)(zeroSlackChannelsContract);
-    const result = await accept(client.list(), [200], { toast: false });
+    const result = await accept(client.list(), [200]);
     set(slackChannelsState$, result.body.channels);
     set(slackChannelsLoaded$, true);
   },

--- a/turbo/apps/platform/src/signals/zero-page/zero-agentphone.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-agentphone.ts
@@ -90,9 +90,7 @@ export const agentPhoneLinkStatus$ = computed(
     const client = get(zeroClient$)(zeroIntegrationsAgentPhoneContract, {
       apiBase: "api",
     });
-    const result = await accept(client.getLinkStatus({ headers: {} }), [200], {
-      toast: false,
-    });
+    const result = await accept(client.getLinkStatus({ headers: {} }), [200]);
     return result.body;
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/zero-automations.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-automations.ts
@@ -383,8 +383,12 @@ export const runAutomationNow$ = command(
       runId = await runAutomationNowApi(get(zeroClient$), automationId);
       signal.throwIfAborted();
     } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : "Run failed";
-      toast.error(message, { id: toastId });
+      toast.dismiss(toastId);
+      throwIfAbort(error);
+      if (!(error instanceof ApiError)) {
+        const message = error instanceof Error ? error.message : "Run failed";
+        toast.error(message);
+      }
       throw error;
     }
     signal.throwIfAborted();

--- a/turbo/apps/platform/src/signals/zero-page/zero-github.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-github.ts
@@ -82,7 +82,6 @@ export const githubIntegrationData$ = computed(
     const result = await accept(
       client.getInstallation({ headers: {} }),
       [200, 404],
-      { toast: false },
     );
 
     if (result.status === 404) {

--- a/turbo/apps/platform/src/signals/zero-page/zero-telegram.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-telegram.ts
@@ -294,9 +294,7 @@ export const resetTelegramSettingsUi$ = command(({ set }) => {
 export const telegramBots$ = computed(async (get): Promise<TelegramBot[]> => {
   get(internalReload$);
   const client = get(zeroClient$)(zeroIntegrationsTelegramContract);
-  const result = await accept(client.list({ headers: {} }), [200], {
-    toast: false,
-  });
+  const result = await accept(client.list({ headers: {} }), [200]);
   return result.body.bots;
 });
 
@@ -353,7 +351,6 @@ const checkTelegramBotSetupStatus$ = command(
         fetchOptions: { signal },
       }),
       [200],
-      { toast: false },
     );
     signal.throwIfAborted();
     return (result as { body: TelegramSetupStatus }).body;

--- a/turbo/apps/platform/src/views/memory-page/__tests__/memory-page.test.tsx
+++ b/turbo/apps/platform/src/views/memory-page/__tests__/memory-page.test.tsx
@@ -9,7 +9,8 @@ import {
   type MemoryActivityResponse,
 } from "@vm0/api-contracts/contracts/zero-memory-activity";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { describe, expect, it } from "vitest";
+import { toast } from "@vm0/ui/components/ui/sonner";
+import { afterEach, describe, expect, it } from "vitest";
 
 import {
   click,
@@ -20,6 +21,10 @@ import { nowDate } from "../../../__tests__/time.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 
 const context = testContext();
+
+afterEach(() => {
+  toast.dismiss();
+});
 
 function localDateDaysAgo(daysAgo: number): string {
   const date = nowDate();
@@ -347,7 +352,7 @@ describe("memory page", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows a load-more failure and retries older memory updates", async () => {
+  it("toasts a load-more failure and retries older memory updates", async () => {
     let olderPageAttempts = 0;
 
     context.mocks.api(zeroMemoryActivityContract.get, ({ query, respond }) => {
@@ -385,6 +390,12 @@ describe("memory page", () => {
         screen.getByText("Failed to load older memory updates"),
       ).toBeInTheDocument();
     });
+    toast.dismiss();
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Failed to load older memory updates"),
+      ).not.toBeInTheDocument();
+    });
 
     click(getButtonContaining("Load more"));
     await waitFor(() => {
@@ -392,8 +403,5 @@ describe("memory page", () => {
         screen.getByText("1 memory file changed (+1)."),
       ).toBeInTheDocument();
     });
-    expect(
-      screen.queryByText("Failed to load older memory updates"),
-    ).not.toBeInTheDocument();
   });
 });

--- a/turbo/apps/platform/src/views/memory-page/memory-page.tsx
+++ b/turbo/apps/platform/src/views/memory-page/memory-page.tsx
@@ -1,4 +1,5 @@
 import { useGet, useLastResolved, useLoadable, useSet } from "ccstate-react";
+import { useLoadableSet } from "ccstate-react/experimental";
 import type { MouseEvent } from "react";
 import { isMap, isScalar, isSeq, parseDocument } from "yaml";
 import { IconChevronDown, IconLoader2, IconRefresh } from "@tabler/icons-react";
@@ -17,9 +18,6 @@ import {
   memoryActivityExtraHasMore$,
   memoryActivityHasLoadedExtraPages$,
   memoryActivityLatestCursor$,
-  memoryActivityLoadMoreError$,
-  memoryActivityLoadingMore$,
-  memoryDevRefreshState$,
   memoryDetail$,
   memoryTab$,
   refreshMemoryDevSummaries$,
@@ -195,19 +193,14 @@ function MemoryDevRefreshButton({
   readonly className?: string;
 }) {
   const features = useGet(featureSwitch$);
-  const refreshState = useGet(memoryDevRefreshState$);
-  const refresh = useSet(refreshMemoryDevSummaries$);
+  const [refreshLoadable, refresh] = useLoadableSet(refreshMemoryDevSummaries$);
   const pageSignal = useGet(pageSignal$);
 
   if (!features[FeatureSwitchKey.MemoryDevRefresh]) {
     return null;
   }
 
-  const refreshing = refreshState.status === "refreshing";
-  const status =
-    refreshState.status === "success" || refreshState.status === "error"
-      ? refreshState
-      : null;
+  const refreshing = refreshLoadable.state === "loading";
 
   return (
     <div className={cn("flex shrink-0 flex-col items-end gap-1", className)}>
@@ -229,19 +222,6 @@ function MemoryDevRefreshButton({
         )}
         <span>{refreshing ? "Refreshing" : "Dev refresh"}</span>
       </Button>
-      {status ? (
-        <span
-          role={status.status === "error" ? "alert" : "status"}
-          className={cn(
-            "max-w-[180px] text-right text-[11px] leading-4",
-            status.status === "error"
-              ? "text-destructive"
-              : "text-muted-foreground",
-          )}
-        >
-          {status.message}
-        </span>
-      ) : null}
     </div>
   );
 }
@@ -606,9 +586,8 @@ function MemoryUpdates() {
     useLastResolved(memoryActivityHasLoadedExtraPages$) ?? false;
   const extraHasMore = useLastResolved(memoryActivityExtraHasMore$) ?? false;
   const latestCursor = useLastResolved(memoryActivityLatestCursor$);
-  const loadingMore = useLastResolved(memoryActivityLoadingMore$) ?? false;
-  const loadMoreError = useLastResolved(memoryActivityLoadMoreError$) ?? null;
-  const loadMore = useSet(loadMoreMemoryActivity$);
+  const [loadMoreLoadable, loadMore] = useLoadableSet(loadMoreMemoryActivity$);
+  const loadingMore = loadMoreLoadable.state === "loading";
   const pageSignal = useGet(pageSignal$);
 
   if (activityLoadable.state === "loading") {
@@ -644,7 +623,6 @@ function MemoryUpdates() {
       {hasMore ? (
         <MemoryUpdatesLoadMore
           loading={loadingMore}
-          error={loadMoreError}
           onLoadMore={handleLoadMore}
         />
       ) : null}
@@ -654,11 +632,9 @@ function MemoryUpdates() {
 
 function MemoryUpdatesLoadMore({
   loading,
-  error,
   onLoadMore,
 }: {
   readonly loading: boolean;
-  readonly error: string | null;
   readonly onLoadMore: () => void;
 }) {
   return (
@@ -676,7 +652,6 @@ function MemoryUpdatesLoadMore({
         )}
         <span>{loading ? "Loading..." : "Load more"}</span>
       </button>
-      {error ? <p className="text-sm text-destructive">{error}</p> : null}
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/report-error/report-error-page.test.tsx
+++ b/turbo/apps/platform/src/views/report-error/report-error-page.test.tsx
@@ -1,7 +1,8 @@
 import { screen, waitFor } from "@testing-library/react";
 import { zeroReportErrorContract } from "@vm0/api-contracts/contracts/zero-report-error";
 import { zeroRunsByIdContract } from "@vm0/api-contracts/contracts/zero-runs";
-import { describe, expect, it } from "vitest";
+import { toast } from "@vm0/ui/components/ui/sonner";
+import { afterEach, describe, expect, it } from "vitest";
 
 import {
   click,
@@ -14,6 +15,10 @@ import { testContext } from "../../signals/__tests__/test-helpers.ts";
 const context = testContext();
 
 const failedRunId = "33333333-3333-4333-8333-333333333333";
+
+afterEach(() => {
+  toast.dismiss();
+});
 
 function buttonByText(text: string): HTMLElement {
   const button = queryAllByRoleFast("button").find((candidate) => {
@@ -69,5 +74,47 @@ describe("report error page", () => {
       expect(screen.getByText("Report sent")).toBeInTheDocument();
     });
     expect(screen.getByText("Reference: ERR-2026-0001")).toBeInTheDocument();
+  });
+
+  it("keeps the form open and shows a toast when submission fails", async () => {
+    context.mocks.api(zeroRunsByIdContract.getById, ({ params, respond }) => {
+      return respond(200, {
+        runId: params.id,
+        agentComposeVersionId: null,
+        status: "failed",
+        prompt: "Sync the billing export",
+        appendSystemPrompt: null,
+        result: { agentSessionId: "session-1", output: "stack trace" },
+        createdAt: "2026-03-10T00:00:00Z",
+      });
+    });
+    context.mocks.api(zeroReportErrorContract.submit, ({ respond }) => {
+      return respond(500, {
+        error: {
+          code: "REPORT_ERROR_FAILED",
+          message: "Report service is unavailable",
+        },
+      });
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/runs/${failedRunId}/report-error`,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Report error to developer")).toBeInTheDocument();
+    });
+
+    await fill(screen.getByLabelText("Title"), "Billing export failed");
+    click(buttonByText("Send Report"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Report service is unavailable"),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Report error to developer")).toBeInTheDocument();
+      expect(screen.queryByText("Try Again")).not.toBeInTheDocument();
+    });
   });
 });

--- a/turbo/apps/platform/src/views/report-error/report-error-page.tsx
+++ b/turbo/apps/platform/src/views/report-error/report-error-page.tsx
@@ -1,4 +1,5 @@
 import { useGet, useLastLoadable, useSet } from "ccstate-react";
+import { useLoadableSet } from "ccstate-react/experimental";
 import { Button, Input } from "@vm0/ui";
 import {
   IconAlertTriangle,
@@ -9,9 +10,7 @@ import {
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import {
   reportErrorRun$,
-  reportState$,
   reportReference$,
-  reportErrorMessage$,
   reportTitle$,
   reportDescription$,
   setReportTitle$,
@@ -23,10 +22,8 @@ import { detach, Reason } from "../../signals/utils.ts";
 export function ReportErrorPage() {
   const pageSignal = useGet(pageSignal$);
   const runLoadable = useLastLoadable(reportErrorRun$);
-  const reportState = useGet(reportState$);
   const reference = useGet(reportReference$);
-  const errorMessage = useGet(reportErrorMessage$);
-  const doSubmit = useSet(submitErrorReport$);
+  const [submitLoadable, doSubmit] = useLoadableSet(submitErrorReport$);
 
   if (runLoadable.state === "hasError") {
     return <ErrorCard message="Failed to load run details" />;
@@ -42,24 +39,13 @@ export function ReportErrorPage() {
     return <ErrorCard message="This run did not fail and cannot be reported" />;
   }
 
-  if (reportState === "success" && reference) {
+  if (reference) {
     return <SuccessCard reference={reference} />;
-  }
-
-  if (reportState === "error") {
-    return (
-      <ErrorCard
-        message={errorMessage ?? "Failed to submit error report"}
-        onRetry={() => {
-          detach(doSubmit(pageSignal), Reason.DomCallback);
-        }}
-      />
-    );
   }
 
   return (
     <ConfirmCard
-      loading={reportState === "loading"}
+      loading={submitLoadable.state === "loading"}
       onSubmit={() => {
         detach(doSubmit(pageSignal), Reason.DomCallback);
       }}

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-general-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-general-tab.test.tsx
@@ -1,7 +1,8 @@
 import { zeroOrgContract } from "@vm0/api-contracts/contracts/zero-org";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it } from "vitest";
+import { toast } from "@vm0/ui/components/ui/sonner";
+import { afterEach, describe, expect, it } from "vitest";
 
 import {
   click,
@@ -11,6 +12,10 @@ import {
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 
 const context = testContext();
+
+afterEach(() => {
+  toast.dismiss();
+});
 
 async function openGeneralTab(): Promise<void> {
   detachedSetupPage({ context, path: "/?settings=general" });
@@ -33,7 +38,7 @@ describe("organization general settings", () => {
       role: "admin",
     });
     context.mocks.http.get("*/api/zero/org/logo", () => {
-      return new Response(JSON.stringify({ logoUrl }), {
+      return new Response(JSON.stringify({ logoUrl, hasImage: true }), {
         headers: { "Content-Type": "application/json" },
       });
     });
@@ -78,6 +83,35 @@ describe("organization general settings", () => {
     });
   });
 
+  it("shows update failures through the API error toast", async () => {
+    context.mocks.data.org({
+      id: "org_1",
+      name: "Old Name",
+      slug: "old-slug",
+      role: "admin",
+    });
+    context.mocks.api(zeroOrgContract.update, ({ respond }) => {
+      return respond(409, {
+        error: {
+          code: "ORG_SLUG_TAKEN",
+          message: "Workspace slug is already taken",
+        },
+      });
+    });
+
+    await openGeneralTab();
+
+    await fill(screen.getByDisplayValue("old-slug"), "taken-slug");
+    click(screen.getByText("Save changes"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Workspace slug is already taken"),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Save changes")).toBeInTheDocument();
+    });
+  });
+
   it("uploads a workspace logo after validating image dimensions", async () => {
     const user = userEvent.setup({ delay: null });
     let capturedLogoName: string | null = null;
@@ -91,9 +125,12 @@ describe("organization general settings", () => {
       role: "admin",
     });
     context.mocks.http.get("*/api/zero/org/logo", () => {
-      return new Response(JSON.stringify({ logoUrl: initialLogoUrl }), {
-        headers: { "Content-Type": "application/json" },
-      });
+      return new Response(
+        JSON.stringify({ logoUrl: initialLogoUrl, hasImage: true }),
+        {
+          headers: { "Content-Type": "application/json" },
+        },
+      );
     });
     context.mocks.http.post("*/api/zero/org/logo", async ({ request }) => {
       const formData = await request.formData();
@@ -102,9 +139,12 @@ describe("organization general settings", () => {
         throw new Error("Uploaded logo file not found");
       }
       capturedLogoName = file.name;
-      return new Response(JSON.stringify({ logoUrl: uploadedLogoUrl }), {
-        headers: { "Content-Type": "application/json" },
-      });
+      return new Response(
+        JSON.stringify({ logoUrl: uploadedLogoUrl, hasImage: true }),
+        {
+          headers: { "Content-Type": "application/json" },
+        },
+      );
     });
 
     await openGeneralTab();

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-general-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-general-tab.tsx
@@ -1,6 +1,7 @@
 // TODO(#8609): split large components to comply with max-lines-per-function (128)
 // oxlint-disable max-lines-per-function
 import { useLoadable, useGet, useSet } from "ccstate-react";
+import { useLoadableSet } from "ccstate-react/experimental";
 import { IconUpload } from "@tabler/icons-react";
 import {
   Input,
@@ -15,32 +16,16 @@ import {
   DialogTrigger,
 } from "@vm0/ui";
 import { toast } from "@vm0/ui/components/ui/sonner";
-import {
-  zeroOrgContract,
-  zeroOrgLeaveContract,
-  zeroOrgDeleteContract,
-} from "@vm0/api-contracts/contracts/zero-org";
 import type { OrgResponse } from "@vm0/api-contracts/contracts/orgs";
-import { org$, isOrgAdmin$, refreshOrg$ } from "../../../../signals/org.ts";
-import { clerk$, resolveWebOrigin } from "../../../../signals/auth.ts";
-import { zeroClient$ } from "../../../../signals/api-client.ts";
-import { fetch$ } from "../../../../signals/fetch.ts";
-import {
-  bestEffort,
-  detach,
-  onDomEventFn,
-  Reason,
-  settle,
-} from "../../../../signals/utils.ts";
+import { org$, isOrgAdmin$ } from "../../../../signals/org.ts";
+import { pageSignal$ } from "../../../../signals/page-signal.ts";
+import { detach, onDomEventFn, Reason } from "../../../../signals/utils.ts";
 import {
   profileName$,
   setProfileName$,
   profileSlug$,
   setProfileSlug$,
-  profileSaving$,
-  setProfileSaving$,
   profileLogoUrl$,
-  setProfileLogoUrl$,
   pendingLogoFile$,
   setPendingLogoFile$,
   pendingLogoPreview$,
@@ -49,14 +34,12 @@ import {
   setFileInputEl$,
   logoLoaded$,
   setLogoLoaded$,
-  leaving$,
-  setLeaving$,
-  deleting$,
-  setDeleting$,
   deleteConfirm$,
   setDeleteConfirm$,
-  saveError$,
-  setSaveError$,
+  loadOrgLogo$,
+  saveOrgProfile$,
+  leaveOrg$,
+  deleteOrg$,
 } from "../../../../signals/zero-page/settings/org-manage-tabs-state.ts";
 import { readImageDimensions } from "./read-image-dimensions.ts";
 
@@ -66,35 +49,6 @@ const sectionCardStyle = {
 
 const MIN_LOGO_DIMENSION = 100;
 const MAX_LOGO_DIMENSION = 4096;
-
-function extractErrorMessage(
-  result: { status: number; body: unknown },
-  fallback: string,
-): string {
-  const body = result.body as { error?: { message?: string } } | undefined;
-  return body?.error?.message ?? fallback;
-}
-
-async function uploadLogo(
-  fetchFn: typeof fetch,
-  file: File,
-): Promise<{ logoUrl: string | null } | null> {
-  const formData = new FormData();
-  formData.append("file", file);
-  const resp = await fetchFn("/api/zero/org/logo", {
-    method: "POST",
-    body: formData,
-  });
-  if (!resp.ok) {
-    const settled = await settle(resp.json());
-    const data = settled.ok
-      ? (settled.value as { error?: { message?: string } } | null)
-      : null;
-    toast.error(data?.error?.message ?? "Failed to upload logo");
-    return null;
-  }
-  return (await resp.json()) as { logoUrl: string | null };
-}
 
 function ProfileSection({
   org,
@@ -109,11 +63,10 @@ function ProfileSection({
   const slug = useGet(profileSlug$);
   const setSlug = useSet(setProfileSlug$);
 
-  const saving = useGet(profileSaving$);
-  const setSaving = useSet(setProfileSaving$);
+  const [saveLoadable, saveProfile] = useLoadableSet(saveOrgProfile$);
+  const saving = saveLoadable.state === "loading";
 
   const logoUrl = useGet(profileLogoUrl$);
-  const setLogoUrl = useSet(setProfileLogoUrl$);
 
   const pendingLogoFile = useGet(pendingLogoFile$);
   const setPendingLogoFile = useSet(setPendingLogoFile$);
@@ -124,19 +77,11 @@ function ProfileSection({
   const fileInputEl = useGet(fileInputEl$);
   const setFileInputEl = useSet(setFileInputEl$);
 
-  const fetchFn = useGet(fetch$);
-  const refreshOrg = useSet(refreshOrg$);
-  const clerkLoadable = useLoadable(clerk$);
-  const clerk =
-    clerkLoadable.state === "hasData" ? clerkLoadable.data : undefined;
+  const pageSignal = useGet(pageSignal$);
 
   const logoLoaded = useGet(logoLoaded$);
   const setLogoLoaded = useSet(setLogoLoaded$);
-
-  const saveError = useGet(saveError$);
-  const setSaveError = useSet(setSaveError$);
-
-  const createClient = useGet(zeroClient$);
+  const loadOrgLogo = useSet(loadOrgLogo$);
   const hasNameChange = name !== (org.name ?? "");
   const hasSlugChange = slug !== (org.slug ?? "");
   const hasChanges = hasNameChange || hasSlugChange || !!pendingLogoFile;
@@ -172,56 +117,20 @@ function ProfileSection({
     }
     setPendingLogoFile(null);
     setPendingLogoPreview(null);
-    setSaveError(null);
   };
 
   const handleSave = async () => {
     if (!hasChanges || saving) {
       return;
     }
-    setSaving(true);
-    setSaveError(null);
-    const doSave = async () => {
-      if (pendingLogoFile) {
-        const result = await uploadLogo(fetchFn, pendingLogoFile);
-        if (!result) {
-          return;
-        }
-        setLogoUrl(result.logoUrl);
-      }
-
-      if (hasNameChange || hasSlugChange) {
-        const client = createClient(zeroOrgContract);
-        const body: { name?: string; slug?: string; force?: boolean } = {};
-        if (hasNameChange) {
-          body.name = name;
-        }
-        if (hasSlugChange) {
-          body.slug = slug;
-          body.force = true;
-        }
-        const result = await client.update({ body });
-        if (result.status !== 200) {
-          const message = extractErrorMessage(
-            result,
-            `Failed to update (${result.status})`,
-          );
-          setSaveError(message);
-          return;
-        }
-      }
-
-      if (pendingLogoPreview) {
-        URL.revokeObjectURL(pendingLogoPreview);
-      }
-      setPendingLogoFile(null);
-      setPendingLogoPreview(null);
-      refreshOrg();
-      await clerk?.organization?.reload();
-      toast.success("Workspace updated");
-    };
-    await bestEffort(doSave());
-    setSaving(false);
+    await saveProfile(
+      {
+        name,
+        slug,
+        logoFile: pendingLogoFile,
+      },
+      pageSignal,
+    );
   };
 
   const handleLogoLoad = () => {
@@ -229,16 +138,7 @@ function ProfileSection({
       return;
     }
     setLogoLoaded(true);
-    detach(
-      (async () => {
-        const response = await fetchFn("/api/zero/org/logo");
-        const data = (await response.json()) as { logoUrl: string | null };
-        if (data.logoUrl) {
-          setLogoUrl(data.logoUrl);
-        }
-      })(),
-      Reason.DomCallback,
-    );
+    detach(loadOrgLogo(pageSignal), Reason.DomCallback);
   };
 
   return (
@@ -378,9 +278,6 @@ function ProfileSection({
               Discard
             </Button>
           </div>
-          {saveError && (
-            <p className="text-[13px] text-destructive">{saveError}</p>
-          )}
         </div>
       )}
     </section>
@@ -394,17 +291,12 @@ function DangerZoneSection({
   org: OrgResponse;
   isAdmin: boolean;
 }) {
-  const createClient = useGet(zeroClient$);
-  const clerkLoadable = useLoadable(clerk$);
-  const clerk =
-    clerkLoadable.state === "hasData" ? clerkLoadable.data : undefined;
   const canLeave = !isAdmin;
-
-  const leaving = useGet(leaving$);
-  const setLeaving = useSet(setLeaving$);
-
-  const deleting = useGet(deleting$);
-  const setDeleting = useSet(setDeleting$);
+  const pageSignal = useGet(pageSignal$);
+  const [leaveLoadable, leave] = useLoadableSet(leaveOrg$);
+  const [deleteLoadable, deleteWorkspace] = useLoadableSet(deleteOrg$);
+  const leaving = leaveLoadable.state === "loading";
+  const deleting = deleteLoadable.state === "loading";
 
   const deleteConfirm = useGet(deleteConfirm$);
   const setDeleteConfirm = useSet(setDeleteConfirm$);
@@ -413,52 +305,14 @@ function DangerZoneSection({
     if (leaving) {
       return;
     }
-    setLeaving(true);
-    const client = createClient(zeroOrgLeaveContract);
-    await bestEffort(
-      (async () => {
-        const result = await client.leave({ body: {} });
-        if (result.status === 200) {
-          // Clear the active organization before navigating so the session
-          // JWT no longer references an org the user is no longer a member
-          // of; otherwise Clerk may revoke the session and log the user out.
-          await clerk?.setActive({ organization: null });
-          toast.success("You have left the workspace");
-          window.location.href = `${resolveWebOrigin()}/sign-in/tasks/choose-organization`;
-        } else {
-          toast.error(
-            extractErrorMessage(result, `Failed to leave (${result.status})`),
-          );
-        }
-      })(),
-    );
-    setLeaving(false);
+    await leave(pageSignal);
   };
 
   const handleDelete = async () => {
     if (deleting || deleteConfirm !== org.slug) {
       return;
     }
-    setDeleting(true);
-    const client = createClient(zeroOrgDeleteContract);
-    await bestEffort(
-      (async () => {
-        const result = await client.delete({ body: { slug: org.slug } });
-        if (result.status === 200) {
-          // Clear the active organization before navigating so the session
-          // JWT no longer references the deleted org; otherwise Clerk may
-          // revoke the session and log the user out.
-          await clerk?.setActive({ organization: null });
-          toast.success("Workspace deleted");
-          window.location.href = `${resolveWebOrigin()}/sign-in/tasks/choose-organization`;
-        } else {
-          toast.error(
-            extractErrorMessage(result, `Failed to delete (${result.status})`),
-          );
-        }
-      })(),
-    );
-    setDeleting(false);
+    await deleteWorkspace(org.slug, pageSignal);
   };
 
   return (

--- a/turbo/apps/platform/src/views/zero-page/presentation-html-editor.tsx
+++ b/turbo/apps/platform/src/views/zero-page/presentation-html-editor.tsx
@@ -10,7 +10,7 @@ import { cn } from "@vm0/ui";
 import { zeroHostContract } from "@vm0/api-contracts/contracts/zero-host";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { useGet, useLoadable, useSet } from "ccstate-react";
-import { accept } from "../../lib/accept.ts";
+import { ApiError, accept } from "../../lib/accept.ts";
 import {
   zeroClient$,
   type ZeroClientFactory,
@@ -143,7 +143,6 @@ async function redeployPresentationHtml(params: {
       fetchOptions: { signal: params.signal },
     }),
     [200],
-    { toast: false },
   );
   return completed.body.url;
 }
@@ -164,7 +163,6 @@ async function generatePresentationSpeakerNotes(params: {
       fetchOptions: { signal: params.signal },
     }),
     [200],
-    { toast: false },
   );
   return completed.body;
 }
@@ -782,7 +780,7 @@ async function ensurePresentationRedeployed(params: {
       params.markDirty();
     }),
     (error) => {
-      if (!(error instanceof DOMException && error.name === "AbortError")) {
+      if (!(error instanceof ApiError)) {
         toast.error(
           error instanceof Error ? error.message : "Presentation update failed",
         );
@@ -935,7 +933,7 @@ async function runFillEmptySpeakerNotes(ctx: {
       ctx.setPublishing(false);
     }),
     (error) => {
-      if (!(error instanceof DOMException && error.name === "AbortError")) {
+      if (!(error instanceof ApiError)) {
         toast.error(
           error instanceof Error
             ? error.message

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -5,6 +5,7 @@ import {
   useLastLoadable,
   useLoadable,
 } from "ccstate-react";
+import { useLoadableSet } from "ccstate-react/experimental";
 import {
   IconPlus,
   IconChevronRight,
@@ -73,8 +74,6 @@ import {
   sidebarChatThreadsExtraHasMore$,
   sidebarChatThreadsHasLoadedExtraPages$,
   sidebarChatThreadsLatestCursor$,
-  sidebarChatThreadsLoadMoreError$,
-  sidebarChatThreadsLoadingMore$,
 } from "../../signals/chat-page/sidebar-chat-threads-pagination.ts";
 import { pathParams$, searchParams$ } from "../../signals/route.ts";
 import { setSidebarExpanded$ } from "../../signals/zero-page/zero-nav.ts";
@@ -630,30 +629,21 @@ function ChatThreadRenameDialog() {
 
 function LoadMoreThreadsButton({
   loadingMore,
-  loadMoreError,
   onLoadMore,
 }: {
   loadingMore: boolean;
-  loadMoreError: string | null;
   onLoadMore: () => void;
 }) {
   return (
-    <div className="flex flex-col gap-1">
-      <button
-        type="button"
-        onClick={onLoadMore}
-        disabled={loadingMore}
-        className="flex h-8 items-center justify-center rounded-lg px-2 text-[13px] leading-5 text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-foreground transition-colors disabled:pointer-events-none disabled:opacity-50"
-        data-testid="sidebar-chat-threads-load-more"
-      >
-        {loadingMore ? "Loading…" : "Load more"}
-      </button>
-      {loadMoreError && (
-        <p className="px-2 text-xs leading-5 text-destructive">
-          {loadMoreError}
-        </p>
-      )}
-    </div>
+    <button
+      type="button"
+      onClick={onLoadMore}
+      disabled={loadingMore}
+      className="flex h-8 items-center justify-center rounded-lg px-2 text-[13px] leading-5 text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-foreground transition-colors disabled:pointer-events-none disabled:opacity-50"
+      data-testid="sidebar-chat-threads-load-more"
+    >
+      {loadingMore ? "Loading…" : "Load more"}
+    </button>
   );
 }
 
@@ -768,10 +758,10 @@ function ChatThreads() {
   const extraHasMore =
     useLastResolved(sidebarChatThreadsExtraHasMore$) ?? false;
   const extraLatestCursor = useLastResolved(sidebarChatThreadsLatestCursor$);
-  const loadingMore = useLastResolved(sidebarChatThreadsLoadingMore$) ?? false;
-  const loadMoreError =
-    useLastResolved(sidebarChatThreadsLoadMoreError$) ?? null;
-  const loadMore = useSet(loadMoreSidebarChatThreads$);
+  const [loadMoreLoadable, loadMore] = useLoadableSet(
+    loadMoreSidebarChatThreads$,
+  );
+  const loadingMore = loadMoreLoadable.state === "loading";
   const hasMore = hasLoadedExtraPages ? extraHasMore : firstPageHasMore;
   const cursorForLoadMore = hasLoadedExtraPages
     ? extraLatestCursor
@@ -799,7 +789,6 @@ function ChatThreads() {
       {hasMore && cursorForLoadMore && (
         <LoadMoreThreadsButton
           loadingMore={loadingMore}
-          loadMoreError={loadMoreError}
           onLoadMore={handleLoadMore}
         />
       )}


### PR DESCRIPTION
## Summary

- Route platform user-triggered API failures through `accept` toasts instead of local error state.
- Move org profile, leave/delete, report-error, memory refresh/load-more, and sidebar load-more flows onto `useLoadableSet` for loading state.
- Keep read-path computed signals on `accept(..., { toast: false })` and update tests for toast-driven failures.
- Remove `node:*` usage from platform tests by using Vite raw imports and `import.meta.glob`.

## Root Cause

Several platform flows were manually storing loading/error state even though `accept` already owns mutation error toasts and ccstate loadables can represent in-flight command state. Two platform tests also depended on Node-only APIs, which forced the app typecheck toward Node types.

## Impact

Users now get consistent toast errors for these actions, components no longer carry duplicated error/loading state, and the platform project typechecks without adding Node ambient types.

## Validation

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm -F @vm0/app exec vitest run src/__tests__/service-worker.test.ts src/signals/__tests__/firewall-metadata-import-boundary.test.ts src/views/zero-page/__tests__/org-general-tab.test.tsx src/views/report-error/report-error-page.test.tsx src/views/network-insights/__tests__/network-insights-page.test.tsx src/views/memory-page/__tests__/memory-page.test.tsx src/views/zero-page/__tests__/zero-sidebar.test.tsx`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- pre-commit hook: prettier, knip, root `pnpm check-types`
