### PR TITLE
fix: align automation agent picker modal

### DIFF
--- a/turbo/apps/platform/src/signals/automation-page/workflow-trigger-automation-dialog.ts
+++ b/turbo/apps/platform/src/signals/automation-page/workflow-trigger-automation-dialog.ts
@@ -6,6 +6,7 @@ const workflowAutomationDialogOpenState$ = state(false);
 const workflowAutomationDialogStepState$ =
   state<WorkflowAutomationDialogStep>(1);
 const selectedWorkflowAutomationAgentIdState$ = state("");
+const workflowAutomationAgentQueryState$ = state("");
 
 export const workflowAutomationDialogOpen$ = computed((get) => {
   return get(workflowAutomationDialogOpenState$);
@@ -19,12 +20,17 @@ export const selectedWorkflowAutomationAgentId$ = computed((get) => {
   return get(selectedWorkflowAutomationAgentIdState$);
 });
 
+export const workflowAutomationAgentQuery$ = computed((get) => {
+  return get(workflowAutomationAgentQueryState$);
+});
+
 export const setWorkflowAutomationDialogOpen$ = command(
   ({ set }, open: boolean) => {
     set(workflowAutomationDialogOpenState$, open);
     if (open) {
       set(workflowAutomationDialogStepState$, 1);
       set(selectedWorkflowAutomationAgentIdState$, "");
+      set(workflowAutomationAgentQueryState$, "");
     }
   },
 );
@@ -38,5 +44,11 @@ export const setWorkflowAutomationDialogStep$ = command(
 export const setSelectedWorkflowAutomationAgentId$ = command(
   ({ set }, agentId: string) => {
     set(selectedWorkflowAutomationAgentIdState$, agentId);
+  },
+);
+
+export const setWorkflowAutomationAgentQuery$ = command(
+  ({ set }, query: string) => {
+    set(workflowAutomationAgentQueryState$, query);
   },
 );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-automations-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-automations-page.test.tsx
@@ -424,46 +424,57 @@ describe("zero automations page", () => {
     expect(screen.getByText("Webhook trigger")).toBeInTheDocument();
   });
 
-  it("starts workflow-trigger creation from the add automation modal", async () => {
-    mockWorkflowTriggerStory();
+  it.each([
+    ["Fixed interval", /interval triggered workflow/u],
+    ["Fixed schedule", /schedule triggered workflow/u],
+    ["Web trigger", /web triggered workflow/u],
+    ["New email", /email triggered workflow that runs when a Gmail message/u],
+    ["Email label", /email-label triggered workflow/u],
+  ])(
+    "starts workflow-trigger creation with the %s prompt",
+    async (triggerName, promptPattern) => {
+      mockWorkflowTriggerStory();
 
-    detachedSetupPage({
-      context,
-      path: "/automations",
-      featureSwitches: {
-        [FeatureSwitchKey.SwitchScheduleAutomationToWorkflowTrigger]: true,
-      },
-    });
+      detachedSetupPage({
+        context,
+        path: "/automations",
+        featureSwitches: {
+          [FeatureSwitchKey.SwitchScheduleAutomationToWorkflowTrigger]: true,
+        },
+      });
 
-    await waitFor(() => {
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", { name: "Automations" }),
+        ).toBeInTheDocument();
+      });
+
+      click(buttonByText("Add automation"));
+      const dialog = await screen.findByRole("dialog");
+      expect(within(dialog).queryByText("1 Agent")).not.toBeInTheDocument();
+      expect(within(dialog).queryByText("2 Trigger")).not.toBeInTheDocument();
+      expect(within(dialog).getByText("Zero")).toBeInTheDocument();
       expect(
-        screen.getByRole("heading", { name: "Automations" }),
-      ).toBeInTheDocument();
-    });
+        within(dialog).queryByLabelText("Pin to sidebar"),
+      ).not.toBeInTheDocument();
 
-    click(buttonByText("Add automation"));
-    const dialog = await screen.findByRole("dialog");
-    expect(within(dialog).getByText("1 Agent")).toBeInTheDocument();
-    expect(within(dialog).getByText("Zero")).toBeInTheDocument();
-    expect(
-      within(dialog).queryByLabelText("Pin to sidebar"),
-    ).not.toBeInTheDocument();
+      click(buttonByText("Zero", dialog));
+      await waitFor(() => {
+        expect(within(dialog).queryByText("1 Agent")).not.toBeInTheDocument();
+        expect(within(dialog).queryByText("2 Trigger")).not.toBeInTheDocument();
+        expect(within(dialog).getByText(triggerName)).toBeInTheDocument();
+      });
 
-    click(buttonByText("Zero", dialog));
-    await waitFor(() => {
-      expect(within(dialog).getByText("2 Trigger")).toBeInTheDocument();
-      expect(within(dialog).getByText("Fixed interval")).toBeInTheDocument();
-    });
+      click(within(dialog).getByText(triggerName));
 
-    click(within(dialog).getByText("Fixed interval"));
-
-    await waitFor(() => {
-      expect(pathname()).toBe(`/agents/${zeroAgentId}/chat`);
-    });
-    await expect(
-      screen.findByDisplayValue(/interval triggered workflow/u),
-    ).resolves.toBeInTheDocument();
-  });
+      await waitFor(() => {
+        expect(pathname()).toBe(`/agents/${zeroAgentId}/chat`);
+      });
+      await expect(
+        screen.findByDisplayValue(promptPattern),
+      ).resolves.toBeInTheDocument();
+    },
+  );
 
   it("shows scheduled work in the calendar", async () => {
     mockAutomationsPageStory();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-automations-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-automations-page.test.tsx
@@ -462,6 +462,9 @@ describe("zero automations page", () => {
       await waitFor(() => {
         expect(within(dialog).queryByText("1 Agent")).not.toBeInTheDocument();
         expect(within(dialog).queryByText("2 Trigger")).not.toBeInTheDocument();
+        expect(
+          within(dialog).getByText("What do you want me to do?"),
+        ).toBeInTheDocument();
         expect(within(dialog).getByText(triggerName)).toBeInTheDocument();
       });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-automations-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-automations-page.test.tsx
@@ -445,8 +445,11 @@ describe("zero automations page", () => {
     const dialog = await screen.findByRole("dialog");
     expect(within(dialog).getByText("1 Agent")).toBeInTheDocument();
     expect(within(dialog).getByText("Zero")).toBeInTheDocument();
+    expect(
+      within(dialog).queryByLabelText("Pin to sidebar"),
+    ).not.toBeInTheDocument();
 
-    click(buttonByText("Next", dialog));
+    click(buttonByText("Zero", dialog));
     await waitFor(() => {
       expect(within(dialog).getByText("2 Trigger")).toBeInTheDocument();
       expect(within(dialog).getByText("Fixed interval")).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx
@@ -19,7 +19,7 @@ import {
   IconPlus,
   IconRepeat,
 } from "@tabler/icons-react";
-import { Button, cn } from "@vm0/ui";
+import { Button } from "@vm0/ui";
 import {
   Dialog,
   DialogContent,
@@ -422,29 +422,6 @@ function EmptyTriggers({ onAdd }: { readonly onAdd: () => void }) {
   );
 }
 
-function WorkflowAutomationStepPills({ step }: { readonly step: 1 | 2 }) {
-  return (
-    <div className="flex items-center gap-2 text-sm text-muted-foreground">
-      <span
-        className={cn(
-          "inline-flex h-7 items-center rounded-full px-3",
-          step === 1 ? "bg-gray-50 text-foreground" : "text-muted-foreground",
-        )}
-      >
-        1 Agent
-      </span>
-      <span
-        className={cn(
-          "inline-flex h-7 items-center rounded-full px-3",
-          step === 2 ? "bg-gray-50 text-foreground" : "text-muted-foreground",
-        )}
-      >
-        2 Trigger
-      </span>
-    </div>
-  );
-}
-
 function AgentSelectionStep({
   agents,
   onSelectAgent,
@@ -666,10 +643,6 @@ function CreateWorkflowAutomationDialog() {
             Choose the agent and trigger type for this workflow.
           </DialogDescription>
         </DialogHeader>
-
-        <div className="px-5 pb-3">
-          <WorkflowAutomationStepPills step={step} />
-        </div>
 
         {step === 1 ? (
           <AgentSelectionStep agents={agents} onSelectAgent={selectAgent} />

--- a/turbo/apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx
@@ -459,21 +459,21 @@ function AgentSelectionStep({
 
   if (agents.length === 0) {
     return (
-      <>
+      <div className="flex min-h-0 flex-1 flex-col">
         <AgentDialogSearch query={query} setQuery={setQuery} />
-        <div className="px-5 pb-5">
+        <div className="min-h-0 flex-1 overflow-y-auto px-5 pb-4">
           <p className="px-1 py-2 text-xs text-muted-foreground">
             No agents yet
           </p>
         </div>
-      </>
+      </div>
     );
   }
 
   return (
-    <>
+    <div className="flex min-h-0 flex-1 flex-col">
       <AgentDialogSearch query={query} setQuery={setQuery} />
-      <div className="max-h-[min(520px,65vh)] overflow-y-auto">
+      <div className="min-h-0 flex-1 overflow-y-auto pb-2">
         {filteredPinned.length > 0 ? (
           <AgentDialogSection label="Pinned">
             {filteredPinned.map((agent) => {
@@ -527,7 +527,7 @@ function AgentSelectionStep({
           </div>
         ) : null}
       </div>
-    </>
+    </div>
   );
 }
 
@@ -541,7 +541,7 @@ function TriggerSelectionStep({
   const selectedAgentName = selectedAgent?.displayName ?? "Selected agent";
   return (
     <div className="grid gap-2">
-      <div className="mb-2 flex min-w-0 items-center gap-2 rounded-lg border border-border/60 bg-gray-50 p-2.5">
+      <div className="mb-2 flex min-w-0 items-center gap-2 px-1 py-1">
         {selectedAgent ? (
           <AgentAvatarImg
             name={selectedAgent.id}
@@ -599,7 +599,7 @@ function WorkflowAutomationDialogFooter({
   readonly onCancel: () => void;
 }) {
   return (
-    <DialogFooter className="px-5 pb-5 pt-3">
+    <DialogFooter className="shrink-0 border-t border-border/60 bg-card px-5 py-4">
       {step === 2 ? (
         <Button
           type="button"
@@ -652,8 +652,8 @@ function CreateWorkflowAutomationDialog() {
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogContent className="zero-app w-[calc(100vw-2rem)] gap-0 p-0 sm:max-w-xl">
-        <DialogHeader className="px-5 pb-3 pt-5">
+      <DialogContent className="zero-app !flex max-h-[min(720px,calc(100dvh-2rem))] w-[calc(100vw-2rem)] !flex-col !overflow-hidden gap-0 p-0 sm:max-w-xl">
+        <DialogHeader className="shrink-0 px-5 pb-3 pt-5">
           <DialogTitle className="text-base font-semibold">
             Add automation
           </DialogTitle>
@@ -665,7 +665,7 @@ function CreateWorkflowAutomationDialog() {
         {step === 1 ? (
           <AgentSelectionStep agents={agents} onSelectAgent={selectAgent} />
         ) : (
-          <div className="px-5">
+          <div className="min-h-0 flex-1 overflow-y-auto px-5 pb-4">
             <TriggerSelectionStep
               selectedAgent={selectedAgent}
               onSelectOption={startWorkflowCreation}

--- a/turbo/apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx
@@ -64,6 +64,7 @@ import {
   AgentDialogSearch,
   AgentDialogSection,
 } from "./zero-sidebar-dialogs.tsx";
+import { AgentAvatarImg } from "./zero-sidebar-shared.tsx";
 import {
   agentLabel,
   formatWorkflowIntervalSeconds,
@@ -531,16 +532,33 @@ function AgentSelectionStep({
 }
 
 function TriggerSelectionStep({
-  selectedAgentName,
+  selectedAgent,
   onSelectOption,
 }: {
-  readonly selectedAgentName: string;
+  readonly selectedAgent: TeamComposeItem | null;
   readonly onSelectOption: (option: WorkflowAutomationOption) => void;
 }) {
+  const selectedAgentName = selectedAgent?.displayName ?? "Selected agent";
   return (
     <div className="grid gap-2">
-      <div className="mb-1 text-sm text-muted-foreground">
-        {selectedAgentName}
+      <div className="mb-2 flex min-w-0 items-center gap-2 rounded-lg border border-border/60 bg-gray-50 p-2.5">
+        {selectedAgent ? (
+          <AgentAvatarImg
+            name={selectedAgent.id}
+            alt={selectedAgentName}
+            className="h-8 w-8 shrink-0 rounded-lg bg-gray-100 object-cover object-top"
+          />
+        ) : (
+          <span className="h-8 w-8 shrink-0 rounded-lg bg-gray-100" />
+        )}
+        <span className="min-w-0">
+          <span className="block truncate text-sm font-medium text-foreground">
+            {selectedAgentName}
+          </span>
+          <span className="block truncate text-xs text-muted-foreground">
+            What do you want me to do?
+          </span>
+        </span>
       </div>
       {WORKFLOW_AUTOMATION_OPTIONS.map((option) => {
         const Icon = option.Icon;
@@ -649,7 +667,7 @@ function CreateWorkflowAutomationDialog() {
         ) : (
           <div className="px-5">
             <TriggerSelectionStep
-              selectedAgentName={selectedAgent?.displayName ?? "Selected agent"}
+              selectedAgent={selectedAgent}
               onSelectOption={startWorkflowCreation}
             />
           </div>

--- a/turbo/apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx
@@ -1,5 +1,9 @@
-import type { ReactNode } from "react";
-import { useGet, useLastLoadable, useSet } from "ccstate-react";
+import {
+  useGet,
+  useLastLoadable,
+  useLastResolved,
+  useSet,
+} from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import type { TeamComposeItem } from "@vm0/api-contracts/contracts/zero-team";
 import type { ZeroWorkflowTriggerSummary } from "@vm0/api-contracts/contracts/zero-workflows";
@@ -30,8 +34,10 @@ import { agents$ } from "../../signals/agent.ts";
 import {
   selectedWorkflowAutomationAgentId$,
   setSelectedWorkflowAutomationAgentId$,
+  setWorkflowAutomationAgentQuery$,
   setWorkflowAutomationDialogOpen$,
   setWorkflowAutomationDialogStep$,
+  workflowAutomationAgentQuery$,
   workflowAutomationDialogOpen$,
   workflowAutomationDialogStep$,
 } from "../../signals/automation-page/workflow-trigger-automation-dialog.ts";
@@ -49,8 +55,15 @@ import {
   cronWallTimeInTimezone,
 } from "../../signals/zero-page/cron.ts";
 import { userPreferences$ } from "../../signals/zero-page/settings/user-preferences.ts";
+import { pinnedAgentIds$ } from "../../signals/zero-page/zero-pinned-agents.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { Link } from "../router/link.tsx";
+import {
+  AgentDialogAgentButton,
+  agentDialogMatchesQuery,
+  AgentDialogSearch,
+  AgentDialogSection,
+} from "./zero-sidebar-dialogs.tsx";
 import {
   agentLabel,
   formatWorkflowIntervalSeconds,
@@ -409,31 +422,6 @@ function EmptyTriggers({ onAdd }: { readonly onAdd: () => void }) {
   );
 }
 
-function AgentOption({
-  selected,
-  onSelect,
-  children,
-}: {
-  readonly selected: boolean;
-  readonly onSelect: () => void;
-  readonly children: ReactNode;
-}) {
-  return (
-    <button
-      type="button"
-      className={cn(
-        "flex min-h-12 w-full min-w-0 items-center justify-between rounded-lg border px-3 py-2 text-left text-sm transition-colors",
-        selected
-          ? "border-primary/40 bg-primary/5 text-foreground"
-          : "border-border/60 text-foreground hover:bg-gray-50",
-      )}
-      onClick={onSelect}
-    >
-      {children}
-    </button>
-  );
-}
-
 function WorkflowAutomationStepPills({ step }: { readonly step: 1 | 2 }) {
   return (
     <div className="flex items-center gap-2 text-sm text-muted-foreground">
@@ -459,43 +447,109 @@ function WorkflowAutomationStepPills({ step }: { readonly step: 1 | 2 }) {
 
 function AgentSelectionStep({
   agents,
-  selectedAgentId,
   onSelectAgent,
 }: {
   readonly agents: readonly TeamComposeItem[];
-  readonly selectedAgentId: string;
   readonly onSelectAgent: (agentId: string) => void;
 }) {
+  const query = useGet(workflowAutomationAgentQuery$);
+  const setQuery = useSet(setWorkflowAutomationAgentQuery$);
+  const pinnedIds = useLastResolved(pinnedAgentIds$) ?? [];
+  const pinned = pinnedIds
+    .map((id) => {
+      return agents.find((agent) => {
+        return agent.id === id;
+      });
+    })
+    .filter((agent): agent is TeamComposeItem => {
+      return agent !== undefined;
+    });
+  const unpinned = agents.filter((agent) => {
+    return !pinnedIds.includes(agent.id);
+  });
+  const trimmedQuery = query.trim().toLowerCase();
+  const filteredPinned = trimmedQuery
+    ? pinned.filter((agent) => {
+        return agentDialogMatchesQuery(agent, trimmedQuery);
+      })
+    : pinned;
+  const filteredUnpinned = trimmedQuery
+    ? unpinned.filter((agent) => {
+        return agentDialogMatchesQuery(agent, trimmedQuery);
+      })
+    : unpinned;
+
   if (agents.length === 0) {
     return (
-      <div className="rounded-lg border border-border/60 px-3 py-8 text-center text-sm text-muted-foreground">
-        No agents yet
-      </div>
+      <>
+        <AgentDialogSearch query={query} setQuery={setQuery} />
+        <div className="px-5 pb-5">
+          <p className="px-1 py-2 text-xs text-muted-foreground">
+            No agents yet
+          </p>
+        </div>
+      </>
     );
   }
 
   return (
-    <div className="grid gap-2">
-      {agents.map((agent) => {
-        const selected = selectedAgentId === agent.id;
-        return (
-          <AgentOption
-            key={agent.id}
-            selected={selected}
-            onSelect={() => {
-              onSelectAgent(agent.id);
-            }}
+    <>
+      <AgentDialogSearch query={query} setQuery={setQuery} />
+      <div className="max-h-[min(520px,65vh)] overflow-y-auto">
+        {filteredPinned.length > 0 ? (
+          <AgentDialogSection label="Pinned">
+            {filteredPinned.map((agent) => {
+              return (
+                <div
+                  key={agent.id}
+                  className="flex items-center gap-2 rounded-lg px-1 py-2 transition-colors hover:bg-accent"
+                >
+                  <AgentDialogAgentButton
+                    agent={agent}
+                    onSelect={() => {
+                      onSelectAgent(agent.id);
+                    }}
+                  />
+                </div>
+              );
+            })}
+          </AgentDialogSection>
+        ) : null}
+
+        {filteredUnpinned.length > 0 ? (
+          <AgentDialogSection
+            label={filteredPinned.length > 0 ? "Others" : "Agents"}
+            className="pb-3"
           >
-            <span className="min-w-0 truncate">
-              {agent.displayName ?? agent.id}
-            </span>
-            <span className="ml-3 shrink-0 text-xs text-muted-foreground">
-              {selected ? "Selected" : "Select"}
-            </span>
-          </AgentOption>
-        );
-      })}
-    </div>
+            {filteredUnpinned.map((agent) => {
+              return (
+                <div
+                  key={agent.id}
+                  className="flex items-center gap-2 rounded-lg px-1 py-2 transition-colors hover:bg-accent"
+                >
+                  <AgentDialogAgentButton
+                    agent={agent}
+                    onSelect={() => {
+                      onSelectAgent(agent.id);
+                    }}
+                  />
+                </div>
+              );
+            })}
+          </AgentDialogSection>
+        ) : null}
+
+        {trimmedQuery &&
+        filteredPinned.length === 0 &&
+        filteredUnpinned.length === 0 ? (
+          <div className="px-5 pb-5">
+            <p className="px-1 py-2 text-xs text-muted-foreground">
+              No agents found
+            </p>
+          </div>
+        ) : null}
+      </div>
+    </>
   );
 }
 
@@ -542,19 +596,15 @@ function TriggerSelectionStep({
 
 function WorkflowAutomationDialogFooter({
   step,
-  selectedAgentId,
   onBack,
   onCancel,
-  onNext,
 }: {
   readonly step: 1 | 2;
-  readonly selectedAgentId: string;
   readonly onBack: () => void;
   readonly onCancel: () => void;
-  readonly onNext: () => void;
 }) {
   return (
-    <DialogFooter>
+    <DialogFooter className="px-5 pb-5 pt-3">
       {step === 2 ? (
         <Button
           type="button"
@@ -569,11 +619,6 @@ function WorkflowAutomationDialogFooter({
       <Button type="button" variant="outline" onClick={onCancel}>
         Cancel
       </Button>
-      {step === 1 ? (
-        <Button type="button" disabled={!selectedAgentId} onClick={onNext}>
-          Next
-        </Button>
-      ) : null}
     </DialogFooter>
   );
 }
@@ -588,11 +633,16 @@ function CreateWorkflowAutomationDialog() {
   const selectedAgentIdState = useGet(selectedWorkflowAutomationAgentId$);
   const setSelectedAgentId = useSet(setSelectedWorkflowAutomationAgentId$);
   const navigate = useSet(detachedNavigateTo$);
-  const selectedAgentId = selectedAgentIdState || agents[0]?.id || "";
+  const selectedAgentId = selectedAgentIdState;
   const selectedAgent =
     agents.find((agent) => {
       return agent.id === selectedAgentId;
     }) ?? null;
+
+  const selectAgent = (agentId: string) => {
+    setSelectedAgentId(agentId);
+    setStep(2);
+  };
 
   const startWorkflowCreation = (option: WorkflowAutomationOption) => {
     if (!selectedAgentId) {
@@ -607,40 +657,38 @@ function CreateWorkflowAutomationDialog() {
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogContent className="max-w-2xl">
-        <DialogHeader>
-          <DialogTitle>Add automation</DialogTitle>
-          <DialogDescription>
-            Choose the agent and trigger type for this workflow automation.
+      <DialogContent className="zero-app w-[calc(100vw-2rem)] gap-0 p-0 sm:max-w-xl">
+        <DialogHeader className="px-5 pb-3 pt-5">
+          <DialogTitle className="text-base font-semibold">
+            Add automation
+          </DialogTitle>
+          <DialogDescription className="mt-1 text-sm text-muted-foreground">
+            Choose the agent and trigger type for this workflow.
           </DialogDescription>
         </DialogHeader>
 
-        <WorkflowAutomationStepPills step={step} />
+        <div className="px-5 pb-3">
+          <WorkflowAutomationStepPills step={step} />
+        </div>
 
         {step === 1 ? (
-          <AgentSelectionStep
-            agents={agents}
-            selectedAgentId={selectedAgentId}
-            onSelectAgent={setSelectedAgentId}
-          />
+          <AgentSelectionStep agents={agents} onSelectAgent={selectAgent} />
         ) : (
-          <TriggerSelectionStep
-            selectedAgentName={selectedAgent?.displayName ?? "Selected agent"}
-            onSelectOption={startWorkflowCreation}
-          />
+          <div className="px-5">
+            <TriggerSelectionStep
+              selectedAgentName={selectedAgent?.displayName ?? "Selected agent"}
+              onSelectOption={startWorkflowCreation}
+            />
+          </div>
         )}
 
         <WorkflowAutomationDialogFooter
           step={step}
-          selectedAgentId={selectedAgentId}
           onBack={() => {
             setStep(1);
           }}
           onCancel={() => {
             setOpen(false);
-          }}
-          onNext={() => {
-            setStep(2);
           }}
         />
       </DialogContent>

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-dialogs.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-dialogs.tsx
@@ -1,5 +1,6 @@
 // TODO(#8609): split large components to comply with max-lines-per-function (128)
 // oxlint-disable max-lines-per-function
+import type { ReactNode } from "react";
 import { useGet, useSet, useLastResolved } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import {
@@ -49,6 +50,122 @@ import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { AgentAvatarImg, AvatarFromUrl } from "./zero-sidebar-shared.tsx";
 
+export interface AgentDialogItem {
+  readonly id: string;
+  readonly displayName?: string | null;
+}
+
+function agentDialogLabel(agent: AgentDialogItem): string {
+  return agent.displayName ?? agent.id;
+}
+
+export function agentDialogMatchesQuery(
+  agent: AgentDialogItem,
+  trimmedQuery: string,
+): boolean {
+  return (
+    agent.id.toLowerCase().includes(trimmedQuery) ||
+    (agent.displayName ?? "").toLowerCase().includes(trimmedQuery)
+  );
+}
+
+export function AgentDialogSearch({
+  query,
+  setQuery,
+}: {
+  readonly query: string;
+  readonly setQuery: (query: string) => void;
+}) {
+  return (
+    <div className="px-5 pb-3">
+      <div className="relative w-full">
+        <IconSearch
+          size={16}
+          stroke={2}
+          className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
+        />
+        <Input
+          type="text"
+          value={query}
+          onChange={(e) => {
+            return setQuery(e.target.value);
+          }}
+          placeholder="Search agents..."
+          className={`pl-9 ${query ? "pr-9" : ""}`}
+        />
+        {query && (
+          <button
+            type="button"
+            onClick={() => {
+              return setQuery("");
+            }}
+            className="absolute right-1.5 top-1/2 flex h-7 w-7 shrink-0 -translate-y-1/2 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            aria-label="Clear search"
+          >
+            <IconX size={14} stroke={2} />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function AgentDialogSection({
+  label,
+  children,
+  className = "pb-2",
+}: {
+  readonly label: string;
+  readonly children: ReactNode;
+  readonly className?: string;
+}) {
+  return (
+    <div className={`px-5 ${className}`}>
+      <span className="px-1 text-xs font-medium text-muted-foreground">
+        {label}
+      </span>
+      <div className="mt-1 flex flex-col">{children}</div>
+    </div>
+  );
+}
+
+export function AgentDialogAgentButton({
+  agent,
+  onSelect,
+  avatar,
+  subtitle,
+}: {
+  readonly agent: AgentDialogItem;
+  readonly onSelect: () => void;
+  readonly avatar?: ReactNode;
+  readonly subtitle?: ReactNode;
+}) {
+  const label = agentDialogLabel(agent);
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className="flex min-w-0 flex-1 items-center gap-2 text-left"
+    >
+      {avatar ?? (
+        <AgentAvatarImg
+          name={agent.id}
+          alt={label}
+          className="h-8 w-8 shrink-0 rounded-lg object-cover object-top"
+        />
+      )}
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-sm text-foreground">{label}</span>
+        {subtitle ? (
+          <span className="block truncate text-xs text-muted-foreground">
+            {subtitle}
+          </span>
+        ) : null}
+      </span>
+    </button>
+  );
+}
+
 function SortablePinnedAgent({
   agent,
   onUnpin,
@@ -71,23 +188,10 @@ function SortablePinnedAgent({
     <div
       ref={setNodeRef}
       style={style}
-      className="flex items-center gap-2 px-1 py-2 rounded-lg hover:bg-accent transition-colors group"
+      className="group flex items-center gap-2 rounded-lg px-1 py-2 transition-colors hover:bg-accent"
     >
       {onChat ? (
-        <button
-          type="button"
-          onClick={onChat}
-          className="flex items-center gap-2 flex-1 min-w-0"
-        >
-          <AgentAvatarImg
-            name={agent.id}
-            alt={agent.displayName ?? agent.id}
-            className="h-8 w-8 shrink-0 rounded-lg object-cover object-top"
-          />
-          <span className="text-sm text-foreground truncate">
-            {agent.displayName ?? agent.id}
-          </span>
-        </button>
+        <AgentDialogAgentButton agent={agent} onSelect={onChat} />
       ) : (
         <>
           <AgentAvatarImg
@@ -95,7 +199,7 @@ function SortablePinnedAgent({
             alt={agent.displayName ?? agent.id}
             className="h-8 w-8 shrink-0 rounded-lg object-cover object-top"
           />
-          <span className="text-sm text-foreground min-w-0 flex-1 truncate">
+          <span className="min-w-0 flex-1 truncate text-sm text-foreground">
             {agent.displayName ?? agent.id}
           </span>
         </>
@@ -103,7 +207,7 @@ function SortablePinnedAgent({
       <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100">
         <button
           type="button"
-          className="shrink-0 flex h-8 w-8 items-center justify-center rounded-lg cursor-grab active:cursor-grabbing touch-none text-muted-foreground transition-colors hover:bg-muted-foreground/12 hover:text-foreground dark:hover:bg-muted-foreground/18 disabled:cursor-not-allowed disabled:opacity-50"
+          className="flex h-8 w-8 shrink-0 cursor-grab touch-none items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted-foreground/12 hover:text-foreground active:cursor-grabbing disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-muted-foreground/18"
           aria-label={`Reorder ${agent.displayName ?? agent.id}`}
           disabled={disabled}
           {...attributes}
@@ -113,7 +217,7 @@ function SortablePinnedAgent({
         </button>
         <button
           type="button"
-          className="shrink-0 flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted-foreground/12 hover:text-foreground dark:hover:bg-muted-foreground/18 disabled:cursor-not-allowed disabled:opacity-50"
+          className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted-foreground/12 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-muted-foreground/18"
           onClick={onUnpin}
           aria-label={`Unpin ${agent.displayName ?? agent.id}`}
           disabled={disabled}
@@ -170,18 +274,12 @@ export function AgentListDialog({
   const trimmedQuery = query.trim().toLowerCase();
   const filteredPinned = trimmedQuery
     ? pinned.filter((a) => {
-        return (
-          a.id.toLowerCase().includes(trimmedQuery) ||
-          (a.displayName ?? "").toLowerCase().includes(trimmedQuery)
-        );
+        return agentDialogMatchesQuery(a, trimmedQuery);
       })
     : pinned;
   const filteredUnpinned = trimmedQuery
     ? unpinned.filter((a) => {
-        return (
-          a.id.toLowerCase().includes(trimmedQuery) ||
-          (a.displayName ?? "").toLowerCase().includes(trimmedQuery)
-        );
+        return agentDialogMatchesQuery(a, trimmedQuery);
       })
     : unpinned;
   const showLead =
@@ -228,75 +326,34 @@ export function AgentListDialog({
           </DialogDescription>
         </DialogHeader>
 
-        {/* Search */}
-        <div className="px-5 pb-3">
-          <div className="relative w-full">
-            <IconSearch
-              size={16}
-              stroke={2}
-              className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
-            />
-            <Input
-              type="text"
-              value={query}
-              onChange={(e) => {
-                return setQuery(e.target.value);
-              }}
-              placeholder="Search agents..."
-              className={`pl-9 ${query ? "pr-9" : ""}`}
-            />
-            {query && (
-              <button
-                type="button"
-                onClick={() => {
-                  return setQuery("");
-                }}
-                className="absolute right-1.5 top-1/2 -translate-y-1/2 flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-                aria-label="Clear search"
-              >
-                <IconX size={14} stroke={2} />
-              </button>
-            )}
-          </div>
-        </div>
+        <AgentDialogSearch query={query} setQuery={setQuery} />
 
         <div className="max-h-[min(520px,65vh)] overflow-y-auto">
           {/* Lead agent */}
           {showLead && (
-            <div className="px-5 pb-2">
-              <span className="text-xs font-medium text-muted-foreground px-1">
-                Lead
-              </span>
-              <button
-                type="button"
-                onClick={() => {
-                  return handleChat(null);
-                }}
-                className="flex w-full items-center gap-2 px-1 py-2 rounded-lg hover:bg-accent transition-colors"
-              >
-                <AvatarFromUrl
-                  avatarUrl={zeroAvatarUrl}
-                  alt={displayName}
-                  className="h-8 w-8 shrink-0 rounded-lg object-cover object-top"
+            <AgentDialogSection label="Lead">
+              <div className="flex items-center gap-2 rounded-lg px-1 py-2 transition-colors hover:bg-accent">
+                <AgentDialogAgentButton
+                  agent={{ id: "lead", displayName }}
+                  onSelect={() => {
+                    return handleChat(null);
+                  }}
+                  avatar={
+                    <AvatarFromUrl
+                      avatarUrl={zeroAvatarUrl}
+                      alt={displayName}
+                      className="h-8 w-8 shrink-0 rounded-lg object-cover object-top"
+                    />
+                  }
+                  subtitle="Your lead assistant, always here for you"
                 />
-                <div className="flex-1 min-w-0 text-left">
-                  <span className="text-sm font-medium text-foreground truncate block">
-                    {displayName}
-                  </span>
-                  <span className="text-xs text-muted-foreground">
-                    Your lead assistant, always here for you
-                  </span>
-                </div>
-              </button>
-            </div>
+              </div>
+            </AgentDialogSection>
           )}
 
           {/* Pinned agents */}
           {filteredPinned.length > 0 && (
-            <div className="px-5 pb-2">
-              <span className="text-xs font-medium text-muted-foreground px-1">
-                Pinned
-              </span>
+            <AgentDialogSection label="Pinned">
               <DndContext
                 sensors={sensors}
                 collisionDetection={closestCenter}
@@ -308,7 +365,7 @@ export function AgentListDialog({
                   })}
                   strategy={verticalListSortingStrategy}
                 >
-                  <div className="flex flex-col mt-1">
+                  <>
                     {filteredPinned.map((agent) => {
                       return (
                         <SortablePinnedAgent
@@ -324,66 +381,51 @@ export function AgentListDialog({
                         />
                       );
                     })}
-                  </div>
+                  </>
                 </SortableContext>
               </DndContext>
-            </div>
+            </AgentDialogSection>
           )}
 
           {/* Unpinned agents */}
           {filteredUnpinned.length > 0 && (
-            <div className="px-5 pb-3">
-              <span className="text-xs font-medium text-muted-foreground px-1">
-                Others
-              </span>
-              <div className="flex flex-col mt-1">
-                {filteredUnpinned.map((agent) => {
-                  return (
-                    <div
-                      key={agent.id}
-                      className="flex items-center gap-2 px-1 py-2 rounded-lg hover:bg-accent transition-colors group"
-                    >
-                      <button
-                        type="button"
-                        onClick={() => {
-                          return handleChat(agent.id);
-                        }}
-                        className="flex items-center gap-2 flex-1 min-w-0"
-                      >
-                        <AgentAvatarImg
-                          name={agent.id}
-                          alt={agent.displayName ?? agent.id}
-                          className="h-8 w-8 shrink-0 rounded-lg object-cover object-top"
-                        />
-                        <span className="text-sm text-foreground truncate">
-                          {agent.displayName ?? agent.id}
-                        </span>
-                      </button>
-                      <TooltipProvider delayDuration={200}>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <button
-                              type="button"
-                              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground opacity-0 transition-all duration-150 group-hover:opacity-100 group-focus-within:opacity-100 [@media(hover:none)]:opacity-100 hover:bg-muted-foreground/12 hover:text-foreground dark:hover:bg-muted-foreground/18 disabled:cursor-not-allowed disabled:opacity-50"
-                              onClick={() => {
-                                return togglePin(agent.id);
-                              }}
-                              aria-label="Pin to sidebar"
-                              disabled={saving}
-                            >
-                              <IconPin size={16} stroke={2} />
-                            </button>
-                          </TooltipTrigger>
-                          <TooltipContent side="right">
-                            <p className="text-xs">Pin to sidebar</p>
-                          </TooltipContent>
-                        </Tooltip>
-                      </TooltipProvider>
-                    </div>
-                  );
-                })}
-              </div>
-            </div>
+            <AgentDialogSection label="Others" className="pb-3">
+              {filteredUnpinned.map((agent) => {
+                return (
+                  <div
+                    key={agent.id}
+                    className="group flex items-center gap-2 rounded-lg px-1 py-2 transition-colors hover:bg-accent"
+                  >
+                    <AgentDialogAgentButton
+                      agent={agent}
+                      onSelect={() => {
+                        return handleChat(agent.id);
+                      }}
+                    />
+                    <TooltipProvider delayDuration={200}>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            type="button"
+                            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground opacity-0 transition-all duration-150 group-hover:opacity-100 group-focus-within:opacity-100 [@media(hover:none)]:opacity-100 hover:bg-muted-foreground/12 hover:text-foreground dark:hover:bg-muted-foreground/18 disabled:cursor-not-allowed disabled:opacity-50"
+                            onClick={() => {
+                              return togglePin(agent.id);
+                            }}
+                            aria-label="Pin to sidebar"
+                            disabled={saving}
+                          >
+                            <IconPin size={16} stroke={2} />
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent side="right">
+                          <p className="text-xs">Pin to sidebar</p>
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  </div>
+                );
+              })}
+            </AgentDialogSection>
           )}
 
           {subagents.length === 0 && (


### PR DESCRIPTION
## Summary
- Reuse the Talk to modal's agent search, section, and row styling for the Add automation agent step.
- Make agent row clicks advance directly to the trigger selection step.
- Keep pin/unpin and reorder controls out of the Add automation flow.

## Verification
- `pnpm -C turbo -F @vm0/app lint`
- `pnpm -C turbo -F @vm0/app check-types`
- `pnpm -C turbo -F @vm0/app test src/views/zero-page/__tests__/zero-automations-page.test.tsx`
- `pnpm -C turbo -F @vm0/app test src/views/zero-page/__tests__/zero-sidebar.test.tsx`
