### PR TITLE
fix: improve workflow copy action states

### DIFF
--- a/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
+++ b/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
@@ -29,6 +29,20 @@ import { ensureDraft$ } from "../chat-page/create-chat-thread.ts";
 
 type WorkflowDetailActionDialog = "copy" | "delete" | null;
 export type WorkflowDetailTab = "triggers" | "instructions" | "info";
+export type WorkflowCopyDialogAgent = {
+  readonly id: string;
+  readonly displayName: string | null;
+  readonly visibility?: string | null;
+};
+export type WorkflowCopyDialogState =
+  | { readonly kind: "select" }
+  | { readonly kind: "copying"; readonly agent: WorkflowCopyDialogAgent }
+  | {
+      readonly kind: "copied";
+      readonly agent: WorkflowCopyDialogAgent;
+      readonly workflow: ZeroWorkflowSummary;
+      readonly sourceTriggersPaused: boolean;
+    };
 type WorkflowTriggerCreateDialog =
   | "interval"
   | "scheduled"
@@ -117,6 +131,9 @@ const internalWorkflowDetailActiveTab$ = state<WorkflowDetailTab>("triggers");
 
 const internalSelectedFilePath$ = state<string | null>(null);
 const internalWorkflowActionDialog$ = state<WorkflowDetailActionDialog>(null);
+const internalWorkflowCopyDialogState$ = state<WorkflowCopyDialogState>({
+  kind: "select",
+});
 const internalWorkflowFileDraft$ = state<WorkflowDetailFileDraft | null>(null);
 const internalEditingWorkflowTriggerId$ = state<string | null>(null);
 const internalWorkflowMetadataPatch$ = state<WorkflowMetadataPatch | null>(
@@ -137,9 +154,22 @@ export const workflowActionDialog$ = computed((get) => {
   return get(internalWorkflowActionDialog$);
 });
 
+export const workflowCopyDialogState$ = computed((get) => {
+  return get(internalWorkflowCopyDialogState$);
+});
+
 export const setWorkflowActionDialog$ = command(
   ({ set }, dialog: WorkflowDetailActionDialog) => {
     set(internalWorkflowActionDialog$, dialog);
+    if (dialog === "copy") {
+      set(internalWorkflowCopyDialogState$, { kind: "select" });
+    }
+  },
+);
+
+export const setWorkflowCopyDialogState$ = command(
+  ({ set }, copyState: WorkflowCopyDialogState) => {
+    set(internalWorkflowCopyDialogState$, copyState);
   },
 );
 
@@ -182,6 +212,7 @@ export const resetWorkflowDetailUiState$ = command(({ set }) => {
   set(internalWorkflowDetailActiveTab$, "triggers");
   set(internalSelectedFilePath$, null);
   set(internalWorkflowActionDialog$, null);
+  set(internalWorkflowCopyDialogState$, { kind: "select" });
   set(internalWorkflowFileDraft$, null);
   set(internalEditingWorkflowTriggerId$, null);
   set(internalWorkflowMetadataPatch$, null);
@@ -717,6 +748,34 @@ export const setWorkflowTriggerEnabled$ = command(
     await accept(request, [200]);
     signal.throwIfAborted();
     set(reloadWorkflows$);
+  },
+);
+
+export const pauseWorkflowTriggers$ = command(
+  async (
+    { get, set },
+    triggerIds: readonly string[],
+    signal: AbortSignal,
+  ): Promise<{ readonly pausedCount: number }> => {
+    if (triggerIds.length === 0) {
+      return { pausedCount: 0 };
+    }
+
+    const client = get(zeroClient$)(zeroWorkflowTriggersContract);
+    await Promise.all(
+      triggerIds.map((triggerId) => {
+        return accept(
+          client.disable({
+            params: { id: triggerId },
+            fetchOptions: { signal },
+          }),
+          [200],
+        );
+      }),
+    );
+    signal.throwIfAborted();
+    set(reloadWorkflows$);
+    return { pausedCount: triggerIds.length };
   },
 );
 

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -927,6 +927,48 @@ describe("workflow detail page", () => {
     });
   });
 
