### PR TITLE
perf: start resume history downloads earlier

### DIFF
--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -122,11 +122,6 @@ pub(super) async fn handle_discovered_job(job: DiscoveredJob, mut ctx: Discovere
     } = admission;
     let pre_spawn_timing = RunnerPreSpawnTiming::start_after_claim();
     let resume_session_valid = validate_resume_session_id(claimed.context()).is_ok();
-    let session_history_materializer = start_session_history_materializer_after_claim(
-        &ctx.spawn_ctx.exec_config.http,
-        claimed.context(),
-        resume_session_valid,
-    );
     let active_cli_agent_session_guard = ActiveCliAgentSessionGuard::new(
         ctx.spawn_ctx.active_cli_agent_sessions.clone(),
         if resume_session_valid {
@@ -134,6 +129,11 @@ pub(super) async fn handle_discovered_job(job: DiscoveredJob, mut ctx: Discovere
         } else {
             None
         },
+    );
+    let session_history_materializer = start_session_history_materializer_after_claim(
+        &ctx.spawn_ctx.exec_config.http,
+        claimed.context(),
+        resume_session_valid,
     );
     info!(run_id = %run_id, profile = %profile_name, "job claimed, spawning executor");
     let device_rate_limits = crate::io_limits::device_rate_limits_for_context(

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -21,7 +21,10 @@ use super::idle_lifecycle::{
 };
 use super::job_spawn::{JobProfile, SpawnContext, SpawnJobRequest, spawn_job};
 use crate::config::ProfileConfig;
-use crate::executor::{RunnerPreSpawnTiming, validate_resume_session_id};
+use crate::executor::{
+    RunnerPreSpawnTiming, SessionHistoryMaterializer, validate_resume_session_id,
+};
+use crate::http::HttpClient;
 use crate::idle_pool::{IdlePoolSnapshot, IdleUnparkResult, ReusableIdleSandbox};
 use crate::ids::RunId;
 use crate::paths::diagnostic_session_fingerprint;
@@ -119,6 +122,11 @@ pub(super) async fn handle_discovered_job(job: DiscoveredJob, mut ctx: Discovere
     } = admission;
     let pre_spawn_timing = RunnerPreSpawnTiming::start_after_claim();
     let resume_session_valid = validate_resume_session_id(claimed.context()).is_ok();
+    let session_history_materializer = start_session_history_materializer_after_claim(
+        &ctx.spawn_ctx.exec_config.http,
+        claimed.context(),
+        resume_session_valid,
+    );
     let active_cli_agent_session_guard = ActiveCliAgentSessionGuard::new(
         ctx.spawn_ctx.active_cli_agent_sessions.clone(),
         if resume_session_valid {
@@ -182,11 +190,28 @@ pub(super) async fn handle_discovered_job(job: DiscoveredJob, mut ctx: Discovere
             reuse_entry,
             reuse_result,
             pre_spawn_timing,
+            session_history_materializer,
             active_cli_agent_session_guard,
         },
         ctx.spawn_ctx,
         ctx.jobs,
     );
+}
+
+fn start_session_history_materializer_after_claim(
+    http: &HttpClient,
+    context: &ExecutionContext,
+    resume_session_valid: bool,
+) -> Option<SessionHistoryMaterializer> {
+    if !resume_session_valid {
+        return None;
+    }
+    let resume_session = context.resume_session.as_ref()?;
+    resume_session.history_ref()?;
+    Some(SessionHistoryMaterializer::start(
+        http,
+        Some(resume_session),
+    ))
 }
 
 async fn publish_active_run_status(

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -134,6 +134,7 @@ pub(super) async fn handle_discovered_job(job: DiscoveredJob, mut ctx: Discovere
         &ctx.spawn_ctx.exec_config.http,
         claimed.context(),
         resume_session_valid,
+        &job_cancel,
     );
     info!(run_id = %run_id, profile = %profile_name, "job claimed, spawning executor");
     let device_rate_limits = crate::io_limits::device_rate_limits_for_context(
@@ -202,15 +203,17 @@ fn start_session_history_materializer_after_claim(
     http: &HttpClient,
     context: &ExecutionContext,
     resume_session_valid: bool,
+    cancel: &RunCancellationHandle,
 ) -> Option<SessionHistoryMaterializer> {
     if !resume_session_valid {
         return None;
     }
     let resume_session = context.resume_session.as_ref()?;
     resume_session.history_ref()?;
-    Some(SessionHistoryMaterializer::start(
+    Some(SessionHistoryMaterializer::start_cancellable(
         http,
         Some(resume_session),
+        cancel.token(),
     ))
 }
 

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -26,7 +26,9 @@ use super::ownership::{OwnershipTransitions, RunSandbox};
 use super::sandbox_finalization::{FinalizeContext, finalize_sandbox_for_completion};
 #[cfg(test)]
 use super::{OuterJobPanicPoint, StartLoopTestObserver, maybe_panic_outer_job};
-use crate::executor::{self, ExecutionFailureKind, ExecutorConfig, RunnerPreSpawnTiming};
+use crate::executor::{
+    self, ExecutionFailureKind, ExecutorConfig, RunnerPreSpawnTiming, SessionHistoryMaterializer,
+};
 use crate::idle_pool::{ParkingGate, ReusableIdleSandbox};
 use crate::ids::RunId;
 use crate::network_log_drain::NetworkLogDrainCoordinator;
@@ -86,6 +88,7 @@ pub(super) struct SpawnJobRequest {
     pub(super) reuse_entry: Option<ReusableIdleSandbox>,
     pub(super) reuse_result: SandboxReuseResult,
     pub(super) pre_spawn_timing: RunnerPreSpawnTiming,
+    pub(super) session_history_materializer: Option<SessionHistoryMaterializer>,
     pub(super) active_cli_agent_session_guard: ActiveCliAgentSessionGuard,
 }
 
@@ -99,6 +102,7 @@ struct ExecutorInvocation {
     reuse_entry: Option<ReusableIdleSandbox>,
     reuse_result: SandboxReuseResult,
     pre_spawn_timing: RunnerPreSpawnTiming,
+    session_history_materializer: Option<SessionHistoryMaterializer>,
     cancel: CancellationToken,
     sandbox_token: String,
     sandbox_prepared: Option<executor::SandboxPreparedNotifier>,
@@ -124,6 +128,7 @@ impl ExecutorInvocation {
             reuse_entry,
             reuse_result,
             pre_spawn_timing,
+            session_history_materializer,
             cancel,
             sandbox_token,
             sandbox_prepared,
@@ -136,14 +141,18 @@ impl ExecutorInvocation {
         // still reports completion and releases budget.
         let inner = tokio::spawn(async move {
             if let Some(idle_entry) = reuse_entry {
-                executor::execute_job_reuse_with_active_input_source(
+                executor::execute_job_reuse_with_hooks(
                     idle_entry,
                     context,
                     &exec_config,
                     &params,
                     cancel_for_executor,
-                    active_input_source,
-                    Some(pre_spawn_timing),
+                    executor::ExecutionHooks {
+                        sandbox_prepared: None,
+                        active_input_source,
+                        pre_spawn_timing: Some(pre_spawn_timing),
+                        session_history_materializer,
+                    },
                 )
                 .await
             } else {
@@ -161,6 +170,7 @@ impl ExecutorInvocation {
                         sandbox_prepared,
                         active_input_source,
                         pre_spawn_timing: Some(pre_spawn_timing),
+                        session_history_materializer,
                     },
                 )
                 .await
@@ -440,6 +450,7 @@ pub(super) fn spawn_job(
         reuse_entry,
         reuse_result,
         pre_spawn_timing,
+        session_history_materializer,
         active_cli_agent_session_guard,
     } = request;
     let (context, completion_auth, active_input_source) = claimed.into_parts();
@@ -529,6 +540,7 @@ pub(super) fn spawn_job(
         reuse_entry,
         reuse_result,
         pre_spawn_timing,
+        session_history_materializer,
         cancel: job_cancel.token(),
         sandbox_token: sandbox_token.clone(),
         sandbox_prepared,

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -216,6 +216,7 @@ pub(super) struct RunControls {
     pub(super) cancel: CancellationToken,
     pub(super) active_input_source: Option<ActiveInputSource>,
     pub(super) spawn_timing: Option<RunnerSpawnTiming>,
+    pub(super) session_history_materializer: Option<SessionHistoryMaterializer>,
 }
 
 impl RunControls {
@@ -227,11 +228,20 @@ impl RunControls {
             cancel,
             active_input_source,
             spawn_timing: None,
+            session_history_materializer: None,
         }
     }
 
     pub(super) fn with_spawn_timing(mut self, spawn_timing: RunnerSpawnTiming) -> Self {
         self.spawn_timing = Some(spawn_timing);
+        self
+    }
+
+    pub(super) fn with_session_history_materializer(
+        mut self,
+        materializer: Option<SessionHistoryMaterializer>,
+    ) -> Self {
+        self.session_history_materializer = materializer;
         self
     }
 }
@@ -269,9 +279,11 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         cancel,
         active_input_source,
         spawn_timing,
+        session_history_materializer,
     } = controls;
-    let session_history_materializer =
-        SessionHistoryMaterializer::start(&config.http, context.resume_session.as_ref());
+    let session_history_materializer = session_history_materializer.unwrap_or_else(|| {
+        SessionHistoryMaterializer::start(&config.http, context.resume_session.as_ref())
+    });
 
     // 1. Fix guest clock and reseed entropy (must happen before HTTPS calls).
     //    Needed after snapshot restore (frozen clock) and after idle reuse (drifted clock).
@@ -337,17 +349,37 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         result?;
     }
 
-    // 4. Restore session history. Hash-backed history downloads start before
-    // guest prep/storage download, then materialize here right before restore.
-    let downloaded_resume_session = match session_history_materializer.finish(&cancel).await {
+    // 4. Restore session history. Hash-backed history downloads can start
+    // before sandbox preparation, then materialize here right before restore.
+    let should_record_materialization_wait = session_history_materializer.is_downloading();
+    let materialization_wait_started = Instant::now();
+    let materialization = session_history_materializer.finish(&cancel).await;
+    let materialization_wait = materialization_wait_started.elapsed();
+    let downloaded_resume_session = match materialization {
         SessionHistoryMaterialization::Missing => None,
         SessionHistoryMaterialization::Ready => None,
         SessionHistoryMaterialization::Downloaded { session, elapsed } => {
+            if should_record_materialization_wait {
+                telemetry.record(
+                    "session_history_materialization_wait",
+                    materialization_wait,
+                    true,
+                    None,
+                );
+            }
             telemetry.record("session_history_download", elapsed, true, None);
             Some(session)
         }
         SessionHistoryMaterialization::Failed { elapsed, error } => {
             let error_message = error.to_string();
+            if should_record_materialization_wait {
+                telemetry.record(
+                    "session_history_materialization_wait",
+                    materialization_wait,
+                    false,
+                    Some(&error_message),
+                );
+            }
             telemetry.record(
                 "session_history_download",
                 elapsed,

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -37,6 +37,9 @@ use crate::telemetry::JobTelemetry;
 use crate::types::{ExecutionContext, GuestDownloadManifest};
 
 const AGENT_WRAPPER_STDERR_CAPTURE_LIMIT_BYTES: u32 = 64 * 1024;
+const SESSION_HISTORY_DOWNLOAD_TELEMETRY_ERROR: &str = "session history download failed";
+const SESSION_HISTORY_MATERIALIZATION_WAIT_TELEMETRY_ERROR: &str =
+    "session history materialization failed";
 
 pub(super) fn build_agent_start_command(run_agent_path: &str) -> String {
     let run_agent_path = quote_shell_arg(run_agent_path);
@@ -371,20 +374,19 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
             Some(session)
         }
         SessionHistoryMaterialization::Failed { elapsed, error } => {
-            let error_message = error.to_string();
             if should_record_materialization_wait {
                 telemetry.record(
                     "session_history_materialization_wait",
                     materialization_wait,
                     false,
-                    Some(&error_message),
+                    Some(SESSION_HISTORY_MATERIALIZATION_WAIT_TELEMETRY_ERROR),
                 );
             }
             telemetry.record(
                 "session_history_download",
                 elapsed,
                 false,
-                Some(&error_message),
+                Some(SESSION_HISTORY_DOWNLOAD_TELEMETRY_ERROR),
             );
             return Err(error);
         }

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -285,7 +285,11 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         session_history_materializer,
     } = controls;
     let session_history_materializer = session_history_materializer.unwrap_or_else(|| {
-        SessionHistoryMaterializer::start(&config.http, context.resume_session.as_ref())
+        SessionHistoryMaterializer::start_cancellable(
+            &config.http,
+            context.resume_session.as_ref(),
+            cancel.clone(),
+        )
     });
 
     // 1. Fix guest clock and reseed entropy (must happen before HTTPS calls).

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -37,6 +37,7 @@ mod storage;
 mod telemetry;
 
 pub(crate) use guest_state::{is_valid_guest_timezone_name, restore_guest_state_with_timezone};
+pub(crate) use session_history_download::SessionHistoryMaterializer;
 
 use crate::active_input::ActiveInputSource;
 use agent_run::{ProcessCancelTimeouts, RunControls};
@@ -191,6 +192,7 @@ pub(crate) struct ExecutionHooks {
     pub(crate) sandbox_prepared: Option<SandboxPreparedNotifier>,
     pub(crate) active_input_source: Option<ActiveInputSource>,
     pub(crate) pre_spawn_timing: Option<RunnerPreSpawnTiming>,
+    pub(crate) session_history_materializer: Option<SessionHistoryMaterializer>,
 }
 
 impl ExecutionHooks {
@@ -200,6 +202,7 @@ impl ExecutionHooks {
             sandbox_prepared: None,
             active_input_source: None,
             pre_spawn_timing: None,
+            session_history_materializer: None,
         }
     }
 }
@@ -418,7 +421,13 @@ pub(crate) async fn execute_job_with_prepared_notifier(
     cancel: CancellationToken,
     hooks: ExecutionHooks,
 ) -> (ExecuteOutcome, JobTelemetry) {
-    let spawn_timing = RunnerSpawnTiming::start(hooks.pre_spawn_timing);
+    let ExecutionHooks {
+        sandbox_prepared,
+        active_input_source,
+        pre_spawn_timing,
+        session_history_materializer,
+    } = hooks;
+    let spawn_timing = RunnerSpawnTiming::start(pre_spawn_timing);
     let run_id = context.run_id;
     let mut telemetry =
         JobTelemetry::new(config.http.clone(), run_id, context.sandbox_token.clone());
@@ -451,9 +460,10 @@ pub(crate) async fn execute_job_with_prepared_notifier(
             params,
             &mut telemetry,
             NewSandboxHooks {
-                controls: RunControls::new(cancel, hooks.active_input_source)
-                    .with_spawn_timing(spawn_timing),
-                sandbox_prepared: hooks.sandbox_prepared.as_ref(),
+                controls: RunControls::new(cancel, active_input_source)
+                    .with_spawn_timing(spawn_timing)
+                    .with_session_history_materializer(session_history_materializer),
+                sandbox_prepared: sandbox_prepared.as_ref(),
             },
         )
         .await
@@ -488,27 +498,31 @@ pub async fn execute_job_reuse(
     params: &JobParams,
     cancel: CancellationToken,
 ) -> (ExecuteOutcome, JobTelemetry) {
-    execute_job_reuse_with_active_input_source(
+    execute_job_reuse_with_hooks(
         idle_sandbox,
         context,
         config,
         params,
         cancel,
-        None,
-        None,
+        ExecutionHooks::none(),
     )
     .await
 }
 
-pub(crate) async fn execute_job_reuse_with_active_input_source(
+pub(crate) async fn execute_job_reuse_with_hooks(
     idle_sandbox: ReusableIdleSandbox,
     context: ExecutionContext,
     config: &ExecutorConfig,
     params: &JobParams,
     cancel: CancellationToken,
-    active_input_source: Option<ActiveInputSource>,
-    pre_spawn_timing: Option<RunnerPreSpawnTiming>,
+    hooks: ExecutionHooks,
 ) -> (ExecuteOutcome, JobTelemetry) {
+    let ExecutionHooks {
+        sandbox_prepared: _,
+        active_input_source,
+        pre_spawn_timing,
+        session_history_materializer,
+    } = hooks;
     let spawn_timing = RunnerSpawnTiming::start(pre_spawn_timing);
     let run_id = context.run_id;
     let mut telemetry =
@@ -717,7 +731,9 @@ pub(crate) async fn execute_job_reuse_with_active_input_source(
             config,
             &prev_storage,
             &mut telemetry,
-            RunControls::new(cancel, active_input_source).with_spawn_timing(spawn_timing),
+            RunControls::new(cancel, active_input_source)
+                .with_spawn_timing(spawn_timing)
+                .with_session_history_materializer(session_history_materializer),
         )
         .await;
         outcome.workspace_image = workspace_image;

--- a/crates/runner/src/executor/session_history_download.rs
+++ b/crates/runner/src/executor/session_history_download.rs
@@ -44,22 +44,10 @@ struct SessionHistoryDownloadTaskResult {
 }
 
 impl SessionHistoryMaterializer {
-    pub(crate) fn start(http: &HttpClient, session: Option<&ResumeSession>) -> Self {
-        Self::start_inner(http, session, None)
-    }
-
     pub(crate) fn start_cancellable(
         http: &HttpClient,
         session: Option<&ResumeSession>,
         cancel: CancellationToken,
-    ) -> Self {
-        Self::start_inner(http, session, Some(cancel))
-    }
-
-    fn start_inner(
-        http: &HttpClient,
-        session: Option<&ResumeSession>,
-        cancel: Option<CancellationToken>,
     ) -> Self {
         let Some(session) = session else {
             return Self {
@@ -79,17 +67,12 @@ impl SessionHistoryMaterializer {
             state: SessionHistoryMaterializerState::Downloading {
                 started_at,
                 task: Some(tokio::spawn(async move {
-                    match cancel {
-                        Some(cancel) => {
-                            tokio::select! {
-                                biased;
-                                _ = cancel.cancelled() => {
-                                    SessionHistoryDownloadTaskResult::cancelled(started_at)
-                                }
-                                result = download_resume_session_history_timed(http, session) => result,
-                            }
+                    tokio::select! {
+                        biased;
+                        _ = cancel.cancelled() => {
+                            SessionHistoryDownloadTaskResult::cancelled(started_at)
                         }
-                        None => download_resume_session_history_timed(http, session).await,
+                        result = download_resume_session_history_timed(http, session) => result,
                     }
                 })),
             },
@@ -355,6 +338,14 @@ mod tests {
         }
     }
 
+    fn start_materializer(session: &ResumeSession) -> SessionHistoryMaterializer {
+        SessionHistoryMaterializer::start_cancellable(
+            &http_client(),
+            Some(session),
+            CancellationToken::new(),
+        )
+    }
+
     async fn serve_once(
         status: &'static str,
         body: &'static [u8],
@@ -386,7 +377,7 @@ mod tests {
             Some(body.len() as u64),
         );
 
-        let materializer = SessionHistoryMaterializer::start(&http_client(), Some(&session));
+        let materializer = start_materializer(&session);
         let result = materializer.finish(&CancellationToken::new()).await;
 
         match result {
@@ -408,7 +399,7 @@ mod tests {
             Some(6),
         );
 
-        let result = SessionHistoryMaterializer::start(&http_client(), Some(&session))
+        let result = start_materializer(&session)
             .finish(&CancellationToken::new())
             .await;
 
@@ -432,7 +423,7 @@ mod tests {
             Some(2),
         );
 
-        let result = SessionHistoryMaterializer::start(&http_client(), Some(&session))
+        let result = start_materializer(&session)
             .finish(&CancellationToken::new())
             .await;
 
@@ -454,7 +445,7 @@ mod tests {
             None,
         );
 
-        let result = SessionHistoryMaterializer::start(&http_client(), Some(&session))
+        let result = start_materializer(&session)
             .finish(&CancellationToken::new())
             .await;
 
@@ -497,9 +488,7 @@ mod tests {
         let cancel = CancellationToken::new();
         cancel.cancel();
 
-        let result = SessionHistoryMaterializer::start(&http_client(), Some(&session))
-            .finish(&cancel)
-            .await;
+        let result = start_materializer(&session).finish(&cancel).await;
 
         match result {
             SessionHistoryMaterialization::Failed { error, .. } => {
@@ -532,7 +521,7 @@ mod tests {
             None,
         );
 
-        let materializer = SessionHistoryMaterializer::start(&http_client(), Some(&session));
+        let materializer = start_materializer(&session);
         tokio::time::timeout(Duration::from_secs(5), request_received_rx)
             .await
             .unwrap()

--- a/crates/runner/src/executor/session_history_download.rs
+++ b/crates/runner/src/executor/session_history_download.rs
@@ -571,6 +571,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cancellable_materializer_does_not_request_when_already_cancelled() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let address = listener.local_addr().unwrap();
+        let session = ref_session(
+            format!("http://{address}/history.blob?token=secret"),
+            hex::encode(Sha256::digest(b"")),
+            None,
+        );
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+
+        let materializer = SessionHistoryMaterializer::start_cancellable(
+            &http_client(),
+            Some(&session),
+            cancel.clone(),
+        );
+        let result = materializer.finish(&cancel).await;
+        match result {
+            SessionHistoryMaterialization::Failed { error, .. } => {
+                assert!(error.to_string().contains("cancelled"));
+            }
+            _ => panic!("expected cancelled download"),
+        }
+        let accept_error = listener.accept().unwrap_err();
+        assert_eq!(accept_error.kind(), io::ErrorKind::WouldBlock);
+    }
+
+    #[tokio::test]
     async fn finish_prefers_cancel_over_completed_download_task() {
         let task = tokio::spawn(async {
             SessionHistoryDownloadTaskResult {

--- a/crates/runner/src/executor/session_history_download.rs
+++ b/crates/runner/src/executor/session_history_download.rs
@@ -73,6 +73,7 @@ impl SessionHistoryMaterializer {
                 match cancel {
                     Some(cancel) => {
                         tokio::select! {
+                            biased;
                             _ = cancel.cancelled() => {
                                 SessionHistoryDownloadTaskResult::cancelled(started_at)
                             }
@@ -98,6 +99,10 @@ impl SessionHistoryMaterializer {
             Self::Ready => SessionHistoryMaterialization::Ready,
             Self::Downloading { started_at, task } => {
                 let started_at = *started_at;
+                if cancel.is_cancelled() {
+                    return SessionHistoryDownloadTaskResult::cancelled(started_at)
+                        .into_materialization();
+                }
                 let Some(mut task) = task.take() else {
                     return SessionHistoryMaterialization::Failed {
                         elapsed: Duration::ZERO,
@@ -107,6 +112,7 @@ impl SessionHistoryMaterializer {
                     };
                 };
                 let result = tokio::select! {
+                    biased;
                     _ = cancel.cancelled() => {
                         task.abort();
                         let _ = task.await;
@@ -123,22 +129,26 @@ impl SessionHistoryMaterializer {
                         })
                     }
                 };
-                match result.result {
-                    Ok(session) => SessionHistoryMaterialization::Downloaded {
-                        session,
-                        elapsed: result.elapsed,
-                    },
-                    Err(error) => SessionHistoryMaterialization::Failed {
-                        elapsed: result.elapsed,
-                        error,
-                    },
-                }
+                result.into_materialization()
             }
         }
     }
 }
 
 impl SessionHistoryDownloadTaskResult {
+    fn into_materialization(self) -> SessionHistoryMaterialization {
+        match self.result {
+            Ok(session) => SessionHistoryMaterialization::Downloaded {
+                session,
+                elapsed: self.elapsed,
+            },
+            Err(error) => SessionHistoryMaterialization::Failed {
+                elapsed: self.elapsed,
+                error,
+            },
+        }
+    }
+
     fn cancelled(started_at: Instant) -> Self {
         Self {
             elapsed: started_at.elapsed(),
@@ -552,6 +562,36 @@ mod tests {
             .unwrap();
         assert_eq!(closed, 0);
         let result = materializer.finish(&CancellationToken::new()).await;
+        match result {
+            SessionHistoryMaterialization::Failed { error, .. } => {
+                assert!(error.to_string().contains("cancelled"));
+            }
+            _ => panic!("expected cancelled download"),
+        }
+    }
+
+    #[tokio::test]
+    async fn finish_prefers_cancel_over_completed_download_task() {
+        let task = tokio::spawn(async {
+            SessionHistoryDownloadTaskResult {
+                elapsed: Duration::from_millis(1),
+                result: Ok(ResumeSession::inline(
+                    "sess-123".to_string(),
+                    r#"{"type":"init"}"#.to_string(),
+                )),
+            }
+        });
+        while !task.is_finished() {
+            tokio::task::yield_now().await;
+        }
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+        let materializer = SessionHistoryMaterializer::Downloading {
+            started_at: Instant::now(),
+            task: Some(task),
+        };
+
+        let result = materializer.finish(&cancel).await;
         match result {
             SessionHistoryMaterialization::Failed { error, .. } => {
                 assert!(error.to_string().contains("cancelled"));

--- a/crates/runner/src/executor/session_history_download.rs
+++ b/crates/runner/src/executor/session_history_download.rs
@@ -129,6 +129,10 @@ impl SessionHistoryMaterializer {
                         })
                     }
                 };
+                if cancel.is_cancelled() {
+                    return SessionHistoryDownloadTaskResult::cancelled(started_at)
+                        .into_materialization();
+                }
                 result.into_materialization()
             }
         }
@@ -633,6 +637,36 @@ mod tests {
         }
         let cancel = CancellationToken::new();
         cancel.cancel();
+        let materializer = SessionHistoryMaterializer {
+            state: SessionHistoryMaterializerState::Downloading {
+                started_at: Instant::now(),
+                task: Some(task),
+            },
+        };
+
+        let result = materializer.finish(&cancel).await;
+        match result {
+            SessionHistoryMaterialization::Failed { error, .. } => {
+                assert!(error.to_string().contains("cancelled"));
+            }
+            _ => panic!("expected cancelled download"),
+        }
+    }
+
+    #[tokio::test]
+    async fn finish_prefers_cancel_when_task_cancels_during_join() {
+        let cancel = CancellationToken::new();
+        let cancel_for_task = cancel.clone();
+        let task = tokio::spawn(async move {
+            cancel_for_task.cancel();
+            SessionHistoryDownloadTaskResult {
+                elapsed: Duration::from_millis(1),
+                result: Ok(ResumeSession::inline(
+                    "sess-123".to_string(),
+                    r#"{"type":"init"}"#.to_string(),
+                )),
+            }
+        });
         let materializer = SessionHistoryMaterializer {
             state: SessionHistoryMaterializerState::Downloading {
                 started_at: Instant::now(),

--- a/crates/runner/src/executor/session_history_download.rs
+++ b/crates/runner/src/executor/session_history_download.rs
@@ -213,10 +213,9 @@ async fn download_resume_session_history(
 
     let actual_hash = hex::encode(Sha256::digest(&bytes));
     if actual_hash != history_ref.hash {
-        return Err(RunnerError::Internal(format!(
-            "session history hash mismatch: expected {}, got {actual_hash}",
-            history_ref.hash
-        )));
+        return Err(RunnerError::Internal(
+            "session history hash mismatch".into(),
+        ));
     }
 
     let session_history = String::from_utf8(bytes)
@@ -388,9 +387,11 @@ mod tests {
 
     #[tokio::test]
     async fn materializer_rejects_hash_mismatch_and_redacts_url_query() {
+        let expected_hash = hex::encode(Sha256::digest(b"expected"));
+        let actual_hash = hex::encode(Sha256::digest(b"actual"));
         let session = ref_session(
             serve_once("200 OK", b"actual", Some(6)).await,
-            hex::encode(Sha256::digest(b"expected")),
+            expected_hash.clone(),
             Some(6),
         );
 
@@ -403,6 +404,8 @@ mod tests {
                 let message = error.to_string();
                 assert!(message.contains("hash mismatch"));
                 assert!(!message.contains("token=secret"));
+                assert!(!message.contains(&expected_hash));
+                assert!(!message.contains(&actual_hash));
             }
             _ => panic!("expected failed download"),
         }

--- a/crates/runner/src/executor/session_history_download.rs
+++ b/crates/runner/src/executor/session_history_download.rs
@@ -96,6 +96,10 @@ impl SessionHistoryMaterializer {
             SessionHistoryMaterializerState::Downloading { started_at, task } => {
                 let started_at = *started_at;
                 if cancel.is_cancelled() {
+                    if let Some(task) = task.take() {
+                        task.abort();
+                        let _ = task.await;
+                    }
                     return SessionHistoryDownloadTaskResult::cancelled(started_at)
                         .into_materialization();
                 }

--- a/crates/runner/src/executor/session_history_download.rs
+++ b/crates/runner/src/executor/session_history_download.rs
@@ -478,9 +478,16 @@ mod tests {
     async fn materializer_reports_cancelled_download() {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
-        tokio::spawn(async move {
-            let (_stream, _) = listener.accept().await.unwrap();
-            futures_util::future::pending::<io::Result<()>>().await
+        let shutdown = CancellationToken::new();
+        let shutdown_for_server = shutdown.clone();
+        let server = tokio::spawn(async move {
+            tokio::select! {
+                accepted = listener.accept() => {
+                    let (_stream, _) = accepted.unwrap();
+                    shutdown_for_server.cancelled().await;
+                }
+                _ = shutdown_for_server.cancelled() => {}
+            }
         });
         let session = ref_session(
             format!("http://{address}/history.blob?token=secret"),
@@ -500,6 +507,8 @@ mod tests {
             }
             _ => panic!("expected cancelled download"),
         }
+        shutdown.cancel();
+        server.await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/runner/src/executor/session_history_download.rs
+++ b/crates/runner/src/executor/session_history_download.rs
@@ -41,6 +41,22 @@ pub(crate) struct SessionHistoryDownloadTaskResult {
 
 impl SessionHistoryMaterializer {
     pub(crate) fn start(http: &HttpClient, session: Option<&ResumeSession>) -> Self {
+        Self::start_inner(http, session, None)
+    }
+
+    pub(crate) fn start_cancellable(
+        http: &HttpClient,
+        session: Option<&ResumeSession>,
+        cancel: CancellationToken,
+    ) -> Self {
+        Self::start_inner(http, session, Some(cancel))
+    }
+
+    fn start_inner(
+        http: &HttpClient,
+        session: Option<&ResumeSession>,
+        cancel: Option<CancellationToken>,
+    ) -> Self {
         let Some(session) = session else {
             return Self::Missing;
         };
@@ -50,10 +66,21 @@ impl SessionHistoryMaterializer {
 
         let http = http.clone();
         let session = session.clone();
+        let started_at = Instant::now();
         Self::Downloading {
-            started_at: Instant::now(),
+            started_at,
             task: Some(tokio::spawn(async move {
-                download_resume_session_history_timed(http, session).await
+                match cancel {
+                    Some(cancel) => {
+                        tokio::select! {
+                            _ = cancel.cancelled() => {
+                                SessionHistoryDownloadTaskResult::cancelled(started_at)
+                            }
+                            result = download_resume_session_history_timed(http, session) => result,
+                        }
+                    }
+                    None => download_resume_session_history_timed(http, session).await,
+                }
             })),
         }
     }
@@ -83,12 +110,7 @@ impl SessionHistoryMaterializer {
                     _ = cancel.cancelled() => {
                         task.abort();
                         let _ = task.await;
-                        SessionHistoryDownloadTaskResult {
-                            elapsed: started_at.elapsed(),
-                            result: Err(RunnerError::Internal(
-                                "session history download cancelled".into(),
-                            )),
-                        }
+                        SessionHistoryDownloadTaskResult::cancelled(started_at)
                     }
                     joined = &mut task => {
                         joined.unwrap_or_else(|error| {
@@ -112,6 +134,17 @@ impl SessionHistoryMaterializer {
                     },
                 }
             }
+        }
+    }
+}
+
+impl SessionHistoryDownloadTaskResult {
+    fn cancelled(started_at: Instant) -> Self {
+        Self {
+            elapsed: started_at.elapsed(),
+            result: Err(RunnerError::Internal(
+                "session history download cancelled".into(),
+            )),
         }
     }
 }
@@ -477,5 +510,53 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(closed, 0);
+    }
+
+    #[tokio::test]
+    async fn cancellable_materializer_aborts_pending_download_before_finish() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let (request_received_tx, request_received_rx) = oneshot::channel();
+        let (connection_closed_tx, connection_closed_rx) = oneshot::channel();
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = [0u8; 1024];
+            let _ = stream.read(&mut request).await;
+            let _ = request_received_tx.send(());
+            let mut buf = [0u8; 1];
+            let closed = stream.read(&mut buf).await;
+            let _ = connection_closed_tx.send(closed);
+        });
+        let session = ref_session(
+            format!("http://{address}/history.blob?token=secret"),
+            hex::encode(Sha256::digest(b"")),
+            None,
+        );
+        let cancel = CancellationToken::new();
+
+        let materializer = SessionHistoryMaterializer::start_cancellable(
+            &http_client(),
+            Some(&session),
+            cancel.clone(),
+        );
+        tokio::time::timeout(Duration::from_secs(5), request_received_rx)
+            .await
+            .unwrap()
+            .unwrap();
+        cancel.cancel();
+
+        let closed = tokio::time::timeout(Duration::from_secs(5), connection_closed_rx)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(closed, 0);
+        let result = materializer.finish(&CancellationToken::new()).await;
+        match result {
+            SessionHistoryMaterialization::Failed { error, .. } => {
+                assert!(error.to_string().contains("cancelled"));
+            }
+            _ => panic!("expected cancelled download"),
+        }
     }
 }

--- a/crates/runner/src/executor/session_history_download.rs
+++ b/crates/runner/src/executor/session_history_download.rs
@@ -79,7 +79,7 @@ impl SessionHistoryMaterializer {
         }
     }
 
-    pub(crate) fn is_downloading(&self) -> bool {
+    pub(super) fn is_downloading(&self) -> bool {
         matches!(
             self.state,
             SessionHistoryMaterializerState::Downloading { .. }

--- a/crates/runner/src/executor/session_history_download.rs
+++ b/crates/runner/src/executor/session_history_download.rs
@@ -12,7 +12,7 @@ const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(30);
 // Must stay in sync with RESUME_SESSION_HISTORY_MAX_BYTES in the API contracts.
 const MAX_SESSION_HISTORY_BYTES: u64 = 128 * 1024 * 1024;
 
-pub(super) enum SessionHistoryMaterializer {
+pub(crate) enum SessionHistoryMaterializer {
     Missing,
     Ready,
     Downloading {
@@ -21,7 +21,7 @@ pub(super) enum SessionHistoryMaterializer {
     },
 }
 
-pub(super) enum SessionHistoryMaterialization {
+pub(crate) enum SessionHistoryMaterialization {
     Missing,
     Ready,
     Downloaded {
@@ -34,13 +34,13 @@ pub(super) enum SessionHistoryMaterialization {
     },
 }
 
-pub(super) struct SessionHistoryDownloadTaskResult {
+pub(crate) struct SessionHistoryDownloadTaskResult {
     elapsed: Duration,
     result: RunnerResult<ResumeSession>,
 }
 
 impl SessionHistoryMaterializer {
-    pub(super) fn start(http: &HttpClient, session: Option<&ResumeSession>) -> Self {
+    pub(crate) fn start(http: &HttpClient, session: Option<&ResumeSession>) -> Self {
         let Some(session) = session else {
             return Self::Missing;
         };
@@ -58,7 +58,11 @@ impl SessionHistoryMaterializer {
         }
     }
 
-    pub(super) async fn finish(
+    pub(crate) fn is_downloading(&self) -> bool {
+        matches!(self, Self::Downloading { .. })
+    }
+
+    pub(crate) async fn finish(
         mut self,
         cancel: &CancellationToken,
     ) -> SessionHistoryMaterialization {
@@ -266,6 +270,7 @@ mod tests {
 
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
+    use tokio::sync::oneshot;
 
     use super::*;
     use crate::http::{HttpClient, HttpClientConfig};
@@ -436,5 +441,41 @@ mod tests {
             }
             _ => panic!("expected cancelled download"),
         }
+    }
+
+    #[tokio::test]
+    async fn dropping_materializer_aborts_pending_download() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let (request_received_tx, request_received_rx) = oneshot::channel();
+        let (connection_closed_tx, connection_closed_rx) = oneshot::channel();
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = [0u8; 1024];
+            let _ = stream.read(&mut request).await;
+            let _ = request_received_tx.send(());
+            let mut buf = [0u8; 1];
+            let closed = stream.read(&mut buf).await;
+            let _ = connection_closed_tx.send(closed);
+        });
+        let session = ref_session(
+            format!("http://{address}/history.blob?token=secret"),
+            hex::encode(Sha256::digest(b"")),
+            None,
+        );
+
+        let materializer = SessionHistoryMaterializer::start(&http_client(), Some(&session));
+        tokio::time::timeout(Duration::from_secs(5), request_received_rx)
+            .await
+            .unwrap()
+            .unwrap();
+        drop(materializer);
+
+        let closed = tokio::time::timeout(Duration::from_secs(5), connection_closed_rx)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(closed, 0);
     }
 }

--- a/crates/runner/src/executor/session_history_download.rs
+++ b/crates/runner/src/executor/session_history_download.rs
@@ -12,7 +12,11 @@ const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(30);
 // Must stay in sync with RESUME_SESSION_HISTORY_MAX_BYTES in the API contracts.
 const MAX_SESSION_HISTORY_BYTES: u64 = 128 * 1024 * 1024;
 
-pub(crate) enum SessionHistoryMaterializer {
+pub(crate) struct SessionHistoryMaterializer {
+    state: SessionHistoryMaterializerState,
+}
+
+enum SessionHistoryMaterializerState {
     Missing,
     Ready,
     Downloading {
@@ -21,7 +25,7 @@ pub(crate) enum SessionHistoryMaterializer {
     },
 }
 
-pub(crate) enum SessionHistoryMaterialization {
+pub(super) enum SessionHistoryMaterialization {
     Missing,
     Ready,
     Downloaded {
@@ -34,7 +38,7 @@ pub(crate) enum SessionHistoryMaterialization {
     },
 }
 
-pub(crate) struct SessionHistoryDownloadTaskResult {
+struct SessionHistoryDownloadTaskResult {
     elapsed: Duration,
     result: RunnerResult<ResumeSession>,
 }
@@ -58,46 +62,55 @@ impl SessionHistoryMaterializer {
         cancel: Option<CancellationToken>,
     ) -> Self {
         let Some(session) = session else {
-            return Self::Missing;
+            return Self {
+                state: SessionHistoryMaterializerState::Missing,
+            };
         };
         if session.history_ref().is_none() {
-            return Self::Ready;
+            return Self {
+                state: SessionHistoryMaterializerState::Ready,
+            };
         }
 
         let http = http.clone();
         let session = session.clone();
         let started_at = Instant::now();
-        Self::Downloading {
-            started_at,
-            task: Some(tokio::spawn(async move {
-                match cancel {
-                    Some(cancel) => {
-                        tokio::select! {
-                            biased;
-                            _ = cancel.cancelled() => {
-                                SessionHistoryDownloadTaskResult::cancelled(started_at)
+        Self {
+            state: SessionHistoryMaterializerState::Downloading {
+                started_at,
+                task: Some(tokio::spawn(async move {
+                    match cancel {
+                        Some(cancel) => {
+                            tokio::select! {
+                                biased;
+                                _ = cancel.cancelled() => {
+                                    SessionHistoryDownloadTaskResult::cancelled(started_at)
+                                }
+                                result = download_resume_session_history_timed(http, session) => result,
                             }
-                            result = download_resume_session_history_timed(http, session) => result,
                         }
+                        None => download_resume_session_history_timed(http, session).await,
                     }
-                    None => download_resume_session_history_timed(http, session).await,
-                }
-            })),
+                })),
+            },
         }
     }
 
     pub(crate) fn is_downloading(&self) -> bool {
-        matches!(self, Self::Downloading { .. })
+        matches!(
+            self.state,
+            SessionHistoryMaterializerState::Downloading { .. }
+        )
     }
 
-    pub(crate) async fn finish(
+    pub(super) async fn finish(
         mut self,
         cancel: &CancellationToken,
     ) -> SessionHistoryMaterialization {
-        match &mut self {
-            Self::Missing => SessionHistoryMaterialization::Missing,
-            Self::Ready => SessionHistoryMaterialization::Ready,
-            Self::Downloading { started_at, task } => {
+        match &mut self.state {
+            SessionHistoryMaterializerState::Missing => SessionHistoryMaterialization::Missing,
+            SessionHistoryMaterializerState::Ready => SessionHistoryMaterialization::Ready,
+            SessionHistoryMaterializerState::Downloading { started_at, task } => {
                 let started_at = *started_at;
                 if cancel.is_cancelled() {
                     return SessionHistoryDownloadTaskResult::cancelled(started_at)
@@ -161,9 +174,9 @@ impl SessionHistoryDownloadTaskResult {
 
 impl Drop for SessionHistoryMaterializer {
     fn drop(&mut self) {
-        if let Self::Downloading {
+        if let SessionHistoryMaterializerState::Downloading {
             task: Some(task), ..
-        } = self
+        } = &mut self.state
         {
             task.abort();
         }
@@ -618,9 +631,11 @@ mod tests {
         }
         let cancel = CancellationToken::new();
         cancel.cancel();
-        let materializer = SessionHistoryMaterializer::Downloading {
-            started_at: Instant::now(),
-            task: Some(task),
+        let materializer = SessionHistoryMaterializer {
+            state: SessionHistoryMaterializerState::Downloading {
+                started_at: Instant::now(),
+                task: Some(task),
+            },
         };
 
         let result = materializer.finish(&cancel).await;

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -11,13 +11,14 @@ use sandbox_mock::MockSandboxFactory;
 use sha2::{Digest, Sha256};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
+use tokio::sync::{Notify, oneshot};
 
 use super::super::agent_run::{
     ProcessCancelTimeouts, RunControls, RunStart, build_agent_start_command, run_in_sandbox,
 };
 use super::super::diagnostics::AgentStdoutStreamDiagnostics;
 use super::super::storage::guest_download_stdin_command;
-use super::super::{EXIT_SIGKILL, PROCESS_CANCEL_WRITE_TIMEOUT};
+use super::super::{EXIT_SIGKILL, PROCESS_CANCEL_WRITE_TIMEOUT, SessionHistoryMaterializer};
 use super::support::{
     CancelAfterWaitSandbox, RUN_IN_SANDBOX_TEST_TIMEOUT, api_storage, create_overridden_sandbox,
     minimal_context, spawn_run_in_sandbox_test, spawn_run_in_sandbox_test_with_timeouts,
@@ -38,6 +39,29 @@ async fn serve_history_once(body: &'static [u8]) -> String {
         let (mut stream, _) = listener.accept().await.unwrap();
         let mut request = [0u8; 1024];
         let _ = stream.read(&mut request).await;
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            body.len()
+        );
+        stream.write_all(response.as_bytes()).await.unwrap();
+        stream.write_all(body).await.unwrap();
+    });
+    format!("http://{address}/history.blob?token=secret")
+}
+
+async fn serve_history_once_after_request(
+    body: &'static [u8],
+    request_received: oneshot::Sender<()>,
+    release_response: Arc<Notify>,
+) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let mut request = [0u8; 1024];
+        let _ = stream.read(&mut request).await;
+        let _ = request_received.send(());
+        release_response.notified().await;
         let response = format!(
             "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
             body.len()
@@ -282,6 +306,77 @@ async fn run_in_sandbox_materializes_resume_session_history_ref_before_restore()
         "/home/user/.claude/projects/-home-user-workspace/sess-ref-123.jsonl"
     );
     assert_eq!(writes[0].content, history);
+}
+
+#[tokio::test]
+async fn run_in_sandbox_uses_prestarted_session_history_materializer() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let sandbox = sandbox_mock::MockSandbox::new("test");
+    let history = br#"{"type":"init"}"#;
+    let (request_received_tx, request_received_rx) = oneshot::channel();
+    let release_response = Arc::new(Notify::new());
+    let mut ctx = minimal_context();
+    ctx.resume_session = Some(ResumeSession {
+        cli_agent_session_id: "sess-prestarted-123".into(),
+        history: ResumeSessionHistory::Ref {
+            history_ref: ResumeSessionHistoryRef {
+                kind: ResumeSessionHistoryRefKind::Blob,
+                hash: hex::encode(Sha256::digest(history)),
+                url: serve_history_once_after_request(
+                    history,
+                    request_received_tx,
+                    Arc::clone(&release_response),
+                )
+                .await,
+                size: Some(history.len() as u64),
+            },
+        },
+    });
+
+    let materializer = SessionHistoryMaterializer::start(&config.http, ctx.resume_session.as_ref());
+    tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, request_received_rx)
+        .await
+        .unwrap()
+        .unwrap();
+    release_response.notify_one();
+
+    let mut telemetry = test_telemetry(&config, &ctx);
+    let result = run_in_sandbox(
+        &sandbox,
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::PoolMiss,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None)
+            .with_session_history_materializer(Some(materializer)),
+    )
+    .await
+    .unwrap();
+
+    assert!(result.failure.is_none());
+    let writes = sandbox.write_file_calls();
+    assert_eq!(writes.len(), 1);
+    assert_eq!(
+        writes[0].path,
+        "/home/user/.claude/projects/-home-user-workspace/sess-prestarted-123.jsonl"
+    );
+    assert_eq!(writes[0].content, history);
+    let ops = telemetry.pending_ops_snapshot();
+    assert!(
+        ops.iter()
+            .any(|op| op.0 == "session_history_materialization_wait" && op.1),
+        "expected session history wait telemetry, got: {ops:?}"
+    );
+    assert!(
+        ops.iter()
+            .any(|op| op.0 == "session_history_download" && op.1),
+        "expected session history download telemetry, got: {ops:?}"
+    );
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -380,6 +380,69 @@ async fn run_in_sandbox_uses_prestarted_session_history_materializer() {
 }
 
 #[tokio::test]
+async fn run_in_sandbox_redacts_session_history_download_details_from_telemetry() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let sandbox = sandbox_mock::MockSandbox::new("test");
+    let history = br#"{"type":"init"}"#;
+    let expected_hash = hex::encode(Sha256::digest(b"different"));
+    let actual_hash = hex::encode(Sha256::digest(history));
+    let mut ctx = minimal_context();
+    ctx.resume_session = Some(ResumeSession {
+        cli_agent_session_id: "sess-ref-123".into(),
+        history: ResumeSessionHistory::Ref {
+            history_ref: ResumeSessionHistoryRef {
+                kind: ResumeSessionHistoryRefKind::Blob,
+                hash: expected_hash.clone(),
+                url: serve_history_once(history).await,
+                size: Some(history.len() as u64),
+            },
+        },
+    });
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let result = run_in_sandbox(
+        &sandbox,
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::PoolMiss,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None),
+    )
+    .await;
+    let error = match result {
+        Ok(_) => panic!("expected session history hash mismatch error"),
+        Err(error) => error,
+    };
+
+    assert!(error.to_string().contains("hash mismatch"));
+    let ops = telemetry.pending_ops_snapshot();
+    assert!(
+        ops.iter().any(|op| {
+            op.0 == "session_history_materialization_wait"
+                && !op.1
+                && op.2.as_deref() == Some("session history materialization failed")
+        }),
+        "expected redacted session history wait telemetry, got: {ops:?}"
+    );
+    assert!(
+        ops.iter().any(|op| {
+            op.0 == "session_history_download"
+                && !op.1
+                && op.2.as_deref() == Some("session history download failed")
+        }),
+        "expected redacted session history download telemetry, got: {ops:?}"
+    );
+    let telemetry_debug = format!("{ops:?}");
+    assert!(!telemetry_debug.contains(&expected_hash));
+    assert!(!telemetry_debug.contains(&actual_hash));
+}
+
+#[tokio::test]
 async fn run_in_sandbox_folds_timezone_sync_into_restore_exec() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -334,7 +334,11 @@ async fn run_in_sandbox_uses_prestarted_session_history_materializer() {
         },
     });
 
-    let materializer = SessionHistoryMaterializer::start(&config.http, ctx.resume_session.as_ref());
+    let materializer = SessionHistoryMaterializer::start_cancellable(
+        &config.http,
+        ctx.resume_session.as_ref(),
+        tokio_util::sync::CancellationToken::new(),
+    );
     tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, request_received_rx)
         .await
         .unwrap()

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -420,6 +420,8 @@ async fn run_in_sandbox_redacts_session_history_download_details_from_telemetry(
     };
 
     assert!(error.to_string().contains("hash mismatch"));
+    assert!(!error.to_string().contains(&expected_hash));
+    assert!(!error.to_string().contains(&actual_hash));
     let ops = telemetry.pending_ops_snapshot();
     assert!(
         ops.iter().any(|op| {

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -7,7 +7,7 @@ use sandbox_mock::MockSandboxFactory;
 use super::super::telemetry::{elapsed_since_api_start_ms, record_reuse_result};
 use super::super::{
     ExecutionHooks, NewSandboxDispatch, RunnerPreSpawnTiming, execute_job, execute_job_reuse,
-    execute_job_reuse_with_active_input_source, execute_job_with_prepared_notifier,
+    execute_job_reuse_with_hooks, execute_job_with_prepared_notifier,
 };
 use super::support::{
     default_params, make_reusable_idle_sandbox, minimal_context, test_executor_config,
@@ -195,6 +195,7 @@ async fn execute_job_records_runner_pre_spawn_and_fresh_path_timing() {
             sandbox_prepared: None,
             active_input_source: None,
             pre_spawn_timing: Some(RunnerPreSpawnTiming::start_after_claim()),
+            session_history_materializer: None,
         },
     )
     .await;
@@ -243,14 +244,18 @@ async fn execute_job_reuse_records_runner_pre_spawn_and_reuse_path_timing() {
     let cancel = tokio_util::sync::CancellationToken::new();
     let (idle_sandbox, _lease) =
         make_reusable_idle_sandbox(sandbox, outcome.source_ip, "test-session").await;
-    let (_outcome, telemetry) = execute_job_reuse_with_active_input_source(
+    let (_outcome, telemetry) = execute_job_reuse_with_hooks(
         idle_sandbox,
         minimal_context(),
         &config,
         &default_params(),
         cancel,
-        None,
-        Some(RunnerPreSpawnTiming::start_after_claim()),
+        ExecutionHooks {
+            sandbox_prepared: None,
+            active_input_source: None,
+            pre_spawn_timing: Some(RunnerPreSpawnTiming::start_after_claim()),
+            session_history_materializer: None,
+        },
     )
     .await;
 
@@ -302,6 +307,7 @@ async fn start_process_failure_records_phase_failure_without_spawn_completion() 
             sandbox_prepared: None,
             active_input_source: None,
             pre_spawn_timing: Some(RunnerPreSpawnTiming::start_after_claim()),
+            session_history_materializer: None,
         },
     )
     .await;


### PR DESCRIPTION
## Summary
- start ref-backed resume session history materialization after successful claim and valid resume session id
- pass the run-owned materializer through fresh and reused executor paths while keeping guest restore at the existing point
- add restore-point wait telemetry via `session_history_materialization_wait` and cover prestarted/drop-abort paths in tests

Fixes #19117

## Tests
- `cargo test --manifest-path crates/Cargo.toml -p runner session_history`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- pre-commit: cargo-fmt, cargo-doc, cargo-clippy