### PR TITLE
perf: add session history identity telemetry

### DIFF
--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -547,13 +547,20 @@ async fn try_reuse_from_pool(
 mod tests {
     use super::*;
 
+    use super::super::StartLoopTestObserver;
+    use super::super::job_lifecycle::{ActiveBudgetLease, CompletionPayload, RunCleanupState};
+    use super::super::sandbox_finalization::{FinalizeContext, finalize_sandbox_for_completion};
     use crate::http::HttpClientConfig;
     use crate::idle_pool::test_support::ParkedIdleCandidateBuilder;
-    use crate::idle_pool::{IdlePool, IdlePoolConfig, ParkResult};
+    use crate::idle_pool::{IdlePool, IdlePoolConfig, ParkResult, ParkingGate};
+    use crate::network_log_drain::NetworkLogDrainCoordinator;
+    use crate::provider::CompletionAuth;
     use crate::resource_budget::ResourceBudget;
     use crate::status::IdleVm;
     use crate::test_fixtures::execution_context_for_test;
     use crate::types::{ResumeSession, ResumeSessionHistory, ResumeSessionHistoryRef};
+    use sandbox::SandboxFactory;
+    use sandbox_mock::{MockSandbox, MockSandboxFactory};
 
     fn read_active_run_phase(path: &std::path::Path) -> String {
         let raw = std::fs::read_to_string(path).unwrap();
@@ -631,6 +638,81 @@ mod tests {
         *sandbox
     }
 
+    async fn reusable_sandbox_parked_by_finalizer(
+        restored_session_identity: Option<RestoredSessionIdentity>,
+    ) -> ReusableIdleSandbox {
+        let dir = tempfile::tempdir().unwrap();
+        let status = Arc::new(StatusTracker::new(
+            dir.path().join("status.json"),
+            4,
+            None,
+            None,
+        ));
+        status.write_initial().await;
+        let parking_gate = ParkingGate::new_open();
+        let idle_pool: SharedIdlePool =
+            Arc::new(tokio::sync::Mutex::new(IdlePool::new_with_parking_gate(
+                IdlePoolConfig {
+                    default_timeout: std::time::Duration::from_secs(300),
+                    max_idle: 10,
+                },
+                parking_gate.clone(),
+            )));
+        let budget = Arc::new(ResourceBudget::new(2, 4096, 1.0, 0));
+        let lease = ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap();
+        let run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+
+        let _completion_ready = finalize_sandbox_for_completion(
+            Some(Box::new(MockSandbox::new("restore-plan-finalizer"))),
+            ActiveBudgetLease::new(lease),
+            CompletionPayload::new(
+                run_id,
+                0,
+                None,
+                sandbox_id,
+                SandboxReuseResult::PoolMiss,
+                CompletionAuth::local(),
+            ),
+            FinalizeContext {
+                run_id,
+                sandbox_id,
+                profile_name: "vm0/default".into(),
+                cli_agent_session_id: Some("sess-restore-plan".into()),
+                discovered_cli_agent_session_id: None,
+                restored_session_identity,
+                source_ip: "10.0.0.1".into(),
+                network_log_session: None,
+                workspace_image: None,
+                workspace_image_size_bytes: 0,
+                storage_fingerprints: crate::storage_fingerprints::StorageFingerprints::default(),
+                device_rate_limits: None,
+                factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
+                idle_pool: Arc::clone(&idle_pool),
+                status,
+                park_notify: Arc::new(tokio::sync::Notify::new()),
+                parking_gate,
+                network_log_drain: NetworkLogDrainCoordinator::noop(),
+                exit_code: 0,
+                cancel: RunCancellationHandle::new(),
+                cleanup_state: RunCleanupState::new(),
+                outer_job_panic: None,
+                test_observer: StartLoopTestObserver::default(),
+            },
+        )
+        .await;
+
+        let entry = idle_pool
+            .lock()
+            .await
+            .take("sess-restore-plan")
+            .expect("finalizer should park reusable sandbox");
+        let IdleUnparkResult::Reused { sandbox, .. } = entry.try_unpark().await else {
+            panic!("finalized idle entry should unpark");
+        };
+        *sandbox
+    }
+
     #[tokio::test]
     async fn publish_active_run_status_writes_preparing_after_reuse_miss_snapshot() {
         let dir = tempfile::tempdir().unwrap();
@@ -701,6 +783,39 @@ mod tests {
                 );
             }
             _ => panic!("matching reused identity should skip restore"),
+        }
+    }
+
+    #[tokio::test]
+    async fn restore_plan_skips_identity_parked_by_finalizer() {
+        let http = test_http_client();
+        let context = context_with_history_ref("history-hash-a");
+        let restored_identity = RestoredSessionIdentity::from_context(&context)
+            .unwrap()
+            .with_guest_history(
+                12,
+                "/home/user/.claude/projects/-home-user-workspace/session.jsonl",
+            );
+        let reusable_sandbox =
+            reusable_sandbox_parked_by_finalizer(Some(restored_identity.clone())).await;
+        let cancel = RunCancellationHandle::new();
+        let mut timing = RunnerPreSpawnTiming::start_after_claim();
+
+        let plan = build_session_history_restore_plan(
+            &http,
+            &context,
+            true,
+            &cancel,
+            Some(&reusable_sandbox),
+            SandboxReuseResult::Reused,
+            &mut timing,
+        );
+
+        match plan {
+            SessionHistoryRestorePlan::SkipVerified(identity) => {
+                assert_eq!(identity, restored_identity);
+            }
+            _ => panic!("finalizer-parked restored identity should skip restore"),
         }
     }
 
@@ -906,6 +1021,35 @@ mod tests {
                 );
             }
             _ => panic!("missing reused identity should fall back to restore"),
