### PR TITLE
perf: batch storage cache warm-hit staging

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1364,6 +1364,7 @@ dependencies = [
  "guest-contracts",
  "libc",
  "tempfile",
+ "vsock-proto",
 ]
 
 [[package]]

--- a/crates/guest-write-file/Cargo.toml
+++ b/crates/guest-write-file/Cargo.toml
@@ -7,6 +7,7 @@ description = "Write guest files from stdin without shell startup overhead"
 [dependencies]
 guest-contracts.workspace = true
 libc.workspace = true
+vsock-proto.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/guest-write-file/src/lib.rs
+++ b/crates/guest-write-file/src/lib.rs
@@ -10,18 +10,20 @@ use std::path::{Path, PathBuf};
 #[derive(Debug, Eq, PartialEq)]
 struct Args {
     append: bool,
+    batch: bool,
     create_parents: bool,
     private: bool,
-    path: PathBuf,
+    path: Option<PathBuf>,
 }
 
-const USAGE: &str = "usage: guest-write-file [--private] [--append | --create-parents] [--] <path>";
+const USAGE: &str = "usage: guest-write-file [--private] [--append | --create-parents] [--] <path> | guest-write-file --batch";
 
 fn parse_args<I>(args: I) -> Result<Args, String>
 where
     I: IntoIterator<Item = String>,
 {
     let mut append = false;
+    let mut batch = false;
     let mut create_parents = false;
     let mut private = false;
     let mut path = None;
@@ -32,6 +34,10 @@ where
             match arg.as_str() {
                 "--append" => {
                     append = true;
+                    continue;
+                }
+                "--batch" => {
+                    batch = true;
                     continue;
                 }
                 "--create-parents" => {
@@ -58,6 +64,24 @@ where
         }
     }
 
+    if batch {
+        if append || create_parents || private {
+            return Err(
+                "--batch cannot be used with --append, --create-parents, or --private".to_string(),
+            );
+        }
+        if path.is_some() {
+            return Err("--batch does not accept a path".to_string());
+        }
+        return Ok(Args {
+            append: false,
+            batch: true,
+            create_parents: false,
+            private: false,
+            path: None,
+        });
+    }
+
     let path = path.ok_or_else(|| "missing path".to_string())?;
     if append && create_parents {
         return Err("--append and --create-parents cannot be used together".to_string());
@@ -68,27 +92,64 @@ where
 
     Ok(Args {
         append,
+        batch: false,
         create_parents,
         private,
-        path,
+        path: Some(path),
     })
 }
 
 fn run(args: Args, mut stdin: impl Read) -> io::Result<()> {
+    if args.batch {
+        return run_batch(stdin);
+    }
+    let Some(path) = args.path else {
+        return Err(io::Error::new(io::ErrorKind::InvalidInput, "missing path"));
+    };
+
     let mut file = if args.private {
-        open_private_output_file(&args.path, args.append)?
+        open_private_output_file(&path, args.append)?
     } else {
         if args.create_parents
-            && let Some(parent) = args.path.parent()
+            && let Some(parent) = path.parent()
             && !parent.as_os_str().is_empty()
         {
             fs::create_dir_all(parent)?;
         }
-        open_output_file(&args.path, args.append)?
+        open_output_file(&path, args.append)?
     };
 
     io::copy(&mut stdin, &mut file)?;
     file.flush()
+}
+
+fn run_batch(mut stdin: impl Read) -> io::Result<()> {
+    let mut payload = Vec::new();
+    let mut limited = stdin
+        .by_ref()
+        .take(vsock_proto::MAX_MESSAGE_SIZE as u64 + 1);
+    limited.read_to_end(&mut payload)?;
+    if payload.len() > vsock_proto::MAX_MESSAGE_SIZE {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "write_files payload exceeds maximum protocol message size",
+        ));
+    }
+    let files = vsock_proto::decode_write_files(&payload)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
+
+    for file in files {
+        let path = Path::new(file.path);
+        if let Some(parent) = path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            fs::create_dir_all(parent)?;
+        }
+        let mut output = open_output_file(path, false)?;
+        output.write_all(file.content)?;
+        output.flush()?;
+    }
+    Ok(())
 }
 
 fn open_private_output_file(path: &Path, append: bool) -> io::Result<File> {
@@ -176,6 +237,7 @@ fn prepare_output_file(_file: &File) -> io::Result<()> {
 ///
 /// ```text
 /// guest-write-file [--private] [--append | --create-parents] [--] <path>
+/// guest-write-file --batch
 /// ```
 ///
 /// Use `--` before `<path>` when the literal path begins with `-`. `stdin`
@@ -188,6 +250,9 @@ fn prepare_output_file(_file: &File) -> io::Result<()> {
 /// private file helpers, ensuring parent directories are private, creating
 /// missing parent directories even with `--append`, and rejecting symlinked
 /// parent components.
+///
+/// `--batch` reads a `vsock-proto` `write_files` payload from stdin and writes
+/// every ordinary file entry with create-parent and truncate semantics.
 ///
 /// Returns process-style exit codes: `0` for success, `1` for runtime or write
 /// failures, and `2` for usage or argument errors.
@@ -225,9 +290,10 @@ mod tests {
             args,
             Args {
                 append: false,
+                batch: false,
                 create_parents: true,
                 private: false,
-                path: PathBuf::from("/tmp/out.txt"),
+                path: Some(PathBuf::from("/tmp/out.txt")),
             }
         );
     }
@@ -245,9 +311,10 @@ mod tests {
             args,
             Args {
                 append: true,
+                batch: false,
                 create_parents: false,
                 private: false,
-                path: PathBuf::from("-literal"),
+                path: Some(PathBuf::from("-literal")),
             }
         );
     }
@@ -291,11 +358,42 @@ mod tests {
             args,
             Args {
                 append: true,
+                batch: false,
                 create_parents: false,
                 private: true,
-                path: PathBuf::from("/tmp/out.txt"),
+                path: Some(PathBuf::from("/tmp/out.txt")),
             }
         );
+    }
+
+    #[test]
+    fn parse_batch() {
+        let args = parse_args(["--batch".to_string()]).unwrap();
+
+        assert_eq!(
+            args,
+            Args {
+                append: false,
+                batch: true,
+                create_parents: false,
+                private: false,
+                path: None,
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_batch_with_path() {
+        let err = parse_args(["--batch".to_string(), "/tmp/out.txt".to_string()]).unwrap_err();
+
+        assert!(err.contains("does not accept a path"));
+    }
+
+    #[test]
+    fn rejects_batch_with_single_file_flags() {
+        let err = parse_args(["--batch".to_string(), "--create-parents".to_string()]).unwrap_err();
+
+        assert!(err.contains("cannot be used"));
     }
 
     #[test]

--- a/crates/guest-write-file/src/lib.rs
+++ b/crates/guest-write-file/src/lib.rs
@@ -125,11 +125,10 @@ fn run(args: Args, mut stdin: impl Read) -> io::Result<()> {
 
 fn run_batch(mut stdin: impl Read) -> io::Result<()> {
     let mut payload = Vec::new();
-    let mut limited = stdin
-        .by_ref()
-        .take(vsock_proto::MAX_MESSAGE_SIZE as u64 + 1);
+    let max_payload_size = vsock_proto::MAX_MESSAGE_SIZE - vsock_proto::MIN_BODY_SIZE;
+    let mut limited = stdin.by_ref().take(max_payload_size as u64 + 1);
     limited.read_to_end(&mut payload)?;
-    if payload.len() > vsock_proto::MAX_MESSAGE_SIZE {
+    if payload.len() > max_payload_size {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             "write_files payload exceeds maximum protocol message size",

--- a/crates/guest-write-file/tests/integration.rs
+++ b/crates/guest-write-file/tests/integration.rs
@@ -7,7 +7,7 @@ use std::sync::mpsc;
 use std::time::Duration;
 
 const BIN: &str = env!("CARGO_BIN_EXE_guest-write-file");
-const USAGE: &str = "usage: guest-write-file [--private] [--append | --create-parents] [--] <path>";
+const USAGE: &str = "usage: guest-write-file [--private] [--append | --create-parents] [--] <path> | guest-write-file --batch";
 
 fn run_helper(args: &[&str], stdin: &[u8]) -> std::process::Output {
     run_helper_with_current_dir(args, stdin, None)
@@ -153,6 +153,69 @@ fn create_mode_writes_empty_file() {
 
     assert!(output.status.success(), "stderr={:?}", output.stderr);
     assert_eq!(std::fs::read(path).unwrap(), b"");
+}
+
+#[test]
+fn batch_mode_creates_missing_parents_and_writes_files() {
+    let dir = tempfile::tempdir().unwrap();
+    let first = dir.path().join("a/b/one.txt");
+    let second = dir.path().join("c/two.txt");
+    let payload = vsock_proto::encode_write_files(&[
+        vsock_proto::WriteFileBatchEntry {
+            path: first.to_str().unwrap(),
+            content: b"one",
+        },
+        vsock_proto::WriteFileBatchEntry {
+            path: second.to_str().unwrap(),
+            content: b"two",
+        },
+    ])
+    .unwrap();
+
+    let output = run_helper(&["--batch"], &payload);
+
+    assert!(output.status.success(), "stderr={:?}", output.stderr);
+    assert_eq!(std::fs::read(first).unwrap(), b"one");
+    assert_eq!(std::fs::read(second).unwrap(), b"two");
+}
+
+#[test]
+fn batch_mode_truncates_existing_files() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("out.txt");
+    std::fs::write(&path, b"old longer content").unwrap();
+    let payload = vsock_proto::encode_write_files(&[vsock_proto::WriteFileBatchEntry {
+        path: path.to_str().unwrap(),
+        content: b"new",
+    }])
+    .unwrap();
+
+    let output = run_helper(&["--batch"], &payload);
+
+    assert!(output.status.success(), "stderr={:?}", output.stderr);
+    assert_eq!(std::fs::read(path).unwrap(), b"new");
+}
+
+#[test]
+fn batch_mode_rejects_malformed_payload() {
+    let output = run_helper(&["--batch"], &[0, 0]);
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("file count must be positive"),
+        "stderr={stderr}"
+    );
+}
+
+#[test]
+fn batch_mode_rejects_single_file_flags() {
+    let output = run_helper(&["--batch", "--create-parents"], b"");
+
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("cannot be used"), "stderr={stderr}");
+    assert!(stderr.contains(USAGE));
 }
 
 #[test]

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -33,7 +33,7 @@ use std::time::{Duration, Instant};
 use bytes::Bytes;
 use futures_util::stream::{self, StreamExt};
 use reqwest::Client;
-use sandbox::Sandbox;
+use sandbox::{Sandbox, WriteFileEntry};
 use tokio::fs;
 use tokio::io::AsyncReadExt as _;
 use tracing::{info, warn};
@@ -49,6 +49,12 @@ const CACHE_MAX_SIZE: u64 = 8 * 1024 * 1024;
 
 /// Parallel (probe GET / full GET / flock / vsock) operations per `populate_cache` call.
 const CONCURRENCY: usize = 4;
+
+/// Maximum number of warm cache-hit archives staged in one guest batch write.
+const GUEST_STAGE_BATCH_MAX_FILES: usize = 64;
+
+/// Maximum total warm cache-hit bytes staged in one guest batch write.
+const GUEST_STAGE_BATCH_MAX_BYTES: usize = 15 * 1024 * 1024;
 
 /// Guest stage directory for `file://` archives.
 const GUEST_STAGE_DIR: &str = "/tmp/vm0-storage-cache";
@@ -89,6 +95,27 @@ enum GroupOutcome {
         outcome: TargetOutcome,
     },
     PerTarget(Vec<TargetOutcome>),
+}
+
+struct ProcessedGroup {
+    outcome: GroupOutcome,
+    stage_write: Option<GuestStageWrite>,
+}
+
+struct ProcessedTarget {
+    outcome: TargetOutcome,
+    stage_write: Option<GuestStageWrite>,
+}
+
+struct GuestStageWrite {
+    guest_path: String,
+    bytes: Bytes,
+}
+
+#[derive(Default)]
+struct GuestStageBatch {
+    writes: Vec<GuestStageWrite>,
+    content_bytes: usize,
 }
 
 #[derive(Clone, Copy)]
@@ -157,6 +184,78 @@ impl GuestWriteLocks {
     }
 }
 
+impl GuestStageBatch {
+    fn should_flush_before(&self, write: &GuestStageWrite) -> bool {
+        !self.writes.is_empty()
+            && (self.writes.len() >= GUEST_STAGE_BATCH_MAX_FILES
+                || self.content_bytes.saturating_add(write.bytes.len())
+                    > GUEST_STAGE_BATCH_MAX_BYTES)
+    }
+
+    fn push(&mut self, write: GuestStageWrite) {
+        self.content_bytes += write.bytes.len();
+        self.writes.push(write);
+    }
+
+    fn should_flush_after_push(&self) -> bool {
+        self.writes.len() >= GUEST_STAGE_BATCH_MAX_FILES
+            || self.content_bytes >= GUEST_STAGE_BATCH_MAX_BYTES
+    }
+}
+
+async fn flush_guest_stage_batch(
+    batch: &mut GuestStageBatch,
+    sandbox: &dyn Sandbox,
+) -> RunnerResult<()> {
+    if batch.writes.is_empty() {
+        return Ok(());
+    }
+    write_guest_stage_files(sandbox, &batch.writes).await?;
+    batch.writes.clear();
+    batch.content_bytes = 0;
+    Ok(())
+}
+
+async fn write_guest_stage_files(
+    sandbox: &dyn Sandbox,
+    writes: &[GuestStageWrite],
+) -> RunnerResult<()> {
+    if writes.is_empty() {
+        return Ok(());
+    }
+    let entries = writes
+        .iter()
+        .map(|write| WriteFileEntry {
+            path: write.guest_path.as_str(),
+            content: write.bytes.as_ref(),
+        })
+        .collect::<Vec<_>>();
+    sandbox.write_files(&entries).await?;
+    Ok(())
+}
+
+async fn push_guest_stage_write(
+    batch: &mut GuestStageBatch,
+    write: GuestStageWrite,
+    sandbox: &dyn Sandbox,
+    guest_writes: &GuestWriteLocks,
+) -> RunnerResult<()> {
+    if write.bytes.len() > GUEST_STAGE_BATCH_MAX_BYTES {
+        guest_writes
+            .write_file(sandbox, &write.guest_path, &write.bytes)
+            .await?;
+        return Ok(());
+    }
+    if batch.should_flush_before(&write) {
+        flush_guest_stage_batch(batch, sandbox).await?;
+    }
+    batch.push(write);
+    if batch.should_flush_after_push() {
+        flush_guest_stage_batch(batch, sandbox).await?;
+    }
+    Ok(())
+}
+
 /// Populate the runner-side cache for eligible entries in `manifest`.
 ///
 /// Mutates `manifest.storages[i].archive_url` / `manifest.artifacts[i].archive_url`
@@ -188,7 +287,7 @@ pub async fn populate_cache(
     // keeping their borrows alive on the caller's stack. Unlike
     // `tokio::task::JoinSet`, it does not require `'static` futures — which
     // matters because our `sandbox: &dyn Sandbox` is a borrow, not an Arc.
-    let outcomes: Vec<(CacheTargetGroup, RunnerResult<GroupOutcome>)> = stream::iter(target_groups)
+    let mut groups = stream::iter(target_groups)
         .map(|group| {
             let http = http.clone();
             let guest_writes = &guest_writes;
@@ -197,12 +296,20 @@ pub async fn populate_cache(
                 (group, res)
             }
         })
-        .buffer_unordered(CONCURRENCY)
-        .collect()
-        .await;
+        .buffer_unordered(CONCURRENCY);
+
+    let mut outcomes = Vec::new();
+    let mut stage_batch = GuestStageBatch::default();
+    while let Some((group, outcome)) = groups.next().await {
+        let outcome = outcome?;
+        if let Some(stage_write) = outcome.stage_write {
+            push_guest_stage_write(&mut stage_batch, stage_write, sandbox, &guest_writes).await?;
+        }
+        outcomes.push((group, outcome.outcome));
+    }
+    flush_guest_stage_batch(&mut stage_batch, sandbox).await?;
 
     for (group, outcome) in outcomes {
-        let outcome = outcome?;
         apply_group_outcome(manifest, &group, &outcome, telemetry);
     }
     Ok(())
@@ -296,32 +403,44 @@ async fn process_group(
     home: &HomePaths,
     sandbox: &dyn Sandbox,
     guest_writes: &GuestWriteLocks,
-) -> RunnerResult<GroupOutcome> {
+) -> RunnerResult<ProcessedGroup> {
     // Same-key targets are expected to refer to the same archive content, so a
     // definitive cache outcome can be shared across the group. Probe and full
     // download passthrough failures are the exception: they are URL/request
     // level decisions, so try the next duplicate before giving up per target.
     let mut retryable_passthrough_outcomes = Vec::new();
     for (index, target) in group.targets.iter().enumerate() {
-        let outcome = process_one(target, http, home, sandbox, guest_writes).await?;
+        let ProcessedTarget {
+            outcome,
+            stage_write,
+        } = process_one(target, http, home, sandbox, guest_writes).await?;
         match outcome {
             TargetOutcome::SkippedHeadFailed { .. }
             | TargetOutcome::SkippedInvalidDownload { .. } => {
                 retryable_passthrough_outcomes.push(outcome);
                 if retryable_passthrough_outcomes.len() == group.targets.len() {
-                    return Ok(GroupOutcome::PerTarget(retryable_passthrough_outcomes));
+                    return Ok(ProcessedGroup {
+                        outcome: GroupOutcome::PerTarget(retryable_passthrough_outcomes),
+                        stage_write: None,
+                    });
                 }
             }
             outcome => {
-                return Ok(GroupOutcome::Shared {
-                    outcome_target_index: index,
-                    outcome,
+                return Ok(ProcessedGroup {
+                    outcome: GroupOutcome::Shared {
+                        outcome_target_index: index,
+                        outcome,
+                    },
+                    stage_write,
                 });
             }
         }
     }
 
-    Ok(GroupOutcome::PerTarget(retryable_passthrough_outcomes))
+    Ok(ProcessedGroup {
+        outcome: GroupOutcome::PerTarget(retryable_passthrough_outcomes),
+        stage_write: None,
+    })
 }
 
 async fn process_one(
@@ -330,7 +449,7 @@ async fn process_one(
     home: &HomePaths,
     sandbox: &dyn Sandbox,
     guest_writes: &GuestWriteLocks,
-) -> RunnerResult<TargetOutcome> {
+) -> RunnerResult<ProcessedTarget> {
     let lock_path = home.storage_lock(&target.name, &target.version);
     let cache_dir = home.storage_cache_dir(&target.name, &target.version);
     let archive_path = cache_dir.join("archive.tar.gz");
@@ -342,10 +461,10 @@ async fn process_one(
         if let CachedArchive::Hit(bytes) = read_cache_entry(&cache_dir, &archive_path).await? {
             let guest_path = guest_archive_path(&target.name, &target.version);
             drop(reader);
-            guest_writes
-                .write_file(sandbox, &guest_path, &bytes)
-                .await?;
-            return Ok(TargetOutcome::Hit);
+            return Ok(ProcessedTarget {
+                outcome: TargetOutcome::Hit,
+                stage_write: Some(GuestStageWrite { guest_path, bytes }),
+            });
         }
     }
 
@@ -356,10 +475,10 @@ async fn process_one(
         CachedArchive::Hit(bytes) => {
             let guest_path = guest_archive_path(&target.name, &target.version);
             drop(writer);
-            guest_writes
-                .write_file(sandbox, &guest_path, &bytes)
-                .await?;
-            return Ok(TargetOutcome::Hit);
+            return Ok(ProcessedTarget {
+                outcome: TargetOutcome::Hit,
+                stage_write: Some(GuestStageWrite { guest_path, bytes }),
+            });
         }
         CachedArchive::Missing => {}
         CachedArchive::Empty => {
@@ -388,8 +507,11 @@ async fn process_one(
                 reason,
                 "storage_cache: probe returned no usable size header, passthrough"
             );
-            return Ok(TargetOutcome::SkippedHeadFailed {
-                reason: reason.to_string(),
+            return Ok(ProcessedTarget {
+                outcome: TargetOutcome::SkippedHeadFailed {
+                    reason: reason.to_string(),
+                },
+                stage_write: None,
             });
         }
         Err(e) => {
@@ -400,7 +522,10 @@ async fn process_one(
                 error = %reason,
                 "storage_cache: probe failed, passthrough"
             );
-            return Ok(TargetOutcome::SkippedHeadFailed { reason });
+            return Ok(ProcessedTarget {
+                outcome: TargetOutcome::SkippedHeadFailed { reason },
+                stage_write: None,
+            });
         }
     };
     if size > CACHE_MAX_SIZE {
@@ -410,7 +535,10 @@ async fn process_one(
             size,
             "storage_cache: entry over size limit, passthrough"
         );
-        return Ok(TargetOutcome::SkippedOverSize);
+        return Ok(ProcessedTarget {
+            outcome: TargetOutcome::SkippedOverSize,
+            stage_write: None,
+        });
     }
 
     // Download, stage, fsync, atomic rename, then release cache ownership before
@@ -424,8 +552,11 @@ async fn process_one(
                 version = %target.version,
                 "storage_cache: full download returned empty archive, passthrough"
             );
-            return Ok(TargetOutcome::SkippedInvalidDownload {
-                reason: "empty-download".to_string(),
+            return Ok(ProcessedTarget {
+                outcome: TargetOutcome::SkippedInvalidDownload {
+                    reason: "empty-download".to_string(),
+                },
+                stage_write: None,
             });
         }
         DownloadBody::OverSize { observed_size } => {
@@ -453,8 +584,11 @@ async fn process_one(
             observed_size,
             "storage_cache: full download size differed from probe, passthrough"
         );
-        return Ok(TargetOutcome::SkippedInvalidDownload {
-            reason: "size-mismatch".to_string(),
+        return Ok(ProcessedTarget {
+            outcome: TargetOutcome::SkippedInvalidDownload {
+                reason: "size-mismatch".to_string(),
+            },
+            stage_write: None,
         });
     }
     if let Err(reason) = validate_tar_gz_archive(bytes.clone()).await? {
@@ -464,8 +598,11 @@ async fn process_one(
             error = %reason,
             "storage_cache: full download returned invalid archive, passthrough"
         );
-        return Ok(TargetOutcome::SkippedInvalidDownload {
-            reason: "invalid-archive".to_string(),
+        return Ok(ProcessedTarget {
+            outcome: TargetOutcome::SkippedInvalidDownload {
+                reason: "invalid-archive".to_string(),
+            },
+            stage_write: None,
         });
     }
     write_to_cache(&cache_dir, &bytes).await?;
@@ -475,8 +612,11 @@ async fn process_one(
         .write_file(sandbox, &guest_path, &bytes)
         .await?;
 
-    Ok(TargetOutcome::Miss {
-        download_duration: t.elapsed(),
+    Ok(ProcessedTarget {
+        outcome: TargetOutcome::Miss {
+            download_duration: t.elapsed(),
+        },
+        stage_write: None,
     })
 }
 
@@ -1414,6 +1554,68 @@ mod tests {
             ops.iter().any(|(k, _, _)| k == "storage_cache_hit"),
             "expected storage_cache_hit in {ops:?}"
         );
+        let batches = sandbox.write_files_calls();
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].files.len(), 1);
+        assert_eq!(batches[0].files[0].path, guest_archive_path(name, version));
+    }
+
+    #[tokio::test]
+    async fn warm_hits_are_staged_in_one_guest_batch() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = home_at(&temp);
+        let sandbox = MockSandbox::new("test");
+        let mut telemetry = new_telemetry();
+        let body = tarball_bytes();
+        let first_name = "warm-batch-a";
+        let second_name = "warm-batch-b";
+        let version = "v1";
+        write_cached_archive(&home, first_name, version, &body);
+        write_cached_archive(&home, second_name, version, &body);
+
+        let mut manifest = GuestDownloadManifest {
+            storages: vec![
+                GuestDownloadStorageEntry {
+                    mount_path: "/mnt/a".into(),
+                    archive_url: Some("https://r2.example.com/a.tar.gz".into()),
+                    cached: false,
+                    instructions_target_filename: None,
+                    vas_storage_name: first_name.to_string(),
+                    vas_version_id: version.to_string(),
+                },
+                GuestDownloadStorageEntry {
+                    mount_path: "/mnt/b".into(),
+                    archive_url: Some("https://r2.example.com/b.tar.gz".into()),
+                    cached: false,
+                    instructions_target_filename: None,
+                    vas_storage_name: second_name.to_string(),
+                    vas_version_id: version.to_string(),
+                },
+            ],
+            artifacts: Vec::new(),
+            cleanup_paths: Vec::new(),
+        };
+
+        populate_cache(&mut manifest, &sandbox, &home, &mut telemetry)
+            .await
+            .unwrap();
+
+        let batches = sandbox.write_files_calls();
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].files.len(), 2);
+        let staged_paths = batches[0]
+            .files
+            .iter()
+            .map(|file| file.path.clone())
+            .collect::<HashSet<_>>();
+        assert_eq!(
+            staged_paths,
+            HashSet::from([
+                guest_archive_path(first_name, version),
+                guest_archive_path(second_name, version),
+            ])
+        );
+        assert_eq!(sandbox.write_file_calls().len(), 2);
     }
 
     #[tokio::test]

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -182,6 +182,48 @@ impl GuestWriteLocks {
         sandbox.write_file(guest_path, bytes).await?;
         Ok(())
     }
+
+    async fn write_files(
+        &self,
+        sandbox: &dyn Sandbox,
+        writes: &[GuestStageWrite],
+    ) -> RunnerResult<()> {
+        if writes.is_empty() {
+            return Ok(());
+        }
+        let mut paths = writes
+            .iter()
+            .map(|write| write.guest_path.as_str())
+            .collect::<Vec<_>>();
+        paths.sort_unstable();
+        paths.dedup();
+        let locks = {
+            let mut lock_map = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+            paths
+                .into_iter()
+                .map(|path| {
+                    Arc::clone(
+                        lock_map
+                            .entry(path.to_string())
+                            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(()))),
+                    )
+                })
+                .collect::<Vec<_>>()
+        };
+        let mut guards = Vec::with_capacity(locks.len());
+        for lock in &locks {
+            guards.push(lock.lock().await);
+        }
+        let entries = writes
+            .iter()
+            .map(|write| WriteFileEntry {
+                path: write.guest_path.as_str(),
+                content: write.bytes.as_ref(),
+            })
+            .collect::<Vec<_>>();
+        sandbox.write_files(&entries).await?;
+        Ok(())
+    }
 }
 
 impl GuestStageBatch {
@@ -206,31 +248,14 @@ impl GuestStageBatch {
 async fn flush_guest_stage_batch(
     batch: &mut GuestStageBatch,
     sandbox: &dyn Sandbox,
+    guest_writes: &GuestWriteLocks,
 ) -> RunnerResult<()> {
     if batch.writes.is_empty() {
         return Ok(());
     }
-    write_guest_stage_files(sandbox, &batch.writes).await?;
+    guest_writes.write_files(sandbox, &batch.writes).await?;
     batch.writes.clear();
     batch.content_bytes = 0;
-    Ok(())
-}
-
-async fn write_guest_stage_files(
-    sandbox: &dyn Sandbox,
-    writes: &[GuestStageWrite],
-) -> RunnerResult<()> {
-    if writes.is_empty() {
-        return Ok(());
-    }
-    let entries = writes
-        .iter()
-        .map(|write| WriteFileEntry {
-            path: write.guest_path.as_str(),
-            content: write.bytes.as_ref(),
-        })
-        .collect::<Vec<_>>();
-    sandbox.write_files(&entries).await?;
     Ok(())
 }
 
@@ -247,13 +272,23 @@ async fn push_guest_stage_write(
         return Ok(());
     }
     if batch.should_flush_before(&write) {
-        flush_guest_stage_batch(batch, sandbox).await?;
+        flush_guest_stage_batch(batch, sandbox, guest_writes).await?;
     }
     batch.push(write);
     if batch.should_flush_after_push() {
-        flush_guest_stage_batch(batch, sandbox).await?;
+        flush_guest_stage_batch(batch, sandbox, guest_writes).await?;
     }
     Ok(())
+}
+
+fn should_batch_stage_write(outcome: &GroupOutcome) -> bool {
+    matches!(
+        outcome,
+        GroupOutcome::Shared {
+            outcome: TargetOutcome::Hit,
+            ..
+        }
+    )
 }
 
 /// Populate the runner-side cache for eligible entries in `manifest`.
@@ -285,14 +320,13 @@ pub async fn populate_cache(
 
     // `buffer_unordered` drives up to CONCURRENCY futures concurrently while
     // keeping their borrows alive on the caller's stack. Unlike
-    // `tokio::task::JoinSet`, it does not require `'static` futures — which
-    // matters because our `sandbox: &dyn Sandbox` is a borrow, not an Arc.
+    // `tokio::task::JoinSet`, it does not require `'static` futures for the
+    // borrowed cache home and HTTP client state used here.
     let mut groups = stream::iter(target_groups)
         .map(|group| {
             let http = http.clone();
-            let guest_writes = &guest_writes;
             async move {
-                let res = process_group(&group, &http, home, sandbox, guest_writes).await;
+                let res = process_group(&group, &http, home).await;
                 (group, res)
             }
         })
@@ -302,12 +336,24 @@ pub async fn populate_cache(
     let mut stage_batch = GuestStageBatch::default();
     while let Some((group, outcome)) = groups.next().await {
         let outcome = outcome?;
-        if let Some(stage_write) = outcome.stage_write {
-            push_guest_stage_write(&mut stage_batch, stage_write, sandbox, &guest_writes).await?;
+        let ProcessedGroup {
+            outcome,
+            stage_write,
+        } = outcome;
+        if let Some(stage_write) = stage_write {
+            if should_batch_stage_write(&outcome) {
+                push_guest_stage_write(&mut stage_batch, stage_write, sandbox, &guest_writes)
+                    .await?;
+            } else {
+                flush_guest_stage_batch(&mut stage_batch, sandbox, &guest_writes).await?;
+                guest_writes
+                    .write_file(sandbox, &stage_write.guest_path, &stage_write.bytes)
+                    .await?;
+            }
         }
-        outcomes.push((group, outcome.outcome));
+        outcomes.push((group, outcome));
     }
-    flush_guest_stage_batch(&mut stage_batch, sandbox).await?;
+    flush_guest_stage_batch(&mut stage_batch, sandbox, &guest_writes).await?;
 
     for (group, outcome) in outcomes {
         apply_group_outcome(manifest, &group, &outcome, telemetry);
@@ -401,8 +447,6 @@ async fn process_group(
     group: &CacheTargetGroup,
     http: &Client,
     home: &HomePaths,
-    sandbox: &dyn Sandbox,
-    guest_writes: &GuestWriteLocks,
 ) -> RunnerResult<ProcessedGroup> {
     // Same-key targets are expected to refer to the same archive content, so a
     // definitive cache outcome can be shared across the group. Probe and full
@@ -413,7 +457,7 @@ async fn process_group(
         let ProcessedTarget {
             outcome,
             stage_write,
-        } = process_one(target, http, home, sandbox, guest_writes).await?;
+        } = process_one(target, http, home).await?;
         match outcome {
             TargetOutcome::SkippedHeadFailed { .. }
             | TargetOutcome::SkippedInvalidDownload { .. } => {
@@ -447,8 +491,6 @@ async fn process_one(
     target: &CacheTarget,
     http: &Client,
     home: &HomePaths,
-    sandbox: &dyn Sandbox,
-    guest_writes: &GuestWriteLocks,
 ) -> RunnerResult<ProcessedTarget> {
     let lock_path = home.storage_lock(&target.name, &target.version);
     let cache_dir = home.storage_cache_dir(&target.name, &target.version);
@@ -608,15 +650,12 @@ async fn process_one(
     write_to_cache(&cache_dir, &bytes).await?;
     let guest_path = guest_archive_path(&target.name, &target.version);
     drop(writer);
-    guest_writes
-        .write_file(sandbox, &guest_path, &bytes)
-        .await?;
 
     Ok(ProcessedTarget {
         outcome: TargetOutcome::Miss {
             download_duration: t.elapsed(),
         },
-        stage_write: None,
+        stage_write: Some(GuestStageWrite { guest_path, bytes }),
     })
 }
 

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -3830,9 +3830,9 @@ mod tests {
         // Two `populate_cache` invocations race for the same (name, version).
         // The per-version flock must serialize them, so exactly one issues a
         // GET to upstream and the second hits the just-warmed disk cache.
-        // `buffer_unordered(CONCURRENCY)` inside `populate_cache` means both
-        // tasks touch the flock acquire from separate spawn_blocking threads,
-        // so the test exercises real cross-thread flock semantics.
+        // `populate_cache` runs cache workers in spawned tasks, so both tasks
+        // touch the flock acquire from separate spawn_blocking threads. This
+        // exercises real cross-thread flock semantics.
         let temp = tempfile::tempdir().unwrap();
         let home = home_at(&temp);
         let sandbox_a = MockSandbox::new("test-a");

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -31,11 +31,11 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use bytes::Bytes;
-use futures_util::stream::{self, StreamExt};
 use reqwest::Client;
 use sandbox::{Sandbox, WriteFileEntry};
 use tokio::fs;
 use tokio::io::AsyncReadExt as _;
+use tokio::task::JoinSet;
 use tracing::{info, warn};
 
 use crate::error::{RunnerError, RunnerResult};
@@ -117,6 +117,8 @@ struct GuestStageBatch {
     writes: Vec<GuestStageWrite>,
     content_bytes: usize,
 }
+
+type ProcessedGroupTaskResult = (CacheTargetGroup, RunnerResult<ProcessedGroup>);
 
 #[derive(Clone, Copy)]
 enum TargetKind {
@@ -291,6 +293,84 @@ fn should_batch_stage_write(outcome: &GroupOutcome) -> bool {
     )
 }
 
+async fn abort_pending_processed_groups(groups: &mut JoinSet<ProcessedGroupTaskResult>) {
+    groups.abort_all();
+    while groups.join_next().await.is_some() {}
+}
+
+async fn join_next_processed_group(
+    groups: &mut JoinSet<ProcessedGroupTaskResult>,
+) -> RunnerResult<Option<ProcessedGroupTaskResult>> {
+    match groups.join_next().await {
+        Some(Ok(result)) => Ok(Some(result)),
+        Some(Err(error)) => {
+            abort_pending_processed_groups(groups).await;
+            Err(RunnerError::Internal(format!(
+                "storage cache group task failed: {error}"
+            )))
+        }
+        None => Ok(None),
+    }
+}
+
+async fn stage_processed_group(
+    group: CacheTargetGroup,
+    processed: ProcessedGroup,
+    outcomes: &mut Vec<(CacheTargetGroup, GroupOutcome)>,
+    stage_batch: &mut GuestStageBatch,
+    sandbox: &dyn Sandbox,
+    guest_writes: &GuestWriteLocks,
+) -> RunnerResult<()> {
+    let ProcessedGroup {
+        outcome,
+        stage_write,
+    } = processed;
+    if let Some(stage_write) = stage_write {
+        if should_batch_stage_write(&outcome) {
+            push_guest_stage_write(stage_batch, stage_write, sandbox, guest_writes).await?;
+        } else {
+            flush_guest_stage_batch(stage_batch, sandbox, guest_writes).await?;
+            guest_writes
+                .write_file(sandbox, &stage_write.guest_path, &stage_write.bytes)
+                .await?;
+        }
+    }
+    outcomes.push((group, outcome));
+    Ok(())
+}
+
+async fn stage_joined_processed_group(
+    groups: &mut JoinSet<ProcessedGroupTaskResult>,
+    group: CacheTargetGroup,
+    processed: RunnerResult<ProcessedGroup>,
+    outcomes: &mut Vec<(CacheTargetGroup, GroupOutcome)>,
+    stage_batch: &mut GuestStageBatch,
+    sandbox: &dyn Sandbox,
+    guest_writes: &GuestWriteLocks,
+) -> RunnerResult<()> {
+    let processed = match processed {
+        Ok(processed) => processed,
+        Err(error) => {
+            abort_pending_processed_groups(groups).await;
+            return Err(error);
+        }
+    };
+    if let Err(error) = stage_processed_group(
+        group,
+        processed,
+        outcomes,
+        stage_batch,
+        sandbox,
+        guest_writes,
+    )
+    .await
+    {
+        abort_pending_processed_groups(groups).await;
+        return Err(error);
+    }
+    Ok(())
+}
+
 /// Populate the runner-side cache for eligible entries in `manifest`.
 ///
 /// Mutates `manifest.storages[i].archive_url` / `manifest.artifacts[i].archive_url`
@@ -318,40 +398,50 @@ pub async fn populate_cache(
         .map_err(|e| RunnerError::Internal(format!("build http client: {e}")))?;
     let guest_writes = GuestWriteLocks::default();
 
-    // `buffer_unordered` drives up to CONCURRENCY futures concurrently while
-    // keeping their borrows alive on the caller's stack. Unlike
-    // `tokio::task::JoinSet`, it does not require `'static` futures for the
-    // borrowed cache home and HTTP client state used here.
-    let mut groups = stream::iter(target_groups)
-        .map(|group| {
-            let http = http.clone();
-            async move {
-                let res = process_group(&group, &http, home).await;
-                (group, res)
-            }
-        })
-        .buffer_unordered(CONCURRENCY);
-
+    // Cache population runs in owned tasks so a slow guest staging write does
+    // not stop already-started workers from releasing host cache flocks. Failure
+    // paths explicitly abort and drain pending workers so locks are not left for
+    // the runtime to clean up later.
+    let mut groups = JoinSet::new();
     let mut outcomes = Vec::new();
     let mut stage_batch = GuestStageBatch::default();
-    while let Some((group, outcome)) = groups.next().await {
-        let outcome = outcome?;
-        let ProcessedGroup {
-            outcome,
-            stage_write,
-        } = outcome;
-        if let Some(stage_write) = stage_write {
-            if should_batch_stage_write(&outcome) {
-                push_guest_stage_write(&mut stage_batch, stage_write, sandbox, &guest_writes)
-                    .await?;
-            } else {
-                flush_guest_stage_batch(&mut stage_batch, sandbox, &guest_writes).await?;
-                guest_writes
-                    .write_file(sandbox, &stage_write.guest_path, &stage_write.bytes)
-                    .await?;
-            }
+
+    for group in target_groups {
+        while groups.len() >= CONCURRENCY {
+            let Some((group, outcome)) = join_next_processed_group(&mut groups).await? else {
+                break;
+            };
+            stage_joined_processed_group(
+                &mut groups,
+                group,
+                outcome,
+                &mut outcomes,
+                &mut stage_batch,
+                sandbox,
+                &guest_writes,
+            )
+            .await?;
         }
-        outcomes.push((group, outcome));
+
+        let http = http.clone();
+        let home = home.clone();
+        groups.spawn(async move {
+            let res = process_group(&group, &http, &home).await;
+            (group, res)
+        });
+    }
+
+    while let Some((group, outcome)) = join_next_processed_group(&mut groups).await? {
+        stage_joined_processed_group(
+            &mut groups,
+            group,
+            outcome,
+            &mut outcomes,
+            &mut stage_batch,
+            sandbox,
+            &guest_writes,
+        )
+        .await?;
     }
     flush_guest_stage_batch(&mut stage_batch, sandbox, &guest_writes).await?;
 
@@ -2855,6 +2945,201 @@ mod tests {
         assert_eq!(
             manifest_b.storages[0].archive_url.as_deref(),
             Some(expected.as_str())
+        );
+    }
+
+    #[tokio::test]
+    async fn slow_guest_staging_does_not_pause_in_flight_cache_population() {
+        async fn read_request(socket: &mut tokio::net::TcpStream) -> std::io::Result<String> {
+            let mut request = Vec::new();
+            let mut buf = [0u8; 1024];
+            loop {
+                let n = socket.read(&mut buf).await?;
+                if n == 0 {
+                    break;
+                }
+                request.extend_from_slice(&buf[..n]);
+                if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                    break;
+                }
+            }
+            Ok(String::from_utf8_lossy(&request).into_owned())
+        }
+
+        let temp = tempfile::tempdir().unwrap();
+        let home = home_at(&temp);
+        let sandbox = Arc::new(MockSandbox::new("test"));
+        let gate = MockLifecycleGate::new();
+        sandbox.set_write_file_lifecycle_gate(gate.clone());
+
+        let ready_name = "ready-stages-while-cold-in-flight";
+        let cold_name = "cold-continues-while-stage-blocked";
+        let version = "v1";
+
+        let ready_body = tarball_bytes();
+        let cold_body = tarball_bytes();
+        let ready_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let ready_addr = ready_listener.local_addr().unwrap();
+        let cold_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let cold_addr = cold_listener.local_addr().unwrap();
+        let (allow_ready_tx, allow_ready_rx) = tokio::sync::oneshot::channel::<()>();
+        let (cold_probe_seen_tx, cold_probe_seen_rx) = tokio::sync::oneshot::channel::<()>();
+        let (release_cold_probe_tx, release_cold_probe_rx) = tokio::sync::oneshot::channel::<()>();
+        let (cold_full_seen_tx, cold_full_seen_rx) = tokio::sync::oneshot::channel::<()>();
+
+        let ready_server_task = tokio::spawn(async move {
+            let (mut probe_socket, _) = ready_listener.accept().await?;
+            let probe_request = read_request(&mut probe_socket).await?;
+            assert!(
+                probe_request
+                    .to_ascii_lowercase()
+                    .contains("range: bytes=0-0"),
+                "expected range probe, got {probe_request:?}"
+            );
+            let _ = allow_ready_rx.await;
+            probe_socket
+                .write_all(
+                    format!(
+                        "HTTP/1.1 206 Partial Content\r\nContent-Range: bytes 0-0/{}\r\nContent-Length: 1\r\nConnection: close\r\n\r\nx",
+                        ready_body.len()
+                    )
+                    .as_bytes(),
+                )
+                .await?;
+            drop(probe_socket);
+
+            let (mut full_socket, _) = ready_listener.accept().await?;
+            let full_request = read_request(&mut full_socket).await?;
+            assert!(
+                !full_request
+                    .to_ascii_lowercase()
+                    .contains("range: bytes=0-0"),
+                "expected full download, got {full_request:?}"
+            );
+            full_socket
+                .write_all(
+                    format!(
+                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                        ready_body.len()
+                    )
+                    .as_bytes(),
+                )
+                .await?;
+            full_socket.write_all(&ready_body).await?;
+            Ok::<(), std::io::Error>(())
+        });
+
+        let cold_server_task = tokio::spawn(async move {
+            let (mut probe_socket, _) = cold_listener.accept().await?;
+            let probe_request = read_request(&mut probe_socket).await?;
+            assert!(
+                probe_request
+                    .to_ascii_lowercase()
+                    .contains("range: bytes=0-0"),
+                "expected range probe, got {probe_request:?}"
+            );
+            let _ = cold_probe_seen_tx.send(());
+            let _ = release_cold_probe_rx.await;
+            probe_socket
+                .write_all(
+                    format!(
+                        "HTTP/1.1 206 Partial Content\r\nContent-Range: bytes 0-0/{}\r\nContent-Length: 1\r\nConnection: close\r\n\r\nx",
+                        cold_body.len()
+                    )
+                    .as_bytes(),
+                )
+                .await?;
+            drop(probe_socket);
+
+            let (mut full_socket, _) = cold_listener.accept().await?;
+            let full_request = read_request(&mut full_socket).await?;
+            assert!(
+                !full_request
+                    .to_ascii_lowercase()
+                    .contains("range: bytes=0-0"),
+                "expected full download, got {full_request:?}"
+            );
+            full_socket
+                .write_all(
+                    format!(
+                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                        cold_body.len()
+                    )
+                    .as_bytes(),
+                )
+                .await?;
+            full_socket.write_all(&cold_body).await?;
+            let _ = cold_full_seen_tx.send(());
+            Ok::<(), std::io::Error>(())
+        });
+
+        let task = {
+            let home = home.clone();
+            let sandbox = Arc::clone(&sandbox);
+            tokio::spawn(async move {
+                let mut manifest = GuestDownloadManifest {
+                    storages: vec![
+                        GuestDownloadStorageEntry {
+                            mount_path: "/mnt/ready".into(),
+                            archive_url: Some(format!("http://{ready_addr}/ready.tar.gz")),
+                            cached: false,
+                            instructions_target_filename: None,
+                            vas_storage_name: ready_name.to_string(),
+                            vas_version_id: version.to_string(),
+                        },
+                        GuestDownloadStorageEntry {
+                            mount_path: "/mnt/cold".into(),
+                            archive_url: Some(format!("http://{cold_addr}/cold.tar.gz")),
+                            cached: false,
+                            instructions_target_filename: None,
+                            vas_storage_name: cold_name.to_string(),
+                            vas_version_id: version.to_string(),
+                        },
+                    ],
+                    artifacts: Vec::new(),
+                    cleanup_paths: Vec::new(),
+                };
+                let mut telemetry = new_telemetry();
+                populate_cache(&mut manifest, sandbox.as_ref(), &home, &mut telemetry).await?;
+                Ok::<GuestDownloadManifest, RunnerError>(manifest)
+            })
+        };
+
+        tokio::time::timeout(Duration::from_secs(5), cold_probe_seen_rx)
+            .await
+            .expect("cold worker should start the probe")
+            .unwrap();
+        allow_ready_tx.send(()).unwrap();
+        gate.wait_entered(1, Duration::from_secs(5)).await.unwrap();
+        release_cold_probe_tx.send(()).unwrap();
+        tokio::time::timeout(Duration::from_secs(5), cold_full_seen_rx)
+            .await
+            .expect("cold worker should continue while guest staging is blocked")
+            .unwrap();
+
+        let cold_lock = tokio::time::timeout(
+            Duration::from_secs(5),
+            lock::acquire(home.storage_lock(cold_name, version)),
+        )
+        .await
+        .expect("cold worker should release the host cache lock before guest staging unblocks")
+        .unwrap();
+        drop(cold_lock);
+
+        gate.release_one();
+        gate.wait_entered(2, Duration::from_secs(5)).await.unwrap();
+        gate.release_one();
+        let manifest = task.await.unwrap().unwrap();
+        ready_server_task.await.unwrap().unwrap();
+        cold_server_task.await.unwrap().unwrap();
+
+        assert_eq!(
+            manifest.storages[0].archive_url.as_deref(),
+            Some(format!("file://{}", guest_archive_path(ready_name, version)).as_str())
+        );
+        assert_eq!(
+            manifest.storages[1].archive_url.as_deref(),
+            Some(format!("file://{}", guest_archive_path(cold_name, version)).as_str())
         );
     }
 

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -16,7 +16,7 @@ use sandbox::{
     GuestProcessControlHandle, GuestProcessHandle, GuestProcessWaiter, ProcessControlAck,
     ProcessControlMode, ProcessExit, ProcessOutputChunk, ProcessOutputMode, Sandbox, SandboxConfig,
     SandboxError, SandboxIdleTransition, SandboxInvalidStateContext, SandboxOperation,
-    SandboxOperationReason, StartProcessRequest,
+    SandboxOperationReason, StartProcessRequest, WriteFileEntry,
 };
 use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
 use tokio::sync::{mpsc, watch};
@@ -2167,6 +2167,22 @@ impl Sandbox for FirecrackerSandbox {
 
         self.run_bounded_guest_operation(operation, |guest| async move {
             guest.write_file(path, content, false).await
+        })
+        .await
+    }
+
+    async fn write_files(&self, files: &[WriteFileEntry<'_>]) -> sandbox::Result<()> {
+        let operation = SandboxOperation::WriteFile;
+        let files = files
+            .iter()
+            .map(|file| vsock_host::WriteFileEntry {
+                path: file.path,
+                content: file.content,
+            })
+            .collect::<Vec<_>>();
+
+        self.run_bounded_guest_operation(operation, |guest| async move {
+            guest.write_files(&files).await
         })
         .await
     }

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -210,6 +210,13 @@ pub struct WriteFileCall {
     pub content: Vec<u8>,
 }
 
+/// Captured `write_files` batch request fields recorded for test assertions.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WriteFilesCall {
+    /// Guest files passed to `write_files`.
+    pub files: Vec<WriteFileCall>,
+}
+
 /// Captured `read_file` request fields recorded for test assertions.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ReadFileCall {
@@ -472,6 +479,8 @@ pub struct MockSandboxOverrides {
     exec_calls: Mutex<Vec<ExecCall>>,
     /// Recorded write_file calls across all sandboxes built from this override set.
     write_file_calls: Mutex<Vec<WriteFileCall>>,
+    /// Recorded write_files calls across all sandboxes built from this override set.
+    write_files_calls: Mutex<Vec<WriteFilesCall>>,
     /// Recorded write_private_file calls across all sandboxes built from this override set.
     private_write_file_calls: Mutex<Vec<WriteFileCall>>,
     /// FIFO queue of read_file results consumed by factory-created sandboxes.
@@ -568,6 +577,7 @@ impl MockSandboxOverrides {
             exec_matchers: Mutex::new(Vec::new()),
             exec_calls: Mutex::new(Vec::new()),
             write_file_calls: Mutex::new(Vec::new()),
+            write_files_calls: Mutex::new(Vec::new()),
             private_write_file_calls: Mutex::new(Vec::new()),
             read_file_results: Mutex::new(VecDeque::new()),
             wait_process_code: None,
@@ -702,6 +712,12 @@ impl MockSandboxOverrides {
     /// result queue.
     pub fn write_file_calls(&self) -> Vec<WriteFileCall> {
         self.write_file_calls.lock_ignoring_poison().clone()
+    }
+
+    /// Return recorded write-files batch calls across all sandboxes built from
+    /// this override set.
+    pub fn write_files_calls(&self) -> Vec<WriteFilesCall> {
+        self.write_files_calls.lock_ignoring_poison().clone()
     }
 
     /// Return recorded private write-file calls across all sandboxes built
@@ -1038,6 +1054,7 @@ pub struct MockSandbox {
     copy_file_calls: Mutex<Vec<CopyFileCall>>,
     write_file_results: Mutex<VecDeque<Result<()>>>,
     write_file_calls: Mutex<Vec<WriteFileCall>>,
+    write_files_calls: Mutex<Vec<WriteFilesCall>>,
     private_write_file_results: Mutex<VecDeque<Result<()>>>,
     private_write_file_calls: Mutex<Vec<WriteFileCall>>,
     write_file_gate: Mutex<Option<MockLifecycleGate>>,
@@ -1073,6 +1090,7 @@ impl MockSandbox {
             copy_file_calls: Mutex::new(Vec::new()),
             write_file_results: Mutex::new(VecDeque::new()),
             write_file_calls: Mutex::new(Vec::new()),
+            write_files_calls: Mutex::new(Vec::new()),
             private_write_file_results: Mutex::new(VecDeque::new()),
             private_write_file_calls: Mutex::new(Vec::new()),
             write_file_gate: Mutex::new(None),
@@ -1155,6 +1173,14 @@ impl MockSandbox {
     /// recorded in [`MockSandboxOverrides::write_file_calls`].
     pub fn write_file_calls(&self) -> Vec<WriteFileCall> {
         self.write_file_calls.lock_ignoring_poison().clone()
+    }
+
+    /// Return this sandbox's recorded write-files batch calls.
+    ///
+    /// Batch entries are also expanded into [`Self::write_file_calls`] so tests
+    /// that only need path/content assertions can use one observation surface.
+    pub fn write_files_calls(&self) -> Vec<WriteFilesCall> {
+        self.write_files_calls.lock_ignoring_poison().clone()
     }
 
     /// Queue a write_private_file result. Results are consumed in FIFO order.
@@ -1456,6 +1482,43 @@ impl Sandbox for MockSandbox {
             .push(call.clone());
         if let Some(overrides) = &self.overrides {
             overrides.write_file_calls.lock_ignoring_poison().push(call);
+        }
+        let gate = self.write_file_gate.lock_ignoring_poison().clone();
+        if let Some(gate) = gate {
+            gate.enter_and_wait().await;
+        }
+        self.write_file_results
+            .lock_ignoring_poison()
+            .pop_front()
+            .unwrap_or(Ok(()))
+    }
+
+    async fn write_files(&self, files: &[WriteFileEntry<'_>]) -> Result<()> {
+        let calls = files
+            .iter()
+            .map(|file| WriteFileCall {
+                path: file.path.to_string(),
+                content: file.content.to_vec(),
+            })
+            .collect::<Vec<_>>();
+        let batch_call = WriteFilesCall {
+            files: calls.clone(),
+        };
+        self.write_files_calls
+            .lock_ignoring_poison()
+            .push(batch_call.clone());
+        self.write_file_calls
+            .lock_ignoring_poison()
+            .extend(calls.clone());
+        if let Some(overrides) = &self.overrides {
+            overrides
+                .write_files_calls
+                .lock_ignoring_poison()
+                .push(batch_call);
+            overrides
+                .write_file_calls
+                .lock_ignoring_poison()
+                .extend(calls);
         }
         let gate = self.write_file_gate.lock_ignoring_poison().clone();
         if let Some(gate) = gate {
@@ -3885,6 +3948,42 @@ mod tests {
 
         // Falls back to default Ok.
         sandbox.write_file("/tmp/test.txt", b"data").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn sandbox_write_files_records_batch_and_consumes_one_result() {
+        let sandbox = MockSandbox::new("test-1");
+        sandbox.push_write_file_result(Err(SandboxError::Operation {
+            operation: SandboxOperation::WriteFile,
+            reason: SandboxOperationReason::Guest,
+            message: "disk full".into(),
+        }));
+
+        let files = [
+            WriteFileEntry {
+                path: "/tmp/a.txt",
+                content: b"a",
+            },
+            WriteFileEntry {
+                path: "/tmp/b.txt",
+                content: b"b",
+            },
+        ];
+        let result = sandbox.write_files(&files).await;
+        assert!(result.is_err());
+
+        sandbox.write_files(&files).await.unwrap();
+
+        let batch_calls = sandbox.write_files_calls();
+        assert_eq!(batch_calls.len(), 2);
+        assert_eq!(batch_calls[0].files.len(), 2);
+        assert_eq!(batch_calls[0].files[0].path, "/tmp/a.txt");
+        assert_eq!(batch_calls[0].files[0].content, b"a");
+        assert_eq!(batch_calls[0].files[1].path, "/tmp/b.txt");
+        assert_eq!(batch_calls[0].files[1].content, b"b");
+
+        let write_calls = sandbox.write_file_calls();
+        assert_eq!(write_calls.len(), 4);
     }
 
     #[tokio::test]

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -47,5 +47,5 @@ pub use types::{
     EXEC_OUTPUT_LIMIT_64_KIB, ExecOutputLimits, ExecRequest, ExecResult, ExecTermination,
     GuestProcessCancelHandle, GuestProcessControlHandle, GuestProcessHandle, GuestProcessWaiter,
     ProcessControlAck, ProcessControlMode, ProcessExit, ProcessOutputChunk, ProcessOutputMode,
-    ProcessOutputReceiver, StartProcessRequest,
+    ProcessOutputReceiver, StartProcessRequest, WriteFileEntry,
 };

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -39,7 +39,7 @@ use async_trait::async_trait;
 use crate::error::Result;
 use crate::types::{
     CopyFileOptions, CopyFileResult, ExecRequest, ExecResult, GuestProcessHandle, ProcessExit,
-    StartProcessRequest,
+    StartProcessRequest, WriteFileEntry,
 };
 
 /// A process-isolation environment that runs guest workloads for the runner.
@@ -246,6 +246,21 @@ pub trait Sandbox: Send + Sync + Any {
     /// directories and truncating the file as needed. Returns an error if
     /// the sandbox is not running or if the backing process crashes.
     async fn write_file(&self, path: &str, content: &[u8]) -> Result<()>;
+
+    /// Write multiple ordinary files inside the guest.
+    ///
+    /// Each entry has the same semantics as [`write_file`](Self::write_file):
+    /// create parent directories, create or truncate the target file, and write
+    /// the provided content without sudo or private runtime-file semantics.
+    /// Callers are responsible for bounding the number of files and total
+    /// content size. The default implementation preserves compatibility by
+    /// writing entries sequentially with [`write_file`](Self::write_file).
+    async fn write_files(&self, files: &[WriteFileEntry<'_>]) -> Result<()> {
+        for file in files {
+            self.write_file(file.path, file.content).await?;
+        }
+        Ok(())
+    }
 
     /// Write `content` to a private runtime file inside the guest.
     ///

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -40,6 +40,19 @@ pub const EXEC_OUTPUT_LIMIT_1_MIB: ExecOutputLimits = ExecOutputLimits::same(102
 /// Larger output budget used by interactive runner exec-style tooling.
 pub const EXEC_OUTPUT_LIMIT_7_MIB: ExecOutputLimits = ExecOutputLimits::same(7 * 1024 * 1024);
 
+/// One ordinary guest file write entry for a multi-file write operation.
+///
+/// Entries use the same semantics as [`crate::Sandbox::write_file`]: create
+/// missing parent directories, create or truncate the target file, and write
+/// the provided bytes without private runtime-file semantics.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct WriteFileEntry<'a> {
+    /// Guest path to create or replace.
+    pub path: &'a str,
+    /// Bytes to write to the guest path.
+    pub content: &'a [u8],
+}
+
 /// Request for a bounded command whose output is captured in memory.
 pub struct ExecRequest<'a> {
     /// Shell command to run inside the guest.

--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant};
 use vsock_proto::{
     self, MSG_EXEC_CANCEL, MSG_EXEC_CONTROL, MSG_EXEC_START, MSG_OPERATIONS_QUIESCED,
     MSG_OPERATIONS_RESUMED, MSG_QUIESCE_OPERATIONS, MSG_READY, MSG_RESUME_OPERATIONS,
-    MSG_WRITE_FILE, RawMessage,
+    MSG_WRITE_FILE, MSG_WRITE_FILES, RawMessage,
 };
 
 use crate::error::to_io_error;
@@ -18,8 +18,8 @@ use crate::exec_operation::{
     start_exec_operation,
 };
 use crate::handlers::{
-    MessageOutcome, decode_write_file_message, handle_basic_message,
-    handle_decoded_write_file_message,
+    MessageOutcome, decode_write_file_message, decode_write_files_message, handle_basic_message,
+    handle_decoded_write_file_message, handle_decoded_write_files_message,
 };
 use crate::log::log;
 use crate::quiesce::{AcquireOperationError, OperationGuard, OperationState, QuiesceResult};
@@ -119,6 +119,7 @@ fn is_real_host_work_message(msg_type: u8) -> bool {
             | MSG_EXEC_CANCEL
             | MSG_EXEC_CONTROL
             | MSG_WRITE_FILE
+            | MSG_WRITE_FILES
             | MSG_QUIESCE_OPERATIONS
             | MSG_RESUME_OPERATIONS
     )
@@ -257,6 +258,7 @@ impl ConnectionDispatcher {
             MSG_EXEC_CANCEL => self.handle_exec_cancel(msg)?,
             MSG_EXEC_CONTROL => self.handle_exec_control(msg)?,
             MSG_WRITE_FILE => self.handle_write_file(msg)?,
+            MSG_WRITE_FILES => self.handle_write_files(msg)?,
             MSG_QUIESCE_OPERATIONS => self.handle_quiesce_operations(msg)?,
             MSG_RESUME_OPERATIONS => self.handle_resume_operations(msg)?,
             _ => return self.handle_basic_message(msg),
@@ -379,6 +381,31 @@ impl ConnectionDispatcher {
             return Ok(());
         };
         let response = handle_decoded_write_file_message(msg.seq, decoded)?;
+        self.writer.write_frame_after_lock(&response, || {
+            operation_guard.release();
+        })
+    }
+
+    fn handle_write_files(&self, msg: &RawMessage) -> io::Result<()> {
+        if !require_non_zero_sequence(msg.seq, "write_files", &self.writer)? {
+            return Ok(());
+        }
+        if reject_operation_if_quiescing(&self.operation_state, msg.seq, &self.writer)? {
+            return Ok(());
+        }
+        let decoded = match decode_write_files_message(msg) {
+            Ok(decoded) => decoded,
+            Err(error) => {
+                send_error_response(msg.seq, &error.to_string(), &self.writer)?;
+                return Ok(());
+            }
+        };
+        let Some(operation_guard) =
+            acquire_operation_guard(&self.operation_state, msg.seq, &self.writer)?
+        else {
+            return Ok(());
+        };
+        let response = handle_decoded_write_files_message(msg.seq, decoded)?;
         self.writer.write_frame_after_lock(&response, || {
             operation_guard.release();
         })

--- a/crates/vsock-guest/src/handlers.rs
+++ b/crates/vsock-guest/src/handlers.rs
@@ -7,7 +7,8 @@ use std::sync::Mutex;
 use std::sync::atomic::AtomicBool;
 
 use vsock_proto::{
-    self, MSG_ERROR, MSG_PING, MSG_PONG, MSG_SHUTDOWN, MSG_WRITE_FILE_RESULT, RawMessage,
+    self, MSG_ERROR, MSG_PING, MSG_PONG, MSG_SHUTDOWN, MSG_WRITE_FILE_RESULT,
+    MSG_WRITE_FILES_RESULT, RawMessage,
 };
 
 use crate::drain::drain_into_vec_cancellable;
@@ -41,6 +42,12 @@ pub(crate) struct DecodedWriteFileMessage<'a> {
     private: bool,
 }
 
+pub(crate) struct DecodedWriteFilesMessage<'a> {
+    payload: &'a [u8],
+    file_count: usize,
+    content_bytes: usize,
+}
+
 /// Handle write_file message
 fn handle_write_file(
     path: &str,
@@ -67,6 +74,20 @@ fn handle_write_file(
     };
 
     wait_write_file_child(child, content, SystemThreadSpawner)
+}
+
+fn handle_write_files(payload: &[u8], file_count: usize, content_bytes: usize) -> (bool, String) {
+    log(
+        "INFO",
+        &format!("write_files: files={file_count} content_bytes={content_bytes}"),
+    );
+
+    let child = match spawn_write_files_command() {
+        Ok(c) => c,
+        Err(e) => return (false, format!("Failed to spawn batch write command: {e}")),
+    };
+
+    wait_write_file_child(child, payload, SystemThreadSpawner)
 }
 
 fn wait_write_file_child<S>(child: Child, content: &[u8], spawner: S) -> (bool, String)
@@ -233,6 +254,17 @@ fn spawn_write_file_command(
     spawn_in_own_process_group(&mut command)
 }
 
+fn spawn_write_files_command() -> io::Result<Child> {
+    let mut command = Command::new(guest_write_file_path());
+    command
+        .arg("--batch")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped());
+    apply_write_file_identity(&mut command, false)?;
+    spawn_in_own_process_group(&mut command)
+}
+
 fn guest_write_file_path() -> PathBuf {
     #[cfg(any(debug_assertions, feature = "test-support"))]
     {
@@ -269,6 +301,18 @@ pub(crate) fn decode_write_file_message(
     })
 }
 
+pub(crate) fn decode_write_files_message(
+    msg: &RawMessage,
+) -> Result<DecodedWriteFilesMessage<'_>, vsock_proto::ProtocolError> {
+    let files = vsock_proto::decode_write_files(&msg.payload)?;
+    let content_bytes = files.iter().map(|file| file.content.len()).sum();
+    Ok(DecodedWriteFilesMessage {
+        payload: &msg.payload,
+        file_count: files.len(),
+        content_bytes,
+    })
+}
+
 pub(crate) fn handle_decoded_write_file_message(
     seq: u32,
     decoded: DecodedWriteFileMessage<'_>,
@@ -282,6 +326,16 @@ pub(crate) fn handle_decoded_write_file_message(
     );
     let payload = vsock_proto::encode_write_file_result(success, &error);
     vsock_proto::encode(MSG_WRITE_FILE_RESULT, seq, &payload).map_err(to_io_error)
+}
+
+pub(crate) fn handle_decoded_write_files_message(
+    seq: u32,
+    decoded: DecodedWriteFilesMessage<'_>,
+) -> io::Result<Vec<u8>> {
+    let (success, error) =
+        handle_write_files(decoded.payload, decoded.file_count, decoded.content_bytes);
+    let payload = vsock_proto::encode_write_files_result(success, &error);
+    vsock_proto::encode(MSG_WRITE_FILES_RESULT, seq, &payload).map_err(to_io_error)
 }
 
 /// Handle basic incoming messages and return the connection-loop outcome.

--- a/crates/vsock-host/src/file/mod.rs
+++ b/crates/vsock-host/src/file/mod.rs
@@ -9,6 +9,7 @@ use shell_quote::quote_shell_arg;
 use crate::exec_operation;
 
 pub use copy::{CopyFileOptions, CopyFileResult};
+pub use write::WriteFileEntry;
 
 const MISSING_FILE_EXIT_CODE: i32 = 66;
 

--- a/crates/vsock-host/src/file/write.rs
+++ b/crates/vsock-host/src/file/write.rs
@@ -5,7 +5,10 @@ use std::time::Duration;
 use std::{fmt, io};
 
 use shell_quote::quote_shell_arg;
-use vsock_proto::{ExecTermination, MSG_ERROR, MSG_WRITE_FILE, MSG_WRITE_FILE_RESULT};
+use vsock_proto::{
+    ExecTermination, MSG_ERROR, MSG_WRITE_FILE, MSG_WRITE_FILE_RESULT, MSG_WRITE_FILES,
+    MSG_WRITE_FILES_RESULT,
+};
 
 use crate::{
     CompositeNormalOperation, ExecCaptureRequest, ExecOperationResult, ExecOwnedCapturedOutput,
@@ -20,6 +23,13 @@ use super::{normalize_file_exec_stderr, validate_guest_file_path};
 /// [`vsock_proto::MAX_MESSAGE_SIZE`] for the path and frame overhead.
 pub(super) const WRITE_FILE_CHUNK_LIMIT: usize = 15 * 1024 * 1024;
 const WRITE_FILE_TERMINAL_MSG_TYPES: &[u8] = &[MSG_ERROR, MSG_WRITE_FILE_RESULT];
+const WRITE_FILES_TERMINAL_MSG_TYPES: &[u8] = &[MSG_ERROR, MSG_WRITE_FILES_RESULT];
+
+/// Maximum number of files in one write_files request.
+pub const WRITE_FILES_BATCH_FILE_LIMIT: usize = 64;
+
+/// Maximum total file content bytes in one write_files request.
+pub const WRITE_FILES_BATCH_CONTENT_LIMIT: usize = WRITE_FILE_CHUNK_LIMIT;
 
 /// Timeout (ms) for short helper commands (mv, rm) used during chunked writes.
 const HELPER_EXEC_TIMEOUT_MS: u32 = 5000;
@@ -61,6 +71,15 @@ impl<'a> WriteFileChunkRequest<'a> {
             private: true,
         }
     }
+}
+
+/// One ordinary guest file write entry for [`VsockHost::write_files`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct WriteFileEntry<'a> {
+    /// Guest path to create or replace.
+    pub path: &'a str,
+    /// Bytes to write to the guest path.
+    pub content: &'a [u8],
 }
 
 #[derive(Debug)]
@@ -386,6 +405,17 @@ impl VsockHost {
             .await
     }
 
+    /// Write multiple ordinary files on the guest in one request.
+    ///
+    /// Every file uses non-sudo create-parent and truncate semantics. The
+    /// caller must use [`write_file`](Self::write_file) for private, sudo,
+    /// append, or larger individual writes. Empty batches are accepted as a
+    /// no-op to match the higher-level sandbox trait default.
+    pub async fn write_files(&self, files: &[WriteFileEntry<'_>]) -> io::Result<()> {
+        self.write_files_with_write_observer(files, FrameWriteObserver::default())
+            .await
+    }
+
     /// Write a private runtime file on the guest.
     ///
     /// Content larger than 15 MB is split into multiple messages. The first
@@ -541,6 +571,87 @@ impl VsockHost {
                 Err(err.error)
             }
         }
+    }
+
+    /// Write multiple ordinary files on the guest and report before the batch
+    /// frame is written.
+    pub async fn write_files_with_write_observer(
+        &self,
+        files: &[WriteFileEntry<'_>],
+        write_observer: FrameWriteObserver,
+    ) -> io::Result<()> {
+        if files.is_empty() {
+            return Ok(());
+        }
+        if files.len() > WRITE_FILES_BATCH_FILE_LIMIT {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "write_files batch contains {} files, limit is {WRITE_FILES_BATCH_FILE_LIMIT}",
+                    files.len()
+                ),
+            ));
+        }
+
+        let mut total_content_len = 0usize;
+        let mut proto_entries = Vec::with_capacity(files.len());
+        for file in files {
+            validate_guest_file_path(file.path)?;
+            total_content_len = total_content_len
+                .checked_add(file.content.len())
+                .ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "write_files content length overflow",
+                    )
+                })?;
+            proto_entries.push(vsock_proto::WriteFileBatchEntry {
+                path: file.path,
+                content: file.content,
+            });
+        }
+        if total_content_len > WRITE_FILES_BATCH_CONTENT_LIMIT {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "write_files batch contains {total_content_len} content bytes, limit is {WRITE_FILES_BATCH_CONTENT_LIMIT}"
+                ),
+            ));
+        }
+
+        let payload = vsock_proto::encode_write_files(&proto_entries)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
+        let timeout = Duration::from_secs(300);
+        let resp = normal_request_on_shared_with_write_observer(
+            &self.shared,
+            MSG_WRITE_FILES,
+            &payload,
+            WRITE_FILES_TERMINAL_MSG_TYPES,
+            timeout,
+            write_observer,
+        )
+        .await?;
+
+        if resp.msg_type == MSG_ERROR {
+            let msg = vsock_proto::decode_error(&resp.payload)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+            return Err(write_file_guest_error(msg));
+        }
+
+        if resp.msg_type != MSG_WRITE_FILES_RESULT {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("unexpected response type: 0x{:02X}", resp.msg_type),
+            ));
+        }
+
+        let (success, error) = vsock_proto::decode_write_files_result(&resp.payload)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+        if !success {
+            return Err(write_file_guest_error(error));
+        }
+
+        Ok(())
     }
 
     /// Send a single write_file message and validate the response.

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -103,7 +103,7 @@ pub use exec_operation::{
     ExecOutputEvent, ExecOwnedCapturedOutput, ExecStreamRequest, SupervisedExecCancelHandle,
     SupervisedExecControl, SupervisedExecHandle, SupervisedExecRequest,
 };
-pub use file::{CopyFileOptions, CopyFileResult};
+pub use file::{CopyFileOptions, CopyFileResult, WriteFileEntry};
 
 const READ_BUF_SIZE: usize = 64 * 1024;
 

--- a/crates/vsock-host/src/tests/file/support.rs
+++ b/crates/vsock-host/src/tests/file/support.rs
@@ -8,11 +8,11 @@ use tokio::task::JoinHandle;
 use uuid::Uuid;
 use vsock_proto::{
     DecodedExecStart, ExecOutputPolicy, MSG_ERROR, MSG_EXEC_START, MSG_WRITE_FILE,
-    MSG_WRITE_FILE_RESULT, RawMessage,
+    MSG_WRITE_FILE_RESULT, MSG_WRITE_FILES, MSG_WRITE_FILES_RESULT, RawMessage,
 };
 
 use super::super::support::read_guest_message;
-use crate::{CopyFileOptions, CopyFileResult, VsockHost};
+use crate::{CopyFileOptions, CopyFileResult, VsockHost, WriteFileEntry};
 
 pub(super) struct HostTempDir {
     path: PathBuf,
@@ -127,6 +127,22 @@ pub(super) fn spawn_write_private_file(
     tokio::spawn(async move { host.write_private_file(path, &content).await })
 }
 
+pub(super) fn spawn_write_files(
+    host: Arc<VsockHost>,
+    files: Vec<(&'static str, Vec<u8>)>,
+) -> JoinHandle<io::Result<()>> {
+    tokio::spawn(async move {
+        let entries = files
+            .iter()
+            .map(|(path, content)| WriteFileEntry {
+                path,
+                content: content.as_slice(),
+            })
+            .collect::<Vec<_>>();
+        host.write_files(&entries).await
+    })
+}
+
 pub(super) struct ExecStartFrame {
     pub(super) msg: RawMessage,
     pub(super) command: String,
@@ -196,6 +212,17 @@ impl WriteFileFrame {
     }
 }
 
+pub(super) struct WriteFilesFrame {
+    pub(super) msg: RawMessage,
+    pub(super) files: Vec<(String, Vec<u8>)>,
+}
+
+impl WriteFilesFrame {
+    pub(super) fn seq(&self) -> u32 {
+        self.msg.seq
+    }
+}
+
 pub(super) async fn expect_write_file(guest: &mut UnixStream) -> WriteFileFrame {
     let msg = read_guest_message(guest).await;
     assert_eq!(msg.msg_type, MSG_WRITE_FILE);
@@ -212,6 +239,17 @@ pub(super) async fn expect_write_file(guest: &mut UnixStream) -> WriteFileFrame 
         append,
         private,
     }
+}
+
+pub(super) async fn expect_write_files(guest: &mut UnixStream) -> WriteFilesFrame {
+    let msg = read_guest_message(guest).await;
+    assert_eq!(msg.msg_type, MSG_WRITE_FILES);
+    let files = vsock_proto::decode_write_files(&msg.payload)
+        .unwrap()
+        .into_iter()
+        .map(|file| (file.path.to_string(), file.content.to_vec()))
+        .collect();
+    WriteFilesFrame { msg, files }
 }
 
 pub(super) async fn send_write_file_success(guest: &mut UnixStream, seq: u32) {
@@ -231,6 +269,27 @@ pub(super) async fn send_write_file_result(
     let payload = vsock_proto::encode_write_file_result(success, message);
     guest
         .write_all(&vsock_proto::encode(MSG_WRITE_FILE_RESULT, seq, &payload).unwrap())
+        .await
+        .unwrap();
+}
+
+pub(super) async fn send_write_files_success(guest: &mut UnixStream, seq: u32) {
+    send_write_files_result(guest, seq, true, "").await;
+}
+
+pub(super) async fn send_write_files_failure(guest: &mut UnixStream, seq: u32, message: &str) {
+    send_write_files_result(guest, seq, false, message).await;
+}
+
+pub(super) async fn send_write_files_result(
+    guest: &mut UnixStream,
+    seq: u32,
+    success: bool,
+    message: &str,
+) {
+    let payload = vsock_proto::encode_write_files_result(success, message);
+    guest
+        .write_all(&vsock_proto::encode(MSG_WRITE_FILES_RESULT, seq, &payload).unwrap())
         .await
         .unwrap();
 }

--- a/crates/vsock-host/src/tests/file/write.rs
+++ b/crates/vsock-host/src/tests/file/write.rs
@@ -11,10 +11,11 @@ use super::super::support::{
     make_pair, normal_operation_readiness, pending_request_count, setup_host_and_guest,
 };
 use super::support::{
-    expect_write_file, send_guest_error, send_write_file_failure, send_write_file_success,
-    spawn_write_file,
+    expect_write_file, expect_write_files, send_guest_error, send_write_file_failure,
+    send_write_file_success, send_write_files_failure, send_write_files_success, spawn_write_file,
+    spawn_write_files,
 };
-use crate::{FrameWriteObserver, operation_tracker::NormalOperationReadiness};
+use crate::{FrameWriteObserver, WriteFileEntry, operation_tracker::NormalOperationReadiness};
 
 #[tokio::test]
 async fn test_write_file() {
@@ -31,6 +32,122 @@ async fn test_write_file() {
     send_write_file_success(&mut guest, write.seq()).await;
 
     write_task.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn write_files_sends_single_batch_and_tracks_until_result() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let write_task = spawn_write_files(
+        Arc::clone(&host),
+        vec![
+            ("/tmp/a.txt", b"alpha".to_vec()),
+            ("/tmp/b.txt", b"beta".to_vec()),
+        ],
+    );
+
+    let write = expect_write_files(&mut guest).await;
+    assert_eq!(
+        write.files,
+        vec![
+            ("/tmp/a.txt".to_string(), b"alpha".to_vec()),
+            ("/tmp/b.txt".to_string(), b"beta".to_vec()),
+        ]
+    );
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Busy
+    );
+
+    send_write_files_success(&mut guest, write.seq()).await;
+
+    write_task.await.unwrap().unwrap();
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+}
+
+#[tokio::test]
+async fn write_files_guest_failure_releases_tracker() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let write_task = spawn_write_files(
+        Arc::clone(&host),
+        vec![
+            ("/tmp/a.txt", b"alpha".to_vec()),
+            ("/tmp/b.txt", b"beta".to_vec()),
+        ],
+    );
+
+    let write = expect_write_files(&mut guest).await;
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Busy
+    );
+
+    send_write_files_failure(&mut guest, write.seq(), "permission denied").await;
+
+    let err = write_task.await.unwrap().unwrap_err();
+    assert!(err.to_string().contains("permission denied"));
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+}
+
+#[tokio::test]
+async fn write_files_empty_batch_is_noop() {
+    let (host, guest) = setup_host_and_guest().await;
+
+    host.write_files(&[]).await.unwrap();
+
+    match guest.try_read(&mut [0u8; 1]) {
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+        Ok(n) => panic!("empty write_files must not send a frame; read {n} bytes"),
+        Err(err) => panic!("unexpected read error after empty write_files: {err}"),
+    }
+    assert_eq!(pending_request_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+}
+
+#[tokio::test]
+async fn write_files_rejects_invalid_path_before_sending_frame() {
+    let (host, guest) = setup_host_and_guest().await;
+    let write_start_count = Arc::new(AtomicUsize::new(0));
+
+    let err = host
+        .write_files_with_write_observer(
+            &[WriteFileEntry {
+                path: "/tmp/has\0nul",
+                content: b"hello",
+            }],
+            FrameWriteObserver::new({
+                let write_start_count = Arc::clone(&write_start_count);
+                move || {
+                    write_start_count.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                }
+            }),
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    assert_eq!(write_start_count.load(Ordering::SeqCst), 0);
+    match guest.try_read(&mut [0u8; 1]) {
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+        Ok(n) => panic!("invalid write_files path must not send a frame; read {n} bytes"),
+        Err(err) => panic!("unexpected read error after invalid write_files path: {err}"),
+    }
+    assert_eq!(pending_request_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
 }
 
 #[tokio::test]

--- a/crates/vsock-host/src/tests/support.rs
+++ b/crates/vsock-host/src/tests/support.rs
@@ -12,7 +12,7 @@ use vsock_proto::{
     MSG_EXEC_CONTROL_RESULT, MSG_EXEC_OUTPUT, MSG_EXEC_RESULT, MSG_EXEC_START, MSG_EXEC_STARTED,
     MSG_OPERATIONS_QUIESCED, MSG_OPERATIONS_RESUMED, MSG_PING, MSG_PONG, MSG_QUIESCE_OPERATIONS,
     MSG_READY, MSG_RESUME_OPERATIONS, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_WRITE_FILE,
-    MSG_WRITE_FILE_RESULT, RawMessage,
+    MSG_WRITE_FILE_RESULT, MSG_WRITE_FILES, MSG_WRITE_FILES_RESULT, RawMessage,
 };
 
 use crate::operation_tracker::NormalOperationReadiness;
@@ -149,6 +149,8 @@ fn message_type_name(msg_type: u8) -> &'static str {
         MSG_OPERATIONS_RESUMED => "operations_resumed",
         MSG_WRITE_FILE => "write_file",
         MSG_WRITE_FILE_RESULT => "write_file_result",
+        MSG_WRITE_FILES => "write_files",
+        MSG_WRITE_FILES_RESULT => "write_files_result",
         MSG_EXEC_START => "exec_start",
         MSG_EXEC_STARTED => "exec_started",
         MSG_EXEC_OUTPUT => "exec_output",

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -49,11 +49,12 @@
 //! | 0xFF | G→H       | error             | `[2B error_len][error]` |
 //!
 //! Request-scoped operation messages must use non-zero sequence numbers. This
-//! covers `write_file`, `exec_start`, `exec_cancel`, and `exec_control`; guest
-//! exec lifecycle frames reuse the original non-zero request sequence.
-//! `exec_output.output_seq` is per exec operation and starts at 0,
-//! incrementing by 1 for each output frame across stdout and stderr.
-//! `write_file_result.success` uses 0=false and 1=true.
+//! covers `write_file`, `write_files`, `exec_start`, `exec_cancel`, and
+//! `exec_control`; guest exec lifecycle frames reuse the original non-zero
+//! request sequence. `exec_output.output_seq` is per exec operation and starts
+//! at 0, incrementing by 1 for each output frame across stdout and stderr.
+//! `write_file_result.success` / `write_files_result.success` use 0=false and
+//! 1=true.
 //! `exec_control_result.status` is an [`ExecControlStatus`] wire value.
 //! `exec_control.request_timeout_ms` is the caller-visible budget, counted
 //! from guest receipt through local sink connection, request write, and response

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -44,6 +44,8 @@
 //! | 0x0F | H→G       | exec_cancel    | (empty) |
 //! | 0x10 | H→G       | exec_control | `[4B target_seq][4B request_timeout_ms][16B nonce][2B message_id_len][message_id][4B payload_len][payload]` |
 //! | 0x11 | G→H       | exec_control_result | `[4B target_seq][16B nonce][2B message_id_len][message_id][1B status][2B diagnostic_len][diagnostic]` |
+//! | 0x12 | H→G       | write_files       | `[2B file_count][file_entry]...`, where each file entry is `[2B path_len][path][4B content_len][content]` |
+//! | 0x13 | G→H       | write_files_result | `[1B success][2B error_len][error]` |
 //! | 0xFF | G→H       | error             | `[2B error_len][error]` |
 //!
 //! Request-scoped operation messages must use non-zero sequence numbers. This
@@ -171,8 +173,9 @@ pub use payloads::exec_operation::{
     encode_exec_started,
 };
 pub use payloads::write_file::{
-    decode_write_file, decode_write_file_result, encode_private_write_file, encode_write_file,
-    encode_write_file_result,
+    WriteFileBatchEntry, decode_write_file, decode_write_file_result, decode_write_files,
+    decode_write_files_result, encode_private_write_file, encode_write_file,
+    encode_write_file_result, encode_write_files, encode_write_files_result,
 };
 pub use wire::{
     EXEC_CAPTURED_OUTPUT_FLAG_TRUNCATED, EXEC_FLAG_SUDO, EXEC_OUTPUT_FLAG_TRUNCATED, HEADER_SIZE,
@@ -180,6 +183,6 @@ pub use wire::{
     MSG_EXEC_CONTROL_RESULT, MSG_EXEC_OUTPUT, MSG_EXEC_RESULT, MSG_EXEC_START, MSG_EXEC_STARTED,
     MSG_OPERATIONS_QUIESCED, MSG_OPERATIONS_RESUMED, MSG_PING, MSG_PONG, MSG_QUIESCE_OPERATIONS,
     MSG_READY, MSG_RESUME_OPERATIONS, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_WRITE_FILE,
-    MSG_WRITE_FILE_RESULT, VSOCK_PORT, WRITE_FILE_FLAG_APPEND, WRITE_FILE_FLAG_PRIVATE,
-    WRITE_FILE_FLAG_SUDO,
+    MSG_WRITE_FILE_RESULT, MSG_WRITE_FILES, MSG_WRITE_FILES_RESULT, VSOCK_PORT,
+    WRITE_FILE_FLAG_APPEND, WRITE_FILE_FLAG_PRIVATE, WRITE_FILE_FLAG_SUDO,
 };

--- a/crates/vsock-proto/src/payloads/write_file.rs
+++ b/crates/vsock-proto/src/payloads/write_file.rs
@@ -6,6 +6,15 @@ use crate::read::{
 };
 use crate::wire::{WRITE_FILE_FLAG_APPEND, WRITE_FILE_FLAG_PRIVATE, WRITE_FILE_FLAG_SUDO};
 
+/// One ordinary file write entry in a `write_files` batch payload.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct WriteFileBatchEntry<'a> {
+    /// Guest path to create or replace.
+    pub path: &'a str,
+    /// Bytes to write to the guest path.
+    pub content: &'a [u8],
+}
+
 /// Encode write_file payload: `[2B path_len][path][1B flags][4B content_len][content]`.
 ///
 /// Returns `Err` if path exceeds 65535 bytes (u16 field limit).
@@ -26,6 +35,44 @@ pub fn encode_private_write_file(
     append: bool,
 ) -> Result<Vec<u8>, ProtocolError> {
     encode_write_file_flags(path, content, false, append, true)
+}
+
+/// Encode write_files payload:
+/// `[2B file_count]` followed by `[2B path_len][path][4B content_len][content]` for each file.
+///
+/// Returns `Err` if the batch is empty, any path exceeds 65535 bytes, or the
+/// payload cannot fit in one protocol frame.
+pub fn encode_write_files(files: &[WriteFileBatchEntry<'_>]) -> Result<Vec<u8>, ProtocolError> {
+    if files.is_empty() {
+        return Err(ProtocolError::InvalidPayload(
+            "write_files file count must be positive",
+        ));
+    }
+    let file_count = ensure_u16_len("files", files.len())?;
+    let mut payload_len = 2;
+    let mut encoded_entries = Vec::with_capacity(files.len());
+    for file in files {
+        let path_bytes = file.path.as_bytes();
+        let path_len = ensure_u16_len("path", path_bytes.len())?;
+        let content_len = ensure_u32_len("content", file.content.len())?;
+        payload_len = checked_payload_len_add(payload_len, 2)?;
+        payload_len = checked_payload_len_add(payload_len, path_bytes.len())?;
+        payload_len = checked_payload_len_add(payload_len, 4)?;
+        payload_len = checked_payload_len_add(payload_len, file.content.len())?;
+        encoded_entries.push((path_len, path_bytes, content_len, file.content));
+    }
+    ensure_payload_fits_message(payload_len)?;
+
+    let mut p = Vec::with_capacity(payload_len);
+    p.extend_from_slice(&file_count.to_be_bytes());
+    for (path_len, path_bytes, content_len, content) in encoded_entries {
+        p.extend_from_slice(&path_len.to_be_bytes());
+        p.extend_from_slice(path_bytes);
+        p.extend_from_slice(&content_len.to_be_bytes());
+        p.extend_from_slice(content);
+    }
+    debug_assert_eq!(p.len(), payload_len);
+    Ok(p)
 }
 
 fn encode_write_file_flags(
@@ -75,6 +122,11 @@ pub fn encode_write_file_result(success: bool, error: &str) -> Vec<u8> {
     p
 }
 
+/// Encode write_files_result payload: `[1B success][2B error_len][error]`.
+pub fn encode_write_files_result(success: bool, error: &str) -> Vec<u8> {
+    encode_write_file_result(success, error)
+}
+
 /// Decode write_file payload. Returns `(path, content, sudo, append, private)`.
 pub fn decode_write_file(payload: &[u8]) -> Result<(&str, &[u8], bool, bool, bool), ProtocolError> {
     let mut offset = 0;
@@ -114,6 +166,43 @@ pub fn decode_write_file(payload: &[u8]) -> Result<(&str, &[u8], bool, bool, boo
     ))
 }
 
+/// Decode write_files payload.
+///
+/// Returns borrowed file entries backed by `payload`.
+pub fn decode_write_files(payload: &[u8]) -> Result<Vec<WriteFileBatchEntry<'_>>, ProtocolError> {
+    let mut offset = 0;
+    let file_count = read_u16(payload, &mut offset, "write_files too short")? as usize;
+    if file_count == 0 {
+        return Err(ProtocolError::InvalidPayload(
+            "write_files file count must be positive",
+        ));
+    }
+
+    let mut files = Vec::with_capacity(file_count);
+    for _ in 0..file_count {
+        let path_len = read_u16(payload, &mut offset, "write_files path_len truncated")? as usize;
+        let path = read_str(
+            payload,
+            &mut offset,
+            path_len,
+            "write_files path truncated",
+            "invalid UTF-8 in write_files path",
+        )?;
+        let content_len =
+            read_u32(payload, &mut offset, "write_files content_len truncated")? as usize;
+        let content = read_slice(
+            payload,
+            &mut offset,
+            content_len,
+            "write_files content truncated",
+        )?;
+        files.push(WriteFileBatchEntry { path, content });
+    }
+    expect_consumed(payload, offset, "write_files trailing bytes")?;
+
+    Ok(files)
+}
+
 /// Decode write_file_result payload. Returns `(success, error)`.
 pub fn decode_write_file_result(payload: &[u8]) -> Result<(bool, &str), ProtocolError> {
     let mut offset = 0;
@@ -137,6 +226,11 @@ pub fn decode_write_file_result(payload: &[u8]) -> Result<(bool, &str), Protocol
     expect_consumed(payload, offset, "write_file_result trailing bytes")?;
 
     Ok((success, error))
+}
+
+/// Decode write_files_result payload. Returns `(success, error)`.
+pub fn decode_write_files_result(payload: &[u8]) -> Result<(bool, &str), ProtocolError> {
+    decode_write_file_result(payload)
 }
 
 #[cfg(test)]
@@ -199,6 +293,66 @@ mod tests {
         assert!(!sudo);
         assert!(append);
         assert!(private);
+    }
+
+    #[test]
+    fn write_files_payload_roundtrip() {
+        let files = [
+            WriteFileBatchEntry {
+                path: "/tmp/a.txt",
+                content: b"alpha",
+            },
+            WriteFileBatchEntry {
+                path: "/tmp/b.txt",
+                content: b"beta",
+            },
+        ];
+
+        let payload = encode_write_files(&files).unwrap();
+        let decoded = decode_write_files(&payload).unwrap();
+
+        assert_eq!(decoded, files);
+    }
+
+    #[test]
+    fn write_files_rejects_empty_batch() {
+        let err = encode_write_files(&[]).unwrap_err();
+
+        assert_invalid_payload(err, "write_files file count must be positive");
+    }
+
+    #[test]
+    fn write_files_content_too_large() {
+        let path = "/tmp/f";
+        let payload_overhead = 2 + 2 + path.len() + 4;
+        let big = vec![0u8; MAX_PAYLOAD_SIZE - payload_overhead + 1];
+
+        let err = encode_write_files(&[WriteFileBatchEntry {
+            path,
+            content: &big,
+        }])
+        .unwrap_err();
+
+        assert!(matches!(err, ProtocolError::MessageTooLarge(_)));
+    }
+
+    #[test]
+    fn write_files_content_at_payload_limit() {
+        let path = "/tmp/f";
+        let payload_overhead = 2 + 2 + path.len() + 4;
+        let content = vec![0u8; MAX_PAYLOAD_SIZE - payload_overhead];
+
+        let payload = encode_write_files(&[WriteFileBatchEntry {
+            path,
+            content: &content,
+        }])
+        .unwrap();
+
+        assert_eq!(payload.len(), MAX_PAYLOAD_SIZE);
+        let decoded = decode_write_files(&payload).unwrap();
+        assert_eq!(decoded.len(), 1);
+        assert_eq!(decoded[0].path, path);
+        assert_eq!(decoded[0].content, content.as_slice());
     }
 
     #[test]
@@ -328,6 +482,51 @@ mod tests {
         let err = decode_write_file(&payload).unwrap_err();
 
         assert_invalid_payload(err, "invalid UTF-8 in path");
+    }
+
+    #[test]
+    fn decode_write_files_rejects_zero_count() {
+        let err = decode_write_files(&[0, 0]).unwrap_err();
+
+        assert_invalid_payload(err, "write_files file count must be positive");
+    }
+
+    #[test]
+    fn decode_write_files_rejects_truncated_fields() {
+        for (payload, expected) in [
+            (b"".as_slice(), "write_files too short"),
+            (&[0], "write_files too short"),
+            (&[0, 1], "write_files path_len truncated"),
+            (&[0, 1, 0, 1], "write_files path truncated"),
+            (&[0, 1, 0, 0], "write_files content_len truncated"),
+            (&[0, 1, 0, 0, 0, 0, 0, 1], "write_files content truncated"),
+        ] {
+            let err = decode_write_files(payload).unwrap_err();
+            assert_invalid_payload(err, expected);
+        }
+    }
+
+    #[test]
+    fn decode_write_files_rejects_trailing_bytes() {
+        let mut payload = encode_write_files(&[WriteFileBatchEntry {
+            path: "/tmp/test.txt",
+            content: b"content",
+        }])
+        .unwrap();
+        payload.push(0);
+
+        let err = decode_write_files(&payload).unwrap_err();
+
+        assert_invalid_payload(err, "write_files trailing bytes");
+    }
+
+    #[test]
+    fn decode_write_files_rejects_invalid_utf8_path() {
+        let payload = [0, 1, 0, 1, 0xC3, 0, 0, 0, 0];
+
+        let err = decode_write_files(&payload).unwrap_err();
+
+        assert_invalid_payload(err, "invalid UTF-8 in write_files path");
     }
 
     #[test]

--- a/crates/vsock-proto/src/wire.rs
+++ b/crates/vsock-proto/src/wire.rs
@@ -69,6 +69,12 @@ pub const MSG_EXEC_CONTROL: u8 = 0x10;
 /// Guest-to-host exec control delivery result.
 pub const MSG_EXEC_CONTROL_RESULT: u8 = 0x11;
 
+/// Host-to-guest multi-file write request.
+pub const MSG_WRITE_FILES: u8 = 0x12;
+
+/// Guest-to-host multi-file write completion response.
+pub const MSG_WRITE_FILES_RESULT: u8 = 0x13;
+
 /// Guest-to-host protocol error response.
 pub const MSG_ERROR: u8 = 0xFF;
 
@@ -120,6 +126,8 @@ mod tests {
             MSG_EXEC_CANCEL,
             MSG_EXEC_CONTROL,
             MSG_EXEC_CONTROL_RESULT,
+            MSG_WRITE_FILES,
+            MSG_WRITE_FILES_RESULT,
         ];
 
         for (expected, actual) in (0_u8..).zip(non_error_types) {


### PR DESCRIPTION
## Summary
- add a vsock `write_files` request/response and sandbox `write_files` API for ordinary guest file writes
- add `guest-write-file --batch` to apply a bounded `write_files` payload in one helper process
- batch runner storage-cache warm-hit staging while keeping cold misses on the existing immediate write path

Fixes #19038

## Tests
- `cargo test --manifest-path crates/Cargo.toml -p vsock-proto`
- `cargo test --manifest-path crates/Cargo.toml -p guest-write-file`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host write_files`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-mock write_files`
- `cargo test --manifest-path crates/Cargo.toml -p runner storage_cache`
- pre-commit: cargo fmt, cargo doc, cargo clippy