### PR TITLE
refactor(mitm-addon): split registry firewall resolution

### DIFF
--- a/crates/runner/mitm-addon/src/builtin_base_url.py
+++ b/crates/runner/mitm-addon/src/builtin_base_url.py
@@ -1,0 +1,406 @@
+"""Builtin firewall base URL template resolution."""
+
+import re
+import urllib.parse
+
+import matching
+from authority_utils import percent_decode_host
+from path_security import has_unsafe_path
+from url_syntax import has_raw_whitespace, has_unsafe_url_codepoint
+
+_BASE_URL_VAR_PATTERN = re.compile(r"\$\{\{\s*vars\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}")
+_URL_COMPONENT_DELIMITER_PATTERN = re.compile(r"[/?#]")
+_AUTHORITY_VAR_STRUCTURE_CHARS = frozenset(("/", "?", "#", "@", "\\"))
+_AUTHORITY_FRAGMENT_VAR_STRUCTURE_CHARS = frozenset(("/", ":", "?", "#", "@", "\\"))
+_PERCENT_DECODED_BOUNDARY_CHARS = frozenset(("/", ":", "?", "#", "@", "\\"))
+_BASE_URL_VAR_PARAMETER_CHARS = frozenset(("{", "}"))
+_PATH_VAR_STRUCTURE_CHARS = frozenset(("/", "?", "#", "\\"))
+_PORT_VAR_PATTERN = re.compile(r"^[0-9]+$")
+_MAX_PATH_VAR_PERCENT_DECODE_PASSES = 5
+
+
+def _string_record(value: object, field_name: str) -> dict[str, str]:
+    if not isinstance(value, dict):
+        raise TypeError(f"{field_name} must be an object")
+
+    result: dict[str, str] = {}
+    for key, nested in value.items():
+        if not isinstance(key, str) or not isinstance(nested, str):
+            raise TypeError(f"{field_name} must contain string values")
+        result[key] = nested
+    return result
+
+
+def base_url_vars_for_entry(entry: dict) -> dict[str, str]:
+    if "baseUrlVars" in entry:
+        return _string_record(entry["baseUrlVars"], "baseUrlVars")
+    return {}
+
+
+def _base_url_variable_error(
+    *,
+    firewall_name: str,
+    base: str,
+    name: str,
+    detail: str,
+) -> ValueError:
+    return ValueError(
+        f'builtin firewall "{firewall_name}" base URL variable "{name}" {detail}: {base}'
+    )
+
+
+def _validate_base_url_variable_common_syntax(
+    *,
+    firewall_name: str,
+    base: str,
+    name: str,
+    value: str,
+) -> None:
+    if has_raw_whitespace(value) or any(char.isspace() for char in value):
+        raise _base_url_variable_error(
+            firewall_name=firewall_name,
+            base=base,
+            name=name,
+            detail="must not contain whitespace",
+        )
+    if has_unsafe_url_codepoint(value):
+        raise _base_url_variable_error(
+            firewall_name=firewall_name,
+            base=base,
+            name=name,
+            detail="must not contain control characters or invalid Unicode",
+        )
+    if any(char in _BASE_URL_VAR_PARAMETER_CHARS for char in value):
+        raise _base_url_variable_error(
+            firewall_name=firewall_name,
+            base=base,
+            name=name,
+            detail="must not contain firewall parameter syntax",
+        )
+
+
+def _validate_base_url_variable_percent_encoding(
+    *,
+    firewall_name: str,
+    base: str,
+    name: str,
+    value: str,
+    structure_chars: frozenset[str] = _PERCENT_DECODED_BOUNDARY_CHARS,
+) -> str:
+    decoded = percent_decode_host(value, syntax_chars=structure_chars)
+    if decoded.invalid_encoding:
+        raise _base_url_variable_error(
+            firewall_name=firewall_name,
+            base=base,
+            name=name,
+            detail="has invalid percent encoding",
+        )
+    if decoded.decoded_syntax or any(char.isspace() for char in decoded.value):
+        raise _base_url_variable_error(
+            firewall_name=firewall_name,
+            base=base,
+            name=name,
+            detail="must not contain encoded URL structure",
+        )
+    if has_unsafe_url_codepoint(decoded.value):
+        raise _base_url_variable_error(
+            firewall_name=firewall_name,
+            base=base,
+            name=name,
+            detail="must not contain encoded control characters or invalid Unicode",
+        )
+    return decoded.value
+
+
+def _path_variable_value_has_encoded_structure(value: str) -> bool:
+    current = value
+    for _ in range(_MAX_PATH_VAR_PERCENT_DECODE_PASSES):
+        decoded = percent_decode_host(current, syntax_chars=_PATH_VAR_STRUCTURE_CHARS)
+        if (
+            decoded.invalid_encoding
+            or decoded.decoded_syntax
+            or any(char.isspace() for char in decoded.value)
+            or has_unsafe_url_codepoint(decoded.value)
+        ):
+            return True
+        if decoded.value == current:
+            return False
+        current = decoded.value
+
+    decoded = percent_decode_host(current, syntax_chars=_PATH_VAR_STRUCTURE_CHARS)
+    return (
+        decoded.invalid_encoding
+        or decoded.decoded_syntax
+        or decoded.value != current
+        or any(char.isspace() for char in decoded.value)
+        or has_unsafe_url_codepoint(decoded.value)
+    )
+
+
+def _validate_base_url_prefix_variable(
+    *,
+    firewall_name: str,
+    base: str,
+    name: str,
+    value: str,
+) -> None:
+    if not matching.firewall_base_config_is_valid(value):
+        raise _base_url_variable_error(
+            firewall_name=firewall_name,
+            base=base,
+            name=name,
+            detail="must be a valid base URL before a fixed path suffix",
+        )
+    parts = urllib.parse.urlsplit(value)
+    if parts.query or parts.fragment:
+        raise _base_url_variable_error(
+            firewall_name=firewall_name,
+            base=base,
+            name=name,
+            detail="must not contain query or fragment before a fixed path suffix",
+        )
+    if has_unsafe_path(parts.path):
+        raise _base_url_variable_error(
+            firewall_name=firewall_name,
+            base=base,
+            name=name,
+            detail="must not contain unsafe path segments before a fixed path suffix",
+        )
+
+
+def _validate_base_url_authority_variable(
+    *,
+    firewall_name: str,
+    base: str,
+    name: str,
+    value: str,
+) -> None:
+    if any(char in _AUTHORITY_VAR_STRUCTURE_CHARS for char in value):
+        raise _base_url_variable_error(
+            firewall_name=firewall_name,
+            base=base,
+            name=name,
+            detail="must not introduce URL structure",
+        )
+    _validate_base_url_variable_percent_encoding(
+        firewall_name=firewall_name,
+        base=base,
+        name=name,
+        value=value,
+    )
+    if not matching.firewall_base_config_is_valid(f"https://{value}"):
+        raise _base_url_variable_error(
+            firewall_name=firewall_name,
+            base=base,
+            name=name,
+            detail="must be a valid URL authority",
+        )
+
+
+def _validate_base_url_authority_fragment_variable(
+    *,
+    firewall_name: str,
+    base: str,
+    name: str,
+    value: str,
+) -> None:
+    if any(char in _AUTHORITY_FRAGMENT_VAR_STRUCTURE_CHARS for char in value):
+        raise _base_url_variable_error(
+            firewall_name=firewall_name,
+            base=base,
+            name=name,
+            detail="must not introduce URL structure",
+        )
+    _validate_base_url_variable_percent_encoding(
+        firewall_name=firewall_name,
+        base=base,
+        name=name,
+        value=value,
+    )
+
+
+def _validate_base_url_port_variable(
+    *,
+    firewall_name: str,
+    base: str,
+    name: str,
+    value: str,
+) -> None:
+    if _PORT_VAR_PATTERN.fullmatch(value) is None:
+        raise _base_url_variable_error(
+            firewall_name=firewall_name,
+            base=base,
+            name=name,
+            detail="must be a numeric URL port",
+        )
+
+
+def _validate_base_url_path_variable(
+    *,
+    firewall_name: str,
+    base: str,
+    name: str,
+    value: str,
+    prefix: str,
+    suffix: str,
+) -> None:
+    if any(char in _PATH_VAR_STRUCTURE_CHARS for char in value):
+        raise _base_url_variable_error(
+            firewall_name=firewall_name,
+            base=base,
+            name=name,
+            detail="must not introduce path structure",
+        )
+    decoded = _validate_base_url_variable_percent_encoding(
+        firewall_name=firewall_name,
+        base=base,
+        name=name,
+        value=value,
+        structure_chars=_PATH_VAR_STRUCTURE_CHARS,
+    )
+    prefix_segment = prefix[prefix.rfind("/") + 1 :]
+    suffix_delimiter = _URL_COMPONENT_DELIMITER_PATTERN.search(suffix)
+    suffix_segment = suffix if suffix_delimiter is None else suffix[: suffix_delimiter.start()]
+    if _path_variable_value_has_encoded_structure(decoded) or has_unsafe_path(
+        f"/{prefix_segment}{decoded}{suffix_segment}"
+    ):
+        raise _base_url_variable_error(
+            firewall_name=firewall_name,
+            base=base,
+            name=name,
+            detail="must not contain unsafe path segments",
+        )
+
+
+def _prefix_is_inside_authority(prefix: str) -> bool:
+    scheme_end = prefix.find("://")
+    if scheme_end == -1:
+        return False
+    after_scheme = prefix[scheme_end + 3 :]
+    return _URL_COMPONENT_DELIMITER_PATTERN.search(after_scheme) is None
+
+
+def _prefix_is_inside_path(prefix: str) -> bool:
+    scheme_end = prefix.find("://")
+    if scheme_end == -1:
+        return False
+    after_scheme = prefix[scheme_end + 3 :]
+    if "?" in after_scheme or "#" in after_scheme:
+        return False
+    return "/" in after_scheme
+
+
+def _suffix_authority_prefix(suffix: str) -> str:
+    delimiter = _URL_COMPONENT_DELIMITER_PATTERN.search(suffix)
+    if delimiter is None:
+        return suffix
+    return suffix[: delimiter.start()]
+
+
+def _validate_base_url_template_variable(
+    *,
+    firewall_name: str,
+    base: str,
+    name: str,
+    value: str,
+    prefix: str,
+    suffix: str,
+) -> None:
+    _validate_base_url_variable_common_syntax(
+        firewall_name=firewall_name,
+        base=base,
+        name=name,
+        value=value,
+    )
+    if prefix == "" and suffix == "":
+        return
+    if prefix == "" and suffix.startswith("/"):
+        _validate_base_url_prefix_variable(
+            firewall_name=firewall_name,
+            base=base,
+            name=name,
+            value=value,
+        )
+        return
+    if prefix.endswith("://") and (suffix == "" or suffix.startswith("/")):
+        _validate_base_url_authority_variable(
+            firewall_name=firewall_name,
+            base=base,
+            name=name,
+            value=value,
+        )
+        return
+    if (
+        _prefix_is_inside_authority(prefix)
+        and prefix.endswith(":")
+        and (suffix == "" or suffix.startswith("/"))
+    ):
+        _validate_base_url_port_variable(
+            firewall_name=firewall_name,
+            base=base,
+            name=name,
+            value=value,
+        )
+        return
+    if _prefix_is_inside_authority(prefix) and _suffix_authority_prefix(suffix) != "":
+        _validate_base_url_authority_fragment_variable(
+            firewall_name=firewall_name,
+            base=base,
+            name=name,
+            value=value,
+        )
+        return
+    if _prefix_is_inside_path(prefix):
+        _validate_base_url_path_variable(
+            firewall_name=firewall_name,
+            base=base,
+            name=name,
+            value=value,
+            prefix=prefix,
+            suffix=suffix,
+        )
+        return
+    raise _base_url_variable_error(
+        firewall_name=firewall_name,
+        base=base,
+        name=name,
+        detail="is used in an unsupported base URL template position",
+    )
+
+
+def resolve_base_url_template(
+    *,
+    firewall_name: str,
+    base: str,
+    vars_map: dict[str, str],
+) -> str:
+    resolved_parts: list[str] = []
+    last_index = 0
+    for match in _BASE_URL_VAR_PATTERN.finditer(base):
+        name = match.group(1)
+        value = vars_map.get(name)
+        if not value:
+            raise ValueError(
+                f'builtin firewall "{firewall_name}" base URL requires variable "{name}"'
+            )
+        _validate_base_url_template_variable(
+            firewall_name=firewall_name,
+            base=base,
+            name=name,
+            value=value,
+            prefix=base[: match.start()],
+            suffix=base[match.end() :],
+        )
+        resolved_parts.append(base[last_index : match.start()])
+        resolved_parts.append(value)
+        last_index = match.end()
+
+    resolved_parts.append(base[last_index:])
+    resolved = "".join(resolved_parts)
+    if not matching.firewall_base_config_is_valid(resolved):
+        raise ValueError(f'builtin firewall "{firewall_name}" resolved base URL is invalid')
+    if has_unsafe_path(urllib.parse.urlsplit(resolved).path):
+        raise ValueError(
+            f'builtin firewall "{firewall_name}" resolved base URL has unsafe path segments'
+        )
+    return resolved

