### PR TITLE
perf: add storage cache staging telemetry

### DIFF
--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -1498,6 +1498,13 @@ mod tests {
         );
     }
 
+    fn op_duration_ms(ops: &[(String, u64, bool, Option<String>)], action_type: &str) -> u64 {
+        ops.iter()
+            .find(|(key, _, _, _)| key == action_type)
+            .map(|(_, duration_ms, _, _)| *duration_ms)
+            .unwrap_or_else(|| panic!("expected {action_type} in {ops:?}"))
+    }
+
     fn home_at(temp: &tempfile::TempDir) -> HomePaths {
         HomePaths::with_root(temp.path().to_path_buf())
     }
@@ -1570,6 +1577,41 @@ mod tests {
         let cache_dir = home.storage_cache_dir(name, version);
         std::fs::create_dir_all(&cache_dir).unwrap();
         std::fs::write(cache_dir.join("archive.tar.gz"), bytes).unwrap();
+    }
+
+    #[test]
+    fn stage_metrics_total_sums_guest_write_durations() {
+        let mut telemetry = new_telemetry();
+        let mut metrics = StorageCacheStageMetrics::start();
+        let ok: RunnerResult<()> = Ok(());
+
+        metrics.record_write_result(
+            &mut telemetry,
+            STORAGE_CACHE_STAGE_SINGLE_WRITE,
+            Instant::now() - Duration::from_millis(5_000),
+            &ok,
+        );
+        metrics.record_write_result(
+            &mut telemetry,
+            STORAGE_CACHE_STAGE_BATCH_WRITE,
+            Instant::now() - Duration::from_millis(7_000),
+            &ok,
+        );
+        metrics.record_total(&mut telemetry);
+
+        let ops = telemetry.pending_ops_with_duration_snapshot();
+        assert!(
+            op_duration_ms(&ops, STORAGE_CACHE_STAGE_SINGLE_WRITE) >= 5_000,
+            "expected single write duration in {ops:?}"
+        );
+        assert!(
+            op_duration_ms(&ops, STORAGE_CACHE_STAGE_BATCH_WRITE) >= 7_000,
+            "expected batch write duration in {ops:?}"
+        );
+        assert!(
+            op_duration_ms(&ops, STORAGE_CACHE_STAGE_TOTAL) >= 12_000,
+            "expected total to include both guest writes in {ops:?}"
+        );
     }
 
     struct SamePathConcurrentWriteDetectingSandbox {

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -1472,6 +1472,22 @@ mod tests {
         );
     }
 
