### PR TITLE
fix(runner): disable inactive units during service drain

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1828,8 +1828,20 @@ jobs:
           echo "--- Waiting for job 2 ---"
           wait $SUBMIT2_PID || fail "Job 2 failed"
 
-          # 7. Wait for A to exit after drain, then uninstall
+          # 7. Wait for A to exit after drain, then verify drain still disables
+          # an inactive-but-enabled installed unit.
           wait_for_exit "$SVC_A"
+          echo "--- Re-enable inactive runner A, then drain again ---"
+          sudo systemctl enable "vm0-runner-${SVC_A}.service"
+          sudo systemctl is-enabled --quiet "vm0-runner-${SVC_A}.service" \
+            || fail "runner A should be enabled before inactive drain"
+          sudo "$BIN_DIR/runner" service drain --name "$SVC_A" \
+            || fail "inactive drain of runner A failed"
+          if sudo systemctl is-enabled --quiet "vm0-runner-${SVC_A}.service"; then
+            fail "runner A remained enabled after inactive drain"
+          fi
+          echo "PASS: inactive drain disabled runner A"
+
           echo "--- Uninstalling runner A ---"
           sudo "$BIN_DIR/runner" service uninstall --name "$SVC_A" --force
 

--- a/ansible/playbooks/promote-runner.yml
+++ b/ansible/playbooks/promote-runner.yml
@@ -67,18 +67,19 @@
     # ========================================
     # Phase 5: Drain old runners + Cleanup
     # ========================================
-    - name: Find running runner services
-      shell: >
-        systemctl list-units 'vm0-runner-*.service' --state=running
-        --plain --no-legend | awk '{print $1}'
-        | sed 's/^vm0-runner-//;s/\.service$//'
-      register: running_runners
+    - name: Find runner services to drain
+      shell: |
+        (
+          systemctl list-units 'vm0-runner-*.service' --state=running --plain --no-legend | awk '{print $1}'
+          systemctl list-unit-files 'vm0-runner-*.service' --state=enabled --plain --no-legend | awk '{print $1}'
+        ) | sed 's/^vm0-runner-//;s/\.service$//' | sort -u
+      register: runner_service_candidates
       changed_when: false
       ignore_errors: true
 
     - name: Drain old runner services
       command: "{{ bin_dir }}/runner service drain --name {{ item }}"
-      loop: "{{ running_runners.stdout_lines | default([]) }}"
+      loop: "{{ runner_service_candidates.stdout_lines | default([]) }}"
       when: item != runner_name
       ignore_errors: true
 

--- a/ansible/playbooks/rollback-runner.yml
+++ b/ansible/playbooks/rollback-runner.yml
@@ -423,12 +423,13 @@
       register: tgt_bin_precheck
       failed_when: not (tgt_bin_precheck.stat.exists and tgt_bin_precheck.stat.executable)
 
-    - name: Find running runner services
-      shell: >
-        systemctl list-units 'vm0-runner-*.service' --state=running
-        --plain --no-legend | awk '{print $1}'
-        | sed 's/^vm0-runner-//;s/\.service$//'
-      register: running_runners
+    - name: Find runner services to drain or stop
+      shell: |
+        (
+          systemctl list-units 'vm0-runner-*.service' --state=running --plain --no-legend | awk '{print $1}'
+          systemctl list-unit-files 'vm0-runner-*.service' --state=enabled --plain --no-legend | awk '{print $1}'
+        ) | sed 's/^vm0-runner-//;s/\.service$//' | sort -u
+      register: runner_service_candidates
       changed_when: false
 
     # `failed_when: false` tolerates non-zero exits from individual
@@ -440,13 +441,13 @@
     # still visible in Ansible's per-host log.
     - name: Drain non-target runners (graceful)
       command: "{{ bin_dir }}/runner service drain --name {{ item }}"
-      loop: "{{ running_runners.stdout_lines | default([]) }}"
+      loop: "{{ runner_service_candidates.stdout_lines | default([]) }}"
       when: item != runner_name and rollback_mode == "graceful"
       failed_when: false
 
     - name: Stop non-target runners (emergency)
       command: "{{ bin_dir }}/runner service stop --name {{ item }} --force"
