### PR TITLE
docs: add axiom firewall permission descriptions

### DIFF
--- a/crates/runner/mitm-addon/src/generated/builtin_firewalls/axiom_0.py
+++ b/crates/runner/mitm-addon/src/generated/builtin_firewalls/axiom_0.py
@@ -14,18 +14,21 @@ JSON_PART = r"""{
       "base": "https://api.axiom.co",
       "permissions": [
         {
+          "description": "Create Axiom annotations.",
           "name": "annotations|create",
           "rules": [
             "POST /v2/annotations"
           ]
         },
         {
+          "description": "Delete Axiom annotations.",
           "name": "annotations|delete",
           "rules": [
             "DELETE /v2/annotations/{id}"
           ]
         },
         {
+          "description": "Read Axiom annotations.",
           "name": "annotations|read",
           "rules": [
             "GET /v2/annotations",
@@ -33,24 +36,28 @@ JSON_PART = r"""{
           ]
         },
         {
+          "description": "Update Axiom annotations.",
           "name": "annotations|update",
           "rules": [
             "PUT /v2/annotations/{id}"
           ]
         },
         {
+          "description": "Create Axiom API tokens.",
           "name": "apiTokens|create",
           "rules": [
             "POST /v2/tokens"
           ]
         },
         {
+          "description": "Delete Axiom API tokens.",
           "name": "apiTokens|delete",
           "rules": [
             "DELETE /v2/tokens/{id}"
           ]
         },
         {
+          "description": "Read Axiom API tokens and token metadata.",
           "name": "apiTokens|read",
           "rules": [
             "GET /v2/tokens",
@@ -58,24 +65,28 @@ JSON_PART = r"""{
           ]
         },
         {
+          "description": "Regenerate Axiom API tokens.",
           "name": "apiTokens|update",
           "rules": [
             "POST /v2/tokens/{id}/regenerate"
           ]
         },
         {
+          "description": "Create Axiom dashboards.",
           "name": "dashboards|create",
           "rules": [
             "POST /v2/dashboards"
           ]
         },
         {
+          "description": "Delete Axiom dashboards.",
           "name": "dashboards|delete",
           "rules": [
             "DELETE /v2/dashboards/uid/{uid}"
           ]
         },
         {
+          "description": "Read Axiom dashboards.",
           "name": "dashboards|read",
           "rules": [
             "GET /v2/dashboards",
@@ -83,6 +94,7 @@ JSON_PART = r"""{
           ]
         },
         {
+          "description": "Update Axiom dashboards and dashboard charts.",
           "name": "dashboards|update",
           "rules": [
             "PUT /v2/dashboards/uid/{uid}",
@@ -90,18 +102,21 @@ JSON_PART = r"""{
           ]
         },
         {
+          "description": "Create Axiom datasets.",
           "name": "datasets|create",
           "rules": [
             "POST /v2/datasets"
           ]
         },
         {
+          "description": "Delete Axiom datasets.",
           "name": "datasets|delete",
           "rules": [
             "DELETE /v2/datasets/{dataset_id}"
           ]
         },
         {
+          "description": "Read Axiom datasets, fields, and map fields.",
           "name": "datasets|read",
           "rules": [
             "GET /v1/datasets",
@@ -114,6 +129,7 @@ JSON_PART = r"""{
           ]
         },
         {
+          "description": "Create, update, delete, and trim Axiom datasets, fields, and map fields.",
           "name": "datasets|update",
           "rules": [
             "POST /v1/datasets",
@@ -128,6 +144,7 @@ JSON_PART = r"""{
           ]
         },
         {
+          "description": "Ingest events into Axiom datasets.",
           "name": "ingest|create",
           "rules": [
             "POST /v1/datasets/{dataset_name}/ingest",
@@ -135,18 +152,21 @@ JSON_PART = r"""{
           ]
         },
         {
+          "description": "Create Axiom monitors.",
           "name": "monitors|create",
           "rules": [
             "POST /v2/monitors"
           ]
         },
         {
+          "description": "Delete Axiom monitors.",
           "name": "monitors|delete",
           "rules": [
             "DELETE /v2/monitors/{id}"
           ]
         },
         {
+          "description": "Read Axiom monitors and monitor history.",
           "name": "monitors|read",
           "rules": [
             "GET /v2/monitors",
@@ -155,24 +175,28 @@ JSON_PART = r"""{
           ]
         },
         {
+          "description": "Update Axiom monitors.",
           "name": "monitors|update",
           "rules": [
             "PUT /v2/monitors/{id}"
           ]
         },
         {
+          "description": "Create Axiom notifiers.",
           "name": "notifiers|create",
           "rules": [
             "POST /v2/notifiers"
           ]
         },
         {
+          "description": "Delete Axiom notifiers.",
           "name": "notifiers|delete",
           "rules": [
             "DELETE /v2/notifiers/{id}"
           ]
         },
         {
+          "description": "Read Axiom notifiers.",
           "name": "notifiers|read",
           "rules": [
             "GET /v2/notifiers",
@@ -180,18 +204,21 @@ JSON_PART = r"""{
           ]
         },
         {
+          "description": "Update Axiom notifiers.",
           "name": "notifiers|update",
           "rules": [
             "PUT /v2/notifiers/{id}"
           ]
         },
         {
+          "description": "Create Axiom organizations.",
           "name": "orgs|create",
           "rules": [
             "POST /v2/orgs"
           ]
         },
         {
+          "description": "Read Axiom organizations.",
           "name": "orgs|read",
           "rules": [
             "GET /v2/orgs",
@@ -199,12 +226,14 @@ JSON_PART = r"""{
           ]
         },
         {
+          "description": "Update Axiom organizations.",
           "name": "orgs|update",
           "rules": [
             "PUT /v2/orgs/{id}"
           ]
         },
         {
+          "description": "Run Axiom queries and read query results.",
           "name": "query|read",
           "rules": [
             "POST /v1/datasets/_apl",
@@ -221,6 +250,7 @@ JSON_PART = r"""{
           ]
         },
         {
+          "description": "Create, update, and delete Axiom RBAC groups and roles.",
           "name": "rbac|create",
           "rules": [
             "POST /v2/rbac/groups",
@@ -232,6 +262,7 @@ JSON_PART = r"""{
           ]
         },
         {
+          "description": "Read Axiom RBAC groups and roles.",
           "name": "rbac|read",
           "rules": [
             "GET /v2/rbac/groups",
@@ -241,18 +272,21 @@ JSON_PART = r"""{
           ]
         },
         {
+          "description": "Create Axiom starred queries.",
           "name": "starredQueries|create",
           "rules": [
             "POST /v2/apl-starred-queries"
           ]
         },
         {
+          "description": "Delete Axiom starred queries.",
           "name": "starredQueries|delete",
           "rules": [
             "DELETE /v2/apl-starred-queries/{id}"
           ]
         },
         {
+          "description": "Read Axiom starred queries.",
           "name": "starredQueries|read",
           "rules": [
             "GET /v2/apl-starred-queries",
@@ -260,30 +294,35 @@ JSON_PART = r"""{
           ]
         },
         {
+          "description": "Update Axiom starred queries.",
           "name": "starredQueries|update",
           "rules": [
             "PUT /v2/apl-starred-queries/{id}"
           ]
         },
         {
+          "description": "Trim data from Axiom datasets.",
           "name": "trim|update",
           "rules": [
             "POST /v2/datasets/{dataset_id}/trim"
           ]
         },
         {
+          "description": "Create Axiom users.",
           "name": "users|create",
           "rules": [
             "POST /v2/users"
           ]
         },
         {
+          "description": "Delete Axiom users.",
           "name": "users|delete",
           "rules": [
             "DELETE /v2/users/{id}"
           ]
         },
         {
+          "description": "Read Axiom users and current user information.",
           "name": "users|read",
           "rules": [
             "GET /v1/user",
@@ -293,6 +332,7 @@ JSON_PART = r"""{
           ]
         },
         {
+          "description": "Update Axiom current user information and user roles.",
           "name": "users|update",
           "rules": [
             "PUT /v2/user",
@@ -300,24 +340,28 @@ JSON_PART = r"""{
           ]
         },
         {
+          "description": "Start Axiom dataset vacuum operations.",
           "name": "vacuum|update",
           "rules": [
             "POST /v2/datasets/{dataset_id}/vacuum"
           ]
         },
         {
+          "description": "Create Axiom views.",
           "name": "views|create",
           "rules": [
             "POST /v2/views"
           ]
         },
         {
+          "description": "Delete Axiom views.",
           "name": "views|delete",
           "rules": [
             "DELETE /v2/views/{id}"
           ]
         },
         {
+          "description": "Read Axiom views.",
           "name": "views|read",
           "rules": [
             "GET /v2/views",
@@ -325,24 +369,28 @@ JSON_PART = r"""{
           ]
         },
         {
+          "description": "Update Axiom views.",
           "name": "views|update",
           "rules": [
             "PUT /v2/views/{id}"
           ]
         },
         {
+          "description": "Create Axiom virtual fields.",
           "name": "virtualFields|create",
           "rules": [
             "POST /v2/vfields"
           ]
         },
         {
+          "description": "Delete Axiom virtual fields.",
           "name": "virtualFields|delete",
           "rules": [
             "DELETE /v2/vfields/{id}"
           ]
         },
         {
+          "description": "Read Axiom virtual fields.",
           "name": "virtualFields|read",
           "rules": [
             "GET /v2/vfields",
@@ -350,6 +398,7 @@ JSON_PART = r"""{
           ]
         },
         {
+          "description": "Update Axiom virtual fields.",
           "name": "virtualFields|update",
           "rules": [
             "PUT /v2/vfields/{id}"

--- a/turbo/packages/firewalls-generator/src/__tests__/codegen.test.ts
+++ b/turbo/packages/firewalls-generator/src/__tests__/codegen.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+
+import { applyPermissionDescriptions } from "../codegen";
+import type { PermissionGroup } from "../codegen";
+
+describe("applyPermissionDescriptions", () => {
+  it("attaches descriptions without changing permission order or rules", () => {
+    const permissions: PermissionGroup[] = [
+      {
+        name: "tokens.read",
+        rules: ["GET /tokens"],
+      },
+      {
+        name: "tokens.update",
+        rules: ["POST /tokens/{id}/regenerate"],
+      },
+    ];
+
+    expect(
+      applyPermissionDescriptions("Test API", permissions, {
+        "tokens.read": "Read API tokens.",
+        "tokens.update": "Regenerate API tokens.",
+      }),
+    ).toStrictEqual([
+      {
+        name: "tokens.read",
+        description: "Read API tokens.",
+        rules: ["GET /tokens"],
+      },
+      {
+        name: "tokens.update",
+        description: "Regenerate API tokens.",
+        rules: ["POST /tokens/{id}/regenerate"],
+      },
+    ]);
+    expect(permissions).toStrictEqual([
+      {
+        name: "tokens.read",
+        rules: ["GET /tokens"],
+      },
+      {
+        name: "tokens.update",
+        rules: ["POST /tokens/{id}/regenerate"],
+      },
+    ]);
+  });
+
+  it("fails when a rule-bearing permission has no description", () => {
+    expect(() => {
+      applyPermissionDescriptions(
+        "Test API",
+        [
+          {
+            name: "tokens.read",
+            rules: ["GET /tokens"],
+          },
+          {
+            name: "tokens.update",
+            rules: ["POST /tokens/{id}/regenerate"],
+          },
+        ],
+        {
+          "tokens.read": "Read API tokens.",
+        },
+      );
+    }).toThrowErrorMatchingInlineSnapshot(`
+      [Error: Test API permissions missing descriptions:
+      tokens.update]
+    `);
+  });
+
+  it("treats blank descriptions as missing", () => {
+    expect(() => {
+      applyPermissionDescriptions(
+        "Test API",
+        [
+          {
+            name: "tokens.read",
+            rules: ["GET /tokens"],
+          },
+        ],
+        {
+          "tokens.read": " ",
+        },
+      );
+    }).toThrowErrorMatchingInlineSnapshot(`
+      [Error: Test API permissions missing descriptions:
+      tokens.read]
+    `);
+  });
+
+  it("fails when the description map has stale permission names", () => {
+    expect(() => {
+      applyPermissionDescriptions(
+        "Test API",
+        [
+          {
+            name: "tokens.read",
+            rules: ["GET /tokens"],
+          },
+        ],
+        {
+          "tokens.read": "Read API tokens.",
+          "tokens.update": "Regenerate API tokens.",
+        },
+      );
+    }).toThrowErrorMatchingInlineSnapshot(`
+      [Error: Test API permission descriptions reference unknown permissions:
+      tokens.update]
+    `);
+  });
+
+  it("does not require descriptions for permissions without rules", () => {
+    expect(
+      applyPermissionDescriptions(
+        "Test API",
+        [
+          {
+            name: "tokens.read",
+            rules: [],
+          },
+        ],
+        {},
+      ),
+    ).toStrictEqual([
+      {
+        name: "tokens.read",
+        rules: [],
+      },
+    ]);
+  });
+});

--- a/turbo/packages/firewalls-generator/src/axiom.ts
+++ b/turbo/packages/firewalls-generator/src/axiom.ts
@@ -16,6 +16,7 @@
 
 import {
   ALL_METHODS,
+  applyPermissionDescriptions,
   fetchSpec,
   logStats,
   renderPermissions,
@@ -33,6 +34,59 @@ const SPEC_URLS = [
 
 // Format: xaat- prefix + UUID (8-4-4-4-12 hex) = 41 total
 const PLACEHOLDER_VALUE = "xaat-c0ffee5a-fe10-ca1c-0ffe-e5afe10ca1c0";
+
+const AXIOM_SCOPE_DESCRIPTIONS: Readonly<Record<string, string>> = {
+  "annotations|create": "Create Axiom annotations.",
+  "annotations|delete": "Delete Axiom annotations.",
+  "annotations|read": "Read Axiom annotations.",
+  "annotations|update": "Update Axiom annotations.",
+  "apiTokens|create": "Create Axiom API tokens.",
+  "apiTokens|delete": "Delete Axiom API tokens.",
+  "apiTokens|read": "Read Axiom API tokens and token metadata.",
+  "apiTokens|update": "Regenerate Axiom API tokens.",
+  "dashboards|create": "Create Axiom dashboards.",
+  "dashboards|delete": "Delete Axiom dashboards.",
+  "dashboards|read": "Read Axiom dashboards.",
+  "dashboards|update": "Update Axiom dashboards and dashboard charts.",
+  "datasets|create": "Create Axiom datasets.",
+  "datasets|delete": "Delete Axiom datasets.",
+  "datasets|read": "Read Axiom datasets, fields, and map fields.",
+  "datasets|update":
+    "Create, update, delete, and trim Axiom datasets, fields, and map fields.",
+  "ingest|create": "Ingest events into Axiom datasets.",
+  "monitors|create": "Create Axiom monitors.",
+  "monitors|delete": "Delete Axiom monitors.",
+  "monitors|read": "Read Axiom monitors and monitor history.",
+  "monitors|update": "Update Axiom monitors.",
+  "notifiers|create": "Create Axiom notifiers.",
+  "notifiers|delete": "Delete Axiom notifiers.",
+  "notifiers|read": "Read Axiom notifiers.",
+  "notifiers|update": "Update Axiom notifiers.",
+  "orgs|create": "Create Axiom organizations.",
+  "orgs|read": "Read Axiom organizations.",
+  "orgs|update": "Update Axiom organizations.",
+  "query|read": "Run Axiom queries and read query results.",
+  "rbac|create": "Create, update, and delete Axiom RBAC groups and roles.",
+  "rbac|read": "Read Axiom RBAC groups and roles.",
+  "starredQueries|create": "Create Axiom starred queries.",
+  "starredQueries|delete": "Delete Axiom starred queries.",
+  "starredQueries|read": "Read Axiom starred queries.",
+  "starredQueries|update": "Update Axiom starred queries.",
+  "trim|update": "Trim data from Axiom datasets.",
+  "users|create": "Create Axiom users.",
+  "users|delete": "Delete Axiom users.",
+  "users|read": "Read Axiom users and current user information.",
+  "users|update": "Update Axiom current user information and user roles.",
+  "vacuum|update": "Start Axiom dataset vacuum operations.",
+  "views|create": "Create Axiom views.",
+  "views|delete": "Delete Axiom views.",
+  "views|read": "Read Axiom views.",
+  "views|update": "Update Axiom views.",
+  "virtualFields|create": "Create Axiom virtual fields.",
+  "virtualFields|delete": "Delete Axiom virtual fields.",
+  "virtualFields|read": "Read Axiom virtual fields.",
+  "virtualFields|update": "Update Axiom virtual fields.",
+};
 
 // ── OpenAPI types ────────────────────────────────────────────────────────
 
@@ -227,7 +281,11 @@ export async function generate(): Promise<void> {
     }),
   );
 
-  const permissions = buildGroups(fetched);
+  const permissions = applyPermissionDescriptions(
+    "Axiom",
+    buildGroups(fetched),
+    AXIOM_SCOPE_DESCRIPTIONS,
+  );
   const ts = generateTypeScript(permissions);
 
   logStats(permissions);

--- a/turbo/packages/firewalls-generator/src/codegen.ts
+++ b/turbo/packages/firewalls-generator/src/codegen.ts
@@ -139,6 +139,52 @@ export function escapeString(s: string): string {
   return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }
 
+function sortedStrings(values: Iterable<string>): string[] {
+  return [...values].sort((a, b) => a.localeCompare(b));
+}
+
+export function applyPermissionDescriptions(
+  serviceLabel: string,
+  permissions: readonly PermissionGroup[],
+  descriptions: Readonly<Record<string, string>>,
+): PermissionGroup[] {
+  const permissionNames = new Set(
+    permissions.map((permission) => permission.name),
+  );
+  const staleDescriptions = sortedStrings(
+    Object.keys(descriptions).filter((name) => !permissionNames.has(name)),
+  );
+  const missingDescriptions: string[] = [];
+
+  const result = permissions.map((permission) => {
+    const description = descriptions[permission.name]?.trim();
+    if (permission.rules.length > 0 && !description) {
+      missingDescriptions.push(permission.name);
+    }
+    return {
+      ...permission,
+      ...(description ? { description } : {}),
+    };
+  });
+
+  const messages: string[] = [];
+  if (missingDescriptions.length > 0) {
+    messages.push(
+      `${serviceLabel} permissions missing descriptions:\n${sortedStrings(missingDescriptions).join("\n")}`,
+    );
+  }
+  if (staleDescriptions.length > 0) {
+    messages.push(
+      `${serviceLabel} permission descriptions reference unknown permissions:\n${staleDescriptions.join("\n")}`,
+    );
+  }
+  if (messages.length > 0) {
+    throw new Error(messages.join("\n\n"));
+  }
+
+  return result;
+}
+
 // ── TypeScript rendering ─────────────────────────────────────────────────
 
 /**


### PR DESCRIPTION
## Summary
- Add curated descriptions for every generated Axiom firewall permission.
- Add a generator helper that fails when rule-bearing permissions are missing descriptions or when description maps go stale.
- Regenerate the Python builtin firewall catalog.

The Axiom permission descriptions are vm0-curated from the generated scope names and route coverage; they are not provider-authored text.

Closes #19048

## Tests
- pnpm format
- pnpm lint
- pnpm check-types
- pnpm knip
- pnpm -F @vm0/firewalls-generator exec vitest
- pnpm vitest