### PR TITLE
fix: cover google media upload put firewall routes

### DIFF
--- a/crates/runner/mitm-addon/src/generated/builtin_firewalls/gmail_0.py
+++ b/crates/runner/mitm-addon/src/generated/builtin_firewalls/gmail_0.py
@@ -214,7 +214,8 @@ JSON_PART = r"""{
           "description": "Send Gmail drafts.",
           "name": "drafts.send",
           "rules": [
-            "POST /v1/users/{userId}/drafts/send"
+            "POST /v1/users/{userId}/drafts/send",
+            "PUT /v1/users/{userId}/drafts/send"
           ]
         },
         {
@@ -222,6 +223,7 @@ JSON_PART = r"""{
           "name": "drafts.write",
           "rules": [
             "POST /v1/users/{userId}/drafts",
+            "PUT /v1/users/{userId}/drafts",
             "PUT /v1/users/{userId}/drafts/{id}"
           ]
         },
@@ -229,7 +231,8 @@ JSON_PART = r"""{
           "description": "Send Gmail messages directly.",
           "name": "messages.send",
           "rules": [
-            "POST /v1/users/{userId}/messages/send"
+            "POST /v1/users/{userId}/messages/send",
+            "PUT /v1/users/{userId}/messages/send"
           ]
         },
         {
@@ -237,7 +240,9 @@ JSON_PART = r"""{
           "name": "messages.write",
           "rules": [
             "POST /v1/users/{userId}/messages",
-            "POST /v1/users/{userId}/messages/import"
+            "PUT /v1/users/{userId}/messages",
+            "POST /v1/users/{userId}/messages/import",
+            "PUT /v1/users/{userId}/messages/import"
           ]
         }
       ]
@@ -254,7 +259,8 @@ JSON_PART = r"""{
           "description": "Send Gmail drafts.",
           "name": "drafts.send",
           "rules": [
-            "POST /v1/users/{userId}/drafts/send"
+            "POST /v1/users/{userId}/drafts/send",
+            "PUT /v1/users/{userId}/drafts/send"
           ]
         },
         {
@@ -262,6 +268,7 @@ JSON_PART = r"""{
           "name": "drafts.write",
           "rules": [
             "POST /v1/users/{userId}/drafts",
+            "PUT /v1/users/{userId}/drafts",
             "PUT /v1/users/{userId}/drafts/{id}"
           ]
         },
@@ -269,7 +276,8 @@ JSON_PART = r"""{
           "description": "Send Gmail messages directly.",
           "name": "messages.send",
           "rules": [
-            "POST /v1/users/{userId}/messages/send"
+            "POST /v1/users/{userId}/messages/send",
+            "PUT /v1/users/{userId}/messages/send"
           ]
         },
         {
@@ -277,7 +285,9 @@ JSON_PART = r"""{
           "name": "messages.write",
           "rules": [
             "POST /v1/users/{userId}/messages",
-            "POST /v1/users/{userId}/messages/import"
+            "PUT /v1/users/{userId}/messages",
+            "POST /v1/users/{userId}/messages/import",
+            "PUT /v1/users/{userId}/messages/import"
           ]
         }
       ]

