### PR TITLE
feat: redesign workflow trigger cards

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/automations-store.ts
+++ b/turbo/apps/platform/src/mocks/handlers/automations-store.ts
@@ -9,6 +9,10 @@ type MockWorkflowTriggerOverrides = Partial<
   Omit<ChatThreadWorkflowTrigger, "workflow">
 > & {
   readonly eventType?: "gmail-new-message" | "gmail-label-applied";
+  readonly eventConfig?: Extract<
+    ChatThreadWorkflowTrigger,
+    { kind: "event" }
+  >["eventConfig"];
   readonly workflow?: Partial<ChatThreadWorkflowTrigger["workflow"]>;
 };
 

--- a/turbo/apps/platform/src/signals/chat-page/header-automation-menu.ts
+++ b/turbo/apps/platform/src/signals/chat-page/header-automation-menu.ts
@@ -5,6 +5,7 @@ import {
   type ChatThreadWorkflowTrigger,
   type GmailLabelAppliedEventConfig,
   type GmailNewMessageEventConfig,
+  type ZeroWorkflowSchedule,
 } from "@vm0/api-contracts/contracts/zero-workflows";
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
@@ -12,7 +13,6 @@ import { userPreferences$ } from "../zero-page/settings/user-preferences.ts";
 import {
   listAutomations,
   listThreadWorkflowTriggers,
-  setWorkflowTriggerEnabled,
 } from "../zero-page/automations-api.ts";
 import { automationToTimeString } from "../zero-page/zero-automations.ts";
 
@@ -83,8 +83,8 @@ export interface HeaderWorkflowTriggerEntry {
   readonly workflowAgentId: string;
   readonly workflowName: string;
   readonly workflowDisplayName: string | null;
-  readonly workflowDescription: string | null;
   readonly summary: string;
+  readonly timezone: string;
   readonly trigger: ChatThreadWorkflowTrigger;
 }
 
