### PR TITLE
Allow zero price redemptions without coupons

### DIFF
--- a/turbo/apps/api/src/lib/env.ts
+++ b/turbo/apps/api/src/lib/env.ts
@@ -92,7 +92,7 @@ const SCHEMA = {
       return z
         .record(
           z.string(),
-          z.object({ priceId: z.string(), couponId: z.string() }),
+          z.object({ priceId: z.string(), couponId: z.string().optional() }),
         )
         .parse(JSON.parse(val));
     }),

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-redeem.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-redeem.test.ts
@@ -31,12 +31,17 @@ const APP_ORIGIN = "http://app.localhost:3002";
 const SUCCESS_URL = `${APP_ORIGIN}/redeem/${CAMPAIGN}?stripe=success`;
 const CANCEL_URL = `${APP_ORIGIN}/redeem/${CAMPAIGN}`;
 
-function setRedeemEnv(): void {
+function setRedeemEnv(options: { readonly coupon?: boolean } = {}): void {
   mockOptionalEnv("STRIPE_SECRET_KEY", "sk_test_fake");
   mockEnv("APP_URL", APP_ORIGIN);
   mockEnv(
     "ZERO_ONE_TIME_CAMPAIGN",
-    JSON.stringify({ [CAMPAIGN]: { priceId: PRICE_ID, couponId: COUPON_ID } }),
+    JSON.stringify({
+      [CAMPAIGN]: {
+        priceId: PRICE_ID,
+        ...(options.coupon ? { couponId: COUPON_ID } : {}),
+      },
+    }),
   );
 }
 
@@ -47,11 +52,7 @@ describe("POST /api/zero/billing/redeem/:campaign", () => {
 
   beforeEach(() => {
     setRedeemEnv();
-    // Default-safe coupon/price responses; specific tests override.
-    context.mocks.stripe.coupons.retrieve.mockResolvedValue({
-      id: COUPON_ID,
-      valid: true,
-    });
+    // Default-safe price response; specific tests override.
     context.mocks.stripe.prices.retrieve.mockResolvedValue({
       id: PRICE_ID,
       active: true,
@@ -218,7 +219,6 @@ describe("POST /api/zero/billing/redeem/:campaign", () => {
       expect.objectContaining({
         mode: "payment",
         line_items: [{ price: PRICE_ID, quantity: 1 }],
-        discounts: [{ coupon: COUPON_ID }],
         success_url: SUCCESS_URL,
         cancel_url: CANCEL_URL,
         metadata: {
@@ -228,6 +228,9 @@ describe("POST /api/zero/billing/redeem/:campaign", () => {
         },
       }),
     );
+    expect(
+      context.mocks.stripe.checkout.sessions.create.mock.calls[0]?.[0],
+    ).not.toHaveProperty("discounts");
 
     const row = await store.set(findOrgPromoRedemption$, {
       orgId: fixture.orgId,
@@ -281,6 +284,7 @@ describe("POST /api/zero/billing/redeem/:campaign", () => {
   });
 
   it("drops the cached session and returns campaign_misconfigured when the coupon was deleted", async () => {
+    setRedeemEnv({ coupon: true });
     const fixture = await track(
       store.set(
         seedRedeemOrg$,
@@ -337,6 +341,7 @@ describe("POST /api/zero/billing/redeem/:campaign", () => {
   });
 
   it("still drops the cached session row when expiring it in Stripe fails", async () => {
+    setRedeemEnv({ coupon: true });
     const fixture = await track(
       store.set(
         seedRedeemOrg$,
@@ -400,6 +405,7 @@ describe("POST /api/zero/billing/redeem/:campaign", () => {
   });
 
   it("drops the cached session and returns campaign_misconfigured when the coupon is no longer valid", async () => {
+    setRedeemEnv({ coupon: true });
     const fixture = await track(
       store.set(
         seedRedeemOrg$,
@@ -697,6 +703,7 @@ describe("POST /api/zero/billing/redeem/:campaign", () => {
   });
 
   it("returns campaign_misconfigured when Stripe coupon is missing at create time", async () => {
+    setRedeemEnv({ coupon: true });
     const fixture = await track(
       store.set(
         seedRedeemOrg$,

--- a/turbo/apps/api/src/signals/services/one-time-products.ts
+++ b/turbo/apps/api/src/signals/services/one-time-products.ts
@@ -7,11 +7,12 @@ import { env } from "../../lib/env";
  * page (which calls `POST /api/zero/billing/redeem/:campaign`). It bundles:
  *   - business policy (credits, expiry, source) — hardcoded here so ops can't
  *     inflate credits by flipping an env var;
- *   - Stripe identifiers (priceId, couponId) — sourced from env so test and
- *     live Stripe accounts can point at different prices/coupons without a
+ *   - Stripe identifiers (priceId, optional couponId) — sourced from env so
+ *     test and live Stripe accounts can point at different prices/coupons without a
  *     code change.
  *
- * The redeem route uses `priceId`/`couponId`; the webhook handler (still on
+ * The redeem route uses `priceId` and applies `couponId` only when present;
+ * the webhook handler (still on
  * apps/web in this Wave) uses `credits`/`expiresDays`/`source`. Keep the
  * full registry shape so future webhook migration is a copy-paste.
  */

--- a/turbo/apps/api/src/signals/services/zero-billing-redeem.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-billing-redeem.service.ts
@@ -22,7 +22,7 @@ const log = logger("zero-billing-redeem");
  * - `already_granted`  — credits already landed in the org ledger.
  * - `processing`       — Stripe accepted the payment but the webhook hasn't
  *                        persisted the grant yet; the user should refresh.
- * - `stripe_error`     — Stripe rejected the create/retrieve/coupon/price
+ * - `stripe_error`     — Stripe rejected the create/retrieve/price/coupon
  *                        call; the route maps this to `campaign_misconfigured`.
  */
 type RedemptionResult =
@@ -238,11 +238,12 @@ const ensureCampaignStillAvailable$ = command(
     }
 
     const stripe = getStripeClient();
-    // Parallel: each is an independent Stripe read; wall time is one RTT.
     const fetched = await settle(
       Promise.all([
-        stripe.coupons.retrieve(campaign.couponId),
         stripe.prices.retrieve(campaign.priceId),
+        ...(campaign.couponId
+          ? [stripe.coupons.retrieve(campaign.couponId)]
+          : []),
       ]),
     );
     signal.throwIfAborted();
@@ -254,7 +255,7 @@ const ensureCampaignStillAvailable$ = command(
         log.warn("one_time_purchase stripe resource missing on resume", {
           orgId: args.orgId,
           campaignKey: args.campaignKey,
-          couponId: campaign.couponId,
+          couponId: campaign.couponId ?? null,
           priceId: campaign.priceId,
           stripeMessage: fetched.error.message,
         });
@@ -263,19 +264,19 @@ const ensureCampaignStillAvailable$ = command(
       throw fetched.error;
     }
     signal.throwIfAborted();
-    const [coupon, price] = fetched.value;
+    const [price, coupon] = fetched.value;
 
-    if (!coupon.valid) {
+    if (coupon && !coupon.valid) {
       log.warn("one_time_purchase coupon no longer valid on resume", {
         orgId: args.orgId,
         campaignKey: args.campaignKey,
-        couponId: campaign.couponId,
+        couponId: campaign.couponId ?? null,
       });
       await set(cleanupStaleRedemption$, { args, stripeSessionId }, signal);
       throw new StripeSDK.errors.StripeInvalidRequestError({
         type: "invalid_request_error",
         code: "resource_missing",
-        message: `Coupon ${campaign.couponId} is no longer valid`,
+        message: `Coupon ${campaign.couponId ?? ""} is no longer valid`,
       });
     }
 
@@ -353,7 +354,9 @@ const createOneTimeCheckoutSession$ = command(
       mode: "payment",
       customer: customerId,
       line_items: [{ price: campaign.priceId, quantity: 1 }],
-      discounts: [{ coupon: campaign.couponId }],
+      ...(campaign.couponId
+        ? { discounts: [{ coupon: campaign.couponId }] }
+        : {}),
       success_url: args.successUrl,
       cancel_url: args.cancelUrl,
       metadata: {


### PR DESCRIPTION
## Summary
- make ZERO_ONE_TIME_CAMPAIGN couponId optional
- create zero-price redeem checkout sessions without discounts when no coupon is configured
- keep existing coupon behavior for legacy campaigns that still set couponId

## Verification
- pnpm --filter api check-types
- pnpm --filter api exec vitest run src/signals/routes/__tests__/zero-billing-redeem.test.ts (blocked locally: database `vm0_test` does not exist)