### PR TITLE
feat: add presentation image resolver endpoint

### DIFF
--- a/turbo/apps/api/src/lib/env.ts
+++ b/turbo/apps/api/src/lib/env.ts
@@ -28,6 +28,7 @@ const SCHEMA = {
   FAL_KEY: z.string().min(1).optional(),
   BYTEPLUS_API_KEY: z.string().min(1).optional(),
   ZERO_MAPS_GOOGLE_MAPS_TOKEN: z.string().min(1).optional(),
+  UNSPLASH_ACCESS_KEY: z.string().min(1).optional(),
   FINICITY_APP_KEY: z.string().min(1).optional(),
   FINICITY_APP_SECRET: z.string().min(1).optional(),
   FINICITY_PARTNER_ID: z.string().min(1).optional(),

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -42,6 +42,7 @@ import { githubOauthRoutes } from "./routes/github-oauth";
 import { legacyFileRoutes } from "./routes/legacy-file";
 import { logsSearchRoutes } from "./routes/logs-search";
 import { modelStatsRoutes } from "./routes/model-stats";
+import { presentationImagesRoutes } from "./routes/presentation-images";
 import { registryResourceDownloadRoutes } from "./routes/registry-resources-download";
 import { runnersRoutes } from "./routes/runners";
 import { usageRoutes } from "./routes/usage";
@@ -357,6 +358,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...chatThreadsV1Routes,
   ...audioTranscriptionsV1Routes,
   ...modelStatsRoutes,
+  ...presentationImagesRoutes,
   ...runnersRoutes,
   ...testOAuthProviderAuthorizeRoutes,
   ...testOAuthProviderDeviceAuthRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/presentation-images.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/presentation-images.test.ts
@@ -266,6 +266,40 @@ describe("POST /api/presentation/images/resolve", () => {
     ]);
   });
 
