### PR TITLE
perf: split create-run connector context timing

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -123,6 +123,35 @@ const API_DISPATCH_TIMING_ACTION_TYPES = [
   "api_dispatch_prepare_storage_manifest",
   "api_dispatch_build_stored_execution_context",
 ] as const;
+const API_DISPATCH_STORED_CONNECTOR_ROW_ACTION_TYPES = [
+  "api_dispatch_prepare_context_load_stored_connector_rows",
+  "api_dispatch_prepare_context_filter_stored_connector_rows",
+  "api_dispatch_prepare_context_build_stored_connector_state",
+] as const;
+const API_DISPATCH_STORED_CONNECTOR_SECRET_ACTION_TYPES = [
+  "api_dispatch_prepare_context_load_stored_connector_secret_rows",
+  "api_dispatch_prepare_context_decrypt_stored_connector_secrets",
+] as const;
+const API_DISPATCH_STORED_CONNECTOR_VARIABLE_ACTION_TYPES = [
+  "api_dispatch_prepare_context_load_stored_connector_variable_rows",
+] as const;
+const API_DISPATCH_STORED_CONNECTOR_SUBSTEP_ACTION_TYPES = [
+  ...API_DISPATCH_STORED_CONNECTOR_ROW_ACTION_TYPES,
+  ...API_DISPATCH_STORED_CONNECTOR_SECRET_ACTION_TYPES,
+  ...API_DISPATCH_STORED_CONNECTOR_VARIABLE_ACTION_TYPES,
+] as const;
+const API_DISPATCH_CUSTOM_CONNECTOR_SUBSTEP_ACTION_TYPES = [
+  "api_dispatch_prepare_context_load_custom_connector_rows",
+  "api_dispatch_prepare_context_load_custom_connector_value_rows",
+  "api_dispatch_prepare_context_build_custom_connector_firewalls",
+] as const;
+const API_DISPATCH_PERMISSION_MANIFEST_SUBSTEP_ACTION_TYPES = [
+  "api_dispatch_prepare_context_load_builtin_permission_indexes",
+  "api_dispatch_prepare_context_apply_builtin_permission_policies",
+  "api_dispatch_prepare_context_apply_custom_permission_policies",
+  "api_dispatch_prepare_context_apply_model_provider_permission_policy",
+  "api_dispatch_prepare_context_merge_permission_manifest",
+] as const;
 const API_DISPATCH_RESOLVE_COMPOSE_PATH_ACTION_TYPES = [
   "api_dispatch_resolve_compose_by_compose_id",
   "api_dispatch_resolve_compose_by_version_id",
@@ -359,6 +388,21 @@ function expectNoApiDispatchActions(
   }
 }
 
+function expectApiDispatchTimingEventsNotToLeak(
+  events: readonly Record<string, unknown>[],
+  forbiddenValues: readonly string[],
+): void {
+  for (const event of events) {
+    for (const forbiddenKey of FORBIDDEN_API_DISPATCH_TIMING_KEYS) {
+      expect(event).not.toHaveProperty(forbiddenKey);
+    }
+    const serialized = JSON.stringify(event);
+    for (const forbiddenValue of forbiddenValues) {
+      expect(serialized).not.toContain(forbiddenValue);
+    }
+  }
+}
+
 function mockSessionHistoryBlob(hash: string, history: string): void {
   context.mocks.s3.send.mockImplementation((command: unknown) => {
     const input = (command as { readonly input?: { readonly Key?: string } })
@@ -483,6 +527,10 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
 
     const timingEvents = apiDispatchTimingEventsForRun(created.runId);
     expectApiDispatchActions(timingEvents, API_DISPATCH_TIMING_ACTION_TYPES);
+    expectApiDispatchActions(
+      timingEvents,
+      API_DISPATCH_PERMISSION_MANIFEST_SUBSTEP_ACTION_TYPES,
+    );
     expectApiDispatchActions(timingEvents, [
       "api_dispatch_resolve_compose_by_compose_id",
       "api_dispatch_resolve_compose_lookup_compose",
@@ -539,13 +587,8 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       expect(event.duration_ms).toStrictEqual(expect.any(Number));
       expect(Number(event.duration_ms)).toBeGreaterThanOrEqual(0);
       expect(["top_level", "nested"]).toContain(event.span_kind);
-      for (const forbiddenKey of FORBIDDEN_API_DISPATCH_TIMING_KEYS) {
-        expect(event).not.toHaveProperty(forbiddenKey);
-      }
-      const serialized = JSON.stringify(event);
-      expect(serialized).not.toContain(prompt);
-      expect(serialized).not.toContain(agentId);
     }
+    expectApiDispatchTimingEventsNotToLeak(timingEvents, [prompt, agentId]);
   });
 
   it("emits compose resolution timing for direct compose version runs", async () => {
@@ -1409,6 +1452,15 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
       prompt: "run without enabled stored connectors",
       modelProvider: "anthropic-api-key",
     });
+    const timingEvents = apiDispatchTimingEventsForRun(run.runId);
+    expectNoApiDispatchActions(
+      timingEvents,
+      API_DISPATCH_STORED_CONNECTOR_SUBSTEP_ACTION_TYPES,
+    );
+    expectNoApiDispatchActions(
+      timingEvents,
+      API_DISPATCH_CUSTOM_CONNECTOR_SUBSTEP_ACTION_TYPES,
+    );
     await api.heartbeatRunner(runnerGroup);
     const claim = await api.claimRunnerJob(run.runId);
 
@@ -1447,6 +1499,19 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
       prompt: "use the x connector",
       modelProvider: "anthropic-api-key",
     });