--- a/crates/runner/mitm-addon/src/builtin_base_url.py
+++ b/crates/runner/mitm-addon/src/builtin_base_url.py
@@ -19,14 +19,18 @@ _PORT_VAR_PATTERN = re.compile(r"^[0-9]+$")
 _MAX_PATH_VAR_PERCENT_DECODE_PASSES = 5
 
 
+class BuiltinBaseUrlResolutionError(ValueError):
+    """Builtin firewall base URL variables could not produce a safe runtime URL."""
+
+
 def _string_record(value: object, field_name: str) -> dict[str, str]:
     if not isinstance(value, dict):
-        raise TypeError(f"{field_name} must be an object")
+        raise BuiltinBaseUrlResolutionError(f"{field_name} must be an object")
 
     result: dict[str, str] = {}
     for key, nested in value.items():
         if not isinstance(key, str) or not isinstance(nested, str):
-            raise TypeError(f"{field_name} must contain string values")
+            raise BuiltinBaseUrlResolutionError(f"{field_name} must contain string values")
         result[key] = nested
     return result
 
@@ -43,8 +47,8 @@ def _base_url_variable_error(
     base: str,
     name: str,
     detail: str,
-) -> ValueError:
-    return ValueError(
+) -> BuiltinBaseUrlResolutionError:
+    return BuiltinBaseUrlResolutionError(
         f'builtin firewall "{firewall_name}" base URL variable "{name}" {detail}: {base}'
     )
 
