### PR TITLE
fix: saturate telemetry duration milliseconds

### DIFF
--- a/crates/guest-common/src/telemetry.rs
+++ b/crates/guest-common/src/telemetry.rs
@@ -112,7 +112,7 @@ pub fn record_sandbox_op(
     let entry = SandboxOpEntry {
         ts: log::timestamp(),
         action_type: action_type.to_string(),
-        duration_ms: duration.as_millis() as u64,
+        duration_ms: duration_ms(duration),
         success,
         error: error.map(String::from),
     };
@@ -128,6 +128,10 @@ pub fn record_sandbox_op(
     record.push(b'\n');
 
     let _ = append_sandbox_op_record(path, &record);
+}
+
+fn duration_ms(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
 }
 
 fn append_sandbox_op_record(path: &str, record: &[u8]) -> io::Result<()> {
@@ -162,6 +166,7 @@ mod tests {
 
         record_sandbox_op("op_a", Duration::from_millis(10), true, None);
         record_sandbox_op("op_b", Duration::from_millis(20), false, Some("fail"));
+        record_sandbox_op("op_max", Duration::MAX, true, None);
 
         const THREAD_COUNT: usize = 8;
         const RECORDS_PER_THREAD: usize = 64;
@@ -185,7 +190,7 @@ mod tests {
 
         let content = std::fs::read_to_string(log_path).unwrap();
         let lines: Vec<&str> = content.lines().collect();
-        assert_eq!(lines.len(), 2 + THREAD_COUNT * RECORDS_PER_THREAD);
+        assert_eq!(lines.len(), 3 + THREAD_COUNT * RECORDS_PER_THREAD);
 
         let a: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
         assert_eq!(a["action_type"], "op_a");
@@ -198,15 +203,21 @@ mod tests {
         assert_eq!(b["error"], "fail");
         assert!(!b["success"].as_bool().unwrap());
 
+        let max_duration: serde_json::Value = serde_json::from_str(lines[2]).unwrap();
+        assert_eq!(max_duration["action_type"], "op_max");
+        assert_eq!(max_duration["duration_ms"], u64::MAX);
+        assert!(max_duration["success"].as_bool().unwrap());
+
         let mut actions = HashSet::new();
         for line in lines {
             let entry: serde_json::Value = serde_json::from_str(line).unwrap();
             actions.insert(entry["action_type"].as_str().unwrap().to_string());
         }
 
-        assert_eq!(actions.len(), 2 + THREAD_COUNT * RECORDS_PER_THREAD);
+        assert_eq!(actions.len(), 3 + THREAD_COUNT * RECORDS_PER_THREAD);
         assert!(actions.contains("op_a"));
         assert!(actions.contains("op_b"));
+        assert!(actions.contains("op_max"));
         for thread_index in 0..THREAD_COUNT {
             for record_index in 0..RECORDS_PER_THREAD {
                 assert!(actions.contains(&format!("op_{thread_index}_{record_index}")));

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -39,6 +39,7 @@ use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
+use crate::duration::duration_ms as saturated_duration_ms;
 use crate::ids::RunId;
 
 use crate::config::{self, ProfileConfig};
@@ -113,7 +114,7 @@ impl TeardownTimer {
     }
 
     fn duration_ms(duration: Duration) -> u64 {
-        duration.as_millis().min(u128::from(u64::MAX)) as u64
+        saturated_duration_ms(duration)
     }
 
     fn elapsed_ms(&self) -> u64 {

--- a/crates/runner/src/duration.rs
+++ b/crates/runner/src/duration.rs
@@ -1,0 +1,9 @@
+use std::time::Duration;
+
+/// Convert runtime durations for telemetry, metrics, and structured log fields.
+///
+/// Timeout/deadline conversions may need different minimum-value or destination
+/// type semantics, so keep those paths local to their caller.
+pub(crate) fn duration_ms(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -21,6 +21,7 @@ use super::{
     ExecuteOutcome, ExecutionFailure, ExecutorConfig, JobParams, NewSandboxDispatch, RunnerError,
     RunnerResult, SandboxPreparedNotifier, SandboxReuseResult,
 };
+use crate::duration::duration_ms;
 use crate::ids::RunId;
 use crate::network_log_manager::NetworkLogSession;
 use crate::paths::diagnostic_session_fingerprint;
@@ -697,10 +698,6 @@ pub(super) fn log_proxy_register_failure(
         error,
         "proxy register failed"
     );
-}
-
-fn duration_ms(duration: Duration) -> u64 {
-    duration.as_millis() as u64
 }
 
 /// Unregister a VM from the proxy registry.

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -6,6 +6,7 @@ mod cmd;
 mod config;
 mod deps;
 mod dns;
+mod duration;
 mod error;
 mod executor;
 mod group;

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -19,6 +19,7 @@ use super::api_ably_supervisor::{
 use super::{
     ClaimedJob, CompletionAuth, CompletionAuthError, JobCandidate, JobDiscoverySource, JobProvider,
 };
+use crate::duration::duration_ms;
 use crate::error::{RunnerError, RunnerResult};
 use crate::http::HttpClient;
 use crate::ids::RunId;
@@ -630,10 +631,6 @@ fn poll_reason_value(reason: PollReason) -> &'static str {
         PollReason::Slow => "slow",
         PollReason::Fast => "fast",
     }
-}
-
-fn duration_ms(duration: Duration) -> u64 {
-    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
 }
 
 async fn send_api(req: RequestBuilder, label: &str) -> RunnerResult<Response> {

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -59,6 +59,8 @@ struct ClaimRequestTelemetry {
     poll_reason: Option<String>,
 }
 
+const CLAIM_TELEMETRY_DURATION_MS_MAX: u64 = 9_007_199_254_740_991;
+
 #[derive(Debug)]
 struct PollApiResult {
     job: Option<Job>,
@@ -584,18 +586,28 @@ fn claim_request_body(candidate: &JobCandidate) -> ClaimRequestBody {
     ClaimRequestBody {
         telemetry: ClaimRequestTelemetry {
             discovery_source: candidate.discovery_source().map(JobDiscoverySource::as_str),
-            job_discovered_to_claim_request_ms: duration_ms(candidate.job_discovered_elapsed()),
+            job_discovered_to_claim_request_ms: claim_telemetry_duration_ms(
+                candidate.job_discovered_elapsed(),
+            ),
             local_admission_to_claim_request_ms: candidate
                 .local_admission_elapsed()
-                .map(duration_ms),
+                .map(claim_telemetry_duration_ms),
             poll_due_to_job_discovered_ms: candidate
                 .poll_due_to_job_discovered_elapsed()
-                .map(duration_ms),
-            poll_http_request_ms: candidate.poll_http_request_elapsed().map(duration_ms),
+                .map(claim_telemetry_duration_ms),
+            poll_http_request_ms: candidate
+                .poll_http_request_elapsed()
+                .map(claim_telemetry_duration_ms),
             poll_reason: candidate.poll_reason().map(String::from),
         },
         capabilities: [ClaimCapability::ResumeSessionHistoryRef],
     }
+}
+
+fn claim_telemetry_duration_ms(duration: Duration) -> u64 {
+    // The TypeScript claim route validates these fields with z.number().int(),
+    // which rejects values above Number.MAX_SAFE_INTEGER.
+    duration_ms(duration).min(CLAIM_TELEMETRY_DURATION_MS_MAX)
 }
 
 fn poll_request_body(
@@ -1090,6 +1102,27 @@ mod tests {
         assert_eq!(
             body["capabilities"],
             serde_json::json!(["resumeSessionHistoryRef"])
+        );
+    }
+
+    #[test]
+    fn claim_request_body_saturates_wire_timing_to_js_safe_integer() {
+        let candidate =
+            JobCandidate::new(RunId::nil(), crate::profile::DEFAULT_PROFILE.to_string())
+                .with_poll_timing(
+                    Duration::MAX,
+                    Duration::from_millis(CLAIM_TELEMETRY_DURATION_MS_MAX + 1),
+                );
+
+        let body = serde_json::to_value(claim_request_body(&candidate)).unwrap();
+
+        assert_eq!(
+            body["telemetry"]["pollDueToJobDiscoveredMs"],
+            CLAIM_TELEMETRY_DURATION_MS_MAX
+        );
+        assert_eq!(
+            body["telemetry"]["pollHttpRequestMs"],
+            CLAIM_TELEMETRY_DURATION_MS_MAX
         );
     }
 

--- a/crates/runner/src/telemetry.rs
+++ b/crates/runner/src/telemetry.rs
@@ -6,6 +6,7 @@ use serde::Serialize;
 use tokio::task::JoinHandle;
 use tracing::warn;
 
+use crate::duration::duration_ms;
 use crate::http::HttpClient;
 use crate::ids::RunId;
 
@@ -71,7 +72,7 @@ impl JobTelemetry {
         self.pending_ops.push(SandboxOp {
             ts: Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
             action_type: action_type.to_string(),
-            duration_ms: duration.as_millis() as u64,
+            duration_ms: duration_ms(duration),
             success,
             error: error.map(String::from),
         });
@@ -303,6 +304,17 @@ mod tests {
         assert!(!telemetry.pending_ops[1].success);
         assert_eq!(telemetry.pending_ops[1].error.as_deref(), Some("timeout"));
         assert!(telemetry.oldest_pending.is_some());
+    }
+
+    #[test]
+    fn record_saturates_large_duration() {
+        let http = http_client();
+        let mut telemetry = JobTelemetry::new(http, RunId::nil(), "tok".to_string());
+
+        telemetry.record("huge_op", Duration::MAX, true, None);
+
+        assert_eq!(telemetry.pending_ops.len(), 1);
+        assert_eq!(telemetry.pending_ops[0].duration_ms, u64::MAX);
     }
 
     #[tokio::test]

--- a/crates/sandbox-fc/src/cow_pool/state.rs
+++ b/crates/sandbox-fc/src/cow_pool/state.rs
@@ -14,6 +14,7 @@ use super::{
     AcquireResult, BUFFER_SIZE, CowPoolConfig, CowPoolError, MAX_CONCURRENT_SLOT_CREATIONS,
     MAX_SLOTS, PrewarmedSlot, SlotSpawner, WARM_RETRY_BACKOFF, destroy_slot_async,
 };
+use crate::duration::duration_ms;
 
 #[derive(Clone, Copy, Debug)]
 enum CreationPurpose {
@@ -177,7 +178,7 @@ impl CowPool {
 
     fn assign_slot_to_waiter(&mut self, mut slot: PrewarmedSlot) -> AssignOutcome {
         while let Some(waiter) = self.waiters.pop_front() {
-            let waited_ms = waiter.requested_at.elapsed().as_millis() as u64;
+            let waited_ms = duration_ms(waiter.requested_at.elapsed());
             let slot_id = slot.id().to_owned();
             match waiter.respond_to.send(Ok(slot)) {
                 Ok(()) => {
@@ -263,7 +264,7 @@ impl CowPool {
     }
 
     async fn handle_creation_outcome(&mut self, outcome: SlotCreationOutcome) {
-        let elapsed_ms = outcome.elapsed.as_millis() as u64;
+        let elapsed_ms = duration_ms(outcome.elapsed);
         match outcome.result {
             Ok(slot) => {
                 let slot_id = slot.id().to_owned();
@@ -368,7 +369,7 @@ impl CowPool {
         info!(
             pending_at_start,
             ready_at_start,
-            elapsed_ms = started.elapsed().as_millis() as u64,
+            elapsed_ms = duration_ms(started.elapsed()),
             "COW pool cleanup complete"
         );
     }
@@ -398,7 +399,7 @@ impl CowPool {
                 let slot_id = slot.id().to_owned();
                 info!(
                     id = %slot_id,
-                    elapsed_ms = elapsed.as_millis() as u64,
+                    elapsed_ms = duration_ms(elapsed),
                     "dropping late COW slot during cleanup"
                 );
                 destroy_slot_async(slot).await;
@@ -410,7 +411,7 @@ impl CowPool {
             }) => {
                 error!(
                     error = %e,
-                    elapsed_ms = elapsed.as_millis() as u64,
+                    elapsed_ms = duration_ms(elapsed),
                     "pending COW slot creation failed during cleanup"
                 );
             }

--- a/crates/sandbox-fc/src/duration.rs
+++ b/crates/sandbox-fc/src/duration.rs
@@ -1,0 +1,21 @@
+use std::time::Duration;
+
+/// Convert runtime durations for telemetry and structured log fields.
+///
+/// Timeout/deadline conversions may need different minimum-value or destination
+/// type semantics, so keep those paths local to their caller.
+pub(crate) fn duration_ms(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    #[test]
+    fn duration_ms_saturates_large_duration() {
+        assert_eq!(duration_ms(Duration::MAX), u64::MAX);
+    }
+}

--- a/crates/sandbox-fc/src/factory/create_timing.rs
+++ b/crates/sandbox-fc/src/factory/create_timing.rs
@@ -3,6 +3,7 @@ use std::time::{Duration, Instant};
 
 use tracing::{info, warn};
 
+use crate::duration::duration_ms;
 use crate::workspace_drive_image::{
     WorkspaceDriveImagePrepareObserver, WorkspaceDriveImagePrepareStage,
 };
@@ -281,10 +282,6 @@ impl WorkspaceDriveImagePrepareObserver for SandboxCreateTiming {
     }
 }
 
-fn duration_ms(duration: Duration) -> u64 {
-    duration.as_millis() as u64
-}
-
 fn optional_duration_ms(duration: Option<Duration>) -> u64 {
     duration.map_or(0, duration_ms)
 }
@@ -539,6 +536,20 @@ mod tests {
             let expected = ((index as u64 + 1) * 10).to_string();
             assert_field(&event, field, &expected);
         }
+    }
+
+    #[test]
+    fn success_summary_saturates_large_durations() {
+        let mut timing = SandboxCreateTiming::new("sandbox-1".into(), "vm0/default".into());
+        timing.record_stage_duration(SandboxCreateStage::CowPoolAcquire, Duration::MAX);
+
+        let event = capture_success_summary_event(&timing, Duration::MAX);
+
+        assert_eq!(event.level, Level::WARN);
+        assert_field(&event, "message", "slow sandbox create");
+        assert_field(&event, "total_elapsed_ms", &u64::MAX.to_string());
+        assert_field(&event, "cow_pool_acquire_ms", &u64::MAX.to_string());
+        assert_field(&event, "threshold_ms", "3000");
     }
 
     #[test]

--- a/crates/sandbox-fc/src/factory/mod.rs
+++ b/crates/sandbox-fc/src/factory/mod.rs
@@ -17,6 +17,7 @@ use tracing::{info, warn};
 
 use crate::config::{FirecrackerConfig, FirecrackerDeviceRateLimits};
 use crate::cow_cleanup::CowCleanupOutcome;
+use crate::duration::duration_ms;
 use crate::factory::cleanup_group::{FactoryCleanupGroup, FactoryCleanupTaskKind};
 use crate::factory::cow_cleanup::destroy_cow_device_with_retries;
 use crate::factory::create_timing::{SandboxCreateStage, SandboxCreateTiming};
@@ -91,7 +92,7 @@ impl FirecrackerFactory {
         })
         .await?;
         info!(
-            elapsed_ms = t.elapsed().as_millis() as u64,
+            elapsed_ms = duration_ms(t.elapsed()),
             "prerequisites checked"
         );
 
@@ -112,10 +113,7 @@ impl FirecrackerFactory {
                         phase: SandboxInitializationPhase::Factory,
                         message: format!("netns pool: {e}"),
                     })?;
-                info!(
-                    elapsed_ms = t.elapsed().as_millis() as u64,
-                    "netns pool created"
-                );
+                info!(elapsed_ms = duration_ms(t.elapsed()), "netns pool created");
                 (netns_pool, NetnsPoolOwnership::Owned)
             }
         };

--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -30,6 +30,7 @@ mod config;
 pub mod control;
 mod cow_cleanup;
 mod cow_pool;
+mod duration;
 mod exec_operation_result;
 mod factory;
 mod guest_operations;

--- a/crates/sandbox-fc/src/runtime.rs
+++ b/crates/sandbox-fc/src/runtime.rs
@@ -9,6 +9,7 @@ use sandbox::{
 use nbd_cow::pool::{DevicePoolConfig, DevicePoolHandle};
 
 use crate::config::{FirecrackerConfig, SnapshotConfig};
+use crate::duration::duration_ms;
 use crate::factory::FirecrackerFactory;
 use crate::network::{NetnsPoolConfig, NetnsPoolHandle};
 use crate::paths::{RuntimePaths, SandboxPaths, SnapshotOutputPaths, SockPaths};
@@ -45,14 +46,14 @@ impl FirecrackerRuntime {
                 message: format!("netns pool: {e}"),
             })?;
         info!(
-            elapsed_ms = t.elapsed().as_millis() as u64,
+            elapsed_ms = duration_ms(t.elapsed()),
             "runtime netns pool created"
         );
 
         let t = std::time::Instant::now();
         let device_pool = DevicePoolHandle::new(DevicePoolConfig::default());
         info!(
-            elapsed_ms = t.elapsed().as_millis() as u64,
+            elapsed_ms = duration_ms(t.elapsed()),
             "runtime device pool created"
         );
 

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -29,6 +29,7 @@ use vsock_host::{
 use vsock_proto::{ExecOutputPolicy, ExecOutputStream, ExecTimeoutPolicy};
 
 use crate::api::{ApiError, BalloonStatistics};
+use crate::duration::duration_ms;
 use nbd_cow::PooledNbdCowDevice;
 
 use crate::api::ApiClient;
@@ -2978,8 +2979,7 @@ impl BalloonSettleSummary {
     }
 
     fn elapsed_ms(&self) -> u64 {
-        let elapsed_ms = self.started_at.elapsed().as_millis();
-        u64::try_from(elapsed_ms).unwrap_or(u64::MAX)
+        duration_ms(self.started_at.elapsed())
     }
 
     fn actual_delta_mib(&self) -> Option<i64> {


### PR DESCRIPTION
## Summary

- add saturated runtime-duration millisecond helpers for runner and sandbox-fc structured telemetry/log fields
- clamp runner `JobTelemetry`, guest-common `sandbox_ops`, and sandbox-fc runtime elapsed structured logs instead of wrapping on huge `Duration` values
- keep runner claim telemetry within the TypeScript route's JS safe-integer wire contract while preserving `u64::MAX` saturation for telemetry/log payloads
- add regression coverage for `Duration::MAX` in runner telemetry, guest-common JSONL telemetry, sandbox-fc structured timing logs, and claim telemetry serialization

## Notes

Remaining raw `as_millis() as u64` matches are intentionally outside this issue scope: timeout metadata, configured backoff metadata, or fixed clock-skew constants. Timeout/deadline conversions keep their existing semantics.

Fixes #19110

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner provider::api::tests`
- `cargo test --manifest-path crates/Cargo.toml -p runner telemetry::tests`
- `cargo test --manifest-path crates/Cargo.toml -p guest-common telemetry::tests`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc duration::tests`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc factory::create_timing::tests`
- `cargo test --manifest-path crates/Cargo.toml -p runner -p guest-common -p sandbox-fc`
