### PR TITLE
perf: park checkpointed session history identity

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1298,6 +1298,8 @@ name = "guest-contracts"
 version = "0.2.6"
 dependencies = [
  "libc",
+ "serde",
+ "serde_json",
  "tempfile",
  "uuid",
 ]

--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -8,6 +8,7 @@ use crate::error::AgentError;
 use crate::http::HttpClient;
 use crate::paths;
 use crate::session_history;
+use crate::session_history_identity::build_final_session_history_identity;
 use api_contracts::generated::types::runners::storage::ArtifactEntryMissingRootPolicy;
 use bytes::Bytes;
 use guest_common::telemetry::record_sandbox_op;
@@ -517,6 +518,13 @@ async fn create_checkpoint_impl_with_artifacts(
         .and_then(|v| v.as_str());
 
     if let Some(id) = checkpoint_id {
+        write_final_session_history_identity(
+            mode,
+            &cli_agent_session_id,
+            &history_hash,
+            history_size,
+            &history_marker_payload,
+        );
         log_info!(LOG_TAG, "{} created successfully: {id}", mode.log_label());
         record_sandbox_op("checkpoint_api_call", api_start.elapsed(), true, None);
         Ok(())
@@ -527,6 +535,42 @@ async fn create_checkpoint_impl_with_artifacts(
             api_start,
             "Invalid checkpoint API response",
         ))
+    }
+}
+
+fn write_final_session_history_identity(
+    mode: CheckpointMode,
+    cli_agent_session_id: &str,
+    history_hash: &str,
+    history_size: u64,
+    history_marker_payload: &str,
+) {
+    if !matches!(mode, CheckpointMode::Success) {
+        return;
+    }
+    let identity = match build_final_session_history_identity(
+        env::Framework::from_env(),
+        cli_agent_session_id,
+        history_hash,
+        history_size,
+        history_marker_payload,
+    ) {
+        Ok(identity) => identity,
+        Err(error) => {
+            log_info!(LOG_TAG, "Final session history identity skipped: {error}");
+            return;
+        }
+    };
+    let bytes = match identity.to_json_vec() {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            log_info!(LOG_TAG, "Final session history identity skipped: {error}");
+            return;
+        }
+    };
+    match paths::write_private(paths::final_session_history_identity_file(), bytes) {
+        Ok(()) => log_info!(LOG_TAG, "Final session history identity written"),
+        Err(_) => log_warn!(LOG_TAG, "Failed to write final session history identity"),
     }
 }
 

--- a/crates/guest-agent/src/lib.rs
+++ b/crates/guest-agent/src/lib.rs
@@ -19,6 +19,7 @@ pub mod metrics;
 mod nofollow_fs;
 pub mod paths;
 pub mod session_history;
+pub mod session_history_identity;
 pub mod session_metadata;
 pub mod telemetry;
 pub mod timing;

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -12,6 +12,7 @@ use guest_agent::http::HttpClient;
 use guest_agent::masker;
 use guest_agent::metrics;
 use guest_agent::paths;
+use guest_agent::session_history_identity;
 use guest_agent::session_metadata;
 use guest_agent::telemetry::{Telemetry, UploadMode};
 
@@ -35,9 +36,33 @@ const CODEX_OAUTH_TOKEN_CONNECTOR: &str = "codex-oauth-token";
 
 #[tokio::main]
 async fn main() {
+    if let Some(exit_code) = helper_exit_code_from_args() {
+        std::process::exit(exit_code);
+    }
     guest_common::log::enable_system_log_file();
     let exit_code = run().await;
     std::process::exit(exit_code);
+}
+
+fn helper_exit_code_from_args() -> Option<i32> {
+    let mut args = std::env::args_os();
+    let _program = args.next()?;
+    let command = args.next()?;
+    if command != "verify-session-history-identity" {
+        return None;
+    }
+    let metadata_path = args
+        .next()
+        .unwrap_or_else(|| paths::final_session_history_identity_file().into());
+    if args.next().is_some() {
+        return Some(2);
+    }
+    Some(
+        match session_history_identity::verify_final_session_history_identity_file(metadata_path) {
+            Ok(()) => 0,
+            Err(_) => 1,
+        },
+    )
 }
 
 /// Top-level orchestrator. Returns exit code directly (never panics/errors out).

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -22,6 +22,7 @@ use agent_diagnostics::{
 };
 use guest_common::telemetry::record_sandbox_op;
 use guest_common::{log_error, log_info, log_warn};
+use guest_contracts::session_history_identity::FinalSessionHistoryIdentityExpectation;
 use serde_json::Value;
 use std::io::ErrorKind;
 use std::path::Path;
@@ -54,15 +55,62 @@ fn helper_exit_code_from_args() -> Option<i32> {
     let metadata_path = args
         .next()
         .unwrap_or_else(|| paths::final_session_history_identity_file().into());
-    if args.next().is_some() {
-        return Some(2);
-    }
+    let remaining = args.collect::<Vec<_>>();
+    let expected = match parse_session_history_identity_expectation(&remaining) {
+        Ok(expected) => expected,
+        Err(()) => return Some(2),
+    };
     Some(
-        match session_history_identity::verify_final_session_history_identity_file(metadata_path) {
+        match session_history_identity::verify_final_session_history_identity_file(
+            metadata_path,
+            expected.as_ref(),
+        ) {
             Ok(()) => 0,
             Err(_) => 1,
         },
     )
+}
+
+fn parse_session_history_identity_expectation(
+    args: &[std::ffi::OsString],
+) -> Result<Option<FinalSessionHistoryIdentityExpectation>, ()> {
+    let [
+        framework,
+        session_id_hash,
+        history_ref_kind,
+        history_hash,
+        history_size_bytes,
+    ] = match args {
+        [] => return Ok(None),
+        [
+            framework,
+            session_id_hash,
+            history_ref_kind,
+            history_hash,
+            history_size_bytes,
+        ] => [
+            framework,
+            session_id_hash,
+            history_ref_kind,
+            history_hash,
+            history_size_bytes,
+        ],
+        _ => return Err(()),
+    };
+    let framework = framework.to_str().ok_or(())?;
+    let session_id_hash = session_id_hash.to_str().ok_or(())?;
+    let history_ref_kind = history_ref_kind.to_str().ok_or(())?;
+    let history_hash = history_hash.to_str().ok_or(())?;
+    let history_size_bytes = history_size_bytes.to_str().ok_or(())?;
+    FinalSessionHistoryIdentityExpectation::from_cli_args([
+        framework,
+        session_id_hash,
+        history_ref_kind,
+        history_hash,
+        history_size_bytes,
+    ])
+    .map(Some)
+    .map_err(|_| ())
 }
 
 /// Top-level orchestrator. Returns exit code directly (never panics/errors out).

--- a/crates/guest-agent/src/paths.rs
+++ b/crates/guest-agent/src/paths.rs
@@ -75,6 +75,11 @@ static CHECKPOINT_ERROR_FILE: LazyLock<String> = LazyLock::new(|| {
         runtime_dir(),
     ))
 });
