### PR TITLE
perf: add Zero service pre-create timing

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -147,6 +147,9 @@ const API_DISPATCH_ZERO_PRE_CREATE_ACTION_TYPES = [
   "api_dispatch_pre_create_zero_resolve_permission_policies",
   "api_dispatch_pre_create_zero_build_create_run_args",
 ] as const;
+const API_DISPATCH_ZERO_INTERNAL_ENTRYPOINT_ACTION_TYPES = [
+  "api_dispatch_pre_create_zero_entrypoint_gap",
+] as const;
 const API_DISPATCH_STORED_CONNECTOR_ROW_ACTION_TYPES = [
   "api_dispatch_prepare_context_load_stored_connector_rows",
   "api_dispatch_prepare_context_filter_stored_connector_rows",
@@ -641,6 +644,10 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       timingEvents,
       API_DISPATCH_DIRECT_PRE_CREATE_ACTION_TYPES,
     );
+    expectNoApiDispatchActions(
+      timingEvents,
+      API_DISPATCH_ZERO_INTERNAL_ENTRYPOINT_ACTION_TYPES,
+    );
     expectApiDispatchActions(
       timingEvents,
       API_DISPATCH_PERMISSION_MANIFEST_SUBSTEP_ACTION_TYPES,
@@ -696,6 +703,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
           runner_group: runnerGroup,
           profile: "vm0/default",
           dispatch_path: "direct",
+          trigger_source: "web",
         }),
       );
       expect(event.duration_ms).toStrictEqual(expect.any(Number));
@@ -748,6 +756,10 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expectNoApiDispatchActions(
       timingEvents,
       API_DISPATCH_ZERO_PRE_CREATE_ACTION_TYPES,
+    );
+    expectNoApiDispatchActions(
+      timingEvents,
+      API_DISPATCH_ZERO_INTERNAL_ENTRYPOINT_ACTION_TYPES,
     );
     expectApiDispatchSpanKind(
       timingEvents,

--- a/turbo/apps/api/src/signals/routes/__tests__/test-telegram-dispatch-probe.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-telegram-dispatch-probe.test.ts
@@ -62,6 +62,25 @@ function uniqueNumericId(): string {
   return String(100_000_000 + Math.floor(Math.random() * 899_999_999));
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function apiDispatchTimingEventsForRun(
+  runId: string,
+): readonly Record<string, unknown>[] {
+  return context.mocks.axiom.sdkIngest.mock.calls.flatMap((call) => {
+    const dataset = call[0];
+    const events = call[1];
+    if (dataset !== "vm0-sandbox-op-log-dev" || !Array.isArray(events)) {
+      return [];
+    }
+    return events.filter((event): event is Record<string, unknown> => {
+      return isRecord(event) && event.run_id === runId;
+    });
+  });
+}
+
 async function cleanupFixture(fixture: TelegramProbeFixture): Promise<void> {
   const db = store.set(writeDb$);
   const runRows = await db
@@ -334,6 +353,46 @@ describe("POST /api/test/telegram-dispatch-probe", () => {
         isDM: true,
       },
     });
+
+    const timingEvents = apiDispatchTimingEventsForRun(run!.id);
+    expect(timingEvents).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          op_type: "api_dispatch_pre_create_agent_run",
+          span_kind: "top_level",
+          trigger_source: "telegram",
+        }),
+        expect.objectContaining({
+          op_type: "api_dispatch_pre_create_zero_entrypoint_gap",
+          span_kind: "nested",
+          trigger_source: "telegram",
+        }),
+        expect.objectContaining({
+          op_type: "api_dispatch_pre_create_zero_load_agent",
+          span_kind: "nested",
+          trigger_source: "telegram",
+        }),
+        expect.objectContaining({
+          op_type: "api_dispatch_pre_create_zero_load_connector_scopes",
+          span_kind: "nested",
+          trigger_source: "telegram",
+        }),
+        expect.objectContaining({
+          op_type: "api_dispatch_pre_create_zero_build_create_run_args",
+          span_kind: "nested",
+          trigger_source: "telegram",
+        }),
+      ]),
+    );
+    const timingActionTypes = timingEvents.map((event) => {
+      return event.op_type;
+    });
+    expect(timingActionTypes).not.toContain(
+      "api_dispatch_pre_create_zero_parse_body",
+    );
+    expect(timingActionTypes).not.toContain(
+      "api_dispatch_pre_create_zero_prepare_args",
+    );
   });
 
   it("dispatches group mentions with mention stripping and Telegram metadata", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
@@ -1291,14 +1291,39 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
         expect.objectContaining({
           op_type: "api_dispatch_pre_create_agent_run",
           span_kind: "top_level",
+          trigger_source: "telegram",
+        }),
+        expect.objectContaining({
+          op_type: "api_dispatch_pre_create_zero_entrypoint_gap",
+          span_kind: "nested",
+          trigger_source: "telegram",
+        }),
+        expect.objectContaining({
+          op_type: "api_dispatch_pre_create_zero_load_agent",
+          span_kind: "nested",
+          trigger_source: "telegram",
+        }),
+        expect.objectContaining({
+          op_type: "api_dispatch_pre_create_zero_load_connector_scopes",
+          span_kind: "nested",
+          trigger_source: "telegram",
+        }),
+        expect.objectContaining({
+          op_type: "api_dispatch_pre_create_zero_build_create_run_args",
+          span_kind: "nested",
+          trigger_source: "telegram",
         }),
       ]),
     );
