### PR TITLE
fix: clean up mock claude shell process groups

### DIFF
--- a/crates/guest-mock-claude/src/process.rs
+++ b/crates/guest-mock-claude/src/process.rs
@@ -590,6 +590,9 @@ where
         // Cancellation switches to a zero-timeout final drain instead of
         // waiting for EOF from those descendants.
         let cancelled = cancel.load(Ordering::Acquire);
+        if cancelled && stream.truncated {
+            break;
+        }
         let timeout_ms = if cancelled {
             0
         } else {

--- a/crates/guest-mock-claude/src/process.rs
+++ b/crates/guest-mock-claude/src/process.rs
@@ -10,9 +10,12 @@ use serde_json::json;
 use std::collections::BTreeMap;
 use std::io::{BufRead, BufReader, ErrorKind, Read, Write};
 use std::path::Path;
-use std::process::{Command, ExitCode, Stdio};
+use std::process::{Child, Command, ExitCode, ExitStatus, Stdio};
 use std::thread;
 use std::time::Duration;
+
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
 
 const REAPABLE_HANG_DURATION: Duration = Duration::from_secs(3600);
 const ACTIVE_INPUT_READY_RESULT: &str = "READY_FOR_ACTIVE_INPUT";
@@ -558,32 +561,123 @@ fn join_captured_shell_stream(
     }
 }
 
