### PR TITLE
perf(runner): reduce workspace cache size walk metadata calls

### DIFF
--- a/crates/runner/src/workspace_image_cache/fs.rs
+++ b/crates/runner/src/workspace_image_cache/fs.rs
@@ -65,14 +65,21 @@ pub(super) fn existing_fs_stats_path(path: &Path) -> PathBuf {
 }
 
 pub(super) async fn workspace_cache_path_allocated_bytes(path: &Path) -> u64 {
-    let Ok(metadata) = fs::symlink_metadata(path).await else {
-        return 0;
-    };
-    if metadata.is_dir() {
-        directory_tree_allocated_bytes(path).await
-    } else {
-        allocated_bytes(&metadata)
+    match workspace_cache_existing_path_allocated_bytes(path).await {
+        Ok(Some(bytes)) => bytes,
+        Ok(None) | Err(_) => 0,
     }
+}
+
+pub(super) async fn workspace_cache_existing_path_allocated_bytes(
+    path: &Path,
+) -> std::io::Result<Option<u64>> {
+    let metadata = match fs::symlink_metadata(path).await {
+        Ok(metadata) => metadata,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e),
+    };
+    Ok(Some(path_tree_allocated_bytes(path, metadata).await))
 }
 
 pub(super) async fn remove_workspace_cache_path_if_exists(path: &Path) -> std::io::Result<bool> {
@@ -246,26 +253,39 @@ pub(super) fn statvfs_bytes_sync(path: &Path) -> RunnerResult<FsStats> {
     })
 }
 
