### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1581,9 +1581,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "typenum",
 ]


### PR DESCRIPTION
## Summary

- Updated the Rust workspace lockfile under `crates/`.
- `hybrid-array` was updated from `0.4.12` to `0.4.13`.
- No `Cargo.toml` changes were required.

## Dependencies not updated

- `generic-array` remains at `0.14.7` although Cargo reports `0.14.9` is available. It is transitive and held by `block-buffer 0.10.4`, whose manifest requires `generic-array =0.14.7`; it is not declared directly in this workspace's `Cargo.toml` files.

## Manual version bumps

- None. Direct workspace dependencies were checked against crates.io latest versions and already resolve to the latest versions allowed by their manifest constraints. No safe minor/patch `Cargo.toml` bumps were identified.

## Test status

- Passed: `CARGO_TARGET_DIR=/home/user/workspace/vm0-rust-target CARGO_BUILD_JOBS=1 cargo test --workspace --exclude runner`
- Not fully completed locally: `cargo test --workspace`
  - Initial run failed because `/tmp` ran out of disk space while building test artifacts.
  - Retried with `CARGO_TARGET_DIR=/home/user/workspace/vm0-rust-target`; the full workspace run then failed while linking the `runner` test binary because the linker was killed by the sandbox (`collect2: fatal error: ld terminated with signal 9 [Killed]`).
  - Retried with `CARGO_BUILD_JOBS=1`; the same `runner` test-binary link step failed with `signal 9`.
  - No Rust compiler errors or test assertion failures were observed; all non-`runner` workspace crates passed.
