### PR TITLE
test(mitm-addon): avoid responses extractor monkeypatches

### DIFF
--- a/crates/runner/mitm-addon/tests/test_openai_responses_event_json.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_event_json.py
@@ -7,7 +7,6 @@ from usage import (
     extract_openai_responses_usage_from_event_json,
     merge_openai_responses_usage_result,
 )
-from usage.json_selective import JsonExtractionResult
 
 
 def test_extracts_usage_from_wrapped_response_completed_event():
@@ -202,11 +201,7 @@ def test_known_non_usage_event_with_usage_fields_is_ignored():
     assert extract_openai_responses_usage_from_event_json(body) is None
 
 
-def test_non_terminal_event_skips_full_usage_extractor(monkeypatch):
-    def fail_extractor(**_kwargs):
-        raise AssertionError("full extractor should not run for non-terminal events")
-
-    monkeypatch.setattr(openai_responses, "JsonSelectiveExtractor", fail_extractor)
+def test_large_non_terminal_event_is_ignored():
     body = json.dumps(
         {
             "type": "response.output_text.delta",
@@ -214,14 +209,14 @@ def test_non_terminal_event_skips_full_usage_extractor(monkeypatch):
         }
     ).encode()
 
+    assert (
+        openai_responses._classify_responses_event_type(body)
+        == openai_responses._RESPONSES_EVENT_KNOWN_NON_USAGE
+    )
     assert extract_openai_responses_usage_from_event_json(body) is None
 
 
