### PR TITLE
feat: show connector access agent avatars

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/connector-access-management.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connector-access-management.ts
@@ -15,6 +15,11 @@ export interface ConnectorAgentAccessRow {
   readonly grants: readonly UserPermissionGrantResponse[];
 }
 
+interface ConnectorAgentAuthorizationRow {
+  readonly agent: TeamComposeItem;
+  readonly enabledTypes: readonly string[];
+}
+
 interface ConnectorAgentAccessRowsParams {
   readonly connectorType: ConnectorType;
 }
@@ -86,6 +91,54 @@ export const setConnectorAccessManagementPermissionAgentId$ = command(
   },
 );
 
+const connectorAgentAuthorizations$ = computed(
+  async (get): Promise<readonly ConnectorAgentAuthorizationRow[]> => {
+    get(internalConnectorAccessManagementReload$);
+    const allAgents = await get(agents$);
+    const client = get(zeroClient$)(zeroUserConnectorsContract);
+    return await Promise.all(
+      allAgents.map(async (agent) => {
+        const result = await accept(
+          client.get({ params: { id: agent.id } }),
+          [200],
+          { toast: false },
+        );
+        return {
+          agent,
+          enabledTypes: result.body.enabledTypes,
+        };
+      }),
+    );
+  },
+);
+
+function createConnectorAuthorizedAgentsFactory(): (
+  params: ConnectorAgentAccessRowsParams,
+) => Computed<Promise<readonly TeamComposeItem[]>> {
+  const cache = new Map<
+    string,
+    Computed<Promise<readonly TeamComposeItem[]>>
+  >();
+  return (params) => {
+    const existing = cache.get(params.connectorType);
+    if (existing) {
+      return existing;
+    }
+    const atom$ = computed(async (get): Promise<readonly TeamComposeItem[]> => {
+      const authorizations = await get(connectorAgentAuthorizations$);
+      return authorizations
+        .filter((row) => {
+          return row.enabledTypes.includes(params.connectorType);
+        })
+        .map((row) => {
+          return row.agent;
+        });
+    });
+    cache.set(params.connectorType, atom$);
+    return atom$;
+  };
+}
+
 function createConnectorAgentAccessRowsFactory(): (
   params: ConnectorAgentAccessRowsParams,
 ) => Computed<Promise<readonly ConnectorAgentAccessRow[]>> {
@@ -100,19 +153,10 @@ function createConnectorAgentAccessRowsFactory(): (
     }
     const atom$ = computed(
       async (get): Promise<readonly ConnectorAgentAccessRow[]> => {
-        get(internalConnectorAccessManagementReload$);
-        const allAgents = await get(agents$);
-        const client = get(zeroClient$)(zeroUserConnectorsContract);
+        const authorizations = await get(connectorAgentAuthorizations$);
         return await Promise.all(
-          allAgents.map(async (agent) => {
-            const result = await accept(
-              client.get({ params: { id: agent.id } }),
-              [200],
-              { toast: false },
-            );
-            const authorized = result.body.enabledTypes.includes(
-              params.connectorType,
-            );
+          authorizations.map(async ({ agent, enabledTypes }) => {
+            const authorized = enabledTypes.includes(params.connectorType);
             const grants = authorized
               ? await get(userPermissionGrantsByAgent({ agentId: agent.id }))
               : [];
@@ -129,6 +173,9 @@ function createConnectorAgentAccessRowsFactory(): (
     return atom$;
   };
 }
+
+export const connectorAuthorizedAgents =
+  createConnectorAuthorizedAgentsFactory();
 
 export const connectorAgentAccessRows = createConnectorAgentAccessRowsFactory();
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -667,6 +667,31 @@ describe("connectors page", () => {
     expect(dialog).toBeInTheDocument();
   });
 
+  it("shows a stable placeholder when no agents are authorized", async () => {
+    const agentId = "c0000000-0000-4000-a000-000000000001";
+    mockConnectors([{ type: "github", externalUsername: "octocat" }]);
+    context.mocks.data.team([teamAgent(agentId, "Research Agent", "preset:0")]);
+    context.mocks.api(zeroUserConnectorsContract.get, ({ respond }) => {
+      return respond(200, { enabledTypes: [] });
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/connectors",
+      featureSwitches: {
+        [FeatureSwitchKey.ConnectorAccessManagement]: true,
+      },
+    });
+
+    await waitFor(() => {
+      const card = connectorCardByLabel("GitHub");
+      const placeholder = within(card).getByTestId(
+        "connector-card-agent-avatar-placeholder",
+      );
+      expect(placeholder).toHaveClass("block", "h-7", "w-7");
+    });
+  });
+
   it("hides permission controls for connectors without firewall rules", async () => {
     const mediaAgentId = "c0000000-0000-4000-a000-000000000003";
     mockConnectors([

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -102,14 +102,18 @@ function reconnectReasonHelpButton(container: ParentNode): HTMLElement | null {
   );
 }
 
-function teamAgent(id: string, displayName: string): TeamComposeItem {
+function teamAgent(
+  id: string,
+  displayName: string,
+  avatarUrl: string | null = null,
+): TeamComposeItem {
   return {
     id,
     ownerId: "test-user-123",
     displayName,
     description: null,
     sound: null,
-    avatarUrl: null,
+    avatarUrl,
     visibility: "public",
     headVersionId: "version_1",
     updatedAt: "2024-01-01T00:00:00Z",
@@ -606,6 +610,61 @@ describe("connectors page", () => {
         within(dialog).getByLabelText("Revoke GitHub access for Support Agent"),
       ).toBeInTheDocument();
     });
+  });
+
+  it("shows up to three authorized agent avatars on connector cards", async () => {
+    const agentIds = [
+      "c0000000-0000-4000-a000-000000000001",
+      "c0000000-0000-4000-a000-000000000002",
+      "c0000000-0000-4000-a000-000000000003",
+      "c0000000-0000-4000-a000-000000000004",
+    ] as const;
+    const enabledByAgent = new Map<string, string[]>(
+      agentIds.map((agentId) => {
+        return [agentId, ["github"]];
+      }),
+    );
+
+    mockConnectors([{ type: "github", externalUsername: "octocat" }]);
+    context.mocks.data.team([
+      teamAgent(agentIds[0], "Research Agent", "preset:0"),
+      teamAgent(agentIds[1], "Support Agent", "preset:1"),
+      teamAgent(agentIds[2], "Growth Agent"),
+      teamAgent(agentIds[3], "Ops Agent", "preset:3"),
+    ]);
+    context.mocks.api(zeroUserConnectorsContract.get, ({ params, respond }) => {
+      return respond(200, {
+        enabledTypes: enabledByAgent.get(params.id) ?? [],
+      });
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/connectors",
+      featureSwitches: {
+        [FeatureSwitchKey.ConnectorAccessManagement]: true,
+      },
+    });
+
+    await waitFor(() => {
+      const card = connectorCardByLabel("GitHub");
+      const avatars = within(card).getAllByTestId(
+        "connector-card-agent-avatar",
+      );
+      expect(avatars).toHaveLength(3);
+      expect(avatars[2]).toHaveClass("block", "h-7", "w-7");
+    });
+
+    click(
+      within(connectorCardByLabel("GitHub")).getByLabelText(
+        "Manage GitHub access",
+      ),
+    );
+
+    const dialog = await screen.findByRole("dialog", {
+      name: "Manage GitHub access",
+    });
+    expect(dialog).toBeInTheDocument();
   });
 
   it("hides permission controls for connectors without firewall rules", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -16,12 +16,12 @@ import {
   IconLoader2,
   IconDotsVertical,
   IconInfoCircle,
-  IconAdjustmentsHorizontal,
 } from "@tabler/icons-react";
 import {
   CONNECTOR_TYPES,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
+import type { TeamComposeItem } from "@vm0/api-contracts/contracts/zero-team";
 import { Tabs, TabsList, TabsTrigger } from "@vm0/ui/components/ui/tabs";
 import {
   connectorsPageTab$,
@@ -76,11 +76,13 @@ import { ConnectorPermissionDialog } from "./components/settings/connector-permi
 import { ConnectorAccessManagementDialog } from "./components/settings/connector-access-management-dialog.tsx";
 import {
   closeConnectorAccessManagement$,
+  connectorAuthorizedAgents,
   managedConnectorAccessType$,
   setManagedConnectorAccessType$,
 } from "../../signals/zero-page/settings/connector-access-management.ts";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { noConnectorImg } from "./platform-assets.ts";
+import { AvatarFromUrl } from "./zero-sidebar-shared.tsx";
 import { detach, onDomEventFn, Reason } from "../../signals/utils.ts";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import {
@@ -95,6 +97,8 @@ import {
   TooltipTrigger,
   cn,
 } from "@vm0/ui";
+
+const CONNECTOR_CARD_AGENT_AVATAR_LIMIT = 3;
 
 // Callback ref that attaches scroll tracking while enabled. Each call returns
 // a fresh ref callback; React only invokes it when the underlying element
@@ -361,6 +365,74 @@ function ConnectorCategoryGroupSection({
   );
 }
 
+function connectorAgentName(agent: TeamComposeItem): string {
+  return agent.displayName ?? "Unnamed";
+}
+
+function ConnectorAccessAvatar({ agent }: { readonly agent: TeamComposeItem }) {
+  const name = connectorAgentName(agent);
+  return (
+    <span key={agent.id} className="relative shrink-0" title={name}>
+      <AvatarFromUrl
+        avatarUrl={agent.avatarUrl}
+        alt={name}
+        className="block h-7 w-7 rounded-full bg-muted/80 object-cover zero-border"
+        data-testid="connector-card-agent-avatar"
+      />
+    </span>
+  );
+}
+
+function ConnectorAccessAvatarButton({
+  connectorType,
+  connectorLabel,
+  onClick,
+}: {
+  readonly connectorType: ConnectorType;
+  readonly connectorLabel: string;
+  readonly onClick: () => void;
+}) {
+  const agentsLoadable = useLastLoadable(
+    connectorAuthorizedAgents({ connectorType }),
+  );
+  const agents = agentsLoadable.state === "hasData" ? agentsLoadable.data : [];
+  const visibleAgents = agents.slice(0, CONNECTOR_CARD_AGENT_AVATAR_LIMIT);
+  const loading = agentsLoadable.state === "loading";
+
+  return (
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            className="inline-flex h-8 min-w-8 shrink-0 items-center justify-center rounded-lg px-1 transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            aria-label={`Manage ${connectorLabel} access`}
+            onClick={onClick}
+          >
+            {loading ? (
+              <span className="h-7 w-7 animate-pulse rounded-full bg-muted zero-border" />
+            ) : visibleAgents.length > 0 ? (
+              <span className="flex items-center -space-x-1.5">
+                {visibleAgents.map((agent) => {
+                  return <ConnectorAccessAvatar key={agent.id} agent={agent} />;
+                })}
+              </span>
+            ) : (
+              <span
+                className="h-7 w-7 rounded-full bg-muted/80 zero-border"
+                data-testid="connector-card-agent-avatar-placeholder"
+              />
+            )}
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="text-xs">
+          Manage access
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
 function GlobalConnectorCard({
   connector,
   isPolling,
@@ -498,25 +570,11 @@ function GlobalConnectorCard({
         {connector.connected && (
           <div className="flex shrink-0 items-center gap-1">
             {showManageAccess && (
-              <TooltipProvider delayDuration={200}>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      className="h-7 w-7 shrink-0 rounded-lg text-muted-foreground hover:text-foreground"
-                      aria-label={`Manage ${connector.label} access`}
-                      onClick={onManageAccess}
-                    >
-                      <IconAdjustmentsHorizontal size={14} stroke={1.5} />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent side="top" className="text-xs">
-                    Manage access
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
+              <ConnectorAccessAvatarButton
+                connectorType={connector.type}
+                connectorLabel={connector.label}
+                onClick={onManageAccess}
+              />
             )}
             <DropdownMenu>
               <DropdownMenuTrigger asChild>

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -410,7 +410,7 @@ function ConnectorAccessAvatarButton({
             onClick={onClick}
           >
             {loading ? (
-              <span className="h-7 w-7 animate-pulse rounded-full bg-muted zero-border" />
+              <span className="block h-7 w-7 animate-pulse rounded-full bg-muted zero-border" />
             ) : visibleAgents.length > 0 ? (
               <span className="flex items-center -space-x-1.5">
                 {visibleAgents.map((agent) => {
@@ -419,7 +419,7 @@ function ConnectorAccessAvatarButton({
               </span>
             ) : (
               <span
-                className="h-7 w-7 rounded-full bg-muted/80 zero-border"
+                className="block h-7 w-7 rounded-full bg-muted/80 zero-border"
                 data-testid="connector-card-agent-avatar-placeholder"
               />
             )}


### PR DESCRIPTION
## Summary
- Replace the connector access icon button with a compact stack of up to three authorized agent avatars on connected connector cards.
- Reuse shared connector access authorization data for both the avatar preview and management dialog.
- Add coverage for the avatar cap and existing dialog-opening behavior.

## Verification
- pnpm exec prettier --write apps/platform/src/signals/zero-page/settings/connector-access-management.ts apps/platform/src/views/zero-page/zero-connectors-page.tsx apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-connectors-page.test.tsx