### PR TITLE
fix(runner): avoid host archive validation in storage cache

### DIFF
--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -174,7 +174,6 @@ enum CachedArchive {
     Hit(Bytes),
     Missing,
     Empty,
-    Invalid { reason: String },
     OverSize { observed_size: u64 },
 }
 
@@ -702,9 +701,6 @@ async fn process_one(
         CachedArchive::Empty => {
             evict_empty_cache(target, &cache_dir).await?;
         }
-        CachedArchive::Invalid { reason } => {
-            evict_invalid_cache(target, &cache_dir, &reason).await?;
-        }
         CachedArchive::OverSize { observed_size } => {
             evict_oversized_cache(target, &cache_dir, observed_size).await?;
         }
@@ -809,20 +805,6 @@ async fn process_one(
             stage_write: None,
         });
     }
-    if let Err(reason) = validate_tar_gz_archive(bytes.clone()).await? {
-        warn!(
-            name = %target.name,
-            version = %target.version,
-            error = %reason,
-            "storage_cache: full download returned invalid archive, passthrough"
-        );
-        return Ok(ProcessedTarget {
-            outcome: TargetOutcome::SkippedInvalidDownload {
-                reason: "invalid-archive".to_string(),
-            },
-            stage_write: None,
-        });
-    }
     write_to_cache(&cache_dir, &bytes).await?;
     let guest_path = guest_archive_path(&target.name, &target.version);
     drop(writer);
