### PR TITLE
fix: preserve raw resume session history bytes

### DIFF
--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -22,7 +22,7 @@ use super::diagnostics::{
 use super::env::{build_env_json, build_user_env_json, write_user_env_file};
 use super::guest_state::{restore_guest_state, sync_guest_timezone};
 use super::session_history_download::{SessionHistoryMaterialization, SessionHistoryMaterializer};
-use super::session_restore::restore_session;
+use super::session_restore::{MaterializedResumeSession, restore_session};
 use super::storage::{apply_storage_fingerprint_reuse, download_storages, guest_download_has_work};
 use super::telemetry::{RunnerSpawnTiming, record_api_latency};
 use super::{
@@ -562,12 +562,18 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                 return Err(error);
             }
         };
-        let resume_session = downloaded_resume_session
-            .as_ref()
-            .or(context.resume_session.as_ref());
+        let resume_session = downloaded_resume_session.map(Ok).or_else(|| {
+            context
+                .resume_session
+                .as_ref()
+                .map(MaterializedResumeSession::from_inline_resume_session)
+        });
         if let Some(session) = resume_session {
             let t = Instant::now();
-            let result = restore_session(sandbox, context, session).await;
+            let result = match session {
+                Ok(session) => restore_session(sandbox, context, &session).await,
+                Err(error) => Err(error),
+            };
             let err = result.as_ref().err().map(|e| e.to_string());
             telemetry.record(
                 "session_restore",

--- a/crates/runner/src/executor/session_history_download.rs
+++ b/crates/runner/src/executor/session_history_download.rs
@@ -4,6 +4,7 @@ use sha2::{Digest, Sha256};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
+use super::session_restore::MaterializedResumeSession;
 use crate::error::{RunnerError, RunnerResult};
 use crate::http::HttpClient;
 use crate::types::{ResumeSession, ResumeSessionHistoryRefKind};
@@ -29,7 +30,7 @@ pub(super) enum SessionHistoryMaterialization {
     Missing,
     Ready,
     Downloaded {
-        session: ResumeSession,
+        session: MaterializedResumeSession,
         elapsed: Duration,
     },
     Failed {
@@ -40,7 +41,7 @@ pub(super) enum SessionHistoryMaterialization {
 
 struct SessionHistoryDownloadTaskResult {
     elapsed: Duration,
-    result: RunnerResult<ResumeSession>,
+    result: RunnerResult<MaterializedResumeSession>,
 }
 
 impl SessionHistoryMaterializer {
@@ -189,7 +190,7 @@ async fn download_resume_session_history_timed(
 async fn download_resume_session_history(
     http: HttpClient,
     session: ResumeSession,
-) -> RunnerResult<ResumeSession> {
+) -> RunnerResult<MaterializedResumeSession> {
     let history_ref = session
         .history_ref()
         .ok_or_else(|| RunnerError::Internal("resume session history ref is missing".into()))?
@@ -222,11 +223,9 @@ async fn download_resume_session_history(
         ));
     }
 
-    let session_history = String::from_utf8(bytes)
-        .map_err(|error| RunnerError::Internal(format!("session history is not utf-8: {error}")))?;
-    Ok(ResumeSession::inline(
+    Ok(MaterializedResumeSession::new(
         session.cli_agent_session_id,
-        session_history,
+        bytes,
     ))
 }
 
@@ -377,7 +376,7 @@ mod tests {
 
     #[tokio::test]
     async fn materializer_downloads_and_verifies_hash() {
-        let body = br#"{"type":"init"}"#;
+        let body = b"{\"type\":\"init\"}\n\xff\n";
         let hash = hex::encode(Sha256::digest(body));
         let session = ref_session(
             serve_once("200 OK", body, Some(body.len() as u64)).await,
@@ -390,8 +389,8 @@ mod tests {
 
         match result {
             SessionHistoryMaterialization::Downloaded { session, .. } => {
-                assert_eq!(session.cli_agent_session_id, "sess-123");
-                assert_eq!(session.session_history(), Some(r#"{"type":"init"}"#));
+                assert_eq!(session.cli_agent_session_id(), "sess-123");
+                assert_eq!(session.history_bytes(), body);
             }
             _ => panic!("expected downloaded session"),
         }
@@ -626,9 +625,9 @@ mod tests {
         let task = tokio::spawn(async {
             SessionHistoryDownloadTaskResult {
                 elapsed: Duration::from_millis(1),
-                result: Ok(ResumeSession::inline(
+                result: Ok(MaterializedResumeSession::new(
                     "sess-123".to_string(),
-                    r#"{"type":"init"}"#.to_string(),
+                    br#"{"type":"init"}"#.to_vec(),
                 )),
             }
         });
@@ -661,9 +660,9 @@ mod tests {
             cancel_for_task.cancel();
             SessionHistoryDownloadTaskResult {
                 elapsed: Duration::from_millis(1),
-                result: Ok(ResumeSession::inline(
+                result: Ok(MaterializedResumeSession::new(
                     "sess-123".to_string(),
-                    r#"{"type":"init"}"#.to_string(),
+                    br#"{"type":"init"}"#.to_vec(),
                 )),
             }
         });

--- a/crates/runner/src/executor/session_history_download.rs
+++ b/crates/runner/src/executor/session_history_download.rs
@@ -30,7 +30,7 @@ pub(super) enum SessionHistoryMaterialization {
     Missing,
     Ready,
     Downloaded {
-        session: MaterializedResumeSession,
+        session: MaterializedResumeSession<'static>,
         elapsed: Duration,
     },
     Failed {
@@ -41,7 +41,7 @@ pub(super) enum SessionHistoryMaterialization {
 
 struct SessionHistoryDownloadTaskResult {
     elapsed: Duration,
-    result: RunnerResult<MaterializedResumeSession>,
+    result: RunnerResult<MaterializedResumeSession<'static>>,
 }
 
 impl SessionHistoryMaterializer {
@@ -190,7 +190,7 @@ async fn download_resume_session_history_timed(
 async fn download_resume_session_history(
     http: HttpClient,
     session: ResumeSession,
-) -> RunnerResult<MaterializedResumeSession> {
+) -> RunnerResult<MaterializedResumeSession<'static>> {
     let history_ref = session
         .history_ref()
         .ok_or_else(|| RunnerError::Internal("resume session history ref is missing".into()))?

--- a/crates/runner/src/executor/session_restore.rs
+++ b/crates/runner/src/executor/session_restore.rs
@@ -60,6 +60,45 @@ fn restored_session_framework(framework: EffectiveCliFramework) -> RestoredSessi
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct MaterializedResumeSession {
+    cli_agent_session_id: String,
+    history_bytes: Vec<u8>,
+}
+
+impl MaterializedResumeSession {
+    pub(super) fn new(cli_agent_session_id: String, history_bytes: Vec<u8>) -> Self {
+        Self {
+            cli_agent_session_id,
+            history_bytes,
+        }
+    }
+
+    pub(super) fn from_inline_resume_session(session: &ResumeSession) -> RunnerResult<Self> {
+        let Some(session_history) = session.session_history() else {
+            return Err(RunnerError::Internal(
+                "resume session history was not materialized".into(),
+            ));
+        };
+        Ok(Self::new(
+            session.cli_agent_session_id.clone(),
+            session_history.as_bytes().to_vec(),
+        ))
+    }
+
+    pub(super) fn cli_agent_session_id(&self) -> &str {
+        &self.cli_agent_session_id
+    }
+
+    pub(super) fn history_bytes(&self) -> &[u8] {
+        &self.history_bytes
+    }
+
+    pub(super) fn history_text(&self) -> Option<&str> {
+        std::str::from_utf8(&self.history_bytes).ok()
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub(super) struct SessionRestoreDiagnostics {
     pub(super) framework: &'static str,
     pub(super) session_fingerprint: String,
@@ -70,20 +109,14 @@ pub(super) struct SessionRestoreDiagnostics {
 pub(super) async fn restore_session(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,
-    session: &ResumeSession,
+    session: &MaterializedResumeSession,
 ) -> RunnerResult<SessionRestoreDiagnostics> {
     // Validate the CLI agent session id to prevent path traversal.
     // Only allow alnum, dash, and underscore.
     // Applied up-front so unknown frameworks still reject malformed IDs in case the
     // skip branch is ever upgraded to a write.
-    if !is_valid_session_id(&session.cli_agent_session_id) {
+    if !is_valid_session_id(session.cli_agent_session_id()) {
         return Err(RunnerError::Internal("invalid session_id".into()));
-    }
-
-    if session.session_history().is_none() {
-        return Err(RunnerError::Internal(
-            "resume session history was not materialized".into(),
-        ));
     }
 
     match effective_cli_framework(&context.cli_agent_type) {
@@ -107,27 +140,20 @@ pub(super) async fn restore_session(
 pub(super) async fn restore_claude_session(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,
-    session: &ResumeSession,
+    session: &MaterializedResumeSession,
 ) -> RunnerResult<SessionRestoreDiagnostics> {
-    let session_history = session.session_history().ok_or_else(|| {
-        RunnerError::Internal("resume session history was not materialized".into())
-    })?;
+    let session_history = session.history_bytes();
     let project_name = CANONICAL_WORKING_DIR
         .trim_start_matches('/')
         .replace('/', "-");
     let session_dir = format!("/home/user/.claude/projects/-{project_name}");
-    let session_path = format!("{session_dir}/{}.jsonl", session.cli_agent_session_id);
+    let session_id = session.cli_agent_session_id();
+    let session_path = format!("{session_dir}/{session_id}.jsonl");
 
-    write_session_history_file(
-        sandbox,
-        &session_path,
-        &[&session.cli_agent_session_id],
-        session_history,
-    )
-    .await?;
+    write_session_history_file(sandbox, &session_path, &[session_id], session_history).await?;
     let diagnostics = SessionRestoreDiagnostics {
         framework: "claude-code",
-        session_fingerprint: diagnostic_session_fingerprint(&session.cli_agent_session_id),
+        session_fingerprint: diagnostic_session_fingerprint(session_id),
         bytes_in: session_history.len(),
         restored_session_identity: RestoredSessionIdentity::from_context(context).map(|identity| {
             identity.with_guest_history(session_history.len() as u64, session_path.clone())
@@ -147,10 +173,10 @@ async fn write_session_history_file(
     sandbox: &dyn Sandbox,
     session_path: &str,
     session_ids: &[&str],
-    session_history: &str,
+    session_history: &[u8],
 ) -> RunnerResult<()> {
     sandbox
-        .write_file(session_path, session_history.as_bytes())
+        .write_file(session_path, session_history)
         .await
         .map_err(|error| redact_session_restore_sandbox_error(error, session_ids, session_path))
 }

--- a/crates/runner/src/executor/session_restore.rs
+++ b/crates/runner/src/executor/session_restore.rs
@@ -61,13 +61,13 @@ fn restored_session_framework(framework: EffectiveCliFramework) -> RestoredSessi
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Debug)]
 pub(super) struct MaterializedResumeSession<'a> {
     cli_agent_session_id: Cow<'a, str>,
     history: MaterializedResumeHistory<'a>,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Debug)]
 enum MaterializedResumeHistory<'a> {
     InlineText(&'a str),
     Bytes(Vec<u8>),

--- a/crates/runner/src/executor/session_restore.rs
+++ b/crates/runner/src/executor/session_restore.rs
@@ -2,6 +2,8 @@
 
 mod codex;
 
+use std::borrow::Cow;
+
 use sandbox::{Sandbox, SandboxError};
 use tracing::{info, warn};
 
@@ -60,29 +62,39 @@ fn restored_session_framework(framework: EffectiveCliFramework) -> RestoredSessi
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub(super) struct MaterializedResumeSession {
-    cli_agent_session_id: String,
-    history_bytes: Vec<u8>,
+pub(super) struct MaterializedResumeSession<'a> {
+    cli_agent_session_id: Cow<'a, str>,
+    history: MaterializedResumeHistory<'a>,
 }
 
-impl MaterializedResumeSession {
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum MaterializedResumeHistory<'a> {
+    InlineText(&'a str),
+    Bytes(Vec<u8>),
+}
+
+impl MaterializedResumeSession<'static> {
     pub(super) fn new(cli_agent_session_id: String, history_bytes: Vec<u8>) -> Self {
         Self {
-            cli_agent_session_id,
-            history_bytes,
+            cli_agent_session_id: Cow::Owned(cli_agent_session_id),
+            history: MaterializedResumeHistory::Bytes(history_bytes),
         }
     }
+}
 
-    pub(super) fn from_inline_resume_session(session: &ResumeSession) -> RunnerResult<Self> {
+impl<'a> MaterializedResumeSession<'a> {
+    pub(super) fn from_inline_resume_session(
+        session: &'a ResumeSession,
+    ) -> RunnerResult<MaterializedResumeSession<'a>> {
         let Some(session_history) = session.session_history() else {
             return Err(RunnerError::Internal(
                 "resume session history was not materialized".into(),
             ));
         };
-        Ok(Self::new(
-            session.cli_agent_session_id.clone(),
-            session_history.as_bytes().to_vec(),
-        ))
+        Ok(Self {
+            cli_agent_session_id: Cow::Borrowed(&session.cli_agent_session_id),
+            history: MaterializedResumeHistory::InlineText(session_history),
+        })
     }
 
     pub(super) fn cli_agent_session_id(&self) -> &str {
@@ -90,11 +102,19 @@ impl MaterializedResumeSession {
     }
 
     pub(super) fn history_bytes(&self) -> &[u8] {
-        &self.history_bytes
+        match &self.history {
+            MaterializedResumeHistory::InlineText(session_history) => session_history.as_bytes(),
+            MaterializedResumeHistory::Bytes(history_bytes) => history_bytes,
+        }
     }
 
     pub(super) fn history_text(&self) -> Option<&str> {
-        std::str::from_utf8(&self.history_bytes).ok()
+        match &self.history {
+            MaterializedResumeHistory::InlineText(session_history) => Some(session_history),
+            MaterializedResumeHistory::Bytes(history_bytes) => {
+                std::str::from_utf8(history_bytes).ok()
+            }
+        }
     }
 }
 
@@ -109,7 +129,7 @@ pub(super) struct SessionRestoreDiagnostics {
 pub(super) async fn restore_session(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,
-    session: &MaterializedResumeSession,
+    session: &MaterializedResumeSession<'_>,
 ) -> RunnerResult<SessionRestoreDiagnostics> {
     // Validate the CLI agent session id to prevent path traversal.
     // Only allow alnum, dash, and underscore.
@@ -140,7 +160,7 @@ pub(super) async fn restore_session(
 pub(super) async fn restore_claude_session(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,
-    session: &MaterializedResumeSession,
+    session: &MaterializedResumeSession<'_>,
 ) -> RunnerResult<SessionRestoreDiagnostics> {
     let session_history = session.history_bytes();
     let project_name = CANONICAL_WORKING_DIR

--- a/crates/runner/src/executor/session_restore/codex.rs
+++ b/crates/runner/src/executor/session_restore/codex.rs
@@ -3,12 +3,13 @@ use shell_quote::quote_shell_arg;
 use tracing::info;
 
 use super::{
-    SessionRestoreDiagnostics, redact_session_restore_diagnostic, write_session_history_file,
+    MaterializedResumeSession, SessionRestoreDiagnostics, redact_session_restore_diagnostic,
+    write_session_history_file,
 };
 use crate::helper_exec::{format_helper_exec_failure, helper_exec_succeeded};
 use crate::paths::diagnostic_session_fingerprint;
 use crate::restored_session_identity::RestoredSessionIdentity;
-use crate::types::{ExecutionContext, ResumeSession};
+use crate::types::ExecutionContext;
 
 use super::super::{DEFAULT_EXEC_TIMEOUT, RunnerError, RunnerResult};
 use guest_contracts::codex_thread_id::CodexThreadId;
@@ -19,10 +20,12 @@ const CODEX_SESSION_CLEANUP_SCRIPT: &str =
 
 fn codex_restore_rollout_path(
     session_id: &str,
-    session_history: &str,
+    session_history: Option<&str>,
     fallback_timestamp: chrono::DateTime<chrono::Utc>,
 ) -> String {
-    let timestamp = codex_session_meta_timestamp(session_history).unwrap_or(fallback_timestamp);
+    let timestamp = session_history
+        .and_then(codex_session_meta_timestamp)
+        .unwrap_or(fallback_timestamp);
     format!(
         "{CODEX_HOME}/sessions/{}/{}/{}/rollout-{}-{session_id}.jsonl",
         timestamp.format("%Y"),
@@ -91,17 +94,17 @@ fn parse_codex_rollout_timestamp(raw: &str) -> Option<chrono::DateTime<chrono::U
 pub(super) async fn restore_codex_session(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,
-    session: &ResumeSession,
+    session: &MaterializedResumeSession,
 ) -> RunnerResult<SessionRestoreDiagnostics> {
-    let session_history = session.session_history().ok_or_else(|| {
-        RunnerError::Internal("resume session history was not materialized".into())
-    })?;
-    let thread_id = CodexThreadId::parse(&session.cli_agent_session_id)
+    let session_history = session.history_bytes();
+    let original_session_id = session.cli_agent_session_id();
+    let thread_id = CodexThreadId::parse(original_session_id)
         .ok_or_else(|| RunnerError::Internal("invalid codex session_id".into()))?;
     let session_id = thread_id.as_str();
     let session_filename_key = thread_id.filename_key();
 
-    let session_path = codex_restore_rollout_path(session_id, session_history, chrono::Utc::now());
+    let session_path =
+        codex_restore_rollout_path(session_id, session.history_text(), chrono::Utc::now());
 
     cleanup_existing_codex_session_files(
         sandbox,
@@ -115,7 +118,7 @@ pub(super) async fn restore_codex_session(
     write_session_history_file(
         sandbox,
         &session_path,
-        &[session_id, &session.cli_agent_session_id],
+        &[session_id, original_session_id],
         session_history,
     )
     .await?;

--- a/crates/runner/src/executor/session_restore/codex.rs
+++ b/crates/runner/src/executor/session_restore/codex.rs
@@ -94,7 +94,7 @@ fn parse_codex_rollout_timestamp(raw: &str) -> Option<chrono::DateTime<chrono::U
 pub(super) async fn restore_codex_session(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,
-    session: &MaterializedResumeSession,
+    session: &MaterializedResumeSession<'_>,
 ) -> RunnerResult<SessionRestoreDiagnostics> {
     let session_history = session.history_bytes();
     let original_session_id = session.cli_agent_session_id();

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -283,7 +283,7 @@ async fn run_in_sandbox_materializes_resume_session_history_ref_before_restore()
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
     let sandbox = sandbox_mock::MockSandbox::new("test");
-    let history = br#"{"type":"init"}"#;
+    let history = b"{\"type\":\"init\"}\n\xff\n";
     let mut ctx = minimal_context();
     ctx.resume_session = Some(ResumeSession {
         cli_agent_session_id: "sess-ref-123".into(),
@@ -328,7 +328,7 @@ async fn run_in_sandbox_uses_prestarted_session_history_materializer() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
     let sandbox = sandbox_mock::MockSandbox::new("test");
-    let history = br#"{"type":"init"}"#;
+    let history = b"{\"type\":\"init\"}\n\xff\n";
     let (request_received_tx, request_received_rx) = oneshot::channel();
     let release_response = Arc::new(Notify::new());
     let mut ctx = minimal_context();

--- a/crates/runner/src/executor/tests/session_restore_tests.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests.rs
@@ -19,11 +19,17 @@ use crate::types::{
 
 static RESTORE_SESSION_LOG_CALLSITE_LOCK: Mutex<()> = Mutex::new(());
 
-fn materialized_text_session(session_id: String, history: String) -> MaterializedResumeSession {
+fn materialized_text_session(
+    session_id: String,
+    history: String,
+) -> MaterializedResumeSession<'static> {
     MaterializedResumeSession::new(session_id, history.into_bytes())
 }
 
-fn materialized_bytes_session(session_id: String, history: &[u8]) -> MaterializedResumeSession {
+fn materialized_bytes_session(
+    session_id: String,
+    history: &[u8],
+) -> MaterializedResumeSession<'static> {
     MaterializedResumeSession::new(session_id, history.to_vec())
 }
 

--- a/crates/runner/src/executor/tests/session_restore_tests.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests.rs
@@ -9,7 +9,7 @@ use tracing_subscriber::prelude::*;
 
 use super::super::DEFAULT_EXEC_TIMEOUT;
 use super::super::session_id::{canonical_codex_thread_id, is_valid_session_id};
-use super::super::session_restore::restore_session;
+use super::super::session_restore::{MaterializedResumeSession, restore_session};
 use super::support::{CapturedEvent, CapturedEvents, minimal_context, sandbox_write_file_error};
 use crate::paths::diagnostic_session_fingerprint;
 use crate::restored_session_identity::RestoredSessionIdentity;
@@ -18,6 +18,14 @@ use crate::types::{
 };
 
 static RESTORE_SESSION_LOG_CALLSITE_LOCK: Mutex<()> = Mutex::new(());
+
+fn materialized_text_session(session_id: String, history: String) -> MaterializedResumeSession {
+    MaterializedResumeSession::new(session_id, history.into_bytes())
+}
+
+fn materialized_bytes_session(session_id: String, history: &[u8]) -> MaterializedResumeSession {
+    MaterializedResumeSession::new(session_id, history.to_vec())
+}
 
 #[test]
 fn session_id_validation_rejects_path_traversal() {
@@ -198,7 +206,7 @@ fn restore_session_writes_history() {
             },
         },
     });
-    let session = ResumeSession::inline("sess-abc-123".into(), history.into());
+    let session = materialized_text_session("sess-abc-123".into(), history.into());
     let diagnostics = run_restore_session(restore_session(&sandbox, &ctx, &session)).unwrap();
 
     let writes = sandbox.write_file_calls();
@@ -217,7 +225,7 @@ async fn restore_session_rejects_invalid_session_id() {
     let sandbox = MockSandbox::new("test");
     let ctx = minimal_context();
     let raw_session_id = "../../etc/passwd";
-    let session = ResumeSession::inline(raw_session_id.into(), "data".into());
+    let session = materialized_text_session(raw_session_id.into(), "data".into());
     let err = restore_session(&sandbox, &ctx, &session).await.unwrap_err();
     let message = err.to_string();
     assert!(message.contains("invalid session_id"));
@@ -233,7 +241,7 @@ fn restore_session_logs_fingerprint_without_raw_claude_session_id() {
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "claude-code".into();
     let raw_session_id = "sess-sensitive-restore-17975";
-    let session = ResumeSession::inline(raw_session_id.into(), r#"{"type":"init"}"#.into());
+    let session = materialized_text_session(raw_session_id.into(), r#"{"type":"init"}"#.into());
 
     let (result, events) = capture_restore_events(restore_session(&sandbox, &ctx, &session));
 
@@ -243,10 +251,7 @@ fn restore_session_logs_fingerprint_without_raw_claude_session_id() {
         diagnostics.session_fingerprint,
         diagnostic_session_fingerprint(raw_session_id)
     );
-    assert_eq!(
-        diagnostics.bytes_in,
-        session.session_history().unwrap().len()
-    );
+    assert_eq!(diagnostics.bytes_in, session.history_bytes().len());
     assert_captured_events_do_not_contain(&events, raw_session_id);
     let event = captured_event(&events, "restored session history");
     assert_eq!(
@@ -268,7 +273,7 @@ fn restore_session_unknown_framework_uses_claude_fallback() {
     let sandbox = MockSandbox::new("test");
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "custom-agent".into();
-    let session = ResumeSession::inline("sess-1".into(), "data".into());
+    let session = materialized_text_session("sess-1".into(), "data".into());
 
     run_restore_session(restore_session(&sandbox, &ctx, &session)).unwrap();
 
@@ -286,7 +291,7 @@ fn restore_session_allows_empty_agent_type() {
     let sandbox = MockSandbox::new("test");
     let mut ctx = minimal_context();
     ctx.cli_agent_type = String::new(); // empty defaults to claude-code
-    let session = ResumeSession::inline("sess-1".into(), "{}".into());
+    let session = materialized_text_session("sess-1".into(), "{}".into());
     // Should proceed (empty agent type treated as claude-code).
     run_restore_session(restore_session(&sandbox, &ctx, &session)).unwrap();
 }
@@ -325,7 +330,7 @@ fn restore_session_writes_codex_session() {
             },
         },
     });
-    let session = ResumeSession::inline(session_id.into(), history.clone());
+    let session = materialized_text_session(session_id.into(), history.clone());
     let diagnostics = run_restore_session(restore_session(&sandbox, &ctx, &session)).unwrap();
 
     assert_codex_cleanup_call(&sandbox);
@@ -339,10 +344,7 @@ fn restore_session_writes_codex_session() {
         "codex resume history must be restored as a canonical rollout jsonl, got {}",
         writes[0].path
     );
-    assert_eq!(
-        writes[0].content,
-        session.session_history().unwrap().as_bytes()
-    );
+    assert_eq!(writes[0].content, session.history_bytes());
     let expected_identity = RestoredSessionIdentity::from_context(&ctx)
         .expect("restored identity")
         .with_guest_history(history.len() as u64, writes[0].path.clone());
@@ -358,7 +360,7 @@ fn restore_session_logs_fingerprint_without_raw_codex_session_id() {
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "codex".into();
     let raw_session_id = "019e9154-c304-70f0-adde-36efb1be1701";
-    let session = ResumeSession::inline(raw_session_id.into(), "{}\n".into());
+    let session = materialized_text_session(raw_session_id.into(), "{}\n".into());
 
     let (result, events) = capture_restore_events(restore_session(&sandbox, &ctx, &session));
 
@@ -368,10 +370,7 @@ fn restore_session_logs_fingerprint_without_raw_codex_session_id() {
         diagnostics.session_fingerprint,
         diagnostic_session_fingerprint(raw_session_id)
     );
-    assert_eq!(
-        diagnostics.bytes_in,
-        session.session_history().unwrap().len()
-    );
+    assert_eq!(diagnostics.bytes_in, session.history_bytes().len());
     assert_captured_events_do_not_contain(&events, raw_session_id);
     let restore_event = captured_event(&events, "restored session history");
     assert_eq!(
@@ -396,7 +395,7 @@ fn restore_session_writes_codex_session_with_canonical_fallback_filename() {
     let sandbox = MockSandbox::new("test");
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "codex".into();
-    let session = ResumeSession::inline(
+    let session = materialized_text_session(
         "019e9154-c304-70f0-adde-36efb1be1701".into(),
         "{\"type\":\"thread.started\"}\n{not-json}\n".into(),
     );
@@ -425,10 +424,64 @@ fn restore_session_writes_codex_session_with_canonical_fallback_filename() {
         filename.ends_with("-019e9154-c304-70f0-adde-36efb1be1701.jsonl"),
         "codex resume history filename must include the thread id, got {filename}"
     );
+    assert_eq!(writes[0].content, session.history_bytes());
+}
+
+#[test]
+fn restore_session_writes_invalid_utf8_claude_history_bytes() {
+    let sandbox = MockSandbox::new("test");
+    let mut ctx = minimal_context();
+    ctx.cli_agent_type = "claude-code".into();
+    let history = b"{\"type\":\"init\"}\n\xff\n";
+    let session = materialized_bytes_session("sess-non-utf8-123".into(), history);
+
+    let diagnostics = run_restore_session(restore_session(&sandbox, &ctx, &session)).unwrap();
+
+    let writes = sandbox.write_file_calls();
+    assert_eq!(writes.len(), 1);
     assert_eq!(
-        writes[0].content,
-        session.session_history().unwrap().as_bytes()
+        writes[0].path,
+        "/home/user/.claude/projects/-home-user-workspace/sess-non-utf8-123.jsonl"
     );
+    assert_eq!(writes[0].content, history);
+    assert_eq!(diagnostics.bytes_in, history.len());
+}
+
+#[test]
+fn restore_session_writes_invalid_utf8_codex_history_with_fallback_filename() {
+    let sandbox = MockSandbox::new("test");
+    let mut ctx = minimal_context();
+    ctx.cli_agent_type = "codex".into();
+    let session_id = "019e9154-c304-70f0-adde-36efb1be1701";
+    let history = b"{\"type\":\"session_meta\",\"payload\":{\"timestamp\":\"2026-06-04T07:18:08.000Z\"}}\n\xff\n";
+    let session = materialized_bytes_session(session_id.into(), history);
+
+    let diagnostics = run_restore_session(restore_session(&sandbox, &ctx, &session)).unwrap();
+
+    assert_codex_cleanup_call(&sandbox);
+
+    let writes = sandbox.write_file_calls();
+    assert_eq!(writes.len(), 1);
+    assert!(
+        writes[0].path.starts_with("/home/user/.codex/sessions/"),
+        "codex resume history must be restored under codex sessions, got {}",
+        writes[0].path
+    );
+    let filename = writes[0]
+        .path
+        .rsplit('/')
+        .next()
+        .expect("restored codex path should have a filename");
+    assert!(
+        filename.starts_with("rollout-"),
+        "codex resume history filename must use rollout prefix, got {filename}"
+    );
+    assert!(
+        filename.ends_with("-019e9154-c304-70f0-adde-36efb1be1701.jsonl"),
+        "codex resume history filename must include the thread id, got {filename}"
+    );
+    assert_eq!(writes[0].content, history);
+    assert_eq!(diagnostics.bytes_in, history.len());
 }
 
 #[test]
@@ -436,7 +489,8 @@ fn restore_session_canonicalizes_codex_session_id() {
     let sandbox = MockSandbox::new("test");
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "codex".into();
-    let session = ResumeSession::inline("019E9154C30470F0ADDE36EFB1BE1701".into(), "{}\n".into());
+    let session =
+        materialized_text_session("019E9154C30470F0ADDE36EFB1BE1701".into(), "{}\n".into());
 
     run_restore_session(restore_session(&sandbox, &ctx, &session)).unwrap();
 
@@ -460,7 +514,7 @@ async fn restore_session_rejects_invalid_codex_session_id() {
     let sandbox = MockSandbox::new("test");
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "codex".into();
-    let session = ResumeSession::inline("../../etc/passwd".into(), "{}".into());
+    let session = materialized_text_session("../../etc/passwd".into(), "{}".into());
     let err = restore_session(&sandbox, &ctx, &session).await.unwrap_err();
     assert!(err.to_string().contains("invalid session_id"));
 }
@@ -470,7 +524,7 @@ async fn restore_session_rejects_short_codex_session_id_without_cleanup() {
     let sandbox = MockSandbox::new("test");
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "codex".into();
-    let session = ResumeSession::inline("abc".into(), "{}".into());
+    let session = materialized_text_session("abc".into(), "{}".into());
 
     let err = restore_session(&sandbox, &ctx, &session).await.unwrap_err();
 
@@ -493,7 +547,7 @@ async fn restore_session_rejects_decorated_codex_session_id_without_cleanup() {
         let sandbox = MockSandbox::new("test");
         let mut ctx = minimal_context();
         ctx.cli_agent_type = "codex".into();
-        let session = ResumeSession::inline(raw_session_id.into(), "{}".into());
+        let session = materialized_text_session(raw_session_id.into(), "{}".into());
 
         let err = restore_session(&sandbox, &ctx, &session).await.unwrap_err();
 
@@ -514,7 +568,7 @@ async fn restore_session_fails_when_codex_cleanup_fails() {
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "codex".into();
     let session =
-        ResumeSession::inline("019e9154-c304-70f0-adde-36efb1be1701".into(), "{}\n".into());
+        materialized_text_session("019e9154-c304-70f0-adde-36efb1be1701".into(), "{}\n".into());
     sandbox.push_exec_result(Ok(ExecResult::new(
         1,
         b"cleanup stdout".to_vec(),
@@ -561,7 +615,7 @@ async fn restore_session_redacts_codex_cleanup_failure_output() {
     let session_id = "019e9154-c304-70f0-adde-36efb1be1701";
     let session_id_no_dashes = session_id.replace('-', "");
     let session_path = "/home/user/.codex/sessions/2026/06/04/rollout-2026-06-04T07-18-08-019e9154-c304-70f0-adde-36efb1be1701.jsonl";
-    let session = ResumeSession::inline(
+    let session = materialized_text_session(
         session_id.into(),
         format!(
             "{}\n",
@@ -610,7 +664,7 @@ async fn restore_session_redacts_non_exited_codex_cleanup_failure_output() {
     let session_id = "019e9154-c304-70f0-adde-36efb1be1701";
     let session_id_no_dashes = session_id.replace('-', "");
     let session_path = "/home/user/.codex/sessions/2026/06/04/rollout-2026-06-04T07-18-08-019e9154-c304-70f0-adde-36efb1be1701.jsonl";
-    let session = ResumeSession::inline(
+    let session = materialized_text_session(
         session_id.into(),
         format!(
             "{}\n",
@@ -652,7 +706,7 @@ async fn restore_session_redacts_claude_write_file_error() {
     let session_id = "sess-sensitive-write-17975";
     let session_path =
         "/home/user/.claude/projects/-home-user-workspace/sess-sensitive-write-17975.jsonl";
-    let session = ResumeSession::inline(session_id.into(), r#"{"type":"init"}"#.into());
+    let session = materialized_text_session(session_id.into(), r#"{"type":"init"}"#.into());
     sandbox.push_write_file_result(Err(sandbox_write_file_error(format!(
         "failed to write {session_path} for {session_id}"
     ))));
@@ -680,7 +734,7 @@ async fn restore_session_redacts_codex_write_file_error() {
     let session_id = "019e9154-c304-70f0-adde-36efb1be1701";
     let session_id_no_dashes = session_id.replace('-', "");
     let session_path = "/home/user/.codex/sessions/2026/06/04/rollout-2026-06-04T07-18-08-019e9154-c304-70f0-adde-36efb1be1701.jsonl";
-    let session = ResumeSession::inline(
+    let session = materialized_text_session(
         session_id.into(),
         format!(
             "{}\n",
@@ -725,7 +779,7 @@ async fn restore_session_redacts_codex_original_no_dash_write_file_error() {
     let raw_session_id = "019E9154C30470F0ADDE36EFB1BE1701";
     let canonical_session_id = "019e9154-c304-70f0-adde-36efb1be1701";
     let session_path = "/home/user/.codex/sessions/2026/06/04/rollout-2026-06-04T07-18-08-019e9154-c304-70f0-adde-36efb1be1701.jsonl";
-    let session = ResumeSession::inline(
+    let session = materialized_text_session(
         raw_session_id.into(),
         format!(
             "{}\n",
@@ -769,7 +823,7 @@ async fn restore_session_redacts_codex_mixed_case_original_write_file_error() {
     ctx.cli_agent_type = "codex".into();
     let raw_session_id = "019e9154C30470f0ADDE36efB1be1701";
     let canonical_session_id = "019e9154-c304-70f0-adde-36efb1be1701";
-    let session = ResumeSession::inline(
+    let session = materialized_text_session(
         raw_session_id.into(),
         format!(
             "{}\n",
@@ -809,7 +863,7 @@ async fn restore_session_redacts_write_file_invalid_state() {
     let session_id = "sess-invalid-state-17975";
     let session_path =
         "/home/user/.claude/projects/-home-user-workspace/sess-invalid-state-17975.jsonl";
-    let session = ResumeSession::inline(session_id.into(), r#"{"type":"init"}"#.into());
+    let session = materialized_text_session(session_id.into(), r#"{"type":"init"}"#.into());
     sandbox.push_write_file_result(Err(SandboxError::InvalidState {
         context: SandboxInvalidStateContext::Operation(SandboxOperation::WriteFile),
         state: format!("blocked for {session_path}"),
@@ -838,7 +892,7 @@ async fn restore_session_redaction_does_not_rewrite_markers() {
     ctx.cli_agent_type = "claude-code".into();
     let session_id = "session";
     let session_path = "/home/user/.claude/projects/-home-user-workspace/session.jsonl";
-    let session = ResumeSession::inline(session_id.into(), r#"{"type":"init"}"#.into());
+    let session = materialized_text_session(session_id.into(), r#"{"type":"init"}"#.into());
     sandbox.push_write_file_result(Err(sandbox_write_file_error(format!(
         "failed to write {session_path} for {session_id}"
     ))));
@@ -867,7 +921,7 @@ async fn restore_session_redaction_preserves_words_for_short_ids() {
     ctx.cli_agent_type = "claude-code".into();
     let session_id = "a";
     let session_path = "/home/user/.claude/projects/-home-user-workspace/a.jsonl";
-    let session = ResumeSession::inline(session_id.into(), r#"{"type":"init"}"#.into());
+    let session = materialized_text_session(session_id.into(), r#"{"type":"init"}"#.into());
     sandbox.push_write_file_result(Err(sandbox_write_file_error(format!(
         "failed to write {session_path} for {session_id}"
     ))));
@@ -893,7 +947,7 @@ async fn restore_session_redaction_preserves_words_for_short_ids() {
 async fn restore_session_fails_on_write_file_error() {
     let sandbox = MockSandbox::new("test");
     let ctx = minimal_context();
-    let session = ResumeSession::inline("sess-abc".into(), r#"{"type":"init"}"#.into());
+    let session = materialized_text_session("sess-abc".into(), r#"{"type":"init"}"#.into());
     sandbox.push_write_file_result(Err(sandbox_write_file_error("disk full")));
     let err = restore_session(&sandbox, &ctx, &session).await.unwrap_err();
     assert!(err.to_string().contains("disk full"), "got: {err}");

--- a/crates/runner/src/executor/tests/session_restore_tests.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests.rs
@@ -598,7 +598,7 @@ async fn restore_session_fails_when_codex_cleanup_exceeds_scan_budget() {
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "codex".into();
     let session =
-        ResumeSession::inline("019e9154-c304-70f0-adde-36efb1be1701".into(), "{}\n".into());
+        materialized_text_session("019e9154-c304-70f0-adde-36efb1be1701".into(), "{}\n".into());
     sandbox.push_exec_result(Ok(ExecResult::new(
         1,
         Vec::new(),


### PR DESCRIPTION
## Summary

- Preserve verified hash-backed resume session history as raw bytes inside runner materialization instead of converting the blob to UTF-8 text.
- Convert inline string resume history to runner-internal bytes before restore and write exact bytes for Claude Code and Codex history files.
- Keep Codex timestamp extraction for valid UTF-8 histories, but fall back to the existing timestamp behavior when history bytes are not valid UTF-8.
- Leave the public runner claim contract and old string-only API fallback strict UTF-8 behavior unchanged.

Closes #19258

## Tests

- cargo test --manifest-path crates/Cargo.toml -p runner session_restore_tests
- cargo test --manifest-path crates/Cargo.toml -p runner session_history
- cargo test --manifest-path crates/Cargo.toml -p runner run_in_sandbox_materializes
- cargo test --manifest-path crates/Cargo.toml -p runner
- cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings -D clippy::all
- cargo fmt --manifest-path crates/Cargo.toml --all -- --check