### PR TITLE
feat: add quick website color editing

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/html-dom-comment-editor.ts
+++ b/turbo/apps/platform/src/signals/zero-page/html-dom-comment-editor.ts
@@ -19,6 +19,7 @@ import {
   HTML_DOM_EDIT_SELECTED_ATTR,
   HTML_DOM_NODE_ID_ATTR,
   instrumentHtmlDomEditDocument,
+  stripHtmlDomEditInstrumentation,
   stripHtmlDomEditOverlaysFromDocument,
 } from "../../views/zero-page/html-dom-edit-protocol.ts";
 import type {
@@ -46,6 +47,24 @@ interface CommentPopoverAnchor {
   readonly top: number;
 }
 
+export type HtmlDomStyleEditProperty =
+  | "backgroundColor"
+  | "borderColor"
+  | "color";
+
+export interface HtmlDomStyleEdit {
+  readonly backgroundColor?: string;
+  readonly borderColor?: string;
+  readonly color?: string;
+}
+
+export interface HtmlDomSelectedStyle {
+  readonly backgroundColor: string;
+  readonly borderColor: string;
+  readonly color: string;
+  readonly nodeId: string;
+}
+
 interface FrameCleanup {
   readonly run: () => void;
 }
@@ -62,6 +81,7 @@ export interface HtmlDomCommentEditorModel {
   readonly loadState: EditorLoadState;
   readonly popoverTextAreaKey: string;
   readonly prepared: boolean;
+  readonly selectedStyle: HtmlDomSelectedStyle | null;
   readonly submitting: boolean;
 }
 
@@ -141,6 +161,9 @@ const internalHoveredNodeId$ = state<string | null>(null);
 const internalCommentText$ = state("");
 const internalComments$ = state<readonly HtmlDomEditComment[]>([]);
 const internalCommentsOpen$ = state(false);
+const internalStyleEdits$ = state<Readonly<Record<string, HtmlDomStyleEdit>>>(
+  {},
+);
 const internalSubmitting$ = state(false);
 const internalPreparedPayload$ = state<HtmlDomEditPayload | null>(null);
 const internalFrameCleanup$ = state<FrameCleanup | null>(null);
@@ -319,6 +342,124 @@ function syncFrameEditState(
   }
 }
 
