### PR TITLE
fix(mitm-addon): use monotonic force-refresh cooldown

### DIFF
--- a/crates/runner/mitm-addon/src/firewall_auth_cache.py
+++ b/crates/runner/mitm-addon/src/firewall_auth_cache.py
@@ -40,7 +40,7 @@ class _FirewallAuthState:
     cache: _FirewallHeaderCacheEntry | None = None
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     force_refresh_pending: bool = False
-    last_force_refresh_at: float = 0.0
+    last_force_refresh_monotonic_at: float | None = None
 
 
 _auth_state: dict[FirewallAuthCacheKey, _FirewallAuthState] = {}
@@ -72,24 +72,27 @@ def request_force_refresh(cache_key: FirewallAuthCacheKey) -> None:
 
     Design notes for future changes:
 
-    * The consume timestamp in ``state.last_force_refresh_at`` is written **before**
-      ``fetch_firewall_headers`` is awaited in ``get_firewall_headers``, not
-      after. Recording after would allow a 401 arriving during the fetch to
-      re-add the marker; after the fetch completes and writes the cache, a
-      later cache miss would then consume the stale marker and trigger an
-      unnecessary second refresh. The trade-off is that a failed fetch
-      (webhook down, ``TOKEN_REFRESH_FAILED``, etc.) still burns the
-      cooldown — intentional, because if the refresh grant itself is broken,
-      retrying faster than once per cooldown wouldn't help and would hammer
-      the provider.
-    * ``time.time()`` is used for the cooldown (not ``time.monotonic()``) for
-      consistency with the rest of this module, which compares wall-clock
-      ``expiresAt`` values from the webhook. An NTP backward step could
-      freeze the cooldown until wall-clock catches up; on NTP-slewed runners
-      this is not a realistic concern.
+    * The consume timestamp in ``state.last_force_refresh_monotonic_at`` is
+      written **before** ``fetch_firewall_headers`` is awaited in
+      ``get_firewall_headers``, not after. Recording after would allow a 401
+      arriving during the fetch to re-add the marker; after the fetch
+      completes and writes the cache, a later cache miss would then consume
+      the stale marker and trigger an unnecessary second refresh. The
+      trade-off is that a failed fetch (webhook down,
+      ``TOKEN_REFRESH_FAILED``, etc.) still burns the cooldown — intentional,
+      because if the refresh grant itself is broken, retrying faster than once
+      per cooldown wouldn't help and would hammer the provider.
+    * The cooldown is process-local elapsed time and uses ``time.monotonic()``.
+      Absolute webhook ``expiresAt`` checks remain wall-clock based elsewhere
+      in this module.
     """
     state = _get_auth_state(cache_key)
-    if time.time() - state.last_force_refresh_at >= _FORCE_REFRESH_COOLDOWN_SECS:
+    now = time.monotonic()
+    last_force_refresh_monotonic_at = state.last_force_refresh_monotonic_at
+    if (
+        last_force_refresh_monotonic_at is None
+        or now - last_force_refresh_monotonic_at >= _FORCE_REFRESH_COOLDOWN_SECS
+    ):
         state.force_refresh_pending = True
 
 
@@ -198,7 +201,7 @@ async def get_firewall_headers(
         force_refresh = state.force_refresh_pending
         state.force_refresh_pending = False
         if force_refresh:
-            state.last_force_refresh_at = time.time()
+            state.last_force_refresh_monotonic_at = time.monotonic()
 
         result = await fetch_firewall_headers(
             request,

--- a/crates/runner/mitm-addon/tests/auth_state_helpers.py
+++ b/crates/runner/mitm-addon/tests/auth_state_helpers.py
@@ -72,16 +72,22 @@ def force_refresh_pending(cache_key: auth_cache.FirewallAuthCacheKey) -> bool:
     return bool(state and state.force_refresh_pending)
 
 
-def set_last_force_refresh_at(cache_key: auth_cache.FirewallAuthCacheKey, timestamp: float) -> None:
-    auth_cache._get_auth_state(cache_key).last_force_refresh_at = timestamp
+def set_last_force_refresh_monotonic_at(
+    cache_key: auth_cache.FirewallAuthCacheKey, timestamp: float
+) -> None:
+    auth_cache._get_auth_state(cache_key).last_force_refresh_monotonic_at = timestamp
 
 
-def last_force_refresh_at(cache_key: auth_cache.FirewallAuthCacheKey) -> float | None:
+def last_force_refresh_monotonic_at(
+    cache_key: auth_cache.FirewallAuthCacheKey,
+) -> float | None:
     state = auth_cache._auth_state.get(cache_key)
-    return state.last_force_refresh_at if state else None
+    return state.last_force_refresh_monotonic_at if state else None
 
 
-def require_last_force_refresh_at(cache_key: auth_cache.FirewallAuthCacheKey) -> float:
-    timestamp = last_force_refresh_at(cache_key)
+def require_last_force_refresh_monotonic_at(
+    cache_key: auth_cache.FirewallAuthCacheKey,
+) -> float:
+    timestamp = last_force_refresh_monotonic_at(cache_key)
     assert timestamp is not None
     return timestamp

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -23,11 +23,12 @@ from tests.auth_state_helpers import (
     auth_cache_key,
     cached_headers,
     force_refresh_pending,
-    last_force_refresh_at,
+    last_force_refresh_monotonic_at,
     mark_force_refresh,
     require_cached_headers,
-    require_last_force_refresh_at,
+    require_last_force_refresh_monotonic_at,
     set_cached_headers,
+    set_last_force_refresh_monotonic_at,
 )
 from tests.firewall_helpers import cancel_pending_task
 from tests.jsonl_log_helpers import read_jsonl_text_after_flush
@@ -523,7 +524,7 @@ class TestGetFirewallHeaders:
         is recorded so the cooldown can suppress re-marking (#9860)."""
         cache_key = auth_cache_key()
         mark_force_refresh(cache_key)
