### PR TITLE
Add a session-authenticated chat-thread goal read endpoint for fetching the full goal objective.

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
@@ -346,6 +346,29 @@ describe("zero goals", () => {
     });
   });
 
+  it("reads a chat thread goal with session auth", async () => {
+    const fixture = await seedGoalApiFixture({ featureEnabled: true });
+    const objective =
+      "# Ship goals\n\nKeep the release moving with **daily** checks.";
+    await createGoal(fixture, objective);
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+
+    const response = await accept(
+      goalsClient().getForChatThread({
+        headers: { authorization: "Bearer clerk-session" },
+        params: { threadId: fixture.threadId },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      objective,
+      objectiveBrief:
+        "# Ship goals\n\nKeep the release moving with **daily** checks.",
+      status: "active",
+    });
+  });
+
   it("clears the current goal and writes a cleared marker", async () => {
     const fixture = await seedGoalApiFixture({ featureEnabled: true });
     await createGoal(fixture, "ship thread goals");

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
@@ -363,8 +363,7 @@ describe("zero goals", () => {
 
     expect(response.body).toStrictEqual({
       objective,
-      objectiveBrief:
-        "# Ship goals\n\nKeep the release moving with **daily** checks.",
+      objectiveBrief: "Ship goals",
       status: "active",
     });
   });

--- a/turbo/apps/api/src/signals/routes/zero-goals.ts
+++ b/turbo/apps/api/src/signals/routes/zero-goals.ts
@@ -20,6 +20,7 @@ import {
   createGoalForCurrentThread,
   editCurrentGoal,
   getCurrentGoal,
+  getGoalForChatThread,
   pauseCurrentGoal,
   pauseGoalForChatThread,
   resumeCurrentGoal,
@@ -56,6 +57,13 @@ const sessionGoalUserControlWriteAuth = {
   requireOrganization: true,
   missingOrganizationStatus: 401,
   requiredCapability: "goal:user-control:write",
+  accept: ["session"],
+} as const;
+
+const sessionGoalReadAuth = {
+  requireOrganization: true,
+  missingOrganizationStatus: 401,
+  requiredCapability: "goal:read",
   accept: ["session"],
 } as const;
 
@@ -224,6 +232,29 @@ const getGoalInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   return goalErrorResponse(result);
 });
 
+const getChatThreadGoalInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = sessionGoalAuth(get(organizationAuthContext$));
+    const params = get(pathParamsOf(zeroGoalsContract.getForChatThread));
+    const db = set(writeDb$);
+    if (!(await goalFeatureEnabled(db, auth))) {
+      return forbidden("Goal workflows are not enabled");
+    }
+    signal.throwIfAborted();
+
+    const result = await getGoalForChatThread(db, {
+      orgId: auth.orgId,
+      userId: auth.userId,
+      threadId: params.threadId,
+    });
+    signal.throwIfAborted();
+    if (result.kind === "ok") {
+      return { status: 200 as const, body: result.goal };
+    }
+    return goalErrorResponse(result);
+  },
+);
+
 const completeGoalInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = goalAuth(get(organizationAuthContext$));
