### PR TITLE
perf: skip verified idle resume restore

### DIFF
--- a/crates/runner/src/cmd/start/idle_lifecycle.rs
+++ b/crates/runner/src/cmd/start/idle_lifecycle.rs
@@ -250,6 +250,7 @@ mod tests {
             budget_lease: lease,
             source_ip: "10.0.0.1".into(),
             storage_fingerprints: StorageFingerprints::default(),
+            restored_session_identity: None,
             workspace_image_size_bytes: b"workspace image".len() as u64,
             workspace_promotion: Some(fixture.promotion),
         });

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -237,8 +237,14 @@ fn build_session_history_restore_plan(
             let requested_identity = RestoredSessionIdentity::from_context(context);
             if let Some(requested_identity) = requested_identity {
                 match reuse_entry.and_then(ReusableIdleSandbox::restored_session_identity) {
+                    Some(restored_identity)
+                        if restored_identity == &requested_identity
+                            && restored_identity.has_guest_history_verification() =>
+                    {
+                        return SessionHistoryRestorePlan::SkipVerified(restored_identity.clone());
+                    }
                     Some(restored_identity) if restored_identity == &requested_identity => {
-                        return SessionHistoryRestorePlan::SkipVerified(requested_identity);
+                        Some(SessionHistoryRestoreFallback::UnverifiedIdleIdentity)
                     }
                     Some(_) => Some(SessionHistoryRestoreFallback::IdentityMismatch),
                     None => Some(SessionHistoryRestoreFallback::MissingIdleIdentity),
@@ -656,8 +662,12 @@ mod tests {
         let http = test_http_client();
         let context = context_with_history_ref("history-hash-a");
         let requested_identity = RestoredSessionIdentity::from_context(&context).unwrap();
+        let restored_identity = requested_identity.clone().with_guest_history(
+            12,
+            "/home/user/.claude/projects/-home-user-workspace/session.jsonl",
+        );
         let reusable_sandbox =
-            reusable_sandbox_with_identity(Some(requested_identity.clone())).await;
+            reusable_sandbox_with_identity(Some(restored_identity.clone())).await;
         let cancel = RunCancellationHandle::new();
         let mut timing = RunnerPreSpawnTiming::start_after_claim();
 
@@ -673,9 +683,71 @@ mod tests {
 
         match plan {
             SessionHistoryRestorePlan::SkipVerified(identity) => {
-                assert_eq!(identity, requested_identity);
+                assert_eq!(identity, restored_identity);
             }
             _ => panic!("matching reused identity should skip restore"),
+        }
+    }
+
+    #[tokio::test]
+    async fn restore_plan_falls_back_when_matching_reused_identity_is_unverified() {
+        let http = test_http_client();
+        let context = context_with_history_ref("history-hash-a");
+        let restored_identity = RestoredSessionIdentity::from_context(&context).unwrap();
+        let reusable_sandbox = reusable_sandbox_with_identity(Some(restored_identity)).await;
+        let cancel = RunCancellationHandle::new();
+        let mut timing = RunnerPreSpawnTiming::start_after_claim();
+
+        let plan = build_session_history_restore_plan(
+            &http,
+            &context,
+            true,
+            &cancel,
+            Some(&reusable_sandbox),
+            SandboxReuseResult::Reused,
+            &mut timing,
+        );
+
+        match plan {
+            SessionHistoryRestorePlan::Prestarted { fallback, .. } => {
+                assert_eq!(
+                    fallback,
+                    Some(SessionHistoryRestoreFallback::UnverifiedIdleIdentity)
+                );
+            }
+            _ => panic!("unverified reused identity should fall back to restore"),
+        }
+    }
+
+    #[tokio::test]
+    async fn restore_plan_falls_back_when_matching_reused_identity_has_empty_history_path() {
+        let http = test_http_client();
+        let context = context_with_history_ref("history-hash-a");
+        let restored_identity = RestoredSessionIdentity::from_context(&context)
+            .unwrap()
+            .with_guest_history(12, "");
+        let reusable_sandbox = reusable_sandbox_with_identity(Some(restored_identity)).await;
+        let cancel = RunCancellationHandle::new();
+        let mut timing = RunnerPreSpawnTiming::start_after_claim();
+
+        let plan = build_session_history_restore_plan(
+            &http,
+            &context,
+            true,
+            &cancel,
+            Some(&reusable_sandbox),
+            SandboxReuseResult::Reused,
+            &mut timing,
+        );
+
+        match plan {
+            SessionHistoryRestorePlan::Prestarted { fallback, .. } => {
+                assert_eq!(
+                    fallback,
+                    Some(SessionHistoryRestoreFallback::UnverifiedIdleIdentity)
+                );
+            }
+            _ => panic!("reused identity with empty history path should fall back to restore"),
         }
     }
 

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -772,34 +772,38 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn restore_plan_falls_back_when_matching_reused_identity_has_empty_history_path() {
-        let http = test_http_client();
-        let context = context_with_history_ref("history-hash-a");
-        let restored_identity = RestoredSessionIdentity::from_context(&context)
-            .unwrap()
-            .with_guest_history(12, "");
-        let reusable_sandbox = reusable_sandbox_with_identity(Some(restored_identity)).await;
-        let cancel = RunCancellationHandle::new();
-        let mut timing = RunnerPreSpawnTiming::start_after_claim();
+    async fn restore_plan_falls_back_when_matching_reused_identity_has_invalid_history_path() {
+        for guest_history_path in ["", "relative/session.jsonl"] {
+            let http = test_http_client();
+            let context = context_with_history_ref("history-hash-a");
+            let restored_identity = RestoredSessionIdentity::from_context(&context)
+                .unwrap()
+                .with_guest_history(12, guest_history_path);
+            let reusable_sandbox = reusable_sandbox_with_identity(Some(restored_identity)).await;
+            let cancel = RunCancellationHandle::new();
+            let mut timing = RunnerPreSpawnTiming::start_after_claim();
 
-        let plan = build_session_history_restore_plan(
-            &http,
-            &context,
-            true,
-            &cancel,
-            Some(&reusable_sandbox),
-            SandboxReuseResult::Reused,
-            &mut timing,
-        );
+            let plan = build_session_history_restore_plan(
+                &http,
+                &context,
+                true,
+                &cancel,
+                Some(&reusable_sandbox),
+                SandboxReuseResult::Reused,
+                &mut timing,
+            );
 
-        match plan {
-            SessionHistoryRestorePlan::Prestarted { fallback, .. } => {
-                assert_eq!(
-                    fallback,
-                    Some(SessionHistoryRestoreFallback::UnverifiedIdleIdentity)
-                );
+            match plan {
+                SessionHistoryRestorePlan::Prestarted { fallback, .. } => {
+                    assert_eq!(
+                        fallback,
+                        Some(SessionHistoryRestoreFallback::UnverifiedIdleIdentity)
+                    );
+                }
+                _ => {
+                    panic!("reused identity with invalid history path should fall back to restore")
+                }
             }
-            _ => panic!("reused identity with empty history path should fall back to restore"),
         }
     }
 

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -843,6 +843,44 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn restore_plan_falls_back_when_matching_reused_identity_is_too_large_to_verify() {
+        let http = test_http_client();
+        let context = context_with_history_ref_and_size(
+            "history-hash-a",
+            Some(crate::restored_session_identity::RESTORED_SESSION_IDENTITY_VERIFY_MAX_BYTES),
+        );
+        let restored_identity = RestoredSessionIdentity::from_context(&context)
+            .unwrap()
+            .with_guest_history(
+                crate::restored_session_identity::RESTORED_SESSION_IDENTITY_VERIFY_MAX_BYTES,
+                "/home/user/.claude/projects/-home-user-workspace/session.jsonl",
+            );
+        let reusable_sandbox = reusable_sandbox_with_identity(Some(restored_identity)).await;
+        let cancel = RunCancellationHandle::new();
+        let mut timing = RunnerPreSpawnTiming::start_after_claim();
+
+        let plan = build_session_history_restore_plan(
+            &http,
+            &context,
+            true,
+            &cancel,
+            Some(&reusable_sandbox),
+            SandboxReuseResult::Reused,
+            &mut timing,
+        );
+
+        match plan {
+            SessionHistoryRestorePlan::Prestarted { fallback, .. } => {
+                assert_eq!(
+                    fallback,
+                    Some(SessionHistoryRestoreFallback::UnverifiedIdleIdentity)
+                );
+            }
+            _ => panic!("oversized reused identity should fall back to prestarted restore"),
+        }
+    }
+
+    #[tokio::test]
     async fn restore_plan_falls_back_when_reused_identity_is_missing() {
         let http = test_http_client();
         let context = context_with_history_ref("history-hash-a");

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -23,7 +23,7 @@ use super::idle_lifecycle::{
 use super::job_spawn::{JobProfile, SpawnContext, SpawnJobRequest, spawn_job};
 use crate::config::ProfileConfig;
 use crate::executor::{
-    RestoredSessionIdentity, RunnerPreSpawnPhase, RunnerPreSpawnTiming, SessionHistoryMaterializer,
+    RunnerPreSpawnPhase, RunnerPreSpawnTiming, SessionHistoryMaterializer,
     SessionHistoryRestoreFallback, SessionHistoryRestorePlan, validate_resume_session_id,
 };
 use crate::http::HttpClient;
@@ -32,6 +32,7 @@ use crate::ids::RunId;
 use crate::paths::diagnostic_session_fingerprint;
 use crate::provider::{ClaimedJob, JobCandidate};
 use crate::resource_budget::{BudgetLease, ResourceBudget};
+use crate::restored_session_identity::RestoredSessionIdentity;
 use crate::run_cancellation::{RunCancellationHandle, SharedRunCancellationMap};
 use crate::status::{RunnerMode, StatusTracker};
 use crate::types::{ExecutionContext, SandboxReuseResult};
@@ -704,6 +705,36 @@ mod tests {
                 );
             }
             _ => panic!("missing reused identity should fall back to restore"),
+        }
+    }
+
+    #[tokio::test]
+    async fn restore_plan_falls_back_when_reused_identity_mismatches() {
+        let http = test_http_client();
+        let context = context_with_history_ref("history-hash-a");
+        let restored_identity = RestoredSessionIdentity::claude_code_for_test("history-hash-b");
+        let reusable_sandbox = reusable_sandbox_with_identity(Some(restored_identity)).await;
+        let cancel = RunCancellationHandle::new();
+        let mut timing = RunnerPreSpawnTiming::start_after_claim();
+
+        let plan = build_session_history_restore_plan(
+            &http,
+            &context,
+            true,
+            &cancel,
+            Some(&reusable_sandbox),
+            SandboxReuseResult::Reused,
+            &mut timing,
+        );
+
+        match plan {
+            SessionHistoryRestorePlan::Prestarted { fallback, .. } => {
+                assert_eq!(
+                    fallback,
+                    Some(SessionHistoryRestoreFallback::IdentityMismatch)
+                );
+            }
+            _ => panic!("mismatched reused identity should fall back to restore"),
         }
     }
 }

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -23,8 +23,8 @@ use super::idle_lifecycle::{
 use super::job_spawn::{JobProfile, SpawnContext, SpawnJobRequest, spawn_job};
 use crate::config::ProfileConfig;
 use crate::executor::{
-    RunnerPreSpawnPhase, RunnerPreSpawnTiming, SessionHistoryMaterializer,
-    validate_resume_session_id,
+    RestoredSessionIdentity, RunnerPreSpawnPhase, RunnerPreSpawnTiming, SessionHistoryMaterializer,
+    SessionHistoryRestoreFallback, SessionHistoryRestorePlan, validate_resume_session_id,
 };
 use crate::http::HttpClient;
 use crate::idle_pool::{IdlePoolSnapshot, IdleUnparkResult, ReusableIdleSandbox};
@@ -134,19 +134,6 @@ pub(super) async fn handle_discovered_job(job: DiscoveredJob, mut ctx: Discovere
             None
         },
     );
-    let started_at = Instant::now();
-    let session_history_materializer = start_session_history_materializer_after_claim(
-        &ctx.spawn_ctx.exec_config.http,
-        claimed.context(),
-        resume_session_valid,
-        &job_cancel,
-    );
-    if session_history_materializer.is_some() {
-        pre_spawn_timing.record_phase_elapsed(
-            RunnerPreSpawnPhase::SessionHistoryMaterializerStart,
-            started_at,
-        );
-    }
     info!(run_id = %run_id, profile = %profile_name, "job claimed, spawning executor");
     let started_at = Instant::now();
     let device_rate_limits = crate::io_limits::device_rate_limits_for_context(
@@ -169,6 +156,16 @@ pub(super) async fn handle_discovered_job(job: DiscoveredJob, mut ctx: Discovere
         &mut pre_spawn_timing,
     )
     .await;
+
+    let session_history_restore_plan = build_session_history_restore_plan(
+        &ctx.spawn_ctx.exec_config.http,
+        claimed.context(),
+        resume_session_valid,
+        &job_cancel,
+        reuse_entry.as_ref(),
+        reuse_result,
+        &mut pre_spawn_timing,
+    );
 
     // Determine sandbox_id after the reuse decision. On reuse, the sandbox keeps
     // its original identity; on a fresh create, allocate a new UUID for the
@@ -207,7 +204,7 @@ pub(super) async fn handle_discovered_job(job: DiscoveredJob, mut ctx: Discovere
             reuse_entry,
             reuse_result,
             pre_spawn_timing,
-            session_history_materializer,
+            session_history_restore_plan,
             active_cli_agent_session_guard,
         },
         ctx.spawn_ctx,
@@ -215,22 +212,58 @@ pub(super) async fn handle_discovered_job(job: DiscoveredJob, mut ctx: Discovere
     );
 }
 
-fn start_session_history_materializer_after_claim(
+fn build_session_history_restore_plan(
     http: &HttpClient,
     context: &ExecutionContext,
     resume_session_valid: bool,
     cancel: &RunCancellationHandle,
-) -> Option<SessionHistoryMaterializer> {
+    reuse_entry: Option<&ReusableIdleSandbox>,
+    reuse_result: SandboxReuseResult,
+    pre_spawn_timing: &mut RunnerPreSpawnTiming,
+) -> SessionHistoryRestorePlan {
     if !resume_session_valid {
-        return None;
+        return SessionHistoryRestorePlan::Default;
     }
-    let resume_session = context.resume_session.as_ref()?;
-    resume_session.history_ref()?;
-    Some(SessionHistoryMaterializer::start_cancellable(
-        http,
-        Some(resume_session),
-        cancel.token(),
-    ))
+    let Some(resume_session) = context.resume_session.as_ref() else {
+        return SessionHistoryRestorePlan::Default;
+    };
+    if resume_session.history_ref().is_none() {
+        return SessionHistoryRestorePlan::Default;
+    }
+
+    let fallback = match reuse_result {
+        SandboxReuseResult::Reused => {
+            let requested_identity = RestoredSessionIdentity::from_context(context);
+            if let Some(requested_identity) = requested_identity {
+                match reuse_entry.and_then(ReusableIdleSandbox::restored_session_identity) {
+                    Some(restored_identity) if restored_identity == &requested_identity => {
+                        return SessionHistoryRestorePlan::SkipVerified(requested_identity);
+                    }
+                    Some(_) => Some(SessionHistoryRestoreFallback::IdentityMismatch),
+                    None => Some(SessionHistoryRestoreFallback::MissingIdleIdentity),
+                }
+            } else {
+                Some(SessionHistoryRestoreFallback::IdentityMismatch)
+            }
+        }
+        SandboxReuseResult::NoSessionId
+        | SandboxReuseResult::PoolMiss
+        | SandboxReuseResult::ProfileMismatch
+        | SandboxReuseResult::DeviceLimitMismatch
+        | SandboxReuseResult::UnparkFailed => Some(SessionHistoryRestoreFallback::NonReuse),
+    };
+
+    let started_at = Instant::now();
+    let materializer =
+        SessionHistoryMaterializer::start_cancellable(http, Some(resume_session), cancel.token());
+    pre_spawn_timing.record_phase_elapsed(
+        RunnerPreSpawnPhase::SessionHistoryMaterializerStart,
+        started_at,
+    );
+    SessionHistoryRestorePlan::Prestarted {
+        materializer,
+        fallback,
+    }
 }
 
 async fn publish_active_run_status(
@@ -504,7 +537,13 @@ async fn try_reuse_from_pool(
 mod tests {
     use super::*;
 
+    use crate::http::HttpClientConfig;
+    use crate::idle_pool::test_support::ParkedIdleCandidateBuilder;
+    use crate::idle_pool::{IdlePool, IdlePoolConfig, ParkResult};
+    use crate::resource_budget::ResourceBudget;
     use crate::status::IdleVm;
+    use crate::test_fixtures::execution_context_for_test;
+    use crate::types::{ResumeSession, ResumeSessionHistory, ResumeSessionHistoryRef};
 
     fn read_active_run_phase(path: &std::path::Path) -> String {
         let raw = std::fs::read_to_string(path).unwrap();
@@ -523,6 +562,56 @@ mod tests {
                 sandbox_id: SandboxId::new_v4(),
             }],
         }
+    }
+
+    fn test_http_client() -> HttpClient {
+        HttpClient::new(HttpClientConfig {
+            api_url: "http://localhost".into(),
+            vercel_bypass: None,
+        })
+        .unwrap()
+    }
+
+    fn context_with_history_ref(history_hash: &str) -> ExecutionContext {
+        let mut context = execution_context_for_test(RunId::new_v4());
+        context.resume_session = Some(ResumeSession {
+            cli_agent_session_id: "sess-restore-plan".into(),
+            history: ResumeSessionHistory::Ref {
+                history_ref: ResumeSessionHistoryRef {
+                    kind: crate::types::ResumeSessionHistoryRefKind::Blob,
+                    hash: history_hash.into(),
+                    url: "http://127.0.0.1:9/history.blob".into(),
+                    size: Some(12),
+                },
+            },
+        });
+        context
+    }
+
+    async fn reusable_sandbox_with_identity(
+        restored_session_identity: Option<RestoredSessionIdentity>,
+    ) -> ReusableIdleSandbox {
+        let budget = Arc::new(ResourceBudget::new(1, 1, 1.0, 0));
+        let lease = ResourceBudget::try_reserve_lease(&budget, 1, 1).unwrap();
+        let builder = ParkedIdleCandidateBuilder::new("sess-restore-plan", lease);
+        let builder = if let Some(restored_session_identity) = restored_session_identity {
+            builder.with_restored_session_identity(restored_session_identity)
+        } else {
+            builder
+        };
+        let candidate = builder.build();
+        let mut pool = IdlePool::new(IdlePoolConfig {
+            default_timeout: std::time::Duration::from_secs(300),
+            max_idle: 0,
+        });
+        assert!(matches!(pool.park(candidate), ParkResult::Parked));
+        let entry = pool
+            .take("sess-restore-plan")
+            .expect("idle entry should exist");
+        let IdleUnparkResult::Reused { sandbox, .. } = entry.try_unpark().await else {
+            panic!("idle entry should unpark");
+        };
+        *sandbox
     }
 
     #[tokio::test]
@@ -559,5 +648,62 @@ mod tests {
         .await;
 
         assert_eq!(read_active_run_phase(&status_path), "running");
+    }
+
+    #[tokio::test]
+    async fn restore_plan_skips_matching_reused_identity() {
+        let http = test_http_client();
+        let context = context_with_history_ref("history-hash-a");
+        let requested_identity = RestoredSessionIdentity::from_context(&context).unwrap();
+        let reusable_sandbox =
+            reusable_sandbox_with_identity(Some(requested_identity.clone())).await;
+        let cancel = RunCancellationHandle::new();
+        let mut timing = RunnerPreSpawnTiming::start_after_claim();
+
+        let plan = build_session_history_restore_plan(
+            &http,
+            &context,
+            true,
+            &cancel,
+            Some(&reusable_sandbox),
+            SandboxReuseResult::Reused,
+            &mut timing,
+        );
+
+        match plan {
+            SessionHistoryRestorePlan::SkipVerified(identity) => {
+                assert_eq!(identity, requested_identity);
+            }
+            _ => panic!("matching reused identity should skip restore"),
+        }
+    }
+
+    #[tokio::test]
+    async fn restore_plan_falls_back_when_reused_identity_is_missing() {
+        let http = test_http_client();
+        let context = context_with_history_ref("history-hash-a");
+        let reusable_sandbox = reusable_sandbox_with_identity(None).await;
+        let cancel = RunCancellationHandle::new();
+        let mut timing = RunnerPreSpawnTiming::start_after_claim();
+
+        let plan = build_session_history_restore_plan(
+            &http,
+            &context,
+            true,
+            &cancel,
+            Some(&reusable_sandbox),
+            SandboxReuseResult::Reused,
+            &mut timing,
+        );
+
+        match plan {
+            SessionHistoryRestorePlan::Prestarted { fallback, .. } => {
+                assert_eq!(
+                    fallback,
+                    Some(SessionHistoryRestoreFallback::MissingIdleIdentity)
+                );
+            }
+            _ => panic!("missing reused identity should fall back to restore"),
+        }
     }
 }

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -238,13 +238,16 @@ fn build_session_history_restore_plan(
             if let Some(requested_identity) = requested_identity {
                 match reuse_entry.and_then(ReusableIdleSandbox::restored_session_identity) {
                     Some(restored_identity)
-                        if restored_identity == &requested_identity
-                            && restored_identity.has_guest_history_verification() =>
+                        if restored_identity.is_verified_match_for_request(&requested_identity) =>
                     {
                         return SessionHistoryRestorePlan::SkipVerified(restored_identity.clone());
                     }
                     Some(restored_identity) if restored_identity == &requested_identity => {
-                        Some(SessionHistoryRestoreFallback::UnverifiedIdleIdentity)
+                        if restored_identity.has_guest_history_verification() {
+                            Some(SessionHistoryRestoreFallback::IdentityMismatch)
+                        } else {
+                            Some(SessionHistoryRestoreFallback::UnverifiedIdleIdentity)
+                        }
                     }
                     Some(_) => Some(SessionHistoryRestoreFallback::IdentityMismatch),
                     None => Some(SessionHistoryRestoreFallback::MissingIdleIdentity),
@@ -580,6 +583,13 @@ mod tests {
     }
 
     fn context_with_history_ref(history_hash: &str) -> ExecutionContext {
+        context_with_history_ref_and_size(history_hash, Some(12))
+    }
+
+    fn context_with_history_ref_and_size(
+        history_hash: &str,
+        size: Option<u64>,
+    ) -> ExecutionContext {
         let mut context = execution_context_for_test(RunId::new_v4());
         context.resume_session = Some(ResumeSession {
             cli_agent_session_id: "sess-restore-plan".into(),
@@ -588,7 +598,7 @@ mod tests {
                     kind: crate::types::ResumeSessionHistoryRefKind::Blob,
                     hash: history_hash.into(),
                     url: "http://127.0.0.1:9/history.blob".into(),
-                    size: Some(12),
+                    size,
                 },
             },
         });
@@ -684,8 +694,50 @@ mod tests {
         match plan {
             SessionHistoryRestorePlan::SkipVerified(identity) => {
                 assert_eq!(identity, restored_identity);
+                assert_eq!(identity.history_size_bytes(), Some(12));
+                assert_eq!(
+                    identity.guest_history_path(),
+                    Some("/home/user/.claude/projects/-home-user-workspace/session.jsonl")
+                );
             }
             _ => panic!("matching reused identity should skip restore"),
+        }
+    }
+
+    #[tokio::test]
+    async fn restore_plan_skips_matching_reused_identity_without_requested_size() {
+        let http = test_http_client();
+        let context = context_with_history_ref_and_size("history-hash-a", None);
+        let requested_identity = RestoredSessionIdentity::from_context(&context).unwrap();
+        let restored_identity = requested_identity.clone().with_guest_history(
+            12,
+            "/home/user/.claude/projects/-home-user-workspace/session.jsonl",
+        );
+        let reusable_sandbox =
+            reusable_sandbox_with_identity(Some(restored_identity.clone())).await;
+        let cancel = RunCancellationHandle::new();
+        let mut timing = RunnerPreSpawnTiming::start_after_claim();
+
+        let plan = build_session_history_restore_plan(
+            &http,
+            &context,
+            true,
+            &cancel,
+            Some(&reusable_sandbox),
+            SandboxReuseResult::Reused,
+            &mut timing,
+        );
+
+        match plan {
+            SessionHistoryRestorePlan::SkipVerified(identity) => {
+                assert_eq!(identity, restored_identity);
+                assert_eq!(identity.history_size_bytes(), Some(12));
+                assert_eq!(
+                    identity.guest_history_path(),
+                    Some("/home/user/.claude/projects/-home-user-workspace/session.jsonl")
+                );
+            }
+            _ => panic!("missing requested size should still allow verified skip"),
         }
     }
 
@@ -748,6 +800,41 @@ mod tests {
                 );
             }
             _ => panic!("reused identity with empty history path should fall back to restore"),
+        }
+    }
+
+    #[tokio::test]
+    async fn restore_plan_falls_back_when_matching_reused_identity_size_mismatches() {
+        let http = test_http_client();
+        let context = context_with_history_ref("history-hash-a");
+        let restored_identity = RestoredSessionIdentity::from_context(&context)
+            .unwrap()
+            .with_guest_history(
+                13,
+                "/home/user/.claude/projects/-home-user-workspace/session.jsonl",
+            );
+        let reusable_sandbox = reusable_sandbox_with_identity(Some(restored_identity)).await;
+        let cancel = RunCancellationHandle::new();
+        let mut timing = RunnerPreSpawnTiming::start_after_claim();
+
+        let plan = build_session_history_restore_plan(
+            &http,
+            &context,
+            true,
+            &cancel,
+            Some(&reusable_sandbox),
+            SandboxReuseResult::Reused,
+            &mut timing,
+        );
+
+        match plan {
+            SessionHistoryRestorePlan::Prestarted { fallback, .. } => {
+                assert_eq!(
+                    fallback,
+                    Some(SessionHistoryRestoreFallback::IdentityMismatch)
+                );
+            }
+            _ => panic!("reused identity with mismatched size should fall back to restore"),
         }
     }
 

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -29,7 +29,7 @@ use super::sandbox_finalization::{FinalizeContext, finalize_sandbox_for_completi
 use super::{OuterJobPanicPoint, StartLoopTestObserver, maybe_panic_outer_job};
 use crate::executor::{
     self, ExecutionFailureKind, ExecutorConfig, RunnerPreSpawnPhase, RunnerPreSpawnTiming,
-    SessionHistoryMaterializer,
+    SessionHistoryRestorePlan,
 };
 use crate::idle_pool::{ParkingGate, ReusableIdleSandbox};
 use crate::ids::RunId;
@@ -90,7 +90,7 @@ pub(super) struct SpawnJobRequest {
     pub(super) reuse_entry: Option<ReusableIdleSandbox>,
     pub(super) reuse_result: SandboxReuseResult,
     pub(super) pre_spawn_timing: RunnerPreSpawnTiming,
-    pub(super) session_history_materializer: Option<SessionHistoryMaterializer>,
+    pub(super) session_history_restore_plan: SessionHistoryRestorePlan,
     pub(super) active_cli_agent_session_guard: ActiveCliAgentSessionGuard,
 }
 
@@ -104,7 +104,7 @@ struct ExecutorInvocation {
     reuse_entry: Option<ReusableIdleSandbox>,
     reuse_result: SandboxReuseResult,
     pre_spawn_timing: RunnerPreSpawnTiming,
-    session_history_materializer: Option<SessionHistoryMaterializer>,
+    session_history_restore_plan: SessionHistoryRestorePlan,
     cancel: CancellationToken,
     sandbox_token: String,
     sandbox_prepared: Option<executor::SandboxPreparedNotifier>,
@@ -130,7 +130,7 @@ impl ExecutorInvocation {
             reuse_entry,
             reuse_result,
             pre_spawn_timing,
-            session_history_materializer,
+            session_history_restore_plan,
             cancel,
             sandbox_token,
             sandbox_prepared,
@@ -153,7 +153,7 @@ impl ExecutorInvocation {
                         sandbox_prepared: None,
                         active_input_source,
                         pre_spawn_timing: Some(pre_spawn_timing),
-                        session_history_materializer,
+                        session_history_restore_plan,
                     },
                 )
                 .await
@@ -172,7 +172,7 @@ impl ExecutorInvocation {
                         sandbox_prepared,
                         active_input_source,
                         pre_spawn_timing: Some(pre_spawn_timing),
-                        session_history_materializer,
+                        session_history_restore_plan,
                     },
                 )
                 .await
@@ -211,6 +211,7 @@ impl ExecutorInvocation {
                         network_log_session: None,
                         workspace_image: None,
                         discovered_cli_agent_session_id: None,
+                        restored_session_identity: None,
                     },
                     exit_code,
                     err,
@@ -290,6 +291,7 @@ impl FinalizationPhase {
             network_log_session,
             workspace_image,
             discovered_cli_agent_session_id,
+            restored_session_identity,
         } = outcome;
 
         let completion_payload = CompletionPayload::new(
@@ -313,6 +315,7 @@ impl FinalizationPhase {
                 profile_name,
                 cli_agent_session_id,
                 discovered_cli_agent_session_id,
+                restored_session_identity,
                 source_ip,
                 network_log_session,
                 workspace_image,
@@ -453,7 +456,7 @@ pub(super) fn spawn_job(
         reuse_entry,
         reuse_result,
         pre_spawn_timing,
-        session_history_materializer,
+        session_history_restore_plan,
         active_cli_agent_session_guard,
     } = request;
     let (context, completion_auth, active_input_source) = claimed.into_parts();
@@ -543,7 +546,7 @@ pub(super) fn spawn_job(
         reuse_entry,
         reuse_result,
         pre_spawn_timing,
-        session_history_materializer,
+        session_history_restore_plan,
         cancel: job_cancel.token(),
         sandbox_token: sandbox_token.clone(),
         sandbox_prepared,

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -21,7 +21,6 @@ use super::job_lifecycle::{
 use super::ownership::OwnershipTransitions;
 #[cfg(test)]
 use super::{OuterJobPanicPoint, StartLoopTestObserver, maybe_panic_outer_job};
-use crate::executor::RestoredSessionIdentity;
 use crate::idle_pool::{
     DestroyOutcome, IdleDestroyPayload, IdleParkActiveParts, IdleParkRequest, IdleParkRequestParts,
     ParkResult, ParkingGate,
@@ -33,6 +32,7 @@ use crate::paths::diagnostic_session_fingerprint;
 #[cfg(test)]
 use crate::provider::CompletionAuth;
 use crate::resource_budget::BudgetLease;
+use crate::restored_session_identity::RestoredSessionIdentity;
 use crate::run_cancellation::RunCancellationHandle;
 use crate::status::StatusTracker;
 use crate::storage_fingerprints::StorageFingerprints;

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -21,6 +21,7 @@ use super::job_lifecycle::{
 use super::ownership::OwnershipTransitions;
 #[cfg(test)]
 use super::{OuterJobPanicPoint, StartLoopTestObserver, maybe_panic_outer_job};
+use crate::executor::RestoredSessionIdentity;
 use crate::idle_pool::{
     DestroyOutcome, IdleDestroyPayload, IdleParkActiveParts, IdleParkRequest, IdleParkRequestParts,
     ParkResult, ParkingGate,
@@ -64,6 +65,7 @@ pub(super) struct FinalizeContext {
     pub(super) profile_name: String,
     pub(super) cli_agent_session_id: Option<String>,
     pub(super) discovered_cli_agent_session_id: Option<String>,
+    pub(super) restored_session_identity: Option<RestoredSessionIdentity>,
     pub(super) source_ip: String,
     pub(super) network_log_session: Option<NetworkLogSession>,
     pub(super) workspace_image: Option<WorkspaceImageLease>,
@@ -101,6 +103,7 @@ pub(super) async fn finalize_sandbox_for_completion(
         profile_name,
         cli_agent_session_id,
         discovered_cli_agent_session_id,
+        restored_session_identity,
         source_ip,
         mut network_log_session,
         workspace_image,
@@ -168,6 +171,7 @@ pub(super) async fn finalize_sandbox_for_completion(
             budget_lease: active_lease.into_idle_park_lease(),
             source_ip,
             storage_fingerprints,
+            restored_session_identity,
             workspace_image_size_bytes,
             workspace_promotion,
         });
@@ -672,6 +676,7 @@ mod tests {
                 profile_name: "vm0/default".into(),
                 cli_agent_session_id: Some(session_id.into()),
                 discovered_cli_agent_session_id: None,
+                restored_session_identity: None,
                 source_ip: "10.0.0.1".into(),
                 network_log_session: Some(network_log_session),
                 workspace_image: None,
@@ -1375,6 +1380,7 @@ mod tests {
             device_rate_limits: None,
             budget_lease: existing_lease,
             storage_fingerprints: crate::storage_fingerprints::StorageFingerprints::default(),
+            restored_session_identity: None,
             workspace_image_size_bytes: b"image".len() as u64,
             workspace_promotion: Some(old_promotion),
         })

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -104,17 +104,10 @@ async fn verify_restored_session_identity_for_reuse(
     identity: Option<RestoredSessionIdentity>,
 ) -> Option<RestoredSessionIdentity> {
     let identity = identity?;
-    let Some(expected_size) = identity.history_size_bytes() else {
+    let Some((expected_size, guest_history_path)) = identity.guest_history_verification() else {
         debug!(
             run_id = %context.run_id,
-            "restored session identity cannot be verified without history size"
-        );
-        return None;
-    };
-    let Some(guest_history_path) = identity.guest_history_path() else {
-        debug!(
-            run_id = %context.run_id,
-            "restored session identity cannot be verified without guest history path"
+            "restored session identity cannot be verified without history size and absolute guest history path"
         );
         return None;
     };

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -5,9 +5,10 @@ use sandbox::{
     EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, ExecTermination, ProcessControlMode, ProcessOutputMode,
     Sandbox, StartProcessRequest,
 };
+use sha2::{Digest, Sha256};
 use shell_quote::quote_shell_arg;
 use tokio_util::sync::CancellationToken;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use super::diagnostics::{
     AgentBootstrapAbnormalExitLogContext, AgentStdoutStreamDiagnostics, StdoutDrainReport,
@@ -38,6 +39,7 @@ use crate::telemetry::JobTelemetry;
 use crate::types::{ExecutionContext, GuestDownloadManifest};
 
 const AGENT_WRAPPER_STDERR_CAPTURE_LIMIT_BYTES: u32 = 64 * 1024;
+const RESTORED_SESSION_IDENTITY_VERIFY_MAX_BYTES: u64 = 1024 * 1024;
 const SESSION_HISTORY_DOWNLOAD_TELEMETRY_ERROR: &str = "session history download failed";
 const SESSION_HISTORY_MATERIALIZATION_WAIT_TELEMETRY_ERROR: &str =
     "session history materialization failed";
@@ -88,6 +90,81 @@ pub(super) fn build_agent_start_command(run_agent_path: &str) -> String {
         fi; \
         exec {run_agent_path} 2>&1"
     )
+}
+
+async fn verify_restored_session_identity_for_reuse(
+    sandbox: &dyn Sandbox,
+    context: &ExecutionContext,
+    identity: Option<RestoredSessionIdentity>,
+) -> Option<RestoredSessionIdentity> {
+    let identity = identity?;
+    let Some(expected_size) = identity.history_size_bytes() else {
+        debug!(
+            run_id = %context.run_id,
+            "restored session identity cannot be verified without history size"
+        );
+        return None;
+    };
+    let Some(guest_history_path) = identity.guest_history_path() else {
+        debug!(
+            run_id = %context.run_id,
+            "restored session identity cannot be verified without guest history path"
+        );
+        return None;
+    };
+    let Some(read_limit) = expected_size.checked_add(1) else {
+        debug!(
+            run_id = %context.run_id,
+            "restored session identity cannot be verified because history size overflowed"
+        );
+        return None;
+    };
+    if read_limit > RESTORED_SESSION_IDENTITY_VERIFY_MAX_BYTES {
+        debug!(
+            run_id = %context.run_id,
+            expected_size,
+            "restored session identity verification skipped for large history"
+        );
+        return None;
+    }
+
+    let read_result = sandbox.read_file(guest_history_path, read_limit).await;
+    let bytes = match read_result {
+        Ok(Some(bytes)) => bytes,
+        Ok(None) => {
+            debug!(
+                run_id = %context.run_id,
+                "restored session identity invalidated because history file is missing"
+            );
+            return None;
+        }
+        Err(_) => {
+            debug!(
+                run_id = %context.run_id,
+                "restored session identity verification failed"
+            );
+            return None;
+        }
+    };
+    if bytes.len() as u64 != expected_size {
+        debug!(
+            run_id = %context.run_id,
+            expected_size,
+            actual_size = bytes.len(),
+            "restored session identity invalidated because history size changed"
+        );
+        return None;
+    }
+    let actual_hash = hex::encode(Sha256::digest(&bytes));
+    if actual_hash != identity.history_hash() {
+        debug!(
+            run_id = %context.run_id,
+            "restored session identity invalidated because history hash changed"
+        );
+        return None;
+    }
+
+    Some(identity)
 }
 
 pub(super) struct ProcessCancelTimeouts {
@@ -457,7 +534,6 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
             .as_ref()
             .or(context.resume_session.as_ref());
         if let Some(session) = resume_session {
-            let requested_identity = RestoredSessionIdentity::from_context(context);
             let t = Instant::now();
             let result = restore_session(sandbox, context, session).await;
             let err = result.as_ref().err().map(|e| e.to_string());
@@ -467,8 +543,9 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                 result.is_ok(),
                 err.as_deref(),
             );
-            session_restore_diagnostics = Some(result?);
-            restored_session_identity = requested_identity;
+            let diagnostics = result?;
+            restored_session_identity = diagnostics.restored_session_identity.clone();
+            session_restore_diagnostics = Some(diagnostics);
         }
     }
 
@@ -908,6 +985,12 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
     } else {
         None
     };
+
+    if failure.is_none() {
+        restored_session_identity =
+            verify_restored_session_identity_for_reuse(sandbox, context, restored_session_identity)
+                .await;
+    }
 
     let agent_result = match failure {
         Some(failure) => AgentExecutionResult {

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -21,7 +21,7 @@ use super::diagnostics::{
 use super::env::{build_env_json, build_user_env_json, write_user_env_file};
 use super::guest_state::{restore_guest_state, sync_guest_timezone};
 use super::session_history_download::{SessionHistoryMaterialization, SessionHistoryMaterializer};
-use super::session_restore::{RestoredSessionIdentity, restore_session};
+use super::session_restore::restore_session;
 use super::storage::{apply_storage_fingerprint_reuse, download_storages, guest_download_has_work};
 use super::telemetry::{RunnerSpawnTiming, record_api_latency};
 use super::{
@@ -33,6 +33,7 @@ use super::{
 use crate::active_input::ActiveInputSource;
 use crate::helper_exec::{helper_exec_succeeded, helper_exec_termination_label};
 use crate::paths::guest;
+use crate::restored_session_identity::RestoredSessionIdentity;
 use crate::telemetry::JobTelemetry;
 use crate::types::{ExecutionContext, GuestDownloadManifest};
 

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -39,7 +39,6 @@ use crate::telemetry::JobTelemetry;
 use crate::types::{ExecutionContext, GuestDownloadManifest};
 
 const AGENT_WRAPPER_STDERR_CAPTURE_LIMIT_BYTES: u32 = 64 * 1024;
-const RESTORED_SESSION_IDENTITY_VERIFY_MAX_BYTES: u64 = 1024 * 1024;
 const SESSION_HISTORY_DOWNLOAD_TELEMETRY_ERROR: &str = "session history download failed";
 const SESSION_HISTORY_MATERIALIZATION_WAIT_TELEMETRY_ERROR: &str =
     "session history materialization failed";
@@ -104,30 +103,17 @@ async fn verify_restored_session_identity_for_reuse(
     identity: Option<RestoredSessionIdentity>,
 ) -> Option<RestoredSessionIdentity> {
     let identity = identity?;
-    let Some((expected_size, guest_history_path)) = identity.guest_history_verification() else {
+    let Some(verification) = identity.guest_history_verification() else {
         debug!(
             run_id = %context.run_id,
-            "restored session identity cannot be verified without history size and absolute guest history path"
+            "restored session identity cannot be verified without bounded history size and absolute guest history path"
         );
         return None;
     };
-    let Some(read_limit) = expected_size.checked_add(1) else {
-        debug!(
-            run_id = %context.run_id,
-            "restored session identity cannot be verified because history size overflowed"
-        );
-        return None;
-    };
-    if read_limit > RESTORED_SESSION_IDENTITY_VERIFY_MAX_BYTES {
-        debug!(
-            run_id = %context.run_id,
-            expected_size,
-            "restored session identity verification skipped for large history"
-        );
-        return None;
-    }
 
-    let read_result = sandbox.read_file(guest_history_path, read_limit).await;
+    let read_result = sandbox
+        .read_file(verification.guest_history_path, verification.read_limit)
+        .await;
     let bytes = match read_result {
         Ok(Some(bytes)) => bytes,
         Ok(None) => {
@@ -145,10 +131,10 @@ async fn verify_restored_session_identity_for_reuse(
             return None;
         }
     };
-    if bytes.len() as u64 != expected_size {
+    if bytes.len() as u64 != verification.expected_size {
         debug!(
             run_id = %context.run_id,
-            expected_size,
+            expected_size = verification.expected_size,
             actual_size = bytes.len(),
             "restored session identity invalidated because history size changed"
         );

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -21,7 +21,7 @@ use super::diagnostics::{
 use super::env::{build_env_json, build_user_env_json, write_user_env_file};
 use super::guest_state::{restore_guest_state, sync_guest_timezone};
 use super::session_history_download::{SessionHistoryMaterialization, SessionHistoryMaterializer};
-use super::session_restore::restore_session;
+use super::session_restore::{RestoredSessionIdentity, restore_session};
 use super::storage::{apply_storage_fingerprint_reuse, download_storages, guest_download_has_work};
 use super::telemetry::{RunnerSpawnTiming, record_api_latency};
 use super::{
@@ -40,6 +40,35 @@ const AGENT_WRAPPER_STDERR_CAPTURE_LIMIT_BYTES: u32 = 64 * 1024;
 const SESSION_HISTORY_DOWNLOAD_TELEMETRY_ERROR: &str = "session history download failed";
 const SESSION_HISTORY_MATERIALIZATION_WAIT_TELEMETRY_ERROR: &str =
     "session history materialization failed";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum SessionHistoryRestoreFallback {
+    NonReuse,
+    MissingIdleIdentity,
+    IdentityMismatch,
+}
+
+impl SessionHistoryRestoreFallback {
+    const fn action_type(self) -> &'static str {
+        match self {
+            Self::NonReuse => "session_history_restore_fallback_non_reuse",
+            Self::MissingIdleIdentity => "session_history_restore_fallback_missing_idle_identity",
+            Self::IdentityMismatch => "session_history_restore_fallback_identity_mismatch",
+        }
+    }
+}
+
+#[derive(Default)]
+#[must_use = "restore plans decide whether resume history download can be skipped"]
+pub(crate) enum SessionHistoryRestorePlan {
+    #[default]
+    Default,
+    Prestarted {
+        materializer: SessionHistoryMaterializer,
+        fallback: Option<SessionHistoryRestoreFallback>,
+    },
+    SkipVerified(RestoredSessionIdentity),
+}
 
 pub(super) fn build_agent_start_command(run_agent_path: &str) -> String {
     let run_agent_path = quote_shell_arg(run_agent_path);
@@ -68,6 +97,7 @@ pub(super) struct ProcessCancelTimeouts {
 pub(super) struct AgentExecutionResult {
     pub(super) failure: Option<ExecutionFailure>,
     pub(super) stdout_stream_diagnostics: AgentStdoutStreamDiagnostics,
+    pub(super) restored_session_identity: Option<RestoredSessionIdentity>,
 }
 
 impl AgentExecutionResult {
@@ -75,6 +105,7 @@ impl AgentExecutionResult {
         Self {
             failure: None,
             stdout_stream_diagnostics: AgentStdoutStreamDiagnostics::default(),
+            restored_session_identity: None,
         }
     }
 
@@ -86,6 +117,7 @@ impl AgentExecutionResult {
         Self {
             failure: Some(ExecutionFailure::new(exit_code, error, diagnostic)),
             stdout_stream_diagnostics: AgentStdoutStreamDiagnostics::default(),
+            restored_session_identity: None,
         }
     }
 
@@ -102,6 +134,14 @@ impl AgentExecutionResult {
         diagnostics: AgentStdoutStreamDiagnostics,
     ) -> Self {
         self.stdout_stream_diagnostics = diagnostics;
+        self
+    }
+
+    pub(super) fn with_restored_session_identity(
+        mut self,
+        restored_session_identity: Option<RestoredSessionIdentity>,
+    ) -> Self {
+        self.restored_session_identity = restored_session_identity;
         self
     }
 
@@ -219,7 +259,7 @@ pub(super) struct RunControls {
     pub(super) cancel: CancellationToken,
     pub(super) active_input_source: Option<ActiveInputSource>,
     pub(super) spawn_timing: Option<RunnerSpawnTiming>,
-    pub(super) session_history_materializer: Option<SessionHistoryMaterializer>,
+    pub(super) session_history_restore_plan: SessionHistoryRestorePlan,
 }
 
 impl RunControls {
@@ -231,7 +271,7 @@ impl RunControls {
             cancel,
             active_input_source,
             spawn_timing: None,
-            session_history_materializer: None,
+            session_history_restore_plan: SessionHistoryRestorePlan::Default,
         }
     }
 
@@ -240,11 +280,11 @@ impl RunControls {
         self
     }
 
-    pub(super) fn with_session_history_materializer(
+    pub(super) fn with_session_history_restore_plan(
         mut self,
-        materializer: Option<SessionHistoryMaterializer>,
+        plan: SessionHistoryRestorePlan,
     ) -> Self {
-        self.session_history_materializer = materializer;
+        self.session_history_restore_plan = plan;
         self
     }
 }
@@ -282,15 +322,8 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         cancel,
         active_input_source,
         spawn_timing,
-        session_history_materializer,
+        session_history_restore_plan,
     } = controls;
-    let session_history_materializer = session_history_materializer.unwrap_or_else(|| {
-        SessionHistoryMaterializer::start_cancellable(
-            &config.http,
-            context.resume_session.as_ref(),
-            cancel.clone(),
-        )
-    });
 
     // 1. Fix guest clock and reseed entropy (must happen before HTTPS calls).
     //    Needed after snapshot restore (frozen clock) and after idle reuse (drifted clock).
@@ -356,60 +389,86 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         result?;
     }
 
-    // 4. Restore session history. Hash-backed history downloads can start
-    // before sandbox preparation, then materialize here right before restore.
-    let should_record_materialization_wait = session_history_materializer.is_downloading();
-    let materialization_wait_started = Instant::now();
-    let materialization = session_history_materializer.finish(&cancel).await;
-    let materialization_wait = materialization_wait_started.elapsed();
-    let downloaded_resume_session = match materialization {
-        SessionHistoryMaterialization::Missing => None,
-        SessionHistoryMaterialization::Ready => None,
-        SessionHistoryMaterialization::Downloaded { session, elapsed } => {
-            if should_record_materialization_wait {
-                telemetry.record(
-                    "session_history_materialization_wait",
-                    materialization_wait,
-                    true,
-                    None,
-                );
-            }
-            telemetry.record("session_history_download", elapsed, true, None);
-            Some(session)
+    let mut session_restore_diagnostics = None;
+    let mut restored_session_identity = None;
+    let session_history_materializer = match session_history_restore_plan {
+        SessionHistoryRestorePlan::SkipVerified(identity) => {
+            telemetry.record("session_history_restore_skip", Duration::ZERO, true, None);
+            restored_session_identity = Some(identity);
+            None
         }
-        SessionHistoryMaterialization::Failed { elapsed, error } => {
-            if should_record_materialization_wait {
-                telemetry.record(
-                    "session_history_materialization_wait",
-                    materialization_wait,
-                    false,
-                    Some(SESSION_HISTORY_MATERIALIZATION_WAIT_TELEMETRY_ERROR),
-                );
+        SessionHistoryRestorePlan::Default => Some(SessionHistoryMaterializer::start_cancellable(
+            &config.http,
+            context.resume_session.as_ref(),
+            cancel.clone(),
+        )),
+        SessionHistoryRestorePlan::Prestarted {
+            materializer,
+            fallback,
+        } => {
+            if let Some(fallback) = fallback {
+                telemetry.record(fallback.action_type(), Duration::ZERO, true, None);
             }
-            telemetry.record(
-                "session_history_download",
-                elapsed,
-                false,
-                Some(SESSION_HISTORY_DOWNLOAD_TELEMETRY_ERROR),
-            );
-            return Err(error);
+            Some(materializer)
         }
     };
-    let resume_session = downloaded_resume_session
-        .as_ref()
-        .or(context.resume_session.as_ref());
-    let mut session_restore_diagnostics = None;
-    if let Some(session) = resume_session {
-        let t = Instant::now();
-        let result = restore_session(sandbox, context, session).await;
-        let err = result.as_ref().err().map(|e| e.to_string());
-        telemetry.record(
-            "session_restore",
-            t.elapsed(),
-            result.is_ok(),
-            err.as_deref(),
-        );
-        session_restore_diagnostics = Some(result?);
+    if let Some(session_history_materializer) = session_history_materializer {
+        // 4. Restore session history. Hash-backed history downloads can start
+        // before sandbox preparation, then materialize here right before restore.
+        let should_record_materialization_wait = session_history_materializer.is_downloading();
+        let materialization_wait_started = Instant::now();
+        let materialization = session_history_materializer.finish(&cancel).await;
+        let materialization_wait = materialization_wait_started.elapsed();
+        let downloaded_resume_session = match materialization {
+            SessionHistoryMaterialization::Missing => None,
+            SessionHistoryMaterialization::Ready => None,
+            SessionHistoryMaterialization::Downloaded { session, elapsed } => {
+                if should_record_materialization_wait {
+                    telemetry.record(
+                        "session_history_materialization_wait",
+                        materialization_wait,
+                        true,
+                        None,
+                    );
+                }
+                telemetry.record("session_history_download", elapsed, true, None);
+                Some(session)
+            }
+            SessionHistoryMaterialization::Failed { elapsed, error } => {
+                if should_record_materialization_wait {
+                    telemetry.record(
+                        "session_history_materialization_wait",
+                        materialization_wait,
+                        false,
+                        Some(SESSION_HISTORY_MATERIALIZATION_WAIT_TELEMETRY_ERROR),
+                    );
+                }
+                telemetry.record(
+                    "session_history_download",
+                    elapsed,
+                    false,
+                    Some(SESSION_HISTORY_DOWNLOAD_TELEMETRY_ERROR),
+                );
+                return Err(error);
+            }
+        };
+        let resume_session = downloaded_resume_session
+            .as_ref()
+            .or(context.resume_session.as_ref());
+        if let Some(session) = resume_session {
+            let requested_identity = RestoredSessionIdentity::from_context(context);
+            let t = Instant::now();
+            let result = restore_session(sandbox, context, session).await;
+            let err = result.as_ref().err().map(|e| e.to_string());
+            telemetry.record(
+                "session_restore",
+                t.elapsed(),
+                result.is_ok(),
+                err.as_deref(),
+            );
+            session_restore_diagnostics = Some(result?);
+            restored_session_identity = requested_identity;
+        }
     }
 
     // 5. Build env vars. The guest-agent bootstrap env is runner-owned only;
@@ -662,7 +721,8 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                     .to_string();
                 telemetry.record("agent_execute", t.elapsed(), false, Some(&error));
                 return Ok(AgentExecutionResult::failure(1, error, None)
-                    .with_resource_failure_kind(ResourceFailureKind::HostMemoryOomKilled));
+                    .with_resource_failure_kind(ResourceFailureKind::HostMemoryOomKilled)
+                    .with_restored_session_identity(restored_session_identity));
             }
             let error = e.to_string();
             telemetry.record("agent_execute", t.elapsed(), false, Some(&error));
@@ -677,6 +737,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                         None,
                     )),
                     stdout_stream_diagnostics: stdout_stream_diagnostics_on_wait_error,
+                    restored_session_identity,
                 });
             }
             return Err(e.into());
@@ -740,7 +801,8 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                 telemetry.record("agent_execute", t.elapsed(), false, Some(error));
                 return Ok(AgentExecutionResult::failure(1, error, None)
                     .with_resource_failure_kind(ResourceFailureKind::GuestMemoryOomKilled)
-                    .with_stdout_stream_diagnostics(stdout_stream_diagnostics));
+                    .with_stdout_stream_diagnostics(stdout_stream_diagnostics)
+                    .with_restored_session_identity(restored_session_identity));
             }
             Err(e) => {
                 warn!(run_id = %context.run_id, error = %e, "failed to exec dmesg for OOM check");
@@ -850,9 +912,11 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         Some(failure) => AgentExecutionResult {
             failure: Some(failure),
             stdout_stream_diagnostics,
+            restored_session_identity,
         },
         None => AgentExecutionResult::success()
-            .with_stdout_stream_diagnostics(stdout_stream_diagnostics),
+            .with_stdout_stream_diagnostics(stdout_stream_diagnostics)
+            .with_restored_session_identity(restored_session_identity),
     };
     telemetry.record(
         "agent_execute",

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -103,6 +103,20 @@ async fn verify_restored_session_identity_for_reuse(
     identity: Option<RestoredSessionIdentity>,
 ) -> Option<RestoredSessionIdentity> {
     let identity = identity?;
+    let Some(requested_identity) = RestoredSessionIdentity::from_context(context) else {
+        debug!(
+            run_id = %context.run_id,
+            "restored session identity cannot be verified without a valid hash-backed resume request"
+        );
+        return None;
+    };
+    if !identity.is_verified_match_for_request(&requested_identity) {
+        debug!(
+            run_id = %context.run_id,
+            "restored session identity invalidated because it does not match the resume request"
+        );
+        return None;
+    }
     let Some(verification) = identity.guest_history_verification() else {
         debug!(
             run_id = %context.run_id,

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -49,6 +49,7 @@ pub(crate) enum SessionHistoryRestoreFallback {
     NonReuse,
     MissingIdleIdentity,
     UnverifiedIdleIdentity,
+    StaleIdleIdentity,
     IdentityMismatch,
 }
 
@@ -60,6 +61,7 @@ impl SessionHistoryRestoreFallback {
             Self::UnverifiedIdleIdentity => {
                 "session_history_restore_fallback_unverified_idle_identity"
             }
+            Self::StaleIdleIdentity => "session_history_restore_fallback_stale_idle_identity",
             Self::IdentityMismatch => "session_history_restore_fallback_identity_mismatch",
         }
     }
@@ -475,9 +477,27 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
     let mut restored_session_identity = None;
     let session_history_materializer = match session_history_restore_plan {
         SessionHistoryRestorePlan::SkipVerified(identity) => {
-            telemetry.record("session_history_restore_skip", Duration::ZERO, true, None);
-            restored_session_identity = Some(identity);
-            None
+            match verify_restored_session_identity_for_reuse(sandbox, context, Some(identity)).await
+            {
+                Some(identity) => {
+                    telemetry.record("session_history_restore_skip", Duration::ZERO, true, None);
+                    restored_session_identity = Some(identity);
+                    None
+                }
+                None => {
+                    telemetry.record(
+                        SessionHistoryRestoreFallback::StaleIdleIdentity.action_type(),
+                        Duration::ZERO,
+                        true,
+                        None,
+                    );
+                    Some(SessionHistoryMaterializer::start_cancellable(
+                        &config.http,
+                        context.resume_session.as_ref(),
+                        cancel.clone(),
+                    ))
+                }
+            }
         }
         SessionHistoryRestorePlan::Default => Some(SessionHistoryMaterializer::start_cancellable(
             &config.http,

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -48,6 +48,7 @@ const SESSION_HISTORY_MATERIALIZATION_WAIT_TELEMETRY_ERROR: &str =
 pub(crate) enum SessionHistoryRestoreFallback {
     NonReuse,
     MissingIdleIdentity,
+    UnverifiedIdleIdentity,
     IdentityMismatch,
 }
 
@@ -56,6 +57,9 @@ impl SessionHistoryRestoreFallback {
         match self {
             Self::NonReuse => "session_history_restore_fallback_non_reuse",
             Self::MissingIdleIdentity => "session_history_restore_fallback_missing_idle_identity",
+            Self::UnverifiedIdleIdentity => {
+                "session_history_restore_fallback_unverified_idle_identity"
+            }
             Self::IdentityMismatch => "session_history_restore_fallback_identity_mismatch",
         }
     }

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -36,8 +36,10 @@ mod session_restore;
 mod storage;
 mod telemetry;
 
+pub(crate) use agent_run::{SessionHistoryRestoreFallback, SessionHistoryRestorePlan};
 pub(crate) use guest_state::{is_valid_guest_timezone_name, restore_guest_state_with_timezone};
 pub(crate) use session_history_download::SessionHistoryMaterializer;
+pub(crate) use session_restore::RestoredSessionIdentity;
 
 use crate::active_input::ActiveInputSource;
 use agent_run::{ProcessCancelTimeouts, RunControls};
@@ -192,7 +194,7 @@ pub(crate) struct ExecutionHooks {
     pub(crate) sandbox_prepared: Option<SandboxPreparedNotifier>,
     pub(crate) active_input_source: Option<ActiveInputSource>,
     pub(crate) pre_spawn_timing: Option<RunnerPreSpawnTiming>,
-    pub(crate) session_history_materializer: Option<SessionHistoryMaterializer>,
+    pub(crate) session_history_restore_plan: SessionHistoryRestorePlan,
 }
 
 impl ExecutionHooks {
@@ -202,7 +204,7 @@ impl ExecutionHooks {
             sandbox_prepared: None,
             active_input_source: None,
             pre_spawn_timing: None,
-            session_history_materializer: None,
+            session_history_restore_plan: SessionHistoryRestorePlan::Default,
         }
     }
 }
@@ -220,6 +222,7 @@ pub struct ExecuteOutcome {
     /// CLI-generated session ID read from the guest after execution.
     /// Used for first-run VM parking when `resume_session` is absent.
     pub discovered_cli_agent_session_id: Option<String>,
+    pub restored_session_identity: Option<RestoredSessionIdentity>,
 }
 
 impl ExecuteOutcome {
@@ -425,7 +428,7 @@ pub(crate) async fn execute_job_with_prepared_notifier(
         sandbox_prepared,
         active_input_source,
         pre_spawn_timing,
-        session_history_materializer,
+        session_history_restore_plan,
     } = hooks;
     let spawn_timing = RunnerSpawnTiming::start(pre_spawn_timing);
     let run_id = context.run_id;
@@ -450,6 +453,7 @@ pub(crate) async fn execute_job_with_prepared_notifier(
             network_log_session: None,
             workspace_image: None,
             discovered_cli_agent_session_id: None,
+            restored_session_identity: None,
         }
     } else {
         match execute_new_sandbox_with_prepared_notifier(
@@ -462,7 +466,7 @@ pub(crate) async fn execute_job_with_prepared_notifier(
             NewSandboxHooks {
                 controls: RunControls::new(cancel, active_input_source)
                     .with_spawn_timing(spawn_timing)
-                    .with_session_history_materializer(session_history_materializer),
+                    .with_session_history_restore_plan(session_history_restore_plan),
                 sandbox_prepared: sandbox_prepared.as_ref(),
             },
         )
@@ -476,6 +480,7 @@ pub(crate) async fn execute_job_with_prepared_notifier(
                 network_log_session: None,
                 workspace_image: None,
                 discovered_cli_agent_session_id: None,
+                restored_session_identity: None,
             },
         }
     };
@@ -521,7 +526,7 @@ pub(crate) async fn execute_job_reuse_with_hooks(
         sandbox_prepared: _,
         active_input_source,
         pre_spawn_timing,
-        session_history_materializer,
+        session_history_restore_plan,
     } = hooks;
     let spawn_timing = RunnerSpawnTiming::start(pre_spawn_timing);
     let run_id = context.run_id;
@@ -537,6 +542,7 @@ pub(crate) async fn execute_job_reuse_with_hooks(
     let idle_cli_agent_session_id = idle_parts.cli_agent_session_id;
     let source_ip = idle_parts.source_ip;
     let prev_storage = idle_parts.storage_fingerprints;
+    let _restored_session_identity = idle_parts.restored_session_identity;
     let workspace_promotion = idle_parts.workspace_promotion;
     let sandbox = idle_parts.sandbox;
 
@@ -576,6 +582,7 @@ pub(crate) async fn execute_job_reuse_with_hooks(
                                 network_log_session: None,
                                 workspace_image: None,
                                 discovered_cli_agent_session_id: None,
+                                restored_session_identity: None,
                             },
                             telemetry,
                         );
@@ -600,6 +607,7 @@ pub(crate) async fn execute_job_reuse_with_hooks(
                             network_log_session: None,
                             workspace_image: None,
                             discovered_cli_agent_session_id: None,
+                            restored_session_identity: None,
                         },
                         telemetry,
                     );
@@ -615,6 +623,7 @@ pub(crate) async fn execute_job_reuse_with_hooks(
                 network_log_session: None,
                 workspace_image,
                 discovered_cli_agent_session_id: None,
+                restored_session_identity: None,
             },
             telemetry,
         );
@@ -659,6 +668,7 @@ pub(crate) async fn execute_job_reuse_with_hooks(
                                 network_log_session: None,
                                 workspace_image: None,
                                 discovered_cli_agent_session_id: None,
+                                restored_session_identity: None,
                             },
                             telemetry,
                         );
@@ -698,6 +708,7 @@ pub(crate) async fn execute_job_reuse_with_hooks(
                         network_log_session: None,
                         workspace_image: None,
                         discovered_cli_agent_session_id: None,
+                        restored_session_identity: None,
                     },
                     telemetry,
                 );
@@ -722,6 +733,7 @@ pub(crate) async fn execute_job_reuse_with_hooks(
             network_log_session: None,
             workspace_image,
             discovered_cli_agent_session_id: None,
+            restored_session_identity: None,
         }
     } else {
         let mut outcome = execute_reused_sandbox(
@@ -733,7 +745,7 @@ pub(crate) async fn execute_job_reuse_with_hooks(
             &mut telemetry,
             RunControls::new(cancel, active_input_source)
                 .with_spawn_timing(spawn_timing)
-                .with_session_history_materializer(session_history_materializer),
+                .with_session_history_restore_plan(session_history_restore_plan),
         )
         .await;
         outcome.workspace_image = workspace_image;

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -114,7 +114,7 @@ const AGENT_ABNORMAL_EXIT_DIAGNOSTIC_SCRIPT: &str =
 
 use crate::error::{RunnerError, RunnerResult};
 use crate::http::HttpClient;
-use crate::idle_pool::ReusableIdleSandbox;
+use crate::idle_pool::{ReusableIdleSandbox, ReusableIdleSandboxParts};
 use crate::network_log_drain::NetworkLogDrainCoordinator;
 use crate::network_log_manager::NetworkLogManager;
 use crate::network_log_manager::NetworkLogSession;
@@ -538,13 +538,14 @@ pub(crate) async fn execute_job_reuse_with_hooks(
     record_api_latency("api_to_vm_start", &context, &mut telemetry);
 
     let sandbox_id = idle_sandbox.sandbox_id();
-    let idle_parts = idle_sandbox.into_parts();
-    let idle_cli_agent_session_id = idle_parts.cli_agent_session_id;
-    let source_ip = idle_parts.source_ip;
-    let prev_storage = idle_parts.storage_fingerprints;
-    let _restored_session_identity = idle_parts.restored_session_identity;
-    let workspace_promotion = idle_parts.workspace_promotion;
-    let sandbox = idle_parts.sandbox;
+    let ReusableIdleSandboxParts {
+        sandbox,
+        cli_agent_session_id: idle_cli_agent_session_id,
+        source_ip,
+        storage_fingerprints: prev_storage,
+        restored_session_identity: _restored_session_identity,
+        workspace_promotion,
+    } = idle_sandbox.into_parts();
 
     if let Err(error) = validate_resume_session_id(&context) {
         let workspace_image = match config.workspace_cache.as_ref() {

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -36,10 +36,10 @@ mod session_restore;
 mod storage;
 mod telemetry;
 
+pub(crate) use crate::restored_session_identity::RestoredSessionIdentity;
 pub(crate) use agent_run::{SessionHistoryRestoreFallback, SessionHistoryRestorePlan};
 pub(crate) use guest_state::{is_valid_guest_timezone_name, restore_guest_state_with_timezone};
 pub(crate) use session_history_download::SessionHistoryMaterializer;
-pub(crate) use session_restore::RestoredSessionIdentity;
 
 use crate::active_input::ActiveInputSource;
 use agent_run::{ProcessCancelTimeouts, RunControls};

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -437,6 +437,7 @@ pub(super) async fn execute_reused_sandbox(
                 network_log_session: None,
                 workspace_image: None,
                 discovered_cli_agent_session_id: None,
+                restored_session_identity: None,
             };
         }
     };
@@ -469,6 +470,7 @@ pub(super) async fn execute_reused_sandbox(
             network_log_session: Some(network_log_session),
             workspace_image: None,
             discovered_cli_agent_session_id: None,
+            restored_session_identity: None,
         };
     }
     telemetry.record("workspace_drive_mount", mount_started.elapsed(), true, None);
@@ -527,6 +529,10 @@ pub(super) async fn execute_prepared_sandbox_run(
         |_| AgentStdoutStreamDiagnostics::default(),
         |result| result.stdout_stream_diagnostics,
     );
+    let restored_session_identity = result
+        .as_ref()
+        .ok()
+        .and_then(|result| result.restored_session_identity.clone());
 
     let cleanup_result = post_job_cleanup(
         sandbox.as_ref(),
@@ -580,6 +586,7 @@ pub(super) async fn execute_prepared_sandbox_run(
         network_log_session: Some(network_log_session),
         workspace_image: None,
         discovered_cli_agent_session_id,
+        restored_session_identity,
     }
 }
 

--- a/crates/runner/src/executor/session_restore.rs
+++ b/crates/runner/src/executor/session_restore.rs
@@ -23,11 +23,13 @@ const SUBSTRING_SESSION_ID_REDACTION_MIN_LEN: usize = 8;
 impl RestoredSessionIdentity {
     pub(crate) fn from_context(context: &ExecutionContext) -> Option<Self> {
         validate_resume_session_id(context).ok()?;
-        let history_ref = context.resume_session.as_ref()?.history_ref()?;
+        let resume_session = context.resume_session.as_ref()?;
+        let history_ref = resume_session.history_ref()?;
         let framework =
             restored_session_framework(effective_cli_framework(&context.cli_agent_type));
         Some(Self::new(
             framework,
+            &resume_session.cli_agent_session_id,
             history_ref.kind,
             history_ref.hash.clone(),
             history_ref.size,

--- a/crates/runner/src/executor/session_restore.rs
+++ b/crates/runner/src/executor/session_restore.rs
@@ -30,6 +30,8 @@ impl RestoredSessionIdentity {
             framework,
             history_ref.kind,
             history_ref.hash.clone(),
+            history_ref.size,
+            None,
         ))
     }
 }
@@ -46,6 +48,7 @@ pub(super) struct SessionRestoreDiagnostics {
     pub(super) framework: &'static str,
     pub(super) session_fingerprint: String,
     pub(super) bytes_in: usize,
+    pub(super) restored_session_identity: Option<RestoredSessionIdentity>,
 }
 
 pub(super) async fn restore_session(
@@ -110,6 +113,9 @@ pub(super) async fn restore_claude_session(
         framework: "claude-code",
         session_fingerprint: diagnostic_session_fingerprint(&session.cli_agent_session_id),
         bytes_in: session_history.len(),
+        restored_session_identity: RestoredSessionIdentity::from_context(context).map(|identity| {
+            identity.with_guest_history(session_history.len() as u64, session_path.clone())
+        }),
     };
     info!(
         run_id = %context.run_id,

--- a/crates/runner/src/executor/session_restore.rs
+++ b/crates/runner/src/executor/session_restore.rs
@@ -2,14 +2,17 @@
 
 mod codex;
 
+use std::fmt;
+
 use sandbox::{Sandbox, SandboxError};
 use tracing::{info, warn};
 
 use super::cli_framework::{EffectiveCliFramework, effective_cli_framework};
+use super::env::validate_resume_session_id;
 use super::session_id::is_valid_session_id;
 use super::{RunnerError, RunnerResult};
 use crate::paths::diagnostic_session_fingerprint;
-use crate::types::{ExecutionContext, ResumeSession};
+use crate::types::{ExecutionContext, ResumeSession, ResumeSessionHistoryRefKind};
 use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 
 const SESSION_PATH_SENTINEL: &str = "\u{0}\u{1}";
@@ -17,6 +20,77 @@ const SESSION_ID_SENTINEL: &str = "\u{0}\u{2}";
 const REDACTED_SESSION_PATH: &str = "[redacted-session-path]";
 const REDACTED_SESSION_ID: &str = "[redacted-session-id]";
 const SUBSTRING_SESSION_ID_REDACTION_MIN_LEN: usize = 8;
+
+const CLAUDE_CODE_RESTORE_FORMAT_VERSION: u8 = 1;
+const CODEX_RESTORE_FORMAT_VERSION: u8 = 1;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RestoredSessionFramework {
+    ClaudeCode,
+    Codex,
+}
+
+impl RestoredSessionFramework {
+    fn from_effective(framework: EffectiveCliFramework) -> Self {
+        match framework {
+            EffectiveCliFramework::ClaudeCode => Self::ClaudeCode,
+            EffectiveCliFramework::Codex => Self::Codex,
+        }
+    }
+
+    const fn restore_format_version(self) -> u8 {
+        match self {
+            Self::ClaudeCode => CLAUDE_CODE_RESTORE_FORMAT_VERSION,
+            Self::Codex => CODEX_RESTORE_FORMAT_VERSION,
+        }
+    }
+}
+
+#[derive(Clone, Eq, PartialEq)]
+pub(crate) struct RestoredSessionIdentity {
+    framework: RestoredSessionFramework,
+    restore_format_version: u8,
+    history_ref_kind: ResumeSessionHistoryRefKind,
+    history_hash: String,
+}
+
+impl RestoredSessionIdentity {
+    pub(crate) fn from_context(context: &ExecutionContext) -> Option<Self> {
+        validate_resume_session_id(context).ok()?;
+        let history_ref = context.resume_session.as_ref()?.history_ref()?;
+        let framework = RestoredSessionFramework::from_effective(effective_cli_framework(
+            &context.cli_agent_type,
+        ));
+        Some(Self {
+            framework,
+            restore_format_version: framework.restore_format_version(),
+            history_ref_kind: history_ref.kind,
+            history_hash: history_ref.hash.clone(),
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn claude_code_for_test(history_hash: impl Into<String>) -> Self {
+        let framework = RestoredSessionFramework::ClaudeCode;
+        Self {
+            framework,
+            restore_format_version: framework.restore_format_version(),
+            history_ref_kind: ResumeSessionHistoryRefKind::Blob,
+            history_hash: history_hash.into(),
+        }
+    }
+}
+
+impl fmt::Debug for RestoredSessionIdentity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RestoredSessionIdentity")
+            .field("framework", &self.framework)
+            .field("restore_format_version", &self.restore_format_version)
+            .field("history_ref_kind", &self.history_ref_kind)
+            .field("history_hash", &"[redacted]")
+            .finish()
+    }
+}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(super) struct SessionRestoreDiagnostics {

--- a/crates/runner/src/executor/session_restore.rs
+++ b/crates/runner/src/executor/session_restore.rs
@@ -2,8 +2,6 @@
 
 mod codex;
 
-use std::fmt;
-
 use sandbox::{Sandbox, SandboxError};
 use tracing::{info, warn};
 
@@ -12,7 +10,8 @@ use super::env::validate_resume_session_id;
 use super::session_id::is_valid_session_id;
 use super::{RunnerError, RunnerResult};
 use crate::paths::diagnostic_session_fingerprint;
-use crate::types::{ExecutionContext, ResumeSession, ResumeSessionHistoryRefKind};
+use crate::restored_session_identity::{RestoredSessionFramework, RestoredSessionIdentity};
+use crate::types::{ExecutionContext, ResumeSession};
 use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 
 const SESSION_PATH_SENTINEL: &str = "\u{0}\u{1}";
@@ -21,74 +20,24 @@ const REDACTED_SESSION_PATH: &str = "[redacted-session-path]";
 const REDACTED_SESSION_ID: &str = "[redacted-session-id]";
 const SUBSTRING_SESSION_ID_REDACTION_MIN_LEN: usize = 8;
 
-const CLAUDE_CODE_RESTORE_FORMAT_VERSION: u8 = 1;
-const CODEX_RESTORE_FORMAT_VERSION: u8 = 1;
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum RestoredSessionFramework {
-    ClaudeCode,
-    Codex,
-}
-
-impl RestoredSessionFramework {
-    fn from_effective(framework: EffectiveCliFramework) -> Self {
-        match framework {
-            EffectiveCliFramework::ClaudeCode => Self::ClaudeCode,
-            EffectiveCliFramework::Codex => Self::Codex,
-        }
-    }
-
-    const fn restore_format_version(self) -> u8 {
-        match self {
-            Self::ClaudeCode => CLAUDE_CODE_RESTORE_FORMAT_VERSION,
-            Self::Codex => CODEX_RESTORE_FORMAT_VERSION,
-        }
-    }
-}
-
-#[derive(Clone, Eq, PartialEq)]
-pub(crate) struct RestoredSessionIdentity {
-    framework: RestoredSessionFramework,
-    restore_format_version: u8,
-    history_ref_kind: ResumeSessionHistoryRefKind,
-    history_hash: String,
-}
-
 impl RestoredSessionIdentity {
     pub(crate) fn from_context(context: &ExecutionContext) -> Option<Self> {
         validate_resume_session_id(context).ok()?;
         let history_ref = context.resume_session.as_ref()?.history_ref()?;
-        let framework = RestoredSessionFramework::from_effective(effective_cli_framework(
-            &context.cli_agent_type,
-        ));
-        Some(Self {
+        let framework =
+            restored_session_framework(effective_cli_framework(&context.cli_agent_type));
+        Some(Self::new(
             framework,
-            restore_format_version: framework.restore_format_version(),
-            history_ref_kind: history_ref.kind,
-            history_hash: history_ref.hash.clone(),
-        })
-    }
-
-    #[cfg(test)]
-    pub(crate) fn claude_code_for_test(history_hash: impl Into<String>) -> Self {
-        let framework = RestoredSessionFramework::ClaudeCode;
-        Self {
-            framework,
-            restore_format_version: framework.restore_format_version(),
-            history_ref_kind: ResumeSessionHistoryRefKind::Blob,
-            history_hash: history_hash.into(),
-        }
+            history_ref.kind,
+            history_ref.hash.clone(),
+        ))
     }
 }
 
-impl fmt::Debug for RestoredSessionIdentity {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("RestoredSessionIdentity")
-            .field("framework", &self.framework)
-            .field("restore_format_version", &self.restore_format_version)
-            .field("history_ref_kind", &self.history_ref_kind)
-            .field("history_hash", &"[redacted]")
-            .finish()
+fn restored_session_framework(framework: EffectiveCliFramework) -> RestoredSessionFramework {
+    match framework {
+        EffectiveCliFramework::ClaudeCode => RestoredSessionFramework::ClaudeCode,
+        EffectiveCliFramework::Codex => RestoredSessionFramework::Codex,
     }
 }
 

--- a/crates/runner/src/executor/session_restore.rs
+++ b/crates/runner/src/executor/session_restore.rs
@@ -7,7 +7,7 @@ use tracing::{info, warn};
 
 use super::cli_framework::{EffectiveCliFramework, effective_cli_framework};
 use super::env::validate_resume_session_id;
-use super::session_id::is_valid_session_id;
+use super::session_id::{canonical_codex_thread_id, is_valid_session_id};
 use super::{RunnerError, RunnerResult};
 use crate::paths::diagnostic_session_fingerprint;
 use crate::restored_session_identity::{RestoredSessionFramework, RestoredSessionIdentity};
@@ -25,16 +25,30 @@ impl RestoredSessionIdentity {
         validate_resume_session_id(context).ok()?;
         let resume_session = context.resume_session.as_ref()?;
         let history_ref = resume_session.history_ref()?;
-        let framework =
-            restored_session_framework(effective_cli_framework(&context.cli_agent_type));
+        let effective_framework = effective_cli_framework(&context.cli_agent_type);
+        let framework = restored_session_framework(effective_framework);
+        let session_id = restored_session_identity_session_id(
+            effective_framework,
+            &resume_session.cli_agent_session_id,
+        )?;
         Some(Self::new(
             framework,
-            &resume_session.cli_agent_session_id,
+            &session_id,
             history_ref.kind,
             history_ref.hash.clone(),
             history_ref.size,
             None,
         ))
+    }
+}
+
+fn restored_session_identity_session_id(
+    framework: EffectiveCliFramework,
+    session_id: &str,
+) -> Option<String> {
+    match framework {
+        EffectiveCliFramework::ClaudeCode => Some(session_id.to_owned()),
+        EffectiveCliFramework::Codex => canonical_codex_thread_id(session_id),
     }
 }
 

--- a/crates/runner/src/executor/session_restore/codex.rs
+++ b/crates/runner/src/executor/session_restore/codex.rs
@@ -7,6 +7,7 @@ use super::{
 };
 use crate::helper_exec::{format_helper_exec_failure, helper_exec_succeeded};
 use crate::paths::diagnostic_session_fingerprint;
+use crate::restored_session_identity::RestoredSessionIdentity;
 use crate::types::{ExecutionContext, ResumeSession};
 
 use super::super::{DEFAULT_EXEC_TIMEOUT, RunnerError, RunnerResult};
@@ -123,6 +124,9 @@ pub(super) async fn restore_codex_session(
         framework: "codex",
         session_fingerprint: diagnostic_session_fingerprint(session_id),
         bytes_in: session_history.len(),
+        restored_session_identity: RestoredSessionIdentity::from_context(context).map(|identity| {
+            identity.with_guest_history(session_history.len() as u64, session_path.clone())
+        }),
     };
     info!(
         run_id = %context.run_id,

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -488,11 +488,11 @@ async fn run_in_sandbox_restores_when_skip_verified_identity_mismatches_request(
     });
     let mut mismatched_ctx = minimal_context();
     mismatched_ctx.resume_session = Some(ResumeSession {
-        cli_agent_session_id: "sess-mismatch-skip-123".into(),
+        cli_agent_session_id: "sess-other-skip-123".into(),
         history: ResumeSessionHistory::Ref {
             history_ref: ResumeSessionHistoryRef {
                 kind: ResumeSessionHistoryRefKind::Blob,
-                hash: hex::encode(Sha256::digest(b"different history")),
+                hash: hex::encode(Sha256::digest(history)),
                 url: server.url("/other-history.blob?token=secret"),
                 size: Some(history.len() as u64),
             },

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -415,7 +415,13 @@ async fn run_in_sandbox_skips_verified_session_history_restore() {
             },
         },
     });
-    let identity = RestoredSessionIdentity::from_context(&ctx).expect("identity");
+    let identity = RestoredSessionIdentity::from_context(&ctx)
+        .expect("identity")
+        .with_guest_history(
+            history.len() as u64,
+            "/home/user/.claude/projects/-home-user-workspace/sess-skip-123.jsonl",
+        );
+    sandbox.push_read_file_result(Ok(Some(history.to_vec())));
     let mut telemetry = test_telemetry(&config, &ctx);
 
     let result = run_in_sandbox(
@@ -479,6 +485,7 @@ async fn run_in_sandbox_records_fallback_and_restores_prestarted_history() {
         },
     });
     let expected_identity = RestoredSessionIdentity::from_context(&ctx).expect("identity");
+    sandbox.push_read_file_result(Ok(Some(history.to_vec())));
     let materializer = SessionHistoryMaterializer::start_cancellable(
         &config.http,
         ctx.resume_session.as_ref(),
@@ -530,6 +537,64 @@ async fn run_in_sandbox_records_fallback_and_restores_prestarted_history() {
         ops.iter().any(|op| op.0 == "session_restore" && op.1),
         "expected restore telemetry, got: {ops:?}"
     );
+}
+
+#[tokio::test]
+async fn run_in_sandbox_clears_restored_identity_when_history_changes_before_parking() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let sandbox = sandbox_mock::MockSandbox::new("test");
+    let history = br#"{"type":"init"}"#;
+    let server = MockServer::start_async().await;
+    server
+        .mock_async(|when, then| {
+            when.method(GET).path("/history.blob");
+            then.status(200).body(history);
+        })
+        .await;
+    let mut ctx = minimal_context();
+    ctx.resume_session = Some(ResumeSession {
+        cli_agent_session_id: "sess-mutated-123".into(),
+        history: ResumeSessionHistory::Ref {
+            history_ref: ResumeSessionHistoryRef {
+                kind: ResumeSessionHistoryRefKind::Blob,
+                hash: hex::encode(Sha256::digest(history)),
+                url: server.url("/history.blob?token=secret"),
+                size: Some(history.len() as u64),
+            },
+        },
+    });
+    let mut changed_history = history.to_vec();
+    changed_history[0] = b'[';
+    sandbox.push_read_file_result(Ok(Some(changed_history)));
+    let materializer = SessionHistoryMaterializer::start_cancellable(
+        &config.http,
+        ctx.resume_session.as_ref(),
+        tokio_util::sync::CancellationToken::new(),
+    );
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let result = run_in_sandbox(
+        &sandbox,
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::Reused,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None)
+            .with_session_history_restore_plan(SessionHistoryRestorePlan::Prestarted {
+                materializer,
+                fallback: None,
+            }),
+    )
+    .await
+    .unwrap();
+
+    assert!(result.failure.is_none());
+    assert_eq!(result.restored_session_identity, None);
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -548,6 +548,82 @@ async fn run_in_sandbox_restores_when_skip_verified_identity_is_stale_before_sta
 }
 
 #[tokio::test]
+async fn run_in_sandbox_restores_when_skip_verified_identity_has_invalid_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let sandbox = sandbox_mock::MockSandbox::new("test");
+    let history = br#"{"type":"init"}"#;
+    let server = MockServer::start_async().await;
+    let history_mock = server
+        .mock_async(|when, then| {
+            when.method(GET).path("/history.blob");
+            then.status(200).body(history);
+        })
+        .await;
+    let mut ctx = minimal_context();
+    ctx.resume_session = Some(ResumeSession {
+        cli_agent_session_id: "sess-invalid-path-123".into(),
+        history: ResumeSessionHistory::Ref {
+            history_ref: ResumeSessionHistoryRef {
+                kind: ResumeSessionHistoryRefKind::Blob,
+                hash: hex::encode(Sha256::digest(history)),
+                url: server.url("/history.blob?token=secret"),
+                size: Some(history.len() as u64),
+            },
+        },
+    });
+    let idle_identity = RestoredSessionIdentity::from_context(&ctx)
+        .expect("identity")
+        .with_guest_history(history.len() as u64, "relative/session.jsonl");
+    sandbox.push_read_file_result(Ok(Some(history.to_vec())));
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let result = run_in_sandbox(
+        &sandbox,
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::Reused,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None)
+            .with_session_history_restore_plan(SessionHistoryRestorePlan::SkipVerified(
+                idle_identity,
+            )),
+    )
+    .await
+    .unwrap();
+
+    assert!(result.failure.is_none());
+    history_mock.assert_calls_async(1).await;
+    let writes = sandbox.write_file_calls();
+    assert_eq!(writes.len(), 1);
+    assert_eq!(
+        writes[0].path,
+        "/home/user/.claude/projects/-home-user-workspace/sess-invalid-path-123.jsonl"
+    );
+    assert_eq!(writes[0].content, history);
+    let read_calls = sandbox.read_file_calls();
+    assert_eq!(read_calls.len(), 1);
+    assert_eq!(
+        read_calls[0].path,
+        "/home/user/.claude/projects/-home-user-workspace/sess-invalid-path-123.jsonl"
+    );
+    let ops = telemetry.pending_ops_snapshot();
+    assert!(
+        ops.iter()
+            .any(|op| op.0 == "session_history_restore_fallback_stale_idle_identity" && op.1),
+        "expected invalid path fallback telemetry, got: {ops:?}"
+    );
+    assert!(
+        ops.iter().all(|op| op.0 != "session_history_restore_skip"),
+        "invalid path should not record skip telemetry, got: {ops:?}"
+    );
+}
+
+#[tokio::test]
 async fn run_in_sandbox_records_fallback_and_restores_prestarted_history() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use api_contracts::generated::types::runners::storage::StorageManifest;
+use httpmock::prelude::*;
 use sandbox::{ProcessExit, ProcessOutputChunk, SandboxConfig, SandboxFactory, SandboxId};
 use sandbox_mock::MockSandboxFactory;
 use sha2::{Digest, Sha256};
@@ -18,7 +19,10 @@ use super::super::agent_run::{
 };
 use super::super::diagnostics::AgentStdoutStreamDiagnostics;
 use super::super::storage::guest_download_stdin_command;
-use super::super::{EXIT_SIGKILL, PROCESS_CANCEL_WRITE_TIMEOUT, SessionHistoryMaterializer};
+use super::super::{
+    EXIT_SIGKILL, PROCESS_CANCEL_WRITE_TIMEOUT, RestoredSessionIdentity,
+    SessionHistoryMaterializer, SessionHistoryRestoreFallback, SessionHistoryRestorePlan,
+};
 use super::support::{
     CancelAfterWaitSandbox, RUN_IN_SANDBOX_TEST_TIMEOUT, api_storage, create_overridden_sandbox,
     minimal_context, spawn_run_in_sandbox_test, spawn_run_in_sandbox_test_with_timeouts,
@@ -357,7 +361,10 @@ async fn run_in_sandbox_uses_prestarted_session_history_materializer() {
         },
         &mut telemetry,
         RunControls::new(tokio_util::sync::CancellationToken::new(), None)
-            .with_session_history_materializer(Some(materializer)),
+            .with_session_history_restore_plan(SessionHistoryRestorePlan::Prestarted {
+                materializer,
+                fallback: None,
+            }),
     )
     .await
     .unwrap();
@@ -380,6 +387,148 @@ async fn run_in_sandbox_uses_prestarted_session_history_materializer() {
         ops.iter()
             .any(|op| op.0 == "session_history_download" && op.1),
         "expected session history download telemetry, got: {ops:?}"
+    );
+}
+
+#[tokio::test]
+async fn run_in_sandbox_skips_verified_session_history_restore() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let sandbox = sandbox_mock::MockSandbox::new("test");
+    let history = br#"{"type":"init"}"#;
+    let server = MockServer::start_async().await;
+    let history_mock = server
+        .mock_async(|when, then| {
+            when.method(GET).path("/history.blob");
+            then.status(200).body(history);
+        })
+        .await;
+    let mut ctx = minimal_context();
+    ctx.resume_session = Some(ResumeSession {
+        cli_agent_session_id: "sess-skip-123".into(),
+        history: ResumeSessionHistory::Ref {
+            history_ref: ResumeSessionHistoryRef {
+                kind: ResumeSessionHistoryRefKind::Blob,
+                hash: hex::encode(Sha256::digest(history)),
+                url: server.url("/history.blob?token=secret"),
+                size: Some(history.len() as u64),
+            },
+        },
+    });
+    let identity = RestoredSessionIdentity::from_context(&ctx).expect("identity");
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let result = run_in_sandbox(
+        &sandbox,
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::Reused,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None)
+            .with_session_history_restore_plan(SessionHistoryRestorePlan::SkipVerified(
+                identity.clone(),
+            )),
+    )
+    .await
+    .unwrap();
+
+    assert!(result.failure.is_none());
+    assert_eq!(result.restored_session_identity, Some(identity));
+    assert!(sandbox.write_file_calls().is_empty());
+    history_mock.assert_calls_async(0).await;
+    let ops = telemetry.pending_ops_snapshot();
+    assert!(
+        ops.iter()
+            .any(|op| op.0 == "session_history_restore_skip" && op.1),
+        "expected skip telemetry, got: {ops:?}"
+    );
+    assert!(
+        ops.iter()
+            .all(|op| op.0 != "session_history_download" && op.0 != "session_restore"),
+        "skip path should not download or restore, got: {ops:?}"
+    );
+}
+
+#[tokio::test]
+async fn run_in_sandbox_records_fallback_and_restores_prestarted_history() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let sandbox = sandbox_mock::MockSandbox::new("test");
+    let history = br#"{"type":"init"}"#;
+    let server = MockServer::start_async().await;
+    let history_mock = server
+        .mock_async(|when, then| {
+            when.method(GET).path("/history.blob");
+            then.status(200).body(history);
+        })
+        .await;
+    let mut ctx = minimal_context();
+    ctx.resume_session = Some(ResumeSession {
+        cli_agent_session_id: "sess-fallback-123".into(),
+        history: ResumeSessionHistory::Ref {
+            history_ref: ResumeSessionHistoryRef {
+                kind: ResumeSessionHistoryRefKind::Blob,
+                hash: hex::encode(Sha256::digest(history)),
+                url: server.url("/history.blob?token=secret"),
+                size: Some(history.len() as u64),
+            },
+        },
+    });
+    let expected_identity = RestoredSessionIdentity::from_context(&ctx).expect("identity");
+    let materializer = SessionHistoryMaterializer::start_cancellable(
+        &config.http,
+        ctx.resume_session.as_ref(),
+        tokio_util::sync::CancellationToken::new(),
+    );
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let result = run_in_sandbox(
+        &sandbox,
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::Reused,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None)
+            .with_session_history_restore_plan(SessionHistoryRestorePlan::Prestarted {
+                materializer,
+                fallback: Some(SessionHistoryRestoreFallback::IdentityMismatch),
+            }),
+    )
+    .await
+    .unwrap();
+
+    assert!(result.failure.is_none());
+    assert_eq!(result.restored_session_identity, Some(expected_identity));
+    history_mock.assert_calls_async(1).await;
+    let writes = sandbox.write_file_calls();
+    assert_eq!(writes.len(), 1);
+    assert_eq!(
+        writes[0].path,
+        "/home/user/.claude/projects/-home-user-workspace/sess-fallback-123.jsonl"
+    );
+    assert_eq!(writes[0].content, history);
+    let ops = telemetry.pending_ops_snapshot();
+    assert!(
+        ops.iter()
+            .any(|op| op.0 == "session_history_restore_fallback_identity_mismatch" && op.1),
+        "expected fallback telemetry, got: {ops:?}"
+    );
+    assert!(
+        ops.iter()
+            .any(|op| op.0 == "session_history_download" && op.1),
+        "expected download telemetry, got: {ops:?}"
+    );
+    assert!(
+        ops.iter().any(|op| op.0 == "session_restore" && op.1),
+        "expected restore telemetry, got: {ops:?}"
     );
 }
 

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -462,6 +462,92 @@ async fn run_in_sandbox_skips_verified_session_history_restore() {
 }
 
 #[tokio::test]
+async fn run_in_sandbox_restores_when_skip_verified_identity_mismatches_request() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let sandbox = sandbox_mock::MockSandbox::new("test");
+    let history = br#"{"type":"init"}"#;
+    let server = MockServer::start_async().await;
+    let history_mock = server
+        .mock_async(|when, then| {
+            when.method(GET).path("/history.blob");
+            then.status(200).body(history);
+        })
+        .await;
+    let mut ctx = minimal_context();
+    ctx.resume_session = Some(ResumeSession {
+        cli_agent_session_id: "sess-mismatch-skip-123".into(),
+        history: ResumeSessionHistory::Ref {
+            history_ref: ResumeSessionHistoryRef {
+                kind: ResumeSessionHistoryRefKind::Blob,
+                hash: hex::encode(Sha256::digest(history)),
+                url: server.url("/history.blob?token=secret"),
+                size: Some(history.len() as u64),
+            },
+        },
+    });
+    let mut mismatched_ctx = minimal_context();
+    mismatched_ctx.resume_session = Some(ResumeSession {
+        cli_agent_session_id: "sess-mismatch-skip-123".into(),
+        history: ResumeSessionHistory::Ref {
+            history_ref: ResumeSessionHistoryRef {
+                kind: ResumeSessionHistoryRefKind::Blob,
+                hash: hex::encode(Sha256::digest(b"different history")),
+                url: server.url("/other-history.blob?token=secret"),
+                size: Some(history.len() as u64),
+            },
+        },
+    });
+    let idle_identity = RestoredSessionIdentity::from_context(&mismatched_ctx)
+        .expect("identity")
+        .with_guest_history(
+            history.len() as u64,
+            "/home/user/.claude/projects/-home-user-workspace/sess-mismatch-skip-123.jsonl",
+        );
+    sandbox.push_read_file_result(Ok(Some(history.to_vec())));
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let result = run_in_sandbox(
+        &sandbox,
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::Reused,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None)
+            .with_session_history_restore_plan(SessionHistoryRestorePlan::SkipVerified(
+                idle_identity,
+            )),
+    )
+    .await
+    .unwrap();
+
+    assert!(result.failure.is_none());
+    history_mock.assert_calls_async(1).await;
+    let writes = sandbox.write_file_calls();
+    assert_eq!(writes.len(), 1);
+    assert_eq!(
+        writes[0].path,
+        "/home/user/.claude/projects/-home-user-workspace/sess-mismatch-skip-123.jsonl"
+    );
+    assert_eq!(writes[0].content, history);
+    assert_eq!(sandbox.read_file_calls().len(), 1);
+    let ops = telemetry.pending_ops_snapshot();
+    assert!(
+        ops.iter()
+            .any(|op| op.0 == "session_history_restore_fallback_stale_idle_identity" && op.1),
+        "expected mismatch fallback telemetry, got: {ops:?}"
+    );
+    assert!(
+        ops.iter().all(|op| op.0 != "session_history_restore_skip"),
+        "mismatched identity should not record skip telemetry, got: {ops:?}"
+    );
+}
+
+#[tokio::test]
 async fn run_in_sandbox_restores_when_skip_verified_identity_is_stale_before_start() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -624,6 +624,86 @@ async fn run_in_sandbox_restores_when_skip_verified_identity_has_invalid_path() 
 }
 
 #[tokio::test]
+async fn run_in_sandbox_restores_when_skip_verified_identity_is_too_large_to_verify() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let sandbox = sandbox_mock::MockSandbox::new("test");
+    let history = br#"{"type":"init"}"#;
+    let server = MockServer::start_async().await;
+    let history_mock = server
+        .mock_async(|when, then| {
+            when.method(GET).path("/history.blob");
+            then.status(200).body(history);
+        })
+        .await;
+    let mut ctx = minimal_context();
+    ctx.resume_session = Some(ResumeSession {
+        cli_agent_session_id: "sess-large-skip-123".into(),
+        history: ResumeSessionHistory::Ref {
+            history_ref: ResumeSessionHistoryRef {
+                kind: ResumeSessionHistoryRefKind::Blob,
+                hash: hex::encode(Sha256::digest(history)),
+                url: server.url("/history.blob?token=secret"),
+                size: Some(history.len() as u64),
+            },
+        },
+    });
+    let idle_identity = RestoredSessionIdentity::from_context(&ctx)
+        .expect("identity")
+        .with_guest_history(
+            crate::restored_session_identity::RESTORED_SESSION_IDENTITY_VERIFY_MAX_BYTES,
+            "/home/user/.claude/projects/-home-user-workspace/sess-large-skip-123.jsonl",
+        );
+    sandbox.push_read_file_result(Ok(Some(history.to_vec())));
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let result = run_in_sandbox(
+        &sandbox,
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::Reused,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None)
+            .with_session_history_restore_plan(SessionHistoryRestorePlan::SkipVerified(
+                idle_identity,
+            )),
+    )
+    .await
+    .unwrap();
+
+    assert!(result.failure.is_none());
+    history_mock.assert_calls_async(1).await;
+    let writes = sandbox.write_file_calls();
+    assert_eq!(writes.len(), 1);
+    assert_eq!(
+        writes[0].path,
+        "/home/user/.claude/projects/-home-user-workspace/sess-large-skip-123.jsonl"
+    );
+    assert_eq!(writes[0].content, history);
+    let read_calls = sandbox.read_file_calls();
+    assert_eq!(read_calls.len(), 1);
+    assert_eq!(
+        read_calls[0].path,
+        "/home/user/.claude/projects/-home-user-workspace/sess-large-skip-123.jsonl"
+    );
+    assert_eq!(read_calls[0].max_bytes, history.len() as u64 + 1);
+    let ops = telemetry.pending_ops_snapshot();
+    assert!(
+        ops.iter()
+            .any(|op| op.0 == "session_history_restore_fallback_stale_idle_identity" && op.1),
+        "expected oversized identity fallback telemetry, got: {ops:?}"
+    );
+    assert!(
+        ops.iter().all(|op| op.0 != "session_history_restore_skip"),
+        "oversized identity should not record skip telemetry, got: {ops:?}"
+    );
+}
+
+#[tokio::test]
 async fn run_in_sandbox_records_fallback_and_restores_prestarted_history() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -422,6 +422,7 @@ async fn run_in_sandbox_skips_verified_session_history_restore() {
             "/home/user/.claude/projects/-home-user-workspace/sess-skip-123.jsonl",
         );
     sandbox.push_read_file_result(Ok(Some(history.to_vec())));
+    sandbox.push_read_file_result(Ok(Some(history.to_vec())));
     let mut telemetry = test_telemetry(&config, &ctx);
 
     let result = run_in_sandbox(
@@ -444,6 +445,7 @@ async fn run_in_sandbox_skips_verified_session_history_restore() {
 
     assert!(result.failure.is_none());
     assert_eq!(result.restored_session_identity, Some(identity));
+    assert_eq!(sandbox.read_file_calls().len(), 2);
     assert!(sandbox.write_file_calls().is_empty());
     history_mock.assert_calls_async(0).await;
     let ops = telemetry.pending_ops_snapshot();
@@ -456,6 +458,92 @@ async fn run_in_sandbox_skips_verified_session_history_restore() {
         ops.iter()
             .all(|op| op.0 != "session_history_download" && op.0 != "session_restore"),
         "skip path should not download or restore, got: {ops:?}"
+    );
+}
+
+#[tokio::test]
+async fn run_in_sandbox_restores_when_skip_verified_identity_is_stale_before_start() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let sandbox = sandbox_mock::MockSandbox::new("test");
+    let history = br#"{"type":"init"}"#;
+    let server = MockServer::start_async().await;
+    let history_mock = server
+        .mock_async(|when, then| {
+            when.method(GET).path("/history.blob");
+            then.status(200).body(history);
+        })
+        .await;
+    let mut ctx = minimal_context();
+    ctx.resume_session = Some(ResumeSession {
+        cli_agent_session_id: "sess-stale-skip-123".into(),
+        history: ResumeSessionHistory::Ref {
+            history_ref: ResumeSessionHistoryRef {
+                kind: ResumeSessionHistoryRefKind::Blob,
+                hash: hex::encode(Sha256::digest(history)),
+                url: server.url("/history.blob?token=secret"),
+                size: Some(history.len() as u64),
+            },
+        },
+    });
+    let idle_identity = RestoredSessionIdentity::from_context(&ctx)
+        .expect("identity")
+        .with_guest_history(
+            history.len() as u64,
+            "/home/user/.claude/projects/-home-user-workspace/sess-stale-skip-123.jsonl",
+        );
+    sandbox.push_read_file_result(Ok(None));
+    sandbox.push_read_file_result(Ok(Some(history.to_vec())));
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let result = run_in_sandbox(
+        &sandbox,
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::Reused,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None)
+            .with_session_history_restore_plan(SessionHistoryRestorePlan::SkipVerified(
+                idle_identity,
+            )),
+    )
+    .await
+    .unwrap();
+
+    assert!(result.failure.is_none());
+    let restored_identity = result
+        .restored_session_identity
+        .as_ref()
+        .expect("restored identity");
+    assert_eq!(
+        restored_identity.guest_history_path(),
+        Some("/home/user/.claude/projects/-home-user-workspace/sess-stale-skip-123.jsonl")
+    );
+    assert_eq!(
+        restored_identity.history_size_bytes(),
+        Some(history.len() as u64)
+    );
+    history_mock.assert_calls_async(1).await;
+    let writes = sandbox.write_file_calls();
+    assert_eq!(writes.len(), 1);
+    assert_eq!(
+        writes[0].path,
+        "/home/user/.claude/projects/-home-user-workspace/sess-stale-skip-123.jsonl"
+    );
+    assert_eq!(writes[0].content, history);
+    let ops = telemetry.pending_ops_snapshot();
+    assert!(
+        ops.iter()
+            .any(|op| op.0 == "session_history_restore_fallback_stale_idle_identity" && op.1),
+        "expected stale identity fallback telemetry, got: {ops:?}"
+    );
+    assert!(
+        ops.iter().all(|op| op.0 != "session_history_restore_skip"),
+        "stale identity should not record skip telemetry, got: {ops:?}"
     );
 }
 

--- a/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
@@ -654,6 +654,7 @@ async fn reusable_idle_sandbox_with_workspace_promotion(
         budget_lease: test_budget_lease(),
         source_ip,
         storage_fingerprints: StorageFingerprints::default(),
+        restored_session_identity: None,
         workspace_image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
         workspace_promotion: Some(promotion),
     })
@@ -759,6 +760,7 @@ async fn reusable_idle_sandbox_with_unlocked_workspace_promotion(
         budget_lease: test_budget_lease(),
         source_ip,
         storage_fingerprints: StorageFingerprints::default(),
+        restored_session_identity: None,
         workspace_image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
         workspace_promotion: Some(promotion),
     })

--- a/crates/runner/src/executor/tests/session_restore_tests.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests.rs
@@ -8,9 +8,10 @@ use tracing_subscriber::prelude::*;
 
 use super::super::DEFAULT_EXEC_TIMEOUT;
 use super::super::session_id::{canonical_codex_thread_id, is_valid_session_id};
-use super::super::session_restore::{RestoredSessionIdentity, restore_session};
+use super::super::session_restore::restore_session;
 use super::support::{CapturedEvent, CapturedEvents, minimal_context, sandbox_write_file_error};
 use crate::paths::diagnostic_session_fingerprint;
+use crate::restored_session_identity::RestoredSessionIdentity;
 use crate::types::{
     ResumeSession, ResumeSessionHistory, ResumeSessionHistoryRef, ResumeSessionHistoryRefKind,
 };

--- a/crates/runner/src/executor/tests/session_restore_tests.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests.rs
@@ -3,6 +3,7 @@ use sandbox::{
     SandboxOperation,
 };
 use sandbox_mock::MockSandbox;
+use sha2::{Digest, Sha256};
 use std::sync::Mutex;
 use tracing_subscriber::prelude::*;
 
@@ -155,8 +156,30 @@ fn restore_session_writes_history() {
     let sandbox = MockSandbox::new("test");
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "claude-code".into();
-    let session = ResumeSession::inline("sess-abc-123".into(), r#"{"type":"init"}"#.into());
-    run_restore_session(restore_session(&sandbox, &ctx, &session)).unwrap();
+    let history = r#"{"type":"init"}"#;
+    ctx.resume_session = Some(ResumeSession {
+        cli_agent_session_id: "sess-abc-123".into(),
+        history: ResumeSessionHistory::Ref {
+            history_ref: ResumeSessionHistoryRef {
+                kind: ResumeSessionHistoryRefKind::Blob,
+                hash: hex::encode(Sha256::digest(history.as_bytes())),
+                url: "https://example.com/history".into(),
+                size: Some(history.len() as u64),
+            },
+        },
+    });
+    let session = ResumeSession::inline("sess-abc-123".into(), history.into());
+    let diagnostics = run_restore_session(restore_session(&sandbox, &ctx, &session)).unwrap();
+
+    let writes = sandbox.write_file_calls();
+    assert_eq!(writes.len(), 1);
+    let expected_identity = RestoredSessionIdentity::from_context(&ctx)
+        .expect("restored identity")
+        .with_guest_history(history.len() as u64, writes[0].path.clone());
+    assert_eq!(
+        diagnostics.restored_session_identity,
+        Some(expected_identity)
+    );
 }
 
 #[tokio::test]
@@ -244,27 +267,36 @@ fn restore_session_writes_codex_session() {
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "codex".into();
     let session_id = "019e9154-c304-70f0-adde-36efb1be1701";
-    let session = ResumeSession::inline(
-        session_id.into(),
-        format!(
-            "{}\n",
-            serde_json::json!({
-                "timestamp": "2026-06-04T07:18:08.001Z",
-                "type": "session_meta",
-                "payload": {
-                    "id": session_id,
-                    "timestamp": "2026-06-04T07:18:08.000Z",
-                    "cwd": "/workspace",
-                    "originator": "test",
-                    "cli_version": "0.137.0",
-                    "source": "cli",
-                    "model_provider": "test-provider",
-                    "base_instructions": null,
-                },
-            }),
-        ),
+    let history = format!(
+        "{}\n",
+        serde_json::json!({
+            "timestamp": "2026-06-04T07:18:08.001Z",
+            "type": "session_meta",
+            "payload": {
+                "id": session_id,
+                "timestamp": "2026-06-04T07:18:08.000Z",
+                "cwd": "/workspace",
+                "originator": "test",
+                "cli_version": "0.137.0",
+                "source": "cli",
+                "model_provider": "test-provider",
+                "base_instructions": null,
+            },
+        }),
     );
-    run_restore_session(restore_session(&sandbox, &ctx, &session)).unwrap();
+    ctx.resume_session = Some(ResumeSession {
+        cli_agent_session_id: session_id.into(),
+        history: ResumeSessionHistory::Ref {
+            history_ref: ResumeSessionHistoryRef {
+                kind: ResumeSessionHistoryRefKind::Blob,
+                hash: hex::encode(Sha256::digest(history.as_bytes())),
+                url: "https://example.com/history".into(),
+                size: Some(history.len() as u64),
+            },
+        },
+    });
+    let session = ResumeSession::inline(session_id.into(), history.clone());
+    let diagnostics = run_restore_session(restore_session(&sandbox, &ctx, &session)).unwrap();
 
     assert_codex_cleanup_call(&sandbox);
 
@@ -280,6 +312,13 @@ fn restore_session_writes_codex_session() {
     assert_eq!(
         writes[0].content,
         session.session_history().unwrap().as_bytes()
+    );
+    let expected_identity = RestoredSessionIdentity::from_context(&ctx)
+        .expect("restored identity")
+        .with_guest_history(history.len() as u64, writes[0].path.clone());
+    assert_eq!(
+        diagnostics.restored_session_identity,
+        Some(expected_identity)
     );
 }
 

--- a/crates/runner/src/executor/tests/session_restore_tests.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests.rs
@@ -104,7 +104,7 @@ fn restored_session_identity_requires_valid_hash_ref() {
 }
 
 #[test]
-fn restored_session_identity_changes_with_framework_and_history_hash() {
+fn restored_session_identity_changes_with_framework_session_and_history_hash() {
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "claude-code".into();
     ctx.resume_session = Some(ResumeSession {
@@ -134,6 +134,21 @@ fn restored_session_identity_changes_with_framework_and_history_hash() {
     let different_hash_identity =
         RestoredSessionIdentity::from_context(&ctx).expect("different hash identity");
     assert_ne!(claude_identity, different_hash_identity);
+
+    ctx.resume_session = Some(ResumeSession {
+        cli_agent_session_id: "sess-identity-other".into(),
+        history: ResumeSessionHistory::Ref {
+            history_ref: ResumeSessionHistoryRef {
+                kind: ResumeSessionHistoryRefKind::Blob,
+                hash: "hash-a".into(),
+                url: "https://example.com/history".into(),
+                size: Some(12),
+            },
+        },
+    });
+    let different_session_identity =
+        RestoredSessionIdentity::from_context(&ctx).expect("different session identity");
+    assert_ne!(claude_identity, different_session_identity);
 
     ctx.cli_agent_type = "codex".into();
     ctx.resume_session = Some(ResumeSession {

--- a/crates/runner/src/executor/tests/session_restore_tests.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests.rs
@@ -8,10 +8,12 @@ use tracing_subscriber::prelude::*;
 
 use super::super::DEFAULT_EXEC_TIMEOUT;
 use super::super::session_id::{canonical_codex_thread_id, is_valid_session_id};
-use super::super::session_restore::restore_session;
+use super::super::session_restore::{RestoredSessionIdentity, restore_session};
 use super::support::{CapturedEvent, CapturedEvents, minimal_context, sandbox_write_file_error};
 use crate::paths::diagnostic_session_fingerprint;
-use crate::types::ResumeSession;
+use crate::types::{
+    ResumeSession, ResumeSessionHistory, ResumeSessionHistoryRef, ResumeSessionHistoryRefKind,
+};
 
 static RESTORE_SESSION_LOG_CALLSITE_LOCK: Mutex<()> = Mutex::new(());
 
@@ -60,6 +62,91 @@ fn codex_thread_id_canonicalizes_uuid_spellings() {
         Some("019e9154-c304-70f0-adde-36efb1be1701")
     );
     assert!(canonical_codex_thread_id("codex-safe-but-not-uuid").is_none());
+}
+
+#[test]
+fn restored_session_identity_requires_valid_hash_ref() {
+    let mut ctx = minimal_context();
+    ctx.resume_session = Some(ResumeSession {
+        cli_agent_session_id: "sess-identity-123".into(),
+        history: ResumeSessionHistory::Ref {
+            history_ref: ResumeSessionHistoryRef {
+                kind: ResumeSessionHistoryRefKind::Blob,
+                hash: "hash-a".into(),
+                url: "https://example.com/history".into(),
+                size: Some(12),
+            },
+        },
+    });
+
+    assert!(RestoredSessionIdentity::from_context(&ctx).is_some());
+
+    ctx.resume_session = Some(ResumeSession::inline(
+        "sess-identity-123".into(),
+        "{}".into(),
+    ));
+    assert!(RestoredSessionIdentity::from_context(&ctx).is_none());
+
+    ctx.resume_session = Some(ResumeSession {
+        cli_agent_session_id: "../../etc/passwd".into(),
+        history: ResumeSessionHistory::Ref {
+            history_ref: ResumeSessionHistoryRef {
+                kind: ResumeSessionHistoryRefKind::Blob,
+                hash: "hash-a".into(),
+                url: "https://example.com/history".into(),
+                size: Some(12),
+            },
+        },
+    });
+    assert!(RestoredSessionIdentity::from_context(&ctx).is_none());
+}
+
+#[test]
+fn restored_session_identity_changes_with_framework_and_history_hash() {
+    let mut ctx = minimal_context();
+    ctx.cli_agent_type = "claude-code".into();
+    ctx.resume_session = Some(ResumeSession {
+        cli_agent_session_id: "sess-identity-123".into(),
+        history: ResumeSessionHistory::Ref {
+            history_ref: ResumeSessionHistoryRef {
+                kind: ResumeSessionHistoryRefKind::Blob,
+                hash: "hash-a".into(),
+                url: "https://example.com/history".into(),
+                size: Some(12),
+            },
+        },
+    });
+    let claude_identity = RestoredSessionIdentity::from_context(&ctx).expect("claude identity");
+
+    ctx.resume_session = Some(ResumeSession {
+        cli_agent_session_id: "sess-identity-123".into(),
+        history: ResumeSessionHistory::Ref {
+            history_ref: ResumeSessionHistoryRef {
+                kind: ResumeSessionHistoryRefKind::Blob,
+                hash: "hash-b".into(),
+                url: "https://example.com/history".into(),
+                size: Some(12),
+            },
+        },
+    });
+    let different_hash_identity =
+        RestoredSessionIdentity::from_context(&ctx).expect("different hash identity");
+    assert_ne!(claude_identity, different_hash_identity);
+
+    ctx.cli_agent_type = "codex".into();
+    ctx.resume_session = Some(ResumeSession {
+        cli_agent_session_id: "019e9154-c304-70f0-adde-36efb1be1701".into(),
+        history: ResumeSessionHistory::Ref {
+            history_ref: ResumeSessionHistoryRef {
+                kind: ResumeSessionHistoryRefKind::Blob,
+                hash: "hash-a".into(),
+                url: "https://example.com/history".into(),
+                size: Some(12),
+            },
+        },
+    });
+    let codex_identity = RestoredSessionIdentity::from_context(&ctx).expect("codex identity");
+    assert_ne!(claude_identity, codex_identity);
 }
 
 #[test]

--- a/crates/runner/src/executor/tests/session_restore_tests.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests.rs
@@ -164,6 +164,21 @@ fn restored_session_identity_changes_with_framework_session_and_history_hash() {
     });
     let codex_identity = RestoredSessionIdentity::from_context(&ctx).expect("codex identity");
     assert_ne!(claude_identity, codex_identity);
+
+    ctx.resume_session = Some(ResumeSession {
+        cli_agent_session_id: "019E9154C30470F0ADDE36EFB1BE1701".into(),
+        history: ResumeSessionHistory::Ref {
+            history_ref: ResumeSessionHistoryRef {
+                kind: ResumeSessionHistoryRefKind::Blob,
+                hash: "hash-a".into(),
+                url: "https://example.com/history".into(),
+                size: Some(12),
+            },
+        },
+    });
+    let codex_compact_uppercase_identity =
+        RestoredSessionIdentity::from_context(&ctx).expect("codex compact uppercase identity");
+    assert_eq!(codex_identity, codex_compact_uppercase_identity);
 }
 
 #[test]

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -8,8 +8,9 @@ use super::super::telemetry::{
     RunnerPreSpawnPhase, elapsed_since_api_start_ms, record_reuse_result,
 };
 use super::super::{
-    ExecutionHooks, NewSandboxDispatch, RunnerPreSpawnTiming, execute_job, execute_job_reuse,
-    execute_job_reuse_with_hooks, execute_job_with_prepared_notifier,
+    ExecutionHooks, NewSandboxDispatch, RunnerPreSpawnTiming, SessionHistoryRestorePlan,
+    execute_job, execute_job_reuse, execute_job_reuse_with_hooks,
+    execute_job_with_prepared_notifier,
 };
 use super::support::{
     default_params, make_reusable_idle_sandbox, minimal_context, test_executor_config,
@@ -240,7 +241,7 @@ async fn execute_job_records_runner_pre_spawn_and_fresh_path_timing() {
             sandbox_prepared: None,
             active_input_source: None,
             pre_spawn_timing: Some(pre_spawn_timing_with_phases()),
-            session_history_materializer: None,
+            session_history_restore_plan: SessionHistoryRestorePlan::Default,
         },
     )
     .await;
@@ -300,7 +301,7 @@ async fn execute_job_reuse_records_runner_pre_spawn_and_reuse_path_timing() {
             sandbox_prepared: None,
             active_input_source: None,
             pre_spawn_timing: Some(pre_spawn_timing_with_phases()),
-            session_history_materializer: None,
+            session_history_restore_plan: SessionHistoryRestorePlan::Default,
         },
     )
     .await;
@@ -354,7 +355,7 @@ async fn start_process_failure_records_phase_failure_without_spawn_completion() 
             sandbox_prepared: None,
             active_input_source: None,
             pre_spawn_timing: Some(RunnerPreSpawnTiming::start_after_claim()),
-            session_history_materializer: None,
+            session_history_restore_plan: SessionHistoryRestorePlan::Default,
         },
     )
     .await;

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -10,6 +10,7 @@ use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 use futures_util::FutureExt;
 use sandbox::{DeviceRateLimits, Sandbox, SandboxFactory, SandboxId};
 
+use crate::executor::RestoredSessionIdentity;
 use crate::resource_budget::BudgetLease;
 use crate::status::IdleVm;
 use crate::storage_fingerprints::StorageFingerprints;
@@ -143,6 +144,7 @@ pub(crate) struct IdleParkRequestParts {
     pub(crate) budget_lease: BudgetLease,
     pub(crate) source_ip: String,
     pub(crate) storage_fingerprints: StorageFingerprints,
+    pub(crate) restored_session_identity: Option<RestoredSessionIdentity>,
     pub(crate) workspace_image_size_bytes: u64,
     pub(crate) workspace_promotion: Option<WorkspaceImagePromotionContext>,
 }
@@ -159,6 +161,9 @@ struct IdleSandboxMetadata {
     /// Version fingerprints of storages downloaded in the previous turn.
     /// Used to skip re-downloading unchanged entries on reuse.
     storage_fingerprints: StorageFingerprints,
+    /// Verified hash-backed resume state restored into this sandbox before it
+    /// was parked. Missing means reuse must fall back to materialize+restore.
+    restored_session_identity: Option<RestoredSessionIdentity>,
     /// Local terminal timestamp for this parked session.
     ///
     /// `None` is reserved for synthetic test entries and means the VM is not
@@ -174,6 +179,7 @@ impl IdleSandboxMetadata {
         device_rate_limits: Option<DeviceRateLimits>,
         source_ip: String,
         storage_fingerprints: StorageFingerprints,
+        restored_session_identity: Option<RestoredSessionIdentity>,
     ) -> Self {
         Self {
             cli_agent_session_id,
@@ -182,6 +188,7 @@ impl IdleSandboxMetadata {
             device_rate_limits,
             source_ip,
             storage_fingerprints,
+            restored_session_identity,
             last_completed_at: None,
         }
     }
@@ -276,6 +283,7 @@ impl IdleParkRequest {
             budget_lease,
             source_ip,
             storage_fingerprints,
+            restored_session_identity,
             workspace_image_size_bytes,
             workspace_promotion,
         } = self.parts;
@@ -287,6 +295,7 @@ impl IdleParkRequest {
             device_rate_limits,
             source_ip,
             storage_fingerprints,
+            restored_session_identity,
         );
 
         if let Some(promotion) = workspace_promotion.as_ref()
@@ -488,12 +497,17 @@ pub struct ReusableIdleSandboxParts {
     pub cli_agent_session_id: String,
     pub source_ip: String,
     pub storage_fingerprints: StorageFingerprints,
+    pub restored_session_identity: Option<RestoredSessionIdentity>,
     pub workspace_promotion: Option<WorkspaceImagePromotionContext>,
 }
 
 impl ReusableIdleSandbox {
     pub fn sandbox_id(&self) -> SandboxId {
         self.metadata.sandbox_id
+    }
+
+    pub fn restored_session_identity(&self) -> Option<&RestoredSessionIdentity> {
+        self.metadata.restored_session_identity.as_ref()
     }
 
     pub fn into_parts(self) -> ReusableIdleSandboxParts {
@@ -509,6 +523,7 @@ impl ReusableIdleSandbox {
             device_rate_limits: _,
             source_ip,
             storage_fingerprints,
+            restored_session_identity,
             last_completed_at: _,
         } = metadata;
 
@@ -517,6 +532,7 @@ impl ReusableIdleSandbox {
             cli_agent_session_id,
             source_ip,
             storage_fingerprints,
+            restored_session_identity,
             workspace_promotion,
         }
     }
@@ -1126,6 +1142,7 @@ mod tests {
             budget_lease,
             source_ip: "10.0.0.1".into(),
             storage_fingerprints: StorageFingerprints::default(),
+            restored_session_identity: None,
             workspace_image_size_bytes: 0,
             workspace_promotion: None,
         })
@@ -1184,6 +1201,8 @@ mod tests {
             )]),
         };
         let expected_storage_fingerprints = storage_fingerprints.clone();
+        let restored_session_identity =
+            RestoredSessionIdentity::claude_code_for_test("history-hash-a");
         let request = IdleParkRequest::new(IdleParkRequestParts {
             sandbox,
             factory,
@@ -1194,6 +1213,7 @@ mod tests {
             budget_lease,
             source_ip: source_ip.into(),
             storage_fingerprints,
+            restored_session_identity: Some(restored_session_identity.clone()),
             workspace_image_size_bytes: 0,
             workspace_promotion: None,
         });
@@ -1225,6 +1245,10 @@ mod tests {
         let reused_parts = sandbox.into_parts();
         assert_eq!(reused_parts.cli_agent_session_id, session_id);
         assert_eq!(reused_parts.source_ip, source_ip);
+        assert_eq!(
+            reused_parts.restored_session_identity,
+            Some(restored_session_identity)
+        );
         assert_eq!(
             reused_parts.storage_fingerprints.storages,
             expected_storage_fingerprints.storages

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -10,8 +10,8 @@ use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 use futures_util::FutureExt;
 use sandbox::{DeviceRateLimits, Sandbox, SandboxFactory, SandboxId};
 
-use crate::executor::RestoredSessionIdentity;
 use crate::resource_budget::BudgetLease;
+use crate::restored_session_identity::RestoredSessionIdentity;
 use crate::status::IdleVm;
 use crate::storage_fingerprints::StorageFingerprints;
 use crate::types::HeldSessionState;

--- a/crates/runner/src/idle_pool/test_support.rs
+++ b/crates/runner/src/idle_pool/test_support.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use sandbox::{DeviceRateLimits, Sandbox, SandboxFactory, SandboxId};
 use sandbox_mock::{MockSandbox, MockSandboxFactory};
 
-use crate::executor::RestoredSessionIdentity;
 use crate::resource_budget::BudgetLease;
+use crate::restored_session_identity::RestoredSessionIdentity;
 use crate::storage_fingerprints::StorageFingerprints;
 use crate::workspace_image_cache::WorkspaceImagePromotionContext;
 

--- a/crates/runner/src/idle_pool/test_support.rs
+++ b/crates/runner/src/idle_pool/test_support.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use sandbox::{DeviceRateLimits, Sandbox, SandboxFactory, SandboxId};
 use sandbox_mock::{MockSandbox, MockSandboxFactory};
 
+use crate::executor::RestoredSessionIdentity;
 use crate::resource_budget::BudgetLease;
 use crate::storage_fingerprints::StorageFingerprints;
 use crate::workspace_image_cache::WorkspaceImagePromotionContext;
@@ -23,6 +24,7 @@ pub(crate) struct ParkedIdleCandidateBuilder {
     budget_lease: BudgetLease,
     source_ip: String,
     storage_fingerprints: StorageFingerprints,
+    restored_session_identity: Option<RestoredSessionIdentity>,
     last_completed_at: Option<String>,
     workspace_promotion: Option<WorkspaceImagePromotionContext>,
 }
@@ -42,6 +44,7 @@ impl ParkedIdleCandidateBuilder {
             budget_lease,
             source_ip: DEFAULT_SOURCE_IP.into(),
             storage_fingerprints: StorageFingerprints::default(),
+            restored_session_identity: None,
             last_completed_at: None,
             workspace_promotion: None,
         }
@@ -82,6 +85,14 @@ impl ParkedIdleCandidateBuilder {
         self
     }
 
+    pub(crate) fn with_restored_session_identity(
+        mut self,
+        restored_session_identity: RestoredSessionIdentity,
+    ) -> Self {
+        self.restored_session_identity = Some(restored_session_identity);
+        self
+    }
+
     pub(crate) fn with_workspace_promotion(
         mut self,
         workspace_promotion: WorkspaceImagePromotionContext,
@@ -101,6 +112,7 @@ impl ParkedIdleCandidateBuilder {
             budget_lease,
             source_ip,
             storage_fingerprints,
+            restored_session_identity,
             last_completed_at,
             workspace_promotion,
         } = self;
@@ -111,6 +123,7 @@ impl ParkedIdleCandidateBuilder {
             device_rate_limits,
             source_ip,
             storage_fingerprints,
+            restored_session_identity,
         );
         if let Some(last_completed_at) = last_completed_at {
             metadata = metadata.with_last_completed_at(last_completed_at);

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -36,6 +36,7 @@ mod provider;
 mod proxy;
 mod r2_cache;
 mod resource_budget;
+mod restored_session_identity;
 mod retry;
 mod run_cancellation;
 mod run_resolution;

--- a/crates/runner/src/restored_session_identity.rs
+++ b/crates/runner/src/restored_session_identity.rs
@@ -1,5 +1,7 @@
 use std::fmt;
 
+use sha2::{Digest, Sha256};
+
 use crate::types::ResumeSessionHistoryRefKind;
 
 const CLAUDE_CODE_RESTORE_FORMAT_VERSION: u8 = 1;
@@ -28,6 +30,7 @@ impl RestoredSessionFramework {
 pub(crate) struct RestoredSessionIdentity {
     framework: RestoredSessionFramework,
     restore_format_version: u8,
+    session_id_hash: String,
     history_ref_kind: ResumeSessionHistoryRefKind,
     history_hash: String,
     history_size_bytes: Option<u64>,
@@ -43,6 +46,7 @@ pub(crate) struct RestoredSessionHistoryVerification<'a> {
 impl RestoredSessionIdentity {
     pub(crate) fn new(
         framework: RestoredSessionFramework,
+        cli_agent_session_id: &str,
         history_ref_kind: ResumeSessionHistoryRefKind,
         history_hash: impl Into<String>,
         history_size_bytes: Option<u64>,
@@ -51,6 +55,7 @@ impl RestoredSessionIdentity {
         Self {
             framework,
             restore_format_version: framework.restore_format_version(),
+            session_id_hash: hex::encode(Sha256::digest(cli_agent_session_id.as_bytes())),
             history_ref_kind,
             history_hash: history_hash.into(),
             history_size_bytes,
@@ -62,6 +67,7 @@ impl RestoredSessionIdentity {
     pub(crate) fn claude_code_for_test(history_hash: impl Into<String>) -> Self {
         Self::new(
             RestoredSessionFramework::ClaudeCode,
+            "sess-restore-plan",
             ResumeSessionHistoryRefKind::Blob,
             history_hash,
             None,
@@ -129,6 +135,7 @@ impl PartialEq for RestoredSessionIdentity {
     fn eq(&self, other: &Self) -> bool {
         self.framework == other.framework
             && self.restore_format_version == other.restore_format_version
+            && self.session_id_hash == other.session_id_hash
             && self.history_ref_kind == other.history_ref_kind
             && self.history_hash == other.history_hash
     }
@@ -139,6 +146,7 @@ impl fmt::Debug for RestoredSessionIdentity {
         f.debug_struct("RestoredSessionIdentity")
             .field("framework", &self.framework)
             .field("restore_format_version", &self.restore_format_version)
+            .field("session_id_hash", &"[redacted]")
             .field("history_ref_kind", &self.history_ref_kind)
             .field("history_hash", &"[redacted]")
             .field("history_size_bytes", &self.history_size_bytes)

--- a/crates/runner/src/restored_session_identity.rs
+++ b/crates/runner/src/restored_session_identity.rs
@@ -73,20 +73,26 @@ impl RestoredSessionIdentity {
         &self.history_hash
     }
 
+    #[cfg(test)]
     pub(crate) fn history_size_bytes(&self) -> Option<u64> {
         self.history_size_bytes
     }
 
+    #[cfg(test)]
     pub(crate) fn guest_history_path(&self) -> Option<&str> {
         self.guest_history_path.as_deref()
     }
 
+    pub(crate) fn guest_history_verification(&self) -> Option<(u64, &str)> {
+        let history_size_bytes = self.history_size_bytes?;
+        let guest_history_path = self.guest_history_path.as_deref()?;
+        guest_history_path
+            .starts_with('/')
+            .then_some((history_size_bytes, guest_history_path))
+    }
+
     pub(crate) fn has_guest_history_verification(&self) -> bool {
-        self.history_size_bytes.is_some()
-            && self
-                .guest_history_path
-                .as_ref()
-                .is_some_and(|path| !path.is_empty())
+        self.guest_history_verification().is_some()
     }
 
     pub(crate) fn is_verified_match_for_request(&self, requested: &Self) -> bool {

--- a/crates/runner/src/restored_session_identity.rs
+++ b/crates/runner/src/restored_session_identity.rs
@@ -88,6 +88,14 @@ impl RestoredSessionIdentity {
                 .as_ref()
                 .is_some_and(|path| !path.is_empty())
     }
+
+    pub(crate) fn is_verified_match_for_request(&self, requested: &Self) -> bool {
+        self == requested
+            && self.has_guest_history_verification()
+            && requested
+                .history_size_bytes
+                .is_none_or(|requested_size| self.history_size_bytes == Some(requested_size))
+    }
 }
 
 impl PartialEq for RestoredSessionIdentity {

--- a/crates/runner/src/restored_session_identity.rs
+++ b/crates/runner/src/restored_session_identity.rs
@@ -80,6 +80,14 @@ impl RestoredSessionIdentity {
     pub(crate) fn guest_history_path(&self) -> Option<&str> {
         self.guest_history_path.as_deref()
     }
+
+    pub(crate) fn has_guest_history_verification(&self) -> bool {
+        self.history_size_bytes.is_some()
+            && self
+                .guest_history_path
+                .as_ref()
+                .is_some_and(|path| !path.is_empty())
+    }
 }
 
 impl PartialEq for RestoredSessionIdentity {

--- a/crates/runner/src/restored_session_identity.rs
+++ b/crates/runner/src/restored_session_identity.rs
@@ -20,12 +20,14 @@ impl RestoredSessionFramework {
     }
 }
 
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq)]
 pub(crate) struct RestoredSessionIdentity {
     framework: RestoredSessionFramework,
     restore_format_version: u8,
     history_ref_kind: ResumeSessionHistoryRefKind,
     history_hash: String,
+    history_size_bytes: Option<u64>,
+    guest_history_path: Option<String>,
 }
 
 impl RestoredSessionIdentity {
@@ -33,12 +35,16 @@ impl RestoredSessionIdentity {
         framework: RestoredSessionFramework,
         history_ref_kind: ResumeSessionHistoryRefKind,
         history_hash: impl Into<String>,
+        history_size_bytes: Option<u64>,
+        guest_history_path: Option<String>,
     ) -> Self {
         Self {
             framework,
             restore_format_version: framework.restore_format_version(),
             history_ref_kind,
             history_hash: history_hash.into(),
+            history_size_bytes,
+            guest_history_path,
         }
     }
 
@@ -48,7 +54,40 @@ impl RestoredSessionIdentity {
             RestoredSessionFramework::ClaudeCode,
             ResumeSessionHistoryRefKind::Blob,
             history_hash,
+            None,
+            None,
         )
+    }
+
+    pub(crate) fn with_guest_history(
+        mut self,
+        history_size_bytes: u64,
+        guest_history_path: impl Into<String>,
+    ) -> Self {
+        self.history_size_bytes = Some(history_size_bytes);
+        self.guest_history_path = Some(guest_history_path.into());
+        self
+    }
+
+    pub(crate) fn history_hash(&self) -> &str {
+        &self.history_hash
+    }
+
+    pub(crate) fn history_size_bytes(&self) -> Option<u64> {
+        self.history_size_bytes
+    }
+
+    pub(crate) fn guest_history_path(&self) -> Option<&str> {
+        self.guest_history_path.as_deref()
+    }
+}
+
+impl PartialEq for RestoredSessionIdentity {
+    fn eq(&self, other: &Self) -> bool {
+        self.framework == other.framework
+            && self.restore_format_version == other.restore_format_version
+            && self.history_ref_kind == other.history_ref_kind
+            && self.history_hash == other.history_hash
     }
 }
 
@@ -59,6 +98,11 @@ impl fmt::Debug for RestoredSessionIdentity {
             .field("restore_format_version", &self.restore_format_version)
             .field("history_ref_kind", &self.history_ref_kind)
             .field("history_hash", &"[redacted]")
+            .field("history_size_bytes", &self.history_size_bytes)
+            .field(
+                "guest_history_path",
+                &self.guest_history_path.as_ref().map(|_| "[redacted]"),
+            )
             .finish()
     }
 }

--- a/crates/runner/src/restored_session_identity.rs
+++ b/crates/runner/src/restored_session_identity.rs
@@ -1,0 +1,64 @@
+use std::fmt;
+
+use crate::types::ResumeSessionHistoryRefKind;
+
+const CLAUDE_CODE_RESTORE_FORMAT_VERSION: u8 = 1;
+const CODEX_RESTORE_FORMAT_VERSION: u8 = 1;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum RestoredSessionFramework {
+    ClaudeCode,
+    Codex,
+}
+
+impl RestoredSessionFramework {
+    pub(crate) const fn restore_format_version(self) -> u8 {
+        match self {
+            Self::ClaudeCode => CLAUDE_CODE_RESTORE_FORMAT_VERSION,
+            Self::Codex => CODEX_RESTORE_FORMAT_VERSION,
+        }
+    }
+}
+
+#[derive(Clone, Eq, PartialEq)]
+pub(crate) struct RestoredSessionIdentity {
+    framework: RestoredSessionFramework,
+    restore_format_version: u8,
+    history_ref_kind: ResumeSessionHistoryRefKind,
+    history_hash: String,
+}
+
+impl RestoredSessionIdentity {
+    pub(crate) fn new(
+        framework: RestoredSessionFramework,
+        history_ref_kind: ResumeSessionHistoryRefKind,
+        history_hash: impl Into<String>,
+    ) -> Self {
+        Self {
+            framework,
+            restore_format_version: framework.restore_format_version(),
+            history_ref_kind,
+            history_hash: history_hash.into(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn claude_code_for_test(history_hash: impl Into<String>) -> Self {
+        Self::new(
+            RestoredSessionFramework::ClaudeCode,
+            ResumeSessionHistoryRefKind::Blob,
+            history_hash,
+        )
+    }
+}
+
+impl fmt::Debug for RestoredSessionIdentity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RestoredSessionIdentity")
+            .field("framework", &self.framework)
+            .field("restore_format_version", &self.restore_format_version)
+            .field("history_ref_kind", &self.history_ref_kind)
+            .field("history_hash", &"[redacted]")
+            .finish()
+    }
+}

--- a/crates/runner/src/restored_session_identity.rs
+++ b/crates/runner/src/restored_session_identity.rs
@@ -5,6 +5,10 @@ use crate::types::ResumeSessionHistoryRefKind;
 const CLAUDE_CODE_RESTORE_FORMAT_VERSION: u8 = 1;
 const CODEX_RESTORE_FORMAT_VERSION: u8 = 1;
 
+// Verification reads `expected_size + 1` bytes so a larger guest file cannot
+// masquerade as the requested history by sharing the expected prefix.
+pub(crate) const RESTORED_SESSION_IDENTITY_VERIFY_MAX_BYTES: u64 = 1024 * 1024;
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum RestoredSessionFramework {
     ClaudeCode,
@@ -28,6 +32,12 @@ pub(crate) struct RestoredSessionIdentity {
     history_hash: String,
     history_size_bytes: Option<u64>,
     guest_history_path: Option<String>,
+}
+
+pub(crate) struct RestoredSessionHistoryVerification<'a> {
+    pub(crate) expected_size: u64,
+    pub(crate) guest_history_path: &'a str,
+    pub(crate) read_limit: u64,
 }
 
 impl RestoredSessionIdentity {
@@ -83,12 +93,23 @@ impl RestoredSessionIdentity {
         self.guest_history_path.as_deref()
     }
 
-    pub(crate) fn guest_history_verification(&self) -> Option<(u64, &str)> {
-        let history_size_bytes = self.history_size_bytes?;
+    pub(crate) fn guest_history_verification(
+        &self,
+    ) -> Option<RestoredSessionHistoryVerification<'_>> {
+        let expected_size = self.history_size_bytes?;
         let guest_history_path = self.guest_history_path.as_deref()?;
-        guest_history_path
-            .starts_with('/')
-            .then_some((history_size_bytes, guest_history_path))
+        if !guest_history_path.starts_with('/') {
+            return None;
+        }
+        let read_limit = expected_size.checked_add(1)?;
+        if read_limit > RESTORED_SESSION_IDENTITY_VERIFY_MAX_BYTES {
+            return None;
+        }
+        Some(RestoredSessionHistoryVerification {
+            expected_size,
+            guest_history_path,
+            read_limit,
+        })
     }
 
     pub(crate) fn has_guest_history_verification(&self) -> bool {


### PR DESCRIPTION
## Summary
- add a runner-local restored session identity for hash-backed resume history
- carry the identity through executor outcomes and idle sandbox metadata
- skip session history download and restore only for verified matching idle reuse hits
- keep missing, mismatched, invalid, inline, and non-reuse paths on the existing restore behavior with low-cardinality fallback telemetry

## Tests
- cargo test --manifest-path crates/Cargo.toml -p runner session_history
- cargo test --manifest-path crates/Cargo.toml -p runner agent_run_tests
- cargo test --manifest-path crates/Cargo.toml -p runner restore_plan
- cargo test --manifest-path crates/Cargo.toml -p runner idle_park_request_success_preserves_reuse_metadata
- cargo test --manifest-path crates/Cargo.toml -p runner sandbox_run_tests::reuse
- cargo test --manifest-path crates/Cargo.toml -p runner sandbox_finalization
- cargo test --manifest-path crates/Cargo.toml -p runner idle_reuse
- cargo test --manifest-path crates/Cargo.toml -p runner session_restore_tests
- cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings -D clippy::all
- cargo test --manifest-path crates/Cargo.toml -p runner

Closes #19166