### PR TITLE
docs: clarify runner image hash identity

### DIFF
--- a/crates/runner/src/cmd/build/hashes.rs
+++ b/crates/runner/src/cmd/build/hashes.rs
@@ -28,6 +28,7 @@ const SNAPSHOT_CACHE_VERSION: u32 = 3;
 /// Inputs:
 ///   - `TEMPLATE_CACHE_VERSION` — bump to force invalidation
 ///   - `TEMPLATE_BUILD_SCRIPT` — template build script content
+///   - `std::env::consts::ARCH` — host build architecture
 ///   - `rootfs_disk_mb` — rootfs disk size from profile
 ///
 /// Guest binaries and host-local CA are deliberately excluded; those belong

--- a/crates/runner/src/cmd/build/hashes.rs
+++ b/crates/runner/src/cmd/build/hashes.rs
@@ -28,7 +28,7 @@ const SNAPSHOT_CACHE_VERSION: u32 = 3;
 /// Inputs:
 ///   - `TEMPLATE_CACHE_VERSION` — bump to force invalidation
 ///   - `TEMPLATE_BUILD_SCRIPT` — template build script content
-///   - `std::env::consts::ARCH` — host build architecture
+///   - `std::env::consts::ARCH` — runner binary target architecture
 ///   - `rootfs_disk_mb` — rootfs disk size from profile
 ///
 /// Guest binaries and host-local CA are deliberately excluded; those belong

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -15,15 +15,21 @@
 //! 4. Callers derive runtime objects (e.g. [`sandbox::FactoryConfig`]) from
 //!    the loaded config.
 //!
-//! # Image identity: two content hashes per profile
-//! Each [`ProfileConfig`] carries two hashes with different scopes:
-//! - `rootfs_hash` — content hash of the bootable guest filesystem image on
-//!   this runner. Shared across snapshot variants on the same host.
-//! - `snapshot_hash` — content hash of the rootfs hash plus the
-//!   FC/kernel/vcpu/memory/provider config used to capture the memory snapshot.
-//!   Local-only: snapshots are produced on each runner by booting the rootfs
-//!   and capturing state, since the captured memory binds to host-specific
-//!   state.
+//! # Image identity: two image-identity hashes per profile
+//! Each [`ProfileConfig`] carries two hashes with different scopes. They are
+//! image identities, not just artifact byte digests: cache versions and local
+//! build inputs can also affect them.
+//! - `rootfs_hash` — identity of the bootable guest filesystem image on this
+//!   runner. Shared across snapshot variants on the same host.
+//! - `snapshot_hash` — host-local identity of the snapshot captured from that
+//!   rootfs. It includes `rootfs_hash` plus VM/snapshot shape inputs such as
+//!   `vcpu`, `memory_mb`, and `workspace_disk_mb`, along with
+//!   Firecracker/kernel/provider config inputs. Snapshots are produced on each
+//!   runner by booting the rootfs and capturing state, since the captured
+//!   memory binds to host-specific state.
+//!
+//! `rootfs_disk_mb` affects `snapshot_hash` through `rootfs_hash`, not as a
+//! separate direct snapshot input.
 //!
 //! Together they identify an exact boot image on this host.
 //!
@@ -105,7 +111,8 @@ pub struct FirecrackerConfig {
 pub struct ProfileConfig {
     /// Content-addressed rootfs hash (shared across snapshot variants on this host).
     pub rootfs_hash: String,
-    /// Content-addressed snapshot hash (local-only, covers rootfs plus VM/provider config).
+    /// Host-local snapshot identity, covering rootfs identity plus VM shape,
+    /// workspace disk size, and provider/runtime inputs.
     pub snapshot_hash: String,
     /// Guest vCPU count. Must be non-zero and ≤ 1024.
     pub vcpu: u32,

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -109,7 +109,7 @@ pub struct FirecrackerConfig {
 /// (`rootfs_hash` covers the local rootfs, `snapshot_hash` is local-only).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ProfileConfig {
-    /// Content-addressed rootfs hash (shared across snapshot variants on this host).
+    /// Local rootfs image identity, shared across snapshot variants on this host.
     pub rootfs_hash: String,
     /// Host-local snapshot identity, covering rootfs identity plus VM shape,
     /// workspace disk size, and provider/runtime inputs.

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -15,7 +15,7 @@
 //! 4. Callers derive runtime objects (e.g. [`sandbox::FactoryConfig`]) from
 //!    the loaded config.
 //!
-//! # Image identity: two image-identity hashes per profile
+//! # Image identity: two scoped hashes per profile
 //! Each [`ProfileConfig`] carries two hashes with different scopes. They are
 //! image identities, not just artifact byte digests: cache versions and local
 //! build inputs can also affect them.


### PR DESCRIPTION
## Summary

- Clarify the operator-facing `runner.yaml` image identity model for `rootfs_hash` and `snapshot_hash`.
- Explicitly document that `workspace_disk_mb` is part of the host-local snapshot identity inputs.
- Update the implementation-level `compute_template_hash` comment to include the architecture input already hashed by the code.

Closes #19223

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::build::hashes`
- Pre-commit hook ran Rust formatting, clippy, and docs checks for the staged Rust files.
