### PR TITLE
fix(runner): key firewall auth cache by identity

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -6,6 +6,7 @@ Cache state and platform API calls live in dedicated owner modules.
 """
 
 import asyncio
+import hashlib
 import json
 import urllib.parse
 from dataclasses import dataclass
@@ -28,7 +29,11 @@ from auth_base_forwarder import (
     resolved_auth_header_pairs,
 )
 from aws_sigv4 import AwsSigV4Credentials, AwsSigV4SigningError, sign_request
-from firewall_auth_cache import InvalidBillableAuthExpiryError, get_firewall_headers
+from firewall_auth_cache import (
+    FirewallAuthCacheKey,
+    InvalidBillableAuthExpiryError,
+    get_firewall_headers,
+)
 from firewall_auth_client import (
     ConnectorNotConfiguredError,
     FirewallAuthApiError,
@@ -59,6 +64,7 @@ class FirewallHeaderPhaseAuthResult(Enum):
 _HTTP_STATUS_CLIENT_ERROR_MIN = 400
 _HTTP_STATUS_SERVER_ERROR_MIN = 500
 AUTH_BASE_FORWARDING_SATURATED_ERROR = "auth_base_forwarding_saturated"
+_FIREWALL_AUTH_IDENTITY_VERSION = 1
 
 
 @dataclass(frozen=True)
@@ -67,10 +73,9 @@ class _FirewallAuthContext:
 
     allow: matching.FirewallAllow
     firewall_base: str
-    api_id: str
-    run_id: str
     proxy_log_path: str
     auth_request: FirewallAuthRequest
+    auth_cache_key: FirewallAuthCacheKey
 
 
 def is_billable_firewall(firewall_name: str, vm_info: dict) -> bool:
@@ -118,25 +123,56 @@ def _build_firewall_auth_context(
     """Capture request-local auth inputs after matched-firewall metadata exists."""
     api_entry = allow.api_entry
     auth_config = api_entry.get("auth", {})
-    return _FirewallAuthContext(
-        allow=allow,
-        firewall_base=flow.metadata[metadata_keys.FIREWALL_BASE],
-        api_id=flow.metadata[metadata_keys.FIREWALL_API_ID],
-        run_id=flow.metadata.get(metadata_keys.VM_RUN_ID, ""),
-        proxy_log_path=flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, ""),
-        auth_request=FirewallAuthRequest(
-            sandbox_token=vm_info.get("sandboxToken", ""),
-            encrypted_secrets=vm_info.get("encryptedSecrets") or "",
-            auth_headers=auth_config.get("headers", {}),
-            auth_base=auth_config.get("base"),
-            auth_query=auth_config.get("query"),
-            auth_aws_sigv4=auth_config.get("awsSigv4"),
-            secret_connector_map=vm_info.get("secretConnectorMap"),
-            secret_connector_metadata_map=vm_info.get("secretConnectorMetadataMap"),
-            vars_map=vm_info.get("vars"),
-            firewall_billable=bool(flow.metadata[metadata_keys.FIREWALL_BILLABLE]),
+    firewall_base = flow.metadata[metadata_keys.FIREWALL_BASE]
+    api_id = flow.metadata[metadata_keys.FIREWALL_API_ID]
+    run_id = flow.metadata.get(metadata_keys.VM_RUN_ID, "")
+    auth_request = FirewallAuthRequest(
+        sandbox_token=vm_info.get("sandboxToken", ""),
+        encrypted_secrets=vm_info.get("encryptedSecrets") or "",
+        auth_headers=auth_config.get("headers", {}),
+        auth_base=auth_config.get("base"),
+        auth_query=auth_config.get("query"),
+        auth_aws_sigv4=auth_config.get("awsSigv4"),
+        secret_connector_map=vm_info.get("secretConnectorMap"),
+        secret_connector_metadata_map=vm_info.get("secretConnectorMetadataMap"),
+        vars_map=vm_info.get("vars"),
+        firewall_billable=bool(flow.metadata[metadata_keys.FIREWALL_BILLABLE]),
+    )
+    auth_cache_key = FirewallAuthCacheKey(
+        run_id=run_id,
+        api_id=api_id,
+        auth_identity=_build_firewall_auth_identity(
+            firewall_name=allow.name,
+            firewall_base=firewall_base,
+            auth_request=auth_request,
         ),
     )
+    flow.metadata[metadata_keys.FIREWALL_AUTH_CACHE_KEY] = auth_cache_key
+    return _FirewallAuthContext(
+        allow=allow,
+        firewall_base=firewall_base,
+        proxy_log_path=flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, ""),
+        auth_request=auth_request,
+        auth_cache_key=auth_cache_key,
+    )
+
+
+def _build_firewall_auth_identity(
+    *,
+    firewall_name: str,
+    firewall_base: str,
+    auth_request: FirewallAuthRequest,
+) -> str:
+    sandbox_token_sha256 = hashlib.sha256(auth_request.sandbox_token.encode("utf-8")).hexdigest()
+    material = {
+        "version": _FIREWALL_AUTH_IDENTITY_VERSION,
+        "firewallName": firewall_name,
+        "firewallBase": firewall_base,
+        "auth": auth_request.to_body(force_refresh=False),
+        "sandboxTokenSha256": sandbox_token_sha256,
+    }
+    canonical_json = json.dumps(material, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(canonical_json).hexdigest()
 
 
 def _firewall_auth_context_injects_credentials(context: _FirewallAuthContext) -> bool:
@@ -914,8 +950,7 @@ async def handle_firewall_request(
 
         try:
             token_meta = await get_firewall_headers(
-                context.run_id,
-                context.api_id,
+                context.auth_cache_key,
                 context.auth_request,
             )
         except Exception as exc:
@@ -972,8 +1007,7 @@ async def try_apply_stream_safe_firewall_auth_for_requestheaders(
 
     try:
         token_meta = await get_firewall_headers(
-            context.run_id,
-            context.api_id,
+            context.auth_cache_key,
             context.auth_request,
         )
     except asyncio.CancelledError:

--- a/crates/runner/mitm-addon/src/firewall_auth_cache.py
+++ b/crates/runner/mitm-addon/src/firewall_auth_cache.py
@@ -16,6 +16,15 @@ class InvalidBillableAuthExpiryError(Exception):
     """Raised when billable firewall auth succeeds with an invalid cache expiry."""
 
 
+@dataclass(frozen=True)
+class FirewallAuthCacheKey:
+    """Auth cache identity for one run, API, and resolved auth input set."""
+
+    run_id: str
+    api_id: str
+    auth_identity: str
+
+
 @dataclass
 class _FirewallHeaderCacheEntry:
     """Cached /firewall/auth response data for a single firewall key."""
@@ -26,7 +35,7 @@ class _FirewallHeaderCacheEntry:
 
 @dataclass
 class _FirewallAuthState:
-    """Per-(run_id, api_id) auth lifecycle state."""
+    """Per-auth-identity lifecycle state."""
 
     cache: _FirewallHeaderCacheEntry | None = None
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
@@ -34,7 +43,7 @@ class _FirewallAuthState:
     last_force_refresh_at: float = 0.0
 
 
-_auth_state: dict[tuple[str, str], _FirewallAuthState] = {}
+_auth_state: dict[FirewallAuthCacheKey, _FirewallAuthState] = {}
 
 # Cooldown window for re-marking a force-refresh. Caps amplification at
 # 30 refreshes/hour/key under a persistent non-token 401 loop — safely
@@ -45,7 +54,7 @@ _auth_state: dict[tuple[str, str], _FirewallAuthState] = {}
 _FORCE_REFRESH_COOLDOWN_SECS = 120.0
 
 
-def _get_auth_state(cache_key: tuple[str, str]) -> _FirewallAuthState:
+def _get_auth_state(cache_key: FirewallAuthCacheKey) -> _FirewallAuthState:
     state = _auth_state.get(cache_key)
     if state is None:
         state = _FirewallAuthState()
@@ -53,7 +62,7 @@ def _get_auth_state(cache_key: tuple[str, str]) -> _FirewallAuthState:
     return state
 
 
-def request_force_refresh(cache_key: tuple[str, str]) -> None:
+def request_force_refresh(cache_key: FirewallAuthCacheKey) -> None:
     """Request a forced token refresh on the next /firewall/auth fetch.
 
     No-op if a forced refresh already completed within
@@ -84,7 +93,7 @@ def request_force_refresh(cache_key: tuple[str, str]) -> None:
         state.force_refresh_pending = True
 
 
