### PR TITLE
refactor: reduce fallback slop in image generation contract

### DIFF
--- a/turbo/packages/api-contracts/src/contracts/zero-image-io-generate.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-image-io-generate.ts
@@ -29,11 +29,11 @@ export const zeroImageIoGenerateRequestSchema = z
     imageUrls: stringOrStringArraySchema.optional(),
     image_urls: stringOrStringArraySchema.optional(),
     maskImageUrl: z.string().optional(),
-    mask_image_url: z.unknown().optional(),
-    inputFidelity: z.unknown().optional(),
-    input_fidelity: z.unknown().optional(),
-    imagePromptStrength: z.unknown().optional(),
-    image_prompt_strength: z.unknown().optional(),
+    mask_image_url: z.string().optional(),
+    inputFidelity: z.string().optional(),
+    input_fidelity: z.string().optional(),
+    imagePromptStrength: numberOrStringSchema.optional(),
+    image_prompt_strength: numberOrStringSchema.optional(),
   })
   .passthrough();
 


### PR DESCRIPTION
## Summary

Daily AI-slop fallback cleanup for the image generation API contract.

## Scan

- Scan timestamp: `2026-06-29T20:01:58.479Z`
- Base commit: `3e2c7f64f81518f36df41d81521201dc8bff51ff`
- Files scanned: `3665`
- Scanner `actionableTotal`: `3635`
- `actionable_total` used for the 5% budget: `212` high-confidence production-actionable candidates
- `edit_budget`: `11`
- Candidates changed: `5`

Total matches by category from `/tmp/ai-slop-fallback-scan.json`:

- `nullish`: `4633`
- `nullish-chain`: `105`
- `field-fallback-chain`: `84`
- `optional-prop`: `4892`
- `zod-optional`: `1646`
- `zod-loose-optional`: `12`
- `loose-record`: `935`
- `loose-index-signature`: `6`
- `as-any`: `0`
- `as-unknown-as`: `41`
- `empty-fallback`: `524`
- `string-fallback`: `620`
- `null-undefined-fallback`: `1289`
- `empty-catch`: `3`
- `promise-catch-swallow`: `16`
- `rust-unwrap-or`: `555`
- `rust-ok-discard`: `132`

## Files Changed

- `turbo/packages/api-contracts/src/contracts/zero-image-io-generate.ts`
  - Replaced five loose `z.unknown().optional()` request fields with primitive schemas.
  - This is safe because the consuming image generation service already parses `mask_image_url` as a string, `inputFidelity` / `input_fidelity` as strings, and `imagePromptStrength` / `image_prompt_strength` as number-or-string before applying the existing semantic validation.
  - The PR intentionally preserves accepted numeric strings for prompt strength to avoid changing request compatibility.

## Verification

- `git diff --check` passed.
- `pnpm -F @vm0/api-contracts check-types` was attempted, but this fresh clone has no `node_modules`, so `tsc` was unavailable. The PR pipeline will run the full checks.

This workflow intentionally leaves the remaining candidates for later daily runs.
