### PR TITLE
fix: add ScrapeNinja RapidAPI host header

### DIFF
--- a/crates/runner/mitm-addon/src/generated/builtin_firewalls/diagnostics.py
+++ b/crates/runner/mitm-addon/src/generated/builtin_firewalls/diagnostics.py
@@ -3709,6 +3709,7 @@ CONNECTOR_DIAGNOSTIC_FIREWALLS = json.loads(r"""[
     "apis": [
       {
         "authHeaderNames": [
+          "X-RapidAPI-Host",
           "X-RapidAPI-Key"
         ],
         "authQueryParamNames": [],

--- a/crates/runner/mitm-addon/src/generated/builtin_firewalls/scrapeninja_0.py
+++ b/crates/runner/mitm-addon/src/generated/builtin_firewalls/scrapeninja_0.py
@@ -8,6 +8,7 @@ JSON_PART = r"""{
     {
       "auth": {
         "headers": {
+          "X-RapidAPI-Host": "scrapeninja.p.rapidapi.com",
           "X-RapidAPI-Key": "${{ secrets.SCRAPENINJA_TOKEN }}"
         }
       },

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
@@ -141,10 +141,13 @@ describe("FW-2: template resolution without connector refresh", () => {
           BASIC_USER: "alice",
           BASE_SECRET: "base-secret",
           QUERY_SECRET: "query-secret",
+          SCRAPENINJA_TOKEN: "rapidapi-secret",
           SHARED: "secret-shared",
         }),
         authHeaders: {
           Authorization: `Bearer ${secretTemplate("API_KEY")}`,
+          "X-RapidAPI-Host": "scrapeninja.p.rapidapi.com",
+          "X-RapidAPI-Key": secretTemplate("SCRAPENINJA_TOKEN"),
           "X-Tenant": varTemplate("TENANT"),
           "X-Basic": basicTemplate("secrets.BASIC_USER", "vars.BASIC_PASS"),
           "X-Literal-Basic": basicTemplate('"alice"', '"literal-pass"'),
@@ -164,6 +167,10 @@ describe("FW-2: template resolution without connector refresh", () => {
       throw new Error("Expected firewall auth resolution to succeed");
     }
     expect(resolved.body.headers.Authorization).toBe("Bearer secret-value");
+    expect(resolved.body.headers["X-RapidAPI-Host"]).toBe(
+      "scrapeninja.p.rapidapi.com",
+    );
+    expect(resolved.body.headers["X-RapidAPI-Key"]).toBe("rapidapi-secret");
     expect(resolved.body.headers["X-Tenant"]).toBe("tenant-1");
     expect(resolved.body.headers["X-Basic"]).toBe(
       `Basic ${Buffer.from("alice:var-pass").toString("base64")}`,
@@ -182,6 +189,7 @@ describe("FW-2: template resolution without connector refresh", () => {
     );
     expect(resolved.body.resolvedSecrets).toContain("BASE_SECRET");
     expect(resolved.body.resolvedSecrets).toContain("QUERY_SECRET");
+    expect(resolved.body.resolvedSecrets).toContain("SCRAPENINJA_TOKEN");
   });
 
   it("reports unresolvable template references as connector-not-configured", async () => {

--- a/turbo/packages/connectors/src/connectors/scrapeninja.ts
+++ b/turbo/packages/connectors/src/connectors/scrapeninja.ts
@@ -8,7 +8,7 @@ export const scrapeninja = {
       "Connect your ScrapeNinja account to scrape web pages with Chrome TLS fingerprint and JS rendering",
     authMethods: {
       "api-token": {
-        label: "API Token",
+        label: "RapidAPI Key",
         storage: {
           secrets: ["SCRAPENINJA_TOKEN"],
           variables: [],
@@ -17,7 +17,7 @@ export const scrapeninja = {
           kind: "manual",
           fields: {
             SCRAPENINJA_TOKEN: {
-              label: "API Token",
+              label: "RapidAPI Key",
               required: true,
             },
           },

--- a/turbo/packages/firewalls-generator/src/__tests__/python-builtin-firewall-catalog-composition.test.ts
+++ b/turbo/packages/firewalls-generator/src/__tests__/python-builtin-firewall-catalog-composition.test.ts
@@ -62,6 +62,44 @@ function findGeneratedContent(
   return file.content;
 }
 
+function jsonAssignmentFromContent(content: string, name: string): unknown {
+  const prefix = `${name} = `;
+  const start = content.indexOf(prefix);
+  if (start === -1) {
+    throw new Error(`missing ${name} assignment`);
+  }
+
+  const valueStart = start + prefix.length;
+  const nextAssignment = content.indexOf("\n\n", valueStart);
+  const literal = content
+    .slice(valueStart, nextAssignment === -1 ? content.length : nextAssignment)
+    .trim();
+  if (!literal.startsWith("json.loads(")) {
+    return JSON.parse(literal);
+  }
+
+  const chunks: string[] = [];
+  const stringLiteralPattern = /r"""([\s\S]*?)"""|"(?:\\.|[^"\\])*"/g;
+  for (
+    let match = stringLiteralPattern.exec(literal);
+    match !== null;
+    match = stringLiteralPattern.exec(literal)
+  ) {
+    const rawLiteral = match[1];
+    if (rawLiteral !== undefined) {
+      chunks.push(rawLiteral);
+      continue;
+    }
+    const parsedLiteral: unknown = JSON.parse(match[0]);
+    if (typeof parsedLiteral !== "string") {
+      throw new Error("invalid Python JSON string literal");
+    }
+    chunks.push(parsedLiteral);
+  }
+
+  return JSON.parse(chunks.join(""));
+}
+
 describe("Python builtin firewall catalog composition", () => {
   it(
     "composes connector and caller-provided model-provider firewalls",
@@ -113,6 +151,53 @@ describe("Python builtin firewall catalog composition", () => {
           sessionToken: "${{ secrets.AWS_SESSION_TOKEN }}",
         },
       });
+    },
+    FULL_FIREWALL_SOURCE_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "keeps ScrapeNinja RapidAPI auth headers in the builtin catalog and diagnostics",
+    async () => {
+      const catalog = await buildPythonBuiltinFirewallCatalog({
+        modelProviderFirewalls: [],
+      });
+
+      expect(catalog.firewalls.scrapeninja?.apis[0]).toMatchObject({
+        base: "https://scrapeninja.p.rapidapi.com",
+        auth: {
+          headers: {
+            "X-RapidAPI-Host": "scrapeninja.p.rapidapi.com",
+            "X-RapidAPI-Key": "${{ secrets.SCRAPENINJA_TOKEN }}",
+          },
+        },
+      });
+
+      const files = await renderComposedPythonBuiltinFirewallCatalogFiles({
+        modelProviderFirewalls: [],
+        generatedHeader: TEST_GENERATED_HEADER,
+      });
+      const diagnostics = findGeneratedContent(files, "diagnostics.py");
+
+      expect(
+        jsonAssignmentFromContent(
+          diagnostics,
+          "CONNECTOR_DIAGNOSTIC_FIREWALLS",
+        ),
+      ).toEqual(
+        expect.arrayContaining([
+          {
+            apis: [
+              {
+                authHeaderNames: ["X-RapidAPI-Host", "X-RapidAPI-Key"],
+                authQueryParamNames: [],
+                base: "https://scrapeninja.p.rapidapi.com",
+                envNames: ["SCRAPENINJA_TOKEN"],
+              },
+            ],
+            name: "scrapeninja",
+          },
+        ]),
+      );
     },
     FULL_FIREWALL_SOURCE_TEST_TIMEOUT_MS,
   );

--- a/turbo/packages/firewalls-generator/src/scrapeninja.ts
+++ b/turbo/packages/firewalls-generator/src/scrapeninja.ts
@@ -26,6 +26,7 @@ function generateTypeScript(): string {
     "      auth: {",
     "        headers: {",
     '          "X-RapidAPI-Key": "${{ secrets.SCRAPENINJA_TOKEN }}",',
+    '          "X-RapidAPI-Host": "scrapeninja.p.rapidapi.com",',
     "        },",
     "      },",
     "      permissions: [],",


### PR DESCRIPTION
## Summary
- add the required `X-RapidAPI-Host` header to the ScrapeNinja RapidAPI firewall generator
- regenerate the builtin firewall and connector diagnostics artifacts
- clarify the ScrapeNinja manual credential label as `RapidAPI Key`
- add regression coverage for the generated catalog, diagnostics, and firewall auth header resolution

Fixes #19115

## Tests
- `pnpm format`
- `pnpm -F @vm0/firewalls-generator check-types`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm -F @vm0/firewalls-generator exec vitest src/__tests__/python-builtin-firewall-catalog-composition.test.ts --run`
- `pnpm -F @vm0/firewalls-generator exec vitest --run`
- `pnpm -F @vm0/connectors test`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F api exec vitest src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts --run -t "resolves secret, var, and basic templates"`
- `pytest tests/test_builtin_connector_diagnostics.py`
- pre-commit hook: `knip`, `ruff`, `prettier`, `check-types`