### PR TITLE
fix(runner): harden workspace orphan GC

### DIFF
--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -69,9 +69,10 @@ pub async fn run_gc(args: GcArgs) -> RunnerResult<()> {
     // gc_orphaned_locks runs first, it deletes those lock files and the
     // dead runner's workspaces become undiscoverable.
     let nbd_orphans = gc_nbd_orphans(args.dry_run).await?;
-    let (workspace_orphans, workspace_freed) = gc_workspace_orphans(&home, args.dry_run).await?;
+    let workspace_gc = gc_workspace_orphans(&home, args.dry_run).await?;
 
-    let locks_removed = gc_orphaned_locks(&home, args.dry_run).await?;
+    let locks_removed =
+        gc_orphaned_locks(&home, args.dry_run).await? + workspace_gc.base_dir_locks_removed;
     let (job_logs_removed, job_logs_freed) = gc_job_logs(&home, args.dry_run).await?;
     let versions_removed = gc_versions(
         &home,
@@ -92,7 +93,7 @@ pub async fn run_gc(args: GcArgs) -> RunnerResult<()> {
     let total = images_freed
         + job_logs_freed
         + debootstrap_freed
-        + workspace_freed
+        + workspace_gc.bytes_freed
         + r2_freed
         + storages_freed;
     if total == 0
@@ -101,7 +102,7 @@ pub async fn run_gc(args: GcArgs) -> RunnerResult<()> {
         && versions_removed.is_empty()
         && version_service_locks_removed == 0
         && nbd_orphans == 0
-        && workspace_orphans == 0
+        && workspace_gc.workspaces_cleaned == 0
         && r2_deleted == 0
     {
         info!("nothing to clean up");
@@ -945,7 +946,9 @@ async fn gc_orphaned_locks(home: &HomePaths, dry_run: bool) -> RunnerResult<u64>
         }
         // Version GC later in this same command uses service locks to avoid
         // deleting a version that another process is installing or uninstalling.
-        if name.starts_with("service-") {
+        // Workspace GC owns base-dir lock lifecycle because those locks carry
+        // the base_dir metadata needed to rediscover dead-runner workspaces.
+        if name.starts_with("service-") || is_base_dir_lock_name(name) {
             continue;
         }
 
@@ -1498,13 +1501,37 @@ async fn gc_nbd_orphans(dry_run: bool) -> RunnerResult<u32> {
     Ok(cleaned)
 }
 
+#[derive(Default)]
+struct WorkspaceGcSummary {
+    workspaces_cleaned: u32,
+    bytes_freed: u64,
+    base_dir_locks_removed: u64,
+}
+
+struct DeadRunnerBaseDirLease {
+    base_dir: PathBuf,
+    lock_path: PathBuf,
+    lock_name: String,
+    lock_guard: Flock<std::fs::File>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum BaseDirLockDecision {
+    RemoveIfStillFree,
+    Preserve,
+}
+
+fn is_base_dir_lock_name(name: &str) -> bool {
+    name.starts_with("base-dir-") && name.ends_with(".lock")
+}
+
 /// Read base_dir paths from lock files written by `runner start`, returning
-/// only those whose runner is dead (lock not held).
+/// only those whose runner is dead (lock not held), while keeping the lock held.
 ///
 /// Live runners manage their own workspaces via the factory — GC must not
 /// touch them because CowPool pre-warmed slots would be indistinguishable
 /// from orphaned workspaces.
-fn discover_dead_runner_base_dirs(locks_dir: &Path) -> Vec<PathBuf> {
+fn discover_dead_runner_base_dirs(locks_dir: &Path) -> Vec<DeadRunnerBaseDirLease> {
     let entries = match std::fs::read_dir(locks_dir) {
         Ok(rd) => rd,
         Err(e) => {
@@ -1524,32 +1551,65 @@ fn discover_dead_runner_base_dirs(locks_dir: &Path) -> Vec<PathBuf> {
         };
         let name = entry.file_name();
         let Some(name) = name.to_str() else { continue };
-        if !name.starts_with("base-dir-") || !name.ends_with(".lock") {
+        if !is_base_dir_lock_name(name) {
             continue;
         }
+        let lock_path = entry.path();
         // Only include base_dirs from dead runners (lock not held).
         // Hold the lock while reading the file to prevent a new runner from
-        // starting and overwriting the content between the probe and the read.
-        let LockProbe::Free(lock_guard) = probe_lock(&entry.path()) else {
+        // starting and overwriting the content between the probe and the read,
+        // and keep it held while workspace GC deletes under the base_dir.
+        let LockProbe::Free(lock_guard) = probe_lock(&lock_path) else {
             continue;
         };
-        let content = match std::fs::read_to_string(entry.path()) {
+        let content = match std::fs::read_to_string(&lock_path) {
             Ok(c) => c,
             Err(e) => {
-                warn!("workspace gc: cannot read {}: {e}", entry.path().display());
+                warn!("workspace gc: cannot read {}: {e}", lock_path.display());
                 continue;
             }
         };
-        // lock_guard dropped after read — new runner can now start, but its
-        // CowPool slots will have mtime=now and be age-gated.
-        drop(lock_guard);
         let path = content.trim();
         if path.is_empty() {
             continue; // pre-upgrade lock file without base_dir
         }
-        base_dirs.push(PathBuf::from(path));
+        base_dirs.push(DeadRunnerBaseDirLease {
+            base_dir: PathBuf::from(path),
+            lock_path,
+            lock_name: name.to_string(),
+            lock_guard,
+        });
     }
     base_dirs
+}
+
+fn active_workspace_paths(
+    firecrackers: &[crate::process::FirecrackerProcessInfo],
+) -> HashSet<PathBuf> {
+    firecrackers
+        .iter()
+        .filter_map(|fc| {
+            fc.base_dir
+                .as_ref()
+                .map(|bd| bd.join("workspaces").join(&fc.sandbox_id))
+        })
+        .collect()
+}
+
+async fn workspace_firecracker_discovery_uncertain(
+    firecrackers: &[crate::process::FirecrackerProcessInfo],
+    live_runner_pids: &[u32],
+) -> bool {
+    for firecracker in firecrackers
+        .iter()
+        .filter(|firecracker| firecracker.workspace_identity_incomplete())
+    {
+        match crate::process::process_has_ancestor(firecracker.pid, live_runner_pids).await {
+            Some(true) => {}
+            Some(false) | None => return true,
+        }
+    }
+    false
 }
 
 /// Remove workspace directories from dead runners.
@@ -1562,20 +1622,32 @@ fn discover_dead_runner_base_dirs(locks_dir: &Path) -> Vec<PathBuf> {
 /// Even for dead runners, workspaces owned by still-running orphaned
 /// Firecracker processes are protected via process discovery. Recently-created
 /// workspaces (< [`GC_MIN_AGE`]) are also skipped as a safety margin.
-async fn gc_workspace_orphans(home: &HomePaths, dry_run: bool) -> RunnerResult<(u32, u64)> {
+async fn gc_workspace_orphans(home: &HomePaths, dry_run: bool) -> RunnerResult<WorkspaceGcSummary> {
     // 1. Discover active workspaces from any running Firecracker process.
     //    This protects orphaned FCs whose parent runner already died but
     //    whose VM is still running.
     let discovered = crate::process::discover_all().await;
-    let active: HashSet<PathBuf> = discovered
-        .firecrackers
+    let live_runners = match crate::live_runner_instances::try_list(home).await {
+        Ok(runners) => runners,
+        Err(e) => {
+            warn!(
+                "workspace gc: cannot list live runner instances ({e}); skipping workspace orphan cleanup"
+            );
+            return Ok(WorkspaceGcSummary::default());
+        }
+    };
+    let live_runner_pids: Vec<u32> = live_runners.iter().map(|runner| runner.pid).collect();
+    let live_runner_base_dirs: HashSet<PathBuf> = live_runners
         .iter()
-        .filter_map(|fc| {
-            fc.base_dir
-                .as_ref()
-                .map(|bd| bd.join("workspaces").join(&fc.sandbox_id))
-        })
+        .map(|runner| runner.base_dir.clone())
         .collect();
+    if workspace_firecracker_discovery_uncertain(&discovered.firecrackers, &live_runner_pids).await
+    {
+        warn!(
+            "workspace gc: Firecracker discovery is incomplete; skipping workspace orphan cleanup"
+        );
+        return Ok(WorkspaceGcSummary::default());
+    }
 
     // 2. Only scan base_dirs from dead runners (lock not held).
     //    Runs on a blocking thread because probe_lock uses flock(2) and
@@ -1587,128 +1659,70 @@ async fn gc_workspace_orphans(home: &HomePaths, dry_run: bool) -> RunnerResult<(
 
     if base_dirs.is_empty() {
         tracing::debug!("workspace gc: no dead-runner base_dirs discovered");
-        return Ok((0, 0));
+        return Ok(WorkspaceGcSummary::default());
     }
 
+    gc_workspace_orphans_with_leases(
+        base_dirs,
+        &discovered.firecrackers,
+        &live_runner_base_dirs,
+        false,
+        dry_run,
+    )
+    .await
+}
+
+async fn gc_workspace_orphans_with_leases(
+    base_dirs: Vec<DeadRunnerBaseDirLease>,
+    firecrackers: &[crate::process::FirecrackerProcessInfo],
+    live_runner_base_dirs: &HashSet<PathBuf>,
+    firecracker_discovery_uncertain: bool,
+    dry_run: bool,
+) -> RunnerResult<WorkspaceGcSummary> {
+    if firecracker_discovery_uncertain {
+        warn!(
+            "workspace gc: Firecracker discovery is incomplete; skipping workspace orphan cleanup"
+        );
+        return Ok(WorkspaceGcSummary::default());
+    }
+
+    let active = active_workspace_paths(firecrackers);
     // 3. Scan each base_dir/workspaces/ for orphans.
     let now = SystemTime::now();
-    let mut cleaned: u32 = 0;
-    let mut freed: u64 = 0;
+    let mut summary = WorkspaceGcSummary::default();
 
     for base_dir in &base_dirs {
-        match gc_path_dir_status(base_dir).await {
-            Ok(GcDirStatus::RealDir(_)) => {}
-            Ok(GcDirStatus::Missing) => continue,
-            Ok(GcDirStatus::NotDirectory) => {
-                info!(
-                    "workspace gc: {} is not a real base directory, skipping",
-                    base_dir.display()
-                );
-                continue;
-            }
-            Err(e) => {
-                warn!(
-                    "workspace gc: cannot stat base directory {}: {e}",
-                    base_dir.display()
-                );
-                continue;
-            }
+        if live_runner_base_dirs.contains(&base_dir.base_dir) {
+            warn!(
+                "workspace gc: {} is listed as a live runner base directory, skipping",
+                base_dir.base_dir.display()
+            );
+            continue;
         }
 
-        let workspaces_dir = base_dir.join("workspaces");
-        match gc_path_dir_status(&workspaces_dir).await {
-            Ok(GcDirStatus::RealDir(_)) => {}
-            Ok(GcDirStatus::Missing) => continue,
-            Ok(GcDirStatus::NotDirectory) => {
-                info!(
-                    "workspace gc: {} is not a real directory, skipping",
-                    workspaces_dir.display()
-                );
-                continue;
-            }
-            Err(e) => {
-                warn!(
-                    "workspace gc: cannot stat {}: {e}",
-                    workspaces_dir.display()
-                );
-                continue;
-            }
-        }
+        let (cleaned, freed, lock_decision) =
+            gc_workspace_orphans_in_base_dir(&base_dir.base_dir, &active, now, dry_run).await;
+        summary.workspaces_cleaned += cleaned;
+        summary.bytes_freed += freed;
 
-        let mut entries = match tokio::fs::read_dir(&workspaces_dir).await {
-            Ok(rd) => rd,
-            Err(e) => {
-                warn!(
-                    "workspace gc: cannot read {}: {e}",
-                    workspaces_dir.display()
-                );
-                continue;
-            }
-        };
-
-        while let Some(entry) = next_entry_warn(&mut entries, "workspace gc", &workspaces_dir).await
+        if lock_decision == BaseDirLockDecision::RemoveIfStillFree
+            && remove_unused_lock_after_probe(
+                &base_dir.lock_path,
+                &base_dir.lock_guard,
+                &base_dir.lock_name,
+                dry_run,
+            )
+            .await
         {
-            let path = entry.path();
-            let meta = match gc_path_dir_status(&path).await {
-                Ok(GcDirStatus::RealDir(meta)) => meta,
-                Ok(GcDirStatus::Missing | GcDirStatus::NotDirectory) => continue,
-                Err(e) => {
-                    warn!("workspace gc: cannot stat {}: {e}", path.display());
-                    continue;
-                }
-            };
-
-            // Skip if actively owned by a running process.
-            if active.contains(&path) {
-                continue;
-            }
-
-            // Age-gate: skip recently created workspaces.
-            let age = meta
-                .modified()
-                .ok()
-                .and_then(|mtime| now.duration_since(mtime).ok())
-                .unwrap_or_default();
-            if age < GC_MIN_AGE {
-                tracing::debug!(
-                    "workspace gc: {} too recent ({}s), skipping",
-                    path.display(),
-                    age.as_secs()
-                );
-                continue;
-            }
-
-            let (size, _) = dir_stats(&path).await;
-            if dry_run {
-                info!(
-                    "[dry-run] would remove orphaned workspace {} ({})",
-                    path.display(),
-                    human_bytes(size)
-                );
-            } else {
-                match tokio::fs::remove_dir_all(&path).await {
-                    Ok(()) => {
-                        info!(
-                            "removed orphaned workspace {} ({})",
-                            path.display(),
-                            human_bytes(size)
-                        );
-                    }
-                    Err(e) => {
-                        warn!("workspace gc: cannot remove {}: {e}", path.display());
-                        continue;
-                    }
-                }
-            }
-            cleaned += 1;
-            freed += size;
+            summary.base_dir_locks_removed += 1;
         }
     }
 
-    if cleaned > 0 {
+    if summary.workspaces_cleaned > 0 {
         info!(
-            "workspace orphans: {cleaned} cleaned ({})",
-            human_bytes(freed)
+            "workspace orphans: {} cleaned ({})",
+            summary.workspaces_cleaned,
+            human_bytes(summary.bytes_freed)
         );
     } else {
         tracing::debug!(
@@ -1717,7 +1731,149 @@ async fn gc_workspace_orphans(home: &HomePaths, dry_run: bool) -> RunnerResult<(
         );
     }
 
-    Ok((cleaned, freed))
+    Ok(summary)
+}
+
+async fn gc_workspace_orphans_in_base_dir(
+    base_dir: &Path,
+    active: &HashSet<PathBuf>,
+    now: SystemTime,
+    dry_run: bool,
+) -> (u32, u64, BaseDirLockDecision) {
+    match gc_path_dir_status(base_dir).await {
+        Ok(GcDirStatus::RealDir(_)) => {}
+        Ok(GcDirStatus::Missing) => return (0, 0, BaseDirLockDecision::RemoveIfStillFree),
+        Ok(GcDirStatus::NotDirectory) => {
+            info!(
+                "workspace gc: {} is not a real base directory, skipping",
+                base_dir.display()
+            );
+            return (0, 0, BaseDirLockDecision::Preserve);
+        }
+        Err(e) => {
+            warn!(
+                "workspace gc: cannot stat base directory {}: {e}",
+                base_dir.display()
+            );
+            return (0, 0, BaseDirLockDecision::Preserve);
+        }
+    }
+
+    let workspaces_dir = base_dir.join("workspaces");
+    match gc_path_dir_status(&workspaces_dir).await {
+        Ok(GcDirStatus::RealDir(_)) => {}
+        Ok(GcDirStatus::Missing) => return (0, 0, BaseDirLockDecision::RemoveIfStillFree),
+        Ok(GcDirStatus::NotDirectory) => {
+            info!(
+                "workspace gc: {} is not a real directory, skipping",
+                workspaces_dir.display()
+            );
+            return (0, 0, BaseDirLockDecision::Preserve);
+        }
+        Err(e) => {
+            warn!(
+                "workspace gc: cannot stat {}: {e}",
+                workspaces_dir.display()
+            );
+            return (0, 0, BaseDirLockDecision::Preserve);
+        }
+    }
+
+    let mut entries = match tokio::fs::read_dir(&workspaces_dir).await {
+        Ok(rd) => rd,
+        Err(e) => {
+            warn!(
+                "workspace gc: cannot read {}: {e}",
+                workspaces_dir.display()
+            );
+            return (0, 0, BaseDirLockDecision::Preserve);
+        }
+    };
+
+    let mut cleaned: u32 = 0;
+    let mut freed: u64 = 0;
+    let mut preserve_lock = false;
+
+    loop {
+        let entry = match entries.next_entry().await {
+            Ok(Some(entry)) => entry,
+            Ok(None) => break,
+            Err(e) => {
+                warn!(
+                    "workspace gc: read entry in {}: {e}",
+                    workspaces_dir.display()
+                );
+                preserve_lock = true;
+                break;
+            }
+        };
+        let path = entry.path();
+        let meta = match gc_path_dir_status(&path).await {
+            Ok(GcDirStatus::RealDir(meta)) => meta,
+            Ok(GcDirStatus::Missing | GcDirStatus::NotDirectory) => continue,
+            Err(e) => {
+                warn!("workspace gc: cannot stat {}: {e}", path.display());
+                preserve_lock = true;
+                continue;
+            }
+        };
+
+        // Skip if actively owned by a running process.
+        if active.contains(&path) {
+            preserve_lock = true;
+            continue;
+        }
+
+        // Age-gate: skip recently created workspaces.
+        let age = meta
+            .modified()
+            .ok()
+            .and_then(|mtime| now.duration_since(mtime).ok())
+            .unwrap_or_default();
+        if age < GC_MIN_AGE {
+            tracing::debug!(
+                "workspace gc: {} too recent ({}s), skipping",
+                path.display(),
+                age.as_secs()
+            );
+            preserve_lock = true;
+            continue;
+        }
+
+        let (size, _) = dir_stats(&path).await;
+        if dry_run {
+            info!(
+                "[dry-run] would remove orphaned workspace {} ({})",
+                path.display(),
+                human_bytes(size)
+            );
+        } else {
+            match tokio::fs::remove_dir_all(&path).await {
+                Ok(()) => {
+                    info!(
+                        "removed orphaned workspace {} ({})",
+                        path.display(),
+                        human_bytes(size)
+                    );
+                }
+                Err(e) => {
+                    warn!("workspace gc: cannot remove {}: {e}", path.display());
+                    preserve_lock = true;
+                    continue;
+                }
+            }
+        }
+        cleaned += 1;
+        freed += size;
+    }
+
+    let lock_decision = if preserve_lock {
+        BaseDirLockDecision::Preserve
+    } else {
+        BaseDirLockDecision::RemoveIfStillFree
+    };
+
+    (cleaned, freed, lock_decision)
 }
 
 /// Eligible `<version>` directory discovered during the scan phase.
@@ -2470,6 +2626,30 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn gc_orphaned_locks_preserves_base_dir_locks() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let locks_dir = home.locks_dir();
+        std::fs::create_dir_all(&locks_dir).unwrap();
+        let base_dir_lock = locks_dir.join("base-dir-dead.lock");
+        let stale_lock = locks_dir.join("workspace-image-cache-test.lock");
+        std::fs::write(&base_dir_lock, "/data/dead-runner").unwrap();
+        std::fs::write(&stale_lock, "").unwrap();
+
+        let removed = gc_orphaned_locks(&home, false).await.unwrap();
+
+        assert_eq!(removed, 1);
+        assert!(
+            base_dir_lock.exists(),
+            "base-dir locks must remain available for workspace GC retry"
+        );
+        assert!(
+            !stale_lock.exists(),
+            "ordinary free locks should still be cleaned"
+        );
+    }
+
     fn test_home(root: &Path) -> HomePaths {
         HomePaths::with_root(root.to_path_buf())
     }
@@ -2494,6 +2674,34 @@ mod tests {
                 .is_symlink(),
             "{message}"
         );
+    }
+
+    fn discovered_base_dirs(leases: &[DeadRunnerBaseDirLease]) -> Vec<PathBuf> {
+        leases.iter().map(|lease| lease.base_dir.clone()).collect()
+    }
+
+    fn firecracker_with_base_dir(
+        pid: u32,
+        sandbox_id: &str,
+        base_dir: &Path,
+    ) -> crate::process::FirecrackerProcessInfo {
+        crate::process::FirecrackerProcessInfo {
+            pid,
+            ppid: Some(1),
+            sandbox_id: sandbox_id.to_string(),
+            base_dir: Some(base_dir.to_path_buf()),
+            identity: None,
+        }
+    }
+
+    fn incomplete_firecracker(pid: u32) -> crate::process::FirecrackerProcessInfo {
+        crate::process::FirecrackerProcessInfo {
+            pid,
+            ppid: Some(1),
+            sandbox_id: format!("pid-{pid}"),
+            base_dir: None,
+            identity: None,
+        }
     }
 
     fn test_version_service_lock(home: &HomePaths, version: &str) -> PathBuf {
@@ -4529,8 +4737,9 @@ mod tests {
 
         let dirs = discover_dead_runner_base_dirs(&home.locks_dir());
         assert_eq!(dirs.len(), 2);
-        assert!(dirs.contains(&PathBuf::from("/data/runner-01")));
-        assert!(dirs.contains(&PathBuf::from("/data/runner-02")));
+        let base_dirs = discovered_base_dirs(&dirs);
+        assert!(base_dirs.contains(&PathBuf::from("/data/runner-01")));
+        assert!(base_dirs.contains(&PathBuf::from("/data/runner-02")));
     }
 
     #[test]
@@ -4580,7 +4789,31 @@ mod tests {
 
         let dirs = discover_dead_runner_base_dirs(&home.locks_dir());
         assert_eq!(dirs.len(), 1);
-        assert_eq!(dirs[0], PathBuf::from("/data/dead-runner"));
+        assert_eq!(dirs[0].base_dir, PathBuf::from("/data/dead-runner"));
+    }
+
+    #[test]
+    fn discover_dead_runner_base_dirs_keeps_lock_guard_alive() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let locks_dir = home.locks_dir();
+        std::fs::create_dir_all(&locks_dir).unwrap();
+
+        let lock_path = locks_dir.join("base-dir-dead.lock");
+        std::fs::write(&lock_path, "/data/dead-runner").unwrap();
+
+        let leases = discover_dead_runner_base_dirs(&home.locks_dir());
+        assert_eq!(leases.len(), 1);
+        match probe_existing_lock(&lock_path) {
+            ExistingLockProbe::Held => {}
+            _ => panic!("base-dir lease must keep the lock held"),
+        }
+
+        drop(leases);
+        match probe_existing_lock(&lock_path) {
+            ExistingLockProbe::Free(_) => {}
+            _ => panic!("base-dir lock should be free after dropping leases"),
+        }
     }
 
     #[tokio::test]
@@ -4600,11 +4833,8 @@ mod tests {
         std::fs::write(workspace.join("cow.img"), vec![0u8; 4096]).unwrap();
 
         // Register base_dir in lock file
-        std::fs::write(
-            locks_dir.join("base-dir-test.lock"),
-            base_dir.to_str().unwrap(),
-        )
-        .unwrap();
+        let lock_path = locks_dir.join("base-dir-test.lock");
+        std::fs::write(&lock_path, base_dir.to_str().unwrap()).unwrap();
 
         // Set workspace mtime to 1 hour ago (past GC_MIN_AGE)
         let old_time = SystemTime::now() - Duration::from_secs(3600);
@@ -4613,11 +4843,12 @@ mod tests {
             .set_times(FileTimes::new().set_modified(old_time))
             .unwrap();
 
-        let (cleaned, freed) = gc_workspace_orphans(&home, false).await.unwrap();
+        let summary = gc_workspace_orphans(&home, false).await.unwrap();
 
         assert!(!workspace.exists(), "orphaned workspace should be deleted");
-        assert_eq!(cleaned, 1);
-        assert!(freed > 0 || cfg!(target_os = "macos"));
+        assert_eq!(summary.workspaces_cleaned, 1);
+        assert!(summary.bytes_freed > 0 || cfg!(target_os = "macos"));
+        assert_eq!(summary.base_dir_locks_removed, 1);
     }
 
     #[tokio::test]
@@ -4633,16 +4864,14 @@ mod tests {
         std::fs::write(workspace.join("cow.img"), b"data").unwrap();
         // mtime = now (default), so workspace is too recent
 
-        std::fs::write(
-            locks_dir.join("base-dir-test.lock"),
-            base_dir.to_str().unwrap(),
-        )
-        .unwrap();
+        let lock_path = locks_dir.join("base-dir-test.lock");
+        std::fs::write(&lock_path, base_dir.to_str().unwrap()).unwrap();
 
-        let (cleaned, _) = gc_workspace_orphans(&home, false).await.unwrap();
+        let summary = gc_workspace_orphans(&home, false).await.unwrap();
 
         assert!(workspace.exists(), "recent workspace should NOT be deleted");
-        assert_eq!(cleaned, 0);
+        assert_eq!(summary.workspaces_cleaned, 0);
+        assert_eq!(summary.base_dir_locks_removed, 0);
     }
 
     #[tokio::test]
@@ -4659,11 +4888,8 @@ mod tests {
         std::fs::create_dir_all(&workspace).unwrap();
         std::fs::write(workspace.join("cow.img"), b"data").unwrap();
 
-        std::fs::write(
-            locks_dir.join("base-dir-test.lock"),
-            base_dir.to_str().unwrap(),
-        )
-        .unwrap();
+        let lock_path = locks_dir.join("base-dir-test.lock");
+        std::fs::write(&lock_path, base_dir.to_str().unwrap()).unwrap();
 
         let old_time = SystemTime::now() - Duration::from_secs(3600);
         std::fs::File::open(&workspace)
@@ -4671,11 +4897,208 @@ mod tests {
             .set_times(FileTimes::new().set_modified(old_time))
             .unwrap();
 
-        let (cleaned, freed) = gc_workspace_orphans(&home, true).await.unwrap();
+        let summary = gc_workspace_orphans(&home, true).await.unwrap();
 
         assert!(workspace.exists(), "dry-run should NOT delete");
-        assert_eq!(cleaned, 1);
-        assert!(freed > 0 || cfg!(target_os = "macos"));
+        assert!(
+            lock_path.exists(),
+            "dry-run should NOT remove base-dir lock"
+        );
+        assert_eq!(summary.workspaces_cleaned, 1);
+        assert!(summary.bytes_freed > 0 || cfg!(target_os = "macos"));
+        assert_eq!(summary.base_dir_locks_removed, 1);
+    }
+
+    #[tokio::test]
+    async fn gc_workspace_orphans_skips_when_incomplete_firecracker_unattributed() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let locks_dir = home.locks_dir();
+        std::fs::create_dir_all(&locks_dir).unwrap();
+
+        let base_dir = dir.path().join("runner-data");
+        let workspace = base_dir.join("workspaces").join("run-old");
+        std::fs::create_dir_all(&workspace).unwrap();
+        std::fs::write(workspace.join("cow.img"), b"data").unwrap();
+        set_mtime(&workspace, old_gc_time());
+        let lock_path = locks_dir.join("base-dir-test.lock");
+        std::fs::write(&lock_path, base_dir.to_str().unwrap()).unwrap();
+
+        let leases = discover_dead_runner_base_dirs(&home.locks_dir());
+        let firecrackers = [incomplete_firecracker(1234)];
+        let summary =
+            gc_workspace_orphans_with_leases(leases, &firecrackers, &HashSet::new(), true, false)
+                .await
+                .unwrap();
+
+        assert_eq!(summary.workspaces_cleaned, 0);
+        assert_eq!(summary.base_dir_locks_removed, 0);
+        assert!(
+            workspace.exists(),
+            "uncertain discovery must preserve workspace"
+        );
+        assert!(lock_path.exists(), "lock must remain for a later retry");
+    }
+
+    #[tokio::test]
+    async fn gc_workspace_orphans_cleans_when_incomplete_firecracker_is_live_runner_owned() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let locks_dir = home.locks_dir();
+        std::fs::create_dir_all(&locks_dir).unwrap();
+
+        let base_dir = dir.path().join("runner-data");
+        let workspace = base_dir.join("workspaces").join("run-old");
+        std::fs::create_dir_all(&workspace).unwrap();
+        std::fs::write(workspace.join("cow.img"), b"data").unwrap();
+        set_mtime(&workspace, old_gc_time());
+        let lock_path = locks_dir.join("base-dir-test.lock");
+        std::fs::write(&lock_path, base_dir.to_str().unwrap()).unwrap();
+
+        let leases = discover_dead_runner_base_dirs(&home.locks_dir());
+        let firecrackers = [incomplete_firecracker(1234)];
+        let summary =
+            gc_workspace_orphans_with_leases(leases, &firecrackers, &HashSet::new(), false, false)
+                .await
+                .unwrap();
+
+        assert_eq!(summary.workspaces_cleaned, 1);
+        assert_eq!(summary.base_dir_locks_removed, 1);
+        assert!(
+            !workspace.exists(),
+            "unrelated old workspace should be removed"
+        );
+        assert!(
+            !lock_path.exists(),
+            "base-dir lock can be removed after conclusive cleanup"
+        );
+    }
+
+    #[tokio::test]
+    async fn gc_workspace_orphans_preserves_known_live_firecracker_workspace() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let locks_dir = home.locks_dir();
+        std::fs::create_dir_all(&locks_dir).unwrap();
+
+        let base_dir = dir.path().join("runner-data");
+        let sandbox_id = "sandbox-live";
+        let workspace = base_dir.join("workspaces").join(sandbox_id);
+        std::fs::create_dir_all(&workspace).unwrap();
+        std::fs::write(workspace.join("cow.img"), b"data").unwrap();
+        set_mtime(&workspace, old_gc_time());
+        let lock_path = locks_dir.join("base-dir-test.lock");
+        std::fs::write(&lock_path, base_dir.to_str().unwrap()).unwrap();
+
+        let leases = discover_dead_runner_base_dirs(&home.locks_dir());
+        let firecrackers = [firecracker_with_base_dir(1234, sandbox_id, &base_dir)];
+        let summary =
+            gc_workspace_orphans_with_leases(leases, &firecrackers, &HashSet::new(), false, false)
+                .await
+                .unwrap();
+
+        assert_eq!(summary.workspaces_cleaned, 0);
+        assert_eq!(summary.base_dir_locks_removed, 0);
+        assert!(
+            workspace.exists(),
+            "known live Firecracker workspace must remain"
+        );
+        assert!(
+            lock_path.exists(),
+            "lock must remain while workspace remains"
+        );
+    }
+
+    #[tokio::test]
+    async fn gc_workspace_orphans_preserves_live_runner_base_dir_candidate() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let locks_dir = home.locks_dir();
+        std::fs::create_dir_all(&locks_dir).unwrap();
+
+        let base_dir = dir.path().join("runner-data");
+        let workspace = base_dir.join("workspaces").join("run-old");
+        std::fs::create_dir_all(&workspace).unwrap();
+        std::fs::write(workspace.join("cow.img"), b"data").unwrap();
+        set_mtime(&workspace, old_gc_time());
+        let lock_path = locks_dir.join("base-dir-test.lock");
+        std::fs::write(&lock_path, base_dir.to_str().unwrap()).unwrap();
+
+        let leases = discover_dead_runner_base_dirs(&home.locks_dir());
+        let live_runner_base_dirs = HashSet::from([base_dir.clone()]);
+        let summary =
+            gc_workspace_orphans_with_leases(leases, &[], &live_runner_base_dirs, false, false)
+                .await
+                .unwrap();
+
+        assert_eq!(summary.workspaces_cleaned, 0);
+        assert_eq!(summary.base_dir_locks_removed, 0);
+        assert!(
+            workspace.exists(),
+            "live runner base dir must not be cleaned"
+        );
+        assert!(
+            lock_path.exists(),
+            "lock must remain for live runner base dir"
+        );
+    }
+
+    #[tokio::test]
+    async fn base_dir_lock_cleanup_removes_missing_or_empty_base_dir_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let locks_dir = home.locks_dir();
+        std::fs::create_dir_all(&locks_dir).unwrap();
+
+        let missing_base_dir = dir.path().join("missing-runner-data");
+        let missing_lock = locks_dir.join("base-dir-missing.lock");
+        std::fs::write(&missing_lock, missing_base_dir.to_str().unwrap()).unwrap();
+
+        let empty_base_dir = dir.path().join("empty-runner-data");
+        std::fs::create_dir_all(empty_base_dir.join("workspaces")).unwrap();
+        let empty_lock = locks_dir.join("base-dir-empty-workspaces.lock");
+        std::fs::write(&empty_lock, empty_base_dir.to_str().unwrap()).unwrap();
+
+        let leases = discover_dead_runner_base_dirs(&home.locks_dir());
+        let summary = gc_workspace_orphans_with_leases(leases, &[], &HashSet::new(), false, false)
+            .await
+            .unwrap();
+
+        assert_eq!(summary.workspaces_cleaned, 0);
+        assert_eq!(summary.base_dir_locks_removed, 2);
+        assert!(
+            !missing_lock.exists(),
+            "missing base-dir lock should be removed"
+        );
+        assert!(
+            !empty_lock.exists(),
+            "empty base-dir lock should be removed"
+        );
+    }
+
+    #[tokio::test]
+    async fn base_dir_lock_cleanup_preserves_recent_workspace_retry_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let locks_dir = home.locks_dir();
+        std::fs::create_dir_all(&locks_dir).unwrap();
+
+        let base_dir = dir.path().join("runner-data");
+        let workspace = base_dir.join("workspaces").join("run-recent");
+        std::fs::create_dir_all(&workspace).unwrap();
+        std::fs::write(workspace.join("cow.img"), b"data").unwrap();
+        let lock_path = locks_dir.join("base-dir-test.lock");
+        std::fs::write(&lock_path, base_dir.to_str().unwrap()).unwrap();
+
+        let leases = discover_dead_runner_base_dirs(&home.locks_dir());
+        let summary = gc_workspace_orphans_with_leases(leases, &[], &HashSet::new(), false, false)
+            .await
+            .unwrap();
+
+        assert_eq!(summary.workspaces_cleaned, 0);
+        assert_eq!(summary.base_dir_locks_removed, 0);
+        assert!(workspace.exists(), "recent workspace should remain");
+        assert!(lock_path.exists(), "lock must remain for future retry");
     }
 
     #[tokio::test]
@@ -4683,9 +5106,10 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let home = test_home(dir.path());
         // No lock files, no running processes → no base_dirs
-        let (cleaned, freed) = gc_workspace_orphans(&home, false).await.unwrap();
-        assert_eq!(cleaned, 0);
-        assert_eq!(freed, 0);
+        let summary = gc_workspace_orphans(&home, false).await.unwrap();
+        assert_eq!(summary.workspaces_cleaned, 0);
+        assert_eq!(summary.bytes_freed, 0);
+        assert_eq!(summary.base_dir_locks_removed, 0);
     }
 
     #[tokio::test]
@@ -4716,8 +5140,8 @@ mod tests {
         )
         .unwrap();
 
-        let (cleaned, _) = gc_workspace_orphans(&home, false).await.unwrap();
-        assert_eq!(cleaned, 0);
+        let summary = gc_workspace_orphans(&home, false).await.unwrap();
+        assert_eq!(summary.workspaces_cleaned, 0);
         assert!(stray_file.exists(), "non-directory entries must be skipped");
     }
 
@@ -4738,9 +5162,10 @@ mod tests {
         )
         .unwrap();
 
-        let (cleaned, freed) = gc_workspace_orphans(&home, false).await.unwrap();
-        assert_eq!(cleaned, 0);
-        assert_eq!(freed, 0);
+        let summary = gc_workspace_orphans(&home, false).await.unwrap();
+        assert_eq!(summary.workspaces_cleaned, 0);
+        assert_eq!(summary.bytes_freed, 0);
+        assert_eq!(summary.base_dir_locks_removed, 1);
     }
 
     #[tokio::test]
@@ -4777,12 +5202,16 @@ mod tests {
         )
         .unwrap();
 
-        let (cleaned, freed) = gc_workspace_orphans(&home, false).await.unwrap();
+        let summary = gc_workspace_orphans(&home, false).await.unwrap();
 
-        assert_eq!(cleaned, 1, "only old workspace should be cleaned");
+        assert_eq!(
+            summary.workspaces_cleaned, 1,
+            "only old workspace should be cleaned"
+        );
         assert!(!old_ws.exists(), "old workspace should be deleted");
         assert!(new_ws.exists(), "recent workspace should be kept");
-        assert!(freed > 0 || cfg!(target_os = "macos"));
+        assert!(summary.bytes_freed > 0 || cfg!(target_os = "macos"));
+        assert_eq!(summary.base_dir_locks_removed, 0);
     }
 
     #[cfg(unix)]
@@ -4808,10 +5237,10 @@ mod tests {
         )
         .unwrap();
 
-        let (cleaned, freed) = gc_workspace_orphans(&home, false).await.unwrap();
+        let summary = gc_workspace_orphans(&home, false).await.unwrap();
 
-        assert_eq!(cleaned, 0);
-        assert_eq!(freed, 0);
+        assert_eq!(summary.workspaces_cleaned, 0);
+        assert_eq!(summary.bytes_freed, 0);
         assert_is_symlink(
             &base_dir.join("workspaces"),
             "symlinked workspaces dir must remain",
@@ -4844,10 +5273,10 @@ mod tests {
         )
         .unwrap();
 
-        let (cleaned, freed) = gc_workspace_orphans(&home, false).await.unwrap();
+        let summary = gc_workspace_orphans(&home, false).await.unwrap();
 
-        assert_eq!(cleaned, 0);
-        assert_eq!(freed, 0);
+        assert_eq!(summary.workspaces_cleaned, 0);
+        assert_eq!(summary.bytes_freed, 0);
         assert_is_symlink(&base_dir, "symlinked base dir must remain");
         assert!(
             outside_workspace.exists(),
@@ -4879,10 +5308,10 @@ mod tests {
         )
         .unwrap();
 
-        let (cleaned, freed) = gc_workspace_orphans(&home, false).await.unwrap();
+        let summary = gc_workspace_orphans(&home, false).await.unwrap();
 
-        assert_eq!(cleaned, 0);
-        assert_eq!(freed, 0);
+        assert_eq!(summary.workspaces_cleaned, 0);
+        assert_eq!(summary.bytes_freed, 0);
         assert_is_symlink(&workspace_link, "symlinked workspace entry must remain");
         assert!(
             outside_workspace.exists(),
@@ -4902,7 +5331,7 @@ mod tests {
 
         let dirs = discover_dead_runner_base_dirs(&home.locks_dir());
         assert_eq!(dirs.len(), 1);
-        assert_eq!(dirs[0], PathBuf::from("/data/runner-01"));
+        assert_eq!(dirs[0].base_dir, PathBuf::from("/data/runner-01"));
     }
 
     // -----------------------------------------------------------------------
@@ -5835,11 +6264,15 @@ mod tests {
                 .unwrap();
         }
 
-        let (cleaned, freed) = gc_workspace_orphans(&home, false).await.unwrap();
+        let summary = gc_workspace_orphans(&home, false).await.unwrap();
 
-        assert_eq!(cleaned, 2, "both orphans should be cleaned");
+        assert_eq!(
+            summary.workspaces_cleaned, 2,
+            "both orphans should be cleaned"
+        );
         assert!(!ws_a.exists(), "workspace A should be deleted");
         assert!(!ws_b.exists(), "workspace B should be deleted");
-        assert!(freed > 0 || cfg!(target_os = "macos"));
+        assert!(summary.bytes_freed > 0 || cfg!(target_os = "macos"));
+        assert_eq!(summary.base_dir_locks_removed, 2);
     }
 }

--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -1598,8 +1598,16 @@ fn acquire_dead_runner_base_dir_lease(
     // reading the file to prevent a new runner from starting and overwriting the
     // content between the probe and the read, and keep it held while workspace
     // GC deletes under the base_dir or removes an unusable free lock file.
-    let LockProbe::Free(lock_guard) = probe_lock(&candidate.lock_path) else {
-        return None;
+    let lock_guard = match probe_existing_lock(&candidate.lock_path) {
+        ExistingLockProbe::Free(lock_guard) => lock_guard,
+        ExistingLockProbe::Held | ExistingLockProbe::Missing => return None,
+        ExistingLockProbe::Error(e) => {
+            warn!(
+                "workspace gc: cannot probe base-dir lock {}: {e}",
+                candidate.lock_path.display()
+            );
+            return None;
+        }
     };
     let content = match std::fs::read_to_string(&candidate.lock_path) {
         Ok(c) => c,
@@ -4915,6 +4923,33 @@ mod tests {
             ExistingLockProbe::Free(_) => {}
             _ => panic!("candidate discovery must not hold base-dir locks"),
         }
+    }
+
+    #[tokio::test]
+    async fn gc_workspace_orphans_does_not_recreate_missing_candidate_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let locks_dir = home.locks_dir();
+        std::fs::create_dir_all(&locks_dir).unwrap();
+
+        let lock_path = locks_dir.join("base-dir-dead.lock");
+        std::fs::write(&lock_path, "/data/dead-runner").unwrap();
+
+        let candidates = discover_base_dir_lock_candidates(&home);
+        assert_eq!(candidates.len(), 1);
+        std::fs::remove_file(&lock_path).unwrap();
+
+        let summary =
+            gc_workspace_orphans_with_candidates(candidates, &[], &HashSet::new(), false, true)
+                .await
+                .unwrap();
+
+        assert_eq!(summary.workspaces_cleaned, 0);
+        assert_eq!(summary.base_dir_locks_removed, 0);
+        assert!(
+            !lock_path.exists(),
+            "GC must not recreate a lock path that disappeared after discovery"
+        );
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -1515,6 +1515,11 @@ struct DeadRunnerBaseDirLease {
     lock_guard: Flock<std::fs::File>,
 }
 
+struct DeadRunnerBaseDirLockCandidate {
+    lock_path: PathBuf,
+    lock_name: String,
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum BaseDirLockDecision {
     RemoveIfStillFree,
@@ -1542,17 +1547,10 @@ fn parse_base_dir_lock_content(content: &str, lock_path: &Path) -> Option<PathBu
     Some(base_dir)
 }
 
-/// Read base-dir lock files written by `runner start`, returning only those
-/// whose runner is dead (lock not held), while keeping the lock held.
-///
-/// Some old or corrupted lock files do not contain a usable absolute base_dir.
-/// They are still returned as leases so workspace GC can safely remove the
-/// free lock file instead of leaving retry metadata behind forever.
-///
-/// Live runners manage their own workspaces via the factory — GC must not
-/// touch them because CowPool pre-warmed slots would be indistinguishable
-/// from orphaned workspaces.
-fn discover_dead_runner_base_dirs(locks_dir: &Path) -> Vec<DeadRunnerBaseDirLease> {
+/// Find base-dir lock paths written by `runner start`.
+fn discover_dead_runner_base_dir_lock_candidates(
+    locks_dir: &Path,
+) -> Vec<DeadRunnerBaseDirLockCandidate> {
     let entries = match std::fs::read_dir(locks_dir) {
         Ok(rd) => rd,
         Err(e) => {
@@ -1561,7 +1559,7 @@ fn discover_dead_runner_base_dirs(locks_dir: &Path) -> Vec<DeadRunnerBaseDirLeas
         }
     };
 
-    let mut base_dirs = Vec::new();
+    let mut candidates = Vec::new();
     for result in entries {
         let entry = match result {
             Ok(entry) => entry,
@@ -1575,30 +1573,50 @@ fn discover_dead_runner_base_dirs(locks_dir: &Path) -> Vec<DeadRunnerBaseDirLeas
         if !is_base_dir_lock_name(name) {
             continue;
         }
-        let lock_path = entry.path();
-        // Only include locks from dead runners (lock not held).
-        // Hold the lock while reading the file to prevent a new runner from
-        // starting and overwriting the content between the probe and the read,
-        // and keep it held while workspace GC deletes under the base_dir or
-        // removes an unusable free lock file.
-        let LockProbe::Free(lock_guard) = probe_lock(&lock_path) else {
-            continue;
-        };
-        let content = match std::fs::read_to_string(&lock_path) {
-            Ok(c) => c,
-            Err(e) => {
-                warn!("workspace gc: cannot read {}: {e}", lock_path.display());
-                continue;
-            }
-        };
-        base_dirs.push(DeadRunnerBaseDirLease {
-            base_dir: parse_base_dir_lock_content(&content, &lock_path),
-            lock_path,
+        candidates.push(DeadRunnerBaseDirLockCandidate {
+            lock_path: entry.path(),
             lock_name: name.to_string(),
-            lock_guard,
         });
     }
-    base_dirs
+    candidates
+}
+
+/// Acquire a base-dir lock candidate whose runner is dead, while keeping the
+/// lock held for the caller.
+///
+/// Some old or corrupted lock files do not contain a usable absolute base_dir.
+/// They are still returned as leases so workspace GC can safely remove the
+/// free lock file instead of leaving retry metadata behind forever.
+///
+/// Live runners manage their own workspaces via the factory — GC must not
+/// touch them because CowPool pre-warmed slots would be indistinguishable
+/// from orphaned workspaces.
+fn acquire_dead_runner_base_dir_lease(
+    candidate: DeadRunnerBaseDirLockCandidate,
+) -> Option<DeadRunnerBaseDirLease> {
+    // Only include locks from dead runners (lock not held). Hold the lock while
+    // reading the file to prevent a new runner from starting and overwriting the
+    // content between the probe and the read, and keep it held while workspace
+    // GC deletes under the base_dir or removes an unusable free lock file.
+    let LockProbe::Free(lock_guard) = probe_lock(&candidate.lock_path) else {
+        return None;
+    };
+    let content = match std::fs::read_to_string(&candidate.lock_path) {
+        Ok(c) => c,
+        Err(e) => {
+            warn!(
+                "workspace gc: cannot read {}: {e}",
+                candidate.lock_path.display()
+            );
+            return None;
+        }
+    };
+    Some(DeadRunnerBaseDirLease {
+        base_dir: parse_base_dir_lock_content(&content, &candidate.lock_path),
+        lock_path: candidate.lock_path,
+        lock_name: candidate.lock_name,
+        lock_guard,
+    })
 }
 
 fn active_workspace_paths(
@@ -1674,21 +1692,23 @@ async fn gc_workspace_orphans(home: &HomePaths, dry_run: bool) -> RunnerResult<W
         return Ok(WorkspaceGcSummary::default());
     }
 
-    // 2. Only scan base_dirs from dead runners (lock not held).
-    //    Runs on a blocking thread because probe_lock uses flock(2) and
-    //    std::fs::read_to_string — both synchronous.
+    // 2. Enumerate base-dir lock candidates without holding their fds. Each
+    //    candidate is leased separately while it is processed, so a large
+    //    backlog of old lock files cannot exhaust the process fd limit.
     let locks_dir = home.locks_dir();
-    let base_dirs = tokio::task::spawn_blocking(move || discover_dead_runner_base_dirs(&locks_dir))
-        .await
-        .map_err(|e| RunnerError::Internal(format!("discover base_dirs task failed: {e}")))?;
+    let candidates = tokio::task::spawn_blocking(move || {
+        discover_dead_runner_base_dir_lock_candidates(&locks_dir)
+    })
+    .await
+    .map_err(|e| RunnerError::Internal(format!("discover base-dir locks task failed: {e}")))?;
 
-    if base_dirs.is_empty() {
+    if candidates.is_empty() {
         tracing::debug!("workspace gc: no dead-runner base_dirs discovered");
         return Ok(WorkspaceGcSummary::default());
     }
 
-    gc_workspace_orphans_with_leases(
-        base_dirs,
+    gc_workspace_orphans_with_candidates(
+        candidates,
         &discovered.firecrackers,
         &live_runner_base_dirs,
         false,
@@ -1697,8 +1717,8 @@ async fn gc_workspace_orphans(home: &HomePaths, dry_run: bool) -> RunnerResult<W
     .await
 }
 
-async fn gc_workspace_orphans_with_leases(
-    base_dirs: Vec<DeadRunnerBaseDirLease>,
+async fn gc_workspace_orphans_with_candidates(
+    candidates: Vec<DeadRunnerBaseDirLockCandidate>,
     firecrackers: &[crate::process::FirecrackerProcessInfo],
     live_runner_base_dirs: &HashSet<PathBuf>,
     process_discovery_uncertain: bool,
@@ -1713,8 +1733,19 @@ async fn gc_workspace_orphans_with_leases(
     // 3. Scan each base_dir/workspaces/ for orphans.
     let now = SystemTime::now();
     let mut summary = WorkspaceGcSummary::default();
+    let candidate_count = candidates.len();
 
-    for lease in &base_dirs {
+    for candidate in candidates {
+        let lease =
+            tokio::task::spawn_blocking(move || acquire_dead_runner_base_dir_lease(candidate))
+                .await
+                .map_err(|e| {
+                    RunnerError::Internal(format!("acquire base-dir lease task failed: {e}"))
+                })?;
+        let Some(lease) = lease else {
+            continue;
+        };
+
         let Some(base_dir) = lease.base_dir.as_deref() else {
             if remove_unused_lock_after_probe(
                 &lease.lock_path,
@@ -1763,8 +1794,8 @@ async fn gc_workspace_orphans_with_leases(
         );
     } else {
         tracing::debug!(
-            "workspace gc: no orphans found across {} base_dirs",
-            base_dirs.len()
+            "workspace gc: no orphans found across {} base-dir lock candidates",
+            candidate_count
         );
     }
 
@@ -2718,6 +2749,17 @@ mod tests {
             .iter()
             .filter_map(|lease| lease.base_dir.clone())
             .collect()
+    }
+
+    fn discover_dead_runner_base_dirs(locks_dir: &Path) -> Vec<DeadRunnerBaseDirLease> {
+        discover_dead_runner_base_dir_lock_candidates(locks_dir)
+            .into_iter()
+            .filter_map(acquire_dead_runner_base_dir_lease)
+            .collect()
+    }
+
+    fn discover_base_dir_lock_candidates(home: &HomePaths) -> Vec<DeadRunnerBaseDirLockCandidate> {
+        discover_dead_runner_base_dir_lock_candidates(&home.locks_dir())
     }
 
     fn firecracker_with_base_dir(
@@ -4857,6 +4899,24 @@ mod tests {
         }
     }
 
+    #[test]
+    fn discover_base_dir_lock_candidates_does_not_hold_locks() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let locks_dir = home.locks_dir();
+        std::fs::create_dir_all(&locks_dir).unwrap();
+
+        let lock_path = locks_dir.join("base-dir-dead.lock");
+        std::fs::write(&lock_path, "/data/dead-runner").unwrap();
+
+        let candidates = discover_base_dir_lock_candidates(&home);
+        assert_eq!(candidates.len(), 1);
+        match probe_existing_lock(&lock_path) {
+            ExistingLockProbe::Free(_) => {}
+            _ => panic!("candidate discovery must not hold base-dir locks"),
+        }
+    }
+
     #[tokio::test]
     async fn gc_workspace_orphans_deletes_old_orphan() {
         use std::fs::FileTimes;
@@ -4965,12 +5025,17 @@ mod tests {
         let lock_path = locks_dir.join("base-dir-test.lock");
         std::fs::write(&lock_path, base_dir.to_str().unwrap()).unwrap();
 
-        let leases = discover_dead_runner_base_dirs(&home.locks_dir());
+        let candidates = discover_base_dir_lock_candidates(&home);
         let firecrackers = [incomplete_firecracker(1234)];
-        let summary =
-            gc_workspace_orphans_with_leases(leases, &firecrackers, &HashSet::new(), true, false)
-                .await
-                .unwrap();
+        let summary = gc_workspace_orphans_with_candidates(
+            candidates,
+            &firecrackers,
+            &HashSet::new(),
+            true,
+            false,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(summary.workspaces_cleaned, 0);
         assert_eq!(summary.base_dir_locks_removed, 0);
@@ -4996,10 +5061,11 @@ mod tests {
         let lock_path = locks_dir.join("base-dir-test.lock");
         std::fs::write(&lock_path, base_dir.to_str().unwrap()).unwrap();
 
-        let leases = discover_dead_runner_base_dirs(&home.locks_dir());
-        let summary = gc_workspace_orphans_with_leases(leases, &[], &HashSet::new(), true, false)
-            .await
-            .unwrap();
+        let candidates = discover_base_dir_lock_candidates(&home);
+        let summary =
+            gc_workspace_orphans_with_candidates(candidates, &[], &HashSet::new(), true, false)
+                .await
+                .unwrap();
 
         assert_eq!(summary.workspaces_cleaned, 0);
         assert_eq!(summary.base_dir_locks_removed, 0);
@@ -5025,12 +5091,17 @@ mod tests {
         let lock_path = locks_dir.join("base-dir-test.lock");
         std::fs::write(&lock_path, base_dir.to_str().unwrap()).unwrap();
 
-        let leases = discover_dead_runner_base_dirs(&home.locks_dir());
+        let candidates = discover_base_dir_lock_candidates(&home);
         let firecrackers = [incomplete_firecracker(1234)];
-        let summary =
-            gc_workspace_orphans_with_leases(leases, &firecrackers, &HashSet::new(), false, false)
-                .await
-                .unwrap();
+        let summary = gc_workspace_orphans_with_candidates(
+            candidates,
+            &firecrackers,
+            &HashSet::new(),
+            false,
+            false,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(summary.workspaces_cleaned, 1);
         assert_eq!(summary.base_dir_locks_removed, 1);
@@ -5060,12 +5131,17 @@ mod tests {
         let lock_path = locks_dir.join("base-dir-test.lock");
         std::fs::write(&lock_path, base_dir.to_str().unwrap()).unwrap();
 
-        let leases = discover_dead_runner_base_dirs(&home.locks_dir());
+        let candidates = discover_base_dir_lock_candidates(&home);
         let firecrackers = [firecracker_with_base_dir(1234, sandbox_id, &base_dir)];
-        let summary =
-            gc_workspace_orphans_with_leases(leases, &firecrackers, &HashSet::new(), false, false)
-                .await
-                .unwrap();
+        let summary = gc_workspace_orphans_with_candidates(
+            candidates,
+            &firecrackers,
+            &HashSet::new(),
+            false,
+            false,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(summary.workspaces_cleaned, 0);
         assert_eq!(summary.base_dir_locks_removed, 0);
@@ -5094,12 +5170,17 @@ mod tests {
         let lock_path = locks_dir.join("base-dir-test.lock");
         std::fs::write(&lock_path, base_dir.to_str().unwrap()).unwrap();
 
-        let leases = discover_dead_runner_base_dirs(&home.locks_dir());
+        let candidates = discover_base_dir_lock_candidates(&home);
         let live_runner_base_dirs = HashSet::from([base_dir.clone()]);
-        let summary =
-            gc_workspace_orphans_with_leases(leases, &[], &live_runner_base_dirs, false, false)
-                .await
-                .unwrap();
+        let summary = gc_workspace_orphans_with_candidates(
+            candidates,
+            &[],
+            &live_runner_base_dirs,
+            false,
+            false,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(summary.workspaces_cleaned, 0);
         assert_eq!(summary.base_dir_locks_removed, 0);
@@ -5135,10 +5216,11 @@ mod tests {
         let relative_content_lock = locks_dir.join("base-dir-relative-content.lock");
         std::fs::write(&relative_content_lock, "relative-runner-data").unwrap();
 
-        let leases = discover_dead_runner_base_dirs(&home.locks_dir());
-        let summary = gc_workspace_orphans_with_leases(leases, &[], &HashSet::new(), false, false)
-            .await
-            .unwrap();
+        let candidates = discover_base_dir_lock_candidates(&home);
+        let summary =
+            gc_workspace_orphans_with_candidates(candidates, &[], &HashSet::new(), false, false)
+                .await
+                .unwrap();
 
         assert_eq!(summary.workspaces_cleaned, 0);
         assert_eq!(summary.base_dir_locks_removed, 4);
@@ -5174,10 +5256,11 @@ mod tests {
         let lock_path = locks_dir.join("base-dir-test.lock");
         std::fs::write(&lock_path, base_dir.to_str().unwrap()).unwrap();
 
-        let leases = discover_dead_runner_base_dirs(&home.locks_dir());
-        let summary = gc_workspace_orphans_with_leases(leases, &[], &HashSet::new(), false, false)
-            .await
-            .unwrap();
+        let candidates = discover_base_dir_lock_candidates(&home);
+        let summary =
+            gc_workspace_orphans_with_candidates(candidates, &[], &HashSet::new(), false, false)
+                .await
+                .unwrap();
 
         assert_eq!(summary.workspaces_cleaned, 0);
         assert_eq!(summary.base_dir_locks_removed, 0);

--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -1509,7 +1509,7 @@ struct WorkspaceGcSummary {
 }
 
 struct DeadRunnerBaseDirLease {
-    base_dir: PathBuf,
+    base_dir: Option<PathBuf>,
     lock_path: PathBuf,
     lock_name: String,
     lock_guard: Flock<std::fs::File>,
@@ -1525,8 +1525,29 @@ fn is_base_dir_lock_name(name: &str) -> bool {
     name.starts_with("base-dir-") && name.ends_with(".lock")
 }
 
-/// Read base_dir paths from lock files written by `runner start`, returning
-/// only those whose runner is dead (lock not held), while keeping the lock held.
+fn parse_base_dir_lock_content(content: &str, lock_path: &Path) -> Option<PathBuf> {
+    let path = content.trim();
+    if path.is_empty() {
+        return None;
+    }
+    let base_dir = PathBuf::from(path);
+    if !base_dir.is_absolute() {
+        warn!(
+            "workspace gc: {} contains non-absolute base_dir {}, treating lock as unusable",
+            lock_path.display(),
+            base_dir.display()
+        );
+        return None;
+    }
+    Some(base_dir)
+}
+
+/// Read base-dir lock files written by `runner start`, returning only those
+/// whose runner is dead (lock not held), while keeping the lock held.
+///
+/// Some old or corrupted lock files do not contain a usable absolute base_dir.
+/// They are still returned as leases so workspace GC can safely remove the
+/// free lock file instead of leaving retry metadata behind forever.
 ///
 /// Live runners manage their own workspaces via the factory — GC must not
 /// touch them because CowPool pre-warmed slots would be indistinguishable
@@ -1555,10 +1576,11 @@ fn discover_dead_runner_base_dirs(locks_dir: &Path) -> Vec<DeadRunnerBaseDirLeas
             continue;
         }
         let lock_path = entry.path();
-        // Only include base_dirs from dead runners (lock not held).
+        // Only include locks from dead runners (lock not held).
         // Hold the lock while reading the file to prevent a new runner from
         // starting and overwriting the content between the probe and the read,
-        // and keep it held while workspace GC deletes under the base_dir.
+        // and keep it held while workspace GC deletes under the base_dir or
+        // removes an unusable free lock file.
         let LockProbe::Free(lock_guard) = probe_lock(&lock_path) else {
             continue;
         };
@@ -1569,12 +1591,8 @@ fn discover_dead_runner_base_dirs(locks_dir: &Path) -> Vec<DeadRunnerBaseDirLeas
                 continue;
             }
         };
-        let path = content.trim();
-        if path.is_empty() {
-            continue; // pre-upgrade lock file without base_dir
-        }
         base_dirs.push(DeadRunnerBaseDirLease {
-            base_dir: PathBuf::from(path),
+            base_dir: parse_base_dir_lock_content(&content, &lock_path),
             lock_path,
             lock_name: name.to_string(),
             lock_guard,
@@ -1696,25 +1714,39 @@ async fn gc_workspace_orphans_with_leases(
     let now = SystemTime::now();
     let mut summary = WorkspaceGcSummary::default();
 
-    for base_dir in &base_dirs {
-        if live_runner_base_dirs.contains(&base_dir.base_dir) {
+    for lease in &base_dirs {
+        let Some(base_dir) = lease.base_dir.as_deref() else {
+            if remove_unused_lock_after_probe(
+                &lease.lock_path,
+                &lease.lock_guard,
+                &lease.lock_name,
+                dry_run,
+            )
+            .await
+            {
+                summary.base_dir_locks_removed += 1;
+            }
+            continue;
+        };
+
+        if live_runner_base_dirs.contains(base_dir) {
             warn!(
                 "workspace gc: {} is listed as a live runner base directory, skipping",
-                base_dir.base_dir.display()
+                base_dir.display()
             );
             continue;
         }
 
         let (cleaned, freed, lock_decision) =
-            gc_workspace_orphans_in_base_dir(&base_dir.base_dir, &active, now, dry_run).await;
+            gc_workspace_orphans_in_base_dir(base_dir, &active, now, dry_run).await;
         summary.workspaces_cleaned += cleaned;
         summary.bytes_freed += freed;
 
         if lock_decision == BaseDirLockDecision::RemoveIfStillFree
             && remove_unused_lock_after_probe(
-                &base_dir.lock_path,
-                &base_dir.lock_guard,
-                &base_dir.lock_name,
+                &lease.lock_path,
+                &lease.lock_guard,
+                &lease.lock_name,
                 dry_run,
             )
             .await
@@ -2682,7 +2714,10 @@ mod tests {
     }
 
     fn discovered_base_dirs(leases: &[DeadRunnerBaseDirLease]) -> Vec<PathBuf> {
-        leases.iter().map(|lease| lease.base_dir.clone()).collect()
+        leases
+            .iter()
+            .filter_map(|lease| lease.base_dir.clone())
+            .collect()
     }
 
     fn firecracker_with_base_dir(
@@ -4748,7 +4783,7 @@ mod tests {
     }
 
     #[test]
-    fn discover_dead_runner_base_dirs_skips_empty_and_non_matching() {
+    fn discover_dead_runner_base_dirs_keeps_empty_locks_for_cleanup() {
         let dir = tempfile::tempdir().unwrap();
         let home = test_home(dir.path());
         let locks_dir = home.locks_dir();
@@ -4760,7 +4795,8 @@ mod tests {
         std::fs::write(locks_dir.join("rootfs-abc.lock"), "/some/path").unwrap();
 
         let dirs = discover_dead_runner_base_dirs(&home.locks_dir());
-        assert!(dirs.is_empty());
+        assert_eq!(dirs.len(), 1);
+        assert_eq!(dirs[0].base_dir, None);
     }
 
     #[test]
@@ -4794,7 +4830,7 @@ mod tests {
 
         let dirs = discover_dead_runner_base_dirs(&home.locks_dir());
         assert_eq!(dirs.len(), 1);
-        assert_eq!(dirs[0].base_dir, PathBuf::from("/data/dead-runner"));
+        assert_eq!(dirs[0].base_dir, Some(PathBuf::from("/data/dead-runner")));
     }
 
     #[test]
@@ -5093,13 +5129,19 @@ mod tests {
         let empty_lock = locks_dir.join("base-dir-empty-workspaces.lock");
         std::fs::write(&empty_lock, empty_base_dir.to_str().unwrap()).unwrap();
 
+        let empty_content_lock = locks_dir.join("base-dir-empty-content.lock");
+        std::fs::write(&empty_content_lock, "").unwrap();
+
+        let relative_content_lock = locks_dir.join("base-dir-relative-content.lock");
+        std::fs::write(&relative_content_lock, "relative-runner-data").unwrap();
+
         let leases = discover_dead_runner_base_dirs(&home.locks_dir());
         let summary = gc_workspace_orphans_with_leases(leases, &[], &HashSet::new(), false, false)
             .await
             .unwrap();
 
         assert_eq!(summary.workspaces_cleaned, 0);
-        assert_eq!(summary.base_dir_locks_removed, 2);
+        assert_eq!(summary.base_dir_locks_removed, 4);
         assert!(
             !missing_lock.exists(),
             "missing base-dir lock should be removed"
@@ -5107,6 +5149,14 @@ mod tests {
         assert!(
             !empty_lock.exists(),
             "empty base-dir lock should be removed"
+        );
+        assert!(
+            !empty_content_lock.exists(),
+            "empty-content base-dir lock should be removed"
+        );
+        assert!(
+            !relative_content_lock.exists(),
+            "relative-content base-dir lock should be removed"
         );
     }
 
@@ -5365,7 +5415,7 @@ mod tests {
 
         let dirs = discover_dead_runner_base_dirs(&home.locks_dir());
         assert_eq!(dirs.len(), 1);
-        assert_eq!(dirs[0].base_dir, PathBuf::from("/data/runner-01"));
+        assert_eq!(dirs[0].base_dir, Some(PathBuf::from("/data/runner-01")));
     }
 
     // -----------------------------------------------------------------------
@@ -6244,7 +6294,7 @@ mod tests {
     }
 
     #[test]
-    fn discover_dead_runner_base_dirs_skips_whitespace_only() {
+    fn discover_dead_runner_base_dirs_keeps_whitespace_only_locks_for_cleanup() {
         let dir = tempfile::tempdir().unwrap();
         let home = test_home(dir.path());
         let locks_dir = home.locks_dir();
@@ -6254,7 +6304,8 @@ mod tests {
         std::fs::write(locks_dir.join("base-dir-ws-only.lock"), "  \n\t\n").unwrap();
 
         let dirs = discover_dead_runner_base_dirs(&home.locks_dir());
-        assert!(dirs.is_empty());
+        assert_eq!(dirs.len(), 1);
+        assert_eq!(dirs[0].base_dir, None);
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -1,4 +1,6 @@
 use std::collections::HashSet;
+use std::ffi::OsString;
+use std::os::unix::ffi::OsStringExt;
 use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
@@ -11,7 +13,7 @@ use crate::cmd::service;
 use crate::error::{RunnerError, RunnerResult};
 use crate::host_file;
 use crate::lock;
-use crate::paths::{HomePaths, LogPaths};
+use crate::paths::{HomePaths, LogPaths, base_dir_lock_name};
 use crate::r2_cache::R2ImageCache;
 
 /// Default TTL for completed R2 image objects. Older objects are deleted by
@@ -1530,17 +1532,30 @@ fn is_base_dir_lock_name(name: &str) -> bool {
     name.starts_with("base-dir-") && name.ends_with(".lock")
 }
 
-fn parse_base_dir_lock_content(content: &str, lock_path: &Path) -> Option<PathBuf> {
-    let path = content.trim();
-    if path.is_empty() {
+fn parse_base_dir_lock_content(
+    content: &[u8],
+    lock_path: &Path,
+    lock_name: &str,
+) -> Option<PathBuf> {
+    if content.is_empty() {
         return None;
     }
-    let base_dir = PathBuf::from(path);
+    let base_dir = PathBuf::from(OsString::from_vec(content.to_vec()));
     if !base_dir.is_absolute() {
         warn!(
             "workspace gc: {} contains non-absolute base_dir {}, treating lock as unusable",
             lock_path.display(),
             base_dir.display()
+        );
+        return None;
+    }
+    let expected_lock_name = base_dir_lock_name(&base_dir);
+    if lock_name != expected_lock_name {
+        warn!(
+            "workspace gc: {} contains base_dir {}, but lock name should be {}; treating lock as unusable",
+            lock_path.display(),
+            base_dir.display(),
+            expected_lock_name
         );
         return None;
     }
@@ -1609,7 +1624,7 @@ fn acquire_dead_runner_base_dir_lease(
             return None;
         }
     };
-    let content = match std::fs::read_to_string(&candidate.lock_path) {
+    let content = match std::fs::read(&candidate.lock_path) {
         Ok(c) => c,
         Err(e) => {
             warn!(
@@ -1620,7 +1635,7 @@ fn acquire_dead_runner_base_dir_lease(
         }
     };
     Some(DeadRunnerBaseDirLease {
-        base_dir: parse_base_dir_lock_content(&content, &candidate.lock_path),
+        base_dir: parse_base_dir_lock_content(&content, &candidate.lock_path, &candidate.lock_name),
         lock_path: candidate.lock_path,
         lock_name: candidate.lock_name,
         lock_guard,
@@ -2768,6 +2783,12 @@ mod tests {
 
     fn discover_base_dir_lock_candidates(home: &HomePaths) -> Vec<DeadRunnerBaseDirLockCandidate> {
         discover_dead_runner_base_dir_lock_candidates(&home.locks_dir())
+    }
+
+    fn write_base_dir_lock(home: &HomePaths, base_dir: &Path) -> PathBuf {
+        let lock_path = home.base_dir_lock(base_dir);
+        std::fs::write(&lock_path, base_dir.as_os_str().as_encoded_bytes()).unwrap();
+        lock_path
     }
 
     fn firecracker_with_base_dir(
@@ -4822,8 +4843,8 @@ mod tests {
         let locks_dir = home.locks_dir();
         std::fs::create_dir_all(&locks_dir).unwrap();
 
-        std::fs::write(locks_dir.join("base-dir-abc123.lock"), "/data/runner-01").unwrap();
-        std::fs::write(locks_dir.join("base-dir-def456.lock"), "/data/runner-02").unwrap();
+        write_base_dir_lock(&home, Path::new("/data/runner-01"));
+        write_base_dir_lock(&home, Path::new("/data/runner-02"));
 
         let dirs = discover_dead_runner_base_dirs(&home.locks_dir());
         assert_eq!(dirs.len(), 2);
@@ -4866,8 +4887,7 @@ mod tests {
         std::fs::create_dir_all(&locks_dir).unwrap();
 
         // Lock file with content, held by us (simulating a live runner).
-        let lock_path = locks_dir.join("base-dir-live.lock");
-        std::fs::write(&lock_path, "/data/live-runner").unwrap();
+        let lock_path = write_base_dir_lock(&home, Path::new("/data/live-runner"));
         let file = std::fs::File::options()
             .read(true)
             .write(true)
@@ -4876,7 +4896,7 @@ mod tests {
         let _held = Flock::lock(file, FlockArg::LockExclusive).unwrap();
 
         // Lock file with content, NOT held (simulating a dead runner).
-        std::fs::write(locks_dir.join("base-dir-dead.lock"), "/data/dead-runner").unwrap();
+        write_base_dir_lock(&home, Path::new("/data/dead-runner"));
 
         let dirs = discover_dead_runner_base_dirs(&home.locks_dir());
         assert_eq!(dirs.len(), 1);
@@ -4890,8 +4910,7 @@ mod tests {
         let locks_dir = home.locks_dir();
         std::fs::create_dir_all(&locks_dir).unwrap();
 
-        let lock_path = locks_dir.join("base-dir-dead.lock");
-        std::fs::write(&lock_path, "/data/dead-runner").unwrap();
+        let lock_path = write_base_dir_lock(&home, Path::new("/data/dead-runner"));
 
         let leases = discover_dead_runner_base_dirs(&home.locks_dir());
         assert_eq!(leases.len(), 1);
@@ -4914,8 +4933,7 @@ mod tests {
         let locks_dir = home.locks_dir();
         std::fs::create_dir_all(&locks_dir).unwrap();
 
-        let lock_path = locks_dir.join("base-dir-dead.lock");
-        std::fs::write(&lock_path, "/data/dead-runner").unwrap();
+        let lock_path = write_base_dir_lock(&home, Path::new("/data/dead-runner"));
 
         let candidates = discover_base_dir_lock_candidates(&home);
         assert_eq!(candidates.len(), 1);
@@ -4932,8 +4950,7 @@ mod tests {
         let locks_dir = home.locks_dir();
         std::fs::create_dir_all(&locks_dir).unwrap();
 
-        let lock_path = locks_dir.join("base-dir-dead.lock");
-        std::fs::write(&lock_path, "/data/dead-runner").unwrap();
+        let lock_path = write_base_dir_lock(&home, Path::new("/data/dead-runner"));
 
         let candidates = discover_base_dir_lock_candidates(&home);
         assert_eq!(candidates.len(), 1);
@@ -4969,8 +4986,7 @@ mod tests {
         std::fs::write(workspace.join("cow.img"), vec![0u8; 4096]).unwrap();
 
         // Register base_dir in lock file
-        let lock_path = locks_dir.join("base-dir-test.lock");
-        std::fs::write(&lock_path, base_dir.to_str().unwrap()).unwrap();
+        write_base_dir_lock(&home, &base_dir);
 
         // Set workspace mtime to 1 hour ago (past GC_MIN_AGE)
         let old_time = SystemTime::now() - Duration::from_secs(3600);
@@ -5000,8 +5016,7 @@ mod tests {
         std::fs::write(workspace.join("cow.img"), b"data").unwrap();
         // mtime = now (default), so workspace is too recent
 
-        let lock_path = locks_dir.join("base-dir-test.lock");
-        std::fs::write(&lock_path, base_dir.to_str().unwrap()).unwrap();
+        write_base_dir_lock(&home, &base_dir);
 
         let summary = gc_workspace_orphans(&home, false).await.unwrap();
 
@@ -5024,8 +5039,7 @@ mod tests {
         std::fs::create_dir_all(&workspace).unwrap();
         std::fs::write(workspace.join("cow.img"), b"data").unwrap();
 
-        let lock_path = locks_dir.join("base-dir-test.lock");
-        std::fs::write(&lock_path, base_dir.to_str().unwrap()).unwrap();
+        let lock_path = write_base_dir_lock(&home, &base_dir);
 
         let old_time = SystemTime::now() - Duration::from_secs(3600);
         std::fs::File::open(&workspace)
@@ -5057,8 +5071,7 @@ mod tests {
         std::fs::create_dir_all(&workspace).unwrap();
         std::fs::write(workspace.join("cow.img"), b"data").unwrap();
         set_mtime(&workspace, old_gc_time());
-        let lock_path = locks_dir.join("base-dir-test.lock");
-        std::fs::write(&lock_path, base_dir.to_str().unwrap()).unwrap();
+        let lock_path = write_base_dir_lock(&home, &base_dir);
 
         let candidates = discover_base_dir_lock_candidates(&home);
         let firecrackers = [incomplete_firecracker(1234)];
@@ -5093,8 +5106,7 @@ mod tests {
         std::fs::create_dir_all(&workspace).unwrap();
         std::fs::write(workspace.join("cow.img"), b"data").unwrap();
         set_mtime(&workspace, old_gc_time());
-        let lock_path = locks_dir.join("base-dir-test.lock");
-        std::fs::write(&lock_path, base_dir.to_str().unwrap()).unwrap();
+        let lock_path = write_base_dir_lock(&home, &base_dir);
 
         let candidates = discover_base_dir_lock_candidates(&home);
         let summary =
@@ -5123,8 +5135,7 @@ mod tests {
         std::fs::create_dir_all(&workspace).unwrap();
         std::fs::write(workspace.join("cow.img"), b"data").unwrap();
         set_mtime(&workspace, old_gc_time());
-        let lock_path = locks_dir.join("base-dir-test.lock");
-        std::fs::write(&lock_path, base_dir.to_str().unwrap()).unwrap();
+        let lock_path = write_base_dir_lock(&home, &base_dir);
 
         let candidates = discover_base_dir_lock_candidates(&home);
         let firecrackers = [incomplete_firecracker(1234)];
@@ -5163,8 +5174,7 @@ mod tests {
         std::fs::create_dir_all(&workspace).unwrap();
         std::fs::write(workspace.join("cow.img"), b"data").unwrap();
         set_mtime(&workspace, old_gc_time());
-        let lock_path = locks_dir.join("base-dir-test.lock");
-        std::fs::write(&lock_path, base_dir.to_str().unwrap()).unwrap();
+        let lock_path = write_base_dir_lock(&home, &base_dir);
 
         let candidates = discover_base_dir_lock_candidates(&home);
         let firecrackers = [firecracker_with_base_dir(1234, sandbox_id, &base_dir)];
@@ -5202,8 +5212,7 @@ mod tests {
         std::fs::create_dir_all(&workspace).unwrap();
         std::fs::write(workspace.join("cow.img"), b"data").unwrap();
         set_mtime(&workspace, old_gc_time());
-        let lock_path = locks_dir.join("base-dir-test.lock");
-        std::fs::write(&lock_path, base_dir.to_str().unwrap()).unwrap();
+        let lock_path = write_base_dir_lock(&home, &base_dir);
 
         let candidates = discover_base_dir_lock_candidates(&home);
         let live_runner_base_dirs = HashSet::from([base_dir.clone()]);
@@ -5237,13 +5246,11 @@ mod tests {
         std::fs::create_dir_all(&locks_dir).unwrap();
 
         let missing_base_dir = dir.path().join("missing-runner-data");
-        let missing_lock = locks_dir.join("base-dir-missing.lock");
-        std::fs::write(&missing_lock, missing_base_dir.to_str().unwrap()).unwrap();
+        let missing_lock = write_base_dir_lock(&home, &missing_base_dir);
 
         let empty_base_dir = dir.path().join("empty-runner-data");
         std::fs::create_dir_all(empty_base_dir.join("workspaces")).unwrap();
-        let empty_lock = locks_dir.join("base-dir-empty-workspaces.lock");
-        std::fs::write(&empty_lock, empty_base_dir.to_str().unwrap()).unwrap();
+        let empty_lock = write_base_dir_lock(&home, &empty_base_dir);
 
         let empty_content_lock = locks_dir.join("base-dir-empty-content.lock");
         std::fs::write(&empty_content_lock, "").unwrap();
@@ -5288,8 +5295,7 @@ mod tests {
         let workspace = base_dir.join("workspaces").join("run-recent");
         std::fs::create_dir_all(&workspace).unwrap();
         std::fs::write(workspace.join("cow.img"), b"data").unwrap();
-        let lock_path = locks_dir.join("base-dir-test.lock");
-        std::fs::write(&lock_path, base_dir.to_str().unwrap()).unwrap();
+        let lock_path = write_base_dir_lock(&home, &base_dir);
 
         let candidates = discover_base_dir_lock_candidates(&home);
         let summary =
@@ -5336,11 +5342,7 @@ mod tests {
             .set_times(FileTimes::new().set_modified(old_time))
             .unwrap();
 
-        std::fs::write(
-            locks_dir.join("base-dir-test.lock"),
-            base_dir.to_str().unwrap(),
-        )
-        .unwrap();
+        write_base_dir_lock(&home, &base_dir);
 
         let summary = gc_workspace_orphans(&home, false).await.unwrap();
         assert_eq!(summary.workspaces_cleaned, 0);
@@ -5358,11 +5360,7 @@ mod tests {
         let base_dir = dir.path().join("runner-data");
         std::fs::create_dir_all(&base_dir).unwrap();
 
-        std::fs::write(
-            locks_dir.join("base-dir-test.lock"),
-            base_dir.to_str().unwrap(),
-        )
-        .unwrap();
+        write_base_dir_lock(&home, &base_dir);
 
         let summary = gc_workspace_orphans(&home, false).await.unwrap();
         assert_eq!(summary.workspaces_cleaned, 0);
@@ -5398,11 +5396,7 @@ mod tests {
         std::fs::write(new_ws.join("cow.img"), b"data").unwrap();
         // mtime = now (default)
 
-        std::fs::write(
-            locks_dir.join("base-dir-test.lock"),
-            base_dir.to_str().unwrap(),
-        )
-        .unwrap();
+        write_base_dir_lock(&home, &base_dir);
 
         let summary = gc_workspace_orphans(&home, false).await.unwrap();
 
@@ -5433,11 +5427,7 @@ mod tests {
         set_mtime(&outside_workspace, old_gc_time());
         std::os::unix::fs::symlink(&outside_workspaces, base_dir.join("workspaces")).unwrap();
 
-        std::fs::write(
-            locks_dir.join("base-dir-test.lock"),
-            base_dir.to_str().unwrap(),
-        )
-        .unwrap();
+        write_base_dir_lock(&home, &base_dir);
 
         let summary = gc_workspace_orphans(&home, false).await.unwrap();
 
@@ -5469,11 +5459,7 @@ mod tests {
         set_mtime(&outside_workspace, old_gc_time());
         std::os::unix::fs::symlink(&outside_base_dir, &base_dir).unwrap();
 
-        std::fs::write(
-            locks_dir.join("base-dir-test.lock"),
-            base_dir.to_str().unwrap(),
-        )
-        .unwrap();
+        write_base_dir_lock(&home, &base_dir);
 
         let summary = gc_workspace_orphans(&home, false).await.unwrap();
 
@@ -5504,11 +5490,7 @@ mod tests {
         let workspace_link = workspaces_dir.join("run-link");
         std::os::unix::fs::symlink(&outside_workspace, &workspace_link).unwrap();
 
-        std::fs::write(
-            locks_dir.join("base-dir-test.lock"),
-            base_dir.to_str().unwrap(),
-        )
-        .unwrap();
+        write_base_dir_lock(&home, &base_dir);
 
         let summary = gc_workspace_orphans(&home, false).await.unwrap();
 
@@ -5522,18 +5504,78 @@ mod tests {
     }
 
     #[test]
-    fn discover_dead_runner_base_dirs_trims_whitespace() {
+    fn discover_dead_runner_base_dirs_rejects_hash_mismatch() {
         let dir = tempfile::tempdir().unwrap();
         let home = test_home(dir.path());
         let locks_dir = home.locks_dir();
         std::fs::create_dir_all(&locks_dir).unwrap();
 
-        // Content with trailing newline (e.g., written by shell tools)
-        std::fs::write(locks_dir.join("base-dir-ws.lock"), "/data/runner-01\n").unwrap();
+        let trimmed_base_dir = Path::new("/data/runner-01");
+        let lock_path = home.base_dir_lock(trimmed_base_dir);
+        std::fs::write(&lock_path, b"/data/runner-01\n").unwrap();
 
         let dirs = discover_dead_runner_base_dirs(&home.locks_dir());
         assert_eq!(dirs.len(), 1);
-        assert_eq!(dirs[0].base_dir, Some(PathBuf::from("/data/runner-01")));
+        assert_eq!(dirs[0].base_dir, None);
+    }
+
+    #[tokio::test]
+    async fn gc_workspace_orphans_does_not_scan_mismatched_base_dir_lock_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let locks_dir = home.locks_dir();
+        std::fs::create_dir_all(&locks_dir).unwrap();
+
+        let base_dir = dir.path().join("runner-data");
+        let workspace = base_dir.join("workspaces").join("run-old");
+        std::fs::create_dir_all(&workspace).unwrap();
+        std::fs::write(workspace.join("cow.img"), b"data").unwrap();
+        set_mtime(&workspace, old_gc_time());
+
+        let lock_path = locks_dir.join("base-dir-mismatch.lock");
+        std::fs::write(&lock_path, base_dir.as_os_str().as_encoded_bytes()).unwrap();
+
+        let summary = gc_workspace_orphans(&home, false).await.unwrap();
+
+        assert_eq!(summary.workspaces_cleaned, 0);
+        assert_eq!(summary.base_dir_locks_removed, 1);
+        assert!(
+            workspace.exists(),
+            "mismatched base-dir lock must not authorize workspace cleanup"
+        );
+        assert!(!lock_path.exists(), "mismatched lock should be removed");
+    }
+
+    #[test]
+    fn discover_dead_runner_base_dirs_preserves_trailing_space() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let locks_dir = home.locks_dir();
+        std::fs::create_dir_all(&locks_dir).unwrap();
+
+        let base_dir = PathBuf::from("/data/runner-01 ");
+        write_base_dir_lock(&home, &base_dir);
+
+        let dirs = discover_dead_runner_base_dirs(&home.locks_dir());
+        assert_eq!(dirs.len(), 1);
+        assert_eq!(dirs[0].base_dir, Some(base_dir));
+    }
+
+    #[test]
+    fn discover_dead_runner_base_dirs_accepts_non_utf8_path_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let locks_dir = home.locks_dir();
+        std::fs::create_dir_all(&locks_dir).unwrap();
+
+        let mut base_dir_bytes = b"/data/runner-".to_vec();
+        base_dir_bytes.push(0xff);
+        let base_dir = PathBuf::from(OsString::from_vec(base_dir_bytes.clone()));
+        write_base_dir_lock(&home, &base_dir);
+
+        let dirs = discover_dead_runner_base_dirs(&home.locks_dir());
+        assert_eq!(dirs.len(), 1);
+        assert_eq!(dirs[0].base_dir, Some(base_dir));
     }
 
     // -----------------------------------------------------------------------
@@ -6447,16 +6489,8 @@ mod tests {
         std::fs::write(ws_b.join("cow.img"), vec![0u8; 4096]).unwrap();
 
         // Register both in separate lock files
-        std::fs::write(
-            locks_dir.join("base-dir-aaa.lock"),
-            base_dir_a.to_str().unwrap(),
-        )
-        .unwrap();
-        std::fs::write(
-            locks_dir.join("base-dir-bbb.lock"),
-            base_dir_b.to_str().unwrap(),
-        )
-        .unwrap();
+        write_base_dir_lock(&home, &base_dir_a);
+        write_base_dir_lock(&home, &base_dir_b);
 
         // Age both workspaces past GC_MIN_AGE
         let old_time = SystemTime::now() - Duration::from_secs(3600);

--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -1626,7 +1626,14 @@ async fn gc_workspace_orphans(home: &HomePaths, dry_run: bool) -> RunnerResult<W
     // 1. Discover active workspaces from any running Firecracker process.
     //    This protects orphaned FCs whose parent runner already died but
     //    whose VM is still running.
-    let discovered = crate::process::discover_all().await;
+    let discovered = crate::process::discover_all_with_status().await;
+    if !discovered.proc_scan_complete {
+        warn!(
+            "workspace gc: process discovery scan is incomplete; skipping workspace orphan cleanup"
+        );
+        return Ok(WorkspaceGcSummary::default());
+    }
+    let discovered = discovered.processes;
     let live_runners = match crate::live_runner_instances::try_list(home).await {
         Ok(runners) => runners,
         Err(e) => {
@@ -1676,13 +1683,11 @@ async fn gc_workspace_orphans_with_leases(
     base_dirs: Vec<DeadRunnerBaseDirLease>,
     firecrackers: &[crate::process::FirecrackerProcessInfo],
     live_runner_base_dirs: &HashSet<PathBuf>,
-    firecracker_discovery_uncertain: bool,
+    process_discovery_uncertain: bool,
     dry_run: bool,
 ) -> RunnerResult<WorkspaceGcSummary> {
-    if firecracker_discovery_uncertain {
-        warn!(
-            "workspace gc: Firecracker discovery is incomplete; skipping workspace orphan cleanup"
-        );
+    if process_discovery_uncertain {
+        warn!("workspace gc: process discovery is incomplete; skipping workspace orphan cleanup");
         return Ok(WorkspaceGcSummary::default());
     }
 
@@ -4936,6 +4941,35 @@ mod tests {
         assert!(
             workspace.exists(),
             "uncertain discovery must preserve workspace"
+        );
+        assert!(lock_path.exists(), "lock must remain for a later retry");
+    }
+
+    #[tokio::test]
+    async fn gc_workspace_orphans_skips_when_process_discovery_incomplete() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let locks_dir = home.locks_dir();
+        std::fs::create_dir_all(&locks_dir).unwrap();
+
+        let base_dir = dir.path().join("runner-data");
+        let workspace = base_dir.join("workspaces").join("run-old");
+        std::fs::create_dir_all(&workspace).unwrap();
+        std::fs::write(workspace.join("cow.img"), b"data").unwrap();
+        set_mtime(&workspace, old_gc_time());
+        let lock_path = locks_dir.join("base-dir-test.lock");
+        std::fs::write(&lock_path, base_dir.to_str().unwrap()).unwrap();
+
+        let leases = discover_dead_runner_base_dirs(&home.locks_dir());
+        let summary = gc_workspace_orphans_with_leases(leases, &[], &HashSet::new(), true, false)
+            .await
+            .unwrap();
+
+        assert_eq!(summary.workspaces_cleaned, 0);
+        assert_eq!(summary.base_dir_locks_removed, 0);
+        assert!(
+            workspace.exists(),
+            "incomplete process discovery must preserve workspace"
         );
         assert!(lock_path.exists(), "lock must remain for a later retry");
     }

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -48,6 +48,11 @@ pub(crate) fn short_digest(s: &str) -> String {
     hex::encode(prefix)
 }
 
+pub(crate) fn base_dir_lock_name(base_dir: &Path) -> String {
+    let hash = hex::encode(Sha256::digest(base_dir.as_os_str().as_encoded_bytes()));
+    format!("base-dir-{hash}.lock")
+}
+
 /// Stable non-reversible label for diagnostics that need to correlate one CLI
 /// session across logs without exposing the resumable session ID.
 ///
@@ -277,8 +282,7 @@ impl HomePaths {
     }
 
     pub fn base_dir_lock(&self, base_dir: &Path) -> PathBuf {
-        let hash = hex::encode(Sha256::digest(base_dir.as_os_str().as_encoded_bytes()));
-        self.locks_dir().join(format!("base-dir-{hash}.lock"))
+        self.locks_dir().join(base_dir_lock_name(base_dir))
     }
 
     /// Lock file for a rootfs hash.

--- a/crates/runner/src/process.rs
+++ b/crates/runner/src/process.rs
@@ -11,9 +11,8 @@ mod procfs;
 mod types;
 
 pub use self::ancestry::{is_orphan, process_has_ancestor};
-pub use self::discovery::{
-    discover_all, discover_all_with_status, firecracker_process_exists_for_sandbox_id,
-};
+pub(crate) use self::discovery::discover_all_with_status;
+pub use self::discovery::{discover_all, firecracker_process_exists_for_sandbox_id};
 pub(crate) use self::discovery::{is_firecracker_cmdline, parse_workspace_cwd};
 pub use self::procfs::read_service_unit;
 pub(crate) use self::procfs::{read_cmdline, read_cwd, read_process_stat};

--- a/crates/runner/src/process.rs
+++ b/crates/runner/src/process.rs
@@ -11,7 +11,9 @@ mod procfs;
 mod types;
 
 pub use self::ancestry::{is_orphan, process_has_ancestor};
-pub use self::discovery::{discover_all, firecracker_process_exists_for_sandbox_id};
+pub use self::discovery::{
+    discover_all, discover_all_with_status, firecracker_process_exists_for_sandbox_id,
+};
 pub(crate) use self::discovery::{is_firecracker_cmdline, parse_workspace_cwd};
 pub use self::procfs::read_service_unit;
 pub(crate) use self::procfs::{read_cmdline, read_cwd, read_process_stat};

--- a/crates/runner/src/process/discovery.rs
+++ b/crates/runner/src/process/discovery.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use super::procfs::{read_cmdline, read_cwd, read_ppid, read_process_stat, scan_proc_cmdlines};
 use super::types::{
     DiscoveredProcesses, DnsmasqProcessInfo, FirecrackerProcessIdentity, FirecrackerProcessInfo,
-    MitmproxyProcessInfo, ProcessStat, process_stat_is_live,
+    MitmproxyProcessInfo, ProcessDiscovery, ProcessStat, process_stat_is_live,
 };
 
 /// Check if an argv belongs to a firecracker process.
@@ -253,13 +253,21 @@ async fn resolve_firecracker_candidate(pid: u32) -> FirecrackerCandidateResoluti
 /// Live runner identity is published by `live_runner_instances`; this scan
 /// intentionally does not infer runner identity from argv.
 pub async fn discover_all() -> DiscoveredProcesses {
-    let procs = scan_proc_cmdlines().await;
+    discover_all_with_status().await.processes
+}
+
+/// Scan `/proc` once and include whether the top-level process scan completed.
+///
+/// Destructive cleanup code should use this variant so it can fail closed when
+/// `/proc` could not be scanned reliably.
+pub async fn discover_all_with_status() -> ProcessDiscovery {
+    let proc_scan = scan_proc_cmdlines().await;
 
     let mut firecrackers = Vec::new();
     let mut mitmdumps = Vec::new();
     let mut dnsmasqs = Vec::new();
 
-    for (pid, argv) in &procs {
+    for (pid, argv) in &proc_scan.entries {
         if is_firecracker_cmdline(argv) {
             firecrackers.push(*pid);
         }
@@ -286,10 +294,13 @@ pub async fn discover_all() -> DiscoveredProcesses {
         mitm_infos.push(MitmproxyProcessInfo { pid, ppid, port });
     }
 
-    DiscoveredProcesses {
-        firecrackers: fc_infos,
-        mitmdumps: mitm_infos,
-        dnsmasqs,
+    ProcessDiscovery {
+        processes: DiscoveredProcesses {
+            firecrackers: fc_infos,
+            mitmdumps: mitm_infos,
+            dnsmasqs,
+        },
+        proc_scan_complete: proc_scan.complete,
     }
 }
 

--- a/crates/runner/src/process/discovery.rs
+++ b/crates/runner/src/process/discovery.rs
@@ -260,7 +260,7 @@ pub async fn discover_all() -> DiscoveredProcesses {
 ///
 /// Destructive cleanup code should use this variant so it can fail closed when
 /// `/proc` could not be scanned reliably.
-pub async fn discover_all_with_status() -> ProcessDiscovery {
+pub(crate) async fn discover_all_with_status() -> ProcessDiscovery {
     let proc_scan = scan_proc_cmdlines().await;
 
     let mut firecrackers = Vec::new();

--- a/crates/runner/src/process/procfs.rs
+++ b/crates/runner/src/process/procfs.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use super::types::ProcessStat;
 
+#[derive(Debug, Eq, PartialEq)]
 enum CmdlineRead {
     Args(Vec<String>),
     Ignored,
@@ -36,27 +37,35 @@ pub(crate) async fn read_cmdline(pid: u32) -> Option<Vec<String>> {
 async fn read_cmdline_for_scan(pid: u32) -> CmdlineRead {
     let path = format!("/proc/{pid}/cmdline");
     match tokio::fs::read(&path).await {
-        Ok(bytes) => parse_cmdline_bytes(&bytes)
-            .map(CmdlineRead::Args)
-            .unwrap_or(CmdlineRead::Ignored),
+        Ok(bytes) => match parse_cmdline_bytes(&bytes) {
+            Some(argv) => CmdlineRead::Args(argv),
+            None => cmdline_problem_for_scan(pid, "cmdline is empty or NUL-free").await,
+        },
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => CmdlineRead::Missing,
-        Err(e) => cmdline_error_for_scan(pid, e).await,
+        Err(e) => {
+            let problem = format!("cmdline read failed: {e}");
+            cmdline_problem_for_scan(pid, &problem).await
+        }
     }
 }
 
-async fn cmdline_error_for_scan(pid: u32, cmdline_error: std::io::Error) -> CmdlineRead {
-    match read_process_comm_for_scan(pid).await {
+async fn cmdline_problem_for_scan(pid: u32, problem: &str) -> CmdlineRead {
+    cmdline_problem_for_comm(read_process_comm_for_scan(pid).await, problem)
+}
+
+fn cmdline_problem_for_comm(comm_read: ProcessCommRead, problem: &str) -> CmdlineRead {
+    match comm_read {
         ProcessCommRead::Name(comm) if comm == b"firecracker" => {
-            CmdlineRead::Unreadable(cmdline_error.to_string())
+            CmdlineRead::Unreadable(problem.to_string())
         }
         ProcessCommRead::Name(_) => CmdlineRead::Ignored,
         ProcessCommRead::Missing => CmdlineRead::Missing,
-        ProcessCommRead::Unreadable(stat_error) => CmdlineRead::Unreadable(format!(
-            "cmdline read failed: {cmdline_error}; stat read failed: {stat_error}"
-        )),
-        ProcessCommRead::Invalid => CmdlineRead::Unreadable(format!(
-            "cmdline read failed: {cmdline_error}; stat parse failed"
-        )),
+        ProcessCommRead::Unreadable(stat_error) => {
+            CmdlineRead::Unreadable(format!("{problem}; stat read failed: {stat_error}"))
+        }
+        ProcessCommRead::Invalid => {
+            CmdlineRead::Unreadable(format!("{problem}; stat parse failed"))
+        }
     }
 }
 
@@ -274,6 +283,28 @@ mod tests {
     #[test]
     fn parse_cmdline_bytes_rejects_all_empty_segments() {
         assert_eq!(parse_cmdline_bytes(b"\0\0"), None);
+    }
+
+    #[test]
+    fn cmdline_problem_for_firecracker_comm_is_unreadable() {
+        assert_eq!(
+            cmdline_problem_for_comm(
+                ProcessCommRead::Name(b"firecracker".to_vec()),
+                "cmdline is empty or NUL-free",
+            ),
+            CmdlineRead::Unreadable("cmdline is empty or NUL-free".to_string())
+        );
+    }
+
+    #[test]
+    fn cmdline_problem_for_non_firecracker_comm_is_ignored() {
+        assert_eq!(
+            cmdline_problem_for_comm(
+                ProcessCommRead::Name(b"postgres".to_vec()),
+                "cmdline is empty or NUL-free",
+            ),
+            CmdlineRead::Ignored
+        );
     }
 
     #[test]

--- a/crates/runner/src/process/procfs.rs
+++ b/crates/runner/src/process/procfs.rs
@@ -6,7 +6,7 @@ enum CmdlineRead {
     Args(Vec<String>),
     Ignored,
     Missing,
-    Unreadable(std::io::Error),
+    Unreadable(String),
 }
 
 fn parse_cmdline_bytes(bytes: &[u8]) -> Option<Vec<String>> {
@@ -40,7 +40,23 @@ async fn read_cmdline_for_scan(pid: u32) -> CmdlineRead {
             .map(CmdlineRead::Args)
             .unwrap_or(CmdlineRead::Ignored),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => CmdlineRead::Missing,
-        Err(e) => CmdlineRead::Unreadable(e),
+        Err(e) => cmdline_error_for_scan(pid, e).await,
+    }
+}
+
+async fn cmdline_error_for_scan(pid: u32, cmdline_error: std::io::Error) -> CmdlineRead {
+    match read_process_comm_for_scan(pid).await {
+        ProcessCommRead::Name(comm) if comm == b"firecracker" => {
+            CmdlineRead::Unreadable(cmdline_error.to_string())
+        }
+        ProcessCommRead::Name(_) => CmdlineRead::Ignored,
+        ProcessCommRead::Missing => CmdlineRead::Missing,
+        ProcessCommRead::Unreadable(stat_error) => CmdlineRead::Unreadable(format!(
+            "cmdline read failed: {cmdline_error}; stat read failed: {stat_error}"
+        )),
+        ProcessCommRead::Invalid => CmdlineRead::Unreadable(format!(
+            "cmdline read failed: {cmdline_error}; stat parse failed"
+        )),
     }
 }
 
@@ -64,6 +80,33 @@ fn stat_fields_after_comm(content: &[u8]) -> Option<impl Iterator<Item = &[u8]> 
             .split(|byte| byte.is_ascii_whitespace())
             .filter(|field| !field.is_empty()),
     )
+}
+
+fn process_comm(content: &[u8]) -> Option<&[u8]> {
+    let open_paren = content.iter().position(|byte| *byte == b'(')?;
+    let close_paren = content.iter().rposition(|byte| *byte == b')')?;
+    if close_paren <= open_paren {
+        return None;
+    }
+    content.get(open_paren + 1..close_paren)
+}
+
+enum ProcessCommRead {
+    Name(Vec<u8>),
+    Missing,
+    Unreadable(std::io::Error),
+    Invalid,
+}
+
+async fn read_process_comm_for_scan(pid: u32) -> ProcessCommRead {
+    let path = format!("/proc/{pid}/stat");
+    match tokio::fs::read(&path).await {
+        Ok(content) => process_comm(&content)
+            .map(|comm| ProcessCommRead::Name(comm.to_vec()))
+            .unwrap_or(ProcessCommRead::Invalid),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => ProcessCommRead::Missing,
+        Err(e) => ProcessCommRead::Unreadable(e),
+    }
 }
 
 fn parse_char_field(field: &[u8]) -> Option<char> {
@@ -231,6 +274,29 @@ mod tests {
     #[test]
     fn parse_cmdline_bytes_rejects_all_empty_segments() {
         assert_eq!(parse_cmdline_bytes(b"\0\0"), None);
+    }
+
+    #[test]
+    fn process_comm_extracts_comm_with_spaces_and_parens() {
+        let stat = stat_with_comm("firecracker (worker)", "S", "1100", "123456");
+
+        assert_eq!(
+            process_comm(stat.as_bytes()),
+            Some(&b"firecracker (worker)"[..])
+        );
+    }
+
+    #[test]
+    fn process_comm_accepts_non_utf8_comm() {
+        let stat = stat_bytes_with_comm(b"firecracker\xff", "S", "1100", "123456");
+
+        assert_eq!(process_comm(&stat), Some(&b"firecracker\xff"[..]));
+    }
+
+    #[test]
+    fn process_comm_rejects_missing_delimiters() {
+        assert_eq!(process_comm(b"1234 firecracker) S 1 1"), None);
+        assert_eq!(process_comm(b"1234 (firecracker S 1 1"), None);
     }
 
     #[test]

--- a/crates/runner/src/process/procfs.rs
+++ b/crates/runner/src/process/procfs.rs
@@ -116,14 +116,24 @@ pub async fn read_service_unit(pid: u32) -> Option<String> {
 
 /// Scan `/proc` for all process argvs.
 ///
-/// Returns `(pid, argv)` pairs for every readable process.
-pub(super) async fn scan_proc_cmdlines() -> Vec<(u32, Vec<String>)> {
+/// Returns `(pid, argv)` pairs for every readable process plus whether the
+/// top-level directory scan completed without errors.
+pub(super) struct ProcCmdlineScan {
+    pub(super) entries: Vec<(u32, Vec<String>)>,
+    pub(super) complete: bool,
+}
+
+pub(super) async fn scan_proc_cmdlines() -> ProcCmdlineScan {
     let mut result = Vec::new();
+    let mut complete = true;
     let mut entries = match tokio::fs::read_dir("/proc").await {
         Ok(e) => e,
         Err(e) => {
             tracing::warn!("scan_proc_cmdlines: cannot read /proc: {e}");
-            return result;
+            return ProcCmdlineScan {
+                entries: result,
+                complete: false,
+            };
         }
     };
     loop {
@@ -132,6 +142,7 @@ pub(super) async fn scan_proc_cmdlines() -> Vec<(u32, Vec<String>)> {
             Ok(None) => break,
             Err(e) => {
                 tracing::warn!("scan_proc_cmdlines: read entry in /proc: {e}");
+                complete = false;
                 continue;
             }
         };
@@ -146,7 +157,10 @@ pub(super) async fn scan_proc_cmdlines() -> Vec<(u32, Vec<String>)> {
             result.push((pid, argv));
         }
     }
-    result
+    ProcCmdlineScan {
+        entries: result,
+        complete,
+    }
 }
 
 #[cfg(test)]

--- a/crates/runner/src/process/procfs.rs
+++ b/crates/runner/src/process/procfs.rs
@@ -2,15 +2,14 @@ use std::path::PathBuf;
 
 use super::types::ProcessStat;
 
-/// Read `/proc/{pid}/cmdline` as the NUL-separated argv.
-///
-/// Returns `None` for kernel threads (empty cmdline) and for processes whose
-/// cmdline has been rewritten (via `prctl(PR_SET_NAME)` or similar) into a
-/// single NUL-free blob — those aren't the exec-spawned processes we care
-/// about identifying here.
-pub(crate) async fn read_cmdline(pid: u32) -> Option<Vec<String>> {
-    let path = format!("/proc/{pid}/cmdline");
-    let bytes = tokio::fs::read(&path).await.ok()?;
+enum CmdlineRead {
+    Args(Vec<String>),
+    Ignored,
+    Missing,
+    Unreadable(std::io::Error),
+}
+
+fn parse_cmdline_bytes(bytes: &[u8]) -> Option<Vec<String>> {
     if bytes.is_empty() || !bytes.contains(&0) {
         return None;
     }
@@ -20,6 +19,29 @@ pub(crate) async fn read_cmdline(pid: u32) -> Option<Vec<String>> {
         .map(|s| String::from_utf8_lossy(s).into_owned())
         .collect();
     if argv.is_empty() { None } else { Some(argv) }
+}
+
+/// Read `/proc/{pid}/cmdline` as the NUL-separated argv.
+///
+/// Returns `None` for kernel threads (empty cmdline) and for processes whose
+/// cmdline has been rewritten (via `prctl(PR_SET_NAME)` or similar) into a
+/// single NUL-free blob — those aren't the exec-spawned processes we care
+/// about identifying here.
+pub(crate) async fn read_cmdline(pid: u32) -> Option<Vec<String>> {
+    let path = format!("/proc/{pid}/cmdline");
+    let bytes = tokio::fs::read(&path).await.ok()?;
+    parse_cmdline_bytes(&bytes)
+}
+
+async fn read_cmdline_for_scan(pid: u32) -> CmdlineRead {
+    let path = format!("/proc/{pid}/cmdline");
+    match tokio::fs::read(&path).await {
+        Ok(bytes) => parse_cmdline_bytes(&bytes)
+            .map(CmdlineRead::Args)
+            .unwrap_or(CmdlineRead::Ignored),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => CmdlineRead::Missing,
+        Err(e) => CmdlineRead::Unreadable(e),
+    }
 }
 
 /// Read `/proc/{pid}/stat` and extract the PPid field.
@@ -153,8 +175,13 @@ pub(super) async fn scan_proc_cmdlines() -> ProcCmdlineScan {
         let Ok(pid) = name_str.parse::<u32>() else {
             continue;
         };
-        if let Some(argv) = read_cmdline(pid).await {
-            result.push((pid, argv));
+        match read_cmdline_for_scan(pid).await {
+            CmdlineRead::Args(argv) => result.push((pid, argv)),
+            CmdlineRead::Ignored | CmdlineRead::Missing => {}
+            CmdlineRead::Unreadable(e) => {
+                tracing::warn!("scan_proc_cmdlines: cannot read /proc/{pid}/cmdline: {e}");
+                complete = false;
+            }
         }
     }
     ProcCmdlineScan {
@@ -185,6 +212,25 @@ mod tests {
         stat.extend_from_slice(b") ");
         stat.extend_from_slice(fields.join(" ").as_bytes());
         stat
+    }
+
+    #[test]
+    fn parse_cmdline_bytes_accepts_nul_separated_argv() {
+        assert_eq!(
+            parse_cmdline_bytes(b"firecracker\0--no-api\0"),
+            Some(vec!["firecracker".to_string(), "--no-api".to_string()])
+        );
+    }
+
+    #[test]
+    fn parse_cmdline_bytes_rejects_empty_or_nul_free_content() {
+        assert_eq!(parse_cmdline_bytes(b""), None);
+        assert_eq!(parse_cmdline_bytes(b"firecracker"), None);
+    }
+
+    #[test]
+    fn parse_cmdline_bytes_rejects_all_empty_segments() {
+        assert_eq!(parse_cmdline_bytes(b"\0\0"), None);
     }
 
     #[test]

--- a/crates/runner/src/process/procfs.rs
+++ b/crates/runner/src/process/procfs.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use super::types::ProcessStat;
+use super::types::{ProcessStat, process_stat_is_live};
 
 #[derive(Debug, Eq, PartialEq)]
 enum CmdlineRead {
@@ -55,10 +55,14 @@ async fn cmdline_problem_for_scan(pid: u32, problem: &str) -> CmdlineRead {
 
 fn cmdline_problem_for_comm(comm_read: ProcessCommRead, problem: &str) -> CmdlineRead {
     match comm_read {
-        ProcessCommRead::Name(comm) if comm == b"firecracker" => {
-            CmdlineRead::Unreadable(problem.to_string())
+        ProcessCommRead::Name {
+            comm,
+            live: Some(true),
+        } if comm == b"firecracker" => CmdlineRead::Unreadable(problem.to_string()),
+        ProcessCommRead::Name { comm, live: None } if comm == b"firecracker" => {
+            CmdlineRead::Unreadable(format!("{problem}; stat parse failed"))
         }
-        ProcessCommRead::Name(_) => CmdlineRead::Ignored,
+        ProcessCommRead::Name { .. } => CmdlineRead::Ignored,
         ProcessCommRead::Missing => CmdlineRead::Missing,
         ProcessCommRead::Unreadable(stat_error) => {
             CmdlineRead::Unreadable(format!("{problem}; stat read failed: {stat_error}"))
@@ -101,7 +105,7 @@ fn process_comm(content: &[u8]) -> Option<&[u8]> {
 }
 
 enum ProcessCommRead {
-    Name(Vec<u8>),
+    Name { comm: Vec<u8>, live: Option<bool> },
     Missing,
     Unreadable(std::io::Error),
     Invalid,
@@ -110,9 +114,15 @@ enum ProcessCommRead {
 async fn read_process_comm_for_scan(pid: u32) -> ProcessCommRead {
     let path = format!("/proc/{pid}/stat");
     match tokio::fs::read(&path).await {
-        Ok(content) => process_comm(&content)
-            .map(|comm| ProcessCommRead::Name(comm.to_vec()))
-            .unwrap_or(ProcessCommRead::Invalid),
+        Ok(content) => {
+            let Some(comm) = process_comm(&content) else {
+                return ProcessCommRead::Invalid;
+            };
+            ProcessCommRead::Name {
+                comm: comm.to_vec(),
+                live: parse_process_stat(&content).map(|stat| process_stat_is_live(&stat)),
+            }
+        }
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => ProcessCommRead::Missing,
         Err(e) => ProcessCommRead::Unreadable(e),
     }
@@ -289,7 +299,10 @@ mod tests {
     fn cmdline_problem_for_firecracker_comm_is_unreadable() {
         assert_eq!(
             cmdline_problem_for_comm(
-                ProcessCommRead::Name(b"firecracker".to_vec()),
+                ProcessCommRead::Name {
+                    comm: b"firecracker".to_vec(),
+                    live: Some(true),
+                },
                 "cmdline is empty or NUL-free",
             ),
             CmdlineRead::Unreadable("cmdline is empty or NUL-free".to_string())
@@ -297,10 +310,41 @@ mod tests {
     }
 
     #[test]
+    fn cmdline_problem_for_zombie_firecracker_comm_is_ignored() {
+        assert_eq!(
+            cmdline_problem_for_comm(
+                ProcessCommRead::Name {
+                    comm: b"firecracker".to_vec(),
+                    live: Some(false),
+                },
+                "cmdline is empty or NUL-free",
+            ),
+            CmdlineRead::Ignored
+        );
+    }
+
+    #[test]
+    fn cmdline_problem_for_firecracker_comm_with_invalid_stat_is_unreadable() {
+        assert_eq!(
+            cmdline_problem_for_comm(
+                ProcessCommRead::Name {
+                    comm: b"firecracker".to_vec(),
+                    live: None,
+                },
+                "cmdline is empty or NUL-free",
+            ),
+            CmdlineRead::Unreadable("cmdline is empty or NUL-free; stat parse failed".to_string())
+        );
+    }
+
+    #[test]
     fn cmdline_problem_for_non_firecracker_comm_is_ignored() {
         assert_eq!(
             cmdline_problem_for_comm(
-                ProcessCommRead::Name(b"postgres".to_vec()),
+                ProcessCommRead::Name {
+                    comm: b"postgres".to_vec(),
+                    live: Some(true),
+                },
                 "cmdline is empty or NUL-free",
             ),
             CmdlineRead::Ignored

--- a/crates/runner/src/process/types.rs
+++ b/crates/runner/src/process/types.rs
@@ -69,3 +69,9 @@ pub struct DiscoveredProcesses {
     pub mitmdumps: Vec<MitmproxyProcessInfo>,
     pub dnsmasqs: Vec<DnsmasqProcessInfo>,
 }
+
+/// Process discovery plus whether the top-level `/proc` scan completed.
+pub struct ProcessDiscovery {
+    pub processes: DiscoveredProcesses,
+    pub proc_scan_complete: bool,
+}

--- a/crates/runner/src/process/types.rs
+++ b/crates/runner/src/process/types.rs
@@ -71,7 +71,7 @@ pub struct DiscoveredProcesses {
 }
 
 /// Process discovery plus whether the top-level `/proc` scan completed.
-pub struct ProcessDiscovery {
-    pub processes: DiscoveredProcesses,
-    pub proc_scan_complete: bool,
+pub(crate) struct ProcessDiscovery {
+    pub(crate) processes: DiscoveredProcesses,
+    pub(crate) proc_scan_complete: bool,
 }


### PR DESCRIPTION
## Summary

Closes #19221.

This hardens runner workspace orphan GC so it does not delete live Firecracker workspaces when process discovery is incomplete, when a base-dir lock can be raced by another runner, or when corrupted base-dir lock metadata points at a directory the lock does not actually own.

## Changes

- Keep the free `base-dir-*.lock` guard alive while scanning and deleting workspaces under that base dir.
- Enumerate base-dir lock candidates without holding all lock fds, then acquire/process/release each candidate separately so old lock backlogs cannot exhaust the runner fd limit during GC.
- Probe enumerated base-dir lock candidates as existing-only paths so GC does not recreate a lock that disappeared after discovery, including in dry-run mode.
- Read base-dir lock content as raw Unix path bytes, preserving non-UTF-8 paths and legal trailing spaces instead of forcing UTF-8 and trimming.
- Validate the base-dir lock file name against the base_dir content hash before scanning that base_dir; mismatched/corrupted locks are treated as unusable retry metadata and removed only while their own lock is free.
- Share the base-dir lock-name helper between `HomePaths` and workspace GC so the writer and validator cannot drift.
- Treat incomplete Firecracker workspace discovery as unsafe unless the process can be attributed to a live runner.
- Treat incomplete `/proc` process discovery as unsafe for workspace GC:
  - top-level `/proc` scan errors make workspace GC fail closed
  - unreadable `/proc/{pid}/cmdline` entries are checked against `/proc/{pid}/stat` comm so unreadable non-Firecracker processes do not starve workspace GC
  - empty or NUL-free cmdline content is also checked against comm and process state; live Firecracker comm makes workspace GC fail closed, while zombie/exit Firecracker state is ignored so stale proc entries do not permanently block cleanup
  - unreadable or invalid stat data after an unreadable/malformed cmdline still makes workspace GC fail closed
  - process disappearance during scan is still treated as a normal transient and does not block GC
- Skip live runner base dirs defensively even if a lock anomaly exposes them as candidates.
- Move `base-dir-*.lock` cleanup out of generic orphan lock GC and remove those locks only after workspace GC proves the base dir is empty/missing or fully cleaned.
- Clean free base-dir locks with empty, whitespace-only, non-absolute, or hash-mismatched base-dir content so unusable retry metadata does not accumulate indefinitely.
- Keep the new process-discovery status API crate-private.
- Add regression coverage for held leases, candidate discovery not holding locks, disappeared candidate locks, incomplete process/Firecracker discovery, active workspace preservation, live runner base-dir protection, unusable lock cleanup, raw base-dir lock path bytes, mismatched lock-name rejection, malformed live Firecracker cmdline handling, zombie Firecracker cmdline gaps, base-dir lock lifecycle, and process `comm` parsing.

## Verification

- `cargo test --manifest-path crates/Cargo.toml -p runner process::procfs --quiet`
- `cargo test --manifest-path crates/Cargo.toml -p runner process::discovery --quiet`
- `cargo test --manifest-path crates/Cargo.toml -p runner process::`
- `cargo test --manifest-path crates/Cargo.toml -p runner gc_workspace_orphans`
- `cargo test --manifest-path crates/Cargo.toml -p runner gc_orphaned_locks`
- `cargo test --manifest-path crates/Cargo.toml -p runner discover_dead_runner_base_dirs`
- `cargo test --manifest-path crates/Cargo.toml -p runner base_dir_lock`
- `cargo test --manifest-path crates/Cargo.toml -p runner gc_workspace_orphans_does_not_recreate_missing_candidate_lock`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p runner --quiet` (2190 passed, 2 ignored)
- `git diff --check`
