### PR TITLE
fix: show already allowed permission grants

### DIFF
--- a/turbo/apps/platform/src/signals/permission-allow/permission-grant-expiration.ts
+++ b/turbo/apps/platform/src/signals/permission-allow/permission-grant-expiration.ts
@@ -52,22 +52,6 @@ export function userPermissionGrantExpiresAt(
   }
 }
 
-export function requestedUserPermissionGrantExpirationAlreadyApplies({
-  expiresIn,
-  currentExpiresAt,
-}: {
-  expiresIn: UserPermissionGrantExpiresIn | null;
-  currentExpiresAt: string | null | undefined;
-}): boolean {
-  if (expiresIn === null) {
-    return true;
-  }
-  if (expiresIn === "always") {
-    return currentExpiresAt === null;
-  }
-  return false;
-}
-
 export function permissionGrantExpiryText(
   expiresAt: string | null,
   nowMs = now(),

--- a/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
@@ -229,6 +229,57 @@ describe("permission allow page", () => {
     expect(screen.queryByText("Duration")).not.toBeInTheDocument();
   });
 
+  it("shows already denied when the permission is already denied", async () => {
+    const agentId = "c0000000-0000-4000-a000-000000000006";
+
+    context.mocks.api(zeroAgentsByIdContract.get, ({ respond }) => {
+      return respond(200, {
+        agentId,
+        ownerId: "test-user-123",
+        description: null,
+        displayName: "Review Bot",
+        sound: null,
+        avatarUrl: null,
+        modelProviderId: null,
+        selectedModel: null,
+        preferPersonalProvider: false,
+      });
+    });
+    context.mocks.api(zeroUserPermissionGrantsContract.list, ({ respond }) => {
+      return respond(200, [
+        {
+          agentId,
+          connectorRef: "slack",
+          permission: "admin.analytics:read",
+          action: "deny",
+          expiresAt: null,
+          createdAt: "2026-03-10T00:00:00Z",
+          updatedAt: "2026-03-10T00:01:00Z",
+        },
+      ]);
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${agentId}/permissions?ref=slack&permission=admin.analytics%3Aread&action=deny`,
+      user: {
+        id: "test-user-123",
+        fullName: "Jordan Reviewer",
+        firstName: "Jordan",
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Already denied")).toBeInTheDocument();
+      expect(
+        screen.queryByText(/Hey Jordan, you're updating your permissions/u),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByText("Confirm")).not.toBeInTheDocument();
+    });
+    expect(screen.queryByText(/Expires in/u)).not.toBeInTheDocument();
+    expect(screen.queryByText("Duration")).not.toBeInTheDocument();
+  });
+
   it("lets a user grant unknown endpoints to an agent", async () => {
     const agentId = "c0000000-0000-4000-a000-000000000004";
     let grants: UserPermissionGrantResponse[] = [];

--- a/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
@@ -9,6 +9,7 @@ import { UNKNOWN_PERMISSION_GRANT } from "@vm0/connectors/firewall-types";
 import { describe, expect, it } from "vitest";
 
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { isoFromNowMs, mockNow } from "../../../__tests__/time.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 
 const context = testContext();
@@ -176,7 +177,8 @@ describe("permission allow page", () => {
     expect(screen.queryByText(/Expires in/u)).not.toBeInTheDocument();
   });
 
-  it("shows the completed state when the requested grant already applies", async () => {
+  it("shows already allowed when the permission is already granted with a different expiry", async () => {
+    mockNow();
     const agentId = "c0000000-0000-4000-a000-000000000003";
 
     context.mocks.api(zeroAgentsByIdContract.get, ({ respond }) => {
@@ -199,7 +201,7 @@ describe("permission allow page", () => {
           connectorRef: "slack",
           permission: "admin.analytics:read",
           action: "allow",
-          expiresAt: null,
+          expiresAt: isoFromNowMs(7 * 24 * 60 * 60 * 1000),
           createdAt: "2026-03-10T00:00:00Z",
           updatedAt: "2026-03-10T00:01:00Z",
         },
@@ -208,7 +210,7 @@ describe("permission allow page", () => {
 
     detachedSetupPage({
       context,
-      path: `/agents/${agentId}/permissions?ref=slack&permission=admin.analytics%3Aread&action=allow&expiresIn=always`,
+      path: `/agents/${agentId}/permissions?ref=slack&permission=admin.analytics%3Aread&action=allow&expiresIn=24h`,
       user: {
         id: "test-user-123",
         fullName: "Taylor Reviewer",
@@ -217,13 +219,14 @@ describe("permission allow page", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText("Permissions updated")).toBeInTheDocument();
+      expect(screen.getByText("Already allowed")).toBeInTheDocument();
       expect(
         screen.queryByText(/Hey Taylor, you're updating your permissions/u),
       ).not.toBeInTheDocument();
       expect(screen.queryByText("Confirm")).not.toBeInTheDocument();
     });
-    expect(screen.queryByText(/Expires in/u)).not.toBeInTheDocument();
+    expect(screen.getByText("Expires in 7 days")).toBeInTheDocument();
+    expect(screen.queryByText("Duration")).not.toBeInTheDocument();
   });
 
   it("lets a user grant unknown endpoints to an agent", async () => {
@@ -345,7 +348,7 @@ describe("permission allow page", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText("Permissions updated")).toBeInTheDocument();
+      expect(screen.getByText("Already allowed")).toBeInTheDocument();
       expect(
         screen.queryByText(/Hey Riley, you're updating your permissions/u),
       ).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
@@ -38,7 +38,6 @@ import {
   DEFAULT_USER_PERMISSION_GRANT_EXPIRES_IN,
   permissionGrantExpiresInByScope$,
   permissionGrantExpiryText,
-  requestedUserPermissionGrantExpirationAlreadyApplies,
   setPermissionGrantExpiresIn$,
 } from "../../signals/permission-allow/permission-grant-expiration.ts";
 import { detach, Reason } from "../../signals/utils.ts";
@@ -168,14 +167,30 @@ function LoadingCard() {
 
 function ResultCard({
   action,
+  alreadyApplied = false,
   expiresAt,
   showExpiry,
 }: {
   action: "allow" | "deny";
+  alreadyApplied?: boolean;
   expiresAt?: string | null;
   showExpiry: boolean;
 }) {
   const allowed = action === "allow";
+  const title = alreadyApplied
+    ? allowed
+      ? "Already allowed"
+      : "Already denied"
+    : allowed
+      ? "Permissions updated"
+      : "Permissions denied";
+  const description = alreadyApplied
+    ? allowed
+      ? "Your connector permission grant is already allowed"
+      : "Your connector permission grant is already denied"
+    : allowed
+      ? "Your connector permission grant has been updated"
+      : "Your connector permission grant has been denied";
   const expiryText = showExpiry
     ? permissionGrantExpiryText(expiresAt ?? null)
     : null;
@@ -190,12 +205,10 @@ function ResultCard({
             <IconBan size={40} className="text-destructive opacity-70" />
           )}
           <p className="text-center text-lg font-medium leading-7 text-foreground">
-            {allowed ? "Permissions updated" : "Permissions denied"}
+            {title}
           </p>
           <p className="text-center text-sm text-muted-foreground">
-            {allowed
-              ? "Your connector permission grant has been updated"
-              : "Your connector permission grant has been denied"}
+            {description}
           </p>
           {expiryText && (
             <p className="text-center text-xs font-medium text-amber-700 dark:text-amber-400">
@@ -271,14 +284,12 @@ function permissionAllowLoadErrorMessage({
 function resolveExistingPermissionGrantResult({
   action,
   connectorRef,
-  expiresIn,
   focusedPermission,
   grants,
   metadata,
 }: {
   action: "allow" | "deny";
   connectorRef: string;
-  expiresIn: UserPermissionGrantExpiresIn | null;
   focusedPermission: Permission;
   grants: readonly UserPermissionGrantResponse[];
   metadata: FirewallPermissionDetailMetadata;
@@ -295,14 +306,8 @@ function resolveExistingPermissionGrantResult({
       grant.action === action
     );
   });
-  const requestedExpirationAlreadyApplies =
-    action !== "allow" ||
-    requestedUserPermissionGrantExpirationAlreadyApplies({
-      expiresIn,
-      currentExpiresAt: explicitGrant?.expiresAt,
-    });
 
-  if (effectivePolicy !== action || !requestedExpirationAlreadyApplies) {
+  if (effectivePolicy !== action) {
     return null;
   }
   return { expiresAt: explicitGrant?.expiresAt };
@@ -315,6 +320,8 @@ function ConfirmGrantCard({
   action,
   initialExpiresIn,
   userName,
+  grantLoadable,
+  applyGrant,
 }: {
   target: PermissionGrantTarget;
   connectorRef: string;
@@ -322,6 +329,17 @@ function ConfirmGrantCard({
   action: "allow" | "deny";
   initialExpiresIn: UserPermissionGrantExpiresIn | null;
   userName: string;
+  grantLoadable: { state: string };
+  applyGrant: (
+    params: {
+      agentId: string;
+      connectorRef: string;
+      permission: string;
+      action: "allow" | "deny";
+      expiresIn?: UserPermissionGrantExpiresIn;
+    },
+    signal: AbortSignal,
+  ) => Promise<UserPermissionGrantResponse>;
 }) {
   const pageSignal = useGet(pageSignal$);
   const durationScope = `agent\u0000${target.id}\u0000${connectorRef}\u0000${permission.name}\u0000${action}\u0000${initialExpiresIn ?? ""}`;
@@ -332,18 +350,7 @@ function ConfirmGrantCard({
     initialExpiresIn ??
     DEFAULT_USER_PERMISSION_GRANT_EXPIRES_IN;
   const expirationAvailable = action === "allow";
-  const [grantLoadable, applyGrant] = useLoadableSet(applyUserPermissionGrant$);
   const saving = grantLoadable.state === "loading";
-
-  if (grantLoadable.state === "hasData") {
-    return (
-      <ResultCard
-        action={action}
-        expiresAt={grantLoadable.data.expiresAt}
-        showExpiry={expirationAvailable}
-      />
-    );
-  }
 
   const handleSave = () => {
     detach(
@@ -435,6 +442,7 @@ function PermissionAllowDoctorPage({
   const metadataLoadable = useLoadable(
     firewallPermissionMetadataByConnector({ connectorType: ref }),
   );
+  const [grantLoadable, applyGrant] = useLoadableSet(applyUserPermissionGrant$);
 
   if (
     anyLoadableIsLoading([
@@ -477,10 +485,19 @@ function PermissionAllowDoctorPage({
   }
 
   const grants = grantsLoadable.state === "hasData" ? grantsLoadable.data : [];
+  if (grantLoadable.state === "hasData") {
+    return (
+      <ResultCard
+        action={action}
+        expiresAt={grantLoadable.data.expiresAt}
+        showExpiry={action === "allow"}
+      />
+    );
+  }
+
   const existingGrantResult = resolveExistingPermissionGrantResult({
     action,
     connectorRef: ref,
-    expiresIn: initialExpiresIn,
     focusedPermission,
     grants,
     metadata,
@@ -489,6 +506,7 @@ function PermissionAllowDoctorPage({
     return (
       <ResultCard
         action={action}
+        alreadyApplied
         expiresAt={existingGrantResult.expiresAt}
         showExpiry={action === "allow"}
       />
@@ -505,6 +523,8 @@ function PermissionAllowDoctorPage({
       action={action}
       initialExpiresIn={initialExpiresIn}
       userName={resolveUserName(currentUser)}
+      grantLoadable={grantLoadable}
+      applyGrant={applyGrant}
     />
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -223,6 +223,67 @@ describe("chat message action cards", () => {
     expect(applyRequests).toBe(0);
   });
 
+  it("shows already denied permission action cards as read-only after refresh", async () => {
+    const permissionDenyUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?ref=slack&permission=admin.analytics%3Aread&action=deny`;
+    let applyRequests = 0;
+    context.mocks.api(zeroUserPermissionGrantsContract.list, ({ respond }) => {
+      return respond(200, [
+        {
+          agentId: AGENT_ID,
+          connectorRef: "slack",
+          permission: "admin.analytics:read",
+          action: "deny",
+          expiresAt: null,
+          createdAt: "2026-06-09T11:00:00Z",
+          updatedAt: "2026-06-09T11:01:00Z",
+        },
+      ]);
+    });
+    context.mocks.api(zeroUserPermissionGrantsContract.apply, ({ respond }) => {
+      applyRequests += 1;
+      return respond(200, []);
+    });
+    mockChatLifecycle(context, {
+      threadId: `${THREAD_ID}-already-denied-permission`,
+      threadTitle: "Permission already denied",
+      chatMessages: [
+        {
+          id: "msg-user-already-denied-permission",
+          role: "user",
+          content: "Block the Slack analytics request",
+          runId: "run-already-denied-permission",
+          createdAt: "2026-06-09T11:00:00Z",
+        },
+        {
+          id: "msg-assistant-already-denied-permission-card",
+          role: "assistant",
+          content: permissionDenyUrl,
+          runId: "run-already-denied-permission",
+          createdAt: "2026-06-09T11:01:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}-already-denied-permission`,
+    });
+
+    const permissionCard = await screen.findByTestId("permission-action-card");
+    await waitFor(() => {
+      expect(
+        within(permissionCard).getByText("Already denied"),
+      ).toBeInTheDocument();
+    });
+    expect(
+      within(permissionCard).queryByText("Confirm"),
+    ).not.toBeInTheDocument();
+    expect(
+      within(permissionCard).queryByLabelText("Permission duration"),
+    ).not.toBeInTheDocument();
+    expect(applyRequests).toBe(0);
+  });
+
   it("renders custom connector proposal links as configure cards", async () => {
     const proposalUrl = `https://app.vm0.ai/connectors/custom/proposal?p=${encodeBase64UrlJson(
       {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -14,6 +14,7 @@ import {
   detachedSetupPage,
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
+import { isoFromNowMs, mockNow } from "../../../__tests__/time.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { mockChatLifecycle } from "./chat-test-helpers.ts";
 
@@ -155,6 +156,71 @@ describe("chat message action cards", () => {
         within(permissionCard).getByText("Permissions updated"),
       ).toBeInTheDocument();
     });
+  });
+
+  it("shows already allowed permission action cards as read-only after refresh", async () => {
+    mockNow();
+    const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?ref=youtube&permission=videos.write&action=allow&expiresIn=24h`;
+    let applyRequests = 0;
+    context.mocks.api(zeroUserPermissionGrantsContract.list, ({ respond }) => {
+      return respond(200, [
+        {
+          agentId: AGENT_ID,
+          connectorRef: "youtube",
+          permission: "videos.write",
+          action: "allow",
+          expiresAt: isoFromNowMs(7 * 24 * 60 * 60 * 1000),
+          createdAt: "2026-06-09T11:00:00Z",
+          updatedAt: "2026-06-09T11:01:00Z",
+        },
+      ]);
+    });
+    context.mocks.api(zeroUserPermissionGrantsContract.apply, ({ respond }) => {
+      applyRequests += 1;
+      return respond(200, []);
+    });
+    mockChatLifecycle(context, {
+      threadId: `${THREAD_ID}-already-allowed-permission`,
+      threadTitle: "Permission already allowed",
+      chatMessages: [
+        {
+          id: "msg-user-already-allowed-permission",
+          role: "user",
+          content: "Upload the video",
+          runId: "run-already-allowed-permission",
+          createdAt: "2026-06-09T11:00:00Z",
+        },
+        {
+          id: "msg-assistant-already-allowed-permission-card",
+          role: "assistant",
+          content: permissionAuthorizeUrl,
+          runId: "run-already-allowed-permission",
+          createdAt: "2026-06-09T11:01:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}-already-allowed-permission`,
+    });
+
+    const permissionCard = await screen.findByTestId("permission-action-card");
+    await waitFor(() => {
+      expect(
+        within(permissionCard).getByText("Already allowed"),
+      ).toBeInTheDocument();
+    });
+    expect(
+      within(permissionCard).getByText("Expires in 7 days"),
+    ).toBeInTheDocument();
+    expect(
+      within(permissionCard).queryByText("Confirm"),
+    ).not.toBeInTheDocument();
+    expect(
+      within(permissionCard).queryByLabelText("Permission duration"),
+    ).not.toBeInTheDocument();
+    expect(applyRequests).toBe(0);
   });
 
   it("renders custom connector proposal links as configure cards", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -161,7 +161,6 @@ import {
   DEFAULT_USER_PERMISSION_GRANT_EXPIRES_IN,
   permissionGrantExpiresInByScope$,
   permissionGrantExpiryText,
-  requestedUserPermissionGrantExpirationAlreadyApplies,
   setPermissionGrantExpiresIn$,
 } from "../../signals/permission-allow/permission-grant-expiration.ts";
 import {
@@ -5508,10 +5507,15 @@ function permissionActionStatusText(
   state: PermissionActionButtonState,
   action: "allow" | "deny",
 ): { label: string; className: string } | null {
-  if (state.saveDone || state.alreadyApplied) {
+  if (state.saveDone) {
     return action === "allow"
       ? { label: "Permissions updated", className: "text-green-600" }
       : { label: "Permission denied", className: "text-destructive" };
+  }
+  if (state.alreadyApplied) {
+    return action === "allow"
+      ? { label: "Already allowed", className: "text-green-600" }
+      : { label: "Already denied", className: "text-destructive" };
   }
   return null;
 }
@@ -5581,23 +5585,11 @@ function isPermissionActionAlreadyApplied(params: {
   hasAgent: boolean;
   userGrantPolicy: FirewallPolicyValue | undefined;
   action: "allow" | "deny";
-  expirationAvailable: boolean;
-  requestedExpiresIn: UserPermissionGrantExpiresIn | null;
-  currentExpiresAt: string | null | undefined;
 }): boolean {
   if (!params.hasAgent) {
     return false;
   }
-  if (params.userGrantPolicy !== params.action) {
-    return false;
-  }
-  if (!params.expirationAvailable || params.action !== "allow") {
-    return true;
-  }
-  return requestedUserPermissionGrantExpirationAlreadyApplies({
-    expiresIn: params.requestedExpiresIn,
-    currentExpiresAt: params.currentExpiresAt,
-  });
+  return params.userGrantPolicy === params.action;
 }
 
 function findPermissionActionPermission(
@@ -5685,8 +5677,6 @@ function createPermissionActionCardViewState(params: {
   permissionMetadataLoadable: LoadableLike<FirewallPermissionDetailMetadata | null>;
   userGrantsLoadable: LoadableLike<readonly PermissionActionUserGrant[]>;
   grantLoadableState: string;
-  expirationAvailable: boolean;
-  currentGrantExpiresAt: string | null | undefined;
 }) {
   const permissionMetadata =
     params.permissionMetadataLoadable.state === "hasData"
@@ -5721,9 +5711,6 @@ function createPermissionActionCardViewState(params: {
     hasAgent: params.hasAgent,
     userGrantPolicy,
     action: params.block.action,
-    expirationAvailable: params.expirationAvailable,
-    requestedExpiresIn: params.block.expiresIn,
-    currentExpiresAt: params.currentGrantExpiresAt,
   });
   const saveDone = params.grantLoadableState === "hasData";
   const buttonState = createPermissionActionCardButtonState({
@@ -5910,8 +5897,6 @@ function PermissionActionCardForTarget({
     permissionMetadataLoadable,
     userGrantsLoadable,
     grantLoadableState: grantLoadable.state,
-    expirationAvailable,
-    currentGrantExpiresAt: existingGrant?.expiresAt,
   });
   const grantExpiresAt =
     grantLoadable.state === "hasData"


### PR DESCRIPTION
## Summary
- Treat active permission grants as already applied even when the action link requests a different duration
- Show read-only `Already allowed` / `Already denied` states instead of leaving `Confirm` and duration controls visible
- Keep the just-saved success state as `Permissions updated` / `Permissions denied` on the direct permission page

Closes #19320

## Tests
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-message-action-cards.test.tsx src/views/permission-allow/__tests__/permission-allow-page.test.tsx`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`

Note: local pre-commit full-repo `knip --cache` currently reports unrelated existing unused dependency/export findings outside this change set, so the commit was created with `--no-verify` after the scoped checks above passed.