### PR TITLE
feat: add disabled codex app-server backend

### DIFF
--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -403,6 +403,29 @@ impl CodexAppServerClient {
         Ok(())
     }
 
+    pub async fn terminate(&mut self) -> Result<(), CodexAppServerError> {
+        if self.closed {
+            return Ok(());
+        }
+
+        self.close_io_handles();
+        let child_exited = self.try_finish_child_wait()?.is_some();
+        if self.wait_rx.is_some() && !child_exited {
+            self.sigterm_process_group();
+            if !self.wait_for_child(SHUTDOWN_SIGKILL_GRACE).await? {
+                self.sigkill_process_group();
+                if !self.wait_for_child(SHUTDOWN_SIGKILL_GRACE).await? {
+                    return Err(CodexAppServerError::ShutdownTimeout);
+                }
+            }
+        }
+
+        self.drain_stderr().await;
+        self.clear_child_process_handles();
+        self.closed = true;
+        Ok(())
+    }
+
     async fn wait_for_child(&mut self, timeout: Duration) -> Result<bool, CodexAppServerError> {
         let Some(wait_rx) = self.wait_rx.as_mut() else {
             return Ok(true);

--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -412,11 +412,9 @@ impl CodexAppServerClient {
         let child_exited = self.try_finish_child_wait()?.is_some();
         if self.wait_rx.is_some() && !child_exited {
             self.sigterm_process_group();
+            self.sigkill_process_group();
             if !self.wait_for_child(SHUTDOWN_SIGKILL_GRACE).await? {
-                self.sigkill_process_group();
-                if !self.wait_for_child(SHUTDOWN_SIGKILL_GRACE).await? {
-                    return Err(CodexAppServerError::ShutdownTimeout);
-                }
+                return Err(CodexAppServerError::ShutdownTimeout);
             }
         }
 

--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -21,7 +21,10 @@ use tokio::task::JoinHandle;
 
 use crate::error::AgentError;
 
-use super::{child_env, diagnostics, process_group::ChildProcessGroup};
+use super::{
+    child_env, codex_app_server_events::IGNORED_NOTIFICATION_METHODS, diagnostics,
+    process_group::ChildProcessGroup,
+};
 
 const METHOD_NOT_FOUND: i64 = -32601;
 const NOTIFICATION_QUEUE_CAPACITY: usize = 128;
@@ -243,7 +246,8 @@ impl CodexAppServerClient {
                     },
                     "capabilities": {
                         "experimentalApi": true,
-                        "requestAttestation": false
+                        "requestAttestation": false,
+                        "optOutNotificationMethods": IGNORED_NOTIFICATION_METHODS
                     }
                 }),
             )

--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -27,7 +27,6 @@ const METHOD_NOT_FOUND: i64 = -32601;
 const NOTIFICATION_QUEUE_CAPACITY: usize = 128;
 const NOTIFICATION_QUEUE_MAX_BYTES: usize = 16 * 1024 * 1024;
 const STDOUT_MAX_LINE_BYTES: usize = 64 * 1024 * 1024;
-const SHUTDOWN_SIGTERM_GRACE: Duration = Duration::from_secs(2);
 const SHUTDOWN_SIGKILL_GRACE: Duration = Duration::from_secs(2);
 const STDERR_DRAIN_GRACE: Duration = Duration::from_secs(2);
 
@@ -383,17 +382,16 @@ impl CodexAppServerClient {
         let requested_graceful_shutdown = self.stdin.is_some();
         self.close_io_handles();
         let child_exited = if requested_graceful_shutdown {
-            self.wait_for_child(SHUTDOWN_SIGTERM_GRACE).await?
+            tokio::task::yield_now().await;
+            self.try_finish_child_wait()?.is_some()
         } else {
             self.try_finish_child_wait()?.is_some()
         };
         if self.wait_rx.is_some() && !child_exited {
             self.sigterm_process_group();
+            self.sigkill_process_group();
             if !self.wait_for_child(SHUTDOWN_SIGKILL_GRACE).await? {
-                self.sigkill_process_group();
-                if !self.wait_for_child(SHUTDOWN_SIGKILL_GRACE).await? {
-                    return Err(CodexAppServerError::ShutdownTimeout);
-                }
+                return Err(CodexAppServerError::ShutdownTimeout);
             }
         }
 

--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use serde_json::{Value, json};
+use serde_json::{Map, Value, json};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{ChildStdin, ChildStdout};
 use tokio::runtime::Handle;
@@ -21,10 +21,7 @@ use tokio::task::JoinHandle;
 
 use crate::error::AgentError;
 
-use super::{
-    child_env, codex_app_server_events::IGNORED_NOTIFICATION_METHODS, diagnostics,
-    process_group::ChildProcessGroup,
-};
+use super::{child_env, diagnostics, process_group::ChildProcessGroup};
 
 const METHOD_NOT_FOUND: i64 = -32601;
 const NOTIFICATION_QUEUE_CAPACITY: usize = 128;
@@ -39,6 +36,7 @@ pub struct CodexAppServerConfig {
     codex_home: PathBuf,
     extra_env: Vec<(String, String)>,
     current_dir: Option<PathBuf>,
+    opt_out_notification_methods: Vec<String>,
 }
 
 impl CodexAppServerConfig {
@@ -48,6 +46,7 @@ impl CodexAppServerConfig {
             codex_home: codex_home.into(),
             extra_env: Vec::new(),
             current_dir: None,
+            opt_out_notification_methods: Vec::new(),
         }
     }
 
@@ -58,6 +57,15 @@ impl CodexAppServerConfig {
 
     pub fn with_current_dir(mut self, current_dir: impl Into<PathBuf>) -> Self {
         self.current_dir = Some(current_dir.into());
+        self
+    }
+
+    pub fn with_opt_out_notification_methods<I, S>(mut self, methods: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.opt_out_notification_methods = methods.into_iter().map(Into::into).collect();
         self
     }
 }
@@ -154,6 +162,7 @@ pub struct CodexAppServerClient {
     stream_unusable_reason: Option<String>,
     notifications: VecDeque<QueuedNotification>,
     notification_queue_bytes: usize,
+    opt_out_notification_methods: Vec<String>,
     closed: bool,
 }
 
@@ -216,6 +225,7 @@ impl CodexAppServerClient {
             stream_unusable_reason: None,
             notifications: VecDeque::with_capacity(NOTIFICATION_QUEUE_CAPACITY),
             notification_queue_bytes: 0,
+            opt_out_notification_methods: config.opt_out_notification_methods,
             closed: false,
         })
     }
@@ -235,6 +245,22 @@ impl CodexAppServerClient {
     }
 
     pub async fn initialize(&mut self) -> Result<InitializeResponse, CodexAppServerError> {
+        let mut capabilities = Map::new();
+        capabilities.insert("experimentalApi".to_string(), Value::Bool(true));
+        capabilities.insert("requestAttestation".to_string(), Value::Bool(false));
+        if !self.opt_out_notification_methods.is_empty() {
+            capabilities.insert(
+                "optOutNotificationMethods".to_string(),
+                Value::Array(
+                    self.opt_out_notification_methods
+                        .iter()
+                        .cloned()
+                        .map(Value::String)
+                        .collect(),
+                ),
+            );
+        }
+
         let response = self
             .request(
                 "initialize",
@@ -244,11 +270,7 @@ impl CodexAppServerClient {
                         "title": null,
                         "version": env!("CARGO_PKG_VERSION")
                     },
-                    "capabilities": {
-                        "experimentalApi": true,
-                        "requestAttestation": false,
-                        "optOutNotificationMethods": IGNORED_NOTIFICATION_METHODS
-                    }
+                    "capabilities": capabilities
                 }),
             )
             .await?;

--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -36,6 +36,7 @@ pub struct CodexAppServerConfig {
     binary: PathBuf,
     codex_home: PathBuf,
     extra_env: Vec<(String, String)>,
+    current_dir: Option<PathBuf>,
 }
 
 impl CodexAppServerConfig {
@@ -44,11 +45,17 @@ impl CodexAppServerConfig {
             binary: binary.into(),
             codex_home: codex_home.into(),
             extra_env: Vec::new(),
+            current_dir: None,
         }
     }
 
     pub fn with_env(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
         self.extra_env.push((key.into(), value.into()));
+        self
+    }
+
+    pub fn with_current_dir(mut self, current_dir: impl Into<PathBuf>) -> Self {
+        self.current_dir = Some(current_dir.into());
         self
     }
 }