+function normalizeHexColor(value: string): string | null {
+  const trimmed = value.trim();
+  const match = /^#?([0-9a-f]{3}|[0-9a-f]{6})$/iu.exec(trimmed);
+  const raw = match?.[1];
+  if (!raw) {
+    return null;
+  }
+  if (raw.length === 3) {
+    return `#${raw
+      .split("")
+      .map((part) => {
+        return `${part}${part}`;
+      })
+      .join("")}`.toLowerCase();
+  }
+  return `#${raw}`.toLowerCase();
+}
+
+function componentToHex(value: number): string {
+  return Math.max(0, Math.min(255, Math.round(value)))
+    .toString(16)
+    .padStart(2, "0");
+}
+
+function cssColorToHex(value: string, fallback: string): string {
+  const hex = normalizeHexColor(value);
+  if (hex) {
+    return hex;
+  }
+
+  const rgbMatch =
+    /^rgba?\(\s*([.\d]+)\s*,\s*([.\d]+)\s*,\s*([.\d]+)(?:\s*,\s*([.\d]+))?\s*\)$/iu.exec(
+      value.trim(),
+    );
+  if (!rgbMatch) {
+    return fallback;
+  }
+
+  const alpha = rgbMatch[4] === undefined ? 1 : Number(rgbMatch[4]);
+  if (alpha === 0) {
+    return fallback;
+  }
+
+  return `#${componentToHex(Number(rgbMatch[1]))}${componentToHex(
+    Number(rgbMatch[2]),
+  )}${componentToHex(Number(rgbMatch[3]))}`;
+}
+
+function selectedElementForNodeId(
+  doc: Document | null | undefined,
+  nodeId: string,
+): HTMLElement | null {
+  const element = doc?.querySelector(nodeSelector(nodeId));
+  return element instanceof HTMLElement ? element : null;
+}
+
+function computedStyleForElement(element: HTMLElement): CSSStyleDeclaration {
+  const view = element.ownerDocument.defaultView ?? window;
+  return view.getComputedStyle(element);
+}
+
+function selectedStyleForNode(params: {
+  readonly doc: Document | null | undefined;
+  readonly nodeId: string;
+  readonly styleEdits: Readonly<Record<string, HtmlDomStyleEdit>>;
+}): HtmlDomSelectedStyle | null {
+  const element = selectedElementForNodeId(params.doc, params.nodeId);
+  if (!element) {
+    return null;
+  }
+
+  const computedStyle = computedStyleForElement(element);
+  const edit = params.styleEdits[params.nodeId];
+  return {
+    nodeId: params.nodeId,
+    color:
+      edit?.color ??
+      cssColorToHex(computedStyle.color, cssColorToHex("black", "#000000")),
+    backgroundColor:
+      edit?.backgroundColor ??
+      cssColorToHex(computedStyle.backgroundColor, "#ffffff"),
+    borderColor:
+      edit?.borderColor ??
+      cssColorToHex(computedStyle.borderTopColor, "#000000"),
+  };
+}
+
+function applyStyleEditToElement(
+  element: HTMLElement,
+  edit: HtmlDomStyleEdit,
+): void {
+  if (edit.color) {
+    element.style.color = edit.color;
+  }
+  if (edit.backgroundColor) {
+    element.style.backgroundColor = edit.backgroundColor;
+  }
+  if (edit.borderColor) {
+    element.style.borderColor = edit.borderColor;
+  }
+}
+
+function syncFrameStyleEdits(
+  doc: Document | null | undefined,
+  styleEdits: Readonly<Record<string, HtmlDomStyleEdit>>,
+): void {
+  if (!doc) {
+    return;
+  }
+
+  for (const [nodeId, edit] of Object.entries(styleEdits)) {
+    const element = selectedElementForNodeId(doc, nodeId);
+    if (element) {
+      applyStyleEditToElement(element, edit);
+    }
+  }
+}
+
 function installFrameStyles(doc: Document): void {
   if (doc.head.querySelector(`style[${HTML_DOM_EDIT_OVERLAY_ATTR}]`)) {
     return;
@@ -391,6 +532,13 @@ function htmlWithEditOverlaysRemoved(params: {
     return params.fallbackHtml;
   }
   return stripHtmlDomEditOverlaysFromDocument(params.frameDocument);
+}
+
+function htmlWithEditInstrumentationRemoved(params: {
+  readonly fallbackHtml: string;
+  readonly frameDocument: Document | null | undefined;
+}): string {
+  return stripHtmlDomEditInstrumentation(htmlWithEditOverlaysRemoved(params));
 }
 
 function restoreFrameDocumentHtml(params: {
@@ -1232,6 +1380,7 @@ const resetHtmlDomCommentEditor$ = command(({ set }) => {
   set(internalCommentText$, "");
   set(internalComments$, []);
   set(internalCommentsOpen$, false);
+  set(internalStyleEdits$, {});
   set(internalSubmitting$, false);
   set(internalPreparedPayload$, null);
 });
@@ -1583,6 +1732,7 @@ export const bindHtmlDomCommentFrame$ = command(
         view?.removeEventListener("resize", syncMarkers);
       },
     });
+    syncFrameStyleEdits(doc, get(internalStyleEdits$));
     syncMarkers();
   },
 );
@@ -1603,6 +1753,36 @@ export const setHtmlDomCommentText$ = command(({ set }, value: string) => {
   set(internalCommentText$, value);
   set(internalPreparedPayload$, null);
 });
