### PR TITLE
perf: verify large session histories in guest

### DIFF
--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -8,7 +8,9 @@ use crate::error::AgentError;
 use crate::http::HttpClient;
 use crate::paths;
 use crate::session_history;
-use crate::session_history_identity::build_final_session_history_identity;
+use crate::session_history_identity::{
+    FinalSessionHistoryIdentityBuildError, build_final_session_history_identity,
+};
 use api_contracts::generated::types::runners::storage::ArtifactEntryMissingRootPolicy;
 use bytes::Bytes;
 use guest_common::telemetry::record_sandbox_op;
@@ -16,6 +18,7 @@ use guest_common::{log_error, log_info, log_warn};
 use serde_json::json;
 use sha2::{Digest, Sha256};
 use std::io::ErrorKind;
+use std::time::Duration;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
 
@@ -557,6 +560,20 @@ fn write_final_session_history_identity(
     ) {
         Ok(identity) => identity,
         Err(error) => {
+            match error {
+                FinalSessionHistoryIdentityBuildError::InvalidSessionId => record_sandbox_op(
+                    "session_history_identity_write_skipped_invalid_session_id",
+                    Duration::ZERO,
+                    true,
+                    None,
+                ),
+                FinalSessionHistoryIdentityBuildError::InvalidMetadata(_) => record_sandbox_op(
+                    "session_history_identity_write_skipped_invalid_metadata",
+                    Duration::ZERO,
+                    true,
+                    None,
+                ),
+            }
             log_info!(LOG_TAG, "Final session history identity skipped: {error}");
             return;
         }
@@ -564,13 +581,35 @@ fn write_final_session_history_identity(
     let bytes = match identity.to_json_vec() {
         Ok(bytes) => bytes,
         Err(error) => {
+            record_sandbox_op(
+                "session_history_identity_write_skipped_invalid_metadata",
+                Duration::ZERO,
+                true,
+                None,
+            );
             log_info!(LOG_TAG, "Final session history identity skipped: {error}");
             return;
         }
     };
     match paths::write_private(paths::final_session_history_identity_file(), bytes) {
-        Ok(()) => log_info!(LOG_TAG, "Final session history identity written"),
-        Err(_) => log_warn!(LOG_TAG, "Failed to write final session history identity"),
+        Ok(()) => {
+            record_sandbox_op(
+                "session_history_identity_written",
+                Duration::ZERO,
+                true,
+                None,
+            );
+            log_info!(LOG_TAG, "Final session history identity written");
+        }
+        Err(_) => {
+            record_sandbox_op(
+                "session_history_identity_write_failed",
+                Duration::ZERO,
+                false,
+                None,
+            );
+            log_warn!(LOG_TAG, "Failed to write final session history identity");
+        }
     }
 }
 

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -22,7 +22,11 @@ use guest_contracts::diagnostics::{
     AgentFramework, CliTerminationDiagnostic, CliTerminationReason, FailureClass,
     FailureDetailSource, FailureDiagnostic, FailureReason, PromptMetadata, SessionHistoryStatus,
 };
-use guest_contracts::session_history_identity::FinalSessionHistoryIdentityExpectation;
+use guest_contracts::session_history_identity::{
+    FinalSessionHistoryIdentityExpectation, SESSION_HISTORY_IDENTITY_VERIFY_EXIT_FAILURE,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_INVALID_ARGS,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_SUCCESS,
+};
 use serde_json::Value;
 use std::io::ErrorKind;
 use std::path::Path;
@@ -58,15 +62,22 @@ fn helper_exit_code_from_args() -> Option<i32> {
     let remaining = args.collect::<Vec<_>>();
     let expected = match parse_session_history_identity_expectation(&remaining) {
         Ok(expected) => expected,
-        Err(()) => return Some(2),
+        Err(()) => return Some(SESSION_HISTORY_IDENTITY_VERIFY_EXIT_INVALID_ARGS),
     };
     Some(
         match session_history_identity::verify_final_session_history_identity_file(
             metadata_path,
             expected.as_ref(),
         ) {
-            Ok(()) => 0,
-            Err(_) => 1,
+            Ok(()) => SESSION_HISTORY_IDENTITY_VERIFY_EXIT_SUCCESS,
+            Err(error) => {
+                let exit_code = error.helper_exit_code();
+                if exit_code == SESSION_HISTORY_IDENTITY_VERIFY_EXIT_SUCCESS {
+                    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_FAILURE
+                } else {
+                    exit_code
+                }
+            }
         },
     )
 }

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -33,6 +33,7 @@ use crate::error::AgentError;
 #[cfg(target_os = "linux")]
 use crate::nofollow_fs::Dir;
 use guest_contracts::codex_thread_id::codex_thread_id_filename_key;
+use sha2::{Digest, Sha256};
 use std::ffi::OsStr;
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
@@ -82,14 +83,46 @@ pub(crate) fn read_session_history_from_payload(payload: &str) -> Result<Vec<u8>
     read_session_history_from_payload_impl(payload, None)
 }
 
-/// Read session history bytes from an already-resolved marker payload, bounded
-/// to `max_bytes + 1` decoded bytes so callers can detect oversized history
-/// without loading the full file.
-pub(crate) fn read_session_history_from_payload_bounded(
+pub(crate) struct SessionHistoryDigest {
+    pub(crate) size_bytes: u64,
+    pub(crate) sha256_hex: String,
+}
+
+#[derive(Debug)]
+pub(crate) enum SessionHistoryDigestError {
+    Read(AgentError),
+    ExceedsMaxBytes,
+}
+
+impl From<AgentError> for SessionHistoryDigestError {
+    fn from(error: AgentError) -> Self {
+        Self::Read(error)
+    }
+}
+
+/// Compute decoded session-history size and hash without returning the bytes.
+pub(crate) fn digest_session_history_from_payload_bounded(
     payload: &str,
     max_bytes: u64,
-) -> Result<Vec<u8>, AgentError> {
-    read_session_history_from_payload_impl(payload, Some(max_bytes))
+) -> Result<SessionHistoryDigest, SessionHistoryDigestError> {
+    if is_codex_marker(payload) {
+        let Some((sessions_dir, thread_id)) = decode_marker(payload) else {
+            return Err(SessionHistoryDigestError::Read(AgentError::Checkpoint(
+                "Invalid Codex session history marker".to_string(),
+            )));
+        };
+        return digest_codex_session_history(&sessions_dir, thread_id, max_bytes)?.ok_or_else(
+            || {
+                SessionHistoryDigestError::Read(AgentError::Checkpoint(format!(
+                    "Codex session file not found under {}",
+                    sessions_dir.display()
+                )))
+            },
+        );
+    }
+
+    let session_path = PathBuf::from(payload);
+    digest_history_bytes(&session_path, max_bytes)
 }
 
 fn read_session_history_from_payload_impl(
@@ -153,6 +186,20 @@ fn read_codex_session_history(
     read_codex_session_history_impl(sessions_dir, &id_norm, max_bytes)
 }
 
+fn digest_codex_session_history(
+    sessions_dir: &Path,
+    thread_id: &str,
+    max_bytes: u64,
+) -> Result<Option<SessionHistoryDigest>, SessionHistoryDigestError> {
+    let Some(id_norm) = codex_thread_id_filename_key(thread_id) else {
+        return Ok(None);
+    };
+    if !codex_sessions_parent_is_usable(sessions_dir)? {
+        return Ok(None);
+    }
+    digest_codex_session_history_impl(sessions_dir, &id_norm, max_bytes)
+}
+
 fn codex_sessions_parent_is_usable(sessions_dir: &Path) -> Result<bool, AgentError> {
     let Some(parent) = sessions_dir.parent() else {
         return Ok(true);
@@ -186,6 +233,27 @@ fn read_codex_session_history_impl(
         &mut budget,
     )?;
     found.map(|session| session.read(max_bytes)).transpose()
+}
+
+fn digest_codex_session_history_impl(
+    sessions_dir: &Path,
+    id_norm: &str,
+    max_bytes: u64,
+) -> Result<Option<SessionHistoryDigest>, SessionHistoryDigestError> {
+    let Some(root) = CodexSessionDir::open_root(sessions_dir)? else {
+        return Ok(None);
+    };
+    let mut found = None;
+    let mut budget = CodexSessionLookupBudget::new();
+    scan_codex_session_dirs(
+        &root,
+        root.path(),
+        CodexSessionDateLevel::Year,
+        id_norm,
+        &mut found,
+        &mut budget,
+    )?;
+    found.map(|session| session.digest(max_bytes)).transpose()
 }
 
 fn scan_codex_session_dirs(
@@ -419,6 +487,18 @@ impl ResolvedCodexSession {
             read_history_bytes(&self.path, max_bytes)
         }
     }
+
+    fn digest(self, max_bytes: u64) -> Result<SessionHistoryDigest, SessionHistoryDigestError> {
+        #[cfg(target_os = "linux")]
+        {
+            digest_history_bytes_from_file(&self.path, self.file, max_bytes)
+        }
+
+        #[cfg(not(target_os = "linux"))]
+        {
+            digest_history_bytes(&self.path, max_bytes)
+        }
+    }
 }
 
 struct CodexSessionLookupBudget {
@@ -511,6 +591,14 @@ fn read_history_bytes(path: &Path, max_bytes: Option<u64>) -> Result<Vec<u8>, Ag
     read_history_bytes_from_reader(path, file, max_bytes)
 }
 
+fn digest_history_bytes(
+    path: &Path,
+    max_bytes: u64,
+) -> Result<SessionHistoryDigest, SessionHistoryDigestError> {
+    let file = std::fs::File::open(path).map_err(|e| read_history_error(path, e))?;
+    digest_history_bytes_from_reader(path, file, max_bytes)
+}
+
 #[cfg(target_os = "linux")]
 fn read_history_bytes_from_file(
     path: &Path,
@@ -518,6 +606,15 @@ fn read_history_bytes_from_file(
     max_bytes: Option<u64>,
 ) -> Result<Vec<u8>, AgentError> {
     read_history_bytes_from_reader(path, file, max_bytes)
+}
+
+#[cfg(target_os = "linux")]
+fn digest_history_bytes_from_file(
+    path: &Path,
+    file: File,
+    max_bytes: u64,
+) -> Result<SessionHistoryDigest, SessionHistoryDigestError> {
+    digest_history_bytes_from_reader(path, file, max_bytes)
 }
 
 fn read_history_error(_path: &Path, source: io::Error) -> AgentError {
@@ -539,6 +636,27 @@ fn read_history_bytes_from_reader(
         return read_zstd_history_reader(decoder, max_bytes);
     }
     read_history_reader(path, reader, max_bytes)
+}
+
+fn digest_history_bytes_from_reader(
+    path: &Path,
+    reader: impl Read,
+    max_bytes: u64,
+) -> Result<SessionHistoryDigest, SessionHistoryDigestError> {
+    if path
+        .extension()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("zst"))
+    {
+        let decoder = zstd::stream::read::Decoder::new(reader).map_err(|e| {
+            SessionHistoryDigestError::Read(AgentError::Checkpoint(format!(
+                "Failed to decompress zstd session history: {e}"
+            )))
+        })?;
+        return digest_history_reader(decoder, max_bytes, |e| {
+            AgentError::Checkpoint(format!("Failed to decompress zstd session history: {e}"))
+        });
+    }
+    digest_history_reader(reader, max_bytes, |e| read_history_error(path, e))
 }
 
 fn read_zstd_history_reader(
@@ -585,6 +703,40 @@ fn read_history_reader(
         }
     }
     Ok(bytes)
+}
+
+fn digest_history_reader(
+    mut reader: impl Read,
+    max_bytes: u64,
+    map_error: impl Fn(io::Error) -> AgentError,
+) -> Result<SessionHistoryDigest, SessionHistoryDigestError> {
+    let mut hasher = Sha256::new();
+    let mut size_bytes = 0u64;
+    let mut buffer = [0u8; 8192];
+
+    loop {
+        let bytes_read = reader
+            .read(&mut buffer)
+            .map_err(|error| SessionHistoryDigestError::Read(map_error(error)))?;
+        if bytes_read == 0 {
+            break;
+        }
+        size_bytes = size_bytes
+            .checked_add(bytes_read as u64)
+            .ok_or(SessionHistoryDigestError::ExceedsMaxBytes)?;
+        if size_bytes > max_bytes {
+            return Err(SessionHistoryDigestError::ExceedsMaxBytes);
+        }
+        let chunk = buffer
+            .get(..bytes_read)
+            .ok_or(SessionHistoryDigestError::ExceedsMaxBytes)?;
+        hasher.update(chunk);
+    }
+
+    Ok(SessionHistoryDigest {
+        size_bytes,
+        sha256_hex: hex::encode(hasher.finalize()),
+    })
 }
 
 // Note: integration coverage for the public `read_session_history` entry

--- a/crates/guest-agent/src/session_history_identity.rs
+++ b/crates/guest-agent/src/session_history_identity.rs
@@ -8,7 +8,14 @@ use guest_contracts::session_history_identity::{
     FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES, FinalSessionHistoryFramework,
     FinalSessionHistoryIdentity, FinalSessionHistoryIdentityError,
     FinalSessionHistoryIdentityExpectation, FinalSessionHistoryRefKind,
-    SESSION_HISTORY_IDENTITY_VERIFY_MAX_BYTES,
+    SESSION_HISTORY_IDENTITY_GUEST_VERIFY_MAX_BYTES,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_EXPECTED_MISMATCH,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_FRAMEWORK_MISMATCH,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_MISMATCH,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_READ,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_TOO_LARGE,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_INVALID_METADATA,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_METADATA_READ,
 };
 use sha2::{Digest, Sha256};
 use std::fmt;
@@ -101,16 +108,25 @@ fn verify_final_session_history_identity(
         }
     }
 
