### PR TITLE
feat: add connected connectors filter

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -13,7 +13,6 @@ import {
   type ConnectorType,
   type ConnectorDisplayCategory,
 } from "@vm0/connectors/connectors";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   getConnectorAuthMethodAccessMetadata,
   getConnectorAuthMethod,
@@ -406,16 +405,12 @@ export const connectorsSearch$ = computed((get) => {
 export const filteredConnectorTypes$ = computed(async (get) => {
   const keyword = get(connectorsSearch$);
   const connectionFilter = get(connectorsConnectionFilter$);
-  const features = get(featureSwitch$);
-  const shouldFilterConnected =
-    connectionFilter === "connected" &&
-    (features[FeatureSwitchKey.ConnectorAccessManagement] ?? false);
   const allConnectorTypes = await get(allConnectorTypes$);
   return allConnectorTypes.filter((connector) => {
     if (!matchesConnectorSearch(keyword, connector)) {
       return false;
     }
-    return !shouldFilterConnected || connector.connected;
+    return connectionFilter !== "connected" || connector.connected;
   });
 });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -430,16 +430,10 @@ describe("connectors page", () => {
     expect(screen.queryByText("GitHub")).not.toBeInTheDocument();
   });
 
-  it("filters connectors by connected status when access management is enabled", async () => {
+  it("filters connectors by connected status", async () => {
     mockConnectors([{ type: "github", externalUsername: "octocat" }]);
 
-    detachedSetupPage({
-      context,
-      path: "/connectors",
-      featureSwitches: {
-        [FeatureSwitchKey.ConnectorAccessManagement]: true,
-      },
-    });
+    detachedSetupPage({ context, path: "/connectors" });
 
     await waitFor(() => {
       expect(screen.getByText("GitHub")).toBeInTheDocument();
@@ -512,7 +506,7 @@ describe("connectors page", () => {
     expect(screen.queryByLabelText("Connect AWS")).not.toBeInTheDocument();
   });
 
-  it("hides connector access management when its switch is disabled", async () => {
+  it("shows the connection filter and hides access management when its switch is disabled", async () => {
     mockConnectors([{ type: "github", externalUsername: "octocat" }]);
 
     detachedSetupPage({
@@ -527,10 +521,10 @@ describe("connectors page", () => {
       expect(screen.getByText("GitHub")).toBeInTheDocument();
     });
     expect(
-      screen.queryByRole("group", {
+      screen.getByRole("group", {
         name: "Connector connection filter",
       }),
-    ).not.toBeInTheDocument();
+    ).toBeInTheDocument();
     expect(
       screen.queryByLabelText("Manage GitHub access"),
     ).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -910,7 +910,7 @@ export function ZeroConnectorsPage() {
     filteredCount: filteredConnectors.length,
     renderCard,
     search,
-    connectionFilter: showConnectorAccessManagement ? connectionFilter : "all",
+    connectionFilter,
   });
   return (
     <div
@@ -972,7 +972,7 @@ export function ZeroConnectorsPage() {
                 </TabsList>
               </Tabs>
               <div className="flex items-center gap-2">
-                {activeTab === "builtin" && showConnectorAccessManagement && (
+                {activeTab === "builtin" && (
                   <ConnectorConnectionFilter
                     value={connectionFilter}
                     onChange={setConnectionFilter}


### PR DESCRIPTION
Summary:
- Show the built-in connector connection filter independently of connector access management.
- Apply the connected-only filter in the shared connector filtering signal for grouped built-in connectors.
- Update connector page tests for the always-available connection filter.

Tests:
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-connectors-page.test.tsx
- pnpm format
- pnpm -F @vm0/app lint
- pnpm lint
- pnpm -F @vm0/app check-types
- NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types
- pnpm knip

Note:
- Attempted pnpm vitest --run, then stopped it after persistent local API-suite failures from missing PostgreSQL (ECONNREFUSED to localhost:5432). The connector page suite passed.