### PR TITLE
fix: hand off Clerk auth to paid onboarding

### DIFF
--- a/turbo/apps/platform/src/__tests__/mock-auth.ts
+++ b/turbo/apps/platform/src/__tests__/mock-auth.ts
@@ -162,6 +162,8 @@ export function clearMockedAuth() {
     status: "complete",
     createdSessionId: "test-created-session-id",
   });
+  mockedClerk.buildUrlWithAuth.mockReset();
+  mockedClerk.buildUrlWithAuth.mockImplementation(defaultBuildUrlWithAuthImpl);
 }
 
 const clerkListeners: (() => void)[] = [];
@@ -183,6 +185,12 @@ const clientSignInCreate = vi.fn(
     });
   },
 );
+const defaultBuildUrlWithAuthImpl = (targetUrl: string): string => {
+  const url = new URL(targetUrl);
+  url.searchParams.set("__clerk_db_jwt", "test-dev-browser-jwt");
+  return url.toString();
+};
+const buildUrlWithAuth = vi.fn(defaultBuildUrlWithAuthImpl);
 
 export const mockedClerk = {
   get user() {
@@ -199,6 +207,7 @@ export const mockedClerk = {
   },
   sessionGetToken,
   clientSignInCreate,
+  buildUrlWithAuth,
   client: {
     get sessions() {
       return internalMockedClientSessions;

--- a/turbo/apps/platform/src/signals/__tests__/auth-url.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/auth-url.test.ts
@@ -2,8 +2,10 @@ import { waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { detachedSetupPage } from "../../__tests__/page-helper.ts";
+import { mockedClerk } from "../../__tests__/mock-auth.ts";
 import { resolveWebAuthUrl, resolveWebOrigin } from "../auth.ts";
 import { testContext } from "./test-helpers.ts";
+import { redirectToConfiguredOnboarding$ } from "../zero-page/onboard-guard.ts";
 
 const context = testContext();
 
@@ -44,6 +46,26 @@ describe("platform auth URLs", () => {
 });
 
 describe("platform auth redirects", () => {
+  it("adds Clerk auth handoff to the paid onboarding target URL", async () => {
+    setBrowserUrl("https://app.vm7.ai:8443/");
+
+    await context.store.set(
+      redirectToConfiguredOnboarding$,
+      new URLSearchParams({ prompt: "hello" }),
+      context.signal,
+    );
+
+    expect(mockedClerk.buildUrlWithAuth).toHaveBeenCalledOnce();
+    const redirectUrl = new URL(window.location.href);
+    expect(redirectUrl.origin).toBe("https://so.vm7.ai:8443");
+    expect(redirectUrl.pathname).toBe("/onboarding/2afcf6");
+    expect(redirectUrl.searchParams.get("prompt")).toBe("hello");
+    expect(redirectUrl.searchParams.get("domain")).toBe("api.vm7.ai:8443");
+    expect(redirectUrl.searchParams.get("__clerk_db_jwt")).toBe(
+      "test-dev-browser-jwt",
+    );
+  });
+
   it("redirects unauthenticated preview users to web sign-in with API domain override", async () => {
     setBrowserUrl("https://pr-18532-app.vm6.ai/agents");
 

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -1,4 +1,5 @@
 import { command, computed, state } from "ccstate";
+import type { Clerk } from "@clerk/clerk-js";
 import { clearSentryUser, setSentryUser } from "../lib/sentry.ts";
 import { clearPostHogUser, setPostHogUser } from "../lib/posthog.ts";
 import { bestEffort, onDomEventFn } from "./utils.ts";
@@ -54,6 +55,13 @@ export function resolveWebAuthUrl(
     url.searchParams.set("redirect_url", options.redirectUrl);
   }
   return url.toString();
+}
+
+export function resolveClerkHandoffUrl(
+  clerk: Pick<Clerk, "buildUrlWithAuth">,
+  targetUrl: string,
+): string {
+  return clerk.buildUrlWithAuth(targetUrl);
 }
 
 /**

--- a/turbo/apps/platform/src/signals/prompt-page/prompt-page-setup.ts
+++ b/turbo/apps/platform/src/signals/prompt-page/prompt-page-setup.ts
@@ -71,7 +71,8 @@ export const setupPromptPage$ = command(
     const agentId = await get(defaultAgentId$);
     signal.throwIfAborted();
     if (!agentId) {
-      set(redirectToConfiguredOnboarding$, params);
+      await set(redirectToConfiguredOnboarding$, params, signal);
+      signal.throwIfAborted();
       return;
     }
 

--- a/turbo/apps/platform/src/signals/zero-page/onboard-guard.ts
+++ b/turbo/apps/platform/src/signals/zero-page/onboard-guard.ts
@@ -1,5 +1,5 @@
 import { command } from "ccstate";
-import { clerk$, resolveWebAuthUrl } from "../auth.ts";
+import { clerk$, resolveClerkHandoffUrl, resolveWebAuthUrl } from "../auth.ts";
 import { searchParams$ } from "../route.ts";
 import {
   zeroOnboardingStatus$,
@@ -31,23 +31,34 @@ function paidOnboardingUrl(searchParams: URLSearchParams): string {
 }
 
 const redirectToPaidOnboarding$ = command(
-  ({ get }, searchParams?: URLSearchParams) => {
-    window.location.href = paidOnboardingUrl(
-      searchParams ?? get(searchParams$),
-    );
+  async (
+    { get },
+    searchParams: URLSearchParams | undefined,
+    signal: AbortSignal,
+  ) => {
+    const targetUrl = paidOnboardingUrl(searchParams ?? get(searchParams$));
+    const clerk = await get(clerk$);
+    signal.throwIfAborted();
+    window.location.href = resolveClerkHandoffUrl(clerk, targetUrl);
   },
 );
 
 export const redirectToConfiguredOnboarding$ = command(
-  ({ set }, searchParams?: URLSearchParams) => {
-    set(redirectToPaidOnboarding$, searchParams);
+  async (
+    { set },
+    searchParams: URLSearchParams | undefined,
+    signal: AbortSignal,
+  ) => {
+    await set(redirectToPaidOnboarding$, searchParams, signal);
+    signal.throwIfAborted();
   },
 );
 
 export const setupOnboardingRedirectPage$ = command(
-  ({ set }, signal: AbortSignal) => {
+  async ({ set }, signal: AbortSignal) => {
     signal.throwIfAborted();
-    set(redirectToConfiguredOnboarding$);
+    await set(redirectToConfiguredOnboarding$, undefined, signal);
+    signal.throwIfAborted();
   },
 );
 
@@ -86,7 +97,8 @@ export const onboardGuard$ = command(
       }
     }
 
-    set(redirectToConfiguredOnboarding$);
+    await set(redirectToConfiguredOnboarding$, undefined, signal);
+    signal.throwIfAborted();
     return true;
   },
 );

--- a/turbo/apps/web/app/sign-in/[[...sign-in]]/SignInClient.tsx
+++ b/turbo/apps/web/app/sign-in/[[...sign-in]]/SignInClient.tsx
@@ -1,17 +1,35 @@
 "use client";
 
 import { SignIn } from "@clerk/nextjs";
+import { useSearchParams } from "next/navigation";
 import { useTheme } from "../../components/ThemeProvider";
 import { AuthLayout } from "../../components/auth/AuthLayout";
 import { getClerkAppearance } from "../../components/auth/clerk-appearance";
+import { buildSignInRedirectUrl } from "../../../src/lib/adAttribution";
+import {
+  getAllowedRedirectOrigins,
+  getAppUrl,
+  getPaidOnboardingUrl,
+} from "../../../src/lib/zero/url";
 
 export function SignInClient() {
   const { theme } = useTheme();
+  const searchParams = useSearchParams();
+  const redirectUrl = buildSignInRedirectUrl(
+    getAppUrl(),
+    searchParams.toString(),
+    getAllowedRedirectOrigins(),
+    getPaidOnboardingUrl(),
+  );
 
   return (
     <AuthLayout>
       <div className="relative z-10 flex w-full max-w-md flex-col gap-3">
-        <SignIn appearance={getClerkAppearance(theme)} />
+        <SignIn
+          appearance={getClerkAppearance(theme)}
+          fallbackRedirectUrl={redirectUrl}
+          forceRedirectUrl={redirectUrl}
+        />
       </div>
     </AuthLayout>
   );

--- a/turbo/apps/web/src/__tests__/adAttribution.test.ts
+++ b/turbo/apps/web/src/__tests__/adAttribution.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildHomepageAttributionProperties,
+  buildSignInRedirectUrl,
   buildSignupHref,
   buildSignupRedirectUrl,
   hasAdAttributionParams,
@@ -273,5 +274,27 @@ describe("buildSignupRedirectUrl", () => {
     expect(url.origin).toBe("https://app.vm0.ai");
     expect(url.pathname).toBe("/onboarding");
     expect(url.searchParams.get("gclid")).toBe("test-click");
+  });
+});
+
+describe("buildSignInRedirectUrl", () => {
+  it("honors an allowed redirect_url without applying signup attribution fallback", () => {
+    const redirectUrl = buildSignInRedirectUrl(
+      "https://app.vm7.ai:8443",
+      "redirect_url=https%3A%2F%2Fso.vm7.ai%3A8443%2Fonboarding%2F2afcf6&gclid=test-click",
+      ["https://app.vm7.ai:8443", "https://so.vm7.ai:8443"],
+    );
+
+    expect(redirectUrl).toBe("https://so.vm7.ai:8443/onboarding/2afcf6");
+  });
+
+  it("falls back to the app URL when redirect_url is not allowed", () => {
+    expect(
+      buildSignInRedirectUrl(
+        "https://app.vm0.ai",
+        "redirect_url=https%3A%2F%2Fevil.example%2Fonboarding",
+        ["https://app.vm0.ai", "https://so.vm0.ai"],
+      ),
+    ).toBe("https://app.vm0.ai");
   });
 });

--- a/turbo/apps/web/src/lib/adAttribution.ts
+++ b/turbo/apps/web/src/lib/adAttribution.ts
@@ -293,6 +293,19 @@ export function buildSignupRedirectUrl(
   return url.toString();
 }
 
+export function buildSignInRedirectUrl(
+  appUrl: string,
+  signInSearch: string,
+  allowedRedirectOrigins: readonly string[] = [appUrl],
+  paidOnboardingUrl?: string,
+): string {
+  const params = new URLSearchParams(signInSearch);
+  return (
+    readAllowedRedirectUrl(params, allowedRedirectOrigins, paidOnboardingUrl) ??
+    appUrl
+  );
+}
+
 function readAllowedRedirectUrl(
   params: URLSearchParams,
   allowedRedirectOrigins: readonly string[],


### PR DESCRIPTION
## Summary
- send paid onboarding redirects through Clerk `buildUrlWithAuth` so SO receives the dev-browser handoff JWT directly
- make paid onboarding redirect commands await Clerk before assigning `window.location.href`
- add platform auth redirect coverage for the SO handoff URL

## Validation
- `pnpm -F @vm0/app exec vitest run src/signals/__tests__/auth-url.test.ts`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- pre-commit `pnpm check-types`
- browser signup with `+clerk_test` and OTP `424242`, then app -> SO handoff via local Caddy to PR #98 preview

## Related
- vm0-marketing PR: https://github.com/vm0-ai/vm0-marketing/pull/98