-pub(super) async fn directory_tree_allocated_bytes(path: &Path) -> u64 {
-    let mut total: u64 = 0;
-    let mut pending = vec![path.to_path_buf()];
-    while let Some(dir) = pending.pop() {
-        let Ok(metadata) = fs::symlink_metadata(&dir).await else {
-            continue;
-        };
-        total = total.saturating_add(allocated_bytes(&metadata));
+async fn path_tree_allocated_bytes(path: &Path, metadata: std::fs::Metadata) -> u64 {
+    let mut total = allocated_bytes(&metadata);
+    if !metadata.file_type().is_dir() {
+        return total;
+    }
+
+    let mut pending = vec![(path.to_path_buf(), true)];
+    while let Some((dir, metadata_counted)) = pending.pop() {
+        if !metadata_counted {
+            let Ok(metadata) = fs::symlink_metadata(&dir).await else {
+                continue;
+            };
+            total = total.saturating_add(allocated_bytes(&metadata));
+            if !metadata.file_type().is_dir() {
+                continue;
+            }
+        }
+
         let mut entries = match fs::read_dir(&dir).await {
             Ok(entries) => entries,
             Err(_) => continue,
         };
         while let Ok(Some(entry)) = entries.next_entry().await {
             let path = entry.path();
-            let Ok(metadata) = fs::symlink_metadata(&path).await else {
+            let Ok(file_type) = entry.file_type().await else {
                 continue;
             };
-            if metadata.is_dir() {
-                pending.push(path);
+            if file_type.is_dir() {
+                pending.push((path, false));
             } else {
+                let Ok(metadata) = fs::symlink_metadata(&path).await else {
+                    continue;
+                };
                 total = total.saturating_add(allocated_bytes(&metadata));
             }
         }

--- a/crates/runner/src/workspace_image_cache/gc.rs
+++ b/crates/runner/src/workspace_image_cache/gc.rs
@@ -9,8 +9,8 @@ use crate::types::MAX_HELD_SESSION_STATES;
 
 use super::entry::is_cache_key_name;
 use super::fs::{
-    allocated_bytes, cache_entry_dir_is_dir, directory_tree_allocated_bytes,
-    entry_file_type_is_dir, fs_stats_with_additional_available, is_workspace_tmp_path_name,
+    allocated_bytes, cache_entry_dir_is_dir, entry_file_type_is_dir,
+    fs_stats_with_additional_available, is_workspace_tmp_path_name,
     remove_workspace_cache_path_if_exists, workspace_cache_path_allocated_bytes,
 };
 use super::metadata::{
@@ -219,7 +219,7 @@ impl SessionWorkspaceCache {
                 continue;
             };
 
-            let allocated = directory_tree_allocated_bytes(&entry_dir).await;
+            let allocated = workspace_cache_path_allocated_bytes(&entry_dir).await;
             if dry_run {
                 info!(
                     cache_key,
@@ -330,7 +330,7 @@ impl SessionWorkspaceCache {
                     return Err(e.into());
                 }
             }
-            let allocated = directory_tree_allocated_bytes(&entry_dir).await;
+            let allocated = workspace_cache_path_allocated_bytes(&entry_dir).await;
             if dry_run {
                 info!(
                     cache_key,

--- a/crates/runner/src/workspace_image_cache/inspection.rs
+++ b/crates/runner/src/workspace_image_cache/inspection.rs
@@ -6,8 +6,8 @@ use crate::error::{RunnerError, RunnerResult};
 
 use super::entry::is_cache_key_name;
 use super::fs::{
-    allocated_bytes, cache_entry_dir_is_dir, directory_tree_allocated_bytes,
-    entry_file_type_is_dir, is_workspace_tmp_path_name,
+    allocated_bytes, cache_entry_dir_is_dir, entry_file_type_is_dir, is_workspace_tmp_path_name,
+    workspace_cache_existing_path_allocated_bytes, workspace_cache_path_allocated_bytes,
 };
 use super::metadata::WorkspaceCacheMetadata;
 use super::types::{
@@ -139,7 +139,9 @@ impl SessionWorkspaceCache {
             Err(e) => (None, Some(e.to_string())),
         };
         let current_allocated_bytes = match current_metadata.as_ref() {
-            Some(metadata) if metadata.is_dir() => directory_tree_allocated_bytes(&current).await,
+            Some(metadata) if metadata.is_dir() => {
+                workspace_cache_path_allocated_bytes(&current).await
+            }
             Some(metadata) => allocated_bytes(metadata),
             None => 0,
         };
@@ -256,15 +258,8 @@ pub(super) async fn inspect_temporary_paths(entry_dir: &Path) -> RunnerResult<Te
             continue;
         }
         let path = file.path();
-        let metadata = match fs::symlink_metadata(&path).await {
-            Ok(metadata) => metadata,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
-            Err(e) => return Err(e.into()),
-        };
-        let allocated = if metadata.is_dir() {
-            directory_tree_allocated_bytes(&path).await
-        } else {
-            allocated_bytes(&metadata)
+        let Some(allocated) = workspace_cache_existing_path_allocated_bytes(&path).await? else {
+            continue;
         };
         stats.path_count += 1;
         stats.allocated_bytes = stats.allocated_bytes.saturating_add(allocated);

--- a/crates/runner/src/workspace_image_cache/tests/mod.rs
+++ b/crates/runner/src/workspace_image_cache/tests/mod.rs
@@ -3,8 +3,8 @@ use std::os::unix::fs::MetadataExt;
 use std::path::Path;
 
 use super::fs::{
-    allocated_bytes, directory_tree_allocated_bytes, has_copy_headroom, local_timestamp,
-    sparse_copy_with_timeout, workspace_cache_path_allocated_bytes,
+    allocated_bytes, has_copy_headroom, local_timestamp, sparse_copy_with_timeout,
+    workspace_cache_path_allocated_bytes,
 };
 use super::gc::gc_budget_satisfied;
 use super::lifecycle::cap_workspace_held_session_states;
@@ -3364,7 +3364,7 @@ async fn gc_dry_run_counts_temporary_only_entry_once() {
     tokio::fs::create_dir_all(&entry_dir).await.unwrap();
     let tmp = paths.session_workspace_cache_tmp_image(&key, RunId::new_v4());
     tokio::fs::write(&tmp, vec![1_u8; 4096]).await.unwrap();
-    let expected = directory_tree_allocated_bytes(&entry_dir).await;
+    let expected = workspace_cache_path_allocated_bytes(&entry_dir).await;
 
     let freed = cache.gc(true).await.unwrap();
 
@@ -3389,7 +3389,7 @@ async fn gc_dry_run_counts_unusable_entry_with_temporary_path_once() {
     tokio::fs::write(&current, b"orphan image").await.unwrap();
     let tmp = paths.session_workspace_cache_tmp_image(&key, RunId::new_v4());
     tokio::fs::write(&tmp, vec![1_u8; 4096]).await.unwrap();
-    let expected = directory_tree_allocated_bytes(&entry_dir).await;
+    let expected = workspace_cache_path_allocated_bytes(&entry_dir).await;
 
     let freed = cache.gc(true).await.unwrap();
 
@@ -3447,6 +3447,62 @@ async fn gc_dry_run_uses_pre_cleanup_freed_bytes_for_disk_pressure() {
     assert!(
         paths.session_workspace_cache_current_image(&key).exists(),
         "dry-run must not preview deleting a valid entry when temporary cleanup would relieve disk pressure"
+    );
+}
+
+#[tokio::test]
+async fn workspace_cache_path_allocated_bytes_does_not_follow_root_symlink_to_directory() {
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("target");
+    tokio::fs::create_dir_all(&target).await.unwrap();
+    tokio::fs::write(target.join("payload"), vec![1_u8; 1024 * 1024])
+        .await
+        .unwrap();
+    let link = dir.path().join("link");
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+
+    let link_allocated = allocated_bytes(&fs::symlink_metadata(&link).await.unwrap());
+    let target_allocated = workspace_cache_path_allocated_bytes(&target).await;
+    let actual = workspace_cache_path_allocated_bytes(&link).await;
+
+    assert_eq!(actual, link_allocated);
+    assert!(
+        target_allocated > link_allocated,
+        "test setup should make following the symlink visibly larger"
+    );
+}
+
+#[tokio::test]
+async fn workspace_cache_path_allocated_bytes_does_not_follow_nested_symlink_to_directory() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().join("root");
+    let real_nested = root.join("real-nested");
+    tokio::fs::create_dir_all(&real_nested).await.unwrap();
+    tokio::fs::write(real_nested.join("payload"), vec![1_u8; 1024 * 1024])
+        .await
+        .unwrap();
+    let external_target = dir.path().join("external-target");
+    tokio::fs::create_dir_all(&external_target).await.unwrap();
+    tokio::fs::write(external_target.join("payload"), vec![1_u8; 8 * 1024 * 1024])
+        .await
+        .unwrap();
+    let nested_link = root.join("external-link");
+    std::os::unix::fs::symlink(&external_target, &nested_link).unwrap();
+
+    let root_allocated = allocated_bytes(&fs::symlink_metadata(&root).await.unwrap());
+    let real_nested_allocated = workspace_cache_path_allocated_bytes(&real_nested).await;
+    let nested_link_allocated = allocated_bytes(&fs::symlink_metadata(&nested_link).await.unwrap());
+    let external_target_allocated = workspace_cache_path_allocated_bytes(&external_target).await;
+    let expected = root_allocated
+        .saturating_add(real_nested_allocated)
+        .saturating_add(nested_link_allocated);
+
+    let actual = workspace_cache_path_allocated_bytes(&root).await;
+
+    assert_eq!(actual, expected);
+    assert!(
+        external_target_allocated > nested_link_allocated,
+        "test setup should make following the nested symlink visibly larger"
     );
 }
 


### PR DESCRIPTION
## Summary

- route workspace cache allocated-byte accounting through a single best-effort path/tree walker
- avoid re-statting directory roots and child directories just to decide traversal
- keep no-follow symlink accounting and add coverage for root and nested symlink-to-directory paths

Fixes #19157

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p runner workspace_cache_path_allocated_bytes_does_not_follow -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p runner workspace_image_cache`
- `cargo fmt --manifest-path crates/runner/Cargo.toml --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- `git diff --check`