-        before = time.time()
+        before = time.monotonic()
 
         mock_fetch = AsyncMock(return_value=_auth_success(headers={"Authorization": "Bearer new"}))
         with patch.object(auth_cache, "fetch_firewall_headers", mock_fetch):
@@ -534,13 +535,13 @@ class TestGetFirewallHeaders:
         # Marker cleared after consumption
         assert not force_refresh_pending(cache_key)
         # Consume timestamp recorded for cooldown enforcement
-        assert require_last_force_refresh_at(cache_key) >= before
+        assert require_last_force_refresh_monotonic_at(cache_key) >= before
 
     async def test_force_refresh_fetch_failure_still_consumes_marker(self, headers):
         """A failed forced refresh burns the cooldown and does not cache headers."""
         cache_key = auth_cache_key()
         mark_force_refresh(cache_key)
-        before = time.time()
+        before = time.monotonic()
 
         mock_fetch = AsyncMock(side_effect=ConnectionError("server unreachable"))
         with (
@@ -551,8 +552,67 @@ class TestGetFirewallHeaders:
 
         assert mock_fetch.call_args.kwargs["force_refresh"] is True
         assert not force_refresh_pending(cache_key)
-        assert require_last_force_refresh_at(cache_key) >= before
+        assert require_last_force_refresh_monotonic_at(cache_key) >= before
         assert cached_headers(cache_key) is None
+
+    def test_force_refresh_first_request_is_allowed_without_previous_timestamp(self, headers):
+        """A fresh auth state has no cooldown timestamp, so the first 401 marks."""
+        cache_key = auth_cache_key()
+
+        with patch.object(auth_cache.time, "monotonic", return_value=10.0):
+            auth_cache.request_force_refresh(cache_key)
+
+        assert force_refresh_pending(cache_key)
+
+    def test_force_refresh_inside_monotonic_cooldown_is_suppressed(self, headers):
+        """Repeated 401s inside the process-local cooldown do not re-mark."""
+        cache_key = auth_cache_key()
+        set_last_force_refresh_monotonic_at(cache_key, 1000.0)
+
+        with patch.object(auth_cache.time, "monotonic", return_value=1119.0):
+            auth_cache.request_force_refresh(cache_key)
+
+        assert not force_refresh_pending(cache_key)
+
+    def test_force_refresh_after_monotonic_cooldown_is_allowed(self, headers):
+        """A 401 after the monotonic cooldown elapsed can re-mark."""
+        cache_key = auth_cache_key()
+        set_last_force_refresh_monotonic_at(cache_key, 1000.0)
+
+        with patch.object(auth_cache.time, "monotonic", return_value=1121.0):
+            auth_cache.request_force_refresh(cache_key)
+
+        assert force_refresh_pending(cache_key)
+
+    async def test_force_refresh_records_monotonic_timestamp_before_fetch_returns(self, headers):
+        """The cooldown is burned before awaiting the forced auth fetch."""
+        cache_key = auth_cache_key()
+        mark_force_refresh(cache_key)
+        fetch_entered = asyncio.Event()
+        allow_fetch_return = asyncio.Event()
+
+        async def delayed_fetch(*args, **kwargs):
+            assert kwargs["force_refresh"] is True
+            assert require_last_force_refresh_monotonic_at(cache_key) == 1234.0
+            fetch_entered.set()
+            await allow_fetch_return.wait()
+            return _auth_success(headers={"Authorization": "Bearer new"})
+
+        with (
+            patch.object(auth_cache.time, "monotonic", return_value=1234.0),
+            patch.object(auth_cache, "fetch_firewall_headers", side_effect=delayed_fetch),
+        ):
+            task = asyncio.create_task(
+                auth_cache.get_firewall_headers(cache_key, _firewall_auth_request())
+            )
+            try:
+                await asyncio.wait_for(fetch_entered.wait(), timeout=5)
+                assert require_last_force_refresh_monotonic_at(cache_key) == 1234.0
+                allow_fetch_return.set()
+                await task
+            finally:
+                allow_fetch_return.set()
+                await cancel_pending_task(task)
 
     async def test_non_forced_fetch_does_not_cache_if_marker_appears_in_flight(self, headers):
         """A 401 marker during a non-forced fetch must win over the cache write."""
@@ -594,7 +654,7 @@ class TestGetFirewallHeaders:
         forced_fetch = AsyncMock(
             return_value=_auth_success(headers=forced_headers, expires_at=time.time() + 3600)
         )
-        before_forced = time.time()
+        before_forced = time.monotonic()
 
         with patch.object(auth_cache, "fetch_firewall_headers", forced_fetch):
             forced_result = await auth_cache.get_firewall_headers(
@@ -605,7 +665,7 @@ class TestGetFirewallHeaders:
         assert forced_result["headers"] == forced_headers
         assert forced_result["cache_hit"] is False
         assert not force_refresh_pending(cache_key)
-        assert require_last_force_refresh_at(cache_key) >= before_forced
+        assert require_last_force_refresh_monotonic_at(cache_key) >= before_forced
         assert require_cached_headers(cache_key).payload.headers == forced_headers
 
     async def test_waiting_request_force_refreshes_after_in_flight_marker(self, headers):
@@ -667,7 +727,7 @@ class TestGetFirewallHeaders:
 
         assert mock_fetch.call_args.kwargs["force_refresh"] is False
         # No consume timestamp written when force-refresh didn't happen
-        assert last_force_refresh_at(cache_key) == 0.0
+        assert last_force_refresh_monotonic_at(cache_key) is None
 
     async def test_force_refresh_marker_is_scoped_to_auth_identity(self, headers):
         old_key = auth_cache_key(auth_identity="old-auth")

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -588,31 +588,19 @@ class TestGetFirewallHeaders:
         """The cooldown is burned before awaiting the forced auth fetch."""
         cache_key = auth_cache_key()
         mark_force_refresh(cache_key)
-        fetch_entered = asyncio.Event()
-        allow_fetch_return = asyncio.Event()
 
         async def delayed_fetch(*args, **kwargs):
             assert kwargs["force_refresh"] is True
             assert require_last_force_refresh_monotonic_at(cache_key) == 1234.0
-            fetch_entered.set()
-            await allow_fetch_return.wait()
             return _auth_success(headers={"Authorization": "Bearer new"})
 
         with (
             patch.object(auth_cache.time, "monotonic", return_value=1234.0),
             patch.object(auth_cache, "fetch_firewall_headers", side_effect=delayed_fetch),
         ):
-            task = asyncio.create_task(
-                auth_cache.get_firewall_headers(cache_key, _firewall_auth_request())
-            )
-            try:
-                await asyncio.wait_for(fetch_entered.wait(), timeout=5)
-                assert require_last_force_refresh_monotonic_at(cache_key) == 1234.0
-                allow_fetch_return.set()
-                await task
-            finally:
-                allow_fetch_return.set()
-                await cancel_pending_task(task)
+            await auth_cache.get_firewall_headers(cache_key, _firewall_auth_request())
+
+        assert require_last_force_refresh_monotonic_at(cache_key) == 1234.0
 
     async def test_non_forced_fetch_does_not_cache_if_marker_appears_in_flight(self, headers):
         """A 401 marker during a non-forced fetch must win over the cache write."""

--- a/crates/runner/mitm-addon/tests/test_registry_auth_cache_eviction.py
+++ b/crates/runner/mitm-addon/tests/test_registry_auth_cache_eviction.py
@@ -9,10 +9,10 @@ from tests.auth_state_helpers import (
     cached_headers,
     force_refresh_pending,
     has_auth_state,
-    last_force_refresh_at,
+    last_force_refresh_monotonic_at,
     mark_force_refresh,
     set_cached_headers,
-    set_last_force_refresh_at,
+    set_last_force_refresh_monotonic_at,
 )
 from tests.registry_helpers import write_firewall_registry, write_simple_registry
 
@@ -47,14 +47,14 @@ class TestRegistryAuthCacheEviction:
             headers={"Authorization": "Bearer tok"},
         )
         mark_force_refresh(removed_key)
-        set_last_force_refresh_at(removed_key, 100.0)
+        set_last_force_refresh_monotonic_at(removed_key, 100.0)
         # Also cache for run-other (will appear in new registry)
         set_cached_headers(
             retained_key,
             headers={"Authorization": "Bearer other"},
         )
         mark_force_refresh(retained_key)
-        set_last_force_refresh_at(retained_key, 200.0)
+        set_last_force_refresh_monotonic_at(retained_key, 200.0)
 
         # Update registry: remove run-abc-123, add run-other
         new_data = {"vms": {"10.200.0.99": {"runId": "run-other"}}, "updatedAt": 0}
@@ -67,7 +67,7 @@ class TestRegistryAuthCacheEviction:
         # run-other state should remain (still in registry)
         assert cached_headers(retained_key)
         assert force_refresh_pending(retained_key)
-        assert last_force_refresh_at(retained_key) == 200.0
+        assert last_force_refresh_monotonic_at(retained_key) == 200.0
 
     def test_repeated_parse_failure_does_not_re_evict_auth_state(
         self,
@@ -82,7 +82,7 @@ class TestRegistryAuthCacheEviction:
             headers={"Authorization": "Bearer tok"},
         )
         mark_force_refresh(old_cache_key)
-        set_last_force_refresh_at(old_cache_key, 100.0)
+        set_last_force_refresh_monotonic_at(old_cache_key, 100.0)
 
         registry_file.write_text("{ broken while evicting cache")
 
@@ -97,14 +97,14 @@ class TestRegistryAuthCacheEviction:
             headers={"Authorization": "Bearer after-failure"},
         )
         mark_force_refresh(new_cache_key)
