### PR TITLE
perf: add storage manifest dispatch timing

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -129,7 +129,23 @@ const API_DISPATCH_TIMING_ACTION_TYPES = [
   "api_dispatch_check_concurrency_limit",
   "api_dispatch_insert_run_record",
   "api_dispatch_prepare_storage_manifest",
+  "api_dispatch_prepare_storage_manifest_resolve_inputs",
+  "api_dispatch_prepare_storage_manifest_ensure_artifacts",
+  "api_dispatch_prepare_storage_manifest_load_storage_index",
+  "api_dispatch_prepare_storage_manifest_build_compose_entries",
+  "api_dispatch_prepare_storage_manifest_build_additional_entries",
+  "api_dispatch_prepare_storage_manifest_build_artifact_entries",
+  "api_dispatch_prepare_storage_manifest_assemble",
   "api_dispatch_build_stored_execution_context",
+] as const;
+const API_DISPATCH_STORAGE_MANIFEST_ACTION_TYPES = [
+  "api_dispatch_prepare_storage_manifest_resolve_inputs",
+  "api_dispatch_prepare_storage_manifest_ensure_artifacts",
+  "api_dispatch_prepare_storage_manifest_load_storage_index",
+  "api_dispatch_prepare_storage_manifest_build_compose_entries",
+  "api_dispatch_prepare_storage_manifest_build_additional_entries",
+  "api_dispatch_prepare_storage_manifest_build_artifact_entries",
+  "api_dispatch_prepare_storage_manifest_assemble",
 ] as const;
 const API_DISPATCH_DIRECT_PRE_CREATE_ACTION_TYPES = [
   "api_dispatch_pre_create_direct_parse_body",
@@ -207,6 +223,20 @@ const FORBIDDEN_API_DISPATCH_TIMING_KEYS = [
   "environment",
   "execution_context",
   "presigned_url",
+  "presignedUrl",
+  "archive_url",
+  "archiveUrl",
+  "manifest_url",
+  "manifestUrl",
+  "url",
+  "storage_name",
+  "storageName",
+  "artifact_name",
+  "artifactName",
+  "volume_name",
+  "volumeName",
+  "mount_path",
+  "mountPath",
   "runner_id",
   "runnerId",
   "target_runner_id",
@@ -652,6 +682,11 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       timingEvents,
       API_DISPATCH_PERMISSION_MANIFEST_SUBSTEP_ACTION_TYPES,
     );
+    expectApiDispatchSpanKind(
+      timingEvents,
+      API_DISPATCH_STORAGE_MANIFEST_ACTION_TYPES,
+      "nested",
+    );
     expectApiDispatchActions(timingEvents, [
       "api_dispatch_resolve_compose_by_compose_id",
       "api_dispatch_resolve_compose_lookup_compose",
@@ -751,6 +786,11 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expectApiDispatchSpanKind(
       timingEvents,
       API_DISPATCH_DIRECT_PRE_CREATE_ACTION_TYPES,
+      "nested",
+    );
+    expectApiDispatchSpanKind(
+      timingEvents,
+      API_DISPATCH_STORAGE_MANIFEST_ACTION_TYPES,
       "nested",
     );
     expectNoApiDispatchActions(

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -4205,6 +4205,7 @@ function buildRunnerJobPayload(
               volumeVersionOverrides: body.volumeVersions,
               additionalVolumes: args.additionalVolumes,
               framework: args.framework,
+              timing: args.timing,
             }),
           );
         },

--- a/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
@@ -21,11 +21,17 @@ import { generatePresignedGetUrl, putS3Object } from "../external/s3";
 import type { Db } from "../external/db";
 import { nowDate } from "../external/time";
 import { settle } from "../utils";
+import {
+  measureApiDispatchTiming,
+  type ApiDispatchTimingCollector,
+} from "./api-dispatch-timing.service";
 import { computeContentHashFromHashes } from "./storage-content-hash.service";
 
 type StorageType = "artifact" | "volume";
 type ManifestStorage = StorageManifest["storages"][number];
 type ManifestArtifact = StorageManifest["artifacts"][number];
+type OptionalManifestStorage = ManifestStorage | null;
+type ComputedGetter = <T>(computedValue: Computed<T>) => T;
 
 interface ContextArtifact {
   readonly name: string;
@@ -60,6 +66,20 @@ interface AgentComposeContent {
   readonly volumes?: Record<string, VolumeConfig | undefined>;
 }
 
+interface PrepareAgentRunStorageManifestArgs {
+  readonly db: Db;
+  readonly content: AgentComposeContent;
+  readonly vars: Record<string, string> | undefined;
+  readonly agentOrgId: string;
+  readonly runtimeOrgId: string;
+  readonly userId: string;
+  readonly artifacts: readonly ContextArtifact[];
+  readonly volumeVersionOverrides: Record<string, string> | undefined;
+  readonly additionalVolumes: readonly AdditionalVolume[] | undefined;
+  readonly framework: SupportedFramework;
+  readonly timing?: ApiDispatchTimingCollector;
+}
+
 interface ResolvedVolume {
   readonly name: string;
   readonly mountPath: string;
@@ -87,6 +107,17 @@ interface StorageIndexEntry {
   readonly storageId: string;
   readonly headVersionId: string | null;
   readonly headVersion: { readonly id: string; readonly s3Key: string } | null;
+}
+
+interface StorageManifestInputs {
+  readonly artifacts: readonly ContextArtifact[];
+  readonly composeVolumes: readonly ResolvedVolume[];
+}
+
+interface StorageManifestEntries {
+  readonly composeEntries: readonly OptionalManifestStorage[];
+  readonly additionalEntries: readonly OptionalManifestStorage[];
+  readonly artifactEntries: ManifestArtifact[];
 }
 
 /**
@@ -743,111 +774,236 @@ function mergeStorageEntries(args: {
   ];
 }
 
-export function prepareAgentRunStorageManifest(args: {
+function isManifestStorage(
+  entry: OptionalManifestStorage,
+): entry is ManifestStorage {
+  return entry !== null;
+}
+
+async function resolveStorageManifestInputs(
+  args: PrepareAgentRunStorageManifestArgs,
+): Promise<StorageManifestInputs> {
+  return await measureApiDispatchTiming(
+    args.timing,
+    "api_dispatch_prepare_storage_manifest_resolve_inputs",
+    "nested",
+    () => {
+      return {
+        artifacts: dedupArtifacts(args.artifacts),
+        composeVolumes: resolveComposeVolumes({
+          content: args.content,
+          vars: args.vars,
+          volumeVersionOverrides: args.volumeVersionOverrides,
+          framework: args.framework,
+        }),
+      };
+    },
+  );
+}
+
+async function ensureStorageManifestArtifacts(
+  get: ComputedGetter,
+  args: {
+    readonly db: Db;
+    readonly runtimeOrgId: string;
+    readonly userId: string;
+    readonly bucket: string;
+    readonly artifacts: readonly ContextArtifact[];
+    readonly timing?: ApiDispatchTimingCollector;
+  },
+): Promise<void> {
+  await measureApiDispatchTiming(
+    args.timing,
+    "api_dispatch_prepare_storage_manifest_ensure_artifacts",
+    "nested",
+    async () => {
+      await Promise.all(
+        args.artifacts.map((artifact) => {
+          return get(
+            ensureArtifactStorage({
+              db: args.db,
+              orgId: args.runtimeOrgId,
+              userId: args.userId,
+              name: artifact.name,
+              bucket: args.bucket,
+            }),
+          );
+        }),
+      );
+    },
+  );
+}
+
+async function loadTimedStorageIndex(args: {
   readonly db: Db;
-  readonly content: AgentComposeContent;
-  readonly vars: Record<string, string> | undefined;
   readonly agentOrgId: string;
   readonly runtimeOrgId: string;
-  readonly userId: string;
-  readonly artifacts: readonly ContextArtifact[];
-  readonly volumeVersionOverrides: Record<string, string> | undefined;
-  readonly additionalVolumes: readonly AdditionalVolume[] | undefined;
-  readonly framework: SupportedFramework;
-}): Computed<Promise<StorageManifest>> {
-  return computed(async (get): Promise<StorageManifest> => {
-    const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
-    const artifacts = dedupArtifacts(args.artifacts);
-    const composeVolumes = resolveComposeVolumes({
-      content: args.content,
-      vars: args.vars,
-      volumeVersionOverrides: args.volumeVersionOverrides,
-      framework: args.framework,
-    });
+  readonly timing?: ApiDispatchTimingCollector;
+}): Promise<StorageIndex> {
+  // Resolve every volume/artifact from one pre-fetched snapshot instead of a
+  // per-item `SELECT storages` round-trip. Loaded after ensureArtifactStorage
+  // so freshly created artifact rows are included.
+  return await measureApiDispatchTiming(
+    args.timing,
+    "api_dispatch_prepare_storage_manifest_load_storage_index",
+    "nested",
+    async () => {
+      return await loadStorageIndex(args.db, [
+        args.agentOrgId,
+        args.runtimeOrgId,
+        SYSTEM_ORG_ID,
+      ]);
+    },
+  );
+}
 
-    await Promise.all(
-      artifacts.map((artifact) => {
-        return get(
-          ensureArtifactStorage({
-            db: args.db,
-            orgId: args.runtimeOrgId,
-            userId: args.userId,
-            name: artifact.name,
-            bucket,
-          }),
-        );
-      }),
-    );
-
-    // Resolve every volume/artifact from one pre-fetched snapshot instead of a
-    // per-item `SELECT storages` round-trip. Loaded after ensureArtifactStorage
-    // so freshly created artifact rows are included.
-    const storageIndex = await loadStorageIndex(args.db, [
-      args.agentOrgId,
-      args.runtimeOrgId,
-      SYSTEM_ORG_ID,
+async function buildStorageManifestEntries(
+  get: ComputedGetter,
+  args: {
+    readonly db: Db;
+    readonly bucket: string;
+    readonly storageIndex: StorageIndex;
+    readonly agentOrgId: string;
+    readonly runtimeOrgId: string;
+    readonly userId: string;
+    readonly composeVolumes: readonly ResolvedVolume[];
+    readonly additionalVolumes: readonly AdditionalVolume[] | undefined;
+    readonly artifacts: readonly ContextArtifact[];
+    readonly timing?: ApiDispatchTimingCollector;
+  },
+): Promise<StorageManifestEntries> {
+  const [composeEntries, additionalEntries, artifactEntries] =
+    await Promise.all([
+      measureApiDispatchTiming(
+        args.timing,
+        "api_dispatch_prepare_storage_manifest_build_compose_entries",
+        "nested",
+        async () => {
+          return await Promise.all(
+            args.composeVolumes.map((volume) => {
+              return get(
+                buildComposeStorageEntry({
+                  db: args.db,
+                  index: args.storageIndex,
+                  bucket: args.bucket,
+                  agentOrgId: args.agentOrgId,
+                  volume,
+                }),
+              );
+            }),
+          );
+        },
+      ),
+      measureApiDispatchTiming(
+        args.timing,
+        "api_dispatch_prepare_storage_manifest_build_additional_entries",
+        "nested",
+        async () => {
+          return await Promise.all(
+            (args.additionalVolumes ?? []).map((volume) => {
+              return get(
+                buildAdditionalStorageEntry({
+                  db: args.db,
+                  index: args.storageIndex,
+                  bucket: args.bucket,
+                  runtimeOrgId: args.runtimeOrgId,
+                  volume,
+                }),
+              );
+            }),
+          );
+        },
+      ),
+      measureApiDispatchTiming(
+        args.timing,
+        "api_dispatch_prepare_storage_manifest_build_artifact_entries",
+        "nested",
+        async () => {
+          return await Promise.all(
+            args.artifacts.map((artifact) => {
+              return get(
+                buildArtifactEntry({
+                  db: args.db,
+                  index: args.storageIndex,
+                  bucket: args.bucket,
+                  runtimeOrgId: args.runtimeOrgId,
+                  userId: args.userId,
+                  artifact,
+                }),
+              );
+            }),
+          );
+        },
+      ),
     ]);
 
-    const [composeEntries, additionalEntries, artifactEntries] =
-      await Promise.all([
-        Promise.all(
-          composeVolumes.map((volume) => {
-            return get(
-              buildComposeStorageEntry({
-                db: args.db,
-                index: storageIndex,
-                bucket,
-                agentOrgId: args.agentOrgId,
-                volume,
-              }),
-            );
-          }),
-        ),
-        Promise.all(
-          (args.additionalVolumes ?? []).map((volume) => {
-            return get(
-              buildAdditionalStorageEntry({
-                db: args.db,
-                index: storageIndex,
-                bucket,
-                runtimeOrgId: args.runtimeOrgId,
-                volume,
-              }),
-            );
-          }),
-        ),
-        Promise.all(
-          artifacts.map((artifact) => {
-            return get(
-              buildArtifactEntry({
-                db: args.db,
-                index: storageIndex,
-                bucket,
-                runtimeOrgId: args.runtimeOrgId,
-                userId: args.userId,
-                artifact,
-              }),
-            );
-          }),
-        ),
-      ]);
+  return { composeEntries, additionalEntries, artifactEntries };
+}
 
-    return {
-      storages: [
-        ...mergeStorageEntries({
-          composeEntries: composeEntries.filter(
-            (entry): entry is ManifestStorage => {
-              return entry !== null;
-            },
-          ),
-          additionalEntries: additionalEntries.filter(
-            (entry): entry is ManifestStorage => {
-              return entry !== null;
-            },
-          ),
-        }),
-      ],
-      artifacts: artifactEntries,
-    };
+async function assembleStorageManifest(args: {
+  readonly composeEntries: readonly OptionalManifestStorage[];
+  readonly additionalEntries: readonly OptionalManifestStorage[];
+  readonly artifactEntries: ManifestArtifact[];
+  readonly timing?: ApiDispatchTimingCollector;
+}): Promise<StorageManifest> {
+  return await measureApiDispatchTiming(
+    args.timing,
+    "api_dispatch_prepare_storage_manifest_assemble",
+    "nested",
+    () => {
+      return {
+        storages: [
+          ...mergeStorageEntries({
+            composeEntries: args.composeEntries.filter(isManifestStorage),
+            additionalEntries: args.additionalEntries.filter(isManifestStorage),
+          }),
+        ],
+        artifacts: args.artifactEntries,
+      };
+    },
+  );
+}
+
+export function prepareAgentRunStorageManifest(
+  args: PrepareAgentRunStorageManifestArgs,
+): Computed<Promise<StorageManifest>> {
+  return computed(async (get): Promise<StorageManifest> => {
+    const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
+    const { artifacts, composeVolumes } =
+      await resolveStorageManifestInputs(args);
+
+    await ensureStorageManifestArtifacts(get, {
+      db: args.db,
+      runtimeOrgId: args.runtimeOrgId,
+      userId: args.userId,
+      bucket,
+      artifacts,
+      timing: args.timing,
+    });
+
+    const storageIndex = await loadTimedStorageIndex({
+      db: args.db,
+      agentOrgId: args.agentOrgId,
+      runtimeOrgId: args.runtimeOrgId,
+      timing: args.timing,
+    });
+
+    const entries = await buildStorageManifestEntries(get, {
+      db: args.db,
+      bucket,
+      storageIndex,
+      agentOrgId: args.agentOrgId,
+      runtimeOrgId: args.runtimeOrgId,
+      userId: args.userId,
+      composeVolumes,
+      additionalVolumes: args.additionalVolumes,
+      artifacts,
+      timing: args.timing,
+    });
+
+    return await assembleStorageManifest({
+      ...entries,
+      timing: args.timing,
+    });
   });
 }

--- a/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
+++ b/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
@@ -74,6 +74,13 @@ export type ApiDispatchTimingActionType =
   | "api_dispatch_check_concurrency_limit"
   | "api_dispatch_insert_run_record"
   | "api_dispatch_prepare_storage_manifest"
+  | "api_dispatch_prepare_storage_manifest_resolve_inputs"
+  | "api_dispatch_prepare_storage_manifest_ensure_artifacts"
+  | "api_dispatch_prepare_storage_manifest_load_storage_index"
+  | "api_dispatch_prepare_storage_manifest_build_compose_entries"
+  | "api_dispatch_prepare_storage_manifest_build_additional_entries"
+  | "api_dispatch_prepare_storage_manifest_build_artifact_entries"
+  | "api_dispatch_prepare_storage_manifest_assemble"
   | "api_dispatch_build_stored_execution_context";
 
 interface ApiDispatchTimingRecord {


### PR DESCRIPTION
## Summary
- Add nested API dispatch timing spans inside storage manifest preparation.
- Pass the existing create-run timing collector into storage manifest construction.
- Extend API dispatch timing tests to assert storage manifest spans and avoid logging storage URL/path-like fields.

Refs #19062

## Verification
- pnpm -F api lint
- pnpm -F api check-types
- pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "api dispatch timing"
- pnpm -F api exec vitest run src/signals/routes/__tests__/run-reads.bdd.test.ts -t "restores volumes, memory, and conversation state when resuming checkpoints"
- pnpm prettier --check apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts apps/api/src/signals/services/agent-run-create.service.ts apps/api/src/signals/services/agent-run-storage.service.ts apps/api/src/signals/services/api-dispatch-timing.service.ts
- pnpm knip --workspace api --cache

## Note
- Full pre-commit `pnpm knip --cache` currently reports unrelated repo-wide unused dependency/export findings outside this PR. The api workspace knip check passes.