### PR TITLE
feat: add agent unread indicators

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -1027,6 +1027,48 @@ describe("CHAT-01 chat thread list pagination and read state", () => {
     expect(listedThreadIds(otherOrgList)).toStrictEqual([]);
   }, 60_000);
 
+  it("lists unread agent ids behind the agent unread feature switch", async () => {
+    const owner = bdd.user();
+    bdd.acceptAgentStorageWrites();
+    const agentA = await bdd.createAgent(owner, {
+      displayName: "Unread agent A",
+    });
+    const agentB = await bdd.createAgent(owner, {
+      displayName: "Unread agent B",
+    });
+
+    const disabled = await chat.requestListUnreadAgents(owner, [403]);
+    expectApiError(disabled.body);
+    expect(disabled.body.error.code).toBe("FORBIDDEN");
+
+    await connectorsApi.updateFeatureSwitches(owner, {
+      [FeatureSwitchKey.AgentUnreadIndicators]: true,
+    });
+    await expect(chat.listUnreadAgents(owner)).resolves.toStrictEqual([]);
+
+    const threadA = await sendNoCreditMessage(owner, {
+      agentId: agentA.agentId,
+      prompt: "unread aggregate A",
+    });
+    const threadB = await sendNoCreditMessage(owner, {
+      agentId: agentB.agentId,
+      prompt: "unread aggregate B",
+    });
+
+    const unreadAgents = await chat.listUnreadAgents(owner);
+    expect(new Set(unreadAgents)).toStrictEqual(
+      new Set([agentA.agentId, agentB.agentId]),
+    );
+
+    await chat.markThreadRead(owner, threadA);
+    await expect(chat.listUnreadAgents(owner)).resolves.toStrictEqual([
+      agentB.agentId,
+    ]);
+
+    await chat.markThreadRead(owner, threadB);
+    await expect(chat.listUnreadAgents(owner)).resolves.toStrictEqual([]);
+  }, 60_000);
+
   it("pages thread messages with since and before cursors", async () => {
     const owner = bdd.user();
     bdd.acceptAgentStorageWrites();

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
@@ -524,6 +524,28 @@ export function createChatFilesBddApi(context: TestContext) {
       return response.body.unreads;
     },
 
+    async requestListUnreadAgents(
+      actor: ApiTestUser | null,
+      statuses: readonly (200 | 401 | 403)[],
+    ) {
+      return await accept(
+        threadsClient().unreadAgents({
+          headers: authenticate(context, actor),
+        }),
+        statuses,
+      );
+    },
+
+    async listUnreadAgents(actor: ApiTestUser): Promise<readonly string[]> {
+      const response = await accept(
+        threadsClient().unreadAgents({
+          headers: authenticate(context, actor),
+        }),
+        [200],
+      );
+      return response.body.agentIds;
+    },
+
     async readThread(
       actor: ApiTestUser,
       threadId: string,

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads-mark-read.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads-mark-read.ts
@@ -79,14 +79,13 @@ const markReadInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     );
   signal.throwIfAborted();
 
-  // Per-thread read-cursor signal only. No threadListChanged broadcast: the
-  // caller syncs from the unread snapshot in this response, and other
-  // clients converge on their next unreads fetch.
-  await publishUserSignal(
-    [auth.userId],
-    `chatThreadReadCursorUpdated:${params.id}`,
-    { lastReadMessageId: latestMessageId },
-  );
+  // Read-state invalidation only. Thread-list shape is unchanged, and
+  // clients refetch unread snapshots from this generic user-level topic.
+  await publishUserSignal([auth.userId], "chatThreadReadCursorUpdated", {
+    threadId: params.id,
+    agentId: thread.agentComposeId,
+    lastReadMessageId: latestMessageId,
+  });
   signal.throwIfAborted();
 
   return {

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads.ts
@@ -26,6 +26,7 @@ import {
   zeroChatThreadDraftIds,
   zeroChatThreadList,
   zeroChatThreadMessagesPage,
+  zeroChatThreadUnreadAgentIds,
   zeroChatThreadUnreads,
 } from "../services/zero-chat-thread.service";
 import { zeroChatThreadGithubPrs$ } from "../services/chat-thread-github-prs.service";
@@ -166,6 +167,29 @@ const listChatThreadUnreadsInner$ = computed(async (get) => {
   return { status: 200 as const, body: { unreads: [...unreads] } };
 });
 
+const listChatThreadUnreadAgentsInner$ = computed(async (get) => {
+  const auth = get(organizationAuthContext$);
+  const overrides = await get(
+    userFeatureSwitchOverrides(auth.orgId, auth.userId),
+  );
+
+  if (
+    !isFeatureEnabled(FeatureSwitchKey.AgentUnreadIndicators, {
+      orgId: auth.orgId,
+      userId: auth.userId,
+      overrides,
+    })
+  ) {
+    return forbidden("Agent unread indicators are not enabled");
+  }
+
+  const agentIds = await get(
+    zeroChatThreadUnreadAgentIds({ userId: auth.userId, orgId: auth.orgId }),
+  );
+
+  return { status: 200 as const, body: { agentIds: [...agentIds] } };
+});
+
 const listChatThreadArtifactsInner$ = computed(async (get) => {
   const auth = get(authContext$);
   const params = get(pathParamsOf(chatThreadArtifactsContract.list));
@@ -278,6 +302,13 @@ export const zeroChatThreadRoutes: readonly RouteEntry[] = [
   {
     route: chatThreadsContract.unreads,
     handler: authRoute({}, listChatThreadUnreadsInner$),
+  },
+  {
+    route: chatThreadsContract.unreadAgents,
+    handler: authRoute(
+      { requireOrganization: true, missingOrganizationStatus: 401 },
+      listChatThreadUnreadAgentsInner$,
+    ),
   },
   {
     route: chatThreadByIdContract.get,

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -972,6 +972,39 @@ export function zeroChatThreadUnreads(args: {
 }
 
 /**
+ * Agents that currently have at least one unread thread for the user. Uses
+ * the same read-cursor comparison as `zeroChatThreadUnreads`.
+ */
+export function zeroChatThreadUnreadAgentIds(args: {
+  readonly userId: string;
+  readonly orgId: string;
+}): Computed<Promise<readonly string[]>> {
+  return computed(async (get) => {
+    const db = get(db$);
+    const lastMessage = lastVisibleMessageSubquery(db);
+    const rows = await db
+      .selectDistinct({ agentId: chatThreads.agentComposeId })
+      .from(chatThreads)
+      .innerJoin(zeroAgents, eq(zeroAgents.id, chatThreads.agentComposeId))
+      .leftJoinLateral(lastMessage, sql`true`)
+      .where(
+        and(
+          eq(chatThreads.userId, args.userId),
+          eq(zeroAgents.orgId, args.orgId),
+          isNotNull(lastMessage.id),
+          or(
+            isNull(chatThreads.lastReadMessageId),
+            sql`${chatThreads.lastReadMessageId} <> ${lastMessage.id}`,
+          ),
+        ),
+      );
+    return rows.map((row) => {
+      return row.agentId;
+    });
+  });
+}
+
+/**
  * Of the given thread ids, the ones owned by the user that currently hold an
  * unsent composer draft (non-empty `draftContent` or one+ `draftAttachments`).
  */

--- a/turbo/apps/platform/src/mocks/handlers/api-agents.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-agents.ts
@@ -216,6 +216,11 @@ export const apiAgentsHandlers = [
     return respond(200, { unreads: [] });
   }),
 
+  // GET /api/zero/chat-thread-unread-agents
+  mockApi(chatThreadsContract.unreadAgents, ({ respond }) => {
+    return respond(200, { agentIds: [] });
+  }),
+
   // POST /api/zero/chat-threads/:id/mark-read
   mockApi(chatThreadMarkReadContract.markRead, ({ respond }) => {
     return respond(200, { lastReadMessageId: null, unreads: [] });

--- a/turbo/apps/platform/src/signals/chat-page/remote-chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/remote-chat-thread-data-source.ts
@@ -13,10 +13,6 @@ import { zeroClient$ } from "../api-client.ts";
 import { setAblyLoop$ } from "../realtime.ts";
 import { logger } from "../log.ts";
 import { reloadSidebarDraftThreads$ } from "./sidebar-draft-threads.ts";
-import {
-  applyUnreadSnapshot$,
-  recordOptimisticReadMark$,
-} from "./sidebar-unread-threads.ts";
 import type { ChatThread } from "../agent-chat.ts";
 import type {
   CancelRunsArgs,
@@ -264,14 +260,10 @@ const cancelRuns$ = command(
 
 const markRead$ = command(
   async (
-    { get, set },
+    { get },
     { threadId, latestMessageId }: MarkReadArgs,
     signal: AbortSignal,
   ): Promise<string | null> => {
-    // Optimistic: suppress this thread's sidebar unread dot immediately.
-    // The response's unread snapshot kicks the mark if a newer message
-    // already landed. Mark-read is not broadcast by the server.
-    set(recordOptimisticReadMark$, threadId);
     const client = get(zeroClient$)(chatThreadMarkReadContract);
     const result = await accept(
       client.markRead({
@@ -281,7 +273,6 @@ const markRead$ = command(
       [200],
     );
     signal.throwIfAborted();
-    set(applyUnreadSnapshot$, result.body.unreads);
     return result.body.lastReadMessageId ?? latestMessageId;
   },
 );

--- a/turbo/apps/platform/src/signals/chat-page/sidebar-unread-threads.ts
+++ b/turbo/apps/platform/src/signals/chat-page/sidebar-unread-threads.ts
@@ -1,63 +1,21 @@
-import { command, computed, state } from "ccstate";
+import { computed } from "ccstate";
 import { chatThreadsContract } from "@vm0/api-contracts/contracts/chat-threads";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { accept } from "../../lib/accept.ts";
-import { now } from "../../lib/time.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { currentChatAgentId$ } from "../agent-chat.ts";
-import { reloadChatThreadsCounter$ } from "../chat-thread-list-reload.ts";
+import { reloadChatUnreadStateCounter$ } from "../chat-thread-list-reload.ts";
+import { featureSwitch$ } from "../external/feature-switch.ts";
 
 type UnreadSnapshot = readonly { threadId: string; unreadAt: string }[];
 
 /**
- * Local optimistic mark-read timestamps (threadId → epoch ms, recorded when
- * the mark-read POST fires). A thread present in the server unread snapshot
- * is still rendered as read while a local mark exists — until a snapshot
- * reports an `unreadAt` NEWER than the mark, which means a fresh message
- * arrived after the user read the thread and the optimistic entry must be
- * kicked. This absorbs the race between mark-read and an in-flight unreads
- * fetch without any server broadcast.
- */
-const optimisticReadMarks$ = state<ReadonlyMap<string, number>>(new Map());
-
-export const recordOptimisticReadMark$ = command(
-  ({ get, set }, threadId: string) => {
-    const next = new Map(get(optimisticReadMarks$));
-    next.set(threadId, now());
-    set(optimisticReadMarks$, next);
-  },
-);
-
-/**
- * Kick optimistic marks that a server snapshot has overtaken. Called with
- * the snapshot from a mark-read response so a message that landed between
- * the fetch and the mark resurfaces immediately.
- */
-export const applyUnreadSnapshot$ = command(
-  ({ get, set }, unreads: UnreadSnapshot) => {
-    const marks = get(optimisticReadMarks$);
-    if (marks.size === 0) {
-      return;
-    }
-    const next = new Map(marks);
-    for (const unread of unreads) {
-      const markedAt = next.get(unread.threadId);
-      if (markedAt !== undefined && Date.parse(unread.unreadAt) > markedAt) {
-        next.delete(unread.threadId);
-      }
-    }
-    if (next.size !== marks.size) {
-      set(optimisticReadMarks$, next);
-    }
-  },
-);
-
-/**
  * Server unread snapshot for the current agent. Refetched alongside the
- * thread list (same reload counter); mark-read does not broadcast, so reads
- * by this client are reflected through `optimisticReadMarks$` instead.
+ * unread-state counter. Thread-list changes and read-cursor updates both
+ * invalidate this counter through Ably.
  */
 const fetchedUnreads$ = computed(async (get): Promise<UnreadSnapshot> => {
-  get(reloadChatThreadsCounter$);
+  get(reloadChatUnreadStateCounter$);
   const agentId = await get(currentChatAgentId$);
   if (!agentId) {
     return [];
@@ -67,21 +25,28 @@ const fetchedUnreads$ = computed(async (get): Promise<UnreadSnapshot> => {
   return result.body.unreads;
 });
 
-/**
- * Thread ids to render with the sidebar unread dot: the server snapshot
- * minus threads suppressed by a still-valid local mark.
- */
 export const sidebarUnreadThreadIds$ = computed(
   async (get): Promise<ReadonlySet<string>> => {
     const unreads = await get(fetchedUnreads$);
-    const marks = get(optimisticReadMarks$);
-    const ids = new Set<string>();
-    for (const unread of unreads) {
-      const markedAt = marks.get(unread.threadId);
-      if (markedAt === undefined || Date.parse(unread.unreadAt) > markedAt) {
-        ids.add(unread.threadId);
-      }
+    return new Set(
+      unreads.map((unread) => {
+        return unread.threadId;
+      }),
+    );
+  },
+);
+
+export const unreadAgentIds$ = computed(
+  async (get): Promise<ReadonlySet<string>> => {
+    get(reloadChatUnreadStateCounter$);
+    const features = get(featureSwitch$);
+    if (!features[FeatureSwitchKey.AgentUnreadIndicators]) {
+      return new Set();
     }
-    return ids;
+    const client = get(zeroClient$)(chatThreadsContract);
+    const result = await accept(client.unreadAgents(), [200], {
+      toast: false,
+    });
+    return new Set(result.body.agentIds);
   },
 );

--- a/turbo/apps/platform/src/signals/chat-thread-list-reload.ts
+++ b/turbo/apps/platform/src/signals/chat-thread-list-reload.ts
@@ -2,6 +2,7 @@ import { command, computed, state } from "ccstate";
 import { setAblyLoop$ } from "./realtime.ts";
 
 const internalReloadChatThreads$ = state(0);
+const internalReloadChatUnreadState$ = state(0);
 
 /**
  * Read-only view of the reload counter. Consumers subscribe to this to
@@ -9,6 +10,10 @@ const internalReloadChatThreads$ = state(0);
  */
 export const reloadChatThreadsCounter$ = computed((get) => {
   return get(internalReloadChatThreads$);
+});
+
+export const reloadChatUnreadStateCounter$ = computed((get) => {
+  return get(internalReloadChatUnreadState$);
 });
 
 /**
@@ -21,12 +26,17 @@ export const reloadChatThreads$ = command(({ set }) => {
   });
 });
 
+export const reloadChatUnreadState$ = command(({ set }) => {
+  set(internalReloadChatUnreadState$, (n) => {
+    return n + 1;
+  });
+});
+
 /**
  * Subscribe to the user-level `threadListChanged` topic and trigger a
  * sidebar reload on every signal. Server publishes this on any mutation
  * that alters the thread list shape (create, delete, new message, run
- * create/update, title update). Mark-read intentionally syncs through the
- * unread snapshot returned by the mark-read response.
+ * create/update, title update). These changes can also affect unread state.
  *
  * Loop command returns false so it keeps listening until the signal aborts.
  * Isolated in its own file to avoid an import cycle when `route.ts` wires
@@ -36,8 +46,19 @@ export const subscribeThreadListChanged$ = command(
   async ({ set }, signal: AbortSignal) => {
     const onChanged$ = command(({ set }) => {
       set(reloadChatThreads$);
+      set(reloadChatUnreadState$);
       return false;
     });
     await set(setAblyLoop$, "threadListChanged", onChanged$, signal);
+  },
+);
+
+export const subscribeChatThreadReadCursorUpdated$ = command(
+  async ({ set }, signal: AbortSignal) => {
+    const onChanged$ = command(({ set }) => {
+      set(reloadChatUnreadState$);
+      return false;
+    });
+    await set(setAblyLoop$, "chatThreadReadCursorUpdated", onChanged$, signal);
   },
 );

--- a/turbo/apps/platform/src/views/main.tsx
+++ b/turbo/apps/platform/src/views/main.tsx
@@ -5,7 +5,10 @@ import { Toaster } from "@vm0/ui/components/ui/sonner";
 import { ErrorBoundary } from "./error-boundary.tsx";
 import { Router } from "./router.tsx";
 import { VM0ClerkProvider } from "./clerk/clerk-provider.tsx";
-import { subscribeThreadListChanged$ } from "../signals/chat-thread-list-reload.ts";
+import {
+  subscribeChatThreadReadCursorUpdated$,
+  subscribeThreadListChanged$,
+} from "../signals/chat-thread-list-reload.ts";
 import { subscribeBackgroundChatThreadRunFinished$ } from "../signals/chat-page/background-chat-thread-cache.ts";
 import { rootSignal$ } from "../signals/root-signal.ts";
 import { detach, Reason } from "../signals/utils.ts";
@@ -18,6 +21,10 @@ export const setupRouter = (
 ) => {
   const signal = store.get(rootSignal$);
   detach(store.set(subscribeThreadListChanged$, signal), Reason.Daemon);
+  detach(
+    store.set(subscribeChatThreadReadCursorUpdated$, signal),
+    Reason.Daemon,
+  );
   detach(
     store.set(subscribeBackgroundChatThreadRunFinished$, signal),
     Reason.Daemon,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -169,6 +169,15 @@ function threadLinkByTitle(title: string): HTMLElement {
   return link;
 }
 
+function agentRowByName(container: HTMLElement, name: string): HTMLElement {
+  const text = within(container).getByText(name);
+  const row = text.closest(".group");
+  if (!(row instanceof HTMLElement)) {
+    throw new Error(`${name} agent row not found`);
+  }
+  return row;
+}
+
 function openThreadMenu(title: string): void {
   click(
     within(threadRowByTitle(title)).getByTestId("chat-thread-menu-trigger"),
@@ -772,6 +781,92 @@ describe("zero sidebar", () => {
     });
 
     createDeferred.resolve();
+  });
+
+  it("shows agent unread indicators and dropdown actions behind the feature switch", async () => {
+    prepareAgentTeam();
+    context.mocks.data.userPreferences({
+      pinnedAgentIds: [RESEARCH_AGENT_ID],
+    });
+    context.mocks.api(chatThreadsContract.list, ({ respond }) => {
+      return respond(200, splitChatThreadListResponse([]));
+    });
+
+    let unreadAgentIds = [RESEARCH_AGENT_ID, SUPPORT_AGENT_ID];
+    let unreadAgentRequests = 0;
+    context.mocks.api(chatThreadsContract.unreadAgents, ({ respond }) => {
+      unreadAgentRequests += 1;
+      return respond(200, { agentIds: unreadAgentIds });
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      featureSwitches: { [FeatureSwitchKey.AgentUnreadIndicators]: true },
+    });
+
+    const nav = await waitFor(() => {
+      const current = sidebar();
+      expect(within(current).getByText("Research Agent")).toBeInTheDocument();
+      return current;
+    });
+    const researchSidebarRow = agentRowByName(nav, "Research Agent");
+    await waitFor(() => {
+      expect(
+        within(researchSidebarRow).getByLabelText("Unread"),
+      ).toBeInTheDocument();
+      expect(
+        within(researchSidebarRow).getByLabelText("Open agent menu"),
+      ).toBeInTheDocument();
+      expect(
+        within(researchSidebarRow).queryByLabelText("Remove from list"),
+      ).not.toBeInTheDocument();
+    });
+
+    click(within(researchSidebarRow).getByLabelText("Open agent menu"));
+    expect(menuItemByText("Remove from list")).toBeInTheDocument();
+    fireEvent.keyDown(document.body, { key: "Escape" });
+
+    click(within(nav).getByLabelText("Open a conversation"));
+    const dialog = await screen.findByRole("dialog", { name: "Talk to" });
+    const researchDialogRow = agentRowByName(dialog, "Research Agent");
+    const supportDialogRow = agentRowByName(dialog, "Support Agent");
+    expect(
+      within(researchDialogRow).getByLabelText("Unread"),
+    ).toBeInTheDocument();
+    expect(
+      within(supportDialogRow).getByLabelText("Unread"),
+    ).toBeInTheDocument();
+    expect(
+      within(supportDialogRow).queryByLabelText("Pin to sidebar"),
+    ).not.toBeInTheDocument();
+
+    click(within(supportDialogRow).getByLabelText("Open agent menu"));
+    expect(menuItemByText("Pin to sidebar")).toBeInTheDocument();
+    fireEvent.keyDown(document.body, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(
+        context.mocks.ably.hasSubscription("chatThreadReadCursorUpdated"),
+      ).toBeTruthy();
+    });
+    unreadAgentIds = [SUPPORT_AGENT_ID];
+    context.mocks.ably.trigger("chatThreadReadCursorUpdated", {
+      agentId: RESEARCH_AGENT_ID,
+    });
+
+    await waitFor(() => {
+      expect(unreadAgentRequests).toBeGreaterThan(1);
+      expect(
+        within(researchSidebarRow).queryByLabelText("Unread"),
+      ).not.toBeInTheDocument();
+      expect(
+        within(researchDialogRow).queryByLabelText("Unread"),
+      ).not.toBeInTheDocument();
+      expect(
+        within(supportDialogRow).getByLabelText("Unread"),
+      ).toBeInTheDocument();
+    });
   });
 
   it("collapses and reopens the sidebar", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-dialogs.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-dialogs.tsx
@@ -1,6 +1,6 @@
 // TODO(#8609): split large components to comply with max-lines-per-function (128)
 // oxlint-disable max-lines-per-function
-import type { ReactNode } from "react";
+import type { MouseEvent, ReactNode } from "react";
 import { useGet, useSet, useLastResolved } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import {
@@ -8,7 +8,10 @@ import {
   IconX,
   IconArrowsMove,
   IconPin,
+  IconDots,
+  IconPinnedOff,
 } from "@tabler/icons-react";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   DndContext,
   closestCenter,
@@ -36,16 +39,26 @@ import {
   DialogHeader,
   DialogTitle,
   Input,
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
 } from "@vm0/ui";
 import {
   chatListQuery$,
   setChatListQuery$,
 } from "../../signals/zero-page/zero-sidebar-state.ts";
-import { leadAgentAvatarUrl$, type SubagentInfo } from "../../signals/agent.ts";
+import {
+  defaultAgentId$,
+  leadAgentAvatarUrl$,
+  type SubagentInfo,
+} from "../../signals/agent.ts";
 import {
   pinnedAgentIds$,
   updatePinnedAgentIds$,
 } from "../../signals/zero-page/zero-pinned-agents.ts";
+import { unreadAgentIds$ } from "../../signals/chat-page/sidebar-unread-threads.ts";
+import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { AgentAvatarImg, AvatarFromUrl } from "./zero-sidebar-shared.tsx";
@@ -166,16 +179,88 @@ export function AgentDialogAgentButton({
   );
 }
 
+function AgentUnreadIndicator() {
+  return (
+    <span aria-label="Unread" className="h-2 w-2 rounded-full bg-sky-600" />
+  );
+}
+
+function AgentDialogMenuAction({
+  label,
+  disabled,
+  icon,
+  onSelect,
+}: {
+  readonly label: string;
+  readonly disabled?: boolean;
+  readonly icon: ReactNode;
+  readonly onSelect: () => void;
+}) {
+  function handleMenuTriggerClick(e: MouseEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="peer absolute inset-0 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground invisible transition-colors duration-150 group-hover:visible group-focus-within:visible data-[state=open]:visible hover:bg-muted-foreground/12 hover:text-foreground dark:hover:bg-muted-foreground/18 disabled:cursor-not-allowed disabled:opacity-50"
+          onClick={handleMenuTriggerClick}
+          aria-label="Open agent menu"
+          disabled={disabled}
+        >
+          <IconDots size={16} stroke={2} />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-44">
+        <DropdownMenuItem onSelect={onSelect} disabled={disabled}>
+          <span className="mr-2">{icon}</span>
+          {label}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function AgentDialogSideDecorator({
+  hasUnread,
+  action,
+}: {
+  readonly hasUnread: boolean;
+  readonly action?: ReactNode;
+}) {
+  if (!hasUnread && !action) {
+    return null;
+  }
+
+  return (
+    <div className="relative flex h-8 w-8 shrink-0 items-center justify-center">
+      {action}
+      {hasUnread && (
+        <span className="flex items-center justify-center group-hover:hidden group-focus-within:hidden peer-data-[state=open]:hidden">
+          <AgentUnreadIndicator />
+        </span>
+      )}
+    </div>
+  );
+}
+
 function SortablePinnedAgent({
   agent,
   onUnpin,
   onChat,
   disabled,
+  unreadIndicatorsEnabled,
+  hasUnread,
 }: {
   agent: SubagentInfo;
   onUnpin: () => void;
   onChat?: () => void;
   disabled?: boolean;
+  unreadIndicatorsEnabled: boolean;
+  hasUnread: boolean;
 }) {
   const { attributes, listeners, setNodeRef, transform, transition } =
     useSortable({ id: agent.id });
@@ -204,27 +289,53 @@ function SortablePinnedAgent({
           </span>
         </>
       )}
-      <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100">
-        <button
-          type="button"
-          className="flex h-8 w-8 shrink-0 cursor-grab touch-none items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted-foreground/12 hover:text-foreground active:cursor-grabbing disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-muted-foreground/18"
-          aria-label={`Reorder ${agent.displayName ?? agent.id}`}
-          disabled={disabled}
-          {...attributes}
-          {...listeners}
-        >
-          <IconArrowsMove size={16} stroke={2} />
-        </button>
-        <button
-          type="button"
-          className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted-foreground/12 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-muted-foreground/18"
-          onClick={onUnpin}
-          aria-label={`Unpin ${agent.displayName ?? agent.id}`}
-          disabled={disabled}
-        >
-          <IconX size={16} stroke={2} />
-        </button>
-      </div>
+      {unreadIndicatorsEnabled ? (
+        <div className="flex shrink-0 items-center gap-0.5">
+          <button
+            type="button"
+            className="flex h-8 w-8 shrink-0 cursor-grab touch-none items-center justify-center rounded-lg text-muted-foreground opacity-0 transition-colors duration-150 group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-muted-foreground/12 hover:text-foreground active:cursor-grabbing disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-muted-foreground/18"
+            aria-label={`Reorder ${agent.displayName ?? agent.id}`}
+            disabled={disabled}
+            {...attributes}
+            {...listeners}
+          >
+            <IconArrowsMove size={16} stroke={2} />
+          </button>
+          <AgentDialogSideDecorator
+            hasUnread={hasUnread}
+            action={
+              <AgentDialogMenuAction
+                label="Remove from list"
+                disabled={disabled}
+                icon={<IconPinnedOff size={16} stroke={2} />}
+                onSelect={onUnpin}
+              />
+            }
+          />
+        </div>
+      ) : (
+        <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100">
+          <button
+            type="button"
+            className="flex h-8 w-8 shrink-0 cursor-grab touch-none items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted-foreground/12 hover:text-foreground active:cursor-grabbing disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-muted-foreground/18"
+            aria-label={`Reorder ${agent.displayName ?? agent.id}`}
+            disabled={disabled}
+            {...attributes}
+            {...listeners}
+          >
+            <IconArrowsMove size={16} stroke={2} />
+          </button>
+          <button
+            type="button"
+            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted-foreground/12 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-muted-foreground/18"
+            onClick={onUnpin}
+            aria-label={`Unpin ${agent.displayName ?? agent.id}`}
+            disabled={disabled}
+          >
+            <IconX size={16} stroke={2} />
+          </button>
+        </div>
+      )}
     </div>
   );
 }
@@ -243,9 +354,14 @@ export function AgentListDialog({
   onNewChat?: (agentId: string | null) => void;
 }) {
   const zeroAvatarUrl = useLastResolved(leadAgentAvatarUrl$) ?? null;
+  const defaultAgentId = useLastResolved(defaultAgentId$);
   const query = useGet(chatListQuery$);
   const setQuery = useSet(setChatListQuery$);
   const pinnedIds = useLastResolved(pinnedAgentIds$) ?? [];
+  const features = useGet(featureSwitch$);
+  const unreadIndicatorsEnabled =
+    features[FeatureSwitchKey.AgentUnreadIndicators] ?? false;
+  const unreadAgentIds = useLastResolved(unreadAgentIds$);
   const pageSignal = useGet(pageSignal$);
   const [pinLoadable, savePinnedIds] = useLoadableSet(updatePinnedAgentIds$);
   const saving = pinLoadable.state === "loading";
@@ -347,6 +463,15 @@ export function AgentListDialog({
                   }
                   subtitle="Your lead assistant, always here for you"
                 />
+                {unreadIndicatorsEnabled && (
+                  <AgentDialogSideDecorator
+                    hasUnread={
+                      defaultAgentId
+                        ? (unreadAgentIds?.has(defaultAgentId) ?? false)
+                        : false
+                    }
+                  />
+                )}
               </div>
             </AgentDialogSection>
           )}
@@ -378,6 +503,8 @@ export function AgentListDialog({
                             return handleChat(agent.id);
                           }}
                           disabled={saving}
+                          unreadIndicatorsEnabled={unreadIndicatorsEnabled}
+                          hasUnread={unreadAgentIds?.has(agent.id) ?? false}
                         />
                       );
                     })}
@@ -402,26 +529,42 @@ export function AgentListDialog({
                         return handleChat(agent.id);
                       }}
                     />
-                    <TooltipProvider delayDuration={200}>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <button
-                            type="button"
-                            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground opacity-0 transition-all duration-150 group-hover:opacity-100 group-focus-within:opacity-100 [@media(hover:none)]:opacity-100 hover:bg-muted-foreground/12 hover:text-foreground dark:hover:bg-muted-foreground/18 disabled:cursor-not-allowed disabled:opacity-50"
-                            onClick={() => {
+                    {unreadIndicatorsEnabled ? (
+                      <AgentDialogSideDecorator
+                        hasUnread={unreadAgentIds?.has(agent.id) ?? false}
+                        action={
+                          <AgentDialogMenuAction
+                            label="Pin to sidebar"
+                            disabled={saving}
+                            icon={<IconPin size={16} stroke={2} />}
+                            onSelect={() => {
                               return togglePin(agent.id);
                             }}
-                            aria-label="Pin to sidebar"
-                            disabled={saving}
-                          >
-                            <IconPin size={16} stroke={2} />
-                          </button>
-                        </TooltipTrigger>
-                        <TooltipContent side="right">
-                          <p className="text-xs">Pin to sidebar</p>
-                        </TooltipContent>
-                      </Tooltip>
-                    </TooltipProvider>
+                          />
+                        }
+                      />
+                    ) : (
+                      <TooltipProvider delayDuration={200}>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <button
+                              type="button"
+                              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground opacity-0 transition-all duration-150 group-hover:opacity-100 group-focus-within:opacity-100 [@media(hover:none)]:opacity-100 hover:bg-muted-foreground/12 hover:text-foreground dark:hover:bg-muted-foreground/18 disabled:cursor-not-allowed disabled:opacity-50"
+                              onClick={() => {
+                                return togglePin(agent.id);
+                              }}
+                              aria-label="Pin to sidebar"
+                              disabled={saving}
+                            >
+                              <IconPin size={16} stroke={2} />
+                            </button>
+                          </TooltipTrigger>
+                          <TooltipContent side="right">
+                            <p className="text-xs">Pin to sidebar</p>
+                          </TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                    )}
                   </div>
                 );
               })}

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
@@ -1,5 +1,6 @@
 // TODO(#8609): split large components to comply with max-lines-per-function (128)
 // oxlint-disable max-lines-per-function
+import type { MouseEvent } from "react";
 import {
   useGet,
   useSet,
@@ -7,12 +8,23 @@ import {
   useLastLoadable,
 } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
-import { IconPlus, IconChevronRight, IconX } from "@tabler/icons-react";
+import {
+  IconPlus,
+  IconChevronRight,
+  IconX,
+  IconDots,
+  IconPinnedOff,
+} from "@tabler/icons-react";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
 } from "@vm0/ui";
 import {
   isChatRoute,
@@ -38,6 +50,8 @@ import {
   updatePinnedAgentIds$,
   pinnedAgents$,
 } from "../../signals/zero-page/zero-pinned-agents.ts";
+import { unreadAgentIds$ } from "../../signals/chat-page/sidebar-unread-threads.ts";
+import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { createNewChatThreadOptimistically$ } from "../../signals/chat-page/optimistic-chat-thread-page.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { rootSignal$ } from "../../signals/root-signal.ts";
@@ -89,6 +103,106 @@ function UnpinButton({
   );
 }
 
+function AgentUnreadIndicator() {
+  return (
+    <span aria-label="Unread" className="h-2 w-2 rounded-full bg-sky-600" />
+  );
+}
+
+function PinnedAgentMenu({
+  agentId,
+  isPrimarySelected,
+}: {
+  agentId: string;
+  isPrimarySelected: boolean;
+}) {
+  const pinnedIds = useLastResolved(pinnedAgentIds$) ?? [];
+  const [pinLoadable, savePinnedIds] = useLoadableSet(updatePinnedAgentIds$);
+  const savingPinned = pinLoadable.state === "loading";
+  const pageSignal = useGet(pageSignal$);
+
+  function removeFromList() {
+    const next = pinnedIds.filter((id): id is string => {
+      return id !== null && id !== agentId;
+    });
+    detach(savePinnedIds(next, pageSignal), Reason.DomCallback);
+  }
+
+  function handleMenuTriggerClick(e: MouseEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+  }
+
+  return (
+    <TooltipProvider delayDuration={200}>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            onClick={handleMenuTriggerClick}
+            disabled={savingPinned}
+            className={`peer pointer-events-auto absolute left-1 top-1 flex h-6 w-6 cursor-pointer items-center justify-center rounded-md invisible group-hover:visible data-[state=open]:visible transition-opacity duration-150 disabled:cursor-not-allowed disabled:opacity-50 ${
+              isPrimarySelected
+                ? "text-sidebar-foreground/80 hover:text-foreground hover:bg-[hsl(var(--gray-300))]"
+                : "text-sidebar-foreground/80 hover:text-foreground hover:bg-[hsl(var(--gray-200))]"
+            }`}
+            aria-label="Open agent menu"
+          >
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span>
+                  <IconDots size={16} stroke={2} />
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                <p className="text-xs">More</p>
+              </TooltipContent>
+            </Tooltip>
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-44">
+          <DropdownMenuItem onSelect={removeFromList} disabled={savingPinned}>
+            <IconPinnedOff size={16} stroke={2} className="mr-2" />
+            Remove from list
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </TooltipProvider>
+  );
+}
+
+function PinnedAgentSideDecorator({
+  agentId,
+  isDefaultAgent,
+  isPrimarySelected,
+  hasUnread,
+}: {
+  agentId: string;
+  isDefaultAgent: boolean;
+  isPrimarySelected: boolean;
+  hasUnread: boolean;
+}) {
+  if (isDefaultAgent && !hasUnread) {
+    return null;
+  }
+
+  return (
+    <div className="pointer-events-none absolute right-0 top-0 flex h-8 w-8 items-center justify-center">
+      {!isDefaultAgent && (
+        <PinnedAgentMenu
+          agentId={agentId}
+          isPrimarySelected={isPrimarySelected}
+        />
+      )}
+      {hasUnread && (
+        <span className="flex items-center justify-center group-hover:hidden group-focus-within:hidden peer-data-[state=open]:hidden">
+          <AgentUnreadIndicator />
+        </span>
+      )}
+    </div>
+  );
+}
+
 function AgentListDialogContainer() {
   const open = useGet(chatListOpen$);
   const onOpenChange = useSet(setChatListOpen$);
@@ -133,6 +247,10 @@ export function PinnedAgentListSection() {
     typeof pathParams?.threadId === "string" ? pathParams.threadId : null;
   const sidebarAgentId = useLastResolved(currentChatAgentId$) ?? null;
   const pinnedAgentsLoadable = useLastLoadable(pinnedAgents$);
+  const features = useGet(featureSwitch$);
+  const agentUnreadIndicatorsEnabled =
+    features[FeatureSwitchKey.AgentUnreadIndicators] ?? false;
+  const unreadAgentIds = useLastResolved(unreadAgentIds$);
 
   const setChatListOpenFn = useSet(setChatListOpen$);
   const collapsed = useGet(agentCardCollapsed$);
@@ -202,6 +320,8 @@ export function PinnedAgentListSection() {
               const isPrimarySelected =
                 isChatRoute(activeRoute) && selectedAgentId === agent.id;
               const isFromChat = sidebarAgentId === agent.id;
+              const hasUnread = unreadAgentIds?.has(agent.id) ?? false;
+              const isDefaultAgent = agent.id === defaultAgentId;
               return (
                 <div
                   key={agent.id}
@@ -211,7 +331,9 @@ export function PinnedAgentListSection() {
                   <Link
                     pathname="/agents/:agentId/chat"
                     options={{ pathParams: { agentId: agent.id } }}
-                    className={`flex w-full h-8 shrink-0 items-center gap-2 rounded-lg px-2 text-left text-sm leading-5 no-underline transition-colors duration-200 ${
+                    className={`flex w-full h-8 shrink-0 items-center gap-2 rounded-lg text-left text-sm leading-5 no-underline transition-colors duration-200 ${
+                      agentUnreadIndicatorsEnabled ? "pl-2 pr-8" : "px-2"
+                    } ${
                       isPrimarySelected
                         ? "bg-gray-200 text-foreground font-medium"
                         : isFromChat
@@ -228,14 +350,21 @@ export function PinnedAgentListSection() {
                       {agent.displayName ?? agent.id}
                     </span>
                   </Link>
-                  {agent.id !== defaultAgentId && (
+                  {agentUnreadIndicatorsEnabled ? (
+                    <PinnedAgentSideDecorator
+                      agentId={agent.id}
+                      isDefaultAgent={isDefaultAgent}
+                      isPrimarySelected={isPrimarySelected}
+                      hasUnread={hasUnread}
+                    />
+                  ) : agent.id !== defaultAgentId ? (
                     <div className="absolute right-0 top-0 flex h-8 w-8 items-center justify-center">
                       <UnpinButton
                         agentId={agent.id}
                         isPrimarySelected={isPrimarySelected}
                       />
                     </div>
-                  )}
+                  ) : null}
                 </div>
               );
             })}

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -96,9 +96,7 @@ const persistedAttachmentSchema = z.object({
 
 /**
  * Per-agent unread snapshot. `unreadAt` is the creation time of the latest
- * visible message — the one that made the thread unread. Clients keep local
- * optimistic mark-read timestamps and drop them whenever a snapshot reports
- * an `unreadAt` newer than the local mark.
+ * visible message — the one that made the thread unread.
  */
 const chatThreadUnreadsSchema = z.object({
   unreads: z.array(
@@ -107,6 +105,10 @@ const chatThreadUnreadsSchema = z.object({
       unreadAt: z.string(),
     }),
   ),
+});
+
+const chatThreadUnreadAgentsSchema = z.object({
+  agentIds: z.array(z.string()),
 });
 
 const chatThreadListItemSchema = z.object({
@@ -451,7 +453,19 @@ export const chatThreadsContract = c.router({
       401: apiErrorSchema,
     },
     summary:
-      "List the caller's unread chat threads under an agent, each with the timestamp of the message that made it unread. Fetched separately from the thread list; mark-read returns the same snapshot so read state needs no broadcast.",
+      "List the caller's unread chat threads under an agent, each with the timestamp of the message that made it unread.",
+  },
+  unreadAgents: {
+    method: "GET",
+    path: "/api/zero/chat-thread-unread-agents",
+    headers: authHeadersSchema,
+    responses: {
+      200: chatThreadUnreadAgentsSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+    },
+    summary:
+      "List agent IDs with at least one unread chat thread for the caller.",
   },
 });
 
@@ -530,8 +544,8 @@ export const chatThreadMarkReadContract = c.router({
         lastReadMessageId: z.string().nullable(),
         /**
          * Fresh unread snapshot for the thread's agent (same shape as the
-         * unreads endpoint), so the caller syncs read state from the response
-         * instead of a broadcast-triggered refetch.
+         * unreads endpoint). Kept for response compatibility; clients should
+         * treat `chatThreadReadCursorUpdated` as read-state invalidation.
          */
         unreads: chatThreadUnreadsSchema.shape.unreads,
       }),
@@ -539,8 +553,7 @@ export const chatThreadMarkReadContract = c.router({
       401: apiErrorSchema,
       404: apiErrorSchema,
     },
-    summary:
-      "Mark a chat thread as read up to the latest message and return the agent's unread snapshot",
+    summary: "Mark a chat thread as read up to the latest message",
   },
 });
 

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -58,4 +58,5 @@ export enum FeatureSwitchKey {
   ComputerUseDelegatedAuthorization = "computerUseDelegatedAuthorization",
   ConnectorAccessManagement = "connectorAccessManagement",
   PresentationTemplateRunbook = "presentationTemplateRunbook",
+  AgentUnreadIndicators = "agentUnreadIndicators",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -340,6 +340,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.AgentUnreadIndicators]: {
+    maintainer: "ethan@vm0.ai",
+    description:
+      "Show chat unread indicators in sidebar pinned agent lists and the conversation picker.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
 };
 
 interface ResolvedHashes {


### PR DESCRIPTION
## Summary
- add an org-enabled feature switch for agent unread indicators
- add a feature-gated unread-agent IDs API using the same unread thread query semantics
- replace the unused per-thread read-cursor topic with generic chatThreadReadCursorUpdated and reload unread state from Ably
- show unread dots and three-dot menus in sidebar pinned agents and the conversation picker when the switch is enabled

## Verification
- pnpm --filter @vm0/app test src/views/zero-page/__tests__/zero-sidebar.test.tsx
- pnpm --filter @vm0/app check-types
- NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter api check-types
- pnpm --filter @vm0/app exec oxlint src/views/zero-page/zero-sidebar-dialogs.tsx src/views/zero-page/zero-sidebar-pinned.tsx src/views/zero-page/__tests__/zero-sidebar.test.tsx src/signals/chat-page/sidebar-unread-threads.ts src/signals/chat-page/remote-chat-thread-data-source.ts src/signals/chat-thread-list-reload.ts src/views/main.tsx src/mocks/handlers/api-agents.ts
- pnpm --filter api exec oxlint src/signals/routes/zero-chat-threads.ts src/signals/routes/zero-chat-threads-mark-read.ts src/signals/services/zero-chat-thread.service.ts src/signals/routes/__tests__/chat-threads.bdd.test.ts src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
- pnpm --filter @vm0/api-contracts exec oxlint src/contracts/chat-threads.ts
- pnpm --filter @vm0/connectors exec oxlint src/feature-switch-key.ts
- pnpm --filter @vm0/core exec oxlint src/feature-switch.ts

## Notes
- API BDD test command was attempted, but the local Postgres test database was unavailable (ECONNREFUSED), so the suite failed before exercising the new assertions.
