### PR TITLE
test: extract supervised exec control fixtures

### DIFF
--- a/crates/vsock-host/src/tests/exec_operation/supervised/control.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised/control.rs
@@ -1,53 +1,38 @@
 use std::io;
-use std::sync::Arc;
 use std::time::Duration;
 
 use tokio::io::AsyncWriteExt;
 use vsock_proto::{
-    ExecControlPolicy, ExecControlStatus, ExecTermination, MSG_ERROR, MSG_EXEC_CONTROL,
-    MSG_EXEC_CONTROL_RESULT,
+    ExecControlStatus, ExecTermination, MSG_ERROR, MSG_EXEC_CONTROL, MSG_EXEC_CONTROL_RESULT,
 };
 
 use super::super::super::support::{
     normal_operation_readiness, operation_count, read_guest_message, send_exec_control_result,
-    send_exec_result, send_exec_started, setup_host_and_guest,
+    send_exec_result,
 };
-use super::support::{send_guest_error, supervised_request};
+use super::support::{
+    StartedControlSupervisedExec, StartedSupervisedExec, assert_no_guest_frame,
+    finish_supervised_exec_success, send_guest_error, start_control_supervised_exec_fixture,
+    start_supervised_exec_fixture, supervised_request,
+};
 use crate::operation_tracker::NormalOperationReadiness;
-use crate::{SupervisedExecControl, SupervisedExecRequest};
 
 #[tokio::test]
 async fn supervised_exec_control_uses_exec_control_messages() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
