### PR TITLE
fix(cli): guide computer-use capability denials

### DIFF
--- a/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
@@ -54,10 +54,18 @@ function hiddenCommandNames(prog: Command): string[] {
 }
 
 describe("computer-use command visibility", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
   const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
 
   beforeEach(() => {
+    mockExit.mockClear();
     mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
     vi.stubEnv("ZERO_TOKEN", "");
   });
 
@@ -178,6 +186,42 @@ describe("computer-use command visibility", () => {
     expect(helpOutput).toContain("overwrites the same files");
     expect(helpOutput).toContain("shift+semicolon");
     expect(helpOutput).toContain("Control_L+J");
+  });
+
+  it("should guide missing computer-use capability errors to delegated authorization", async () => {
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("ZERO_TOKEN", "zero-run-token-without-computer-use");
+
+    server.use(
+      http.post("http://localhost:3000/api/zero/computer-use/commands", () => {
+        return HttpResponse.json(
+          {
+            error: {
+              message: "Missing required capability: computer-use:write",
+              code: "FORBIDDEN",
+            },
+          },
+          { status: 403 },
+        );
+      }),
+    );
+
+    await expect(async () => {
+      await zeroComputerUseCommand.parseAsync(["node", "cli", "list-apps"]);
+    }).rejects.toThrow("process.exit called");
+
+    const errorOutput = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errorOutput).toContain("Computer Use authorization required");
+    expect(errorOutput).toContain(
+      "zero doctor permission-change computer-use --permission computer-use:write --enable",
+    );
+    expect(errorOutput).toContain(
+      "Existing run tokens cannot be upgraded in place",
+    );
+    expect(errorOutput).not.toContain(
+      "403: Missing required capability: computer-use:write",
+    );
+    expect(mockExit).toHaveBeenCalledWith(1);
   });
 
   it("should write screenshot and app state data to local files in command result console output", async () => {

--- a/turbo/apps/cli/src/commands/zero/computer-use/index.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/index.ts
@@ -7,6 +7,7 @@ import type {
   ComputerUseWriteCommandKind,
 } from "@vm0/api-contracts/contracts/zero-computer-use";
 import {
+  ApiRequestError,
   createComputerUseReadCommand,
   createComputerUseWriteCommand,
   fetchComputerUseScreenshot,
@@ -66,6 +67,10 @@ interface ComputerUsePressKeyOptions extends ComputerUseAppOptions {
 
 const COMPUTER_USE_OUTPUT_DIR = "/tmp/vm0/computer-use";
 const DATA_URL_PATTERN = /^data:([^;,]+);base64,(.*)$/s;
+const COMPUTER_USE_REQUIRED_CAPABILITY_MESSAGE =
+  "Missing required capability: computer-use:write";
+const COMPUTER_USE_AUTHORIZATION_REQUIRED_ERROR =
+  "COMPUTER_USE_AUTHORIZATION_REQUIRED";
 const COMPUTER_USE_HELP_TEXT = `
 Workflow:
   1. Start the Zero Desktop app and make sure Computer Use is online.
@@ -124,6 +129,23 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);
   });
+}
+
+function throwComputerUseAuthorizationGuidanceError(error: unknown): never {
+  if (
+    error instanceof ApiRequestError &&
+    error.status === 403 &&
+    error.code === "FORBIDDEN" &&
+    error.message === COMPUTER_USE_REQUIRED_CAPABILITY_MESSAGE
+  ) {
+    throw new ApiRequestError(
+      "Computer Use authorization required",
+      COMPUTER_USE_AUTHORIZATION_REQUIRED_ERROR,
+      403,
+    );
+  }
+
+  throw error;
 }
 
 function parseTimeoutSeconds(value: string | undefined): number {
@@ -414,12 +436,16 @@ async function runReadCommand(
   payload: { readonly app?: string } = {},
 ): Promise<void> {
   const timeoutSeconds = parseTimeoutSeconds(options.timeout);
-  const created = await createComputerUseReadCommand({
-    kind,
-    timeoutMs: timeoutSeconds * 1000,
-    ...payload,
-  });
-  await waitForCommand(created.commandId, timeoutSeconds);
+  try {
+    const created = await createComputerUseReadCommand({
+      kind,
+      timeoutMs: timeoutSeconds * 1000,
+      ...payload,
+    });
+    await waitForCommand(created.commandId, timeoutSeconds);
+  } catch (error) {
+    throwComputerUseAuthorizationGuidanceError(error);
+  }
 }
 
 async function runWriteCommand(
@@ -443,12 +469,16 @@ async function runWriteCommand(
   },
 ): Promise<void> {
   const timeoutSeconds = parseTimeoutSeconds(options.timeout);
-  const created = await createComputerUseWriteCommand({
-    kind,
-    timeoutMs: timeoutSeconds * 1000,
-    ...payload,
-  });
-  await waitForCommand(created.commandId, timeoutSeconds);
+  try {
+    const created = await createComputerUseWriteCommand({
+      kind,
+      timeoutMs: timeoutSeconds * 1000,
+      ...payload,
+    });
+    await waitForCommand(created.commandId, timeoutSeconds);
+  } catch (error) {
+    throwComputerUseAuthorizationGuidanceError(error);
+  }
 }
 
 function addTargetOptions(command: Command): Command {

--- a/turbo/packages/api-contracts/src/contracts/errors.ts
+++ b/turbo/packages/api-contracts/src/contracts/errors.ts
@@ -90,6 +90,13 @@ export const RUN_ERROR_GUIDANCE: Record<
   string,
   { title: string; guidance: string; cliHint?: string }
 > = {
+  COMPUTER_USE_AUTHORIZATION_REQUIRED: {
+    title: "Computer Use authorization required",
+    guidance:
+      "Request a delegated Computer Use authorization link, ask the user to select a Zero Desktop host for this chat or Slack thread, then start a new run. Existing run tokens cannot be upgraded in place.",
+    cliHint:
+      "zero doctor permission-change computer-use --permission computer-use:write --enable",
+  },
   NO_MODEL_PROVIDER: {
     title: "No model provider configured",
     guidance: "Configure a model provider to start running agents.",


### PR DESCRIPTION
## Summary
- translate missing `computer-use:write` capability denials from `zero computer-use` into Computer Use-specific CLI guidance
- point agents to `zero doctor permission-change computer-use --permission computer-use:write --enable`
- keep the existing note that current run tokens cannot be upgraded in place

Fixes #19069

## Tests
- `pnpm exec vitest run apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts`
- `pnpm -F @vm0/cli check-types`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/cli lint`
- `pnpm -F @vm0/api-contracts lint`