### PR TITLE
perf: split create-run pre-create timing

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -123,6 +123,22 @@ const API_DISPATCH_TIMING_ACTION_TYPES = [
   "api_dispatch_prepare_storage_manifest",
   "api_dispatch_build_stored_execution_context",
 ] as const;
+const API_DISPATCH_DIRECT_PRE_CREATE_ACTION_TYPES = [
+  "api_dispatch_pre_create_direct_parse_body",
+  "api_dispatch_pre_create_direct_prepare_args",
+] as const;
+const API_DISPATCH_ZERO_PRE_CREATE_ACTION_TYPES = [
+  "api_dispatch_pre_create_zero_parse_body",
+  "api_dispatch_pre_create_zero_prepare_args",
+  "api_dispatch_pre_create_zero_resolve_agent_id",
+  "api_dispatch_pre_create_zero_load_agent",
+  "api_dispatch_pre_create_zero_load_user_info",
+  "api_dispatch_pre_create_zero_resolve_trigger_context",
+  "api_dispatch_pre_create_zero_load_connector_scopes",
+  "api_dispatch_pre_create_zero_load_workflows",
+  "api_dispatch_pre_create_zero_resolve_permission_policies",
+  "api_dispatch_pre_create_zero_build_create_run_args",
+] as const;
 const API_DISPATCH_STORED_CONNECTOR_ROW_ACTION_TYPES = [
   "api_dispatch_prepare_context_load_stored_connector_rows",
   "api_dispatch_prepare_context_filter_stored_connector_rows",
@@ -388,6 +404,24 @@ function expectNoApiDispatchActions(
   }
 }
 
