### PR TITLE
feat: add workflow cron trigger time form

### DIFF
--- a/turbo/apps/api/src/signals/services/zero-workflow-trigger.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-trigger.service.ts
@@ -466,48 +466,65 @@ export async function listThreadBoundWorkflowTriggers(
     }),
   );
 
-  return summaries.flatMap(({ trigger, workflow, summary }) => {
-    if (!summary || trigger.chatThreadId === null) {
-      return [];
-    }
-    const base = {
-      id: summary.id,
-      enabled: summary.enabled,
-      chatThreadId: trigger.chatThreadId,
-      nextRunAt: summary.nextRunAt,
-      lastRunAt: summary.lastRunAt,
-      ownerUserId: summary.ownerUserId,
-      unattendedConnectorRefs: summary.unattendedConnectorRefs,
-      unattendedPermissionPolicy: summary.unattendedPermissionPolicy,
-      workflow: {
-        id: workflow.id,
-        agentId: workflow.agentId,
-        name: workflow.name,
-        displayName: workflow.displayName,
-        description: workflow.description,
-      },
-    };
-    if (summary.kind === "schedule") {
+  return summaries.flatMap(
+    ({ trigger, workflow, summary }): readonly ChatThreadWorkflowTrigger[] => {
+      if (!summary || trigger.chatThreadId === null) {
+        return [];
+      }
+      const base = {
+        id: summary.id,
+        enabled: summary.enabled,
+        chatThreadId: trigger.chatThreadId,
+        nextRunAt: summary.nextRunAt,
+        lastRunAt: summary.lastRunAt,
+        ownerUserId: summary.ownerUserId,
+        unattendedConnectorRefs: summary.unattendedConnectorRefs,
+        unattendedPermissionPolicy: summary.unattendedPermissionPolicy,
+        workflow: {
+          id: workflow.id,
+          agentId: workflow.agentId,
+          name: workflow.name,
+          displayName: workflow.displayName,
+          description: workflow.description,
+        },
+      };
+      if (summary.kind === "schedule") {
+        return [
+          {
+            ...base,
+            kind: "schedule",
+            schedule: summary.schedule,
+            scheduleSummary: summary.scheduleSummary,
+          },
+        ];
+      }
+      if (summary.eventType === "webhook-received") {
+        return [];
+      }
+      if (summary.eventType === "gmail-new-message") {
+        return [
+          {
+            ...base,
+            kind: "event",
+            eventType: "gmail-new-message",
+            eventConfig: summary.eventConfig,
+            schedule: null,
+            scheduleSummary: null,
+          },
+        ];
+      }
       return [
         {
           ...base,
-          kind: "schedule",
-          schedule: summary.schedule,
-          scheduleSummary: summary.scheduleSummary,
+          kind: "event",
+          eventType: "gmail-label-applied",
+          eventConfig: summary.eventConfig,
+          schedule: null,
+          scheduleSummary: null,
         },
       ];
-    }
-    return [
-      {
-        ...base,
-        kind: "event",
-        eventType: summary.eventType,
-        eventConfig: summary.eventConfig,
-        schedule: null,
-        scheduleSummary: null,
-      },
-    ];
-  });
+    },
+  );
 }
 
 /**

--- a/turbo/apps/platform/src/mocks/handlers/api-workflows.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-workflows.ts
@@ -80,32 +80,6 @@ function triggerSummary(
       unattendedPermissionPolicy: trigger.unattendedPermissionPolicy,
     };
   }
-  if (trigger.kind === "event" && trigger.eventType === "webhook-received") {
-    return {
-      id: trigger.id,
-      ownerUserId: "test-user-123",
-      enabled: trigger.enabled,
-      chatThreadId: trigger.chatThreadId,
-      nextRunAt: trigger.nextRunAt,
-      lastRunAt: trigger.lastRunAt,
-      kind: "event",
-      eventType: "webhook-received",
-      eventConfig: {
-        provider: "webhook",
-        event: "received",
-        auth: { mode: "hmac-sha256" },
-      },
-      schedule: null,
-      scheduleSummary: null,
-      webhookUrl:
-        "https://api.vm0.test/api/webhooks/workflow-triggers/whk_test",
-      secretLastFour: "abcd",
-      lastReceivedAt: null,
-      unattendedConnectorRefs: [],
-      unattendedPermissionPolicy: null,
-    };
-  }
-
   return {
     id: trigger.id,
     ownerUserId: trigger.ownerUserId,

--- a/turbo/apps/platform/src/signals/chat-page/header-automation-menu.ts
+++ b/turbo/apps/platform/src/signals/chat-page/header-automation-menu.ts
@@ -93,9 +93,6 @@ function workflowTriggerSummary(trigger: ChatThreadWorkflowTrigger): string {
     if (trigger.eventType === "gmail-new-message") {
       return "Gmail new message";
     }
-    if (trigger.eventType === "webhook-received") {
-      return "Webhook";
-    }
     return "Event";
   }
   return trigger.scheduleSummary ?? "Schedule";

--- a/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
+++ b/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
@@ -41,6 +41,33 @@ type WorkflowWebhookTriggerSummary = Extract<
 const WORKFLOW_DETAIL_SIDEBAR_PARAM = "sidebar";
 const WORKFLOW_TRIGGER_SIDEBAR_VALUE = "triggers";
 
+export type WorkflowCronFrequency =
+  | "every_day"
+  | "every_weekday"
+  | "every_week"
+  | "every_month"
+  | "custom";
+
+export interface WorkflowCronFields {
+  readonly frequency: WorkflowCronFrequency;
+  readonly hour: number;
+  readonly minute: number;
+  readonly dayOfWeek: string;
+  readonly dayOfMonth: string;
+  readonly customCronExpression: string;
+}
+
+export function defaultWorkflowCronFields(): WorkflowCronFields {
+  return {
+    frequency: "every_day",
+    hour: 9,
+    minute: 0,
+    dayOfWeek: "1",
+    dayOfMonth: "1",
+    customCronExpression: "0 9 * * *",
+  };
+}
+
 interface WorkflowDetailFileDraft {
   readonly workflowId: string;
   readonly filePath: string | null;
@@ -64,7 +91,7 @@ const internalWorkflowReload$ = state(0);
 const internalSelectedFilePath$ = state<string | null>(null);
 const internalWorkflowActionDialog$ = state<WorkflowDetailActionDialog>(null);
 const internalWorkflowFileDraft$ = state<WorkflowDetailFileDraft | null>(null);
-const internalEditingGmailTriggerId$ = state<string | null>(null);
+const internalEditingWorkflowTriggerId$ = state<string | null>(null);
 const internalWorkflowTriggerPermissionsDrawerTriggerId$ = state<string | null>(
   null,
 );
@@ -73,6 +100,12 @@ const internalWorkflowTriggerCreateDialog$ =
 const internalScheduleTriggerType$ = state<ZeroWorkflowScheduleType>("cron");
 const internalCreatedWorkflowWebhookTrigger$ =
   state<WorkflowWebhookTriggerSummary | null>(null);
+const internalCreateScheduleCronFields$ = state<WorkflowCronFields>(
+  defaultWorkflowCronFields(),
+);
+const internalEditingScheduleCronFields$ = state<WorkflowCronFields>(
+  defaultWorkflowCronFields(),
+);
 
 export const workflowDetailTriggerSidebarOpen$ = computed((get) => {
   return (
@@ -101,7 +134,7 @@ export const setWorkflowDetailTriggerSidebarOpen$ = command(
       set(reloadWorkflows$);
     }
     params.delete(WORKFLOW_DETAIL_SIDEBAR_PARAM);
-    set(internalEditingGmailTriggerId$, null);
+    set(internalEditingWorkflowTriggerId$, null);
     set(internalWorkflowTriggerPermissionsDrawerTriggerId$, null);
     set(internalWorkflowTriggerCreateDialog$, null);
     set(internalCreatedWorkflowWebhookTrigger$, null);
@@ -133,24 +166,26 @@ export const resetWorkflowDetailUiState$ = command(({ set }) => {
   set(internalSelectedFilePath$, null);
   set(internalWorkflowActionDialog$, null);
   set(internalWorkflowFileDraft$, null);
-  set(internalEditingGmailTriggerId$, null);
+  set(internalEditingWorkflowTriggerId$, null);
   set(internalWorkflowTriggerPermissionsDrawerTriggerId$, null);
   set(internalWorkflowTriggerCreateDialog$, null);
   set(internalCreatedWorkflowWebhookTrigger$, null);
   set(internalScheduleTriggerType$, "cron");
+  set(internalCreateScheduleCronFields$, defaultWorkflowCronFields());
+  set(internalEditingScheduleCronFields$, defaultWorkflowCronFields());
 });
 
-export const editingGmailTriggerId$ = computed((get) => {
-  return get(internalEditingGmailTriggerId$);
+export const editingWorkflowTriggerId$ = computed((get) => {
+  return get(internalEditingWorkflowTriggerId$);
 });
 
 export const workflowTriggerPermissionsDrawerTriggerId$ = computed((get) => {
   return get(internalWorkflowTriggerPermissionsDrawerTriggerId$);
 });
 
-export const setEditingGmailTriggerId$ = command(
+export const setEditingWorkflowTriggerId$ = command(
   ({ set }, triggerId: string | null) => {
-    set(internalEditingGmailTriggerId$, triggerId);
+    set(internalEditingWorkflowTriggerId$, triggerId);
   },
 );
 
@@ -182,6 +217,7 @@ export const setWorkflowTriggerCreateDialog$ = command(
     }
     if (dialog === "schedule") {
       set(internalScheduleTriggerType$, "cron");
+      set(internalCreateScheduleCronFields$, defaultWorkflowCronFields());
     }
   },
 );
@@ -193,6 +229,26 @@ export const scheduleTriggerType$ = computed((get) => {
 export const setScheduleTriggerType$ = command(
   ({ set }, scheduleType: ZeroWorkflowScheduleType) => {
     set(internalScheduleTriggerType$, scheduleType);
+  },
+);
+
+export const createScheduleCronFields$ = computed((get) => {
+  return get(internalCreateScheduleCronFields$);
+});
+
+export const setCreateScheduleCronFields$ = command(
+  ({ set }, fields: WorkflowCronFields) => {
+    set(internalCreateScheduleCronFields$, fields);
+  },
+);
+
+export const editingScheduleCronFields$ = computed((get) => {
+  return get(internalEditingScheduleCronFields$);
+});
+
+export const setEditingScheduleCronFields$ = command(
+  ({ set }, fields: WorkflowCronFields) => {
+    set(internalEditingScheduleCronFields$, fields);
   },
 );
 
@@ -544,6 +600,29 @@ export const updateWorkflowGmailLabelAppliedTrigger$ = command(
       client.update({
         params: { id: input.triggerId },
         body: { eventConfig: input.eventConfig },
+        fetchOptions: { signal },
+      }),
+      [200],
+    );
+    signal.throwIfAborted();
+    set(reloadWorkflows$);
+  },
+);
+
+export const updateWorkflowScheduleTrigger$ = command(
+  async (
+    { get, set },
+    input: {
+      readonly triggerId: string;
+      readonly schedule: ZeroWorkflowSchedule;
+    },
+    signal: AbortSignal,
+  ) => {
+    const client = get(zeroClient$)(zeroWorkflowTriggersContract);
+    await accept(
+      client.update({
+        params: { id: input.triggerId },
+        body: { schedule: input.schedule },
         fetchOptions: { signal },
       }),
       [200],

--- a/turbo/apps/platform/src/signals/zero-page/cron.ts
+++ b/turbo/apps/platform/src/signals/zero-page/cron.ts
@@ -193,8 +193,23 @@ export function cronTimeInTimezone(
   sourceTimezone: string,
   displayTimezone: string,
 ): { hour: number; minute: number } {
+  const result = cronWallTimeInTimezone(
+    hour,
+    minute,
+    sourceTimezone,
+    displayTimezone,
+  );
+  return { hour: result.hour, minute: result.minute };
+}
+
+export function cronWallTimeInTimezone(
+  hour: number,
+  minute: number,
+  sourceTimezone: string,
+  displayTimezone: string,
+): { hour: number; minute: number; dayOffset: number } {
   if (sourceTimezone === displayTimezone) {
-    return { hour, minute };
+    return { hour, minute, dayOffset: 0 };
   }
   const sourceDateParts = new Intl.DateTimeFormat("en-US", {
     year: "numeric",
@@ -210,11 +225,24 @@ export function cronTimeInTimezone(
     minute,
   });
   const parts = new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
     hour: "2-digit",
     minute: "2-digit",
     hourCycle: "h23",
     timeZone: displayTimezone,
   }).formatToParts(d);
+  const sourceDay = Date.UTC(
+    Number(datePart(sourceDateParts, "year")),
+    Number(datePart(sourceDateParts, "month")) - 1,
+    Number(datePart(sourceDateParts, "day")),
+  );
+  const displayDay = Date.UTC(
+    Number(datePart(parts, "year")),
+    Number(datePart(parts, "month")) - 1,
+    Number(datePart(parts, "day")),
+  );
   return {
     hour: Number(
       parts.find((p) => {
@@ -226,6 +254,7 @@ export function cronTimeInTimezone(
         return p.type === "minute";
       })?.value ?? minute,
     ),
+    dayOffset: Math.round((displayDay - sourceDay) / 86_400_000),
   };
 }
 

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -563,6 +563,15 @@ function menuItemByText(text: RoleTextMatch): HTMLElement {
   return item;
 }
 
+function selectOptionByLabel(
+  label: string,
+  option: string | RegExp,
+  container: HTMLElement,
+): void {
+  click(within(container).getByLabelText(label));
+  click(screen.getByRole("option", { name: option }));
+}
+
 describe("agent workflows tab", () => {
   it("shows the agent's workflows and links into the detail page", async () => {
     mockAgentPageApis();
@@ -627,6 +636,7 @@ describe("agent workflows tab", () => {
 
 describe("workflow detail page", () => {
   it("renders the instruction, files, and triggers", async () => {
+    context.mocks.data.userPreferences({ timezone: "UTC" });
     mockWorkflowApis([salesResearch()]);
     mockConnectedTriggerConnectors();
 
@@ -659,7 +669,9 @@ describe("workflow detail page", () => {
     click(buttonByText(/trigger/i));
     expect(search()).toBe("?sidebar=triggers");
     expect(buttonByText("Close trigger sidebar")).toBeInTheDocument();
-    expect(screen.getByText("Weekdays at 9:00 AM")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("Every weekday at 9:00 AM")).toBeInTheDocument();
+    });
     expect(screen.getByText("Enabled")).toBeInTheDocument();
     expect(screen.getByText("Open thread")).toBeInTheDocument();
     click(workflowFilesButton);
@@ -748,6 +760,7 @@ describe("workflow detail page", () => {
   });
 
   it("derives the trigger sidebar from workflow detail search params", async () => {
+    context.mocks.data.userPreferences({ timezone: "UTC" });
     mockWorkflowApis([salesResearch()]);
 
     detachedSetupPage({
@@ -758,7 +771,7 @@ describe("workflow detail page", () => {
     await waitFor(() => {
       expect(buttonByText("Close trigger sidebar")).toBeInTheDocument();
     });
-    expect(screen.getByText("Weekdays at 9:00 AM")).toBeInTheDocument();
+    expect(screen.getByText("Every weekday at 9:00 AM")).toBeInTheDocument();
     click(buttonByText("Close trigger sidebar"));
 
     await waitFor(() => {
@@ -980,6 +993,110 @@ describe("workflow detail page", () => {
       "webhook-secret",
     );
     expect(screen.getByText(/X-VM0-Signature/)).toBeInTheDocument();
+  });
+
+  it("creates a cron schedule trigger from the preferred time zone", async () => {
+    const createBodies: ZeroWorkflowTriggerCreateRequest[] = [];
+    context.mocks.data.userPreferences({ timezone: "Asia/Shanghai" });
+    mockWorkflowApis([salesResearch()]);
+    mockCreateWorkflowTrigger((body) => {
+      createBodies.push(body);
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/workflows/${SALES_WORKFLOW_ID}`,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Gather CRM context before outreach."),
+      ).toBeInTheDocument();
+    });
+    click(buttonByText(/trigger/i));
+    click(buttonByText("Add trigger"));
+    click(menuItemByText(/Schedule/u));
+
+    const createTriggerForm = await screen.findByRole("form", {
+      name: "Add schedule trigger",
+    });
+    expect(
+      within(createTriggerForm).getByText("Time (Asia/Shanghai)"),
+    ).toBeInTheDocument();
+    expect(within(createTriggerForm).queryByText(/Saved as/u)).toBeNull();
+    click(buttonByText("Add schedule", createTriggerForm));
+
+    await waitFor(() => {
+      expect(createBodies.at(-1)).toStrictEqual({
+        schedule: {
+          type: "cron",
+          cronExpression: "0 1 * * *",
+          timezone: "UTC",
+        },
+      });
+    });
+  });
+
+  it("updates a cron schedule trigger from the preferred time zone", async () => {
+    const updateBodies: {
+      readonly triggerId: string;
+      readonly body: ZeroWorkflowTriggerUpdateRequest;
+    }[] = [];
+    context.mocks.data.userPreferences({ timezone: "Asia/Shanghai" });
+    const workflow = {
+      ...salesResearch(),
+      triggers: [
+        {
+          ...weekdayWorkflowTrigger(),
+          schedule: {
+            type: "cron",
+            cronExpression: "0 1 * * 1-5",
+            timezone: "UTC",
+          },
+        } satisfies WorkflowScheduleTriggerSummary,
+      ],
+    };
+    mockWorkflowApis([workflow]);
+    mockUpdateWorkflowTrigger((triggerId, body) => {
+      updateBodies.push({ triggerId, body });
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/workflows/${SALES_WORKFLOW_ID}`,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Gather CRM context before outreach."),
+      ).toBeInTheDocument();
+    });
+    click(buttonByText(/trigger/i));
+
+    await waitFor(() => {
+      expect(screen.getByText("Every weekday at 9:00 AM")).toBeInTheDocument();
+    });
+    click(screen.getByText("Edit schedule"));
+
+    const updateTriggerForm = screen.getByRole("form", {
+      name: "Update schedule trigger",
+    });
+    selectOptionByLabel("Hour", "16", updateTriggerForm);
+    selectOptionByLabel("Minute", "45", updateTriggerForm);
+    click(buttonByText("Save schedule", updateTriggerForm));
+
+    await waitFor(() => {
+      expect(updateBodies.at(-1)).toStrictEqual({
+        triggerId: "workflow-trigger-weekday-brief",
+        body: {
+          schedule: {
+            type: "cron",
+            cronExpression: "45 8 * * 1-5",
+            timezone: "UTC",
+          },
+        },
+      });
+    });
   });
 
   it("updates a Gmail new message trigger with text match rules", async () => {

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -2,7 +2,7 @@
 // the instruction editor, supplementary file manager (SKILL.md is never shown),
 // triggers, visibility controls, metadata editing, slash use, copy, and delete.
 import type { CSSProperties, FormEvent, ReactNode } from "react";
-import { useGet, useLoadable, useSet } from "ccstate-react";
+import { useGet, useLastResolved, useLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import type {
   GmailLabelAppliedEventConfig,
@@ -62,19 +62,24 @@ import {
   createWorkflowGmailLabelAppliedTrigger$,
   createWorkflowGmailNewMessageTrigger$,
   createWorkflowWebhookTrigger$,
+  createScheduleCronFields$,
   createWorkflowScheduleTrigger$,
   createdWorkflowWebhookTrigger$,
   currentWorkflowId$,
   copyWorkflow$,
+  defaultWorkflowCronFields,
   deleteWorkflow$,
   deleteWorkflowTrigger$,
-  editingGmailTriggerId$,
+  editingScheduleCronFields$,
+  editingWorkflowTriggerId$,
   reloadWorkflows$,
   scheduleTriggerType$,
   selectedWorkflowFilePath$,
+  setCreateScheduleCronFields$,
   setCreatedWorkflowWebhookTrigger$,
+  setEditingScheduleCronFields$,
+  setEditingWorkflowTriggerId$,
   setScheduleTriggerType$,
-  setEditingGmailTriggerId$,
   setSelectedWorkflowFilePath$,
   setWorkflowActionDialog$,
   setWorkflowDetailTriggerSidebarOpen$,
@@ -84,6 +89,7 @@ import {
   setWorkflowTriggerPermissionsDrawerTriggerId$,
   updateWorkflowGmailNewMessageTrigger$,
   updateWorkflowGmailLabelAppliedTrigger$,
+  updateWorkflowScheduleTrigger$,
   updateWorkflow$,
   workflowActionDialog$,
   workflowTriggerCreateDialog$,
@@ -91,6 +97,8 @@ import {
   workflowFileDraft$,
   workflowDetail,
   workflowTriggerPermissionsDrawerTriggerId$,
+  type WorkflowCronFields,
+  type WorkflowCronFrequency,
 } from "../../signals/workflows-page/workflows-signals.ts";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import {
@@ -102,6 +110,13 @@ import { ROUTES } from "../../signals/route-paths.ts";
 import { detachedNavigateTo$ } from "../../signals/route.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { writeToClipboard } from "../../signals/zero-page/clipboard.ts";
+import {
+  atTimeInTimezone,
+  buildCronExpression,
+  cronWallTimeInTimezone,
+  type CronTimeOption,
+} from "../../signals/zero-page/cron.ts";
+import { userPreferences$ } from "../../signals/zero-page/settings/user-preferences.ts";
 import { Link } from "../router/link.tsx";
 import {
   DetailPageBreadcrumbBar,
@@ -151,6 +166,50 @@ const GMAIL_TEXT_FIELDS: readonly {
   { field: "to", label: "To" },
   { field: "cc", label: "Cc" },
 ];
+
+const WORKFLOW_CRON_FREQUENCY_OPTIONS: readonly {
+  readonly value: WorkflowCronFrequency;
+  readonly label: string;
+}[] = [
+  { value: "every_day", label: "Every day" },
+  { value: "every_weekday", label: "Every weekday" },
+  { value: "every_week", label: "Every week" },
+  { value: "every_month", label: "Every month" },
+  { value: "custom", label: "Custom cron" },
+];
+
+const WORKFLOW_CRON_HOUR_OPTIONS: readonly number[] = Array.from(
+  { length: 24 },
+  (_, index) => {
+    return index;
+  },
+);
+
+const WORKFLOW_CRON_MINUTE_OPTIONS: readonly number[] = Array.from(
+  { length: 12 },
+  (_, index) => {
+    return index * 5;
+  },
+);
+
+const WORKFLOW_DAY_OF_WEEK_OPTIONS = [
+  ["1", "Mon"],
+  ["2", "Tue"],
+  ["3", "Wed"],
+  ["4", "Thu"],
+  ["5", "Fri"],
+  ["6", "Sat"],
+  ["0", "Sun"],
+] as const;
+
+const WORKFLOW_CRON_FREQUENCY_TO_TIME_OPTION: Readonly<
+  Record<Exclude<WorkflowCronFrequency, "custom">, CronTimeOption>
+> = Object.freeze({
+  every_day: "every-day",
+  every_weekday: "every-weekday",
+  every_week: "every-week",
+  every_month: "every-month",
+});
 
 function isGmailWorkflowTrigger(
   trigger: ZeroWorkflowTriggerSummary,
@@ -1408,16 +1467,304 @@ async function readUploadedWorkflowFiles(
   );
 }
 
+function browserTimezone(): string {
+  return new Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+}
+
+function timezoneDisplayName(timezone: string): string {
+  return timezone.replace(/_/g, " ");
+}
+
+function formatClockTime(hour: number, minute: number): string {
+  const ampm = hour >= 12 ? "PM" : "AM";
+  const h12 = hour === 0 ? 12 : hour > 12 ? hour - 12 : hour;
+  return `${h12}:${String(minute).padStart(2, "0")} ${ampm}`;
+}
+
+function getWorkflowMinuteOptions(currentMinute: number): readonly number[] {
+  if (WORKFLOW_CRON_MINUTE_OPTIONS.includes(currentMinute)) {
+    return WORKFLOW_CRON_MINUTE_OPTIONS;
+  }
+  return [...WORKFLOW_CRON_MINUTE_OPTIONS, currentMinute].sort((a, b) => {
+    return a - b;
+  });
+}
+
+function parseCronNumber(
+  value: string | undefined,
+  min: number,
+  max: number,
+): number | null {
+  if (!value || !/^\d+$/u.test(value)) {
+    return null;
+  }
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed >= min && parsed <= max
+    ? parsed
+    : null;
+}
+
+function normalizeCronDayOfWeek(day: number): number {
+  return day === 7 ? 0 : day;
+}
+
+function parseCronDayOfWeekList(value: string): readonly number[] | null {
+  const days: number[] = [];
+  for (const part of value.split(",")) {
+    const [startRaw, endRaw] = part.split("-");
+    const start = parseCronNumber(startRaw, 0, 7);
+    const end = parseCronNumber(endRaw ?? startRaw, 0, 7);
+    if (start === null || end === null) {
+      return null;
+    }
+    const normalizedStart = normalizeCronDayOfWeek(start);
+    const normalizedEnd = normalizeCronDayOfWeek(end);
+    if (normalizedStart <= normalizedEnd) {
+      for (let day = normalizedStart; day <= normalizedEnd; day += 1) {
+        days.push(day);
+      }
+    } else {
+      for (let day = normalizedStart; day <= 6; day += 1) {
+        days.push(day);
+      }
+      for (let day = 0; day <= normalizedEnd; day += 1) {
+        days.push(day);
+      }
+    }
+  }
+  const unique = [...new Set(days)];
+  return unique.length > 0
+    ? unique.sort((a, b) => {
+        return a - b;
+      })
+    : null;
+}
+
+function shiftCronDays(
+  days: readonly number[],
+  dayOffset: number,
+): readonly number[] {
+  return [
+    ...new Set(
+      days.map((day) => {
+        return (day + dayOffset + 7) % 7;
+      }),
+    ),
+  ].sort((a, b) => {
+    return a - b;
+  });
+}
+
+function formatCronDayOfWeekList(days: readonly number[]): string {
+  const sorted = [...new Set(days)].sort((a, b) => {
+    return a - b;
+  });
+  const weekdays = [1, 2, 3, 4, 5];
+  if (
+    sorted.length === weekdays.length &&
+    sorted.every((day, index) => {
+      return day === weekdays[index];
+    })
+  ) {
+    return "1-5";
+  }
+  return sorted.join(",");
+}
+
+function sameNumberList(a: readonly number[], b: readonly number[]): boolean {
+  return (
+    a.length === b.length &&
+    a.every((value, index) => {
+      return value === b[index];
+    })
+  );
+}
+
+function shiftedDayOfMonth(
+  dayOfMonth: string,
+  dayOffset: number,
+): string | null {
+  const day = parseCronNumber(dayOfMonth, 1, 31);
+  if (day === null) {
+    return null;
+  }
+  const shifted = day + dayOffset;
+  return shifted >= 1 && shifted <= 31 ? String(shifted) : String(day);
+}
+
+function parseWorkflowCronFields(
+  schedule: Extract<ZeroWorkflowSchedule, { type: "cron" }>,
+  displayTimezone: string,
+): WorkflowCronFields {
+  const parts = schedule.cronExpression.trim().split(/\s+/u);
+  const minute = parseCronNumber(parts[0], 0, 59);
+  const hour = parseCronNumber(parts[1], 0, 23);
+  const dayOfMonth = parts[2] ?? "*";
+  const dayOfWeek = parts[4] ?? "*";
+  if (parts.length !== 5 || minute === null || hour === null) {
+    return {
+      ...defaultWorkflowCronFields(),
+      frequency: "custom",
+      customCronExpression: schedule.cronExpression,
+    };
+  }
+
+  const converted = cronWallTimeInTimezone(
+    hour,
+    minute,
+    schedule.timezone || TRIGGER_TIMEZONE,
+    displayTimezone,
+  );
+  const base = {
+    ...defaultWorkflowCronFields(),
+    hour: converted.hour,
+    minute: converted.minute,
+    customCronExpression: schedule.cronExpression,
+  };
+
+  if (dayOfMonth === "*" && dayOfWeek === "*") {
+    return { ...base, frequency: "every_day" };
+  }
+
+  if (dayOfMonth !== "*" && dayOfWeek === "*") {
+    const displayDayOfMonth = shiftedDayOfMonth(
+      dayOfMonth,
+      converted.dayOffset,
+    );
+    return displayDayOfMonth
+      ? { ...base, frequency: "every_month", dayOfMonth: displayDayOfMonth }
+      : { ...base, frequency: "custom" };
+  }
+
+  if (dayOfMonth === "*" && dayOfWeek !== "*") {
+    const utcDays = parseCronDayOfWeekList(dayOfWeek);
+    if (!utcDays) {
+      return { ...base, frequency: "custom" };
+    }
+    const displayDays = shiftCronDays(utcDays, converted.dayOffset);
+    if (sameNumberList(displayDays, [1, 2, 3, 4, 5])) {
+      return {
+        ...base,
+        frequency: "every_weekday",
+        dayOfWeek: "1,2,3,4,5",
+      };
+    }
+    return {
+      ...base,
+      frequency: "every_week",
+      dayOfWeek: formatCronDayOfWeekList(displayDays),
+    };
+  }
+
+  return { ...base, frequency: "custom" };
+}
+
+function buildUtcCronExpressionFromFields(
+  fields: WorkflowCronFields,
+  displayTimezone: string,
+): string | null {
+  if (fields.frequency === "custom") {
+    const cronExpression = fields.customCronExpression.trim();
+    return cronExpression.length > 0 ? cronExpression : null;
+  }
+
+  const converted = cronWallTimeInTimezone(
+    fields.hour,
+    fields.minute,
+    displayTimezone,
+    TRIGGER_TIMEZONE,
+  );
+  const minute = String(converted.minute);
+  const hour = String(converted.hour);
+
+  if (fields.frequency === "every_weekday") {
+    const days = shiftCronDays([1, 2, 3, 4, 5], converted.dayOffset);
+    return `${minute} ${hour} * * ${formatCronDayOfWeekList(days)}`;
+  }
+  if (fields.frequency === "every_week") {
+    const displayDays = parseCronDayOfWeekList(fields.dayOfWeek);
+    if (!displayDays) {
+      return null;
+    }
+    const days = shiftCronDays(displayDays, converted.dayOffset);
+    return `${minute} ${hour} * * ${formatCronDayOfWeekList(days)}`;
+  }
+  if (fields.frequency === "every_month") {
+    const dayOfMonth = shiftedDayOfMonth(
+      fields.dayOfMonth,
+      converted.dayOffset,
+    );
+    return dayOfMonth ? `${minute} ${hour} ${dayOfMonth} * *` : null;
+  }
+
+  return buildCronExpression({
+    timeOption: WORKFLOW_CRON_FREQUENCY_TO_TIME_OPTION[fields.frequency],
+    hour,
+    minute,
+  });
+}
+
+function workflowScheduleTitle(
+  trigger: ZeroWorkflowTriggerSummary,
+  displayTimezone: string,
+): string {
+  if (trigger.kind !== "schedule") {
+    return workflowTriggerTitle(trigger);
+  }
+  const schedule = trigger.schedule;
+  if (schedule.type === "loop") {
+    return `Every ${schedule.intervalSeconds}s`;
+  }
+  if (schedule.type === "once") {
+    const { date, hour, minute } = atTimeInTimezone(
+      schedule.atTime,
+      displayTimezone,
+    );
+    return `Once on ${date} at ${formatClockTime(hour, minute)}`;
+  }
+
+  const fields = parseWorkflowCronFields(schedule, displayTimezone);
+  if (fields.frequency === "custom") {
+    return `${schedule.cronExpression} (${TRIGGER_TIMEZONE})`;
+  }
+  const time = formatClockTime(fields.hour, fields.minute);
+  if (fields.frequency === "every_day") {
+    return `Every day at ${time}`;
+  }
+  if (fields.frequency === "every_weekday") {
+    return `Every weekday at ${time}`;
+  }
+  if (fields.frequency === "every_month") {
+    return `Every month on day ${fields.dayOfMonth} at ${time}`;
+  }
+  const dayLabels = fields.dayOfWeek
+    .split(",")
+    .map((day) => {
+      return WORKFLOW_DAY_OF_WEEK_OPTIONS.find(([value]) => {
+        return value === day;
+      })?.[1];
+    })
+    .filter(Boolean)
+    .join(", ");
+  return dayLabels
+    ? `Every week on ${dayLabels} at ${time}`
+    : trigger.scheduleSummary;
+}
+
 function buildTriggerSchedule(
   type: ZeroWorkflowScheduleType,
   fields: {
-    readonly cronExpression: string;
+    readonly cronFields: WorkflowCronFields;
     readonly intervalSeconds: string;
     readonly atTime: string;
   },
+  displayTimezone: string,
 ): ZeroWorkflowSchedule | null {
   if (type === "cron") {
-    const cronExpression = fields.cronExpression.trim();
+    const cronExpression = buildUtcCronExpressionFromFields(
+      fields.cronFields,
+      displayTimezone,
+    );
     return cronExpression
       ? { type: "cron", cronExpression, timezone: TRIGGER_TIMEZONE }
       : null;
@@ -1693,8 +2040,10 @@ function TriggersSection({
   const setCreateDialog = useSet(setWorkflowTriggerCreateDialog$);
   const features = useGet(featureSwitch$);
   const userLoadable = useLoadable(user$);
+  const preferences = useLastResolved(userPreferences$);
   const currentUserId =
     userLoadable.state === "hasData" ? (userLoadable.data?.id ?? "") : "";
+  const displayTimezone = preferences?.timezone ?? browserTimezone();
   const triggers = detail.triggers;
   const webhookTriggersEnabled =
     features[FeatureSwitchKey.WorkflowWebhookTriggers] ?? false;
@@ -1732,6 +2081,7 @@ function TriggersSection({
                   key={trigger.id}
                   trigger={trigger}
                   canManage={trigger.ownerUserId === currentUserId}
+                  displayTimezone={displayTimezone}
                   onOpenPermissions={onOpenTriggerPermissions}
                 />
               );
@@ -1745,6 +2095,7 @@ function TriggersSection({
       </div>
       <CreateScheduleTriggerDialog
         workflowId={detail.id}
+        displayTimezone={displayTimezone}
         open={createDialog === "schedule"}
         onOpenChange={(open) => {
           setCreateDialog(open ? "schedule" : null);
@@ -1777,15 +2128,19 @@ function TriggersSection({
 
 function CreateScheduleTriggerDialog({
   workflowId,
+  displayTimezone,
   open,
   onOpenChange,
 }: {
   readonly workflowId: string;
+  readonly displayTimezone: string;
   readonly open: boolean;
   readonly onOpenChange: (open: boolean) => void;
 }) {
   const scheduleType = useGet(scheduleTriggerType$);
   const setScheduleType = useSet(setScheduleTriggerType$);
+  const cronFields = useGet(createScheduleCronFields$);
+  const setCronFields = useSet(setCreateScheduleCronFields$);
   const pageSignal = useGet(pageSignal$);
   const [createLoadable, createScheduleTrigger] = useLoadableSet(
     createWorkflowScheduleTrigger$,
@@ -1807,11 +2162,15 @@ function CreateScheduleTriggerDialog({
           onSubmit={(event) => {
             event.preventDefault();
             const form = new FormData(event.currentTarget);
-            const schedule = buildTriggerSchedule(scheduleType, {
-              cronExpression: String(form.get("cronExpression") ?? ""),
-              intervalSeconds: String(form.get("intervalSeconds") ?? ""),
-              atTime: String(form.get("atTime") ?? ""),
-            });
+            const schedule = buildTriggerSchedule(
+              scheduleType,
+              {
+                cronFields,
+                intervalSeconds: String(form.get("intervalSeconds") ?? ""),
+                atTime: String(form.get("atTime") ?? ""),
+              },
+              displayTimezone,
+            );
             if (!schedule) {
               return;
             }
@@ -1849,6 +2208,9 @@ function CreateScheduleTriggerDialog({
 
           <ScheduleTriggerFields
             scheduleType={scheduleType}
+            cronFields={cronFields}
+            setCronFields={setCronFields}
+            displayTimezone={displayTimezone}
             creating={creating}
           />
 
@@ -1878,9 +2240,15 @@ function CreateScheduleTriggerDialog({
 
 function ScheduleTriggerFields({
   scheduleType,
+  cronFields,
+  setCronFields,
+  displayTimezone,
   creating,
 }: {
   readonly scheduleType: ZeroWorkflowScheduleType;
+  readonly cronFields: WorkflowCronFields;
+  readonly setCronFields: (fields: WorkflowCronFields) => void;
+  readonly displayTimezone: string;
   readonly creating: boolean;
 }) {
   if (scheduleType === "loop") {
@@ -1919,20 +2287,308 @@ function ScheduleTriggerFields({
   }
 
   return (
+    <WorkflowCronFieldsForm
+      fields={cronFields}
+      onChange={setCronFields}
+      displayTimezone={displayTimezone}
+      disabled={creating}
+    />
+  );
+}
+
+function WorkflowCronFieldsForm({
+  fields,
+  onChange,
+  displayTimezone,
+  disabled,
+}: {
+  readonly fields: WorkflowCronFields;
+  readonly onChange: (fields: WorkflowCronFields) => void;
+  readonly displayTimezone: string;
+  readonly disabled: boolean;
+}) {
+  const updateFields = (patch: Partial<WorkflowCronFields>) => {
+    onChange({ ...fields, ...patch });
+  };
+  return (
+    <div className="flex flex-col gap-3">
+      <WorkflowCronFrequencyField
+        frequency={fields.frequency}
+        disabled={disabled}
+        onChange={(frequency) => {
+          updateFields({ frequency });
+        }}
+      />
+
+      {fields.frequency === "custom" ? (
+        <WorkflowCustomCronField
+          value={fields.customCronExpression}
+          disabled={disabled}
+          onChange={(customCronExpression) => {
+            updateFields({ customCronExpression });
+          }}
+        />
+      ) : (
+        <>
+          {fields.frequency === "every_week" ? (
+            <WorkflowDayOfWeekPicker
+              dayOfWeek={fields.dayOfWeek}
+              disabled={disabled}
+              onChange={(dayOfWeek) => {
+                updateFields({ dayOfWeek });
+              }}
+            />
+          ) : null}
+
+          {fields.frequency === "every_month" ? (
+            <WorkflowDayOfMonthField
+              dayOfMonth={fields.dayOfMonth}
+              disabled={disabled}
+              onChange={(dayOfMonth) => {
+                updateFields({ dayOfMonth });
+              }}
+            />
+          ) : null}
+
+          <WorkflowCronTimeField
+            hour={fields.hour}
+            minute={fields.minute}
+            disabled={disabled}
+            onHourChange={(hour) => {
+              updateFields({ hour });
+            }}
+            onMinuteChange={(minute) => {
+              updateFields({ minute });
+            }}
+          />
+        </>
+      )}
+
+      <span className="text-xs text-muted-foreground">
+        Shown in {timezoneDisplayName(displayTimezone)}. Saved as UTC.
+      </span>
+    </div>
+  );
+}
+
+function WorkflowCronFrequencyField({
+  frequency,
+  disabled,
+  onChange,
+}: {
+  readonly frequency: WorkflowCronFrequency;
+  readonly disabled: boolean;
+  readonly onChange: (frequency: WorkflowCronFrequency) => void;
+}) {
+  return (
+    <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+      Repeats
+      <Select
+        value={frequency}
+        disabled={disabled}
+        onValueChange={(value) => {
+          onChange(value as WorkflowCronFrequency);
+        }}
+      >
+        <SelectTrigger className="h-9 w-full">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {WORKFLOW_CRON_FREQUENCY_OPTIONS.map((option) => {
+            return (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            );
+          })}
+        </SelectContent>
+      </Select>
+    </label>
+  );
+}
+
+function WorkflowCustomCronField({
+  value,
+  disabled,
+  onChange,
+}: {
+  readonly value: string;
+  readonly disabled: boolean;
+  readonly onChange: (value: string) => void;
+}) {
+  return (
     <label className="flex flex-col gap-1 text-xs text-muted-foreground">
       Cron expression
       <input
-        name="cronExpression"
         aria-label="Cron expression"
-        defaultValue="0 9 * * *"
-        disabled={creating}
+        value={value}
+        disabled={disabled}
         placeholder="0 9 * * *"
         className={FIELD_CLASS}
+        onChange={(event) => {
+          onChange(event.currentTarget.value);
+        }}
       />
-      <span className="text-xs text-muted-foreground">
-        Runs in {TRIGGER_TIMEZONE}.
-      </span>
     </label>
+  );
+}
+
+function WorkflowDayOfMonthField({
+  dayOfMonth,
+  disabled,
+  onChange,
+}: {
+  readonly dayOfMonth: string;
+  readonly disabled: boolean;
+  readonly onChange: (dayOfMonth: string) => void;
+}) {
+  return (
+    <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+      Day of month
+      <Select value={dayOfMonth} disabled={disabled} onValueChange={onChange}>
+        <SelectTrigger className="h-9 w-full" aria-label="Day of month">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {Array.from({ length: 31 }, (_, index) => {
+            const day = String(index + 1);
+            return (
+              <SelectItem key={day} value={day}>
+                {day}
+              </SelectItem>
+            );
+          })}
+        </SelectContent>
+      </Select>
+    </label>
+  );
+}
+
+function WorkflowCronTimeField({
+  hour,
+  minute,
+  disabled,
+  onHourChange,
+  onMinuteChange,
+}: {
+  readonly hour: number;
+  readonly minute: number;
+  readonly disabled: boolean;
+  readonly onHourChange: (hour: number) => void;
+  readonly onMinuteChange: (minute: number) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-xs text-muted-foreground">Time</span>
+      <div className="flex items-center gap-2">
+        <WorkflowNumberSelect
+          value={hour}
+          options={WORKFLOW_CRON_HOUR_OPTIONS}
+          disabled={disabled}
+          ariaLabel="Hour"
+          onChange={onHourChange}
+        />
+        <span className="text-muted-foreground">:</span>
+        <WorkflowNumberSelect
+          value={minute}
+          options={getWorkflowMinuteOptions(minute)}
+          disabled={disabled}
+          ariaLabel="Minute"
+          onChange={onMinuteChange}
+        />
+      </div>
+    </div>
+  );
+}
+
+function WorkflowNumberSelect({
+  value,
+  options,
+  disabled,
+  ariaLabel,
+  onChange,
+}: {
+  readonly value: number;
+  readonly options: readonly number[];
+  readonly disabled: boolean;
+  readonly ariaLabel: string;
+  readonly onChange: (value: number) => void;
+}) {
+  return (
+    <Select
+      value={String(value)}
+      disabled={disabled}
+      onValueChange={(nextValue) => {
+        onChange(Number(nextValue));
+      }}
+    >
+      <SelectTrigger className="h-9 w-20" aria-label={ariaLabel}>
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {options.map((option) => {
+          return (
+            <SelectItem key={option} value={String(option)}>
+              {String(option).padStart(2, "0")}
+            </SelectItem>
+          );
+        })}
+      </SelectContent>
+    </Select>
+  );
+}
+
+function WorkflowDayOfWeekPicker({
+  dayOfWeek,
+  disabled,
+  onChange,
+}: {
+  readonly dayOfWeek: string;
+  readonly disabled: boolean;
+  readonly onChange: (dayOfWeek: string) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-xs text-muted-foreground">Day of week</span>
+      <div className="flex flex-wrap gap-1">
+        {WORKFLOW_DAY_OF_WEEK_OPTIONS.map(([value, label]) => {
+          const selected = dayOfWeek.split(",").includes(value);
+          return (
+            <button
+              key={value}
+              type="button"
+              disabled={disabled}
+              aria-pressed={selected}
+              className={cn(
+                "h-8 min-w-10 rounded-md border px-2 text-xs font-medium transition-colors disabled:opacity-60",
+                selected
+                  ? "border-primary bg-primary text-primary-foreground"
+                  : "border-border/60 bg-background text-muted-foreground hover:bg-muted",
+              )}
+              onClick={() => {
+                const current = dayOfWeek.split(",").filter(Boolean);
+                if (selected) {
+                  if (current.length <= 1) {
+                    return;
+                  }
+                  onChange(
+                    current
+                      .filter((day) => {
+                        return day !== value;
+                      })
+                      .join(","),
+                  );
+                  return;
+                }
+                onChange([...current, value].join(","));
+              }}
+            >
+              {label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
   );
 }
 
@@ -2307,17 +2963,18 @@ function CreateWebhookTriggerView({
 function TriggerRow({
   trigger,
   canManage,
+  displayTimezone,
   onOpenPermissions,
 }: {
   readonly trigger: ZeroWorkflowTriggerSummary;
   readonly canManage: boolean;
+  readonly displayTimezone: string;
   readonly onOpenPermissions: (triggerId: string) => void;
 }) {
-  const editingTriggerId = useGet(editingGmailTriggerId$);
-  const setEditingTriggerId = useSet(setEditingGmailTriggerId$);
-  const editingMatch =
-    isGmailWorkflowTrigger(trigger) && editingTriggerId === trigger.id;
-  const title = workflowTriggerTitle(trigger);
+  const editingTriggerId = useGet(editingWorkflowTriggerId$);
+  const setEditingTriggerId = useSet(setEditingWorkflowTriggerId$);
+  const editing = editingTriggerId === trigger.id;
+  const title = workflowScheduleTitle(trigger, displayTimezone);
   const matchSummary = workflowTriggerSummary(trigger);
   const TriggerIcon =
     trigger.kind === "schedule"
@@ -2372,14 +3029,24 @@ function TriggerRow({
         {canManage ? (
           <TriggerControls
             trigger={trigger}
-            editingMatch={editingMatch}
+            editing={editing}
+            displayTimezone={displayTimezone}
             onOpenPermissions={onOpenPermissions}
+          />
+        ) : null}
+        {canManage && trigger.kind === "schedule" && editing ? (
+          <UpdateScheduleTriggerForm
+            trigger={trigger}
+            displayTimezone={displayTimezone}
+            onCancel={() => {
+              setEditingTriggerId(null);
+            }}
           />
         ) : null}
         {canManage &&
         trigger.kind === "event" &&
         trigger.eventType === "gmail-new-message" &&
-        editingMatch ? (
+        editing ? (
           <UpdateGmailNewMessageTriggerForm
             trigger={trigger}
             onCancel={() => {
@@ -2390,7 +3057,7 @@ function TriggerRow({
         {canManage &&
         trigger.kind === "event" &&
         trigger.eventType === "gmail-label-applied" &&
-        editingMatch ? (
+        editing ? (
           <UpdateGmailLabelAppliedTriggerForm
             trigger={trigger}
             onCancel={() => {
@@ -2405,15 +3072,18 @@ function TriggerRow({
 
 function TriggerControls({
   trigger,
-  editingMatch,
+  editing,
+  displayTimezone,
   onOpenPermissions,
 }: {
   readonly trigger: ZeroWorkflowTriggerSummary;
-  readonly editingMatch: boolean;
+  readonly editing: boolean;
+  readonly displayTimezone: string;
   readonly onOpenPermissions: (triggerId: string) => void;
 }) {
   const pageSignal = useGet(pageSignal$);
-  const setEditingTriggerId = useSet(setEditingGmailTriggerId$);
+  const setEditingTriggerId = useSet(setEditingWorkflowTriggerId$);
+  const setEditingScheduleCronFields = useSet(setEditingScheduleCronFields$);
   const [enabledLoadable, setEnabled] = useLoadableSet(
     setWorkflowTriggerEnabled$,
   );
@@ -2422,6 +3092,9 @@ function TriggerControls({
   );
   const busy =
     enabledLoadable.state === "loading" || deleteLoadable.state === "loading";
+  const canEdit =
+    isGmailWorkflowTrigger(trigger) ||
+    (trigger.kind === "schedule" && trigger.schedule.type === "cron");
 
   return (
     <div className="mt-1 flex items-center gap-2">
@@ -2436,18 +3109,28 @@ function TriggerControls({
         <IconShieldLock size={13} stroke={1.5} />
         <span>Permissions</span>
       </button>
-      {isGmailWorkflowTrigger(trigger) && !editingMatch ? (
+      {canEdit && !editing ? (
         <button
           type="button"
           disabled={busy}
           className="text-xs text-muted-foreground transition-colors hover:text-foreground disabled:opacity-60"
           onClick={() => {
+            if (
+              trigger.kind === "schedule" &&
+              trigger.schedule.type === "cron"
+            ) {
+              setEditingScheduleCronFields(
+                parseWorkflowCronFields(trigger.schedule, displayTimezone),
+              );
+            }
             setEditingTriggerId(trigger.id);
           }}
         >
-          {trigger.eventType === "gmail-label-applied"
-            ? "Edit label"
-            : "Edit match"}
+          {trigger.kind === "schedule"
+            ? "Edit schedule"
+            : trigger.eventType === "gmail-label-applied"
+              ? "Edit label"
+              : "Edit match"}
         </button>
       ) : null}
       <button
@@ -2477,6 +3160,90 @@ function TriggerControls({
         Delete
       </button>
     </div>
+  );
+}
+
+function UpdateScheduleTriggerForm({
+  trigger,
+  displayTimezone,
+  onCancel,
+}: {
+  readonly trigger: Extract<ZeroWorkflowTriggerSummary, { kind: "schedule" }>;
+  readonly displayTimezone: string;
+  readonly onCancel: () => void;
+}) {
+  const cronFields = useGet(editingScheduleCronFields$);
+  const setCronFields = useSet(setEditingScheduleCronFields$);
+  const pageSignal = useGet(pageSignal$);
+  const [updateLoadable, updateScheduleTrigger] = useLoadableSet(
+    updateWorkflowScheduleTrigger$,
+  );
+  const saving = updateLoadable.state === "loading";
+
+  return (
+    <form
+      aria-label="Update schedule trigger"
+      className="mt-2 rounded-md border border-border/60 bg-background/70 p-2"
+      onSubmit={(event) => {
+        event.preventDefault();
+        const cronExpression = buildUtcCronExpressionFromFields(
+          cronFields,
+          displayTimezone,
+        );
+        if (!cronExpression) {
+          return;
+        }
+        detach(
+          (async () => {
+            await updateScheduleTrigger(
+              {
+                triggerId: trigger.id,
+                schedule: {
+                  type: "cron",
+                  cronExpression,
+                  timezone: TRIGGER_TIMEZONE,
+                },
+              },
+              pageSignal,
+            );
+            onCancel();
+          })(),
+          Reason.DomCallback,
+        );
+      }}
+    >
+      <WorkflowCronFieldsForm
+        fields={cronFields}
+        onChange={setCronFields}
+        displayTimezone={displayTimezone}
+        disabled={saving}
+      />
+      <div className="mt-2 flex items-center gap-2">
+        <button
+          type="submit"
+          disabled={saving}
+          className={cn(
+            "zero-btn-morandi inline-flex h-8 shrink-0 items-center justify-center gap-1.5 rounded-md px-2 text-xs",
+            saving ? "cursor-not-allowed opacity-60" : "",
+          )}
+        >
+          {saving ? (
+            <IconLoader2 size={13} className="animate-spin" />
+          ) : (
+            <IconClock size={13} stroke={1.5} />
+          )}
+          <span>Save schedule</span>
+        </button>
+        <button
+          type="button"
+          disabled={saving}
+          className="text-xs text-muted-foreground transition-colors hover:text-foreground disabled:opacity-60"
+          onClick={onCancel}
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
   );
 }
 

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -2353,6 +2353,7 @@ function WorkflowCronFieldsForm({
           <WorkflowCronTimeField
             hour={fields.hour}
             minute={fields.minute}
+            displayTimezone={displayTimezone}
             disabled={disabled}
             onHourChange={(hour) => {
               updateFields({ hour });
@@ -2363,10 +2364,6 @@ function WorkflowCronFieldsForm({
           />
         </>
       )}
-
-      <span className="text-xs text-muted-foreground">
-        Shown in {timezoneDisplayName(displayTimezone)}. Saved as UTC.
-      </span>
     </div>
   );
 }
@@ -2467,19 +2464,23 @@ function WorkflowDayOfMonthField({
 function WorkflowCronTimeField({
   hour,
   minute,
+  displayTimezone,
   disabled,
   onHourChange,
   onMinuteChange,
 }: {
   readonly hour: number;
   readonly minute: number;
+  readonly displayTimezone: string;
   readonly disabled: boolean;
   readonly onHourChange: (hour: number) => void;
   readonly onMinuteChange: (minute: number) => void;
 }) {
   return (
     <div className="flex flex-col gap-1">
-      <span className="text-xs text-muted-foreground">Time</span>
+      <span className="text-xs text-muted-foreground">
+        Time ({timezoneDisplayName(displayTimezone)})
+      </span>
       <div className="flex items-center gap-2">
         <WorkflowNumberSelect
           value={hour}

--- a/turbo/apps/platform/src/views/workflows-page/workflow-shared.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-shared.tsx
@@ -166,9 +166,13 @@ export function gmailTriggerSummary(
   if (trigger.kind !== "event") {
     return null;
   }
-  return trigger.eventType === "gmail-label-applied"
-    ? `Label ${quote(trigger.eventConfig.labelName)}`
-    : formatGmailMatchSummary(trigger.eventConfig);
+  if (trigger.eventType === "gmail-label-applied") {
+    return `Label ${quote(trigger.eventConfig.labelName)}`;
+  }
+  if (trigger.eventType === "gmail-new-message") {
+    return formatGmailMatchSummary(trigger.eventConfig);
+  }
+  return null;
 }
 
 export function gmailMatcherDefaultValue(


### PR DESCRIPTION
## Summary
- Add a user-friendly workflow cron trigger form for create and edit flows
- Show/edit time in the user preference timezone while persisting UTC cron schedules
- Label the time field with the timezone instead of showing storage details
- Rebase on the latest workflow trigger sidebar/editing styles from PR #19102

## Validation
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app exec vitest run src/views/workflows-page/__tests__/workflows-page.test.tsx --reporter=dot
- git diff --check