### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -112,7 +112,7 @@ CACHE_TMP_TAR=""
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.4"
 CLAUDE_CODE_VERSION="2.1.195"
-CODEX_CLI_VERSION="0.142.3"
+CODEX_CLI_VERSION="0.142.4"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"
 AGENT_BROWSER_VERSION="0.31.1"


### PR DESCRIPTION
## Summary

- Updated `@openai/codex` in `crates/runner/scripts/build-template.sh`.

## Version updates

- `@openai/codex`: `0.142.3` -> `0.142.4`

## Checked and unchanged

- Go: `1.26.4` is current.
- Claude Code: `2.1.195` is current.
- `@googleworkspace/cli`: `0.22.5` is current.
- `@xdevplatform/xurl`: `1.0.3` is current.
- `agent-browser`: `0.31.1` is current.
- `pnpm`: `11.9.0` is current.
- Node.js remains on the latest LTS major channel, `24.x`.
- PostgreSQL remains on the current PGDG major, `18`.

Ubuntu/noble was intentionally not changed.