### PR TITLE
perf(runner): add session history identity reason telemetry

### DIFF
--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -1,7 +1,9 @@
 use std::time::{Duration, Instant};
 
 use guest_contracts::diagnostics::FailureDiagnostic;
-use guest_contracts::session_history_identity::FinalSessionHistoryIdentity;
+use guest_contracts::session_history_identity::{
+    FinalSessionHistoryIdentity, FinalSessionHistoryIdentityError,
+};
 use sandbox::{
     EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, ExecTermination, ProcessControlMode, ProcessOutputMode,
     Sandbox, StartProcessRequest,
@@ -72,6 +74,87 @@ impl SessionHistoryRestoreFallback {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SessionHistoryIdentityReason {
+    FinalizeMetadataPathUnresolved,
+    FinalizeRuntimeDirUnresolved,
+    FinalizeMissingMetadata,
+    FinalizeMetadataReadFailed,
+    FinalizeInvalidMetadata,
+    FinalizeUnverifiableMetadata,
+    VerifyMissingIdentity,
+    VerifyRequestMissing,
+    VerifyRequestMismatch,
+    VerifyMissingVerifier,
+    VerifyMissingFile,
+    VerifyReadFailed,
+    VerifySizeMismatch,
+    VerifyHashMismatch,
+    VerifyHelperFailed,
+    VerifyHelperExecError,
+    ReuseMissingNoIdleIdentity,
+}
+
+impl SessionHistoryIdentityReason {
+    const fn action_type(self) -> &'static str {
+        match self {
+            Self::FinalizeMetadataPathUnresolved => {
+                "session_history_identity_finalize_metadata_path_unresolved"
+            }
+            Self::FinalizeRuntimeDirUnresolved => {
+                "session_history_identity_finalize_runtime_dir_unresolved"
+            }
+            Self::FinalizeMissingMetadata => "session_history_identity_finalize_missing_metadata",
+            Self::FinalizeMetadataReadFailed => {
+                "session_history_identity_finalize_metadata_read_failed"
+            }
+            Self::FinalizeInvalidMetadata => "session_history_identity_finalize_invalid_metadata",
+            Self::FinalizeUnverifiableMetadata => {
+                "session_history_identity_finalize_unverifiable_metadata"
+            }
+            Self::VerifyMissingIdentity => "session_history_identity_verify_missing_identity",
+            Self::VerifyRequestMissing => "session_history_identity_verify_request_missing",
+            Self::VerifyRequestMismatch => "session_history_identity_verify_request_mismatch",
+            Self::VerifyMissingVerifier => "session_history_identity_verify_missing_verifier",
+            Self::VerifyMissingFile => "session_history_identity_verify_missing_file",
+            Self::VerifyReadFailed => "session_history_identity_verify_read_failed",
+            Self::VerifySizeMismatch => "session_history_identity_verify_size_mismatch",
+            Self::VerifyHashMismatch => "session_history_identity_verify_hash_mismatch",
+            Self::VerifyHelperFailed => "session_history_identity_verify_helper_failed",
+            Self::VerifyHelperExecError => "session_history_identity_verify_helper_exec_error",
+            Self::ReuseMissingNoIdleIdentity => {
+                "session_history_identity_reuse_missing_no_idle_identity"
+            }
+        }
+    }
+
+    const fn from_final_metadata_error(error: FinalSessionHistoryIdentityError) -> Self {
+        match error {
+            FinalSessionHistoryIdentityError::MetadataTooLarge
+            | FinalSessionHistoryIdentityError::HistoryTooLarge => {
+                Self::FinalizeUnverifiableMetadata
+            }
+            FinalSessionHistoryIdentityError::InvalidJson
+            | FinalSessionHistoryIdentityError::UnsupportedVersion
+            | FinalSessionHistoryIdentityError::InvalidFramework
+            | FinalSessionHistoryIdentityError::InvalidHistoryRefKind
+            | FinalSessionHistoryIdentityError::InvalidSessionIdHash
+            | FinalSessionHistoryIdentityError::InvalidHistoryHash
+            | FinalSessionHistoryIdentityError::InvalidHistorySize
+            | FinalSessionHistoryIdentityError::MissingHistoryMarker => {
+                Self::FinalizeInvalidMetadata
+            }
+        }
+    }
+}
+
+fn record_session_history_identity_reason(
+    telemetry: &mut JobTelemetry,
+    reason: SessionHistoryIdentityReason,
+) {
+    telemetry.record(reason.action_type(), Duration::ZERO, true, None);
+}
+
 #[derive(Default)]
 #[must_use = "restore plans decide whether resume history download can be skipped"]
 pub(crate) enum SessionHistoryRestorePlan {
@@ -107,29 +190,34 @@ async fn verify_restored_session_identity_for_reuse(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,
     identity: Option<RestoredSessionIdentity>,
-) -> Option<RestoredSessionIdentity> {
-    let identity = identity?;
+) -> Result<RestoredSessionIdentity, SessionHistoryIdentityReason> {
+    let Some(identity) = identity else {
+        return Err(SessionHistoryIdentityReason::VerifyMissingIdentity);
+    };
     let Some(requested_identity) = RestoredSessionIdentity::from_context(context) else {
         debug!(
             run_id = %context.run_id,
             "restored session identity cannot be verified without a valid hash-backed resume request"
         );
-        return None;
+        return Err(SessionHistoryIdentityReason::VerifyRequestMissing);
     };
-    if !identity.is_verified_match_for_request(&requested_identity) {
+    if identity != requested_identity {
         debug!(
             run_id = %context.run_id,
             "restored session identity invalidated because it does not match the resume request"
         );
-        return None;
+        return Err(SessionHistoryIdentityReason::VerifyRequestMismatch);
     }
     let Some(verification) = identity.guest_history_verification() else {
         debug!(
             run_id = %context.run_id,
             "restored session identity cannot be verified without a bounded verifier"
         );
-        return None;
+        return Err(SessionHistoryIdentityReason::VerifyMissingVerifier);
     };
+    if !identity.is_verified_match_for_request(&requested_identity) {
+        return Err(SessionHistoryIdentityReason::VerifyRequestMismatch);
+    }
 
     match verification {
         RestoredSessionHistoryVerification::GuestHistoryPath {
@@ -180,7 +268,7 @@ async fn verify_guest_history_path_identity(
     expected_size: u64,
     guest_history_path: &str,
     read_limit: u64,
-) -> Option<RestoredSessionIdentity> {
+) -> Result<RestoredSessionIdentity, SessionHistoryIdentityReason> {
     let read_result = sandbox.read_file(guest_history_path, read_limit).await;
     let bytes = match read_result {
         Ok(Some(bytes)) => bytes,
@@ -189,14 +277,14 @@ async fn verify_guest_history_path_identity(
                 run_id = %context.run_id,
                 "restored session identity invalidated because history file is missing"
             );
-            return None;
+            return Err(SessionHistoryIdentityReason::VerifyMissingFile);
         }
         Err(_) => {
             debug!(
                 run_id = %context.run_id,
                 "restored session identity verification failed"
             );
-            return None;
+            return Err(SessionHistoryIdentityReason::VerifyReadFailed);
         }
     };
     if bytes.len() as u64 != expected_size {
@@ -206,7 +294,7 @@ async fn verify_guest_history_path_identity(
             actual_size = bytes.len(),
             "restored session identity invalidated because history size changed"
         );
-        return None;
+        return Err(SessionHistoryIdentityReason::VerifySizeMismatch);
     }
     let actual_hash = hex::encode(Sha256::digest(&bytes));
     if actual_hash != identity.history_hash() {
@@ -214,10 +302,10 @@ async fn verify_guest_history_path_identity(
             run_id = %context.run_id,
             "restored session identity invalidated because history hash changed"
         );
-        return None;
+        return Err(SessionHistoryIdentityReason::VerifyHashMismatch);
     }
 
-    Some(identity)
+    Ok(identity)
 }
 
 async fn verify_final_identity_metadata(
@@ -226,7 +314,7 @@ async fn verify_final_identity_metadata(
     identity: RestoredSessionIdentity,
     command: String,
     runtime_dir: &str,
-) -> Option<RestoredSessionIdentity> {
+) -> Result<RestoredSessionIdentity, SessionHistoryIdentityReason> {
     let env = [(
         guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
         runtime_dir,
@@ -243,21 +331,21 @@ async fn verify_final_identity_metadata(
         .exec_with_diagnostic_label(&request, "session-history-identity-verify")
         .await
     {
-        Ok(result) if helper_exec_succeeded(&result) => Some(identity),
+        Ok(result) if helper_exec_succeeded(&result) => Ok(identity),
         Ok(result) => {
             debug!(
                 run_id = %context.run_id,
                 termination = %helper_exec_termination_label(&result),
                 "restored session identity final metadata verification failed"
             );
-            None
+            Err(SessionHistoryIdentityReason::VerifyHelperFailed)
         }
         Err(_) => {
             debug!(
                 run_id = %context.run_id,
                 "restored session identity final metadata verification errored"
             );
-            None
+            Err(SessionHistoryIdentityReason::VerifyHelperExecError)
         }
     }
 }
@@ -287,7 +375,7 @@ fn build_final_identity_verify_command(
 async fn read_final_session_history_identity(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,
-) -> Option<RestoredSessionIdentity> {
+) -> Result<RestoredSessionIdentity, SessionHistoryIdentityReason> {
     let metadata_path = match guest_runtime_path(
         context.run_id,
         guest_contracts::runtime_paths::final_session_history_identity_file,
@@ -299,7 +387,7 @@ async fn read_final_session_history_identity(
                 error = %error,
                 "final session history identity path could not be resolved"
             );
-            return None;
+            return Err(SessionHistoryIdentityReason::FinalizeMetadataPathUnresolved);
         }
     };
     let runtime_dir = match guest_runtime_dir(context.run_id) {
@@ -310,7 +398,7 @@ async fn read_final_session_history_identity(
                 error = %error,
                 "guest runtime dir could not be resolved for final session history identity"
             );
-            return None;
+            return Err(SessionHistoryIdentityReason::FinalizeRuntimeDirUnresolved);
         }
     };
     let bytes = match sandbox
@@ -318,13 +406,13 @@ async fn read_final_session_history_identity(
         .await
     {
         Ok(Some(bytes)) => bytes,
-        Ok(None) => return None,
+        Ok(None) => return Err(SessionHistoryIdentityReason::FinalizeMissingMetadata),
         Err(_) => {
             debug!(
                 run_id = %context.run_id,
                 "final session history identity metadata read failed"
             );
-            return None;
+            return Err(SessionHistoryIdentityReason::FinalizeMetadataReadFailed);
         }
     };
     let metadata = match FinalSessionHistoryIdentity::from_json_slice(&bytes) {
@@ -335,10 +423,13 @@ async fn read_final_session_history_identity(
                 error = %error,
                 "final session history identity metadata was invalid"
             );
-            return None;
+            return Err(SessionHistoryIdentityReason::from_final_metadata_error(
+                error,
+            ));
         }
     };
     RestoredSessionIdentity::from_final_metadata(metadata, metadata_path, runtime_dir)
+        .ok_or(SessionHistoryIdentityReason::FinalizeUnverifiableMetadata)
 }
 
 pub(super) struct ProcessCancelTimeouts {
@@ -648,7 +739,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         SessionHistoryRestorePlan::SkipVerified(identity) => {
             match verify_restored_session_identity_for_reuse(sandbox, context, Some(identity)).await
             {
-                Some(identity) => {
+                Ok(identity) => {
                     telemetry.record(
                         "session_history_identity_reuse_hit",
                         Duration::ZERO,
@@ -659,13 +750,14 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                     restored_session_identity = Some(identity);
                     None
                 }
-                None => {
+                Err(reason) => {
                     telemetry.record(
                         SessionHistoryRestoreFallback::StaleIdleIdentity.action_type(),
                         Duration::ZERO,
                         true,
                         None,
                     );
+                    record_session_history_identity_reason(telemetry, reason);
                     Some(SessionHistoryMaterializer::start_cancellable(
                         &config.http,
                         context.resume_session.as_ref(),
@@ -691,6 +783,10 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                         Duration::ZERO,
                         true,
                         None,
+                    );
+                    record_session_history_identity_reason(
+                        telemetry,
+                        SessionHistoryIdentityReason::ReuseMissingNoIdleIdentity,
                     );
                 }
             }
@@ -1201,30 +1297,43 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
     };
 
     if failure.is_none() {
-        if let Some(final_identity) = read_final_session_history_identity(sandbox, context).await {
-            telemetry.record(
-                "session_history_identity_finalized",
-                Duration::ZERO,
-                true,
-                None,
-            );
-            restored_session_identity = Some(final_identity);
-        } else {
-            let verified_restored_session_identity = verify_restored_session_identity_for_reuse(
-                sandbox,
-                context,
-                restored_session_identity,
-            )
-            .await;
-            if produced_restored_session_identity && verified_restored_session_identity.is_some() {
+        match read_final_session_history_identity(sandbox, context).await {
+            Ok(final_identity) => {
                 telemetry.record(
-                    "session_history_identity_restored",
+                    "session_history_identity_finalized",
                     Duration::ZERO,
                     true,
                     None,
                 );
+                restored_session_identity = Some(final_identity);
             }
-            restored_session_identity = verified_restored_session_identity;
+            Err(final_identity_reason) => {
+                record_session_history_identity_reason(telemetry, final_identity_reason);
+                if let Some(restored_identity) = restored_session_identity.take() {
+                    match verify_restored_session_identity_for_reuse(
+                        sandbox,
+                        context,
+                        Some(restored_identity),
+                    )
+                    .await
+                    {
+                        Ok(verified_restored_session_identity) => {
+                            if produced_restored_session_identity {
+                                telemetry.record(
+                                    "session_history_identity_restored",
+                                    Duration::ZERO,
+                                    true,
+                                    None,
+                                );
+                            }
+                            restored_session_identity = Some(verified_restored_session_identity);
+                        }
+                        Err(reason) => {
+                            record_session_history_identity_reason(telemetry, reason);
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -82,7 +82,6 @@ enum SessionHistoryIdentityReason {
     FinalizeMetadataReadFailed,
     FinalizeInvalidMetadata,
     FinalizeUnverifiableMetadata,
-    VerifyMissingIdentity,
     VerifyRequestMissing,
     VerifyRequestMismatch,
     VerifyMissingVerifier,
@@ -112,7 +111,6 @@ impl SessionHistoryIdentityReason {
             Self::FinalizeUnverifiableMetadata => {
                 "session_history_identity_finalize_unverifiable_metadata"
             }
-            Self::VerifyMissingIdentity => "session_history_identity_verify_missing_identity",
             Self::VerifyRequestMissing => "session_history_identity_verify_request_missing",
             Self::VerifyRequestMismatch => "session_history_identity_verify_request_mismatch",
             Self::VerifyMissingVerifier => "session_history_identity_verify_missing_verifier",
@@ -189,11 +187,8 @@ pub(super) fn build_agent_start_command(run_agent_path: &str) -> String {
 async fn verify_restored_session_identity_for_reuse(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,
-    identity: Option<RestoredSessionIdentity>,
+    identity: RestoredSessionIdentity,
 ) -> Result<RestoredSessionIdentity, SessionHistoryIdentityReason> {
-    let Some(identity) = identity else {
-        return Err(SessionHistoryIdentityReason::VerifyMissingIdentity);
-    };
     let Some(requested_identity) = RestoredSessionIdentity::from_context(context) else {
         debug!(
             run_id = %context.run_id,
@@ -737,8 +732,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
     let mut produced_restored_session_identity = false;
     let session_history_materializer = match session_history_restore_plan {
         SessionHistoryRestorePlan::SkipVerified(identity) => {
-            match verify_restored_session_identity_for_reuse(sandbox, context, Some(identity)).await
-            {
+            match verify_restored_session_identity_for_reuse(sandbox, context, identity).await {
                 Ok(identity) => {
                     telemetry.record(
                         "session_history_identity_reuse_hit",
@@ -1313,7 +1307,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                     match verify_restored_session_identity_for_reuse(
                         sandbox,
                         context,
-                        Some(restored_identity),
+                        restored_identity,
                     )
                     .await
                     {

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -33,8 +33,8 @@ use super::super::{
 };
 use super::support::{
     CancelAfterWaitSandbox, RUN_IN_SANDBOX_TEST_TIMEOUT, api_storage, create_overridden_sandbox,
-    minimal_context, spawn_run_in_sandbox_test, spawn_run_in_sandbox_test_with_timeouts,
-    test_executor_config, test_telemetry,
+    minimal_context, sandbox_exec_error, spawn_run_in_sandbox_test,
+    spawn_run_in_sandbox_test_with_timeouts, test_executor_config, test_telemetry,
 };
 use crate::active_input::ActiveInputSource;
 use crate::local_queue::{ActiveInputEntry, LocalQueue};
@@ -117,6 +117,13 @@ fn final_identity_metadata_bytes(
     .unwrap()
     .to_json_vec()
     .unwrap()
+}
+
+fn assert_successful_action(ops: &[(String, bool, Option<String>)], action: &str) {
+    assert!(
+        ops.iter().any(|op| op.0 == action && op.1),
+        "expected {action} telemetry, got: {ops:?}"
+    );
 }
 
 #[test]
@@ -730,6 +737,7 @@ async fn run_in_sandbox_restores_when_checkpointed_final_identity_helper_fails()
     assert_eq!(writes[0].path, claude_history_path(session_id));
     assert_eq!(writes[0].content, history);
     let ops = telemetry.pending_ops_snapshot();
+    assert_successful_action(&ops, "session_history_identity_verify_helper_failed");
     assert!(
         ops.iter()
             .any(|op| op.0 == "session_history_restore_fallback_stale_idle_identity" && op.1),
@@ -738,6 +746,80 @@ async fn run_in_sandbox_restores_when_checkpointed_final_identity_helper_fails()
     assert!(
         ops.iter().all(|op| op.0 != "session_history_restore_skip"),
         "helper failure should not record skip telemetry, got: {ops:?}"
+    );
+}
+
+#[tokio::test]
+async fn run_in_sandbox_restores_when_checkpointed_final_identity_helper_exec_errors() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let sandbox = sandbox_mock::MockSandbox::new("test");
+    let history = br#"{"type":"init"}"#;
+    let server = MockServer::start_async().await;
+    let history_mock = server
+        .mock_async(|when, then| {
+            when.method(GET).path("/history.blob");
+            then.status(200).body(history);
+        })
+        .await;
+    let mut ctx = minimal_context();
+    let session_id = "sess-final-helper-exec-errors-123";
+    ctx.resume_session = Some(ResumeSession {
+        cli_agent_session_id: session_id.into(),
+        history: ResumeSessionHistory::Ref {
+            history_ref: ResumeSessionHistoryRef {
+                kind: ResumeSessionHistoryRefKind::Blob,
+                hash: hex::encode(Sha256::digest(history)),
+                url: server.url("/history.blob?token=secret"),
+                size: Some(history.len() as u64),
+            },
+        },
+    });
+    let (metadata_path, runtime_dir) = final_identity_runtime_paths(&ctx);
+    let metadata = FinalSessionHistoryIdentity::new(
+        FinalSessionHistoryFramework::ClaudeCode,
+        hex::encode(Sha256::digest(session_id.as_bytes())),
+        FinalSessionHistoryRefKind::Blob,
+        hex::encode(Sha256::digest(history)),
+        history.len() as u64,
+        claude_history_path(session_id),
+    )
+    .unwrap();
+    let idle_identity =
+        RestoredSessionIdentity::from_final_metadata(metadata, metadata_path.clone(), runtime_dir)
+            .expect("checkpointed identity");
+    sandbox.push_exec_result(Err(sandbox_exec_error("vsock exec failed")));
+    sandbox.push_read_file_result(Ok(None));
+    sandbox.push_read_file_result(Ok(Some(history.to_vec())));
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let result = run_in_sandbox(
+        &sandbox,
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::Reused,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None)
+            .with_session_history_restore_plan(SessionHistoryRestorePlan::SkipVerified(
+                idle_identity,
+            )),
+    )
+    .await
+    .unwrap();
+
+    assert!(result.failure.is_none());
+    history_mock.assert_calls_async(1).await;
+    assert_eq!(sandbox.exec_calls().len(), 1);
+    let ops = telemetry.pending_ops_snapshot();
+    assert_successful_action(&ops, "session_history_identity_verify_helper_exec_error");
+    assert_successful_action(&ops, "session_history_restore_fallback_stale_idle_identity");
+    assert!(
+        ops.iter().all(|op| op.0 != "session_history_restore_skip"),
+        "helper exec error should not record skip telemetry, got: {ops:?}"
     );
 }
 
@@ -817,6 +899,7 @@ async fn run_in_sandbox_restores_when_skip_verified_identity_mismatches_request(
     assert_eq!(writes[0].content, history);
     assert_eq!(sandbox.read_file_calls().len(), 2);
     let ops = telemetry.pending_ops_snapshot();
+    assert_successful_action(&ops, "session_history_identity_verify_request_mismatch");
     assert!(
         ops.iter()
             .any(|op| op.0 == "session_history_restore_fallback_stale_idle_identity" && op.1),
@@ -904,6 +987,7 @@ async fn run_in_sandbox_restores_when_skip_verified_identity_is_stale_before_sta
     );
     assert_eq!(writes[0].content, history);
     let ops = telemetry.pending_ops_snapshot();
+    assert_successful_action(&ops, "session_history_identity_verify_missing_file");
     assert!(
         ops.iter()
             .any(|op| op.0 == "session_history_restore_fallback_stale_idle_identity" && op.1),
@@ -981,6 +1065,7 @@ async fn run_in_sandbox_restores_when_skip_verified_identity_has_invalid_path() 
         "/home/user/.claude/projects/-home-user-workspace/sess-invalid-path-123.jsonl"
     );
     let ops = telemetry.pending_ops_snapshot();
+    assert_successful_action(&ops, "session_history_identity_verify_missing_verifier");
     assert!(
         ops.iter()
             .any(|op| op.0 == "session_history_restore_fallback_stale_idle_identity" && op.1),
@@ -989,6 +1074,138 @@ async fn run_in_sandbox_restores_when_skip_verified_identity_has_invalid_path() 
     assert!(
         ops.iter().all(|op| op.0 != "session_history_restore_skip"),
         "invalid path should not record skip telemetry, got: {ops:?}"
+    );
+}
+
+#[tokio::test]
+async fn run_in_sandbox_restores_when_skip_verified_identity_read_errors() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let sandbox = sandbox_mock::MockSandbox::new("test");
+    let history = br#"{"type":"init"}"#;
+    let server = MockServer::start_async().await;
+    let history_mock = server
+        .mock_async(|when, then| {
+            when.method(GET).path("/history.blob");
+            then.status(200).body(history);
+        })
+        .await;
+    let mut ctx = minimal_context();
+    ctx.resume_session = Some(ResumeSession {
+        cli_agent_session_id: "sess-read-error-skip-123".into(),
+        history: ResumeSessionHistory::Ref {
+            history_ref: ResumeSessionHistoryRef {
+                kind: ResumeSessionHistoryRefKind::Blob,
+                hash: hex::encode(Sha256::digest(history)),
+                url: server.url("/history.blob?token=secret"),
+                size: Some(history.len() as u64),
+            },
+        },
+    });
+    let idle_identity = RestoredSessionIdentity::from_context(&ctx)
+        .expect("identity")
+        .with_guest_history(
+            history.len() as u64,
+            "/home/user/.claude/projects/-home-user-workspace/sess-read-error-skip-123.jsonl",
+        );
+    sandbox.push_read_file_result(Err(sandbox_exec_error("vsock read failed")));
+    sandbox.push_read_file_result(Ok(None));
+    sandbox.push_read_file_result(Ok(Some(history.to_vec())));
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let result = run_in_sandbox(
+        &sandbox,
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::Reused,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None)
+            .with_session_history_restore_plan(SessionHistoryRestorePlan::SkipVerified(
+                idle_identity,
+            )),
+    )
+    .await
+    .unwrap();
+
+    assert!(result.failure.is_none());
+    history_mock.assert_calls_async(1).await;
+    let ops = telemetry.pending_ops_snapshot();
+    assert_successful_action(&ops, "session_history_identity_verify_read_failed");
+    assert_successful_action(&ops, "session_history_restore_fallback_stale_idle_identity");
+    assert!(
+        ops.iter().all(|op| op.0 != "session_history_restore_skip"),
+        "read error should not record skip telemetry, got: {ops:?}"
+    );
+}
+
+#[tokio::test]
+async fn run_in_sandbox_restores_when_skip_verified_identity_size_changes() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let sandbox = sandbox_mock::MockSandbox::new("test");
+    let history = br#"{"type":"init"}"#;
+    let server = MockServer::start_async().await;
+    let history_mock = server
+        .mock_async(|when, then| {
+            when.method(GET).path("/history.blob");
+            then.status(200).body(history);
+        })
+        .await;
+    let mut ctx = minimal_context();
+    ctx.resume_session = Some(ResumeSession {
+        cli_agent_session_id: "sess-size-changed-skip-123".into(),
+        history: ResumeSessionHistory::Ref {
+            history_ref: ResumeSessionHistoryRef {
+                kind: ResumeSessionHistoryRefKind::Blob,
+                hash: hex::encode(Sha256::digest(history)),
+                url: server.url("/history.blob?token=secret"),
+                size: Some(history.len() as u64),
+            },
+        },
+    });
+    let idle_identity = RestoredSessionIdentity::from_context(&ctx)
+        .expect("identity")
+        .with_guest_history(
+            history.len() as u64,
+            "/home/user/.claude/projects/-home-user-workspace/sess-size-changed-skip-123.jsonl",
+        );
+    let mut changed_history = history.to_vec();
+    changed_history.push(b'\n');
+    sandbox.push_read_file_result(Ok(Some(changed_history)));
+    sandbox.push_read_file_result(Ok(None));
+    sandbox.push_read_file_result(Ok(Some(history.to_vec())));
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let result = run_in_sandbox(
+        &sandbox,
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::Reused,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None)
+            .with_session_history_restore_plan(SessionHistoryRestorePlan::SkipVerified(
+                idle_identity,
+            )),
+    )
+    .await
+    .unwrap();
+
+    assert!(result.failure.is_none());
+    history_mock.assert_calls_async(1).await;
+    let ops = telemetry.pending_ops_snapshot();
+    assert_successful_action(&ops, "session_history_identity_verify_size_mismatch");
+    assert_successful_action(&ops, "session_history_restore_fallback_stale_idle_identity");
+    assert!(
+        ops.iter().all(|op| op.0 != "session_history_restore_skip"),
+        "size mismatch should not record skip telemetry, got: {ops:?}"
     );
 }
 
@@ -1062,6 +1279,7 @@ async fn run_in_sandbox_restores_when_skip_verified_identity_is_too_large_to_ver
     );
     assert_eq!(read_calls[1].max_bytes, history.len() as u64 + 1);
     let ops = telemetry.pending_ops_snapshot();
+    assert_successful_action(&ops, "session_history_identity_verify_missing_verifier");
     assert!(
         ops.iter()
             .any(|op| op.0 == "session_history_restore_fallback_stale_idle_identity" && op.1),
@@ -1223,6 +1441,11 @@ async fn run_in_sandbox_records_missing_idle_identity_reuse_fallback() {
     );
     assert_eq!(writes[0].content, history);
     let ops = telemetry.pending_ops_snapshot();
+    assert_successful_action(
+        &ops,
+        "session_history_identity_reuse_missing_no_idle_identity",
+    );
+    assert_successful_action(&ops, "session_history_identity_finalize_missing_metadata");
     assert!(
         ops.iter()
             .any(|op| { op.0 == "session_history_restore_fallback_missing_idle_identity" && op.1 }),
@@ -1297,6 +1520,9 @@ async fn run_in_sandbox_clears_restored_identity_when_history_changes_before_par
 
     assert!(result.failure.is_none());
     assert_eq!(result.restored_session_identity, None);
+    let ops = telemetry.pending_ops_snapshot();
+    assert_successful_action(&ops, "session_history_identity_finalize_missing_metadata");
+    assert_successful_action(&ops, "session_history_identity_verify_hash_mismatch");
 }
 
 #[tokio::test]
@@ -1444,6 +1670,126 @@ async fn run_in_sandbox_uses_final_identity_without_resume_request() {
         ops.iter()
             .any(|op| op.0 == "session_history_identity_finalized" && op.1),
         "expected first-turn final identity telemetry, got: {ops:?}"
+    );
+}
+
+#[tokio::test]
+async fn run_in_sandbox_records_invalid_final_identity_metadata_reason() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let sandbox = sandbox_mock::MockSandbox::new("test");
+    let ctx = minimal_context();
+    sandbox.push_read_file_result(Ok(Some(b"{not-json".to_vec())));
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let result = run_in_sandbox(
+        &sandbox,
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::PoolMiss,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None),
+    )
+    .await
+    .unwrap();
+
+    assert!(result.failure.is_none());
+    assert!(result.restored_session_identity.is_none());
+    let ops = telemetry.pending_ops_snapshot();
+    assert_successful_action(&ops, "session_history_identity_finalize_invalid_metadata");
+    assert!(
+        ops.iter()
+            .all(|op| op.0 != "session_history_identity_finalized"),
+        "invalid metadata should not record finalized identity telemetry, got: {ops:?}"
+    );
+}
+
+#[tokio::test]
+async fn run_in_sandbox_records_unverifiable_final_identity_metadata_reason() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let sandbox = sandbox_mock::MockSandbox::new("test");
+    let ctx = minimal_context();
+    let metadata = serde_json::json!({
+        "version": 1,
+        "framework": "claude-code",
+        "sessionIdHash": "a".repeat(64),
+        "historyRefKind": "blob",
+        "historyHash": "b".repeat(64),
+        "historySizeBytes": SESSION_HISTORY_IDENTITY_VERIFY_MAX_BYTES + 1,
+        "historyMarkerPayload": "/home/user/.claude/projects/-home-user-workspace/session.jsonl",
+    });
+    sandbox.push_read_file_result(Ok(Some(serde_json::to_vec(&metadata).unwrap())));
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let result = run_in_sandbox(
+        &sandbox,
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::PoolMiss,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None),
+    )
+    .await
+    .unwrap();
+
+    assert!(result.failure.is_none());
+    assert!(result.restored_session_identity.is_none());
+    let ops = telemetry.pending_ops_snapshot();
+    assert_successful_action(
+        &ops,
+        "session_history_identity_finalize_unverifiable_metadata",
+    );
+    assert!(
+        ops.iter()
+            .all(|op| op.0 != "session_history_identity_finalized"),
+        "unverifiable metadata should not record finalized identity telemetry, got: {ops:?}"
+    );
+}
+
+#[tokio::test]
+async fn run_in_sandbox_records_final_identity_metadata_read_failure_reason() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let sandbox = sandbox_mock::MockSandbox::new("test");
+    let ctx = minimal_context();
+    sandbox.push_read_file_result(Err(sandbox_exec_error("vsock read failed")));
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let result = run_in_sandbox(
+        &sandbox,
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::PoolMiss,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None),
+    )
+    .await
+    .unwrap();
+
+    assert!(result.failure.is_none());
+    assert!(result.restored_session_identity.is_none());
+    let ops = telemetry.pending_ops_snapshot();
+    assert_successful_action(
+        &ops,
+        "session_history_identity_finalize_metadata_read_failed",
+    );
+    assert!(
+        ops.iter()
+            .all(|op| op.0 != "session_history_identity_finalized"),
+        "metadata read failure should not record finalized identity telemetry, got: {ops:?}"
     );
 }
 


### PR DESCRIPTION
## Summary

This PR adds privacy-safe reason telemetry for session-history identity park/reuse misses. It is diagnostic-only: existing restore, fallback, skip, and parking behavior stays fail-closed.

## Problem

The runner already reports aggregate actions such as `session_history_identity_park_missing`, `session_history_identity_reuse_missing`, and `session_history_restore_fallback_stale_idle_identity`, but those actions do not explain why a session-history identity could not be reused or parked. Without reason-level visibility, the next #18746 performance optimization would be guesswork.

## Solution

- Convert internal final-metadata and identity-verification paths from silent `Option` failures to typed, low-cardinality reason results.
- Emit static reason actions for missing/invalid/unverifiable final metadata, missing idle identity, request mismatch, missing verifier, guest-history read/size/hash failures, and helper failures.
- Preserve existing aggregate actions for before/after comparisons, including restore fallback, reuse missing, restore skip, restored identity, and finalized identity.
- Avoid telemetry schema changes and do not put raw session ids, hashes, paths, URLs, metadata JSON, user ids, or org ids into action names or errors.
- Keep all uncertain cases fail-closed by falling back to normal session-history materialization instead of broadening verified-skip semantics.

## Testing

- `cargo test --manifest-path crates/Cargo.toml -p runner run_in_sandbox`
- `cargo test --manifest-path crates/Cargo.toml -p runner restore_plan`
- `cargo test --manifest-path crates/Cargo.toml -p runner finalization_records_identity`
- `cargo fmt -p runner -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- pre-commit hook: cargo-fmt, cargo-clippy, cargo-doc

Closes #19346