+        }
+    }
+
+    #[tokio::test]
+    async fn restore_plan_falls_back_when_finalizer_parked_without_identity() {
+        let http = test_http_client();
+        let context = context_with_history_ref("history-hash-a");
+        let reusable_sandbox = reusable_sandbox_parked_by_finalizer(None).await;
+        let cancel = RunCancellationHandle::new();
+        let mut timing = RunnerPreSpawnTiming::start_after_claim();
+
+        let plan = build_session_history_restore_plan(
+            &http,
+            &context,
+            true,
+            &cancel,
+            Some(&reusable_sandbox),
+            SandboxReuseResult::Reused,
+            &mut timing,
+        );
+
+        match plan {
+            SessionHistoryRestorePlan::Prestarted { fallback, .. } => {
+                assert_eq!(
+                    fallback,
+                    Some(SessionHistoryRestoreFallback::MissingIdleIdentity)
+                );
+            }
+            _ => panic!("finalizer-parked missing identity should fall back to restore"),
         }
     }
 

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -6,7 +6,7 @@
 
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use agent_diagnostics::{CliTerminationDiagnostic, FailureClass, FailureDiagnostic, FailureReason};
 use futures_util::FutureExt;
@@ -282,7 +282,7 @@ impl FinalizationPhase {
             outcome,
             exit_code,
             err,
-            telemetry,
+            mut telemetry,
         } = executor_result;
         let executor::ExecuteOutcome {
             failure: _,
@@ -293,6 +293,8 @@ impl FinalizationPhase {
             discovered_cli_agent_session_id,
             restored_session_identity,
         } = outcome;
+        let has_restored_session_identity = restored_session_identity.is_some();
+        let cleanup_state_after_finalize = cleanup_state.clone();
 
         let completion_payload = CompletionPayload::new(
             run_id,
@@ -338,12 +340,33 @@ impl FinalizationPhase {
             },
         )
         .await;
+        record_session_history_identity_park_telemetry(
+            &mut telemetry,
+            cleanup_state_after_finalize.disposition(),
+            has_restored_session_identity,
+        );
 
         FinalizedJob {
             completion_ready,
             telemetry,
         }
     }
