### PR TITLE
perf: parallelize stored connector secret decrypts

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/fake-kms-client.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/fake-kms-client.ts
@@ -6,6 +6,7 @@ import {
 } from "@aws-sdk/client-kms";
 
 import type { SecretKmsClient } from "../../../services/crypto.utils";
+import { onRejection } from "../../../utils";
 
 type MockKmsCommand = GenerateDataKeyCommand | DecryptCommand;
 type MockKmsResponse = GenerateDataKeyCommandOutput | DecryptCommandOutput;
@@ -19,6 +20,13 @@ interface FakeKmsDecryptContext {
 
 interface FakeKmsClientOptions {
   readonly onDecrypt?: (context: FakeKmsDecryptContext) => void | Promise<void>;
+}
+
+async function runFakeKmsDecryptHook(
+  options: FakeKmsClientOptions,
+  context: FakeKmsDecryptContext,
+): Promise<void> {
+  await options.onDecrypt?.(context);
 }
 
 export function fakeKmsClient(options: FakeKmsClientOptions = {}): {
@@ -51,11 +59,13 @@ export function fakeKmsClient(options: FakeKmsClientOptions = {}): {
 
     inFlightDecrypts += 1;
     maxInFlightDecrypts = Math.max(maxInFlightDecrypts, inFlightDecrypts);
-    await Promise.resolve(
-      options.onDecrypt?.({ command, inFlightDecrypts }),
-    ).finally(() => {
-      inFlightDecrypts -= 1;
-    });
+    await onRejection(
+      runFakeKmsDecryptHook(options, { command, inFlightDecrypts }),
+      () => {
+        inFlightDecrypts -= 1;
+      },
+    );
+    inFlightDecrypts -= 1;
     return { $metadata: {}, Plaintext: dataKey };
   }
 

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/fake-kms-client.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/fake-kms-client.ts
@@ -12,21 +12,33 @@ type MockKmsResponse = GenerateDataKeyCommandOutput | DecryptCommandOutput;
 
 const dataKey = Buffer.from("0123456789abcdef0123456789abcdef", "utf8");
 
-export function fakeKmsClient(): {
+interface FakeKmsDecryptContext {
+  readonly command: DecryptCommand;
+  readonly inFlightDecrypts: number;
+}
+
+interface FakeKmsClientOptions {
+  readonly onDecrypt?: (context: FakeKmsDecryptContext) => void | Promise<void>;
+}
+
+export function fakeKmsClient(options: FakeKmsClientOptions = {}): {
   readonly calls: readonly MockKmsCommand[];
   readonly client: SecretKmsClient;
+  readonly getMaxInFlightDecrypts: () => number;
 } {
   const calls: MockKmsCommand[] = [];
+  let inFlightDecrypts = 0;
+  let maxInFlightDecrypts = 0;
 
   function send(
     command: GenerateDataKeyCommand,
   ): Promise<GenerateDataKeyCommandOutput>;
   function send(command: DecryptCommand): Promise<DecryptCommandOutput>;
-  function send(command: MockKmsCommand): Promise<MockKmsResponse> {
+  async function send(command: MockKmsCommand): Promise<MockKmsResponse> {
     calls.push(command);
 
     if (command instanceof GenerateDataKeyCommand) {
-      return Promise.resolve({
+      return {
         $metadata: {},
         KeyId: command.input.KeyId,
         CiphertextBlob: Buffer.from(
@@ -34,11 +46,24 @@ export function fakeKmsClient(): {
           "utf8",
         ),
         Plaintext: dataKey,
-      });
+      };
     }
 
-    return Promise.resolve({ $metadata: {}, Plaintext: dataKey });
+    inFlightDecrypts += 1;
+    maxInFlightDecrypts = Math.max(maxInFlightDecrypts, inFlightDecrypts);
+    await Promise.resolve(
+      options.onDecrypt?.({ command, inFlightDecrypts }),
+    ).finally(() => {
+      inFlightDecrypts -= 1;
+    });
+    return { $metadata: {}, Plaintext: dataKey };
   }
 
-  return { calls, client: { send } };
+  return {
+    calls,
+    client: { send },
+    getMaxInFlightDecrypts: () => {
+      return maxInFlightDecrypts;
+    },
+  };
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -29,6 +29,11 @@ import { server } from "../../../mocks/server";
 import { writeDb$ } from "../../external/db";
 import { assistantMessageIdForRunEvent } from "../../services/assistant-message-id";
 import {
+  resetSecretKmsClientForTests,
+  setSecretKmsClientForTests,
+} from "../../services/crypto.utils";
+import { settle } from "../../utils";
+import {
   createBddApi,
   expectApiError,
   type ApiTestUser,
@@ -44,6 +49,7 @@ import { createMiscRoutesApi } from "./helpers/api-bdd-misc";
 import { createRunsAutomationsApi } from "./helpers/api-bdd-runs-automations";
 import { createStoragesBddApi } from "./helpers/api-bdd-storages";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
+import { fakeKmsClient } from "./helpers/fake-kms-client";
 
 /**
  * RUN-01..04 and CHAIN-RUN: successful run dispatch and lifecycle.
@@ -1729,6 +1735,98 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     await api.requestCancelRun(actor, withHost.runId, [200]);
     const drained = await api.readRunQueue(actor);
     expect(drained.body.concurrency.active).toBe(0);
+  });
+
+  it("decrypts multiple stored connector secrets with bounded concurrency", async () => {
+    const api = createRunsAutomationsApi(context);
+    const connectors = createConnectorBddApi(context);
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+    await seedVm0ManagedDefaultModelKey();
+
+    await connectors.connectManualGrant(actor, "agora", "api-token", {
+      AGORA_CUSTOMER_ID: "agora-customer-id",
+      AGORA_CUSTOMER_SECRET: "agora-customer-secret",
+      AGORA_APP_ID: "agora-app-id",
+      AGORA_APP_CERTIFICATE: "agora-app-certificate",
+    });
+    await api.enableAgentConnectors(actor, agentId, ["agora"]);
+
+    let releaseDecrypts: (() => void) | undefined;
+    const decryptGate = new Promise<void>((resolve) => {
+      releaseDecrypts = resolve;
+    });
+    const kms = fakeKmsClient({
+      onDecrypt: () => {
+        return decryptGate;
+      },
+    });
+    setSecretKmsClientForTests(kms.client);
+    onTestFinished(() => {
+      releaseDecrypts?.();
+      resetSecretKmsClientForTests();
+    });
+
+    const createRunPromise = api.createRun(actor, {
+      agentId,
+      prompt: "use agora credentials",
+      modelProvider: "vm0",
+    });
+
+    const concurrencyResult = await settle(
+      expect
+        .poll(
+          () => {
+            return kms.getMaxInFlightDecrypts();
+          },
+          { timeout: 10_000 },
+        )
+        .toBeGreaterThan(1),
+    );
+    releaseDecrypts?.();
+
+    const run = await createRunPromise;
+    if (!concurrencyResult.ok) {
+      throw concurrencyResult.error;
+    }
+    expect(kms.getMaxInFlightDecrypts()).toBeLessThanOrEqual(4);
+
+    const timingEvents = apiDispatchTimingEventsForRun(run.runId);
+    expectApiDispatchActions(
+      timingEvents,
+      API_DISPATCH_STORED_CONNECTOR_ROW_ACTION_TYPES,
+    );
+    expectApiDispatchActions(
+      timingEvents,
+      API_DISPATCH_STORED_CONNECTOR_SECRET_ACTION_TYPES,
+    );
+    expectApiDispatchActions(
+      timingEvents,
+      API_DISPATCH_STORED_CONNECTOR_VARIABLE_ACTION_TYPES,
+    );
+
+    await api.heartbeatRunner(runnerGroup);
+    const claim = await api.claimRunnerJob(run.runId);
+
+    expect(claim.environment?.AGORA_CUSTOMER_ID).toBe(
+      connectorPlaceholder("agora", "AGORA_CUSTOMER_ID"),
+    );
+    expect(claim.environment?.AGORA_CUSTOMER_SECRET).toBe(
+      connectorPlaceholder("agora", "AGORA_CUSTOMER_SECRET"),
+    );
+    expect(claim.environment?.AGORA_APP_ID).toBe("agora-app-id");
+    expect(claim.environment?.AGORA_APP_CERTIFICATE).toBe(
+      "agora-app-certificate",
+    );
+    expect(claim.secretConnectorMap).toMatchObject({
+      AGORA_CUSTOMER_ID: "agora",
+      AGORA_CUSTOMER_SECRET: "agora",
+      AGORA_APP_CERTIFICATE: "agora",
+    });
+    expect(claim.secretConnectorMap).not.toHaveProperty("AGORA_APP_ID");
+
+    await api.requestCancelRun(actor, run.runId, [200]);
+    const cancelled = await api.readRun(actor, run.runId);
+    expect(cancelled.status).toBe("cancelled");
   });
 
   it("uses the builtin Figma firewall for personal access tokens", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1,5 +1,6 @@
 import { createHash, randomUUID } from "node:crypto";
 
+import { DecryptCommand } from "@aws-sdk/client-kms";
 import {
   getProviderRuntimeModel,
   getModelProviderFirewall,
@@ -1749,7 +1750,17 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
       AGORA_APP_ID: "agora-app-id",
       AGORA_APP_CERTIFICATE: "agora-app-certificate",
     });
-    await api.enableAgentConnectors(actor, agentId, ["agora"]);
+    await connectors.connectManualGrant(actor, "gitlab", "api-token", {
+      GITLAB_TOKEN: "glpat-bdd-parallel",
+    });
+    await connectors.connectManualGrant(actor, "figma", "api-token", {
+      FIGMA_TOKEN: "figd_bdd-parallel",
+    });
+    await api.enableAgentConnectors(actor, agentId, [
+      "agora",
+      "gitlab",
+      "figma",
+    ]);
 
     let releaseDecrypts: (() => void) | undefined;
     const decryptGate = new Promise<void>((resolve) => {
@@ -1780,7 +1791,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
           },
           { timeout: 10_000 },
         )
-        .toBeGreaterThan(1),
+        .toBe(4),
     );
     releaseDecrypts?.();
 
@@ -1789,6 +1800,11 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
       throw concurrencyResult.error;
     }
     expect(kms.getMaxInFlightDecrypts()).toBeLessThanOrEqual(4);
+    expect(
+      kms.calls.filter((call) => {
+        return call instanceof DecryptCommand;
+      }),
+    ).toHaveLength(5);
 
     const timingEvents = apiDispatchTimingEventsForRun(run.runId);
     expectApiDispatchActions(
@@ -1817,10 +1833,18 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     expect(claim.environment?.AGORA_APP_CERTIFICATE).toBe(
       "agora-app-certificate",
     );
+    expect(claim.environment?.GITLAB_TOKEN).toBe(
+      connectorPlaceholder("gitlab", "GITLAB_TOKEN"),
+    );
+    expect(claim.environment?.FIGMA_TOKEN).toBe(
+      connectorPlaceholder("figma", "FIGMA_TOKEN"),
+    );
     expect(claim.secretConnectorMap).toMatchObject({
       AGORA_CUSTOMER_ID: "agora",
       AGORA_CUSTOMER_SECRET: "agora",
       AGORA_APP_CERTIFICATE: "agora",
+      GITLAB_TOKEN: "gitlab",
+      FIGMA_TOKEN: "figma",
     });
     expect(claim.secretConnectorMap).not.toHaveProperty("AGORA_APP_ID");
 

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1777,11 +1777,13 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
       resetSecretKmsClientForTests();
     });
 
-    const createRunPromise = api.createRun(actor, {
-      agentId,
-      prompt: "use agora credentials",
-      modelProvider: "vm0",
-    });
+    const createRunResultPromise = settle(
+      api.createRun(actor, {
+        agentId,
+        prompt: "use agora credentials",
+        modelProvider: "vm0",
+      }),
+    );
 
     const concurrencyResult = await settle(
       expect
@@ -1795,10 +1797,14 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     );
     releaseDecrypts?.();
 
-    const run = await createRunPromise;
+    const createRunResult = await createRunResultPromise;
+    if (!createRunResult.ok) {
+      throw createRunResult.error;
+    }
     if (!concurrencyResult.ok) {
       throw concurrencyResult.error;
     }
+    const run = createRunResult.value;
     expect(kms.getMaxInFlightDecrypts()).toBeLessThanOrEqual(4);
     expect(
       kms.calls.filter((call) => {

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -175,6 +175,7 @@ type ArtifactMissingRootPolicy = NonNullable<
 >;
 const AUTO_MEMORY_MISSING_ROOT_POLICY: ArtifactMissingRootPolicy =
   "preserveParentVersion";
+const STORED_CONNECTOR_SECRET_DECRYPT_CONCURRENCY = 4;
 
 const TIER_LIMITS = Object.freeze({
   free: 1,
@@ -1804,6 +1805,24 @@ interface StoredConnectorRequirements {
   readonly variableNames: Set<string>;
 }
 
+interface StoredConnectorSecretRow {
+  readonly name: string;
+  readonly encryptedValue: string;
+}
+
+interface StoredConnectorVariableRow {
+  readonly name: string;
+  readonly value: string;
+}
+
+interface StoredConnectorMaterializationSnapshot {
+  readonly allowedConnectorRows: readonly StoredConnectorRuntimeRow[];
+  readonly bindingSets: readonly ConnectorEnvBindingSet[];
+  readonly requirements: StoredConnectorRequirements;
+  readonly secretRows: readonly StoredConnectorSecretRow[];
+  readonly variableRows: readonly StoredConnectorVariableRow[];
+}
+
 interface ResolvedStoredConnectorState {
   readonly secrets: Record<string, string>;
   readonly vars: Record<string, string>;
@@ -1915,21 +1934,71 @@ function collectStoredConnectorRequirements(
   return { secretNames, variableNames };
 }
 
-async function loadStoredConnectorSecrets(
+async function mapWithBoundedConcurrency<TInput, TOutput>(
+  values: readonly TInput[],
+  concurrency: number,
+  mapper: (value: TInput, index: number) => Promise<TOutput>,
+): Promise<TOutput[]> {
+  if (values.length === 0) {
+    return [];
+  }
+
+  const indexedValues = values.map((value, index) => {
+    return { index, value };
+  });
+  const results: ({ readonly value: TOutput } | undefined)[] = Array.from({
+    length: values.length,
+  });
+  const workerCount = Math.min(Math.max(1, concurrency), indexedValues.length);
+  let nextIndex = 0;
+  let stopped = false;
+
+  async function worker(): Promise<void> {
+    while (!stopped) {
+      const item = indexedValues[nextIndex];
+      nextIndex += 1;
+      if (!item) {
+        return;
+      }
+
+      const result = await settle(mapper(item.value, item.index));
+      if (!result.ok) {
+        stopped = true;
+        throw result.error;
+      }
+      results[item.index] = { value: result.value };
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      await worker();
+    }),
+  );
+
+  return indexedValues.map((item) => {
+    const result = results[item.index];
+    if (!result) {
+      throw new Error("Missing bounded concurrency result");
+    }
+    return result.value;
+  });
+}
+
+async function loadStoredConnectorSecretRows(
   db: Db,
   args: {
     readonly orgId: string;
     readonly userId: string;
     readonly names: ReadonlySet<string>;
-    readonly featureSwitchContext: FeatureSwitchContext;
   },
   timing?: ApiDispatchTimingCollector,
-): Promise<Record<string, string>> {
+): Promise<readonly StoredConnectorSecretRow[]> {
   if (args.names.size === 0) {
-    return {};
+    return [];
   }
 
-  const rows = await measureApiDispatchTiming(
+  return await measureApiDispatchTiming(
     timing,
     "api_dispatch_prepare_context_load_stored_connector_secret_rows",
     "nested",
@@ -1950,29 +2019,13 @@ async function loadStoredConnectorSecrets(
         );
     },
   );
-  return await measureApiDispatchTiming(
-    timing,
-    "api_dispatch_prepare_context_decrypt_stored_connector_secrets",
-    "nested",
-    async () => {
-      const values: Record<string, string> = {};
-      for (const row of rows) {
-        values[row.name] = await decryptStoredSecretValue(
-          row.encryptedValue,
-          args.featureSwitchContext,
-        );
-      }
-      return values;
-    },
-  );
 }
 
-async function loadStoredConnectorVariables(
-  db: Db,
+async function decryptStoredConnectorSecrets(
+  rows: readonly StoredConnectorSecretRow[],
   args: {
-    readonly orgId: string;
-    readonly userId: string;
     readonly names: ReadonlySet<string>;
+    readonly featureSwitchContext: FeatureSwitchContext;
   },
   timing?: ApiDispatchTimingCollector,
 ): Promise<Record<string, string>> {
@@ -1980,7 +2033,47 @@ async function loadStoredConnectorVariables(
     return {};
   }
 
-  const rows = await measureApiDispatchTiming(
+  return await measureApiDispatchTiming(
+    timing,
+    "api_dispatch_prepare_context_decrypt_stored_connector_secrets",
+    "nested",
+    async () => {
+      const decryptedRows = await mapWithBoundedConcurrency(
+        rows,
+        STORED_CONNECTOR_SECRET_DECRYPT_CONCURRENCY,
+        async (row) => {
+          return {
+            name: row.name,
+            value: await decryptStoredSecretValue(
+              row.encryptedValue,
+              args.featureSwitchContext,
+            ),
+          };
+        },
+      );
+      const values: Record<string, string> = {};
+      for (const row of decryptedRows) {
+        values[row.name] = row.value;
+      }
+      return values;
+    },
+  );
+}
+
+async function loadStoredConnectorVariableRows(
+  db: Db,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly names: ReadonlySet<string>;
+  },
+  timing?: ApiDispatchTimingCollector,
+): Promise<readonly StoredConnectorVariableRow[]> {
+  if (args.names.size === 0) {
+    return [];
+  }
+
+  return await measureApiDispatchTiming(
     timing,
     "api_dispatch_prepare_context_load_stored_connector_variable_rows",
     "nested",
@@ -2001,6 +2094,11 @@ async function loadStoredConnectorVariables(
         );
     },
   );
+}
+
+function storedConnectorVariablesFromRows(
+  rows: readonly StoredConnectorVariableRow[],
+): Record<string, string> {
   return Object.fromEntries(
     rows.map((row) => {
       return [row.name, row.value];
@@ -2089,6 +2187,64 @@ async function loadStoredConnectorContext(
     ? [...new Set(args.allowedConnectorTypes)]
     : undefined;
 
+  const snapshot = await loadStoredConnectorMaterializationSnapshot(
+    db,
+    {
+      orgId: args.orgId,
+      userId: args.userId,
+      allowedConnectorTypes,
+    },
+    timing,
+  );
+  if (!snapshot) {
+    return emptyConnectorRuntimeContext();
+  }
+
+  const connectorSecrets = await decryptStoredConnectorSecrets(
+    snapshot.secretRows,
+    {
+      names: snapshot.requirements.secretNames,
+      featureSwitchContext: args.featureSwitchContext,
+    },
+    timing,
+  );
+  const connectorVariables = storedConnectorVariablesFromRows(
+    snapshot.variableRows,
+  );
+
+  return await measureApiDispatchTiming(
+    timing,
+    "api_dispatch_prepare_context_build_stored_connector_state",
+    "nested",
+    () => {
+      const resolved = resolveStoredConnectorState(
+        snapshot.bindingSets,
+        connectorSecrets,
+        connectorVariables,
+      );
+
+      return Promise.resolve({
+        secrets: compactRecord(resolved.secrets),
+        vars: compactRecord(resolved.vars),
+        secretConnectorMap: compactRecord(resolved.secretConnectorMap),
+        connectorTypes: snapshot.allowedConnectorRows.map((row) => {
+          return row.connectorType;
+        }),
+        storedEnvironment: compactRecord(resolved.environment),
+      });
+    },
+  );
+}
+
+async function loadStoredConnectorMaterializationSnapshot(
+  db: Db,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly allowedConnectorTypes: readonly ConnectorType[] | undefined;
+  },
+  timing?: ApiDispatchTimingCollector,
+): Promise<StoredConnectorMaterializationSnapshot | null> {
   return await db.transaction(async (tx) => {
     const connectorRows = await measureApiDispatchTiming(
       timing,
@@ -2110,15 +2266,15 @@ async function loadStoredConnectorContext(
             and(
               eq(connectors.orgId, args.orgId),
               eq(connectors.userId, args.userId),
-              allowedConnectorTypes
-                ? inArray(connectors.type, allowedConnectorTypes)
+              args.allowedConnectorTypes
+                ? inArray(connectors.type, args.allowedConnectorTypes)
                 : undefined,
             ),
           );
       },
     );
     if (connectorRows.length === 0) {
-      return emptyConnectorRuntimeContext();
+      return null;
     }
 
     const storedConnectorPlan = await measureApiDispatchTiming(
@@ -2128,7 +2284,7 @@ async function loadStoredConnectorContext(
       () => {
         const allowedConnectorRows = allowedStoredConnectorRows(
           connectorRows,
-          allowedConnectorTypes,
+          args.allowedConnectorTypes,
           nowDate(),
         );
         if (allowedConnectorRows.length === 0) {
@@ -2144,20 +2300,19 @@ async function loadStoredConnectorContext(
       },
     );
     if (!storedConnectorPlan) {
-      return emptyConnectorRuntimeContext();
+      return null;
     }
 
-    const connectorSecrets = await loadStoredConnectorSecrets(
+    const secretRows = await loadStoredConnectorSecretRows(
       tx,
       {
         orgId: args.orgId,
         userId: args.userId,
         names: storedConnectorPlan.requirements.secretNames,
-        featureSwitchContext: args.featureSwitchContext,
       },
       timing,
     );
-    const connectorVariables = await loadStoredConnectorVariables(
+    const variableRows = await loadStoredConnectorVariableRows(
       tx,
       {
         orgId: args.orgId,
@@ -2167,30 +2322,11 @@ async function loadStoredConnectorContext(
       timing,
     );
 
-    return await measureApiDispatchTiming(
-      timing,
-      "api_dispatch_prepare_context_build_stored_connector_state",
-      "nested",
-      () => {
-        const resolved = resolveStoredConnectorState(
-          storedConnectorPlan.bindingSets,
-          connectorSecrets,
-          connectorVariables,
-        );
-
-        return Promise.resolve({
-          secrets: compactRecord(resolved.secrets),
-          vars: compactRecord(resolved.vars),
-          secretConnectorMap: compactRecord(resolved.secretConnectorMap),
-          connectorTypes: storedConnectorPlan.allowedConnectorRows.map(
-            (row) => {
-              return row.connectorType;
-            },
-          ),
-          storedEnvironment: compactRecord(resolved.environment),
-        });
-      },
-    );
+    return {
+      ...storedConnectorPlan,
+      secretRows,
+      variableRows,
+    } satisfies StoredConnectorMaterializationSnapshot;
   });
 }
 

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -121,7 +121,7 @@ import {
 } from "../external/realtime";
 import { now, nowDate } from "../external/time";
 import { generateZeroToken } from "../auth/tokens";
-import { settle, tapError } from "../utils";
+import { onRejection, settle, tapError } from "../utils";
 import {
   environmentRecordToEntries,
   featureFlagsRecordToEntries,
@@ -1961,12 +1961,10 @@ async function mapWithBoundedConcurrency<TInput, TOutput>(
         return;
       }
 
-      const result = await settle(mapper(item.value, item.index));
-      if (!result.ok) {
+      const value = await onRejection(mapper(item.value, item.index), () => {
         stopped = true;
-        throw result.error;
-      }
-      results[item.index] = { value: result.value };
+      });
+      results[item.index] = { value };
     }
   }
 


### PR DESCRIPTION
## Summary

- Split stored connector materialization so the repeatable-read transaction only reads connector, secret, and variable rows.
- Decrypt stored connector secret rows after the transaction with bounded concurrency capped at 4.
- Extend the route-test fake KMS client and add a run lifecycle integration test covering multiple Agora connector secrets, timing spans, and claimed-run context output.

Closes #19121

## Verification

- `pnpm exec prettier --write apps/api/src/signals/services/agent-run-create.service.ts apps/api/src/signals/routes/__tests__/helpers/fake-kms-client.ts apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `pnpm knip --workspace api`

Note: full `pnpm knip` is currently blocked locally by unrelated untracked `packages/connectors/src/firewalls/*.generated.ts` files and existing platform unused exports; the API workspace knip check passes.