### PR TITLE
fix: bound codex session cleanup traversal

### DIFF
--- a/crates/guest-mock-codex/tests/integration.rs
+++ b/crates/guest-mock-codex/tests/integration.rs
@@ -1588,6 +1588,38 @@ fn resume_rejects_duplicate_matching_sessions_without_events() -> std::io::Resul
 }
 
 #[test]
+fn resume_rejects_duplicate_matching_session_in_non_layout_tree_without_events()
+-> std::io::Result<()> {
+    let dir = TempDir::new().unwrap();
+    let thread_id = "0199a213-81c0-7800-8aa1-bbab2a035a53";
+    let layout_path = dir
+        .path()
+        .join(format!("sessions/2001/01/01/{thread_id}.jsonl"));
+    let non_layout_path = dir.path().join(format!(
+        "sessions/not-layout/deep/rollout-restored-{thread_id}.jsonl"
+    ));
+    write_session_file(&layout_path, &build_events(thread_id, "layout"))?;
+    write_session_file(&non_layout_path, &build_events(thread_id, "non-layout"))?;
+
+    let out = run(dir.path(), &["exec", "resume", thread_id, "--", "turn-3"])?;
+
+    assert_ne!(out.status, 0);
+    assert!(
+        out.events.is_empty(),
+        "non-layout duplicate should fail before emitting events: {:?}",
+        out.events
+    );
+    assert!(
+        out.stderr.contains("multiple session files found"),
+        "resume should report duplicate session files: {:?}",
+        out.stderr
+    );
+    assert_eq!(read_session_file(&layout_path)?.len(), 3);
+    assert_eq!(read_session_file(&non_layout_path)?.len(), 3);
+    Ok(())
+}
+
+#[test]
 fn resume_preserves_stale_fixed_temp_file() -> std::io::Result<()> {
     let dir = TempDir::new().unwrap();
     let thread_id = "0199a213-81c0-7800-8aa1-bbab2a035a53";

--- a/crates/runner/scripts/codex-session-cleanup.sh
+++ b/crates/runner/scripts/codex-session-cleanup.sh
@@ -80,8 +80,18 @@ if [ "$scan_budget" -eq 0 ]; then
   echo "invalid codex session cleanup scan budget" >&2
   exit 1
 fi
-id_lc=$(printf '%s' "$id" | tr '[:upper:]' '[:lower:]')
-id_no_dashes_lc=$(printf '%s' "$id_no_dashes" | tr '[:upper:]' '[:lower:]')
+id_lc=$(printf '%s' "$id" | tr '[:upper:]' '[:lower:]') || {
+  echo "failed to normalize codex restore session id" >&2
+  exit 1
+}
+id_no_dashes_lc=$(printf '%s' "$id_no_dashes" | tr '[:upper:]' '[:lower:]') || {
+  echo "failed to normalize codex restore session id" >&2
+  exit 1
+}
+if [ "${#id_lc}" -ne 36 ] || [ "${#id_no_dashes_lc}" -ne 32 ]; then
+  echo "failed to normalize codex restore session id" >&2
+  exit 1
+fi
 # Codex resume can see matching session files anywhere below sessions; the
 # explicit entry budget keeps that required duplicate cleanup bounded.
 scan_error_file=""

--- a/crates/runner/scripts/codex-session-cleanup.sh
+++ b/crates/runner/scripts/codex-session-cleanup.sh
@@ -133,9 +133,6 @@ collect_matching_session_entries() {
         }
         filename_matches($0) {
           printf "%s%c", $0, 0 >> matches_file
-          if (ERRNO != "") {
-            exit 1
-          }
         }
       '
   scan_status=$?

--- a/crates/runner/scripts/codex-session-cleanup.sh
+++ b/crates/runner/scripts/codex-session-cleanup.sh
@@ -63,15 +63,89 @@ if [ "${#id_no_dashes}" -ne 32 ]; then
   echo "invalid codex restore session id" >&2
   exit 1
 fi
+scan_budget="${VM0_CODEX_SESSION_CLEANUP_SCAN_BUDGET:-16384}"
+case "$scan_budget" in
+  ""|*[!0123456789]*)
+    echo "invalid codex session cleanup scan budget" >&2
+    exit 1
+    ;;
+esac
+case "$scan_budget" in
+  ???????*)
+    echo "invalid codex session cleanup scan budget" >&2
+    exit 1
+    ;;
+esac
+if [ "$scan_budget" -eq 0 ]; then
+  echo "invalid codex session cleanup scan budget" >&2
+  exit 1
+fi
+id_lc=$(printf '%s' "$id" | tr '[:upper:]' '[:lower:]')
+id_no_dashes_lc=$(printf '%s' "$id_no_dashes" | tr '[:upper:]' '[:lower:]')
+scanned_entries=0
+check_scan_budget() {
+  scanned_entries=$((scanned_entries + 1))
+  if [ "$scanned_entries" -gt "$scan_budget" ]; then
+    echo "codex session cleanup exceeded scan budget" >&2
+    exit 1
+  fi
+}
+ensure_scannable_session_dir() {
+  dir="$1"
+  if [ ! -r "$dir" ] || [ ! -x "$dir" ]; then
+    echo "cannot scan codex session directory: $dir" >&2
+    exit 1
+  fi
+}
+session_filename_matches() {
+  name="${1##*/}"
+  case "$name" in
+    *[ABCDEFGHIJKLMNOPQRSTUVWXYZ]*)
+      name=$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')
+      ;;
+  esac
+  case "$name" in
+    *"$id_lc"*.jsonl|*"$id_lc"*.jsonl.zst|*"$id_lc"*.jsonl.vm0tmp-*|*"$id_lc"*.jsonl.zst.vm0tmp-*|*"$id_no_dashes_lc"*.jsonl|*"$id_no_dashes_lc"*.jsonl.zst|*"$id_no_dashes_lc"*.jsonl.vm0tmp-*|*"$id_no_dashes_lc"*.jsonl.zst.vm0tmp-*)
+      return 0
+      ;;
+  esac
+  return 1
+}
+delete_matching_session_entry() {
+  path="$1"
+  if [ ! -f "$path" ] && [ ! -L "$path" ]; then
+    return
+  fi
+  if session_filename_matches "$path"; then
+    rm -f -- "$path" || {
+      echo "failed to delete codex session file: $path" >&2
+      exit 1
+    }
+  fi
+}
+# Codex resume can see matching session files anywhere below sessions; the
+# explicit entry budget keeps that required duplicate cleanup bounded.
+scan_session_tree() {
+  dir="$1"
+  action="$2"
+  ensure_scannable_session_dir "$dir"
+  for path in "$dir"/* "$dir"/.[!.]* "$dir"/..?*; do
+    if [ ! -e "$path" ] && [ ! -L "$path" ]; then
+      continue
+    fi
+    check_scan_budget
+    case "$action" in
+      delete)
+        delete_matching_session_entry "$path"
+        ;;
+    esac
+    if [ -d "$path" ] && [ ! -L "$path" ]; then
+      scan_session_tree "$path" "$action"
+    fi
+  done
+}
 if [ -d "$root" ]; then
-  find "$root" \( -type f -o -type l \) \( \
-    -iname "*${id}*.jsonl" -o \
-    -iname "*${id}*.jsonl.zst" -o \
-    -iname "*${id}*.jsonl.vm0tmp-*" -o \
-    -iname "*${id}*.jsonl.zst.vm0tmp-*" -o \
-    -iname "*${id_no_dashes}*.jsonl" -o \
-    -iname "*${id_no_dashes}*.jsonl.zst" -o \
-    -iname "*${id_no_dashes}*.jsonl.vm0tmp-*" -o \
-    -iname "*${id_no_dashes}*.jsonl.zst.vm0tmp-*" \
-  \) -delete
+  scan_session_tree "$root" validate
+  scanned_entries=0
+  scan_session_tree "$root" delete
 fi

--- a/crates/runner/scripts/codex-session-cleanup.sh
+++ b/crates/runner/scripts/codex-session-cleanup.sh
@@ -85,9 +85,13 @@ id_no_dashes_lc=$(printf '%s' "$id_no_dashes" | tr '[:upper:]' '[:lower:]')
 # Codex resume can see matching session files anywhere below sessions; the
 # explicit entry budget keeps that required duplicate cleanup bounded.
 scan_error_file=""
+matching_entries_file=""
 cleanup_scan_error_file() {
   if [ -n "$scan_error_file" ]; then
     rm -f -- "$scan_error_file"
+  fi
+  if [ -n "$matching_entries_file" ]; then
+    rm -f -- "$matching_entries_file"
   fi
 }
 cleanup_scan_error_file_and_exit() {
@@ -96,27 +100,51 @@ cleanup_scan_error_file_and_exit() {
 }
 trap cleanup_scan_error_file EXIT
 trap cleanup_scan_error_file_and_exit HUP INT TERM
-count_session_entries() {
+collect_matching_session_entries() {
   : > "$scan_error_file" || {
     echo "failed to reset codex session cleanup temp file" >&2
     exit 1
   }
-  entry_count=$(
-    find "$root" -mindepth 1 -print 2>"$scan_error_file" |
-      awk -v budget="$scan_budget" '
-        NR > budget {
-          print NR
-          exit
+  : > "$matching_entries_file" || {
+    echo "failed to reset codex session cleanup temp file" >&2
+    exit 1
+  }
+  find "$root" -mindepth 1 -print0 2>"$scan_error_file" |
+    awk -v RS='\0' \
+      -v budget="$scan_budget" \
+      -v id="$id_lc" \
+      -v id_no_dashes="$id_no_dashes_lc" \
+      -v matches_file="$matching_entries_file" '
+        function id_pattern_matches(name, key) {
+          return name ~ key ".*\\.jsonl$" ||
+            name ~ key ".*\\.jsonl\\.zst$" ||
+            name ~ key ".*\\.jsonl\\.vm0tmp-" ||
+            name ~ key ".*\\.jsonl\\.zst\\.vm0tmp-"
         }
-        END {
-          if (NR <= budget) {
-            print NR
+        function filename_matches(path, name) {
+          name = path
+          sub(/^.*\//, "", name)
+          name = tolower(name)
+          return id_pattern_matches(name, id) ||
+            id_pattern_matches(name, id_no_dashes)
+        }
+        NR > budget {
+          exit 42
+        }
+        filename_matches($0) {
+          printf "%s%c", $0, 0 >> matches_file
+          if (ERRNO != "") {
+            exit 1
           }
         }
       '
-  )
-  if [ "$entry_count" -gt "$scan_budget" ]; then
+  scan_status=$?
+  if [ "$scan_status" -eq 42 ]; then
     echo "codex session cleanup exceeded scan budget" >&2
+    exit 1
+  fi
+  if [ "$scan_status" -ne 0 ]; then
+    echo "cannot scan codex session directory" >&2
     exit 1
   fi
   if [ -s "$scan_error_file" ]; then
@@ -125,33 +153,29 @@ count_session_entries() {
   fi
 }
 delete_matching_session_entries() {
-  : > "$scan_error_file" || {
-    echo "failed to reset codex session cleanup temp file" >&2
+  if [ ! -s "$matching_entries_file" ]; then
+    return
+  fi
+  xargs -0 sh -c '
+    for path do
+      if [ -f "$path" ] || [ -L "$path" ]; then
+        rm -f -- "$path" || exit 1
+      fi
+    done
+  ' sh < "$matching_entries_file" || {
+    echo "failed to delete codex session files" >&2
     exit 1
   }
-  if ! find "$root" \( -type f -o -type l \) \( \
-    -iname "*${id_lc}*.jsonl" -o \
-    -iname "*${id_lc}*.jsonl.zst" -o \
-    -iname "*${id_lc}*.jsonl.vm0tmp-*" -o \
-    -iname "*${id_lc}*.jsonl.zst.vm0tmp-*" -o \
-    -iname "*${id_no_dashes_lc}*.jsonl" -o \
-    -iname "*${id_no_dashes_lc}*.jsonl.zst" -o \
-    -iname "*${id_no_dashes_lc}*.jsonl.vm0tmp-*" -o \
-    -iname "*${id_no_dashes_lc}*.jsonl.zst.vm0tmp-*" \
-  \) -delete 2>"$scan_error_file"; then
-    echo "failed to delete codex session files" >&2
-    exit 1
-  fi
-  if [ -s "$scan_error_file" ]; then
-    echo "failed to delete codex session files" >&2
-    exit 1
-  fi
 }
 if [ -d "$root" ]; then
   scan_error_file=$(mktemp "${TMPDIR:-/tmp}/codex-session-cleanup.XXXXXX") || {
     echo "failed to create codex session cleanup temp file" >&2
     exit 1
   }
-  count_session_entries
+  matching_entries_file=$(mktemp "${TMPDIR:-/tmp}/codex-session-cleanup.XXXXXX") || {
+    echo "failed to create codex session cleanup temp file" >&2
+    exit 1
+  }
+  collect_matching_session_entries
   delete_matching_session_entries
 fi

--- a/crates/runner/scripts/codex-session-cleanup.sh
+++ b/crates/runner/scripts/codex-session-cleanup.sh
@@ -82,77 +82,76 @@ if [ "$scan_budget" -eq 0 ]; then
 fi
 id_lc=$(printf '%s' "$id" | tr '[:upper:]' '[:lower:]')
 id_no_dashes_lc=$(printf '%s' "$id_no_dashes" | tr '[:upper:]' '[:lower:]')
-scanned_entries=0
-check_scan_budget() {
-  scanned_entries=$((scanned_entries + 1))
-  if [ "$scanned_entries" -gt "$scan_budget" ]; then
+# Codex resume can see matching session files anywhere below sessions; the
+# explicit entry budget keeps that required duplicate cleanup bounded.
+scan_error_file=""
+cleanup_scan_error_file() {
+  if [ -n "$scan_error_file" ]; then
+    rm -f -- "$scan_error_file"
+  fi
+}
+cleanup_scan_error_file_and_exit() {
+  cleanup_scan_error_file
+  exit 1
+}
+trap cleanup_scan_error_file EXIT
+trap cleanup_scan_error_file_and_exit HUP INT TERM
+count_session_entries() {
+  : > "$scan_error_file" || {
+    echo "failed to reset codex session cleanup temp file" >&2
+    exit 1
+  }
+  entry_count=$(
+    find "$root" -mindepth 1 -print 2>"$scan_error_file" |
+      awk -v budget="$scan_budget" '
+        NR > budget {
+          print NR
+          exit
+        }
+        END {
+          if (NR <= budget) {
+            print NR
+          }
+        }
+      '
+  )
+  if [ "$entry_count" -gt "$scan_budget" ]; then
     echo "codex session cleanup exceeded scan budget" >&2
     exit 1
   fi
-}
-ensure_scannable_session_dir() {
-  dir="$1"
-  if [ ! -r "$dir" ] || [ ! -x "$dir" ]; then
+  if [ -s "$scan_error_file" ]; then
     echo "cannot scan codex session directory" >&2
     exit 1
   fi
 }
-session_filename_matches() {
-  name="${1##*/}"
-  case "$name" in
-    *[ABCDEFGHIJKLMNOPQRSTUVWXYZ]*)
-      name=$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')
-      ;;
-  esac
-  case "$name" in
-    *"$id_lc"*.jsonl|\
-    *"$id_lc"*.jsonl.zst|\
-    *"$id_lc"*.jsonl.vm0tmp-*|\
-    *"$id_lc"*.jsonl.zst.vm0tmp-*|\
-    *"$id_no_dashes_lc"*.jsonl|\
-    *"$id_no_dashes_lc"*.jsonl.zst|\
-    *"$id_no_dashes_lc"*.jsonl.vm0tmp-*|\
-    *"$id_no_dashes_lc"*.jsonl.zst.vm0tmp-*)
-      return 0
-      ;;
-  esac
-  return 1
-}
-delete_matching_session_entry() {
-  path="$1"
-  if [ ! -f "$path" ] && [ ! -L "$path" ]; then
-    return
+delete_matching_session_entries() {
+  : > "$scan_error_file" || {
+    echo "failed to reset codex session cleanup temp file" >&2
+    exit 1
+  }
+  if ! find "$root" \( -type f -o -type l \) \( \
+    -iname "*${id_lc}*.jsonl" -o \
+    -iname "*${id_lc}*.jsonl.zst" -o \
+    -iname "*${id_lc}*.jsonl.vm0tmp-*" -o \
+    -iname "*${id_lc}*.jsonl.zst.vm0tmp-*" -o \
+    -iname "*${id_no_dashes_lc}*.jsonl" -o \
+    -iname "*${id_no_dashes_lc}*.jsonl.zst" -o \
+    -iname "*${id_no_dashes_lc}*.jsonl.vm0tmp-*" -o \
+    -iname "*${id_no_dashes_lc}*.jsonl.zst.vm0tmp-*" \
+  \) -delete 2>"$scan_error_file"; then
+    echo "failed to delete codex session files" >&2
+    exit 1
   fi
-  if session_filename_matches "$path"; then
-    rm -f -- "$path" || {
-      echo "failed to delete codex session file" >&2
-      exit 1
-    }
+  if [ -s "$scan_error_file" ]; then
+    echo "failed to delete codex session files" >&2
+    exit 1
   fi
-}
-# Codex resume can see matching session files anywhere below sessions; the
-# explicit entry budget keeps that required duplicate cleanup bounded.
-scan_session_tree() {
-  dir="$1"
-  action="$2"
-  ensure_scannable_session_dir "$dir"
-  for path in "$dir"/* "$dir"/.[!.]* "$dir"/..?*; do
-    if [ ! -e "$path" ] && [ ! -L "$path" ]; then
-      continue
-    fi
-    check_scan_budget
-    case "$action" in
-      delete)
-        delete_matching_session_entry "$path"
-        ;;
-    esac
-    if [ -d "$path" ] && [ ! -L "$path" ]; then
-      scan_session_tree "$path" "$action"
-    fi
-  done
 }
 if [ -d "$root" ]; then
-  scan_session_tree "$root" validate
-  scanned_entries=0
-  scan_session_tree "$root" delete
+  scan_error_file=$(mktemp "${TMPDIR:-/tmp}/codex-session-cleanup.XXXXXX") || {
+    echo "failed to create codex session cleanup temp file" >&2
+    exit 1
+  }
+  count_session_entries
+  delete_matching_session_entries
 fi

--- a/crates/runner/scripts/codex-session-cleanup.sh
+++ b/crates/runner/scripts/codex-session-cleanup.sh
@@ -93,7 +93,7 @@ check_scan_budget() {
 ensure_scannable_session_dir() {
   dir="$1"
   if [ ! -r "$dir" ] || [ ! -x "$dir" ]; then
-    echo "cannot scan codex session directory: $dir" >&2
+    echo "cannot scan codex session directory" >&2
     exit 1
   fi
 }
@@ -105,7 +105,14 @@ session_filename_matches() {
       ;;
   esac
   case "$name" in
-    *"$id_lc"*.jsonl|*"$id_lc"*.jsonl.zst|*"$id_lc"*.jsonl.vm0tmp-*|*"$id_lc"*.jsonl.zst.vm0tmp-*|*"$id_no_dashes_lc"*.jsonl|*"$id_no_dashes_lc"*.jsonl.zst|*"$id_no_dashes_lc"*.jsonl.vm0tmp-*|*"$id_no_dashes_lc"*.jsonl.zst.vm0tmp-*)
+    *"$id_lc"*.jsonl|\
+    *"$id_lc"*.jsonl.zst|\
+    *"$id_lc"*.jsonl.vm0tmp-*|\
+    *"$id_lc"*.jsonl.zst.vm0tmp-*|\
+    *"$id_no_dashes_lc"*.jsonl|\
+    *"$id_no_dashes_lc"*.jsonl.zst|\
+    *"$id_no_dashes_lc"*.jsonl.vm0tmp-*|\
+    *"$id_no_dashes_lc"*.jsonl.zst.vm0tmp-*)
       return 0
       ;;
   esac
@@ -118,7 +125,7 @@ delete_matching_session_entry() {
   fi
   if session_filename_matches "$path"; then
     rm -f -- "$path" || {
-      echo "failed to delete codex session file: $path" >&2
+      echo "failed to delete codex session file" >&2
       exit 1
     }
   fi

--- a/crates/runner/scripts/verify-rootfs.sh
+++ b/crates/runner/scripts/verify-rootfs.sh
@@ -183,6 +183,27 @@ else
   fi
 fi
 
+# Check required sandbox runtime commands. Runner helper exec scripts run inside
+# the sandbox via `sh -c`, so missing POSIX utilities should fail image
+# verification instead of surfacing during a user session restore.
+check_bin() {
+  local pattern="$1" name="$2"
+  # shellcheck disable=SC2086
+  if ls ${MOUNT_DIR}${pattern} &>/dev/null; then
+    echo "  ${name}: found"
+  else
+    errors+=("${name} not found (pattern: ${pattern})")
+  fi
+}
+
+check_bin "/bin/sh"        "sh"
+check_bin "/usr/bin/find"  "find"
+check_bin "/usr/bin/awk"   "awk"
+check_bin "/usr/bin/xargs" "xargs"
+check_bin "/usr/bin/mktemp" "mktemp"
+check_bin "/usr/bin/tr"    "tr"
+check_bin "/usr/bin/rm"    "rm"
+
 # Check CLIs
 if [[ -f "${MOUNT_DIR}/usr/bin/gh" ]]; then
   echo "  gh CLI: found"
@@ -207,16 +228,6 @@ fi
 # Some binaries use update-alternatives symlinks or versioned names (e.g.
 # php8.3 instead of php, javac under /usr/lib/jvm/). Use glob patterns
 # and ls to handle both exact paths and wildcards.
-check_bin() {
-  local pattern="$1" name="$2"
-  # shellcheck disable=SC2086
-  if ls ${MOUNT_DIR}${pattern} &>/dev/null; then
-    echo "  ${name}: found"
-  else
-    errors+=("${name} not found (pattern: ${pattern})")
-  fi
-}
-
 check_bin "/usr/bin/ruby"                      "ruby"
 check_bin "/usr/bin/php*"                      "php"
 check_bin "/usr/lib/jvm/java-*/bin/javac"      "javac"

--- a/crates/runner/src/cmd/build/scripts.rs
+++ b/crates/runner/src/cmd/build/scripts.rs
@@ -491,6 +491,24 @@ exit 1
     }
 
     #[test]
+    fn verify_script_checks_sandbox_helper_runtime_commands() {
+        for command_path in [
+            "/bin/sh",
+            "/usr/bin/find",
+            "/usr/bin/awk",
+            "/usr/bin/xargs",
+            "/usr/bin/mktemp",
+            "/usr/bin/tr",
+            "/usr/bin/rm",
+        ] {
+            assert!(
+                VERIFY_SCRIPT.contains(command_path),
+                "verify-rootfs.sh should verify {command_path} is present for sandbox helper exec scripts"
+            );
+        }
+    }
+
+    #[test]
     fn build_script_publishes_debootstrap_cache_atomically() {
         assert!(
             TEMPLATE_BUILD_SCRIPT.contains(r#"CACHE_TMP_TAR="${cache_tar%.tar}.tmp.$$.tar""#),

--- a/crates/runner/src/executor/session_restore/codex.rs
+++ b/crates/runner/src/executor/session_restore/codex.rs
@@ -300,9 +300,11 @@ mod tests {
         assert!(command.contains("codex_home='/home/user/.codex'"));
         assert!(command.contains("root=\"$codex_home/sessions\""));
         assert!(command.contains("scan_budget="));
-        assert!(command.contains("count_session_entries"));
-        assert!(command.contains("find \"$root\" -mindepth 1 -print"));
+        assert!(command.contains("collect_matching_session_entries"));
+        assert!(command.contains("find \"$root\" -mindepth 1 -print0"));
         assert!(command.contains("delete_matching_session_entries"));
+        assert!(command.contains("xargs -0"));
+        assert!(!command.contains("-delete"));
         assert!(!command.contains("for path in \"$dir\"/*"));
     }
 
@@ -320,6 +322,7 @@ mod tests {
         let matching_no_dash = codex_home.join("sessions/2026/06/05").join(format!(
             "rollout-b-{SESSION_ID_NO_DASHES}.jsonl.zst.vm0tmp-456"
         ));
+        let matching_newline = restore_dir.join(format!("rollout-line\nbreak-{SESSION_ID}.jsonl"));
         let matching_non_layout = codex_home
             .join("sessions/not-layout/deep")
             .join(format!("rollout-c-{SESSION_ID}.jsonl"));
@@ -331,6 +334,7 @@ mod tests {
         create_file(&matching_zst);
         create_file(&matching_tmp);
         create_file(&matching_no_dash);
+        create_file(&matching_newline);
         create_file(&matching_non_layout);
         create_file(&unrelated);
         fs::create_dir(&matching_directory).unwrap();
@@ -343,6 +347,7 @@ mod tests {
         assert!(!matching_zst.exists());
         assert!(!matching_tmp.exists());
         assert!(!matching_no_dash.exists());
+        assert!(!matching_newline.exists());
         assert!(!matching_non_layout.exists());
         assert!(!matching_symlink.exists());
         assert!(matching_directory.exists());

--- a/crates/runner/src/executor/session_restore/codex.rs
+++ b/crates/runner/src/executor/session_restore/codex.rs
@@ -234,7 +234,26 @@ mod tests {
         session_id: &str,
         session_filename_key: &str,
     ) -> Output {
-        Command::new("sh")
+        cleanup_command(codex_home, restore_path, session_id, session_filename_key)
+            .output()
+            .unwrap()
+    }
+
+    fn run_cleanup_with_budget(codex_home: &Path, restore_path: &Path, budget: &str) -> Output {
+        cleanup_command(codex_home, restore_path, SESSION_ID, SESSION_ID_NO_DASHES)
+            .env("VM0_CODEX_SESSION_CLEANUP_SCAN_BUDGET", budget)
+            .output()
+            .unwrap()
+    }
+
+    fn cleanup_command(
+        codex_home: &Path,
+        restore_path: &Path,
+        session_id: &str,
+        session_filename_key: &str,
+    ) -> Command {
+        let mut command = Command::new("sh");
+        command
             .arg("-c")
             .arg(codex_session_cleanup_command(
                 codex_home.to_str().expect("test path should be utf-8"),
@@ -247,9 +266,8 @@ mod tests {
             .env(
                 "VM0_CODEX_RESTORE_SESSION_PATH",
                 restore_path.to_str().expect("test path should be utf-8"),
-            )
-            .output()
-            .unwrap()
+            );
+        command
     }
 
     fn assert_success(output: &Output) {
@@ -281,7 +299,9 @@ mod tests {
 
         assert!(command.contains("codex_home='/home/user/.codex'"));
         assert!(command.contains("root=\"$codex_home/sessions\""));
-        assert!(command.contains("find \"$root\" \\( -type f -o -type l \\)"));
+        assert!(command.contains("scan_budget="));
+        assert!(command.contains("scan_session_tree \"$root\" validate"));
+        assert!(command.contains("scan_session_tree \"$root\" delete"));
     }
 
     #[test]
@@ -298,6 +318,9 @@ mod tests {
         let matching_no_dash = codex_home.join("sessions/2026/06/05").join(format!(
             "rollout-b-{SESSION_ID_NO_DASHES}.jsonl.zst.vm0tmp-456"
         ));
+        let matching_non_layout = codex_home
+            .join("sessions/not-layout/deep")
+            .join(format!("rollout-c-{SESSION_ID}.jsonl"));
         let matching_symlink = restore_dir.join(format!("rollout-link-{SESSION_ID}.jsonl"));
         let matching_directory = restore_dir.join(format!("rollout-dir-{SESSION_ID}.jsonl"));
         let unrelated = restore_dir.join("rollout-other-session.jsonl");
@@ -306,6 +329,7 @@ mod tests {
         create_file(&matching_zst);
         create_file(&matching_tmp);
         create_file(&matching_no_dash);
+        create_file(&matching_non_layout);
         create_file(&unrelated);
         fs::create_dir(&matching_directory).unwrap();
         symlink(&unrelated, &matching_symlink).unwrap();
@@ -317,9 +341,44 @@ mod tests {
         assert!(!matching_zst.exists());
         assert!(!matching_tmp.exists());
         assert!(!matching_no_dash.exists());
+        assert!(!matching_non_layout.exists());
         assert!(!matching_symlink.exists());
         assert!(matching_directory.exists());
         assert!(unrelated.exists());
+    }
+
+    #[test]
+    fn cleanup_script_fails_when_scan_budget_exceeded_without_deleting_sessions() {
+        let temp = tempfile::tempdir().unwrap();
+        let codex_home = temp.path().join(".codex");
+        let restore_path = restore_path(&codex_home);
+        let restore_dir = restore_path.parent().unwrap();
+        fs::create_dir_all(restore_dir).unwrap();
+        let matching_jsonl = restore_dir.join(format!("rollout-a-{SESSION_ID}.jsonl"));
+        create_file(&matching_jsonl);
+
+        let output = run_cleanup_with_budget(&codex_home, &restore_path, "1");
+
+        assert_failure_contains(&output, "codex session cleanup exceeded scan budget");
+        assert!(matching_jsonl.exists());
+    }
+
+    #[test]
+    fn cleanup_script_rejects_invalid_scan_budget_without_deleting_sessions() {
+        let temp = tempfile::tempdir().unwrap();
+        let codex_home = temp.path().join(".codex");
+        let restore_path = restore_path(&codex_home);
+        let restore_dir = restore_path.parent().unwrap();
+        fs::create_dir_all(restore_dir).unwrap();
+        let matching_jsonl = restore_dir.join(format!("rollout-a-{SESSION_ID}.jsonl"));
+        create_file(&matching_jsonl);
+
+        for budget in ["0", "1000000", "not-a-number"] {
+            let output = run_cleanup_with_budget(&codex_home, &restore_path, budget);
+
+            assert_failure_contains(&output, "invalid codex session cleanup scan budget");
+            assert!(matching_jsonl.exists());
+        }
     }
 
     #[test]

--- a/crates/runner/src/executor/session_restore/codex.rs
+++ b/crates/runner/src/executor/session_restore/codex.rs
@@ -300,8 +300,10 @@ mod tests {
         assert!(command.contains("codex_home='/home/user/.codex'"));
         assert!(command.contains("root=\"$codex_home/sessions\""));
         assert!(command.contains("scan_budget="));
-        assert!(command.contains("scan_session_tree \"$root\" validate"));
-        assert!(command.contains("scan_session_tree \"$root\" delete"));
+        assert!(command.contains("count_session_entries"));
+        assert!(command.contains("find \"$root\" -mindepth 1 -print"));
+        assert!(command.contains("delete_matching_session_entries"));
+        assert!(!command.contains("for path in \"$dir\"/*"));
     }
 
     #[test]
@@ -450,7 +452,10 @@ mod tests {
         fs::create_dir_all(&codex_home).unwrap();
         let restore_path = restore_path(&codex_home);
 
-        let output = run_cleanup(&codex_home, &restore_path);
+        let output = cleanup_command(&codex_home, &restore_path, SESSION_ID, SESSION_ID_NO_DASHES)
+            .env("TMPDIR", temp.path().join("missing-tmp"))
+            .output()
+            .unwrap();
 
         assert_success(&output);
     }

--- a/crates/runner/src/executor/session_restore/codex.rs
+++ b/crates/runner/src/executor/session_restore/codex.rs
@@ -192,7 +192,7 @@ mod tests {
     use super::*;
 
     use std::fs;
-    use std::os::unix::fs::symlink;
+    use std::os::unix::fs::{PermissionsExt, symlink};
     use std::path::{Path, PathBuf};
     use std::process::{Command, Output};
 
@@ -406,6 +406,34 @@ mod tests {
 
         assert_success(&output);
         assert!(!matching_jsonl.exists());
+    }
+
+    #[test]
+    fn cleanup_script_rejects_failed_session_id_normalization_without_deleting_sessions() {
+        let temp = tempfile::tempdir().unwrap();
+        let codex_home = temp.path().join(".codex");
+        let restore_path = restore_path(&codex_home);
+        let restore_dir = restore_path.parent().unwrap();
+        fs::create_dir_all(restore_dir).unwrap();
+        let matching_jsonl = restore_dir.join(format!("rollout-a-{SESSION_ID}.jsonl"));
+        create_file(&matching_jsonl);
+
+        let fake_bin = temp.path().join("fake-bin");
+        fs::create_dir(&fake_bin).unwrap();
+        symlink("/bin/sh", fake_bin.join("sh")).unwrap();
+        let fake_tr = fake_bin.join("tr");
+        fs::write(&fake_tr, "#!/bin/sh\nexit 1\n").unwrap();
+        let mut permissions = fs::metadata(&fake_tr).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&fake_tr, permissions).unwrap();
+
+        let output = cleanup_command(&codex_home, &restore_path, SESSION_ID, SESSION_ID_NO_DASHES)
+            .env("PATH", &fake_bin)
+            .output()
+            .unwrap();
+
+        assert_failure_contains(&output, "failed to normalize codex restore session id");
+        assert!(matching_jsonl.exists());
     }
 
     #[test]

--- a/crates/runner/src/executor/tests/session_restore_tests.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests.rs
@@ -533,6 +533,27 @@ async fn restore_session_fails_when_codex_cleanup_fails() {
 }
 
 #[tokio::test]
+async fn restore_session_fails_when_codex_cleanup_exceeds_scan_budget() {
+    let sandbox = MockSandbox::new("test");
+    let mut ctx = minimal_context();
+    ctx.cli_agent_type = "codex".into();
+    let session =
+        ResumeSession::inline("019e9154-c304-70f0-adde-36efb1be1701".into(), "{}\n".into());
+    sandbox.push_exec_result(Ok(ExecResult::new(
+        1,
+        Vec::new(),
+        b"codex session cleanup exceeded scan budget".to_vec(),
+    )));
+
+    let err = restore_session(&sandbox, &ctx, &session).await.unwrap_err();
+
+    let message = err.to_string();
+    assert!(message.contains("codex session cleanup failed"));
+    assert!(message.contains("codex session cleanup exceeded scan budget"));
+    assert!(sandbox.write_file_calls().is_empty());
+}
+
+#[tokio::test]
 async fn restore_session_redacts_codex_cleanup_failure_output() {
     let sandbox = MockSandbox::new("test");
     let mut ctx = minimal_context();
@@ -906,12 +927,18 @@ fn assert_codex_cleanup_call(sandbox: &MockSandbox) {
             .cmd
             .contains("codex restore directory is a symlink")
     );
+    assert!(exec_calls[0].cmd.contains("scan_budget="));
     assert!(
         exec_calls[0]
             .cmd
-            .contains("find \"$root\" \\( -type f -o -type l \\)")
+            .contains("scan_session_tree \"$root\" validate")
     );
-    assert!(exec_calls[0].cmd.contains("-iname"));
+    assert!(
+        exec_calls[0]
+            .cmd
+            .contains("scan_session_tree \"$root\" delete")
+    );
+    assert!(exec_calls[0].cmd.contains("session_filename_matches"));
     assert!(exec_calls[0].cmd.contains(".jsonl.zst"));
     assert!(exec_calls[0].cmd.contains(".jsonl.vm0tmp-*"));
     assert!(exec_calls[0].cmd.contains("id_no_dashes"));
@@ -921,7 +948,7 @@ fn assert_codex_cleanup_call(sandbox: &MockSandbox) {
             .contains("VM0_CODEX_RESTORE_SESSION_FILENAME_KEY")
     );
     assert!(!exec_calls[0].cmd.contains("tr -d"));
-    assert!(exec_calls[0].cmd.contains("-delete"));
+    assert!(exec_calls[0].cmd.contains("rm -f --"));
 }
 
 fn capture_restore_events<F>(future: F) -> (F::Output, Vec<CapturedEvent>)

--- a/crates/runner/src/executor/tests/session_restore_tests.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests.rs
@@ -928,17 +928,22 @@ fn assert_codex_cleanup_call(sandbox: &MockSandbox) {
             .contains("codex restore directory is a symlink")
     );
     assert!(exec_calls[0].cmd.contains("scan_budget="));
+    assert!(exec_calls[0].cmd.contains("count_session_entries"));
     assert!(
         exec_calls[0]
             .cmd
-            .contains("scan_session_tree \"$root\" validate")
+            .contains("find \"$root\" -mindepth 1 -print")
     );
     assert!(
         exec_calls[0]
             .cmd
-            .contains("scan_session_tree \"$root\" delete")
+            .contains("delete_matching_session_entries")
     );
-    assert!(exec_calls[0].cmd.contains("session_filename_matches"));
+    assert!(
+        exec_calls[0]
+            .cmd
+            .contains("find \"$root\" \\( -type f -o -type l \\)")
+    );
     assert!(exec_calls[0].cmd.contains(".jsonl.zst"));
     assert!(exec_calls[0].cmd.contains(".jsonl.vm0tmp-*"));
     assert!(exec_calls[0].cmd.contains("id_no_dashes"));
@@ -948,7 +953,8 @@ fn assert_codex_cleanup_call(sandbox: &MockSandbox) {
             .contains("VM0_CODEX_RESTORE_SESSION_FILENAME_KEY")
     );
     assert!(!exec_calls[0].cmd.contains("tr -d"));
-    assert!(exec_calls[0].cmd.contains("rm -f --"));
+    assert!(exec_calls[0].cmd.contains("-delete"));
+    assert!(!exec_calls[0].cmd.contains("for path in \"$dir\"/*"));
 }
 
 fn capture_restore_events<F>(future: F) -> (F::Output, Vec<CapturedEvent>)

--- a/crates/runner/src/executor/tests/session_restore_tests.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests.rs
@@ -928,24 +928,24 @@ fn assert_codex_cleanup_call(sandbox: &MockSandbox) {
             .contains("codex restore directory is a symlink")
     );
     assert!(exec_calls[0].cmd.contains("scan_budget="));
-    assert!(exec_calls[0].cmd.contains("count_session_entries"));
     assert!(
         exec_calls[0]
             .cmd
-            .contains("find \"$root\" -mindepth 1 -print")
+            .contains("collect_matching_session_entries")
+    );
+    assert!(
+        exec_calls[0]
+            .cmd
+            .contains("find \"$root\" -mindepth 1 -print0")
     );
     assert!(
         exec_calls[0]
             .cmd
             .contains("delete_matching_session_entries")
     );
-    assert!(
-        exec_calls[0]
-            .cmd
-            .contains("find \"$root\" \\( -type f -o -type l \\)")
-    );
-    assert!(exec_calls[0].cmd.contains(".jsonl.zst"));
-    assert!(exec_calls[0].cmd.contains(".jsonl.vm0tmp-*"));
+    assert!(exec_calls[0].cmd.contains("xargs -0"));
+    assert!(exec_calls[0].cmd.contains("\\\\.jsonl\\\\.zst"));
+    assert!(exec_calls[0].cmd.contains("\\\\.jsonl\\\\.vm0tmp-"));
     assert!(exec_calls[0].cmd.contains("id_no_dashes"));
     assert!(
         exec_calls[0]
@@ -953,7 +953,7 @@ fn assert_codex_cleanup_call(sandbox: &MockSandbox) {
             .contains("VM0_CODEX_RESTORE_SESSION_FILENAME_KEY")
     );
     assert!(!exec_calls[0].cmd.contains("tr -d"));
-    assert!(exec_calls[0].cmd.contains("-delete"));
+    assert!(!exec_calls[0].cmd.contains("-delete"));
     assert!(!exec_calls[0].cmd.contains("for path in \"$dir\"/*"));
 }
 


### PR DESCRIPTION
## Summary
- add a bounded single-pass Codex session cleanup traversal that fails before deleting or writing restored history when the sessions tree exceeds the entry budget
- keep full sessions-tree duplicate cleanup because Codex resume can observe non-layout matching session files
- avoid a GNU awk-only dependency and verify sandbox helper command dependencies during rootfs validation
- add guest-mock-codex and runner tests for non-layout duplicates, budget exhaustion, invalid budgets, missing sessions roots, and fail-closed restore behavior

## Testing
- cargo fmt --manifest-path crates/Cargo.toml --all
- sh -n crates/runner/scripts/codex-session-cleanup.sh
- bash -n crates/runner/scripts/verify-rootfs.sh
- cargo test --manifest-path crates/Cargo.toml -p runner cleanup_script
- cargo test --manifest-path crates/Cargo.toml -p guest-mock-codex resume_rejects_duplicate
- cargo test --manifest-path crates/Cargo.toml -p runner session_restore
- cargo test --manifest-path crates/Cargo.toml -p runner verify_script_checks_sandbox_helper_runtime_commands
- cargo clippy --manifest-path crates/Cargo.toml -p runner -p guest-mock-codex --tests -- -D warnings

Closes #19220
