### PR TITLE
fix: hide workflow dirty state without edit permission

### DIFF
--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -24,6 +24,10 @@ import {
 import { pathname, search } from "../../../signals/location.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import {
+  patchWorkflowMetadataForm$,
+  setWorkflowFileDraft$,
+} from "../../../signals/workflows-page/workflows-signals.ts";
+import {
   mockChatLifecycle,
   PLACEHOLDER,
 } from "../../zero-page/__tests__/chat-test-helpers.ts";
@@ -725,6 +729,37 @@ describe("workflow detail page", () => {
     expect(search()).toBe("?tab=instructions&file=config%2Fsettings.json");
   });
 
+  it("ignores stale workflow instruction drafts without edit permission", async () => {
+    const workflow = {
+      ...salesResearch(),
+      canManage: false,
+    };
+    context.store.set(setWorkflowFileDraft$, {
+      workflowId: SALES_WORKFLOW_ID,
+      filePath: null,
+      sourceContent: "Gather CRM context before outreach.",
+      content: "Unsaved local workflow draft.",
+    });
+    mockWorkflowApis([workflow]);
+
+    detachedSetupPage({
+      context,
+      path: workflowDetailPath("instructions"),
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Gather CRM context before outreach."),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByText("Unsaved local workflow draft."),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("You have unsaved changes"),
+    ).not.toBeInTheDocument();
+  });
+
   it("opens the shared workflow chat thread with the workflow slash command", async () => {
     const openedWorkflowIds: string[] = [];
     mockChatLifecycle(context, { threadId: WORKFLOW_CHAT_THREAD_ID });
@@ -836,6 +871,31 @@ describe("workflow detail page", () => {
         description: "Use when an account needs a fresh research brief.",
       });
     });
+  });
+
+  it("ignores stale workflow metadata edits without edit permission", async () => {
+    const workflow = {
+      ...salesResearch(),
+      canManage: false,
+    };
+    context.store.set(patchWorkflowMetadataForm$, {
+      workflowId: SALES_WORKFLOW_ID,
+      patch: { displayName: "Unsaved Account Brief" },
+    });
+    mockWorkflowApis([workflow]);
+
+    detachedSetupPage({
+      context,
+      path: workflowDetailPath("info"),
+    });
+
+    const form = await screen.findByRole("form", {
+      name: "Workflow metadata",
+    });
+    expect(within(form).getByLabelText("Name")).toHaveValue("Sales Research");
+    expect(
+      screen.queryByText("You have unsaved changes"),
+    ).not.toBeInTheDocument();
   });
 
   it("derives the active tab from workflow detail search params", async () => {

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -728,12 +728,17 @@ function WorkflowMetadataForm({
   const disabled = !detail.canManage || saving;
   const defaults = workflowMetadataDefaults(detail);
   const values =
-    patch?.workflowId === detail.id ? { ...defaults, ...patch } : defaults;
+    detail.canManage && patch?.workflowId === detail.id
+      ? { ...defaults, ...patch }
+      : defaults;
   const dirty =
     values.displayName !== defaults.displayName ||
     values.name !== defaults.name ||
     values.description !== defaults.description;
   const patchValues = (patch: Partial<WorkflowMetadataValues>) => {
+    if (!detail.canManage || saving) {
+      return;
+    }
     patchForm({ workflowId: detail.id, patch });
   };
   const save = () => {
@@ -785,7 +790,7 @@ function WorkflowMetadataForm({
           values={values}
         />
       </form>
-      {dirty ? (
+      {detail.canManage && dirty ? (
         <ZeroUnsavedBar onDiscard={resetForm} onSave={save} saving={saving} />
       ) : null}
     </>
@@ -1429,12 +1434,15 @@ function WorkflowSelectedFileEditor({
     draftState?.workflowId === detail.id &&
     draftState.filePath === selectedFilePath &&
     draftState.sourceContent === sourceContent;
-  const draft = draftMatches ? draftState.content : null;
+  const draft = detail.canManage && draftMatches ? draftState.content : null;
   const content = draft ?? sourceContent;
   const dirty = draft !== null && draft !== sourceContent;
   const markdown =
     selectedFilePath === null || isMarkdownPath(selectedFilePath);
   const setDraft = (nextContent: string) => {
+    if (!detail.canManage || saving) {
+      return;
+    }
     setDraftState({
       workflowId: detail.id,
       filePath: selectedFilePath,
@@ -1494,7 +1502,7 @@ function WorkflowSelectedFileEditor({
           }}
         />
       )}
-      {dirty ? (
+      {detail.canManage && dirty ? (
         <ZeroUnsavedBar
           saving={saving}
           onDiscard={() => {


### PR DESCRIPTION
## Summary

- Ignore workflow instruction drafts and metadata patches when the current user cannot manage the workflow
- Hide the workflow unsaved-changes bar unless `detail.canManage` is true
- Add regression coverage for stale instruction and metadata dirty state in read-only workflow detail views

Fixes #19297

## Tests

- `pnpm -F @vm0/app exec vitest run src/views/workflows-page/__tests__/workflows-page.test.tsx`
- `pnpm -F @vm0/app check-types`
- `pnpm exec prettier --check apps/platform/src/views/workflows-page/workflow-detail-page.tsx apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx`