### PR TITLE
fix: restore chat unread sidebar controls

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/remote-chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/remote-chat-thread-data-source.ts
@@ -13,6 +13,10 @@ import { zeroClient$ } from "../api-client.ts";
 import { setAblyLoop$ } from "../realtime.ts";
 import { logger } from "../log.ts";
 import { reloadSidebarDraftThreads$ } from "./sidebar-draft-threads.ts";
+import {
+  applyUnreadSnapshot$,
+  recordOptimisticReadMark$,
+} from "./sidebar-unread-threads.ts";
 import type { ChatThread } from "../agent-chat.ts";
 import type {
   CancelRunsArgs,
@@ -260,10 +264,11 @@ const cancelRuns$ = command(
 
 const markRead$ = command(
   async (
-    { get },
+    { get, set },
     { threadId, latestMessageId }: MarkReadArgs,
     signal: AbortSignal,
   ): Promise<string | null> => {
+    set(recordOptimisticReadMark$, threadId);
     const client = get(zeroClient$)(chatThreadMarkReadContract);
     const result = await accept(
       client.markRead({
@@ -273,6 +278,7 @@ const markRead$ = command(
       [200],
     );
     signal.throwIfAborted();
+    set(applyUnreadSnapshot$, result.body.unreads);
     return result.body.lastReadMessageId ?? latestMessageId;
   },
 );

--- a/turbo/apps/platform/src/signals/chat-page/sidebar-unread-threads.ts
+++ b/turbo/apps/platform/src/signals/chat-page/sidebar-unread-threads.ts
@@ -1,13 +1,47 @@
-import { computed } from "ccstate";
+import { command, computed, state } from "ccstate";
 import { chatThreadsContract } from "@vm0/api-contracts/contracts/chat-threads";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { accept } from "../../lib/accept.ts";
+import { now } from "../../lib/time.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { currentChatAgentId$ } from "../agent-chat.ts";
 import { reloadChatUnreadStateCounter$ } from "../chat-thread-list-reload.ts";
 import { featureSwitch$ } from "../external/feature-switch.ts";
 
 type UnreadSnapshot = readonly { threadId: string; unreadAt: string }[];
+
+/**
+ * Local optimistic mark-read timestamps. A thread in the server unread
+ * snapshot stays hidden while the local mark is newer than that snapshot.
+ */
+const optimisticReadMarks$ = state<ReadonlyMap<string, number>>(new Map());
+
+export const recordOptimisticReadMark$ = command(
+  ({ get, set }, threadId: string) => {
+    const next = new Map(get(optimisticReadMarks$));
+    next.set(threadId, now());
+    set(optimisticReadMarks$, next);
+  },
+);
+
+export const applyUnreadSnapshot$ = command(
+  ({ get, set }, unreads: UnreadSnapshot) => {
+    const marks = get(optimisticReadMarks$);
+    if (marks.size === 0) {
+      return;
+    }
+    const next = new Map(marks);
+    for (const unread of unreads) {
+      const markedAt = next.get(unread.threadId);
+      if (markedAt !== undefined && Date.parse(unread.unreadAt) > markedAt) {
+        next.delete(unread.threadId);
+      }
+    }
+    if (next.size !== marks.size) {
+      set(optimisticReadMarks$, next);
+    }
+  },
+);
 
 /**
  * Server unread snapshot for the current agent. Refetched alongside the
@@ -28,11 +62,15 @@ const fetchedUnreads$ = computed(async (get): Promise<UnreadSnapshot> => {
 export const sidebarUnreadThreadIds$ = computed(
   async (get): Promise<ReadonlySet<string>> => {
     const unreads = await get(fetchedUnreads$);
-    return new Set(
-      unreads.map((unread) => {
-        return unread.threadId;
-      }),
-    );
+    const marks = get(optimisticReadMarks$);
+    const ids = new Set<string>();
+    for (const unread of unreads) {
+      const markedAt = marks.get(unread.threadId);
+      if (markedAt === undefined || Date.parse(unread.unreadAt) > markedAt) {
+        ids.add(unread.threadId);
+      }
+    }
+    return ids;
   },
 );
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-sidebar-state.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-sidebar-state.ts
@@ -78,6 +78,19 @@ export const setSessionListCollapsed$ = command(
 );
 
 // ---------------------------------------------------------------------------
+// Session list unread filter (RecentChatSection)
+// ---------------------------------------------------------------------------
+const internalSessionListUnreadOnly$ = state(false);
+export const sessionListUnreadOnly$ = computed((get) => {
+  return get(internalSessionListUnreadOnly$);
+});
+export const setSessionListUnreadOnly$ = command(
+  ({ set }, unreadOnly: boolean) => {
+    set(internalSessionListUnreadOnly$, unreadOnly);
+  },
+);
+
+// ---------------------------------------------------------------------------
 // Manage section collapse state (ZeroSidebar) — persisted in localStorage
 // ---------------------------------------------------------------------------
 const {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
@@ -193,7 +193,7 @@ describe("zero sidebar account menu", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByLabelText("New chat with Zero")).toBeInTheDocument();
+      expect(screen.getByLabelText("Open chat list menu")).toBeInTheDocument();
     });
     const accountName = await screen.findByText("Alex Rivera");
     const accountButton = accountName.closest("button");

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -4,6 +4,8 @@ import { describe, expect, it } from "vitest";
 import {
   chatThreadByIdContract,
   chatThreadArtifactsContract,
+  chatThreadMarkReadContract,
+  chatThreadMessagesContract,
   chatThreadPinContract,
   chatThreadRenameContract,
   chatThreadUnpinContract,
@@ -184,6 +186,10 @@ function openThreadMenu(title: string): void {
   );
 }
 
+function openChatListMenu(): void {
+  click(within(sidebar()).getByLabelText("Open chat list menu"));
+}
+
 function mockSidebarThreadStory(
   firstPageThreads: SidebarThread[],
   extraThreads: SidebarThread[] = [],
@@ -307,10 +313,11 @@ describe("zero sidebar", () => {
 
     const newChatButton = await waitFor(() => {
       expect(screen.getByText("Existing conversation")).toBeInTheDocument();
-      return screen.getByLabelText("New chat with Zero");
+      return screen.getByLabelText("Open chat list menu");
     });
 
     click(newChatButton);
+    click(menuItemByText("New chat"));
 
     await waitFor(() => {
       const sidebar = screen.getByRole("navigation", { name: "Sidebar" });
@@ -381,17 +388,123 @@ describe("zero sidebar", () => {
       expect(
         within(sidebar()).getByText("Existing conversation"),
       ).toBeInTheDocument();
-      const button = screen.getByLabelText("New chat with Zero");
+      const button = screen.getByLabelText("Open chat list menu");
       expect(button).not.toBeDisabled();
       return button;
     });
 
     click(newChatButton);
+    click(menuItemByText("New chat"));
 
     await waitFor(() => {
       expect(screen.queryByTestId("artifact-sidebar")).not.toBeInTheDocument();
       expect(window.location.search).not.toContain("artifact=");
     });
+  });
+
+  it("filters chat threads to unread threads and the current chat from the menu", async () => {
+    prepareDefaultAgent();
+    mockSidebarThreadStory([
+      createThread(EXISTING_THREAD_ID, "Release plan"),
+      createThread(INCIDENT_THREAD_ID, "Incident notes"),
+      createThread(ARCHIVED_THREAD_ID, "Archived context"),
+    ]);
+    context.mocks.api(chatThreadsContract.unreads, ({ respond }) => {
+      return respond(200, {
+        unreads: [
+          { threadId: INCIDENT_THREAD_ID, unreadAt: "2026-03-10T00:05:00Z" },
+        ],
+      });
+    });
+
+    detachedSetupPage({ context, path: `/chats/${EXISTING_THREAD_ID}` });
+
+    await waitFor(() => {
+      expect(within(sidebar()).getByText("Release plan")).toBeInTheDocument();
+      expect(within(sidebar()).getByText("Incident notes")).toBeInTheDocument();
+      expect(
+        within(sidebar()).getByText("Archived context"),
+      ).toBeInTheDocument();
+    });
+
+    openChatListMenu();
+    click(screen.getByRole("switch", { name: "Unread" }));
+    fireEvent.keyDown(document.body, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(within(sidebar()).getByText("Release plan")).toBeInTheDocument();
+      expect(within(sidebar()).getByText("Incident notes")).toBeInTheDocument();
+      expect(
+        within(sidebar()).queryByText("Archived context"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("clears a thread unread marker optimistically before mark-read resolves", async () => {
+    prepareDefaultAgent();
+    const markReadDeferred = context.mocks.deferred<void>();
+    let markReadCalls = 0;
+    mockSidebarThreadStory([
+      createThread(EXISTING_THREAD_ID, "Release plan"),
+      createThread(INCIDENT_THREAD_ID, "Incident notes"),
+    ]);
+    context.mocks.api(chatThreadsContract.unreads, ({ respond }) => {
+      return respond(200, {
+        unreads: [
+          { threadId: INCIDENT_THREAD_ID, unreadAt: "2026-03-10T00:05:00Z" },
+        ],
+      });
+    });
+    context.mocks.api(
+      chatThreadMessagesContract.list,
+      ({ params, query, respond }) => {
+        if (query.sinceId || query.beforeId) {
+          return respond(200, { messages: [] });
+        }
+        return respond(200, {
+          messages:
+            params.threadId === INCIDENT_THREAD_ID
+              ? [
+                  {
+                    id: "incident-message-1",
+                    role: "assistant",
+                    content: "Incident update",
+                    createdAt: "2026-03-10T00:05:00Z",
+                  },
+                ]
+              : [],
+          hasHistoryBefore: false,
+        });
+      },
+    );
+    context.mocks.api(
+      chatThreadMarkReadContract.markRead,
+      async ({ respond }) => {
+        markReadCalls += 1;
+        await markReadDeferred.promise;
+        return respond(200, {
+          lastReadMessageId: "incident-message-1",
+          unreads: [],
+        });
+      },
+    );
+
+    detachedSetupPage({ context, path: `/chats/${INCIDENT_THREAD_ID}` });
+
+    await waitFor(() => {
+      expect(markReadCalls).toBe(1);
+      expect(within(sidebar()).getByText("Release plan")).toBeInTheDocument();
+    });
+
+    click(threadLinkByTitle("Release plan"));
+
+    await waitFor(() => {
+      expect(
+        within(threadRowByTitle("Incident notes")).queryByLabelText("Unread"),
+      ).not.toBeInTheDocument();
+    });
+
+    markReadDeferred.resolve();
   });
 
   it("pins and unpins a chat thread from the sidebar menu", async () => {
@@ -819,12 +932,12 @@ describe("zero sidebar", () => {
         within(researchSidebarRow).getByLabelText("Open agent menu"),
       ).toBeInTheDocument();
       expect(
-        within(researchSidebarRow).queryByLabelText("Remove from list"),
+        within(researchSidebarRow).queryByLabelText("Unpin"),
       ).not.toBeInTheDocument();
     });
 
     click(within(researchSidebarRow).getByLabelText("Open agent menu"));
-    expect(menuItemByText("Remove from list")).toBeInTheDocument();
+    expect(menuItemByText("Unpin")).toBeInTheDocument();
     fireEvent.keyDown(document.body, { key: "Escape" });
 
     click(within(nav).getByLabelText("Open a conversation"));

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -31,6 +31,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
 } from "@vm0/ui";
+import { Switch } from "@vm0/ui/components/ui/switch";
 import {
   Dialog,
   DialogContent,
@@ -94,6 +95,8 @@ import {
   setRenameDialogInput$,
   sessionListCollapsed$,
   setSessionListCollapsed$,
+  sessionListUnreadOnly$,
+  setSessionListUnreadOnly$,
 } from "../../signals/zero-page/zero-sidebar-state.ts";
 import { Link } from "../router/link.tsx";
 
@@ -751,6 +754,10 @@ function ChatThreads() {
   const pageSignal = useGet(pageSignal$);
 
   const chatThreads = useLastResolved(sidebarChatThreads$) ?? [];
+  const unreadOnly = useGet(sessionListUnreadOnly$);
+  const unreadThreadIds = useLastResolved(sidebarUnreadThreadIds$);
+  const pathParams = useGet(pathParams$);
+  const searchParams = useGet(searchParams$);
   const firstPageHasMore = useLastResolved(chatThreadsHasMore$) ?? false;
   const firstPageNextCursor = useLastResolved(chatThreadsNextCursor$);
   const hasLoadedExtraPages =
@@ -766,6 +773,18 @@ function ChatThreads() {
   const cursorForLoadMore = hasLoadedExtraPages
     ? extraLatestCursor
     : firstPageNextCursor;
+  const currentThreadId =
+    typeof pathParams?.threadId === "string" ? pathParams.threadId : null;
+  const sidebarThreadId = searchParams.get(SIDEBAR_PARAM);
+  const visibleChatThreads = unreadOnly
+    ? chatThreads.filter((session) => {
+        return (
+          session.id === currentThreadId ||
+          session.id === sidebarThreadId ||
+          (unreadThreadIds?.has(session.id) ?? false)
+        );
+      })
+    : chatThreads;
 
   function handleLoadMore() {
     if (!cursorForLoadMore || loadingMore) {
@@ -774,16 +793,18 @@ function ChatThreads() {
     detach(loadMore(cursorForLoadMore, pageSignal), Reason.DomCallback);
   }
 
-  if (chatThreads.length === 0) {
+  if (visibleChatThreads.length === 0) {
     return (
       <p className="px-2 py-2 text-xs text-muted-foreground/70 leading-relaxed">
-        Start a conversation and it&apos;ll show up here
+        {unreadOnly
+          ? "No unread chats"
+          : "Start a conversation and it'll show up here"}
       </p>
     );
   }
   return (
     <>
-      {chatThreads.map((session) => {
+      {visibleChatThreads.map((session) => {
         return <ChatThreadItem key={session.id} session={session} />;
       })}
       {hasMore && cursorForLoadMore && (
@@ -803,7 +824,7 @@ function ChatThreadsTitle() {
   const createNewChat = useSet(createNewChatThreadOptimistically$);
   const setExpanded = useSet(setSidebarExpanded$);
   const rootSignal = useGet(rootSignal$);
-  const { titleLabel, newChatAriaLabel } = useChatThreadsTitleLabels();
+  const { titleLabel } = useChatThreadsTitleLabels();
   const newChatDisabled = useGet(optimisticChatThread$) !== null;
   const onNewChat = (pane: OptimisticChatPane) => {
     if (!currentChatAgentId) {
@@ -817,6 +838,15 @@ function ChatThreadsTitle() {
   };
   const setCollapsed = useSet(setSessionListCollapsed$);
   const collapsed = useGet(sessionListCollapsed$);
+  const unreadOnly = useGet(sessionListUnreadOnly$);
+  const setUnreadOnly = useSet(setSessionListUnreadOnly$);
+
+  function toggleUnreadOnly(next: boolean) {
+    setUnreadOnly(next);
+    if (next) {
+      setCollapsed(false);
+    }
+  }
 
   return (
     <div
@@ -837,25 +867,54 @@ function ChatThreadsTitle() {
       </span>
       <div className="flex items-center gap-0.5">
         <TooltipProvider delayDuration={200}>
-          <Tooltip>
-            <TooltipTrigger asChild>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
               <button
                 type="button"
                 onClick={(e) => {
                   e.stopPropagation();
-                  onNewChat(e.altKey ? "sidebar" : "main");
+                }}
+                className="relative z-10 flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-[hsl(var(--gray-200))] transition-colors"
+                aria-label="Open chat list menu"
+              >
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span>
+                      <IconDots size={16} stroke={2} />
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">
+                    <p className="text-xs">More</p>
+                  </TooltipContent>
+                </Tooltip>
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              align="end"
+              className="w-44"
+              onClick={(e) => {
+                e.stopPropagation();
+              }}
+            >
+              <DropdownMenuItem
+                onSelect={() => {
+                  onNewChat("main");
                 }}
                 disabled={!currentChatAgentId || newChatDisabled}
-                className="relative z-10 flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-[hsl(var(--gray-200))] transition-colors disabled:opacity-50"
-                aria-label={newChatAriaLabel}
               >
-                <IconPlus size={15} stroke={2.5} />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">
-              <p className="text-xs">New chat</p>
-            </TooltipContent>
-          </Tooltip>
+                <IconPlus size={16} stroke={2} className="mr-2" />
+                New chat
+              </DropdownMenuItem>
+              <div className="flex h-9 items-center justify-between gap-3 px-2 text-sm text-popover-foreground">
+                <span>Unread</span>
+                <Switch
+                  checked={unreadOnly}
+                  onCheckedChange={toggleUnreadOnly}
+                  aria-label="Unread"
+                />
+              </div>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </TooltipProvider>
       </div>
     </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-dialogs.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-dialogs.tsx
@@ -305,7 +305,7 @@ function SortablePinnedAgent({
             hasUnread={hasUnread}
             action={
               <AgentDialogMenuAction
-                label="Remove from list"
+                label="Unpin"
                 disabled={disabled}
                 icon={<IconPinnedOff size={16} stroke={2} />}
                 onSelect={onUnpin}

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
@@ -90,13 +90,13 @@ function UnpinButton({
                 ? "text-sidebar-foreground/80 hover:text-foreground hover:bg-[hsl(var(--gray-300))]"
                 : "text-sidebar-foreground/80 hover:text-foreground hover:bg-[hsl(var(--gray-200))]"
             }`}
-            aria-label="Remove from list"
+            aria-label="Unpin"
           >
             <IconX size={12} stroke={2} />
           </button>
         </TooltipTrigger>
         <TooltipContent side="right">
-          <p className="text-xs">Remove from list</p>
+          <p className="text-xs">Unpin</p>
         </TooltipContent>
       </Tooltip>
     </TooltipProvider>
@@ -121,7 +121,7 @@ function PinnedAgentMenu({
   const savingPinned = pinLoadable.state === "loading";
   const pageSignal = useGet(pageSignal$);
 
-  function removeFromList() {
+  function unpinAgent() {
     const next = pinnedIds.filter((id): id is string => {
       return id !== null && id !== agentId;
     });
@@ -161,9 +161,9 @@ function PinnedAgentMenu({
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-44">
-          <DropdownMenuItem onSelect={removeFromList} disabled={savingPinned}>
+          <DropdownMenuItem onSelect={unpinAgent} disabled={savingPinned}>
             <IconPinnedOff size={16} stroke={2} className="mr-2" />
-            Remove from list
+            Unpin
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>


### PR DESCRIPTION
## Summary
- restore optimistic thread unread clearing when mark-read starts and apply returned unread snapshots
- replace the Chats with Zero plus button with a three-dot menu containing New chat and an Unread filter toggle
- rename pinned-agent unread-menu action from Remove from list to Unpin

## Verification
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-sidebar.test.tsx src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app exec oxlint src/signals/chat-page/remote-chat-thread-data-source.ts src/signals/chat-page/sidebar-unread-threads.ts src/signals/zero-page/zero-sidebar-state.ts src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx src/views/zero-page/__tests__/zero-sidebar.test.tsx src/views/zero-page/sidebar-threads.tsx src/views/zero-page/zero-sidebar-dialogs.tsx src/views/zero-page/zero-sidebar-pinned.tsx
- pnpm -F @vm0/app exec eslint src/signals/chat-page/remote-chat-thread-data-source.ts src/signals/chat-page/sidebar-unread-threads.ts src/signals/zero-page/zero-sidebar-state.ts src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx src/views/zero-page/__tests__/zero-sidebar.test.tsx src/views/zero-page/sidebar-threads.tsx src/views/zero-page/zero-sidebar-dialogs.tsx src/views/zero-page/zero-sidebar-pinned.tsx --max-warnings 0