### PR TITLE
test: update billing redirect origin fixture

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-billing-checkout.test.ts
@@ -614,7 +614,7 @@ describe("POST /api/zero/billing/checkout", () => {
     });
   });
 
-  it("accepts successUrl on a first-party so.vm0.ai origin", async () => {
+  it("accepts successUrl on a first-party www.vm0.ai origin", async () => {
     const fixture = await trackedPendingSeed();
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
 
@@ -631,8 +631,8 @@ describe("POST /api/zero/billing/checkout", () => {
         body: {
           tier: "pro",
           trialDays: 7,
-          successUrl: "https://so.vm0.ai/onboarding?billing=pro",
-          cancelUrl: "https://so.vm0.ai/onboarding?billing=canceled",
+          successUrl: "https://www.vm0.ai/onboarding?billing=pro",
+          cancelUrl: "https://www.vm0.ai/onboarding?billing=canceled",
         },
         headers: { authorization: "Bearer clerk-session" },
       }),


### PR DESCRIPTION
## Summary
- update the billing checkout redirect fixture from `so.vm0.ai` to `www.vm0.ai`
- keep the test covering a first-party `*.vm0.ai` billing redirect origin

## Tests
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-billing-checkout.test.ts`
- `pnpm format`
- `pnpm turbo run lint`
- `pnpm -F api check-types`

## Notes
- `pnpm check-types` and `pnpm knip` are blocked locally by pre-existing untracked files under `turbo/packages/core/src/firewalls/` with unresolved `../contracts/firewalls` imports. Those files are not part of this PR.