### PR TITLE
fix: check workflow connector authorization in doctor

### DIFF
--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
@@ -119,6 +119,7 @@ describe("zero doctor check-connector command", () => {
     vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("GH_TOKEN", "");
+    vi.stubEnv("ZERO_TOKEN", "");
   });
 
   function getOutput(): string {
@@ -421,6 +422,121 @@ describe("zero doctor check-connector command", () => {
       const output = getOutput();
       expect(output).toContain("connected and active");
       expect(output).toContain("authorized for this agent");
+    });
+
+    it("should use workflow authorization inside workflow-triggered runs", async () => {
+      const workflowId = "11111111-1111-4111-8111-111111111111";
+      const triggerId = "22222222-2222-4222-8222-222222222222";
+      vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+      vi.stubEnv("VM0_TOKEN", "test-token");
+      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
+      vi.stubEnv("ZERO_WORKFLOW_ID", workflowId);
+      vi.stubEnv("ZERO_WORKFLOW_TRIGGER_ID", triggerId);
+      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
+      server.use(
+        http.get("https://app.vm0.ai/api/zero/connectors/github", () => {
+          return HttpResponse.json(connectedResponse);
+        }),
+        http.get(
+          "https://app.vm0.ai/api/zero/workflows/:id/user-connectors",
+          () => {
+            return HttpResponse.json({ enabledTypes: [] });
+          },
+        ),
+        http.get(
+          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
+          () => {
+            return HttpResponse.json(
+              { error: { message: "wrong scope", code: "WRONG_SCOPE" } },
+              { status: 500 },
+            );
+          },
+        ),
+        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
+          return HttpResponse.json({
+            ...runContextResponse,
+            firewalls: [],
+            networkPolicies: null,
+          });
+        }),
+      );
+
+      await checkConnectorCommand.parseAsync([
+        "node",
+        "cli",
+        "--env-name",
+        "GH_TOKEN",
+        "--check-permission",
+        "contents:read",
+      ]);
+
+      const output = getOutput();
+      expect(output).toContain("Workflow authorization");
+      expect(output).toContain(
+        `The GitHub connector is not authorized for this workflow (${workflowId}).`,
+      );
+      expect(output).toContain(
+        `/agents/agent-abc-123/workflows/${workflowId}/permissions?`,
+      );
+      expect(output).toContain("ref=github");
+      expect(output).toContain(`triggerId=${triggerId}`);
+      expect(output).toContain("not the agent's connector authorization");
+      expect(output).toContain("Check the workflow authorization settings");
+      expect(output).not.toContain("Agent authorization");
+      expect(output).not.toContain(
+        "/connectors/github/authorize?agentId=agent-abc-123",
+      );
+      expect(output).not.toContain("fully permissive");
+    });
+
+    it("should report workflow authorization when the workflow enabled the connector", async () => {
+      const workflowId = "11111111-1111-4111-8111-111111111111";
+      vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+      vi.stubEnv("VM0_TOKEN", "test-token");
+      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
+      vi.stubEnv("ZERO_WORKFLOW_ID", workflowId);
+      vi.stubEnv(
+        "ZERO_WORKFLOW_TRIGGER_ID",
+        "22222222-2222-4222-8222-222222222222",
+      );
+      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
+      server.use(
+        http.get("https://app.vm0.ai/api/zero/connectors/github", () => {
+          return HttpResponse.json(connectedResponse);
+        }),
+        http.get(
+          "https://app.vm0.ai/api/zero/workflows/:id/user-connectors",
+          () => {
+            return HttpResponse.json({ enabledTypes: ["github"] });
+          },
+        ),
+        http.get(
+          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
+          () => {
+            return HttpResponse.json(
+              { error: { message: "wrong scope", code: "WRONG_SCOPE" } },
+              { status: 500 },
+            );
+          },
+        ),
+        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
+          return HttpResponse.json(runContextResponse);
+        }),
+      );
+
+      await checkConnectorCommand.parseAsync([
+        "node",
+        "cli",
+        "--env-name",
+        "GH_TOKEN",
+      ]);
+
+      const output = getOutput();
+      expect(output).toContain(
+        `The GitHub connector is authorized for this workflow (${workflowId}).`,
+      );
+      expect(output).not.toContain("authorized for this agent");
+      expect(output).not.toContain("Agent authorization");
     });
   });
 

