### PR TITLE
fix: bind workflow creation to current chat thread

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflows.test.ts
@@ -229,6 +229,137 @@ describe("zero workflows", () => {
     );
   });
 
+  it("binds a newly created workflow to the current matching agent chat thread", async () => {
+    const fixture = await track(
+      store.set(seedWorkflowsFixture$, undefined, context.signal),
+    );
+    const agent = await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        displayName: "Thread Agent",
+        visibility: "private",
+      },
+      context.signal,
+    );
+    const db = store.set(writeDb$);
+    const [thread] = await db
+      .insert(chatThreads)
+      .values({
+        userId: fixture.userId,
+        agentComposeId: agent.agentId,
+        title: "Current chat",
+      })
+      .returning({ id: chatThreads.id });
+    if (!thread) {
+      throw new Error("Failed to seed current chat thread");
+    }
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+    context.mocks.s3.send.mockResolvedValue({});
+
+    const created = await accept(
+      collectionClient().create({
+        headers: authHeaders(),
+        body: {
+          agentId: agent.agentId,
+          chatThreadId: thread.id,
+          name: "thread-workflow",
+          displayName: "Thread Workflow",
+          instruction: "# thread workflow",
+        },
+      }),
+      [201],
+    );
+
+    const [binding] = await db
+      .select({ chatThreadId: workflowUserTriggerThreads.chatThreadId })
+      .from(workflowUserTriggerThreads)
+      .where(
+        and(
+          eq(workflowUserTriggerThreads.orgId, fixture.orgId),
+          eq(workflowUserTriggerThreads.userId, fixture.userId),
+          eq(workflowUserTriggerThreads.workflowId, created.body.id),
+        ),
+      );
+    expect(binding?.chatThreadId).toBe(thread.id);
+
+    const prepared = await accept(
+      detailClient().chatThread({
+        headers: authHeaders(),
+        params: { workflowId: created.body.id },
+      }),
+      [200],
+    );
+    expect(prepared.body.chatThreadId).toBe(thread.id);
+  });
+
+  it("does not bind a newly created workflow to a chat thread from another agent", async () => {
+    const fixture = await track(
+      store.set(seedWorkflowsFixture$, undefined, context.signal),
+    );
+    const sourceAgent = await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        displayName: "Source Agent",
+        visibility: "private",
+      },
+      context.signal,
+    );
+    const targetAgent = await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        displayName: "Target Agent",
+        visibility: "private",
+      },
+      context.signal,
+    );
+    const db = store.set(writeDb$);
+    const [thread] = await db
+      .insert(chatThreads)
+      .values({
+        userId: fixture.userId,
+        agentComposeId: sourceAgent.agentId,
+        title: "Source chat",
+      })
+      .returning({ id: chatThreads.id });
+    if (!thread) {
+      throw new Error("Failed to seed source chat thread");
+    }
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+    context.mocks.s3.send.mockResolvedValue({});
+
+    const created = await accept(
+      collectionClient().create({
+        headers: authHeaders(),
+        body: {
+          agentId: targetAgent.agentId,
+          chatThreadId: thread.id,
+          name: "target-workflow",
+          displayName: "Target Workflow",
+          instruction: "# target workflow",
+        },
+      }),
+      [201],
+    );
+
+    const bindings = await db
+      .select({ chatThreadId: workflowUserTriggerThreads.chatThreadId })
+      .from(workflowUserTriggerThreads)
+      .where(
+        and(
+          eq(workflowUserTriggerThreads.orgId, fixture.orgId),
+          eq(workflowUserTriggerThreads.userId, fixture.userId),
+          eq(workflowUserTriggerThreads.workflowId, created.body.id),
+        ),
+      );
+    expect(bindings).toStrictEqual([]);
+  });
+
   it("enforces public workflow slug uniqueness per agent while allowing private overrides", async () => {
     const fixture = await track(
       store.set(seedWorkflowsFixture$, undefined, context.signal),

--- a/turbo/apps/api/src/signals/routes/zero-workflows.ts
+++ b/turbo/apps/api/src/signals/routes/zero-workflows.ts
@@ -14,8 +14,12 @@ import {
 import { SEED_SKILLS } from "@vm0/core/zero-seed-skills";
 import { getCustomSkillStorageName } from "@vm0/core/storage-names";
 import { synthesizeWorkflowSkillMd } from "@vm0/core/zero-workflow-skill";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
-import { zeroWorkflows } from "@vm0/db/schema/zero-workflow";
+import {
+  workflowUserTriggerThreads,
+  zeroWorkflows,
+} from "@vm0/db/schema/zero-workflow";
 import { workflowUserConnectors } from "@vm0/db/schema/workflow-user-connector";
 import { and, eq, ne } from "drizzle-orm";
 
@@ -167,6 +171,30 @@ async function requirePublicWorkflowSlugAvailable(
     : null;
 }
 
+async function loadMatchingWorkflowCreationThreadId(
+  db: Db,
+  args: {
+    readonly userId: string;
+    readonly agentId: string;
+    readonly chatThreadId: string;
+  },
+): Promise<string | null> {
+  const [thread] = await db
+    .select({ id: chatThreads.id })
+    .from(chatThreads)
+    .where(
+      and(
+        eq(chatThreads.id, args.chatThreadId),
+        eq(chatThreads.userId, args.userId),
+        eq(chatThreads.agentComposeId, args.agentId),
+      ),
+    )
+    .limit(1)
+    .for("update");
+
+  return thread?.id ?? null;
+}
+
 const createWorkflowBody$ = bodyResultOf(
   zeroWorkflowsCollectionContract.create,
 );
@@ -239,21 +267,47 @@ const createWorkflowInner$ = command(
       }
     }
 
-    const [inserted] = await writeDb
-      .insert(zeroWorkflows)
-      .values({
-        orgId: auth.orgId,
-        agentId: agent.id,
-        name: body.name,
-        visibility,
-        instruction: body.instruction ?? null,
-        ownerUserId: auth.userId,
-        displayName: body.displayName ?? null,
-        description: body.description ?? null,
-        createdBy: auth.userId,
-        updatedBy: auth.userId,
-      })
-      .returning({ id: zeroWorkflows.id });
+    const currentTime = nowDate();
+    const inserted = await writeDb.transaction(async (tx) => {
+      const [workflow] = await tx
+        .insert(zeroWorkflows)
+        .values({
+          orgId: auth.orgId,
+          agentId: agent.id,
+          name: body.name,
+          visibility,
+          instruction: body.instruction ?? null,
+          ownerUserId: auth.userId,
+          displayName: body.displayName ?? null,
+          description: body.description ?? null,
+          createdBy: auth.userId,
+          updatedBy: auth.userId,
+          createdAt: currentTime,
+          updatedAt: currentTime,
+        })
+        .returning({ id: zeroWorkflows.id });
+
+      if (workflow && body.chatThreadId) {
+        const chatThreadId = await loadMatchingWorkflowCreationThreadId(tx, {
+          userId: auth.userId,
+          agentId: agent.id,
+          chatThreadId: body.chatThreadId,
+        });
+
+        if (chatThreadId) {
+          await tx.insert(workflowUserTriggerThreads).values({
+            orgId: auth.orgId,
+            userId: auth.userId,
+            workflowId: workflow.id,
+            chatThreadId,
+            createdAt: currentTime,
+            updatedAt: currentTime,
+          });
+        }
+      }
+
+      return workflow;
+    });
     signal.throwIfAborted();
     if (!inserted) {
       throw new Error("Failed to create workflow");

--- a/turbo/apps/cli/src/commands/zero/workflow/__tests__/create.test.ts
+++ b/turbo/apps/cli/src/commands/zero/workflow/__tests__/create.test.ts
@@ -17,6 +17,7 @@ import { createCommand } from "../create";
 import chalk from "chalk";
 
 const AGENT_ID = "11111111-1111-1111-1111-111111111111";
+const CHAT_THREAD_ID = "33333333-3333-4333-8333-333333333333";
 
 const mockWorkflow = {
   id: "22222222-2222-2222-2222-222222222222",
@@ -48,6 +49,7 @@ describe("zero workflow create command", () => {
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");
     vi.stubEnv("ZERO_AGENT_ID", "");
+    vi.stubEnv("ZERO_CHAT_THREAD_ID", "");
 
     workflowDir = join(tmpdir(), `test-workflow-${Date.now()}`);
     mkdirSync(workflowDir, { recursive: true });
@@ -139,6 +141,33 @@ describe("zero workflow create command", () => {
       ]);
 
       expect(capturedBody?.agentId).toBe(AGENT_ID);
+    });
+
+    it("should forward ZERO_CHAT_THREAD_ID when creating from a chat thread", async () => {
+      vi.stubEnv("ZERO_AGENT_ID", AGENT_ID);
+      vi.stubEnv("ZERO_CHAT_THREAD_ID", CHAT_THREAD_ID);
+
+      let capturedBody: Record<string, unknown> | undefined;
+      server.use(
+        http.post(
+          "http://localhost:3000/api/zero/workflows",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(mockWorkflow, { status: 201 });
+          },
+        ),
+      );
+
+      await createCommand.parseAsync([
+        "node",
+        "cli",
+        "my-workflow",
+        "--instruction",
+        "Do things",
+      ]);
+
+      expect(capturedBody?.agentId).toBe(AGENT_ID);
+      expect(capturedBody?.chatThreadId).toBe(CHAT_THREAD_ID);
     });
   });
 

--- a/turbo/apps/cli/src/commands/zero/workflow/create.ts
+++ b/turbo/apps/cli/src/commands/zero/workflow/create.ts
@@ -85,6 +85,7 @@ Notes:
 
         const workflow = await createWorkflow({
           agentId,
+          chatThreadId: process.env.ZERO_CHAT_THREAD_ID || undefined,
           name,
           instruction,
           files,

--- a/turbo/apps/cli/src/lib/api/domains/zero-workflows.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-workflows.ts
@@ -26,6 +26,7 @@ export async function listWorkflows(query: {
 
 export async function createWorkflow(body: {
   agentId: string;
+  chatThreadId?: string;
   name: string;
   instruction?: string;
   files?: WorkflowFileEntry[];

--- a/turbo/packages/api-contracts/src/contracts/zero-workflows.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-workflows.ts
@@ -434,6 +434,7 @@ export const zeroWorkflowTriggerAutomationListResponseSchema = z.array(
 
 export const zeroWorkflowCreateRequestSchema = z.object({
   agentId: z.string().uuid(),
+  chatThreadId: z.string().uuid().optional(),
   name: zeroWorkflowNameSchema,
   instruction: workflowInstructionSchema.optional(),
   files: workflowFilesSchema.optional(),


### PR DESCRIPTION
## Summary
- Allow workflow creation requests to include an optional current chatThreadId.
- When the supplied thread belongs to the current user and the target workflow agent, seed workflow_user_trigger_threads with that existing thread.
- Forward ZERO_CHAT_THREAD_ID from the Zero CLI workflow create command and cover matching/mismatched thread behavior with tests.

## Verification
- pnpm -F @vm0/cli test src/commands/zero/workflow/__tests__/create.test.ts
- pnpm exec prettier --check apps/api/src/signals/routes/zero-workflows.ts apps/api/src/signals/routes/__tests__/zero-workflows.test.ts apps/cli/src/commands/zero/workflow/create.ts apps/cli/src/commands/zero/workflow/__tests__/create.test.ts apps/cli/src/lib/api/domains/zero-workflows.ts packages/api-contracts/src/contracts/zero-workflows.ts
- pnpm -F @vm0/cli check-types
- pnpm -F api exec oxlint src/signals/routes/zero-workflows.ts src/signals/routes/__tests__/zero-workflows.test.ts
- pnpm -F @vm0/cli exec oxlint src/commands/zero/workflow/create.ts src/commands/zero/workflow/__tests__/create.test.ts src/lib/api/domains/zero-workflows.ts
- pnpm -F api exec eslint src/signals/routes/zero-workflows.ts src/signals/routes/__tests__/zero-workflows.test.ts --max-warnings 0
- pnpm -F @vm0/cli exec eslint src/commands/zero/workflow/create.ts src/commands/zero/workflow/__tests__/create.test.ts src/lib/api/domains/zero-workflows.ts --max-warnings 0

## Notes
- API route test command could not complete locally because no Postgres is listening on 127.0.0.1:5432.
- API check-types exceeded local memory limits: default heap OOM, 8GB heap was killed with exit 137.