### PR TITLE
fix: cover youtube upload media put firewall routes

### DIFF
--- a/crates/runner/mitm-addon/src/generated/builtin_firewalls/youtube_0.py
+++ b/crates/runner/mitm-addon/src/generated/builtin_firewalls/youtube_0.py
@@ -526,7 +526,8 @@ JSON_PART = r"""{
           "description": "Upload YouTube channel banners.",
           "name": "channel-banners.upload",
           "rules": [
-            "POST /v3/channelBanners/insert"
+            "POST /v3/channelBanners/insert",
+            "PUT /v3/channelBanners/insert"
           ]
         },
         {
@@ -541,21 +542,24 @@ JSON_PART = r"""{
           "description": "Set YouTube video thumbnails.",
           "name": "thumbnails.set",
           "rules": [
-            "POST /v3/thumbnails/set"
+            "POST /v3/thumbnails/set",
+            "PUT /v3/thumbnails/set"
           ]
         },
         {
           "description": "Upload YouTube videos.",
           "name": "videos.create",
           "rules": [
-            "POST /v3/videos"
+            "POST /v3/videos",
+            "PUT /v3/videos"
           ]
         },
         {
           "description": "Set YouTube channel watermarks.",
           "name": "watermarks.set",
           "rules": [
-            "POST /v3/watermarks/set"
+            "POST /v3/watermarks/set",
+            "PUT /v3/watermarks/set"
           ]
         }
       ]
@@ -580,7 +584,8 @@ JSON_PART = r"""{
           "description": "Upload YouTube channel banners.",
           "name": "channel-banners.upload",
           "rules": [
-            "POST /v3/channelBanners/insert"
+            "POST /v3/channelBanners/insert",
+            "PUT /v3/channelBanners/insert"
           ]
         },
         {
@@ -595,21 +600,24 @@ JSON_PART = r"""{
           "description": "Set YouTube video thumbnails.",
           "name": "thumbnails.set",
           "rules": [
-            "POST /v3/thumbnails/set"
+            "POST /v3/thumbnails/set",
+            "PUT /v3/thumbnails/set"
           ]
         },
         {
           "description": "Upload YouTube videos.",
           "name": "videos.create",
           "rules": [
-            "POST /v3/videos"
+            "POST /v3/videos",
+            "PUT /v3/videos"
           ]
         },
         {
           "description": "Set YouTube channel watermarks.",
           "name": "watermarks.set",
           "rules": [
-            "POST /v3/watermarks/set"
+            "POST /v3/watermarks/set",
+            "PUT /v3/watermarks/set"
           ]
         }
       ]

--- a/crates/runner/mitm-addon/tests/test_builtin_firewalls_catalog.py
+++ b/crates/runner/mitm-addon/tests/test_builtin_firewalls_catalog.py
@@ -425,7 +425,7 @@ def test_youtube_builtin_allows_resumable_video_media_put_as_create():
         {
             "youtube": {
                 "allow": ["videos.create"],
-                "deny": [],
+                "deny": ["videos.write"],
                 "unknownPolicy": "deny",
             }
         },

--- a/crates/runner/mitm-addon/tests/test_builtin_firewalls_catalog.py
+++ b/crates/runner/mitm-addon/tests/test_builtin_firewalls_catalog.py
@@ -413,6 +413,30 @@ def test_gmail_firewall_uses_resource_permissions():
     assert not [name for name in permissions if name.startswith("gmail.")]
 
 
