### PR TITLE
fix(runner): verify sandbox runtime commands in rootfs

### DIFF
--- a/crates/runner/scripts/verify-rootfs.sh
+++ b/crates/runner/scripts/verify-rootfs.sh
@@ -107,7 +107,7 @@ trap cleanup EXIT
 # ---------------------------------------------------------------------------
 
 missing=()
-for cmd in sudo unshare mount umount mountpoint stat mktemp sed grep chroot; do
+for cmd in sudo unshare mount umount mountpoint stat mktemp sed grep readlink; do
   if ! command -v "$cmd" &> /dev/null; then
     missing+=("$cmd")
   fi
@@ -136,9 +136,69 @@ sudo mount -o loop,ro "$ROOTFS" "$MOUNT_DIR"
 
 errors=()
 
+resolve_rootfs_path() {
+  local rootfs_path="$1"
+  local resolved="/"
+  local remaining="${rootfs_path#/}"
+  local symlink_count=0
+  local component candidate target
+
+  while [[ -n "$remaining" ]]; do
+    component="${remaining%%/*}"
+    if [[ "$component" == "$remaining" ]]; then
+      remaining=""
+    else
+      remaining="${remaining#*/}"
+    fi
+
+    case "$component" in
+      ""|".")
+        continue
+        ;;
+      "..")
+        resolved="${resolved%/*}"
+        [[ -n "$resolved" ]] || resolved="/"
+        continue
+        ;;
+    esac
+
+    if [[ "$resolved" == "/" ]]; then
+      candidate="/${component}"
+    else
+      candidate="${resolved}/${component}"
+    fi
+
+    if [[ -L "${MOUNT_DIR}${candidate}" ]]; then
+      symlink_count=$((symlink_count + 1))
+      if [[ "$symlink_count" -gt 40 ]]; then
+        return 1
+      fi
+      target="$(readlink -- "${MOUNT_DIR}${candidate}")"
+      if [[ "$target" == /* ]]; then
+        resolved="/"
+        target="${target#/}"
+      fi
+      if [[ -n "$remaining" ]]; then
+        remaining="${target}/${remaining}"
+      else
+        remaining="$target"
+      fi
+    else
+      resolved="$candidate"
+    fi
+  done
+
+  printf '%s\n' "$resolved"
+}
+
 check_required_executable() {
   local path="$1" name="${2:-$1}"
-  if sudo chroot "$MOUNT_DIR" /bin/sh -c 'test -x "$1"' sh "$path" 2>/dev/null; then
+  local resolved_path
+  if ! resolved_path="$(resolve_rootfs_path "$path")"; then
+    errors+=("${name} cannot resolve rootfs path at ${path}")
+    return
+  fi
+  if [[ -f "${MOUNT_DIR}${resolved_path}" && -x "${MOUNT_DIR}${resolved_path}" ]]; then
     echo "  ${name}: found"
   else
     errors+=("${name} not found or not executable at ${path}")

--- a/crates/runner/scripts/verify-rootfs.sh
+++ b/crates/runner/scripts/verify-rootfs.sh
@@ -136,6 +136,26 @@ sudo mount -o loop,ro "$ROOTFS" "$MOUNT_DIR"
 
 errors=()
 
+check_required_executable() {
+  local path="$1" name="${2:-$1}"
+  local check_path="${MOUNT_DIR}${path}"
+  if [[ -x "$check_path" ]]; then
+    echo "  ${name}: found"
+  else
+    errors+=("${name} not found or not executable at ${path}")
+  fi
+}
+
+check_bin() {
+  local pattern="$1" name="$2"
+  # shellcheck disable=SC2086
+  if ls ${MOUNT_DIR}${pattern} &>/dev/null; then
+    echo "  ${name}: found"
+  else
+    errors+=("${name} not found (pattern: ${pattern})")
+  fi
+}
+
 # Check root directory permissions (must be 0755 for non-root users to access files)
 root_perms=$(stat -c%a "$MOUNT_DIR")
 if [[ "$root_perms" == "755" ]]; then
@@ -163,12 +183,7 @@ guest_dests=(
 if [[ "$MODE" == "rootfs" ]]; then
   # Check guest binaries
   for dest in "${guest_dests[@]}"; do
-    check_path="${MOUNT_DIR}${dest}"
-    if [[ -f "$check_path" ]]; then
-      echo "  ${dest}: found"
-    else
-      errors+=("${dest} not found")
-    fi
+    check_required_executable "$dest" "$dest"
   done
 else
   guest_contamination=0
@@ -183,26 +198,49 @@ else
   fi
 fi
 
-# Check required sandbox runtime commands. Runner helper exec scripts run inside
-# the sandbox via `sh -c`, so missing POSIX utilities should fail image
-# verification instead of surfacing during a user session restore.
-check_bin() {
-  local pattern="$1" name="$2"
-  # shellcheck disable=SC2086
-  if ls ${MOUNT_DIR}${pattern} &>/dev/null; then
-    echo "  ${name}: found"
-  else
-    errors+=("${name} not found (pattern: ${pattern})")
-  fi
-}
+# Check required sandbox runtime commands. Runner-owned exec/start-process
+# commands run inside the guest via shell wrappers and included helper scripts,
+# so missing commands should fail image verification before a user session.
+#
+# Intentionally unchecked: best-effort diagnostics from
+# agent-abnormal-exit-diagnostics.sh such as file, sha256sum, free, timeout,
+# and ps. That script runs with `set +e` and has command/fallback guards where
+# absence should reduce diagnostic detail, not block image verification.
 
-check_bin "/bin/sh"        "sh"
-check_bin "/usr/bin/find"  "find"
-check_bin "/usr/bin/awk"   "awk"
-check_bin "/usr/bin/xargs" "xargs"
-check_bin "/usr/bin/mktemp" "mktemp"
-check_bin "/usr/bin/tr"    "tr"
-check_bin "/usr/bin/rm"    "rm"
+# Shell wrappers used by vsock-guest before the runner command body executes.
+check_required_executable "/bin/sh" "sh"
+check_required_executable "/bin/bash" "bash"
+check_required_executable "/usr/bin/su" "su"
+
+# Guest state and timezone repair. /sbin/guest-reseed is rootfs-only and is
+# checked with the guest binaries above when verifying a rootfs image.
+check_required_executable "/usr/bin/date" "date"
+check_required_executable "/usr/bin/ln" "ln"
+check_required_executable "/usr/bin/sed" "sed"
+
+# Storage manifest cleanup and Codex session cleanup helpers.
+check_required_executable "/usr/bin/rm" "rm"
+check_required_executable "/usr/bin/find" "find"
+check_required_executable "/usr/bin/awk" "awk"
+check_required_executable "/usr/bin/xargs" "xargs"
+check_required_executable "/usr/bin/mktemp" "mktemp"
+check_required_executable "/usr/bin/tr" "tr"
+
+# Workspace mount/unmount helpers.
+check_required_executable "/usr/bin/mountpoint" "mountpoint"
+check_required_executable "/usr/bin/mount" "mount"
+check_required_executable "/usr/bin/umount" "umount"
+check_required_executable "/usr/bin/sync" "sync"
+check_required_executable "/usr/bin/chown" "chown"
+check_required_executable "/usr/bin/mkdir" "mkdir"
+check_required_executable "/usr/bin/stat" "stat"
+check_required_executable "/usr/bin/cat" "cat"
+check_required_executable "/usr/bin/readlink" "readlink"
+check_required_executable "/usr/bin/cut" "cut"
+check_required_executable "/usr/bin/sort" "sort"
+check_required_executable "/usr/bin/wc" "wc"
+check_required_executable "/usr/bin/kill" "kill"
+check_required_executable "/usr/bin/sleep" "sleep"
 
 # Check CLIs
 if [[ -f "${MOUNT_DIR}/usr/bin/gh" ]]; then

--- a/crates/runner/scripts/verify-rootfs.sh
+++ b/crates/runner/scripts/verify-rootfs.sh
@@ -202,10 +202,9 @@ fi
 # commands run inside the guest via shell wrappers and included helper scripts,
 # so missing commands should fail image verification before a user session.
 #
-# Intentionally unchecked: best-effort diagnostics from
-# agent-abnormal-exit-diagnostics.sh such as file, sha256sum, free, timeout,
-# and ps. That script runs with `set +e` and has command/fallback guards where
-# absence should reduce diagnostic detail, not block image verification.
+# Intentionally unchecked optional diagnostic commands: file sha256sum free timeout ps.
+# agent-abnormal-exit-diagnostics.sh runs with `set +e` and has command/fallback
+# guards where absence should reduce diagnostic detail, not block image verification.
 
 # Shell wrappers used by vsock-guest before the runner command body executes.
 check_required_executable "/bin/sh" "sh"

--- a/crates/runner/scripts/verify-rootfs.sh
+++ b/crates/runner/scripts/verify-rootfs.sh
@@ -136,6 +136,8 @@ sudo mount -o loop,ro "$ROOTFS" "$MOUNT_DIR"
 
 errors=()
 
+# Resolve inside the mounted rootfs without chroot: verification may inspect
+# cached or downloaded images, so it must not execute binaries from the image.
 resolve_rootfs_path() {
   local rootfs_path="$1"
   local resolved="/"

--- a/crates/runner/scripts/verify-rootfs.sh
+++ b/crates/runner/scripts/verify-rootfs.sh
@@ -107,7 +107,7 @@ trap cleanup EXIT
 # ---------------------------------------------------------------------------
 
 missing=()
-for cmd in sudo unshare mount umount mountpoint stat mktemp sed grep; do
+for cmd in sudo unshare mount umount mountpoint stat mktemp sed grep chroot; do
   if ! command -v "$cmd" &> /dev/null; then
     missing+=("$cmd")
   fi
@@ -138,8 +138,7 @@ errors=()
 
 check_required_executable() {
   local path="$1" name="${2:-$1}"
-  local check_path="${MOUNT_DIR}${path}"
-  if [[ -x "$check_path" ]]; then
+  if sudo chroot "$MOUNT_DIR" /bin/sh -c 'test -x "$1"' sh "$path" 2>/dev/null; then
     echo "  ${name}: found"
   else
     errors+=("${name} not found or not executable at ${path}")

--- a/crates/runner/scripts/verify-rootfs.sh
+++ b/crates/runner/scripts/verify-rootfs.sh
@@ -268,9 +268,11 @@ fi
 # guards where absence should reduce diagnostic detail, not block image verification.
 
 # Shell wrappers used by vsock-guest before the runner command body executes.
+# Env-backed wrappers clean up their transient script directory before exec.
 check_required_executable "/bin/sh" "sh"
 check_required_executable "/bin/bash" "bash"
 check_required_executable "/usr/bin/su" "su"
+check_required_executable "/usr/bin/rmdir" "rmdir"
 
 # Guest state and timezone repair. /sbin/guest-reseed is rootfs-only and is
 # checked with the guest binaries above when verifying a rootfs image.

--- a/crates/runner/src/cmd/build/scripts.rs
+++ b/crates/runner/src/cmd/build/scripts.rs
@@ -493,14 +493,18 @@ exit 1
     #[test]
     fn verify_script_checks_sandbox_helper_runtime_commands() {
         assert!(
-            VERIFY_SCRIPT.contains(r#"sudo chroot "$MOUNT_DIR" /bin/sh -c 'test -x "$1"'"#),
-            "verify-rootfs.sh should resolve required executable symlinks inside the guest rootfs"
+            VERIFY_SCRIPT.contains("resolve_rootfs_path()"),
+            "verify-rootfs.sh should resolve required executable symlinks within the mounted rootfs"
         );
         assert!(
             VERIFY_SCRIPT.contains(
-                "for cmd in sudo unshare mount umount mountpoint stat mktemp sed grep chroot; do"
+                "for cmd in sudo unshare mount umount mountpoint stat mktemp sed grep readlink; do"
             ),
-            "verify-rootfs.sh should declare chroot as a host dependency"
+            "verify-rootfs.sh should declare readlink as a host dependency for safe symlink resolution"
+        );
+        assert!(
+            !VERIFY_SCRIPT.contains(r#"sudo chroot "$MOUNT_DIR" /bin/sh"#),
+            "verify-rootfs.sh must not execute binaries from the image it is verifying"
         );
 
         for (group, command_paths) in [
@@ -570,6 +574,66 @@ exit 1
                 "verify-rootfs.sh should verify {guest_binary_path} in rootfs mode"
             );
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn verify_script_resolves_rootfs_symlinks_without_host_paths() {
+        use std::os::unix::fs::symlink;
+        use std::process::Command;
+
+        let resolver_start = VERIFY_SCRIPT
+            .find("resolve_rootfs_path() {")
+            .expect("verify-rootfs.sh should define resolve_rootfs_path");
+        let resolver_end = VERIFY_SCRIPT
+            .find("\ncheck_required_executable() {")
+            .expect("verify-rootfs.sh should define check_required_executable after resolver");
+        let resolver_function = &VERIFY_SCRIPT[resolver_start..resolver_end];
+
+        let rootfs = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(rootfs.path().join("usr/bin")).unwrap();
+        std::fs::create_dir_all(rootfs.path().join("etc/alternatives")).unwrap();
+        symlink("usr/bin", rootfs.path().join("bin")).unwrap();
+        symlink("/etc/alternatives/awk", rootfs.path().join("usr/bin/awk")).unwrap();
+        symlink(
+            "../../usr/bin/real-tool",
+            rootfs.path().join("etc/alternatives/awk"),
+        )
+        .unwrap();
+        let real_tool = rootfs.path().join("usr/bin/real-tool");
+        std::fs::write(&real_tool, b"#!/bin/sh\n").unwrap();
+        let mut perms = std::fs::metadata(&real_tool).unwrap().permissions();
+        std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o755);
+        std::fs::set_permissions(&real_tool, perms).unwrap();
+        symlink("loop-b", rootfs.path().join("usr/bin/loop-a")).unwrap();
+        symlink("loop-a", rootfs.path().join("usr/bin/loop-b")).unwrap();
+
+        let script = format!(
+            r#"
+set -euo pipefail
+{resolver_function}
+resolved="$(resolve_rootfs_path /bin/awk)"
+test "$resolved" = "/usr/bin/real-tool"
+test -x "${{MOUNT_DIR}}${{resolved}}"
+if resolve_rootfs_path /usr/bin/loop-a >/dev/null; then
+  echo "loop not detected" >&2
+  exit 1
+fi
+"#
+        );
+        let output = Command::new("bash")
+            .arg("-c")
+            .arg(script)
+            .env("MOUNT_DIR", rootfs.path())
+            .output()
+            .unwrap();
+
+        assert!(
+            output.status.success(),
+            "resolver script failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 
     #[test]

--- a/crates/runner/src/cmd/build/scripts.rs
+++ b/crates/runner/src/cmd/build/scripts.rs
@@ -636,6 +636,49 @@ fi
         );
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn verify_script_does_not_treat_host_executables_as_rootfs_executables() {
+        use std::os::unix::fs::symlink;
+        use std::process::Command;
+
+        let functions_start = VERIFY_SCRIPT
+            .find("resolve_rootfs_path() {")
+            .expect("verify-rootfs.sh should define resolve_rootfs_path");
+        let functions_end = VERIFY_SCRIPT
+            .find("\ncheck_bin() {")
+            .expect("verify-rootfs.sh should define check_bin after executable checks");
+        let verifier_functions = &VERIFY_SCRIPT[functions_start..functions_end];
+
+        let rootfs = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(rootfs.path().join("bin")).unwrap();
+        symlink("/bin/bash", rootfs.path().join("bin/awk")).unwrap();
+
+        let script = format!(
+            r#"
+set -euo pipefail
+{verifier_functions}
+errors=()
+check_required_executable /bin/awk awk
+test "${{#errors[@]}}" -eq 1
+test "${{errors[0]}}" = "awk not found or not executable at /bin/awk"
+"#
+        );
+        let output = Command::new("bash")
+            .arg("-c")
+            .arg(script)
+            .env("MOUNT_DIR", rootfs.path())
+            .output()
+            .unwrap();
+
+        assert!(
+            output.status.success(),
+            "rootfs executable check script failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
     #[test]
     fn verify_script_documents_optional_diagnostic_commands() {
         assert!(

--- a/crates/runner/src/cmd/build/scripts.rs
+++ b/crates/runner/src/cmd/build/scripts.rs
@@ -492,6 +492,17 @@ exit 1
 
     #[test]
     fn verify_script_checks_sandbox_helper_runtime_commands() {
+        assert!(
+            VERIFY_SCRIPT.contains(r#"sudo chroot "$MOUNT_DIR" /bin/sh -c 'test -x "$1"'"#),
+            "verify-rootfs.sh should resolve required executable symlinks inside the guest rootfs"
+        );
+        assert!(
+            VERIFY_SCRIPT.contains(
+                "for cmd in sudo unshare mount umount mountpoint stat mktemp sed grep chroot; do"
+            ),
+            "verify-rootfs.sh should declare chroot as a host dependency"
+        );
+
         for (group, command_paths) in [
             (
                 "shell wrapper runtime",

--- a/crates/runner/src/cmd/build/scripts.rs
+++ b/crates/runner/src/cmd/build/scripts.rs
@@ -492,18 +492,85 @@ exit 1
 
     #[test]
     fn verify_script_checks_sandbox_helper_runtime_commands() {
-        for command_path in [
-            "/bin/sh",
-            "/usr/bin/find",
-            "/usr/bin/awk",
-            "/usr/bin/xargs",
-            "/usr/bin/mktemp",
-            "/usr/bin/tr",
-            "/usr/bin/rm",
+        for (group, command_paths) in [
+            (
+                "shell wrapper runtime",
+                &["/bin/sh", "/bin/bash", "/usr/bin/su"][..],
+            ),
+            (
+                "guest state runtime",
+                &["/usr/bin/date", "/usr/bin/ln", "/usr/bin/sed"][..],
+            ),
+            (
+                "storage and Codex cleanup runtime",
+                &[
+                    "/usr/bin/rm",
+                    "/usr/bin/find",
+                    "/usr/bin/awk",
+                    "/usr/bin/xargs",
+                    "/usr/bin/mktemp",
+                    "/usr/bin/tr",
+                ][..],
+            ),
+            (
+                "workspace mount runtime",
+                &[
+                    "/usr/bin/mountpoint",
+                    "/usr/bin/mount",
+                    "/usr/bin/umount",
+                    "/usr/bin/sync",
+                    "/usr/bin/chown",
+                    "/usr/bin/mkdir",
+                    "/usr/bin/stat",
+                    "/usr/bin/cat",
+                    "/usr/bin/readlink",
+                    "/usr/bin/cut",
+                    "/usr/bin/sort",
+                    "/usr/bin/wc",
+                    "/usr/bin/kill",
+                    "/usr/bin/sleep",
+                ][..],
+            ),
+        ] {
+            for command_path in command_paths {
+                let verifier_check = format!(r#"check_required_executable "{command_path}""#);
+                assert!(
+                    VERIFY_SCRIPT.contains(&verifier_check),
+                    "verify-rootfs.sh should verify {command_path} is present for {group}"
+                );
+            }
+        }
+
+        assert!(
+            VERIFY_SCRIPT.contains(r#"check_required_executable "$dest" "$dest""#),
+            "verify-rootfs.sh should verify rootfs-only guest binaries are executable"
+        );
+        for guest_binary_path in [
+            "/usr/local/bin/guest-agent",
+            "/usr/local/bin/guest-download",
+            "/sbin/guest-init",
+            "/usr/local/bin/guest-mock-claude",
+            "/usr/local/bin/guest-mock-codex",
+            "/sbin/guest-reseed",
+            "/sbin/guest-write-file",
         ] {
             assert!(
-                VERIFY_SCRIPT.contains(command_path),
-                "verify-rootfs.sh should verify {command_path} is present for sandbox helper exec scripts"
+                VERIFY_SCRIPT.contains(guest_binary_path),
+                "verify-rootfs.sh should verify {guest_binary_path} in rootfs mode"
+            );
+        }
+    }
+
+    #[test]
+    fn verify_script_documents_optional_diagnostic_commands() {
+        assert!(
+            VERIFY_SCRIPT.contains("Intentionally unchecked: best-effort diagnostics"),
+            "verify-rootfs.sh should document intentionally unchecked diagnostic commands"
+        );
+        for optional_command in ["file", "sha256sum", "free", "timeout", "ps"] {
+            assert!(
+                VERIFY_SCRIPT.contains(optional_command),
+                "verify-rootfs.sh should document {optional_command} as optional diagnostics"
             );
         }
     }

--- a/crates/runner/src/cmd/build/scripts.rs
+++ b/crates/runner/src/cmd/build/scripts.rs
@@ -503,7 +503,10 @@ exit 1
             "verify-rootfs.sh should declare readlink as a host dependency for safe symlink resolution"
         );
         assert!(
-            !VERIFY_SCRIPT.contains(r#"chroot "$MOUNT_DIR""#),
+            VERIFY_SCRIPT
+                .lines()
+                .filter(|line| !line.trim_start().starts_with('#'))
+                .all(|line| !line.contains("chroot")),
             "verify-rootfs.sh must not chroot into the image it is verifying"
         );
 
@@ -655,6 +658,7 @@ fi
         std::fs::create_dir_all(rootfs.path().join("bin")).unwrap();
         std::fs::create_dir_all(rootfs.path().join("usr/bin")).unwrap();
         symlink("/bin/bash", rootfs.path().join("bin/awk")).unwrap();
+        symlink("../../../../bin/bash", rootfs.path().join("bin/sh")).unwrap();
         let non_executable = rootfs.path().join("usr/bin/not-executable");
         std::fs::write(&non_executable, b"#!/bin/sh\n").unwrap();
         let mut perms = std::fs::metadata(&non_executable).unwrap().permissions();
@@ -674,6 +678,7 @@ assert_check_error() {{
   test "${{errors[0]}}" = "$expected"
 }}
 assert_check_error /bin/awk awk "awk not found or not executable at /bin/awk"
+assert_check_error /bin/sh sh "sh not found or not executable at /bin/sh"
 assert_check_error \
   /usr/bin/not-executable \
   not-executable \

--- a/crates/runner/src/cmd/build/scripts.rs
+++ b/crates/runner/src/cmd/build/scripts.rs
@@ -503,8 +503,8 @@ exit 1
             "verify-rootfs.sh should declare readlink as a host dependency for safe symlink resolution"
         );
         assert!(
-            !VERIFY_SCRIPT.contains(r#"sudo chroot "$MOUNT_DIR" /bin/sh"#),
-            "verify-rootfs.sh must not execute binaries from the image it is verifying"
+            !VERIFY_SCRIPT.contains(r#"chroot "$MOUNT_DIR""#),
+            "verify-rootfs.sh must not chroot into the image it is verifying"
         );
 
         for (group, command_paths) in [

--- a/crates/runner/src/cmd/build/scripts.rs
+++ b/crates/runner/src/cmd/build/scripts.rs
@@ -510,7 +510,7 @@ exit 1
         for (group, command_paths) in [
             (
                 "shell wrapper runtime",
-                &["/bin/sh", "/bin/bash", "/usr/bin/su"][..],
+                &["/bin/sh", "/bin/bash", "/usr/bin/su", "/usr/bin/rmdir"][..],
             ),
             (
                 "guest state runtime",

--- a/crates/runner/src/cmd/build/scripts.rs
+++ b/crates/runner/src/cmd/build/scripts.rs
@@ -639,6 +639,7 @@ fi
     #[cfg(unix)]
     #[test]
     fn verify_script_does_not_treat_host_executables_as_rootfs_executables() {
+        use std::os::unix::fs::PermissionsExt;
         use std::os::unix::fs::symlink;
         use std::process::Command;
 
@@ -652,16 +653,35 @@ fi
 
         let rootfs = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(rootfs.path().join("bin")).unwrap();
+        std::fs::create_dir_all(rootfs.path().join("usr/bin")).unwrap();
         symlink("/bin/bash", rootfs.path().join("bin/awk")).unwrap();
+        let non_executable = rootfs.path().join("usr/bin/not-executable");
+        std::fs::write(&non_executable, b"#!/bin/sh\n").unwrap();
+        let mut perms = std::fs::metadata(&non_executable).unwrap().permissions();
+        perms.set_mode(0o644);
+        std::fs::set_permissions(&non_executable, perms).unwrap();
+        std::fs::create_dir(rootfs.path().join("usr/bin/dir-command")).unwrap();
 
         let script = format!(
             r#"
 set -euo pipefail
 {verifier_functions}
-errors=()
-check_required_executable /bin/awk awk
-test "${{#errors[@]}}" -eq 1
-test "${{errors[0]}}" = "awk not found or not executable at /bin/awk"
+assert_check_error() {{
+  local path="$1" name="$2" expected="$3"
+  errors=()
+  check_required_executable "$path" "$name"
+  test "${{#errors[@]}}" -eq 1
+  test "${{errors[0]}}" = "$expected"
+}}
+assert_check_error /bin/awk awk "awk not found or not executable at /bin/awk"
+assert_check_error \
+  /usr/bin/not-executable \
+  not-executable \
+  "not-executable not found or not executable at /usr/bin/not-executable"
+assert_check_error \
+  /usr/bin/dir-command \
+  dir-command \
+  "dir-command not found or not executable at /usr/bin/dir-command"
 "#
         );
         let output = Command::new("bash")

--- a/crates/runner/src/cmd/build/scripts.rs
+++ b/crates/runner/src/cmd/build/scripts.rs
@@ -564,15 +564,11 @@ exit 1
     #[test]
     fn verify_script_documents_optional_diagnostic_commands() {
         assert!(
-            VERIFY_SCRIPT.contains("Intentionally unchecked: best-effort diagnostics"),
-            "verify-rootfs.sh should document intentionally unchecked diagnostic commands"
+            VERIFY_SCRIPT.contains(
+                "Intentionally unchecked optional diagnostic commands: file sha256sum free timeout ps"
+            ),
+            "verify-rootfs.sh should document intentionally unchecked optional diagnostics"
         );
-        for optional_command in ["file", "sha256sum", "free", "timeout", "ps"] {
-            assert!(
-                VERIFY_SCRIPT.contains(optional_command),
-                "verify-rootfs.sh should document {optional_command} as optional diagnostics"
-            );
-        }
     }
 
     #[test]

--- a/crates/runner/src/cmd/build/scripts.rs
+++ b/crates/runner/src/cmd/build/scripts.rs
@@ -659,6 +659,12 @@ fi
         std::fs::create_dir_all(rootfs.path().join("usr/bin")).unwrap();
         symlink("/bin/bash", rootfs.path().join("bin/awk")).unwrap();
         symlink("../../../../bin/bash", rootfs.path().join("bin/sh")).unwrap();
+        symlink("/usr/bin/missing-target", rootfs.path().join("bin/broken")).unwrap();
+        std::fs::write(
+            rootfs.path().join("usr/bin/file-parent"),
+            b"not a directory",
+        )
+        .unwrap();
         let non_executable = rootfs.path().join("usr/bin/not-executable");
         std::fs::write(&non_executable, b"#!/bin/sh\n").unwrap();
         let mut perms = std::fs::metadata(&non_executable).unwrap().permissions();
@@ -679,6 +685,11 @@ assert_check_error() {{
 }}
 assert_check_error /bin/awk awk "awk not found or not executable at /bin/awk"
 assert_check_error /bin/sh sh "sh not found or not executable at /bin/sh"
+assert_check_error /bin/broken broken "broken not found or not executable at /bin/broken"
+assert_check_error \
+  /usr/bin/file-parent/tool \
+  file-parent-tool \
+  "file-parent-tool not found or not executable at /usr/bin/file-parent/tool"
 assert_check_error \
   /usr/bin/not-executable \
   not-executable \


### PR DESCRIPTION
## Summary

- expand rootfs verification for runner-owned sandbox runtime commands
- require rootfs-only guest binaries to be executable
- document optional best-effort diagnostic commands as non-blocking
- strengthen runner script contract tests for the expanded verifier coverage

Closes #19272

## Tests

- bash -n crates/runner/scripts/verify-rootfs.sh
- cargo fmt --manifest-path crates/Cargo.toml -p runner --check
- cargo test --manifest-path crates/Cargo.toml -p runner verify_script_checks_sandbox_helper_runtime_commands
- cargo test --manifest-path crates/Cargo.toml -p runner cmd::build::scripts
- git diff --check

Pre-commit also ran cargo-fmt, cargo-clippy, and cargo-doc successfully.