### PR TITLE
fix: add marketing rewrites for new locales

### DIFF
--- a/turbo/apps/web/__tests__/proxy.legal-pages.test.ts
+++ b/turbo/apps/web/__tests__/proxy.legal-pages.test.ts
@@ -65,6 +65,16 @@ describe("legalRedirectLayer", () => {
         "/support",
       );
     });
+
+    it("redirects /pt-BR/privacy-policy to /privacy-policy with 308", async () => {
+      const response = await runLegal(
+        "https://www.vm0.ai/pt-BR/privacy-policy",
+      );
+      expect(response.status).toBe(308);
+      expect(new URL(response.headers.get("location")!).pathname).toBe(
+        "/privacy-policy",
+      );
+    });
   });
 
   describe("does not redirect root legal pages", () => {

--- a/turbo/apps/web/__tests__/proxy.matcher.test.ts
+++ b/turbo/apps/web/__tests__/proxy.matcher.test.ts
@@ -22,6 +22,8 @@ describe("proxy matcher", () => {
     expectProxyMatch("/de/docs/schedules.md", true);
     expectProxyMatch("/ja/docs/what-zero-delivers/examples.md", true);
     expectProxyMatch("/es/docs/a.b/c.md", true);
+    expectProxyMatch("/fr/docs/quickstart.md", true);
+    expectProxyMatch("/pt-BR/docs/quickstart.md", true);
   });
 
   it("keeps canonical docs routes matched", () => {

--- a/turbo/apps/web/__tests__/so-frontend-rewrites.test.ts
+++ b/turbo/apps/web/__tests__/so-frontend-rewrites.test.ts
@@ -53,6 +53,14 @@ describe("so frontend rewrites", () => {
       destination: "https://pr-123-so.vm6.ai/en/models/:path*",
     });
     expect(rewrites).toContainEqual({
+      source: "/fr/blog/:path*",
+      destination: "https://pr-123-so.vm6.ai/fr/blog/:path*",
+    });
+    expect(rewrites).toContainEqual({
+      source: "/pt-BR/security",
+      destination: "https://pr-123-so.vm6.ai/pt-BR/security",
+    });
+    expect(rewrites).toContainEqual({
       source: "/sign-in",
       destination: "https://pr-123-so.vm6.ai/sign-in",
     });
@@ -110,6 +118,9 @@ describe("so frontend rewrites", () => {
   it("matches configured so frontend rewrite paths", () => {
     expect(matchesSoFrontendRewritePath("/pricing")).toBe(true);
     expect(matchesSoFrontendRewritePath("/en/pricing")).toBe(true);
+    expect(matchesSoFrontendRewritePath("/fr")).toBe(true);
+    expect(matchesSoFrontendRewritePath("/fr/blog/posts/example")).toBe(true);
+    expect(matchesSoFrontendRewritePath("/pt-BR/security")).toBe(true);
     expect(matchesSoFrontendRewritePath("/video")).toBe(true);
     expect(matchesSoFrontendRewritePath("/en/video")).toBe(true);
     expect(matchesSoFrontendRewritePath("/en/blog/posts/example")).toBe(true);
@@ -144,6 +155,10 @@ describe("so frontend rewrites", () => {
     );
     expect(resolveSoFrontendRewritePath("/en/docs/reference/api")).toBe(
       "/en/docs/reference/api",
+    );
+    expect(resolveSoFrontendRewritePath("/fr/blog")).toBe("/fr/blog");
+    expect(resolveSoFrontendRewritePath("/pt-BR/security")).toBe(
+      "/pt-BR/security",
     );
     expect(resolveSoFrontendRewritePath("/sign-in/factor-one")).toBe(
       "/sign-in/factor-one",

--- a/turbo/apps/web/i18n.ts
+++ b/turbo/apps/web/i18n.ts
@@ -1,7 +1,18 @@
 import { getRequestConfig } from "next-intl/server";
 
 // Supported locales
-export const locales = ["en", "de", "ja", "es"] as const;
+export const locales = [
+  "en",
+  "de",
+  "ja",
+  "es",
+  "fr",
+  "it",
+  "pt-BR",
+  "ko",
+  "hi",
+  "id",
+] as const;
 export type Locale = (typeof locales)[number];
 
 // Default locale

--- a/turbo/apps/web/proxy.layers.ts
+++ b/turbo/apps/web/proxy.layers.ts
@@ -125,7 +125,15 @@ export async function runLayers(
  * pages (/sign-up). Auth pages live outside the [locale] route tree, so
  * /:locale/sign-up would 404 without this redirect.
  */
-const LOCALE_AUTH_RE = /^\/(\w{2})\/(sign-in|sign-up)(\/.*)?$/;
+const LOCALE_PATTERN = locales
+  .map((locale) => {
+    return locale.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  })
+  .join("|");
+
+const LOCALE_AUTH_RE = new RegExp(
+  `^/(${LOCALE_PATTERN})/(sign-in|sign-up)(/.*)?$`,
+);
 
 export const authRedirectLayer: ProxyLayer = (ctx) => {
   const match = ctx.request.nextUrl.pathname.match(LOCALE_AUTH_RE);
@@ -143,8 +151,9 @@ export const authRedirectLayer: ProxyLayer = (ctx) => {
  * route tree: legal pages use Termly iframe embeds (Termly handles its own
  * language) and /support is English-only per Slack App Directory guidelines.
  */
-const LOCALE_LEGAL_RE =
-  /^\/(\w{2})\/(privacy-policy|terms-of-use|support)(\/.*)?$/;
+const LOCALE_LEGAL_RE = new RegExp(
+  `^/(${LOCALE_PATTERN})/(privacy-policy|terms-of-use|support)(/.*)?$`,
+);
 
 export const legalRedirectLayer: ProxyLayer = (ctx) => {
   const match = ctx.request.nextUrl.pathname.match(LOCALE_LEGAL_RE);

--- a/turbo/apps/web/proxy.ts
+++ b/turbo/apps/web/proxy.ts
@@ -386,7 +386,7 @@ export const config = {
   matcher: [
     // Keep locale-prefixed docs routes behind Clerk even when legacy crawlers
     // request markdown-like URLs such as /en/docs/quickstart.md.
-    "/:locale(en|de|ja|es)/docs/(.*)",
+    "/:locale(en|de|ja|es|fr|it|pt-BR|ko|hi|id)/docs/(.*)",
     // Match all routes except:
     // - _next (Next.js internals)
     // - _vercel (Vercel internals)

--- a/turbo/apps/web/so-frontend-rewrites.js
+++ b/turbo/apps/web/so-frontend-rewrites.js
@@ -1,4 +1,4 @@
-const LOCALES = ["en", "de", "ja", "es"];
+const LOCALES = ["en", "de", "ja", "es", "fr", "it", "pt-BR", "ko", "hi", "id"];
 
 const SO_FRONTEND_EXACT_PATHS = [
   "/",


### PR DESCRIPTION
## Summary
- add the newly launched marketing locales to the web i18n allowlist
- generate SO frontend rewrites for fr, it, pt-BR, ko, hi, and id paths
- update locale-aware proxy matching and legal-page redirect handling for hyphenated locales

## Tests
- pnpm exec prettier --write apps/web/i18n.ts apps/web/so-frontend-rewrites.js apps/web/proxy.layers.ts apps/web/proxy.ts apps/web/__tests__/so-frontend-rewrites.test.ts apps/web/__tests__/proxy.matcher.test.ts apps/web/__tests__/proxy.legal-pages.test.ts
- pnpm exec oxlint i18n.ts so-frontend-rewrites.js proxy.layers.ts proxy.ts __tests__/so-frontend-rewrites.test.ts __tests__/proxy.matcher.test.ts __tests__/proxy.legal-pages.test.ts
- pnpm exec eslint i18n.ts so-frontend-rewrites.js proxy.layers.ts proxy.ts __tests__/so-frontend-rewrites.test.ts __tests__/proxy.matcher.test.ts __tests__/proxy.legal-pages.test.ts --max-warnings 0
- pnpm -F web check-types
- pnpm exec vitest run apps/web/__tests__/so-frontend-rewrites.test.ts
- pnpm exec vitest run apps/web/__tests__/proxy.matcher.test.ts
- pnpm exec vitest run apps/web/__tests__/proxy.legal-pages.test.ts