### PR TITLE
fix: scope computer use authorization state to selected host

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/computer-use.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/computer-use.bdd.test.ts
@@ -255,6 +255,7 @@ describe("FILE-03 desktop computer-use runtime", () => {
     expect(readable).toMatchObject({
       source: "chat",
       completedAt: null,
+      computerUseHostId: null,
       hosts: [expect.objectContaining({ id: host.hostId })],
     });
 
@@ -281,6 +282,7 @@ describe("FILE-03 desktop computer-use runtime", () => {
       requestToken,
     );
     expect(completed.completedAt).not.toBeNull();
+    expect(completed.computerUseHostId).toBe(host.hostId);
   });
 
   it("only exposes online hosts for delegated authorization requests", async () => {

--- a/turbo/apps/api/src/signals/routes/zero-computer-use-authorization.ts
+++ b/turbo/apps/api/src/signals/routes/zero-computer-use-authorization.ts
@@ -176,6 +176,7 @@ const getAuthorizationRequestInner$ = command(
         source: result.source,
         expiresAt: result.expiresAt,
         completedAt: result.completedAt,
+        computerUseHostId: result.computerUseHostId,
         hosts: result.hosts,
       },
     };

--- a/turbo/apps/api/src/signals/services/zero-computer-use-authorization.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-computer-use-authorization.service.ts
@@ -62,6 +62,7 @@ type ReadComputerUseAuthorizationRequestResult =
       readonly source: ComputerUseAuthorizationSource;
       readonly expiresAt: string;
       readonly completedAt: string | null;
+      readonly computerUseHostId: string | null;
       readonly hosts: ComputerUseHostListResponse["hosts"];
     }
   | { readonly status: "not_found" }
@@ -233,6 +234,58 @@ async function onlineHostExists(args: {
   return host !== undefined && computerUseHostIsOnline(host, args.now);
 }
 
+async function loadAuthorizedComputerUseHostId(args: {
+  readonly db: Db;
+  readonly request: AuthorizationRequestRow;
+  readonly userId: string;
+}): Promise<string | null> {
+  if (!args.request.completedAt) {
+    return null;
+  }
+
+  if (args.request.source === "chat") {
+    const [thread] = await args.db
+      .select({ computerUseHostId: chatThreads.computerUseHostId })
+      .from(chatThreads)
+      .where(
+        and(
+          eq(chatThreads.id, args.request.chatThreadId ?? ""),
+          eq(chatThreads.userId, args.userId),
+        ),
+      )
+      .limit(1);
+    return thread?.computerUseHostId ?? null;
+  }
+
+  if (
+    args.request.source === "slack" &&
+    args.request.slackConnectionId &&
+    args.request.slackChannelId &&
+    args.request.slackThreadTs
+  ) {
+    const [threadSession] = await args.db
+      .select({ computerUseHostId: slackOrgThreadSessions.computerUseHostId })
+      .from(slackOrgThreadSessions)
+      .where(
+        and(
+          eq(
+            slackOrgThreadSessions.connectionId,
+            args.request.slackConnectionId,
+          ),
+          eq(
+            slackOrgThreadSessions.slackChannelId,
+            args.request.slackChannelId,
+          ),
+          eq(slackOrgThreadSessions.slackThreadTs, args.request.slackThreadTs),
+        ),
+      )
+      .limit(1);
+    return threadSession?.computerUseHostId ?? null;
+  }
+
+  return null;
+}
+
 async function slackScopeExists(args: {
   readonly db: Db;
   readonly orgId: string;
@@ -337,6 +390,13 @@ export const readComputerUseAuthorizationRequest$ = command(
       return loaded;
     }
 
+    const computerUseHostId = await loadAuthorizedComputerUseHostId({
+      db,
+      request: loaded.request,
+      userId: args.userId,
+    });
+    signal.throwIfAborted();
+
     const hosts = await set(
       listComputerUseHosts$,
       { orgId: args.orgId, userId: args.userId },
@@ -349,6 +409,7 @@ export const readComputerUseAuthorizationRequest$ = command(
       source: loaded.request.source as ComputerUseAuthorizationSource,
       expiresAt: loaded.request.expiresAt.toISOString(),
       completedAt: loaded.request.completedAt?.toISOString() ?? null,
+      computerUseHostId,
       hosts: hosts.hosts.filter((host) => {
         return host.status === "online";
       }),

--- a/turbo/apps/platform/src/views/computer-use-authorization/__tests__/computer-use-authorization-page.test.tsx
+++ b/turbo/apps/platform/src/views/computer-use-authorization/__tests__/computer-use-authorization-page.test.tsx
@@ -33,6 +33,7 @@ describe("computer use authorization page", () => {
   it("shows only online hosts and applies the selected host", async () => {
     const user = userEvent.setup({ delay: null });
     let appliedHostId: string | null = null;
+    let completedHostId: string | null = null;
 
     context.mocks.api(
       zeroComputerUseAuthorizationRequestsContract.get,
@@ -40,11 +41,17 @@ describe("computer use authorization page", () => {
         return respond(200, {
           source: "chat",
           expiresAt: "2026-06-25T12:00:00Z",
-          completedAt: null,
+          completedAt: completedHostId ? "2026-06-25T11:00:00Z" : null,
+          computerUseHostId: completedHostId,
           hosts: [
             computerUseHost({
               id: "00000000-0000-4000-a000-000000000001",
               displayName: "Studio Mac",
+              status: "online",
+            }),
+            computerUseHost({
+              id: "00000000-0000-4000-a000-000000000004",
+              displayName: "Travel Mac",
               status: "online",
             }),
             computerUseHost({
@@ -60,6 +67,7 @@ describe("computer use authorization page", () => {
       zeroComputerUseAuthorizationRequestsContract.apply,
       ({ body, respond }) => {
         appliedHostId = body.computerUseHostId;
+        completedHostId = body.computerUseHostId;
         return respond(200, {
           ok: true,
           source: "chat",
@@ -82,6 +90,7 @@ describe("computer use authorization page", () => {
       ),
     ).toBeInTheDocument();
     await expect(screen.findByText("Studio Mac")).resolves.toBeInTheDocument();
+    expect(screen.getByText("Travel Mac")).toBeInTheDocument();
     expect(screen.queryByText("Offline Desktop")).not.toBeInTheDocument();
 
     const authorizeButton = queryAllByRoleFast("button").find((button) => {
@@ -93,6 +102,24 @@ describe("computer use authorization page", () => {
     await waitFor(() => {
       expect(appliedHostId).toBe("00000000-0000-4000-a000-000000000001");
     });
+    await waitFor(() => {
+      expect(
+        queryAllByRoleFast("button").filter((button) => {
+          return button.textContent === "Authorized";
+        }),
+      ).toHaveLength(1);
+    });
+    const authorizedButton = queryAllByRoleFast("button").find((button) => {
+      return button.textContent === "Authorized";
+    });
+    expect(authorizedButton).toBeDisabled();
+    const remainingAuthorizeButtons = queryAllByRoleFast("button").filter(
+      (button) => {
+        return button.textContent === "Authorize";
+      },
+    );
+    expect(remainingAuthorizeButtons).toHaveLength(1);
+    expect(remainingAuthorizeButtons[0]).toBeDisabled();
   });
 
   it("shows desktop guidance when there are no online hosts", async () => {
@@ -103,6 +130,7 @@ describe("computer use authorization page", () => {
           source: "slack",
           expiresAt: "2026-06-25T12:00:00Z",
           completedAt: null,
+          computerUseHostId: null,
           hosts: [
             computerUseHost({
               id: "00000000-0000-4000-a000-000000000003",

--- a/turbo/apps/platform/src/views/computer-use-authorization/computer-use-authorization-page.tsx
+++ b/turbo/apps/platform/src/views/computer-use-authorization/computer-use-authorization-page.tsx
@@ -141,7 +141,11 @@ export function ComputerUseAuthorizationPage() {
   const request =
     requestLoadable.state === "hasData" ? requestLoadable.data : null;
   const hosts = request?.hosts;
-  const visibleHosts = visibleComputerUseHosts(hosts ?? [], null);
+  const selectedHostId =
+    applyLoadable.state === "hasData"
+      ? applyLoadable.data.computerUseHostId
+      : (request?.computerUseHostId ?? null);
+  const visibleHosts = visibleComputerUseHosts(hosts ?? [], selectedHostId);
 
   if (requestLoadable.state === "loading") {
     return (
@@ -156,7 +160,7 @@ export function ComputerUseAuthorizationPage() {
   }
 
   const applying = applyLoadable.state === "loading";
-  const applied =
+  const completed =
     applyLoadable.state === "hasData" || Boolean(request.completedAt);
 
   return (
@@ -187,9 +191,9 @@ export function ComputerUseAuthorizationPage() {
                 <HostOption
                   key={host.id}
                   host={host}
-                  disabled={applying || applied}
+                  disabled={applying || completed}
                   applying={applying}
-                  applied={applied}
+                  applied={selectedHostId === host.id}
                   onAuthorize={() => {
                     detach(
                       applyAuthorization(host, pageSignal),

--- a/turbo/packages/api-contracts/src/contracts/zero-computer-use.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-computer-use.ts
@@ -408,6 +408,7 @@ export const computerUseAuthorizationRequestResponseSchema = z.object({
   source: computerUseAuthorizationSourceSchema,
   expiresAt: z.string(),
   completedAt: z.string().nullable(),
+  computerUseHostId: z.string().uuid().nullable(),
   hosts: z.array(computerUseHostSchema),
 });
 


### PR DESCRIPTION
## Summary

- Include the selected `computerUseHostId` when reading completed Computer Use authorization requests.
- Render `Authorized` only for the selected host card instead of treating completion as a page-wide card state.
- Add frontend and API coverage for multi-host authorization state.

Fixes #19060

## Verification

- `pnpm format`
- `pnpm -F @vm0/app lint`
- `pnpm -F api lint`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/app check-types`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm exec vitest run apps/platform/src/views/computer-use-authorization/__tests__/computer-use-authorization-page.test.tsx`
- `DATABASE_URL="postgresql://postgres@localhost:5432/vm0_test" pnpm exec vitest run apps/api/src/signals/routes/__tests__/computer-use.bdd.test.ts`

Note: full `pnpm turbo run lint --log-order grouped` was attempted after the fixes, but the API type-aware linter subprocess was SIGKILLed in this runtime. The affected single-package lint commands above passed.