### PR TITLE
fix: shorten goal message label

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -3695,7 +3695,7 @@ describe("chat lifecycle", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Latest goal result")).toBeInTheDocument();
-      expect(screen.getByLabelText("Goal prompt")).toBeInTheDocument();
+      expect(screen.getByLabelText("Goal")).toBeInTheDocument();
       expect(screen.getByText(goalPrompt)).toBeInTheDocument();
       expect(buttonByLabel("Expand grouped run history")).toHaveTextContent(
         "3 mins for Keep the release moving",
@@ -3797,7 +3797,7 @@ describe("chat lifecycle", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Latest workflow result")).toBeInTheDocument();
-      expect(screen.queryByLabelText("Goal prompt")).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("Goal")).not.toBeInTheDocument();
       expect(buttonByLabel("Expand grouped run history")).toHaveTextContent(
         "1 run for Daily workflow summary",
       );

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -6885,11 +6885,11 @@ function GoalUserMessage({
         <div className="hidden @[900px]:block @[900px]:w-9 @[900px]:h-9 @[900px]:shrink-0" />
         <div className="flex w-full flex-col items-end">
           <div
-            aria-label="Goal prompt"
+            aria-label="Goal"
             className="mb-1.5 flex max-w-[85%] items-center gap-1.5 self-end text-xs font-medium text-muted-foreground"
           >
             <IconTarget size={15} stroke={1.8} className="shrink-0" />
-            <span>Goal prompt</span>
+            <span>Goal</span>
           </div>
           {bodyBlocks.length > 0 ? (
             <div className="zero-chat-bubble-user rounded-xl max-w-[85%] text-[0.9375rem] leading-[1.7] [overflow-wrap:anywhere] overflow-hidden ring-1 ring-emerald-900/10">


### PR DESCRIPTION
## Summary
- Rename the goal-run user message marker from "Goal prompt" to "Goal"
- Update the existing chat lifecycle assertions for the new accessible label

## Verification
- npx --yes prettier@3.8.1 --check apps/platform/src/views/zero-page/zero-chat-thread-page.tsx apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
- git diff --check

Note: local platform vitest was not run because this fresh checkout has no monorepo dependencies installed; CI will run the PR checks.