### PR TITLE
feat: improve connector access management

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -13,6 +13,7 @@ import {
   type ConnectorType,
   type ConnectorDisplayCategory,
 } from "@vm0/connectors/connectors";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   getConnectorAuthMethodAccessMetadata,
   getConnectorAuthMethod,
@@ -386,15 +387,35 @@ const hiddenConnectorTypes$ = computed((get): Set<ConnectorType> => {
 // ---------------------------------------------------------------------------
 
 const CONNECTORS_SEARCH_PARAM = "keywords";
+const CONNECTORS_CONNECTION_FILTER_PARAM = "connection";
+export type ConnectorsConnectionFilter = "all" | "connected";
+
+export const connectorsConnectionFilter$ = computed(
+  (get): ConnectorsConnectionFilter => {
+    return get(searchParams$).get(CONNECTORS_CONNECTION_FILTER_PARAM) ===
+      "connected"
+      ? "connected"
+      : "all";
+  },
+);
+
 export const connectorsSearch$ = computed((get) => {
   return get(searchParams$).get(CONNECTORS_SEARCH_PARAM) ?? "";
 });
 
 export const filteredConnectorTypes$ = computed(async (get) => {
   const keyword = get(connectorsSearch$);
+  const connectionFilter = get(connectorsConnectionFilter$);
+  const features = get(featureSwitch$);
+  const shouldFilterConnected =
+    connectionFilter === "connected" &&
+    (features[FeatureSwitchKey.ConnectorAccessManagement] ?? false);
   const allConnectorTypes = await get(allConnectorTypes$);
   return allConnectorTypes.filter((connector) => {
-    return matchesConnectorSearch(keyword, connector);
+    if (!matchesConnectorSearch(keyword, connector)) {
+      return false;
+    }
+    return !shouldFilterConnected || connector.connected;
   });
 });
 
@@ -407,6 +428,18 @@ export const setConnectorsSearch$ = command(({ get, set }, value: string) => {
   }
   set(replaceSearchParams$, params);
 });
+
+export const setConnectorsConnectionFilter$ = command(
+  ({ get, set }, value: ConnectorsConnectionFilter) => {
+    const params = new URLSearchParams(get(searchParams$));
+    if (value === "connected") {
+      params.set(CONNECTORS_CONNECTION_FILTER_PARAM, value);
+    } else {
+      params.delete(CONNECTORS_CONNECTION_FILTER_PARAM);
+    }
+    set(replaceSearchParams$, params);
+  },
+);
 
 // ---------------------------------------------------------------------------
 // Selected connector for connect modal

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -417,6 +417,41 @@ describe("connectors page", () => {
     expect(screen.queryByText("GitHub")).not.toBeInTheDocument();
   });
 
+  it("filters connectors by connected status when access management is enabled", async () => {
+    mockConnectors([{ type: "github", externalUsername: "octocat" }]);
+
+    detachedSetupPage({
+      context,
+      path: "/connectors",
+      featureSwitches: {
+        [FeatureSwitchKey.ConnectorAccessManagement]: true,
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("GitHub")).toBeInTheDocument();
+      expect(screen.getByText("Asana")).toBeInTheDocument();
+    });
+
+    const connectionFilter = screen.getByRole("group", {
+      name: "Connector connection filter",
+    });
+    click(buttonByText("Connected", connectionFilter));
+
+    await waitFor(() => {
+      expect(screen.getByText("GitHub")).toBeInTheDocument();
+      expect(screen.queryByText("Asana")).not.toBeInTheDocument();
+    });
+    expect(search()).toBe("?connection=connected");
+
+    click(buttonByText("All", connectionFilter));
+
+    await waitFor(() => {
+      expect(screen.getByText("Asana")).toBeInTheDocument();
+    });
+    expect(search()).toBe("");
+  });
+
   it("hydrates connector search from URL keywords", async () => {
     mockConnectors([
       { type: "github", externalUsername: "octocat" },
@@ -478,6 +513,14 @@ describe("connectors page", () => {
     await waitFor(() => {
       expect(screen.getByText("GitHub")).toBeInTheDocument();
     });
+    expect(
+      screen.queryByRole("group", {
+        name: "Connector connection filter",
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Manage GitHub access"),
+    ).not.toBeInTheDocument();
     click(
       within(connectorCardByLabel("GitHub")).getByLabelText("More options"),
     );
@@ -528,12 +571,10 @@ describe("connectors page", () => {
       expect(screen.getByText("GitHub")).toBeInTheDocument();
     });
     click(
-      within(connectorCardByLabel("GitHub")).getByLabelText("More options"),
+      within(connectorCardByLabel("GitHub")).getByLabelText(
+        "Manage GitHub access",
+      ),
     );
-    await waitFor(() => {
-      expect(menuItemByText("Manage")).toBeInTheDocument();
-    });
-    click(menuItemByText("Manage"));
 
     const dialog = await screen.findByRole("dialog", {
       name: "Manage GitHub access",

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-access-management-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-access-management-dialog.tsx
@@ -344,7 +344,7 @@ function AgentAccessList({
   }
 
   return (
-    <div className="min-h-0 flex-1 overflow-y-auto">
+    <div className="h-full min-h-0 overflow-y-auto pr-1">
       {rows.map((row) => {
         return (
           <AgentAccessRow
@@ -414,7 +414,7 @@ function ConnectorAccessDialog({
       }}
     >
       <DialogContent className="!flex h-[min(720px,calc(100dvh-2rem))] w-[calc(100vw-2rem)] max-w-[720px] !flex-col !overflow-hidden">
-        <DialogHeader className="gap-2">
+        <DialogHeader className="shrink-0 gap-2">
           <div className="flex items-center gap-3">
             <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted">
               <ConnectorIcon type={connectorType} size={22} />
@@ -430,12 +430,15 @@ function ConnectorAccessDialog({
           </div>
         </DialogHeader>
 
-        <ConnectorAccessSearch value={search} onChange={onSearchChange} />
+        <div className="shrink-0">
+          <ConnectorAccessSearch value={search} onChange={onSearchChange} />
+        </div>
 
         <div
           className={cn(
-            "min-h-0 flex-1 rounded-lg border-[0.7px] border-border px-3",
+            "min-h-0 flex-1 overflow-hidden rounded-lg border-[0.7px] border-border px-3",
             !rowsLoaded && "flex",
+            rowsLoaded && "flex flex-col",
           )}
         >
           {rowsLoaded ? (

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -16,6 +16,7 @@ import {
   IconLoader2,
   IconDotsVertical,
   IconInfoCircle,
+  IconAdjustmentsHorizontal,
 } from "@tabler/icons-react";
 import {
   CONNECTOR_TYPES,
@@ -35,8 +36,10 @@ import {
   allConnectorTypes$,
   connectConnectorOAuthAuthCode$,
   connectorsSearch$,
+  connectorsConnectionFilter$,
   disconnectConnector$,
   filteredConnectorTypes$,
+  setConnectorsConnectionFilter$,
   setConnectorsSearch$,
   selectedConnectorType$,
   setSelectedConnectorType$,
@@ -55,6 +58,7 @@ import {
   connectorExpiryCountdownText,
   connectorReconnectReasonTooltipText,
   type ConnectorTypeWithStatus,
+  type ConnectorsConnectionFilter,
 } from "../../signals/zero-page/settings/connectors.ts";
 import {
   activeConnectorCategoryId$,
@@ -89,6 +93,7 @@ import {
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
+  cn,
 } from "@vm0/ui";
 
 // Callback ref that attaches scroll tracking while enabled. Each call returns
@@ -248,6 +253,52 @@ function ConnectorCategoryMenuItem({
         {menuLabel}
       </span>
     </button>
+  );
+}
+
+function ConnectorConnectionFilter({
+  value,
+  onChange,
+}: {
+  readonly value: ConnectorsConnectionFilter;
+  readonly onChange: (value: ConnectorsConnectionFilter) => void;
+}) {
+  const options: readonly {
+    readonly value: ConnectorsConnectionFilter;
+    readonly label: string;
+  }[] = [
+    { value: "all", label: "All" },
+    { value: "connected", label: "Connected" },
+  ];
+
+  return (
+    <div
+      role="group"
+      aria-label="Connector connection filter"
+      className="inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground"
+    >
+      {options.map((option) => {
+        const active = value === option.value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            aria-pressed={active}
+            className={cn(
+              "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+              active
+                ? "bg-background text-foreground shadow"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+            onClick={() => {
+              onChange(option.value);
+            }}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
   );
 }
 
@@ -445,31 +496,49 @@ function GlobalConnectorCard({
       <div className="flex h-11 items-center justify-between border-t border-border/50 pl-5 pr-2">
         <div className="flex items-center gap-2 min-w-0">{status}</div>
         {connector.connected && (
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-7 w-7 shrink-0 rounded-lg text-muted-foreground hover:text-foreground"
-                aria-label="More options"
-              >
-                <IconDotsVertical size={14} stroke={1.5} />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-44">
-              {showManageAccess && (
-                <DropdownMenuItem onClick={onManageAccess}>
-                  Manage
+          <div className="flex shrink-0 items-center gap-1">
+            {showManageAccess && (
+              <TooltipProvider delayDuration={200}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7 shrink-0 rounded-lg text-muted-foreground hover:text-foreground"
+                      aria-label={`Manage ${connector.label} access`}
+                      onClick={onManageAccess}
+                    >
+                      <IconAdjustmentsHorizontal size={14} stroke={1.5} />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="top" className="text-xs">
+                    Manage access
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            )}
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7 shrink-0 rounded-lg text-muted-foreground hover:text-foreground"
+                  aria-label="More options"
+                >
+                  <IconDotsVertical size={14} stroke={1.5} />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-44">
+                <DropdownMenuItem
+                  onClick={onDisconnect}
+                  disabled={isDisconnecting}
+                >
+                  Disconnect
                 </DropdownMenuItem>
-              )}
-              <DropdownMenuItem
-                onClick={onDisconnect}
-                disabled={isDisconnecting}
-              >
-                Disconnect
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
         )}
       </div>
     </div>
@@ -575,12 +644,14 @@ function renderBuiltinList({
   filteredCount,
   renderCard,
   search,
+  connectionFilter,
 }: {
   loadingState: "loading" | "hasData" | "hasError";
   grouped: ConnectorCategoryGroup<ConnectorTypeWithStatus>[];
   filteredCount: number;
   renderCard: (connector: ConnectorTypeWithStatus) => ReactNode;
   search: string;
+  connectionFilter: ConnectorsConnectionFilter;
 }): ReactNode {
   if (loadingState !== "hasData") {
     return (
@@ -606,7 +677,19 @@ function renderBuiltinList({
     );
   }
 
-  if (filteredCount === 0 && search) {
+  if (filteredCount === 0) {
+    const trimmedSearch = search.trim();
+    const message =
+      connectionFilter === "connected"
+        ? trimmedSearch
+          ? `No connected connectors matching "${trimmedSearch}"`
+          : "No connected connectors"
+        : trimmedSearch
+          ? `No connectors matching "${trimmedSearch}"`
+          : null;
+    if (!message) {
+      return null;
+    }
     return (
       <div className="flex flex-col items-center gap-3 py-12">
         <img
@@ -614,9 +697,7 @@ function renderBuiltinList({
           alt="No connectors"
           className="h-20 w-20 object-contain opacity-80"
         />
-        <p className="text-center text-sm text-muted-foreground">
-          No connectors matching &ldquo;{search}&rdquo;
-        </p>
+        <p className="text-center text-sm text-muted-foreground">{message}</p>
       </div>
     );
   }
@@ -667,6 +748,8 @@ export function ZeroConnectorsPage() {
 
   const search = useGet(connectorsSearch$);
   const setSearch = useSet(setConnectorsSearch$);
+  const connectionFilter = useGet(connectorsConnectionFilter$);
+  const setConnectionFilter = useSet(setConnectorsConnectionFilter$);
 
   const filteredConnectors =
     filteredTypesLoadable.state === "hasData" ? filteredTypesLoadable.data : [];
@@ -769,6 +852,7 @@ export function ZeroConnectorsPage() {
     filteredCount: filteredConnectors.length,
     renderCard,
     search,
+    connectionFilter: showConnectorAccessManagement ? connectionFilter : "all",
   });
   return (
     <div
@@ -817,7 +901,7 @@ export function ZeroConnectorsPage() {
             )}
 
           <div className="min-w-0 flex w-full max-w-[900px] flex-col gap-6">
-            <div className="flex items-center justify-between">
+            <div className="flex items-center justify-between gap-3">
               <Tabs
                 value={activeTab}
                 onValueChange={(v) => {
@@ -829,17 +913,25 @@ export function ZeroConnectorsPage() {
                   <TabsTrigger value="custom">Custom</TabsTrigger>
                 </TabsList>
               </Tabs>
-              {activeTab === "custom" && isAdmin && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="zero-btn-morandi h-9 gap-2 shrink-0 rounded-lg border"
-                  onClick={openCreateCustom}
-                >
-                  <IconPlus size={14} stroke={2} />
-                  New connector
-                </Button>
-              )}
+              <div className="flex items-center gap-2">
+                {activeTab === "builtin" && showConnectorAccessManagement && (
+                  <ConnectorConnectionFilter
+                    value={connectionFilter}
+                    onChange={setConnectionFilter}
+                  />
+                )}
+                {activeTab === "custom" && isAdmin && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="zero-btn-morandi h-9 gap-2 shrink-0 rounded-lg border"
+                    onClick={openCreateCustom}
+                  >
+                    <IconPlus size={14} stroke={2} />
+                    New connector
+                  </Button>
+                )}
+              </div>
             </div>
 
             {activeTab === "builtin" && builtinList}

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -130,6 +130,9 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.PresentationHtmlPptxDownload]).toBe(
       true,
     );
+    expect(staffOrgStates[FeatureSwitchKey.ConnectorAccessManagement]).toBe(
+      true,
+    );
     expect(staffOrgStates[FeatureSwitchKey.ChatGithubPrTracking]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.HtmlArtifactCommentEditing]).toBe(
       false,
@@ -145,6 +148,9 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.VideoTemplatePicker]).toBe(true);
     expect(otherOrgStates[FeatureSwitchKey.PresentationHtmlPptxDownload]).toBe(
       true,
+    );
+    expect(otherOrgStates[FeatureSwitchKey.ConnectorAccessManagement]).toBe(
+      false,
     );
     expect(otherOrgStates[FeatureSwitchKey.ChatGithubPrTracking]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.HtmlArtifactCommentEditing]).toBe(

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -323,8 +323,9 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.ConnectorAccessManagement]: {
     maintainer: "ethan@vm0.ai",
     description:
-      "Show the Manage entry on connected connector cards for per-agent connector access and permission management.",
+      "Show connected connector filtering and per-agent connector access management on connected connector cards.",
     enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
 };
 


### PR DESCRIPTION
## Summary
- enable connector access management at the staff organization rollout level
- add an All/Connected filter for built-in connectors when the feature is enabled
- move connector access management from the overflow menu to a dedicated icon button and fix the agent access dialog scroll area

## Verification
- pnpm -F @vm0/app test src/views/zero-page/__tests__/zero-connectors-page.test.tsx
- pnpm -F @vm0/core test src/__tests__/feature-switch.test.ts
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/core check-types
- pnpm -F @vm0/app lint
- pnpm -F @vm0/core lint