-        set_last_force_refresh_at(new_cache_key, 200.0)
+        set_last_force_refresh_monotonic_at(new_cache_key, 200.0)
 
         with patch.object(registry.ctx, "log", MagicMock(), create=True):
             assert registry.load_registry(str(registry_file)) == {}
 
         assert cached_headers(new_cache_key)
         assert force_refresh_pending(new_cache_key)
-        assert last_force_refresh_at(new_cache_key) == 200.0
+        assert last_force_refresh_monotonic_at(new_cache_key) == 200.0
 
     def test_evicts_marker_only_auth_state_on_run_removal(self, registry_file):
         """Registry eviction removes auth state even when it has no cached headers."""
@@ -112,7 +112,7 @@ class TestRegistryAuthCacheEviction:
 
         cache_key = auth_cache_key(run_id="run-abc-123", api_id="api-0")
         mark_force_refresh(cache_key)
-        set_last_force_refresh_at(cache_key, 100.0)
+        set_last_force_refresh_monotonic_at(cache_key, 100.0)
 
         registry_file.write_text(json.dumps({"vms": {}, "updatedAt": 0}))
 
@@ -128,10 +128,10 @@ class TestRegistryAuthCacheEviction:
         active_run_key = auth_cache_key(run_id="run-active", api_id="api-0")
         set_cached_headers(blank_run_key, headers={})
         mark_force_refresh(blank_run_key)
