### PR TITLE
fix: block schedule automation writes behind workflow trigger switch

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/automations.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/automations.test.ts
@@ -6,6 +6,7 @@ import {
   automationTriggersContract,
 } from "@vm0/api-contracts/contracts/automations";
 import { cronExecuteAutomationsContract } from "@vm0/api-contracts/contracts/cron";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { agentRunCallbacks } from "@vm0/db/schema/agent-run-callback";
 import { agentRuns } from "@vm0/db/schema/agent-run";
@@ -14,6 +15,7 @@ import { automations, automationTriggers } from "@vm0/db/schema/automation";
 import { chatMessages } from "@vm0/db/schema/chat-message";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
+import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { createStore } from "ccstate";
 import { and, asc, eq, inArray } from "drizzle-orm";
@@ -44,6 +46,8 @@ const mocks = createZeroRouteMocks(context);
 
 const SESSION_HEADERS = { authorization: "Bearer clerk-session" } as const;
 const CRON_SECRET = "test-cron-secret";
+const SCHEDULE_AUTOMATION_DISABLED_MESSAGE =
+  "Schedule automation has been disabled. Use zero workflow trigger to create scheduled tasks.";
 // Keep global-cron fixtures invisible to parallel test workers using real time.
 const ISOLATED_CRON_POLL_TIME_MS = Date.UTC(2099, 0, 1, 0, 0, 0);
 
@@ -118,6 +122,21 @@ async function seedFixture(): Promise<AutomationsFixture> {
   await trackCreatedAutomations(Promise.resolve(fixture));
   mocks.clerk.session(fixture.userId, fixture.orgId);
   return fixture;
+}
+
+async function enableScheduleAutomationToWorkflowTriggerSwitch(
+  fixture: AutomationsFixture,
+): Promise<void> {
+  await store
+    .set(writeDb$)
+    .insert(userFeatureSwitches)
+    .values({
+      orgId: fixture.orgId,
+      userId: fixture.userId,
+      switches: {
+        [FeatureSwitchKey.SwitchScheduleAutomationToWorkflowTrigger]: true,
+      },
+    });
 }
 
 interface CreateArgs {
@@ -221,6 +240,36 @@ describe("Automations API", () => {
     });
   });
 
