### PR TITLE
perf: add zero run origin timing attribution

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1894,6 +1894,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
         connector_scope_source: "zero_agent",
         stored_connector_count_bucket: "1",
         stored_connector_secret_count_bucket: "1",
+        zero_run_origin: "zero_run",
       }),
     );
     expectApiDispatchTimingEventsNotToLeak(timingEvents, [
@@ -2012,17 +2013,19 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     expectNoApiDispatchActions(timingEvents, [
       "api_dispatch_prepare_context_decrypt_stored_connector_secrets",
     ]);
-    expect(
-      singleApiDispatchEvent(
-        timingEvents,
-        "api_dispatch_prepare_context_build_stored_connector_state",
-      ),
-    ).toStrictEqual(
+    const buildStoredConnectorStateEvent = singleApiDispatchEvent(
+      timingEvents,
+      "api_dispatch_prepare_context_build_stored_connector_state",
+    );
+    expect(buildStoredConnectorStateEvent).toStrictEqual(
       expect.objectContaining({
         connector_scope_source: "legacy_all",
         stored_connector_count_bucket: "1",
         stored_connector_secret_count_bucket: "0",
       }),
+    );
+    expect(buildStoredConnectorStateEvent).not.toHaveProperty(
+      "zero_run_origin",
     );
     expectApiDispatchTimingEventsNotToLeak(timingEvents, [
       "x-bdd-overridden-access",

--- a/turbo/apps/api/src/signals/routes/__tests__/test-telegram-dispatch-probe.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-telegram-dispatch-probe.test.ts
@@ -365,6 +365,7 @@ describe("POST /api/test/telegram-dispatch-probe", () => {
           op_type: "api_dispatch_pre_create_agent_run",
           span_kind: "top_level",
           trigger_source: "telegram",
+          zero_run_origin: "zero_integration",
         }),
         expect.objectContaining({
           op_type: "api_dispatch_pre_create_zero_entrypoint_gap",

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts
@@ -1292,6 +1292,7 @@ describe("POST /api/telegram/webhook/:telegramBotId", () => {
           op_type: "api_dispatch_pre_create_agent_run",
           span_kind: "top_level",
           trigger_source: "telegram",
+          zero_run_origin: "zero_run",
         }),
         expect.objectContaining({
           op_type: "api_dispatch_pre_create_zero_entrypoint_gap",

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-triggers.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-triggers.test.ts
@@ -57,6 +57,25 @@ function detailClient() {
   return setupApp({ context })(zeroWorkflowsDetailContract);
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function sandboxOperationEventsForRun(
+  runId: string,
+): readonly Record<string, unknown>[] {
+  return context.mocks.axiom.sdkIngest.mock.calls.flatMap((call) => {
+    const dataset = call[0];
+    const events = call[1];
+    if (dataset !== "vm0-sandbox-op-log-dev" || !Array.isArray(events)) {
+      return [];
+    }
+    return events.filter((event): event is Record<string, unknown> => {
+      return isRecord(event) && event.run_id === runId;
+    });
+  });
+}
+
 const WORKFLOW_NAME = "trigger-workflow";
 const GMAIL_TOPIC_NAME = "projects/vm0-ai-488909/topics/gmail-events";
 const GMAIL_EMAIL = "workflow-user@example.com";
@@ -1172,6 +1191,15 @@ describe("zero workflow triggers", () => {
       workflowTriggerId: created.body.id,
       triggerSource: "workflow-schedule",
     });
+    expect(sandboxOperationEventsForRun(run.body.runId)).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          op_type: "api_dispatch_pre_create_agent_run",
+          trigger_source: "workflow-schedule",
+          zero_run_origin: "workflow_trigger",
+        }),
+      ]),
+    );
 
     const [trigger] = await db
       .select({

--- a/turbo/apps/api/src/signals/services/__tests__/agent-run-callback.service.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/agent-run-callback.service.test.ts
@@ -4,6 +4,7 @@ import { createStore } from "ccstate";
 import { and, eq, inArray } from "drizzle-orm";
 import { HttpResponse, http } from "msw";
 import { afterEach, describe, expect, it } from "vitest";
+import { agentComposeVersions } from "@vm0/db/schema/agent-compose";
 import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
 import { agentSessions } from "@vm0/db/schema/agent-session";
 import { automations, automationTriggers } from "@vm0/db/schema/automation";
@@ -1690,13 +1691,51 @@ async function seedGoalForThread(args: {
   });
 }
 
+async function addAnthropicKeyToCompose(composeId: string): Promise<void> {
+  await store
+    .set(writeDb$)
+    .update(agentComposeVersions)
+    .set({
+      content: {
+        version: "1.0",
+        agents: {
+          "test-agent": {
+            framework: "claude-code",
+            environment: { ANTHROPIC_API_KEY: "test-key" },
+          },
+        },
+      },
+    })
+    .where(eq(agentComposeVersions.composeId, composeId));
+}
+
 function pushPayload(call: readonly unknown[] | undefined): unknown {
   const raw = call?.[1];
   return JSON.parse(typeof raw === "string" ? raw : "{}");
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function sandboxOperationEventsForRun(
+  runId: string,
+): readonly Record<string, unknown>[] {
+  return context.mocks.axiom.sdkIngest.mock.calls.flatMap((call) => {
+    const dataset = call[0];
+    const events = call[1];
+    if (dataset !== "vm0-sandbox-op-log-dev" || !Array.isArray(events)) {
+      return [];
+    }
+    return events.filter((event): event is Record<string, unknown> => {
+      return isRecord(event) && event.run_id === runId;
+    });
+  });
+}
+
 describe("dispatchRunCallbacks$ goal push notification gating", () => {
   it("suppresses the push while an active goal keeps looping", async () => {
+    mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
     const fixture = await seedChatCallbackRun({ status: "completed" });
     await enablePushDelivery(fixture.userId);
     await seedGoalForThread({
@@ -1707,6 +1746,7 @@ describe("dispatchRunCallbacks$ goal push notification gating", () => {
       objective: "Keep the changelog up to date",
       status: "active",
     });
+    await addAnthropicKeyToCompose(fixture.composeId);
     mockChatOutput("Made progress this turn.");
     mockChatOpenRouterCompletions();
     await store.set(
@@ -1732,6 +1772,33 @@ describe("dispatchRunCallbacks$ goal push notification gating", () => {
     await flushWaitUntilForTest();
 
     expect(context.mocks.webpush.sendNotification).not.toHaveBeenCalled();
+    const [continuationRun] = await db
+      .select({
+        id: zeroRuns.id,
+        goalId: zeroRuns.goalId,
+        triggerSource: zeroRuns.triggerSource,
+      })
+      .from(zeroRuns)
+      .where(
+        and(
+          eq(zeroRuns.chatThreadId, fixture.threadId),
+          eq(zeroRuns.triggerSource, "workflow-event"),
+        ),
+      )
+      .limit(1);
+    if (!continuationRun) {
+      throw new Error("Expected goal continuation to create a run");
+    }
+    expect(continuationRun.goalId).not.toBeNull();
+    expect(sandboxOperationEventsForRun(continuationRun.id)).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          op_type: "api_dispatch_pre_create_agent_run",
+          trigger_source: "workflow-event",
+          zero_run_origin: "goal_continuation",
+        }),
+      ]),
+    );
   });
 
   it("sends the push once the goal reaches a terminal state", async () => {

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -468,6 +468,7 @@ export interface CreateAgentRunArgs {
   readonly enforceVm0Credits?: boolean;
   readonly dispatchFailedCallbacks?: DispatchFailedRunCallbacks;
   readonly timing?: ApiDispatchTimingCollector;
+  readonly timingDimensions?: ApiDispatchTimingDimensions;
 }
 
 interface ConnectorRuntimeContext {
@@ -4605,6 +4606,7 @@ function dispatchRun(
     readonly userTimezone: string | undefined;
     readonly featureSwitchContext: FeatureSwitchContext;
     readonly timing: ApiDispatchTimingCollector;
+    readonly timingDimensions: ApiDispatchTimingDimensions | undefined;
   },
 ): Computed<Promise<DerivedPersistenceResult>> {
   return computed(async (get): Promise<DerivedPersistenceResult> => {
@@ -4702,6 +4704,7 @@ function dispatchRun(
         runnerGroup: payload.runnerGroup,
         profile: payload.profile,
         dispatchPath: "direct",
+        ...(args.timingDimensions ? { dimensions: args.timingDimensions } : {}),
         ...(args.body.triggerSource
           ? { triggerSource: args.body.triggerSource }
           : {}),
@@ -5703,6 +5706,7 @@ function completePendingRun(input: {
             userTimezone: input.context.userTimezone,
             featureSwitchContext: input.context.featureSwitchContext,
             timing: input.timing,
+            timingDimensions: input.args.timingDimensions,
           }),
         ),
       );

--- a/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
+++ b/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
@@ -137,6 +137,7 @@ export class ApiDispatchTimingCollector {
     readonly profile: string;
     readonly dispatchPath: "direct";
     readonly triggerSource?: TriggerSource;
+    readonly dimensions?: ApiDispatchTimingDimensions;
   }): void {
     const records = this.records.splice(0);
     recordSandboxOperations(
@@ -149,6 +150,7 @@ export class ApiDispatchTimingCollector {
           runId: args.runId,
           timestamp: record.timestamp,
           dimensions: {
+            ...args.dimensions,
             ...record.dimensions,
             runner_group: args.runnerGroup,
             profile: args.profile,

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -40,6 +40,7 @@ import {
   ApiDispatchTimingCollector,
   measureApiDispatchTiming,
   type ApiDispatchTimingActionType,
+  type ApiDispatchTimingDimensions,
 } from "./api-dispatch-timing.service";
 import { loadAgentConnectorScope } from "./agent-connector-scope.service";
 import { loadActiveUserPermissionGrants } from "./zero-user-permission-grants.service";
@@ -48,6 +49,11 @@ import type { InternalRunCallbackKind } from "./internal-run-callback";
 
 type ZeroRunCreateBody = z.infer<(typeof zeroRunsMainContract.create)["body"]>;
 type WorkflowConnectorRefs = readonly string[];
+type ZeroRunOrigin =
+  | "zero_run"
+  | "workflow_trigger"
+  | "goal_continuation"
+  | "zero_integration";
 
 const DISALLOWED_TOOLS = [
   "CronCreate",
@@ -561,6 +567,28 @@ function buildZeroRunExtraEnvironment(args: {
   };
 }
 
+function zeroRunTimingDimensions(
+  origin: ZeroRunOrigin,
+): ApiDispatchTimingDimensions {
+  return { zero_run_origin: origin };
+}
+
+function zeroRunOrigin(args: {
+  readonly command: CreateZeroRunCommandArgs;
+  readonly triggerRun: Awaited<ReturnType<typeof resolveTriggerRunContext>>;
+}): ZeroRunOrigin {
+  if (
+    args.triggerRun.unattended ||
+    args.command.zeroRunMetadata?.workflowTriggerId
+  ) {
+    return "workflow_trigger";
+  }
+  if (args.command.zeroRunMetadata?.goalId) {
+    return "goal_continuation";
+  }
+  return "zero_run";
+}
+
 /**
  * Resolves the firewall policies for a run.
  *
@@ -913,6 +941,12 @@ function buildZeroCreateAgentRunArgs(args: {
     },
     dispatchFailedCallbacks: command.dispatchFailedCallbacks,
     timing: args.timing,
+    timingDimensions: zeroRunTimingDimensions(
+      zeroRunOrigin({
+        command,
+        triggerRun: args.triggerRun,
+      }),
+    ),
   };
 }
 
@@ -956,6 +990,7 @@ function buildZeroIntegrationCreateAgentRunArgs(args: {
     validateEnvironmentReferences: false,
     dispatchFailedCallbacks: command.dispatchFailedCallbacks,
     timing: args.timing,
+    timingDimensions: zeroRunTimingDimensions("zero_integration"),
   };
 }
 


### PR DESCRIPTION
## Summary

- add a bounded `zero_run_origin` API dispatch timing dimension for Zero run paths
- classify normal Zero runs, workflow-triggered runs, goal continuations, and integration dispatches without changing connector scope behavior
- cover the new timing dimension across Zero run, workflow trigger, Telegram integration dispatch, and goal continuation paths

Refs #19234

## Tests

- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts src/signals/routes/__tests__/zero-workflow-triggers.test.ts src/signals/routes/__tests__/zero-integrations-telegram-post.test.ts src/signals/routes/__tests__/test-telegram-dispatch-probe.test.ts src/signals/services/__tests__/agent-run-callback.service.test.ts`
- `pnpm -F api check-types`
- `pnpm -F api lint`

## Notes

- The first pre-commit attempt hit existing full-repo `knip --cache` findings unrelated to these files; the focused API checks above passed.