### PR TITLE
perf(mitm-addon): offload server_connect dns lookups

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -166,6 +166,7 @@ _STALE_TLS_ADMISSION_ERROR: Final = "stale_tls_admission"
 _UPSTREAM_DESTINATION_UNBOUND_ERROR: Final = "upstream_destination_unbound"
 _UPSTREAM_BINDING_DIAGNOSTICS = "_upstream_binding_diagnostics"
 _TRUSTED_HOST_ADDRESS_CACHE_TTL_SECONDS: Final = 60.0
+_TRUSTED_HOST_ADDRESS_NEGATIVE_CACHE_TTL_SECONDS: Final = 5.0
 _TRUSTED_HOST_ADDRESS_CACHE_MAX_ENTRIES: Final = 512
 
 _TlsAdmissionKind = Literal[
@@ -188,6 +189,7 @@ _RequestClassificationKind = Literal[
 ]
 _AuthBaseBodyCheckKind = Literal["ok", "too_large", "length_required"]
 _trusted_host_address_cache: dict[tuple[str, int], tuple[float, frozenset[str]]] = {}
+_trusted_host_address_lookup_tasks: dict[tuple[str, int], asyncio.Task[frozenset[str]]] = {}
 _REQUEST_HEADERS_TERMINATED = "_request_headers_terminated"
 _REQUEST_CLASSIFICATION = "_request_classification"
 _FIREWALL_AUTH_APPLIED_IN_REQUESTHEADERS = "_firewall_auth_applied_in_requestheaders"
@@ -1707,6 +1709,10 @@ def _ip_address_text(host: str) -> str | None:
     return str(address)
 
 
+def _trusted_host_address_cache_time() -> float:
+    return time.monotonic()
+
+
 def _is_authoritative_connected_endpoint(endpoint: tuple[str, int] | None) -> bool:
     if endpoint is None:
         return False
@@ -1734,16 +1740,46 @@ def _connected_destination_candidate_endpoints(
     return (peername, server_address, *extra_endpoints)
 
 
-def _resolved_trusted_host_addresses(host: str, port: int) -> frozenset[str]:
-    now = time.monotonic()
-    cache_key = (host, port)
+def _cached_trusted_host_addresses(
+    cache_key: tuple[str, int],
+    *,
+    now: float,
+) -> frozenset[str] | None:
     cached = _trusted_host_address_cache.get(cache_key)
     if cached is not None:
         expires_at, cached_addresses = cached
         if expires_at > now:
             return cached_addresses
         _trusted_host_address_cache.pop(cache_key, None)
+    return None
 
+
+def _cache_trusted_host_addresses(
+    cache_key: tuple[str, int],
+    addresses: frozenset[str],
+    *,
+    now: float,
+) -> None:
+    if len(_trusted_host_address_cache) >= _TRUSTED_HOST_ADDRESS_CACHE_MAX_ENTRIES:
+        expired_keys = [
+            key
+            for key, (expires_at, _addresses) in _trusted_host_address_cache.items()
+            if expires_at <= now
+        ]
+        for key in expired_keys:
+            _trusted_host_address_cache.pop(key, None)
+        if len(_trusted_host_address_cache) >= _TRUSTED_HOST_ADDRESS_CACHE_MAX_ENTRIES:
+            _trusted_host_address_cache.pop(next(iter(_trusted_host_address_cache)), None)
+
+    ttl = (
+        _TRUSTED_HOST_ADDRESS_CACHE_TTL_SECONDS
+        if addresses
+        else _TRUSTED_HOST_ADDRESS_NEGATIVE_CACHE_TTL_SECONDS
+    )
+    _trusted_host_address_cache[cache_key] = (now + ttl, addresses)
+
+
+def _resolve_trusted_host_addresses_sync(host: str, port: int) -> frozenset[str]:
     try:
         infos = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
     except OSError:
@@ -1761,26 +1797,43 @@ def _resolved_trusted_host_addresses(host: str, port: int) -> frozenset[str]:
         if resolved_ip is not None:
             address_set.add(resolved_ip)
 
-    resolved_addresses = frozenset(address_set)
-    if not resolved_addresses:
-        return resolved_addresses
+    return frozenset(address_set)
 
-    if len(_trusted_host_address_cache) >= _TRUSTED_HOST_ADDRESS_CACHE_MAX_ENTRIES:
-        expired_keys = [
-            key
-            for key, (expires_at, _addresses) in _trusted_host_address_cache.items()
-            if expires_at <= now
-        ]
-        for key in expired_keys:
-            _trusted_host_address_cache.pop(key, None)
-        if len(_trusted_host_address_cache) >= _TRUSTED_HOST_ADDRESS_CACHE_MAX_ENTRIES:
-            _trusted_host_address_cache.pop(next(iter(_trusted_host_address_cache)), None)
 
-    _trusted_host_address_cache[cache_key] = (
-        now + _TRUSTED_HOST_ADDRESS_CACHE_TTL_SECONDS,
+def _complete_trusted_host_address_lookup(
+    cache_key: tuple[str, int],
+    task: asyncio.Task[frozenset[str]],
+) -> None:
+    if _trusted_host_address_lookup_tasks.get(cache_key) is not task:
+        return
+    _trusted_host_address_lookup_tasks.pop(cache_key, None)
+    if task.cancelled():
+        return
+    resolved_addresses = task.result()
+    _cache_trusted_host_addresses(
+        cache_key,
         resolved_addresses,
+        now=_trusted_host_address_cache_time(),
     )
-    return resolved_addresses
+
+
+async def _resolved_trusted_host_addresses(host: str, port: int) -> frozenset[str]:
+    cache_key = (host, port)
+    cached = _cached_trusted_host_addresses(cache_key, now=_trusted_host_address_cache_time())
+    if cached is not None:
+        return cached
+
+    lookup_task = _trusted_host_address_lookup_tasks.get(cache_key)
+    if lookup_task is None:
+        lookup_task = asyncio.create_task(
+            asyncio.to_thread(_resolve_trusted_host_addresses_sync, host, port)
+        )
+        _trusted_host_address_lookup_tasks[cache_key] = lookup_task
+        lookup_task.add_done_callback(
+            functools.partial(_complete_trusted_host_address_lookup, cache_key)
+        )
+
+    return await asyncio.shield(lookup_task)
 
 
 def _connected_verified_tls_destination_endpoint(
@@ -1888,6 +1941,7 @@ def _flow_requires_platform_connector_auth_bypass(
 
 def reset_upstream_destination_resolution_cache_for_tests() -> None:
     _trusted_host_address_cache.clear()
+    _trusted_host_address_lookup_tasks.clear()
 
 
 def _api_hostname_matches(hostname: str) -> bool:
@@ -1921,7 +1975,7 @@ def _api_destination() -> tuple[str, int] | None:
     return api_hostname, api_port
 
 
-def _address_resolves_to_trusted_host(
+async def _address_resolves_to_trusted_host(
     address: tuple[str, int] | None,
     *,
     host: str,
@@ -1935,10 +1989,10 @@ def _address_resolves_to_trusted_host(
     address_ip = _ip_address_text(address_host)
     if address_ip is None:
         return False
-    return address_ip in _resolved_trusted_host_addresses(host, port)
+    return address_ip in await _resolved_trusted_host_addresses(host, port)
 
 
-def _bind_api_upstream_destination_from_original_address(
+async def _bind_api_upstream_destination_from_original_address(
     *,
     client: object,
     server: connection.Server,
@@ -1951,18 +2005,15 @@ def _bind_api_upstream_destination_from_original_address(
         return False
     api_hostname, api_port = api_destination
 
-    original_address = next(
-        (
-            address
-            for address in (_server_address(server), _connection_sockname(client))
-            if _address_resolves_to_trusted_host(
-                address,
-                host=api_hostname,
-                port=api_port,
-            )
-        ),
-        None,
-    )
+    original_address = None
+    for candidate_address in (_server_address(server), _connection_sockname(client)):
+        if await _address_resolves_to_trusted_host(
+            candidate_address,
+            host=api_hostname,
+            port=api_port,
+        ):
+            original_address = candidate_address
+            break
     if original_address is None:
         return False
 
@@ -2055,7 +2106,7 @@ def _bind_privileged_upstream_destination(
     )
 
 
-def server_connect(data: object) -> None:
+async def server_connect(data: object) -> None:
     """Bind privileged HTTPS upstream connections to their trusted SNI host."""
     client = getattr(data, "client", None)
     server = getattr(data, "server", None)
@@ -2079,7 +2130,7 @@ def server_connect(data: object) -> None:
     raw_sni = getattr(client, "sni", None)
     if not raw_sni and tls_admission is not None:
         raw_sni = tls_admission.sni
-    if not raw_sni and _bind_api_upstream_destination_from_original_address(
+    if not raw_sni and await _bind_api_upstream_destination_from_original_address(
         client=client,
         server=server,
     ):

--- a/crates/runner/mitm-addon/tests/test_server_connect_hook.py
+++ b/crates/runner/mitm-addon/tests/test_server_connect_hook.py
@@ -457,7 +457,7 @@ async def test_server_connect_cancelled_waiter_does_not_cancel_shared_dns_lookup
         cancelled_task.cancel()
         release_lookup.set()
         await asyncio.gather(cancelled_task, return_exceptions=True)
-        await completed_task
+        _ = await completed_task
 
     assert calls == [("pr-test-api.vm6.ai", 443)]
     assert cancelled.server.address == ("198.18.20.34", 443)

--- a/crates/runner/mitm-addon/tests/test_server_connect_hook.py
+++ b/crates/runner/mitm-addon/tests/test_server_connect_hook.py
@@ -1,6 +1,8 @@
 """Tests for upstream destination binding in server_connect()."""
 
+import asyncio
 import socket
+import threading
 import uuid
 from unittest.mock import patch
 
@@ -11,6 +13,8 @@ from tests.request_handler_helpers import (
     _write_github_firewall_registry,
     _write_registry,
 )
+
+_API_ADDRINFO = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("198.18.20.34", 443))]
 
 
 class _Server:
@@ -63,12 +67,12 @@ def _data(
     )
 
 
-def test_server_connect_retargets_credentialed_connector_host(tmp_path, mitm_ctx):
+async def test_server_connect_retargets_credentialed_connector_host(tmp_path, mitm_ctx):
     reg_path = _write_github_firewall_registry(tmp_path)
     data = _data()
 
     with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
-        mitm_addon.server_connect(data)
+        await mitm_addon.server_connect(data)
 
     assert data.server.address == ("api.github.com", 443)
     binding = upstream_destination_binding.binding_snapshot_for_tests()[data.server.id]
@@ -78,7 +82,7 @@ def test_server_connect_retargets_credentialed_connector_host(tmp_path, mitm_ctx
     assert binding.original_address == ("203.0.113.10", 443)
 
 
-def test_server_connect_uses_tls_clienthello_sni_when_client_sni_is_empty(tmp_path, mitm_ctx):
+async def test_server_connect_uses_tls_clienthello_sni_when_client_sni_is_empty(tmp_path, mitm_ctx):
     reg_path = _write_github_firewall_registry(tmp_path)
     data = _data(sni="")
     mitm_addon._record_tls_admission(
@@ -92,7 +96,7 @@ def test_server_connect_uses_tls_clienthello_sni_when_client_sni_is_empty(tmp_pa
     )
 
     with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
-        mitm_addon.server_connect(data)
+        await mitm_addon.server_connect(data)
 
     assert data.server.address == ("api.github.com", 443)
     binding = upstream_destination_binding.binding_snapshot_for_tests()[data.server.id]
@@ -100,18 +104,18 @@ def test_server_connect_uses_tls_clienthello_sni_when_client_sni_is_empty(tmp_pa
     assert binding.kinds == frozenset(("connector_auth",))
 
 
-def test_server_connect_retargets_api_allow_host(registry_file, mitm_ctx):
+async def test_server_connect_retargets_api_allow_host(registry_file, mitm_ctx):
     data = _data(client_ip="10.200.0.1", sni="api.vm0.ai")
 
     with mitm_ctx(registry_path=str(registry_file), api_url="https://api.vm0.ai"):
-        mitm_addon.server_connect(data)
+        await mitm_addon.server_connect(data)
 
     assert data.server.address == ("api.vm0.ai", 443)
     binding = upstream_destination_binding.binding_snapshot_for_tests()[data.server.id]
     assert binding.kinds == frozenset(("api_allow",))
 
 
-def test_server_connect_does_not_prebind_platform_connector_auth(tmp_path, mitm_ctx):
+async def test_server_connect_does_not_prebind_platform_connector_auth(tmp_path, mitm_ctx):
     reg_path = _write_registry(
         tmp_path,
         vm_info=_single_firewall_vm(
@@ -128,14 +132,16 @@ def test_server_connect_does_not_prebind_platform_connector_auth(tmp_path, mitm_
     data = _data(sni="api.vm0.ai")
 
     with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
-        mitm_addon.server_connect(data)
+        await mitm_addon.server_connect(data)
 
     assert data.server.address == ("api.vm0.ai", 443)
     binding = upstream_destination_binding.binding_snapshot_for_tests()[data.server.id]
     assert binding.kinds == frozenset(("api_allow",))
 
 
-def test_server_connect_does_not_bind_connected_api_edge_from_sni_only(registry_file, mitm_ctx):
+async def test_server_connect_does_not_bind_connected_api_edge_from_sni_only(
+    registry_file, mitm_ctx
+):
     data = _data(
         client_ip="10.200.0.1",
         sni="pr-test-api.vm6.ai",
@@ -152,13 +158,13 @@ def test_server_connect_does_not_bind_connected_api_edge_from_sni_only(registry_
             return_value=[(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("66.33.60.34", 443))],
         ),
     ):
-        mitm_addon.server_connect(data)
+        await mitm_addon.server_connect(data)
 
     assert data.server.address == ("76.76.21.164", 443)
     assert upstream_destination_binding.binding_snapshot_for_tests() == {}
 
 
-def test_server_connect_does_not_bind_connected_connector_from_sni_only(tmp_path, mitm_ctx):
+async def test_server_connect_does_not_bind_connected_connector_from_sni_only(tmp_path, mitm_ctx):
     reg_path = _write_github_firewall_registry(tmp_path)
     data = _data(
         sni="api.github.com",
@@ -175,24 +181,20 @@ def test_server_connect_does_not_bind_connected_connector_from_sni_only(tmp_path
             side_effect=AssertionError("connector binding must not use fresh DNS"),
         ),
     ):
-        mitm_addon.server_connect(data)
+        await mitm_addon.server_connect(data)
 
     assert data.server.address == ("140.82.112.5", 443)
     assert upstream_destination_binding.binding_snapshot_for_tests() == {}
 
 
-def test_server_connect_binds_api_host_from_original_address(registry_file, mitm_ctx):
+async def test_server_connect_binds_api_host_from_original_address(registry_file, mitm_ctx):
     data = _data(client_ip="10.200.0.1", sni="", address=("198.18.20.34", 443))
 
     with (
         mitm_ctx(registry_path=str(registry_file), api_url="https://pr-test-api.vm6.ai"),
-        patch.object(
-            mitm_addon.socket,
-            "getaddrinfo",
-            return_value=[(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("198.18.20.34", 443))],
-        ),
+        patch.object(mitm_addon.socket, "getaddrinfo", return_value=_API_ADDRINFO),
     ):
-        mitm_addon.server_connect(data)
+        await mitm_addon.server_connect(data)
 
     assert data.server.address == ("pr-test-api.vm6.ai", 443)
     binding = upstream_destination_binding.binding_snapshot_for_tests()[data.server.id]
@@ -201,7 +203,7 @@ def test_server_connect_binds_api_host_from_original_address(registry_file, mitm
     assert binding.original_address == ("198.18.20.34", 443)
 
 
-def test_server_connect_does_not_bind_connected_api_host_from_original_address(
+async def test_server_connect_does_not_bind_connected_api_host_from_original_address(
     registry_file, mitm_ctx
 ):
     data = _data(
@@ -214,19 +216,15 @@ def test_server_connect_does_not_bind_connected_api_host_from_original_address(
 
     with (
         mitm_ctx(registry_path=str(registry_file), api_url="https://pr-test-api.vm6.ai"),
-        patch.object(
-            mitm_addon.socket,
-            "getaddrinfo",
-            return_value=[(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("198.18.20.34", 443))],
-        ),
+        patch.object(mitm_addon.socket, "getaddrinfo", return_value=_API_ADDRINFO),
     ):
-        mitm_addon.server_connect(data)
+        await mitm_addon.server_connect(data)
 
     assert data.server.address == ("198.18.20.34", 443)
     assert upstream_destination_binding.binding_snapshot_for_tests() == {}
 
 
-def test_server_connect_binds_api_host_from_transparent_sockname(registry_file, mitm_ctx):
+async def test_server_connect_binds_api_host_from_transparent_sockname(registry_file, mitm_ctx):
     data = _data(
         client_ip="10.200.0.1",
         sni="",
@@ -236,13 +234,9 @@ def test_server_connect_binds_api_host_from_transparent_sockname(registry_file, 
 
     with (
         mitm_ctx(registry_path=str(registry_file), api_url="https://pr-test-api.vm6.ai"),
-        patch.object(
-            mitm_addon.socket,
-            "getaddrinfo",
-            return_value=[(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("198.18.20.34", 443))],
-        ),
+        patch.object(mitm_addon.socket, "getaddrinfo", return_value=_API_ADDRINFO),
     ):
-        mitm_addon.server_connect(data)
+        await mitm_addon.server_connect(data)
 
     assert data.server.address == ("pr-test-api.vm6.ai", 443)
     binding = upstream_destination_binding.binding_snapshot_for_tests()[data.server.id]
@@ -251,26 +245,22 @@ def test_server_connect_binds_api_host_from_transparent_sockname(registry_file, 
     assert binding.original_address == ("198.18.20.34", 443)
 
 
-def test_server_connect_does_not_bind_api_host_when_original_address_misses_dns(
+async def test_server_connect_does_not_bind_api_host_when_original_address_misses_dns(
     registry_file, mitm_ctx
 ):
     data = _data(client_ip="10.200.0.1", sni="", address=("198.18.20.35", 443))
 
     with (
         mitm_ctx(registry_path=str(registry_file), api_url="https://pr-test-api.vm6.ai"),
-        patch.object(
-            mitm_addon.socket,
-            "getaddrinfo",
-            return_value=[(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("198.18.20.34", 443))],
-        ),
+        patch.object(mitm_addon.socket, "getaddrinfo", return_value=_API_ADDRINFO),
     ):
-        mitm_addon.server_connect(data)
+        await mitm_addon.server_connect(data)
 
     assert data.server.address == ("198.18.20.35", 443)
     assert upstream_destination_binding.binding_snapshot_for_tests() == {}
 
 
-def test_server_connect_does_not_retarget_auth_base_only_connector(tmp_path, mitm_ctx):
+async def test_server_connect_does_not_retarget_auth_base_only_connector(tmp_path, mitm_ctx):
     reg_path = _write_registry(
         tmp_path,
         vm_info=_single_firewall_vm(
@@ -286,47 +276,189 @@ def test_server_connect_does_not_retarget_auth_base_only_connector(tmp_path, mit
     data = _data(sni="placeholder.example.com")
 
     with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
-        mitm_addon.server_connect(data)
+        await mitm_addon.server_connect(data)
 
     assert data.server.address == ("203.0.113.10", 443)
     assert upstream_destination_binding.binding_snapshot_for_tests() == {}
 
 
-def test_server_connect_ignores_unregistered_vm(registry_file, mitm_ctx):
+async def test_server_connect_ignores_unregistered_vm(registry_file, mitm_ctx):
     data = _data(client_ip="192.168.99.99")
 
     with mitm_ctx(registry_path=str(registry_file), api_url="https://api.vm0.ai"):
-        mitm_addon.server_connect(data)
+        await mitm_addon.server_connect(data)
 
     assert data.server.address == ("203.0.113.10", 443)
     assert upstream_destination_binding.binding_snapshot_for_tests() == {}
 
 
-def test_server_connect_ignores_invalid_sni(tmp_path, mitm_ctx):
+async def test_server_connect_ignores_invalid_sni(tmp_path, mitm_ctx):
     reg_path = _write_github_firewall_registry(tmp_path)
     data = _data(sni="api.github.com..")
 
     with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
-        mitm_addon.server_connect(data)
+        await mitm_addon.server_connect(data)
 
     assert data.server.address == ("203.0.113.10", 443)
     assert upstream_destination_binding.binding_snapshot_for_tests() == {}
 
 
-def test_server_disconnect_and_connect_error_clear_binding(tmp_path, mitm_ctx):
+async def test_server_disconnect_and_connect_error_clear_binding(tmp_path, mitm_ctx):
     reg_path = _write_github_firewall_registry(tmp_path)
     data = _data()
 
     with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
-        mitm_addon.server_connect(data)
+        await mitm_addon.server_connect(data)
 
     assert data.server.id in upstream_destination_binding.binding_snapshot_for_tests()
     mitm_addon.server_disconnected(data)
     assert data.server.id not in upstream_destination_binding.binding_snapshot_for_tests()
 
     with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
-        mitm_addon.server_connect(data)
+        await mitm_addon.server_connect(data)
 
     assert data.server.id in upstream_destination_binding.binding_snapshot_for_tests()
     mitm_addon.server_connect_error(data)
     assert data.server.id not in upstream_destination_binding.binding_snapshot_for_tests()
+
+
+async def test_server_connect_negative_caches_dns_errors(registry_file, mitm_ctx):
+    first = _data(client_ip="10.200.0.1", sni="", address=("198.18.20.34", 443))
+    second = _data(client_ip="10.200.0.1", sni="", address=("198.18.20.34", 443))
+
+    with (
+        mitm_ctx(registry_path=str(registry_file), api_url="https://pr-test-api.vm6.ai"),
+        patch.object(mitm_addon, "_trusted_host_address_cache_time", return_value=10.0),
+        patch.object(mitm_addon.socket, "getaddrinfo", side_effect=OSError("dns down")) as dns,
+    ):
+        await mitm_addon.server_connect(first)
+        await mitm_addon.server_connect(second)
+
+    assert dns.call_count == 1
+    assert first.server.address == ("198.18.20.34", 443)
+    assert second.server.address == ("198.18.20.34", 443)
+    assert upstream_destination_binding.binding_snapshot_for_tests() == {}
+
+
+async def test_server_connect_negative_caches_empty_dns_results(registry_file, mitm_ctx):
+    first = _data(client_ip="10.200.0.1", sni="", address=("198.18.20.34", 443))
+    second = _data(client_ip="10.200.0.1", sni="", address=("198.18.20.34", 443))
+
+    with (
+        mitm_ctx(registry_path=str(registry_file), api_url="https://pr-test-api.vm6.ai"),
+        patch.object(mitm_addon, "_trusted_host_address_cache_time", return_value=10.0),
+        patch.object(mitm_addon.socket, "getaddrinfo", return_value=[]) as dns,
+    ):
+        await mitm_addon.server_connect(first)
+        await mitm_addon.server_connect(second)
+
+    assert dns.call_count == 1
+    assert first.server.address == ("198.18.20.34", 443)
+    assert second.server.address == ("198.18.20.34", 443)
+    assert upstream_destination_binding.binding_snapshot_for_tests() == {}
+
+
+async def test_server_connect_retries_after_negative_dns_cache_expires(registry_file, mitm_ctx):
+    failed = _data(client_ip="10.200.0.1", sni="", address=("198.18.20.34", 443))
+    retried = _data(client_ip="10.200.0.1", sni="", address=("198.18.20.34", 443))
+
+    monotonic_values = [10.0, 10.0, 20.0, 20.0]
+    with (
+        mitm_ctx(registry_path=str(registry_file), api_url="https://pr-test-api.vm6.ai"),
+        patch.object(
+            mitm_addon,
+            "_trusted_host_address_cache_time",
+            side_effect=monotonic_values,
+        ),
+        patch.object(
+            mitm_addon.socket,
+            "getaddrinfo",
+            side_effect=[OSError("dns down"), _API_ADDRINFO],
+        ) as dns,
+    ):
+        await mitm_addon.server_connect(failed)
+        await mitm_addon.server_connect(retried)
+
+    assert dns.call_count == 2
+    assert failed.server.address == ("198.18.20.34", 443)
+    assert retried.server.address == ("pr-test-api.vm6.ai", 443)
+    assert retried.server.id in upstream_destination_binding.binding_snapshot_for_tests()
+
+
+async def test_server_connect_positive_caches_dns_results(registry_file, mitm_ctx):
+    first = _data(client_ip="10.200.0.1", sni="", address=("198.18.20.34", 443))
+    second = _data(client_ip="10.200.0.1", sni="", address=("198.18.20.34", 443))
+
+    with (
+        mitm_ctx(registry_path=str(registry_file), api_url="https://pr-test-api.vm6.ai"),
+        patch.object(mitm_addon, "_trusted_host_address_cache_time", return_value=10.0),
+        patch.object(mitm_addon.socket, "getaddrinfo", return_value=_API_ADDRINFO) as dns,
+    ):
+        await mitm_addon.server_connect(first)
+        await mitm_addon.server_connect(second)
+
+    assert dns.call_count == 1
+    assert first.server.address == ("pr-test-api.vm6.ai", 443)
+    assert second.server.address == ("pr-test-api.vm6.ai", 443)
+
+
+async def test_server_connect_coalesces_concurrent_dns_resolution(registry_file, mitm_ctx):
+    first = _data(client_ip="10.200.0.1", sni="", address=("198.18.20.34", 443))
+    second = _data(client_ip="10.200.0.1", sni="", address=("198.18.20.34", 443))
+    lookup_started = threading.Event()
+    release_lookup = threading.Event()
+    calls: list[tuple[str, int]] = []
+
+    def getaddrinfo(host: str, port: int, *args, **kwargs):
+        calls.append((host, port))
+        lookup_started.set()
+        release_lookup.wait()
+        return _API_ADDRINFO
+
+    with (
+        mitm_ctx(registry_path=str(registry_file), api_url="https://pr-test-api.vm6.ai"),
+        patch.object(mitm_addon.socket, "getaddrinfo", side_effect=getaddrinfo),
+    ):
+        first_task = asyncio.create_task(mitm_addon.server_connect(first))
+        assert await asyncio.to_thread(lookup_started.wait, 5)
+        second_task = asyncio.create_task(mitm_addon.server_connect(second))
+        await asyncio.sleep(0)
+        release_lookup.set()
+        await asyncio.gather(first_task, second_task)
+
+    assert calls == [("pr-test-api.vm6.ai", 443)]
+    assert first.server.address == ("pr-test-api.vm6.ai", 443)
+    assert second.server.address == ("pr-test-api.vm6.ai", 443)
+
+
+async def test_server_connect_cancelled_waiter_does_not_cancel_shared_dns_lookup(
+    registry_file, mitm_ctx
+):
+    cancelled = _data(client_ip="10.200.0.1", sni="", address=("198.18.20.34", 443))
+    completed = _data(client_ip="10.200.0.1", sni="", address=("198.18.20.34", 443))
+    lookup_started = threading.Event()
+    release_lookup = threading.Event()
+    calls: list[tuple[str, int]] = []
+
+    def getaddrinfo(host: str, port: int, *args, **kwargs):
+        calls.append((host, port))
+        lookup_started.set()
+        release_lookup.wait()
+        return _API_ADDRINFO
+
+    with (
+        mitm_ctx(registry_path=str(registry_file), api_url="https://pr-test-api.vm6.ai"),
+        patch.object(mitm_addon.socket, "getaddrinfo", side_effect=getaddrinfo),
+    ):
+        cancelled_task = asyncio.create_task(mitm_addon.server_connect(cancelled))
+        assert await asyncio.to_thread(lookup_started.wait, 5)
+        completed_task = asyncio.create_task(mitm_addon.server_connect(completed))
+        await asyncio.sleep(0)
+        cancelled_task.cancel()
+        release_lookup.set()
+        await asyncio.gather(cancelled_task, return_exceptions=True)
+        await completed_task
+
+    assert calls == [("pr-test-api.vm6.ai", 443)]
+    assert cancelled.server.address == ("198.18.20.34", 443)
+    assert completed.server.address == ("pr-test-api.vm6.ai", 443)

--- a/crates/runner/mitm-addon/tests/test_server_connect_hook.py
+++ b/crates/runner/mitm-addon/tests/test_server_connect_hook.py
@@ -412,7 +412,8 @@ async def test_server_connect_coalesces_concurrent_dns_resolution(registry_file,
     def getaddrinfo(host: str, port: int, *args, **kwargs):
         calls.append((host, port))
         lookup_started.set()
-        release_lookup.wait()
+        if not release_lookup.wait(timeout=5):
+            raise AssertionError("timed out waiting to release DNS lookup")
         return _API_ADDRINFO
 
     with (
@@ -443,7 +444,8 @@ async def test_server_connect_cancelled_waiter_does_not_cancel_shared_dns_lookup
     def getaddrinfo(host: str, port: int, *args, **kwargs):
         calls.append((host, port))
         lookup_started.set()
-        release_lookup.wait()
+        if not release_lookup.wait(timeout=5):
+            raise AssertionError("timed out waiting to release DNS lookup")
         return _API_ADDRINFO
 
     with (


### PR DESCRIPTION
## Summary

- convert `server_connect` to an async hook and make only the no-SNI API recovery path await DNS
- move trusted API-host DNS lookups to `asyncio.to_thread` with positive and short negative caching
- coalesce concurrent lookups per `(host, port)` and shield shared lookup tasks from waiter cancellation
- add regression coverage for DNS errors, empty results, cache expiry, single-flight, cancellation, and existing binding behavior

Closes #19285

## Tests

- `cd crates/runner/mitm-addon && .venv/bin/pytest tests/test_server_connect_hook.py -q`
- `cd crates/runner/mitm-addon && .venv/bin/pytest tests/test_tls_clienthello_hook.py tests/test_request_headers_handler.py tests/test_request_handler_authority_validation.py -q`
- `cd crates/runner/mitm-addon && .venv/bin/pytest -q`
- `cd crates/runner/mitm-addon && .venv/bin/ruff check .`
- `cd crates/runner/mitm-addon && .venv/bin/ruff format --check .`
- `cd crates/runner/mitm-addon && .venv/bin/basedpyright -p .`