### PR TITLE
refactor: reduce fallback slop in runtime validation

### DIFF
--- a/turbo/apps/api/src/signals/external/s3.ts
+++ b/turbo/apps/api/src/signals/external/s3.ts
@@ -233,6 +233,18 @@ export function downloadS3BufferWithMaxBytes(
   });
 }
 
+function isAsyncIterableByteStream(
+  value: unknown,
+): value is AsyncIterable<Uint8Array> {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const iterator = (value as { [Symbol.asyncIterator]?: unknown })[
+    Symbol.asyncIterator
+  ];
+  return typeof iterator === "function";
+}
+
 function downloadS3BufferWithClient(
   client$: Computed<S3Client>,
   bucket: string,
@@ -247,6 +259,9 @@ function downloadS3BufferWithClient(
     if (!response.Body) {
       throw new Error("S3 object body is empty");
     }
+    if (!isAsyncIterableByteStream(response.Body)) {
+      throw new Error("S3 object body is not an async byte stream");
+    }
     if (
       options.maxBytes !== undefined &&
       response.ContentLength !== undefined &&
@@ -259,9 +274,11 @@ function downloadS3BufferWithClient(
       );
     }
     const chunks: Uint8Array[] = [];
-    const stream = response.Body as unknown as AsyncIterable<Uint8Array>;
     let totalLength = 0;
-    for await (const chunk of stream) {
+    for await (const chunk of response.Body) {
+      if (!(chunk instanceof Uint8Array)) {
+        throw new Error("S3 object body yielded a non-byte chunk");
+      }
       totalLength += chunk.length;
       if (options.maxBytes !== undefined && totalLength > options.maxBytes) {
         throw new S3ObjectSizeLimitError(key, totalLength, options.maxBytes);

--- a/turbo/packages/api-contracts/src/contracts/test-telegram-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-telegram-state.ts
@@ -14,12 +14,12 @@ export const testTelegramStateErrorSchema = z.object({
 
 export const testTelegramStateSeedBodySchema = z
   .object({
-    bot_id: z.unknown().optional(),
-    telegram_user_id: z.unknown().optional(),
-    bot_username: z.unknown().optional(),
-    webhook_secret: z.unknown().optional(),
-    email: z.unknown().optional(),
-    seed_link: z.unknown().optional(),
+    bot_id: z.string().optional(),
+    telegram_user_id: z.string().optional(),
+    bot_username: z.string().optional(),
+    webhook_secret: z.string().optional(),
+    email: z.string().optional(),
+    seed_link: z.boolean().optional(),
   })
   .passthrough();
 


### PR DESCRIPTION
## Summary

Daily AI slop fallback cleanup run focused on runtime validation candidates.

## Scan

- Scan timestamp: 2026-06-27T12:59:58.916Z
- Base commit: 988375fa8823aeb870ae478c9aac7ce253bab8c8
- Source: /tmp/ai-slop-fallback-scan.json

Total matches by category:

- nullish: 4576
- nullish-chain: 103
- field-fallback-chain: 81
- optional-prop: 4878
- zod-optional: 1591
- zod-loose-optional: 42
- loose-record: 916
- loose-index-signature: 6
- as-any: 1
- as-unknown-as: 43
- empty-fallback: 544
- string-fallback: 616
- null-undefined-fallback: 1248
- empty-catch: 4
- promise-catch-swallow: 16
- rust-unwrap-or: 553
- rust-ok-discard: 128

Selection budget:

- actionable_total: 240
- edit_budget: 12
- candidates changed: 7

## Files Changed

- `turbo/packages/api-contracts/src/contracts/test-telegram-state.ts`
  - Replaced six `z.unknown().optional()` seed-body fields with exact `z.string().optional()` or `z.boolean().optional()` schemas.
  - Safe because the route immediately reads these fields as strings or checks `seed_link === false`, and local callers/tests already pass those concrete types.

- `turbo/apps/api/src/signals/external/s3.ts`
  - Replaced an `as unknown as AsyncIterable<Uint8Array>` cast with an explicit async-iterable byte-stream guard and per-chunk byte validation.
  - Safe because the existing happy path still iterates the same S3 body stream, while invalid runtime shapes now fail with clear errors instead of relying on a double cast.

## Verification

- `pnpm install --frozen-lockfile --ignore-scripts` to install dependencies without changing the lockfile.
- `pnpm -F @vm0/firewalls-generator generate` to recreate ignored generated firewall metadata needed by API test imports.
- `pnpm -F @vm0/api-contracts check-types` passed.
- `pnpm -F api exec oxlint src/signals/external/s3.ts` passed.
- `pnpm -F @vm0/api-contracts exec oxlint src/contracts/test-telegram-state.ts` passed.
- `pnpm exec prettier --write apps/api/src/signals/external/s3.ts packages/api-contracts/src/contracts/test-telegram-state.ts` reported both files unchanged.
- `git diff --check` passed.
- `pnpm -F api check-types` could not complete locally: default heap run hit OOM and the larger-heap retry was killed by the runtime.
- `pnpm -F api test src/signals/routes/__tests__/test-telegram-state.test.ts` imported successfully after generating firewall metadata, then failed because local Postgres was unavailable at `127.0.0.1:5432` / `::1:5432`; 6 tests passed before DB-backed cases failed.

This workflow intentionally leaves the remaining scanner candidates for later daily runs.
