### PR TITLE
refactor(mitm-addon): clarify body limit semantics

### DIFF
--- a/crates/runner/mitm-addon/src/billing_body.py
+++ b/crates/runner/mitm-addon/src/billing_body.py
@@ -5,7 +5,7 @@ from typing import Literal
 
 from mitmproxy import http
 
-from body_limits import STREAM_BUFFER_LIMIT
+from body_limits import REQUEST_BODY_BILLING_INSPECTION_LIMIT
 
 
 def _decode_zlib_request_body_for_billing(
@@ -32,8 +32,8 @@ def decode_request_body_for_billing(
     raw_content: bytes | None,
     headers: http.Headers,
     *,
-    max_raw: int = STREAM_BUFFER_LIMIT,
-    max_decoded: int = STREAM_BUFFER_LIMIT,
+    max_raw: int = REQUEST_BODY_BILLING_INSPECTION_LIMIT,
+    max_decoded: int = REQUEST_BODY_BILLING_INSPECTION_LIMIT,
 ) -> bytes | None:
     """Decode a request body for conservative billing inspection.
 

--- a/crates/runner/mitm-addon/src/body_capture.py
+++ b/crates/runner/mitm-addon/src/body_capture.py
@@ -12,7 +12,7 @@ import body_decoding
 import flow_metadata_keys as metadata_keys
 import request_streaming
 import response_streaming
-from body_limits import STREAM_BUFFER_LIMIT
+from body_limits import BODY_CAPTURE_LIMIT
 
 _REDACTED_HEADER_VALUE = "***"
 
@@ -263,7 +263,7 @@ def _set_body_fields(
     *,
     already_truncated: bool = False,
 ) -> None:
-    truncated = already_truncated or len(body) > STREAM_BUFFER_LIMIT
+    truncated = already_truncated or len(body) > BODY_CAPTURE_LIMIT
     if truncated:
         # Truncation describes capture completeness, even when no body string is emitted.
         log_entry[f"{side}_body_truncated"] = True
@@ -272,7 +272,7 @@ def _set_body_fields(
         return
 
     encoded, encoding = _encode_body(
-        _truncate_bytes_utf8_safe(body, STREAM_BUFFER_LIMIT) if truncated else body,
+        _truncate_bytes_utf8_safe(body, BODY_CAPTURE_LIMIT) if truncated else body,
         content_type,
     )
     if encoded is None:
@@ -316,7 +316,7 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
             request_body = body_decoding.decode_body_bounded(
                 bytes(request_stream_body.buffer),
                 flow.request.headers,
-                max_output=STREAM_BUFFER_LIMIT + 1,
+                max_output=BODY_CAPTURE_LIMIT + 1,
                 fail_on_unsupported_encoding=True,
             )
             if request_body.failed:
@@ -336,7 +336,7 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
             request_body = body_decoding.decode_body_bounded(
                 flow.request.raw_content,
                 flow.request.headers,
-                max_output=STREAM_BUFFER_LIMIT + 1,
+                max_output=BODY_CAPTURE_LIMIT + 1,
                 fail_on_unsupported_encoding=True,
             )
             if request_body.failed:
@@ -356,7 +356,7 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
             body = body_decoding.decompress_body(
                 bytes(stream_body.buffer),
                 flow.response.headers,
-                max_output=STREAM_BUFFER_LIMIT + 1,
+                max_output=BODY_CAPTURE_LIMIT + 1,
             )
         else:
             try:

--- a/crates/runner/mitm-addon/src/body_decoding.py
+++ b/crates/runner/mitm-addon/src/body_decoding.py
@@ -17,8 +17,8 @@ import zstandard
 from mitmproxy import ctx, http
 
 from body_limits import (
+    DEFAULT_BODY_DECODE_LIMIT,
     LARGE_RESPONSE_DECOMPRESS_LIMIT,
-    STREAM_BUFFER_LIMIT,
     STREAM_DECODE_CHUNK_LIMIT,
 )
 
@@ -241,7 +241,7 @@ def create_stream_decode_feed(
 
 
 def decompress_body(
-    data: bytes, headers: http.Headers, max_output: int = STREAM_BUFFER_LIMIT
+    data: bytes, headers: http.Headers, max_output: int = DEFAULT_BODY_DECODE_LIMIT
 ) -> bytes:
     """Decompress response body based on Content-Encoding header.
 

--- a/crates/runner/mitm-addon/src/body_limits.py
+++ b/crates/runner/mitm-addon/src/body_limits.py
@@ -8,9 +8,9 @@
 # of treating every 64 KB body limit as interchangeable.
 _SMALL_BODY_LIMIT_BYTES = 64 * 1024  # 64 KB
 
-# Cap for request and response stream buffers. Request-body billing inspection
-# currently depends on complete, untruncated request stream buffers, so do not
-# raise its inspection cap independently without also changing its body source.
+# Cap for request and response stream buffers. Stream-buffered request-body
+# billing inspection depends on this cap for complete, untruncated bodies, so do
+# not raise its inspection cap independently without also changing that source.
 STREAM_BUFFER_LIMIT = _SMALL_BODY_LIMIT_BYTES
 
 # Cap for request and response bodies persisted into network-log capture fields.
@@ -20,8 +20,8 @@ BODY_CAPTURE_LIMIT = _SMALL_BODY_LIMIT_BYTES
 DEFAULT_BODY_DECODE_LIMIT = _SMALL_BODY_LIMIT_BYTES
 
 # Cap for connector request-body billing inspection. This is intentionally tied
-# to STREAM_BUFFER_LIMIT while billing reads complete bodies from request stream
-# buffers.
+# to STREAM_BUFFER_LIMIT while stream-buffered billing refinement reads complete
+# bodies from request stream buffers.
 REQUEST_BODY_BILLING_INSPECTION_LIMIT = _SMALL_BODY_LIMIT_BYTES
 
 # Maximum decoded chunk size fed to incremental usage parsers. This bounds

--- a/crates/runner/mitm-addon/src/body_limits.py
+++ b/crates/runner/mitm-addon/src/body_limits.py
@@ -22,7 +22,7 @@ DEFAULT_BODY_DECODE_LIMIT = _SMALL_BODY_LIMIT_BYTES
 # Cap for connector request-body billing inspection. This is intentionally tied
 # to STREAM_BUFFER_LIMIT while stream-buffered billing refinement reads complete
 # bodies from request stream buffers.
-REQUEST_BODY_BILLING_INSPECTION_LIMIT = _SMALL_BODY_LIMIT_BYTES
+REQUEST_BODY_BILLING_INSPECTION_LIMIT = STREAM_BUFFER_LIMIT
 
 # Maximum decoded chunk size fed to incremental usage parsers. This bounds
 # transient decompressor output without truncating the total response scanned by

--- a/crates/runner/mitm-addon/src/body_limits.py
+++ b/crates/runner/mitm-addon/src/body_limits.py
@@ -1,7 +1,28 @@
 """Shared body size limits for mitm-addon buffering and decoding."""
 
-# Cap for non-model-provider response body buffering and decompression output.
-STREAM_BUFFER_LIMIT = 64 * 1024  # 64 KB
+# Small bounded-body cap shared by stream buffers, persisted capture fields,
+# default small decode output, and request-body billing inspection.
+#
+# These aliases intentionally share one value today. Keep them separate at call
+# sites so future changes can review each semantic contract explicitly instead
+# of treating every 64 KB body limit as interchangeable.
+_SMALL_BODY_LIMIT_BYTES = 64 * 1024  # 64 KB
+
+# Cap for request and response stream buffers. Request-body billing inspection
+# currently depends on complete, untruncated request stream buffers, so do not
+# raise its inspection cap independently without also changing its body source.
+STREAM_BUFFER_LIMIT = _SMALL_BODY_LIMIT_BYTES
+
+# Cap for request and response bodies persisted into network-log capture fields.
+BODY_CAPTURE_LIMIT = _SMALL_BODY_LIMIT_BYTES
+
+# Default cap for small bounded body decompression helpers.
+DEFAULT_BODY_DECODE_LIMIT = _SMALL_BODY_LIMIT_BYTES
+
+# Cap for connector request-body billing inspection. This is intentionally tied
+# to STREAM_BUFFER_LIMIT while billing reads complete bodies from request stream
+# buffers.
+REQUEST_BODY_BILLING_INSPECTION_LIMIT = _SMALL_BODY_LIMIT_BYTES
 
 # Maximum decoded chunk size fed to incremental usage parsers. This bounds
 # transient decompressor output without truncating the total response scanned by

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -17,7 +17,10 @@ import body_decoding
 import flow_metadata_keys as metadata_keys
 import matching
 import request_streaming
-from body_limits import LARGE_RESPONSE_DECOMPRESS_LIMIT, STREAM_BUFFER_LIMIT
+from body_limits import (
+    LARGE_RESPONSE_DECOMPRESS_LIMIT,
+    REQUEST_BODY_BILLING_INSPECTION_LIMIT,
+)
 from logging_utils import log_proxy_entry
 from platform_api import get_api_url
 
@@ -96,7 +99,7 @@ def _strip_request_target_query(request_target: str) -> str:
 # exceeding it indicates malformed or hostile upstream data, so the parser
 # discards that row through its terminating newline to protect memory.
 _MAX_NDJSON_LINE_BYTES = LARGE_RESPONSE_DECOMPRESS_LIMIT
-_REQUEST_BODY_REFINEMENT_LIMIT = STREAM_BUFFER_LIMIT
+_REQUEST_BODY_REFINEMENT_LIMIT = REQUEST_BODY_BILLING_INSPECTION_LIMIT
 _REQUEST_QUERY_HINT_MAX_BYTES = 64 * 1024
 _REQUEST_QUERY_HINT_KEY_MAX_CHARS = 128
 _REQUEST_QUERY_HINT_VALUE_MAX_BYTES = 16 * 1024

--- a/crates/runner/mitm-addon/tests/test_body_capture_decompression.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture_decompression.py
@@ -9,7 +9,7 @@ import zstandard
 from mitmproxy import http
 
 from body_capture import add_capture_fields
-from body_limits import STREAM_BUFFER_LIMIT
+from body_limits import BODY_CAPTURE_LIMIT
 from tests.body_decode_helpers import pseudo_random_ascii, track_brotli_decompressor
 from tests.stream_buffer_helpers import set_response_stream_buffer
 
@@ -86,31 +86,31 @@ class TestDecompression:
         assert entry["response_body"] == '{"result": "hello world"}'
 
     def test_brotli_exact_limit_not_truncated(self, real_flow):
-        original = b"x" * STREAM_BUFFER_LIMIT
+        original = b"x" * BODY_CAPTURE_LIMIT
         compressed = brotli.compress(original)
-        assert len(compressed) < STREAM_BUFFER_LIMIT
+        assert len(compressed) < BODY_CAPTURE_LIMIT
         flow = self._make_flow_with_compressed_buffer(real_flow, compressed, "br", "text/plain")
         entry = {}
         add_capture_fields(flow, entry)
         assert "response_body_truncated" not in entry
-        assert len(entry["response_body"]) == STREAM_BUFFER_LIMIT
+        assert len(entry["response_body"]) == BODY_CAPTURE_LIMIT
 
     def test_brotli_truncation_preserves_utf8_boundary(self, real_flow):
-        original = b"x" * STREAM_BUFFER_LIMIT + "\u20ac".encode("utf-8")
+        original = b"x" * BODY_CAPTURE_LIMIT + "\u20ac".encode("utf-8")
         compressed = brotli.compress(original)
-        assert len(compressed) < STREAM_BUFFER_LIMIT
+        assert len(compressed) < BODY_CAPTURE_LIMIT
         flow = self._make_flow_with_compressed_buffer(real_flow, compressed, "br", "text/plain")
         entry = {}
         add_capture_fields(flow, entry)
         assert entry["response_body_truncated"] is True
         assert entry["response_body_encoding"] == "utf-8"
-        assert len(entry["response_body"]) == STREAM_BUFFER_LIMIT
+        assert len(entry["response_body"]) == BODY_CAPTURE_LIMIT
 
     def test_brotli_large_text_uses_adaptive_chunks(self, real_flow, monkeypatch):
-        original = pseudo_random_ascii(STREAM_BUFFER_LIMIT // 2)
+        original = pseudo_random_ascii(BODY_CAPTURE_LIMIT // 2)
         compressed = brotli.compress(original)
         old_call_count = (len(compressed) + 15) // 16
-        assert len(compressed) < STREAM_BUFFER_LIMIT
+        assert len(compressed) < BODY_CAPTURE_LIMIT
         assert old_call_count > 1000
 
         stats = track_brotli_decompressor(monkeypatch)
@@ -128,7 +128,7 @@ class TestDecompression:
     def test_brotli_zip_bomb_capped_without_full_decode(self, real_flow, monkeypatch):
         original = b"\x00" * (10 * 1024 * 1024)
         compressed = brotli.compress(original)
-        assert len(compressed) < STREAM_BUFFER_LIMIT
+        assert len(compressed) < BODY_CAPTURE_LIMIT
 
         stats = track_brotli_decompressor(monkeypatch)
 
@@ -137,7 +137,7 @@ class TestDecompression:
         add_capture_fields(flow, entry)
 
         assert entry["response_body_truncated"] is True
-        assert len(entry["response_body"]) == STREAM_BUFFER_LIMIT
+        assert len(entry["response_body"]) == BODY_CAPTURE_LIMIT
         assert stats["max_input"] < len(compressed)
         assert stats["max_input"] <= 16
         assert stats["max_output"] < len(original)
@@ -202,13 +202,13 @@ class TestDecompression:
         original = b"\x00" * (1024 * 1024)
         compressed = gzip.compress(original)
         # Compressed data fits in buffer limit
-        assert len(compressed) < STREAM_BUFFER_LIMIT
+        assert len(compressed) < BODY_CAPTURE_LIMIT
         flow = self._make_flow_with_compressed_buffer(real_flow, compressed, "gzip", "text/plain")
         entry = {}
         add_capture_fields(flow, entry)
         # Body should be capped, not 1MB
         assert entry["response_body_truncated"] is True
-        assert len(entry["response_body"]) == STREAM_BUFFER_LIMIT
+        assert len(entry["response_body"]) == BODY_CAPTURE_LIMIT
 
     def test_truncated_brotli_falls_back(self, real_flow):
         """Truncated brotli data should fall back gracefully."""

--- a/crates/runner/mitm-addon/tests/test_body_capture_fields.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture_fields.py
@@ -4,7 +4,7 @@ import base64
 import gzip
 
 from body_capture import add_capture_fields
-from body_limits import STREAM_BUFFER_LIMIT
+from body_limits import BODY_CAPTURE_LIMIT
 
 
 class TestAddCaptureFields:
@@ -147,7 +147,7 @@ class TestAddCaptureFields:
         assert "response_headers" not in entry
 
     def test_truncates_large_request_body(self, real_flow):
-        body = b"x" * (STREAM_BUFFER_LIMIT + 1000)
+        body = b"x" * (BODY_CAPTURE_LIMIT + 1000)
         flow = real_flow(
             method="POST",
             host="api.example.com",
@@ -159,12 +159,12 @@ class TestAddCaptureFields:
         entry = {}
         add_capture_fields(flow, entry)
         assert entry["request_body_truncated"] is True
-        assert len(entry["request_body"]) == STREAM_BUFFER_LIMIT
+        assert len(entry["request_body"]) == BODY_CAPTURE_LIMIT
 
     def test_request_gzip_zip_bomb_capped_without_full_content_decode(self, real_flow, monkeypatch):
-        original = b"x" * (STREAM_BUFFER_LIMIT + 4096)
+        original = b"x" * (BODY_CAPTURE_LIMIT + 4096)
         compressed = gzip.compress(original)
-        assert len(compressed) < STREAM_BUFFER_LIMIT
+        assert len(compressed) < BODY_CAPTURE_LIMIT
         flow = real_flow(
             method="POST",
             host="api.example.com",
@@ -185,13 +185,13 @@ class TestAddCaptureFields:
         add_capture_fields(flow, entry)
 
         assert entry["request_body_truncated"] is True
-        assert len(entry["request_body"]) == STREAM_BUFFER_LIMIT
+        assert len(entry["request_body"]) == BODY_CAPTURE_LIMIT
         assert set(entry["request_body"]) == {"x"}
 
     def test_request_gzip_exact_limit_not_truncated(self, real_flow):
-        original = b"x" * STREAM_BUFFER_LIMIT
+        original = b"x" * BODY_CAPTURE_LIMIT
         compressed = gzip.compress(original)
-        assert len(compressed) < STREAM_BUFFER_LIMIT
+        assert len(compressed) < BODY_CAPTURE_LIMIT
         flow = real_flow(
             method="POST",
             host="api.example.com",
@@ -206,10 +206,10 @@ class TestAddCaptureFields:
         add_capture_fields(flow, entry)
 
         assert "request_body_truncated" not in entry
-        assert len(entry["request_body"]) == STREAM_BUFFER_LIMIT
+        assert len(entry["request_body"]) == BODY_CAPTURE_LIMIT
 
     def test_truncates_large_response_body(self, real_flow):
-        body = b"y" * (STREAM_BUFFER_LIMIT + 1000)
+        body = b"y" * (BODY_CAPTURE_LIMIT + 1000)
         flow = real_flow(
             method="POST",
             host="api.example.com",
@@ -221,7 +221,7 @@ class TestAddCaptureFields:
         entry = {}
         add_capture_fields(flow, entry)
         assert entry["response_body_truncated"] is True
-        assert len(entry["response_body"]) == STREAM_BUFFER_LIMIT
+        assert len(entry["response_body"]) == BODY_CAPTURE_LIMIT
 
     def test_no_body_fields_when_empty(self, real_flow):
         flow = real_flow(
@@ -342,7 +342,7 @@ class TestAddCaptureFields:
             host="api.example.com",
             response_content_type="application/json",
             include_request_id=True,
-            request_body=b"\x89PNG" + b"\x00" * STREAM_BUFFER_LIMIT,
+            request_body=b"\x89PNG" + b"\x00" * BODY_CAPTURE_LIMIT,
             request_content_type="image/png",
         )
         entry = {}
@@ -373,7 +373,7 @@ class TestAddCaptureFields:
             host="api.example.com",
             request_content_type="application/json",
             include_request_id=True,
-            response_body=b"\x00" * (STREAM_BUFFER_LIMIT + 1),
+            response_body=b"\x00" * (BODY_CAPTURE_LIMIT + 1),
             response_content_type="application/octet-stream",
         )
         entry = {}
@@ -383,7 +383,7 @@ class TestAddCaptureFields:
         assert entry["response_body_truncated"] is True
 
     def test_request_body_exactly_at_limit_not_truncated(self, real_flow):
-        body = b"x" * STREAM_BUFFER_LIMIT
+        body = b"x" * BODY_CAPTURE_LIMIT
         flow = real_flow(
             method="POST",
             host="api.example.com",
@@ -395,10 +395,10 @@ class TestAddCaptureFields:
         entry = {}
         add_capture_fields(flow, entry)
         assert "request_body_truncated" not in entry
-        assert len(entry["request_body"]) == STREAM_BUFFER_LIMIT
+        assert len(entry["request_body"]) == BODY_CAPTURE_LIMIT
 
     def test_response_body_exactly_at_limit_not_truncated(self, real_flow):
-        body = b"y" * STREAM_BUFFER_LIMIT
+        body = b"y" * BODY_CAPTURE_LIMIT
         flow = real_flow(
             method="POST",
             host="api.example.com",
@@ -410,11 +410,11 @@ class TestAddCaptureFields:
         entry = {}
         add_capture_fields(flow, entry)
         assert "response_body_truncated" not in entry
-        assert len(entry["response_body"]) == STREAM_BUFFER_LIMIT
+        assert len(entry["response_body"]) == BODY_CAPTURE_LIMIT
 
     def test_truncation_preserves_utf8_boundary(self, real_flow):
-        # Body is STREAM_BUFFER_LIMIT + a 3-byte char "€" (\xe2\x82\xac)
-        body = b"x" * STREAM_BUFFER_LIMIT + "\u20ac".encode("utf-8")
+        # Body is BODY_CAPTURE_LIMIT + a 3-byte char "€" (\xe2\x82\xac)
+        body = b"x" * BODY_CAPTURE_LIMIT + "\u20ac".encode("utf-8")
         flow = real_flow(
             method="POST",
             host="api.example.com",
@@ -428,7 +428,7 @@ class TestAddCaptureFields:
         assert entry["request_body_truncated"] is True
         # Should be valid UTF-8 (truncated at char boundary, not mid-char)
         assert entry["request_body_encoding"] == "utf-8"
-        assert len(entry["request_body"]) == STREAM_BUFFER_LIMIT  # all ASCII before the €
+        assert len(entry["request_body"]) == BODY_CAPTURE_LIMIT  # all ASCII before the €
 
     def test_text_request_with_binary_response(self, real_flow):
         flow = real_flow(
@@ -501,8 +501,8 @@ class TestAddCaptureFields:
         assert base64.b64decode(entry["response_body"]) == response_body
 
     def test_large_non_utf8_text_bodies_capture_truncated_base64(self, real_flow):
-        request_body = b"\xff" + b"r" * STREAM_BUFFER_LIMIT
-        response_body = b"\xfe" + b"s" * STREAM_BUFFER_LIMIT
+        request_body = b"\xff" + b"r" * BODY_CAPTURE_LIMIT
+        response_body = b"\xfe" + b"s" * BODY_CAPTURE_LIMIT
         flow = real_flow(
             method="POST",
             host="api.example.com",
@@ -515,8 +515,8 @@ class TestAddCaptureFields:
         entry = {}
         add_capture_fields(flow, entry)
         assert entry["request_body_encoding"] == "base64"
-        assert base64.b64decode(entry["request_body"]) == request_body[:STREAM_BUFFER_LIMIT]
+        assert base64.b64decode(entry["request_body"]) == request_body[:BODY_CAPTURE_LIMIT]
         assert entry["request_body_truncated"] is True
         assert entry["response_body_encoding"] == "base64"
-        assert base64.b64decode(entry["response_body"]) == response_body[:STREAM_BUFFER_LIMIT]
+        assert base64.b64decode(entry["response_body"]) == response_body[:BODY_CAPTURE_LIMIT]
         assert entry["response_body_truncated"] is True

--- a/crates/runner/mitm-addon/tests/test_body_decoding.py
+++ b/crates/runner/mitm-addon/tests/test_body_decoding.py
@@ -12,7 +12,7 @@ from body_decoding import (
     create_stream_decode_session,
     decompress_body,
 )
-from body_limits import STREAM_BUFFER_LIMIT, STREAM_DECODE_CHUNK_LIMIT
+from body_limits import DEFAULT_BODY_DECODE_LIMIT, STREAM_DECODE_CHUNK_LIMIT
 from tests.body_decode_helpers import pseudo_random_ascii, track_brotli_decompressor
 
 
@@ -391,16 +391,16 @@ class TestDecompressBody:
         assert result == plaintext
 
     def test_brotli_large_input_caps_adaptive_chunk_size(self, headers, monkeypatch):
-        plaintext = pseudo_random_ascii(STREAM_BUFFER_LIMIT * 3)
+        plaintext = pseudo_random_ascii(DEFAULT_BODY_DECODE_LIMIT * 3)
         compressed = brotli.compress(plaintext)
         assert len(compressed) > 64 * 1024
 
         stats = track_brotli_decompressor(monkeypatch)
 
         hdrs = headers(("Content-Encoding", "br"))
-        result = decompress_body(compressed, hdrs, max_output=STREAM_BUFFER_LIMIT)
+        result = decompress_body(compressed, hdrs, max_output=DEFAULT_BODY_DECODE_LIMIT)
 
-        assert result == plaintext[:STREAM_BUFFER_LIMIT]
+        assert result == plaintext[:DEFAULT_BODY_DECODE_LIMIT]
         assert stats["max_input"] == 1024
 
     def test_zstd_corrupted_returns_original_data(self, headers, mitm_ctx):

--- a/crates/runner/mitm-addon/tests/x_connector_usage/test_writes.py
+++ b/crates/runner/mitm-addon/tests/x_connector_usage/test_writes.py
@@ -9,7 +9,7 @@ import pytest
 
 import flow_metadata_keys as metadata_keys
 import request_streaming
-from body_limits import STREAM_BUFFER_LIMIT
+from body_limits import REQUEST_BODY_BILLING_INSPECTION_LIMIT, STREAM_BUFFER_LIMIT
 from tests.jsonl_log_helpers import (
     jsonl_exists_after_flush,
     read_jsonl_entries_after_flush,
@@ -137,7 +137,7 @@ def test_tweet_create_compressed_plain_text_downgrades_to_content_create(
 
 def test_tweet_create_gzip_decoded_body_over_cap_stays_conservative(x_usage, tmp_path, real_flow):
     """A gzip body that expands beyond the billing inspection cap is not refined."""
-    long_text = "x" * STREAM_BUFFER_LIMIT
+    long_text = "x" * REQUEST_BODY_BILLING_INSPECTION_LIMIT
     request_body = gzip.compress(json.dumps({"text": long_text}).encode())
     flow = x_usage.make_flow(
         real_flow,
@@ -158,7 +158,7 @@ def test_tweet_create_gzip_decoded_body_over_cap_stays_conservative(x_usage, tmp
 
 def test_tweet_create_raw_body_over_cap_stays_conservative(x_usage, tmp_path, real_flow):
     """An oversized identity request body is not refined."""
-    request_body = b"{" + b'"text":"' + b"x" * STREAM_BUFFER_LIMIT + b'"}'
+    request_body = b"{" + b'"text":"' + b"x" * REQUEST_BODY_BILLING_INSPECTION_LIMIT + b'"}'
     flow = x_usage.make_flow(
         real_flow,
         tmp_path,


### PR DESCRIPTION
## Summary

- Add semantic aliases for the shared 64 KB mitm-addon small-body limit.
- Use capture, billing, and default decode names at matching call sites.
- Keep stream buffer paths on `STREAM_BUFFER_LIMIT` and preserve all existing limit values and behavior.

Closes #19105

## Tests

- `cd crates/runner/mitm-addon && pytest tests/test_body_capture_fields.py tests/test_body_capture_stream_buffer.py tests/test_body_capture_decompression.py tests/test_body_decoding.py`
- `cd crates/runner/mitm-addon && pytest tests/test_request_headers_handler.py tests/x_connector_usage/test_writes.py`
- `cd crates/runner/mitm-addon && pytest tests/test_response_handler.py tests/test_request_handler_firewall_dispatch.py`
- `cd crates/runner/mitm-addon && ruff check src tests && ruff format --check src tests`