@@ -341,6 +372,10 @@ export const zeroGoalsRoutes: readonly RouteEntry[] = [
   {
     route: zeroGoalsContract.get,
     handler: authRoute(goalReadAuth, getGoalInner$),
+  },
+  {
+    route: zeroGoalsContract.getForChatThread,
+    handler: authRoute(sessionGoalReadAuth, getChatThreadGoalInner$),
   },
   {
     route: zeroGoalsContract.complete,

--- a/turbo/apps/api/src/signals/services/zero-goal.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal.service.ts
@@ -380,6 +380,22 @@ export async function getCurrentGoal(
   return { kind: "ok", goal: goalResponse(goal) };
 }
 
+export async function getGoalForChatThread(
+  db: ReadonlyDb,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly threadId: string;
+  },
+): Promise<GoalResult> {
+  const goal = await loadOwnedGoalForThread(db, args);
+  if (!goal) {
+    return { kind: "not-found" };
+  }
+
+  return { kind: "ok", goal: goalResponse(goal) };
+}
+
 export async function completeCurrentGoal(
   db: Db,
   args: GoalAuth,

--- a/turbo/apps/platform/src/signals/chat-page/chat-goal.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-goal.ts
@@ -1,8 +1,43 @@
-import { command } from "ccstate";
-import { zeroGoalsContract } from "@vm0/api-contracts/contracts/zero-goals";
+import { command, computed, state } from "ccstate";
+import {
+  zeroGoalsContract,
+  type ZeroGoalResponse,
+} from "@vm0/api-contracts/contracts/zero-goals";
 
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
+
+const activeGoalDialogThreadIdState$ = state<string | null>(null);
+
+export const activeGoalDialogThreadId$ = computed((get): string | null => {
+  return get(activeGoalDialogThreadIdState$);
+});
+
+export const activeGoalDialogGoal$ = computed(
+  async (get): Promise<ZeroGoalResponse | null> => {
+    const threadId = get(activeGoalDialogThreadIdState$);
+    if (!threadId) {
+      return null;
+    }
+    const client = get(zeroClient$)(zeroGoalsContract);
+    const response = await accept(
+      client.getForChatThread({ params: { threadId } }),
+      [200],
+      { toast: false },
+    );
+    return response.body;
+  },
+);
+
+export const openChatThreadGoalDialog$ = command(
+  ({ set }, threadId: string) => {
+    set(activeGoalDialogThreadIdState$, threadId);
+  },
+);
+
+export const closeChatThreadGoalDialog$ = command(({ set }) => {
+  set(activeGoalDialogThreadIdState$, null);
+});
 
 export const pauseChatThreadGoal$ = command(
   async ({ get }, threadId: string, signal: AbortSignal) => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -3385,6 +3385,67 @@ describe("chat lifecycle", () => {
     });
   });
 
+  it("opens an active goal objective dialog from the goal row", async () => {
+    const user = userEvent.setup({ delay: null });
+    const threadId = "thread-goal-dialog";
+    mockChatLifecycle(context, {
+      threadId,
+      chatMessages: [
+        {
+          id: "msg-goal-dialog-user",
+          role: "user",
+          content: "Start the active run",
+          runId: "run-active",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          id: "msg-goal-dialog-assistant",
+          role: "assistant",
+          content: null,
+          runId: "run-active",
+          createdAt: "2026-06-09T10:00:01Z",
+        },
+        {
+          id: "msg-goal-dialog-active",
+          runId: undefined,
+          role: "assistant",
+          content: null,
+          goalEvent: {
+            type: "state",
+            status: "active",
+            objectiveBrief: "Release brief",
+          },
+          createdAt: "2026-06-09T10:00:02Z",
+        },
+      ],
+      activeRunIds: ["run-active"],
+    });
+    let requestedThreadId: string | null = null;
+    context.mocks.api(
+      zeroGoalsContract.getForChatThread,
+      ({ params, respond }) => {
+        requestedThreadId = params.threadId;
+        return respond(200, {
+          objective: "# Full goal\n\n- Keep **shipping**\n- Review `objective`",
+          objectiveBrief: "Release brief",
+          status: "active",
+        });
+      },
+    );
+
+    detachedSetupPage({ context, path: `/chats/${threadId}` });
+
+    const goalRow = await screen.findByLabelText("Active goal");
+    await user.click(within(goalRow).getByLabelText("Open goal details"));
+
+    const dialog = await screen.findByRole("dialog", { name: "Goal" });
+    expect(requestedThreadId).toBe(threadId);
+    expect(
+      within(dialog).getByRole("heading", { name: "Full goal" }),
+    ).toBeInTheDocument();
+    expect(dialog.querySelector(".wmde-markdown")).not.toBeNull();
+  });
+
   it("hides the goal row once a completion marker folds in", async () => {
     const threadId = "thread-goal-complete";
     mockChatLifecycle(context, {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -80,6 +80,12 @@ import {
   navigateToNewChat$,
   toggleSidebarOff$,
 } from "../../signals/zero-page/zero-nav.ts";
+import {
+  activeGoalDialogGoal$,
+  activeGoalDialogThreadId$,
+  closeChatThreadGoalDialog$,
+  openChatThreadGoalDialog$,
+} from "../../signals/chat-page/chat-goal.ts";
 import type { DraftSignals } from "../../signals/chat-page/create-chat-thread.ts";
 import { isVisualAttachment } from "../../signals/chat-page/resolve-draft-attachments.ts";
 import type { Command, Computed } from "ccstate";
@@ -210,6 +216,7 @@ import {
 import { setOrgManageDialogOpen$ } from "../../signals/zero-page/settings/org-manage-dialog.ts";
 import { readChatMessageFromClipboard } from "../../signals/zero-page/clipboard.ts";
 import type { FeedbackItem } from "../../signals/zero-page/chat-feedback.ts";
+import { Markdown } from "../components/markdown.tsx";
 
 const MAX_FILE_SIZE = 1024 * 1024 * 1024; // 1 GB — keep in sync with web constants
 
@@ -277,6 +284,8 @@ interface ZeroChatComposerProps {
   >;
   /** Register the textarea element for external focus control. */
   setInputRef?: (el: HTMLElement | null) => void;
+  /** Current chat thread id. Used by thread-scoped goal controls. */
+  chatThreadId?: string;
   /** Called after attachment upload/remove mutations so the caller can trigger side-effects (e.g. draft sync). */
   onDraftChange?: () => void;
   /**
@@ -361,7 +370,7 @@ export interface QueuedComposerItem {
 }
 
 interface ActiveGoalComposerItem {
-  /** The goal's objective — the human-readable text shown in the row. */
+  /** The goal's brief objective — the human-readable text shown in the row. */
   objective: string;
 }
 
@@ -525,17 +534,19 @@ function ComposerQueueGlyph() {
 
 // A single strip row — a queued message or the active goal. Both share one
 // layout so they read as the same kind of pending item; only the leading icon
-// distinguishes them. The icon is a popover trigger that names the row's kind
-// and shows its full prompt, since the inline text is truncated.
+// distinguishes them. Queued messages keep the inline popover; goals open a
+// modal because their full objective is fetched lazily by thread.
 function ComposerStripRow({
   kind,
   text,
   onRemove,
+  onOpenDetail,
   removeAriaLabel,
 }: {
   kind: "queued" | "goal";
   text: string;
   onRemove?: () => void;
+  onOpenDetail?: () => void;
   removeAriaLabel: string;
 }) {
   const isGoal = kind === "goal";
@@ -545,41 +556,60 @@ function ComposerStripRow({
       aria-label={isGoal ? "Active goal" : "Queued message"}
       className="group flex items-center gap-2 rounded-md pl-2 pr-1 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-sidebar-accent"
     >
-      <Popover>
-        <PopoverTrigger asChild>
-          <button
-            type="button"
-            className="shrink-0 rounded-md p-1 text-emerald-800 transition-colors hover:bg-[hsl(var(--gray-200))] focus-visible:bg-[hsl(var(--gray-200))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            aria-label={
-              isGoal ? "About this goal" : "About this queued message"
-            }
-          >
-            {isGoal ? (
-              <IconTarget size={16} stroke={1.5} aria-hidden="true" />
-            ) : (
-              <ComposerQueueGlyph />
-            )}
-          </button>
-        </PopoverTrigger>
-        <PopoverContent
-          side="top"
-          align="start"
-          className="w-80 rounded-lg p-3"
+      {isGoal && onOpenDetail ? (
+        <button
+          type="button"
+          className="-ml-1 flex min-w-0 flex-1 items-center gap-2 rounded-md p-1 text-left transition-colors hover:bg-[hsl(var(--gray-200))] hover:text-sidebar-foreground focus-visible:bg-[hsl(var(--gray-200))] focus-visible:text-sidebar-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          onClick={onOpenDetail}
+          aria-label="Open goal details"
         >
-          <p className="text-xs font-semibold text-foreground">
-            {isGoal ? "Goal" : "Queued message"}
-          </p>
-          <p className="mt-1 text-xs text-muted-foreground">
-            {isGoal
-              ? "Runs after the queue drains and keeps running until you cancel it."
-              : "Waits in line and sends once the current run finishes."}
-          </p>
-          <div className="mt-2 max-h-48 overflow-y-auto whitespace-pre-wrap break-words rounded-md bg-muted/50 px-2.5 py-2 text-sm text-foreground">
-            {text}
-          </div>
-        </PopoverContent>
-      </Popover>
-      <span className="min-w-0 flex-1 truncate">{text}</span>
+          <IconTarget
+            size={16}
+            stroke={1.5}
+            className="shrink-0 text-emerald-800"
+            aria-hidden="true"
+          />
+          <span className="min-w-0 flex-1 truncate">{text}</span>
+        </button>
+      ) : (
+        <>
+          <Popover>
+            <PopoverTrigger asChild>
+              <button
+                type="button"
+                className="shrink-0 rounded-md p-1 text-emerald-800 transition-colors hover:bg-[hsl(var(--gray-200))] focus-visible:bg-[hsl(var(--gray-200))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                aria-label={
+                  isGoal ? "About this goal" : "About this queued message"
+                }
+              >
+                {isGoal ? (
+                  <IconTarget size={16} stroke={1.5} aria-hidden="true" />
+                ) : (
+                  <ComposerQueueGlyph />
+                )}
+              </button>
+            </PopoverTrigger>
+            <PopoverContent
+              side="top"
+              align="start"
+              className="w-80 rounded-lg p-3"
+            >
+              <p className="text-xs font-semibold text-foreground">
+                {isGoal ? "Goal" : "Queued message"}
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {isGoal
+                  ? "Runs after the queue drains and keeps running until you cancel it."
+                  : "Waits in line and sends once the current run finishes."}
+              </p>
+              <div className="mt-2 max-h-48 overflow-y-auto whitespace-pre-wrap break-words rounded-md bg-muted/50 px-2.5 py-2 text-sm text-foreground">
+                {text}
+              </div>
+            </PopoverContent>
+          </Popover>
+          <span className="min-w-0 flex-1 truncate">{text}</span>
+        </>
+      )}
       <button
         type="button"
         className="shrink-0 rounded-lg p-1.5 text-muted-foreground/45 transition-colors hover:bg-[hsl(var(--gray-200))] hover:text-sidebar-foreground focus-visible:bg-[hsl(var(--gray-200))] focus-visible:text-sidebar-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
@@ -594,16 +624,82 @@ function ComposerStripRow({
   );
 }
 
+function ActiveGoalObjectiveDialog({ threadId }: { threadId?: string }) {
+  const dialogThreadId = useGet(activeGoalDialogThreadId$);
+  const goalLoadable = useLoadable(activeGoalDialogGoal$);
+  const closeDialog = useSet(closeChatThreadGoalDialog$);
+  const open = threadId !== undefined && dialogThreadId === threadId;
+  const goal = goalLoadable.state === "hasData" ? goalLoadable.data : undefined;
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) {
+          closeDialog();
+        }
+      }}
+    >
+      <DialogContent
+        className="w-[calc(100vw-2rem)] max-w-2xl gap-5 p-5 sm:p-6"
+        aria-describedby={undefined}
+      >
+        <DialogHeader>
+          <DialogTitle className="text-base">Goal</DialogTitle>
+          <DialogDescription className="leading-6">
+            Runs after the queue drains and keeps running until you cancel it.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="max-h-[min(60vh,520px)] overflow-y-auto rounded-lg bg-muted/40 px-3 py-3 text-sm text-foreground sm:px-4">
+          {goalLoadable.state === "loading" ? (
+            <div className="flex min-h-28 items-center justify-center gap-2 text-muted-foreground">
+              <IconLoader2
+                size={16}
+                stroke={1.7}
+                className="animate-spin"
+                aria-hidden="true"
+              />
+              <span>Loading goal...</span>
+            </div>
+          ) : goalLoadable.state === "hasError" ? (
+            <div className="flex min-h-28 flex-col justify-center gap-1 text-muted-foreground">
+              <p className="font-medium text-foreground">
+                Couldn&apos;t load this goal
+              </p>
+              <p className="text-xs">
+                Close the dialog and open it again to retry.
+              </p>
+            </div>
+          ) : goal ? (
+            <Markdown
+              source={goal.objective}
+              escapeHtml
+              mathEnabled
+              style={{ fontSize: "inherit", lineHeight: "inherit" }}
+            />
+          ) : (
+            <div className="flex min-h-28 items-center text-muted-foreground">
+              This goal is no longer available.
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 function QueuedMessagesStrip({
   items,
   onRemove,
   activeGoal,
   onCancelGoal,
+  onOpenGoal,
 }: {
   items: QueuedComposerItem[] | undefined;
   onRemove?: (id: string) => void;
   activeGoal?: ActiveGoalComposerItem;
   onCancelGoal?: () => void;
+  onOpenGoal?: () => void;
 }) {
   const queued = items ?? [];
   if (queued.length === 0 && !activeGoal) {
@@ -646,6 +742,7 @@ function QueuedMessagesStrip({
           <ComposerStripRow
             kind="goal"
             text={activeGoal.objective}
+            onOpenDetail={onOpenGoal}
             onRemove={() => {
               onCancelGoal?.();
             }}
@@ -6020,6 +6117,7 @@ export function ZeroChatComposer({
   composerFileInput$: composerFileInputProp$,
   setComposerFileInput$: setComposerFileInputProp$,
   setInputRef,
+  chatThreadId,
   onDraftChange,
   actionsLoading = false,
   modelPicker,
@@ -6037,6 +6135,7 @@ export function ZeroChatComposer({
   const setShowAddDialog = useSet(setShowAddDialog$);
   const modelPickerOpen = useGet(modelPickerOpen$);
   const setModelPickerOpen = useSet(setModelPickerOpen$);
+  const openGoalDialog = useSet(openChatThreadGoalDialog$);
 
   const resolved = useResolvedComposerSignals(
     input,
@@ -6404,6 +6503,13 @@ export function ZeroChatComposer({
           onRemove={onRemoveQueuedItem}
           activeGoal={activeGoal}
           onCancelGoal={onCancelActiveGoal}
+          onOpenGoal={
+            chatThreadId
+              ? () => {
+                  openGoalDialog(chatThreadId);
+                }
+              : undefined
+          }
         />
         <Card
           className={cn(
@@ -6516,6 +6622,7 @@ export function ZeroChatComposer({
             </div>
           </CardContent>
         </Card>
+        <ActiveGoalObjectiveDialog threadId={chatThreadId} />
       </div>
       {selectedConnType && (
         <ConnectModal

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -4854,6 +4854,7 @@ function ChatThreadComposer({
             composerFileInput$={thread.composerFileInput$}
             setComposerFileInput$={thread.setComposerFileInput$}
             setInputRef={setInputRef}
+            chatThreadId={thread.threadId}
             actionsLoading={skeletonVisible}
             modelPicker={modelPicker}
             templatePicker={templatePicker}

--- a/turbo/packages/api-contracts/src/contracts/zero-goals.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-goals.ts
@@ -90,6 +90,20 @@ export const zeroGoalsContract = c.router({
     },
     summary: "Get the current thread goal",
   },
+  getForChatThread: {
+    method: "GET",
+    path: "/api/zero/chat-threads/:threadId/goal",
+    headers: authHeadersSchema,
+    pathParams: chatThreadGoalParamsSchema,
+    responses: {
+      200: zeroGoalResponseSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+      409: apiErrorSchema,
+    },
+    summary: "Get a chat thread goal",
+  },
   complete: {
     method: "POST",
     path: "/api/zero/goal/complete",


### PR DESCRIPTION
## Summary
- Add a session-authenticated chat-thread goal read endpoint for fetching the full goal objective.
- Wire goal detail modal state through ccstate and fetch the objective lazily when the goal brief is clicked.
- Render the full objective with the existing Markdown component and keep the composer strip showing only the brief.

## Tests
- `pnpm exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx -t "opens an active goal objective dialog|folds goal-state markers"`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm prettier --check packages/api-contracts/src/contracts/zero-goals.ts apps/api/src/signals/services/zero-goal.service.ts apps/api/src/signals/routes/zero-goals.ts apps/api/src/signals/routes/__tests__/zero-goals.test.ts apps/platform/src/signals/chat-page/chat-goal.ts apps/platform/src/views/zero-page/zero-chat-composer.tsx apps/platform/src/views/zero-page/zero-chat-thread-page.tsx apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx`
- `pnpm -F @vm0/app exec oxlint src/signals/chat-page/chat-goal.ts src/views/zero-page/zero-chat-composer.tsx src/views/zero-page/zero-chat-thread-page.tsx src/views/zero-page/__tests__/chat-lifecycle.test.tsx`
- `pnpm -F api exec oxlint src/signals/services/zero-goal.service.ts src/signals/routes/zero-goals.ts src/signals/routes/__tests__/zero-goals.test.ts`
- `pnpm -F @vm0/api-contracts exec oxlint src/contracts/zero-goals.ts`

## Notes
- API route test could not complete locally because Postgres was unavailable at `127.0.0.1:5432`.
- `pnpm -F api check-types` was attempted twice but the local process hit memory/resource limits before producing type errors.