+  it("shows copy failure in the source and target progress state", async () => {
+    mockAgentPageApis();
+    mockWorkflowApis([salesResearch()]);
+    context.mocks.api(zeroWorkflowsDetailContract.copy, ({ respond }) => {
+      return respond(400, {
+        error: {
+          code: "BAD_REQUEST",
+          message: "Failed to copy workflow",
+        },
+      });
+    });
+
+    detachedSetupPage({
+      context,
+      path: workflowDetailPath("info"),
+    });
+
+    await waitFor(() => {
+      expect(buttonByText(/^Copy workflow$/)).toBeInTheDocument();
+    });
+    click(buttonByText(/^Copy workflow$/));
+    await waitFor(() => {
+      expect(buttonByText(/Support Bot/)).toBeInTheDocument();
+    });
+    click(buttonByText(/Support Bot/));
+
+    expect(
+      screen.getByText(
+        "Copying Sales Research from Research Bot to Support Bot.",
+      ),
+    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("Copy failed")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText("Close this dialog and try again."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Source")).toBeInTheDocument();
+    expect(screen.getByText("Target")).toBeInTheDocument();
+    expect(screen.queryByText(/Workflow copied to/)).not.toBeInTheDocument();
+  });
+
   it("deletes the source workflow from copied workflow actions", async () => {
     const workflows = [salesResearch()];
     const copiedWorkflow: ZeroWorkflowDetailResponse = {

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -37,6 +37,7 @@ const SALES_WORKFLOW_ID = "d0000000-0000-4000-a000-000000000201";
 const OPS_WORKFLOW_ID = "d0000000-0000-4000-a000-000000000202";
 const OTHER_WORKFLOW_ID = "d0000000-0000-4000-a000-000000000203";
 const PENDING_WORKFLOW_ID = "d0000000-0000-4000-a000-000000000204";
+const COPIED_WORKFLOW_ID = "d0000000-0000-4000-a000-000000000205";
 const GMAIL_TRIGGER_ID = "workflow-trigger-gmail-new-message";
 const GMAIL_LABEL_TRIGGER_ID = "workflow-trigger-gmail-label-applied";
 const WORKFLOW_CHAT_THREAD_ID = "00000000-0000-4000-a000-000000000300";
@@ -416,6 +417,25 @@ function mockWorkflowApis(
   );
 }
 
+function mockDeleteWorkflow(
+  workflows: ZeroWorkflowDetailResponse[],
+  onDelete: (workflowId: string) => void | Promise<void>,
+): void {
+  context.mocks.api(
+    zeroWorkflowsDetailContract.delete,
+    async ({ params, respond }) => {
+      await onDelete(params.workflowId);
+      const index = workflows.findIndex((workflow) => {
+        return workflow.id === params.workflowId;
+      });
+      if (index !== -1) {
+        workflows.splice(index, 1);
+      }
+      return respond(204);
+    },
+  );
+}
+
 function mockConnectedTriggerConnectors(): void {
   context.mocks.data.connectors([
     {
@@ -518,6 +538,22 @@ function mockRunWorkflowTrigger(onRun: (triggerId: string) => void): void {
       chatThreadId: TRIGGER_RUN_THREAD_ID,
     });
   });
+}
+
+function mockDisableWorkflowTrigger(
+  onDisable: (triggerId: string) => void,
+): void {
+  context.mocks.api(
+    zeroWorkflowTriggersContract.disable,
+    ({ params, respond }) => {
+      onDisable(params.id);
+      return respond(200, {
+        ...weekdayWorkflowTrigger(),
+        id: params.id,
+        enabled: false,
+      });
+    },
+  );
 }
 
 function mockOpenWorkflowChat(onOpen: (workflowId: string) => void): void {
@@ -790,6 +826,175 @@ describe("workflow detail page", () => {
     expect(pageText.indexOf("Delete workflow")).toBeLessThan(
       pageText.indexOf("Created by"),
     );
+  });
+
+  it("shows source and target actions after copying a workflow", async () => {
+    const workflows = [salesResearch()];
+    const copiedWorkflow: ZeroWorkflowDetailResponse = {
+      ...salesResearch(),
+      id: COPIED_WORKFLOW_ID,
+      agentId: OTHER_AGENT_ID,
+      agentName: "support-bot",
+      agentDisplayName: "Support Bot",
+      visibility: "private",
+      triggers: [],
+    };
+    const copyGate = context.mocks.deferred<void>();
+    const copyRequests: {
+      readonly workflowId: string;
+      readonly toAgentId: string;
+    }[] = [];
+    const disabledTriggerIds: string[] = [];
+    mockAgentPageApis();
+    mockWorkflowApis(workflows);
+    mockDisableWorkflowTrigger((triggerId) => {
+      disabledTriggerIds.push(triggerId);
+    });
+    context.mocks.api(
+      zeroWorkflowsDetailContract.copy,
+      async ({ params, body, respond }) => {
+        copyRequests.push({
+          workflowId: params.workflowId,
+          toAgentId: body.toAgentId,
+        });
+        await copyGate.promise;
+        workflows.push(copiedWorkflow);
+        return respond(201, summary(copiedWorkflow));
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: workflowDetailPath("info"),
+    });
+
+    await waitFor(() => {
+      expect(buttonByText(/^Copy workflow$/)).toBeInTheDocument();
+    });
+    click(buttonByText(/^Copy workflow$/));
+    await waitFor(() => {
+      expect(buttonByText(/Support Bot/)).toBeInTheDocument();
+    });
+    click(buttonByText(/Support Bot/));
+
+    await waitFor(() => {
+      expect(copyRequests).toStrictEqual([
+        { workflowId: SALES_WORKFLOW_ID, toAgentId: OTHER_AGENT_ID },
+      ]);
+    });
+    expect(
+      screen.getByText(
+        "Copying Sales Research from Research Bot to Support Bot.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Copy to another agent as a new private workflow."),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Public target agent")).toBeInTheDocument();
+
+    copyGate.resolve();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Workflow copied to Support Bot"),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByText("Source")).toBeInTheDocument();
+    expect(screen.getByText("Target")).toBeInTheDocument();
+    expect(buttonByText(/Pause source triggers/)).toBeInTheDocument();
+    expect(buttonByText(/Delete source workflow/)).toBeInTheDocument();
+    expect(buttonByText(/View target workflow/)).toBeInTheDocument();
+
+    click(buttonByText(/Pause source triggers/));
+    expect(buttonByText(/Pause source triggers/)).toBeDisabled();
+    expect(
+      buttonByText(/Pause source triggers/).querySelector(".animate-spin"),
+    ).not.toBeNull();
+    await waitFor(() => {
+      expect(disabledTriggerIds).toStrictEqual([
+        "workflow-trigger-weekday-brief",
+      ]);
+    });
+    expect(
+      screen.getByText("Source triggers are paused on Research Bot"),
+    ).toBeInTheDocument();
+
+    click(buttonByText(/View target workflow/));
+    await waitFor(() => {
+      expect(pathname()).toBe(
+        `/agents/${OTHER_AGENT_ID}/workflows/${COPIED_WORKFLOW_ID}`,
+      );
+    });
+  });
+
+  it("deletes the source workflow from copied workflow actions", async () => {
+    const workflows = [salesResearch()];
+    const copiedWorkflow: ZeroWorkflowDetailResponse = {
+      ...salesResearch(),
+      id: COPIED_WORKFLOW_ID,
+      agentId: OTHER_AGENT_ID,
+      agentName: "support-bot",
+      agentDisplayName: "Support Bot",
+      visibility: "private",
+      triggers: [],
+    };
+    const deleteGate = context.mocks.deferred<void>();
+    const deletedWorkflowIds: string[] = [];
+    mockAgentPageApis();
+    mockWorkflowApis(workflows);
+    mockDeleteWorkflow(workflows, async (workflowId) => {
+      deletedWorkflowIds.push(workflowId);
+      await deleteGate.promise;
+    });
+    context.mocks.api(zeroWorkflowsDetailContract.copy, ({ respond }) => {
+      workflows.push(copiedWorkflow);
+      return respond(201, summary(copiedWorkflow));
+    });
+
+    detachedSetupPage({
+      context,
+      path: workflowDetailPath("info"),
+    });
+
+    await waitFor(() => {
+      expect(buttonByText(/^Copy workflow$/)).toBeInTheDocument();
+    });
+    click(buttonByText(/^Copy workflow$/));
+    await waitFor(() => {
+      expect(buttonByText(/Support Bot/)).toBeInTheDocument();
+    });
+    click(buttonByText(/Support Bot/));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Workflow copied to Support Bot"),
+      ).toBeInTheDocument();
+    });
+    expect(buttonByText(/Pause source triggers/)).not.toBeDisabled();
+    click(buttonByText(/Delete source workflow/));
+
+    await waitFor(() => {
+      expect(deletedWorkflowIds).toStrictEqual([SALES_WORKFLOW_ID]);
+    });
+    expect(buttonByText(/Pause source triggers/)).toBeDisabled();
+    expect(buttonByText(/Delete source workflow/)).toBeDisabled();
+    expect(
+      buttonByText(/Delete source workflow/).querySelector(".animate-spin"),
+    ).not.toBeNull();
+    expect(
+      screen.queryByRole("heading", { name: "Delete workflow" }),
+    ).not.toBeInTheDocument();
+
+    deleteGate.resolve();
+
+    await waitFor(() => {
+      expect(pathname()).toBe(`/agents/${AGENT_ID}/workflows`);
+    });
+    expect(
+      workflows.some((workflow) => {
+        return workflow.id === SALES_WORKFLOW_ID;
+      }),
+    ).toBeFalsy();
   });
 
   it("prefills and updates workflow metadata from the info tab", async () => {

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -17,6 +17,7 @@ import type {
 } from "@vm0/api-contracts/contracts/zero-workflows";
 import {
   IconAlertTriangle,
+  IconArrowRight,
   IconChevronDown,
   IconClock,
   IconCopy,
@@ -78,6 +79,7 @@ import {
   editingWorkflowTriggerId$,
   patchWorkflowMetadataForm$,
   openWorkflowChat$,
+  pauseWorkflowTriggers$,
   reloadWorkflows$,
   resetWorkflowMetadataForm$,
   runWorkflowTriggerNow$,
@@ -90,6 +92,7 @@ import {
   setWorkflowActionDialog$,
   setWorkflowDetailActiveTab$,
   setWorkflowFileDraft$,
+  setWorkflowCopyDialogState$,
   setWorkflowTriggerCreateDialog$,
   setWorkflowTriggerEnabled$,
   updateWorkflowGmailNewMessageTrigger$,
@@ -97,10 +100,13 @@ import {
   updateWorkflowScheduleTrigger$,
   updateWorkflow$,
   workflowActionDialog$,
+  workflowCopyDialogState$,
   workflowDetailActiveTab$,
   workflowTriggerCreateDialog$,
   workflowFileDraft$,
   workflowDetail,
+  type WorkflowCopyDialogAgent,
+  type WorkflowCopyDialogState,
   type WorkflowCronFields,
   type WorkflowCronFrequency,
   type WorkflowDetailTab,
@@ -259,9 +265,13 @@ function WorkflowDetailContent({
 }: {
   readonly workflowId: string;
 }) {
-  const detailLoadable = useLoadable(workflowDetail(workflowId));
+  const detail$ = workflowDetail(workflowId);
+  const detailLoadable = useLoadable(detail$);
+  const lastResolvedDetail = useLastResolved(detail$);
   const detail =
-    detailLoadable.state === "hasData" ? detailLoadable.data : null;
+    detailLoadable.state === "hasData"
+      ? detailLoadable.data
+      : (lastResolvedDetail ?? null);
   const activeTab = useGet(workflowDetailActiveTab$);
   const setActiveTab = useSet(setWorkflowDetailActiveTab$);
 
@@ -998,6 +1008,7 @@ function WorkflowCopyDialog({
   readonly open: boolean;
   readonly onOpenChange: (open: boolean) => void;
 }) {
+  const copyState = useGet(workflowCopyDialogState$);
   const agentsLoadable = useLoadable(agents$);
   const agents =
     agentsLoadable.state === "hasData"
@@ -1005,73 +1016,430 @@ function WorkflowCopyDialog({
           return agent.id !== detail.agentId;
         })
       : [];
-  const pageSignal = useGet(pageSignal$);
-  const [copyLoadable, copyWorkflow] = useLoadableSet(copyWorkflow$);
-  const copying = copyLoadable.state === "loading";
+  const sourceAgentName = agentLabel(detail);
+  const sourceWorkflowName = workflowTitle(detail);
+  const enabledSourceTriggerIds = detail.triggers
+    .filter((trigger) => {
+      return trigger.enabled;
+    })
+    .map((trigger) => {
+      return trigger.id;
+    });
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
+      <DialogContent className="sm:max-w-[560px]">
         <DialogHeader>
-          <DialogTitle>Copy workflow</DialogTitle>
+          <DialogTitle>{workflowCopyDialogTitle(copyState)}</DialogTitle>
           <DialogDescription>
-            Copy to another agent as a new private workflow.
+            {workflowCopyDialogDescription({
+              copyState,
+              sourceAgentName,
+              sourceWorkflowName,
+            })}
           </DialogDescription>
         </DialogHeader>
-        {agents.length > 0 ? (
-          <div className="max-h-[360px] overflow-auto rounded-md border border-border/60">
-            {agents.map((agent) => {
-              return (
-                <button
-                  key={agent.id}
-                  type="button"
-                  disabled={copying}
-                  className="flex w-full items-center justify-between gap-3 border-b border-border/60 px-3 py-2 text-left last:border-b-0 transition-colors hover:bg-muted disabled:opacity-60"
-                  onClick={() => {
-                    detach(
-                      (async () => {
-                        await copyWorkflow(
-                          {
-                            workflowId: detail.id,
-                            toAgentId: agent.id,
-                          },
-                          pageSignal,
-                        );
-                        onOpenChange(false);
-                      })(),
-                      Reason.DomCallback,
-                    );
-                  }}
-                >
-                  <span className="min-w-0">
-                    <span className="block truncate text-sm font-medium text-foreground">
-                      {agent.displayName ?? agent.id}
-                    </span>
-                    <span className="block text-xs text-muted-foreground">
-                      {agent.visibility === "private"
-                        ? "Private agent"
-                        : "Public agent"}
-                    </span>
-                  </span>
-                  {copying ? (
-                    <IconLoader2
-                      size={14}
-                      className="shrink-0 animate-spin text-muted-foreground"
-                    />
-                  ) : null}
-                </button>
-              );
-            })}
-          </div>
-        ) : agentsLoadable.state === "hasData" ? (
-          <p className="text-sm text-muted-foreground">
-            No other agents are available.
-          </p>
+        {copyState.kind === "copying" ? (
+          <WorkflowCopyProgressState
+            copyState={copyState}
+            sourceAgentName={sourceAgentName}
+            sourceWorkflowName={sourceWorkflowName}
+          />
+        ) : copyState.kind === "copied" ? (
+          <WorkflowCopySuccessState
+            copyState={copyState}
+            enabledSourceTriggerIds={enabledSourceTriggerIds}
+            onOpenChange={onOpenChange}
+            sourceAgentId={detail.agentId}
+            sourceAgentName={sourceAgentName}
+            sourceWorkflowId={detail.id}
+            sourceWorkflowName={sourceWorkflowName}
+          />
         ) : (
-          <div className="h-24 rounded-md bg-muted/50" aria-hidden="true" />
+          <WorkflowCopySelectState
+            agents={agents}
+            agentsLoaded={agentsLoadable.state === "hasData"}
+            detail={detail}
+          />
         )}
       </DialogContent>
     </Dialog>
+  );
+}
+
+function WorkflowCopySelectState({
+  agents,
+  agentsLoaded,
+  detail,
+}: {
+  readonly agents: readonly WorkflowCopyDialogAgent[];
+  readonly agentsLoaded: boolean;
+  readonly detail: ZeroWorkflowDetailResponse;
+}) {
+  const pageSignal = useGet(pageSignal$);
+  const setCopyState = useSet(setWorkflowCopyDialogState$);
+  const [, copyWorkflow] = useLoadableSet(copyWorkflow$);
+
+  if (agents.length === 0) {
+    return agentsLoaded ? (
+      <p className="text-sm text-muted-foreground">
+        No other agents are available.
+      </p>
+    ) : (
+      <div className="h-24 rounded-md bg-muted/50" aria-hidden="true" />
+    );
+  }
+
+  return (
+    <div className="max-h-[360px] overflow-auto rounded-md border border-border/60">
+      {agents.map((agent) => {
+        return (
+          <button
+            key={agent.id}
+            type="button"
+            className="flex w-full items-center justify-between gap-3 border-b border-border/60 px-3 py-2 text-left last:border-b-0 transition-colors hover:bg-muted disabled:opacity-60"
+            onClick={() => {
+              setCopyState({ kind: "copying", agent });
+              detach(
+                (async () => {
+                  const copiedWorkflow = await copyWorkflow(
+                    {
+                      workflowId: detail.id,
+                      toAgentId: agent.id,
+                    },
+                    pageSignal,
+                  );
+                  setCopyState({
+                    kind: "copied",
+                    agent,
+                    workflow: copiedWorkflow,
+                    sourceTriggersPaused: false,
+                  });
+                })(),
+                Reason.DomCallback,
+              );
+            }}
+          >
+            <span className="min-w-0">
+              <span className="block truncate text-sm font-medium text-foreground">
+                {workflowCopyAgentName(agent)}
+              </span>
+              <span className="block text-xs text-muted-foreground">
+                {agent.visibility === "private"
+                  ? "Private agent"
+                  : "Public agent"}
+              </span>
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function WorkflowCopyProgressState({
+  copyState,
+  sourceAgentName,
+  sourceWorkflowName,
+}: {
+  readonly copyState: Extract<WorkflowCopyDialogState, { kind: "copying" }>;
+  readonly sourceAgentName: string;
+  readonly sourceWorkflowName: string;
+}) {
+  const [copyLoadable] = useLoadableSet(copyWorkflow$);
+  const copyFailed = copyLoadable.state === "hasError";
+
+  return (
+    <div className="space-y-3">
+      <WorkflowCopyAgentPanels
+        sourceAgentName={sourceAgentName}
+        sourceWorkflowName={sourceWorkflowName}
+        targetAgentName={workflowCopyAgentName(copyState.agent)}
+        targetWorkflowName={sourceWorkflowName}
+      />
+      <div className="rounded-lg border border-border/60 bg-gray-50 px-3 py-3">
+        <div className="flex items-start gap-3">
+          {copyFailed ? (
+            <IconAlertTriangle
+              size={16}
+              className="mt-0.5 shrink-0 text-destructive"
+              stroke={1.5}
+            />
+          ) : (
+            <IconLoader2
+              size={16}
+              className="mt-0.5 shrink-0 animate-spin text-muted-foreground"
+            />
+          )}
+          <div className="min-w-0">
+            <p className="text-sm font-medium text-foreground">
+              {copyFailed
+                ? "Copy failed"
+                : workflowCopyAgentName(copyState.agent)}
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {copyFailed
+                ? "Close this dialog and try again."
+                : `${copyState.agent.visibility === "private" ? "Private" : "Public"} target agent`}
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function WorkflowCopySuccessState({
+  copyState,
+  enabledSourceTriggerIds,
+  onOpenChange,
+  sourceAgentId,
+  sourceAgentName,
+  sourceWorkflowId,
+  sourceWorkflowName,
+}: {
+  readonly copyState: Extract<WorkflowCopyDialogState, { kind: "copied" }>;
+  readonly enabledSourceTriggerIds: readonly string[];
+  readonly onOpenChange: (open: boolean) => void;
+  readonly sourceAgentId: string;
+  readonly sourceAgentName: string;
+  readonly sourceWorkflowId: string;
+  readonly sourceWorkflowName: string;
+}) {
+  const pageSignal = useGet(pageSignal$);
+  const navigate = useSet(detachedNavigateTo$);
+  const setCopyState = useSet(setWorkflowCopyDialogState$);
+  const [pauseLoadable, pauseWorkflowTriggers] = useLoadableSet(
+    pauseWorkflowTriggers$,
+  );
+  const [deleteLoadable, deleteWorkflow] = useLoadableSet(deleteWorkflow$);
+  const pausingSourceTriggers = pauseLoadable.state === "loading";
+  const deletingSourceWorkflow = deleteLoadable.state === "loading";
+
+  return (
+    <>
+      <WorkflowCopyAgentPanels
+        sourceAgentName={sourceAgentName}
+        sourceWorkflowName={sourceWorkflowName}
+        targetAgentName={workflowCopyAgentName(copyState.agent)}
+        targetWorkflowName={workflowTitle(copyState.workflow)}
+      />
+      <div className="space-y-2">
+        <WorkflowCopyActionButton
+          icon={
+            pausingSourceTriggers ? (
+              <IconLoader2 size={15} className="animate-spin" />
+            ) : (
+              <IconPlayerPause size={15} stroke={1.5} />
+            )
+          }
+          title="Pause source triggers"
+          description={sourceTriggerActionDescription({
+            enabledCount: enabledSourceTriggerIds.length,
+            sourceAgentName,
+            paused: copyState.sourceTriggersPaused,
+          })}
+          disabled={
+            pausingSourceTriggers ||
+            deletingSourceWorkflow ||
+            copyState.sourceTriggersPaused ||
+            enabledSourceTriggerIds.length === 0
+          }
+          onClick={() => {
+            detach(
+              (async () => {
+                await pauseWorkflowTriggers(
+                  enabledSourceTriggerIds,
+                  pageSignal,
+                );
+                setCopyState({ ...copyState, sourceTriggersPaused: true });
+              })(),
+              Reason.DomCallback,
+            );
+          }}
+        />
+        <WorkflowCopyActionButton
+          icon={
+            deletingSourceWorkflow ? (
+              <IconLoader2 size={15} className="animate-spin" />
+            ) : (
+              <IconTrash size={15} stroke={1.5} />
+            )
+          }
+          title="Delete source workflow"
+          description={`Delete ${sourceWorkflowName} from ${sourceAgentName}`}
+          disabled={deletingSourceWorkflow}
+          destructive
+          onClick={() => {
+            detach(
+              (async () => {
+                await deleteWorkflow(sourceWorkflowId, pageSignal);
+                onOpenChange(false);
+                navigate(ROUTES.agentWorkflows, {
+                  pathParams: { agentId: sourceAgentId },
+                });
+              })(),
+              Reason.DomCallback,
+            );
+          }}
+        />
+        <WorkflowCopyActionButton
+          icon={<IconArrowRight size={15} stroke={1.5} />}
+          title="View target workflow"
+          description={`Open ${workflowTitle(copyState.workflow)} on ${workflowCopyAgentName(copyState.agent)}`}
+          onClick={() => {
+            onOpenChange(false);
+            navigate(ROUTES.agentWorkflowDetail, {
+              pathParams: {
+                agentId: copyState.workflow.agentId,
+                workflowId: copyState.workflow.id,
+              },
+            });
+          }}
+        />
+      </div>
+      <DialogFooter>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => {
+            onOpenChange(false);
+          }}
+        >
+          Close
+        </Button>
+      </DialogFooter>
+    </>
+  );
+}
+
+function workflowCopyDialogTitle(copyState: WorkflowCopyDialogState): string {
+  return copyState.kind === "copied"
+    ? `Workflow copied to ${workflowCopyAgentName(copyState.agent)}`
+    : "Copy workflow";
+}
+
+function workflowCopyDialogDescription({
+  copyState,
+  sourceAgentName,
+  sourceWorkflowName,
+}: {
+  readonly copyState: WorkflowCopyDialogState;
+  readonly sourceAgentName: string;
+  readonly sourceWorkflowName: string;
+}): string {
+  if (copyState.kind === "copying") {
+    return `Copying ${sourceWorkflowName} from ${sourceAgentName} to ${workflowCopyAgentName(copyState.agent)}.`;
+  }
+  if (copyState.kind === "copied") {
+    return "The new private workflow is ready on the target agent.";
+  }
+  return "Copy to another agent as a new private workflow.";
+}
+
+function workflowCopyAgentName(agent: WorkflowCopyDialogAgent): string {
+  return agent.displayName ?? agent.id;
+}
+
+function sourceTriggerActionDescription({
+  enabledCount,
+  sourceAgentName,
+  paused,
+}: {
+  readonly enabledCount: number;
+  readonly sourceAgentName: string;
+  readonly paused: boolean;
+}): string {
+  if (paused) {
+    return `Source triggers are paused on ${sourceAgentName}`;
+  }
+  if (enabledCount === 0) {
+    return `No enabled source triggers on ${sourceAgentName}`;
+  }
+  return `Pause ${enabledCount} enabled source ${
+    enabledCount === 1 ? "trigger" : "triggers"
+  } on ${sourceAgentName}`;
+}
+
+function WorkflowCopyAgentPanels({
+  sourceAgentName,
+  sourceWorkflowName,
+  targetAgentName,
+  targetWorkflowName,
+}: {
+  readonly sourceAgentName: string;
+  readonly sourceWorkflowName: string;
+  readonly targetAgentName: string;
+  readonly targetWorkflowName: string;
+}) {
+  return (
+    <div className="grid gap-2 sm:grid-cols-2">
+      <div className="rounded-lg border border-border/60 bg-gray-50 px-3 py-3">
+        <span className="text-xs text-muted-foreground">Source</span>
+        <span className="mt-1 block truncate text-sm font-semibold text-foreground">
+          {sourceAgentName}
+        </span>
+        <span className="mt-1 block truncate text-xs text-muted-foreground">
+          {sourceWorkflowName}
+        </span>
+      </div>
+      <div className="rounded-lg border border-border/60 bg-gray-50 px-3 py-3">
+        <span className="text-xs text-muted-foreground">Target</span>
+        <span className="mt-1 block truncate text-sm font-semibold text-foreground">
+          {targetAgentName}
+        </span>
+        <span className="mt-1 block truncate text-xs text-muted-foreground">
+          {targetWorkflowName}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function WorkflowCopyActionButton({
+  icon,
+  title,
+  description,
+  disabled,
+  destructive = false,
+  onClick,
+}: {
+  readonly icon: ReactNode;
+  readonly title: string;
+  readonly description: string;
+  readonly disabled?: boolean;
+  readonly destructive?: boolean;
+  readonly onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      className={cn(
+        "flex w-full items-center gap-3 rounded-lg border border-border/60 bg-background px-3 py-3 text-left transition-colors hover:bg-gray-50 disabled:pointer-events-none disabled:opacity-60",
+        destructive && "border-destructive/30 hover:bg-destructive/10",
+      )}
+      onClick={onClick}
+    >
+      <span
+        className={cn(
+          "flex size-8 shrink-0 items-center justify-center rounded-lg bg-gray-50 text-muted-foreground",
+          destructive
+            ? "bg-destructive/10 text-destructive"
+            : "text-primary bg-primary/10",
+        )}
+      >
+        {icon}
+      </span>
+      <span className="min-w-0">
+        <span className="block text-sm font-semibold text-foreground">
+          {title}
+        </span>
+        <span className="mt-1 block text-xs leading-5 text-muted-foreground">
+          {description}
+        </span>
+      </span>
+    </button>
   );
 }
 

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -1009,6 +1009,9 @@ function WorkflowCopyDialog({
   readonly onOpenChange: (open: boolean) => void;
 }) {
   const copyState = useGet(workflowCopyDialogState$);
+  const pageSignal = useGet(pageSignal$);
+  const setCopyState = useSet(setWorkflowCopyDialogState$);
+  const [copyLoadable, copyWorkflow] = useLoadableSet(copyWorkflow$);
   const agentsLoadable = useLoadable(agents$);
   const agents =
     agentsLoadable.state === "hasData"
@@ -1041,6 +1044,7 @@ function WorkflowCopyDialog({
         </DialogHeader>
         {copyState.kind === "copying" ? (
           <WorkflowCopyProgressState
+            copyFailed={copyLoadable.state === "hasError"}
             copyState={copyState}
             sourceAgentName={sourceAgentName}
             sourceWorkflowName={sourceWorkflowName}
@@ -1059,46 +1063,7 @@ function WorkflowCopyDialog({
           <WorkflowCopySelectState
             agents={agents}
             agentsLoaded={agentsLoadable.state === "hasData"}
-            detail={detail}
-          />
-        )}
-      </DialogContent>
-    </Dialog>
-  );
-}
-
-function WorkflowCopySelectState({
-  agents,
-  agentsLoaded,
-  detail,
-}: {
-  readonly agents: readonly WorkflowCopyDialogAgent[];
-  readonly agentsLoaded: boolean;
-  readonly detail: ZeroWorkflowDetailResponse;
-}) {
-  const pageSignal = useGet(pageSignal$);
-  const setCopyState = useSet(setWorkflowCopyDialogState$);
-  const [, copyWorkflow] = useLoadableSet(copyWorkflow$);
-
-  if (agents.length === 0) {
-    return agentsLoaded ? (
-      <p className="text-sm text-muted-foreground">
-        No other agents are available.
-      </p>
-    ) : (
-      <div className="h-24 rounded-md bg-muted/50" aria-hidden="true" />
-    );
-  }
-
-  return (
-    <div className="max-h-[360px] overflow-auto rounded-md border border-border/60">
-      {agents.map((agent) => {
-        return (
-          <button
-            key={agent.id}
-            type="button"
-            className="flex w-full items-center justify-between gap-3 border-b border-border/60 px-3 py-2 text-left last:border-b-0 transition-colors hover:bg-muted disabled:opacity-60"
-            onClick={() => {
+            onCopyToAgent={(agent) => {
               setCopyState({ kind: "copying", agent });
               detach(
                 (async () => {
@@ -1119,6 +1084,43 @@ function WorkflowCopySelectState({
                 Reason.DomCallback,
               );
             }}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function WorkflowCopySelectState({
+  agents,
+  agentsLoaded,
+  onCopyToAgent,
+}: {
+  readonly agents: readonly WorkflowCopyDialogAgent[];
+  readonly agentsLoaded: boolean;
+  readonly onCopyToAgent: (agent: WorkflowCopyDialogAgent) => void;
+}) {
+  if (agents.length === 0) {
+    return agentsLoaded ? (
+      <p className="text-sm text-muted-foreground">
+        No other agents are available.
+      </p>
+    ) : (
+      <div className="h-24 rounded-md bg-muted/50" aria-hidden="true" />
+    );
+  }
+
+  return (
+    <div className="max-h-[360px] overflow-auto rounded-md border border-border/60">
+      {agents.map((agent) => {
+        return (
+          <button
+            key={agent.id}
+            type="button"
+            className="flex w-full items-center justify-between gap-3 border-b border-border/60 px-3 py-2 text-left last:border-b-0 transition-colors hover:bg-muted disabled:opacity-60"
+            onClick={() => {
+              onCopyToAgent(agent);
+            }}
           >
             <span className="min-w-0">
               <span className="block truncate text-sm font-medium text-foreground">
@@ -1138,17 +1140,16 @@ function WorkflowCopySelectState({
 }
 
 function WorkflowCopyProgressState({
+  copyFailed,
   copyState,
   sourceAgentName,
   sourceWorkflowName,
 }: {
+  readonly copyFailed: boolean;
   readonly copyState: Extract<WorkflowCopyDialogState, { kind: "copying" }>;
   readonly sourceAgentName: string;
   readonly sourceWorkflowName: string;
 }) {
-  const [copyLoadable] = useLoadableSet(copyWorkflow$);
-  const copyFailed = copyLoadable.state === "hasError";
-
   return (
     <div className="space-y-3">
       <WorkflowCopyAgentPanels


### PR DESCRIPTION
## Summary
- Replace the workflow copy agent-list loading state with Source/Target progress and success states
- Add explicit success actions for pausing source triggers, deleting the source workflow, and viewing the target workflow
- Show spinner/disabled states for source trigger pause and source workflow delete actions

## Verification
- pnpm -C turbo test apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
- pnpm -C turbo -F @vm0/app lint
- pnpm -C turbo -F @vm0/app check-types