### PR TITLE
fix: prevent org switcher horizontal scroll

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-org-switcher.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-org-switcher.test.tsx
@@ -199,6 +199,9 @@ describe("zero org switcher", () => {
   });
 
   it("bounds long workspace lists inside a scrollable menu region", async () => {
+    const longWorkspaceName =
+      "Workspace-with-a-very-long-name-that-should-not-create-horizontal-scroll";
+
     context.mocks.data.org({
       id: "org_current",
       name: "Current",
@@ -232,6 +235,13 @@ describe("zero org switcher", () => {
               },
             };
           }),
+          {
+            id: "membership_long",
+            organization: {
+              id: "org_long",
+              name: longWorkspaceName,
+            },
+          },
         ],
       },
     });
@@ -252,7 +262,9 @@ describe("zero org switcher", () => {
     );
 
     expect(scrollRegion).toHaveClass("max-h-72");
+    expect(scrollRegion).toHaveClass("overflow-x-hidden");
     expect(scrollRegion).toHaveClass("overflow-y-auto");
     expect(screen.getByText("Workspace 12")).toBeInTheDocument();
+    expect(screen.getByText(longWorkspaceName)).toBeInTheDocument();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-org-switcher.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-org-switcher.tsx
@@ -96,7 +96,7 @@ function InvitationRow({
   });
 
   return (
-    <div className="flex items-center gap-3 px-3 py-2.5">
+    <div className="flex min-w-0 items-center gap-3 overflow-hidden px-3 py-2.5">
       <OrgAvatar
         name={invitation.publicOrganizationData.name}
         imageUrl={invitation.publicOrganizationData.imageUrl}
@@ -144,7 +144,7 @@ function CreateWorkspaceItem() {
       <DropdownMenuItem
         onClick={handleCreateOrg}
         disabled={clerk === null || creatingOrg}
-        className="gap-3 px-3 py-2.5 rounded-lg"
+        className="min-w-0 gap-3 px-3 py-2.5 rounded-lg"
       >
         <IconPlus
           size={18}
@@ -185,13 +185,13 @@ function OtherMembershipsList() {
             onClick={() => {
               handleSwitchOrg(membership.organization.id);
             }}
-            className="gap-3 px-3 py-2.5 rounded-lg"
+            className="min-w-0 gap-3 px-3 py-2.5 rounded-lg"
           >
             <OrgAvatar
               name={membership.organization.name}
               imageUrl={membership.organization.imageUrl}
             />
-            <span className="truncate flex-1">
+            <span className="min-w-0 flex-1 truncate">
               {membership.organization.name}
             </span>
           </DropdownMenuItem>
@@ -228,7 +228,7 @@ function OrgDropdownContent() {
       align="start"
       className="flex max-h-[min(420px,var(--radix-dropdown-menu-content-available-height))] w-72 flex-col overflow-hidden"
     >
-      <div className="flex shrink-0 items-center gap-3 px-2 py-1.5">
+      <div className="flex min-w-0 shrink-0 items-center gap-3 px-2 py-1.5">
         <OrgAvatar name={orgName} imageUrl={currentOrg?.imageUrl} size="lg" />
         <div className="min-w-0 flex-1">
           <p className="text-sm font-semibold leading-tight truncate text-foreground">
@@ -245,7 +245,7 @@ function OrgDropdownContent() {
       {hasOrgOptions && (
         <div
           data-testid="org-switcher-options-scroll"
-          className="min-h-0 max-h-72 flex-1 overflow-y-auto [scrollbar-gutter:stable]"
+          className="min-h-0 max-h-72 flex-1 overflow-x-hidden overflow-y-auto [scrollbar-gutter:stable]"
         >
           <OtherMembershipsList />
 


### PR DESCRIPTION
## Summary
- prevent the VM0 org switcher scroll region from showing horizontal overflow
- keep long workspace and invitation names constrained with truncation
- cover long workspace names in the org switcher menu test

## Verification
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-org-switcher.test.tsx
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types