-    let task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move {
-            host.start_supervised_exec(SupervisedExecRequest {
-                control: SupervisedExecControl::Enabled { sink: true },
-                ..supervised_request("control")
-            })
-            .await
-        })
-    };
-
-    let start = read_guest_message(&mut guest).await;
-    let decoded_start = vsock_proto::decode_exec_start(&start.payload).unwrap();
-    let ExecControlPolicy::Enabled {
+    let StartedControlSupervisedExec {
+        host: _host,
+        mut guest,
+        start,
+        handle,
+        control_handle,
         control_nonce,
-        sink,
-    } = decoded_start.control
-    else {
-        panic!("supervised exec should enable control");
-    };
-    assert!(sink);
-    send_exec_started(&mut guest, start.seq, 123).await;
-    let handle = task.await.unwrap().unwrap();
+        ..
+    } = start_control_supervised_exec_fixture("control").await;
+    let start_seq = start.seq();
 
     let control_task = tokio::spawn({
-        let handle = handle.control_handle().unwrap();
         async move {
-            handle
+            control_handle
                 .control("message-1", b"payload", Duration::from_secs(5))
                 .await
         }
@@ -55,7 +40,7 @@ async fn supervised_exec_control_uses_exec_control_messages() {
     let control = read_guest_message(&mut guest).await;
     assert_eq!(control.msg_type, MSG_EXEC_CONTROL);
     let decoded_control = vsock_proto::decode_exec_control(&control.payload).unwrap();
-    assert_eq!(decoded_control.target_seq, start.seq);
+    assert_eq!(decoded_control.target_seq, start_seq);
     assert_eq!(decoded_control.control_nonce, control_nonce);
     assert_eq!(decoded_control.message_id, "message-1");
     assert_eq!(decoded_control.payload, b"payload");
@@ -71,38 +56,24 @@ async fn supervised_exec_control_uses_exec_control_messages() {
     )
     .await;
     let ack = control_task.await.unwrap().unwrap();
-    assert_eq!(ack.target_seq, start.seq);
+    assert_eq!(ack.target_seq, start_seq);
     assert_eq!(ack.message_id, "message-1");
 
-    send_exec_result(
-        &mut guest,
-        start.seq,
-        ExecTermination::Exited { exit_code: 0 },
-        b"",
-        b"",
-    )
-    .await;
-    handle.wait(Duration::from_secs(5)).await.unwrap();
+    finish_supervised_exec_success(&mut guest, start_seq, handle)
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
 async fn supervised_exec_control_rejects_empty_message_id_without_frame() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
-    let task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move {
-            host.start_supervised_exec(SupervisedExecRequest {
-                control: SupervisedExecControl::Enabled { sink: true },
-                ..supervised_request("control-empty-message-id")
-            })
-            .await
-        })
-    };
-
-    let start = read_guest_message(&mut guest).await;
-    send_exec_started(&mut guest, start.seq, 123).await;
-    let handle = task.await.unwrap().unwrap();
+    let StartedControlSupervisedExec {
+        host: _host,
+        mut guest,
+        start,
+        handle,
+        ..
+    } = start_control_supervised_exec_fixture("control-empty-message-id").await;
+    let start_seq = start.seq();
 
     let err = handle
         .control("", b"payload", Duration::from_secs(5))
@@ -113,48 +84,27 @@ async fn supervised_exec_control_rejects_empty_message_id_without_frame() {
         err.to_string().contains("exec_control message_id empty"),
         "unexpected error: {err}",
     );
-    match guest.try_read(&mut [0u8; 1]) {
-        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
-        Ok(n) => panic!("invalid control request must not send a frame; read {n} bytes"),
-        Err(err) => panic!("unexpected read error after invalid control request: {err}"),
-    }
+    assert_no_guest_frame(&mut guest, "invalid control request must not send a frame");
 
-    send_exec_result(
-        &mut guest,
-        start.seq,
-        ExecTermination::Exited { exit_code: 0 },
-        b"",
-        b"",
-    )
-    .await;
-    handle.wait(Duration::from_secs(5)).await.unwrap();
+    finish_supervised_exec_success(&mut guest, start_seq, handle)
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
 async fn supervised_exec_control_sub_millisecond_timeout_rounds_up_to_one_ms() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
-    let task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move {
-            host.start_supervised_exec(SupervisedExecRequest {
-                control: SupervisedExecControl::Enabled { sink: true },
-                ..supervised_request("control-sub-ms-timeout")
-            })
-            .await
-        })
-    };
-
-    let start = read_guest_message(&mut guest).await;
-    let decoded_start = vsock_proto::decode_exec_start(&start.payload).unwrap();
-    let ExecControlPolicy::Enabled { control_nonce, .. } = decoded_start.control else {
-        panic!("supervised exec should enable control");
-    };
-    send_exec_started(&mut guest, start.seq, 123).await;
-    let handle = task.await.unwrap().unwrap();
+    let StartedControlSupervisedExec {
+        host: _host,
+        mut guest,
+        start,
+        handle,
+        control_handle,
+        control_nonce,
+        ..
+    } = start_control_supervised_exec_fixture("control-sub-ms-timeout").await;
+    let start_seq = start.seq();
 
     let control_task = tokio::spawn({
-        let control_handle = handle.control_handle().unwrap();
         async move {
             control_handle
                 .control("sub-ms-timeout", b"payload", Duration::from_nanos(1))
@@ -163,49 +113,32 @@ async fn supervised_exec_control_sub_millisecond_timeout_rounds_up_to_one_ms() {
     });
     let control = read_guest_message(&mut guest).await;
     let decoded_control = vsock_proto::decode_exec_control(&control.payload).unwrap();
-    assert_eq!(decoded_control.target_seq, start.seq);
+    assert_eq!(decoded_control.target_seq, start_seq);
     assert_eq!(decoded_control.control_nonce, control_nonce);
     assert_eq!(decoded_control.message_id, "sub-ms-timeout");
     assert_eq!(decoded_control.request_timeout_ms, 1);
     let err = control_task.await.unwrap().unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::TimedOut);
 
-    send_exec_result(
-        &mut guest,
-        start.seq,
-        ExecTermination::Exited { exit_code: 0 },
-        b"",
-        b"",
-    )
-    .await;
-    handle.wait(Duration::from_secs(5)).await.unwrap();
+    finish_supervised_exec_success(&mut guest, start_seq, handle)
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
 async fn supervised_exec_control_large_timeout_saturates_request_timeout_ms() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
-    let task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move {
-            host.start_supervised_exec(SupervisedExecRequest {
-                control: SupervisedExecControl::Enabled { sink: true },
-                ..supervised_request("control-large-timeout")
-            })
-            .await
-        })
-    };
-
-    let start = read_guest_message(&mut guest).await;
-    let decoded_start = vsock_proto::decode_exec_start(&start.payload).unwrap();
-    let ExecControlPolicy::Enabled { control_nonce, .. } = decoded_start.control else {
-        panic!("supervised exec should enable control");
-    };
-    send_exec_started(&mut guest, start.seq, 123).await;
-    let handle = task.await.unwrap().unwrap();
+    let StartedControlSupervisedExec {
+        host: _host,
+        mut guest,
+        start,
+        handle,
+        control_handle,
+        control_nonce,
+        ..
+    } = start_control_supervised_exec_fixture("control-large-timeout").await;
+    let start_seq = start.seq();
 
     let control_task = tokio::spawn({
-        let control_handle = handle.control_handle().unwrap();
         async move {
             control_handle
                 .control(
@@ -218,7 +151,7 @@ async fn supervised_exec_control_large_timeout_saturates_request_timeout_ms() {
     });
     let control = read_guest_message(&mut guest).await;
     let decoded_control = vsock_proto::decode_exec_control(&control.payload).unwrap();
-    assert_eq!(decoded_control.target_seq, start.seq);
+    assert_eq!(decoded_control.target_seq, start_seq);
     assert_eq!(decoded_control.control_nonce, control_nonce);
     assert_eq!(decoded_control.message_id, "large-timeout");
     assert_eq!(decoded_control.request_timeout_ms, u32::MAX);
@@ -226,7 +159,7 @@ async fn supervised_exec_control_large_timeout_saturates_request_timeout_ms() {
     send_exec_control_result(
         &mut guest,
         control.seq,
-        start.seq,
+        start_seq,
         control_nonce,
         "large-timeout",
         ExecControlStatus::Delivered,
@@ -234,35 +167,24 @@ async fn supervised_exec_control_large_timeout_saturates_request_timeout_ms() {
     )
     .await;
     let ack = control_task.await.unwrap().unwrap();
-    assert_eq!(ack.target_seq, start.seq);
+    assert_eq!(ack.target_seq, start_seq);
     assert_eq!(ack.message_id, "large-timeout");
 
-    send_exec_result(
-        &mut guest,
-        start.seq,
-        ExecTermination::Exited { exit_code: 0 },
-        b"",
-        b"",
-    )
-    .await;
-    handle.wait(Duration::from_secs(5)).await.unwrap();
+    finish_supervised_exec_success(&mut guest, start_seq, handle)
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
 async fn supervised_exec_control_disabled_returns_unsupported_without_frame() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
-    let task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move {
-            host.start_supervised_exec(supervised_request("control-disabled"))
-                .await
-        })
-    };
-
-    let start = read_guest_message(&mut guest).await;
-    send_exec_started(&mut guest, start.seq, 123).await;
-    let handle = task.await.unwrap().unwrap();
+    let StartedSupervisedExec {
+        host: _host,
+        mut guest,
+        start,
+        handle,
+        ..
+    } = start_supervised_exec_fixture(supervised_request("control-disabled")).await;
+    let start_seq = start.seq();
     assert!(handle.control_handle().is_none());
 
     let err = handle
@@ -270,46 +192,25 @@ async fn supervised_exec_control_disabled_returns_unsupported_without_frame() {
         .await
         .unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::Unsupported);
-    match guest.try_read(&mut [0u8; 1]) {
-        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
-        Ok(n) => panic!("disabled control must not send a frame; read {n} bytes"),
-        Err(err) => panic!("unexpected read error after disabled control: {err}"),
-    }
+    assert_no_guest_frame(&mut guest, "disabled control must not send a frame");
 
-    send_exec_result(
-        &mut guest,
-        start.seq,
-        ExecTermination::Exited { exit_code: 0 },
-        b"",
-        b"",
-    )
-    .await;
-    handle.wait(Duration::from_secs(5)).await.unwrap();
+    finish_supervised_exec_success(&mut guest, start_seq, handle)
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
 async fn supervised_exec_control_reports_guest_status_and_error() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
-    let task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move {
-            host.start_supervised_exec(SupervisedExecRequest {
-                control: SupervisedExecControl::Enabled { sink: true },
-                ..supervised_request("control-status")
-            })
-            .await
-        })
-    };
-
-    let start = read_guest_message(&mut guest).await;
-    let decoded_start = vsock_proto::decode_exec_start(&start.payload).unwrap();
-    let ExecControlPolicy::Enabled { control_nonce, .. } = decoded_start.control else {
-        panic!("supervised exec should enable control");
-    };
-    send_exec_started(&mut guest, start.seq, 123).await;
-    let handle = task.await.unwrap().unwrap();
-    let control_handle = handle.control_handle().unwrap();
+    let StartedControlSupervisedExec {
+        host: _host,
+        mut guest,
+        start,
+        handle,
+        control_handle,
+        control_nonce,
+        ..
+    } = start_control_supervised_exec_fixture("control-status").await;
+    let start_seq = start.seq();
 
     let status_task = tokio::spawn({
         let control_handle = control_handle.clone();
@@ -323,7 +224,7 @@ async fn supervised_exec_control_reports_guest_status_and_error() {
     send_exec_control_result(
         &mut guest,
         status_control.seq,
-        start.seq,
+        start_seq,
         control_nonce,
         "status",
         ExecControlStatus::QueueFull,
@@ -350,7 +251,7 @@ async fn supervised_exec_control_reports_guest_status_and_error() {
 
     send_exec_result(
         &mut guest,
-        start.seq,
+        start_seq,
         ExecTermination::Exited { exit_code: 0 },
         b"",
         b"",
@@ -361,25 +262,17 @@ async fn supervised_exec_control_reports_guest_status_and_error() {
 
 #[tokio::test]
 async fn supervised_exec_control_guest_error_uses_control_error_fallback() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
-    let task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move {
-            host.start_supervised_exec(SupervisedExecRequest {
-                control: SupervisedExecControl::Enabled { sink: true },
-                ..supervised_request("control-error-fallback")
-            })
-            .await
-        })
-    };
-
-    let start = read_guest_message(&mut guest).await;
-    send_exec_started(&mut guest, start.seq, 123).await;
-    let handle = task.await.unwrap().unwrap();
+    let StartedControlSupervisedExec {
+        host: _host,
+        mut guest,
+        start,
+        handle,
+        control_handle,
+        ..
+    } = start_control_supervised_exec_fixture("control-error-fallback").await;
+    let start_seq = start.seq();
 
     let control_task = tokio::spawn({
-        let control_handle = handle.control_handle().unwrap();
         async move {
             control_handle
                 .control("guest-error", b"payload", Duration::from_secs(5))
@@ -395,7 +288,7 @@ async fn supervised_exec_control_guest_error_uses_control_error_fallback() {
 
     send_exec_result(
         &mut guest,
-        start.seq,
+        start_seq,
         ExecTermination::Exited { exit_code: 0 },
         b"",
         b"",
@@ -406,29 +299,18 @@ async fn supervised_exec_control_guest_error_uses_control_error_fallback() {
 
 #[tokio::test]
 async fn supervised_exec_control_timeout_ignores_late_result() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
-    let task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move {
-            host.start_supervised_exec(SupervisedExecRequest {
-                control: SupervisedExecControl::Enabled { sink: true },
-                ..supervised_request("control-timeout")
-            })
-            .await
-        })
-    };
-
-    let start = read_guest_message(&mut guest).await;
-    let decoded_start = vsock_proto::decode_exec_start(&start.payload).unwrap();
-    let ExecControlPolicy::Enabled { control_nonce, .. } = decoded_start.control else {
-        panic!("supervised exec should enable control");
-    };
-    send_exec_started(&mut guest, start.seq, 123).await;
-    let handle = task.await.unwrap().unwrap();
+    let StartedControlSupervisedExec {
+        host,
+        mut guest,
+        start,
+        handle,
+        control_handle,
+        control_nonce,
+        ..
+    } = start_control_supervised_exec_fixture("control-timeout").await;
+    let start_seq = start.seq();
 
     let control_task = tokio::spawn({
-        let control_handle = handle.control_handle().unwrap();
         async move {
             control_handle
                 .control("timeout", b"payload", Duration::ZERO)
@@ -448,7 +330,7 @@ async fn supervised_exec_control_timeout_ignores_late_result() {
     send_exec_control_result(
         &mut guest,
         control.seq,
-        start.seq,
+        start_seq,
         control_nonce,
         "timeout",
         ExecControlStatus::Delivered,
@@ -457,7 +339,7 @@ async fn supervised_exec_control_timeout_ignores_late_result() {
     .await;
     send_exec_result(
         &mut guest,
-        start.seq,
+        start_seq,
         ExecTermination::Exited { exit_code: 0 },
         b"",
         b"",
@@ -474,25 +356,15 @@ async fn supervised_exec_control_timeout_ignores_late_result() {
 
 #[tokio::test]
 async fn supervised_exec_control_malformed_result_poisons_connection() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
-    let task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move {
-            host.start_supervised_exec(SupervisedExecRequest {
-                control: SupervisedExecControl::Enabled { sink: true },
-                ..supervised_request("control-malformed-result")
-            })
-            .await
-        })
-    };
-
-    let start = read_guest_message(&mut guest).await;
-    send_exec_started(&mut guest, start.seq, 123).await;
-    let handle = task.await.unwrap().unwrap();
+    let StartedControlSupervisedExec {
+        host,
+        mut guest,
+        handle,
+        control_handle,
+        ..
+    } = start_control_supervised_exec_fixture("control-malformed-result").await;
 
     let control_task = tokio::spawn({
-        let control_handle = handle.control_handle().unwrap();
         async move {
             control_handle
                 .control("malformed-result", b"payload", Duration::from_secs(5))
@@ -519,25 +391,15 @@ async fn supervised_exec_control_malformed_result_poisons_connection() {
 
 #[tokio::test]
 async fn supervised_exec_control_malformed_error_poisons_connection() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
-    let task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move {
-            host.start_supervised_exec(SupervisedExecRequest {
-                control: SupervisedExecControl::Enabled { sink: true },
-                ..supervised_request("control-malformed-error")
-            })
-            .await
-        })
-    };
-
-    let start = read_guest_message(&mut guest).await;
-    send_exec_started(&mut guest, start.seq, 123).await;
-    let handle = task.await.unwrap().unwrap();
+    let StartedControlSupervisedExec {
+        host,
+        mut guest,
+        handle,
+        control_handle,
+        ..
+    } = start_control_supervised_exec_fixture("control-malformed-error").await;
 
     let control_task = tokio::spawn({
-        let control_handle = handle.control_handle().unwrap();
         async move {
             control_handle
                 .control("malformed-error", b"payload", Duration::from_secs(5))
@@ -564,32 +426,18 @@ async fn supervised_exec_control_malformed_error_poisons_connection() {
 
 #[tokio::test]
 async fn supervised_exec_control_nonce_mismatch_poisons_connection() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
-    let task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move {
-            host.start_supervised_exec(SupervisedExecRequest {
-                control: SupervisedExecControl::Enabled { sink: true },
-                ..supervised_request("control-mismatch")
-            })
-            .await
-        })
-    };
-
-    let start = read_guest_message(&mut guest).await;
-    let decoded_start = vsock_proto::decode_exec_start(&start.payload).unwrap();
-    let ExecControlPolicy::Enabled {
-        mut control_nonce, ..
-    } = decoded_start.control
-    else {
-        panic!("supervised exec should enable control");
-    };
-    send_exec_started(&mut guest, start.seq, 123).await;
-    let handle = task.await.unwrap().unwrap();
+    let StartedControlSupervisedExec {
+        host,
+        mut guest,
+        start,
+        handle,
+        control_handle,
+        control_nonce,
+        ..
+    } = start_control_supervised_exec_fixture("control-mismatch").await;
+    let start_seq = start.seq();
 
     let control_task = tokio::spawn({
-        let control_handle = handle.control_handle().unwrap();
         async move {
             control_handle
                 .control("nonce-mismatch", b"payload", Duration::from_secs(5))
@@ -597,11 +445,12 @@ async fn supervised_exec_control_nonce_mismatch_poisons_connection() {
         }
     });
     let control = read_guest_message(&mut guest).await;
+    let mut control_nonce = control_nonce;
     control_nonce[0] ^= 1;
     send_exec_control_result(
         &mut guest,
         control.seq,
-        start.seq,
+        start_seq,
         control_nonce,
         "nonce-mismatch",
         ExecControlStatus::Delivered,
@@ -620,29 +469,18 @@ async fn supervised_exec_control_nonce_mismatch_poisons_connection() {
 
 #[tokio::test]
 async fn supervised_exec_control_target_seq_mismatch_poisons_connection() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
-    let task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move {
-            host.start_supervised_exec(SupervisedExecRequest {
-                control: SupervisedExecControl::Enabled { sink: true },
-                ..supervised_request("control-target-mismatch")
-            })
-            .await
-        })
-    };
-
-    let start = read_guest_message(&mut guest).await;
-    let decoded_start = vsock_proto::decode_exec_start(&start.payload).unwrap();
-    let ExecControlPolicy::Enabled { control_nonce, .. } = decoded_start.control else {
-        panic!("supervised exec should enable control");
-    };
-    send_exec_started(&mut guest, start.seq, 123).await;
-    let handle = task.await.unwrap().unwrap();
+    let StartedControlSupervisedExec {
+        host,
+        mut guest,
+        start,
+        handle,
+        control_handle,
+        control_nonce,
+        ..
+    } = start_control_supervised_exec_fixture("control-target-mismatch").await;
+    let start_seq = start.seq();
 
     let control_task = tokio::spawn({
-        let control_handle = handle.control_handle().unwrap();
         async move {
             control_handle
                 .control("target-mismatch", b"payload", Duration::from_secs(5))
@@ -653,7 +491,7 @@ async fn supervised_exec_control_target_seq_mismatch_poisons_connection() {
     send_exec_control_result(
         &mut guest,
         control.seq,
-        start.seq + 1,
+        start_seq + 1,
         control_nonce,
         "target-mismatch",
         ExecControlStatus::Delivered,
@@ -672,29 +510,18 @@ async fn supervised_exec_control_target_seq_mismatch_poisons_connection() {
 
 #[tokio::test]
 async fn supervised_exec_control_message_id_mismatch_poisons_connection() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
-    let task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move {
-            host.start_supervised_exec(SupervisedExecRequest {
-                control: SupervisedExecControl::Enabled { sink: true },
-                ..supervised_request("control-message-mismatch")
-            })
-            .await
-        })
-    };
-
-    let start = read_guest_message(&mut guest).await;
-    let decoded_start = vsock_proto::decode_exec_start(&start.payload).unwrap();
-    let ExecControlPolicy::Enabled { control_nonce, .. } = decoded_start.control else {
-        panic!("supervised exec should enable control");
-    };
-    send_exec_started(&mut guest, start.seq, 123).await;
-    let handle = task.await.unwrap().unwrap();
+    let StartedControlSupervisedExec {
+        host,
+        mut guest,
+        start,
+        handle,
+        control_handle,
+        control_nonce,
+        ..
+    } = start_control_supervised_exec_fixture("control-message-mismatch").await;
+    let start_seq = start.seq();
 
     let control_task = tokio::spawn({
-        let control_handle = handle.control_handle().unwrap();
         async move {
             control_handle
                 .control("message-mismatch", b"payload", Duration::from_secs(5))
@@ -705,7 +532,7 @@ async fn supervised_exec_control_message_id_mismatch_poisons_connection() {
     send_exec_control_result(
         &mut guest,
         control.seq,
-        start.seq,
+        start_seq,
         control_nonce,
         "different-message-id",
         ExecControlStatus::Delivered,
@@ -724,26 +551,18 @@ async fn supervised_exec_control_message_id_mismatch_poisons_connection() {
 
 #[tokio::test]
 async fn supervised_exec_control_inactive_target_returns_not_found_without_frame() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
-    let task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move {
-            host.start_supervised_exec(SupervisedExecRequest {
-                control: SupervisedExecControl::Enabled { sink: true },
-                ..supervised_request("control-inactive")
-            })
-            .await
-        })
-    };
-
-    let start = read_guest_message(&mut guest).await;
-    send_exec_started(&mut guest, start.seq, 123).await;
-    let handle = task.await.unwrap().unwrap();
-    let control_handle = handle.control_handle().unwrap();
+    let StartedControlSupervisedExec {
+        host: _host,
+        mut guest,
+        start,
+        handle,
+        control_handle,
+        ..
+    } = start_control_supervised_exec_fixture("control-inactive").await;
+    let start_seq = start.seq();
     send_exec_result(
         &mut guest,
-        start.seq,
+        start_seq,
         ExecTermination::Exited { exit_code: 0 },
         b"",
         b"",
@@ -756,9 +575,5 @@ async fn supervised_exec_control_inactive_target_returns_not_found_without_frame
         .await
         .unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::NotFound);
-    match guest.try_read(&mut [0u8; 1]) {
-        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
-        Ok(n) => panic!("inactive control must not send a frame; read {n} bytes"),
-        Err(err) => panic!("unexpected read error after inactive control: {err}"),
-    }
+    assert_no_guest_frame(&mut guest, "inactive control must not send a frame");
 }

--- a/crates/vsock-host/src/tests/exec_operation/supervised/support.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised/support.rs
@@ -3,16 +3,22 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use tokio::io::AsyncWriteExt;
+use tokio::net::UnixStream;
+use tokio::task::JoinHandle;
 use vsock_proto::{
-    ExecCapturedOutput, ExecOutputPolicy, ExecTermination, ExecTimeoutPolicy, MSG_ERROR,
+    ExecCapturedOutput, ExecControlNonce, ExecControlPolicy, ExecOutputPolicy, ExecTermination,
+    ExecTimeoutPolicy, MSG_ERROR, MSG_EXEC_START, RawMessage,
 };
 
 use super::super::super::support::{
     assert_connection_accepts_exec_operation, normal_operation_readiness, operation_count,
-    setup_host_and_guest,
+    read_guest_message, send_exec_result, send_exec_started, setup_host_and_guest,
 };
 use crate::operation_tracker::NormalOperationReadiness;
-use crate::{SupervisedExecControl, SupervisedExecRequest};
+use crate::{
+    ExecControlHandle, SupervisedExecControl, SupervisedExecHandle, SupervisedExecRequest,
+};
+use crate::{ExecOperationResult, VsockHost};
 
 pub(super) fn supervised_request(command: &str) -> SupervisedExecRequest<'_> {
     SupervisedExecRequest {
@@ -41,6 +47,143 @@ pub(super) fn supervised_stream_request(command: &str) -> SupervisedExecRequest<
         stdin_bytes: None,
         stream_queue_capacity: Some(1),
         ..supervised_request(command)
+    }
+}
+
+pub(super) struct SupervisedExecStartFrame {
+    pub(super) msg: RawMessage,
+    pub(super) control: ExecControlPolicy,
+}
+
+impl SupervisedExecStartFrame {
+    pub(super) fn seq(&self) -> u32 {
+        self.msg.seq
+    }
+
+    pub(super) fn control_enabled(&self) -> (ExecControlNonce, bool) {
+        let ExecControlPolicy::Enabled {
+            control_nonce,
+            sink,
+        } = self.control
+        else {
+            panic!("supervised exec should enable control");
+        };
+        (control_nonce, sink)
+    }
+}
+
+pub(super) struct PendingSupervisedExec {
+    pub(super) host: Arc<VsockHost>,
+    pub(super) guest: UnixStream,
+    pub(super) start: SupervisedExecStartFrame,
+    task: JoinHandle<io::Result<SupervisedExecHandle>>,
+}
+
+impl PendingSupervisedExec {
+    pub(super) async fn started(self) -> StartedSupervisedExec {
+        self.started_with_pid(123).await
+    }
+
+    pub(super) async fn started_with_pid(mut self, pid: u32) -> StartedSupervisedExec {
+        send_exec_started(&mut self.guest, self.start.seq(), pid).await;
+        let handle = self.task.await.unwrap().unwrap();
+        StartedSupervisedExec {
+            host: self.host,
+            guest: self.guest,
+            start: self.start,
+            handle,
+        }
+    }
+}
+
+pub(super) struct StartedSupervisedExec {
+    pub(super) host: Arc<VsockHost>,
+    pub(super) guest: UnixStream,
+    pub(super) start: SupervisedExecStartFrame,
+    pub(super) handle: SupervisedExecHandle,
+}
+
+pub(super) struct StartedControlSupervisedExec {
+    pub(super) host: Arc<VsockHost>,
+    pub(super) guest: UnixStream,
+    pub(super) start: SupervisedExecStartFrame,
+    pub(super) handle: SupervisedExecHandle,
+    pub(super) control_handle: ExecControlHandle,
+    pub(super) control_nonce: ExecControlNonce,
+}
+
+pub(super) async fn start_pending_supervised_exec(
+    request: SupervisedExecRequest<'static>,
+) -> PendingSupervisedExec {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move { host.start_supervised_exec(request).await })
+    };
+
+    let msg = read_guest_message(&mut guest).await;
+    assert_eq!(msg.msg_type, MSG_EXEC_START);
+    let control = vsock_proto::decode_exec_start(&msg.payload)
+        .unwrap()
+        .control;
+
+    PendingSupervisedExec {
+        host,
+        guest,
+        start: SupervisedExecStartFrame { msg, control },
+        task,
+    }
+}
+
+pub(super) async fn start_supervised_exec_fixture(
+    request: SupervisedExecRequest<'static>,
+) -> StartedSupervisedExec {
+    start_pending_supervised_exec(request).await.started().await
+}
+
+pub(super) async fn start_control_supervised_exec_fixture(
+    command: &'static str,
+) -> StartedControlSupervisedExec {
+    let started = start_supervised_exec_fixture(SupervisedExecRequest {
+        control: SupervisedExecControl::Enabled { sink: true },
+        ..supervised_request(command)
+    })
+    .await;
+    let (control_nonce, sink) = started.start.control_enabled();
+    assert!(sink);
+    let control_handle = started.handle.control_handle().unwrap();
+    StartedControlSupervisedExec {
+        host: started.host,
+        guest: started.guest,
+        start: started.start,
+        handle: started.handle,
+        control_handle,
+        control_nonce,
+    }
+}
+
+pub(super) async fn finish_supervised_exec_success(
+    guest: &mut UnixStream,
+    seq: u32,
+    handle: SupervisedExecHandle,
+) -> io::Result<ExecOperationResult> {
+    send_exec_result(
+        guest,
+        seq,
+        ExecTermination::Exited { exit_code: 0 },
+        b"",
+        b"",
+    )
+    .await;
+    handle.wait(Duration::from_secs(5)).await
+}
+
+pub(super) fn assert_no_guest_frame(guest: &mut UnixStream, context: &str) {
+    match guest.try_read(&mut [0u8; 1]) {
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+        Ok(n) => panic!("{context}; read {n} bytes"),
+        Err(err) => panic!("unexpected read error after {context}: {err}"),
     }
 }
 


### PR DESCRIPTION
## Summary

- Add two-stage supervised exec test fixtures for pending and started states.
- Add a thin control-enabled supervised exec fixture plus small success/no-frame helpers.
- Migrate `supervised/control.rs` to use the fixture while keeping protocol assertions inline.

Closes #19156

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p vsock-host supervised::control`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host supervised`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-host --all-targets -- -D warnings`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `git diff --check`

Pre-commit also ran crates `cargo-fmt`, `cargo-doc`, and `cargo-clippy`.
