### PR TITLE
perf: split runner claim timing spans

### DIFF
--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -6,6 +6,7 @@
 use std::collections::BTreeMap;
 use std::collections::hash_map::Entry;
 use std::sync::Arc;
+use std::time::Instant;
 
 use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 use sandbox::SandboxId;
@@ -22,7 +23,8 @@ use super::idle_lifecycle::{
 use super::job_spawn::{JobProfile, SpawnContext, SpawnJobRequest, spawn_job};
 use crate::config::ProfileConfig;
 use crate::executor::{
-    RunnerPreSpawnTiming, SessionHistoryMaterializer, validate_resume_session_id,
+    RunnerPreSpawnPhase, RunnerPreSpawnTiming, SessionHistoryMaterializer,
+    validate_resume_session_id,
 };
 use crate::http::HttpClient;
 use crate::idle_pool::{IdlePoolSnapshot, IdleUnparkResult, ReusableIdleSandbox};
@@ -120,8 +122,10 @@ pub(super) async fn handle_discovered_job(job: DiscoveredJob, mut ctx: Discovere
         budget_lease: job_lease,
         cancel: job_cancel,
     } = admission;
-    let pre_spawn_timing = RunnerPreSpawnTiming::start_after_claim();
+    let mut pre_spawn_timing = RunnerPreSpawnTiming::start_after_claim();
+    let started_at = Instant::now();
     let resume_session_valid = validate_resume_session_id(claimed.context()).is_ok();
+    pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::ResumeSessionValidation, started_at);
     let active_cli_agent_session_guard = ActiveCliAgentSessionGuard::new(
         ctx.spawn_ctx.active_cli_agent_sessions.clone(),
         if resume_session_valid {
@@ -130,17 +134,26 @@ pub(super) async fn handle_discovered_job(job: DiscoveredJob, mut ctx: Discovere
             None
         },
     );
+    let started_at = Instant::now();
     let session_history_materializer = start_session_history_materializer_after_claim(
         &ctx.spawn_ctx.exec_config.http,
         claimed.context(),
         resume_session_valid,
         &job_cancel,
     );
+    if session_history_materializer.is_some() {
+        pre_spawn_timing.record_phase_elapsed(
+            RunnerPreSpawnPhase::SessionHistoryMaterializerStart,
+            started_at,
+        );
+    }
     info!(run_id = %run_id, profile = %profile_name, "job claimed, spawning executor");
+    let started_at = Instant::now();
     let device_rate_limits = crate::io_limits::device_rate_limits_for_context(
         ctx.spawn_ctx.device_rate_limits.as_ref(),
         claimed.context(),
     );
+    pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::DeviceRateLimits, started_at);
 
     let (reuse_entry, active_lease, reuse_result, idle_snapshot) = try_reuse_from_pool(
         run_id,
@@ -153,6 +166,7 @@ pub(super) async fn handle_discovered_job(job: DiscoveredJob, mut ctx: Discovere
             job_lease,
         },
         &mut ctx,
+        &mut pre_spawn_timing,
     )
     .await;
 
@@ -163,6 +177,7 @@ pub(super) async fn handle_discovered_job(job: DiscoveredJob, mut ctx: Discovere
         Some(entry) => entry.sandbox_id(),
         None => SandboxId::new_v4(),
     };
+    let started_at = Instant::now();
     publish_active_run_status(
         ctx.status,
         run_id,
@@ -171,6 +186,7 @@ pub(super) async fn handle_discovered_job(job: DiscoveredJob, mut ctx: Discovere
         idle_snapshot,
     )
     .await;
+    pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::ActiveStatusPublish, started_at);
 
     let job_profile = JobProfile {
         profile_name,
@@ -313,6 +329,7 @@ async fn try_reuse_from_pool(
     run_id: RunId,
     request: ReuseAdmissionRequest<'_>,
     ctx: &mut DiscoveredJobContext<'_>,
+    pre_spawn_timing: &mut RunnerPreSpawnTiming,
 ) -> (
     Option<ReusableIdleSandbox>,
     BudgetLease,
@@ -328,10 +345,13 @@ async fn try_reuse_from_pool(
         job_lease,
     } = request;
 
+    let started_at = Instant::now();
     if !resume_session_valid {
+        pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::IdleReuseLookup, started_at);
         return (None, job_lease, SandboxReuseResult::NoSessionId, None);
     }
     let Some(cli_agent_session_id) = context.cli_agent_session_id() else {
+        pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::IdleReuseLookup, started_at);
         return (None, job_lease, SandboxReuseResult::NoSessionId, None);
     };
     let session_fingerprint = diagnostic_session_fingerprint(cli_agent_session_id);
@@ -345,6 +365,8 @@ async fn try_reuse_from_pool(
         let held_session_states = pool.held_session_states();
         (taken, snapshot, held_session_states)
     };