+  it("rejects creating an automation when schedule automations are switched to workflow triggers", async () => {
+    const fixture = await seedFixture();
+    await enableScheduleAutomationToWorkflowTriggerSwitch(fixture);
+
+    const response = await accept(
+      mainApi().create({
+        headers: SESSION_HEADERS,
+        body: {
+          name: "daily-digest",
+          agentId: fixture.composeId,
+          instruction: "Summarize the day.",
+          trigger: { kind: "cron", cronExpression: "0 9 * * *" },
+        },
+      }),
+      [403],
+    );
+
+    expect(response.body.error).toStrictEqual({
+      message: SCHEDULE_AUTOMATION_DISABLED_MESSAGE,
+      code: "FORBIDDEN",
+    });
+
+    const rows = await store
+      .set(writeDb$)
+      .select({ id: automations.id })
+      .from(automations)
+      .where(eq(automations.orgId, fixture.orgId));
+    expect(rows).toHaveLength(0);
+  });
+
   it("creates an automation with a first cron trigger via sugar", async () => {
     const fixture = await seedFixture();
 
@@ -254,6 +303,81 @@ describe("Automations API", () => {
       throw new Error("Expected a cron trigger");
     }
     expect(disabledTrigger.nextRunAt).toBeNull();
+  });
+
+  it("rejects enabling a disabled automation when schedule automations are switched to workflow triggers", async () => {
+    const fixture = await seedFixture();
+    const created = await createAutomation({
+      name: "paused-digest",
+      agentId: fixture.composeId,
+      enabled: false,
+      trigger: { kind: "cron", cronExpression: "0 9 * * *" },
+    });
+    await enableScheduleAutomationToWorkflowTriggerSwitch(fixture);
+
+    const response = await accept(
+      refApi().enable({
+        headers: SESSION_HEADERS,
+        params: { ref: created.automation.id },
+        body: {},
+      }),
+      [403],
+    );
+
+    expect(response.body.error).toStrictEqual({
+      message: SCHEDULE_AUTOMATION_DISABLED_MESSAGE,
+      code: "FORBIDDEN",
+    });
+
+    const [row] = await store
+      .set(writeDb$)
+      .select({ enabled: automations.enabled })
+      .from(automations)
+      .where(eq(automations.id, created.automation.id));
+    expect(row?.enabled).toBeFalsy();
+  });
+
+  it("rejects enabling a disabled automation trigger when schedule automations are switched to workflow triggers", async () => {
+    const fixture = await seedFixture();
+    const created = await createAutomation({
+      name: "paused-trigger-digest",
+      agentId: fixture.composeId,
+      trigger: { kind: "cron", cronExpression: "0 9 * * *" },
+    });
+    const [trigger] = created.automation.triggers;
+    if (!trigger) {
+      throw new Error("Expected a trigger");
+    }
+    await accept(
+      triggerApi().disable({
+        headers: SESSION_HEADERS,
+        params: { id: trigger.id },
+        body: {},
+      }),
+      [200],
+    );
+    await enableScheduleAutomationToWorkflowTriggerSwitch(fixture);
+
+    const response = await accept(
+      triggerApi().enable({
+        headers: SESSION_HEADERS,
+        params: { id: trigger.id },
+        body: {},
+      }),
+      [403],
+    );
+
+    expect(response.body.error).toStrictEqual({
+      message: SCHEDULE_AUTOMATION_DISABLED_MESSAGE,
+      code: "FORBIDDEN",
+    });
+
+    const [row] = await store
+      .set(writeDb$)
+      .select({ enabled: automationTriggers.enabled })
+      .from(automationTriggers)
+      .where(eq(automationTriggers.id, trigger.id));
+    expect(row?.enabled).toBeFalsy();
   });
 
   it("creates and updates one-time triggers by interpreting local atTime in timezone", async () => {

--- a/turbo/apps/api/src/signals/routes/automations.ts
+++ b/turbo/apps/api/src/signals/routes/automations.ts
@@ -6,6 +6,8 @@ import {
   type AutomationResponse,
   type AutomationTriggerResponse,
 } from "@vm0/api-contracts/contracts/automations";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { isFeatureEnabled } from "@vm0/core/feature-switch";
 
 import { badRequestMessage, conflict, notFound } from "../../lib/error";
 import { organizationAuthContext$ } from "../auth/auth-context";
@@ -27,10 +29,20 @@ import {
   type AutomationTriggerRow,
   type AutomationView,
 } from "../services/automations.service";
+import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
 import type { RouteEntry } from "../route-entry";
 
 const NOT_FOUND_MESSAGE = "Resource not found";
 const AMBIGUOUS_MESSAGE = "Ambiguous name, use the id";
+const SCHEDULE_AUTOMATION_DISABLED_MESSAGE =
+  "Schedule automation has been disabled. Use zero workflow trigger to create scheduled tasks.";
+
+function forbidden(message: string) {
+  return {
+    status: 403 as const,
+    body: { error: { message, code: "FORBIDDEN" as const } },
+  };
+}
 
 function triggerResponse(
   trigger: AutomationTriggerRow,
@@ -95,8 +107,28 @@ function automationResponse(view: AutomationView): AutomationResponse {
   };
 }
 
+const scheduleAutomationToWorkflowTriggerEnabled$ = command(async ({ get }) => {
+  const auth = get(organizationAuthContext$);
+  const overrides = await get(
+    userFeatureSwitchOverrides(auth.orgId, auth.userId),
+  );
+  return isFeatureEnabled(
+    FeatureSwitchKey.SwitchScheduleAutomationToWorkflowTrigger,
+    { orgId: auth.orgId, userId: auth.userId, overrides },
+  );
+});
+
+function scheduleAutomationDisabled() {
+  return forbidden(SCHEDULE_AUTOMATION_DISABLED_MESSAGE);
+}
+
 const createInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   const auth = get(organizationAuthContext$);
+  if (await set(scheduleAutomationToWorkflowTriggerEnabled$)) {
+    return scheduleAutomationDisabled();
+  }
+  signal.throwIfAborted();
+
   const bodyResult = await get(bodyResultOf(automationsMainContract.create));
   signal.throwIfAborted();
   if (!bodyResult.ok) {
@@ -232,6 +264,11 @@ function makeSetEnabledInner(enabled: boolean) {
     const auth = get(organizationAuthContext$);
     const params = get(pathParamsOf(automationsByRefContract.enable));
 
+    if (enabled && (await set(scheduleAutomationToWorkflowTriggerEnabled$))) {
+      return scheduleAutomationDisabled();
+    }
+    signal.throwIfAborted();
+
     if (enabled && auth.orgRole !== undefined) {
       await set(
         upsertMemberRoleCache$,
@@ -352,6 +389,11 @@ function makeSetTriggerEnabledInner(enabled: boolean) {
   return command(async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
     const params = get(pathParamsOf(automationTriggersContract.enable));
+
+    if (enabled && (await set(scheduleAutomationToWorkflowTriggerEnabled$))) {
+      return scheduleAutomationDisabled();
+    }
+    signal.throwIfAborted();
 
     const result = await set(
       setTriggerEnabled$,

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -53,6 +53,12 @@ describe("isFeatureEnabled", () => {
         orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
       }),
     ).toBe(true);
+    expect(
+      isFeatureEnabled(
+        FeatureSwitchKey.SwitchScheduleAutomationToWorkflowTrigger,
+        { orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe" },
+      ),
+    ).toBe(true);
   });
 
   it("should return false when orgId does not match enabledOrgIdHashes", () => {
@@ -75,6 +81,12 @@ describe("isFeatureEnabled", () => {
       isFeatureEnabled(FeatureSwitchKey.GoalWorkflows, {
         orgId: "org_nonexistent",
       }),
+    ).toBe(false);
+    expect(
+      isFeatureEnabled(
+        FeatureSwitchKey.SwitchScheduleAutomationToWorkflowTrigger,
+        { orgId: "org_nonexistent" },
+      ),
     ).toBe(false);
   });
 
@@ -129,6 +141,11 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.ConnectorAccessManagement]).toBe(
       true,
     );
+    expect(
+      staffOrgStates[
+        FeatureSwitchKey.SwitchScheduleAutomationToWorkflowTrigger
+      ],
+    ).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatGithubPrTracking]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.HtmlArtifactCommentEditing]).toBe(
       false,
@@ -144,6 +161,11 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.ConnectorAccessManagement]).toBe(
       false,
     );
+    expect(
+      otherOrgStates[
+        FeatureSwitchKey.SwitchScheduleAutomationToWorkflowTrigger
+      ],
+    ).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatGithubPrTracking]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.HtmlArtifactCommentEditing]).toBe(
       false,

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -296,6 +296,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Replace the /automations schedule list and calendar with a workflow-trigger surface and route new automation setup into triggered workflow creation.",
     enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.GoalWorkflows]: {
     maintainer: "ethan@vm0.ai",


### PR DESCRIPTION
## Summary
- Block legacy schedule automation create, automation enable, and trigger enable when switchScheduleAutomationToWorkflowTrigger is enabled.
- Return a 403 message directing users to zero workflow trigger for scheduled tasks.
- Enable switchScheduleAutomationToWorkflowTrigger for staff orgs by default.

## Tests
- DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm -F api exec vitest run src/signals/routes/__tests__/automations.test.ts
- pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts
- DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm -F api lint
- NODE_OPTIONS=--max-old-space-size=4096 DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm -F api check-types
- pnpm -F @vm0/core lint
- pnpm -F @vm0/core check-types