### PR TITLE
feat: add zero chat rename command

### DIFF
--- a/turbo/apps/api/src/signals/auth/__tests__/tokens.test.ts
+++ b/turbo/apps/api/src/signals/auth/__tests__/tokens.test.ts
@@ -120,6 +120,12 @@ describe("auth tokens", () => {
     expect(verifyZeroToken(token)?.capabilities).toContain("maps:read");
   });
 
+  it("includes chat thread write capability in zero-scoped tokens", () => {
+    const token = generateZeroToken("user_zero", "run_zero", "org_zero");
+
+    expect(verifyZeroToken(token)?.capabilities).toContain("chat-thread:write");
+  });
+
   it("gates banking capability behind the banking feature switch", () => {
     const defaultToken = generateZeroToken("user_zero", "run_zero", "org_zero");
     const enabledToken = generateZeroToken(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-rename.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-chat-threads-rename.test.ts
@@ -1,0 +1,144 @@
+import { randomUUID } from "node:crypto";
+
+import { chatThreadRenameContract } from "@vm0/api-contracts/contracts/chat-threads";
+import type { ZeroCapability } from "@vm0/api-contracts/contracts/composes";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
+import { createStore } from "ccstate";
+import { eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { now } from "../../../lib/time";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+import { writeDb$ } from "../../external/db";
+import {
+  deleteZeroChatThread$,
+  seedZeroChatThread$,
+  type ZeroChatThreadFixture,
+} from "./helpers/zero-chat-threads";
+import {
+  deleteOrgMembership$,
+  seedOrgMembership$,
+  type OrgMembershipFixture,
+} from "./helpers/zero-org-membership";
+import { createFixtureTracker } from "./helpers/zero-route-test";
+
+const context = testContext();
+const store = createStore();
+
+function currentSecond(): number {
+  return Math.floor(now() / 1000);
+}
+
+function zeroToken(args: {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly capabilities: readonly ZeroCapability[];
+}): string {
+  const seconds = currentSecond();
+  return signSandboxJwtForTests({
+    scope: "zero",
+    userId: args.userId,
+    orgId: args.orgId,
+    runId: `run_${randomUUID()}`,
+    capabilities: [...args.capabilities],
+    iat: seconds,
+    exp: seconds + 600,
+  });
+}
+
+function client() {
+  return setupApp({ context })(chatThreadRenameContract);
+}
+
+describe("POST /api/zero/chat-threads/:id/rename", () => {
+  const trackThread = createFixtureTracker<ZeroChatThreadFixture>((fixture) => {
+    return store.set(deleteZeroChatThread$, fixture, context.signal);
+  });
+  const trackMembership = createFixtureTracker<OrgMembershipFixture>(
+    (fixture) => {
+      return store.set(deleteOrgMembership$, fixture, context.signal);
+    },
+  );
+
+  it("renames a thread with ZERO_TOKEN chat-thread:write capability", async () => {
+    const fixture = await trackThread(
+      store.set(
+        seedZeroChatThread$,
+        { title: "Original title" },
+        context.signal,
+      ),
+    );
+    await trackMembership(
+      store.set(
+        seedOrgMembership$,
+        { orgId: fixture.orgId, userId: fixture.userId },
+        context.signal,
+      ),
+    );
+    const token = zeroToken({
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      capabilities: ["chat-thread:write"],
+    });
+
+    const response = await accept(
+      client().rename({
+        headers: { authorization: `Bearer ${token}` },
+        params: { id: fixture.threadId },
+        body: { title: "CLI renamed title" },
+      }),
+      [204],
+    );
+    expect(response.status).toBe(204);
+
+    const [thread] = await store
+      .set(writeDb$)
+      .select({ title: chatThreads.title, renamedAt: chatThreads.renamedAt })
+      .from(chatThreads)
+      .where(eq(chatThreads.id, fixture.threadId))
+      .limit(1);
+    expect(thread).toStrictEqual({
+      title: "CLI renamed title",
+      renamedAt: expect.any(Date),
+    });
+  });
+
+  it("rejects ZERO_TOKEN without chat-thread:write capability", async () => {
+    const fixture = await trackThread(
+      store.set(
+        seedZeroChatThread$,
+        { title: "Original title" },
+        context.signal,
+      ),
+    );
+    await trackMembership(
+      store.set(
+        seedOrgMembership$,
+        { orgId: fixture.orgId, userId: fixture.userId },
+        context.signal,
+      ),
+    );
+    const token = zeroToken({
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      capabilities: ["chat-message:read"],
+    });
+
+    const response = await accept(
+      client().rename({
+        headers: { authorization: `Bearer ${token}` },
+        params: { id: fixture.threadId },
+        body: { title: "Unauthorized title" },
+      }),
+      [403],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        code: "FORBIDDEN",
+        message: "Missing required capability: chat-thread:write",
+      },
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads-rename.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads-rename.ts
@@ -47,6 +47,9 @@ const renameInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 export const zeroChatThreadRenameRoutes: readonly RouteEntry[] = [
   {
     route: chatThreadRenameContract.rename,
-    handler: authRoute({}, renameInner$),
+    handler: authRoute(
+      { requiredCapability: "chat-thread:write" },
+      renameInner$,
+    ),
   },
 ];

--- a/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
@@ -20,6 +20,7 @@ function buildCommands(): Command[] {
     new Command("connector"),
     new Command("credit"),
     new Command("logs"),
+    new Command("chat"),
     new Command("resource"),
     new Command("preference"),
     new Command("schedule"),
@@ -156,6 +157,7 @@ describe("registerZeroCommands", () => {
       "connector",
       "credit",
       "logs",
+      "chat",
       "preference",
       "schedule",
       "secret",
@@ -259,6 +261,19 @@ describe("registerZeroCommands", () => {
     const prog = buildProgram();
 
     expect(visibleCommandNames(prog)).toContain("github");
+    expect(visibleCommandNames(prog)).toContain("whoami");
+  });
+
+  it("should show chat when chat-thread:write capability is present", () => {
+    const token = buildZeroToken({
+      scope: "zero",
+      capabilities: ["chat-thread:write"],
+    });
+    vi.stubEnv("ZERO_TOKEN", token);
+
+    const prog = buildProgram();
+
+    expect(visibleCommandNames(prog)).toContain("chat");
     expect(visibleCommandNames(prog)).toContain("whoami");
   });
 

--- a/turbo/apps/cli/src/__tests__/zero.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero.test.ts
@@ -22,6 +22,7 @@ describe("zero CLI program", () => {
       "doctor",
       "logs",
       "search",
+      "chat",
       "resource",
       "preference",
       "schedule",
@@ -66,7 +67,7 @@ describe("zero CLI program", () => {
     }
   });
 
-  it("should have exactly 30 commands", () => {
-    expect(commandNames).toHaveLength(30);
+  it("should have exactly 31 commands", () => {
+    expect(commandNames).toHaveLength(31);
   });
 });

--- a/turbo/apps/cli/src/commands/zero/chat/__tests__/rename.test.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/__tests__/rename.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Tests for zero chat rename command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): backend rename route via MSW
+ * - Real (internal): CLI argument parsing, API client, env handling
+ */
+
+import chalk from "chalk";
+import { HttpResponse, http } from "msw";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { server } from "../../../../mocks/server";
+import { zeroChatCommand } from "../index";
+
+const THREAD_ID = "00000000-0000-4000-8000-000000000001";
+const RENAME_URL = `http://localhost:3000/api/zero/chat-threads/${THREAD_ID}/rename`;
+
+describe("zero chat rename command", () => {
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("ZERO_TOKEN", "test-zero-token");
+    vi.stubEnv("ZERO_CHAT_THREAD_ID", THREAD_ID);
+  });
+
+  afterEach(() => {
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+    mockExit.mockClear();
+    vi.unstubAllEnvs();
+  });
+
+  it("renames the current chat thread and prints a human-readable summary", async () => {
+    server.use(
+      http.post(RENAME_URL, async ({ request }) => {
+        expect(request.headers.get("authorization")).toBe(
+          "Bearer test-zero-token",
+        );
+        await expect(request.json()).resolves.toStrictEqual({
+          title: "Launch plan",
+        });
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    await zeroChatCommand.parseAsync([
+      "node",
+      "cli",
+      "rename",
+      "Launch",
+      "plan",
+    ]);
+
+    const output = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(output).toContain("Chat title updated");
+    expect(output).toContain(`Thread: ${THREAD_ID}`);
+    expect(output).toContain("Title:  Launch plan");
+  });
+
+  it("prints JSON output when --json is passed", async () => {
+    server.use(
+      http.post(RENAME_URL, async ({ request }) => {
+        await expect(request.json()).resolves.toStrictEqual({
+          title: "Launch plan",
+        });
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    await zeroChatCommand.parseAsync([
+      "node",
+      "cli",
+      "rename",
+      "Launch",
+      "plan",
+      "--json",
+    ]);
+
+    expect(JSON.parse(String(mockConsoleLog.mock.calls[0]?.[0]))).toStrictEqual(
+      {
+        threadId: THREAD_ID,
+        title: "Launch plan",
+      },
+    );
+  });
+
+  it("rejects whitespace-only titles before calling the API", async () => {
+    await expect(async () => {
+      await zeroChatCommand.parseAsync(["node", "cli", "rename", "   "]);
+    }).rejects.toThrow("process.exit called");
+
+    const stderr = mockConsoleError.mock.calls.flat().join("\n");
+    expect(stderr).toContain("Title is required");
+    expect(stderr).toContain('Run: zero chat rename "New title"');
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  it("requires ZERO_CHAT_THREAD_ID from the current web chat", async () => {
+    vi.stubEnv("ZERO_CHAT_THREAD_ID", undefined);
+
+    await expect(async () => {
+      await zeroChatCommand.parseAsync([
+        "node",
+        "cli",
+        "rename",
+        "Launch plan",
+      ]);
+    }).rejects.toThrow("process.exit called");
+
+    const stderr = mockConsoleError.mock.calls.flat().join("\n");
+    expect(stderr).toContain("ZERO_CHAT_THREAD_ID is not set");
+    expect(stderr).toContain("Run this command from a Zero web chat thread.");
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/chat/index.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/index.ts
@@ -1,0 +1,14 @@
+import { Command } from "commander";
+
+import { renameCommand } from "./rename";
+
+export const zeroChatCommand = new Command()
+  .name("chat")
+  .description("Manage the current web chat thread")
+  .addCommand(renameCommand)
+  .addHelpText(
+    "after",
+    `
+Examples:
+  Rename this chat:  zero chat rename "Launch plan"`,
+  );

--- a/turbo/apps/cli/src/commands/zero/chat/rename.ts
+++ b/turbo/apps/cli/src/commands/zero/chat/rename.ts
@@ -1,0 +1,64 @@
+import chalk from "chalk";
+import { Command } from "commander";
+
+import { renameZeroChatThread } from "../../../lib/api";
+import { withErrorHandler } from "../../../lib/command";
+
+interface RenameOptions {
+  readonly json?: boolean;
+}
+
+function getCurrentChatThreadId(): string | undefined {
+  return process.env.ZERO_CHAT_THREAD_ID?.trim() || undefined;
+}
+
+function printUsageError(message: string, hint: string): never {
+  console.error(chalk.red(`✗ ${message}`));
+  console.error(chalk.dim(`  ${hint}`));
+  process.exit(1);
+}
+
+export const renameCommand = new Command()
+  .name("rename")
+  .description("Rename the current web chat thread")
+  .argument("<title...>", "New chat title")
+  .option("--json", "Print machine-readable JSON")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  Rename this chat:  zero chat rename "Launch plan"
+
+Notes:
+  - Uses ZERO_CHAT_THREAD_ID from the current web chat thread
+  - Authenticates via ZERO_TOKEN (requires chat-thread:write capability)`,
+  )
+  .action(
+    withErrorHandler(async (titleParts: string[], options: RenameOptions) => {
+      const title = titleParts.join(" ").trim();
+      if (!title) {
+        printUsageError(
+          "Title is required",
+          'Run: zero chat rename "New title"',
+        );
+      }
+
+      const threadId = getCurrentChatThreadId();
+      if (!threadId) {
+        printUsageError(
+          "ZERO_CHAT_THREAD_ID is not set",
+          "Run this command from a Zero web chat thread.",
+        );
+      }
+
+      const result = await renameZeroChatThread({ threadId, title });
+      if (options.json) {
+        console.log(JSON.stringify(result));
+        return;
+      }
+
+      console.log(chalk.green("✓ Chat title updated"));
+      console.log(chalk.dim(`  Thread: ${result.threadId}`));
+      console.log(chalk.dim(`  Title:  ${result.title}`));
+    }),
+  );

--- a/turbo/apps/cli/src/lib/api/domains/zero-chat.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-chat.ts
@@ -1,5 +1,6 @@
 import { initClient } from "@vm0/api-contracts/contracts/trpc-contract";
 import {
+  chatThreadRenameContract,
   chatSearchContract,
   type ChatSearchResponse,
 } from "@vm0/api-contracts/contracts/chat-threads";
@@ -27,4 +28,20 @@ export async function searchZeroChat(options: {
   });
   if (result.status === 200) return result.body;
   handleError(result, "Failed to search chat messages");
+}
+
+export async function renameZeroChatThread(options: {
+  threadId: string;
+  title: string;
+}): Promise<{ threadId: string; title: string }> {
+  const config = await getClientConfig();
+  const client = initClient(chatThreadRenameContract, config);
+  const result = await client.rename({
+    params: { id: options.threadId },
+    body: { title: options.title },
+  });
+  if (result.status === 204) {
+    return { threadId: options.threadId, title: options.title };
+  }
+  handleError(result, "Failed to rename chat thread");
 }

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -211,7 +211,7 @@ export { getZeroRunAgentEvents } from "./domains/zero-runs";
 export { listZeroLogs, searchZeroLogs } from "./domains/zero-logs";
 
 // Domain modules - Zero Chat
-export { searchZeroChat } from "./domains/zero-chat";
+export { renameZeroChatThread, searchZeroChat } from "./domains/zero-chat";
 
 // Domain modules - Logs
 export {

--- a/turbo/apps/cli/src/zero.ts
+++ b/turbo/apps/cli/src/zero.ts
@@ -38,6 +38,7 @@ const COMMAND_CAPABILITY_MAP: Record<
   "model-provider": null,
   logs: "agent-run:read",
   search: "chat-message:read",
+  chat: "chat-thread:write",
   resource: null,
   github: ["github:read", "github:write"],
   slack: "slack:write",
@@ -184,6 +185,13 @@ const ZERO_COMMAND_DEFINITIONS: readonly ZeroCommandDefinition[] = [
     description: "Search logs, chat, or get a recipe for external sources",
     load: async () => {
       return (await import("./commands/zero/search")).zeroSearchCommand;
+    },
+  },
+  {
+    name: "chat",
+    description: "Manage the current web chat thread",
+    load: async () => {
+      return (await import("./commands/zero/chat")).zeroChatCommand;
     },
   },
   {
@@ -382,6 +390,9 @@ export function buildZeroHelpText(
     "  Model routing?        zero model-provider ls",
     "  Update yourself?       zero agent --help",
     "  Manage workflows?     zero workflow --help",
+    ...(shouldHideCommand("chat", payload)
+      ? []
+      : ['  Rename this chat?     zero chat rename "New title"']),
     "  List generators?       zero generate --help",
     '  Generate image?        zero generate image --prompt "..."',
     '  Generate website?      zero generate website --prompt "..."',

--- a/turbo/packages/api-contracts/src/contracts/__tests__/composes.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/composes.test.ts
@@ -40,8 +40,8 @@ describe("agentDefinitionSchema strips unknown experimental_capabilities", () =>
 });
 
 describe("ZERO_CAPABILITIES", () => {
-  it("should have exactly 29 capabilities", () => {
-    expect(ZERO_CAPABILITIES).toHaveLength(29);
+  it("should have exactly 30 capabilities", () => {
+    expect(ZERO_CAPABILITIES).toHaveLength(30);
   });
 
   it("should follow {resource}:{action} naming pattern", () => {
@@ -102,6 +102,10 @@ describe("ZERO_CAPABILITIES", () => {
     expect(ZERO_CAPABILITIES).toContain("goal:read");
     expect(ZERO_CAPABILITIES).toContain("goal:agent-result:write");
     expect(ZERO_CAPABILITIES).toContain("goal:user-control:write");
+  });
+
+  it("should include chat thread write capability", () => {
+    expect(ZERO_CAPABILITIES).toContain("chat-thread:write");
   });
 });
 

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -620,6 +620,7 @@ export const chatThreadRenameContract = c.router({
       204: c.noBody(),
       400: apiErrorSchema,
       401: apiErrorSchema,
+      403: apiErrorSchema,
       404: apiErrorSchema,
     },
     summary: "Rename a chat thread (suppresses automated title generation)",

--- a/turbo/packages/api-contracts/src/contracts/composes.ts
+++ b/turbo/packages/api-contracts/src/contracts/composes.ts
@@ -56,6 +56,7 @@ export const ZERO_CAPABILITIES = [
   "telegram:read",
   "telegram:write",
   "chat-message:read",
+  "chat-thread:write",
   "connector:read",
   "billing:read",
   "billing:write",
@@ -135,6 +136,10 @@ export const ZERO_CAPABILITY_META: Record<ZeroCapability, ZeroCapabilityMeta> =
     "chat-message:read": {
       group: "Integrations",
       label: "Read chat messages",
+    },
+    "chat-thread:write": {
+      group: "Chat Threads",
+      label: "Update chat thread metadata",
     },
     "connector:read": { group: "Connectors", label: "View connected services" },
     "billing:read": { group: "Billing", label: "View billing and credits" },


### PR DESCRIPTION
Summary:
- Add `chat-thread:write` as a dedicated ZERO_TOKEN capability and require it on the chat thread rename endpoint.
- Add `zero chat rename <title...>` for renaming the current web chat thread via `ZERO_CHAT_THREAD_ID`, with optional `--json` output.
- Cover capability metadata, token generation, CLI visibility, CLI behavior, and rename route authorization.

Testing:
- `pnpm --filter @vm0/cli exec vitest run src/commands/zero/chat/__tests__/rename.test.ts src/__tests__/zero-capability-visibility.test.ts --testTimeout=15000`
- `pnpm --filter @vm0/api-contracts exec vitest run src/contracts/__tests__/composes.test.ts`
- `pnpm --filter api exec vitest run src/signals/auth/__tests__/tokens.test.ts`
- `pnpm --filter @vm0/cli check-types`
- `pnpm --filter @vm0/api-contracts check-types`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter api check-types`
- `pnpm --filter @vm0/cli lint`
- `pnpm --filter @vm0/api-contracts lint`
- `pnpm --filter api lint`

Note:
- `pnpm --filter api exec vitest run src/signals/routes/__tests__/zero-chat-threads-rename.test.ts` was attempted locally but requires Postgres on `localhost:5432`; this sandbox has no local DB, so it failed with `ECONNREFUSED` before hitting route assertions.