-    let history_bytes = session_history::read_session_history_from_payload_bounded(
+    if identity.history_size_bytes > SESSION_HISTORY_IDENTITY_GUEST_VERIFY_MAX_BYTES {
+        return Err(FinalSessionHistoryIdentityVerifyError::HistoryTooLarge);
+    }
+    let digest = match session_history::digest_session_history_from_payload_bounded(
         &identity.history_marker_payload,
-        SESSION_HISTORY_IDENTITY_VERIFY_MAX_BYTES,
-    )
-    .map_err(FinalSessionHistoryIdentityVerifyError::HistoryRead)?;
-    if history_bytes.len() as u64 != identity.history_size_bytes {
+        identity.history_size_bytes,
+    ) {
+        Ok(digest) => digest,
+        Err(session_history::SessionHistoryDigestError::Read(error)) => {
+            return Err(FinalSessionHistoryIdentityVerifyError::HistoryRead(error));
+        }
+        Err(session_history::SessionHistoryDigestError::ExceedsMaxBytes) => {
+            return Err(FinalSessionHistoryIdentityVerifyError::HistoryMismatch);
+        }
+    };
+    if digest.size_bytes != identity.history_size_bytes {
         return Err(FinalSessionHistoryIdentityVerifyError::HistoryMismatch);
     }
-    let actual_hash = hex::encode(Sha256::digest(&history_bytes));
-    if actual_hash != identity.history_hash {
+    if digest.sha256_hex != identity.history_hash {
         return Err(FinalSessionHistoryIdentityVerifyError::HistoryMismatch);
     }
     Ok(())
@@ -153,6 +169,25 @@ pub enum FinalSessionHistoryIdentityVerifyError {
     HistoryRead(AgentError),
     /// Session history size or hash does not match metadata.
     HistoryMismatch,
+    /// Session history exceeds the guest helper verification budget.
+    HistoryTooLarge,
+}
+
+impl FinalSessionHistoryIdentityVerifyError {
+    /// Return the stable helper exit code for this verification failure.
+    pub fn helper_exit_code(&self) -> i32 {
+        match self {
+            Self::MetadataRead => SESSION_HISTORY_IDENTITY_VERIFY_EXIT_METADATA_READ,
+            Self::InvalidMetadata(_) => SESSION_HISTORY_IDENTITY_VERIFY_EXIT_INVALID_METADATA,
+            Self::FrameworkMismatch => SESSION_HISTORY_IDENTITY_VERIFY_EXIT_FRAMEWORK_MISMATCH,
+            Self::ExpectedIdentityMismatch => {
+                SESSION_HISTORY_IDENTITY_VERIFY_EXIT_EXPECTED_MISMATCH
+            }
+            Self::HistoryRead(_) => SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_READ,
+            Self::HistoryMismatch => SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_MISMATCH,
+            Self::HistoryTooLarge => SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_TOO_LARGE,
+        }
+    }
 }
 
 impl fmt::Display for FinalSessionHistoryIdentityVerifyError {
@@ -168,6 +203,9 @@ impl fmt::Display for FinalSessionHistoryIdentityVerifyError {
             }
             Self::HistoryRead(_) => f.write_str("final session history could not be read"),
             Self::HistoryMismatch => f.write_str("final session history did not match identity"),
+            Self::HistoryTooLarge => {
+                f.write_str("final session history exceeds verification budget")
+            }
         }
     }
 }
@@ -237,6 +275,36 @@ mod tests {
     }
 
     #[test]
