### PR TITLE
fix: declare guest-contracts serde dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1298,6 +1298,8 @@ name = "guest-contracts"
 version = "0.2.7"
 dependencies = [
  "libc",
+ "serde",
+ "serde_json",
  "tempfile",
  "uuid",
 ]

--- a/crates/guest-contracts/Cargo.toml
+++ b/crates/guest-contracts/Cargo.toml
@@ -6,6 +6,8 @@ description = "Shared contracts between runner and guest binaries"
 
 [dependencies]
 libc.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary
- Add serde and serde_json as explicit guest-contracts dependencies
- Update the Rust lockfile so the standalone guest-contracts crate builds

## Testing
- cargo check --manifest-path crates/Cargo.toml -p guest-contracts
- cargo test --manifest-path crates/Cargo.toml -p guest-contracts --quiet
- cargo fmt --manifest-path crates/Cargo.toml --all
- cargo clippy --manifest-path crates/Cargo.toml -p guest-contracts --tests -- -D warnings
- pre-commit hook: cargo-doc, cargo-clippy