@@ -119,6 +119,10 @@ function createHeaderWorkflowTriggersFactory(): (
         const triggers = await listThreadWorkflowTriggers(get(zeroClient$), {
           threadId,
         });
+        const prefs = await get(userPreferences$);
+        const displayTz =
+          prefs?.timezone ??
+          new Intl.DateTimeFormat().resolvedOptions().timeZone;
         return triggers.map((trigger) => {
           return {
             id: trigger.id,
@@ -128,8 +132,8 @@ function createHeaderWorkflowTriggersFactory(): (
             workflowAgentId: trigger.workflow.agentId,
             workflowName: trigger.workflow.name,
             workflowDisplayName: trigger.workflow.displayName,
-            workflowDescription: trigger.workflow.description,
             summary: workflowTriggerSummary(trigger),
+            timezone: displayTz,
             trigger,
           };
         });
@@ -143,18 +147,24 @@ function createHeaderWorkflowTriggersFactory(): (
 export const headerWorkflowTriggersForThread =
   createHeaderWorkflowTriggersFactory();
 
-/**
- * Enable/disable a thread's workflow trigger from the sidebar toggle,
- * then refetch so the card reflects the new state. The backend also publishes
- * the realtime signal so other open clients refresh.
- */
-export const toggleWorkflowTriggerEnabled$ = command(
+export const updateHeaderWorkflowScheduleTrigger$ = command(
   async (
     { get, set },
-    params: { readonly triggerId: string; readonly enabled: boolean },
+    params: {
+      readonly triggerId: string;
+      readonly schedule: ZeroWorkflowSchedule;
+    },
     signal: AbortSignal,
   ) => {
-    await setWorkflowTriggerEnabled(get(zeroClient$), params);
+    const client = get(zeroClient$)(zeroWorkflowTriggersContract);
+    await accept(
+      client.update({
+        params: { id: params.triggerId },
+        body: { schedule: params.schedule },
+        fetchOptions: { signal },
+      }),
+      [200],
+    );
     signal.throwIfAborted();
     set(reloadHeaderAutomationMenu$);
   },
@@ -177,6 +187,21 @@ export const updateHeaderWorkflowGmailNewMessageTrigger$ = command(
         fetchOptions: { signal },
       }),
       [200],
+    );
+    signal.throwIfAborted();
+    set(reloadHeaderAutomationMenu$);
+  },
+);
+
+export const runHeaderWorkflowTriggerNow$ = command(
+  async ({ get, set }, triggerId: string, signal: AbortSignal) => {
+    const client = get(zeroClient$)(zeroWorkflowTriggersContract);
+    await accept(
+      client.run({
+        params: { id: triggerId },
+        fetchOptions: { signal },
+      }),
+      [201],
     );
     signal.throwIfAborted();
     set(reloadHeaderAutomationMenu$);

--- a/turbo/apps/platform/src/signals/chat-page/header-automation-sidebar.ts
+++ b/turbo/apps/platform/src/signals/chat-page/header-automation-sidebar.ts
@@ -1,4 +1,4 @@
-import { command, computed } from "ccstate";
+import { command, computed, state } from "ccstate";
 
 import {
   replaceSearchParams$,
@@ -15,6 +15,18 @@ export const currentHeaderAutomationThreadId$ = computed((get) => {
   return get(searchParams$).get(CHAT_AUTOMATIONS_QUERY_PARAM);
 });
 
+const editingHeaderWorkflowTriggerId$ = state<string | null>(null);
+
+export const currentEditingHeaderWorkflowTriggerId$ = computed((get) => {
+  return get(editingHeaderWorkflowTriggerId$);
+});
+
+export const setEditingHeaderWorkflowTriggerId$ = command(
+  ({ set }, triggerId: string | null) => {
+    set(editingHeaderWorkflowTriggerId$, triggerId);
+  },
+);
+
 export const openHeaderAutomationSidebar$ = command(
   ({ get, set }, threadId: string) => {
     const params = new URLSearchParams(get(searchParams$));
@@ -30,5 +42,6 @@ export const closeHeaderAutomationSidebar$ = command(({ get, set }) => {
     return;
   }
   clearChatAutomationSidebarParams(params);
+  set(setEditingHeaderWorkflowTriggerId$, null);
   set(replaceSearchParams$, params);
 });

--- a/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
+++ b/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
@@ -8,7 +8,6 @@ import {
   type GmailNewMessageEventConfig,
   type ZeroWorkflowDetailResponse,
   type ZeroWorkflowSchedule,
-  type ZeroWorkflowScheduleType,
   type ZeroWorkflowSummary,
   type ZeroWorkflowTriggerSummary,
   type ZeroWorkflowUpdateRequest,
@@ -35,7 +34,8 @@ export type WorkflowDetailTab =
   | "instructions"
   | "info";
 type WorkflowTriggerCreateDialog =
-  | "schedule"
+  | "interval"
+  | "scheduled"
   | "gmail"
   | "gmail-label"
   | "webhook"
@@ -130,7 +130,6 @@ const internalWorkflowMetadataPatch$ = state<WorkflowMetadataPatch | null>(
 );
 const internalWorkflowTriggerCreateDialog$ =
   state<WorkflowTriggerCreateDialog>(null);
-const internalScheduleTriggerType$ = state<ZeroWorkflowScheduleType>("cron");
 const internalCreatedWorkflowWebhookTrigger$ =
   state<WorkflowWebhookTriggerSummary | null>(null);
 const internalCreateScheduleCronFields$ = state<WorkflowCronFields>(
@@ -194,7 +193,6 @@ export const resetWorkflowDetailUiState$ = command(({ set }) => {
   set(internalWorkflowMetadataPatch$, null);
   set(internalWorkflowTriggerCreateDialog$, null);
   set(internalCreatedWorkflowWebhookTrigger$, null);
-  set(internalScheduleTriggerType$, "cron");
   set(internalCreateScheduleCronFields$, defaultWorkflowCronFields());
   set(internalEditingScheduleCronFields$, defaultWorkflowCronFields());
 });
@@ -251,20 +249,9 @@ export const setWorkflowTriggerCreateDialog$ = command(
     if (dialog !== "webhook") {
       set(internalCreatedWorkflowWebhookTrigger$, null);
     }
-    if (dialog === "schedule") {
-      set(internalScheduleTriggerType$, "cron");
+    if (dialog === "scheduled") {
       set(internalCreateScheduleCronFields$, defaultWorkflowCronFields());
     }
-  },
-);
-
-export const scheduleTriggerType$ = computed((get) => {
-  return get(internalScheduleTriggerType$);
-});
-
-export const setScheduleTriggerType$ = command(
-  ({ set }, scheduleType: ZeroWorkflowScheduleType) => {
-    set(internalScheduleTriggerType$, scheduleType);
   },
 );
 

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -692,8 +692,10 @@ describe("workflow detail page", () => {
       expect(screen.getByText("Every weekday at 9:00 AM")).toBeInTheDocument();
     });
     expect(search()).toBe("?tab=triggers");
-    expect(screen.getByText("Enabled")).toBeInTheDocument();
-    expect(screen.getByText("Open thread")).toBeInTheDocument();
+    expect(screen.getByText("Schedule")).toBeInTheDocument();
+    expect(screen.getAllByText("Last run").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Next run").length).toBeGreaterThan(0);
+    expect(buttonByText("Run now")).toBeInTheDocument();
     click(buttonByText("Info"));
     await waitFor(() => {
       expect(screen.getAllByText("Visibility").length).toBeGreaterThan(0);
@@ -904,9 +906,9 @@ describe("workflow detail page", () => {
     });
 
     await waitFor(() => {
-      expect(buttonByText("Trigger now")).toBeInTheDocument();
+      expect(buttonByText("Run now")).toBeInTheDocument();
     });
-    click(buttonByText("Trigger now"));
+    click(buttonByText("Run now"));
 
     await waitFor(() => {
       expect(runTriggerIds).toStrictEqual(["workflow-trigger-weekday-brief"]);
@@ -1163,7 +1165,7 @@ describe("workflow detail page", () => {
       expect(screen.getByText("Every weekday at 9:00 AM")).toBeInTheDocument();
     });
 
-    click(screen.getByText("Edit schedule"));
+    click(buttonByText("Edit"));
 
     const updateTriggerForm = screen.getByRole("form", {
       name: "Update schedule trigger",
@@ -1180,6 +1182,62 @@ describe("workflow detail page", () => {
             type: "cron",
             cronExpression: "45 8 * * 1-5",
             timezone: "UTC",
+          },
+        },
+      });
+    });
+  });
+
+  it("updates a loop schedule trigger from the edit dialog", async () => {
+    const updateBodies: {
+      readonly triggerId: string;
+      readonly body: ZeroWorkflowTriggerUpdateRequest;
+    }[] = [];
+    const workflow = {
+      ...salesResearch(),
+      triggers: [
+        {
+          ...weekdayWorkflowTrigger(),
+          schedule: {
+            type: "loop",
+            intervalSeconds: 3600,
+          },
+          scheduleSummary: "Every 3600s",
+        } satisfies WorkflowScheduleTriggerSummary,
+      ],
+    };
+    mockWorkflowApis([workflow]);
+    mockUpdateWorkflowTrigger((triggerId, body) => {
+      updateBodies.push({ triggerId, body });
+    });
+
+    detachedSetupPage({
+      context,
+      path: workflowDetailPath("triggers"),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Every 3600s")).toBeInTheDocument();
+    });
+
+    click(buttonByText("Edit"));
+
+    const updateTriggerForm = screen.getByRole("form", {
+      name: "Update schedule trigger",
+    });
+    await fill(
+      within(updateTriggerForm).getByLabelText("Interval seconds"),
+      "7200",
+    );
+    fireEvent.submit(updateTriggerForm);
+
+    await waitFor(() => {
+      expect(updateBodies.at(-1)).toStrictEqual({
+        triggerId: "workflow-trigger-weekday-brief",
+        body: {
+          schedule: {
+            type: "loop",
+            intervalSeconds: 7200,
           },
         },
       });
@@ -1223,7 +1281,7 @@ describe("workflow detail page", () => {
       );
     });
 
-    click(screen.getByText("Edit match"));
+    click(buttonByText("Edit"));
 
     const updateTriggerForm = screen.getByRole("form", {
       name: "Update Gmail new message trigger",
@@ -1282,7 +1340,7 @@ describe("workflow detail page", () => {
       expect(screen.getByText("Gmail label applied")).toBeInTheDocument();
     });
 
-    click(screen.getByText("Edit label"));
+    click(buttonByText("Edit"));
 
     const updateTriggerForm = screen.getByRole("form", {
       name: "Update Gmail label trigger",

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -588,7 +588,13 @@ function selectOptionByLabel(
   option: string | RegExp,
   container: HTMLElement,
 ): void {
-  click(within(container).getByLabelText(label));
+  const control =
+    within(container)
+      .getAllByLabelText(label)
+      .find((element) => {
+        return element.getAttribute("role") === "combobox";
+      }) ?? within(container).getByLabelText(label);
+  click(control);
   click(screen.getByRole("option", { name: option }));
 }
 
@@ -1110,7 +1116,7 @@ describe("workflow detail page", () => {
       expect(buttonByText("Add trigger")).toBeInTheDocument();
     });
     click(buttonByText("Add trigger"));
-    click(menuItemByText(/Schedule/u));
+    click(menuItemByText(/Scheduled time/u));
 
     const createTriggerForm = await screen.findByRole("form", {
       name: "Add schedule trigger",
@@ -1127,6 +1133,40 @@ describe("workflow detail page", () => {
           type: "cron",
           cronExpression: "0 1 * * *",
           timezone: "UTC",
+        },
+      });
+    });
+  });
+
+  it("creates an interval trigger from the trigger menu", async () => {
+    const createBodies: ZeroWorkflowTriggerCreateRequest[] = [];
+    mockWorkflowApis([salesResearch()]);
+    mockCreateWorkflowTrigger((body) => {
+      createBodies.push(body);
+    });
+
+    detachedSetupPage({
+      context,
+      path: workflowDetailPath("triggers"),
+    });
+
+    await waitFor(() => {
+      expect(buttonByText("Add trigger")).toBeInTheDocument();
+    });
+    click(buttonByText("Add trigger"));
+    click(menuItemByText(/^Interval/u));
+
+    const createTriggerForm = await screen.findByRole("form", {
+      name: "Add interval trigger",
+    });
+    selectOptionByLabel("Every", "30 minutes", createTriggerForm);
+    click(buttonByText("Add interval", createTriggerForm));
+
+    await waitFor(() => {
+      expect(createBodies.at(-1)).toStrictEqual({
+        schedule: {
+          type: "loop",
+          intervalSeconds: 1800,
         },
       });
     });
@@ -1217,7 +1257,7 @@ describe("workflow detail page", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText("Every 3600s")).toBeInTheDocument();
+      expect(screen.getByText("Every 1 hour")).toBeInTheDocument();
     });
 
     click(buttonByText("Edit"));
@@ -1225,10 +1265,7 @@ describe("workflow detail page", () => {
     const updateTriggerForm = screen.getByRole("form", {
       name: "Update schedule trigger",
     });
-    await fill(
-      within(updateTriggerForm).getByLabelText("Interval seconds"),
-      "7200",
-    );
+    selectOptionByLabel("Every", "30 minutes", updateTriggerForm);
     fireEvent.submit(updateTriggerForm);
 
     await waitFor(() => {
@@ -1237,7 +1274,7 @@ describe("workflow detail page", () => {
         body: {
           schedule: {
             type: "loop",
-            intervalSeconds: 7200,
+            intervalSeconds: 1800,
           },
         },
       });

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -32,7 +32,6 @@ import {
   IconLoader2,
   IconMail,
   IconMessageCircle,
-  IconPencil,
   IconPlayerPause,
   IconPlayerPlay,
   IconPlus,
@@ -196,9 +195,12 @@ import {
 import {
   agentLabel,
   isMarkdownPath,
-  triggerKindLabel,
   workflowTitle,
 } from "./workflow-shared.tsx";
+import {
+  WorkflowTriggerCard,
+  type WorkflowTriggerCardRow,
+} from "./workflow-trigger-card.tsx";
 
 const FIELD_CLASS =
   "h-9 w-full rounded-md border border-border/60 bg-background px-2.5 text-sm outline-none focus:border-primary";
@@ -2187,6 +2189,19 @@ function buildTriggerSchedule(
       };
 }
 
+function localDateTimeInputValue(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "";
+  }
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const hour = String(date.getHours()).padStart(2, "0");
+  const minute = String(date.getMinutes()).padStart(2, "0");
+  return `${year}-${month}-${day}T${hour}:${minute}`;
+}
+
 function formTextValue(form: FormData, name: string): string | undefined {
   const value = form.get(name);
   if (typeof value !== "string") {
@@ -2593,7 +2608,7 @@ function CreateScheduleTriggerDialog({
             cronFields={cronFields}
             setCronFields={setCronFields}
             displayTimezone={displayTimezone}
-            creating={creating}
+            disabled={creating}
           />
 
           <DialogFooter>
@@ -2625,13 +2640,17 @@ function ScheduleTriggerFields({
   cronFields,
   setCronFields,
   displayTimezone,
-  creating,
+  disabled,
+  defaultIntervalSeconds,
+  defaultAtTime,
 }: {
   readonly scheduleType: ZeroWorkflowScheduleType;
   readonly cronFields: WorkflowCronFields;
   readonly setCronFields: (fields: WorkflowCronFields) => void;
   readonly displayTimezone: string;
-  readonly creating: boolean;
+  readonly disabled: boolean;
+  readonly defaultIntervalSeconds?: number;
+  readonly defaultAtTime?: string;
 }) {
   if (scheduleType === "loop") {
     return (
@@ -2642,8 +2661,8 @@ function ScheduleTriggerFields({
           aria-label="Interval seconds"
           type="number"
           min="1"
-          defaultValue="3600"
-          disabled={creating}
+          defaultValue={String(defaultIntervalSeconds ?? 3600)}
+          disabled={disabled}
           className={FIELD_CLASS}
         />
       </label>
@@ -2658,7 +2677,8 @@ function ScheduleTriggerFields({
           name="atTime"
           aria-label="Run at"
           type="datetime-local"
-          disabled={creating}
+          defaultValue={defaultAtTime}
+          disabled={disabled}
           className={FIELD_CLASS}
         />
         <span className="text-xs text-muted-foreground">
@@ -2673,7 +2693,7 @@ function ScheduleTriggerFields({
       fields={cronFields}
       onChange={setCronFields}
       displayTimezone={displayTimezone}
-      disabled={creating}
+      disabled={disabled}
     />
   );
 }
@@ -3355,165 +3375,66 @@ function TriggerRow({
   const editingTriggerId = useGet(editingWorkflowTriggerId$);
   const setEditingTriggerId = useSet(setEditingWorkflowTriggerId$);
   const editing = editingTriggerId === trigger.id;
-  const title = workflowScheduleTitle(trigger, displayTimezone);
-  const detailRows = triggerDetailRows(trigger, displayTimezone);
-  const TriggerIcon =
-    trigger.kind === "schedule"
-      ? IconClock
-      : isGmailWorkflowTrigger(trigger)
-        ? IconMail
-        : IconLink;
+  const rows = triggerCardRows(trigger, displayTimezone);
 
   return (
-    <article
-      className={cn(
-        "zero-card p-4 transition-colors",
-        !trigger.enabled && "bg-muted/20",
-      )}
-    >
-      <div className="flex min-w-0 items-start gap-3">
-        <span className="flex size-8 shrink-0 items-center justify-center rounded-md border border-border/60 bg-muted/30 text-muted-foreground">
-          <TriggerIcon size={15} stroke={1.5} />
-        </span>
-        <div className="min-w-0 flex-1">
-          <div className="flex min-w-0 flex-wrap items-start justify-between gap-3">
-            <div className="min-w-0">
-              <div className="flex min-w-0 items-center gap-2">
-                <h3
-                  className={cn(
-                    "min-w-0 truncate text-sm font-medium leading-5",
-                    trigger.enabled
-                      ? "text-foreground"
-                      : "text-muted-foreground",
-                  )}
-                >
-                  {title}
-                </h3>
-                <span
-                  className={cn(
-                    "shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-medium",
-                    trigger.enabled
-                      ? "bg-emerald-500/10 text-emerald-700"
-                      : "bg-muted text-muted-foreground",
-                  )}
-                >
-                  {trigger.enabled ? "Enabled" : "Paused"}
-                </span>
-              </div>
-              <p className="mt-0.5 truncate text-xs text-muted-foreground">
-                {triggerKindLabel(trigger)}
-              </p>
-            </div>
-          </div>
-          <dl className="mt-3 divide-y divide-border/50 text-xs">
-            {detailRows.map((row) => {
-              return (
-                <div
-                  key={row.label}
-                  className="flex min-w-0 items-center justify-between gap-3 py-2 first:pt-0 last:pb-0"
-                >
-                  <dt className="shrink-0 text-muted-foreground">
-                    {row.label}
-                  </dt>
-                  <dd className="min-w-0 truncate text-right font-medium text-foreground">
-                    {row.value}
-                  </dd>
-                </div>
-              );
-            })}
-          </dl>
-          {canManage ? (
+    <>
+      <WorkflowTriggerCard
+        rows={rows}
+        dimmed={!trigger.enabled}
+        actions={
+          canManage ? (
             <TriggerControls
               trigger={trigger}
-              editing={editing}
               displayTimezone={displayTimezone}
             />
-          ) : null}
-          {canManage && trigger.kind === "schedule" && editing ? (
-            <UpdateScheduleTriggerForm
-              trigger={trigger}
-              displayTimezone={displayTimezone}
-              onCancel={() => {
-                setEditingTriggerId(null);
-              }}
-            />
-          ) : null}
-          {canManage &&
-          trigger.kind === "event" &&
-          trigger.eventType === "gmail-new-message" &&
-          editing ? (
-            <UpdateGmailNewMessageTriggerForm
-              trigger={trigger}
-              onCancel={() => {
-                setEditingTriggerId(null);
-              }}
-            />
-          ) : null}
-          {canManage &&
-          trigger.kind === "event" &&
-          trigger.eventType === "gmail-label-applied" &&
-          editing ? (
-            <UpdateGmailLabelAppliedTriggerForm
-              trigger={trigger}
-              onCancel={() => {
-                setEditingTriggerId(null);
-              }}
-            />
-          ) : null}
-        </div>
-      </div>
-    </article>
+          ) : null
+        }
+      />
+      {canManage ? (
+        <EditWorkflowTriggerDialog
+          trigger={trigger}
+          displayTimezone={displayTimezone}
+          open={editing}
+          onOpenChange={(open) => {
+            if (!open) {
+              setEditingTriggerId(null);
+            }
+          }}
+        />
+      ) : null}
+    </>
   );
 }
 
-function triggerDetailRows(
+function triggerCardRows(
   trigger: ZeroWorkflowTriggerSummary,
   displayTimezone: string,
-): readonly {
-  readonly label: string;
-  readonly value: ReactNode;
-}[] {
-  const rows: {
-    readonly label: string;
-    readonly value: ReactNode;
-  }[] = [
+): readonly WorkflowTriggerCardRow[] {
+  const rows: WorkflowTriggerCardRow[] = [
+    {
+      label: trigger.kind === "schedule" ? "Schedule" : "Trigger",
+      value: workflowScheduleTitle(trigger, displayTimezone),
+    },
     {
       label: "Last run",
       value: formatWorkflowTriggerRun(trigger.lastRunAt, displayTimezone),
     },
-  ];
-
-  if (trigger.nextRunAt) {
-    rows.unshift({
+    {
       label: "Next run",
-      value: formatWorkflowTriggerRun(trigger.nextRunAt, displayTimezone),
-    });
-  }
+      value: formatWorkflowTriggerNextRun(trigger.nextRunAt, displayTimezone),
+    },
+  ];
 
   const matchSummary = workflowTriggerSummary(trigger);
   if (matchSummary) {
-    rows.unshift({ label: "Match", value: matchSummary });
+    rows.splice(1, 0, { label: "Match", value: matchSummary });
   }
 
   if (isWebhookWorkflowTrigger(trigger)) {
-    rows.unshift({
+    rows.splice(1, 0, {
       label: "Webhook",
       value: trigger.webhookUrl,
-    });
-  }
-
-  if (trigger.chatThreadId) {
-    rows.unshift({
-      label: "Thread",
-      value: (
-        <Link
-          pathname={ROUTES.chat}
-          options={{ pathParams: { threadId: trigger.chatThreadId } }}
-          className="text-xs font-medium text-muted-foreground underline-offset-4 transition-colors hover:text-foreground hover:underline"
-        >
-          Open thread
-        </Link>
-      ),
     });
   }
 
@@ -3540,26 +3461,15 @@ function formatWorkflowTriggerRun(
   });
 }
 
-function triggerEditLabel(trigger: ZeroWorkflowTriggerSummary): string {
-  if (trigger.kind === "schedule") {
-    return "Edit schedule";
+function formatWorkflowTriggerNextRun(
+  value: string | null,
+  displayTimezone: string,
+): string {
+  if (!value) {
+    return "No upcoming run";
   }
 
-  return trigger.eventType === "gmail-label-applied"
-    ? "Edit label"
-    : "Edit match";
-}
-
-function TriggerEditIcon({
-  trigger,
-}: {
-  readonly trigger: ZeroWorkflowTriggerSummary;
-}) {
-  if (trigger.kind === "schedule") {
-    return <IconClock size={13} stroke={1.5} />;
-  }
-
-  return <IconPencil size={13} stroke={1.5} />;
+  return formatWorkflowTriggerRun(value, displayTimezone);
 }
 
 function TriggerToggleIcon({ enabled }: { readonly enabled: boolean }) {
@@ -3572,11 +3482,9 @@ function TriggerToggleIcon({ enabled }: { readonly enabled: boolean }) {
 
 function TriggerControls({
   trigger,
-  editing,
   displayTimezone,
 }: {
   readonly trigger: ZeroWorkflowTriggerSummary;
-  readonly editing: boolean;
   readonly displayTimezone: string;
 }) {
   const pageSignal = useGet(pageSignal$);
@@ -3594,40 +3502,15 @@ function TriggerControls({
     deleteLoadable.state === "loading" ||
     runNowLoadable.state === "loading";
   const running = runNowLoadable.state === "loading";
-  const canEdit =
-    isGmailWorkflowTrigger(trigger) ||
-    (trigger.kind === "schedule" && trigger.schedule.type === "cron");
+  const canEdit = canEditWorkflowTrigger(trigger);
 
   return (
-    <div className="mt-3 flex min-w-0 flex-wrap items-center justify-end gap-2 border-t border-border/50 pt-3">
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        disabled={busy}
-        className="zero-btn-morandi h-8 gap-1.5 rounded-lg px-3 text-xs font-medium"
-        onClick={() => {
-          detach(
-            runNow(trigger.id, pageSignal),
-            Reason.DomCallback,
-            "run workflow trigger now",
-          );
-        }}
-      >
-        {running ? (
-          <IconLoader2 size={13} className="animate-spin" />
-        ) : (
-          <IconPlayerPlay size={13} stroke={1.5} />
-        )}
-        <span>{running ? "Starting..." : "Trigger now"}</span>
-      </Button>
-      {canEdit && !editing ? (
-        <Button
+    <>
+      {canEdit ? (
+        <button
           type="button"
-          variant="outline"
-          size="sm"
           disabled={busy}
-          className="zero-btn-morandi h-8 gap-1.5 rounded-lg px-3 text-xs font-medium"
+          className="rounded-md px-1 py-1 text-sm font-medium text-muted-foreground underline-offset-4 transition-colors hover:text-foreground hover:underline disabled:opacity-60"
           onClick={() => {
             if (
               trigger.kind === "schedule" &&
@@ -3640,43 +3523,129 @@ function TriggerControls({
             setEditingTriggerId(trigger.id);
           }}
         >
-          <TriggerEditIcon trigger={trigger} />
-          <span>{triggerEditLabel(trigger)}</span>
-        </Button>
+          Edit
+        </button>
       ) : null}
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        disabled={busy}
-        className="zero-btn-morandi h-8 gap-1.5 rounded-lg px-3 text-xs font-medium"
-        onClick={() => {
-          detach(
-            setEnabled(
-              { triggerId: trigger.id, enabled: !trigger.enabled },
-              pageSignal,
-            ),
-            Reason.DomCallback,
-          );
-        }}
+      <div className="ml-auto flex min-w-0 flex-wrap items-center justify-end gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={busy}
+          className="zero-btn-morandi h-8 gap-1.5 rounded-lg px-3 text-xs font-medium"
+          onClick={() => {
+            detach(
+              runNow(trigger.id, pageSignal),
+              Reason.DomCallback,
+              "run workflow trigger now",
+            );
+          }}
+        >
+          {running ? (
+            <IconLoader2 size={13} className="animate-spin" />
+          ) : (
+            <IconPlayerPlay size={13} stroke={1.5} />
+          )}
+          <span>{running ? "Starting..." : "Run now"}</span>
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={busy}
+          className="zero-btn-morandi h-8 gap-1.5 rounded-lg px-3 text-xs font-medium"
+          onClick={() => {
+            detach(
+              setEnabled(
+                { triggerId: trigger.id, enabled: !trigger.enabled },
+                pageSignal,
+              ),
+              Reason.DomCallback,
+            );
+          }}
+        >
+          <TriggerToggleIcon enabled={trigger.enabled} />
+          <span>{trigger.enabled ? "Pause" : "Resume"}</span>
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          disabled={busy}
+          className="h-8 gap-1.5 rounded-lg px-3 text-xs font-medium text-destructive/80 hover:bg-destructive/10 hover:text-destructive"
+          onClick={() => {
+            detach(deleteTrigger(trigger.id, pageSignal), Reason.DomCallback);
+          }}
+        >
+          <IconTrash size={13} stroke={1.5} />
+          <span>Delete</span>
+        </Button>
+      </div>
+    </>
+  );
+}
+
+function canEditWorkflowTrigger(trigger: ZeroWorkflowTriggerSummary): boolean {
+  return trigger.kind === "schedule" || isGmailWorkflowTrigger(trigger);
+}
+
+function editWorkflowTriggerTitle(trigger: ZeroWorkflowTriggerSummary): string {
+  if (trigger.kind === "schedule") {
+    return "Edit schedule";
+  }
+
+  return trigger.eventType === "gmail-label-applied"
+    ? "Edit label"
+    : "Edit match";
+}
+
+function EditWorkflowTriggerDialog({
+  trigger,
+  displayTimezone,
+  open,
+  onOpenChange,
+}: {
+  readonly trigger: ZeroWorkflowTriggerSummary;
+  readonly displayTimezone: string;
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+}) {
+  const close = () => {
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className={isGmailWorkflowTrigger(trigger) ? "max-w-2xl" : ""}
       >
-        <TriggerToggleIcon enabled={trigger.enabled} />
-        <span>{trigger.enabled ? "Pause" : "Resume"}</span>
-      </Button>
-      <Button
-        type="button"
-        variant="ghost"
-        size="sm"
-        disabled={busy}
-        className="h-8 gap-1.5 rounded-lg px-3 text-xs font-medium text-destructive/80 hover:text-destructive"
-        onClick={() => {
-          detach(deleteTrigger(trigger.id, pageSignal), Reason.DomCallback);
-        }}
-      >
-        <IconTrash size={13} stroke={1.5} />
-        <span>Delete</span>
-      </Button>
-    </div>
+        <DialogHeader>
+          <DialogTitle>{editWorkflowTriggerTitle(trigger)}</DialogTitle>
+          <DialogDescription>Update this trigger.</DialogDescription>
+        </DialogHeader>
+        {trigger.kind === "schedule" ? (
+          <UpdateScheduleTriggerForm
+            trigger={trigger}
+            displayTimezone={displayTimezone}
+            onCancel={close}
+          />
+        ) : null}
+        {trigger.kind === "event" &&
+        trigger.eventType === "gmail-new-message" ? (
+          <UpdateGmailNewMessageTriggerForm
+            trigger={trigger}
+            onCancel={close}
+          />
+        ) : null}
+        {trigger.kind === "event" &&
+        trigger.eventType === "gmail-label-applied" ? (
+          <UpdateGmailLabelAppliedTriggerForm
+            trigger={trigger}
+            onCancel={close}
+          />
+        ) : null}
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -3696,18 +3665,25 @@ function UpdateScheduleTriggerForm({
     updateWorkflowScheduleTrigger$,
   );
   const saving = updateLoadable.state === "loading";
+  const schedule = trigger.schedule;
 
   return (
     <form
       aria-label="Update schedule trigger"
-      className="mt-2 rounded-md border border-border/60 bg-background/70 p-2"
+      className="flex flex-col gap-4"
       onSubmit={(event) => {
         event.preventDefault();
-        const cronExpression = buildUtcCronExpressionFromFields(
-          cronFields,
+        const form = new FormData(event.currentTarget);
+        const scheduleValue = buildTriggerSchedule(
+          schedule.type,
+          {
+            cronFields,
+            intervalSeconds: String(form.get("intervalSeconds") ?? ""),
+            atTime: String(form.get("atTime") ?? ""),
+          },
           displayTimezone,
         );
-        if (!cronExpression) {
+        if (!scheduleValue) {
           return;
         }
         detach(
@@ -3715,11 +3691,7 @@ function UpdateScheduleTriggerForm({
             await updateScheduleTrigger(
               {
                 triggerId: trigger.id,
-                schedule: {
-                  type: "cron",
-                  cronExpression,
-                  timezone: TRIGGER_TIMEZONE,
-                },
+                schedule: scheduleValue,
               },
               pageSignal,
             );
@@ -3729,37 +3701,39 @@ function UpdateScheduleTriggerForm({
         );
       }}
     >
-      <WorkflowCronFieldsForm
-        fields={cronFields}
-        onChange={setCronFields}
+      <ScheduleTriggerFields
+        scheduleType={schedule.type}
+        cronFields={cronFields}
+        setCronFields={setCronFields}
         displayTimezone={displayTimezone}
+        defaultIntervalSeconds={
+          schedule.type === "loop" ? schedule.intervalSeconds : undefined
+        }
+        defaultAtTime={
+          schedule.type === "once"
+            ? localDateTimeInputValue(schedule.atTime)
+            : undefined
+        }
         disabled={saving}
       />
-      <div className="mt-2 flex items-center gap-2">
-        <button
-          type="submit"
+      <DialogFooter>
+        <Button
+          type="button"
+          variant="outline"
           disabled={saving}
-          className={cn(
-            "zero-btn-morandi inline-flex h-8 shrink-0 items-center justify-center gap-1.5 rounded-md px-2 text-xs",
-            saving ? "cursor-not-allowed opacity-60" : "",
-          )}
+          onClick={onCancel}
         >
+          Cancel
+        </Button>
+        <Button type="submit" disabled={saving}>
           {saving ? (
             <IconLoader2 size={13} className="animate-spin" />
           ) : (
             <IconClock size={13} stroke={1.5} />
           )}
           <span>Save schedule</span>
-        </button>
-        <button
-          type="button"
-          disabled={saving}
-          className="text-xs text-muted-foreground transition-colors hover:text-foreground disabled:opacity-60"
-          onClick={onCancel}
-        >
-          Cancel
-        </button>
-      </div>
+        </Button>
+      </DialogFooter>
     </form>
   );
 }
@@ -3783,7 +3757,7 @@ function UpdateGmailNewMessageTriggerForm({
   return (
     <form
       aria-label="Update Gmail new message trigger"
-      className="mt-2 rounded-md border border-border/60 bg-background/70 p-2"
+      className="flex flex-col gap-4"
       onSubmit={(event) => {
         event.preventDefault();
         const form = new FormData(event.currentTarget);
@@ -3837,31 +3811,24 @@ function UpdateGmailNewMessageTriggerForm({
           );
         })}
       </div>
-      <div className="mt-2 flex items-center gap-2">
-        <button
-          type="submit"
+      <DialogFooter>
+        <Button
+          type="button"
+          variant="outline"
           disabled={saving}
-          className={cn(
-            "zero-btn-morandi inline-flex h-8 shrink-0 items-center justify-center gap-1.5 rounded-md px-2 text-xs",
-            saving ? "cursor-not-allowed opacity-60" : "",
-          )}
+          onClick={onCancel}
         >
+          Cancel
+        </Button>
+        <Button type="submit" disabled={saving}>
           {saving ? (
             <IconLoader2 size={13} className="animate-spin" />
           ) : (
             <IconMail size={13} stroke={1.5} />
           )}
           <span>Save match</span>
-        </button>
-        <button
-          type="button"
-          disabled={saving}
-          className="text-xs text-muted-foreground transition-colors hover:text-foreground disabled:opacity-60"
-          onClick={onCancel}
-        >
-          Cancel
-        </button>
-      </div>
+        </Button>
+      </DialogFooter>
     </form>
   );
 }
@@ -3885,7 +3852,7 @@ function UpdateGmailLabelAppliedTriggerForm({
   return (
     <form
       aria-label="Update Gmail label trigger"
-      className="mt-2 rounded-md border border-border/60 bg-background/70 p-2"
+      className="flex flex-col gap-4"
       onSubmit={(event) => {
         event.preventDefault();
         const form = new FormData(event.currentTarget);
@@ -3920,31 +3887,24 @@ function UpdateGmailLabelAppliedTriggerForm({
           className={TRIGGER_FIELD_CLASS}
         />
       </label>
-      <div className="mt-2 flex items-center gap-2">
-        <button
-          type="submit"
+      <DialogFooter>
+        <Button
+          type="button"
+          variant="outline"
           disabled={saving}
-          className={cn(
-            "zero-btn-morandi inline-flex h-8 shrink-0 items-center justify-center gap-1.5 rounded-md px-2 text-xs",
-            saving ? "cursor-not-allowed opacity-60" : "",
-          )}
+          onClick={onCancel}
         >
+          Cancel
+        </Button>
+        <Button type="submit" disabled={saving}>
           {saving ? (
             <IconLoader2 size={13} className="animate-spin" />
           ) : (
             <IconMail size={13} stroke={1.5} />
           )}
           <span>Save label</span>
-        </button>
-        <button
-          type="button"
-          disabled={saving}
-          className="text-xs text-muted-foreground transition-colors hover:text-foreground disabled:opacity-60"
-          onClick={onCancel}
-        >
-          Cancel
-        </button>
-      </div>
+        </Button>
+      </DialogFooter>
     </form>
   );
 }

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -35,6 +35,7 @@ import {
   IconPlayerPause,
   IconPlayerPlay,
   IconPlus,
+  IconRepeat,
   IconShieldLock,
   IconTrash,
   IconUpload,
@@ -93,13 +94,11 @@ import {
   reloadWorkflows$,
   resetWorkflowMetadataForm$,
   runWorkflowTriggerNow$,
-  scheduleTriggerType$,
   selectedWorkflowFilePath$,
   setCreateScheduleCronFields$,
   setCreatedWorkflowWebhookTrigger$,
   setEditingScheduleCronFields$,
   setEditingWorkflowTriggerId$,
-  setScheduleTriggerType$,
   setSelectedWorkflowFilePath$,
   setWorkflowActionDialog$,
   setWorkflowAuthorizedConnectors$,
@@ -194,6 +193,8 @@ import {
 } from "../team-page/zero-job-detail-page.tsx";
 import {
   agentLabel,
+  formatWorkflowIntervalSeconds,
+  getWorkflowIntervalSecondOptions,
   isMarkdownPath,
   workflowTitle,
 } from "./workflow-shared.tsx";
@@ -2114,7 +2115,7 @@ function workflowScheduleTitle(
   }
   const schedule = trigger.schedule;
   if (schedule.type === "loop") {
-    return `Every ${schedule.intervalSeconds}s`;
+    return `Every ${formatWorkflowIntervalSeconds(schedule.intervalSeconds)}`;
   }
   if (schedule.type === "once") {
     const { date, hour, minute } = atTimeInTimezone(
@@ -2339,7 +2340,12 @@ function gmailMatcherDefaultValue(
   return config.match?.[field]?.[key] ?? "";
 }
 
-type TriggerCreateDialogKind = "schedule" | "gmail" | "gmail-label" | "webhook";
+type TriggerCreateDialogKind =
+  | "interval"
+  | "scheduled"
+  | "gmail"
+  | "gmail-label"
+  | "webhook";
 
 function TriggerCreateMenu({
   onSelect,
@@ -2363,7 +2369,25 @@ function TriggerCreateMenu({
         <DropdownMenuItem
           className="items-start gap-2 py-2"
           onSelect={() => {
-            onSelect("schedule");
+            onSelect("interval");
+          }}
+        >
+          <IconRepeat
+            size={15}
+            stroke={1.5}
+            className="mt-0.5 shrink-0 text-muted-foreground"
+          />
+          <span className="min-w-0">
+            <span className="block text-sm font-medium">Interval</span>
+            <span className="block text-xs text-muted-foreground">
+              Run this workflow on a fixed interval.
+            </span>
+          </span>
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          className="items-start gap-2 py-2"
+          onSelect={() => {
+            onSelect("scheduled");
           }}
         >
           <IconClock
@@ -2372,7 +2396,7 @@ function TriggerCreateMenu({
             className="mt-0.5 shrink-0 text-muted-foreground"
           />
           <span className="min-w-0">
-            <span className="block text-sm font-medium">Schedule</span>
+            <span className="block text-sm font-medium">Scheduled time</span>
             <span className="block text-xs text-muted-foreground">
               Run this workflow from a time rule.
             </span>
@@ -2490,12 +2514,19 @@ function TriggersSection({
           </div>
         )}
       </div>
-      <CreateScheduleTriggerDialog
+      <CreateIntervalTriggerDialog
+        workflowId={detail.id}
+        open={createDialog === "interval"}
+        onOpenChange={(open) => {
+          setCreateDialog(open ? "interval" : null);
+        }}
+      />
+      <CreateScheduledTriggerDialog
         workflowId={detail.id}
         displayTimezone={displayTimezone}
-        open={createDialog === "schedule"}
+        open={createDialog === "scheduled"}
         onOpenChange={(open) => {
-          setCreateDialog(open ? "schedule" : null);
+          setCreateDialog(open ? "scheduled" : null);
         }}
       />
       <CreateGmailNewMessageTriggerDialog
@@ -2523,7 +2554,87 @@ function TriggersSection({
   );
 }
 
-function CreateScheduleTriggerDialog({
+function CreateIntervalTriggerDialog({
+  workflowId,
+  open,
+  onOpenChange,
+}: {
+  readonly workflowId: string;
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+}) {
+  const pageSignal = useGet(pageSignal$);
+  const [createLoadable, createScheduleTrigger] = useLoadableSet(
+    createWorkflowScheduleTrigger$,
+  );
+  const creating = createLoadable.state === "loading";
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add interval trigger</DialogTitle>
+          <DialogDescription>
+            Choose how often this workflow should run.
+          </DialogDescription>
+        </DialogHeader>
+        <form
+          aria-label="Add interval trigger"
+          className="flex flex-col gap-4"
+          onSubmit={(event) => {
+            event.preventDefault();
+            const form = new FormData(event.currentTarget);
+            const schedule = buildTriggerSchedule(
+              "loop",
+              {
+                cronFields: defaultWorkflowCronFields(),
+                intervalSeconds: String(form.get("intervalSeconds") ?? ""),
+                atTime: "",
+              },
+              TRIGGER_TIMEZONE,
+            );
+            if (!schedule) {
+              return;
+            }
+            detach(
+              (async () => {
+                await createScheduleTrigger(
+                  { workflowId, schedule },
+                  pageSignal,
+                );
+                onOpenChange(false);
+              })(),
+              Reason.DomCallback,
+            );
+          }}
+        >
+          <WorkflowIntervalField disabled={creating} />
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={creating}
+              onClick={() => {
+                onOpenChange(false);
+              }}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={creating}>
+              {creating ? (
+                <IconLoader2 size={14} className="animate-spin" />
+              ) : null}
+              Add interval
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function CreateScheduledTriggerDialog({
   workflowId,
   displayTimezone,
   open,
@@ -2534,8 +2645,6 @@ function CreateScheduleTriggerDialog({
   readonly open: boolean;
   readonly onOpenChange: (open: boolean) => void;
 }) {
-  const scheduleType = useGet(scheduleTriggerType$);
-  const setScheduleType = useSet(setScheduleTriggerType$);
   const cronFields = useGet(createScheduleCronFields$);
   const setCronFields = useSet(setCreateScheduleCronFields$);
   const pageSignal = useGet(pageSignal$);
@@ -2560,10 +2669,10 @@ function CreateScheduleTriggerDialog({
             event.preventDefault();
             const form = new FormData(event.currentTarget);
             const schedule = buildTriggerSchedule(
-              scheduleType,
+              "cron",
               {
                 cronFields,
-                intervalSeconds: String(form.get("intervalSeconds") ?? ""),
+                intervalSeconds: "",
                 atTime: String(form.get("atTime") ?? ""),
               },
               displayTimezone,
@@ -2583,28 +2692,8 @@ function CreateScheduleTriggerDialog({
             );
           }}
         >
-          <label className="flex flex-col gap-1 text-xs text-muted-foreground">
-            Schedule type
-            <Select
-              value={scheduleType}
-              disabled={creating}
-              onValueChange={(value) => {
-                setScheduleType(value as ZeroWorkflowScheduleType);
-              }}
-            >
-              <SelectTrigger className="h-9 w-full">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="cron">Repeat with cron</SelectItem>
-                <SelectItem value="loop">Loop every interval</SelectItem>
-                <SelectItem value="once">Run once</SelectItem>
-              </SelectContent>
-            </Select>
-          </label>
-
           <ScheduleTriggerFields
-            scheduleType={scheduleType}
+            scheduleType="cron"
             cronFields={cronFields}
             setCronFields={setCronFields}
             displayTimezone={displayTimezone}
@@ -2654,18 +2743,10 @@ function ScheduleTriggerFields({
 }) {
   if (scheduleType === "loop") {
     return (
-      <label className="flex flex-col gap-1 text-xs text-muted-foreground">
-        Interval seconds
-        <input
-          name="intervalSeconds"
-          aria-label="Interval seconds"
-          type="number"
-          min="1"
-          defaultValue={String(defaultIntervalSeconds ?? 3600)}
-          disabled={disabled}
-          className={FIELD_CLASS}
-        />
-      </label>
+      <WorkflowIntervalField
+        disabled={disabled}
+        defaultIntervalSeconds={defaultIntervalSeconds}
+      />
     );
   }
 
@@ -2695,6 +2776,40 @@ function ScheduleTriggerFields({
       displayTimezone={displayTimezone}
       disabled={disabled}
     />
+  );
+}
+
+function WorkflowIntervalField({
+  disabled,
+  defaultIntervalSeconds = 15 * 60,
+}: {
+  readonly disabled: boolean;
+  readonly defaultIntervalSeconds?: number;
+}) {
+  return (
+    <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+      Every
+      <Select
+        name="intervalSeconds"
+        defaultValue={String(defaultIntervalSeconds)}
+        disabled={disabled}
+      >
+        <SelectTrigger className="h-9 w-full" aria-label="Every">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {getWorkflowIntervalSecondOptions(defaultIntervalSeconds).map(
+            (seconds) => {
+              return (
+                <SelectItem key={seconds} value={String(seconds)}>
+                  {formatWorkflowIntervalSeconds(seconds)}
+                </SelectItem>
+              );
+            },
+          )}
+        </SelectContent>
+      </Select>
+    </label>
   );
 }
 

--- a/turbo/apps/platform/src/views/workflows-page/workflow-shared.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-shared.tsx
@@ -24,6 +24,36 @@ export function agentLabel(workflow: {
   return workflow.agentDisplayName ?? workflow.agentName ?? workflow.agentId;
 }
 
+const WORKFLOW_INTERVAL_SECONDS_OPTIONS = [5, 15, 30, 60].map((minutes) => {
+  return minutes * 60;
+});
+
+export function getWorkflowIntervalSecondOptions(
+  currentSeconds?: number,
+): readonly number[] {
+  if (
+    currentSeconds === undefined ||
+    WORKFLOW_INTERVAL_SECONDS_OPTIONS.includes(currentSeconds)
+  ) {
+    return WORKFLOW_INTERVAL_SECONDS_OPTIONS;
+  }
+  return [...WORKFLOW_INTERVAL_SECONDS_OPTIONS, currentSeconds].sort((a, b) => {
+    return a - b;
+  });
+}
+
+export function formatWorkflowIntervalSeconds(seconds: number): string {
+  if (seconds % 3600 === 0) {
+    const hours = seconds / 3600;
+    return `${hours} ${hours === 1 ? "hour" : "hours"}`;
+  }
+  if (seconds % 60 === 0) {
+    const minutes = seconds / 60;
+    return `${minutes} ${minutes === 1 ? "minute" : "minutes"}`;
+  }
+  return `${seconds} ${seconds === 1 ? "second" : "seconds"}`;
+}
+
 export function triggerKindLabel(trigger: ZeroWorkflowTriggerSummary): string {
   if (trigger.kind === "schedule") {
     return "Schedule trigger";

--- a/turbo/apps/platform/src/views/workflows-page/workflow-trigger-card.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-trigger-card.tsx
@@ -1,0 +1,55 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@vm0/ui";
+
+export interface WorkflowTriggerCardRow {
+  readonly label: string;
+  readonly value: ReactNode;
+}
+
+interface WorkflowTriggerCardProps {
+  readonly rows: readonly WorkflowTriggerCardRow[];
+  readonly actions?: ReactNode;
+  readonly dimmed?: boolean;
+  readonly className?: string;
+}
+
+export function WorkflowTriggerCard({
+  rows,
+  actions,
+  dimmed,
+  className,
+}: WorkflowTriggerCardProps) {
+  return (
+    <article
+      className={cn(
+        "zero-card overflow-hidden transition-colors",
+        dimmed && "opacity-75",
+        className,
+      )}
+    >
+      <dl className="px-5 py-1">
+        {rows.map((row) => {
+          return (
+            <div
+              key={row.label}
+              className="flex min-w-0 items-center justify-between gap-3 border-b border-border/50 py-3 last:border-b-0"
+            >
+              <dt className="shrink-0 text-sm text-muted-foreground">
+                {row.label}
+              </dt>
+              <dd className="min-w-0 truncate text-right text-sm font-medium text-foreground">
+                {row.value}
+              </dd>
+            </div>
+          );
+        })}
+      </dl>
+      {actions ? (
+        <div className="flex min-w-0 items-center justify-between gap-2 px-5 pb-4 pt-2">
+          {actions}
+        </div>
+      ) : null}
+    </article>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -3081,6 +3081,13 @@ describe("chat lifecycle", () => {
         screen.getByRole("dialog", { name: "Edit trigger" }),
       ).toBeInTheDocument();
     });
+    const editDialog = screen.getByRole("dialog", { name: "Edit trigger" });
+    expect(
+      within(editDialog).getByRole("combobox", { name: "Every" }),
+    ).toHaveTextContent("1 minute");
+    expect(
+      within(editDialog).queryByLabelText("Interval seconds"),
+    ).not.toBeInTheDocument();
   });
 
   it("folds goal-state markers into the goal row beneath the queued messages", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -3060,11 +3060,27 @@ describe("chat lifecycle", () => {
     });
 
     const sidebar = screen.getByTestId("automation-sidebar");
-    // The workflow trigger card shows its name and description.
     expect(within(sidebar).getByText("Nightly sync")).toBeInTheDocument();
+    expect(within(sidebar).getByText("View")).toBeInTheDocument();
+    expect(within(sidebar).getAllByText("Schedule").length).toBeGreaterThan(0);
+    expect(within(sidebar).getByText("Every 1 minute")).toBeInTheDocument();
+    expect(within(sidebar).getByText("Last run")).toBeInTheDocument();
+    expect(within(sidebar).getByText("No runs yet")).toBeInTheDocument();
+    expect(within(sidebar).getAllByText("Next run").length).toBeGreaterThan(0);
     expect(
-      within(sidebar).getByText("Sync the changelog every night"),
-    ).toBeInTheDocument();
+      within(sidebar).getAllByText("No upcoming run").length,
+    ).toBeGreaterThan(0);
+    expect(
+      within(sidebar).queryByText("Authorization"),
+    ).not.toBeInTheDocument();
+
+    click(within(sidebar).getAllByText("Edit").at(-1)!);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("dialog", { name: "Edit trigger" }),
+      ).toBeInTheDocument();
+    });
   });
 
   it("folds goal-state markers into the goal row beneath the queued messages", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -32,6 +32,10 @@ import {
 import { zeroQueuePositionContract } from "@vm0/api-contracts/contracts/zero-queue-position";
 import { zeroGoalsContract } from "@vm0/api-contracts/contracts/zero-goals";
 import {
+  zeroWorkflowTriggersContract,
+  type ZeroWorkflowTriggerUpdateRequest,
+} from "@vm0/api-contracts/contracts/zero-workflows";
+import {
   createMockAutomationView,
   createMockWorkflowTrigger,
   setMockWorkflowTriggers,
@@ -399,6 +403,41 @@ function mockAutomationThread(): void {
   ]);
 }
 
+function mockWorkflowTriggerUpdate(
+  onUpdate: (triggerId: string, body: ZeroWorkflowTriggerUpdateRequest) => void,
+): void {
+  context.mocks.api(
+    zeroWorkflowTriggersContract.update,
+    ({ body, params, respond }) => {
+      onUpdate(params.id, body);
+      if ("schedule" in body) {
+        return respond(
+          200,
+          createMockWorkflowTrigger({
+            id: params.id,
+            chatThreadId: AUTOMATION_THREAD_ID,
+            kind: "schedule",
+            schedule: body.schedule,
+          }),
+        );
+      }
+      return respond(
+        200,
+        createMockWorkflowTrigger({
+          id: params.id,
+          chatThreadId: AUTOMATION_THREAD_ID,
+          kind: "event",
+          eventType:
+            body.eventConfig.event === "label_applied"
+              ? "gmail-label-applied"
+              : "gmail-new-message",
+          eventConfig: body.eventConfig,
+        }),
+      );
+    },
+  );
+}
+
 function mockServerQueuedThreadStories(): void {
   const threads = [
     {
@@ -708,14 +747,41 @@ function setupGithubPrTrackingPage(): void {
   });
 }
 
-function buttonByText(text: string): HTMLElement {
-  const button = queryAllByRoleFast("button").find((candidate) => {
+function buttonByText(text: string, container?: ParentNode): HTMLElement {
+  const button = queryAllByRoleFast("button", container).find((candidate) => {
     return candidate.textContent?.replace(/\s+/g, " ").trim() === text;
   });
   if (!button) {
     throw new Error(`${text} button not found`);
   }
   return button;
+}
+
+async function openAutomationSidebarWithWorkflowTrigger(
+  trigger: ReturnType<typeof createMockWorkflowTrigger>,
+): Promise<HTMLElement> {
+  mockAutomationThread();
+  setMockWorkflowTriggers([trigger]);
+  context.mocks.api(chatThreadArtifactsContract.list, ({ respond }) => {
+    return respond(200, { runs: [] });
+  });
+
+  detachedSetupPage({
+    context,
+    path: `/chats/${AUTOMATION_THREAD_ID}`,
+  });
+
+  await waitFor(() => {
+    expect(buttonByLabel("Automations")).toBeInTheDocument();
+  });
+
+  click(buttonByLabel("Automations"));
+
+  await waitFor(() => {
+    expect(screen.getByTestId("automation-sidebar")).toBeInTheDocument();
+  });
+
+  return screen.getByTestId("automation-sidebar");
 }
 
 function buttonByLabel(label: string): HTMLElement {
@@ -3088,6 +3154,134 @@ describe("chat lifecycle", () => {
     expect(
       within(editDialog).queryByLabelText("Interval seconds"),
     ).not.toBeInTheDocument();
+  });
+
+  it("updates a schedule workflow trigger from the sidebar", async () => {
+    const updateBodies: {
+      readonly triggerId: string;
+      readonly body: ZeroWorkflowTriggerUpdateRequest;
+    }[] = [];
+    const sidebar = await openAutomationSidebarWithWorkflowTrigger(
+      createMockWorkflowTrigger({
+        id: "e0000001-0000-4000-a000-000000000003",
+        chatThreadId: AUTOMATION_THREAD_ID,
+        kind: "schedule",
+        schedule: { type: "loop", intervalSeconds: 3600 },
+        scheduleSummary: "Every 3600s",
+      }),
+    );
+    mockWorkflowTriggerUpdate((triggerId, body) => {
+      updateBodies.push({ triggerId, body });
+    });
+
+    click(within(sidebar).getAllByText("Edit").at(-1)!);
+
+    const dialog = await screen.findByRole("dialog", { name: "Edit trigger" });
+    await fill(within(dialog).getByLabelText("Interval seconds"), "7200");
+    click(buttonByText("Save trigger", dialog));
+
+    await waitFor(() => {
+      expect(updateBodies.at(-1)).toStrictEqual({
+        triggerId: "e0000001-0000-4000-a000-000000000003",
+        body: {
+          schedule: {
+            type: "loop",
+            intervalSeconds: 7200,
+          },
+        },
+      });
+    });
+  });
+
+  it("updates a Gmail workflow trigger match from the sidebar", async () => {
+    const updateBodies: {
+      readonly triggerId: string;
+      readonly body: ZeroWorkflowTriggerUpdateRequest;
+    }[] = [];
+    const sidebar = await openAutomationSidebarWithWorkflowTrigger(
+      createMockWorkflowTrigger({
+        id: "e0000001-0000-4000-a000-000000000004",
+        chatThreadId: AUTOMATION_THREAD_ID,
+        kind: "event",
+        eventType: "gmail-new-message",
+        eventConfig: {
+          provider: "gmail",
+          event: "new_message",
+          match: {
+            subject: { doesNotContain: "newsletter" },
+          },
+        },
+      }),
+    );
+    mockWorkflowTriggerUpdate((triggerId, body) => {
+      updateBodies.push({ triggerId, body });
+    });
+
+    click(within(sidebar).getAllByText("Edit").at(-1)!);
+
+    const dialog = await screen.findByRole("dialog", { name: "Edit trigger" });
+    await fill(within(dialog).getByLabelText("From contains"), "@acme.com");
+    await fill(within(dialog).getByLabelText("Body contains"), "invoice");
+    click(buttonByText("Save trigger", dialog));
+
+    await waitFor(() => {
+      expect(updateBodies.at(-1)).toStrictEqual({
+        triggerId: "e0000001-0000-4000-a000-000000000004",
+        body: {
+          eventConfig: {
+            provider: "gmail",
+            event: "new_message",
+            match: {
+              from: { contains: "@acme.com" },
+              subject: { doesNotContain: "newsletter" },
+              body: { contains: "invoice" },
+            },
+          },
+        },
+      });
+    });
+  });
+
+  it("updates a Gmail label workflow trigger from the sidebar", async () => {
+    const updateBodies: {
+      readonly triggerId: string;
+      readonly body: ZeroWorkflowTriggerUpdateRequest;
+    }[] = [];
+    const sidebar = await openAutomationSidebarWithWorkflowTrigger(
+      createMockWorkflowTrigger({
+        id: "e0000001-0000-4000-a000-000000000005",
+        chatThreadId: AUTOMATION_THREAD_ID,
+        kind: "event",
+        eventType: "gmail-label-applied",
+        eventConfig: {
+          provider: "gmail",
+          event: "label_applied",
+          labelName: "Support",
+        },
+      }),
+    );
+    mockWorkflowTriggerUpdate((triggerId, body) => {
+      updateBodies.push({ triggerId, body });
+    });
+
+    click(within(sidebar).getAllByText("Edit").at(-1)!);
+
+    const dialog = await screen.findByRole("dialog", { name: "Edit trigger" });
+    await fill(within(dialog).getByLabelText("Label name"), "Escalated");
+    click(buttonByText("Save trigger", dialog));
+
+    await waitFor(() => {
+      expect(updateBodies.at(-1)).toStrictEqual({
+        triggerId: "e0000001-0000-4000-a000-000000000005",
+        body: {
+          eventConfig: {
+            provider: "gmail",
+            event: "label_applied",
+            labelName: "Escalated",
+          },
+        },
+      });
+    });
   });
 
   it("folds goal-state markers into the goal row beneath the queued messages", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -757,6 +757,21 @@ function buttonByText(text: string, container?: ParentNode): HTMLElement {
   return button;
 }
 
+function selectOptionByLabel(
+  label: string,
+  option: string | RegExp,
+  container: HTMLElement,
+): void {
+  const control =
+    within(container)
+      .getAllByLabelText(label)
+      .find((element) => {
+        return element.getAttribute("role") === "combobox";
+      }) ?? within(container).getByLabelText(label);
+  click(control);
+  click(screen.getByRole("option", { name: option }));
+}
+
 async function openAutomationSidebarWithWorkflowTrigger(
   trigger: ReturnType<typeof createMockWorkflowTrigger>,
 ): Promise<HTMLElement> {
@@ -3177,7 +3192,7 @@ describe("chat lifecycle", () => {
     click(within(sidebar).getAllByText("Edit").at(-1)!);
 
     const dialog = await screen.findByRole("dialog", { name: "Edit trigger" });
-    await fill(within(dialog).getByLabelText("Interval seconds"), "7200");
+    selectOptionByLabel("Every", "30 minutes", dialog);
     click(buttonByText("Save trigger", dialog));
 
     await waitFor(() => {
@@ -3186,7 +3201,7 @@ describe("chat lifecycle", () => {
         body: {
           schedule: {
             type: "loop",
-            intervalSeconds: 7200,
+            intervalSeconds: 1800,
           },
         },
       });

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -1,5 +1,6 @@
 import type {
   CSSProperties,
+  FormEvent,
   KeyboardEvent as ReactKeyboardEvent,
   MouseEvent as ReactMouseEvent,
   PointerEvent as ReactPointerEvent,
@@ -49,7 +50,6 @@ import {
   IconClock,
   IconCoins,
   IconHourglass,
-  IconKey,
 } from "@tabler/icons-react";
 import {
   cn,
@@ -61,6 +61,12 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
   Popover,
   PopoverContent,
   PopoverTrigger,
@@ -76,6 +82,10 @@ import type {
   GenerationTemplateRequest,
   ChatThreadGithubPr,
 } from "@vm0/api-contracts/contracts/chat-threads";
+import type {
+  ChatThreadWorkflowTrigger,
+  ZeroWorkflowSchedule,
+} from "@vm0/api-contracts/contracts/zero-workflows";
 import {
   ILLUSTRATION_TEMPLATE_ITEMS,
   PRESENTATION_TEMPLATE_ITEMS,
@@ -192,8 +202,11 @@ import {
 import {
   headerAutomationMenu$,
   headerWorkflowTriggersForThread,
+  runHeaderWorkflowTriggerNow$,
   reloadHeaderAutomationMenu$,
-  toggleWorkflowTriggerEnabled$,
+  updateHeaderWorkflowGmailLabelAppliedTrigger$,
+  updateHeaderWorkflowGmailNewMessageTrigger$,
+  updateHeaderWorkflowScheduleTrigger$,
   automationsForThread,
   type HeaderAutomationEntry,
   type HeaderWorkflowTriggerEntry,
@@ -201,8 +214,10 @@ import {
 import { pauseChatThreadGoal$ } from "../../signals/chat-page/chat-goal.ts";
 import {
   closeHeaderAutomationSidebar$,
+  currentEditingHeaderWorkflowTriggerId$,
   currentHeaderAutomationThreadId$,
   openHeaderAutomationSidebar$,
+  setEditingHeaderWorkflowTriggerId$,
 } from "../../signals/chat-page/header-automation-sidebar.ts";
 import {
   runAutomationNow$,
@@ -216,9 +231,21 @@ import { Link } from "../router/link.tsx";
 import { ROUTES } from "../../signals/route-paths.ts";
 import { WORKFLOW_DETAIL_TAB_PARAM } from "../../signals/workflows-page/workflows-signals.ts";
 import {
+  atTimeInTimezone,
+  cronWallTimeInTimezone,
+} from "../../signals/zero-page/cron.ts";
+import {
+  buildGmailLabelAppliedEventConfig,
+  buildGmailNewMessageEventConfig,
+  GMAIL_TEXT_FIELDS,
+  gmailMatcherDefaultValue,
   gmailTriggerSummary,
   gmailTriggerTitle,
 } from "../workflows-page/workflow-shared.tsx";
+import {
+  WorkflowTriggerCard,
+  type WorkflowTriggerCardRow,
+} from "../workflows-page/workflow-trigger-card.tsx";
 
 import type {
   EnrichedChatMessage,
@@ -2011,6 +2038,127 @@ function formatHeaderWorkflowTriggerRun(value: string | null): string {
   });
 }
 
+function formatHeaderWorkflowTriggerNextRun(value: string | null): string {
+  if (!value) {
+    return "No upcoming run";
+  }
+  return formatHeaderWorkflowTriggerRun(value);
+}
+
+function formatHeaderClockTime(hour: number, minute: number): string {
+  const ampm = hour >= 12 ? "PM" : "AM";
+  const h12 = hour === 0 ? 12 : hour > 12 ? hour - 12 : hour;
+  return `${h12}:${String(minute).padStart(2, "0")} ${ampm}`;
+}
+
+function formatHeaderIntervalSeconds(seconds: number): string {
+  if (seconds % 3600 === 0) {
+    const hours = seconds / 3600;
+    return `Every ${hours} ${hours === 1 ? "hour" : "hours"}`;
+  }
+  if (seconds % 60 === 0) {
+    const minutes = seconds / 60;
+    return `Every ${minutes} ${minutes === 1 ? "minute" : "minutes"}`;
+  }
+  return `Every ${seconds} ${seconds === 1 ? "second" : "seconds"}`;
+}
+
+function headerCronRuleLabel(
+  cronExpression: string,
+  sourceTimezone: string,
+  displayTimezone: string,
+): string {
+  const [minutePart, hourPart, dayOfMonth = "*", , dayOfWeek = "*"] =
+    cronExpression.split(" ");
+  const minute = Number(minutePart);
+  const hour = Number(hourPart);
+  if (!Number.isFinite(hour) || !Number.isFinite(minute)) {
+    return `${cronExpression} (${sourceTimezone})`;
+  }
+  const converted = cronWallTimeInTimezone(
+    hour,
+    minute,
+    sourceTimezone,
+    displayTimezone,
+  );
+  const time = formatHeaderClockTime(converted.hour, converted.minute);
+  if (dayOfMonth !== "*") {
+    return `Every month on day ${dayOfMonth} at ${time}`;
+  }
+  if (dayOfWeek === "1-5") {
+    return `Every weekday at ${time}`;
+  }
+  if (dayOfWeek !== "*") {
+    const dayNames: Readonly<Record<string, string>> = {
+      "0": "Sunday",
+      "1": "Monday",
+      "2": "Tuesday",
+      "3": "Wednesday",
+      "4": "Thursday",
+      "5": "Friday",
+      "6": "Saturday",
+    };
+    const days = dayOfWeek
+      .split(",")
+      .map((day) => {
+        return dayNames[day];
+      })
+      .filter(Boolean)
+      .join(", ");
+    return days ? `Every week on ${days} at ${time}` : `Every week at ${time}`;
+  }
+  return `Every day at ${time}`;
+}
+
+function headerWorkflowTriggerRule(
+  trigger: HeaderWorkflowTriggerEntry,
+): string {
+  const source = trigger.trigger;
+  if (source.kind !== "schedule") {
+    return gmailTriggerTitle(source);
+  }
+  const schedule = source.schedule;
+  if (schedule.type === "loop") {
+    return formatHeaderIntervalSeconds(schedule.intervalSeconds);
+  }
+  if (schedule.type === "once") {
+    const { date, hour, minute } = atTimeInTimezone(
+      schedule.atTime,
+      trigger.timezone,
+    );
+    return `Once on ${date} at ${formatHeaderClockTime(hour, minute)}`;
+  }
+  return headerCronRuleLabel(
+    schedule.cronExpression,
+    schedule.timezone,
+    trigger.timezone,
+  );
+}
+
+function headerWorkflowTriggerRows(
+  trigger: HeaderWorkflowTriggerEntry,
+): readonly WorkflowTriggerCardRow[] {
+  const rows: WorkflowTriggerCardRow[] = [
+    {
+      label: trigger.trigger.kind === "schedule" ? "Schedule" : "Trigger",
+      value: headerWorkflowTriggerRule(trigger),
+    },
+    {
+      label: "Last run",
+      value: formatHeaderWorkflowTriggerRun(trigger.trigger.lastRunAt),
+    },
+    {
+      label: "Next run",
+      value: formatHeaderWorkflowTriggerNextRun(trigger.trigger.nextRunAt),
+    },
+  ];
+  const matchSummary = gmailTriggerSummary(trigger.trigger);
+  if (matchSummary) {
+    rows.splice(1, 0, { label: "Match", value: matchSummary });
+  }
+  return rows;
+}
+
 function HeaderAutomationSidebarCard({
   automation,
 }: {
@@ -2132,151 +2280,462 @@ function HeaderAutomationSidebarCard({
   );
 }
 
-function HeaderWorkflowTriggerDetails({
-  trigger,
-}: {
-  readonly trigger: HeaderWorkflowTriggerEntry;
-}) {
-  const triggerTitle = gmailTriggerTitle(trigger.trigger);
-  const triggerSummary = gmailTriggerSummary(trigger.trigger);
-  const summaryLabel =
-    trigger.trigger.kind === "event" &&
-    trigger.trigger.eventType === "gmail-label-applied"
-      ? "Label"
-      : "Match";
-  const summaryValue =
-    trigger.trigger.kind === "event" &&
-    trigger.trigger.eventType === "gmail-label-applied"
-      ? trigger.trigger.eventConfig.labelName
-      : triggerSummary;
-
-  return (
-    <dl className="mt-3 text-xs">
-      <div className="flex items-center justify-between gap-3 border-b border-border/50 py-2.5">
-        <dt className="shrink-0 text-muted-foreground">Trigger</dt>
-        <dd className="min-w-0 truncate text-right font-medium text-foreground">
-          {triggerTitle}
-        </dd>
-      </div>
-      {summaryValue ? (
-        <div className="flex items-center justify-between gap-3 border-b border-border/50 py-2.5">
-          <dt className="shrink-0 text-muted-foreground">{summaryLabel}</dt>
-          <dd className="min-w-0 truncate text-right font-medium text-foreground">
-            {summaryValue}
-          </dd>
-        </div>
-      ) : null}
-      <div className="flex items-center justify-between gap-3 py-2.5">
-        <dt className="shrink-0 text-muted-foreground">Last run</dt>
-        <dd className="min-w-0 truncate text-right font-medium text-foreground">
-          {formatHeaderWorkflowTriggerRun(trigger.trigger.lastRunAt)}
-        </dd>
-      </div>
-    </dl>
-  );
-}
-
-function HeaderWorkflowTriggerActions({
-  trigger,
-}: {
-  readonly trigger: HeaderWorkflowTriggerEntry;
-}) {
-  return (
-    <div className="mt-4 grid min-w-0 grid-cols-2 gap-2">
-      <Link
-        pathname={ROUTES.agentWorkflowDetail}
-        options={{
-          pathParams: {
-            agentId: trigger.workflowAgentId,
-            workflowId: trigger.workflowId,
-          },
-          searchParams: new URLSearchParams({
-            [WORKFLOW_DETAIL_TAB_PARAM]: "authorization",
-          }),
-        }}
-        className="zero-btn-morandi inline-flex h-8 items-center justify-center gap-1.5 rounded-lg border px-3 text-xs font-medium text-foreground transition-colors hover:bg-accent"
-      >
-        <IconKey size={13} stroke={1.5} />
-        Authorization
-      </Link>
-      <Link
-        pathname={ROUTES.agentWorkflowDetail}
-        options={{
-          pathParams: {
-            agentId: trigger.workflowAgentId,
-            workflowId: trigger.workflowId,
-          },
-          searchParams: new URLSearchParams({
-            [WORKFLOW_DETAIL_TAB_PARAM]: "triggers",
-          }),
-        }}
-        className="zero-btn-morandi inline-flex h-8 items-center justify-center gap-1.5 rounded-lg border px-3 text-xs font-medium text-foreground transition-colors hover:bg-accent"
-      >
-        <IconArrowUpRight size={13} stroke={1.5} />
-        Triggers
-      </Link>
-    </div>
-  );
-}
-
 function HeaderWorkflowTriggerCard({
   trigger,
 }: {
   trigger: HeaderWorkflowTriggerEntry;
 }) {
   const pageSignal = useGet(pageSignal$);
-  const [togglingLoadable, toggleEnabledTracked] = useLoadableSet(
-    toggleWorkflowTriggerEnabled$,
+  const editingTriggerId = useGet(currentEditingHeaderWorkflowTriggerId$);
+  const setEditingTriggerId = useSet(setEditingHeaderWorkflowTriggerId$);
+  const [runningLoadable, runNow] = useLoadableSet(
+    runHeaderWorkflowTriggerNow$,
   );
-  const toggling = togglingLoadable.state === "loading";
+  const running = runningLoadable.state === "loading";
   const title = trigger.workflowDisplayName?.trim() || trigger.workflowName;
-  const description = trigger.workflowDescription?.trim();
-
-  const toggleEnabled = (enabled: boolean) => {
-    detach(
-      toggleEnabledTracked({ triggerId: trigger.id, enabled }, pageSignal),
-      Reason.DomCallback,
-      "toggle workflow trigger enabled",
-    );
-  };
+  const rows = headerWorkflowTriggerRows(trigger);
+  const editing = editingTriggerId === trigger.id;
 
   return (
-    <article
-      className={cn(
-        "rounded-lg border border-border bg-background p-4 transition-colors",
-        !trigger.enabled && "opacity-75",
-      )}
-    >
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0">
-          <p
-            className={cn(
-              "line-clamp-1 text-sm font-medium leading-snug",
-              trigger.enabled ? "text-foreground" : "text-muted-foreground",
-            )}
-          >
-            {title}
-          </p>
-          {description ? (
-            <p className="mt-1 line-clamp-3 text-xs text-muted-foreground">
-              {description}
-            </p>
-          ) : null}
-        </div>
-        <LoadingSwitch
-          checked={trigger.enabled}
-          loading={toggling}
-          onCheckedChange={toggleEnabled}
-          ariaLabel={`${trigger.enabled ? "Disable" : "Enable"} ${title}`}
-        />
+    <div className="min-w-0">
+      <div className="mb-2 flex min-w-0 items-center justify-between gap-3">
+        <p className="min-w-0 truncate text-sm font-normal leading-snug text-muted-foreground">
+          {title}
+        </p>
+        <Link
+          pathname={ROUTES.agentWorkflowDetail}
+          options={{
+            pathParams: {
+              agentId: trigger.workflowAgentId,
+              workflowId: trigger.workflowId,
+            },
+            searchParams: new URLSearchParams({
+              [WORKFLOW_DETAIL_TAB_PARAM]: "triggers",
+            }),
+          }}
+          className="inline-flex h-7 shrink-0 items-center gap-1 rounded-md px-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-gray-50 hover:text-foreground"
+        >
+          View
+          <IconArrowUpRight size={12} stroke={1.5} />
+        </Link>
       </div>
-
-      <HeaderWorkflowTriggerDetails trigger={trigger} />
-      <HeaderWorkflowTriggerActions trigger={trigger} />
-    </article>
+      <WorkflowTriggerCard
+        rows={rows}
+        dimmed={!trigger.enabled}
+        actions={
+          <>
+            <button
+              type="button"
+              className="rounded-md px-1 py-1 text-sm font-medium text-muted-foreground underline-offset-4 transition-colors hover:text-foreground hover:underline"
+              onClick={() => {
+                setEditingTriggerId(trigger.id);
+              }}
+            >
+              Edit
+            </button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="zero-btn-morandi h-8 shrink-0 gap-1.5 rounded-lg px-3 text-xs font-medium"
+              disabled={running}
+              onClick={() => {
+                detach(
+                  runNow(trigger.id, pageSignal),
+                  Reason.DomCallback,
+                  "run header workflow trigger now",
+                );
+              }}
+            >
+              {running ? (
+                <IconLoader2 size={13} className="animate-spin" />
+              ) : (
+                <IconPlayerPlay size={13} stroke={1.5} />
+              )}
+              {running ? "Starting..." : "Run now"}
+            </Button>
+          </>
+        }
+      />
+      <HeaderWorkflowTriggerEditDialog
+        trigger={trigger.trigger}
+        displayTimezone={trigger.timezone}
+        open={editing}
+        onOpenChange={(open) => {
+          setEditingTriggerId(open ? trigger.id : null);
+        }}
+      />
+    </div>
   );
 }
 
+function HeaderWorkflowTriggerEditDialog({
+  trigger,
+  displayTimezone,
+  open,
+  onOpenChange,
+}: {
+  readonly trigger: ChatThreadWorkflowTrigger;
+  readonly displayTimezone: string;
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className={
+          trigger.kind === "event" && trigger.eventType === "gmail-new-message"
+            ? "max-w-2xl"
+            : ""
+        }
+      >
+        <DialogHeader>
+          <DialogTitle>Edit trigger</DialogTitle>
+          <DialogDescription>Update this workflow trigger.</DialogDescription>
+        </DialogHeader>
+        {trigger.kind === "schedule" ? (
+          <HeaderScheduleTriggerEditForm
+            trigger={trigger}
+            displayTimezone={displayTimezone}
+            onDone={() => {
+              onOpenChange(false);
+            }}
+          />
+        ) : null}
+        {trigger.kind === "event" &&
+        trigger.eventType === "gmail-new-message" ? (
+          <HeaderGmailNewMessageTriggerEditForm
+            trigger={trigger}
+            onDone={() => {
+              onOpenChange(false);
+            }}
+          />
+        ) : null}
+        {trigger.kind === "event" &&
+        trigger.eventType === "gmail-label-applied" ? (
+          <HeaderGmailLabelTriggerEditForm
+            trigger={trigger}
+            onDone={() => {
+              onOpenChange(false);
+            }}
+          />
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+const HEADER_TRIGGER_FIELD_CLASS =
+  "h-9 w-full rounded-md border border-border/60 bg-background px-2.5 text-sm outline-none transition-colors focus:border-primary disabled:opacity-60";
+
+function localDateTimeInputValue(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "";
+  }
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const hour = String(date.getHours()).padStart(2, "0");
+  const minute = String(date.getMinutes()).padStart(2, "0");
+  return `${year}-${month}-${day}T${hour}:${minute}`;
+}
+
+function scheduleFromHeaderTriggerForm(
+  trigger: Extract<ChatThreadWorkflowTrigger, { kind: "schedule" }>,
+  form: FormData,
+): ZeroWorkflowSchedule | null {
+  const schedule = trigger.schedule;
+  if (schedule.type === "loop") {
+    const intervalSeconds = Number(form.get("intervalSeconds"));
+    return Number.isInteger(intervalSeconds) && intervalSeconds > 0
+      ? { type: "loop", intervalSeconds }
+      : null;
+  }
+  if (schedule.type === "once") {
+    const rawAtTime = String(form.get("atTime") ?? "");
+    if (!rawAtTime) {
+      return null;
+    }
+    const atTime = new Date(rawAtTime);
+    return Number.isNaN(atTime.getTime())
+      ? null
+      : {
+          type: "once",
+          atTime: atTime.toISOString(),
+          timezone: schedule.timezone,
+        };
+  }
+  const cronExpression = String(form.get("cronExpression") ?? "").trim();
+  return cronExpression
+    ? {
+        type: "cron",
+        cronExpression,
+        timezone: schedule.timezone,
+      }
+    : null;
+}
+
+function HeaderScheduleTriggerEditForm({
+  trigger,
+  displayTimezone,
+  onDone,
+}: {
+  readonly trigger: Extract<ChatThreadWorkflowTrigger, { kind: "schedule" }>;
+  readonly displayTimezone: string;
+  readonly onDone: () => void;
+}) {
+  const pageSignal = useGet(pageSignal$);
+  const [updateLoadable, updateTrigger] = useLoadableSet(
+    updateHeaderWorkflowScheduleTrigger$,
+  );
+  const saving = updateLoadable.state === "loading";
+  const schedule = trigger.schedule;
+
+  return (
+    <form
+      className="flex flex-col gap-4"
+      onSubmit={(event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        const scheduleValue = scheduleFromHeaderTriggerForm(
+          trigger,
+          new FormData(event.currentTarget),
+        );
+        if (!scheduleValue) {
+          return;
+        }
+        detach(
+          (async () => {
+            await updateTrigger(
+              { triggerId: trigger.id, schedule: scheduleValue },
+              pageSignal,
+            );
+            onDone();
+          })(),
+          Reason.DomCallback,
+          "update header workflow schedule trigger",
+        );
+      }}
+    >
+      {schedule.type === "loop" ? (
+        <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+          Interval seconds
+          <input
+            name="intervalSeconds"
+            aria-label="Interval seconds"
+            type="number"
+            min="1"
+            defaultValue={schedule.intervalSeconds}
+            disabled={saving}
+            className={HEADER_TRIGGER_FIELD_CLASS}
+          />
+        </label>
+      ) : null}
+      {schedule.type === "once" ? (
+        <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+          Run at
+          <input
+            name="atTime"
+            aria-label="Run at"
+            type="datetime-local"
+            defaultValue={localDateTimeInputValue(schedule.atTime)}
+            disabled={saving}
+            className={HEADER_TRIGGER_FIELD_CLASS}
+          />
+          <span>Displays in {displayTimezone}</span>
+        </label>
+      ) : null}
+      {schedule.type === "cron" ? (
+        <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+          Cron expression
+          <input
+            name="cronExpression"
+            aria-label="Cron expression"
+            defaultValue={schedule.cronExpression}
+            disabled={saving}
+            className={HEADER_TRIGGER_FIELD_CLASS}
+          />
+          <span>Runs in {schedule.timezone}</span>
+        </label>
+      ) : null}
+      <DialogFooter>
+        <Button
+          type="button"
+          variant="outline"
+          disabled={saving}
+          onClick={onDone}
+        >
+          Cancel
+        </Button>
+        <Button type="submit" disabled={saving}>
+          {saving ? <IconLoader2 size={14} className="animate-spin" /> : null}
+          Save trigger
+        </Button>
+      </DialogFooter>
+    </form>
+  );
+}
+
+function HeaderGmailNewMessageTriggerEditForm({
+  trigger,
+  onDone,
+}: {
+  readonly trigger: Extract<
+    ChatThreadWorkflowTrigger,
+    { eventType: "gmail-new-message" }
+  >;
+  readonly onDone: () => void;
+}) {
+  const pageSignal = useGet(pageSignal$);
+  const [updateLoadable, updateTrigger] = useLoadableSet(
+    updateHeaderWorkflowGmailNewMessageTrigger$,
+  );
+  const saving = updateLoadable.state === "loading";
+
+  return (
+    <form
+      className="flex flex-col gap-4"
+      onSubmit={(event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        const form = new FormData(event.currentTarget);
+        detach(
+          (async () => {
+            await updateTrigger(
+              {
+                triggerId: trigger.id,
+                eventConfig: buildGmailNewMessageEventConfig(
+                  form,
+                  trigger.eventConfig,
+                ),
+              },
+              pageSignal,
+            );
+            onDone();
+          })(),
+          Reason.DomCallback,
+          "update header workflow Gmail trigger",
+        );
+      }}
+    >
+      <div className="grid gap-3 sm:grid-cols-2">
+        {GMAIL_TEXT_FIELDS.map(({ field, label }) => {
+          return (
+            <div key={field} className="grid grid-cols-2 gap-2">
+              <input
+                name={`${field}Contains`}
+                aria-label={`${label} contains`}
+                defaultValue={gmailMatcherDefaultValue(
+                  trigger.eventConfig,
+                  field,
+                  "contains",
+                )}
+                disabled={saving}
+                placeholder={`${label} contains`}
+                className={HEADER_TRIGGER_FIELD_CLASS}
+              />
+              <input
+                name={`${field}DoesNotContain`}
+                aria-label={`${label} does not contain`}
+                defaultValue={gmailMatcherDefaultValue(
+                  trigger.eventConfig,
+                  field,
+                  "doesNotContain",
+                )}
+                disabled={saving}
+                placeholder={`${label} does not contain`}
+                className={HEADER_TRIGGER_FIELD_CLASS}
+              />
+            </div>
+          );
+        })}
+      </div>
+      <DialogFooter>
+        <Button
+          type="button"
+          variant="outline"
+          disabled={saving}
+          onClick={onDone}
+        >
+          Cancel
+        </Button>
+        <Button type="submit" disabled={saving}>
+          {saving ? <IconLoader2 size={14} className="animate-spin" /> : null}
+          Save trigger
+        </Button>
+      </DialogFooter>
+    </form>
+  );
+}
+
+function HeaderGmailLabelTriggerEditForm({
+  trigger,
+  onDone,
+}: {
+  readonly trigger: Extract<
+    ChatThreadWorkflowTrigger,
+    { eventType: "gmail-label-applied" }
+  >;
+  readonly onDone: () => void;
+}) {
+  const pageSignal = useGet(pageSignal$);
+  const [updateLoadable, updateTrigger] = useLoadableSet(
+    updateHeaderWorkflowGmailLabelAppliedTrigger$,
+  );
+  const saving = updateLoadable.state === "loading";
+
+  return (
+    <form
+      className="flex flex-col gap-4"
+      onSubmit={(event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        const eventConfig = buildGmailLabelAppliedEventConfig(
+          new FormData(event.currentTarget),
+        );
+        if (!eventConfig) {
+          return;
+        }
+        detach(
+          (async () => {
+            await updateTrigger(
+              { triggerId: trigger.id, eventConfig },
+              pageSignal,
+            );
+            onDone();
+          })(),
+          Reason.DomCallback,
+          "update header workflow Gmail label trigger",
+        );
+      }}
+    >
+      <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+        Label name
+        <input
+          name="labelName"
+          aria-label="Label name"
+          required
+          defaultValue={trigger.eventConfig.labelName}
+          disabled={saving}
+          placeholder="Support"
+          className={HEADER_TRIGGER_FIELD_CLASS}
+        />
+      </label>
+      <DialogFooter>
+        <Button
+          type="button"
+          variant="outline"
+          disabled={saving}
+          onClick={onDone}
+        >
+          Cancel
+        </Button>
+        <Button type="submit" disabled={saving}>
+          {saving ? <IconLoader2 size={14} className="animate-spin" /> : null}
+          Save trigger
+        </Button>
+      </DialogFooter>
+    </form>
+  );
+}
 function HeaderAutomationSidebar({ threadId }: { threadId: string }) {
   const automationsLoadable = useLastLoadable(headerAutomationMenu$);
   const lastResolvedAutomations = useLastResolved(headerAutomationMenu$);

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -70,6 +70,11 @@ import {
   Popover,
   PopoverContent,
   PopoverTrigger,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
   Tooltip,
   TooltipContent,
   TooltipProvider,
@@ -237,7 +242,9 @@ import {
 import {
   buildGmailLabelAppliedEventConfig,
   buildGmailNewMessageEventConfig,
+  formatWorkflowIntervalSeconds,
   GMAIL_TEXT_FIELDS,
+  getWorkflowIntervalSecondOptions,
   gmailMatcherDefaultValue,
   gmailTriggerSummary,
   gmailTriggerTitle,
@@ -2518,18 +2525,10 @@ function HeaderScheduleTriggerEditForm({
       }}
     >
       {schedule.type === "loop" ? (
-        <label className="flex flex-col gap-1 text-xs text-muted-foreground">
-          Interval seconds
-          <input
-            name="intervalSeconds"
-            aria-label="Interval seconds"
-            type="number"
-            min="1"
-            defaultValue={schedule.intervalSeconds}
-            disabled={saving}
-            className={HEADER_TRIGGER_FIELD_CLASS}
-          />
-        </label>
+        <HeaderIntervalField
+          disabled={saving}
+          defaultIntervalSeconds={schedule.intervalSeconds}
+        />
       ) : null}
       {schedule.type === "once" ? (
         <label className="flex flex-col gap-1 text-xs text-muted-foreground">
@@ -2573,6 +2572,40 @@ function HeaderScheduleTriggerEditForm({
         </Button>
       </DialogFooter>
     </form>
+  );
+}
+
+function HeaderIntervalField({
+  disabled,
+  defaultIntervalSeconds,
+}: {
+  readonly disabled: boolean;
+  readonly defaultIntervalSeconds: number;
+}) {
+  return (
+    <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+      Every
+      <Select
+        name="intervalSeconds"
+        defaultValue={String(defaultIntervalSeconds)}
+        disabled={disabled}
+      >
+        <SelectTrigger className="h-9 w-full" aria-label="Every">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {getWorkflowIntervalSecondOptions(defaultIntervalSeconds).map(
+            (seconds) => {
+              return (
+                <SelectItem key={seconds} value={String(seconds)}>
+                  {formatWorkflowIntervalSeconds(seconds)}
+                </SelectItem>
+              );
+            },
+          )}
+        </SelectContent>
+      </Select>
+    </label>
   );
 }
 


### PR DESCRIPTION
## Summary
- Redesign workflow trigger cards in the chat automation sidebar around the selected after direction
- Share the trigger card structure with the workflow detail triggers tab
- Move trigger editing behind dialogs and support schedule loop/once/cron edits where applicable

## Tests
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app lint
- pnpm exec vitest run src/views/workflows-page/__tests__/workflows-page.test.tsx --reporter=verbose
- pnpm exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx -t "lists workflow triggers in the sidebar" --reporter=verbose
- git diff --check