### PR TITLE
fix: allow concurrent workflow event triggers

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-gmail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-gmail.test.ts
@@ -2,6 +2,8 @@ import { Buffer } from "node:buffer";
 
 import { zeroWorkflowTriggersContract } from "@vm0/api-contracts/contracts/zero-workflows";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { agentSessions } from "@vm0/db/schema/agent-session";
 import { connectors } from "@vm0/db/schema/connector";
 import {
   gmailProcessedEvents,
@@ -9,6 +11,7 @@ import {
 } from "@vm0/db/schema/gmail-event";
 import { secrets } from "@vm0/db/schema/secret";
 import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
 import {
   zeroWorkflowTriggers,
   zeroWorkflows,
@@ -61,6 +64,7 @@ function triggersClient() {
 }
 
 function configureGmailEnv(): void {
+  mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
   mockOptionalEnv("GMAIL_PUBSUB_TOPIC_NAME", GMAIL_TOPIC_NAME);
   mockOptionalEnv("GMAIL_PUBSUB_PUSH_AUDIENCE", GMAIL_AUDIENCE);
   mockOptionalEnv(
@@ -286,6 +290,7 @@ async function seedGmailConnector(fixture: WorkflowsFixture): Promise<string> {
 
 async function setupFixture(): Promise<{
   readonly fixture: WorkflowsFixture;
+  readonly agentId: string;
   readonly workflowId: string;
 }> {
   const fixture = await store.set(
@@ -301,6 +306,15 @@ async function setupFixture(): Promise<{
       userId: fixture.userId,
       name: "gmail-webhook-agent",
       workflowNames: [WORKFLOW_NAME],
+      composeContent: {
+        version: "1",
+        agents: {
+          "gmail-webhook-agent": {
+            framework: "claude-code",
+            environment: { ANTHROPIC_API_KEY: "test-key" },
+          },
+        },
+      },
     },
     context.signal,
   );
@@ -319,7 +333,40 @@ async function setupFixture(): Promise<{
     throw new Error("Expected the agent to own the seeded workflow");
   }
   mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
-  return { fixture, workflowId: workflow.id };
+  return { fixture, agentId, workflowId: workflow.id };
+}
+
+async function markTriggerWithActiveRun(args: {
+  readonly fixture: WorkflowsFixture;
+  readonly agentId: string;
+  readonly triggerId: string;
+}): Promise<string> {
+  const db = store.set(writeDb$);
+  const [session] = await db
+    .insert(agentSessions)
+    .values({
+      userId: args.fixture.userId,
+      orgId: args.fixture.orgId,
+      agentComposeId: args.agentId,
+    })
+    .returning({ id: agentSessions.id });
+  const [run] = await db
+    .insert(agentRuns)
+    .values({
+      userId: args.fixture.userId,
+      orgId: args.fixture.orgId,
+      sessionId: session!.id,
+      status: "running",
+      prompt: "active event run",
+    })
+    .returning({ id: agentRuns.id });
+
+  await db
+    .update(zeroWorkflowTriggers)
+    .set({ lastRunId: run!.id })
+    .where(eq(zeroWorkflowTriggers.id, args.triggerId));
+
+  return run!.id;
 }
 
 describe("POST /api/webhooks/gmail", () => {
@@ -522,5 +569,77 @@ describe("POST /api/webhooks/gmail", () => {
       labelName: "Support",
       resolvedLabelId: "Label_support_new",
     });
+  });
+
+  it("starts an event run when the trigger's previous run is still active", async () => {
+    configureGmailEnv();
+    configureGmailWatchMock();
+    configureGmailMessageMocks();
+
+    const { fixture, agentId, workflowId } = await setupFixture();
+    await track(Promise.resolve(fixture));
+    await enableGmailWorkflowTriggers(fixture);
+    await seedGmailConnector(fixture);
+
+    const restoreOidcVerifier = setGmailPubSubOidcVerifierForTests(() => {
+      return Promise.resolve({
+        email: GMAIL_PUSH_SERVICE_ACCOUNT,
+        emailVerified: true,
+      });
+    });
+    onTestFinished(() => {
+      restoreOidcVerifier();
+    });
+
+    const created = await accept(
+      triggersClient().create({
+        headers: authHeaders(),
+        params: { workflowId },
+        body: {
+          kind: "event",
+          eventType: "gmail-new-message",
+          eventConfig: {
+            provider: "gmail",
+            event: "new_message",
+            match: { subject: { contains: "invoice" } },
+          },
+        },
+      }),
+      [201],
+    );
+    const activeRunId = await markTriggerWithActiveRun({
+      fixture,
+      agentId,
+      triggerId: created.body.id,
+    });
+
+    const response = await postGmailWebhook(
+      gmailPushBody({
+        emailAddress: GMAIL_EMAIL,
+        historyId: 101,
+        messageId: "pubsub-active-run",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({ dispatched: 1, duplicates: 0 });
+
+    const db = store.set(writeDb$);
+    const runs = await db
+      .select({ id: zeroRuns.id, triggerSource: zeroRuns.triggerSource })
+      .from(zeroRuns)
+      .where(eq(zeroRuns.workflowTriggerId, created.body.id));
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.triggerSource).toBe("workflow-event");
+
+    const [trigger] = await db
+      .select({
+        lastRunId: zeroWorkflowTriggers.lastRunId,
+        lastRunAt: zeroWorkflowTriggers.lastRunAt,
+      })
+      .from(zeroWorkflowTriggers)
+      .where(eq(zeroWorkflowTriggers.id, created.body.id));
+    expect(trigger?.lastRunId).toBe(activeRunId);
+    expect(trigger?.lastRunAt).toBeInstanceOf(Date);
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-workflow-triggers.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-workflow-triggers.test.ts
@@ -1,7 +1,13 @@
 import { zeroWorkflowTriggersContract } from "@vm0/api-contracts/contracts/zero-workflows";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { agentSessions } from "@vm0/db/schema/agent-session";
 import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
-import { zeroWorkflows } from "@vm0/db/schema/zero-workflow";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
+import {
+  zeroWorkflowTriggers,
+  zeroWorkflows,
+} from "@vm0/db/schema/zero-workflow";
 import { createStore } from "ccstate";
 import { and, eq } from "drizzle-orm";
 import { onTestFinished } from "vitest";
@@ -9,6 +15,7 @@ import { onTestFinished } from "vitest";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { createApp } from "../../../app-factory";
 import { computeHmacSignature } from "../../../lib/event-consumer/hmac";
+import { mockOptionalEnv } from "../../../lib/env";
 import { now } from "../../../lib/time";
 import { writeDb$ } from "../../external/db";
 import {
@@ -44,6 +51,7 @@ function triggersClient() {
 
 async function setupFixture(): Promise<{
   readonly fixture: WorkflowsFixture;
+  readonly agentId: string;
   readonly workflowId: string;
 }> {
   const fixture = await store.set(
@@ -59,6 +67,15 @@ async function setupFixture(): Promise<{
       userId: fixture.userId,
       name: "webhook-trigger-agent",
       workflowNames: [WORKFLOW_NAME],
+      composeContent: {
+        version: "1",
+        agents: {
+          "webhook-trigger-agent": {
+            framework: "claude-code",
+            environment: { ANTHROPIC_API_KEY: "test-key" },
+          },
+        },
+      },
     },
     context.signal,
   );
@@ -77,7 +94,40 @@ async function setupFixture(): Promise<{
     throw new Error("Expected the agent to own the seeded workflow");
   }
   mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
-  return { fixture, workflowId: workflow.id };
+  return { fixture, agentId, workflowId: workflow.id };
+}
+
+async function markTriggerWithActiveRun(args: {
+  readonly fixture: WorkflowsFixture;
+  readonly agentId: string;
+  readonly triggerId: string;
+}): Promise<string> {
+  const db = store.set(writeDb$);
+  const [session] = await db
+    .insert(agentSessions)
+    .values({
+      userId: args.fixture.userId,
+      orgId: args.fixture.orgId,
+      agentComposeId: args.agentId,
+    })
+    .returning({ id: agentSessions.id });
+  const [run] = await db
+    .insert(agentRuns)
+    .values({
+      userId: args.fixture.userId,
+      orgId: args.fixture.orgId,
+      sessionId: session!.id,
+      status: "running",
+      prompt: "active event run",
+    })
+    .returning({ id: agentRuns.id });
+
+  await db
+    .update(zeroWorkflowTriggers)
+    .set({ lastRunId: run!.id })
+    .where(eq(zeroWorkflowTriggers.id, args.triggerId));
+
+  return run!.id;
 }
 
 async function enableWebhookWorkflowTriggers(
@@ -241,5 +291,69 @@ describe("POST /api/webhooks/workflow-triggers/:token", () => {
     );
 
     expect(response.status).toBe(401);
+  });
+
+  it("starts an event run when the trigger's previous run is still active", async () => {
+    mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
+    const { fixture, agentId, workflowId } = await setupFixture();
+    await track(Promise.resolve(fixture));
+    await enableWebhookWorkflowTriggers(fixture);
+
+    const created = await accept(
+      triggersClient().create({
+        headers: authHeaders(),
+        params: { workflowId },
+        body: { kind: "event", eventType: "webhook-received" },
+      }),
+      [201],
+    );
+    if (
+      created.body.kind !== "event" ||
+      created.body.eventType !== "webhook-received" ||
+      !created.body.webhookSecret
+    ) {
+      throw new Error("Expected a webhook trigger with a one-time secret");
+    }
+
+    const token = new URL(created.body.webhookUrl).pathname.split("/").at(-1);
+    if (!token) {
+      throw new Error("Expected webhook URL token");
+    }
+    const activeRunId = await markTriggerWithActiveRun({
+      fixture,
+      agentId,
+      triggerId: created.body.id,
+    });
+
+    const response = await postWorkflowWebhook({
+      token,
+      rawBody: JSON.stringify({ event: "active-run" }),
+      secret: created.body.webhookSecret,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      success: true,
+      duplicate: false,
+      runId: expect.any(String),
+    });
+
+    const db = store.set(writeDb$);
+    const runs = await db
+      .select({ id: zeroRuns.id, triggerSource: zeroRuns.triggerSource })
+      .from(zeroRuns)
+      .where(eq(zeroRuns.workflowTriggerId, created.body.id));
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.triggerSource).toBe("workflow-event");
+
+    const [trigger] = await db
+      .select({
+        lastRunId: zeroWorkflowTriggers.lastRunId,
+        lastRunAt: zeroWorkflowTriggers.lastRunAt,
+      })
+      .from(zeroWorkflowTriggers)
+      .where(eq(zeroWorkflowTriggers.id, created.body.id));
+    expect(trigger?.lastRunId).toBe(activeRunId);
+    expect(trigger?.lastRunAt).toBeInstanceOf(Date);
   });
 });

--- a/turbo/apps/api/src/signals/services/gmail-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/gmail-workflow-event.service.ts
@@ -1836,6 +1836,8 @@ export const dispatchGmailPubSubPush$ = command(
                 trigger.chatThreadId,
                 trigger.agentId,
               ),
+              activePreviousRunPolicy: "allow",
+              recordLastRunId: false,
               recordLastRunAt: true,
               dispatchFailedCallbacks: dispatchFailedRunCallbacks,
             },

--- a/turbo/apps/api/src/signals/services/workflow-webhook-trigger.service.ts
+++ b/turbo/apps/api/src/signals/services/workflow-webhook-trigger.service.ts
@@ -549,6 +549,8 @@ const startWorkflowWebhookRun$ = command(
           args.row.chatThreadId,
           args.row.agentId,
         ),
+        activePreviousRunPolicy: "allow",
+        recordLastRunId: false,
         recordLastRunAt: true,
         dispatchFailedCallbacks: dispatchFailedRunCallbacks,
       },

--- a/turbo/apps/api/src/signals/services/zero-workflow-trigger-run.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-trigger-run.service.ts
@@ -45,6 +45,7 @@ export type RunWorkflowTriggerResult =
   | { readonly kind: "run_error"; readonly response: RunErrorResponse };
 
 export type RunFailure = Exclude<RunWorkflowTriggerResult, { kind: "ok" }>;
+type ActivePreviousRunPolicy = "block" | "allow";
 
 interface InternalRunCallbackInput {
   readonly internalKind: InternalRunCallbackKind;
@@ -201,6 +202,7 @@ export const runWorkflowTriggerNow$ = command(
       readonly triggerSource?: TriggerSource;
       readonly appendSystemPrompt?: string;
       readonly callbacks?: readonly InternalRunCallbackInput[];
+      readonly activePreviousRunPolicy?: ActivePreviousRunPolicy;
       readonly recordLastRunId?: boolean;
       readonly recordLastRunAt?: boolean;
       readonly dispatchFailedCallbacks: DispatchFailedRunCallbacks;
@@ -210,7 +212,7 @@ export const runWorkflowTriggerNow$ = command(
     const db = set(writeDb$);
     const { trigger, agentId, workflowName, chatThreadId } = args.due;
 
-    if (trigger.lastRunId) {
+    if (args.activePreviousRunPolicy !== "allow" && trigger.lastRunId) {
       const [lastRun] = await db
         .select({ status: agentRuns.status })
         .from(agentRuns)


### PR DESCRIPTION
## Summary

- add an explicit active previous run policy to workflow trigger runs
- allow Gmail and workflow webhook event triggers to start independent runs while a previous run is active
- stop event-triggered runs from updating trigger lastRunId while preserving lastRunAt

Closes #19301

## Verification

- pnpm format
- pnpm -F api lint
- NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types
- pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-gmail.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-workflow-triggers.test.ts