### PR TITLE
refactor: centralize auth base admission ownership

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -17,15 +17,15 @@ import flow_metadata_keys as metadata_keys
 import matching
 from auth_base_forwarder import (
     MAX_AUTH_BASE_REQUEST_BODY_BYTES,
-    AuthBaseForwardingAdmission,
     AuthBaseForwardingSaturatedError,
     ForwardedRequestTooLargeError,
     InvalidResolvedAuthHeaderError,
     forward_request,
     forwarded_auth_base_client_header_pairs,
     header_pairs,
-    release_forward_request_admission,
+    release_forward_request_admission_from_flow,
     resolved_auth_header_pairs,
+    take_forward_request_admission_from_flow,
 )
 from aws_sigv4 import AwsSigV4Credentials, AwsSigV4SigningError, sign_request
 from firewall_auth_cache import InvalidBillableAuthExpiryError, get_firewall_headers
@@ -694,19 +694,6 @@ def _set_invalid_resolved_auth_header_response(
     )
 
 
-def _take_auth_base_forward_admission(
-    flow: http.HTTPFlow,
-) -> AuthBaseForwardingAdmission | None:
-    admission = flow.metadata.pop(metadata_keys.AUTH_BASE_FORWARD_ADMISSION, None)
-    return admission if isinstance(admission, AuthBaseForwardingAdmission) else None
-
-
-def _release_auth_base_forward_admission(flow: http.HTTPFlow) -> None:
-    admission = _take_auth_base_forward_admission(flow)
-    if admission is not None:
-        release_forward_request_admission(admission)
-
-
 async def _apply_url_rewrite(
     flow: http.HTTPFlow,
     *,
@@ -765,7 +752,7 @@ async def _apply_url_rewrite(
             return FirewallAuthHandlingResult.LOCAL_RESPONSE
 
     try:
-        admission = _take_auth_base_forward_admission(flow)
+        admission = take_forward_request_admission_from_flow(flow)
         status, resp_body, resp_headers = await forward_request(
             new_url,
             flow.request.method,
@@ -838,7 +825,7 @@ async def _apply_resolved_firewall_auth(
                 proxy_log_path=proxy_log_path,
             )
 
-        _release_auth_base_forward_admission(flow)
+        release_forward_request_admission_from_flow(flow)
         _apply_header_query_injection(
             flow,
             headers=headers,
@@ -896,7 +883,7 @@ def _finish_firewall_auth_result(
     flow: http.HTTPFlow, result: FirewallAuthHandlingResult
 ) -> FirewallAuthHandlingResult:
     if result is FirewallAuthHandlingResult.LOCAL_RESPONSE:
-        _release_auth_base_forward_admission(flow)
+        release_forward_request_admission_from_flow(flow)
     return result
 
 
@@ -937,7 +924,7 @@ async def handle_firewall_request(
         _finalize_firewall_auth_success(flow, context, token_meta)
         return auth_result
     except BaseException:
-        _release_auth_base_forward_admission(flow)
+        release_forward_request_admission_from_flow(flow)
         raise
 
 

--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -20,6 +20,7 @@ from typing import NamedTuple
 
 from mitmproxy import http
 
+import flow_metadata_keys as metadata_keys
 from http_header_syntax import has_forbidden_header_value_control, is_http_header_name
 
 HOP_BY_HOP: frozenset[str] = frozenset(
@@ -523,6 +524,30 @@ def release_forward_request_admission(admission: AuthBaseForwardingAdmission) ->
         admission._released = True
         _forward_request_admitted_count -= 1
         _forward_request_admitted_body_bytes -= admission._body_bytes
+
+
+def attach_forward_request_admission_to_flow(
+    flow: http.HTTPFlow, admission: AuthBaseForwardingAdmission
+) -> None:
+    """Attach an auth.base forward admission to a flow until ownership is transferred."""
+    if metadata_keys.AUTH_BASE_FORWARD_ADMISSION in flow.metadata:
+        raise RuntimeError("auth.base forwarding admission is already attached to flow")
+    flow.metadata[metadata_keys.AUTH_BASE_FORWARD_ADMISSION] = admission
+
+
+def take_forward_request_admission_from_flow(
+    flow: http.HTTPFlow,
+) -> AuthBaseForwardingAdmission | None:
+    """Remove an attached auth.base forward admission and transfer ownership."""
+    admission = flow.metadata.pop(metadata_keys.AUTH_BASE_FORWARD_ADMISSION, None)
+    return admission if isinstance(admission, AuthBaseForwardingAdmission) else None
+
+
+def release_forward_request_admission_from_flow(flow: http.HTTPFlow) -> None:
+    """Release any auth.base forward admission still attached to a flow."""
+    admission = take_forward_request_admission_from_flow(flow)
+    if admission is not None:
+        release_forward_request_admission(admission)
 
 
 def forward_request_admission_state_for_tests() -> tuple[int, int]:

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1482,7 +1482,11 @@ def requestheaders(flow: http.HTTPFlow) -> Awaitable[None] | None:
             flow.metadata[_REQUEST_HEADERS_TERMINATED] = True
             flow.kill()
             return None
-        flow.metadata[metadata_keys.AUTH_BASE_FORWARD_ADMISSION] = admission
+        try:
+            auth_base_forwarder.attach_forward_request_admission_to_flow(flow, admission)
+        except BaseException:
+            auth_base_forwarder.release_forward_request_admission(admission)
+            raise
         flow.metadata[_REQUEST_CLASSIFICATION] = classification
         return None
 
@@ -1587,12 +1591,12 @@ async def request(flow: http.HTTPFlow) -> None:
     3. Firewall match (inject auth headers for allowed requests)
     """
     if flow.metadata.get(_REQUEST_HEADERS_TERMINATED):
-        _release_auth_base_forward_admission(flow)
+        auth_base_forwarder.release_forward_request_admission_from_flow(flow)
         flow.metadata.pop(_REQUEST_CLASSIFICATION, None)
         return
 
     if flow.response is not None or flow.error is not None:
-        _release_auth_base_forward_admission(flow)
+        auth_base_forwarder.release_forward_request_admission_from_flow(flow)
         flow.metadata.pop(_REQUEST_CLASSIFICATION, None)
         return
 
@@ -1660,7 +1664,7 @@ async def request(flow: http.HTTPFlow) -> None:
                 # Local firewall/auth errors never reach a provider. They only
                 # need pre-tracking to keep shutdown from racing while auth is
                 # resolving, so release as soon as the local response exists.
-                _release_auth_base_forward_admission(flow)
+                auth_base_forwarder.release_forward_request_admission_from_flow(flow)
                 _release_tracked_usage_flow(flow)
             return
 
@@ -1678,7 +1682,7 @@ async def request(flow: http.HTTPFlow) -> None:
         flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
     except (asyncio.CancelledError, Exception):
         flow.metadata.pop(metadata_keys.HTTP_REQUEST_START_MONOTONIC, None)
-        _release_auth_base_forward_admission(flow)
+        auth_base_forwarder.release_forward_request_admission_from_flow(flow)
         _release_tracked_usage_flow(flow)
         raise
     finally:
@@ -1716,12 +1720,6 @@ def _maybe_track_usage_flow(
 def _release_tracked_usage_flow(flow: http.HTTPFlow) -> None:
     if flow.metadata.pop(_USAGE_FLOW_TRACKED, False):
         usage.decrement_in_flight_flows()
-
-
-def _release_auth_base_forward_admission(flow: http.HTTPFlow) -> None:
-    admission = flow.metadata.pop(metadata_keys.AUTH_BASE_FORWARD_ADMISSION, None)
-    if isinstance(admission, auth_base_forwarder.AuthBaseForwardingAdmission):
-        auth_base_forwarder.release_forward_request_admission(admission)
 
 
 def _report_model_provider_usage_once(flow: http.HTTPFlow, run_id: str) -> None:
@@ -1864,7 +1862,7 @@ def _single_content_length_response_size(content_length: str, start: int, end: i
     return response_size
 
 
-def _release_usage_hook_state(
+def _release_terminal_flow_state(
     flow: http.HTTPFlow,
     *,
     release_tracking: bool,
@@ -1877,7 +1875,7 @@ def _release_usage_hook_state(
     flow.metadata.pop(_FIREWALL_AUTH_APPLIED_IN_REQUESTHEADERS, None)
     request_streaming.release_request_stream_state(flow)
     response_streaming.release_response_stream_state(flow)
-    _release_auth_base_forward_admission(flow)
+    auth_base_forwarder.release_forward_request_admission_from_flow(flow)
     if release_tracking:
         _release_tracked_usage_flow(flow)
 
@@ -1894,7 +1892,7 @@ def _track_usage_flow(fn):
         try:
             return fn(flow, *args, **kwargs)
         finally:
-            _release_usage_hook_state(flow, release_tracking=True)
+            _release_terminal_flow_state(flow, release_tracking=True)
 
     return wrapper
 
@@ -1910,7 +1908,7 @@ def _track_response_usage_flow(fn):
             release_tracking = not response_streaming.is_model_websocket_usage_enabled(flow)
             return result
         finally:
-            _release_usage_hook_state(flow, release_tracking=release_tracking)
+            _release_terminal_flow_state(flow, release_tracking=release_tracking)
 
     return wrapper
 

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
@@ -641,6 +641,25 @@ class TestAuthBaseForwarderRequestBodyLimit:
 
 
 class TestAuthBaseForwarderResourceCleanup:
+    def test_duplicate_flow_admission_attach_does_not_overwrite_existing(self, real_flow):
+        flow = real_flow(with_response=False)
+        first = forwarder.reserve_forward_request_admission(7)
+        second = forwarder.reserve_forward_request_admission(11)
+
+        try:
+            forwarder.attach_forward_request_admission_to_flow(flow, first)
+
+            with pytest.raises(RuntimeError, match="already attached"):
+                forwarder.attach_forward_request_admission_to_flow(flow, second)
+
+            assert forwarder.forward_request_admission_state_for_tests() == (2, 18)
+        finally:
+            forwarder.release_forward_request_admission_from_flow(flow)
+            forwarder.release_forward_request_admission(first)
+            forwarder.release_forward_request_admission(second)
+
+        assert forwarder.forward_request_admission_state_for_tests() == (0, 0)
+
     async def test_closes_response_and_connection_on_success(self):
         with fake_forwarder_upstream(headers=[("Content-Type", "application/json")]) as upstream:
             status, body, _ = await forwarder.forward_request(

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -1452,7 +1452,7 @@ class TestHandleFirewallRequest:
         vm_info = _vm_info(network_log_path="", include_encrypted_secrets=False)
         allow = _allow(api_entry)
         admission = auth_base_forwarder.reserve_forward_request_admission(42)
-        flow.metadata[metadata_keys.AUTH_BASE_FORWARD_ADMISSION] = admission
+        auth_base_forwarder.attach_forward_request_admission_to_flow(flow, admission)
 
         with mitm_ctx():
             result = await auth.handle_firewall_request(flow, allow, vm_info)
@@ -1479,7 +1479,7 @@ class TestHandleFirewallRequest:
         vm_info = _vm_info(tmp_path)
         allow = _allow(api_entry)
         admission = auth_base_forwarder.reserve_forward_request_admission(42)
-        flow.metadata[metadata_keys.AUTH_BASE_FORWARD_ADMISSION] = admission
+        auth_base_forwarder.attach_forward_request_admission_to_flow(flow, admission)
         auth_resolution_entered = asyncio.Event()
         release_auth_resolution = asyncio.Event()
 


### PR DESCRIPTION
## Summary

- Add `auth_base_forwarder` helpers to attach, take, and release auth.base forwarding admissions from flows.
- Route `auth.py` and `mitm_addon.py` through the owner API instead of mutating `AUTH_BASE_FORWARD_ADMISSION` directly.
- Add coverage that duplicate flow admission attachment fails without orphaning reservations.

## Tests

- `PYTHONPATH=/tmp/vm0-mitm-addon-test-pkgs-19112:src python3 -m pytest -q tests/test_auth_base_forwarder.py tests/test_firewall_auth.py tests/test_request_handler_firewall_dispatch.py tests/test_request_headers_handler.py tests/test_error_handler.py`
- `PYTHONPATH=/tmp/vm0-mitm-addon-test-pkgs-19112:src python3 -m pytest -q tests/`
- `PYTHONPATH=/tmp/vm0-mitm-addon-test-pkgs-19112:src /tmp/vm0-mitm-addon-test-pkgs-19112/bin/ruff check .`
- `PYTHONPATH=/tmp/vm0-mitm-addon-test-pkgs-19112:src /tmp/vm0-mitm-addon-test-pkgs-19112/bin/ruff format --check .`
- `git diff --check`

Closes #19112
