### PR TITLE
fix: guard post-result cleanup deadlines

### DIFF
--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -54,7 +54,7 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::process::Stdio;
 use std::time::{Duration, Instant};
-use termination::{PostResultCleanupState, TerminationReason, TerminationState};
+use termination::{PostResultCleanupState, TerminationReason, TerminationState, deadline_after};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 use tokio::sync::oneshot;
 
@@ -664,10 +664,8 @@ async fn execute_cli_inner(
                                     let now = tokio::time::Instant::now();
                                     let cleanup = PostResultCleanupState::arm(
                                         now,
-                                        Duration::from_secs(
-                                            env::post_result_sigterm_grace_secs(),
-                                        ),
-                                        Duration::from_secs(env::post_result_total_cap_secs()),
+                                        env::post_result_sigterm_grace(),
+                                        env::post_result_total_cap(),
                                     );
                                     if let Some(next_deadline) = cleanup.next_deadline() {
                                         termination_runtime.state =
@@ -715,7 +713,7 @@ async fn execute_cli_inner(
                             {
                                 let next_deadline = cleanup.record_meaningful_event(
                                     tokio::time::Instant::now(),
-                                    Duration::from_secs(env::post_result_sigterm_grace_secs()),
+                                    env::post_result_sigterm_grace(),
                                 );
                                 if let Some(next_deadline) = next_deadline {
                                     termination_deadline.as_mut().reset(next_deadline);
@@ -797,9 +795,7 @@ async fn execute_cli_inner(
                                 .flatten();
                         let grace = cleanup_timeout
                             .map(|timeout| timeout.elapsed)
-                            .unwrap_or_else(|| {
-                                Duration::from_secs(env::post_result_sigterm_grace_secs())
-                            });
+                            .unwrap_or_else(env::post_result_sigterm_grace);
                         if let Some(pid) = termination_runtime.pgid {
                             if reason == TerminationReason::PostResult {
                                 if let Some(timeout) = cleanup_timeout {
@@ -846,13 +842,13 @@ async fn execute_cli_inner(
                             }
                         }
                         termination_runtime.state = TerminationState::SigkillPending { reason };
-                        termination_deadline.as_mut().reset(
-                            tokio::time::Instant::now()
-                                + Duration::from_secs(env::post_result_sigkill_grace_secs()),
-                        );
+                        termination_deadline.as_mut().reset(deadline_after(
+                            tokio::time::Instant::now(),
+                            env::post_result_sigkill_grace(),
+                        ));
                     }
                     TerminationState::SigkillPending { reason } => {
-                        let grace = Duration::from_secs(env::post_result_sigkill_grace_secs());
+                        let grace = env::post_result_sigkill_grace();
                         let now = tokio::time::Instant::now();
                         if let Some(pid) = termination_runtime.pgid {
                             log_warn!(
@@ -1187,7 +1183,7 @@ impl CliTerminationRuntime {
         post_result_cleanup: &mut Option<PostResultCleanupState>,
         mut termination_deadline: std::pin::Pin<&mut tokio::time::Sleep>,
     ) {
-        let grace = Duration::from_secs(env::post_result_sigkill_grace_secs());
+        let grace = env::post_result_sigkill_grace();
         record_cli_termination_signal(
             &mut self.diagnostic,
             reason,
@@ -1203,7 +1199,7 @@ impl CliTerminationRuntime {
         self.state = TerminationState::SigkillPending { reason };
         termination_deadline
             .as_mut()
-            .reset(tokio::time::Instant::now() + grace);
+            .reset(deadline_after(tokio::time::Instant::now(), grace));
     }
 }
 

--- a/crates/guest-agent/src/cli/termination.rs
+++ b/crates/guest-agent/src/cli/termination.rs
@@ -107,13 +107,17 @@ impl PostResultCleanupTrigger {
     }
 }
 
+pub(super) fn deadline_after(now: Instant, duration: Duration) -> Instant {
+    now.checked_add(duration).unwrap_or(now)
+}
+
 impl PostResultCleanupState {
     pub(super) fn arm(now: Instant, quiet: Duration, total_cap: Duration) -> Self {
         Self {
             started_at: now,
             last_meaningful_event_at: now,
-            quiet_deadline: now + quiet,
-            total_cap_deadline: now + total_cap,
+            quiet_deadline: deadline_after(now, quiet),
+            total_cap_deadline: deadline_after(now, total_cap),
             meaningful_event_count: 0,
             signal_sent: false,
         }
@@ -135,7 +139,7 @@ impl PostResultCleanupState {
             return None;
         }
         self.last_meaningful_event_at = now;
-        self.quiet_deadline = now + quiet;
+        self.quiet_deadline = deadline_after(now, quiet);
         self.meaningful_event_count = self.meaningful_event_count.saturating_add(1);
         self.next_deadline()
     }
@@ -247,6 +251,14 @@ mod tests {
     }
 
     #[test]
+    fn post_result_cleanup_arm_uses_immediate_deadline_on_overflow() {
+        let now = Instant::now();
+        let cleanup = PostResultCleanupState::arm(now, Duration::MAX, Duration::MAX);
+
+        assert_eq!(cleanup.next_deadline(), Some(now));
+    }
+
+    #[test]
     fn post_result_cleanup_meaningful_event_refreshes_quiet_deadline_only() {
         let now = Instant::now();
         let mut cleanup =
@@ -271,6 +283,19 @@ mod tests {
                 quiet_for: Duration::from_secs(2),
                 meaningful_event_count: 1,
             })
+        );
+    }
+
+    #[test]
+    fn post_result_cleanup_meaningful_event_uses_immediate_deadline_on_overflow() {
+        let now = Instant::now();
+        let mut cleanup =
+            PostResultCleanupState::arm(now, Duration::from_secs(10), Duration::from_secs(20));
+        let event_at = now + Duration::from_secs(1);
+
+        assert_eq!(
+            cleanup.record_meaningful_event(event_at, Duration::MAX),
+            Some(event_at)
         );
     }
 

--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
+use std::time::Duration;
 
 use api_contracts::generated::types::runners::storage::ArtifactEntryMissingRootPolicy;
 
@@ -14,6 +15,7 @@ const LOG_TAG: &str = "sandbox:guest-agent";
 const USER_ENV_FILE_ENV_KEY: &str = guest_contracts::env::USER_ENV_FILE_ENV;
 const USER_ENV_PRIVATE_DIR_NAME: &str = "user-env";
 const USER_ENV_FILENAME: &str = "env.json";
+const POST_RESULT_CLEANUP_MAX_SECS: u64 = 60 * 60;
 
 fn env_or_empty(name: &str) -> String {
     std::env::var(name).unwrap_or_default()
@@ -168,6 +170,43 @@ fn u64_env_or(name: &str, default: u64) -> u64 {
     }
 }
 
+/// Read an optional bounded seconds env var as `Duration`, falling back to
+/// `default_secs` when unset, unparseable, or outside the supported range.
+fn bounded_duration_secs_env_or(name: &str, default_secs: u64, max_secs: u64) -> Duration {
+    match std::env::var(name) {
+        Ok(v) => bounded_duration_secs_value_or(name, Some(&v), default_secs, max_secs),
+        Err(_) => Duration::from_secs(default_secs),
+    }
+}
+
+fn bounded_duration_secs_value_or(
+    name: &str,
+    value: Option<&str>,
+    default_secs: u64,
+    max_secs: u64,
+) -> Duration {
+    match value {
+        Some(v) => match v.parse::<u64>() {
+            Ok(secs) if secs <= max_secs => Duration::from_secs(secs),
+            Ok(secs) => {
+                log_warn!(
+                    LOG_TAG,
+                    "{name}={secs}s exceeds maximum {max_secs}s, using default {default_secs}s"
+                );
+                Duration::from_secs(default_secs)
+            }
+            Err(_) => {
+                log_warn!(
+                    LOG_TAG,
+                    "{name}={v:?} is not a valid u64, using default {default_secs}s"
+                );
+                Duration::from_secs(default_secs)
+            }
+        },
+        None => Duration::from_secs(default_secs),
+    }
+}
+
 /// Workaround for Claude Code bug: WebSearch/WebFetch can hang indefinitely.
 /// See: https://github.com/anthropics/claude-code/issues/11650
 static STUCK_TOOL_TIMEOUT: LazyLock<u64> = LazyLock::new(|| {
@@ -181,28 +220,31 @@ static STUCK_TOOL_TIMEOUT: LazyLock<u64> = LazyLock::new(|| {
 /// Shortened in integration tests via env override so runs converge
 /// within a test-sized window instead of the prod default.
 /// See: https://github.com/vm0-ai/vm0/issues/10879
-static POST_RESULT_SIGTERM_GRACE: LazyLock<u64> = LazyLock::new(|| {
-    u64_env_or(
+static POST_RESULT_SIGTERM_GRACE: LazyLock<Duration> = LazyLock::new(|| {
+    bounded_duration_secs_env_or(
         guest_contracts::env::POST_RESULT_SIGTERM_GRACE_SECS_ENV,
         constants::POST_RESULT_SIGTERM_GRACE_SECS,
+        POST_RESULT_CLEANUP_MAX_SECS,
     )
 });
 
 /// Absolute post-result cap. Unlike the quiet grace, this is fixed from the
 /// terminal result time and does not refresh on later stdout events.
-static POST_RESULT_TOTAL_CAP: LazyLock<u64> = LazyLock::new(|| {
-    u64_env_or(
+static POST_RESULT_TOTAL_CAP: LazyLock<Duration> = LazyLock::new(|| {
+    bounded_duration_secs_env_or(
         guest_contracts::env::POST_RESULT_TOTAL_CAP_SECS_ENV,
         constants::POST_RESULT_TOTAL_CAP_SECS,
+        POST_RESULT_CLEANUP_MAX_SECS,
     )
 });
 
 /// Follow-up grace after SIGTERM before escalating to SIGKILL. Same
 /// override rationale as `POST_RESULT_SIGTERM_GRACE`.
-static POST_RESULT_SIGKILL_GRACE: LazyLock<u64> = LazyLock::new(|| {
-    u64_env_or(
+static POST_RESULT_SIGKILL_GRACE: LazyLock<Duration> = LazyLock::new(|| {
+    bounded_duration_secs_env_or(
         guest_contracts::env::POST_RESULT_SIGKILL_GRACE_SECS_ENV,
         constants::POST_RESULT_SIGKILL_GRACE_SECS,
+        POST_RESULT_CLEANUP_MAX_SECS,
     )
 });
 
@@ -526,24 +568,24 @@ pub fn stuck_tool_timeout_secs() -> u64 {
 /// Grace period before SIGTERM after `type=result`, from
 /// `VM0_POST_RESULT_SIGTERM_GRACE_SECS`.
 ///
-/// Unset or unparseable values use the compiled default; unparseable values
-/// also log a warning.
-pub fn post_result_sigterm_grace_secs() -> u64 {
+/// Unset, unparseable, or out-of-range values use the compiled default;
+/// invalid values also log a warning.
+pub fn post_result_sigterm_grace() -> Duration {
     *POST_RESULT_SIGTERM_GRACE
 }
 /// Absolute cap after `type=result`, from `VM0_POST_RESULT_TOTAL_CAP_SECS`.
 ///
-/// Unset or unparseable values use the compiled default; unparseable values
-/// also log a warning.
-pub fn post_result_total_cap_secs() -> u64 {
+/// Unset, unparseable, or out-of-range values use the compiled default;
+/// invalid values also log a warning.
+pub fn post_result_total_cap() -> Duration {
     *POST_RESULT_TOTAL_CAP
 }
 /// Grace period before SIGKILL after SIGTERM, from
 /// `VM0_POST_RESULT_SIGKILL_GRACE_SECS`.
 ///
-/// Unset or unparseable values use the compiled default; unparseable values
-/// also log a warning.
-pub fn post_result_sigkill_grace_secs() -> u64 {
+/// Unset, unparseable, or out-of-range values use the compiled default;
+/// invalid values also log a warning.
+pub fn post_result_sigkill_grace() -> Duration {
     *POST_RESULT_SIGKILL_GRACE
 }
 
@@ -559,6 +601,9 @@ pub fn has_api() -> bool {
 mod tests {
     use super::*;
 
+    const TEST_DEFAULT_SECS: u64 = 10;
+    const TEST_MAX_SECS: u64 = 60;
+
     fn write_user_env_fixture(json: &str) -> (tempfile::TempDir, std::path::PathBuf) {
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path().join(USER_ENV_PRIVATE_DIR_NAME);
@@ -566,6 +611,66 @@ mod tests {
         let path = dir.join(USER_ENV_FILENAME);
         std::fs::write(&path, json).unwrap();
         (tmp, path)
+    }
+
+    #[test]
+    fn bounded_duration_secs_value_defaults_when_unset() {
+        assert_eq!(
+            bounded_duration_secs_value_or("TEST_TIMEOUT", None, TEST_DEFAULT_SECS, TEST_MAX_SECS),
+            Duration::from_secs(TEST_DEFAULT_SECS)
+        );
+    }
+
+    #[test]
+    fn bounded_duration_secs_value_defaults_when_invalid() {
+        assert_eq!(
+            bounded_duration_secs_value_or(
+                "TEST_TIMEOUT",
+                Some("not-a-number"),
+                TEST_DEFAULT_SECS,
+                TEST_MAX_SECS,
+            ),
+            Duration::from_secs(TEST_DEFAULT_SECS)
+        );
+    }
+
+    #[test]
+    fn bounded_duration_secs_value_defaults_when_above_max() {
+        assert_eq!(
+            bounded_duration_secs_value_or(
+                "TEST_TIMEOUT",
+                Some("61"),
+                TEST_DEFAULT_SECS,
+                TEST_MAX_SECS,
+            ),
+            Duration::from_secs(TEST_DEFAULT_SECS)
+        );
+    }
+
+    #[test]
+    fn bounded_duration_secs_value_accepts_zero() {
+        assert_eq!(
+            bounded_duration_secs_value_or(
+                "TEST_TIMEOUT",
+                Some("0"),
+                TEST_DEFAULT_SECS,
+                TEST_MAX_SECS,
+            ),
+            Duration::ZERO
+        );
+    }
+
+    #[test]
+    fn bounded_duration_secs_value_accepts_value_at_max() {
+        assert_eq!(
+            bounded_duration_secs_value_or(
+                "TEST_TIMEOUT",
+                Some("60"),
+                TEST_DEFAULT_SECS,
+                TEST_MAX_SECS,
+            ),
+            Duration::from_secs(TEST_MAX_SECS)
+        );
     }
 
     #[test]

--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -133,24 +133,24 @@ pub const STUCK_TOOL_TIMEOUT_SECS_ENV: &str = "VM0_STUCK_TOOL_TIMEOUT_SECS";
 /// reports a final result.
 ///
 /// This is a tuning key: local execution may pass it through user env via
-/// [`GUEST_AGENT_TUNING_ENV_KEYS`]. The guest-agent parses the value as `u64`;
-/// unset or unparseable values use the compiled default.
+/// [`GUEST_AGENT_TUNING_ENV_KEYS`]. Unset, unparseable, or out-of-range values
+/// use the guest-agent's compiled default.
 pub const POST_RESULT_SIGTERM_GRACE_SECS_ENV: &str = "VM0_POST_RESULT_SIGTERM_GRACE_SECS";
 
 /// Guest-agent absolute cap in seconds before sending SIGTERM after the CLI
 /// reports a final result, regardless of later post-result stdout events.
 ///
 /// This is a tuning key: local execution may pass it through user env via
-/// [`GUEST_AGENT_TUNING_ENV_KEYS`]. The guest-agent parses the value as `u64`;
-/// unset or unparseable values use the compiled default.
+/// [`GUEST_AGENT_TUNING_ENV_KEYS`]. Unset, unparseable, or out-of-range values
+/// use the guest-agent's compiled default.
 pub const POST_RESULT_TOTAL_CAP_SECS_ENV: &str = "VM0_POST_RESULT_TOTAL_CAP_SECS";
 
 /// Guest-agent grace period in seconds before escalating from SIGTERM to
 /// SIGKILL after the CLI reports a final result.
 ///
 /// This is a tuning key: local execution may pass it through user env via
-/// [`GUEST_AGENT_TUNING_ENV_KEYS`]. The guest-agent parses the value as `u64`;
-/// unset or unparseable values use the compiled default.
+/// [`GUEST_AGENT_TUNING_ENV_KEYS`]. Unset, unparseable, or out-of-range values
+/// use the guest-agent's compiled default.
 pub const POST_RESULT_SIGKILL_GRACE_SECS_ENV: &str = "VM0_POST_RESULT_SIGKILL_GRACE_SECS";
 
 /// Test/debug bootstrap switch that makes the guest-agent use the mock Claude


### PR DESCRIPTION
## Summary

- Bound guest-agent post-result cleanup timeout env values to a one-hour maximum and default invalid/out-of-range values.
- Return `Duration` from post-result cleanup env accessors so call sites stop rebuilding durations from raw seconds.
- Use checked deadline construction for post-result cleanup and SIGKILL escalation deadlines.
- Update guest-contracts comments for the bounded timeout behavior.

Closes #19158

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p guest-agent post_result`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent env::tests`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p guest-contracts`
