### PR TITLE
fix: preserve Cloudflare upload authorization

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -186,6 +186,12 @@ def _firewall_auth_context_injects_credentials(context: _FirewallAuthContext) ->
     )
 
 
+def _firewall_auth_context_needs_resolution(context: _FirewallAuthContext) -> bool:
+    return context.auth_request.firewall_billable or _firewall_auth_context_injects_credentials(
+        context
+    )
+
+
 def _set_matched_firewall_failure_response(
     flow: http.HTTPFlow,
     *,
@@ -258,6 +264,16 @@ def _record_firewall_auth_success_metadata(flow: http.HTTPFlow, token_meta: dict
     )
     flow.metadata[metadata_keys.AUTH_REFRESHED_SECRETS] = token_meta.get("refreshed_secrets", [])
     flow.metadata[metadata_keys.AUTH_CACHE_HIT] = token_meta.get("cache_hit", False)
+
+
+def _empty_firewall_auth_metadata() -> dict:
+    return {
+        "headers": {},
+        "resolved_secrets": [],
+        "refreshed_connectors": [],
+        "refreshed_secrets": [],
+        "cache_hit": False,
+    }
 
 
 def _auth_config_uses_body_dependent_auth(auth_config: object) -> bool:
@@ -575,7 +591,9 @@ def _preflight_firewall_auth(
         )
         return FirewallAuthHandlingResult.LOCAL_RESPONSE
 
-    if not context.auth_request.encrypted_secrets:
+    if not context.auth_request.encrypted_secrets and _firewall_auth_context_needs_resolution(
+        context
+    ):
         log_proxy_entry(
             context.proxy_log_path,
             "error",
@@ -935,16 +953,19 @@ async def handle_firewall_request(
         if preflight_result is not None:
             return _finish_firewall_auth_result(flow, preflight_result)
 
-        try:
-            token_meta = await get_firewall_headers(
-                context.auth_cache_key,
-                context.auth_request,
-            )
-        except Exception as exc:
-            return _finish_firewall_auth_result(
-                flow,
-                _set_firewall_auth_resolution_failure(flow, context, exc),
-            )
+        if _firewall_auth_context_needs_resolution(context):
+            try:
+                token_meta = await get_firewall_headers(
+                    context.auth_cache_key,
+                    context.auth_request,
+                )
+            except Exception as exc:
+                return _finish_firewall_auth_result(
+                    flow,
+                    _set_firewall_auth_resolution_failure(flow, context, exc),
+                )
+        else:
+            token_meta = _empty_firewall_auth_metadata()
 
         auth_result = await _apply_resolved_firewall_auth(
             flow,
@@ -978,11 +999,13 @@ async def try_apply_stream_safe_firewall_auth_for_requestheaders(
     if _auth_config_uses_body_dependent_auth(auth_config):
         return FirewallHeaderPhaseAuthResult.FALLBACK
 
+    injects_credentials = auth_config_injects_credentials(auth_config)
+    needs_auth_resolution = injects_credentials or is_billable_firewall(allow.name, vm_info)
     request_scheme = flow.request.scheme.lower()
-    if request_scheme != "https" and auth_config_injects_credentials(auth_config):
+    if request_scheme != "https" and injects_credentials:
         return FirewallHeaderPhaseAuthResult.FALLBACK
 
-    if not vm_info.get("encryptedSecrets"):
+    if not vm_info.get("encryptedSecrets") and needs_auth_resolution:
         return FirewallHeaderPhaseAuthResult.FALLBACK
 
     metadata_snapshot = dict(flow.metadata)
@@ -992,27 +1015,30 @@ async def try_apply_stream_safe_firewall_auth_for_requestheaders(
     _prepare_firewall_metadata(flow, allow, vm_info)
     context = _build_firewall_auth_context(flow, allow, vm_info)
 
-    try:
-        token_meta = await get_firewall_headers(
-            context.auth_cache_key,
-            context.auth_request,
-        )
-    except asyncio.CancelledError:
-        _restore_header_phase_probe_state(
-            flow,
-            metadata_snapshot=metadata_snapshot,
-            request_headers_snapshot=request_headers_snapshot,
-            request_path_snapshot=request_path_snapshot,
-        )
-        raise
-    except Exception:
-        _restore_header_phase_probe_state(
-            flow,
-            metadata_snapshot=metadata_snapshot,
-            request_headers_snapshot=request_headers_snapshot,
-            request_path_snapshot=request_path_snapshot,
-        )
-        return FirewallHeaderPhaseAuthResult.FALLBACK
+    if needs_auth_resolution:
+        try:
+            token_meta = await get_firewall_headers(
+                context.auth_cache_key,
+                context.auth_request,
+            )
+        except asyncio.CancelledError:
+            _restore_header_phase_probe_state(
+                flow,
+                metadata_snapshot=metadata_snapshot,
+                request_headers_snapshot=request_headers_snapshot,
+                request_path_snapshot=request_path_snapshot,
+            )
+            raise
+        except Exception:
+            _restore_header_phase_probe_state(
+                flow,
+                metadata_snapshot=metadata_snapshot,
+                request_headers_snapshot=request_headers_snapshot,
+                request_path_snapshot=request_path_snapshot,
+            )
+            return FirewallHeaderPhaseAuthResult.FALLBACK
+    else:
+        token_meta = _empty_firewall_auth_metadata()
 
     if not isinstance(token_meta, dict):
         _restore_header_phase_probe_state(

--- a/crates/runner/mitm-addon/src/generated/builtin_firewalls/cloudflare_0.py
+++ b/crates/runner/mitm-addon/src/generated/builtin_firewalls/cloudflare_0.py
@@ -2331,12 +2331,15 @@ JSON_PART = r"""{
             "DELETE /v4/accounts/{account_id}/pages/projects/{project_name}/deployments/{deployment_id}",
             "POST /v4/accounts/{account_id}/pages/projects/{project_name}/deployments/{deployment_id}/retry",
             "POST /v4/accounts/{account_id}/pages/projects/{project_name}/deployments/{deployment_id}/rollback",
+            "POST /v4/accounts/{account_id}/pages/projects/{project_name}/deployments/{deployment_id}/tails",
+            "DELETE /v4/accounts/{account_id}/pages/projects/{project_name}/deployments/{deployment_id}/tails/{tail_id}",
             "POST /v4/accounts/{account_id}/pages/projects/{project_name}/domains",
             "PATCH /v4/accounts/{account_id}/pages/projects/{project_name}/domains/{domain_name}",
             "DELETE /v4/accounts/{account_id}/pages/projects/{project_name}/domains/{domain_name}",
             "POST /v4/accounts/{account_id}/pages/projects/{project_name}/purge_build_cache",
             "POST /v4/accounts/{account_id}/pages/projects/{project_name}/source",
-            "DELETE /v4/accounts/{account_id}/pages/projects/{project_name}/source"
+            "DELETE /v4/accounts/{account_id}/pages/projects/{project_name}/source",
+            "GET /v4/accounts/{account_id}/pages/projects/{project_name}/upload-token"
           ]
         },
         {
@@ -3309,9 +3312,4 @@ JSON_PART = r"""{
             "GET /v4/radar/http/summary/{dimension}",
             "GET /v4/radar/http/timeseries",
             "GET /v4/radar/http/timeseries_groups/bot_class",
-            "GET /v4/radar/http/timeseries_groups/browser",
-            "GET /v4/radar/http/timeseries_groups/browser_family",
-            "GET /v4/radar/http/timeseries_groups/device_type",
-            "GET /v4/radar/http/timeseries_groups/http_protocol",
-            "GET /v4/radar/http/timeseries_groups/http_version",
 """

--- a/crates/runner/mitm-addon/src/generated/builtin_firewalls/cloudflare_1.py
+++ b/crates/runner/mitm-addon/src/generated/builtin_firewalls/cloudflare_1.py
@@ -3,7 +3,12 @@
 # Regenerate with: cd turbo && pnpm -F @vm0/firewalls-generator generate
 # ruff: noqa
 
-JSON_PART = r"""            "GET /v4/radar/http/timeseries_groups/ip_version",
+JSON_PART = r"""            "GET /v4/radar/http/timeseries_groups/browser",
+            "GET /v4/radar/http/timeseries_groups/browser_family",
+            "GET /v4/radar/http/timeseries_groups/device_type",
+            "GET /v4/radar/http/timeseries_groups/http_protocol",
+            "GET /v4/radar/http/timeseries_groups/http_version",
+            "GET /v4/radar/http/timeseries_groups/ip_version",
             "GET /v4/radar/http/timeseries_groups/os",
             "GET /v4/radar/http/timeseries_groups/post_quantum",
             "GET /v4/radar/http/timeseries_groups/tls_version",
@@ -358,6 +363,7 @@ JSON_PART = r"""            "GET /v4/radar/http/timeseries_groups/ip_version",
             "DELETE /v4/accounts/{account_id}/workers/dispatch/namespaces/{dispatch_namespace}/scripts",
             "PUT /v4/accounts/{account_id}/workers/dispatch/namespaces/{dispatch_namespace}/scripts/{script_name}",
             "DELETE /v4/accounts/{account_id}/workers/dispatch/namespaces/{dispatch_namespace}/scripts/{script_name}",
+            "POST /v4/accounts/{account_id}/workers/dispatch/namespaces/{dispatch_namespace}/scripts/{script_name}/assets-upload-session",
             "PUT /v4/accounts/{account_id}/workers/dispatch/namespaces/{dispatch_namespace}/scripts/{script_name}/content",
             "PUT /v4/accounts/{account_id}/workers/dispatch/namespaces/{dispatch_namespace}/scripts/{script_name}/secrets",
             "DELETE /v4/accounts/{account_id}/workers/dispatch/namespaces/{dispatch_namespace}/scripts/{script_name}/secrets/{secret_name}",
@@ -633,6 +639,28 @@ JSON_PART = r"""            "GET /v4/radar/http/timeseries_groups/ip_version",
             "POST /v4/zones/{zone_id}/hold",
             "PATCH /v4/zones/{zone_id}/hold",
             "DELETE /v4/zones/{zone_id}/hold"
+          ]
+        }
+      ]
+    },
+    {
+      "auth": {},
+      "base": "https://api.cloudflare.com/client",
+      "permissions": [
+        {
+          "description": "Cloudflare supplemental permission: page.write",
+          "name": "page.write",
+          "rules": [
+            "POST /v4/pages/assets/check-missing",
+            "POST /v4/pages/assets/upload",
+            "POST /v4/pages/assets/upsert-hashes"
+          ]
+        },
+        {
+          "description": "Cloudflare supplemental permission: workers-scripts.write",
+          "name": "workers-scripts.write",
+          "rules": [
+            "POST /v4/accounts/{account_id}/workers/assets/upload"
           ]
         }
       ]

--- a/crates/runner/mitm-addon/tests/test_builtin_firewalls_catalog.py
+++ b/crates/runner/mitm-addon/tests/test_builtin_firewalls_catalog.py
@@ -73,6 +73,38 @@ def test_builtin_firewalls_mapping_is_read_only():
     assert not hasattr(builtin_firewalls.BUILTIN_FIREWALLS, "__setitem__")
 
 
+def test_cloudflare_builtin_preserves_upload_authorization_endpoints():
+    firewall = builtin_firewalls.BUILTIN_FIREWALLS["cloudflare"]
+    connector_api, upload_api = firewall["apis"]
+
+    assert connector_api["auth"] == {
+        "headers": {"Authorization": "Bearer ${{ secrets.CLOUDFLARE_TOKEN }}"}
+    }
+    assert upload_api["auth"] == {}
+
+    connector_rules = {
+        rule for permission in connector_api["permissions"] for rule in permission.get("rules", [])
+    }
+    upload_rules = {
+        rule for permission in upload_api["permissions"] for rule in permission.get("rules", [])
+    }
+
+    assert (
+        "GET /v4/accounts/{account_id}/pages/projects/{project_name}/upload-token"
+        in connector_rules
+    )
+    assert (
+        "POST /v4/accounts/{account_id}/workers/dispatch/namespaces/"
+        "{dispatch_namespace}/scripts/{script_name}/assets-upload-session" in connector_rules
+    )
+    assert upload_rules == {
+        "POST /v4/pages/assets/check-missing",
+        "POST /v4/pages/assets/upload",
+        "POST /v4/pages/assets/upsert-hashes",
+        "POST /v4/accounts/{account_id}/workers/assets/upload",
+    }
+
+
 def test_read_like_builtin_permissions_do_not_own_mutation_methods():
     violations: list[str] = []
 

--- a/crates/runner/mitm-addon/tests/test_compiled_firewall_cross_firewall_precedence.py
+++ b/crates/runner/mitm-addon/tests/test_compiled_firewall_cross_firewall_precedence.py
@@ -119,6 +119,103 @@ def test_specific_permission_api_wins_after_earlier_unknown_same_firewall():
     assert result.api_entry["auth"] == {}
 
 
+def test_cloudflare_upload_api_preserves_auth_without_shadowing_normal_api():
+    pages_upload_token_rule = (
+        "GET /v4/accounts/{account_id}/pages/projects/{project_name}/upload-token"
+    )
+    pages_deployment_rule = (
+        "POST /v4/accounts/{account_id}/pages/projects/{project_name}/deployments"
+    )
+    dispatch_upload_session_rule = (
+        "POST /v4/accounts/{account_id}/workers/dispatch/namespaces/"
+        "{dispatch_namespace}/scripts/{script_name}/assets-upload-session"
+    )
+    fws = [
+        {
+            "name": "cloudflare",
+            "apis": [
+                {
+                    "base": "https://api.cloudflare.com/client",
+                    "auth": {"headers": {"Authorization": "Bearer connector-token"}},
+                    "permissions": [
+                        {
+                            "name": "page.write",
+                            "rules": [
+                                pages_upload_token_rule,
+                                pages_deployment_rule,
+                            ],
+                        },
+                        {
+                            "name": "workers-scripts.write",
+                            "rules": [
+                                dispatch_upload_session_rule,
+                            ],
+                        },
+                    ],
+                },
+                {
+                    "base": "https://api.cloudflare.com/client",
+                    "auth": {},
+                    "permissions": [
+                        {
+                            "name": "page.write",
+                            "rules": [
+                                "POST /v4/pages/assets/check-missing",
+                                "POST /v4/pages/assets/upload",
+                                "POST /v4/pages/assets/upsert-hashes",
+                            ],
+                        },
+                        {
+                            "name": "workers-scripts.write",
+                            "rules": [
+                                "POST /v4/accounts/{account_id}/workers/assets/upload",
+                            ],
+                        },
+                    ],
+                },
+            ],
+        },
+    ]
+    policies = {
+        "cloudflare": {
+            "allow": ["page.write", "workers-scripts.write"],
+            "deny": [],
+            "unknownPolicy": "deny",
+        }
+    }
+    compiled = compile_firewalls_or_fail(fws)
+
+    normal_result = matching.match_compiled_firewall_request(
+        "https://api.cloudflare.com/client/v4/accounts/account-id/pages/projects/project-name/deployments",
+        "POST",
+        compiled,
+        policies,
+    )
+    assert isinstance(normal_result, matching.FirewallAllow)
+    assert normal_result.permission == "page.write"
+    assert normal_result.api_entry["auth"]["headers"]["Authorization"] == ("Bearer connector-token")
+
+    pages_upload_result = matching.match_compiled_firewall_request(
+        "https://api.cloudflare.com/client/v4/pages/assets/check-missing",
+        "POST",
+        compiled,
+        policies,
+    )
+    assert isinstance(pages_upload_result, matching.FirewallAllow)
+    assert pages_upload_result.permission == "page.write"
+    assert pages_upload_result.api_entry["auth"] == {}
+
+    workers_upload_result = matching.match_compiled_firewall_request(
+        "https://api.cloudflare.com/client/v4/accounts/account-id/workers/assets/upload?base64=true",
+        "POST",
+        compiled,
+        policies,
+    )
+    assert isinstance(workers_upload_result, matching.FirewallAllow)
+    assert workers_upload_result.permission == "workers-scripts.write"
+    assert workers_upload_result.api_entry["auth"] == {}
+
+
 def test_later_denied_firewall_wins_after_earlier_unknown_allow():
     fws = [
         {

--- a/crates/runner/mitm-addon/tests/test_compiled_firewall_cross_firewall_precedence.py
+++ b/crates/runner/mitm-addon/tests/test_compiled_firewall_cross_firewall_precedence.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+import generated.builtin_firewalls as builtin_firewalls
 import matching
 from tests.firewall_helpers import compile_firewalls_or_fail, wrap_firewalls
 
@@ -120,62 +121,7 @@ def test_specific_permission_api_wins_after_earlier_unknown_same_firewall():
 
 
 def test_cloudflare_upload_api_preserves_auth_without_shadowing_normal_api():
-    pages_upload_token_rule = (
-        "GET /v4/accounts/{account_id}/pages/projects/{project_name}/upload-token"
-    )
-    pages_deployment_rule = (
-        "POST /v4/accounts/{account_id}/pages/projects/{project_name}/deployments"
-    )
-    dispatch_upload_session_rule = (
-        "POST /v4/accounts/{account_id}/workers/dispatch/namespaces/"
-        "{dispatch_namespace}/scripts/{script_name}/assets-upload-session"
-    )
-    fws = [
-        {
-            "name": "cloudflare",
-            "apis": [
-                {
-                    "base": "https://api.cloudflare.com/client",
-                    "auth": {"headers": {"Authorization": "Bearer connector-token"}},
-                    "permissions": [
-                        {
-                            "name": "page.write",
-                            "rules": [
-                                pages_upload_token_rule,
-                                pages_deployment_rule,
-                            ],
-                        },
-                        {
-                            "name": "workers-scripts.write",
-                            "rules": [
-                                dispatch_upload_session_rule,
-                            ],
-                        },
-                    ],
-                },
-                {
-                    "base": "https://api.cloudflare.com/client",
-                    "auth": {},
-                    "permissions": [
-                        {
-                            "name": "page.write",
-                            "rules": [
-                                "POST /v4/pages/assets/check-missing",
-                                "POST /v4/pages/assets/upload",
-                                "POST /v4/pages/assets/upsert-hashes",
-                            ],
-                        },
-                        {
-                            "name": "workers-scripts.write",
-                            "rules": [
-                                "POST /v4/accounts/{account_id}/workers/assets/upload",
-                            ],
-                        },
-                    ],
-                },
-            ],
-        },
-    ]
+    fws = [builtin_firewalls.BUILTIN_FIREWALLS["cloudflare"]]
     policies = {
         "cloudflare": {
             "allow": ["page.write", "workers-scripts.write"],
@@ -193,7 +139,21 @@ def test_cloudflare_upload_api_preserves_auth_without_shadowing_normal_api():
     )
     assert isinstance(normal_result, matching.FirewallAllow)
     assert normal_result.permission == "page.write"
-    assert normal_result.api_entry["auth"]["headers"]["Authorization"] == ("Bearer connector-token")
+    assert normal_result.api_entry["auth"]["headers"]["Authorization"] == (
+        "Bearer ${{ secrets.CLOUDFLARE_TOKEN }}"
+    )
+
+    upload_token_result = matching.match_compiled_firewall_request(
+        "https://api.cloudflare.com/client/v4/accounts/account-id/pages/projects/project-name/upload-token",
+        "GET",
+        compiled,
+        policies,
+    )
+    assert isinstance(upload_token_result, matching.FirewallAllow)
+    assert upload_token_result.permission == "page.write"
+    assert upload_token_result.api_entry["auth"]["headers"]["Authorization"] == (
+        "Bearer ${{ secrets.CLOUDFLARE_TOKEN }}"
+    )
 
     pages_upload_result = matching.match_compiled_firewall_request(
         "https://api.cloudflare.com/client/v4/pages/assets/check-missing",

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -142,7 +142,7 @@ def _api_entry(
 
 def _copy_auth_config(auth_config: dict | None) -> dict:
     if auth_config is None:
-        return {"headers": {}}
+        return {"headers": {"Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"}}
 
     copied = dict(auth_config)
     for key in ("headers", "query"):
@@ -773,7 +773,7 @@ class TestHandleFirewallRequest:
             auth_config={},
             api_id="run-1:1",
         )
-        vm_info = _vm_info(tmp_path)
+        vm_info = _vm_info(tmp_path, include_encrypted_secrets=False)
         allow = _allow(
             api_entry,
             name="cloudflare",
@@ -781,19 +781,65 @@ class TestHandleFirewallRequest:
             rule="POST /v4/pages/assets/check-missing",
             rel_path="/v4/pages/assets/check-missing",
         )
-        token_meta = _token_meta(headers={})
+        mock_get_firewall_headers = AsyncMock()
 
         with (
-            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+            patch.object(auth, "get_firewall_headers", mock_get_firewall_headers),
             mitm_ctx(),
         ):
             result = await auth.handle_firewall_request(flow, allow, vm_info)
 
         assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
+        mock_get_firewall_headers.assert_not_called()
         assert flow.request.headers["Authorization"] == "Bearer upload-jwt"
         assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
         assert flow.metadata[metadata_keys.FIREWALL_NAME] == "cloudflare"
         assert flow.metadata[metadata_keys.FIREWALL_PERMISSION] == "page.write"
+        assert flow.metadata[metadata_keys.AUTH_CACHE_HIT] is False
+
+    async def test_empty_auth_config_requestheaders_preserves_authorization_without_auth_resolution(
+        self, real_flow, mitm_ctx, tmp_path
+    ):
+        flow = real_flow(
+            with_response=False,
+            host="api.cloudflare.com",
+            path="/client/v4/pages/assets/upload",
+            method="POST",
+        )
+        flow.request.headers["Authorization"] = "Bearer upload-jwt"
+        flow.metadata[metadata_keys.VM_RUN_ID] = "test-run"
+        api_entry = _api_entry(
+            base="https://api.cloudflare.com/client",
+            auth_config={},
+            api_id="run-1:1",
+        )
+        vm_info = _vm_info(tmp_path, include_encrypted_secrets=False)
+        allow = _allow(
+            api_entry,
+            name="cloudflare",
+            permission="page.write",
+            rule="POST /v4/pages/assets/upload",
+            rel_path="/v4/pages/assets/upload",
+        )
+        mock_get_firewall_headers = AsyncMock()
+
+        with (
+            patch.object(auth, "get_firewall_headers", mock_get_firewall_headers),
+            mitm_ctx(),
+        ):
+            result = await auth.try_apply_stream_safe_firewall_auth_for_requestheaders(
+                flow,
+                allow,
+                vm_info,
+            )
+
+        assert result is auth.FirewallHeaderPhaseAuthResult.APPLIED
+        mock_get_firewall_headers.assert_not_called()
+        assert flow.request.headers["Authorization"] == "Bearer upload-jwt"
+        assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+        assert flow.metadata[metadata_keys.FIREWALL_NAME] == "cloudflare"
+        assert flow.metadata[metadata_keys.FIREWALL_PERMISSION] == "page.write"
+        assert flow.metadata[metadata_keys.AUTH_CACHE_HIT] is False
 
     async def test_auth_cache_identity_tracks_request_auth_inputs(
         self, real_flow, mitm_ctx, tmp_path
@@ -1509,7 +1555,9 @@ class TestHandleFirewallRequest:
     async def test_missing_encrypted_secrets_returns_502(self, real_flow, headers, mitm_ctx):
         """When encryptedSecrets is missing from vm_info, return 502."""
         flow = _firewall_flow(real_flow)
-        api_entry = _api_entry()
+        api_entry = _api_entry(
+            auth_config={"headers": {"Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"}}
+        )
         vm_info = _vm_info(network_log_path="", include_encrypted_secrets=False)
         allow = _allow(api_entry)
         admission = auth_base_forwarder.reserve_forward_request_admission(42)

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -757,6 +757,44 @@ class TestHandleFirewallRequest:
         log_text = await asyncio.to_thread(read_jsonl_text_after_flush, proxy_log_path)
         assert "Firewall https://api.github.com: api.github.com" in log_text
 
+    async def test_empty_auth_config_preserves_existing_authorization(
+        self, real_flow, mitm_ctx, tmp_path
+    ):
+        flow = real_flow(
+            with_response=False,
+            host="api.cloudflare.com",
+            path="/client/v4/pages/assets/check-missing",
+            method="POST",
+        )
+        flow.request.headers["Authorization"] = "Bearer upload-jwt"
+        flow.metadata[metadata_keys.VM_RUN_ID] = "test-run"
+        api_entry = _api_entry(
+            base="https://api.cloudflare.com/client",
+            auth_config={},
+            api_id="run-1:1",
+        )
+        vm_info = _vm_info(tmp_path)
+        allow = _allow(
+            api_entry,
+            name="cloudflare",
+            permission="page.write",
+            rule="POST /v4/pages/assets/check-missing",
+            rel_path="/v4/pages/assets/check-missing",
+        )
+        token_meta = _token_meta(headers={})
+
+        with (
+            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+            mitm_ctx(),
+        ):
+            result = await auth.handle_firewall_request(flow, allow, vm_info)
+
+        assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
+        assert flow.request.headers["Authorization"] == "Bearer upload-jwt"
+        assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+        assert flow.metadata[metadata_keys.FIREWALL_NAME] == "cloudflare"
+        assert flow.metadata[metadata_keys.FIREWALL_PERMISSION] == "page.write"
+
     async def test_auth_cache_identity_tracks_request_auth_inputs(
         self, real_flow, mitm_ctx, tmp_path
     ):

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -740,7 +740,7 @@ async def test_http_firewall_without_managed_credentials_still_matches(
     ):
         await mitm_addon.request(flow)
 
-    auth_fetch.assert_called_once()
+    auth_fetch.assert_not_called()
     assert flow.response is None
     assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
     assert flow.metadata[metadata_keys.FIREWALL_BASE] == "http://api.github.com"

--- a/turbo/packages/connectors/src/__tests__/firewalls/cloudflare.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewalls/cloudflare.test.ts
@@ -20,24 +20,20 @@ let cloudflareCategoryOrder: readonly string[];
 let cloudflareDefaultAllowed: readonly string[];
 let cloudflareGenerationStats: Record<string, number>;
 
-function getCloudflarePermission(name: string) {
-  const permission = firewall.apis
+function expectCloudflareRule(permissionName: string, rule: string): void {
+  const permissions = firewall.apis
     .flatMap((api) => {
       return api.permissions ?? [];
     })
-    .find((candidate) => {
-      return candidate.name === name;
+    .filter((permission) => {
+      return permission.name === permissionName;
     });
 
-  if (!permission) {
-    throw new Error(`Missing Cloudflare permission "${name}"`);
-  }
-  return permission;
-}
-
-function expectCloudflareRule(permissionName: string, rule: string): void {
-  const permission = getCloudflarePermission(permissionName);
-  expect(permission.rules).toContain(rule);
+  expect(
+    permissions.some((permission) => {
+      return permission.rules.includes(rule);
+    }),
+  ).toBe(true);
 }
 
 function expectCloudflareMatches(
@@ -79,7 +75,7 @@ describe("cloudflare firewall", () => {
 
   it("registers the Cloudflare firewall with API token auth", () => {
     expect(firewall.name).toBe("cloudflare");
-    expect(firewall.apis).toHaveLength(1);
+    expect(firewall.apis).toHaveLength(2);
     expect(firewall.apis[0]).toMatchObject({
       base: "https://api.cloudflare.com/client",
       auth: {
@@ -87,6 +83,10 @@ describe("cloudflare firewall", () => {
           Authorization: "Bearer ${{ secrets.CLOUDFLARE_TOKEN }}",
         },
       },
+    });
+    expect(firewall.apis[1]).toMatchObject({
+      base: "https://api.cloudflare.com/client",
+      auth: {},
     });
     expect(extractSecretNamesFromApis([...firewall.apis])).toStrictEqual([
       "CLOUDFLARE_TOKEN",
@@ -325,6 +325,62 @@ describe("cloudflare firewall", () => {
     );
   });
 
+  it("covers Wrangler upload endpoints with endpoint-specific auth behavior", () => {
+    const connectorApi = firewall.apis[0];
+    const authlessUploadApi = firewall.apis[1];
+
+    expect(connectorApi?.auth).toMatchObject({
+      headers: {
+        Authorization: "Bearer ${{ secrets.CLOUDFLARE_TOKEN }}",
+      },
+    });
+    expect(authlessUploadApi?.auth).toStrictEqual({});
+
+    expectCloudflareRule(
+      "page.write",
+      "GET /v4/accounts/{account_id}/pages/projects/{project_name}/upload-token",
+    );
+    expectCloudflareRule("page.write", "POST /v4/pages/assets/check-missing");
+    expectCloudflareRule("page.write", "POST /v4/pages/assets/upload");
+    expectCloudflareRule("page.write", "POST /v4/pages/assets/upsert-hashes");
+    expectCloudflareRule(
+      "workers-scripts.write",
+      "POST /v4/accounts/{account_id}/workers/dispatch/namespaces/{dispatch_namespace}/scripts/{script_name}/assets-upload-session",
+    );
+    expectCloudflareRule(
+      "workers-scripts.write",
+      "POST /v4/accounts/{account_id}/workers/assets/upload",
+    );
+
+    expectCloudflareMatches(
+      "GET",
+      "/v4/accounts/account-id/pages/projects/project-name/upload-token",
+      ["page.write"],
+    );
+    expectCloudflareMatches("POST", "/v4/pages/assets/check-missing", [
+      "page.write",
+    ]);
+    expectCloudflareMatches(
+      "POST",
+      "/v4/accounts/account-id/workers/assets/upload",
+      ["workers-scripts.write"],
+    );
+
+    const authlessRules = new Set(
+      authlessUploadApi?.permissions?.flatMap((permission) => {
+        return permission.rules;
+      }) ?? [],
+    );
+    expect(authlessRules).toStrictEqual(
+      new Set([
+        "POST /v4/pages/assets/check-missing",
+        "POST /v4/pages/assets/upload",
+        "POST /v4/pages/assets/upsert-hashes",
+        "POST /v4/accounts/{account_id}/workers/assets/upload",
+      ]),
+    );
+  });
+
   it("reports generated mapping coverage from the official OpenAPI schema", () => {
     const permissionCount = firewall.apis.reduce((count, api) => {
       return count + (api.permissions?.length ?? 0);
@@ -335,8 +391,15 @@ describe("cloudflare firewall", () => {
     expect(cloudflareGenerationStats.operationsWithCfPermissionsRequired).toBe(
       703,
     );
-    expect(cloudflareGenerationStats.mappedOperations).toBe(2655);
-    expect(cloudflareGenerationStats.unmappedOperations).toBe(495);
+    expect(cloudflareGenerationStats.openApiTokenGroupMappedOperations).toBe(
+      2655,
+    );
+    expect(cloudflareGenerationStats.supplementalOpenApiMappedOperations).toBe(
+      2,
+    );
+    expect(cloudflareGenerationStats.nonOpenApiSupplementalOperations).toBe(6);
+    expect(cloudflareGenerationStats.mappedOperations).toBe(2657);
+    expect(cloudflareGenerationStats.unmappedOperations).toBe(493);
     expect(cloudflareGenerationStats.ambiguousOperations).toBe(0);
     expect(cloudflareGenerationStats.multiGroupOperations).toBe(1673);
     expect(cloudflareGenerationStats.operationsWithPrioritizedOwners).toBe(496);
@@ -348,7 +411,7 @@ describe("cloudflare firewall", () => {
       140,
     );
     expect(cloudflareGenerationStats.readGroupsDroppedByPriority).toBe(145);
-    expect(cloudflareGenerationStats.permissionCount).toBe(213);
+    expect(cloudflareGenerationStats.permissionCount).toBe(215);
     expect(cloudflareGenerationStats.permissionCount).toBe(permissionCount);
   });
 

--- a/turbo/packages/firewalls-generator/src/cloudflare-supplemental.ts
+++ b/turbo/packages/firewalls-generator/src/cloudflare-supplemental.ts
@@ -1,0 +1,103 @@
+export type CloudflareSupplementalAuthBehavior =
+  | "connector"
+  | "preserveAuthorization";
+
+export type CloudflareSupplementalOpenApiPresence = "present" | "absent";
+
+export interface CloudflareSupplementalOperation {
+  readonly method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "HEAD";
+  readonly path: string;
+  readonly permission: string;
+  readonly authBehavior: CloudflareSupplementalAuthBehavior;
+  readonly openApi: CloudflareSupplementalOpenApiPresence;
+  readonly source: string;
+  readonly reason: string;
+}
+
+export const CLOUDFLARE_SUPPLEMENTAL_OPERATIONS = [
+  {
+    method: "GET",
+    path: "/accounts/{account_id}/pages/projects/{project_name}/upload-token",
+    permission: "page.write",
+    authBehavior: "connector",
+    openApi: "absent",
+    source:
+      "https://github.com/cloudflare/workers-sdk/blob/1cea1299432fdf8e15a8e91816d8fe5e3b53e520/packages/wrangler/src/pages/upload.ts",
+    reason: "Wrangler fetches a Pages upload JWT before direct asset upload.",
+  },
+  {
+    method: "POST",
+    path: "/pages/assets/check-missing",
+    permission: "page.write",
+    authBehavior: "preserveAuthorization",
+    openApi: "absent",
+    source:
+      "https://github.com/cloudflare/workers-sdk/blob/1cea1299432fdf8e15a8e91816d8fe5e3b53e520/packages/wrangler/src/pages/upload.ts",
+    reason:
+      "Cloudflare Pages asset service expects the provider-issued upload JWT.",
+  },
+  {
+    method: "POST",
+    path: "/pages/assets/upload",
+    permission: "page.write",
+    authBehavior: "preserveAuthorization",
+    openApi: "absent",
+    source:
+      "https://github.com/cloudflare/workers-sdk/blob/1cea1299432fdf8e15a8e91816d8fe5e3b53e520/packages/wrangler/src/pages/upload.ts",
+    reason:
+      "Cloudflare Pages asset service expects the provider-issued upload JWT.",
+  },
+  {
+    method: "POST",
+    path: "/pages/assets/upsert-hashes",
+    permission: "page.write",
+    authBehavior: "preserveAuthorization",
+    openApi: "absent",
+    source:
+      "https://github.com/cloudflare/workers-sdk/blob/1cea1299432fdf8e15a8e91816d8fe5e3b53e520/packages/wrangler/src/pages/upload.ts",
+    reason:
+      "Cloudflare Pages asset service expects the provider-issued upload JWT.",
+  },
+  {
+    method: "POST",
+    path: "/accounts/{account_id}/workers/dispatch/namespaces/{dispatch_namespace}/scripts/{script_name}/assets-upload-session",
+    permission: "workers-scripts.write",
+    authBehavior: "connector",
+    openApi: "present",
+    source:
+      "https://github.com/cloudflare/workers-sdk/blob/1cea1299432fdf8e15a8e91816d8fe5e3b53e520/packages/deploy-helpers/src/deploy/helpers/assets.ts",
+    reason:
+      "Wrangler Workers for Platforms initializes an asset upload session before uploading static assets.",
+  },
+  {
+    method: "POST",
+    path: "/accounts/{account_id}/workers/assets/upload",
+    permission: "workers-scripts.write",
+    authBehavior: "preserveAuthorization",
+    openApi: "present",
+    source:
+      "https://developers.cloudflare.com/workers/static-assets/direct-upload/index.md",
+    reason:
+      "Workers static asset upload expects the temporary JWT returned by the upload-session endpoint.",
+  },
+  {
+    method: "POST",
+    path: "/accounts/{account_id}/pages/projects/{project_name}/deployments/{deployment_id}/tails",
+    permission: "page.write",
+    authBehavior: "connector",
+    openApi: "absent",
+    source:
+      "https://github.com/cloudflare/workers-sdk/blob/1cea1299432fdf8e15a8e91816d8fe5e3b53e520/packages/wrangler/src/tail/createTail.ts",
+    reason: "Wrangler Pages deployment tail uses this Cloudflare endpoint.",
+  },
+  {
+    method: "DELETE",
+    path: "/accounts/{account_id}/pages/projects/{project_name}/deployments/{deployment_id}/tails/{tail_id}",
+    permission: "page.write",
+    authBehavior: "connector",
+    openApi: "absent",
+    source:
+      "https://github.com/cloudflare/workers-sdk/blob/1cea1299432fdf8e15a8e91816d8fe5e3b53e520/packages/wrangler/src/tail/createTail.ts",
+    reason: "Wrangler Pages deployment tail uses this Cloudflare endpoint.",
+  },
+] as const satisfies readonly CloudflareSupplementalOperation[];

--- a/turbo/packages/firewalls-generator/src/cloudflare.ts
+++ b/turbo/packages/firewalls-generator/src/cloudflare.ts
@@ -38,6 +38,11 @@ import {
   CLOUDFLARE_OAUTH_SCOPES_URL,
   CLOUDFLARE_OPENAPI_URL,
 } from "./cloudflare-sources";
+import {
+  CLOUDFLARE_SUPPLEMENTAL_OPERATIONS,
+  type CloudflareSupplementalAuthBehavior,
+  type CloudflareSupplementalOperation,
+} from "./cloudflare-supplemental";
 
 // Format: [A-Za-z0-9_-]{40} (gitleaks: cloudflare-api-key)
 const PLACEHOLDER_VALUE = "CoffeeSafeLocalCoffeeSafeLocalCoffeeSafe";
@@ -90,6 +95,9 @@ interface BuildStats {
   totalOperations: number;
   operationsWithApiTokenGroup: number;
   operationsWithCfPermissionsRequired: number;
+  openApiTokenGroupMappedOperations: number;
+  supplementalOpenApiMappedOperations: number;
+  nonOpenApiSupplementalOperations: number;
   mappedOperations: number;
   unmappedOperations: number;
   ambiguousOperations: number;
@@ -103,7 +111,9 @@ interface BuildStats {
 }
 
 interface BuildResult {
-  permissions: PermissionGroup[];
+  connectorPermissions: PermissionGroup[];
+  preserveAuthorizationPermissions: PermissionGroup[];
+  allPermissions: PermissionGroup[];
   categories: Record<string, string>;
   categoryOrder: string[];
   defaultAllowed: string[];
@@ -705,6 +715,66 @@ function getPermissionGroup(
   return created;
 }
 
+function normalizedPermissionFromName(name: string): NormalizedPermission {
+  const action = permissionAction(name);
+  if (!action) {
+    throw new Error(
+      `Cloudflare supplemental permission has unknown action: ${name}`,
+    );
+  }
+  const ownerKey = permissionOwnerKey(name);
+  return {
+    name,
+    action,
+    ownerKey,
+    sourceGroup: name,
+    sourceStem: ownerKey,
+    description: `Cloudflare supplemental permission: ${name}`,
+  };
+}
+
+function openApiOperationKey(method: string, apiPath: string): string {
+  return `${method.toUpperCase()} ${apiPath}`;
+}
+
+function supplementalOperationKey(
+  operation: CloudflareSupplementalOperation,
+): string {
+  return openApiOperationKey(operation.method, operation.path);
+}
+
+function supplementalRule(operation: CloudflareSupplementalOperation): string {
+  return `${operation.method} ${apiPathToRulePath(operation.path)}`;
+}
+
+function buildSupplementalOperationIndex(): Map<
+  string,
+  CloudflareSupplementalOperation
+> {
+  const operations = new Map<string, CloudflareSupplementalOperation>();
+  for (const operation of CLOUDFLARE_SUPPLEMENTAL_OPERATIONS) {
+    const key = supplementalOperationKey(operation);
+    if (operations.has(key)) {
+      throw new Error(`Duplicate Cloudflare supplemental operation: ${key}`);
+    }
+    operations.set(key, operation);
+  }
+  return operations;
+}
+
+function addSupplementalOperationRule(
+  operation: CloudflareSupplementalOperation,
+  permissionGroupsByAuthBehavior: Record<
+    CloudflareSupplementalAuthBehavior,
+    Map<string, { rules: Set<string>; metadata: NormalizedPermission }>
+  >,
+): void {
+  getPermissionGroup(
+    permissionGroupsByAuthBehavior[operation.authBehavior],
+    normalizedPermissionFromName(operation.permission),
+  ).rules.add(supplementalRule(operation));
+}
+
 function operationContext(
   apiPath: string,
   method: string,
@@ -1041,6 +1111,42 @@ function assertUniquePermissionRules(
   );
 }
 
+function permissionGroupsToPermissions(
+  permissionGroups: Map<
+    string,
+    { rules: Set<string>; metadata: NormalizedPermission }
+  >,
+): PermissionGroup[] {
+  return [...permissionGroups.entries()]
+    .map(([name, group]) => {
+      return {
+        name,
+        description: group.metadata.description,
+        rules: sanitizeAndSortRules([...group.rules]),
+      };
+    })
+    .filter((group) => {
+      return group.rules.length > 0;
+    })
+    .sort((a, b) => {
+      return a.name.localeCompare(b.name);
+    });
+}
+
+function uniquePermissionsByName(
+  permissions: readonly PermissionGroup[],
+): PermissionGroup[] {
+  const byName = new Map<string, PermissionGroup>();
+  for (const permission of permissions) {
+    if (!byName.has(permission.name)) {
+      byName.set(permission.name, permission);
+    }
+  }
+  return [...byName.values()].sort((a, b) => {
+    return a.name.localeCompare(b.name);
+  });
+}
+
 function buildGroups(
   spec: OpenApiSpec,
   oauthCategoryData: OAuthCategoryData,
@@ -1049,15 +1155,29 @@ function buildGroups(
     throw new Error("OpenAPI spec has no 'paths'");
   }
 
-  const permissionGroups = new Map<
+  const connectorPermissionGroups = new Map<
     string,
     { rules: Set<string>; metadata: NormalizedPermission }
   >();
+  const preserveAuthorizationPermissionGroups = new Map<
+    string,
+    { rules: Set<string>; metadata: NormalizedPermission }
+  >();
+  const permissionGroupsByAuthBehavior = {
+    connector: connectorPermissionGroups,
+    preserveAuthorization: preserveAuthorizationPermissionGroups,
+  };
+  const supplementalOperationsByKey = buildSupplementalOperationIndex();
+  const matchedSupplementalOpenApiKeys = new Set<string>();
+  const openApiOperationKeys = new Set<string>();
   const unscoredOwnerExamples: string[] = [];
   const stats: BuildStats = {
     totalOperations: 0,
     operationsWithApiTokenGroup: 0,
     operationsWithCfPermissionsRequired: 0,
+    openApiTokenGroupMappedOperations: 0,
+    supplementalOpenApiMappedOperations: 0,
+    nonOpenApiSupplementalOperations: 0,
     mappedOperations: 0,
     unmappedOperations: 0,
     ambiguousOperations: 0,
@@ -1086,12 +1206,30 @@ function buildGroups(
       if (!isRecord(rawOperation)) continue;
 
       stats.totalOperations += 1;
+      const operationKey = openApiOperationKey(methodLower, apiPath);
+      openApiOperationKeys.add(operationKey);
       if (hasCfPermissionsRequired(rawOperation)) {
         stats.operationsWithCfPermissionsRequired += 1;
       }
 
       const officialGroups = stringArray(rawOperation["x-api-token-group"]);
       if (officialGroups.length === 0) {
+        const supplemental = supplementalOperationsByKey.get(operationKey);
+        if (supplemental) {
+          if (supplemental.openApi !== "present") {
+            throw new Error(
+              `Cloudflare supplemental operation is marked absent but exists in OpenAPI: ${operationKey}`,
+            );
+          }
+          addSupplementalOperationRule(
+            supplemental,
+            permissionGroupsByAuthBehavior,
+          );
+          matchedSupplementalOpenApiKeys.add(operationKey);
+          stats.supplementalOpenApiMappedOperations += 1;
+          stats.mappedOperations += 1;
+          continue;
+        }
         stats.unmappedOperations += 1;
         continue;
       }
@@ -1148,27 +1286,52 @@ function buildGroups(
         stats.operationsWithPrioritizedReadGroups += 1;
         stats.readGroupsDroppedByPriority += droppedReadGroupCount;
       }
+      stats.openApiTokenGroupMappedOperations += 1;
       stats.mappedOperations += 1;
 
       const rule = `${methodLower.toUpperCase()} ${apiPathToRulePath(apiPath)}`;
-      getPermissionGroup(permissionGroups, selectedGroup).rules.add(rule);
+      getPermissionGroup(connectorPermissionGroups, selectedGroup).rules.add(
+        rule,
+      );
     }
   }
 
-  const permissions = [...permissionGroups.entries()]
-    .map(([name, group]) => {
-      return {
-        name,
-        description: group.metadata.description,
-        rules: sanitizeAndSortRules([...group.rules]),
-      };
-    })
-    .filter((group) => {
-      return group.rules.length > 0;
-    })
-    .sort((a, b) => {
-      return a.name.localeCompare(b.name);
-    });
+  for (const operation of CLOUDFLARE_SUPPLEMENTAL_OPERATIONS) {
+    const key = supplementalOperationKey(operation);
+    const existsInOpenApi = openApiOperationKeys.has(key);
+    if (operation.openApi === "present") {
+      if (!existsInOpenApi) {
+        throw new Error(
+          `Cloudflare supplemental operation is marked present but missing from OpenAPI: ${key}`,
+        );
+      }
+      if (!matchedSupplementalOpenApiKeys.has(key)) {
+        throw new Error(
+          `Cloudflare supplemental operation is marked present but was not needed: ${key}`,
+        );
+      }
+      continue;
+    }
+
+    if (existsInOpenApi) {
+      throw new Error(
+        `Cloudflare supplemental operation is marked absent but exists in OpenAPI: ${key}`,
+      );
+    }
+    addSupplementalOperationRule(operation, permissionGroupsByAuthBehavior);
+    stats.nonOpenApiSupplementalOperations += 1;
+  }
+
+  const connectorPermissions = permissionGroupsToPermissions(
+    connectorPermissionGroups,
+  );
+  const preserveAuthorizationPermissions = permissionGroupsToPermissions(
+    preserveAuthorizationPermissionGroups,
+  );
+  const allPermissions = uniquePermissionsByName([
+    ...connectorPermissions,
+    ...preserveAuthorizationPermissions,
+  ]);
 
   if (unscoredOwnerExamples.length > 0) {
     throw new Error(
@@ -1183,7 +1346,7 @@ function buildGroups(
 
   const categories: Record<string, string> = {};
   const missingCategoryPermissions: string[] = [];
-  for (const permission of permissions) {
+  for (const permission of allPermissions) {
     const category =
       oauthCategoryData.categoriesByPermission.get(permission.name) ??
       API_TOKEN_ONLY_CATEGORY_OVERRIDES.get(permission.name);
@@ -1213,7 +1376,7 @@ function buildGroups(
     return usedCategories.has(category);
   });
 
-  const defaultAllowed = permissions
+  const defaultAllowed = allPermissions
     .filter((permission) => {
       return permissionAction(permission.name) === "read";
     })
@@ -1221,11 +1384,23 @@ function buildGroups(
       return permission.name;
     });
 
-  assertUniquePermissionRules(permissions);
+  assertUniquePermissionRules([
+    ...connectorPermissions,
+    ...preserveAuthorizationPermissions,
+  ]);
 
-  stats.permissionCount = permissions.length;
+  stats.permissionCount =
+    connectorPermissions.length + preserveAuthorizationPermissions.length;
 
-  return { permissions, categories, categoryOrder, defaultAllowed, stats };
+  return {
+    connectorPermissions,
+    preserveAuthorizationPermissions,
+    allPermissions,
+    categories,
+    categoryOrder,
+    defaultAllowed,
+    stats,
+  };
 }
 
 function renderStats(stats: BuildStats): string[] {
@@ -1234,6 +1409,9 @@ function renderStats(stats: BuildStats): string[] {
     `  totalOperations: ${stats.totalOperations},`,
     `  operationsWithApiTokenGroup: ${stats.operationsWithApiTokenGroup},`,
     `  operationsWithCfPermissionsRequired: ${stats.operationsWithCfPermissionsRequired},`,
+    `  openApiTokenGroupMappedOperations: ${stats.openApiTokenGroupMappedOperations},`,
+    `  supplementalOpenApiMappedOperations: ${stats.supplementalOpenApiMappedOperations},`,
+    `  nonOpenApiSupplementalOperations: ${stats.nonOpenApiSupplementalOperations},`,
     `  mappedOperations: ${stats.mappedOperations},`,
     `  unmappedOperations: ${stats.unmappedOperations},`,
     `  ambiguousOperations: ${stats.ambiguousOperations},`,
@@ -1254,6 +1432,7 @@ function generateTypeScript(result: BuildResult): string {
     "// Auto-generated from Cloudflare's official OpenAPI spec and OAuth scopes.",
     `// Source: ${CLOUDFLARE_OPENAPI_URL}`,
     `// Source: ${CLOUDFLARE_OAUTH_SCOPES_URL}`,
+    "// Supplemental sources are listed in cloudflare-supplemental.ts.",
     "// Update sources: cd turbo && pnpm -F @vm0/firewalls-generator update-specs:cloudflare",
     "// Regenerate: cd turbo && pnpm -F @vm0/firewalls-generator generate:cloudflare",
     "//",
@@ -1278,10 +1457,19 @@ function generateTypeScript(result: BuildResult): string {
     "      permissions: [",
   ];
 
-  lines.push(...renderPermissions(result.permissions));
+  lines.push(...renderPermissions(result.connectorPermissions));
 
   lines.push("      ],");
   lines.push("    },");
+  if (result.preserveAuthorizationPermissions.length > 0) {
+    lines.push("    {");
+    lines.push(`      base: "${CLOUDFLARE_API_BASE}",`);
+    lines.push("      auth: {},");
+    lines.push("      permissions: [");
+    lines.push(...renderPermissions(result.preserveAuthorizationPermissions));
+    lines.push("      ],");
+    lines.push("    },");
+  }
   lines.push("  ],");
   lines.push("} as const satisfies FirewallConfig;");
   lines.push("");
@@ -1324,7 +1512,10 @@ export async function generate(): Promise<void> {
   const result = buildGroups(spec, oauthCategoryData);
   const ts = generateTypeScript(result);
 
-  logStats(result.permissions);
+  logStats([
+    ...result.connectorPermissions,
+    ...result.preserveAuthorizationPermissions,
+  ]);
   console.error(
     `  ${result.stats.mappedOperations}/${result.stats.totalOperations} operations mapped`,
   );


### PR DESCRIPTION
## Summary

Closes #19153.

- add an explicit Cloudflare supplemental operation catalog for Wrangler/Cloudflare upload and tail endpoints missing usable OpenAPI token-group metadata
- split Cloudflare firewall generation into the normal connector-auth API entry and a same-origin `auth: {}` upload API entry for provider-issued temporary JWT endpoints
- regenerate the Python built-in Cloudflare firewall chunks
- add TypeScript and mitm-addon regression coverage for Pages direct upload and Workers static assets upload auth behavior

## Notes

This PR does not infer permissions for every Cloudflare OpenAPI operation that lacks `x-api-token-group`. The generator now reports supplemental coverage separately; the cached OpenAPI still has 493 operations without token-group metadata after the two reviewed OpenAPI-present supplemental mappings. Those are left unmapped instead of guessed from method/path.

## Tests

- `pnpm -F @vm0/firewalls-generator check-types`
- `pnpm -F @vm0/firewalls-generator generate:cloudflare`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/connectors exec vitest run src/__tests__/firewalls/cloudflare.test.ts`
- `python3 -m ruff check . && python3 -m ruff format --check .` in `crates/runner/mitm-addon`
- `python3 -m basedpyright -p .` in `crates/runner/mitm-addon`
- `python3 -m pytest tests/test_builtin_firewalls_catalog.py tests/test_compiled_firewall_cross_firewall_precedence.py tests/test_firewall_auth.py -v` in `crates/runner/mitm-addon`

`git commit` pre-commit was bypassed after these focused checks because full-repo `knip --cache` failed on unrelated existing unused exports in `apps/platform/src/views/zero-page/components/settings/permission-policy-toggle.tsx`.
