### PR TITLE
Add workflow setup seed skill and clarify workflow agent IDs

### DIFF
--- a/turbo/apps/cli/src/commands/zero/workflow/__tests__/copy.test.ts
+++ b/turbo/apps/cli/src/commands/zero/workflow/__tests__/copy.test.ts
@@ -78,7 +78,8 @@ describe("zero workflow copy command", () => {
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("copied");
       expect(logCalls).toContain(NEW_ID);
-      expect(logCalls).toContain("target-agent");
+      expect(logCalls).toContain("Agent Name:   Target Agent");
+      expect(logCalls).toContain(`Agent ID:     ${TARGET_AGENT_ID}`);
     });
   });
 

--- a/turbo/apps/cli/src/commands/zero/workflow/__tests__/create.test.ts
+++ b/turbo/apps/cli/src/commands/zero/workflow/__tests__/create.test.ts
@@ -111,6 +111,8 @@ describe("zero workflow create command", () => {
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("my-workflow");
       expect(logCalls).toContain("created");
+      expect(logCalls).toContain("Agent Name:   My Agent");
+      expect(logCalls).toContain(`Agent ID:     ${AGENT_ID}`);
       expect(logCalls).toContain("1 file(s)");
     });
 

--- a/turbo/apps/cli/src/commands/zero/workflow/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/workflow/__tests__/list.test.ts
@@ -75,7 +75,10 @@ describe("zero workflow list command", () => {
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("code-review");
-      expect(logCalls).toContain("my-agent");
+      expect(logCalls).toContain("AGENT NAME");
+      expect(logCalls).toContain("AGENT ID");
+      expect(logCalls).toContain("My Agent");
+      expect(logCalls).toContain(AGENT_ID);
       expect(logCalls).toContain("private");
       expect(logCalls).toContain("deploy");
     });

--- a/turbo/apps/cli/src/commands/zero/workflow/__tests__/view.test.ts
+++ b/turbo/apps/cli/src/commands/zero/workflow/__tests__/view.test.ts
@@ -70,7 +70,8 @@ describe("zero workflow view command", () => {
       expect(logCalls).toContain("my-workflow");
       expect(logCalls).toContain("My Workflow");
       expect(logCalls).toContain("A helpful workflow");
-      expect(logCalls).toContain("my-agent");
+      expect(logCalls).toContain("Agent Name:   My Agent");
+      expect(logCalls).toContain(`Agent ID:     ${AGENT_ID}`);
       expect(logCalls).toContain("Do helpful things.");
     });
   });

--- a/turbo/apps/cli/src/commands/zero/workflow/copy.ts
+++ b/turbo/apps/cli/src/commands/zero/workflow/copy.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { copyWorkflow } from "../../../lib/api";
 import { withErrorHandler } from "../../../lib/command";
+import { formatWorkflowAgentName } from "./format";
 
 export const copyCommand = new Command()
   .name("copy")
@@ -20,8 +21,9 @@ Examples:
         const workflow = await copyWorkflow(workflowId, options.toAgent);
 
         console.log(chalk.green(`✓ Workflow "${workflow.name}" copied`));
-        console.log(`  ID:     ${workflow.id}`);
-        console.log(`  Agent:  ${workflow.agentName ?? workflow.agentId}`);
+        console.log(`  ID:           ${workflow.id}`);
+        console.log(`  Agent Name:   ${formatWorkflowAgentName(workflow)}`);
+        console.log(`  Agent ID:     ${workflow.agentId}`);
         console.log();
         console.log(`View it: zero workflow view ${workflow.id}`);
       },

--- a/turbo/apps/cli/src/commands/zero/workflow/create.ts
+++ b/turbo/apps/cli/src/commands/zero/workflow/create.ts
@@ -4,6 +4,7 @@ import { readFileSync } from "node:fs";
 import { createWorkflow } from "../../../lib/api";
 import { withErrorHandler } from "../../../lib/command";
 import { readSupplementaryFiles } from "../../../lib/skill-directory";
+import { formatWorkflowAgentName } from "./format";
 
 export const createCommand = new Command()
   .name("create")
@@ -95,9 +96,8 @@ Notes:
         console.log(chalk.green(`✓ Workflow "${workflow.name}" created`));
         console.log(`  ID:           ${workflow.id}`);
         console.log(`  Name:         ${workflow.name}`);
