### PR TITLE
fix: update connector access agent rows

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -45,13 +45,22 @@ function buttonByText(
   text: string,
   container: ParentNode = document.body,
 ): HTMLElement {
-  const button = queryAllByRoleFast("button", container).find((candidate) => {
-    return candidate.textContent?.replace(/\s+/g, " ").trim() === text;
-  });
+  const button = queryButtonByText(text, container);
   if (!button) {
     throw new Error(`${text} button not found`);
   }
   return button;
+}
+
+function queryButtonByText(
+  text: string,
+  container: ParentNode = document.body,
+): HTMLElement | null {
+  return (
+    queryAllByRoleFast("button", container).find((candidate) => {
+      return candidate.textContent?.replace(/\s+/g, " ").trim() === text;
+    }) ?? null
+  );
 }
 
 function queryMenuItemByText(text: string): HTMLElement | null {
@@ -597,6 +606,56 @@ describe("connectors page", () => {
         within(dialog).getByLabelText("Revoke GitHub access for Support Agent"),
       ).toBeInTheDocument();
     });
+  });
+
+  it("hides permission controls for connectors without firewall rules", async () => {
+    const mediaAgentId = "c0000000-0000-4000-a000-000000000003";
+    mockConnectors([
+      {
+        type: "cloudinary",
+        authMethod: "api-token",
+        externalUsername: "demo-cloud",
+      },
+    ]);
+    context.mocks.data.team([teamAgent(mediaAgentId, "Media Agent")]);
+    context.mocks.api(zeroUserConnectorsContract.get, ({ respond }) => {
+      return respond(200, {
+        enabledTypes: ["cloudinary"],
+      });
+    });
+    context.mocks.api(zeroUserPermissionGrantsContract.list, ({ respond }) => {
+      return respond(200, []);
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/connectors",
+      featureSwitches: {
+        [FeatureSwitchKey.ConnectorAccessManagement]: true,
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Cloudinary")).toBeInTheDocument();
+    });
+    click(
+      within(connectorCardByLabel("Cloudinary")).getByLabelText(
+        "Manage Cloudinary access",
+      ),
+    );
+
+    const dialog = await screen.findByRole("dialog", {
+      name: "Manage Cloudinary access",
+    });
+    expect(within(dialog).getByText("Media Agent")).toBeInTheDocument();
+    expect(
+      within(dialog).getByLabelText("Revoke Cloudinary access for Media Agent"),
+    ).toBeInTheDocument();
+    expect(within(dialog).queryByText("Allowed")).not.toBeInTheDocument();
+    expect(
+      within(dialog).queryByText("No configurable permissions"),
+    ).not.toBeInTheDocument();
+    expect(queryButtonByText("Manage", dialog)).not.toBeInTheDocument();
   });
 
   it("shows Google Maps approval guidance before OAuth", async () => {

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-access-management-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-access-management-dialog.tsx
@@ -20,6 +20,7 @@ import {
   type ConnectorType,
 } from "@vm0/connectors/connectors";
 import {
+  hasFirewallMetadataPermissions,
   permissionGrantsToFirewallPolicies,
   resolveFirewallMetadataPolicies,
   type FirewallPermissionDetailMetadata,
@@ -248,6 +249,8 @@ function AgentAccessRow({
 }) {
   const name = agentName(row.agent);
   const canManage = row.authorized && metadata !== null;
+  const showPermissions =
+    row.authorized && hasFirewallMetadataPermissions(connectorType);
 
   return (
     <div className="flex flex-col gap-3 border-b border-border/50 px-1 py-4 last:border-b-0">
@@ -259,10 +262,10 @@ function AgentAccessRow({
         />
         <div className="min-w-0 flex-1">
           <p className="truncate text-sm font-medium text-foreground">{name}</p>
-          <p className="text-xs text-muted-foreground">
-            {row.authorized ? "Authorized" : "Not authorized"}
-          </p>
         </div>
+        <p className="shrink-0 whitespace-nowrap text-xs text-muted-foreground">
+          {row.authorized ? "Authorized" : "Not authorized"}
+        </p>
         <LoadingSwitch
           checked={row.authorized}
           loading={saving}
@@ -273,12 +276,9 @@ function AgentAccessRow({
         />
       </div>
 
-      {row.authorized && (
-        <div className="ml-12 flex items-start justify-between gap-3">
+      {showPermissions && (
+        <div className="ml-12 flex items-center justify-between gap-3">
           <div className="min-w-0 flex-1">
-            <p className="mb-1 text-xs font-medium text-muted-foreground">
-              Allowed
-            </p>
             <AuthorizedPermissionsPreview
               connectorType={connectorType}
               grants={row.grants}


### PR DESCRIPTION
## Summary
- Move the authorized/not authorized state next to the access toggle so agent names stay one line.
- Remove the Allowed label from the permission preview row and keep Manage as the row action.
- Hide permission preview and Manage controls when the connector has no firewall permission rules.

## Verification
- pnpm --filter @vm0/app lint
- pnpm --filter @vm0/app check-types
- pnpm exec vitest run apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx