### PR TITLE
perf: lazy materialize firewall auth secrets

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -1245,6 +1245,9 @@ describe("CHAT-02: explicit provider pins", () => {
         authHeaders: {
           Authorization: `Bearer ${secretTemplate("OPENROUTER_API_KEY")}`,
         },
+        secretConnectorMap: claim.secretConnectorMap ?? undefined,
+        secretConnectorMetadataMap:
+          claim.secretConnectorMetadataMap ?? undefined,
       },
       [200],
     );
@@ -1358,8 +1361,9 @@ describe("CHAT-02: explicit provider pins", () => {
       );
   }, 90_000);
 
-  it("rejects legacy blank OpenRouter provider secrets before runner claim", async () => {
-    const { actor, agentId } = await entitledChatActor();
+  it("rejects legacy blank OpenRouter provider secrets during firewall auth", async () => {
+    const fw = createFirewallApi(context);
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
     const orgId = actor.orgId;
     if (!orgId) {
       throw new Error("Expected entitled actor to have an org");
@@ -1370,7 +1374,7 @@ describe("CHAT-02: explicit provider pins", () => {
     });
     await overwriteOrgModelProviderSecret(orgId, "OPENROUTER_API_KEY", "   ");
 
-    const response = await requestSendMessageRaw(actor, {
+    const run = await sendChatRun(actor, {
       agentId,
       prompt: "run with a legacy blank openrouter provider",
       modelSelection: {
@@ -1378,12 +1382,31 @@ describe("CHAT-02: explicit provider pins", () => {
         selectedModel: "claude-opus-4-7",
       },
     });
-
-    expect(response.status).toBe(503);
-    expectApiError(response.body);
-    expect(response.body.error.message).toContain(
-      "No model provider configured",
+    const { claim, sandboxHeaders } = await claimChatRun(
+      runnerGroup,
+      run.runId,
     );
+    if (!claim.encryptedSecrets) {
+      throw new Error("Expected OpenRouter claim to carry encrypted secrets");
+    }
+
+    const rejected = await fw.requestFirewallAuth(
+      sandboxHeaders,
+      {
+        encryptedSecrets: claim.encryptedSecrets,
+        authHeaders: {
+          Authorization: `Bearer ${secretTemplate("OPENROUTER_API_KEY")}`,
+        },
+        secretConnectorMap: claim.secretConnectorMap ?? undefined,
+        secretConnectorMetadataMap:
+          claim.secretConnectorMetadataMap ?? undefined,
+      },
+      [424],
+    );
+    expectApiError(rejected.body);
+    expect(rejected.body.error.code).toBe("CONNECTOR_NOT_CONFIGURED");
+
+    await api.requestCancelRun(actor, run.runId, [200]);
   }, 60_000);
 });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -2059,6 +2059,73 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     await api.requestCancelRun(actor, run.runId, [200]);
   });
 
+  it("does not decrypt stored connector secrets overridden by compose environment", async () => {
+    const bdd = createBddApi(context);
+    const api = createRunsAutomationsApi(context);
+    const connectors = createConnectorBddApi(context);
+    const actor = bdd.user();
+    bdd.acceptAgentStorageWrites();
+    api.acceptStorageDownloads();
+    api.acceptTelemetryIngest();
+    const runnerGroup = api.configureRunnerGroup();
+    await api.grantProEntitlement(actor);
+
+    await connectors.connectManualGrant(actor, "agora", "api-token", {
+      AGORA_CUSTOMER_ID: "agora-customer-id",
+      AGORA_CUSTOMER_SECRET: "agora-customer-secret",
+      AGORA_APP_ID: "agora-app-id",
+      AGORA_APP_CERTIFICATE: "agora-stored-certificate",
+    });
+    const composeName = `bdd-compose-overrides-connector-${randomUUID().slice(0, 8)}`;
+    const compose = await api.createCompose(actor, {
+      version: "1",
+      agents: {
+        [composeName]: {
+          framework: "claude-code",
+          environment: {
+            ANTHROPIC_API_KEY: "bdd-inline-key",
+            AGORA_APP_CERTIFICATE: "inline-agora-certificate",
+          },
+        },
+      },
+    });
+
+    const kms = fakeKmsClient();
+    setSecretKmsClientForTests(kms.client);
+    onTestFinished(() => {
+      resetSecretKmsClientForTests();
+    });
+
+    const run = await api.createDirectRun(actor, {
+      agentComposeId: compose.composeId,
+      prompt: "use compose-overridden agora certificate",
+    });
+    expect(
+      kms.calls.filter((call) => {
+        return call instanceof DecryptCommand;
+      }),
+    ).toHaveLength(0);
+    const timingEvents = apiDispatchTimingEventsForRun(run.runId);
+    expectNoApiDispatchActions(timingEvents, [
+      "api_dispatch_prepare_context_decrypt_stored_connector_secrets",
+    ]);
+
+    await api.heartbeatRunner(runnerGroup);
+    const claim = await api.claimRunnerJob(run.runId);
+    expect(claim.environment?.AGORA_CUSTOMER_ID).toBe(
+      connectorPlaceholder("agora", "AGORA_CUSTOMER_ID"),
+    );
+    expect(claim.environment?.AGORA_CUSTOMER_SECRET).toBe(
+      connectorPlaceholder("agora", "AGORA_CUSTOMER_SECRET"),
+    );
+    expect(claim.environment?.AGORA_APP_ID).toBe("agora-app-id");
+    expect(claim.environment?.AGORA_APP_CERTIFICATE).toBe(
+      "inline-agora-certificate",
+    );
+
+    await api.requestCancelRun(actor, run.runId, [200]);
+  });
+
   it("maps stored connector variable sources to runtime aliases for permission manifests", async () => {
     const bdd = createBddApi(context);
     const api = createRunsAutomationsApi(context);

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -33,7 +33,6 @@ import {
   resetSecretKmsClientForTests,
   setSecretKmsClientForTests,
 } from "../../services/crypto.utils";
-import { settle } from "../../utils";
 import {
   createBddApi,
   expectApiError,
@@ -175,7 +174,6 @@ const API_DISPATCH_STORED_CONNECTOR_ROW_ACTION_TYPES = [
 ] as const;
 const API_DISPATCH_STORED_CONNECTOR_SECRET_ACTION_TYPES = [
   "api_dispatch_prepare_context_load_stored_connector_secret_rows",
-  "api_dispatch_prepare_context_decrypt_stored_connector_secrets",
 ] as const;
 const API_DISPATCH_STORED_CONNECTOR_VARIABLE_ACTION_TYPES = [
   "api_dispatch_prepare_context_load_stored_connector_variable_rows",
@@ -1884,19 +1882,9 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
       timingEvents,
       API_DISPATCH_STORED_CONNECTOR_VARIABLE_ACTION_TYPES,
     );
-    expect(
-      singleApiDispatchEvent(
-        timingEvents,
-        "api_dispatch_prepare_context_decrypt_stored_connector_secrets",
-      ),
-    ).toStrictEqual(
-      expect.objectContaining({
-        connector_scope_source: "zero_agent",
-        stored_connector_count_bucket: "1",
-        stored_connector_secret_count_bucket: "1",
-        zero_run_origin: "zero_run",
-      }),
-    );
+    expectNoApiDispatchActions(timingEvents, [
+      "api_dispatch_prepare_context_decrypt_stored_connector_secrets",
+    ]);
     expectApiDispatchTimingEventsNotToLeak(timingEvents, [
       "x-bdd-access",
       "x-bdd-refresh",
@@ -1913,7 +1901,9 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     expect(claim.environment).not.toHaveProperty("X_REFRESH_TOKEN");
     expect(claim.secretConnectorMap).toMatchObject({ X_TOKEN: "x" });
     expect(claim.secretConnectorMap).not.toHaveProperty("X_REFRESH_TOKEN");
-    expect(claim.secretConnectorMetadataMap ?? null).toBeNull();
+    expect(claim.secretConnectorMetadataMap ?? {}).not.toHaveProperty(
+      "X_TOKEN",
+    );
 
     expect(
       claim.firewalls?.map((firewall) => {
@@ -2153,18 +2143,9 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
       timingEvents,
       API_DISPATCH_STORED_CONNECTOR_SECRET_ACTION_TYPES,
     );
-    expect(
-      singleApiDispatchEvent(
-        timingEvents,
-        "api_dispatch_prepare_context_decrypt_stored_connector_secrets",
-      ),
-    ).toStrictEqual(
-      expect.objectContaining({
-        connector_scope_source: "zero_agent",
-        stored_connector_count_bucket: "1",
-        stored_connector_secret_count_bucket: "1",
-      }),
-    );
+    expectNoApiDispatchActions(timingEvents, [
+      "api_dispatch_prepare_context_decrypt_stored_connector_secrets",
+    ]);
     await api.heartbeatRunner(runnerGroup);
     const claim = await api.claimRunnerJob(run.runId);
 
@@ -2247,17 +2228,17 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     expect(drained.body.concurrency.active).toBe(0);
   });
 
-  it("decrypts multiple stored connector secrets with bounded concurrency", async () => {
+  it("does not decrypt stored connector auth secrets during create-run", async () => {
     const api = createRunsAutomationsApi(context);
     const connectors = createConnectorBddApi(context);
-    const { actor, agentId, runnerGroup } = await entitledRunActor();
-    await seedVm0ManagedDefaultModelKey();
+    const fw = createFirewallApi(context);
+    const { actor, agentId } = await entitledRunActor();
 
-    await connectors.connectManualGrant(actor, "agora", "api-token", {
-      AGORA_CUSTOMER_ID: "agora-customer-id",
-      AGORA_CUSTOMER_SECRET: "agora-customer-secret",
-      AGORA_APP_ID: "agora-app-id",
-      AGORA_APP_CERTIFICATE: "agora-app-certificate",
+    await fw.seedTestConnector(actor, {
+      connectorName: "x",
+      authMethod: "oauth",
+      accessToken: "x-bdd-lazy-access",
+      refreshToken: "x-bdd-lazy-refresh",
     });
     await connectors.connectManualGrant(actor, "gitlab", "api-token", {
       GITLAB_TOKEN: "glpat-bdd-parallel",
@@ -2265,103 +2246,24 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     await connectors.connectManualGrant(actor, "figma", "api-token", {
       FIGMA_TOKEN: "figd_bdd-parallel",
     });
-    await api.enableAgentConnectors(actor, agentId, [
-      "agora",
-      "gitlab",
-      "figma",
-    ]);
+    await api.enableAgentConnectors(actor, agentId, ["x", "gitlab", "figma"]);
 
-    let releaseDecrypts: (() => void) | undefined;
-    const decryptGate = new Promise<void>((resolve) => {
-      releaseDecrypts = resolve;
-    });
-    const kms = fakeKmsClient({
-      onDecrypt: () => {
-        return decryptGate;
-      },
-    });
+    const kms = fakeKmsClient();
     setSecretKmsClientForTests(kms.client);
     onTestFinished(() => {
-      releaseDecrypts?.();
       resetSecretKmsClientForTests();
     });
 
-    const createRunResultPromise = settle(
-      api.createRun(actor, {
-        agentId,
-        prompt: "use agora credentials",
-        modelProvider: "vm0",
-      }),
-    );
-
-    const concurrencyResult = await settle(
-      expect
-        .poll(
-          () => {
-            return kms.getMaxInFlightDecrypts();
-          },
-          { timeout: 10_000 },
-        )
-        .toBe(4),
-    );
-    releaseDecrypts?.();
-
-    const createRunResult = await createRunResultPromise;
-    if (!createRunResult.ok) {
-      throw createRunResult.error;
-    }
-    if (!concurrencyResult.ok) {
-      throw concurrencyResult.error;
-    }
-    const run = createRunResult.value;
-    expect(kms.getMaxInFlightDecrypts()).toBeLessThanOrEqual(4);
+    const run = await api.createRun(actor, {
+      agentId,
+      prompt: "use lazy connector auth credentials",
+      modelProvider: "anthropic-api-key",
+    });
     expect(
       kms.calls.filter((call) => {
         return call instanceof DecryptCommand;
       }),
-    ).toHaveLength(5);
-
-    const timingEvents = apiDispatchTimingEventsForRun(run.runId);
-    expectApiDispatchActions(
-      timingEvents,
-      API_DISPATCH_STORED_CONNECTOR_ROW_ACTION_TYPES,
-    );
-    expectApiDispatchActions(
-      timingEvents,
-      API_DISPATCH_STORED_CONNECTOR_SECRET_ACTION_TYPES,
-    );
-    expectApiDispatchActions(
-      timingEvents,
-      API_DISPATCH_STORED_CONNECTOR_VARIABLE_ACTION_TYPES,
-    );
-
-    await api.heartbeatRunner(runnerGroup);
-    const claim = await api.claimRunnerJob(run.runId);
-
-    expect(claim.environment?.AGORA_CUSTOMER_ID).toBe(
-      connectorPlaceholder("agora", "AGORA_CUSTOMER_ID"),
-    );
-    expect(claim.environment?.AGORA_CUSTOMER_SECRET).toBe(
-      connectorPlaceholder("agora", "AGORA_CUSTOMER_SECRET"),
-    );
-    expect(claim.environment?.AGORA_APP_ID).toBe("agora-app-id");
-    expect(claim.environment?.AGORA_APP_CERTIFICATE).toBe(
-      "agora-app-certificate",
-    );
-    expect(claim.environment?.GITLAB_TOKEN).toBe(
-      connectorPlaceholder("gitlab", "GITLAB_TOKEN"),
-    );
-    expect(claim.environment?.FIGMA_TOKEN).toBe(
-      connectorPlaceholder("figma", "FIGMA_TOKEN"),
-    );
-    expect(claim.secretConnectorMap).toMatchObject({
-      AGORA_CUSTOMER_ID: "agora",
-      AGORA_CUSTOMER_SECRET: "agora",
-      AGORA_APP_CERTIFICATE: "agora",
-      GITLAB_TOKEN: "gitlab",
-      FIGMA_TOKEN: "figma",
-    });
-    expect(claim.secretConnectorMap).not.toHaveProperty("AGORA_APP_ID");
+    ).toHaveLength(0);
 
     await api.requestCancelRun(actor, run.runId, [200]);
     const cancelled = await api.readRun(actor, run.runId);
@@ -3158,18 +3060,9 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       timingEvents,
       API_DISPATCH_PERMISSION_MANIFEST_SUBSTEP_ACTION_TYPES,
     );
-    expect(
-      singleApiDispatchEvent(
-        timingEvents,
-        "api_dispatch_prepare_context_decrypt_stored_connector_secrets",
-      ),
-    ).toStrictEqual(
-      expect.objectContaining({
-        connector_scope_source: "legacy_all",
-        stored_connector_count_bucket: "1",
-        stored_connector_secret_count_bucket: "1",
-      }),
-    );
+    expectNoApiDispatchActions(timingEvents, [
+      "api_dispatch_prepare_context_decrypt_stored_connector_secrets",
+    ]);
     await api.heartbeatRunner(runnerGroup);
     const claim = await api.claimRunnerJob(run.runId);
     expect(claim.environment?.CLOUDFLARE_TOKEN).toBe(

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
@@ -1412,6 +1412,36 @@ describe("FW-8: static access tokens and unavailable sources", () => {
 });
 
 describe("FW-9: codex model-provider access", () => {
+  it("resolves static model-provider auth from an empty runtime namespace", async () => {
+    const fw = createFirewallApi(context);
+    const { headers } = await firewallRun();
+
+    const resolved = await fw.requestFirewallAuth(
+      headers,
+      {
+        encryptedSecrets: fw.encryptedSecretsBody({}),
+        authHeaders: {
+          "x-api-key": secretTemplate("ANTHROPIC_API_KEY"),
+        },
+        secretConnectorMap: { ANTHROPIC_API_KEY: "anthropic-api-key" },
+        secretConnectorMetadataMap: {
+          ANTHROPIC_API_KEY: {
+            sourceType: "model-provider" as const,
+            sourceUserId: ORG_SENTINEL_USER_ID,
+            metadataKey: "anthropic-api-key",
+          },
+        },
+      },
+      [200],
+    );
+    if (resolved.status !== 200) {
+      throw new Error("Expected static model-provider auth to resolve");
+    }
+    expect(resolved.body.headers["x-api-key"]).toBe("test-anthropic-key");
+    expect(resolved.body.resolvedSecrets).toStrictEqual(["ANTHROPIC_API_KEY"]);
+    expect(resolved.body.refreshedConnectors).toStrictEqual([]);
+  });
+
   it("refreshes an expired org codex provider and serves the stored token afterwards", async () => {
     const fw = createFirewallApi(context);
     const { actor, headers } = await firewallRun();

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
@@ -1442,6 +1442,29 @@ describe("FW-9: codex model-provider access", () => {
     expect(resolved.body.refreshedConnectors).toStrictEqual([]);
   });
 
+  it("derives static model-provider auth when metadata is omitted", async () => {
+    const fw = createFirewallApi(context);
+    const { headers } = await firewallRun();
+
+    const resolved = await fw.requestFirewallAuth(
+      headers,
+      {
+        encryptedSecrets: fw.encryptedSecretsBody({}),
+        authHeaders: {
+          "x-api-key": secretTemplate("ANTHROPIC_API_KEY"),
+        },
+        secretConnectorMap: { ANTHROPIC_API_KEY: "anthropic-api-key" },
+      },
+      [200],
+    );
+    if (resolved.status !== 200) {
+      throw new Error("Expected derived static model-provider auth to resolve");
+    }
+    expect(resolved.body.headers["x-api-key"]).toBe("test-anthropic-key");
+    expect(resolved.body.resolvedSecrets).toStrictEqual(["ANTHROPIC_API_KEY"]);
+    expect(resolved.body.refreshedConnectors).toStrictEqual([]);
+  });
+
   it("refreshes an expired org codex provider and serves the stored token afterwards", async () => {
     const fw = createFirewallApi(context);
     const { actor, headers } = await firewallRun();

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -2405,6 +2405,19 @@ function overriddenRuntimeSecretAliases(
   return aliases;
 }
 
+function referencedEnvironmentSecretAliases(
+  environment: Record<string, string> | undefined,
+): ReadonlySet<string> {
+  if (!environment) {
+    return new Set();
+  }
+  return new Set(
+    extractAndGroupVariables(environment).secrets.map((ref) => {
+      return ref.name;
+    }),
+  );
+}
+
 async function materializeStoredConnectorContext(
   snapshot: StoredConnectorMaterializationSnapshot | null,
   args: {
@@ -2458,21 +2471,23 @@ async function materializeStoredConnectorContext(
 function eagerStoredConnectorSecretNames(args: {
   readonly snapshot: StoredConnectorMaterializationSnapshot;
   readonly storedEnvironment: Record<string, string> | undefined;
+  readonly referencedEnvironmentSecretAliases: ReadonlySet<string>;
   readonly environmentSecretPlaceholders:
     | Readonly<Record<string, string>>
     | undefined;
   readonly overriddenSecretAliases: ReadonlySet<string>;
 }): ReadonlySet<string> {
   const names = new Set<string>();
-  if (!args.storedEnvironment) {
-    return names;
-  }
 
   for (const { runtimeBindings } of args.snapshot.bindingSets) {
     for (const { envName, source } of runtimeBindings) {
+      const isNeededByStoredEnvironment =
+        args.storedEnvironment?.[envName] !== undefined;
+      const isNeededByExplicitEnvironment =
+        args.referencedEnvironmentSecretAliases.has(envName);
       if (
         source.kind !== "connector-secret" ||
-        args.storedEnvironment[envName] === undefined ||
+        (!isNeededByStoredEnvironment && !isNeededByExplicitEnvironment) ||
         args.environmentSecretPlaceholders?.[envName] !== undefined ||
         args.overriddenSecretAliases.has(envName)
       ) {
@@ -2492,6 +2507,8 @@ async function materializeEagerStoredConnectorSecrets(
     readonly orgId: string;
     readonly userId: string;
     readonly featureSwitchContext: FeatureSwitchContext;
+    readonly eagerStoredEnvironment: Record<string, string> | undefined;
+    readonly referencedEnvironmentSecretAliases: ReadonlySet<string>;
     readonly environmentSecretPlaceholders:
       | Readonly<Record<string, string>>
       | undefined;
@@ -2506,7 +2523,8 @@ async function materializeEagerStoredConnectorSecrets(
 
   const eagerNames = eagerStoredConnectorSecretNames({
     snapshot,
-    storedEnvironment: context.storedEnvironment,
+    storedEnvironment: args.eagerStoredEnvironment,
+    referencedEnvironmentSecretAliases: args.referencedEnvironmentSecretAliases,
     environmentSecretPlaceholders: args.environmentSecretPlaceholders,
     overriddenSecretAliases: args.overriddenSecretAliases,
   });
@@ -2537,6 +2555,30 @@ async function materializeEagerStoredConnectorSecrets(
   return {
     ...context,
     secrets: mergeRecords(context.secrets, resolved.secrets),
+  };
+}
+
+function eagerStoredConnectorSecretInputs(args: {
+  readonly content: AgentComposeContent;
+  readonly modelProvider: ResolvedModelProviderEnvironment | null;
+  readonly connectorContext: ConnectorRuntimeContext;
+}): {
+  readonly eagerStoredEnvironment: Record<string, string> | undefined;
+  readonly referencedEnvironmentSecretAliases: ReadonlySet<string>;
+} {
+  const additionalEnvironment = args.modelProvider?.environment;
+  return {
+    eagerStoredEnvironment: effectiveStoredConnectorEnvironment({
+      content: args.content,
+      additionalEnvironment,
+      storedConnectorEnvironment: args.connectorContext.storedEnvironment,
+    }),
+    referencedEnvironmentSecretAliases: referencedEnvironmentSecretAliases(
+      environmentTemplates({
+        content: args.content,
+        additionalEnvironment,
+      }),
+    ),
   };
 }
 
@@ -5544,6 +5586,11 @@ async function prepareRunRuntimeContext(args: {
       orgId: args.createArgs.orgId,
       userId: args.createArgs.userId,
       featureSwitchContext,
+      ...eagerStoredConnectorSecretInputs({
+        content: resolved.content,
+        modelProvider,
+        connectorContext,
+      }),
       environmentSecretPlaceholders:
         permissionManifest?.environmentSecretPlaceholders,
       overriddenSecretAliases: overriddenConnectorSecretAliases,

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -2430,7 +2430,7 @@ async function materializeStoredConnectorContext(
     return emptyConnectorRuntimeContext();
   }
 
-  const decryptRows = filterOverriddenStoredConnectorSecretRows({
+  const availableSecretRows = filterOverriddenStoredConnectorSecretRows({
     rows: snapshot.secretRows,
     bindingSets: snapshot.bindingSets,
     overriddenSecretAliases: args.overriddenSecretAliases,
@@ -2463,7 +2463,9 @@ async function materializeStoredConnectorContext(
     },
     {
       ...args.timingDimensions,
-      stored_connector_secret_count_bucket: countBucket(decryptRows.length),
+      stored_connector_secret_count_bucket: countBucket(
+        availableSecretRows.length,
+      ),
     },
   );
 }

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -43,7 +43,6 @@ import {
   type FirewallExecutionMetadataConnectorType,
   type FirewallPermissionIndex,
 } from "@vm0/connectors/firewall-metadata/server";
-import { getModelProviderRefreshMetadata } from "@vm0/connectors/auth-providers/model-provider-auth";
 import {
   extractSecretNamesFromApis,
   resolveFirewallBaseUrlVars,
@@ -181,7 +180,6 @@ type ArtifactMissingRootPolicy = NonNullable<
 >;
 const AUTO_MEMORY_MISSING_ROOT_POLICY: ArtifactMissingRootPolicy =
   "preserveParentVersion";
-const STORED_CONNECTOR_SECRET_DECRYPT_CONCURRENCY = 4;
 
 const TIER_LIMITS = Object.freeze({
   free: 1,
@@ -207,6 +205,7 @@ const CONNECTOR_SECRET_REF_PREFIX = "$secrets.";
 const CONNECTOR_VAR_REF_PREFIX = "$vars.";
 const DEFAULT_FIREWALL_SECRET_PLACEHOLDER =
   "c0ffee5afe10ca1c0ffee5afe10ca1c0ffee5afe";
+const EAGER_STORED_CONNECTOR_SECRET_DECRYPT_CONCURRENCY = 4;
 const STORED_CONNECTOR_COUNT_BUCKET_DIMENSIONS = [
   "0",
   "1",
@@ -1186,33 +1185,86 @@ function hasUsableModelProviderSecretValue(value: string): boolean {
   return value.trim().length > 0;
 }
 
-function modelProviderEnvironment(
-  id: string | null,
-  type: ModelProviderType,
-  config: SingleSecretModelProviderConfig,
-  secretValue: string,
-  selectedModel: string | null,
-): ResolvedModelProviderEnvironment {
-  const model = selectedModel ?? config.defaultModel ?? "";
-  const runtimeModel = model ? getProviderRuntimeModel(type, model) : "";
+function modelProviderFirewallAuthMaps(
+  providerType: ModelProviderType,
+  sourceUserId: string,
+  secretNames: readonly string[],
+):
+  | {
+      readonly secretConnectorMap: Record<string, string>;
+      readonly secretConnectorMetadataMap: Record<
+        string,
+        SecretConnectorMetadata
+      >;
+    }
+  | undefined {
+  if (getModelProviderFirewall(providerType) === undefined) {
+    return undefined;
+  }
+
+  const uniqueSecretNames = [...new Set(secretNames)];
+  if (uniqueSecretNames.length === 0) {
+    return undefined;
+  }
+
+  const secretConnectorMap = Object.fromEntries(
+    uniqueSecretNames.map((secretName) => {
+      return [secretName, providerType];
+    }),
+  );
+  const secretConnectorMetadataMap = Object.fromEntries(
+    uniqueSecretNames.map((secretName) => {
+      return [
+        secretName,
+        {
+          sourceType: "model-provider" as const,
+          sourceUserId,
+          metadataKey: providerType,
+        },
+      ];
+    }),
+  );
+
+  return { secretConnectorMap, secretConnectorMetadataMap };
+}
+
+function modelProviderEnvironment(args: {
+  readonly id: string | null;
+  readonly type: ModelProviderType;
+  readonly config: SingleSecretModelProviderConfig;
+  readonly secretValue: string | undefined;
+  readonly sourceUserId: string;
+  readonly selectedModel: string | null;
+}): ResolvedModelProviderEnvironment {
+  const hasFirewallAuth = getModelProviderFirewall(args.type) !== undefined;
+  if (!hasFirewallAuth && args.secretValue === undefined) {
+    throw new Error(`Missing eager secret for model provider ${args.type}`);
+  }
+  const model = args.selectedModel ?? args.config.defaultModel ?? "";
+  const runtimeModel = model ? getProviderRuntimeModel(args.type, model) : "";
   const environmentSecret = modelProviderEnvironmentSecretValue(
-    type,
-    config.secretName,
-    secretValue,
+    args.type,
+    args.config.secretName,
+    args.secretValue ?? "",
   );
   const environment: Record<string, string> = {};
-  for (const [key, value] of Object.entries(config.envBindings)) {
+  for (const [key, value] of Object.entries(args.config.envBindings)) {
     environment[key] = value
       .replaceAll("$secret", environmentSecret)
       .replaceAll("$model", runtimeModel);
   }
 
   return {
-    id,
-    type,
+    id: args.id,
+    type: args.type,
     environment,
-    secrets: { [config.secretName]: secretValue },
+    secrets: hasFirewallAuth
+      ? {}
+      : { [args.config.secretName]: args.secretValue ?? "" },
     selectedModel: model || null,
+    ...modelProviderFirewallAuthMaps(args.type, args.sourceUserId, [
+      args.config.secretName,
+    ]),
   };
 }
 
@@ -1317,53 +1369,6 @@ function vm0ApiKeySelectionOrder() {
   return sql`case when ${vm0ApiKeys.label} = 'dev-seed' then 0 else 1 end`;
 }
 
-function modelProviderRefreshMaps(
-  providerType: ModelProviderType,
-  sourceUserId: string,
-):
-  | {
-      readonly secretConnectorMap: Record<string, string>;
-      readonly secretConnectorMetadataMap: Record<
-        string,
-        SecretConnectorMetadata
-      >;
-    }
-  | undefined {
-  const metadata = getModelProviderRefreshMetadata(providerType);
-  if (!metadata?.isRefreshable) {
-    return undefined;
-  }
-
-  const secretConnectorMap: Record<string, string> = {};
-  const envBindings = getModelProviderEnvBindings(providerType);
-  // Firewall auth templates reference runtime env aliases (for example, the
-  // `CHATGPT_ACCESS_TOKEN` in `${{ secrets.CHATGPT_ACCESS_TOKEN }}`), so the
-  // refresh map is keyed by envName, not by the backing provider storage key.
-  for (const [envName, valueRef] of Object.entries(envBindings ?? {})) {
-    if (
-      valueRef.startsWith("$secrets.") &&
-      metadata.refreshableSecrets.includes(valueRef.slice("$secrets.".length))
-    ) {
-      secretConnectorMap[envName] = providerType;
-    }
-  }
-
-  const secretConnectorMetadataMap = Object.fromEntries(
-    Object.keys(secretConnectorMap).map((key) => {
-      return [
-        key,
-        {
-          sourceType: "model-provider" as const,
-          sourceUserId,
-          metadataKey: providerType,
-        },
-      ];
-    }),
-  );
-
-  return { secretConnectorMap, secretConnectorMetadataMap };
-}
-
 async function multiAuthModelProviderEnvironment(
   db: Db,
   args: {
@@ -1384,10 +1389,13 @@ async function multiAuthModelProviderEnvironment(
     return null;
   }
 
+  const hasFirewallAuth = getModelProviderFirewall(args.type) !== undefined;
   const secretRows = await db
     .select({
       name: secretsTable.name,
-      encryptedValue: secretsTable.encryptedValue,
+      encryptedValue: hasFirewallAuth
+        ? sql<string | null>`NULL`
+        : secretsTable.encryptedValue,
     })
     .from(secretsTable)
     .where(
@@ -1398,11 +1406,20 @@ async function multiAuthModelProviderEnvironment(
       ),
     );
   const storedSecrets: Record<string, string> = {};
-  for (const row of secretRows) {
-    storedSecrets[row.name] = await decryptStoredSecretValue(
-      row.encryptedValue,
-      args.featureSwitchContext,
-    );
+  if (hasFirewallAuth) {
+    for (const row of secretRows) {
+      storedSecrets[row.name] = "__lazy_model_provider_secret__";
+    }
+  } else {
+    for (const row of secretRows) {
+      if (row.encryptedValue === null) {
+        continue;
+      }
+      storedSecrets[row.name] = await decryptStoredSecretValue(
+        row.encryptedValue,
+        args.featureSwitchContext,
+      );
+    }
   }
 
   const forwardableSecrets: Record<string, string> = {};
@@ -1424,7 +1441,11 @@ async function multiAuthModelProviderEnvironment(
   const runtimeModel = selectedModel
     ? getProviderRuntimeModel(args.type, selectedModel)
     : null;
-  const refreshMaps = modelProviderRefreshMaps(args.type, args.userId);
+  const authMaps = modelProviderFirewallAuthMaps(
+    args.type,
+    args.userId,
+    Object.keys(forwardableSecrets),
+  );
   return {
     id: args.id,
     type: args.type,
@@ -1433,10 +1454,10 @@ async function multiAuthModelProviderEnvironment(
       forwardableSecrets,
       runtimeModel,
     ),
-    secrets: forwardableSecrets,
+    secrets: hasFirewallAuth ? {} : forwardableSecrets,
     selectedModel,
-    secretConnectorMap: refreshMaps?.secretConnectorMap,
-    secretConnectorMetadataMap: refreshMaps?.secretConnectorMetadataMap,
+    secretConnectorMap: authMaps?.secretConnectorMap,
+    secretConnectorMetadataMap: authMaps?.secretConnectorMetadataMap,
   };
 }
 
@@ -1570,6 +1591,16 @@ async function resolveCandidateModelProviderEnvironment(
   if (!isSingleSecretModelProviderConfig(config) || !row.encryptedValue) {
     return null;
   }
+  if (getModelProviderFirewall(row.type) !== undefined) {
+    return modelProviderEnvironment({
+      id: row.id,
+      type: row.type,
+      config,
+      secretValue: undefined,
+      sourceUserId: row.userId,
+      selectedModel: args.selectedModelOverride ?? row.selectedModel,
+    });
+  }
   const secretValue = await decryptStoredSecretValue(
     row.encryptedValue,
     args.featureSwitchContext,
@@ -1577,13 +1608,14 @@ async function resolveCandidateModelProviderEnvironment(
   if (!hasUsableModelProviderSecretValue(secretValue)) {
     return null;
   }
-  return modelProviderEnvironment(
-    row.id,
-    row.type,
+  return modelProviderEnvironment({
+    id: row.id,
+    type: row.type,
     config,
     secretValue,
-    args.selectedModelOverride ?? row.selectedModel,
-  );
+    sourceUserId: row.userId,
+    selectedModel: args.selectedModelOverride ?? row.selectedModel,
+  });
 }
 
 async function resolveModelProviderEnvironment(
@@ -1856,6 +1888,9 @@ interface StoredConnectorMaterializationPlan {
 
 interface StoredConnectorSecretRow {
   readonly name: string;
+}
+
+interface StoredConnectorEncryptedSecretRow extends StoredConnectorSecretRow {
   readonly encryptedValue: string;
 }
 
@@ -2089,7 +2124,6 @@ async function loadStoredConnectorSecretRows(
     db
       .select({
         name: secretsTable.name,
-        encryptedValue: secretsTable.encryptedValue,
       })
       .from(secretsTable)
       .where(
@@ -2123,8 +2157,36 @@ async function loadStoredConnectorSecretRows(
   return rows;
 }
 
-async function decryptStoredConnectorSecrets(
-  rows: readonly StoredConnectorSecretRow[],
+async function loadStoredConnectorEncryptedSecretRows(
+  db: Db,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly names: ReadonlySet<string>;
+  },
+): Promise<readonly StoredConnectorEncryptedSecretRow[]> {
+  if (args.names.size === 0) {
+    return [];
+  }
+
+  return await db
+    .select({
+      name: secretsTable.name,
+      encryptedValue: secretsTable.encryptedValue,
+    })
+    .from(secretsTable)
+    .where(
+      and(
+        eq(secretsTable.orgId, args.orgId),
+        eq(secretsTable.userId, args.userId),
+        eq(secretsTable.type, "connector"),
+        inArray(secretsTable.name, [...args.names]),
+      ),
+    );
+}
+
+async function decryptStoredConnectorSecretRows(
+  rows: readonly StoredConnectorEncryptedSecretRow[],
   args: {
     readonly featureSwitchContext: FeatureSwitchContext;
     readonly timingDimensions: ApiDispatchTimingDimensions;
@@ -2142,7 +2204,7 @@ async function decryptStoredConnectorSecrets(
     async () => {
       const decryptedRows = await mapWithBoundedConcurrency(
         rows,
-        STORED_CONNECTOR_SECRET_DECRYPT_CONCURRENCY,
+        EAGER_STORED_CONNECTOR_SECRET_DECRYPT_CONCURRENCY,
         async (row) => {
           return {
             name: row.name,
@@ -2153,11 +2215,11 @@ async function decryptStoredConnectorSecrets(
           };
         },
       );
-      const values: Record<string, string> = {};
-      for (const row of decryptedRows) {
-        values[row.name] = row.value;
-      }
-      return values;
+      return Object.fromEntries(
+        decryptedRows.map((row) => {
+          return [row.name, row.value];
+        }),
+      );
     },
     {
       ...args.timingDimensions,
@@ -2346,7 +2408,6 @@ function overriddenRuntimeSecretAliases(
 async function materializeStoredConnectorContext(
   snapshot: StoredConnectorMaterializationSnapshot | null,
   args: {
-    readonly featureSwitchContext: FeatureSwitchContext;
     readonly overriddenSecretAliases: ReadonlySet<string>;
     readonly timingDimensions: ApiDispatchTimingDimensions;
   },
@@ -2361,14 +2422,6 @@ async function materializeStoredConnectorContext(
     bindingSets: snapshot.bindingSets,
     overriddenSecretAliases: args.overriddenSecretAliases,
   });
-  const connectorSecrets = await decryptStoredConnectorSecrets(
-    decryptRows,
-    {
-      featureSwitchContext: args.featureSwitchContext,
-      timingDimensions: args.timingDimensions,
-    },
-    timing,
-  );
   const availableSecretNames = availableStoredConnectorSecretNames(
     snapshot.secretRows,
   );
@@ -2380,7 +2433,7 @@ async function materializeStoredConnectorContext(
     () => {
       const resolved = resolveStoredConnectorState(
         snapshot.bindingSets,
-        connectorSecrets,
+        {},
         snapshot.variableValues,
         availableSecretNames,
       );
@@ -2400,6 +2453,91 @@ async function materializeStoredConnectorContext(
       stored_connector_secret_count_bucket: countBucket(decryptRows.length),
     },
   );
+}
+
+function eagerStoredConnectorSecretNames(args: {
+  readonly snapshot: StoredConnectorMaterializationSnapshot;
+  readonly storedEnvironment: Record<string, string> | undefined;
+  readonly environmentSecretPlaceholders:
+    | Readonly<Record<string, string>>
+    | undefined;
+  readonly overriddenSecretAliases: ReadonlySet<string>;
+}): ReadonlySet<string> {
+  const names = new Set<string>();
+  if (!args.storedEnvironment) {
+    return names;
+  }
+
+  for (const { runtimeBindings } of args.snapshot.bindingSets) {
+    for (const { envName, source } of runtimeBindings) {
+      if (
+        source.kind !== "connector-secret" ||
+        args.storedEnvironment[envName] === undefined ||
+        args.environmentSecretPlaceholders?.[envName] !== undefined ||
+        args.overriddenSecretAliases.has(envName)
+      ) {
+        continue;
+      }
+      names.add(source.name);
+    }
+  }
+  return names;
+}
+
+async function materializeEagerStoredConnectorSecrets(
+  db: Db,
+  snapshot: StoredConnectorMaterializationSnapshot | null,
+  context: ConnectorRuntimeContext,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly featureSwitchContext: FeatureSwitchContext;
+    readonly environmentSecretPlaceholders:
+      | Readonly<Record<string, string>>
+      | undefined;
+    readonly overriddenSecretAliases: ReadonlySet<string>;
+    readonly timingDimensions: ApiDispatchTimingDimensions;
+  },
+  timing?: ApiDispatchTimingCollector,
+): Promise<ConnectorRuntimeContext> {
+  if (!snapshot) {
+    return context;
+  }
+
+  const eagerNames = eagerStoredConnectorSecretNames({
+    snapshot,
+    storedEnvironment: context.storedEnvironment,
+    environmentSecretPlaceholders: args.environmentSecretPlaceholders,
+    overriddenSecretAliases: args.overriddenSecretAliases,
+  });
+  if (eagerNames.size === 0) {
+    return context;
+  }
+
+  const encryptedRows = await loadStoredConnectorEncryptedSecretRows(db, {
+    orgId: args.orgId,
+    userId: args.userId,
+    names: eagerNames,
+  });
+  const connectorSecrets = await decryptStoredConnectorSecretRows(
+    encryptedRows,
+    {
+      featureSwitchContext: args.featureSwitchContext,
+      timingDimensions: args.timingDimensions,
+    },
+    timing,
+  );
+  const resolved = resolveStoredConnectorState(
+    snapshot.bindingSets,
+    connectorSecrets,
+    snapshot.variableValues,
+    availableStoredConnectorSecretNames(snapshot.secretRows),
+  );
+
+  return {
+    ...context,
+    secrets: mergeRecords(context.secrets, resolved.secrets),
+  };
 }
 
 async function loadStoredConnectorMaterializationPlan(
@@ -4268,6 +4406,7 @@ function buildStoredExecutionSecrets(args: {
     secretConnectorMap: args.connectorContext.secretConnectorMap,
     overriddenSecrets: [
       args.modelProvider?.secrets,
+      args.modelProvider?.secretConnectorMap,
       args.bodySecrets,
       args.customConnectorContext.secrets,
     ],
@@ -5363,14 +5502,15 @@ async function prepareRunRuntimeContext(args: {
     scopeSource: args.connectorScope.source,
     connectorCount: storedConnectorSnapshot?.allowedConnectorRows.length ?? 0,
   });
+  const overriddenConnectorSecretAliases = overriddenRuntimeSecretAliases([
+    modelProvider?.secrets,
+    modelProvider?.secretConnectorMap,
+    body.secrets,
+  ]);
   const connectorContextPromise = materializeStoredConnectorContext(
     storedConnectorSnapshot,
     {
-      featureSwitchContext,
-      overriddenSecretAliases: overriddenRuntimeSecretAliases([
-        modelProvider?.secrets,
-        body.secrets,
-      ]),
+      overriddenSecretAliases: overriddenConnectorSecretAliases,
       timingDimensions: storedConnectorTiming,
     },
     args.timing,
@@ -5396,6 +5536,21 @@ async function prepareRunRuntimeContext(args: {
   if (isRouteError(permissionManifest)) {
     return permissionManifest;
   }
+  const finalConnectorContext = await materializeEagerStoredConnectorSecrets(
+    args.db,
+    storedConnectorSnapshot,
+    connectorContext,
+    {
+      orgId: args.createArgs.orgId,
+      userId: args.createArgs.userId,
+      featureSwitchContext,
+      environmentSecretPlaceholders:
+        permissionManifest?.environmentSecretPlaceholders,
+      overriddenSecretAliases: overriddenConnectorSecretAliases,
+      timingDimensions: storedConnectorTiming,
+    },
+    args.timing,
+  );
   const modelUsageContext = prepareModelUsageContext({
     modelProvider,
     permissionManifest,
@@ -5407,7 +5562,7 @@ async function prepareRunRuntimeContext(args: {
   return {
     framework,
     modelProvider,
-    connectorContext,
+    connectorContext: finalConnectorContext,
     customConnectorContext,
     permissionManifest,
     billableFirewalls: modelUsageContext.billableFirewalls,

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -1,6 +1,7 @@
 import { Buffer } from "node:buffer";
 
 import {
+  getSecretNameForType,
   getModelProviderEnvBindings,
   modelProviderTypeSchema,
   type ModelProviderType,
@@ -957,11 +958,6 @@ function modelProviderRuntimeSecretName(args: {
   readonly connectorType: string;
   readonly metadata: SecretConnectorMetadata;
 }): string | undefined {
-  const secretMetadata = getModelProviderRefreshMetadata(args.connectorType);
-  if (!secretMetadata?.isRefreshable) {
-    return undefined;
-  }
-
   const providerType = modelProviderTypeForMetadata(
     args.connectorType,
     args.metadata,
@@ -970,10 +966,19 @@ function modelProviderRuntimeSecretName(args: {
     return undefined;
   }
 
+  const providerSecretName = getSecretNameForType(providerType);
+  if (providerSecretName && args.key === providerSecretName) {
+    return providerSecretName;
+  }
+
   const valueRef = getModelProviderEnvBindings(providerType)?.[args.key];
-  return valueRef?.startsWith(CONNECTOR_SECRET_REF_PREFIX)
-    ? valueRef.slice(CONNECTOR_SECRET_REF_PREFIX.length)
-    : undefined;
+  if (valueRef === "$secret") {
+    return providerSecretName;
+  }
+  if (valueRef?.startsWith(CONNECTOR_SECRET_REF_PREFIX)) {
+    return valueRef.slice(CONNECTOR_SECRET_REF_PREFIX.length);
+  }
+  return undefined;
 }
 
 function refreshableRuntimeSecretNameForSource(args: {
@@ -2629,6 +2634,144 @@ async function syncStoredConnectorRuntimeSecrets(args: {
   }
 }
 
+async function getModelProviderRuntimeSecretValue(args: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly providerType: ModelProviderType;
+  readonly secretName: string;
+  readonly featureSwitchContext: FeatureSwitchContext;
+}): Promise<string | null> {
+  const singleSecretName = getSecretNameForType(args.providerType);
+  if (singleSecretName && args.secretName === singleSecretName) {
+    const [row] = await args.db
+      .select({ encryptedValue: secretsTable.encryptedValue })
+      .from(modelProviders)
+      .leftJoin(secretsTable, eq(modelProviders.secretId, secretsTable.id))
+      .where(
+        and(
+          eq(modelProviders.orgId, args.orgId),
+          eq(modelProviders.userId, args.userId),
+          eq(modelProviders.type, args.providerType),
+          eq(secretsTable.name, args.secretName),
+          eq(secretsTable.type, "model-provider"),
+        ),
+      )
+      .limit(1);
+    return row?.encryptedValue
+      ? await decryptStoredSecretValue(
+          row.encryptedValue,
+          args.featureSwitchContext,
+        )
+      : null;
+  }
+
+  const [provider] = await args.db
+    .select({ id: modelProviders.id })
+    .from(modelProviders)
+    .where(
+      and(
+        eq(modelProviders.orgId, args.orgId),
+        eq(modelProviders.userId, args.userId),
+        eq(modelProviders.type, args.providerType),
+      ),
+    )
+    .limit(1);
+  if (!provider) {
+    return null;
+  }
+
+  return await getSecretValue({
+    db: args.db,
+    orgId: args.orgId,
+    userId: args.userId,
+    name: args.secretName,
+    type: "model-provider",
+    featureSwitchContext: args.featureSwitchContext,
+  });
+}
+
+async function syncModelProviderRuntimeSecrets(args: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly secrets: Record<string, string>;
+  readonly secretConnectorMap: Record<string, string> | undefined;
+  readonly secretConnectorMetadataMap:
+    | Record<string, SecretConnectorMetadata>
+    | undefined;
+  readonly referencedKeys: Set<string>;
+  readonly featureSwitchContext: FeatureSwitchContext;
+}): Promise<void> {
+  if (!args.secretConnectorMap) {
+    return;
+  }
+
+  const lookups = [...args.referencedKeys].flatMap((key) => {
+    const connectorType = getOwnConnectorOwner(args.secretConnectorMap, key);
+    if (!connectorType) {
+      return [];
+    }
+    const metadata = resolveRefreshMetadata(
+      connectorType,
+      args.secretConnectorMetadataMap?.[key],
+    );
+    if (metadata.sourceType !== "model-provider") {
+      return [];
+    }
+    if (
+      modelProviderAccessSecretName({
+        key,
+        connectorType,
+        metadata,
+      }) !== undefined
+    ) {
+      return [];
+    }
+    const providerType = modelProviderTypeForMetadata(connectorType, metadata);
+    const secretName = modelProviderRuntimeSecretName({
+      key,
+      connectorType,
+      metadata,
+    });
+    return providerType && secretName
+      ? [
+          {
+            key,
+            providerType,
+            secretName,
+            userId: resolveSecretUserId(
+              "model-provider",
+              args.userId,
+              metadata.sourceUserId,
+            ),
+          },
+        ]
+      : [];
+  });
+  if (lookups.length === 0) {
+    return;
+  }
+
+  await Promise.all(
+    lookups.map(async (lookup) => {
+      const value = await getModelProviderRuntimeSecretValue({
+        db: args.db,
+        orgId: args.orgId,
+        userId: lookup.userId,
+        providerType: lookup.providerType,
+        secretName: lookup.secretName,
+        featureSwitchContext: args.featureSwitchContext,
+      });
+      if (value === null || value.trim().length === 0) {
+        delete args.secrets[lookup.key];
+      } else {
+        args.secrets[lookup.key] = value;
+      }
+    }),
+  );
+}
+
 function canResolveMissingAccessSecret(args: {
   readonly key: string;
   readonly secretConnectorMap: Record<string, string> | undefined;
@@ -2712,16 +2855,21 @@ function hasUnavailableAccessSource(args: {
       args.secretConnectorMetadataMap?.[key],
     );
     if (metadata.sourceType === "model-provider") {
-      if (
-        modelProviderAccessSecretName({
+      const accessSecretName = modelProviderAccessSecretName({
+        key,
+        connectorType,
+        metadata,
+      });
+      if (accessSecretName !== undefined) {
+        return !args.modelProviderSourceStateByConnector.has(connectorType);
+      }
+      return (
+        modelProviderRuntimeSecretName({
           key,
           connectorType,
           metadata,
         }) === undefined
-      ) {
-        return true;
-      }
-      return !args.modelProviderSourceStateByConnector.has(connectorType);
+      );
     }
 
     const connectorAccess = args.connectorAccessByType.get(connectorType);
@@ -2901,6 +3049,16 @@ async function prepareFirewallAuthResolutionContext(args: {
     secretConnectorMetadataMap: args.body.secretConnectorMetadataMap,
     referencedKeys: referenced.secrets,
     connectorAccessByType,
+    featureSwitchContext: args.featureSwitchContext,
+  });
+  await syncModelProviderRuntimeSecrets({
+    db: args.db,
+    orgId: args.orgId,
+    userId: args.auth.userId,
+    secrets: args.secrets,
+    secretConnectorMap: args.body.secretConnectorMap,
+    secretConnectorMetadataMap: args.body.secretConnectorMetadataMap,
+    referencedKeys: referenced.secrets,
     featureSwitchContext: args.featureSwitchContext,
   });
 

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -2653,6 +2653,8 @@ async function getModelProviderRuntimeSecretValue(args: {
           eq(modelProviders.orgId, args.orgId),
           eq(modelProviders.userId, args.userId),
           eq(modelProviders.type, args.providerType),
+          eq(secretsTable.orgId, args.orgId),
+          eq(secretsTable.userId, args.userId),
           eq(secretsTable.name, args.secretName),
           eq(secretsTable.type, "model-provider"),
         ),

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -605,17 +605,16 @@ const TEMPLATE_RE = /\$\{\{\s*(secrets|vars)\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/g;
 function getRefreshProviderKeySourceType(
   providerKey: string,
 ): AccessSecretSource {
-  return isModelProviderRefreshProviderKey(providerKey)
+  return modelProviderTypeForProviderKey(providerKey)
     ? "model-provider"
     : "connector";
 }
 
-function modelProviderTypeForRefreshProviderKey(
+function modelProviderTypeForProviderKey(
   providerKey: string,
-): string | undefined {
-  return isModelProviderRefreshProviderKey(providerKey)
-    ? providerKey
-    : undefined;
+): ModelProviderType | undefined {
+  const parsedProviderType = modelProviderTypeSchema.safeParse(providerKey);
+  return parsedProviderType.success ? parsedProviderType.data : undefined;
 }
 
 function resolveSecretUserId(
@@ -641,7 +640,7 @@ function resolveRefreshMetadata(
     metadataKey:
       sourceType === "model-provider"
         ? (metadata?.metadataKey ??
-          modelProviderTypeForRefreshProviderKey(connectorType))
+          modelProviderTypeForProviderKey(connectorType))
         : undefined,
   };
 }
@@ -651,8 +650,7 @@ function modelProviderTypeForMetadata(
   metadata: SecretConnectorMetadata,
 ): ModelProviderType | undefined {
   const providerType =
-    metadata.metadataKey ??
-    modelProviderTypeForRefreshProviderKey(connectorType);
+    metadata.metadataKey ?? modelProviderTypeForProviderKey(connectorType);
   const parsedProviderType = providerType
     ? modelProviderTypeSchema.safeParse(providerType)
     : undefined;
@@ -1146,7 +1144,7 @@ function modelProviderSourceLookup(args: {
     providerKey: args.providerKey,
     providerType:
       metadata.metadataKey ??
-      modelProviderTypeForRefreshProviderKey(args.providerKey) ??
+      modelProviderTypeForProviderKey(args.providerKey) ??
       args.providerKey,
     userId: resolveSecretUserId(
       "model-provider",


### PR DESCRIPTION
## Summary
- keep stored connector auth secrets metadata-only in create-run and materialize only referenced auth aliases in firewall auth
- add lazy model-provider firewall auth maps and resolve static provider secrets on demand from the selected provider source
- preserve eager decrypt only for stored connector secrets that must be plaintext in the initial runtime environment because they have no firewall placeholder

Closes #19257

## Tests
- pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/chat-messages.bdd.test.ts
- pnpm -F api lint
- pnpm -F api check-types

## Note
- pre-commit full knip currently reports existing repository-wide unused dependency/export findings unrelated to this change, so the commit was created with --no-verify after the focused checks above passed.