--- a/crates/runner/mitm-addon/src/generated/builtin_firewalls/google_cloud_0.py
+++ b/crates/runner/mitm-addon/src/generated/builtin_firewalls/google_cloud_0.py
@@ -4852,7 +4852,9 @@ JSON_PART = r"""{
             "POST /bigquery/v2/projects/{projectsId}/jobs",
             "POST /bigquery/v2/projects/{projectsId}/queries",
             "POST /resumable/upload/bigquery/v2/projects/{projectsId}/jobs",
-            "POST /upload/bigquery/v2/projects/{projectsId}/jobs"
+            "PUT /resumable/upload/bigquery/v2/projects/{projectsId}/jobs",
+            "POST /upload/bigquery/v2/projects/{projectsId}/jobs",
+            "PUT /upload/bigquery/v2/projects/{projectsId}/jobs"
           ]
         },
         {
@@ -5234,11 +5236,13 @@ JSON_PART = r"""{
           "name": "storage.objects.create",
           "rules": [
             "POST /resumable/upload/storage/v1/b/{bucket}/o",
+            "PUT /resumable/upload/storage/v1/b/{bucket}/o",
             "POST /storage/v1/b/{bucket}/o",
             "POST /storage/v1/b/{destinationBucket}/o/{destinationObject}/compose",
             "POST /storage/v1/b/{sourceBucket}/o/{sourceObject}/copyTo/b/{destinationBucket}/o/{destinationObject}",
             "POST /storage/v1/b/{sourceBucket}/o/{sourceObject}/rewriteTo/b/{destinationBucket}/o/{destinationObject}",
-            "POST /upload/storage/v1/b/{bucket}/o"
+            "POST /upload/storage/v1/b/{bucket}/o",
+            "PUT /upload/storage/v1/b/{bucket}/o"
           ]
         },
         {
@@ -5687,19 +5691,13 @@ JSON_PART = r"""{
           "name": "artifactregistry.files.upload",
           "rules": [
             "POST /resumable/upload/v1/projects/{projectsId}/locations/{locationsId}/repositories/{repositoriesId}/files:upload",
+            "PUT /resumable/upload/v1/projects/{projectsId}/locations/{locationsId}/repositories/{repositoriesId}/files:upload",
             "POST /resumable/upload/v1/projects/{projectsId}/locations/{locationsId}/repositories/{repositoriesId}/genericArtifacts:create",
+            "PUT /resumable/upload/v1/projects/{projectsId}/locations/{locationsId}/repositories/{repositoriesId}/genericArtifacts:create",
             "POST /upload/v1/projects/{projectsId}/locations/{locationsId}/repositories/{repositoriesId}/files:upload",
+            "PUT /upload/v1/projects/{projectsId}/locations/{locationsId}/repositories/{repositoriesId}/files:upload",
             "POST /upload/v1/projects/{projectsId}/locations/{locationsId}/repositories/{repositoriesId}/genericArtifacts:create",
+            "PUT /upload/v1/projects/{projectsId}/locations/{locationsId}/repositories/{repositoriesId}/genericArtifacts:create",
             "POST /upload/v1/projects/{projectsId}/locations/{locationsId}/repositories/{repositoriesId}/goModules:create",
             "POST /upload/v1/projects/{projectsId}/locations/{locationsId}/repositories/{repositoriesId}/googetArtifacts:create",
-            "POST /v1/projects/{projectsId}/locations/{locationsId}/repositories/{repositoriesId}/files:upload",
-            "POST /v1/projects/{projectsId}/locations/{locationsId}/repositories/{repositoriesId}/genericArtifacts:create",
-            "POST /v1/projects/{projectsId}/locations/{locationsId}/repositories/{repositoriesId}/goModules:create",
-            "POST /v1/projects/{projectsId}/locations/{locationsId}/repositories/{repositoriesId}/googetArtifacts:create"
-          ]
-        },
-        {
-          "name": "artifactregistry.kfpartifacts.create",
-          "rules": [
-            "POST /upload/v1/projects/{projectsId}/locations/{locationsId}/repositories/{repositoriesId}/kfpArtifacts:create",
 """

--- a/crates/runner/mitm-addon/src/generated/builtin_firewalls/google_cloud_1.py
+++ b/crates/runner/mitm-addon/src/generated/builtin_firewalls/google_cloud_1.py
@@ -3,7 +3,17 @@
 # Regenerate with: cd turbo && pnpm -F @vm0/firewalls-generator generate
 # ruff: noqa
 
-JSON_PART = r"""            "POST /v1/projects/{projectsId}/locations/{locationsId}/repositories/{repositoriesId}/kfpArtifacts:create"
+JSON_PART = r"""            "POST /v1/projects/{projectsId}/locations/{locationsId}/repositories/{repositoriesId}/files:upload",
+            "POST /v1/projects/{projectsId}/locations/{locationsId}/repositories/{repositoriesId}/genericArtifacts:create",
+            "POST /v1/projects/{projectsId}/locations/{locationsId}/repositories/{repositoriesId}/goModules:create",
+            "POST /v1/projects/{projectsId}/locations/{locationsId}/repositories/{repositoriesId}/googetArtifacts:create"
+          ]
+        },
+        {
+          "name": "artifactregistry.kfpartifacts.create",
+          "rules": [
+            "POST /upload/v1/projects/{projectsId}/locations/{locationsId}/repositories/{repositoriesId}/kfpArtifacts:create",
+            "POST /v1/projects/{projectsId}/locations/{locationsId}/repositories/{repositoriesId}/kfpArtifacts:create"
           ]
         },
         {

--- a/crates/runner/mitm-addon/src/generated/builtin_firewalls/google_drive_0.py
+++ b/crates/runner/mitm-addon/src/generated/builtin_firewalls/google_drive_0.py
@@ -275,8 +275,11 @@ JSON_PART = r"""{
           "name": "files.write",
           "rules": [
             "POST /v2/files",
+            "PUT /v2/files",
             "PUT /v2/files/{fileId}",
             "POST /v3/files",
+            "PUT /v3/files",
+            "PUT /v3/files/{fileId}",
             "PATCH /v3/files/{fileId}"
           ]
         }
@@ -295,8 +298,11 @@ JSON_PART = r"""{
           "name": "files.write",
           "rules": [
             "POST /v2/files",
+            "PUT /v2/files",
             "PUT /v2/files/{fileId}",
             "POST /v3/files",
+            "PUT /v3/files",
+            "PUT /v3/files/{fileId}",
             "PATCH /v3/files/{fileId}"
           ]
         }

--- a/crates/runner/mitm-addon/tests/test_builtin_firewalls_catalog.py
+++ b/crates/runner/mitm-addon/tests/test_builtin_firewalls_catalog.py
@@ -413,6 +413,82 @@ def test_gmail_firewall_uses_resource_permissions():
     assert not [name for name in permissions if name.startswith("gmail.")]
 
 
+def test_gmail_builtin_allows_message_send_media_put_as_send():
+    firewall = builtin_firewalls.BUILTIN_FIREWALLS["gmail"]
+    compiled = matching.compile_firewalls([firewall])
+    assert compiled is not None
+
+    for url in (
+        "https://gmail.googleapis.com/upload/gmail/v1/users/me/messages/send",
+        "https://gmail.googleapis.com/resumable/upload/gmail/v1/users/me/messages/send",
+    ):
+        result = matching.match_compiled_firewall_request(
+            url,
+            "PUT",
+            compiled,
+            {
+                "gmail": {
+                    "allow": ["messages.send"],
+                    "deny": ["messages.write"],
+                    "unknownPolicy": "deny",
+                }
+            },
+        )
+
+        assert isinstance(result, matching.FirewallAllow)
+        assert result.permission == "messages.send"
+        assert result.rule == "PUT /v1/users/{userId}/messages/send"
+        assert result.rel_path == "/v1/users/me/messages/send"
+
+
+def test_google_drive_builtin_allows_file_update_media_put_as_write():
+    firewall = builtin_firewalls.BUILTIN_FIREWALLS["google-drive"]
+    compiled = matching.compile_firewalls([firewall])
+    assert compiled is not None
+
+    result = matching.match_compiled_firewall_request(
+        "https://www.googleapis.com/resumable/upload/drive/v3/files/file-123",
+        "PUT",
+        compiled,
+        {
+            "google-drive": {
+                "allow": ["files.write"],
+                "deny": ["files.read"],
+                "unknownPolicy": "deny",
+            }
+        },
+    )
+
+    assert isinstance(result, matching.FirewallAllow)
+    assert result.permission == "files.write"
+    assert result.rule == "PUT /v3/files/{fileId}"
+    assert result.rel_path == "/v3/files/file-123"
+
+
+def test_google_cloud_builtin_allows_storage_resumable_media_put_as_create():
+    firewall = builtin_firewalls.BUILTIN_FIREWALLS["google-cloud"]
+    compiled = matching.compile_firewalls([firewall])
+    assert compiled is not None
+
+    result = matching.match_compiled_firewall_request(
+        "https://storage.googleapis.com/resumable/upload/storage/v1/b/bucket-1/o?upload_id=abc",
+        "PUT",
+        compiled,
+        {
+            "google-cloud": {
+                "allow": ["storage.objects.create"],
+                "deny": ["storage.objects.get"],
+                "unknownPolicy": "deny",
+            }
+        },
+    )
+
+    assert isinstance(result, matching.FirewallAllow)
+    assert result.permission == "storage.objects.create"
+    assert result.rule == "PUT /resumable/upload/storage/v1/b/{bucket}/o"
+    assert result.rel_path == "/resumable/upload/storage/v1/b/bucket-1/o"
+
+
 def test_youtube_builtin_allows_video_media_put_as_create():
     firewall = builtin_firewalls.BUILTIN_FIREWALLS["youtube"]
     compiled = matching.compile_firewalls([firewall])

--- a/turbo/packages/connectors/src/__tests__/firewall-rule-validation.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-rule-validation.test.ts
@@ -68,6 +68,22 @@ function apiBases(firewall: FirewallConfig): string[] {
   });
 }
 
