### PR TITLE
refactor: align firewall permission metadata artifacts

### DIFF
--- a/scripts/ensure-generated-connector-firewalls-untracked.sh
+++ b/scripts/ensure-generated-connector-firewalls-untracked.sh
@@ -19,6 +19,7 @@ tracked_disallowed_firewall_metadata="$(
         "$firewall_metadata_dir"/*.generated.ts) printf '%s\n' "$tracked_file" ;;
         "$firewall_metadata_dir"/.*.previous-* | "$firewall_metadata_dir"/.*.previous-*/*) printf '%s\n' "$tracked_file" ;;
         "$firewall_metadata_dir"/.metadata-* | "$firewall_metadata_dir"/.metadata-*/*) printf '%s\n' "$tracked_file" ;;
+        "$firewall_metadata_dir/permission-details/"*) printf '%s\n' "$tracked_file" ;;
         "$firewall_metadata_dir/details/"*) printf '%s\n' "$tracked_file" ;;
         "$firewall_metadata_dir/routing-details/"*) printf '%s\n' "$tracked_file" ;;
       esac

--- a/turbo/.prettierignore
+++ b/turbo/.prettierignore
@@ -7,6 +7,7 @@ packages/connectors/src/firewalls/*.generated.ts
 packages/connectors/src/firewall-metadata/*.generated.ts
 packages/connectors/src/firewall-metadata/.metadata-*
 packages/connectors/src/firewall-metadata/.*.previous-*
+packages/connectors/src/firewall-metadata/permission-details/*.generated.ts
 packages/connectors/src/firewall-metadata/details/*.generated.ts
 packages/connectors/src/firewall-metadata/routing-details/*.generated.ts
 packages/connectors/src/firewall-execution-metadata/*.generated.ts

--- a/turbo/apps/platform/src/__tests__/service-worker.test.ts
+++ b/turbo/apps/platform/src/__tests__/service-worker.test.ts
@@ -181,7 +181,7 @@ async function dispatchFetch(
 }
 
 const REVALIDATED_STATIC_ASSET_URLS = [
-  "https://app.test/firewall-metadata/v1/gmail.generated.js",
+  "https://app.test/firewall-metadata/permission-details/v1/gmail.generated.js",
 ] as const;
 
 describe("platform service worker", () => {

--- a/turbo/apps/platform/vite.config.ts
+++ b/turbo/apps/platform/vite.config.ts
@@ -20,13 +20,13 @@ const STATIC_ASSETS_BASE_URL =
   process.env.VERCEL_ENV === "production"
     ? "https://static.vm0.io"
     : "https://static.vm7.io");
-const FIREWALL_METADATA_DETAIL_CHUNK_NAME_PREFIX =
-  "vm0-firewall-metadata-detail-";
-const FIREWALL_METADATA_DETAIL_CHUNK_PROTOCOL_VERSION = "v1";
-const FIREWALL_METADATA_DETAIL_MODULE_ID_RE =
-  /\/packages\/connectors\/src\/firewall-metadata\/details\/([a-z0-9][a-z0-9-]*)\.generated\.ts$/;
-const FIREWALL_METADATA_DETAIL_CHUNK_NAME_RE =
-  /^vm0-firewall-metadata-detail-([a-z0-9][a-z0-9-]*)\.generated$/;
+const FIREWALL_PERMISSION_DETAIL_METADATA_CHUNK_NAME_PREFIX =
+  "vm0-firewall-permission-detail-metadata-";
+const FIREWALL_PERMISSION_DETAIL_METADATA_CHUNK_PROTOCOL_VERSION = "v1";
+const FIREWALL_PERMISSION_DETAIL_METADATA_MODULE_ID_RE =
+  /\/packages\/connectors\/src\/firewall-metadata\/permission-details\/([a-z0-9][a-z0-9-]*)\.generated\.ts$/;
+const FIREWALL_PERMISSION_DETAIL_METADATA_CHUNK_NAME_RE =
+  /^vm0-firewall-permission-detail-metadata-([a-z0-9][a-z0-9-]*)\.generated$/;
 
 process.env.VITE_STATIC_ASSETS_BASE_URL = STATIC_ASSETS_BASE_URL;
 
@@ -36,32 +36,37 @@ function normalizedModuleId(id: string): string {
   return pathname.replaceAll("\\", "/");
 }
 
-function firewallMetadataDetailChunkName(moduleId: string): string | null {
-  const match = FIREWALL_METADATA_DETAIL_MODULE_ID_RE.exec(
+function firewallPermissionDetailMetadataChunkName(
+  moduleId: string,
+): string | null {
+  const match = FIREWALL_PERMISSION_DETAIL_METADATA_MODULE_ID_RE.exec(
     normalizedModuleId(moduleId),
   );
   if (!match) {
     return null;
   }
-  return `${FIREWALL_METADATA_DETAIL_CHUNK_NAME_PREFIX}${match[1]}.generated`;
+  return `${FIREWALL_PERMISSION_DETAIL_METADATA_CHUNK_NAME_PREFIX}${match[1]}.generated`;
 }
 
-function firewallMetadataDetailChunkFileName(chunkName: string): string | null {
-  const match = FIREWALL_METADATA_DETAIL_CHUNK_NAME_RE.exec(chunkName);
+function firewallPermissionDetailMetadataChunkFileName(
+  chunkName: string,
+): string | null {
+  const match =
+    FIREWALL_PERMISSION_DETAIL_METADATA_CHUNK_NAME_RE.exec(chunkName);
   if (!match) {
     return null;
   }
-  return `firewall-metadata/${FIREWALL_METADATA_DETAIL_CHUNK_PROTOCOL_VERSION}/${match[1]}.generated.js`;
+  return `firewall-metadata/permission-details/${FIREWALL_PERMISSION_DETAIL_METADATA_CHUNK_PROTOCOL_VERSION}/${match[1]}.generated.js`;
 }
 
 function stableGeneratedFirewallChunkName(moduleId: string): string | null {
-  return firewallMetadataDetailChunkName(moduleId);
+  return firewallPermissionDetailMetadataChunkName(moduleId);
 }
 
 function stableGeneratedFirewallChunkFileName(
   chunkName: string,
 ): string | null {
-  return firewallMetadataDetailChunkFileName(chunkName);
+  return firewallPermissionDetailMetadataChunkFileName(chunkName);
 }
 
 function isAllowedDevArtifactFetchUrl(url: URL): boolean {

--- a/turbo/packages/connectors/.gitignore
+++ b/turbo/packages/connectors/.gitignore
@@ -2,5 +2,5 @@
 src/firewall-metadata/*.generated.ts
 src/firewall-metadata/.metadata-*
 src/firewall-metadata/.*.previous-*
-src/firewall-metadata/details/*
+src/firewall-metadata/permission-details/*
 src/firewall-metadata/routing-details/*

--- a/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
@@ -314,9 +314,9 @@ describe("firewall metadata", () => {
 
     expect(staticImportSpecifiers(source).sort(compareStrings)).toStrictEqual([
       "../firewall-types",
-      "./loader.generated",
+      "./permission-detail-loader.generated",
+      "./permission-summaries.generated",
       "./policy-resolver",
-      "./summary.generated",
       "./types",
     ]);
     expect(exportFromSpecifiers(source).sort(compareStrings)).toStrictEqual([
@@ -329,24 +329,28 @@ describe("firewall metadata", () => {
   it("keeps permission detail metadata behind connector-specific dynamic imports", () => {
     const loader = path.resolve(
       import.meta.dirname,
-      "../firewall-metadata/loader.generated.ts",
+      "../firewall-metadata/permission-detail-loader.generated.ts",
     );
     const source = fs.readFileSync(loader, "utf-8");
     const dynamicSpecifiers = dynamicImportSpecifiers(source);
 
     expect(staticImportSpecifiers(source)).toStrictEqual(["./types"]);
-    expect(dynamicSpecifiers).toContain("./details/slack.generated");
-    expect(dynamicSpecifiers).toContain("./details/github.generated");
+    expect(dynamicSpecifiers).toContain("./permission-details/slack.generated");
+    expect(dynamicSpecifiers).toContain(
+      "./permission-details/github.generated",
+    );
     expect(new Set(dynamicSpecifiers).size).toBe(dynamicSpecifiers.length);
     for (const specifier of dynamicSpecifiers) {
-      expect(specifier).toMatch(/^\.\/details\/[a-z0-9][a-z0-9-]*\.generated$/);
+      expect(specifier).toMatch(
+        /^\.\/permission-details\/[a-z0-9][a-z0-9-]*\.generated$/,
+      );
     }
   });
 
   it("keeps generated permission detail modules runtime-free", () => {
     const detailsDir = path.resolve(
       import.meta.dirname,
-      "../firewall-metadata/details",
+      "../firewall-metadata/permission-details",
     );
     const files = listTsFiles(detailsDir);
 

--- a/turbo/packages/connectors/src/firewall-metadata/index.ts
+++ b/turbo/packages/connectors/src/firewall-metadata/index.ts
@@ -4,9 +4,9 @@ import {
   type FirewallPolicy,
   type FirewallPolicyValue,
 } from "../firewall-types";
-import { loadGeneratedFirewallPermissionMetadata } from "./loader.generated";
+import { loadGeneratedFirewallPermissionMetadata } from "./permission-detail-loader.generated";
 import { createFirewallMetadataPolicyResolver } from "./policy-resolver";
-import { FIREWALL_PERMISSION_METADATA_SUMMARIES } from "./summary.generated";
+import { FIREWALL_PERMISSION_METADATA_SUMMARIES } from "./permission-summaries.generated";
 import type {
   FirewallPermissionDetailMetadata,
   FirewallPermissionSummaryMetadata,

--- a/turbo/packages/connectors/src/firewall-metadata/server.ts
+++ b/turbo/packages/connectors/src/firewall-metadata/server.ts
@@ -3,14 +3,14 @@ import {
   type FirewallPolicies,
   type FirewallPolicyValue,
 } from "../firewall-types";
-import { loadGeneratedFirewallPermissionMetadata } from "./loader.generated";
+import { loadGeneratedFirewallPermissionMetadata } from "./permission-detail-loader.generated";
+import { FIREWALL_PERMISSION_METADATA_SUMMARIES } from "./permission-summaries.generated";
 import {
   createFirewallMetadataPolicyResolver,
   type FirewallMetadataPolicyResolver,
 } from "./policy-resolver";
 import { FIREWALL_SERVER_EXECUTION_METADATA } from "./server-execution.generated";
 import { BUILTIN_FIREWALL_FIXED_HOST_OWNERS } from "./server.generated";
-import { FIREWALL_PERMISSION_METADATA_SUMMARIES } from "./summary.generated";
 import type {
   FirewallExecutionMetadata,
   FirewallPermissionDefaultPolicyMetadata,

--- a/turbo/packages/firewalls-generator/src/__tests__/metadata.test.ts
+++ b/turbo/packages/firewalls-generator/src/__tests__/metadata.test.ts
@@ -429,16 +429,18 @@ describe("firewall metadata generator", () => {
     const loaderSource = fs.readFileSync(
       path.resolve(
         import.meta.dirname,
-        "../../../connectors/src/firewall-metadata/loader.generated.ts",
+        "../../../connectors/src/firewall-metadata/permission-detail-loader.generated.ts",
       ),
       "utf-8",
     );
     const dynamicSpecifiers = dynamicImportSpecifiers(loaderSource);
 
     expect(staticValueModuleSpecifiers(loaderSource)).toStrictEqual([]);
-    expect(dynamicSpecifiers).toContain("./details/slack.generated");
-    expect(dynamicSpecifiers).toContain("./details/github.generated");
-    expect(loaderSource).toContain("/firewall-metadata/v1/");
+    expect(dynamicSpecifiers).toContain("./permission-details/slack.generated");
+    expect(dynamicSpecifiers).toContain(
+      "./permission-details/github.generated",
+    );
+    expect(loaderSource).toContain("/firewall-metadata/permission-details/v1/");
     expect(loaderSource).toContain(
       "const FIREWALL_PERMISSION_METADATA_LOADERS",
     );
@@ -451,7 +453,9 @@ describe("firewall metadata generator", () => {
     expect(new Set(dynamicSpecifiers).size).toBe(dynamicSpecifiers.length);
     expect(dynamicSpecifiers.length).toBe(FIREWALL_CONNECTOR_TYPES.length);
     for (const specifier of dynamicSpecifiers) {
-      expect(specifier).toMatch(/^\.\/details\/[a-z0-9][a-z0-9-]*\.generated$/);
+      expect(specifier).toMatch(
+        /^\.\/permission-details\/[a-z0-9][a-z0-9-]*\.generated$/,
+      );
     }
   });
 

--- a/turbo/packages/firewalls-generator/src/metadata.ts
+++ b/turbo/packages/firewalls-generator/src/metadata.ts
@@ -85,8 +85,10 @@ function writeGeneratedFile(filePath: string, content: string): void {
   }
 }
 
-function generatedDetailModuleSpecifier(type: FirewallConnectorType): string {
-  return `./details/${generatedConnectorMetadataFileName(type).replace(/\.ts$/, "")}`;
+function generatedPermissionDetailModuleSpecifier(
+  type: FirewallConnectorType,
+): string {
+  return `./permission-details/${generatedConnectorMetadataFileName(type).replace(/\.ts$/, "")}`;
 }
 
 function generatedRoutingDetailModuleSpecifier(
@@ -572,12 +574,12 @@ function renderLoaderFile(types: readonly FirewallConnectorType[]): string {
   const loaderEntries = types.map((type): LazyLoaderEntry => {
     return {
       key: type,
-      moduleSpecifier: generatedDetailModuleSpecifier(type),
+      moduleSpecifier: generatedPermissionDetailModuleSpecifier(type),
       exportName: "firewallPermissionMetadata",
     };
   });
 
-  return `${generatedHeader()}// The platform build serves these dynamic imports from /firewall-metadata/v1/.
+  return `${generatedHeader()}// The platform build serves these dynamic imports from /firewall-metadata/permission-details/v1/.
 // Bump that URL version before shipping an incompatible metadata module shape or import contract change.
 import type { FirewallPermissionDetailMetadata } from "./types";
 
@@ -641,17 +643,26 @@ export async function generateFirewallMetadata(): Promise<void> {
     import.meta.dirname,
     "../../connectors/src/firewall-metadata",
   );
-  const summaryFile = path.join(outputDir, "summary.generated.ts");
-  const loaderFile = path.join(outputDir, "loader.generated.ts");
+  const permissionSummariesFile = path.join(
+    outputDir,
+    "permission-summaries.generated.ts",
+  );
+  const permissionDetailLoaderFile = path.join(
+    outputDir,
+    "permission-detail-loader.generated.ts",
+  );
   const routingIndexFile = path.join(outputDir, "routing-index.generated.ts");
   const routingLoaderFile = path.join(outputDir, "routing-loader.generated.ts");
   const obsoleteRoutingFile = path.join(outputDir, "routing.generated.ts");
+  const obsoleteSummaryFile = path.join(outputDir, "summary.generated.ts");
+  const obsoleteLoaderFile = path.join(outputDir, "loader.generated.ts");
+  const obsoleteDetailsDir = path.join(outputDir, "details");
   const serverFile = path.join(outputDir, "server.generated.ts");
   const serverExecutionFile = path.join(
     outputDir,
     "server-execution.generated.ts",
   );
-  const detailsDir = path.join(outputDir, "details");
+  const permissionDetailsDir = path.join(outputDir, "permission-details");
   const routingDetailsDir = path.join(outputDir, "routing-details");
 
   const { sources, registryOrderedSources, billableTypes } =
@@ -687,13 +698,16 @@ export async function generateFirewallMetadata(): Promise<void> {
   }
 
   const nextOutputDir = fs.mkdtempSync(path.join(outputDir, ".metadata-"));
-  const nextDetailsDir = path.join(nextOutputDir, "details");
+  const nextPermissionDetailsDir = path.join(
+    nextOutputDir,
+    "permission-details",
+  );
   const nextRoutingDetailsDir = path.join(nextOutputDir, "routing-details");
 
   for (const detail of permissionDetails) {
     writeGeneratedFile(
       path.join(
-        nextDetailsDir,
+        nextPermissionDetailsDir,
         generatedConnectorMetadataFileName(detail.type),
       ),
       detail.content,
@@ -709,7 +723,7 @@ export async function generateFirewallMetadata(): Promise<void> {
     );
   }
   writeGeneratedFile(
-    path.join(nextOutputDir, "summary.generated.ts"),
+    path.join(nextOutputDir, "permission-summaries.generated.ts"),
     renderSummaryFile(summaries),
   );
   writeGeneratedFile(
@@ -733,7 +747,7 @@ export async function generateFirewallMetadata(): Promise<void> {
     renderServerFile(buildFixedHostOwners(registryOrderedSources)),
   );
   writeGeneratedFile(
-    path.join(nextOutputDir, "loader.generated.ts"),
+    path.join(nextOutputDir, "permission-detail-loader.generated.ts"),
     renderLoaderFile(
       sources.map((source) => {
         return source.type;
@@ -742,20 +756,22 @@ export async function generateFirewallMetadata(): Promise<void> {
   );
   const replacements: GeneratedPathReplacement[] = [];
   try {
-    replacements.push(replaceGeneratedPath(detailsDir, nextDetailsDir));
+    replacements.push(
+      replaceGeneratedPath(permissionDetailsDir, nextPermissionDetailsDir),
+    );
     replacements.push(
       replaceGeneratedPath(routingDetailsDir, nextRoutingDetailsDir),
     );
     replacements.push(
       replaceGeneratedPath(
-        summaryFile,
-        path.join(nextOutputDir, "summary.generated.ts"),
+        permissionSummariesFile,
+        path.join(nextOutputDir, "permission-summaries.generated.ts"),
       ),
     );
     replacements.push(
       replaceGeneratedPath(
-        loaderFile,
-        path.join(nextOutputDir, "loader.generated.ts"),
+        permissionDetailLoaderFile,
+        path.join(nextOutputDir, "permission-detail-loader.generated.ts"),
       ),
     );
     replacements.push(
@@ -792,6 +808,9 @@ export async function generateFirewallMetadata(): Promise<void> {
   for (const replacement of replacements) {
     replacement.commit();
   }
+  fs.rmSync(obsoleteDetailsDir, { recursive: true, force: true });
+  fs.rmSync(obsoleteSummaryFile, { force: true });
+  fs.rmSync(obsoleteLoaderFile, { force: true });
   fs.rmSync(obsoleteRoutingFile, { force: true });
 
   console.error(`  Written ${sources.length} metadata detail files`);


### PR DESCRIPTION
## Summary

- Rename generated firewall permission detail metadata internals from `details` to `permission-details`.
- Rename permission metadata generated root files to `permission-detail-loader.generated.ts` and `permission-summaries.generated.ts`.
- Emit platform permission detail chunks at `/firewall-metadata/permission-details/v1/{connector}.generated.js` instead of `/firewall-metadata/v1/{connector}.generated.js`.
- Keep public `@vm0/connectors/firewall-metadata*` exports stable and leave routing/server metadata behavior unchanged.

Fixes #19099
Parent: #18945

## Verification

- `pnpm -F @vm0/firewalls-generator generate`
- `pnpm -F @vm0/firewalls-generator generate:metadata`
- `pnpm format`
- `pnpm -F @vm0/connectors exec vitest src/__tests__/firewall-metadata.test.ts src/__tests__/firewall-routing-metadata.test.ts`
- `pnpm -F @vm0/firewalls-generator exec vitest src/__tests__/metadata.test.ts`
- `pnpm -F @vm0/app exec vitest src/__tests__/service-worker.test.ts`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/firewalls-generator check-types`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/app lint`

Pre-commit also ran `pnpm knip` and root `pnpm check-types` successfully.
