### PR TITLE
fix: hide agent workflow tabs after automation migration

### DIFF
--- a/turbo/apps/platform/src/signals/agents-page/agent-detail-page-setup.ts
+++ b/turbo/apps/platform/src/signals/agents-page/agent-detail-page-setup.ts
@@ -2,9 +2,11 @@ import { command } from "ccstate";
 import type { TeamComposeItem } from "@vm0/core";
 import { createElement } from "react";
 import { AgentDetailPage } from "../../views/team-page/zero-team-detail-page.tsx";
+import { activeRoute$ } from "../active-route.ts";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
 import { detachedNavigateTo$, searchParams$ } from "../route.ts";
+import { ROUTES } from "../route-paths.ts";
 import {
   currentAgentId$,
   agents$,
@@ -17,7 +19,6 @@ import { setActiveAgent$ } from "../zero-page/zero-job-detail.ts";
 import { setChatAgentId$ } from "../agent-chat.ts";
 import { featureSwitch$ } from "../external/feature-switch.ts";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { reloadWorkflows$ } from "../workflows-page/workflows-signals.ts";
 
 export const setupAgentDetailPage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
@@ -58,7 +59,23 @@ export const setupAgentDetailPage$ = command(
     set(rememberLastUsedAgentId$, agentId);
     const features = get(featureSwitch$);
     if (features[FeatureSwitchKey.SwitchScheduleAutomationToWorkflowTrigger]) {
-      set(reloadWorkflows$);
+      const route = get(activeRoute$);
+      const params = get(searchParams$);
+      const tab = params.get("tab");
+      if (
+        route === "agentWorkflows" ||
+        tab === "automations" ||
+        tab === "workflows"
+      ) {
+        const nextParams = new URLSearchParams(params);
+        nextParams.delete("tab");
+        set(detachedNavigateTo$, ROUTES.agentDetail, {
+          pathParams: { agentId },
+          searchParams: nextParams,
+          replace: true,
+        });
+        return;
+      }
     }
 
     const displayName = agent.displayName ?? "Agent";

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -11,10 +11,6 @@ import {
 } from "@vm0/api-contracts/contracts/zero-agents";
 import { zeroComposesMainContract } from "@vm0/api-contracts/contracts/zero-composes";
 import {
-  zeroWorkflowTriggersContract,
-  type ZeroWorkflowTriggerAutomationEntry,
-} from "@vm0/api-contracts/contracts/zero-workflows";
-import {
   type ApplyUserPermissionGrantsRequest,
   type UserPermissionGrantResponse,
   zeroUserPermissionGrantsContract,
@@ -153,6 +149,14 @@ function tabByText(text: string): HTMLElement {
     throw new Error(`${text} tab not found`);
   }
   return tab;
+}
+
+function queryTabByText(text: string): HTMLElement | null {
+  return (
+    queryAllByRoleFast("tab").find((candidate) => {
+      return candidate.textContent?.replace(/\s+/g, " ").trim() === text;
+    }) ?? null
+  );
 }
 
 async function permissionRowByName(
@@ -316,53 +320,6 @@ function mockTeamAPIs(): void {
   context.mocks.api(zeroAgentInstructionsContract.get, ({ respond }) => {
     return respond(200, { content: null, filename: null });
   });
-}
-
-function workflowAutomationEntry({
-  workflowId,
-  agentId,
-  agentDisplayName,
-  name,
-  displayName,
-  triggerId,
-  intervalSeconds,
-}: {
-  workflowId: string;
-  agentId: string;
-  agentDisplayName: string;
-  name: string;
-  displayName: string;
-  triggerId: string;
-  intervalSeconds: number;
-}): ZeroWorkflowTriggerAutomationEntry {
-  return {
-    workflow: {
-      id: workflowId,
-      agentId,
-      agentName: null,
-      agentDisplayName,
-      name,
-      displayName,
-      description: null,
-      visibility: "private",
-      requestToPublish: false,
-      ownerUserId: "test-owner-id",
-      ownerUserDisplayName: "Test Owner",
-      ownerUserImageUrl: null,
-      canManage: true,
-    },
-    trigger: {
-      id: triggerId,
-      ownerUserId: "test-owner-id",
-      enabled: true,
-      chatThreadId: "thread-workflow-trigger",
-      nextRunAt: null,
-      lastRunAt: null,
-      kind: "schedule",
-      schedule: { type: "loop", intervalSeconds },
-      scheduleSummary: `Every ${intervalSeconds / 60} minutes`,
-    },
-  };
 }
 
 describe("team page navigation", () => {
@@ -629,40 +586,15 @@ describe("team page navigation", () => {
     });
   });
 
-  it("shows agent workflow triggers when workflow automation is enabled", async () => {
+  it("hides agent automation and workflow tabs when workflow automation is enabled", async () => {
     mockTeamAPIs();
-    context.mocks.data.userPreferences({ timezone: "UTC" });
-    context.mocks.api(
-      zeroWorkflowTriggersContract.listWorkspace,
-      ({ respond }) => {
-        return respond(200, [
-          workflowAutomationEntry({
-            workflowId: "d0000000-0000-4000-a000-000000000401",
-            agentId: researchAgentId,
-            agentDisplayName: "Research Agent",
-            name: "research-digest-workflow",
-            displayName: "Research digest workflow",
-            triggerId: "workflow-trigger-research-digest",
-            intervalSeconds: 900,
-          }),
-          workflowAutomationEntry({
-            workflowId: "d0000000-0000-4000-a000-000000000402",
-            agentId: zeroAgentId,
-            agentDisplayName: "Zero",
-            name: "zero-brief-workflow",
-            displayName: "Zero brief workflow",
-            triggerId: "workflow-trigger-zero-brief",
-            intervalSeconds: 1800,
-          }),
-        ]);
-      },
-    );
 
     detachedSetupPage({
       context,
-      path: `/agents/${researchAgentId}`,
+      path: `/agents/${researchAgentId}?tab=automations`,
       featureSwitches: {
         [FeatureSwitchKey.SwitchScheduleAutomationToWorkflowTrigger]: true,
+        [FeatureSwitchKey.WorkflowsViewer]: true,
       },
     });
 
@@ -671,30 +603,18 @@ describe("team page navigation", () => {
         screen.getByRole("heading", { name: "Research Agent" }),
       ).toBeInTheDocument();
     });
-    click(tabByText("Automations"));
 
     await waitFor(() => {
-      expect(screen.getByText("Research digest workflow")).toBeInTheDocument();
+      expect(screen.getByText("@workspace")).toBeInTheDocument();
     });
+    expect(queryTabByText("Automations")).not.toBeInTheDocument();
+    expect(queryTabByText("Workflows")).not.toBeInTheDocument();
     expect(
-      screen.getByText("Workflow triggers attached to Research Agent."),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Every 15 minutes")).toBeInTheDocument();
-    expect(screen.queryByText("Zero brief workflow")).not.toBeInTheDocument();
-    expect(screen.queryByText("Research digest")).not.toBeInTheDocument();
-
-    click(buttonByText("Add automation"));
-
-    const dialog = await screen.findByRole("dialog");
-    expect(
-      within(dialog).getByText("Choose how this workflow should run."),
-    ).toBeInTheDocument();
-    expect(within(dialog).getByText("Research Agent")).toBeInTheDocument();
-    expect(within(dialog).getByText("Fixed interval")).toBeInTheDocument();
-    expect(
-      within(dialog).queryByPlaceholderText("Search agents..."),
+      screen.queryByText("Research Agent's automations"),
     ).not.toBeInTheDocument();
-    expect(within(dialog).queryByText("Zero")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Workflow triggers attached to Research Agent."),
+    ).not.toBeInTheDocument();
   });
 
   it("runs an agent automation and opens its detail page", async () => {

--- a/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
@@ -21,7 +21,6 @@ import {
   IconMessageCircle,
   IconWand,
   IconListCheck,
-  IconPlus,
 } from "@tabler/icons-react";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import type { ConnectorType } from "@vm0/connectors/connectors";
@@ -73,7 +72,6 @@ import {
 } from "../../signals/zero-page/zero-job-detail.ts";
 import { runAutomationNow$ } from "../../signals/zero-page/zero-automations.ts";
 import { zeroOnboardingStatus$ } from "../../signals/zero-page/zero-onboarding.ts";
-import { userPreferences$ } from "../../signals/zero-page/settings/user-preferences.ts";
 import { Link } from "../router/link.tsx";
 import { detachedNavigateTo$ } from "../../signals/route.ts";
 import {
@@ -122,16 +120,8 @@ import {
   type FirewallPermissionDetailMetadata,
 } from "@vm0/connectors/firewall-metadata";
 import type { UserPermissionGrantResponse } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
-import { openWorkflowAutomationDialogForAgent$ } from "../../signals/automation-page/workflow-trigger-automation-dialog.ts";
-import {
-  agentVisibleWorkflows$,
-  allWorkflowTriggerEntries$,
-} from "../../signals/workflows-page/workflows-signals.ts";
+import { agentVisibleWorkflows$ } from "../../signals/workflows-page/workflows-signals.ts";
 import { WorkflowListPanel } from "../workflows-page/workflows-page.tsx";
-import {
-  CreateWorkflowAutomationDialog,
-  WorkflowTriggerAutomationList,
-} from "../zero-page/workflow-trigger-automations-page.tsx";
 import {
   DetailPageBreadcrumbBar,
   DetailPageHeader,
@@ -253,12 +243,16 @@ function DetailError({ error, agentId }: { error: string; agentId: string }) {
 const TAB_TRIGGER_CLASS =
   "gap-1.5 text-sm data-[state=active]:bg-background px-3";
 
-/** Coerce hidden tabs back to "authorization" for non-admin default-agent view. */
+/** Coerce hidden tabs back to "authorization". */
 function resolveVisibleTab(
   rawTab: string,
   hideProfileAndInstructions: boolean,
+  showAutomations: boolean,
   showWorkflows: boolean,
 ): string {
+  if (!showAutomations && rawTab === "automations") {
+    return "authorization";
+  }
   if (!showWorkflows && rawTab === "workflows") {
     return "authorization";
   }
@@ -277,11 +271,13 @@ function AgentTabNav({
   activeTab,
   onTabChange,
   showProfileAndInstructions,
+  showAutomations,
   showWorkflows,
 }: {
   activeTab: string;
   onTabChange: (tab: string) => void;
   showProfileAndInstructions: boolean;
+  showAutomations: boolean;
   showWorkflows: boolean;
 }) {
   return (
@@ -298,7 +294,9 @@ function AgentTabNav({
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="authorization">Authorization</SelectItem>
-            <SelectItem value="automations">Automations</SelectItem>
+            {showAutomations && (
+              <SelectItem value="automations">Automations</SelectItem>
+            )}
             {showWorkflows && (
               <SelectItem value="workflows">Workflows</SelectItem>
             )}
@@ -317,10 +315,12 @@ function AgentTabNav({
           <IconShield size={14} stroke={1.5} />
           Authorization
         </TabsTrigger>
-        <TabsTrigger value="automations" className={TAB_TRIGGER_CLASS}>
-          <IconCalendar size={14} stroke={1.5} />
-          Automations
-        </TabsTrigger>
+        {showAutomations && (
+          <TabsTrigger value="automations" className={TAB_TRIGGER_CLASS}>
+            <IconCalendar size={14} stroke={1.5} />
+            Automations
+          </TabsTrigger>
+        )}
         {showWorkflows && (
           <TabsTrigger value="workflows" className={TAB_TRIGGER_CLASS}>
             <IconListCheck size={14} stroke={1.5} />
@@ -822,76 +822,10 @@ function JobPermissionsTab({
   );
 }
 
-function JobWorkflowAutomationsTab({
-  agentId,
-  displayName,
-}: {
-  agentId: string;
-  displayName: string;
-}) {
-  const entriesLoadable = useLastLoadable(allWorkflowTriggerEntries$);
-  const prefsLoadable = useLastLoadable(userPreferences$);
-  const openForAgent = useSet(openWorkflowAutomationDialogForAgent$);
-  const entries =
-    entriesLoadable.state === "hasData" ? entriesLoadable.data : [];
-  const displayTimezone =
-    prefsLoadable.state === "hasData" && prefsLoadable.data?.timezone
-      ? prefsLoadable.data.timezone
-      : new Intl.DateTimeFormat().resolvedOptions().timeZone;
-  const loading = entriesLoadable.state === "loading";
-  const agentEntries = entries.filter((entry) => {
-    return entry.workflow.agentId === agentId;
-  });
-  const openAddAutomation = () => {
-    openForAgent(agentId);
-  };
-
-  return (
-    <div className="mx-auto flex max-w-[900px] flex-col gap-4">
-      <div className="flex flex-wrap items-end justify-between gap-4">
-        <div className="hidden min-w-0 md:block">
-          <h2 className="text-lg font-semibold tracking-tight text-foreground">
-            Automations
-          </h2>
-          <p className="mt-0.5 text-sm text-muted-foreground">
-            Workflow triggers attached to {displayName}.
-          </p>
-        </div>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          className="zero-btn-morandi h-9 shrink-0 gap-2 rounded-lg border"
-          onClick={openAddAutomation}
-        >
-          <IconPlus size={14} stroke={2} />
-          Add automation
-        </Button>
-      </div>
-
-      <WorkflowTriggerAutomationList
-        entries={agentEntries}
-        displayTimezone={displayTimezone}
-        loading={loading}
-        onAdd={openAddAutomation}
-      />
-      <CreateWorkflowAutomationDialog />
-    </div>
-  );
-}
-
-function JobAutomationsTab({
-  agentId,
-  displayName,
-}: {
-  agentId: string;
-  displayName: string;
-}) {
+function JobAutomationsTab({ displayName }: { displayName: string }) {
   const features = useLastResolved(featureSwitch$);
   if (features?.[FeatureSwitchKey.SwitchScheduleAutomationToWorkflowTrigger]) {
-    return (
-      <JobWorkflowAutomationsTab agentId={agentId} displayName={displayName} />
-    );
+    return null;
   }
 
   return <JobLegacyAutomationsTab displayName={displayName} />;
@@ -1011,6 +945,7 @@ function AgentHeader({
   activeTab,
   onTabChange,
   showProfileAndInstructions,
+  showAutomations,
   showWorkflows,
 }: {
   displayName: string;
@@ -1019,6 +954,7 @@ function AgentHeader({
   activeTab: string;
   onTabChange: (tab: string) => void;
   showProfileAndInstructions: boolean;
+  showAutomations: boolean;
   showWorkflows: boolean;
 }) {
   const nav = useSet(detachedNavigateTo$);
@@ -1071,6 +1007,7 @@ function AgentHeader({
           activeTab={activeTab}
           onTabChange={onTabChange}
           showProfileAndInstructions={showProfileAndInstructions}
+          showAutomations={showAutomations}
           showWorkflows={showWorkflows}
         />
         <Button
@@ -1127,7 +1064,7 @@ function AgentTabContent({
       return <JobPermissionsTab agentId={agentId} displayName={displayName} />;
     }
     case "automations": {
-      return <JobAutomationsTab agentId={agentId} displayName={displayName} />;
+      return <JobAutomationsTab displayName={displayName} />;
     }
     case "workflows": {
       return <JobWorkflowsTab agentId={agentId} />;
@@ -1204,11 +1141,17 @@ function useTabVisibility(agentId: string, ownerId: string) {
   const rawTab = useGet(agentActiveTab$);
   const setActiveTab = useSet(setAgentActiveTab$);
   const features = useLastResolved(featureSwitch$);
-  const showWorkflows = features?.[FeatureSwitchKey.WorkflowsViewer] ?? false;
+  const showAutomations = !(
+    features?.[FeatureSwitchKey.SwitchScheduleAutomationToWorkflowTrigger] ??
+    false
+  );
+  const showWorkflows =
+    showAutomations && (features?.[FeatureSwitchKey.WorkflowsViewer] ?? false);
   const hideProfileAndInstructions = !isAdmin && !isOwner;
   const activeTab = resolveVisibleTab(
     rawTab,
     hideProfileAndInstructions,
+    showAutomations,
     showWorkflows,
   );
 
@@ -1216,6 +1159,7 @@ function useTabVisibility(agentId: string, ownerId: string) {
     isDefaultAgent,
     hideProfileAndInstructions,
     isOwner,
+    showAutomations,
     showWorkflows,
     activeTab,
     setActiveTab,
@@ -1232,6 +1176,7 @@ export function ZeroJobDetailPage() {
     isDefaultAgent,
     hideProfileAndInstructions,
     isOwner,
+    showAutomations,
     showWorkflows,
     activeTab,
     setActiveTab,
@@ -1255,6 +1200,7 @@ export function ZeroJobDetailPage() {
         activeTab={activeTab}
         onTabChange={setActiveTab}
         showProfileAndInstructions={!hideProfileAndInstructions}
+        showAutomations={showAutomations}
         showWorkflows={showWorkflows}
       />
       <DetailPageMain>


### PR DESCRIPTION
## Summary
- Hide the agent detail Automations tab when `switchScheduleAutomationToWorkflowTrigger` is enabled.
- Hide the agent detail Workflows tab under the same migration switch, even when `WorkflowsViewer` is enabled.
- Replace old agent-scoped automation/workflow tab URLs back to the agent detail route and remove the now-unused agent-scoped workflow-trigger automation panel.

## Verification
- `pnpm exec prettier --write apps/platform/src/signals/agents-page/agent-detail-page-setup.ts apps/platform/src/views/team-page/zero-job-detail-page.tsx apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx`
- `pnpm -F @vm0/app exec vitest run src/views/team-page/__tests__/team-navigation.test.tsx --reporter dot`
- `pnpm exec oxlint src/signals/agents-page/agent-detail-page-setup.ts src/views/team-page/zero-job-detail-page.tsx src/views/team-page/__tests__/team-navigation.test.tsx`
- `pnpm exec oxlint --type-aware -c ../../.oxlintrc.typeaware.json src/signals/agents-page/agent-detail-page-setup.ts src/views/team-page/zero-job-detail-page.tsx src/views/team-page/__tests__/team-navigation.test.tsx`
- `pnpm exec eslint src/signals/agents-page/agent-detail-page-setup.ts src/views/team-page/zero-job-detail-page.tsx src/views/team-page/__tests__/team-navigation.test.tsx --max-warnings 0`
- `pnpm -F @vm0/app check-types`
