### PR TITLE
fix: copy workflow runtime configuration

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflows.test.ts
@@ -9,8 +9,12 @@ import { getCustomSkillStorageName } from "@vm0/core/storage-names";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import {
   workflowUserTriggerThreads,
+  zeroWorkflowTriggers,
+  zeroWorkflowWebhookTriggers,
   zeroWorkflows,
 } from "@vm0/db/schema/zero-workflow";
+import { workflowUserConnectors } from "@vm0/db/schema/workflow-user-connector";
+import { workflowUserPermissionGrants } from "@vm0/db/schema/workflow-user-permission-grant";
 import { createStore } from "ccstate";
 import { and, eq } from "drizzle-orm";
 
@@ -820,6 +824,282 @@ describe("zero workflows", () => {
     expect(copyableAgentIds).toStrictEqual(
       [sourceAgent.agentId, targetAgent.agentId].sort(),
     );
+  });
+
+  it("copies caller-owned workflow triggers, connector access, and permission grants", async () => {
+    const fixture = await track(
+      store.set(seedWorkflowsFixture$, undefined, context.signal),
+    );
+    const sourceAgent = await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        displayName: "Source Agent",
+        visibility: "private",
+      },
+      context.signal,
+    );
+    const targetAgent = await store.set(
+      seedAgentForInstructions$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        displayName: "Target Agent",
+        visibility: "public",
+      },
+      context.signal,
+    );
+    const db = store.set(writeDb$);
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+    context.mocks.s3.send.mockResolvedValue({});
+
+    const created = await accept(
+      collectionClient().create({
+        headers: authHeaders(),
+        body: {
+          agentId: sourceAgent.agentId,
+          name: "runtime-config-workflow",
+          displayName: "Runtime Config Workflow",
+          instruction: "# runtime config workflow",
+        },
+      }),
+      [201],
+    );
+    const workflowId = created.body.id;
+
+    const otherUserId = `user_${randomUUID()}`;
+    const grantExpiresAt = new Date("2099-01-01T00:00:00.000Z");
+    const nextRunAt = new Date("2099-01-01T09:00:00.000Z");
+    await db.insert(workflowUserConnectors).values([
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        workflowId,
+        connectorType: "gmail",
+      },
+      {
+        orgId: fixture.orgId,
+        userId: otherUserId,
+        workflowId,
+        connectorType: "slack",
+      },
+    ]);
+    await db.insert(workflowUserPermissionGrants).values([
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        workflowId,
+        connectorRef: "gmail",
+        permission: "messages.read",
+        action: "allow",
+        expiresAt: grantExpiresAt,
+      },
+      {
+        orgId: fixture.orgId,
+        userId: otherUserId,
+        workflowId,
+        connectorRef: "slack",
+        permission: "chat.write",
+        action: "allow",
+      },
+    ]);
+
+    const [sourceScheduleTrigger] = await db
+      .insert(zeroWorkflowTriggers)
+      .values({
+        orgId: fixture.orgId,
+        workflowId,
+        ownerUserId: fixture.userId,
+        kind: "schedule",
+        eventType: null,
+        eventConfig: null,
+        scheduleType: "cron",
+        cronExpression: "0 9 * * *",
+        intervalSeconds: null,
+        atTime: null,
+        timezone: "Asia/Shanghai",
+        enabled: true,
+        nextRunAt,
+        lastRunAt: new Date("2026-01-01T00:00:00.000Z"),
+        lastRunId: randomUUID(),
+        consecutiveFailures: 2,
+      })
+      .returning({ id: zeroWorkflowTriggers.id });
+    const [sourceWebhookTrigger] = await db
+      .insert(zeroWorkflowTriggers)
+      .values({
+        orgId: fixture.orgId,
+        workflowId,
+        ownerUserId: fixture.userId,
+        kind: "event",
+        eventType: "webhook-received",
+        eventConfig: {
+          provider: "webhook",
+          event: "received",
+          auth: { mode: "hmac-sha256" },
+        },
+        scheduleType: null,
+        cronExpression: null,
+        intervalSeconds: null,
+        atTime: null,
+        timezone: "UTC",
+        enabled: false,
+        nextRunAt: null,
+      })
+      .returning({ id: zeroWorkflowTriggers.id });
+    if (!sourceScheduleTrigger || !sourceWebhookTrigger) {
+      throw new Error("Failed to seed source workflow triggers");
+    }
+    const sourceWebhookTokenHash = `source-${randomUUID()}`;
+    await db.insert(zeroWorkflowWebhookTriggers).values({
+      triggerId: sourceWebhookTrigger.id,
+      tokenHash: sourceWebhookTokenHash,
+      encryptedToken: "source-encrypted-token",
+      encryptedSecret: "source-encrypted-secret",
+      secretLastFour: "1234",
+    });
+    await db.insert(zeroWorkflowTriggers).values({
+      orgId: fixture.orgId,
+      workflowId,
+      ownerUserId: otherUserId,
+      kind: "schedule",
+      eventType: null,
+      eventConfig: null,
+      scheduleType: "loop",
+      cronExpression: null,
+      intervalSeconds: 300,
+      atTime: null,
+      timezone: "UTC",
+      enabled: true,
+      nextRunAt,
+    });
+
+    const copied = await accept(
+      detailClient().copy({
+        headers: authHeaders(),
+        params: { workflowId },
+        body: { toAgentId: targetAgent.agentId },
+      }),
+      [201],
+    );
+
+    const copiedConnectors = await db
+      .select({ connectorType: workflowUserConnectors.connectorType })
+      .from(workflowUserConnectors)
+      .where(
+        and(
+          eq(workflowUserConnectors.orgId, fixture.orgId),
+          eq(workflowUserConnectors.userId, fixture.userId),
+          eq(workflowUserConnectors.workflowId, copied.body.id),
+        ),
+      );
+    expect(
+      copiedConnectors.map((row) => {
+        return row.connectorType;
+      }),
+    ).toStrictEqual(["gmail"]);
+
+    const copiedGrants = await db
+      .select()
+      .from(workflowUserPermissionGrants)
+      .where(
+        and(
+          eq(workflowUserPermissionGrants.orgId, fixture.orgId),
+          eq(workflowUserPermissionGrants.userId, fixture.userId),
+          eq(workflowUserPermissionGrants.workflowId, copied.body.id),
+        ),
+      );
+    expect(copiedGrants).toHaveLength(1);
+    expect(copiedGrants[0]).toMatchObject({
+      connectorRef: "gmail",
+      permission: "messages.read",
+      action: "allow",
+    });
+    expect(copiedGrants[0]?.expiresAt?.toISOString()).toBe(
+      grantExpiresAt.toISOString(),
+    );
+
+    const copiedTriggers = await db
+      .select()
+      .from(zeroWorkflowTriggers)
+      .where(
+        and(
+          eq(zeroWorkflowTriggers.orgId, fixture.orgId),
+          eq(zeroWorkflowTriggers.ownerUserId, fixture.userId),
+          eq(zeroWorkflowTriggers.workflowId, copied.body.id),
+        ),
+      );
+    expect(copiedTriggers).toHaveLength(2);
+    const copiedScheduleTrigger = copiedTriggers.find((trigger) => {
+      return trigger.kind === "schedule";
+    });
+    const copiedWebhookTrigger = copiedTriggers.find((trigger) => {
+      return (
+        trigger.kind === "event" && trigger.eventType === "webhook-received"
+      );
+    });
+    if (!copiedScheduleTrigger || !copiedWebhookTrigger) {
+      throw new Error("Expected copied schedule and webhook triggers");
+    }
+    expect(copiedScheduleTrigger.id).not.toBe(sourceScheduleTrigger.id);
+    expect(copiedScheduleTrigger).toMatchObject({
+      scheduleType: "cron",
+      cronExpression: "0 9 * * *",
+      timezone: "Asia/Shanghai",
+      enabled: true,
+      lastRunAt: null,
+      lastRunId: null,
+      consecutiveFailures: 0,
+    });
+    expect(copiedScheduleTrigger.nextRunAt?.toISOString()).toBe(
+      nextRunAt.toISOString(),
+    );
+    expect(copiedWebhookTrigger.id).not.toBe(sourceWebhookTrigger.id);
+    expect(copiedWebhookTrigger).toMatchObject({
+      eventType: "webhook-received",
+      enabled: false,
+      nextRunAt: null,
+      lastRunAt: null,
+      lastRunId: null,
+      consecutiveFailures: 0,
+    });
+
+    const [copiedWebhookConfig] = await db
+      .select()
+      .from(zeroWorkflowWebhookTriggers)
+      .where(
+        eq(zeroWorkflowWebhookTriggers.triggerId, copiedWebhookTrigger.id),
+      );
+    expect(copiedWebhookConfig?.tokenHash).toBeDefined();
+    expect(copiedWebhookConfig?.tokenHash).not.toBe(sourceWebhookTokenHash);
+    expect(copiedWebhookConfig?.encryptedSecret).toBe(
+      "source-encrypted-secret",
+    );
+    expect(copiedWebhookConfig?.secretLastFour).toBe("1234");
+
+    const leakedTriggers = await db
+      .select()
+      .from(zeroWorkflowTriggers)
+      .where(
+        and(
+          eq(zeroWorkflowTriggers.orgId, fixture.orgId),
+          eq(zeroWorkflowTriggers.ownerUserId, otherUserId),
+          eq(zeroWorkflowTriggers.workflowId, copied.body.id),
+        ),
+      );
+    expect(leakedTriggers).toHaveLength(0);
+    const leakedGrants = await db
+      .select()
+      .from(workflowUserPermissionGrants)
+      .where(
+        and(
+          eq(workflowUserPermissionGrants.orgId, fixture.orgId),
+          eq(workflowUserPermissionGrants.userId, otherUserId),
+          eq(workflowUserPermissionGrants.workflowId, copied.body.id),
+        ),
+      );
+    expect(leakedGrants).toHaveLength(0);
   });
 
   it("gets or creates the shared workflow chat thread with a slash prompt", async () => {

--- a/turbo/apps/api/src/signals/routes/zero-workflows.ts
+++ b/turbo/apps/api/src/signals/routes/zero-workflows.ts
@@ -18,9 +18,12 @@ import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import {
   workflowUserTriggerThreads,
+  zeroWorkflowTriggers,
+  zeroWorkflowWebhookTriggers,
   zeroWorkflows,
 } from "@vm0/db/schema/zero-workflow";
 import { workflowUserConnectors } from "@vm0/db/schema/workflow-user-connector";
+import { workflowUserPermissionGrants } from "@vm0/db/schema/workflow-user-permission-grant";
 import { and, eq, ne } from "drizzle-orm";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
@@ -39,6 +42,13 @@ import { zeroWorkflowDetail } from "../services/zero-workflow-detail.service";
 import { ensureWorkflowUserTriggerThread } from "../services/zero-workflow-user-trigger-thread.service";
 import { updateZeroWorkflow$ } from "../services/zero-workflow-update.service";
 import { loadWorkflowVolumeFiles } from "../services/zero-workflow-volume.service";
+import {
+  encryptWorkflowWebhookSecret,
+  encryptWorkflowWebhookToken,
+  hashWorkflowWebhookToken,
+  mintWorkflowWebhookSecret,
+  mintWorkflowWebhookToken,
+} from "../services/workflow-webhook-trigger.service";
 import {
   unavailableUserConnectorTypes,
   userConnectorAvailability,
@@ -631,6 +641,275 @@ const deleteWorkflowInner$ = command(
   },
 );
 
+type WorkflowCopyTransaction = Parameters<Parameters<Db["transaction"]>[0]>[0];
+
+interface CopyWorkflowRuntimeArgs {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly sourceWorkflow: WorkflowRow;
+  readonly targetAgentId: string;
+  readonly currentTime: Date;
+}
+
+interface CopyWorkflowScopedRowsArgs {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly sourceWorkflowId: string;
+  readonly targetWorkflowId: string;
+  readonly currentTime: Date;
+}
+
+interface CopyWorkflowTriggerRowsArgs extends CopyWorkflowScopedRowsArgs {
+  readonly targetAgentId: string;
+  readonly workflowTitle: string;
+}
+
+async function insertCopiedWorkflowRow(
+  tx: WorkflowCopyTransaction,
+  args: CopyWorkflowRuntimeArgs,
+): Promise<{ readonly id: string } | undefined> {
+  const [workflow] = await tx
+    .insert(zeroWorkflows)
+    .values({
+      orgId: args.orgId,
+      agentId: args.targetAgentId,
+      name: args.sourceWorkflow.name,
+      visibility: "private",
+      instruction: args.sourceWorkflow.instruction,
+      ownerUserId: args.userId,
+      displayName: args.sourceWorkflow.displayName,
+      description: args.sourceWorkflow.description,
+      createdBy: args.userId,
+      updatedBy: args.userId,
+      createdAt: args.currentTime,
+      updatedAt: args.currentTime,
+    })
+    .returning({ id: zeroWorkflows.id });
+  return workflow;
+}
+
+async function copyWorkflowUserConnectors(
+  tx: WorkflowCopyTransaction,
+  args: CopyWorkflowScopedRowsArgs,
+): Promise<void> {
+  const rows = await tx
+    .select({ connectorType: workflowUserConnectors.connectorType })
+    .from(workflowUserConnectors)
+    .where(
+      and(
+        eq(workflowUserConnectors.orgId, args.orgId),
+        eq(workflowUserConnectors.userId, args.userId),
+        eq(workflowUserConnectors.workflowId, args.sourceWorkflowId),
+      ),
+    );
+  if (rows.length === 0) {
+    return;
+  }
+
+  await tx.insert(workflowUserConnectors).values(
+    rows.map((row) => {
+      return {
+        orgId: args.orgId,
+        userId: args.userId,
+        workflowId: args.targetWorkflowId,
+        connectorType: row.connectorType,
+        createdAt: args.currentTime,
+      };
+    }),
+  );
+}
+
+async function copyWorkflowUserPermissionGrants(
+  tx: WorkflowCopyTransaction,
+  args: CopyWorkflowScopedRowsArgs,
+): Promise<void> {
+  const rows = await tx
+    .select({
+      connectorRef: workflowUserPermissionGrants.connectorRef,
+      permission: workflowUserPermissionGrants.permission,
+      action: workflowUserPermissionGrants.action,
+      expiresAt: workflowUserPermissionGrants.expiresAt,
+    })
+    .from(workflowUserPermissionGrants)
+    .where(
+      and(
+        eq(workflowUserPermissionGrants.orgId, args.orgId),
+        eq(workflowUserPermissionGrants.userId, args.userId),
+        eq(workflowUserPermissionGrants.workflowId, args.sourceWorkflowId),
+      ),
+    );
+  if (rows.length === 0) {
+    return;
+  }
+
+  await tx.insert(workflowUserPermissionGrants).values(
+    rows.map((row) => {
+      return {
+        orgId: args.orgId,
+        userId: args.userId,
+        workflowId: args.targetWorkflowId,
+        connectorRef: row.connectorRef,
+        permission: row.permission,
+        action: row.action,
+        expiresAt: row.expiresAt,
+        createdAt: args.currentTime,
+        updatedAt: args.currentTime,
+      };
+    }),
+  );
+}
+
+async function copyWorkflowWebhookTriggerConfig(
+  tx: WorkflowCopyTransaction,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly sourceTriggerId: string;
+    readonly targetTriggerId: string;
+    readonly currentTime: Date;
+  },
+): Promise<void> {
+  const [sourceWebhook] = await tx
+    .select({
+      encryptedSecret: zeroWorkflowWebhookTriggers.encryptedSecret,
+      secretLastFour: zeroWorkflowWebhookTriggers.secretLastFour,
+    })
+    .from(zeroWorkflowWebhookTriggers)
+    .where(eq(zeroWorkflowWebhookTriggers.triggerId, args.sourceTriggerId))
+    .limit(1);
+  const token = mintWorkflowWebhookToken();
+  let encryptedSecret: string;
+  let secretLastFour: string;
+  if (sourceWebhook) {
+    encryptedSecret = sourceWebhook.encryptedSecret;
+    secretLastFour = sourceWebhook.secretLastFour;
+  } else {
+    const secret = mintWorkflowWebhookSecret();
+    encryptedSecret = await encryptWorkflowWebhookSecret(secret, {
+      orgId: args.orgId,
+      userId: args.userId,
+    });
+    secretLastFour = secret.slice(-4);
+  }
+
+  await tx.insert(zeroWorkflowWebhookTriggers).values({
+    triggerId: args.targetTriggerId,
+    tokenHash: hashWorkflowWebhookToken(token),
+    encryptedToken: await encryptWorkflowWebhookToken(token, {
+      orgId: args.orgId,
+      userId: args.userId,
+    }),
+    encryptedSecret,
+    secretLastFour,
+    createdAt: args.currentTime,
+    updatedAt: args.currentTime,
+  });
+}
+
+async function copyWorkflowTriggerRow(
+  tx: WorkflowCopyTransaction,
+  args: CopyWorkflowScopedRowsArgs & {
+    readonly trigger: typeof zeroWorkflowTriggers.$inferSelect;
+  },
+): Promise<void> {
+  const [copiedTrigger] = await tx
+    .insert(zeroWorkflowTriggers)
+    .values({
+      orgId: args.orgId,
+      workflowId: args.targetWorkflowId,
+      ownerUserId: args.userId,
+      kind: args.trigger.kind,
+      eventType: args.trigger.eventType,
+      eventConfig: args.trigger.eventConfig,
+      scheduleType: args.trigger.scheduleType,
+      cronExpression: args.trigger.cronExpression,
+      intervalSeconds: args.trigger.intervalSeconds,
+      atTime: args.trigger.atTime,
+      timezone: args.trigger.timezone,
+      enabled: args.trigger.enabled,
+      nextRunAt: args.trigger.nextRunAt,
+      lastRunAt: null,
+      lastRunId: null,
+      consecutiveFailures: 0,
+      createdAt: args.currentTime,
+      updatedAt: args.currentTime,
+    })
+    .returning({ id: zeroWorkflowTriggers.id });
+  if (!copiedTrigger) {
+    throw new Error("Failed to copy workflow trigger");
+  }
+
+  if (
+    args.trigger.kind === "event" &&
+    args.trigger.eventType === "webhook-received"
+  ) {
+    await copyWorkflowWebhookTriggerConfig(tx, {
+      orgId: args.orgId,
+      userId: args.userId,
+      sourceTriggerId: args.trigger.id,
+      targetTriggerId: copiedTrigger.id,
+      currentTime: args.currentTime,
+    });
+  }
+}
+
+async function copyWorkflowUserTriggers(
+  tx: WorkflowCopyTransaction,
+  args: CopyWorkflowTriggerRowsArgs,
+): Promise<void> {
+  const rows = await tx
+    .select()
+    .from(zeroWorkflowTriggers)
+    .where(
+      and(
+        eq(zeroWorkflowTriggers.orgId, args.orgId),
+        eq(zeroWorkflowTriggers.ownerUserId, args.userId),
+        eq(zeroWorkflowTriggers.workflowId, args.sourceWorkflowId),
+      ),
+    );
+  if (rows.length === 0) {
+    return;
+  }
+
+  await ensureWorkflowUserTriggerThread(tx, {
+    orgId: args.orgId,
+    userId: args.userId,
+    workflowId: args.targetWorkflowId,
+    agentId: args.targetAgentId,
+    workflowTitle: args.workflowTitle,
+    currentTime: args.currentTime,
+  });
+  for (const trigger of rows) {
+    await copyWorkflowTriggerRow(tx, { ...args, trigger });
+  }
+}
+
+async function copyWorkflowRuntimeConfiguration(
+  tx: WorkflowCopyTransaction,
+  args: CopyWorkflowRuntimeArgs,
+): Promise<{ readonly id: string } | undefined> {
+  const workflow = await insertCopiedWorkflowRow(tx, args);
+  if (!workflow) {
+    return undefined;
+  }
+
+  const scopedRowsArgs = {
+    orgId: args.orgId,
+    userId: args.userId,
+    sourceWorkflowId: args.sourceWorkflow.id,
+    targetWorkflowId: workflow.id,
+    currentTime: args.currentTime,
+  };
+  await copyWorkflowUserConnectors(tx, scopedRowsArgs);
+  await copyWorkflowUserPermissionGrants(tx, scopedRowsArgs);
+  await copyWorkflowUserTriggers(tx, {
+    ...scopedRowsArgs,
+    targetAgentId: args.targetAgentId,
+    workflowTitle: args.sourceWorkflow.displayName ?? args.sourceWorkflow.name,
+  });
+  return workflow;
+}
+
 const copyWorkflowInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
@@ -672,22 +951,18 @@ const copyWorkflowInner$ = command(
     }
 
     // A copy is a fork owned by the caller: a new private workflow under the
-    // target agent, carrying the source instruction/metadata and volume files.
-    const [inserted] = await writeDb
-      .insert(zeroWorkflows)
-      .values({
+    // target agent. User-scoped runtime configuration is cloned only for the
+    // caller so copies do not leak another user's triggers or authorization.
+    const currentTime = nowDate();
+    const inserted = await writeDb.transaction(async (tx) => {
+      return await copyWorkflowRuntimeConfiguration(tx, {
         orgId: auth.orgId,
-        agentId: targetAgent.id,
-        name: source.workflow.name,
-        visibility: "private",
-        instruction: source.workflow.instruction,
-        ownerUserId: auth.userId,
-        displayName: source.workflow.displayName,
-        description: source.workflow.description,
-        createdBy: auth.userId,
-        updatedBy: auth.userId,
-      })
-      .returning({ id: zeroWorkflows.id });
+        userId: auth.userId,
+        sourceWorkflow: source.workflow,
+        targetAgentId: targetAgent.id,
+        currentTime,
+      });
+    });
     signal.throwIfAborted();
     if (!inserted) {
       throw new Error("Failed to copy workflow");

--- a/turbo/apps/platform/src/mocks/handlers/api-workflows.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-workflows.ts
@@ -222,7 +222,14 @@ export const apiWorkflowsHandlers = [
       updatedByUserId: "test-user-123",
       createdAt: now,
       updatedAt: now,
-      triggers: [],
+      triggers: source.triggers.map((trigger) => {
+        return {
+          ...trigger,
+          id: crypto.randomUUID(),
+          ownerUserId: "test-user-123",
+          lastRunAt: null,
+        };
+      }),
     };
     mockWorkflows = [...mockWorkflows, copied];
     return respond(201, summary(copied));


### PR DESCRIPTION
## Summary
- Copy caller-owned workflow connector access, permission grants, and triggers when copying a workflow.
- Reset copied trigger runtime state while preserving schedule/webhook configuration.
- Mint independent webhook tokens for copied webhook triggers and keep the existing signing secret.
- Update workflow copy API coverage and platform mock behavior.

## Testing
- `pnpm format`
- `pnpm -F api lint`
- `pnpm -F @vm0/app lint`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- `DATABASE_URL="postgresql://postgres@localhost:5432/vm0_test" pnpm exec vitest run apps/api/src/signals/routes/__tests__/zero-workflows.test.ts`

Note: full `pnpm check-types` reached API after 12 packages passed, then hit Node default heap OOM; the API package passes with a larger heap.