### PR TITLE
test(sandbox-fc): cover create rollback COW cleanup outcomes

### DIFF
--- a/crates/sandbox-fc/src/factory/create_transaction.rs
+++ b/crates/sandbox-fc/src/factory/create_transaction.rs
@@ -202,6 +202,14 @@ pub(super) enum CreateTransactionCowDevice {
 }
 
 impl CreateTransactionCowDevice {
+    fn requires_async_cleanup(&self) -> bool {
+        match self {
+            Self::Real(_) => true,
+            #[cfg(test)]
+            Self::Test => false,
+        }
+    }
+
     fn validate_real(&self, _context: &str) -> sandbox::Result<()> {
         match self {
             Self::Real(_) => Ok(()),
@@ -473,7 +481,10 @@ impl SandboxCreateTransaction {
         self.workspace.has_resources()
             || self.sock_dir.is_some()
             || self.network.is_some()
-            || self.cow_device.is_some()
+            || self
+                .cow_device
+                .as_ref()
+                .is_some_and(CreateTransactionCowDevice::requires_async_cleanup)
     }
 
     fn take_filesystem_cleanup_on_rollback(
@@ -556,7 +567,11 @@ impl SandboxCreateTransaction {
     }
 
     fn send_async_leaked_resources(&mut self) -> bool {
-        if self.network.is_none() && self.cow_device.is_none() {
+        let has_async_cow_resource = self
+            .cow_device
+            .as_ref()
+            .is_some_and(CreateTransactionCowDevice::requires_async_cleanup);
+        if self.network.is_none() && !has_async_cow_resource {
             return false;
         }
 
@@ -621,7 +636,11 @@ impl Drop for SandboxCreateTransaction {
             let _ = std::fs::remove_dir_all(sock_dir);
         }
         self.cleanup_workspace_on_drop();
-        if self.cow_device.is_some() {
+        if self
+            .cow_device
+            .as_ref()
+            .is_some_and(CreateTransactionCowDevice::requires_async_cleanup)
+        {
             warn!(
                 id = %self.id,
                 "COW device acquired during create requires async rollback and may need runner gc"

--- a/crates/sandbox-fc/src/factory/create_transaction.rs
+++ b/crates/sandbox-fc/src/factory/create_transaction.rs
@@ -44,7 +44,8 @@ use crate::paths::{SandboxPaths, SockPaths};
 
 #[async_trait]
 pub(super) trait CreateRollbackCleanup {
-    async fn destroy_cow_device(&self, cow_device: PooledNbdCowDevice) -> CowCleanupOutcome;
+    async fn destroy_cow_device(&self, cow_device: CreateTransactionCowDevice)
+    -> CowCleanupOutcome;
     async fn release_network(&self, network: &mut Option<NetnsLease>);
     fn start_filesystem_cleanup(
         &self,
@@ -141,8 +142,19 @@ pub(super) struct FactoryCreateRollbackCleanup {
 
 #[async_trait]
 impl CreateRollbackCleanup for FactoryCreateRollbackCleanup {
-    async fn destroy_cow_device(&self, cow_device: PooledNbdCowDevice) -> CowCleanupOutcome {
-        destroy_cow_device_with_retries(&self.id, cow_device).await
+    async fn destroy_cow_device(
+        &self,
+        cow_device: CreateTransactionCowDevice,
+    ) -> CowCleanupOutcome {
+        match cow_device {
+            CreateTransactionCowDevice::Real(cow_device) => {
+                destroy_cow_device_with_retries(&self.id, cow_device).await
+            }
+            #[cfg(test)]
+            CreateTransactionCowDevice::Test => {
+                panic!("factory cleanup should not receive a test COW device")
+            }
+        }
     }
 
     async fn release_network(&self, network: &mut Option<NetnsLease>) {
@@ -181,6 +193,32 @@ pub(super) struct SandboxCreateResources {
     pub(super) sock_paths: SockPaths,
     pub(super) network: NetnsLease,
     pub(super) cow_device: PooledNbdCowDevice,
+}
+
+pub(super) enum CreateTransactionCowDevice {
+    Real(PooledNbdCowDevice),
+    #[cfg(test)]
+    Test,
+}
+
+impl CreateTransactionCowDevice {
+    fn into_real(self, _context: &str) -> sandbox::Result<PooledNbdCowDevice> {
+        match self {
+            Self::Real(cow_device) => Ok(cow_device),
+            #[cfg(test)]
+            Self::Test => Err(create_transaction_invalid_state(&format!(
+                "test COW device cannot be used at {_context}"
+            ))),
+        }
+    }
+
+    fn into_leaked_real(self) -> Option<PooledNbdCowDevice> {
+        match self {
+            Self::Real(cow_device) => Some(cow_device),
+            #[cfg(test)]
+            Self::Test => None,
+        }
+    }
 }
 
 #[derive(Default)]
@@ -222,7 +260,7 @@ pub(super) struct SandboxCreateTransaction {
     workspace: WorkspaceOwnership,
     sock_dir: Option<PathBuf>,
     network: Option<NetnsLease>,
-    cow_device: Option<PooledNbdCowDevice>,
+    cow_device: Option<CreateTransactionCowDevice>,
     leak_tx: Option<tokio::sync::mpsc::UnboundedSender<LeakedResources>>,
     delete_workspace_on_leak_cleanup: bool,
 }
@@ -325,7 +363,7 @@ impl SandboxCreateTransaction {
     }
 
     pub(super) fn track_cow_device(&mut self, cow_device: PooledNbdCowDevice) {
-        self.cow_device = Some(cow_device);
+        self.cow_device = Some(CreateTransactionCowDevice::Real(cow_device));
     }
 
     pub(super) fn commit(&mut self) -> sandbox::Result<SandboxCreateResources> {
@@ -340,7 +378,8 @@ impl SandboxCreateTransaction {
         let cow_device = self
             .cow_device
             .take()
-            .ok_or_else(|| create_transaction_invalid_state("missing COW device at commit"))?;
+            .ok_or_else(|| create_transaction_invalid_state("missing COW device at commit"))?
+            .into_real("commit")?;
 
         Ok(SandboxCreateResources {
             sandbox_paths: SandboxPaths::new(workspace),
@@ -525,7 +564,10 @@ impl SandboxCreateTransaction {
 
         let leaked = LeakedResources {
             sandbox_id: self.id.clone(),
-            cow_device: self.cow_device.take(),
+            cow_device: self
+                .cow_device
+                .take()
+                .and_then(CreateTransactionCowDevice::into_leaked_real),
             network: self.network.take(),
             sock_dir,
             workspace,
@@ -535,7 +577,10 @@ impl SandboxCreateTransaction {
         match leak_tx.send(leaked) {
             Ok(()) => true,
             Err(tokio::sync::mpsc::error::SendError(mut leaked)) => {
-                self.cow_device = leaked.cow_device.take();
+                self.cow_device = leaked
+                    .cow_device
+                    .take()
+                    .map(CreateTransactionCowDevice::Real);
                 self.network = leaked.network.take();
                 self.sock_dir = Some(leaked.sock_dir);
                 self.workspace = WorkspaceOwnership::Workspace(leaked.workspace);

--- a/crates/sandbox-fc/src/factory/create_transaction.rs
+++ b/crates/sandbox-fc/src/factory/create_transaction.rs
@@ -202,6 +202,16 @@ pub(super) enum CreateTransactionCowDevice {
 }
 
 impl CreateTransactionCowDevice {
+    fn validate_real(&self, _context: &str) -> sandbox::Result<()> {
+        match self {
+            Self::Real(_) => Ok(()),
+            #[cfg(test)]
+            Self::Test => Err(create_transaction_invalid_state(&format!(
+                "test COW device cannot be used at {_context}"
+            ))),
+        }
+    }
+
     fn into_real(self, _context: &str) -> sandbox::Result<PooledNbdCowDevice> {
         match self {
             Self::Real(cow_device) => Ok(cow_device),
@@ -368,11 +378,10 @@ impl SandboxCreateTransaction {
 
     pub(super) fn commit(&mut self) -> sandbox::Result<SandboxCreateResources> {
         self.validate_base_resources("commit")?;
-        if self.cow_device.is_none() {
-            return Err(create_transaction_invalid_state(
-                "missing COW device at commit",
-            ));
-        }
+        self.cow_device
+            .as_ref()
+            .ok_or_else(|| create_transaction_invalid_state("missing COW device at commit"))?
+            .validate_real("commit")?;
 
         let (workspace, sock_dir, network) = self.take_base_resources_after_validation()?;
         let cow_device = self

--- a/crates/sandbox-fc/src/factory/create_transaction/tests.rs
+++ b/crates/sandbox-fc/src/factory/create_transaction/tests.rs
@@ -304,6 +304,43 @@ impl BlockingCowCleanup {
     }
 }
 
+#[derive(Clone)]
+struct BlockingNetworkAfterCowCleanup {
+    events: CleanupEvents,
+    cow_outcome: CowCleanupOutcome,
+    entered: Arc<AtomicBool>,
+    entered_notify: Arc<tokio::sync::Notify>,
+}
+
+impl BlockingNetworkAfterCowCleanup {
+    fn new(cow_outcome: CowCleanupOutcome) -> Self {
+        Self {
+            events: CleanupEvents::default(),
+            cow_outcome,
+            entered: Arc::new(AtomicBool::new(false)),
+            entered_notify: Arc::new(tokio::sync::Notify::new()),
+        }
+    }
+
+    fn events(&self) -> Vec<String> {
+        self.events.events()
+    }
+
+    fn record(&self, event: String) {
+        self.events.record(event);
+    }
+
+    async fn wait_entered(&self) {
+        loop {
+            let notified = self.entered_notify.notified();
+            if self.entered.load(Ordering::SeqCst) {
+                return;
+            }
+            notified.await;
+        }
+    }
+}
+
 fn assert_test_cow_device(cow_device: CreateTransactionCowDevice) {
     match cow_device {
         CreateTransactionCowDevice::Test => {}
@@ -486,6 +523,37 @@ impl CreateRollbackCleanup for BlockingCowCleanup {
         _cleanup: CreateRollbackFilesystemCleanup,
     ) -> CreateRollbackFilesystemCleanupWaiter {
         panic!("blocked COW cleanup should prevent filesystem cleanup");
+    }
+}
+
+#[async_trait]
+impl CreateRollbackCleanup for BlockingNetworkAfterCowCleanup {
+    async fn destroy_cow_device(
+        &self,
+        cow_device: CreateTransactionCowDevice,
+    ) -> CowCleanupOutcome {
+        assert_test_cow_device(cow_device);
+        self.record("destroy_cow_device".into());
+        self.cow_outcome
+    }
+
+    async fn release_network(&self, network: &mut Option<NetnsLease>) {
+        let network_name = network
+            .as_ref()
+            .expect("test network lease")
+            .name()
+            .to_owned();
+        self.record(format!("release_network:{network_name}"));
+        self.entered.store(true, Ordering::SeqCst);
+        self.entered_notify.notify_waiters();
+        std::future::pending::<()>().await;
+    }
+
+    fn start_filesystem_cleanup(
+        &self,
+        _cleanup: CreateRollbackFilesystemCleanup,
+    ) -> CreateRollbackFilesystemCleanupWaiter {
+        panic!("blocked network release should prevent filesystem cleanup");
     }
 }
 
@@ -916,6 +984,47 @@ async fn create_transaction_rollback_cancellation_during_cow_cleanup_preserves_w
     assert_eq!(leaked.sock_dir, fixture.sock_dir);
     assert_eq!(leaked.workspace, fixture.workspace);
     assert_eq!(cleanup.events(), vec!["destroy_cow_device"]);
+}
+
+#[tokio::test]
+async fn create_rollback_cancel_after_safe_cow_marks_leak_workspace_deletable() {
+    let fixture = WorkspaceSockFixture::new().await;
+
+    let (leak_tx, mut leak_rx) = tokio::sync::mpsc::unbounded_channel();
+    let mut tx = SandboxCreateTransaction::new_with_leak_tx("sandbox".into(), Some(leak_tx));
+    fixture.track_on(&mut tx);
+    tx.track_network(test_network());
+    tx.track_test_cow_device_for_test();
+
+    let cleanup = BlockingNetworkAfterCowCleanup::new(CowCleanupOutcome::BackingFilesSafeToDelete);
+    let rollback_cleanup = cleanup.clone();
+    let rollback = tokio::spawn(async move {
+        let mut tx = tx;
+        tx.rollback(&rollback_cleanup).await;
+    });
+
+    tokio::time::timeout(std::time::Duration::from_secs(1), cleanup.wait_entered())
+        .await
+        .unwrap();
+
+    rollback.abort();
+    assert!(rollback.await.unwrap_err().is_cancelled());
+
+    let mut leaked = tokio::time::timeout(std::time::Duration::from_secs(1), leak_rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(leaked.cow_device.is_none());
+    assert!(leaked.delete_workspace);
+    let network = leaked.network.take().unwrap();
+    assert_eq!(network.name(), "test-ns");
+    let _ = network.into_info_for_test();
+    assert_eq!(leaked.sock_dir, fixture.sock_dir);
+    assert_eq!(leaked.workspace, fixture.workspace);
+    assert_eq!(
+        cleanup.events(),
+        vec!["destroy_cow_device", "release_network:test-ns"]
+    );
 }
 
 #[tokio::test]

--- a/crates/sandbox-fc/src/factory/create_transaction/tests.rs
+++ b/crates/sandbox-fc/src/factory/create_transaction/tests.rs
@@ -1218,6 +1218,25 @@ async fn create_transaction_drop_without_async_resources_removes_dirs() {
 }
 
 #[tokio::test]
+async fn create_transaction_drop_with_test_cow_only_does_not_send_empty_leak_work() {
+    let fixture = WorkspaceSockFixture::new().await;
+    let (leak_tx, mut leak_rx) = tokio::sync::mpsc::unbounded_channel();
+
+    let mut tx = SandboxCreateTransaction::new_with_leak_tx("sandbox".into(), Some(leak_tx));
+    fixture.track_on(&mut tx);
+    tx.track_test_cow_device_for_test();
+
+    drop(tx);
+
+    assert!(matches!(
+        leak_rx.try_recv(),
+        Err(tokio::sync::mpsc::error::TryRecvError::Disconnected)
+    ));
+    assert!(!fixture.workspace.exists());
+    assert!(!fixture.sock_dir.exists());
+}
+
+#[tokio::test]
 async fn create_transaction_drop_with_closed_leak_channel_falls_back_to_sync_dirs() {
     let fixture = WorkspaceSockFixture::new().await;
     let (leak_tx, leak_rx) = tokio::sync::mpsc::unbounded_channel();

--- a/crates/sandbox-fc/src/factory/create_transaction/tests.rs
+++ b/crates/sandbox-fc/src/factory/create_transaction/tests.rs
@@ -1028,6 +1028,48 @@ async fn create_rollback_cancel_after_safe_cow_marks_leak_workspace_deletable() 
 }
 
 #[tokio::test]
+async fn create_rollback_cancel_after_unsafe_cow_marks_leak_workspace_preserved() {
+    let fixture = WorkspaceSockFixture::new().await;
+
+    let (leak_tx, mut leak_rx) = tokio::sync::mpsc::unbounded_channel();
+    let mut tx = SandboxCreateTransaction::new_with_leak_tx("sandbox".into(), Some(leak_tx));
+    fixture.track_on(&mut tx);
+    tx.track_network(test_network());
+    tx.track_test_cow_device_for_test();
+
+    let cleanup =
+        BlockingNetworkAfterCowCleanup::new(CowCleanupOutcome::DeviceMayStillReferenceBackingFiles);
+    let rollback_cleanup = cleanup.clone();
+    let rollback = tokio::spawn(async move {
+        let mut tx = tx;
+        tx.rollback(&rollback_cleanup).await;
+    });
+
+    tokio::time::timeout(std::time::Duration::from_secs(1), cleanup.wait_entered())
+        .await
+        .unwrap();
+
+    rollback.abort();
+    assert!(rollback.await.unwrap_err().is_cancelled());
+
+    let mut leaked = tokio::time::timeout(std::time::Duration::from_secs(1), leak_rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(leaked.cow_device.is_none());
+    assert!(!leaked.delete_workspace);
+    let network = leaked.network.take().unwrap();
+    assert_eq!(network.name(), "test-ns");
+    let _ = network.into_info_for_test();
+    assert_eq!(leaked.sock_dir, fixture.sock_dir);
+    assert_eq!(leaked.workspace, fixture.workspace);
+    assert_eq!(
+        cleanup.events(),
+        vec!["destroy_cow_device", "release_network:test-ns"]
+    );
+}
+
+#[tokio::test]
 async fn create_transaction_rollback_keeps_dirs_when_network_release_fails() {
     let fixture = WorkspaceSockFixture::new().await;
 

--- a/crates/sandbox-fc/src/factory/create_transaction/tests.rs
+++ b/crates/sandbox-fc/src/factory/create_transaction/tests.rs
@@ -28,6 +28,11 @@ impl SandboxCreateTransaction {
         Ok(())
     }
 
+    fn track_test_cow_device_for_test(&mut self) {
+        assert!(self.cow_device.is_none(), "test COW device already tracked");
+        self.cow_device = Some(CreateTransactionCowDevice::Test);
+    }
+
     fn commit_without_cow_for_test(&mut self) -> sandbox::Result<SandboxCreateResourcesWithoutCow> {
         self.validate_base_resources("test commit")?;
         let (workspace, sock_dir, network) = self.take_base_resources_after_validation()?;
@@ -156,6 +161,38 @@ impl FailingNetworkReleaseCleanup {
     }
 }
 
+struct CowOutcomeCreateRollbackCleanup {
+    events: CleanupEvents,
+    cow_outcome: CowCleanupOutcome,
+    release_network: bool,
+}
+
+impl CowOutcomeCreateRollbackCleanup {
+    fn releasing_network(cow_outcome: CowCleanupOutcome) -> Self {
+        Self {
+            events: CleanupEvents::default(),
+            cow_outcome,
+            release_network: true,
+        }
+    }
+
+    fn failing_network(cow_outcome: CowCleanupOutcome) -> Self {
+        Self {
+            events: CleanupEvents::default(),
+            cow_outcome,
+            release_network: false,
+        }
+    }
+
+    fn events(&self) -> Vec<String> {
+        self.events.events()
+    }
+
+    fn record(&self, event: String) {
+        self.events.record(event);
+    }
+}
+
 #[derive(Clone, Default)]
 struct BlockingRemoveDirCleanup {
     events: CleanupEvents,
@@ -240,9 +277,48 @@ impl BlockingRemoveDirCleanup {
     }
 }
 
+#[derive(Clone, Default)]
+struct BlockingCowCleanup {
+    events: CleanupEvents,
+    entered: Arc<AtomicBool>,
+    entered_notify: Arc<tokio::sync::Notify>,
+}
+
+impl BlockingCowCleanup {
+    fn events(&self) -> Vec<String> {
+        self.events.events()
+    }
+
+    fn record(&self, event: String) {
+        self.events.record(event);
+    }
+
+    async fn wait_entered(&self) {
+        loop {
+            let notified = self.entered_notify.notified();
+            if self.entered.load(Ordering::SeqCst) {
+                return;
+            }
+            notified.await;
+        }
+    }
+}
+
+fn assert_test_cow_device(cow_device: CreateTransactionCowDevice) {
+    match cow_device {
+        CreateTransactionCowDevice::Test => {}
+        CreateTransactionCowDevice::Real(_) => {
+            panic!("test cleanup should not receive a real COW device")
+        }
+    }
+}
+
 #[async_trait]
 impl CreateRollbackCleanup for BlockingRemoveDirCleanup {
-    async fn destroy_cow_device(&self, _cow_device: PooledNbdCowDevice) -> CowCleanupOutcome {
+    async fn destroy_cow_device(
+        &self,
+        _cow_device: CreateTransactionCowDevice,
+    ) -> CowCleanupOutcome {
         panic!("test cleanup should not receive a real COW device");
     }
 
@@ -279,7 +355,10 @@ impl CreateRollbackCleanup for BlockingRemoveDirCleanup {
 
 #[async_trait]
 impl CreateRollbackCleanup for FailingNetworkReleaseCleanup {
-    async fn destroy_cow_device(&self, _cow_device: PooledNbdCowDevice) -> CowCleanupOutcome {
+    async fn destroy_cow_device(
+        &self,
+        _cow_device: CreateTransactionCowDevice,
+    ) -> CowCleanupOutcome {
         panic!("test cleanup should not receive a real COW device");
     }
 
@@ -300,7 +379,10 @@ impl CreateRollbackCleanup for FailingNetworkReleaseCleanup {
 
 #[async_trait]
 impl CreateRollbackCleanup for RecordingCreateRollbackCleanup {
-    async fn destroy_cow_device(&self, _cow_device: PooledNbdCowDevice) -> CowCleanupOutcome {
+    async fn destroy_cow_device(
+        &self,
+        _cow_device: CreateTransactionCowDevice,
+    ) -> CowCleanupOutcome {
         panic!("test cleanup should not receive a real COW device");
     }
 
@@ -331,6 +413,79 @@ impl CreateRollbackCleanup for RecordingCreateRollbackCleanup {
             }
         }
         CreateRollbackFilesystemCleanupWaiter::ready()
+    }
+}
+
+#[async_trait]
+impl CreateRollbackCleanup for CowOutcomeCreateRollbackCleanup {
+    async fn destroy_cow_device(
+        &self,
+        cow_device: CreateTransactionCowDevice,
+    ) -> CowCleanupOutcome {
+        assert_test_cow_device(cow_device);
+        self.record("destroy_cow_device".into());
+        self.cow_outcome
+    }
+
+    async fn release_network(&self, network: &mut Option<NetnsLease>) {
+        let network_name = network
+            .as_ref()
+            .expect("test network lease")
+            .name()
+            .to_owned();
+        self.record(format!("release_network:{network_name}"));
+        if self.release_network {
+            let network = network.take().expect("test network lease");
+            let _ = network.into_info_for_test();
+        }
+    }
+
+    fn start_filesystem_cleanup(
+        &self,
+        cleanup: CreateRollbackFilesystemCleanup,
+    ) -> CreateRollbackFilesystemCleanupWaiter {
+        for step in cleanup.steps {
+            match step {
+                CreateRollbackFilesystemCleanupStep::RemoveDir { kind, path } => {
+                    let name = path
+                        .file_name()
+                        .and_then(|name| name.to_str())
+                        .unwrap_or("<unknown>");
+                    self.record(format!("remove_dir:{kind}:{name}"));
+                    remove_create_rollback_dir_sync("sandbox", kind, path);
+                }
+                CreateRollbackFilesystemCleanupStep::DestroySlot(slot) => {
+                    self.record(format!("destroy_slot:{}", slot.id()));
+                    crate::cow_pool::destroy_slot_sync(slot);
+                }
+            }
+        }
+        CreateRollbackFilesystemCleanupWaiter::ready()
+    }
+}
+
+#[async_trait]
+impl CreateRollbackCleanup for BlockingCowCleanup {
+    async fn destroy_cow_device(
+        &self,
+        cow_device: CreateTransactionCowDevice,
+    ) -> CowCleanupOutcome {
+        assert_test_cow_device(cow_device);
+        self.record("destroy_cow_device".into());
+        self.entered.store(true, Ordering::SeqCst);
+        self.entered_notify.notify_waiters();
+        std::future::pending::<CowCleanupOutcome>().await
+    }
+
+    async fn release_network(&self, _network: &mut Option<NetnsLease>) {
+        panic!("blocked COW cleanup should prevent network release");
+    }
+
+    fn start_filesystem_cleanup(
+        &self,
+        _cleanup: CreateRollbackFilesystemCleanup,
+    ) -> CreateRollbackFilesystemCleanupWaiter {
+        panic!("blocked COW cleanup should prevent filesystem cleanup");
     }
 }
 
@@ -602,6 +757,132 @@ async fn create_transaction_rollback_releases_network_before_dirs() {
             "remove_dir:workspace:workspace"
         ]
     );
+}
+
+#[tokio::test]
+async fn create_transaction_rollback_safe_cow_cleanup_removes_workspace() {
+    let fixture = WorkspaceSockFixture::new().await;
+
+    let mut tx = SandboxCreateTransaction::new("sandbox".into());
+    fixture.track_on(&mut tx);
+    tx.track_network(test_network());
+    tx.track_test_cow_device_for_test();
+    let cleanup = CowOutcomeCreateRollbackCleanup::releasing_network(
+        CowCleanupOutcome::BackingFilesSafeToDelete,
+    );
+
+    tx.rollback(&cleanup).await;
+
+    assert!(!fixture.workspace.exists());
+    assert!(!fixture.sock_dir.exists());
+    assert_eq!(
+        cleanup.events(),
+        vec![
+            "destroy_cow_device",
+            "release_network:test-ns",
+            "remove_dir:sock:sock",
+            "remove_dir:workspace:workspace"
+        ]
+    );
+}
+
+#[tokio::test]
+async fn create_transaction_rollback_unsafe_cow_cleanup_preserves_workspace() {
+    let fixture = WorkspaceSockFixture::new().await;
+
+    let mut tx = SandboxCreateTransaction::new("sandbox".into());
+    fixture.track_on(&mut tx);
+    tx.track_network(test_network());
+    tx.track_test_cow_device_for_test();
+    let cleanup = CowOutcomeCreateRollbackCleanup::releasing_network(
+        CowCleanupOutcome::DeviceMayStillReferenceBackingFiles,
+    );
+
+    tx.rollback(&cleanup).await;
+
+    assert!(fixture.workspace.exists());
+    assert!(!fixture.sock_dir.exists());
+    assert_eq!(
+        cleanup.events(),
+        vec![
+            "destroy_cow_device",
+            "release_network:test-ns",
+            "remove_dir:sock:sock"
+        ]
+    );
+}
+
+#[tokio::test]
+async fn create_transaction_rollback_unsafe_cow_cleanup_marks_leaked_workspace_preserved() {
+    let fixture = WorkspaceSockFixture::new().await;
+
+    let (leak_tx, mut leak_rx) = tokio::sync::mpsc::unbounded_channel();
+    let mut tx = SandboxCreateTransaction::new_with_leak_tx("sandbox".into(), Some(leak_tx));
+    fixture.track_on(&mut tx);
+    tx.track_network(test_network());
+    tx.track_test_cow_device_for_test();
+    let cleanup = CowOutcomeCreateRollbackCleanup::failing_network(
+        CowCleanupOutcome::DeviceMayStillReferenceBackingFiles,
+    );
+
+    tx.rollback(&cleanup).await;
+
+    assert!(fixture.workspace.exists());
+    assert!(fixture.sock_dir.exists());
+    assert_eq!(
+        cleanup.events(),
+        vec!["destroy_cow_device", "release_network:test-ns"]
+    );
+
+    drop(tx);
+    let mut leaked = leak_rx.recv().await.unwrap();
+    assert!(leaked.cow_device.is_none());
+    assert!(!leaked.delete_workspace);
+    let network = leaked.network.take().unwrap();
+    assert_eq!(network.name(), "test-ns");
+    let _ = network.into_info_for_test();
+    assert_eq!(leaked.sock_dir, fixture.sock_dir);
+    assert_eq!(leaked.workspace, fixture.workspace);
+}
+
+#[tokio::test]
+async fn create_transaction_rollback_cancellation_during_cow_cleanup_preserves_workspace() {
+    let fixture = WorkspaceSockFixture::new().await;
+
+    let (leak_tx, mut leak_rx) = tokio::sync::mpsc::unbounded_channel();
+    let mut tx = SandboxCreateTransaction::new_with_leak_tx("sandbox".into(), Some(leak_tx));
+    fixture.track_on(&mut tx);
+    tx.track_network(test_network());
+    tx.track_test_cow_device_for_test();
+
+    let cleanup = BlockingCowCleanup::default();
+    let rollback_cleanup = cleanup.clone();
+    let rollback = tokio::spawn(async move {
+        let mut tx = tx;
+        tx.rollback(&rollback_cleanup).await;
+    });
+
+    tokio::time::timeout(std::time::Duration::from_secs(1), cleanup.wait_entered())
+        .await
+        .unwrap();
+    assert!(fixture.workspace.exists());
+    assert!(fixture.sock_dir.exists());
+
+    rollback.abort();
+    assert!(rollback.await.unwrap_err().is_cancelled());
+
+    let mut leaked = tokio::time::timeout(std::time::Duration::from_secs(1), leak_rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(leaked.cow_device.is_none());
+    assert!(!leaked.delete_workspace);
+    let network = leaked.network.take().unwrap();
+    assert_eq!(network.name(), "test-ns");
+    let _ = network.into_info_for_test();
+    assert_eq!(leaked.sock_dir, fixture.sock_dir);
+    assert_eq!(leaked.workspace, fixture.workspace);
+    assert_eq!(cleanup.events(), vec!["destroy_cow_device"]);
 }
 
 #[tokio::test]

--- a/crates/sandbox-fc/src/factory/create_transaction/tests.rs
+++ b/crates/sandbox-fc/src/factory/create_transaction/tests.rs
@@ -846,6 +846,39 @@ async fn create_transaction_rollback_unsafe_cow_cleanup_marks_leaked_workspace_p
 }
 
 #[tokio::test]
+async fn create_transaction_rollback_safe_cow_cleanup_marks_leaked_workspace_deletable() {
+    let fixture = WorkspaceSockFixture::new().await;
+
+    let (leak_tx, mut leak_rx) = tokio::sync::mpsc::unbounded_channel();
+    let mut tx = SandboxCreateTransaction::new_with_leak_tx("sandbox".into(), Some(leak_tx));
+    fixture.track_on(&mut tx);
+    tx.track_network(test_network());
+    tx.track_test_cow_device_for_test();
+    let cleanup = CowOutcomeCreateRollbackCleanup::failing_network(
+        CowCleanupOutcome::BackingFilesSafeToDelete,
+    );
+
+    tx.rollback(&cleanup).await;
+
+    assert!(fixture.workspace.exists());
+    assert!(fixture.sock_dir.exists());
+    assert_eq!(
+        cleanup.events(),
+        vec!["destroy_cow_device", "release_network:test-ns"]
+    );
+
+    drop(tx);
+    let mut leaked = leak_rx.recv().await.unwrap();
+    assert!(leaked.cow_device.is_none());
+    assert!(leaked.delete_workspace);
+    let network = leaked.network.take().unwrap();
+    assert_eq!(network.name(), "test-ns");
+    let _ = network.into_info_for_test();
+    assert_eq!(leaked.sock_dir, fixture.sock_dir);
+    assert_eq!(leaked.workspace, fixture.workspace);
+}
+
+#[tokio::test]
 async fn create_transaction_rollback_cancellation_during_cow_cleanup_preserves_workspace() {
     let fixture = WorkspaceSockFixture::new().await;
 

--- a/crates/sandbox-fc/src/factory/create_transaction/tests.rs
+++ b/crates/sandbox-fc/src/factory/create_transaction/tests.rs
@@ -1076,6 +1076,29 @@ async fn create_transaction_commit_disarms_rollback() {
 }
 
 #[tokio::test]
+async fn create_transaction_commit_rejects_test_cow_without_losing_base_resources() {
+    let fixture = WorkspaceSockFixture::new().await;
+    let (leak_tx, mut leak_rx) = tokio::sync::mpsc::unbounded_channel();
+
+    let mut tx = SandboxCreateTransaction::new_with_leak_tx("sandbox".into(), Some(leak_tx));
+    fixture.track_on(&mut tx);
+    tx.track_network(test_network());
+    tx.track_test_cow_device_for_test();
+
+    assert!(tx.commit().is_err());
+
+    drop(tx);
+    let mut leaked = leak_rx.recv().await.unwrap();
+    assert!(leaked.cow_device.is_none());
+    assert!(leaked.delete_workspace);
+    let network = leaked.network.take().unwrap();
+    assert_eq!(network.name(), "test-ns");
+    let _ = network.into_info_for_test();
+    assert_eq!(leaked.sock_dir, fixture.sock_dir);
+    assert_eq!(leaked.workspace, fixture.workspace);
+}
+
+#[tokio::test]
 async fn create_transaction_drop_before_rename_destroys_slot_workspace() {
     let fixture = SlotWorkspaceFixture::new().await;
 


### PR DESCRIPTION
## Summary
- wrap create-transaction COW ownership so tests can inject deterministic cleanup outcomes without constructing real NBD devices
- cover safe COW cleanup, unsafe cleanup, network-release failure, rollback cancellation while COW cleanup is pending, and rollback cancellation after safe COW cleanup while network release is pending
- verify unsafe or cancelled cleanup preserves the workspace correctly, and safe cleanup keeps the leak-cleaner workspace deletion flag enabled

Fixes #19372

## Verification
- cargo fmt --manifest-path crates/Cargo.toml --all
- cargo test --manifest-path crates/Cargo.toml -p sandbox-fc create_transaction
- cargo test --manifest-path crates/Cargo.toml -p sandbox-fc
- pre-commit: cargo-doc, cargo-clippy