@@ -841,9 +823,6 @@ async fn read_cache_entry(cache_dir: &Path, archive_path: &Path) -> RunnerResult
         Ok(metadata) if metadata.len() <= CACHE_MAX_SIZE => {
             match read_cached_archive(archive_path, CACHE_MAX_SIZE).await? {
                 DownloadBody::Complete(bytes) => {
-                    if let Err(reason) = validate_tar_gz_archive(bytes.clone()).await? {
-                        return Ok(CachedArchive::Invalid { reason });
-                    }
                     touch_mtime(cache_dir);
                     Ok(CachedArchive::Hit(bytes))
                 }
@@ -1090,28 +1069,6 @@ async fn read_cached_archive(path: &Path, max_size: u64) -> RunnerResult<Downloa
     Ok(DownloadBody::Complete(Bytes::from(bytes)))
 }
 
-async fn validate_tar_gz_archive(bytes: Bytes) -> RunnerResult<Result<(), String>> {
-    // Gzip/tar validation is synchronous CPU work; keep it off the async worker.
-    // The caller only passes bodies already capped by CACHE_MAX_SIZE.
-    tokio::task::spawn_blocking(move || validate_tar_gz_archive_sync(bytes))
-        .await
-        .map_err(|e| RunnerError::Internal(format!("join archive validation: {e}")))
-}
-
-fn validate_tar_gz_archive_sync(bytes: Bytes) -> Result<(), String> {
-    let decoder = flate2::read::GzDecoder::new(io::Cursor::new(bytes));
-    let mut archive = tar::Archive::new(decoder);
-    let entries = archive
-        .entries()
-        .map_err(|e| format!("read archive entries: {e}"))?;
-    for entry in entries {
-        let mut entry = entry.map_err(|e| format!("read archive entry: {e}"))?;
-        io::copy(&mut entry, &mut io::sink())
-            .map_err(|e| format!("read archive entry body: {e}"))?;
-    }
-    Ok(())
-}
-
 fn append_limited_chunk(
     bytes: &mut Vec<u8>,
     downloaded: &mut u64,
@@ -1148,28 +1105,6 @@ async fn evict_oversized_cache(
     {
         return Err(RunnerError::Internal(format!(
             "remove oversized cache {}: {e}",
-            cache_dir.display()
-        )));
-    }
-    Ok(())
-}
-
-async fn evict_invalid_cache(
-    target: &CacheTarget,
-    cache_dir: &Path,
-    reason: &str,
-) -> RunnerResult<()> {
-    warn!(
-        name = %target.name,
-        version = %target.version,
-        error = %reason,
-        "storage_cache: cached archive is invalid, evicting"
-    );
-    if let Err(e) = fs::remove_dir_all(cache_dir).await
-        && e.kind() != io::ErrorKind::NotFound
-    {
-        return Err(RunnerError::Internal(format!(
-            "remove invalid cache {}: {e}",
             cache_dir.display()
         )));
     }
@@ -2218,7 +2153,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn invalid_full_download_is_passthrough_without_cache_write() {
+    async fn non_tar_full_download_is_cached_as_opaque_bytes() {
         let temp = tempfile::tempdir().unwrap();
         let home = home_at(&temp);
         let sandbox = MockSandbox::new("test");
@@ -2241,7 +2176,7 @@ mod tests {
                 when.method(GET)
                     .path("/invalid-body.tar.gz")
                     .header_missing("range");
-                then.status(200).body(body);
+                then.status(200).body(body.clone());
             })
             .await;
 
@@ -2258,17 +2193,19 @@ mod tests {
         get.assert_async().await;
         assert_eq!(
             manifest.storages[0].archive_url.as_deref(),
-            Some(original.as_str())
+            Some(format!("file://{}", guest_archive_path(name, version)).as_str())
         );
-        assert!(
-            !home
-                .storage_cache_dir(name, version)
-                .join("archive.tar.gz")
-                .exists()
+        assert_eq!(
+            std::fs::read(home.storage_cache_dir(name, version).join("archive.tar.gz")).unwrap(),
+            body
         );
-        assert!(sandbox.write_file_calls().is_empty());
+        let writes = sandbox.write_file_calls();
+        assert_eq!(writes.len(), 1);
+        assert_eq!(writes[0].path, guest_archive_path(name, version));
+        assert_eq!(writes[0].content, body);
         let ops = telemetry.pending_ops_snapshot();
-        assert_storage_cache_skipped_invalid_download(&ops, "invalid-archive");
+        assert!(ops.iter().any(|(k, _, _)| k == "storage_cache_miss"));
+        assert_no_op(&ops, "storage_cache_skipped_invalid_download");
     }
 
     #[tokio::test]
@@ -2607,24 +2544,24 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn invalid_disk_hit_is_evicted_and_revalidated() {
+    async fn non_tar_disk_hit_is_staged_without_revalidation() {
         let temp = tempfile::tempdir().unwrap();
         let home = home_at(&temp);
         let sandbox = MockSandbox::new("test");
         let mut telemetry = new_telemetry();
         let server = MockServer::start_async().await;
-        let body = tarball_bytes();
+        let body = b"not a valid tar.gz".to_vec();
 
-        let name = "invalid-hit";
+        let name = "non-tar-hit";
         let version = "v1";
         let cache_dir = home.storage_cache_dir(name, version);
         std::fs::create_dir_all(&cache_dir).unwrap();
-        std::fs::write(cache_dir.join("archive.tar.gz"), b"not a valid tar.gz").unwrap();
+        std::fs::write(cache_dir.join("archive.tar.gz"), &body).unwrap();
 
         let probe = server
             .mock_async(|when, then| {
                 when.method(GET)
-                    .path("/invalid-revalidated.tar.gz")
+                    .path("/should-not-revalidate.tar.gz")
                     .header("range", "bytes=0-0");
                 then.status(206)
                     .header("content-range", format!("bytes 0-0/{}", body.len()))
@@ -2634,21 +2571,21 @@ mod tests {
         let get = server
             .mock_async(|when, then| {
                 when.method(GET)
-                    .path("/invalid-revalidated.tar.gz")
+                    .path("/should-not-revalidate.tar.gz")
                     .header_missing("range");
                 then.status(200).body(body.clone());
             })
             .await;
 
-        let url = server.url("/invalid-revalidated.tar.gz");
+        let url = server.url("/should-not-revalidate.tar.gz");
         let mut manifest = manifest_single_storage(url, name, version);
 
         populate_cache(&mut manifest, &sandbox, &home, &mut telemetry)
             .await
             .unwrap();
 
-        probe.assert_async().await;
-        get.assert_async().await;
+        probe.assert_calls_async(0).await;
+        get.assert_calls_async(0).await;
         assert_eq!(
             std::fs::read(home.storage_cache_dir(name, version).join("archive.tar.gz")).unwrap(),
             body
@@ -2657,14 +2594,19 @@ mod tests {
             manifest.storages[0].archive_url.as_deref(),
             Some(format!("file://{}", guest_archive_path(name, version)).as_str())
         );
+        let batches = sandbox.write_files_calls();
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].files.len(), 1);
+        assert_eq!(batches[0].files[0].path, guest_archive_path(name, version));
+        assert_eq!(batches[0].files[0].content, body);
         let ops = telemetry.pending_ops_snapshot();
         assert!(
-            ops.iter().any(|(k, _, _)| k == "storage_cache_miss"),
-            "expected revalidation miss in {ops:?}"
+            ops.iter().any(|(k, _, _)| k == "storage_cache_hit"),
+            "expected cache hit in {ops:?}"
         );
         assert!(
-            !ops.iter().any(|(k, _, _)| k == "storage_cache_hit"),
-            "invalid cache file must not be treated as a hit: {ops:?}"
+            !ops.iter().any(|(k, _, _)| k == "storage_cache_miss"),
+            "non-tar cache file must not be revalidated: {ops:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

- remove runner storage cache tar/gzip semantic validation on cache miss and hit
- keep compressed-byte probe, size limit, empty body, and size mismatch handling
- update storage cache tests so non-tar bytes are treated as opaque cacheable bodies and staged to guest-download

Fixes #19160

## Tests

- cargo test --manifest-path crates/Cargo.toml -p runner storage_cache::tests::non_tar_full_download_is_cached_as_opaque_bytes
- cargo test --manifest-path crates/Cargo.toml -p runner storage_cache::tests::non_tar_disk_hit_is_staged_without_revalidation
- cargo test --manifest-path crates/Cargo.toml -p runner storage_cache
- cargo fmt --all --check (from crates/)
- lefthook pre-commit: cargo fmt, cargo doc, cargo clippy
