### PR TITLE
fix: stream connector diagnostic response fallback

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -115,6 +115,7 @@ _CONNECTOR_DIAGNOSTIC_RESPONSE_REPLACED_IN_HEADERS = (
 _CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_BODY_SENT = "_connector_diagnostic_response_stream_body_sent"
 _CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_CALLBACK = "_connector_diagnostic_response_stream_callback"
 _CONNECTOR_DIAGNOSTIC_PROXY_ENTRY_LOGGED = "_connector_diagnostic_proxy_entry_logged"
+_EMPTY_RESPONSE_STREAM_CHUNKS: tuple[bytes, ...] = ()
 _GENERIC_AUTH_HEADER_NAMES = frozenset(
     (
         "authorization",
@@ -1235,11 +1236,11 @@ def _install_connector_diagnostic_response_stream(flow: http.HTTPFlow) -> bool:
         return False
     flow.metadata[_CONNECTOR_DIAGNOSTIC_RESPONSE_REPLACED_IN_HEADERS] = True
 
-    def stream_connector_diagnostic_response(chunk: bytes) -> bytes:
+    def stream_connector_diagnostic_response(chunk: bytes) -> bytes | tuple[bytes, ...]:
         if chunk:
-            return b""
+            return _EMPTY_RESPONSE_STREAM_CHUNKS
         if flow.metadata.get(_CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_BODY_SENT):
-            return b""
+            return _EMPTY_RESPONSE_STREAM_CHUNKS
         flow.metadata[_CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_BODY_SENT] = True
         return body
 

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1126,6 +1126,12 @@ def _maybe_replace_connector_diagnostic_response(
     if flow.response is None:
         return
     if flow.metadata.get(_CONNECTOR_DIAGNOSTIC_RESPONSE_REPLACED_IN_HEADERS):
+        flow.response.trailers = None
+        _log_connector_diagnostic_proxy_entry(
+            flow,
+            original_url=original_url,
+            upstream_status=flow.response.status_code,
+        )
         return
     if flow.response.status_code not in (
         _HTTP_STATUS_UNAUTHORIZED,
@@ -1228,11 +1234,6 @@ def _install_connector_diagnostic_response_stream(flow: http.HTTPFlow) -> bool:
     if body is None:
         return False
     flow.metadata[_CONNECTOR_DIAGNOSTIC_RESPONSE_REPLACED_IN_HEADERS] = True
-    _log_connector_diagnostic_proxy_entry(
-        flow,
-        original_url=original_url,
-        upstream_status=upstream_status,
-    )
 
     def stream_connector_diagnostic_response(chunk: bytes) -> bytes:
         if chunk:

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1169,6 +1169,10 @@ def _maybe_make_connector_diagnostic_error_response(
     *,
     original_url: str,
 ) -> None:
+    if flow.metadata.get(_CONNECTOR_DIAGNOSTIC_RESPONSE_REPLACED_IN_HEADERS):
+        if flow.response is not None:
+            flow.response.trailers = None
+        return
     if flow.metadata.get(metadata_keys.BROWSER_USER_AGENT) or _is_browser_passthrough_heuristic(
         flow
     ):

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -109,6 +109,12 @@ _CONNECTOR_DIAGNOSTIC_LOOKUP_DONE = "_connector_diagnostic_lookup_done"
 _CONNECTOR_DIAGNOSTIC_CANDIDATE = "_connector_diagnostic_candidate"
 _CONNECTOR_DIAGNOSTIC_AUTH_HEADER_NAMES = "_connector_diagnostic_auth_header_names"
 _CONNECTOR_DIAGNOSTIC_AUTH_QUERY_PARAM_NAMES = "_connector_diagnostic_auth_query_param_names"
+_CONNECTOR_DIAGNOSTIC_RESPONSE_REPLACED_IN_HEADERS = (
+    "_connector_diagnostic_response_replaced_in_headers"
+)
+_CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_BODY_SENT = "_connector_diagnostic_response_stream_body_sent"
+_CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_CALLBACK = "_connector_diagnostic_response_stream_callback"
+_CONNECTOR_DIAGNOSTIC_PROXY_ENTRY_LOGGED = "_connector_diagnostic_proxy_entry_logged"
 _GENERIC_AUTH_HEADER_NAMES = frozenset(
     (
         "authorization",
@@ -1037,19 +1043,23 @@ def _replace_connector_diagnostic_response_content(
     candidate: builtin_connector_diagnostics.ConnectorDiagnosticCandidate,
     *,
     upstream_status: int,
-) -> None:
+) -> bytes | None:
     if flow.response is None:
-        return
+        return None
     flow.metadata.pop(metadata_keys.STREAM_BUFFER, None)
     flow.metadata.pop(metadata_keys.STREAM_BUFFER_STATE, None)
-    for header in ("content-encoding", "transfer-encoding"):
+    for header in ("content-encoding", "content-length", "transfer-encoding"):
         if header in flow.response.headers:
             del flow.response.headers[header]
-    flow.response.headers["Content-Type"] = "application/json"
-    flow.response.content = _connector_diagnostic_response_body(
+    flow.response.trailers = None
+    body = _connector_diagnostic_response_body(
         candidate,
         upstream_status=upstream_status,
     )
+    flow.response.content = body
+    flow.response.headers["Content-Type"] = "application/json"
+    flow.response.headers["Content-Length"] = str(len(body))
+    return body
 
 
 def _log_connector_diagnostic_proxy_entry(
@@ -1058,6 +1068,8 @@ def _log_connector_diagnostic_proxy_entry(
     original_url: str,
     upstream_status: int,
 ) -> None:
+    if flow.metadata.get(_CONNECTOR_DIAGNOSTIC_PROXY_ENTRY_LOGGED):
+        return
     candidate = _connector_diagnostic_candidate_from_flow(flow)
     if candidate is None:
         return
@@ -1072,6 +1084,7 @@ def _log_connector_diagnostic_proxy_entry(
         upstream_status=upstream_status,
         url=original_url,
     )
+    flow.metadata[_CONNECTOR_DIAGNOSTIC_PROXY_ENTRY_LOGGED] = True
 
 
 def _maybe_make_connector_diagnostic_local_response(
@@ -1111,6 +1124,8 @@ def _maybe_replace_connector_diagnostic_response(
     original_url: str,
 ) -> None:
     if flow.response is None:
+        return
+    if flow.metadata.get(_CONNECTOR_DIAGNOSTIC_RESPONSE_REPLACED_IN_HEADERS):
         return
     if flow.response.status_code not in (
         _HTTP_STATUS_UNAUTHORIZED,
@@ -1169,7 +1184,7 @@ def _maybe_make_connector_diagnostic_error_response(
     )
 
 
-def _should_buffer_connector_diagnostic_response(flow: http.HTTPFlow) -> bool:
+def _should_stream_connector_diagnostic_response(flow: http.HTTPFlow) -> bool:
     if flow.response is None:
         return False
     if flow.response.status_code not in (
@@ -1189,6 +1204,49 @@ def _should_buffer_connector_diagnostic_response(flow: http.HTTPFlow) -> bool:
     if candidate is None:
         return False
     return not _request_has_connector_auth_material(flow, candidate, original_url)
+
+
+def _install_connector_diagnostic_response_stream(flow: http.HTTPFlow) -> bool:
+    if flow.response is None:
+        return False
+    original_url = flow.metadata.get(metadata_keys.ORIGINAL_URL)
+    if not isinstance(original_url, str):
+        return False
+    candidate = _resolve_connector_diagnostic_candidate(flow, original_url=original_url)
+    if candidate is None:
+        return False
+    if _request_has_connector_auth_material(flow, candidate, original_url):
+        return False
+
+    upstream_status = flow.response.status_code
+    _set_connector_diagnostic_failure_metadata(flow, candidate)
+    body = _replace_connector_diagnostic_response_content(
+        flow,
+        candidate,
+        upstream_status=upstream_status,
+    )
+    if body is None:
+        return False
+    flow.metadata[_CONNECTOR_DIAGNOSTIC_RESPONSE_REPLACED_IN_HEADERS] = True
+    _log_connector_diagnostic_proxy_entry(
+        flow,
+        original_url=original_url,
+        upstream_status=upstream_status,
+    )
+
+    def stream_connector_diagnostic_response(chunk: bytes) -> bytes:
+        if chunk:
+            return b""
+        if flow.metadata.get(_CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_BODY_SENT):
+            return b""
+        flow.metadata[_CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_BODY_SENT] = True
+        return body
+
+    flow.response.stream = stream_connector_diagnostic_response
+    flow.metadata[_CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_CALLBACK] = (
+        stream_connector_diagnostic_response
+    )
+    return True
 
 
 def _network_log_target(flow: http.HTTPFlow, original_url: str) -> tuple[str, str, int]:
@@ -1776,7 +1834,8 @@ def _schedule_model_websocket_message_trim(flow: http.HTTPFlow) -> None:
 
 def responseheaders(flow: http.HTTPFlow) -> None:
     """Install response stream buffering and incremental body parsers."""
-    if _should_buffer_connector_diagnostic_response(flow):
+    should_stream_diagnostic = _should_stream_connector_diagnostic_response(flow)
+    if should_stream_diagnostic and _install_connector_diagnostic_response_stream(flow):
         return
     response_streaming.configure_response_stream(flow)
 
@@ -1878,10 +1937,20 @@ def _release_terminal_flow_state(
     flow.metadata.pop(_REQUEST_CLASSIFICATION, None)
     flow.metadata.pop(_FIREWALL_AUTH_APPLIED_IN_REQUESTHEADERS, None)
     request_streaming.release_request_stream_state(flow)
+    _release_connector_diagnostic_response_stream_state(flow)
     response_streaming.release_response_stream_state(flow)
     auth_base_forwarder.release_forward_request_admission_from_flow(flow)
     if release_tracking:
         _release_tracked_usage_flow(flow)
+
+
+def _release_connector_diagnostic_response_stream_state(flow: http.HTTPFlow) -> None:
+    stream_callback = flow.metadata.pop(_CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_CALLBACK, None)
+    flow.metadata.pop(_CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_BODY_SENT, None)
+    flow.metadata.pop(_CONNECTOR_DIAGNOSTIC_RESPONSE_REPLACED_IN_HEADERS, None)
+    flow.metadata.pop(_CONNECTOR_DIAGNOSTIC_PROXY_ENTRY_LOGGED, None)
+    if stream_callback is not None and flow.response and flow.response.stream is stream_callback:
+        flow.response.stream = False
 
 
 def _track_usage_flow(fn):

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -112,6 +112,7 @@ _CONNECTOR_DIAGNOSTIC_AUTH_QUERY_PARAM_NAMES = "_connector_diagnostic_auth_query
 _CONNECTOR_DIAGNOSTIC_RESPONSE_REPLACED_IN_HEADERS = (
     "_connector_diagnostic_response_replaced_in_headers"
 )
+_CONNECTOR_DIAGNOSTIC_RESPONSE_BODY = "_connector_diagnostic_response_body"
 _CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_BODY_SENT = "_connector_diagnostic_response_stream_body_sent"
 _CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_CALLBACK = "_connector_diagnostic_response_stream_callback"
 _CONNECTOR_DIAGNOSTIC_PROXY_ENTRY_LOGGED = "_connector_diagnostic_proxy_entry_logged"
@@ -1128,6 +1129,13 @@ def _maybe_replace_connector_diagnostic_response(
         return
     if flow.metadata.get(_CONNECTOR_DIAGNOSTIC_RESPONSE_REPLACED_IN_HEADERS):
         flow.response.trailers = None
+        body = flow.metadata.get(_CONNECTOR_DIAGNOSTIC_RESPONSE_BODY)
+        if isinstance(body, bytes) and not flow.metadata.get(
+            _CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_BODY_SENT
+        ):
+            flow.response.content = body
+            flow.response.headers["Content-Type"] = "application/json"
+            flow.response.headers["Content-Length"] = str(len(body))
         _log_connector_diagnostic_proxy_entry(
             flow,
             original_url=original_url,
@@ -1238,6 +1246,7 @@ def _install_connector_diagnostic_response_stream(flow: http.HTTPFlow) -> bool:
     )
     if body is None:
         return False
+    flow.metadata[_CONNECTOR_DIAGNOSTIC_RESPONSE_BODY] = body
     flow.metadata[_CONNECTOR_DIAGNOSTIC_RESPONSE_REPLACED_IN_HEADERS] = True
 
     def stream_connector_diagnostic_response(chunk: bytes) -> bytes | tuple[bytes, ...]:
@@ -1952,6 +1961,7 @@ def _release_terminal_flow_state(
 
 def _release_connector_diagnostic_response_stream_state(flow: http.HTTPFlow) -> None:
     stream_callback = flow.metadata.pop(_CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_CALLBACK, None)
+    flow.metadata.pop(_CONNECTOR_DIAGNOSTIC_RESPONSE_BODY, None)
     flow.metadata.pop(_CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_BODY_SENT, None)
     flow.metadata.pop(_CONNECTOR_DIAGNOSTIC_RESPONSE_REPLACED_IN_HEADERS, None)
     flow.metadata.pop(_CONNECTOR_DIAGNOSTIC_PROXY_ENTRY_LOGGED, None)

--- a/crates/runner/mitm-addon/tests/test_error_handler.py
+++ b/crates/runner/mitm-addon/tests/test_error_handler.py
@@ -168,6 +168,46 @@ class TestErrorHandler:
         assert metadata_keys.REQUEST_STREAM_BUFFER_STATE not in flow.metadata
         assert mitm_addon._REQUEST_CLASSIFICATION not in flow.metadata
 
+    def test_header_phase_connector_diagnostic_error_keeps_connection_error(
+        self, tmp_path, real_flow, mitm_ctx
+    ):
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="fal.run",
+            path="/fal-ai/nano-banana-pro",
+            method="POST",
+        )
+        _prepare_legacy_connector_diagnostic_flow(tmp_path, flow)
+
+        with mitm_ctx():
+            flow.response = tutils.tresp(
+                status_code=401,
+                headers=header_map({"content-type": "text/plain"}),
+                content=b"upstream auth error",
+            )
+            mitm_addon.responseheaders(flow)
+            assert response_stream(flow)(b"partial upstream body") == ()
+            flow.response.trailers = header_map({"x-upstream-trailer": "discarded"})
+            flow.error = Error("connection reset by peer")
+            mitm_addon.error(flow)
+
+        assert flow.response is not None
+        assert flow.response.status_code == 401
+        assert flow.response.trailers is None
+        assert flow.response.stream is False
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
+
+        [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
+        assert entry["status"] == 0
+        assert entry["error"] == "connection reset by peer"
+        assert entry["firewall_error"] == "connector_not_configured_for_run"
+        assert entry["connector_diagnostic_type"] == "fal"
+
+        [proxy_entry] = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
+        assert proxy_entry["type"] == "connection_error"
+
     def test_streamed_authenticated_connector_candidate_error_keeps_original_error(
         self, tmp_path, real_flow, mitm_ctx, headers
     ):

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -50,11 +50,11 @@ def _prepare_legacy_connector_diagnostic_flow(tmp_path, flow, *, capture_body: b
 
 def _drain_connector_diagnostic_response_stream(flow, *, upstream_chunk: bytes = b"upstream"):
     stream = response_stream(flow)
-    assert stream(upstream_chunk) == b""
+    assert stream(upstream_chunk) == ()
     diagnostic_body = stream(b"")
     assert isinstance(diagnostic_body, bytes)
     assert json.loads(diagnostic_body)["error"] == "connector_not_configured_for_run"
-    assert stream(b"") == b""
+    assert stream(b"") == ()
     return diagnostic_body
 
 

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -138,6 +138,8 @@ class TestResponseHandler:
                 flow,
                 upstream_chunk=upstream_chunk,
             )
+            assert not jsonl_exists_after_flush(tmp_path / "proxy.jsonl")
+            flow.response.trailers = header_map({"x-upstream-trailer": "discarded"})
             mitm_addon.response(flow)
 
         content = flow.response.content
@@ -148,6 +150,7 @@ class TestResponseHandler:
         assert flow.response.headers["content-length"] == str(len(diagnostic_body))
         assert "content-encoding" not in flow.response.headers
         assert "transfer-encoding" not in flow.response.headers
+        assert flow.response.trailers is None
         assert flow.response.stream is False
         assert metadata_keys.STREAM_BUFFER not in flow.metadata
         assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -48,6 +48,16 @@ def _prepare_legacy_connector_diagnostic_flow(tmp_path, flow, *, capture_body: b
     flow.metadata[mitm_addon._CONNECTOR_DIAGNOSTIC_ACTIVE_FIREWALL_NAMES] = ()
 
 
+def _drain_connector_diagnostic_response_stream(flow, *, upstream_chunk: bytes = b"upstream"):
+    stream = response_stream(flow)
+    assert stream(upstream_chunk) == b""
+    diagnostic_body = stream(b"")
+    assert isinstance(diagnostic_body, bytes)
+    assert json.loads(diagnostic_body)["error"] == "connector_not_configured_for_run"
+    assert stream(b"") == b""
+    return diagnostic_body
+
+
 class TestResponseHandler:
     async def test_replaces_unauthenticated_connector_401_body(self, tmp_path, real_flow, mitm_ctx):
         flow = real_flow(
@@ -97,7 +107,7 @@ class TestResponseHandler:
         assert proxy_entry["connector"] == "fal"
         assert proxy_entry["upstream_status"] == 401
 
-    async def test_buffers_unauthenticated_connector_401_before_response_replacement(
+    async def test_streams_unauthenticated_connector_401_diagnostic_without_upstream_body(
         self, tmp_path, real_flow, mitm_ctx
     ):
         flow = real_flow(
@@ -107,21 +117,52 @@ class TestResponseHandler:
             path="/fal-ai/nano-banana-pro",
             method="POST",
         )
-        _prepare_legacy_connector_diagnostic_flow(tmp_path, flow)
+        _prepare_legacy_connector_diagnostic_flow(tmp_path, flow, capture_body=True)
+        upstream_chunk = b"discarded-upstream-body-" * 1024
 
         with mitm_ctx():
             flow.response = tutils.tresp(
                 status_code=401,
-                headers=header_map({"content-type": "text/plain"}),
+                headers=header_map(
+                    {
+                        "content-encoding": "gzip",
+                        "content-length": "10485760",
+                        "content-type": "text/plain",
+                        "transfer-encoding": "chunked",
+                    }
+                ),
                 content=b"upstream",
             )
             mitm_addon.responseheaders(flow)
-            assert flow.response.stream is False
+            diagnostic_body = _drain_connector_diagnostic_response_stream(
+                flow,
+                upstream_chunk=upstream_chunk,
+            )
             mitm_addon.response(flow)
 
         content = flow.response.content
         assert content is not None
+        assert content == diagnostic_body
         assert json.loads(content)["error"] == "connector_not_configured_for_run"
+        assert flow.response.headers["content-type"] == "application/json"
+        assert flow.response.headers["content-length"] == str(len(diagnostic_body))
+        assert "content-encoding" not in flow.response.headers
+        assert "transfer-encoding" not in flow.response.headers
+        assert flow.response.stream is False
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
+        [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
+        assert entry["response_size"] == len(diagnostic_body)
+        response_headers = {
+            name.lower(): value for name, value in entry["response_headers"].items()
+        }
+        assert response_headers["content-type"] == "application/json"
+        assert response_headers["content-length"] == str(len(diagnostic_body))
+        assert json.loads(entry["response_body"])["error"] == "connector_not_configured_for_run"
+        assert "discarded-upstream-body" not in entry["response_body"]
+        assert entry["response_body_encoding"] == "utf-8"
+        proxy_entries = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
+        assert sum(entry["type"] == "connector_diagnostic" for entry in proxy_entries) == 1
 
     async def test_streams_connector_401_when_user_auth_is_present(
         self, tmp_path, real_flow, mitm_ctx, headers
@@ -258,11 +299,12 @@ class TestResponseHandler:
                 content=b"upstream auth error",
             )
             mitm_addon.responseheaders(flow)
-            assert flow.response.stream is False
+            diagnostic_body = _drain_connector_diagnostic_response_stream(flow)
             mitm_addon.response(flow)
 
         content = flow.response.content
         assert content is not None
+        assert content == diagnostic_body
         body = json.loads(content)
         assert body["error"] == "connector_not_configured_for_run"
         assert body["connector"] == "fal"
@@ -466,11 +508,12 @@ class TestResponseHandler:
                 content=b"upstream empty auth error",
             )
             mitm_addon.responseheaders(flow)
-            assert flow.response.stream is False
+            diagnostic_body = _drain_connector_diagnostic_response_stream(flow)
             mitm_addon.response(flow)
 
         content = flow.response.content
         assert content is not None
+        assert content == diagnostic_body
         body = json.loads(content)
         assert body["error"] == "connector_not_configured_for_run"
         [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
@@ -499,11 +542,12 @@ class TestResponseHandler:
                 content=b"upstream proxy auth error",
             )
             mitm_addon.responseheaders(flow)
-            assert flow.response.stream is False
+            diagnostic_body = _drain_connector_diagnostic_response_stream(flow)
             mitm_addon.response(flow)
 
         content = flow.response.content
         assert content is not None
+        assert content == diagnostic_body
         body = json.loads(content)
         assert body["error"] == "connector_not_configured_for_run"
         [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
@@ -532,11 +576,12 @@ class TestResponseHandler:
                 content=b"upstream empty key auth error",
             )
             mitm_addon.responseheaders(flow)
-            assert flow.response.stream is False
+            diagnostic_body = _drain_connector_diagnostic_response_stream(flow)
             mitm_addon.response(flow)
 
         content = flow.response.content
         assert content is not None
+        assert content == diagnostic_body
         body = json.loads(content)
         assert body["error"] == "connector_not_configured_for_run"
         [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
@@ -561,11 +606,12 @@ class TestResponseHandler:
                 content=b"upstream empty query auth error",
             )
             mitm_addon.responseheaders(flow)
-            assert flow.response.stream is False
+            diagnostic_body = _drain_connector_diagnostic_response_stream(flow)
             mitm_addon.response(flow)
 
         content = flow.response.content
         assert content is not None
+        assert content == diagnostic_body
         body = json.loads(content)
         assert body["error"] == "connector_not_configured_for_run"
         [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -167,6 +167,40 @@ class TestResponseHandler:
         proxy_entries = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
         assert sum(entry["type"] == "connector_diagnostic" for entry in proxy_entries) == 1
 
+    async def test_restores_connector_diagnostic_body_when_headers_end_stream(
+        self, tmp_path, real_flow, mitm_ctx
+    ):
+        flow = real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="fal.run",
+            path="/fal-ai/nano-banana-pro",
+            method="POST",
+        )
+        _prepare_legacy_connector_diagnostic_flow(tmp_path, flow, capture_body=True)
+
+        with mitm_ctx():
+            flow.response = tutils.tresp(
+                status_code=401,
+                headers=header_map({"content-type": "text/plain"}),
+                content=b"",
+            )
+            mitm_addon.responseheaders(flow)
+            flow.response.data.content = b""
+            mitm_addon.response(flow)
+
+        content = flow.response.content
+        assert content is not None
+        body = json.loads(content)
+        assert body["error"] == "connector_not_configured_for_run"
+        assert flow.response.headers["content-type"] == "application/json"
+        assert flow.response.headers["content-length"] == str(len(content))
+        assert flow.response.stream is False
+
+        [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
+        assert entry["response_size"] == len(content)
+        assert json.loads(entry["response_body"])["error"] == "connector_not_configured_for_run"
+
     async def test_streams_connector_401_when_user_auth_is_present(
         self, tmp_path, real_flow, mitm_ctx, headers
     ):


### PR DESCRIPTION
## Summary
- install a diagnostic-only response stream for unauthenticated built-in connector 401/403 fallback responses
- discard upstream response chunks and emit the local diagnostic JSON once on stream finalization
- keep network log size/body capture aligned with the local diagnostic response and avoid duplicate connector diagnostic proxy logs

## Tests
- `cd crates/runner/mitm-addon && ./.venv/bin/ruff check src tests`
- `cd crates/runner/mitm-addon && ./.venv/bin/basedpyright src tests`
- `cd crates/runner/mitm-addon && ./.venv/bin/pytest tests/test_response_handler.py`
- `cd crates/runner/mitm-addon && ./.venv/bin/pytest`

Closes #19167