-def test_non_terminal_prefilter_ignores_nested_types_and_payload_text(monkeypatch):
-    def fail_extractor(**_kwargs):
-        raise AssertionError("full extractor should not run for non-terminal events")
-
-    monkeypatch.setattr(openai_responses, "JsonSelectiveExtractor", fail_extractor)
+def test_non_terminal_prefilter_ignores_nested_types_and_payload_text():
     body = json.dumps(
         {
             "metadata": {
@@ -235,23 +230,25 @@ def test_non_terminal_prefilter_ignores_nested_types_and_payload_text(monkeypatc
         }
     ).encode()
 
+    assert (
+        openai_responses._classify_responses_event_type(body)
+        == openai_responses._RESPONSES_EVENT_KNOWN_NON_USAGE
+    )
     assert extract_openai_responses_usage_from_event_json(body) is None
 
 
-def test_duplicate_top_level_type_uses_first_type_boundary(monkeypatch):
-    def fail_extractor(**_kwargs):
-        raise AssertionError("duplicate type boundary should not scan beyond first type")
-
-    monkeypatch.setattr(openai_responses, "JsonSelectiveExtractor", fail_extractor)
+def test_duplicate_top_level_type_uses_first_type_boundary():
+    body = (
+        b'{"type":"response.output_text.delta",'
+        b'"type":"response.completed",'
+        b'"response":{"usage":{"input_tokens":1,"output_tokens":1}}}'
+    )
 
     assert (
-        extract_openai_responses_usage_from_event_json(
-            b'{"type":"response.output_text.delta",'
-            b'"type":"response.completed",'
-            b'"response":{"usage":{"input_tokens":1,"output_tokens":1}}}'
-        )
-        is None
+        openai_responses._classify_responses_event_type(body)
+        == openai_responses._RESPONSES_EVENT_KNOWN_NON_USAGE
     )
+    assert extract_openai_responses_usage_from_event_json(body) is None
 
 
 def test_duplicate_top_level_unknown_type_keeps_first_type_boundary():
@@ -309,55 +306,35 @@ def test_terminal_event_type_after_skipped_fields_still_extracts_usage():
     }
 
 
-def test_non_string_type_falls_back_to_full_extractor(monkeypatch):
-    class FakeExtractor:
-        def __init__(self, **_kwargs):
-            pass
+def test_non_string_type_falls_back_to_real_extractor():
+    body = (
+        b'{"type":123,"response":{"model":"gpt-5.6","usage":{"input_tokens":3,"output_tokens":2}}}'
+    )
 
-        def feed(self, _body):
-            pass
-
-        def finish(self):
-            return JsonExtractionResult(
-                complete=True,
-                values={
-                    ("type",): "response.completed",
-                    ("usage", "input_tokens"): 3,
-                    ("usage", "output_tokens"): 2,
-                },
-            )
-
-    monkeypatch.setattr(openai_responses, "JsonSelectiveExtractor", FakeExtractor)
-
-    assert extract_openai_responses_usage_from_event_json(b'{"type":123}') == {
+    assert (
+        openai_responses._classify_responses_event_type(body)
+        == openai_responses._RESPONSES_EVENT_UNKNOWN
+    )
+    assert extract_openai_responses_usage_from_event_json(body) == {
+        "model": "gpt-5.6",
         "tokens.input": 3,
         "tokens.output": 2,
     }
 
 
-def test_oversized_type_falls_back_to_full_extractor(monkeypatch):
-    class FakeExtractor:
-        def __init__(self, **_kwargs):
-            pass
+def test_oversized_type_falls_back_to_real_extractor():
+    body = (
+        b'{"type":"'
+        + b"x" * 2048
+        + b'","response":{"model":"gpt-5.6","usage":{"input_tokens":5,"output_tokens":1}}}'
+    )
 
-        def feed(self, _body):
-            pass
-
-        def finish(self):
-            return JsonExtractionResult(
-                complete=True,
-                values={
-                    ("type",): "response.completed",
-                    ("usage", "input_tokens"): 5,
-                    ("usage", "output_tokens"): 1,
-                },
-            )
-
-    monkeypatch.setattr(openai_responses, "JsonSelectiveExtractor", FakeExtractor)
-
-    assert extract_openai_responses_usage_from_event_json(
-        json.dumps({"type": "x" * 2048}).encode()
-    ) == {
+    assert (
+        openai_responses._classify_responses_event_type(body)
+        == openai_responses._RESPONSES_EVENT_UNKNOWN
+    )
+    assert extract_openai_responses_usage_from_event_json(body) == {
+        "model": "gpt-5.6",
         "tokens.input": 5,
         "tokens.output": 1,
     }

--- a/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
@@ -139,6 +139,9 @@ class TestOpenAIResponsesSseUsageExtractor:
         )
         parse(b"event: response.future_delta\n")
         parse(b"data: " + large_delta + b"\n\n")
+
+        assert usage == {}
+
         parse(
             b"event: response.completed\n"
             b'data: {"response":{"model":"gpt-5.4","usage":{"output_tokens":6}}}\n\n'

--- a/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
@@ -127,29 +127,20 @@ class TestOpenAIResponsesSseUsageExtractor:
 
         assert usage == {}
 
-    def test_named_unknown_event_with_known_non_usage_type_stops_full_extraction(self, monkeypatch):
-        real_extractor = openai_responses.JsonSelectiveExtractor
-        fed_chunks: list[bytes] = []
-
-        class TrackingExtractor:
-            def __init__(self, **kwargs):
-                self._inner = real_extractor(**kwargs)
-
-            def feed(self, chunk: bytes) -> None:
-                fed_chunks.append(chunk)
-                self._inner.feed(chunk)
-
-            def finish(self):
-                return self._inner.finish()
-
-        monkeypatch.setattr(openai_responses, "JsonSelectiveExtractor", TrackingExtractor)
+    def test_named_unknown_event_with_large_known_non_usage_type_is_ignored(self):
         parse, usage = create_openai_responses_sse_usage_extractor()
         large_delta = b'{"type":"response.output_text.delta","delta":"' + b"x" * 100_000 + b'"}'
+
+        assert (
+            openai_responses._classify_responses_event_type(
+                large_delta[: openai_responses._RESPONSES_EVENTLESS_SSE_PREFILTER_MAX_BYTES]
+            )
+            == openai_responses._RESPONSES_EVENT_KNOWN_NON_USAGE
+        )
         parse(b"event: response.future_delta\n")
         parse(b"data: " + large_delta + b"\n\n")
 
         assert usage == {}
-        assert large_delta not in b"".join(fed_chunks)
 
     def test_named_terminal_event_with_known_non_usage_type_is_ignored(self):
         parse, usage = create_openai_responses_sse_usage_extractor()
@@ -257,24 +248,16 @@ class TestOpenAIResponsesSseUsageExtractor:
 
         assert usage == {}
 
-    def test_eventless_non_terminal_skips_large_delta_before_full_extraction(self, monkeypatch):
-        real_extractor = openai_responses.JsonSelectiveExtractor
-        fed_chunks: list[bytes] = []
-
-        class TrackingExtractor:
-            def __init__(self, **kwargs):
-                self._inner = real_extractor(**kwargs)
-
-            def feed(self, chunk: bytes) -> None:
-                fed_chunks.append(chunk)
-                self._inner.feed(chunk)
-
-            def finish(self):
-                return self._inner.finish()
-
-        monkeypatch.setattr(openai_responses, "JsonSelectiveExtractor", TrackingExtractor)
+    def test_eventless_large_non_terminal_delta_recovers_for_next_event(self):
         parse, usage = create_openai_responses_sse_usage_extractor()
         delta_payload = b'{"type":"response.output_text.delta","delta":"' + b"x" * 100_000 + b'"}'
+
+        assert (
+            openai_responses._classify_responses_event_type(
+                delta_payload[: openai_responses._RESPONSES_EVENTLESS_SSE_PREFILTER_MAX_BYTES]
+            )
+            == openai_responses._RESPONSES_EVENT_KNOWN_NON_USAGE
+        )
         parse(
             b"data: "
             + delta_payload
@@ -285,7 +268,6 @@ class TestOpenAIResponsesSseUsageExtractor:
 
         assert usage["model"] == "gpt-5.4"
         assert usage["tokens.output"] == 9
-        assert delta_payload not in b"".join(fed_chunks)
 
     def test_eventless_terminal_type_split_across_chunks_extracts_usage(self):
         parse, usage = create_openai_responses_sse_usage_extractor()

--- a/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
@@ -127,7 +127,7 @@ class TestOpenAIResponsesSseUsageExtractor:
 
         assert usage == {}
 
-    def test_named_unknown_event_with_large_known_non_usage_type_is_ignored(self):
+    def test_named_unknown_event_with_large_known_non_usage_type_recovers_for_next_event(self):
         parse, usage = create_openai_responses_sse_usage_extractor()
         large_delta = b'{"type":"response.output_text.delta","delta":"' + b"x" * 100_000 + b'"}'
 
@@ -139,8 +139,13 @@ class TestOpenAIResponsesSseUsageExtractor:
         )
         parse(b"event: response.future_delta\n")
         parse(b"data: " + large_delta + b"\n\n")
+        parse(
+            b"event: response.completed\n"
+            b'data: {"response":{"model":"gpt-5.4","usage":{"output_tokens":6}}}\n\n'
+        )
 
-        assert usage == {}
+        assert usage["model"] == "gpt-5.4"
+        assert usage["tokens.output"] == 6
 
     def test_named_terminal_event_with_known_non_usage_type_is_ignored(self):
         parse, usage = create_openai_responses_sse_usage_extractor()


### PR DESCRIPTION
## Summary
- replace OpenAI Responses event JSON fake-extractor assertions with real payload parser checks
- keep prefilter edge coverage through bounded classifier assertions instead of runtime extractor monkeypatches
- preserve SSE large non-usage and recovery coverage without tracking internal extractor calls

## Tests
- /tmp/mitm-addon-venv-19227/bin/python -m ruff check tests/test_openai_responses_event_json.py tests/test_openai_responses_sse.py
- /tmp/mitm-addon-venv-19227/bin/python -m pytest tests/test_openai_responses_event_json.py tests/test_openai_responses_sse.py -q

Closes #19227