### PR TITLE
test: make NBD dispatch shutdown tests deterministic

### DIFF
--- a/crates/nbd-cow/src/server.rs
+++ b/crates/nbd-cow/src/server.rs
@@ -36,6 +36,86 @@ enum HandlerOutcome {
     Shutdown,
 }
 
+#[derive(Clone, Copy)]
+enum ReadContext {
+    Header,
+    WritePayload { handle: u64 },
+    OversizedDiscard { handle: u64 },
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DispatchReadEventKind {
+    WritePayload,
+    OversizedDiscard,
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct DispatchReadEvent {
+    kind: DispatchReadEventKind,
+    handle: u64,
+}
+
+#[cfg(test)]
+impl DispatchReadEvent {
+    fn from_context(context: ReadContext) -> Option<Self> {
+        match context {
+            ReadContext::Header => None,
+            ReadContext::WritePayload { handle } => Some(Self {
+                kind: DispatchReadEventKind::WritePayload,
+                handle,
+            }),
+            ReadContext::OversizedDiscard { handle } => Some(Self {
+                kind: DispatchReadEventKind::OversizedDiscard,
+                handle,
+            }),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct DispatchReadObserver {
+    #[cfg(test)]
+    sender: Option<tokio::sync::mpsc::UnboundedSender<DispatchReadEvent>>,
+}
+
+impl DispatchReadObserver {
+    fn none() -> Self {
+        Self {
+            #[cfg(test)]
+            sender: None,
+        }
+    }
+
+    #[cfg(test)]
+    fn new(sender: tokio::sync::mpsc::UnboundedSender<DispatchReadEvent>) -> Self {
+        Self {
+            sender: Some(sender),
+        }
+    }
+
+    fn notify_partial_read(&self, context: ReadContext) {
+        #[cfg(test)]
+        {
+            if let Some(sender) = &self.sender
+                && let Some(event) = DispatchReadEvent::from_context(context)
+            {
+                let _ = sender.send(event);
+            }
+        }
+        #[cfg(not(test))]
+        {
+            match context {
+                ReadContext::Header => {}
+                ReadContext::WritePayload { handle } | ReadContext::OversizedDiscard { handle } => {
+                    let _ = handle;
+                }
+            }
+        }
+    }
+}
+
 /// Run the NBD dispatch loop on a Unix stream.
 ///
 /// Reads NBD requests from the socket, dispatches to the COW layer,
@@ -50,6 +130,15 @@ pub async fn dispatch(
     cow: Arc<RwLock<CowLayer>>,
     shutdown: CancellationToken,
 ) -> Result<()> {
+    dispatch_with_read_observer(socket_fd, cow, shutdown, DispatchReadObserver::none()).await
+}
+
+async fn dispatch_with_read_observer(
+    socket_fd: OwnedFd,
+    cow: Arc<RwLock<CowLayer>>,
+    shutdown: CancellationToken,
+    read_observer: DispatchReadObserver,
+) -> Result<()> {
     let raw_fd = socket_fd.into_raw_fd();
     let std_stream = unsafe { std::os::unix::net::UnixStream::from_raw_fd(raw_fd) };
     std_stream.set_nonblocking(true)?;
@@ -61,7 +150,15 @@ pub async fn dispatch(
     let mut payload_buf = Vec::with_capacity(crate::BLOCK_SIZE);
 
     loop {
-        match read_exact_or_shutdown(&mut reader, &mut header_buf, &shutdown).await {
+        match read_exact_or_shutdown(
+            &mut reader,
+            &mut header_buf,
+            &shutdown,
+            ReadContext::Header,
+            &read_observer,
+        )
+        .await
+        {
             Ok(IoOutcome::Complete) => {}
             Ok(IoOutcome::Shutdown) => {
                 sync_cow_on_shutdown(&cow).await?;
@@ -87,6 +184,7 @@ pub async fn dispatch(
                     &mut writer,
                     &mut payload_buf,
                     &shutdown,
+                    &read_observer,
                 )
                 .await?
             }
@@ -121,6 +219,8 @@ async fn read_exact_or_shutdown(
     reader: &mut tokio::net::unix::OwnedReadHalf,
     buf: &mut [u8],
     shutdown: &CancellationToken,
+    context: ReadContext,
+    read_observer: &DispatchReadObserver,
 ) -> Result<IoOutcome> {
     let mut filled = 0usize;
     while filled < buf.len() {
@@ -141,6 +241,9 @@ async fn read_exact_or_shutdown(
                     ).into());
                 }
                 filled += count;
+                if filled < buf.len() {
+                    read_observer.notify_partial_read(context);
+                }
             }
         }
     }
@@ -254,10 +357,19 @@ async fn handle_write(
     writer: &mut tokio::net::unix::OwnedWriteHalf,
     payload_buf: &mut Vec<u8>,
     shutdown: &CancellationToken,
+    read_observer: &DispatchReadObserver,
 ) -> Result<HandlerOutcome> {
     if request.length > MAX_REQUEST_LENGTH {
         // Must consume the payload to keep the protocol stream in sync
-        if let IoOutcome::Shutdown = discard_bytes(reader, request.length as u64, shutdown).await? {
+        if let IoOutcome::Shutdown = discard_bytes(
+            reader,
+            request.length as u64,
+            shutdown,
+            request.handle,
+            read_observer,
+        )
+        .await?
+        {
             return Ok(HandlerOutcome::Shutdown);
         }
         return send_error_reply(writer, request.handle, libc::EIO as u32, shutdown)
@@ -274,13 +386,23 @@ async fn handle_write(
             writer,
             payload_buf.as_mut_slice(),
             shutdown,
+            read_observer,
         )
         .await;
         reset_reusable_payload_if_oversized(payload_buf);
         result
     } else {
         let mut data = vec![0u8; len];
-        read_and_apply_write(request, reader, cow, writer, data.as_mut_slice(), shutdown).await
+        read_and_apply_write(
+            request,
+            reader,
+            cow,
+            writer,
+            data.as_mut_slice(),
+            shutdown,
+            read_observer,
+        )
+        .await
     }
 }
 
@@ -291,8 +413,19 @@ async fn read_and_apply_write(
     writer: &mut tokio::net::unix::OwnedWriteHalf,
     data: &mut [u8],
     shutdown: &CancellationToken,
+    read_observer: &DispatchReadObserver,
 ) -> Result<HandlerOutcome> {
-    if let IoOutcome::Shutdown = read_exact_or_shutdown(reader, data, shutdown).await? {
+    if let IoOutcome::Shutdown = read_exact_or_shutdown(
+        reader,
+        data,
+        shutdown,
+        ReadContext::WritePayload {
+            handle: request.handle,
+        },
+        read_observer,
+    )
+    .await?
+    {
         return Ok(HandlerOutcome::Shutdown);
     }
 
@@ -396,6 +529,8 @@ async fn discard_bytes(
     reader: &mut tokio::net::unix::OwnedReadHalf,
     mut remaining: u64,
     shutdown: &CancellationToken,
+    handle: u64,
+    read_observer: &DispatchReadObserver,
 ) -> Result<IoOutcome> {
     let mut buf = [0u8; 4096];
     while remaining > 0 {
@@ -403,7 +538,15 @@ async fn discard_bytes(
         let dest = buf
             .get_mut(..to_read)
             .ok_or_else(|| NbdCowError::Io(std::io::Error::other("discard slice error")))?;
-        if let IoOutcome::Shutdown = read_exact_or_shutdown(reader, dest, shutdown).await? {
+        if let IoOutcome::Shutdown = read_exact_or_shutdown(
+            reader,
+            dest,
+            shutdown,
+            ReadContext::OversizedDiscard { handle },
+            read_observer,
+        )
+        .await?
+        {
             return Ok(IoOutcome::Shutdown);
         }
         remaining -= to_read as u64;

--- a/crates/nbd-cow/src/server/tests.rs
+++ b/crates/nbd-cow/src/server/tests.rs
@@ -39,6 +39,33 @@ async fn setup_dispatch(
     tokio::task::JoinHandle<crate::error::Result<()>>,
     CancellationToken,
 ) {
+    setup_dispatch_with_observer(cow, DispatchReadObserver::none()).await
+}
+
+async fn setup_observed_dispatch(
+    cow: Arc<RwLock<CowLayer>>,
+) -> (
+    tokio::net::unix::OwnedReadHalf,
+    tokio::net::unix::OwnedWriteHalf,
+    tokio::task::JoinHandle<crate::error::Result<()>>,
+    CancellationToken,
+    tokio::sync::mpsc::UnboundedReceiver<DispatchReadEvent>,
+) {
+    let (event_sender, read_events) = tokio::sync::mpsc::unbounded_channel();
+    let (reader, writer, task, shutdown) =
+        setup_dispatch_with_observer(cow, DispatchReadObserver::new(event_sender)).await;
+    (reader, writer, task, shutdown, read_events)
+}
+
+async fn setup_dispatch_with_observer(
+    cow: Arc<RwLock<CowLayer>>,
+    read_observer: DispatchReadObserver,
+) -> (
+    tokio::net::unix::OwnedReadHalf,
+    tokio::net::unix::OwnedWriteHalf,
+    tokio::task::JoinHandle<crate::error::Result<()>>,
+    CancellationToken,
+) {
     let shutdown = CancellationToken::new();
     let (client_fd, server_fd) = {
         let mut fds = [0i32; 2];
@@ -50,7 +77,9 @@ async fn setup_dispatch(
 
     let cow_clone = cow.clone();
     let shutdown_clone = shutdown.clone();
-    let task = tokio::spawn(async move { dispatch(server_fd, cow_clone, shutdown_clone).await });
+    let task = tokio::spawn(async move {
+        dispatch_with_read_observer(server_fd, cow_clone, shutdown_clone, read_observer).await
+    });
 
     let client_std =
         unsafe { std::os::unix::net::UnixStream::from_raw_fd(client_fd.into_raw_fd()) };
@@ -146,9 +175,22 @@ async fn assert_dispatch_exits_after_shutdown(
     must(result, "dispatch should not fail");
 }
 
-async fn yield_to_dispatch() {
-    for _ in 0..10 {
-        tokio::task::yield_now().await;
+async fn wait_for_read_event(
+    read_events: &mut tokio::sync::mpsc::UnboundedReceiver<DispatchReadEvent>,
+    expected: DispatchReadEvent,
+) {
+    let observed = tokio::time::timeout(Duration::from_secs(1), async {
+        while let Some(event) = read_events.recv().await {
+            if event == expected {
+                return;
+            }
+        }
+        panic!("dispatch read observer closed before {expected:?}");
+    })
+    .await;
+    match observed {
+        Ok(()) => {}
+        Err(_) => panic!("dispatch should reach {expected:?}"),
     }
 }
 
@@ -286,7 +328,7 @@ async fn dispatch_shutdown_while_write_payload_pending_exits() {
     let (_base, _cow_file, cow) = create_test_cow(&base_data);
     let cow = Arc::new(RwLock::new(cow));
 
-    let (_reader, mut writer, task, shutdown) = setup_dispatch(cow).await;
+    let (_reader, mut writer, task, shutdown, mut read_events) = setup_observed_dispatch(cow).await;
 
     let write_req = NbdRequest {
         command: Command::Write,
@@ -303,7 +345,14 @@ async fn dispatch_shutdown_while_write_payload_pending_exits() {
         writer.write_all(&partial_payload).await,
         "write partial payload",
     );
-    yield_to_dispatch().await;
+    wait_for_read_event(
+        &mut read_events,
+        DispatchReadEvent {
+            kind: DispatchReadEventKind::WritePayload,
+            handle: 1,
+        },
+    )
+    .await;
 
     shutdown.cancel();
     assert_dispatch_exits_after_shutdown(task).await;
@@ -315,7 +364,7 @@ async fn dispatch_shutdown_while_oversized_write_discard_pending_exits() {
     let (_base, _cow_file, cow) = create_test_cow(&base_data);
     let cow = Arc::new(RwLock::new(cow));
 
-    let (_reader, mut writer, task, shutdown) = setup_dispatch(cow).await;
+    let (_reader, mut writer, task, shutdown, mut read_events) = setup_observed_dispatch(cow).await;
 
     let write_req = NbdRequest {
         command: Command::Write,
@@ -327,12 +376,19 @@ async fn dispatch_shutdown_while_oversized_write_discard_pending_exits() {
         writer.write_all(&serialize_request(&write_req)).await,
         "write oversized request",
     );
-    let partial_payload = vec![0xAA; 64 * 1024];
+    let partial_payload = vec![0xAA; 512];
     must(
         writer.write_all(&partial_payload).await,
         "write oversized partial payload",
     );
-    yield_to_dispatch().await;
+    wait_for_read_event(
+        &mut read_events,
+        DispatchReadEvent {
+            kind: DispatchReadEventKind::OversizedDiscard,
+            handle: 1,
+        },
+    )
+    .await;
 
     shutdown.cancel();
     assert_dispatch_exits_after_shutdown(task).await;
@@ -344,7 +400,8 @@ async fn dispatch_shutdown_during_partial_write_flushes_accepted_data() {
     let (_base, _cow_file, cow) = create_test_cow(&base_data);
     let cow = Arc::new(RwLock::new(cow));
 
-    let (mut reader, mut writer, task, shutdown) = setup_dispatch(cow.clone()).await;
+    let (mut reader, mut writer, task, shutdown, mut read_events) =
+        setup_observed_dispatch(cow.clone()).await;
 
     let accepted_write = NbdRequest {
         command: Command::Write,
@@ -376,7 +433,14 @@ async fn dispatch_shutdown_during_partial_write_flushes_accepted_data() {
         writer.write_all(&partial_payload).await,
         "write partial payload",
     );
-    yield_to_dispatch().await;
+    wait_for_read_event(
+        &mut read_events,
+        DispatchReadEvent {
+            kind: DispatchReadEventKind::WritePayload,
+            handle: 2,
+        },
+    )
+    .await;
 
     shutdown.cancel();
     assert_dispatch_exits_after_shutdown(task).await;

--- a/crates/nbd-cow/src/server/tests.rs
+++ b/crates/nbd-cow/src/server/tests.rs
@@ -39,7 +39,14 @@ async fn setup_dispatch(
     tokio::task::JoinHandle<crate::error::Result<()>>,
     CancellationToken,
 ) {
-    setup_dispatch_with_observer(cow, DispatchReadObserver::none()).await
+    let shutdown = CancellationToken::new();
+    let (reader, writer, server_fd) = setup_dispatch_socket();
+
+    let cow_clone = cow.clone();
+    let shutdown_clone = shutdown.clone();
+    let task = tokio::spawn(async move { dispatch(server_fd, cow_clone, shutdown_clone).await });
+
+    (reader, writer, task, shutdown)
 }
 
 async fn setup_observed_dispatch(
@@ -51,22 +58,30 @@ async fn setup_observed_dispatch(
     CancellationToken,
     tokio::sync::mpsc::UnboundedReceiver<DispatchReadEvent>,
 ) {
+    let shutdown = CancellationToken::new();
+    let (reader, writer, server_fd) = setup_dispatch_socket();
     let (event_sender, read_events) = tokio::sync::mpsc::unbounded_channel();
-    let (reader, writer, task, shutdown) =
-        setup_dispatch_with_observer(cow, DispatchReadObserver::new(event_sender)).await;
+
+    let cow_clone = cow.clone();
+    let shutdown_clone = shutdown.clone();
+    let task = tokio::spawn(async move {
+        dispatch_with_read_observer(
+            server_fd,
+            cow_clone,
+            shutdown_clone,
+            DispatchReadObserver::new(event_sender),
+        )
+        .await
+    });
+
     (reader, writer, task, shutdown, read_events)
 }
 
-async fn setup_dispatch_with_observer(
-    cow: Arc<RwLock<CowLayer>>,
-    read_observer: DispatchReadObserver,
-) -> (
+fn setup_dispatch_socket() -> (
     tokio::net::unix::OwnedReadHalf,
     tokio::net::unix::OwnedWriteHalf,
-    tokio::task::JoinHandle<crate::error::Result<()>>,
-    CancellationToken,
+    OwnedFd,
 ) {
-    let shutdown = CancellationToken::new();
     let (client_fd, server_fd) = {
         let mut fds = [0i32; 2];
         let ret =
@@ -74,12 +89,6 @@ async fn setup_dispatch_with_observer(
         assert_eq!(ret, 0);
         unsafe { (OwnedFd::from_raw_fd(fds[0]), OwnedFd::from_raw_fd(fds[1])) }
     };
-
-    let cow_clone = cow.clone();
-    let shutdown_clone = shutdown.clone();
-    let task = tokio::spawn(async move {
-        dispatch_with_read_observer(server_fd, cow_clone, shutdown_clone, read_observer).await
-    });
 
     let client_std =
         unsafe { std::os::unix::net::UnixStream::from_raw_fd(client_fd.into_raw_fd()) };
@@ -93,7 +102,7 @@ async fn setup_dispatch_with_observer(
     );
 
     let (reader, writer) = client_stream.into_split();
-    (reader, writer, task, shutdown)
+    (reader, writer, server_fd)
 }
 
 async fn send_and_recv_reply(


### PR DESCRIPTION
## Summary

- Add a per-dispatch test read observer for partial write payload and oversized discard reads.
- Replace scheduler-yield coordination in NBD shutdown tests with observer-backed waits for the exact request handle and read kind.
- Shrink the oversized discard partial payload so the test is known to be mid-discard when shutdown is cancelled.

Fixes #19085

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml -p nbd-cow`
- `cargo test --manifest-path crates/Cargo.toml -p nbd-cow dispatch_shutdown_while_write_payload_pending_exits`
- `cargo test --manifest-path crates/Cargo.toml -p nbd-cow dispatch_shutdown_while_oversized_write_discard_pending_exits`
- `cargo test --manifest-path crates/Cargo.toml -p nbd-cow dispatch_shutdown_during_partial_write_flushes_accepted_data`
- `cargo test --manifest-path crates/Cargo.toml -p nbd-cow`
- `cargo clippy --manifest-path crates/Cargo.toml -p nbd-cow --all-targets --all-features`