--- a/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
@@ -32,6 +32,7 @@ import {
   searchZeroConnectors,
 } from "../../../lib/api/domains/zero-connectors";
 import { getZeroAgentUserConnectors } from "../../../lib/api/domains/zero-agents";
+import { getZeroWorkflowUserConnectors } from "../../../lib/api/domains/zero-workflows";
 import { getZeroRunContext } from "../../../lib/api/domains/zero-runs";
 import { withErrorHandler } from "../../../lib/command";
 import { toPlatformUrl } from "./platform-url";
@@ -51,6 +52,17 @@ interface DiagContext {
   connectorAvailable: boolean;
   platformOrigin: string;
   agentId: string | undefined;
+  triggerContext: TriggerContext | undefined;
+}
+
+interface TriggerContext {
+  readonly workflowId: string;
+  readonly triggerId: string;
+}
+
+interface RunConnectorState {
+  readonly networkPolicies: NetworkPolicies | null;
+  readonly configuredForRun: boolean | null;
 }
 
 interface DiagnosticRoutingConfig {
@@ -283,6 +295,23 @@ async function getCurrentRunContext(): Promise<RunContextResponse | null> {
   return await getZeroRunContext(runId);
 }
 
+function resolveTriggerContext(): TriggerContext | undefined {
+  const workflowId = process.env.ZERO_WORKFLOW_ID;
+  const triggerId = process.env.ZERO_WORKFLOW_TRIGGER_ID;
+  return workflowId && triggerId ? { workflowId, triggerId } : undefined;
+}
+
+function workflowPermissionUrl(ctx: DiagContext): string | null {
+  if (!ctx.agentId || !ctx.triggerContext) {
+    return null;
+  }
+  const params = new URLSearchParams({
+    ref: ctx.connectorType,
+    triggerId: ctx.triggerContext.triggerId,
+  });
+  return `${ctx.platformOrigin}/agents/${ctx.agentId}/workflows/${ctx.triggerContext.workflowId}/permissions?${params.toString()}`;
+}
+
 function checkEnvName(ctx: DiagContext): boolean {
   console.log("## Step 1: Sandbox environment name");
   console.log("");
@@ -317,9 +346,11 @@ async function checkConnectorStatus(ctx: DiagContext): Promise<{
 
   const [connector, enabledTypes] = await Promise.all([
     getZeroConnector(ctx.connectorType),
-    ctx.agentId
-      ? getZeroAgentUserConnectors(ctx.agentId)
-      : Promise.resolve(null),
+    ctx.triggerContext
+      ? getZeroWorkflowUserConnectors(ctx.triggerContext.workflowId)
+      : ctx.agentId
+        ? getZeroAgentUserConnectors(ctx.agentId)
+        : Promise.resolve(null),
   ]);
 
   const isConnected = connector !== null;
@@ -338,7 +369,10 @@ async function checkConnectorStatus(ctx: DiagContext): Promise<{
     );
   } else if (!isConnected) {
     console.log(`The ${ctx.label} connector is not connected.`);
-    if (ctx.agentId && hasPermission) {
+    if (ctx.triggerContext) {
+      const connectUrl = `${ctx.platformOrigin}/connectors/${ctx.connectorType}/connect`;
+      console.log(`Connect it at: [Connect ${ctx.label}](${connectUrl})`);
+    } else if (ctx.agentId && hasPermission) {
       const connectUrl = `${ctx.platformOrigin}/connectors/${ctx.connectorType}/connect?agentId=${ctx.agentId}`;
       console.log(`Connect it at: [Connect ${ctx.label}](${connectUrl})`);
     } else if (!ctx.agentId) {
@@ -359,15 +393,38 @@ async function checkConnectorStatus(ctx: DiagContext): Promise<{
   }
   console.log("");
 
-  // 2b: Agent authorization — user must authorize the agent to use this connector
   console.log(
-    `### 2b: Agent authorization (user must authorize agent to use this connector)`,
+    ctx.triggerContext
+      ? `### 2b: Workflow authorization (user must authorize workflow to use this connector)`
+      : `### 2b: Agent authorization (user must authorize agent to use this connector)`,
   );
   console.log("");
   if (!ctx.connectorAvailable) {
     console.log(
       `Skipped — the ${ctx.label} connector is not available for this account.`,
     );
+  } else if (ctx.triggerContext) {
+    const url = workflowPermissionUrl(ctx);
+    if (hasPermission) {
+      console.log(
+        isConnected
+          ? `The ${ctx.label} connector is authorized for this workflow (${ctx.triggerContext.workflowId}).`
+          : `The ${ctx.label} connector is authorized for this workflow (${ctx.triggerContext.workflowId}), but it is not connected.`,
+      );
+    } else {
+      console.log(
+        isConnected
+          ? `The ${ctx.label} connector is not authorized for this workflow (${ctx.triggerContext.workflowId}).`
+          : `The ${ctx.label} connector needs to be connected and authorized for this workflow (${ctx.triggerContext.workflowId}).`,
+      );
+      if (url) {
+        console.log(`Authorize it at: [Authorize ${ctx.label}](${url})`);
+      } else {
+        console.log(
+          "ZERO_AGENT_ID is not set — cannot build a workflow authorization link.",
+        );
+      }
+    }
   } else if (!ctx.agentId) {
     console.log("ZERO_AGENT_ID is not set — cannot check agent authorization.");
   } else if (isExpired) {
@@ -391,6 +448,11 @@ async function checkConnectorStatus(ctx: DiagContext): Promise<{
     );
     console.log(`Authorize it at: [Authorize ${ctx.label}](${url})`);
   }
+  console.log(
+    ctx.triggerContext
+      ? `This is a workflow-triggered run, so ${ctx.label} access is scoped by the workflow's authorization settings, not the agent's connector authorization.`
+      : `This is an interactive/agent-scoped run, so ${ctx.label} access is scoped by the agent's connector authorization.`,
+  );
   console.log("");
 
   return { isConnected, isExpired, hasPermission };
@@ -399,7 +461,7 @@ async function checkConnectorStatus(ctx: DiagContext): Promise<{
 async function checkConnectorDomains(
   ctx: DiagContext,
   preloadedRunContext?: RunContextResponse | null,
-): Promise<NetworkPolicies | null> {
+): Promise<RunConnectorState> {
   // 2c: Registered base URLs — connector defines which URL prefixes get credential replacement
   console.log(
     `### 2c: Registered base URLs (credential replacement only applies to URLs matching these prefixes)`,
@@ -415,18 +477,18 @@ async function checkConnectorDomains(
       "Cannot determine run ID from ZERO_TOKEN — skipping base URL check.",
     );
     console.log("");
-    return null;
+    return { networkPolicies: null, configuredForRun: null };
   }
 
-  await printConnectorDomains(ctx, runContext);
+  const configuredForRun = await printConnectorDomains(ctx, runContext);
   console.log("");
-  return runContext.networkPolicies;
+  return { networkPolicies: runContext.networkPolicies, configuredForRun };
 }
 
 async function printConnectorDomains(
   ctx: DiagContext,
   runContext: RunContextResponse,
-): Promise<void> {
+): Promise<boolean> {
   const matchingEntry = runContext.firewalls.find((fw) => {
     return fw.name === ctx.connectorType;
   });
@@ -438,7 +500,7 @@ async function printConnectorDomains(
     console.log(
       "This means no base URLs are registered for credential replacement for this connector.",
     );
-    return;
+    return false;
   }
   const routingConfig = await runContextFirewallRoutingConfig(matchingEntry);
   if (!routingConfig) {
@@ -448,7 +510,7 @@ async function printConnectorDomains(
     console.log(
       "This means no base URLs are registered for credential replacement for this connector.",
     );
-    return;
+    return false;
   }
 
   console.log(
@@ -468,6 +530,7 @@ async function printConnectorDomains(
   if (secretNames.length > 0) {
     console.log(`Credentials resolved from: ${secretNames.join(", ")}`);
   }
+  return true;
 }
 
 function checkPermissionPolicy(
@@ -475,6 +538,7 @@ function checkPermissionPolicy(
   label: string,
   permissionName: string,
   networkPolicies: NetworkPolicies | null,
+  configuredForRun: boolean | null,
 ): void {
   console.log("## Step 3: Permission policy check");
   console.log("");
@@ -497,6 +561,16 @@ function checkPermissionPolicy(
   const connectorPolicies = networkPolicies[connectorType];
 
   if (!connectorPolicies) {
+    if (configuredForRun === false) {
+      console.log(
+        `No policy entry found because the ${label} connector is not configured for this run.`,
+      );
+      console.log(
+        "Requests for this connector cannot receive credentials in the current run.",
+      );
+      console.log("");
+      return;
+    }
     console.log(
       `No policy entry found for the ${label} connector in this run's network policies.`,
     );
@@ -548,6 +622,7 @@ async function resolvePermissionFromUrl(
   matchedBase: string,
   routingConfig: DiagnosticRoutingConfig | undefined,
   networkPolicies: NetworkPolicies | null,
+  configuredForRun: boolean | null,
 ): Promise<void> {
   console.log("## Step 3: Permission policy check (auto-detected from URL)");
   console.log("");
@@ -598,6 +673,16 @@ async function resolvePermissionFromUrl(
   const connectorPolicies = networkPolicies[connectorType];
 
   if (!connectorPolicies) {
+    if (configuredForRun === false) {
+      console.log(
+        `No policy entry found because the ${label} connector is not configured for this run.`,
+      );
+      console.log(
+        "Requests for this connector cannot receive credentials in the current run.",
+      );
+      console.log("");
+      return;
+    }
     console.log(
       `No policy entry found for the ${label} connector. All requests are fully permissive (allowed).`,
     );
@@ -751,15 +836,24 @@ How connectors work:
         connectorAvailable,
         platformOrigin: platformUrl.origin,
         agentId: process.env.ZERO_AGENT_ID || undefined,
+        triggerContext: resolveTriggerContext(),
       };
 
       checkEnvName(ctx);
       const { isConnected, isExpired, hasPermission } =
         await checkConnectorStatus(ctx);
-      const networkPolicies = await checkConnectorDomains(ctx, runContext);
+      const { networkPolicies, configuredForRun } = await checkConnectorDomains(
+        ctx,
+        runContext,
+      );
 
       // Summary for Step 2
-      if (isConnected && !isExpired && hasPermission) {
+      if (configuredForRun === false) {
+        const scope = ctx.triggerContext ? "workflow" : "agent";
+        console.log(
+          `Steps 1-2 summary: The ${label} connector is not configured for this run. Check the ${scope} authorization settings, then start a new run after updating them.`,
+        );
+      } else if (isConnected && !isExpired && hasPermission) {
         console.log(
           `Steps 1-2 summary: The ${label} connector is connected, active, and authorized. Outbound requests to the registered base URLs will have credentials injected at the network boundary.`,
         );
@@ -777,6 +871,7 @@ How connectors work:
           urlLookup.matchedBase,
           urlLookup.routingConfig,
           networkPolicies,
+          configuredForRun,
         );
       } else if (opts.checkPermission) {
         // --env-name mode with explicit --check-permission
@@ -785,6 +880,7 @@ How connectors work:
           label,
           opts.checkPermission,
           networkPolicies,
+          configuredForRun,
         );
       }
 

--- a/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
@@ -312,6 +312,140 @@ function workflowPermissionUrl(ctx: DiagContext): string | null {
   return `${ctx.platformOrigin}/agents/${ctx.agentId}/workflows/${ctx.triggerContext.workflowId}/permissions?${params.toString()}`;
 }
 
+function printConnectorConnectionStatus(
+  ctx: DiagContext,
+  isConnected: boolean,
+  isExpired: boolean,
+  hasPermission: boolean,
+): void {
+  console.log(
+    `### 2a: Connector status (user must configure via OAuth login or API key)`,
+  );
+  console.log("");
+  if (!ctx.connectorAvailable) {
+    console.log(
+      `The ${ctx.label} connector is not available for this account.`,
+    );
+  } else if (!isConnected) {
+    console.log(`The ${ctx.label} connector is not connected.`);
+    if (ctx.triggerContext) {
+      const connectUrl = `${ctx.platformOrigin}/connectors/${ctx.connectorType}/connect`;
+      console.log(`Connect it at: [Connect ${ctx.label}](${connectUrl})`);
+    } else if (ctx.agentId && hasPermission) {
+      const connectUrl = `${ctx.platformOrigin}/connectors/${ctx.connectorType}/connect?agentId=${ctx.agentId}`;
+      console.log(`Connect it at: [Connect ${ctx.label}](${connectUrl})`);
+    } else if (!ctx.agentId) {
+      // No agentId: can't scope the authorize page, so fall back to a plain
+      // connect link. With agentId, 2b's Authorize link performs the initial
+      // OAuth connect before granting permission — one link covers both steps.
+      const connectUrl = `${ctx.platformOrigin}/connectors/${ctx.connectorType}/connect`;
+      console.log(`Connect it at: [Connect ${ctx.label}](${connectUrl})`);
+    }
+  } else if (isExpired) {
+    const url = `${ctx.platformOrigin}/connectors`;
+    console.log(
+      `The ${ctx.label} connector is connected but has expired and needs to be reconnected.`,
+    );
+    console.log(`Reconnect it at: [Reconnect ${ctx.label}](${url})`);
+  } else {
+    console.log(`The ${ctx.label} connector is connected and active.`);
+  }
+  console.log("");
+}
+
+function printWorkflowAuthorizationStatus(
+  ctx: DiagContext & { readonly triggerContext: TriggerContext },
+  isConnected: boolean,
+  hasPermission: boolean,
+): void {
+  const url = workflowPermissionUrl(ctx);
+  if (hasPermission) {
+    console.log(
+      isConnected
+        ? `The ${ctx.label} connector is authorized for this workflow (${ctx.triggerContext.workflowId}).`
+        : `The ${ctx.label} connector is authorized for this workflow (${ctx.triggerContext.workflowId}), but it is not connected.`,
+    );
+    return;
+  }
+
+  console.log(
+    isConnected
+      ? `The ${ctx.label} connector is not authorized for this workflow (${ctx.triggerContext.workflowId}).`
+      : `The ${ctx.label} connector needs to be connected and authorized for this workflow (${ctx.triggerContext.workflowId}).`,
+  );
+  if (url) {
+    console.log(`Authorize it at: [Authorize ${ctx.label}](${url})`);
+  } else {
+    console.log(
+      "ZERO_AGENT_ID is not set — cannot build a workflow authorization link.",
+    );
+  }
+}
+
+function printAgentAuthorizationStatus(
+  ctx: DiagContext,
+  isConnected: boolean,
+  isExpired: boolean,
+  hasPermission: boolean,
+): void {
+  if (!ctx.agentId) {
+    console.log("ZERO_AGENT_ID is not set — cannot check agent authorization.");
+  } else if (isExpired) {
+    // The /authorize page treats an expired connector as "already connected"
+    // and won't re-trigger OAuth. Defer to 2a's Reconnect link in that case.
+    console.log(
+      `Skipped — agent authorization can only be checked once the ${ctx.label} connector is reconnected (see 2a).`,
+    );
+  } else if (hasPermission) {
+    console.log(
+      isConnected
+        ? `The ${ctx.label} connector is authorized for this agent.`
+        : `The ${ctx.label} connector is authorized for this agent, but it is not connected.`,
+    );
+  } else {
+    const url = `${ctx.platformOrigin}/connectors/${ctx.connectorType}/authorize?agentId=${ctx.agentId}`;
+    console.log(
+      isConnected
+        ? `The ${ctx.label} connector is not authorized for this agent (${ctx.agentId}).`
+        : `The ${ctx.label} connector needs to be connected and authorized for this agent (${ctx.agentId}).`,
+    );
+    console.log(`Authorize it at: [Authorize ${ctx.label}](${url})`);
+  }
+}
+
+function printConnectorAuthorizationStatus(
+  ctx: DiagContext,
+  isConnected: boolean,
+  isExpired: boolean,
+  hasPermission: boolean,
+): void {
+  console.log(
+    ctx.triggerContext
+      ? `### 2b: Workflow authorization (user must authorize workflow to use this connector)`
+      : `### 2b: Agent authorization (user must authorize agent to use this connector)`,
+  );
+  console.log("");
+  if (!ctx.connectorAvailable) {
+    console.log(
+      `Skipped — the ${ctx.label} connector is not available for this account.`,
+    );
+  } else if (ctx.triggerContext) {
+    printWorkflowAuthorizationStatus(
+      { ...ctx, triggerContext: ctx.triggerContext },
+      isConnected,
+      hasPermission,
+    );
+  } else {
+    printAgentAuthorizationStatus(ctx, isConnected, isExpired, hasPermission);
+  }
+  console.log(
+    ctx.triggerContext
+      ? `This is a workflow-triggered run, so ${ctx.label} access is scoped by the workflow's authorization settings, not the agent's connector authorization.`
+      : `This is an interactive/agent-scoped run, so ${ctx.label} access is scoped by the agent's connector authorization.`,
+  );
+  console.log("");
+}
+
 function checkEnvName(ctx: DiagContext): boolean {
   console.log("## Step 1: Sandbox environment name");
   console.log("");
@@ -358,102 +492,8 @@ async function checkConnectorStatus(ctx: DiagContext): Promise<{
   const hasPermission =
     enabledTypes !== null && enabledTypes.includes(ctx.connectorType);
 
-  // 2a: Connector status — user must have configured the connector (OAuth or API token)
-  console.log(
-    `### 2a: Connector status (user must configure via OAuth login or API key)`,
-  );
-  console.log("");
-  if (!ctx.connectorAvailable) {
-    console.log(
-      `The ${ctx.label} connector is not available for this account.`,
-    );
-  } else if (!isConnected) {
-    console.log(`The ${ctx.label} connector is not connected.`);
-    if (ctx.triggerContext) {
-      const connectUrl = `${ctx.platformOrigin}/connectors/${ctx.connectorType}/connect`;
-      console.log(`Connect it at: [Connect ${ctx.label}](${connectUrl})`);
-    } else if (ctx.agentId && hasPermission) {
-      const connectUrl = `${ctx.platformOrigin}/connectors/${ctx.connectorType}/connect?agentId=${ctx.agentId}`;
-      console.log(`Connect it at: [Connect ${ctx.label}](${connectUrl})`);
-    } else if (!ctx.agentId) {
-      // No agentId: can't scope the authorize page, so fall back to a plain
-      // connect link. With agentId, 2b's Authorize link performs the initial
-      // OAuth connect before granting permission — one link covers both steps.
-      const connectUrl = `${ctx.platformOrigin}/connectors/${ctx.connectorType}/connect`;
-      console.log(`Connect it at: [Connect ${ctx.label}](${connectUrl})`);
-    }
-  } else if (isExpired) {
-    const url = `${ctx.platformOrigin}/connectors`;
-    console.log(
-      `The ${ctx.label} connector is connected but has expired and needs to be reconnected.`,
-    );
-    console.log(`Reconnect it at: [Reconnect ${ctx.label}](${url})`);
-  } else {
-    console.log(`The ${ctx.label} connector is connected and active.`);
-  }
-  console.log("");
-
-  console.log(
-    ctx.triggerContext
-      ? `### 2b: Workflow authorization (user must authorize workflow to use this connector)`
-      : `### 2b: Agent authorization (user must authorize agent to use this connector)`,
-  );
-  console.log("");
-  if (!ctx.connectorAvailable) {
-    console.log(
-      `Skipped — the ${ctx.label} connector is not available for this account.`,
-    );
-  } else if (ctx.triggerContext) {
-    const url = workflowPermissionUrl(ctx);
-    if (hasPermission) {
-      console.log(
-        isConnected
-          ? `The ${ctx.label} connector is authorized for this workflow (${ctx.triggerContext.workflowId}).`
-          : `The ${ctx.label} connector is authorized for this workflow (${ctx.triggerContext.workflowId}), but it is not connected.`,
-      );
-    } else {
-      console.log(
-        isConnected
-          ? `The ${ctx.label} connector is not authorized for this workflow (${ctx.triggerContext.workflowId}).`
-          : `The ${ctx.label} connector needs to be connected and authorized for this workflow (${ctx.triggerContext.workflowId}).`,
-      );
-      if (url) {
-        console.log(`Authorize it at: [Authorize ${ctx.label}](${url})`);
-      } else {
-        console.log(
-          "ZERO_AGENT_ID is not set — cannot build a workflow authorization link.",
-        );
-      }
-    }
-  } else if (!ctx.agentId) {
-    console.log("ZERO_AGENT_ID is not set — cannot check agent authorization.");
-  } else if (isExpired) {
-    // The /authorize page treats an expired connector as "already connected"
-    // and won't re-trigger OAuth. Defer to 2a's Reconnect link in that case.
-    console.log(
-      `Skipped — agent authorization can only be checked once the ${ctx.label} connector is reconnected (see 2a).`,
-    );
-  } else if (hasPermission) {
-    console.log(
-      isConnected
-        ? `The ${ctx.label} connector is authorized for this agent.`
-        : `The ${ctx.label} connector is authorized for this agent, but it is not connected.`,
-    );
-  } else {
-    const url = `${ctx.platformOrigin}/connectors/${ctx.connectorType}/authorize?agentId=${ctx.agentId}`;
-    console.log(
-      isConnected
-        ? `The ${ctx.label} connector is not authorized for this agent (${ctx.agentId}).`
-        : `The ${ctx.label} connector needs to be connected and authorized for this agent (${ctx.agentId}).`,
-    );
-    console.log(`Authorize it at: [Authorize ${ctx.label}](${url})`);
-  }
-  console.log(
-    ctx.triggerContext
-      ? `This is a workflow-triggered run, so ${ctx.label} access is scoped by the workflow's authorization settings, not the agent's connector authorization.`
-      : `This is an interactive/agent-scoped run, so ${ctx.label} access is scoped by the agent's connector authorization.`,
-  );
-  console.log("");
+  printConnectorConnectionStatus(ctx, isConnected, isExpired, hasPermission);
+  printConnectorAuthorizationStatus(ctx, isConnected, isExpired, hasPermission);
 
   return { isConnected, isExpired, hasPermission };
 }

--- a/turbo/apps/cli/src/lib/api/domains/zero-workflows.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-workflows.ts
@@ -11,6 +11,7 @@ import {
   type ZeroWorkflowTriggerSummary,
   type ZeroWorkflowTriggerUpdateRequest,
 } from "@vm0/api-contracts/contracts/zero-workflows";
+import { zeroWorkflowUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import { getClientConfig, handleError } from "../core/client-factory";
 
 export async function listWorkflows(query: {
@@ -95,6 +96,19 @@ export async function runWorkflow(
   const result = await client.run({ params: { workflowId } });
   if (result.status === 200) return result.body;
   handleError(result, `Failed to run workflow "${workflowId}"`);
+}
+
+export async function getZeroWorkflowUserConnectors(
+  workflowId: string,
+): Promise<string[]> {
+  const config = await getClientConfig();
+  const client = initClient(zeroWorkflowUserConnectorsContract, config);
+  const result = await client.get({ params: { id: workflowId } });
+  if (result.status === 200) return result.body.enabledTypes;
+  handleError(
+    result,
+    `Failed to get connector permissions for zero workflow "${workflowId}"`,
+  );
 }
 
 export async function listWorkflowTriggers(

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -124,6 +124,7 @@ export {
   deleteWorkflow,
   copyWorkflow,
   runWorkflow,
+  getZeroWorkflowUserConnectors,
   listWorkflowTriggers,
   createWorkflowTrigger,
   getWorkflowTrigger,

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -124,7 +124,6 @@ export {
   deleteWorkflow,
   copyWorkflow,
   runWorkflow,
-  getZeroWorkflowUserConnectors,
   listWorkflowTriggers,
   createWorkflowTrigger,
   getWorkflowTrigger,


### PR DESCRIPTION
## Summary
- make `zero doctor check-connector` detect workflow-triggered runs via `ZERO_WORKFLOW_ID` and `ZERO_WORKFLOW_TRIGGER_ID`
- check workflow user connectors instead of agent connectors for workflow-triggered runs
- clarify diagnostics when a connector is not configured for the current run and avoid reporting missing policy entries as permissive
- add CLI tests for workflow-scoped connector authorization diagnostics

## Verification
- `pnpm --filter @vm0/cli exec vitest run src/commands/zero/doctor/__tests__/check-connector.test.ts`
- `pnpm --filter @vm0/cli exec tsc --noEmit --pretty false`
- `git diff --check`