### PR TITLE
fix: align agent workflow detail headers

### DIFF
--- a/turbo/apps/platform/src/views/components/detail-page-layout.tsx
+++ b/turbo/apps/platform/src/views/components/detail-page-layout.tsx
@@ -1,0 +1,104 @@
+import type { CSSProperties, ReactNode } from "react";
+import { cn } from "@vm0/ui";
+
+export const DETAIL_PAGE_CONTENT_CLASS = "mx-auto w-full max-w-[900px]";
+
+export function DetailPageShell({
+  children,
+  className,
+  scroll = true,
+  style,
+}: {
+  readonly children: ReactNode;
+  readonly className?: string;
+  readonly scroll?: boolean;
+  readonly style?: CSSProperties;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex min-h-0 flex-1 flex-col",
+        scroll ? "overflow-auto [scrollbar-gutter:stable]" : "",
+        className,
+      )}
+      style={style}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function DetailPageBreadcrumbBar({
+  children,
+  className,
+}: {
+  readonly children: ReactNode;
+  readonly className?: string;
+}) {
+  return (
+    <nav
+      aria-label="Breadcrumb"
+      className={cn(
+        "hidden shrink-0 items-center gap-1 px-4 pt-4 text-sm text-muted-foreground md:flex",
+        className,
+      )}
+    >
+      {children}
+    </nav>
+  );
+}
+
+export function DetailPageHeader({
+  children,
+  className,
+  contentClassName,
+}: {
+  readonly children: ReactNode;
+  readonly className?: string;
+  readonly contentClassName?: string;
+}) {
+  return (
+    <header
+      className={cn(
+        "shrink-0 bg-transparent px-4 pt-6 pb-0 sm:px-6",
+        className,
+      )}
+    >
+      <div className={cn(DETAIL_PAGE_CONTENT_CLASS, contentClassName)}>
+        {children}
+      </div>
+    </header>
+  );
+}
+
+export function DetailPageMain({
+  children,
+  className,
+  contentClassName,
+  constrainContent = false,
+  scrollable = false,
+}: {
+  readonly children: ReactNode;
+  readonly className?: string;
+  readonly contentClassName?: string;
+  readonly constrainContent?: boolean;
+  readonly scrollable?: boolean;
+}) {
+  return (
+    <main
+      className={cn(
+        scrollable ? "min-h-0 flex-1 overflow-auto" : "shrink-0",
+        "px-4 pt-4 pb-16 sm:px-6 sm:pt-6",
+        className,
+      )}
+    >
+      {constrainContent ? (
+        <div className={cn(DETAIL_PAGE_CONTENT_CLASS, contentClassName)}>
+          {children}
+        </div>
+      ) : (
+        children
+      )}
+    </main>
+  );
+}

