### PR TITLE
fix(app): simplify workflow trigger creation prompts

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-automations-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-automations-page.test.tsx
@@ -424,14 +424,29 @@ describe("zero automations page", () => {
   });
 
   it.each([
-    ["Fixed interval", /interval triggered workflow/u],
-    ["Fixed schedule", /schedule triggered workflow/u],
-    ["Web trigger", /web triggered workflow/u],
-    ["New email", /email triggered workflow that runs when a Gmail message/u],
-    ["Email label", /email-label triggered workflow/u],
+    [
+      "Fixed interval",
+      "I'd like to set up an interval workflow trigger that runs every few minutes or hours. Help me define the workflow.",
+    ],
+    [
+      "Fixed schedule",
+      "I'd like to set up a scheduled workflow trigger that runs on a daily, weekly, monthly, or custom cron schedule. Help me define the workflow.",
+    ],
+    [
+      "Web trigger",
+      "I'd like to set up a webhook workflow trigger that runs when an inbound webhook is received. Help me define the workflow.",
+    ],
+    [
+      "New email",
+      "I'd like to set up an email workflow trigger that runs when a Gmail message matches my criteria. Help me define the workflow.",
+    ],
+    [
+      "Email label",
+      "I'd like to set up an email-label workflow trigger that runs when a Gmail label is applied. Help me define the workflow.",
+    ],
   ])(
     "starts workflow-trigger creation with the %s prompt",
-    async (triggerName, promptPattern) => {
+    async (triggerName, prompt) => {
       mockWorkflowTriggerStory();
 
       detachedSetupPage({
@@ -473,7 +488,7 @@ describe("zero automations page", () => {
         expect(pathname()).toBe(`/agents/${zeroAgentId}/chat`);
       });
       await expect(
-        screen.findByDisplayValue(promptPattern),
+        screen.findByDisplayValue(prompt),
       ).resolves.toBeInTheDocument();
     },
   );

--- a/turbo/apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx
@@ -99,7 +99,7 @@ const WORKFLOW_AUTOMATION_OPTIONS: readonly WorkflowAutomationOption[] = [
     description: "Run a workflow every few minutes or hours.",
     Icon: IconRepeat,
     prompt:
-      "I'd like to create an interval triggered workflow. Help me define the workflow, create the interval trigger, check the required connectors, and grant only the permissions it needs.",
+      "I'd like to set up an interval workflow trigger that runs every few minutes or hours. Help me define the workflow.",
   },
   {
     kind: "scheduled",
@@ -108,7 +108,7 @@ const WORKFLOW_AUTOMATION_OPTIONS: readonly WorkflowAutomationOption[] = [
       "Run a workflow on a daily, weekly, monthly, or custom cron schedule.",
     Icon: IconCalendarTime,
     prompt:
-      "I'd like to create a schedule triggered workflow. Help me define the workflow, create the schedule trigger, check the required connectors, and grant only the permissions it needs.",
+      "I'd like to set up a scheduled workflow trigger that runs on a daily, weekly, monthly, or custom cron schedule. Help me define the workflow.",
   },
   {
     kind: "webhook",
@@ -116,7 +116,7 @@ const WORKFLOW_AUTOMATION_OPTIONS: readonly WorkflowAutomationOption[] = [
     description: "Run a workflow when an inbound webhook is received.",
     Icon: IconLink,
     prompt:
-      "I'd like to create a web triggered workflow. Help me define the workflow, create the webhook trigger, check any connector needs, and grant only the permissions it needs.",
+      "I'd like to set up a webhook workflow trigger that runs when an inbound webhook is received. Help me define the workflow.",
   },
   {
     kind: "gmail-new-message",
@@ -124,7 +124,7 @@ const WORKFLOW_AUTOMATION_OPTIONS: readonly WorkflowAutomationOption[] = [
     description: "Run a workflow when a matching Gmail message arrives.",
     Icon: IconMail,
     prompt:
-      "I'd like to create an email triggered workflow that runs when a Gmail message matches my criteria. Help me define the workflow, create the Gmail trigger, check my Gmail connector, and grant only the permissions it needs.",
+      "I'd like to set up an email workflow trigger that runs when a Gmail message matches my criteria. Help me define the workflow.",
   },
   {
     kind: "gmail-label-applied",
@@ -132,7 +132,7 @@ const WORKFLOW_AUTOMATION_OPTIONS: readonly WorkflowAutomationOption[] = [
     description: "Run a workflow when a Gmail label is applied.",
     Icon: IconMail,
     prompt:
-      "I'd like to create an email-label triggered workflow that runs when a Gmail label is applied. Help me define the workflow, create the Gmail label trigger, check my Gmail connector, and grant only the permissions it needs.",
+      "I'd like to set up an email-label workflow trigger that runs when a Gmail label is applied. Help me define the workflow.",
   },
 ] as const;
 


### PR DESCRIPTION
## Summary
- Shorten workflow trigger creation prompts to only state the desired trigger scenario and ask to define the workflow.
- Remove explicit trigger creation, connector checking, and permission-grant instructions from the web-generated prompts so workflow-setup owns those details.
- Update the automations page test to assert the full prompt text for each trigger type.

## Verification
- pnpm --dir turbo exec vitest run apps/platform/src/views/zero-page/__tests__/zero-automations-page.test.tsx
- pnpm --dir turbo exec prettier --check apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx apps/platform/src/views/zero-page/__tests__/zero-automations-page.test.tsx
- git diff --check