-def clear_cached_firewall_headers(cache_key: tuple[str, str]) -> None:
+def clear_cached_firewall_headers(cache_key: FirewallAuthCacheKey) -> None:
     """Invalidate only cached headers while preserving refresh lifecycle state."""
     state = _auth_state.get(cache_key)
     if state:
@@ -93,7 +102,7 @@ def clear_cached_firewall_headers(cache_key: tuple[str, str]) -> None:
 
 def evict_stale_cache_keys(active_run_ids: set[str]) -> None:
     """Remove cache entries for runs no longer in the registry."""
-    stale = [k for k in _auth_state if k[0] not in active_run_ids]
+    stale = [k for k in _auth_state if k.run_id not in active_run_ids]
     for k in stale:
         _auth_state.pop(k, None)
 
@@ -151,21 +160,19 @@ def _build_cache_hit(
 
 
 async def get_firewall_headers(
-    run_id: str,
-    api_id: str,
+    cache_key: FirewallAuthCacheKey,
     request: FirewallAuthRequest,
 ) -> dict:
     """Get firewall auth headers with TTL-based caching.
 
     Uses per-key locking so that concurrent requests for the same
-    (run_id, api_id) coalesce into a single HTTP fetch.
+    auth identity coalesce into a single HTTP fetch.
 
     Cache is evicted when:
     - The run is removed from the registry (see registry.load_registry)
     - A 401 response is received (see response handler)
     - The expiresAt timestamp from the auth endpoint has passed
     """
-    cache_key = (run_id, api_id)
     state = _get_auth_state(cache_key)
 
     # Fast path: cache hit (no lock needed — single-threaded event loop)
@@ -183,7 +190,7 @@ async def get_firewall_headers(
                 return hit
 
         # Consume the force-refresh marker inside the lock so concurrent
-        # coroutines for the same (run_id, api_id) cannot both trigger a
+        # coroutines for the same auth identity cannot both trigger a
         # refresh — the one that loses the lock will see the fresh cache
         # on its double-check above and never reach this path. Record the
         # consume timestamp so request_force_refresh() suppresses re-marking

--- a/crates/runner/mitm-addon/src/flow_metadata_keys.py
+++ b/crates/runner/mitm-addon/src/flow_metadata_keys.py
@@ -51,7 +51,10 @@ Firewall and auth context
   matched firewall block, and auth paths. Read by logging, auth cache
   invalidation, usage dispatch, and local error responses.
 - ``FIREWALL_API_ID``: ``str`` API id or base fallback from the matched
-  firewall. Read by auth handling and 401 cache invalidation.
+  firewall. Read by auth handling.
+- ``FIREWALL_AUTH_CACHE_KEY``: opaque typed auth cache key written by matched
+  auth handling after the full auth input identity is known. Read by 401 cache
+  invalidation; stores only a digest of auth inputs and sandbox token.
 - ``FIREWALL_NAME``: ``str`` firewall connector/model name. Read by logging,
   model-provider gates, and connector usage dispatch.
 - ``FIREWALL_PERMISSION``: ``str`` matched permission name or empty string.
@@ -171,6 +174,7 @@ TCP_START_MONOTONIC: Final = "tcp_start_monotonic"
 # Firewall and auth metadata
 FIREWALL_BASE: Final = "firewall_base"
 FIREWALL_API_ID: Final = "firewall_api_id"
+FIREWALL_AUTH_CACHE_KEY: Final = "firewall_auth_cache_key"
 FIREWALL_NAME: Final = "firewall_name"
 FIREWALL_PERMISSION: Final = "firewall_permission"
 FIREWALL_RULE_MATCH: Final = "firewall_rule_match"

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -64,7 +64,11 @@ from auth import (
     try_apply_stream_safe_firewall_auth_for_requestheaders,
 )
 from body_limits import STREAM_BUFFER_LIMIT
-from firewall_auth_cache import clear_cached_firewall_headers, request_force_refresh
+from firewall_auth_cache import (
+    FirewallAuthCacheKey,
+    clear_cached_firewall_headers,
+    request_force_refresh,
+)
 from logging_utils import (
     add_firewall_metadata,
     flush_log_path,
@@ -2025,9 +2029,8 @@ def response(flow: http.HTTPFlow) -> None:
         and flow.response.status_code == _HTTP_STATUS_UNAUTHORIZED
         and flow.metadata.get(metadata_keys.FIREWALL_BASE)
     ):
-        api_id = flow.metadata.get(metadata_keys.FIREWALL_API_ID, "")
-        if api_id:
-            cache_key = (run_id, api_id)
+        cache_key = flow.metadata.get(metadata_keys.FIREWALL_AUTH_CACHE_KEY)
+        if isinstance(cache_key, FirewallAuthCacheKey):
             clear_cached_firewall_headers(cache_key)
             request_force_refresh(cache_key)
 

--- a/crates/runner/mitm-addon/tests/auth_state_helpers.py
+++ b/crates/runner/mitm-addon/tests/auth_state_helpers.py
@@ -9,12 +9,25 @@ def clear_auth_state() -> None:
     auth_cache._auth_state.clear()
 
 
-def has_auth_state(cache_key: tuple[str, str]) -> bool:
+def auth_cache_key(
+    *,
+    run_id: str = "run-1",
+    api_id: str = "api-1",
+    auth_identity: str = "auth-identity-1",
+) -> auth_cache.FirewallAuthCacheKey:
+    return auth_cache.FirewallAuthCacheKey(
+        run_id=run_id,
+        api_id=api_id,
+        auth_identity=auth_identity,
+    )
+
+
+def has_auth_state(cache_key: auth_cache.FirewallAuthCacheKey) -> bool:
     return cache_key in auth_cache._auth_state
 
 
 def set_cached_headers(
-    cache_key: tuple[str, str],
+    cache_key: auth_cache.FirewallAuthCacheKey,
     *,
     headers: dict,
     expires_at: object = None,
@@ -35,36 +48,40 @@ def set_cached_headers(
     )
 
 
-def cached_headers(cache_key: tuple[str, str]) -> auth_cache._FirewallHeaderCacheEntry | None:
+def cached_headers(
+    cache_key: auth_cache.FirewallAuthCacheKey,
+) -> auth_cache._FirewallHeaderCacheEntry | None:
     state = auth_cache._auth_state.get(cache_key)
     return state.cache if state else None
 
 
-def require_cached_headers(cache_key: tuple[str, str]) -> auth_cache._FirewallHeaderCacheEntry:
+def require_cached_headers(
+    cache_key: auth_cache.FirewallAuthCacheKey,
+) -> auth_cache._FirewallHeaderCacheEntry:
     entry = cached_headers(cache_key)
     assert entry is not None
     return entry
 
 
-def mark_force_refresh(cache_key: tuple[str, str]) -> None:
+def mark_force_refresh(cache_key: auth_cache.FirewallAuthCacheKey) -> None:
     auth_cache._get_auth_state(cache_key).force_refresh_pending = True
 
 
-def force_refresh_pending(cache_key: tuple[str, str]) -> bool:
+def force_refresh_pending(cache_key: auth_cache.FirewallAuthCacheKey) -> bool:
     state = auth_cache._auth_state.get(cache_key)
     return bool(state and state.force_refresh_pending)
 
 
-def set_last_force_refresh_at(cache_key: tuple[str, str], timestamp: float) -> None:
+def set_last_force_refresh_at(cache_key: auth_cache.FirewallAuthCacheKey, timestamp: float) -> None:
     auth_cache._get_auth_state(cache_key).last_force_refresh_at = timestamp
 
 
-def last_force_refresh_at(cache_key: tuple[str, str]) -> float | None:
+def last_force_refresh_at(cache_key: auth_cache.FirewallAuthCacheKey) -> float | None:
     state = auth_cache._auth_state.get(cache_key)
     return state.last_force_refresh_at if state else None
 
 
-def require_last_force_refresh_at(cache_key: tuple[str, str]) -> float:
+def require_last_force_refresh_at(cache_key: auth_cache.FirewallAuthCacheKey) -> float:
     timestamp = last_force_refresh_at(cache_key)
     assert timestamp is not None
     return timestamp

--- a/crates/runner/mitm-addon/tests/test_auth_cache.py
+++ b/crates/runner/mitm-addon/tests/test_auth_cache.py
@@ -13,6 +13,7 @@ import firewall_auth_client as auth_client
 import registry as registry_cache
 from tests.auth_endpoint_helpers import FakeAuthEndpoint
 from tests.auth_state_helpers import (
+    auth_cache_key,
     cached_headers,
     has_auth_state,
     require_cached_headers,
@@ -51,12 +52,11 @@ class TestFirewallHeaderCache:
 
         with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
             started = [asyncio.Event() for _ in range(3)]
+            cache_key = auth_cache_key()
 
             async def fetch_headers(started_event: asyncio.Event) -> dict:
                 started_event.set()
-                return await auth_cache.get_firewall_headers(
-                    "run-1", "api-1", _firewall_auth_request()
-                )
+                return await auth_cache.get_firewall_headers(cache_key, _firewall_auth_request())
 
             tasks = [asyncio.create_task(fetch_headers(started_event)) for started_event in started]
             try:
@@ -81,12 +81,12 @@ class TestFirewallHeaderCache:
         cache_hit_flags = [result["cache_hit"] for result in results]
         assert sum(flag is False for flag in cache_hit_flags) == 1
         assert sum(flag is True for flag in cache_hit_flags) == 2
-        assert require_cached_headers(("run-1", "api-1")).payload.headers == {
+        assert require_cached_headers(cache_key).payload.headers == {
             "Authorization": "Bearer token"
         }
 
     async def test_different_keys_fetch_independently(self, mitm_ctx):
-        """Different (run_id, api_id) pairs should fetch independently."""
+        """Different auth cache keys should fetch independently."""
         endpoint = FakeAuthEndpoint()
         endpoint.queue_json_response(
             {
@@ -102,9 +102,11 @@ class TestFirewallHeaderCache:
         )
 
         with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
+            first_key = auth_cache_key(api_id="api-1")
+            second_key = auth_cache_key(api_id="api-2")
             first, second = await asyncio.gather(
-                auth_cache.get_firewall_headers("run-1", "api-1", _firewall_auth_request()),
-                auth_cache.get_firewall_headers("run-1", "api-2", _firewall_auth_request()),
+                auth_cache.get_firewall_headers(first_key, _firewall_auth_request()),
+                auth_cache.get_firewall_headers(second_key, _firewall_auth_request()),
             )
 
         assert endpoint.request_count == 2
@@ -112,12 +114,48 @@ class TestFirewallHeaderCache:
         assert second["cache_hit"] is False
         cached_tokens = {
             require_cached_headers(cache_key).payload.headers["Authorization"]
-            for cache_key in (("run-1", "api-1"), ("run-1", "api-2"))
+            for cache_key in (first_key, second_key)
         }
         assert cached_tokens == {"Bearer token-1", "Bearer token-2"}
 
+    async def test_same_run_and_api_with_different_auth_identities_fetch_independently(
+        self, mitm_ctx
+    ):
+        """Same run/api pairs with different auth inputs must not share headers."""
+        endpoint = FakeAuthEndpoint()
+        endpoint.queue_json_response(
+            {
+                "headers": {"Authorization": "Bearer explicit"},
+                "expiresAt": time.time() + 3600,
+            }
+        )
+        endpoint.queue_json_response(
+            {
+                "headers": {"Authorization": "Bearer default"},
+                "expiresAt": time.time() + 3600,
+            }
+        )
+
+        explicit_key = auth_cache_key(auth_identity="explicit-permission")
+        default_key = auth_cache_key(auth_identity="default-permission")
+
+        with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
+            explicit = await auth_cache.get_firewall_headers(explicit_key, _firewall_auth_request())
+            default = await auth_cache.get_firewall_headers(default_key, _firewall_auth_request())
+
+        assert endpoint.request_count == 2
+        assert explicit["headers"] == {"Authorization": "Bearer explicit"}
+        assert default["headers"] == {"Authorization": "Bearer default"}
+        assert require_cached_headers(explicit_key).payload.headers == {
+            "Authorization": "Bearer explicit"
+        }
+        assert require_cached_headers(default_key).payload.headers == {
+            "Authorization": "Bearer default"
+        }
+
     async def test_fetch_failure_does_not_cache(self, mitm_ctx):
         """Failed fetch should not populate cache; next caller retries independently."""
+        cache_key = auth_cache_key()
         endpoint = FakeAuthEndpoint()
         endpoint.queue_response(500, body=b"not-json")
         endpoint.queue_json_response(
@@ -129,31 +167,27 @@ class TestFirewallHeaderCache:
 
         with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
             with pytest.raises(urllib.error.HTTPError):
-                await auth_cache.get_firewall_headers("run-1", "api-1", _firewall_auth_request())
+                await auth_cache.get_firewall_headers(cache_key, _firewall_auth_request())
 
             assert endpoint.request_count == 1
-            assert cached_headers(("run-1", "api-1")) is None
+            assert cached_headers(cache_key) is None
 
-            retry = await auth_cache.get_firewall_headers(
-                "run-1", "api-1", _firewall_auth_request()
-            )
+            retry = await auth_cache.get_firewall_headers(cache_key, _firewall_auth_request())
             assert retry["headers"] == {"Authorization": "Bearer retry"}
             assert retry["cache_hit"] is False
             assert endpoint.request_count == 2
-            assert require_cached_headers(("run-1", "api-1")).payload.headers == {
+            assert require_cached_headers(cache_key).payload.headers == {
                 "Authorization": "Bearer retry"
             }
 
-            cached = await auth_cache.get_firewall_headers(
-                "run-1", "api-1", _firewall_auth_request()
-            )
+            cached = await auth_cache.get_firewall_headers(cache_key, _firewall_auth_request())
             assert cached["headers"] == {"Authorization": "Bearer retry"}
             assert cached["cache_hit"] is True
             assert endpoint.request_count == 2
 
     def test_registry_eviction_cleans_locks(self, tmp_path, mitm_ctx):
         """When a run is evicted from registry, its locks should be cleaned up too."""
-        cache_key = ("run-old", "api-1")
+        cache_key = auth_cache_key(run_id="run-old")
         set_cached_headers(cache_key, headers={}, expires_at=None)
 
         registry = {"vms": {"10.200.0.1": {"runId": "run-new", "billableFirewalls": []}}}

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -20,6 +20,7 @@ import platform_api
 from aws_sigv4 import AwsSigV4Credentials
 from tests.auth_endpoint_helpers import FakeAuthEndpoint
 from tests.auth_state_helpers import (
+    auth_cache_key,
     cached_headers,
     force_refresh_pending,
     last_force_refresh_at,
@@ -207,12 +208,12 @@ class TestGetFirewallHeaders:
         mock_result = _auth_success(headers=mock_headers)
         encrypted = "iv:tag:data"
         auth_templates = {"Authorization": "Bearer ${{ secrets.TOKEN }}"}
+        cache_key = auth_cache_key(api_id="https://api.github.com")
 
         mock_fetch = AsyncMock(return_value=mock_result)
         with patch.object(auth_cache, "fetch_firewall_headers", mock_fetch):
             headers = await auth_cache.get_firewall_headers(
-                "run-1",
-                "https://api.github.com",
+                cache_key,
                 _firewall_auth_request(
                     encrypted_secrets=encrypted,
                     auth_headers=auth_templates,
@@ -232,21 +233,17 @@ class TestGetFirewallHeaders:
         )
         assert mock_fetch.call_args.kwargs == {"force_refresh": False}
 
-        # Verify the cache was populated
-        cache_key = ("run-1", "https://api.github.com")
         assert cached_headers(cache_key)
         assert require_cached_headers(cache_key).payload.headers == mock_headers
 
     async def test_cache_hit_returns_cached(self, headers):
-        cache_key = ("run-1", "https://api.github.com")
+        cache_key = auth_cache_key(api_id="https://api.github.com")
         cached_headers = {"Authorization": "Bearer cached-token"}
         set_cached_headers(cache_key, headers=cached_headers)
 
         mock_fetch = AsyncMock()
         with patch.object(auth_cache, "fetch_firewall_headers", mock_fetch):
-            headers = await auth_cache.get_firewall_headers(
-                "run-1", "https://api.github.com", _firewall_auth_request()
-            )
+            headers = await auth_cache.get_firewall_headers(cache_key, _firewall_auth_request())
 
         assert headers["headers"] == cached_headers
         assert headers["cache_hit"] is True
@@ -254,7 +251,7 @@ class TestGetFirewallHeaders:
 
     async def test_cache_hit_with_valid_ttl_returns_cached(self, headers):
         """Cached entry with expiresAt in the future should be returned without fetching."""
-        cache_key = ("run-1", "api-1")
+        cache_key = auth_cache_key()
         cached_headers = {"Authorization": "Bearer valid-token"}
         set_cached_headers(
             cache_key,
@@ -264,9 +261,7 @@ class TestGetFirewallHeaders:
 
         mock_fetch = AsyncMock()
         with patch.object(auth_cache, "fetch_firewall_headers", mock_fetch):
-            headers = await auth_cache.get_firewall_headers(
-                "run-1", "api-1", _firewall_auth_request()
-            )
+            headers = await auth_cache.get_firewall_headers(cache_key, _firewall_auth_request())
 
         assert headers["headers"] == cached_headers
         assert headers["cache_hit"] is True
@@ -274,7 +269,7 @@ class TestGetFirewallHeaders:
 
     async def test_cache_evicted_when_ttl_expired(self, headers):
         """Cached entry with expiresAt in the past should trigger a re-fetch."""
-        cache_key = ("run-1", "api-1")
+        cache_key = auth_cache_key()
         set_cached_headers(
             cache_key,
             headers={"Authorization": "Bearer stale-token"},
@@ -286,9 +281,7 @@ class TestGetFirewallHeaders:
 
         mock_fetch = AsyncMock(return_value=mock_result)
         with patch.object(auth_cache, "fetch_firewall_headers", mock_fetch):
-            headers = await auth_cache.get_firewall_headers(
-                "run-1", "api-1", _firewall_auth_request()
-            )
+            headers = await auth_cache.get_firewall_headers(cache_key, _firewall_auth_request())
 
         assert headers["headers"] == fresh_headers
         assert headers["cache_hit"] is False
@@ -299,30 +292,27 @@ class TestGetFirewallHeaders:
 
     async def test_cache_with_null_expires_at_never_evicts(self, headers):
         """Cached entry with expiresAt=None (non-expiring) should never be evicted by TTL."""
-        cache_key = ("run-1", "api-1")
+        cache_key = auth_cache_key()
         cached_headers = {"Authorization": "Bearer permanent-token"}
         set_cached_headers(cache_key, headers=cached_headers, expires_at=None)
 
         mock_fetch = AsyncMock()
         with patch.object(auth_cache, "fetch_firewall_headers", mock_fetch):
-            headers = await auth_cache.get_firewall_headers(
-                "run-1", "api-1", _firewall_auth_request()
-            )
+            headers = await auth_cache.get_firewall_headers(cache_key, _firewall_auth_request())
 
         assert headers["headers"] == cached_headers
         assert headers["cache_hit"] is True
         mock_fetch.assert_not_called()
 
     async def test_billable_cache_hit_requires_valid_expiry(self, headers):
-        cache_key = ("run-1", "api-1")
+        cache_key = auth_cache_key()
         cached_headers = {"Authorization": "Bearer cached-token"}
         set_cached_headers(cache_key, headers=cached_headers, expires_at=time.time() + 30)
 
         mock_fetch = AsyncMock()
         with patch.object(auth_cache, "fetch_firewall_headers", mock_fetch):
             headers = await auth_cache.get_firewall_headers(
-                "run-1",
-                "api-1",
+                cache_key,
                 _firewall_auth_request(firewall_billable=True),
             )
 
@@ -347,7 +337,7 @@ class TestGetFirewallHeaders:
 
     @pytest.mark.parametrize("expiry", [True, "123", float("inf"), float("nan")])
     async def test_cache_with_invalid_expiry_refetches(self, headers, expiry):
-        cache_key = ("run-1", "api-1")
+        cache_key = auth_cache_key()
         set_cached_headers(
             cache_key,
             headers={"Authorization": "Bearer malformed-token"},
@@ -357,16 +347,14 @@ class TestGetFirewallHeaders:
         mock_fetch = AsyncMock(return_value=_auth_success(headers=fresh_headers, expires_at=None))
 
         with patch.object(auth_cache, "fetch_firewall_headers", mock_fetch):
-            headers = await auth_cache.get_firewall_headers(
-                "run-1", "api-1", _firewall_auth_request()
-            )
+            headers = await auth_cache.get_firewall_headers(cache_key, _firewall_auth_request())
 
         assert headers["headers"] == fresh_headers
         assert headers["cache_hit"] is False
         mock_fetch.assert_called_once()
 
     async def test_billable_cache_without_expiry_refetches(self, headers):
-        cache_key = ("run-1", "api-1")
+        cache_key = auth_cache_key()
         set_cached_headers(
             cache_key,
             headers={"Authorization": "Bearer stale-token"},
@@ -380,8 +368,7 @@ class TestGetFirewallHeaders:
 
         with patch.object(auth_cache, "fetch_firewall_headers", mock_fetch):
             headers = await auth_cache.get_firewall_headers(
-                "run-1",
-                "api-1",
+                cache_key,
                 _firewall_auth_request(firewall_billable=True),
             )
 
@@ -392,7 +379,7 @@ class TestGetFirewallHeaders:
         assert require_cached_headers(cache_key).expires_at == expires_at
 
     async def test_billable_cache_with_expired_expiry_refetches(self, headers):
-        cache_key = ("run-1", "api-1")
+        cache_key = auth_cache_key()
         set_cached_headers(
             cache_key,
             headers={"Authorization": "Bearer stale-token"},
@@ -405,8 +392,7 @@ class TestGetFirewallHeaders:
 
         with patch.object(auth_cache, "fetch_firewall_headers", mock_fetch):
             headers = await auth_cache.get_firewall_headers(
-                "run-1",
-                "api-1",
+                cache_key,
                 _firewall_auth_request(firewall_billable=True),
             )
 
@@ -426,7 +412,7 @@ class TestGetFirewallHeaders:
         ],
     )
     async def test_billable_fetch_with_invalid_expiry_fails_closed(self, expires_at):
-        cache_key = ("run-1", "api-1")
+        cache_key = auth_cache_key()
         mock_fetch = AsyncMock(
             return_value=_auth_success(
                 headers={"Authorization": "Bearer token"},
@@ -439,15 +425,14 @@ class TestGetFirewallHeaders:
             pytest.raises(auth_cache.InvalidBillableAuthExpiryError),
         ):
             await auth_cache.get_firewall_headers(
-                "run-1",
-                "api-1",
+                cache_key,
                 _firewall_auth_request(firewall_billable=True),
             )
         assert cached_headers(cache_key) is None
 
     async def test_cache_hit_includes_base_when_present(self, headers):
         """Cached entry with 'base' returns it on cache hit."""
-        cache_key = ("run-1", "api-1")
+        cache_key = auth_cache_key()
         set_cached_headers(
             cache_key,
             headers={},
@@ -458,9 +443,7 @@ class TestGetFirewallHeaders:
 
         mock_fetch = AsyncMock()
         with patch.object(auth_cache, "fetch_firewall_headers", mock_fetch):
-            result = await auth_cache.get_firewall_headers(
-                "run-1", "api-1", _firewall_auth_request()
-            )
+            result = await auth_cache.get_firewall_headers(cache_key, _firewall_auth_request())
 
         assert result["base"] == "https://discord.com/api/webhooks/123/abc"
         assert result["cache_hit"] is True
@@ -468,7 +451,7 @@ class TestGetFirewallHeaders:
 
     async def test_query_is_cached_and_returned_on_cache_hit(self):
         """auth.query is cached after a fetch and returned on cache hit."""
-        cache_key = ("run-1", "api-1")
+        cache_key = auth_cache_key()
         cached_query = {"api_key": "cached-key", "empty_auth": ""}
         mock_fetch = AsyncMock(
             return_value=_auth_success(
@@ -479,12 +462,8 @@ class TestGetFirewallHeaders:
         )
 
         with patch.object(auth_cache, "fetch_firewall_headers", mock_fetch):
-            first = await auth_cache.get_firewall_headers(
-                "run-1", "api-1", _firewall_auth_request()
-            )
-            second = await auth_cache.get_firewall_headers(
-                "run-1", "api-1", _firewall_auth_request()
-            )
+            first = await auth_cache.get_firewall_headers(cache_key, _firewall_auth_request())
+            second = await auth_cache.get_firewall_headers(cache_key, _firewall_auth_request())
 
         assert first["query"] == cached_query
         assert first["cache_hit"] is False
@@ -495,7 +474,7 @@ class TestGetFirewallHeaders:
 
     async def test_base_and_query_are_cached_together(self):
         """auth.base and auth.query survive the same cache entry."""
-        cache_key = ("run-1", "api-1")
+        cache_key = auth_cache_key()
         cached_base = "https://example.com/webhook/secret"
         cached_query = {"api_key": "cached-key", "empty_auth": ""}
         mock_fetch = AsyncMock(
@@ -507,12 +486,8 @@ class TestGetFirewallHeaders:
         )
 
         with patch.object(auth_cache, "fetch_firewall_headers", mock_fetch):
-            first = await auth_cache.get_firewall_headers(
-                "run-1", "api-1", _firewall_auth_request()
-            )
-            second = await auth_cache.get_firewall_headers(
-                "run-1", "api-1", _firewall_auth_request()
-            )
+            first = await auth_cache.get_firewall_headers(cache_key, _firewall_auth_request())
+            second = await auth_cache.get_firewall_headers(cache_key, _firewall_auth_request())
 
         assert first["base"] == cached_base
         assert first["query"] == cached_query
@@ -527,7 +502,7 @@ class TestGetFirewallHeaders:
 
     async def test_cache_hit_omits_base_when_absent(self, headers):
         """Cached entry without 'base' does not include it in result."""
-        cache_key = ("run-1", "api-1")
+        cache_key = auth_cache_key()
         set_cached_headers(
             cache_key,
             headers={"Authorization": "Bearer tok"},
@@ -537,9 +512,7 @@ class TestGetFirewallHeaders:
 
         mock_fetch = AsyncMock()
         with patch.object(auth_cache, "fetch_firewall_headers", mock_fetch):
-            result = await auth_cache.get_firewall_headers(
-                "run-1", "api-1", _firewall_auth_request()
-            )
+            result = await auth_cache.get_firewall_headers(cache_key, _firewall_auth_request())
 
         assert "base" not in result
         assert result["cache_hit"] is True
@@ -548,13 +521,13 @@ class TestGetFirewallHeaders:
         """When a force-refresh marker is set, the next fetch passes
         force_refresh=True, the marker is cleared, and the consume timestamp
         is recorded so the cooldown can suppress re-marking (#9860)."""
-        cache_key = ("run-1", "api-1")
+        cache_key = auth_cache_key()
         mark_force_refresh(cache_key)
         before = time.time()
 
         mock_fetch = AsyncMock(return_value=_auth_success(headers={"Authorization": "Bearer new"}))
         with patch.object(auth_cache, "fetch_firewall_headers", mock_fetch):
-            await auth_cache.get_firewall_headers("run-1", "api-1", _firewall_auth_request())
+            await auth_cache.get_firewall_headers(cache_key, _firewall_auth_request())
 
         # force_refresh kwarg must be True
         assert mock_fetch.call_args.kwargs["force_refresh"] is True
@@ -565,7 +538,7 @@ class TestGetFirewallHeaders:
 
     async def test_force_refresh_fetch_failure_still_consumes_marker(self, headers):
         """A failed forced refresh burns the cooldown and does not cache headers."""
-        cache_key = ("run-1", "api-1")
+        cache_key = auth_cache_key()
         mark_force_refresh(cache_key)
         before = time.time()
 
@@ -574,7 +547,7 @@ class TestGetFirewallHeaders:
             patch.object(auth_cache, "fetch_firewall_headers", mock_fetch),
             pytest.raises(ConnectionError),
         ):
-            await auth_cache.get_firewall_headers("run-1", "api-1", _firewall_auth_request())
+            await auth_cache.get_firewall_headers(cache_key, _firewall_auth_request())
 
         assert mock_fetch.call_args.kwargs["force_refresh"] is True
         assert not force_refresh_pending(cache_key)
@@ -583,7 +556,7 @@ class TestGetFirewallHeaders:
 
     async def test_non_forced_fetch_does_not_cache_if_marker_appears_in_flight(self, headers):
         """A 401 marker during a non-forced fetch must win over the cache write."""
-        cache_key = ("run-1", "api-1")
+        cache_key = auth_cache_key()
         fetch_entered = asyncio.Event()
         allow_fetch_return = asyncio.Event()
         first_force_refresh_values = []
@@ -600,7 +573,7 @@ class TestGetFirewallHeaders:
 
         with patch.object(auth_cache, "fetch_firewall_headers", side_effect=delayed_fetch):
             task = asyncio.create_task(
-                auth_cache.get_firewall_headers("run-1", "api-1", _firewall_auth_request())
+                auth_cache.get_firewall_headers(cache_key, _firewall_auth_request())
             )
             try:
                 await asyncio.wait_for(fetch_entered.wait(), timeout=5)
@@ -625,7 +598,7 @@ class TestGetFirewallHeaders:
 
         with patch.object(auth_cache, "fetch_firewall_headers", forced_fetch):
             forced_result = await auth_cache.get_firewall_headers(
-                "run-1", "api-1", _firewall_auth_request()
+                cache_key, _firewall_auth_request()
             )
 
         assert forced_fetch.call_args.kwargs["force_refresh"] is True
@@ -637,7 +610,7 @@ class TestGetFirewallHeaders:
 
     async def test_waiting_request_force_refreshes_after_in_flight_marker(self, headers):
         """A same-key waiter must not reuse headers from the stale-prone leader fetch."""
-        cache_key = ("run-1", "api-1")
+        cache_key = auth_cache_key()
         first_fetch_entered = asyncio.Event()
         allow_first_fetch_return = asyncio.Event()
         force_refresh_values = []
@@ -661,13 +634,13 @@ class TestGetFirewallHeaders:
             auth_cache, "fetch_firewall_headers", side_effect=fetch_with_blocked_leader
         ):
             leader = asyncio.create_task(
-                auth_cache.get_firewall_headers("run-1", "api-1", _firewall_auth_request())
+                auth_cache.get_firewall_headers(cache_key, _firewall_auth_request())
             )
             waiter = None
             try:
                 await asyncio.wait_for(first_fetch_entered.wait(), timeout=5)
                 waiter = asyncio.create_task(
-                    auth_cache.get_firewall_headers("run-1", "api-1", _firewall_auth_request())
+                    auth_cache.get_firewall_headers(cache_key, _firewall_auth_request())
                 )
                 auth_cache.request_force_refresh(cache_key)
                 allow_first_fetch_return.set()
@@ -687,18 +660,32 @@ class TestGetFirewallHeaders:
 
     async def test_force_refresh_absent_passes_false(self, headers):
         """Without a marker, fetch is called with force_refresh=False (#9860)."""
+        cache_key = auth_cache_key(api_id="api-2")
         mock_fetch = AsyncMock(return_value=_auth_success(headers={}))
         with patch.object(auth_cache, "fetch_firewall_headers", mock_fetch):
-            await auth_cache.get_firewall_headers("run-1", "api-2", _firewall_auth_request())
+            await auth_cache.get_firewall_headers(cache_key, _firewall_auth_request())
 
         assert mock_fetch.call_args.kwargs["force_refresh"] is False
         # No consume timestamp written when force-refresh didn't happen
-        assert last_force_refresh_at(("run-1", "api-2")) == 0.0
+        assert last_force_refresh_at(cache_key) == 0.0
+
+    async def test_force_refresh_marker_is_scoped_to_auth_identity(self, headers):
+        old_key = auth_cache_key(auth_identity="old-auth")
+        new_key = auth_cache_key(auth_identity="new-auth")
+        mark_force_refresh(old_key)
+
+        mock_fetch = AsyncMock(return_value=_auth_success(headers={}))
+        with patch.object(auth_cache, "fetch_firewall_headers", mock_fetch):
+            await auth_cache.get_firewall_headers(new_key, _firewall_auth_request())
+
+        assert mock_fetch.call_args.kwargs["force_refresh"] is False
+        assert force_refresh_pending(old_key)
+        assert not force_refresh_pending(new_key)
 
     async def test_force_refresh_marker_ignored_on_cache_hit(self, headers):
         """Fast-path cache hit does NOT consume the force-refresh marker —
         marker survives until the next actual fetch (#9860)."""
-        cache_key = ("run-1", "api-1")
+        cache_key = auth_cache_key()
         set_cached_headers(
             cache_key,
             headers={"Authorization": "Bearer cached"},
@@ -708,9 +695,7 @@ class TestGetFirewallHeaders:
 
         mock_fetch = AsyncMock()
         with patch.object(auth_cache, "fetch_firewall_headers", mock_fetch):
-            result = await auth_cache.get_firewall_headers(
-                "run-1", "api-1", _firewall_auth_request()
-            )
+            result = await auth_cache.get_firewall_headers(cache_key, _firewall_auth_request())
 
         assert result["cache_hit"] is True
         mock_fetch.assert_not_called()
@@ -1074,7 +1059,7 @@ class TestHandleFirewallRequest:
         assert "Authorization" not in flow.request.headers
         assert "api_key" not in flow.request.query
         assert flow.request.query["existing"] == "1"
-        assert cached_headers(("test-run", "https://api.github.com")) is None
+        assert cached_headers(flow.metadata[metadata_keys.FIREWALL_AUTH_CACHE_KEY]) is None
         body = json.loads(flow.response.content)
         assert body["error"] == "auth_failed"
         assert body["permission"] == "github"
@@ -1118,7 +1103,7 @@ class TestHandleFirewallRequest:
         assert "Authorization" not in flow.request.headers
         assert "api_key" not in flow.request.query
         assert flow.request.query["existing"] == "1"
-        assert cached_headers(("test-run", "https://api.github.com")) is None
+        assert cached_headers(flow.metadata[metadata_keys.FIREWALL_AUTH_CACHE_KEY]) is None
         body = json.loads(flow.response.content)
         assert body["error"] == "auth_failed"
         assert "Firewall auth response body too large" in body["message"]
@@ -1157,7 +1142,7 @@ class TestHandleFirewallRequest:
         assert "Authorization" not in flow.request.headers
         assert "api_key" not in flow.request.query
         assert flow.request.query["existing"] == "1"
-        assert cached_headers(("test-run", "https://api.github.com")) is None
+        assert cached_headers(flow.metadata[metadata_keys.FIREWALL_AUTH_CACHE_KEY]) is None
         body = json.loads(flow.response.content)
         assert body["error"] == "auth_failed"
         assert _MALFORMED_SUCCESS_PREFIX in body["message"]
@@ -1278,7 +1263,7 @@ class TestHandleFirewallRequest:
         assert "Authorization" not in flow.request.headers
         assert metadata_keys.AUTH_URL_REWRITE not in flow.metadata
         assert "api_key" not in flow.request.query
-        assert cached_headers(("test-run", "https://api.github.com")) is None
+        assert cached_headers(flow.metadata[metadata_keys.FIREWALL_AUTH_CACHE_KEY]) is None
         body = json.loads(flow.response.content)
         assert body["error"] == "invalid_auth_expiry"
         assert "valid cache expiry" in body["message"]

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -757,6 +757,44 @@ class TestHandleFirewallRequest:
         log_text = await asyncio.to_thread(read_jsonl_text_after_flush, proxy_log_path)
         assert "Firewall https://api.github.com: api.github.com" in log_text
 
+    async def test_auth_cache_identity_tracks_request_auth_inputs(
+        self, real_flow, mitm_ctx, tmp_path
+    ):
+        """Same run/api entries must not share headers across auth input changes."""
+        api_entry = _api_entry(
+            api_id="run-1:0",
+            auth_config={"headers": {"Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"}},
+        )
+        allow = _allow(api_entry)
+        first_flow = _firewall_flow(real_flow, run_id="run-1")
+        second_flow = _firewall_flow(real_flow, run_id="run-1")
+        first_vm_info = _vm_info(tmp_path, run_id="run-1", encrypted_secrets="encrypted-first")
+        second_vm_info = _vm_info(tmp_path, run_id="run-1", encrypted_secrets="encrypted-second")
+        mock_fetch = AsyncMock(
+            side_effect=[
+                _auth_success(headers={"Authorization": "Bearer first"}),
+                _auth_success(headers={"Authorization": "Bearer second"}),
+            ]
+        )
+
+        with patch.object(auth_cache, "fetch_firewall_headers", mock_fetch), mitm_ctx():
+            first_result = await auth.handle_firewall_request(first_flow, allow, first_vm_info)
+            second_result = await auth.handle_firewall_request(second_flow, allow, second_vm_info)
+
+        assert first_result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
+        assert second_result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
+        assert first_flow.request.headers["Authorization"] == "Bearer first"
+        assert second_flow.request.headers["Authorization"] == "Bearer second"
+        assert mock_fetch.call_count == 2
+
+        first_cache_key = first_flow.metadata[metadata_keys.FIREWALL_AUTH_CACHE_KEY]
+        second_cache_key = second_flow.metadata[metadata_keys.FIREWALL_AUTH_CACHE_KEY]
+        assert first_cache_key.run_id == "run-1"
+        assert first_cache_key.api_id == "run-1:0"
+        assert second_cache_key.run_id == "run-1"
+        assert second_cache_key.api_id == "run-1:0"
+        assert first_cache_key.auth_identity != second_cache_key.auth_identity
+
     async def test_standard_auth_filters_unsafe_resolved_headers(
         self, real_flow, headers, mitm_ctx, tmp_path
     ):

--- a/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
@@ -5,11 +5,12 @@ import urllib.parse
 import pytest
 
 import auth
+import firewall_auth_client as auth_client
 import flow_metadata_keys as metadata_keys
 import matching
 from aws_sigv4 import AwsSigV4Credentials
 from tests.auth_endpoint_helpers import FakeAuthEndpoint
-from tests.auth_state_helpers import set_cached_headers
+from tests.auth_state_helpers import auth_cache_key, set_cached_headers
 from url_utils import get_original_url
 
 
@@ -72,6 +73,28 @@ def _prepare_firewall_request(flow, *, original_url: str | None = None) -> None:
     flow.metadata[metadata_keys.VM_RUN_ID] = "run-1"
     flow.metadata[metadata_keys.ORIGINAL_URL] = (
         get_original_url(flow) if original_url is None else original_url
+    )
+
+
+def _aws_auth_cache_key(tmp_path, api_entry: dict | None = None):
+    resolved_api_entry = api_entry or _api_entry()
+    vm_info = _vm_info(tmp_path)
+    auth_config = resolved_api_entry["auth"]
+    auth_request = auth_client.FirewallAuthRequest(
+        encrypted_secrets=vm_info["encryptedSecrets"],
+        auth_headers=auth_config["headers"],
+        sandbox_token=vm_info["sandboxToken"],
+        auth_aws_sigv4=auth_config["awsSigv4"],
+        vars_map=vm_info["vars"],
+    )
+    return auth_cache_key(
+        run_id=vm_info["runId"],
+        api_id=resolved_api_entry["base"],
+        auth_identity=auth._build_firewall_auth_identity(
+            firewall_name="aws",
+            firewall_base=resolved_api_entry["base"],
+            auth_request=auth_request,
+        ),
     )
 
 
@@ -806,7 +829,7 @@ async def test_header_sigv4_with_empty_resolved_secret_key_fails_closed(
     )
     _prepare_firewall_request(flow)
     set_cached_headers(
-        ("run-1", "https://sts.amazonaws.com"),
+        _aws_auth_cache_key(tmp_path),
         headers={},
         aws_sigv4=AwsSigV4Credentials("AKIDEXAMPLE", ""),
     )
@@ -846,7 +869,7 @@ async def test_header_sigv4_without_trusted_original_url_fails_closed(
     )
     flow.metadata[metadata_keys.VM_RUN_ID] = "run-1"
     set_cached_headers(
-        ("run-1", "https://sts.amazonaws.com"),
+        _aws_auth_cache_key(tmp_path),
         headers={},
         aws_sigv4=AwsSigV4Credentials(
             "AKIDEXAMPLE",
@@ -898,7 +921,7 @@ async def test_header_sigv4_with_malformed_current_request_target_fails_closed(
     _prepare_firewall_request(flow)
     flow.request.path = request_path
     set_cached_headers(
-        ("run-1", "https://sts.amazonaws.com"),
+        _aws_auth_cache_key(tmp_path),
         headers={},
         aws_sigv4=AwsSigV4Credentials(
             "AKIDEXAMPLE",
@@ -941,7 +964,7 @@ async def test_header_sigv4_with_empty_resolved_session_token_fails_closed(
     )
     _prepare_firewall_request(flow)
     set_cached_headers(
-        ("run-1", "https://sts.amazonaws.com"),
+        _aws_auth_cache_key(tmp_path),
         headers={},
         aws_sigv4=AwsSigV4Credentials(
             "AKIDEXAMPLE",

--- a/crates/runner/mitm-addon/tests/test_registry_auth_cache_eviction.py
+++ b/crates/runner/mitm-addon/tests/test_registry_auth_cache_eviction.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import registry
 from tests.auth_state_helpers import (
+    auth_cache_key,
     cached_headers,
     force_refresh_pending,
     has_auth_state,
@@ -23,14 +24,15 @@ class TestRegistryAuthCacheEviction:
         write_simple_registry(path_a, run_id="run-one")
         write_simple_registry(path_b, run_id="run-two")
         registry.load_registry(str(path_a))
+        cache_key = auth_cache_key(run_id="run-one", api_id="api-0")
         set_cached_headers(
-            ("run-one", "api-0"),
+            cache_key,
             headers={"Authorization": "Bearer old"},
         )
 
         registry.load_registry(str(path_b))
 
-        assert not has_auth_state(("run-one", "api-0"))
+        assert not has_auth_state(cache_key)
 
     def test_evicts_header_cache_on_run_removal(self, registry_file):
         """When a run disappears from registry, its header cache entries are evicted."""
@@ -38,19 +40,21 @@ class TestRegistryAuthCacheEviction:
 
         # Simulate cached headers, locks, markers, and refresh timestamps
         # for run-abc-123
+        removed_key = auth_cache_key(run_id="run-abc-123", api_id="api-0")
+        retained_key = auth_cache_key(run_id="run-other", api_id="api-0")
         set_cached_headers(
-            ("run-abc-123", "api-0"),
+            removed_key,
             headers={"Authorization": "Bearer tok"},
         )
-        mark_force_refresh(("run-abc-123", "api-0"))
-        set_last_force_refresh_at(("run-abc-123", "api-0"), 100.0)
+        mark_force_refresh(removed_key)
+        set_last_force_refresh_at(removed_key, 100.0)
         # Also cache for run-other (will appear in new registry)
         set_cached_headers(
-            ("run-other", "api-0"),
+            retained_key,
             headers={"Authorization": "Bearer other"},
         )
-        mark_force_refresh(("run-other", "api-0"))
-        set_last_force_refresh_at(("run-other", "api-0"), 200.0)
+        mark_force_refresh(retained_key)
+        set_last_force_refresh_at(retained_key, 200.0)
 
         # Update registry: remove run-abc-123, add run-other
         new_data = {"vms": {"10.200.0.99": {"runId": "run-other"}}, "updatedAt": 0}
@@ -59,11 +63,11 @@ class TestRegistryAuthCacheEviction:
         registry.load_registry(str(registry_file))  # reload triggers eviction
 
         # run-abc-123 state should be evicted (no longer in registry)
-        assert not has_auth_state(("run-abc-123", "api-0"))
+        assert not has_auth_state(removed_key)
         # run-other state should remain (still in registry)
-        assert cached_headers(("run-other", "api-0"))
-        assert force_refresh_pending(("run-other", "api-0"))
-        assert last_force_refresh_at(("run-other", "api-0")) == 200.0
+        assert cached_headers(retained_key)
+        assert force_refresh_pending(retained_key)
+        assert last_force_refresh_at(retained_key) == 200.0
 
     def test_repeated_parse_failure_does_not_re_evict_auth_state(
         self,
@@ -72,7 +76,7 @@ class TestRegistryAuthCacheEviction:
         """Unavailable registry clears auth state once when ownership is unknown."""
         registry.load_registry(str(registry_file))
 
-        old_cache_key = ("run-abc-123", "api-0")
+        old_cache_key = auth_cache_key(run_id="run-abc-123", api_id="api-0")
         set_cached_headers(
             old_cache_key,
             headers={"Authorization": "Bearer tok"},
@@ -87,7 +91,7 @@ class TestRegistryAuthCacheEviction:
 
         assert not has_auth_state(old_cache_key)
 
-        new_cache_key = ("run-after-failure", "api-0")
+        new_cache_key = auth_cache_key(run_id="run-after-failure", api_id="api-0")
         set_cached_headers(
             new_cache_key,
             headers={"Authorization": "Bearer after-failure"},
@@ -106,25 +110,28 @@ class TestRegistryAuthCacheEviction:
         """Registry eviction removes auth state even when it has no cached headers."""
         registry.load_registry(str(registry_file))
 
-        mark_force_refresh(("run-abc-123", "api-0"))
-        set_last_force_refresh_at(("run-abc-123", "api-0"), 100.0)
+        cache_key = auth_cache_key(run_id="run-abc-123", api_id="api-0")
+        mark_force_refresh(cache_key)
+        set_last_force_refresh_at(cache_key, 100.0)
 
         registry_file.write_text(json.dumps({"vms": {}, "updatedAt": 0}))
 
         registry.load_registry(str(registry_file))
 
-        assert not has_auth_state(("run-abc-123", "api-0"))
+        assert not has_auth_state(cache_key)
 
     def test_registry_entries_without_run_id_do_not_keep_header_cache(self, registry_file):
         """Registry entries with missing or blank runId are not active cache owners."""
         registry.load_registry(str(registry_file))
 
-        set_cached_headers(("", "api-0"), headers={})
-        mark_force_refresh(("", "api-0"))
-        set_last_force_refresh_at(("", "api-0"), 100.0)
-        set_cached_headers(("run-active", "api-0"), headers={})
-        mark_force_refresh(("run-active", "api-0"))
-        set_last_force_refresh_at(("run-active", "api-0"), 200.0)
+        blank_run_key = auth_cache_key(run_id="", api_id="api-0")
+        active_run_key = auth_cache_key(run_id="run-active", api_id="api-0")
+        set_cached_headers(blank_run_key, headers={})
+        mark_force_refresh(blank_run_key)
+        set_last_force_refresh_at(blank_run_key, 100.0)
+        set_cached_headers(active_run_key, headers={})
+        mark_force_refresh(active_run_key)
+        set_last_force_refresh_at(active_run_key, 200.0)
 
         registry_file.write_text(
             json.dumps(
@@ -144,10 +151,10 @@ class TestRegistryAuthCacheEviction:
         with patch.object(registry.ctx, "log", MagicMock(), create=True):
             registry.load_registry(str(registry_file))
 
-        assert not has_auth_state(("", "api-0"))
-        assert cached_headers(("run-active", "api-0"))
-        assert force_refresh_pending(("run-active", "api-0"))
-        assert last_force_refresh_at(("run-active", "api-0")) == 200.0
+        assert not has_auth_state(blank_run_key)
+        assert cached_headers(active_run_key)
+        assert force_refresh_pending(active_run_key)
+        assert last_force_refresh_at(active_run_key) == 200.0
 
     def test_valid_entry_becoming_invalid_evicts_context_and_cache(self, tmp_path):
         registry_file = tmp_path / "registry.json"
@@ -157,8 +164,9 @@ class TestRegistryAuthCacheEviction:
         assert context is not None
         _, compiled_firewalls, _ = context
         assert compiled_firewalls is not None
+        cache_key = auth_cache_key(run_id="run-abc-123", api_id="api-0")
         set_cached_headers(
-            ("run-abc-123", "api-0"),
+            cache_key,
             headers={"Authorization": "Bearer tok"},
         )
 
@@ -182,18 +190,20 @@ class TestRegistryAuthCacheEviction:
         assert state.compiled_firewalls == {}
         assert state.compiled_network_policies == {}
         assert registry.get_vm_context("10.200.0.1", str(registry_file)) is None
-        assert not has_auth_state(("run-abc-123", "api-0"))
+        assert not has_auth_state(cache_key)
 
     def test_invalid_vm_entries_do_not_block_header_cache_eviction(self, registry_file):
         """Invalid VM entries are not active cache owners."""
         registry.load_registry(str(registry_file))
 
-        set_cached_headers(("run-old", "api-0"), headers={})
-        mark_force_refresh(("run-old", "api-0"))
-        set_last_force_refresh_at(("run-old", "api-0"), 100.0)
-        set_cached_headers(("run-active", "api-0"), headers={})
-        mark_force_refresh(("run-active", "api-0"))
-        set_last_force_refresh_at(("run-active", "api-0"), 200.0)
+        old_run_key = auth_cache_key(run_id="run-old", api_id="api-0")
+        active_run_key = auth_cache_key(run_id="run-active", api_id="api-0")
+        set_cached_headers(old_run_key, headers={})
+        mark_force_refresh(old_run_key)
+        set_last_force_refresh_at(old_run_key, 100.0)
+        set_cached_headers(active_run_key, headers={})
+        mark_force_refresh(active_run_key)
+        set_last_force_refresh_at(active_run_key, 200.0)
 
         registry_file.write_text(
             json.dumps(
@@ -211,7 +221,7 @@ class TestRegistryAuthCacheEviction:
         with patch.object(registry.ctx, "log", MagicMock(), create=True):
             registry.load_registry(str(registry_file))
 
-        assert not has_auth_state(("run-old", "api-0"))
-        assert cached_headers(("run-active", "api-0"))
-        assert force_refresh_pending(("run-active", "api-0"))
-        assert last_force_refresh_at(("run-active", "api-0")) == 200.0
+        assert not has_auth_state(old_run_key)
+        assert cached_headers(active_run_key)
+        assert force_refresh_pending(active_run_key)
+        assert last_force_refresh_at(active_run_key) == 200.0

--- a/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
@@ -7,7 +7,7 @@ import pytest
 import flow_metadata_keys as metadata_keys
 import mitm_addon
 import registry
-from tests.auth_state_helpers import has_auth_state
+from tests.auth_state_helpers import auth_cache_key, has_auth_state
 from tests.request_handler_helpers import _single_firewall_vm, _write_registry
 
 
@@ -538,7 +538,7 @@ async def test_invalid_registered_vm_blocks_before_auth_injection(
         "reason": expected_reason,
     }
     auth_fetch.assert_not_called()
-    assert not has_auth_state(("", "https://api.github.com"))
+    assert not has_auth_state(auth_cache_key(run_id="", api_id="https://api.github.com"))
     assert metadata_keys.VM_RUN_ID not in flow.metadata
     assert metadata_keys.FIREWALL_BASE not in flow.metadata
     assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "BLOCK"

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -14,6 +14,7 @@ import mitm_addon
 import request_streaming
 from body_limits import STREAM_BUFFER_LIMIT
 from tests.auth_state_helpers import (
+    auth_cache_key,
     cached_headers,
     force_refresh_pending,
     has_auth_state,
@@ -1490,8 +1491,9 @@ class TestResponseHandler:
 
         flow.response = tutils.tresp(status_code=401, headers=http.Headers())
 
-        # Pre-populate firewall header cache keyed by api_id
-        cache_key = ("run-conn-1", "run-conn-1:0")
+        # Pre-populate firewall header cache with the request auth identity key.
+        cache_key = auth_cache_key(run_id="run-conn-1", api_id="run-conn-1:0")
+        flow.metadata[metadata_keys.FIREWALL_AUTH_CACHE_KEY] = cache_key
         set_cached_headers(cache_key, headers={"Authorization": "Bearer old-token"})
 
         with mitm_ctx():
@@ -1521,7 +1523,11 @@ class TestResponseHandler:
             headers=header_map({"content-length": "not-an-int"}),
         )
 
-        cache_key = ("run-conn-invalid-length", "run-conn-invalid-length:0")
+        cache_key = auth_cache_key(
+            run_id="run-conn-invalid-length",
+            api_id="run-conn-invalid-length:0",
+        )
+        flow.metadata[metadata_keys.FIREWALL_AUTH_CACHE_KEY] = cache_key
         set_cached_headers(cache_key, headers={"Authorization": "Bearer old-token"})
 
         with mitm_ctx():
@@ -1549,7 +1555,11 @@ class TestResponseHandler:
             headers=header_map({"content-length": "not-an-int"}),
         )
 
-        cache_key = ("run-conn-invalid-length-log", "run-conn-invalid-length-log:0")
+        cache_key = auth_cache_key(
+            run_id="run-conn-invalid-length-log",
+            api_id="run-conn-invalid-length-log:0",
+        )
+        flow.metadata[metadata_keys.FIREWALL_AUTH_CACHE_KEY] = cache_key
         set_cached_headers(cache_key, headers={"Authorization": "Bearer old-token"})
 
         with mitm_ctx():
@@ -1571,7 +1581,8 @@ class TestResponseHandler:
         flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.github.com/repos"
         flow.response = tutils.tresp(status_code=401, headers=http.Headers())
 
-        cache_key = ("run-conn-new", "run-conn-new:0")
+        cache_key = auth_cache_key(run_id="run-conn-new", api_id="run-conn-new:0")
+        flow.metadata[metadata_keys.FIREWALL_AUTH_CACHE_KEY] = cache_key
         assert not has_auth_state(cache_key)
 
         with mitm_ctx():
@@ -1594,7 +1605,8 @@ class TestResponseHandler:
         flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.github.com/repos"
         flow.response = tutils.tresp(status_code=401, headers=http.Headers())
 
-        cache_key = ("run-conn-cd", "run-conn-cd:0")
+        cache_key = auth_cache_key(run_id="run-conn-cd", api_id="run-conn-cd:0")
+        flow.metadata[metadata_keys.FIREWALL_AUTH_CACHE_KEY] = cache_key
         set_cached_headers(cache_key, headers={"Authorization": "Bearer cached-token"})
         # Simulate: a forced refresh JUST completed a moment ago
         set_last_force_refresh_at(cache_key, time.time())
@@ -1621,7 +1633,8 @@ class TestResponseHandler:
         flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.github.com/repos"
         flow.response = tutils.tresp(status_code=401, headers=http.Headers())
 
-        cache_key = ("run-conn-re", "run-conn-re:0")
+        cache_key = auth_cache_key(run_id="run-conn-re", api_id="run-conn-re:0")
+        flow.metadata[metadata_keys.FIREWALL_AUTH_CACHE_KEY] = cache_key
         # Simulate: last forced refresh happened well before the cooldown window
         set_last_force_refresh_at(
             cache_key,
@@ -1633,6 +1646,26 @@ class TestResponseHandler:
 
         # Cooldown elapsed → marker re-added
         assert force_refresh_pending(cache_key)
+
+    def test_401_without_auth_cache_key_does_not_synthesize_state(
+        self, real_flow, mitm_ctx, headers
+    ):
+        """401 invalidation requires the full request auth identity cache key."""
+        flow = real_flow(with_response=False, host="api.github.com")
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-conn-no-key"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = ""
+        flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+        flow.metadata[metadata_keys.FIREWALL_BASE] = "https://api.github.com"
+        flow.metadata[metadata_keys.FIREWALL_API_ID] = "run-conn-no-key:0"
+        flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.github.com/repos"
+        flow.response = tutils.tresp(status_code=401, headers=http.Headers())
+
+        assert auth_cache._auth_state == {}
+
+        with mitm_ctx():
+            mitm_addon.response(flow)
+
+        assert auth_cache._auth_state == {}
 
     def test_error_status_logs_warning(self, tmp_path, real_flow, headers):
         """Response with status >= 400 writes to per-job proxy log."""

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -151,8 +151,9 @@ pub struct Firewall {
 /// A single firewall API entry with base URL and auth headers for proxy-side matching.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct FirewallApi {
-    /// Unique identifier for cache keying in mitm-addon. Filled by the Python
-    /// registry loader after built-in refs and inline firewalls are resolved.
+    /// Stable API identifier used as one component of mitm-addon auth cache keys.
+    /// Filled by the Python registry loader after built-in refs and inline firewalls
+    /// are resolved.
     #[serde(default)]
     pub id: String,
     pub base: String,


### PR DESCRIPTION
## Problem

Firewall auth cache entries were keyed only by `run_id` and `api_id`. Default API IDs can remain stable for the same active run, so a registry update that changes the matched firewall auth inputs could still reuse a previously resolved credential payload before calling `/firewall/auth` again.

That can inject stale managed auth material into a different current firewall request when the base, secrets, vars, auth config, connector maps, or sandbox token changes while the run remains active.

## Solution

- Key mitm-addon firewall auth state with a typed `FirewallAuthCacheKey` containing `run_id`, `api_id`, and an auth input identity.
- Derive the auth identity from canonical auth request material, firewall identity fields, and a sandbox-token digest.
- Keep `forceRefresh` out of the identity because it is a one-shot fetch directive, not part of the credential identity.
- Store the typed cache key in request metadata and use that same key for 401 response invalidation instead of reconstructing a run/api-only key.
- Keep stale-cache eviction scoped by active run IDs.

Closes #19109

## Tests

- `cd crates/runner/mitm-addon && PATH=/tmp/mitm-addon-venv/bin:$PATH pytest tests`
- `cd crates/runner/mitm-addon && PATH=/tmp/mitm-addon-venv/bin:$PATH ruff format --check . && PATH=/tmp/mitm-addon-venv/bin:$PATH ruff check .`
- `cd crates && cargo fmt --check`