+function expectApiDispatchSpanKind(
+  events: readonly Record<string, unknown>[],
+  expectedActionTypes: readonly string[],
+  spanKind: string,
+): void {
+  for (const actionType of expectedActionTypes) {
+    const matchingEvents = events.filter((event) => {
+      return event.op_type === actionType;
+    });
+    expect(matchingEvents).toHaveLength(1);
+    expect(matchingEvents[0]).toStrictEqual(
+      expect.objectContaining({
+        span_kind: spanKind,
+      }),
+    );
+  }
+}
+
 function expectApiDispatchTimingEventsNotToLeak(
   events: readonly Record<string, unknown>[],
   forbiddenValues: readonly string[],
@@ -529,6 +563,19 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expectApiDispatchActions(timingEvents, API_DISPATCH_TIMING_ACTION_TYPES);
     expectApiDispatchActions(
       timingEvents,
+      API_DISPATCH_ZERO_PRE_CREATE_ACTION_TYPES,
+    );
+    expectApiDispatchSpanKind(
+      timingEvents,
+      API_DISPATCH_ZERO_PRE_CREATE_ACTION_TYPES,
+      "nested",
+    );
+    expectNoApiDispatchActions(
+      timingEvents,
+      API_DISPATCH_DIRECT_PRE_CREATE_ACTION_TYPES,
+    );
+    expectApiDispatchActions(
+      timingEvents,
       API_DISPATCH_PERMISSION_MANIFEST_SUBSTEP_ACTION_TYPES,
     );
     expectApiDispatchActions(timingEvents, [
@@ -589,6 +636,63 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       expect(["top_level", "nested"]).toContain(event.span_kind);
     }
     expectApiDispatchTimingEventsNotToLeak(timingEvents, [prompt, agentId]);
+  });
+
+  it("emits api dispatch timing for direct create route runs", async () => {
+    const api = createRunsAutomationsApi(context);
+    const { actor } = await entitledRunActor();
+    const prompt = "direct route api dispatch timing should not leak prompt";
+    const composeName = `bdd-direct-route-timing-${randomUUID().slice(0, 8)}`;
+    const compose = await api.createCompose(actor, {
+      version: "1",
+      agents: {
+        [composeName]: {
+          framework: "claude-code",
+          environment: { ANTHROPIC_API_KEY: "bdd-inline-key" },
+        },
+      },
+    });
+    const [composeRow] = await writeDb
+      .select({ headVersionId: agentComposes.headVersionId })
+      .from(agentComposes)
+      .where(eq(agentComposes.id, compose.composeId))
+      .limit(1);
+    const headVersionId = composeRow?.headVersionId;
+    if (!headVersionId) {
+      throw new Error("Expected created compose to have a head version id");
+    }
+
+    const created = await api.createDirectRun(actor, {
+      agentComposeVersionId: headVersionId,
+      prompt,
+    });
+
+    const timingEvents = apiDispatchTimingEventsForRun(created.runId);
+    expectApiDispatchActions(timingEvents, API_DISPATCH_TIMING_ACTION_TYPES);
+    expectApiDispatchActions(
+      timingEvents,
+      API_DISPATCH_DIRECT_PRE_CREATE_ACTION_TYPES,
+    );
+    expectApiDispatchSpanKind(
+      timingEvents,
+      API_DISPATCH_DIRECT_PRE_CREATE_ACTION_TYPES,
+      "nested",
+    );
+    expectNoApiDispatchActions(
+      timingEvents,
+      API_DISPATCH_ZERO_PRE_CREATE_ACTION_TYPES,
+    );
+    expectApiDispatchSpanKind(
+      timingEvents,
+      ["api_dispatch_pre_create_agent_run"],
+      "top_level",
+    );
+    expectApiDispatchTimingEventsNotToLeak(timingEvents, [
+      prompt,
+      headVersionId,
+    ]);
+
+    await api.requestCancelRun(actor, created.runId, [200]);
   });
 
   it("emits compose resolution timing for direct compose version runs", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
@@ -416,6 +416,10 @@ async function postWebhook(args: {
   );
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 async function latestRunForFixture(fixture: TelegramPostFixture) {
   const db = store.set(writeDb$);
   const [run] = await db
@@ -430,6 +434,24 @@ async function latestRunForFixture(fixture: TelegramPostFixture) {
     .orderBy(desc(agentRuns.createdAt))
     .limit(1);
   return run;
+}
+
+function sandboxOperationEventsForRun(
+  runId: string,
+): readonly Record<string, unknown>[] {
+  return context.mocks.axiom.sdkIngest.mock.calls.flatMap((call) => {
+    const dataset = call[0];
+    const events = call[1];
+    if (dataset !== "vm0-sandbox-op-log-dev" || !Array.isArray(events)) {
+      return [];
+    }
+    return events.filter((event): event is Record<string, unknown> => {
+      if (!isRecord(event)) {
+        return false;
+      }
+      return event.run_id === runId;
+    });
+  });
 }
 
 async function runForFixturePrompt(
@@ -1256,6 +1278,27 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
       .where(eq(runnerJobQueue.runId, run!.id))
       .limit(1);
     expect(job).toBeDefined();
+    const timingEvents = sandboxOperationEventsForRun(run!.id).filter(
+      (event) => {
+        return (
+          typeof event.op_type === "string" &&
+          event.op_type.startsWith("api_dispatch_")
+        );
+      },
+    );
+    expect(timingEvents).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          op_type: "api_dispatch_pre_create_agent_run",
+          span_kind: "top_level",
+        }),
+      ]),
+    );
+    expect(
+      timingEvents.map((event) => {
+        return event.op_type;
+      }),
+    ).not.toContain("api_dispatch_pre_create_zero_parse_body");
   });
 
   it("keeps Telegram callbacks typed when VM0_API_BACKEND_URL is set", async () => {

--- a/turbo/apps/api/src/signals/routes/agent-runs-create.ts
+++ b/turbo/apps/api/src/signals/routes/agent-runs-create.ts
@@ -6,30 +6,43 @@ import { authRoute } from "../auth/auth-route";
 import { bodyResultOf } from "../context/request";
 import { now } from "../external/time";
 import { createAgentRun$ } from "../services/agent-run-create.service";
+import { ApiDispatchTimingCollector } from "../services/api-dispatch-timing.service";
 import type { RouteEntry } from "../route";
 
 const createRunBody$ = bodyResultOf(runsMainContract.create);
 
 const createRunInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const apiStartTime = now();
-  const body = await get(createRunBody$);
+  const timing = new ApiDispatchTimingCollector();
+  const body = await timing.measure(
+    "api_dispatch_pre_create_direct_parse_body",
+    "nested",
+    async () => {
+      return await get(createRunBody$);
+    },
+  );
   signal.throwIfAborted();
   if (!body.ok) {
     return body.response;
   }
 
-  const auth = get(organizationAuthContext$);
-  return await set(
-    createAgentRun$,
-    {
-      userId: auth.userId,
-      orgId: auth.orgId,
-      body: body.data,
-      apiStartTime,
-      modelProviderType: body.data.modelProviderType,
+  const args = await timing.measure(
+    "api_dispatch_pre_create_direct_prepare_args",
+    "nested",
+    () => {
+      const auth = get(organizationAuthContext$);
+      return {
+        userId: auth.userId,
+        orgId: auth.orgId,
+        body: body.data,
+        apiStartTime,
+        modelProviderType: body.data.modelProviderType,
+        timing,
+      };
     },
-    signal,
   );
+  signal.throwIfAborted();
+  return await set(createAgentRun$, args, signal);
 });
 
 export const agentRunsCreateRoutes: readonly RouteEntry[] = [

--- a/turbo/apps/api/src/signals/routes/zero-runs.ts
+++ b/turbo/apps/api/src/signals/routes/zero-runs.ts
@@ -18,6 +18,7 @@ import {
   zeroRunRunner,
 } from "../services/zero-runs.service";
 import { createZeroRun$ } from "../services/zero-runs-create.service";
+import { ApiDispatchTimingCollector } from "../services/api-dispatch-timing.service";
 import type { RouteEntry } from "../route";
 
 const createRunBody$ = bodyResultOf(zeroRunsMainContract.create);
@@ -73,18 +74,29 @@ const getRunQueueInner$ = computed(async (get) => {
 
 const createRunInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const apiStartTime = now();
-  const body = await get(createRunBody$);
+  const timing = new ApiDispatchTimingCollector();
+  const body = await timing.measure(
+    "api_dispatch_pre_create_zero_parse_body",
+    "nested",
+    async () => {
+      return await get(createRunBody$);
+    },
+  );
   signal.throwIfAborted();
   if (!body.ok) {
     return body.response;
   }
 
-  const auth = get(organizationAuthContext$);
-  return await set(
-    createZeroRun$,
-    { auth, body: body.data, apiStartTime },
-    signal,
+  const args = await timing.measure(
+    "api_dispatch_pre_create_zero_prepare_args",
+    "nested",
+    () => {
+      const auth = get(organizationAuthContext$);
+      return { auth, body: body.data, apiStartTime, timing };
+    },
   );
+  signal.throwIfAborted();
+  return await set(createZeroRun$, args, signal);
 });
 
 export const zeroRunsRoutes: readonly RouteEntry[] = [

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -154,10 +154,7 @@ import {
   type ConnectorCredentialStatus,
 } from "./connector-credential-status.service";
 import { logger } from "../../lib/log";
-import {
-  recordSandboxOperation,
-  recordSandboxOperations,
-} from "../external/sandbox-op-log";
+import { recordSandboxOperation } from "../external/sandbox-op-log";
 import type { InternalRunCallbackKind } from "./internal-run-callback";
 import {
   activePaidConcurrencySlots,
@@ -165,6 +162,10 @@ import {
   totalConcurrencyLimit,
 } from "./org-concurrency-entitlements.service";
 import { checkLimitedFreeRunModelAdmission } from "./zero-run-admission.service";
+import {
+  ApiDispatchTimingCollector,
+  measureApiDispatchTiming,
+} from "./api-dispatch-timing.service";
 
 const PENDING_RUN_TTL_MS = 15 * 60 * 1000;
 const QUEUED_RUN_TTL_MS = 2 * 60 * 60 * 1000;
@@ -174,138 +175,6 @@ type ArtifactMissingRootPolicy = NonNullable<
 >;
 const AUTO_MEMORY_MISSING_ROOT_POLICY: ArtifactMissingRootPolicy =
   "preserveParentVersion";
-
-type ApiDispatchTimingSpanKind = "top_level" | "nested";
-type ApiDispatchTimingActionType =
-  | "api_dispatch_pre_create_agent_run"
-  | "api_dispatch_check_org_tier"
-  | "api_dispatch_prepare_run_context"
-  | "api_dispatch_prepare_context_feature_switches"
-  | "api_dispatch_prepare_context_resolve_compose"
-  | "api_dispatch_prepare_context_load_persisted_environment"
-  | "api_dispatch_prepare_context_build_resolved_body"
-  | "api_dispatch_prepare_context_resolve_framework"
-  | "api_dispatch_prepare_context_resolve_model_provider"
-  | "api_dispatch_prepare_context_load_connector_contexts"
-  | "api_dispatch_prepare_context_load_stored_connectors"
-  | "api_dispatch_prepare_context_load_stored_connector_rows"
-  | "api_dispatch_prepare_context_filter_stored_connector_rows"
-  | "api_dispatch_prepare_context_load_stored_connector_secret_rows"
-  | "api_dispatch_prepare_context_decrypt_stored_connector_secrets"
-  | "api_dispatch_prepare_context_load_stored_connector_variable_rows"
-  | "api_dispatch_prepare_context_build_stored_connector_state"
-  | "api_dispatch_prepare_context_load_custom_connectors"
-  | "api_dispatch_prepare_context_load_custom_connector_rows"
-  | "api_dispatch_prepare_context_load_custom_connector_value_rows"
-  | "api_dispatch_prepare_context_build_custom_connector_firewalls"
-  | "api_dispatch_prepare_context_build_permission_manifest"
-  | "api_dispatch_prepare_context_load_builtin_permission_indexes"
-  | "api_dispatch_prepare_context_apply_builtin_permission_policies"
-  | "api_dispatch_prepare_context_apply_custom_permission_policies"
-  | "api_dispatch_prepare_context_apply_model_provider_permission_policy"
-  | "api_dispatch_prepare_context_merge_permission_manifest"
-  | "api_dispatch_prepare_context_validate_environment"
-  | "api_dispatch_prepare_context_load_user_timezone"
-  | "api_dispatch_prepare_context_prepare_output_metadata"
-  | "api_dispatch_resolve_compose_by_compose_id"
-  | "api_dispatch_resolve_compose_by_version_id"
-  | "api_dispatch_resolve_compose_by_session_id"
-  | "api_dispatch_resolve_compose_by_checkpoint_id"
-  | "api_dispatch_resolve_compose_lookup_compose"
-  | "api_dispatch_resolve_compose_lookup_version"
-  | "api_dispatch_resolve_compose_lookup_session"
-  | "api_dispatch_resolve_compose_lookup_checkpoint"
-  | "api_dispatch_resolve_compose_load_resume_session"
-  | "api_dispatch_resolve_compose_resolve_session_history"
-  | "api_dispatch_resolve_compose_lookup_session_vars"
-  | "api_dispatch_check_vm0_credits"
-  | "api_dispatch_insert_run_with_concurrency"
-  | "api_dispatch_mark_pending_heartbeat"
-  | "api_dispatch_build_runner_job_payload"
-  | "api_dispatch_persist_runner_job_queue"
-  | "api_dispatch_lock_run_for_queue_persistence"
-  | "api_dispatch_insert_runner_job_queue"
-  | "api_dispatch_update_run_runner_group"
-  | "api_dispatch_admission_lock_wait"
-  | "api_dispatch_check_concurrency_limit"
-  | "api_dispatch_insert_run_record"
-  | "api_dispatch_prepare_storage_manifest"
-  | "api_dispatch_build_stored_execution_context";
-
-interface ApiDispatchTimingRecord {
-  readonly actionType: ApiDispatchTimingActionType;
-  readonly spanKind: ApiDispatchTimingSpanKind;
-  readonly durationMs: number;
-  readonly timestamp: string;
-}
-
-class ApiDispatchTimingCollector {
-  private readonly records: ApiDispatchTimingRecord[] = [];
-
-  recordElapsed(
-    actionType: ApiDispatchTimingActionType,
-    spanKind: ApiDispatchTimingSpanKind,
-    startedAt: number,
-    finishedAt: number = now(),
-  ): void {
-    this.records.push({
-      actionType,
-      spanKind,
-      durationMs: Math.max(0, finishedAt - startedAt),
-      timestamp: new Date(finishedAt).toISOString(),
-    });
-  }
-
-  measure<T>(
-    actionType: ApiDispatchTimingActionType,
-    spanKind: ApiDispatchTimingSpanKind,
-    operation: () => Promise<T>,
-  ): Promise<T> {
-    const startedAt = now();
-    return operation().finally(() => {
-      this.recordElapsed(actionType, spanKind, startedAt);
-    });
-  }
-
-  flush(args: {
-    readonly runId: string;
-    readonly runnerGroup: string;
-    readonly profile: string;
-    readonly dispatchPath: "direct";
-  }): void {
-    const records = this.records.splice(0);
-    recordSandboxOperations(
-      records.map((record) => {
-        return {
-          sandboxType: "runner",
-          actionType: record.actionType,
-          durationMs: record.durationMs,
-          success: true,
-          runId: args.runId,
-          timestamp: record.timestamp,
-          dimensions: {
-            runner_group: args.runnerGroup,
-            profile: args.profile,
-            dispatch_path: args.dispatchPath,
-            span_kind: record.spanKind,
-          },
-        };
-      }),
-    );
-  }
-}
-
-async function measureApiDispatchTiming<T>(
-  collector: ApiDispatchTimingCollector | undefined,
-  actionType: ApiDispatchTimingActionType,
-  spanKind: ApiDispatchTimingSpanKind,
-  operation: () => Promise<T>,
-): Promise<T> {
-  if (!collector) {
-    return await operation();
-  }
-  return await collector.measure(actionType, spanKind, operation);
-}
 
 const TIER_LIMITS = Object.freeze({
   free: 1,
@@ -534,7 +403,7 @@ export type DispatchFailedRunCallbacks = (
   error: string,
 ) => Promise<void>;
 
-interface CreateAgentRunArgs {
+export interface CreateAgentRunArgs {
   readonly userId: string;
   readonly orgId: string;
   readonly body: CreateRunBody;
@@ -565,6 +434,7 @@ interface CreateAgentRunArgs {
   readonly queueOnConcurrencyLimit?: boolean;
   readonly enforceVm0Credits?: boolean;
   readonly dispatchFailedCallbacks?: DispatchFailedRunCallbacks;
+  readonly timing?: ApiDispatchTimingCollector;
 }
 
 interface ConnectorRuntimeContext {
@@ -5256,7 +5126,7 @@ export const createAgentRun$ = command(
     signal: AbortSignal,
   ): Promise<CreateRunRouteResult> => {
     const db = set(writeDb$);
-    const timing = new ApiDispatchTimingCollector();
+    const timing = args.timing ?? new ApiDispatchTimingCollector();
     timing.recordElapsed(
       "api_dispatch_pre_create_agent_run",
       "top_level",

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -4225,7 +4225,7 @@ function dispatchRun(
         profile: payload.profile,
         cliAgentSessionId: payload.cliAgentSessionId,
       });
-      args.timing?.flush({
+      args.timing.flush({
         runId: args.run.id,
         runnerGroup: payload.runnerGroup,
         profile: payload.profile,

--- a/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
+++ b/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
@@ -1,0 +1,155 @@
+import { now } from "../external/time";
+import { recordSandboxOperations } from "../external/sandbox-op-log";
+import { onRejection } from "../utils";
+
+type ApiDispatchTimingSpanKind = "top_level" | "nested";
+
+export type ApiDispatchTimingActionType =
+  | "api_dispatch_pre_create_agent_run"
+  | "api_dispatch_pre_create_direct_parse_body"
+  | "api_dispatch_pre_create_direct_prepare_args"
+  | "api_dispatch_pre_create_zero_parse_body"
+  | "api_dispatch_pre_create_zero_prepare_args"
+  | "api_dispatch_pre_create_zero_resolve_agent_id"
+  | "api_dispatch_pre_create_zero_load_agent"
+  | "api_dispatch_pre_create_zero_load_user_info"
+  | "api_dispatch_pre_create_zero_resolve_trigger_context"
+  | "api_dispatch_pre_create_zero_load_connector_scopes"
+  | "api_dispatch_pre_create_zero_load_workflows"
+  | "api_dispatch_pre_create_zero_resolve_permission_policies"
+  | "api_dispatch_pre_create_zero_build_create_run_args"
+  | "api_dispatch_check_org_tier"
+  | "api_dispatch_prepare_run_context"
+  | "api_dispatch_prepare_context_feature_switches"
+  | "api_dispatch_prepare_context_resolve_compose"
+  | "api_dispatch_prepare_context_load_persisted_environment"
+  | "api_dispatch_prepare_context_build_resolved_body"
+  | "api_dispatch_prepare_context_resolve_framework"
+  | "api_dispatch_prepare_context_resolve_model_provider"
+  | "api_dispatch_prepare_context_load_connector_contexts"
+  | "api_dispatch_prepare_context_load_stored_connectors"
+  | "api_dispatch_prepare_context_load_stored_connector_rows"
+  | "api_dispatch_prepare_context_filter_stored_connector_rows"
+  | "api_dispatch_prepare_context_load_stored_connector_secret_rows"
+  | "api_dispatch_prepare_context_decrypt_stored_connector_secrets"
+  | "api_dispatch_prepare_context_load_stored_connector_variable_rows"
+  | "api_dispatch_prepare_context_build_stored_connector_state"
+  | "api_dispatch_prepare_context_load_custom_connectors"
+  | "api_dispatch_prepare_context_load_custom_connector_rows"
+  | "api_dispatch_prepare_context_load_custom_connector_value_rows"
+  | "api_dispatch_prepare_context_build_custom_connector_firewalls"
+  | "api_dispatch_prepare_context_build_permission_manifest"
+  | "api_dispatch_prepare_context_load_builtin_permission_indexes"
+  | "api_dispatch_prepare_context_apply_builtin_permission_policies"
+  | "api_dispatch_prepare_context_apply_custom_permission_policies"
+  | "api_dispatch_prepare_context_apply_model_provider_permission_policy"
+  | "api_dispatch_prepare_context_merge_permission_manifest"
+  | "api_dispatch_prepare_context_validate_environment"
+  | "api_dispatch_prepare_context_load_user_timezone"
+  | "api_dispatch_prepare_context_prepare_output_metadata"
+  | "api_dispatch_resolve_compose_by_compose_id"
+  | "api_dispatch_resolve_compose_by_version_id"
+  | "api_dispatch_resolve_compose_by_session_id"
+  | "api_dispatch_resolve_compose_by_checkpoint_id"
+  | "api_dispatch_resolve_compose_lookup_compose"
+  | "api_dispatch_resolve_compose_lookup_version"
+  | "api_dispatch_resolve_compose_lookup_session"
+  | "api_dispatch_resolve_compose_lookup_checkpoint"
+  | "api_dispatch_resolve_compose_load_resume_session"
+  | "api_dispatch_resolve_compose_resolve_session_history"
+  | "api_dispatch_resolve_compose_lookup_session_vars"
+  | "api_dispatch_check_vm0_credits"
+  | "api_dispatch_insert_run_with_concurrency"
+  | "api_dispatch_mark_pending_heartbeat"
+  | "api_dispatch_build_runner_job_payload"
+  | "api_dispatch_persist_runner_job_queue"
+  | "api_dispatch_lock_run_for_queue_persistence"
+  | "api_dispatch_insert_runner_job_queue"
+  | "api_dispatch_update_run_runner_group"
+  | "api_dispatch_admission_lock_wait"
+  | "api_dispatch_check_concurrency_limit"
+  | "api_dispatch_insert_run_record"
+  | "api_dispatch_prepare_storage_manifest"
+  | "api_dispatch_build_stored_execution_context";
+
+interface ApiDispatchTimingRecord {
+  readonly actionType: ApiDispatchTimingActionType;
+  readonly spanKind: ApiDispatchTimingSpanKind;
+  readonly durationMs: number;
+  readonly timestamp: string;
+}
+
+export class ApiDispatchTimingCollector {
+  private readonly records: ApiDispatchTimingRecord[] = [];
+
+  recordElapsed(
+    actionType: ApiDispatchTimingActionType,
+    spanKind: ApiDispatchTimingSpanKind,
+    startedAt: number,
+    finishedAt: number = now(),
+  ): void {
+    this.records.push({
+      actionType,
+      spanKind,
+      durationMs: Math.max(0, finishedAt - startedAt),
+      timestamp: new Date(finishedAt).toISOString(),
+    });
+  }
+
+  async measure<T>(
+    actionType: ApiDispatchTimingActionType,
+    spanKind: ApiDispatchTimingSpanKind,
+    operation: () => T | Promise<T>,
+  ): Promise<T> {
+    const startedAt = now();
+    const result = await onRejection(
+      (async () => {
+        return await operation();
+      })(),
+      () => {
+        this.recordElapsed(actionType, spanKind, startedAt);
+      },
+    );
+    this.recordElapsed(actionType, spanKind, startedAt);
+    return result;
+  }
+
+  flush(args: {
+    readonly runId: string;
+    readonly runnerGroup: string;
+    readonly profile: string;
+    readonly dispatchPath: "direct";
+  }): void {
+    const records = this.records.splice(0);
+    recordSandboxOperations(
+      records.map((record) => {
+        return {
+          sandboxType: "runner",
+          actionType: record.actionType,
+          durationMs: record.durationMs,
+          success: true,
+          runId: args.runId,
+          timestamp: record.timestamp,
+          dimensions: {
+            runner_group: args.runnerGroup,
+            profile: args.profile,
+            dispatch_path: args.dispatchPath,
+            span_kind: record.spanKind,
+          },
+        };
+      }),
+    );
+  }
+}
+
+export async function measureApiDispatchTiming<T>(
+  collector: ApiDispatchTimingCollector | undefined,
+  actionType: ApiDispatchTimingActionType,
+  spanKind: ApiDispatchTimingSpanKind,
+  operation: () => T | Promise<T>,
+): Promise<T> {
+  if (!collector) {
+    return await operation();
+  }
+  return await collector.measure(actionType, spanKind, operation);
+}

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -38,8 +38,14 @@ import type { AuthContext } from "../../types/auth";
 import { writeDb$, type Db } from "../external/db";
 import {
   createAgentRun$,
+  type CreateAgentRunArgs,
   type DispatchFailedRunCallbacks,
 } from "./agent-run-create.service";
+import {
+  measureApiDispatchTiming,
+  type ApiDispatchTimingActionType,
+  type ApiDispatchTimingCollector,
+} from "./api-dispatch-timing.service";
 import { loadActiveUserPermissionGrants } from "./zero-user-permission-grants.service";
 import { loadWorkflowsForRun } from "./zero-workflow-data.service";
 import type { InternalRunCallbackKind } from "./internal-run-callback";
@@ -149,6 +155,7 @@ interface CreateZeroRunCommandArgs {
   readonly selectedModelOverride?: string;
   readonly zeroRunMetadata?: ZeroRunMetadata;
   readonly dispatchFailedCallbacks?: DispatchFailedRunCallbacks;
+  readonly timing?: ApiDispatchTimingCollector;
 }
 
 function forbidden(message: string) {
@@ -773,6 +780,123 @@ function callbacksForTriggerAgent(triggerAgentId: string | undefined) {
     : undefined;
 }
 
+function measureZeroPreCreate<T>(
+  timing: ApiDispatchTimingCollector | undefined,
+  actionType: ApiDispatchTimingActionType,
+  operation: () => T | Promise<T>,
+): Promise<T> {
+  return measureApiDispatchTiming(timing, actionType, "nested", operation);
+}
+
+async function resolveZeroRunAgentId(
+  db: Db,
+  args: CreateZeroRunCommandArgs,
+): Promise<string | null> {
+  return (
+    args.body.agentId ??
+    (args.body.sessionId
+      ? await inferAgentIdFromSession(db, {
+          sessionId: args.body.sessionId,
+          userId: args.auth.userId,
+          orgId: args.auth.orgId,
+        })
+      : null)
+  );
+}
+
+async function loadZeroRunConnectorScopes(
+  db: Db,
+  args: {
+    readonly auth: AuthContext & { readonly orgId: string };
+    readonly agentId: string;
+    readonly triggerRun: Awaited<ReturnType<typeof resolveTriggerRunContext>>;
+  },
+  signal: AbortSignal,
+): Promise<{
+  readonly allowedConnectorTypes: readonly ConnectorType[];
+  readonly allowedCustomConnectorIds: readonly string[];
+}> {
+  if (args.triggerRun.unattended) {
+    return {
+      allowedConnectorTypes: connectorRefsToConnectorTypes(
+        args.triggerRun.unattended.connectorRefs,
+      ),
+      allowedCustomConnectorIds: [],
+    };
+  }
+
+  const allowedConnectorTypes = await loadAllowedConnectorTypes(db, {
+    userId: args.auth.userId,
+    orgId: args.auth.orgId,
+    agentId: args.agentId,
+  });
+  signal.throwIfAborted();
+  const allowedCustomConnectorIds = await loadAllowedCustomConnectorIds(db, {
+    userId: args.auth.userId,
+    orgId: args.auth.orgId,
+    agentId: args.agentId,
+  });
+  return { allowedConnectorTypes, allowedCustomConnectorIds };
+}
+
+function buildZeroCreateAgentRunArgs(args: {
+  readonly command: CreateZeroRunCommandArgs;
+  readonly agent: ZeroAgentRunRecord;
+  readonly userInfo: UserInfo;
+  readonly runPermissionPolicies: FirewallPolicies | null | undefined;
+  readonly triggerAgentId: string | undefined;
+  readonly triggerRun: Awaited<ReturnType<typeof resolveTriggerRunContext>>;
+  readonly workflows: Awaited<ReturnType<typeof loadWorkflowsForRun>>;
+  readonly allowedConnectorTypes: readonly ConnectorType[];
+  readonly allowedCustomConnectorIds: readonly string[];
+}): CreateAgentRunArgs {
+  const command = args.command;
+  return {
+    userId: command.auth.userId,
+    orgId: command.auth.orgId,
+    body: createRunBody({
+      body: command.body,
+      agent: args.agent,
+      userInfo: { ...args.userInfo, ...command.userInfoExtras },
+      permissionPolicies: args.runPermissionPolicies,
+      triggerAgentId: args.triggerAgentId,
+      triggerSource: command.triggerSource,
+      appendSystemPrompt: command.appendSystemPrompt,
+    }),
+    apiStartTime: command.apiStartTime,
+    modelProviderId:
+      command.modelProviderId ?? args.agent.modelProviderId ?? undefined,
+    modelProviderCredentialScope: command.modelProviderCredentialScope,
+    modelProviderType: command.body.modelProvider,
+    selectedModelOverride:
+      command.selectedModelOverride ?? args.agent.selectedModel ?? undefined,
+    chatThreadId: command.chatThreadId,
+    extraEnvironment: buildZeroRunExtraEnvironment({
+      agentId: args.agent.id,
+      chatThreadId: command.chatThreadId,
+      triggerEnvironment: args.triggerRun.environment,
+    }),
+    callbacks: [
+      ...(callbacksForTriggerAgent(args.triggerAgentId) ?? []),
+      ...(command.callbacks ?? []),
+    ],
+    includeZeroTokenSecret: true,
+    zeroTokenComputerUseHostId: command.computerUseHostId,
+    enforceVm0Credits: true,
+    queueOnConcurrencyLimit: true,
+    injectSkillVolumes: { workflows: args.workflows },
+    allowedConnectorTypes: args.allowedConnectorTypes,
+    allowedCustomConnectorIds: args.allowedCustomConnectorIds,
+    validateEnvironmentReferences: false,
+    zeroRunMetadata: {
+      ...command.zeroRunMetadata,
+      triggerAgentId: args.triggerAgentId,
+    },
+    dispatchFailedCallbacks: command.dispatchFailedCallbacks,
+    ...(command.timing ? { timing: command.timing } : {}),
+  };
+}
+
 export const createZeroIntegrationRun$ = command(
   async (
     { set },
@@ -883,15 +1007,14 @@ export const createZeroIntegrationRun$ = command(
 export const createZeroRun$ = command(
   async ({ set }, args: CreateZeroRunCommandArgs, signal: AbortSignal) => {
     const db = set(writeDb$);
-    const agentId =
-      args.body.agentId ??
-      (args.body.sessionId
-        ? await inferAgentIdFromSession(db, {
-            sessionId: args.body.sessionId,
-            userId: args.auth.userId,
-            orgId: args.auth.orgId,
-          })
-        : null);
+
+    const agentId = await measureZeroPreCreate(
+      args.timing,
+      "api_dispatch_pre_create_zero_resolve_agent_id",
+      async () => {
+        return await resolveZeroRunAgentId(db, args);
+      },
+    );
     signal.throwIfAborted();
 
     if (!agentId) {
@@ -900,7 +1023,13 @@ export const createZeroRun$ = command(
         : badRequestMessage("agentId is required");
     }
 
-    const agent = await loadZeroAgent(db, agentId);
+    const agent = await measureZeroPreCreate(
+      args.timing,
+      "api_dispatch_pre_create_zero_load_agent",
+      async () => {
+        return await loadZeroAgent(db, agentId);
+      },
+    );
     signal.throwIfAborted();
     if (!agent || agent.orgId !== args.auth.orgId) {
       return notFound("Agent not found");
@@ -910,107 +1039,109 @@ export const createZeroRun$ = command(
       return forbidden("Only the private agent owner can run this agent");
     }
 
-    const userInfo = await loadUserInfo(db, {
-      userId: args.auth.userId,
-      orgId: args.auth.orgId,
-    });
-    signal.throwIfAborted();
-    const triggerAgentId = await triggerAgentIdForAuth(db, args.auth);
-    signal.throwIfAborted();
-
-    // Trigger-fired runs resolve from the trigger's own isolated unattended
-    // connector scope and policy (never the caller's grants) and expose their
-    // trigger/workflow ids so the in-sandbox permission-change deep-link
-    // targets the trigger editor.
-    const triggerRun = await resolveTriggerRunContext(
-      db,
-      {
-        orgId: args.auth.orgId,
-        workflowTriggerId: args.zeroRunMetadata?.workflowTriggerId,
+    const userInfo = await measureZeroPreCreate(
+      args.timing,
+      "api_dispatch_pre_create_zero_load_user_info",
+      async () => {
+        return await loadUserInfo(db, {
+          userId: args.auth.userId,
+          orgId: args.auth.orgId,
+        });
       },
-      signal,
     );
-    const allowedConnectorTypes = triggerRun.unattended
-      ? connectorRefsToConnectorTypes(triggerRun.unattended.connectorRefs)
-      : await loadAllowedConnectorTypes(db, {
+    signal.throwIfAborted();
+    const triggerContext = await measureZeroPreCreate(
+      args.timing,
+      "api_dispatch_pre_create_zero_resolve_trigger_context",
+      async () => {
+        const triggerAgentId = await triggerAgentIdForAuth(db, args.auth);
+        signal.throwIfAborted();
+
+        // Trigger-fired runs resolve from the trigger's own isolated unattended
+        // connector scope and policy (never the caller's grants) and expose their
+        // trigger/workflow ids so the in-sandbox permission-change deep-link
+        // targets the trigger editor.
+        const triggerRun = await resolveTriggerRunContext(
+          db,
+          {
+            orgId: args.auth.orgId,
+            workflowTriggerId: args.zeroRunMetadata?.workflowTriggerId,
+          },
+          signal,
+        );
+        return { triggerAgentId, triggerRun };
+      },
+    );
+    signal.throwIfAborted();
+    const { triggerAgentId, triggerRun } = triggerContext;
+    const connectorScopes = await measureZeroPreCreate(
+      args.timing,
+      "api_dispatch_pre_create_zero_load_connector_scopes",
+      async () => {
+        return await loadZeroRunConnectorScopes(
+          db,
+          {
+            auth: args.auth,
+            agentId: agent.id,
+            triggerRun,
+          },
+          signal,
+        );
+      },
+    );
+    signal.throwIfAborted();
+    const { allowedConnectorTypes, allowedCustomConnectorIds } =
+      connectorScopes;
+    const workflows = await measureZeroPreCreate(
+      args.timing,
+      "api_dispatch_pre_create_zero_load_workflows",
+      async () => {
+        return await loadWorkflowsForRun(db, {
           userId: args.auth.userId,
           orgId: args.auth.orgId,
           agentId: agent.id,
         });
-    signal.throwIfAborted();
-    const allowedCustomConnectorIds = triggerRun.unattended
-      ? []
-      : await loadAllowedCustomConnectorIds(db, {
-          userId: args.auth.userId,
-          orgId: args.auth.orgId,
-          agentId: agent.id,
-        });
-    signal.throwIfAborted();
-    const workflows = await loadWorkflowsForRun(db, {
-      userId: args.auth.userId,
-      orgId: args.auth.orgId,
-      agentId: agent.id,
-    });
-    signal.throwIfAborted();
-    const runPermissionPolicies = await resolveZeroRunPermissionPolicies(
-      db,
-      {
-        orgId: args.auth.orgId,
-        userId: args.auth.userId,
-        agent,
-        allowedConnectorTypes,
-        checkedAt: new Date(args.apiStartTime),
-        unattended: triggerRun.unattended,
       },
-      signal,
     );
+    signal.throwIfAborted();
+    const runPermissionPolicies = await measureZeroPreCreate(
+      args.timing,
+      "api_dispatch_pre_create_zero_resolve_permission_policies",
+      async () => {
+        return await resolveZeroRunPermissionPolicies(
+          db,
+          {
+            orgId: args.auth.orgId,
+            userId: args.auth.userId,
+            agent,
+            allowedConnectorTypes,
+            checkedAt: new Date(args.apiStartTime),
+            unattended: triggerRun.unattended,
+          },
+          signal,
+        );
+      },
+    );
+    signal.throwIfAborted();
 
-    return await set(
-      createAgentRun$,
-      {
-        userId: args.auth.userId,
-        orgId: args.auth.orgId,
-        body: createRunBody({
-          body: args.body,
+    const createAgentRunArgs = await measureZeroPreCreate(
+      args.timing,
+      "api_dispatch_pre_create_zero_build_create_run_args",
+      () => {
+        return buildZeroCreateAgentRunArgs({
+          command: args,
           agent,
-          userInfo: { ...userInfo, ...args.userInfoExtras },
-          permissionPolicies: runPermissionPolicies,
+          userInfo,
+          runPermissionPolicies,
           triggerAgentId,
-          triggerSource: args.triggerSource,
-          appendSystemPrompt: args.appendSystemPrompt,
-        }),
-        apiStartTime: args.apiStartTime,
-        modelProviderId:
-          args.modelProviderId ?? agent.modelProviderId ?? undefined,
-        modelProviderCredentialScope: args.modelProviderCredentialScope,
-        modelProviderType: args.body.modelProvider,
-        selectedModelOverride:
-          args.selectedModelOverride ?? agent.selectedModel ?? undefined,
-        chatThreadId: args.chatThreadId,
-        extraEnvironment: buildZeroRunExtraEnvironment({
-          agentId: agent.id,
-          chatThreadId: args.chatThreadId,
-          triggerEnvironment: triggerRun.environment,
-        }),
-        callbacks: [
-          ...(callbacksForTriggerAgent(triggerAgentId) ?? []),
-          ...(args.callbacks ?? []),
-        ],
-        includeZeroTokenSecret: true,
-        zeroTokenComputerUseHostId: args.computerUseHostId,
-        enforceVm0Credits: true,
-        queueOnConcurrencyLimit: true,
-        injectSkillVolumes: { workflows },
-        allowedConnectorTypes,
-        allowedCustomConnectorIds,
-        validateEnvironmentReferences: false,
-        zeroRunMetadata: {
-          ...args.zeroRunMetadata,
-          triggerAgentId,
-        },
-        dispatchFailedCallbacks: args.dispatchFailedCallbacks,
+          triggerRun,
+          workflows,
+          allowedConnectorTypes,
+          allowedCustomConnectorIds,
+        });
       },
-      signal,
     );
+    signal.throwIfAborted();
+    return await set(createAgentRun$, createAgentRunArgs, signal);
   },
 );


### PR DESCRIPTION
## Summary
- move API dispatch timing collection into a shared service so route-level pre-create spans can be accumulated with createAgentRun spans
- add low-cardinality pre-create spans for direct `/api/runs` and Zero `/api/zero/runs` create paths
- cover direct and Zero timing events with integration assertions that verify span kind and route exclusivity

Closes #19063

## Tests
- `pnpm -F @vm0/db db:migrate`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "api dispatch timing"`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `pnpm knip --cache`
- pre-commit: `pnpm format` on staged files, `pnpm knip --cache`, `pnpm check-types`