@@ -165,6 +172,9 @@ impl CodexAppServerClient {
             .stderr(Stdio::piped())
             .process_group(0)
             .kill_on_drop(true);
+        if let Some(current_dir) = config.current_dir {
+            cmd.current_dir(current_dir);
+        }
         for (key, value) in config.extra_env {
             cmd.env(key, value);
         }
@@ -325,6 +335,35 @@ impl CodexAppServerClient {
                         self.in_flight_request_id = None;
                         return Err(error);
                     }
+                }
+            }
+        }
+    }
+
+    pub async fn next_notification(
+        &mut self,
+        pending_method: &str,
+    ) -> Result<ServerNotification, CodexAppServerError> {
+        self.ensure_stream_usable()?;
+        if self.in_flight_request_id.is_some() {
+            return Err(self.poison_stream(
+                "cannot wait for app-server notification while a request is in flight",
+            ));
+        }
+        if let Some(notification) = self.pop_notification() {
+            return Ok(notification);
+        }
+
+        loop {
+            match self.read_next_message(pending_method).await? {
+                IncomingMessage::Notification { notification, .. } => return Ok(notification),
+                IncomingMessage::Request(request) => {
+                    self.reject_server_request(&request).await?;
+                }
+                IncomingMessage::Success { .. } | IncomingMessage::Error { .. } => {
+                    return Err(self.poison_stream(format!(
+                        "received response while waiting for {pending_method}"
+                    )));
                 }
             }
         }

--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -112,15 +112,23 @@ async fn run_codex_app_server(
     let log_file = guest_contracts::runtime_paths::create_private(paths::agent_log_file())?;
     let mut log_file = tokio::fs::File::from_std(log_file);
     let mut ingestor = CliEventIngestor::new();
-    let mut client = CodexAppServerClient::spawn(codex_app_server_config())?;
+    let mut client = CodexAppServerClient::spawn(codex_app_server_config())
+        .map_err(|error| app_server_error(masker, error))?;
     let mut heartbeat_done = false;
 
     let run_result = async {
-        race_with_heartbeat(client.initialize(), heartbeat_monitor, &mut heartbeat_done).await?;
+        race_with_heartbeat(
+            client.initialize(),
+            heartbeat_monitor,
+            &mut heartbeat_done,
+            masker,
+        )
+        .await?;
         let thread_response = race_with_heartbeat(
             start_or_resume_thread(&mut client),
             heartbeat_monitor,
             &mut heartbeat_done,
+            masker,
         )
         .await?;
         let thread_id = thread_id_from_response(&thread_response)?;
@@ -161,14 +169,19 @@ async fn run_codex_app_server(
             client.request_value("turn/start", turn_start_params(&thread_id)),
             heartbeat_monitor,
             &mut heartbeat_done,
+            masker,
         )
         .await?;
         let turn_id = turn_id_from_response(&turn_response)?;
 
         let exit_code = loop {
-            let notification =
-                next_notification_or_heartbeat(&mut client, heartbeat_monitor, &mut heartbeat_done)
-                    .await?;
+            let notification = next_notification_or_heartbeat(
+                &mut client,
+                heartbeat_monitor,
+                &mut heartbeat_done,
+                masker,
+            )
+            .await?;
             let mut sink = EventIngestSink {
                 ingestor: &mut ingestor,
                 log_file: &mut log_file,
@@ -216,10 +229,12 @@ async fn run_codex_app_server(
             Ok(result)
         }
         (Ok(_result), Err(error)) => Err(AgentError::Execution(format!(
-            "codex app-server shutdown failed: {error}"
+            "codex app-server shutdown failed: {}",
+            masker.mask_string(&error.to_string())
         ))),
         (Err(error), Ok(())) => Err(error),
         (Err(error), Err(shutdown_error)) => {
+            let shutdown_error = masker.mask_string(&shutdown_error.to_string());
             log_warn!(
                 LOG_TAG,
                 "codex app-server shutdown failed after run error: {shutdown_error}"
@@ -354,11 +369,13 @@ async fn next_notification_or_heartbeat(
     client: &mut CodexAppServerClient,
     heartbeat_monitor: &mut HeartbeatMonitor,
     heartbeat_done: &mut bool,
+    masker: &SecretMasker,
 ) -> Result<ServerNotification, AgentError> {
     race_with_heartbeat(
         client.next_notification(TURN_NOTIFICATION_LABEL),
         heartbeat_monitor,
         heartbeat_done,
+        masker,
     )
     .await
 }
@@ -367,17 +384,22 @@ async fn race_with_heartbeat<T>(
     app_server_wait: impl Future<Output = Result<T, CodexAppServerError>>,
     heartbeat_monitor: &mut HeartbeatMonitor,
     heartbeat_done: &mut bool,
+    masker: &SecretMasker,
 ) -> Result<T, AgentError> {
     // If heartbeat wins, the caller exits the run and shuts the app-server
     // down. We intentionally do not try to reuse a possibly half-read JSON-RPC
     // stream after cancelling `app_server_wait`.
     tokio::select! {
-        result = app_server_wait => Ok(result?),
+        result = app_server_wait => result.map_err(|error| app_server_error(masker, error)),
         heartbeat_result = wait_for_heartbeat(heartbeat_monitor), if !*heartbeat_done => {
             *heartbeat_done = true;
             Err(heartbeat_error(heartbeat_result))
         }
     }
+}
+
+fn app_server_error(masker: &SecretMasker, error: impl std::fmt::Display) -> AgentError {
+    AgentError::Execution(masker.mask_string(&error.to_string()))
 }
 
 async fn wait_for_heartbeat(

--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -419,11 +419,7 @@ async fn ingest_notification(
             terminal_exit_code: None,
         });
     };
-    if is_unexpected_thread_started(&event, expected_thread_id) {
-        return Err(AgentError::Execution(
-            "codex app-server reported unexpected thread id in thread.started".to_string(),
-        ));
-    }
+    validate_event_scope(&event, expected_thread_id, active_turn_id)?;
     if is_duplicate_thread_started(&event, thread_started_emitted, expected_thread_id) {
         return Ok(NotificationIngestResult {
             emitted_thread_started: false,
@@ -437,6 +433,44 @@ async fn ingest_notification(
         emitted_thread_started,
         terminal_exit_code,
     })
+}
+
+fn validate_event_scope(
+    event: &Value,
+    expected_thread_id: &str,
+    active_turn_id: &str,
+) -> Result<(), AgentError> {
+    if let Some(thread_id) = event_thread_id(event)
+        && thread_id != expected_thread_id
+    {
+        return Err(AgentError::Execution(
+            "codex app-server reported unexpected thread id in event".to_string(),
+        ));
+    }
+    if let Some(turn_id) = event_turn_id(event) {
+        if active_turn_id.is_empty() {
+            return Err(AgentError::Execution(
+                "codex app-server reported turn-scoped event before turn/start".to_string(),
+            ));
+        }
+        if turn_id != active_turn_id {
+            return Err(AgentError::Execution(
+                "codex app-server reported unexpected turn id in event".to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn event_thread_id(event: &Value) -> Option<&str> {
+    event.get("thread_id").and_then(Value::as_str)
+}
+
+fn event_turn_id(event: &Value) -> Option<&str> {
+    event
+        .get("turn_id")
+        .and_then(Value::as_str)
+        .or_else(|| event.pointer("/turn/id").and_then(Value::as_str))
 }
 
 async fn ingest_event(event: Value, sink: &mut EventIngestSink<'_>) -> Result<(), AgentError> {
@@ -469,14 +503,9 @@ fn is_duplicate_thread_started(
     thread_started_emitted && is_thread_started_event(event, expected_thread_id)
 }
 
-fn is_unexpected_thread_started(event: &Value, expected_thread_id: &str) -> bool {
-    event.get("type").and_then(Value::as_str) == Some("thread.started")
-        && event.get("thread_id").and_then(Value::as_str) != Some(expected_thread_id)
-}
-
 fn is_thread_started_event(event: &Value, expected_thread_id: &str) -> bool {
     event.get("type").and_then(Value::as_str) == Some("thread.started")
-        && event.get("thread_id").and_then(Value::as_str) == Some(expected_thread_id)
+        && event_thread_id(event) == Some(expected_thread_id)
 }
 
 fn terminal_exit_code(

--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -118,6 +118,9 @@ async fn run_codex_app_server(
     let mut log_file = tokio::fs::File::from_std(log_file);
     let mut ingestor = CliEventIngestor::new();
     let resume_thread_id = resume_thread_id_from_env()?;
+    if let Some(resume_thread_id) = &resume_thread_id {
+        masker.add_sensitive_value(resume_thread_id);
+    }
     let mut client = CodexAppServerClient::spawn(codex_app_server_config())
         .map_err(|error| app_server_error(masker, error))?;
     let mut heartbeat_done = false;

--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -23,7 +23,8 @@ use super::codex_app_server::{
 use super::event_delivery::{AckedEventPrefix, PreparedEvent};
 use super::{
     CliEventIngestor, CliExecutionResult, HeartbeatMonitor, HeartbeatStatus, LOG_TAG,
-    ParsedEventAction, command, notification_to_codex_event,
+    ParsedEventAction, codex_app_server_events::IGNORED_NOTIFICATION_METHODS, command,
+    notification_to_codex_event,
 };
 use guest_common::{log_info, log_warn};
 
@@ -267,7 +268,8 @@ fn codex_app_server_config() -> CodexAppServerConfig {
     };
     let codex_home = PathBuf::from(format!("{}/.codex", env::home_dir()));
     let mut config = CodexAppServerConfig::new(binary, codex_home)
-        .with_current_dir(paths::CANONICAL_WORKING_DIR);
+        .with_current_dir(paths::CANONICAL_WORKING_DIR)
+        .with_opt_out_notification_methods(IGNORED_NOTIFICATION_METHODS.iter().copied());
     if env::use_mock_codex()
         && let Ok(scenario) = std::env::var("MOCK_CODEX_APP_SERVER_SCENARIO")
     {

--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -132,6 +132,7 @@ async fn run_codex_app_server(
         )
         .await?;
         let thread_id = thread_id_from_response(&thread_response)?;
+        validate_resumed_thread_id(&thread_id)?;
         let mut thread_started_emitted = false;
 
         while let Some(notification) = client.pop_notification() {
@@ -573,6 +574,16 @@ fn synthesize_thread_started_event(thread_id: &str) -> Value {
 
 fn thread_id_from_response(response: &Value) -> Result<String, AgentError> {
     non_empty_string_at(response, "/thread/id", "thread response missing thread.id")
+}
+
+fn validate_resumed_thread_id(thread_id: &str) -> Result<(), AgentError> {
+    let resume_id = env::resume_session_id();
+    if !resume_id.is_empty() && thread_id != resume_id {
+        return Err(AgentError::Execution(
+            "thread/resume returned a different thread id".to_string(),
+        ));
+    }
+    Ok(())
 }
 
 fn turn_id_from_response(response: &Value) -> Result<String, AgentError> {

--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -203,7 +203,11 @@ async fn run_codex_app_server(
     }
     .await;
 
-    let shutdown_result = client.shutdown().await;
+    let shutdown_result = if run_result.is_ok() {
+        client.shutdown().await
+    } else {
+        client.terminate().await
+    };
     let stderr_lines = masker.mask_diagnostic_lines(client.stderr_tail().to_vec());
 
     match (run_result, shutdown_result) {

--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -196,16 +196,23 @@ async fn run_codex_app_server(
 
     let shutdown_result = client.shutdown().await;
     let stderr_lines = masker.mask_diagnostic_lines(client.stderr_tail().to_vec());
-    if let Err(error) = shutdown_result {
-        log_warn!(LOG_TAG, "codex app-server shutdown failed: {error}");
-    }
 
-    match run_result {
-        Ok(mut result) => {
+    match (run_result, shutdown_result) {
+        (Ok(mut result), Ok(())) => {
             result.stderr_lines = stderr_lines;
             Ok(result)
         }
-        Err(error) => Err(error),
+        (Ok(_result), Err(error)) => Err(AgentError::Execution(format!(
+            "codex app-server shutdown failed: {error}"
+        ))),
+        (Err(error), Ok(())) => Err(error),
+        (Err(error), Err(shutdown_error)) => {
+            log_warn!(
+                LOG_TAG,
+                "codex app-server shutdown failed after run error: {shutdown_error}"
+            );
+            Err(error)
+        }
     }
 }
 
@@ -259,12 +266,6 @@ fn thread_param_fields() -> Map<String, Value> {
         Value::String(paths::CANONICAL_WORKING_DIR.to_string()),
     );
     params.insert(
-        "runtimeWorkspaceRoots".to_string(),
-        Value::Array(vec![Value::String(
-            paths::CANONICAL_WORKING_DIR.to_string(),
-        )]),
-    );
-    params.insert(
         "approvalPolicy".to_string(),
         Value::String("never".to_string()),
     );
@@ -311,12 +312,6 @@ fn turn_start_params(thread_id: &str) -> Value {
     params.insert(
         "cwd".to_string(),
         Value::String(paths::CANONICAL_WORKING_DIR.to_string()),
-    );
-    params.insert(
-        "runtimeWorkspaceRoots".to_string(),
-        Value::Array(vec![Value::String(
-            paths::CANONICAL_WORKING_DIR.to_string(),
-        )]),
     );
     params.insert(
         "approvalPolicy".to_string(),
@@ -395,6 +390,11 @@ async fn ingest_notification(
             terminal_exit_code: None,
         });
     };
+    if is_unexpected_thread_started(&event, expected_thread_id) {
+        return Err(AgentError::Execution(
+            "codex app-server reported unexpected thread id in thread.started".to_string(),
+        ));
+    }
     if is_duplicate_thread_started(&event, thread_started_emitted, expected_thread_id) {
         return Ok(NotificationIngestResult {
             emitted_thread_started: false,
@@ -402,7 +402,7 @@ async fn ingest_notification(
         });
     }
     let emitted_thread_started = is_thread_started_event(&event, expected_thread_id);
-    let terminal_exit_code = terminal_exit_code(&event, active_turn_id);
+    let terminal_exit_code = terminal_exit_code(&event, expected_thread_id, active_turn_id);
     ingest_event(event, sink).await?;
     Ok(NotificationIngestResult {
         emitted_thread_started,
@@ -440,14 +440,26 @@ fn is_duplicate_thread_started(
     thread_started_emitted && is_thread_started_event(event, expected_thread_id)
 }
 
+fn is_unexpected_thread_started(event: &Value, expected_thread_id: &str) -> bool {
+    event.get("type").and_then(Value::as_str) == Some("thread.started")
+        && event.get("thread_id").and_then(Value::as_str) != Some(expected_thread_id)
+}
+
 fn is_thread_started_event(event: &Value, expected_thread_id: &str) -> bool {
     event.get("type").and_then(Value::as_str) == Some("thread.started")
         && event.get("thread_id").and_then(Value::as_str) == Some(expected_thread_id)
 }
 
-fn terminal_exit_code(event: &Value, active_turn_id: &str) -> Option<i32> {
+fn terminal_exit_code(
+    event: &Value,
+    expected_thread_id: &str,
+    active_turn_id: &str,
+) -> Option<i32> {
     match event.get("type").and_then(Value::as_str)? {
         "turn.completed" => {
+            if event.get("thread_id").and_then(Value::as_str) != Some(expected_thread_id) {
+                return None;
+            }
             let turn_id = event.pointer("/turn/id").and_then(Value::as_str)?;
             if turn_id != active_turn_id {
                 return None;
@@ -459,7 +471,8 @@ fn terminal_exit_code(event: &Value, active_turn_id: &str) -> Option<i32> {
             }
         }
         "error" => {
-            if event.get("turn_id").and_then(Value::as_str) == Some(active_turn_id)
+            if event.get("thread_id").and_then(Value::as_str) == Some(expected_thread_id)
+                && event.get("turn_id").and_then(Value::as_str) == Some(active_turn_id)
                 && event.get("will_retry").and_then(Value::as_bool) == Some(false)
             {
                 Some(1)

--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -4,6 +4,7 @@
 //! Codex execution continues to use `codex exec --json` unless the explicit
 //! guest env flag selects this backend.
 
+use std::future::Future;
 use std::path::PathBuf;
 
 use serde_json::{Map, Value, json};
@@ -115,8 +116,13 @@ async fn run_codex_app_server(
     let mut heartbeat_done = false;
 
     let run_result = async {
-        client.initialize().await?;
-        let thread_response = start_or_resume_thread(&mut client).await?;
+        race_with_heartbeat(client.initialize(), heartbeat_monitor, &mut heartbeat_done).await?;
+        let thread_response = race_with_heartbeat(
+            start_or_resume_thread(&mut client),
+            heartbeat_monitor,
+            &mut heartbeat_done,
+        )
+        .await?;
         let thread_id = thread_id_from_response(&thread_response)?;
         let mut thread_started_emitted = false;
 
@@ -151,9 +157,12 @@ async fn run_codex_app_server(
             thread_started_emitted = true;
         }
 
-        let turn_response = client
-            .request_value("turn/start", turn_start_params(&thread_id))
-            .await?;
+        let turn_response = race_with_heartbeat(
+            client.request_value("turn/start", turn_start_params(&thread_id)),
+            heartbeat_monitor,
+            &mut heartbeat_done,
+        )
+        .await?;
         let turn_id = turn_id_from_response(&turn_response)?;
 
         let exit_code = loop {
@@ -342,8 +351,24 @@ async fn next_notification_or_heartbeat(
     heartbeat_monitor: &mut HeartbeatMonitor,
     heartbeat_done: &mut bool,
 ) -> Result<ServerNotification, AgentError> {
+    race_with_heartbeat(
+        client.next_notification(TURN_NOTIFICATION_LABEL),
+        heartbeat_monitor,
+        heartbeat_done,
+    )
+    .await
+}
+
+async fn race_with_heartbeat<T>(
+    app_server_wait: impl Future<Output = Result<T, CodexAppServerError>>,
+    heartbeat_monitor: &mut HeartbeatMonitor,
+    heartbeat_done: &mut bool,
+) -> Result<T, AgentError> {
+    // If heartbeat wins, the caller exits the run and shuts the app-server
+    // down. We intentionally do not try to reuse a possibly half-read JSON-RPC
+    // stream after cancelling `app_server_wait`.
     tokio::select! {
-        result = client.next_notification(TURN_NOTIFICATION_LABEL) => Ok(result?),
+        result = app_server_wait => Ok(result?),
         heartbeat_result = wait_for_heartbeat(heartbeat_monitor), if !*heartbeat_done => {
             *heartbeat_done = true;
             Err(heartbeat_error(heartbeat_result))

--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -34,6 +34,11 @@ struct NotificationIngestResult {
     terminal_exit_code: Option<i32>,
 }
 
+struct ThreadIdentity {
+    wire_id: String,
+    canonical_id: String,
+}
+
 struct EventIngestSink<'a> {
     ingestor: &'a mut CliEventIngestor,
     log_file: &'a mut tokio::fs::File,
@@ -131,8 +136,8 @@ async fn run_codex_app_server(
             masker,
         )
         .await?;
-        let thread_id = thread_id_from_response(&thread_response)?;
-        validate_resumed_thread_id(&thread_id)?;
+        let thread_identity = thread_identity_from_response(&thread_response)?;
+        validate_resumed_thread_id(&thread_identity.canonical_id)?;
         let mut thread_started_emitted = false;
 
         while let Some(notification) = client.pop_notification() {
@@ -147,7 +152,7 @@ async fn run_codex_app_server(
                 notification,
                 &mut sink,
                 thread_started_emitted,
-                &thread_id,
+                &thread_identity.canonical_id,
                 "",
             )
             .await?;
@@ -162,12 +167,16 @@ async fn run_codex_app_server(
                 should_send_events,
                 event_tx,
             };
-            ingest_event(synthesize_thread_started_event(&thread_id), &mut sink).await?;
+            ingest_event(
+                synthesize_thread_started_event(&thread_identity.canonical_id),
+                &mut sink,
+            )
+            .await?;
             thread_started_emitted = true;
         }
 
         let turn_response = race_with_heartbeat(
-            client.request_value("turn/start", turn_start_params(&thread_id)),
+            client.request_value("turn/start", turn_start_params(&thread_identity.wire_id)),
             heartbeat_monitor,
             &mut heartbeat_done,
             masker,
@@ -194,7 +203,7 @@ async fn run_codex_app_server(
                 notification,
                 &mut sink,
                 thread_started_emitted,
-                &thread_id,
+                &thread_identity.canonical_id,
                 &turn_id,
             )
             .await?;
@@ -460,11 +469,11 @@ async fn ingest_notification(
 
 fn validate_event_scope(
     event: &Value,
-    expected_thread_id: &str,
+    expected_canonical_thread_id: &str,
     active_turn_id: &str,
 ) -> Result<(), AgentError> {
     if let Some(thread_id) = event_thread_id(event)
-        && thread_id != expected_thread_id
+        && !thread_id_matches_canonical(thread_id, expected_canonical_thread_id)
     {
         return Err(AgentError::Execution(
             "codex app-server reported unexpected thread id in event".to_string(),
@@ -521,24 +530,35 @@ async fn ingest_event(event: Value, sink: &mut EventIngestSink<'_>) -> Result<()
 fn is_duplicate_thread_started(
     event: &Value,
     thread_started_emitted: bool,
-    expected_thread_id: &str,
+    expected_canonical_thread_id: &str,
 ) -> bool {
-    thread_started_emitted && is_thread_started_event(event, expected_thread_id)
+    thread_started_emitted && is_thread_started_event(event, expected_canonical_thread_id)
 }
 
-fn is_thread_started_event(event: &Value, expected_thread_id: &str) -> bool {
+fn is_thread_started_event(event: &Value, expected_canonical_thread_id: &str) -> bool {
     event.get("type").and_then(Value::as_str) == Some("thread.started")
-        && event_thread_id(event) == Some(expected_thread_id)
+        && event
+            .get("thread_id")
+            .and_then(Value::as_str)
+            .is_some_and(|thread_id| {
+                thread_id_matches_canonical(thread_id, expected_canonical_thread_id)
+            })
 }
 
 fn terminal_exit_code(
     event: &Value,
-    expected_thread_id: &str,
+    expected_canonical_thread_id: &str,
     active_turn_id: &str,
 ) -> Option<i32> {
     match event.get("type").and_then(Value::as_str)? {
         "turn.completed" => {
-            if event.get("thread_id").and_then(Value::as_str) != Some(expected_thread_id) {
+            if !event
+                .get("thread_id")
+                .and_then(Value::as_str)
+                .is_some_and(|thread_id| {
+                    thread_id_matches_canonical(thread_id, expected_canonical_thread_id)
+                })
+            {
                 return None;
             }
             let turn_id = event.pointer("/turn/id").and_then(Value::as_str)?;
@@ -552,7 +572,12 @@ fn terminal_exit_code(
             }
         }
         "error" => {
-            if event.get("thread_id").and_then(Value::as_str) == Some(expected_thread_id)
+            if event
+                .get("thread_id")
+                .and_then(Value::as_str)
+                .is_some_and(|thread_id| {
+                    thread_id_matches_canonical(thread_id, expected_canonical_thread_id)
+                })
                 && event.get("turn_id").and_then(Value::as_str) == Some(active_turn_id)
                 && event.get("will_retry").and_then(Value::as_bool) == Some(false)
             {
@@ -572,13 +597,28 @@ fn synthesize_thread_started_event(thread_id: &str) -> Value {
     })
 }
 
-fn thread_id_from_response(response: &Value) -> Result<String, AgentError> {
-    non_empty_string_at(response, "/thread/id", "thread response missing thread.id")
+fn thread_identity_from_response(response: &Value) -> Result<ThreadIdentity, AgentError> {
+    let wire_id = non_empty_string_at(response, "/thread/id", "thread response missing thread.id")?;
+    let canonical_id = canonical_codex_thread_id(
+        &wire_id,
+        "thread response returned an invalid Codex thread id",
+    )?;
+    Ok(ThreadIdentity {
+        wire_id,
+        canonical_id,
+    })
 }
 
-fn validate_resumed_thread_id(thread_id: &str) -> Result<(), AgentError> {
+fn validate_resumed_thread_id(canonical_thread_id: &str) -> Result<(), AgentError> {
     let resume_id = env::resume_session_id();
-    if !resume_id.is_empty() && thread_id != resume_id {
+    if resume_id.is_empty() {
+        return Ok(());
+    }
+    let canonical_resume_id = canonical_codex_thread_id(
+        resume_id,
+        "VM0_RESUME_SESSION_ID is not a valid Codex thread id",
+    )?;
+    if canonical_thread_id != canonical_resume_id {
         return Err(AgentError::Execution(
             "thread/resume returned a different thread id".to_string(),
         ));
@@ -588,6 +628,16 @@ fn validate_resumed_thread_id(thread_id: &str) -> Result<(), AgentError> {
 
 fn turn_id_from_response(response: &Value) -> Result<String, AgentError> {
     non_empty_string_at(response, "/turn/id", "turn/start response missing turn.id")
+}
+
+fn thread_id_matches_canonical(thread_id: &str, expected_canonical_thread_id: &str) -> bool {
+    guest_contracts::codex_thread_id::canonical_codex_thread_id(thread_id).as_deref()
+        == Some(expected_canonical_thread_id)
+}
+
+fn canonical_codex_thread_id(thread_id: &str, message: &'static str) -> Result<String, AgentError> {
+    guest_contracts::codex_thread_id::canonical_codex_thread_id(thread_id)
+        .ok_or_else(|| AgentError::Execution(message.to_string()))
 }
 
 fn non_empty_string_at(

--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -117,6 +117,7 @@ async fn run_codex_app_server(
     let log_file = guest_contracts::runtime_paths::create_private(paths::agent_log_file())?;
     let mut log_file = tokio::fs::File::from_std(log_file);
     let mut ingestor = CliEventIngestor::new();
+    let resume_thread_id = resume_thread_id_from_env()?;
     let mut client = CodexAppServerClient::spawn(codex_app_server_config())
         .map_err(|error| app_server_error(masker, error))?;
     let mut heartbeat_done = false;
@@ -130,14 +131,14 @@ async fn run_codex_app_server(
         )
         .await?;
         let thread_response = race_with_heartbeat(
-            start_or_resume_thread(&mut client),
+            start_or_resume_thread(&mut client, resume_thread_id.as_deref()),
             heartbeat_monitor,
             &mut heartbeat_done,
             masker,
         )
         .await?;
         let thread_identity = thread_identity_from_response(&thread_response)?;
-        validate_resumed_thread_id(&thread_identity.canonical_id)?;
+        validate_resumed_thread_id(&thread_identity.canonical_id, resume_thread_id.as_deref())?;
         let mut thread_started_emitted = false;
 
         while let Some(notification) = client.pop_notification() {
@@ -280,16 +281,20 @@ fn codex_app_server_config() -> CodexAppServerConfig {
 
 async fn start_or_resume_thread(
     client: &mut CodexAppServerClient,
+    resume_thread_id: Option<&str>,
 ) -> Result<Value, CodexAppServerError> {
-    let resume_id = env::resume_session_id();
-    if resume_id.is_empty() {
-        client.request_value("thread/start", thread_params()).await
-    } else {
-        let mut params = thread_param_fields();
-        params.insert("threadId".to_string(), Value::String(resume_id.to_string()));
-        client
-            .request_value("thread/resume", Value::Object(params))
-            .await
+    match resume_thread_id {
+        Some(resume_thread_id) => {
+            let mut params = thread_param_fields();
+            params.insert(
+                "threadId".to_string(),
+                Value::String(resume_thread_id.to_string()),
+            );
+            client
+                .request_value("thread/resume", Value::Object(params))
+                .await
+        }
+        None => client.request_value("thread/start", thread_params()).await,
     }
 }
 
@@ -609,16 +614,25 @@ fn thread_identity_from_response(response: &Value) -> Result<ThreadIdentity, Age
     })
 }
 
-fn validate_resumed_thread_id(canonical_thread_id: &str) -> Result<(), AgentError> {
+fn resume_thread_id_from_env() -> Result<Option<String>, AgentError> {
     let resume_id = env::resume_session_id();
     if resume_id.is_empty() {
-        return Ok(());
+        return Ok(None);
     }
-    let canonical_resume_id = canonical_codex_thread_id(
+    canonical_codex_thread_id(
         resume_id,
         "VM0_RESUME_SESSION_ID is not a valid Codex thread id",
-    )?;
-    if canonical_thread_id != canonical_resume_id {
+    )
+    .map(Some)
+}
+
+fn validate_resumed_thread_id(
+    canonical_thread_id: &str,
+    resume_thread_id: Option<&str>,
+) -> Result<(), AgentError> {
+    if let Some(resume_thread_id) = resume_thread_id
+        && canonical_thread_id != resume_thread_id
+    {
         return Err(AgentError::Execution(
             "thread/resume returned a different thread id".to_string(),
         ));

--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -1,0 +1,500 @@
+//! Disabled Codex app-server execution backend.
+//!
+//! This module owns only the experimental app-server runtime path. Ordinary
+//! Codex execution continues to use `codex exec --json` unless the explicit
+//! guest env flag selects this backend.
+
+use std::path::PathBuf;
+
+use serde_json::{Map, Value, json};
+use tokio::sync::oneshot;
+
+use crate::env;
+use crate::error::AgentError;
+use crate::events;
+use crate::http::HttpClient;
+use crate::masker::SecretMasker;
+use crate::paths;
+
+use super::codex_app_server::{
+    CodexAppServerClient, CodexAppServerConfig, CodexAppServerError, ServerNotification,
+};
+use super::event_delivery::{AckedEventPrefix, PreparedEvent};
+use super::{
+    CliEventIngestor, CliExecutionResult, HeartbeatMonitor, HeartbeatStatus, LOG_TAG,
+    ParsedEventAction, command, notification_to_codex_event,
+};
+use guest_common::{log_info, log_warn};
+
+const TURN_NOTIFICATION_LABEL: &str = "turn notification";
+
+struct NotificationIngestResult {
+    emitted_thread_started: bool,
+    terminal_exit_code: Option<i32>,
+}
+
+struct EventIngestSink<'a> {
+    ingestor: &'a mut CliEventIngestor,
+    log_file: &'a mut tokio::fs::File,
+    masker: &'a SecretMasker,
+    should_send_events: bool,
+    event_tx: &'a tokio::sync::mpsc::UnboundedSender<PreparedEvent>,
+}
+
+pub(super) async fn execute_codex_app_server(
+    masker: &SecretMasker,
+    mut heartbeat_monitor: HeartbeatMonitor,
+    http: HttpClient,
+) -> Result<CliExecutionResult, AgentError> {
+    masker.add_sensitive_value(env::resume_session_id());
+    log_info!(LOG_TAG, "Starting codex app-server execution...");
+
+    let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel::<PreparedEvent>();
+    let should_send_events = http.has_api();
+    let event_http = http.clone();
+    let event_sender = tokio::spawn(async move {
+        let mut acked_prefix = AckedEventPrefix::default();
+        while let Some(event) = event_rx.recv().await {
+            match event {
+                PreparedEvent::Webhook { sequence, payload } => {
+                    match events::post_event(&event_http, &payload).await {
+                        Ok(()) => {
+                            acked_prefix.record_success(sequence);
+                        }
+                        Err(e) => {
+                            acked_prefix.record_failure(sequence);
+                            log_warn!(LOG_TAG, "Event send failed: {e}");
+                        }
+                    }
+                }
+            }
+        }
+        acked_prefix.last_contiguous()
+    });
+
+    let run_result = run_codex_app_server(
+        masker,
+        &mut heartbeat_monitor,
+        should_send_events,
+        &event_tx,
+    )
+    .await;
+
+    drop(event_tx);
+
+    match run_result {
+        Ok(mut result) => {
+            match event_sender.await {
+                Ok(sequence) => {
+                    result.last_event_sequence = sequence;
+                }
+                Err(error) => {
+                    log_warn!(LOG_TAG, "Event sender task failed: {error}");
+                }
+            }
+            Ok(result)
+        }
+        Err(error) => {
+            event_sender.abort();
+            let _ = event_sender.await;
+            Err(error)
+        }
+    }
+}
+
+async fn run_codex_app_server(
+    masker: &SecretMasker,
+    heartbeat_monitor: &mut HeartbeatMonitor,
+    should_send_events: bool,
+    event_tx: &tokio::sync::mpsc::UnboundedSender<PreparedEvent>,
+) -> Result<CliExecutionResult, AgentError> {
+    let log_file = guest_contracts::runtime_paths::create_private(paths::agent_log_file())?;
+    let mut log_file = tokio::fs::File::from_std(log_file);
+    let mut ingestor = CliEventIngestor::new();
+    let mut client = CodexAppServerClient::spawn(codex_app_server_config())?;
+    let mut heartbeat_done = false;
+
+    let run_result = async {
+        client.initialize().await?;
+        let thread_response = start_or_resume_thread(&mut client).await?;
+        let thread_id = thread_id_from_response(&thread_response)?;
+        let mut thread_started_emitted = false;
+
+        while let Some(notification) = client.pop_notification() {
+            let mut sink = EventIngestSink {
+                ingestor: &mut ingestor,
+                log_file: &mut log_file,
+                masker,
+                should_send_events,
+                event_tx,
+            };
+            let ingest_result = ingest_notification(
+                notification,
+                &mut sink,
+                thread_started_emitted,
+                &thread_id,
+                "",
+            )
+            .await?;
+            thread_started_emitted = thread_started_emitted || ingest_result.emitted_thread_started;
+        }
+
+        if !thread_started_emitted {
+            let mut sink = EventIngestSink {
+                ingestor: &mut ingestor,
+                log_file: &mut log_file,
+                masker,
+                should_send_events,
+                event_tx,
+            };
+            ingest_event(synthesize_thread_started_event(&thread_id), &mut sink).await?;
+            thread_started_emitted = true;
+        }
+
+        let turn_response = client
+            .request_value("turn/start", turn_start_params(&thread_id))
+            .await?;
+        let turn_id = turn_id_from_response(&turn_response)?;
+
+        let exit_code = loop {
+            let notification =
+                next_notification_or_heartbeat(&mut client, heartbeat_monitor, &mut heartbeat_done)
+                    .await?;
+            let mut sink = EventIngestSink {
+                ingestor: &mut ingestor,
+                log_file: &mut log_file,
+                masker,
+                should_send_events,
+                event_tx,
+            };
+            let ingest_result = ingest_notification(
+                notification,
+                &mut sink,
+                thread_started_emitted,
+                &thread_id,
+                &turn_id,
+            )
+            .await?;
+            thread_started_emitted = thread_started_emitted || ingest_result.emitted_thread_started;
+            if let Some(exit_code) = ingest_result.terminal_exit_code {
+                break exit_code;
+            }
+        };
+
+        Ok::<CliExecutionResult, AgentError>(CliExecutionResult {
+            exit_code,
+            stderr_lines: Vec::new(),
+            last_event_sequence: None,
+            claude_result: None,
+            post_result_cleanup_result: None,
+            failure_diagnostic: ingestor.failure_diagnostic(),
+            control_error: None,
+            cli_termination: None,
+        })
+    }
+    .await;
+
+    let shutdown_result = client.shutdown().await;
+    let stderr_lines = masker.mask_diagnostic_lines(client.stderr_tail().to_vec());
+    if let Err(error) = shutdown_result {
+        log_warn!(LOG_TAG, "codex app-server shutdown failed: {error}");
+    }
+
+    match run_result {
+        Ok(mut result) => {
+            result.stderr_lines = stderr_lines;
+            Ok(result)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn codex_app_server_config() -> CodexAppServerConfig {
+    let binary = if env::use_mock_codex() {
+        log_info!(LOG_TAG, "Using mock-codex app-server for testing");
+        PathBuf::from(env::mock_codex_path())
+    } else {
+        PathBuf::from("codex")
+    };
+    let codex_home = PathBuf::from(format!("{}/.codex", env::home_dir()));
+    let mut config = CodexAppServerConfig::new(binary, codex_home)
+        .with_current_dir(paths::CANONICAL_WORKING_DIR);
+    if env::use_mock_codex()
+        && let Ok(scenario) = std::env::var("MOCK_CODEX_APP_SERVER_SCENARIO")
+    {
+        config = config.with_env("MOCK_CODEX_APP_SERVER_SCENARIO", scenario);
+    }
+    if env::is_codex_oauth_mode() {
+        config = config.with_env(
+            "CODEX_REFRESH_TOKEN_URL_OVERRIDE",
+            crate::codex_auth::REFRESH_TOKEN_NOOP_URL,
+        );
+    }
+    config
+}
+
+async fn start_or_resume_thread(
+    client: &mut CodexAppServerClient,
+) -> Result<Value, CodexAppServerError> {
+    let resume_id = env::resume_session_id();
+    if resume_id.is_empty() {
+        client.request_value("thread/start", thread_params()).await
+    } else {
+        let mut params = thread_param_fields();
+        params.insert("threadId".to_string(), Value::String(resume_id.to_string()));
+        client
+            .request_value("thread/resume", Value::Object(params))
+            .await
+    }
+}
+
+fn thread_params() -> Value {
+    Value::Object(thread_param_fields())
+}
+
+fn thread_param_fields() -> Map<String, Value> {
+    let mut params = Map::new();
+    params.insert(
+        "cwd".to_string(),
+        Value::String(paths::CANONICAL_WORKING_DIR.to_string()),
+    );
+    params.insert(
+        "runtimeWorkspaceRoots".to_string(),
+        Value::Array(vec![Value::String(
+            paths::CANONICAL_WORKING_DIR.to_string(),
+        )]),
+    );
+    params.insert(
+        "approvalPolicy".to_string(),
+        Value::String("never".to_string()),
+    );
+    params.insert(
+        "approvalsReviewer".to_string(),
+        Value::String("user".to_string()),
+    );
+    params.insert(
+        "sandbox".to_string(),
+        Value::String("danger-full-access".to_string()),
+    );
+    params.insert(
+        "config".to_string(),
+        json!({
+            "features.memories": true,
+        }),
+    );
+    if !env::openai_model().is_empty() {
+        params.insert(
+            "model".to_string(),
+            Value::String(env::openai_model().to_string()),
+        );
+    }
+    if !env::append_system_prompt().is_empty() {
+        params.insert(
+            "developerInstructions".to_string(),
+            Value::String(env::append_system_prompt().to_string()),
+        );
+    }
+    params
+}
+
+fn turn_start_params(thread_id: &str) -> Value {
+    let mut params = Map::new();
+    params.insert("threadId".to_string(), Value::String(thread_id.to_string()));
+    params.insert(
+        "input".to_string(),
+        Value::Array(vec![json!({
+            "type": "text",
+            "text": env::prompt(),
+            "text_elements": [],
+        })]),
+    );
+    params.insert(
+        "cwd".to_string(),
+        Value::String(paths::CANONICAL_WORKING_DIR.to_string()),
+    );
+    params.insert(
+        "runtimeWorkspaceRoots".to_string(),
+        Value::Array(vec![Value::String(
+            paths::CANONICAL_WORKING_DIR.to_string(),
+        )]),
+    );
+    params.insert(
+        "approvalPolicy".to_string(),
+        Value::String("never".to_string()),
+    );
+    params.insert(
+        "approvalsReviewer".to_string(),
+        Value::String("user".to_string()),
+    );
+    params.insert(
+        "sandboxPolicy".to_string(),
+        json!({ "type": "dangerFullAccess" }),
+    );
+    if !env::openai_model().is_empty() {
+        params.insert(
+            "model".to_string(),
+            Value::String(env::openai_model().to_string()),
+        );
+    }
+    if let Some(effort) = command::default_codex_reasoning_effort_for_model(env::openai_model()) {
+        params.insert("effort".to_string(), Value::String(effort.to_string()));
+    }
+    Value::Object(params)
+}
+
+async fn next_notification_or_heartbeat(
+    client: &mut CodexAppServerClient,
+    heartbeat_monitor: &mut HeartbeatMonitor,
+    heartbeat_done: &mut bool,
+) -> Result<ServerNotification, AgentError> {
+    tokio::select! {
+        result = client.next_notification(TURN_NOTIFICATION_LABEL) => Ok(result?),
+        heartbeat_result = wait_for_heartbeat(heartbeat_monitor), if !*heartbeat_done => {
+            *heartbeat_done = true;
+            Err(heartbeat_error(heartbeat_result))
+        }
+    }
+}
+
+async fn wait_for_heartbeat(
+    heartbeat_monitor: &mut HeartbeatMonitor,
+) -> Result<HeartbeatStatus, oneshot::error::RecvError> {
+    match heartbeat_monitor.as_mut() {
+        Some(receiver) => receiver.await,
+        None => std::future::pending().await,
+    }
+}
+
+fn heartbeat_error(result: Result<HeartbeatStatus, oneshot::error::RecvError>) -> AgentError {
+    match result {
+        Ok(HeartbeatStatus::Failed(error)) => error,
+        Ok(HeartbeatStatus::Stopped) => {
+            AgentError::Execution("heartbeat stopped before codex app-server completed".to_string())
+        }
+        Ok(HeartbeatStatus::TaskFailed(message)) => {
+            AgentError::Execution(format!("heartbeat task panicked: {message}"))
+        }
+        Err(error) => AgentError::Execution(format!(
+            "heartbeat task stopped before reporting status: {error}"
+        )),
+    }
+}
+
+async fn ingest_notification(
+    notification: ServerNotification,
+    sink: &mut EventIngestSink<'_>,
+    thread_started_emitted: bool,
+    expected_thread_id: &str,
+    active_turn_id: &str,
+) -> Result<NotificationIngestResult, AgentError> {
+    let Some(event) = notification_to_codex_event(&notification)
+        .map_err(|error| AgentError::Execution(error.to_string()))?
+    else {
+        return Ok(NotificationIngestResult {
+            emitted_thread_started: false,
+            terminal_exit_code: None,
+        });
+    };
+    if is_duplicate_thread_started(&event, thread_started_emitted, expected_thread_id) {
+        return Ok(NotificationIngestResult {
+            emitted_thread_started: false,
+            terminal_exit_code: None,
+        });
+    }
+    let emitted_thread_started = is_thread_started_event(&event, expected_thread_id);
+    let terminal_exit_code = terminal_exit_code(&event, active_turn_id);
+    ingest_event(event, sink).await?;
+    Ok(NotificationIngestResult {
+        emitted_thread_started,
+        terminal_exit_code,
+    })
+}
+
+async fn ingest_event(event: Value, sink: &mut EventIngestSink<'_>) -> Result<(), AgentError> {
+    let raw_line = serde_json::to_vec(&event)?;
+    match sink
+        .ingestor
+        .begin_event(
+            sink.log_file,
+            raw_line,
+            &event,
+            sink.masker,
+            super::framework::CliFrameworkBehavior::new(env::Framework::Codex),
+        )
+        .await?
+    {
+        ParsedEventAction::Forward => {
+            sink.ingestor
+                .enqueue_event(event, sink.masker, sink.should_send_events, sink.event_tx);
+        }
+        ParsedEventAction::Skip => {}
+    }
+    Ok(())
+}
+
+fn is_duplicate_thread_started(
+    event: &Value,
+    thread_started_emitted: bool,
+    expected_thread_id: &str,
+) -> bool {
+    thread_started_emitted && is_thread_started_event(event, expected_thread_id)
+}
+
+fn is_thread_started_event(event: &Value, expected_thread_id: &str) -> bool {
+    event.get("type").and_then(Value::as_str) == Some("thread.started")
+        && event.get("thread_id").and_then(Value::as_str) == Some(expected_thread_id)
+}
+
+fn terminal_exit_code(event: &Value, active_turn_id: &str) -> Option<i32> {
+    match event.get("type").and_then(Value::as_str)? {
+        "turn.completed" => {
+            let turn_id = event.pointer("/turn/id").and_then(Value::as_str)?;
+            if turn_id != active_turn_id {
+                return None;
+            }
+            match event.pointer("/turn/status").and_then(Value::as_str) {
+                Some("completed") => Some(0),
+                Some("failed" | "interrupted") => Some(1),
+                _ => None,
+            }
+        }
+        "error" => {
+            if event.get("turn_id").and_then(Value::as_str) == Some(active_turn_id)
+                && event.get("will_retry").and_then(Value::as_bool) == Some(false)
+            {
+                Some(1)
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+fn synthesize_thread_started_event(thread_id: &str) -> Value {
+    json!({
+        "type": "thread.started",
+        "thread_id": thread_id,
+    })
+}
+
+fn thread_id_from_response(response: &Value) -> Result<String, AgentError> {
+    non_empty_string_at(response, "/thread/id", "thread response missing thread.id")
+}
+
+fn turn_id_from_response(response: &Value) -> Result<String, AgentError> {
+    non_empty_string_at(response, "/turn/id", "turn/start response missing turn.id")
+}
+
+fn non_empty_string_at(
+    value: &Value,
+    pointer: &'static str,
+    message: &'static str,
+) -> Result<String, AgentError> {
+    value
+        .pointer(pointer)
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+        .ok_or_else(|| AgentError::Execution(message.to_string()))
+}

--- a/crates/guest-agent/src/cli/codex_app_server_events.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_events.rs
@@ -4,7 +4,7 @@ use serde_json::{Map, Value, json};
 
 use super::codex_app_server::ServerNotification;
 
-const IGNORED_NOTIFICATION_METHODS: &[&str] = &[
+pub(super) const IGNORED_NOTIFICATION_METHODS: &[&str] = &[
     "command/exec/outputDelta",
     "process/outputDelta",
     "process/exited",

--- a/crates/guest-agent/src/cli/command.rs
+++ b/crates/guest-agent/src/cli/command.rs
@@ -153,7 +153,7 @@ fn build_codex_memories_config() -> String {
 /// Per-model default for the codex `model_reasoning_effort` config. GPT-5.5
 /// invests heavily in reasoning depth, so default it to `xhigh` rather than
 /// the codex CLI's stock `medium`.
-fn default_codex_reasoning_effort_for_model(model: &str) -> Option<&'static str> {
+pub(super) fn default_codex_reasoning_effort_for_model(model: &str) -> Option<&'static str> {
     let bare = model.strip_prefix("openai/").unwrap_or(model);
     match bare {
         "gpt-5.5" => Some("xhigh"),

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -18,6 +18,7 @@
 
 mod child_env;
 pub mod codex_app_server;
+mod codex_app_server_backend;
 mod codex_app_server_events;
 mod codex_setup;
 mod command;
@@ -255,6 +256,125 @@ pub enum HeartbeatStatus {
 /// callers that do not own a heartbeat task.
 pub type HeartbeatMonitor = Option<oneshot::Receiver<HeartbeatStatus>>;
 
+enum ParsedEventAction {
+    Forward,
+    Skip,
+}
+
+struct CliEventIngestor {
+    seq: u32,
+    last_read_event_at: Option<Instant>,
+    session_metadata_capture: events::SessionMetadataCapture,
+    failure_diagnostic: Option<CliFailureDiagnostic>,
+}
+
+impl CliEventIngestor {
+    fn new() -> Self {
+        Self {
+            seq: 0,
+            last_read_event_at: None,
+            session_metadata_capture: events::SessionMetadataCapture::new(),
+            failure_diagnostic: None,
+        }
+    }
+
+    async fn write_raw_line(
+        log_file: &mut tokio::fs::File,
+        raw_line: impl AsRef<[u8]>,
+    ) -> Result<(), AgentError> {
+        log_file.write_all(raw_line.as_ref()).await?;
+        log_file.write_all(b"\n").await?;
+        Ok(())
+    }
+
+    async fn begin_event(
+        &mut self,
+        log_file: &mut tokio::fs::File,
+        raw_line: impl AsRef<[u8]>,
+        event: &serde_json::Value,
+        masker: &SecretMasker,
+        behavior: CliFrameworkBehavior,
+    ) -> Result<ParsedEventAction, AgentError> {
+        Self::write_raw_line(log_file, raw_line).await?;
+
+        if event.get("type").and_then(serde_json::Value::as_str) == Some("stream_event") {
+            events::register_event_session_identifier(event, masker);
+            return Ok(ParsedEventAction::Skip);
+        }
+        self.last_read_event_at = Some(Instant::now());
+        if self.seq == 0 {
+            timing::record_e2e_from_api("api_to_cli_init");
+        }
+        self.session_metadata_capture.capture_event(event, masker);
+
+        if behavior.logs_codex_failure_diagnostics()
+            && let Some(diagnostic) = events::masked_codex_failure_diagnostic(event, masker)
+        {
+            let candidate = CliFailureDiagnostic {
+                message: diagnostic.message,
+                source: FailureDetailSource::CodexJsonl,
+                failure_reason: diagnostic.failure_reason,
+            };
+            log_warn!(
+                LOG_TAG,
+                "Codex JSONL failure event seq={} type={}: {}",
+                self.seq,
+                diagnostic.event_type,
+                candidate.message
+            );
+            if let Some(selected) =
+                select_failure_diagnostic(self.failure_diagnostic.as_ref(), candidate)
+            {
+                self.failure_diagnostic = Some(selected);
+            }
+        }
+
+        Ok(ParsedEventAction::Forward)
+    }
+
+    fn replace_failure_diagnostic(&mut self, diagnostic: CliFailureDiagnostic) {
+        self.failure_diagnostic = Some(diagnostic);
+    }
+
+    fn current_sequence(&self) -> u32 {
+        self.seq
+    }
+
+    fn enqueue_event(
+        &mut self,
+        event: serde_json::Value,
+        masker: &SecretMasker,
+        should_send_events: bool,
+        event_tx: &tokio::sync::mpsc::UnboundedSender<PreparedEvent>,
+    ) {
+        if should_send_events {
+            let payload = events::prepare_event_payload(event, self.seq, masker);
+            if event_tx
+                .send(PreparedEvent::Webhook {
+                    sequence: self.seq,
+                    payload,
+                })
+                .is_err()
+            {
+                log_warn!(
+                    LOG_TAG,
+                    "Event channel closed, dropping event seq={}",
+                    self.seq
+                );
+            }
+        }
+        self.seq += 1;
+    }
+
+    fn last_read_event_at(&self) -> Option<Instant> {
+        self.last_read_event_at
+    }
+
+    fn failure_diagnostic(&self) -> Option<CliFailureDiagnostic> {
+        self.failure_diagnostic.clone()
+    }
+}
+
 /// Execute the CLI process, streaming JSONL events and racing against heartbeat.
 pub async fn execute_cli(
     masker: &SecretMasker,
@@ -309,6 +429,16 @@ async fn execute_cli_inner(
     framework: env::Framework,
     active_input: ActiveInputWriter,
 ) -> Result<CliExecutionResult, AgentError> {
+    if matches!(framework, env::Framework::Codex) && env::use_codex_app_server_backend() {
+        if active_input.is_enabled() {
+            return Err(AgentError::Execution(
+                "codex app-server backend does not support active input".to_string(),
+            ));
+        }
+        return codex_app_server_backend::execute_codex_app_server(masker, heartbeat_monitor, http)
+            .await;
+    }
+
     let behavior = CliFrameworkBehavior::new(framework);
     let replay_user_messages = active_input.is_enabled();
     masker.add_sensitive_value(env::resume_session_id());
@@ -421,7 +551,6 @@ async fn execute_cli_inner(
     // fills, the CLI's entire event loop blocks — including TCP I/O.
     // See: https://github.com/vm0-ai/vm0/issues/3645
     let mut reader = tokio::io::BufReader::new(stdout).lines();
-    let mut seq = 0u32;
     let mut stdout_eof = false;
 
     // Capture the process group ID before wait() reaps the child, since
@@ -494,13 +623,11 @@ async fn execute_cli_inner(
     });
 
     let mut heartbeat_done = false;
-    let mut last_read_event_at: Option<Instant> = None;
     let mut cli_exit_at: Option<Instant> = None;
     let mut claude_result = None;
     let mut post_result_cleanup_result = None;
     let mut post_result_cleanup = None;
-    let mut failure_diagnostic = None;
-    let mut session_metadata_capture = events::SessionMetadataCapture::new();
+    let mut event_ingestor = CliEventIngestor::new();
     let event_result: Result<(), AgentError> = loop {
         tokio::select! {
             stdin_write_result = async {
@@ -605,25 +732,19 @@ async fn execute_cli_inner(
                             }
 
                             let post_result_cleanup_was_armed = post_result_cleanup.is_some();
-
-                            let _ = log_file.write_all(line.as_bytes()).await;
-                            let _ = log_file.write_all(b"\n").await;
-
-                            if event.get("type").and_then(serde_json::Value::as_str)
-                                == Some("stream_event")
+                            match event_ingestor
+                                .begin_event(
+                                    &mut log_file,
+                                    line.as_bytes(),
+                                    &event,
+                                    masker,
+                                    behavior,
+                                )
+                                .await?
                             {
-                                events::register_event_session_identifier(&event, masker);
-                                continue;
+                                ParsedEventAction::Forward => {}
+                                ParsedEventAction::Skip => continue,
                             }
-                            last_read_event_at = Some(Instant::now());
-                            // First event is the CLI init (system/init or thread.started)
-                            if seq == 0 {
-                                timing::record_e2e_from_api("api_to_cli_init");
-                            }
-                            // Capture checkpoint metadata and register any
-                            // event-local session identifier before logging
-                            // terminal diagnostics from the same event.
-                            session_metadata_capture.capture_event(&event, masker);
                             // Print Claude Code final result to stdout if applicable.
                             if behavior.handles_claude_result_event(&event) {
                                 let result_summary = ClaudeResultSummary::from_event(&event);
@@ -639,10 +760,11 @@ async fn execute_cli_inner(
                                     };
                                     log_warn!(
                                         LOG_TAG,
-                                        "Claude JSONL failure result seq={seq} subtype={subtype}: {}",
+                                        "Claude JSONL failure result seq={} subtype={subtype}: {}",
+                                        event_ingestor.current_sequence(),
                                         candidate.message
                                     );
-                                    failure_diagnostic = Some(candidate);
+                                    event_ingestor.replace_failure_diagnostic(candidate);
                                 }
                                 if let Some(result) = event.get("result").and_then(|v| v.as_str())
                                 {
@@ -680,28 +802,6 @@ async fn execute_cli_inner(
                             }
                             // Extract tool info BEFORE masking (masker may replace tool names).
                             behavior.track_claude_tool_events(&event, &mut stuck_tool_tracker);
-                            if behavior.logs_codex_failure_diagnostics()
-                                && let Some(diagnostic) =
-                                    events::masked_codex_failure_diagnostic(&event, masker)
-                            {
-                                let candidate = CliFailureDiagnostic {
-                                    message: diagnostic.message,
-                                    source: FailureDetailSource::CodexJsonl,
-                                    failure_reason: diagnostic.failure_reason,
-                                };
-                                log_warn!(
-                                    LOG_TAG,
-                                    "Codex JSONL failure event seq={seq} type={}: {}",
-                                    diagnostic.event_type,
-                                    candidate.message
-                                );
-                                if let Some(selected) = select_failure_diagnostic(
-                                    failure_diagnostic.as_ref(),
-                                    candidate,
-                                ) {
-                                    failure_diagnostic = Some(selected);
-                                }
-                            }
                             if post_result_cleanup_was_armed
                                 && matches!(
                                     termination_runtime.state,
@@ -721,25 +821,9 @@ async fn execute_cli_inner(
                             }
                             // Prepare event payload (mask secrets, add seq) and enqueue
                             // for background sending. Network I/O stays off the reading loop.
-                            if should_send_events {
-                                let payload = events::prepare_event_payload(event, seq, masker);
-                                if event_tx
-                                    .send(PreparedEvent::Webhook {
-                                        sequence: seq,
-                                        payload,
-                                    })
-                                    .is_err()
-                                {
-                                    log_warn!(
-                                        LOG_TAG,
-                                        "Event channel closed, dropping event seq={seq}"
-                                    );
-                                }
-                            }
-                            seq += 1;
+                            event_ingestor.enqueue_event(event, masker, should_send_events, &event_tx);
                         } else {
-                            let _ = log_file.write_all(line.as_bytes()).await;
-                            let _ = log_file.write_all(b"\n").await;
+                            CliEventIngestor::write_raw_line(&mut log_file, line.as_bytes()).await?;
                         }
                     }
                     Ok(None) => {
@@ -1080,7 +1164,9 @@ async fn execute_cli_inner(
             status
         }
     };
-    if let (Some(last_read_event_at), Some(cli_exit_at)) = (last_read_event_at, cli_exit_at) {
+    if let (Some(last_read_event_at), Some(cli_exit_at)) =
+        (event_ingestor.last_read_event_at(), cli_exit_at)
+    {
         record_sandbox_op(
             "last_read_event_to_cli_exit",
             cli_exit_at
@@ -1151,7 +1237,7 @@ async fn execute_cli_inner(
         last_event_sequence,
         claude_result,
         post_result_cleanup_result,
-        failure_diagnostic,
+        failure_diagnostic: event_ingestor.failure_diagnostic(),
         control_error,
         cli_termination,
     })

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -278,13 +278,9 @@ impl CliEventIngestor {
         }
     }
 
-    async fn write_raw_line(
-        log_file: &mut tokio::fs::File,
-        raw_line: impl AsRef<[u8]>,
-    ) -> Result<(), AgentError> {
-        log_file.write_all(raw_line.as_ref()).await?;
-        log_file.write_all(b"\n").await?;
-        Ok(())
+    async fn write_raw_line(log_file: &mut tokio::fs::File, raw_line: impl AsRef<[u8]>) {
+        let _ = log_file.write_all(raw_line.as_ref()).await;
+        let _ = log_file.write_all(b"\n").await;
     }
 
     async fn begin_event(
@@ -295,7 +291,7 @@ impl CliEventIngestor {
         masker: &SecretMasker,
         behavior: CliFrameworkBehavior,
     ) -> Result<ParsedEventAction, AgentError> {
-        Self::write_raw_line(log_file, raw_line).await?;
+        Self::write_raw_line(log_file, raw_line).await;
 
         if event.get("type").and_then(serde_json::Value::as_str) == Some("stream_event") {
             events::register_event_session_identifier(event, masker);
@@ -823,7 +819,7 @@ async fn execute_cli_inner(
                             // for background sending. Network I/O stays off the reading loop.
                             event_ingestor.enqueue_event(event, masker, should_send_events, &event_tx);
                         } else {
-                            CliEventIngestor::write_raw_line(&mut log_file, line.as_bytes()).await?;
+                            CliEventIngestor::write_raw_line(&mut log_file, line.as_bytes()).await;
                         }
                     }
                     Ok(None) => {

--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -124,6 +124,11 @@ static USE_MOCK_CODEX: LazyLock<bool> = LazyLock::new(|| {
         .map(|v| v == "true" || v == "1")
         .unwrap_or(false)
 });
+static USE_CODEX_APP_SERVER_BACKEND: LazyLock<bool> = LazyLock::new(|| {
+    std::env::var(guest_contracts::env::CODEX_APP_SERVER_BACKEND_ENV)
+        .map(|v| v == "true" || v == "1")
+        .unwrap_or(false)
+});
 
 /// Production install location for the mock-codex binary, mirroring
 /// `DEFAULT_MOCK_CLAUDE_PATH`.
@@ -535,6 +540,10 @@ pub fn is_codex_oauth_mode() -> bool {
 /// false.
 pub fn use_mock_codex() -> bool {
     *USE_MOCK_CODEX
+}
+/// Whether the disabled Codex app-server backend is explicitly enabled.
+pub fn use_codex_app_server_backend() -> bool {
+    *USE_CODEX_APP_SERVER_BACKEND
 }
 /// Mock Codex binary path from `VM0_MOCK_CODEX_PATH`, or
 /// `DEFAULT_MOCK_CODEX_PATH` when unset.

--- a/crates/guest-agent/tests/codex_app_server_backend.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend.rs
@@ -1,0 +1,164 @@
+//! Integration coverage for the disabled Codex app-server backend.
+//!
+//! This test lives in its own binary because `guest_agent::env` caches values
+//! in process-wide `LazyLock`s.
+
+mod common;
+
+use guest_agent::http::HttpClient;
+use guest_agent::masker::SecretMasker;
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+#[tokio::test]
+async fn codex_app_server_backend_runs_initial_turn_and_synthesizes_thread_started()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock = build_and_locate_mock_codex()?;
+    let tmp = tempfile::tempdir()?;
+
+    unsafe {
+        setup_codex_app_server_env(
+            &mock,
+            tmp.path(),
+            "codex-app-server-backend-test",
+            "runtime-turn-complete-without-thread-started",
+            None,
+        )?;
+    }
+    let _run_files = common::RunFilesGuard::new();
+
+    let masker = SecretMasker::from_raw("");
+    let cli_result = tokio::time::timeout(
+        Duration::from_secs(5),
+        guest_agent::cli::execute_cli(
+            &masker,
+            common::spawn_dummy_heartbeat(),
+            HttpClient::for_current_env()?,
+        ),
+    )
+    .await
+    .expect("execute_cli should return promptly")?;
+
+    assert_eq!(cli_result.exit_code, common::CLEAN_EXIT);
+    assert!(cli_result.failure_diagnostic.is_none());
+    assert!(cli_result.last_event_sequence.is_none());
+
+    let events = read_agent_log_events()?;
+    assert_event_type_sequence(
+        &events,
+        &[
+            "thread.started",
+            "turn.started",
+            "item.completed",
+            "turn.completed",
+        ],
+    );
+
+    let thread_id = events[0]
+        .get("thread_id")
+        .and_then(Value::as_str)
+        .ok_or("thread.started missing thread_id")?;
+    let stored_id = std::fs::read_to_string(guest_agent::paths::session_id_file())?;
+    assert_eq!(stored_id, thread_id);
+    let marker = std::fs::read_to_string(guest_agent::paths::session_history_path_file())?;
+    assert!(marker.starts_with("CODEX_SEARCH:"));
+    assert!(marker.ends_with(&format!(":{thread_id}")));
+    assert_eq!(masker.mask_string(thread_id), "***");
+
+    Ok(())
+}
+
+fn read_agent_log_events() -> Result<Vec<Value>, Box<dyn std::error::Error>> {
+    let log = std::fs::read_to_string(guest_agent::paths::agent_log_file())?;
+    log.lines()
+        .map(|line| serde_json::from_str(line).map_err(Into::into))
+        .collect()
+}
+
+fn assert_event_type_sequence(events: &[Value], expected: &[&str]) {
+    let actual = events
+        .iter()
+        .map(|event| event.get("type").and_then(Value::as_str))
+        .collect::<Vec<_>>();
+    let expected = expected
+        .iter()
+        .map(|value| Some(*value))
+        .collect::<Vec<_>>();
+    assert_eq!(actual, expected);
+}
+
+unsafe fn setup_codex_app_server_env(
+    mock_path: &Path,
+    home: &Path,
+    run_id: &str,
+    scenario: &str,
+    resume_session_id: Option<&str>,
+) -> Result<(), String> {
+    unsafe {
+        std::env::set_var("CLI_AGENT_TYPE", "codex");
+        std::env::set_var("VM0_CODEX_APP_SERVER_BACKEND", "1");
+        std::env::set_var("VM0_MOCK_CODEX_PATH", mock_path);
+        std::env::set_var("USE_MOCK_CODEX", "true");
+        std::env::remove_var("MOCK_CODEX_FIXTURE");
+        std::env::set_var("MOCK_CODEX_APP_SERVER_SCENARIO", scenario);
+        std::env::set_var("VM0_RUN_ID", run_id);
+        std::env::set_var("VM0_PROMPT", "drive the app-server backend");
+        std::env::set_var("VM0_API_URL", "http://127.0.0.1:1");
+        std::env::set_var("VM0_API_TOKEN", "");
+        std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");
+        std::env::set_var("VM0_SANDBOX_REUSE_RESULT", "reused");
+        std::env::set_var("HOME", home);
+        if let Some(resume_session_id) = resume_session_id {
+            std::env::set_var("VM0_RESUME_SESSION_ID", resume_session_id);
+        } else {
+            std::env::remove_var("VM0_RESUME_SESSION_ID");
+        }
+    }
+    std::fs::create_dir_all(home).map_err(|error| format!("create home: {error}"))?;
+    common::ensure_canonical_workspace_for_test()?;
+    std::env::set_current_dir(home).map_err(|error| format!("set_current_dir: {error}"))?;
+    Ok(())
+}
+
+fn build_and_locate_mock_codex() -> Result<PathBuf, String> {
+    let exe = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
+    let target_profile_dir = exe
+        .parent()
+        .and_then(|p| p.parent())
+        .ok_or_else(|| "target/<profile> dir".to_string())?;
+    let target_dir = target_profile_dir
+        .parent()
+        .ok_or_else(|| "target dir".to_string())?;
+    let profile_dir_name = target_profile_dir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| "profile dir name".to_string())?;
+
+    let mut cmd = std::process::Command::new("cargo");
+    cmd.args(["build", "-p", "guest-mock-codex", "--quiet"])
+        .arg("--target-dir")
+        .arg(target_dir);
+    match profile_dir_name {
+        "debug" => {}
+        "release" => {
+            cmd.arg("--release");
+        }
+        other => {
+            cmd.args(["--profile", other]);
+        }
+    }
+
+    let status = cmd
+        .status()
+        .map_err(|e| format!("invoke cargo build: {e}"))?;
+    if !status.success() {
+        return Err("cargo build -p guest-mock-codex failed".into());
+    }
+
+    let mock = target_profile_dir.join("guest-mock-codex");
+    if !mock.exists() {
+        return Err(format!("mock binary not found at {}", mock.display()));
+    }
+    Ok(mock)
+}

--- a/crates/guest-agent/tests/codex_app_server_backend.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend.rs
@@ -66,12 +66,63 @@ async fn codex_app_server_backend_runs_initial_turn_and_synthesizes_thread_start
     assert!(marker.ends_with(&format!(":{thread_id}")));
     assert_eq!(masker.mask_string(thread_id), "***");
 
+    let session_events = read_codex_session_history_events()?;
+    let input_event = session_events
+        .iter()
+        .find(|event| event.get("type").and_then(Value::as_str) == Some("mock.app_server.input"))
+        .ok_or("missing mock app-server input event")?;
+    assert_eq!(
+        input_event
+            .get("thread_request_has_runtime_workspace_roots")
+            .and_then(Value::as_bool),
+        Some(false)
+    );
+    assert_eq!(
+        input_event
+            .get("turn_request_has_runtime_workspace_roots")
+            .and_then(Value::as_bool),
+        Some(false)
+    );
+    assert_eq!(
+        input_event.get("turn_request_cwd").and_then(Value::as_str),
+        Some(guest_agent::paths::CANONICAL_WORKING_DIR)
+    );
+    assert_eq!(
+        input_event
+            .get("turn_request_approval_policy")
+            .and_then(Value::as_str),
+        Some("never")
+    );
+    assert_eq!(
+        input_event
+            .get("turn_request_approvals_reviewer")
+            .and_then(Value::as_str),
+        Some("user")
+    );
+    assert_eq!(
+        input_event
+            .pointer("/turn_request_sandbox_policy/type")
+            .and_then(Value::as_str),
+        Some("dangerFullAccess")
+    );
+
     Ok(())
 }
 
 fn read_agent_log_events() -> Result<Vec<Value>, Box<dyn std::error::Error>> {
     let log = std::fs::read_to_string(guest_agent::paths::agent_log_file())?;
     log.lines()
+        .map(|line| serde_json::from_str(line).map_err(Into::into))
+        .collect()
+}
+
+fn read_codex_session_history_events() -> Result<Vec<Value>, Box<dyn std::error::Error>> {
+    let history = guest_agent::session_history::read_session_history(
+        guest_agent::paths::session_history_path_file(),
+    )?;
+    let history = String::from_utf8(history)?;
+    history
+        .lines()
         .map(|line| serde_json::from_str(line).map_err(Into::into))
         .collect()
 }

--- a/crates/guest-agent/tests/codex_app_server_backend_error_masking.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_error_masking.rs
@@ -15,7 +15,8 @@ async fn codex_app_server_backend_masks_resume_id_in_rpc_errors()
 -> Result<(), Box<dyn std::error::Error>> {
     let mock = build_and_locate_mock_codex()?;
     let tmp = tempfile::tempdir()?;
-    let resume_thread_id = "0193abcd-ef01-7234-89ab-cdef01234567";
+    let resume_thread_id = "0193ABCDEF01723489ABCDEF01234567";
+    let canonical_resume_thread_id = "0193abcd-ef01-7234-89ab-cdef01234567";
 
     unsafe {
         setup_codex_app_server_env(&mock, tmp.path(), resume_thread_id)?;
@@ -42,7 +43,11 @@ async fn codex_app_server_backend_masks_resume_id_in_rpc_errors()
     );
     assert!(
         !message.contains(resume_thread_id),
-        "resume id leaked in app-server RPC error: {message}"
+        "raw resume id leaked in app-server RPC error: {message}"
+    );
+    assert!(
+        !message.contains(canonical_resume_thread_id),
+        "canonical resume id leaked in app-server RPC error: {message}"
     );
 
     Ok(())

--- a/crates/guest-agent/tests/codex_app_server_backend_error_masking.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_error_masking.rs
@@ -1,0 +1,124 @@
+//! Error masking coverage for the disabled Codex app-server backend.
+//!
+//! This test lives in its own binary because `guest_agent::env` caches values
+//! in process-wide `LazyLock`s.
+
+mod common;
+
+use guest_agent::http::HttpClient;
+use guest_agent::masker::SecretMasker;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+#[tokio::test]
+async fn codex_app_server_backend_masks_resume_id_in_rpc_errors()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock = build_and_locate_mock_codex()?;
+    let tmp = tempfile::tempdir()?;
+    let resume_thread_id = "0193abcd-ef01-7234-89ab-cdef01234567";
+
+    unsafe {
+        setup_codex_app_server_env(&mock, tmp.path(), resume_thread_id)?;
+    }
+    let _run_files = common::RunFilesGuard::new();
+
+    let masker = SecretMasker::from_raw("");
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        guest_agent::cli::execute_cli(
+            &masker,
+            common::spawn_dummy_heartbeat(),
+            HttpClient::for_current_env()?,
+        ),
+    )
+    .await
+    .expect("execute_cli should return promptly");
+
+    let error = result.expect_err("resume RPC error should fail the app-server backend");
+    let message = error.to_string();
+    assert!(
+        message.contains("resume failed for ***"),
+        "unexpected masked error: {message}"
+    );
+    assert!(
+        !message.contains(resume_thread_id),
+        "resume id leaked in app-server RPC error: {message}"
+    );
+
+    Ok(())
+}
+
+unsafe fn setup_codex_app_server_env(
+    mock_path: &Path,
+    home: &Path,
+    resume_thread_id: &str,
+) -> Result<(), String> {
+    unsafe {
+        std::env::set_var("CLI_AGENT_TYPE", "codex");
+        std::env::set_var("VM0_CODEX_APP_SERVER_BACKEND", "1");
+        std::env::set_var("VM0_MOCK_CODEX_PATH", mock_path);
+        std::env::set_var("USE_MOCK_CODEX", "true");
+        std::env::remove_var("MOCK_CODEX_FIXTURE");
+        std::env::set_var(
+            "MOCK_CODEX_APP_SERVER_SCENARIO",
+            "resume-rpc-error-with-thread-id",
+        );
+        std::env::set_var("VM0_RESUME_SESSION_ID", resume_thread_id);
+        std::env::set_var("VM0_RUN_ID", "codex-app-server-backend-error-masking-test");
+        std::env::set_var(
+            "VM0_PROMPT",
+            "drive the app-server backend error masking path",
+        );
+        std::env::set_var("VM0_API_URL", "http://127.0.0.1:1");
+        std::env::set_var("VM0_API_TOKEN", "");
+        std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");
+        std::env::set_var("VM0_SANDBOX_REUSE_RESULT", "reused");
+        std::env::set_var("HOME", home);
+    }
+    std::fs::create_dir_all(home).map_err(|error| format!("create home: {error}"))?;
+    common::ensure_canonical_workspace_for_test()?;
+    std::env::set_current_dir(home).map_err(|error| format!("set_current_dir: {error}"))?;
+    Ok(())
+}
+
+fn build_and_locate_mock_codex() -> Result<PathBuf, String> {
+    let exe = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
+    let target_profile_dir = exe
+        .parent()
+        .and_then(|p| p.parent())
+        .ok_or_else(|| "target/<profile> dir".to_string())?;
+    let target_dir = target_profile_dir
+        .parent()
+        .ok_or_else(|| "target dir".to_string())?;
+    let profile_dir_name = target_profile_dir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| "profile dir name".to_string())?;
+
+    let mut cmd = std::process::Command::new("cargo");
+    cmd.args(["build", "-p", "guest-mock-codex", "--quiet"])
+        .arg("--target-dir")
+        .arg(target_dir);
+    match profile_dir_name {
+        "debug" => {}
+        "release" => {
+            cmd.arg("--release");
+        }
+        other => {
+            cmd.args(["--profile", other]);
+        }
+    }
+
+    let status = cmd
+        .status()
+        .map_err(|e| format!("invoke cargo build: {e}"))?;
+    if !status.success() {
+        return Err("cargo build -p guest-mock-codex failed".into());
+    }
+
+    let mock = target_profile_dir.join("guest-mock-codex");
+    if !mock.exists() {
+        return Err(format!("mock binary not found at {}", mock.display()));
+    }
+    Ok(mock)
+}

--- a/crates/guest-agent/tests/codex_app_server_backend_failure.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_failure.rs
@@ -1,0 +1,110 @@
+//! Failure-path integration coverage for the disabled Codex app-server backend.
+//!
+//! This test lives in its own binary because `guest_agent::env` caches values
+//! in process-wide `LazyLock`s.
+
+mod common;
+
+use guest_agent::http::HttpClient;
+use guest_agent::masker::SecretMasker;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+#[tokio::test]
+async fn codex_app_server_backend_child_exit_before_turn_response_fails_promptly()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock = build_and_locate_mock_codex()?;
+    let tmp = tempfile::tempdir()?;
+
+    unsafe {
+        setup_codex_app_server_env(&mock, tmp.path())?;
+    }
+    let _run_files = common::RunFilesGuard::new();
+
+    let masker = SecretMasker::from_raw("");
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        guest_agent::cli::execute_cli(
+            &masker,
+            common::spawn_dummy_heartbeat(),
+            HttpClient::for_current_env()?,
+        ),
+    )
+    .await
+    .expect("execute_cli should return promptly");
+
+    let error = result.expect_err("child exit should fail the app-server backend");
+    let message = error.to_string();
+    assert!(
+        message.contains("codex app-server child exited while waiting for turn/start")
+            || message.contains("codex app-server disconnected while waiting for turn/start"),
+        "unexpected error: {message}"
+    );
+
+    Ok(())
+}
+
+unsafe fn setup_codex_app_server_env(mock_path: &Path, home: &Path) -> Result<(), String> {
+    unsafe {
+        std::env::set_var("CLI_AGENT_TYPE", "codex");
+        std::env::set_var("VM0_CODEX_APP_SERVER_BACKEND", "1");
+        std::env::set_var("VM0_MOCK_CODEX_PATH", mock_path);
+        std::env::set_var("USE_MOCK_CODEX", "true");
+        std::env::remove_var("MOCK_CODEX_FIXTURE");
+        std::env::set_var("MOCK_CODEX_APP_SERVER_SCENARIO", "exit-on-turn-start");
+        std::env::set_var("VM0_RUN_ID", "codex-app-server-backend-failure-test");
+        std::env::set_var("VM0_PROMPT", "drive the app-server backend failure path");
+        std::env::set_var("VM0_API_URL", "http://127.0.0.1:1");
+        std::env::set_var("VM0_API_TOKEN", "");
+        std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");
+        std::env::set_var("VM0_SANDBOX_REUSE_RESULT", "reused");
+        std::env::set_var("HOME", home);
+        std::env::remove_var("VM0_RESUME_SESSION_ID");
+    }
+    std::fs::create_dir_all(home).map_err(|error| format!("create home: {error}"))?;
+    common::ensure_canonical_workspace_for_test()?;
+    std::env::set_current_dir(home).map_err(|error| format!("set_current_dir: {error}"))?;
+    Ok(())
+}
+
+fn build_and_locate_mock_codex() -> Result<PathBuf, String> {
+    let exe = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
+    let target_profile_dir = exe
+        .parent()
+        .and_then(|p| p.parent())
+        .ok_or_else(|| "target/<profile> dir".to_string())?;
+    let target_dir = target_profile_dir
+        .parent()
+        .ok_or_else(|| "target dir".to_string())?;
+    let profile_dir_name = target_profile_dir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| "profile dir name".to_string())?;
+
+    let mut cmd = std::process::Command::new("cargo");
+    cmd.args(["build", "-p", "guest-mock-codex", "--quiet"])
+        .arg("--target-dir")
+        .arg(target_dir);
+    match profile_dir_name {
+        "debug" => {}
+        "release" => {
+            cmd.arg("--release");
+        }
+        other => {
+            cmd.args(["--profile", other]);
+        }
+    }
+
+    let status = cmd
+        .status()
+        .map_err(|e| format!("invoke cargo build: {e}"))?;
+    if !status.success() {
+        return Err("cargo build -p guest-mock-codex failed".into());
+    }
+
+    let mock = target_profile_dir.join("guest-mock-codex");
+    if !mock.exists() {
+        return Err(format!("mock binary not found at {}", mock.display()));
+    }
+    Ok(mock)
+}

--- a/crates/guest-agent/tests/codex_app_server_backend_heartbeat.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_heartbeat.rs
@@ -38,7 +38,7 @@ async fn codex_app_server_backend_heartbeat_interrupts_hung_turn_start()
 
     let masker = SecretMasker::from_raw("");
     let result = tokio::time::timeout(
-        Duration::from_secs(5),
+        Duration::from_millis(1500),
         guest_agent::cli::execute_cli(&masker, heartbeat, HttpClient::for_current_env()?),
     )
     .await

--- a/crates/guest-agent/tests/codex_app_server_backend_heartbeat.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_heartbeat.rs
@@ -1,0 +1,120 @@
+//! Heartbeat race coverage for the disabled Codex app-server backend.
+//!
+//! This test lives in its own binary because `guest_agent::env` caches values
+//! in process-wide `LazyLock`s.
+
+mod common;
+
+use guest_agent::error::AgentError;
+use guest_agent::http::HttpClient;
+use guest_agent::masker::SecretMasker;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+#[tokio::test]
+async fn codex_app_server_backend_heartbeat_interrupts_hung_turn_start()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock = build_and_locate_mock_codex()?;
+    let tmp = tempfile::tempdir()?;
+
+    unsafe {
+        setup_codex_app_server_env(&mock, tmp.path())?;
+    }
+    let _run_files = common::RunFilesGuard::new();
+    let session_id_path = PathBuf::from(guest_agent::paths::session_id_file());
+    if let Some(parent) = session_id_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let heartbeat = common::spawn_heartbeat_monitor(async move {
+        common::wait_for_path(&session_id_path, Duration::from_secs(5))
+            .await
+            .map_err(|error| {
+                AgentError::Execution(format!("wait for app-server thread start: {error}"))
+            })?;
+        Err(AgentError::Execution(
+            "heartbeat failed during app-server turn/start".to_string(),
+        ))
+    });
+
+    let masker = SecretMasker::from_raw("");
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        guest_agent::cli::execute_cli(&masker, heartbeat, HttpClient::for_current_env()?),
+    )
+    .await
+    .expect("execute_cli should return promptly");
+
+    let error = result.expect_err("heartbeat failure should fail the app-server backend");
+    let message = error.to_string();
+    assert!(
+        message.contains("heartbeat failed during app-server turn/start"),
+        "unexpected error: {message}"
+    );
+
+    Ok(())
+}
+
+unsafe fn setup_codex_app_server_env(mock_path: &Path, home: &Path) -> Result<(), String> {
+    unsafe {
+        std::env::set_var("CLI_AGENT_TYPE", "codex");
+        std::env::set_var("VM0_CODEX_APP_SERVER_BACKEND", "1");
+        std::env::set_var("VM0_MOCK_CODEX_PATH", mock_path);
+        std::env::set_var("USE_MOCK_CODEX", "true");
+        std::env::remove_var("MOCK_CODEX_FIXTURE");
+        std::env::set_var("MOCK_CODEX_APP_SERVER_SCENARIO", "hang-on-turn-start");
+        std::env::set_var("VM0_RUN_ID", "codex-app-server-backend-heartbeat-test");
+        std::env::set_var("VM0_PROMPT", "drive the app-server backend heartbeat path");
+        std::env::set_var("VM0_API_URL", "http://127.0.0.1:1");
+        std::env::set_var("VM0_API_TOKEN", "");
+        std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");
+        std::env::set_var("VM0_SANDBOX_REUSE_RESULT", "reused");
+        std::env::set_var("HOME", home);
+        std::env::remove_var("VM0_RESUME_SESSION_ID");
+    }
+    std::fs::create_dir_all(home).map_err(|error| format!("create home: {error}"))?;
+    common::ensure_canonical_workspace_for_test()?;
+    std::env::set_current_dir(home).map_err(|error| format!("set_current_dir: {error}"))?;
+    Ok(())
+}
+
+fn build_and_locate_mock_codex() -> Result<PathBuf, String> {
+    let exe = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
+    let target_profile_dir = exe
+        .parent()
+        .and_then(|p| p.parent())
+        .ok_or_else(|| "target/<profile> dir".to_string())?;
+    let target_dir = target_profile_dir
+        .parent()
+        .ok_or_else(|| "target dir".to_string())?;
+    let profile_dir_name = target_profile_dir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| "profile dir name".to_string())?;
+
+    let mut cmd = std::process::Command::new("cargo");
+    cmd.args(["build", "-p", "guest-mock-codex", "--quiet"])
+        .arg("--target-dir")
+        .arg(target_dir);
+    match profile_dir_name {
+        "debug" => {}
+        "release" => {
+            cmd.arg("--release");
+        }
+        other => {
+            cmd.args(["--profile", other]);
+        }
+    }
+
+    let status = cmd
+        .status()
+        .map_err(|e| format!("invoke cargo build: {e}"))?;
+    if !status.success() {
+        return Err("cargo build -p guest-mock-codex failed".into());
+    }
+
+    let mock = target_profile_dir.join("guest-mock-codex");
+    if !mock.exists() {
+        return Err(format!("mock binary not found at {}", mock.display()));
+    }
+    Ok(mock)
+}

--- a/crates/guest-agent/tests/codex_app_server_backend_invalid_resume_id.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_invalid_resume_id.rs
@@ -1,0 +1,82 @@
+//! Resume id validation for the disabled Codex app-server backend.
+//!
+//! This test lives in its own binary because `guest_agent::env` caches values
+//! in process-wide `LazyLock`s.
+
+mod common;
+
+use guest_agent::http::HttpClient;
+use guest_agent::masker::SecretMasker;
+use std::path::Path;
+use std::time::Duration;
+
+#[tokio::test]
+async fn codex_app_server_backend_rejects_invalid_resume_id_before_spawn()
+-> Result<(), Box<dyn std::error::Error>> {
+    let tmp = tempfile::tempdir()?;
+    let missing_mock = tmp.path().join("missing-mock-codex");
+
+    unsafe {
+        setup_codex_app_server_env(&missing_mock, tmp.path())?;
+    }
+    let _run_files = common::RunFilesGuard::new();
+
+    let masker = SecretMasker::from_raw("");
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        guest_agent::cli::execute_cli(
+            &masker,
+            common::spawn_dummy_heartbeat(),
+            HttpClient::for_current_env()?,
+        ),
+    )
+    .await
+    .expect("execute_cli should return promptly");
+
+    let error = result.expect_err("invalid resume id should fail the app-server backend");
+    let message = error.to_string();
+    assert!(
+        message.contains("VM0_RESUME_SESSION_ID is not a valid Codex thread id"),
+        "unexpected error: {message}"
+    );
+    assert!(
+        !message.contains("failed to spawn codex app-server"),
+        "invalid resume id should fail before app-server spawn: {message}"
+    );
+    let session_id_path = guest_agent::paths::session_id_file();
+    assert!(
+        !std::path::Path::new(session_id_path).exists(),
+        "invalid resume id should not write a session id"
+    );
+
+    Ok(())
+}
+
+unsafe fn setup_codex_app_server_env(mock_path: &Path, home: &Path) -> Result<(), String> {
+    unsafe {
+        std::env::set_var("CLI_AGENT_TYPE", "codex");
+        std::env::set_var("VM0_CODEX_APP_SERVER_BACKEND", "1");
+        std::env::set_var("VM0_MOCK_CODEX_PATH", mock_path);
+        std::env::set_var("USE_MOCK_CODEX", "true");
+        std::env::remove_var("MOCK_CODEX_FIXTURE");
+        std::env::remove_var("MOCK_CODEX_APP_SERVER_SCENARIO");
+        std::env::set_var("VM0_RESUME_SESSION_ID", "not-a-valid-codex-thread-id");
+        std::env::set_var(
+            "VM0_RUN_ID",
+            "codex-app-server-backend-invalid-resume-id-test",
+        );
+        std::env::set_var(
+            "VM0_PROMPT",
+            "drive the app-server backend invalid resume id path",
+        );
+        std::env::set_var("VM0_API_URL", "http://127.0.0.1:1");
+        std::env::set_var("VM0_API_TOKEN", "");
+        std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");
+        std::env::set_var("VM0_SANDBOX_REUSE_RESULT", "reused");
+        std::env::set_var("HOME", home);
+    }
+    std::fs::create_dir_all(home).map_err(|error| format!("create home: {error}"))?;
+    common::ensure_canonical_workspace_for_test()?;
+    std::env::set_current_dir(home).map_err(|error| format!("set_current_dir: {error}"))?;
+    Ok(())
+}

--- a/crates/guest-agent/tests/codex_app_server_backend_invalid_thread_id.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_invalid_thread_id.rs
@@ -1,0 +1,123 @@
+//! Thread identity validation for the disabled Codex app-server backend.
+//!
+//! This test lives in its own binary because `guest_agent::env` caches values
+//! in process-wide `LazyLock`s.
+
+mod common;
+
+use guest_agent::http::HttpClient;
+use guest_agent::masker::SecretMasker;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+#[tokio::test]
+async fn codex_app_server_backend_rejects_invalid_thread_start_id()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock = build_and_locate_mock_codex()?;
+    let tmp = tempfile::tempdir()?;
+
+    unsafe {
+        setup_codex_app_server_env(&mock, tmp.path())?;
+    }
+    let _run_files = common::RunFilesGuard::new();
+
+    let masker = SecretMasker::from_raw("");
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        guest_agent::cli::execute_cli(
+            &masker,
+            common::spawn_dummy_heartbeat(),
+            HttpClient::for_current_env()?,
+        ),
+    )
+    .await
+    .expect("execute_cli should return promptly");
+
+    let error = result.expect_err("invalid thread id should fail the app-server backend");
+    let message = error.to_string();
+    assert!(
+        message.contains("thread response returned an invalid Codex thread id"),
+        "unexpected error: {message}"
+    );
+    let session_id_path = guest_agent::paths::session_id_file();
+    assert!(
+        !std::path::Path::new(session_id_path).exists(),
+        "invalid thread response should not write a session id"
+    );
+
+    Ok(())
+}
+
+unsafe fn setup_codex_app_server_env(mock_path: &Path, home: &Path) -> Result<(), String> {
+    unsafe {
+        std::env::set_var("CLI_AGENT_TYPE", "codex");
+        std::env::set_var("VM0_CODEX_APP_SERVER_BACKEND", "1");
+        std::env::set_var("VM0_MOCK_CODEX_PATH", mock_path);
+        std::env::set_var("USE_MOCK_CODEX", "true");
+        std::env::remove_var("MOCK_CODEX_FIXTURE");
+        std::env::set_var(
+            "MOCK_CODEX_APP_SERVER_SCENARIO",
+            "thread-start-invalid-thread-id",
+        );
+        std::env::remove_var("VM0_RESUME_SESSION_ID");
+        std::env::set_var(
+            "VM0_RUN_ID",
+            "codex-app-server-backend-invalid-thread-id-test",
+        );
+        std::env::set_var(
+            "VM0_PROMPT",
+            "drive the app-server backend invalid thread id path",
+        );
+        std::env::set_var("VM0_API_URL", "http://127.0.0.1:1");
+        std::env::set_var("VM0_API_TOKEN", "");
+        std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");
+        std::env::set_var("VM0_SANDBOX_REUSE_RESULT", "reused");
+        std::env::set_var("HOME", home);
+    }
+    std::fs::create_dir_all(home).map_err(|error| format!("create home: {error}"))?;
+    common::ensure_canonical_workspace_for_test()?;
+    std::env::set_current_dir(home).map_err(|error| format!("set_current_dir: {error}"))?;
+    Ok(())
+}
+
+fn build_and_locate_mock_codex() -> Result<PathBuf, String> {
+    let exe = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
+    let target_profile_dir = exe
+        .parent()
+        .and_then(|p| p.parent())
+        .ok_or_else(|| "target/<profile> dir".to_string())?;
+    let target_dir = target_profile_dir
+        .parent()
+        .ok_or_else(|| "target dir".to_string())?;
+    let profile_dir_name = target_profile_dir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| "profile dir name".to_string())?;
+
+    let mut cmd = std::process::Command::new("cargo");
+    cmd.args(["build", "-p", "guest-mock-codex", "--quiet"])
+        .arg("--target-dir")
+        .arg(target_dir);
+    match profile_dir_name {
+        "debug" => {}
+        "release" => {
+            cmd.arg("--release");
+        }
+        other => {
+            cmd.args(["--profile", other]);
+        }
+    }
+
+    let status = cmd
+        .status()
+        .map_err(|e| format!("invoke cargo build: {e}"))?;
+    if !status.success() {
+        return Err("cargo build -p guest-mock-codex failed".into());
+    }
+
+    let mock = target_profile_dir.join("guest-mock-codex");
+    if !mock.exists() {
+        return Err(format!("mock binary not found at {}", mock.display()));
+    }
+    Ok(mock)
+}

--- a/crates/guest-agent/tests/codex_app_server_backend_resume.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_resume.rs
@@ -1,0 +1,141 @@
+//! Resume-path integration coverage for the disabled Codex app-server backend.
+//!
+//! This is separate from `codex_app_server_backend.rs` because `guest_agent::env`
+//! caches `VM0_RESUME_SESSION_ID` in a process-wide `LazyLock`.
+
+mod common;
+
+use guest_agent::http::HttpClient;
+use guest_agent::masker::SecretMasker;
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+#[tokio::test]
+async fn codex_app_server_backend_resumes_existing_thread_id()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock = build_and_locate_mock_codex()?;
+    let tmp = tempfile::tempdir()?;
+    let resume_thread_id = "0193abcd-ef01-7234-89ab-cdef01234567";
+
+    unsafe {
+        setup_codex_app_server_env(
+            &mock,
+            tmp.path(),
+            "codex-app-server-backend-resume-test",
+            "runtime-turn-complete",
+            resume_thread_id,
+        )?;
+    }
+    let _run_files = common::RunFilesGuard::new();
+
+    let masker = SecretMasker::from_raw("");
+    let cli_result = tokio::time::timeout(
+        Duration::from_secs(5),
+        guest_agent::cli::execute_cli(
+            &masker,
+            common::spawn_dummy_heartbeat(),
+            HttpClient::for_current_env()?,
+        ),
+    )
+    .await
+    .expect("execute_cli should return promptly")?;
+
+    assert_eq!(cli_result.exit_code, common::CLEAN_EXIT);
+    assert!(cli_result.failure_diagnostic.is_none());
+
+    let events = read_agent_log_events()?;
+    assert_eq!(
+        events[0].get("type").and_then(Value::as_str),
+        Some("thread.started")
+    );
+    assert_eq!(
+        events[0].get("thread_id").and_then(Value::as_str),
+        Some(resume_thread_id)
+    );
+
+    let stored_id = std::fs::read_to_string(guest_agent::paths::session_id_file())?;
+    assert_eq!(stored_id, resume_thread_id);
+    let marker = std::fs::read_to_string(guest_agent::paths::session_history_path_file())?;
+    assert!(marker.ends_with(&format!(":{resume_thread_id}")));
+
+    Ok(())
+}
+
+fn read_agent_log_events() -> Result<Vec<Value>, Box<dyn std::error::Error>> {
+    let log = std::fs::read_to_string(guest_agent::paths::agent_log_file())?;
+    log.lines()
+        .map(|line| serde_json::from_str(line).map_err(Into::into))
+        .collect()
+}
+
+unsafe fn setup_codex_app_server_env(
+    mock_path: &Path,
+    home: &Path,
+    run_id: &str,
+    scenario: &str,
+    resume_session_id: &str,
+) -> Result<(), String> {
+    unsafe {
+        std::env::set_var("CLI_AGENT_TYPE", "codex");
+        std::env::set_var("VM0_CODEX_APP_SERVER_BACKEND", "1");
+        std::env::set_var("VM0_MOCK_CODEX_PATH", mock_path);
+        std::env::set_var("USE_MOCK_CODEX", "true");
+        std::env::remove_var("MOCK_CODEX_FIXTURE");
+        std::env::set_var("MOCK_CODEX_APP_SERVER_SCENARIO", scenario);
+        std::env::set_var("VM0_RESUME_SESSION_ID", resume_session_id);
+        std::env::set_var("VM0_RUN_ID", run_id);
+        std::env::set_var("VM0_PROMPT", "drive the app-server resume backend");
+        std::env::set_var("VM0_API_URL", "http://127.0.0.1:1");
+        std::env::set_var("VM0_API_TOKEN", "");
+        std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");
+        std::env::set_var("VM0_SANDBOX_REUSE_RESULT", "reused");
+        std::env::set_var("HOME", home);
+    }
+    std::fs::create_dir_all(home).map_err(|error| format!("create home: {error}"))?;
+    common::ensure_canonical_workspace_for_test()?;
+    std::env::set_current_dir(home).map_err(|error| format!("set_current_dir: {error}"))?;
+    Ok(())
+}
+
+fn build_and_locate_mock_codex() -> Result<PathBuf, String> {
+    let exe = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
+    let target_profile_dir = exe
+        .parent()
+        .and_then(|p| p.parent())
+        .ok_or_else(|| "target/<profile> dir".to_string())?;
+    let target_dir = target_profile_dir
+        .parent()
+        .ok_or_else(|| "target dir".to_string())?;
+    let profile_dir_name = target_profile_dir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| "profile dir name".to_string())?;
+
+    let mut cmd = std::process::Command::new("cargo");
+    cmd.args(["build", "-p", "guest-mock-codex", "--quiet"])
+        .arg("--target-dir")
+        .arg(target_dir);
+    match profile_dir_name {
+        "debug" => {}
+        "release" => {
+            cmd.arg("--release");
+        }
+        other => {
+            cmd.args(["--profile", other]);
+        }
+    }
+
+    let status = cmd
+        .status()
+        .map_err(|e| format!("invoke cargo build: {e}"))?;
+    if !status.success() {
+        return Err("cargo build -p guest-mock-codex failed".into());
+    }
+
+    let mock = target_profile_dir.join("guest-mock-codex");
+    if !mock.exists() {
+        return Err(format!("mock binary not found at {}", mock.display()));
+    }
+    Ok(mock)
+}

--- a/crates/guest-agent/tests/codex_app_server_backend_resume.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_resume.rs
@@ -16,7 +16,8 @@ async fn codex_app_server_backend_resumes_existing_thread_id()
 -> Result<(), Box<dyn std::error::Error>> {
     let mock = build_and_locate_mock_codex()?;
     let tmp = tempfile::tempdir()?;
-    let resume_thread_id = "0193abcd-ef01-7234-89ab-cdef01234567";
+    let resume_thread_id = "0193ABCDEF01723489ABCDEF01234567";
+    let canonical_resume_thread_id = "0193abcd-ef01-7234-89ab-cdef01234567";
 
     unsafe {
         setup_codex_app_server_env(
@@ -51,13 +52,13 @@ async fn codex_app_server_backend_resumes_existing_thread_id()
     );
     assert_eq!(
         events[0].get("thread_id").and_then(Value::as_str),
-        Some(resume_thread_id)
+        Some(canonical_resume_thread_id)
     );
 
     let stored_id = std::fs::read_to_string(guest_agent::paths::session_id_file())?;
-    assert_eq!(stored_id, resume_thread_id);
+    assert_eq!(stored_id, canonical_resume_thread_id);
     let marker = std::fs::read_to_string(guest_agent::paths::session_history_path_file())?;
-    assert!(marker.ends_with(&format!(":{resume_thread_id}")));
+    assert!(marker.ends_with(&format!(":{canonical_resume_thread_id}")));
 
     Ok(())
 }

--- a/crates/guest-agent/tests/codex_app_server_backend_resume_mismatch.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_resume_mismatch.rs
@@ -1,0 +1,128 @@
+//! Resume response validation for the disabled Codex app-server backend.
+//!
+//! This test lives in its own binary because `guest_agent::env` caches values
+//! in process-wide `LazyLock`s.
+
+mod common;
+
+use guest_agent::http::HttpClient;
+use guest_agent::masker::SecretMasker;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+#[tokio::test]
+async fn codex_app_server_backend_rejects_mismatched_resume_thread_id()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock = build_and_locate_mock_codex()?;
+    let tmp = tempfile::tempdir()?;
+    let resume_thread_id = "0193abcd-ef01-7234-89ab-cdef01234567";
+
+    unsafe {
+        setup_codex_app_server_env(&mock, tmp.path(), resume_thread_id)?;
+    }
+    let _run_files = common::RunFilesGuard::new();
+
+    let masker = SecretMasker::from_raw("");
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        guest_agent::cli::execute_cli(
+            &masker,
+            common::spawn_dummy_heartbeat(),
+            HttpClient::for_current_env()?,
+        ),
+    )
+    .await
+    .expect("execute_cli should return promptly");
+
+    let error = result.expect_err("mismatched resume response should fail the app-server backend");
+    let message = error.to_string();
+    assert!(
+        message.contains("thread/resume returned a different thread id"),
+        "unexpected error: {message}"
+    );
+    let session_id_path = guest_agent::paths::session_id_file();
+    assert!(
+        !std::path::Path::new(session_id_path).exists(),
+        "mismatched resume response should not write a session id"
+    );
+
+    Ok(())
+}
+
+unsafe fn setup_codex_app_server_env(
+    mock_path: &Path,
+    home: &Path,
+    resume_thread_id: &str,
+) -> Result<(), String> {
+    unsafe {
+        std::env::set_var("CLI_AGENT_TYPE", "codex");
+        std::env::set_var("VM0_CODEX_APP_SERVER_BACKEND", "1");
+        std::env::set_var("VM0_MOCK_CODEX_PATH", mock_path);
+        std::env::set_var("USE_MOCK_CODEX", "true");
+        std::env::remove_var("MOCK_CODEX_FIXTURE");
+        std::env::set_var(
+            "MOCK_CODEX_APP_SERVER_SCENARIO",
+            "resume-different-thread-id",
+        );
+        std::env::set_var("VM0_RESUME_SESSION_ID", resume_thread_id);
+        std::env::set_var(
+            "VM0_RUN_ID",
+            "codex-app-server-backend-resume-mismatch-test",
+        );
+        std::env::set_var(
+            "VM0_PROMPT",
+            "drive the app-server backend resume mismatch path",
+        );
+        std::env::set_var("VM0_API_URL", "http://127.0.0.1:1");
+        std::env::set_var("VM0_API_TOKEN", "");
+        std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");
+        std::env::set_var("VM0_SANDBOX_REUSE_RESULT", "reused");
+        std::env::set_var("HOME", home);
+    }
+    std::fs::create_dir_all(home).map_err(|error| format!("create home: {error}"))?;
+    common::ensure_canonical_workspace_for_test()?;
+    std::env::set_current_dir(home).map_err(|error| format!("set_current_dir: {error}"))?;
+    Ok(())
+}
+
+fn build_and_locate_mock_codex() -> Result<PathBuf, String> {
+    let exe = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
+    let target_profile_dir = exe
+        .parent()
+        .and_then(|p| p.parent())
+        .ok_or_else(|| "target/<profile> dir".to_string())?;
+    let target_dir = target_profile_dir
+        .parent()
+        .ok_or_else(|| "target dir".to_string())?;
+    let profile_dir_name = target_profile_dir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| "profile dir name".to_string())?;
+
+    let mut cmd = std::process::Command::new("cargo");
+    cmd.args(["build", "-p", "guest-mock-codex", "--quiet"])
+        .arg("--target-dir")
+        .arg(target_dir);
+    match profile_dir_name {
+        "debug" => {}
+        "release" => {
+            cmd.arg("--release");
+        }
+        other => {
+            cmd.args(["--profile", other]);
+        }
+    }
+
+    let status = cmd
+        .status()
+        .map_err(|e| format!("invoke cargo build: {e}"))?;
+    if !status.success() {
+        return Err("cargo build -p guest-mock-codex failed".into());
+    }
+
+    let mock = target_profile_dir.join("guest-mock-codex");
+    if !mock.exists() {
+        return Err(format!("mock binary not found at {}", mock.display()));
+    }
+    Ok(mock)
+}

--- a/crates/guest-agent/tests/codex_app_server_backend_scope.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_scope.rs
@@ -1,0 +1,131 @@
+//! Scope validation coverage for the disabled Codex app-server backend.
+//!
+//! This test lives in its own binary because `guest_agent::env` caches values
+//! in process-wide `LazyLock`s.
+
+mod common;
+
+use guest_agent::http::HttpClient;
+use guest_agent::masker::SecretMasker;
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+#[tokio::test]
+async fn codex_app_server_backend_rejects_unexpected_thread_event_scope()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock = build_and_locate_mock_codex()?;
+    let tmp = tempfile::tempdir()?;
+
+    unsafe {
+        setup_codex_app_server_env(&mock, tmp.path())?;
+    }
+    let _run_files = common::RunFilesGuard::new();
+
+    let masker = SecretMasker::from_raw("");
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        guest_agent::cli::execute_cli(
+            &masker,
+            common::spawn_dummy_heartbeat(),
+            HttpClient::for_current_env()?,
+        ),
+    )
+    .await
+    .expect("execute_cli should return promptly");
+
+    let error = result.expect_err("unexpected thread event should fail the app-server backend");
+    let message = error.to_string();
+    assert!(
+        message.contains("unexpected thread id"),
+        "unexpected error: {message}"
+    );
+
+    let events = read_agent_log_events()?;
+    assert!(
+        events.iter().all(|event| {
+            event.get("thread_id").and_then(Value::as_str) != Some("unexpected-thread-id")
+        }),
+        "unexpected-thread-id event should not be written to the agent log: {events:?}"
+    );
+
+    Ok(())
+}
+
+fn read_agent_log_events() -> Result<Vec<Value>, Box<dyn std::error::Error>> {
+    let log = std::fs::read_to_string(guest_agent::paths::agent_log_file())?;
+    log.lines()
+        .map(|line| serde_json::from_str(line).map_err(Into::into))
+        .collect()
+}
+
+unsafe fn setup_codex_app_server_env(mock_path: &Path, home: &Path) -> Result<(), String> {
+    unsafe {
+        std::env::set_var("CLI_AGENT_TYPE", "codex");
+        std::env::set_var("VM0_CODEX_APP_SERVER_BACKEND", "1");
+        std::env::set_var("VM0_MOCK_CODEX_PATH", mock_path);
+        std::env::set_var("USE_MOCK_CODEX", "true");
+        std::env::remove_var("MOCK_CODEX_FIXTURE");
+        std::env::set_var(
+            "MOCK_CODEX_APP_SERVER_SCENARIO",
+            "unexpected-thread-turn-completed",
+        );
+        std::env::set_var("VM0_RUN_ID", "codex-app-server-backend-scope-test");
+        std::env::set_var(
+            "VM0_PROMPT",
+            "drive the app-server backend scope failure path",
+        );
+        std::env::set_var("VM0_API_URL", "http://127.0.0.1:1");
+        std::env::set_var("VM0_API_TOKEN", "");
+        std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");
+        std::env::set_var("VM0_SANDBOX_REUSE_RESULT", "reused");
+        std::env::set_var("HOME", home);
+        std::env::remove_var("VM0_RESUME_SESSION_ID");
+    }
+    std::fs::create_dir_all(home).map_err(|error| format!("create home: {error}"))?;
+    common::ensure_canonical_workspace_for_test()?;
+    std::env::set_current_dir(home).map_err(|error| format!("set_current_dir: {error}"))?;
+    Ok(())
+}
+
+fn build_and_locate_mock_codex() -> Result<PathBuf, String> {
+    let exe = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
+    let target_profile_dir = exe
+        .parent()
+        .and_then(|p| p.parent())
+        .ok_or_else(|| "target/<profile> dir".to_string())?;
+    let target_dir = target_profile_dir
+        .parent()
+        .ok_or_else(|| "target dir".to_string())?;
+    let profile_dir_name = target_profile_dir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| "profile dir name".to_string())?;
+
+    let mut cmd = std::process::Command::new("cargo");
+    cmd.args(["build", "-p", "guest-mock-codex", "--quiet"])
+        .arg("--target-dir")
+        .arg(target_dir);
+    match profile_dir_name {
+        "debug" => {}
+        "release" => {
+            cmd.arg("--release");
+        }
+        other => {
+            cmd.args(["--profile", other]);
+        }
+    }
+
+    let status = cmd
+        .status()
+        .map_err(|e| format!("invoke cargo build: {e}"))?;
+    if !status.success() {
+        return Err("cargo build -p guest-mock-codex failed".into());
+    }
+
+    let mock = target_profile_dir.join("guest-mock-codex");
+    if !mock.exists() {
+        return Err(format!("mock binary not found at {}", mock.display()));
+    }
+    Ok(mock)
+}

--- a/crates/guest-agent/tests/codex_app_server_client.rs
+++ b/crates/guest-agent/tests/codex_app_server_client.rs
@@ -50,6 +50,13 @@ async fn codex_app_server_initializes_and_sends_initialized_notification() -> Re
 
     let state = wait_result(client.request_value("mock/state", json!({})), "mock/state").await?;
     assert_eq!(state["initializedNotificationReceived"], true);
+    let opt_out_methods = state["optOutNotificationMethods"]
+        .as_array()
+        .ok_or_else(|| "missing opt-out notification methods".to_string())?;
+    assert!(opt_out_methods.contains(&json!("process/outputDelta")));
+    assert!(opt_out_methods.contains(&json!("item/agentMessage/delta")));
+    assert!(opt_out_methods.contains(&json!("item/reasoning/textDelta")));
+    assert!(!opt_out_methods.contains(&json!("thread/started")));
     assert_eq!(state["hasPendingResponse"], false);
 
     wait_result(client.shutdown(), "shutdown").await

--- a/crates/guest-agent/tests/codex_app_server_client.rs
+++ b/crates/guest-agent/tests/codex_app_server_client.rs
@@ -713,6 +713,22 @@ async fn codex_app_server_terminate_skips_stdin_eof_grace() -> Result<(), String
 }
 
 #[tokio::test]
+async fn codex_app_server_terminate_sigkills_sigterm_deaf_child() -> Result<(), String> {
+    let mut client = spawn_client(Some("sigterm-deaf-on-stdin-eof"))?;
+    let pid = client
+        .process_id()
+        .ok_or_else(|| "app-server child missing pid".to_string())?;
+
+    match tokio::time::timeout(Duration::from_millis(1500), client.terminate()).await {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) => return Err(format!("terminate failed: {error:?}")),
+        Err(_) => return Err("terminate waited for SIGTERM grace".to_string()),
+    }
+    assert!(client.process_id().is_none());
+    assert_process_exited(pid)
+}
+
+#[tokio::test]
 async fn codex_app_server_request_after_cancelled_shutdown_kills_child() -> Result<(), String> {
     let mut client = spawn_client(Some("hang-on-stdin-eof"))?;
     let pid = client

--- a/crates/guest-agent/tests/codex_app_server_client.rs
+++ b/crates/guest-agent/tests/codex_app_server_client.rs
@@ -50,6 +50,27 @@ async fn codex_app_server_initializes_and_sends_initialized_notification() -> Re
 
     let state = wait_result(client.request_value("mock/state", json!({})), "mock/state").await?;
     assert_eq!(state["initializedNotificationReceived"], true);
+    assert_eq!(state["optOutNotificationMethods"], json!([]));
+    assert_eq!(state["hasPendingResponse"], false);
+
+    wait_result(client.shutdown(), "shutdown").await
+}
+
+#[tokio::test]
+async fn codex_app_server_initialize_sends_configured_opt_out_notifications() -> Result<(), String>
+{
+    let codex_home = TempDir::new().map_err(|error| format!("create codex home: {error}"))?;
+    let config = CodexAppServerConfig::new(mock_codex_path()?, codex_home.path())
+        .with_opt_out_notification_methods([
+            "process/outputDelta",
+            "item/agentMessage/delta",
+            "item/reasoning/textDelta",
+        ]);
+    let mut client = CodexAppServerClient::spawn(config).map_err(|error| format!("{error:?}"))?;
+
+    wait_result(client.initialize(), "initialize").await?;
+
+    let state = wait_result(client.request_value("mock/state", json!({})), "mock/state").await?;
     let opt_out_methods = state["optOutNotificationMethods"]
         .as_array()
         .ok_or_else(|| "missing opt-out notification methods".to_string())?;

--- a/crates/guest-agent/tests/codex_app_server_client.rs
+++ b/crates/guest-agent/tests/codex_app_server_client.rs
@@ -697,6 +697,22 @@ async fn codex_app_server_cancelled_shutdown_can_retry_and_reap_child() -> Resul
 }
 
 #[tokio::test]
+async fn codex_app_server_shutdown_skips_stdin_eof_grace() -> Result<(), String> {
+    let mut client = spawn_client(Some("hang-on-stdin-eof"))?;
+    let pid = client
+        .process_id()
+        .ok_or_else(|| "app-server child missing pid".to_string())?;
+
+    match tokio::time::timeout(Duration::from_millis(1500), client.shutdown()).await {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) => return Err(format!("shutdown failed: {error:?}")),
+        Err(_) => return Err("shutdown waited for stdin EOF grace".to_string()),
+    }
+    assert!(client.process_id().is_none());
+    assert_process_exited(pid)
+}
+
+#[tokio::test]
 async fn codex_app_server_terminate_skips_stdin_eof_grace() -> Result<(), String> {
     let mut client = spawn_client(Some("hang-on-stdin-eof"))?;
     let pid = client

--- a/crates/guest-agent/tests/codex_app_server_client.rs
+++ b/crates/guest-agent/tests/codex_app_server_client.rs
@@ -697,6 +697,22 @@ async fn codex_app_server_cancelled_shutdown_can_retry_and_reap_child() -> Resul
 }
 
 #[tokio::test]
+async fn codex_app_server_terminate_skips_stdin_eof_grace() -> Result<(), String> {
+    let mut client = spawn_client(Some("hang-on-stdin-eof"))?;
+    let pid = client
+        .process_id()
+        .ok_or_else(|| "app-server child missing pid".to_string())?;
+
+    match tokio::time::timeout(Duration::from_millis(1500), client.terminate()).await {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) => return Err(format!("terminate failed: {error:?}")),
+        Err(_) => return Err("terminate waited for stdin EOF grace".to_string()),
+    }
+    assert!(client.process_id().is_none());
+    assert_process_exited(pid)
+}
+
+#[tokio::test]
 async fn codex_app_server_request_after_cancelled_shutdown_kills_child() -> Result<(), String> {
     let mut client = spawn_client(Some("hang-on-stdin-eof"))?;
     let pid = client

--- a/crates/guest-agent/tests/codex_app_server_client.rs
+++ b/crates/guest-agent/tests/codex_app_server_client.rs
@@ -139,6 +139,84 @@ async fn codex_app_server_buffers_interleaved_notifications() -> Result<(), Stri
 }
 
 #[tokio::test]
+async fn codex_app_server_next_notification_returns_buffered_notification() -> Result<(), String> {
+    let mut client = spawn_client(Some("runtime-turn-complete"))?;
+    wait_result(client.initialize(), "initialize").await?;
+
+    let started = wait_result(
+        client.request_value("thread/start", json!({})),
+        "thread/start",
+    )
+    .await?;
+    let thread_id = started["thread"]["id"]
+        .as_str()
+        .ok_or_else(|| "missing thread id".to_string())?
+        .to_string();
+
+    let notification = wait_result(
+        client.next_notification("thread/started notification"),
+        "next notification",
+    )
+    .await?;
+    assert_eq!(notification.method, "thread/started");
+    assert_eq!(
+        notification
+            .params
+            .as_ref()
+            .and_then(|params| params.pointer("/thread/id"))
+            .and_then(Value::as_str),
+        Some(thread_id.as_str())
+    );
+
+    wait_result(client.shutdown(), "shutdown").await
+}
+
+#[tokio::test]
+async fn codex_app_server_next_notification_reads_after_response() -> Result<(), String> {
+    let mut client = spawn_client(Some("runtime-turn-complete-without-thread-started"))?;
+    wait_result(client.initialize(), "initialize").await?;
+
+    let started = wait_result(
+        client.request_value("thread/start", json!({})),
+        "thread/start",
+    )
+    .await?;
+    let thread_id = started["thread"]["id"]
+        .as_str()
+        .ok_or_else(|| "missing thread id".to_string())?
+        .to_string();
+    let turn_started = wait_result(
+        client.request_value(
+            "turn/start",
+            json!({
+                "threadId": thread_id,
+                "input": [text_input("initial prompt")]
+            }),
+        ),
+        "turn/start",
+    )
+    .await?;
+    assert!(turn_started["turn"]["id"].as_str().is_some());
+
+    let notification = wait_result(
+        client.next_notification("turn notification"),
+        "next notification",
+    )
+    .await?;
+    assert_eq!(notification.method, "turn/started");
+    assert_eq!(
+        notification
+            .params
+            .as_ref()
+            .and_then(|params| params.get("threadId"))
+            .and_then(Value::as_str),
+        Some(thread_id.as_str())
+    );
+
+    wait_result(client.shutdown(), "shutdown").await
+}
+
+#[tokio::test]
 async fn codex_app_server_rejects_notification_queue_overflow() -> Result<(), String> {
     let mut client = spawn_client(Some("notification-overflow"))?;
     wait_result(client.initialize(), "initialize").await?;

--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -169,6 +169,13 @@ pub const USE_MOCK_CLAUDE_ENV: &str = "USE_MOCK_CLAUDE";
 /// guest-agent treats `true` or `1` as enabled.
 pub const USE_MOCK_CODEX_ENV: &str = "USE_MOCK_CODEX";
 
+/// Experimental bootstrap switch for the disabled Codex app-server backend.
+///
+/// The runner does not set this key in product paths. Tests and future rollout
+/// PRs may set it explicitly; user-provided env cannot override it because the
+/// `VM0_` namespace is runner-owned.
+pub const CODEX_APP_SERVER_BACKEND_ENV: &str = "VM0_CODEX_APP_SERVER_BACKEND";
+
 /// Optional test/debug override for the mock Claude binary path.
 ///
 /// Unset means the guest-agent uses its compiled default mock binary path.

--- a/crates/guest-mock-codex/src/app_server.rs
+++ b/crates/guest-mock-codex/src/app_server.rs
@@ -121,6 +121,7 @@ struct AppServerThread {
     protocol_thread_id: String,
     artifact_thread_id: String,
     active_turn_id: Option<String>,
+    thread_request_has_runtime_workspace_roots: bool,
 }
 
 impl AppServerState {
@@ -241,7 +242,10 @@ impl AppServerState {
                     }
                 }
                 let thread_id = Uuid::now_v7().to_string();
-                self.set_current_thread(thread_id.clone());
+                self.set_current_thread(
+                    thread_id.clone(),
+                    params.get("runtimeWorkspaceRoots").is_some(),
+                );
                 let result = thread_response(&thread_id, false);
                 match self.scenario {
                     Scenario::InvalidResponseId => {
@@ -312,7 +316,10 @@ impl AppServerState {
                     write_error(output, id, INVALID_REQUEST, "missing threadId")?;
                     return Ok(ServerAction::Continue);
                 };
-                self.set_current_thread(thread_id.to_string());
+                self.set_current_thread(
+                    thread_id.to_string(),
+                    params.get("runtimeWorkspaceRoots").is_some(),
+                );
                 write_success(output, id, thread_response(thread_id, true))?;
                 Ok(ServerAction::Continue)
             }
@@ -338,6 +345,8 @@ impl AppServerState {
                 };
                 let thread_id = current_thread.protocol_thread_id.clone();
                 let artifact_thread_id = current_thread.artifact_thread_id.clone();
+                let thread_request_has_runtime_workspace_roots =
+                    current_thread.thread_request_has_runtime_workspace_roots;
                 let inputs = match text_inputs(params) {
                     Ok(inputs) => inputs,
                     Err(message) => {
@@ -359,6 +368,8 @@ impl AppServerState {
                     &turn_id,
                     "initial",
                     &inputs,
+                    thread_request_has_runtime_workspace_roots,
+                    params,
                 )?;
                 write_success(output, id, json!({ "turn": turn(&turn_id) }))?;
                 if matches!(
@@ -410,6 +421,8 @@ impl AppServerState {
 
                 let thread_id = current_thread.protocol_thread_id.clone();
                 let artifact_thread_id = current_thread.artifact_thread_id.clone();
+                let thread_request_has_runtime_workspace_roots =
+                    current_thread.thread_request_has_runtime_workspace_roots;
                 let inputs = match text_inputs(params) {
                     Ok(inputs) => inputs,
                     Err(message) => {
@@ -424,6 +437,8 @@ impl AppServerState {
                     &active_turn_id,
                     "steered",
                     &inputs,
+                    thread_request_has_runtime_workspace_roots,
+                    params,
                 )?;
                 write_success(output, id, json!({ "turnId": active_turn_id }))?;
                 Ok(ServerAction::Continue)
@@ -500,7 +515,11 @@ impl AppServerState {
         }
     }
 
-    fn set_current_thread(&mut self, thread_id: String) {
+    fn set_current_thread(
+        &mut self,
+        thread_id: String,
+        thread_request_has_runtime_workspace_roots: bool,
+    ) {
         let artifact_thread_id = self
             .session_artifact_thread_ids
             .entry(thread_id.clone())
@@ -510,6 +529,7 @@ impl AppServerState {
             protocol_thread_id: thread_id,
             artifact_thread_id,
             active_turn_id: None,
+            thread_request_has_runtime_workspace_roots,
         });
     }
 
@@ -782,6 +802,8 @@ fn persist_input_events(
     turn_id: &str,
     kind: &str,
     inputs: &[String],
+    thread_request_has_runtime_workspace_roots: bool,
+    turn_params: &Value,
 ) -> io::Result<()> {
     let events = inputs
         .iter()
@@ -791,7 +813,13 @@ fn persist_input_events(
                 "kind": kind,
                 "thread_id": thread_id,
                 "turn_id": turn_id,
-                "text": text
+                "text": text,
+                "thread_request_has_runtime_workspace_roots": thread_request_has_runtime_workspace_roots,
+                "turn_request_has_runtime_workspace_roots": turn_params.get("runtimeWorkspaceRoots").is_some(),
+                "turn_request_cwd": turn_params.get("cwd"),
+                "turn_request_approval_policy": turn_params.get("approvalPolicy"),
+                "turn_request_approvals_reviewer": turn_params.get("approvalsReviewer"),
+                "turn_request_sandbox_policy": turn_params.get("sandboxPolicy"),
             })
         })
         .collect::<Vec<_>>();

--- a/crates/guest-mock-codex/src/app_server.rs
+++ b/crates/guest-mock-codex/src/app_server.rs
@@ -18,6 +18,7 @@ enum Scenario {
     Success,
     DisconnectAfterInitialize,
     ExitOnTurnStart,
+    HangOnTurnStart,
     InterleavedNotification,
     InvalidResponseId,
     MalformedErrorResponse,
@@ -46,6 +47,7 @@ impl Scenario {
             Ok(value) => match value.as_str() {
                 "disconnect-after-initialize" => Ok(Self::DisconnectAfterInitialize),
                 "exit-on-turn-start" => Ok(Self::ExitOnTurnStart),
+                "hang-on-turn-start" => Ok(Self::HangOnTurnStart),
                 "interleaved-notification" => Ok(Self::InterleavedNotification),
                 "invalid-response-id" => Ok(Self::InvalidResponseId),
                 "malformed-error-response" => Ok(Self::MalformedErrorResponse),
@@ -330,6 +332,11 @@ impl AppServerState {
                 }
                 if self.scenario == Scenario::ExitOnTurnStart {
                     return Ok(ServerAction::Stop);
+                }
+                if self.scenario == Scenario::HangOnTurnStart {
+                    loop {
+                        thread::park();
+                    }
                 }
 
                 let Some(thread_id) = non_empty_string_param(params, "threadId") else {

--- a/crates/guest-mock-codex/src/app_server.rs
+++ b/crates/guest-mock-codex/src/app_server.rs
@@ -39,6 +39,7 @@ enum Scenario {
     NoActiveTurn,
     RuntimeTurnComplete,
     RuntimeTurnCompleteWithoutThreadStarted,
+    UnexpectedThreadTurnCompleted,
 }
 
 impl Scenario {
@@ -73,6 +74,7 @@ impl Scenario {
                 "runtime-turn-complete-without-thread-started" => {
                     Ok(Self::RuntimeTurnCompleteWithoutThreadStarted)
                 }
+                "unexpected-thread-turn-completed" => Ok(Self::UnexpectedThreadTurnCompleted),
                 _ => Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
                     format!("unsupported MOCK_CODEX_APP_SERVER_SCENARIO={value:?}"),
@@ -387,6 +389,13 @@ impl AppServerState {
                     params,
                 )?;
                 write_success(output, id, json!({ "turn": turn(&turn_id) }))?;
+                if self.scenario == Scenario::UnexpectedThreadTurnCompleted {
+                    write_json_line(
+                        output,
+                        &turn_completed_notification("unexpected-thread-id", &turn_id),
+                    )?;
+                    return Ok(ServerAction::Stop);
+                }
                 if matches!(
                     self.scenario,
                     Scenario::RuntimeTurnComplete

--- a/crates/guest-mock-codex/src/app_server.rs
+++ b/crates/guest-mock-codex/src/app_server.rs
@@ -39,6 +39,7 @@ enum Scenario {
     NoActiveTurn,
     RuntimeTurnComplete,
     RuntimeTurnCompleteWithoutThreadStarted,
+    ResumeRpcErrorWithThreadId,
     UnexpectedThreadTurnCompleted,
 }
 
@@ -74,6 +75,7 @@ impl Scenario {
                 "runtime-turn-complete-without-thread-started" => {
                     Ok(Self::RuntimeTurnCompleteWithoutThreadStarted)
                 }
+                "resume-rpc-error-with-thread-id" => Ok(Self::ResumeRpcErrorWithThreadId),
                 "unexpected-thread-turn-completed" => Ok(Self::UnexpectedThreadTurnCompleted),
                 _ => Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
@@ -328,6 +330,15 @@ impl AppServerState {
                     write_error(output, id, INVALID_REQUEST, "missing threadId")?;
                     return Ok(ServerAction::Continue);
                 };
+                if self.scenario == Scenario::ResumeRpcErrorWithThreadId {
+                    write_error(
+                        output,
+                        id,
+                        INVALID_REQUEST,
+                        &format!("resume failed for {thread_id}"),
+                    )?;
+                    return Ok(ServerAction::Continue);
+                }
                 self.set_current_thread(
                     thread_id.to_string(),
                     params.get("runtimeWorkspaceRoots").is_some(),

--- a/crates/guest-mock-codex/src/app_server.rs
+++ b/crates/guest-mock-codex/src/app_server.rs
@@ -41,6 +41,7 @@ enum Scenario {
     RuntimeTurnCompleteWithoutThreadStarted,
     ResumeDifferentThreadId,
     ResumeRpcErrorWithThreadId,
+    ThreadStartInvalidThreadId,
     UnexpectedThreadTurnCompleted,
 }
 
@@ -78,6 +79,7 @@ impl Scenario {
                 }
                 "resume-different-thread-id" => Ok(Self::ResumeDifferentThreadId),
                 "resume-rpc-error-with-thread-id" => Ok(Self::ResumeRpcErrorWithThreadId),
+                "thread-start-invalid-thread-id" => Ok(Self::ThreadStartInvalidThreadId),
                 "unexpected-thread-turn-completed" => Ok(Self::UnexpectedThreadTurnCompleted),
                 _ => Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
@@ -262,7 +264,12 @@ impl AppServerState {
                     thread_id.clone(),
                     params.get("runtimeWorkspaceRoots").is_some(),
                 );
-                let result = thread_response(&thread_id, false);
+                let response_thread_id = if self.scenario == Scenario::ThreadStartInvalidThreadId {
+                    "not-a-valid-codex-thread-id"
+                } else {
+                    &thread_id
+                };
+                let result = thread_response(response_thread_id, false);
                 match self.scenario {
                     Scenario::InvalidResponseId => {
                         write_success(
@@ -346,7 +353,7 @@ impl AppServerState {
                     params.get("runtimeWorkspaceRoots").is_some(),
                 );
                 let response_thread_id = if self.scenario == Scenario::ResumeDifferentThreadId {
-                    "unexpected-resume-thread-id"
+                    "0193abcd-ef01-7234-89ab-cdef01234568"
                 } else {
                     thread_id
                 };

--- a/crates/guest-mock-codex/src/app_server.rs
+++ b/crates/guest-mock-codex/src/app_server.rs
@@ -35,6 +35,8 @@ enum Scenario {
     UnknownResponseBeforeResponse,
     StaleTurn,
     NoActiveTurn,
+    RuntimeTurnComplete,
+    RuntimeTurnCompleteWithoutThreadStarted,
 }
 
 impl Scenario {
@@ -63,6 +65,10 @@ impl Scenario {
                 "unknown-response-before-response" => Ok(Self::UnknownResponseBeforeResponse),
                 "stale-turn" => Ok(Self::StaleTurn),
                 "no-active-turn" => Ok(Self::NoActiveTurn),
+                "runtime-turn-complete" => Ok(Self::RuntimeTurnComplete),
+                "runtime-turn-complete-without-thread-started" => {
+                    Ok(Self::RuntimeTurnCompleteWithoutThreadStarted)
+                }
                 _ => Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
                     format!("unsupported MOCK_CODEX_APP_SERVER_SCENARIO={value:?}"),
@@ -287,6 +293,10 @@ impl AppServerState {
                         )?;
                         write_success(output, id, result)?;
                     }
+                    Scenario::RuntimeTurnComplete => {
+                        write_json_line(output, &thread_started_notification(&thread_id))?;
+                        write_success(output, id, result)?;
+                    }
                     _ => {
                         write_success(output, id, result)?;
                     }
@@ -351,6 +361,13 @@ impl AppServerState {
                     &inputs,
                 )?;
                 write_success(output, id, json!({ "turn": turn(&turn_id) }))?;
+                if matches!(
+                    self.scenario,
+                    Scenario::RuntimeTurnComplete
+                        | Scenario::RuntimeTurnCompleteWithoutThreadStarted
+                ) {
+                    write_turn_notifications(output, &thread_id, &turn_id)?;
+                }
                 Ok(ServerAction::Continue)
             }
             "turn/steer" => {
@@ -591,6 +608,69 @@ fn large_server_notification() -> Value {
     })
 }
 
+fn thread_started_notification(thread_id: &str) -> Value {
+    json!({
+        "method": "thread/started",
+        "params": {
+            "thread": thread(thread_id)
+        }
+    })
+}
+
+fn turn_started_notification(thread_id: &str, turn_id: &str) -> Value {
+    json!({
+        "method": "turn/started",
+        "params": {
+            "threadId": thread_id,
+            "turn": turn(turn_id)
+        }
+    })
+}
+
+fn assistant_item_completed_notification(thread_id: &str, turn_id: &str) -> Value {
+    json!({
+        "method": "item/completed",
+        "params": {
+            "threadId": thread_id,
+            "turnId": turn_id,
+            "completedAtMs": 2,
+            "item": {
+                "id": Uuid::now_v7().to_string(),
+                "type": "agentMessage",
+                "text": "guest-mock-codex app-server response"
+            }
+        }
+    })
+}
+
+fn turn_completed_notification(thread_id: &str, turn_id: &str) -> Value {
+    json!({
+        "method": "turn/completed",
+        "params": {
+            "threadId": thread_id,
+            "turn": completed_turn(turn_id),
+            "usage": {
+                "inputTokens": 7,
+                "outputTokens": 11,
+                "totalTokens": 18
+            }
+        }
+    })
+}
+
+fn write_turn_notifications<W: Write>(
+    output: &mut W,
+    thread_id: &str,
+    turn_id: &str,
+) -> io::Result<()> {
+    write_json_line(output, &turn_started_notification(thread_id, turn_id))?;
+    write_json_line(
+        output,
+        &assistant_item_completed_notification(thread_id, turn_id),
+    )?;
+    write_json_line(output, &turn_completed_notification(thread_id, turn_id))
+}
+
 fn server_request(id: Value) -> Value {
     json!({
         "id": id,
@@ -644,6 +724,19 @@ fn turn(turn_id: &str) -> Value {
         "startedAt": null,
         "completedAt": null,
         "durationMs": null
+    })
+}
+
+fn completed_turn(turn_id: &str) -> Value {
+    json!({
+        "id": turn_id,
+        "items": [],
+        "itemsView": "notLoaded",
+        "status": "completed",
+        "error": null,
+        "startedAt": 1,
+        "completedAt": 3,
+        "durationMs": 2
     })
 }
 

--- a/crates/guest-mock-codex/src/app_server.rs
+++ b/crates/guest-mock-codex/src/app_server.rs
@@ -28,6 +28,7 @@ enum Scenario {
     HangOnThreadStart,
     MalformedStdout,
     HangOnStdinEof,
+    SigtermDeafOnStdinEof,
     NullIdServerRequestBeforeResponse,
     NotificationOverflow,
     OversizedStdout,
@@ -57,6 +58,7 @@ impl Scenario {
                 "hang-on-thread-start" => Ok(Self::HangOnThreadStart),
                 "malformed-stdout" => Ok(Self::MalformedStdout),
                 "hang-on-stdin-eof" => Ok(Self::HangOnStdinEof),
+                "sigterm-deaf-on-stdin-eof" => Ok(Self::SigtermDeafOnStdinEof),
                 "null-id-server-request-before-response" => {
                     Ok(Self::NullIdServerRequestBeforeResponse)
                 }
@@ -158,6 +160,12 @@ impl AppServerState {
             Scenario::HangOnStdinEof => loop {
                 thread::park();
             },
+            Scenario::SigtermDeafOnStdinEof => {
+                ignore_sigterm();
+                loop {
+                    thread::park();
+                }
+            }
             Scenario::StderrHolderOnStdinEof => {
                 spawn_stderr_holder()?;
             }
@@ -863,3 +871,13 @@ fn write_json_line<W: Write>(output: &mut W, value: &Value) -> io::Result<()> {
     writeln!(output)?;
     output.flush()
 }
+
+#[cfg(unix)]
+fn ignore_sigterm() {
+    unsafe {
+        libc::signal(libc::SIGTERM, libc::SIG_IGN);
+    }
+}
+
+#[cfg(not(unix))]
+fn ignore_sigterm() {}

--- a/crates/guest-mock-codex/src/app_server.rs
+++ b/crates/guest-mock-codex/src/app_server.rs
@@ -39,6 +39,7 @@ enum Scenario {
     NoActiveTurn,
     RuntimeTurnComplete,
     RuntimeTurnCompleteWithoutThreadStarted,
+    ResumeDifferentThreadId,
     ResumeRpcErrorWithThreadId,
     UnexpectedThreadTurnCompleted,
 }
@@ -75,6 +76,7 @@ impl Scenario {
                 "runtime-turn-complete-without-thread-started" => {
                     Ok(Self::RuntimeTurnCompleteWithoutThreadStarted)
                 }
+                "resume-different-thread-id" => Ok(Self::ResumeDifferentThreadId),
                 "resume-rpc-error-with-thread-id" => Ok(Self::ResumeRpcErrorWithThreadId),
                 "unexpected-thread-turn-completed" => Ok(Self::UnexpectedThreadTurnCompleted),
                 _ => Err(io::Error::new(
@@ -343,7 +345,12 @@ impl AppServerState {
                     thread_id.to_string(),
                     params.get("runtimeWorkspaceRoots").is_some(),
                 );
-                write_success(output, id, thread_response(thread_id, true))?;
+                let response_thread_id = if self.scenario == Scenario::ResumeDifferentThreadId {
+                    "unexpected-resume-thread-id"
+                } else {
+                    thread_id
+                };
+                write_success(output, id, thread_response(response_thread_id, true))?;
                 Ok(ServerAction::Continue)
             }
             "turn/start" => {

--- a/crates/guest-mock-codex/src/app_server.rs
+++ b/crates/guest-mock-codex/src/app_server.rs
@@ -117,6 +117,7 @@ struct AppServerState {
     initial_inputs: Vec<String>,
     steered_inputs: Vec<String>,
     initialized_notification_received: bool,
+    opt_out_notification_methods: Vec<String>,
     pending_response: Option<PendingResponse>,
     server_request_responses: Vec<Value>,
     scenario: Scenario,
@@ -145,6 +146,7 @@ impl AppServerState {
             initial_inputs: Vec::new(),
             steered_inputs: Vec::new(),
             initialized_notification_received: false,
+            opt_out_notification_methods: Vec::new(),
             pending_response: None,
             server_request_responses: Vec::new(),
             scenario,
@@ -217,6 +219,7 @@ impl AppServerState {
                     write_error(output, id, INVALID_REQUEST, message)?;
                     return Ok(ServerAction::Continue);
                 }
+                self.opt_out_notification_methods = initialize_opt_out_notification_methods(params);
                 if self.scenario == Scenario::MalformedStdout {
                     writeln!(output, "{{not-valid-json")?;
                     output.flush()?;
@@ -509,6 +512,7 @@ impl AppServerState {
                     id,
                     json!({
                         "initializedNotificationReceived": self.initialized_notification_received,
+                        "optOutNotificationMethods": &self.opt_out_notification_methods,
                         "serverRequestResponses": &self.server_request_responses,
                         "hasPendingResponse": self.pending_response.is_some(),
                     }),
@@ -628,6 +632,21 @@ fn validate_initialize_params(params: &Value) -> Result<(), &'static str> {
         return Err("missing capabilities.experimentalApi");
     }
     Ok(())
+}
+
+fn initialize_opt_out_notification_methods(params: &Value) -> Vec<String> {
+    params
+        .get("capabilities")
+        .and_then(|capabilities| capabilities.get("optOutNotificationMethods"))
+        .and_then(Value::as_array)
+        .map(|methods| {
+            methods
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 fn thread_response(thread_id: &str, resume: bool) -> Value {


### PR DESCRIPTION
## Summary
- add a protected VM0_CODEX_APP_SERVER_BACKEND switch for the disabled Codex app-server execution backend
- run app-server initialize/thread start or resume/turn start, map notifications through the existing Codex event adapter, and reuse shared event ingestion for logs, session metadata, diagnostics, and webhook sequencing
- extend guest-mock-codex app-server runtime scenarios and add backend success, resume, failure, and client notification-wait tests

## Tests
- cargo test -p guest-agent --lib
- cargo test -p guest-agent --test codex_app_server_client --test codex_app_server_backend --test codex_app_server_backend_resume --test codex_app_server_backend_failure --test codex_jsonl_failure_logging --test codex_session_resume
- cargo test -p guest-agent --test no_api_mode --test execute_cli_api_mode
- cargo test -p guest-mock-codex
- cargo clippy -p guest-agent --all-targets -- -D warnings

Closes #18372