### PR TITLE
fix: show agent workflow trigger automations

### DIFF
--- a/turbo/apps/platform/src/signals/agents-page/agent-detail-page-setup.ts
+++ b/turbo/apps/platform/src/signals/agents-page/agent-detail-page-setup.ts
@@ -15,6 +15,9 @@ import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import { setActiveAgent$ } from "../zero-page/zero-job-detail.ts";
 import { setChatAgentId$ } from "../agent-chat.ts";
+import { featureSwitch$ } from "../external/feature-switch.ts";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { reloadWorkflows$ } from "../workflows-page/workflows-signals.ts";
 
 export const setupAgentDetailPage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
@@ -53,6 +56,10 @@ export const setupAgentDetailPage$ = command(
     set(setActiveAgent$, agentId);
     set(setChatAgentId$, agentId);
     set(rememberLastUsedAgentId$, agentId);
+    const features = get(featureSwitch$);
+    if (features[FeatureSwitchKey.SwitchScheduleAutomationToWorkflowTrigger]) {
+      set(reloadWorkflows$);
+    }
 
     const displayName = agent.displayName ?? "Agent";
     set(updateDocumentTitle$, displayName);

--- a/turbo/apps/platform/src/signals/automation-page/workflow-trigger-automation-dialog.ts
+++ b/turbo/apps/platform/src/signals/automation-page/workflow-trigger-automation-dialog.ts
@@ -7,6 +7,7 @@ const workflowAutomationDialogStepState$ =
   state<WorkflowAutomationDialogStep>(1);
 const selectedWorkflowAutomationAgentIdState$ = state("");
 const workflowAutomationAgentQueryState$ = state("");
+const workflowAutomationAgentSelectionLockedState$ = state(false);
 
 export const workflowAutomationDialogOpen$ = computed((get) => {
   return get(workflowAutomationDialogOpenState$);
@@ -24,6 +25,10 @@ export const workflowAutomationAgentQuery$ = computed((get) => {
   return get(workflowAutomationAgentQueryState$);
 });
 
+export const workflowAutomationAgentSelectionLocked$ = computed((get) => {
+  return get(workflowAutomationAgentSelectionLockedState$);
+});
+
 export const setWorkflowAutomationDialogOpen$ = command(
   ({ set }, open: boolean) => {
     set(workflowAutomationDialogOpenState$, open);
@@ -31,7 +36,18 @@ export const setWorkflowAutomationDialogOpen$ = command(
       set(workflowAutomationDialogStepState$, 1);
       set(selectedWorkflowAutomationAgentIdState$, "");
       set(workflowAutomationAgentQueryState$, "");
+      set(workflowAutomationAgentSelectionLockedState$, false);
     }
+  },
+);
+
+export const openWorkflowAutomationDialogForAgent$ = command(
+  ({ set }, agentId: string) => {
+    set(workflowAutomationDialogOpenState$, true);
+    set(workflowAutomationDialogStepState$, 2);
+    set(selectedWorkflowAutomationAgentIdState$, agentId);
+    set(workflowAutomationAgentQueryState$, "");
+    set(workflowAutomationAgentSelectionLockedState$, true);
   },
 );
 

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -11,6 +11,10 @@ import {
 } from "@vm0/api-contracts/contracts/zero-agents";
 import { zeroComposesMainContract } from "@vm0/api-contracts/contracts/zero-composes";
 import {
+  zeroWorkflowTriggersContract,
+  type ZeroWorkflowTriggerAutomationEntry,
+} from "@vm0/api-contracts/contracts/zero-workflows";
+import {
   type ApplyUserPermissionGrantsRequest,
   type UserPermissionGrantResponse,
   zeroUserPermissionGrantsContract,
@@ -21,6 +25,7 @@ import {
 } from "@vm0/api-contracts/contracts/zero-custom-connectors";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import type { TeamComposeItem } from "@vm0/api-contracts/contracts/zero-team";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -313,6 +318,53 @@ function mockTeamAPIs(): void {
   });
 }
 
+function workflowAutomationEntry({
+  workflowId,
+  agentId,
+  agentDisplayName,
+  name,
+  displayName,
+  triggerId,
+  intervalSeconds,
+}: {
+  workflowId: string;
+  agentId: string;
+  agentDisplayName: string;
+  name: string;
+  displayName: string;
+  triggerId: string;
+  intervalSeconds: number;
+}): ZeroWorkflowTriggerAutomationEntry {
+  return {
+    workflow: {
+      id: workflowId,
+      agentId,
+      agentName: null,
+      agentDisplayName,
+      name,
+      displayName,
+      description: null,
+      visibility: "private",
+      requestToPublish: false,
+      ownerUserId: "test-owner-id",
+      ownerUserDisplayName: "Test Owner",
+      ownerUserImageUrl: null,
+      canManage: true,
+    },
+    trigger: {
+      id: triggerId,
+      ownerUserId: "test-owner-id",
+      enabled: true,
+      chatThreadId: "thread-workflow-trigger",
+      nextRunAt: null,
+      lastRunAt: null,
+      kind: "schedule",
+      schedule: { type: "loop", intervalSeconds },
+      scheduleSummary: `Every ${intervalSeconds / 60} minutes`,
+    },
+  };
+}
+
 describe("team page navigation", () => {
   it("navigates into an agent and manages connector authorization", async () => {
     mockTeamAPIs();
@@ -575,6 +627,74 @@ describe("team page navigation", () => {
         screen.getAllByText("Collect weekly research links")[0],
       ).toBeInTheDocument();
     });
+  });
+
+  it("shows agent workflow triggers when workflow automation is enabled", async () => {
+    mockTeamAPIs();
+    context.mocks.data.userPreferences({ timezone: "UTC" });
+    context.mocks.api(
+      zeroWorkflowTriggersContract.listWorkspace,
+      ({ respond }) => {
+        return respond(200, [
+          workflowAutomationEntry({
+            workflowId: "d0000000-0000-4000-a000-000000000401",
+            agentId: researchAgentId,
+            agentDisplayName: "Research Agent",
+            name: "research-digest-workflow",
+            displayName: "Research digest workflow",
+            triggerId: "workflow-trigger-research-digest",
+            intervalSeconds: 900,
+          }),
+          workflowAutomationEntry({
+            workflowId: "d0000000-0000-4000-a000-000000000402",
+            agentId: zeroAgentId,
+            agentDisplayName: "Zero",
+            name: "zero-brief-workflow",
+            displayName: "Zero brief workflow",
+            triggerId: "workflow-trigger-zero-brief",
+            intervalSeconds: 1800,
+          }),
+        ]);
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${researchAgentId}`,
+      featureSwitches: {
+        [FeatureSwitchKey.SwitchScheduleAutomationToWorkflowTrigger]: true,
+      },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Research Agent" }),
+      ).toBeInTheDocument();
+    });
+    click(tabByText("Automations"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Research digest workflow")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText("Workflow triggers attached to Research Agent."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Every 15 minutes")).toBeInTheDocument();
+    expect(screen.queryByText("Zero brief workflow")).not.toBeInTheDocument();
+    expect(screen.queryByText("Research digest")).not.toBeInTheDocument();
+
+    click(buttonByText("Add automation"));
+
+    const dialog = await screen.findByRole("dialog");
+    expect(
+      within(dialog).getByText("Choose the trigger type for this workflow."),
+    ).toBeInTheDocument();
+    expect(within(dialog).getByText("Research Agent")).toBeInTheDocument();
+    expect(within(dialog).getByText("Fixed interval")).toBeInTheDocument();
+    expect(
+      within(dialog).queryByPlaceholderText("Search agents..."),
+    ).not.toBeInTheDocument();
+    expect(within(dialog).queryByText("Zero")).not.toBeInTheDocument();
   });
 
   it("runs an agent automation and opens its detail page", async () => {

--- a/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
@@ -21,6 +21,7 @@ import {
   IconMessageCircle,
   IconWand,
   IconListCheck,
+  IconPlus,
 } from "@tabler/icons-react";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import type { ConnectorType } from "@vm0/connectors/connectors";
@@ -72,6 +73,7 @@ import {
 } from "../../signals/zero-page/zero-job-detail.ts";
 import { runAutomationNow$ } from "../../signals/zero-page/zero-automations.ts";
 import { zeroOnboardingStatus$ } from "../../signals/zero-page/zero-onboarding.ts";
+import { userPreferences$ } from "../../signals/zero-page/settings/user-preferences.ts";
 import { Link } from "../router/link.tsx";
 import { detachedNavigateTo$ } from "../../signals/route.ts";
 import {
@@ -120,8 +122,16 @@ import {
   type FirewallPermissionDetailMetadata,
 } from "@vm0/connectors/firewall-metadata";
 import type { UserPermissionGrantResponse } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
-import { agentVisibleWorkflows$ } from "../../signals/workflows-page/workflows-signals.ts";
+import { openWorkflowAutomationDialogForAgent$ } from "../../signals/automation-page/workflow-trigger-automation-dialog.ts";
+import {
+  agentVisibleWorkflows$,
+  allWorkflowTriggerEntries$,
+} from "../../signals/workflows-page/workflows-signals.ts";
 import { WorkflowListPanel } from "../workflows-page/workflows-page.tsx";
+import {
+  CreateWorkflowAutomationDialog,
+  WorkflowTriggerAutomationList,
+} from "../zero-page/workflow-trigger-automations-page.tsx";
 import {
   DetailPageBreadcrumbBar,
   DetailPageHeader,
@@ -812,7 +822,82 @@ function JobPermissionsTab({
   );
 }
 
-function JobAutomationsTab({ displayName }: { displayName: string }) {
+function JobWorkflowAutomationsTab({
+  agentId,
+  displayName,
+}: {
+  agentId: string;
+  displayName: string;
+}) {
+  const entriesLoadable = useLastLoadable(allWorkflowTriggerEntries$);
+  const prefsLoadable = useLastLoadable(userPreferences$);
+  const openForAgent = useSet(openWorkflowAutomationDialogForAgent$);
+  const entries =
+    entriesLoadable.state === "hasData" ? entriesLoadable.data : [];
+  const displayTimezone =
+    prefsLoadable.state === "hasData" && prefsLoadable.data?.timezone
+      ? prefsLoadable.data.timezone
+      : new Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const loading = entriesLoadable.state === "loading";
+  const agentEntries = entries.filter((entry) => {
+    return entry.workflow.agentId === agentId;
+  });
+  const openAddAutomation = () => {
+    openForAgent(agentId);
+  };
+
+  return (
+    <div className="mx-auto flex max-w-[900px] flex-col gap-4">
+      <div className="flex flex-wrap items-end justify-between gap-4">
+        <div className="hidden min-w-0 md:block">
+          <h2 className="text-lg font-semibold tracking-tight text-foreground">
+            Automations
+          </h2>
+          <p className="mt-0.5 text-sm text-muted-foreground">
+            Workflow triggers attached to {displayName}.
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="zero-btn-morandi h-9 shrink-0 gap-2 rounded-lg border"
+          onClick={openAddAutomation}
+        >
+          <IconPlus size={14} stroke={2} />
+          Add automation
+        </Button>
+      </div>
+
+      <WorkflowTriggerAutomationList
+        entries={agentEntries}
+        displayTimezone={displayTimezone}
+        loading={loading}
+        onAdd={openAddAutomation}
+      />
+      <CreateWorkflowAutomationDialog />
+    </div>
+  );
+}
+
+function JobAutomationsTab({
+  agentId,
+  displayName,
+}: {
+  agentId: string;
+  displayName: string;
+}) {
+  const features = useLastResolved(featureSwitch$);
+  if (features?.[FeatureSwitchKey.SwitchScheduleAutomationToWorkflowTrigger]) {
+    return (
+      <JobWorkflowAutomationsTab agentId={agentId} displayName={displayName} />
+    );
+  }
+
+  return <JobLegacyAutomationsTab displayName={displayName} />;
+}
+
+function JobLegacyAutomationsTab({ displayName }: { displayName: string }) {
   const automationLoadable = useLoadable(agentAutomationEntries$);
   const entries = useLastResolved(agentAutomationEntries$) ?? [];
   const loading = automationLoadable.state === "loading";
@@ -1042,7 +1127,7 @@ function AgentTabContent({
       return <JobPermissionsTab agentId={agentId} displayName={displayName} />;
     }
     case "automations": {
-      return <JobAutomationsTab displayName={displayName} />;
+      return <JobAutomationsTab agentId={agentId} displayName={displayName} />;
     }
     case "workflows": {
       return <JobWorkflowsTab agentId={agentId} />;

--- a/turbo/apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx
@@ -37,6 +37,7 @@ import {
   setWorkflowAutomationAgentQuery$,
   setWorkflowAutomationDialogOpen$,
   setWorkflowAutomationDialogStep$,
+  workflowAutomationAgentSelectionLocked$,
   workflowAutomationAgentQuery$,
   workflowAutomationDialogOpen$,
   workflowAutomationDialogStep$,
@@ -590,17 +591,17 @@ function TriggerSelectionStep({
 }
 
 function WorkflowAutomationDialogFooter({
-  step,
+  showBack,
   onBack,
   onCancel,
 }: {
-  readonly step: 1 | 2;
+  readonly showBack: boolean;
   readonly onBack: () => void;
   readonly onCancel: () => void;
 }) {
   return (
     <DialogFooter className="shrink-0 border-t border-border/60 bg-card px-5 py-4">
-      {step === 2 ? (
+      {showBack ? (
         <Button
           type="button"
           variant="outline"
@@ -618,13 +619,14 @@ function WorkflowAutomationDialogFooter({
   );
 }
 
-function CreateWorkflowAutomationDialog() {
+export function CreateWorkflowAutomationDialog() {
   const agentsLoadable = useLastLoadable(agents$);
   const agents = agentsLoadable.state === "hasData" ? agentsLoadable.data : [];
   const open = useGet(workflowAutomationDialogOpen$);
   const setOpen = useSet(setWorkflowAutomationDialogOpen$);
   const step = useGet(workflowAutomationDialogStep$);
   const setStep = useSet(setWorkflowAutomationDialogStep$);
+  const agentSelectionLocked = useGet(workflowAutomationAgentSelectionLocked$);
   const selectedAgentIdState = useGet(selectedWorkflowAutomationAgentId$);
   const setSelectedAgentId = useSet(setSelectedWorkflowAutomationAgentId$);
   const navigate = useSet(detachedNavigateTo$);
@@ -658,7 +660,9 @@ function CreateWorkflowAutomationDialog() {
             Add automation
           </DialogTitle>
           <DialogDescription className="mt-1 text-sm text-muted-foreground">
-            Choose the agent and trigger type for this workflow.
+            {step === 1
+              ? "Choose the agent and trigger type for this workflow."
+              : "Choose the trigger type for this workflow."}
           </DialogDescription>
         </DialogHeader>
 
@@ -674,7 +678,7 @@ function CreateWorkflowAutomationDialog() {
         )}
 
         <WorkflowAutomationDialogFooter
-          step={step}
+          showBack={step === 2 && !agentSelectionLocked}
           onBack={() => {
             setStep(1);
           }}
@@ -684,6 +688,40 @@ function CreateWorkflowAutomationDialog() {
         />
       </DialogContent>
     </Dialog>
+  );
+}
+
+export function WorkflowTriggerAutomationList({
+  entries,
+  displayTimezone,
+  loading,
+  onAdd,
+}: {
+  readonly entries: readonly WorkflowTriggerAutomationEntry[];
+  readonly displayTimezone: string;
+  readonly loading: boolean;
+  readonly onAdd: () => void;
+}) {
+  if (loading) {
+    return <TriggerGridSkeleton />;
+  }
+
+  if (entries.length === 0) {
+    return <EmptyTriggers onAdd={onAdd} />;
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+      {entries.map((entry) => {
+        return (
+          <WorkflowAutomationTriggerCard
+            key={entry.trigger.id}
+            entry={entry}
+            displayTimezone={displayTimezone}
+          />
+        );
+      })}
+    </div>
   );
 }
 
@@ -728,27 +766,14 @@ export function WorkflowTriggerAutomationsPage() {
 
       <main className="flex-1 overflow-auto px-4 pb-8 pt-3 sm:px-6">
         <div className="mx-auto max-w-[1120px]">
-          {loading ? (
-            <TriggerGridSkeleton />
-          ) : entries.length === 0 ? (
-            <EmptyTriggers
-              onAdd={() => {
-                setCreateOpen(true);
-              }}
-            />
-          ) : (
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-              {entries.map((entry) => {
-                return (
-                  <WorkflowAutomationTriggerCard
-                    key={entry.trigger.id}
-                    entry={entry}
-                    displayTimezone={displayTimezone}
-                  />
-                );
-              })}
-            </div>
-          )}
+          <WorkflowTriggerAutomationList
+            entries={entries}
+            displayTimezone={displayTimezone}
+            loading={loading}
+            onAdd={() => {
+              setCreateOpen(true);
+            }}
+          />
         </div>
       </main>
 


### PR DESCRIPTION
## Summary
- switch agent detail Automations tab to show current-agent workflow triggers when `SwitchScheduleAutomationToWorkflowTrigger` is enabled
- reuse the workflow-trigger automation grid/dialog from `/automations`
- let agent-scoped Add automation skip agent selection and open directly on trigger type selection

## Verification
- `pnpm format`
- `pnpm turbo run lint --log-order grouped` hit a SIGKILL in the platform type-aware oxlint subprocess; reran `pnpm -F @vm0/app lint` successfully
- `pnpm check-types` passed through platform and then API tsc OOMed at the default heap; reran `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types` successfully
- `pnpm exec vitest run apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx`
- `pnpm exec vitest run apps/platform/src/views/zero-page/__tests__/zero-automations-page.test.tsx`

Did not start a dev server per vm0 PR preference.