### PR TITLE
refactor: remove legacy agent compose delete route

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/composes.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/composes.bdd.test.ts
@@ -20,9 +20,7 @@ import {
   createComposesBddApi,
   mockComposeInstructionsDownloads,
   sandboxComposeToken,
-  zeroComposeDeleteToken,
 } from "./helpers/api-bdd-composes";
-import { mockClerkMembership } from "./helpers/api-bdd-clerk";
 import { createRunsAutomationsApi } from "./helpers/api-bdd-runs-automations";
 import { createStoragesBddApi } from "./helpers/api-bdd-storages";
 
@@ -668,18 +666,6 @@ describe("COMPOSE-01 token access", () => {
       filename: "CLAUDE.md",
     });
 
-    const sandboxDelete = await composes.requestDeleteCompose(
-      sandbox,
-      composeId,
-      [403],
-    );
-    expect(sandboxDelete.body).toStrictEqual({
-      error: {
-        message: "Agent deletion is not available from sandbox",
-        code: "FORBIDDEN",
-      },
-    });
-
     const foreignSandbox = {
       bearer: sandboxComposeToken({
         userId: `user_${randomUUID()}`,
@@ -692,25 +678,6 @@ describe("COMPOSE-01 token access", () => {
       [200],
     );
     expect(foreignRead.body.id).toBe(composeId);
-
-    mockClerkMembership(context, admin, "org:admin");
-    const zeroToken = {
-      bearer: zeroComposeDeleteToken({
-        userId: admin.userId,
-        orgId: adminOrgId,
-      }),
-    };
-    const zeroDelete = await composes.requestDeleteCompose(
-      zeroToken,
-      composeId,
-      [403],
-    );
-    expect(zeroDelete.body).toStrictEqual({
-      error: {
-        message: "Agent deletion is not available from sandbox",
-        code: "FORBIDDEN",
-      },
-    });
 
     const freshSandbox = {
       bearer: sandboxComposeToken({
@@ -772,13 +739,6 @@ describe("COMPOSE-01 token access", () => {
       [401],
     );
     expect(metadata.body).toStrictEqual(unauthenticatedBody);
-
-    const composeDelete = await composes.requestDeleteCompose(
-      null,
-      missingId,
-      [401],
-    );
-    expect(composeDelete.body).toStrictEqual(unauthenticatedBody);
 
     const zeroByName = await composes.requestReadZeroComposeByName(
       null,
@@ -978,13 +938,6 @@ describe("COMPOSE-01 delete protection and volume sweep", () => {
         code: "CONFLICT",
       },
     };
-    const agentConflict = await composes.requestDeleteCompose(
-      actor,
-      compose.composeId,
-      [409],
-    );
-    expect(agentConflict.body).toStrictEqual(conflictBody);
-
     const zeroConflict = await composes.requestDeleteZeroCompose(
       actor,
       compose.composeId,
@@ -1013,7 +966,7 @@ describe("COMPOSE-01 delete protection and volume sweep", () => {
       },
     ]);
 
-    await composes.requestDeleteCompose(actor, compose.composeId, [204]);
+    await composes.requestDeleteZeroCompose(actor, compose.composeId, [204]);
 
     const deleted = await api.requestReadComposeById(
       actor,
@@ -1047,7 +1000,7 @@ describe("COMPOSE-01 delete protection and volume sweep", () => {
       owner,
       composeWith(slug("bdd-plain-delete")),
     );
-    await composes.requestDeleteCompose(owner, created.composeId, [204]);
+    await composes.requestDeleteZeroCompose(owner, created.composeId, [204]);
     const gone = await api.requestReadComposeById(
       owner,
       created.composeId,
@@ -1056,7 +1009,7 @@ describe("COMPOSE-01 delete protection and volume sweep", () => {
     expectApiError(gone.body);
     expect(context.mocks.s3.send).not.toHaveBeenCalled();
 
-    const unknown = await composes.requestDeleteCompose(
+    const unknown = await composes.requestDeleteZeroCompose(
       owner,
       randomUUID(),
       [404],
@@ -1069,7 +1022,7 @@ describe("COMPOSE-01 delete protection and volume sweep", () => {
       orgId: orgIdOf(owner),
       orgRole: "org:member",
     });
-    const memberDelete = await composes.requestDeleteCompose(
+    const memberDelete = await composes.requestDeleteZeroCompose(
       member,
       kept.composeId,
       [404],

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-org.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-auth-org.ts
@@ -1695,19 +1695,6 @@ export function createAuthOrgAgentsBddApi(context: TestContext) {
       );
     },
 
-    async deleteCompose(actor: ApiTestUser, composeId: string): Promise<void> {
-      const client = setupAppWithRoutes({ context, routes: authOrgRoutes })(
-        composesByIdContract,
-      );
-      await accept(
-        client.delete({
-          headers: authenticate(actor),
-          params: { id: composeId },
-        }),
-        [204],
-      );
-    },
-
     async readZeroComposeById(
       actor: ApiTestUser,
       composeId: string,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-composes.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-composes.ts
@@ -146,26 +146,6 @@ export function sandboxComposeToken(args: {
   });
 }
 
-/**
- * Zero-scope token carrying `agent:delete`, proving compose deletion is
- * refused even for capability-bearing zero tokens (web-compatible 403).
- */
-export function zeroComposeDeleteToken(args: {
-  readonly userId: string;
-  readonly orgId: string;
-}): string {
-  const seconds = Math.floor(now() / 1000);
-  return signSandboxJwtForTests({
-    scope: "zero",
-    userId: args.userId,
-    orgId: args.orgId,
-    runId: `run_${randomUUID()}`,
-    capabilities: ["agent:delete"],
-    iat: seconds,
-    exp: seconds + 3600,
-  });
-}
-
 const TAR_BLOCK_SIZE = 512;
 
 function octal(value: number, length: number): string {
@@ -558,20 +538,6 @@ export function createComposesBddApi(context: TestContext) {
           headers: authenticate(auth),
           params: { id: composeId },
           body,
-        }),
-        statuses,
-      );
-    },
-
-    async requestDeleteCompose<TStatus extends DeleteStatus>(
-      auth: ComposeAuth,
-      composeId: string,
-      statuses: readonly TStatus[],
-    ) {
-      return await accept(
-        byIdClient().delete({
-          headers: authenticate(auth),
-          params: { id: composeId },
         }),
         statuses,
       );

--- a/turbo/apps/api/src/signals/routes/agent-composes-id.ts
+++ b/turbo/apps/api/src/signals/routes/agent-composes-id.ts
@@ -1,51 +1,14 @@
-import { command, computed } from "ccstate";
+import { computed } from "ccstate";
 import { composesByIdContract } from "@vm0/api-contracts/contracts/composes";
 
 import { authContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { pathParamsOf } from "../context/request";
-import { isConflictResponse, isNotFoundResponse } from "../../lib/error";
-import { deleteCompose$ } from "../services/zero-compose-data.service";
 import {
   agentComposeById,
   agentComposeOrgId,
 } from "../services/agent-composes-read.service";
 import type { RouteEntry } from "../route-entry";
-
-const sandboxDeleteForbidden = {
-  status: 403 as const,
-  body: {
-    error: {
-      message: "Agent deletion is not available from sandbox",
-      code: "FORBIDDEN",
-    },
-  },
-} as const;
-
-const deleteAgentComposeInner$ = command(
-  async ({ get, set }, signal: AbortSignal) => {
-    const auth = get(authContext$);
-    if (auth.tokenType === "sandbox" || auth.tokenType === "zero") {
-      return sandboxDeleteForbidden;
-    }
-
-    const params = get(pathParamsOf(composesByIdContract.delete));
-    const result = await set(
-      deleteCompose$,
-      { composeId: params.id, userId: auth.userId },
-      signal,
-    );
-    signal.throwIfAborted();
-
-    if (isNotFoundResponse(result)) {
-      return result;
-    }
-    if (isConflictResponse(result)) {
-      return result;
-    }
-    return { status: 204 as const, body: undefined };
-  },
-);
 
 const getAgentComposeInner$ = computed(async (get) => {
   const auth = get(authContext$);
@@ -91,9 +54,5 @@ export const agentComposesByIdRoutes: readonly RouteEntry[] = [
   {
     route: composesByIdContract.getById,
     handler: authRoute(anySandboxAuth, getAgentComposeInner$),
-  },
-  {
-    route: composesByIdContract.delete,
-    handler: authRoute(anySandboxAuth, deleteAgentComposeInner$),
   },
 ];

--- a/turbo/packages/api-contracts/src/contracts/composes.ts
+++ b/turbo/packages/api-contracts/src/contracts/composes.ts
@@ -413,29 +413,6 @@ export const composesByIdContract = c.router({
     },
     summary: "Get agent compose by ID",
   },
-
-  /**
-   * DELETE /api/agent/composes/:id
-   * Delete agent compose and all associated resources (versions, automations, permissions, etc.)
-   * Returns 409 Conflict if agent has running or pending runs
-   */
-  delete: {
-    method: "DELETE",
-    path: "/api/agent/composes/:id",
-    headers: authHeadersSchema,
-    pathParams: z.object({
-      id: z.string().uuid("Compose ID is required"),
-    }),
-    body: c.noBody(),
-    responses: {
-      204: c.noBody(),
-      401: apiErrorSchema,
-      403: apiErrorSchema,
-      404: apiErrorSchema,
-      409: apiErrorSchema,
-    },
-    summary: "Delete agent compose",
-  },
 });
 
 /**


### PR DESCRIPTION
## Summary
- remove the legacy `DELETE /api/agent/composes/:id` contract and API route
- keep compose deletion covered through the zero compose/agent delete path
- update compose BDD helpers and assertions to stop calling the removed legacy route

Refs #16379

## Checks
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F api lint`
- `pnpm -F @vm0/api-contracts check-types`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm -F api exec vitest run src/signals/routes/__tests__/composes.bdd.test.ts`