### PR TITLE
fix: enforce runtime builtin host policies

### DIFF
--- a/crates/runner/mitm-addon/src/builtin_host_policy.py
+++ b/crates/runner/mitm-addon/src/builtin_host_policy.py
@@ -4,9 +4,13 @@ import ipaddress
 import re
 import urllib.parse
 
-from firewall_auth_config import auth_config_injects_credentials
+from firewall_auth_config import (
+    auth_config_injects_credentials,
+    auth_config_injects_ordinary_upstream_credentials,
+)
 from url_syntax import has_raw_whitespace, has_unsafe_url_codepoint
 
+BUILTIN_HOST_POLICY_RUNTIME_MARKER = "_vm0BuiltinHostPolicy"
 _DEFAULT_HTTPS_PORT = 443
 _MIN_FIXED_HOST_OWNERSHIP_LABELS = 2
 _HOST_DOT_EQUIVALENT_TRANSLATION = str.maketrans(
@@ -59,6 +63,15 @@ class BuiltinHostPolicyError(ValueError):
     """Builtin firewall host policy rejected a credentialed runtime base URL."""
 
 
+class BuiltinRuntimeHostPolicyError(ValueError):
+    """Builtin firewall host policy rejected a credentialed request destination."""
+
+    def __init__(self, *, reason: str, message: str) -> None:
+        super().__init__(message)
+        self.reason = reason
+        self.message = message
+
+
 def validate_credentialed_builtin_base(
     *,
     firewall_name: str,
@@ -79,6 +92,33 @@ def validate_credentialed_builtin_base(
         parsed=parsed,
         host_policy=host_policy,
     )
+
+
+def validate_credentialed_builtin_request_destination(
+    *,
+    firewall_name: str,
+    trusted_host: str,
+    trusted_port: int,
+    auth_config: object,
+    host_policy: object,
+    upstream_endpoint: tuple[str, int] | None,
+) -> None:
+    if not auth_config_injects_ordinary_upstream_credentials(auth_config):
+        return
+    try:
+        _validate_builtin_runtime_host_policy(
+            firewall_name=firewall_name,
+            trusted_host=trusted_host,
+            trusted_port=trusted_port,
+            host_policy=host_policy,
+            upstream_endpoint=upstream_endpoint,
+        )
+    except BuiltinHostPolicyError as e:
+        raise _runtime_host_policy_error(
+            reason="invalid_host_policy",
+            firewall_name=firewall_name,
+            message=str(e),
+        ) from e
 
 
 def _normalize_host_policy_hostname(hostname: str) -> str:
@@ -317,6 +357,126 @@ def _validate_public_destination_host_policy(
             f'builtin firewall "{firewall_name}" host policy does not allow '
             f'non-public IP literal "{hostname}"'
         )
+
+
+def _runtime_host_policy_error(
+    *,
+    reason: str,
+    firewall_name: str,
+    message: str,
+) -> BuiltinRuntimeHostPolicyError:
+    return BuiltinRuntimeHostPolicyError(
+        reason=reason,
+        message=f'builtin firewall "{firewall_name}" {message}',
+    )
+
+
+def _validate_provider_owned_runtime_host_policy(
+    *,
+    firewall_name: str,
+    trusted_host: str,
+    trusted_port: int,
+    policy: dict,
+) -> None:
+    hostname = _normalize_host_policy_hostname(trusted_host)
+    exact_hosts = _host_policy_string_list(policy, "exactHosts")
+    suffixes = _host_policy_string_list(policy, "suffixes")
+    allow_non_default_port = _host_policy_optional_bool(
+        firewall_name=firewall_name,
+        policy=policy,
+        key="allowNonDefaultPort",
+    )
+    if not _provider_owned_host_matches(
+        hostname,
+        exact_hosts=exact_hosts,
+        suffixes=suffixes,
+    ):
+        raise _runtime_host_policy_error(
+            reason="provider_host_not_allowed",
+            firewall_name=firewall_name,
+            message=f'host policy does not allow request host "{hostname}"',
+        )
+    if not allow_non_default_port and trusted_port != _DEFAULT_HTTPS_PORT:
+        raise _runtime_host_policy_error(
+            reason="provider_non_default_port",
+            firewall_name=firewall_name,
+            message="host policy does not allow non-default request ports",
+        )
+
+
+def _validate_public_destination_runtime_host_policy(
+    *,
+    firewall_name: str,
+    trusted_host: str,
+    upstream_endpoint: tuple[str, int] | None,
+) -> None:
+    hostname = _normalize_host_policy_hostname(trusted_host)
+    public_ip_literal = _ip_literal_is_public(hostname)
+    if public_ip_literal is False:
+        raise _runtime_host_policy_error(
+            reason="public_host_non_public_ip",
+            firewall_name=firewall_name,
+            message=f'host policy does not allow non-public request IP "{hostname}"',
+        )
+    if upstream_endpoint is None:
+        return
+    endpoint_host, _endpoint_port = upstream_endpoint
+    public_endpoint_ip_literal = _ip_literal_is_public(endpoint_host)
+    if public_endpoint_ip_literal is False:
+        raise _runtime_host_policy_error(
+            reason="public_endpoint_non_public_ip",
+            firewall_name=firewall_name,
+            message=f'host policy does not allow non-public upstream IP "{endpoint_host}"',
+        )
+
+
+def _validate_builtin_runtime_host_policy(
+    *,
+    firewall_name: str,
+    trusted_host: str,
+    trusted_port: int,
+    host_policy: object,
+    upstream_endpoint: tuple[str, int] | None,
+) -> None:
+    if host_policy is None:
+        return
+    if not isinstance(host_policy, dict):
+        raise _runtime_host_policy_error(
+            reason="invalid_host_policy",
+            firewall_name=firewall_name,
+            message="hostPolicy must be an object",
+        )
+    kind = host_policy.get("kind")
+    if kind == "providerOwned":
+        _validate_host_policy_keys(
+            firewall_name=firewall_name,
+            policy=host_policy,
+            allowed_keys=_PROVIDER_OWNED_HOST_POLICY_KEYS,
+        )
+        _validate_provider_owned_runtime_host_policy(
+            firewall_name=firewall_name,
+            trusted_host=trusted_host,
+            trusted_port=trusted_port,
+            policy=host_policy,
+        )
+        return
+    if kind == "publicDestination":
+        _validate_host_policy_keys(
+            firewall_name=firewall_name,
+            policy=host_policy,
+            allowed_keys=_PUBLIC_DESTINATION_HOST_POLICY_KEYS,
+        )
+        _validate_public_destination_runtime_host_policy(
+            firewall_name=firewall_name,
+            trusted_host=trusted_host,
+            upstream_endpoint=upstream_endpoint,
+        )
+        return
+    raise _runtime_host_policy_error(
+        reason="invalid_host_policy",
+        firewall_name=firewall_name,
+        message="hostPolicy kind is invalid",
+    )
 
 
 def _validate_builtin_base_host_policy(

--- a/crates/runner/mitm-addon/src/builtin_host_policy.py
+++ b/crates/runner/mitm-addon/src/builtin_host_policy.py
@@ -10,7 +10,7 @@ from firewall_auth_config import (
 )
 from url_syntax import has_raw_whitespace, has_unsafe_url_codepoint
 
-BUILTIN_HOST_POLICY_RUNTIME_MARKER = "_vm0BuiltinHostPolicy"
+BUILTIN_HOST_POLICY_RUNTIME_MARKER = "_builtinHostPolicyRuntime"
 _DEFAULT_HTTPS_PORT = 443
 _MIN_FIXED_HOST_OWNERSHIP_LABELS = 2
 _HOST_DOT_EQUIVALENT_TRANSLATION = str.maketrans(

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -47,6 +47,7 @@ from mitmproxy.addonmanager import Loader
 import auth_base_forwarder
 import body_capture
 import builtin_connector_diagnostics
+import builtin_host_policy
 import flow_metadata_keys as metadata_keys
 import matching
 import network_log_sanitization
@@ -103,6 +104,7 @@ _BROWSER_USER_AGENT_MARKERS = (
     " safari/",
 )
 _TEST_ENDPOINT_BYPASS_HEADER: Final = "x-vm0-test-endpoint-bypass"
+_BUILTIN_HOST_POLICY_DENIED_ERROR: Final = "builtin_host_policy_denied"
 _MODEL_PROVIDER_USAGE_REPORTED = "_model_provider_usage_reported"
 _MODEL_WEBSOCKET_MESSAGE_TRIM_SCHEDULED = "_model_websocket_message_trim_scheduled"
 _TCP_MESSAGE_DRAIN_SCHEDULED = "_tcp_message_drain_scheduled"
@@ -801,6 +803,38 @@ def _firewall_allow_injects_ordinary_upstream_credentials(
     allow: matching.FirewallAllow,
 ) -> bool:
     return auth_config_injects_ordinary_upstream_credentials(allow.api_entry.get("auth"))
+
+
+def _builtin_host_policy_error_for_firewall_allow(
+    flow: http.HTTPFlow,
+    allow: matching.FirewallAllow,
+) -> builtin_host_policy.BuiltinRuntimeHostPolicyError | None:
+    if allow.api_entry.get(builtin_host_policy.BUILTIN_HOST_POLICY_RUNTIME_MARKER) is not True:
+        return None
+    if not _firewall_allow_injects_ordinary_upstream_credentials(allow):
+        return None
+    trusted_host = flow.metadata.get(metadata_keys.TRUSTED_AUTHORITY_HOST)
+    if not isinstance(trusted_host, str) or not trusted_host:
+        return builtin_host_policy.BuiltinRuntimeHostPolicyError(
+            reason="trusted_authority_unavailable",
+            message="trusted request authority is unavailable",
+        )
+    upstream_endpoint = upstream_destination_binding.bound_destination_endpoint_for_flow(
+        flow,
+        allowed_kinds=frozenset(("connector_auth",)),
+    )
+    try:
+        builtin_host_policy.validate_credentialed_builtin_request_destination(
+            firewall_name=allow.name,
+            trusted_host=trusted_host,
+            trusted_port=flow.request.port,
+            auth_config=allow.api_entry.get("auth"),
+            host_policy=allow.api_entry.get("hostPolicy"),
+            upstream_endpoint=upstream_endpoint,
+        )
+    except builtin_host_policy.BuiltinRuntimeHostPolicyError as e:
+        return e
+    return None
 
 
 def _has_bound_upstream_destination(
@@ -1615,6 +1649,49 @@ def _block_upstream_destination_unbound(
     )
 
 
+def _block_builtin_host_policy_denied(
+    flow: http.HTTPFlow,
+    *,
+    allow: matching.FirewallAllow,
+    error: builtin_host_policy.BuiltinRuntimeHostPolicyError,
+) -> None:
+    proxy_log_path = flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, "")
+    trusted_host = flow.metadata.get(metadata_keys.TRUSTED_AUTHORITY_HOST, "")
+    upstream_endpoint = upstream_destination_binding.bound_destination_endpoint_for_flow(
+        flow,
+        allowed_kinds=frozenset(("connector_auth",)),
+    )
+    log_proxy_entry(
+        proxy_log_path,
+        "warn",
+        "Request blocked: builtin firewall host policy rejected credential injection",
+        type="builtin_host_policy",
+        name=allow.name,
+        reason=error.reason,
+        trusted_host=trusted_host,
+        request_port=flow.request.port,
+        upstream_endpoint=_endpoint_text(upstream_endpoint),
+    )
+    flow.metadata[metadata_keys.FIREWALL_ACTION] = "BLOCK"
+    flow.metadata[metadata_keys.FIREWALL_ERROR] = _BUILTIN_HOST_POLICY_DENIED_ERROR
+    body: dict[str, object] = {
+        "error": _BUILTIN_HOST_POLICY_DENIED_ERROR,
+        "message": "Request blocked: builtin firewall host policy rejected credential injection",
+        "reason": error.reason,
+        "name": allow.name,
+        "trusted_host": trusted_host,
+        "request_port": flow.request.port,
+    }
+    firewall_base = flow.metadata.get(metadata_keys.FIREWALL_BASE)
+    if isinstance(firewall_base, str):
+        body["base"] = firewall_base
+    flow.response = http.Response.make(
+        403,
+        json.dumps(body).encode(),
+        {"Content-Type": "application/json"},
+    )
+
+
 def _endpoint_text(address: tuple[str, int] | None) -> str:
     if address is None:
         return ""
@@ -2356,6 +2433,9 @@ async def _try_firewall_request_stream_capture_from_headers(
     ) and not _ensure_bound_upstream_destination(flow, kind="connector_auth"):
         _restore_request_headers_probe_metadata(flow, metadata_snapshot)
         return
+    if _builtin_host_policy_error_for_firewall_allow(flow, allow) is not None:
+        _restore_request_headers_probe_metadata(flow, metadata_snapshot)
+        return
 
     _start_request_timing(flow)
     try:
@@ -2508,6 +2588,15 @@ async def request(flow: http.HTTPFlow) -> None:
             ) and not _ensure_bound_upstream_destination(flow, kind="connector_auth"):
                 prepare_firewall_metadata(flow, allow, vm_info)
                 _block_upstream_destination_unbound(flow, reason="connector_auth")
+                return
+            host_policy_error = _builtin_host_policy_error_for_firewall_allow(flow, allow)
+            if host_policy_error is not None:
+                prepare_firewall_metadata(flow, allow, vm_info)
+                _block_builtin_host_policy_denied(
+                    flow,
+                    allow=allow,
+                    error=host_policy_error,
+                )
                 return
             _maybe_track_usage_flow(
                 flow,

--- a/crates/runner/mitm-addon/src/registry_firewalls.py
+++ b/crates/runner/mitm-addon/src/registry_firewalls.py
@@ -98,6 +98,8 @@ def _resolve_builtin_firewall_entry(entry: dict) -> _ResolvedBuiltinFirewallEntr
         ) as e:
             raise _resolution_error(e) from e
         api["base"] = resolved_base
+        if api.get("hostPolicy") is not None:
+            api[builtin_host_policy.BUILTIN_HOST_POLICY_RUNTIME_MARKER] = True
         resolved_bases.append(resolved_base)
 
     return _ResolvedBuiltinFirewallEntry(

--- a/crates/runner/mitm-addon/src/upstream_destination_binding.py
+++ b/crates/runner/mitm-addon/src/upstream_destination_binding.py
@@ -300,6 +300,32 @@ def _client_binding_matches_connected_endpoint(
     return False
 
 
+def _client_binding_connected_endpoint(
+    *,
+    client: object,
+    server: object,
+    bindings: tuple[UpstreamDestinationBinding, ...],
+) -> tuple[str, int] | None:
+    peername = getattr(server, "peername", None)
+    if _is_authoritative_connected_address(peername) and _endpoint_matches_any(peername, bindings):
+        return _address_pair(peername)
+
+    server_address = getattr(server, "address", None)
+    if _is_authoritative_connected_address(server_address) and _endpoint_matches_any(
+        server_address,
+        bindings,
+    ):
+        return _address_pair(server_address)
+
+    client_sockname = getattr(client, "sockname", None)
+    if _is_authoritative_connected_address(client_sockname) and _endpoint_matches_any(
+        client_sockname,
+        bindings,
+    ):
+        return _address_pair(client_sockname)
+    return None
+
+
 def diagnostic_snapshot_for_flow(
     flow: http.HTTPFlow,
     *,
@@ -399,6 +425,50 @@ def flow_matches_bound_destination(
         )
 
     return _address_matches(normalized_host, port, getattr(server, "address", None))
+
+
+def bound_destination_endpoint_for_flow(
+    flow: http.HTTPFlow,
+    *,
+    allowed_kinds: frozenset[BindingKind],
+) -> tuple[str, int] | None:
+    trusted_host = flow.metadata.get(metadata_keys.TRUSTED_AUTHORITY_HOST)
+    if not isinstance(trusted_host, str) or not trusted_host:
+        return None
+    try:
+        normalized_host = normalize_trusted_hostname(trusted_host)
+    except (UnicodeError, ValueError):
+        return None
+
+    port = flow.request.port
+    server = flow.server_conn
+    server_id = _connection_id(server)
+    binding = _bindings_by_server_id.get(server_id) if server_id is not None else None
+    if (
+        binding is not None
+        and _binding_matches(
+            binding,
+            host=normalized_host,
+            port=port,
+            allowed_kinds=allowed_kinds,
+        )
+        and _server_binding_matches_current_destination(server, binding)
+    ):
+        return binding.original_address
+
+    matching_client_bindings = _matching_client_bindings(
+        flow.client_conn,
+        host=normalized_host,
+        port=port,
+        allowed_kinds=allowed_kinds,
+    )
+    if bool(getattr(server, "connected", False)):
+        return _client_binding_connected_endpoint(
+            client=flow.client_conn,
+            server=server,
+            bindings=matching_client_bindings,
+        )
+    return None
 
 
 def binding_snapshot_for_tests() -> dict[str, UpstreamDestinationBinding]:

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_base_url_vars.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_base_url_vars.py
@@ -3,6 +3,7 @@
 import json
 from unittest.mock import MagicMock, patch
 
+import builtin_host_policy
 import registry
 import registry_firewalls
 from tests.registry_helpers import write_builtin_firewall_registry
@@ -154,6 +155,23 @@ class TestRegistryBuiltinBaseUrlVars:
         vm_info, compiled_firewalls, _ = context
         assert compiled_firewalls is not None
         assert vm_info["firewalls"][0]["apis"][0]["base"] == "https://acme.atlassian.net"
+
+    def test_builtin_host_policy_marks_resolved_api_for_runtime_enforcement(self, tmp_path):
+        path = tmp_path / "registry.json"
+        write_builtin_firewall_registry(
+            path,
+            run_id="run-jira",
+            name="jira",
+            base_url_vars={"JIRA_DOMAIN": "acme.atlassian.net"},
+        )
+
+        context = registry.get_vm_context("10.200.0.1", str(path))
+
+        assert context is not None
+        vm_info, compiled_firewalls, _ = context
+        assert compiled_firewalls is not None
+        api = vm_info["firewalls"][0]["apis"][0]
+        assert api[builtin_host_policy.BUILTIN_HOST_POLICY_RUNTIME_MARKER] is True
 
     def test_builtin_provider_owned_accepts_idna_dot_equivalent_host(self, tmp_path):
         path = tmp_path / "registry.json"

--- a/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 from mitmproxy import connection
 
+import builtin_host_policy
 import flow_metadata_keys as metadata_keys
 import mitm_addon
 import upstream_destination_binding
@@ -51,6 +52,39 @@ def _write_test_oauth_registry(tmp_path):
     )
 
 
+def _write_host_policy_registry(
+    tmp_path,
+    *,
+    firewall_name: str,
+    base: str,
+    host_policy: dict[str, object],
+    marked_builtin: bool = True,
+):
+    api_entry: dict[str, object] = {
+        "base": base,
+        "auth": {"headers": {"Authorization": "Bearer ${{ secrets.TEST_TOKEN }}"}},
+        "hostPolicy": host_policy,
+        "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+    }
+    if marked_builtin:
+        api_entry[builtin_host_policy.BUILTIN_HOST_POLICY_RUNTIME_MARKER] = True
+    return _write_registry(
+        tmp_path,
+        client_ip="10.200.0.5",
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            firewall_name=firewall_name,
+            api_entry=api_entry,
+            network_policy={
+                "allow": ["full-access"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "deny",
+            },
+        ),
+    )
+
+
 def _bind_flow_upstream(
     flow,
     *,
@@ -67,6 +101,257 @@ def _bind_flow_upstream(
         kinds=kinds,
         original_address=original_address,
     )
+
+
+async def test_runtime_host_policy_blocks_public_destination_private_endpoint(
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+):
+    reg_path = _write_host_policy_registry(
+        tmp_path,
+        firewall_name="strapi",
+        base="https://strapi.example.com",
+        host_policy={"kind": "publicDestination"},
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="10.0.0.5",
+        sni="strapi.example.com",
+        path="/api/articles",
+        request_headers=headers(("Host", "strapi.example.com")),
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as auth_fetch,
+    ):
+        await mitm_addon.request(flow)
+
+    assert flow.response is not None
+    assert flow.response.status_code == 403
+    body = json.loads(flow.response.content)
+    assert body["error"] == "builtin_host_policy_denied"
+    assert body["reason"] == "public_endpoint_non_public_ip"
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "BLOCK"
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "builtin_host_policy_denied"
+    auth_fetch.assert_not_called()
+    assert "Authorization" not in flow.request.headers
+
+
+async def test_runtime_host_policy_allows_public_destination_public_endpoint(
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+):
+    reg_path = _write_host_policy_registry(
+        tmp_path,
+        firewall_name="strapi",
+        base="https://strapi.example.com",
+        host_policy={"kind": "publicDestination"},
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="8.8.8.8",
+        sni="strapi.example.com",
+        path="/api/articles",
+        request_headers=headers(("Host", "strapi.example.com")),
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as auth_fetch,
+    ):
+        await mitm_addon.request(flow)
+
+    assert flow.response is None
+    assert flow.request.headers["Authorization"] == "Bearer x"
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+    auth_fetch.assert_awaited_once()
+
+
+async def test_runtime_host_policy_allows_public_destination_hostname_without_ip_endpoint(
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers
+):
+    reg_path = _write_host_policy_registry(
+        tmp_path,
+        firewall_name="strapi",
+        base="https://strapi.example.com",
+        host_policy={"kind": "publicDestination"},
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="strapi.example.com",
+        path="/api/articles",
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        patch.object(
+            mitm_addon.socket,
+            "getaddrinfo",
+            side_effect=AssertionError("runtime host policy must not use DNS"),
+        ),
+        fake_firewall_headers() as auth_fetch,
+    ):
+        await mitm_addon.request(flow)
+
+    assert flow.response is None
+    assert flow.request.headers["Authorization"] == "Bearer x"
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+    auth_fetch.assert_awaited_once()
+
+
+async def test_runtime_host_policy_blocks_public_destination_private_request_host(
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers
+):
+    reg_path = _write_host_policy_registry(
+        tmp_path,
+        firewall_name="strapi",
+        base="https://10.0.0.5",
+        host_policy={"kind": "publicDestination"},
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="10.0.0.5",
+        path="/api/articles",
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as auth_fetch,
+    ):
+        await mitm_addon.request(flow)
+
+    assert flow.response is not None
+    assert flow.response.status_code == 403
+    body = json.loads(flow.response.content)
+    assert body["error"] == "builtin_host_policy_denied"
+    assert body["reason"] == "public_host_non_public_ip"
+    auth_fetch.assert_not_called()
+    assert "Authorization" not in flow.request.headers
+
+
+async def test_runtime_host_policy_ignores_inline_public_destination_policy(
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+):
+    reg_path = _write_host_policy_registry(
+        tmp_path,
+        firewall_name="strapi",
+        base="https://strapi.example.com",
+        host_policy={"kind": "publicDestination"},
+        marked_builtin=False,
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="10.0.0.5",
+        sni="strapi.example.com",
+        path="/api/articles",
+        request_headers=headers(("Host", "strapi.example.com")),
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as auth_fetch,
+    ):
+        await mitm_addon.request(flow)
+
+    assert flow.response is None
+    assert flow.request.headers["Authorization"] == "Bearer x"
+    auth_fetch.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    ("base", "host_header", "sni", "port", "expected_reason"),
+    [
+        (
+            "https://attacker.example.com",
+            "attacker.example.com",
+            "attacker.example.com",
+            443,
+            "provider_host_not_allowed",
+        ),
+        (
+            "https://acme.atlassian.net:8443",
+            "acme.atlassian.net:8443",
+            "acme.atlassian.net",
+            8443,
+            "provider_non_default_port",
+        ),
+    ],
+)
+async def test_runtime_host_policy_blocks_provider_owned_request_authority(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+    headers,
+    base,
+    host_header,
+    sni,
+    port,
+    expected_reason,
+):
+    reg_path = _write_host_policy_registry(
+        tmp_path,
+        firewall_name="jira",
+        base=base,
+        host_policy={"kind": "providerOwned", "suffixes": ["atlassian.net"]},
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="203.0.113.10",
+        port=port,
+        sni=sni,
+        path="/rest/api/3/myself",
+        request_headers=headers(("Host", host_header)),
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as auth_fetch,
+    ):
+        await mitm_addon.request(flow)
+
+    assert flow.response is not None
+    assert flow.response.status_code == 403
+    body = json.loads(flow.response.content)
+    assert body["error"] == "builtin_host_policy_denied"
+    assert body["reason"] == expected_reason
+    auth_fetch.assert_not_called()
+    assert "Authorization" not in flow.request.headers
+
+
+async def test_runtime_host_policy_allows_provider_owned_request_authority(
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+):
+    reg_path = _write_host_policy_registry(
+        tmp_path,
+        firewall_name="jira",
+        base="https://acme.atlassian.net",
+        host_policy={"kind": "providerOwned", "suffixes": ["atlassian.net"]},
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="203.0.113.10",
+        sni="acme.atlassian.net",
+        path="/rest/api/3/myself",
+        request_headers=headers(("Host", "acme.atlassian.net")),
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as auth_fetch,
+    ):
+        await mitm_addon.request(flow)
+
+    assert flow.response is None
+    assert flow.request.headers["Authorization"] == "Bearer x"
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+    auth_fetch.assert_awaited_once()
 
 
 @pytest.mark.parametrize(

--- a/crates/runner/mitm-addon/tests/test_request_headers_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_headers_handler.py
@@ -8,6 +8,7 @@ import pytest
 from mitmproxy import connection
 
 import auth
+import builtin_host_policy
 import firewall_auth_client as auth_client
 import flow_metadata_keys as metadata_keys
 import mitm_addon
@@ -1006,6 +1007,62 @@ async def test_firewall_allow_header_auth_requestheaders_falls_back_when_upstrea
     assert flow.response is not None
     assert flow.response.status_code == 403
     assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "upstream_destination_unbound"
+
+
+async def test_firewall_allow_header_auth_requestheaders_defers_on_runtime_host_policy_block(
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+):
+    api_entry: dict[str, object] = {
+        "base": "https://strapi.example.com",
+        "auth": {"headers": {"Authorization": "Bearer ${{ secrets.TEST_TOKEN }}"}},
+        "hostPolicy": {"kind": "publicDestination"},
+        builtin_host_policy.BUILTIN_HOST_POLICY_RUNTIME_MARKER: True,
+        "permissions": [{"name": "full-access", "rules": ["ANY /{path+}"]}],
+    }
+    reg_path = _write_registry(
+        tmp_path,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            firewall_name="strapi",
+            api_entry=api_entry,
+            network_policy={
+                "allow": ["full-access"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "allow",
+            },
+            vm_fields={"captureNetworkBodies": True},
+        ),
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="10.0.0.5",
+        sni="strapi.example.com",
+        method="POST",
+        path="/api/articles",
+        request_headers=headers(
+            ("Host", "strapi.example.com"),
+            ("Content-Length", str(STREAM_BUFFER_LIMIT + 1)),
+        ),
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers(headers={"Authorization": "Bearer resolved"}) as auth_fetch,
+    ):
+        requestheaders_result = mitm_addon.requestheaders(flow)
+        await await_requestheaders_result(requestheaders_result)
+        _assert_no_request_stream(flow)
+        assert "Authorization" not in flow.request.headers
+
+        await mitm_addon.request(flow)
+
+    auth_fetch.assert_not_called()
+    assert flow.response is not None
+    assert flow.response.status_code == 403
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "builtin_host_policy_denied"
+    assert "Authorization" not in flow.request.headers
 
 
 async def test_firewall_allow_header_auth_uses_connected_upstream_when_tls_verified(


### PR DESCRIPTION
## Summary

- mark resolved builtin firewall APIs that carry hostPolicy for runtime-only enforcement
- enforce builtin hostPolicy before ordinary upstream credential injection in request and requestheaders paths
- expose matched upstream binding endpoint data for deterministic publicDestination IP checks
- add mitm-addon integration coverage for provider-owned, public-destination, inline/custom, and requestheaders cases

Fixes #19136

## Tests

- `cd crates/runner/mitm-addon && .venv/bin/python -m pytest tests/test_request_handler_authority_validation.py tests/test_request_headers_handler.py tests/test_registry_builtin_base_url_vars.py`
- `cd crates/runner/mitm-addon && .venv/bin/ruff check .`
- `cd crates/runner/mitm-addon && .venv/bin/ruff format --check .`
- `cd crates/runner/mitm-addon && .venv/bin/basedpyright -p .`