### PR TITLE
fix: separate permission status from action buttons

### DIFF
--- a/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
@@ -500,7 +500,7 @@ describe("permission allow page", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText("Couldn’t update permissions"),
+        screen.getByText("Couldn't update permissions"),
       ).toBeInTheDocument();
     });
     expect(

--- a/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
@@ -406,4 +406,110 @@ describe("permission allow page", () => {
       expect(screen.queryByText("Confirm")).not.toBeInTheDocument();
     });
   });
+
+  it("shows a load error without a confirm action", async () => {
+    const agentId = "c0000000-0000-4000-a000-000000000007";
+
+    context.mocks.api(zeroAgentsByIdContract.get, ({ respond }) => {
+      return respond(200, {
+        agentId,
+        ownerId: "test-user-123",
+        description: null,
+        displayName: "Load Error Bot",
+        sound: null,
+        avatarUrl: null,
+        modelProviderId: null,
+        selectedModel: null,
+        preferPersonalProvider: false,
+      });
+    });
+    context.mocks.api(zeroUserPermissionGrantsContract.list, ({ respond }) => {
+      return respond(403, {
+        error: {
+          code: "FORBIDDEN",
+          message: "Forbidden",
+        },
+      });
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${agentId}/permissions?ref=slack&permission=admin.analytics%3Aread&action=allow&expiresIn=24h`,
+      user: {
+        id: "test-user-123",
+        fullName: "Avery Reviewer",
+        firstName: "Avery",
+      },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Failed to load permission grants"),
+      ).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Confirm")).not.toBeInTheDocument();
+  });
+
+  it("keeps the permission form visible after a save failure", async () => {
+    const agentId = "c0000000-0000-4000-a000-000000000008";
+
+    context.mocks.api(zeroAgentsByIdContract.get, ({ respond }) => {
+      return respond(200, {
+        agentId,
+        ownerId: "test-user-123",
+        description: null,
+        displayName: "Save Error Bot",
+        sound: null,
+        avatarUrl: null,
+        modelProviderId: null,
+        selectedModel: null,
+        preferPersonalProvider: false,
+      });
+    });
+    context.mocks.api(zeroUserPermissionGrantsContract.list, ({ respond }) => {
+      return respond(200, []);
+    });
+    context.mocks.api(zeroUserPermissionGrantsContract.apply, ({ respond }) => {
+      return respond(403, {
+        error: {
+          code: "FORBIDDEN",
+          message: "Forbidden",
+        },
+      });
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${agentId}/permissions?ref=slack&permission=admin.analytics%3Aread&action=allow&expiresIn=24h`,
+      user: {
+        id: "test-user-123",
+        fullName: "Quinn Reviewer",
+        firstName: "Quinn",
+      },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "Hey Quinn, you're updating your permissions for Save Error Bot.",
+        ),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("Confirm"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Couldn’t update permissions"),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(
+        "Hey Quinn, you're updating your permissions for Save Error Bot.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("admin.analytics:read")).toBeInTheDocument();
+    expect(screen.getByText("Confirm")).toBeEnabled();
+    expect(screen.queryByText("Permissions updated")).not.toBeInTheDocument();
+  });
 });

