### PR TITLE
refactor: add connector catalog reader

### DIFF
--- a/turbo/apps/api/src/signals/services/connector-catalog-reader.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-reader.service.ts
@@ -1,0 +1,61 @@
+import type { ConnectorSearchItem } from "@vm0/api-contracts/contracts/zero-connectors";
+import {
+  CONNECTOR_TYPE_KEYS,
+  CONNECTOR_TYPES,
+} from "@vm0/connectors/connectors";
+import {
+  getAvailableConnectorAuthMethodIds,
+  getConnectorTags,
+  type ApiAuthMethodPolicy,
+  type ConnectorFeatureStates,
+} from "@vm0/connectors/connector-utils";
+
+interface ConnectorCatalogSearchArgs {
+  readonly keyword: string | undefined;
+  readonly featureStates: ConnectorFeatureStates;
+  readonly apiAuthMethodPolicy?: ApiAuthMethodPolicy;
+}
+
+export function searchConnectorCatalog(
+  args: ConnectorCatalogSearchArgs,
+): Promise<ConnectorSearchItem[]> {
+  const keyword = args.keyword?.toLowerCase();
+
+  const connectors = CONNECTOR_TYPE_KEYS.flatMap((type) => {
+    const config = CONNECTOR_TYPES[type];
+    const authMethods = getAvailableConnectorAuthMethodIds(
+      type,
+      args.featureStates,
+      {
+        apiAuthMethodPolicy: args.apiAuthMethodPolicy ?? "include",
+      },
+    );
+
+    if (authMethods.length === 0) {
+      return [];
+    }
+
+    const item = {
+      id: type,
+      label: config.label,
+      description: config.helpText,
+      authMethods,
+    };
+    const tags = getConnectorTags(type);
+
+    if (
+      keyword &&
+      !item.label.toLowerCase().includes(keyword) &&
+      !item.description.toLowerCase().includes(keyword) &&
+      !tags.some((tag) => {
+        return tag.toLowerCase().includes(keyword);
+      })
+    ) {
+      return [];
+    }
+
+    return [item];
+  });
+
+  return Promise.resolve(connectors);
+}

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -7,7 +7,7 @@ import {
   type ConnectorResponse,
   type ScopeDiffResponse,
 } from "@vm0/api-contracts/contracts/connector-schemas";
-import type { ConnectorSearchAuthMethod } from "@vm0/api-contracts/contracts/zero-connectors";
+import type { ConnectorSearchItem } from "@vm0/api-contracts/contracts/zero-connectors";
 import {
   connectorAuthMethodRefHasRevokeKind,
   getAvailableConnectorAuthMethodIds,
@@ -27,8 +27,6 @@ import {
 } from "@vm0/connectors/connector-utils";
 import { revokeConnectorAuthMethodAccessToken } from "@vm0/connectors/auth-providers";
 import {
-  CONNECTOR_TYPE_KEYS,
-  CONNECTOR_TYPES,
   connectorAuthMethodIdSchema,
   connectorTypeSchema,
   type ConnectorAuthMethodId,
@@ -64,6 +62,7 @@ import {
   connectorCredentialReconnectReason,
   connectorCredentialStatus,
 } from "./connector-credential-status.service";
+import { searchConnectorCatalog } from "./connector-catalog-reader.service";
 
 type StoredConnectorRow = {
   readonly id: string;
@@ -1999,16 +1998,7 @@ export function zeroConnectorSearch(args: {
   readonly orgId: string | undefined;
   readonly userId: string;
   readonly keyword: string | undefined;
-}): Computed<
-  Promise<
-    {
-      readonly id: string;
-      readonly label: string;
-      readonly description: string;
-      readonly authMethods: ConnectorSearchAuthMethod[];
-    }[]
-  >
-> {
+}): Computed<Promise<ConnectorSearchItem[]>> {
   return computed(async (get) => {
     const overrides = args.orgId
       ? await get(userFeatureSwitchOverrides(args.orgId, args.userId))
@@ -2018,38 +2008,10 @@ export function zeroConnectorSearch(args: {
       orgId: args.orgId,
       overrides,
     });
-    const keyword = args.keyword?.toLowerCase();
-    return CONNECTOR_TYPE_KEYS.flatMap((type) => {
-      const config = CONNECTOR_TYPES[type];
-      const authMethods: ConnectorSearchAuthMethod[] =
-        getAvailableConnectorAuthMethodIds(type, featureStates, {
-          apiAuthMethodPolicy: "include",
-        });
-
-      if (authMethods.length === 0) {
-        return [];
-      }
-
-      const item = {
-        id: type,
-        label: config.label,
-        description: config.helpText,
-        authMethods,
-      };
-      const tags: readonly string[] = "tags" in config ? config.tags : [];
-
-      if (
-        keyword &&
-        !item.label.toLowerCase().includes(keyword) &&
-        !item.description.toLowerCase().includes(keyword) &&
-        !tags.some((tag) => {
-          return tag.toLowerCase().includes(keyword);
-        })
-      ) {
-        return [];
-      }
-
-      return [item];
+    return searchConnectorCatalog({
+      keyword: args.keyword,
+      featureStates,
+      apiAuthMethodPolicy: "include",
     });
   });
 }


### PR DESCRIPTION
## Summary
- add a server-side connector catalog reader service backed by the existing static connector registry
- migrate zero connector search to read through the catalog boundary while preserving existing feature switch and auth method filtering semantics
- keep contracts, auth flows, runtime execution, and firewall paths unchanged

## Tests
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-search.test.ts
- pnpm -F api lint
- pnpm -F api check-types
- pre-commit hook: pnpm knip
- pre-commit hook: pnpm check-types

Closes #19389