+  it("returns unresolved items when the Unsplash request fails", async () => {
+    const fixture = createFixture();
+    routeMocks.clerk.session(fixture.userId, fixture.orgId);
+    mockEnv("UNSPLASH_ACCESS_KEY", "test-unsplash-key");
+    server.use(
+      http.get(UNSPLASH_SEARCH_URL, () => {
+        return HttpResponse.error();
+      }),
+    );
+
+    const client = setupApp({ context })(presentationImagesContract);
+    const response = await accept(
+      client.resolve({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          items: [{ path: "$.pages[0].visual", query: "network failure" }],
+        },
+      }),
+      [200],
+    );
+
+    expect(response.body.items).toStrictEqual([
+      {
+        path: "$.pages[0].visual",
+        query: "network failure",
+        status: "unresolved",
+        error: {
+          code: "PROVIDER_ERROR",
+          message: 'Unsplash search failed for "network failure"',
+        },
+      },
+    ]);
+  });
+
   it("returns 503 when Unsplash is not configured", async () => {
     const fixture = createFixture();
     routeMocks.clerk.session(fixture.userId, fixture.orgId);

--- a/turbo/apps/api/src/signals/routes/__tests__/presentation-images.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/presentation-images.test.ts
@@ -1,0 +1,314 @@
+import { presentationImagesContract } from "@vm0/api-contracts/contracts/presentation-images";
+import type { ZeroCapability } from "@vm0/api-contracts/contracts/composes";
+import { HttpResponse, http } from "msw";
+import { describe, expect, it } from "vitest";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { mockEnv } from "../../../lib/env";
+import { server } from "../../../mocks/server";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+import { now } from "../../external/time";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
+
+const context = testContext();
+const routeMocks = createZeroRouteMocks(context);
+const UNSPLASH_SEARCH_URL = "https://api.unsplash.com/search/photos";
+
+interface PresentationImagesFixture {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly runId: string;
+}
+
+function createFixture(): PresentationImagesFixture {
+  return {
+    orgId: "org_presentation_images",
+    userId: "user_presentation_images",
+    runId: "run_presentation_images",
+  };
+}
+
+function currentSecond(): number {
+  return Math.floor(now() / 1000);
+}
+
+function zeroToken(
+  fixture: PresentationImagesFixture,
+  capabilities: readonly ZeroCapability[] = ["file:write"],
+): string {
+  const seconds = currentSecond();
+  return signSandboxJwtForTests({
+    scope: "zero",
+    userId: fixture.userId,
+    orgId: fixture.orgId,
+    runId: fixture.runId,
+    capabilities,
+    iat: seconds,
+    exp: seconds + 60,
+  });
+}
+
+describe("POST /api/presentation/images/resolve", () => {
+  it("resolves image briefs through Unsplash with per-request query dedupe", async () => {
+    const fixture = createFixture();
+    routeMocks.clerk.session(fixture.userId, fixture.orgId);
+    mockEnv("UNSPLASH_ACCESS_KEY", "test-unsplash-key");
+    const searchQueries: string[] = [];
+    const downloadPhotoIds: string[] = [];
+
+    server.use(
+      http.get(UNSPLASH_SEARCH_URL, ({ request }) => {
+        expect(request.headers.get("authorization")).toBe(
+          "Client-ID test-unsplash-key",
+        );
+        const url = new URL(request.url);
+        const query = url.searchParams.get("query");
+        const orientation = url.searchParams.get("orientation");
+        if (!query) {
+          return HttpResponse.json({ results: [] });
+        }
+
+        searchQueries.push(`${query}:${orientation ?? ""}`);
+        if (query === "modern office") {
+          return HttpResponse.json({
+            results: [
+              {
+                urls: {
+                  regular: "https://images.unsplash.com/photo-office",
+                },
+                links: {
+                  html: "https://unsplash.com/photos/office-photo",
+                  download_location:
+                    "https://api.unsplash.com/photos/office-photo/download",
+                },
+                user: {
+                  name: "Office Photographer",
+                  links: { html: "https://unsplash.com/@office" },
+                },
+                alt_description: "A modern office",
+                width: 1200,
+                height: 800,
+                color: "#aabbcc",
+                blur_hash: "hash-office",
+              },
+            ],
+          });
+        }
+
+        if (query === "forest path") {
+          expect(orientation).toBe("landscape");
+          return HttpResponse.json({
+            results: [
+              {
+                urls: {
+                  regular: "https://images.unsplash.com/photo-forest",
+                },
+                links: {
+                  html: "https://unsplash.com/photos/forest-photo",
+                  download_location:
+                    "https://api.unsplash.com/photos/forest-photo/download",
+                },
+                user: {
+                  name: "Forest Photographer",
+                  links: { html: "https://unsplash.com/@forest" },
+                },
+                description: "A forest path",
+                width: 1600,
+                height: 900,
+              },
+            ],
+          });
+        }
+
+        return HttpResponse.json({ results: [] });
+      }),
+      http.get(
+        "https://api.unsplash.com/photos/:photoId/download",
+        ({ params, request }) => {
+          expect(request.headers.get("authorization")).toBe(
+            "Client-ID test-unsplash-key",
+          );
+          downloadPhotoIds.push(String(params.photoId));
+          return HttpResponse.json({
+            url: "https://images.unsplash.com/tracked",
+          });
+        },
+      ),
+    );
+
+    const client = setupApp({ context })(presentationImagesContract);
+    const response = await accept(
+      client.resolve({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          items: [
+            { path: "$.pages[0].visual", query: "modern office" },
+            { path: "$.pages[1].visual", query: "modern office" },
+            {
+              path: "$.pages[2].visual",
+              query: "forest path",
+              intent: "section divider landscape",
+              orientation: "landscape",
+            },
+          ],
+        },
+      }),
+      [200],
+    );
+
+    expect(searchQueries).toStrictEqual([
+      "modern office:",
+      "forest path:landscape",
+    ]);
+    expect(downloadPhotoIds).toStrictEqual(["office-photo", "forest-photo"]);
+    expect(response.body.items).toStrictEqual([
+      {
+        path: "$.pages[0].visual",
+        query: "modern office",
+        status: "resolved",
+        asset: {
+          src: "https://images.unsplash.com/photo-office",
+          alt: "A modern office",
+          source: "unsplash",
+          sourceName: "Unsplash",
+          sourceUrl:
+            "https://unsplash.com/photos/office-photo?utm_source=vm0_presentation_image_resolver&utm_medium=referral",
+          unsplashUrl:
+            "https://unsplash.com/?utm_source=vm0_presentation_image_resolver&utm_medium=referral",
+          photographerName: "Office Photographer",
+          photographerUrl:
+            "https://unsplash.com/@office?utm_source=vm0_presentation_image_resolver&utm_medium=referral",
+          license: "Unsplash",
+          width: 1200,
+          height: 800,
+          color: "#aabbcc",
+          blurHash: "hash-office",
+        },
+      },
+      {
+        path: "$.pages[1].visual",
+        query: "modern office",
+        status: "resolved",
+        asset: {
+          src: "https://images.unsplash.com/photo-office",
+          alt: "A modern office",
+          source: "unsplash",
+          sourceName: "Unsplash",
+          sourceUrl:
+            "https://unsplash.com/photos/office-photo?utm_source=vm0_presentation_image_resolver&utm_medium=referral",
+          unsplashUrl:
+            "https://unsplash.com/?utm_source=vm0_presentation_image_resolver&utm_medium=referral",
+          photographerName: "Office Photographer",
+          photographerUrl:
+            "https://unsplash.com/@office?utm_source=vm0_presentation_image_resolver&utm_medium=referral",
+          license: "Unsplash",
+          width: 1200,
+          height: 800,
+          color: "#aabbcc",
+          blurHash: "hash-office",
+        },
+      },
+      {
+        path: "$.pages[2].visual",
+        query: "forest path",
+        status: "resolved",
+        asset: {
+          src: "https://images.unsplash.com/photo-forest",
+          alt: "A forest path",
+          source: "unsplash",
+          sourceName: "Unsplash",
+          sourceUrl:
+            "https://unsplash.com/photos/forest-photo?utm_source=vm0_presentation_image_resolver&utm_medium=referral",
+          unsplashUrl:
+            "https://unsplash.com/?utm_source=vm0_presentation_image_resolver&utm_medium=referral",
+          photographerName: "Forest Photographer",
+          photographerUrl:
+            "https://unsplash.com/@forest?utm_source=vm0_presentation_image_resolver&utm_medium=referral",
+          license: "Unsplash",
+          width: 1600,
+          height: 900,
+        },
+      },
+    ]);
+  });
+
+  it("returns unresolved items when Unsplash has no matching result", async () => {
+    const fixture = createFixture();
+    routeMocks.clerk.session(fixture.userId, fixture.orgId);
+    mockEnv("UNSPLASH_ACCESS_KEY", "test-unsplash-key");
+    server.use(
+      http.get(UNSPLASH_SEARCH_URL, () => {
+        return HttpResponse.json({ results: [] });
+      }),
+    );
+
+    const client = setupApp({ context })(presentationImagesContract);
+    const response = await accept(
+      client.resolve({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          items: [{ path: "$.pages[0].visual", query: "missing subject" }],
+        },
+      }),
+      [200],
+    );
+
+    expect(response.body.items).toStrictEqual([
+      {
+        path: "$.pages[0].visual",
+        query: "missing subject",
+        status: "unresolved",
+        error: {
+          code: "NO_RESULTS",
+          message: 'No Unsplash image matched "missing subject"',
+        },
+      },
+    ]);
+  });
+
+  it("returns 503 when Unsplash is not configured", async () => {
+    const fixture = createFixture();
+    routeMocks.clerk.session(fixture.userId, fixture.orgId);
+    const client = setupApp({ context })(presentationImagesContract);
+    const response = await accept(
+      client.resolve({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          items: [{ path: "$.pages[0].visual", query: "modern office" }],
+        },
+      }),
+      [503],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Unsplash image resolution is not configured",
+        code: "NOT_CONFIGURED",
+      },
+    });
+  });
+
+  it("requires file write capability for zero tokens", async () => {
+    const fixture = createFixture();
+    mockEnv("UNSPLASH_ACCESS_KEY", "test-unsplash-key");
+    const client = setupApp({ context })(presentationImagesContract);
+    const response = await accept(
+      client.resolve({
+        headers: {
+          authorization: `Bearer ${zeroToken(fixture, ["file:read"])}`,
+        },
+        body: {
+          items: [{ path: "$.pages[0].visual", query: "modern office" }],
+        },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Missing required capability: file:write",
+        code: "FORBIDDEN",
+      },
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/presentation-images.ts
+++ b/turbo/apps/api/src/signals/routes/presentation-images.ts
@@ -1,0 +1,335 @@
+import { z } from "zod";
+import {
+  presentationImagesContract,
+  type PresentationImageAsset,
+  type PresentationImageResolveItem,
+} from "@vm0/api-contracts/contracts/presentation-images";
+import { command } from "ccstate";
+
+import { env } from "../../lib/env";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf } from "../context/request";
+import type { RouteEntry } from "../route-entry";
+
+const UNSPLASH_SEARCH_URL = "https://api.unsplash.com/search/photos";
+const UNSPLASH_HOME_URL = "https://unsplash.com/";
+const UNSPLASH_UTM_SOURCE = "vm0_presentation_image_resolver";
+const MAX_UNSPLASH_CONCURRENCY = 6;
+const UNSPLASH_RESULTS_PER_QUERY = 10;
+
+type ResolveErrorCode =
+  | "NO_RESULTS"
+  | "DOWNLOAD_TRACKING_FAILED"
+  | "PROVIDER_ERROR";
+
+interface ResolveError {
+  readonly code: ResolveErrorCode;
+  readonly message: string;
+}
+
+type UniqueResolution =
+  | { readonly status: "resolved"; readonly asset: PresentationImageAsset }
+  | { readonly status: "unresolved"; readonly error: ResolveError };
+
+const unsplashPhotoSchema = z
+  .object({
+    urls: z
+      .object({
+        regular: z.url().optional(),
+        small: z.url().optional(),
+        raw: z.url().optional(),
+      })
+      .passthrough()
+      .optional(),
+    links: z
+      .object({
+        html: z.url().optional(),
+        download_location: z.url().optional(),
+      })
+      .passthrough()
+      .optional(),
+    user: z
+      .object({
+        name: z.string().optional(),
+        links: z
+          .object({
+            html: z.url().optional(),
+          })
+          .passthrough()
+          .optional(),
+      })
+      .passthrough()
+      .optional(),
+    alt_description: z.string().nullable().optional(),
+    description: z.string().nullable().optional(),
+    width: z.number().int().positive().optional(),
+    height: z.number().int().positive().optional(),
+    color: z.string().nullable().optional(),
+    blur_hash: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+const unsplashSearchResponseSchema = z
+  .object({
+    results: z.array(unsplashPhotoSchema),
+  })
+  .passthrough();
+
+type UnsplashPhoto = z.infer<typeof unsplashPhotoSchema>;
+
+const resolveBody$ = bodyResultOf(presentationImagesContract.resolve);
+
+function errorBody(message: string, code: string) {
+  return { error: { message, code } };
+}
+
+function serviceUnavailable(message: string) {
+  return {
+    status: 503 as const,
+    body: errorBody(message, "NOT_CONFIGURED"),
+  };
+}
+
+function providerError(message: string): UniqueResolution {
+  return {
+    status: "unresolved",
+    error: { code: "PROVIDER_ERROR", message },
+  };
+}
+
+function noResults(query: string): UniqueResolution {
+  return {
+    status: "unresolved",
+    error: {
+      code: "NO_RESULTS",
+      message: `No Unsplash image matched "${query}"`,
+    },
+  };
+}
+
+function downloadTrackingFailed(query: string): UniqueResolution {
+  return {
+    status: "unresolved",
+    error: {
+      code: "DOWNLOAD_TRACKING_FAILED",
+      message: `Unsplash download tracking failed for "${query}"`,
+    },
+  };
+}
+
+function withUnsplashUtm(value: string, fallback: string): string {
+  const url = new URL(value || fallback);
+  url.searchParams.set("utm_source", UNSPLASH_UTM_SOURCE);
+  url.searchParams.set("utm_medium", "referral");
+  return url.toString();
+}
+
+function searchKey(item: PresentationImageResolveItem): string {
+  return `${item.query.trim().toLowerCase()}\n${item.orientation ?? ""}`;
+}
+
+function selectedImageUrl(photo: UnsplashPhoto): string | undefined {
+  return photo.urls?.regular ?? photo.urls?.small ?? photo.urls?.raw;
+}
+
+function buildAsset(
+  item: PresentationImageResolveItem,
+  photo: UnsplashPhoto,
+): PresentationImageAsset | null {
+  const src = selectedImageUrl(photo);
+  const photographerName = photo.user?.name?.trim();
+  const photographerUrl = photo.user?.links?.html;
+  const sourceUrl = photo.links?.html;
+  if (!src || !photographerName || !photographerUrl || !sourceUrl) {
+    return null;
+  }
+
+  return {
+    src,
+    alt:
+      photo.alt_description?.trim() ||
+      photo.description?.trim() ||
+      item.intent ||
+      item.query,
+    source: "unsplash",
+    sourceName: "Unsplash",
+    sourceUrl: withUnsplashUtm(sourceUrl, UNSPLASH_HOME_URL),
+    unsplashUrl: withUnsplashUtm(UNSPLASH_HOME_URL, UNSPLASH_HOME_URL),
+    photographerName,
+    photographerUrl: withUnsplashUtm(photographerUrl, UNSPLASH_HOME_URL),
+    license: "Unsplash",
+    ...(photo.width ? { width: photo.width } : {}),
+    ...(photo.height ? { height: photo.height } : {}),
+    ...(photo.color ? { color: photo.color } : {}),
+    ...(photo.blur_hash ? { blurHash: photo.blur_hash } : {}),
+  };
+}
+
+async function trackUnsplashDownload(
+  photo: UnsplashPhoto,
+  accessKey: string,
+  signal: AbortSignal,
+): Promise<boolean> {
+  const downloadLocation = photo.links?.download_location;
+  if (!downloadLocation) {
+    return false;
+  }
+
+  const response = await fetch(downloadLocation, {
+    headers: {
+      Authorization: `Client-ID ${accessKey}`,
+      "Accept-Version": "v1",
+      "User-Agent": "vm0-presentation-image-resolver/1.0",
+    },
+    signal,
+  });
+
+  return response.ok;
+}
+
+async function searchUnsplash(
+  item: PresentationImageResolveItem,
+  accessKey: string,
+  signal: AbortSignal,
+): Promise<UniqueResolution> {
+  const url = new URL(UNSPLASH_SEARCH_URL);
+  url.searchParams.set("query", item.query);
+  url.searchParams.set("per_page", String(UNSPLASH_RESULTS_PER_QUERY));
+  url.searchParams.set("order_by", "relevant");
+  url.searchParams.set("content_filter", "high");
+  if (item.orientation) {
+    url.searchParams.set("orientation", item.orientation);
+  }
+
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Client-ID ${accessKey}`,
+      "Accept-Version": "v1",
+      "User-Agent": "vm0-presentation-image-resolver/1.0",
+    },
+    signal,
+  });
+
+  if (!response.ok) {
+    return providerError(
+      `Unsplash search failed with ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const parsed = unsplashSearchResponseSchema.safeParse(await response.json());
+  if (!parsed.success) {
+    return providerError("Unsplash search returned an unexpected response");
+  }
+
+  if (parsed.data.results.length === 0) {
+    return noResults(item.query);
+  }
+
+  for (const photo of parsed.data.results) {
+    const asset = buildAsset(item, photo);
+    if (!asset) {
+      continue;
+    }
+
+    const tracked = await trackUnsplashDownload(photo, accessKey, signal);
+    if (tracked) {
+      return { status: "resolved", asset };
+    }
+  }
+
+  return downloadTrackingFailed(item.query);
+}
+
+async function mapWithConcurrency<T, U>(
+  items: readonly T[],
+  limit: number,
+  mapper: (item: T) => Promise<U>,
+): Promise<U[]> {
+  const results: U[] = [];
+  let nextIndex = 0;
+  const workerCount = Math.min(limit, items.length);
+
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      while (nextIndex < items.length) {
+        const index = nextIndex;
+        nextIndex += 1;
+        results[index] = await mapper(items[index]!);
+      }
+    }),
+  );
+
+  return results;
+}
+
+const resolvePresentationImagesInner$ = command(
+  async ({ get }, signal: AbortSignal) => {
+    const accessKey = env("UNSPLASH_ACCESS_KEY");
+    if (!accessKey) {
+      return serviceUnavailable("Unsplash image resolution is not configured");
+    }
+
+    const bodyResult = await get(resolveBody$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+
+    const uniqueItems = new Map<string, PresentationImageResolveItem>();
+    for (const item of bodyResult.data.items) {
+      const key = searchKey(item);
+      if (!uniqueItems.has(key)) {
+        uniqueItems.set(key, item);
+      }
+    }
+
+    const resolvedEntries = await mapWithConcurrency(
+      [...uniqueItems.entries()],
+      MAX_UNSPLASH_CONCURRENCY,
+      async ([key, item]) => {
+        return [key, await searchUnsplash(item, accessKey, signal)] as const;
+      },
+    );
+    signal.throwIfAborted();
+
+    const resolvedByKey = new Map<string, UniqueResolution>(resolvedEntries);
+
+    return {
+      status: 200 as const,
+      body: {
+        items: bodyResult.data.items.map((item) => {
+          const result = resolvedByKey.get(searchKey(item));
+          if (!result) {
+            throw new Error(`Missing Unsplash resolution for ${item.path}`);
+          }
+
+          if (result.status === "resolved") {
+            return {
+              path: item.path,
+              query: item.query,
+              status: "resolved" as const,
+              asset: result.asset,
+            };
+          }
+
+          return {
+            path: item.path,
+            query: item.query,
+            status: "unresolved" as const,
+            error: result.error,
+          };
+        }),
+      },
+    };
+  },
+);
+
+export const presentationImagesRoutes: readonly RouteEntry[] = [
+  {
+    route: presentationImagesContract.resolve,
+    handler: authRoute(
+      { requireOrganization: true, requiredCapability: "file:write" },
+      resolvePresentationImagesInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/routes/presentation-images.ts
+++ b/turbo/apps/api/src/signals/routes/presentation-images.ts
@@ -10,6 +10,7 @@ import { env } from "../../lib/env";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf } from "../context/request";
 import type { RouteEntry } from "../route-entry";
+import { safeJsonParse, settle } from "../utils";
 
 const UNSPLASH_SEARCH_URL = "https://api.unsplash.com/search/photos";
 const UNSPLASH_HOME_URL = "https://unsplash.com/";
@@ -175,16 +176,22 @@ async function trackUnsplashDownload(
     return false;
   }
 
-  const response = await fetch(downloadLocation, {
-    headers: {
-      Authorization: `Client-ID ${accessKey}`,
-      "Accept-Version": "v1",
-      "User-Agent": "vm0-presentation-image-resolver/1.0",
-    },
+  const responseResult = await settle(
+    fetch(downloadLocation, {
+      headers: {
+        Authorization: `Client-ID ${accessKey}`,
+        "Accept-Version": "v1",
+        "User-Agent": "vm0-presentation-image-resolver/1.0",
+      },
+      signal,
+    }),
     signal,
-  });
+  );
+  if (!responseResult.ok) {
+    return false;
+  }
 
-  return response.ok;
+  return responseResult.value.ok;
 }
 
 async function searchUnsplash(
@@ -201,22 +208,36 @@ async function searchUnsplash(
     url.searchParams.set("orientation", item.orientation);
   }
 
-  const response = await fetch(url, {
-    headers: {
-      Authorization: `Client-ID ${accessKey}`,
-      "Accept-Version": "v1",
-      "User-Agent": "vm0-presentation-image-resolver/1.0",
-    },
+  const responseResult = await settle(
+    fetch(url, {
+      headers: {
+        Authorization: `Client-ID ${accessKey}`,
+        "Accept-Version": "v1",
+        "User-Agent": "vm0-presentation-image-resolver/1.0",
+      },
+      signal,
+    }),
     signal,
-  });
+  );
+  if (!responseResult.ok) {
+    return providerError(`Unsplash search failed for "${item.query}"`);
+  }
 
+  const response = responseResult.value;
   if (!response.ok) {
     return providerError(
       `Unsplash search failed with ${response.status} ${response.statusText}`,
     );
   }
 
-  const parsed = unsplashSearchResponseSchema.safeParse(await response.json());
+  const bodyResult = await settle(response.text(), signal);
+  if (!bodyResult.ok) {
+    return providerError("Unsplash search returned an unreadable response");
+  }
+
+  const parsed = unsplashSearchResponseSchema.safeParse(
+    safeJsonParse(bodyResult.value),
+  );
   if (!parsed.success) {
     return providerError("Unsplash search returned an unexpected response");
   }

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -169,6 +169,20 @@ export {
   type RegistryResourceDownloadContract,
 } from "./registry-resources";
 export {
+  presentationImageAssetSchema,
+  presentationImageOrientationSchema,
+  presentationImageResolveErrorSchema,
+  presentationImageResolveItemSchema,
+  presentationImageResolveRequestSchema,
+  presentationImageResolveResponseSchema,
+  presentationImagesContract,
+  type PresentationImageAsset,
+  type PresentationImageResolveItem,
+  type PresentationImageResolveRequest,
+  type PresentationImageResolveResponse,
+  type PresentationImagesContract,
+} from "./presentation-images";
+export {
   testTelegramDispatchProbeContract,
   type TestTelegramDispatchProbeContract,
 } from "./test-telegram-dispatch-probe";

--- a/turbo/packages/api-contracts/src/contracts/presentation-images.ts
+++ b/turbo/packages/api-contracts/src/contracts/presentation-images.ts
@@ -1,0 +1,113 @@
+import { z } from "zod";
+
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+export const presentationImageOrientationSchema = z.enum([
+  "landscape",
+  "portrait",
+  "squarish",
+]);
+
+export const presentationImageResolveItemSchema = z
+  .object({
+    path: z.string().min(1).max(300),
+    query: z.string().trim().min(1).max(160),
+    intent: z.string().trim().min(1).max(200).optional(),
+    orientation: presentationImageOrientationSchema.optional(),
+  })
+  .strict();
+
+export const presentationImageResolveRequestSchema = z
+  .object({
+    items: z.array(presentationImageResolveItemSchema).min(1).max(40),
+  })
+  .strict();
+
+export const presentationImageAssetSchema = z
+  .object({
+    src: z.url(),
+    alt: z.string().min(1),
+    source: z.literal("unsplash"),
+    sourceName: z.literal("Unsplash"),
+    sourceUrl: z.url(),
+    unsplashUrl: z.url(),
+    photographerName: z.string().min(1),
+    photographerUrl: z.url(),
+    license: z.literal("Unsplash"),
+    width: z.number().int().positive().optional(),
+    height: z.number().int().positive().optional(),
+    color: z.string().min(1).optional(),
+    blurHash: z.string().min(1).optional(),
+  })
+  .strict();
+
+export const presentationImageResolveErrorSchema = z
+  .object({
+    code: z.enum(["NO_RESULTS", "DOWNLOAD_TRACKING_FAILED", "PROVIDER_ERROR"]),
+    message: z.string().min(1),
+  })
+  .strict();
+
+export const presentationImageResolvedItemSchema = z
+  .object({
+    path: z.string(),
+    query: z.string(),
+    status: z.literal("resolved"),
+    asset: presentationImageAssetSchema,
+  })
+  .strict();
+
+export const presentationImageUnresolvedItemSchema = z
+  .object({
+    path: z.string(),
+    query: z.string(),
+    status: z.literal("unresolved"),
+    error: presentationImageResolveErrorSchema,
+  })
+  .strict();
+
+export const presentationImageResolveResponseSchema = z
+  .object({
+    items: z.array(
+      z.discriminatedUnion("status", [
+        presentationImageResolvedItemSchema,
+        presentationImageUnresolvedItemSchema,
+      ]),
+    ),
+  })
+  .strict();
+
+export type PresentationImageResolveRequest = z.infer<
+  typeof presentationImageResolveRequestSchema
+>;
+export type PresentationImageResolveItem = z.infer<
+  typeof presentationImageResolveItemSchema
+>;
+export type PresentationImageAsset = z.infer<
+  typeof presentationImageAssetSchema
+>;
+export type PresentationImageResolveResponse = z.infer<
+  typeof presentationImageResolveResponseSchema
+>;
+
+export const presentationImagesContract = c.router({
+  resolve: {
+    method: "POST",
+    path: "/api/presentation/images/resolve",
+    headers: authHeadersSchema,
+    body: presentationImageResolveRequestSchema,
+    responses: {
+      200: presentationImageResolveResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      503: apiErrorSchema,
+    },
+    summary: "Resolve presentation image briefs through a server-side provider",
+  },
+});
+
+export type PresentationImagesContract = typeof presentationImagesContract;


### PR DESCRIPTION
## Summary
- add `POST /api/presentation/images/resolve` for batch presentation image brief resolution
- call Unsplash server-side with `UNSPLASH_ACCESS_KEY`, per-request query dedupe, bounded concurrency, UTM attribution metadata, and download tracking
- return per-item resolved/unresolved results so generation can continue when individual queries miss

## Tests
- `npx -y prettier@3.8.1 --check apps/api/src/lib/env.ts apps/api/src/signals/route.ts apps/api/src/signals/routes/presentation-images.ts apps/api/src/signals/routes/__tests__/presentation-images.test.ts packages/api-contracts/src/contracts/index.ts packages/api-contracts/src/contracts/presentation-images.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/presentation-images.test.ts`
- `pnpm -F @vm0/api-contracts check-types`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F api lint`

## Notes
- This PR only adds the backend interface. The presentation template resolver / runbook package will call this endpoint in a follow-up.
- `UNSPLASH_ACCESS_KEY` is optional at boot; the endpoint returns 503 when it is not configured.