-    expect(
-      timingEvents.map((event) => {
-        return event.op_type;
-      }),
-    ).not.toContain("api_dispatch_pre_create_zero_parse_body");
+    const timingActionTypes = timingEvents.map((event) => {
+      return event.op_type;
+    });
+    expect(timingActionTypes).not.toContain(
+      "api_dispatch_pre_create_zero_parse_body",
+    );
+    expect(timingActionTypes).not.toContain(
+      "api_dispatch_pre_create_zero_prepare_args",
+    );
   });
 
   it("keeps Telegram callbacks typed when VM0_API_BACKEND_URL is set", async () => {

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -4385,6 +4385,9 @@ function dispatchRun(
         runnerGroup: payload.runnerGroup,
         profile: payload.profile,
         dispatchPath: "direct",
+        ...(args.body.triggerSource
+          ? { triggerSource: args.body.triggerSource }
+          : {}),
       });
     }
 

--- a/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
+++ b/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
@@ -1,3 +1,5 @@
+import type { TriggerSource } from "@vm0/api-contracts/contracts/logs";
+
 import { now } from "../external/time";
 import { recordSandboxOperations } from "../external/sandbox-op-log";
 import { onRejection } from "../utils";
@@ -10,6 +12,7 @@ export type ApiDispatchTimingActionType =
   | "api_dispatch_pre_create_direct_prepare_args"
   | "api_dispatch_pre_create_zero_parse_body"
   | "api_dispatch_pre_create_zero_prepare_args"
+  | "api_dispatch_pre_create_zero_entrypoint_gap"
   | "api_dispatch_pre_create_zero_resolve_agent_id"
   | "api_dispatch_pre_create_zero_load_agent"
   | "api_dispatch_pre_create_zero_load_user_info"
@@ -120,6 +123,7 @@ export class ApiDispatchTimingCollector {
     readonly runnerGroup: string;
     readonly profile: string;
     readonly dispatchPath: "direct";
+    readonly triggerSource?: TriggerSource;
   }): void {
     const records = this.records.splice(0);
     recordSandboxOperations(
@@ -136,6 +140,9 @@ export class ApiDispatchTimingCollector {
             profile: args.profile,
             dispatch_path: args.dispatchPath,
             span_kind: record.spanKind,
+            ...(args.triggerSource
+              ? { trigger_source: args.triggerSource }
+              : {}),
           },
         };
       }),

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -37,9 +37,9 @@ import {
   type DispatchFailedRunCallbacks,
 } from "./agent-run-create.service";
 import {
+  ApiDispatchTimingCollector,
   measureApiDispatchTiming,
   type ApiDispatchTimingActionType,
-  type ApiDispatchTimingCollector,
 } from "./api-dispatch-timing.service";
 import { loadAgentConnectorScope } from "./agent-connector-scope.service";
 import { loadActiveUserPermissionGrants } from "./zero-user-permission-grants.service";
