### PR TITLE
Forward migrated web routes to SO

### DIFF
--- a/turbo/apps/web/__tests__/proxy.public-routes.test.ts
+++ b/turbo/apps/web/__tests__/proxy.public-routes.test.ts
@@ -496,21 +496,26 @@ describe("proxy middleware: public routes", () => {
     await expect(response.text()).resolves.toBe("locale action proxied");
   });
 
-  it("does not proxy app-only functional routes when so forwarding is enabled", async () => {
+  it("proxies migrated functional routes when so forwarding is enabled", async () => {
     vi.stubEnv("NEXT_PUBLIC_PAID_ONBOARDING_URL", "https://so.vm0.ai");
     reloadEnv();
     const forwardedRequests = captureForwardedRequests(
       "post",
       "https://so.vm0.ai/connector/success",
-      new HttpResponse("unexpected proxy", { status: 500 }),
+      new HttpResponse("functional route proxied", { status: 202 }),
     );
     const request = new NextRequest("https://www.vm0.ai/connector/success", {
       method: "POST",
     });
 
-    await middleware(request, createMockEvent());
+    const response = await middleware(request, createMockEvent());
 
-    expect(forwardedRequests).toEqual([]);
+    expect(forwardedRequests).toHaveLength(1);
+    expect(response).toBeDefined();
+    if (!response) {
+      throw new Error("Expected functional route proxy response");
+    }
+    expect(response.status).toBe(202);
   });
 
   it("keeps locale-less web design gallery public", async () => {

--- a/turbo/apps/web/__tests__/so-frontend-rewrites.test.ts
+++ b/turbo/apps/web/__tests__/so-frontend-rewrites.test.ts
@@ -86,7 +86,7 @@ describe("so frontend rewrites", () => {
     });
   });
 
-  it("does not rewrite app-only functional routes", () => {
+  it("rewrites migrated functional routes without rewriting API routes", () => {
     const rewrites = buildSoFrontendRewrites({
       PAID_ONBOARDING_URL: "https://so.vm0.ai",
     });
@@ -97,10 +97,12 @@ describe("so frontend rewrites", () => {
     );
 
     expect(sources.has("/api/:path*")).toBe(false);
-    expect(sources.has("/desktop-auth/:path*")).toBe(false);
-    expect(sources.has("/connector/:path*")).toBe(false);
-    expect(sources.has("/export")).toBe(false);
-    expect(sources.has("/sign-in-token")).toBe(false);
+    expect(sources.has("/cli-auth/:path*")).toBe(true);
+    expect(sources.has("/desktop-auth/:path*")).toBe(true);
+    expect(sources.has("/connector/:path*")).toBe(true);
+    expect(sources.has("/export")).toBe(true);
+    expect(sources.has("/sign-in-token")).toBe(true);
+    expect(sources.has("/monday-app-association.json")).toBe(true);
   });
 
   it("matches configured so frontend rewrite paths", () => {
@@ -116,8 +118,14 @@ describe("so frontend rewrites", () => {
     expect(matchesSoFrontendRewritePath("/sign-up/verify-email-address")).toBe(
       true,
     );
-    expect(matchesSoFrontendRewritePath("/connector/success")).toBe(false);
-    expect(matchesSoFrontendRewritePath("/desktop-auth/start")).toBe(false);
+    expect(matchesSoFrontendRewritePath("/connector/success")).toBe(true);
+    expect(matchesSoFrontendRewritePath("/desktop-auth/start")).toBe(true);
+    expect(matchesSoFrontendRewritePath("/cli-auth/success")).toBe(true);
+    expect(matchesSoFrontendRewritePath("/export")).toBe(true);
+    expect(matchesSoFrontendRewritePath("/sign-in-token")).toBe(true);
+    expect(matchesSoFrontendRewritePath("/monday-app-association.json")).toBe(
+      true,
+    );
     expect(matchesSoFrontendRewritePath("/api/zero/billing/status")).toBe(
       false,
     );
@@ -139,6 +147,21 @@ describe("so frontend rewrites", () => {
     expect(resolveSoFrontendRewritePath("/sign-up/verify-email-address")).toBe(
       "/sign-up/verify-email-address",
     );
-    expect(resolveSoFrontendRewritePath("/connector/success")).toBeUndefined();
+    expect(resolveSoFrontendRewritePath("/connector/success")).toBe(
+      "/connector/success",
+    );
+    expect(resolveSoFrontendRewritePath("/desktop-auth/start")).toBe(
+      "/desktop-auth/start",
+    );
+    expect(resolveSoFrontendRewritePath("/cli-auth/success")).toBe(
+      "/cli-auth/success",
+    );
+    expect(resolveSoFrontendRewritePath("/export")).toBe("/export");
+    expect(resolveSoFrontendRewritePath("/sign-in-token")).toBe(
+      "/sign-in-token",
+    );
+    expect(resolveSoFrontendRewritePath("/monday-app-association.json")).toBe(
+      "/monday-app-association.json",
+    );
   });
 });

--- a/turbo/apps/web/__tests__/so-frontend-rewrites.test.ts
+++ b/turbo/apps/web/__tests__/so-frontend-rewrites.test.ts
@@ -103,6 +103,8 @@ describe("so frontend rewrites", () => {
     expect(sources.has("/export")).toBe(true);
     expect(sources.has("/sign-in-token")).toBe(true);
     expect(sources.has("/monday-app-association.json")).toBe(true);
+    expect(sources.has("/robots.txt")).toBe(true);
+    expect(sources.has("/sitemap.xml")).toBe(true);
   });
 
   it("matches configured so frontend rewrite paths", () => {
@@ -126,6 +128,8 @@ describe("so frontend rewrites", () => {
     expect(matchesSoFrontendRewritePath("/monday-app-association.json")).toBe(
       true,
     );
+    expect(matchesSoFrontendRewritePath("/robots.txt")).toBe(true);
+    expect(matchesSoFrontendRewritePath("/sitemap.xml")).toBe(true);
     expect(matchesSoFrontendRewritePath("/api/zero/billing/status")).toBe(
       false,
     );
@@ -163,5 +167,7 @@ describe("so frontend rewrites", () => {
     expect(resolveSoFrontendRewritePath("/monday-app-association.json")).toBe(
       "/monday-app-association.json",
     );
+    expect(resolveSoFrontendRewritePath("/robots.txt")).toBe("/robots.txt");
+    expect(resolveSoFrontendRewritePath("/sitemap.xml")).toBe("/sitemap.xml");
   });
 });

--- a/turbo/apps/web/so-frontend-rewrites.js
+++ b/turbo/apps/web/so-frontend-rewrites.js
@@ -49,6 +49,8 @@ const SO_FRONTEND_FUNCTIONAL_PATHS = [
   "/export",
   "/sign-in-token",
   "/monday-app-association.json",
+  "/robots.txt",
+  "/sitemap.xml",
 ];
 
 const SO_FRONTEND_ASSET_PATHS = [

--- a/turbo/apps/web/so-frontend-rewrites.js
+++ b/turbo/apps/web/so-frontend-rewrites.js
@@ -41,6 +41,16 @@ const SO_FRONTEND_AUTH_PATHS = [
   "/sign-up/:path*",
 ];
 
+const SO_FRONTEND_FUNCTIONAL_PATHS = [
+  "/cli-auth",
+  "/cli-auth/:path*",
+  "/connector/:path*",
+  "/desktop-auth/:path*",
+  "/export",
+  "/sign-in-token",
+  "/monday-app-association.json",
+];
+
 const SO_FRONTEND_ASSET_PATHS = [
   "/assets/:path*",
   "/images/:path*",
@@ -142,6 +152,9 @@ function rewriteSourceDefinitions(env) {
     ...authRewritePaths(env).map((source) => {
       return { source, destination: source };
     }),
+    ...SO_FRONTEND_FUNCTIONAL_PATHS.map((source) => {
+      return { source, destination: source };
+    }),
     ...SO_FRONTEND_ASSET_PATHS.map((source) => {
       return { source, destination: source };
     }),
@@ -188,6 +201,9 @@ export function buildSoFrontendRewrites(env) {
       });
     }),
     ...authRewritePaths(env).map((source) => {
+      return exactRewrite(source, destinationPrefix);
+    }),
+    ...SO_FRONTEND_FUNCTIONAL_PATHS.map((source) => {
       return exactRewrite(source, destinationPrefix);
     }),
     ...SO_FRONTEND_ASSET_PATHS.map((source) => {


### PR DESCRIPTION
## Summary
- forward migrated functional web routes to the SO frontend rewrite target
- include connector status, desktop auth, CLI auth, export, sign-in-token, and Monday app association paths
- update SO rewrite/proxy tests for the new forwarding behavior

## Tests
- pnpm test __tests__/so-frontend-rewrites.test.ts __tests__/proxy.public-routes.test.ts