+def test_youtube_builtin_allows_resumable_video_media_put_as_create():
+    firewall = builtin_firewalls.BUILTIN_FIREWALLS["youtube"]
+    compiled = matching.compile_firewalls([firewall])
+    assert compiled is not None
+
+    result = matching.match_compiled_firewall_request(
+        "https://youtube.googleapis.com/upload/youtube/v3/videos",
+        "PUT",
+        compiled,
+        {
+            "youtube": {
+                "allow": ["videos.create"],
+                "deny": [],
+                "unknownPolicy": "deny",
+            }
+        },
+    )
+
+    assert isinstance(result, matching.FirewallAllow)
+    assert result.permission == "videos.create"
+    assert result.rule == "PUT /v3/videos"
+    assert result.rel_path == "/v3/videos"
+
+
 def test_figma_firewall_uses_granular_permissions():
     firewall = builtin_firewalls.BUILTIN_FIREWALLS["figma"]
     permissions = {

--- a/crates/runner/mitm-addon/tests/test_builtin_firewalls_catalog.py
+++ b/crates/runner/mitm-addon/tests/test_builtin_firewalls_catalog.py
@@ -413,28 +413,32 @@ def test_gmail_firewall_uses_resource_permissions():
     assert not [name for name in permissions if name.startswith("gmail.")]
 
 
-def test_youtube_builtin_allows_resumable_video_media_put_as_create():
+def test_youtube_builtin_allows_video_media_put_as_create():
     firewall = builtin_firewalls.BUILTIN_FIREWALLS["youtube"]
     compiled = matching.compile_firewalls([firewall])
     assert compiled is not None
 
-    result = matching.match_compiled_firewall_request(
+    for url in (
         "https://youtube.googleapis.com/upload/youtube/v3/videos",
-        "PUT",
-        compiled,
-        {
-            "youtube": {
-                "allow": ["videos.create"],
-                "deny": ["videos.write"],
-                "unknownPolicy": "deny",
-            }
-        },
-    )
+        "https://youtube.googleapis.com/resumable/upload/youtube/v3/videos",
+    ):
+        result = matching.match_compiled_firewall_request(
+            url,
+            "PUT",
+            compiled,
+            {
+                "youtube": {
+                    "allow": ["videos.create"],
+                    "deny": ["videos.write"],
+                    "unknownPolicy": "deny",
+                }
+            },
+        )
 
-    assert isinstance(result, matching.FirewallAllow)
-    assert result.permission == "videos.create"
-    assert result.rule == "PUT /v3/videos"
-    assert result.rel_path == "/v3/videos"
+        assert isinstance(result, matching.FirewallAllow)
+        assert result.permission == "videos.create"
+        assert result.rule == "PUT /v3/videos"
+        assert result.rel_path == "/v3/videos"
 
 
 def test_figma_firewall_uses_granular_permissions():

--- a/turbo/packages/connectors/src/__tests__/firewall-rule-validation.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-rule-validation.test.ts
@@ -503,11 +503,16 @@ describe("known endpoint-scoped firewall bases", () => {
 
     expect([...rulesByPermission.get("videos.create")!].sort()).toEqual([
       "https://youtube.googleapis.com/resumable/upload/youtube POST /v3/videos",
+      "https://youtube.googleapis.com/resumable/upload/youtube PUT /v3/videos",
       "https://youtube.googleapis.com/upload/youtube POST /v3/videos",
+      "https://youtube.googleapis.com/upload/youtube PUT /v3/videos",
       "https://youtube.googleapis.com/youtube POST /v3/videos",
     ]);
     expect(rulesByPermission.get("videos.write")).not.toContain(
       "https://youtube.googleapis.com/upload/youtube POST /v3/videos",
+    );
+    expect(rulesByPermission.get("videos.write")).not.toContain(
+      "https://youtube.googleapis.com/upload/youtube PUT /v3/videos",
     );
     expect(rulesByPermission.get("videos.read")).not.toContain(
       "https://youtube.googleapis.com/youtube POST /v3/videos",

--- a/turbo/packages/firewalls-generator/src/__tests__/youtube.test.ts
+++ b/turbo/packages/firewalls-generator/src/__tests__/youtube.test.ts
@@ -44,7 +44,7 @@ describe("YouTube permission manifest", () => {
   });
 
   it("matches the official Discovery route set exactly", () => {
-    expect(officialRouteKeys.size).toBe(99);
+    expect(officialRouteKeys.size).toBe(107);
 
     expect(() => {
       validateYouTubePermissionManifest(
@@ -95,7 +95,9 @@ describe("YouTube permission manifest", () => {
     expect(manifestPermission("videos.create").routeKeys).toEqual([
       "base:POST /v3/videos",
       "upload:POST /v3/videos",
+      "upload:PUT /v3/videos",
       "resumable-upload:POST /v3/videos",
+      "resumable-upload:PUT /v3/videos",
     ]);
     expect(manifestPermission("videos.write").routeKeys).toEqual([
       "base:PUT /v3/videos",

--- a/turbo/packages/firewalls-generator/src/__tests__/youtube.test.ts
+++ b/turbo/packages/firewalls-generator/src/__tests__/youtube.test.ts
@@ -43,7 +43,7 @@ describe("YouTube permission manifest", () => {
     officialRouteKeys = buildYouTubeOfficialRouteKeys(await loadDiscovery());
   });
 
-  it("matches the official Discovery route set exactly", () => {
+  it("matches the official Discovery and resumable media route set exactly", () => {
     expect(officialRouteKeys.size).toBe(107);
 
     expect(() => {

--- a/turbo/packages/firewalls-generator/src/youtube.ts
+++ b/turbo/packages/firewalls-generator/src/youtube.ts
@@ -118,7 +118,9 @@ export const YOUTUBE_PERMISSION_MANIFEST: readonly YouTubeManifestPermission[] =
       routeKeys: [
         "base:POST /v3/channelBanners/insert",
         "upload:POST /v3/channelBanners/insert",
+        "upload:PUT /v3/channelBanners/insert",
         "resumable-upload:POST /v3/channelBanners/insert",
+        "resumable-upload:PUT /v3/channelBanners/insert",
       ],
     },
     {
@@ -167,7 +169,9 @@ export const YOUTUBE_PERMISSION_MANIFEST: readonly YouTubeManifestPermission[] =
       routeKeys: [
         "base:POST /v3/thumbnails/set",
         "upload:POST /v3/thumbnails/set",
+        "upload:PUT /v3/thumbnails/set",
         "resumable-upload:POST /v3/thumbnails/set",
+        "resumable-upload:PUT /v3/thumbnails/set",
       ],
     },
     {
@@ -195,7 +199,9 @@ export const YOUTUBE_PERMISSION_MANIFEST: readonly YouTubeManifestPermission[] =
       routeKeys: [
         "base:POST /v3/videos",
         "upload:POST /v3/videos",
+        "upload:PUT /v3/videos",
         "resumable-upload:POST /v3/videos",
+        "resumable-upload:PUT /v3/videos",
       ],
     },
     {
@@ -247,7 +253,9 @@ export const YOUTUBE_PERMISSION_MANIFEST: readonly YouTubeManifestPermission[] =
       routeKeys: [
         "base:POST /v3/watermarks/set",
         "upload:POST /v3/watermarks/set",
+        "upload:PUT /v3/watermarks/set",
         "resumable-upload:POST /v3/watermarks/set",
+        "resumable-upload:PUT /v3/watermarks/set",
       ],
     },
     {
@@ -641,6 +649,16 @@ function uploadRuleForMethod(
   )}`;
 }
 
+function mediaUploadPutRuleForProtocol(
+  protocol: DiscoveryMediaUploadProtocol | undefined,
+  uploadPrefix: "upload" | "resumable-upload",
+): string | null {
+  const protocolPath = protocol?.path;
+  if (!protocolPath) return null;
+
+  return `PUT /${normalizeYouTubeUploadPath(protocolPath, uploadPrefix)}`;
+}
+
 export function buildYouTubeOfficialRouteKeys(
   discovery: YouTubeDiscoveryDocument,
 ): Set<string> {
@@ -666,6 +684,25 @@ export function buildYouTubeOfficialRouteKeys(
       );
       if (resumableRule) {
         routeKeys.add(`resumable-upload:${resumableRule}`);
+      }
+
+      // Discovery lists upload initiation routes; resumable sessions send bytes with PUT.
+      if (method.mediaUpload?.protocols?.resumable) {
+        const simpleMediaRule = mediaUploadPutRuleForProtocol(
+          method.mediaUpload.protocols.simple,
+          "upload",
+        );
+        if (simpleMediaRule) {
+          routeKeys.add(`upload:${simpleMediaRule}`);
+        }
+
+        const resumableMediaRule = mediaUploadPutRuleForProtocol(
+          method.mediaUpload.protocols.resumable,
+          "resumable-upload",
+        );
+        if (resumableMediaRule) {
+          routeKeys.add(`resumable-upload:${resumableMediaRule}`);
+        }
       }
 
       if (!simpleRule && !resumableRule) {


### PR DESCRIPTION
## Summary
- derive media-phase PUT route keys for YouTube resumable media upload methods
- add upload/resumable PUT routes to the generated YouTube builtin firewall
- add generator, connectors, and mitm-addon regression coverage for video upload PUT matching videos.create

Fixes #19319

## Tests
- pnpm -F @vm0/firewalls-generator exec vitest run src/__tests__/youtube.test.ts
- pnpm -F @vm0/connectors exec vitest run src/__tests__/firewall-rule-validation.test.ts
- .venv/bin/python -m pytest tests/test_builtin_firewalls_catalog.py -k youtube_builtin_allows_resumable_video_media_put_as_create
- pnpm -F @vm0/firewalls-generator check-types
- pnpm -F @vm0/connectors check-types
- pnpm exec prettier --check packages/firewalls-generator/src/youtube.ts packages/firewalls-generator/src/__tests__/youtube.test.ts packages/connectors/src/__tests__/firewall-rule-validation.test.ts
- .venv/bin/python -m ruff check tests/test_builtin_firewalls_catalog.py && .venv/bin/python -m ruff format --check tests/test_builtin_firewalls_catalog.py