+    const timingEvents = apiDispatchTimingEventsForRun(run.runId);
+    expectApiDispatchActions(
+      timingEvents,
+      API_DISPATCH_STORED_CONNECTOR_ROW_ACTION_TYPES,
+    );
+    expectApiDispatchActions(
+      timingEvents,
+      API_DISPATCH_STORED_CONNECTOR_SECRET_ACTION_TYPES,
+    );
+    expectNoApiDispatchActions(
+      timingEvents,
+      API_DISPATCH_STORED_CONNECTOR_VARIABLE_ACTION_TYPES,
+    );
     await api.heartbeatRunner(runnerGroup);
     const claim = await api.claimRunnerJob(run.runId);
 
@@ -1537,6 +1602,19 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
       prompt: "use gitlab with the optional host",
       modelProvider: "anthropic-api-key",
     });
+    const timingEvents = apiDispatchTimingEventsForRun(withHost.runId);
+    expectApiDispatchActions(
+      timingEvents,
+      API_DISPATCH_STORED_CONNECTOR_ROW_ACTION_TYPES,
+    );
+    expectApiDispatchActions(
+      timingEvents,
+      API_DISPATCH_STORED_CONNECTOR_SECRET_ACTION_TYPES,
+    );
+    expectApiDispatchActions(
+      timingEvents,
+      API_DISPATCH_STORED_CONNECTOR_VARIABLE_ACTION_TYPES,
+    );
     const hostClaim = await api.claimRunnerJob(withHost.runId);
     expect(hostClaim.environment?.GITLAB_TOKEN).toBe(
       connectorPlaceholder("gitlab", "GITLAB_TOKEN"),
@@ -1784,6 +1862,20 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       prompt: "use the custom connector",
       modelProvider: "anthropic-api-key",
     });
+    const timingEvents = apiDispatchTimingEventsForRun(run.runId);
+    expectApiDispatchActions(
+      timingEvents,
+      API_DISPATCH_CUSTOM_CONNECTOR_SUBSTEP_ACTION_TYPES,
+    );
+    expectApiDispatchActions(
+      timingEvents,
+      API_DISPATCH_PERMISSION_MANIFEST_SUBSTEP_ACTION_TYPES,
+    );
+    expectApiDispatchTimingEventsNotToLeak(timingEvents, [
+      custom.id,
+      slug,
+      "custom-secret-value",
+    ]);
     await api.heartbeatRunner(runnerGroup);
     const claim = await api.claimRunnerJob(run.runId);
 
@@ -2214,6 +2306,19 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       agentComposeId: compose.composeId,
       prompt: "direct run cloudflare defaults",
     });