-        set_last_force_refresh_at(blank_run_key, 100.0)
+        set_last_force_refresh_monotonic_at(blank_run_key, 100.0)
         set_cached_headers(active_run_key, headers={})
         mark_force_refresh(active_run_key)
-        set_last_force_refresh_at(active_run_key, 200.0)
+        set_last_force_refresh_monotonic_at(active_run_key, 200.0)
 
         registry_file.write_text(
             json.dumps(
@@ -154,7 +154,7 @@ class TestRegistryAuthCacheEviction:
         assert not has_auth_state(blank_run_key)
         assert cached_headers(active_run_key)
         assert force_refresh_pending(active_run_key)
-        assert last_force_refresh_at(active_run_key) == 200.0
+        assert last_force_refresh_monotonic_at(active_run_key) == 200.0
 
     def test_valid_entry_becoming_invalid_evicts_context_and_cache(self, tmp_path):
         registry_file = tmp_path / "registry.json"
@@ -200,10 +200,10 @@ class TestRegistryAuthCacheEviction:
         active_run_key = auth_cache_key(run_id="run-active", api_id="api-0")
         set_cached_headers(old_run_key, headers={})
         mark_force_refresh(old_run_key)
-        set_last_force_refresh_at(old_run_key, 100.0)
+        set_last_force_refresh_monotonic_at(old_run_key, 100.0)
         set_cached_headers(active_run_key, headers={})
         mark_force_refresh(active_run_key)
-        set_last_force_refresh_at(active_run_key, 200.0)
+        set_last_force_refresh_monotonic_at(active_run_key, 200.0)
 
         registry_file.write_text(
             json.dumps(
@@ -224,4 +224,4 @@ class TestRegistryAuthCacheEviction:
         assert not has_auth_state(old_run_key)
         assert cached_headers(active_run_key)
         assert force_refresh_pending(active_run_key)
-        assert last_force_refresh_at(active_run_key) == 200.0
+        assert last_force_refresh_monotonic_at(active_run_key) == 200.0

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -3,6 +3,7 @@
 import json
 import time
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from mitmproxy import http
@@ -19,7 +20,7 @@ from tests.auth_state_helpers import (
     force_refresh_pending,
     has_auth_state,
     set_cached_headers,
-    set_last_force_refresh_at,
+    set_last_force_refresh_monotonic_at,
 )
 from tests.flow_helpers import header_map, response_stream
 from tests.jsonl_log_helpers import (
@@ -1609,7 +1610,7 @@ class TestResponseHandler:
         flow.metadata[metadata_keys.FIREWALL_AUTH_CACHE_KEY] = cache_key
         set_cached_headers(cache_key, headers={"Authorization": "Bearer cached-token"})
         # Simulate: a forced refresh JUST completed a moment ago
-        set_last_force_refresh_at(cache_key, time.time())
+        set_last_force_refresh_monotonic_at(cache_key, time.monotonic())
 
         with mitm_ctx():
             mitm_addon.response(flow)
@@ -1636,15 +1637,43 @@ class TestResponseHandler:
         cache_key = auth_cache_key(run_id="run-conn-re", api_id="run-conn-re:0")
         flow.metadata[metadata_keys.FIREWALL_AUTH_CACHE_KEY] = cache_key
         # Simulate: last forced refresh happened well before the cooldown window
-        set_last_force_refresh_at(
+        set_last_force_refresh_monotonic_at(
             cache_key,
-            time.time() - auth_cache._FORCE_REFRESH_COOLDOWN_SECS - 1,
+            time.monotonic() - auth_cache._FORCE_REFRESH_COOLDOWN_SECS - 1,
         )
 
         with mitm_ctx():
             mitm_addon.response(flow)
 
         # Cooldown elapsed → marker re-added
+        assert force_refresh_pending(cache_key)
+
+    def test_401_after_cooldown_re_marks_when_wall_clock_steps_back(
+        self, real_flow, mitm_ctx, headers
+    ):
+        """Cooldown uses monotonic elapsed time, not wall-clock time."""
+        flow = real_flow(with_response=False, host="api.github.com")
+        flow.metadata[metadata_keys.VM_RUN_ID] = "run-conn-skew"
+        flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = ""
+        flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+        flow.metadata[metadata_keys.FIREWALL_BASE] = "https://api.github.com"
+        flow.metadata[metadata_keys.FIREWALL_API_ID] = "run-conn-skew:0"
+        flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.github.com/repos"
+        flow.response = tutils.tresp(status_code=401, headers=http.Headers())
+
+        cache_key = auth_cache_key(run_id="run-conn-skew", api_id="run-conn-skew:0")
+        flow.metadata[metadata_keys.FIREWALL_AUTH_CACHE_KEY] = cache_key
+        set_cached_headers(cache_key, headers={"Authorization": "Bearer cached-token"})
+        set_last_force_refresh_monotonic_at(cache_key, 1000.0)
+
+        with (
+            patch.object(auth_cache.time, "monotonic", return_value=1121.0),
+            patch.object(auth_cache.time, "time", return_value=10.0),
+            mitm_ctx(),
+        ):
+            mitm_addon.response(flow)
+
+        assert cached_headers(cache_key) is None
         assert force_refresh_pending(cache_key)
 
     def test_401_without_auth_cache_key_does_not_synthesize_state(


### PR DESCRIPTION
## Summary
- use monotonic elapsed time for firewall auth force-refresh cooldowns
- keep webhook expiresAt validation on wall-clock time
- add deterministic cooldown and wall-clock-step regression coverage

Fixes #19170

## Verification
- .venv/bin/python -m pytest tests/test_firewall_auth.py tests/test_response_handler.py tests/test_registry_auth_cache_eviction.py -q
- .venv/bin/ruff check .
- .venv/bin/ruff format --check .
- .venv/bin/basedpyright -p .