+}
+
+fn record_session_history_identity_park_telemetry(
+    telemetry: &mut JobTelemetry,
+    disposition: RunCleanupDisposition,
+    has_restored_session_identity: bool,
+) {
+    if !matches!(disposition, RunCleanupDisposition::IdlePoolOwned) {
+        return;
+    }
+    let action_type = if has_restored_session_identity {
+        "session_history_identity_parked"
+    } else {
+        "session_history_identity_park_missing"
+    };
+    telemetry.record(action_type, Duration::ZERO, true, None);
 }
 
 struct CompletionPhase {
@@ -951,6 +974,7 @@ mod tests {
         FailureClass, FailureDetailSource, PromptMetadata, SessionHistoryStatus,
     };
     use sandbox::SandboxId;
+    use sandbox_mock::MockSandbox;
     use tracing::Level;
     use tracing_subscriber::prelude::*;
     use tracing_test_support::{CapturedEvent, CapturedEvents};
@@ -958,11 +982,14 @@ mod tests {
     use super::super::idle_lifecycle::SharedIdlePool;
     use super::super::job_lifecycle::RunCleanupState;
     use super::super::orphan_reap::OrphanedActiveRuns;
+    use crate::http::{HttpClient, HttpClientConfig};
     use crate::idle_pool::{
-        IdlePool, IdlePoolConfig, ParkResult, test_support::ParkedIdleCandidateBuilder,
+        IdlePool, IdlePoolConfig, IdleUnparkResult, ParkResult,
+        test_support::ParkedIdleCandidateBuilder,
     };
     use crate::ids::RunId;
     use crate::resource_budget::ResourceBudget;
+    use crate::restored_session_identity::RestoredSessionIdentity;
     use crate::status::StatusTracker;
 
     fn job_failure_diagnostic(failure_reason: Option<FailureReason>) -> FailureDiagnostic {
@@ -1005,6 +1032,118 @@ mod tests {
         assert_eq!(value, expected, "field {field} mismatch; event={event:#?}");
     }
 
+    fn test_http_client() -> HttpClient {
+        HttpClient::new(HttpClientConfig {
+            api_url: "http://localhost".into(),
+            vercel_bypass: None,
+        })
+        .unwrap()
+    }
+
+    fn test_budget_lease() -> (Arc<ResourceBudget>, BudgetLease) {
+        let budget = Arc::new(ResourceBudget::new(8, 32768, 1.0, 0));
+        let lease = ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap();
+        (budget, lease)
+    }
+
+    fn assert_telemetry_action(telemetry: &JobTelemetry, action: &str) {
+        let ops = telemetry.pending_ops_snapshot();
+        assert!(
+            ops.iter().any(|op| op.0 == action && op.1),
+            "expected telemetry action {action}, got: {ops:?}"
+        );
+    }
+
+    struct FinalizationTelemetryFixture {
+        _dir: tempfile::TempDir,
+        status: Arc<StatusTracker>,
+        idle_pool: SharedIdlePool,
+        parking_gate: ParkingGate,
+        park_notify: Arc<tokio::sync::Notify>,
+    }
+
+    impl FinalizationTelemetryFixture {
+        async fn new() -> Self {
+            let dir = tempfile::tempdir().unwrap();
+            let status = Arc::new(StatusTracker::new(
+                dir.path().join("status.json"),
+                4,
+                None,
+                None,
+            ));
+            status.write_initial().await;
+            let parking_gate = ParkingGate::new_open();
+            let idle_pool = Arc::new(tokio::sync::Mutex::new(IdlePool::new_with_parking_gate(
+                IdlePoolConfig {
+                    default_timeout: Duration::from_secs(300),
+                    max_idle: 10,
+                },
+                parking_gate.clone(),
+            )));
+
+            Self {
+                _dir: dir,
+                status,
+                idle_pool,
+                parking_gate,
+                park_notify: Arc::new(tokio::sync::Notify::new()),
+            }
+        }
+
+        fn finalization_phase(
+            &self,
+            run_id: RunId,
+            sandbox_id: SandboxId,
+            session_id: &str,
+            active_lease: BudgetLease,
+            cleanup_state: RunCleanupState,
+        ) -> FinalizationPhase {
+            FinalizationPhase {
+                run_id,
+                sandbox_id,
+                completion_auth: CompletionAuth::local(),
+                active_lease,
+                reuse_result: SandboxReuseResult::PoolMiss,
+                workspace_disk_mb: 0,
+                profile_name: "vm0/default".into(),
+                cli_agent_session_id: Some(session_id.into()),
+                storage_fingerprints: StorageFingerprints::default(),
+                device_rate_limits: None,
+                factory: Arc::new(Box::new(sandbox_mock::MockSandboxFactory::new())),
+                idle_pool: Arc::clone(&self.idle_pool),
+                status: Arc::clone(&self.status),
+                park_notify: Arc::clone(&self.park_notify),
+                parking_gate: self.parking_gate.clone(),
+                network_log_drain: NetworkLogDrainCoordinator::noop(),
+                cancel: RunCancellationHandle::new(),
+                cleanup_state,
+                outer_job_panic: None,
+                test_observer: StartLoopTestObserver::default(),
+            }
+        }
+    }
+
+    fn executor_phase_outcome(
+        run_id: RunId,
+        sandbox_name: &str,
+        restored_session_identity: Option<RestoredSessionIdentity>,
+    ) -> ExecutorPhaseOutcome {
+        ExecutorPhaseOutcome {
+            outcome: executor::ExecuteOutcome {
+                failure: None,
+                sandbox: Some(Box::new(MockSandbox::new(sandbox_name))),
+                source_ip: "10.0.0.1".into(),
+                network_log_session: None,
+                workspace_image: None,
+                discovered_cli_agent_session_id: None,
+                restored_session_identity,
+            },
+            exit_code: 0,
+            err: None,
+            telemetry: JobTelemetry::new(test_http_client(), run_id, "sandbox-token".into()),
+        }
+    }
+
     #[test]
     fn generic_zero_exit_code_normalizes_to_generic_failure() {
         let failure = executor::ExecutionFailure::new(0, "", None);
@@ -1041,6 +1180,95 @@ mod tests {
                 panic!("expected runner job timeout failure kind")
             }
         }
+    }
+
+    #[tokio::test]
+    async fn finalization_records_identity_parked_when_idle_pool_receives_restored_identity() {
+        let fixture = FinalizationTelemetryFixture::new().await;
+        let (_budget, lease) = test_budget_lease();
+        let run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+        let cleanup_state = RunCleanupState::new();
+        let identity = RestoredSessionIdentity::claude_code_for_test("history-hash-a")
+            .with_guest_history(
+                12,
+                "/home/user/.claude/projects/-home-user-workspace/session.jsonl",
+            );
+        let finalization = fixture.finalization_phase(
+            run_id,
+            sandbox_id,
+            "sess-restore-plan",
+            lease,
+            cleanup_state.clone(),
+        );
+
+        let finalized = finalization
+            .finalize(executor_phase_outcome(
+                run_id,
+                "identity-parked",
+                Some(identity.clone()),
+            ))
+            .await;
+
+        assert_telemetry_action(&finalized.telemetry, "session_history_identity_parked");
+        assert_eq!(
+            cleanup_state.disposition(),
+            RunCleanupDisposition::IdlePoolOwned,
+        );
+        let entry = fixture
+            .idle_pool
+            .lock()
+            .await
+            .take("sess-restore-plan")
+            .expect("parked sandbox should be in idle pool");
+        let IdleUnparkResult::Reused { sandbox, .. } = entry.try_unpark().await else {
+            panic!("parked sandbox should unpark");
+        };
+        assert_eq!(sandbox.restored_session_identity(), Some(&identity));
+    }
+
+    #[tokio::test]
+    async fn finalization_records_identity_park_missing_when_parked_without_restored_identity() {
+        let fixture = FinalizationTelemetryFixture::new().await;
+        let (_budget, lease) = test_budget_lease();
+        let run_id = RunId::new_v4();
+        let sandbox_id = SandboxId::new_v4();
+        let cleanup_state = RunCleanupState::new();
+        let session_id = "sess-park-missing";
+        let finalization = fixture.finalization_phase(
+            run_id,
+            sandbox_id,
+            session_id,
+            lease,
+            cleanup_state.clone(),
+        );
+
+        let finalized = finalization
+            .finalize(executor_phase_outcome(
+                run_id,
+                "identity-park-missing",
+                None,
+            ))
+            .await;
+
+        assert_telemetry_action(
+            &finalized.telemetry,
+            "session_history_identity_park_missing",
+        );
+        assert_eq!(
+            cleanup_state.disposition(),
+            RunCleanupDisposition::IdlePoolOwned,
+        );
+        let entry = fixture
+            .idle_pool
+            .lock()
+            .await
+            .take(session_id)
+            .expect("parked sandbox should be in idle pool");
+        let IdleUnparkResult::Reused { sandbox, .. } = entry.try_unpark().await else {
+            panic!("parked sandbox should unpark");
+        };
+        assert!(sandbox.restored_session_identity().is_none());
     }
 
     #[test]

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -473,6 +473,12 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
             match verify_restored_session_identity_for_reuse(sandbox, context, Some(identity)).await
             {
                 Some(identity) => {
+                    telemetry.record(
+                        "session_history_identity_reuse_hit",
+                        Duration::ZERO,
+                        true,
+                        None,
+                    );
                     telemetry.record("session_history_restore_skip", Duration::ZERO, true, None);
                     restored_session_identity = Some(identity);
                     None
@@ -503,6 +509,14 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         } => {
             if let Some(fallback) = fallback {
                 telemetry.record(fallback.action_type(), Duration::ZERO, true, None);
+                if matches!(fallback, SessionHistoryRestoreFallback::MissingIdleIdentity) {
+                    telemetry.record(
+                        "session_history_identity_reuse_missing",
+                        Duration::ZERO,
+                        true,
+                        None,
+                    );
+                }
             }
             Some(materializer)
         }
@@ -1007,6 +1021,14 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         restored_session_identity =
             verify_restored_session_identity_for_reuse(sandbox, context, restored_session_identity)
                 .await;
+        if restored_session_identity.is_some() {
+            telemetry.record(
+                "session_history_identity_restored",
+                Duration::ZERO,
+                true,
+                None,
+            );
+        }
     }
 
     let agent_result = match failure {

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -468,6 +468,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
 
     let mut session_restore_diagnostics = None;
     let mut restored_session_identity = None;
+    let mut produced_restored_session_identity = false;
     let session_history_materializer = match session_history_restore_plan {
         SessionHistoryRestorePlan::SkipVerified(identity) => {
             match verify_restored_session_identity_for_reuse(sandbox, context, Some(identity)).await
@@ -576,6 +577,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
             );
             let diagnostics = result?;
             restored_session_identity = diagnostics.restored_session_identity.clone();
+            produced_restored_session_identity = restored_session_identity.is_some();
             session_restore_diagnostics = Some(diagnostics);
         }
     }
@@ -1021,7 +1023,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         restored_session_identity =
             verify_restored_session_identity_for_reuse(sandbox, context, restored_session_identity)
                 .await;
-        if restored_session_identity.is_some() {
+        if produced_restored_session_identity && restored_session_identity.is_some() {
             telemetry.record(
                 "session_history_identity_restored",
                 Duration::ZERO,

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -467,8 +467,8 @@ async fn run_in_sandbox_skips_verified_session_history_restore() {
     );
     assert!(
         ops.iter()
-            .any(|op| op.0 == "session_history_identity_restored" && op.1),
-        "expected restored identity telemetry, got: {ops:?}"
+            .all(|op| op.0 != "session_history_identity_restored"),
+        "skip path should not record newly restored identity telemetry, got: {ops:?}"
     );
     assert!(
         ops.iter()

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -462,6 +462,16 @@ async fn run_in_sandbox_skips_verified_session_history_restore() {
     let ops = telemetry.pending_ops_snapshot();
     assert!(
         ops.iter()
+            .any(|op| op.0 == "session_history_identity_reuse_hit" && op.1),
+        "expected identity reuse hit telemetry, got: {ops:?}"
+    );
+    assert!(
+        ops.iter()
+            .any(|op| op.0 == "session_history_identity_restored" && op.1),
+        "expected restored identity telemetry, got: {ops:?}"
+    );
+    assert!(
+        ops.iter()
             .any(|op| op.0 == "session_history_restore_skip" && op.1),
         "expected skip telemetry, got: {ops:?}"
     );
@@ -877,6 +887,91 @@ async fn run_in_sandbox_records_fallback_and_restores_prestarted_history() {
     assert!(
         ops.iter().any(|op| op.0 == "session_restore" && op.1),
         "expected restore telemetry, got: {ops:?}"
+    );
+    assert!(
+        ops.iter()
+            .any(|op| op.0 == "session_history_identity_restored" && op.1),
+        "expected restored identity telemetry, got: {ops:?}"
+    );
+}
+
+#[tokio::test]
+async fn run_in_sandbox_records_missing_idle_identity_reuse_fallback() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let sandbox = sandbox_mock::MockSandbox::new("test");
+    let history = br#"{"type":"init"}"#;
+    let server = MockServer::start_async().await;
+    let history_mock = server
+        .mock_async(|when, then| {
+            when.method(GET).path("/history.blob");
+            then.status(200).body(history);
+        })
+        .await;
+    let mut ctx = minimal_context();
+    ctx.resume_session = Some(ResumeSession {
+        cli_agent_session_id: "sess-missing-identity-123".into(),
+        history: ResumeSessionHistory::Ref {
+            history_ref: ResumeSessionHistoryRef {
+                kind: ResumeSessionHistoryRefKind::Blob,
+                hash: hex::encode(Sha256::digest(history)),
+                url: server.url("/history.blob?token=secret"),
+                size: Some(history.len() as u64),
+            },
+        },
+    });
+    sandbox.push_read_file_result(Ok(Some(history.to_vec())));
+    let materializer = SessionHistoryMaterializer::start_cancellable(
+        &config.http,
+        ctx.resume_session.as_ref(),
+        tokio_util::sync::CancellationToken::new(),
+    );
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let result = run_in_sandbox(
+        &sandbox,
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::Reused,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None)
+            .with_session_history_restore_plan(SessionHistoryRestorePlan::Prestarted {
+                materializer,
+                fallback: Some(SessionHistoryRestoreFallback::MissingIdleIdentity),
+            }),
+    )
+    .await
+    .unwrap();
+
+    assert!(result.failure.is_none());
+    assert!(result.restored_session_identity.is_some());
+    history_mock.assert_calls_async(1).await;
+    let writes = sandbox.write_file_calls();
+    assert_eq!(writes.len(), 1);
+    assert_eq!(
+        writes[0].path,
+        "/home/user/.claude/projects/-home-user-workspace/sess-missing-identity-123.jsonl"
+    );
+    assert_eq!(writes[0].content, history);
+    let ops = telemetry.pending_ops_snapshot();
+    assert!(
+        ops.iter()
+            .any(|op| { op.0 == "session_history_restore_fallback_missing_idle_identity" && op.1 }),
+        "expected missing identity fallback telemetry, got: {ops:?}"
+    );
+    assert!(
+        ops.iter()
+            .any(|op| op.0 == "session_history_identity_reuse_missing" && op.1),
+        "expected identity reuse missing telemetry, got: {ops:?}"
+    );
+    assert!(
+        ops.iter()
+            .any(|op| op.0 == "session_history_identity_restored" && op.1),
+        "expected restored identity telemetry, got: {ops:?}"
     );
 }
 


### PR DESCRIPTION
## Summary
- record fixed runner telemetry for restored session identity park, reuse hit, reuse missing, and restored states
- keep identity_restored scoped to identities produced by this run's session restore, not skip/reuse hits
- only report park telemetry after finalization proves idle-pool ownership
- add executor/finalizer/discovery tests covering verified skip, missing idle identity fallback, and parked identity preservation into restore-plan selection

Closes #19233
Refs #18746

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all
- cargo fmt --manifest-path crates/Cargo.toml --all -- --check
- cargo test --manifest-path crates/Cargo.toml -p runner run_in_sandbox_skips_verified_session_history_restore --quiet
- cargo test --manifest-path crates/Cargo.toml -p runner run_in_sandbox_records_fallback_and_restores_prestarted_history --quiet
- cargo test --manifest-path crates/Cargo.toml -p runner run_in_sandbox_records_missing_idle_identity_reuse_fallback --quiet
- cargo test --manifest-path crates/Cargo.toml -p runner finalization_records_identity --quiet
- cargo test --manifest-path crates/Cargo.toml -p runner restore_plan_skips_identity_parked_by_finalizer --quiet
- cargo test --manifest-path crates/Cargo.toml -p runner restore_plan_falls_back_when_finalizer_parked_without_identity --quiet
- cargo test --manifest-path crates/Cargo.toml -p runner restore_plan --quiet
- git diff --check
- lefthook pre-commit cargo-fmt/cargo-doc/cargo-clippy