--- a/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
@@ -122,6 +122,12 @@ import {
 import type { UserPermissionGrantResponse } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import { agentVisibleWorkflows$ } from "../../signals/workflows-page/workflows-signals.ts";
 import { WorkflowListPanel } from "../workflows-page/workflows-page.tsx";
+import {
+  DetailPageBreadcrumbBar,
+  DetailPageHeader,
+  DetailPageMain,
+  DetailPageShell,
+} from "../components/detail-page-layout.tsx";
 
 // ---------------------------------------------------------------------------
 // Page shell: skeleton, error, header
@@ -147,10 +153,7 @@ function Breadcrumb({
   className?: string;
 }) {
   return (
-    <nav
-      aria-label="Breadcrumb"
-      className={`hidden md:flex shrink-0 items-center gap-1 px-4 pt-4 text-sm text-muted-foreground${className ? ` ${className}` : ""}`}
-    >
+    <DetailPageBreadcrumbBar className={className}>
       <Link
         pathname="/agents"
         className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 hover:bg-muted hover:text-foreground transition-colors no-underline text-inherit"
@@ -162,24 +165,22 @@ function Breadcrumb({
       <span className="rounded-md px-1.5 py-0.5 text-foreground font-medium truncate">
         {currentName ?? "Agent"}
       </span>
-    </nav>
+    </DetailPageBreadcrumbBar>
   );
 }
 
 function DetailSkeleton() {
   return (
-    <div className="flex flex-1 flex-col min-h-0">
+    <DetailPageShell scroll={false}>
       <Breadcrumb />
-      <header className="shrink-0 bg-transparent px-4 sm:px-6 pt-6 pb-3">
-        <div className="mx-auto max-w-[900px]">
-          <div className="animate-pulse space-y-3">
-            <div className="h-5 w-48 rounded bg-muted" />
-            <div className="h-4 w-72 rounded bg-muted" />
-            <div className="h-9 w-80 rounded bg-muted mt-4" />
-          </div>
+      <DetailPageHeader className="pb-3">
+        <div className="animate-pulse space-y-3">
+          <div className="h-5 w-48 rounded bg-muted" />
+          <div className="h-4 w-72 rounded bg-muted" />
+          <div className="h-9 w-80 rounded bg-muted mt-4" />
         </div>
-      </header>
-    </div>
+      </DetailPageHeader>
+    </DetailPageShell>
   );
 }
 
@@ -190,7 +191,7 @@ function isNotFoundError(error: string): boolean {
 function DetailError({ error, agentId }: { error: string; agentId: string }) {
   if (isNotFoundError(error)) {
     return (
-      <div className="flex flex-1 flex-col min-h-0">
+      <DetailPageShell scroll={false}>
         <Breadcrumb />
         <main className="flex-1 flex items-center justify-center px-4 sm:px-6 pb-16">
           <div className="flex flex-col items-center text-center gap-4 max-w-sm">
@@ -212,12 +213,12 @@ function DetailError({ error, agentId }: { error: string; agentId: string }) {
             </Link>
           </div>
         </main>
-      </div>
+      </DetailPageShell>
     );
   }
 
   return (
-    <div className="flex flex-1 flex-col min-h-0">
+    <DetailPageShell scroll={false}>
       <Breadcrumb />
       <main className="flex-1 px-4 sm:px-6 pt-4 pb-8">
         <div className="mx-auto max-w-[900px]">
@@ -235,7 +236,7 @@ function DetailError({ error, agentId }: { error: string; agentId: string }) {
           </Card>
         </div>
       </main>
-    </div>
+    </DetailPageShell>
   );
 }
 
@@ -927,72 +928,70 @@ function AgentHeader({
   const openMaker = useSet(openAvatarMaker$);
 
   return (
-    <header className="shrink-0 bg-transparent px-4 sm:px-6 pt-6 pb-0">
-      <div className="mx-auto max-w-[900px]">
-        <div className="flex items-center gap-4">
-          <div className="group relative shrink-0">
-            <AgentAvatarImg
-              name={agentId}
-              alt={displayName}
-              className="h-14 w-14 shrink-0 rounded-full object-cover object-top sm:h-16 sm:w-16"
-            />
-            {showProfileAndInstructions && (
-              <TooltipProvider delayDuration={200}>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        onTabChange("profile");
-                        openMaker();
-                      }}
-                      className="absolute -right-0.5 -bottom-0.5 flex h-6 w-6 items-center justify-center rounded-full bg-background text-muted-foreground shadow-sm border border-border opacity-0 group-hover:opacity-100 hover:text-foreground transition-all"
-                      aria-label="Customize avatar"
-                    >
-                      <IconWand size={12} stroke={1.5} />
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">
-                    <p className="text-xs">Customize avatar</p>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            )}
-          </div>
-          <div className="min-w-0">
-            <h1 className="text-lg font-semibold tracking-tight text-foreground sm:text-xl truncate">
-              {displayName}
-            </h1>
-            <p className="text-sm text-muted-foreground mt-1.5 leading-tight line-clamp-2">
-              {description || "Your AI teammate, tuned to you"}
-            </p>
-          </div>
-        </div>
-
-        <div className="mt-4 sm:mt-6 flex items-center gap-2">
-          <AgentTabNav
-            activeTab={activeTab}
-            onTabChange={onTabChange}
-            showProfileAndInstructions={showProfileAndInstructions}
-            showWorkflows={showWorkflows}
+    <DetailPageHeader>
+      <div className="flex items-center gap-4">
+        <div className="group relative shrink-0">
+          <AgentAvatarImg
+            name={agentId}
+            alt={displayName}
+            className="h-14 w-14 shrink-0 rounded-full object-cover object-top sm:h-16 sm:w-16"
           />
-          <Button
-            variant="outline"
-            size="sm"
-            className="shrink-0 zero-btn-morandi gap-1.5"
-            onClick={() => {
-              nav("/agents/:agentId/chat", {
-                pathParams: { agentId: agentId },
-              });
-            }}
-            aria-label={`Chat with ${displayName}`}
-          >
-            <IconMessageCircle size={14} stroke={2} />
-            Chat with {displayName}
-          </Button>
+          {showProfileAndInstructions && (
+            <TooltipProvider delayDuration={200}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      onTabChange("profile");
+                      openMaker();
+                    }}
+                    className="absolute -right-0.5 -bottom-0.5 flex h-6 w-6 items-center justify-center rounded-full bg-background text-muted-foreground shadow-sm border border-border opacity-0 group-hover:opacity-100 hover:text-foreground transition-all"
+                    aria-label="Customize avatar"
+                  >
+                    <IconWand size={12} stroke={1.5} />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  <p className="text-xs">Customize avatar</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )}
+        </div>
+        <div className="min-w-0">
+          <h1 className="text-lg font-semibold tracking-tight text-foreground sm:text-xl truncate">
+            {displayName}
+          </h1>
+          <p className="text-sm text-muted-foreground mt-1.5 leading-tight line-clamp-2">
+            {description || "Your AI teammate, tuned to you"}
+          </p>
         </div>
       </div>
-    </header>
+
+      <div className="mt-4 sm:mt-6 flex items-center gap-2">
+        <AgentTabNav
+          activeTab={activeTab}
+          onTabChange={onTabChange}
+          showProfileAndInstructions={showProfileAndInstructions}
+          showWorkflows={showWorkflows}
+        />
+        <Button
+          variant="outline"
+          size="sm"
+          className="shrink-0 zero-btn-morandi gap-1.5"
+          onClick={() => {
+            nav("/agents/:agentId/chat", {
+              pathParams: { agentId: agentId },
+            });
+          }}
+          aria-label={`Chat with ${displayName}`}
+        >
+          <IconMessageCircle size={14} stroke={2} />
+          Chat with {displayName}
+        </Button>
+      </div>
+    </DetailPageHeader>
   );
 }
 
@@ -1150,7 +1149,7 @@ export function ZeroJobDetailPage() {
   }
 
   return (
-    <div className="flex flex-1 flex-col min-h-0 overflow-auto [scrollbar-gutter:stable]">
+    <DetailPageShell>
       <Breadcrumb currentName={fields.displayName} />
       <AgentHeader
         displayName={fields.displayName}
@@ -1161,7 +1160,7 @@ export function ZeroJobDetailPage() {
         showProfileAndInstructions={!hideProfileAndInstructions}
         showWorkflows={showWorkflows}
       />
-      <main className="shrink-0 px-4 sm:px-6 pt-4 sm:pt-6 pb-16">
+      <DetailPageMain>
         <AgentTabContent
           activeTab={activeTab}
           agentId={fields.agentId}
@@ -1173,7 +1172,7 @@ export function ZeroJobDetailPage() {
           visibility={fields.visibility}
           canEditVisibility={isOwner}
         />
-      </main>
-    </div>
+      </DetailPageMain>
+    </DetailPageShell>
   );
 }

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -526,7 +526,7 @@ describe("workflow detail page", () => {
     expect(screen.getByText("Weekdays at 9:00 AM")).toBeInTheDocument();
     expect(screen.getByText("Enabled")).toBeInTheDocument();
     expect(screen.getByText("Open thread")).toBeInTheDocument();
-    click(buttonByText("instructions", breadcrumb));
+    click(screen.getByLabelText("Workflow files"));
     click(menuItemByText(/config\/settings\.json/));
     await waitFor(() => {
       expect(
@@ -934,10 +934,9 @@ describe("workflow detail page", () => {
         screen.getByText("Gather CRM context before outreach."),
       ).toBeInTheDocument();
     });
-    const breadcrumb = screen.getByLabelText("Breadcrumb");
-    click(buttonByText("instructions", breadcrumb));
+    click(screen.getByLabelText("Workflow files"));
     click(menuItemByText(/config\/settings\.json/));
-    click(buttonByText(/config\/settings\.json/, breadcrumb));
+    click(screen.getByLabelText("Workflow files"));
     click(screen.getByLabelText("Delete config/settings.json"));
 
     await waitFor(() => {
@@ -967,8 +966,7 @@ describe("workflow detail page", () => {
       ).toBeInTheDocument();
     });
 
-    const breadcrumb = screen.getByLabelText("Breadcrumb");
-    click(buttonByText("instructions", breadcrumb));
+    click(screen.getByLabelText("Workflow files"));
     const input = screen.getByLabelText("Upload workflow files");
     fireEvent.change(input, {
       target: {

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -96,6 +96,12 @@ import { ROUTES } from "../../signals/route-paths.ts";
 import { detachedNavigateTo$ } from "../../signals/route.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { Link } from "../router/link.tsx";
+import {
+  DetailPageBreadcrumbBar,
+  DetailPageHeader,
+  DetailPageMain,
+  DetailPageShell,
+} from "../components/detail-page-layout.tsx";
 import { TriggerPermissionsDrawer } from "../trigger-permissions/trigger-permissions-page.tsx";
 import { TiptapInstructionsEditor } from "../zero-page/tiptap-instructions-editor.tsx";
 import { ZeroUnsavedBar } from "../zero-page/zero-unsaved-bar.tsx";
@@ -164,31 +170,29 @@ function WorkflowDetailContent({
 
   return (
     <div className="flex min-h-0 flex-1" style={shellStyle}>
-      <div
+      <DetailPageShell
+        scroll={false}
         className={cn(
-          "min-h-0 min-w-0 flex-col",
+          "min-w-0",
           triggerSidebarOpen ? "hidden flex-1 basis-0 xl:flex" : "flex flex-1",
         )}
       >
+        <WorkflowBreadcrumb detail={detail} />
         <DetailHeader
           detail={detail}
           triggerSidebarOpen={triggerSidebarOpen}
           onTriggerSidebarOpenChange={setTriggerSidebarOpen}
         />
-        <main className="min-h-0 flex-1 overflow-auto px-4 pb-10 pt-4 sm:px-6">
-          <div className="mx-auto w-full max-w-[900px]">
-            {detail ? (
-              <WorkflowDetailBody detail={detail} />
-            ) : detailLoadable.state === "hasData" ? (
-              <p className="text-sm text-muted-foreground">
-                Workflow not found.
-              </p>
-            ) : (
-              <DetailSkeleton />
-            )}
-          </div>
-        </main>
-      </div>
+        <DetailPageMain scrollable constrainContent>
+          {detail ? (
+            <WorkflowDetailBody detail={detail} />
+          ) : detailLoadable.state === "hasData" ? (
+            <p className="text-sm text-muted-foreground">Workflow not found.</p>
+          ) : (
+            <DetailSkeleton />
+          )}
+        </DetailPageMain>
+      </DetailPageShell>
       {triggerSidebarOpen && detail ? (
         <div className="hidden w-px shrink-0 bg-border/60 xl:block" />
       ) : null}
@@ -235,15 +239,14 @@ function WorkflowBreadcrumb({
 }) {
   if (!detail) {
     return (
-      <div className="h-7 w-56 rounded-md bg-muted/50" aria-hidden="true" />
+      <DetailPageBreadcrumbBar>
+        <div className="h-4 w-56 rounded-md bg-muted/50" aria-hidden="true" />
+      </DetailPageBreadcrumbBar>
     );
   }
 
   return (
-    <nav
-      aria-label="Breadcrumb"
-      className="hidden min-w-0 items-center gap-1 text-sm text-muted-foreground sm:flex"
-    >
+    <DetailPageBreadcrumbBar>
       <BreadcrumbLink
         pathname={ROUTES.agents}
         icon={<IconUsers size={14} stroke={1.5} className="shrink-0" />}
@@ -268,9 +271,7 @@ function WorkflowBreadcrumb({
       <span className="min-w-0 truncate rounded-md px-1.5 py-0.5 text-inherit">
         {workflowTitle(detail)}
       </span>
-      <span className="select-none text-muted-foreground/40">/</span>
-      <WorkflowFilePicker detail={detail} />
-    </nav>
+    </DetailPageBreadcrumbBar>
   );
 }
 
@@ -309,7 +310,7 @@ function WorkflowMobileCascade({
   if (!detail) {
     return (
       <div
-        className="h-8 w-48 rounded-md bg-muted/50 sm:hidden"
+        className="h-8 w-48 rounded-md bg-muted/50 md:hidden"
         aria-hidden="true"
       />
     );
@@ -320,7 +321,7 @@ function WorkflowMobileCascade({
       <DropdownMenuTrigger asChild>
         <button
           type="button"
-          className="inline-flex min-w-0 items-center gap-1.5 rounded-md px-2 py-1 text-sm font-medium text-foreground transition-colors hover:bg-muted sm:hidden"
+          className="inline-flex min-w-0 items-center gap-1.5 rounded-md px-2 py-1 text-sm font-medium text-foreground transition-colors hover:bg-muted md:hidden"
         >
           <IconFileText size={14} stroke={1.5} className="shrink-0" />
           <span className="min-w-0 truncate">
@@ -409,38 +410,69 @@ function DetailHeader({
   readonly onTriggerSidebarOpenChange: (open: boolean) => void;
 }) {
   return (
-    <header className="flex shrink-0 items-center justify-between gap-3 px-4 pt-4 sm:px-6">
-      <div className="min-w-0 flex-1">
-        <WorkflowBreadcrumb detail={detail} />
-        <WorkflowMobileCascade detail={detail} />
+    <DetailPageHeader>
+      <div className="flex min-h-16 items-center gap-4">
+        <div className="min-w-0 flex-1">
+          <WorkflowMobileCascade detail={detail} />
+          {detail ? (
+            <div className="hidden min-w-0 flex-col justify-center md:flex">
+              <h1 className="truncate text-lg font-semibold tracking-tight text-foreground sm:text-xl">
+                {workflowTitle(detail)}
+              </h1>
+              <p className="mt-1.5 line-clamp-2 text-sm leading-tight text-muted-foreground">
+                {detail.description ?? detail.name}
+              </p>
+            </div>
+          ) : (
+            <div
+              className="hidden min-w-0 animate-pulse flex-col gap-2 md:flex"
+              aria-hidden="true"
+            >
+              <div className="h-5 w-48 rounded bg-muted" />
+              <div className="h-4 w-72 rounded bg-muted" />
+            </div>
+          )}
+        </div>
       </div>
-      {detail ? (
-        <div className="flex shrink-0 items-center gap-2">
-          <WorkflowRunOnceButton detail={detail} />
-          <button
-            type="button"
-            className={cn(
-              "zero-btn-morandi inline-flex h-9 items-center gap-1.5 rounded-md px-3 text-sm",
-              triggerSidebarOpen ? "bg-muted" : "",
-            )}
-            aria-pressed={triggerSidebarOpen}
-            onClick={() => {
-              onTriggerSidebarOpenChange(!triggerSidebarOpen);
-            }}
+      <div className="mt-4 flex items-center gap-2 sm:mt-6">
+        <div className="hidden min-w-0 flex-1 md:block">
+          {detail ? (
+            <WorkflowFilePicker detail={detail} />
+          ) : (
+            <div className="h-9 w-44 rounded-md bg-muted/50" />
+          )}
+        </div>
+        {detail ? (
+          <div className="ml-auto flex shrink-0 items-center gap-2">
+            <WorkflowRunOnceButton detail={detail} />
+            <button
+              type="button"
+              className={cn(
+                "zero-btn-morandi inline-flex h-9 items-center gap-1.5 rounded-md px-3 text-sm",
+                triggerSidebarOpen ? "bg-muted" : "",
+              )}
+              aria-pressed={triggerSidebarOpen}
+              onClick={() => {
+                onTriggerSidebarOpenChange(!triggerSidebarOpen);
+              }}
+            >
+              <IconClock size={14} stroke={1.5} />
+              <span className="hidden sm:inline">Trigger</span>
+            </button>
+            <WorkflowActionsMenu detail={detail} />
+          </div>
+        ) : (
+          <div
+            className="ml-auto flex shrink-0 items-center gap-2"
+            aria-hidden="true"
           >
-            <IconClock size={14} stroke={1.5} />
-            <span className="hidden sm:inline">Trigger</span>
-          </button>
-          <WorkflowActionsMenu detail={detail} />
-        </div>
-      ) : (
-        <div className="flex shrink-0 items-center gap-2" aria-hidden="true">
-          <div className="h-9 w-9 rounded-md bg-muted/50 sm:w-24" />
-          <div className="h-9 w-9 rounded-md bg-muted/50 sm:w-20" />
-          <div className="size-9 rounded-md bg-muted/50" />
-        </div>
-      )}
-    </header>
+            <div className="h-9 w-9 rounded-md bg-muted/50 sm:w-24" />
+            <div className="h-9 w-9 rounded-md bg-muted/50 sm:w-20" />
+            <div className="size-9 rounded-md bg-muted/50" />
+          </div>
+        )}
+      </div>
+    </DetailPageHeader>
   );
 }
 
@@ -1063,8 +1095,10 @@ function WorkflowFilePicker({
       <DropdownMenuTrigger asChild>
         <button
           type="button"
-          className="inline-flex min-w-0 items-center gap-1 rounded-md px-1.5 py-0.5 font-medium text-foreground transition-colors hover:bg-muted"
+          aria-label="Workflow files"
+          className="zero-btn-morandi inline-flex h-9 max-w-full items-center gap-1.5 rounded-lg px-3 text-sm"
         >
+          <IconFileText size={14} stroke={1.5} className="shrink-0" />
           <span className="min-w-0 truncate">{selectedLabel}</span>
           <IconChevronDown
             size={14}


### PR DESCRIPTION
## Summary
- Add shared detail page layout primitives for breadcrumb, header, shell, and main spacing
- Move the workflow file picker into the workflow detail header control row
- Update agent detail and workflow detail to share the same header/page chrome

## Tests
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm exec vitest run apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
- pnpm exec vitest run apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx

Note: skipped local dev server per vm0 PR verification preference.