@@ -380,7 +384,7 @@ def resolve_base_url_template(
         name = match.group(1)
         value = vars_map.get(name)
         if not value:
-            raise ValueError(
+            raise BuiltinBaseUrlResolutionError(
                 f'builtin firewall "{firewall_name}" base URL requires variable "{name}"'
             )
         _validate_base_url_template_variable(
@@ -398,9 +402,11 @@ def resolve_base_url_template(
     resolved_parts.append(base[last_index:])
     resolved = "".join(resolved_parts)
     if not matching.firewall_base_config_is_valid(resolved):
-        raise ValueError(f'builtin firewall "{firewall_name}" resolved base URL is invalid')
+        raise BuiltinBaseUrlResolutionError(
+            f'builtin firewall "{firewall_name}" resolved base URL is invalid'
+        )
     if has_unsafe_path(urllib.parse.urlsplit(resolved).path):
-        raise ValueError(
+        raise BuiltinBaseUrlResolutionError(
             f'builtin firewall "{firewall_name}" resolved base URL has unsafe path segments'
         )
     return resolved

--- a/crates/runner/mitm-addon/src/builtin_host_policy.py
+++ b/crates/runner/mitm-addon/src/builtin_host_policy.py
@@ -1,0 +1,344 @@
+"""Builtin firewall credentialed host policy validation."""
+
+import ipaddress
+import re
+import urllib.parse
+
+from firewall_auth_config import auth_config_injects_credentials
+from url_syntax import has_raw_whitespace, has_unsafe_url_codepoint
+
+_DEFAULT_HTTPS_PORT = 443
+_MIN_FIXED_HOST_OWNERSHIP_LABELS = 2
+_HOST_DOT_EQUIVALENT_TRANSLATION = str.maketrans(
+    {
+        "\u3002": ".",
+        "\uff0e": ".",
+        "\uff61": ".",
+    }
+)
+_HOST_POLICY_HOST_FORBIDDEN_CHARS = frozenset("%*[]/?#@\\:{}")
+_IPV4_LITERAL_COMPONENT_PATTERN = re.compile(r"(?:0[xX][0-9a-fA-F]+|[0-9]+)")
+_IPV4_LITERAL_MAX_COMPONENTS = 4
+_PROVIDER_OWNED_HOST_POLICY_KEYS = frozenset(
+    ("kind", "exactHosts", "suffixes", "allowNonDefaultPort")
+)
+_PUBLIC_DESTINATION_HOST_POLICY_KEYS = frozenset(("kind",))
+_IPV4_NON_PUBLIC_RANGES = (
+    (0x00000000, 0x00FFFFFF),
+    (0x0A000000, 0x0AFFFFFF),
+    (0x64400000, 0x647FFFFF),
+    (0x7F000000, 0x7FFFFFFF),
+    (0xA9FE0000, 0xA9FEFFFF),
+    (0xAC100000, 0xAC1FFFFF),
+    (0xC0000000, 0xC00000FF),
+    (0xC0000200, 0xC00002FF),
+    (0xC0586300, 0xC05863FF),
+    (0xC0A80000, 0xC0A8FFFF),
+    (0xC6120000, 0xC613FFFF),
+    (0xC6336400, 0xC63364FF),
+    (0xCB007100, 0xCB0071FF),
+    (0xE0000000, 0xFFFFFFFF),
+)
+_IPV6_GLOBAL_UNICAST_FIRST_MIN = 0x2000
+_IPV6_GLOBAL_UNICAST_FIRST_MAX = 0x3FFF
+_IPV6_IETF_PROTOCOL_ASSIGNMENTS_FIRST = 0x2001
+_IPV6_IETF_PROTOCOL_ASSIGNMENTS_SECOND_MAX = 0x01FF
+_IPV6_DOCUMENTATION_SECOND = 0x0DB8
+_IPV6_6TO4_FIRST = 0x2002
+_IPV6_SPECIAL_EXACT_SECOND = 0x0001
+_IPV6_AMT_SECOND = 0x0003
+_IPV6_AS112_SECOND = 0x0004
+_IPV6_AS112_THIRD = 0x0112
+_IPV6_ORCHID_SECOND_MIN = 0x0020
+_IPV6_ORCHID_SECOND_MAX = 0x002F
+_IPV6_DRONE_REMOTE_ID_SECOND_MIN = 0x0030
+_IPV6_DRONE_REMOTE_ID_SECOND_MAX = 0x003F
+
+
+def validate_credentialed_builtin_base(
+    *,
+    firewall_name: str,
+    base: str,
+    auth_config: object,
+    host_policy: object,
+) -> None:
+    if not auth_config_injects_credentials(auth_config):
+        return
+    parsed = urllib.parse.urlsplit(base)
+    scheme = parsed.scheme.lower()
+    if scheme != "https":
+        raise ValueError(f'builtin firewall "{firewall_name}" credentialed base URL must use https')
+    _validate_builtin_base_host_policy(
+        firewall_name=firewall_name,
+        parsed=parsed,
+        host_policy=host_policy,
+    )
+
+
+def _normalize_host_policy_hostname(hostname: str) -> str:
+    normalized = hostname.translate(_HOST_DOT_EQUIVALENT_TRANSLATION).lower()
+    if normalized.endswith("."):
+        return normalized[:-1]
+    return normalized
+
+
+def _host_policy_string_list(policy: dict, key: str) -> list[str]:
+    value = policy.get(key)
+    if value is None:
+        return []
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ValueError(f"builtin firewall hostPolicy.{key} must be a string list")
+    return value
+
+
+def _validate_host_policy_keys(
+    *,
+    firewall_name: str,
+    policy: dict,
+    allowed_keys: frozenset[str],
+) -> None:
+    extra_keys = sorted(set(policy) - allowed_keys)
+    if extra_keys:
+        joined = ", ".join(extra_keys)
+        raise ValueError(
+            f'builtin firewall "{firewall_name}" hostPolicy has unsupported keys: {joined}'
+        )
+
+
+def _host_policy_optional_bool(*, firewall_name: str, policy: dict, key: str) -> bool:
+    value = policy.get(key)
+    if value is None:
+        return False
+    if not isinstance(value, bool):
+        raise TypeError(f'builtin firewall "{firewall_name}" hostPolicy.{key} must be a boolean')
+    return value
+
+
+def _normalize_host_policy_suffix(suffix: str) -> str:
+    without_leading_dot = suffix[1:] if suffix.startswith(".") else suffix
+    return _normalize_host_policy_hostname(without_leading_dot)
+
+
+def _host_policy_host_is_ip_literal(hostname: str) -> bool:
+    try:
+        ipaddress.ip_address(hostname)
+    except ValueError:
+        return False
+    return True
+
+
+def _host_policy_host_is_ipv4_literal_like(hostname: str) -> bool:
+    parts = hostname.split(".")
+    return 1 <= len(parts) <= _IPV4_LITERAL_MAX_COMPONENTS and all(
+        _IPV4_LITERAL_COMPONENT_PATTERN.fullmatch(part) for part in parts
+    )
+
+
+def _host_policy_host_has_fixed_ownership(
+    hostname: str,
+    *,
+    allow_leading_dot: bool,
+) -> bool:
+    if not allow_leading_dot and hostname.startswith("."):
+        return False
+    raw_hostname = hostname[1:] if allow_leading_dot and hostname.startswith(".") else hostname
+    normalized = _normalize_host_policy_hostname(raw_hostname)
+    if (
+        not normalized
+        or not hostname.isascii()
+        or has_raw_whitespace(hostname)
+        or has_unsafe_url_codepoint(hostname)
+        or any(char in normalized for char in _HOST_POLICY_HOST_FORBIDDEN_CHARS)
+        or _host_policy_host_is_ip_literal(normalized)
+        or _host_policy_host_is_ipv4_literal_like(normalized)
+    ):
+        return False
+    labels = normalized.split(".")
+    return len(labels) >= _MIN_FIXED_HOST_OWNERSHIP_LABELS and all(labels)
+
+
+def _provider_owned_host_matches(
+    hostname: str,
+    *,
+    exact_hosts: list[str],
+    suffixes: list[str],
+) -> bool:
+    for exact_host in exact_hosts:
+        if hostname == _normalize_host_policy_hostname(exact_host):
+            return True
+    for suffix in suffixes:
+        normalized_suffix = _normalize_host_policy_suffix(suffix)
+        if (
+            normalized_suffix
+            and len(hostname) > len(normalized_suffix)
+            and hostname.endswith(f".{normalized_suffix}")
+        ):
+            return True
+    return False
+
+
+def _validate_provider_owned_host_policy(
+    *,
+    firewall_name: str,
+    parsed: urllib.parse.SplitResult,
+    policy: dict,
+) -> None:
+    if parsed.hostname is None:
+        raise ValueError(f'builtin firewall "{firewall_name}" resolved base URL is invalid')
+    hostname = _normalize_host_policy_hostname(parsed.hostname)
+    exact_hosts = _host_policy_string_list(policy, "exactHosts")
+    suffixes = _host_policy_string_list(policy, "suffixes")
+    allow_non_default_port = _host_policy_optional_bool(
+        firewall_name=firewall_name,
+        policy=policy,
+        key="allowNonDefaultPort",
+    )
+    if not exact_hosts and not suffixes:
+        raise ValueError(
+            f'builtin firewall "{firewall_name}" providerOwned hostPolicy '
+            "requires exactHosts or suffixes"
+        )
+    for exact_host in exact_hosts:
+        if not _host_policy_host_has_fixed_ownership(exact_host, allow_leading_dot=False):
+            raise ValueError(
+                f'builtin firewall "{firewall_name}" providerOwned hostPolicy '
+                "exactHosts must be fixed hostnames with at least two labels"
+            )
+    for suffix in suffixes:
+        if not _host_policy_host_has_fixed_ownership(suffix, allow_leading_dot=True):
+            raise ValueError(
+                f'builtin firewall "{firewall_name}" providerOwned hostPolicy '
+                "suffixes must be fixed hostnames with at least two labels"
+            )
+    if not _provider_owned_host_matches(
+        hostname,
+        exact_hosts=exact_hosts,
+        suffixes=suffixes,
+    ):
+        raise ValueError(
+            f'builtin firewall "{firewall_name}" host policy does not allow '
+            f'resolved host "{hostname}"'
+        )
+    if (
+        not allow_non_default_port
+        and parsed.port is not None
+        and parsed.port != _DEFAULT_HTTPS_PORT
+    ):
+        raise ValueError(
+            f'builtin firewall "{firewall_name}" host policy does not allow non-default ports'
+        )
+
+
+def _ip_literal_is_public(hostname: str) -> bool | None:
+    try:
+        ip = ipaddress.ip_address(hostname)
+    except ValueError:
+        return None
+    if isinstance(ip, ipaddress.IPv6Address):
+        if (
+            ip.scope_id is not None
+            or ip.ipv4_mapped is not None
+            or ip.sixtofour is not None
+            or ip.teredo is not None
+        ):
+            return False
+        return _ipv6_literal_is_public_unicast(ip)
+    return _ipv4_literal_is_public(ip)
+
+
+def _ipv4_literal_is_public(ip: ipaddress.IPv4Address) -> bool:
+    value = int(ip)
+    return not any(start <= value <= end for start, end in _IPV4_NON_PUBLIC_RANGES)
+
+
+def _ipv6_word(ip: ipaddress.IPv6Address, index: int) -> int:
+    return (int(ip) >> (112 - (index * 16))) & 0xFFFF
+
+
+def _ipv6_special_registry_exception(ip: ipaddress.IPv6Address) -> bool:
+    second = _ipv6_word(ip, 1)
+    if (
+        second == _IPV6_SPECIAL_EXACT_SECOND
+        and _ipv6_word(ip, 2) == 0
+        and _ipv6_word(ip, 3) == 0
+        and _ipv6_word(ip, 4) == 0
+        and _ipv6_word(ip, 5) == 0
+        and _ipv6_word(ip, 6) == 0
+        and _ipv6_word(ip, 7) in (1, 2)
+    ):
+        return True
+    if second == _IPV6_AMT_SECOND:
+        return True
+    if second == _IPV6_AS112_SECOND and _ipv6_word(ip, 2) == _IPV6_AS112_THIRD:
+        return True
+    if _IPV6_ORCHID_SECOND_MIN <= second <= _IPV6_ORCHID_SECOND_MAX:
+        return True
+    return _IPV6_DRONE_REMOTE_ID_SECOND_MIN <= second <= _IPV6_DRONE_REMOTE_ID_SECOND_MAX
+
+
+def _ipv6_literal_is_public_unicast(ip: ipaddress.IPv6Address) -> bool:
+    first = _ipv6_word(ip, 0)
+    second = _ipv6_word(ip, 1)
+    if first < _IPV6_GLOBAL_UNICAST_FIRST_MIN or first > _IPV6_GLOBAL_UNICAST_FIRST_MAX:
+        return False
+    if (
+        first == _IPV6_IETF_PROTOCOL_ASSIGNMENTS_FIRST
+        and second <= _IPV6_IETF_PROTOCOL_ASSIGNMENTS_SECOND_MAX
+    ):
+        return _ipv6_special_registry_exception(ip)
+    if first == _IPV6_IETF_PROTOCOL_ASSIGNMENTS_FIRST and second == _IPV6_DOCUMENTATION_SECOND:
+        return False
+    return first != _IPV6_6TO4_FIRST
+
+
+def _validate_public_destination_host_policy(
+    *,
+    firewall_name: str,
+    parsed: urllib.parse.SplitResult,
+) -> None:
+    if parsed.hostname is None:
+        raise ValueError(f'builtin firewall "{firewall_name}" resolved base URL is invalid')
+    hostname = _normalize_host_policy_hostname(parsed.hostname)
+    public_ip_literal = _ip_literal_is_public(hostname)
+    if public_ip_literal is False:
+        raise ValueError(
+            f'builtin firewall "{firewall_name}" host policy does not allow '
+            f'non-public IP literal "{hostname}"'
+        )
+
+
+def _validate_builtin_base_host_policy(
+    *,
+    firewall_name: str,
+    parsed: urllib.parse.SplitResult,
+    host_policy: object,
+) -> None:
+    if host_policy is None:
+        return
+    if not isinstance(host_policy, dict):
+        raise TypeError(f'builtin firewall "{firewall_name}" hostPolicy must be an object')
+    kind = host_policy.get("kind")
+    if kind == "providerOwned":
+        _validate_host_policy_keys(
+            firewall_name=firewall_name,
+            policy=host_policy,
+            allowed_keys=_PROVIDER_OWNED_HOST_POLICY_KEYS,
+        )
+        _validate_provider_owned_host_policy(
+            firewall_name=firewall_name,
+            parsed=parsed,
+            policy=host_policy,
+        )
+        return
+    if kind == "publicDestination":
+        _validate_host_policy_keys(
+            firewall_name=firewall_name,
+            policy=host_policy,
+            allowed_keys=_PUBLIC_DESTINATION_HOST_POLICY_KEYS,
+        )
+        _validate_public_destination_host_policy(
+            firewall_name=firewall_name,
+            parsed=parsed,
+        )
+        return
+    raise ValueError(f'builtin firewall "{firewall_name}" hostPolicy kind is invalid')

--- a/crates/runner/mitm-addon/src/builtin_host_policy.py
+++ b/crates/runner/mitm-addon/src/builtin_host_policy.py
@@ -55,6 +55,10 @@ _IPV6_DRONE_REMOTE_ID_SECOND_MIN = 0x0030
 _IPV6_DRONE_REMOTE_ID_SECOND_MAX = 0x003F
 
 
+class BuiltinHostPolicyError(ValueError):
+    """Builtin firewall host policy rejected a credentialed runtime base URL."""
+
+
 def validate_credentialed_builtin_base(
     *,
     firewall_name: str,
@@ -67,7 +71,9 @@ def validate_credentialed_builtin_base(
     parsed = urllib.parse.urlsplit(base)
     scheme = parsed.scheme.lower()
     if scheme != "https":
-        raise ValueError(f'builtin firewall "{firewall_name}" credentialed base URL must use https')
+        raise BuiltinHostPolicyError(
+            f'builtin firewall "{firewall_name}" credentialed base URL must use https'
+        )
     _validate_builtin_base_host_policy(
         firewall_name=firewall_name,
         parsed=parsed,
@@ -87,7 +93,7 @@ def _host_policy_string_list(policy: dict, key: str) -> list[str]:
     if value is None:
         return []
     if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
-        raise ValueError(f"builtin firewall hostPolicy.{key} must be a string list")
+        raise BuiltinHostPolicyError(f"builtin firewall hostPolicy.{key} must be a string list")
     return value
 
 
@@ -100,7 +106,7 @@ def _validate_host_policy_keys(
     extra_keys = sorted(set(policy) - allowed_keys)
     if extra_keys:
         joined = ", ".join(extra_keys)
-        raise ValueError(
+        raise BuiltinHostPolicyError(
             f'builtin firewall "{firewall_name}" hostPolicy has unsupported keys: {joined}'
         )
 
@@ -110,7 +116,9 @@ def _host_policy_optional_bool(*, firewall_name: str, policy: dict, key: str) ->
     if value is None:
         return False
     if not isinstance(value, bool):
-        raise TypeError(f'builtin firewall "{firewall_name}" hostPolicy.{key} must be a boolean')
+        raise BuiltinHostPolicyError(
+            f'builtin firewall "{firewall_name}" hostPolicy.{key} must be a boolean'
+        )
     return value
 
 
@@ -184,7 +192,9 @@ def _validate_provider_owned_host_policy(
     policy: dict,
 ) -> None:
     if parsed.hostname is None:
-        raise ValueError(f'builtin firewall "{firewall_name}" resolved base URL is invalid')
+        raise BuiltinHostPolicyError(
+            f'builtin firewall "{firewall_name}" resolved base URL is invalid'
+        )
     hostname = _normalize_host_policy_hostname(parsed.hostname)
     exact_hosts = _host_policy_string_list(policy, "exactHosts")
     suffixes = _host_policy_string_list(policy, "suffixes")
@@ -194,19 +204,19 @@ def _validate_provider_owned_host_policy(
         key="allowNonDefaultPort",
     )
     if not exact_hosts and not suffixes:
-        raise ValueError(
+        raise BuiltinHostPolicyError(
             f'builtin firewall "{firewall_name}" providerOwned hostPolicy '
             "requires exactHosts or suffixes"
         )
     for exact_host in exact_hosts:
         if not _host_policy_host_has_fixed_ownership(exact_host, allow_leading_dot=False):
-            raise ValueError(
+            raise BuiltinHostPolicyError(
                 f'builtin firewall "{firewall_name}" providerOwned hostPolicy '
                 "exactHosts must be fixed hostnames with at least two labels"
             )
     for suffix in suffixes:
         if not _host_policy_host_has_fixed_ownership(suffix, allow_leading_dot=True):
-            raise ValueError(
+            raise BuiltinHostPolicyError(
                 f'builtin firewall "{firewall_name}" providerOwned hostPolicy '
                 "suffixes must be fixed hostnames with at least two labels"
             )
@@ -215,7 +225,7 @@ def _validate_provider_owned_host_policy(
         exact_hosts=exact_hosts,
         suffixes=suffixes,
     ):
-        raise ValueError(
+        raise BuiltinHostPolicyError(
             f'builtin firewall "{firewall_name}" host policy does not allow '
             f'resolved host "{hostname}"'
         )
@@ -224,7 +234,7 @@ def _validate_provider_owned_host_policy(
         and parsed.port is not None
         and parsed.port != _DEFAULT_HTTPS_PORT
     ):
-        raise ValueError(
+        raise BuiltinHostPolicyError(
             f'builtin firewall "{firewall_name}" host policy does not allow non-default ports'
         )
 
@@ -297,11 +307,13 @@ def _validate_public_destination_host_policy(
     parsed: urllib.parse.SplitResult,
 ) -> None:
     if parsed.hostname is None:
-        raise ValueError(f'builtin firewall "{firewall_name}" resolved base URL is invalid')
+        raise BuiltinHostPolicyError(
+            f'builtin firewall "{firewall_name}" resolved base URL is invalid'
+        )
     hostname = _normalize_host_policy_hostname(parsed.hostname)
     public_ip_literal = _ip_literal_is_public(hostname)
     if public_ip_literal is False:
-        raise ValueError(
+        raise BuiltinHostPolicyError(
             f'builtin firewall "{firewall_name}" host policy does not allow '
             f'non-public IP literal "{hostname}"'
         )
@@ -316,7 +328,9 @@ def _validate_builtin_base_host_policy(
     if host_policy is None:
         return
     if not isinstance(host_policy, dict):
-        raise TypeError(f'builtin firewall "{firewall_name}" hostPolicy must be an object')
+        raise BuiltinHostPolicyError(
+            f'builtin firewall "{firewall_name}" hostPolicy must be an object'
+        )
     kind = host_policy.get("kind")
     if kind == "providerOwned":
         _validate_host_policy_keys(
@@ -341,4 +355,4 @@ def _validate_builtin_base_host_policy(
             parsed=parsed,
         )
         return
-    raise ValueError(f'builtin firewall "{firewall_name}" hostPolicy kind is invalid')
+    raise BuiltinHostPolicyError(f'builtin firewall "{firewall_name}" hostPolicy kind is invalid')

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -1,12 +1,8 @@
 """Proxy registry loading and VM lookup cache."""
 
-import copy
-import ipaddress
 import json
 import os
-import re
 import stat
-import urllib.parse
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -14,12 +10,8 @@ from pathlib import Path
 from mitmproxy import ctx
 
 import matching
-from authority_utils import percent_decode_host
+import registry_firewalls
 from firewall_auth_cache import evict_all_cache_keys, evict_stale_cache_keys
-from firewall_auth_config import auth_config_injects_credentials
-from generated.builtin_firewalls import BUILTIN_FIREWALLS
-from path_security import has_unsafe_path
-from url_syntax import has_raw_whitespace, has_unsafe_url_codepoint
 
 VmContext = tuple[
     dict,
@@ -27,72 +19,12 @@ VmContext = tuple[
     matching.CompiledNetworkPolicies,
 ]
 _RegistryCacheKey = tuple[str, int, int, int, int]
-_BuiltinFirewallCoreCacheKey = tuple[str, int, tuple[tuple[str, str], ...], tuple[str, ...]]
 MAX_REGISTRY_BYTES = 16 * 1024 * 1024
 _READ_CHUNK_BYTES = 1024 * 1024
-_BASE_URL_VAR_PATTERN = re.compile(r"\$\{\{\s*vars\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}")
-_URL_COMPONENT_DELIMITER_PATTERN = re.compile(r"[/?#]")
-_AUTHORITY_VAR_STRUCTURE_CHARS = frozenset(("/", "?", "#", "@", "\\"))
-_AUTHORITY_FRAGMENT_VAR_STRUCTURE_CHARS = frozenset(("/", ":", "?", "#", "@", "\\"))
-_PERCENT_DECODED_BOUNDARY_CHARS = frozenset(("/", ":", "?", "#", "@", "\\"))
-_BASE_URL_VAR_PARAMETER_CHARS = frozenset(("{", "}"))
-_PATH_VAR_STRUCTURE_CHARS = frozenset(("/", "?", "#", "\\"))
-_PORT_VAR_PATTERN = re.compile(r"^[0-9]+$")
-_DEFAULT_HTTPS_PORT = 443
-_MAX_PATH_VAR_PERCENT_DECODE_PASSES = 5
-_MIN_FIXED_HOST_OWNERSHIP_LABELS = 2
-_HOST_DOT_EQUIVALENT_TRANSLATION = str.maketrans(
-    {
-        "\u3002": ".",
-        "\uff0e": ".",
-        "\uff61": ".",
-    }
-)
-_HOST_POLICY_HOST_FORBIDDEN_CHARS = frozenset("%*[]/?#@\\:{}")
-_IPV4_LITERAL_COMPONENT_PATTERN = re.compile(r"(?:0[xX][0-9a-fA-F]+|[0-9]+)")
-_IPV4_LITERAL_MAX_COMPONENTS = 4
-_PROVIDER_OWNED_HOST_POLICY_KEYS = frozenset(
-    ("kind", "exactHosts", "suffixes", "allowNonDefaultPort")
-)
-_PUBLIC_DESTINATION_HOST_POLICY_KEYS = frozenset(("kind",))
-_IPV4_NON_PUBLIC_RANGES = (
-    (0x00000000, 0x00FFFFFF),
-    (0x0A000000, 0x0AFFFFFF),
-    (0x64400000, 0x647FFFFF),
-    (0x7F000000, 0x7FFFFFFF),
-    (0xA9FE0000, 0xA9FEFFFF),
-    (0xAC100000, 0xAC1FFFFF),
-    (0xC0000000, 0xC00000FF),
-    (0xC0000200, 0xC00002FF),
-    (0xC0586300, 0xC05863FF),
-    (0xC0A80000, 0xC0A8FFFF),
-    (0xC6120000, 0xC613FFFF),
-    (0xC6336400, 0xC63364FF),
-    (0xCB007100, 0xCB0071FF),
-    (0xE0000000, 0xFFFFFFFF),
-)
-_IPV6_GLOBAL_UNICAST_FIRST_MIN = 0x2000
-_IPV6_GLOBAL_UNICAST_FIRST_MAX = 0x3FFF
-_IPV6_IETF_PROTOCOL_ASSIGNMENTS_FIRST = 0x2001
-_IPV6_IETF_PROTOCOL_ASSIGNMENTS_SECOND_MAX = 0x01FF
-_IPV6_DOCUMENTATION_SECOND = 0x0DB8
-_IPV6_6TO4_FIRST = 0x2002
-_IPV6_SPECIAL_EXACT_SECOND = 0x0001
-_IPV6_AMT_SECOND = 0x0003
-_IPV6_AS112_SECOND = 0x0004
-_IPV6_AS112_THIRD = 0x0112
-_IPV6_ORCHID_SECOND_MIN = 0x0020
-_IPV6_ORCHID_SECOND_MAX = 0x002F
-_IPV6_DRONE_REMOTE_ID_SECOND_MIN = 0x0030
-_IPV6_DRONE_REMOTE_ID_SECOND_MAX = 0x003F
 
 
 class _RegistryFormatError(ValueError):
     """Registry JSON decoded successfully but does not have the expected shape."""
-
-
-class _FirewallEntryResolutionError(ValueError):
-    """Execution firewall entries could not be expanded into runtime configs."""
 
 
 @dataclass(frozen=True)
@@ -110,18 +42,6 @@ class _RegistrySnapshot:
     compiled_firewalls: dict[str, matching.CompiledFirewallSet]
     compiled_network_policies: dict[str, matching.CompiledNetworkPolicies]
     loaded_key: _RegistryCacheKey | None
-
-
-@dataclass(frozen=True)
-class _ResolvedBuiltinFirewallEntry:
-    firewall: dict
-    cache_key: _BuiltinFirewallCoreCacheKey
-
-
-@dataclass(frozen=True)
-class _ResolvedFirewallEntries:
-    firewalls: list[dict] | None
-    builtin_cache_keys: tuple[_BuiltinFirewallCoreCacheKey | None, ...] | None
 
 
 @dataclass(frozen=True)
@@ -156,7 +76,7 @@ class _RegistryCacheState:
     stat_error_logged: bool = False
     read_error_key: _RegistryCacheKey | None = None
     builtin_firewall_core_cache: dict[
-        _BuiltinFirewallCoreCacheKey,
+        registry_firewalls.BuiltinFirewallCoreCacheKey,
         matching.CompiledFirewallCore,
     ] = field(default_factory=dict)
 
@@ -192,9 +112,12 @@ def _state_for_path(path_key: str) -> _RegistryCacheState:
 
 def _compile_registry(
     new_registry: dict,
-    builtin_cache_keys: dict[str, tuple[_BuiltinFirewallCoreCacheKey | None, ...]],
+    builtin_cache_keys: dict[
+        str,
+        tuple[registry_firewalls.BuiltinFirewallCoreCacheKey | None, ...],
+    ],
     builtin_firewall_core_cache: dict[
-        _BuiltinFirewallCoreCacheKey,
+        registry_firewalls.BuiltinFirewallCoreCacheKey,
         matching.CompiledFirewallCore,
     ],
 ) -> tuple[
@@ -220,10 +143,10 @@ def _compile_registry(
 
 def _prune_builtin_firewall_core_cache(
     builtin_firewall_core_cache: dict[
-        _BuiltinFirewallCoreCacheKey,
+        registry_firewalls.BuiltinFirewallCoreCacheKey,
         matching.CompiledFirewallCore,
     ],
-    active_key_groups: Iterable[tuple[_BuiltinFirewallCoreCacheKey | None, ...]],
+    active_key_groups: Iterable[tuple[registry_firewalls.BuiltinFirewallCoreCacheKey | None, ...]],
 ) -> None:
     active_keys = {
         cache_key
@@ -238,9 +161,9 @@ def _prune_builtin_firewall_core_cache(
 
 def _compile_firewalls_with_builtin_cache(
     firewalls: object | None,
-    builtin_cache_keys: tuple[_BuiltinFirewallCoreCacheKey | None, ...] | None,
+    builtin_cache_keys: tuple[registry_firewalls.BuiltinFirewallCoreCacheKey | None, ...] | None,
     builtin_firewall_core_cache: dict[
-        _BuiltinFirewallCoreCacheKey,
+        registry_firewalls.BuiltinFirewallCoreCacheKey,
         matching.CompiledFirewallCore,
     ],
 ) -> matching.CompiledFirewallSet | None:
@@ -274,832 +197,18 @@ def _compile_firewalls_with_builtin_cache(
     return matching.CompiledFirewallSet(tuple(compiled_firewalls))
 
 
-def _string_record(value: object, field_name: str) -> dict[str, str]:
-    if not isinstance(value, dict):
-        raise _FirewallEntryResolutionError(f"{field_name} must be an object")
-
-    result: dict[str, str] = {}
-    for key, nested in value.items():
-        if not isinstance(key, str) or not isinstance(nested, str):
-            raise _FirewallEntryResolutionError(f"{field_name} must contain string values")
-        result[key] = nested
-    return result
-
-
-def _base_url_vars_for_entry(entry: dict) -> dict[str, str]:
-    if "baseUrlVars" in entry:
-        return _string_record(entry["baseUrlVars"], "baseUrlVars")
-    return {}
-
-
-def _base_url_variable_error(
-    *,
-    firewall_name: str,
-    base: str,
-    name: str,
-    detail: str,
-) -> _FirewallEntryResolutionError:
-    return _FirewallEntryResolutionError(
-        f'builtin firewall "{firewall_name}" base URL variable "{name}" {detail}: {base}'
-    )
-
-
-def _validate_base_url_variable_common_syntax(
-    *,
-    firewall_name: str,
-    base: str,
-    name: str,
-    value: str,
-) -> None:
-    if has_raw_whitespace(value) or any(char.isspace() for char in value):
-        raise _base_url_variable_error(
-            firewall_name=firewall_name,
-            base=base,
-            name=name,
-            detail="must not contain whitespace",
-        )
-    if has_unsafe_url_codepoint(value):
-        raise _base_url_variable_error(
-            firewall_name=firewall_name,
-            base=base,
-            name=name,
-            detail="must not contain control characters or invalid Unicode",
-        )
-    if any(char in _BASE_URL_VAR_PARAMETER_CHARS for char in value):
-        raise _base_url_variable_error(
-            firewall_name=firewall_name,
-            base=base,
-            name=name,
-            detail="must not contain firewall parameter syntax",
-        )
-
-
-def _validate_base_url_variable_percent_encoding(
-    *,
-    firewall_name: str,
-    base: str,
-    name: str,
-    value: str,
-    structure_chars: frozenset[str] = _PERCENT_DECODED_BOUNDARY_CHARS,
-) -> str:
-    decoded = percent_decode_host(value, syntax_chars=structure_chars)
-    if decoded.invalid_encoding:
-        raise _base_url_variable_error(
-            firewall_name=firewall_name,
-            base=base,
-            name=name,
-            detail="has invalid percent encoding",
-        )
-    if decoded.decoded_syntax or any(char.isspace() for char in decoded.value):
-        raise _base_url_variable_error(
-            firewall_name=firewall_name,
-            base=base,
-            name=name,
-            detail="must not contain encoded URL structure",
-        )
-    if has_unsafe_url_codepoint(decoded.value):
-        raise _base_url_variable_error(
-            firewall_name=firewall_name,
-            base=base,
-            name=name,
-            detail="must not contain encoded control characters or invalid Unicode",
-        )
-    return decoded.value
-
-
-def _path_variable_value_has_encoded_structure(value: str) -> bool:
-    current = value
-    for _ in range(_MAX_PATH_VAR_PERCENT_DECODE_PASSES):
-        decoded = percent_decode_host(current, syntax_chars=_PATH_VAR_STRUCTURE_CHARS)
-        if (
-            decoded.invalid_encoding
-            or decoded.decoded_syntax
-            or any(char.isspace() for char in decoded.value)
-            or has_unsafe_url_codepoint(decoded.value)
-        ):
-            return True
-        if decoded.value == current:
-            return False
-        current = decoded.value
-
-    decoded = percent_decode_host(current, syntax_chars=_PATH_VAR_STRUCTURE_CHARS)
-    return (
-        decoded.invalid_encoding
-        or decoded.decoded_syntax
-        or decoded.value != current
-        or any(char.isspace() for char in decoded.value)
-        or has_unsafe_url_codepoint(decoded.value)
-    )
-
-
-def _validate_base_url_prefix_variable(
-    *,
-    firewall_name: str,
-    base: str,
-    name: str,
-    value: str,
-) -> None:
-    if not matching.firewall_base_config_is_valid(value):
-        raise _base_url_variable_error(
-            firewall_name=firewall_name,
-            base=base,
-            name=name,
-            detail="must be a valid base URL before a fixed path suffix",
-        )
-    parts = urllib.parse.urlsplit(value)
-    if parts.query or parts.fragment:
-        raise _base_url_variable_error(
-            firewall_name=firewall_name,
-            base=base,
-            name=name,
-            detail="must not contain query or fragment before a fixed path suffix",
-        )
-    if has_unsafe_path(parts.path):
-        raise _base_url_variable_error(
-            firewall_name=firewall_name,
-            base=base,
-            name=name,
-            detail="must not contain unsafe path segments before a fixed path suffix",
-        )
-
-
-def _validate_base_url_authority_variable(
-    *,
-    firewall_name: str,
-    base: str,
-    name: str,
-    value: str,
-) -> None:
-    if any(char in _AUTHORITY_VAR_STRUCTURE_CHARS for char in value):
-        raise _base_url_variable_error(
-            firewall_name=firewall_name,
-            base=base,
-            name=name,
-            detail="must not introduce URL structure",
-        )
-    _validate_base_url_variable_percent_encoding(
-        firewall_name=firewall_name,
-        base=base,
-        name=name,
-        value=value,
-    )
-    if not matching.firewall_base_config_is_valid(f"https://{value}"):
-        raise _base_url_variable_error(
-            firewall_name=firewall_name,
-            base=base,
-            name=name,
-            detail="must be a valid URL authority",
-        )
-
-
-def _validate_base_url_authority_fragment_variable(
-    *,
-    firewall_name: str,
-    base: str,
-    name: str,
-    value: str,
-) -> None:
-    if any(char in _AUTHORITY_FRAGMENT_VAR_STRUCTURE_CHARS for char in value):
-        raise _base_url_variable_error(
-            firewall_name=firewall_name,
-            base=base,
-            name=name,
-            detail="must not introduce URL structure",
-        )
-    _validate_base_url_variable_percent_encoding(
-        firewall_name=firewall_name,
-        base=base,
-        name=name,
-        value=value,
-    )
-
-
-def _validate_base_url_port_variable(
-    *,
-    firewall_name: str,
-    base: str,
-    name: str,
-    value: str,
-) -> None:
-    if _PORT_VAR_PATTERN.fullmatch(value) is None:
-        raise _base_url_variable_error(
-            firewall_name=firewall_name,
-            base=base,
-            name=name,
-            detail="must be a numeric URL port",
-        )
-
-
-def _validate_base_url_path_variable(
-    *,
-    firewall_name: str,
-    base: str,
-    name: str,
-    value: str,
-    prefix: str,
-    suffix: str,
-) -> None:
-    if any(char in _PATH_VAR_STRUCTURE_CHARS for char in value):
-        raise _base_url_variable_error(
-            firewall_name=firewall_name,
-            base=base,
-            name=name,
-            detail="must not introduce path structure",
-        )
-    decoded = _validate_base_url_variable_percent_encoding(
-        firewall_name=firewall_name,
-        base=base,
-        name=name,
-        value=value,
-        structure_chars=_PATH_VAR_STRUCTURE_CHARS,
-    )
-    prefix_segment = prefix[prefix.rfind("/") + 1 :]
-    suffix_delimiter = _URL_COMPONENT_DELIMITER_PATTERN.search(suffix)
-    suffix_segment = suffix if suffix_delimiter is None else suffix[: suffix_delimiter.start()]
-    if _path_variable_value_has_encoded_structure(decoded) or has_unsafe_path(
-        f"/{prefix_segment}{decoded}{suffix_segment}"
-    ):
-        raise _base_url_variable_error(
-            firewall_name=firewall_name,
-            base=base,
-            name=name,
-            detail="must not contain unsafe path segments",
-        )
-
-
-def _prefix_is_inside_authority(prefix: str) -> bool:
-    scheme_end = prefix.find("://")
-    if scheme_end == -1:
-        return False
-    after_scheme = prefix[scheme_end + 3 :]
-    return _URL_COMPONENT_DELIMITER_PATTERN.search(after_scheme) is None
-
-
-def _prefix_is_inside_path(prefix: str) -> bool:
-    scheme_end = prefix.find("://")
-    if scheme_end == -1:
-        return False
-    after_scheme = prefix[scheme_end + 3 :]
-    if "?" in after_scheme or "#" in after_scheme:
-        return False
-    return "/" in after_scheme
-
-
-def _suffix_authority_prefix(suffix: str) -> str:
-    delimiter = _URL_COMPONENT_DELIMITER_PATTERN.search(suffix)
-    if delimiter is None:
-        return suffix
-    return suffix[: delimiter.start()]
-
-
-def _validate_base_url_template_variable(
-    *,
-    firewall_name: str,
-    base: str,
-    name: str,
-    value: str,
-    prefix: str,
-    suffix: str,
-) -> None:
-    _validate_base_url_variable_common_syntax(
-        firewall_name=firewall_name,
-        base=base,
-        name=name,
-        value=value,
-    )
-    if prefix == "" and suffix == "":
-        return
-    if prefix == "" and suffix.startswith("/"):
-        _validate_base_url_prefix_variable(
-            firewall_name=firewall_name,
-            base=base,
-            name=name,
-            value=value,
-        )
-        return
-    if prefix.endswith("://") and (suffix == "" or suffix.startswith("/")):
-        _validate_base_url_authority_variable(
-            firewall_name=firewall_name,
-            base=base,
-            name=name,
-            value=value,
-        )
-        return
-    if (
-        _prefix_is_inside_authority(prefix)
-        and prefix.endswith(":")
-        and (suffix == "" or suffix.startswith("/"))
-    ):
-        _validate_base_url_port_variable(
-            firewall_name=firewall_name,
-            base=base,
-            name=name,
-            value=value,
-        )
-        return
-    if _prefix_is_inside_authority(prefix) and _suffix_authority_prefix(suffix) != "":
-        _validate_base_url_authority_fragment_variable(
-            firewall_name=firewall_name,
-            base=base,
-            name=name,
-            value=value,
-        )
-        return
-    if _prefix_is_inside_path(prefix):
-        _validate_base_url_path_variable(
-            firewall_name=firewall_name,
-            base=base,
-            name=name,
-            value=value,
-            prefix=prefix,
-            suffix=suffix,
-        )
-        return
-    raise _base_url_variable_error(
-        firewall_name=firewall_name,
-        base=base,
-        name=name,
-        detail="is used in an unsupported base URL template position",
-    )
-
-
-def _resolve_base_url_template(
-    *,
-    firewall_name: str,
-    base: str,
-    vars_map: dict[str, str],
-) -> str:
-    resolved_parts: list[str] = []
-    last_index = 0
-    for match in _BASE_URL_VAR_PATTERN.finditer(base):
-        name = match.group(1)
-        value = vars_map.get(name)
-        if not value:
-            raise _FirewallEntryResolutionError(
-                f'builtin firewall "{firewall_name}" base URL requires variable "{name}"'
-            )
-        _validate_base_url_template_variable(
-            firewall_name=firewall_name,
-            base=base,
-            name=name,
-            value=value,
-            prefix=base[: match.start()],
-            suffix=base[match.end() :],
-        )
-        resolved_parts.append(base[last_index : match.start()])
-        resolved_parts.append(value)
-        last_index = match.end()
-
-    resolved_parts.append(base[last_index:])
-    resolved = "".join(resolved_parts)
-    if not matching.firewall_base_config_is_valid(resolved):
-        raise _FirewallEntryResolutionError(
-            f'builtin firewall "{firewall_name}" resolved base URL is invalid'
-        )
-    if has_unsafe_path(urllib.parse.urlsplit(resolved).path):
-        raise _FirewallEntryResolutionError(
-            f'builtin firewall "{firewall_name}" resolved base URL has unsafe path segments'
-        )
-    return resolved
-
-
-def _validate_credentialed_builtin_base(
-    *,
-    firewall_name: str,
-    base: str,
-    auth_config: object,
-    host_policy: object,
-) -> None:
-    if not auth_config_injects_credentials(auth_config):
-        return
-    parsed = urllib.parse.urlsplit(base)
-    scheme = parsed.scheme.lower()
-    if scheme != "https":
-        raise _FirewallEntryResolutionError(
-            f'builtin firewall "{firewall_name}" credentialed base URL must use https'
-        )
-    _validate_builtin_base_host_policy(
-        firewall_name=firewall_name,
-        parsed=parsed,
-        host_policy=host_policy,
-    )
-
-
-def _normalize_host_policy_hostname(hostname: str) -> str:
-    normalized = hostname.translate(_HOST_DOT_EQUIVALENT_TRANSLATION).lower()
-    if normalized.endswith("."):
-        return normalized[:-1]
-    return normalized
-
-
-def _host_policy_string_list(policy: dict, key: str) -> list[str]:
-    value = policy.get(key)
-    if value is None:
-        return []
-    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
-        raise _FirewallEntryResolutionError(
-            f"builtin firewall hostPolicy.{key} must be a string list"
-        )
-    return value
-
-
-def _validate_host_policy_keys(
-    *,
-    firewall_name: str,
-    policy: dict,
-    allowed_keys: frozenset[str],
-) -> None:
-    extra_keys = sorted(set(policy) - allowed_keys)
-    if extra_keys:
-        joined = ", ".join(extra_keys)
-        raise _FirewallEntryResolutionError(
-            f'builtin firewall "{firewall_name}" hostPolicy has unsupported keys: {joined}'
-        )
-
-
-def _host_policy_optional_bool(*, firewall_name: str, policy: dict, key: str) -> bool:
-    value = policy.get(key)
-    if value is None:
-        return False
-    if not isinstance(value, bool):
-        raise _FirewallEntryResolutionError(
-            f'builtin firewall "{firewall_name}" hostPolicy.{key} must be a boolean'
-        )
-    return value
-
-
-def _normalize_host_policy_suffix(suffix: str) -> str:
-    without_leading_dot = suffix[1:] if suffix.startswith(".") else suffix
-    return _normalize_host_policy_hostname(without_leading_dot)
-
-
-def _host_policy_host_is_ip_literal(hostname: str) -> bool:
-    try:
-        ipaddress.ip_address(hostname)
-    except ValueError:
-        return False
-    return True
-
-
-def _host_policy_host_is_ipv4_literal_like(hostname: str) -> bool:
-    parts = hostname.split(".")
-    return 1 <= len(parts) <= _IPV4_LITERAL_MAX_COMPONENTS and all(
-        _IPV4_LITERAL_COMPONENT_PATTERN.fullmatch(part) for part in parts
-    )
-
-
-def _host_policy_host_has_fixed_ownership(
-    hostname: str,
-    *,
-    allow_leading_dot: bool,
-) -> bool:
-    if not allow_leading_dot and hostname.startswith("."):
-        return False
-    raw_hostname = hostname[1:] if allow_leading_dot and hostname.startswith(".") else hostname
-    normalized = _normalize_host_policy_hostname(raw_hostname)
-    if (
-        not normalized
-        or not hostname.isascii()
-        or has_raw_whitespace(hostname)
-        or has_unsafe_url_codepoint(hostname)
-        or any(char in normalized for char in _HOST_POLICY_HOST_FORBIDDEN_CHARS)
-        or _host_policy_host_is_ip_literal(normalized)
-        or _host_policy_host_is_ipv4_literal_like(normalized)
-    ):
-        return False
-    labels = normalized.split(".")
-    return len(labels) >= _MIN_FIXED_HOST_OWNERSHIP_LABELS and all(labels)
-
-
-def _provider_owned_host_matches(
-    hostname: str,
-    *,
-    exact_hosts: list[str],
-    suffixes: list[str],
-) -> bool:
-    for exact_host in exact_hosts:
-        if hostname == _normalize_host_policy_hostname(exact_host):
-            return True
-    for suffix in suffixes:
-        normalized_suffix = _normalize_host_policy_suffix(suffix)
-        if (
-            normalized_suffix
-            and len(hostname) > len(normalized_suffix)
-            and hostname.endswith(f".{normalized_suffix}")
-        ):
-            return True
-    return False
-
-
-def _validate_provider_owned_host_policy(
-    *,
-    firewall_name: str,
-    parsed: urllib.parse.SplitResult,
-    policy: dict,
-) -> None:
-    if parsed.hostname is None:
-        raise _FirewallEntryResolutionError(
-            f'builtin firewall "{firewall_name}" resolved base URL is invalid'
-        )
-    hostname = _normalize_host_policy_hostname(parsed.hostname)
-    exact_hosts = _host_policy_string_list(policy, "exactHosts")
-    suffixes = _host_policy_string_list(policy, "suffixes")
-    allow_non_default_port = _host_policy_optional_bool(
-        firewall_name=firewall_name,
-        policy=policy,
-        key="allowNonDefaultPort",
-    )
-    if not exact_hosts and not suffixes:
-        raise _FirewallEntryResolutionError(
-            f'builtin firewall "{firewall_name}" providerOwned hostPolicy '
-            "requires exactHosts or suffixes"
-        )
-    for exact_host in exact_hosts:
-        if not _host_policy_host_has_fixed_ownership(exact_host, allow_leading_dot=False):
-            raise _FirewallEntryResolutionError(
-                f'builtin firewall "{firewall_name}" providerOwned hostPolicy '
-                "exactHosts must be fixed hostnames with at least two labels"
-            )
-    for suffix in suffixes:
-        if not _host_policy_host_has_fixed_ownership(suffix, allow_leading_dot=True):
-            raise _FirewallEntryResolutionError(
-                f'builtin firewall "{firewall_name}" providerOwned hostPolicy '
-                "suffixes must be fixed hostnames with at least two labels"
-            )
-    if not _provider_owned_host_matches(
-        hostname,
-        exact_hosts=exact_hosts,
-        suffixes=suffixes,
-    ):
-        raise _FirewallEntryResolutionError(
-            f'builtin firewall "{firewall_name}" host policy does not allow '
-            f'resolved host "{hostname}"'
-        )
-    if (
-        not allow_non_default_port
-        and parsed.port is not None
-        and parsed.port != _DEFAULT_HTTPS_PORT
-    ):
-        raise _FirewallEntryResolutionError(
-            f'builtin firewall "{firewall_name}" host policy does not allow non-default ports'
-        )
-
-
-def _ip_literal_is_public(hostname: str) -> bool | None:
-    try:
-        ip = ipaddress.ip_address(hostname)
-    except ValueError:
-        return None
-    if isinstance(ip, ipaddress.IPv6Address):
-        if (
-            ip.scope_id is not None
-            or ip.ipv4_mapped is not None
-            or ip.sixtofour is not None
-            or ip.teredo is not None
-        ):
-            return False
-        return _ipv6_literal_is_public_unicast(ip)
-    return _ipv4_literal_is_public(ip)
-
-
-def _ipv4_literal_is_public(ip: ipaddress.IPv4Address) -> bool:
-    value = int(ip)
-    return not any(start <= value <= end for start, end in _IPV4_NON_PUBLIC_RANGES)
-
-
-def _ipv6_word(ip: ipaddress.IPv6Address, index: int) -> int:
-    return (int(ip) >> (112 - (index * 16))) & 0xFFFF
-
-
-def _ipv6_special_registry_exception(ip: ipaddress.IPv6Address) -> bool:
-    second = _ipv6_word(ip, 1)
-    if (
-        second == _IPV6_SPECIAL_EXACT_SECOND
-        and _ipv6_word(ip, 2) == 0
-        and _ipv6_word(ip, 3) == 0
-        and _ipv6_word(ip, 4) == 0
-        and _ipv6_word(ip, 5) == 0
-        and _ipv6_word(ip, 6) == 0
-        and _ipv6_word(ip, 7) in (1, 2)
-    ):
-        return True
-    if second == _IPV6_AMT_SECOND:
-        return True
-    if second == _IPV6_AS112_SECOND and _ipv6_word(ip, 2) == _IPV6_AS112_THIRD:
-        return True
-    if _IPV6_ORCHID_SECOND_MIN <= second <= _IPV6_ORCHID_SECOND_MAX:
-        return True
-    return _IPV6_DRONE_REMOTE_ID_SECOND_MIN <= second <= _IPV6_DRONE_REMOTE_ID_SECOND_MAX
-
-
-def _ipv6_literal_is_public_unicast(ip: ipaddress.IPv6Address) -> bool:
-    first = _ipv6_word(ip, 0)
-    second = _ipv6_word(ip, 1)
-    if first < _IPV6_GLOBAL_UNICAST_FIRST_MIN or first > _IPV6_GLOBAL_UNICAST_FIRST_MAX:
-        return False
-    if (
-        first == _IPV6_IETF_PROTOCOL_ASSIGNMENTS_FIRST
-        and second <= _IPV6_IETF_PROTOCOL_ASSIGNMENTS_SECOND_MAX
-    ):
-        return _ipv6_special_registry_exception(ip)
-    if first == _IPV6_IETF_PROTOCOL_ASSIGNMENTS_FIRST and second == _IPV6_DOCUMENTATION_SECOND:
-        return False
-    return first != _IPV6_6TO4_FIRST
-
-
-def _validate_public_destination_host_policy(
-    *,
-    firewall_name: str,
-    parsed: urllib.parse.SplitResult,
-) -> None:
-    if parsed.hostname is None:
-        raise _FirewallEntryResolutionError(
-            f'builtin firewall "{firewall_name}" resolved base URL is invalid'
-        )
-    hostname = _normalize_host_policy_hostname(parsed.hostname)
-    public_ip_literal = _ip_literal_is_public(hostname)
-    if public_ip_literal is False:
-        raise _FirewallEntryResolutionError(
-            f'builtin firewall "{firewall_name}" host policy does not allow '
-            f'non-public IP literal "{hostname}"'
-        )
-
-
-def _validate_builtin_base_host_policy(
-    *,
-    firewall_name: str,
-    parsed: urllib.parse.SplitResult,
-    host_policy: object,
-) -> None:
-    if host_policy is None:
-        return
-    if not isinstance(host_policy, dict):
-        raise _FirewallEntryResolutionError(
-            f'builtin firewall "{firewall_name}" hostPolicy must be an object'
-        )
-    kind = host_policy.get("kind")
-    if kind == "providerOwned":
-        _validate_host_policy_keys(
-            firewall_name=firewall_name,
-            policy=host_policy,
-            allowed_keys=_PROVIDER_OWNED_HOST_POLICY_KEYS,
-        )
-        _validate_provider_owned_host_policy(
-            firewall_name=firewall_name,
-            parsed=parsed,
-            policy=host_policy,
-        )
-        return
-    if kind == "publicDestination":
-        _validate_host_policy_keys(
-            firewall_name=firewall_name,
-            policy=host_policy,
-            allowed_keys=_PUBLIC_DESTINATION_HOST_POLICY_KEYS,
-        )
-        _validate_public_destination_host_policy(
-            firewall_name=firewall_name,
-            parsed=parsed,
-        )
-        return
-    raise _FirewallEntryResolutionError(
-        f'builtin firewall "{firewall_name}" hostPolicy kind is invalid'
-    )
-
-
-def _copy_builtin_firewall_shell(
-    *,
-    firewall_name: str,
-    catalog_firewall: dict,
-) -> tuple[dict, list[dict]]:
-    raw_apis = catalog_firewall.get("apis")
-    if not isinstance(raw_apis, list):
-        raise _FirewallEntryResolutionError(
-            f'builtin firewall "{firewall_name}" apis must be a list'
-        )
-
-    copied_apis: list[dict] = []
-    for api in raw_apis:
-        if not isinstance(api, dict):
-            raise _FirewallEntryResolutionError(
-                f'builtin firewall "{firewall_name}" api entries must be objects'
-            )
-        copied_apis.append(dict(api))
-
-    firewall = dict(catalog_firewall)
-    firewall["apis"] = copied_apis
-    return firewall, copied_apis
-
-
-def _resolve_builtin_firewall_entry(entry: dict) -> _ResolvedBuiltinFirewallEntry:
-    raw_name = entry.get("name")
-    if not isinstance(raw_name, str) or raw_name == "":
-        raise _FirewallEntryResolutionError(
-            "builtin firewall entry name must be a non-empty string"
-        )
-
-    catalog_firewall = BUILTIN_FIREWALLS.get(raw_name)
-    if catalog_firewall is None:
-        raise _FirewallEntryResolutionError(f'unknown builtin firewall "{raw_name}"')
-
-    firewall, raw_apis = _copy_builtin_firewall_shell(
-        firewall_name=raw_name,
-        catalog_firewall=catalog_firewall,
-    )
-
-    vars_map = _base_url_vars_for_entry(entry)
-    resolved_bases: list[str] = []
-    for api in raw_apis:
-        raw_base = api.get("base")
-        if not isinstance(raw_base, str):
-            raise _FirewallEntryResolutionError(
-                f'builtin firewall "{raw_name}" api base must be a string'
-            )
-        resolved_base = _resolve_base_url_template(
-            firewall_name=raw_name,
-            base=raw_base,
-            vars_map=vars_map,
-        )
-        _validate_credentialed_builtin_base(
-            firewall_name=raw_name,
-            base=resolved_base,
-            auth_config=api.get("auth"),
-            host_policy=api.get("hostPolicy"),
-        )
-        api["base"] = resolved_base
-        resolved_bases.append(resolved_base)
-
-    return _ResolvedBuiltinFirewallEntry(
-        firewall=firewall,
-        cache_key=(
-            raw_name,
-            id(catalog_firewall),
-            tuple(sorted(vars_map.items())),
-            tuple(resolved_bases),
-        ),
-    )
-
-
-def _assign_firewall_api_ids(firewalls: list[dict], run_id: str) -> None:
-    index = 0
-    for firewall in firewalls:
-        raw_apis = firewall.get("apis")
-        if not isinstance(raw_apis, list):
-            continue
-        for api in raw_apis:
-            if not isinstance(api, dict):
-                continue
-            raw_id = api.get("id")
-            if not isinstance(raw_id, str) or raw_id == "":
-                api["id"] = f"{run_id}:{index}"
-            index += 1
-
-
-def _resolve_firewall_entries(vm: dict) -> _ResolvedFirewallEntries:
-    raw_firewalls = vm.get("firewalls")
-    if raw_firewalls is None:
-        return _ResolvedFirewallEntries(None, None)
-    if not isinstance(raw_firewalls, list):
-        raise _FirewallEntryResolutionError("firewalls must be a list")
-
-    resolved: list[dict] = []
-    builtin_cache_keys: list[_BuiltinFirewallCoreCacheKey | None] = []
-    for entry in raw_firewalls:
-        if not isinstance(entry, dict):
-            raise _FirewallEntryResolutionError("firewall entries must be objects")
-
-        kind = entry.get("kind")
-        if kind == "builtin":
-            resolved_builtin = _resolve_builtin_firewall_entry(entry)
-            resolved.append(resolved_builtin.firewall)
-            builtin_cache_keys.append(resolved_builtin.cache_key)
-            continue
-        if kind == "inline":
-            firewall = entry.get("firewall")
-            if not isinstance(firewall, dict):
-                raise _FirewallEntryResolutionError(
-                    "inline firewall entry firewall must be an object"
-                )
-            resolved.append(copy.deepcopy(firewall))
-            builtin_cache_keys.append(None)
-            continue
-        raise _FirewallEntryResolutionError("firewall entries must use a supported kind")
-
-    _assign_firewall_api_ids(resolved, vm["runId"])
-    return _ResolvedFirewallEntries(resolved, tuple(builtin_cache_keys))
-
-
 def _classify_registry_vms(
     raw_registry: dict,
 ) -> tuple[
     dict,
     dict[str, InvalidVmEntry],
-    dict[str, tuple[_BuiltinFirewallCoreCacheKey | None, ...]],
+    dict[str, tuple[registry_firewalls.BuiltinFirewallCoreCacheKey | None, ...]],
 ]:
     new_registry: dict = {}
     invalid_vms: dict[str, InvalidVmEntry] = {}
     builtin_cache_keys_by_client_ip: dict[
         str,
-        tuple[_BuiltinFirewallCoreCacheKey | None, ...],
+        tuple[registry_firewalls.BuiltinFirewallCoreCacheKey | None, ...],
     ] = {}
     for client_ip, vm in raw_registry.items():
         if not isinstance(vm, dict):
@@ -1148,8 +257,8 @@ def _classify_registry_vms(
             continue
 
         try:
-            resolved_firewalls = _resolve_firewall_entries(vm)
-        except _FirewallEntryResolutionError as e:
+            resolved_firewalls = registry_firewalls.resolve_firewall_entries(vm)
+        except registry_firewalls.FirewallEntryResolutionError as e:
             invalid_vms[client_ip] = InvalidVmEntry("invalid_firewalls", str(e))
             continue
 

--- a/crates/runner/mitm-addon/src/registry_firewalls.py
+++ b/crates/runner/mitm-addon/src/registry_firewalls.py
@@ -1,0 +1,157 @@
+"""Registry VM firewall entry resolution."""
+
+import copy
+from dataclasses import dataclass
+
+import builtin_base_url
+import builtin_host_policy
+from generated.builtin_firewalls import BUILTIN_FIREWALLS
+
+BuiltinFirewallCoreCacheKey = tuple[str, int, tuple[tuple[str, str], ...], tuple[str, ...]]
+
+
+class FirewallEntryResolutionError(ValueError):
+    """Execution firewall entries could not be expanded into runtime configs."""
+
+
+@dataclass(frozen=True)
+class ResolvedFirewallEntries:
+    firewalls: list[dict] | None
+    builtin_cache_keys: tuple[BuiltinFirewallCoreCacheKey | None, ...] | None
+
+
+@dataclass(frozen=True)
+class _ResolvedBuiltinFirewallEntry:
+    firewall: dict
+    cache_key: BuiltinFirewallCoreCacheKey
+
+
+def _copy_builtin_firewall_shell(
+    *,
+    firewall_name: str,
+    catalog_firewall: dict,
+) -> tuple[dict, list[dict]]:
+    raw_apis = catalog_firewall.get("apis")
+    if not isinstance(raw_apis, list):
+        raise FirewallEntryResolutionError(
+            f'builtin firewall "{firewall_name}" apis must be a list'
+        )
+
+    copied_apis: list[dict] = []
+    for api in raw_apis:
+        if not isinstance(api, dict):
+            raise FirewallEntryResolutionError(
+                f'builtin firewall "{firewall_name}" api entries must be objects'
+            )
+        copied_apis.append(dict(api))
+
+    firewall = dict(catalog_firewall)
+    firewall["apis"] = copied_apis
+    return firewall, copied_apis
+
+
+def _resolution_error(error: Exception) -> FirewallEntryResolutionError:
+    return FirewallEntryResolutionError(str(error))
+
+
+def _resolve_builtin_firewall_entry(entry: dict) -> _ResolvedBuiltinFirewallEntry:
+    raw_name = entry.get("name")
+    if not isinstance(raw_name, str) or raw_name == "":
+        raise FirewallEntryResolutionError("builtin firewall entry name must be a non-empty string")
+
+    catalog_firewall = BUILTIN_FIREWALLS.get(raw_name)
+    if catalog_firewall is None:
+        raise FirewallEntryResolutionError(f'unknown builtin firewall "{raw_name}"')
+
+    firewall, raw_apis = _copy_builtin_firewall_shell(
+        firewall_name=raw_name,
+        catalog_firewall=catalog_firewall,
+    )
+
+    try:
+        vars_map = builtin_base_url.base_url_vars_for_entry(entry)
+    except (TypeError, ValueError) as e:
+        raise _resolution_error(e) from e
+
+    resolved_bases: list[str] = []
+    for api in raw_apis:
+        raw_base = api.get("base")
+        if not isinstance(raw_base, str):
+            raise FirewallEntryResolutionError(
+                f'builtin firewall "{raw_name}" api base must be a string'
+            )
+        try:
+            resolved_base = builtin_base_url.resolve_base_url_template(
+                firewall_name=raw_name,
+                base=raw_base,
+                vars_map=vars_map,
+            )
+            builtin_host_policy.validate_credentialed_builtin_base(
+                firewall_name=raw_name,
+                base=resolved_base,
+                auth_config=api.get("auth"),
+                host_policy=api.get("hostPolicy"),
+            )
+        except (TypeError, ValueError) as e:
+            raise _resolution_error(e) from e
+        api["base"] = resolved_base
+        resolved_bases.append(resolved_base)
+
+    return _ResolvedBuiltinFirewallEntry(
+        firewall=firewall,
+        cache_key=(
+            raw_name,
+            id(catalog_firewall),
+            tuple(sorted(vars_map.items())),
+            tuple(resolved_bases),
+        ),
+    )
+
+
+def _assign_firewall_api_ids(firewalls: list[dict], run_id: str) -> None:
+    index = 0
+    for firewall in firewalls:
+        raw_apis = firewall.get("apis")
+        if not isinstance(raw_apis, list):
+            continue
+        for api in raw_apis:
+            if not isinstance(api, dict):
+                continue
+            raw_id = api.get("id")
+            if not isinstance(raw_id, str) or raw_id == "":
+                api["id"] = f"{run_id}:{index}"
+            index += 1
+
+
+def resolve_firewall_entries(vm: dict) -> ResolvedFirewallEntries:
+    raw_firewalls = vm.get("firewalls")
+    if raw_firewalls is None:
+        return ResolvedFirewallEntries(None, None)
+    if not isinstance(raw_firewalls, list):
+        raise FirewallEntryResolutionError("firewalls must be a list")
+
+    resolved: list[dict] = []
+    builtin_cache_keys: list[BuiltinFirewallCoreCacheKey | None] = []
+    for entry in raw_firewalls:
+        if not isinstance(entry, dict):
+            raise FirewallEntryResolutionError("firewall entries must be objects")
+
+        kind = entry.get("kind")
+        if kind == "builtin":
+            resolved_builtin = _resolve_builtin_firewall_entry(entry)
+            resolved.append(resolved_builtin.firewall)
+            builtin_cache_keys.append(resolved_builtin.cache_key)
+            continue
+        if kind == "inline":
+            firewall = entry.get("firewall")
+            if not isinstance(firewall, dict):
+                raise FirewallEntryResolutionError(
+                    "inline firewall entry firewall must be an object"
+                )
+            resolved.append(copy.deepcopy(firewall))
+            builtin_cache_keys.append(None)
+            continue
+        raise FirewallEntryResolutionError("firewall entries must use a supported kind")
+
+    _assign_firewall_api_ids(resolved, vm["runId"])
+    return ResolvedFirewallEntries(resolved, tuple(builtin_cache_keys))

--- a/crates/runner/mitm-addon/src/registry_firewalls.py
+++ b/crates/runner/mitm-addon/src/registry_firewalls.py
@@ -70,7 +70,7 @@ def _resolve_builtin_firewall_entry(entry: dict) -> _ResolvedBuiltinFirewallEntr
 
     try:
         vars_map = builtin_base_url.base_url_vars_for_entry(entry)
-    except (TypeError, ValueError) as e:
+    except builtin_base_url.BuiltinBaseUrlResolutionError as e:
         raise _resolution_error(e) from e
 
     resolved_bases: list[str] = []
@@ -92,7 +92,10 @@ def _resolve_builtin_firewall_entry(entry: dict) -> _ResolvedBuiltinFirewallEntr
                 auth_config=api.get("auth"),
                 host_policy=api.get("hostPolicy"),
             )
-        except (TypeError, ValueError) as e:
+        except (
+            builtin_base_url.BuiltinBaseUrlResolutionError,
+            builtin_host_policy.BuiltinHostPolicyError,
+        ) as e:
             raise _resolution_error(e) from e
         api["base"] = resolved_base
         resolved_bases.append(resolved_base)

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_base_url_vars.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_base_url_vars.py
@@ -4,6 +4,7 @@ import json
 from unittest.mock import MagicMock, patch
 
 import registry
+import registry_firewalls
 from tests.registry_helpers import write_builtin_firewall_registry
 
 
@@ -22,7 +23,7 @@ def install_test_builtin_firewall(
     if host_policy is not None:
         api["hostPolicy"] = host_policy
     monkeypatch.setattr(
-        registry,
+        registry_firewalls,
         "BUILTIN_FIREWALLS",
         {
             name: {

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_cache.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_cache.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import matching
 import registry
+import registry_firewalls
 from tests.registry_helpers import (
     builtin_vm,
     inline_vm,
@@ -90,7 +91,7 @@ class TestRegistryBuiltinCache:
         auth = {"headers": {"Authorization": "Bearer ${{ secrets.API_TOKEN }}"}}
         permissions = [{"name": "read-items", "rules": ["GET /items"]}]
         monkeypatch.setattr(
-            registry,
+            registry_firewalls,
             "BUILTIN_FIREWALLS",
             {
                 "large": {
@@ -263,7 +264,7 @@ class TestRegistryBuiltinCache:
         self, tmp_path, monkeypatch
     ):
         monkeypatch.setattr(
-            registry,
+            registry_firewalls,
             "BUILTIN_FIREWALLS",
             {
                 "cache-a": {


### PR DESCRIPTION
## Summary

- split builtin base URL template resolution into `builtin_base_url.py`
- split credentialed builtin host policy validation into `builtin_host_policy.py`
- move builtin/inline registry firewall entry expansion into `registry_firewalls.py` while keeping compiled matcher cache ownership in `registry.py`

This is intended as a behavior-preserving refactor. It keeps the public registry APIs stable and preserves builtin cache-key, shallow-copy, inline deep-copy, API id assignment, and invalid-VM isolation semantics.

Closes #19288

## Tests

- `pytest tests/test_registry_builtin_cache.py tests/test_registry_builtin_base_url_vars.py`
- `pytest tests/test_registry_loading.py tests/test_registry_context.py tests/test_registry_context_state.py tests/test_registry_auth_cache_eviction.py`
- `ruff check src tests`
- `basedpyright`
- `pytest tests/`