### PR TITLE
perf(nbd-cow): avoid redundant pid stat during scans

### DIFF
--- a/crates/nbd-cow/src/netlink.rs
+++ b/crates/nbd-cow/src/netlink.rs
@@ -100,17 +100,21 @@ pub fn random_offset(max: u32) -> u32 {
 /// Check if a device index appears free by inspecting its pid file.
 pub fn device_appears_free(index: u32) -> bool {
     let pid_path = format!("/sys/block/nbd{index}/pid");
-    let device_path = format!("/dev/nbd{index}");
-    device_paths_appear_free(Path::new(&pid_path), Path::new(&device_path))
+    device_pid_appears_free(Path::new(&pid_path), || {
+        Path::new(&format!("/dev/nbd{index}")).exists()
+    })
 }
 
-fn device_paths_appear_free(pid_path: &Path, device_path: &Path) -> bool {
+fn device_pid_appears_free<F>(pid_path: &Path, device_exists: F) -> bool
+where
+    F: FnOnce() -> bool,
+{
     match std::fs::read_to_string(pid_path) {
         Ok(contents) => {
             let pid = contents.trim();
             pid == "-1" || pid == "0" || pid.is_empty()
         }
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => device_path.exists(),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => device_exists(),
         Err(_) => false, // Can't read pid file; EBUSY fallback will catch free devices.
     }
 }
@@ -421,11 +425,12 @@ mod tests {
         for contents in ["-1", "0", "", " 0\n"] {
             let dir = tempfile::tempdir().expect("tempdir");
             let pid_path = dir.path().join("pid");
-            let device_path = dir.path().join("nbd0");
             std::fs::write(&pid_path, contents).expect("write pid");
 
             assert!(
-                device_paths_appear_free(&pid_path, &device_path),
+                device_pid_appears_free(&pid_path, || {
+                    panic!("device path should not be checked when pid is readable")
+                }),
                 "pid contents {contents:?} should be free"
             );
         }
@@ -435,10 +440,11 @@ mod tests {
     fn device_appears_free_rejects_busy_pid_value() {
         let dir = tempfile::tempdir().expect("tempdir");
         let pid_path = dir.path().join("pid");
-        let device_path = dir.path().join("nbd0");
         std::fs::write(&pid_path, "1234\n").expect("write pid");
 
-        assert!(!device_paths_appear_free(&pid_path, &device_path));
+        assert!(!device_pid_appears_free(&pid_path, || {
+            panic!("device path should not be checked when pid is readable")
+        }));
     }
 
     #[test]
@@ -448,7 +454,7 @@ mod tests {
         let device_path = dir.path().join("nbd0");
         std::fs::write(&device_path, b"").expect("create device placeholder");
 
-        assert!(device_paths_appear_free(&pid_path, &device_path));
+        assert!(device_pid_appears_free(&pid_path, || device_path.exists()));
     }
 
     #[test]
@@ -457,18 +463,18 @@ mod tests {
         let pid_path = dir.path().join("pid");
         let device_path = dir.path().join("nbd0");
 
-        assert!(!device_paths_appear_free(&pid_path, &device_path));
+        assert!(!device_pid_appears_free(&pid_path, || device_path.exists()));
     }
 
     #[test]
     fn device_appears_free_rejects_unreadable_pid_path() {
         let dir = tempfile::tempdir().expect("tempdir");
         let pid_path = dir.path().join("pid");
-        let device_path = dir.path().join("nbd0");
         std::fs::create_dir(&pid_path).expect("create pid directory");
-        std::fs::write(&device_path, b"").expect("create device placeholder");
 
-        assert!(!device_paths_appear_free(&pid_path, &device_path));
+        assert!(!device_pid_appears_free(&pid_path, || {
+            panic!("device path should not be checked when pid read fails")
+        }));
     }
 
     #[test]

--- a/crates/nbd-cow/src/netlink.rs
+++ b/crates/nbd-cow/src/netlink.rs
@@ -100,18 +100,17 @@ pub fn random_offset(max: u32) -> u32 {
 /// Check if a device index appears free by inspecting its pid file.
 pub fn device_appears_free(index: u32) -> bool {
     let pid_path = format!("/sys/block/nbd{index}/pid");
-    let path = Path::new(&pid_path);
+    let device_path = format!("/dev/nbd{index}");
+    device_paths_appear_free(Path::new(&pid_path), Path::new(&device_path))
+}
 
-    if !path.exists() {
-        // No pid file: free if the device node exists.
-        return Path::new(&format!("/dev/nbd{index}")).exists();
-    }
-
-    match std::fs::read_to_string(path) {
+fn device_paths_appear_free(pid_path: &Path, device_path: &Path) -> bool {
+    match std::fs::read_to_string(pid_path) {
         Ok(contents) => {
             let pid = contents.trim();
             pid == "-1" || pid == "0" || pid.is_empty()
         }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => device_path.exists(),
         Err(_) => false, // Can't read pid file; EBUSY fallback will catch free devices.
     }
 }
@@ -415,6 +414,61 @@ mod tests {
                 assert!(random_offset(max) < max, "offset >= max for max={max}");
             }
         }
+    }
+
+    #[test]
+    fn device_appears_free_accepts_free_pid_values() {
+        for contents in ["-1", "0", "", " 0\n"] {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let pid_path = dir.path().join("pid");
+            let device_path = dir.path().join("nbd0");
+            std::fs::write(&pid_path, contents).expect("write pid");
+
+            assert!(
+                device_paths_appear_free(&pid_path, &device_path),
+                "pid contents {contents:?} should be free"
+            );
+        }
+    }
+
+    #[test]
+    fn device_appears_free_rejects_busy_pid_value() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pid_path = dir.path().join("pid");
+        let device_path = dir.path().join("nbd0");
+        std::fs::write(&pid_path, "1234\n").expect("write pid");
+
+        assert!(!device_paths_appear_free(&pid_path, &device_path));
+    }
+
+    #[test]
+    fn device_appears_free_falls_back_to_device_path_when_pid_is_missing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pid_path = dir.path().join("pid");
+        let device_path = dir.path().join("nbd0");
+        std::fs::write(&device_path, b"").expect("create device placeholder");
+
+        assert!(device_paths_appear_free(&pid_path, &device_path));
+    }
+
+    #[test]
+    fn device_appears_free_rejects_missing_pid_without_device_path() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pid_path = dir.path().join("pid");
+        let device_path = dir.path().join("nbd0");
+
+        assert!(!device_paths_appear_free(&pid_path, &device_path));
+    }
+
+    #[test]
+    fn device_appears_free_rejects_unreadable_pid_path() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pid_path = dir.path().join("pid");
+        let device_path = dir.path().join("nbd0");
+        std::fs::create_dir(&pid_path).expect("create pid directory");
+        std::fs::write(&device_path, b"").expect("create device placeholder");
+
+        assert!(!device_paths_appear_free(&pid_path, &device_path));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`device_appears_free()` checked `/sys/block/nbdN/pid` with `Path::exists()` before reading the same pid file. During NBD device scans this adds an avoidable metadata syscall for every existing pid file, and candidates can be checked both before and after taking the per-index lock.

Fixes #19154

## Solution

- Keep the public `device_appears_free(index)` API unchanged.
- Move pid classification into a narrow helper with lazy device-node fallback.
- Read the pid file once and branch on the result:
  - free for pid contents `-1`, `0`, or empty;
  - check `/dev/nbdN` only when the pid read returns `NotFound`;
  - return busy/false for other read errors.
- Add focused tempfile-backed tests for pid classification, fallback cases, and the cases where fallback must not run.

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p nbd-cow device_appears_free`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo test --manifest-path crates/Cargo.toml -p nbd-cow`
- `cargo clippy --manifest-path crates/Cargo.toml -p nbd-cow --all-targets -- -D warnings`
- `git diff --check`
