### PR TITLE
fix: wrap webhook trigger signing details

### DIFF
--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -1085,18 +1085,20 @@ describe("workflow detail page", () => {
         },
       });
     });
-    await waitFor(() => {
-      expect(
-        screen.getByDisplayValue(webhookWorkflowTrigger().webhookUrl),
-      ).toBeInTheDocument();
-    });
-    expect(
-      screen.getByDisplayValue(webhookWorkflowTrigger().webhookUrl),
-    ).toHaveValue(webhookWorkflowTrigger().webhookUrl);
+    const webhookUrlField = await screen.findByDisplayValue(
+      webhookWorkflowTrigger().webhookUrl,
+    );
+    expect(webhookUrlField).toBeInTheDocument();
+    expect(webhookUrlField).toHaveValue(webhookWorkflowTrigger().webhookUrl);
+    expect(webhookUrlField).toHaveClass("min-w-0");
     expect(screen.getByDisplayValue("webhook-secret")).toHaveValue(
       "webhook-secret",
     );
-    expect(screen.getByText(/X-VM0-Signature/)).toBeInTheDocument();
+    const signedCurlExample = screen
+      .getByText(/X-VM0-Signature/)
+      .closest("pre");
+    expect(signedCurlExample).toBeInTheDocument();
+    expect(signedCurlExample).toHaveClass("whitespace-pre-wrap", "break-all");
   });
 
   it("creates a cron schedule trigger from the preferred time zone", async () => {

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -3379,8 +3379,8 @@ function CreatedWebhookTriggerView({
 }) {
   const curlExample = signedWebhookCurlExample(trigger);
   return (
-    <div className="flex flex-col gap-3">
-      <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+    <div className="flex min-w-0 flex-col gap-3">
+      <label className="flex min-w-0 flex-col gap-1 text-xs text-muted-foreground">
         Webhook URL
         <WebhookReadonlyField
           value={trigger.webhookUrl}
@@ -3390,7 +3390,7 @@ function CreatedWebhookTriggerView({
         />
       </label>
       {trigger.webhookSecret ? (
-        <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+        <label className="flex min-w-0 flex-col gap-1 text-xs text-muted-foreground">
           Signing secret
           <WebhookReadonlyField
             value={trigger.webhookSecret}
@@ -3400,10 +3400,10 @@ function CreatedWebhookTriggerView({
           />
         </label>
       ) : null}
-      <div className="flex flex-col gap-1 text-xs text-muted-foreground">
+      <div className="flex min-w-0 flex-col gap-1 text-xs text-muted-foreground">
         Signed curl
-        <div className="relative">
-          <pre className="max-h-56 overflow-auto rounded-md border border-border/60 bg-muted/40 p-3 text-xs leading-5 text-foreground">
+        <div className="relative min-w-0">
+          <pre className="max-h-56 overflow-y-auto whitespace-pre-wrap break-all rounded-md border border-border/60 bg-muted/40 p-3 pr-20 font-mono text-xs leading-5 text-foreground">
             {curlExample}
           </pre>
           <Button
@@ -3437,7 +3437,7 @@ function WebhookReadonlyField({
 }) {
   return (
     <div className="flex min-w-0 gap-2">
-      <input readOnly value={value} className={FIELD_CLASS} />
+      <input readOnly value={value} className={cn(FIELD_CLASS, "min-w-0")} />
       <Button type="button" variant="outline" onClick={onCopy}>
         <IconCopy size={14} />
         Copy


### PR DESCRIPTION
Summary:
- Allow webhook trigger signing detail fields to shrink inside the dialog.
- Wrap the signed curl sample in place while preserving line breaks.
- Add regression coverage for the wrapping classes.

Tests:
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm exec prettier --check apps/platform/src/views/workflows-page/workflow-detail-page.tsx apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
- Attempted pnpm -F @vm0/app test -- src/views/workflows-page/__tests__/workflows-page.test.tsx and the matching -t case; both did not exit in this environment and were terminated.