### PR TITLE
feat: add workflow permission request cards

### DIFF
--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -92,6 +92,10 @@ type ChatMessageRow = {
   readonly workflowName: string | null;
   readonly workflowDisplayName: string | null;
   readonly workflowDescription: string | null;
+  readonly workflowId: string | null;
+  readonly workflowAgentId: string | null;
+  readonly workflowTriggerId: string | null;
+  readonly workflowTriggerBrief: string | null;
 };
 
 type ChatSearchMessageRow = {
@@ -169,6 +173,26 @@ const messageColumns = {
   interruptsRunId: chatMessages.interruptsRunId,
   automationId: chatMessages.automationId,
   automationTitle: chatMessages.automationTitle,
+  workflowId: sql<string | null>`(
+    SELECT "zero_workflows"."id"
+    FROM "zero_runs"
+    INNER JOIN "zero_workflow_triggers"
+      ON "zero_workflow_triggers"."id" = "zero_runs"."workflow_trigger_id"
+    INNER JOIN "zero_workflows"
+      ON "zero_workflows"."id" = "zero_workflow_triggers"."workflow_id"
+    WHERE "zero_runs"."id" = "chat_messages"."run_id"
+    LIMIT 1
+  )`,
+  workflowAgentId: sql<string | null>`(
+    SELECT "zero_workflows"."agent_id"
+    FROM "zero_runs"
+    INNER JOIN "zero_workflow_triggers"
+      ON "zero_workflow_triggers"."id" = "zero_runs"."workflow_trigger_id"
+    INNER JOIN "zero_workflows"
+      ON "zero_workflows"."id" = "zero_workflow_triggers"."workflow_id"
+    WHERE "zero_runs"."id" = "chat_messages"."run_id"
+    LIMIT 1
+  )`,
   workflowName: sql<string | null>`(
     SELECT "zero_workflows"."name"
     FROM "zero_runs"
@@ -196,6 +220,42 @@ const messageColumns = {
       ON "zero_workflow_triggers"."id" = "zero_runs"."workflow_trigger_id"
     INNER JOIN "zero_workflows"
       ON "zero_workflows"."id" = "zero_workflow_triggers"."workflow_id"
+    WHERE "zero_runs"."id" = "chat_messages"."run_id"
+    LIMIT 1
+  )`,
+  workflowTriggerId: sql<string | null>`(
+    SELECT "zero_workflow_triggers"."id"
+    FROM "zero_runs"
+    INNER JOIN "zero_workflow_triggers"
+      ON "zero_workflow_triggers"."id" = "zero_runs"."workflow_trigger_id"
+    WHERE "zero_runs"."id" = "chat_messages"."run_id"
+    LIMIT 1
+  )`,
+  workflowTriggerBrief: sql<string | null>`(
+    SELECT CASE
+      WHEN "zero_workflow_triggers"."kind" = 'schedule'
+        AND "zero_workflow_triggers"."schedule_type" = 'cron'
+        THEN "zero_workflow_triggers"."cron_expression" || ' (' || "zero_workflow_triggers"."timezone" || ')'
+      WHEN "zero_workflow_triggers"."kind" = 'schedule'
+        AND "zero_workflow_triggers"."schedule_type" = 'loop'
+        THEN 'Every ' || "zero_workflow_triggers"."interval_seconds" || 's'
+      WHEN "zero_workflow_triggers"."kind" = 'schedule'
+        AND "zero_workflow_triggers"."schedule_type" = 'once'
+        THEN 'Once at ' || "zero_workflow_triggers"."at_time"
+      WHEN "zero_workflow_triggers"."kind" = 'event'
+        AND "zero_workflow_triggers"."event_type" = 'gmail-label-applied'
+        THEN 'Gmail label applied'
+      WHEN "zero_workflow_triggers"."kind" = 'event'
+        AND "zero_workflow_triggers"."event_type" = 'gmail-new-message'
+        THEN 'Gmail new message'
+      WHEN "zero_workflow_triggers"."kind" = 'event'
+        AND "zero_workflow_triggers"."event_type" = 'webhook-received'
+        THEN 'Webhook trigger'
+      ELSE NULL
+    END
+    FROM "zero_runs"
+    INNER JOIN "zero_workflow_triggers"
+      ON "zero_workflow_triggers"."id" = "zero_runs"."workflow_trigger_id"
     WHERE "zero_runs"."id" = "chat_messages"."run_id"
     LIMIT 1
   )`,
@@ -455,9 +515,13 @@ function toPagedMessage(
       row.workflowName === null
         ? undefined
         : {
+            id: row.workflowId ?? undefined,
+            agentId: row.workflowAgentId ?? undefined,
             name: row.workflowName,
             displayName: row.workflowDisplayName,
             description: row.workflowDescription,
+            triggerId: row.workflowTriggerId ?? undefined,
+            triggerBrief: row.workflowTriggerBrief,
           };
 
     const role = messageRoleSchema.parse(row.role);

--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/permission-change.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/permission-change.test.ts
@@ -57,7 +57,7 @@ describe("zero doctor permission-change command", () => {
     expect(logCalls).not.toContain("admin approval");
   });
 
-  it("deep-links to the workflow authorization tab inside an unattended trigger run", async () => {
+  it("deep-links to the workflow permission page inside an unattended trigger run", async () => {
     vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
     vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
     vi.stubEnv("ZERO_WORKFLOW_ID", "wf-789");
@@ -73,8 +73,11 @@ describe("zero doctor permission-change command", () => {
     ]);
 
     const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-    expect(logCalls).toContain("/agents/agent-abc-123/workflows/wf-789?");
-    expect(logCalls).toContain("tab=authorization");
+    expect(logCalls).toContain(
+      "/agents/agent-abc-123/workflows/wf-789/permissions?",
+    );
+    expect(logCalls).toContain("triggerId=trig-456");
+    expect(logCalls).not.toContain("tab=authorization");
     expect(logCalls).toContain("ref=slack");
     expect(logCalls).toContain(
       `permission=${encodeURIComponent(SLACK_READ_PERMISSION)}`,

--- a/turbo/apps/cli/src/commands/zero/doctor/permission-change.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/permission-change.ts
@@ -161,13 +161,13 @@ async function outputPermissionChangeMessage(
 
   // Trigger-fired runs configure permissions on the workflow-user grant store,
   // shared by all triggers the same user owns for the workflow. Deep-link to
-  // the workflow Authorization tab for the relevant connector and permission.
+  // the workflow permission page for the relevant connector and permission.
   if (triggerContext && agentId) {
     const workflowUrlParams = new URLSearchParams({
-      tab: "authorization",
       ref: connectorRef,
       permission,
       action: action === "enable" ? "allow" : "deny",
+      triggerId: triggerContext.triggerId,
     });
     if (action === "enable") {
       workflowUrlParams.set(
@@ -175,7 +175,7 @@ async function outputPermissionChangeMessage(
         duration ?? DEFAULT_PERMISSION_GRANT_DURATION,
       );
     }
-    const workflowUrl = `${platformOrigin}/agents/${agentId}/workflows/${triggerContext.workflowId}?${workflowUrlParams.toString()}`;
+    const workflowUrl = `${platformOrigin}/agents/${agentId}/workflows/${triggerContext.workflowId}/permissions?${workflowUrlParams.toString()}`;
     printSensitivePermissionGuidance(connectorRef, permission, action);
     printPermissionActionMessage({
       action,

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -32,7 +32,6 @@ import { setupActivityInspectPage$ } from "./activity-page/activity-inspect-page
 import { setupAgentsPage$ } from "./agents-page/agents-page-setup.ts";
 import { setupAgentDetailPage$ } from "./agents-page/agent-detail-page-setup.ts";
 import { setupWorkflowDetailPage$ } from "./workflows-page/workflow-detail-page-setup.ts";
-import { WORKFLOW_DETAIL_TAB_PARAM } from "./workflows-page/workflows-signals.ts";
 import { setupMemoryPage$ } from "./memory-page/memory-page-setup.ts";
 import { setupWorksPage$ } from "./works-page/works-page-setup.ts";
 import { setupPreferencesPage$ } from "./preferences-page/preferences-page-setup.ts";
@@ -102,17 +101,20 @@ const setupWorkflowTriggerPermissionsRedirect$ = command(({ get, set }) => {
   const params = get(pathParams$) ?? {};
   const agentId = params.agentId;
   const workflowId = params.workflowId;
+  const triggerId = params.triggerId;
   if (typeof agentId !== "string" || typeof workflowId !== "string") {
     set(detachedNavigateTo$, ROUTES.agents, { replace: true });
     return;
   }
   const targetSearchParams = new URLSearchParams(get(searchParams$));
-  targetSearchParams.set(WORKFLOW_DETAIL_TAB_PARAM, "authorization");
-  set(detachedNavigateTo$, ROUTES.agentWorkflowDetail, {
+  if (typeof triggerId === "string" && !targetSearchParams.has("triggerId")) {
+    targetSearchParams.set("triggerId", triggerId);
+  }
+  set(detachedNavigateTo$, ROUTES.agentWorkflowPermissions, {
     pathParams: {
       agentId,
       workflowId,
-    } as RouterPathParams<typeof ROUTES.agentWorkflowDetail>,
+    } as RouterPathParams<typeof ROUTES.agentWorkflowPermissions>,
     searchParams: targetSearchParams,
     replace: true,
   });
@@ -186,6 +188,10 @@ const ROUTE_CONFIG = [
   },
   {
     path: ROUTES.agentPermissions,
+    setup: setupAuthPageWrapper(setupPermissionAllowPage$),
+  },
+  {
+    path: ROUTES.agentWorkflowPermissions,
     setup: setupAuthPageWrapper(setupPermissionAllowPage$),
   },
   {

--- a/turbo/apps/platform/src/signals/chat-page/permission-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/permission-action-block.ts
@@ -9,7 +9,10 @@ type PermissionAction = "allow" | "deny";
 type PlatformHostTarget = "api" | "www" | "app" | "platform";
 
 export interface PermissionActionDescriptor {
+  scope: "agent" | "workflow";
   agentId: string;
+  workflowId: string | null;
+  triggerId: string | null;
   connectorRef: FirewallMetadataConnectorType;
   permission: string;
   action: PermissionAction;
@@ -28,7 +31,10 @@ export type PermissionActionBlock = PermissionActionDescriptor & {
 };
 
 function permissionActionHref(descriptor: PermissionActionDescriptor): string {
-  const path = `/agents/${encodeURIComponent(descriptor.agentId)}/permissions`;
+  const path =
+    descriptor.scope === "workflow" && descriptor.workflowId
+      ? `/agents/${encodeURIComponent(descriptor.agentId)}/workflows/${encodeURIComponent(descriptor.workflowId)}/permissions`
+      : `/agents/${encodeURIComponent(descriptor.agentId)}/permissions`;
   return descriptor.search ? `${path}?${descriptor.search}` : path;
 }
 
@@ -152,8 +158,18 @@ export function parsePermissionActionUrl(
     return null;
   }
 
-  const match = url.pathname.match(/^\/agents\/([^/]+)\/permissions$/);
-  const agentId = match?.[1];
+  const workflowMatch = url.pathname.match(
+    /^\/agents\/([^/]+)\/workflows\/([^/]+)(?:\/triggers\/([^/]+))?\/permissions$/,
+  );
+  const agentMatch = url.pathname.match(/^\/agents\/([^/]+)\/permissions$/);
+  const agentId = workflowMatch?.[1] ?? agentMatch?.[1];
+  const workflowId = workflowMatch?.[2] ?? null;
+  const triggerId =
+    workflowMatch?.[3] ?? url.searchParams.get("triggerId") ?? null;
+  const normalizedSearchParams = new URLSearchParams(url.searchParams);
+  if (triggerId && !normalizedSearchParams.has("triggerId")) {
+    normalizedSearchParams.set("triggerId", triggerId);
+  }
   const connectorRef = url.searchParams.get("ref");
   const permission = url.searchParams.get("permission");
   const action = url.searchParams.get("action") ?? "allow";
@@ -176,7 +192,10 @@ export function parsePermissionActionUrl(
   }
 
   return {
+    scope: workflowId ? "workflow" : "agent",
     agentId,
+    workflowId,
+    triggerId,
     connectorRef,
     permission,
     action,
@@ -184,7 +203,7 @@ export function parsePermissionActionUrl(
     path,
     reason,
     expiresIn,
-    search: url.searchParams.toString(),
+    search: normalizedSearchParams.toString(),
     originalUrl: value,
   };
 }

--- a/turbo/apps/platform/src/signals/chat-page/permission-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/permission-action-block.ts
@@ -146,6 +146,52 @@ function isPermissionAction(value: string): value is PermissionAction {
   return value === "allow" || value === "deny";
 }
 
+type ParsedPermissionActionPath = {
+  scope: "agent" | "workflow";
+  agentId: string;
+  workflowId: string | null;
+  triggerId: string | null;
+};
+
+function parsePermissionActionPath(
+  pathname: string,
+): ParsedPermissionActionPath | null {
+  const workflowMatch = pathname.match(
+    /^\/agents\/([^/]+)\/workflows\/([^/]+)(?:\/triggers\/([^/]+))?\/permissions$/,
+  );
+  if (workflowMatch) {
+    return {
+      scope: "workflow",
+      agentId: workflowMatch[1] ?? "",
+      workflowId: workflowMatch[2] ?? "",
+      triggerId: workflowMatch[3] ?? null,
+    };
+  }
+
+  const agentMatch = pathname.match(/^\/agents\/([^/]+)\/permissions$/);
+  if (!agentMatch) {
+    return null;
+  }
+
+  return {
+    scope: "agent",
+    agentId: agentMatch[1] ?? "",
+    workflowId: null,
+    triggerId: null,
+  };
+}
+
+function normalizedPermissionActionSearch(
+  url: URL,
+  triggerId: string | null,
+): string {
+  const normalizedSearchParams = new URLSearchParams(url.searchParams);
+  if (triggerId && !normalizedSearchParams.has("triggerId")) {
+    normalizedSearchParams.set("triggerId", triggerId);
+  }
+  return normalizedSearchParams.toString();
+}
+
 export function parsePermissionActionUrl(
   value: string,
 ): PermissionActionDescriptor | null {
@@ -158,23 +204,16 @@ export function parsePermissionActionUrl(
     return null;
   }
 
-  const workflowMatch = url.pathname.match(
-    /^\/agents\/([^/]+)\/workflows\/([^/]+)(?:\/triggers\/([^/]+))?\/permissions$/,
-  );
-  const agentMatch = url.pathname.match(/^\/agents\/([^/]+)\/permissions$/);
-  const agentId = workflowMatch?.[1] ?? agentMatch?.[1];
-  const workflowId = workflowMatch?.[2] ?? null;
-  const triggerId =
-    workflowMatch?.[3] ?? url.searchParams.get("triggerId") ?? null;
-  const normalizedSearchParams = new URLSearchParams(url.searchParams);
-  if (triggerId && !normalizedSearchParams.has("triggerId")) {
-    normalizedSearchParams.set("triggerId", triggerId);
+  const path = parsePermissionActionPath(url.pathname);
+  if (!path) {
+    return null;
   }
+  const triggerId = path.triggerId ?? url.searchParams.get("triggerId");
   const connectorRef = url.searchParams.get("ref");
   const permission = url.searchParams.get("permission");
   const action = url.searchParams.get("action") ?? "allow";
   const method = url.searchParams.get("method");
-  const path = url.searchParams.get("path");
+  const requestPath = url.searchParams.get("path");
   const reason = url.searchParams.get("reason");
   const expiresIn =
     action === "allow"
@@ -182,7 +221,7 @@ export function parsePermissionActionUrl(
       : null;
 
   if (
-    !agentId ||
+    !path.agentId ||
     !connectorRef ||
     !isFirewallMetadataConnectorType(connectorRef) ||
     !permission ||
@@ -192,18 +231,18 @@ export function parsePermissionActionUrl(
   }
 
   return {
-    scope: workflowId ? "workflow" : "agent",
-    agentId,
-    workflowId,
+    scope: path.scope,
+    agentId: path.agentId,
+    workflowId: path.workflowId,
     triggerId,
     connectorRef,
     permission,
     action,
     method,
-    path,
+    path: requestPath,
     reason,
     expiresIn,
-    search: normalizedSearchParams.toString(),
+    search: normalizedPermissionActionSearch(url, triggerId),
     originalUrl: value,
   };
 }

--- a/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
+++ b/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
@@ -21,6 +21,7 @@ import { pathParams$, searchParams$ } from "../route.ts";
 import { accept } from "../../lib/accept.ts";
 import { agentById, reloadAgentById$ } from "../agent.ts";
 import { retryTransientLoad } from "../utils.ts";
+import { workflowDetail } from "../workflows-page/workflows-signals.ts";
 import { parseUserPermissionGrantExpiresIn } from "./permission-grant-expiration.ts";
 
 // ---------------------------------------------------------------------------
@@ -31,6 +32,12 @@ export const permissionAllowAgentId$ = computed((get) => {
   const params = get(pathParams$);
   const agentId = params?.agentId;
   return typeof agentId === "string" ? agentId : null;
+});
+
+export const permissionAllowWorkflowId$ = computed((get) => {
+  const params = get(pathParams$);
+  const workflowId = params?.workflowId;
+  return typeof workflowId === "string" ? workflowId : null;
 });
 
 export const permissionAllowRef$ = computed((get) => {
@@ -67,6 +74,14 @@ export const permissionAllowAgent$ = computed((get) => {
     return null;
   }
   return get(agentById(agentId));
+});
+
+export const permissionAllowWorkflow$ = computed((get) => {
+  const workflowId = get(permissionAllowWorkflowId$);
+  if (!workflowId) {
+    return null;
+  }
+  return get(workflowDetail(workflowId));
 });
 
 // ---------------------------------------------------------------------------
@@ -159,6 +174,10 @@ export const userPermissionGrantsByWorkflow =
   createUserPermissionGrantsFactory();
 
 export const permissionAllowUserPermissionGrants$ = computed(async (get) => {
+  const workflowId = get(permissionAllowWorkflowId$);
+  if (workflowId) {
+    return await get(userPermissionGrantsByWorkflow({ workflowId }));
+  }
   const agentId = get(permissionAllowAgentId$);
   if (!agentId) {
     return [];
@@ -178,13 +197,20 @@ export const applyUserPermissionGrants$ = command(
     },
     signal: AbortSignal,
   ): Promise<readonly UserPermissionGrantResponse[]> => {
+    const scope =
+      params.workflowId !== undefined
+        ? { workflowId: params.workflowId }
+        : params.agentId !== undefined
+          ? { agentId: params.agentId }
+          : null;
+    if (!scope) {
+      throw new Error("Permission grant scope is required");
+    }
     const client = get(zeroClient$)(zeroUserPermissionGrantsContract);
     const result = await accept(
       client.apply({
         body: {
-          ...(params.workflowId
-            ? { workflowId: params.workflowId }
-            : { agentId: params.agentId ?? "" }),
+          ...scope,
           connectorRef: params.connectorRef,
           mode: params.mode,
           grants: [...params.grants],
@@ -209,7 +235,8 @@ export const applyUserPermissionGrant$ = command(
   async (
     { set },
     params: {
-      agentId: string;
+      agentId?: string;
+      workflowId?: string;
       connectorRef: string;
       permission: string;
       action: UserPermissionGrantAction;
@@ -220,7 +247,9 @@ export const applyUserPermissionGrant$ = command(
     const grants = await set(
       applyUserPermissionGrants$,
       {
-        agentId: params.agentId,
+        ...(params.workflowId !== undefined
+          ? { workflowId: params.workflowId }
+          : { agentId: params.agentId }),
         connectorRef: params.connectorRef,
         mode: "patch",
         grants: [

--- a/turbo/apps/platform/src/signals/route-paths.ts
+++ b/turbo/apps/platform/src/signals/route-paths.ts
@@ -8,6 +8,8 @@ export const ROUTES = {
   agentPermissions: "/agents/:agentId/permissions",
   agentWorkflows: "/agents/:agentId/workflows",
   agentWorkflowDetail: "/agents/:agentId/workflows/:workflowId",
+  agentWorkflowPermissions:
+    "/agents/:agentId/workflows/:workflowId/permissions",
   agentWorkflowTriggerPermissions:
     "/agents/:agentId/workflows/:workflowId/triggers/:triggerId/permissions",
   activities: "/activities",

--- a/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
@@ -1,6 +1,7 @@
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { zeroAgentsByIdContract } from "@vm0/api-contracts/contracts/zero-agents";
+import { zeroWorkflowsDetailContract } from "@vm0/api-contracts/contracts/zero-workflows";
 import {
   zeroUserPermissionGrantsContract,
   type UserPermissionGrantResponse,
@@ -88,6 +89,127 @@ describe("permission allow page", () => {
       screen.getByText("Your connector permission grant has been updated"),
     ).toBeInTheDocument();
     expect(screen.getByText(/Expires in (1 day|24 hours)/)).toBeInTheDocument();
+  });
+
+  it("lets a user grant an expiring connector permission to a workflow", async () => {
+    const agentId = "c0000000-0000-4000-a000-000000000011";
+    const workflowId = "f0000001-0000-4000-a000-000000000911";
+    let capturedBody: unknown = null;
+
+    context.mocks.api(zeroAgentsByIdContract.get, ({ respond }) => {
+      return respond(200, {
+        agentId,
+        ownerId: "test-user-123",
+        description: null,
+        displayName: "Research Bot",
+        sound: null,
+        avatarUrl: null,
+        modelProviderId: null,
+        selectedModel: null,
+        preferPersonalProvider: false,
+      });
+    });
+    context.mocks.api(
+      zeroWorkflowsDetailContract.get,
+      ({ params, respond }) => {
+        if (params.workflowId !== workflowId) {
+          return respond(404, {
+            error: { code: "NOT_FOUND", message: "Workflow not found" },
+          });
+        }
+        return respond(200, {
+          id: workflowId,
+          agentId,
+          agentName: "research-bot",
+          agentDisplayName: "Research Bot",
+          name: "daily-inbox-triage",
+          displayName: "Daily inbox triage",
+          description: null,
+          visibility: "private",
+          requestToPublish: false,
+          ownerUserId: "test-user-123",
+          canManage: true,
+          createdByUserId: "test-user-123",
+          updatedByUserId: "test-user-123",
+          createdAt: "2026-06-09T10:00:00Z",
+          updatedAt: "2026-06-09T10:00:00Z",
+          instruction: null,
+          files: null,
+          fileContents: null,
+          triggers: [],
+        });
+      },
+    );
+    context.mocks.api(
+      zeroUserPermissionGrantsContract.list,
+      ({ query, respond }) => {
+        expect(query).toMatchObject({ workflowId });
+        expect(query).not.toHaveProperty("agentId");
+        return respond(200, []);
+      },
+    );
+    context.mocks.api(
+      zeroUserPermissionGrantsContract.apply,
+      ({ body, respond }) => {
+        const appliedGrant = body.grants[0];
+        if (!appliedGrant) {
+          throw new Error("Expected a permission grant");
+        }
+        capturedBody = body;
+        expect(body).not.toHaveProperty("agentId");
+        return respond(200, [
+          {
+            workflowId: body.workflowId,
+            connectorRef: body.connectorRef,
+            permission: appliedGrant.permission,
+            action: appliedGrant.action,
+            expiresAt: "2026-06-10T10:00:00Z",
+            createdAt: "2026-06-09T10:00:00Z",
+            updatedAt: "2026-06-09T10:01:00Z",
+          },
+        ]);
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${agentId}/workflows/${workflowId}/permissions?ref=slack&permission=admin.analytics%3Aread&action=allow&expiresIn=24h`,
+      user: {
+        id: "test-user-123",
+        fullName: "Dana Analyst",
+        firstName: "Dana",
+      },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "Hey Dana, you're updating your permissions for Daily inbox triage.",
+        ),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByText("Daily inbox triage")).toBeInTheDocument();
+    expect(screen.getByText("Slack")).toBeInTheDocument();
+    expect(screen.getByText("Duration")).toBeInTheDocument();
+    expect(screen.getByText("24 hours")).toBeInTheDocument();
+
+    await user.click(screen.getByText("Confirm"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Permissions updated")).toBeInTheDocument();
+      expect(capturedBody).toMatchObject({
+        workflowId,
+        connectorRef: "slack",
+        mode: "patch",
+        grants: [
+          {
+            permission: "admin.analytics:read",
+            action: "allow",
+            expiresIn: "24h",
+          },
+        ],
+      });
+    });
   });
 
   it("lets a user deny a connector permission without an expiry choice", async () => {

--- a/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
@@ -6,12 +6,18 @@ import {
   IconAlertTriangle,
   IconBan,
   IconCheck,
-  IconGitBranch,
   IconLoader2,
+  IconRoute,
 } from "@tabler/icons-react";
-import type { UserPermissionGrantExpiresIn } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
+import type {
+  UserPermissionGrantExpiresIn,
+  UserPermissionGrantResponse,
+} from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import { CONNECTOR_TYPES } from "@vm0/connectors/connectors";
-import { isFirewallMetadataConnectorType } from "@vm0/connectors/firewall-metadata";
+import {
+  isFirewallMetadataConnectorType,
+  type FirewallPermissionDetailMetadata,
+} from "@vm0/connectors/firewall-metadata";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { user$ } from "../../signals/auth.ts";
 import { firewallPermissionMetadataByConnector } from "../../signals/firewall-permission-metadata.ts";
@@ -61,7 +67,7 @@ function TargetPill({
         />
       ) : (
         <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-muted/60 text-muted-foreground">
-          <IconGitBranch size={18} stroke={1.7} />
+          <IconRoute size={18} stroke={1.7} />
         </span>
       )}
       <span className="text-sm font-medium text-foreground">{displayName}</span>
@@ -81,6 +87,54 @@ type PermissionGrantTarget =
       id: string;
       displayName: string;
     };
+
+type PermissionAllowAgent = {
+  displayName?: string | null;
+  avatarUrl?: string | null;
+} | null;
+
+type PermissionAllowWorkflow = {
+  id: string;
+  displayName?: string | null;
+  name: string;
+} | null;
+
+function resolvePermissionGrantTarget({
+  agentId,
+  agent,
+  workflow,
+  workflowScope,
+}: {
+  agentId: string;
+  agent: PermissionAllowAgent;
+  workflow: PermissionAllowWorkflow;
+  workflowScope: boolean;
+}): { target: PermissionGrantTarget } | { message: string } {
+  if (workflowScope) {
+    if (!workflow) {
+      return { message: "Workflow not found" };
+    }
+    return {
+      target: {
+        kind: "workflow",
+        id: workflow.id,
+        displayName: workflow.displayName ?? workflow.name,
+      },
+    };
+  }
+
+  if (!agent) {
+    return { message: "Agent not found" };
+  }
+  return {
+    target: {
+      kind: "agent",
+      id: agentId,
+      displayName: agent.displayName ?? agentId,
+      avatarUrl: agent.avatarUrl ?? null,
+    },
+  };
+}
 
 function ConnectorPermissionCard({
   connectorRef,
@@ -225,6 +279,77 @@ function resolveUserName(
   return "there";
 }
 
+function anyLoadableIsLoading(
+  loadables: readonly { state: string }[],
+): boolean {
+  return loadables.some((loadable) => {
+    return loadable.state === "loading";
+  });
+}
+
+function permissionAllowLoadErrorMessage({
+  workflowScope,
+  targetState,
+  grantsState,
+  metadataState,
+}: {
+  workflowScope: boolean;
+  targetState: string;
+  grantsState: string;
+  metadataState: string;
+}): string | null {
+  if (targetState === "hasError") {
+    return workflowScope ? "Failed to load workflow" : "Failed to load agent";
+  }
+  if (grantsState === "hasError") {
+    return "Failed to load permission grants";
+  }
+  if (metadataState === "hasError") {
+    return "Failed to load permission metadata";
+  }
+  return null;
+}
+
+function resolveExistingPermissionGrantResult({
+  action,
+  connectorRef,
+  expiresIn,
+  focusedPermission,
+  grants,
+  metadata,
+}: {
+  action: "allow" | "deny";
+  connectorRef: string;
+  expiresIn: UserPermissionGrantExpiresIn | null;
+  focusedPermission: Permission;
+  grants: readonly UserPermissionGrantResponse[];
+  metadata: FirewallPermissionDetailMetadata;
+}): { expiresAt?: string | null } | null {
+  const effectivePolicy = resolveUserPermissionGrantPolicy(
+    grants,
+    metadata,
+    focusedPermission.name,
+  );
+  const explicitGrant = grants.find((grant) => {
+    return (
+      grant.connectorRef === connectorRef &&
+      grant.permission === focusedPermission.name &&
+      grant.action === action
+    );
+  });
+  const requestedExpirationAlreadyApplies =
+    action !== "allow" ||
+    requestedUserPermissionGrantExpirationAlreadyApplies({
+      expiresIn,
+      currentExpiresAt: explicitGrant?.expiresAt,
+    });
+
+  if (effectivePolicy !== action || !requestedExpirationAlreadyApplies) {
+    return null;
+  }
+  return { expiresAt: explicitGrant?.expiresAt };
+}
+
 function ConfirmGrantCard({
   target,
   connectorRef,
@@ -358,41 +483,44 @@ function PermissionAllowDoctorPage({
     firewallPermissionMetadataByConnector({ connectorType: ref }),
   );
   const workflowScope = workflowId !== null;
+  const targetLoadable = workflowScope ? workflowLoadable : agentLoadable;
 
   if (
-    (workflowScope
-      ? workflowLoadable.state === "loading"
-      : agentLoadable.state === "loading") ||
-    userLoadable.state === "loading" ||
-    grantsLoadable.state === "loading" ||
-    metadataLoadable.state === "loading"
+    anyLoadableIsLoading([
+      targetLoadable,
+      userLoadable,
+      grantsLoadable,
+      metadataLoadable,
+    ])
   ) {
     return <LoadingCard />;
   }
 
-  if (!workflowScope && agentLoadable.state === "hasError") {
-    return <ErrorMessage message="Failed to load agent" />;
-  }
-  if (workflowScope && workflowLoadable.state === "hasError") {
-    return <ErrorMessage message="Failed to load workflow" />;
-  }
-  if (grantsLoadable.state === "hasError") {
-    return <ErrorMessage message="Failed to load permission grants" />;
-  }
-  if (metadataLoadable.state === "hasError") {
-    return <ErrorMessage message="Failed to load permission metadata" />;
+  const loadErrorMessage = permissionAllowLoadErrorMessage({
+    workflowScope,
+    targetState: targetLoadable.state,
+    grantsState: grantsLoadable.state,
+    metadataState: metadataLoadable.state,
+  });
+  if (loadErrorMessage) {
+    return <ErrorMessage message={loadErrorMessage} />;
   }
 
   const agent = agentLoadable.state === "hasData" ? agentLoadable.data : null;
   const workflow =
     workflowLoadable.state === "hasData" ? workflowLoadable.data : null;
-  if (!workflowScope && !agent) {
-    return <ErrorMessage message="Agent not found" />;
+  const targetResult = resolvePermissionGrantTarget({
+    agentId,
+    agent,
+    workflow,
+    workflowScope,
+  });
+  if ("message" in targetResult) {
+    return <ErrorMessage message={targetResult.message} />;
   }
-  if (workflowScope && !workflow) {
-    return <ErrorMessage message="Workflow not found" />;
-  }
-  const metadata = metadataLoadable.data;
+
+  const metadata =
+    metadataLoadable.state === "hasData" ? metadataLoadable.data : null;
   if (!metadata) {
     return <ErrorMessage message={`Unknown connector: ${ref}`} />;
   }
@@ -403,29 +531,19 @@ function PermissionAllowDoctorPage({
   }
 
   const grants = grantsLoadable.state === "hasData" ? grantsLoadable.data : [];
-  const effectivePolicy = resolveUserPermissionGrantPolicy(
+  const existingGrantResult = resolveExistingPermissionGrantResult({
+    action,
+    connectorRef: ref,
+    expiresIn: initialExpiresIn,
+    focusedPermission,
     grants,
     metadata,
-    focusedPermission.name,
-  );
-  const explicitGrant = grants.find((grant) => {
-    return (
-      grant.connectorRef === ref &&
-      grant.permission === focusedPermission.name &&
-      grant.action === action
-    );
   });
-  const requestedExpirationAlreadyApplies =
-    action !== "allow" ||
-    requestedUserPermissionGrantExpirationAlreadyApplies({
-      expiresIn: initialExpiresIn,
-      currentExpiresAt: explicitGrant?.expiresAt,
-    });
-  if (effectivePolicy === action && requestedExpirationAlreadyApplies) {
+  if (existingGrantResult) {
     return (
       <ResultCard
         action={action}
-        expiresAt={explicitGrant?.expiresAt}
+        expiresAt={existingGrantResult.expiresAt}
         showExpiry={action === "allow"}
       />
     );
@@ -433,23 +551,9 @@ function PermissionAllowDoctorPage({
 
   const currentUser =
     userLoadable.state === "hasData" ? userLoadable.data : undefined;
-  const target: PermissionGrantTarget =
-    workflowScope && workflow
-      ? {
-          kind: "workflow",
-          id: workflow.id,
-          displayName: workflow.displayName ?? workflow.name,
-        }
-      : {
-          kind: "agent",
-          id: agentId,
-          displayName: agent?.displayName ?? agentId,
-          avatarUrl: agent?.avatarUrl ?? null,
-        };
-
   return (
     <ConfirmGrantCard
-      target={target}
+      target={targetResult.target}
       connectorRef={ref}
       permission={focusedPermission}
       action={action}

--- a/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { useGet, useLastLoadable, useLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { Button } from "@vm0/ui";
@@ -5,6 +6,7 @@ import {
   IconAlertTriangle,
   IconBan,
   IconCheck,
+  IconGitBranch,
   IconLoader2,
 } from "@tabler/icons-react";
 import type { UserPermissionGrantExpiresIn } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
@@ -23,6 +25,8 @@ import {
   permissionAllowPermission$,
   permissionAllowRef$,
   permissionAllowUserPermissionGrants$,
+  permissionAllowWorkflow$,
+  permissionAllowWorkflowId$,
   resolveUserPermissionGrantPolicy,
   type Permission,
   applyUserPermissionGrant$,
@@ -40,24 +44,43 @@ import { PermissionGrantDurationSelect } from "../components/permission-grant-du
 import { ConnectorIcon } from "../zero-page/components/settings/connector-icons.tsx";
 import { AvatarFromUrl } from "../zero-page/zero-sidebar-shared.tsx";
 
-function AgentPill({
+function TargetPill({
   avatarUrl,
   displayName,
 }: {
-  avatarUrl: string | null;
+  avatarUrl?: string | null;
   displayName: string;
 }) {
   return (
     <div className="w-full rounded-lg border border-border bg-muted/30 pl-2 pr-8 py-3 flex items-center gap-2">
-      <AvatarFromUrl
-        avatarUrl={avatarUrl}
-        alt=""
-        className="h-10 w-10 shrink-0 rounded-full object-cover object-top"
-      />
+      {avatarUrl !== undefined ? (
+        <AvatarFromUrl
+          avatarUrl={avatarUrl}
+          alt=""
+          className="h-10 w-10 shrink-0 rounded-full object-cover object-top"
+        />
+      ) : (
+        <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-muted/60 text-muted-foreground">
+          <IconGitBranch size={18} stroke={1.7} />
+        </span>
+      )}
       <span className="text-sm font-medium text-foreground">{displayName}</span>
     </div>
   );
 }
+
+type PermissionGrantTarget =
+  | {
+      kind: "agent";
+      id: string;
+      displayName: string;
+      avatarUrl: string | null;
+    }
+  | {
+      kind: "workflow";
+      id: string;
+      displayName: string;
+    };
 
 function ConnectorPermissionCard({
   connectorRef,
@@ -171,7 +194,7 @@ function ResultCard({
   );
 }
 
-function StatusMessage({ children }: { children: React.ReactNode }) {
+function StatusMessage({ children }: { children: ReactNode }) {
   return (
     <div className="flex flex-1 items-center justify-center text-muted-foreground">
       {children}
@@ -203,26 +226,22 @@ function resolveUserName(
 }
 
 function ConfirmGrantCard({
-  agentId,
+  target,
   connectorRef,
   permission,
   action,
   initialExpiresIn,
-  agentDisplayName,
-  agentAvatarUrl,
   userName,
 }: {
-  agentId: string;
+  target: PermissionGrantTarget;
   connectorRef: string;
   permission: Permission;
   action: "allow" | "deny";
   initialExpiresIn: UserPermissionGrantExpiresIn | null;
-  agentDisplayName: string;
-  agentAvatarUrl: string | null;
   userName: string;
 }) {
   const pageSignal = useGet(pageSignal$);
-  const durationScope = `${agentId}\u0000${connectorRef}\u0000${permission.name}\u0000${action}\u0000${initialExpiresIn ?? ""}`;
+  const durationScope = `${target.kind}\u0000${target.id}\u0000${connectorRef}\u0000${permission.name}\u0000${action}\u0000${initialExpiresIn ?? ""}`;
   const expiresInByScope = useGet(permissionGrantExpiresInByScope$);
   const setExpiresInForScope = useSet(setPermissionGrantExpiresIn$);
   const expiresIn =
@@ -247,7 +266,9 @@ function ConfirmGrantCard({
     detach(
       applyGrant(
         {
-          agentId,
+          ...(target.kind === "workflow"
+            ? { workflowId: target.id }
+            : { agentId: target.id }),
           connectorRef,
           permission: permission.name,
           action,
@@ -266,12 +287,12 @@ function ConfirmGrantCard({
 
         <div className="flex w-[500px] max-w-[calc(100vw-96px)] flex-col items-center gap-4 px-[26px]">
           <p className="text-center text-lg font-medium leading-7 text-foreground">
-            {`Hey ${userName}, you're updating your permissions for ${agentDisplayName}.`}
+            {`Hey ${userName}, you're updating your permissions for ${target.displayName}.`}
           </p>
 
-          <AgentPill
-            avatarUrl={agentAvatarUrl}
-            displayName={agentDisplayName}
+          <TargetPill
+            avatarUrl={target.kind === "agent" ? target.avatarUrl : undefined}
+            displayName={target.displayName}
           />
 
           <div className="w-full flex flex-col gap-3">
@@ -316,26 +337,32 @@ function ConfirmGrantCard({
 
 function PermissionAllowDoctorPage({
   agentId,
+  workflowId,
   ref,
   permission,
   action,
   initialExpiresIn,
 }: {
   agentId: string;
+  workflowId: string | null;
   ref: string;
   permission: string;
   action: "allow" | "deny";
   initialExpiresIn: UserPermissionGrantExpiresIn | null;
 }) {
   const agentLoadable = useLastLoadable(permissionAllowAgent$);
+  const workflowLoadable = useLastLoadable(permissionAllowWorkflow$);
   const userLoadable = useLastLoadable(user$);
   const grantsLoadable = useLastLoadable(permissionAllowUserPermissionGrants$);
   const metadataLoadable = useLoadable(
     firewallPermissionMetadataByConnector({ connectorType: ref }),
   );
+  const workflowScope = workflowId !== null;
 
   if (
-    agentLoadable.state === "loading" ||
+    (workflowScope
+      ? workflowLoadable.state === "loading"
+      : agentLoadable.state === "loading") ||
     userLoadable.state === "loading" ||
     grantsLoadable.state === "loading" ||
     metadataLoadable.state === "loading"
@@ -343,8 +370,11 @@ function PermissionAllowDoctorPage({
     return <LoadingCard />;
   }
 
-  if (agentLoadable.state === "hasError") {
+  if (!workflowScope && agentLoadable.state === "hasError") {
     return <ErrorMessage message="Failed to load agent" />;
+  }
+  if (workflowScope && workflowLoadable.state === "hasError") {
+    return <ErrorMessage message="Failed to load workflow" />;
   }
   if (grantsLoadable.state === "hasError") {
     return <ErrorMessage message="Failed to load permission grants" />;
@@ -353,9 +383,14 @@ function PermissionAllowDoctorPage({
     return <ErrorMessage message="Failed to load permission metadata" />;
   }
 
-  const agent = agentLoadable.data;
-  if (!agent) {
+  const agent = agentLoadable.state === "hasData" ? agentLoadable.data : null;
+  const workflow =
+    workflowLoadable.state === "hasData" ? workflowLoadable.data : null;
+  if (!workflowScope && !agent) {
     return <ErrorMessage message="Agent not found" />;
+  }
+  if (workflowScope && !workflow) {
+    return <ErrorMessage message="Workflow not found" />;
   }
   const metadata = metadataLoadable.data;
   if (!metadata) {
@@ -398,16 +433,27 @@ function PermissionAllowDoctorPage({
 
   const currentUser =
     userLoadable.state === "hasData" ? userLoadable.data : undefined;
+  const target: PermissionGrantTarget =
+    workflowScope && workflow
+      ? {
+          kind: "workflow",
+          id: workflow.id,
+          displayName: workflow.displayName ?? workflow.name,
+        }
+      : {
+          kind: "agent",
+          id: agentId,
+          displayName: agent?.displayName ?? agentId,
+          avatarUrl: agent?.avatarUrl ?? null,
+        };
 
   return (
     <ConfirmGrantCard
-      agentId={agentId}
+      target={target}
       connectorRef={ref}
       permission={focusedPermission}
       action={action}
       initialExpiresIn={initialExpiresIn}
-      agentDisplayName={agent.displayName ?? agentId}
-      agentAvatarUrl={agent.avatarUrl}
       userName={resolveUserName(currentUser)}
     />
   );
@@ -415,6 +461,7 @@ function PermissionAllowDoctorPage({
 
 export function PermissionAllowPage() {
   const agentId = useGet(permissionAllowAgentId$);
+  const workflowId = useGet(permissionAllowWorkflowId$);
   const ref = useGet(permissionAllowRef$);
   const permission = useGet(permissionAllowPermission$);
   const actionParam = useGet(permissionAllowActionParam$);
@@ -442,6 +489,7 @@ export function PermissionAllowPage() {
   return (
     <PermissionAllowDoctorPage
       agentId={agentId}
+      workflowId={workflowId}
       ref={ref}
       permission={permission}
       action={action ?? "allow"}

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -3807,6 +3807,56 @@ describe("chat lifecycle", () => {
     });
   });
 
+  it("renders workflow trigger user messages with an inline marker", async () => {
+    const threadId = "thread-workflow-user-message-marker";
+    const workflowPrompt = "/daily-workflow";
+
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Workflow user message marker",
+      chatMessages: [
+        {
+          id: "msg-workflow-marker-user",
+          role: "user",
+          content: workflowPrompt,
+          runId: "f0000001-0000-4000-a000-00000000083c",
+          triggerSource: "workflow-event",
+          workflowSnapshot: {
+            id: "f0000001-0000-4000-a000-000000000831",
+            agentId: "c0000000-0000-4000-a000-000000000001",
+            name: "daily-workflow",
+            displayName: "Daily workflow",
+            description: "Daily workflow summary",
+            triggerId: "f0000001-0000-4000-a000-000000000832",
+            triggerBrief: "Gmail label applied",
+          },
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          id: "msg-workflow-marker-assistant",
+          role: "assistant",
+          content: "Workflow result",
+          runId: "f0000001-0000-4000-a000-00000000083c",
+          triggerSource: "workflow-event",
+          createdAt: "2026-06-09T10:00:30Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Workflow trigger")).toBeInTheDocument();
+      expect(
+        screen.getByText("Daily workflow · Gmail label applied"),
+      ).toBeInTheDocument();
+      expect(screen.queryByText(workflowPrompt)).not.toBeInTheDocument();
+    });
+  });
+
   it("shows template labels on historical user messages", async () => {
     const threadId = "template-message-history";
     const presentationTemplate = PRESENTATION_TEMPLATE_PICKER_ITEMS[0]!;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -1,6 +1,10 @@
 import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import {
+  zeroWorkflowsDetailContract,
+  type ZeroWorkflowDetailResponse,
+} from "@vm0/api-contracts/contracts/zero-workflows";
+import {
   zeroUserPermissionGrantsContract,
   type UserPermissionGrantResponse,
 } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
@@ -20,6 +24,7 @@ import { mockChatLifecycle } from "./chat-test-helpers.ts";
 const context = testContext();
 
 const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
+const WORKFLOW_ID = "f0000001-0000-4000-a000-000000000901";
 const THREAD_ID = "thread-action-cards";
 
 function connectedConnector(
@@ -50,6 +55,33 @@ function mockAgentConnectorAuthorizations(initialTypes: string[]): void {
     enabledTypes = body.enabledTypes;
     return respond(200, { enabledTypes });
   });
+}
+
+function workflowDetailResponse(
+  overrides: Partial<ZeroWorkflowDetailResponse> = {},
+): ZeroWorkflowDetailResponse {
+  return {
+    id: WORKFLOW_ID,
+    agentId: AGENT_ID,
+    agentName: null,
+    agentDisplayName: null,
+    name: "daily-inbox-triage",
+    displayName: "Daily inbox triage",
+    description: null,
+    visibility: "private",
+    requestToPublish: false,
+    ownerUserId: "test-user-123",
+    canManage: true,
+    createdByUserId: "test-user-123",
+    updatedByUserId: "test-user-123",
+    createdAt: "2026-06-09T10:00:00Z",
+    updatedAt: "2026-06-09T10:00:00Z",
+    instruction: null,
+    files: null,
+    fileContents: null,
+    triggers: [],
+    ...overrides,
+  };
 }
 
 function encodeBase64UrlJson(value: unknown): string {
@@ -154,6 +186,115 @@ describe("chat message action cards", () => {
       expect(
         within(permissionCard).getByText("Permissions updated"),
       ).toBeInTheDocument();
+    });
+  });
+
+  it("lets users confirm workflow permission requests from assistant messages", async () => {
+    const user = userEvent.setup({ delay: null });
+    const triggerId = "f0000001-0000-4000-a000-000000000902";
+    const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/workflows/${WORKFLOW_ID}/permissions?ref=gmail&permission=messages.write&action=allow&expiresIn=24h&triggerId=${triggerId}`;
+    let capturedBody: unknown = null;
+
+    context.mocks.api(
+      zeroWorkflowsDetailContract.get,
+      ({ params, respond }) => {
+        if (params.workflowId !== WORKFLOW_ID) {
+          return respond(404, {
+            error: {
+              code: "NOT_FOUND",
+              message: "Workflow not found",
+            },
+          });
+        }
+        return respond(200, workflowDetailResponse());
+      },
+    );
+    context.mocks.api(
+      zeroUserPermissionGrantsContract.list,
+      ({ query, respond }) => {
+        expect(query).toMatchObject({ workflowId: WORKFLOW_ID });
+        expect(query).not.toHaveProperty("agentId");
+        return respond(200, []);
+      },
+    );
+    context.mocks.api(
+      zeroUserPermissionGrantsContract.apply,
+      ({ body, respond }) => {
+        const grant = body.grants[0];
+        if (!grant) {
+          throw new Error("Expected a permission grant");
+        }
+        capturedBody = body;
+        expect(body).not.toHaveProperty("agentId");
+        return respond(200, [
+          {
+            workflowId: body.workflowId,
+            connectorRef: body.connectorRef,
+            permission: grant.permission,
+            action: grant.action,
+            expiresAt: "2026-06-10T11:00:00.000Z",
+            createdAt: "2026-06-09T11:00:00Z",
+            updatedAt: "2026-06-09T11:01:00Z",
+          },
+        ]);
+      },
+    );
+
+    mockChatLifecycle(context, {
+      threadId: `${THREAD_ID}-workflow-permission`,
+      threadTitle: "Workflow permission card",
+      chatMessages: [
+        {
+          id: "msg-user-workflow-permission-request",
+          role: "user",
+          content: "Workflow needs Gmail access",
+          runId: "run-workflow-permission",
+          createdAt: "2026-06-09T11:00:00Z",
+        },
+        {
+          id: "msg-assistant-workflow-permission-card",
+          role: "assistant",
+          content: permissionAuthorizeUrl,
+          runId: "run-workflow-permission",
+          createdAt: "2026-06-09T11:01:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}-workflow-permission`,
+    });
+
+    const permissionCard = await screen.findByTestId("permission-action-card");
+    expect(
+      within(permissionCard).getByText("Gmail permissions"),
+    ).toBeInTheDocument();
+    expect(
+      within(permissionCard).getByText(
+        "Allow messages.write for Daily inbox triage",
+      ),
+    ).toBeInTheDocument();
+    expect(within(permissionCard).getByText("24 hours")).toBeInTheDocument();
+
+    await confirmPermissionAction(user, permissionCard);
+
+    await waitFor(() => {
+      expect(
+        within(permissionCard).getByText("Permissions updated"),
+      ).toBeInTheDocument();
+      expect(capturedBody).toMatchObject({
+        workflowId: WORKFLOW_ID,
+        connectorRef: "gmail",
+        mode: "patch",
+        grants: [
+          {
+            permission: "messages.write",
+            action: "allow",
+            expiresIn: "24h",
+          },
+        ],
+      });
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -234,7 +234,10 @@ import { openRenameChatThreadDialog$ } from "../../signals/zero-page/zero-sideba
 import { LoadingSwitch } from "../components/loading-switch.tsx";
 import { Link } from "../router/link.tsx";
 import { ROUTES } from "../../signals/route-paths.ts";
-import { WORKFLOW_DETAIL_TAB_PARAM } from "../../signals/workflows-page/workflows-signals.ts";
+import {
+  WORKFLOW_DETAIL_TAB_PARAM,
+  workflowDetail,
+} from "../../signals/workflows-page/workflows-signals.ts";
 import {
   atTimeInTimezone,
   cronWallTimeInTimezone,
@@ -306,6 +309,7 @@ import {
   findPermissionInMetadata,
   resolveUserPermissionGrantPolicy,
   userPermissionGrantsByAgent,
+  userPermissionGrantsByWorkflow,
 } from "../../signals/permission-allow/permission-allow-signals.ts";
 import type { FirewallPermissionDetailMetadata } from "@vm0/connectors/firewall-metadata";
 import { firewallPermissionMetadataByConnector } from "../../signals/firewall-permission-metadata.ts";
@@ -3831,6 +3835,7 @@ function runGroupFoldWorkflowLabel(fold: RunGroupFold): string | null {
   for (const message of runGroupFoldMessages(fold)) {
     const workflowSnapshot = message.workflowSnapshot;
     const label =
+      workflowSnapshot?.triggerBrief?.trim() ||
       workflowSnapshot?.description?.trim() ||
       workflowSnapshot?.displayName?.trim() ||
       workflowSnapshot?.name?.trim();
@@ -3854,6 +3859,7 @@ function isGoalUserMessage(
     message.role === "user" &&
     message.isGoalRun === true &&
     !hasAutomationMessageMetadata(message) &&
+    !hasWorkflowMessageMetadata(message) &&
     (message.content?.trim().length ?? 0) > 0
   );
 }
@@ -5453,7 +5459,8 @@ interface LoadableLike<T> {
 
 type ApplyUserPermissionGrantFn = (
   params: {
-    agentId: string;
+    agentId?: string;
+    workflowId?: string;
     connectorRef: string;
     permission: string;
     action: PermissionAction;
@@ -5784,7 +5791,9 @@ function createPermissionActionHandler(params: {
         detach(
           params.applyGrant(
             {
-              agentId: params.block.agentId,
+              ...(params.block.scope === "workflow" && params.block.workflowId
+                ? { workflowId: params.block.workflowId }
+                : { agentId: params.block.agentId }),
               connectorRef: params.block.connectorRef,
               permission: permissionName,
               action: params.block.action,
@@ -5804,6 +5813,7 @@ function createPermissionActionHandler(params: {
 function PermissionActionCardContent({
   block,
   connectorLabel,
+  targetLabel,
   actionLabel,
   permissionName,
   buttonState,
@@ -5815,6 +5825,7 @@ function PermissionActionCardContent({
 }: {
   block: PermissionActionBlock;
   connectorLabel: string;
+  targetLabel: string | null;
   actionLabel: string;
   permissionName: string;
   buttonState: PermissionActionButtonState;
@@ -5844,6 +5855,7 @@ function PermissionActionCardContent({
           </div>
           <div className="mt-0.5 line-clamp-2 text-sm leading-5 text-muted-foreground">
             {actionLabel} {permissionName}
+            {targetLabel ? ` for ${targetLabel}` : ""}
           </div>
           {expiryText && (
             <div className="mt-0.5 text-xs font-medium text-amber-700 dark:text-amber-400">
@@ -5871,7 +5883,19 @@ function PermissionActionCardContent({
   );
 }
 
-function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
+function PermissionActionCardForTarget({
+  block,
+  hasTarget,
+  targetLabel,
+  targetLoadableState,
+  userGrantsLoadable,
+}: {
+  block: PermissionActionBlock;
+  hasTarget: boolean;
+  targetLabel: string | null;
+  targetLoadableState: string;
+  userGrantsLoadable: LoadableLike<readonly PermissionActionUserGrant[]>;
+}) {
   const pageSignal = useGet(pageSignal$);
   const config = CONNECTOR_TYPES[block.connectorRef];
   const expirationAvailable = block.action === "allow";
@@ -5882,25 +5906,17 @@ function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
     expiresInByScope[durationScope] ??
     block.expiresIn ??
     DEFAULT_USER_PERMISSION_GRANT_EXPIRES_IN;
-  const agentLoadable = useLastLoadable(agentById(block.agentId));
   const permissionMetadataLoadable = useLoadable(
     firewallPermissionMetadataByConnector({
       connectorType: block.connectorRef,
     }),
   );
   const [grantLoadable, applyGrant] = useLoadableSet(applyUserPermissionGrant$);
-  const userGrantsLoadable = useLoadable(
-    userPermissionGrantsByAgent({
-      agentId: block.agentId,
-    }),
-  );
-  const hasAgent =
-    agentLoadable.state === "hasData" && Boolean(agentLoadable.data);
   const existingGrant = permissionActionUserGrant(userGrantsLoadable, block);
   const actionState = createPermissionActionCardViewState({
     block,
-    hasAgent,
-    agentLoadableState: agentLoadable.state,
+    hasAgent: hasTarget,
+    agentLoadableState: targetLoadableState,
     permissionMetadataLoadable,
     userGrantsLoadable,
     grantLoadableState: grantLoadable.state,
@@ -5916,6 +5932,7 @@ function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
     <PermissionActionCardContent
       block={block}
       connectorLabel={config.label}
+      targetLabel={block.scope === "workflow" ? targetLabel : null}
       actionLabel={actionState.actionLabel}
       permissionName={actionState.focusedPermission?.name ?? block.permission}
       buttonState={actionState.buttonState}
@@ -5928,7 +5945,7 @@ function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
       onClick={createPermissionActionHandler({
         block,
         pageSignal,
-        hasAgent,
+        hasAgent: hasTarget,
         focusedPermission: actionState.focusedPermission,
         state: actionState.buttonState,
         finished: actionState.finished,
@@ -5938,6 +5955,70 @@ function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
       })}
     />
   );
+}
+
+function AgentPermissionActionCard({
+  block,
+}: {
+  block: PermissionActionBlock;
+}) {
+  const agentLoadable = useLastLoadable(agentById(block.agentId));
+  const userGrantsLoadable = useLoadable(
+    userPermissionGrantsByAgent({
+      agentId: block.agentId,
+    }),
+  );
+  const agent = agentLoadable.state === "hasData" ? agentLoadable.data : null;
+  const targetLabel = agent?.displayName ?? block.agentId;
+  return (
+    <PermissionActionCardForTarget
+      block={block}
+      hasTarget={Boolean(agent)}
+      targetLabel={targetLabel}
+      targetLoadableState={agentLoadable.state}
+      userGrantsLoadable={userGrantsLoadable}
+    />
+  );
+}
+
+function WorkflowPermissionActionCard({
+  block,
+  workflowId,
+}: {
+  block: PermissionActionBlock;
+  workflowId: string;
+}) {
+  const workflowLoadable = useLastLoadable(workflowDetail(workflowId));
+  const userGrantsLoadable = useLoadable(
+    userPermissionGrantsByWorkflow({
+      workflowId,
+    }),
+  );
+  const workflow =
+    workflowLoadable.state === "hasData" ? workflowLoadable.data : null;
+  const targetLabel =
+    workflow?.displayName ?? workflow?.name ?? "this workflow";
+  return (
+    <PermissionActionCardForTarget
+      block={block}
+      hasTarget={Boolean(workflow)}
+      targetLabel={targetLabel}
+      targetLoadableState={workflowLoadable.state}
+      userGrantsLoadable={userGrantsLoadable}
+    />
+  );
+}
+
+function PermissionActionCard({ block }: { block: PermissionActionBlock }) {
+  if (block.scope === "workflow" && block.workflowId) {
+    return (
+      <WorkflowPermissionActionCard
+        block={block}
+        workflowId={block.workflowId}
+      />
+    );
+  }
+  return <AgentPermissionActionCard block={block} />;
 }
 
 function ChatConnectorActionConnectModal() {
@@ -6406,6 +6487,20 @@ function hasAutomationMessageMetadata(message: EnrichedChatMessage): boolean {
   );
 }
 
+function isWorkflowUserMessage(
+  message: EnrichedChatMessage,
+): message is EnrichedChatMessage & { role: "user" } {
+  return (
+    message.role === "user" &&
+    hasWorkflowMessageMetadata(message) &&
+    !hasAutomationMessageMetadata(message)
+  );
+}
+
+function hasWorkflowMessageMetadata(message: EnrichedChatMessage): boolean {
+  return message.workflowSnapshot !== undefined;
+}
+
 function automationMessageLabel(
   message: EnrichedChatMessage & { role: "user" },
 ): string {
@@ -6415,6 +6510,38 @@ function automationMessageLabel(
     message.automationTitle?.trim() ||
     "Automation run"
   );
+}
+
+function workflowSnapshotTitle(
+  workflowSnapshot: NonNullable<EnrichedChatMessage["workflowSnapshot"]>,
+): string {
+  return (
+    workflowSnapshot.displayName?.trim() ||
+    workflowSnapshot.name.trim() ||
+    "Workflow"
+  );
+}
+
+function workflowMessageBrief(
+  workflowSnapshot: NonNullable<EnrichedChatMessage["workflowSnapshot"]>,
+): string | null {
+  const brief =
+    workflowSnapshot.triggerBrief?.trim() ||
+    workflowSnapshot.description?.trim() ||
+    "";
+  return brief.length > 0 ? brief : null;
+}
+
+function workflowMessageLabel(
+  message: EnrichedChatMessage & { role: "user" },
+): string {
+  const workflowSnapshot = message.workflowSnapshot;
+  if (!workflowSnapshot) {
+    return "Workflow";
+  }
+  const title = workflowSnapshotTitle(workflowSnapshot);
+  const brief = workflowMessageBrief(workflowSnapshot);
+  return brief ? `${title} · ${brief}` : title;
 }
 
 function resolveAttachments(
@@ -6736,6 +6863,64 @@ function AutomationUserMessage({
   );
 }
 
+function WorkflowUserMessage({
+  message,
+}: {
+  message: EnrichedChatMessage & { role: "user" };
+}) {
+  const workflowSnapshot = message.workflowSnapshot;
+  if (!workflowSnapshot) {
+    return null;
+  }
+  const workflowLabel = workflowMessageLabel(message);
+  const bubbleClassName =
+    "zero-chat-bubble-user rounded-xl max-w-[85%] text-[0.9375rem] leading-[1.7] [overflow-wrap:anywhere] overflow-hidden transition-colors duration-150";
+  const body = (
+    <div className={bubbleClassName}>
+      <div className="px-4 py-3">{workflowLabel}</div>
+    </div>
+  );
+  const workflowAgentId = workflowSnapshot.agentId;
+  const workflowId = workflowSnapshot.id;
+  const linked = workflowAgentId !== undefined && workflowId !== undefined;
+
+  return (
+    <div data-role="user" className="group">
+      <div className="flex flex-col items-end min-w-0 animate-in fade-in slide-in-from-bottom-2 duration-300 @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start">
+        <div className="hidden @[900px]:block @[900px]:w-9 @[900px]:h-9 @[900px]:shrink-0" />
+        <div className="flex w-full flex-col items-end">
+          <div
+            aria-label="Workflow trigger"
+            className="mb-1.5 flex max-w-[85%] items-center gap-1.5 self-end text-xs font-medium text-muted-foreground"
+          >
+            <IconGitBranch size={15} stroke={1.8} className="shrink-0" />
+            <span>Workflow trigger</span>
+          </div>
+          {linked ? (
+            <Link
+              pathname={ROUTES.agentWorkflowDetail}
+              options={{
+                pathParams: {
+                  agentId: workflowAgentId,
+                  workflowId,
+                },
+              }}
+              className="contents"
+              aria-label={`Open workflow ${workflowSnapshotTitle(
+                workflowSnapshot,
+              )}`}
+            >
+              {body}
+            </Link>
+          ) : (
+            body
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function GoalUserMessage({
   bodyBlocks,
   openLightbox,
@@ -6833,6 +7018,10 @@ function PagedUserMessage({
         automationLabel={automationMessageLabel(message)}
       />
     );
+  }
+
+  if (isWorkflowUserMessage(message)) {
+    return <WorkflowUserMessage message={message} />;
   }
 
   if (isGoalUserMessage(message)) {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -43,6 +43,7 @@ import {
   IconMessageCircle,
   IconPackage,
   IconPresentation,
+  IconRoute,
   IconSearch,
   IconTag,
   IconTarget,
@@ -6893,7 +6894,7 @@ function WorkflowUserMessage({
             aria-label="Workflow trigger"
             className="mb-1.5 flex max-w-[85%] items-center gap-1.5 self-end text-xs font-medium text-muted-foreground"
           >
-            <IconGitBranch size={15} stroke={1.8} className="shrink-0" />
+            <IconRoute size={15} stroke={1.8} className="shrink-0" />
             <span>Workflow trigger</span>
           </div>
           {linked ? (

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -237,9 +237,13 @@ const pagedChatMessageBaseSchema = z.object({
     .optional(),
   workflowSnapshot: z
     .object({
+      id: z.string().uuid().optional(),
+      agentId: z.string().uuid().optional(),
       name: z.string(),
       displayName: z.string().nullable(),
       description: z.string().nullable(),
+      triggerId: z.string().uuid().optional(),
+      triggerBrief: z.string().nullable().optional(),
     })
     .optional(),
   createdAt: z.string(),


### PR DESCRIPTION
## Summary
- add workflow snapshot fields for chat display and render workflow trigger user messages with an inline marker instead of slash workflow prompts
- add canonical workflow permission URLs and keep legacy trigger permission URLs redirecting into the workflow permission landing page
- let Web Chat permission action cards resolve workflow links, display the workflow name, and apply workflow-scoped grants

## Tests
- pnpm --dir turbo/apps/cli test src/commands/zero/doctor/__tests__/permission-change.test.ts
- pnpm --dir turbo/apps/platform test src/views/zero-page/__tests__/chat-message-action-cards.test.tsx src/views/zero-page/__tests__/chat-lifecycle.test.tsx src/views/permission-allow/__tests__/permission-allow-page.test.tsx
- pnpm --dir turbo/apps/cli check-types
- pnpm --dir turbo/apps/platform check-types
- NODE_OPTIONS=--max-old-space-size=4096 pnpm --dir turbo/apps/api check-types