### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -111,11 +111,11 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.4"
-CLAUDE_CODE_VERSION="2.1.193"
-CODEX_CLI_VERSION="0.142.2"
+CLAUDE_CODE_VERSION="2.1.195"
+CODEX_CLI_VERSION="0.142.3"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"
-AGENT_BROWSER_VERSION="0.31.0"
+AGENT_BROWSER_VERSION="0.31.1"
 PNPM_VERSION="11.9.0"
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Updates pinned rootfs dependency versions in `crates/runner/scripts/build-template.sh`:

- Claude Code CLI: `2.1.193` -> `2.1.195`
- OpenAI Codex CLI: `0.142.2` -> `0.142.3`
- agent-browser: `0.31.0` -> `0.31.1`

Checked and left unchanged because they are already current for the selected stable/LTS stream:

- Go: `1.26.4`
- NodeSource Node.js LTS stream: `24.x`
- PostgreSQL packages: `18`
- Google Workspace CLI: `0.22.5`
- xurl: `1.0.3`
- pnpm: `11.9.0`

## Validation

- `bash -n crates/runner/scripts/build-template.sh`