+    fn assert_op_error(
+        ops: &[(String, bool, Option<String>)],
+        action_type: &str,
+        expected_error: &str,
+    ) {
+        let error = ops
+            .iter()
+            .find(|(key, _, _)| key == action_type)
+            .and_then(|(_, _, error)| error.as_deref());
+        assert_eq!(
+            error,
+            Some(expected_error),
+            "expected {action_type} error {expected_error:?} in {ops:?}"
+        );
+    }
+
     fn assert_no_op(ops: &[(String, bool, Option<String>)], action_type: &str) {
         assert!(
             !ops.iter().any(|(key, _, _)| key == action_type),
@@ -1876,6 +1892,12 @@ mod tests {
         let ops = telemetry.pending_ops_snapshot();
         assert_op(&ops, STORAGE_CACHE_STAGE_BATCH_WRITE, false);
         assert_op(&ops, STORAGE_CACHE_STAGE_TOTAL, false);
+        assert_op_error(
+            &ops,
+            STORAGE_CACHE_STAGE_BATCH_WRITE,
+            STORAGE_CACHE_STAGE_FAILED,
+        );
+        assert_op_error(&ops, STORAGE_CACHE_STAGE_TOTAL, STORAGE_CACHE_STAGE_FAILED);
         assert_no_op(&ops, STORAGE_CACHE_STAGE_SINGLE_WRITE);
         assert_no_op(&ops, "storage_cache_hit");
     }

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -1982,6 +1982,73 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn miss_path_single_stage_failure_records_failed_staging_telemetry() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = home_at(&temp);
+        let sandbox = MockSandbox::new("test");
+        sandbox.push_write_file_result(Err(sandbox_write_file_error("single write failed")));
+        let mut telemetry = new_telemetry();
+        let server = MockServer::start_async().await;
+        let body = tarball_bytes();
+
+        let probe = server
+            .mock_async(|when, then| {
+                when.method(GET)
+                    .path("/archive.tar.gz")
+                    .header("range", "bytes=0-0");
+                then.status(206)
+                    .header("content-range", format!("bytes 0-0/{}", body.len()))
+                    .body(b"x");
+            })
+            .await;
+        let get = server
+            .mock_async(|when, then| {
+                when.method(GET)
+                    .path("/archive.tar.gz")
+                    .header_missing("range");
+                then.status(200).body(body.clone());
+            })
+            .await;
+
+        let original = server.url("/archive.tar.gz");
+        let name = "single-stage-fail";
+        let version = "v1";
+        let mut manifest = manifest_single_storage(original.clone(), name, version);
+
+        let err = populate_cache(&mut manifest, &sandbox, &home, &mut telemetry)
+            .await
+            .unwrap_err();
+
+        probe.assert_async().await;
+        get.assert_async().await;
+        assert!(
+            err.to_string().contains("single write failed"),
+            "got: {err}"
+        );
+        assert_eq!(
+            manifest.storages[0].archive_url.as_deref(),
+            Some(original.as_str())
+        );
+        assert_eq!(
+            std::fs::read(home.storage_cache_dir(name, version).join("archive.tar.gz")).unwrap(),
+            body
+        );
+
+        let ops = telemetry.pending_ops_snapshot();
+        assert_op(&ops, STORAGE_CACHE_STAGE_SINGLE_WRITE, false);
+        assert_op(&ops, STORAGE_CACHE_STAGE_TOTAL, false);
+        assert_op_error(
+            &ops,
+            STORAGE_CACHE_STAGE_SINGLE_WRITE,
+            STORAGE_CACHE_STAGE_FAILED,
+        );
+        assert_op_error(&ops, STORAGE_CACHE_STAGE_TOTAL, STORAGE_CACHE_STAGE_FAILED);
+        assert_no_op(&ops, STORAGE_CACHE_STAGE_BATCH_WRITE);
+        assert_no_op(&ops, "storage_cache_miss");
+        assert_no_op(&ops, "storage_cache_download");
+    }
+
+    #[tokio::test]
     async fn over_size_entry_is_passthrough() {
         let temp = tempfile::tempdir().unwrap();
         let home = home_at(&temp);

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -1579,41 +1579,6 @@ mod tests {
         std::fs::write(cache_dir.join("archive.tar.gz"), bytes).unwrap();
     }
 
-    #[test]
-    fn stage_metrics_total_sums_guest_write_durations() {
-        let mut telemetry = new_telemetry();
-        let mut metrics = StorageCacheStageMetrics::start();
-        let ok: RunnerResult<()> = Ok(());
-
-        metrics.record_write_result(
-            &mut telemetry,
-            STORAGE_CACHE_STAGE_SINGLE_WRITE,
-            Instant::now() - Duration::from_millis(5_000),
-            &ok,
-        );
-        metrics.record_write_result(
-            &mut telemetry,
-            STORAGE_CACHE_STAGE_BATCH_WRITE,
-            Instant::now() - Duration::from_millis(7_000),
-            &ok,
-        );
-        metrics.record_total(&mut telemetry);
-
-        let ops = telemetry.pending_ops_with_duration_snapshot();
-        assert!(
-            op_duration_ms(&ops, STORAGE_CACHE_STAGE_SINGLE_WRITE) >= 5_000,
-            "expected single write duration in {ops:?}"
-        );
-        assert!(
-            op_duration_ms(&ops, STORAGE_CACHE_STAGE_BATCH_WRITE) >= 7_000,
-            "expected batch write duration in {ops:?}"
-        );
-        assert!(
-            op_duration_ms(&ops, STORAGE_CACHE_STAGE_TOTAL) >= 12_000,
-            "expected total to include both guest writes in {ops:?}"
-        );
-    }
-
     struct SamePathConcurrentWriteDetectingSandbox {
         inner: MockSandbox,
         gate: MockLifecycleGate,
@@ -1908,6 +1873,12 @@ mod tests {
         assert_op(&ops, STORAGE_CACHE_STAGE_TOTAL, true);
         assert_op(&ops, STORAGE_CACHE_STAGE_BATCH_WRITE, true);
         assert_no_op(&ops, STORAGE_CACHE_STAGE_SINGLE_WRITE);
+        let ops_with_duration = telemetry.pending_ops_with_duration_snapshot();
+        assert_eq!(
+            op_duration_ms(&ops_with_duration, STORAGE_CACHE_STAGE_TOTAL),
+            op_duration_ms(&ops_with_duration, STORAGE_CACHE_STAGE_BATCH_WRITE),
+            "pure batch staging total should equal the batch guest write duration in {ops_with_duration:?}"
+        );
     }
 
     #[tokio::test]
@@ -2000,6 +1971,12 @@ mod tests {
         assert_op(&ops, STORAGE_CACHE_STAGE_TOTAL, true);
         assert_op(&ops, STORAGE_CACHE_STAGE_SINGLE_WRITE, true);
         assert_no_op(&ops, STORAGE_CACHE_STAGE_BATCH_WRITE);
+        let ops_with_duration = telemetry.pending_ops_with_duration_snapshot();
+        assert_eq!(
+            op_duration_ms(&ops_with_duration, STORAGE_CACHE_STAGE_TOTAL),
+            op_duration_ms(&ops_with_duration, STORAGE_CACHE_STAGE_SINGLE_WRITE),
+            "single-write staging total should equal the single guest write duration in {ops_with_duration:?}"
+        );
         assert!(ops.iter().any(|(k, _, _)| k == "storage_cache_miss"));
         assert!(ops.iter().any(|(k, _, _)| k == "storage_cache_download"));
     }

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -122,8 +122,9 @@ struct GuestStageBatch {
     content_bytes: usize,
 }
 
+/// Aggregates actual guest write time, excluding cache probe/download work.
 struct StorageCacheStageMetrics {
-    started_at: Instant,
+    total_duration: Duration,
     attempted: bool,
     failed: bool,
 }
@@ -267,7 +268,7 @@ impl GuestStageBatch {
 impl StorageCacheStageMetrics {
     fn start() -> Self {
         Self {
-            started_at: Instant::now(),
+            total_duration: Duration::ZERO,
             attempted: false,
             failed: false,
         }
@@ -281,13 +282,15 @@ impl StorageCacheStageMetrics {
         result: &RunnerResult<()>,
     ) {
         self.attempted = true;
+        let duration = started_at.elapsed();
+        self.total_duration = self.total_duration.saturating_add(duration);
         let success = result.is_ok();
         if !success {
             self.failed = true;
         }
         telemetry.record(
             action_type,
-            started_at.elapsed(),
+            duration,
             success,
             (!success).then_some(STORAGE_CACHE_STAGE_FAILED),
         );
@@ -298,7 +301,7 @@ impl StorageCacheStageMetrics {
             let success = !self.failed;
             telemetry.record(
                 STORAGE_CACHE_STAGE_TOTAL,
-                self.started_at.elapsed(),
+                self.total_duration,
                 success,
                 (!success).then_some(STORAGE_CACHE_STAGE_FAILED),
             );

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -61,6 +61,10 @@ const GUEST_STAGE_DIR: &str = "/tmp/vm0-storage-cache";
 
 const HEAD_TIMEOUT: Duration = Duration::from_secs(10);
 const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(120);
+const STORAGE_CACHE_STAGE_TOTAL: &str = "storage_cache_stage_total";
+const STORAGE_CACHE_STAGE_BATCH_WRITE: &str = "storage_cache_stage_batch_write";
+const STORAGE_CACHE_STAGE_SINGLE_WRITE: &str = "storage_cache_stage_single_write";
+const STORAGE_CACHE_STAGE_FAILED: &str = "storage-cache-stage-failed";
 
 /// Guest-side filename for a cached archive.
 ///
@@ -116,6 +120,19 @@ struct GuestStageWrite {
 struct GuestStageBatch {
     writes: Vec<GuestStageWrite>,
     content_bytes: usize,
+}
+
+struct StorageCacheStageMetrics {
+    started_at: Instant,
+    attempted: bool,
+    failed: bool,
+}
+
+struct GuestStageRecorder<'a> {
+    sandbox: &'a dyn Sandbox,
+    guest_writes: &'a GuestWriteLocks,
+    telemetry: &'a mut JobTelemetry,
+    metrics: &'a mut StorageCacheStageMetrics,
 }
 
 type ProcessedGroupTaskResult = (CacheTargetGroup, RunnerResult<ProcessedGroup>);
@@ -247,38 +264,105 @@ impl GuestStageBatch {
     }
 }
 
+impl StorageCacheStageMetrics {
+    fn start() -> Self {
+        Self {
+            started_at: Instant::now(),
+            attempted: false,
+            failed: false,
+        }
+    }
+
+    fn record_write_result(
+        &mut self,
+        telemetry: &mut JobTelemetry,
+        action_type: &str,
+        started_at: Instant,
+        result: &RunnerResult<()>,
+    ) {
+        self.attempted = true;
+        let success = result.is_ok();
+        if !success {
+            self.failed = true;
+        }
+        telemetry.record(
+            action_type,
+            started_at.elapsed(),
+            success,
+            (!success).then_some(STORAGE_CACHE_STAGE_FAILED),
+        );
+    }
+
+    fn record_total(&self, telemetry: &mut JobTelemetry) {
+        if self.attempted {
+            let success = !self.failed;
+            telemetry.record(
+                STORAGE_CACHE_STAGE_TOTAL,
+                self.started_at.elapsed(),
+                success,
+                (!success).then_some(STORAGE_CACHE_STAGE_FAILED),
+            );
+        }
+    }
+}
+
 async fn flush_guest_stage_batch(
     batch: &mut GuestStageBatch,
-    sandbox: &dyn Sandbox,
-    guest_writes: &GuestWriteLocks,
+    stage: &mut GuestStageRecorder<'_>,
 ) -> RunnerResult<()> {
     if batch.writes.is_empty() {
         return Ok(());
     }
-    guest_writes.write_files(sandbox, &batch.writes).await?;
+    let started_at = Instant::now();
+    let result = stage
+        .guest_writes
+        .write_files(stage.sandbox, &batch.writes)
+        .await;
+    stage.metrics.record_write_result(
+        stage.telemetry,
+        STORAGE_CACHE_STAGE_BATCH_WRITE,
+        started_at,
+        &result,
+    );
+    result?;
     batch.writes.clear();
     batch.content_bytes = 0;
     Ok(())
 }
 
+async fn stage_single_guest_write(
+    write: &GuestStageWrite,
+    stage: &mut GuestStageRecorder<'_>,
+) -> RunnerResult<()> {
+    let started_at = Instant::now();
+    let result = stage
+        .guest_writes
+        .write_file(stage.sandbox, &write.guest_path, &write.bytes)
+        .await;
+    stage.metrics.record_write_result(
+        stage.telemetry,
+        STORAGE_CACHE_STAGE_SINGLE_WRITE,
+        started_at,
+        &result,
+    );
+    result
+}
+
 async fn push_guest_stage_write(
     batch: &mut GuestStageBatch,
     write: GuestStageWrite,
-    sandbox: &dyn Sandbox,
-    guest_writes: &GuestWriteLocks,
+    stage: &mut GuestStageRecorder<'_>,
 ) -> RunnerResult<()> {
     if write.bytes.len() > GUEST_STAGE_BATCH_MAX_BYTES {
-        guest_writes
-            .write_file(sandbox, &write.guest_path, &write.bytes)
-            .await?;
+        stage_single_guest_write(&write, stage).await?;
         return Ok(());
     }
     if batch.should_flush_before(&write) {
-        flush_guest_stage_batch(batch, sandbox, guest_writes).await?;
+        flush_guest_stage_batch(batch, stage).await?;
     }
     batch.push(write);
     if batch.should_flush_after_push() {
-        flush_guest_stage_batch(batch, sandbox, guest_writes).await?;
+        flush_guest_stage_batch(batch, stage).await?;
     }
     Ok(())
 }
@@ -318,8 +402,7 @@ async fn stage_processed_group(
     processed: ProcessedGroup,
     outcomes: &mut Vec<(CacheTargetGroup, GroupOutcome)>,
     stage_batch: &mut GuestStageBatch,
-    sandbox: &dyn Sandbox,
-    guest_writes: &GuestWriteLocks,
+    stage: &mut GuestStageRecorder<'_>,
 ) -> RunnerResult<()> {
     let ProcessedGroup {
         outcome,
@@ -327,12 +410,10 @@ async fn stage_processed_group(
     } = processed;
     if let Some(stage_write) = stage_write {
         if should_batch_stage_write(&outcome) {
-            push_guest_stage_write(stage_batch, stage_write, sandbox, guest_writes).await?;
+            push_guest_stage_write(stage_batch, stage_write, stage).await?;
         } else {
-            flush_guest_stage_batch(stage_batch, sandbox, guest_writes).await?;
-            guest_writes
-                .write_file(sandbox, &stage_write.guest_path, &stage_write.bytes)
-                .await?;
+            flush_guest_stage_batch(stage_batch, stage).await?;
+            stage_single_guest_write(&stage_write, stage).await?;
         }
     }
     outcomes.push((group, outcome));
@@ -345,8 +426,7 @@ async fn stage_joined_processed_group(
     processed: RunnerResult<ProcessedGroup>,
     outcomes: &mut Vec<(CacheTargetGroup, GroupOutcome)>,
     stage_batch: &mut GuestStageBatch,
-    sandbox: &dyn Sandbox,
-    guest_writes: &GuestWriteLocks,
+    stage: &mut GuestStageRecorder<'_>,
 ) -> RunnerResult<()> {
     let processed = match processed {
         Ok(processed) => processed,
@@ -355,15 +435,7 @@ async fn stage_joined_processed_group(
             return Err(error);
         }
     };
-    if let Err(error) = stage_processed_group(
-        group,
-        processed,
-        outcomes,
-        stage_batch,
-        sandbox,
-        guest_writes,
-    )
-    .await
+    if let Err(error) = stage_processed_group(group, processed, outcomes, stage_batch, stage).await
     {
         abort_pending_processed_groups(groups).await;
         return Err(error);
@@ -397,53 +469,64 @@ pub async fn populate_cache(
         .build()
         .map_err(|e| RunnerError::Internal(format!("build http client: {e}")))?;
     let guest_writes = GuestWriteLocks::default();
+    let mut stage_metrics = StorageCacheStageMetrics::start();
 
     // Cache population runs in owned tasks so a slow guest staging write does
     // not stop already-started workers from releasing host cache flocks. Failure
     // paths explicitly abort and drain pending workers so locks are not left for
     // the runtime to clean up later.
     let mut groups = JoinSet::new();
-    let mut outcomes = Vec::new();
-    let mut stage_batch = GuestStageBatch::default();
+    let stage_result: RunnerResult<Vec<(CacheTargetGroup, GroupOutcome)>> = async {
+        let mut outcomes = Vec::new();
+        let mut stage_batch = GuestStageBatch::default();
+        let mut stage = GuestStageRecorder {
+            sandbox,
+            guest_writes: &guest_writes,
+            telemetry,
+            metrics: &mut stage_metrics,
+        };
 
-    for group in target_groups {
-        while groups.len() >= CONCURRENCY {
-            let Some((group, outcome)) = join_next_processed_group(&mut groups).await? else {
-                break;
-            };
+        for group in target_groups {
+            while groups.len() >= CONCURRENCY {
+                let Some((group, outcome)) = join_next_processed_group(&mut groups).await? else {
+                    break;
+                };
+                stage_joined_processed_group(
+                    &mut groups,
+                    group,
+                    outcome,
+                    &mut outcomes,
+                    &mut stage_batch,
+                    &mut stage,
+                )
+                .await?;
+            }
+
+            let http = http.clone();
+            let home = home.clone();
+            groups.spawn(async move {
+                let res = process_group(&group, &http, &home).await;
+                (group, res)
+            });
+        }
+
+        while let Some((group, outcome)) = join_next_processed_group(&mut groups).await? {
             stage_joined_processed_group(
                 &mut groups,
                 group,
                 outcome,
                 &mut outcomes,
                 &mut stage_batch,
-                sandbox,
-                &guest_writes,
+                &mut stage,
             )
             .await?;
         }
-
-        let http = http.clone();
-        let home = home.clone();
-        groups.spawn(async move {
-            let res = process_group(&group, &http, &home).await;
-            (group, res)
-        });
+        flush_guest_stage_batch(&mut stage_batch, &mut stage).await?;
+        Ok(outcomes)
     }
-
-    while let Some((group, outcome)) = join_next_processed_group(&mut groups).await? {
-        stage_joined_processed_group(
-            &mut groups,
-            group,
-            outcome,
-            &mut outcomes,
-            &mut stage_batch,
-            sandbox,
-            &guest_writes,
-        )
-        .await?;
-    }
-    flush_guest_stage_batch(&mut stage_batch, sandbox, &guest_writes).await?;
+    .await;
+    stage_metrics.record_total(telemetry);
+    let outcomes = stage_result?;
 
     for (group, outcome) in outcomes {
         apply_group_outcome(manifest, &group, &outcome, telemetry);
@@ -1381,6 +1464,21 @@ mod tests {
         JobTelemetry::new(http, RunId::nil(), "test-token".to_string())
     }
 
+    fn assert_op(ops: &[(String, bool, Option<String>)], action_type: &str, success: bool) {
+        assert!(
+            ops.iter()
+                .any(|(key, op_success, _)| key == action_type && *op_success == success),
+            "expected {action_type} success={success} in {ops:?}"
+        );
+    }
+
+    fn assert_no_op(ops: &[(String, bool, Option<String>)], action_type: &str) {
+        assert!(
+            !ops.iter().any(|(key, _, _)| key == action_type),
+            "expected no {action_type} in {ops:?}"
+        );
+    }
+
     fn home_at(temp: &tempfile::TempDir) -> HomePaths {
         HomePaths::with_root(temp.path().to_path_buf())
     }
@@ -1745,6 +1843,41 @@ mod tests {
             ])
         );
         assert_eq!(sandbox.write_file_calls().len(), 2);
+        let ops = telemetry.pending_ops_snapshot();
+        assert_op(&ops, STORAGE_CACHE_STAGE_TOTAL, true);
+        assert_op(&ops, STORAGE_CACHE_STAGE_BATCH_WRITE, true);
+        assert_no_op(&ops, STORAGE_CACHE_STAGE_SINGLE_WRITE);
+    }
+
+    #[tokio::test]
+    async fn warm_hit_batch_stage_failure_records_failed_staging_telemetry() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = home_at(&temp);
+        let sandbox = MockSandbox::new("test");
+        sandbox.push_write_file_result(Err(sandbox_write_file_error("vsock write failed")));
+        let mut telemetry = new_telemetry();
+
+        let name = "warm-batch-fail";
+        let version = "v1";
+        let original = "https://r2.example.com/fail.tar.gz".to_string();
+        write_cached_archive(&home, name, version, &tarball_bytes());
+        let mut manifest = manifest_single_storage(original.clone(), name, version);
+
+        let err = populate_cache(&mut manifest, &sandbox, &home, &mut telemetry)
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("vsock write failed"), "got: {err}");
+        assert_eq!(
+            manifest.storages[0].archive_url.as_deref(),
+            Some(original.as_str())
+        );
+
+        let ops = telemetry.pending_ops_snapshot();
+        assert_op(&ops, STORAGE_CACHE_STAGE_BATCH_WRITE, false);
+        assert_op(&ops, STORAGE_CACHE_STAGE_TOTAL, false);
+        assert_no_op(&ops, STORAGE_CACHE_STAGE_SINGLE_WRITE);
+        assert_no_op(&ops, "storage_cache_hit");
     }
 
     #[tokio::test]
@@ -1797,6 +1930,9 @@ mod tests {
         );
 
         let ops = telemetry.pending_ops_snapshot();
+        assert_op(&ops, STORAGE_CACHE_STAGE_TOTAL, true);
+        assert_op(&ops, STORAGE_CACHE_STAGE_SINGLE_WRITE, true);
+        assert_no_op(&ops, STORAGE_CACHE_STAGE_BATCH_WRITE);
         assert!(ops.iter().any(|(k, _, _)| k == "storage_cache_miss"));
         assert!(ops.iter().any(|(k, _, _)| k == "storage_cache_download"));
     }
@@ -1842,6 +1978,9 @@ mod tests {
         assert!(!home.storage_cache_dir(name, version).exists());
 
         let ops = telemetry.pending_ops_snapshot();
+        assert_no_op(&ops, STORAGE_CACHE_STAGE_TOTAL);
+        assert_no_op(&ops, STORAGE_CACHE_STAGE_BATCH_WRITE);
+        assert_no_op(&ops, STORAGE_CACHE_STAGE_SINGLE_WRITE);
         assert!(
             ops.iter()
                 .any(|(k, _, _)| k == "storage_cache_skipped_over_size")

--- a/crates/runner/src/telemetry.rs
+++ b/crates/runner/src/telemetry.rs
@@ -112,6 +112,24 @@ impl JobTelemetry {
             .collect()
     }
 
+    /// Snapshot of buffered ops for tests that need to assert duration semantics.
+    #[cfg(test)]
+    pub(crate) fn pending_ops_with_duration_snapshot(
+        &self,
+    ) -> Vec<(String, u64, bool, Option<String>)> {
+        self.pending_ops
+            .iter()
+            .map(|op| {
+                (
+                    op.action_type.clone(),
+                    op.duration_ms,
+                    op.success,
+                    op.error.clone(),
+                )
+            })
+            .collect()
+    }
+
     /// Rewind the oldest-pending marker to simulate a buffered op that has
     /// aged past the auto-flush threshold, without needing a real sleep or a
     /// paused tokio clock.


### PR DESCRIPTION
## Summary

- Add runner telemetry for storage cache staging using the existing `JobTelemetry` payload shape.
- Record `storage_cache_stage_total` as the sum of actual guest write durations, excluding cache probe/download/cache-write work.
- Record `storage_cache_stage_batch_write` and `storage_cache_stage_single_write` around the corresponding guest write calls.
- Record failed guest staging writes with a generic staging failure tag while preserving the existing fail-closed manifest rewrite behavior.
- Keep existing storage cache hit, miss, download, and skipped outcome telemetry unchanged.

Closes #19101

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p runner storage_cache`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings -D clippy::all`
- Lefthook pre-commit: `cargo-fmt`, `cargo-clippy`, `cargo-doc`
