### PR TITLE
fix: route browser auth through staging so

### DIFF
--- a/e2e/playwright/playwright.config.ts
+++ b/e2e/playwright/playwright.config.ts
@@ -4,17 +4,25 @@ import path from "node:path";
 
 dotenv.config({ path: path.join(__dirname, "../.env.local") });
 
-if (!process.env.VM0_API_URL) {
+const apiUrl = process.env.VM0_API_URL;
+if (!apiUrl) {
   throw new Error("VM0_API_URL environment variable is required");
 }
 
-export function deriveAppUrl(webUrl: string): string {
-  // Handle preview URLs like https://pr-8510-www.vm6.ai -> https://pr-8510-app.vm6.ai
-  // and production URLs like https://www.vm7.ai -> https://app.vm7.ai
-  return webUrl.replace(/-www\./, "-app.").replace(/\/\/www\./, "//app.");
+export function deriveAppUrl(sourceUrl: string): string {
+  if (process.env.VM0_APP_URL) {
+    return process.env.VM0_APP_URL;
+  }
+
+  // Handle preview API/web URLs like pr-8510-api/www.vm6.ai and production
+  // URLs like api/www.vm7.ai.
+  return sourceUrl
+    .replace(/-(api|www)\./, "-app.")
+    .replace(/\/\/(api|www)\./, "//app.");
 }
 
 export const STORAGE_STATE = path.join(__dirname, ".auth/storage-state.json");
+const appUrl = deriveAppUrl(apiUrl);
 
 export default defineConfig({
   testDir: "./tests",
@@ -22,7 +30,7 @@ export default defineConfig({
   globalTeardown: "./global-teardown",
   timeout: 120_000,
   use: {
-    baseURL: process.env.VM0_API_URL,
+    baseURL: appUrl,
     ignoreHTTPSErrors: true,
     trace: "on-first-retry",
     ...devices["Desktop Chrome"],

--- a/e2e/playwright/tests/smoke.spec.ts
+++ b/e2e/playwright/tests/smoke.spec.ts
@@ -26,7 +26,7 @@ test("sign in through onboarding handoff to chat page", async ({ page }) => {
   await clerkSetup();
   await setupClerkTestingToken({ page });
 
-  // Navigate to app — redirects to www sign-in
+  // Navigate to app, which redirects to the hosted auth sign-in surface.
   await page.goto(appUrl, { waitUntil: "domcontentloaded" });
   await page.waitForURL((url) => url.pathname.includes("/sign-in"), {
     timeout: 30_000,

--- a/e2e/tests/02-browser/brw-t01-platform-e2e.bats
+++ b/e2e/tests/02-browser/brw-t01-platform-e2e.bats
@@ -10,10 +10,12 @@
 # by the Playwright suite and have been removed from this file.
 #
 # Required env vars:
-#   VM0_API_URL   — Target web app URL (e.g., https://www.vm7.ai:8443)
+#   VM0_AUTH_URL   - Target auth URL (e.g., https://staging-so.vm6.ai)
 #
 # Optional env vars:
-#   E2E_ACCOUNT   — Test email (auto-generated if empty)
+#   VM0_API_URL     - API URL, used as a local fallback for auth URL
+#   VM0_AUTH_DOMAIN - API domain override for auth callbacks
+#   E2E_ACCOUNT     - Test email (auto-generated if empty)
 
 load '../../helpers/setup'
 load '../../helpers/browser'
@@ -26,7 +28,8 @@ setup_file() {
   export SIGNUP_PASSWORD
 
   echo "# Clerk UI E2E (sign-up and sign-in)" >&3
-  echo "#   Web URL: $VM0_API_URL" >&3
+  echo "#   Auth URL: ${VM0_AUTH_URL:-${VM0_API_URL:-}}" >&3
+  echo "#   Auth domain: ${VM0_AUTH_DOMAIN:-<default>}" >&3
   echo "#   Email: $E2E_ACCOUNT" >&3
 }
 
@@ -34,13 +37,31 @@ teardown_file() {
   browser_teardown
 }
 
+auth_url() {
+  local path="$1"
+  local base="${VM0_AUTH_URL:-${VM0_API_URL:-}}"
+  local url="${base%/}${path}"
+
+  if [[ -n "${VM0_AUTH_DOMAIN:-}" ]]; then
+    local separator="?"
+    if [[ "$url" == *\?* ]]; then
+      separator="&"
+    fi
+    url="${url}${separator}domain=${VM0_AUTH_DOMAIN}"
+  fi
+
+  printf '%s' "$url"
+}
+
 # ===========================================================================
 # Phase 1: Sign up
 # ===========================================================================
 
 @test "sign up a new test account" {
-  echo "# Navigating to $VM0_API_URL/sign-up" >&3
-  agent-browser open "$VM0_API_URL/sign-up" --ignore-https-errors
+  local sign_up_url
+  sign_up_url="$(auth_url "/sign-up")"
+  echo "# Navigating to $sign_up_url" >&3
+  agent-browser open "$sign_up_url" --ignore-https-errors
   agent-browser wait 3000
   step_screenshot "sign-up-page"
 
@@ -106,8 +127,10 @@ teardown_file() {
   sleep 1
 
   # Re-open sign-in page
-  echo "# Navigating to $VM0_API_URL/sign-in" >&3
-  agent-browser open "$VM0_API_URL/sign-in" --ignore-https-errors
+  local sign_in_url
+  sign_in_url="$(auth_url "/sign-in")"
+  echo "# Navigating to $sign_in_url" >&3
+  agent-browser open "$sign_in_url" --ignore-https-errors
   agent-browser wait 3000
   step_screenshot "sign-in-page"
 

--- a/turbo/apps/platform/src/signals/__tests__/auth-url.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/auth-url.test.ts
@@ -1,50 +1,87 @@
 import { waitFor } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { detachedSetupPage } from "../../__tests__/page-helper.ts";
 import { resolveWebAuthUrl, resolveWebOrigin } from "../auth.ts";
 import { testContext } from "./test-helpers.ts";
 
 const context = testContext();
+const AUTH_ORIGIN = "https://so.vm7.ai:8443";
+const AUTH_DOMAIN = "api.vm7.ai:8443";
 
 function setBrowserUrl(url: string): void {
   window.location.href = url;
 }
 
+async function withoutConfiguredOnboarding<T>(
+  callback: () => T | Promise<T>,
+): Promise<T> {
+  vi.stubEnv("VITE_PAID_ONBOARDING_URL", "");
+  vi.stubEnv("VITE_PAID_ONBOARDING_DOMAIN", "");
+  try {
+    return await callback();
+  } finally {
+    vi.stubEnv("VITE_PAID_ONBOARDING_URL", AUTH_ORIGIN);
+    vi.stubEnv("VITE_PAID_ONBOARDING_DOMAIN", AUTH_DOMAIN);
+  }
+}
+
 describe("platform auth URLs", () => {
-  it("derives the web origin from the app origin", () => {
+  it("uses the configured onboarding origin for auth URLs", () => {
     setBrowserUrl("https://pr-18532-app.vm6.ai/agents");
 
-    expect(resolveWebOrigin()).toBe("https://pr-18532-www.vm6.ai");
+    expect(resolveWebOrigin()).toBe(AUTH_ORIGIN);
   });
 
-  it("adds the PR API domain override to vm6 auth URLs", () => {
+  it("adds the configured API domain override to auth URLs", () => {
     setBrowserUrl("https://pr-18532-app.vm6.ai/agents");
 
-    expect(resolveWebAuthUrl("/sign-in")).toBe(
-      "https://pr-18532-www.vm6.ai/sign-in?domain=pr-18532-api.vm6.ai",
+    const signInUrl = new URL(resolveWebAuthUrl("/sign-in"));
+    expect(signInUrl.origin).toBe(AUTH_ORIGIN);
+    expect(signInUrl.pathname).toBe("/sign-in");
+    expect(signInUrl.searchParams.get("domain")).toBe(AUTH_DOMAIN);
+
+    const chooseOrgUrl = new URL(
+      resolveWebAuthUrl("/sign-in/tasks/choose-organization"),
     );
-    expect(resolveWebAuthUrl("/sign-in/tasks/choose-organization")).toBe(
-      "https://pr-18532-www.vm6.ai/sign-in/tasks/choose-organization?domain=pr-18532-api.vm6.ai",
-    );
-    expect(
+    expect(chooseOrgUrl.origin).toBe(AUTH_ORIGIN);
+    expect(chooseOrgUrl.pathname).toBe("/sign-in/tasks/choose-organization");
+    expect(chooseOrgUrl.searchParams.get("domain")).toBe(AUTH_DOMAIN);
+
+    const redirectUrl = new URL(
       resolveWebAuthUrl("/sign-in", {
         redirectUrl: "https://pr-18532-app.vm6.ai/",
       }),
-    ).toBe(
-      "https://pr-18532-www.vm6.ai/sign-in?domain=pr-18532-api.vm6.ai&redirect_url=https%3A%2F%2Fpr-18532-app.vm6.ai%2F",
+    );
+    expect(redirectUrl.origin).toBe(AUTH_ORIGIN);
+    expect(redirectUrl.pathname).toBe("/sign-in");
+    expect(redirectUrl.searchParams.get("domain")).toBe(AUTH_DOMAIN);
+    expect(redirectUrl.searchParams.get("redirect_url")).toBe(
+      "https://pr-18532-app.vm6.ai/",
     );
   });
 
-  it("does not add a domain override outside vm6 preview origins", () => {
-    setBrowserUrl("https://app.vm0.ai/agents");
+  it("falls back to derived vm6 web and API origins without configured onboarding", async () => {
+    await withoutConfiguredOnboarding(() => {
+      setBrowserUrl("https://pr-18532-app.vm6.ai/agents");
 
-    expect(resolveWebAuthUrl("/sign-in")).toBe("https://www.vm0.ai/sign-in");
+      const url = new URL(resolveWebAuthUrl("/sign-in"));
+      expect(url.origin).toBe("https://pr-18532-www.vm6.ai");
+      expect(url.searchParams.get("domain")).toBe("pr-18532-api.vm6.ai");
+    });
+  });
+
+  it("does not add a fallback domain override outside vm6 preview origins", async () => {
+    await withoutConfiguredOnboarding(() => {
+      setBrowserUrl("https://app.vm0.ai/agents");
+
+      expect(resolveWebAuthUrl("/sign-in")).toBe("https://www.vm0.ai/sign-in");
+    });
   });
 });
 
 describe("platform auth redirects", () => {
-  it("redirects unauthenticated preview users to web sign-in with API domain override", async () => {
+  it("redirects unauthenticated users to configured auth with API domain override", async () => {
     setBrowserUrl("https://pr-18532-app.vm6.ai/agents");
 
     detachedSetupPage({
@@ -56,16 +93,16 @@ describe("platform auth redirects", () => {
 
     await waitFor(() => {
       const url = new URL(window.location.href);
-      expect(url.origin).toBe("https://pr-18532-www.vm6.ai");
+      expect(url.origin).toBe(AUTH_ORIGIN);
       expect(url.pathname).toBe("/sign-in");
-      expect(url.searchParams.get("domain")).toBe("pr-18532-api.vm6.ai");
+      expect(url.searchParams.get("domain")).toBe(AUTH_DOMAIN);
       expect(url.searchParams.get("redirect_url")).toBe(
         "https://pr-18532-app.vm6.ai/agents",
       );
     });
   });
 
-  it("redirects preview users who need org selection with API domain override", async () => {
+  it("redirects users who need org selection to configured auth", async () => {
     setBrowserUrl("https://pr-18532-app.vm6.ai/agents");
 
     detachedSetupPage({
@@ -79,29 +116,31 @@ describe("platform auth redirects", () => {
 
     await waitFor(() => {
       const url = new URL(window.location.href);
-      expect(url.origin).toBe("https://pr-18532-www.vm6.ai");
+      expect(url.origin).toBe(AUTH_ORIGIN);
       expect(url.pathname).toBe("/sign-in/tasks/choose-organization");
-      expect(url.searchParams.get("domain")).toBe("pr-18532-api.vm6.ai");
+      expect(url.searchParams.get("domain")).toBe(AUTH_DOMAIN);
     });
   });
 
-  it("redirects non-preview org selection without an API domain override", async () => {
-    setBrowserUrl("https://app.vm0.ai/agents");
+  it("falls back to derived web auth for non-preview org selection", async () => {
+    await withoutConfiguredOnboarding(async () => {
+      setBrowserUrl("https://app.vm0.ai/agents");
 
-    detachedSetupPage({
-      context,
-      org: {
-        activeOrg: null,
-        memberships: [{ id: "org_member" }],
-      },
-      path: "/agents",
-    });
+      detachedSetupPage({
+        context,
+        org: {
+          activeOrg: null,
+          memberships: [{ id: "org_member" }],
+        },
+        path: "/agents",
+      });
 
-    await waitFor(() => {
-      const url = new URL(window.location.href);
-      expect(url.origin).toBe("https://www.vm0.ai");
-      expect(url.pathname).toBe("/sign-in/tasks/choose-organization");
-      expect(url.searchParams.has("domain")).toBeFalsy();
+      await waitFor(() => {
+        const url = new URL(window.location.href);
+        expect(url.origin).toBe("https://www.vm0.ai");
+        expect(url.pathname).toBe("/sign-in/tasks/choose-organization");
+        expect(url.searchParams.has("domain")).toBeFalsy();
+      });
     });
   });
 });

--- a/turbo/apps/platform/src/signals/__tests__/auth-url.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/auth-url.test.ts
@@ -26,6 +26,17 @@ async function withoutConfiguredOnboarding<T>(
   }
 }
 
+async function withProductionDeployment<T>(
+  callback: () => T | Promise<T>,
+): Promise<T> {
+  vi.stubEnv("VITE_VERCEL_ENV", "production");
+  try {
+    return await callback();
+  } finally {
+    vi.stubEnv("VITE_VERCEL_ENV", "");
+  }
+}
+
 describe("platform auth URLs", () => {
   it("uses the configured onboarding origin for auth URLs", () => {
     setBrowserUrl("https://pr-18532-app.vm6.ai/agents");
@@ -76,6 +87,17 @@ describe("platform auth URLs", () => {
       setBrowserUrl("https://app.vm0.ai/agents");
 
       expect(resolveWebAuthUrl("/sign-in")).toBe("https://www.vm0.ai/sign-in");
+    });
+  });
+
+  it("keeps production auth on the derived web origin", async () => {
+    await withProductionDeployment(() => {
+      setBrowserUrl("https://app.vm0.ai/agents");
+
+      const url = new URL(resolveWebAuthUrl("/sign-in"));
+      expect(url.origin).toBe("https://www.vm0.ai");
+      expect(url.pathname).toBe("/sign-in");
+      expect(url.searchParams.has("domain")).toBeFalsy();
     });
   });
 });

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -7,11 +7,19 @@ const reload$ = state(0);
 const clerkVersion$ = state(0);
 
 /**
- * Resolve the web app origin from the current app origin.
- * Replaces "platform" or "app" with "www" in the hostname so sign-in/sign-out
- * redirects land on the web app where auth pages live.
+ * Resolve the hosted auth/onboarding origin.
+ * Preview and staging deployments use the shared SO surface from
+ * VITE_PAID_ONBOARDING_URL; local and legacy deployments fall back to the web
+ * origin derived from the current app origin.
  */
 export function resolveWebOrigin(): string {
+  const configuredUrl = import.meta.env.VITE_PAID_ONBOARDING_URL as
+    | string
+    | undefined;
+  if (configuredUrl) {
+    return new URL(configuredUrl).origin;
+  }
+
   const origin = location.origin;
   if (!origin || origin === "null") {
     return "";
@@ -22,6 +30,13 @@ export function resolveWebOrigin(): string {
 }
 
 function resolveDomainOverride(): string | null {
+  const configuredDomain = import.meta.env.VITE_PAID_ONBOARDING_DOMAIN as
+    | string
+    | undefined;
+  if (configuredDomain) {
+    return configuredDomain;
+  }
+
   const origin = location.origin;
   if (!origin || origin === "null") {
     return null;

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -8,16 +8,18 @@ const clerkVersion$ = state(0);
 
 /**
  * Resolve the hosted auth/onboarding origin.
- * Preview and staging deployments use the shared SO surface from
- * VITE_PAID_ONBOARDING_URL; local and legacy deployments fall back to the web
- * origin derived from the current app origin.
+ * Preview and staging deployments can use the shared SO surface from
+ * VITE_PAID_ONBOARDING_URL; production keeps the historical web origin so this
+ * auth bridge does not change live sign-in behavior.
  */
 export function resolveWebOrigin(): string {
-  const configuredUrl = import.meta.env.VITE_PAID_ONBOARDING_URL as
-    | string
-    | undefined;
-  if (configuredUrl) {
-    return new URL(configuredUrl).origin;
+  if (import.meta.env.VITE_VERCEL_ENV !== "production") {
+    const configuredUrl = import.meta.env.VITE_PAID_ONBOARDING_URL as
+      | string
+      | undefined;
+    if (configuredUrl) {
+      return new URL(configuredUrl).origin;
+    }
   }
 
   const origin = location.origin;
@@ -30,11 +32,13 @@ export function resolveWebOrigin(): string {
 }
 
 function resolveDomainOverride(): string | null {
-  const configuredDomain = import.meta.env.VITE_PAID_ONBOARDING_DOMAIN as
-    | string
-    | undefined;
-  if (configuredDomain) {
-    return configuredDomain;
+  if (import.meta.env.VITE_VERCEL_ENV !== "production") {
+    const configuredDomain = import.meta.env.VITE_PAID_ONBOARDING_DOMAIN as
+      | string
+      | undefined;
+    if (configuredDomain) {
+      return configuredDomain;
+    }
   }
 
   const origin = location.origin;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
@@ -342,7 +342,7 @@ describe("zero sidebar account menu", () => {
       expect(mockedClerk.signOut).toHaveBeenCalledWith(
         expect.objectContaining({
           sessionId: "test-session-id",
-          redirectUrl: expect.stringContaining("/sign-in?redirect_url="),
+          redirectUrl: expect.stringMatching(/\/sign-in\?.*redirect_url=/),
         }),
       );
     });


### PR DESCRIPTION
## Summary
- make platform auth URLs prefer the configured onboarding origin/domain, with the legacy app-to-www fallback retained
- update auth URL tests for the configured staging SO origin and PR API domain override
- keep browser/Playwright e2e helpers compatible with explicit auth/app/API URLs without reintroducing the removed cli-e2e-02 workflow jobs
- relax the sidebar sign-out redirect assertion so query parameter order does not matter

## Notes
- Latest main already includes #19310, which removed the legacy cli-e2e-02 browser/playwright jobs from turbo.yml. This PR keeps that main workflow shape and does not restore those jobs.

## Tests
- pnpm -F @vm0/app exec vitest run src/signals/__tests__/auth-url.test.ts src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
- pnpm -F @vm0/app run lint
- pnpm -F @vm0/app run check-types
- pnpm exec prettier --check --ignore-unknown ../e2e/tests/02-browser/brw-t01-platform-e2e.bats ../e2e/playwright/playwright.config.ts ../e2e/playwright/tests/smoke.spec.ts apps/platform/src/signals/auth.ts apps/platform/src/signals/__tests__/auth-url.test.ts apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
- VM0_API_URL=https://pr-1-api.vm6.ai VM0_APP_URL=https://pr-1-app.vm6.ai npx playwright test --config playwright/playwright.config.ts --list
- pre-commit hook: turbo prettier, knip, and turbo run check-types