+
+export const setHtmlDomStyleEditProperty$ = command(
+  (
+    { get, set },
+    params: { property: HtmlDomStyleEditProperty; value: string },
+  ) => {
+    const normalized = normalizeHexColor(params.value);
+    if (!normalized) {
+      return;
+    }
+
+    const nodeId = get(internalSelectedNodeIds$)[0];
+    const doc = currentFrameDocument(get(internalIframeElement$));
+    const element = nodeId ? selectedElementForNodeId(doc, nodeId) : null;
+    if (!nodeId || !element) {
+      return;
+    }
+
+    const nextEdit = {
+      ...get(internalStyleEdits$)[nodeId],
+      [params.property]: normalized,
+    };
+    set(internalStyleEdits$, {
+      ...get(internalStyleEdits$),
+      [nodeId]: nextEdit,
+    });
+    applyStyleEditToElement(element, nextEdit);
+    set(internalPreparedPayload$, null);
+  },
+);
 
 export const beginEditingCurrentHtmlDomComment$ = command(({ get, set }) => {
   const currentComment = commentForSelectedNodes({
@@ -1637,6 +1817,10 @@ const resetHtmlDomCommentDraft$ = command(({ get, set }) => {
     currentFrameDocument(get(internalIframeElement$)),
     get(internalComments$),
   );
+});
+
+export const closeHtmlDomCommentPopover$ = command(({ set }) => {
+  set(resetHtmlDomCommentDraft$);
 });
 
 export const addHtmlDomComment$ = command(({ get, set }) => {
@@ -1691,6 +1875,7 @@ export const discardHtmlDomComments$ = command(({ get, set }) => {
   const doc = currentFrameDocument(get(internalIframeElement$));
 
   set(internalComments$, []);
+  set(internalStyleEdits$, {});
   set(internalCommentsOpen$, false);
   if (readyLoadState.status === "ready" && doc) {
     restoreFrameDocumentHtml({
@@ -1711,9 +1896,10 @@ export const sendHtmlDomEditRequest$ = command(
   ) => {
     const readyLoadState = get(internalLoadState$);
     const comments = get(internalComments$);
+    const styleEdits = get(internalStyleEdits$);
     if (
       readyLoadState.status !== "ready" ||
-      comments.length === 0 ||
+      (comments.length === 0 && Object.keys(styleEdits).length === 0) ||
       get(internalSubmitting$)
     ) {
       return;
@@ -1729,6 +1915,20 @@ export const sendHtmlDomEditRequest$ = command(
         frameDocument: currentFrameDocument(get(internalIframeElement$)),
       });
       params.onStarted?.();
+      if (comments.length === 0 && params.onGenerated) {
+        await params.onGenerated({
+          comments,
+          editRequestId: crypto.randomUUID(),
+          html: htmlWithEditInstrumentationRemoved({
+            fallbackHtml: readyLoadState.html,
+            frameDocument: currentFrameDocument(get(internalIframeElement$)),
+          }),
+        });
+        signal.throwIfAborted();
+        toast.success("Edit draft applied");
+        return;
+      }
+
       if (params.onGenerated) {
         const editRequestId = crypto.randomUUID();
         const draftHtml = await tapError(
@@ -1805,6 +2005,7 @@ export const htmlDomCommentEditorModel$ = computed(
     const editingCommentId = get(internalEditingCommentId$);
     const selectedNodeIds = get(internalSelectedNodeIds$);
     const loadState = get(internalLoadState$);
+    const styleEdits = get(internalStyleEdits$);
     const submitting = get(internalSubmitting$);
     const currentComment = commentForSelectedNodes({
       comments,
@@ -1818,7 +2019,9 @@ export const htmlDomCommentEditorModel$ = computed(
           commentText.trim() !== "" &&
           !hasCommentForSelectedNodes({ comments, selectedNodeIds }),
       canSend:
-        loadState.status === "ready" && comments.length > 0 && !submitting,
+        loadState.status === "ready" &&
+        (comments.length > 0 || Object.keys(styleEdits).length > 0) &&
+        !submitting,
       commentsOpen: get(internalCommentsOpen$),
       commentText,
       commentPopoverAnchor: get(internalCommentPopoverAnchor$),
@@ -1832,6 +2035,14 @@ export const htmlDomCommentEditorModel$ = computed(
         currentComment?.id ?? "draft",
       ].join("|"),
       prepared: get(internalPreparedPayload$) !== null,
+      selectedStyle:
+        selectedNodeIds[0] && loadState.status === "ready"
+          ? selectedStyleForNode({
+              doc: currentFrameDocument(get(internalIframeElement$)),
+              nodeId: selectedNodeIds[0],
+              styleEdits,
+            })
+          : null,
       submitting,
     };
   },

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -1446,7 +1446,10 @@ describe("zero attachment chips", () => {
         screen.queryByLabelText("Close comment popover"),
       ).not.toBeInTheDocument();
       expect(popover.querySelectorAll("textarea")).toHaveLength(1);
-      expect(popover.querySelectorAll("button")).toHaveLength(1);
+      expect(popover.querySelectorAll("button")).toHaveLength(2);
+      expect(
+        within(popover).getByLabelText("Close editor"),
+      ).toBeInTheDocument();
       expect(popover).toHaveClass("flex");
     });
     fireEvent.click(screen.getByTestId("html-dom-comment-textarea"));
@@ -1743,6 +1746,118 @@ describe("zero attachment chips", () => {
       expect(restoredEditFrame.contentDocument?.body.textContent).not.toContain(
         "Launch sooner",
       );
+    });
+  });
+
+  it("applies hosted-site color edits directly before publishing", async () => {
+    const htmlUrl = "https://style-edit-launch-site.sites.vm7.io";
+    let createDraftCalled = false;
+    let publishCalled = false;
+
+    setupHostedSiteArtifactPreview({
+      filename: "style-edit-launch-site.html",
+      htmlUrl,
+      label: "Style edit launch site",
+      runId: "run-hosted-site-style-edit",
+    });
+    context.mocks.api(zeroHostContract.createHtmlEditDraft, () => {
+      createDraftCalled = true;
+      throw new Error("Color-only edits should not create an AI draft");
+    });
+    context.mocks.api(zeroHostContract.redeployHtml, ({ body, respond }) => {
+      publishCalled = true;
+      expect(body.url).toBe(htmlUrl);
+      expect(body.html).not.toContain(HTML_DOM_NODE_ID_ATTR);
+      const doc = new DOMParser().parseFromString(body.html, "text/html");
+      const title = doc.querySelector("h1");
+      expect(title).not.toBeNull();
+      expect(title).toHaveStyle({
+        color: "#faf7f2",
+        backgroundColor: "#123456",
+        borderColor: "#abcdef",
+      });
+      return respond(200, {
+        siteId: "7c82da29-6280-4d65-b078-e233c8ad14bf",
+        deploymentId: "dc8b4d42-5dc1-4769-ad8b-17bdf1ad035a",
+        publicSlug: "style-edit-launch-site",
+        url: htmlUrl,
+        status: "ready",
+      });
+    });
+
+    click(
+      await screen.findByLabelText(
+        "Open html preview for Style edit launch site",
+      ),
+    );
+    click(await screen.findByLabelText("Edit page"));
+
+    const frame = (await screen.findByTestId(
+      "html-dom-comment-frame",
+    )) as HTMLIFrameElement;
+    await waitFor(() => {
+      expect(
+        frame.contentDocument
+          ?.querySelector("h1")
+          ?.hasAttribute(HTML_DOM_NODE_ID_ATTR),
+      ).toBeTruthy();
+    });
+    const title = frame.contentDocument?.querySelector("h1");
+    expect(title).not.toBeNull();
+    fireEvent.click(title!);
+
+    await waitFor(() => {
+      expect(screen.getByText("Style")).toBeInTheDocument();
+      expect(screen.getByText("Colors")).toBeInTheDocument();
+      expect(screen.getByText("Border")).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByTestId("html-dom-style-text-color"), {
+      target: { value: "#faf7f2" },
+    });
+    fireEvent.change(screen.getByTestId("html-dom-style-background-color"), {
+      target: { value: "#123456" },
+    });
+    fireEvent.change(screen.getByTestId("html-dom-style-border-color"), {
+      target: { value: "#abcdef" },
+    });
+
+    await waitFor(() => {
+      expect(title).toHaveStyle({
+        color: "#faf7f2",
+        backgroundColor: "#123456",
+        borderColor: "#abcdef",
+      });
+      expect(screen.getByTestId("html-dom-toolbar-send")).toBeEnabled();
+    });
+
+    click(screen.getByTestId("html-dom-toolbar-send"));
+
+    await waitFor(() => {
+      const previewFrame = screen.getByTestId("artifact-sidebar-body-html");
+      expect(previewFrame).toHaveAttribute(
+        "srcdoc",
+        expect.stringContaining("style="),
+      );
+      expect(previewFrame).not.toHaveAttribute(
+        "srcdoc",
+        expect.stringContaining(HTML_DOM_NODE_ID_ATTR),
+      );
+      expect(screen.getByTestId("html-dom-draft-toolbar")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("artifact-sidebar-html-edit-status"),
+      ).toHaveTextContent("Preview draft");
+    });
+    expect(createDraftCalled).toBeFalsy();
+
+    click(screen.getByTestId("html-dom-draft-publish"));
+
+    await waitFor(() => {
+      expect(publishCalled).toBeTruthy();
+      expect(
+        screen.queryByTestId("artifact-sidebar-html-edit-status"),
+      ).toBeNull();
+      expect(screen.queryByTestId("html-dom-draft-toolbar")).toBeNull();
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/html-dom-comment-editor.tsx
+++ b/turbo/apps/platform/src/views/zero-page/html-dom-comment-editor.tsx
@@ -1,17 +1,22 @@
-import type { KeyboardEvent } from "react";
+import type { KeyboardEvent, ReactNode } from "react";
 import {
   IconArrowUp,
+  IconChevronDown,
+  IconChevronUp,
   IconLoader2,
   IconMessageCircle,
   IconSend,
   IconTrash,
+  IconX,
 } from "@tabler/icons-react";
 import { useGet, useSet } from "ccstate-react";
+import { Input } from "@vm0/ui";
 import { detach, Reason } from "../../signals/utils.ts";
 import {
   addHtmlDomComment$,
   beginEditingCurrentHtmlDomComment$,
   bindHtmlDomCommentFrame$,
+  closeHtmlDomCommentPopover$,
   deleteHtmlDomComment$,
   discardHtmlDomComments$,
   focusHtmlDomComment$,
@@ -21,8 +26,11 @@ import {
   setHtmlDomCommentStageRef$,
   setHtmlDomCommentTextareaRef$,
   setHtmlDomCommentText$,
+  setHtmlDomStyleEditProperty$,
   toggleHtmlDomCommentsOpen$,
   type HtmlDomCommentEditorModel,
+  type HtmlDomSelectedStyle,
+  type HtmlDomStyleEditProperty,
 } from "../../signals/zero-page/html-dom-comment-editor.ts";
 import type {
   HtmlDomEditComment,
@@ -285,6 +293,7 @@ function HtmlDomCommentPopover({
 }) {
   const addComment = useSet(addHtmlDomComment$);
   const beginEditingCurrentComment = useSet(beginEditingCurrentHtmlDomComment$);
+  const closePopover = useSet(closeHtmlDomCommentPopover$);
   const setCommentText = useSet(setHtmlDomCommentText$);
   const setTextAreaRef = useSet(setHtmlDomCommentTextareaRef$);
   const isEditingCurrentComment =
@@ -292,6 +301,8 @@ function HtmlDomCommentPopover({
     model.currentComment?.id === model.editingCommentId;
   const isShowingExistingComment =
     model.currentComment !== null && !isEditingCurrentComment;
+  const showStyleControls =
+    model.selectedStyle !== null && !isShowingExistingComment;
   const visibleCommentText = isEditingCurrentComment
     ? model.commentText
     : (model.currentComment?.comment ?? model.commentText);
@@ -316,51 +327,213 @@ function HtmlDomCommentPopover({
 
   return (
     <div
-      className="absolute z-30 flex w-[min(380px,calc(100%-24px))] -translate-x-1/2 items-end gap-2 rounded-[28px] border border-border/60 bg-background px-3 py-2 shadow-lg"
+      className="absolute z-30 flex w-[min(430px,calc(100%-24px))] -translate-x-1/2 flex-col overflow-hidden rounded-[20px] border border-border/60 bg-background shadow-lg"
       style={{
         left: model.commentPopoverAnchor.left,
         top: model.commentPopoverAnchor.top,
       }}
       data-testid="html-dom-comment-popover"
     >
-      <textarea
-        key={model.popoverTextAreaKey}
-        ref={setTextAreaRef}
-        rows={1}
-        value={visibleCommentText}
-        readOnly={isShowingExistingComment}
-        onClick={() => {
-          if (isShowingExistingComment) {
-            beginEditingCurrentComment();
-          }
-        }}
-        onFocus={() => {
-          if (isShowingExistingComment) {
-            beginEditingCurrentComment();
-          }
-        }}
-        onChange={(event) => {
-          if (isShowingExistingComment) {
-            return;
-          }
-          setCommentText(event.currentTarget.value);
-        }}
-        onKeyDown={handleTextAreaKeyDown}
-        placeholder="Describe the change you want"
-        className="max-h-32 min-h-9 min-w-0 flex-1 resize-none overflow-y-auto border-0 bg-transparent px-1 py-2 text-sm leading-5 outline-none [field-sizing:content] placeholder:text-muted-foreground"
-        data-testid="html-dom-comment-textarea"
-      />
+      <div className="flex items-start gap-2 p-3">
+        <textarea
+          key={model.popoverTextAreaKey}
+          ref={setTextAreaRef}
+          rows={1}
+          value={visibleCommentText}
+          readOnly={isShowingExistingComment}
+          onClick={() => {
+            if (isShowingExistingComment) {
+              beginEditingCurrentComment();
+            }
+          }}
+          onFocus={() => {
+            if (isShowingExistingComment) {
+              beginEditingCurrentComment();
+            }
+          }}
+          onChange={(event) => {
+            if (isShowingExistingComment) {
+              return;
+            }
+            setCommentText(event.currentTarget.value);
+          }}
+          onKeyDown={handleTextAreaKeyDown}
+          placeholder="Describe the change you want"
+          className="max-h-32 min-h-20 min-w-0 flex-1 resize-none rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-input px-3 py-2 text-sm leading-5 text-foreground outline-none transition-colors [field-sizing:content] placeholder:text-muted-foreground focus:border-primary focus:ring-[3px] focus:ring-primary/10"
+          data-testid="html-dom-comment-textarea"
+        />
+        <div className="flex shrink-0 flex-col gap-1">
+          <button
+            type="button"
+            disabled={!model.canAddComment}
+            onClick={addComment}
+            className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-blue-600 text-white transition-colors hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-45"
+            data-testid="html-dom-comment-add"
+            aria-label="Add comment"
+          >
+            <IconArrowUp size={19} stroke={2.2} />
+          </button>
+          <button
+            type="button"
+            onClick={closePopover}
+            className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-gray-50 hover:text-foreground"
+            aria-label="Close editor"
+            data-testid="html-dom-comment-close"
+          >
+            <IconX size={17} stroke={1.8} />
+          </button>
+        </div>
+      </div>
+      {showStyleControls && (
+        <HtmlDomStyleInspector selectedStyle={model.selectedStyle} />
+      )}
+    </div>
+  );
+}
+
+function HtmlDomStyleInspector({
+  selectedStyle,
+}: {
+  readonly selectedStyle: HtmlDomSelectedStyle;
+}) {
+  return (
+    <div className="border-t border-border/60">
+      <div className="flex h-11 items-end gap-6 px-4" role="tablist">
+        <span
+          role="tab"
+          aria-selected="true"
+          className="h-11 border-b-2 border-foreground px-0 text-sm font-medium text-foreground"
+        >
+          Style
+        </span>
+        <span
+          role="tab"
+          aria-selected="false"
+          aria-disabled="true"
+          className="h-11 px-0 text-sm font-medium text-muted-foreground opacity-70"
+        >
+          Layout
+        </span>
+      </div>
+      <StyleSection title="Colors" open>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <ColorField
+            label="Text color"
+            property="color"
+            value={selectedStyle.color}
+            testId="html-dom-style-text-color"
+          />
+          <ColorField
+            label="Background"
+            property="backgroundColor"
+            value={selectedStyle.backgroundColor}
+            testId="html-dom-style-background-color"
+          />
+        </div>
+      </StyleSection>
+      <StyleSection title="Typography" />
+      <StyleSection title="Border" open>
+        <ColorField
+          label="Border color"
+          property="borderColor"
+          value={selectedStyle.borderColor}
+          testId="html-dom-style-border-color"
+        />
+      </StyleSection>
+      <StyleSection title="Display" />
+    </div>
+  );
+}
+
+function StyleSection({
+  children,
+  open = false,
+  title,
+}: {
+  readonly children?: ReactNode;
+  readonly open?: boolean;
+  readonly title: string;
+}) {
+  return (
+    <section className="border-t border-border/60 first:border-t-0">
       <button
         type="button"
-        disabled={!model.canAddComment}
-        onClick={addComment}
-        className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-blue-600 text-white transition-colors hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-45"
-        data-testid="html-dom-comment-add"
-        aria-label="Add comment"
+        className="flex h-11 w-full items-center justify-between px-4 text-left text-sm font-medium text-foreground transition-colors hover:bg-gray-50"
+        aria-expanded={open}
+        disabled={!open}
       >
-        <IconArrowUp size={19} stroke={2.2} />
+        {title}
+        {open ? (
+          <IconChevronUp
+            size={17}
+            stroke={1.8}
+            className="text-muted-foreground"
+          />
+        ) : (
+          <IconChevronDown
+            size={17}
+            stroke={1.8}
+            className="text-muted-foreground"
+          />
+        )}
       </button>
-    </div>
+      {open && children && <div className="px-4 pb-4">{children}</div>}
+    </section>
+  );
+}
+
+function ColorField({
+  label,
+  property,
+  testId,
+  value,
+}: {
+  readonly label: string;
+  readonly property: HtmlDomStyleEditProperty;
+  readonly testId: string;
+  readonly value: string;
+}) {
+  const setStyleEditProperty = useSet(setHtmlDomStyleEditProperty$);
+
+  const commitColor = (nextValue: string) => {
+    setStyleEditProperty({ property, value: nextValue });
+  };
+
+  return (
+    <label className="block min-w-0">
+      <span className="mb-1.5 block text-xs font-medium text-muted-foreground">
+        {label}
+      </span>
+      <div className="relative">
+        <span
+          className="pointer-events-none absolute left-2 top-1/2 h-5 w-5 -translate-y-1/2 rounded-md border border-border/70"
+          style={{ backgroundColor: value }}
+          aria-hidden="true"
+        />
+        <input
+          type="color"
+          value={value}
+          aria-label={`${label} picker`}
+          onChange={(event) => {
+            commitColor(event.currentTarget.value);
+          }}
+          className="absolute left-2 top-1/2 h-5 w-5 -translate-y-1/2 cursor-pointer opacity-0"
+        />
+        <Input
+          value={value}
+          onFocus={(event) => {
+            event.currentTarget.select();
+          }}
+          onChange={(event) => {
+            commitColor(event.currentTarget.value);
+          }}
+          className="h-9 pl-10 font-mono lowercase"
+          maxLength={7}
+          spellCheck={false}
+          data-testid={testId}
+        />
+      </div>
+    </label>
   );
 }
 


### PR DESCRIPTION
## Summary
- redesign the hosted-site HTML edit popover with a style inspector matching the requested color-editing workflow
- add direct text, background, and border color edits for selected DOM nodes with immediate iframe preview
- generate clean HTML preview drafts for color-only edits without calling the AI draft endpoint, while preserving the existing comment-based edit flow

## Tests
- pnpm exec prettier --check apps/platform/src/signals/zero-page/html-dom-comment-editor.ts apps/platform/src/views/zero-page/html-dom-comment-editor.tsx apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm exec vitest run src/views/zero-page/__tests__/zero-attachment-chips.test.tsx