--- a/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
@@ -351,6 +351,7 @@ function ConfirmGrantCard({
     DEFAULT_USER_PERMISSION_GRANT_EXPIRES_IN;
   const expirationAvailable = action === "allow";
   const saving = grantLoadable.state === "loading";
+  const saveError = grantLoadable.state === "hasError";
 
   const handleSave = () => {
     detach(
@@ -408,7 +409,13 @@ function ConfirmGrantCard({
           )}
         </div>
 
-        <div className="w-[500px] max-w-[calc(100vw-96px)] px-[26px]">
+        <div className="flex w-[500px] max-w-[calc(100vw-96px)] flex-col gap-3 px-[26px]">
+          {saveError && (
+            <div className="flex items-center justify-center gap-2 text-sm font-medium text-destructive">
+              <IconAlertTriangle size={16} />
+              <span>Couldn’t update permissions</span>
+            </div>
+          )}
           <Button
             type="button"
             onClick={handleSave}

--- a/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
@@ -413,7 +413,7 @@ function ConfirmGrantCard({
           {saveError && (
             <div className="flex items-center justify-center gap-2 text-sm font-medium text-destructive">
               <IconAlertTriangle size={16} />
-              <span>Couldn’t update permissions</span>
+              <span>Couldn&apos;t update permissions</span>
             </div>
           )}
           <Button

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -60,10 +60,19 @@ function encodeBase64UrlJson(value: unknown): string {
     .replace(/=+$/u, "");
 }
 
+function queryButtonByText(
+  text: string,
+  container: ParentNode,
+): HTMLElement | null {
+  return (
+    queryAllByRoleFast("button", container).find((candidate) => {
+      return candidate.textContent?.replace(/\s+/g, " ").trim() === text;
+    }) ?? null
+  );
+}
+
 function buttonByText(text: string, container: ParentNode): HTMLElement {
-  const button = queryAllByRoleFast("button", container).find((candidate) => {
-    return candidate.textContent?.replace(/\s+/g, " ").trim() === text;
-  });
+  const button = queryButtonByText(text, container);
   if (!button) {
     throw new Error(`${text} button not found`);
   }
@@ -499,6 +508,62 @@ describe("chat message action cards", () => {
     });
   });
 
+  it("shows permission status loading outside the action button", async () => {
+    const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?ref=gmail&permission=messages.write&action=allow&expiresIn=1h`;
+    let resolveList: () => void = () => {
+      throw new Error("Permission grant list request did not start");
+    };
+    context.mocks.api(
+      zeroUserPermissionGrantsContract.list,
+      async ({ deferred, respond }) => {
+        const listDeferred = deferred<void>();
+        resolveList = () => {
+          listDeferred.resolve();
+        };
+        await listDeferred.promise;
+        return respond(200, []);
+      },
+    );
+
+    mockChatLifecycle(context, {
+      threadId: `${THREAD_ID}-permission-status-loading`,
+      threadTitle: "Permission status loading",
+      chatMessages: [
+        {
+          id: "msg-user-permission-status-loading",
+          role: "user",
+          content: "Allow Gmail message writes",
+          runId: "run-permission-status-loading",
+          createdAt: "2026-06-09T11:00:00Z",
+        },
+        {
+          id: "msg-assistant-permission-status-loading-card",
+          role: "assistant",
+          content: permissionAuthorizeUrl,
+          runId: "run-permission-status-loading",
+          createdAt: "2026-06-09T11:01:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}-permission-status-loading`,
+    });
+
+    const permissionCard = await screen.findByTestId("permission-action-card");
+    expect(
+      within(permissionCard).getByText("Checking permission status..."),
+    ).toBeInTheDocument();
+    expect(
+      queryButtonByText("Checking permission status...", permissionCard),
+    ).toBeNull();
+    expect(queryButtonByText("Confirm", permissionCard)).toBeNull();
+
+    resolveList();
+    await waitForButtonByText("Confirm", permissionCard);
+  });
+
   it("does not retry non-transient permission action loading failures", async () => {
     const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?ref=gmail&permission=messages.write&action=allow&expiresIn=1h`;
     let listRequests = 0;
@@ -541,10 +606,78 @@ describe("chat message action cards", () => {
     const permissionCard = await screen.findByTestId("permission-action-card");
     await waitFor(() => {
       expect(
-        buttonByText("Failed to load permissions", permissionCard),
-      ).toBeDisabled();
+        within(permissionCard).getByText("Couldn’t load permission status"),
+      ).toBeInTheDocument();
     });
+    expect(
+      queryButtonByText("Failed to load permissions", permissionCard),
+    ).toBeNull();
+    expect(
+      queryButtonByText("Couldn’t load permission status", permissionCard),
+    ).toBeNull();
+    expect(queryButtonByText("Confirm", permissionCard)).toBeNull();
     expect(listRequests).toBe(1);
+  });
+
+  it("shows permission save failures outside the action button", async () => {
+    const user = userEvent.setup({ delay: null });
+    const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?ref=gmail&permission=messages.write&action=allow&expiresIn=1h`;
+    context.mocks.api(zeroUserPermissionGrantsContract.list, ({ respond }) => {
+      return respond(200, []);
+    });
+    context.mocks.api(zeroUserPermissionGrantsContract.apply, ({ respond }) => {
+      return respond(403, {
+        error: {
+          code: "FORBIDDEN",
+          message: "Forbidden",
+        },
+      });
+    });
+
+    mockChatLifecycle(context, {
+      threadId: `${THREAD_ID}-permission-save-error`,
+      threadTitle: "Permission save error",
+      chatMessages: [
+        {
+          id: "msg-user-permission-save-error",
+          role: "user",
+          content: "Allow Gmail message writes",
+          runId: "run-permission-save-error",
+          createdAt: "2026-06-09T11:00:00Z",
+        },
+        {
+          id: "msg-assistant-permission-save-error-card",
+          role: "assistant",
+          content: permissionAuthorizeUrl,
+          runId: "run-permission-save-error",
+          createdAt: "2026-06-09T11:01:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}-permission-save-error`,
+    });
+
+    const permissionCard = await screen.findByTestId("permission-action-card");
+    await confirmPermissionAction(user, permissionCard);
+
+    await waitFor(() => {
+      expect(
+        within(permissionCard).getByText("Couldn’t update permissions"),
+      ).toBeInTheDocument();
+    });
+    expect(
+      queryButtonByText("Couldn’t update permissions", permissionCard),
+    ).toBeNull();
+    await waitForButtonByText("Confirm", permissionCard);
+    expect(
+      within(permissionCard).queryByText("Permissions updated"),
+    ).not.toBeInTheDocument();
+    expect(
+      within(permissionCard).queryByText("Already allowed"),
+    ).not.toBeInTheDocument();
   });
 
   it("lets users change permission duration before confirming", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -606,14 +606,14 @@ describe("chat message action cards", () => {
     const permissionCard = await screen.findByTestId("permission-action-card");
     await waitFor(() => {
       expect(
-        within(permissionCard).getByText("Couldn’t load permission status"),
+        within(permissionCard).getByText("Couldn't load permission status"),
       ).toBeInTheDocument();
     });
     expect(
       queryButtonByText("Failed to load permissions", permissionCard),
     ).toBeNull();
     expect(
-      queryButtonByText("Couldn’t load permission status", permissionCard),
+      queryButtonByText("Couldn't load permission status", permissionCard),
     ).toBeNull();
     expect(queryButtonByText("Confirm", permissionCard)).toBeNull();
     expect(listRequests).toBe(1);
@@ -665,11 +665,11 @@ describe("chat message action cards", () => {
 
     await waitFor(() => {
       expect(
-        within(permissionCard).getByText("Couldn’t update permissions"),
+        within(permissionCard).getByText("Couldn't update permissions"),
       ).toBeInTheDocument();
     });
     expect(
-      queryButtonByText("Couldn’t update permissions", permissionCard),
+      queryButtonByText("Couldn't update permissions", permissionCard),
     ).toBeNull();
     await waitForButtonByText("Confirm", permissionCard);
     expect(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -680,6 +680,100 @@ describe("chat message action cards", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("keeps permission success visible while permission grants reload", async () => {
+    const user = userEvent.setup({ delay: null });
+    const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?ref=gmail&permission=messages.write&action=allow&expiresIn=1h`;
+    let listRequests = 0;
+    let storedGrants: UserPermissionGrantResponse[] = [];
+    let resolveReload: () => void = () => {
+      throw new Error("Permission grant reload request did not start");
+    };
+    context.mocks.api(
+      zeroUserPermissionGrantsContract.list,
+      async ({ deferred, respond }) => {
+        listRequests += 1;
+        if (listRequests === 1) {
+          return respond(200, []);
+        }
+        if (listRequests === 2) {
+          const reloadDeferred = deferred<void>();
+          resolveReload = () => {
+            reloadDeferred.resolve();
+          };
+          await reloadDeferred.promise;
+        }
+        return respond(200, storedGrants);
+      },
+    );
+    context.mocks.api(
+      zeroUserPermissionGrantsContract.apply,
+      ({ body, respond }) => {
+        const grant = body.grants[0];
+        if (!grant) {
+          throw new Error("Expected a permission grant");
+        }
+        storedGrants = [
+          {
+            agentId: body.agentId,
+            connectorRef: body.connectorRef,
+            permission: grant.permission,
+            action: grant.action,
+            expiresAt: "2026-06-09T12:00:00.000Z",
+            createdAt: "2026-06-09T11:00:00Z",
+            updatedAt: "2026-06-09T11:01:00Z",
+          },
+        ];
+        return respond(200, storedGrants);
+      },
+    );
+
+    mockChatLifecycle(context, {
+      threadId: `${THREAD_ID}-permission-save-reload`,
+      threadTitle: "Permission save reload",
+      chatMessages: [
+        {
+          id: "msg-user-permission-save-reload",
+          role: "user",
+          content: "Allow Gmail message writes",
+          runId: "run-permission-save-reload",
+          createdAt: "2026-06-09T11:00:00Z",
+        },
+        {
+          id: "msg-assistant-permission-save-reload-card",
+          role: "assistant",
+          content: permissionAuthorizeUrl,
+          runId: "run-permission-save-reload",
+          createdAt: "2026-06-09T11:01:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}-permission-save-reload`,
+    });
+
+    const permissionCard = await screen.findByTestId("permission-action-card");
+    await confirmPermissionAction(user, permissionCard);
+
+    await waitFor(() => {
+      expect(listRequests).toBe(2);
+    });
+    expect(
+      within(permissionCard).getByText("Permissions updated"),
+    ).toBeInTheDocument();
+    expect(
+      within(permissionCard).queryByText("Checking permission status..."),
+    ).not.toBeInTheDocument();
+
+    resolveReload();
+    await waitFor(() => {
+      expect(
+        within(permissionCard).getByText("Permissions updated"),
+      ).toBeInTheDocument();
+    });
+  });
+
   it("lets users change permission duration before confirming", async () => {
     const user = userEvent.setup({ delay: null });
     const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?ref=slack&permission=admin.analytics%3Aread&action=allow&expiresIn=24h`;

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -5689,6 +5689,15 @@ function createPermissionActionCardStatus(params: {
   saveError: boolean;
   alreadyApplied: boolean;
 }): PermissionActionCardStatus {
+  if (params.saving) {
+    return { kind: "saving" };
+  }
+  if (params.saveDone) {
+    return { kind: "saved" };
+  }
+  if (params.saveError) {
+    return { kind: "save-error" };
+  }
   if (params.loading) {
     return { kind: "loading" };
   }
@@ -5700,15 +5709,6 @@ function createPermissionActionCardStatus(params: {
   }
   if (!params.hasPermission) {
     return { kind: "missing-permission" };
-  }
-  if (params.saving) {
-    return { kind: "saving" };
-  }
-  if (params.saveDone) {
-    return { kind: "saved" };
-  }
-  if (params.saveError) {
-    return { kind: "save-error" };
   }
   if (params.alreadyApplied) {
     return { kind: "already-applied" };

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -5695,9 +5695,6 @@ function createPermissionActionCardStatus(params: {
   if (params.saveDone) {
     return { kind: "saved" };
   }
-  if (params.saveError) {
-    return { kind: "save-error" };
-  }
   if (params.loading) {
     return { kind: "loading" };
   }
@@ -5712,6 +5709,9 @@ function createPermissionActionCardStatus(params: {
   }
   if (params.alreadyApplied) {
     return { kind: "already-applied" };
+  }
+  if (params.saveError) {
+    return { kind: "save-error" };
   }
   return { kind: "ready" };
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -5443,19 +5443,20 @@ function ComputerUseAuthorizationCard({
   );
 }
 
-interface PermissionActionButtonState {
-  hasAgent: boolean;
-  hasPermission: boolean;
-  loading: boolean;
-  loadError: boolean;
-  saving: boolean;
-  saveDone: boolean;
-  alreadyApplied: boolean;
-}
-
 type PermissionAction = "allow" | "deny";
 
 type PermissionActionUserGrant = UserPermissionGrantResponse;
+
+type PermissionActionCardStatus =
+  | { kind: "loading" }
+  | { kind: "load-error" }
+  | { kind: "save-error" }
+  | { kind: "ready" }
+  | { kind: "saving" }
+  | { kind: "saved" }
+  | { kind: "already-applied" }
+  | { kind: "missing-target" }
+  | { kind: "missing-permission" };
 
 interface LoadableLike<T> {
   state: string;
@@ -5482,46 +5483,16 @@ function permissionActionVerb(action: PermissionAction): string {
   return action === "allow" ? "Allow" : "Deny";
 }
 
-function permissionActionButtonLabel(
-  state: PermissionActionButtonState,
-): string {
-  if (state.loading) {
-    return "Checking permissions";
-  }
-  if (state.loadError) {
-    return "Failed to load permissions";
-  }
-  if (!state.hasPermission) {
-    return "Unknown permission";
-  }
-  if (state.saving) {
-    return "Saving...";
-  }
-  return "Confirm";
-}
-
-function permissionActionButtonDisabled(
-  state: PermissionActionButtonState,
-): boolean {
-  return (
-    state.loading ||
-    state.loadError ||
-    state.saving ||
-    !state.hasAgent ||
-    !state.hasPermission
-  );
-}
-
 function permissionActionStatusText(
-  state: PermissionActionButtonState,
+  status: PermissionActionCardStatus,
   action: "allow" | "deny",
 ): { label: string; className: string } | null {
-  if (state.saveDone) {
+  if (status.kind === "saved") {
     return action === "allow"
       ? { label: "Permissions updated", className: "text-green-600" }
       : { label: "Permission denied", className: "text-destructive" };
   }
-  if (state.alreadyApplied) {
+  if (status.kind === "already-applied") {
     return action === "allow"
       ? { label: "Already allowed", className: "text-green-600" }
       : { label: "Already denied", className: "text-destructive" };
@@ -5530,36 +5501,105 @@ function permissionActionStatusText(
 }
 
 function PermissionActionButton({
-  state,
-  action,
+  status,
   onClick,
 }: {
-  state: PermissionActionButtonState;
-  action: "allow" | "deny";
+  status: PermissionActionCardStatus;
   onClick: () => void;
 }) {
-  const status = permissionActionStatusText(state, action);
-  if (status) {
-    return (
-      <span
-        className={`shrink-0 text-[0.9375rem] font-medium ${status.className}`}
-      >
-        {status.label}
-      </span>
-    );
+  if (
+    status.kind !== "ready" &&
+    status.kind !== "saving" &&
+    status.kind !== "save-error"
+  ) {
+    return null;
   }
 
+  const saving = status.kind === "saving";
   return (
     <button
       type="button"
-      disabled={permissionActionButtonDisabled(state)}
+      disabled={saving}
       onClick={onClick}
       className="inline-flex h-9 w-full shrink-0 items-center justify-center gap-2 rounded-lg border border-border bg-background px-3 text-[0.9375rem] font-medium text-foreground transition-colors hover:bg-accent sm:w-auto"
     >
-      {state.saving && <IconLoader2 size={15} className="animate-spin" />}
-      {permissionActionButtonLabel(state)}
+      {saving && <IconLoader2 size={15} className="animate-spin" />}
+      {saving ? "Saving..." : "Confirm"}
     </button>
   );
+}
+
+function PermissionActionTerminalStatus({
+  status,
+  action,
+}: {
+  status: PermissionActionCardStatus;
+  action: "allow" | "deny";
+}) {
+  const text = permissionActionStatusText(status, action);
+  if (!text) {
+    return null;
+  }
+  return (
+    <span className={`shrink-0 text-[0.9375rem] font-medium ${text.className}`}>
+      {text.label}
+    </span>
+  );
+}
+
+function PermissionActionInlineStatus({
+  status,
+}: {
+  status: PermissionActionCardStatus;
+}) {
+  switch (status.kind) {
+    case "loading": {
+      return (
+        <div className="mt-1 flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+          <IconLoader2 size={13} className="animate-spin" />
+          <span>Checking permission status...</span>
+        </div>
+      );
+    }
+    case "load-error": {
+      return (
+        <div className="mt-1 flex items-center gap-1.5 text-xs font-medium text-destructive">
+          <IconAlertCircle size={13} />
+          <span>Couldn’t load permission status</span>
+        </div>
+      );
+    }
+    case "save-error": {
+      return (
+        <div className="mt-1 flex items-center gap-1.5 text-xs font-medium text-destructive">
+          <IconAlertCircle size={13} />
+          <span>Couldn’t update permissions</span>
+        </div>
+      );
+    }
+    case "missing-target": {
+      return (
+        <div className="mt-1 flex items-center gap-1.5 text-xs font-medium text-destructive">
+          <IconAlertCircle size={13} />
+          <span>Agent not found</span>
+        </div>
+      );
+    }
+    case "missing-permission": {
+      return (
+        <div className="mt-1 flex items-center gap-1.5 text-xs font-medium text-destructive">
+          <IconAlertCircle size={13} />
+          <span>Unknown permission</span>
+        </div>
+      );
+    }
+    case "ready":
+    case "saving":
+    case "saved":
+    case "already-applied": {
+      return null;
+    }
+  }
 }
 
 function isPermissionActionLoading(params: {
@@ -5639,44 +5679,41 @@ function permissionActionUserGrant(
   });
 }
 
-function createPermissionActionButtonState(params: {
+function createPermissionActionCardStatus(params: {
   hasAgent: boolean;
   hasPermission: boolean;
   loading: boolean;
   loadError: boolean;
   saving: boolean;
-  alreadyApplied: boolean;
   saveDone: boolean;
-}): PermissionActionButtonState {
-  return {
-    hasAgent: params.hasAgent,
-    hasPermission: params.hasPermission,
-    loading: params.loading,
-    loadError: params.loadError,
-    saving: params.saving,
-    saveDone: params.saveDone,
-    alreadyApplied: params.alreadyApplied,
-  };
-}
-
-function createPermissionActionCardButtonState(params: {
-  hasAgent: boolean;
-  focusedPermission: { name: string } | undefined;
-  loading: boolean;
-  loadError: boolean;
-  saving: boolean;
-  saveDone: boolean;
+  saveError: boolean;
   alreadyApplied: boolean;
-}): PermissionActionButtonState {
-  return createPermissionActionButtonState({
-    hasAgent: params.hasAgent,
-    hasPermission: Boolean(params.focusedPermission),
-    loading: params.loading,
-    loadError: params.loadError,
-    saving: params.saving,
-    saveDone: params.saveDone,
-    alreadyApplied: params.alreadyApplied,
-  });
+}): PermissionActionCardStatus {
+  if (params.loading) {
+    return { kind: "loading" };
+  }
+  if (params.loadError) {
+    return { kind: "load-error" };
+  }
+  if (!params.hasAgent) {
+    return { kind: "missing-target" };
+  }
+  if (!params.hasPermission) {
+    return { kind: "missing-permission" };
+  }
+  if (params.saving) {
+    return { kind: "saving" };
+  }
+  if (params.saveDone) {
+    return { kind: "saved" };
+  }
+  if (params.saveError) {
+    return { kind: "save-error" };
+  }
+  if (params.alreadyApplied) {
+    return { kind: "already-applied" };
+  }
+  return { kind: "ready" };
 }
 
 function createPermissionActionCardViewState(params: {
@@ -5711,6 +5748,7 @@ function createPermissionActionCardViewState(params: {
   const saving = isPermissionActionSaving({
     grantLoading: params.grantLoadableState === "loading",
   });
+  const saveError = params.grantLoadableState === "hasError";
   const userGrantPolicy = permissionActionUserGrantPolicy(
     params.userGrantsLoadable,
     params.block,
@@ -5722,39 +5760,28 @@ function createPermissionActionCardViewState(params: {
     action: params.block.action,
   });
   const saveDone = params.grantLoadableState === "hasData";
-  const buttonState = createPermissionActionCardButtonState({
+  const status = createPermissionActionCardStatus({
     hasAgent: params.hasAgent,
-    focusedPermission,
+    hasPermission: Boolean(focusedPermission),
     loading,
     loadError,
     saving,
     saveDone,
+    saveError,
     alreadyApplied,
   });
   return {
     actionLabel,
-    buttonState,
+    status,
     focusedPermission,
-    finished: saveDone,
   };
 }
 
 function runPermissionAction(params: {
-  hasAgent: boolean;
-  focusedPermission: { name: string } | undefined;
-  state: PermissionActionButtonState;
-  finished: boolean;
+  status: PermissionActionCardStatus;
   runUserGrant: () => void;
 }): void {
-  if (
-    !params.hasAgent ||
-    !params.focusedPermission ||
-    params.state.loading ||
-    params.state.loadError ||
-    params.state.saving ||
-    params.state.alreadyApplied ||
-    params.finished
-  ) {
+  if (params.status.kind !== "ready" && params.status.kind !== "save-error") {
     return;
   }
 
@@ -5764,10 +5791,8 @@ function runPermissionAction(params: {
 function createPermissionActionHandler(params: {
   block: PermissionActionBlock;
   pageSignal: AbortSignal;
-  hasAgent: boolean;
   focusedPermission: { name: string } | undefined;
-  state: PermissionActionButtonState;
-  finished: boolean;
+  status: PermissionActionCardStatus;
   expirationAvailable: boolean;
   expiresIn: UserPermissionGrantExpiresIn;
   applyGrant: ApplyUserPermissionGrantFn;
@@ -5776,10 +5801,7 @@ function createPermissionActionHandler(params: {
     const permissionName =
       params.focusedPermission?.name ?? params.block.permission;
     runPermissionAction({
-      hasAgent: params.hasAgent,
-      focusedPermission: params.focusedPermission,
-      state: params.state,
-      finished: params.finished,
+      status: params.status,
       runUserGrant: () => {
         detach(
           params.applyGrant(
@@ -5806,7 +5828,7 @@ function PermissionActionCardContent({
   connectorLabel,
   actionLabel,
   permissionName,
-  buttonState,
+  status,
   expirationAvailable,
   expiresIn,
   onExpiresInChange,
@@ -5817,7 +5839,7 @@ function PermissionActionCardContent({
   connectorLabel: string;
   actionLabel: string;
   permissionName: string;
-  buttonState: PermissionActionButtonState;
+  status: PermissionActionCardStatus;
   expirationAvailable: boolean;
   expiresIn: UserPermissionGrantExpiresIn;
   onExpiresInChange: (value: UserPermissionGrantExpiresIn) => void;
@@ -5828,7 +5850,10 @@ function PermissionActionCardContent({
     ? permissionGrantExpiryText(expiresAt)
     : null;
   const showDurationSelect =
-    expirationAvailable && !buttonState.alreadyApplied && !buttonState.saveDone;
+    expirationAvailable &&
+    (status.kind === "ready" ||
+      status.kind === "saving" ||
+      status.kind === "save-error");
   return (
     <div
       data-testid="permission-action-card"
@@ -5845,6 +5870,7 @@ function PermissionActionCardContent({
           <div className="mt-0.5 line-clamp-2 text-sm leading-5 text-muted-foreground">
             {actionLabel} {permissionName}
           </div>
+          <PermissionActionInlineStatus status={status} />
           {expiryText && (
             <div className="mt-0.5 text-xs font-medium text-amber-700 dark:text-amber-400">
               {expiryText}
@@ -5857,15 +5883,12 @@ function PermissionActionCardContent({
           <PermissionGrantDurationSelect
             value={expiresIn}
             onValueChange={onExpiresInChange}
-            disabled={buttonState.loading || buttonState.saving}
+            disabled={status.kind === "saving"}
             ariaLabel="Permission duration"
           />
         )}
-        <PermissionActionButton
-          state={buttonState}
-          action={block.action}
-          onClick={onClick}
-        />
+        <PermissionActionTerminalStatus status={status} action={block.action} />
+        <PermissionActionButton status={status} onClick={onClick} />
       </div>
     </div>
   );
@@ -5918,7 +5941,7 @@ function PermissionActionCardForTarget({
       connectorLabel={config.label}
       actionLabel={actionState.actionLabel}
       permissionName={actionState.focusedPermission?.name ?? block.permission}
-      buttonState={actionState.buttonState}
+      status={actionState.status}
       expirationAvailable={expirationAvailable}
       expiresIn={expiresIn}
       onExpiresInChange={(value) => {
@@ -5928,10 +5951,8 @@ function PermissionActionCardForTarget({
       onClick={createPermissionActionHandler({
         block,
         pageSignal,
-        hasAgent: hasTarget,
         focusedPermission: actionState.focusedPermission,
-        state: actionState.buttonState,
-        finished: actionState.finished,
+        status: actionState.status,
         expirationAvailable,
         expiresIn,
         applyGrant,

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -5565,7 +5565,7 @@ function PermissionActionInlineStatus({
       return (
         <div className="mt-1 flex items-center gap-1.5 text-xs font-medium text-destructive">
           <IconAlertCircle size={13} />
-          <span>Couldn’t load permission status</span>
+          <span>Couldn&apos;t load permission status</span>
         </div>
       );
     }
@@ -5573,7 +5573,7 @@ function PermissionActionInlineStatus({
       return (
         <div className="mt-1 flex items-center gap-1.5 text-xs font-medium text-destructive">
           <IconAlertCircle size={13} />
-          <span>Couldn’t update permissions</span>
+          <span>Couldn&apos;t update permissions</span>
         </div>
       );
     }


### PR DESCRIPTION
## Summary
- render permission action loading and load failures as inline card status instead of button labels
- keep save failures visible inline while preserving the Confirm retry action
- add regression coverage for chat permission cards and the standalone permission page

Closes #19360

## Tests
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-message-action-cards.test.tsx src/views/permission-allow/__tests__/permission-allow-page.test.tsx`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- pre-commit hook: prettier, knip, `pnpm check-types`