### PR TITLE
ci: inject unsplash access key into api env

### DIFF
--- a/.github/actions/web-api-env/action.yml
+++ b/.github/actions/web-api-env/action.yml
@@ -250,6 +250,7 @@ runs:
         add_secret OPENAI_API_KEY OPENAI_API_KEY
         add_secret FAL_KEY FAL_KEY
         add_secret BYTEPLUS_API_KEY BYTEPLUS_API_KEY
+        add_secret UNSPLASH_ACCESS_KEY UNSPLASH_ACCESS_KEY
         add_var VAPID_PUBLIC_KEY VAPID_PUBLIC_KEY
         add_secret VAPID_PRIVATE_KEY VAPID_PRIVATE_KEY
         add_env CONCURRENT_RUN_LIMIT_CAP "$concurrent_run_limit_cap"

--- a/.github/scripts/tests/web-api-env-action-test.sh
+++ b/.github/scripts/tests/web-api-env-action-test.sh
@@ -132,7 +132,7 @@ run_action() {
     INPUT_API_URL="https://pr-123-api.vm0.test" \
     INPUT_API_BACKEND_URL="https://pr-123-api-backend.vm0.test" \
     REPO_VARS_JSON='{"GH_OAUTH_CLIENT_ID":"github-gh-client-id","SLACK_OAUTH_CLIENT_ID":"github-slack-client-id","VM0_API_URL":"https://api.github.test","GOOGLE_ADS_DEVELOPER_TOKEN":"github-google-ads-var","FINICITY_PARTNER_ID":"github-finicity-partner-id","POSTHOG_KEY":"github-posthog-key","POSTHOG_HOST":"https://posthog.github.test","ATOM_URL":"https://atom.github.test","STRIPE_OAUTH_CLIENT_ID":"ca_test_connect_client","ZERO_PRICE_PRO":"price_test_pro","ZERO_PRICE_TEAM":"price_test_team","ATOM_GRANT_PRICE":"price_test_atom_grant","ZERO_PRICE_CUSTOM_CREDITS":"price_test_custom_credits","ZERO_PRICE_CONCURRENCY":"price_test_concurrency"}' \
-    REPO_SECRETS_JSON='{"GH_OAUTH_CLIENT_SECRET":"github-gh-client-secret","SLACK_OAUTH_CLIENT_SECRET":"github-slack-client-secret","GOOGLE_ADS_DEVELOPER_TOKEN":"github-google-ads-secret","FINICITY_APP_KEY":"github-finicity-app-key","FINICITY_APP_SECRET":"github-finicity-app-secret","VM0_MACHINE_SECRET_KEY":"github-atom-machine-secret"}' \
+    REPO_SECRETS_JSON='{"GH_OAUTH_CLIENT_SECRET":"github-gh-client-secret","SLACK_OAUTH_CLIENT_SECRET":"github-slack-client-secret","GOOGLE_ADS_DEVELOPER_TOKEN":"github-google-ads-secret","FINICITY_APP_KEY":"github-finicity-app-key","FINICITY_APP_SECRET":"github-finicity-app-secret","UNSPLASH_ACCESS_KEY":"github-unsplash-access-key","VM0_MACHINE_SECRET_KEY":"github-atom-machine-secret"}' \
     DOPPLER_SECRETS_JSON="$doppler_secrets_json" \
     bash "$action_script"
 }
@@ -158,6 +158,7 @@ assert_env_value "$success_env_file" GOOGLE_ADS_DEVELOPER_TOKEN "github-google-a
 assert_env_value "$success_env_file" FINICITY_APP_KEY "github-finicity-app-key"
 assert_env_value "$success_env_file" FINICITY_APP_SECRET "github-finicity-app-secret"
 assert_env_value "$success_env_file" FINICITY_PARTNER_ID "github-finicity-partner-id"
+assert_env_value "$success_env_file" UNSPLASH_ACCESS_KEY "github-unsplash-access-key"
 assert_env_value "$success_env_file" ATOM_URL "https://tunnel-yuma-atom-api.vm7.ai"
 assert_env_value "$success_env_file" VM0_MACHINE_SECRET_KEY "github-atom-machine-secret"
 assert_env_value "$success_env_file" VM0_PREVIEW_JOB_REF "pr-123"

--- a/turbo/apps/api/.env.local.tpl
+++ b/turbo/apps/api/.env.local.tpl
@@ -93,6 +93,9 @@ FAL_KEY=op://Development/fal/FAL_KEY
 # Optional: BytePlus ModelArk video generation
 BYTEPLUS_API_KEY=op://Development/byteplus/BYTEPLUS_API_KEY
 
+# Optional: Unsplash presentation image resolution
+UNSPLASH_ACCESS_KEY=op://Development/unsplash/UNSPLASH_ACCESS_KEY
+
 # Optional: Airtable OAuth Connector
 AIRTABLE_OAUTH_CLIENT_ID=op://Development/airtable/AIRTABLE_OAUTH_CLIENT_ID
 AIRTABLE_OAUTH_CLIENT_SECRET=op://Development/airtable/AIRTABLE_OAUTH_CLIENT_SECRET


### PR DESCRIPTION
## Summary
- inject `UNSPLASH_ACCESS_KEY` from GitHub Actions secrets into the rendered API Vercel env file
- document the local API env template entry for Unsplash presentation image resolution
- cover the env renderer with the existing shell action test

## Tests
- `bash .github/scripts/tests/web-api-env-action-test.sh`
- `npx -y prettier@3.8.1 --check --ignore-unknown .github/actions/web-api-env/action.yml turbo/apps/api/.env.local.tpl .github/scripts/tests/web-api-env-action-test.sh`
- `git diff --check`

## Notes
- This PR does not add the secret value itself. Add `UNSPLASH_ACCESS_KEY` under GitHub repository Actions secrets before relying on the endpoint in preview/production deploys.