+    pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::IdleReuseLookup, started_at);
+    let started_at = Instant::now();
     let held_session_states = current_held_session_states(
         held_session_states,
         ctx.spawn_ctx.exec_config.workspace_cache.as_ref(),
@@ -352,37 +374,50 @@ async fn try_reuse_from_pool(
         Some(cli_agent_session_id),
     )
     .await;
+    pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::HeldSessionStateRefresh, started_at);
+    let started_at = Instant::now();
     ctx.spawn_ctx
         .provider
         .set_held_session_states(held_session_states)
         .await;
+    pre_spawn_timing
+        .record_phase_elapsed(RunnerPreSpawnPhase::ProviderHeldSessionUpdate, started_at);
     match taken {
         Some(entry)
             if entry.profile_name() == profile_name
                 && entry.device_rate_limits() == device_rate_limits =>
         {
-            if let Some(cache) = ctx.spawn_ctx.exec_config.workspace_cache.as_ref()
-                && let Err(mismatch) = entry.validate_workspace_promotion_identity(
+            if let Some(cache) = ctx.spawn_ctx.exec_config.workspace_cache.as_ref() {
+                let started_at = Instant::now();
+                let validation = entry.validate_workspace_promotion_identity(
                     cache,
                     CANONICAL_WORKING_DIR,
                     u64::from(workspace_disk_mb) * 1024 * 1024,
-                )
-            {
-                warn!(
-                    run_id = %run_id,
-                    session_fingerprint = %session_fingerprint,
-                    profile = %profile_name,
-                    mismatch = mismatch.as_str(),
-                    "workspace promotion identity mismatch, destroying idle VM and falling through to fresh create"
                 );
-                spawn_idle_destroy_job(
-                    ctx.destroy_tasks,
-                    entry.into_destroy_job_without_workspace_promotion_for_mismatch(),
-                    "reuse_workspace_promotion_mismatch",
+                pre_spawn_timing.record_phase_elapsed(
+                    RunnerPreSpawnPhase::WorkspacePromotionValidation,
+                    started_at,
                 );
-                return (None, job_lease, SandboxReuseResult::PoolMiss, snapshot);
+                if let Err(mismatch) = validation {
+                    warn!(
+                        run_id = %run_id,
+                        session_fingerprint = %session_fingerprint,
+                        profile = %profile_name,
+                        mismatch = mismatch.as_str(),
+                        "workspace promotion identity mismatch, destroying idle VM and falling through to fresh create"
+                    );
+                    spawn_idle_destroy_job(
+                        ctx.destroy_tasks,
+                        entry.into_destroy_job_without_workspace_promotion_for_mismatch(),
+                        "reuse_workspace_promotion_mismatch",
+                    );
+                    return (None, job_lease, SandboxReuseResult::PoolMiss, snapshot);
+                }
             }
-            match entry.try_unpark().await {
+            let started_at = Instant::now();
+            let unpark_result = entry.try_unpark().await;
+            pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::IdleUnpark, started_at);
+            match unpark_result {
                 IdleUnparkResult::Reused {
                     sandbox,
                     budget_lease,

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -6,6 +6,7 @@
 
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
+use std::time::Instant;
 
 use agent_diagnostics::{CliTerminationDiagnostic, FailureClass, FailureDiagnostic, FailureReason};
 use futures_util::FutureExt;
@@ -27,7 +28,8 @@ use super::sandbox_finalization::{FinalizeContext, finalize_sandbox_for_completi
 #[cfg(test)]
 use super::{OuterJobPanicPoint, StartLoopTestObserver, maybe_panic_outer_job};
 use crate::executor::{
-    self, ExecutionFailureKind, ExecutorConfig, RunnerPreSpawnTiming, SessionHistoryMaterializer,
+    self, ExecutionFailureKind, ExecutorConfig, RunnerPreSpawnPhase, RunnerPreSpawnTiming,
+    SessionHistoryMaterializer,
 };
 use crate::idle_pool::{ParkingGate, ReusableIdleSandbox};
 use crate::ids::RunId;
@@ -443,6 +445,7 @@ pub(super) fn spawn_job(
     ctx: &SpawnContext,
     jobs: &mut JoinSet<Option<RunId>>,
 ) {
+    let started_at = Instant::now();
     let SpawnJobRequest {
         claimed,
         sandbox_id,
@@ -530,7 +533,7 @@ pub(super) fn spawn_job(
             },
         ))
     };
-    let executor = ExecutorInvocation {
+    let mut executor = ExecutorInvocation {
         run_id,
         sandbox_id,
         context,
@@ -576,6 +579,10 @@ pub(super) fn spawn_job(
         exec_config: Arc::clone(&exec_config),
     };
 
+    executor
+        .pre_spawn_timing
+        .record_phase_elapsed(RunnerPreSpawnPhase::SpawnJobSetup, started_at);
+    executor.pre_spawn_timing.mark_task_enqueued();
     jobs.spawn(async move {
         let mut active_cli_agent_session_guard = active_cli_agent_session_guard;
         let body = async move {

--- a/crates/runner/src/cmd/start/tests/main_loop/mod.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/mod.rs
@@ -4,4 +4,5 @@ mod heartbeat;
 mod job_flow;
 mod shutdown;
 mod startup;
+mod telemetry;
 mod usage_flush;

--- a/crates/runner/src/cmd/start/tests/main_loop/telemetry.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/telemetry.rs
@@ -1,6 +1,7 @@
 use super::super::super::*;
 use super::super::support::{
-    context_with_session, mock_run_config_with_api_url, push_job, shutdown, test_profiles,
+    context_with_session, mock_run_config_with_api_url, push_job, seed_idle_pool, shutdown,
+    test_profiles,
 };
 
 #[tokio::test]
@@ -44,6 +45,65 @@ async fn telemetry_flush_includes_start_loop_claim_phase_spans() {
         .wait_completion(run_id, Duration::from_secs(5))
         .await;
     assert!(completion.is_some(), "job should complete");
+
+    shutdown(&env, run_handle).await;
+
+    telemetry_mock.assert_calls_async(1).await;
+}
+
+#[tokio::test]
+async fn telemetry_flush_includes_reuse_hit_claim_phase_spans() {
+    use httpmock::prelude::*;
+
+    let server = MockServer::start_async().await;
+    let telemetry_mock = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/telemetry")
+                .body_includes("sandbox_reuse_hit")
+                .body_includes("runner_claim_idle_reuse_lookup")
+                .body_includes("runner_claim_held_session_state_refresh")
+                .body_includes("runner_claim_provider_held_session_update")
+                .body_includes("runner_claim_idle_unpark")
+                .body_includes("runner_claim_task_schedule_wait");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"success":true,"id":"ok"}"#);
+        })
+        .await;
+
+    let (config, env) =
+        mock_run_config_with_api_url(test_profiles(), 8, 32768, 4, &server.base_url());
+    let idle_pool = config.shared.idle_pool.clone();
+    let budget = config.capacity.budget.clone();
+    seed_idle_pool(
+        &idle_pool,
+        &budget,
+        "sess-reuse-claim-timing",
+        "vm0/default",
+        2,
+        4096,
+    )
+    .await;
+    let run_handle = tokio::spawn(run(config));
+
+    let run_id = RunId::new_v4();
+    push_job(
+        &env,
+        run_id,
+        "vm0/default",
+        Some(context_with_session(run_id, "sess-reuse-claim-timing")),
+    );
+
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("job should complete");
+    assert_eq!(
+        completion.reuse_result,
+        Some(crate::types::SandboxReuseResult::Reused)
+    );
 
     shutdown(&env, run_handle).await;
 

--- a/crates/runner/src/cmd/start/tests/main_loop/telemetry.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/telemetry.rs
@@ -1,0 +1,51 @@
+use super::super::super::*;
+use super::super::support::{
+    context_with_session, mock_run_config_with_api_url, push_job, shutdown, test_profiles,
+};
+
+#[tokio::test]
+async fn telemetry_flush_includes_start_loop_claim_phase_spans() {
+    use httpmock::prelude::*;
+
+    let server = MockServer::start_async().await;
+    let telemetry_mock = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/telemetry")
+                .body_includes("runner_claim_to_executor_start")
+                .body_includes("runner_claim_resume_session_validation")
+                .body_includes("runner_claim_device_rate_limits")
+                .body_includes("runner_claim_idle_reuse_lookup")
+                .body_includes("runner_claim_held_session_state_refresh")
+                .body_includes("runner_claim_provider_held_session_update")
+                .body_includes("runner_claim_active_status_publish")
+                .body_includes("runner_claim_spawn_job_setup")
+                .body_includes("runner_claim_task_schedule_wait");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"success":true,"id":"ok"}"#);
+        })
+        .await;
+
+    let (config, env) =
+        mock_run_config_with_api_url(test_profiles(), 8, 32768, 4, &server.base_url());
+    let run_handle = tokio::spawn(run(config));
+
+    let run_id = RunId::new_v4();
+    push_job(
+        &env,
+        run_id,
+        "vm0/default",
+        Some(context_with_session(run_id, "sess-claim-timing")),
+    );
+
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await;
+    assert!(completion.is_some(), "job should complete");
+
+    shutdown(&env, run_handle).await;
+
+    telemetry_mock.assert_calls_async(1).await;
+}

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -46,7 +46,7 @@ pub(crate) use env::validate_resume_session_id;
 use sandbox_run::{
     NewSandboxHooks, execute_new_sandbox_with_prepared_notifier, execute_reused_sandbox,
 };
-pub(crate) use telemetry::RunnerPreSpawnTiming;
+pub(crate) use telemetry::{RunnerPreSpawnPhase, RunnerPreSpawnTiming};
 use telemetry::{RunnerSpawnTiming, record_api_latency, record_reuse_result};
 
 use crate::ids::RunId;

--- a/crates/runner/src/executor/telemetry.rs
+++ b/crates/runner/src/executor/telemetry.rs
@@ -58,7 +58,7 @@ impl RunnerPreSpawnPhase {
     }
 }
 
-#[derive(Clone, Copy, Default)]
+#[derive(Default)]
 struct RunnerPreSpawnPhaseDurations {
     resume_session_validation: Option<Duration>,
     session_history_materializer_start: Option<Duration>,
@@ -94,7 +94,7 @@ impl RunnerPreSpawnPhaseDurations {
         }
     }
 
-    fn get(self, phase: RunnerPreSpawnPhase) -> Option<Duration> {
+    fn get(&self, phase: RunnerPreSpawnPhase) -> Option<Duration> {
         match phase {
             RunnerPreSpawnPhase::ResumeSessionValidation => self.resume_session_validation,
             RunnerPreSpawnPhase::SessionHistoryMaterializerStart => {
@@ -114,14 +114,12 @@ impl RunnerPreSpawnPhaseDurations {
     }
 }
 
-#[derive(Clone, Copy)]
 pub(crate) struct RunnerPreSpawnTiming {
     claim_returned_at: Instant,
     phase_durations: RunnerPreSpawnPhaseDurations,
     task_enqueued_at: Option<Instant>,
 }
 
-#[derive(Clone, Copy)]
 pub(super) struct RunnerSpawnTiming {
     executor_started_at: Instant,
     pre_spawn_timing: Option<RunnerPreSpawnTiming>,
@@ -148,11 +146,11 @@ impl RunnerPreSpawnTiming {
         self.task_enqueued_at = Some(Instant::now());
     }
 
-    fn elapsed_at(self, at: Instant) -> Duration {
+    fn elapsed_at(&self, at: Instant) -> Duration {
         at.saturating_duration_since(self.claim_returned_at)
     }
 
-    fn record_collected_phases(self, telemetry: &mut JobTelemetry, executor_started_at: Instant) {
+    fn record_collected_phases(&self, telemetry: &mut JobTelemetry, executor_started_at: Instant) {
         for phase in RunnerPreSpawnPhase::ALL {
             if let Some(duration) = self.phase_durations.get(phase) {
                 telemetry.record(phase.action_type(), duration, true, None);
@@ -177,8 +175,8 @@ impl RunnerSpawnTiming {
         }
     }
 
-    pub(super) fn record_claim_to_executor_start(self, telemetry: &mut JobTelemetry) {
-        if let Some(pre_spawn_timing) = self.pre_spawn_timing {
+    pub(super) fn record_claim_to_executor_start(&self, telemetry: &mut JobTelemetry) {
+        if let Some(pre_spawn_timing) = self.pre_spawn_timing.as_ref() {
             telemetry.record(
                 "runner_claim_to_executor_start",
                 pre_spawn_timing.elapsed_at(self.executor_started_at),
@@ -189,14 +187,18 @@ impl RunnerSpawnTiming {
         }
     }
 
-    pub(super) fn record_spawn_success_at(self, telemetry: &mut JobTelemetry, spawned_at: Instant) {
+    pub(super) fn record_spawn_success_at(
+        &self,
+        telemetry: &mut JobTelemetry,
+        spawned_at: Instant,
+    ) {
         telemetry.record(
             "runner_executor_start_to_spawn",
             spawned_at.saturating_duration_since(self.executor_started_at),
             true,
             None,
         );
-        if let Some(pre_spawn_timing) = self.pre_spawn_timing {
+        if let Some(pre_spawn_timing) = self.pre_spawn_timing.as_ref() {
             telemetry.record(
                 "runner_claim_to_spawn",
                 pre_spawn_timing.elapsed_at(spawned_at),

--- a/crates/runner/src/executor/telemetry.rs
+++ b/crates/runner/src/executor/telemetry.rs
@@ -11,7 +11,6 @@ use crate::types::{ExecutionContext, SandboxReuseResult};
 use crate::workspace_image_cache::WorkspaceCacheCheckoutResult;
 
 static INVALID_API_START_TIME_WARNED: AtomicBool = AtomicBool::new(false);
-const RUNNER_PRE_SPAWN_PHASE_COUNT: usize = 10;
 
 #[derive(Clone, Copy)]
 pub(crate) enum RunnerPreSpawnPhase {
@@ -28,7 +27,7 @@ pub(crate) enum RunnerPreSpawnPhase {
 }
 
 impl RunnerPreSpawnPhase {
-    const ALL: [Self; RUNNER_PRE_SPAWN_PHASE_COUNT] = [
+    const ALL: [Self; 10] = [
         Self::ResumeSessionValidation,
         Self::SessionHistoryMaterializerStart,
         Self::DeviceRateLimits,
@@ -40,21 +39,6 @@ impl RunnerPreSpawnPhase {
         Self::ActiveStatusPublish,
         Self::SpawnJobSetup,
     ];
-
-    const fn index(self) -> usize {
-        match self {
-            Self::ResumeSessionValidation => 0,
-            Self::SessionHistoryMaterializerStart => 1,
-            Self::DeviceRateLimits => 2,
-            Self::IdleReuseLookup => 3,
-            Self::HeldSessionStateRefresh => 4,
-            Self::ProviderHeldSessionUpdate => 5,
-            Self::WorkspacePromotionValidation => 6,
-            Self::IdleUnpark => 7,
-            Self::ActiveStatusPublish => 8,
-            Self::SpawnJobSetup => 9,
-        }
-    }
 
     const fn action_type(self) -> &'static str {
         match self {
@@ -74,10 +58,66 @@ impl RunnerPreSpawnPhase {
     }
 }
 
+#[derive(Clone, Copy, Default)]
+struct RunnerPreSpawnPhaseDurations {
+    resume_session_validation: Option<Duration>,
+    session_history_materializer_start: Option<Duration>,
+    device_rate_limits: Option<Duration>,
+    idle_reuse_lookup: Option<Duration>,
+    held_session_state_refresh: Option<Duration>,
+    provider_held_session_update: Option<Duration>,
+    workspace_promotion_validation: Option<Duration>,
+    idle_unpark: Option<Duration>,
+    active_status_publish: Option<Duration>,
+    spawn_job_setup: Option<Duration>,
+}
+
+impl RunnerPreSpawnPhaseDurations {
+    fn get_mut(&mut self, phase: RunnerPreSpawnPhase) -> &mut Option<Duration> {
+        match phase {
+            RunnerPreSpawnPhase::ResumeSessionValidation => &mut self.resume_session_validation,
+            RunnerPreSpawnPhase::SessionHistoryMaterializerStart => {
+                &mut self.session_history_materializer_start
+            }
+            RunnerPreSpawnPhase::DeviceRateLimits => &mut self.device_rate_limits,
+            RunnerPreSpawnPhase::IdleReuseLookup => &mut self.idle_reuse_lookup,
+            RunnerPreSpawnPhase::HeldSessionStateRefresh => &mut self.held_session_state_refresh,
+            RunnerPreSpawnPhase::ProviderHeldSessionUpdate => {
+                &mut self.provider_held_session_update
+            }
+            RunnerPreSpawnPhase::WorkspacePromotionValidation => {
+                &mut self.workspace_promotion_validation
+            }
+            RunnerPreSpawnPhase::IdleUnpark => &mut self.idle_unpark,
+            RunnerPreSpawnPhase::ActiveStatusPublish => &mut self.active_status_publish,
+            RunnerPreSpawnPhase::SpawnJobSetup => &mut self.spawn_job_setup,
+        }
+    }
+
+    fn get(self, phase: RunnerPreSpawnPhase) -> Option<Duration> {
+        match phase {
+            RunnerPreSpawnPhase::ResumeSessionValidation => self.resume_session_validation,
+            RunnerPreSpawnPhase::SessionHistoryMaterializerStart => {
+                self.session_history_materializer_start
+            }
+            RunnerPreSpawnPhase::DeviceRateLimits => self.device_rate_limits,
+            RunnerPreSpawnPhase::IdleReuseLookup => self.idle_reuse_lookup,
+            RunnerPreSpawnPhase::HeldSessionStateRefresh => self.held_session_state_refresh,
+            RunnerPreSpawnPhase::ProviderHeldSessionUpdate => self.provider_held_session_update,
+            RunnerPreSpawnPhase::WorkspacePromotionValidation => {
+                self.workspace_promotion_validation
+            }
+            RunnerPreSpawnPhase::IdleUnpark => self.idle_unpark,
+            RunnerPreSpawnPhase::ActiveStatusPublish => self.active_status_publish,
+            RunnerPreSpawnPhase::SpawnJobSetup => self.spawn_job_setup,
+        }
+    }
+}
+
 #[derive(Clone, Copy)]
 pub(crate) struct RunnerPreSpawnTiming {
     claim_returned_at: Instant,
-    phase_durations: [Option<Duration>; RUNNER_PRE_SPAWN_PHASE_COUNT],
+    phase_durations: RunnerPreSpawnPhaseDurations,
     task_enqueued_at: Option<Instant>,
 }
 
@@ -91,15 +131,13 @@ impl RunnerPreSpawnTiming {
     pub(crate) fn start_after_claim() -> Self {
         Self {
             claim_returned_at: Instant::now(),
-            phase_durations: [None; RUNNER_PRE_SPAWN_PHASE_COUNT],
+            phase_durations: RunnerPreSpawnPhaseDurations::default(),
             task_enqueued_at: None,
         }
     }
 
     pub(crate) fn record_phase(&mut self, phase: RunnerPreSpawnPhase, duration: Duration) {
-        if let Some(slot) = self.phase_durations.get_mut(phase.index()) {
-            *slot = Some(duration);
-        }
+        *self.phase_durations.get_mut(phase) = Some(duration);
     }
 
     pub(crate) fn record_phase_elapsed(&mut self, phase: RunnerPreSpawnPhase, started_at: Instant) {
@@ -116,7 +154,7 @@ impl RunnerPreSpawnTiming {
 
     fn record_collected_phases(self, telemetry: &mut JobTelemetry, executor_started_at: Instant) {
         for phase in RunnerPreSpawnPhase::ALL {
-            if let Some(Some(duration)) = self.phase_durations.get(phase.index()).copied() {
+            if let Some(duration) = self.phase_durations.get(phase) {
                 telemetry.record(phase.action_type(), duration, true, None);
             }
         }

--- a/crates/runner/src/executor/telemetry.rs
+++ b/crates/runner/src/executor/telemetry.rs
@@ -11,10 +11,74 @@ use crate::types::{ExecutionContext, SandboxReuseResult};
 use crate::workspace_image_cache::WorkspaceCacheCheckoutResult;
 
 static INVALID_API_START_TIME_WARNED: AtomicBool = AtomicBool::new(false);
+const RUNNER_PRE_SPAWN_PHASE_COUNT: usize = 10;
+
+#[derive(Clone, Copy)]
+pub(crate) enum RunnerPreSpawnPhase {
+    ResumeSessionValidation,
+    SessionHistoryMaterializerStart,
+    DeviceRateLimits,
+    IdleReuseLookup,
+    HeldSessionStateRefresh,
+    ProviderHeldSessionUpdate,
+    WorkspacePromotionValidation,
+    IdleUnpark,
+    ActiveStatusPublish,
+    SpawnJobSetup,
+}
+
+impl RunnerPreSpawnPhase {
+    const ALL: [Self; RUNNER_PRE_SPAWN_PHASE_COUNT] = [
+        Self::ResumeSessionValidation,
+        Self::SessionHistoryMaterializerStart,
+        Self::DeviceRateLimits,
+        Self::IdleReuseLookup,
+        Self::HeldSessionStateRefresh,
+        Self::ProviderHeldSessionUpdate,
+        Self::WorkspacePromotionValidation,
+        Self::IdleUnpark,
+        Self::ActiveStatusPublish,
+        Self::SpawnJobSetup,
+    ];
+
+    const fn index(self) -> usize {
+        match self {
+            Self::ResumeSessionValidation => 0,
+            Self::SessionHistoryMaterializerStart => 1,
+            Self::DeviceRateLimits => 2,
+            Self::IdleReuseLookup => 3,
+            Self::HeldSessionStateRefresh => 4,
+            Self::ProviderHeldSessionUpdate => 5,
+            Self::WorkspacePromotionValidation => 6,
+            Self::IdleUnpark => 7,
+            Self::ActiveStatusPublish => 8,
+            Self::SpawnJobSetup => 9,
+        }
+    }
+
+    const fn action_type(self) -> &'static str {
+        match self {
+            Self::ResumeSessionValidation => "runner_claim_resume_session_validation",
+            Self::SessionHistoryMaterializerStart => {
+                "runner_claim_session_history_materializer_start"
+            }
+            Self::DeviceRateLimits => "runner_claim_device_rate_limits",
+            Self::IdleReuseLookup => "runner_claim_idle_reuse_lookup",
+            Self::HeldSessionStateRefresh => "runner_claim_held_session_state_refresh",
+            Self::ProviderHeldSessionUpdate => "runner_claim_provider_held_session_update",
+            Self::WorkspacePromotionValidation => "runner_claim_workspace_promotion_validation",
+            Self::IdleUnpark => "runner_claim_idle_unpark",
+            Self::ActiveStatusPublish => "runner_claim_active_status_publish",
+            Self::SpawnJobSetup => "runner_claim_spawn_job_setup",
+        }
+    }
+}
 
 #[derive(Clone, Copy)]
 pub(crate) struct RunnerPreSpawnTiming {
     claim_returned_at: Instant,
+    phase_durations: [Option<Duration>; RUNNER_PRE_SPAWN_PHASE_COUNT],
+    task_enqueued_at: Option<Instant>,
 }
 
 #[derive(Clone, Copy)]
@@ -27,11 +91,43 @@ impl RunnerPreSpawnTiming {
     pub(crate) fn start_after_claim() -> Self {
         Self {
             claim_returned_at: Instant::now(),
+            phase_durations: [None; RUNNER_PRE_SPAWN_PHASE_COUNT],
+            task_enqueued_at: None,
         }
+    }
+
+    pub(crate) fn record_phase(&mut self, phase: RunnerPreSpawnPhase, duration: Duration) {
+        if let Some(slot) = self.phase_durations.get_mut(phase.index()) {
+            *slot = Some(duration);
+        }
+    }
+
+    pub(crate) fn record_phase_elapsed(&mut self, phase: RunnerPreSpawnPhase, started_at: Instant) {
+        self.record_phase(phase, started_at.elapsed());
+    }
+
+    pub(crate) fn mark_task_enqueued(&mut self) {
+        self.task_enqueued_at = Some(Instant::now());
     }
 
     fn elapsed_at(self, at: Instant) -> Duration {
         at.saturating_duration_since(self.claim_returned_at)
+    }
+
+    fn record_collected_phases(self, telemetry: &mut JobTelemetry, executor_started_at: Instant) {
+        for phase in RunnerPreSpawnPhase::ALL {
+            if let Some(Some(duration)) = self.phase_durations.get(phase.index()).copied() {
+                telemetry.record(phase.action_type(), duration, true, None);
+            }
+        }
+        if let Some(task_enqueued_at) = self.task_enqueued_at {
+            telemetry.record(
+                "runner_claim_task_schedule_wait",
+                executor_started_at.saturating_duration_since(task_enqueued_at),
+                true,
+                None,
+            );
+        }
     }
 }
 
@@ -51,6 +147,7 @@ impl RunnerSpawnTiming {
                 true,
                 None,
             );
+            pre_spawn_timing.record_collected_phases(telemetry, self.executor_started_at);
         }
     }
 

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -4,7 +4,9 @@ use sandbox::SandboxId;
 use sandbox::{ProcessOutputChunk, ProcessOutputMode};
 use sandbox_mock::MockSandboxFactory;
 
-use super::super::telemetry::{elapsed_since_api_start_ms, record_reuse_result};
+use super::super::telemetry::{
+    RunnerPreSpawnPhase, elapsed_since_api_start_ms, record_reuse_result,
+};
 use super::super::{
     ExecutionHooks, NewSandboxDispatch, RunnerPreSpawnTiming, execute_job, execute_job_reuse,
     execute_job_reuse_with_hooks, execute_job_with_prepared_notifier,
@@ -76,6 +78,26 @@ fn assert_action_success(telemetry: &JobTelemetry, action: &str, success: bool) 
     assert_eq!(op.1, success, "{action} success flag");
 }
 
+fn pre_spawn_timing_with_phases() -> RunnerPreSpawnTiming {
+    let mut timing = RunnerPreSpawnTiming::start_after_claim();
+    for (phase, duration_ms) in [
+        (RunnerPreSpawnPhase::ResumeSessionValidation, 1),
+        (RunnerPreSpawnPhase::SessionHistoryMaterializerStart, 2),
+        (RunnerPreSpawnPhase::DeviceRateLimits, 3),
+        (RunnerPreSpawnPhase::IdleReuseLookup, 4),
+        (RunnerPreSpawnPhase::HeldSessionStateRefresh, 5),
+        (RunnerPreSpawnPhase::ProviderHeldSessionUpdate, 6),
+        (RunnerPreSpawnPhase::WorkspacePromotionValidation, 7),
+        (RunnerPreSpawnPhase::IdleUnpark, 8),
+        (RunnerPreSpawnPhase::ActiveStatusPublish, 9),
+        (RunnerPreSpawnPhase::SpawnJobSetup, 10),
+    ] {
+        timing.record_phase(phase, Duration::from_millis(duration_ms));
+    }
+    timing.mark_task_enqueued();
+    timing
+}
+
 #[test]
 fn record_reuse_result_emits_hit_for_reuse() {
     let mut telemetry = new_telemetry();
@@ -130,6 +152,9 @@ async fn execute_job_records_sandbox_reuse_miss_in_telemetry() {
         .collect();
     assert_eq!(reuse_events.len(), 1);
     assert_eq!(reuse_events[0].0, "sandbox_reuse_miss");
+    assert_lacks_action(&telemetry, "runner_claim_to_executor_start");
+    assert_lacks_action(&telemetry, "runner_claim_resume_session_validation");
+    assert_lacks_action(&telemetry, "runner_claim_task_schedule_wait");
 }
 
 #[tokio::test]
@@ -194,7 +219,7 @@ async fn execute_job_records_runner_pre_spawn_and_fresh_path_timing() {
         ExecutionHooks {
             sandbox_prepared: None,
             active_input_source: None,
-            pre_spawn_timing: Some(RunnerPreSpawnTiming::start_after_claim()),
+            pre_spawn_timing: Some(pre_spawn_timing_with_phases()),
             session_history_materializer: None,
         },
     )
@@ -202,6 +227,17 @@ async fn execute_job_records_runner_pre_spawn_and_fresh_path_timing() {
 
     for action in [
         "runner_claim_to_executor_start",
+        "runner_claim_resume_session_validation",
+        "runner_claim_session_history_materializer_start",
+        "runner_claim_device_rate_limits",
+        "runner_claim_idle_reuse_lookup",
+        "runner_claim_held_session_state_refresh",
+        "runner_claim_provider_held_session_update",
+        "runner_claim_workspace_promotion_validation",
+        "runner_claim_idle_unpark",
+        "runner_claim_active_status_publish",
+        "runner_claim_spawn_job_setup",
+        "runner_claim_task_schedule_wait",
         "runner_executor_start_to_spawn",
         "runner_claim_to_spawn",
         "runner_fresh_sandbox_prepare",
@@ -253,7 +289,7 @@ async fn execute_job_reuse_records_runner_pre_spawn_and_reuse_path_timing() {
         ExecutionHooks {
             sandbox_prepared: None,
             active_input_source: None,
-            pre_spawn_timing: Some(RunnerPreSpawnTiming::start_after_claim()),
+            pre_spawn_timing: Some(pre_spawn_timing_with_phases()),
             session_history_materializer: None,
         },
     )
@@ -261,6 +297,17 @@ async fn execute_job_reuse_records_runner_pre_spawn_and_reuse_path_timing() {
 
     for action in [
         "runner_claim_to_executor_start",
+        "runner_claim_resume_session_validation",
+        "runner_claim_session_history_materializer_start",
+        "runner_claim_device_rate_limits",
+        "runner_claim_idle_reuse_lookup",
+        "runner_claim_held_session_state_refresh",
+        "runner_claim_provider_held_session_update",
+        "runner_claim_workspace_promotion_validation",
+        "runner_claim_idle_unpark",
+        "runner_claim_active_status_publish",
+        "runner_claim_spawn_job_setup",
+        "runner_claim_task_schedule_wait",
         "runner_executor_start_to_spawn",
         "runner_claim_to_spawn",
         "runner_reused_sandbox_prepare",

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -78,6 +78,26 @@ fn assert_action_success(telemetry: &JobTelemetry, action: &str, success: bool) 
     assert_eq!(op.1, success, "{action} success flag");
 }
 
+const RUNNER_PRE_SPAWN_PHASE_ACTIONS: &[&str] = &[
+    "runner_claim_resume_session_validation",
+    "runner_claim_session_history_materializer_start",
+    "runner_claim_device_rate_limits",
+    "runner_claim_idle_reuse_lookup",
+    "runner_claim_held_session_state_refresh",
+    "runner_claim_provider_held_session_update",
+    "runner_claim_workspace_promotion_validation",
+    "runner_claim_idle_unpark",
+    "runner_claim_active_status_publish",
+    "runner_claim_spawn_job_setup",
+    "runner_claim_task_schedule_wait",
+];
+
+fn assert_pre_spawn_phase_actions_succeeded(telemetry: &JobTelemetry) {
+    for action in RUNNER_PRE_SPAWN_PHASE_ACTIONS {
+        assert_action_success(telemetry, action, true);
+    }
+}
+
 fn pre_spawn_timing_with_phases() -> RunnerPreSpawnTiming {
     let mut timing = RunnerPreSpawnTiming::start_after_claim();
     for (phase, duration_ms) in [
@@ -227,17 +247,6 @@ async fn execute_job_records_runner_pre_spawn_and_fresh_path_timing() {
 
     for action in [
         "runner_claim_to_executor_start",
-        "runner_claim_resume_session_validation",
-        "runner_claim_session_history_materializer_start",
-        "runner_claim_device_rate_limits",
-        "runner_claim_idle_reuse_lookup",
-        "runner_claim_held_session_state_refresh",
-        "runner_claim_provider_held_session_update",
-        "runner_claim_workspace_promotion_validation",
-        "runner_claim_idle_unpark",
-        "runner_claim_active_status_publish",
-        "runner_claim_spawn_job_setup",
-        "runner_claim_task_schedule_wait",
         "runner_executor_start_to_spawn",
         "runner_claim_to_spawn",
         "runner_fresh_sandbox_prepare",
@@ -252,6 +261,7 @@ async fn execute_job_records_runner_pre_spawn_and_fresh_path_timing() {
     ] {
         assert_has_action(&telemetry, action);
     }
+    assert_pre_spawn_phase_actions_succeeded(&telemetry);
     assert_lacks_action(&telemetry, "runner_reused_sandbox_prepare");
     assert_lacks_action(&telemetry, "runner_guest_state_restore");
 }
@@ -297,17 +307,6 @@ async fn execute_job_reuse_records_runner_pre_spawn_and_reuse_path_timing() {
 
     for action in [
         "runner_claim_to_executor_start",
-        "runner_claim_resume_session_validation",
-        "runner_claim_session_history_materializer_start",
-        "runner_claim_device_rate_limits",
-        "runner_claim_idle_reuse_lookup",
-        "runner_claim_held_session_state_refresh",
-        "runner_claim_provider_held_session_update",
-        "runner_claim_workspace_promotion_validation",
-        "runner_claim_idle_unpark",
-        "runner_claim_active_status_publish",
-        "runner_claim_spawn_job_setup",
-        "runner_claim_task_schedule_wait",
         "runner_executor_start_to_spawn",
         "runner_claim_to_spawn",
         "runner_reused_sandbox_prepare",
@@ -321,6 +320,7 @@ async fn execute_job_reuse_records_runner_pre_spawn_and_reuse_path_timing() {
     ] {
         assert_has_action(&telemetry, action);
     }
+    assert_pre_spawn_phase_actions_succeeded(&telemetry);
     assert_lacks_action(&telemetry, "runner_fresh_sandbox_prepare");
     assert_lacks_action(&telemetry, "runner_guest_timezone_sync");
 }


### PR DESCRIPTION
## Summary

- expand the runner pre-spawn timing carrier with fixed post-claim phase spans
- record runner-local claim phases for resume validation, idle reuse, held-state refresh, status publication, spawn setup, and task scheduling wait
- preserve existing coarse runner claim timing telemetry and reuse/fresh executor behavior

Closes #19118

## Testing

- cargo fmt --manifest-path crates/Cargo.toml -p runner
- cargo test --manifest-path crates/Cargo.toml -p runner telemetry_flush_includes_start_loop_claim_phase_spans
- cargo test --manifest-path crates/Cargo.toml -p runner telemetry_flush_includes_reuse_hit_claim_phase_spans
- cargo test --manifest-path crates/Cargo.toml -p runner telemetry_tests
- cargo test --manifest-path crates/Cargo.toml -p runner idle_reuse
- cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings -D clippy::all