+    const timingEvents = apiDispatchTimingEventsForRun(run.runId);
+    expectApiDispatchActions(
+      timingEvents,
+      API_DISPATCH_STORED_CONNECTOR_ROW_ACTION_TYPES,
+    );
+    expectApiDispatchActions(
+      timingEvents,
+      API_DISPATCH_STORED_CONNECTOR_SECRET_ACTION_TYPES,
+    );
+    expectApiDispatchActions(
+      timingEvents,
+      API_DISPATCH_PERMISSION_MANIFEST_SUBSTEP_ACTION_TYPES,
+    );
     await api.heartbeatRunner(runnerGroup);
     const claim = await api.claimRunnerJob(run.runId);
     expect(claim.environment?.CLOUDFLARE_TOKEN).toBe(

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -188,8 +188,22 @@ type ApiDispatchTimingActionType =
   | "api_dispatch_prepare_context_resolve_model_provider"
   | "api_dispatch_prepare_context_load_connector_contexts"
   | "api_dispatch_prepare_context_load_stored_connectors"
+  | "api_dispatch_prepare_context_load_stored_connector_rows"
+  | "api_dispatch_prepare_context_filter_stored_connector_rows"
+  | "api_dispatch_prepare_context_load_stored_connector_secret_rows"
+  | "api_dispatch_prepare_context_decrypt_stored_connector_secrets"
+  | "api_dispatch_prepare_context_load_stored_connector_variable_rows"
+  | "api_dispatch_prepare_context_build_stored_connector_state"
   | "api_dispatch_prepare_context_load_custom_connectors"
+  | "api_dispatch_prepare_context_load_custom_connector_rows"
+  | "api_dispatch_prepare_context_load_custom_connector_value_rows"
+  | "api_dispatch_prepare_context_build_custom_connector_firewalls"
   | "api_dispatch_prepare_context_build_permission_manifest"
+  | "api_dispatch_prepare_context_load_builtin_permission_indexes"
+  | "api_dispatch_prepare_context_apply_builtin_permission_policies"
+  | "api_dispatch_prepare_context_apply_custom_permission_policies"
+  | "api_dispatch_prepare_context_apply_model_provider_permission_policy"
+  | "api_dispatch_prepare_context_merge_permission_manifest"
   | "api_dispatch_prepare_context_validate_environment"
   | "api_dispatch_prepare_context_load_user_timezone"
   | "api_dispatch_prepare_context_prepare_output_metadata"
@@ -2039,33 +2053,48 @@ async function loadStoredConnectorSecrets(
     readonly names: ReadonlySet<string>;
     readonly featureSwitchContext: FeatureSwitchContext;
   },
+  timing?: ApiDispatchTimingCollector,
 ): Promise<Record<string, string>> {
   if (args.names.size === 0) {
     return {};
   }
 
-  const rows = await db
-    .select({
-      name: secretsTable.name,
-      encryptedValue: secretsTable.encryptedValue,
-    })
-    .from(secretsTable)
-    .where(
-      and(
-        eq(secretsTable.orgId, args.orgId),
-        eq(secretsTable.userId, args.userId),
-        eq(secretsTable.type, "connector"),
-        inArray(secretsTable.name, [...args.names]),
-      ),
-    );
-  const values: Record<string, string> = {};
-  for (const row of rows) {
-    values[row.name] = await decryptStoredSecretValue(
-      row.encryptedValue,
-      args.featureSwitchContext,
-    );
-  }
-  return values;
+  const rows = await measureApiDispatchTiming(
+    timing,
+    "api_dispatch_prepare_context_load_stored_connector_secret_rows",
+    "nested",
+    async () => {
+      return await db
+        .select({
+          name: secretsTable.name,
+          encryptedValue: secretsTable.encryptedValue,
+        })
+        .from(secretsTable)
+        .where(
+          and(
+            eq(secretsTable.orgId, args.orgId),
+            eq(secretsTable.userId, args.userId),
+            eq(secretsTable.type, "connector"),
+            inArray(secretsTable.name, [...args.names]),
+          ),
+        );
+    },
+  );
+  return await measureApiDispatchTiming(
+    timing,
+    "api_dispatch_prepare_context_decrypt_stored_connector_secrets",
+    "nested",
+    async () => {
+      const values: Record<string, string> = {};
+      for (const row of rows) {
+        values[row.name] = await decryptStoredSecretValue(
+          row.encryptedValue,
+          args.featureSwitchContext,
+        );
+      }
+      return values;
+    },
+  );
 }
 
 async function loadStoredConnectorVariables(
@@ -2075,25 +2104,33 @@ async function loadStoredConnectorVariables(
     readonly userId: string;
     readonly names: ReadonlySet<string>;
   },
+  timing?: ApiDispatchTimingCollector,
 ): Promise<Record<string, string>> {
   if (args.names.size === 0) {
     return {};
   }
 
-  const rows = await db
-    .select({
-      name: variables.name,
-      value: variables.value,
-    })
-    .from(variables)
-    .where(
-      and(
-        eq(variables.orgId, args.orgId),
-        eq(variables.userId, args.userId),
-        eq(variables.type, "connector"),
-        inArray(variables.name, [...args.names]),
-      ),
-    );
+  const rows = await measureApiDispatchTiming(
+    timing,
+    "api_dispatch_prepare_context_load_stored_connector_variable_rows",
+    "nested",
+    async () => {
+      return await db
+        .select({
+          name: variables.name,
+          value: variables.value,
+        })
+        .from(variables)
+        .where(
+          and(
+            eq(variables.orgId, args.orgId),
+            eq(variables.userId, args.userId),
+            eq(variables.type, "connector"),
+            inArray(variables.name, [...args.names]),
+          ),
+        );
+    },
+  );
   return Object.fromEntries(
     rows.map((row) => {
       return [row.name, row.value];
@@ -2172,6 +2209,7 @@ async function loadStoredConnectorContext(
     readonly allowedConnectorTypes: readonly ConnectorType[] | undefined;
     readonly featureSwitchContext: FeatureSwitchContext;
   },
+  timing?: ApiDispatchTimingCollector,
 ): Promise<ConnectorRuntimeContext> {
   if (args.allowedConnectorTypes?.length === 0) {
     return emptyConnectorRuntimeContext();
@@ -2182,91 +2220,121 @@ async function loadStoredConnectorContext(
     : undefined;
 
   return await db.transaction(async (tx) => {
-    await tx.execute(
-      sql`SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY`,
+    const connectorRows = await measureApiDispatchTiming(
+      timing,
+      "api_dispatch_prepare_context_load_stored_connector_rows",
+      "nested",
+      async () => {
+        await tx.execute(
+          sql`SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY`,
+        );
+        return await tx
+          .select({
+            type: connectors.type,
+            authMethod: connectors.authMethod,
+            needsReconnect: connectors.needsReconnect,
+            tokenExpiresAt: connectors.tokenExpiresAt,
+          })
+          .from(connectors)
+          .where(
+            and(
+              eq(connectors.orgId, args.orgId),
+              eq(connectors.userId, args.userId),
+              allowedConnectorTypes
+                ? inArray(connectors.type, allowedConnectorTypes)
+                : undefined,
+            ),
+          );
+      },
     );
-    const connectorRows = await tx
-      .select({
-        type: connectors.type,
-        authMethod: connectors.authMethod,
-        needsReconnect: connectors.needsReconnect,
-        tokenExpiresAt: connectors.tokenExpiresAt,
-      })
-      .from(connectors)
-      .where(
-        and(
-          eq(connectors.orgId, args.orgId),
-          eq(connectors.userId, args.userId),
-          allowedConnectorTypes
-            ? inArray(connectors.type, allowedConnectorTypes)
-            : undefined,
-        ),
-      );
     if (connectorRows.length === 0) {
       return emptyConnectorRuntimeContext();
     }
 
-    const allowedConnectorRows = allowedStoredConnectorRows(
-      connectorRows,
-      allowedConnectorTypes,
-      nowDate(),
+    const storedConnectorPlan = await measureApiDispatchTiming(
+      timing,
+      "api_dispatch_prepare_context_filter_stored_connector_rows",
+      "nested",
+      () => {
+        const allowedConnectorRows = allowedStoredConnectorRows(
+          connectorRows,
+          allowedConnectorTypes,
+          nowDate(),
+        );
+        if (allowedConnectorRows.length === 0) {
+          return Promise.resolve(null);
+        }
+
+        const bindingSets = connectorEnvBindingSets(allowedConnectorRows);
+        return Promise.resolve({
+          allowedConnectorRows,
+          bindingSets,
+          requirements: collectStoredConnectorRequirements(bindingSets),
+        });
+      },
     );
-    if (allowedConnectorRows.length === 0) {
+    if (!storedConnectorPlan) {
       return emptyConnectorRuntimeContext();
     }
 
-    const bindingSets = connectorEnvBindingSets(allowedConnectorRows);
-    const requirements = collectStoredConnectorRequirements(bindingSets);
-    const connectorSecrets = await loadStoredConnectorSecrets(tx, {
-      orgId: args.orgId,
-      userId: args.userId,
-      names: requirements.secretNames,
-      featureSwitchContext: args.featureSwitchContext,
-    });
-    const connectorVariables = await loadStoredConnectorVariables(tx, {
-      orgId: args.orgId,
-      userId: args.userId,
-      names: requirements.variableNames,
-    });
-    const resolved = resolveStoredConnectorState(
-      bindingSets,
-      connectorSecrets,
-      connectorVariables,
+    const connectorSecrets = await loadStoredConnectorSecrets(
+      tx,
+      {
+        orgId: args.orgId,
+        userId: args.userId,
+        names: storedConnectorPlan.requirements.secretNames,
+        featureSwitchContext: args.featureSwitchContext,
+      },
+      timing,
+    );
+    const connectorVariables = await loadStoredConnectorVariables(
+      tx,
+      {
+        orgId: args.orgId,
+        userId: args.userId,
+        names: storedConnectorPlan.requirements.variableNames,
+      },
+      timing,
     );
 
-    return {
-      secrets: compactRecord(resolved.secrets),
-      vars: compactRecord(resolved.vars),
-      secretConnectorMap: compactRecord(resolved.secretConnectorMap),
-      connectorTypes: allowedConnectorRows.map((row) => {
-        return row.connectorType;
-      }),
-      storedEnvironment: compactRecord(resolved.environment),
-    };
+    return await measureApiDispatchTiming(
+      timing,
+      "api_dispatch_prepare_context_build_stored_connector_state",
+      "nested",
+      () => {
+        const resolved = resolveStoredConnectorState(
+          storedConnectorPlan.bindingSets,
+          connectorSecrets,
+          connectorVariables,
+        );
+
+        return Promise.resolve({
+          secrets: compactRecord(resolved.secrets),
+          vars: compactRecord(resolved.vars),
+          secretConnectorMap: compactRecord(resolved.secretConnectorMap),
+          connectorTypes: storedConnectorPlan.allowedConnectorRows.map(
+            (row) => {
+              return row.connectorType;
+            },
+          ),
+          storedEnvironment: compactRecord(resolved.environment),
+        });
+      },
+    );
   });
 }
 
-async function loadCustomConnectorContext(
-  db: Db,
-  args: {
-    readonly orgId: string;
-    readonly userId: string;
-    readonly allowedCustomConnectorIds: readonly string[] | undefined;
-    readonly featureSwitchContext: FeatureSwitchContext;
-  },
-): Promise<CustomConnectorRuntimeContext> {
-  if (args.allowedCustomConnectorIds?.length === 0) {
-    return { firewalls: [], secrets: undefined };
-  }
+type CustomConnectorRuntimeDataRows = Awaited<
+  ReturnType<typeof loadCustomConnectorRuntimeData>
+>;
 
-  const rows = await loadCustomConnectorRuntimeData(db, {
-    orgId: args.orgId,
-    userId: args.userId,
-    connectorIds: args.allowedCustomConnectorIds,
-  });
+async function buildCustomConnectorRuntimeContext(args: {
+  readonly rows: CustomConnectorRuntimeDataRows;
+  readonly featureSwitchContext: FeatureSwitchContext;
+}): Promise<CustomConnectorRuntimeContext> {
   const firewalls: ExpandedFirewallConfig[] = [];
   const secrets: Record<string, string> = {};
-  for (const row of rows) {
+  for (const row of args.rows) {
     const valueMarkers = new Set(
       row.values.map((value) => {
         return `${value.kind}:${value.key}`;
@@ -2351,6 +2419,54 @@ async function loadCustomConnectorContext(
   }
 
   return { firewalls, secrets: compactRecord(secrets) };
+}
+
+async function loadCustomConnectorContext(
+  db: Db,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly allowedCustomConnectorIds: readonly string[] | undefined;
+    readonly featureSwitchContext: FeatureSwitchContext;
+  },
+  timing?: ApiDispatchTimingCollector,
+): Promise<CustomConnectorRuntimeContext> {
+  if (args.allowedCustomConnectorIds?.length === 0) {
+    return { firewalls: [], secrets: undefined };
+  }
+
+  const rows = await loadCustomConnectorRuntimeData(db, {
+    orgId: args.orgId,
+    userId: args.userId,
+    connectorIds: args.allowedCustomConnectorIds,
+    measure: async (step, operation) => {
+      const actionType =
+        step === "connectorRows"
+          ? "api_dispatch_prepare_context_load_custom_connector_rows"
+          : "api_dispatch_prepare_context_load_custom_connector_value_rows";
+      return await measureApiDispatchTiming(
+        timing,
+        actionType,
+        "nested",
+        operation,
+      );
+    },
+  });
+  if (rows.length === 0) {
+    return { firewalls: [], secrets: undefined };
+  }
+
+  return await measureApiDispatchTiming(
+    timing,
+    "api_dispatch_prepare_context_build_custom_connector_firewalls",
+    "nested",
+    async () => {
+      return await buildCustomConnectorRuntimeContext({
+        rows,
+        featureSwitchContext: args.featureSwitchContext,
+      });
+    },
+  );
 }
 
 function collectPermissionNames(
@@ -2675,6 +2791,7 @@ async function buildPermissionManifest(args: {
   readonly connectorVars?: Record<string, string>;
   readonly connectorTypes?: readonly ConnectorType[];
   readonly customConnectorFirewalls?: readonly ExpandedFirewallConfig[];
+  readonly timing?: ApiDispatchTimingCollector;
 }): Promise<PermissionManifest | undefined> {
   const connectorTypes =
     args.connectorTypes ??
@@ -2686,62 +2803,104 @@ async function buildPermissionManifest(args: {
     isFirewallExecutionMetadataConnectorType,
   );
 
-  const builtinSources = await Promise.all(
-    builtinConnectorTypes.map(async (type) => {
-      const metadata = getRequiredFirewallExecutionMetadata(type);
-      const permissionIndex = await loadRequiredFirewallPermissionIndex(type);
-      return { metadata, permissionIndex };
-    }),
-  );
-
-  const connectorManifest = applyBuiltinConnectorMetadataPolicies(
-    builtinSources,
-    args.permissionPolicies,
-    connectorBaseUrlVars,
-  );
-  const resolvedCustomConnectorFirewalls = resolveFirewallBaseUrlVars(
-    (args.customConnectorFirewalls ?? []).map(runtimeFirewall),
-    args.vars,
-  );
-  const customConnectorManifest = applyConnectorPolicies(
-    resolvedCustomConnectorFirewalls,
-    args.permissionPolicies,
-    inlineFirewallEntry,
-    (_firewall, permissionNames) => {
-      return allAllowPolicyForPermissions(permissionNames);
+  const builtinSources = await measureApiDispatchTiming(
+    args.timing,
+    "api_dispatch_prepare_context_load_builtin_permission_indexes",
+    "nested",
+    async () => {
+      return await Promise.all(
+        builtinConnectorTypes.map(async (type) => {
+          const metadata = getRequiredFirewallExecutionMetadata(type);
+          const permissionIndex =
+            await loadRequiredFirewallPermissionIndex(type);
+          return { metadata, permissionIndex };
+        }),
+      );
     },
   );
-  const providerManifest = modelProviderPermissionManifest(
-    args.modelProvider,
-    args.vars,
-  );
-  const firewalls = [
-    ...(providerManifest?.firewalls ?? []),
-    ...connectorManifest.firewalls,
-    ...customConnectorManifest.firewalls,
-  ];
 
-  if (firewalls.length === 0) {
-    return undefined;
-  }
-
-  return {
-    firewalls,
-    environmentSecretPlaceholders: mergeRecords(
-      providerManifest?.environmentSecretPlaceholders,
-      connectorManifest.environmentSecretPlaceholders,
-      firewallSecretPlaceholdersFromFirewalls(args.customConnectorFirewalls),
-    ),
-    billableFirewalls: [
-      ...(providerManifest?.billableFirewalls ?? []),
-      ...connectorManifest.billableFirewalls,
-    ],
-    networkPolicies: {
-      ...providerManifest?.networkPolicies,
-      ...connectorManifest.networkPolicies,
-      ...customConnectorManifest.networkPolicies,
+  const connectorManifest = await measureApiDispatchTiming(
+    args.timing,
+    "api_dispatch_prepare_context_apply_builtin_permission_policies",
+    "nested",
+    () => {
+      return Promise.resolve(
+        applyBuiltinConnectorMetadataPolicies(
+          builtinSources,
+          args.permissionPolicies,
+          connectorBaseUrlVars,
+        ),
+      );
     },
-  };
+  );
+  const customConnectorManifest = await measureApiDispatchTiming(
+    args.timing,
+    "api_dispatch_prepare_context_apply_custom_permission_policies",
+    "nested",
+    () => {
+      const resolvedCustomConnectorFirewalls = resolveFirewallBaseUrlVars(
+        (args.customConnectorFirewalls ?? []).map(runtimeFirewall),
+        args.vars,
+      );
+      return Promise.resolve(
+        applyConnectorPolicies(
+          resolvedCustomConnectorFirewalls,
+          args.permissionPolicies,
+          inlineFirewallEntry,
+          (_firewall, permissionNames) => {
+            return allAllowPolicyForPermissions(permissionNames);
+          },
+        ),
+      );
+    },
+  );
+  const providerManifest = await measureApiDispatchTiming(
+    args.timing,
+    "api_dispatch_prepare_context_apply_model_provider_permission_policy",
+    "nested",
+    () => {
+      return Promise.resolve(
+        modelProviderPermissionManifest(args.modelProvider, args.vars),
+      );
+    },
+  );
+
+  return await measureApiDispatchTiming(
+    args.timing,
+    "api_dispatch_prepare_context_merge_permission_manifest",
+    "nested",
+    () => {
+      const firewalls = [
+        ...(providerManifest?.firewalls ?? []),
+        ...connectorManifest.firewalls,
+        ...customConnectorManifest.firewalls,
+      ];
+
+      if (firewalls.length === 0) {
+        return Promise.resolve(undefined);
+      }
+
+      return Promise.resolve({
+        firewalls,
+        environmentSecretPlaceholders: mergeRecords(
+          providerManifest?.environmentSecretPlaceholders,
+          connectorManifest.environmentSecretPlaceholders,
+          firewallSecretPlaceholdersFromFirewalls(
+            args.customConnectorFirewalls,
+          ),
+        ),
+        billableFirewalls: [
+          ...(providerManifest?.billableFirewalls ?? []),
+          ...connectorManifest.billableFirewalls,
+        ],
+        networkPolicies: {
+          ...providerManifest?.networkPolicies,
+          ...connectorManifest.networkPolicies,
+          ...customConnectorManifest.networkPolicies,
+        },
+      });
+    },
+  );
 }
 
 function parseVolumeVersionsSnapshot(
@@ -4445,12 +4604,16 @@ async function loadRunConnectorContexts(
       "api_dispatch_prepare_context_load_stored_connectors",
       "nested",
       async () => {
-        return await loadStoredConnectorContext(db, {
-          orgId: args.orgId,
-          userId: args.userId,
-          allowedConnectorTypes: args.allowedConnectorTypes,
-          featureSwitchContext,
-        });
+        return await loadStoredConnectorContext(
+          db,
+          {
+            orgId: args.orgId,
+            userId: args.userId,
+            allowedConnectorTypes: args.allowedConnectorTypes,
+            featureSwitchContext,
+          },
+          timing,
+        );
       },
     ),
     measureApiDispatchTiming(
@@ -4458,12 +4621,16 @@ async function loadRunConnectorContexts(
       "api_dispatch_prepare_context_load_custom_connectors",
       "nested",
       async () => {
-        return await loadCustomConnectorContext(db, {
-          orgId: args.orgId,
-          userId: args.userId,
-          allowedCustomConnectorIds: args.allowedCustomConnectorIds,
-          featureSwitchContext,
-        });
+        return await loadCustomConnectorContext(
+          db,
+          {
+            orgId: args.orgId,
+            userId: args.userId,
+            allowedCustomConnectorIds: args.allowedCustomConnectorIds,
+            featureSwitchContext,
+          },
+          timing,
+        );
       },
     ),
   ]);
@@ -4546,6 +4713,7 @@ async function buildPreparedPermissionManifest(args: {
   readonly modelProvider: ResolvedModelProviderEnvironment | null;
   readonly connectorContext: ConnectorRuntimeContext;
   readonly customConnectorContext: CustomConnectorRuntimeContext;
+  readonly timing: ApiDispatchTimingCollector;
 }): Promise<PermissionManifest | undefined> {
   return await buildPermissionManifest({
     modelProvider: args.modelProvider,
@@ -4554,6 +4722,7 @@ async function buildPreparedPermissionManifest(args: {
     connectorVars: args.connectorContext.vars,
     connectorTypes: args.connectorContext.connectorTypes,
     customConnectorFirewalls: args.customConnectorContext.firewalls,
+    timing: args.timing,
   });
 }
 
@@ -4739,6 +4908,7 @@ async function prepareRunRuntimeContext(args: {
         modelProvider,
         connectorContext,
         customConnectorContext,
+        timing: args.timing,
       });
     },
   );

--- a/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
@@ -1443,12 +1443,21 @@ export function renderCustomConnectorRuntimePrefix(args: {
   return "error" in validation ? null : base;
 }
 
+type CustomConnectorRuntimeDataTimingStep =
+  | "connectorRows"
+  | "connectorValueRows";
+type CustomConnectorRuntimeDataTimingMeasure = <T>(
+  step: CustomConnectorRuntimeDataTimingStep,
+  operation: () => Promise<T>,
+) => Promise<T>;
+
 export async function loadCustomConnectorRuntimeData(
   db: ReadonlyDb,
   args: {
     readonly orgId: string;
     readonly userId: string;
     readonly connectorIds: readonly string[] | undefined;
+    readonly measure?: CustomConnectorRuntimeDataTimingMeasure;
   },
 ): Promise<
   readonly {
@@ -1456,29 +1465,45 @@ export async function loadCustomConnectorRuntimeData(
     readonly values: readonly StoredValueRow[];
   }[]
 > {
-  const connectors = await db
-    .select()
-    .from(orgCustomConnectors)
-    .where(
-      args.connectorIds
-        ? and(
-            eq(orgCustomConnectors.orgId, args.orgId),
-            inArray(orgCustomConnectors.id, [...args.connectorIds]),
-          )
-        : eq(orgCustomConnectors.orgId, args.orgId),
+  const measure =
+    args.measure ??
+    (async <T>(
+      _step: CustomConnectorRuntimeDataTimingStep,
+      operation: () => Promise<T>,
+    ) => {
+      return await operation();
+    });
+  const connectors = await measure("connectorRows", async () => {
+    return await db
+      .select()
+      .from(orgCustomConnectors)
+      .where(
+        args.connectorIds
+          ? and(
+              eq(orgCustomConnectors.orgId, args.orgId),
+              inArray(orgCustomConnectors.id, [...args.connectorIds]),
+            )
+          : eq(orgCustomConnectors.orgId, args.orgId),
+      );
+  });
+  if (connectors.length === 0) {
+    return [];
+  }
+
+  return await measure("connectorValueRows", async () => {
+    return await Promise.all(
+      connectors.map(async (row) => {
+        const connector = normaliseCustomConnectorRow(row);
+        const values = await loadStoredValuesForConnector({
+          db,
+          orgId: args.orgId,
+          userId: args.userId,
+          connectorId: connector.id,
+        });
+        return { connector, values };
+      }),
     );
-  return await Promise.all(
-    connectors.map(async (row) => {
-      const connector = normaliseCustomConnectorRow(row);
-      const values = await loadStoredValuesForConnector({
-        db,
-        orgId: args.orgId,
-        userId: args.userId,
-        connectorId: connector.id,
-      });
-      return { connector, values };
-    }),
-  );
+  });
 }
 
 interface SaveCustomConnectorProposalArgs {


### PR DESCRIPTION
## Summary

- Split create-run connector context telemetry into low-cardinality nested spans for stored connector rows/filtering/secrets/variables/state assembly.
- Split custom connector telemetry into connector row loading, value row loading, and firewall/secret assembly spans.
- Split permission manifest telemetry into builtin index loading, builtin/custom/model-provider policy application, and final merge spans.
- Preserve connector permission, firewall, secret placeholder, and allowlist semantics, including `allowedConnectorTypes === undefined` loading all available stored connectors.

Closes #19061

## Tests

- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-agent-custom-connectors.test.ts src/signals/services/__tests__/firewall-metadata-import-boundary.test.ts`
- `pnpm check-types`
- pre-commit hook: prettier, knip, check-types

## Production validation

After deployment, compare the old parent spans and the new nested spans over stable 1h/6h windows:

```apl
['vm0-sandbox-op-log-prod']
| where _time > ago(6h)
| where op_type in (
  'api_dispatch_prepare_context_load_connector_contexts',
  'api_dispatch_prepare_context_load_stored_connectors',
  'api_dispatch_prepare_context_load_custom_connectors',
  'api_dispatch_prepare_context_build_permission_manifest',
  'api_dispatch_prepare_context_load_stored_connector_rows',
  'api_dispatch_prepare_context_filter_stored_connector_rows',
  'api_dispatch_prepare_context_load_stored_connector_secret_rows',
  'api_dispatch_prepare_context_decrypt_stored_connector_secrets',
  'api_dispatch_prepare_context_load_stored_connector_variable_rows',
  'api_dispatch_prepare_context_build_stored_connector_state',
  'api_dispatch_prepare_context_load_custom_connector_rows',
  'api_dispatch_prepare_context_load_custom_connector_value_rows',
  'api_dispatch_prepare_context_build_custom_connector_firewalls',
  'api_dispatch_prepare_context_load_builtin_permission_indexes',
  'api_dispatch_prepare_context_apply_builtin_permission_policies',
  'api_dispatch_prepare_context_apply_custom_permission_policies',
  'api_dispatch_prepare_context_apply_model_provider_permission_policy',
  'api_dispatch_prepare_context_merge_permission_manifest'
)
| summarize samples=count(), p50=percentile(duration_ms, 50), p90=percentile(duration_ms, 90), p95=percentile(duration_ms, 95), max=max(duration_ms) by op_type
| order by p95 desc
```

Also compare end-to-end dispatch impact:

```apl
['vm0-sandbox-op-log-prod']
| where _time > ago(6h)
| where op_type in ('api_dispatch_prepare_run_context', 'api_to_runner_queue', 'api_to_spawn')
| summarize samples=count(), p50=percentile(duration_ms, 50), p90=percentile(duration_ms, 90), p95=percentile(duration_ms, 95), max=max(duration_ms) by op_type
| order by p95 desc
```

If one nested span dominates p95, create a follow-up optimization issue for that specific bottleneck instead of changing connector semantics speculatively.