-        console.log(
-          `  Agent:        ${workflow.agentName ?? workflow.agentId}`,
-        );
+        console.log(`  Agent Name:   ${formatWorkflowAgentName(workflow)}`);
+        console.log(`  Agent ID:     ${workflow.agentId}`);
         console.log(`  Visibility:   ${workflow.visibility}`);
         if (files) {
           console.log(`  Files:        ${files.length} file(s)`);

--- a/turbo/apps/cli/src/commands/zero/workflow/format.ts
+++ b/turbo/apps/cli/src/commands/zero/workflow/format.ts
@@ -1,0 +1,10 @@
+import type { ZeroWorkflowSummary } from "@vm0/api-contracts/contracts/zero-workflows";
+
+type WorkflowAgentFields = Pick<
+  ZeroWorkflowSummary,
+  "agentDisplayName" | "agentName" | "agentId"
+>;
+
+export function formatWorkflowAgentName(workflow: WorkflowAgentFields): string {
+  return workflow.agentDisplayName ?? workflow.agentName ?? "-";
+}

--- a/turbo/apps/cli/src/commands/zero/workflow/list.ts
+++ b/turbo/apps/cli/src/commands/zero/workflow/list.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { listWorkflows } from "../../../lib/api";
 import { withErrorHandler } from "../../../lib/command";
+import { formatWorkflowAgentName } from "./format";
 
 export const listCommand = new Command()
   .name("list")
@@ -42,9 +43,15 @@ Examples:
         }),
       );
       const agentWidth = Math.max(
-        5,
+        10,
         ...workflows.map((s) => {
-          return (s.agentName ?? s.agentId).length;
+          return formatWorkflowAgentName(s).length;
+        }),
+      );
+      const agentIdWidth = Math.max(
+        8,
+        ...workflows.map((s) => {
+          return s.agentId.length;
         }),
       );
 
@@ -52,7 +59,8 @@ Examples:
         "ID".padEnd(idWidth),
         "NAME".padEnd(nameWidth),
         "VISIBILITY".padEnd(10),
-        "AGENT".padEnd(agentWidth),
+        "AGENT NAME".padEnd(agentWidth),
+        "AGENT ID".padEnd(agentIdWidth),
         "DESCRIPTION",
       ].join("  ");
       console.log(chalk.dim(header));
@@ -62,7 +70,8 @@ Examples:
           workflow.id.padEnd(idWidth),
           workflow.name.padEnd(nameWidth),
           workflow.visibility.padEnd(10),
-          (workflow.agentName ?? workflow.agentId).padEnd(agentWidth),
+          formatWorkflowAgentName(workflow).padEnd(agentWidth),
+          workflow.agentId.padEnd(agentIdWidth),
           workflow.description ?? "-",
         ].join("  ");
         console.log(row);

--- a/turbo/apps/cli/src/commands/zero/workflow/view.ts
+++ b/turbo/apps/cli/src/commands/zero/workflow/view.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { getWorkflow } from "../../../lib/api";
 import { withErrorHandler } from "../../../lib/command";
+import { formatWorkflowAgentName } from "./format";
 
 export const viewCommand = new Command()
   .name("view")
@@ -23,9 +24,8 @@ Examples:
       console.log(`ID:           ${workflow.id}`);
       console.log(`Name:         ${workflow.name}`);
       console.log(`Visibility:   ${workflow.visibility}`);
-      console.log(
-        `Agent:        ${workflow.agentName ?? workflow.agentId} (${workflow.agentId})`,
-      );
+      console.log(`Agent Name:   ${formatWorkflowAgentName(workflow)}`);
+      console.log(`Agent ID:     ${workflow.agentId}`);
       if (workflow.displayName)
         console.log(`Display Name: ${workflow.displayName}`);
       if (workflow.description)

--- a/turbo/packages/core/src/zero-seed-skills.ts
+++ b/turbo/packages/core/src/zero-seed-skills.ts
@@ -45,6 +45,7 @@ export const SEED_SKILLS: readonly string[] = [
   "sql-cookbook",
   "stats-methods",
   "status-updates",
+  "workflow-setup",
 ] as const;
 
 /**


### PR DESCRIPTION
## Summary
- add workflow-setup to the always-on seed skill list
- make workflow CLI output show Agent Name and Agent ID separately
- update workflow create/list/view/copy tests for the clearer agent display

## Tests
- pnpm exec vitest --run apps/cli/src/commands/zero/workflow/__tests__/create.test.ts apps/cli/src/commands/zero/workflow/__tests__/list.test.ts apps/cli/src/commands/zero/workflow/__tests__/view.test.ts apps/cli/src/commands/zero/workflow/__tests__/copy.test.ts
- pnpm exec prettier --check apps/cli/src/commands/zero/workflow/create.ts apps/cli/src/commands/zero/workflow/list.ts apps/cli/src/commands/zero/workflow/view.ts apps/cli/src/commands/zero/workflow/copy.ts apps/cli/src/commands/zero/workflow/format.ts apps/cli/src/commands/zero/workflow/__tests__/create.test.ts apps/cli/src/commands/zero/workflow/__tests__/list.test.ts apps/cli/src/commands/zero/workflow/__tests__/view.test.ts apps/cli/src/commands/zero/workflow/__tests__/copy.test.ts packages/core/src/zero-seed-skills.ts
- pnpm -F @vm0/cli check-types
- pnpm -F @vm0/core check-types