-fn capture_shell_output(prompt: &str) -> CapturedShellOutput {
-    let mut child = match Command::new("bash")
+fn spawn_captured_shell(prompt: &str) -> std::io::Result<Child> {
+    let mut command = Command::new("bash");
+    command
         .args(["-c", prompt])
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-    {
+        .stderr(Stdio::piped());
+    spawn_shell_process(&mut command)
+}
+
+#[cfg(unix)]
+fn spawn_shell_process(command: &mut Command) -> std::io::Result<Child> {
+    command.process_group(0).spawn()
+}
+
+#[cfg(not(unix))]
+fn spawn_shell_process(command: &mut Command) -> std::io::Result<Child> {
+    command.spawn()
+}
+
+fn terminate_shell_child(mut child: Child) {
+    terminate_shell_process_group(child.id());
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[cfg(unix)]
+fn wait_shell_child_and_cleanup_group(mut child: Child) -> std::io::Result<ExitStatus> {
+    let pid = child.id();
+    if let Err(error) = observe_shell_child_exit_without_reaping(pid) {
+        terminate_shell_process_group(pid);
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err(error);
+    }
+
+    terminate_shell_process_group(pid);
+    child.wait()
+}
+
+#[cfg(not(unix))]
+fn wait_shell_child_and_cleanup_group(mut child: Child) -> std::io::Result<ExitStatus> {
+    child.wait()
+}
+
+#[cfg(unix)]
+fn observe_shell_child_exit_without_reaping(pid: u32) -> std::io::Result<()> {
+    let pid = i32::try_from(pid).map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "shell child PID does not fit in i32",
+        )
+    })?;
+
+    loop {
+        let mut info = std::mem::MaybeUninit::<libc::siginfo_t>::uninit();
+        let result = unsafe {
+            libc::waitid(
+                libc::P_PID,
+                pid as libc::id_t,
+                info.as_mut_ptr(),
+                libc::WEXITED | libc::WNOWAIT,
+            )
+        };
+        if result == 0 {
+            return Ok(());
+        }
+
+        let error = std::io::Error::last_os_error();
+        if error.kind() != ErrorKind::Interrupted {
+            return Err(error);
+        }
+    }
+}
+
+#[cfg(unix)]
+fn terminate_shell_process_group(child_pid: u32) {
+    if let Some(pgid) = signalable_shell_process_group(child_pid) {
+        unsafe {
+            libc::kill(-pgid, libc::SIGKILL);
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn terminate_shell_process_group(_child_pid: u32) {}
+
+#[cfg(unix)]
+fn signalable_shell_process_group(child_pid: u32) -> Option<libc::pid_t> {
+    let pgid = i32::try_from(child_pid).ok()?;
+    (pgid > 1 && pgid != current_process_group()).then_some(pgid as libc::pid_t)
+}
+
+#[cfg(unix)]
+fn current_process_group() -> i32 {
+    unsafe { libc::getpgrp() }
+}
+
+fn capture_shell_output(prompt: &str) -> CapturedShellOutput {
+    let mut child = match spawn_captured_shell(prompt) {
         Ok(child) => child,
         Err(_) => return CapturedShellOutput::failed(),
     };
 
     let Some(stdout) = child.stdout.take() else {
-        let _ = child.kill();
-        let _ = child.wait();
+        terminate_shell_child(child);
         return CapturedShellOutput::failed();
     };
     let Some(stderr) = child.stderr.take() else {
-        let _ = child.kill();
-        let _ = child.wait();
+        terminate_shell_child(child);
         return CapturedShellOutput::failed();
     };
     let stdout_thread = thread::spawn(move || capture_shell_stream(stdout));
     let stderr_thread = thread::spawn(move || capture_shell_stream(stderr));
 
-    let exit_code = child.wait().map_or(1, |status| status.code().unwrap_or(1));
+    let exit_code =
+        wait_shell_child_and_cleanup_group(child).map_or(1, |status| status.code().unwrap_or(1));
     let stdout = join_captured_shell_stream(stdout_thread);
     let stderr = join_captured_shell_stream(stderr_thread);
     let (Ok(stdout), Ok(stderr)) = (stdout, stderr) else {
@@ -664,4 +758,19 @@ fn run_stream_json_mode(prompt: &str, session_id: &str) -> ExitCode {
     }
 
     ExitCode::from(exit_code as u8)
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn signalable_shell_process_group_rejects_dangerous_values() {
+        assert_eq!(signalable_shell_process_group(0), None);
+        assert_eq!(signalable_shell_process_group(1), None);
+        assert_eq!(signalable_shell_process_group((i32::MAX as u32) + 1), None);
+        if let Ok(current_pgid) = u32::try_from(current_process_group()) {
+            assert_eq!(signalable_shell_process_group(current_pgid), None);
+        }
+    }
 }

--- a/crates/guest-mock-claude/src/process.rs
+++ b/crates/guest-mock-claude/src/process.rs
@@ -9,8 +9,15 @@ use serde_json::Value;
 use serde_json::json;
 use std::collections::BTreeMap;
 use std::io::{BufRead, BufReader, ErrorKind, Read, Write};
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
 use std::path::Path;
 use std::process::{Child, Command, ExitCode, ExitStatus, Stdio};
+#[cfg(unix)]
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
 use std::thread;
 use std::time::Duration;
 
@@ -21,6 +28,8 @@ const REAPABLE_HANG_DURATION: Duration = Duration::from_secs(3600);
 const ACTIVE_INPUT_READY_RESULT: &str = "READY_FOR_ACTIVE_INPUT";
 const STREAM_JSON_SHELL_OUTPUT_LIMIT_BYTES: usize = 1024 * 1024;
 const STREAM_JSON_SHELL_READ_BUFFER_BYTES: usize = 8 * 1024;
+#[cfg(unix)]
+const STREAM_JSON_SHELL_CANCEL_POLL_TIMEOUT_MS: libc::c_int = 100;
 
 pub(crate) fn run(parsed: ParsedArgs) -> ExitCode {
     if parsed.input_format == "stream-json" {
@@ -521,11 +530,30 @@ impl CapturedShellOutput {
     }
 }
 
-fn capture_shell_stream(mut reader: impl Read) -> std::io::Result<CapturedShellStream> {
-    let mut stream = CapturedShellStream {
+fn new_captured_shell_stream() -> CapturedShellStream {
+    CapturedShellStream {
         bytes: Vec::with_capacity(STREAM_JSON_SHELL_READ_BUFFER_BYTES),
         truncated: false,
-    };
+    }
+}
+
+fn retain_captured_shell_bytes(stream: &mut CapturedShellStream, bytes: &[u8]) {
+    let remaining = STREAM_JSON_SHELL_OUTPUT_LIMIT_BYTES.saturating_sub(stream.bytes.len());
+    if remaining == 0 {
+        stream.truncated = true;
+        return;
+    }
+
+    let retained = remaining.min(bytes.len());
+    stream.bytes.extend(bytes.iter().take(retained).copied());
+    if retained < bytes.len() {
+        stream.truncated = true;
+    }
+}
+
+#[cfg(not(unix))]
+fn capture_shell_stream(mut reader: impl Read) -> std::io::Result<CapturedShellStream> {
+    let mut stream = new_captured_shell_stream();
     let mut buffer = [0_u8; STREAM_JSON_SHELL_READ_BUFFER_BYTES];
 
     loop {
@@ -536,17 +564,77 @@ fn capture_shell_stream(mut reader: impl Read) -> std::io::Result<CapturedShellS
             Err(error) => return Err(error),
         };
 
-        let remaining = STREAM_JSON_SHELL_OUTPUT_LIMIT_BYTES.saturating_sub(stream.bytes.len());
-        if remaining == 0 {
-            stream.truncated = true;
+        let Some(chunk) = buffer.get(..read) else {
+            return Err(std::io::Error::other("shell stream read exceeded buffer"));
+        };
+        retain_captured_shell_bytes(&mut stream, chunk);
+    }
+
+    Ok(stream)
+}
+
+#[cfg(unix)]
+fn capture_shell_stream_until_cancelled<R>(
+    mut reader: R,
+    cancel: Arc<AtomicBool>,
+) -> std::io::Result<CapturedShellStream>
+where
+    R: Read + AsRawFd,
+{
+    let fd = reader.as_raw_fd();
+    let mut stream = new_captured_shell_stream();
+    let mut buffer = [0_u8; STREAM_JSON_SHELL_READ_BUFFER_BYTES];
+
+    loop {
+        // After bash exits, escaped descendants can keep the write end open.
+        // Cancellation switches to a zero-timeout final drain instead of
+        // waiting for EOF from those descendants.
+        let cancelled = cancel.load(Ordering::Acquire);
+        let timeout_ms = if cancelled {
+            0
+        } else {
+            STREAM_JSON_SHELL_CANCEL_POLL_TIMEOUT_MS
+        };
+        let mut pollfd = libc::pollfd {
+            fd,
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        let poll_result = unsafe { libc::poll(&mut pollfd, 1, timeout_ms) };
+        if poll_result < 0 {
+            let error = std::io::Error::last_os_error();
+            if error.kind() == ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(error);
+        }
+        if poll_result == 0 {
+            if cancelled {
+                break;
+            }
+            continue;
+        }
+        if pollfd.revents & libc::POLLNVAL != 0 {
+            break;
+        }
+        if pollfd.revents & (libc::POLLIN | libc::POLLHUP) == 0 {
+            if pollfd.revents & libc::POLLERR != 0 || cancelled {
+                break;
+            }
             continue;
         }
 
-        let retained = remaining.min(read);
-        stream.bytes.extend(buffer.iter().take(retained).copied());
-        if retained < read {
-            stream.truncated = true;
-        }
+        let read = match reader.read(&mut buffer) {
+            Ok(0) => break,
+            Ok(read) => read,
+            Err(error) if error.kind() == ErrorKind::Interrupted => continue,
+            Err(error) if error.kind() == ErrorKind::WouldBlock => continue,
+            Err(error) => return Err(error),
+        };
+        let Some(chunk) = buffer.get(..read) else {
+            return Err(std::io::Error::other("shell stream read exceeded buffer"));
+        };
+        retain_captured_shell_bytes(&mut stream, chunk);
     }
 
     Ok(stream)
@@ -673,11 +761,30 @@ fn capture_shell_output(prompt: &str) -> CapturedShellOutput {
         terminate_shell_child(child);
         return CapturedShellOutput::failed();
     };
+    #[cfg(unix)]
+    let cancel_streams = Arc::new(AtomicBool::new(false));
+
+    #[cfg(unix)]
+    let stdout_thread = {
+        let cancel = Arc::clone(&cancel_streams);
+        thread::spawn(move || capture_shell_stream_until_cancelled(stdout, cancel))
+    };
+    #[cfg(unix)]
+    let stderr_thread = {
+        let cancel = Arc::clone(&cancel_streams);
+        thread::spawn(move || capture_shell_stream_until_cancelled(stderr, cancel))
+    };
+
+    #[cfg(not(unix))]
     let stdout_thread = thread::spawn(move || capture_shell_stream(stdout));
+    #[cfg(not(unix))]
     let stderr_thread = thread::spawn(move || capture_shell_stream(stderr));
 
     let exit_code =
         wait_shell_child_and_cleanup_group(child).map_or(1, |status| status.code().unwrap_or(1));
+    #[cfg(unix)]
+    cancel_streams.store(true, Ordering::Release);
+
     let stdout = join_captured_shell_stream(stdout_thread);
     let stderr = join_captured_shell_stream(stderr_thread);
     let (Ok(stdout), Ok(stderr)) = (stdout, stderr) else {

--- a/crates/guest-mock-claude/tests/echo_jsonl.rs
+++ b/crates/guest-mock-claude/tests/echo_jsonl.rs
@@ -677,6 +677,52 @@ fn stream_json_shell_background_child_does_not_hold_output_open()
     Ok(())
 }
 
+#[cfg(target_os = "linux")]
+#[test]
+fn stream_json_shell_escaped_child_does_not_hold_output_open()
+-> Result<(), Box<dyn std::error::Error>> {
+    let home = tempfile::tempdir()?;
+    let ready = home.path().join("escaped-child-ready");
+    let pid_file = home.path().join("escaped-child-pid");
+    let ready_path = ready.to_string_lossy();
+    let pid_path = pid_file.to_string_lossy();
+    let prompt = format!(
+        "setsid sh -c 'echo $$ > \"{pid_path}\"; echo ready > \"{ready_path}\"; sleep 30' & \
+         while [ ! -f \"{ready_path}\" ]; do :; done; echo done"
+    );
+
+    let output = mock_stream_json_shell_output(home.path(), &prompt);
+    if let Ok(pid) = fs::read_to_string(&pid_file).map(|value| value.trim().to_string())
+        && let Ok(pid) = pid.parse::<libc::pid_t>()
+    {
+        unsafe {
+            libc::kill(pid, libc::SIGKILL);
+        }
+    }
+    let output = output?;
+    assert!(
+        output.status.success(),
+        "expected success, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.stderr.is_empty());
+
+    let events = parse_jsonl(&output.stdout)?;
+    assert_eq!(
+        events.iter().map(event_kind).collect::<Vec<_>>(),
+        [
+            "system/init",
+            "assistant/text",
+            "assistant/tool_use",
+            "user/tool_result",
+            "result/success",
+        ]
+    );
+    assert!(tool_result_content(&events)?.contains("done"));
+    assert!(result_content(&events)?.contains("done"));
+    Ok(())
+}
+
 #[test]
 fn stream_json_input_reads_prompt_from_stdin() -> Result<(), Box<dyn std::error::Error>> {
     let home = tempfile::tempdir()?;

--- a/crates/guest-mock-claude/tests/echo_jsonl.rs
+++ b/crates/guest-mock-claude/tests/echo_jsonl.rs
@@ -649,6 +649,35 @@ fn stream_json_shell_writes_matching_session_history() -> Result<(), Box<dyn std
 }
 
 #[test]
+fn stream_json_shell_background_child_does_not_hold_output_open()
+-> Result<(), Box<dyn std::error::Error>> {
+    let home = tempfile::tempdir()?;
+
+    let output = mock_stream_json_shell_output(home.path(), "sleep 30 & echo done")?;
+    assert!(
+        output.status.success(),
+        "expected success, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.stderr.is_empty());
+
+    let events = parse_jsonl(&output.stdout)?;
+    assert_eq!(
+        events.iter().map(event_kind).collect::<Vec<_>>(),
+        [
+            "system/init",
+            "assistant/text",
+            "assistant/tool_use",
+            "user/tool_result",
+            "result/success",
+        ]
+    );
+    assert!(tool_result_content(&events)?.contains("done"));
+    assert!(result_content(&events)?.contains("done"));
+    Ok(())
+}
+
+#[test]
 fn stream_json_input_reads_prompt_from_stdin() -> Result<(), Box<dyn std::error::Error>> {
     let home = tempfile::tempdir()?;
     let mut command = mock_claude();

--- a/crates/guest-mock-claude/tests/echo_jsonl.rs
+++ b/crates/guest-mock-claude/tests/echo_jsonl.rs
@@ -730,7 +730,7 @@ fn stream_json_shell_escaped_child_does_not_hold_output_open()
 
 #[cfg(target_os = "linux")]
 #[test]
-fn stream_json_shell_escaped_stderr_writer_does_not_hold_output_open()
+fn stream_json_shell_truncated_escaped_stderr_writer_does_not_hold_output_open()
 -> Result<(), Box<dyn std::error::Error>> {
     let home = tempfile::tempdir()?;
     let ready = home.path().join("escaped-stderr-ready");
@@ -738,7 +738,7 @@ fn stream_json_shell_escaped_stderr_writer_does_not_hold_output_open()
     let ready_path = ready.to_string_lossy();
     let pid_path = pid_file.to_string_lossy();
     let prompt = format!(
-        "setsid sh -c 'echo $$ > \"{pid_path}\"; echo ready > \"{ready_path}\"; exec yes escaped-stderr >&2' & \
+        "setsid sh -c 'echo $$ > \"{pid_path}\"; yes escaped-stderr | head -c {LARGE_MOCK_OUTPUT_BYTES} >&2; echo ready > \"{ready_path}\"; exec yes escaped-stderr >&2' & \
          while [ ! -f \"{ready_path}\" ]; do :; done; echo done"
     );
 

--- a/crates/guest-mock-claude/tests/echo_jsonl.rs
+++ b/crates/guest-mock-claude/tests/echo_jsonl.rs
@@ -687,7 +687,7 @@ fn stream_json_shell_escaped_child_does_not_hold_output_open()
     let ready_path = ready.to_string_lossy();
     let pid_path = pid_file.to_string_lossy();
     let prompt = format!(
-        "setsid sh -c 'echo $$ > \"{pid_path}\"; echo ready > \"{ready_path}\"; sleep 30' & \
+        "setsid sh -c 'echo $$ > \"{pid_path}\"; echo ready > \"{ready_path}\"; exec sleep 30' & \
          while [ ! -f \"{ready_path}\" ]; do :; done; echo done"
     );
 

--- a/crates/guest-mock-claude/tests/echo_jsonl.rs
+++ b/crates/guest-mock-claude/tests/echo_jsonl.rs
@@ -533,6 +533,17 @@ fn mock_stream_json_shell_output(
     wait_child_output(spawn_managed_mock_child(&mut command)?)
 }
 
+#[cfg(target_os = "linux")]
+fn kill_pid_file(pid_file: &std::path::Path) {
+    if let Ok(pid) = fs::read_to_string(pid_file).map(|value| value.trim().to_string())
+        && let Ok(pid) = pid.parse::<libc::pid_t>()
+    {
+        unsafe {
+            libc::kill(pid, libc::SIGKILL);
+        }
+    }
+}
+
 #[test]
 fn echo_jsonl_outputs_valid_payload_unchanged() -> Result<(), Box<dyn std::error::Error>> {
     let home = tempfile::tempdir()?;
@@ -692,13 +703,7 @@ fn stream_json_shell_escaped_child_does_not_hold_output_open()
     );
 
     let output = mock_stream_json_shell_output(home.path(), &prompt);
-    if let Ok(pid) = fs::read_to_string(&pid_file).map(|value| value.trim().to_string())
-        && let Ok(pid) = pid.parse::<libc::pid_t>()
-    {
-        unsafe {
-            libc::kill(pid, libc::SIGKILL);
-        }
-    }
+    kill_pid_file(&pid_file);
     let output = output?;
     assert!(
         output.status.success(),
@@ -720,6 +725,48 @@ fn stream_json_shell_escaped_child_does_not_hold_output_open()
     );
     assert!(tool_result_content(&events)?.contains("done"));
     assert!(result_content(&events)?.contains("done"));
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn stream_json_shell_escaped_stderr_writer_does_not_hold_output_open()
+-> Result<(), Box<dyn std::error::Error>> {
+    let home = tempfile::tempdir()?;
+    let ready = home.path().join("escaped-stderr-ready");
+    let pid_file = home.path().join("escaped-stderr-pid");
+    let ready_path = ready.to_string_lossy();
+    let pid_path = pid_file.to_string_lossy();
+    let prompt = format!(
+        "setsid sh -c 'echo $$ > \"{pid_path}\"; echo ready > \"{ready_path}\"; exec yes escaped-stderr >&2' & \
+         while [ ! -f \"{ready_path}\" ]; do :; done; echo done"
+    );
+
+    let output = mock_stream_json_shell_output(home.path(), &prompt);
+    kill_pid_file(&pid_file);
+    let output = output?;
+    assert!(
+        output.status.success(),
+        "expected success, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.stderr.is_empty());
+
+    let events = parse_jsonl(&output.stdout)?;
+    assert_eq!(
+        events.iter().map(event_kind).collect::<Vec<_>>(),
+        [
+            "system/init",
+            "assistant/text",
+            "assistant/tool_use",
+            "user/tool_result",
+            "result/success",
+        ]
+    );
+    assert!(tool_result_content(&events)?.contains("done"));
+    assert!(result_content(&events)?.contains("done"));
+    assert!(!tool_result_content(&events)?.contains("escaped-stderr"));
+    assert!(!result_content(&events)?.contains("escaped-stderr"));
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- run stream-json shell captures in their own process group
- observe the bash parent exit before reaping, then terminate the shell process group before joining pipe readers
- make Unix pipe readers cancellable so descendants that escape the process group cannot keep final stream-json events blocked
- add regressions for both ordinary background children and escaped `setsid` children holding stdout/stderr open

Closes #19056

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p guest-mock-claude stream_json_shell_background_child_does_not_hold_output_open --quiet`
- `cargo test --manifest-path crates/Cargo.toml -p guest-mock-claude stream_json_shell_escaped_child_does_not_hold_output_open --quiet`
- `cargo test --manifest-path crates/Cargo.toml -p guest-mock-claude --quiet`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-mock-claude --all-targets --all-features -- -D warnings`