### PR TITLE
fix: preserve workflow trigger loop cadence

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-triggers.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-triggers.test.ts
@@ -902,6 +902,44 @@ describe("zero workflow triggers", () => {
     });
   });
 
+  it("schedules updated loop triggers from the last run interval", async () => {
+    mockNow(Date.parse("2026-06-28T06:00:00.000Z"));
+    const { workflowId } = await setupFixture();
+    const created = await accept(
+      triggersClient().create({
+        headers: authHeaders(),
+        params: { workflowId },
+        body: {
+          schedule: { type: "loop", intervalSeconds: 600 },
+        },
+      }),
+      [201],
+    );
+
+    await store
+      .set(writeDb$)
+      .update(zeroWorkflowTriggers)
+      .set({
+        lastRunAt: new Date("2026-06-28T06:05:00.000Z"),
+        nextRunAt: null,
+      })
+      .where(eq(zeroWorkflowTriggers.id, created.body.id));
+
+    mockNow(Date.parse("2026-06-28T06:10:00.000Z"));
+    const updated = await accept(
+      triggersClient().update({
+        headers: authHeaders(),
+        params: { id: created.body.id },
+        body: {
+          schedule: { type: "loop", intervalSeconds: 3600 },
+        },
+      }),
+      [200],
+    );
+
+    expect(updated.body.nextRunAt).toBe("2026-06-28T07:05:00.000Z");
+  });
+
   it("clears next run on disable and recomputes it on enable", async () => {
     const { workflowId } = await setupFixture();
     const created = await accept(
@@ -938,6 +976,42 @@ describe("zero workflow triggers", () => {
     );
     expect(enabled.body.enabled).toBeTruthy();
     expect(enabled.body.nextRunAt).toBeTruthy();
+  });
+
+  it("keeps enabled loop triggers scheduled from the last run interval", async () => {
+    mockNow(Date.parse("2026-06-28T06:00:00.000Z"));
+    const { workflowId } = await setupFixture();
+    const created = await accept(
+      triggersClient().create({
+        headers: authHeaders(),
+        params: { workflowId },
+        body: {
+          schedule: { type: "loop", intervalSeconds: 1800 },
+        },
+      }),
+      [201],
+    );
+
+    await store
+      .set(writeDb$)
+      .update(zeroWorkflowTriggers)
+      .set({
+        lastRunAt: new Date("2026-06-28T06:05:00.000Z"),
+        nextRunAt: null,
+      })
+      .where(eq(zeroWorkflowTriggers.id, created.body.id));
+
+    mockNow(Date.parse("2026-06-28T06:10:00.000Z"));
+    const enabled = await accept(
+      triggersClient().enable({
+        headers: authHeaders(),
+        params: { id: created.body.id },
+      }),
+      [200],
+    );
+
+    expect(enabled.body.enabled).toBeTruthy();
+    expect(enabled.body.nextRunAt).toBe("2026-06-28T06:35:00.000Z");
   });
 
   it("treats a deleted workflow's trigger as not found on enable", async () => {

--- a/turbo/apps/api/src/signals/services/zero-workflow-trigger.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-trigger.service.ts
@@ -182,6 +182,7 @@ function resolveNextRunAt(
   schedule: ZeroWorkflowSchedule,
   enabled: boolean,
   now: Date,
+  lastRunAt: Date | null = null,
 ): Date | null {
   if (!enabled) {
     return null;
@@ -192,7 +193,21 @@ function resolveNextRunAt(
   if (schedule.type === "once") {
     return parseOnceAtTime(schedule);
   }
-  return now;
+  return resolveLoopNextRunAt(schedule.intervalSeconds, now, lastRunAt);
+}
+
+function resolveLoopNextRunAt(
+  intervalSeconds: number,
+  now: Date,
+  lastRunAt: Date | null,
+): Date {
+  if (!lastRunAt) {
+    return now;
+  }
+  const nextFromLastRun = new Date(
+    lastRunAt.getTime() + intervalSeconds * 1000,
+  );
+  return nextFromLastRun.getTime() > now.getTime() ? nextFromLastRun : now;
 }
 
 function summarizeSchedule(schedule: ZeroWorkflowSchedule): string {
@@ -1170,7 +1185,12 @@ export const updateWorkflowTrigger$ = command(
       return { kind: "bad-request", message: scheduleError };
     }
     const cols = scheduleToColumns(args.schedule);
-    const nextRunAt = resolveNextRunAt(args.schedule, trigger.enabled, now);
+    const nextRunAt = resolveNextRunAt(
+      args.schedule,
+      trigger.enabled,
+      now,
+      trigger.lastRunAt,
+    );
 
     const [row] = await writeDb
       .update(zeroWorkflowTriggers)
@@ -1378,7 +1398,7 @@ export const enableWorkflowTrigger$ = command(
     const now = nowDate();
     const nextRunAt =
       trigger.kind === "schedule"
-        ? resolveNextRunAt(rowToSchedule(trigger), true, now)
+        ? resolveNextRunAt(rowToSchedule(trigger), true, now, trigger.lastRunAt)
         : trigger.nextRunAt;
     if (trigger.kind === "event" && trigger.eventType === "gmail-new-message") {
       const featureEnabled = await get(


### PR DESCRIPTION
## Summary

- preserve loop workflow trigger cadence on schedule update by using `max(now, lastRunAt + interval)`
- apply the same cadence rule when enabling an existing loop workflow trigger
- add regression coverage for update and enable paths with prior `lastRunAt`

## Verification

- `NODE_OPTIONS=--max-old-space-size=8192 pnpm -F api check-types`
- `pnpm exec prettier --check apps/api/src/signals/services/zero-workflow-trigger.service.ts apps/api/src/signals/routes/__tests__/zero-workflow-triggers.test.ts`
- `git diff --check`

Attempted:

- `pnpm test apps/api/src/signals/routes/__tests__/zero-workflow-triggers.test.ts`
  - blocked locally because this fresh environment has no Postgres listening on `127.0.0.1:5432`; the test file failed during fixture setup before assertions.
