### PR TITLE
fix: cancel trial subscriptions on account deletion

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -3527,7 +3527,7 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
           {
             id: extraSubscriptionId,
             status: "trialing",
-            cancel_at_period_end: false,
+            cancel_at_period_end: true,
           },
         ],
         has_more: false,

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -3492,7 +3492,7 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
     );
   });
 
-  it("marks every Stripe subscription non-renewing and deletes an empty org after a verified user.deleted event", async () => {
+  it("cancels trialing Stripe subscriptions and deletes an empty org after a verified user.deleted event", async () => {
     const bdd = createBddApi(context);
     const runs = createRunsAutomationsApi(context);
     api.configureClerkWebhookSecret();
@@ -3561,19 +3561,19 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
         },
       );
       expect(context.mocks.stripe.subscriptions.update).toHaveBeenCalledTimes(
-        2,
+        1,
       );
       expect(context.mocks.stripe.subscriptions.update).toHaveBeenNthCalledWith(
         1,
         granted.subscriptionId,
         { cancel_at_period_end: true },
       );
-      expect(context.mocks.stripe.subscriptions.update).toHaveBeenNthCalledWith(
-        2,
-        extraSubscriptionId,
-        { cancel_at_period_end: true },
+      expect(context.mocks.stripe.subscriptions.cancel).toHaveBeenCalledTimes(
+        1,
       );
-      expect(context.mocks.stripe.subscriptions.cancel).not.toHaveBeenCalled();
+      expect(context.mocks.stripe.subscriptions.cancel).toHaveBeenCalledWith(
+        extraSubscriptionId,
+      );
     });
     await expect
       .poll(async () => {

--- a/turbo/apps/api/src/signals/services/webhooks-clerk-cleanup.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-clerk-cleanup.service.ts
@@ -197,13 +197,18 @@ function queueStripeSubscriptionCleanup(
     readonly cancel_at_period_end: boolean | null;
   },
 ): void {
-  if (subscription.status === "canceled" || subscription.cancel_at_period_end) {
+  if (subscription.status === "canceled") {
     targets.nonRenewingSubscriptionIds.add(subscription.id);
     return;
   }
 
   if (subscription.status === "trialing") {
     targets.cancelNowSubscriptionIds.add(subscription.id);
+    return;
+  }
+
+  if (subscription.cancel_at_period_end) {
+    targets.nonRenewingSubscriptionIds.add(subscription.id);
     return;
   }
 

--- a/turbo/apps/api/src/signals/services/webhooks-clerk-cleanup.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-clerk-cleanup.service.ts
@@ -117,12 +117,19 @@ async function cancelLastAdminOrgsStripeSubscriptions(
       );
 
     if ((result?.adminCount ?? 0) <= 1) {
-      await tapError(markStripeSubscriptionsNonRenewing(db, orgId), (error) => {
-        L.warn(
-          "failed to mark stripe subscriptions non-renewing for org with banned last admin",
-          { userId, orgId, error },
-        );
-      });
+      await tapError(
+        cancelStripeSubscriptionsForDeletedOrg(db, orgId),
+        (error) => {
+          L.warn(
+            "failed to cancel stripe subscriptions for banned last admin",
+            {
+              userId,
+              orgId,
+              error,
+            },
+          );
+        },
+      );
     }
   }
 }
@@ -176,7 +183,57 @@ async function cleanupWorkspaceInstallation(
     .where(eq(slackOrgInstallations.slackWorkspaceId, workspaceId));
 }
 
-async function markStripeSubscriptionsNonRenewing(
+interface StripeSubscriptionCleanupTargets {
+  readonly cancelNowSubscriptionIds: Set<string>;
+  readonly cancelAtPeriodEndSubscriptionIds: Set<string>;
+  readonly nonRenewingSubscriptionIds: Set<string>;
+}
+
+function queueStripeSubscriptionCleanup(
+  targets: StripeSubscriptionCleanupTargets,
+  subscription: {
+    readonly id: string;
+    readonly status: string | null;
+    readonly cancel_at_period_end: boolean | null;
+  },
+): void {
+  if (subscription.status === "canceled" || subscription.cancel_at_period_end) {
+    targets.nonRenewingSubscriptionIds.add(subscription.id);
+    return;
+  }
+
+  if (subscription.status === "trialing") {
+    targets.cancelNowSubscriptionIds.add(subscription.id);
+    return;
+  }
+
+  targets.cancelAtPeriodEndSubscriptionIds.add(subscription.id);
+}
+
+function queueFallbackStripeSubscriptionCleanup(
+  targets: StripeSubscriptionCleanupTargets,
+  subscriptionId: string | null,
+  subscriptionStatus: string | null,
+): void {
+  if (
+    !subscriptionId ||
+    subscriptionStatus === "canceled" ||
+    targets.nonRenewingSubscriptionIds.has(subscriptionId) ||
+    targets.cancelNowSubscriptionIds.has(subscriptionId) ||
+    targets.cancelAtPeriodEndSubscriptionIds.has(subscriptionId)
+  ) {
+    return;
+  }
+
+  if (subscriptionStatus === "trialing") {
+    targets.cancelNowSubscriptionIds.add(subscriptionId);
+    return;
+  }
+
+  targets.cancelAtPeriodEndSubscriptionIds.add(subscriptionId);
+}
+
+async function cancelStripeSubscriptionsForDeletedOrg(
   db: Db,
   orgId: string,
 ): Promise<void> {
@@ -195,8 +252,11 @@ async function markStripeSubscriptionsNonRenewing(
   }
 
   const stripe = getStripeClient();
-  const renewingSubscriptionIds = new Set<string>();
-  const nonRenewingSubscriptionIds = new Set<string>();
+  const targets: StripeSubscriptionCleanupTargets = {
+    cancelNowSubscriptionIds: new Set<string>(),
+    cancelAtPeriodEndSubscriptionIds: new Set<string>(),
+    nonRenewingSubscriptionIds: new Set<string>(),
+  };
 
   if (meta.stripeCustomerId) {
     let startingAfter: string | undefined;
@@ -210,14 +270,7 @@ async function markStripeSubscriptionsNonRenewing(
       });
 
       for (const subscription of subscriptions.data) {
-        if (
-          subscription.status === "canceled" ||
-          subscription.cancel_at_period_end
-        ) {
-          nonRenewingSubscriptionIds.add(subscription.id);
-        } else {
-          renewingSubscriptionIds.add(subscription.id);
-        }
+        queueStripeSubscriptionCleanup(targets, subscription);
       }
 
       const lastSubscription =
@@ -229,15 +282,17 @@ async function markStripeSubscriptionsNonRenewing(
     }
   }
 
-  if (
-    meta.stripeSubscriptionId &&
-    meta.subscriptionStatus !== "canceled" &&
-    !nonRenewingSubscriptionIds.has(meta.stripeSubscriptionId)
-  ) {
-    renewingSubscriptionIds.add(meta.stripeSubscriptionId);
+  queueFallbackStripeSubscriptionCleanup(
+    targets,
+    meta.stripeSubscriptionId,
+    meta.subscriptionStatus,
+  );
+
+  for (const subscriptionId of targets.cancelNowSubscriptionIds) {
+    await stripe.subscriptions.cancel(subscriptionId);
   }
 
-  for (const subscriptionId of renewingSubscriptionIds) {
+  for (const subscriptionId of targets.cancelAtPeriodEndSubscriptionIds) {
     await stripe.subscriptions.update(subscriptionId, {
       cancel_at_period_end: true,
     });
@@ -388,7 +443,7 @@ const cleanupOrgExternalServices$ = command(
       {
         name: "stripe subscriptions",
         run: () => {
-          return markStripeSubscriptionsNonRenewing(db, orgId);
+          return cancelStripeSubscriptionsForDeletedOrg(db, orgId);
         },
       },
       {


### PR DESCRIPTION
## Summary
- Cancel trialing Stripe subscriptions immediately when deleted org cleanup runs after account/org deletion.
- Keep non-trial subscriptions on the existing `cancel_at_period_end: true` path.
- Update Clerk deletion webhook BDD coverage for the mixed active + trial subscription case.

## Verification
- `pnpm -F api lint`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts`