### PR TITLE
docs: document proxy log sanitization contract

### DIFF
--- a/crates/runner/mitm-addon/src/logging_utils.py
+++ b/crates/runner/mitm-addon/src/logging_utils.py
@@ -63,6 +63,12 @@ def log_network_entry(log_path: str, entry: dict) -> None:
 
 
 def sanitize_proxy_log_extra_value(key: str, value: object) -> object:
+    """Sanitize the narrow set of proxy-log extras owned by this module.
+
+    Only the exact ``url`` field is treated specially, and only when the
+    value is a string.  Every other field is returned unchanged; this helper
+    is not a general secret-redaction boundary for arbitrary proxy-log data.
+    """
     if key == "url" and isinstance(value, str):
         return network_log_sanitization.sanitize_url_for_network_log(value)
     return value
@@ -75,7 +81,19 @@ def log_proxy_entry(
     /,
     **extra: object,
 ) -> None:
-    """Write a diagnostic log entry to the per-job proxy log file (JSONL)."""
+    """Write a best-effort per-job proxy diagnostic JSONL entry.
+
+    The logger owns the canonical ``timestamp``, ``level``, and ``message``
+    fields; extras with those exact names are ignored and cannot override
+    them.  Among remaining extras, only an exact ``url`` string is sanitized
+    by ``sanitize_proxy_log_extra_value``.  All other extras are written as
+    provided, so callers must pass only values that are safe to persist and
+    JSON-serializable.
+
+    Do not assume broad redaction for raw headers, bodies, cookies, tokens,
+    or arbitrary nested values.  Usage underbilling signals should use the
+    dedicated usage-underbilling helper for that logging contract.
+    """
     entry: dict = {
         "timestamp": _utc_log_timestamp(),
         "level": log_level,

--- a/crates/runner/mitm-addon/src/usage/underbilling.py
+++ b/crates/runner/mitm-addon/src/usage/underbilling.py
@@ -212,6 +212,18 @@ def log_usage_underbilling(
     /,
     **extra: object,
 ) -> None:
+    """Log a usage-underbilling signal with the underbilling field contract.
+
+    ``type``, ``reason``, ``underbilling_class``, and ``component`` are owned
+    by this helper and cannot be overridden by caller context.  Without a
+    proxy log path, the stderr fallback additionally applies key-based secret
+    redaction, exact-``url`` sanitization, escaping, and truncation.
+
+    When a proxy log path is available, this still writes structured JSONL
+    through ``log_proxy_entry``.  In that path, the proxy-log extra-field
+    contract still applies; callers must not assume broad proxy-log redaction
+    for arbitrary context.
+    """
     fields = underbilling_fields(reason, underbilling_class, **extra)
     if not proxy_log_path:
         parts = [


### PR DESCRIPTION
## Summary

- Document the narrow proxy-log extra-field sanitization contract in `logging_utils.py`
- Clarify that `log_proxy_entry()` only protects `timestamp`/`level`/`message` and only sanitizes an exact `url` extra
- Document the usage-underbilling helper boundary, including the stderr fallback vs proxy JSONL distinction

Runtime behavior is unchanged.

## Tests

- `.venv/bin/pytest tests/test_logging_utils.py tests/test_usage_underbilling.py`
- `.venv/bin/ruff check src/logging_utils.py src/usage/underbilling.py`
- `.venv/bin/ruff format --check src/logging_utils.py src/usage/underbilling.py`

Fixes #19084
