### PR TITLE
refactor: centralize guest-agent cli termination runtime

### DIFF
--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -46,16 +46,13 @@ use event_delivery::{AckedEventPrefix, PreparedEvent};
 use framework::CliFrameworkBehavior;
 use guest_common::telemetry::record_sandbox_op;
 use guest_common::{log_info, log_warn};
-use guest_contracts::diagnostics::{
-    CliTerminationDiagnostic, CliTerminationReason as DiagnosticTerminationReason,
-    CliTerminationSignal, FailureDetailSource, FailureReason,
-};
+use guest_contracts::diagnostics::{CliTerminationDiagnostic, FailureDetailSource, FailureReason};
 use process_group::ChildProcessGroup;
 use std::collections::HashMap;
 use std::path::Path;
 use std::process::Stdio;
 use std::time::{Duration, Instant};
-use termination::{PostResultCleanupState, TerminationReason, TerminationState, deadline_after};
+use termination::{CliTerminationRuntime, ControlTerminationLog, TerminationReason};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 use tokio::sync::oneshot;
 
@@ -622,7 +619,6 @@ async fn execute_cli_inner(
     let mut cli_exit_at: Option<Instant> = None;
     let mut claude_result = None;
     let mut post_result_cleanup_result = None;
-    let mut post_result_cleanup = None;
     let mut event_ingestor = CliEventIngestor::new();
     let event_result: Result<(), AgentError> = loop {
         tokio::select! {
@@ -633,24 +629,17 @@ async fn execute_cli_inner(
                 }
             }, if claude_stdin_write_handle.is_some() => {
                 claude_stdin_write_handle = None;
-                let can_terminate_for_stdin_error =
-                    matches!(termination_runtime.state, TerminationState::Idle)
-                        && cli_status.is_none();
+                let can_terminate_for_stdin_error = termination_runtime
+                    .can_begin_initial_prompt_stdin_control_failure(cli_status.is_some());
                 match stdin_write_result {
                     Some(Ok(Ok(()))) => {}
                     Some(Ok(Err(error))) if can_terminate_for_stdin_error => {
                         active_input_controller.close_terminal();
-                        log_warn!(
-                            LOG_TAG,
-                            "Claude stdin writer failed, SIGTERM pgid={}: {error}",
-                            termination_runtime
-                                .pgid
-                                .map_or_else(|| "unknown".to_string(), |pid| pid.to_string())
-                        );
-                        termination_runtime.begin_forced_sigkill_pending(
+                        let error_log = error.to_string();
+                        termination_runtime.begin_control_failure(
                             TerminationReason::InitialPromptStdin,
                             error,
-                            &mut post_result_cleanup,
+                            ControlTerminationLog::ClaudeStdinWriterFailed { error: error_log },
                             termination_deadline.as_mut(),
                         );
                     }
@@ -659,19 +648,13 @@ async fn execute_cli_inner(
                     }
                     Some(Err(error)) if can_terminate_for_stdin_error => {
                         active_input_controller.close_terminal();
-                        log_warn!(
-                            LOG_TAG,
-                            "Claude stdin writer task failed, SIGTERM pgid={}: {error}",
-                            termination_runtime
-                                .pgid
-                                .map_or_else(|| "unknown".to_string(), |pid| pid.to_string())
-                        );
-                        termination_runtime.begin_forced_sigkill_pending(
+                        let error_log = error.to_string();
+                        let control_error =
+                            AgentError::Execution(format!("Claude stdin writer task failed: {error_log}"));
+                        termination_runtime.begin_control_failure(
                             TerminationReason::InitialPromptStdin,
-                            AgentError::Execution(format!(
-                                "Claude stdin writer task failed: {error}"
-                            )),
-                            &mut post_result_cleanup,
+                            control_error,
+                            ControlTerminationLog::ClaudeStdinWriterTaskFailed { error: error_log },
                             termination_deadline.as_mut(),
                         );
                     }
@@ -727,7 +710,8 @@ async fn execute_cli_inner(
                                 }
                             }
 
-                            let post_result_cleanup_was_armed = post_result_cleanup.is_some();
+                            let post_result_cleanup_was_armed =
+                                termination_runtime.has_post_result_cleanup();
                             match event_ingestor
                                 .begin_event(
                                     &mut log_file,
@@ -773,48 +757,22 @@ async fn execute_cli_inner(
                                     active_input_controller.close_for_result_if_idle();
                                 // Arm the post-result reap deadline once per
                                 // run when no active follow-up input is still
-                                // pending — see `TerminationState::should_arm_post_result`.
+                                // pending.
                                 if active_input_idle
-                                    && termination_runtime
-                                        .state
-                                        .should_arm_post_result(cli_status.is_some())
+                                    && termination_runtime.arm_post_result_cleanup(
+                                        cli_status.is_some(),
+                                        termination_deadline.as_mut(),
+                                    )
                                 {
-                                    let now = tokio::time::Instant::now();
-                                    let cleanup = PostResultCleanupState::arm(
-                                        now,
-                                        env::post_result_sigterm_grace(),
-                                        env::post_result_total_cap(),
-                                    );
-                                    if let Some(next_deadline) = cleanup.next_deadline() {
-                                        termination_runtime.state =
-                                            TerminationState::SigtermPending {
-                                            reason: TerminationReason::PostResult,
-                                        };
-                                        termination_deadline.as_mut().reset(next_deadline);
-                                        post_result_cleanup = Some(cleanup);
-                                        post_result_cleanup_result = Some(result_summary);
-                                    }
+                                    post_result_cleanup_result = Some(result_summary);
                                 }
                             }
                             // Extract tool info BEFORE masking (masker may replace tool names).
                             behavior.track_claude_tool_events(&event, &mut stuck_tool_tracker);
-                            if post_result_cleanup_was_armed
-                                && matches!(
-                                    termination_runtime.state,
-                                    TerminationState::SigtermPending {
-                                        reason: TerminationReason::PostResult
-                                    }
-                                )
-                                && let Some(cleanup) = post_result_cleanup.as_mut()
-                            {
-                                let next_deadline = cleanup.record_meaningful_event(
-                                    tokio::time::Instant::now(),
-                                    env::post_result_sigterm_grace(),
-                                );
-                                if let Some(next_deadline) = next_deadline {
-                                    termination_deadline.as_mut().reset(next_deadline);
-                                }
-                            }
+                            termination_runtime.record_post_result_activity(
+                                post_result_cleanup_was_armed,
+                                termination_deadline.as_mut(),
+                            );
                             // Prepare event payload (mask secrets, add seq) and enqueue
                             // for background sending. Network I/O stays off the reading loop.
                             event_ingestor.enqueue_event(event, masker, should_send_events, &event_tx);
@@ -842,8 +800,7 @@ async fn execute_cli_inner(
                         // CLI exited on its own (possibly in response to our
                         // SIGTERM). Park the termination FSM so it can't
                         // re-arm on any late `type=result` event.
-                        termination_runtime.state = TerminationState::Done;
-                        post_result_cleanup = None;
+                        termination_runtime.mark_child_exited();
                         if stdout_eof {
                             break Ok(());
                         }
@@ -855,137 +812,8 @@ async fn execute_cli_inner(
                     Err(e) => break Err(AgentError::Io(e)),
                 }
             }
-            () = &mut termination_deadline, if termination_runtime.state.is_pending() && cli_status.is_none() => {
-                // Process-group signal results are intentionally discarded in
-                // both arms: ESRCH (child reaped since the is_pending() /
-                // is_none() check) is racy-but-harmless, and every other
-                // error would be unrecoverable from userspace.
-                // The sigkill_grace deadline is the escalation path if
-                // the signal fails to take effect in time.
-                match termination_runtime.state {
-                    TerminationState::SigtermPending { reason } => {
-                        let now = tokio::time::Instant::now();
-                        let cleanup_timeout =
-                            (reason == TerminationReason::PostResult)
-                                .then(|| {
-                                    post_result_cleanup
-                                        .as_mut()
-                                        .and_then(|cleanup| cleanup.mark_signal_sent(now))
-                                })
-                                .flatten();
-                        let grace = cleanup_timeout
-                            .map(|timeout| timeout.elapsed)
-                            .unwrap_or_else(env::post_result_sigterm_grace);
-                        if let Some(pid) = termination_runtime.pgid {
-                            if reason == TerminationReason::PostResult {
-                                if let Some(timeout) = cleanup_timeout {
-                                    let trigger = timeout.trigger.label();
-                                    let elapsed_ms = timeout.elapsed.as_millis();
-                                    let quiet_ms = timeout.quiet_for.as_millis();
-                                    let meaningful_events = timeout.meaningful_event_count;
-                                    let detail = format!(
-                                        "trigger={trigger} signal=sigterm elapsed_ms={elapsed_ms} quiet_ms={quiet_ms} meaningful_events={meaningful_events}"
-                                    );
-                                    log_warn!(
-                                        LOG_TAG,
-                                        "Post-result cleanup {trigger} reached after {elapsed_ms}ms (quiet {quiet_ms}ms, meaningful events {meaningful_events}), SIGTERM pgid={pid}"
-                                    );
-                                    record_sandbox_op(
-                                        "post_result_cleanup_terminated",
-                                        timeout.elapsed,
-                                        true,
-                                        Some(&detail),
-                                    );
-                                } else {
-                                    log_warn!(
-                                        LOG_TAG,
-                                        "Post-result cleanup deadline fired without state, SIGTERM pgid={pid}"
-                                    );
-                                }
-                            } else {
-                                log_warn!(
-                                    LOG_TAG,
-                                    "CLI still running after {} sigterm grace {}ms, SIGTERM pgid={pid}",
-                                    reason.label(),
-                                    grace.as_millis()
-                                );
-                            }
-                            record_cli_termination_signal(
-                                &mut termination_runtime.diagnostic,
-                                reason,
-                                CliTerminationSignal::Sigterm,
-                                termination_runtime.pgid,
-                                grace,
-                            );
-                            if let Some(process_group) = termination_runtime.process_group {
-                                process_group.sigterm();
-                            }
-                        }
-                        termination_runtime.state = TerminationState::SigkillPending { reason };
-                        termination_deadline.as_mut().reset(deadline_after(
-                            tokio::time::Instant::now(),
-                            env::post_result_sigkill_grace(),
-                        ));
-                    }
-                    TerminationState::SigkillPending { reason } => {
-                        let grace = env::post_result_sigkill_grace();
-                        let now = tokio::time::Instant::now();
-                        if let Some(pid) = termination_runtime.pgid {
-                            log_warn!(
-                                LOG_TAG,
-                                "CLI did not exit after {} SIGTERM+{}ms, SIGKILL pgid={pid}",
-                                reason.label(),
-                                grace.as_millis()
-                            );
-                            if reason == TerminationReason::PostResult
-                                && let Some(cleanup) = post_result_cleanup
-                            {
-                                let elapsed = cleanup.elapsed(now);
-                                let quiet_ms = cleanup.quiet_for(now).as_millis();
-                                let meaningful_events = cleanup.meaningful_event_count();
-                                let elapsed_ms = elapsed.as_millis();
-                                let detail = format!(
-                                    "trigger=sigkill_escalation signal=sigkill elapsed_ms={elapsed_ms} quiet_ms={quiet_ms} meaningful_events={meaningful_events}"
-                                );
-                                record_sandbox_op(
-                                    "post_result_cleanup_terminated",
-                                    elapsed,
-                                    true,
-                                    Some(&detail),
-                                );
-                            }
-                            record_cli_termination_signal(
-                                &mut termination_runtime.diagnostic,
-                                reason,
-                                CliTerminationSignal::Sigkill,
-                                termination_runtime.pgid,
-                                grace,
-                            );
-                            if let Some(process_group) = termination_runtime.process_group {
-                                process_group.sigkill();
-                            }
-                        }
-                        post_result_cleanup = None;
-                        termination_runtime.state = TerminationState::Done;
-                    }
-                    // Unreachable by the is_pending() guard. Log in
-                    // every build so any future FSM regression surfaces
-                    // in production runner logs; debug_assert adds a
-                    // fail-fast panic under cfg(debug_assertions) so
-                    // CI / dev tests abort on the same condition.
-                    TerminationState::Idle | TerminationState::Done => {
-                        log_warn!(
-                            LOG_TAG,
-                            "termination_deadline fired in non-pending state {:?}",
-                            termination_runtime.state
-                        );
-                        debug_assert!(
-                            false,
-                            "termination_deadline fired in non-pending state {:?}",
-                            termination_runtime.state
-                        );
-                    }
-                }
+            () = &mut termination_deadline, if termination_runtime.has_pending_deadline() && cli_status.is_none() => {
+                termination_runtime.handle_deadline(termination_deadline.as_mut());
             }
             () = &mut drain_deadline, if cli_status.is_some() => {
                 log_warn!(
@@ -1007,22 +835,14 @@ async fn execute_cli_inner(
                     .min_by_key(|(_, started)| *started)
                     .map(|(name, started)| (name.clone(), started.elapsed().as_secs()));
                 if let Some((name, elapsed)) = stuck
-                    && termination_runtime.control_error.is_none()
                 {
                     let timeout_error = AgentError::Execution(format!(
                         "Tool timeout: {name} exceeded {timeout_secs}s without returning a result"
                     ));
-                    log_warn!(
-                        LOG_TAG,
-                        "Tool timeout: {name} stuck for {elapsed}s, SIGTERM pgid={}",
-                        termination_runtime
-                            .pgid
-                            .map_or_else(|| "unknown".to_string(), |pid| pid.to_string())
-                    );
-                    termination_runtime.begin_forced_sigkill_pending(
+                    termination_runtime.begin_control_failure(
                         TerminationReason::StuckTool,
                         timeout_error,
-                        &mut post_result_cleanup,
+                        ControlTerminationLog::StuckTool { name, elapsed },
                         termination_deadline.as_mut(),
                     );
                 }
@@ -1040,21 +860,12 @@ async fn execute_cli_inner(
                 match heartbeat_result {
                     Ok(HeartbeatStatus::Failed(e)) => {
                         // Heartbeat failed — kill process group
-                        if termination_runtime.control_error.is_none() {
-                            log_warn!(
-                                LOG_TAG,
-                                "Heartbeat failed, SIGTERM pgid={}",
-                                termination_runtime
-                                    .pgid
-                                    .map_or_else(|| "unknown".to_string(), |pid| pid.to_string())
-                            );
-                            termination_runtime.begin_forced_sigkill_pending(
-                                TerminationReason::HeartbeatError,
-                                e,
-                                &mut post_result_cleanup,
-                                termination_deadline.as_mut(),
-                            );
-                        }
+                        termination_runtime.begin_control_failure(
+                            TerminationReason::HeartbeatError,
+                            e,
+                            ControlTerminationLog::HeartbeatFailed,
+                            termination_deadline.as_mut(),
+                        );
                     }
                     Ok(HeartbeatStatus::Stopped) => {
                         // Heartbeat shutdown (should not happen before CLI exits)
@@ -1062,39 +873,21 @@ async fn execute_cli_inner(
                     }
                     Ok(HeartbeatStatus::TaskFailed(message)) => {
                         let error = AgentError::Execution(format!("heartbeat task panicked: {message}"));
-                        if termination_runtime.control_error.is_none() {
-                            log_warn!(
-                                LOG_TAG,
-                                "Heartbeat task panicked, SIGTERM pgid={}",
-                                termination_runtime
-                                    .pgid
-                                    .map_or_else(|| "unknown".to_string(), |pid| pid.to_string())
-                            );
-                            termination_runtime.begin_forced_sigkill_pending(
-                                TerminationReason::HeartbeatPanic,
-                                error,
-                                &mut post_result_cleanup,
-                                termination_deadline.as_mut(),
-                            );
-                        }
+                        termination_runtime.begin_control_failure(
+                            TerminationReason::HeartbeatPanic,
+                            error,
+                            ControlTerminationLog::HeartbeatTaskPanicked,
+                            termination_deadline.as_mut(),
+                        );
                     }
                     Err(e) => {
                         let error = AgentError::Execution(format!("heartbeat task stopped before reporting status: {e}"));
-                        if termination_runtime.control_error.is_none() {
-                            log_warn!(
-                                LOG_TAG,
-                                "Heartbeat task stopped before reporting status, SIGTERM pgid={}",
-                                termination_runtime
-                                    .pgid
-                                    .map_or_else(|| "unknown".to_string(), |pid| pid.to_string())
-                            );
-                            termination_runtime.begin_forced_sigkill_pending(
-                                TerminationReason::HeartbeatPanic,
-                                error,
-                                &mut post_result_cleanup,
-                                termination_deadline.as_mut(),
-                            );
-                        }
+                        termination_runtime.begin_control_failure(
+                            TerminationReason::HeartbeatPanic,
+                            error,
+                            ControlTerminationLog::HeartbeatStoppedBeforeStatus,
+                            termination_deadline.as_mut(),
+                        );
                     }
                 }
             }
@@ -1126,7 +919,7 @@ async fn execute_cli_inner(
         }
     }
 
-    let has_control_error = termination_runtime.control_error.is_some();
+    let has_control_error = termination_runtime.has_control_error();
     let event_error = if has_control_error {
         None
     } else {
@@ -1215,13 +1008,7 @@ async fn execute_cli_inner(
     };
     let masked_stderr_lines = masker.mask_diagnostic_lines(stderr_lines);
 
-    let CliTerminationRuntime {
-        control_error,
-        diagnostic: cli_termination,
-        ..
-    } = termination_runtime;
-    let cli_termination =
-        cli_termination.map(|diagnostic| diagnostic.with_observed_exit_code(exit_code));
+    let (control_error, cli_termination) = termination_runtime.finish(exit_code);
 
     if let Some(err) = event_error {
         return Err(err);
@@ -1237,76 +1024,6 @@ async fn execute_cli_inner(
         control_error,
         cli_termination,
     })
-}
-
-struct CliTerminationRuntime {
-    process_group: Option<ChildProcessGroup>,
-    pgid: Option<i32>,
-    state: TerminationState,
-    control_error: Option<AgentError>,
-    diagnostic: Option<CliTerminationDiagnostic>,
-}
-
-impl CliTerminationRuntime {
-    fn new(process_group: Option<ChildProcessGroup>) -> Self {
-        Self {
-            process_group,
-            pgid: process_group.map(ChildProcessGroup::raw_pgid),
-            state: TerminationState::Idle,
-            control_error: None,
-            diagnostic: None,
-        }
-    }
-
-    fn begin_forced_sigkill_pending(
-        &mut self,
-        reason: TerminationReason,
-        error: AgentError,
-        post_result_cleanup: &mut Option<PostResultCleanupState>,
-        mut termination_deadline: std::pin::Pin<&mut tokio::time::Sleep>,
-    ) {
-        let grace = env::post_result_sigkill_grace();
-        record_cli_termination_signal(
-            &mut self.diagnostic,
-            reason,
-            CliTerminationSignal::Sigterm,
-            self.pgid,
-            grace,
-        );
-        if let Some(process_group) = self.process_group {
-            process_group.sigterm();
-        }
-        self.control_error = Some(error);
-        *post_result_cleanup = None;
-        self.state = TerminationState::SigkillPending { reason };
-        termination_deadline
-            .as_mut()
-            .reset(deadline_after(tokio::time::Instant::now(), grace));
-    }
-}
-
-fn record_cli_termination_signal(
-    cli_termination: &mut Option<CliTerminationDiagnostic>,
-    reason: TerminationReason,
-    signal: CliTerminationSignal,
-    pgid: Option<i32>,
-    grace: Duration,
-) {
-    let diagnostic = cli_termination
-        .take()
-        .unwrap_or_else(|| CliTerminationDiagnostic::new(diagnostic_termination_reason(reason)));
-    let grace_ms = u64::try_from(grace.as_millis()).unwrap_or(u64::MAX);
-    *cli_termination = Some(diagnostic.record_signal(signal, pgid, Some(grace_ms)));
-}
-
-fn diagnostic_termination_reason(reason: TerminationReason) -> DiagnosticTerminationReason {
-    match reason {
-        TerminationReason::PostResult => DiagnosticTerminationReason::PostResultReap,
-        TerminationReason::InitialPromptStdin => DiagnosticTerminationReason::InitialPromptStdin,
-        TerminationReason::StuckTool => DiagnosticTerminationReason::StuckToolWatchdog,
-        TerminationReason::HeartbeatError => DiagnosticTerminationReason::HeartbeatError,
-        TerminationReason::HeartbeatPanic => DiagnosticTerminationReason::HeartbeatPanic,
-    }
 }
 
 fn set_cli_current_dir(cmd: &mut tokio::process::Command, path: &str) -> Result<(), AgentError> {
@@ -1377,15 +1094,10 @@ fn with_carried_failure_reason(
 #[cfg(test)]
 mod tests {
     use super::{
-        AgentError, CliFailureDiagnostic, CliTerminationRuntime, PostResultCleanupState,
-        TerminationReason, TerminationState, claude_initial_prompt_frame,
-        record_cli_termination_signal, select_failure_diagnostic, set_cli_current_dir,
-        with_carried_failure_reason,
+        CliFailureDiagnostic, claude_initial_prompt_frame, select_failure_diagnostic,
+        set_cli_current_dir, with_carried_failure_reason,
     };
-    use guest_contracts::diagnostics::{
-        CliTerminationReason, CliTerminationSignal, FailureDetailSource, FailureReason,
-    };
-    use std::time::Duration;
+    use guest_contracts::diagnostics::{FailureDetailSource, FailureReason};
 
     #[test]
     fn claude_initial_prompt_frame_matches_stream_json_user_shape() {
@@ -1418,81 +1130,6 @@ mod tests {
             .and_then(serde_json::Value::as_str)
             .expect("uuid");
         uuid::Uuid::parse_str(uuid).expect("valid uuid");
-    }
-
-    #[test]
-    fn cli_termination_signal_records_initial_prompt_stdin_and_escalation() {
-        let mut diagnostic = None;
-
-        record_cli_termination_signal(
-            &mut diagnostic,
-            TerminationReason::InitialPromptStdin,
-            CliTerminationSignal::Sigterm,
-            Some(42),
-            Duration::from_secs(1),
-        );
-
-        let first = diagnostic.expect("diagnostic after SIGTERM");
-        assert_eq!(first.reason, CliTerminationReason::InitialPromptStdin);
-        assert_eq!(first.signal_sent, Some(CliTerminationSignal::Sigterm));
-        assert_eq!(first.signal_pgid, Some(42));
-        assert_eq!(first.signal_grace_ms, Some(1_000));
-        assert!(!first.escalated);
-
-        let mut diagnostic = Some(first);
-        record_cli_termination_signal(
-            &mut diagnostic,
-            TerminationReason::InitialPromptStdin,
-            CliTerminationSignal::Sigkill,
-            Some(42),
-            Duration::from_secs(2),
-        );
-
-        let escalated = diagnostic.expect("diagnostic after SIGKILL");
-        assert_eq!(escalated.reason, CliTerminationReason::InitialPromptStdin);
-        assert_eq!(escalated.signal_sent, Some(CliTerminationSignal::Sigkill));
-        assert_eq!(escalated.signal_pgid, Some(42));
-        assert_eq!(escalated.signal_grace_ms, Some(2_000));
-        assert!(escalated.escalated);
-    }
-
-    #[tokio::test]
-    async fn forced_sigkill_pending_records_control_failure_transition() {
-        let deadline = tokio::time::sleep(Duration::MAX);
-        tokio::pin!(deadline);
-        let mut runtime = CliTerminationRuntime::new(None);
-        let now = tokio::time::Instant::now();
-        let mut post_result_cleanup = Some(PostResultCleanupState::arm(
-            now,
-            Duration::from_secs(1),
-            Duration::from_secs(2),
-        ));
-
-        runtime.begin_forced_sigkill_pending(
-            TerminationReason::HeartbeatError,
-            AgentError::Execution("heartbeat failed".to_string()),
-            &mut post_result_cleanup,
-            deadline.as_mut(),
-        );
-
-        let control_error = runtime
-            .control_error
-            .as_ref()
-            .expect("control error should be stored");
-        assert!(control_error.to_string().contains("heartbeat failed"));
-        assert!(post_result_cleanup.is_none());
-        assert_eq!(
-            runtime.state,
-            TerminationState::SigkillPending {
-                reason: TerminationReason::HeartbeatError
-            }
-        );
-        let diagnostic = runtime.diagnostic.expect("diagnostic should be recorded");
-        assert_eq!(diagnostic.reason, CliTerminationReason::HeartbeatError);
-        assert_eq!(diagnostic.signal_sent, Some(CliTerminationSignal::Sigterm));
-        assert_eq!(diagnostic.signal_pgid, None);
-        assert!(diagnostic.signal_grace_ms.is_some());
-        assert!(!diagnostic.escalated);
     }
 
     #[tokio::test]

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -823,7 +823,7 @@ async fn execute_cli_inner(
                 );
                 break Ok(());
             }
-            _ = tick_optional_interval(&mut stuck_tool_check) => {
+            _ = tick_optional_interval(&mut stuck_tool_check), if cli_status.is_none() => {
                 let timeout_secs = env::stuck_tool_timeout_secs();
                 // Find the oldest network tool that has exceeded the timeout.
                 let stuck = stuck_tool_tracker
@@ -855,7 +855,7 @@ async fn execute_cli_inner(
                             .await
                     }
                 }
-            }, if !heartbeat_done => {
+            }, if !heartbeat_done && cli_status.is_none() => {
                 heartbeat_done = true;
                 match heartbeat_result {
                     Ok(HeartbeatStatus::Failed(e)) => {

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -740,8 +740,22 @@ async fn execute_cli_inner(
                                 ParsedEventAction::Forward => {}
                                 ParsedEventAction::Skip => continue,
                             }
+                            let is_result_event = behavior.handles_claude_result_event(&event);
+                            if (post_result_cleanup_was_armed || is_result_event)
+                                && try_observe_cli_exit(
+                                    &mut child,
+                                    &mut cli_status,
+                                    &mut cli_exit_at,
+                                    &active_input_controller,
+                                    &mut termination_runtime,
+                                    stdout_eof,
+                                    drain_deadline.as_mut(),
+                                )?
+                            {
+                                break Ok(());
+                            }
                             // Print Claude Code final result to stdout if applicable.
-                            if behavior.handles_claude_result_event(&event) {
+                            if is_result_event {
                                 let result_summary = ClaudeResultSummary::from_event(&event);
                                 claude_result = Some(result_summary);
                                 if let Some(diagnostic) =

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -33,7 +33,9 @@ pub use codex_setup::setup_codex;
 pub use command::build_cli_command;
 pub use framework::{ClaudeResultStatus, ClaudeResultSummary};
 
-use crate::active_input::{ActiveInputRuntime, ActiveInputWriter, ReplayUserEventAction};
+use crate::active_input::{
+    ActiveInputController, ActiveInputRuntime, ActiveInputWriter, ReplayUserEventAction,
+};
 use crate::constants;
 use crate::env;
 use crate::error::AgentError;
@@ -50,11 +52,13 @@ use guest_contracts::diagnostics::{CliTerminationDiagnostic, FailureDetailSource
 use process_group::ChildProcessGroup;
 use std::collections::HashMap;
 use std::path::Path;
-use std::process::Stdio;
+use std::pin::Pin;
+use std::process::{ExitStatus, Stdio};
 use std::time::{Duration, Instant};
 use termination::{CliTerminationRuntime, ControlTerminationLog, TerminationReason};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 use tokio::sync::oneshot;
+use tokio::time::Sleep;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
 
@@ -629,6 +633,17 @@ async fn execute_cli_inner(
                 }
             }, if claude_stdin_write_handle.is_some() => {
                 claude_stdin_write_handle = None;
+                if try_observe_cli_exit(
+                    &mut child,
+                    &mut cli_status,
+                    &mut cli_exit_at,
+                    &active_input_controller,
+                    &mut termination_runtime,
+                    stdout_eof,
+                    drain_deadline.as_mut(),
+                )? {
+                    break Ok(());
+                }
                 let can_terminate_for_stdin_error = termination_runtime
                     .can_begin_initial_prompt_stdin_control_failure(cli_status.is_some());
                 match stdin_write_result {
@@ -793,26 +808,33 @@ async fn execute_cli_inner(
             status = child.wait(), if cli_status.is_none() => {
                 match status {
                     Ok(s) => {
-                        cli_exit_at = Some(Instant::now());
-                        log_info!(LOG_TAG, "CLI process exited (status: {s}), draining stdout");
-                        cli_status = Some(s);
-                        active_input_controller.close_terminal();
-                        // CLI exited on its own (possibly in response to our
-                        // SIGTERM). Park the termination FSM so it can't
-                        // re-arm on any late `type=result` event.
-                        termination_runtime.mark_child_exited();
-                        if stdout_eof {
+                        if record_cli_exit(
+                            s,
+                            &mut cli_status,
+                            &mut cli_exit_at,
+                            &active_input_controller,
+                            &mut termination_runtime,
+                            stdout_eof,
+                            drain_deadline.as_mut(),
+                        ) {
                             break Ok(());
                         }
-                        drain_deadline.as_mut().reset(
-                            tokio::time::Instant::now()
-                                + Duration::from_secs(constants::STDOUT_DRAIN_DEADLINE_SECS),
-                        );
                     }
                     Err(e) => break Err(AgentError::Io(e)),
                 }
             }
             () = &mut termination_deadline, if termination_runtime.has_pending_deadline() && cli_status.is_none() => {
+                if try_observe_cli_exit(
+                    &mut child,
+                    &mut cli_status,
+                    &mut cli_exit_at,
+                    &active_input_controller,
+                    &mut termination_runtime,
+                    stdout_eof,
+                    drain_deadline.as_mut(),
+                )? {
+                    break Ok(());
+                }
                 termination_runtime.handle_deadline(termination_deadline.as_mut());
             }
             () = &mut drain_deadline, if cli_status.is_some() => {
@@ -836,6 +858,17 @@ async fn execute_cli_inner(
                     .map(|(name, started)| (name.clone(), started.elapsed().as_secs()));
                 if let Some((name, elapsed)) = stuck
                 {
+                    if try_observe_cli_exit(
+                        &mut child,
+                        &mut cli_status,
+                        &mut cli_exit_at,
+                        &active_input_controller,
+                        &mut termination_runtime,
+                        stdout_eof,
+                        drain_deadline.as_mut(),
+                    )? {
+                        break Ok(());
+                    }
                     let timeout_error = AgentError::Execution(format!(
                         "Tool timeout: {name} exceeded {timeout_secs}s without returning a result"
                     ));
@@ -857,6 +890,17 @@ async fn execute_cli_inner(
                 }
             }, if !heartbeat_done && cli_status.is_none() => {
                 heartbeat_done = true;
+                if try_observe_cli_exit(
+                    &mut child,
+                    &mut cli_status,
+                    &mut cli_exit_at,
+                    &active_input_controller,
+                    &mut termination_runtime,
+                    stdout_eof,
+                    drain_deadline.as_mut(),
+                )? {
+                    break Ok(());
+                }
                 match heartbeat_result {
                     Ok(HeartbeatStatus::Failed(e)) => {
                         // Heartbeat failed — kill process group
@@ -1024,6 +1068,65 @@ async fn execute_cli_inner(
         control_error,
         cli_termination,
     })
+}
+
+fn try_observe_cli_exit(
+    child: &mut tokio::process::Child,
+    cli_status: &mut Option<ExitStatus>,
+    cli_exit_at: &mut Option<Instant>,
+    active_input_controller: &ActiveInputController,
+    termination_runtime: &mut CliTerminationRuntime,
+    stdout_eof: bool,
+    drain_deadline: Pin<&mut Sleep>,
+) -> Result<bool, AgentError> {
+    if cli_status.is_some() {
+        return Ok(false);
+    }
+
+    let Some(status) = child.try_wait().map_err(AgentError::Io)? else {
+        return Ok(false);
+    };
+
+    Ok(record_cli_exit(
+        status,
+        cli_status,
+        cli_exit_at,
+        active_input_controller,
+        termination_runtime,
+        stdout_eof,
+        drain_deadline,
+    ))
+}
+
+fn record_cli_exit(
+    status: ExitStatus,
+    cli_status: &mut Option<ExitStatus>,
+    cli_exit_at: &mut Option<Instant>,
+    active_input_controller: &ActiveInputController,
+    termination_runtime: &mut CliTerminationRuntime,
+    stdout_eof: bool,
+    mut drain_deadline: Pin<&mut Sleep>,
+) -> bool {
+    debug_assert!(cli_status.is_none(), "CLI exit recorded more than once");
+    *cli_exit_at = Some(Instant::now());
+    log_info!(
+        LOG_TAG,
+        "CLI process exited (status: {status}), draining stdout"
+    );
+    *cli_status = Some(status);
+    active_input_controller.close_terminal();
+    // CLI exited on its own (possibly in response to our SIGTERM). Park the
+    // termination FSM so it can't re-arm on late result/control events while
+    // stdout is draining.
+    termination_runtime.mark_child_exited();
+    if stdout_eof {
+        return true;
+    }
+
+    drain_deadline.as_mut().reset(
+        tokio::time::Instant::now() + Duration::from_secs(constants::STDOUT_DRAIN_DEADLINE_SECS),
+    );
+    false
 }
 
 fn set_cli_current_dir(cmd: &mut tokio::process::Command, path: &str) -> Result<(), AgentError> {

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -633,7 +633,7 @@ async fn execute_cli_inner(
                 }
             }, if claude_stdin_write_handle.is_some() => {
                 claude_stdin_write_handle = None;
-                if try_observe_cli_exit(
+                match try_observe_cli_exit(
                     &mut child,
                     &mut cli_status,
                     &mut cli_exit_at,
@@ -642,7 +642,9 @@ async fn execute_cli_inner(
                     stdout_eof,
                     drain_deadline.as_mut(),
                 )? {
-                    break Ok(());
+                    CliExitObservation::NoNewExit => {}
+                    CliExitObservation::ExitedDrainingStdout => continue,
+                    CliExitObservation::ExitedAndStdoutEof => break Ok(()),
                 }
                 let can_terminate_for_stdin_error = termination_runtime
                     .can_begin_initial_prompt_stdin_control_failure(cli_status.is_some());
@@ -741,8 +743,8 @@ async fn execute_cli_inner(
                                 ParsedEventAction::Skip => continue,
                             }
                             let is_result_event = behavior.handles_claude_result_event(&event);
-                            if (post_result_cleanup_was_armed || is_result_event)
-                                && try_observe_cli_exit(
+                            if post_result_cleanup_was_armed || is_result_event {
+                                match try_observe_cli_exit(
                                     &mut child,
                                     &mut cli_status,
                                     &mut cli_exit_at,
@@ -750,9 +752,11 @@ async fn execute_cli_inner(
                                     &mut termination_runtime,
                                     stdout_eof,
                                     drain_deadline.as_mut(),
-                                )?
-                            {
-                                break Ok(());
+                                )? {
+                                    CliExitObservation::NoNewExit
+                                    | CliExitObservation::ExitedDrainingStdout => {}
+                                    CliExitObservation::ExitedAndStdoutEof => break Ok(()),
+                                }
                             }
                             // Print Claude Code final result to stdout if applicable.
                             if is_result_event {
@@ -822,14 +826,17 @@ async fn execute_cli_inner(
             status = child.wait(), if cli_status.is_none() => {
                 match status {
                     Ok(s) => {
-                        if record_cli_exit(
-                            s,
-                            &mut cli_status,
-                            &mut cli_exit_at,
-                            &active_input_controller,
-                            &mut termination_runtime,
-                            stdout_eof,
-                            drain_deadline.as_mut(),
+                        if matches!(
+                            record_cli_exit(
+                                s,
+                                &mut cli_status,
+                                &mut cli_exit_at,
+                                &active_input_controller,
+                                &mut termination_runtime,
+                                stdout_eof,
+                                drain_deadline.as_mut(),
+                            ),
+                            CliExitObservation::ExitedAndStdoutEof
                         ) {
                             break Ok(());
                         }
@@ -838,7 +845,7 @@ async fn execute_cli_inner(
                 }
             }
             () = &mut termination_deadline, if termination_runtime.has_pending_deadline() && cli_status.is_none() => {
-                if try_observe_cli_exit(
+                match try_observe_cli_exit(
                     &mut child,
                     &mut cli_status,
                     &mut cli_exit_at,
@@ -847,7 +854,9 @@ async fn execute_cli_inner(
                     stdout_eof,
                     drain_deadline.as_mut(),
                 )? {
-                    break Ok(());
+                    CliExitObservation::NoNewExit => {}
+                    CliExitObservation::ExitedDrainingStdout => continue,
+                    CliExitObservation::ExitedAndStdoutEof => break Ok(()),
                 }
                 termination_runtime.handle_deadline(termination_deadline.as_mut());
             }
@@ -872,7 +881,7 @@ async fn execute_cli_inner(
                     .map(|(name, started)| (name.clone(), started.elapsed().as_secs()));
                 if let Some((name, elapsed)) = stuck
                 {
-                    if try_observe_cli_exit(
+                    match try_observe_cli_exit(
                         &mut child,
                         &mut cli_status,
                         &mut cli_exit_at,
@@ -881,7 +890,9 @@ async fn execute_cli_inner(
                         stdout_eof,
                         drain_deadline.as_mut(),
                     )? {
-                        break Ok(());
+                        CliExitObservation::NoNewExit => {}
+                        CliExitObservation::ExitedDrainingStdout => continue,
+                        CliExitObservation::ExitedAndStdoutEof => break Ok(()),
                     }
                     let timeout_error = AgentError::Execution(format!(
                         "Tool timeout: {name} exceeded {timeout_secs}s without returning a result"
@@ -904,7 +915,7 @@ async fn execute_cli_inner(
                 }
             }, if !heartbeat_done && cli_status.is_none() => {
                 heartbeat_done = true;
-                if try_observe_cli_exit(
+                match try_observe_cli_exit(
                     &mut child,
                     &mut cli_status,
                     &mut cli_exit_at,
@@ -913,7 +924,9 @@ async fn execute_cli_inner(
                     stdout_eof,
                     drain_deadline.as_mut(),
                 )? {
-                    break Ok(());
+                    CliExitObservation::NoNewExit => {}
+                    CliExitObservation::ExitedDrainingStdout => continue,
+                    CliExitObservation::ExitedAndStdoutEof => break Ok(()),
                 }
                 match heartbeat_result {
                     Ok(HeartbeatStatus::Failed(e)) => {
@@ -1084,6 +1097,13 @@ async fn execute_cli_inner(
     })
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CliExitObservation {
+    NoNewExit,
+    ExitedDrainingStdout,
+    ExitedAndStdoutEof,
+}
+
 fn try_observe_cli_exit(
     child: &mut tokio::process::Child,
     cli_status: &mut Option<ExitStatus>,
@@ -1092,13 +1112,13 @@ fn try_observe_cli_exit(
     termination_runtime: &mut CliTerminationRuntime,
     stdout_eof: bool,
     drain_deadline: Pin<&mut Sleep>,
-) -> Result<bool, AgentError> {
+) -> Result<CliExitObservation, AgentError> {
     if cli_status.is_some() {
-        return Ok(false);
+        return Ok(CliExitObservation::NoNewExit);
     }
 
     let Some(status) = child.try_wait().map_err(AgentError::Io)? else {
-        return Ok(false);
+        return Ok(CliExitObservation::NoNewExit);
     };
 
     Ok(record_cli_exit(
@@ -1120,7 +1140,7 @@ fn record_cli_exit(
     termination_runtime: &mut CliTerminationRuntime,
     stdout_eof: bool,
     mut drain_deadline: Pin<&mut Sleep>,
-) -> bool {
+) -> CliExitObservation {
     debug_assert!(cli_status.is_none(), "CLI exit recorded more than once");
     *cli_exit_at = Some(Instant::now());
     log_info!(
@@ -1134,13 +1154,13 @@ fn record_cli_exit(
     // stdout is draining.
     termination_runtime.mark_child_exited();
     if stdout_eof {
-        return true;
+        return CliExitObservation::ExitedAndStdoutEof;
     }
 
     drain_deadline.as_mut().reset(
         tokio::time::Instant::now() + Duration::from_secs(constants::STDOUT_DRAIN_DEADLINE_SECS),
     );
-    false
+    CliExitObservation::ExitedDrainingStdout
 }
 
 fn set_cli_current_dir(cmd: &mut tokio::process::Command, path: &str) -> Result<(), AgentError> {
@@ -1210,11 +1230,16 @@ fn with_carried_failure_reason(
 
 #[cfg(test)]
 mod tests {
+    use super::termination::CliTerminationRuntime;
     use super::{
-        CliFailureDiagnostic, claude_initial_prompt_frame, select_failure_diagnostic,
-        set_cli_current_dir, with_carried_failure_reason,
+        CliExitObservation, CliFailureDiagnostic, claude_initial_prompt_frame, record_cli_exit,
+        select_failure_diagnostic, set_cli_current_dir, with_carried_failure_reason,
     };
+    use crate::active_input::ActiveInputRuntime;
     use guest_contracts::diagnostics::{FailureDetailSource, FailureReason};
+    #[cfg(unix)]
+    use std::os::unix::process::ExitStatusExt;
+    use std::time::Duration;
 
     #[test]
     fn claude_initial_prompt_frame_matches_stream_json_user_shape() {
@@ -1264,6 +1289,38 @@ mod tests {
             String::from_utf8_lossy(&output.stdout).trim(),
             dir.path().to_string_lossy()
         );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn cli_exit_observation_distinguishes_stdout_drain_from_loop_completion() {
+        let active_input = ActiveInputRuntime::new_disabled("run-exit-observation");
+        let controller = active_input.controller();
+        let termination_deadline = tokio::time::sleep(Duration::MAX);
+        tokio::pin!(termination_deadline);
+        let drain_deadline = tokio::time::sleep(Duration::MAX);
+        tokio::pin!(drain_deadline);
+        let mut runtime = CliTerminationRuntime::new(None);
+        assert!(runtime.arm_post_result_cleanup(false, termination_deadline.as_mut()));
+
+        let mut cli_status = None;
+        let mut cli_exit_at = None;
+        let observation = record_cli_exit(
+            std::process::ExitStatus::from_raw(0),
+            &mut cli_status,
+            &mut cli_exit_at,
+            &controller,
+            &mut runtime,
+            false,
+            drain_deadline.as_mut(),
+        );
+
+        assert_eq!(observation, CliExitObservation::ExitedDrainingStdout);
+        assert!(cli_status.is_some());
+        assert!(cli_exit_at.is_some());
+        assert!(!runtime.has_pending_deadline());
+        assert!(!runtime.has_post_result_cleanup());
+        assert!(!runtime.arm_post_result_cleanup(false, termination_deadline.as_mut()));
     }
 
     #[test]

--- a/crates/guest-agent/src/cli/termination.rs
+++ b/crates/guest-agent/src/cli/termination.rs
@@ -1,10 +1,24 @@
 //! CLI process-group termination state machine.
 //!
-//! Signal sending, deadline reset timing, and child wait ordering remain in
-//! `execute_cli`; this module only owns the FSM state and guards.
+//! `execute_cli` owns the select-loop orchestration and decides when external
+//! events happen. This module owns the termination policy state transitions,
+//! process-group signal side effects, diagnostics, and post-result cleanup
+//! deadlines for those events.
 
+use super::process_group::ChildProcessGroup;
+use crate::env;
+use crate::error::AgentError;
+use guest_common::log_warn;
+use guest_common::telemetry::record_sandbox_op;
+use guest_contracts::diagnostics::{
+    CliTerminationDiagnostic, CliTerminationReason as DiagnosticTerminationReason,
+    CliTerminationSignal,
+};
+use std::pin::Pin;
 use std::time::Duration;
-use tokio::time::Instant;
+use tokio::time::{Instant, Sleep};
+
+const LOG_TAG: &str = "sandbox:guest-agent";
 
 /// State machine driving forced CLI process-group termination. A single
 /// pinned deadline is resettable across phases; the enum value tells the
@@ -21,7 +35,7 @@ use tokio::time::Instant;
 /// `Done` is sticky: a late second `type=result` on the same run cannot
 /// re-arm the deadline, and any in-flight signalling is one-shot.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum TerminationState {
+enum TerminationState {
     Idle,
     SigtermPending { reason: TerminationReason },
     SigkillPending { reason: TerminationReason },
@@ -38,7 +52,7 @@ pub(super) enum TerminationReason {
 }
 
 impl TerminationReason {
-    pub(super) fn label(self) -> &'static str {
+    fn label(self) -> &'static str {
         match self {
             TerminationReason::PostResult => "post-result reap",
             TerminationReason::InitialPromptStdin => "initial-prompt stdin",
@@ -52,7 +66,7 @@ impl TerminationReason {
 impl TerminationState {
     /// True while waiting for an armed SIGTERM or SIGKILL deadline to fire;
     /// used as the select! branch's eligibility guard.
-    pub(super) fn is_pending(self) -> bool {
+    fn is_pending(self) -> bool {
         matches!(
             self,
             TerminationState::SigtermPending { .. } | TerminationState::SigkillPending { .. }
@@ -64,7 +78,7 @@ impl TerminationState {
     /// fire -- later events (or a result that races a CLI exit) must
     /// not re-arm. Single source of truth consumed by both the
     /// production guard in `execute_cli` and the FSM unit tests.
-    pub(super) fn should_arm_post_result(self, cli_exited: bool) -> bool {
+    fn should_arm_post_result(self, cli_exited: bool) -> bool {
         matches!(self, TerminationState::Idle) && !cli_exited
     }
 }
@@ -75,7 +89,7 @@ impl TerminationState {
 /// total cap is fixed from the initial arm time so a noisy child cannot keep the
 /// sandbox alive indefinitely.
 #[derive(Debug, Clone, Copy)]
-pub(super) struct PostResultCleanupState {
+struct PostResultCleanupState {
     started_at: Instant,
     last_meaningful_event_at: Instant,
     quiet_deadline: Instant,
@@ -85,21 +99,21 @@ pub(super) struct PostResultCleanupState {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) struct PostResultCleanupTimeout {
-    pub(super) trigger: PostResultCleanupTrigger,
-    pub(super) elapsed: Duration,
-    pub(super) quiet_for: Duration,
-    pub(super) meaningful_event_count: u64,
+struct PostResultCleanupTimeout {
+    trigger: PostResultCleanupTrigger,
+    elapsed: Duration,
+    quiet_for: Duration,
+    meaningful_event_count: u64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum PostResultCleanupTrigger {
+enum PostResultCleanupTrigger {
     Quiet,
     TotalCap,
 }
 
 impl PostResultCleanupTrigger {
-    pub(super) fn label(self) -> &'static str {
+    fn label(self) -> &'static str {
         match self {
             Self::Quiet => "quiet_timeout",
             Self::TotalCap => "total_cap",
@@ -107,12 +121,12 @@ impl PostResultCleanupTrigger {
     }
 }
 
-pub(super) fn deadline_after(now: Instant, duration: Duration) -> Instant {
+fn deadline_after(now: Instant, duration: Duration) -> Instant {
     now.checked_add(duration).unwrap_or(now)
 }
 
 impl PostResultCleanupState {
-    pub(super) fn arm(now: Instant, quiet: Duration, total_cap: Duration) -> Self {
+    fn arm(now: Instant, quiet: Duration, total_cap: Duration) -> Self {
         Self {
             started_at: now,
             last_meaningful_event_at: now,
@@ -123,18 +137,14 @@ impl PostResultCleanupState {
         }
     }
 
-    pub(super) fn next_deadline(self) -> Option<Instant> {
+    fn next_deadline(self) -> Option<Instant> {
         if self.signal_sent {
             return None;
         }
         Some(self.quiet_deadline.min(self.total_cap_deadline))
     }
 
-    pub(super) fn record_meaningful_event(
-        &mut self,
-        now: Instant,
-        quiet: Duration,
-    ) -> Option<Instant> {
+    fn record_meaningful_event(&mut self, now: Instant, quiet: Duration) -> Option<Instant> {
         if self.signal_sent {
             return None;
         }
@@ -144,7 +154,7 @@ impl PostResultCleanupState {
         self.next_deadline()
     }
 
-    pub(super) fn mark_signal_sent(&mut self, now: Instant) -> Option<PostResultCleanupTimeout> {
+    fn mark_signal_sent(&mut self, now: Instant) -> Option<PostResultCleanupTimeout> {
         if self.signal_sent {
             return None;
         }
@@ -152,7 +162,7 @@ impl PostResultCleanupState {
         self.timeout_due(now)
     }
 
-    pub(super) fn timeout_due(self, now: Instant) -> Option<PostResultCleanupTimeout> {
+    fn timeout_due(self, now: Instant) -> Option<PostResultCleanupTimeout> {
         let trigger =
             if now >= self.total_cap_deadline && self.total_cap_deadline <= self.quiet_deadline {
                 PostResultCleanupTrigger::TotalCap
@@ -172,22 +182,370 @@ impl PostResultCleanupState {
         })
     }
 
-    pub(super) fn elapsed(self, now: Instant) -> Duration {
+    fn elapsed(self, now: Instant) -> Duration {
         now.saturating_duration_since(self.started_at)
     }
 
-    pub(super) fn quiet_for(self, now: Instant) -> Duration {
+    fn quiet_for(self, now: Instant) -> Duration {
         now.saturating_duration_since(self.last_meaningful_event_at)
     }
 
-    pub(super) fn meaningful_event_count(self) -> u64 {
+    fn meaningful_event_count(self) -> u64 {
         self.meaningful_event_count
+    }
+}
+
+pub(super) enum ControlTerminationLog {
+    ClaudeStdinWriterFailed { error: String },
+    ClaudeStdinWriterTaskFailed { error: String },
+    StuckTool { name: String, elapsed: u64 },
+    HeartbeatFailed,
+    HeartbeatTaskPanicked,
+    HeartbeatStoppedBeforeStatus,
+}
+
+impl ControlTerminationLog {
+    fn write(self, pgid: &str) {
+        match self {
+            Self::ClaudeStdinWriterFailed { error } => {
+                log_warn!(
+                    LOG_TAG,
+                    "Claude stdin writer failed, SIGTERM pgid={pgid}: {error}"
+                );
+            }
+            Self::ClaudeStdinWriterTaskFailed { error } => {
+                log_warn!(
+                    LOG_TAG,
+                    "Claude stdin writer task failed, SIGTERM pgid={pgid}: {error}"
+                );
+            }
+            Self::StuckTool { name, elapsed } => {
+                log_warn!(
+                    LOG_TAG,
+                    "Tool timeout: {name} stuck for {elapsed}s, SIGTERM pgid={pgid}"
+                );
+            }
+            Self::HeartbeatFailed => {
+                log_warn!(LOG_TAG, "Heartbeat failed, SIGTERM pgid={pgid}");
+            }
+            Self::HeartbeatTaskPanicked => {
+                log_warn!(LOG_TAG, "Heartbeat task panicked, SIGTERM pgid={pgid}");
+            }
+            Self::HeartbeatStoppedBeforeStatus => {
+                log_warn!(
+                    LOG_TAG,
+                    "Heartbeat task stopped before reporting status, SIGTERM pgid={pgid}"
+                );
+            }
+        }
+    }
+}
+
+pub(super) struct CliTerminationRuntime {
+    process_group: Option<ChildProcessGroup>,
+    pgid: Option<i32>,
+    state: TerminationState,
+    post_result_cleanup: Option<PostResultCleanupState>,
+    control_error: Option<AgentError>,
+    diagnostic: Option<CliTerminationDiagnostic>,
+}
+
+impl CliTerminationRuntime {
+    pub(super) fn new(process_group: Option<ChildProcessGroup>) -> Self {
+        Self {
+            process_group,
+            pgid: process_group.map(ChildProcessGroup::raw_pgid),
+            state: TerminationState::Idle,
+            post_result_cleanup: None,
+            control_error: None,
+            diagnostic: None,
+        }
+    }
+
+    pub(super) fn can_begin_initial_prompt_stdin_control_failure(&self, cli_exited: bool) -> bool {
+        matches!(self.state, TerminationState::Idle) && !cli_exited
+    }
+
+    pub(super) fn has_control_error(&self) -> bool {
+        self.control_error.is_some()
+    }
+
+    pub(super) fn has_pending_deadline(&self) -> bool {
+        self.state.is_pending()
+    }
+
+    pub(super) fn has_post_result_cleanup(&self) -> bool {
+        self.post_result_cleanup.is_some()
+    }
+
+    pub(super) fn arm_post_result_cleanup(
+        &mut self,
+        cli_exited: bool,
+        mut termination_deadline: Pin<&mut Sleep>,
+    ) -> bool {
+        if !self.state.should_arm_post_result(cli_exited) {
+            return false;
+        }
+
+        let now = Instant::now();
+        let cleanup = PostResultCleanupState::arm(
+            now,
+            env::post_result_sigterm_grace(),
+            env::post_result_total_cap(),
+        );
+        let Some(next_deadline) = cleanup.next_deadline() else {
+            return false;
+        };
+
+        self.state = TerminationState::SigtermPending {
+            reason: TerminationReason::PostResult,
+        };
+        termination_deadline.as_mut().reset(next_deadline);
+        self.post_result_cleanup = Some(cleanup);
+        true
+    }
+
+    pub(super) fn record_post_result_activity(
+        &mut self,
+        cleanup_was_armed_before_event: bool,
+        mut termination_deadline: Pin<&mut Sleep>,
+    ) {
+        if !cleanup_was_armed_before_event {
+            return;
+        }
+
+        if matches!(
+            self.state,
+            TerminationState::SigtermPending {
+                reason: TerminationReason::PostResult
+            }
+        ) && let Some(cleanup) = self.post_result_cleanup.as_mut()
+        {
+            let next_deadline =
+                cleanup.record_meaningful_event(Instant::now(), env::post_result_sigterm_grace());
+            if let Some(next_deadline) = next_deadline {
+                termination_deadline.as_mut().reset(next_deadline);
+            }
+        }
+    }
+
+    pub(super) fn mark_child_exited(&mut self) {
+        self.state = TerminationState::Done;
+        self.post_result_cleanup = None;
+    }
+
+    pub(super) fn begin_control_failure(
+        &mut self,
+        reason: TerminationReason,
+        error: AgentError,
+        log: ControlTerminationLog,
+        termination_deadline: Pin<&mut Sleep>,
+    ) -> bool {
+        if self.control_error.is_some() {
+            return false;
+        }
+
+        let pgid = self.pgid_label();
+        log.write(&pgid);
+        self.begin_forced_sigkill_pending(reason, error, termination_deadline);
+        true
+    }
+
+    fn pgid_label(&self) -> String {
+        self.pgid
+            .map_or_else(|| "unknown".to_string(), |pid| pid.to_string())
+    }
+
+    fn begin_forced_sigkill_pending(
+        &mut self,
+        reason: TerminationReason,
+        error: AgentError,
+        mut termination_deadline: Pin<&mut Sleep>,
+    ) {
+        let grace = env::post_result_sigkill_grace();
+        record_cli_termination_signal(
+            &mut self.diagnostic,
+            reason,
+            CliTerminationSignal::Sigterm,
+            self.pgid,
+            grace,
+        );
+        if let Some(process_group) = self.process_group {
+            process_group.sigterm();
+        }
+        self.control_error = Some(error);
+        self.post_result_cleanup = None;
+        self.state = TerminationState::SigkillPending { reason };
+        termination_deadline
+            .as_mut()
+            .reset(deadline_after(Instant::now(), grace));
+    }
+
+    pub(super) fn handle_deadline(&mut self, mut termination_deadline: Pin<&mut Sleep>) {
+        match self.state {
+            TerminationState::SigtermPending { reason } => {
+                let now = Instant::now();
+                let cleanup_timeout = (reason == TerminationReason::PostResult)
+                    .then(|| {
+                        self.post_result_cleanup
+                            .as_mut()
+                            .and_then(|cleanup| cleanup.mark_signal_sent(now))
+                    })
+                    .flatten();
+                let grace = cleanup_timeout
+                    .map(|timeout| timeout.elapsed)
+                    .unwrap_or_else(env::post_result_sigterm_grace);
+
+                if let Some(pid) = self.pgid {
+                    if reason == TerminationReason::PostResult {
+                        if let Some(timeout) = cleanup_timeout {
+                            let trigger = timeout.trigger.label();
+                            let elapsed_ms = timeout.elapsed.as_millis();
+                            let quiet_ms = timeout.quiet_for.as_millis();
+                            let meaningful_events = timeout.meaningful_event_count;
+                            let detail = format!(
+                                "trigger={trigger} signal=sigterm elapsed_ms={elapsed_ms} quiet_ms={quiet_ms} meaningful_events={meaningful_events}"
+                            );
+                            log_warn!(
+                                LOG_TAG,
+                                "Post-result cleanup {trigger} reached after {elapsed_ms}ms (quiet {quiet_ms}ms, meaningful events {meaningful_events}), SIGTERM pgid={pid}"
+                            );
+                            record_sandbox_op(
+                                "post_result_cleanup_terminated",
+                                timeout.elapsed,
+                                true,
+                                Some(&detail),
+                            );
+                        } else {
+                            log_warn!(
+                                LOG_TAG,
+                                "Post-result cleanup deadline fired without state, SIGTERM pgid={pid}"
+                            );
+                        }
+                    } else {
+                        log_warn!(
+                            LOG_TAG,
+                            "CLI still running after {} sigterm grace {}ms, SIGTERM pgid={pid}",
+                            reason.label(),
+                            grace.as_millis()
+                        );
+                    }
+                    record_cli_termination_signal(
+                        &mut self.diagnostic,
+                        reason,
+                        CliTerminationSignal::Sigterm,
+                        self.pgid,
+                        grace,
+                    );
+                    if let Some(process_group) = self.process_group {
+                        process_group.sigterm();
+                    }
+                }
+
+                self.state = TerminationState::SigkillPending { reason };
+                termination_deadline.as_mut().reset(deadline_after(
+                    Instant::now(),
+                    env::post_result_sigkill_grace(),
+                ));
+            }
+            TerminationState::SigkillPending { reason } => {
+                let grace = env::post_result_sigkill_grace();
+                let now = Instant::now();
+                if let Some(pid) = self.pgid {
+                    log_warn!(
+                        LOG_TAG,
+                        "CLI did not exit after {} SIGTERM+{}ms, SIGKILL pgid={pid}",
+                        reason.label(),
+                        grace.as_millis()
+                    );
+                    if reason == TerminationReason::PostResult
+                        && let Some(cleanup) = self.post_result_cleanup
+                    {
+                        let elapsed = cleanup.elapsed(now);
+                        let quiet_ms = cleanup.quiet_for(now).as_millis();
+                        let meaningful_events = cleanup.meaningful_event_count();
+                        let elapsed_ms = elapsed.as_millis();
+                        let detail = format!(
+                            "trigger=sigkill_escalation signal=sigkill elapsed_ms={elapsed_ms} quiet_ms={quiet_ms} meaningful_events={meaningful_events}"
+                        );
+                        record_sandbox_op(
+                            "post_result_cleanup_terminated",
+                            elapsed,
+                            true,
+                            Some(&detail),
+                        );
+                    }
+                    record_cli_termination_signal(
+                        &mut self.diagnostic,
+                        reason,
+                        CliTerminationSignal::Sigkill,
+                        self.pgid,
+                        grace,
+                    );
+                    if let Some(process_group) = self.process_group {
+                        process_group.sigkill();
+                    }
+                }
+                self.post_result_cleanup = None;
+                self.state = TerminationState::Done;
+            }
+            // Unreachable by the is_pending() guard. Log in every build so
+            // any future FSM regression surfaces in production runner logs;
+            // debug_assert adds a fail-fast panic under cfg(debug_assertions).
+            TerminationState::Idle | TerminationState::Done => {
+                log_warn!(
+                    LOG_TAG,
+                    "termination_deadline fired in non-pending state {:?}",
+                    self.state
+                );
+                debug_assert!(
+                    false,
+                    "termination_deadline fired in non-pending state {:?}",
+                    self.state
+                );
+            }
+        }
+    }
+
+    pub(super) fn finish(
+        self,
+        exit_code: i32,
+    ) -> (Option<AgentError>, Option<CliTerminationDiagnostic>) {
+        let cli_termination = self
+            .diagnostic
+            .map(|diagnostic| diagnostic.with_observed_exit_code(exit_code));
+        (self.control_error, cli_termination)
+    }
+}
+
+fn record_cli_termination_signal(
+    cli_termination: &mut Option<CliTerminationDiagnostic>,
+    reason: TerminationReason,
+    signal: CliTerminationSignal,
+    pgid: Option<i32>,
+    grace: Duration,
+) {
+    let diagnostic = cli_termination
+        .take()
+        .unwrap_or_else(|| CliTerminationDiagnostic::new(diagnostic_termination_reason(reason)));
+    let grace_ms = u64::try_from(grace.as_millis()).unwrap_or(u64::MAX);
+    *cli_termination = Some(diagnostic.record_signal(signal, pgid, Some(grace_ms)));
+}
+
+fn diagnostic_termination_reason(reason: TerminationReason) -> DiagnosticTerminationReason {
+    match reason {
+        TerminationReason::PostResult => DiagnosticTerminationReason::PostResultReap,
+        TerminationReason::InitialPromptStdin => DiagnosticTerminationReason::InitialPromptStdin,
+        TerminationReason::StuckTool => DiagnosticTerminationReason::StuckToolWatchdog,
+        TerminationReason::HeartbeatError => DiagnosticTerminationReason::HeartbeatError,
+        TerminationReason::HeartbeatPanic => DiagnosticTerminationReason::HeartbeatPanic,
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use guest_contracts::diagnostics::{CliTerminationReason, CliTerminationSignal};
 
     #[test]
     fn termination_state_is_pending_only_between_arming_and_done() {
@@ -239,6 +597,181 @@ mod tests {
 
         // Done is sticky.
         assert!(!TerminationState::Done.should_arm_post_result(false));
+    }
+
+    #[test]
+    fn cli_termination_signal_records_initial_prompt_stdin_and_escalation() {
+        let mut diagnostic = None;
+
+        record_cli_termination_signal(
+            &mut diagnostic,
+            TerminationReason::InitialPromptStdin,
+            CliTerminationSignal::Sigterm,
+            Some(42),
+            Duration::from_secs(1),
+        );
+
+        let first = diagnostic.expect("diagnostic after SIGTERM");
+        assert_eq!(first.reason, CliTerminationReason::InitialPromptStdin);
+        assert_eq!(first.signal_sent, Some(CliTerminationSignal::Sigterm));
+        assert_eq!(first.signal_pgid, Some(42));
+        assert_eq!(first.signal_grace_ms, Some(1_000));
+        assert!(!first.escalated);
+
+        let mut diagnostic = Some(first);
+        record_cli_termination_signal(
+            &mut diagnostic,
+            TerminationReason::InitialPromptStdin,
+            CliTerminationSignal::Sigkill,
+            Some(42),
+            Duration::from_secs(2),
+        );
+
+        let escalated = diagnostic.expect("diagnostic after SIGKILL");
+        assert_eq!(escalated.reason, CliTerminationReason::InitialPromptStdin);
+        assert_eq!(escalated.signal_sent, Some(CliTerminationSignal::Sigkill));
+        assert_eq!(escalated.signal_pgid, Some(42));
+        assert_eq!(escalated.signal_grace_ms, Some(2_000));
+        assert!(escalated.escalated);
+    }
+
+    #[tokio::test]
+    async fn control_failure_overrides_post_result_cleanup() {
+        let deadline = tokio::time::sleep(Duration::MAX);
+        tokio::pin!(deadline);
+        let mut runtime = CliTerminationRuntime::new(None);
+
+        assert!(runtime.arm_post_result_cleanup(false, deadline.as_mut()));
+        assert!(runtime.has_post_result_cleanup());
+
+        assert!(runtime.begin_control_failure(
+            TerminationReason::HeartbeatError,
+            AgentError::Execution("heartbeat failed".to_string()),
+            ControlTerminationLog::HeartbeatFailed,
+            deadline.as_mut(),
+        ));
+
+        let control_error = runtime
+            .control_error
+            .as_ref()
+            .expect("control error should be stored");
+        assert!(control_error.to_string().contains("heartbeat failed"));
+        assert!(!runtime.has_post_result_cleanup());
+        assert_eq!(
+            runtime.state,
+            TerminationState::SigkillPending {
+                reason: TerminationReason::HeartbeatError
+            }
+        );
+        let diagnostic = runtime.diagnostic.expect("diagnostic should be recorded");
+        assert_eq!(diagnostic.reason, CliTerminationReason::HeartbeatError);
+        assert_eq!(diagnostic.signal_sent, Some(CliTerminationSignal::Sigterm));
+        assert_eq!(diagnostic.signal_pgid, None);
+        assert!(diagnostic.signal_grace_ms.is_some());
+        assert!(!diagnostic.escalated);
+    }
+
+    #[tokio::test]
+    async fn second_control_failure_does_not_overwrite_first() {
+        let deadline = tokio::time::sleep(Duration::MAX);
+        tokio::pin!(deadline);
+        let mut runtime = CliTerminationRuntime::new(None);
+
+        assert!(runtime.begin_control_failure(
+            TerminationReason::HeartbeatError,
+            AgentError::Execution("first heartbeat failure".to_string()),
+            ControlTerminationLog::HeartbeatFailed,
+            deadline.as_mut(),
+        ));
+        assert!(!runtime.begin_control_failure(
+            TerminationReason::StuckTool,
+            AgentError::Execution("second tool failure".to_string()),
+            ControlTerminationLog::StuckTool {
+                name: "WebFetch".to_string(),
+                elapsed: 30,
+            },
+            deadline.as_mut(),
+        ));
+
+        let control_error = runtime
+            .control_error
+            .as_ref()
+            .expect("first control error should remain");
+        assert!(
+            control_error
+                .to_string()
+                .contains("first heartbeat failure")
+        );
+        assert_eq!(
+            runtime.state,
+            TerminationState::SigkillPending {
+                reason: TerminationReason::HeartbeatError
+            }
+        );
+        assert_eq!(
+            runtime.diagnostic.expect("diagnostic").reason,
+            CliTerminationReason::HeartbeatError
+        );
+    }
+
+    #[tokio::test]
+    async fn stdin_control_failure_is_only_eligible_while_idle() {
+        let deadline = tokio::time::sleep(Duration::MAX);
+        tokio::pin!(deadline);
+        let mut runtime = CliTerminationRuntime::new(None);
+
+        assert!(runtime.can_begin_initial_prompt_stdin_control_failure(false));
+        assert!(!runtime.can_begin_initial_prompt_stdin_control_failure(true));
+
+        assert!(runtime.arm_post_result_cleanup(false, deadline.as_mut()));
+        assert!(!runtime.can_begin_initial_prompt_stdin_control_failure(false));
+
+        runtime.mark_child_exited();
+        assert!(!runtime.can_begin_initial_prompt_stdin_control_failure(false));
+    }
+
+    #[tokio::test]
+    async fn child_exit_parks_termination_and_prevents_late_post_result_arm() {
+        let deadline = tokio::time::sleep(Duration::MAX);
+        tokio::pin!(deadline);
+        let mut runtime = CliTerminationRuntime::new(None);
+
+        assert!(runtime.arm_post_result_cleanup(false, deadline.as_mut()));
+        runtime.mark_child_exited();
+
+        assert!(!runtime.has_pending_deadline());
+        assert!(!runtime.has_post_result_cleanup());
+        assert!(!runtime.arm_post_result_cleanup(false, deadline.as_mut()));
+        assert_eq!(runtime.state, TerminationState::Done);
+    }
+
+    #[tokio::test]
+    async fn post_result_activity_refreshes_only_for_previously_armed_cleanup() {
+        let deadline = tokio::time::sleep(Duration::MAX);
+        tokio::pin!(deadline);
+        let mut runtime = CliTerminationRuntime::new(None);
+
+        runtime.record_post_result_activity(false, deadline.as_mut());
+        assert!(runtime.post_result_cleanup.is_none());
+
+        assert!(runtime.arm_post_result_cleanup(false, deadline.as_mut()));
+        runtime.record_post_result_activity(false, deadline.as_mut());
+        assert_eq!(
+            runtime
+                .post_result_cleanup
+                .expect("cleanup")
+                .meaningful_event_count(),
+            0
+        );
+
+        runtime.record_post_result_activity(true, deadline.as_mut());
+        assert_eq!(
+            runtime
+                .post_result_cleanup
+                .expect("cleanup")
+                .meaningful_event_count(),
+            1
+        );
     }
 
     #[test]

--- a/crates/guest-agent/src/cli/termination.rs
+++ b/crates/guest-agent/src/cli/termination.rs
@@ -341,7 +341,7 @@ impl CliTerminationRuntime {
         log: ControlTerminationLog,
         termination_deadline: Pin<&mut Sleep>,
     ) -> bool {
-        if self.control_error.is_some() {
+        if self.control_error.is_some() || matches!(self.state, TerminationState::Done) {
             return false;
         }
 
@@ -742,6 +742,14 @@ mod tests {
         assert!(!runtime.has_pending_deadline());
         assert!(!runtime.has_post_result_cleanup());
         assert!(!runtime.arm_post_result_cleanup(false, deadline.as_mut()));
+        assert!(!runtime.begin_control_failure(
+            TerminationReason::HeartbeatError,
+            AgentError::Execution("late heartbeat failure".to_string()),
+            ControlTerminationLog::HeartbeatFailed,
+            deadline.as_mut(),
+        ));
+        assert!(runtime.control_error.is_none());
+        assert!(runtime.diagnostic.is_none());
         assert_eq!(runtime.state, TerminationState::Done);
     }
 


### PR DESCRIPTION
## Summary
- move the CLI termination runtime into `cli/termination.rs` so it owns termination state, diagnostics, signal side effects, and post-result cleanup deadlines
- replace direct state mutation in `execute_cli_inner` with intention-level runtime calls for control failures, post-result cleanup, child exit, deadline handling, and final extraction
- add focused termination state tests for control-failure override, first-error-wins behavior, stdin eligibility, child-exit parking, and post-result activity refresh

## Feature switch
- not needed; this is an internal guest-agent refactor with no user-facing feature surface

## Testing
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `git diff --check`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent cli::termination --quiet`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --quiet`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features -- -D warnings`
- pre-commit: crates cargo-fmt, cargo-doc, cargo-clippy

Closes #19307