+    fn verifies_codex_zstd_marker_history() {
+        let dir = tempfile::tempdir().unwrap();
+        let sessions_dir = dir.path().join("sessions");
+        let history_dir = sessions_dir.join("2026").join("06").join("29");
+        std::fs::create_dir_all(&history_dir).unwrap();
+        let thread_id = "00000000-0000-4000-8000-000000000001";
+        let history = br#"{"type":"session_meta","timestamp":"2026-06-29T10:00:00Z"}"#;
+        let compressed = zstd::encode_all(history.as_slice(), 0).unwrap();
+        std::fs::write(
+            history_dir
+                .join("rollout-2026-06-29T10-00-00-00000000000040008000000000000001.jsonl.zst"),
+            compressed,
+        )
+        .unwrap();
+        let marker = session_history::codex_marker_payload(&sessions_dir, thread_id);
+        let identity = FinalSessionHistoryIdentity::new(
+            FinalSessionHistoryFramework::Codex,
+            "a".repeat(64),
+            FinalSessionHistoryRefKind::Blob,
+            hex::encode(Sha256::digest(history)),
+            history.len() as u64,
+            marker,
+        )
+        .unwrap();
+        let metadata_path = write_metadata(&dir, &identity);
+
+        verify_final_session_history_identity_file(metadata_path, None).unwrap();
+    }
+
+    #[test]
     fn rejects_history_mismatch() {
         let dir = tempfile::tempdir().unwrap();
         let history_path = dir.path().join("history.jsonl");
@@ -280,25 +348,65 @@ mod tests {
     }
 
     #[test]
-    fn build_rejects_history_above_verify_cap() {
-        let err = FinalSessionHistoryIdentity::new(
+    fn build_allows_history_above_host_read_cap() {
+        let identity = FinalSessionHistoryIdentity::new(
             FinalSessionHistoryFramework::ClaudeCode,
             "a".repeat(64),
             FinalSessionHistoryRefKind::Blob,
             "b".repeat(64),
-            SESSION_HISTORY_IDENTITY_VERIFY_MAX_BYTES + 1,
+            guest_contracts::session_history_identity::SESSION_HISTORY_IDENTITY_HOST_READ_MAX_BYTES
+                + 1,
             "/history.jsonl",
         )
-        .unwrap_err();
-        assert_eq!(err, FinalSessionHistoryIdentityError::HistoryTooLarge);
+        .unwrap();
+
+        assert_eq!(
+            identity.history_size_bytes,
+            guest_contracts::session_history_identity::SESSION_HISTORY_IDENTITY_HOST_READ_MAX_BYTES
+                + 1
+        );
     }
 
     #[test]
-    fn rejects_current_history_above_verify_cap() {
+    fn verifies_large_claude_literal_history() {
         let dir = tempfile::tempdir().unwrap();
         let history_path = dir.path().join("history.jsonl");
-        let expected_history = vec![b'a'; SESSION_HISTORY_IDENTITY_VERIFY_MAX_BYTES as usize];
-        let oversized_history = vec![b'a'; SESSION_HISTORY_IDENTITY_VERIFY_MAX_BYTES as usize + 1];
+        let history = vec![
+            b'a';
+            guest_contracts::session_history_identity::SESSION_HISTORY_IDENTITY_HOST_READ_MAX_BYTES
+                as usize
+                + 1
+        ];
+        std::fs::write(&history_path, &history).unwrap();
+        let identity = FinalSessionHistoryIdentity::new(
+            FinalSessionHistoryFramework::ClaudeCode,
+            "a".repeat(64),
+            FinalSessionHistoryRefKind::Blob,
+            hex::encode(Sha256::digest(&history)),
+            history.len() as u64,
+            history_path.to_string_lossy(),
+        )
+        .unwrap();
+        let metadata_path = write_metadata(&dir, &identity);
+
+        verify_final_session_history_identity_file(metadata_path, None).unwrap();
+    }
+
+    #[test]
+    fn rejects_current_history_larger_than_identity_size() {
+        let dir = tempfile::tempdir().unwrap();
+        let history_path = dir.path().join("history.jsonl");
+        let expected_history = vec![
+            b'a';
+            guest_contracts::session_history_identity::SESSION_HISTORY_IDENTITY_HOST_READ_MAX_BYTES
+                as usize
+        ];
+        let oversized_history = vec![
+            b'a';
+            guest_contracts::session_history_identity::SESSION_HISTORY_IDENTITY_HOST_READ_MAX_BYTES
+                as usize
+                + 1
+        ];
         std::fs::write(&history_path, oversized_history).unwrap();
         let identity = FinalSessionHistoryIdentity::new(
             FinalSessionHistoryFramework::ClaudeCode,
@@ -315,6 +423,29 @@ mod tests {
         assert!(matches!(
             err,
             FinalSessionHistoryIdentityVerifyError::HistoryMismatch
+        ));
+    }
+
+    #[test]
+    fn rejects_history_above_guest_verify_cap() {
+        let dir = tempfile::tempdir().unwrap();
+        let history_path = dir.path().join("history.jsonl");
+        std::fs::write(&history_path, b"small").unwrap();
+        let identity = FinalSessionHistoryIdentity::new(
+            FinalSessionHistoryFramework::ClaudeCode,
+            "a".repeat(64),
+            FinalSessionHistoryRefKind::Blob,
+            "b".repeat(64),
+            SESSION_HISTORY_IDENTITY_GUEST_VERIFY_MAX_BYTES + 1,
+            history_path.to_string_lossy(),
+        )
+        .unwrap();
+        let metadata_path = write_metadata(&dir, &identity);
+
+        let err = verify_final_session_history_identity_file(metadata_path, None).unwrap_err();
+        assert!(matches!(
+            err,
+            FinalSessionHistoryIdentityVerifyError::HistoryTooLarge
         ));
     }
 

--- a/crates/guest-agent/src/session_history_identity.rs
+++ b/crates/guest-agent/src/session_history_identity.rs
@@ -217,6 +217,8 @@ mod tests {
     use super::*;
     use std::io::Write;
 
+    const LARGE_SESSION_HISTORY_SIZE_BYTES: usize = 1024 * 1024 + 1;
+
     fn write_metadata(
         dir: &tempfile::TempDir,
         identity: &FinalSessionHistoryIdentity,
@@ -348,22 +350,20 @@ mod tests {
     }
 
     #[test]
-    fn build_allows_history_above_host_read_cap() {
+    fn build_allows_large_history_metadata() {
         let identity = FinalSessionHistoryIdentity::new(
             FinalSessionHistoryFramework::ClaudeCode,
             "a".repeat(64),
             FinalSessionHistoryRefKind::Blob,
             "b".repeat(64),
-            guest_contracts::session_history_identity::SESSION_HISTORY_IDENTITY_HOST_READ_MAX_BYTES
-                + 1,
+            LARGE_SESSION_HISTORY_SIZE_BYTES as u64,
             "/history.jsonl",
         )
         .unwrap();
 
         assert_eq!(
             identity.history_size_bytes,
-            guest_contracts::session_history_identity::SESSION_HISTORY_IDENTITY_HOST_READ_MAX_BYTES
-                + 1
+            LARGE_SESSION_HISTORY_SIZE_BYTES as u64
         );
     }
 
@@ -371,12 +371,7 @@ mod tests {
     fn verifies_large_claude_literal_history() {
         let dir = tempfile::tempdir().unwrap();
         let history_path = dir.path().join("history.jsonl");
-        let history = vec![
-            b'a';
-            guest_contracts::session_history_identity::SESSION_HISTORY_IDENTITY_HOST_READ_MAX_BYTES
-                as usize
-                + 1
-        ];
+        let history = vec![b'a'; LARGE_SESSION_HISTORY_SIZE_BYTES];
         std::fs::write(&history_path, &history).unwrap();
         let identity = FinalSessionHistoryIdentity::new(
             FinalSessionHistoryFramework::ClaudeCode,
@@ -396,17 +391,8 @@ mod tests {
     fn rejects_current_history_larger_than_identity_size() {
         let dir = tempfile::tempdir().unwrap();
         let history_path = dir.path().join("history.jsonl");
-        let expected_history = vec![
-            b'a';
-            guest_contracts::session_history_identity::SESSION_HISTORY_IDENTITY_HOST_READ_MAX_BYTES
-                as usize
-        ];
-        let oversized_history = vec![
-            b'a';
-            guest_contracts::session_history_identity::SESSION_HISTORY_IDENTITY_HOST_READ_MAX_BYTES
-                as usize
-                + 1
-        ];
+        let expected_history = vec![b'a'; LARGE_SESSION_HISTORY_SIZE_BYTES - 1];
+        let oversized_history = vec![b'a'; LARGE_SESSION_HISTORY_SIZE_BYTES];
         std::fs::write(&history_path, oversized_history).unwrap();
         let identity = FinalSessionHistoryIdentity::new(
             FinalSessionHistoryFramework::ClaudeCode,

--- a/crates/guest-agent/tests/integration/checkpoint.rs
+++ b/crates/guest-agent/tests/integration/checkpoint.rs
@@ -1,11 +1,12 @@
 use crate::support::*;
 use guest_contracts::session_history_identity::{
     FinalSessionHistoryFramework, FinalSessionHistoryIdentity, FinalSessionHistoryRefKind,
-    SESSION_HISTORY_IDENTITY_HOST_READ_MAX_BYTES,
 };
 use httpmock::prelude::*;
 use serde_json::json;
 use sha2::{Digest, Sha256};
+
+const LARGE_SESSION_HISTORY_SIZE_BYTES: usize = 1024 * 1024 + 1;
 
 fn write_derived_claude_history(session_id: &str, history: &str) -> Result<(), String> {
     guest_agent::paths::write_private(guest_agent::paths::session_id_file(), session_id)
@@ -127,7 +128,7 @@ async fn success_checkpoint_writes_large_final_identity_metadata() {
     let server = api.server();
 
     let _files_guard = SessionCheckpointFilesGuard::new();
-    let history = vec![b'a'; SESSION_HISTORY_IDENTITY_HOST_READ_MAX_BYTES as usize + 1];
+    let history = vec![b'a'; LARGE_SESSION_HISTORY_SIZE_BYTES];
     let _history_dir = write_literal_session_history("success-large-session", &history).unwrap();
 
     let history_hash = hex::encode(Sha256::digest(&history));

--- a/crates/guest-agent/tests/integration/checkpoint.rs
+++ b/crates/guest-agent/tests/integration/checkpoint.rs
@@ -1,6 +1,7 @@
 use crate::support::*;
 use guest_contracts::session_history_identity::{
     FinalSessionHistoryFramework, FinalSessionHistoryIdentity, FinalSessionHistoryRefKind,
+    SESSION_HISTORY_IDENTITY_HOST_READ_MAX_BYTES,
 };
 use httpmock::prelude::*;
 use serde_json::json;
@@ -111,6 +112,76 @@ async fn success_checkpoint_uploads_non_utf8_session_history() {
     assert_eq!(
         identity.session_id_hash,
         hex::encode(Sha256::digest(b"success-non-utf8-session"))
+    );
+    assert_eq!(identity.history_hash, history_hash);
+    assert_eq!(identity.history_size_bytes, history_size as u64);
+    assert_eq!(
+        std::fs::read(&identity.history_marker_payload).unwrap(),
+        history
+    );
+}
+
+#[tokio::test]
+async fn success_checkpoint_writes_large_final_identity_metadata() {
+    let api = SharedApiMock::new().await;
+    let server = api.server();
+
+    let _files_guard = SessionCheckpointFilesGuard::new();
+    let history = vec![b'a'; SESSION_HISTORY_IDENTITY_HOST_READ_MAX_BYTES as usize + 1];
+    let _history_dir = write_literal_session_history("success-large-session", &history).unwrap();
+
+    let history_hash = hex::encode(Sha256::digest(&history));
+    let history_size = history.len();
+    let prepare_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history")
+            .json_body(json!({
+                "runId": "test-run-001",
+                "hash": history_hash,
+                "size": history_size,
+            }));
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({
+                "presignedUrl": server.url("/test/success-large-history-upload"),
+                "existing": false
+            }));
+    });
+    let upload_len = history_size.to_string();
+    let upload_body = history.clone();
+    let upload_mock = server.mock(|when, then| {
+        when.method(PUT)
+            .path("/test/success-large-history-upload")
+            .header("Content-Type", "application/octet-stream");
+        then.respond_with(move |req| upload_validation_response(req, &upload_body, &upload_len));
+    });
+    let checkpoint_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints")
+            .json_body_includes(r#"{"cliAgentSessionId":"success-large-session"}"#)
+            .json_body_includes(format!(
+                r#"{{"cliAgentSessionHistoryHash":"{history_hash}"}}"#
+            ));
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({"checkpointId": "checkpoint-success-large"}));
+    });
+
+    let result = guest_agent::checkpoint::create_checkpoint(&http_client!()).await;
+
+    assert!(result.is_ok());
+    prepare_mock.assert_calls_async(1).await;
+    upload_mock.assert_calls_async(1).await;
+    checkpoint_mock.assert_calls_async(1).await;
+
+    let identity_bytes =
+        std::fs::read(guest_agent::paths::final_session_history_identity_file()).unwrap();
+    let identity = FinalSessionHistoryIdentity::from_json_slice(&identity_bytes).unwrap();
+    assert_eq!(identity.framework, FinalSessionHistoryFramework::ClaudeCode);
+    assert_eq!(identity.history_ref_kind, FinalSessionHistoryRefKind::Blob);
+    assert_eq!(
+        identity.session_id_hash,
+        hex::encode(Sha256::digest(b"success-large-session"))
     );
     assert_eq!(identity.history_hash, history_hash);
     assert_eq!(identity.history_size_bytes, history_size as u64);

--- a/crates/guest-contracts/src/session_history_identity.rs
+++ b/crates/guest-contracts/src/session_history_identity.rs
@@ -13,8 +13,32 @@ pub const FINAL_SESSION_HISTORY_IDENTITY_VERSION: u8 = 1;
 /// Maximum size of the serialized final identity metadata file.
 pub const FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES: u64 = 16 * 1024;
 
-/// Maximum session-history bytes verified for idle restore skip.
-pub const SESSION_HISTORY_IDENTITY_VERIFY_MAX_BYTES: u64 = 1024 * 1024;
+/// Maximum raw session-history bytes the runner may read from a guest path.
+pub const SESSION_HISTORY_IDENTITY_HOST_READ_MAX_BYTES: u64 = 1024 * 1024;
+
+/// Maximum decoded session-history bytes the guest helper may verify locally.
+pub const SESSION_HISTORY_IDENTITY_GUEST_VERIFY_MAX_BYTES: u64 = 32 * 1024 * 1024;
+
+/// Guest helper exit code for successful final identity verification.
+pub const SESSION_HISTORY_IDENTITY_VERIFY_EXIT_SUCCESS: i32 = 0;
+/// Guest helper exit code for uncategorized final identity verification failure.
+pub const SESSION_HISTORY_IDENTITY_VERIFY_EXIT_FAILURE: i32 = 1;
+/// Guest helper exit code for invalid command arguments.
+pub const SESSION_HISTORY_IDENTITY_VERIFY_EXIT_INVALID_ARGS: i32 = 2;
+/// Guest helper exit code for metadata read failure.
+pub const SESSION_HISTORY_IDENTITY_VERIFY_EXIT_METADATA_READ: i32 = 3;
+/// Guest helper exit code for invalid metadata.
+pub const SESSION_HISTORY_IDENTITY_VERIFY_EXIT_INVALID_METADATA: i32 = 4;
+/// Guest helper exit code for framework/marker mismatch.
+pub const SESSION_HISTORY_IDENTITY_VERIFY_EXIT_FRAMEWORK_MISMATCH: i32 = 5;
+/// Guest helper exit code for expected identity mismatch.
+pub const SESSION_HISTORY_IDENTITY_VERIFY_EXIT_EXPECTED_MISMATCH: i32 = 6;
+/// Guest helper exit code for local history read failure.
+pub const SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_READ: i32 = 7;
+/// Guest helper exit code for local history size/hash mismatch.
+pub const SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_MISMATCH: i32 = 8;
+/// Guest helper exit code for local history exceeding the guest verification budget.
+pub const SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_TOO_LARGE: i32 = 9;
 
 /// Framework that owns a final session-history file.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -112,9 +136,6 @@ impl FinalSessionHistoryIdentity {
         }
         if self.history_size_bytes == 0 {
             return Err(FinalSessionHistoryIdentityError::InvalidHistorySize);
-        }
-        if self.history_size_bytes > SESSION_HISTORY_IDENTITY_VERIFY_MAX_BYTES {
-            return Err(FinalSessionHistoryIdentityError::HistoryTooLarge);
         }
         if self.history_marker_payload.trim().is_empty() {
             return Err(FinalSessionHistoryIdentityError::MissingHistoryMarker);
@@ -232,9 +253,6 @@ impl FinalSessionHistoryIdentityExpectation {
         if self.history_size_bytes == 0 {
             return Err(FinalSessionHistoryIdentityError::InvalidHistorySize);
         }
-        if self.history_size_bytes > SESSION_HISTORY_IDENTITY_VERIFY_MAX_BYTES {
-            return Err(FinalSessionHistoryIdentityError::HistoryTooLarge);
-        }
         Ok(())
     }
 
@@ -281,7 +299,7 @@ pub enum FinalSessionHistoryIdentityError {
     InvalidHistoryHash,
     /// History size is zero.
     InvalidHistorySize,
-    /// History size exceeds the verification cap.
+    /// History size exceeds a verifier work budget.
     HistoryTooLarge,
     /// History marker payload is missing.
     MissingHistoryMarker,
@@ -382,7 +400,7 @@ mod tests {
     }
 
     #[test]
-    fn final_identity_rejects_zero_and_oversized_history() {
+    fn final_identity_rejects_zero_history() {
         let err = FinalSessionHistoryIdentity::new(
             FinalSessionHistoryFramework::ClaudeCode,
             "a".repeat(64),
@@ -393,17 +411,28 @@ mod tests {
         )
         .unwrap_err();
         assert_eq!(err, FinalSessionHistoryIdentityError::InvalidHistorySize);
+    }
 
-        let err = FinalSessionHistoryIdentity::new(
+    #[test]
+    fn final_identity_accepts_large_history_size() {
+        let identity = FinalSessionHistoryIdentity::new(
             FinalSessionHistoryFramework::ClaudeCode,
             "a".repeat(64),
             FinalSessionHistoryRefKind::Blob,
             "b".repeat(64),
-            SESSION_HISTORY_IDENTITY_VERIFY_MAX_BYTES + 1,
+            SESSION_HISTORY_IDENTITY_GUEST_VERIFY_MAX_BYTES + 1,
             "/history.jsonl",
         )
-        .unwrap_err();
-        assert_eq!(err, FinalSessionHistoryIdentityError::HistoryTooLarge);
+        .unwrap();
+
+        assert_eq!(
+            identity.history_size_bytes,
+            SESSION_HISTORY_IDENTITY_GUEST_VERIFY_MAX_BYTES + 1
+        );
+        assert_eq!(
+            FinalSessionHistoryIdentity::from_json_slice(&identity.to_json_vec().unwrap()).unwrap(),
+            identity
+        );
     }
 
     #[test]
@@ -444,6 +473,23 @@ mod tests {
         .unwrap();
 
         assert!(expectation.matches_identity(&identity));
+    }
+
+    #[test]
+    fn final_identity_expectation_accepts_large_history_size() {
+        let expectation = FinalSessionHistoryIdentityExpectation::new(
+            FinalSessionHistoryFramework::ClaudeCode,
+            "a".repeat(64),
+            FinalSessionHistoryRefKind::Blob,
+            "b".repeat(64),
+            SESSION_HISTORY_IDENTITY_GUEST_VERIFY_MAX_BYTES + 1,
+        )
+        .unwrap();
+
+        assert_eq!(
+            expectation.history_size_bytes,
+            SESSION_HISTORY_IDENTITY_GUEST_VERIFY_MAX_BYTES + 1
+        );
     }
 
     #[test]

--- a/crates/guest-contracts/src/session_history_identity.rs
+++ b/crates/guest-contracts/src/session_history_identity.rs
@@ -13,9 +13,6 @@ pub const FINAL_SESSION_HISTORY_IDENTITY_VERSION: u8 = 1;
 /// Maximum size of the serialized final identity metadata file.
 pub const FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES: u64 = 16 * 1024;
 
-/// Maximum raw session-history bytes the runner may read from a guest path.
-pub const SESSION_HISTORY_IDENTITY_HOST_READ_MAX_BYTES: u64 = 1024 * 1024;
-
 /// Maximum decoded session-history bytes the guest helper may verify locally.
 pub const SESSION_HISTORY_IDENTITY_GUEST_VERIFY_MAX_BYTES: u64 = 32 * 1024 * 1024;
 

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -563,7 +563,7 @@ mod tests {
         codex_thread_id::canonical_codex_thread_id,
         session_history_identity::{
             FinalSessionHistoryFramework, FinalSessionHistoryIdentity, FinalSessionHistoryRefKind,
-            SESSION_HISTORY_IDENTITY_VERIFY_MAX_BYTES,
+            SESSION_HISTORY_IDENTITY_HOST_READ_MAX_BYTES,
         },
     };
     use sandbox::SandboxFactory;
@@ -1076,12 +1076,12 @@ mod tests {
         let http = test_http_client();
         let context = context_with_history_ref_and_size(
             "history-hash-a",
-            Some(SESSION_HISTORY_IDENTITY_VERIFY_MAX_BYTES),
+            Some(SESSION_HISTORY_IDENTITY_HOST_READ_MAX_BYTES),
         );
         let restored_identity = RestoredSessionIdentity::from_context(&context)
             .unwrap()
             .with_guest_history(
-                SESSION_HISTORY_IDENTITY_VERIFY_MAX_BYTES,
+                SESSION_HISTORY_IDENTITY_HOST_READ_MAX_BYTES,
                 "/home/user/.claude/projects/-home-user-workspace/session.jsonl",
             );
         let reusable_sandbox = reusable_sandbox_with_identity(Some(restored_identity)).await;

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -243,7 +243,7 @@ fn build_session_history_restore_plan(
                         return SessionHistoryRestorePlan::SkipVerified(restored_identity.clone());
                     }
                     Some(restored_identity) if restored_identity == &requested_identity => {
-                        if restored_identity.has_guest_history_verification() {
+                        if restored_identity.has_final_metadata_verification() {
                             Some(SessionHistoryRestoreFallback::IdentityMismatch)
                         } else {
                             Some(SessionHistoryRestoreFallback::UnverifiedIdleIdentity)

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -563,7 +563,6 @@ mod tests {
         codex_thread_id::canonical_codex_thread_id,
         session_history_identity::{
             FinalSessionHistoryFramework, FinalSessionHistoryIdentity, FinalSessionHistoryRefKind,
-            SESSION_HISTORY_IDENTITY_HOST_READ_MAX_BYTES,
         },
     };
     use sandbox::SandboxFactory;
@@ -758,43 +757,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn restore_plan_skips_matching_reused_identity() {
-        let http = test_http_client();
-        let context = context_with_history_ref("history-hash-a");
-        let requested_identity = RestoredSessionIdentity::from_context(&context).unwrap();
-        let restored_identity = requested_identity.clone().with_guest_history(
-            12,
-            "/home/user/.claude/projects/-home-user-workspace/session.jsonl",
-        );
-        let reusable_sandbox =
-            reusable_sandbox_with_identity(Some(restored_identity.clone())).await;
-        let cancel = RunCancellationHandle::new();
-        let mut timing = RunnerPreSpawnTiming::start_after_claim();
-
-        let plan = build_session_history_restore_plan(
-            &http,
-            &context,
-            true,
-            &cancel,
-            Some(&reusable_sandbox),
-            SandboxReuseResult::Reused,
-            &mut timing,
-        );
-
-        match plan {
-            SessionHistoryRestorePlan::SkipVerified(identity) => {
-                assert_eq!(identity, restored_identity);
-                assert_eq!(identity.history_size_bytes(), Some(12));
-                assert_eq!(
-                    identity.guest_history_path(),
-                    Some("/home/user/.claude/projects/-home-user-workspace/session.jsonl")
-                );
-            }
-            _ => panic!("matching reused identity should skip restore"),
-        }
-    }
-
-    #[tokio::test]
     async fn restore_plan_skips_matching_checkpointed_final_identity() {
         let http = test_http_client();
         let history_hash = "a".repeat(64);
@@ -833,7 +795,6 @@ mod tests {
             SessionHistoryRestorePlan::SkipVerified(identity) => {
                 assert_eq!(identity, restored_identity);
                 assert_eq!(identity.history_size_bytes(), Some(12));
-                assert_eq!(identity.guest_history_path(), None);
                 assert_eq!(identity.final_metadata_path(), Some(metadata_path));
             }
             _ => panic!("matching checkpointed final identity should skip restore"),
@@ -893,7 +854,6 @@ mod tests {
             SessionHistoryRestorePlan::SkipVerified(identity) => {
                 assert_eq!(identity, restored_identity);
                 assert_eq!(identity.history_size_bytes(), Some(12));
-                assert_eq!(identity.guest_history_path(), None);
                 assert_eq!(identity.final_metadata_path(), Some(metadata_path));
             }
             _ => panic!("matching Codex checkpointed final identity should skip restore"),
@@ -903,13 +863,23 @@ mod tests {
     #[tokio::test]
     async fn restore_plan_skips_identity_parked_by_finalizer() {
         let http = test_http_client();
-        let context = context_with_history_ref("history-hash-a");
-        let restored_identity = RestoredSessionIdentity::from_context(&context)
-            .unwrap()
-            .with_guest_history(
-                12,
-                "/home/user/.claude/projects/-home-user-workspace/session.jsonl",
-            );
+        let history_hash = "a".repeat(64);
+        let context = context_with_history_ref(&history_hash);
+        let metadata = FinalSessionHistoryIdentity::new(
+            FinalSessionHistoryFramework::ClaudeCode,
+            hex::encode(Sha256::digest(b"sess-restore-plan")),
+            FinalSessionHistoryRefKind::Blob,
+            history_hash,
+            12,
+            "/home/user/.claude/projects/-home-user-workspace/session.jsonl",
+        )
+        .unwrap();
+        let restored_identity = RestoredSessionIdentity::from_final_metadata(
+            metadata,
+            "/home/user/.vm0/guest-agent/runs/previous/final-session-history-identity.json",
+            "/home/user/.vm0/guest-agent/runs/previous",
+        )
+        .expect("checkpointed final identity");
         let reusable_sandbox =
             reusable_sandbox_parked_by_finalizer(Some(restored_identity.clone())).await;
         let cancel = RunCancellationHandle::new();
@@ -936,12 +906,23 @@ mod tests {
     #[tokio::test]
     async fn restore_plan_skips_matching_reused_identity_without_requested_size() {
         let http = test_http_client();
-        let context = context_with_history_ref_and_size("history-hash-a", None);
-        let requested_identity = RestoredSessionIdentity::from_context(&context).unwrap();
-        let restored_identity = requested_identity.clone().with_guest_history(
+        let history_hash = "a".repeat(64);
+        let context = context_with_history_ref_and_size(&history_hash, None);
+        let metadata = FinalSessionHistoryIdentity::new(
+            FinalSessionHistoryFramework::ClaudeCode,
+            hex::encode(Sha256::digest(b"sess-restore-plan")),
+            FinalSessionHistoryRefKind::Blob,
+            history_hash,
             12,
             "/home/user/.claude/projects/-home-user-workspace/session.jsonl",
-        );
+        )
+        .unwrap();
+        let restored_identity = RestoredSessionIdentity::from_final_metadata(
+            metadata,
+            "/home/user/.vm0/guest-agent/runs/previous/final-session-history-identity.json",
+            "/home/user/.vm0/guest-agent/runs/previous",
+        )
+        .expect("checkpointed final identity");
         let reusable_sandbox =
             reusable_sandbox_with_identity(Some(restored_identity.clone())).await;
         let cancel = RunCancellationHandle::new();
@@ -961,10 +942,6 @@ mod tests {
             SessionHistoryRestorePlan::SkipVerified(identity) => {
                 assert_eq!(identity, restored_identity);
                 assert_eq!(identity.history_size_bytes(), Some(12));
-                assert_eq!(
-                    identity.guest_history_path(),
-                    Some("/home/user/.claude/projects/-home-user-workspace/session.jsonl")
-                );
             }
             _ => panic!("missing requested size should still allow verified skip"),
         }
@@ -1001,51 +978,25 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn restore_plan_falls_back_when_matching_reused_identity_has_invalid_history_path() {
-        for guest_history_path in ["", "relative/session.jsonl"] {
-            let http = test_http_client();
-            let context = context_with_history_ref("history-hash-a");
-            let restored_identity = RestoredSessionIdentity::from_context(&context)
-                .unwrap()
-                .with_guest_history(12, guest_history_path);
-            let reusable_sandbox = reusable_sandbox_with_identity(Some(restored_identity)).await;
-            let cancel = RunCancellationHandle::new();
-            let mut timing = RunnerPreSpawnTiming::start_after_claim();
-
-            let plan = build_session_history_restore_plan(
-                &http,
-                &context,
-                true,
-                &cancel,
-                Some(&reusable_sandbox),
-                SandboxReuseResult::Reused,
-                &mut timing,
-            );
-
-            match plan {
-                SessionHistoryRestorePlan::Prestarted { fallback, .. } => {
-                    assert_eq!(
-                        fallback,
-                        Some(SessionHistoryRestoreFallback::UnverifiedIdleIdentity)
-                    );
-                }
-                _ => {
-                    panic!("reused identity with invalid history path should fall back to restore")
-                }
-            }
-        }
-    }
-
-    #[tokio::test]
     async fn restore_plan_falls_back_when_matching_reused_identity_size_mismatches() {
         let http = test_http_client();
-        let context = context_with_history_ref("history-hash-a");
-        let restored_identity = RestoredSessionIdentity::from_context(&context)
-            .unwrap()
-            .with_guest_history(
-                13,
-                "/home/user/.claude/projects/-home-user-workspace/session.jsonl",
-            );
+        let history_hash = "a".repeat(64);
+        let context = context_with_history_ref(&history_hash);
+        let metadata = FinalSessionHistoryIdentity::new(
+            FinalSessionHistoryFramework::ClaudeCode,
+            hex::encode(Sha256::digest(b"sess-restore-plan")),
+            FinalSessionHistoryRefKind::Blob,
+            history_hash,
+            13,
+            "/home/user/.claude/projects/-home-user-workspace/session.jsonl",
+        )
+        .unwrap();
+        let restored_identity = RestoredSessionIdentity::from_final_metadata(
+            metadata,
+            "/home/user/.vm0/guest-agent/runs/previous/final-session-history-identity.json",
+            "/home/user/.vm0/guest-agent/runs/previous",
+        )
+        .expect("checkpointed final identity");
         let reusable_sandbox = reusable_sandbox_with_identity(Some(restored_identity)).await;
         let cancel = RunCancellationHandle::new();
         let mut timing = RunnerPreSpawnTiming::start_after_claim();
@@ -1068,44 +1019,6 @@ mod tests {
                 );
             }
             _ => panic!("reused identity with mismatched size should fall back to restore"),
-        }
-    }
-
-    #[tokio::test]
-    async fn restore_plan_falls_back_when_matching_reused_identity_is_too_large_to_verify() {
-        let http = test_http_client();
-        let context = context_with_history_ref_and_size(
-            "history-hash-a",
-            Some(SESSION_HISTORY_IDENTITY_HOST_READ_MAX_BYTES),
-        );
-        let restored_identity = RestoredSessionIdentity::from_context(&context)
-            .unwrap()
-            .with_guest_history(
-                SESSION_HISTORY_IDENTITY_HOST_READ_MAX_BYTES,
-                "/home/user/.claude/projects/-home-user-workspace/session.jsonl",
-            );
-        let reusable_sandbox = reusable_sandbox_with_identity(Some(restored_identity)).await;
-        let cancel = RunCancellationHandle::new();
-        let mut timing = RunnerPreSpawnTiming::start_after_claim();
-
-        let plan = build_session_history_restore_plan(
-            &http,
-            &context,
-            true,
-            &cancel,
-            Some(&reusable_sandbox),
-            SandboxReuseResult::Reused,
-            &mut timing,
-        );
-
-        match plan {
-            SessionHistoryRestorePlan::Prestarted { fallback, .. } => {
-                assert_eq!(
-                    fallback,
-                    Some(SessionHistoryRestoreFallback::UnverifiedIdleIdentity)
-                );
-            }
-            _ => panic!("oversized reused identity should fall back to prestarted restore"),
         }
     }
 

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -1191,11 +1191,7 @@ mod tests {
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
         let cleanup_state = RunCleanupState::new();
-        let identity = RestoredSessionIdentity::claude_code_for_test("history-hash-a")
-            .with_guest_history(
-                12,
-                "/home/user/.claude/projects/-home-user-workspace/session.jsonl",
-            );
+        let identity = RestoredSessionIdentity::claude_code_for_test("history-hash-a");
         let finalization = fixture.finalization_phase(
             run_id,
             sandbox_id,

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -16,7 +16,6 @@ use sandbox::{
     EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, ExecTermination, ProcessControlMode, ProcessOutputMode,
     Sandbox, StartProcessRequest,
 };
-use sha2::{Digest, Sha256};
 use shell_quote::quote_shell_arg;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
@@ -93,10 +92,6 @@ enum SessionHistoryIdentityReason {
     VerifyRequestMissing,
     VerifyRequestMismatch,
     VerifyMissingVerifier,
-    VerifyMissingFile,
-    VerifyReadFailed,
-    VerifySizeMismatch,
-    VerifyHashMismatch,
     VerifyHelperFailed,
     VerifyHelperTimedOut,
     VerifyHelperInvalidArgs,
@@ -131,10 +126,6 @@ impl SessionHistoryIdentityReason {
             Self::VerifyRequestMissing => "session_history_identity_verify_request_missing",
             Self::VerifyRequestMismatch => "session_history_identity_verify_request_mismatch",
             Self::VerifyMissingVerifier => "session_history_identity_verify_missing_verifier",
-            Self::VerifyMissingFile => "session_history_identity_verify_missing_file",
-            Self::VerifyReadFailed => "session_history_identity_verify_read_failed",
-            Self::VerifySizeMismatch => "session_history_identity_verify_size_mismatch",
-            Self::VerifyHashMismatch => "session_history_identity_verify_hash_mismatch",
             Self::VerifyHelperFailed => "session_history_identity_verify_helper_failed",
             Self::VerifyHelperTimedOut => "session_history_identity_verify_helper_timed_out",
             Self::VerifyHelperInvalidArgs => "session_history_identity_verify_helper_invalid_args",
@@ -254,93 +245,27 @@ async fn verify_restored_session_identity_for_reuse(
         return Err(SessionHistoryIdentityReason::VerifyRequestMismatch);
     }
 
-    match verification {
-        RestoredSessionHistoryVerification::GuestHistoryPath {
-            expected_size,
-            guest_history_path,
-            read_limit,
-        } => {
-            let guest_history_path = guest_history_path.to_owned();
-            verify_guest_history_path_identity(
-                sandbox,
-                context,
-                identity,
-                expected_size,
-                &guest_history_path,
-                read_limit,
-            )
-            .await
-        }
-        RestoredSessionHistoryVerification::FinalIdentityMetadata {
-            metadata_path,
-            runtime_dir,
-            framework,
-            session_id_hash,
-            history_ref_kind,
-            history_hash,
-            history_size_bytes,
-        } => {
-            let metadata_path = metadata_path.to_owned();
-            let runtime_dir = runtime_dir.to_owned();
-            let command = build_final_identity_verify_command(
-                guest::RUN_AGENT,
-                &metadata_path,
-                framework.as_str(),
-                session_id_hash,
-                history_ref_kind.as_str(),
-                history_hash,
-                history_size_bytes,
-            );
-            verify_final_identity_metadata(sandbox, context, identity, command, &runtime_dir).await
-        }
-    }
-}
-
-async fn verify_guest_history_path_identity(
-    sandbox: &dyn Sandbox,
-    context: &ExecutionContext,
-    identity: RestoredSessionIdentity,
-    expected_size: u64,
-    guest_history_path: &str,
-    read_limit: u64,
-) -> Result<RestoredSessionIdentity, SessionHistoryIdentityReason> {
-    let read_result = sandbox.read_file(guest_history_path, read_limit).await;
-    let bytes = match read_result {
-        Ok(Some(bytes)) => bytes,
-        Ok(None) => {
-            debug!(
-                run_id = %context.run_id,
-                "restored session identity invalidated because history file is missing"
-            );
-            return Err(SessionHistoryIdentityReason::VerifyMissingFile);
-        }
-        Err(_) => {
-            debug!(
-                run_id = %context.run_id,
-                "restored session identity verification failed"
-            );
-            return Err(SessionHistoryIdentityReason::VerifyReadFailed);
-        }
-    };
-    if bytes.len() as u64 != expected_size {
-        debug!(
-            run_id = %context.run_id,
-            expected_size = expected_size,
-            actual_size = bytes.len(),
-            "restored session identity invalidated because history size changed"
-        );
-        return Err(SessionHistoryIdentityReason::VerifySizeMismatch);
-    }
-    let actual_hash = hex::encode(Sha256::digest(&bytes));
-    if actual_hash != identity.history_hash() {
-        debug!(
-            run_id = %context.run_id,
-            "restored session identity invalidated because history hash changed"
-        );
-        return Err(SessionHistoryIdentityReason::VerifyHashMismatch);
-    }
-
-    Ok(identity)
+    let RestoredSessionHistoryVerification {
+        metadata_path,
+        runtime_dir,
+        framework,
+        session_id_hash,
+        history_ref_kind,
+        history_hash,
+        history_size_bytes,
+    } = verification;
+    let metadata_path = metadata_path.to_owned();
+    let runtime_dir = runtime_dir.to_owned();
+    let command = build_final_identity_verify_command(
+        guest::RUN_AGENT,
+        &metadata_path,
+        framework.as_str(),
+        session_id_hash,
+        history_ref_kind.as_str(),
+        history_hash,
+        history_size_bytes,
+    );
+    verify_final_identity_metadata(sandbox, context, identity, command, &runtime_dir).await
 }
 
 async fn verify_final_identity_metadata(
@@ -807,7 +732,6 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
 
     let mut session_restore_diagnostics = None;
     let mut restored_session_identity = None;
-    let mut produced_restored_session_identity = false;
     let session_history_materializer = match session_history_restore_plan {
         SessionHistoryRestorePlan::SkipVerified(identity) => {
             match verify_restored_session_identity_for_reuse(sandbox, context, identity).await {
@@ -925,8 +849,6 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                 err.as_deref(),
             );
             let diagnostics = result?;
-            restored_session_identity = diagnostics.restored_session_identity.clone();
-            produced_restored_session_identity = restored_session_identity.is_some();
             session_restore_diagnostics = Some(diagnostics);
         }
     }
@@ -1390,14 +1312,6 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                     .await
                     {
                         Ok(verified_restored_session_identity) => {
-                            if produced_restored_session_identity {
-                                telemetry.record(
-                                    "session_history_identity_restored",
-                                    Duration::ZERO,
-                                    true,
-                                    None,
-                                );
-                            }
                             restored_session_identity = Some(verified_restored_session_identity);
                         }
                         Err(reason) => {

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -3,6 +3,14 @@ use std::time::{Duration, Instant};
 use guest_contracts::diagnostics::FailureDiagnostic;
 use guest_contracts::session_history_identity::{
     FinalSessionHistoryIdentity, FinalSessionHistoryIdentityError,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_EXPECTED_MISMATCH,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_FRAMEWORK_MISMATCH,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_MISMATCH,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_READ,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_TOO_LARGE,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_INVALID_ARGS,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_INVALID_METADATA,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_METADATA_READ,
 };
 use sandbox::{
     EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, ExecTermination, ProcessControlMode, ProcessOutputMode,
@@ -90,6 +98,15 @@ enum SessionHistoryIdentityReason {
     VerifySizeMismatch,
     VerifyHashMismatch,
     VerifyHelperFailed,
+    VerifyHelperTimedOut,
+    VerifyHelperInvalidArgs,
+    VerifyHelperMetadataRead,
+    VerifyHelperInvalidMetadata,
+    VerifyHelperFrameworkMismatch,
+    VerifyHelperExpectedMismatch,
+    VerifyHelperHistoryRead,
+    VerifyHelperHistoryMismatch,
+    VerifyHelperHistoryTooLarge,
     VerifyHelperExecError,
     ReuseMissingNoIdleIdentity,
 }
@@ -119,6 +136,29 @@ impl SessionHistoryIdentityReason {
             Self::VerifySizeMismatch => "session_history_identity_verify_size_mismatch",
             Self::VerifyHashMismatch => "session_history_identity_verify_hash_mismatch",
             Self::VerifyHelperFailed => "session_history_identity_verify_helper_failed",
+            Self::VerifyHelperTimedOut => "session_history_identity_verify_helper_timed_out",
+            Self::VerifyHelperInvalidArgs => "session_history_identity_verify_helper_invalid_args",
+            Self::VerifyHelperMetadataRead => {
+                "session_history_identity_verify_helper_metadata_read_failed"
+            }
+            Self::VerifyHelperInvalidMetadata => {
+                "session_history_identity_verify_helper_invalid_metadata"
+            }
+            Self::VerifyHelperFrameworkMismatch => {
+                "session_history_identity_verify_helper_framework_mismatch"
+            }
+            Self::VerifyHelperExpectedMismatch => {
+                "session_history_identity_verify_helper_expected_mismatch"
+            }
+            Self::VerifyHelperHistoryRead => {
+                "session_history_identity_verify_helper_history_read_failed"
+            }
+            Self::VerifyHelperHistoryMismatch => {
+                "session_history_identity_verify_helper_history_mismatch"
+            }
+            Self::VerifyHelperHistoryTooLarge => {
+                "session_history_identity_verify_helper_history_too_large"
+            }
             Self::VerifyHelperExecError => "session_history_identity_verify_helper_exec_error",
             Self::ReuseMissingNoIdleIdentity => {
                 "session_history_identity_reuse_missing_no_idle_identity"
@@ -333,7 +373,7 @@ async fn verify_final_identity_metadata(
                 termination = %helper_exec_termination_label(&result),
                 "restored session identity final metadata verification failed"
             );
-            Err(SessionHistoryIdentityReason::VerifyHelperFailed)
+            Err(session_history_identity_reason_from_helper_result(&result))
         }
         Err(_) => {
             debug!(
@@ -341,6 +381,44 @@ async fn verify_final_identity_metadata(
                 "restored session identity final metadata verification errored"
             );
             Err(SessionHistoryIdentityReason::VerifyHelperExecError)
+        }
+    }
+}
+
+fn session_history_identity_reason_from_helper_result(
+    result: &sandbox::ExecResult,
+) -> SessionHistoryIdentityReason {
+    match result.termination {
+        ExecTermination::TimedOut => SessionHistoryIdentityReason::VerifyHelperTimedOut,
+        ExecTermination::Exited { exit_code } => match exit_code {
+            SESSION_HISTORY_IDENTITY_VERIFY_EXIT_INVALID_ARGS => {
+                SessionHistoryIdentityReason::VerifyHelperInvalidArgs
+            }
+            SESSION_HISTORY_IDENTITY_VERIFY_EXIT_METADATA_READ => {
+                SessionHistoryIdentityReason::VerifyHelperMetadataRead
+            }
+            SESSION_HISTORY_IDENTITY_VERIFY_EXIT_INVALID_METADATA => {
+                SessionHistoryIdentityReason::VerifyHelperInvalidMetadata
+            }
+            SESSION_HISTORY_IDENTITY_VERIFY_EXIT_FRAMEWORK_MISMATCH => {
+                SessionHistoryIdentityReason::VerifyHelperFrameworkMismatch
+            }
+            SESSION_HISTORY_IDENTITY_VERIFY_EXIT_EXPECTED_MISMATCH => {
+                SessionHistoryIdentityReason::VerifyHelperExpectedMismatch
+            }
+            SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_READ => {
+                SessionHistoryIdentityReason::VerifyHelperHistoryRead
+            }
+            SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_MISMATCH => {
+                SessionHistoryIdentityReason::VerifyHelperHistoryMismatch
+            }
+            SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_TOO_LARGE => {
+                SessionHistoryIdentityReason::VerifyHelperHistoryTooLarge
+            }
+            _ => SessionHistoryIdentityReason::VerifyHelperFailed,
+        },
+        ExecTermination::Cancelled | ExecTermination::StartFailed | ExecTermination::WaitFailed => {
+            SessionHistoryIdentityReason::VerifyHelperFailed
         }
     }
 }

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -46,7 +46,7 @@ use crate::active_input::ActiveInputSource;
 use crate::helper_exec::{helper_exec_succeeded, helper_exec_termination_label};
 use crate::paths::guest;
 use crate::restored_session_identity::{
-    FINAL_SESSION_HISTORY_IDENTITY_READ_LIMIT, RestoredSessionHistoryVerification,
+    FINAL_SESSION_HISTORY_IDENTITY_READ_LIMIT, RestoredSessionFinalMetadataVerification,
     RestoredSessionIdentity,
 };
 use crate::telemetry::JobTelemetry;
@@ -234,10 +234,10 @@ async fn verify_restored_session_identity_for_reuse(
         );
         return Err(SessionHistoryIdentityReason::VerifyRequestMismatch);
     }
-    let Some(verification) = identity.guest_history_verification() else {
+    let Some(verification) = identity.final_metadata_verification() else {
         debug!(
             run_id = %context.run_id,
-            "restored session identity cannot be verified without a bounded verifier"
+            "restored session identity cannot be verified without a final metadata verifier"
         );
         return Err(SessionHistoryIdentityReason::VerifyMissingVerifier);
     };
@@ -245,7 +245,7 @@ async fn verify_restored_session_identity_for_reuse(
         return Err(SessionHistoryIdentityReason::VerifyRequestMismatch);
     }
 
-    let RestoredSessionHistoryVerification {
+    let RestoredSessionFinalMetadataVerification {
         metadata_path,
         runtime_dir,
         framework,

--- a/crates/runner/src/executor/session_restore.rs
+++ b/crates/runner/src/executor/session_restore.rs
@@ -39,7 +39,6 @@ impl RestoredSessionIdentity {
             history_ref.kind,
             history_ref.hash.clone(),
             history_ref.size,
-            None,
         ))
     }
 }
@@ -123,7 +122,6 @@ pub(super) struct SessionRestoreDiagnostics {
     pub(super) framework: &'static str,
     pub(super) session_fingerprint: String,
     pub(super) bytes_in: usize,
-    pub(super) restored_session_identity: Option<RestoredSessionIdentity>,
 }
 
 pub(super) async fn restore_session(
@@ -175,9 +173,6 @@ pub(super) async fn restore_claude_session(
         framework: "claude-code",
         session_fingerprint: diagnostic_session_fingerprint(session_id),
         bytes_in: session_history.len(),
-        restored_session_identity: RestoredSessionIdentity::from_context(context).map(|identity| {
-            identity.with_guest_history(session_history.len() as u64, session_path.clone())
-        }),
     };
     info!(
         run_id = %context.run_id,

--- a/crates/runner/src/executor/session_restore/codex.rs
+++ b/crates/runner/src/executor/session_restore/codex.rs
@@ -8,7 +8,6 @@ use super::{
 };
 use crate::helper_exec::{format_helper_exec_failure, helper_exec_succeeded};
 use crate::paths::diagnostic_session_fingerprint;
-use crate::restored_session_identity::RestoredSessionIdentity;
 use crate::types::ExecutionContext;
 
 use super::super::{DEFAULT_EXEC_TIMEOUT, RunnerError, RunnerResult};
@@ -127,9 +126,6 @@ pub(super) async fn restore_codex_session(
         framework: "codex",
         session_fingerprint: diagnostic_session_fingerprint(session_id),
         bytes_in: session_history.len(),
-        restored_session_identity: RestoredSessionIdentity::from_context(context).map(|identity| {
-            identity.with_guest_history(session_history.len() as u64, session_path.clone())
-        }),
     };
     info!(
         run_id = %context.run_id,

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -10,7 +10,8 @@ use api_contracts::generated::types::runners::storage::StorageManifest;
 use guest_contracts::session_history_identity::{
     FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES, FinalSessionHistoryFramework,
     FinalSessionHistoryIdentity, FinalSessionHistoryRefKind,
-    SESSION_HISTORY_IDENTITY_VERIFY_MAX_BYTES,
+    SESSION_HISTORY_IDENTITY_HOST_READ_MAX_BYTES,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_MISMATCH,
 };
 use httpmock::prelude::*;
 use sandbox::{
@@ -538,12 +539,12 @@ async fn run_in_sandbox_skips_checkpointed_final_session_history_restore() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
     let sandbox = sandbox_mock::MockSandbox::new("test");
-    let history = br#"{"type":"init"}"#;
+    let history = vec![b'a'; SESSION_HISTORY_IDENTITY_HOST_READ_MAX_BYTES as usize + 1];
     let server = MockServer::start_async().await;
     let history_mock = server
         .mock_async(|when, then| {
             when.method(GET).path("/history.blob");
-            then.status(200).body(history);
+            then.status(200).body(history.clone());
         })
         .await;
     let mut ctx = minimal_context();
@@ -553,7 +554,7 @@ async fn run_in_sandbox_skips_checkpointed_final_session_history_restore() {
         history: ResumeSessionHistory::Ref {
             history_ref: ResumeSessionHistoryRef {
                 kind: ResumeSessionHistoryRefKind::Blob,
-                hash: hex::encode(Sha256::digest(history)),
+                hash: hex::encode(Sha256::digest(&history)),
                 url: server.url("/history.blob?token=secret"),
                 size: Some(history.len() as u64),
             },
@@ -567,7 +568,7 @@ async fn run_in_sandbox_skips_checkpointed_final_session_history_restore() {
         FinalSessionHistoryFramework::ClaudeCode,
         hex::encode(Sha256::digest(session_id.as_bytes())),
         FinalSessionHistoryRefKind::Blob,
-        hex::encode(Sha256::digest(history)),
+        hex::encode(Sha256::digest(&history)),
         history.len() as u64,
         claude_history_path(session_id),
     )
@@ -654,7 +655,7 @@ async fn run_in_sandbox_skips_checkpointed_final_session_history_restore() {
 }
 
 #[tokio::test]
-async fn run_in_sandbox_restores_when_checkpointed_final_identity_helper_fails() {
+async fn run_in_sandbox_restores_when_checkpointed_final_identity_helper_reports_mismatch() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
     let sandbox = sandbox_mock::MockSandbox::new("test");
@@ -667,7 +668,7 @@ async fn run_in_sandbox_restores_when_checkpointed_final_identity_helper_fails()
         })
         .await;
     let mut ctx = minimal_context();
-    let session_id = "sess-final-helper-fails-123";
+    let session_id = "sess-final-helper-mismatch-123";
     ctx.resume_session = Some(ResumeSession {
         cli_agent_session_id: session_id.into(),
         history: ResumeSessionHistory::Ref {
@@ -692,7 +693,11 @@ async fn run_in_sandbox_restores_when_checkpointed_final_identity_helper_fails()
     let idle_identity =
         RestoredSessionIdentity::from_final_metadata(metadata, metadata_path.clone(), runtime_dir)
             .expect("checkpointed identity");
-    sandbox.push_exec_result(Ok(ExecResult::new(1, Vec::new(), Vec::new())));
+    sandbox.push_exec_result(Ok(ExecResult::new(
+        SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_MISMATCH,
+        Vec::new(),
+        Vec::new(),
+    )));
     sandbox.push_read_file_result(Ok(None));
     sandbox.push_read_file_result(Ok(Some(history.to_vec())));
     let mut telemetry = test_telemetry(&config, &ctx);
@@ -737,7 +742,10 @@ async fn run_in_sandbox_restores_when_checkpointed_final_identity_helper_fails()
     assert_eq!(writes[0].path, claude_history_path(session_id));
     assert_eq!(writes[0].content, history);
     let ops = telemetry.pending_ops_snapshot();
-    assert_successful_action(&ops, "session_history_identity_verify_helper_failed");
+    assert_successful_action(
+        &ops,
+        "session_history_identity_verify_helper_history_mismatch",
+    );
     assert!(
         ops.iter()
             .any(|op| op.0 == "session_history_restore_fallback_stale_idle_identity" && op.1),
@@ -1237,7 +1245,7 @@ async fn run_in_sandbox_restores_when_skip_verified_identity_is_too_large_to_ver
     let idle_identity = RestoredSessionIdentity::from_context(&ctx)
         .expect("identity")
         .with_guest_history(
-            SESSION_HISTORY_IDENTITY_VERIFY_MAX_BYTES,
+            SESSION_HISTORY_IDENTITY_HOST_READ_MAX_BYTES,
             "/home/user/.claude/projects/-home-user-workspace/sess-large-skip-123.jsonl",
         );
     sandbox.push_read_file_result(Ok(None));
@@ -1709,18 +1717,19 @@ async fn run_in_sandbox_records_invalid_final_identity_metadata_reason() {
 }
 
 #[tokio::test]
-async fn run_in_sandbox_records_unverifiable_final_identity_metadata_reason() {
+async fn run_in_sandbox_records_large_final_identity_metadata() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
     let sandbox = sandbox_mock::MockSandbox::new("test");
     let ctx = minimal_context();
+    let (metadata_path, _) = final_identity_runtime_paths(&ctx);
     let metadata = serde_json::json!({
         "version": 1,
         "framework": "claude-code",
         "sessionIdHash": "a".repeat(64),
         "historyRefKind": "blob",
         "historyHash": "b".repeat(64),
-        "historySizeBytes": SESSION_HISTORY_IDENTITY_VERIFY_MAX_BYTES + 1,
+        "historySizeBytes": SESSION_HISTORY_IDENTITY_HOST_READ_MAX_BYTES + 1,
         "historyMarkerPayload": "/home/user/.claude/projects/-home-user-workspace/session.jsonl",
     });
     sandbox.push_read_file_result(Ok(Some(serde_json::to_vec(&metadata).unwrap())));
@@ -1742,16 +1751,20 @@ async fn run_in_sandbox_records_unverifiable_final_identity_metadata_reason() {
     .unwrap();
 
     assert!(result.failure.is_none());
-    assert!(result.restored_session_identity.is_none());
-    let ops = telemetry.pending_ops_snapshot();
-    assert_successful_action(
-        &ops,
-        "session_history_identity_finalize_unverifiable_metadata",
+    let identity = result
+        .restored_session_identity
+        .as_ref()
+        .expect("large final identity");
+    assert_eq!(
+        identity.history_size_bytes(),
+        Some(SESSION_HISTORY_IDENTITY_HOST_READ_MAX_BYTES + 1)
     );
+    assert_eq!(identity.final_metadata_path(), Some(metadata_path.as_str()));
+    let ops = telemetry.pending_ops_snapshot();
     assert!(
         ops.iter()
-            .all(|op| op.0 != "session_history_identity_finalized"),
-        "unverifiable metadata should not record finalized identity telemetry, got: {ops:?}"
+            .any(|op| op.0 == "session_history_identity_finalized" && op.1),
+        "large metadata should record finalized identity telemetry, got: {ops:?}"
     );
 }
 

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -10,7 +10,6 @@ use api_contracts::generated::types::runners::storage::StorageManifest;
 use guest_contracts::session_history_identity::{
     FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES, FinalSessionHistoryFramework,
     FinalSessionHistoryIdentity, FinalSessionHistoryRefKind,
-    SESSION_HISTORY_IDENTITY_HOST_READ_MAX_BYTES,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_MISMATCH,
 };
 use httpmock::prelude::*;
@@ -44,6 +43,8 @@ use crate::types::{
     ResumeSession, ResumeSessionHistory, ResumeSessionHistoryRef, ResumeSessionHistoryRefKind,
     SandboxReuseResult,
 };
+
+const LARGE_SESSION_HISTORY_SIZE_BYTES: usize = 1024 * 1024 + 1;
 
 async fn serve_history_once(body: &'static [u8]) -> String {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -453,93 +454,11 @@ async fn run_in_sandbox_uses_prestarted_session_history_materializer() {
 }
 
 #[tokio::test]
-async fn run_in_sandbox_skips_verified_session_history_restore() {
-    let dir = tempfile::tempdir().unwrap();
-    let config = test_executor_config(dir.path()).await;
-    let sandbox = sandbox_mock::MockSandbox::new("test");
-    let history = br#"{"type":"init"}"#;
-    let server = MockServer::start_async().await;
-    let history_mock = server
-        .mock_async(|when, then| {
-            when.method(GET).path("/history.blob");
-            then.status(200).body(history);
-        })
-        .await;
-    let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession {
-        cli_agent_session_id: "sess-skip-123".into(),
-        history: ResumeSessionHistory::Ref {
-            history_ref: ResumeSessionHistoryRef {
-                kind: ResumeSessionHistoryRefKind::Blob,
-                hash: hex::encode(Sha256::digest(history)),
-                url: server.url("/history.blob?token=secret"),
-                size: Some(history.len() as u64),
-            },
-        },
-    });
-    let identity = RestoredSessionIdentity::from_context(&ctx)
-        .expect("identity")
-        .with_guest_history(
-            history.len() as u64,
-            "/home/user/.claude/projects/-home-user-workspace/sess-skip-123.jsonl",
-        );
-    sandbox.push_read_file_result(Ok(Some(history.to_vec())));
-    sandbox.push_read_file_result(Ok(None));
-    sandbox.push_read_file_result(Ok(Some(history.to_vec())));
-    let mut telemetry = test_telemetry(&config, &ctx);
-
-    let result = run_in_sandbox(
-        &sandbox,
-        &ctx,
-        &config,
-        RunStart {
-            restore_guest_state: false,
-            reuse_result: SandboxReuseResult::Reused,
-            prev_storage: None,
-        },
-        &mut telemetry,
-        RunControls::new(tokio_util::sync::CancellationToken::new(), None)
-            .with_session_history_restore_plan(SessionHistoryRestorePlan::SkipVerified(
-                identity.clone(),
-            )),
-    )
-    .await
-    .unwrap();
-
-    assert!(result.failure.is_none());
-    assert_eq!(result.restored_session_identity, Some(identity));
-    assert_eq!(sandbox.read_file_calls().len(), 3);
-    assert!(sandbox.write_file_calls().is_empty());
-    history_mock.assert_calls_async(0).await;
-    let ops = telemetry.pending_ops_snapshot();
-    assert!(
-        ops.iter()
-            .any(|op| op.0 == "session_history_identity_reuse_hit" && op.1),
-        "expected identity reuse hit telemetry, got: {ops:?}"
-    );
-    assert!(
-        ops.iter()
-            .all(|op| op.0 != "session_history_identity_restored"),
-        "skip path should not record newly restored identity telemetry, got: {ops:?}"
-    );
-    assert!(
-        ops.iter()
-            .any(|op| op.0 == "session_history_restore_skip" && op.1),
-        "expected skip telemetry, got: {ops:?}"
-    );
-    assert!(
-        ops.iter()
-            .all(|op| op.0 != "session_history_download" && op.0 != "session_restore"),
-        "skip path should not download or restore, got: {ops:?}"
-    );
-}
-
-#[tokio::test]
 async fn run_in_sandbox_skips_checkpointed_final_session_history_restore() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
     let sandbox = sandbox_mock::MockSandbox::new("test");
-    let history = vec![b'a'; SESSION_HISTORY_IDENTITY_HOST_READ_MAX_BYTES as usize + 1];
+    let history = vec![b'a'; LARGE_SESSION_HISTORY_SIZE_BYTES];
     let server = MockServer::start_async().await;
     let history_mock = server
         .mock_async(|when, then| {
@@ -699,7 +618,6 @@ async fn run_in_sandbox_restores_when_checkpointed_final_identity_helper_reports
         Vec::new(),
     )));
     sandbox.push_read_file_result(Ok(None));
-    sandbox.push_read_file_result(Ok(Some(history.to_vec())));
     let mut telemetry = test_telemetry(&config, &ctx);
 
     let result = run_in_sandbox(
@@ -721,18 +639,7 @@ async fn run_in_sandbox_restores_when_checkpointed_final_identity_helper_reports
     .unwrap();
 
     assert!(result.failure.is_none());
-    let restored_identity = result
-        .restored_session_identity
-        .as_ref()
-        .expect("restored identity");
-    assert_eq!(
-        restored_identity.guest_history_path(),
-        Some(claude_history_path(session_id).as_str())
-    );
-    assert_eq!(
-        restored_identity.history_size_bytes(),
-        Some(history.len() as u64)
-    );
+    assert!(result.restored_session_identity.is_none());
     let exec_calls = sandbox.exec_calls();
     assert_eq!(exec_calls.len(), 1);
     assert!(exec_calls[0].cmd.contains(&metadata_path));
@@ -798,7 +705,6 @@ async fn run_in_sandbox_restores_when_checkpointed_final_identity_helper_exec_er
             .expect("checkpointed identity");
     sandbox.push_exec_result(Err(sandbox_exec_error("vsock exec failed")));
     sandbox.push_read_file_result(Ok(None));
-    sandbox.push_read_file_result(Ok(Some(history.to_vec())));
     let mut telemetry = test_telemetry(&config, &ctx);
 
     let result = run_in_sandbox(
@@ -820,6 +726,7 @@ async fn run_in_sandbox_restores_when_checkpointed_final_identity_helper_exec_er
     .unwrap();
 
     assert!(result.failure.is_none());
+    assert!(result.restored_session_identity.is_none());
     history_mock.assert_calls_async(1).await;
     assert_eq!(sandbox.exec_calls().len(), 1);
     let ops = telemetry.pending_ops_snapshot();
@@ -868,14 +775,8 @@ async fn run_in_sandbox_restores_when_skip_verified_identity_mismatches_request(
             },
         },
     });
-    let idle_identity = RestoredSessionIdentity::from_context(&mismatched_ctx)
-        .expect("identity")
-        .with_guest_history(
-            history.len() as u64,
-            "/home/user/.claude/projects/-home-user-workspace/sess-mismatch-skip-123.jsonl",
-        );
+    let idle_identity = RestoredSessionIdentity::from_context(&mismatched_ctx).expect("identity");
     sandbox.push_read_file_result(Ok(None));
-    sandbox.push_read_file_result(Ok(Some(history.to_vec())));
     let mut telemetry = test_telemetry(&config, &ctx);
 
     let result = run_in_sandbox(
@@ -897,6 +798,7 @@ async fn run_in_sandbox_restores_when_skip_verified_identity_mismatches_request(
     .unwrap();
 
     assert!(result.failure.is_none());
+    assert!(result.restored_session_identity.is_none());
     history_mock.assert_calls_async(1).await;
     let writes = sandbox.write_file_calls();
     assert_eq!(writes.len(), 1);
@@ -905,7 +807,6 @@ async fn run_in_sandbox_restores_when_skip_verified_identity_mismatches_request(
         "/home/user/.claude/projects/-home-user-workspace/sess-mismatch-skip-123.jsonl"
     );
     assert_eq!(writes[0].content, history);
-    assert_eq!(sandbox.read_file_calls().len(), 2);
     let ops = telemetry.pending_ops_snapshot();
     assert_successful_action(&ops, "session_history_identity_verify_request_mismatch");
     assert!(
@@ -916,386 +817,6 @@ async fn run_in_sandbox_restores_when_skip_verified_identity_mismatches_request(
     assert!(
         ops.iter().all(|op| op.0 != "session_history_restore_skip"),
         "mismatched identity should not record skip telemetry, got: {ops:?}"
-    );
-}
-
-#[tokio::test]
-async fn run_in_sandbox_restores_when_skip_verified_identity_is_stale_before_start() {
-    let dir = tempfile::tempdir().unwrap();
-    let config = test_executor_config(dir.path()).await;
-    let sandbox = sandbox_mock::MockSandbox::new("test");
-    let history = br#"{"type":"init"}"#;
-    let server = MockServer::start_async().await;
-    let history_mock = server
-        .mock_async(|when, then| {
-            when.method(GET).path("/history.blob");
-            then.status(200).body(history);
-        })
-        .await;
-    let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession {
-        cli_agent_session_id: "sess-stale-skip-123".into(),
-        history: ResumeSessionHistory::Ref {
-            history_ref: ResumeSessionHistoryRef {
-                kind: ResumeSessionHistoryRefKind::Blob,
-                hash: hex::encode(Sha256::digest(history)),
-                url: server.url("/history.blob?token=secret"),
-                size: Some(history.len() as u64),
-            },
-        },
-    });
-    let idle_identity = RestoredSessionIdentity::from_context(&ctx)
-        .expect("identity")
-        .with_guest_history(
-            history.len() as u64,
-            "/home/user/.claude/projects/-home-user-workspace/sess-stale-skip-123.jsonl",
-        );
-    sandbox.push_read_file_result(Ok(None));
-    sandbox.push_read_file_result(Ok(None));
-    sandbox.push_read_file_result(Ok(Some(history.to_vec())));
-    let mut telemetry = test_telemetry(&config, &ctx);
-
-    let result = run_in_sandbox(
-        &sandbox,
-        &ctx,
-        &config,
-        RunStart {
-            restore_guest_state: false,
-            reuse_result: SandboxReuseResult::Reused,
-            prev_storage: None,
-        },
-        &mut telemetry,
-        RunControls::new(tokio_util::sync::CancellationToken::new(), None)
-            .with_session_history_restore_plan(SessionHistoryRestorePlan::SkipVerified(
-                idle_identity,
-            )),
-    )
-    .await
-    .unwrap();
-
-    assert!(result.failure.is_none());
-    let restored_identity = result
-        .restored_session_identity
-        .as_ref()
-        .expect("restored identity");
-    assert_eq!(
-        restored_identity.guest_history_path(),
-        Some("/home/user/.claude/projects/-home-user-workspace/sess-stale-skip-123.jsonl")
-    );
-    assert_eq!(
-        restored_identity.history_size_bytes(),
-        Some(history.len() as u64)
-    );
-    history_mock.assert_calls_async(1).await;
-    let writes = sandbox.write_file_calls();
-    assert_eq!(writes.len(), 1);
-    assert_eq!(
-        writes[0].path,
-        "/home/user/.claude/projects/-home-user-workspace/sess-stale-skip-123.jsonl"
-    );
-    assert_eq!(writes[0].content, history);
-    let ops = telemetry.pending_ops_snapshot();
-    assert_successful_action(&ops, "session_history_identity_verify_missing_file");
-    assert!(
-        ops.iter()
-            .any(|op| op.0 == "session_history_restore_fallback_stale_idle_identity" && op.1),
-        "expected stale identity fallback telemetry, got: {ops:?}"
-    );
-    assert!(
-        ops.iter().all(|op| op.0 != "session_history_restore_skip"),
-        "stale identity should not record skip telemetry, got: {ops:?}"
-    );
-}
-
-#[tokio::test]
-async fn run_in_sandbox_restores_when_skip_verified_identity_has_invalid_path() {
-    let dir = tempfile::tempdir().unwrap();
-    let config = test_executor_config(dir.path()).await;
-    let sandbox = sandbox_mock::MockSandbox::new("test");
-    let history = br#"{"type":"init"}"#;
-    let server = MockServer::start_async().await;
-    let history_mock = server
-        .mock_async(|when, then| {
-            when.method(GET).path("/history.blob");
-            then.status(200).body(history);
-        })
-        .await;
-    let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession {
-        cli_agent_session_id: "sess-invalid-path-123".into(),
-        history: ResumeSessionHistory::Ref {
-            history_ref: ResumeSessionHistoryRef {
-                kind: ResumeSessionHistoryRefKind::Blob,
-                hash: hex::encode(Sha256::digest(history)),
-                url: server.url("/history.blob?token=secret"),
-                size: Some(history.len() as u64),
-            },
-        },
-    });
-    let idle_identity = RestoredSessionIdentity::from_context(&ctx)
-        .expect("identity")
-        .with_guest_history(history.len() as u64, "relative/session.jsonl");
-    sandbox.push_read_file_result(Ok(None));
-    sandbox.push_read_file_result(Ok(Some(history.to_vec())));
-    let mut telemetry = test_telemetry(&config, &ctx);
-
-    let result = run_in_sandbox(
-        &sandbox,
-        &ctx,
-        &config,
-        RunStart {
-            restore_guest_state: false,
-            reuse_result: SandboxReuseResult::Reused,
-            prev_storage: None,
-        },
-        &mut telemetry,
-        RunControls::new(tokio_util::sync::CancellationToken::new(), None)
-            .with_session_history_restore_plan(SessionHistoryRestorePlan::SkipVerified(
-                idle_identity,
-            )),
-    )
-    .await
-    .unwrap();
-
-    assert!(result.failure.is_none());
-    history_mock.assert_calls_async(1).await;
-    let writes = sandbox.write_file_calls();
-    assert_eq!(writes.len(), 1);
-    assert_eq!(
-        writes[0].path,
-        "/home/user/.claude/projects/-home-user-workspace/sess-invalid-path-123.jsonl"
-    );
-    assert_eq!(writes[0].content, history);
-    let read_calls = sandbox.read_file_calls();
-    assert_eq!(read_calls.len(), 2);
-    assert_eq!(
-        read_calls[1].path,
-        "/home/user/.claude/projects/-home-user-workspace/sess-invalid-path-123.jsonl"
-    );
-    let ops = telemetry.pending_ops_snapshot();
-    assert_successful_action(&ops, "session_history_identity_verify_missing_verifier");
-    assert!(
-        ops.iter()
-            .any(|op| op.0 == "session_history_restore_fallback_stale_idle_identity" && op.1),
-        "expected invalid path fallback telemetry, got: {ops:?}"
-    );
-    assert!(
-        ops.iter().all(|op| op.0 != "session_history_restore_skip"),
-        "invalid path should not record skip telemetry, got: {ops:?}"
-    );
-}
-
-#[tokio::test]
-async fn run_in_sandbox_restores_when_skip_verified_identity_read_errors() {
-    let dir = tempfile::tempdir().unwrap();
-    let config = test_executor_config(dir.path()).await;
-    let sandbox = sandbox_mock::MockSandbox::new("test");
-    let history = br#"{"type":"init"}"#;
-    let server = MockServer::start_async().await;
-    let history_mock = server
-        .mock_async(|when, then| {
-            when.method(GET).path("/history.blob");
-            then.status(200).body(history);
-        })
-        .await;
-    let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession {
-        cli_agent_session_id: "sess-read-error-skip-123".into(),
-        history: ResumeSessionHistory::Ref {
-            history_ref: ResumeSessionHistoryRef {
-                kind: ResumeSessionHistoryRefKind::Blob,
-                hash: hex::encode(Sha256::digest(history)),
-                url: server.url("/history.blob?token=secret"),
-                size: Some(history.len() as u64),
-            },
-        },
-    });
-    let idle_identity = RestoredSessionIdentity::from_context(&ctx)
-        .expect("identity")
-        .with_guest_history(
-            history.len() as u64,
-            "/home/user/.claude/projects/-home-user-workspace/sess-read-error-skip-123.jsonl",
-        );
-    sandbox.push_read_file_result(Err(sandbox_exec_error("vsock read failed")));
-    sandbox.push_read_file_result(Ok(None));
-    sandbox.push_read_file_result(Ok(Some(history.to_vec())));
-    let mut telemetry = test_telemetry(&config, &ctx);
-
-    let result = run_in_sandbox(
-        &sandbox,
-        &ctx,
-        &config,
-        RunStart {
-            restore_guest_state: false,
-            reuse_result: SandboxReuseResult::Reused,
-            prev_storage: None,
-        },
-        &mut telemetry,
-        RunControls::new(tokio_util::sync::CancellationToken::new(), None)
-            .with_session_history_restore_plan(SessionHistoryRestorePlan::SkipVerified(
-                idle_identity,
-            )),
-    )
-    .await
-    .unwrap();
-
-    assert!(result.failure.is_none());
-    history_mock.assert_calls_async(1).await;
-    let ops = telemetry.pending_ops_snapshot();
-    assert_successful_action(&ops, "session_history_identity_verify_read_failed");
-    assert_successful_action(&ops, "session_history_restore_fallback_stale_idle_identity");
-    assert!(
-        ops.iter().all(|op| op.0 != "session_history_restore_skip"),
-        "read error should not record skip telemetry, got: {ops:?}"
-    );
-}
-
-#[tokio::test]
-async fn run_in_sandbox_restores_when_skip_verified_identity_size_changes() {
-    let dir = tempfile::tempdir().unwrap();
-    let config = test_executor_config(dir.path()).await;
-    let sandbox = sandbox_mock::MockSandbox::new("test");
-    let history = br#"{"type":"init"}"#;
-    let server = MockServer::start_async().await;
-    let history_mock = server
-        .mock_async(|when, then| {
-            when.method(GET).path("/history.blob");
-            then.status(200).body(history);
-        })
-        .await;
-    let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession {
-        cli_agent_session_id: "sess-size-changed-skip-123".into(),
-        history: ResumeSessionHistory::Ref {
-            history_ref: ResumeSessionHistoryRef {
-                kind: ResumeSessionHistoryRefKind::Blob,
-                hash: hex::encode(Sha256::digest(history)),
-                url: server.url("/history.blob?token=secret"),
-                size: Some(history.len() as u64),
-            },
-        },
-    });
-    let idle_identity = RestoredSessionIdentity::from_context(&ctx)
-        .expect("identity")
-        .with_guest_history(
-            history.len() as u64,
-            "/home/user/.claude/projects/-home-user-workspace/sess-size-changed-skip-123.jsonl",
-        );
-    let mut changed_history = history.to_vec();
-    changed_history.push(b'\n');
-    sandbox.push_read_file_result(Ok(Some(changed_history)));
-    sandbox.push_read_file_result(Ok(None));
-    sandbox.push_read_file_result(Ok(Some(history.to_vec())));
-    let mut telemetry = test_telemetry(&config, &ctx);
-
-    let result = run_in_sandbox(
-        &sandbox,
-        &ctx,
-        &config,
-        RunStart {
-            restore_guest_state: false,
-            reuse_result: SandboxReuseResult::Reused,
-            prev_storage: None,
-        },
-        &mut telemetry,
-        RunControls::new(tokio_util::sync::CancellationToken::new(), None)
-            .with_session_history_restore_plan(SessionHistoryRestorePlan::SkipVerified(
-                idle_identity,
-            )),
-    )
-    .await
-    .unwrap();
-
-    assert!(result.failure.is_none());
-    history_mock.assert_calls_async(1).await;
-    let ops = telemetry.pending_ops_snapshot();
-    assert_successful_action(&ops, "session_history_identity_verify_size_mismatch");
-    assert_successful_action(&ops, "session_history_restore_fallback_stale_idle_identity");
-    assert!(
-        ops.iter().all(|op| op.0 != "session_history_restore_skip"),
-        "size mismatch should not record skip telemetry, got: {ops:?}"
-    );
-}
-
-#[tokio::test]
-async fn run_in_sandbox_restores_when_skip_verified_identity_is_too_large_to_verify() {
-    let dir = tempfile::tempdir().unwrap();
-    let config = test_executor_config(dir.path()).await;
-    let sandbox = sandbox_mock::MockSandbox::new("test");
-    let history = br#"{"type":"init"}"#;
-    let server = MockServer::start_async().await;
-    let history_mock = server
-        .mock_async(|when, then| {
-            when.method(GET).path("/history.blob");
-            then.status(200).body(history);
-        })
-        .await;
-    let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession {
-        cli_agent_session_id: "sess-large-skip-123".into(),
-        history: ResumeSessionHistory::Ref {
-            history_ref: ResumeSessionHistoryRef {
-                kind: ResumeSessionHistoryRefKind::Blob,
-                hash: hex::encode(Sha256::digest(history)),
-                url: server.url("/history.blob?token=secret"),
-                size: Some(history.len() as u64),
-            },
-        },
-    });
-    let idle_identity = RestoredSessionIdentity::from_context(&ctx)
-        .expect("identity")
-        .with_guest_history(
-            SESSION_HISTORY_IDENTITY_HOST_READ_MAX_BYTES,
-            "/home/user/.claude/projects/-home-user-workspace/sess-large-skip-123.jsonl",
-        );
-    sandbox.push_read_file_result(Ok(None));
-    sandbox.push_read_file_result(Ok(Some(history.to_vec())));
-    let mut telemetry = test_telemetry(&config, &ctx);
-
-    let result = run_in_sandbox(
-        &sandbox,
-        &ctx,
-        &config,
-        RunStart {
-            restore_guest_state: false,
-            reuse_result: SandboxReuseResult::Reused,
-            prev_storage: None,
-        },
-        &mut telemetry,
-        RunControls::new(tokio_util::sync::CancellationToken::new(), None)
-            .with_session_history_restore_plan(SessionHistoryRestorePlan::SkipVerified(
-                idle_identity,
-            )),
-    )
-    .await
-    .unwrap();
-
-    assert!(result.failure.is_none());
-    history_mock.assert_calls_async(1).await;
-    let writes = sandbox.write_file_calls();
-    assert_eq!(writes.len(), 1);
-    assert_eq!(
-        writes[0].path,
-        "/home/user/.claude/projects/-home-user-workspace/sess-large-skip-123.jsonl"
-    );
-    assert_eq!(writes[0].content, history);
-    let read_calls = sandbox.read_file_calls();
-    assert_eq!(read_calls.len(), 2);
-    assert_eq!(
-        read_calls[1].path,
-        "/home/user/.claude/projects/-home-user-workspace/sess-large-skip-123.jsonl"
-    );
-    assert_eq!(read_calls[1].max_bytes, history.len() as u64 + 1);
-    let ops = telemetry.pending_ops_snapshot();
-    assert_successful_action(&ops, "session_history_identity_verify_missing_verifier");
-    assert!(
-        ops.iter()
-            .any(|op| op.0 == "session_history_restore_fallback_stale_idle_identity" && op.1),
-        "expected oversized identity fallback telemetry, got: {ops:?}"
-    );
-    assert!(
-        ops.iter().all(|op| op.0 != "session_history_restore_skip"),
-        "oversized identity should not record skip telemetry, got: {ops:?}"
     );
 }
 
@@ -1324,9 +845,7 @@ async fn run_in_sandbox_records_fallback_and_restores_prestarted_history() {
             },
         },
     });
-    let expected_identity = RestoredSessionIdentity::from_context(&ctx).expect("identity");
     sandbox.push_read_file_result(Ok(None));
-    sandbox.push_read_file_result(Ok(Some(history.to_vec())));
     let materializer = SessionHistoryMaterializer::start_cancellable(
         &config.http,
         ctx.resume_session.as_ref(),
@@ -1354,7 +873,7 @@ async fn run_in_sandbox_records_fallback_and_restores_prestarted_history() {
     .unwrap();
 
     assert!(result.failure.is_none());
-    assert_eq!(result.restored_session_identity, Some(expected_identity));
+    assert!(result.restored_session_identity.is_none());
     history_mock.assert_calls_async(1).await;
     let writes = sandbox.write_file_calls();
     assert_eq!(writes.len(), 1);
@@ -1378,11 +897,7 @@ async fn run_in_sandbox_records_fallback_and_restores_prestarted_history() {
         ops.iter().any(|op| op.0 == "session_restore" && op.1),
         "expected restore telemetry, got: {ops:?}"
     );
-    assert!(
-        ops.iter()
-            .any(|op| op.0 == "session_history_identity_restored" && op.1),
-        "expected restored identity telemetry, got: {ops:?}"
-    );
+    assert_successful_action(&ops, "session_history_identity_finalize_missing_metadata");
 }
 
 #[tokio::test]
@@ -1411,7 +926,6 @@ async fn run_in_sandbox_records_missing_idle_identity_reuse_fallback() {
         },
     });
     sandbox.push_read_file_result(Ok(None));
-    sandbox.push_read_file_result(Ok(Some(history.to_vec())));
     let materializer = SessionHistoryMaterializer::start_cancellable(
         &config.http,
         ctx.resume_session.as_ref(),
@@ -1439,7 +953,7 @@ async fn run_in_sandbox_records_missing_idle_identity_reuse_fallback() {
     .unwrap();
 
     assert!(result.failure.is_none());
-    assert!(result.restored_session_identity.is_some());
+    assert!(result.restored_session_identity.is_none());
     history_mock.assert_calls_async(1).await;
     let writes = sandbox.write_file_calls();
     assert_eq!(writes.len(), 1);
@@ -1464,73 +978,6 @@ async fn run_in_sandbox_records_missing_idle_identity_reuse_fallback() {
             .any(|op| op.0 == "session_history_identity_reuse_missing" && op.1),
         "expected identity reuse missing telemetry, got: {ops:?}"
     );
-    assert!(
-        ops.iter()
-            .any(|op| op.0 == "session_history_identity_restored" && op.1),
-        "expected restored identity telemetry, got: {ops:?}"
-    );
-}
-
-#[tokio::test]
-async fn run_in_sandbox_clears_restored_identity_when_history_changes_before_parking() {
-    let dir = tempfile::tempdir().unwrap();
-    let config = test_executor_config(dir.path()).await;
-    let sandbox = sandbox_mock::MockSandbox::new("test");
-    let history = br#"{"type":"init"}"#;
-    let server = MockServer::start_async().await;
-    server
-        .mock_async(|when, then| {
-            when.method(GET).path("/history.blob");
-            then.status(200).body(history);
-        })
-        .await;
-    let mut ctx = minimal_context();
-    ctx.resume_session = Some(ResumeSession {
-        cli_agent_session_id: "sess-mutated-123".into(),
-        history: ResumeSessionHistory::Ref {
-            history_ref: ResumeSessionHistoryRef {
-                kind: ResumeSessionHistoryRefKind::Blob,
-                hash: hex::encode(Sha256::digest(history)),
-                url: server.url("/history.blob?token=secret"),
-                size: Some(history.len() as u64),
-            },
-        },
-    });
-    let mut changed_history = history.to_vec();
-    changed_history[0] = b'[';
-    sandbox.push_read_file_result(Ok(None));
-    sandbox.push_read_file_result(Ok(Some(changed_history)));
-    let materializer = SessionHistoryMaterializer::start_cancellable(
-        &config.http,
-        ctx.resume_session.as_ref(),
-        tokio_util::sync::CancellationToken::new(),
-    );
-    let mut telemetry = test_telemetry(&config, &ctx);
-
-    let result = run_in_sandbox(
-        &sandbox,
-        &ctx,
-        &config,
-        RunStart {
-            restore_guest_state: false,
-            reuse_result: SandboxReuseResult::Reused,
-            prev_storage: None,
-        },
-        &mut telemetry,
-        RunControls::new(tokio_util::sync::CancellationToken::new(), None)
-            .with_session_history_restore_plan(SessionHistoryRestorePlan::Prestarted {
-                materializer,
-                fallback: None,
-            }),
-    )
-    .await
-    .unwrap();
-
-    assert!(result.failure.is_none());
-    assert_eq!(result.restored_session_identity, None);
-    let ops = telemetry.pending_ops_snapshot();
-    assert_successful_action(&ops, "session_history_identity_finalize_missing_metadata");
-    assert_successful_action(&ops, "session_history_identity_verify_hash_mismatch");
 }
 
 #[tokio::test]
@@ -1605,7 +1052,6 @@ async fn run_in_sandbox_uses_final_identity_when_restored_history_changes_before
         identity.history_size_bytes(),
         Some(final_history.len() as u64)
     );
-    assert_eq!(identity.guest_history_path(), None);
     assert_eq!(identity.final_metadata_path(), Some(metadata_path.as_str()));
     let read_calls = sandbox.read_file_calls();
     assert_eq!(read_calls.len(), 1);
@@ -1619,11 +1065,6 @@ async fn run_in_sandbox_uses_final_identity_when_restored_history_changes_before
         ops.iter()
             .any(|op| op.0 == "session_history_identity_finalized" && op.1),
         "expected final identity telemetry, got: {ops:?}"
-    );
-    assert!(
-        ops.iter()
-            .all(|op| op.0 != "session_history_identity_restored"),
-        "mutated restore-time identity should not record restored telemetry, got: {ops:?}"
     );
 }
 
@@ -1668,7 +1109,6 @@ async fn run_in_sandbox_uses_final_identity_without_resume_request() {
         hex::encode(Sha256::digest(history))
     );
     assert_eq!(identity.history_size_bytes(), Some(history.len() as u64));
-    assert_eq!(identity.guest_history_path(), None);
     assert_eq!(identity.final_metadata_path(), Some(metadata_path.as_str()));
     let read_calls = sandbox.read_file_calls();
     assert_eq!(read_calls.len(), 1);
@@ -1729,7 +1169,7 @@ async fn run_in_sandbox_records_large_final_identity_metadata() {
         "sessionIdHash": "a".repeat(64),
         "historyRefKind": "blob",
         "historyHash": "b".repeat(64),
-        "historySizeBytes": SESSION_HISTORY_IDENTITY_HOST_READ_MAX_BYTES + 1,
+        "historySizeBytes": LARGE_SESSION_HISTORY_SIZE_BYTES,
         "historyMarkerPayload": "/home/user/.claude/projects/-home-user-workspace/session.jsonl",
     });
     sandbox.push_read_file_result(Ok(Some(serde_json::to_vec(&metadata).unwrap())));
@@ -1757,7 +1197,7 @@ async fn run_in_sandbox_records_large_final_identity_metadata() {
         .expect("large final identity");
     assert_eq!(
         identity.history_size_bytes(),
-        Some(SESSION_HISTORY_IDENTITY_HOST_READ_MAX_BYTES + 1)
+        Some(LARGE_SESSION_HISTORY_SIZE_BYTES as u64)
     );
     assert_eq!(identity.final_metadata_path(), Some(metadata_path.as_str()));
     let ops = telemetry.pending_ops_snapshot();

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -11,10 +11,12 @@ use guest_contracts::session_history_identity::{
     FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES, FinalSessionHistoryFramework,
     FinalSessionHistoryIdentity, FinalSessionHistoryRefKind,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_MISMATCH,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_TOO_LARGE,
 };
 use httpmock::prelude::*;
 use sandbox::{
-    ExecResult, ProcessExit, ProcessOutputChunk, SandboxConfig, SandboxFactory, SandboxId,
+    ExecResult, ExecTermination, ProcessExit, ProcessOutputChunk, SandboxConfig, SandboxFactory,
+    SandboxId,
 };
 use sandbox_mock::MockSandboxFactory;
 use sha2::{Digest, Sha256};
@@ -125,6 +127,82 @@ fn assert_successful_action(ops: &[(String, bool, Option<String>)], action: &str
     assert!(
         ops.iter().any(|op| op.0 == action && op.1),
         "expected {action} telemetry, got: {ops:?}"
+    );
+}
+
+async fn assert_checkpointed_final_identity_helper_failure_falls_back(
+    session_id: &str,
+    helper_result: ExecResult,
+    expected_reason_action: &str,
+) {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let sandbox = sandbox_mock::MockSandbox::new("test");
+    let history = br#"{"type":"init"}"#;
+    let server = MockServer::start_async().await;
+    let history_mock = server
+        .mock_async(|when, then| {
+            when.method(GET).path("/history.blob");
+            then.status(200).body(history);
+        })
+        .await;
+    let mut ctx = minimal_context();
+    ctx.resume_session = Some(ResumeSession {
+        cli_agent_session_id: session_id.into(),
+        history: ResumeSessionHistory::Ref {
+            history_ref: ResumeSessionHistoryRef {
+                kind: ResumeSessionHistoryRefKind::Blob,
+                hash: hex::encode(Sha256::digest(history)),
+                url: server.url("/history.blob?token=secret"),
+                size: Some(history.len() as u64),
+            },
+        },
+    });
+    let (metadata_path, runtime_dir) = final_identity_runtime_paths(&ctx);
+    let metadata = FinalSessionHistoryIdentity::new(
+        FinalSessionHistoryFramework::ClaudeCode,
+        hex::encode(Sha256::digest(session_id.as_bytes())),
+        FinalSessionHistoryRefKind::Blob,
+        hex::encode(Sha256::digest(history)),
+        history.len() as u64,
+        claude_history_path(session_id),
+    )
+    .unwrap();
+    let idle_identity =
+        RestoredSessionIdentity::from_final_metadata(metadata, metadata_path, runtime_dir)
+            .expect("checkpointed identity");
+    sandbox.push_exec_result(Ok(helper_result));
+    sandbox.push_read_file_result(Ok(None));
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let result = run_in_sandbox(
+        &sandbox,
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::Reused,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None)
+            .with_session_history_restore_plan(SessionHistoryRestorePlan::SkipVerified(
+                idle_identity,
+            )),
+    )
+    .await
+    .unwrap();
+
+    assert!(result.failure.is_none());
+    assert!(result.restored_session_identity.is_none());
+    history_mock.assert_calls_async(1).await;
+    assert_eq!(sandbox.exec_calls().len(), 1);
+    let ops = telemetry.pending_ops_snapshot();
+    assert_successful_action(&ops, expected_reason_action);
+    assert_successful_action(&ops, "session_history_restore_fallback_stale_idle_identity");
+    assert!(
+        ops.iter().all(|op| op.0 != "session_history_restore_skip"),
+        "helper failure should not record skip telemetry, got: {ops:?}"
     );
 }
 
@@ -736,6 +814,37 @@ async fn run_in_sandbox_restores_when_checkpointed_final_identity_helper_exec_er
         ops.iter().all(|op| op.0 != "session_history_restore_skip"),
         "helper exec error should not record skip telemetry, got: {ops:?}"
     );
+}
+
+#[tokio::test]
+async fn run_in_sandbox_restores_when_checkpointed_final_identity_helper_times_out() {
+    assert_checkpointed_final_identity_helper_failure_falls_back(
+        "sess-final-helper-timeout-123",
+        ExecResult {
+            termination: ExecTermination::TimedOut,
+            stdout: Vec::new(),
+            stderr: Vec::new(),
+            diagnostic: "session history identity helper timed out".to_string(),
+            stdout_truncated: false,
+            stderr_truncated: false,
+        },
+        "session_history_identity_verify_helper_timed_out",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn run_in_sandbox_restores_when_checkpointed_final_identity_helper_is_over_budget() {
+    assert_checkpointed_final_identity_helper_failure_falls_back(
+        "sess-final-helper-too-large-123",
+        ExecResult::new(
+            SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_TOO_LARGE,
+            Vec::new(),
+            Vec::new(),
+        ),
+        "session_history_identity_verify_helper_history_too_large",
+    )
+    .await;
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor/tests/session_restore_tests.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests.rs
@@ -217,13 +217,7 @@ fn restore_session_writes_history() {
 
     let writes = sandbox.write_file_calls();
     assert_eq!(writes.len(), 1);
-    let expected_identity = RestoredSessionIdentity::from_context(&ctx)
-        .expect("restored identity")
-        .with_guest_history(history.len() as u64, writes[0].path.clone());
-    assert_eq!(
-        diagnostics.restored_session_identity,
-        Some(expected_identity)
-    );
+    assert_eq!(diagnostics.bytes_in, history.len());
 }
 
 #[tokio::test]
@@ -351,13 +345,7 @@ fn restore_session_writes_codex_session() {
         writes[0].path
     );
     assert_eq!(writes[0].content, session.history_bytes());
-    let expected_identity = RestoredSessionIdentity::from_context(&ctx)
-        .expect("restored identity")
-        .with_guest_history(history.len() as u64, writes[0].path.clone());
-    assert_eq!(
-        diagnostics.restored_session_identity,
-        Some(expected_identity)
-    );
+    assert_eq!(diagnostics.bytes_in, history.len());
 }
 
 #[test]

--- a/crates/runner/src/restored_session_identity.rs
+++ b/crates/runner/src/restored_session_identity.rs
@@ -45,7 +45,7 @@ enum RestoredSessionIdentityVerifier {
     },
 }
 
-pub(crate) struct RestoredSessionHistoryVerification<'a> {
+pub(crate) struct RestoredSessionFinalMetadataVerification<'a> {
     pub(crate) metadata_path: &'a str,
     pub(crate) runtime_dir: &'a str,
     pub(crate) framework: FinalSessionHistoryFramework,
@@ -97,7 +97,7 @@ impl RestoredSessionIdentity {
             }),
         };
         identity
-            .has_guest_history_verification()
+            .has_final_metadata_verification()
             .then_some(identity)
     }
 
@@ -132,9 +132,9 @@ impl RestoredSessionIdentity {
         }
     }
 
-    pub(crate) fn guest_history_verification(
+    pub(crate) fn final_metadata_verification(
         &self,
-    ) -> Option<RestoredSessionHistoryVerification<'_>> {
+    ) -> Option<RestoredSessionFinalMetadataVerification<'_>> {
         let expected_size = self.history_size_bytes?;
         match self.verifier.as_ref()? {
             RestoredSessionIdentityVerifier::FinalIdentityMetadata {
@@ -144,7 +144,7 @@ impl RestoredSessionIdentity {
                 if !metadata_path.starts_with('/') || !runtime_dir.starts_with('/') {
                     return None;
                 }
-                Some(RestoredSessionHistoryVerification {
+                Some(RestoredSessionFinalMetadataVerification {
                     metadata_path,
                     runtime_dir,
                     framework: final_session_history_framework(self.framework),
@@ -157,13 +157,13 @@ impl RestoredSessionIdentity {
         }
     }
 
-    pub(crate) fn has_guest_history_verification(&self) -> bool {
-        self.guest_history_verification().is_some()
+    pub(crate) fn has_final_metadata_verification(&self) -> bool {
+        self.final_metadata_verification().is_some()
     }
 
     pub(crate) fn is_verified_match_for_request(&self, requested: &Self) -> bool {
         self == requested
-            && self.has_guest_history_verification()
+            && self.has_final_metadata_verification()
             && requested
                 .history_size_bytes
                 .is_none_or(|requested_size| self.history_size_bytes == Some(requested_size))

--- a/crates/runner/src/restored_session_identity.rs
+++ b/crates/runner/src/restored_session_identity.rs
@@ -3,7 +3,6 @@ use std::fmt;
 use guest_contracts::session_history_identity::{
     FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES, FinalSessionHistoryFramework,
     FinalSessionHistoryIdentity, FinalSessionHistoryRefKind,
-    SESSION_HISTORY_IDENTITY_HOST_READ_MAX_BYTES,
 };
 use sha2::{Digest, Sha256};
 
@@ -40,30 +39,20 @@ pub(crate) struct RestoredSessionIdentity {
 
 #[derive(Clone, Eq, PartialEq)]
 enum RestoredSessionIdentityVerifier {
-    GuestHistoryPath {
-        guest_history_path: String,
-    },
     FinalIdentityMetadata {
         metadata_path: String,
         runtime_dir: String,
     },
 }
 
-pub(crate) enum RestoredSessionHistoryVerification<'a> {
-    GuestHistoryPath {
-        expected_size: u64,
-        guest_history_path: &'a str,
-        read_limit: u64,
-    },
-    FinalIdentityMetadata {
-        metadata_path: &'a str,
-        runtime_dir: &'a str,
-        framework: FinalSessionHistoryFramework,
-        session_id_hash: &'a str,
-        history_ref_kind: FinalSessionHistoryRefKind,
-        history_hash: &'a str,
-        history_size_bytes: u64,
-    },
+pub(crate) struct RestoredSessionHistoryVerification<'a> {
+    pub(crate) metadata_path: &'a str,
+    pub(crate) runtime_dir: &'a str,
+    pub(crate) framework: FinalSessionHistoryFramework,
+    pub(crate) session_id_hash: &'a str,
+    pub(crate) history_ref_kind: FinalSessionHistoryRefKind,
+    pub(crate) history_hash: &'a str,
+    pub(crate) history_size_bytes: u64,
 }
 
 impl RestoredSessionIdentity {
@@ -73,7 +62,6 @@ impl RestoredSessionIdentity {
         history_ref_kind: ResumeSessionHistoryRefKind,
         history_hash: impl Into<String>,
         history_size_bytes: Option<u64>,
-        guest_history_path: Option<String>,
     ) -> Self {
         // Callers pass the framework-normalized identity id. Claude Code uses
         // the raw session id; Codex uses the canonical thread id.
@@ -84,9 +72,7 @@ impl RestoredSessionIdentity {
             history_ref_kind,
             history_hash: history_hash.into(),
             history_size_bytes,
-            verifier: guest_history_path.map(|guest_history_path| {
-                RestoredSessionIdentityVerifier::GuestHistoryPath { guest_history_path }
-            }),
+            verifier: None,
         }
     }
 
@@ -123,22 +109,10 @@ impl RestoredSessionIdentity {
             ResumeSessionHistoryRefKind::Blob,
             history_hash,
             None,
-            None,
         )
     }
 
-    pub(crate) fn with_guest_history(
-        mut self,
-        history_size_bytes: u64,
-        guest_history_path: impl Into<String>,
-    ) -> Self {
-        self.history_size_bytes = Some(history_size_bytes);
-        self.verifier = Some(RestoredSessionIdentityVerifier::GuestHistoryPath {
-            guest_history_path: guest_history_path.into(),
-        });
-        self
-    }
-
+    #[cfg(test)]
     pub(crate) fn history_hash(&self) -> &str {
         &self.history_hash
     }
@@ -146,16 +120,6 @@ impl RestoredSessionIdentity {
     #[cfg(test)]
     pub(crate) fn history_size_bytes(&self) -> Option<u64> {
         self.history_size_bytes
-    }
-
-    #[cfg(test)]
-    pub(crate) fn guest_history_path(&self) -> Option<&str> {
-        match &self.verifier {
-            Some(RestoredSessionIdentityVerifier::GuestHistoryPath { guest_history_path }) => {
-                Some(guest_history_path)
-            }
-            _ => None,
-        }
     }
 
     #[cfg(test)]
@@ -173,23 +137,6 @@ impl RestoredSessionIdentity {
     ) -> Option<RestoredSessionHistoryVerification<'_>> {
         let expected_size = self.history_size_bytes?;
         match self.verifier.as_ref()? {
-            RestoredSessionIdentityVerifier::GuestHistoryPath { guest_history_path } => {
-                if !guest_history_path.starts_with('/') {
-                    return None;
-                }
-                if expected_size > SESSION_HISTORY_IDENTITY_HOST_READ_MAX_BYTES {
-                    return None;
-                }
-                let read_limit = expected_size.checked_add(1)?;
-                if read_limit > SESSION_HISTORY_IDENTITY_HOST_READ_MAX_BYTES {
-                    return None;
-                }
-                Some(RestoredSessionHistoryVerification::GuestHistoryPath {
-                    expected_size,
-                    guest_history_path,
-                    read_limit,
-                })
-            }
             RestoredSessionIdentityVerifier::FinalIdentityMetadata {
                 metadata_path,
                 runtime_dir,
@@ -197,7 +144,7 @@ impl RestoredSessionIdentity {
                 if !metadata_path.starts_with('/') || !runtime_dir.starts_with('/') {
                     return None;
                 }
-                Some(RestoredSessionHistoryVerification::FinalIdentityMetadata {
+                Some(RestoredSessionHistoryVerification {
                     metadata_path,
                     runtime_dir,
                     framework: final_session_history_framework(self.framework),
@@ -245,9 +192,6 @@ impl fmt::Debug for RestoredSessionIdentity {
             .field(
                 "verifier",
                 &self.verifier.as_ref().map(|verifier| match verifier {
-                    RestoredSessionIdentityVerifier::GuestHistoryPath { .. } => {
-                        "[redacted-guest-history-path]"
-                    }
                     RestoredSessionIdentityVerifier::FinalIdentityMetadata { .. } => {
                         "[redacted-final-identity-metadata]"
                     }

--- a/crates/runner/src/restored_session_identity.rs
+++ b/crates/runner/src/restored_session_identity.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use guest_contracts::session_history_identity::{
     FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES, FinalSessionHistoryFramework,
     FinalSessionHistoryIdentity, FinalSessionHistoryRefKind,
-    SESSION_HISTORY_IDENTITY_VERIFY_MAX_BYTES,
+    SESSION_HISTORY_IDENTITY_HOST_READ_MAX_BYTES,
 };
 use sha2::{Digest, Sha256};
 
@@ -172,16 +172,16 @@ impl RestoredSessionIdentity {
         &self,
     ) -> Option<RestoredSessionHistoryVerification<'_>> {
         let expected_size = self.history_size_bytes?;
-        if expected_size > SESSION_HISTORY_IDENTITY_VERIFY_MAX_BYTES {
-            return None;
-        }
         match self.verifier.as_ref()? {
             RestoredSessionIdentityVerifier::GuestHistoryPath { guest_history_path } => {
                 if !guest_history_path.starts_with('/') {
                     return None;
                 }
+                if expected_size > SESSION_HISTORY_IDENTITY_HOST_READ_MAX_BYTES {
+                    return None;
+                }
                 let read_limit = expected_size.checked_add(1)?;
-                if read_limit > SESSION_HISTORY_IDENTITY_VERIFY_MAX_BYTES {
+                if read_limit > SESSION_HISTORY_IDENTITY_HOST_READ_MAX_BYTES {
                     return None;
                 }
                 Some(RestoredSessionHistoryVerification::GuestHistoryPath {


### PR DESCRIPTION
## Summary
- Make session-history reuse a single verified path: only checkpointed final identity metadata can let an idle sandbox skip restore.
- Remove restore-time `GuestHistoryPath` verifier state, runner-side guest history reads, and the old 1 MiB host-read cap. If final metadata is missing or cannot be verified, the runner falls back to normal restore.
- Verify large final metadata histories inside the guest with streaming decoded size/hash checks for Claude and Codex markers, including `.jsonl.zst`.
- Add stable helper exit-code categories and low-cardinality identity write/verify telemetry without logging raw history, hashes, paths, markers, or ids.

Closes #19375

## Tests
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `git diff --check`
- `cargo test --manifest-path crates/Cargo.toml -p guest-contracts`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent session_history_identity`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent success_checkpoint_writes_large_final_identity_metadata`
- pre-commit hook during commit: `cargo-fmt`, `cargo-doc`, `cargo-clippy`