### PR TITLE
perf: scope direct run connectors

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs-automations.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs-automations.ts
@@ -617,6 +617,20 @@ export function createRunsAutomationsApi(context: TestContext) {
       return response.body;
     },
 
+    async requestDirectRun(
+      actor: ApiTestUser | null,
+      body: DirectRunRequest,
+      statuses: readonly (201 | 400 | 401 | 402 | 403 | 404 | 429 | 503)[],
+    ) {
+      return await accept(
+        setupApp({ context })(runsMainContract).create({
+          headers: authenticate(context, actor),
+          body,
+        }),
+        statuses,
+      );
+    },
+
     async applyUserPermissionGrant(
       actor: ApiTestUser,
       body: {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -541,15 +541,32 @@ async function zeroBackedDirectRunActor(): Promise<{
 
 function zeroBackedDirectRunBody(args: {
   readonly agentId: string;
+  readonly agentComposeVersionId?: string;
   readonly prompt: string;
 }) {
   return {
-    agentComposeId: args.agentId,
+    ...(args.agentComposeVersionId
+      ? { agentComposeVersionId: args.agentComposeVersionId }
+      : { agentComposeId: args.agentId }),
     prompt: args.prompt,
     modelProviderType: "anthropic-api-key" as const,
     vars: { ZERO_AGENT_ID: args.agentId },
     secrets: { ZERO_TOKEN: "bdd-zero-direct-token" },
   };
+}
+
+async function readAgentHeadVersionId(agentId: string): Promise<string> {
+  const [composeRow] = await writeDb
+    .select({ headVersionId: agentComposes.headVersionId })
+    .from(agentComposes)
+    .where(eq(agentComposes.id, agentId))
+    .limit(1);
+  if (!composeRow?.headVersionId) {
+    throw new Error(
+      "Expected Zero-backed direct run agent to have a head version",
+    );
+  }
+  return composeRow.headVersionId;
 }
 
 const CHAT_CALLBACK_URL = "http://localhost:3000/api/internal/callbacks/chat";
@@ -1667,6 +1684,42 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     await api.requestCancelRun(actor, run.runId, [200]);
     const cancelled = await api.readRun(actor, run.runId);
     expect(cancelled.status).toBe("cancelled");
+  });
+
+  it("omits connected stored connectors for pinned Zero-backed direct run versions", async () => {
+    const api = createRunsAutomationsApi(context);
+    const fw = createFirewallApi(context);
+    const { actor, agentId, runnerGroup } = await zeroBackedDirectRunActor();
+    const agentComposeVersionId = await readAgentHeadVersionId(agentId);
+
+    await fw.seedTestConnector(actor, {
+      connectorName: "x",
+      authMethod: "oauth",
+      accessToken: "x-bdd-version-unallowed-access",
+      refreshToken: "x-bdd-version-unallowed-refresh",
+    });
+
+    const run = await api.createDirectRun(
+      actor,
+      zeroBackedDirectRunBody({
+        agentId,
+        agentComposeVersionId,
+        prompt: "direct run pinned to a zero agent version",
+      }),
+    );
+    const timingEvents = apiDispatchTimingEventsForRun(run.runId);
+    expectNoApiDispatchActions(
+      timingEvents,
+      API_DISPATCH_STORED_CONNECTOR_SUBSTEP_ACTION_TYPES,
+    );
+    await api.heartbeatRunner(runnerGroup);
+    const claim = await api.claimRunnerJob(run.runId);
+
+    expect(claim.agentComposeVersionId).toBe(agentComposeVersionId);
+    expect(claim.environment ?? {}).not.toHaveProperty("X_TOKEN");
+    expect(findFirewallEntry(claim.firewalls, "x")).toBeUndefined();
+
+    await api.requestCancelRun(actor, run.runId, [200]);
   });
 
   it("injects oauth connector tokens with billable firewalls and resolvable secrets", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -512,7 +512,9 @@ async function entitledRunActor(): Promise<{
   return { actor, agentId: agent.agentId, runnerGroup, granted };
 }
 
-async function zeroBackedDirectRunActor(): Promise<{
+async function zeroBackedDirectRunActor(args?: {
+  readonly visibility?: "private" | "public";
+}): Promise<{
   readonly actor: ApiTestUser;
   readonly orgId: string;
   readonly agentId: string;
@@ -533,7 +535,7 @@ async function zeroBackedDirectRunActor(): Promise<{
 
   const agent = await bdd.createAgent(actor, {
     displayName: "BDD zero-backed direct agent",
-    visibility: "private",
+    visibility: args?.visibility ?? "private",
   });
 
   return { actor, orgId: actor.orgId, agentId: agent.agentId, runnerGroup };
@@ -1720,6 +1722,64 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     expect(findFirewallEntry(claim.firewalls, "x")).toBeUndefined();
 
     await api.requestCancelRun(actor, run.runId, [200]);
+  });
+
+  it("rejects same-org non-owner Zero-backed direct runs for private agents", async () => {
+    const bdd = createBddApi(context);
+    const api = createRunsAutomationsApi(context);
+    const { actor, agentId } = await zeroBackedDirectRunActor();
+    const member = bdd.user({ orgId: actor.orgId, orgRole: "org:member" });
+
+    const rejected = await api.requestDirectRun(
+      member,
+      zeroBackedDirectRunBody({
+        agentId,
+        prompt: "direct run someone else's private zero agent",
+      }),
+      [403],
+    );
+
+    expectApiError(rejected.body);
+    expect(rejected.body.error.message).toBe(
+      "Only the private agent owner can run this agent",
+    );
+  });
+
+  it("allows same-org non-owner Zero-backed direct runs for public agents without owner connector leakage", async () => {
+    const bdd = createBddApi(context);
+    const api = createRunsAutomationsApi(context);
+    const fw = createFirewallApi(context);
+    const { actor, agentId, runnerGroup } = await zeroBackedDirectRunActor({
+      visibility: "public",
+    });
+    const member = bdd.user({ orgId: actor.orgId, orgRole: "org:member" });
+
+    await fw.seedTestConnector(actor, {
+      connectorName: "x",
+      authMethod: "oauth",
+      accessToken: "x-bdd-public-owner-access",
+      refreshToken: "x-bdd-public-owner-refresh",
+    });
+    const enabled = await api.enableAgentConnectors(actor, agentId, ["x"]);
+    expect(enabled).toContain("x");
+
+    const run = await api.createDirectRun(
+      member,
+      zeroBackedDirectRunBody({
+        agentId,
+        prompt: "direct run someone else's public zero agent",
+      }),
+    );
+    await api.heartbeatRunner(runnerGroup);
+    const claim = await api.claimRunnerJob(run.runId);
+
+    expect(claim.environment ?? {}).not.toHaveProperty("X_TOKEN");
+    expect(claim.secretConnectorMap ?? {}).not.toHaveProperty("X_TOKEN");
+    expect(findFirewallEntry(claim.firewalls, "x")).toBeUndefined();
+    expect(claim.billableFirewalls).not.toContain("x");
+    expect(claim.networkPolicies ?? {}).not.toHaveProperty("x");
+
+    await api.requestCancelRun(member, run.runId, [200]);
   });
 
   it("injects oauth connector tokens with billable firewalls and resolvable secrets", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -17,9 +17,7 @@ import {
 } from "@vm0/connectors/firewall-types";
 import { getFirewallExecutionMetadata } from "@vm0/connectors/firewall-metadata/server";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
-import { userConnectors } from "@vm0/db/schema/user-connector";
 import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
-import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { createStore } from "ccstate";
 import { eq } from "drizzle-orm";
 import { HttpResponse, http } from "msw";
@@ -531,34 +529,27 @@ async function zeroBackedDirectRunActor(): Promise<{
   api.acceptTelemetryIngest();
   const runnerGroup = api.configureRunnerGroup();
   await api.grantProEntitlement(actor);
+  await api.ensureOrgModelProvider(actor);
 
-  const composeName = `bdd-zero-direct-${randomUUID().slice(0, 8)}`;
-  const compose = await api.createCompose(actor, {
-    version: "1",
-    agents: {
-      [composeName]: {
-        framework: "claude-code",
-        environment: { ANTHROPIC_API_KEY: "bdd-inline-key" },
-      },
-    },
-  });
-
-  await writeDb.insert(zeroAgents).values({
-    id: compose.composeId,
-    orgId: actor.orgId,
-    owner: actor.userId,
-    name: compose.name,
-    visibility: "private",
+  const agent = await bdd.createAgent(actor, {
     displayName: "BDD zero-backed direct agent",
-    description: null,
-    sound: null,
-    avatarUrl: null,
-    modelProviderId: null,
-    selectedModel: null,
-    preferPersonalProvider: false,
+    visibility: "private",
   });
 
-  return { actor, orgId: actor.orgId, agentId: compose.composeId, runnerGroup };
+  return { actor, orgId: actor.orgId, agentId: agent.agentId, runnerGroup };
+}
+
+function zeroBackedDirectRunBody(args: {
+  readonly agentId: string;
+  readonly prompt: string;
+}) {
+  return {
+    agentComposeId: args.agentId,
+    prompt: args.prompt,
+    modelProviderType: "anthropic-api-key" as const,
+    vars: { ZERO_AGENT_ID: args.agentId },
+    secrets: { ZERO_TOKEN: "bdd-zero-direct-token" },
+  };
 }
 
 const CHAT_CALLBACK_URL = "http://localhost:3000/api/internal/callbacks/chat";
@@ -1648,10 +1639,13 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
       refreshToken: "x-bdd-direct-unallowed-refresh",
     });
 
-    const run = await api.createDirectRun(actor, {
-      agentComposeId: agentId,
-      prompt: "direct run without enabled stored connectors",
-    });
+    const run = await api.createDirectRun(
+      actor,
+      zeroBackedDirectRunBody({
+        agentId,
+        prompt: "direct run without enabled stored connectors",
+      }),
+    );
     const timingEvents = apiDispatchTimingEventsForRun(run.runId);
     expectNoApiDispatchActions(
       timingEvents,
@@ -1770,8 +1764,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
   it("injects only enabled stored connectors for Zero-backed direct runs", async () => {
     const api = createRunsAutomationsApi(context);
     const fw = createFirewallApi(context);
-    const { actor, orgId, agentId, runnerGroup } =
-      await zeroBackedDirectRunActor();
+    const { actor, agentId, runnerGroup } = await zeroBackedDirectRunActor();
 
     await fw.seedTestConnector(actor, {
       connectorName: "x",
@@ -1784,17 +1777,16 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
       authMethod: "oauth",
       accessToken: "xoxb-bdd-direct-unenabled-access",
     });
-    await writeDb.insert(userConnectors).values({
-      orgId,
-      userId: actor.userId,
-      agentId,
-      connectorType: "x",
-    });
+    const enabled = await api.enableAgentConnectors(actor, agentId, ["x"]);
+    expect(enabled).toContain("x");
 
-    const run = await api.createDirectRun(actor, {
-      agentComposeId: agentId,
-      prompt: "direct run with the x connector",
-    });
+    const run = await api.createDirectRun(
+      actor,
+      zeroBackedDirectRunBody({
+        agentId,
+        prompt: "direct run with the x connector",
+      }),
+    );
     const timingEvents = apiDispatchTimingEventsForRun(run.runId);
     expectApiDispatchActions(
       timingEvents,
@@ -2330,10 +2322,13 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
 
     await connectors.updateAgentCustomConnectors(actor, agentId, [allowed.id]);
 
-    const run = await api.createDirectRun(actor, {
-      agentComposeId: agentId,
-      prompt: "direct run with the custom connector",
-    });
+    const run = await api.createDirectRun(
+      actor,
+      zeroBackedDirectRunBody({
+        agentId,
+        prompt: "direct run with the custom connector",
+      }),
+    );
     const timingEvents = apiDispatchTimingEventsForRun(run.runId);
     expectApiDispatchActions(
       timingEvents,

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -17,7 +17,9 @@ import {
 } from "@vm0/connectors/firewall-types";
 import { getFirewallExecutionMetadata } from "@vm0/connectors/firewall-metadata/server";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
+import { userConnectors } from "@vm0/db/schema/user-connector";
 import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { createStore } from "ccstate";
 import { eq } from "drizzle-orm";
 import { HttpResponse, http } from "msw";
@@ -111,6 +113,7 @@ const API_DISPATCH_TIMING_ACTION_TYPES = [
   "api_dispatch_prepare_context_load_persisted_environment",
   "api_dispatch_prepare_context_build_resolved_body",
   "api_dispatch_prepare_context_resolve_framework",
+  "api_dispatch_prepare_context_resolve_connector_scope",
   "api_dispatch_prepare_context_resolve_model_provider",
   "api_dispatch_prepare_context_load_connector_contexts",
   "api_dispatch_prepare_context_load_stored_connectors",
@@ -509,6 +512,53 @@ async function entitledRunActor(): Promise<{
     visibility: "private",
   });
   return { actor, agentId: agent.agentId, runnerGroup, granted };
+}
+
+async function zeroBackedDirectRunActor(): Promise<{
+  readonly actor: ApiTestUser;
+  readonly orgId: string;
+  readonly agentId: string;
+  readonly runnerGroup: string;
+}> {
+  const bdd = createBddApi(context);
+  const api = createRunsAutomationsApi(context);
+  const actor = bdd.user();
+  if (!actor.orgId) {
+    throw new Error("Zero-backed direct run tests require an org-scoped actor");
+  }
+  bdd.acceptAgentStorageWrites();
+  api.acceptStorageDownloads();
+  api.acceptTelemetryIngest();
+  const runnerGroup = api.configureRunnerGroup();
+  await api.grantProEntitlement(actor);
+
+  const composeName = `bdd-zero-direct-${randomUUID().slice(0, 8)}`;
+  const compose = await api.createCompose(actor, {
+    version: "1",
+    agents: {
+      [composeName]: {
+        framework: "claude-code",
+        environment: { ANTHROPIC_API_KEY: "bdd-inline-key" },
+      },
+    },
+  });
+
+  await writeDb.insert(zeroAgents).values({
+    id: compose.composeId,
+    orgId: actor.orgId,
+    owner: actor.userId,
+    name: compose.name,
+    visibility: "private",
+    displayName: "BDD zero-backed direct agent",
+    description: null,
+    sound: null,
+    avatarUrl: null,
+    modelProviderId: null,
+    selectedModel: null,
+    preferPersonalProvider: false,
+  });
+
+  return { actor, orgId: actor.orgId, agentId: compose.composeId, runnerGroup };
 }
 
 const CHAT_CALLBACK_URL = "http://localhost:3000/api/internal/callbacks/chat";
@@ -1586,6 +1636,45 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     expect(cancelled.status).toBe("cancelled");
   });
 
+  it("omits connected stored connectors when the Zero-backed direct run allowlist is empty", async () => {
+    const api = createRunsAutomationsApi(context);
+    const fw = createFirewallApi(context);
+    const { actor, agentId, runnerGroup } = await zeroBackedDirectRunActor();
+
+    await fw.seedTestConnector(actor, {
+      connectorName: "x",
+      authMethod: "oauth",
+      accessToken: "x-bdd-direct-unallowed-access",
+      refreshToken: "x-bdd-direct-unallowed-refresh",
+    });
+
+    const run = await api.createDirectRun(actor, {
+      agentComposeId: agentId,
+      prompt: "direct run without enabled stored connectors",
+    });
+    const timingEvents = apiDispatchTimingEventsForRun(run.runId);
+    expectNoApiDispatchActions(
+      timingEvents,
+      API_DISPATCH_STORED_CONNECTOR_SUBSTEP_ACTION_TYPES,
+    );
+    expectNoApiDispatchActions(
+      timingEvents,
+      API_DISPATCH_CUSTOM_CONNECTOR_SUBSTEP_ACTION_TYPES,
+    );
+    await api.heartbeatRunner(runnerGroup);
+    const claim = await api.claimRunnerJob(run.runId);
+
+    expect(claim.environment ?? {}).not.toHaveProperty("X_TOKEN");
+    expect(claim.secretConnectorMap ?? {}).not.toHaveProperty("X_TOKEN");
+    expect(findFirewallEntry(claim.firewalls, "x")).toBeUndefined();
+    expect(claim.billableFirewalls).not.toContain("x");
+    expect(claim.networkPolicies ?? {}).not.toHaveProperty("x");
+
+    await api.requestCancelRun(actor, run.runId, [200]);
+    const cancelled = await api.readRun(actor, run.runId);
+    expect(cancelled.status).toBe("cancelled");
+  });
+
   it("injects oauth connector tokens with billable firewalls and resolvable secrets", async () => {
     const api = createRunsAutomationsApi(context);
     const fw = createFirewallApi(context);
@@ -1676,6 +1765,65 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     await api.requestCancelRun(actor, run.runId, [200]);
     const cancelled = await api.readRun(actor, run.runId);
     expect(cancelled.status).toBe("cancelled");
+  });
+
+  it("injects only enabled stored connectors for Zero-backed direct runs", async () => {
+    const api = createRunsAutomationsApi(context);
+    const fw = createFirewallApi(context);
+    const { actor, orgId, agentId, runnerGroup } =
+      await zeroBackedDirectRunActor();
+
+    await fw.seedTestConnector(actor, {
+      connectorName: "x",
+      authMethod: "oauth",
+      accessToken: "x-bdd-direct-access",
+      refreshToken: "x-bdd-direct-refresh",
+    });
+    await fw.seedTestConnector(actor, {
+      connectorName: "slack",
+      authMethod: "oauth",
+      accessToken: "xoxb-bdd-direct-unenabled-access",
+    });
+    await writeDb.insert(userConnectors).values({
+      orgId,
+      userId: actor.userId,
+      agentId,
+      connectorType: "x",
+    });
+
+    const run = await api.createDirectRun(actor, {
+      agentComposeId: agentId,
+      prompt: "direct run with the x connector",
+    });
+    const timingEvents = apiDispatchTimingEventsForRun(run.runId);
+    expectApiDispatchActions(
+      timingEvents,
+      API_DISPATCH_STORED_CONNECTOR_ROW_ACTION_TYPES,
+    );
+    expectApiDispatchActions(
+      timingEvents,
+      API_DISPATCH_STORED_CONNECTOR_SECRET_ACTION_TYPES,
+    );
+    await api.heartbeatRunner(runnerGroup);
+    const claim = await api.claimRunnerJob(run.runId);
+
+    expect(claim.environment?.X_TOKEN).toBe(
+      connectorPlaceholder("x", "X_TOKEN"),
+    );
+    expect(claim.secretConnectorMap).toMatchObject({ X_TOKEN: "x" });
+    expect(findFirewallEntry(claim.firewalls, "x")).toStrictEqual({
+      kind: "builtin",
+      name: "x",
+    });
+    expect(claim.billableFirewalls).toContain("x");
+    expect(claim.networkPolicies?.x?.unknownPolicy).toBe("allow");
+    expect(claim.environment).not.toHaveProperty("SLACK_TOKEN");
+    expect(claim.secretConnectorMap).not.toHaveProperty("SLACK_TOKEN");
+    expect(findFirewallEntry(claim.firewalls, "slack")).toBeUndefined();
+    expect(claim.billableFirewalls).not.toContain("slack");
+    expect(claim.networkPolicies ?? {}).not.toHaveProperty("slack");
+
+    await api.requestCancelRun(actor, run.runId, [200]);
   });
 
   it("injects manual-grant api-token connectors and their optional variables", async () => {
@@ -2145,6 +2293,77 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     await api.requestCancelRun(actor, run.runId, [200]);
     const cancelled = await api.readRun(actor, run.runId);
     expect(cancelled.status).toBe("cancelled");
+  });
+
+  it("injects only enabled custom connector firewalls for Zero-backed direct runs", async () => {
+    const api = createRunsAutomationsApi(context);
+    const connectors = createConnectorBddApi(context);
+    const { actor, agentId, runnerGroup } = await zeroBackedDirectRunActor();
+
+    const allowedSlug = `bdd-direct-internal-${randomUUID().slice(0, 8)}`;
+    const allowed = await connectors.createCustomConnector(actor, {
+      slug: allowedSlug,
+      displayName: "BDD Direct Internal API",
+      prefixes: ["https://*.direct.internal.example.com/api/"],
+      headerName: "Authorization",
+      headerTemplate: "Bearer {{secret}}",
+    });
+    await connectors.setCustomConnectorSecret(
+      actor,
+      allowed.id,
+      "direct-custom-secret-value",
+    );
+
+    const blockedSlug = `bdd-direct-blocked-${randomUUID().slice(0, 8)}`;
+    const blocked = await connectors.createCustomConnector(actor, {
+      slug: blockedSlug,
+      displayName: "BDD Direct Blocked API",
+      prefixes: ["https://*.blocked.internal.example.com/api/"],
+      headerName: "Authorization",
+      headerTemplate: "Bearer {{secret}}",
+    });
+    await connectors.setCustomConnectorSecret(
+      actor,
+      blocked.id,
+      "blocked-custom-secret-value",
+    );
+
+    await connectors.updateAgentCustomConnectors(actor, agentId, [allowed.id]);
+
+    const run = await api.createDirectRun(actor, {
+      agentComposeId: agentId,
+      prompt: "direct run with the custom connector",
+    });
+    const timingEvents = apiDispatchTimingEventsForRun(run.runId);
+    expectApiDispatchActions(
+      timingEvents,
+      API_DISPATCH_CUSTOM_CONNECTOR_SUBSTEP_ACTION_TYPES,
+    );
+    expectApiDispatchTimingEventsNotToLeak(timingEvents, [
+      allowed.id,
+      allowedSlug,
+      "direct-custom-secret-value",
+      blocked.id,
+      blockedSlug,
+      "blocked-custom-secret-value",
+    ]);
+    await api.heartbeatRunner(runnerGroup);
+    const claim = await api.claimRunnerJob(run.runId);
+
+    const allowedInternalName = `custom_connector_${allowed.id.replaceAll("-", "")}`;
+    const blockedInternalName = `custom_connector_${blocked.id.replaceAll("-", "")}`;
+    expect(
+      findFirewallEntry(claim.firewalls, allowedInternalName),
+    ).toBeDefined();
+    expect(
+      findFirewallEntry(claim.firewalls, blockedInternalName),
+    ).toBeUndefined();
+    expect(claim.networkPolicies?.[allowedInternalName]?.unknownPolicy).toBe(
+      "allow",
+    );
+    expect(claim.networkPolicies ?? {}).not.toHaveProperty(blockedInternalName);
+
+    await api.requestCancelRun(actor, run.runId, [200]);
   });
 
   it("injects proposed custom connector fields into headers, query, and host templates", async () => {

--- a/turbo/apps/api/src/signals/services/agent-connector-scope.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-connector-scope.service.ts
@@ -1,0 +1,105 @@
+import {
+  connectorTypeSchema,
+  type ConnectorType,
+} from "@vm0/connectors/connectors";
+import { userCustomConnectors } from "@vm0/db/schema/user-custom-connector";
+import { userConnectors } from "@vm0/db/schema/user-connector";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { and, eq } from "drizzle-orm";
+
+import type { Db } from "../external/db";
+
+interface AgentConnectorScope {
+  readonly allowedConnectorTypes: readonly ConnectorType[];
+  readonly allowedCustomConnectorIds: readonly string[];
+}
+
+async function loadAgentAllowedConnectorTypes(
+  db: Db,
+  args: {
+    readonly userId: string;
+    readonly orgId: string;
+    readonly agentId: string;
+  },
+): Promise<readonly ConnectorType[]> {
+  const rows = await db
+    .select({ connectorType: userConnectors.connectorType })
+    .from(userConnectors)
+    .where(
+      and(
+        eq(userConnectors.orgId, args.orgId),
+        eq(userConnectors.userId, args.userId),
+        eq(userConnectors.agentId, args.agentId),
+      ),
+    );
+
+  return rows.flatMap((row) => {
+    const parsed = connectorTypeSchema.safeParse(row.connectorType);
+    return parsed.success ? [parsed.data] : [];
+  });
+}
+
+async function loadAgentAllowedCustomConnectorIds(
+  db: Db,
+  args: {
+    readonly userId: string;
+    readonly orgId: string;
+    readonly agentId: string;
+  },
+): Promise<readonly string[]> {
+  const rows = await db
+    .select({ customConnectorId: userCustomConnectors.customConnectorId })
+    .from(userCustomConnectors)
+    .where(
+      and(
+        eq(userCustomConnectors.orgId, args.orgId),
+        eq(userCustomConnectors.userId, args.userId),
+        eq(userCustomConnectors.agentId, args.agentId),
+      ),
+    );
+
+  return rows.map((row) => {
+    return row.customConnectorId;
+  });
+}
+
+export async function loadAgentConnectorScope(
+  db: Db,
+  args: {
+    readonly userId: string;
+    readonly orgId: string;
+    readonly agentId: string;
+  },
+): Promise<AgentConnectorScope> {
+  const [allowedConnectorTypes, allowedCustomConnectorIds] = await Promise.all([
+    loadAgentAllowedConnectorTypes(db, args),
+    loadAgentAllowedCustomConnectorIds(db, args),
+  ]);
+  return { allowedConnectorTypes, allowedCustomConnectorIds };
+}
+
+export async function loadZeroBackedComposeConnectorScope(
+  db: Db,
+  args: {
+    readonly userId: string;
+    readonly orgId: string;
+    readonly composeId: string;
+  },
+): Promise<AgentConnectorScope | null> {
+  const [agent] = await db
+    .select({ id: zeroAgents.id })
+    .from(zeroAgents)
+    .where(
+      and(eq(zeroAgents.id, args.composeId), eq(zeroAgents.orgId, args.orgId)),
+    )
+    .limit(1);
+  if (!agent) {
+    return null;
+  }
+
+  return await loadAgentConnectorScope(db, {
+    userId: args.userId,
+    orgId: args.orgId,
+    agentId: args.composeId,
+  });
+}

--- a/turbo/apps/api/src/signals/services/agent-connector-scope.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-connector-scope.service.ts
@@ -4,7 +4,10 @@ import {
 } from "@vm0/connectors/connectors";
 import { userCustomConnectors } from "@vm0/db/schema/user-custom-connector";
 import { userConnectors } from "@vm0/db/schema/user-connector";
-import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import {
+  zeroAgents,
+  type ZeroAgentVisibility,
+} from "@vm0/db/schema/zero-agent";
 import { and, eq } from "drizzle-orm";
 
 import type { Db } from "../external/db";
@@ -12,6 +15,11 @@ import type { Db } from "../external/db";
 interface AgentConnectorScope {
   readonly allowedConnectorTypes: readonly ConnectorType[];
   readonly allowedCustomConnectorIds: readonly string[];
+}
+
+interface ZeroBackedComposeAgent {
+  readonly owner: string;
+  readonly visibility: ZeroAgentVisibility;
 }
 
 async function loadAgentAllowedConnectorTypes(
@@ -78,28 +86,25 @@ export async function loadAgentConnectorScope(
   return { allowedConnectorTypes, allowedCustomConnectorIds };
 }
 
-export async function loadZeroBackedComposeConnectorScope(
+export async function loadZeroBackedComposeAgent(
   db: Db,
   args: {
-    readonly userId: string;
-    readonly orgId: string;
     readonly composeId: string;
   },
-): Promise<AgentConnectorScope | null> {
+): Promise<ZeroBackedComposeAgent | null> {
+  // The caller must verify agent_composes.org_id first. zero_agents.org_id is
+  // denormalized and must not decide whether a resolved compose is Zero-backed.
   const [agent] = await db
-    .select({ id: zeroAgents.id })
+    .select({
+      id: zeroAgents.id,
+      owner: zeroAgents.owner,
+      visibility: zeroAgents.visibility,
+    })
     .from(zeroAgents)
-    .where(
-      and(eq(zeroAgents.id, args.composeId), eq(zeroAgents.orgId, args.orgId)),
-    )
+    .where(eq(zeroAgents.id, args.composeId))
     .limit(1);
   if (!agent) {
     return null;
   }
-
-  return await loadAgentConnectorScope(db, {
-    userId: args.userId,
-    orgId: args.orgId,
-    agentId: args.composeId,
-  });
+  return { owner: agent.owner, visibility: agent.visibility };
 }

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -167,6 +167,7 @@ import {
   ApiDispatchTimingCollector,
   measureApiDispatchTiming,
 } from "./api-dispatch-timing.service";
+import { loadZeroBackedComposeConnectorScope } from "./agent-connector-scope.service";
 
 const PENDING_RUN_TTL_MS = 15 * 60 * 1000;
 const QUEUED_RUN_TTL_MS = 2 * 60 * 60 * 1000;
@@ -290,6 +291,17 @@ interface ResolvedCompose {
   readonly resumedFromCheckpointId?: string;
   readonly continuedFromAgentSessionId?: string;
   readonly resumeSession?: StoredExecutionContext["resumeSession"];
+}
+
+type EffectiveConnectorScopeSource =
+  | "create-args"
+  | "zero-backed-direct"
+  | "legacy-direct";
+
+interface EffectiveConnectorScope {
+  readonly allowedConnectorTypes: readonly ConnectorType[] | undefined;
+  readonly allowedCustomConnectorIds: readonly string[] | undefined;
+  readonly source: EffectiveConnectorScopeSource;
 }
 
 // Session naming in this service:
@@ -597,7 +609,10 @@ function buildWorkflowSkillVolumes(
 }
 
 function buildInjectedSkillVolumes(
-  args: CreateAgentRunArgs,
+  args: {
+    readonly injectSkillVolumes: CreateAgentRunArgs["injectSkillVolumes"];
+    readonly allowedConnectorTypes: readonly ConnectorType[] | undefined;
+  },
   framework: SupportedFramework,
   goalSeedEnabled: boolean,
 ): readonly AdditionalVolume[] | undefined {
@@ -4746,6 +4761,7 @@ async function buildPreparedPermissionManifest(args: {
 
 function preparedRunAdditionalVolumes(args: {
   readonly createArgs: CreateAgentRunArgs;
+  readonly connectorScope: EffectiveConnectorScope;
   readonly framework: SupportedFramework;
   readonly featureSwitchContext: FeatureSwitchContext;
   readonly body: CreateRunBody;
@@ -4753,7 +4769,10 @@ function preparedRunAdditionalVolumes(args: {
 }): readonly AdditionalVolume[] | undefined {
   return mergeAdditionalVolumes({
     prepend: buildInjectedSkillVolumes(
-      args.createArgs,
+      {
+        injectSkillVolumes: args.createArgs.injectSkillVolumes,
+        allowedConnectorTypes: args.connectorScope.allowedConnectorTypes,
+      },
       args.framework,
       isFeatureEnabled(
         FeatureSwitchKey.GoalWorkflows,
@@ -4781,6 +4800,54 @@ interface PreparedRuntimeContext {
   readonly permissionManifest: PermissionManifest | undefined;
   readonly billableFirewalls: readonly string[];
   readonly modelUsageProvider: string | undefined;
+}
+
+function connectorScopeFromCreateArgs(
+  args: CreateAgentRunArgs,
+): EffectiveConnectorScope | null {
+  if (
+    args.allowedConnectorTypes === undefined &&
+    args.allowedCustomConnectorIds === undefined
+  ) {
+    return null;
+  }
+
+  return {
+    allowedConnectorTypes: args.allowedConnectorTypes ?? [],
+    allowedCustomConnectorIds: args.allowedCustomConnectorIds ?? [],
+    source: "create-args",
+  };
+}
+
+async function resolveEffectiveConnectorScope(args: {
+  readonly db: Db;
+  readonly createArgs: CreateAgentRunArgs;
+  readonly resolved: ResolvedCompose;
+  readonly signal: AbortSignal;
+}): Promise<EffectiveConnectorScope> {
+  const createArgsScope = connectorScopeFromCreateArgs(args.createArgs);
+  if (createArgsScope) {
+    return createArgsScope;
+  }
+
+  const zeroBackedScope = await loadZeroBackedComposeConnectorScope(args.db, {
+    userId: args.createArgs.userId,
+    orgId: args.createArgs.orgId,
+    composeId: args.resolved.composeId,
+  });
+  args.signal.throwIfAborted();
+  if (zeroBackedScope) {
+    return {
+      ...zeroBackedScope,
+      source: "zero-backed-direct",
+    };
+  }
+
+  return {
+    allowedConnectorTypes: undefined,
+    allowedCustomConnectorIds: undefined,
+    source: "legacy-direct",
+  };
 }
 
 async function prepareRunBodyContext(args: {
@@ -4878,6 +4945,7 @@ async function prepareRunBodyContext(args: {
 async function prepareRunRuntimeContext(args: {
   readonly db: Db;
   readonly createArgs: CreateAgentRunArgs;
+  readonly connectorScope: EffectiveConnectorScope;
   readonly timing: ApiDispatchTimingCollector;
   readonly signal: AbortSignal;
   readonly bodyContext: PreparedRunBodyContext;
@@ -4909,7 +4977,13 @@ async function prepareRunRuntimeContext(args: {
       async () => {
         return await loadRunConnectorContexts(
           args.db,
-          args.createArgs,
+          {
+            orgId: args.createArgs.orgId,
+            userId: args.createArgs.userId,
+            allowedConnectorTypes: args.connectorScope.allowedConnectorTypes,
+            allowedCustomConnectorIds:
+              args.connectorScope.allowedCustomConnectorIds,
+          },
           featureSwitchContext,
           args.timing,
         );
@@ -4955,6 +5029,7 @@ async function prepareRunRuntimeContext(args: {
 
 function prepareRunOutputMetadata(args: {
   readonly createArgs: CreateAgentRunArgs;
+  readonly connectorScope: EffectiveConnectorScope;
   readonly framework: SupportedFramework;
   readonly featureSwitchContext: FeatureSwitchContext;
   readonly body: CreateRunBody;
@@ -4965,6 +5040,7 @@ function prepareRunOutputMetadata(args: {
 } {
   const additionalVolumes = preparedRunAdditionalVolumes({
     createArgs: args.createArgs,
+    connectorScope: args.connectorScope,
     framework: args.framework,
     featureSwitchContext: args.featureSwitchContext,
     body: args.body,
@@ -5009,9 +5085,24 @@ function prepareRunContext(
         return bodyContext;
       }
 
+      const connectorScope = await timing.measure(
+        "api_dispatch_prepare_context_resolve_connector_scope",
+        "nested",
+        async () => {
+          return await resolveEffectiveConnectorScope({
+            db,
+            createArgs: args,
+            resolved: bodyContext.resolved,
+            signal,
+          });
+        },
+      );
+      signal.throwIfAborted();
+
       const runtimeContext = await prepareRunRuntimeContext({
         db,
         createArgs: args,
+        connectorScope,
         timing,
         signal,
         bodyContext,
@@ -5057,6 +5148,7 @@ function prepareRunContext(
           return await Promise.resolve(
             prepareRunOutputMetadata({
               createArgs: args,
+              connectorScope,
               framework: runtimeContext.framework,
               featureSwitchContext: bodyContext.featureSwitchContext,
               body: bodyContext.body,

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -293,15 +293,9 @@ interface ResolvedCompose {
   readonly resumeSession?: StoredExecutionContext["resumeSession"];
 }
 
-type EffectiveConnectorScopeSource =
-  | "create-args"
-  | "zero-backed-direct"
-  | "legacy-direct";
-
 interface EffectiveConnectorScope {
   readonly allowedConnectorTypes: readonly ConnectorType[] | undefined;
   readonly allowedCustomConnectorIds: readonly string[] | undefined;
-  readonly source: EffectiveConnectorScopeSource;
 }
 
 // Session naming in this service:
@@ -4815,7 +4809,6 @@ function connectorScopeFromCreateArgs(
   return {
     allowedConnectorTypes: args.allowedConnectorTypes ?? [],
     allowedCustomConnectorIds: args.allowedCustomConnectorIds ?? [],
-    source: "create-args",
   };
 }
 
@@ -4837,16 +4830,12 @@ async function resolveEffectiveConnectorScope(args: {
   });
   args.signal.throwIfAborted();
   if (zeroBackedScope) {
-    return {
-      ...zeroBackedScope,
-      source: "zero-backed-direct",
-    };
+    return zeroBackedScope;
   }
 
   return {
     allowedConnectorTypes: undefined,
     allowedCustomConnectorIds: undefined,
-    source: "legacy-direct",
   };
 }
 

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -167,7 +167,10 @@ import {
   ApiDispatchTimingCollector,
   measureApiDispatchTiming,
 } from "./api-dispatch-timing.service";
-import { loadZeroBackedComposeConnectorScope } from "./agent-connector-scope.service";
+import {
+  loadAgentConnectorScope,
+  loadZeroBackedComposeAgent,
+} from "./agent-connector-scope.service";
 
 const PENDING_RUN_TTL_MS = 15 * 60 * 1000;
 const QUEUED_RUN_TTL_MS = 2 * 60 * 60 * 1000;
@@ -4786,6 +4789,7 @@ type PrepareRunContextGet = <T>(value: Computed<T>) => T;
 interface PreparedRunBodyContext {
   readonly body: CreateRunBody;
   readonly resolved: ResolvedCompose;
+  readonly connectorScope: EffectiveConnectorScope;
   readonly requestedFramework: SupportedFramework;
   readonly featureSwitchContext: FeatureSwitchContext;
 }
@@ -4811,20 +4815,28 @@ async function resolveEffectiveConnectorScope(args: {
   readonly createArgs: CreateAgentRunArgs;
   readonly resolved: ResolvedCompose;
   readonly signal: AbortSignal;
-}): Promise<EffectiveConnectorScope> {
+}): Promise<EffectiveConnectorScope | CreateRunErrorResult> {
   const createArgsScope = connectorScopeFromCreateArgs(args.createArgs);
   if (createArgsScope) {
     return createArgsScope;
   }
 
-  const zeroBackedScope = await loadZeroBackedComposeConnectorScope(args.db, {
-    userId: args.createArgs.userId,
-    orgId: args.createArgs.orgId,
+  const zeroBackedAgent = await loadZeroBackedComposeAgent(args.db, {
     composeId: args.resolved.composeId,
   });
   args.signal.throwIfAborted();
-  if (zeroBackedScope) {
-    return zeroBackedScope;
+  if (zeroBackedAgent) {
+    if (
+      zeroBackedAgent.visibility === "private" &&
+      zeroBackedAgent.owner !== args.createArgs.userId
+    ) {
+      return forbidden("Only the private agent owner can run this agent");
+    }
+    return await loadAgentConnectorScope(args.db, {
+      userId: args.createArgs.userId,
+      orgId: args.createArgs.orgId,
+      agentId: args.resolved.composeId,
+    });
   }
 
   return {
@@ -4871,6 +4883,23 @@ async function prepareRunBodyContext(args: {
   }
   if (resolved.orgId !== args.createArgs.orgId) {
     return notFound("Resource not found");
+  }
+
+  const connectorScope = await args.timing.measure(
+    "api_dispatch_prepare_context_resolve_connector_scope",
+    "nested",
+    async () => {
+      return await resolveEffectiveConnectorScope({
+        db: args.db,
+        createArgs: args.createArgs,
+        resolved,
+        signal: args.signal,
+      });
+    },
+  );
+  args.signal.throwIfAborted();
+  if (isRouteError(connectorScope)) {
+    return connectorScope;
   }
 
   const persistedEnvironment = await args.timing.measure(
@@ -4920,6 +4949,7 @@ async function prepareRunBodyContext(args: {
   return {
     body,
     resolved,
+    connectorScope,
     requestedFramework: requestedFrameworkResult,
     featureSwitchContext,
   };
@@ -5068,24 +5098,10 @@ function prepareRunContext(
         return bodyContext;
       }
 
-      const connectorScope = await timing.measure(
-        "api_dispatch_prepare_context_resolve_connector_scope",
-        "nested",
-        async () => {
-          return await resolveEffectiveConnectorScope({
-            db,
-            createArgs: args,
-            resolved: bodyContext.resolved,
-            signal,
-          });
-        },
-      );
-      signal.throwIfAborted();
-
       const runtimeContext = await prepareRunRuntimeContext({
         db,
         createArgs: args,
-        connectorScope,
+        connectorScope: bodyContext.connectorScope,
         timing,
         signal,
         bodyContext,
@@ -5131,7 +5147,7 @@ function prepareRunContext(
           return await Promise.resolve(
             prepareRunOutputMetadata({
               createArgs: args,
-              connectorScope,
+              connectorScope: bodyContext.connectorScope,
               framework: runtimeContext.framework,
               featureSwitchContext: bodyContext.featureSwitchContext,
               body: bodyContext.body,

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -298,6 +298,11 @@ interface EffectiveConnectorScope {
   readonly allowedCustomConnectorIds: readonly string[] | undefined;
 }
 
+interface ExplicitConnectorScope {
+  readonly allowedConnectorTypes: readonly ConnectorType[];
+  readonly allowedCustomConnectorIds: readonly string[];
+}
+
 // Session naming in this service:
 // - agentSessionId is the vm0 application session (`agent_sessions.id`) used
 //   for product-level continuation and future correctness checks.
@@ -435,8 +440,7 @@ export interface CreateAgentRunArgs {
       readonly workflowId: string;
     }[];
   };
-  readonly allowedConnectorTypes?: readonly ConnectorType[];
-  readonly allowedCustomConnectorIds?: readonly string[];
+  readonly connectorScope?: ExplicitConnectorScope;
   readonly validateEnvironmentReferences?: boolean;
   readonly zeroRunMetadata?: ZeroRunMetadata;
   readonly queueOnConcurrencyLimit?: boolean;
@@ -4799,17 +4803,7 @@ interface PreparedRuntimeContext {
 function connectorScopeFromCreateArgs(
   args: CreateAgentRunArgs,
 ): EffectiveConnectorScope | null {
-  if (
-    args.allowedConnectorTypes === undefined &&
-    args.allowedCustomConnectorIds === undefined
-  ) {
-    return null;
-  }
-
-  return {
-    allowedConnectorTypes: args.allowedConnectorTypes ?? [],
-    allowedCustomConnectorIds: args.allowedCustomConnectorIds ?? [],
-  };
+  return args.connectorScope ?? null;
 }
 
 async function resolveEffectiveConnectorScope(args: {

--- a/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
+++ b/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
@@ -25,6 +25,7 @@ export type ApiDispatchTimingActionType =
   | "api_dispatch_prepare_context_load_persisted_environment"
   | "api_dispatch_prepare_context_build_resolved_body"
   | "api_dispatch_prepare_context_resolve_framework"
+  | "api_dispatch_prepare_context_resolve_connector_scope"
   | "api_dispatch_prepare_context_resolve_model_provider"
   | "api_dispatch_prepare_context_load_connector_contexts"
   | "api_dispatch_prepare_context_load_stored_connectors"

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -21,8 +21,6 @@ import {
 } from "@vm0/db/schema/agent-compose";
 import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
 import { userCache } from "@vm0/db/schema/user-cache";
-import { userCustomConnectors } from "@vm0/db/schema/user-custom-connector";
-import { userConnectors } from "@vm0/db/schema/user-connector";
 import { workflowUserConnectors } from "@vm0/db/schema/workflow-user-connector";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroWorkflowTriggers } from "@vm0/db/schema/zero-workflow";
@@ -43,6 +41,7 @@ import {
   type ApiDispatchTimingActionType,
   type ApiDispatchTimingCollector,
 } from "./api-dispatch-timing.service";
+import { loadAgentConnectorScope } from "./agent-connector-scope.service";
 import { loadActiveUserPermissionGrants } from "./zero-user-permission-grants.service";
 import { loadWorkflowsForRun } from "./zero-workflow-data.service";
 import type { InternalRunCallbackKind } from "./internal-run-callback";
@@ -393,55 +392,6 @@ async function loadZeroAgent(
         content: agent.content as ZeroAgentComposeContent,
       }
     : null;
-}
-
-async function loadAllowedConnectorTypes(
-  db: Db,
-  args: {
-    readonly userId: string;
-    readonly orgId: string;
-    readonly agentId: string;
-  },
-): Promise<readonly ConnectorType[]> {
-  const rows = await db
-    .select({ connectorType: userConnectors.connectorType })
-    .from(userConnectors)
-    .where(
-      and(
-        eq(userConnectors.orgId, args.orgId),
-        eq(userConnectors.userId, args.userId),
-        eq(userConnectors.agentId, args.agentId),
-      ),
-    );
-
-  return rows.flatMap((row) => {
-    const parsed = connectorTypeSchema.safeParse(row.connectorType);
-    return parsed.success ? [parsed.data] : [];
-  });
-}
-
-async function loadAllowedCustomConnectorIds(
-  db: Db,
-  args: {
-    readonly userId: string;
-    readonly orgId: string;
-    readonly agentId: string;
-  },
-): Promise<readonly string[]> {
-  const rows = await db
-    .select({ customConnectorId: userCustomConnectors.customConnectorId })
-    .from(userCustomConnectors)
-    .where(
-      and(
-        eq(userCustomConnectors.orgId, args.orgId),
-        eq(userCustomConnectors.userId, args.userId),
-        eq(userCustomConnectors.agentId, args.agentId),
-      ),
-    );
-
-  return rows.map((row) => {
-    return row.customConnectorId;
-  });
 }
 
 /**
@@ -832,18 +782,13 @@ async function loadZeroRunConnectorScopes(
     };
   }
 
-  const allowedConnectorTypes = await loadAllowedConnectorTypes(db, {
+  const scope = await loadAgentConnectorScope(db, {
     userId: args.auth.userId,
     orgId: args.auth.orgId,
     agentId: args.agentId,
   });
   signal.throwIfAborted();
-  const allowedCustomConnectorIds = await loadAllowedCustomConnectorIds(db, {
-    userId: args.auth.userId,
-    orgId: args.auth.orgId,
-    agentId: args.agentId,
-  });
-  return { allowedConnectorTypes, allowedCustomConnectorIds };
+  return scope;
 }
 
 function buildZeroCreateAgentRunArgs(args: {
@@ -947,17 +892,12 @@ export const createZeroIntegrationRun$ = command(
       orgId: args.orgId,
     });
     signal.throwIfAborted();
-    const allowedConnectorTypes = await loadAllowedConnectorTypes(db, {
-      userId: args.userId,
-      orgId: args.orgId,
-      agentId: agent.id,
-    });
-    signal.throwIfAborted();
-    const allowedCustomConnectorIds = await loadAllowedCustomConnectorIds(db, {
-      userId: args.userId,
-      orgId: args.orgId,
-      agentId: agent.id,
-    });
+    const { allowedConnectorTypes, allowedCustomConnectorIds } =
+      await loadAgentConnectorScope(db, {
+        userId: args.userId,
+        orgId: args.orgId,
+        agentId: agent.id,
+      });
     signal.throwIfAborted();
     const workflows = await loadWorkflowsForRun(db, {
       userId: args.userId,

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -837,8 +837,10 @@ function buildZeroCreateAgentRunArgs(args: {
     enforceVm0Credits: true,
     queueOnConcurrencyLimit: true,
     injectSkillVolumes: { workflows: args.workflows },
-    allowedConnectorTypes: args.allowedConnectorTypes,
-    allowedCustomConnectorIds: args.allowedCustomConnectorIds,
+    connectorScope: {
+      allowedConnectorTypes: args.allowedConnectorTypes,
+      allowedCustomConnectorIds: args.allowedCustomConnectorIds,
+    },
     validateEnvironmentReferences: false,
     zeroRunMetadata: {
       ...command.zeroRunMetadata,
@@ -941,8 +943,10 @@ export const createZeroIntegrationRun$ = command(
         enforceVm0Credits: true,
         queueOnConcurrencyLimit: true,
         injectSkillVolumes: { workflows },
-        allowedConnectorTypes,
-        allowedCustomConnectorIds,
+        connectorScope: {
+          allowedConnectorTypes,
+          allowedCustomConnectorIds,
+        },
         validateEnvironmentReferences: false,
         dispatchFailedCallbacks: args.dispatchFailedCallbacks,
       },


### PR DESCRIPTION
## Summary
- add shared per-agent connector scope loading for built-in and custom connectors
- resolve an effective connector scope for direct runs after compose resolution
- use Zero-backed compose allowlists for direct runs while preserving raw direct compose legacy fallback
- thread the effective scope into connector context loading and injected connector skill volumes

Fixes #19123

## Testing
- pnpm -F api exec vitest src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --run
- pnpm -F api check-types
- pnpm check-types
- pnpm -F api lint

## Notes
- pnpm install was run to restore missing workspace links and generated firewall metadata needed by the local test environment; no generated files are part of this diff.
- pre-commit knip is currently blocked by unrelated existing platform exported types: InstrumentHtmlDomEditDocumentParams and InstrumentedHtmlDomEditDocument. The new unused export reported by knip was fixed before commit.