### PR TITLE
perf: reduce queued chat auto-send delay

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -8,8 +8,13 @@ import type {
   GenerationTemplateRequest,
   PagedChatMessage,
 } from "@vm0/api-contracts/contracts/chat-threads";
+import type {
+  TestChatMessagesStateActionBody,
+  TestChatMessagesStateActionResponse,
+} from "@vm0/api-contracts/contracts/test-chat-messages-state";
 import { describe, expect, it, onTestFinished } from "vitest";
 
+import { createAppWithRoutes } from "../../../app-factory-core";
 import { mockOptionalEnv } from "../../../lib/env";
 import { testContext } from "../../../__tests__/test-context";
 import { flushWaitUntilForTest } from "../../context/wait-until";
@@ -21,6 +26,7 @@ import { createMiscRoutesApi } from "./helpers/api-bdd-misc";
 import { createRunsAutomationsApi } from "./helpers/api-bdd-runs-automations";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
 import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
+import { testChatMessagesStateRoutes } from "../test-chat-messages-state";
 
 /**
  * CHAT-02 / HOOK-01: signed chat run callbacks through real dispatch.
@@ -344,6 +350,36 @@ function resultEvent(
 function pushPayload(call: readonly unknown[] | undefined): unknown {
   const raw = call?.[1];
   return JSON.parse(typeof raw === "string" ? raw : "{}");
+}
+
+function requestChatMessagesState(
+  path: string,
+  init?: RequestInit,
+): Promise<Response> {
+  const app = createAppWithRoutes({
+    signal: context.signal,
+    routes: testChatMessagesStateRoutes,
+  });
+  return Promise.resolve(app.request(path, init));
+}
+
+async function postChatMessagesStateAction(
+  body: TestChatMessagesStateActionBody,
+): Promise<TestChatMessagesStateActionResponse> {
+  const response = await requestChatMessagesState(
+    "/api/test/chat-messages-state/action",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+  if (!response.ok) {
+    throw new Error(
+      `chat messages state action ${body.action} failed with ${response.status}`,
+    );
+  }
+  return (await response.json()) as TestChatMessagesStateActionResponse;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -923,6 +959,58 @@ describe("CHAT-02: completed chat callback", () => {
 
     await api.requestCancelRun(actor, claimed.runId, [200]);
     await waitForRunStatus(actor, claimed.runId, "cancelled");
+  }, 90_000);
+
+  it("excludes pre-dispatch cancelled rows without chat messages from later context", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const first = await startChatRun(actor, {
+      agentId,
+      prompt: "anchor before ghost",
+    });
+    const firstHeaders = await claimChatRun(runnerGroup, first.runId);
+    chatCallbacks.mockChatOutputEvents([assistantEvent(0, "anchor answer")]);
+    await completeChatRunOk(first.runId, firstHeaders, {
+      lastEventSequence: 0,
+    });
+    await waitForThreadMessages(actor, first.threadId, (messages) => {
+      return assistantMessages(messages).some((message) => {
+        return (
+          message.runId === first.runId && message.content === "anchor answer"
+        );
+      });
+    });
+
+    const ghost = await api.createRun(actor, {
+      agentId,
+      prompt: "ghost pre-dispatch queued prompt",
+      modelProvider: "anthropic-api-key",
+    });
+    await api.requestCancelRun(actor, ghost.runId, [200]);
+    await waitForRunStatus(actor, ghost.runId, "cancelled");
+    await postChatMessagesStateAction({
+      action: "attach-pre-dispatch-cancelled-run-to-thread",
+      run_id: ghost.runId,
+      thread_id: first.threadId,
+    });
+
+    const second = await startChatRun(actor, {
+      agentId,
+      threadId: first.threadId,
+      prompt: "continue after ghost",
+    });
+    const secondRun = await api.readRun(actor, second.runId);
+    const appended = secondRun.appendSystemPrompt ?? "";
+    expect(appended).toContain("# Web Chat Run Context");
+    expect(appended).toContain(`- RUN_ID: ${first.runId}`);
+    expect(appended).toContain("User: anchor before ghost");
+    expect(appended).toContain("Assistant: anchor answer");
+    expect(appended).not.toContain(`- RUN_ID: ${ghost.runId}`);
+    expect(appended).not.toContain("ghost pre-dispatch queued prompt");
+
+    await api.requestCancelRun(actor, second.runId, [200]);
+    await waitForRunStatus(actor, second.runId, "cancelled");
   }, 90_000);
 });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -345,6 +345,52 @@ function pushPayload(call: readonly unknown[] | undefined): unknown {
   return JSON.parse(typeof raw === "string" ? raw : "{}");
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function sandboxOperationEventsForRun(
+  runId: string,
+): readonly Record<string, unknown>[] {
+  return context.mocks.axiom.sdkIngest.mock.calls.flatMap((call) => {
+    const dataset = call[0];
+    const events = call[1];
+    if (dataset !== "vm0-sandbox-op-log-dev" || !Array.isArray(events)) {
+      return [];
+    }
+    return events.filter((event): event is Record<string, unknown> => {
+      return isRecord(event) && event.run_id === runId;
+    });
+  });
+}
+
+function expectZeroPreCreateSource(runId: string, source: string): void {
+  expect(sandboxOperationEventsForRun(runId)).toStrictEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        op_type: "api_dispatch_pre_create_agent_run",
+        zero_pre_create_source: source,
+      }),
+    ]),
+  );
+}
+
+function deferredGate(): {
+  readonly wait: () => Promise<void>;
+  readonly release: () => void;
+} {
+  let releaseGate = (): void => {};
+  const promise = new Promise<void>((resolve) => {
+    releaseGate = resolve;
+  });
+  return {
+    wait: () => {
+      return promise;
+    },
+    release: releaseGate,
+  };
+}
+
 describe("CHAT-02: completed chat callback", () => {
   it("persists assistant output, reorders threads, titles the thread, recommends follow-ups, notifies, and auto-sends the queued template message", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
@@ -656,6 +702,7 @@ describe("CHAT-02: completed chat callback", () => {
     chatCallbacks.mockChatOutputEvents([
       assistantEvent(0, "Daily support queue summary is ready."),
     ]);
+
     await completeChatRunOk(first.runId, sandboxHeaders, {
       lastEventSequence: 0,
     });
@@ -698,6 +745,122 @@ describe("CHAT-02: completed chat callback", () => {
       }),
     ).toHaveLength(2);
   });
+
+  it("auto-sends the queued message before completed-run LLM side effects finish", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const first = await startChatRun(actor, {
+      agentId,
+      prompt: "finish the current turn",
+    });
+    await queueChatMessage(actor, {
+      agentId,
+      threadId: first.threadId,
+      prompt: "queued while side effects wait",
+    });
+
+    const queuedBeforeComplete = await chat.listThreadMessages(
+      actor,
+      first.threadId,
+    );
+    const queued = userMessages(queuedBeforeComplete.messages).find(
+      (message) => {
+        return message.content === "queued while side effects wait";
+      },
+    );
+    if (!queued) {
+      throw new Error("Expected the queued user message to be listed");
+    }
+
+    const openRouterGate = deferredGate();
+    mockOptionalEnv("OPENROUTER_API_KEY", "bdd-openrouter-key");
+    chatCallbacks.mockOpenRouterCompletions(async (body) => {
+      await openRouterGate.wait();
+      const systemContent = body.messages[0]?.content ?? "";
+      if (
+        systemContent.includes("Generate up to three concise follow-up prompts")
+      ) {
+        return JSON.stringify([
+          { prompt: "Review the queued result", kind: "talk" },
+        ]);
+      }
+      if (systemContent.includes("Generate a short, descriptive title")) {
+        return "Deferred Side Effects";
+      }
+      return "Deferred summary";
+    });
+
+    const sandboxHeaders = await claimChatRun(runnerGroup, first.runId);
+    chatCallbacks.mockChatOutputEvents([assistantEvent(0, "completed answer")]);
+    await completeChatRunOk(first.runId, sandboxHeaders, {
+      lastEventSequence: 0,
+    });
+
+    const afterAutoSend = await waitForThreadMessages(
+      actor,
+      first.threadId,
+      (messages) => {
+        return userMessages(messages).some((message) => {
+          return (
+            message.revokesMessageId === queued.id &&
+            message.runId !== undefined
+          );
+        });
+      },
+    );
+    const markerBeforeRelease = lifecycleMarkers(
+      afterAutoSend.messages,
+      first.runId,
+      "completed",
+    )[0];
+    if (!markerBeforeRelease) {
+      throw new Error(
+        "Expected completed marker before releasing side effects",
+      );
+    }
+    expect(markerBeforeRelease.recommendedFollowups).toBeUndefined();
+
+    const claimed = userMessages(afterAutoSend.messages).find((message) => {
+      return message.revokesMessageId === queued.id;
+    });
+    if (!claimed?.runId) {
+      throw new Error("Expected the queued message to auto-send");
+    }
+    expect(claimed.runId).not.toBe(first.runId);
+    expectZeroPreCreateSource(claimed.runId, "chat_callback_auto_send");
+
+    openRouterGate.release();
+    const afterFollowups = await waitForThreadMessages(
+      actor,
+      first.threadId,
+      (messages) => {
+        return lifecycleMarkers(messages, first.runId, "completed").some(
+          (message) => {
+            return (
+              message.id === markerBeforeRelease.id &&
+              (message.recommendedFollowups?.length ?? 0) === 1
+            );
+          },
+        );
+      },
+    );
+    expect(
+      lifecycleMarkers(afterFollowups.messages, first.runId, "completed"),
+    ).toHaveLength(1);
+    const markerAfterRelease = lifecycleMarkers(
+      afterFollowups.messages,
+      first.runId,
+      "completed",
+    )[0];
+    expect(markerAfterRelease?.id).toBe(markerBeforeRelease.id);
+    expect(markerAfterRelease?.recommendedFollowups).toStrictEqual([
+      { prompt: "Review the queued result", kind: "talk" },
+    ]);
+
+    await api.requestCancelRun(actor, claimed.runId, [200]);
+    await waitForRunStatus(actor, claimed.runId, "cancelled");
+  }, 90_000);
 });
 
 describe("CHAT-02: chat output extraction and progress callbacks", () => {
@@ -1178,6 +1341,13 @@ describe("CHAT-02: auto-send after failures", () => {
       ],
     });
 
+    await chatCallbacks.registerPushSubscription(actor);
+    chatCallbacks.enableVapid();
+    const pushGate = deferredGate();
+    context.mocks.webpush.sendNotification.mockImplementation(() => {
+      return pushGate.wait();
+    });
+
     context.mocks.ably.publish.mockClear();
     await failChatRun(second.runId, secondHeaders, "boom");
 
@@ -1204,6 +1374,7 @@ describe("CHAT-02: auto-send after failures", () => {
       );
     }
     expect(claimed.runId).not.toBe(second.runId);
+    expectZeroPreCreateSource(claimed.runId, "chat_callback_auto_send");
     expect(claimed.attachFiles).toHaveLength(1);
     expect(claimed.attachFiles?.[0]).toMatchObject({
       filename: "queued-notes.txt",
@@ -1234,6 +1405,13 @@ describe("CHAT-02: auto-send after failures", () => {
     expect(appended).toContain(`[Web file]\n   [ID] ${contextFile.id}`);
     expect(appended).not.toContain("# Web Chat Run Context");
     expect(autoContext.body.sessionId).toBe(`bdd-cli-${first.runId}`);
+
+    pushGate.release();
+    await expect
+      .poll(() => {
+        return context.mocks.webpush.sendNotification.mock.calls.length;
+      })
+      .toBe(1);
 
     await api.requestCancelRun(actor, claimed.runId, [200]);
     await waitForRunStatus(actor, claimed.runId, "cancelled");

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -8,10 +8,11 @@ import type {
   GenerationTemplateRequest,
   PagedChatMessage,
 } from "@vm0/api-contracts/contracts/chat-threads";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, onTestFinished } from "vitest";
 
 import { mockOptionalEnv } from "../../../lib/env";
 import { testContext } from "../../../__tests__/test-context";
+import { flushWaitUntilForTest } from "../../context/wait-until";
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
 import { mockClerkMembership } from "./helpers/api-bdd-clerk";
 import { createChatCallbacksApi } from "./helpers/api-bdd-chat-callbacks";
@@ -382,6 +383,9 @@ function deferredGate(): {
   let releaseGate = (): void => {};
   const promise = new Promise<void>((resolve) => {
     releaseGate = resolve;
+  });
+  onTestFinished(() => {
+    releaseGate();
   });
   return {
     wait: () => {
@@ -857,6 +861,48 @@ describe("CHAT-02: completed chat callback", () => {
     expect(markerAfterRelease?.recommendedFollowups).toStrictEqual([
       { prompt: "Review the queued result", kind: "talk" },
     ]);
+
+    await flushWaitUntilForTest();
+
+    await queueChatMessage(actor, {
+      agentId,
+      threadId: first.threadId,
+      prompt: "queued after duplicate callback",
+    });
+    const afterSecondQueue = await chat.listThreadMessages(
+      actor,
+      first.threadId,
+    );
+    const duplicateProbeQueued = userMessages(afterSecondQueue.messages).find(
+      (message) => {
+        return message.content === "queued after duplicate callback";
+      },
+    );
+    if (!duplicateProbeQueued) {
+      throw new Error("Expected the duplicate probe message to queue");
+    }
+
+    await completeChatRunOk(first.runId, sandboxHeaders, {
+      lastEventSequence: 0,
+    });
+    await flushWaitUntilForTest();
+
+    const afterDuplicateCallback = await chat.listThreadMessages(
+      actor,
+      first.threadId,
+    );
+    const duplicateProbeClaimed = userMessages(
+      afterDuplicateCallback.messages,
+    ).filter((message) => {
+      return message.revokesMessageId === duplicateProbeQueued.id;
+    });
+    expect(duplicateProbeClaimed).toHaveLength(0);
+    const duplicateProbeStillQueued = userMessages(
+      afterDuplicateCallback.messages,
+    ).find((message) => {
+      return message.id === duplicateProbeQueued.id;
+    });
+    expect(duplicateProbeStillQueued?.runId).toBeUndefined();
 
     await api.requestCancelRun(actor, claimed.runId, [200]);
     await waitForRunStatus(actor, claimed.runId, "cancelled");
@@ -1380,10 +1426,13 @@ describe("CHAT-02: auto-send after failures", () => {
       filename: "queued-notes.txt",
       url: expect.stringContaining(queuedFile.id),
     });
-    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
-      `chatThreadRunCreated:${first.threadId}`,
-      null,
-    );
+    await expect
+      .poll(() => {
+        return context.mocks.ably.publish.mock.calls.some((call) => {
+          return call[0] === `chatThreadRunCreated:${first.threadId}`;
+        });
+      })
+      .toBe(true);
 
     const autoContext = await api.requestRunContext(
       actor,

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -365,15 +365,22 @@ function sandboxOperationEventsForRun(
   });
 }
 
-function expectZeroPreCreateSource(runId: string, source: string): void {
-  expect(sandboxOperationEventsForRun(runId)).toStrictEqual(
-    expect.arrayContaining([
-      expect.objectContaining({
-        op_type: "api_dispatch_pre_create_agent_run",
-        zero_pre_create_source: source,
-      }),
-    ]),
-  );
+async function expectZeroPreCreateSource(
+  runId: string,
+  source: string,
+): Promise<void> {
+  await expect
+    .poll(() => {
+      return sandboxOperationEventsForRun(runId);
+    })
+    .toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          op_type: "api_dispatch_pre_create_agent_run",
+          zero_pre_create_source: source,
+        }),
+      ]),
+    );
 }
 
 function deferredGate(): {
@@ -837,7 +844,7 @@ describe("CHAT-02: completed chat callback", () => {
       throw new Error("Expected the queued message to auto-send");
     }
     expect(claimed.runId).not.toBe(first.runId);
-    expectZeroPreCreateSource(claimed.runId, "chat_callback_auto_send");
+    await expectZeroPreCreateSource(claimed.runId, "chat_callback_auto_send");
 
     openRouterGate.release();
     const afterFollowups = await waitForThreadMessages(
@@ -1425,7 +1432,7 @@ describe("CHAT-02: auto-send after failures", () => {
       );
     }
     expect(claimed.runId).not.toBe(second.runId);
-    expectZeroPreCreateSource(claimed.runId, "chat_callback_auto_send");
+    await expectZeroPreCreateSource(claimed.runId, "chat_callback_auto_send");
     expect(claimed.attachFiles).toHaveLength(1);
     expect(claimed.attachFiles?.[0]).toMatchObject({
       filename: "queued-notes.txt",

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -15,7 +15,7 @@ import type {
 import { describe, expect, it, onTestFinished } from "vitest";
 
 import { createAppWithRoutes } from "../../../app-factory-core";
-import { mockOptionalEnv } from "../../../lib/env";
+import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { testContext } from "../../../__tests__/test-context";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
@@ -959,6 +959,95 @@ describe("CHAT-02: completed chat callback", () => {
 
     await api.requestCancelRun(actor, claimed.runId, [200]);
     await waitForRunStatus(actor, claimed.runId, "cancelled");
+  }, 90_000);
+
+  it("marks an auto-sent follow-up when org concurrency queues the new run", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+    mockEnv("CONCURRENT_RUN_LIMIT_CAP", "2");
+
+    const first = await startChatRun(actor, {
+      agentId,
+      prompt: "finish before auto-send queues",
+    });
+    const blocker = await startChatRun(actor, {
+      agentId,
+      prompt: "hold org concurrency open",
+    });
+    await waitForRunStatus(actor, first.runId, "pending");
+    await waitForRunStatus(actor, blocker.runId, "pending");
+
+    await queueChatMessage(actor, {
+      agentId,
+      threadId: first.threadId,
+      prompt: "queued while org cap is full",
+    });
+    const queuedBeforeComplete = await chat.listThreadMessages(
+      actor,
+      first.threadId,
+    );
+    const queued = userMessages(queuedBeforeComplete.messages).find(
+      (message) => {
+        return message.content === "queued while org cap is full";
+      },
+    );
+    if (!queued) {
+      throw new Error("Expected the queued user message to be listed");
+    }
+
+    mockEnv("CONCURRENT_RUN_LIMIT_CAP", "1");
+    const sandboxHeaders = await claimChatRun(runnerGroup, first.runId);
+    chatCallbacks.mockChatOutputEvents([assistantEvent(0, "anchor completed")]);
+    await completeChatRunOk(first.runId, sandboxHeaders, {
+      lastEventSequence: 0,
+    });
+
+    const afterAutoSend = await waitForThreadMessages(
+      actor,
+      first.threadId,
+      (messages) => {
+        const claimed = userMessages(messages).find((message) => {
+          return (
+            message.revokesMessageId === queued.id &&
+            message.runId !== undefined
+          );
+        });
+        return (
+          claimed !== undefined &&
+          assistantMessages(messages).some((message) => {
+            return (
+              message.runId === claimed.runId &&
+              message.runEventId === "queue:queued"
+            );
+          })
+        );
+      },
+    );
+    const claimed = userMessages(afterAutoSend.messages).find((message) => {
+      return message.revokesMessageId === queued.id;
+    });
+    if (!claimed?.runId) {
+      throw new Error("Expected the queued message to auto-send");
+    }
+    const marker = assistantMessages(afterAutoSend.messages).find((message) => {
+      return (
+        message.runId === claimed.runId && message.runEventId === "queue:queued"
+      );
+    });
+    if (!marker) {
+      throw new Error("Expected an assistant queue marker");
+    }
+    expect(marker).toMatchObject({
+      content: "Waiting in queue...",
+      runId: claimed.runId,
+    });
+
+    await api.requestCancelRun(actor, blocker.runId, [200]);
+    await waitForRunStatus(actor, blocker.runId, "cancelled");
+    await waitForRunStatus(actor, claimed.runId, "pending");
+    await api.requestCancelRun(actor, claimed.runId, [200]);
+    await waitForRunStatus(actor, claimed.runId, "cancelled");
+    await flushWaitUntilForTest();
   }, 90_000);
 
   it("excludes pre-dispatch cancelled rows without chat messages from later context", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -401,6 +401,7 @@ describe("CHAT-02: completed chat callback", () => {
     chatCallbacks.failIfChatCallbackRouteIsFetched();
 
     const titlePrompts: string[] = [];
+    const followupPrompts: string[] = [];
     mockOptionalEnv("OPENROUTER_API_KEY", "bdd-openrouter-key");
     chatCallbacks.mockOpenRouterCompletions((body) => {
       const systemContent = body.messages[0]?.content ?? "";
@@ -411,6 +412,7 @@ describe("CHAT-02: completed chat callback", () => {
       if (
         systemContent.includes("Generate up to three concise follow-up prompts")
       ) {
+        followupPrompts.push(body.messages[1]?.content ?? "");
         return JSON.stringify([
           { prompt: "Turn this into a checklist", kind: "talk" },
           {
@@ -517,6 +519,9 @@ describe("CHAT-02: completed chat callback", () => {
         generationType: "website",
       },
     ]);
+    expect(followupPrompts).toHaveLength(1);
+    expect(followupPrompts[0]).toContain("final answer");
+    expect(followupPrompts[0]).not.toContain("queued next turn");
     await expect
       .poll(() => {
         return publishedChatThreadRunFinished(first.threadId);

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -1462,12 +1462,47 @@ describe("CHAT-02: auto-send after failures", () => {
       })
       .toBe(1);
 
+    await queueChatMessage(actor, {
+      agentId,
+      threadId: first.threadId,
+      prompt: "queued after duplicate failed callback",
+    });
+    const afterFailureSecondQueue = await chat.listThreadMessages(
+      actor,
+      first.threadId,
+    );
+    const duplicateFailureProbeQueued = userMessages(
+      afterFailureSecondQueue.messages,
+    ).find((message) => {
+      return message.content === "queued after duplicate failed callback";
+    });
+    if (!duplicateFailureProbeQueued) {
+      throw new Error("Expected the duplicate failure probe message to queue");
+    }
+
     await failChatRun(second.runId, secondHeaders, "boom");
+    await flushWaitUntilForTest();
     await expect
       .poll(() => {
         return context.mocks.webpush.sendNotification.mock.calls.length;
       })
       .toBe(1);
+    const afterDuplicateFailure = await chat.listThreadMessages(
+      actor,
+      first.threadId,
+    );
+    const duplicateFailureProbeClaimed = userMessages(
+      afterDuplicateFailure.messages,
+    ).filter((message) => {
+      return message.revokesMessageId === duplicateFailureProbeQueued.id;
+    });
+    expect(duplicateFailureProbeClaimed).toHaveLength(0);
+    const duplicateFailureProbeStillQueued = userMessages(
+      afterDuplicateFailure.messages,
+    ).find((message) => {
+      return message.id === duplicateFailureProbeQueued.id;
+    });
+    expect(duplicateFailureProbeStillQueued?.runId).toBeUndefined();
 
     await api.requestCancelRun(actor, claimed.runId, [200]);
     await waitForRunStatus(actor, claimed.runId, "cancelled");

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -1413,6 +1413,13 @@ describe("CHAT-02: auto-send after failures", () => {
       })
       .toBe(1);
 
+    await failChatRun(second.runId, secondHeaders, "boom");
+    await expect
+      .poll(() => {
+        return context.mocks.webpush.sendNotification.mock.calls.length;
+      })
+      .toBe(1);
+
     await api.requestCancelRun(actor, claimed.runId, [200]);
     await waitForRunStatus(actor, claimed.runId, "cancelled");
   }, 90_000);

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -790,6 +790,7 @@ describe("CHAT-02: completed chat callback", () => {
     }
 
     const openRouterGate = deferredGate();
+    const titlePrompts: string[] = [];
     mockOptionalEnv("OPENROUTER_API_KEY", "bdd-openrouter-key");
     chatCallbacks.mockOpenRouterCompletions(async (body) => {
       await openRouterGate.wait();
@@ -802,6 +803,7 @@ describe("CHAT-02: completed chat callback", () => {
         ]);
       }
       if (systemContent.includes("Generate a short, descriptive title")) {
+        titlePrompts.push(body.messages[1]?.content ?? "");
         return "Deferred Side Effects";
       }
       return "Deferred summary";
@@ -873,6 +875,9 @@ describe("CHAT-02: completed chat callback", () => {
     expect(markerAfterRelease?.recommendedFollowups).toStrictEqual([
       { prompt: "Review the queued result", kind: "talk" },
     ]);
+    expect(titlePrompts).toHaveLength(1);
+    expect(titlePrompts[0]).toContain("finish the current turn");
+    expect(titlePrompts[0]).not.toContain("queued while side effects wait");
 
     await flushWaitUntilForTest();
 

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -2612,10 +2612,7 @@ describe("CHAT-01 v1 chat threads for personal access tokens", () => {
       throw new Error("Expected the queued v1 message to auto-send into a run");
     }
     expect(promoted.content).toBe("queued from v1");
-    await expectZeroPreCreateSource(
-      promoted.runId,
-      "chat_callback_auto_send",
-    );
+    await expectZeroPreCreateSource(promoted.runId, "chat_callback_auto_send");
     await cancelChatRun(actor, promoted.runId);
 
     // Workflows still mount as SKILL.md-backed volumes in the runtime. Under

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -82,6 +82,37 @@ const MODEL_FIRST_SELECTION_PROVIDER_ID =
 type AssistantMessage = Extract<PagedChatMessage, { role: "assistant" }>;
 type UserMessage = Extract<PagedChatMessage, { role: "user" }>;
 type RunnerClaim = Awaited<ReturnType<typeof api.claimRunnerJob>>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function sandboxOperationEventsForRun(
+  runId: string,
+): readonly Record<string, unknown>[] {
+  return context.mocks.axiom.sdkIngest.mock.calls.flatMap((call) => {
+    const dataset = call[0];
+    const events = call[1];
+    if (dataset !== "vm0-sandbox-op-log-dev" || !Array.isArray(events)) {
+      return [];
+    }
+    return events.filter((event): event is Record<string, unknown> => {
+      return isRecord(event) && event.run_id === runId;
+    });
+  });
+}
+
+function expectZeroPreCreateSource(runId: string, source: string): void {
+  expect(sandboxOperationEventsForRun(runId)).toStrictEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        op_type: "api_dispatch_pre_create_agent_run",
+        zero_pre_create_source: source,
+      }),
+    ]),
+  );
+}
+
 interface EntitledChatActor {
   readonly actor: ApiTestUser;
   readonly agentId: string;
@@ -2525,6 +2556,7 @@ describe("CHAT-01 v1 chat threads for personal access tokens", () => {
       throw new Error("Expected the second v1 send to create a run");
     }
     const run2Id = second.body.runId;
+    expectZeroPreCreateSource(run2Id, "chat_thread_v1_send");
     const run2 = await api.readRun(actor, run2Id);
     const appended = run2.appendSystemPrompt ?? "";
     expect(appended).toContain("# Web Chat Run Context");
@@ -2573,6 +2605,7 @@ describe("CHAT-01 v1 chat threads for personal access tokens", () => {
       throw new Error("Expected the queued v1 message to auto-send into a run");
     }
     expect(promoted.content).toBe("queued from v1");
+    expectZeroPreCreateSource(promoted.runId, "chat_callback_auto_send");
     await cancelChatRun(actor, promoted.runId);
 
     // Workflows still mount as SKILL.md-backed volumes in the runtime. Under

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -102,15 +102,22 @@ function sandboxOperationEventsForRun(
   });
 }
 
-function expectZeroPreCreateSource(runId: string, source: string): void {
-  expect(sandboxOperationEventsForRun(runId)).toStrictEqual(
-    expect.arrayContaining([
-      expect.objectContaining({
-        op_type: "api_dispatch_pre_create_agent_run",
-        zero_pre_create_source: source,
-      }),
-    ]),
-  );
+async function expectZeroPreCreateSource(
+  runId: string,
+  source: string,
+): Promise<void> {
+  await expect
+    .poll(() => {
+      return sandboxOperationEventsForRun(runId);
+    })
+    .toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          op_type: "api_dispatch_pre_create_agent_run",
+          zero_pre_create_source: source,
+        }),
+      ]),
+    );
 }
 
 interface EntitledChatActor {
@@ -2556,7 +2563,7 @@ describe("CHAT-01 v1 chat threads for personal access tokens", () => {
       throw new Error("Expected the second v1 send to create a run");
     }
     const run2Id = second.body.runId;
-    expectZeroPreCreateSource(run2Id, "chat_thread_v1_send");
+    await expectZeroPreCreateSource(run2Id, "chat_thread_v1_send");
     const run2 = await api.readRun(actor, run2Id);
     const appended = run2.appendSystemPrompt ?? "";
     expect(appended).toContain("# Web Chat Run Context");
@@ -2605,7 +2612,10 @@ describe("CHAT-01 v1 chat threads for personal access tokens", () => {
       throw new Error("Expected the queued v1 message to auto-send into a run");
     }
     expect(promoted.content).toBe("queued from v1");
-    expectZeroPreCreateSource(promoted.runId, "chat_callback_auto_send");
+    await expectZeroPreCreateSource(
+      promoted.runId,
+      "chat_callback_auto_send",
+    );
     await cancelChatRun(actor, promoted.runId);
 
     // Workflows still mount as SKILL.md-backed volumes in the runtime. Under

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-callbacks.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-callbacks.ts
@@ -176,7 +176,7 @@ export function createChatCallbacksApi(context: TestContext) {
      * system prompt and returns the completion text.
      */
     mockOpenRouterCompletions(
-      handler: (body: OpenRouterCompletionBody) => string,
+      handler: (body: OpenRouterCompletionBody) => string | Promise<string>,
     ): void {
       server.use(
         http.post(OPENROUTER_COMPLETIONS_URL, async ({ request }) => {
@@ -184,7 +184,7 @@ export function createChatCallbacksApi(context: TestContext) {
             await request.json(),
           );
           return HttpResponse.json({
-            choices: [{ message: { content: handler(body) } }],
+            choices: [{ message: { content: await handler(body) } }],
           });
         }),
       );

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflows.test.ts
@@ -15,6 +15,7 @@ import {
   type ApiTestUser,
   type ApiTestUserOptions,
 } from "./helpers/api-bdd";
+import { createRunsAutomationsApi } from "./helpers/api-bdd-runs-automations";
 import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
 import { createMiscRoutesApi } from "./helpers/api-bdd-misc";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
@@ -24,6 +25,7 @@ const bdd = createBddApi(context);
 const chat = createChatFilesBddApi(context);
 createMiscRoutesApi(context);
 const mocks = createZeroRouteMocks(context);
+const api = createRunsAutomationsApi(context);
 
 function user(options: ApiTestUserOptions = {}): ApiTestUser {
   return bdd.user(options);
@@ -126,6 +128,36 @@ function names(workflows: readonly { readonly name: string }[]): string[] {
   });
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function sandboxOperationEventsForRun(
+  runId: string,
+): readonly Record<string, unknown>[] {
+  return context.mocks.axiom.sdkIngest.mock.calls.flatMap((call) => {
+    const dataset = call[0];
+    const events = call[1];
+    if (dataset !== "vm0-sandbox-op-log-dev" || !Array.isArray(events)) {
+      return [];
+    }
+    return events.filter((event): event is Record<string, unknown> => {
+      return isRecord(event) && event.run_id === runId;
+    });
+  });
+}
+
+function expectZeroPreCreateSource(runId: string, source: string): void {
+  expect(sandboxOperationEventsForRun(runId)).toStrictEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        op_type: "api_dispatch_pre_create_agent_run",
+        zero_pre_create_source: source,
+      }),
+    ]),
+  );
+}
+
 describe("zero workflows", () => {
   it("creates private workflows by default and hides them from other org members", async () => {
     const owner = user();
@@ -161,6 +193,36 @@ describe("zero workflows", () => {
       [200],
     );
     expect(names(memberList.body)).not.toContain(created.body.name);
+  });
+
+  it("runs a workflow slash command with workflow timing attribution", async () => {
+    const actor = user({ orgRole: "org:admin" });
+    await api.grantProEntitlement(actor);
+    await api.ensureOrgModelProvider(actor);
+    const agent = await createAgent(actor, {
+      displayName: "Workflow Runner Agent",
+      visibility: "private",
+    });
+    api.configureRunnerGroup();
+
+    const created = await createWorkflow(actor, {
+      agentId: agent.agentId,
+      name: `run-attribution-workflow-${randomUUID().slice(0, 8)}`,
+      displayName: "Run Attribution Workflow",
+      instruction: "# run attribution workflow",
+    });
+
+    const run = await accept(
+      detailClient().run({
+        headers: authHeaders(actor),
+        params: { workflowId: created.body.id },
+      }),
+      [200],
+    );
+
+    expect(run.body.chatThreadId).toStrictEqual(expect.any(String));
+    expect(run.body.runId).toStrictEqual(expect.any(String));
+    expectZeroPreCreateSource(run.body.runId, "workflow_slash_command");
   });
 
   it("requires agent write-permission to create workflows under an agent", async () => {

--- a/turbo/apps/api/src/signals/routes/test-chat-messages-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-chat-messages-state.ts
@@ -3,15 +3,19 @@ import {
   testChatMessagesStateContract,
   type TestChatMessagesStateActionBody,
 } from "@vm0/api-contracts/contracts/test-chat-messages-state";
+import { agentRuns } from "@vm0/db/schema/agent-run";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { secrets } from "@vm0/db/schema/secret";
 import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { and, eq, like, or } from "drizzle-orm";
 
+import { nowDate } from "../../lib/time";
 import { bodyResultOf } from "../context/request";
 import { request$ } from "../context/hono";
 import { writeDb$, type Db } from "../external/db";
 import type { RouteEntry } from "../route-entry";
+import { BEFORE_DISPATCH_CANCELLED_ERROR } from "../services/agent-run-create.service";
 import { encryptPersistentSecretValue } from "../services/crypto.utils";
 import {
   isTestEndpointAllowed,
@@ -118,6 +122,29 @@ async function deleteOpenRouterVm0ApiKeysForAction(
   return actionOk();
 }
 
+async function attachPreDispatchCancelledRunToThreadForAction(
+  db: Db,
+  body: ChatMessagesAction<"attach-pre-dispatch-cancelled-run-to-thread">,
+  signal: AbortSignal,
+) {
+  await db.transaction(async (tx) => {
+    await tx
+      .update(agentRuns)
+      .set({
+        status: "cancelled",
+        completedAt: nowDate(),
+        error: BEFORE_DISPATCH_CANCELLED_ERROR,
+      })
+      .where(eq(agentRuns.id, body.run_id));
+    await tx
+      .update(zeroRuns)
+      .set({ chatThreadId: body.thread_id })
+      .where(eq(zeroRuns.id, body.run_id));
+  });
+  signal.throwIfAborted();
+  return actionOk();
+}
+
 const mutateChatMessagesState$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     if (!isTestEndpointAllowed(get(request$))) {
@@ -144,6 +171,13 @@ const mutateChatMessagesState$ = command(
       }
       case "delete-openrouter-vm0-api-keys": {
         return await deleteOpenRouterVm0ApiKeysForAction(db, body, signal);
+      }
+      case "attach-pre-dispatch-cancelled-run-to-thread": {
+        return await attachPreDispatchCancelledRunToThreadForAction(
+          db,
+          body,
+          signal,
+        );
       }
     }
   },

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -51,6 +51,7 @@ import {
   createZeroRun$,
   type ZeroPreCreateSource,
 } from "../services/zero-runs-create.service";
+import { BEFORE_DISPATCH_CANCELLED_ERROR } from "../services/agent-run-create.service";
 import { dispatchFailedRunCallbacks } from "../services/agent-run-callback.service";
 import {
   ApiDispatchTimingCollector,
@@ -806,7 +807,12 @@ async function getLatestRunsByThreadId(
     })
     .from(zeroRuns)
     .innerJoin(agentRuns, eq(agentRuns.id, zeroRuns.id))
-    .where(eq(zeroRuns.chatThreadId, threadId))
+    .where(
+      and(
+        eq(zeroRuns.chatThreadId, threadId),
+        sql`(${agentRuns.status} IS DISTINCT FROM ${"cancelled"} OR ${agentRuns.error} IS DISTINCT FROM ${BEFORE_DISPATCH_CANCELLED_ERROR})`,
+      ),
+    )
     .orderBy(desc(agentRuns.createdAt))
     .limit(limit);
 

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -47,7 +47,10 @@ import {
 import { env } from "../../lib/env";
 import { buildArtifactKey, sanitizeArtifactFilename } from "../../lib/file-url";
 import type { AuthContext } from "../../types/auth";
-import { createZeroRun$ } from "../services/zero-runs-create.service";
+import {
+  createZeroRun$,
+  type ZeroPreCreateSource,
+} from "../services/zero-runs-create.service";
 import { dispatchFailedRunCallbacks } from "../services/agent-run-callback.service";
 import {
   ApiDispatchTimingCollector,
@@ -184,6 +187,7 @@ interface NormalSendArgs {
   readonly orgId: string;
   readonly apiStartTime: number;
   readonly timing?: ApiDispatchTimingCollector;
+  readonly zeroPreCreateSource?: ZeroPreCreateSource;
 }
 
 interface PreparedNormalSend {
@@ -2443,6 +2447,9 @@ function buildCreateZeroRunArgs(params: {
       prepared.computerUseHostGrant?.displayName ?? null,
     ),
     ...(args.timing ? { timing: args.timing } : {}),
+    ...(args.zeroPreCreateSource
+      ? { zeroPreCreateSource: args.zeroPreCreateSource }
+      : {}),
   };
 }
 

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -1688,6 +1688,7 @@ function appendRecallUserMessage(params: {
       .select({
         role: chatMessages.role,
         runId: chatMessages.runId,
+        content: chatMessages.content,
         createdAt: chatMessages.createdAt,
       })
       .from(chatMessages)
@@ -1699,7 +1700,11 @@ function appendRecallUserMessage(params: {
       )
       .limit(1);
     if (existingRevoker) {
-      if (existingRevoker.role === "user" && existingRevoker.runId === null) {
+      if (
+        existingRevoker.role === "user" &&
+        existingRevoker.runId === null &&
+        existingRevoker.content === null
+      ) {
         return { ok: true, createdAt: existingRevoker.createdAt };
       }
       return {

--- a/turbo/apps/api/src/signals/routes/zero-workflows.ts
+++ b/turbo/apps/api/src/signals/routes/zero-workflows.ts
@@ -896,6 +896,7 @@ const runWorkflowInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       body: { prompt, agentId: agent.id },
       apiStartTime: now.getTime(),
       triggerSource: "web",
+      zeroPreCreateSource: "workflow_slash_command",
       chatThreadId,
       callbacks: [
         {

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -6002,12 +6002,13 @@ async function beforeDispatchResponse(args: {
     return null;
   }
 
+  // Do not bind the outer request signal here. A successful gate may have
+  // persisted pre-dispatch state that must be followed by queue/job persistence.
   const beforeDispatchResult = await settle(
     beforeDispatch({
       runId: args.run.id,
       status: args.run.status,
     }),
-    args.signal,
   );
   if (!beforeDispatchResult.ok) {
     const transitioned = await markRunFailed(

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -5014,7 +5014,7 @@ function failedRunResponse(
   };
 }
 
-const BEFORE_DISPATCH_CANCELLED_ERROR =
+export const BEFORE_DISPATCH_CANCELLED_ERROR =
   "Run dispatch cancelled before runner queue persistence";
 
 function cancelledBeforeDispatchRunResponse(
@@ -5036,20 +5036,29 @@ async function cancelRunBeforeDispatch(
   db: Db,
   runId: string,
 ): Promise<boolean> {
-  const [updated] = await db
-    .update(agentRuns)
-    .set({
-      status: "cancelled",
-      completedAt: nowDate(),
-      error: BEFORE_DISPATCH_CANCELLED_ERROR,
-    })
-    .where(
-      and(
-        eq(agentRuns.id, runId),
-        inArray(agentRuns.status, ["queued", "pending"]),
-      ),
-    )
-    .returning({ userId: agentRuns.userId });
+  const updated = await db.transaction(async (tx) => {
+    const [row] = await tx
+      .update(agentRuns)
+      .set({
+        status: "cancelled",
+        completedAt: nowDate(),
+        error: BEFORE_DISPATCH_CANCELLED_ERROR,
+      })
+      .where(
+        and(
+          eq(agentRuns.id, runId),
+          inArray(agentRuns.status, ["queued", "pending"]),
+        ),
+      )
+      .returning({ userId: agentRuns.userId });
+    if (!row) {
+      return undefined;
+    }
+
+    await tx.delete(agentRunQueue).where(eq(agentRunQueue.runId, runId));
+    await tx.delete(runnerJobQueue).where(eq(runnerJobQueue.runId, runId));
+    return row;
+  });
 
   if (!updated) {
     return false;

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -6010,13 +6010,22 @@ async function beforeDispatchResponse(args: {
     args.signal,
   );
   if (!beforeDispatchResult.ok) {
-    await markRunFailed(
+    const transitioned = await markRunFailed(
       args.db,
       args.run.id,
       beforeDispatchResult.error,
       args.createArgs.dispatchFailedCallbacks,
     );
     args.signal.throwIfAborted();
+    if (transitioned && args.run.status === "pending") {
+      await tapError(args.drainOrgQueue(), (error) => {
+        L.error("Failed to drain org queue after run pre-dispatch failure", {
+          runId: args.run.id,
+          error,
+        });
+      });
+      args.signal.throwIfAborted();
+    }
     return failedRunResponse(args.run, beforeDispatchResult.error);
   }
   if (beforeDispatchResult.value) {

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -431,6 +431,11 @@ export type DispatchFailedRunCallbacks = (
   error: string,
 ) => Promise<void>;
 
+export type BeforeRunDispatch = (args: {
+  readonly runId: string;
+  readonly status: "queued" | "pending";
+}) => Promise<boolean>;
+
 export interface CreateAgentRunArgs {
   readonly userId: string;
   readonly orgId: string;
@@ -461,6 +466,7 @@ export interface CreateAgentRunArgs {
   readonly queueOnConcurrencyLimit?: boolean;
   readonly enforceVm0Credits?: boolean;
   readonly dispatchFailedCallbacks?: DispatchFailedRunCallbacks;
+  readonly beforeDispatch?: BeforeRunDispatch;
   readonly timing?: ApiDispatchTimingCollector;
   readonly timingDimensions?: ApiDispatchTimingDimensions;
 }
@@ -5008,6 +5014,53 @@ function failedRunResponse(
   };
 }
 
+const BEFORE_DISPATCH_CANCELLED_ERROR =
+  "Run dispatch cancelled before runner queue persistence";
+
+function cancelledBeforeDispatchRunResponse(
+  run: RunRecord,
+): Extract<CreateRunRouteResult, { readonly status: 201 }> {
+  return {
+    status: 201,
+    body: {
+      runId: run.id,
+      status: "cancelled",
+      sessionId: run.sessionId,
+      error: BEFORE_DISPATCH_CANCELLED_ERROR,
+      createdAt: run.createdAt.toISOString(),
+    },
+  };
+}
+
+async function cancelRunBeforeDispatch(
+  db: Db,
+  runId: string,
+): Promise<boolean> {
+  const [updated] = await db
+    .update(agentRuns)
+    .set({
+      status: "cancelled",
+      completedAt: nowDate(),
+      error: BEFORE_DISPATCH_CANCELLED_ERROR,
+    })
+    .where(
+      and(
+        eq(agentRuns.id, runId),
+        inArray(agentRuns.status, ["queued", "pending"]),
+      ),
+    )
+    .returning({ userId: agentRuns.userId });
+
+  if (!updated) {
+    return false;
+  }
+
+  await publishRunChangedForUserSafely(updated.userId, runId, {
+    status: "cancelled",
+  });
+  return true;
+}
+
 interface PreparedRunContext {
   readonly body: CreateRunBody;
   readonly resolved: ResolvedCompose;
@@ -5937,6 +5990,53 @@ function completePendingRun(input: {
   );
 }
 
+async function beforeDispatchResponse(args: {
+  readonly db: Db;
+  readonly run: RunRecord;
+  readonly createArgs: CreateAgentRunArgs;
+  readonly signal: AbortSignal;
+  readonly drainOrgQueue: () => Promise<void>;
+}): Promise<Extract<CreateRunRouteResult, { readonly status: 201 }> | null> {
+  const beforeDispatch = args.createArgs.beforeDispatch;
+  if (!beforeDispatch) {
+    return null;
+  }
+
+  const beforeDispatchResult = await settle(
+    beforeDispatch({
+      runId: args.run.id,
+      status: args.run.status,
+    }),
+    args.signal,
+  );
+  if (!beforeDispatchResult.ok) {
+    await markRunFailed(
+      args.db,
+      args.run.id,
+      beforeDispatchResult.error,
+      args.createArgs.dispatchFailedCallbacks,
+    );
+    args.signal.throwIfAborted();
+    return failedRunResponse(args.run, beforeDispatchResult.error);
+  }
+  if (beforeDispatchResult.value) {
+    return null;
+  }
+
+  const cancelled = await cancelRunBeforeDispatch(args.db, args.run.id);
+  args.signal.throwIfAborted();
+  if (cancelled && args.run.status === "pending") {
+    await tapError(args.drainOrgQueue(), (error) => {
+      L.error("Failed to drain org queue after run dispatch cancellation", {
+        runId: args.run.id,
+        error,
+      });
+    });
+    args.signal.throwIfAborted();
+  }
+  return cancelledBeforeDispatchRunResponse(args.run);
+}
+
 export const createAgentRun$ = command(
   async (
     { get, set },
@@ -6010,6 +6110,19 @@ export const createAgentRun$ = command(
 
     if (isRouteError(transactionResult)) {
       return transactionResult;
+    }
+
+    const beforeDispatch = await beforeDispatchResponse({
+      db,
+      run: transactionResult,
+      createArgs: args,
+      signal,
+      drainOrgQueue: async () => {
+        await set(drainOrgQueue$, { orgId: args.orgId }, signal);
+      },
+    });
+    if (beforeDispatch) {
+      return beforeDispatch;
     }
 
     if (transactionResult.status === "queued") {

--- a/turbo/apps/api/src/signals/services/chat-thread-v1-send.service.ts
+++ b/turbo/apps/api/src/signals/services/chat-thread-v1-send.service.ts
@@ -8,6 +8,7 @@ import { notFound } from "../../lib/error";
 import type { AuthContext } from "../../types/auth";
 import { sendNormalMessage$ } from "../routes/zero-chat-messages";
 import { writeDb$ } from "../external/db";
+import { ApiDispatchTimingCollector } from "./api-dispatch-timing.service";
 
 export const sendChatThreadMessageV1$ = command(
   async (
@@ -41,6 +42,7 @@ export const sendChatThreadMessageV1$ = command(
     }
 
     const messageId = randomUUID();
+    const timing = new ApiDispatchTimingCollector();
     const result = await set(
       sendNormalMessage$,
       {
@@ -48,6 +50,8 @@ export const sendChatThreadMessageV1$ = command(
         userId: args.auth.userId,
         orgId: args.auth.orgId,
         apiStartTime: args.apiStartTime,
+        timing,
+        zeroPreCreateSource: "chat_thread_v1_send",
         body: {
           agentId: thread.agentComposeId,
           threadId: thread.id,

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -64,7 +64,7 @@ import {
 import { createZeroRun$ } from "./zero-runs-create.service";
 import { loadActiveGoalForThread } from "./zero-goal.service";
 import { loadUserFeatureSwitchContext } from "./feature-switches.service";
-import { settle, tapError } from "../utils";
+import { settle, tapError, throwIfAbort } from "../utils";
 import { resolveThreadGenerationTemplatePrompt } from "../routes/thread-generation-template";
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
@@ -882,12 +882,25 @@ async function runCompletedChatCallbackSideEffects(args: {
     });
   })();
 
-  await Promise.all([
+  const results = await Promise.allSettled([
     saveSummaryStep,
     titleStep,
     lifecycleMarkerStep,
     pushStep,
   ]);
+  const errors = results.flatMap((result) => {
+    if (result.status === "fulfilled") {
+      return [];
+    }
+    throwIfAbort(result.reason);
+    return [result.reason];
+  });
+  if (errors.length > 0) {
+    throw new AggregateError(
+      errors,
+      "Completed chat callback side effects failed",
+    );
+  }
 }
 
 async function handleFailedChatCallback(args: {

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -40,6 +40,7 @@ import {
   publishUserSignal,
 } from "../external/realtime";
 import { recordSandboxOperation } from "../external/sandbox-op-log";
+import type { DispatchFailedRunCallbacks } from "./agent-run-create.service";
 import type { InternalRunCallbackEnvelope } from "./internal-run-callback";
 import { formatRunErrorForRunOwner$ } from "./run-error-format.service";
 import { saveRunSummary, saveRunSummary$ } from "./run-summary.service";
@@ -288,6 +289,7 @@ function parseModelProviderCredentialScope(
 function buildQueuedCreateZeroRunArgs(
   input: CreateQueuedChatRunInput,
   apiStartTime: number,
+  dispatchFailedCallbacks?: DispatchFailedRunCallbacks,
 ) {
   return {
     auth: {
@@ -315,6 +317,7 @@ function buildQueuedCreateZeroRunArgs(
     triggerSource: "web" as const,
     zeroPreCreateSource: "chat_callback_auto_send" as const,
     appendSystemPrompt: input.appendSystemPrompt,
+    dispatchFailedCallbacks,
     beforeDispatch: input.beforeDispatch,
     body: {
       prompt: input.prompt,
@@ -2059,6 +2062,65 @@ async function processTerminalChatCallback(args: {
   }
 }
 
+function withoutQueuedRunDependency(
+  dependencies: ChatCallbackDependencies,
+): ChatCallbackDependencies {
+  return {
+    insertAssistantItems: dependencies.insertAssistantItems,
+    saveRunSummary: dependencies.saveRunSummary,
+    formatRunError: dependencies.formatRunError,
+    getResolvedAttachFiles: dependencies.getResolvedAttachFiles,
+  };
+}
+
+async function claimedUserMessageExistsForRun(
+  db: Db,
+  runId: string,
+): Promise<boolean> {
+  const [message] = await db
+    .select({ id: chatMessages.id })
+    .from(chatMessages)
+    .where(
+      and(
+        eq(chatMessages.runId, runId),
+        eq(chatMessages.role, "user"),
+        isNotNull(chatMessages.revokesMessageId),
+      ),
+    )
+    .limit(1);
+  return message !== undefined;
+}
+
+function buildQueuedChatDispatchFailedCallbacks(args: {
+  readonly apiStartTime: number;
+  readonly dependencies: ChatCallbackDependencies;
+  readonly runInput: CreateQueuedChatRunInput;
+  readonly signal: AbortSignal;
+}): DispatchFailedRunCallbacks {
+  return async (db, runId, error) => {
+    if (!(await claimedUserMessageExistsForRun(db, runId))) {
+      return;
+    }
+    const payload = {
+      threadId: args.runInput.threadId,
+      agentId: args.runInput.agentId,
+    };
+    await processTerminalChatCallback({
+      apiStartTime: args.apiStartTime,
+      db,
+      callback: {
+        runId,
+        status: "failed",
+        error,
+        payload,
+      },
+      payload,
+      dependencies: withoutQueuedRunDependency(args.dependencies),
+      signal: args.signal,
+    });
+  };
+}
+
 function handleChatInternalCallback(args: {
   readonly db: Db;
   readonly callback: InternalRunCallbackEnvelope;
@@ -2157,52 +2219,65 @@ export const handleChatInternalCallback$ = command(
     | { readonly success: false; readonly error: string }
   > => {
     const db = set(writeDb$);
+    const baseDependencies: ChatCallbackDependencies = {
+      insertAssistantItems: async (args, inputSignal) => {
+        await set(insertAssistantEventMessages$, args, inputSignal);
+      },
+      saveRunSummary: (runId, prompt, resultText, inputSignal) => {
+        return set(
+          saveRunSummary$,
+          {
+            runId,
+            triggerSource: "chat",
+            prompt,
+            resultText,
+          },
+          inputSignal,
+        );
+      },
+      formatRunError: (params, inputSignal) => {
+        return set(formatRunErrorForRunOwner$, params, inputSignal);
+      },
+      getResolvedAttachFiles: (userId, fileIds) => {
+        return get(resolveAttachFileUrls(userId, fileIds));
+      },
+    };
+    const dependencies: ChatCallbackDependencies = {
+      ...baseDependencies,
+      createQueuedRun: async (runInput, apiStartTime, inputSignal) => {
+        const runResult = await set(
+          createZeroRun$,
+          buildQueuedCreateZeroRunArgs(
+            runInput,
+            apiStartTime,
+            buildQueuedChatDispatchFailedCallbacks({
+              apiStartTime,
+              dependencies: baseDependencies,
+              runInput,
+              signal: inputSignal,
+            }),
+          ),
+          inputSignal,
+        );
+        if (
+          runResult.status !== 201 ||
+          runResult.body.status === "failed" ||
+          runResult.body.status === "cancelled"
+        ) {
+          log.warn("Auto-send failed to create run", {
+            threadId: runInput.threadId,
+            status: runResult.status,
+          });
+          return null;
+        }
+        return { runId: runResult.body.runId };
+      },
+    };
     return await handleChatInternalCallback({
       db,
       callback,
       signal,
-      dependencies: {
-        insertAssistantItems: async (args, inputSignal) => {
-          await set(insertAssistantEventMessages$, args, inputSignal);
-        },
-        saveRunSummary: (runId, prompt, resultText, inputSignal) => {
-          return set(
-            saveRunSummary$,
-            {
-              runId,
-              triggerSource: "chat",
-              prompt,
-              resultText,
-            },
-            inputSignal,
-          );
-        },
-        formatRunError: (params, inputSignal) => {
-          return set(formatRunErrorForRunOwner$, params, inputSignal);
-        },
-        getResolvedAttachFiles: (userId, fileIds) => {
-          return get(resolveAttachFileUrls(userId, fileIds));
-        },
-        createQueuedRun: async (runInput, apiStartTime, inputSignal) => {
-          const runResult = await set(
-            createZeroRun$,
-            buildQueuedCreateZeroRunArgs(runInput, apiStartTime),
-            inputSignal,
-          );
-          if (
-            runResult.status !== 201 ||
-            runResult.body.status === "failed" ||
-            runResult.body.status === "cancelled"
-          ) {
-            log.warn("Auto-send failed to create run", {
-              threadId: runInput.threadId,
-              status: runResult.status,
-            });
-            return null;
-          }
-          return { runId: runResult.body.runId };
-        },
-      },
+      dependencies,
     });
   },
 );

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -81,17 +81,19 @@ const RECENT_CHAT_RUN_LIMIT = 10;
 const PRIOR_MESSAGE_CHAR_CAP = 4000;
 const INCOMPLETE_MESSAGE_CHAR_CAP = 4000;
 
+function errorCode(value: unknown): string | undefined {
+  if (typeof value !== "object" || value === null || !("code" in value)) {
+    return undefined;
+  }
+  return typeof value.code === "string" ? value.code : undefined;
+}
+
 function isForeignKeyViolation(error: unknown): boolean {
-  if (!(error instanceof Error)) {
-    return false;
-  }
-
-  const { cause } = error;
-  if (typeof cause !== "object" || cause === null || !("code" in cause)) {
-    return false;
-  }
-
-  return cause.code === PG_FOREIGN_KEY_VIOLATION;
+  return (
+    errorCode(error) === PG_FOREIGN_KEY_VIOLATION ||
+    (error instanceof Error &&
+      errorCode(error.cause) === PG_FOREIGN_KEY_VIOLATION)
+  );
 }
 
 const chatCallbackPayloadSchema = z

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -54,15 +54,17 @@ import {
 } from "./zero-chat-message-shared.service";
 import { sendUserPushNotifications } from "./zero-push-notifications.service";
 import {
+  type ChatCompletionContextMessage,
   generateAndPersistChatThreadTitleFromCallback,
-  generateChatThreadRecommendedFollowups,
-  generateChatThreadWorkflowAutomationSuggestion,
+  generateChatThreadRecommendedFollowupsFromContext,
+  generateChatThreadWorkflowAutomationSuggestionFromContext,
   generateChatNotificationSummary,
+  loadChatThreadRecommendedFollowupContext,
 } from "./zero-chat-title.service";
 import { createZeroRun$ } from "./zero-runs-create.service";
 import { loadActiveGoalForThread } from "./zero-goal.service";
 import { loadUserFeatureSwitchContext } from "./feature-switches.service";
-import { settle, tapError } from "../utils";
+import { onRejection, settle, tapError } from "../utils";
 import { resolveThreadGenerationTemplatePrompt } from "../routes/thread-generation-template";
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
@@ -245,6 +247,15 @@ interface CreateQueuedChatRunInput {
   readonly queuedMessage: QueuedUserMessage;
 }
 
+interface CompletedChatCallbackResult {
+  readonly lastResultText: string | null;
+  readonly followupContext: readonly ChatCompletionContextMessage[];
+}
+
+interface FailedChatCallbackResult {
+  readonly displayErrorMessage: string;
+}
+
 function generateCallbackSecret(): string {
   return randomBytes(32).toString("hex");
 }
@@ -286,6 +297,7 @@ function buildQueuedCreateZeroRunArgs(
       },
     ],
     triggerSource: "web" as const,
+    zeroPreCreateSource: "chat_callback_auto_send" as const,
     appendSystemPrompt: input.appendSystemPrompt,
     body: {
       prompt: input.prompt,
@@ -465,14 +477,12 @@ async function recordLastEventToComplete(db: Db, runId: string): Promise<void> {
 async function insertAssistantErrorMessage(args: {
   readonly db: Db;
   readonly runId: string;
-  readonly prompt: string;
   readonly threadId: string;
   readonly userId: string;
   readonly publishRunFinished: boolean;
   readonly lifecycleEvent: "failed" | "cancelled";
-  readonly isGoalRun: boolean;
   readonly getFormattedError: () => Promise<string>;
-}): Promise<boolean> {
+}): Promise<FailedChatCallbackResult> {
   const displayErrorMessage = await args.getFormattedError();
   const runGroupId = await runGroupIdForRun(args.db, args.runId);
   const inserted = await args.db.transaction(async (tx) => {
@@ -499,7 +509,7 @@ async function insertAssistantErrorMessage(args: {
     return true;
   });
   if (!inserted) {
-    return false;
+    return { displayErrorMessage };
   }
 
   await publishUserSignal(
@@ -513,16 +523,7 @@ async function insertAssistantErrorMessage(args: {
       threadId: args.threadId,
     });
   }
-  await sendUserPushNotifications({
-    db: args.db,
-    userId: args.userId,
-    notification: {
-      title: args.prompt.slice(0, 60),
-      body: `Task failed: ${displayErrorMessage.slice(0, 80)}`,
-      url: `/chats/${args.threadId}`,
-    },
-  });
-  return true;
+  return { displayErrorMessage };
 }
 
 async function insertRunLifecycleMarker(args: {
@@ -592,14 +593,44 @@ async function insertRunLifecycleMarker(args: {
   return true;
 }
 
-async function generateRecommendedFollowupsForCompletedRun(args: {
+async function updateCompletedLifecycleMarkerFollowups(args: {
   readonly db: Db;
+  readonly runId: string;
+  readonly threadId: string;
+  readonly userId: string;
+  readonly recommendedFollowups: ChatMessageRecommendedFollowups;
+}): Promise<boolean> {
+  const updated = await args.db
+    .update(chatMessages)
+    .set({ recommendedFollowups: args.recommendedFollowups })
+    .where(
+      and(
+        eq(chatMessages.runId, args.runId),
+        eq(chatMessages.role, "assistant"),
+        eq(chatMessages.runLifecycleEvent, "completed"),
+      ),
+    )
+    .returning({ id: chatMessages.id });
+
+  if (updated.length === 0) {
+    return false;
+  }
+
+  await publishUserSignal(
+    [args.userId],
+    `chatThreadMessageCreated:${args.threadId}`,
+  );
+  return true;
+}
+
+async function generateRecommendedFollowupsForCompletedRun(args: {
+  readonly followupContext: readonly ChatCompletionContextMessage[];
   readonly threadId: string;
   readonly signal: AbortSignal;
 }): Promise<ChatMessageRecommendedFollowups | undefined> {
   args.signal.throwIfAborted();
-  const suggestions = await generateChatThreadRecommendedFollowups({
-    db: args.db,
+  const suggestions = await generateChatThreadRecommendedFollowupsFromContext({
+    messages: args.followupContext,
     threadId: args.threadId,
   });
   args.signal.throwIfAborted();
@@ -611,6 +642,7 @@ async function generateWorkflowAutomationSuggestionForCompletedRun(args: {
   readonly orgId: string;
   readonly userId: string;
   readonly threadId: string;
+  readonly followupContext: readonly ChatCompletionContextMessage[];
   readonly signal: AbortSignal;
 }): Promise<ChatMessageRecommendedFollowup | undefined> {
   args.signal.throwIfAborted();
@@ -623,8 +655,8 @@ async function generateWorkflowAutomationSuggestionForCompletedRun(args: {
     return undefined;
   }
 
-  const suggestion = await generateChatThreadWorkflowAutomationSuggestion({
-    db: args.db,
+  const suggestion = await generateChatThreadWorkflowAutomationSuggestionFromContext({
+    messages: args.followupContext,
     threadId: args.threadId,
   });
   args.signal.throwIfAborted();
@@ -663,13 +695,11 @@ async function handleCompletedChatCallback(args: {
   readonly runId: string;
   readonly run: ChatRunInfo;
   readonly chatThread: ChatThreadForRunRow;
-  readonly isGoalRun: boolean;
   readonly signal: AbortSignal;
   readonly insertAssistantItems: (
     items: readonly AssistantEventItem[],
   ) => Promise<void>;
-  readonly saveRunSummary: (resultText: string) => Promise<void>;
-}): Promise<void> {
+}): Promise<CompletedChatCallbackResult> {
   const { assistantItems, resultFallback } = await queryChatOutputEvents({
     runId: args.runId,
     lastEventSequence: args.run.lastEventSequence,
@@ -711,12 +741,39 @@ async function handleCompletedChatCallback(args: {
     }),
   );
 
-  // The remaining post-processing steps are mutually independent. They used to
-  // run serially, which stacked several sequential LLM round trips onto the
-  // request tail. Run the independent groups concurrently; steps that depend on
-  // each other (followups -> lifecycle marker, notification summary -> push)
-  // stay ordered within their own group.
-  const saveSummaryStep = args.saveRunSummary(lastResultText ?? "");
+  await insertRunLifecycleMarker({
+    db: args.db,
+    runId: args.runId,
+    threadId: args.chatThread.chatThreadId,
+    userId: args.chatThread.userId,
+    publishRunFinished: args.chatThread.triggerSource === "web",
+    event: "completed",
+  });
+  args.signal.throwIfAborted();
+
+  const followupContext = await loadChatThreadRecommendedFollowupContext({
+    db: args.db,
+    threadId: args.chatThread.chatThreadId,
+  });
+  args.signal.throwIfAborted();
+
+  return { lastResultText, followupContext };
+}
+
+async function runCompletedChatCallbackSideEffects(args: {
+  readonly db: Db;
+  readonly runId: string;
+  readonly run: ChatRunInfo;
+  readonly chatThread: ChatThreadForRunRow;
+  readonly isGoalRun: boolean;
+  readonly lastResultText: string | null;
+  readonly followupContext: readonly ChatCompletionContextMessage[];
+  readonly signal: AbortSignal;
+  readonly saveRunSummary: (resultText: string) => Promise<void>;
+}): Promise<void> {
+  // The post-processing steps are mutually independent. Run them after queued
+  // auto-send so LLM/push latency does not delay the next run.
+  const saveSummaryStep = args.saveRunSummary(args.lastResultText ?? "");
 
   const titleStep = generateAndPersistChatThreadTitleFromCallback({
     db: args.db,
@@ -724,14 +781,14 @@ async function handleCompletedChatCallback(args: {
     userId: args.chatThread.userId,
     runId: args.runId,
     prompt: args.run.prompt,
-    currentAssistantReply: lastResultText ?? undefined,
+    currentAssistantReply: args.lastResultText ?? undefined,
   });
 
   const lifecycleMarkerStep = (async () => {
     const [recommendedFollowups, workflowAutomationSuggestion] =
       await Promise.all([
         generateRecommendedFollowupsForCompletedRun({
-          db: args.db,
+          followupContext: args.followupContext,
           threadId: args.chatThread.chatThreadId,
           signal: args.signal,
         }),
@@ -740,6 +797,7 @@ async function handleCompletedChatCallback(args: {
           orgId: args.chatThread.orgId,
           userId: args.chatThread.userId,
           threadId: args.chatThread.chatThreadId,
+          followupContext: args.followupContext,
           signal: args.signal,
         }),
       ]);
@@ -747,13 +805,14 @@ async function handleCompletedChatCallback(args: {
       recommendedFollowups,
       workflowAutomationSuggestion,
     );
-    await insertRunLifecycleMarker({
+    if (!mergedRecommendedFollowups) {
+      return;
+    }
+    await updateCompletedLifecycleMarkerFollowups({
       db: args.db,
       runId: args.runId,
       threadId: args.chatThread.chatThreadId,
       userId: args.chatThread.userId,
-      publishRunFinished: args.chatThread.triggerSource === "web",
-      event: "completed",
       recommendedFollowups: mergedRecommendedFollowups,
     });
   })();
@@ -774,9 +833,9 @@ async function handleCompletedChatCallback(args: {
     }
 
     let summary: string | null = null;
-    if (lastResultText) {
+    if (args.lastResultText) {
       const generated = await settle(
-        generateChatNotificationSummary(args.run.prompt, lastResultText),
+        generateChatNotificationSummary(args.run.prompt, args.lastResultText),
       );
       if (generated.ok) {
         summary = generated.value;
@@ -810,27 +869,56 @@ async function handleCompletedChatCallback(args: {
 async function handleFailedChatCallback(args: {
   readonly db: Db;
   readonly runId: string;
-  readonly run: ChatRunInfo;
   readonly chatThread: ChatThreadForRunRow;
   readonly errorMessage: string;
-  readonly isGoalRun: boolean;
   readonly getFormattedError: () => Promise<string>;
-}): Promise<void> {
+}): Promise<FailedChatCallbackResult> {
   const lifecycleEvent =
     args.errorMessage.trim().toLowerCase() === "run cancelled"
       ? "cancelled"
       : "failed";
-  await insertAssistantErrorMessage({
+  return await insertAssistantErrorMessage({
     db: args.db,
     runId: args.runId,
-    prompt: args.run.prompt,
     threadId: args.chatThread.chatThreadId,
     userId: args.chatThread.userId,
     publishRunFinished: args.chatThread.triggerSource === "web",
     lifecycleEvent,
-    isGoalRun: args.isGoalRun,
     getFormattedError: args.getFormattedError,
   });
+}
+
+async function runFailedChatCallbackSideEffects(args: {
+  readonly db: Db;
+  readonly run: ChatRunInfo;
+  readonly chatThread: ChatThreadForRunRow;
+  readonly displayErrorMessage: string;
+}): Promise<void> {
+  await sendUserPushNotifications({
+    db: args.db,
+    userId: args.chatThread.userId,
+    notification: {
+      title: args.run.prompt.slice(0, 60),
+      body: `Task failed: ${args.displayErrorMessage.slice(0, 80)}`,
+      url: `/chats/${args.chatThread.chatThreadId}`,
+    },
+  });
+}
+
+function scheduleTerminalChatCallbackSideEffects(args: {
+  readonly runId: string;
+  readonly status: "completed" | "failed";
+  readonly run: () => Promise<void>;
+}): void {
+  waitUntil(
+    tapError(args.run(), (error) => {
+      log.warn("Failed to process terminal chat callback side effects", {
+        runId: args.runId,
+        status: args.status,
+        error,
+      });
+    }),
+  );
 }
 
 function buildWebChatPrompt(): string {
@@ -1672,6 +1760,37 @@ async function loadTerminalChatCallback(args: {
   return { run, chatThread };
 }
 
+async function autoSendQueuedMessageForTerminalCallback(args: {
+  readonly db: Db;
+  readonly runId: string;
+  readonly agentId: string;
+  readonly apiStartTime: number;
+  readonly dependencies: ChatCallbackDependencies;
+  readonly signal: AbortSignal;
+}): Promise<void> {
+  const createQueuedRun = args.dependencies.createQueuedRun;
+  if (!createQueuedRun) {
+    return;
+  }
+
+  await autoSendQueuedMessageOnRunComplete({
+    db: args.db,
+    runId: args.runId,
+    agentId: args.agentId,
+    getResolvedAttachFiles: args.dependencies.getResolvedAttachFiles,
+    createRun: (input) => {
+      return createQueuedChatRun({
+        db: args.db,
+        input,
+        signal: args.signal,
+        createRun: (runInput) => {
+          return createQueuedRun(runInput, args.apiStartTime, args.signal);
+        },
+      });
+    },
+  });
+}
+
 async function processTerminalChatCallback(args: {
   readonly apiStartTime: number;
   readonly db: Db;
@@ -1699,13 +1818,14 @@ async function processTerminalChatCallback(args: {
   const { run, chatThread } = loaded;
   const isGoalRun = args.payload.isGoalRun ?? false;
 
+  let deferredSideEffects: (() => Promise<void>) | undefined;
+
   if (callbackStatus === "completed") {
-    await handleCompletedChatCallback({
+    const completed = await handleCompletedChatCallback({
       db: args.db,
       runId,
       run,
       chatThread,
-      isGoalRun,
       signal: args.signal,
       insertAssistantItems: async (items) => {
         await args.dependencies.insertAssistantItems(
@@ -1718,24 +1838,34 @@ async function processTerminalChatCallback(args: {
           args.signal,
         );
       },
-      saveRunSummary: (resultText) => {
-        return args.dependencies.saveRunSummary(
-          runId,
-          run.prompt,
-          resultText,
-          args.signal,
-        );
-      },
     });
+    deferredSideEffects = () => {
+      return runCompletedChatCallbackSideEffects({
+        db: args.db,
+        runId,
+        run,
+        chatThread,
+        isGoalRun,
+        lastResultText: completed.lastResultText,
+        followupContext: completed.followupContext,
+        signal: args.signal,
+        saveRunSummary: (resultText) => {
+          return args.dependencies.saveRunSummary(
+            runId,
+            run.prompt,
+            resultText,
+            args.signal,
+          );
+        },
+      });
+    };
   } else {
     const errorMessage = args.callback.error ?? run.error ?? "Run failed";
-    await handleFailedChatCallback({
+    const failed = await handleFailedChatCallback({
       db: args.db,
       runId,
-      run,
       chatThread,
       errorMessage,
-      isGoalRun,
       getFormattedError: () => {
         return args.dependencies.formatRunError(
           {
@@ -1747,29 +1877,41 @@ async function processTerminalChatCallback(args: {
         );
       },
     });
-  }
-
-  const createQueuedRun = args.dependencies.createQueuedRun;
-  if (!createQueuedRun) {
-    return;
-  }
-
-  await autoSendQueuedMessageOnRunComplete({
-    db: args.db,
-    runId,
-    agentId: args.payload.agentId,
-    getResolvedAttachFiles: args.dependencies.getResolvedAttachFiles,
-    createRun: (input) => {
-      return createQueuedChatRun({
+    deferredSideEffects = () => {
+      return runFailedChatCallbackSideEffects({
         db: args.db,
-        input,
-        signal: args.signal,
-        createRun: (runInput) => {
-          return createQueuedRun(runInput, args.apiStartTime, args.signal);
-        },
+        run,
+        chatThread,
+        displayErrorMessage: failed.displayErrorMessage,
       });
-    },
-  });
+    };
+  }
+
+  let sideEffectsScheduled = false;
+  const scheduleSideEffects = (): void => {
+    if (!deferredSideEffects || sideEffectsScheduled) {
+      return;
+    }
+    sideEffectsScheduled = true;
+    scheduleTerminalChatCallbackSideEffects({
+      runId,
+      status: callbackStatus,
+      run: deferredSideEffects,
+    });
+  };
+
+  await onRejection(
+    autoSendQueuedMessageForTerminalCallback({
+      db: args.db,
+      runId,
+      agentId: args.payload.agentId,
+      apiStartTime: args.apiStartTime,
+      dependencies: args.dependencies,
+      signal: args.signal,
+    }),
+    scheduleSideEffects,
+  );
+  scheduleSideEffects();
 }
 
 function handleChatInternalCallback(args: {

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -57,6 +57,7 @@ import {
   touchChatThreadLastMessageAt,
   visibleChatMessageCondition,
 } from "./zero-chat-message-shared.service";
+import { appendQueuedRunAssistantMarker } from "./zero-chat-queue-marker.service";
 import { sendUserPushNotifications } from "./zero-push-notifications.service";
 import {
   type ChatCompletionContextMessage,
@@ -210,11 +211,16 @@ type ResolveAttachFiles = (
   fileIds: readonly string[],
 ) => Promise<readonly ResolvedAttachFile[]>;
 
+type CreatedQueuedRun = {
+  readonly runId: string;
+  readonly status: "queued" | "pending" | "running";
+};
+
 type CreateQueuedRun = (
   input: CreateQueuedChatRunInput,
   apiStartTime: number,
   signal: AbortSignal,
-) => Promise<{ readonly runId: string } | null>;
+) => Promise<CreatedQueuedRun | null>;
 
 interface ChatCallbackDependencies {
   readonly insertAssistantItems: (
@@ -292,6 +298,12 @@ interface TerminalChatCallbackWork {
 type AutoSendOutcome =
   | { readonly ok: true }
   | { readonly ok: false; readonly error: unknown };
+
+function isCreatedQueuedRunStatus(
+  status: string,
+): status is CreatedQueuedRun["status"] {
+  return status === "queued" || status === "pending" || status === "running";
+}
 
 function generateCallbackSecret(): string {
   return randomBytes(32).toString("hex");
@@ -1738,7 +1750,7 @@ async function claimQueuedUserMessage(args: {
       return [];
     }
 
-    return await tx
+    const [message] = await tx
       .insert(chatMessages)
       .values({
         chatThreadId: args.threadId,
@@ -1756,16 +1768,48 @@ async function claimQueuedUserMessage(args: {
       })
       .onConflictDoNothing({ target: chatMessages.revokesMessageId })
       .returning({ id: chatMessages.id });
+    return message ? [message] : [];
   });
 
   return claimed.length > 0;
+}
+
+async function appendAutoSentQueuedRunMarker(args: {
+  readonly db: Db;
+  readonly queuedMessageId: string;
+  readonly runId: string;
+  readonly threadId: string;
+}): Promise<void> {
+  await args.db.transaction(async (tx) => {
+    const [message] = await tx
+      .select({ createdAt: chatMessages.createdAt })
+      .from(chatMessages)
+      .where(
+        and(
+          eq(chatMessages.chatThreadId, args.threadId),
+          eq(chatMessages.runId, args.runId),
+          eq(chatMessages.role, "user"),
+          eq(chatMessages.revokesMessageId, args.queuedMessageId),
+        ),
+      )
+      .limit(1);
+    if (!message) {
+      return;
+    }
+
+    await appendQueuedRunAssistantMarker(tx, {
+      chatThreadId: args.threadId,
+      runId: args.runId,
+      createdAfter: message.createdAt,
+    });
+  });
 }
 
 async function autoSendQueuedMessageOnRunComplete(args: {
   readonly getResolvedAttachFiles: ResolveAttachFiles;
   readonly createRun: (
     input: CreateQueuedChatRunInput,
-  ) => Promise<{ readonly runId: string } | null>;
+  ) => Promise<CreatedQueuedRun | null>;
   readonly db: Db;
   readonly runId: string;
   readonly agentId: string;
@@ -1834,6 +1878,14 @@ async function autoSendQueuedMessageOnRunComplete(args: {
   if (!run) {
     return;
   }
+  if (run.status === "queued") {
+    await appendAutoSentQueuedRunMarker({
+      db: args.db,
+      queuedMessageId: queuedMessage.id,
+      runId: run.runId,
+      threadId,
+    });
+  }
 
   await publishUserSignal([userId], `chatThreadMessageCreated:${threadId}`);
   await publishUserSignal([userId], `chatThreadRunCreated:${threadId}`);
@@ -1846,8 +1898,8 @@ async function createQueuedChatRun(args: {
   readonly signal: AbortSignal;
   readonly createRun: (
     input: CreateQueuedChatRunInput,
-  ) => Promise<{ readonly runId: string } | null>;
-}): Promise<{ readonly runId: string } | null> {
+  ) => Promise<CreatedQueuedRun | null>;
+}): Promise<CreatedQueuedRun | null> {
   const created = await args.createRun(args.input);
   args.signal.throwIfAborted();
   if (!created) {
@@ -2365,7 +2417,18 @@ export const handleChatInternalCallback$ = command(
           });
           return null;
         }
-        return { runId: runResult.body.runId };
+        if (!isCreatedQueuedRunStatus(runResult.body.status)) {
+          log.warn("Auto-send created run with unexpected status", {
+            threadId: runInput.threadId,
+            runId: runResult.body.runId,
+            status: runResult.body.status,
+          });
+          return null;
+        }
+        return {
+          runId: runResult.body.runId,
+          status: runResult.body.status,
+        };
       },
     };
     return await handleChatInternalCallback({

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -41,7 +41,10 @@ import {
   publishUserSignal,
 } from "../external/realtime";
 import { recordSandboxOperation } from "../external/sandbox-op-log";
-import type { DispatchFailedRunCallbacks } from "./agent-run-create.service";
+import {
+  BEFORE_DISPATCH_CANCELLED_ERROR,
+  type DispatchFailedRunCallbacks,
+} from "./agent-run-create.service";
 import type { InternalRunCallbackEnvelope } from "./internal-run-callback";
 import { formatRunErrorForRunOwner$ } from "./run-error-format.service";
 import { saveRunSummary, saveRunSummary$ } from "./run-summary.service";
@@ -1308,7 +1311,12 @@ async function getLatestRunsByThreadId(
     })
     .from(zeroRuns)
     .innerJoin(agentRuns, eq(agentRuns.id, zeroRuns.id))
-    .where(eq(zeroRuns.chatThreadId, threadId))
+    .where(
+      and(
+        eq(zeroRuns.chatThreadId, threadId),
+        sql`(${agentRuns.status} IS DISTINCT FROM ${"cancelled"} OR ${agentRuns.error} IS DISTINCT FROM ${BEFORE_DISPATCH_CANCELLED_ERROR})`,
+      ),
+    )
     .orderBy(desc(agentRuns.createdAt))
     .limit(limit);
 

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -76,9 +76,23 @@ import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 
 const log = logger("callback:chat");
 const AGENT_RUN_EVENTS_DATASET = "agent-run-events";
+const PG_FOREIGN_KEY_VIOLATION = "23503";
 const RECENT_CHAT_RUN_LIMIT = 10;
 const PRIOR_MESSAGE_CHAR_CAP = 4000;
 const INCOMPLETE_MESSAGE_CHAR_CAP = 4000;
+
+function isForeignKeyViolation(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const { cause } = error;
+  if (typeof cause !== "object" || cause === null || !("code" in cause)) {
+    return false;
+  }
+
+  return cause.code === PG_FOREIGN_KEY_VIOLATION;
+}
 
 const chatCallbackPayloadSchema = z
   .object({
@@ -1537,6 +1551,15 @@ async function activeChatRunExistsForThread(
   return run !== undefined;
 }
 
+async function chatThreadExists(db: Db, threadId: string): Promise<boolean> {
+  const [thread] = await db
+    .select({ id: chatThreads.id })
+    .from(chatThreads)
+    .where(eq(chatThreads.id, threadId))
+    .limit(1);
+  return thread !== undefined;
+}
+
 function fallbackAttachFiles(
   ids: readonly string[] | null,
 ): readonly ResolvedAttachFile[] {
@@ -2304,20 +2327,31 @@ export const handleChatInternalCallback$ = command(
     const dependencies: ChatCallbackDependencies = {
       ...baseDependencies,
       createQueuedRun: async (runInput, apiStartTime, inputSignal) => {
-        const runResult = await set(
-          createZeroRun$,
-          buildQueuedCreateZeroRunArgs(
-            runInput,
+        const createArgs = buildQueuedCreateZeroRunArgs(
+          runInput,
+          apiStartTime,
+          buildQueuedChatDispatchFailedCallbacks({
             apiStartTime,
-            buildQueuedChatDispatchFailedCallbacks({
-              apiStartTime,
-              dependencies: baseDependencies,
-              runInput,
-              signal: inputSignal,
-            }),
-          ),
+            dependencies: baseDependencies,
+            runInput,
+            signal: inputSignal,
+          }),
+        );
+        const settledRunResult = await settle(
+          set(createZeroRun$, createArgs, inputSignal),
           inputSignal,
         );
+        inputSignal.throwIfAborted();
+        if (!settledRunResult.ok) {
+          if (
+            isForeignKeyViolation(settledRunResult.error) &&
+            !(await chatThreadExists(db, runInput.threadId))
+          ) {
+            return null;
+          }
+          throw settledRunResult.error;
+        }
+        const runResult = settledRunResult.value;
         if (
           runResult.status !== 201 ||
           runResult.body.status === "failed" ||

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -254,6 +254,7 @@ interface CompletedChatCallbackResult {
 
 interface FailedChatCallbackResult {
   readonly displayErrorMessage: string;
+  readonly inserted: boolean;
 }
 
 function generateCallbackSecret(): string {
@@ -509,7 +510,7 @@ async function insertAssistantErrorMessage(args: {
     return true;
   });
   if (!inserted) {
-    return { displayErrorMessage };
+    return { displayErrorMessage, inserted: false };
   }
 
   await publishUserSignal(
@@ -523,7 +524,7 @@ async function insertAssistantErrorMessage(args: {
       threadId: args.threadId,
     });
   }
-  return { displayErrorMessage };
+  return { displayErrorMessage, inserted: true };
 }
 
 async function insertRunLifecycleMarker(args: {
@@ -1898,14 +1899,16 @@ async function processTerminalChatCallback(args: {
         );
       },
     });
-    deferredSideEffects = () => {
-      return runFailedChatCallbackSideEffects({
-        db: args.db,
-        run,
-        chatThread,
-        displayErrorMessage: failed.displayErrorMessage,
-      });
-    };
+    if (failed.inserted) {
+      deferredSideEffects = () => {
+        return runFailedChatCallbackSideEffects({
+          db: args.db,
+          run,
+          chatThread,
+          displayErrorMessage: failed.displayErrorMessage,
+        });
+      };
+    }
   }
 
   const autoSendResult = await settle(

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -1781,6 +1781,16 @@ async function appendAutoSentQueuedRunMarker(args: {
   readonly threadId: string;
 }): Promise<void> {
   await args.db.transaction(async (tx) => {
+    const threadRows = await tx.execute<{ readonly id: string }>(sql`
+      SELECT ${chatThreads.id} AS "id"
+      FROM ${chatThreads}
+      WHERE ${chatThreads.id} = ${args.threadId}
+      FOR KEY SHARE
+    `);
+    if (!threadRows.rows[0]) {
+      return;
+    }
+
     const [message] = await tx
       .select({ createdAt: chatMessages.createdAt })
       .from(chatMessages)

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -171,10 +171,6 @@ interface QueuedUserMessage {
   readonly selectedModel: string | null;
 }
 
-interface QueuedUserMessageClaimReservation {
-  readonly id: string;
-}
-
 interface AgentForAutoSend {
   readonly id: string;
   readonly orgId: string;
@@ -249,6 +245,10 @@ interface CreateQueuedChatRunInput {
   readonly appendSystemPrompt: string;
   readonly threadId: string;
   readonly queuedMessage: QueuedUserMessage;
+  readonly beforeDispatch?: (args: {
+    readonly runId: string;
+    readonly status: "queued" | "pending";
+  }) => Promise<boolean>;
 }
 
 type CompletedChatCallbackResult =
@@ -315,6 +315,7 @@ function buildQueuedCreateZeroRunArgs(
     triggerSource: "web" as const,
     zeroPreCreateSource: "chat_callback_auto_send" as const,
     appendSystemPrompt: input.appendSystemPrompt,
+    beforeDispatch: input.beforeDispatch,
     body: {
       prompt: input.prompt,
       agentId: input.agentId,
@@ -1657,18 +1658,19 @@ async function buildCreateQueuedChatRunInput(args: {
   };
 }
 
-async function reserveQueuedUserMessageClaim(args: {
+async function claimQueuedUserMessage(args: {
   readonly db: Db;
   readonly queuedMessage: QueuedUserMessage;
+  readonly runId: string;
   readonly threadId: string;
-}): Promise<QueuedUserMessageClaimReservation | null> {
-  const [reservation] = await args.db
+}): Promise<boolean> {
+  const claimed = await args.db
     .insert(chatMessages)
     .values({
       chatThreadId: args.threadId,
       role: "user",
       content: args.queuedMessage.content,
-      runId: null,
+      runId: args.runId,
       attachFiles: args.queuedMessage.attachFiles
         ? [...args.queuedMessage.attachFiles]
         : null,
@@ -1681,79 +1683,7 @@ async function reserveQueuedUserMessageClaim(args: {
     .onConflictDoNothing({ target: chatMessages.revokesMessageId })
     .returning({ id: chatMessages.id });
 
-  return reservation ?? null;
-}
-
-async function releaseQueuedUserMessageClaimReservation(args: {
-  readonly db: Db;
-  readonly reservation: QueuedUserMessageClaimReservation;
-}): Promise<void> {
-  await args.db
-    .delete(chatMessages)
-    .where(
-      and(eq(chatMessages.id, args.reservation.id), isNull(chatMessages.runId)),
-    );
-}
-
-async function finalizeQueuedUserMessageClaim(args: {
-  readonly db: Db;
-  readonly reservation: QueuedUserMessageClaimReservation;
-  readonly queuedMessage: QueuedUserMessage;
-  readonly runId: string;
-}): Promise<boolean> {
-  const finalized = await args.db
-    .update(chatMessages)
-    .set({
-      runId: args.runId,
-    })
-    .where(
-      and(
-        eq(chatMessages.id, args.reservation.id),
-        eq(chatMessages.revokesMessageId, args.queuedMessage.id),
-        isNull(chatMessages.runId),
-      ),
-    )
-    .returning({ id: chatMessages.id });
-
-  return finalized.length > 0;
-}
-
-async function cancelUnclaimedQueuedRun(args: {
-  readonly db: Db;
-  readonly runId: string;
-  readonly threadId: string;
-  readonly queuedMessage: QueuedUserMessage;
-}): Promise<void> {
-  const cancelledAt = nowDate();
-  const cancelled = await args.db
-    .update(agentRuns)
-    .set({
-      status: "cancelled",
-      completedAt: cancelledAt,
-      error: "Queued message claim was not finalized",
-    })
-    .where(
-      and(
-        eq(agentRuns.id, args.runId),
-        inArray(agentRuns.status, ["queued", "pending"]),
-      ),
-    )
-    .returning({ id: agentRuns.id });
-
-  if (cancelled.length === 0) {
-    log.warn("Auto-send run escaped queued-message claim cancellation", {
-      threadId: args.threadId,
-      runId: args.runId,
-      userMessageId: args.queuedMessage.id,
-    });
-    return;
-  }
-
-  log.warn("Auto-send cancelled a run without a finalized message claim", {
-    threadId: args.threadId,
-    runId: args.runId,
-    userMessageId: args.queuedMessage.id,
-  });
+  return claimed.length > 0;
 }
 
 async function autoSendQueuedMessageOnRunComplete(args: {
@@ -1793,74 +1723,31 @@ async function autoSendQueuedMessageOnRunComplete(args: {
     agent,
     queuedMessage,
   });
-  const reservation = await reserveQueuedUserMessageClaim({
-    db: args.db,
-    queuedMessage,
-    threadId,
-  });
-  if (!reservation) {
-    return;
-  }
-
   const activeRunExists = await activeChatRunExistsForThread(args.db, threadId);
   if (activeRunExists) {
-    await releaseQueuedUserMessageClaimReservation({
-      db: args.db,
-      reservation,
-    });
     return;
   }
 
-  const runResult = await settle(args.createRun(runInput));
-  if (!runResult.ok) {
-    await releaseQueuedUserMessageClaimReservation({
-      db: args.db,
-      reservation,
-    });
-    throw runResult.error;
-  }
-  const run = runResult.value;
+  const run = await args.createRun({
+    ...runInput,
+    beforeDispatch: async ({ runId }) => {
+      const claimed = await claimQueuedUserMessage({
+        db: args.db,
+        queuedMessage,
+        runId,
+        threadId,
+      });
+      if (!claimed) {
+        log.warn("Auto-send created a run for an already-claimed message", {
+          threadId,
+          runId,
+          userMessageId: queuedMessage.id,
+        });
+      }
+      return claimed;
+    },
+  });
   if (!run) {
-    await releaseQueuedUserMessageClaimReservation({
-      db: args.db,
-      reservation,
-    });
-    return;
-  }
-
-  const finalizeResult = await settle(
-    finalizeQueuedUserMessageClaim({
-      db: args.db,
-      reservation,
-      queuedMessage,
-      runId: run.runId,
-    }),
-  );
-  if (!finalizeResult.ok) {
-    await releaseQueuedUserMessageClaimReservation({
-      db: args.db,
-      reservation,
-    });
-    await cancelUnclaimedQueuedRun({
-      db: args.db,
-      runId: run.runId,
-      threadId,
-      queuedMessage,
-    });
-    throw finalizeResult.error;
-  }
-  const finalized = finalizeResult.value;
-  if (!finalized) {
-    await releaseQueuedUserMessageClaimReservation({
-      db: args.db,
-      reservation,
-    });
-    await cancelUnclaimedQueuedRun({
-      db: args.db,
-      runId: run.runId,
-      threadId,
-      queuedMessage,
-    });
     return;
   }
 
@@ -2302,7 +2189,11 @@ export const handleChatInternalCallback$ = command(
             buildQueuedCreateZeroRunArgs(runInput, apiStartTime),
             inputSignal,
           );
-          if (runResult.status !== 201 || runResult.body.status === "failed") {
+          if (
+            runResult.status !== 201 ||
+            runResult.body.status === "failed" ||
+            runResult.body.status === "cancelled"
+          ) {
             log.warn("Auto-send failed to create run", {
               threadId: runInput.threadId,
               status: runResult.status,

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -23,6 +23,7 @@ import {
   inArray,
   isNotNull,
   isNull,
+  ne,
   sql,
 } from "drizzle-orm";
 import { z } from "zod";
@@ -1509,17 +1510,21 @@ async function loadAgentForAutoSend(
 async function activeChatRunExistsForThread(
   db: Db,
   threadId: string,
+  options?: { readonly excludeRunId?: string },
 ): Promise<boolean> {
+  const filters = [
+    eq(zeroRuns.chatThreadId, threadId),
+    inArray(agentRuns.status, ["queued", "pending", "running"]),
+  ];
+  if (options?.excludeRunId !== undefined) {
+    filters.push(ne(zeroRuns.id, options.excludeRunId));
+  }
+
   const [run] = await db
     .select({ id: zeroRuns.id })
     .from(zeroRuns)
     .innerJoin(agentRuns, eq(agentRuns.id, zeroRuns.id))
-    .where(
-      and(
-        eq(zeroRuns.chatThreadId, threadId),
-        inArray(agentRuns.status, ["queued", "pending", "running"]),
-      ),
-    )
+    .where(and(...filters))
     .limit(1);
   return run !== undefined;
 }
@@ -1735,6 +1740,15 @@ async function autoSendQueuedMessageOnRunComplete(args: {
   const run = await args.createRun({
     ...runInput,
     beforeDispatch: async ({ runId }) => {
+      const competingRunExists = await activeChatRunExistsForThread(
+        args.db,
+        threadId,
+        { excludeRunId: runId },
+      );
+      if (competingRunExists) {
+        return false;
+      }
+
       const claimed = await claimQueuedUserMessage({
         db: args.db,
         queuedMessage,

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -1712,13 +1712,26 @@ async function buildCreateQueuedChatRunInput(args: {
   };
 }
 
-async function claimQueuedUserMessage(args: {
+async function claimQueuedUserMessageForDispatch(args: {
   readonly db: Db;
   readonly queuedMessage: QueuedUserMessage;
   readonly runId: string;
   readonly threadId: string;
 }): Promise<boolean> {
   const claimed = await args.db.transaction(async (tx) => {
+    // Serialize auto-send dispatch decisions per thread. Otherwise two terminal
+    // callbacks can insert candidate runs, each see the other as active, and
+    // both cancel before either claims the queued message.
+    const threadRows = await tx.execute<{ readonly id: string }>(sql`
+      SELECT ${chatThreads.id} AS "id"
+      FROM ${chatThreads}
+      WHERE ${chatThreads.id} = ${args.threadId}
+      FOR UPDATE
+    `);
+    if (!threadRows.rows[0]) {
+      return [];
+    }
+
     const rows = await tx.execute<{
       readonly status: string;
       readonly chatThreadId: string | null;
@@ -1740,13 +1753,19 @@ async function claimQueuedUserMessage(args: {
       return [];
     }
 
-    const threadRows = await tx.execute<{ readonly id: string }>(sql`
-      SELECT ${chatThreads.id} AS "id"
-      FROM ${chatThreads}
-      WHERE ${chatThreads.id} = ${args.threadId}
-      FOR KEY SHARE
-    `);
-    if (!threadRows.rows[0]) {
+    const [competingRun] = await tx
+      .select({ id: zeroRuns.id })
+      .from(zeroRuns)
+      .innerJoin(agentRuns, eq(agentRuns.id, zeroRuns.id))
+      .where(
+        and(
+          eq(zeroRuns.chatThreadId, args.threadId),
+          ne(zeroRuns.id, args.runId),
+          inArray(agentRuns.status, ["queued", "pending", "running"]),
+        ),
+      )
+      .limit(1);
+    if (competingRun) {
       return [];
     }
 
@@ -1860,16 +1879,7 @@ async function autoSendQueuedMessageOnRunComplete(args: {
   const run = await args.createRun({
     ...runInput,
     beforeDispatch: async ({ runId }) => {
-      const competingRunExists = await activeChatRunExistsForThread(
-        args.db,
-        threadId,
-        { excludeRunId: runId },
-      );
-      if (competingRunExists) {
-        return false;
-      }
-
-      const claimed = await claimQueuedUserMessage({
+      const claimed = await claimQueuedUserMessageForDispatch({
         db: args.db,
         queuedMessage,
         runId,

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -171,6 +171,10 @@ interface QueuedUserMessage {
   readonly selectedModel: string | null;
 }
 
+interface QueuedUserMessageClaimReservation {
+  readonly id: string;
+}
+
 interface AgentForAutoSend {
   readonly id: string;
   readonly orgId: string;
@@ -1497,6 +1501,24 @@ async function loadAgentForAutoSend(
   return agent ?? null;
 }
 
+async function activeChatRunExistsForThread(
+  db: Db,
+  threadId: string,
+): Promise<boolean> {
+  const [run] = await db
+    .select({ id: zeroRuns.id })
+    .from(zeroRuns)
+    .innerJoin(agentRuns, eq(agentRuns.id, zeroRuns.id))
+    .where(
+      and(
+        eq(zeroRuns.chatThreadId, threadId),
+        inArray(agentRuns.status, ["queued", "pending", "running"]),
+      ),
+    )
+    .limit(1);
+  return run !== undefined;
+}
+
 function fallbackAttachFiles(
   ids: readonly string[] | null,
 ): readonly ResolvedAttachFile[] {
@@ -1635,19 +1657,18 @@ async function buildCreateQueuedChatRunInput(args: {
   };
 }
 
-async function claimQueuedUserMessage(args: {
+async function reserveQueuedUserMessageClaim(args: {
   readonly db: Db;
   readonly queuedMessage: QueuedUserMessage;
-  readonly runId: string;
   readonly threadId: string;
-}): Promise<boolean> {
-  const claimed = await args.db
+}): Promise<QueuedUserMessageClaimReservation | null> {
+  const [reservation] = await args.db
     .insert(chatMessages)
     .values({
       chatThreadId: args.threadId,
       role: "user",
       content: args.queuedMessage.content,
-      runId: args.runId,
+      runId: null,
       attachFiles: args.queuedMessage.attachFiles
         ? [...args.queuedMessage.attachFiles]
         : null,
@@ -1660,20 +1681,79 @@ async function claimQueuedUserMessage(args: {
     .onConflictDoNothing({ target: chatMessages.revokesMessageId })
     .returning({ id: chatMessages.id });
 
-  if (claimed.length > 0) {
-    return true;
+  return reservation ?? null;
+}
+
+async function releaseQueuedUserMessageClaimReservation(args: {
+  readonly db: Db;
+  readonly reservation: QueuedUserMessageClaimReservation;
+}): Promise<void> {
+  await args.db
+    .delete(chatMessages)
+    .where(
+      and(eq(chatMessages.id, args.reservation.id), isNull(chatMessages.runId)),
+    );
+}
+
+async function finalizeQueuedUserMessageClaim(args: {
+  readonly db: Db;
+  readonly reservation: QueuedUserMessageClaimReservation;
+  readonly queuedMessage: QueuedUserMessage;
+  readonly runId: string;
+}): Promise<boolean> {
+  const finalized = await args.db
+    .update(chatMessages)
+    .set({
+      runId: args.runId,
+    })
+    .where(
+      and(
+        eq(chatMessages.id, args.reservation.id),
+        eq(chatMessages.revokesMessageId, args.queuedMessage.id),
+        isNull(chatMessages.runId),
+      ),
+    )
+    .returning({ id: chatMessages.id });
+
+  return finalized.length > 0;
+}
+
+async function cancelUnclaimedQueuedRun(args: {
+  readonly db: Db;
+  readonly runId: string;
+  readonly threadId: string;
+  readonly queuedMessage: QueuedUserMessage;
+}): Promise<void> {
+  const cancelledAt = nowDate();
+  const cancelled = await args.db
+    .update(agentRuns)
+    .set({
+      status: "cancelled",
+      completedAt: cancelledAt,
+      error: "Queued message claim was not finalized",
+    })
+    .where(
+      and(
+        eq(agentRuns.id, args.runId),
+        inArray(agentRuns.status, ["queued", "pending"]),
+      ),
+    )
+    .returning({ id: agentRuns.id });
+
+  if (cancelled.length === 0) {
+    log.warn("Auto-send run escaped queued-message claim cancellation", {
+      threadId: args.threadId,
+      runId: args.runId,
+      userMessageId: args.queuedMessage.id,
+    });
+    return;
   }
 
-  await args.db
-    .update(agentRuns)
-    .set({ status: "cancelled", error: "Queued message already claimed" })
-    .where(eq(agentRuns.id, args.runId));
-  log.warn("Auto-send created a run for an already-claimed message", {
+  log.warn("Auto-send cancelled a run without a finalized message claim", {
     threadId: args.threadId,
     runId: args.runId,
     userMessageId: args.queuedMessage.id,
   });
-  return false;
 }
 
 async function autoSendQueuedMessageOnRunComplete(args: {
@@ -1713,18 +1793,74 @@ async function autoSendQueuedMessageOnRunComplete(args: {
     agent,
     queuedMessage,
   });
-  const run = await args.createRun(runInput);
-  if (!run) {
+  const reservation = await reserveQueuedUserMessageClaim({
+    db: args.db,
+    queuedMessage,
+    threadId,
+  });
+  if (!reservation) {
     return;
   }
 
-  const claimed = await claimQueuedUserMessage({
-    db: args.db,
-    queuedMessage,
-    runId: run.runId,
-    threadId,
-  });
-  if (!claimed) {
+  const activeRunExists = await activeChatRunExistsForThread(args.db, threadId);
+  if (activeRunExists) {
+    await releaseQueuedUserMessageClaimReservation({
+      db: args.db,
+      reservation,
+    });
+    return;
+  }
+
+  const runResult = await settle(args.createRun(runInput));
+  if (!runResult.ok) {
+    await releaseQueuedUserMessageClaimReservation({
+      db: args.db,
+      reservation,
+    });
+    throw runResult.error;
+  }
+  const run = runResult.value;
+  if (!run) {
+    await releaseQueuedUserMessageClaimReservation({
+      db: args.db,
+      reservation,
+    });
+    return;
+  }
+
+  const finalizeResult = await settle(
+    finalizeQueuedUserMessageClaim({
+      db: args.db,
+      reservation,
+      queuedMessage,
+      runId: run.runId,
+    }),
+  );
+  if (!finalizeResult.ok) {
+    await releaseQueuedUserMessageClaimReservation({
+      db: args.db,
+      reservation,
+    });
+    await cancelUnclaimedQueuedRun({
+      db: args.db,
+      runId: run.runId,
+      threadId,
+      queuedMessage,
+    });
+    throw finalizeResult.error;
+  }
+  const finalized = finalizeResult.value;
+  if (!finalized) {
+    await releaseQueuedUserMessageClaimReservation({
+      db: args.db,
+      reservation,
+    });
+    await cancelUnclaimedQueuedRun({
+      db: args.db,
+      runId: run.runId,
+      threadId,
+      queuedMessage,
+    });
     return;
   }
 

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -690,6 +690,28 @@ function mergeRecommendedFollowups(
   return merged.length > 0 ? merged : undefined;
 }
 
+async function loadRecommendedFollowupContextForCompletedRun(args: {
+  readonly db: Db;
+  readonly threadId: string;
+  readonly signal: AbortSignal;
+}): Promise<readonly ChatCompletionContextMessage[]> {
+  const result = await settle(
+    loadChatThreadRecommendedFollowupContext({
+      db: args.db,
+      threadId: args.threadId,
+    }),
+    args.signal,
+  );
+  if (!result.ok) {
+    log.warn("Recommended follow-up context load failed", {
+      threadId: args.threadId,
+      err: result.error,
+    });
+    return [];
+  }
+  return result.value;
+}
+
 async function handleCompletedChatCallback(args: {
   readonly db: Db;
   readonly runId: string;
@@ -751,9 +773,10 @@ async function handleCompletedChatCallback(args: {
   });
   args.signal.throwIfAborted();
 
-  const followupContext = await loadChatThreadRecommendedFollowupContext({
+  const followupContext = await loadRecommendedFollowupContextForCompletedRun({
     db: args.db,
     threadId: args.chatThread.chatThreadId,
+    signal: args.signal,
   });
   args.signal.throwIfAborted();
 

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -1681,24 +1681,47 @@ async function claimQueuedUserMessage(args: {
   readonly runId: string;
   readonly threadId: string;
 }): Promise<boolean> {
-  const claimed = await args.db
-    .insert(chatMessages)
-    .values({
-      chatThreadId: args.threadId,
-      role: "user",
-      content: args.queuedMessage.content,
-      runId: args.runId,
-      attachFiles: args.queuedMessage.attachFiles
-        ? [...args.queuedMessage.attachFiles]
-        : null,
-      attachFileMetadata: args.queuedMessage.attachFileMetadata
-        ? [...args.queuedMessage.attachFileMetadata]
-        : null,
-      generationTemplate: args.queuedMessage.generationTemplate,
-      revokesMessageId: args.queuedMessage.id,
-    })
-    .onConflictDoNothing({ target: chatMessages.revokesMessageId })
-    .returning({ id: chatMessages.id });
+  const claimed = await args.db.transaction(async (tx) => {
+    const rows = await tx.execute<{
+      readonly status: string;
+      readonly chatThreadId: string | null;
+    }>(sql`
+      SELECT
+        ${agentRuns.status} AS "status",
+        ${zeroRuns.chatThreadId} AS "chatThreadId"
+      FROM ${agentRuns}
+      INNER JOIN ${zeroRuns} ON ${zeroRuns.id} = ${agentRuns.id}
+      WHERE ${agentRuns.id} = ${args.runId}
+      FOR UPDATE OF ${agentRuns}
+    `);
+    const run = rows.rows[0];
+    if (
+      !run ||
+      run.chatThreadId !== args.threadId ||
+      (run.status !== "queued" && run.status !== "pending")
+    ) {
+      return [];
+    }
+
+    return await tx
+      .insert(chatMessages)
+      .values({
+        chatThreadId: args.threadId,
+        role: "user",
+        content: args.queuedMessage.content,
+        runId: args.runId,
+        attachFiles: args.queuedMessage.attachFiles
+          ? [...args.queuedMessage.attachFiles]
+          : null,
+        attachFileMetadata: args.queuedMessage.attachFileMetadata
+          ? [...args.queuedMessage.attachFileMetadata]
+          : null,
+        generationTemplate: args.queuedMessage.generationTemplate,
+        revokesMessageId: args.queuedMessage.id,
+      })
+      .onConflictDoNothing({ target: chatMessages.revokesMessageId })
+      .returning({ id: chatMessages.id });
+  });
 
   return claimed.length > 0;
 }
@@ -1764,7 +1787,7 @@ async function autoSendQueuedMessageOnRunComplete(args: {
         threadId,
       });
       if (!claimed) {
-        log.warn("Auto-send created a run for an already-claimed message", {
+        log.warn("Auto-send could not claim queued message before dispatch", {
           threadId,
           runId,
           userMessageId: queuedMessage.id,

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -64,7 +64,7 @@ import {
 import { createZeroRun$ } from "./zero-runs-create.service";
 import { loadActiveGoalForThread } from "./zero-goal.service";
 import { loadUserFeatureSwitchContext } from "./feature-switches.service";
-import { onRejection, settle, tapError } from "../utils";
+import { settle, tapError } from "../utils";
 import { resolveThreadGenerationTemplatePrompt } from "../routes/thread-generation-template";
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
@@ -905,20 +905,18 @@ async function runFailedChatCallbackSideEffects(args: {
   });
 }
 
-function scheduleTerminalChatCallbackSideEffects(args: {
+async function runTerminalChatCallbackSideEffects(args: {
   readonly runId: string;
   readonly status: "completed" | "failed";
   readonly run: () => Promise<void>;
-}): void {
-  waitUntil(
-    tapError(args.run(), (error) => {
-      log.warn("Failed to process terminal chat callback side effects", {
-        runId: args.runId,
-        status: args.status,
-        error,
-      });
-    }),
-  );
+}): Promise<void> {
+  await tapError(args.run(), (error) => {
+    log.warn("Failed to process terminal chat callback side effects", {
+      runId: args.runId,
+      status: args.status,
+      error,
+    });
+  });
 }
 
 function buildWebChatPrompt(): string {
@@ -1887,20 +1885,7 @@ async function processTerminalChatCallback(args: {
     };
   }
 
-  let sideEffectsScheduled = false;
-  const scheduleSideEffects = (): void => {
-    if (!deferredSideEffects || sideEffectsScheduled) {
-      return;
-    }
-    sideEffectsScheduled = true;
-    scheduleTerminalChatCallbackSideEffects({
-      runId,
-      status: callbackStatus,
-      run: deferredSideEffects,
-    });
-  };
-
-  await onRejection(
+  const autoSendResult = await settle(
     autoSendQueuedMessageForTerminalCallback({
       db: args.db,
       runId,
@@ -1909,9 +1894,20 @@ async function processTerminalChatCallback(args: {
       dependencies: args.dependencies,
       signal: args.signal,
     }),
-    scheduleSideEffects,
+    args.signal,
   );
-  scheduleSideEffects();
+
+  if (deferredSideEffects) {
+    await runTerminalChatCallbackSideEffects({
+      runId,
+      status: callbackStatus,
+      run: deferredSideEffects,
+    });
+  }
+
+  if (!autoSendResult.ok) {
+    throw autoSendResult.error;
+  }
 }
 
 function handleChatInternalCallback(args: {

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -675,10 +675,11 @@ async function generateWorkflowAutomationSuggestionForCompletedRun(args: {
     return undefined;
   }
 
-  const suggestion = await generateChatThreadWorkflowAutomationSuggestionFromContext({
-    messages: args.followupContext,
-    threadId: args.threadId,
-  });
+  const suggestion =
+    await generateChatThreadWorkflowAutomationSuggestionFromContext({
+      messages: args.followupContext,
+      threadId: args.threadId,
+    });
   args.signal.throwIfAborted();
   return suggestion ?? undefined;
 }
@@ -2147,7 +2148,10 @@ function handleChatInternalCallback(args: {
   // The frontend learns about new messages through Ably realtime signals, not
   // this HTTP response. So acknowledge immediately and run the heavy terminal
   // processing (Axiom watermark wait, message persistence, LLM generation,
-  // push delivery) in the background, mirroring webhooks-agent-complete.
+  // push delivery) in the background, mirroring webhooks-agent-complete. Use a
+  // detached signal so request cancellation cannot interrupt the idempotency
+  // marker -> queued auto-send sequence after the callback is acknowledged.
+  const backgroundSignal = new AbortController().signal;
   waitUntil(
     tapError(
       processTerminalChatCallback({
@@ -2156,7 +2160,7 @@ function handleChatInternalCallback(args: {
         callback: args.callback,
         payload: payload.data,
         dependencies: args.dependencies,
-        signal: args.signal,
+        signal: backgroundSignal,
       }),
       (error) => {
         log.error("Failed to process terminal chat callback", {

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -247,15 +247,26 @@ interface CreateQueuedChatRunInput {
   readonly queuedMessage: QueuedUserMessage;
 }
 
-interface CompletedChatCallbackResult {
-  readonly lastResultText: string | null;
-  readonly followupContext: readonly ChatCompletionContextMessage[];
+type CompletedChatCallbackResult =
+  | {
+      readonly inserted: true;
+      readonly lastResultText: string | null;
+      readonly followupContext: readonly ChatCompletionContextMessage[];
+    }
+  | { readonly inserted: false };
+
+type FailedChatCallbackResult =
+  | { readonly inserted: true; readonly displayErrorMessage: string }
+  | { readonly inserted: false };
+
+interface TerminalChatCallbackWork {
+  readonly shouldAutoSendQueuedMessage: boolean;
+  readonly deferredSideEffects?: () => Promise<void>;
 }
 
-interface FailedChatCallbackResult {
-  readonly displayErrorMessage: string;
-  readonly inserted: boolean;
-}
+type AutoSendOutcome =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly error: unknown };
 
 function generateCallbackSecret(): string {
   return randomBytes(32).toString("hex");
@@ -510,7 +521,7 @@ async function insertAssistantErrorMessage(args: {
     return true;
   });
   if (!inserted) {
-    return { displayErrorMessage, inserted: false };
+    return { inserted: false };
   }
 
   await publishUserSignal(
@@ -764,7 +775,7 @@ async function handleCompletedChatCallback(args: {
     }),
   );
 
-  await insertRunLifecycleMarker({
+  const inserted = await insertRunLifecycleMarker({
     db: args.db,
     runId: args.runId,
     threadId: args.chatThread.chatThreadId,
@@ -773,6 +784,9 @@ async function handleCompletedChatCallback(args: {
     event: "completed",
   });
   args.signal.throwIfAborted();
+  if (!inserted) {
+    return { inserted: false };
+  }
 
   const followupContext = await loadRecommendedFollowupContextForCompletedRun({
     db: args.db,
@@ -781,7 +795,7 @@ async function handleCompletedChatCallback(args: {
   });
   args.signal.throwIfAborted();
 
-  return { lastResultText, followupContext };
+  return { lastResultText, followupContext, inserted: true };
 }
 
 async function runCompletedChatCallbackSideEffects(args: {
@@ -1826,6 +1840,131 @@ async function autoSendQueuedMessageForTerminalCallback(args: {
   });
 }
 
+async function prepareCompletedTerminalChatCallbackWork(args: {
+  readonly db: Db;
+  readonly runId: string;
+  readonly run: ChatRunInfo;
+  readonly chatThread: ChatThreadForRunRow;
+  readonly isGoalRun: boolean;
+  readonly dependencies: ChatCallbackDependencies;
+  readonly signal: AbortSignal;
+}): Promise<TerminalChatCallbackWork> {
+  const completed = await handleCompletedChatCallback({
+    db: args.db,
+    runId: args.runId,
+    run: args.run,
+    chatThread: args.chatThread,
+    signal: args.signal,
+    insertAssistantItems: async (items) => {
+      await args.dependencies.insertAssistantItems(
+        {
+          runId: args.runId,
+          threadId: args.chatThread.chatThreadId,
+          userId: args.chatThread.userId,
+          items,
+        },
+        args.signal,
+      );
+    },
+  });
+  if (!completed.inserted) {
+    return { shouldAutoSendQueuedMessage: false };
+  }
+
+  return {
+    shouldAutoSendQueuedMessage: true,
+    deferredSideEffects: () => {
+      return runCompletedChatCallbackSideEffects({
+        db: args.db,
+        runId: args.runId,
+        run: args.run,
+        chatThread: args.chatThread,
+        isGoalRun: args.isGoalRun,
+        lastResultText: completed.lastResultText,
+        followupContext: completed.followupContext,
+        signal: args.signal,
+        saveRunSummary: (resultText) => {
+          return args.dependencies.saveRunSummary(
+            args.runId,
+            args.run.prompt,
+            resultText,
+            args.signal,
+          );
+        },
+      });
+    },
+  };
+}
+
+async function prepareFailedTerminalChatCallbackWork(args: {
+  readonly db: Db;
+  readonly runId: string;
+  readonly run: ChatRunInfo;
+  readonly chatThread: ChatThreadForRunRow;
+  readonly errorMessage: string;
+  readonly dependencies: ChatCallbackDependencies;
+  readonly signal: AbortSignal;
+}): Promise<TerminalChatCallbackWork> {
+  const failed = await handleFailedChatCallback({
+    db: args.db,
+    runId: args.runId,
+    chatThread: args.chatThread,
+    errorMessage: args.errorMessage,
+    getFormattedError: () => {
+      return args.dependencies.formatRunError(
+        {
+          chatThreadId: args.chatThread.chatThreadId,
+          runId: args.runId,
+          errorMessage: args.errorMessage,
+        },
+        args.signal,
+      );
+    },
+  });
+  if (!failed.inserted) {
+    return { shouldAutoSendQueuedMessage: false };
+  }
+
+  return {
+    shouldAutoSendQueuedMessage: true,
+    deferredSideEffects: () => {
+      return runFailedChatCallbackSideEffects({
+        db: args.db,
+        run: args.run,
+        chatThread: args.chatThread,
+        displayErrorMessage: failed.displayErrorMessage,
+      });
+    },
+  };
+}
+
+async function maybeAutoSendQueuedMessageForTerminalCallback(args: {
+  readonly enabled: boolean;
+  readonly db: Db;
+  readonly runId: string;
+  readonly agentId: string;
+  readonly apiStartTime: number;
+  readonly dependencies: ChatCallbackDependencies;
+  readonly signal: AbortSignal;
+}): Promise<AutoSendOutcome> {
+  if (!args.enabled) {
+    return { ok: true };
+  }
+
+  const result = await settle(
+    autoSendQueuedMessageForTerminalCallback({
+      db: args.db,
+      runId: args.runId,
+      agentId: args.agentId,
+      apiStartTime: args.apiStartTime,
+      dependencies: args.dependencies,
+      signal: args.signal,
+    }),
+    args.signal,
+  );
+  return result.ok ? { ok: true } : { ok: false, error: result.error };
+}
+
 async function processTerminalChatCallback(args: {
   readonly apiStartTime: number;
   readonly db: Db;
@@ -1853,94 +1992,42 @@ async function processTerminalChatCallback(args: {
   const { run, chatThread } = loaded;
   const isGoalRun = args.payload.isGoalRun ?? false;
 
-  let deferredSideEffects: (() => Promise<void>) | undefined;
-
-  if (callbackStatus === "completed") {
-    const completed = await handleCompletedChatCallback({
-      db: args.db,
-      runId,
-      run,
-      chatThread,
-      signal: args.signal,
-      insertAssistantItems: async (items) => {
-        await args.dependencies.insertAssistantItems(
-          {
-            runId,
-            threadId: chatThread.chatThreadId,
-            userId: chatThread.userId,
-            items,
-          },
-          args.signal,
-        );
-      },
-    });
-    deferredSideEffects = () => {
-      return runCompletedChatCallbackSideEffects({
-        db: args.db,
-        runId,
-        run,
-        chatThread,
-        isGoalRun,
-        lastResultText: completed.lastResultText,
-        followupContext: completed.followupContext,
-        signal: args.signal,
-        saveRunSummary: (resultText) => {
-          return args.dependencies.saveRunSummary(
-            runId,
-            run.prompt,
-            resultText,
-            args.signal,
-          );
-        },
-      });
-    };
-  } else {
-    const errorMessage = args.callback.error ?? run.error ?? "Run failed";
-    const failed = await handleFailedChatCallback({
-      db: args.db,
-      runId,
-      chatThread,
-      errorMessage,
-      getFormattedError: () => {
-        return args.dependencies.formatRunError(
-          {
-            chatThreadId: chatThread.chatThreadId,
-            runId,
-            errorMessage,
-          },
-          args.signal,
-        );
-      },
-    });
-    if (failed.inserted) {
-      deferredSideEffects = () => {
-        return runFailedChatCallbackSideEffects({
+  const work =
+    callbackStatus === "completed"
+      ? await prepareCompletedTerminalChatCallbackWork({
           db: args.db,
+          runId,
           run,
           chatThread,
-          displayErrorMessage: failed.displayErrorMessage,
+          isGoalRun,
+          dependencies: args.dependencies,
+          signal: args.signal,
+        })
+      : await prepareFailedTerminalChatCallbackWork({
+          db: args.db,
+          runId,
+          run,
+          chatThread,
+          errorMessage: args.callback.error ?? run.error ?? "Run failed",
+          dependencies: args.dependencies,
+          signal: args.signal,
         });
-      };
-    }
-  }
 
-  const autoSendResult = await settle(
-    autoSendQueuedMessageForTerminalCallback({
-      db: args.db,
-      runId,
-      agentId: args.payload.agentId,
-      apiStartTime: args.apiStartTime,
-      dependencies: args.dependencies,
-      signal: args.signal,
-    }),
-    args.signal,
-  );
+  const autoSendResult = await maybeAutoSendQueuedMessageForTerminalCallback({
+    enabled: work.shouldAutoSendQueuedMessage,
+    db: args.db,
+    runId,
+    agentId: args.payload.agentId,
+    apiStartTime: args.apiStartTime,
+    dependencies: args.dependencies,
+    signal: args.signal,
+  });
 
-  if (deferredSideEffects) {
+  if (work.deferredSideEffects) {
     await runTerminalChatCallbackSideEffects({
       runId,
       status: callbackStatus,
-      run: deferredSideEffects,
+      run: work.deferredSideEffects,
     });
   }
 

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -1703,6 +1703,16 @@ async function claimQueuedUserMessage(args: {
       return [];
     }
 
+    const threadRows = await tx.execute<{ readonly id: string }>(sql`
+      SELECT ${chatThreads.id} AS "id"
+      FROM ${chatThreads}
+      WHERE ${chatThreads.id} = ${args.threadId}
+      FOR KEY SHARE
+    `);
+    if (!threadRows.rows[0]) {
+      return [];
+    }
+
     return await tx
       .insert(chatMessages)
       .values({

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -1552,8 +1552,9 @@ async function activeChatRunExistsForThread(
     eq(zeroRuns.chatThreadId, threadId),
     inArray(agentRuns.status, ["queued", "pending", "running"]),
   ];
-  if (options?.excludeRunId !== undefined) {
-    filters.push(ne(zeroRuns.id, options.excludeRunId));
+  const excludeRunId = options?.excludeRunId;
+  if (excludeRunId !== undefined) {
+    filters.push(ne(zeroRuns.id, excludeRunId));
   }
 
   const [run] = await db

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -1482,8 +1482,6 @@ export function chatThreadForRun(
   });
 }
 
-const ACTIVE_RUN_STATUSES = ["queued", "pending", "running"] as const;
-
 interface ThreadRunToCancel {
   readonly runId: string;
   readonly orgId: string;

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -1482,13 +1482,24 @@ export function chatThreadForRun(
   });
 }
 
+const ACTIVE_RUN_STATUSES = ["queued", "pending", "running"] as const;
+
+interface ThreadRunToCancel {
+  readonly runId: string;
+  readonly orgId: string;
+}
+
 /**
  * Delete a chat thread after winding down everything attached to it. Deleting a
  * thread on its own leaves the linked automations firing and any in-flight runs
  * executing: `zero_runs.chatThreadId` is `ON DELETE SET NULL`, so a running run
- * simply loses its thread reference and keeps consuming credits. We therefore
- * follow the order: stop related automations, cancel related active runs, then
- * delete the thread.
+ * simply loses its thread reference and keeps consuming credits.
+ *
+ * Lock the thread row while deleting it and collecting active runs. Inserts into
+ * `zero_runs.chatThreadId` take a FK lock on the same parent row, so this closes
+ * the race where a new run attaches after the active-run scan but before the
+ * thread delete. Cancellation still happens after the delete transaction because
+ * it has runner notifications and queue-drain side effects.
  *
  * Run cancellation has side effects that cannot participate in the thread's
  * delete transaction (`cancelRun$` opens its own transaction and the runner
@@ -1506,45 +1517,59 @@ export const deleteChatThread$ = command(
   }> => {
     const writeDb = set(writeDb$);
 
-    const [ownedThread] = await writeDb
-      .select({ id: chatThreads.id })
-      .from(chatThreads)
-      .where(
-        and(
-          eq(chatThreads.id, args.threadId),
-          eq(chatThreads.userId, args.userId),
-        ),
-      )
-      .limit(1);
+    const deletion = await writeDb.transaction(async (tx) => {
+      const lockedRows = await tx.execute<{ readonly id: string }>(sql`
+        SELECT ${chatThreads.id} AS "id"
+        FROM ${chatThreads}
+        WHERE ${chatThreads.id} = ${args.threadId}
+          AND ${chatThreads.userId} = ${args.userId}
+        FOR UPDATE
+      `);
+      const ownedThread = lockedRows.rows[0];
+      if (!ownedThread) {
+        return {
+          deleted: false,
+          activeRuns: [] as readonly ThreadRunToCancel[],
+        };
+      }
+
+      // Stop related automations first so none of them can spawn a fresh run
+      // while we are cancelling the in-flight ones (their triggers cascade).
+      await tx
+        .delete(automations)
+        .where(eq(automations.chatThreadId, ownedThread.id));
+
+      // Capture related active runs while the thread row blocks new FK attaches.
+      // Terminal runs (completed/failed/cancelled) are left untouched; only
+      // queued/pending/running runs need stopping.
+      const activeRuns = await tx
+        .select({ runId: agentRuns.id, orgId: agentRuns.orgId })
+        .from(zeroRuns)
+        .innerJoin(agentRuns, eq(agentRuns.id, zeroRuns.id))
+        .where(
+          and(
+            eq(zeroRuns.chatThreadId, ownedThread.id),
+            eq(agentRuns.userId, args.userId),
+            inArray(agentRuns.status, [...ACTIVE_RUN_STATUSES]),
+          ),
+        );
+
+      // Delete the thread last inside the lock. Cascades chat_messages; captured
+      // active runs will have their zero_runs.chatThreadId set to NULL.
+      const [deletedThread] = await tx
+        .delete(chatThreads)
+        .where(eq(chatThreads.id, ownedThread.id))
+        .returning({ id: chatThreads.id });
+
+      return { deleted: Boolean(deletedThread), activeRuns };
+    });
     signal.throwIfAborted();
-    if (!ownedThread) {
+    if (!deletion.deleted) {
       return { deleted: false, cancelledRuns: [] };
     }
 
-    // Stop related automations first so none of them can spawn a fresh run
-    // while we are cancelling the in-flight ones (their triggers cascade).
-    await writeDb
-      .delete(automations)
-      .where(eq(automations.chatThreadId, ownedThread.id));
-    signal.throwIfAborted();
-
-    // Cancel related active runs. Terminal runs (completed/failed/cancelled)
-    // are left untouched; only queued/pending/running runs need stopping.
-    const activeRuns = await writeDb
-      .select({ runId: agentRuns.id, orgId: agentRuns.orgId })
-      .from(zeroRuns)
-      .innerJoin(agentRuns, eq(agentRuns.id, zeroRuns.id))
-      .where(
-        and(
-          eq(zeroRuns.chatThreadId, ownedThread.id),
-          eq(agentRuns.userId, args.userId),
-          inArray(agentRuns.status, [...ACTIVE_RUN_STATUSES]),
-        ),
-      );
-    signal.throwIfAborted();
-
     const cancelledRuns: CancelRunResult[] = [];
-    for (const run of activeRuns) {
+    for (const run of deletion.activeRuns) {
       const result = await set(
         cancelRun$,
         { runId: run.runId, userId: args.userId, orgId: run.orgId },
@@ -1559,15 +1584,7 @@ export const deleteChatThread$ = command(
       }
     }
 
-    // Delete the thread last. Cascades chat_messages; the now-cancelled runs
-    // have their zero_runs.chatThreadId set to NULL.
-    const [deletedThread] = await writeDb
-      .delete(chatThreads)
-      .where(eq(chatThreads.id, ownedThread.id))
-      .returning({ id: chatThreads.id });
-    signal.throwIfAborted();
-
-    return { deleted: Boolean(deletedThread), cancelledRuns };
+    return { deleted: true, cancelledRuns };
   },
 );
 

--- a/turbo/apps/api/src/signals/services/zero-chat-title.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-title.service.ts
@@ -71,8 +71,7 @@ function completedConversationContextMessageCondition() {
       AND ${chatMessages.error} IS NULL
     )
     AND NOT (
-      ${chatMessages.role} = 'user'
-      AND ${chatMessages.runId} IS NOT NULL
+      ${chatMessages.runId} IS NOT NULL
       AND EXISTS (
         SELECT 1
         FROM ${agentRuns}

--- a/turbo/apps/api/src/signals/services/zero-chat-title.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-title.service.ts
@@ -32,7 +32,7 @@ const BUILT_IN_GENERATION_FOLLOWUP_CONTEXT = [
   "- website: create hosted websites or web pages.",
 ].join("\n");
 
-interface TitleContextMessage {
+export interface ChatCompletionContextMessage {
   readonly role: "user" | "assistant";
   readonly content: string;
 }
@@ -40,7 +40,7 @@ interface TitleContextMessage {
 interface ChatTitleInput {
   readonly currentUserMessage: string;
   readonly currentAssistantReply?: string;
-  readonly priorRounds?: readonly TitleContextMessage[];
+  readonly priorRounds?: readonly ChatCompletionContextMessage[];
 }
 
 interface OpenRouterResponse {
@@ -160,7 +160,7 @@ async function getLatestTitleContextMessages(
   db: Db,
   threadId: string,
   options?: { readonly excludeRunId?: string },
-): Promise<TitleContextMessage[]> {
+): Promise<ChatCompletionContextMessage[]> {
   const filters = [
     eq(chatMessages.chatThreadId, threadId),
     isNotNull(chatMessages.content),
@@ -429,7 +429,7 @@ function parseWorkflowAutomationSuggestion(
 async function getLatestFollowupContextMessages(
   db: SelectDb,
   threadId: string,
-): Promise<TitleContextMessage[]> {
+): Promise<ChatCompletionContextMessage[]> {
   const rows = await db
     .select({
       role: chatMessages.role,
@@ -461,7 +461,7 @@ async function getLatestFollowupContextMessages(
 }
 
 async function generateRecommendedFollowups(
-  messages: readonly TitleContextMessage[],
+  messages: readonly ChatCompletionContextMessage[],
 ): Promise<ChatMessageRecommendedFollowups> {
   const last = messages[messages.length - 1];
   if (last?.role !== "assistant" || last.content.trim().length === 0) {
@@ -500,7 +500,7 @@ async function generateRecommendedFollowups(
 }
 
 async function generateWorkflowAutomationSuggestion(
-  messages: readonly TitleContextMessage[],
+  messages: readonly ChatCompletionContextMessage[],
 ): Promise<ChatMessageRecommendedFollowup | null> {
   const last = messages[messages.length - 1];
   if (last?.role !== "assistant" || last.content.trim().length === 0) {
@@ -541,25 +541,39 @@ async function generateWorkflowAutomationSuggestion(
   return text === null ? null : parseWorkflowAutomationSuggestion(text);
 }
 
-export async function generateChatThreadRecommendedFollowups(args: {
+export async function loadChatThreadRecommendedFollowupContext(args: {
   readonly db: SelectDb;
   readonly threadId: string;
+}): Promise<ChatCompletionContextMessage[]> {
+  return await getLatestFollowupContextMessages(args.db, args.threadId);
+}
+
+export async function generateChatThreadRecommendedFollowupsFromContext(args: {
+  readonly messages: readonly ChatCompletionContextMessage[];
+  readonly threadId?: string;
 }): Promise<ChatMessageRecommendedFollowups> {
-  const result = await settle(
-    (async () => {
-      const messages = await getLatestFollowupContextMessages(
-        args.db,
-        args.threadId,
-      );
-      return generateRecommendedFollowups(messages);
-    })(),
-  );
+  const result = await settle(generateRecommendedFollowups(args.messages));
   if (!result.ok) {
     log.warn("Recommended follow-up generation failed", {
-      threadId: args.threadId,
+      ...(args.threadId ? { threadId: args.threadId } : {}),
       err: result.error,
     });
     return [];
+  }
+  return result.value;
+}
+
+export async function generateChatThreadWorkflowAutomationSuggestionFromContext(args: {
+  readonly messages: readonly ChatCompletionContextMessage[];
+  readonly threadId?: string;
+}): Promise<ChatMessageRecommendedFollowup | null> {
+  const result = await settle(generateWorkflowAutomationSuggestion(args.messages));
+  if (!result.ok) {
+    log.warn("Workflow automation suggestion generation failed", {
+      ...(args.threadId ? { threadId: args.threadId } : {}),
+      err: result.error,
+    });
+    return null;
   }
   return result.value;
 }
@@ -574,7 +588,10 @@ export async function generateChatThreadWorkflowAutomationSuggestion(args: {
         args.db,
         args.threadId,
       );
-      return generateWorkflowAutomationSuggestion(messages);
+      return generateChatThreadWorkflowAutomationSuggestionFromContext({
+        messages,
+        threadId: args.threadId,
+      });
     })(),
   );
   if (!result.ok) {

--- a/turbo/apps/api/src/signals/services/zero-chat-title.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-title.service.ts
@@ -62,6 +62,16 @@ export function isChatTitleGenerationConfigured(): boolean {
   return Boolean(optionalEnv("OPENROUTER_API_KEY"));
 }
 
+function nonQueuedContextMessageCondition() {
+  return sql<boolean>`NOT (
+    ${chatMessages.role} = 'user'
+    AND ${chatMessages.runId} IS NULL
+    AND ${chatMessages.revokesMessageId} IS NULL
+    AND ${chatMessages.interruptsRunId} IS NULL
+    AND ${chatMessages.error} IS NULL
+  )`;
+}
+
 function stripMarkdown(text: string): string {
   return text
     .replace(/(\*{1,3}|_{1,3})(.+?)\1/g, "$2")
@@ -166,6 +176,7 @@ async function getLatestTitleContextMessages(
     isNotNull(chatMessages.content),
     inArray(chatMessages.role, ["user", "assistant"]),
     visibleChatMessageCondition(),
+    nonQueuedContextMessageCondition(),
   ];
   if (options?.excludeRunId !== undefined) {
     filters.push(
@@ -444,6 +455,7 @@ async function getLatestFollowupContextMessages(
         isNotNull(chatMessages.content),
         inArray(chatMessages.role, ["user", "assistant"]),
         visibleChatMessageCondition(),
+        nonQueuedContextMessageCondition(),
       ),
     )
     .orderBy(desc(chatMessages.createdAt), desc(chatMessages.sequenceNumber))

--- a/turbo/apps/api/src/signals/services/zero-chat-title.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-title.service.ts
@@ -62,14 +62,24 @@ export function isChatTitleGenerationConfigured(): boolean {
   return Boolean(optionalEnv("OPENROUTER_API_KEY"));
 }
 
-function nonQueuedContextMessageCondition() {
+function completedConversationContextMessageCondition() {
   return sql<boolean>`NOT (
-    ${chatMessages.role} = 'user'
-    AND ${chatMessages.runId} IS NULL
-    AND ${chatMessages.revokesMessageId} IS NULL
-    AND ${chatMessages.interruptsRunId} IS NULL
-    AND ${chatMessages.error} IS NULL
-  )`;
+      ${chatMessages.role} = 'user'
+      AND ${chatMessages.runId} IS NULL
+      AND ${chatMessages.revokesMessageId} IS NULL
+      AND ${chatMessages.interruptsRunId} IS NULL
+      AND ${chatMessages.error} IS NULL
+    )
+    AND NOT (
+      ${chatMessages.role} = 'user'
+      AND ${chatMessages.runId} IS NOT NULL
+      AND EXISTS (
+        SELECT 1
+        FROM ${agentRuns}
+        WHERE ${agentRuns.id} = ${chatMessages.runId}
+          AND ${agentRuns.status} IN ('queued', 'pending', 'running')
+      )
+    )`;
 }
 
 function stripMarkdown(text: string): string {
@@ -176,7 +186,7 @@ async function getLatestTitleContextMessages(
     isNotNull(chatMessages.content),
     inArray(chatMessages.role, ["user", "assistant"]),
     visibleChatMessageCondition(),
-    nonQueuedContextMessageCondition(),
+    completedConversationContextMessageCondition(),
   ];
   if (options?.excludeRunId !== undefined) {
     filters.push(
@@ -455,7 +465,7 @@ async function getLatestFollowupContextMessages(
         isNotNull(chatMessages.content),
         inArray(chatMessages.role, ["user", "assistant"]),
         visibleChatMessageCondition(),
-        nonQueuedContextMessageCondition(),
+        completedConversationContextMessageCondition(),
       ),
     )
     .orderBy(desc(chatMessages.createdAt), desc(chatMessages.sequenceNumber))
@@ -579,36 +589,12 @@ export async function generateChatThreadWorkflowAutomationSuggestionFromContext(
   readonly messages: readonly ChatCompletionContextMessage[];
   readonly threadId?: string;
 }): Promise<ChatMessageRecommendedFollowup | null> {
-  const result = await settle(generateWorkflowAutomationSuggestion(args.messages));
-  if (!result.ok) {
-    log.warn("Workflow automation suggestion generation failed", {
-      ...(args.threadId ? { threadId: args.threadId } : {}),
-      err: result.error,
-    });
-    return null;
-  }
-  return result.value;
-}
-
-export async function generateChatThreadWorkflowAutomationSuggestion(args: {
-  readonly db: SelectDb;
-  readonly threadId: string;
-}): Promise<ChatMessageRecommendedFollowup | null> {
   const result = await settle(
-    (async () => {
-      const messages = await getLatestFollowupContextMessages(
-        args.db,
-        args.threadId,
-      );
-      return generateChatThreadWorkflowAutomationSuggestionFromContext({
-        messages,
-        threadId: args.threadId,
-      });
-    })(),
+    generateWorkflowAutomationSuggestion(args.messages),
   );
   if (!result.ok) {
     log.warn("Workflow automation suggestion generation failed", {
-      threadId: args.threadId,
+      ...(args.threadId ? { threadId: args.threadId } : {}),
       err: result.error,
     });
     return null;

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -25,6 +25,7 @@ import type { AuthContext } from "../../types/auth";
 import { writeDb$, type Db } from "../external/db";
 import {
   createAgentRun$,
+  type BeforeRunDispatch,
   type CreateAgentRunArgs,
   type DispatchFailedRunCallbacks,
 } from "./agent-run-create.service";
@@ -154,6 +155,7 @@ interface CreateZeroRunCommandArgs {
   readonly selectedModelOverride?: string;
   readonly zeroRunMetadata?: ZeroRunMetadata;
   readonly dispatchFailedCallbacks?: DispatchFailedRunCallbacks;
+  readonly beforeDispatch?: BeforeRunDispatch;
   readonly timing?: ApiDispatchTimingCollector;
   readonly zeroPreCreateSource?: ZeroPreCreateSource;
 }
@@ -753,6 +755,7 @@ function buildZeroCreateAgentRunArgs(args: {
       triggerAgentId: args.triggerAgentId,
     },
     dispatchFailedCallbacks: command.dispatchFailedCallbacks,
+    beforeDispatch: command.beforeDispatch,
     timing: args.timing,
     timingDimensions: zeroRunTimingDimensions({
       origin: zeroRunOrigin({

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -45,6 +45,10 @@ type ZeroRunOrigin =
   | "workflow_trigger"
   | "goal_continuation"
   | "zero_integration";
+export type ZeroPreCreateSource =
+  | "chat_callback_auto_send"
+  | "chat_thread_v1_send"
+  | "workflow_slash_command";
 
 const DISALLOWED_TOOLS = [
   "CronCreate",
@@ -151,6 +155,7 @@ interface CreateZeroRunCommandArgs {
   readonly zeroRunMetadata?: ZeroRunMetadata;
   readonly dispatchFailedCallbacks?: DispatchFailedRunCallbacks;
   readonly timing?: ApiDispatchTimingCollector;
+  readonly zeroPreCreateSource?: ZeroPreCreateSource;
 }
 
 interface CreateZeroIntegrationRunCommandArgs {
@@ -428,10 +433,14 @@ function buildZeroRunExtraEnvironment(args: {
   };
 }
 
-function zeroRunTimingDimensions(
-  origin: ZeroRunOrigin,
-): ApiDispatchTimingDimensions {
-  return { zero_run_origin: origin };
+function zeroRunTimingDimensions(args: {
+  readonly origin: ZeroRunOrigin;
+  readonly source?: ZeroPreCreateSource;
+}): ApiDispatchTimingDimensions {
+  return {
+    zero_run_origin: args.origin,
+    ...(args.source ? { zero_pre_create_source: args.source } : {}),
+  };
 }
 
 function zeroRunOrigin(args: {
@@ -745,11 +754,12 @@ function buildZeroCreateAgentRunArgs(args: {
     },
     dispatchFailedCallbacks: command.dispatchFailedCallbacks,
     timing: args.timing,
-    timingDimensions: zeroRunTimingDimensions(
-      zeroRunOrigin({
+    timingDimensions: zeroRunTimingDimensions({
+      origin: zeroRunOrigin({
         command,
       }),
-    ),
+      source: command.zeroPreCreateSource,
+    }),
   };
 }
 
@@ -793,7 +803,7 @@ function buildZeroIntegrationCreateAgentRunArgs(args: {
     validateEnvironmentReferences: false,
     dispatchFailedCallbacks: command.dispatchFailedCallbacks,
     timing: args.timing,
-    timingDimensions: zeroRunTimingDimensions("zero_integration"),
+    timingDimensions: zeroRunTimingDimensions({ origin: "zero_integration" }),
   };
 }
 

--- a/turbo/packages/api-contracts/src/contracts/test-chat-messages-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-chat-messages-state.ts
@@ -35,6 +35,11 @@ export const testChatMessagesStateActionBodySchema = z.discriminatedUnion(
       action: z.literal("delete-openrouter-vm0-api-keys"),
       model: z.string(),
     }),
+    z.object({
+      action: z.literal("attach-pre-dispatch-cancelled-run-to-thread"),
+      run_id: z.uuid(),
+      thread_id: z.uuid(),
+    }),
   ],
 );
 


### PR DESCRIPTION
## Summary
- move completed/failed chat callback summary, title, follow-up, and push work after queued auto-send
- persist the completed lifecycle marker on the critical path, then update that same marker with deferred follow-ups
- add low-cardinality `zero_pre_create_source` timing attribution for chat callback auto-send, v1 chat send, and workflow slash command entry points

## Testing
- `pnpm -F api lint`
- `pnpm -F api exec tsc --noEmit --pretty false`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-callbacks.bdd.test.ts src/signals/routes/__tests__/chat-threads.bdd.test.ts src/signals/routes/__tests__/zero-workflows.test.ts src/signals/routes/__tests__/chat-messages.bdd.test.ts`
- `pnpm knip --cache` currently fails on existing full-repo unused dependency/export baseline outside this PR; the new unused export found during commit was removed

Closes #19376