@@ -153,6 +153,29 @@ interface CreateZeroRunCommandArgs {
   readonly zeroRunMetadata?: ZeroRunMetadata;
   readonly dispatchFailedCallbacks?: DispatchFailedRunCallbacks;
   readonly timing?: ApiDispatchTimingCollector;
+}
+
+interface CreateZeroIntegrationRunCommandArgs {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly agentId: string;
+  readonly sessionId?: string;
+  readonly prompt: string;
+  readonly appendSystemPrompt?: string;
+  readonly triggerSource: TriggerSource;
+  readonly callbacks?: readonly RunCallback[];
+  readonly apiStartTime: number;
+  readonly userInfoExtras?: Pick<
+    UserInfo,
+    | "slackDisplayName"
+    | "slackUserId"
+    | "telegramDisplayName"
+    | "telegramUsername"
+    | "telegramUserId"
+    | "telegramLanguage"
+    | "agentphoneHandle"
+  >;
+  readonly dispatchFailedCallbacks?: DispatchFailedRunCallbacks;
 }
 
 function forbidden(message: string) {
@@ -745,6 +768,21 @@ function measureZeroPreCreate<T>(
   return measureApiDispatchTiming(timing, actionType, "nested", operation);
 }
 
+function zeroServiceEntryTiming(args: {
+  readonly apiStartTime: number;
+  readonly timing?: ApiDispatchTimingCollector;
+}): ApiDispatchTimingCollector {
+  const timing = args.timing ?? new ApiDispatchTimingCollector();
+  if (!args.timing) {
+    timing.recordElapsed(
+      "api_dispatch_pre_create_zero_entrypoint_gap",
+      "nested",
+      args.apiStartTime,
+    );
+  }
+  return timing;
+}
+
 async function resolveZeroRunAgentId(
   db: Db,
   args: CreateZeroRunCommandArgs,
@@ -791,6 +829,31 @@ async function loadZeroRunConnectorScopes(
   return scope;
 }
 
+async function resolveZeroRunTriggerPreCreateContext(
+  db: Db,
+  args: CreateZeroRunCommandArgs,
+  signal: AbortSignal,
+): Promise<{
+  readonly triggerAgentId: string | undefined;
+  readonly triggerRun: Awaited<ReturnType<typeof resolveTriggerRunContext>>;
+}> {
+  const triggerAgentId = await triggerAgentIdForAuth(db, args.auth);
+  signal.throwIfAborted();
+
+  // Trigger-fired runs resolve from the trigger owner's workflow-scoped
+  // connector authorization and grants. Expose trigger/workflow ids so
+  // the in-sandbox permission-change deep-link can target the workflow.
+  const triggerRun = await resolveTriggerRunContext(
+    db,
+    {
+      orgId: args.auth.orgId,
+      workflowTriggerId: args.zeroRunMetadata?.workflowTriggerId,
+    },
+    signal,
+  );
+  return { triggerAgentId, triggerRun };
+}
+
 function buildZeroCreateAgentRunArgs(args: {
   readonly command: CreateZeroRunCommandArgs;
   readonly agent: ZeroAgentRunRecord;
@@ -801,6 +864,7 @@ function buildZeroCreateAgentRunArgs(args: {
   readonly workflows: Awaited<ReturnType<typeof loadWorkflowsForRun>>;
   readonly allowedConnectorTypes: readonly ConnectorType[];
   readonly allowedCustomConnectorIds: readonly string[];
+  readonly timing: ApiDispatchTimingCollector;
 }): CreateAgentRunArgs {
   const command = args.command;
   return {
@@ -847,39 +911,69 @@ function buildZeroCreateAgentRunArgs(args: {
       triggerAgentId: args.triggerAgentId,
     },
     dispatchFailedCallbacks: command.dispatchFailedCallbacks,
-    ...(command.timing ? { timing: command.timing } : {}),
+    timing: args.timing,
+  };
+}
+
+function buildZeroIntegrationCreateAgentRunArgs(args: {
+  readonly command: CreateZeroIntegrationRunCommandArgs;
+  readonly agent: ZeroAgentRunRecord;
+  readonly userInfo: UserInfo;
+  readonly runPermissionPolicies: FirewallPolicies | null | undefined;
+  readonly workflows: Awaited<ReturnType<typeof loadWorkflowsForRun>>;
+  readonly allowedConnectorTypes: readonly ConnectorType[];
+  readonly allowedCustomConnectorIds: readonly string[];
+  readonly timing: ApiDispatchTimingCollector;
+}): CreateAgentRunArgs {
+  const command = args.command;
+  return {
+    userId: command.userId,
+    orgId: command.orgId,
+    body: createIntegrationRunBody({
+      prompt: command.prompt,
+      sessionId: command.sessionId,
+      agent: args.agent,
+      userInfo: { ...args.userInfo, ...command.userInfoExtras },
+      permissionPolicies: args.runPermissionPolicies,
+      triggerSource: command.triggerSource,
+      appendSystemPrompt: command.appendSystemPrompt,
+    }),
+    apiStartTime: command.apiStartTime,
+    modelProviderId: args.agent.modelProviderId ?? undefined,
+    selectedModelOverride: args.agent.selectedModel ?? undefined,
+    extraEnvironment: { ZERO_AGENT_ID: args.agent.id },
+    callbacks: command.callbacks,
+    includeZeroTokenSecret: true,
+    enforceVm0Credits: true,
+    queueOnConcurrencyLimit: true,
+    injectSkillVolumes: { workflows: args.workflows },
+    connectorScope: {
+      allowedConnectorTypes: args.allowedConnectorTypes,
+      allowedCustomConnectorIds: args.allowedCustomConnectorIds,
+    },
+    validateEnvironmentReferences: false,
+    dispatchFailedCallbacks: command.dispatchFailedCallbacks,
+    timing: args.timing,
   };
 }
 
 export const createZeroIntegrationRun$ = command(
   async (
     { set },
-    args: {
-      readonly userId: string;
-      readonly orgId: string;
-      readonly agentId: string;
-      readonly sessionId?: string;
-      readonly prompt: string;
-      readonly appendSystemPrompt?: string;
-      readonly triggerSource: TriggerSource;
-      readonly callbacks?: readonly RunCallback[];
-      readonly apiStartTime: number;
-      readonly userInfoExtras?: Pick<
-        UserInfo,
-        | "slackDisplayName"
-        | "slackUserId"
-        | "telegramDisplayName"
-        | "telegramUsername"
-        | "telegramUserId"
-        | "telegramLanguage"
-        | "agentphoneHandle"
-      >;
-      readonly dispatchFailedCallbacks?: DispatchFailedRunCallbacks;
-    },
+    args: CreateZeroIntegrationRunCommandArgs,
     signal: AbortSignal,
   ) => {
     const db = set(writeDb$);
-    const agent = await loadZeroAgent(db, args.agentId);
+    const timing = zeroServiceEntryTiming({
+      apiStartTime: args.apiStartTime,
+    });
+    const agent = await measureZeroPreCreate(
+      timing,
+      "api_dispatch_pre_create_zero_load_agent",
+      async () => {
+        return await loadZeroAgent(db, args.agentId);
+      },
+    );
     signal.throwIfAborted();
     if (!agent || agent.orgId !== args.orgId) {
       return notFound("Agent not found");
@@ -889,78 +983,94 @@ export const createZeroIntegrationRun$ = command(
       return forbidden("Only the private agent owner can run this agent");
     }
 
-    const userInfo = await loadUserInfo(db, {
-      userId: args.userId,
-      orgId: args.orgId,
-    });
+    const userInfo = await measureZeroPreCreate(
+      timing,
+      "api_dispatch_pre_create_zero_load_user_info",
+      async () => {
+        return await loadUserInfo(db, {
+          userId: args.userId,
+          orgId: args.orgId,
+        });
+      },
+    );
     signal.throwIfAborted();
     const { allowedConnectorTypes, allowedCustomConnectorIds } =
-      await loadAgentConnectorScope(db, {
-        userId: args.userId,
-        orgId: args.orgId,
-        agentId: agent.id,
-      });
+      await measureZeroPreCreate(
+        timing,
+        "api_dispatch_pre_create_zero_load_connector_scopes",
+        async () => {
+          return await loadAgentConnectorScope(db, {
+            userId: args.userId,
+            orgId: args.orgId,
+            agentId: agent.id,
+          });
+        },
+      );
     signal.throwIfAborted();
-    const workflows = await loadWorkflowsForRun(db, {
-      userId: args.userId,
-      orgId: args.orgId,
-      agentId: agent.id,
-    });
-    signal.throwIfAborted();
-
-    const runPermissionPolicies = await resolveZeroRunPermissionPolicies(
-      db,
-      {
-        orgId: args.orgId,
-        userId: args.userId,
-        agent,
-        allowedConnectorTypes,
-        checkedAt: new Date(args.apiStartTime),
+    const workflows = await measureZeroPreCreate(
+      timing,
+      "api_dispatch_pre_create_zero_load_workflows",
+      async () => {
+        return await loadWorkflowsForRun(db, {
+          userId: args.userId,
+          orgId: args.orgId,
+          agentId: agent.id,
+        });
       },
-      signal,
     );
+    signal.throwIfAborted();
 
-    return await set(
-      createAgentRun$,
-      {
-        userId: args.userId,
-        orgId: args.orgId,
-        body: createIntegrationRunBody({
-          prompt: args.prompt,
-          sessionId: args.sessionId,
+    const runPermissionPolicies = await measureZeroPreCreate(
+      timing,
+      "api_dispatch_pre_create_zero_resolve_permission_policies",
+      async () => {
+        return await resolveZeroRunPermissionPolicies(
+          db,
+          {
+            orgId: args.orgId,
+            userId: args.userId,
+            agent,
+            allowedConnectorTypes,
+            checkedAt: new Date(args.apiStartTime),
+          },
+          signal,
+        );
+      },
+    );
+    signal.throwIfAborted();
+
+    const createAgentRunArgs = await measureZeroPreCreate(
+      timing,
+      "api_dispatch_pre_create_zero_build_create_run_args",
+      () => {
+        return buildZeroIntegrationCreateAgentRunArgs({
+          command: args,
           agent,
-          userInfo: { ...userInfo, ...args.userInfoExtras },
-          permissionPolicies: runPermissionPolicies,
-          triggerSource: args.triggerSource,
-          appendSystemPrompt: args.appendSystemPrompt,
-        }),
-        apiStartTime: args.apiStartTime,
-        modelProviderId: agent.modelProviderId ?? undefined,
-        selectedModelOverride: agent.selectedModel ?? undefined,
-        extraEnvironment: { ZERO_AGENT_ID: agent.id },
-        callbacks: args.callbacks,
-        includeZeroTokenSecret: true,
-        enforceVm0Credits: true,
-        queueOnConcurrencyLimit: true,
-        injectSkillVolumes: { workflows },
-        connectorScope: {
+          userInfo,
+          runPermissionPolicies,
+          workflows,
           allowedConnectorTypes,
           allowedCustomConnectorIds,
-        },
-        validateEnvironmentReferences: false,
-        dispatchFailedCallbacks: args.dispatchFailedCallbacks,
+          timing,
+        });
       },
-      signal,
     );
+    signal.throwIfAborted();
+
+    return await set(createAgentRun$, createAgentRunArgs, signal);
   },
 );
 
 export const createZeroRun$ = command(
   async ({ set }, args: CreateZeroRunCommandArgs, signal: AbortSignal) => {
     const db = set(writeDb$);
+    const timing = zeroServiceEntryTiming({
+      apiStartTime: args.apiStartTime,
+      timing: args.timing,
+    });
 
     const agentId = await measureZeroPreCreate(
-      args.timing,
+      timing,
       "api_dispatch_pre_create_zero_resolve_agent_id",
       async () => {
         return await resolveZeroRunAgentId(db, args);
@@ -975,7 +1085,7 @@ export const createZeroRun$ = command(
     }
 
     const agent = await measureZeroPreCreate(
-      args.timing,
+      timing,
       "api_dispatch_pre_create_zero_load_agent",
       async () => {
         return await loadZeroAgent(db, agentId);
@@ -991,7 +1101,7 @@ export const createZeroRun$ = command(
     }
 
     const userInfo = await measureZeroPreCreate(
-      args.timing,
+      timing,
       "api_dispatch_pre_create_zero_load_user_info",
       async () => {
         return await loadUserInfo(db, {
@@ -1002,30 +1112,16 @@ export const createZeroRun$ = command(
     );
     signal.throwIfAborted();
     const triggerContext = await measureZeroPreCreate(
-      args.timing,
+      timing,
       "api_dispatch_pre_create_zero_resolve_trigger_context",
       async () => {
-        const triggerAgentId = await triggerAgentIdForAuth(db, args.auth);
-        signal.throwIfAborted();
-
-        // Trigger-fired runs resolve from the trigger owner's workflow-scoped
-        // connector authorization and grants. Expose trigger/workflow ids so
-        // the in-sandbox permission-change deep-link can target the workflow.
-        const triggerRun = await resolveTriggerRunContext(
-          db,
-          {
-            orgId: args.auth.orgId,
-            workflowTriggerId: args.zeroRunMetadata?.workflowTriggerId,
-          },
-          signal,
-        );
-        return { triggerAgentId, triggerRun };
+        return await resolveZeroRunTriggerPreCreateContext(db, args, signal);
       },
     );
     signal.throwIfAborted();
     const { triggerAgentId, triggerRun } = triggerContext;
     const connectorScopes = await measureZeroPreCreate(
-      args.timing,
+      timing,
       "api_dispatch_pre_create_zero_load_connector_scopes",
       async () => {
         return await loadZeroRunConnectorScopes(
@@ -1043,7 +1139,7 @@ export const createZeroRun$ = command(
     const { allowedConnectorTypes, allowedCustomConnectorIds } =
       connectorScopes;
     const workflows = await measureZeroPreCreate(
-      args.timing,
+      timing,
       "api_dispatch_pre_create_zero_load_workflows",
       async () => {
         return await loadWorkflowsForRun(db, {
@@ -1055,7 +1151,7 @@ export const createZeroRun$ = command(
     );
     signal.throwIfAborted();
     const runPermissionPolicies = await measureZeroPreCreate(
-      args.timing,
+      timing,
       "api_dispatch_pre_create_zero_resolve_permission_policies",
       async () => {
         return await resolveZeroRunPermissionPolicies(
@@ -1075,7 +1171,7 @@ export const createZeroRun$ = command(
     signal.throwIfAborted();
 
     const createAgentRunArgs = await measureZeroPreCreate(
-      args.timing,
+      timing,
       "api_dispatch_pre_create_zero_build_create_run_args",
       () => {
         return buildZeroCreateAgentRunArgs({
@@ -1088,6 +1184,7 @@ export const createZeroRun$ = command(
           workflows,
           allowedConnectorTypes,
           allowedCustomConnectorIds,
+          timing,
         });
       },
     );

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -963,10 +963,10 @@ export const createZeroIntegrationRun$ = command(
     args: CreateZeroIntegrationRunCommandArgs,
     signal: AbortSignal,
   ) => {
-    const db = set(writeDb$);
     const timing = zeroServiceEntryTiming({
       apiStartTime: args.apiStartTime,
     });
+    const db = set(writeDb$);
     const agent = await measureZeroPreCreate(
       timing,
       "api_dispatch_pre_create_zero_load_agent",
@@ -1063,11 +1063,11 @@ export const createZeroIntegrationRun$ = command(
 
 export const createZeroRun$ = command(
   async ({ set }, args: CreateZeroRunCommandArgs, signal: AbortSignal) => {
-    const db = set(writeDb$);
     const timing = zeroServiceEntryTiming({
       apiStartTime: args.apiStartTime,
       timing: args.timing,
     });
+    const db = set(writeDb$);
 
     const agentId = await measureZeroPreCreate(
       timing,


### PR DESCRIPTION
## Summary

- Add a Zero service entrypoint timing span and optional `trigger_source` dimension for API dispatch timing rows.
- Ensure internal `createZeroRun$` and `createZeroIntegrationRun$` paths create and pass an effective timing collector through to `createAgentRun$`.
- Cover internal Telegram run creation paths while keeping route-level Zero parse/prepare spans limited to the `/api/zero/runs` route.

Closes #19172

## Tests

- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "api dispatch timing"`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/test-telegram-dispatch-probe.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`
- `pnpm format`
- `git diff --check`

## Notes

Full pre-commit `pnpm knip --cache` currently reports existing unrelated findings outside this PR; the API workspace knip check passes.