### PR TITLE
refactor(vsock-host): centralize terminal exec cleanup

### DIFF
--- a/crates/vsock-host/src/exec_operation/dispatch.rs
+++ b/crates/vsock-host/src/exec_operation/dispatch.rs
@@ -9,7 +9,6 @@ use vsock_proto::{
 
 use crate::{ConnectionState, Shared, normal_operation_transition_error};
 
-use super::diagnostics::exec_terminal_log_lifecycle;
 use super::state::{ExecCaptureState, ExecOperation, ExecOperationLifecycle};
 use super::types::{
     ExecControlAck, ExecControlGuestStatus, ExecControlOutcome, ExecOperationResult,
@@ -250,15 +249,7 @@ pub(in crate::exec_operation) fn dispatch_result(
     shared: &Arc<Shared>,
     msg: BorrowedRawMessage<'_>,
 ) -> io::Result<()> {
-    let Some((
-        diagnostic,
-        result_tx,
-        start_tx,
-        log_lifecycle,
-        stream_overflowed,
-        host_cancel_requested,
-        decoded,
-    )) = ({
+    let Some((terminal, decoded)) = ({
         let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
         match &mut *guard {
             ConnectionState::Connected { operations, .. } if operations.contains(msg.seq) => {
@@ -269,54 +260,24 @@ pub(in crate::exec_operation) fn dispatch_result(
                 };
                 operation.validates_result_before_start(&decoded)?;
                 validate_result(operation, &decoded)?;
-                let Some(operation) = operations.take(msg.seq) else {
-                    return Ok(());
-                };
-                let ExecOperation {
-                    normal_operation,
-                    mut lifecycle,
-                    diagnostic,
-                    result_tx,
-                    stream_overflowed,
-                    host_cancel_requested,
-                    ..
-                } = operation;
-                let log_lifecycle = exec_terminal_log_lifecycle(&lifecycle);
-                let start_tx = match &mut lifecycle {
-                    ExecOperationLifecycle::SupervisedAwaitingStart { start_tx, .. } => {
-                        start_tx.take()
-                    }
-                    ExecOperationLifecycle::OneShot
-                    | ExecOperationLifecycle::SupervisedStarted { .. } => None,
-                };
-                if let Some(normal_operation) = normal_operation {
-                    normal_operation.complete()?;
-                }
-                Some((
-                    diagnostic,
-                    result_tx,
-                    start_tx,
-                    log_lifecycle,
-                    stream_overflowed,
-                    host_cancel_requested,
-                    decoded,
-                ))
+                operations
+                    .take_terminal_exec_operation(msg.seq)?
+                    .map(|terminal| (terminal, decoded))
             }
             ConnectionState::Connected { .. } | ConnectionState::Closed => None,
         }
-    })
-    else {
+    }) else {
         return Ok(());
     };
 
-    diagnostic.log_terminal(
-        log_lifecycle,
+    terminal.diagnostic.log_terminal(
+        terminal.log_lifecycle,
         &decoded,
-        stream_overflowed,
-        host_cancel_requested,
+        terminal.stream_overflowed,
+        terminal.host_cancel_requested,
     );
-    let result = owned_result(decoded, stream_overflowed);
-    if let Some(start_tx) = start_tx {
+    let result = owned_result(decoded, terminal.stream_overflowed);
+    if let Some(start_tx) = terminal.start_tx {
         let message = if result.diagnostic.is_empty() {
             "supervised exec start failed".to_owned()
         } else {
@@ -324,7 +285,7 @@ pub(in crate::exec_operation) fn dispatch_result(
         };
         let _ = start_tx.send(Err(io::Error::other(message)));
     }
-    let _ = result_tx.send(Ok(result));
+    let _ = terminal.result_tx.send(Ok(result));
 
     Ok(())
 }
@@ -380,34 +341,16 @@ fn dispatch_control_result(shared: &Arc<Shared>, msg: BorrowedRawMessage<'_>) ->
 }
 
 fn dispatch_error(shared: &Arc<Shared>, msg: BorrowedRawMessage<'_>) -> io::Result<bool> {
-    let Some((diagnostic, result_tx, start_tx, err)) = ({
+    let Some((terminal, err)) = ({
         let mut guard = shared.state.lock().unwrap_or_else(|e| e.into_inner());
         match &mut *guard {
             ConnectionState::Connected { operations, .. } if operations.contains(msg.seq) => {
                 let err = vsock_proto::decode_error(msg.payload)
                     .map(|message| exec_operation_guest_error(message.to_string()))
                     .map_err(exec_operation_protocol_error)?;
-                let Some(operation) = operations.take(msg.seq) else {
-                    return Ok(false);
-                };
-                let ExecOperation {
-                    normal_operation,
-                    mut lifecycle,
-                    diagnostic,
-                    result_tx,
-                    ..
-                } = operation;
-                let start_tx = match &mut lifecycle {
-                    ExecOperationLifecycle::SupervisedAwaitingStart { start_tx, .. } => {
-                        start_tx.take()
-                    }
-                    ExecOperationLifecycle::OneShot
-                    | ExecOperationLifecycle::SupervisedStarted { .. } => None,
-                };
-                if let Some(normal_operation) = normal_operation {
-                    normal_operation.complete()?;
-                }
-                Some((diagnostic, result_tx, start_tx, err))
+                operations
+                    .take_terminal_exec_operation(msg.seq)?
+                    .map(|terminal| (terminal, err))
             }
             ConnectionState::Connected { .. } | ConnectionState::Closed => None,
         }
@@ -415,11 +358,11 @@ fn dispatch_error(shared: &Arc<Shared>, msg: BorrowedRawMessage<'_>) -> io::Resu
         return dispatch_control_error(shared, msg);
     };
 
-    diagnostic.log_error_response(&err);
-    if let Some(start_tx) = start_tx {
+    terminal.diagnostic.log_error_response(&err);
+    if let Some(start_tx) = terminal.start_tx {
         let _ = start_tx.send(Err(io::Error::new(err.kind(), err.to_string())));
     }
-    let _ = result_tx.send(Err(err));
+    let _ = terminal.result_tx.send(Err(err));
     Ok(true)
 }
 

--- a/crates/vsock-host/src/exec_operation/state.rs
+++ b/crates/vsock-host/src/exec_operation/state.rs
@@ -10,7 +10,10 @@ use crate::{
     operation_tracker::{NormalOperationToken, NormalOperationTransitionHandle},
 };
 
-use super::diagnostics::{ExecOperationCloseSnapshot, ExecOperationDiagnostic};
+use super::diagnostics::{
+    ExecOperationCloseSnapshot, ExecOperationDiagnostic, ExecTerminalLogLifecycle,
+    exec_terminal_log_lifecycle,
+};
 use super::frame::remove_pending_exec_control;
 use super::types::{
     ExecControlOutcome, ExecOperationResult, ExecOutputEvent, exec_control_status_error,
@@ -56,6 +59,13 @@ impl Operations {
             self.control_targets.remove(request_seq);
         }
         Some(operation)
+    }
+
+    pub(in crate::exec_operation) fn take_terminal_exec_operation(
+        &mut self,
+        seq: u32,
+    ) -> io::Result<Option<TerminalExecOperation>> {
+        self.take(seq).map(ExecOperation::into_terminal).transpose()
     }
 
     pub(in crate::exec_operation) fn contains(&self, seq: u32) -> bool {
@@ -175,6 +185,15 @@ pub(in crate::exec_operation) enum ExecOperationNormalTracking {
     Composite(NormalOperationTransitionHandle),
 }
 
+pub(in crate::exec_operation) struct TerminalExecOperation {
+    pub(in crate::exec_operation) diagnostic: ExecOperationDiagnostic,
+    pub(in crate::exec_operation) result_tx: oneshot::Sender<io::Result<ExecOperationResult>>,
+    pub(in crate::exec_operation) start_tx: Option<oneshot::Sender<io::Result<u32>>>,
+    pub(in crate::exec_operation) log_lifecycle: ExecTerminalLogLifecycle,
+    pub(in crate::exec_operation) stream_overflowed: bool,
+    pub(in crate::exec_operation) host_cancel_requested: bool,
+}
+
 impl ExecOperation {
     pub(in crate::exec_operation) fn allows_output(&self) -> bool {
         matches!(
@@ -230,6 +249,36 @@ impl ExecOperation {
                 ))
             }
         }
+    }
+
+    fn into_terminal(self) -> io::Result<TerminalExecOperation> {
+        let ExecOperation {
+            normal_operation,
+            lifecycle,
+            diagnostic,
+            result_tx,
+            stream_overflowed,
+            host_cancel_requested,
+            ..
+        } = self;
+        let log_lifecycle = exec_terminal_log_lifecycle(&lifecycle);
+        let start_tx = match lifecycle {
+            ExecOperationLifecycle::SupervisedAwaitingStart { start_tx, .. } => start_tx,
+            ExecOperationLifecycle::OneShot | ExecOperationLifecycle::SupervisedStarted { .. } => {
+                None
+            }
+        };
+        if let Some(normal_operation) = normal_operation {
+            normal_operation.complete()?;
+        }
+        Ok(TerminalExecOperation {
+            diagnostic,
+            result_tx,
+            start_tx,
+            log_lifecycle,
+            stream_overflowed,
+            host_cancel_requested,
+        })
     }
 }
 

--- a/crates/vsock-host/src/tests/exec_operation/supervised/control.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised/control.rs
@@ -360,6 +360,51 @@ async fn supervised_exec_control_reports_guest_status_and_error() {
 }
 
 #[tokio::test]
+async fn supervised_exec_control_guest_error_uses_control_error_fallback() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move {
+            host.start_supervised_exec(SupervisedExecRequest {
+                control: SupervisedExecControl::Enabled { sink: true },
+                ..supervised_request("control-error-fallback")
+            })
+            .await
+        })
+    };
+
+    let start = read_guest_message(&mut guest).await;
+    send_exec_started(&mut guest, start.seq, 123).await;
+    let handle = task.await.unwrap().unwrap();
+
+    let control_task = tokio::spawn({
+        let control_handle = handle.control_handle().unwrap();
+        async move {
+            control_handle
+                .control("guest-error", b"payload", Duration::from_secs(5))
+                .await
+        }
+    });
+    let control = read_guest_message(&mut guest).await;
+    send_guest_error(&mut guest, control.seq, "guest rejected control").await;
+
+    let err = control_task.await.unwrap().unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::Other);
+    assert_eq!(err.to_string(), "guest rejected control");
+
+    send_exec_result(
+        &mut guest,
+        start.seq,
+        ExecTermination::Exited { exit_code: 0 },
+        b"",
+        b"",
+    )
+    .await;
+    handle.wait(Duration::from_secs(5)).await.unwrap();
+}
+
+#[tokio::test]
 async fn supervised_exec_control_timeout_ignores_late_result() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);


### PR DESCRIPTION
## Summary

- centralize terminal exec operation cleanup in the state layer with a `TerminalExecOperation` handoff
- refactor `dispatch_result` and `dispatch_error` to share the registry terminalization path while preserving decode and validation ordering
- add a focused supervised exec-control guest-error fallback regression test

Fixes #19107

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p vsock-host supervised_exec_control_guest_error_uses_control_error_fallback`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host exec_operation`
- `cargo fmt --manifest-path crates/vsock-host/Cargo.toml --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-host --all-targets -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host`
- pre-commit hooks: cargo-fmt, cargo-clippy, cargo-doc
