### PR TITLE
Remove fake Codex OAuth denied permission

### DIFF
--- a/crates/runner/mitm-addon/src/generated/builtin_firewalls/diagnostics.py
+++ b/crates/runner/mitm-addon/src/generated/builtin_firewalls/diagnostics.py
@@ -4720,14 +4720,7 @@ MODEL_PROVIDER_DIAGNOSTIC_EXCLUSIONS = json.loads(r"""[
       },
       {
         "base": "https://auth.openai.com",
-        "permissions": [
-          {
-            "name": "denied",
-            "rules": [
-              "ANY /*"
-            ]
-          }
-        ]
+        "permissions": []
       }
     ],
     "name": "model-provider:codex-oauth-token"

--- a/crates/runner/mitm-addon/src/generated/builtin_firewalls/model_provider_codex_oauth_token_0.py
+++ b/crates/runner/mitm-addon/src/generated/builtin_firewalls/model_provider_codex_oauth_token_0.py
@@ -15,6 +15,7 @@ JSON_PART = r"""{
       "base": "https://chatgpt.com/backend-api/codex",
       "permissions": [
         {
+          "description": "Access the ChatGPT Codex backend with GET and POST requests.",
           "name": "codex:api",
           "rules": [
             "GET /{path*}",
@@ -28,14 +29,7 @@ JSON_PART = r"""{
         "headers": {}
       },
       "base": "https://auth.openai.com",
-      "permissions": [
-        {
-          "name": "denied",
-          "rules": [
-            "ANY /*"
-          ]
-        }
-      ]
+      "permissions": []
     }
   ],
   "name": "model-provider:codex-oauth-token"

--- a/crates/runner/mitm-addon/tests/test_builtin_firewalls_catalog.py
+++ b/crates/runner/mitm-addon/tests/test_builtin_firewalls_catalog.py
@@ -259,14 +259,22 @@ def test_model_provider_builtin_firewalls_are_available():
     assert openai_firewall is not None
     assert openai_firewall["apis"][0]["base"] == "https://api.openai.com/v1/responses"
     assert codex_firewall is not None
-    assert any(
-        api["base"] == "https://chatgpt.com/backend-api/codex" for api in codex_firewall["apis"]
-    )
-    assert any(
-        api["base"] == "https://auth.openai.com"
-        and api.get("permissions") == [{"name": "denied", "rules": ["ANY /*"]}]
+    codex_api = next(
+        api
         for api in codex_firewall["apis"]
+        if api["base"] == "https://chatgpt.com/backend-api/codex"
     )
+    assert codex_api.get("permissions") == [
+        {
+            "name": "codex:api",
+            "description": "Access the ChatGPT Codex backend with GET and POST requests.",
+            "rules": ["GET /{path*}", "POST /{path*}"],
+        }
+    ]
+    auth_api = next(
+        api for api in codex_firewall["apis"] if api["base"] == "https://auth.openai.com"
+    )
+    assert auth_api.get("permissions") == []
 
 
 def test_unknown_builtin_firewall_does_not_import(monkeypatch):

--- a/crates/runner/mitm-addon/tests/test_firewall_network_policy_decisions.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_network_policy_decisions.py
@@ -82,6 +82,36 @@ class TestFirewallNetworkPolicyDecisions:
             }
         }
 
+    def test_codex_oauth_auth_host_is_blocked_by_unknown_policy(self):
+        firewalls = [builtin_firewalls.BUILTIN_FIREWALLS["model-provider:codex-oauth-token"]]
+        policies = {
+            "model-provider:codex-oauth-token": {
+                "allow": ["codex:api"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "deny",
+            }
+        }
+
+        auth_result = match_request_with_raw_firewalls(
+            "https://auth.openai.com/oauth/token",
+            "POST",
+            firewalls,
+            network_policies=policies,
+        )
+        codex_result = match_request_with_raw_firewalls(
+            "https://chatgpt.com/backend-api/codex/responses",
+            "POST",
+            firewalls,
+            network_policies=policies,
+        )
+
+        assert isinstance(auth_result, matching.FirewallBlock)
+        assert auth_result.reason == "unknown_endpoint"
+        assert auth_result.permissions == ()
+        assert isinstance(codex_result, matching.FirewallAllow)
+        assert codex_result.permission == "codex:api"
+
     def test_allowed_permission_passes(self):
         policies = {
             "github": {"allow": ["repo-read"], "deny": ["repo-write"], "unknownPolicy": "deny"}

--- a/crates/runner/mitm-addon/tests/test_firewall_network_policy_decisions.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_network_policy_decisions.py
@@ -1,7 +1,5 @@
 """Raw firewall request network policy decision tests."""
 
-import copy
-
 import pytest
 
 import generated.builtin_firewalls as builtin_firewalls
@@ -89,7 +87,7 @@ class TestFirewallNetworkPolicyDecisions:
         policies = {
             "model-provider:codex-oauth-token": {
                 "allow": ["codex:api"],
-                "deny": ["denied"],
+                "deny": [],
                 "ask": [],
                 "unknownPolicy": "deny",
             }
@@ -113,31 +111,6 @@ class TestFirewallNetworkPolicyDecisions:
         assert auth_result.permissions == ()
         assert isinstance(codex_result, matching.FirewallAllow)
         assert codex_result.permission == "codex:api"
-
-    def test_codex_oauth_legacy_denied_policy_blocks_old_runner_catalog(self):
-        firewall = copy.deepcopy(
-            builtin_firewalls.BUILTIN_FIREWALLS["model-provider:codex-oauth-token"]
-        )
-        firewall["apis"][1]["permissions"] = [{"name": "denied", "rules": ["ANY /*"]}]
-        policies = {
-            "model-provider:codex-oauth-token": {
-                "allow": ["codex:api"],
-                "deny": ["denied"],
-                "ask": [],
-                "unknownPolicy": "deny",
-            }
-        }
-
-        result = match_request_with_raw_firewalls(
-            "https://auth.openai.com/*",
-            "POST",
-            [firewall],
-            network_policies=policies,
-        )
-
-        assert isinstance(result, matching.FirewallBlock)
-        assert result.reason == "permission_denied"
-        assert result.permissions == ("denied",)
 
     def test_allowed_permission_passes(self):
         policies = {

--- a/crates/runner/mitm-addon/tests/test_firewall_network_policy_decisions.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_network_policy_decisions.py
@@ -1,5 +1,7 @@
 """Raw firewall request network policy decision tests."""
 
+import copy
+
 import pytest
 
 import generated.builtin_firewalls as builtin_firewalls
@@ -87,7 +89,7 @@ class TestFirewallNetworkPolicyDecisions:
         policies = {
             "model-provider:codex-oauth-token": {
                 "allow": ["codex:api"],
-                "deny": [],
+                "deny": ["denied"],
                 "ask": [],
                 "unknownPolicy": "deny",
             }
@@ -111,6 +113,31 @@ class TestFirewallNetworkPolicyDecisions:
         assert auth_result.permissions == ()
         assert isinstance(codex_result, matching.FirewallAllow)
         assert codex_result.permission == "codex:api"
+
+    def test_codex_oauth_legacy_denied_policy_blocks_old_runner_catalog(self):
+        firewall = copy.deepcopy(
+            builtin_firewalls.BUILTIN_FIREWALLS["model-provider:codex-oauth-token"]
+        )
+        firewall["apis"][1]["permissions"] = [{"name": "denied", "rules": ["ANY /*"]}]
+        policies = {
+            "model-provider:codex-oauth-token": {
+                "allow": ["codex:api"],
+                "deny": ["denied"],
+                "ask": [],
+                "unknownPolicy": "deny",
+            }
+        }
+
+        result = match_request_with_raw_firewalls(
+            "https://auth.openai.com/*",
+            "POST",
+            [firewall],
+            network_policies=policies,
+        )
+
+        assert isinstance(result, matching.FirewallBlock)
+        assert result.reason == "permission_denied"
+        assert result.permissions == ("denied",)
 
     def test_allowed_permission_passes(self):
         policies = {

--- a/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
@@ -960,7 +960,6 @@ describe("codex-oauth-token codex provider", () => {
   it("firewall denies auth.openai.com via unknown endpoint policy", () => {
     const config = MODEL_PROVIDER_FIREWALL_CONFIGS["codex-oauth-token"];
     expect(config.defaultPolicies).toEqual({
-      deny: ["denied"],
       unknownPolicy: "deny",
     });
     expect(config.apis[1]!.permissions).toEqual([]);
@@ -974,11 +973,10 @@ describe("codex-oauth-token codex provider", () => {
     "auth.openai.com matches no allow permission for %s %s",
     (method, path) => {
       // auth.openai.com intentionally exposes no grantable permissions. The
-      // deny is delivered by defaultPolicies.unknownPolicy: "deny" (asserted
-      // just above), so traffic to auth.openai.com must NOT resolve to any
-      // permission name on apis[1]. This pins behavior so a future edit to
-      // `apis[1].permissions` breaks the test rather than silently widening
-      // auth.openai.com.
+      // deny is delivered by defaultPolicies.unknownPolicy: "deny", so traffic
+      // to auth.openai.com must NOT resolve to any permission name on apis[1].
+      // This pins behavior so a future edit to `apis[1].permissions` breaks the
+      // test rather than silently widening auth.openai.com.
       const config = MODEL_PROVIDER_FIREWALL_CONFIGS["codex-oauth-token"];
       const fwConfig = { name: config.name, apis: [config.apis[1]!] };
       expect(findMatchingPermissions(method, path, fwConfig)).toEqual([]);

--- a/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
@@ -960,6 +960,7 @@ describe("codex-oauth-token codex provider", () => {
   it("firewall denies auth.openai.com via unknown endpoint policy", () => {
     const config = MODEL_PROVIDER_FIREWALL_CONFIGS["codex-oauth-token"];
     expect(config.defaultPolicies).toEqual({
+      deny: ["denied"],
       unknownPolicy: "deny",
     });
     expect(config.apis[1]!.permissions).toEqual([]);

--- a/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
@@ -922,6 +922,8 @@ describe("codex-oauth-token codex provider", () => {
     expect(config.apis[0]!.permissions).toEqual([
       {
         name: "codex:api",
+        description:
+          "Access the ChatGPT Codex backend with GET and POST requests.",
         rules: ["GET /{path*}", "POST /{path*}"],
       },
     ]);
@@ -955,15 +957,12 @@ describe("codex-oauth-token codex provider", () => {
     },
   );
 
-  it("firewall denies auth.openai.com via defaultPolicies + permission rule", () => {
+  it("firewall denies auth.openai.com via unknown endpoint policy", () => {
     const config = MODEL_PROVIDER_FIREWALL_CONFIGS["codex-oauth-token"];
     expect(config.defaultPolicies).toEqual({
-      deny: ["denied"],
       unknownPolicy: "deny",
     });
-    expect(config.apis[1]!.permissions).toEqual([
-      { name: "denied", rules: ["ANY /*"] },
-    ]);
+    expect(config.apis[1]!.permissions).toEqual([]);
   });
 
   it.each([
@@ -973,13 +972,12 @@ describe("codex-oauth-token codex provider", () => {
   ] as const)(
     "auth.openai.com matches no allow permission for %s %s",
     (method, path) => {
-      // The `ANY /*` rule on apis[1] is a literal-segment match on "*" and
-      // never matches real traffic — that's intentional. The deny is
-      // delivered by defaultPolicies.unknownPolicy: "deny" (asserted just
-      // above), so traffic to auth.openai.com must NOT resolve to any
-      // permission name on apis[1]. This pins behavior so a future edit
-      // to `apis[1].permissions` (e.g. adding an allow rule) breaks the
-      // test rather than silently widening auth.openai.com.
+      // auth.openai.com intentionally exposes no grantable permissions. The
+      // deny is delivered by defaultPolicies.unknownPolicy: "deny" (asserted
+      // just above), so traffic to auth.openai.com must NOT resolve to any
+      // permission name on apis[1]. This pins behavior so a future edit to
+      // `apis[1].permissions` breaks the test rather than silently widening
+      // auth.openai.com.
       const config = MODEL_PROVIDER_FIREWALL_CONFIGS["codex-oauth-token"];
       const fwConfig = { name: config.name, apis: [config.apis[1]!] };
       expect(findMatchingPermissions(method, path, fwConfig)).toEqual([]);

--- a/turbo/packages/api-contracts/src/contracts/model-provider-firewalls.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-provider-firewalls.ts
@@ -257,9 +257,6 @@ export const MODEL_PROVIDER_FIREWALL_CONFIGS = {
       },
     ],
     defaultPolicies: {
-      // Keep the legacy name denied during rolling deploys so new API-created
-      // policies still block old runner catalogs that exposed denied: ANY /*.
-      deny: ["denied"],
       unknownPolicy: "deny",
     },
     placeholders: {

--- a/turbo/packages/api-contracts/src/contracts/model-provider-firewalls.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-provider-firewalls.ts
@@ -229,7 +229,7 @@ export const MODEL_PROVIDER_FIREWALL_CONFIGS = {
     { name: "Authorization", valuePrefix: "Bearer" },
     MODEL_PROVIDER_ENV_PLACEHOLDERS.OPENAI_API_KEY,
   ),
-  // ChatGPT OAuth provider: multi-header injection plus auth.openai.com deny.
+  // ChatGPT OAuth provider: multi-header injection plus unknown-policy auth.openai.com deny.
   "codex-oauth-token": {
     name: "model-provider:codex-oauth-token",
     apis: [
@@ -244,6 +244,8 @@ export const MODEL_PROVIDER_FIREWALL_CONFIGS = {
         permissions: [
           {
             name: "codex:api",
+            description:
+              "Access the ChatGPT Codex backend with GET and POST requests.",
             rules: ["GET /{path*}", "POST /{path*}"],
           },
         ],
@@ -251,11 +253,10 @@ export const MODEL_PROVIDER_FIREWALL_CONFIGS = {
       {
         base: "https://auth.openai.com",
         auth: { headers: {} },
-        permissions: [{ name: "denied", rules: ["ANY /*"] }],
+        permissions: [],
       },
     ],
     defaultPolicies: {
-      deny: ["denied"],
       unknownPolicy: "deny",
     },
     placeholders: {

--- a/turbo/packages/api-contracts/src/contracts/model-provider-firewalls.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-provider-firewalls.ts
@@ -257,6 +257,9 @@ export const MODEL_PROVIDER_FIREWALL_CONFIGS = {
       },
     ],
     defaultPolicies: {
+      // Keep the legacy name denied during rolling deploys so new API-created
+      // policies still block old runner catalogs that exposed denied: ANY /*.
+      deny: ["denied"],
       unknownPolicy: "deny",
     },
     placeholders: {


### PR DESCRIPTION
## Summary
- remove the fake `denied` permission from the Codex OAuth model-provider firewall metadata
- keep `auth.openai.com` blocked by `unknownPolicy: "deny"` with no grantable permissions
- add the `codex:api` description and regenerate the mitm-addon builtin firewall data

## Tests
- `pnpm -F @vm0/api-contracts exec vitest src/contracts/__tests__/model-providers.test.ts`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/firewalls-generator generate`
- `PYTHONPATH=/tmp/vm5-mitm-addon-pydeps-19371:src python3 -m pytest tests/test_builtin_firewalls_catalog.py tests/test_firewall_network_policy_decisions.py -q`
- pre-commit: ruff, prettier, knip, full `pnpm check-types`

Closes #19371