### PR TITLE
refactor: share exec cancel sent wait helper

### DIFF
--- a/crates/vsock-host/src/exec_operation/handle.rs
+++ b/crates/vsock-host/src/exec_operation/handle.rs
@@ -413,6 +413,19 @@ impl ExecWaitCore {
             }
         }
     }
+
+    async fn wait_for_terminal_after_cancel_sent(
+        &mut self,
+        seq: u32,
+        remaining: Duration,
+        lifecycle: ExecWaitLifecycle,
+    ) -> io::Result<ExecCancelWaitResult> {
+        let result = self.wait_with_timeout(remaining, true, lifecycle).await?;
+        Ok(ExecCancelWaitResult {
+            result,
+            cancel_seq: Some(seq),
+        })
+    }
 }
 
 impl ExecOperationHandle {
@@ -483,14 +496,9 @@ impl ExecOperationHandle {
             ExecCancelWriteOutcome::CancelSent { seq, remaining } => (seq, remaining),
         };
 
-        let result = self
-            .wait_core
-            .wait_with_timeout(remaining, true, ExecWaitLifecycle::OneShot)
-            .await?;
-        Ok(ExecCancelWaitResult {
-            result,
-            cancel_seq: Some(seq),
-        })
+        self.wait_core
+            .wait_for_terminal_after_cancel_sent(seq, remaining, ExecWaitLifecycle::OneShot)
+            .await
     }
 }
 
@@ -676,14 +684,9 @@ impl SupervisedExecHandle {
         };
 
         self.clear_unclaimed_stream_sender();
-        let result = self
-            .wait_core
-            .wait_with_timeout(remaining, true, ExecWaitLifecycle::Supervised)
-            .await?;
-        Ok(ExecCancelWaitResult {
-            result,
-            cancel_seq: Some(seq),
-        })
+        self.wait_core
+            .wait_for_terminal_after_cancel_sent(seq, remaining, ExecWaitLifecycle::Supervised)
+            .await
     }
 }
 


### PR DESCRIPTION
## Summary

- Add a narrow `ExecWaitCore` helper for the final terminal wait after an exec cancel frame has been sent.
- Reuse the helper from one-shot and supervised cancel-and-wait flows.
- Keep supervised stream cleanup explicit at the supervised call site, after `CancelSent` and before the final terminal wait.

Closes #19217

## Testing

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host supervised_exec_cancel_and_wait`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host supervised_exec_cancel_result_timeout_poisons_connection`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host supervised_exec_wait_releases_unclaimed_stream_sender`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host`

Pre-commit also ran Rust formatting, clippy, and docs checks.
