### PR TITLE
feat: add onboarding template params and scrollable org switcher

### DIFF
--- a/turbo/apps/api/.env.local.tpl
+++ b/turbo/apps/api/.env.local.tpl
@@ -12,7 +12,7 @@ APP_URL=https://app.vm7.ai:8443
 PAID_ONBOARDING_URL=https://so.vm7.ai:8443
 
 # Optional: Atom redeem service for onboarding codes
-ATOM_URL=https://atom.vm7.ai:8442/
+ATOM_URL=https://tunnel-yuma-atom-api.vm7.ai
 VM0_MACHINE_SECRET_KEY=op://Development/clerk/VM0_MACHINE_SECRET_KEY
 
 # Required: API deploy stage tag

--- a/turbo/apps/api/src/signals/routes/__tests__/auth-org-agents.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/auth-org-agents.bdd.test.ts
@@ -194,7 +194,10 @@ describe("AUTH-01, ORG-03, AGENT-02, CHAIN-AGENT", () => {
     expectApiError(forgedLimitedFree.body);
     expect(forgedLimitedFree.body.error.code).toBe("BAD_REQUEST");
 
-    const completeLimitedFree = await api.completeLimitedFreeOnboarding(admin);
+    const completeLimitedFree = await api.completeLimitedFreeOnboarding(admin, {
+      credits: 1000,
+      expiresAt: null,
+    });
     expect(completeLimitedFree.status).toBe(200);
     expect(completeLimitedFree.body).toStrictEqual({
       agentId: defaultAgentId,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-org.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-org.ts
@@ -782,14 +782,19 @@ export function createAuthOrgAgentsBddApi(context: TestContext) {
       );
     },
 
-    async completeLimitedFreeOnboarding(actor: ApiTestUser) {
+    async completeLimitedFreeOnboarding(
+      actor: ApiTestUser,
+      body: z.input<
+        typeof onboardingCompleteLimitedFreeContract.complete.body
+      > = {},
+    ) {
       const client = setupApp({ context })(
         onboardingCompleteLimitedFreeContract,
       );
       return await accept(
         client.complete({
           headers: authenticate(actor),
-          body: {},
+          body,
         }),
         [200, 403, 409],
       );

--- a/turbo/apps/api/src/signals/routes/zero-onboarding-complete-limited-free.ts
+++ b/turbo/apps/api/src/signals/routes/zero-onboarding-complete-limited-free.ts
@@ -38,6 +38,8 @@ const completeInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     completeLimitedFreeOnboarding$,
     {
       orgId: auth.orgId,
+      credits: body.data.credits,
+      expiresAt: body.data.expiresAt,
     },
     signal,
   );

--- a/turbo/apps/api/src/signals/services/onboarding.service.ts
+++ b/turbo/apps/api/src/signals/services/onboarding.service.ts
@@ -29,7 +29,6 @@ import { upsertOrgNoSecretModelProvider$ } from "./zero-model-provider.service";
 const L = logger("onboarding.service");
 const ONBOARDING_CREDIT_SOURCE = "onboarding";
 const ONBOARDING_CREDIT_IDEMPOTENCY_KEY = "limited-free-onboarding";
-const ONBOARDING_CREDIT_AMOUNT = 1000;
 const ONBOARDING_CREDITS_NEVER_EXPIRE_AT = "2999-12-31T00:00:00Z";
 
 interface DefaultAgentInfo {
@@ -93,6 +92,12 @@ type CompleteLimitedFreeOnboardingResponse =
       };
     };
 
+interface CompleteLimitedFreeOnboardingArgs {
+  readonly orgId: string;
+  readonly credits: number;
+  readonly expiresAt: string | null;
+}
+
 async function grantOrgCredits(
   tx: Parameters<Parameters<Db["transaction"]>[0]>[0],
   orgId: string,
@@ -109,6 +114,8 @@ async function grantOrgCredits(
 async function grantOnboardingCredits(
   tx: Parameters<Parameters<Db["transaction"]>[0]>[0],
   orgId: string,
+  amount: number,
+  expiresAt: Date,
 ): Promise<void> {
   const rows = await tx
     .insert(creditExpiresRecord)
@@ -116,9 +123,9 @@ async function grantOnboardingCredits(
       orgId,
       source: ONBOARDING_CREDIT_SOURCE,
       stripeInvoiceId: ONBOARDING_CREDIT_IDEMPOTENCY_KEY,
-      amount: ONBOARDING_CREDIT_AMOUNT,
-      remaining: ONBOARDING_CREDIT_AMOUNT,
-      expiresAt: new Date(ONBOARDING_CREDITS_NEVER_EXPIRE_AT),
+      amount,
+      remaining: amount,
+      expiresAt,
     })
     .onConflictDoNothing()
     .returning({ id: creditExpiresRecord.id });
@@ -128,7 +135,7 @@ async function grantOnboardingCredits(
     return;
   }
 
-  await grantOrgCredits(tx, orgId, ONBOARDING_CREDIT_AMOUNT);
+  await grantOrgCredits(tx, orgId, amount);
 }
 
 function unavailableSelectedConnectorsError(
@@ -767,9 +774,7 @@ export const setupOnboarding$ = command(
 export const completeLimitedFreeOnboarding$ = command(
   async (
     { set },
-    args: {
-      readonly orgId: string;
-    },
+    args: CompleteLimitedFreeOnboardingArgs,
     signal: AbortSignal,
   ): Promise<CompleteLimitedFreeOnboardingResponse> => {
     const writeDb = set(writeDb$);
@@ -808,7 +813,12 @@ export const completeLimitedFreeOnboarding$ = command(
           },
         });
 
-      await grantOnboardingCredits(tx, args.orgId);
+      await grantOnboardingCredits(
+        tx,
+        args.orgId,
+        args.credits,
+        new Date(args.expiresAt ?? ONBOARDING_CREDITS_NEVER_EXPIRE_AT),
+      );
     });
     signal.throwIfAborted();
 

--- a/turbo/apps/platform/src/signals/prompt-page/prompt-page-setup.ts
+++ b/turbo/apps/platform/src/signals/prompt-page/prompt-page-setup.ts
@@ -1,7 +1,11 @@
 import { command } from "ccstate";
 import { isSupportedRunModel } from "@vm0/api-contracts/contracts/model-providers";
 import type { GenerationTemplateRequest } from "@vm0/api-contracts/contracts/chat-threads";
-import { findVideoTemplateItem } from "@vm0/core";
+import {
+  ILLUSTRATION_TEMPLATE_ITEMS,
+  PRESENTATION_TEMPLATE_PICKER_ITEMS,
+  findVideoTemplateItem,
+} from "@vm0/core";
 import { sendNewThreadOptimistically$ } from "../chat-page/optimistic-chat-thread-page.ts";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { orgModelPolicies$ } from "../external/org-model-policies.ts";
@@ -33,7 +37,47 @@ function generationTemplateFromSearchParam(
   }
   const videoTemplate = findVideoTemplateItem(id);
   if (!videoTemplate) {
-    return undefined;
+    const presentationTemplateId = id.replace(/^presentation-template:/, "");
+    const presentationTemplate = PRESENTATION_TEMPLATE_PICKER_ITEMS.find(
+      (item) => {
+        return (
+          item.slug === presentationTemplateId ||
+          item.templateId === id ||
+          item.templateId === presentationTemplateId
+        );
+      },
+    );
+    if (!presentationTemplate) {
+      const illustrationTemplateId = id
+        .replace(/^illustration-template:/, "")
+        .replace(/^image-template:/, "");
+      const illustrationTemplate = ILLUSTRATION_TEMPLATE_ITEMS.find((item) => {
+        return (
+          item.slug === illustrationTemplateId ||
+          item.illustrationStyleId === id ||
+          item.illustrationStyleId === illustrationTemplateId
+        );
+      });
+      if (!illustrationTemplate) {
+        return undefined;
+      }
+      return {
+        type: "illustration",
+        selection: {
+          illustrationStyleId: illustrationTemplate.illustrationStyleId,
+        },
+      };
+    }
+    return {
+      type: "presentation",
+      selection: {
+        colorSystemId:
+          presentationTemplate.colorSystemId ?? "color-system:warm-sand",
+        designSystemId: presentationTemplate.designSystemId,
+        templateId: presentationTemplate.templateId,
+        previewUrl: presentationTemplate.embedUrl,
+      },
+    };
   }
   return {
     type: "video",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/prompt-param-injection.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/prompt-param-injection.test.tsx
@@ -1,6 +1,10 @@
 import { screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { VIDEO_TEMPLATE_ITEMS } from "@vm0/core";
+import {
+  ILLUSTRATION_TEMPLATE_ITEMS,
+  PRESENTATION_TEMPLATE_PICKER_ITEMS,
+  VIDEO_TEMPLATE_ITEMS,
+} from "@vm0/core";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { mockChatLifecycle, PLACEHOLDER } from "./chat-test-helpers.ts";
@@ -83,6 +87,82 @@ describe("prompt query parameter injection", () => {
       expect(screen.getByText("Make a product spot")).toBeInTheDocument();
       expect(runPrompt).toBe("Make a product spot");
       expect(stylePresetId).toBe(videoTemplate?.id);
+    });
+  });
+
+  it("starts an optimistic presentation template chat from the prompt route", async () => {
+    const presentationTemplate = PRESENTATION_TEMPLATE_PICKER_ITEMS.find(
+      (item) => {
+        return item.slug === "playful-launch-presentation";
+      },
+    );
+    expect(presentationTemplate).toBeDefined();
+
+    let runPrompt: string | undefined;
+    let selection:
+      | {
+          colorSystemId?: string;
+          designSystemId: string;
+          templateId: string;
+          previewUrl?: string;
+        }
+      | undefined;
+    mockChatLifecycle(context, {
+      onRunCreate: (body) => {
+        runPrompt = body.prompt;
+        selection =
+          body.generationTemplate?.type === "presentation"
+            ? body.generationTemplate.selection
+            : undefined;
+      },
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/prompt?prompt=Make%20a%20launch%20deck&template=presentation-template%3Aplayful-launch-presentation",
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Make a launch deck")).toBeInTheDocument();
+      expect(runPrompt).toBe("Make a launch deck");
+      expect(selection).toMatchObject({
+        colorSystemId: presentationTemplate?.colorSystemId,
+        designSystemId: presentationTemplate?.designSystemId,
+        templateId: presentationTemplate?.templateId,
+        previewUrl: presentationTemplate?.embedUrl,
+      });
+    });
+  });
+
+  it("starts an optimistic illustration template chat from the prompt route", async () => {
+    const illustrationTemplate = ILLUSTRATION_TEMPLATE_ITEMS.find((item) => {
+      return item.slug === "sunlit-gouache";
+    });
+    expect(illustrationTemplate).toBeDefined();
+
+    let runPrompt: string | undefined;
+    let illustrationStyleId: string | undefined;
+    mockChatLifecycle(context, {
+      onRunCreate: (body) => {
+        runPrompt = body.prompt;
+        illustrationStyleId =
+          body.generationTemplate?.type === "illustration"
+            ? body.generationTemplate.selection.illustrationStyleId
+            : undefined;
+      },
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/prompt?prompt=Make%20a%20library%20scene&template=illustration-template%3Asunlit-gouache",
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Make a library scene")).toBeInTheDocument();
+      expect(runPrompt).toBe("Make a library scene");
+      expect(illustrationStyleId).toBe(
+        illustrationTemplate?.illustrationStyleId,
+      );
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-org-switcher.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-org-switcher.test.tsx
@@ -197,4 +197,62 @@ describe("zero org switcher", () => {
       });
     });
   });
+
+  it("bounds long workspace lists inside a scrollable menu region", async () => {
+    context.mocks.data.org({
+      id: "org_current",
+      name: "Current",
+      slug: "current",
+      role: "admin",
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/",
+      org: {
+        activeOrg: {
+          id: "org_current",
+          name: "Current",
+          slug: "current",
+        },
+        memberships: [
+          {
+            id: "membership_current",
+            organization: {
+              id: "org_current",
+              name: "Current",
+            },
+          },
+          ...Array.from({ length: 12 }, (_, index) => {
+            return {
+              id: `membership_${index}`,
+              organization: {
+                id: `org_${index}`,
+                name: `Workspace ${index + 1}`,
+              },
+            };
+          }),
+        ],
+      },
+    });
+
+    const orgSwitcher = await waitFor(() => {
+      const label = screen.getByText("Current");
+      const trigger = label.closest("button");
+      if (!trigger) {
+        throw new Error("Org switcher trigger not found");
+      }
+      return trigger;
+    });
+
+    click(orgSwitcher);
+
+    const scrollRegion = await screen.findByTestId(
+      "org-switcher-options-scroll",
+    );
+
+    expect(scrollRegion).toHaveClass("max-h-72");
+    expect(scrollRegion).toHaveClass("overflow-y-auto");
+    expect(screen.getByText("Workspace 12")).toBeInTheDocument();
+  });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-org-switcher.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-org-switcher.tsx
@@ -210,14 +210,25 @@ function OrgDropdownContent() {
   const clerk = clerkLoadable.state === "hasData" ? clerkLoadable.data : null;
   const orgName = currentOrg?.name ?? "Organization";
   const orgSlug = orgData?.slug;
+  const memberships = clerk?.user?.organizationMemberships ?? [];
+  const currentOrgId = clerk?.organization?.id;
 
   const hasPendingInvitations =
     pendingInvitations !== undefined && pendingInvitations.length > 0;
+  const hasOtherMemberships = memberships.some((membership) => {
+    return (
+      membership.organization && membership.organization.id !== currentOrgId
+    );
+  });
+  const hasOrgOptions = hasOtherMemberships || hasPendingInvitations;
   const canCreateOrg = clerk?.user?.createOrganizationEnabled ?? false;
 
   return (
-    <DropdownMenuContent align="start" className="w-72">
-      <div className="flex items-center gap-3 px-2 py-1.5">
+    <DropdownMenuContent
+      align="start"
+      className="flex max-h-[min(420px,var(--radix-dropdown-menu-content-available-height))] w-72 flex-col overflow-hidden"
+    >
+      <div className="flex shrink-0 items-center gap-3 px-2 py-1.5">
         <OrgAvatar name={orgName} imageUrl={currentOrg?.imageUrl} size="lg" />
         <div className="min-w-0 flex-1">
           <p className="text-sm font-semibold leading-tight truncate text-foreground">
@@ -231,21 +242,32 @@ function OrgDropdownContent() {
         </div>
       </div>
 
-      <OtherMembershipsList />
+      {hasOrgOptions && (
+        <div
+          data-testid="org-switcher-options-scroll"
+          className="min-h-0 max-h-72 flex-1 overflow-y-auto [scrollbar-gutter:stable]"
+        >
+          <OtherMembershipsList />
 
-      {/* Pending invitations */}
-      {hasPendingInvitations && (
-        <>
-          <DropdownMenuSeparator />
-          {pendingInvitations.map((invitation) => {
-            return (
-              <InvitationRow key={invitation.id} invitation={invitation} />
-            );
-          })}
-        </>
+          {/* Pending invitations */}
+          {hasPendingInvitations && (
+            <>
+              <DropdownMenuSeparator />
+              {pendingInvitations.map((invitation) => {
+                return (
+                  <InvitationRow key={invitation.id} invitation={invitation} />
+                );
+              })}
+            </>
+          )}
+        </div>
       )}
 
-      {canCreateOrg && <CreateWorkspaceItem />}
+      {canCreateOrg && (
+        <div className="shrink-0">
+          <CreateWorkspaceItem />
+        </div>
+      )}
     </DropdownMenuContent>
   );
 }

--- a/turbo/packages/api-contracts/src/contracts/onboarding.ts
+++ b/turbo/packages/api-contracts/src/contracts/onboarding.ts
@@ -73,7 +73,12 @@ export const onboardingCompleteLimitedFreeContract = c.router({
     method: "POST",
     path: "/api/zero/onboarding/complete-limited-free",
     headers: authHeadersSchema,
-    body: z.object({}).strict(),
+    body: z
+      .object({
+        credits: z.number().int().positive().max(1000).default(1000),
+        expiresAt: z.string().datetime().nullable().default(null),
+      })
+      .strict(),
     responses: {
       200: z.object({
         agentId: z.string(),


### PR DESCRIPTION
## Summary
- allow limited-free onboarding completion to accept credit amount and expiration inputs
- support presentation and illustration template ids on the `/prompt` route
- cap the VM0 org switcher menu and scroll long workspace/invitation lists

## Tests
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-org-switcher.test.tsx src/views/zero-page/__tests__/prompt-param-injection.test.tsx`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/auth-org-agents.bdd.test.ts`
- `pnpm -F @vm0/app lint`
- `pnpm -F api lint`
- `pnpm -F @vm0/app check-types`
- `pnpm -F api check-types`
- `pnpm -F @vm0/api-contracts check-types`
- pre-commit: `pnpm format`, `pnpm knip`, `pnpm check-types`
