### PR TITLE
refactor: reduce fallback slop in media contracts

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-billing-media.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-billing-media.ts
@@ -702,7 +702,7 @@ export function createBillingMediaApi(context: TestContext) {
         readonly safetyTolerance?: string;
         readonly enhancePrompt?: boolean;
         readonly imageUrl?: string;
-        readonly imageUrls?: readonly unknown[];
+        readonly imageUrls?: readonly string[];
         readonly maskImageUrl?: string;
         readonly inputFidelity?: string;
         readonly imagePromptStrength?: number;

--- a/turbo/packages/api-contracts/src/contracts/zero-image-io-generate.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-image-io-generate.ts
@@ -5,7 +5,10 @@ import { apiErrorSchema } from "./errors";
 import { zeroBuiltInGenerationAcceptedResponseSchema } from "./zero-built-in-generation";
 
 const c = initContract();
-const stringOrStringArraySchema = z.union([z.string(), z.array(z.string())]);
+const stringOrStringArraySchema = z.union([
+  z.string(),
+  z.array(z.string()).readonly(),
+]);
 
 export const zeroImageIoGenerateRequestSchema = z
   .object({

--- a/turbo/packages/api-contracts/src/contracts/zero-image-io-generate.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-image-io-generate.ts
@@ -5,6 +5,7 @@ import { apiErrorSchema } from "./errors";
 import { zeroBuiltInGenerationAcceptedResponseSchema } from "./zero-built-in-generation";
 
 const c = initContract();
+const stringOrStringArraySchema = z.union([z.string(), z.array(z.string())]);
 
 export const zeroImageIoGenerateRequestSchema = z
   .object({
@@ -19,10 +20,10 @@ export const zeroImageIoGenerateRequestSchema = z
     seed: z.unknown().optional(),
     safetyTolerance: z.unknown().optional(),
     enhancePrompt: z.unknown().optional(),
-    imageUrl: z.unknown().optional(),
-    image_url: z.unknown().optional(),
-    imageUrls: z.unknown().optional(),
-    image_urls: z.unknown().optional(),
+    imageUrl: stringOrStringArraySchema.optional(),
+    image_url: stringOrStringArraySchema.optional(),
+    imageUrls: stringOrStringArraySchema.optional(),
+    image_urls: stringOrStringArraySchema.optional(),
     maskImageUrl: z.unknown().optional(),
     mask_image_url: z.unknown().optional(),
     inputFidelity: z.unknown().optional(),

--- a/turbo/packages/api-contracts/src/contracts/zero-video-io-generate.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-video-io-generate.ts
@@ -5,6 +5,7 @@ import { apiErrorSchema } from "./errors";
 import { zeroBuiltInGenerationAcceptedResponseSchema } from "./zero-built-in-generation";
 
 const c = initContract();
+const stringOrStringArraySchema = z.union([z.string(), z.array(z.string())]);
 
 export const zeroVideoIoGenerateRequestSchema = z
   .object({
@@ -18,14 +19,14 @@ export const zeroVideoIoGenerateRequestSchema = z
     seed: z.number().optional(),
     autoFix: z.boolean().optional(),
     safetyTolerance: z.string().optional(),
-    imageUrls: z.unknown().optional(),
-    videoUrls: z.unknown().optional(),
-    audioUrls: z.unknown().optional(),
-    referenceImageUrls: z.unknown().optional(),
-    referenceVideoUrls: z.unknown().optional(),
-    referenceAudioUrls: z.unknown().optional(),
-    firstFrameImageUrl: z.unknown().optional(),
-    lastFrameImageUrl: z.unknown().optional(),
+    imageUrls: stringOrStringArraySchema.optional(),
+    videoUrls: stringOrStringArraySchema.optional(),
+    audioUrls: stringOrStringArraySchema.optional(),
+    referenceImageUrls: stringOrStringArraySchema.optional(),
+    referenceVideoUrls: stringOrStringArraySchema.optional(),
+    referenceAudioUrls: stringOrStringArraySchema.optional(),
+    firstFrameImageUrl: z.string().optional(),
+    lastFrameImageUrl: z.string().optional(),
   })
   .passthrough();
 

--- a/turbo/packages/api-contracts/src/contracts/zero-video-io-generate.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-video-io-generate.ts
@@ -5,7 +5,10 @@ import { apiErrorSchema } from "./errors";
 import { zeroBuiltInGenerationAcceptedResponseSchema } from "./zero-built-in-generation";
 
 const c = initContract();
-const stringOrStringArraySchema = z.union([z.string(), z.array(z.string())]);
+const stringOrStringArraySchema = z.union([
+  z.string(),
+  z.array(z.string()).readonly(),
+]);
 
 export const zeroVideoIoGenerateRequestSchema = z
   .object({


### PR DESCRIPTION
## Summary

Daily AI-slop fallback cleanup for media generation request contracts.

## Scan

- Scan timestamp: 2026-06-27T20:01:46.272Z
- Base commit: 6f47f8ee081c2d2033c74e2a384d92a609d05642
- Scanner output: `/tmp/ai-slop-fallback-scan.json`

Total matches by category:
- `nullish`: 4602
- `nullish-chain`: 103
- `field-fallback-chain`: 81
- `optional-prop`: 4916
- `zod-optional`: 1591
- `zod-loose-optional`: 36
- `loose-record`: 918
- `loose-index-signature`: 6
- `as-any`: 1
- `as-unknown-as`: 42
- `empty-fallback`: 552
- `string-fallback`: 616
- `null-undefined-fallback`: 1253
- `empty-catch`: 4
- `promise-catch-swallow`: 16
- `rust-unwrap-or`: 552
- `rust-ok-discard`: 130

## Candidate Budget

- `actionable_total`: 233
- `edit_budget`: 12
- Candidates changed: 12
- Post-change validation scan: `zod-loose-optional` dropped from 36 to 24, and high-confidence production-actionable matches dropped from 233 to 221.

## Files Changed

- `turbo/packages/api-contracts/src/contracts/zero-image-io-generate.ts`: tightened the four source image URL aliases from `z.unknown().optional()` to a string-or-string-array request schema. This is safe because `parseSourceImageUrls` already accepts either a single string or an array of strings for those keys.
- `turbo/packages/api-contracts/src/contracts/zero-video-io-generate.ts`: tightened reference media URL fields to string-or-string-array and first/last frame fields to strings. This is safe because `parseVideoOptions` already reads the reference list fields through `readStringArrayFromKeys` and first/last frame fields through `readOptionalStringFromKeys`.

This workflow intentionally leaves the remaining candidates for later daily runs.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/api-contracts lint`
- `git diff --check`
- Attempted targeted API route tests: `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-image-io-generate.test.ts src/signals/routes/__tests__/zero-video-io-generate.test.ts`. They did not complete because the local PostgreSQL server was unavailable (`ECONNREFUSED` on `127.0.0.1:5432` and `::1:5432`); the PR pipeline will run the full environment-backed checks.