-      loop: "{{ running_runners.stdout_lines | default([]) }}"
+      loop: "{{ runner_service_candidates.stdout_lines | default([]) }}"
       when: item != runner_name and rollback_mode == "emergency"
       failed_when: false
 

--- a/crates/runner/src/cmd/service.rs
+++ b/crates/runner/src/cmd/service.rs
@@ -1264,32 +1264,31 @@ async fn uninstall(args: ServiceUninstallArgs) -> RunnerResult<()> {
 /// `service drain` — send SIGUSR1, disable unit, return immediately.
 async fn drain(args: ServiceDrainArgs) -> RunnerResult<()> {
     let unit = unit_name(&args.name)?;
-    if !is_unit_active(&unit).await? {
-        info!(unit = %unit, "no active service found");
-        return Ok(());
-    }
-
-    // `is_unit_active` above can race against the runner exiting on its own:
-    // by the time we read MainPID or call `kill`, the process may be gone.
-    // Both outcomes ("live, signal delivered" and "already gone") must still
-    // run `systemctl disable` below so the unit does not auto-start at the
-    // next boot.
-    match signal_service_main(&unit, nix::sys::signal::Signal::SIGUSR1).await? {
-        ServiceSignalOutcome::Sent { pid } => info!(unit = %unit, pid, "sent SIGUSR1 (drain)"),
-        ServiceSignalOutcome::AlreadyGone => {
-            info!(unit = %unit, "runner already exited; drain signal not needed");
+    if is_unit_active(&unit).await? {
+        // `is_unit_active` above can race against the runner exiting on its own:
+        // by the time we read MainPID or call `kill`, the process may be gone.
+        // Both outcomes ("live, signal delivered" and "already gone") must still
+        // run `systemctl disable` below so the unit does not auto-start at the
+        // next boot.
+        match signal_service_main(&unit, nix::sys::signal::Signal::SIGUSR1).await? {
+            ServiceSignalOutcome::Sent { pid } => info!(unit = %unit, pid, "sent SIGUSR1 (drain)"),
+            ServiceSignalOutcome::AlreadyGone => {
+                info!(unit = %unit, "runner already exited; drain signal not needed");
+            }
         }
+    } else {
+        info!(unit = %unit, "no active service found; drain signal not needed");
     }
 
-    // Disable so it won't restart on reboot. The SIGUSR1 has already been
-    // delivered, so a disable failure is a partial-success condition — the
-    // operator can re-run the command manually. Surface the hint on stderr
-    // in addition to the structured log so CLI users don't miss it.
+    // Disable so it won't restart on reboot. At this point the runner either
+    // saw SIGUSR1, already exited, or was inactive, so disabling is the
+    // remaining retirement step. Surface the hint on stderr in addition to
+    // the structured log so CLI users don't miss it.
     let svc = format!("{unit}.service");
     if let Err(e) = run_systemctl(&["disable", &svc]).await {
         warn!(unit = %unit, error = %e, "failed to disable unit");
         eprintln!(
-            "WARNING: drain signal was sent but `systemctl disable {svc}` failed: {e}. \
+            "WARNING: drain could not disable {svc}: {e}. \
              Run it manually to prevent the unit from restarting on reboot."
         );
     } else {


### PR DESCRIPTION
## Summary

- make `runner service drain` still attempt `systemctl disable` when the unit is already inactive
- broaden promote/rollback discovery to drain enabled installed runner services, not only currently running units
- add runner upgrade CI coverage for an inactive-but-enabled installed unit

Fixes #19113

## Tests

- `cargo fmt --manifest-path crates/runner/Cargo.toml --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner service`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
- `ansible-playbook --syntax-check ansible/playbooks/promote-runner.yml`
- `ansible-playbook --syntax-check ansible/playbooks/rollback-runner.yml`
- pre-commit hooks: `cargo-fmt`, `cargo-clippy`, `cargo-doc`