### PR TITLE
fix: match slash workflows by slug prefix

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/slash-workflow.test.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/slash-workflow.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { matchesWorkflowNameQuery } from "../slash-workflow-match.ts";
+
+describe("slash workflow matching", () => {
+  it("matches only slug prefixes", () => {
+    expect(matchesWorkflowNameQuery("pr-auto", "")).toBe(true);
+    expect(matchesWorkflowNameQuery("pr-auto", "pr")).toBe(true);
+    expect(matchesWorkflowNameQuery("pr-auto", "PR-AUTO")).toBe(true);
+    expect(
+      matchesWorkflowNameQuery("ai-slop-fallback-cleanup", "pr-auto"),
+    ).toBe(false);
+    expect(matchesWorkflowNameQuery("pull-request-helper", "pr-auto")).toBe(
+      false,
+    );
+    expect(matchesWorkflowNameQuery("my-pr-auto", "pr-auto")).toBe(false);
+    expect(matchesWorkflowNameQuery("pr-implement", "pr-auto")).toBe(false);
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/slash-workflow.test.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/slash-workflow.test.ts
@@ -3,16 +3,16 @@ import { matchesWorkflowNameQuery } from "../slash-workflow-match.ts";
 
 describe("slash workflow matching", () => {
   it("matches only slug prefixes", () => {
-    expect(matchesWorkflowNameQuery("pr-auto", "")).toBe(true);
-    expect(matchesWorkflowNameQuery("pr-auto", "pr")).toBe(true);
-    expect(matchesWorkflowNameQuery("pr-auto", "PR-AUTO")).toBe(true);
+    expect(matchesWorkflowNameQuery("pr-auto", "")).toBeTruthy();
+    expect(matchesWorkflowNameQuery("pr-auto", "pr")).toBeTruthy();
+    expect(matchesWorkflowNameQuery("pr-auto", "PR-AUTO")).toBeTruthy();
     expect(
       matchesWorkflowNameQuery("ai-slop-fallback-cleanup", "pr-auto"),
-    ).toBe(false);
-    expect(matchesWorkflowNameQuery("pull-request-helper", "pr-auto")).toBe(
-      false,
-    );
-    expect(matchesWorkflowNameQuery("my-pr-auto", "pr-auto")).toBe(false);
-    expect(matchesWorkflowNameQuery("pr-implement", "pr-auto")).toBe(false);
+    ).toBeFalsy();
+    expect(
+      matchesWorkflowNameQuery("pull-request-helper", "pr-auto"),
+    ).toBeFalsy();
+    expect(matchesWorkflowNameQuery("my-pr-auto", "pr-auto")).toBeFalsy();
+    expect(matchesWorkflowNameQuery("pr-implement", "pr-auto")).toBeFalsy();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/slash-workflow-match.ts
+++ b/turbo/apps/platform/src/views/zero-page/slash-workflow-match.ts
@@ -1,0 +1,10 @@
+export function matchesWorkflowNameQuery(
+  workflowName: string,
+  query: string,
+): boolean {
+  if (!query) {
+    return true;
+  }
+
+  return workflowName.toLowerCase().startsWith(query.toLowerCase());
+}

--- a/turbo/apps/platform/src/views/zero-page/slash-workflow.tsx
+++ b/turbo/apps/platform/src/views/zero-page/slash-workflow.tsx
@@ -6,6 +6,7 @@ import type { ZeroWorkflowSummary } from "@vm0/api-contracts/contracts/zero-work
 import { cn, PopoverContent } from "@vm0/ui";
 import { ROUTES } from "../../signals/route-paths.ts";
 import { Link } from "../router/link.tsx";
+import { matchesWorkflowNameQuery } from "./slash-workflow-match.ts";
 
 export interface SlashWorkflowRange {
   readonly start: number;
@@ -40,15 +41,7 @@ export function matchesWorkflowQuery(
   workflow: ComposerSlashWorkflow,
   query: string,
 ): boolean {
-  if (!query) {
-    return true;
-  }
-
-  const normalizedQuery = query.toLowerCase();
-  return [workflow.name, workflow.displayName ?? "", workflow.description ?? ""]
-    .join(" ")
-    .toLowerCase()
-    .includes(normalizedQuery);
+  return matchesWorkflowNameQuery(workflow.name, query);
 }
 
 export function workflowTokenPattern(


### PR DESCRIPTION
## Summary
- Restrict slash workflow suggestion filtering to the workflow slug only
- Require the typed slash query to match from the start of the slug
- Add a focused unit test covering description/display-name/infix non-matches

## Tests
- `pnpm exec vitest run src/views/zero-page/__tests__/slash-workflow.test.ts --reporter verbose`