### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -131,9 +131,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]


### PR DESCRIPTION
## Summary
- Updated the Rust workspace lockfile under `crates/`.
- `cargo update --verbose` updated 1 dependency: `arc-swap` `1.9.1` -> `1.9.2`.

## Dependencies not updated
- `generic-array` remains at `0.14.7` although `0.14.9` is available. A direct `cargo update -p generic-array --precise 0.14.9 --verbose` fails because transitive dependency `crypto-common v0.1.7` requires `generic-array = "=0.14.7"`.

## Manual version bumps
- None. No safe minor/patch `Cargo.toml` version specifier bumps were needed; the blocked dependency is constrained transitively, not by this repo's manifests.

## Test status
- Passed: `cargo test --workspace`.
- Runtime notes: this environment needed `CARGO_TARGET_DIR=/home/user/workspace/vm0-rust-deps-target` because `/tmp` did not have enough space for target artifacts. It also needed `-j 1`, `CARGO_PROFILE_TEST_DEBUG=0`, and `umask 0022` to fit the available memory and satisfy vm0's tempdir permission checks. No tests were skipped or disabled.