+static FINAL_SESSION_HISTORY_IDENTITY_FILE: LazyLock<String> = LazyLock::new(|| {
+    path_to_string(
+        guest_contracts::runtime_paths::final_session_history_identity_file(runtime_dir()),
+    )
+});
 static FAILURE_DIAGNOSTIC_FILE: LazyLock<String> = LazyLock::new(|| {
     path_to_string(guest_contracts::runtime_paths::failure_diagnostic_file(
         runtime_dir(),
@@ -98,6 +103,9 @@ pub fn event_error_flag() -> &'static str {
 }
 pub fn checkpoint_error_file() -> &'static str {
     &CHECKPOINT_ERROR_FILE
+}
+pub fn final_session_history_identity_file() -> &'static str {
+    &FINAL_SESSION_HISTORY_IDENTITY_FILE
 }
 pub fn failure_diagnostic_file() -> &'static str {
     &FAILURE_DIAGNOSTIC_FILE

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -34,11 +34,11 @@ use crate::error::AgentError;
 use crate::nofollow_fs::Dir;
 use guest_contracts::codex_thread_id::codex_thread_id_filename_key;
 use std::ffi::OsStr;
-use std::io;
+use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 
 #[cfg(target_os = "linux")]
-use std::{fs::File, io::Read};
+use std::fs::File;
 
 const CODEX_MARKER_PREFIX: &str = "CODEX_SEARCH:";
 // Checkpoint must resolve Codex history from user-controlled guest-home state.
@@ -79,13 +79,30 @@ pub fn read_session_history(path_file: &str) -> Result<Vec<u8>, AgentError> {
 /// The payload is either a literal path (Claude) or a
 /// codex marker.
 pub(crate) fn read_session_history_from_payload(payload: &str) -> Result<Vec<u8>, AgentError> {
+    read_session_history_from_payload_impl(payload, None)
+}
+
+/// Read session history bytes from an already-resolved marker payload, bounded
+/// to `max_bytes + 1` decoded bytes so callers can detect oversized history
+/// without loading the full file.
+pub(crate) fn read_session_history_from_payload_bounded(
+    payload: &str,
+    max_bytes: u64,
+) -> Result<Vec<u8>, AgentError> {
+    read_session_history_from_payload_impl(payload, Some(max_bytes))
+}
+
+fn read_session_history_from_payload_impl(
+    payload: &str,
+    max_bytes: Option<u64>,
+) -> Result<Vec<u8>, AgentError> {
     if is_codex_marker(payload) {
         let Some((sessions_dir, thread_id)) = decode_marker(payload) else {
             return Err(AgentError::Checkpoint(
                 "Invalid Codex session history marker".to_string(),
             ));
         };
-        return read_codex_session_history(&sessions_dir, thread_id)?.ok_or_else(|| {
+        return read_codex_session_history(&sessions_dir, thread_id, max_bytes)?.ok_or_else(|| {
             AgentError::Checkpoint(format!(
                 "Codex session file not found under {}",
                 sessions_dir.display()
@@ -94,7 +111,7 @@ pub(crate) fn read_session_history_from_payload(payload: &str) -> Result<Vec<u8>
     }
 
     let session_path = PathBuf::from(payload);
-    read_history_bytes(&session_path)
+    read_history_bytes(&session_path, max_bytes)
 }
 
 /// Parse a Codex marker into `(dir, thread_id)`. Markers are length-prefixed so
@@ -125,6 +142,7 @@ fn decode_len_prefixed_marker(rest: &str) -> Option<(PathBuf, &str)> {
 fn read_codex_session_history(
     sessions_dir: &Path,
     thread_id: &str,
+    max_bytes: Option<u64>,
 ) -> Result<Option<Vec<u8>>, AgentError> {
     let Some(id_norm) = codex_thread_id_filename_key(thread_id) else {
         return Ok(None);
@@ -132,7 +150,7 @@ fn read_codex_session_history(
     if !codex_sessions_parent_is_usable(sessions_dir)? {
         return Ok(None);
     }
-    read_codex_session_history_impl(sessions_dir, &id_norm)
+    read_codex_session_history_impl(sessions_dir, &id_norm, max_bytes)
 }
 
 fn codex_sessions_parent_is_usable(sessions_dir: &Path) -> Result<bool, AgentError> {
@@ -152,6 +170,7 @@ fn codex_sessions_parent_is_usable(sessions_dir: &Path) -> Result<bool, AgentErr
 fn read_codex_session_history_impl(
     sessions_dir: &Path,
     id_norm: &str,
+    max_bytes: Option<u64>,
 ) -> Result<Option<Vec<u8>>, AgentError> {
     let Some(root) = CodexSessionDir::open_root(sessions_dir)? else {
         return Ok(None);
@@ -166,7 +185,7 @@ fn read_codex_session_history_impl(
         &mut found,
         &mut budget,
     )?;
-    found.map(ResolvedCodexSession::read).transpose()
+    found.map(|session| session.read(max_bytes)).transpose()
 }
 
 fn scan_codex_session_dirs(
@@ -389,15 +408,15 @@ struct ResolvedCodexSession {
 }
 
 impl ResolvedCodexSession {
-    fn read(self) -> Result<Vec<u8>, AgentError> {
+    fn read(self, max_bytes: Option<u64>) -> Result<Vec<u8>, AgentError> {
         #[cfg(target_os = "linux")]
         {
-            read_history_bytes_from_file(&self.path, self.file)
+            read_history_bytes_from_file(&self.path, self.file, max_bytes)
         }
 
         #[cfg(not(target_os = "linux"))]
         {
-            read_history_bytes(&self.path)
+            read_history_bytes(&self.path, max_bytes)
         }
     }
 }
@@ -487,34 +506,85 @@ fn is_filesystem_loop_error(_: &io::Error) -> bool {
 }
 
 /// Read the bytes at `path`, decompressing legacy zstd files if the extension is `.zst`.
-fn read_history_bytes(path: &Path) -> Result<Vec<u8>, AgentError> {
-    let raw = std::fs::read(path).map_err(|e| read_history_error(path, e))?;
-    decode_history_bytes(path, raw)
+fn read_history_bytes(path: &Path, max_bytes: Option<u64>) -> Result<Vec<u8>, AgentError> {
+    let file = std::fs::File::open(path).map_err(|e| read_history_error(path, e))?;
+    read_history_bytes_from_reader(path, file, max_bytes)
 }
 
 #[cfg(target_os = "linux")]
-fn read_history_bytes_from_file(path: &Path, mut file: File) -> Result<Vec<u8>, AgentError> {
-    let mut raw = Vec::new();
-    file.read_to_end(&mut raw)
-        .map_err(|e| read_history_error(path, e))?;
-    decode_history_bytes(path, raw)
+fn read_history_bytes_from_file(
+    path: &Path,
+    file: File,
+    max_bytes: Option<u64>,
+) -> Result<Vec<u8>, AgentError> {
+    read_history_bytes_from_reader(path, file, max_bytes)
 }
 
 fn read_history_error(_path: &Path, source: io::Error) -> AgentError {
     AgentError::Checkpoint(format!("Failed to read session history: {source}"))
 }
 
-fn decode_history_bytes(path: &Path, raw: Vec<u8>) -> Result<Vec<u8>, AgentError> {
+fn read_history_bytes_from_reader(
+    path: &Path,
+    reader: impl Read,
+    max_bytes: Option<u64>,
+) -> Result<Vec<u8>, AgentError> {
     if path
         .extension()
         .is_some_and(|ext| ext.eq_ignore_ascii_case("zst"))
     {
-        zstd::decode_all(raw.as_slice()).map_err(|e| {
+        let decoder = zstd::stream::read::Decoder::new(reader).map_err(|e| {
             AgentError::Checkpoint(format!("Failed to decompress zstd session history: {e}"))
-        })
-    } else {
-        Ok(raw)
+        })?;
+        return read_zstd_history_reader(decoder, max_bytes);
     }
+    read_history_reader(path, reader, max_bytes)
+}
+
+fn read_zstd_history_reader(
+    mut reader: impl Read,
+    max_bytes: Option<u64>,
+) -> Result<Vec<u8>, AgentError> {
+    let mut bytes = Vec::new();
+    match max_bytes {
+        Some(max_bytes) => {
+            let limit = max_bytes.checked_add(1).ok_or_else(|| {
+                AgentError::Checkpoint("Session history read limit overflowed".to_string())
+            })?;
+            reader.by_ref().take(limit).read_to_end(&mut bytes)
+        }
+        None => reader.read_to_end(&mut bytes),
+    }
+    .map_err(|e| {
+        AgentError::Checkpoint(format!("Failed to decompress zstd session history: {e}"))
+    })?;
+    Ok(bytes)
+}
+
+fn read_history_reader(
+    path: &Path,
+    mut reader: impl Read,
+    max_bytes: Option<u64>,
+) -> Result<Vec<u8>, AgentError> {
+    let mut bytes = Vec::new();
+    match max_bytes {
+        Some(max_bytes) => {
+            let limit = max_bytes.checked_add(1).ok_or_else(|| {
+                AgentError::Checkpoint("Session history read limit overflowed".to_string())
+            })?;
+            reader
+                .by_ref()
+                .take(limit)
+                .read_to_end(&mut bytes)
+                .map_err(|e| read_history_error(path, e))?;
+        }
+        None => {
+            reader
+                .read_to_end(&mut bytes)
+                .map_err(|e| read_history_error(path, e))?;
+        }
+    }
+    Ok(bytes)
 }
 
 // Note: integration coverage for the public `read_session_history` entry

--- a/crates/guest-agent/src/session_history_identity.rs
+++ b/crates/guest-agent/src/session_history_identity.rs
@@ -6,7 +6,8 @@ use crate::session_history;
 use guest_contracts::codex_thread_id::canonical_codex_thread_id;
 use guest_contracts::session_history_identity::{
     FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES, FinalSessionHistoryFramework,
-    FinalSessionHistoryIdentity, FinalSessionHistoryIdentityError, FinalSessionHistoryRefKind,
+    FinalSessionHistoryIdentity, FinalSessionHistoryIdentityError,
+    FinalSessionHistoryIdentityExpectation, FinalSessionHistoryRefKind,
     SESSION_HISTORY_IDENTITY_VERIFY_MAX_BYTES,
 };
 use sha2::{Digest, Sha256};
@@ -54,8 +55,14 @@ fn final_framework(framework: env::Framework) -> FinalSessionHistoryFramework {
 /// Verify the current guest session history matches final identity metadata.
 pub fn verify_final_session_history_identity_file(
     metadata_path: impl AsRef<Path>,
+    expected: Option<&FinalSessionHistoryIdentityExpectation>,
 ) -> Result<(), FinalSessionHistoryIdentityVerifyError> {
     let identity = read_final_session_history_identity(metadata_path)?;
+    if let Some(expected) = expected
+        && !expected.matches_identity(&identity)
+    {
+        return Err(FinalSessionHistoryIdentityVerifyError::ExpectedIdentityMismatch);
+    }
     verify_final_session_history_identity(&identity)
 }
 
@@ -140,6 +147,8 @@ pub enum FinalSessionHistoryIdentityVerifyError {
     InvalidMetadata(FinalSessionHistoryIdentityError),
     /// Metadata framework does not match the marker shape.
     FrameworkMismatch,
+    /// Metadata does not match the identity runner expected to verify.
+    ExpectedIdentityMismatch,
     /// Session history bytes could not be read.
     HistoryRead(AgentError),
     /// Session history size or hash does not match metadata.
@@ -153,6 +162,9 @@ impl fmt::Display for FinalSessionHistoryIdentityVerifyError {
             Self::InvalidMetadata(error) => write!(f, "{error}"),
             Self::FrameworkMismatch => {
                 f.write_str("final session history identity framework mismatch")
+            }
+            Self::ExpectedIdentityMismatch => {
+                f.write_str("final session history identity did not match expected identity")
             }
             Self::HistoryRead(_) => f.write_str("final session history could not be read"),
             Self::HistoryMismatch => f.write_str("final session history did not match identity"),
@@ -193,7 +205,7 @@ mod tests {
         .unwrap();
         let metadata_path = write_metadata(&dir, &identity);
 
-        verify_final_session_history_identity_file(metadata_path).unwrap();
+        verify_final_session_history_identity_file(metadata_path, None).unwrap();
     }
 
     #[test]
@@ -221,7 +233,7 @@ mod tests {
         .unwrap();
         let metadata_path = write_metadata(&dir, &identity);
 
-        verify_final_session_history_identity_file(metadata_path).unwrap();
+        verify_final_session_history_identity_file(metadata_path, None).unwrap();
     }
 
     #[test]
@@ -240,7 +252,7 @@ mod tests {
         .unwrap();
         let metadata_path = write_metadata(&dir, &identity);
 
-        let err = verify_final_session_history_identity_file(metadata_path).unwrap_err();
+        let err = verify_final_session_history_identity_file(metadata_path, None).unwrap_err();
         assert!(matches!(
             err,
             FinalSessionHistoryIdentityVerifyError::HistoryMismatch
@@ -258,7 +270,7 @@ mod tests {
         ])
         .unwrap();
 
-        let err = verify_final_session_history_identity_file(metadata_path).unwrap_err();
+        let err = verify_final_session_history_identity_file(metadata_path, None).unwrap_err();
         assert!(matches!(
             err,
             FinalSessionHistoryIdentityVerifyError::InvalidMetadata(
@@ -299,10 +311,43 @@ mod tests {
         .unwrap();
         let metadata_path = write_metadata(&dir, &identity);
 
-        let err = verify_final_session_history_identity_file(metadata_path).unwrap_err();
+        let err = verify_final_session_history_identity_file(metadata_path, None).unwrap_err();
         assert!(matches!(
             err,
             FinalSessionHistoryIdentityVerifyError::HistoryMismatch
+        ));
+    }
+
+    #[test]
+    fn rejects_expected_identity_mismatch() {
+        let dir = tempfile::tempdir().unwrap();
+        let history = br#"{"type":"system"}"#;
+        let history_path = dir.path().join("history.jsonl");
+        std::fs::write(&history_path, history).unwrap();
+        let identity = FinalSessionHistoryIdentity::new(
+            FinalSessionHistoryFramework::ClaudeCode,
+            "a".repeat(64),
+            FinalSessionHistoryRefKind::Blob,
+            hex::encode(Sha256::digest(history)),
+            history.len() as u64,
+            history_path.to_string_lossy(),
+        )
+        .unwrap();
+        let expected = FinalSessionHistoryIdentityExpectation::new(
+            FinalSessionHistoryFramework::ClaudeCode,
+            "a".repeat(64),
+            FinalSessionHistoryRefKind::Blob,
+            "b".repeat(64),
+            history.len() as u64,
+        )
+        .unwrap();
+        let metadata_path = write_metadata(&dir, &identity);
+
+        let err =
+            verify_final_session_history_identity_file(metadata_path, Some(&expected)).unwrap_err();
+        assert!(matches!(
+            err,
+            FinalSessionHistoryIdentityVerifyError::ExpectedIdentityMismatch
         ));
     }
 }

--- a/crates/guest-agent/src/session_history_identity.rs
+++ b/crates/guest-agent/src/session_history_identity.rs
@@ -1,0 +1,308 @@
+//! Final session-history identity helpers for checkpoint and runner reuse.
+
+use crate::env;
+use crate::error::AgentError;
+use crate::session_history;
+use guest_contracts::codex_thread_id::canonical_codex_thread_id;
+use guest_contracts::session_history_identity::{
+    FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES, FinalSessionHistoryFramework,
+    FinalSessionHistoryIdentity, FinalSessionHistoryIdentityError, FinalSessionHistoryRefKind,
+    SESSION_HISTORY_IDENTITY_VERIFY_MAX_BYTES,
+};
+use sha2::{Digest, Sha256};
+use std::fmt;
+use std::io::Read;
+use std::path::Path;
+
+/// Build final session-history identity metadata for a successful checkpoint.
+pub(crate) fn build_final_session_history_identity(
+    framework: env::Framework,
+    cli_agent_session_id: &str,
+    history_hash: &str,
+    history_size_bytes: u64,
+    history_marker_payload: &str,
+) -> Result<FinalSessionHistoryIdentity, FinalSessionHistoryIdentityBuildError> {
+    let session_id_hash = session_id_hash(framework, cli_agent_session_id)
+        .ok_or(FinalSessionHistoryIdentityBuildError::InvalidSessionId)?;
+    let framework = final_framework(framework);
+    FinalSessionHistoryIdentity::new(
+        framework,
+        session_id_hash,
+        FinalSessionHistoryRefKind::Blob,
+        history_hash,
+        history_size_bytes,
+        history_marker_payload,
+    )
+    .map_err(FinalSessionHistoryIdentityBuildError::InvalidMetadata)
+}
+
+fn session_id_hash(framework: env::Framework, session_id: &str) -> Option<String> {
+    let normalized = match framework {
+        env::Framework::ClaudeCode => session_id.to_owned(),
+        env::Framework::Codex => canonical_codex_thread_id(session_id)?,
+    };
+    Some(hex::encode(Sha256::digest(normalized.as_bytes())))
+}
+
+fn final_framework(framework: env::Framework) -> FinalSessionHistoryFramework {
+    match framework {
+        env::Framework::ClaudeCode => FinalSessionHistoryFramework::ClaudeCode,
+        env::Framework::Codex => FinalSessionHistoryFramework::Codex,
+    }
+}
+
+/// Verify the current guest session history matches final identity metadata.
+pub fn verify_final_session_history_identity_file(
+    metadata_path: impl AsRef<Path>,
+) -> Result<(), FinalSessionHistoryIdentityVerifyError> {
+    let identity = read_final_session_history_identity(metadata_path)?;
+    verify_final_session_history_identity(&identity)
+}
+
+fn read_final_session_history_identity(
+    metadata_path: impl AsRef<Path>,
+) -> Result<FinalSessionHistoryIdentity, FinalSessionHistoryIdentityVerifyError> {
+    let mut file = std::fs::File::open(metadata_path)
+        .map_err(|_| FinalSessionHistoryIdentityVerifyError::MetadataRead)?;
+    let mut bytes = Vec::new();
+    file.by_ref()
+        .take(FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|_| FinalSessionHistoryIdentityVerifyError::MetadataRead)?;
+    if bytes.len() as u64 > FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES {
+        return Err(FinalSessionHistoryIdentityVerifyError::InvalidMetadata(
+            FinalSessionHistoryIdentityError::MetadataTooLarge,
+        ));
+    }
+    FinalSessionHistoryIdentity::from_json_slice(&bytes)
+        .map_err(FinalSessionHistoryIdentityVerifyError::InvalidMetadata)
+}
+
+fn verify_final_session_history_identity(
+    identity: &FinalSessionHistoryIdentity,
+) -> Result<(), FinalSessionHistoryIdentityVerifyError> {
+    match identity.framework {
+        FinalSessionHistoryFramework::ClaudeCode => {
+            if session_history::is_codex_marker(&identity.history_marker_payload) {
+                return Err(FinalSessionHistoryIdentityVerifyError::FrameworkMismatch);
+            }
+        }
+        FinalSessionHistoryFramework::Codex => {
+            if !session_history::is_codex_marker(&identity.history_marker_payload) {
+                return Err(FinalSessionHistoryIdentityVerifyError::FrameworkMismatch);
+            }
+        }
+    }
+
+    let history_bytes = session_history::read_session_history_from_payload_bounded(
+        &identity.history_marker_payload,
+        SESSION_HISTORY_IDENTITY_VERIFY_MAX_BYTES,
+    )
+    .map_err(FinalSessionHistoryIdentityVerifyError::HistoryRead)?;
+    if history_bytes.len() as u64 != identity.history_size_bytes {
+        return Err(FinalSessionHistoryIdentityVerifyError::HistoryMismatch);
+    }
+    let actual_hash = hex::encode(Sha256::digest(&history_bytes));
+    if actual_hash != identity.history_hash {
+        return Err(FinalSessionHistoryIdentityVerifyError::HistoryMismatch);
+    }
+    Ok(())
+}
+
+/// Error returned while building final identity metadata.
+#[derive(Debug)]
+pub(crate) enum FinalSessionHistoryIdentityBuildError {
+    /// Session id cannot be normalized for the current framework.
+    InvalidSessionId,
+    /// Metadata violates the shared final identity contract.
+    InvalidMetadata(FinalSessionHistoryIdentityError),
+}
+
+impl fmt::Display for FinalSessionHistoryIdentityBuildError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidSessionId => {
+                f.write_str("final session history identity session id is invalid")
+            }
+            Self::InvalidMetadata(error) => write!(f, "{error}"),
+        }
+    }
+}
+
+impl std::error::Error for FinalSessionHistoryIdentityBuildError {}
+
+/// Error returned while verifying final identity metadata.
+#[derive(Debug)]
+pub enum FinalSessionHistoryIdentityVerifyError {
+    /// Metadata file could not be read.
+    MetadataRead,
+    /// Metadata failed shared contract validation.
+    InvalidMetadata(FinalSessionHistoryIdentityError),
+    /// Metadata framework does not match the marker shape.
+    FrameworkMismatch,
+    /// Session history bytes could not be read.
+    HistoryRead(AgentError),
+    /// Session history size or hash does not match metadata.
+    HistoryMismatch,
+}
+
+impl fmt::Display for FinalSessionHistoryIdentityVerifyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MetadataRead => f.write_str("final session history identity could not be read"),
+            Self::InvalidMetadata(error) => write!(f, "{error}"),
+            Self::FrameworkMismatch => {
+                f.write_str("final session history identity framework mismatch")
+            }
+            Self::HistoryRead(_) => f.write_str("final session history could not be read"),
+            Self::HistoryMismatch => f.write_str("final session history did not match identity"),
+        }
+    }
+}
+
+impl std::error::Error for FinalSessionHistoryIdentityVerifyError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_metadata(
+        dir: &tempfile::TempDir,
+        identity: &FinalSessionHistoryIdentity,
+    ) -> std::path::PathBuf {
+        let path = dir.path().join("identity.json");
+        std::fs::write(&path, identity.to_json_vec().unwrap()).unwrap();
+        path
+    }
+
+    #[test]
+    fn verifies_claude_literal_history() {
+        let dir = tempfile::tempdir().unwrap();
+        let history = br#"{"type":"system"}"#;
+        let history_path = dir.path().join("history.jsonl");
+        std::fs::write(&history_path, history).unwrap();
+        let identity = FinalSessionHistoryIdentity::new(
+            FinalSessionHistoryFramework::ClaudeCode,
+            "a".repeat(64),
+            FinalSessionHistoryRefKind::Blob,
+            hex::encode(Sha256::digest(history)),
+            history.len() as u64,
+            history_path.to_string_lossy(),
+        )
+        .unwrap();
+        let metadata_path = write_metadata(&dir, &identity);
+
+        verify_final_session_history_identity_file(metadata_path).unwrap();
+    }
+
+    #[test]
+    fn verifies_codex_marker_history() {
+        let dir = tempfile::tempdir().unwrap();
+        let sessions_dir = dir.path().join("sessions");
+        let history_dir = sessions_dir.join("2026").join("06").join("29");
+        std::fs::create_dir_all(&history_dir).unwrap();
+        let thread_id = "00000000-0000-4000-8000-000000000001";
+        let history = br#"{"type":"session_meta","timestamp":"2026-06-29T10:00:00Z"}"#;
+        std::fs::write(
+            history_dir.join("rollout-2026-06-29T10-00-00-00000000000040008000000000000001.jsonl"),
+            history,
+        )
+        .unwrap();
+        let marker = session_history::codex_marker_payload(&sessions_dir, thread_id);
+        let identity = FinalSessionHistoryIdentity::new(
+            FinalSessionHistoryFramework::Codex,
+            "a".repeat(64),
+            FinalSessionHistoryRefKind::Blob,
+            hex::encode(Sha256::digest(history)),
+            history.len() as u64,
+            marker,
+        )
+        .unwrap();
+        let metadata_path = write_metadata(&dir, &identity);
+
+        verify_final_session_history_identity_file(metadata_path).unwrap();
+    }
+
+    #[test]
+    fn rejects_history_mismatch() {
+        let dir = tempfile::tempdir().unwrap();
+        let history_path = dir.path().join("history.jsonl");
+        std::fs::write(&history_path, b"changed").unwrap();
+        let identity = FinalSessionHistoryIdentity::new(
+            FinalSessionHistoryFramework::ClaudeCode,
+            "a".repeat(64),
+            FinalSessionHistoryRefKind::Blob,
+            "b".repeat(64),
+            7,
+            history_path.to_string_lossy(),
+        )
+        .unwrap();
+        let metadata_path = write_metadata(&dir, &identity);
+
+        let err = verify_final_session_history_identity_file(metadata_path).unwrap_err();
+        assert!(matches!(
+            err,
+            FinalSessionHistoryIdentityVerifyError::HistoryMismatch
+        ));
+    }
+
+    #[test]
+    fn rejects_oversized_metadata_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let metadata_path = dir.path().join("identity.json");
+        let mut file = std::fs::File::create(&metadata_path).unwrap();
+        file.write_all(&vec![
+            b'x';
+            FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES as usize + 1
+        ])
+        .unwrap();
+
+        let err = verify_final_session_history_identity_file(metadata_path).unwrap_err();
+        assert!(matches!(
+            err,
+            FinalSessionHistoryIdentityVerifyError::InvalidMetadata(
+                FinalSessionHistoryIdentityError::MetadataTooLarge
+            )
+        ));
+    }
+
+    #[test]
+    fn build_rejects_history_above_verify_cap() {
+        let err = FinalSessionHistoryIdentity::new(
+            FinalSessionHistoryFramework::ClaudeCode,
+            "a".repeat(64),
+            FinalSessionHistoryRefKind::Blob,
+            "b".repeat(64),
+            SESSION_HISTORY_IDENTITY_VERIFY_MAX_BYTES + 1,
+            "/history.jsonl",
+        )
+        .unwrap_err();
+        assert_eq!(err, FinalSessionHistoryIdentityError::HistoryTooLarge);
+    }
+
+    #[test]
+    fn rejects_current_history_above_verify_cap() {
+        let dir = tempfile::tempdir().unwrap();
+        let history_path = dir.path().join("history.jsonl");
+        let expected_history = vec![b'a'; SESSION_HISTORY_IDENTITY_VERIFY_MAX_BYTES as usize];
+        let oversized_history = vec![b'a'; SESSION_HISTORY_IDENTITY_VERIFY_MAX_BYTES as usize + 1];
+        std::fs::write(&history_path, oversized_history).unwrap();
+        let identity = FinalSessionHistoryIdentity::new(
+            FinalSessionHistoryFramework::ClaudeCode,
+            "a".repeat(64),
+            FinalSessionHistoryRefKind::Blob,
+            hex::encode(Sha256::digest(&expected_history)),
+            expected_history.len() as u64,
+            history_path.to_string_lossy(),
+        )
+        .unwrap();
+        let metadata_path = write_metadata(&dir, &identity);
+
+        let err = verify_final_session_history_identity_file(metadata_path).unwrap_err();
+        assert!(matches!(
+            err,
+            FinalSessionHistoryIdentityVerifyError::HistoryMismatch
+        ));
+    }
+}

--- a/crates/guest-agent/tests/integration/checkpoint.rs
+++ b/crates/guest-agent/tests/integration/checkpoint.rs
@@ -1,4 +1,7 @@
 use crate::support::*;
+use guest_contracts::session_history_identity::{
+    FinalSessionHistoryFramework, FinalSessionHistoryIdentity, FinalSessionHistoryRefKind,
+};
 use httpmock::prelude::*;
 use serde_json::json;
 use sha2::{Digest, Sha256};
@@ -99,6 +102,22 @@ async fn success_checkpoint_uploads_non_utf8_session_history() {
     prepare_mock.assert_calls_async(1).await;
     upload_mock.assert_calls_async(1).await;
     checkpoint_mock.assert_calls_async(1).await;
+
+    let identity_bytes =
+        std::fs::read(guest_agent::paths::final_session_history_identity_file()).unwrap();
+    let identity = FinalSessionHistoryIdentity::from_json_slice(&identity_bytes).unwrap();
+    assert_eq!(identity.framework, FinalSessionHistoryFramework::ClaudeCode);
+    assert_eq!(identity.history_ref_kind, FinalSessionHistoryRefKind::Blob);
+    assert_eq!(
+        identity.session_id_hash,
+        hex::encode(Sha256::digest(b"success-non-utf8-session"))
+    );
+    assert_eq!(identity.history_hash, history_hash);
+    assert_eq!(identity.history_size_bytes, history_size as u64);
+    assert_eq!(
+        std::fs::read(&identity.history_marker_payload).unwrap(),
+        history
+    );
 }
 
 // =========================================================================
@@ -156,6 +175,10 @@ async fn recovery_checkpoint_uploads_valid_session_history() {
     prepare_mock.assert_calls_async(1).await;
     upload_mock.assert_calls_async(1).await;
     checkpoint_mock.assert_calls_async(1).await;
+    assert!(
+        !std::path::Path::new(guest_agent::paths::final_session_history_identity_file()).exists(),
+        "recovery checkpoint must not write final session history identity metadata"
+    );
 }
 
 async fn assert_recovery_checkpoint_derives_claude_history_marker(

--- a/crates/guest-agent/tests/integration/support.rs
+++ b/crates/guest-agent/tests/integration/support.rs
@@ -196,6 +196,7 @@ impl MockCallObserver {
 fn cleanup_session_checkpoint_files() {
     let _ = std::fs::remove_file(guest_agent::paths::session_id_file());
     let _ = std::fs::remove_file(guest_agent::paths::session_history_path_file());
+    let _ = std::fs::remove_file(guest_agent::paths::final_session_history_identity_file());
     let _ = std::fs::remove_file(guest_agent::paths::checkpoint_error_file());
     let _ = std::fs::remove_file(guest_agent::paths::failure_diagnostic_file());
 }

--- a/crates/guest-contracts/Cargo.toml
+++ b/crates/guest-contracts/Cargo.toml
@@ -6,6 +6,8 @@ description = "Shared contracts between runner and guest binaries"
 
 [dependencies]
 libc.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]

--- a/crates/guest-contracts/src/lib.rs
+++ b/crates/guest-contracts/src/lib.rs
@@ -8,3 +8,4 @@
 pub mod codex_thread_id;
 pub mod env;
 pub mod runtime_paths;
+pub mod session_history_identity;

--- a/crates/guest-contracts/src/runtime_paths.rs
+++ b/crates/guest-contracts/src/runtime_paths.rs
@@ -154,6 +154,11 @@ pub fn checkpoint_error_file(run_dir: impl AsRef<Path>) -> PathBuf {
     file(run_dir, "checkpoint-error")
 }
 
+/// Return the run-root `final-session-history-identity.json` file.
+pub fn final_session_history_identity_file(run_dir: impl AsRef<Path>) -> PathBuf {
+    file(run_dir, "final-session-history-identity.json")
+}
+
 /// Return the run-root `failure-diagnostic.json` file.
 pub fn failure_diagnostic_file(run_dir: impl AsRef<Path>) -> PathBuf {
     file(run_dir, "failure-diagnostic.json")
@@ -874,6 +879,7 @@ mod tests {
             session_history_marker_file(&run_dir),
             event_error_file(&run_dir),
             checkpoint_error_file(&run_dir),
+            final_session_history_identity_file(&run_dir),
             failure_diagnostic_file(&run_dir),
             system_log_file(&run_dir),
             agent_log_file(&run_dir),

--- a/crates/guest-contracts/src/session_history_identity.rs
+++ b/crates/guest-contracts/src/session_history_identity.rs
@@ -123,6 +123,131 @@ impl FinalSessionHistoryIdentity {
     }
 }
 
+impl FinalSessionHistoryFramework {
+    /// Return the stable CLI argument spelling used by runner and guest-agent.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ClaudeCode => "claude-code",
+            Self::Codex => "codex",
+        }
+    }
+
+    /// Parse the stable CLI argument spelling used by runner and guest-agent.
+    pub fn parse_cli_arg(value: &str) -> Result<Self, FinalSessionHistoryIdentityError> {
+        match value {
+            "claude-code" => Ok(Self::ClaudeCode),
+            "codex" => Ok(Self::Codex),
+            _ => Err(FinalSessionHistoryIdentityError::InvalidFramework),
+        }
+    }
+}
+
+impl FinalSessionHistoryRefKind {
+    /// Return the stable CLI argument spelling used by runner and guest-agent.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Blob => "blob",
+        }
+    }
+
+    /// Parse the stable CLI argument spelling used by runner and guest-agent.
+    pub fn parse_cli_arg(value: &str) -> Result<Self, FinalSessionHistoryIdentityError> {
+        match value {
+            "blob" => Ok(Self::Blob),
+            _ => Err(FinalSessionHistoryIdentityError::InvalidHistoryRefKind),
+        }
+    }
+}
+
+/// Expected final identity fields supplied by runner when verifying a parked
+/// sandbox's checkpointed metadata.
+#[derive(Clone, Eq, PartialEq)]
+pub struct FinalSessionHistoryIdentityExpectation {
+    /// CLI framework expected by runner.
+    pub framework: FinalSessionHistoryFramework,
+    /// SHA-256 hash of the framework-normalized CLI session id expected by runner.
+    pub session_id_hash: String,
+    /// Server resume history ref kind expected by runner.
+    pub history_ref_kind: FinalSessionHistoryRefKind,
+    /// SHA-256 hash of final session-history bytes expected by runner.
+    pub history_hash: String,
+    /// Exact final session-history byte length expected by runner.
+    pub history_size_bytes: u64,
+}
+
+impl fmt::Debug for FinalSessionHistoryIdentityExpectation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FinalSessionHistoryIdentityExpectation")
+            .field("framework", &self.framework)
+            .field("session_id_hash", &"[redacted]")
+            .field("history_ref_kind", &self.history_ref_kind)
+            .field("history_hash", &"[redacted]")
+            .field("history_size_bytes", &self.history_size_bytes)
+            .finish()
+    }
+}
+
+impl FinalSessionHistoryIdentityExpectation {
+    /// Build validated expected final identity fields.
+    pub fn new(
+        framework: FinalSessionHistoryFramework,
+        session_id_hash: impl Into<String>,
+        history_ref_kind: FinalSessionHistoryRefKind,
+        history_hash: impl Into<String>,
+        history_size_bytes: u64,
+    ) -> Result<Self, FinalSessionHistoryIdentityError> {
+        let expectation = Self {
+            framework,
+            session_id_hash: session_id_hash.into(),
+            history_ref_kind,
+            history_hash: history_hash.into(),
+            history_size_bytes,
+        };
+        expectation.validate()?;
+        Ok(expectation)
+    }
+
+    /// Parse expected final identity fields from helper CLI arguments.
+    pub fn from_cli_args(args: [&str; 5]) -> Result<Self, FinalSessionHistoryIdentityError> {
+        let history_size_bytes = args[4]
+            .parse::<u64>()
+            .map_err(|_| FinalSessionHistoryIdentityError::InvalidHistorySize)?;
+        Self::new(
+            FinalSessionHistoryFramework::parse_cli_arg(args[0])?,
+            args[1],
+            FinalSessionHistoryRefKind::parse_cli_arg(args[2])?,
+            args[3],
+            history_size_bytes,
+        )
+    }
+
+    /// Validate expected final identity invariants.
+    pub fn validate(&self) -> Result<(), FinalSessionHistoryIdentityError> {
+        if !is_sha256_hex(&self.session_id_hash) {
+            return Err(FinalSessionHistoryIdentityError::InvalidSessionIdHash);
+        }
+        if !is_sha256_hex(&self.history_hash) {
+            return Err(FinalSessionHistoryIdentityError::InvalidHistoryHash);
+        }
+        if self.history_size_bytes == 0 {
+            return Err(FinalSessionHistoryIdentityError::InvalidHistorySize);
+        }
+        if self.history_size_bytes > SESSION_HISTORY_IDENTITY_VERIFY_MAX_BYTES {
+            return Err(FinalSessionHistoryIdentityError::HistoryTooLarge);
+        }
+        Ok(())
+    }
+
+    /// Return whether metadata read from the guest still matches runner's expected identity.
+    pub fn matches_identity(&self, identity: &FinalSessionHistoryIdentity) -> bool {
+        self.framework == identity.framework
+            && self.session_id_hash == identity.session_id_hash
+            && self.history_ref_kind == identity.history_ref_kind
+            && self.history_hash == identity.history_hash
+            && self.history_size_bytes == identity.history_size_bytes
+    }
+}
+
 impl fmt::Debug for FinalSessionHistoryIdentity {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("FinalSessionHistoryIdentity")
@@ -146,6 +271,10 @@ pub enum FinalSessionHistoryIdentityError {
     InvalidJson,
     /// Metadata version is unsupported.
     UnsupportedVersion,
+    /// Framework value is not recognized.
+    InvalidFramework,
+    /// History ref kind value is not recognized.
+    InvalidHistoryRefKind,
     /// Session id hash is not a SHA-256 hex digest.
     InvalidSessionIdHash,
     /// History hash is not a SHA-256 hex digest.
@@ -165,6 +294,12 @@ impl fmt::Display for FinalSessionHistoryIdentityError {
             Self::InvalidJson => f.write_str("final session history identity is invalid JSON"),
             Self::UnsupportedVersion => {
                 f.write_str("final session history identity version is unsupported")
+            }
+            Self::InvalidFramework => {
+                f.write_str("final session history identity framework is invalid")
+            }
+            Self::InvalidHistoryRefKind => {
+                f.write_str("final session history identity ref kind is invalid")
             }
             Self::InvalidSessionIdHash => {
                 f.write_str("final session history identity session id hash is invalid")
@@ -294,5 +429,53 @@ mod tests {
         assert!(!debug.contains(&identity.session_id_hash));
         assert!(!debug.contains(&identity.history_hash));
         assert!(!debug.contains(&identity.history_marker_payload));
+    }
+
+    #[test]
+    fn final_identity_expectation_parses_cli_args_and_matches_identity() {
+        let identity = valid_identity();
+        let expectation = FinalSessionHistoryIdentityExpectation::from_cli_args([
+            identity.framework.as_str(),
+            &identity.session_id_hash,
+            identity.history_ref_kind.as_str(),
+            &identity.history_hash,
+            &identity.history_size_bytes.to_string(),
+        ])
+        .unwrap();
+
+        assert!(expectation.matches_identity(&identity));
+    }
+
+    #[test]
+    fn final_identity_expectation_detects_mismatch() {
+        let identity = valid_identity();
+        let expectation = FinalSessionHistoryIdentityExpectation::new(
+            identity.framework,
+            identity.session_id_hash.clone(),
+            identity.history_ref_kind,
+            "c".repeat(64),
+            identity.history_size_bytes,
+        )
+        .unwrap();
+
+        assert!(!expectation.matches_identity(&identity));
+    }
+
+    #[test]
+    fn final_identity_expectation_debug_redacts_sensitive_fields() {
+        let identity = valid_identity();
+        let expectation = FinalSessionHistoryIdentityExpectation::new(
+            identity.framework,
+            identity.session_id_hash.clone(),
+            identity.history_ref_kind,
+            identity.history_hash.clone(),
+            identity.history_size_bytes,
+        )
+        .unwrap();
+        let debug = format!("{expectation:?}");
+
+        assert!(debug.contains("[redacted]"));
+        assert!(!debug.contains(&identity.session_id_hash));
+        assert!(!debug.contains(&identity.history_hash));
     }
 }

--- a/crates/guest-contracts/src/session_history_identity.rs
+++ b/crates/guest-contracts/src/session_history_identity.rs
@@ -1,0 +1,298 @@
+//! Shared final session-history identity metadata.
+//!
+//! The guest-agent writes this run-private metadata after a successful
+//! checkpoint. Runner consumes it to decide whether a parked idle sandbox can
+//! safely skip session-history restore on a later same-session run.
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Current final session-history identity metadata format version.
+pub const FINAL_SESSION_HISTORY_IDENTITY_VERSION: u8 = 1;
+
+/// Maximum size of the serialized final identity metadata file.
+pub const FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES: u64 = 16 * 1024;
+
+/// Maximum session-history bytes verified for idle restore skip.
+pub const SESSION_HISTORY_IDENTITY_VERIFY_MAX_BYTES: u64 = 1024 * 1024;
+
+/// Framework that owns a final session-history file.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum FinalSessionHistoryFramework {
+    /// Claude Code session history.
+    ClaudeCode,
+    /// Codex session history.
+    Codex,
+}
+
+/// Storage ref kind for final session-history bytes.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum FinalSessionHistoryRefKind {
+    /// Hash-backed blob storage.
+    Blob,
+}
+
+/// Run-private final session-history identity metadata.
+#[derive(Clone, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FinalSessionHistoryIdentity {
+    /// Metadata schema version.
+    pub version: u8,
+    /// CLI framework.
+    pub framework: FinalSessionHistoryFramework,
+    /// SHA-256 hash of the framework-normalized CLI session id.
+    pub session_id_hash: String,
+    /// Server resume history ref kind.
+    pub history_ref_kind: FinalSessionHistoryRefKind,
+    /// SHA-256 hash of final session-history bytes.
+    pub history_hash: String,
+    /// Exact final session-history byte length.
+    pub history_size_bytes: u64,
+    /// Private guest marker used to read final framework history.
+    pub history_marker_payload: String,
+}
+
+impl FinalSessionHistoryIdentity {
+    /// Build validated final identity metadata.
+    pub fn new(
+        framework: FinalSessionHistoryFramework,
+        session_id_hash: impl Into<String>,
+        history_ref_kind: FinalSessionHistoryRefKind,
+        history_hash: impl Into<String>,
+        history_size_bytes: u64,
+        history_marker_payload: impl Into<String>,
+    ) -> Result<Self, FinalSessionHistoryIdentityError> {
+        let identity = Self {
+            version: FINAL_SESSION_HISTORY_IDENTITY_VERSION,
+            framework,
+            session_id_hash: session_id_hash.into(),
+            history_ref_kind,
+            history_hash: history_hash.into(),
+            history_size_bytes,
+            history_marker_payload: history_marker_payload.into(),
+        };
+        identity.validate()?;
+        Ok(identity)
+    }
+
+    /// Parse and validate final identity metadata from JSON bytes.
+    pub fn from_json_slice(bytes: &[u8]) -> Result<Self, FinalSessionHistoryIdentityError> {
+        if bytes.len() as u64 > FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES {
+            return Err(FinalSessionHistoryIdentityError::MetadataTooLarge);
+        }
+        let identity: Self = serde_json::from_slice(bytes)
+            .map_err(|_| FinalSessionHistoryIdentityError::InvalidJson)?;
+        identity.validate()?;
+        Ok(identity)
+    }
+
+    /// Serialize validated final identity metadata to JSON bytes.
+    pub fn to_json_vec(&self) -> Result<Vec<u8>, FinalSessionHistoryIdentityError> {
+        self.validate()?;
+        let bytes =
+            serde_json::to_vec(self).map_err(|_| FinalSessionHistoryIdentityError::InvalidJson)?;
+        if bytes.len() as u64 > FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES {
+            return Err(FinalSessionHistoryIdentityError::MetadataTooLarge);
+        }
+        Ok(bytes)
+    }
+
+    /// Validate final identity metadata invariants.
+    pub fn validate(&self) -> Result<(), FinalSessionHistoryIdentityError> {
+        if self.version != FINAL_SESSION_HISTORY_IDENTITY_VERSION {
+            return Err(FinalSessionHistoryIdentityError::UnsupportedVersion);
+        }
+        if !is_sha256_hex(&self.session_id_hash) {
+            return Err(FinalSessionHistoryIdentityError::InvalidSessionIdHash);
+        }
+        if !is_sha256_hex(&self.history_hash) {
+            return Err(FinalSessionHistoryIdentityError::InvalidHistoryHash);
+        }
+        if self.history_size_bytes == 0 {
+            return Err(FinalSessionHistoryIdentityError::InvalidHistorySize);
+        }
+        if self.history_size_bytes > SESSION_HISTORY_IDENTITY_VERIFY_MAX_BYTES {
+            return Err(FinalSessionHistoryIdentityError::HistoryTooLarge);
+        }
+        if self.history_marker_payload.trim().is_empty() {
+            return Err(FinalSessionHistoryIdentityError::MissingHistoryMarker);
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Debug for FinalSessionHistoryIdentity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FinalSessionHistoryIdentity")
+            .field("version", &self.version)
+            .field("framework", &self.framework)
+            .field("session_id_hash", &"[redacted]")
+            .field("history_ref_kind", &self.history_ref_kind)
+            .field("history_hash", &"[redacted]")
+            .field("history_size_bytes", &self.history_size_bytes)
+            .field("history_marker_payload", &"[redacted]")
+            .finish()
+    }
+}
+
+/// Final identity metadata validation error.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FinalSessionHistoryIdentityError {
+    /// Metadata file exceeds the metadata read cap.
+    MetadataTooLarge,
+    /// Metadata is not valid JSON.
+    InvalidJson,
+    /// Metadata version is unsupported.
+    UnsupportedVersion,
+    /// Session id hash is not a SHA-256 hex digest.
+    InvalidSessionIdHash,
+    /// History hash is not a SHA-256 hex digest.
+    InvalidHistoryHash,
+    /// History size is zero.
+    InvalidHistorySize,
+    /// History size exceeds the verification cap.
+    HistoryTooLarge,
+    /// History marker payload is missing.
+    MissingHistoryMarker,
+}
+
+impl fmt::Display for FinalSessionHistoryIdentityError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MetadataTooLarge => f.write_str("final session history identity is too large"),
+            Self::InvalidJson => f.write_str("final session history identity is invalid JSON"),
+            Self::UnsupportedVersion => {
+                f.write_str("final session history identity version is unsupported")
+            }
+            Self::InvalidSessionIdHash => {
+                f.write_str("final session history identity session id hash is invalid")
+            }
+            Self::InvalidHistoryHash => {
+                f.write_str("final session history identity history hash is invalid")
+            }
+            Self::InvalidHistorySize => {
+                f.write_str("final session history identity history size is invalid")
+            }
+            Self::HistoryTooLarge => {
+                f.write_str("final session history identity history is too large")
+            }
+            Self::MissingHistoryMarker => {
+                f.write_str("final session history identity marker is missing")
+            }
+        }
+    }
+}
+
+impl std::error::Error for FinalSessionHistoryIdentityError {}
+
+fn is_sha256_hex(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| matches!(byte, b'0'..=b'9' | b'a'..=b'f'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_identity() -> FinalSessionHistoryIdentity {
+        FinalSessionHistoryIdentity::new(
+            FinalSessionHistoryFramework::ClaudeCode,
+            "a".repeat(64),
+            FinalSessionHistoryRefKind::Blob,
+            "b".repeat(64),
+            12,
+            "/home/user/.claude/projects/-home-user-workspace/session.jsonl",
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn final_identity_round_trips_json() {
+        let identity = valid_identity();
+        let bytes = identity.to_json_vec().unwrap();
+
+        assert_eq!(
+            FinalSessionHistoryIdentity::from_json_slice(&bytes).unwrap(),
+            identity
+        );
+    }
+
+    #[test]
+    fn final_identity_rejects_invalid_hashes() {
+        let err = FinalSessionHistoryIdentity::new(
+            FinalSessionHistoryFramework::ClaudeCode,
+            "not-a-hash",
+            FinalSessionHistoryRefKind::Blob,
+            "b".repeat(64),
+            12,
+            "/history.jsonl",
+        )
+        .unwrap_err();
+        assert_eq!(err, FinalSessionHistoryIdentityError::InvalidSessionIdHash);
+
+        let err = FinalSessionHistoryIdentity::new(
+            FinalSessionHistoryFramework::ClaudeCode,
+            "a".repeat(64),
+            FinalSessionHistoryRefKind::Blob,
+            "not-a-hash",
+            12,
+            "/history.jsonl",
+        )
+        .unwrap_err();
+        assert_eq!(err, FinalSessionHistoryIdentityError::InvalidHistoryHash);
+    }
+
+    #[test]
+    fn final_identity_rejects_zero_and_oversized_history() {
+        let err = FinalSessionHistoryIdentity::new(
+            FinalSessionHistoryFramework::ClaudeCode,
+            "a".repeat(64),
+            FinalSessionHistoryRefKind::Blob,
+            "b".repeat(64),
+            0,
+            "/history.jsonl",
+        )
+        .unwrap_err();
+        assert_eq!(err, FinalSessionHistoryIdentityError::InvalidHistorySize);
+
+        let err = FinalSessionHistoryIdentity::new(
+            FinalSessionHistoryFramework::ClaudeCode,
+            "a".repeat(64),
+            FinalSessionHistoryRefKind::Blob,
+            "b".repeat(64),
+            SESSION_HISTORY_IDENTITY_VERIFY_MAX_BYTES + 1,
+            "/history.jsonl",
+        )
+        .unwrap_err();
+        assert_eq!(err, FinalSessionHistoryIdentityError::HistoryTooLarge);
+    }
+
+    #[test]
+    fn final_identity_rejects_missing_marker() {
+        let err = FinalSessionHistoryIdentity::new(
+            FinalSessionHistoryFramework::ClaudeCode,
+            "a".repeat(64),
+            FinalSessionHistoryRefKind::Blob,
+            "b".repeat(64),
+            12,
+            " ",
+        )
+        .unwrap_err();
+        assert_eq!(err, FinalSessionHistoryIdentityError::MissingHistoryMarker);
+    }
+
+    #[test]
+    fn final_identity_debug_redacts_sensitive_fields() {
+        let identity = valid_identity();
+        let debug = format!("{identity:?}");
+
+        assert!(debug.contains("[redacted]"));
+        assert!(!debug.contains(&identity.session_id_hash));
+        assert!(!debug.contains(&identity.history_hash));
+        assert!(!debug.contains(&identity.history_marker_payload));
+    }
+}

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -559,8 +559,13 @@ mod tests {
     use crate::status::IdleVm;
     use crate::test_fixtures::execution_context_for_test;
     use crate::types::{ResumeSession, ResumeSessionHistory, ResumeSessionHistoryRef};
+    use guest_contracts::session_history_identity::{
+        FinalSessionHistoryFramework, FinalSessionHistoryIdentity, FinalSessionHistoryRefKind,
+        SESSION_HISTORY_IDENTITY_VERIFY_MAX_BYTES,
+    };
     use sandbox::SandboxFactory;
     use sandbox_mock::{MockSandbox, MockSandboxFactory};
+    use sha2::{Digest, Sha256};
 
     fn read_active_run_phase(path: &std::path::Path) -> String {
         let raw = std::fs::read_to_string(path).unwrap();
@@ -787,6 +792,52 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn restore_plan_skips_matching_checkpointed_final_identity() {
+        let http = test_http_client();
+        let history_hash = "a".repeat(64);
+        let context = context_with_history_ref_and_size(&history_hash, Some(12));
+        let metadata_path =
+            "/home/user/.vm0/guest-agent/runs/previous/final-session-history-identity.json";
+        let runtime_dir = "/home/user/.vm0/guest-agent/runs/previous";
+        let metadata = FinalSessionHistoryIdentity::new(
+            FinalSessionHistoryFramework::ClaudeCode,
+            hex::encode(Sha256::digest(b"sess-restore-plan")),
+            FinalSessionHistoryRefKind::Blob,
+            history_hash,
+            12,
+            "/home/user/.claude/projects/-home-user-workspace/session.jsonl",
+        )
+        .unwrap();
+        let restored_identity =
+            RestoredSessionIdentity::from_final_metadata(metadata, metadata_path, runtime_dir)
+                .expect("checkpointed final identity");
+        let reusable_sandbox =
+            reusable_sandbox_with_identity(Some(restored_identity.clone())).await;
+        let cancel = RunCancellationHandle::new();
+        let mut timing = RunnerPreSpawnTiming::start_after_claim();
+
+        let plan = build_session_history_restore_plan(
+            &http,
+            &context,
+            true,
+            &cancel,
+            Some(&reusable_sandbox),
+            SandboxReuseResult::Reused,
+            &mut timing,
+        );
+
+        match plan {
+            SessionHistoryRestorePlan::SkipVerified(identity) => {
+                assert_eq!(identity, restored_identity);
+                assert_eq!(identity.history_size_bytes(), Some(12));
+                assert_eq!(identity.guest_history_path(), None);
+                assert_eq!(identity.final_metadata_path(), Some(metadata_path));
+            }
+            _ => panic!("matching checkpointed final identity should skip restore"),
+        }
+    }
+
+    #[tokio::test]
     async fn restore_plan_skips_identity_parked_by_finalizer() {
         let http = test_http_client();
         let context = context_with_history_ref("history-hash-a");
@@ -962,12 +1013,12 @@ mod tests {
         let http = test_http_client();
         let context = context_with_history_ref_and_size(
             "history-hash-a",
-            Some(crate::restored_session_identity::RESTORED_SESSION_IDENTITY_VERIFY_MAX_BYTES),
+            Some(SESSION_HISTORY_IDENTITY_VERIFY_MAX_BYTES),
         );
         let restored_identity = RestoredSessionIdentity::from_context(&context)
             .unwrap()
             .with_guest_history(
-                crate::restored_session_identity::RESTORED_SESSION_IDENTITY_VERIFY_MAX_BYTES,
+                SESSION_HISTORY_IDENTITY_VERIFY_MAX_BYTES,
                 "/home/user/.claude/projects/-home-user-workspace/session.jsonl",
             );
         let reusable_sandbox = reusable_sandbox_with_identity(Some(restored_identity)).await;

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -559,9 +559,12 @@ mod tests {
     use crate::status::IdleVm;
     use crate::test_fixtures::execution_context_for_test;
     use crate::types::{ResumeSession, ResumeSessionHistory, ResumeSessionHistoryRef};
-    use guest_contracts::session_history_identity::{
-        FinalSessionHistoryFramework, FinalSessionHistoryIdentity, FinalSessionHistoryRefKind,
-        SESSION_HISTORY_IDENTITY_VERIFY_MAX_BYTES,
+    use guest_contracts::{
+        codex_thread_id::canonical_codex_thread_id,
+        session_history_identity::{
+            FinalSessionHistoryFramework, FinalSessionHistoryIdentity, FinalSessionHistoryRefKind,
+            SESSION_HISTORY_IDENTITY_VERIFY_MAX_BYTES,
+        },
     };
     use sandbox::SandboxFactory;
     use sandbox_mock::{MockSandbox, MockSandboxFactory};
@@ -834,6 +837,66 @@ mod tests {
                 assert_eq!(identity.final_metadata_path(), Some(metadata_path));
             }
             _ => panic!("matching checkpointed final identity should skip restore"),
+        }
+    }
+
+    #[tokio::test]
+    async fn restore_plan_skips_matching_codex_checkpointed_final_identity() {
+        let http = test_http_client();
+        let history_hash = "a".repeat(64);
+        let mut context = execution_context_for_test(RunId::new_v4());
+        context.cli_agent_type = "codex".into();
+        context.resume_session = Some(ResumeSession {
+            cli_agent_session_id: "019E9154C30470F0ADDE36EFB1BE1701".into(),
+            history: ResumeSessionHistory::Ref {
+                history_ref: ResumeSessionHistoryRef {
+                    kind: crate::types::ResumeSessionHistoryRefKind::Blob,
+                    hash: history_hash.clone(),
+                    url: "http://127.0.0.1:9/history.blob".into(),
+                    size: Some(12),
+                },
+            },
+        });
+        let canonical_thread_id =
+            canonical_codex_thread_id("019E9154C30470F0ADDE36EFB1BE1701").unwrap();
+        let metadata_path =
+            "/home/user/.vm0/guest-agent/runs/previous/final-session-history-identity.json";
+        let runtime_dir = "/home/user/.vm0/guest-agent/runs/previous";
+        let metadata = FinalSessionHistoryIdentity::new(
+            FinalSessionHistoryFramework::Codex,
+            hex::encode(Sha256::digest(canonical_thread_id.as_bytes())),
+            FinalSessionHistoryRefKind::Blob,
+            history_hash,
+            12,
+            format!("CODEX_SEARCH:26:/home/user/.codex/sessions:{canonical_thread_id}"),
+        )
+        .unwrap();
+        let restored_identity =
+            RestoredSessionIdentity::from_final_metadata(metadata, metadata_path, runtime_dir)
+                .expect("checkpointed final identity");
+        let reusable_sandbox =
+            reusable_sandbox_with_identity(Some(restored_identity.clone())).await;
+        let cancel = RunCancellationHandle::new();
+        let mut timing = RunnerPreSpawnTiming::start_after_claim();
+
+        let plan = build_session_history_restore_plan(
+            &http,
+            &context,
+            true,
+            &cancel,
+            Some(&reusable_sandbox),
+            SandboxReuseResult::Reused,
+            &mut timing,
+        );
+
+        match plan {
+            SessionHistoryRestorePlan::SkipVerified(identity) => {
+                assert_eq!(identity, restored_identity);
+                assert_eq!(identity.history_size_bytes(), Some(12));
+                assert_eq!(identity.guest_history_path(), None);
+                assert_eq!(identity.final_metadata_path(), Some(metadata_path));
+            }
+            _ => panic!("matching Codex checkpointed final identity should skip restore"),
         }
     }
 

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -1,6 +1,7 @@
 use std::time::{Duration, Instant};
 
 use agent_diagnostics::FailureDiagnostic;
+use guest_contracts::session_history_identity::FinalSessionHistoryIdentity;
 use sandbox::{
     EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, ExecTermination, ProcessControlMode, ProcessOutputMode,
     Sandbox, StartProcessRequest,
@@ -29,12 +30,16 @@ use super::{
     EXIT_SIGKILL, EXIT_SIGNAL_KILL, ExecutionFailure, ExecutorConfig, JOB_TIMEOUT,
     JOB_TIMEOUT_EXIT_CODE, PROCESS_CANCEL_TIMEOUTS, ResourceFailureDiagnostics,
     ResourceFailureKind, RunnerResult, SandboxReuseResult, USER_ENV_FILE_ENV_KEY,
-    agent_exit_failure_message, job_terminal_wait_timeout, normalize_failure_exit_code,
+    agent_exit_failure_message, guest_runtime_dir, guest_runtime_path, job_terminal_wait_timeout,
+    normalize_failure_exit_code,
 };
 use crate::active_input::ActiveInputSource;
 use crate::helper_exec::{helper_exec_succeeded, helper_exec_termination_label};
 use crate::paths::guest;
-use crate::restored_session_identity::RestoredSessionIdentity;
+use crate::restored_session_identity::{
+    FINAL_SESSION_HISTORY_IDENTITY_READ_LIMIT, RestoredSessionHistoryVerification,
+    RestoredSessionIdentity,
+};
 use crate::telemetry::JobTelemetry;
 use crate::types::{ExecutionContext, GuestDownloadManifest};
 
@@ -42,6 +47,7 @@ const AGENT_WRAPPER_STDERR_CAPTURE_LIMIT_BYTES: u32 = 64 * 1024;
 const SESSION_HISTORY_DOWNLOAD_TELEMETRY_ERROR: &str = "session history download failed";
 const SESSION_HISTORY_MATERIALIZATION_WAIT_TELEMETRY_ERROR: &str =
     "session history materialization failed";
+const SESSION_HISTORY_IDENTITY_VERIFY_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum SessionHistoryRestoreFallback {
@@ -120,14 +126,44 @@ async fn verify_restored_session_identity_for_reuse(
     let Some(verification) = identity.guest_history_verification() else {
         debug!(
             run_id = %context.run_id,
-            "restored session identity cannot be verified without bounded history size and absolute guest history path"
+            "restored session identity cannot be verified without a bounded verifier"
         );
         return None;
     };
 
-    let read_result = sandbox
-        .read_file(verification.guest_history_path, verification.read_limit)
-        .await;
+    match verification {
+        RestoredSessionHistoryVerification::GuestHistoryPath {
+            expected_size,
+            guest_history_path,
+            read_limit,
+        } => {
+            let guest_history_path = guest_history_path.to_owned();
+            verify_guest_history_path_identity(
+                sandbox,
+                context,
+                identity,
+                expected_size,
+                &guest_history_path,
+                read_limit,
+            )
+            .await
+        }
+        RestoredSessionHistoryVerification::FinalIdentityMetadata { runtime_dir } => {
+            let runtime_dir = runtime_dir.to_owned();
+            verify_final_identity_metadata(sandbox, context, identity, &runtime_dir).await
+        }
+    }
+}
+
+async fn verify_guest_history_path_identity(
+    sandbox: &dyn Sandbox,
+    context: &ExecutionContext,
+    identity: RestoredSessionIdentity,
+    expected_size: u64,
+    guest_history_path: &str,
+    read_limit: u64,
+) -> Option<RestoredSessionIdentity> {
+    let read_result = sandbox.read_file(guest_history_path, read_limit).await;
     let bytes = match read_result {
         Ok(Some(bytes)) => bytes,
         Ok(None) => {
@@ -145,10 +181,10 @@ async fn verify_restored_session_identity_for_reuse(
             return None;
         }
     };
-    if bytes.len() as u64 != verification.expected_size {
+    if bytes.len() as u64 != expected_size {
         debug!(
             run_id = %context.run_id,
-            expected_size = verification.expected_size,
+            expected_size = expected_size,
             actual_size = bytes.len(),
             "restored session identity invalidated because history size changed"
         );
@@ -164,6 +200,110 @@ async fn verify_restored_session_identity_for_reuse(
     }
 
     Some(identity)
+}
+
+async fn verify_final_identity_metadata(
+    sandbox: &dyn Sandbox,
+    context: &ExecutionContext,
+    identity: RestoredSessionIdentity,
+    runtime_dir: &str,
+) -> Option<RestoredSessionIdentity> {
+    let command = build_final_identity_verify_command(guest::RUN_AGENT);
+    let env = [(
+        guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+        runtime_dir,
+    )];
+    let request = ExecRequest {
+        cmd: &command,
+        timeout: SESSION_HISTORY_IDENTITY_VERIFY_TIMEOUT,
+        env: &env,
+        sudo: false,
+        stdin_bytes: None,
+        output_limits: EXEC_OUTPUT_LIMIT_64_KIB,
+    };
+    match sandbox
+        .exec_with_diagnostic_label(&request, "session-history-identity-verify")
+        .await
+    {
+        Ok(result) if helper_exec_succeeded(&result) => Some(identity),
+        Ok(result) => {
+            debug!(
+                run_id = %context.run_id,
+                termination = %helper_exec_termination_label(&result),
+                "restored session identity final metadata verification failed"
+            );
+            None
+        }
+        Err(_) => {
+            debug!(
+                run_id = %context.run_id,
+                "restored session identity final metadata verification errored"
+            );
+            None
+        }
+    }
+}
+
+fn build_final_identity_verify_command(run_agent_path: &str) -> String {
+    let run_agent_path = quote_shell_arg(run_agent_path);
+    format!("{run_agent_path} verify-session-history-identity")
+}
+
+async fn read_final_session_history_identity(
+    sandbox: &dyn Sandbox,
+    context: &ExecutionContext,
+) -> Option<RestoredSessionIdentity> {
+    let metadata_path = match guest_runtime_path(
+        context.run_id,
+        guest_contracts::runtime_paths::final_session_history_identity_file,
+    ) {
+        Ok(path) => path,
+        Err(error) => {
+            debug!(
+                run_id = %context.run_id,
+                error = %error,
+                "final session history identity path could not be resolved"
+            );
+            return None;
+        }
+    };
+    let runtime_dir = match guest_runtime_dir(context.run_id) {
+        Ok(path) => path,
+        Err(error) => {
+            debug!(
+                run_id = %context.run_id,
+                error = %error,
+                "guest runtime dir could not be resolved for final session history identity"
+            );
+            return None;
+        }
+    };
+    let bytes = match sandbox
+        .read_file(&metadata_path, FINAL_SESSION_HISTORY_IDENTITY_READ_LIMIT)
+        .await
+    {
+        Ok(Some(bytes)) => bytes,
+        Ok(None) => return None,
+        Err(_) => {
+            debug!(
+                run_id = %context.run_id,
+                "final session history identity metadata read failed"
+            );
+            return None;
+        }
+    };
+    let metadata = match FinalSessionHistoryIdentity::from_json_slice(&bytes) {
+        Ok(metadata) => metadata,
+        Err(error) => {
+            debug!(
+                run_id = %context.run_id,
+                error = %error,
+                "final session history identity metadata was invalid"
+            );
+            return None;
+        }
+    };
+    RestoredSessionIdentity::from_final_metadata(metadata, metadata_path, runtime_dir)
 }
 
 pub(super) struct ProcessCancelTimeouts {
@@ -1020,16 +1160,29 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
     };
 
     if failure.is_none() {
-        restored_session_identity =
+        let verified_restored_session_identity =
             verify_restored_session_identity_for_reuse(sandbox, context, restored_session_identity)
                 .await;
-        if produced_restored_session_identity && restored_session_identity.is_some() {
+        if produced_restored_session_identity && verified_restored_session_identity.is_some() {
             telemetry.record(
                 "session_history_identity_restored",
                 Duration::ZERO,
                 true,
                 None,
             );
+        }
+        restored_session_identity = verified_restored_session_identity;
+        if restored_session_identity.is_none()
+            && let Some(final_identity) =
+                read_final_session_history_identity(sandbox, context).await
+        {
+            telemetry.record(
+                "session_history_identity_finalized",
+                Duration::ZERO,
+                true,
+                None,
+            );
+            restored_session_identity = Some(final_identity);
         }
     }
 

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -148,9 +148,14 @@ async fn verify_restored_session_identity_for_reuse(
             )
             .await
         }
-        RestoredSessionHistoryVerification::FinalIdentityMetadata { runtime_dir } => {
+        RestoredSessionHistoryVerification::FinalIdentityMetadata {
+            metadata_path,
+            runtime_dir,
+        } => {
+            let metadata_path = metadata_path.to_owned();
             let runtime_dir = runtime_dir.to_owned();
-            verify_final_identity_metadata(sandbox, context, identity, &runtime_dir).await
+            verify_final_identity_metadata(sandbox, context, identity, &metadata_path, &runtime_dir)
+                .await
         }
     }
 }
@@ -206,9 +211,10 @@ async fn verify_final_identity_metadata(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,
     identity: RestoredSessionIdentity,
+    metadata_path: &str,
     runtime_dir: &str,
 ) -> Option<RestoredSessionIdentity> {
-    let command = build_final_identity_verify_command(guest::RUN_AGENT);
+    let command = build_final_identity_verify_command(guest::RUN_AGENT, metadata_path);
     let env = [(
         guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
         runtime_dir,
@@ -244,9 +250,10 @@ async fn verify_final_identity_metadata(
     }
 }
 
-fn build_final_identity_verify_command(run_agent_path: &str) -> String {
+fn build_final_identity_verify_command(run_agent_path: &str, metadata_path: &str) -> String {
     let run_agent_path = quote_shell_arg(run_agent_path);
-    format!("{run_agent_path} verify-session-history-identity")
+    let metadata_path = quote_shell_arg(metadata_path);
+    format!("{run_agent_path} verify-session-history-identity {metadata_path}")
 }
 
 async fn read_final_session_history_identity(

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -151,11 +151,24 @@ async fn verify_restored_session_identity_for_reuse(
         RestoredSessionHistoryVerification::FinalIdentityMetadata {
             metadata_path,
             runtime_dir,
+            framework,
+            session_id_hash,
+            history_ref_kind,
+            history_hash,
+            history_size_bytes,
         } => {
             let metadata_path = metadata_path.to_owned();
             let runtime_dir = runtime_dir.to_owned();
-            verify_final_identity_metadata(sandbox, context, identity, &metadata_path, &runtime_dir)
-                .await
+            let command = build_final_identity_verify_command(
+                guest::RUN_AGENT,
+                &metadata_path,
+                framework.as_str(),
+                session_id_hash,
+                history_ref_kind.as_str(),
+                history_hash,
+                history_size_bytes,
+            );
+            verify_final_identity_metadata(sandbox, context, identity, command, &runtime_dir).await
         }
     }
 }
@@ -211,10 +224,9 @@ async fn verify_final_identity_metadata(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,
     identity: RestoredSessionIdentity,
-    metadata_path: &str,
+    command: String,
     runtime_dir: &str,
 ) -> Option<RestoredSessionIdentity> {
-    let command = build_final_identity_verify_command(guest::RUN_AGENT, metadata_path);
     let env = [(
         guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
         runtime_dir,
@@ -250,10 +262,26 @@ async fn verify_final_identity_metadata(
     }
 }
 
-fn build_final_identity_verify_command(run_agent_path: &str, metadata_path: &str) -> String {
-    let run_agent_path = quote_shell_arg(run_agent_path);
-    let metadata_path = quote_shell_arg(metadata_path);
-    format!("{run_agent_path} verify-session-history-identity {metadata_path}")
+fn build_final_identity_verify_command(
+    run_agent_path: &str,
+    metadata_path: &str,
+    framework: &str,
+    session_id_hash: &str,
+    history_ref_kind: &str,
+    history_hash: &str,
+    history_size_bytes: u64,
+) -> String {
+    let args = [
+        quote_shell_arg(run_agent_path),
+        "verify-session-history-identity".to_string(),
+        quote_shell_arg(metadata_path),
+        quote_shell_arg(framework),
+        quote_shell_arg(session_id_hash),
+        quote_shell_arg(history_ref_kind),
+        quote_shell_arg(history_hash),
+        history_size_bytes.to_string(),
+    ];
+    args.join(" ")
 }
 
 async fn read_final_session_history_identity(

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -1160,22 +1160,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
     };
 
     if failure.is_none() {
-        let verified_restored_session_identity =
-            verify_restored_session_identity_for_reuse(sandbox, context, restored_session_identity)
-                .await;
-        if produced_restored_session_identity && verified_restored_session_identity.is_some() {
-            telemetry.record(
-                "session_history_identity_restored",
-                Duration::ZERO,
-                true,
-                None,
-            );
-        }
-        restored_session_identity = verified_restored_session_identity;
-        if restored_session_identity.is_none()
-            && let Some(final_identity) =
-                read_final_session_history_identity(sandbox, context).await
-        {
+        if let Some(final_identity) = read_final_session_history_identity(sandbox, context).await {
             telemetry.record(
                 "session_history_identity_finalized",
                 Duration::ZERO,
@@ -1183,6 +1168,22 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                 None,
             );
             restored_session_identity = Some(final_identity);
+        } else {
+            let verified_restored_session_identity = verify_restored_session_identity_for_reuse(
+                sandbox,
+                context,
+                restored_session_identity,
+            )
+            .await;
+            if produced_restored_session_identity && verified_restored_session_identity.is_some() {
+                telemetry.record(
+                    "session_history_identity_restored",
+                    Duration::ZERO,
+                    true,
+                    None,
+                );
+            }
+            restored_session_identity = verified_restored_session_identity;
         }
     }
 

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -620,6 +620,11 @@ async fn run_in_sandbox_skips_checkpointed_final_session_history_restore() {
     for call in exec_calls {
         assert!(call.cmd.contains("verify-session-history-identity"));
         assert!(call.cmd.contains(previous_metadata_path));
+        assert!(call.cmd.contains(metadata.framework.as_str()));
+        assert!(call.cmd.contains(&metadata.session_id_hash));
+        assert!(call.cmd.contains(metadata.history_ref_kind.as_str()));
+        assert!(call.cmd.contains(&metadata.history_hash));
+        assert!(call.cmd.contains(&metadata.history_size_bytes.to_string()));
         assert_eq!(
             call.env_keys,
             vec![guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV]

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -5,9 +5,17 @@ use std::process::Command;
 use std::sync::Arc;
 use std::time::Duration;
 
+use api_contracts::generated::constants::runners::paths::CANONICAL_GUEST_HOME_DIR;
 use api_contracts::generated::types::runners::storage::StorageManifest;
+use guest_contracts::session_history_identity::{
+    FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES, FinalSessionHistoryFramework,
+    FinalSessionHistoryIdentity, FinalSessionHistoryRefKind,
+    SESSION_HISTORY_IDENTITY_VERIFY_MAX_BYTES,
+};
 use httpmock::prelude::*;
-use sandbox::{ProcessExit, ProcessOutputChunk, SandboxConfig, SandboxFactory, SandboxId};
+use sandbox::{
+    ExecResult, ProcessExit, ProcessOutputChunk, SandboxConfig, SandboxFactory, SandboxId,
+};
 use sandbox_mock::MockSandboxFactory;
 use sha2::{Digest, Sha256};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -74,6 +82,41 @@ async fn serve_history_once_after_request(
         stream.write_all(body).await.unwrap();
     });
     format!("http://{address}/history.blob?token=secret")
+}
+
+fn claude_history_path(session_id: &str) -> String {
+    format!("/home/user/.claude/projects/-home-user-workspace/{session_id}.jsonl")
+}
+
+fn final_identity_runtime_paths(ctx: &crate::types::ExecutionContext) -> (String, String) {
+    let run_dir = guest_contracts::runtime_paths::run_dir_for_home(
+        CANONICAL_GUEST_HOME_DIR,
+        &ctx.run_id.to_string(),
+    )
+    .unwrap();
+    let metadata_path =
+        guest_contracts::runtime_paths::final_session_history_identity_file(&run_dir)
+            .to_string_lossy()
+            .into_owned();
+    (metadata_path, run_dir.to_string_lossy().into_owned())
+}
+
+fn final_identity_metadata_bytes(
+    session_id: &str,
+    history: &[u8],
+    history_marker_payload: impl Into<String>,
+) -> Vec<u8> {
+    FinalSessionHistoryIdentity::new(
+        FinalSessionHistoryFramework::ClaudeCode,
+        hex::encode(Sha256::digest(session_id.as_bytes())),
+        FinalSessionHistoryRefKind::Blob,
+        hex::encode(Sha256::digest(history)),
+        history.len() as u64,
+        history_marker_payload,
+    )
+    .unwrap()
+    .to_json_vec()
+    .unwrap()
 }
 
 #[test]
@@ -483,6 +526,187 @@ async fn run_in_sandbox_skips_verified_session_history_restore() {
 }
 
 #[tokio::test]
+async fn run_in_sandbox_skips_checkpointed_final_session_history_restore() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let sandbox = sandbox_mock::MockSandbox::new("test");
+    let history = br#"{"type":"init"}"#;
+    let server = MockServer::start_async().await;
+    let history_mock = server
+        .mock_async(|when, then| {
+            when.method(GET).path("/history.blob");
+            then.status(200).body(history);
+        })
+        .await;
+    let mut ctx = minimal_context();
+    let session_id = "sess-final-skip-123";
+    ctx.resume_session = Some(ResumeSession {
+        cli_agent_session_id: session_id.into(),
+        history: ResumeSessionHistory::Ref {
+            history_ref: ResumeSessionHistoryRef {
+                kind: ResumeSessionHistoryRefKind::Blob,
+                hash: hex::encode(Sha256::digest(history)),
+                url: server.url("/history.blob?token=secret"),
+                size: Some(history.len() as u64),
+            },
+        },
+    });
+    let (metadata_path, runtime_dir) = final_identity_runtime_paths(&ctx);
+    let metadata = FinalSessionHistoryIdentity::new(
+        FinalSessionHistoryFramework::ClaudeCode,
+        hex::encode(Sha256::digest(session_id.as_bytes())),
+        FinalSessionHistoryRefKind::Blob,
+        hex::encode(Sha256::digest(history)),
+        history.len() as u64,
+        claude_history_path(session_id),
+    )
+    .unwrap();
+    let identity =
+        RestoredSessionIdentity::from_final_metadata(metadata, metadata_path, runtime_dir)
+            .expect("checkpointed identity");
+    sandbox.push_exec_result(Ok(ExecResult::new(0, Vec::new(), Vec::new())));
+    sandbox.push_exec_result(Ok(ExecResult::new(0, Vec::new(), Vec::new())));
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let result = run_in_sandbox(
+        &sandbox,
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::Reused,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None)
+            .with_session_history_restore_plan(SessionHistoryRestorePlan::SkipVerified(
+                identity.clone(),
+            )),
+    )
+    .await
+    .unwrap();
+
+    assert!(result.failure.is_none());
+    assert_eq!(result.restored_session_identity, Some(identity));
+    assert!(sandbox.read_file_calls().is_empty());
+    let exec_calls = sandbox.exec_calls();
+    assert_eq!(exec_calls.len(), 2);
+    for call in exec_calls {
+        assert!(call.cmd.contains("verify-session-history-identity"));
+        assert_eq!(
+            call.env_keys,
+            vec![guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV]
+        );
+        assert!(!call.sudo);
+        assert!(call.stdin_bytes.is_none());
+    }
+    history_mock.assert_calls_async(0).await;
+    let ops = telemetry.pending_ops_snapshot();
+    assert!(
+        ops.iter()
+            .any(|op| op.0 == "session_history_identity_reuse_hit" && op.1),
+        "expected checkpointed identity reuse hit telemetry, got: {ops:?}"
+    );
+    assert!(
+        ops.iter()
+            .any(|op| op.0 == "session_history_restore_skip" && op.1),
+        "expected checkpointed skip telemetry, got: {ops:?}"
+    );
+}
+
+#[tokio::test]
+async fn run_in_sandbox_restores_when_checkpointed_final_identity_helper_fails() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let sandbox = sandbox_mock::MockSandbox::new("test");
+    let history = br#"{"type":"init"}"#;
+    let server = MockServer::start_async().await;
+    let history_mock = server
+        .mock_async(|when, then| {
+            when.method(GET).path("/history.blob");
+            then.status(200).body(history);
+        })
+        .await;
+    let mut ctx = minimal_context();
+    let session_id = "sess-final-helper-fails-123";
+    ctx.resume_session = Some(ResumeSession {
+        cli_agent_session_id: session_id.into(),
+        history: ResumeSessionHistory::Ref {
+            history_ref: ResumeSessionHistoryRef {
+                kind: ResumeSessionHistoryRefKind::Blob,
+                hash: hex::encode(Sha256::digest(history)),
+                url: server.url("/history.blob?token=secret"),
+                size: Some(history.len() as u64),
+            },
+        },
+    });
+    let (metadata_path, runtime_dir) = final_identity_runtime_paths(&ctx);
+    let metadata = FinalSessionHistoryIdentity::new(
+        FinalSessionHistoryFramework::ClaudeCode,
+        hex::encode(Sha256::digest(session_id.as_bytes())),
+        FinalSessionHistoryRefKind::Blob,
+        hex::encode(Sha256::digest(history)),
+        history.len() as u64,
+        claude_history_path(session_id),
+    )
+    .unwrap();
+    let idle_identity =
+        RestoredSessionIdentity::from_final_metadata(metadata, metadata_path, runtime_dir)
+            .expect("checkpointed identity");
+    sandbox.push_exec_result(Ok(ExecResult::new(1, Vec::new(), Vec::new())));
+    sandbox.push_read_file_result(Ok(Some(history.to_vec())));
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let result = run_in_sandbox(
+        &sandbox,
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::Reused,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None)
+            .with_session_history_restore_plan(SessionHistoryRestorePlan::SkipVerified(
+                idle_identity,
+            )),
+    )
+    .await
+    .unwrap();
+
+    assert!(result.failure.is_none());
+    let restored_identity = result
+        .restored_session_identity
+        .as_ref()
+        .expect("restored identity");
+    assert_eq!(
+        restored_identity.guest_history_path(),
+        Some(claude_history_path(session_id).as_str())
+    );
+    assert_eq!(
+        restored_identity.history_size_bytes(),
+        Some(history.len() as u64)
+    );
+    assert_eq!(sandbox.exec_calls().len(), 1);
+    history_mock.assert_calls_async(1).await;
+    let writes = sandbox.write_file_calls();
+    assert_eq!(writes.len(), 1);
+    assert_eq!(writes[0].path, claude_history_path(session_id));
+    assert_eq!(writes[0].content, history);
+    let ops = telemetry.pending_ops_snapshot();
+    assert!(
+        ops.iter()
+            .any(|op| op.0 == "session_history_restore_fallback_stale_idle_identity" && op.1),
+        "expected helper failure stale fallback telemetry, got: {ops:?}"
+    );
+    assert!(
+        ops.iter().all(|op| op.0 != "session_history_restore_skip"),
+        "helper failure should not record skip telemetry, got: {ops:?}"
+    );
+}
+
+#[tokio::test]
 async fn run_in_sandbox_restores_when_skip_verified_identity_mismatches_request() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
@@ -758,7 +982,7 @@ async fn run_in_sandbox_restores_when_skip_verified_identity_is_too_large_to_ver
     let idle_identity = RestoredSessionIdentity::from_context(&ctx)
         .expect("identity")
         .with_guest_history(
-            crate::restored_session_identity::RESTORED_SESSION_IDENTITY_VERIFY_MAX_BYTES,
+            SESSION_HISTORY_IDENTITY_VERIFY_MAX_BYTES,
             "/home/user/.claude/projects/-home-user-workspace/sess-large-skip-123.jsonl",
         );
     sandbox.push_read_file_result(Ok(Some(history.to_vec())));
@@ -1031,6 +1255,157 @@ async fn run_in_sandbox_clears_restored_identity_when_history_changes_before_par
 
     assert!(result.failure.is_none());
     assert_eq!(result.restored_session_identity, None);
+}
+
+#[tokio::test]
+async fn run_in_sandbox_uses_final_identity_when_restored_history_changes_before_parking() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let sandbox = sandbox_mock::MockSandbox::new("test");
+    let history = br#"{"type":"init"}"#;
+    let final_history = br#"{"type":"done"}"#;
+    let server = MockServer::start_async().await;
+    server
+        .mock_async(|when, then| {
+            when.method(GET).path("/history.blob");
+            then.status(200).body(history);
+        })
+        .await;
+    let mut ctx = minimal_context();
+    let session_id = "sess-final-mutated-123";
+    ctx.resume_session = Some(ResumeSession {
+        cli_agent_session_id: session_id.into(),
+        history: ResumeSessionHistory::Ref {
+            history_ref: ResumeSessionHistoryRef {
+                kind: ResumeSessionHistoryRefKind::Blob,
+                hash: hex::encode(Sha256::digest(history)),
+                url: server.url("/history.blob?token=secret"),
+                size: Some(history.len() as u64),
+            },
+        },
+    });
+    let (metadata_path, _) = final_identity_runtime_paths(&ctx);
+    sandbox.push_read_file_result(Ok(Some(final_history.to_vec())));
+    sandbox.push_read_file_result(Ok(Some(final_identity_metadata_bytes(
+        session_id,
+        final_history,
+        claude_history_path(session_id),
+    ))));
+    let materializer = SessionHistoryMaterializer::start_cancellable(
+        &config.http,
+        ctx.resume_session.as_ref(),
+        tokio_util::sync::CancellationToken::new(),
+    );
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let result = run_in_sandbox(
+        &sandbox,
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::Reused,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None)
+            .with_session_history_restore_plan(SessionHistoryRestorePlan::Prestarted {
+                materializer,
+                fallback: None,
+            }),
+    )
+    .await
+    .unwrap();
+
+    assert!(result.failure.is_none());
+    let identity = result
+        .restored_session_identity
+        .as_ref()
+        .expect("final identity");
+    assert_eq!(
+        identity.history_hash(),
+        hex::encode(Sha256::digest(final_history))
+    );
+    assert_eq!(
+        identity.history_size_bytes(),
+        Some(final_history.len() as u64)
+    );
+    assert_eq!(identity.guest_history_path(), None);
+    assert_eq!(identity.final_metadata_path(), Some(metadata_path.as_str()));
+    let read_calls = sandbox.read_file_calls();
+    assert_eq!(read_calls.len(), 2);
+    assert_eq!(read_calls[0].path, claude_history_path(session_id));
+    assert_eq!(read_calls[0].max_bytes, history.len() as u64 + 1);
+    assert_eq!(read_calls[1].path, metadata_path);
+    assert_eq!(
+        read_calls[1].max_bytes,
+        FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES + 1
+    );
+    let ops = telemetry.pending_ops_snapshot();
+    assert!(
+        ops.iter()
+            .any(|op| op.0 == "session_history_identity_finalized" && op.1),
+        "expected final identity telemetry, got: {ops:?}"
+    );
+    assert!(
+        ops.iter()
+            .all(|op| op.0 != "session_history_identity_restored"),
+        "mutated restore-time identity should not record restored telemetry, got: {ops:?}"
+    );
+}
+
+#[tokio::test]
+async fn run_in_sandbox_uses_final_identity_without_resume_request() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let sandbox = sandbox_mock::MockSandbox::new("test");
+    let history = br#"{"type":"init"}"#;
+    let ctx = minimal_context();
+    let session_id = "sess-first-turn-final-123";
+    let (metadata_path, _) = final_identity_runtime_paths(&ctx);
+    sandbox.push_read_file_result(Ok(Some(final_identity_metadata_bytes(
+        session_id,
+        history,
+        claude_history_path(session_id),
+    ))));
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let result = run_in_sandbox(
+        &sandbox,
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::PoolMiss,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None),
+    )
+    .await
+    .unwrap();
+
+    assert!(result.failure.is_none());
+    let identity = result
+        .restored_session_identity
+        .as_ref()
+        .expect("final identity");
+    assert_eq!(
+        identity.history_hash(),
+        hex::encode(Sha256::digest(history))
+    );
+    assert_eq!(identity.history_size_bytes(), Some(history.len() as u64));
+    assert_eq!(identity.guest_history_path(), None);
+    assert_eq!(identity.final_metadata_path(), Some(metadata_path.as_str()));
+    let read_calls = sandbox.read_file_calls();
+    assert_eq!(read_calls.len(), 1);
+    assert_eq!(read_calls[0].path, metadata_path);
+    let ops = telemetry.pending_ops_snapshot();
+    assert!(
+        ops.iter()
+            .any(|op| op.0 == "session_history_identity_finalized" && op.1),
+        "expected first-turn final identity telemetry, got: {ops:?}"
+    );
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -619,6 +619,7 @@ async fn run_in_sandbox_skips_checkpointed_final_session_history_restore() {
     assert_eq!(exec_calls.len(), 1);
     for call in exec_calls {
         assert!(call.cmd.contains("verify-session-history-identity"));
+        assert!(call.cmd.contains(previous_metadata_path));
         assert_eq!(
             call.env_keys,
             vec![guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV]
@@ -677,7 +678,7 @@ async fn run_in_sandbox_restores_when_checkpointed_final_identity_helper_fails()
     )
     .unwrap();
     let idle_identity =
-        RestoredSessionIdentity::from_final_metadata(metadata, metadata_path, runtime_dir)
+        RestoredSessionIdentity::from_final_metadata(metadata, metadata_path.clone(), runtime_dir)
             .expect("checkpointed identity");
     sandbox.push_exec_result(Ok(ExecResult::new(1, Vec::new(), Vec::new())));
     sandbox.push_read_file_result(Ok(None));
@@ -715,7 +716,9 @@ async fn run_in_sandbox_restores_when_checkpointed_final_identity_helper_fails()
         restored_identity.history_size_bytes(),
         Some(history.len() as u64)
     );
-    assert_eq!(sandbox.exec_calls().len(), 1);
+    let exec_calls = sandbox.exec_calls();
+    assert_eq!(exec_calls.len(), 1);
+    assert!(exec_calls[0].cmd.contains(&metadata_path));
     history_mock.assert_calls_async(1).await;
     let writes = sandbox.write_file_calls();
     assert_eq!(writes.len(), 1);

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -476,6 +476,7 @@ async fn run_in_sandbox_skips_verified_session_history_restore() {
             "/home/user/.claude/projects/-home-user-workspace/sess-skip-123.jsonl",
         );
     sandbox.push_read_file_result(Ok(Some(history.to_vec())));
+    sandbox.push_read_file_result(Ok(None));
     sandbox.push_read_file_result(Ok(Some(history.to_vec())));
     let mut telemetry = test_telemetry(&config, &ctx);
 
@@ -499,7 +500,7 @@ async fn run_in_sandbox_skips_verified_session_history_restore() {
 
     assert!(result.failure.is_none());
     assert_eq!(result.restored_session_identity, Some(identity));
-    assert_eq!(sandbox.read_file_calls().len(), 2);
+    assert_eq!(sandbox.read_file_calls().len(), 3);
     assert!(sandbox.write_file_calls().is_empty());
     history_mock.assert_calls_async(0).await;
     let ops = telemetry.pending_ops_snapshot();
@@ -552,6 +553,9 @@ async fn run_in_sandbox_skips_checkpointed_final_session_history_restore() {
         },
     });
     let (metadata_path, runtime_dir) = final_identity_runtime_paths(&ctx);
+    let previous_metadata_path =
+        "/home/user/.vm0/guest-agent/runs/previous/final-session-history-identity.json";
+    let previous_runtime_dir = "/home/user/.vm0/guest-agent/runs/previous";
     let metadata = FinalSessionHistoryIdentity::new(
         FinalSessionHistoryFramework::ClaudeCode,
         hex::encode(Sha256::digest(session_id.as_bytes())),
@@ -561,11 +565,20 @@ async fn run_in_sandbox_skips_checkpointed_final_session_history_restore() {
         claude_history_path(session_id),
     )
     .unwrap();
-    let identity =
-        RestoredSessionIdentity::from_final_metadata(metadata, metadata_path, runtime_dir)
-            .expect("checkpointed identity");
+    let idle_identity = RestoredSessionIdentity::from_final_metadata(
+        metadata.clone(),
+        previous_metadata_path,
+        previous_runtime_dir,
+    )
+    .expect("checkpointed identity");
+    let final_identity = RestoredSessionIdentity::from_final_metadata(
+        metadata.clone(),
+        metadata_path.clone(),
+        runtime_dir,
+    )
+    .expect("final identity");
     sandbox.push_exec_result(Ok(ExecResult::new(0, Vec::new(), Vec::new())));
-    sandbox.push_exec_result(Ok(ExecResult::new(0, Vec::new(), Vec::new())));
+    sandbox.push_read_file_result(Ok(Some(metadata.to_json_vec().unwrap())));
     let mut telemetry = test_telemetry(&config, &ctx);
 
     let result = run_in_sandbox(
@@ -580,17 +593,30 @@ async fn run_in_sandbox_skips_checkpointed_final_session_history_restore() {
         &mut telemetry,
         RunControls::new(tokio_util::sync::CancellationToken::new(), None)
             .with_session_history_restore_plan(SessionHistoryRestorePlan::SkipVerified(
-                identity.clone(),
+                idle_identity,
             )),
     )
     .await
     .unwrap();
 
     assert!(result.failure.is_none());
-    assert_eq!(result.restored_session_identity, Some(identity));
-    assert!(sandbox.read_file_calls().is_empty());
+    assert_eq!(result.restored_session_identity, Some(final_identity));
+    assert_eq!(
+        result
+            .restored_session_identity
+            .as_ref()
+            .and_then(RestoredSessionIdentity::final_metadata_path),
+        Some(metadata_path.as_str())
+    );
+    let read_calls = sandbox.read_file_calls();
+    assert_eq!(read_calls.len(), 1);
+    assert_eq!(read_calls[0].path, metadata_path);
+    assert_eq!(
+        read_calls[0].max_bytes,
+        FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES + 1
+    );
     let exec_calls = sandbox.exec_calls();
-    assert_eq!(exec_calls.len(), 2);
+    assert_eq!(exec_calls.len(), 1);
     for call in exec_calls {
         assert!(call.cmd.contains("verify-session-history-identity"));
         assert_eq!(
@@ -654,6 +680,7 @@ async fn run_in_sandbox_restores_when_checkpointed_final_identity_helper_fails()
         RestoredSessionIdentity::from_final_metadata(metadata, metadata_path, runtime_dir)
             .expect("checkpointed identity");
     sandbox.push_exec_result(Ok(ExecResult::new(1, Vec::new(), Vec::new())));
+    sandbox.push_read_file_result(Ok(None));
     sandbox.push_read_file_result(Ok(Some(history.to_vec())));
     let mut telemetry = test_telemetry(&config, &ctx);
 
@@ -749,6 +776,7 @@ async fn run_in_sandbox_restores_when_skip_verified_identity_mismatches_request(
             history.len() as u64,
             "/home/user/.claude/projects/-home-user-workspace/sess-mismatch-skip-123.jsonl",
         );
+    sandbox.push_read_file_result(Ok(None));
     sandbox.push_read_file_result(Ok(Some(history.to_vec())));
     let mut telemetry = test_telemetry(&config, &ctx);
 
@@ -779,7 +807,7 @@ async fn run_in_sandbox_restores_when_skip_verified_identity_mismatches_request(
         "/home/user/.claude/projects/-home-user-workspace/sess-mismatch-skip-123.jsonl"
     );
     assert_eq!(writes[0].content, history);
-    assert_eq!(sandbox.read_file_calls().len(), 1);
+    assert_eq!(sandbox.read_file_calls().len(), 2);
     let ops = telemetry.pending_ops_snapshot();
     assert!(
         ops.iter()
@@ -823,6 +851,7 @@ async fn run_in_sandbox_restores_when_skip_verified_identity_is_stale_before_sta
             history.len() as u64,
             "/home/user/.claude/projects/-home-user-workspace/sess-stale-skip-123.jsonl",
         );
+    sandbox.push_read_file_result(Ok(None));
     sandbox.push_read_file_result(Ok(None));
     sandbox.push_read_file_result(Ok(Some(history.to_vec())));
     let mut telemetry = test_telemetry(&config, &ctx);
@@ -906,6 +935,7 @@ async fn run_in_sandbox_restores_when_skip_verified_identity_has_invalid_path() 
     let idle_identity = RestoredSessionIdentity::from_context(&ctx)
         .expect("identity")
         .with_guest_history(history.len() as u64, "relative/session.jsonl");
+    sandbox.push_read_file_result(Ok(None));
     sandbox.push_read_file_result(Ok(Some(history.to_vec())));
     let mut telemetry = test_telemetry(&config, &ctx);
 
@@ -937,9 +967,9 @@ async fn run_in_sandbox_restores_when_skip_verified_identity_has_invalid_path() 
     );
     assert_eq!(writes[0].content, history);
     let read_calls = sandbox.read_file_calls();
-    assert_eq!(read_calls.len(), 1);
+    assert_eq!(read_calls.len(), 2);
     assert_eq!(
-        read_calls[0].path,
+        read_calls[1].path,
         "/home/user/.claude/projects/-home-user-workspace/sess-invalid-path-123.jsonl"
     );
     let ops = telemetry.pending_ops_snapshot();
@@ -985,6 +1015,7 @@ async fn run_in_sandbox_restores_when_skip_verified_identity_is_too_large_to_ver
             SESSION_HISTORY_IDENTITY_VERIFY_MAX_BYTES,
             "/home/user/.claude/projects/-home-user-workspace/sess-large-skip-123.jsonl",
         );
+    sandbox.push_read_file_result(Ok(None));
     sandbox.push_read_file_result(Ok(Some(history.to_vec())));
     let mut telemetry = test_telemetry(&config, &ctx);
 
@@ -1016,12 +1047,12 @@ async fn run_in_sandbox_restores_when_skip_verified_identity_is_too_large_to_ver
     );
     assert_eq!(writes[0].content, history);
     let read_calls = sandbox.read_file_calls();
-    assert_eq!(read_calls.len(), 1);
+    assert_eq!(read_calls.len(), 2);
     assert_eq!(
-        read_calls[0].path,
+        read_calls[1].path,
         "/home/user/.claude/projects/-home-user-workspace/sess-large-skip-123.jsonl"
     );
-    assert_eq!(read_calls[0].max_bytes, history.len() as u64 + 1);
+    assert_eq!(read_calls[1].max_bytes, history.len() as u64 + 1);
     let ops = telemetry.pending_ops_snapshot();
     assert!(
         ops.iter()
@@ -1060,6 +1091,7 @@ async fn run_in_sandbox_records_fallback_and_restores_prestarted_history() {
         },
     });
     let expected_identity = RestoredSessionIdentity::from_context(&ctx).expect("identity");
+    sandbox.push_read_file_result(Ok(None));
     sandbox.push_read_file_result(Ok(Some(history.to_vec())));
     let materializer = SessionHistoryMaterializer::start_cancellable(
         &config.http,
@@ -1144,6 +1176,7 @@ async fn run_in_sandbox_records_missing_idle_identity_reuse_fallback() {
             },
         },
     });
+    sandbox.push_read_file_result(Ok(None));
     sandbox.push_read_file_result(Ok(Some(history.to_vec())));
     let materializer = SessionHistoryMaterializer::start_cancellable(
         &config.http,
@@ -1226,6 +1259,7 @@ async fn run_in_sandbox_clears_restored_identity_when_history_changes_before_par
     });
     let mut changed_history = history.to_vec();
     changed_history[0] = b'[';
+    sandbox.push_read_file_result(Ok(None));
     sandbox.push_read_file_result(Ok(Some(changed_history)));
     let materializer = SessionHistoryMaterializer::start_cancellable(
         &config.http,
@@ -1285,7 +1319,6 @@ async fn run_in_sandbox_uses_final_identity_when_restored_history_changes_before
         },
     });
     let (metadata_path, _) = final_identity_runtime_paths(&ctx);
-    sandbox.push_read_file_result(Ok(Some(final_history.to_vec())));
     sandbox.push_read_file_result(Ok(Some(final_identity_metadata_bytes(
         session_id,
         final_history,
@@ -1333,12 +1366,10 @@ async fn run_in_sandbox_uses_final_identity_when_restored_history_changes_before
     assert_eq!(identity.guest_history_path(), None);
     assert_eq!(identity.final_metadata_path(), Some(metadata_path.as_str()));
     let read_calls = sandbox.read_file_calls();
-    assert_eq!(read_calls.len(), 2);
-    assert_eq!(read_calls[0].path, claude_history_path(session_id));
-    assert_eq!(read_calls[0].max_bytes, history.len() as u64 + 1);
-    assert_eq!(read_calls[1].path, metadata_path);
+    assert_eq!(read_calls.len(), 1);
+    assert_eq!(read_calls[0].path, metadata_path);
     assert_eq!(
-        read_calls[1].max_bytes,
+        read_calls[0].max_bytes,
         FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES + 1
     );
     let ops = telemetry.pending_ops_snapshot();

--- a/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
@@ -181,6 +181,7 @@ async fn execute_prepared_sandbox_run_logs_guest_session_fingerprint_without_raw
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     let raw_session_id = "sess-sensitive-first-run-17975";
     overrides.push_wait_process_exit(ProcessExit::new(1, 0, Vec::new(), Vec::new()));
+    overrides.push_read_file_result(Ok(None));
     overrides.push_read_file_result(Ok(Some(raw_session_id.as_bytes().to_vec())));
     let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
     let ctx = minimal_context();
@@ -232,6 +233,7 @@ async fn execute_prepared_sandbox_run_canonicalizes_codex_discovered_cli_agent_s
     let raw_session_id = "019E9154C30470F0ADDE36EFB1BE1701";
     let canonical_session_id = "019e9154-c304-70f0-adde-36efb1be1701";
     overrides.push_wait_process_exit(ProcessExit::new(1, 0, Vec::new(), Vec::new()));
+    overrides.push_read_file_result(Ok(None));
     overrides.push_read_file_result(Ok(Some(raw_session_id.as_bytes().to_vec())));
     let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
     let mut ctx = minimal_context();
@@ -278,6 +280,7 @@ async fn execute_prepared_sandbox_run_ignores_non_uuid_codex_discovered_cli_agen
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     let raw_session_id = "codex-safe-but-not-uuid";
     overrides.push_wait_process_exit(ProcessExit::new(1, 0, Vec::new(), Vec::new()));
+    overrides.push_read_file_result(Ok(None));
     overrides.push_read_file_result(Ok(Some(raw_session_id.as_bytes().to_vec())));
     let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
     let mut ctx = minimal_context();

--- a/crates/runner/src/restored_session_identity.rs
+++ b/crates/runner/src/restored_session_identity.rs
@@ -56,6 +56,7 @@ pub(crate) enum RestoredSessionHistoryVerification<'a> {
         read_limit: u64,
     },
     FinalIdentityMetadata {
+        metadata_path: &'a str,
         runtime_dir: &'a str,
     },
 }
@@ -191,7 +192,10 @@ impl RestoredSessionIdentity {
                 if !metadata_path.starts_with('/') || !runtime_dir.starts_with('/') {
                     return None;
                 }
-                Some(RestoredSessionHistoryVerification::FinalIdentityMetadata { runtime_dir })
+                Some(RestoredSessionHistoryVerification::FinalIdentityMetadata {
+                    metadata_path,
+                    runtime_dir,
+                })
             }
         }
     }

--- a/crates/runner/src/restored_session_identity.rs
+++ b/crates/runner/src/restored_session_identity.rs
@@ -58,6 +58,11 @@ pub(crate) enum RestoredSessionHistoryVerification<'a> {
     FinalIdentityMetadata {
         metadata_path: &'a str,
         runtime_dir: &'a str,
+        framework: FinalSessionHistoryFramework,
+        session_id_hash: &'a str,
+        history_ref_kind: FinalSessionHistoryRefKind,
+        history_hash: &'a str,
+        history_size_bytes: u64,
     },
 }
 
@@ -195,6 +200,11 @@ impl RestoredSessionIdentity {
                 Some(RestoredSessionHistoryVerification::FinalIdentityMetadata {
                     metadata_path,
                     runtime_dir,
+                    framework: final_session_history_framework(self.framework),
+                    session_id_hash: &self.session_id_hash,
+                    history_ref_kind: final_session_history_ref_kind(self.history_ref_kind),
+                    history_hash: &self.history_hash,
+                    history_size_bytes: expected_size,
                 })
             }
         }
@@ -259,10 +269,25 @@ fn restored_session_framework_from_final(
     }
 }
 
+fn final_session_history_framework(
+    framework: RestoredSessionFramework,
+) -> FinalSessionHistoryFramework {
+    match framework {
+        RestoredSessionFramework::ClaudeCode => FinalSessionHistoryFramework::ClaudeCode,
+        RestoredSessionFramework::Codex => FinalSessionHistoryFramework::Codex,
+    }
+}
+
 fn resume_history_ref_kind_from_final(
     kind: FinalSessionHistoryRefKind,
 ) -> ResumeSessionHistoryRefKind {
     match kind {
         FinalSessionHistoryRefKind::Blob => ResumeSessionHistoryRefKind::Blob,
+    }
+}
+
+fn final_session_history_ref_kind(kind: ResumeSessionHistoryRefKind) -> FinalSessionHistoryRefKind {
+    match kind {
+        ResumeSessionHistoryRefKind::Blob => FinalSessionHistoryRefKind::Blob,
     }
 }

--- a/crates/runner/src/restored_session_identity.rs
+++ b/crates/runner/src/restored_session_identity.rs
@@ -63,16 +63,18 @@ pub(crate) enum RestoredSessionHistoryVerification<'a> {
 impl RestoredSessionIdentity {
     pub(crate) fn new(
         framework: RestoredSessionFramework,
-        cli_agent_session_id: &str,
+        identity_session_id: &str,
         history_ref_kind: ResumeSessionHistoryRefKind,
         history_hash: impl Into<String>,
         history_size_bytes: Option<u64>,
         guest_history_path: Option<String>,
     ) -> Self {
+        // Callers pass the framework-normalized identity id. Claude Code uses
+        // the raw session id; Codex uses the canonical thread id.
         Self {
             framework,
             restore_format_version: framework.restore_format_version(),
-            session_id_hash: hex::encode(Sha256::digest(cli_agent_session_id.as_bytes())),
+            session_id_hash: hex::encode(Sha256::digest(identity_session_id.as_bytes())),
             history_ref_kind,
             history_hash: history_hash.into(),
             history_size_bytes,
@@ -87,6 +89,7 @@ impl RestoredSessionIdentity {
         metadata_path: impl Into<String>,
         runtime_dir: impl Into<String>,
     ) -> Option<Self> {
+        metadata.validate().ok()?;
         let framework = restored_session_framework_from_final(metadata.framework);
         let history_ref_kind = resume_history_ref_kind_from_final(metadata.history_ref_kind);
         let identity = Self {

--- a/crates/runner/src/restored_session_identity.rs
+++ b/crates/runner/src/restored_session_identity.rs
@@ -1,15 +1,16 @@
 use std::fmt;
 
+use guest_contracts::session_history_identity::{
+    FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES, FinalSessionHistoryFramework,
+    FinalSessionHistoryIdentity, FinalSessionHistoryRefKind,
+    SESSION_HISTORY_IDENTITY_VERIFY_MAX_BYTES,
+};
 use sha2::{Digest, Sha256};
 
 use crate::types::ResumeSessionHistoryRefKind;
 
 const CLAUDE_CODE_RESTORE_FORMAT_VERSION: u8 = 1;
 const CODEX_RESTORE_FORMAT_VERSION: u8 = 1;
-
-// Verification reads `expected_size + 1` bytes so a larger guest file cannot
-// masquerade as the requested history by sharing the expected prefix.
-pub(crate) const RESTORED_SESSION_IDENTITY_VERIFY_MAX_BYTES: u64 = 1024 * 1024;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum RestoredSessionFramework {
@@ -34,13 +35,29 @@ pub(crate) struct RestoredSessionIdentity {
     history_ref_kind: ResumeSessionHistoryRefKind,
     history_hash: String,
     history_size_bytes: Option<u64>,
-    guest_history_path: Option<String>,
+    verifier: Option<RestoredSessionIdentityVerifier>,
 }
 
-pub(crate) struct RestoredSessionHistoryVerification<'a> {
-    pub(crate) expected_size: u64,
-    pub(crate) guest_history_path: &'a str,
-    pub(crate) read_limit: u64,
+#[derive(Clone, Eq, PartialEq)]
+enum RestoredSessionIdentityVerifier {
+    GuestHistoryPath {
+        guest_history_path: String,
+    },
+    FinalIdentityMetadata {
+        metadata_path: String,
+        runtime_dir: String,
+    },
+}
+
+pub(crate) enum RestoredSessionHistoryVerification<'a> {
+    GuestHistoryPath {
+        expected_size: u64,
+        guest_history_path: &'a str,
+        read_limit: u64,
+    },
+    FinalIdentityMetadata {
+        runtime_dir: &'a str,
+    },
 }
 
 impl RestoredSessionIdentity {
@@ -59,8 +76,34 @@ impl RestoredSessionIdentity {
             history_ref_kind,
             history_hash: history_hash.into(),
             history_size_bytes,
-            guest_history_path,
+            verifier: guest_history_path.map(|guest_history_path| {
+                RestoredSessionIdentityVerifier::GuestHistoryPath { guest_history_path }
+            }),
         }
+    }
+
+    pub(crate) fn from_final_metadata(
+        metadata: FinalSessionHistoryIdentity,
+        metadata_path: impl Into<String>,
+        runtime_dir: impl Into<String>,
+    ) -> Option<Self> {
+        let framework = restored_session_framework_from_final(metadata.framework);
+        let history_ref_kind = resume_history_ref_kind_from_final(metadata.history_ref_kind);
+        let identity = Self {
+            framework,
+            restore_format_version: framework.restore_format_version(),
+            session_id_hash: metadata.session_id_hash,
+            history_ref_kind,
+            history_hash: metadata.history_hash,
+            history_size_bytes: Some(metadata.history_size_bytes),
+            verifier: Some(RestoredSessionIdentityVerifier::FinalIdentityMetadata {
+                metadata_path: metadata_path.into(),
+                runtime_dir: runtime_dir.into(),
+            }),
+        };
+        identity
+            .has_guest_history_verification()
+            .then_some(identity)
     }
 
     #[cfg(test)]
@@ -81,7 +124,9 @@ impl RestoredSessionIdentity {
         guest_history_path: impl Into<String>,
     ) -> Self {
         self.history_size_bytes = Some(history_size_bytes);
-        self.guest_history_path = Some(guest_history_path.into());
+        self.verifier = Some(RestoredSessionIdentityVerifier::GuestHistoryPath {
+            guest_history_path: guest_history_path.into(),
+        });
         self
     }
 
@@ -96,26 +141,56 @@ impl RestoredSessionIdentity {
 
     #[cfg(test)]
     pub(crate) fn guest_history_path(&self) -> Option<&str> {
-        self.guest_history_path.as_deref()
+        match &self.verifier {
+            Some(RestoredSessionIdentityVerifier::GuestHistoryPath { guest_history_path }) => {
+                Some(guest_history_path)
+            }
+            _ => None,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn final_metadata_path(&self) -> Option<&str> {
+        match &self.verifier {
+            Some(RestoredSessionIdentityVerifier::FinalIdentityMetadata {
+                metadata_path, ..
+            }) => Some(metadata_path),
+            _ => None,
+        }
     }
 
     pub(crate) fn guest_history_verification(
         &self,
     ) -> Option<RestoredSessionHistoryVerification<'_>> {
         let expected_size = self.history_size_bytes?;
-        let guest_history_path = self.guest_history_path.as_deref()?;
-        if !guest_history_path.starts_with('/') {
+        if expected_size > SESSION_HISTORY_IDENTITY_VERIFY_MAX_BYTES {
             return None;
         }
-        let read_limit = expected_size.checked_add(1)?;
-        if read_limit > RESTORED_SESSION_IDENTITY_VERIFY_MAX_BYTES {
-            return None;
+        match self.verifier.as_ref()? {
+            RestoredSessionIdentityVerifier::GuestHistoryPath { guest_history_path } => {
+                if !guest_history_path.starts_with('/') {
+                    return None;
+                }
+                let read_limit = expected_size.checked_add(1)?;
+                if read_limit > SESSION_HISTORY_IDENTITY_VERIFY_MAX_BYTES {
+                    return None;
+                }
+                Some(RestoredSessionHistoryVerification::GuestHistoryPath {
+                    expected_size,
+                    guest_history_path,
+                    read_limit,
+                })
+            }
+            RestoredSessionIdentityVerifier::FinalIdentityMetadata {
+                metadata_path,
+                runtime_dir,
+            } => {
+                if !metadata_path.starts_with('/') || !runtime_dir.starts_with('/') {
+                    return None;
+                }
+                Some(RestoredSessionHistoryVerification::FinalIdentityMetadata { runtime_dir })
+            }
         }
-        Some(RestoredSessionHistoryVerification {
-            expected_size,
-            guest_history_path,
-            read_limit,
-        })
     }
 
     pub(crate) fn has_guest_history_verification(&self) -> bool {
@@ -151,9 +226,36 @@ impl fmt::Debug for RestoredSessionIdentity {
             .field("history_hash", &"[redacted]")
             .field("history_size_bytes", &self.history_size_bytes)
             .field(
-                "guest_history_path",
-                &self.guest_history_path.as_ref().map(|_| "[redacted]"),
+                "verifier",
+                &self.verifier.as_ref().map(|verifier| match verifier {
+                    RestoredSessionIdentityVerifier::GuestHistoryPath { .. } => {
+                        "[redacted-guest-history-path]"
+                    }
+                    RestoredSessionIdentityVerifier::FinalIdentityMetadata { .. } => {
+                        "[redacted-final-identity-metadata]"
+                    }
+                }),
             )
             .finish()
+    }
+}
+
+pub(crate) const FINAL_SESSION_HISTORY_IDENTITY_READ_LIMIT: u64 =
+    FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES + 1;
+
+fn restored_session_framework_from_final(
+    framework: FinalSessionHistoryFramework,
+) -> RestoredSessionFramework {
+    match framework {
+        FinalSessionHistoryFramework::ClaudeCode => RestoredSessionFramework::ClaudeCode,
+        FinalSessionHistoryFramework::Codex => RestoredSessionFramework::Codex,
+    }
+}
+
+fn resume_history_ref_kind_from_final(
+    kind: FinalSessionHistoryRefKind,
+) -> ResumeSessionHistoryRefKind {
+    match kind {
+        FinalSessionHistoryRefKind::Blob => ResumeSessionHistoryRefKind::Blob,
     }
 }


### PR DESCRIPTION
## Summary
- add a shared final session-history identity contract written by guest-agent after successful checkpoints
- let runner park checkpointed final identities and verify them in-guest before skipping restore on idle reuse
- keep verification bounded and fail closed to normal restore when metadata or history no longer matches

Closes #19254

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all -- --check
- cargo test --manifest-path crates/Cargo.toml -p guest-contracts session_history_identity
- cargo test --manifest-path crates/Cargo.toml -p guest-agent session_history_identity
- cargo test --manifest-path crates/Cargo.toml -p runner restore_plan
- cargo test --manifest-path crates/Cargo.toml -p runner run_in_sandbox
- cargo test --manifest-path crates/Cargo.toml -p guest-agent --test session_history_read
- cargo test --manifest-path crates/Cargo.toml -p guest-agent checkpoint_uploads
- pre-commit: cargo-fmt, cargo-clippy, cargo-doc