### PR TITLE
fix: avoid workflow detail fanout on automations page

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-triggers.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-triggers.test.ts
@@ -550,6 +550,86 @@ describe("zero workflow triggers", () => {
     );
   });
 
+  it("lists owned workflow triggers across visible workflows", async () => {
+    const { fixture, agentId, workflowId } = await setupFixture();
+    const { agentId: secondAgentId } = await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        name: "second-trigger-agent",
+        workflowNames: [WORKFLOW_NAME],
+        composeContent: {
+          version: "1",
+          agents: {
+            "second-trigger-agent": {
+              framework: "claude-code",
+              environment: { ANTHROPIC_API_KEY: "test-key" },
+            },
+          },
+        },
+      },
+      context.signal,
+    );
+    const secondWorkflowId = await loadWorkflowId(fixture, secondAgentId);
+
+    const first = await accept(
+      triggersClient().create({
+        headers: authHeaders(),
+        params: { workflowId },
+        body: { schedule: { type: "loop", intervalSeconds: 60 } },
+      }),
+      [201],
+    );
+    const second = await accept(
+      triggersClient().create({
+        headers: authHeaders(),
+        params: { workflowId: secondWorkflowId },
+        body: {
+          schedule: {
+            type: "cron",
+            cronExpression: "0 10 * * *",
+            timezone: "UTC",
+          },
+        },
+      }),
+      [201],
+    );
+
+    const listed = await accept(
+      triggersClient().listWorkspace({ headers: authHeaders() }),
+      [200],
+    );
+
+    expect(
+      listed.body.map((entry) => {
+        return {
+          triggerId: entry.trigger.id,
+          workflowId: entry.workflow.id,
+          workflowName: entry.workflow.name,
+          agentId: entry.workflow.agentId,
+        };
+      }),
+    ).toStrictEqual(
+      expect.arrayContaining([
+        {
+          triggerId: first.body.id,
+          workflowId,
+          workflowName: WORKFLOW_NAME,
+          agentId,
+        },
+        {
+          triggerId: second.body.id,
+          workflowId: secondWorkflowId,
+          workflowName: WORKFLOW_NAME,
+          agentId: secondAgentId,
+        },
+      ]),
+    );
+    expect("files" in listed.body[0]!.workflow).toBeFalsy();
+    expect("fileContents" in listed.body[0]!.workflow).toBeFalsy();
+  });
+
   it("creates webhook event triggers with a signed endpoint secret shown once", async () => {
     const { fixture, workflowId } = await setupFixture();
     await enableWebhookWorkflowTriggers(fixture);

--- a/turbo/apps/api/src/signals/routes/zero-workflow-triggers.ts
+++ b/turbo/apps/api/src/signals/routes/zero-workflow-triggers.ts
@@ -17,6 +17,7 @@ import {
   enableWorkflowTrigger$,
   getWorkflowTrigger,
   listThreadBoundWorkflowTriggers,
+  listWorkspaceWorkflowTriggers,
   loadWorkflowTriggers,
   runOwnedWorkflowTriggerNow$,
   updateWorkflowTrigger$,
@@ -75,6 +76,16 @@ function triggerErrorResponse(
 
 const createTriggerBody$ = bodyResultOf(zeroWorkflowTriggersContract.create);
 const updateTriggerBody$ = bodyResultOf(zeroWorkflowTriggersContract.update);
+
+const listWorkspaceTriggersInner$ = computed(async (get) => {
+  const auth = get(organizationAuthContext$);
+  const db = get(db$);
+  const triggers = await listWorkspaceWorkflowTriggers(db, {
+    orgId: auth.orgId,
+    member: memberFromAuth(auth),
+  });
+  return { status: 200 as const, body: [...triggers] };
+});
 
 const listChatThreadTriggersInner$ = computed(async (get) => {
   const auth = get(organizationAuthContext$);
@@ -308,6 +319,10 @@ const runTriggerInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 });
 
 export const zeroWorkflowTriggersRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroWorkflowTriggersContract.listWorkspace,
+    handler: authRoute(workflowReadAuth, listWorkspaceTriggersInner$),
+  },
   {
     route: zeroWorkflowTriggersContract.listForChatThread,
     handler: authRoute(workflowReadAuth, listChatThreadTriggersInner$),

--- a/turbo/apps/api/src/signals/services/zero-workflow-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-data.service.ts
@@ -109,7 +109,7 @@ export function requireWorkflowPermission(
  * parked under another user's private agent must stay hidden, so that resolving
  * it returns 404 rather than leaking the agent's existence via a 403.
  */
-function visibleWorkflowCondition(member: WorkflowMember): SQL {
+export function visibleWorkflowCondition(member: WorkflowMember): SQL {
   const agentVisibleToMember = or(
     eq(zeroAgents.visibility, "public"),
     eq(zeroAgents.owner, member.userId),

--- a/turbo/apps/api/src/signals/services/zero-workflow-trigger.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-trigger.service.ts
@@ -8,6 +8,7 @@ import {
   type WebhookReceivedEventConfig,
   type ZeroWorkflowEventType,
   type ZeroWorkflowSchedule,
+  type ZeroWorkflowTriggerAutomationEntry,
   type ZeroWorkflowTriggerSummary,
 } from "@vm0/api-contracts/contracts/zero-workflows";
 import { parseScheduledAtTime } from "@vm0/core/timezone";
@@ -29,6 +30,8 @@ import { isValidTimeZone, safeSync } from "../utils";
 import { calculateNextRun } from "./automations/time-trigger";
 import {
   loadVisibleWorkflowById,
+  visibleWorkflowCondition,
+  workflowSummary,
   type WorkflowMember,
 } from "./zero-workflow-data.service";
 import {
@@ -486,6 +489,82 @@ export async function loadWorkflowTriggers(
   );
   return summaries.flatMap((summary) => {
     return summary ? [summary] : [];
+  });
+}
+
+/**
+ * List the caller's workflow triggers across every visible workflow in one
+ * lightweight projection for the /automations surface. This deliberately avoids
+ * workflow detail loading, so it does not read workflow volume files from R2.
+ */
+export async function listWorkspaceWorkflowTriggers(
+  db: ReadonlyDb,
+  args: {
+    readonly orgId: string;
+    readonly member: WorkflowMember;
+  },
+): Promise<readonly ZeroWorkflowTriggerAutomationEntry[]> {
+  const rows = await db
+    .select({
+      trigger: zeroWorkflowTriggers,
+      workflow: zeroWorkflows,
+      agent: {
+        id: zeroAgents.id,
+        owner: zeroAgents.owner,
+        visibility: zeroAgents.visibility,
+        name: zeroAgents.name,
+        displayName: zeroAgents.displayName,
+      },
+      chatThreadId: workflowUserTriggerThreads.chatThreadId,
+    })
+    .from(zeroWorkflowTriggers)
+    .innerJoin(
+      zeroWorkflows,
+      eq(zeroWorkflows.id, zeroWorkflowTriggers.workflowId),
+    )
+    .innerJoin(zeroAgents, eq(zeroAgents.id, zeroWorkflows.agentId))
+    .leftJoin(
+      workflowUserTriggerThreads,
+      and(
+        eq(workflowUserTriggerThreads.orgId, zeroWorkflowTriggers.orgId),
+        eq(workflowUserTriggerThreads.userId, zeroWorkflowTriggers.ownerUserId),
+        eq(
+          workflowUserTriggerThreads.workflowId,
+          zeroWorkflowTriggers.workflowId,
+        ),
+      ),
+    )
+    .where(
+      and(
+        eq(zeroWorkflowTriggers.orgId, args.orgId),
+        eq(zeroWorkflowTriggers.ownerUserId, args.member.userId),
+        visibleWorkflowCondition(args.member),
+      ),
+    )
+    .orderBy(asc(zeroWorkflowTriggers.createdAt), asc(zeroWorkflowTriggers.id));
+
+  const entries = await Promise.all(
+    rows.map(
+      async (row): Promise<ZeroWorkflowTriggerAutomationEntry | null> => {
+        const trigger = await rowToPublicSummary(db, row.trigger, {
+          chatThreadId: row.chatThreadId ?? null,
+        });
+        if (!trigger) {
+          return null;
+        }
+        return {
+          workflow: workflowSummary({
+            workflow: row.workflow,
+            agent: row.agent,
+            member: args.member,
+          }),
+          trigger,
+        };
+      },
+    ),
+  );
+  return entries.flatMap((entry) => {
+    return entry ? [entry] : [];
   });
 }
 

--- a/turbo/apps/platform/src/mocks/handlers/api-workflows.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-workflows.ts
@@ -6,6 +6,7 @@ import {
   type ChatThreadWorkflowTrigger,
   type ZeroWorkflowDetailResponse,
   type ZeroWorkflowSummary,
+  type ZeroWorkflowTriggerAutomationEntry,
   type ZeroWorkflowTriggerSummary,
 } from "@vm0/api-contracts/contracts/zero-workflows";
 import { zeroWorkflowUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
@@ -413,6 +414,16 @@ function mockWorkflowTriggerExists(triggerId: string): boolean {
 
 function workflowTriggerListHandlers() {
   return [
+    mockApi(zeroWorkflowTriggersContract.listWorkspace, ({ respond }) => {
+      const entries: ZeroWorkflowTriggerAutomationEntry[] =
+        mockWorkflows.flatMap((workflow) => {
+          return workflow.triggers.map((trigger) => {
+            return { workflow: summary(workflow), trigger };
+          });
+        });
+      return respond(200, entries);
+    }),
+
     mockApi(zeroWorkflowTriggersContract.list, ({ params, respond }) => {
       const workflow = mockWorkflows.find((item) => {
         return item.id === params.workflowId;

--- a/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
+++ b/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
@@ -9,6 +9,7 @@ import {
   type ZeroWorkflowDetailResponse,
   type ZeroWorkflowSchedule,
   type ZeroWorkflowSummary,
+  type ZeroWorkflowTriggerAutomationEntry,
   type ZeroWorkflowTriggerSummary,
   type ZeroWorkflowUpdateRequest,
 } from "@vm0/api-contracts/contracts/zero-workflows";
@@ -44,20 +45,7 @@ type WorkflowWebhookTriggerSummary = Extract<
   ZeroWorkflowTriggerSummary,
   { readonly kind: "event"; readonly eventType: "webhook-received" }
 >;
-export interface WorkflowTriggerAutomationEntry {
-  readonly workflow: Pick<
-    ZeroWorkflowSummary,
-    | "id"
-    | "agentId"
-    | "agentName"
-    | "agentDisplayName"
-    | "name"
-    | "displayName"
-    | "description"
-    | "canManage"
-  >;
-  readonly trigger: ZeroWorkflowTriggerSummary;
-}
+export type WorkflowTriggerAutomationEntry = ZeroWorkflowTriggerAutomationEntry;
 export const WORKFLOW_DETAIL_TAB_PARAM = "tab";
 export const WORKFLOW_DETAIL_FILE_PARAM = "file";
 
@@ -365,61 +353,24 @@ export const composerWorkflows$ = computed(
 export const allWorkflowTriggerEntries$ = computed(
   async (get): Promise<readonly WorkflowTriggerAutomationEntry[]> => {
     get(internalWorkflowReload$);
-    const collectionClient = get(zeroClient$)(zeroWorkflowsCollectionContract);
-    const detailClient = get(zeroClient$)(zeroWorkflowsDetailContract);
-    const workflowsResult = await accept(
-      collectionClient.list({ query: {} }),
-      [200],
-    );
-
-    const details = await Promise.all(
-      workflowsResult.body.map(async (workflow) => {
-        const detailResult = await accept(
-          detailClient.get({ params: { workflowId: workflow.id } }),
-          [200, 404],
-        );
-        if (detailResult.status === 404) {
-          return null;
-        }
-        return detailResult.body;
-      }),
-    );
-
-    return details
-      .flatMap((detail): WorkflowTriggerAutomationEntry[] => {
-        if (!detail) {
-          return [];
-        }
-        const workflow = {
-          id: detail.id,
-          agentId: detail.agentId,
-          agentName: detail.agentName,
-          agentDisplayName: detail.agentDisplayName,
-          name: detail.name,
-          displayName: detail.displayName,
-          description: detail.description,
-          canManage: detail.canManage,
-        };
-        return detail.triggers.map((trigger) => {
-          return { workflow, trigger };
-        });
-      })
-      .sort((a, b) => {
-        if (a.trigger.enabled !== b.trigger.enabled) {
-          return a.trigger.enabled ? -1 : 1;
-        }
-        const aNext = a.trigger.nextRunAt ?? "";
-        const bNext = b.trigger.nextRunAt ?? "";
-        if (aNext && bNext && aNext !== bNext) {
-          return aNext.localeCompare(bNext);
-        }
-        if (aNext !== bNext) {
-          return aNext ? -1 : 1;
-        }
-        const aTitle = a.workflow.displayName ?? a.workflow.name;
-        const bTitle = b.workflow.displayName ?? b.workflow.name;
-        return aTitle.localeCompare(bTitle);
-      });
+    const triggerClient = get(zeroClient$)(zeroWorkflowTriggersContract);
+    const triggerResult = await accept(triggerClient.listWorkspace(), [200]);
+    return [...triggerResult.body].sort((a, b) => {
+      if (a.trigger.enabled !== b.trigger.enabled) {
+        return a.trigger.enabled ? -1 : 1;
+      }
+      const aNext = a.trigger.nextRunAt ?? "";
+      const bNext = b.trigger.nextRunAt ?? "";
+      if (aNext && bNext && aNext !== bNext) {
+        return aNext.localeCompare(bNext);
+      }
+      if (aNext !== bNext) {
+        return aNext ? -1 : 1;
+      }
+      const aTitle = a.workflow.displayName ?? a.workflow.name;
+      const bTitle = b.workflow.displayName ?? b.workflow.name;
+      return aTitle.localeCompare(bTitle);
+    });
   },
 );
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-automations-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-automations-page.test.tsx
@@ -5,8 +5,7 @@ import {
   automationsMainContract,
 } from "@vm0/api-contracts/contracts/automations";
 import {
-  zeroWorkflowsCollectionContract,
-  zeroWorkflowsDetailContract,
+  zeroWorkflowTriggersContract,
   type ZeroWorkflowDetailResponse,
   type ZeroWorkflowSummary,
   type ZeroWorkflowTriggerSummary,
@@ -185,19 +184,19 @@ function mockWorkflowTriggerStory(): void {
     createAgent(researchAgentId, "Research Agent"),
   ]);
   context.mocks.data.userPreferences({ timezone: "UTC" });
-  context.mocks.api(zeroWorkflowsCollectionContract.list, ({ respond }) => {
-    return respond(200, workflows.map(workflowSummary));
-  });
-  context.mocks.api(zeroWorkflowsDetailContract.get, ({ params, respond }) => {
-    const workflow = workflows.find((candidate) => {
-      return candidate.id === params.workflowId;
-    });
-    return workflow
-      ? respond(200, workflow)
-      : respond(404, {
-          error: { message: "Workflow not found", code: "NOT_FOUND" },
-        });
-  });
+  context.mocks.api(
+    zeroWorkflowTriggersContract.listWorkspace,
+    ({ respond }) => {
+      return respond(
+        200,
+        workflows.flatMap((workflow) => {
+          return workflow.triggers.map((trigger) => {
+            return { workflow: workflowSummary(workflow), trigger };
+          });
+        }),
+      );
+    },
+  );
 }
 
 function buttonByText(

--- a/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
+++ b/turbo/apps/web/__tests__/api-backend-rewrite-proxy.test.ts
@@ -2681,6 +2681,15 @@ describe("API backend rewrite proxy behavior", () => {
     ).toBe(true);
   });
 
+  it("matches the zero workflow trigger list rewrite path exactly", () => {
+    expect(matchesApiBackendRewritePath("/api/zero/workflow-triggers")).toBe(
+      true,
+    );
+    expect(
+      matchesApiBackendRewritePath("/api/zero/workflow-triggers/extra"),
+    ).toBe(false);
+  });
+
   it("matches the zero workflow trigger run rewrite path exactly", () => {
     expect(
       matchesApiBackendRewritePath(

--- a/turbo/apps/web/api-backend-rewrites.js
+++ b/turbo/apps/web/api-backend-rewrites.js
@@ -124,6 +124,8 @@ const ZERO_WORKFLOW_TRIGGERS_REWRITE_SOURCE =
   "/api/zero/workflows/:name/triggers";
 const ZERO_WORKFLOW_TRIGGERS_PATH_RE =
   /^\/api\/zero\/workflows\/[^/]+\/triggers$/;
+const ZERO_WORKFLOW_TRIGGER_LIST_REWRITE_SOURCE = "/api/zero/workflow-triggers";
+const ZERO_WORKFLOW_TRIGGER_LIST_PATH_RE = /^\/api\/zero\/workflow-triggers$/;
 const ZERO_WORKFLOW_TRIGGER_BY_ID_REWRITE_SOURCE = `/api/zero/workflow-triggers/:id(${UUID_PATH_SEGMENT_PATTERN})`;
 const ZERO_WORKFLOW_TRIGGER_BY_ID_PATH_RE = new RegExp(
   `^/api/zero/workflow-triggers/${UUID_PATH_SEGMENT_PATTERN}$`,
@@ -1434,6 +1436,11 @@ export const API_BACKEND_REWRITES = [
     ZERO_WORKFLOW_TRIGGERS_REWRITE_SOURCE,
     "/api/zero/workflows/:name/triggers",
     ZERO_WORKFLOW_TRIGGERS_PATH_RE,
+  ],
+  [
+    ZERO_WORKFLOW_TRIGGER_LIST_REWRITE_SOURCE,
+    "/api/zero/workflow-triggers",
+    ZERO_WORKFLOW_TRIGGER_LIST_PATH_RE,
   ],
   [
     ZERO_WORKFLOW_TRIGGER_ENABLE_REWRITE_SOURCE,

--- a/turbo/packages/api-contracts/src/contracts/zero-workflows.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-workflows.ts
@@ -424,6 +424,14 @@ export const zeroWorkflowListResponseSchema = z.array(
   zeroWorkflowSummarySchema,
 );
 
+export const zeroWorkflowTriggerAutomationEntrySchema = z.object({
+  workflow: zeroWorkflowSummarySchema,
+  trigger: zeroWorkflowTriggerSummarySchema,
+});
+export const zeroWorkflowTriggerAutomationListResponseSchema = z.array(
+  zeroWorkflowTriggerAutomationEntrySchema,
+);
+
 export const zeroWorkflowCreateRequestSchema = z.object({
   agentId: z.string().uuid(),
   name: zeroWorkflowNameSchema,
@@ -683,6 +691,17 @@ const triggerIdParams = z.object({ id: z.string().uuid() });
 const chatThreadIdParams = z.object({ threadId: z.string().min(1) });
 
 export const zeroWorkflowTriggersContract = c.router({
+  listWorkspace: {
+    method: "GET",
+    path: "/api/zero/workflow-triggers",
+    headers: authHeadersSchema,
+    responses: {
+      200: zeroWorkflowTriggerAutomationListResponseSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+    },
+    summary: "List the caller's workflow triggers across visible workflows",
+  },
   listForChatThread: {
     method: "GET",
     path: "/api/zero/chat-threads/:threadId/workflow-triggers",
@@ -835,6 +854,9 @@ export type ZeroWorkflowChatThreadResponse = z.infer<
 >;
 export type ZeroWorkflowRunResponse = z.infer<
   typeof zeroWorkflowRunResponseSchema
+>;
+export type ZeroWorkflowTriggerAutomationEntry = z.infer<
+  typeof zeroWorkflowTriggerAutomationEntrySchema
 >;
 export type ZeroWorkflowsCollectionContract =
   typeof zeroWorkflowsCollectionContract;


### PR DESCRIPTION
## Summary
- Add `GET /api/zero/workflow-triggers` for the automations page to fetch workflow trigger cards in one request.
- Replace the frontend workflow list + per-workflow detail fanout with the new lightweight trigger list endpoint.
- Keep workflow detail responsible for full files/fileContents loading, while automations avoids the R2-backed volume read.

## Verification
- `pnpm exec vitest run src/views/zero-page/__tests__/zero-automations-page.test.tsx`
- `pnpm -F @vm0/app check-types`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- `pnpm -F api exec oxlint src/signals/services/zero-workflow-trigger.service.ts src/signals/routes/zero-workflow-triggers.ts src/signals/routes/__tests__/zero-workflow-triggers.test.ts src/signals/services/zero-workflow-data.service.ts`
- `pnpm -F @vm0/app exec oxlint src/signals/workflows-page/workflows-signals.ts src/views/zero-page/__tests__/zero-automations-page.test.tsx src/mocks/handlers/api-workflows.ts`
- `git diff --check`

## Notes
- API route runtime tests require a local Postgres on `localhost:5432`; this environment does not provide one, so the route test file could not run past fixture setup locally.