### PR TITLE
perf: rename runner storage manifest metric

### DIFF
--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -458,7 +458,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         };
         let err = result.as_ref().err().map(|e| e.to_string());
         telemetry.record(
-            "storage_download",
+            "runner_storage_download_total",
             t.elapsed(),
             result.is_ok(),
             err.as_deref(),

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -458,7 +458,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         };
         let err = result.as_ref().err().map(|e| e.to_string());
         telemetry.record(
-            "runner_storage_download_total",
+            "runner_storage_manifest_apply",
             t.elapsed(),
             result.is_ok(),
             err.as_deref(),

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -268,8 +268,8 @@ async fn run_in_sandbox_runs_guest_download_for_cached_instruction_normalization
     let ops = telemetry.pending_ops_snapshot();
     assert!(
         ops.iter()
-            .any(|(action, success, _)| action == "runner_storage_download_total" && *success),
-        "runner storage download total should be recorded with the disambiguated metric name: {ops:?}"
+            .any(|(action, success, _)| action == "runner_storage_manifest_apply" && *success),
+        "runner storage manifest apply should be recorded with the disambiguated metric name: {ops:?}"
     );
     assert!(
         ops.iter()

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -265,6 +265,17 @@ async fn run_in_sandbox_runs_guest_download_for_cached_instruction_normalization
             .any(|call| call.cmd == guest_download_stdin_command()),
         "cached instruction storage should still invoke guest-download; calls: {exec_calls:?}"
     );
+    let ops = telemetry.pending_ops_snapshot();
+    assert!(
+        ops.iter()
+            .any(|(action, success, _)| action == "runner_storage_download_total" && *success),
+        "runner storage download total should be recorded with the disambiguated metric name: {ops:?}"
+    );
+    assert!(
+        ops.iter()
+            .all(|(action, _, _)| action != "storage_download"),
+        "runner telemetry should not use the guest-download per-entry metric name: {ops:?}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Rename the runner top-level storage manifest phase metric to `runner_storage_manifest_apply`.
- Keep guest-download helper telemetry unchanged: guest total remains `download_total`, and per-entry storage work remains `storage_download`.
- Add a runner test assertion to prevent runner-origin telemetry from reusing the guest-download per-entry metric name again.

## Naming rationale

`runner_storage_manifest_apply` is intentionally not named `runner_storage_download_total`: the runner span covers cache population plus the guest-download helper invocation, which can include storage entries, artifacts, cleanup, and instruction normalization. The name describes the runner phase being timed instead of implying a sum of per-entry storage downloads.

## Verification

- `cargo fmt --manifest-path /workspaces/vm7/crates/Cargo.toml --all --check`
- `cargo test --manifest-path /workspaces/vm7/crates/Cargo.toml -p runner run_in_sandbox_runs_guest_download_for_cached_instruction_normalization --quiet`
- pre-commit: cargo-doc and cargo-clippy