### PR TITLE
feat: start workflow creation from chat

### DIFF
--- a/turbo/apps/platform/src/signals/automation-page/workflow-trigger-automation-dialog.ts
+++ b/turbo/apps/platform/src/signals/automation-page/workflow-trigger-automation-dialog.ts
@@ -1,7 +1,10 @@
 import { command, computed, state } from "ccstate";
 
 type WorkflowAutomationDialogStep = 1 | 2;
-export type WorkflowAutomationDialogIntent = "automation" | "workflow";
+export type WorkflowAutomationDialogIntent =
+  | "automation"
+  | "workflow"
+  | "workflow-chat";
 
 const workflowAutomationDialogOpenState$ = state(false);
 const workflowAutomationDialogStepState$ =
@@ -55,7 +58,7 @@ export const openCreateWorkflowDialog$ = command(({ set }) => {
   set(selectedWorkflowAutomationAgentIdState$, "");
   set(workflowAutomationAgentQueryState$, "");
   set(workflowAutomationAgentSelectionLockedState$, false);
-  set(workflowAutomationDialogIntentState$, "workflow");
+  set(workflowAutomationDialogIntentState$, "workflow-chat");
 });
 
 export const openWorkflowAutomationDialogForAgent$ = command(

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -31,6 +31,7 @@ import {
   mockChatLifecycle,
   PLACEHOLDER,
 } from "../../zero-page/__tests__/chat-test-helpers.ts";
+import { CREATE_WORKFLOW_WITH_CHAT_PROMPT } from "../../zero-page/workflow-trigger-automations-page.tsx";
 
 const context = testContext();
 const CURRENT_USER_ID = "test-user-123";
@@ -738,6 +739,7 @@ describe("agent workflows tab", () => {
 
   it("shows all visible workflows on the workspace workflows page", async () => {
     mockAgentPageApis();
+    mockChatLifecycle(context);
     mockWorkflowApis([
       salesResearch(),
       opsPlaybook(),
@@ -776,6 +778,14 @@ describe("agent workflows tab", () => {
     expect(dialog).toBeInTheDocument();
     expect(within(dialog).getByText("Research Bot")).toBeInTheDocument();
     expect(within(dialog).getByText("Support Bot")).toBeInTheDocument();
+
+    click(buttonByText("Research Bot", dialog));
+    await waitFor(() => {
+      expect(pathname()).toBe(`/agents/${AGENT_ID}/chat`);
+    });
+    await expect(
+      screen.findByDisplayValue(CREATE_WORKFLOW_WITH_CHAT_PROMPT),
+    ).resolves.toBeInTheDocument();
   });
 
   it("shows the agent's workflows and links into the detail page", async () => {

--- a/turbo/apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx
@@ -105,6 +105,9 @@ interface WorkflowAutomationOption {
   readonly prompt: string;
 }
 
+export const CREATE_WORKFLOW_WITH_CHAT_PROMPT =
+  "Help me create a Zero workflow for this agent. Use the workflow-setup skill, then ask me for the automation goal, trigger, action, and allowed side effects before creating the workflow and trigger.";
+
 const WORKFLOW_AUTOMATION_OPTIONS: readonly WorkflowAutomationOption[] = [
   {
     kind: "manual",
@@ -772,8 +775,20 @@ export function CreateWorkflowAutomationDialog() {
     agents.find((agent) => {
       return agent.id === selectedAgentId;
     }) ?? null;
+  const creatingWorkflow = intent === "workflow" || intent === "workflow-chat";
+  const creatingWorkflowWithChat = intent === "workflow-chat";
 
   const selectAgent = (agentId: string) => {
+    if (creatingWorkflowWithChat) {
+      setOpen(false);
+      navigate(ROUTES.agentChat, {
+        pathParams: { agentId },
+        searchParams: new URLSearchParams({
+          prompt: CREATE_WORKFLOW_WITH_CHAT_PROMPT,
+        }),
+      });
+      return;
+    }
     setSelectedAgentId(agentId);
     setStep(2);
   };
@@ -798,8 +813,6 @@ export function CreateWorkflowAutomationDialog() {
       }),
     });
   };
-
-  const creatingWorkflow = intent === "workflow";
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>


### PR DESCRIPTION
## Summary
- add a dedicated workflow-chat dialog intent for the `/workflows` create-with-chat entrypoint
- route selected agents directly to `/agents/:id/chat` with a workflow-setup prompt
- keep the existing `/automations` trigger-type creation flow intact

## Tests
- `pnpm format`
- `pnpm turbo run lint --log-order grouped` (turbo run hit a SIGKILL in `@vm0/app` type-aware lint; `pnpm -F @vm0/app lint` passed when rerun directly)
- `pnpm check-types` (`@vm0/app` passed; `api` hit Node heap OOM under default heap, then `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types` passed)
- `pnpm exec vitest run apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx --testNamePattern "shows all visible workflows"`
- `pnpm exec vitest run apps/platform/src/views/zero-page/__tests__/zero-automations-page.test.tsx --testNamePattern "starts workflow-trigger creation"`