### PR TITLE
fix: update atom grant expiry

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs-automations.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs-automations.ts
@@ -453,7 +453,11 @@ export function createRunsAutomationsApi(context: TestContext) {
     // an org whose entire credit balance is already expired.
     async grantProEntitlement(
       actor: ApiTestUser,
-      options: { readonly periodEndUnix?: number } = {},
+      options: {
+        readonly periodEndUnix?: number;
+        readonly subscriptionMetadata?: Record<string, string>;
+        readonly cancelAtUnix?: number | null;
+      } = {},
     ): Promise<{
       readonly customerId: string;
       readonly subscriptionId: string;
@@ -486,10 +490,10 @@ export function createRunsAutomationsApi(context: TestContext) {
         status: "active",
         customer: customerId,
         cancel_at_period_end: false,
-        cancel_at: null,
+        cancel_at: options.cancelAtUnix ?? null,
         schedule: null,
         trial_end: null,
-        metadata: {},
+        metadata: options.subscriptionMetadata ?? {},
         items: { data: [{ price: { id: "price_bdd_pro" } }] },
       });
       const invoicePaidEvent = {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -1675,6 +1675,96 @@ describe("WHCB-09: sandbox storage writes and checkpoint history blobs land in t
 });
 
 describe("WHCB-07: Stripe billing lifecycle webhooks", () => {
+  it("expires Atom day-grant subscription credits at the Atom grant end", async () => {
+    const bdd = createBddApi(context);
+    const runs = createRunsAutomationsApi(context);
+    const billing = createBillingMediaApi(context);
+    const actor = bdd.user();
+    const grantExpiresAtUnix = epochSeconds(7);
+
+    await runs.grantProEntitlement(actor, {
+      periodEndUnix: epochSeconds(30),
+      cancelAtUnix: grantExpiresAtUnix,
+      subscriptionMetadata: {
+        source: "atom_entitlement",
+        duration: "7d",
+        atomGrantExpiresAt: isoOf(grantExpiresAtUnix),
+      },
+    });
+
+    const status = await billing.readBillingStatus(actor);
+    expect(status.tier).toBe("pro");
+    expect(status.currentPeriodEnd).toBe(isoOf(grantExpiresAtUnix));
+    expect(status.creditGrants).toStrictEqual([
+      expect.objectContaining({
+        amount: 20_000,
+        expiresAt: isoOf(grantExpiresAtUnix),
+        source: "subscription_renewal",
+      }),
+    ]);
+  });
+
+  it("expires Atom redeem-code day-grant subscription credits at the grant end", async () => {
+    const bdd = createBddApi(context);
+    const runs = createRunsAutomationsApi(context);
+    const billing = createBillingMediaApi(context);
+    const actor = bdd.user();
+    const grantExpiresAtUnix = epochSeconds(7);
+
+    await runs.grantProEntitlement(actor, {
+      periodEndUnix: epochSeconds(30),
+      cancelAtUnix: grantExpiresAtUnix,
+      subscriptionMetadata: {
+        source: "atom_redeem_code",
+        duration: "7d",
+        atomGrantExpiresAt: isoOf(grantExpiresAtUnix),
+      },
+    });
+
+    const status = await billing.readBillingStatus(actor);
+    expect(status.tier).toBe("pro");
+    expect(status.currentPeriodEnd).toBe(isoOf(grantExpiresAtUnix));
+    expect(status.creditGrants).toStrictEqual([
+      expect.objectContaining({
+        amount: 20_000,
+        expiresAt: isoOf(grantExpiresAtUnix),
+        source: "subscription_renewal",
+      }),
+    ]);
+  });
+
+  it("uses the normal renewal credit window when an Atom day-grant cancel_at is cleared", async () => {
+    const bdd = createBddApi(context);
+    const runs = createRunsAutomationsApi(context);
+    const billing = createBillingMediaApi(context);
+    const actor = bdd.user();
+    const grantExpiresAtUnix = epochSeconds(7);
+    const periodEndUnix = epochSeconds(30);
+    const renewalExpiresAt = new Date(periodEndUnix * 1000);
+    renewalExpiresAt.setMonth(renewalExpiresAt.getMonth() + 1);
+
+    await runs.grantProEntitlement(actor, {
+      periodEndUnix,
+      cancelAtUnix: null,
+      subscriptionMetadata: {
+        source: "atom_entitlement",
+        duration: "7d",
+        atomGrantExpiresAt: isoOf(grantExpiresAtUnix),
+      },
+    });
+
+    const status = await billing.readBillingStatus(actor);
+    expect(status.tier).toBe("pro");
+    expect(status.currentPeriodEnd).toBe(isoOf(periodEndUnix));
+    expect(status.creditGrants).toStrictEqual([
+      expect.objectContaining({
+        amount: 20_000,
+        expiresAt: renewalExpiresAt.toISOString(),
+        source: "subscription_renewal",
+      }),
+    ]);
+  });
+
   it("replays, expires, and auto-recharges subscription invoice credits", async () => {
     const bdd = createBddApi(context);
     const runs = createRunsAutomationsApi(context);

--- a/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
@@ -291,6 +291,11 @@ function subscriptionCreditExpiresAt(
   subscription: SubscriptionInput,
   periodEndDate: Date,
 ): Date {
+  const atomGrantExpiresAt = atomDayGrantCreditExpiresAt(subscription);
+  if (atomGrantExpiresAt) {
+    return atomGrantExpiresAt;
+  }
+
   if (subscription.status === "trialing") {
     return requiredSubscriptionTrialEnd(subscription);
   }
@@ -302,6 +307,44 @@ function subscriptionCreditExpiresAt(
 
 const CREDITS_PER_DOLLAR = 1000;
 const CREDIT_PURCHASE_EXPIRES_AT_METADATA_KEY = "creditsExpiresAt";
+const ATOM_GRANT_EXPIRES_AT_METADATA_KEY = "atomGrantExpiresAt";
+
+function isAtomDayGrantSource(source: string | undefined): boolean {
+  return source === "atom_entitlement" || source === "atom_redeem_code";
+}
+
+function atomDayGrantCreditExpiresAt(
+  subscription: SubscriptionInput,
+): Date | null {
+  const metadata = subscription.metadata ?? {};
+  if (!isAtomDayGrantSource(metadata.source)) {
+    return null;
+  }
+
+  const duration = metadata.duration;
+  if (!duration || !/^\d+d$/.test(duration)) {
+    return null;
+  }
+
+  const cancelAt = subscriptionCancelAt(subscription);
+  if (!cancelAt) {
+    return null;
+  }
+
+  const metadataExpiresAt = metadata[ATOM_GRANT_EXPIRES_AT_METADATA_KEY];
+  if (metadataExpiresAt) {
+    const date = new Date(metadataExpiresAt);
+    if (
+      !Number.isNaN(date.getTime()) &&
+      Math.floor(date.getTime() / 1000) ===
+        Math.floor(cancelAt.getTime() / 1000)
+    ) {
+      return date;
+    }
+  }
+
+  return cancelAt;
+}
 
 function creditsFromAmountCents(
   amountCents: number | null | undefined,


### PR DESCRIPTION
## Summary
- expire Atom day-grant subscription credits at the grant end for atom entitlement and redeem-code metadata
- add BDD coverage and helper support for subscription metadata and cancel_at

## Verification
- pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts -t "Atom"
- pnpm -F api lint
- pnpm -F api check-types