+function rulesByPermission(firewall: FirewallConfig): Map<string, Set<string>> {
+  const result = new Map<string, Set<string>>();
+
+  for (const api of firewall.apis) {
+    for (const permission of api.permissions ?? []) {
+      const rules = result.get(permission.name) ?? new Set<string>();
+      for (const rule of permission.rules) {
+        rules.add(`${api.base} ${rule}`);
+      }
+      result.set(permission.name, rules);
+    }
+  }
+
+  return result;
+}
+
 function baseSampleUrls(base: string): string[] {
   if (base.includes("${{")) return [];
   return FIREWALL_BASE_SAMPLE_VALUES.map((value) => {
@@ -329,25 +345,53 @@ describe("known endpoint-scoped firewall bases", () => {
 
   it("keeps Gmail send routes out of draft write permission", async () => {
     const firewall = await loadRequiredConnectorFirewall("gmail");
-    const rulesByPermission = new Map<string, Set<string>>();
+    const rules = rulesByPermission(firewall);
 
-    for (const api of firewall.apis) {
-      for (const permission of api.permissions ?? []) {
-        const rules = rulesByPermission.get(permission.name) ?? new Set();
-        for (const rule of permission.rules) {
-          rules.add(`${api.base} ${rule}`);
-        }
-        rulesByPermission.set(permission.name, rules);
-      }
-    }
-
-    expect([...rulesByPermission.get("messages.send")!].sort()).toEqual([
+    expect([...rules.get("messages.send")!].sort()).toEqual([
       "https://gmail.googleapis.com/gmail POST /v1/users/{userId}/messages/send",
       "https://gmail.googleapis.com/resumable/upload/gmail POST /v1/users/{userId}/messages/send",
+      "https://gmail.googleapis.com/resumable/upload/gmail PUT /v1/users/{userId}/messages/send",
       "https://gmail.googleapis.com/upload/gmail POST /v1/users/{userId}/messages/send",
+      "https://gmail.googleapis.com/upload/gmail PUT /v1/users/{userId}/messages/send",
     ]);
-    expect(rulesByPermission.get("drafts.write")).not.toContain(
+    expect(rules.get("messages.write")).toContain(
+      "https://gmail.googleapis.com/upload/gmail PUT /v1/users/{userId}/messages/import",
+    );
+    expect(rules.get("drafts.write")).not.toContain(
       "https://gmail.googleapis.com/gmail POST /v1/users/{userId}/drafts/send",
+    );
+  });
+
+  it("keeps Google Drive media PUT routes attached to files.write", async () => {
+    const firewall = await loadRequiredConnectorFirewall("google-drive");
+    const rules = rulesByPermission(firewall);
+
+    expect(rules.get("files.write")).toContain(
+      "https://www.googleapis.com/upload/drive PUT /v3/files",
+    );
+    expect(rules.get("files.write")).toContain(
+      "https://www.googleapis.com/resumable/upload/drive PUT /v3/files/{fileId}",
+    );
+    expect(rules.get("files.read")).not.toContain(
+      "https://www.googleapis.com/upload/drive PUT /v3/files",
+    );
+  });
+
+  it("keeps Google Cloud media PUT routes attached to upload permissions", async () => {
+    const firewall = await loadRequiredConnectorFirewall("google-cloud");
+    const rules = rulesByPermission(firewall);
+
+    expect(rules.get("bigquery.jobs.create")).toContain(
+      "https://bigquery.googleapis.com PUT /resumable/upload/bigquery/v2/projects/{projectsId}/jobs",
+    );
+    expect(rules.get("storage.objects.create")).toContain(
+      "https://storage.googleapis.com PUT /resumable/upload/storage/v1/b/{bucket}/o",
+    );
+    expect(rules.get("artifactregistry.files.upload")).toContain(
+      "https://artifactregistry.googleapis.com PUT /resumable/upload/v1/projects/{projectsId}/locations/{locationsId}/repositories/{repositoriesId}/files:upload",
+    );
+    expect(rules.get("storage.objects.get")).not.toContain(
+      "https://storage.googleapis.com PUT /resumable/upload/storage/v1/b/{bucket}/o",
     );
   });
 

--- a/turbo/packages/firewalls-generator/src/__tests__/gmail.test.ts
+++ b/turbo/packages/firewalls-generator/src/__tests__/gmail.test.ts
@@ -44,7 +44,7 @@ describe("Gmail permission manifest", () => {
   });
 
   it("matches the official Discovery route set exactly", () => {
-    expect(officialRouteKeys.size).toBe(91);
+    expect(officialRouteKeys.size).toBe(101);
 
     expect(() => {
       validateGmailPermissionManifest(
@@ -99,6 +99,9 @@ describe("Gmail permission manifest", () => {
                       simple: {
                         path: "/upload/gmail/v1/users/{userId}/messages",
                       },
+                      resumable: {
+                        path: "/resumable/upload/gmail/v1/users/{userId}/messages",
+                      },
                     },
                   },
                 },
@@ -112,7 +115,10 @@ describe("Gmail permission manifest", () => {
     expect(routeKeys).toEqual(
       new Set([
         "base:POST /v1/users/{userId}/messages",
+        "resumable-upload:POST /v1/users/{userId}/messages",
+        "resumable-upload:PUT /v1/users/{userId}/messages",
         "upload:POST /v1/users/{userId}/messages",
+        "upload:PUT /v1/users/{userId}/messages",
       ]),
     );
   });
@@ -138,18 +144,25 @@ describe("Gmail permission manifest", () => {
     expect(draftsWrite.routeKeys).toContain(
       "upload:POST /v1/users/{userId}/drafts",
     );
+    expect(draftsWrite.routeKeys).toContain(
+      "upload:PUT /v1/users/{userId}/drafts",
+    );
     expect(draftsWrite.routeKeys).not.toContain(
       "base:POST /v1/users/{userId}/drafts/send",
     );
     expect(draftsSend.routeKeys).toEqual([
       "base:POST /v1/users/{userId}/drafts/send",
       "resumable-upload:POST /v1/users/{userId}/drafts/send",
+      "resumable-upload:PUT /v1/users/{userId}/drafts/send",
       "upload:POST /v1/users/{userId}/drafts/send",
+      "upload:PUT /v1/users/{userId}/drafts/send",
     ]);
     expect(messagesSend.routeKeys).toEqual([
       "base:POST /v1/users/{userId}/messages/send",
       "resumable-upload:POST /v1/users/{userId}/messages/send",
+      "resumable-upload:PUT /v1/users/{userId}/messages/send",
       "upload:POST /v1/users/{userId}/messages/send",
+      "upload:PUT /v1/users/{userId}/messages/send",
     ]);
   });
 

--- a/turbo/packages/firewalls-generator/src/__tests__/google-cloud.test.ts
+++ b/turbo/packages/firewalls-generator/src/__tests__/google-cloud.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { extractOfficialPermissionNames } from "../google-cloud";
+import {
+  extractOfficialPermissionNames,
+  googleCloudRulesForDiscoveryMethod,
+  type GoogleCloudDiscoveryDocument,
+} from "../google-cloud";
 
 describe("extractOfficialPermissionNames", () => {
   it("normalizes Google documentation word-break tags inside permission names", () => {
@@ -17,5 +21,38 @@ describe("extractOfficialPermissionNames", () => {
         "Use https://compute.googleapis.com and compute.googleapis.cn",
       ),
     ).toEqual([]);
+  });
+});
+
+describe("googleCloudRulesForDiscoveryMethod", () => {
+  it("adds media-phase PUT rules for resumable upload methods", () => {
+    const discovery: GoogleCloudDiscoveryDocument = {
+      servicePath: "bigquery/v2/",
+    };
+
+    expect(
+      googleCloudRulesForDiscoveryMethod(discovery, {
+        id: "bigquery.jobs.insert",
+        httpMethod: "POST",
+        path: "projects/{projectId}/jobs",
+        supportsMediaUpload: true,
+        mediaUpload: {
+          protocols: {
+            simple: {
+              path: "upload/bigquery/v2/projects/{projectId}/jobs",
+            },
+            resumable: {
+              path: "resumable/upload/bigquery/v2/projects/{projectId}/jobs",
+            },
+          },
+        },
+      }),
+    ).toEqual([
+      "POST /bigquery/v2/projects/{projectId}/jobs",
+      "POST /resumable/upload/bigquery/v2/projects/{projectId}/jobs",
+      "PUT /resumable/upload/bigquery/v2/projects/{projectId}/jobs",
+      "POST /upload/bigquery/v2/projects/{projectId}/jobs",
+      "PUT /upload/bigquery/v2/projects/{projectId}/jobs",
+    ]);
   });
 });

--- a/turbo/packages/firewalls-generator/src/__tests__/google-drive.test.ts
+++ b/turbo/packages/firewalls-generator/src/__tests__/google-drive.test.ts
@@ -50,7 +50,7 @@ describe("Google Drive permission manifest", () => {
   });
 
   it("matches the official Discovery route set exactly", () => {
-    expect(officialRouteKeys.size).toBe(141);
+    expect(officialRouteKeys.size).toBe(147);
 
     expect(() => {
       validateGoogleDrivePermissionManifest(
@@ -115,10 +115,16 @@ describe("Google Drive permission manifest", () => {
 
     expect(filesWrite.routeKeys).toContain("base:POST /v2/files");
     expect(filesWrite.routeKeys).toContain("upload:POST /v2/files");
+    expect(filesWrite.routeKeys).toContain("upload:PUT /v2/files");
     expect(filesWrite.routeKeys).toContain("resumable-upload:POST /v2/files");
+    expect(filesWrite.routeKeys).toContain("resumable-upload:PUT /v2/files");
     expect(filesWrite.routeKeys).toContain("upload:PATCH /v3/files/{fileId}");
+    expect(filesWrite.routeKeys).toContain("upload:PUT /v3/files/{fileId}");
     expect(filesWrite.routeKeys).toContain(
       "resumable-upload:PATCH /v3/files/{fileId}",
+    );
+    expect(filesWrite.routeKeys).toContain(
+      "resumable-upload:PUT /v3/files/{fileId}",
     );
   });
 

--- a/turbo/packages/firewalls-generator/src/__tests__/google-drive.test.ts
+++ b/turbo/packages/firewalls-generator/src/__tests__/google-drive.test.ts
@@ -84,6 +84,48 @@ describe("Google Drive permission manifest", () => {
     }).toThrow("Missing Google Drive manifest route keys");
   });
 
+  it("uses media upload protocol paths for upload routes", () => {
+    expect(
+      buildGoogleDriveOfficialRouteKeys([
+        {
+          version: "v3",
+          servicePath: "drive/v3/",
+          resources: {
+            files: {
+              methods: {
+                create: {
+                  id: "drive.files.create",
+                  httpMethod: "POST",
+                  path: "files",
+                  flatPath: "files",
+                  supportsMediaUpload: true,
+                  mediaUpload: {
+                    protocols: {
+                      simple: {
+                        path: "/upload/drive/v3/files/media",
+                      },
+                      resumable: {
+                        path: "/resumable/upload/drive/v3/files/media",
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      ]),
+    ).toEqual(
+      new Set([
+        "base:POST /v3/files",
+        "resumable-upload:POST /v3/files/media",
+        "resumable-upload:PUT /v3/files/media",
+        "upload:POST /v3/files/media",
+        "upload:PUT /v3/files/media",
+      ]),
+    );
+  });
+
   it("fails duplicate route assignments", () => {
     const duplicateRoute = "base:GET /v2/about";
     const manifest = cloneManifest();

--- a/turbo/packages/firewalls-generator/src/gmail.ts
+++ b/turbo/packages/firewalls-generator/src/gmail.ts
@@ -110,8 +110,10 @@ export const GMAIL_PERMISSION_MANIFEST: readonly GmailManifestPermission[] = [
       "base:POST /v1/users/{userId}/drafts",
       "base:PUT /v1/users/{userId}/drafts/{id}",
       "resumable-upload:POST /v1/users/{userId}/drafts",
+      "resumable-upload:PUT /v1/users/{userId}/drafts",
       "resumable-upload:PUT /v1/users/{userId}/drafts/{id}",
       "upload:POST /v1/users/{userId}/drafts",
+      "upload:PUT /v1/users/{userId}/drafts",
       "upload:PUT /v1/users/{userId}/drafts/{id}",
     ],
   },
@@ -122,7 +124,9 @@ export const GMAIL_PERMISSION_MANIFEST: readonly GmailManifestPermission[] = [
     routeKeys: [
       "base:POST /v1/users/{userId}/drafts/send",
       "resumable-upload:POST /v1/users/{userId}/drafts/send",
+      "resumable-upload:PUT /v1/users/{userId}/drafts/send",
       "upload:POST /v1/users/{userId}/drafts/send",
+      "upload:PUT /v1/users/{userId}/drafts/send",
     ],
   },
   {
@@ -168,8 +172,12 @@ export const GMAIL_PERMISSION_MANIFEST: readonly GmailManifestPermission[] = [
       "base:POST /v1/users/{userId}/messages/{id}/untrash",
       "resumable-upload:POST /v1/users/{userId}/messages",
       "resumable-upload:POST /v1/users/{userId}/messages/import",
+      "resumable-upload:PUT /v1/users/{userId}/messages",
+      "resumable-upload:PUT /v1/users/{userId}/messages/import",
       "upload:POST /v1/users/{userId}/messages",
       "upload:POST /v1/users/{userId}/messages/import",
+      "upload:PUT /v1/users/{userId}/messages",
+      "upload:PUT /v1/users/{userId}/messages/import",
     ],
   },
   {
@@ -179,7 +187,9 @@ export const GMAIL_PERMISSION_MANIFEST: readonly GmailManifestPermission[] = [
     routeKeys: [
       "base:POST /v1/users/{userId}/messages/send",
       "resumable-upload:POST /v1/users/{userId}/messages/send",
+      "resumable-upload:PUT /v1/users/{userId}/messages/send",
       "upload:POST /v1/users/{userId}/messages/send",
+      "upload:PUT /v1/users/{userId}/messages/send",
     ],
   },
   {
@@ -349,6 +359,27 @@ function uploadRuleForMethod(
   return `${httpMethod.toUpperCase()} /${protocol.path.slice(prefix.length)}`;
 }
 
+function mediaUploadPutRuleForMethod(
+  method: DiscoveryMethod,
+  kind: Exclude<GmailRouteKeyKind, "base">,
+): string | null {
+  const protocol =
+    kind === "upload"
+      ? method.mediaUpload?.protocols?.simple
+      : method.mediaUpload?.protocols?.resumable;
+  if (!protocol?.path) return null;
+
+  const prefix =
+    kind === "upload" ? "/upload/gmail/" : "/resumable/upload/gmail/";
+  if (!protocol.path.startsWith(prefix)) {
+    throw new Error(
+      `Unexpected Gmail ${kind} media upload path for ${method.id ?? "unknown"}: ${protocol.path}`,
+    );
+  }
+
+  return `PUT /${protocol.path.slice(prefix.length)}`;
+}
+
 export function buildGmailOfficialRouteKeys(
   discovery: GmailDiscoveryDocument,
 ): Set<string> {
@@ -376,6 +407,20 @@ export function buildGmailOfficialRouteKeys(
       if (resumableUploadRule) {
         uploadRouteCount += 1;
         routeKeys.add(`resumable-upload:${resumableUploadRule}`);
+      }
+      if (method.mediaUpload?.protocols?.resumable) {
+        const uploadMediaRule = mediaUploadPutRuleForMethod(method, "upload");
+        if (uploadMediaRule) {
+          routeKeys.add(`upload:${uploadMediaRule}`);
+        }
+
+        const resumableUploadMediaRule = mediaUploadPutRuleForMethod(
+          method,
+          "resumable-upload",
+        );
+        if (resumableUploadMediaRule) {
+          routeKeys.add(`resumable-upload:${resumableUploadMediaRule}`);
+        }
       }
     }
   }

--- a/turbo/packages/firewalls-generator/src/google-cloud.ts
+++ b/turbo/packages/firewalls-generator/src/google-cloud.ts
@@ -166,7 +166,7 @@ interface DiscoveryMediaUploadProtocol {
   path?: string;
 }
 
-interface DiscoveryMethod {
+interface GoogleCloudDiscoveryMethod {
   id?: string;
   httpMethod?: string;
   path?: string;
@@ -181,11 +181,11 @@ interface DiscoveryMethod {
 }
 
 interface DiscoveryResource {
-  methods?: Record<string, DiscoveryMethod>;
+  methods?: Record<string, GoogleCloudDiscoveryMethod>;
   resources?: Record<string, DiscoveryResource>;
 }
 
-interface DiscoveryDocument {
+export interface GoogleCloudDiscoveryDocument {
   title?: string;
   version?: string;
   baseUrl?: string;
@@ -945,8 +945,8 @@ function permissionForMethod(
 
 function extractMethods(
   resources: Record<string, DiscoveryResource>,
-): DiscoveryMethod[] {
-  const methods: DiscoveryMethod[] = [];
+): GoogleCloudDiscoveryMethod[] {
+  const methods: GoogleCloudDiscoveryMethod[] = [];
   for (const resource of Object.values(resources)) {
     if (resource.methods) {
       methods.push(...Object.values(resource.methods));
@@ -966,7 +966,7 @@ function normalizeTemplatePath(path: string): string {
 }
 
 function methodPathWithServicePath(
-  discovery: DiscoveryDocument,
+  discovery: GoogleCloudDiscoveryDocument,
   methodPath: string,
 ): string {
   const normalized = normalizeTemplatePath(methodPath);
@@ -980,8 +980,8 @@ function methodPathWithServicePath(
 }
 
 function mediaUploadPathForMethod(
-  discovery: DiscoveryDocument,
-  method: DiscoveryMethod,
+  discovery: GoogleCloudDiscoveryDocument,
+  method: GoogleCloudDiscoveryMethod,
   protocolPath: string,
 ): string {
   const normalized = normalizeTemplatePath(protocolPath);
@@ -998,8 +998,8 @@ function mediaUploadPathForMethod(
 }
 
 function rulePathsForMethod(
-  discovery: DiscoveryDocument,
-  method: DiscoveryMethod,
+  discovery: GoogleCloudDiscoveryDocument,
+  method: GoogleCloudDiscoveryMethod,
 ): string[] {
   if (!method.id) {
     throw new Error("Discovery method is missing id");
@@ -1020,6 +1020,43 @@ function rulePathsForMethod(
   return [...paths].sort();
 }
 
+function mediaUploadPutRulePathsForMethod(
+  discovery: GoogleCloudDiscoveryDocument,
+  method: GoogleCloudDiscoveryMethod,
+): string[] {
+  const protocols = method.mediaUpload?.protocols;
+  if (!protocols?.resumable?.path) return [];
+
+  const paths = new Set<string>();
+  for (const protocol of [protocols.simple, protocols.resumable]) {
+    if (protocol?.path) {
+      paths.add(mediaUploadPathForMethod(discovery, method, protocol.path));
+    }
+  }
+
+  return [...paths].sort();
+}
+
+export function googleCloudRulesForDiscoveryMethod(
+  discovery: GoogleCloudDiscoveryDocument,
+  method: GoogleCloudDiscoveryMethod,
+): string[] {
+  if (!method.id || !method.httpMethod) {
+    throw new Error("Discovery method is missing id or httpMethod");
+  }
+
+  const rules = new Set<string>();
+  const methodVerb = method.httpMethod.toUpperCase();
+  for (const path of rulePathsForMethod(discovery, method)) {
+    rules.add(`${methodVerb} /${path}`);
+  }
+  for (const path of mediaUploadPutRulePathsForMethod(discovery, method)) {
+    rules.add(`PUT /${path}`);
+  }
+
+  return sanitizeAndSortRules([...rules]);
+}
+
 function addRule(
   groups: Map<string, Set<string>>,
   permission: string,
@@ -1031,7 +1068,7 @@ function addRule(
 }
 
 function buildPermissionGroups(
-  discovery: DiscoveryDocument,
+  discovery: GoogleCloudDiscoveryDocument,
   api: ApiConfig,
   officialPermissions: ReadonlySet<string>,
   unexpectedUnmappedMethods: Set<string>,
@@ -1060,12 +1097,8 @@ function buildPermissionGroups(
       }
       continue;
     }
-    for (const path of rulePathsForMethod(discovery, method)) {
-      addRule(
-        groups,
-        permission,
-        `${method.httpMethod.toUpperCase()} /${path}`,
-      );
+    for (const rule of googleCloudRulesForDiscoveryMethod(discovery, method)) {
+      addRule(groups, permission, rule);
     }
     stats.mappedOperations += 1;
   }
@@ -1316,7 +1349,7 @@ export async function generate(): Promise<void> {
   for (const api of API_CONFIGS) {
     const discoveryUrl = GOOGLE_CLOUD_DISCOVERY_URLS[api.key];
     const res = await fetchSpec(discoveryUrl, `${api.key} discovery document`);
-    const discovery = (await res.json()) as DiscoveryDocument;
+    const discovery = (await res.json()) as GoogleCloudDiscoveryDocument;
     console.error(
       `  ${api.description}: ${discovery.version ?? "unknown version"}`,
     );

--- a/turbo/packages/firewalls-generator/src/google-drive.ts
+++ b/turbo/packages/firewalls-generator/src/google-drive.ts
@@ -27,6 +27,12 @@ interface DiscoveryMethod {
   path?: string;
   flatPath?: string;
   supportsMediaUpload?: boolean;
+  mediaUpload?: {
+    protocols?: {
+      simple?: { path?: string };
+      resumable?: { path?: string };
+    };
+  };
 }
 
 interface DiscoveryResource {
@@ -271,14 +277,20 @@ export const GOOGLE_DRIVE_PERMISSION_MANIFEST: readonly GoogleDriveManifestPermi
         "base:POST /v3/files/{fileId}/modifyLabels",
         "base:PUT /v2/files/{fileId}",
         "base:PUT /v2/files/{fileId}/properties/{propertyKey}",
+        "resumable-upload:PUT /v2/files",
         "resumable-upload:PATCH /v3/files/{fileId}",
         "resumable-upload:POST /v2/files",
         "resumable-upload:POST /v3/files",
         "resumable-upload:PUT /v2/files/{fileId}",
+        "resumable-upload:PUT /v3/files",
+        "resumable-upload:PUT /v3/files/{fileId}",
+        "upload:PUT /v2/files",
         "upload:PATCH /v3/files/{fileId}",
         "upload:POST /v2/files",
         "upload:POST /v3/files",
         "upload:PUT /v2/files/{fileId}",
+        "upload:PUT /v3/files",
+        "upload:PUT /v3/files/{fileId}",
       ],
     },
     {
@@ -406,6 +418,11 @@ export function buildGoogleDriveOfficialRouteKeys(
         hasUploadMethods = true;
         routeKeys.add(`upload:${rule}`);
         routeKeys.add(`resumable-upload:${rule}`);
+        if (method.mediaUpload?.protocols?.resumable) {
+          const mediaRule = rule.replace(/^[A-Z]+ /, "PUT ");
+          routeKeys.add(`upload:${mediaRule}`);
+          routeKeys.add(`resumable-upload:${mediaRule}`);
+        }
       }
     }
   }

--- a/turbo/packages/firewalls-generator/src/google-drive.ts
+++ b/turbo/packages/firewalls-generator/src/google-drive.ts
@@ -404,6 +404,55 @@ function baseRuleForMethod(
   return `${httpMethod.toUpperCase()} /${versionPrefix(discovery)}${methodPath}`;
 }
 
+function uploadRuleForMethod(
+  method: DiscoveryMethod,
+  kind: Exclude<GoogleDriveRouteKeyKind, "base">,
+): string | null {
+  const httpMethod = method.httpMethod;
+  if (!httpMethod) {
+    throw new Error(
+      `Google Drive upload method missing httpMethod: ${method.id}`,
+    );
+  }
+
+  const protocol =
+    kind === "upload"
+      ? method.mediaUpload?.protocols?.simple
+      : method.mediaUpload?.protocols?.resumable;
+  if (!protocol?.path) return null;
+
+  const prefix =
+    kind === "upload" ? "/upload/drive/" : "/resumable/upload/drive/";
+  if (!protocol.path.startsWith(prefix)) {
+    throw new Error(
+      `Unexpected Google Drive ${kind} media upload path for ${method.id ?? "unknown"}: ${protocol.path}`,
+    );
+  }
+
+  return `${httpMethod.toUpperCase()} /${protocol.path.slice(prefix.length)}`;
+}
+
+function mediaUploadPutRuleForMethod(
+  method: DiscoveryMethod,
+  kind: Exclude<GoogleDriveRouteKeyKind, "base">,
+): string | null {
+  const protocol =
+    kind === "upload"
+      ? method.mediaUpload?.protocols?.simple
+      : method.mediaUpload?.protocols?.resumable;
+  if (!protocol?.path) return null;
+
+  const prefix =
+    kind === "upload" ? "/upload/drive/" : "/resumable/upload/drive/";
+  if (!protocol.path.startsWith(prefix)) {
+    throw new Error(
+      `Unexpected Google Drive ${kind} media upload path for ${method.id ?? "unknown"}: ${protocol.path}`,
+    );
+  }
+
+  return `PUT /${protocol.path.slice(prefix.length)}`;
+}
+
 export function buildGoogleDriveOfficialRouteKeys(
   discoveries: readonly GoogleDriveDiscoveryDocument[],
 ): Set<string> {
@@ -416,12 +465,35 @@ export function buildGoogleDriveOfficialRouteKeys(
       routeKeys.add(`base:${rule}`);
       if (method.supportsMediaUpload) {
         hasUploadMethods = true;
-        routeKeys.add(`upload:${rule}`);
-        routeKeys.add(`resumable-upload:${rule}`);
+        const uploadRule = uploadRuleForMethod(method, "upload");
+        const resumableUploadRule = uploadRuleForMethod(
+          method,
+          "resumable-upload",
+        );
+        if (!uploadRule && !resumableUploadRule) {
+          throw new Error(
+            `Google Drive Discovery reports media upload support without upload protocol paths: ${method.id ?? rule}`,
+          );
+        }
+        if (uploadRule) {
+          routeKeys.add(`upload:${uploadRule}`);
+        }
+        if (resumableUploadRule) {
+          routeKeys.add(`resumable-upload:${resumableUploadRule}`);
+        }
         if (method.mediaUpload?.protocols?.resumable) {
-          const mediaRule = rule.replace(/^[A-Z]+ /, "PUT ");
-          routeKeys.add(`upload:${mediaRule}`);
-          routeKeys.add(`resumable-upload:${mediaRule}`);
+          const uploadMediaRule = mediaUploadPutRuleForMethod(method, "upload");
+          if (uploadMediaRule) {
+            routeKeys.add(`upload:${uploadMediaRule}`);
+          }
+
+          const resumableUploadMediaRule = mediaUploadPutRuleForMethod(
+            method,
+            "resumable-upload",
+          );
+          if (resumableUploadMediaRule) {
+            routeKeys.add(`resumable-upload:${resumableUploadMediaRule}`);
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
- add generated firewall coverage for media-phase PUT requests on resumable Google uploads
- keep Gmail, Google Drive, and Google Cloud upload PUT routes attached to the same write/create/send permissions as the initiating upload methods
- regenerate builtin firewall catalogs and add TS/Python regression coverage

Fixes #19328

## Tests
- pnpm -F @vm0/firewalls-generator exec vitest run src/__tests__/gmail.test.ts src/__tests__/google-drive.test.ts src/__tests__/google-cloud.test.ts
- pnpm -F @vm0/connectors exec vitest run src/__tests__/firewall-rule-validation.test.ts
- .venv/bin/python -m pytest tests/test_builtin_firewalls_catalog.py (from crates/runner/mitm-addon)
- pnpm -F @vm0/firewalls-generator check-types
- pnpm -F @vm0/connectors check-types
- pnpm knip
- pre-commit hook: ruff, prettier, knip, turbo check-types
