### PR TITLE
fix: preserve computer use host order

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/computer-use-hosts.ts
+++ b/turbo/apps/platform/src/signals/zero-page/computer-use-hosts.ts
@@ -73,15 +73,9 @@ export function visibleComputerUseHosts<Host extends SelectableComputerUseHost>(
   selectedHostId: string | null | undefined,
 ): Host[] {
   const selected = selectedComputerUseHostId(hosts, selectedHostId);
-  const selectedHost = selected
-    ? hosts.find((host) => {
-        return host.id === selected;
-      })
-    : undefined;
-  const onlineHosts = hosts.filter((host) => {
-    return host.status === "online" && host.id !== selected;
+  return hosts.filter((host) => {
+    return host.status === "online" || host.id === selected;
   });
-  return selectedHost ? [selectedHost, ...onlineHosts] : onlineHosts;
 }
 
 export const computerUseHosts$ = computed(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -4155,12 +4155,25 @@ describe("chat lifecycle", () => {
   it("shows online computers in the chat composer", async () => {
     const user = userEvent.setup({ delay: null });
     const threadId = "computer-use-selection";
-    mockChatLifecycle(context, { threadId });
+    const lifecycle = mockChatLifecycle(context, {
+      threadId,
+      computerUseHostId: "22222222-2222-4222-8222-222222222222",
+    });
+    lifecycle.setThreadList([
+      {
+        id: threadId,
+        title: null,
+        agent: { id: AGENT_ID, avatarUrl: null },
+        createdAt: "2026-03-10T00:00:00Z",
+        updatedAt: "2026-03-10T00:00:00Z",
+        running: false,
+      },
+    ]);
     context.mocks.api(zeroComputerUseHostsContract.list, ({ respond }) => {
       return respond(200, {
         hosts: [
           {
-            id: "host-online",
+            id: "11111111-1111-4111-8111-111111111111",
             displayName: "Studio Mac",
             appVersion: "1.0.0",
             osVersion: "macOS 15.0",
@@ -4171,7 +4184,7 @@ describe("chat lifecycle", () => {
             createdAt: "2026-06-10T11:00:00Z",
           },
           {
-            id: "host-online-2",
+            id: "22222222-2222-4222-8222-222222222222",
             displayName: "Office Mac",
             appVersion: "1.0.0",
             osVersion: "macOS 15.0",
@@ -4182,7 +4195,7 @@ describe("chat lifecycle", () => {
             createdAt: "2026-06-10T11:01:00Z",
           },
           {
-            id: "host-offline",
+            id: "33333333-3333-4333-8333-333333333333",
             displayName: "Offline Desktop",
             appVersion: "1.0.0",
             osVersion: "Windows 11",
@@ -4212,9 +4225,20 @@ describe("chat lifecycle", () => {
         screen.getByRole("switch", { name: "Connect Studio Mac" }),
       ).toHaveAttribute("aria-checked", "false");
       expect(
-        screen.getByRole("switch", { name: "Connect Office Mac" }),
-      ).toHaveAttribute("aria-checked", "false");
+        screen.getByRole("switch", { name: "Disconnect Office Mac" }),
+      ).toHaveAttribute("aria-checked", "true");
     });
+
+    const hostsGroup = screen.getByRole("group", {
+      name: "Computer Use hosts",
+    });
+    expect(
+      within(hostsGroup)
+        .getAllByRole("switch")
+        .map((item) => {
+          return item.getAttribute("aria-label");
+        }),
+    ).toStrictEqual(["Connect Studio Mac", "Disconnect Office Mac"]);
   });
 
   it("opens the Computer Use download dialog from the chat composer", async () => {


### PR DESCRIPTION
## Summary
- Preserve the backend-provided Computer Use host order when rendering selectable hosts.
- Keep selected offline hosts visible without moving selected hosts to the top.
- Add chat composer coverage for a saved second-host selection staying in place.

## Verification
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx