### PR TITLE
feat: mprove html edit comments

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/html-dom-comment-editor.ts
+++ b/turbo/apps/platform/src/signals/zero-page/html-dom-comment-editor.ts
@@ -1,5 +1,5 @@
 import { createElement } from "react";
-import { IconMessageCircleFilled, IconPointer2 } from "@tabler/icons-react";
+import { IconPointer2 } from "@tabler/icons-react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { command, computed, state } from "ccstate";
 import {
@@ -83,21 +83,48 @@ interface SendHtmlDomEditRequestParams {
   readonly onStarted?: () => void;
 }
 
+type CommentMarkerPlacement = "bottom" | "left" | "right" | "top";
+
+interface CommentMarkerRect {
+  readonly bottom: number;
+  readonly height: number;
+  readonly left: number;
+  readonly right: number;
+  readonly top: number;
+  readonly width: number;
+}
+
+interface CommentMarkerPosition {
+  readonly placement: CommentMarkerPlacement;
+  readonly rect: CommentMarkerRect;
+}
+
 const HTML_DOM_COMMENT_LAYER_ID = "vm0-html-edit-comment-layer";
 const MAX_DIRECT_HTML_EDIT_DRAFT_BYTES = 500_000;
 const HTML_DOM_COMMENT_MARKER_TARGET_ATTR =
   "data-vm0-html-comment-target-node-id";
-const FRAME_COMMENT_MARKER_ICON_SVG = renderToStaticMarkup(
-  createElement(IconMessageCircleFilled, {
-    "aria-hidden": "true",
-    size: 20,
-  }),
-);
+const HTML_DOM_COMMENT_DELETE_ATTR = "data-vm0-html-comment-delete-id";
+const HTML_DOM_COMMENT_FLASH_ATTR = "data-vm0-html-comment-flash";
+const FRAME_COMMENT_MARKER_PLACEMENT_ATTR = "data-vm0-html-comment-placement";
+const FRAME_COMMENT_LABEL_MAX_WIDTH = 136;
+const FRAME_COMMENT_LABEL_LINE_HEIGHT = 20;
+const FRAME_COMMENT_LABEL_VERTICAL_PADDING = 16;
+const FRAME_COMMENT_LABEL_MAX_LINES = 2;
+const FRAME_COMMENT_LABEL_HEIGHT =
+  FRAME_COMMENT_LABEL_MAX_LINES * FRAME_COMMENT_LABEL_LINE_HEIGHT +
+  FRAME_COMMENT_LABEL_VERTICAL_PADDING;
+const FRAME_COMMENT_CONNECTOR_GAP = 36;
+const FRAME_COMMENT_DOT_SIZE = 8;
+const FRAME_COMMENT_VIEWPORT_PADDING = 8;
+const FRAME_COMMENT_COLLISION_GAP = 6;
+const FRAME_COMMENT_NUDGE_STEP = 12;
+const FRAME_COMMENT_NUDGE_STEPS = [0, 1, -1, 2, -2] as const;
 const FRAME_NAVIGATION_CURSOR_SVG = renderToStaticMarkup(
   createElement(IconPointer2, {
     "aria-hidden": "true",
     color: "#2563eb",
     size: 20,
+    stroke: 2.6,
   }),
 );
 const FRAME_NAVIGATION_CURSOR = `url("data:image/svg+xml,${encodeURIComponent(
@@ -248,6 +275,17 @@ function closestCommentMarker(target: EventTarget | null): HTMLElement | null {
   );
 }
 
+function closestCommentDeleteButton(
+  target: EventTarget | null,
+): HTMLElement | null {
+  if (target === null || typeof target !== "object" || !("closest" in target)) {
+    return null;
+  }
+  return (target as Element).closest<HTMLElement>(
+    `[${HTML_DOM_COMMENT_DELETE_ATTR}]`,
+  );
+}
+
 function syncFrameEditState(
   doc: Document | null | undefined,
   params: {
@@ -293,13 +331,31 @@ function installFrameStyles(doc: Document): void {
       cursor: ${FRAME_NAVIGATION_CURSOR} !important;
     }
     [${HTML_DOM_EDIT_HOVER_ATTR}="true"] {
-      outline: 2px solid rgba(37, 99, 235, 0.75) !important;
+      outline: 2px dashed rgba(37, 99, 235, 0.75) !important;
       outline-offset: 2px !important;
     }
     [${HTML_DOM_EDIT_SELECTED_ATTR}="true"] {
       outline: 2px solid rgb(37, 99, 235) !important;
       outline-offset: 2px !important;
       box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.16) !important;
+    }
+    [${HTML_DOM_COMMENT_MARKER_TARGET_ATTR}]:hover [${HTML_DOM_COMMENT_DELETE_ATTR}],
+    [${HTML_DOM_COMMENT_DELETE_ATTR}]:focus-visible {
+      opacity: 1 !important;
+      pointer-events: auto !important;
+    }
+    [${HTML_DOM_COMMENT_FLASH_ATTR}="true"] {
+      animation: vm0-html-comment-flash 900ms ease-out both !important;
+    }
+    @keyframes vm0-html-comment-flash {
+      0%, 100% {
+        box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.16) !important;
+      }
+      35% {
+        box-shadow:
+          0 0 0 5px rgba(37, 99, 235, 0.28),
+          0 0 0 14px rgba(37, 99, 235, 0.16) !important;
+      }
     }
   `;
   doc.head.append(style);
@@ -363,20 +419,6 @@ function restoreFrameDocumentHtml(params: {
   installFrameStyles(params.doc);
 }
 
-function commentedTargetNodeIds(
-  comments: readonly HtmlDomEditComment[],
-): ReadonlySet<string> {
-  const nodeIds = new Set<string>();
-  for (const comment of comments) {
-    const nodeId = comment.targetNodeIds[0];
-    if (!nodeId) {
-      continue;
-    }
-    nodeIds.add(nodeId);
-  }
-  return nodeIds;
-}
-
 function commentForSelectedNodes(params: {
   readonly comments: readonly HtmlDomEditComment[];
   readonly selectedNodeIds: readonly string[];
@@ -413,17 +455,305 @@ function commentForNodeId(
   );
 }
 
-function commentMarkerPosition(params: {
+function clamp(value: number, min: number, max: number): number {
+  if (max < min) {
+    return min;
+  }
+  return Math.max(min, Math.min(max, value));
+}
+
+function commentMarkerRect(params: {
+  readonly height: number;
+  readonly left: number;
+  readonly top: number;
+  readonly width: number;
+}): CommentMarkerRect {
+  return {
+    bottom: params.top + params.height,
+    height: params.height,
+    left: params.left,
+    right: params.left + params.width,
+    top: params.top,
+    width: params.width,
+  };
+}
+
+function commentMarkerRectsOverlap(
+  first: CommentMarkerRect,
+  second: CommentMarkerRect,
+): boolean {
+  return !(
+    first.right + FRAME_COMMENT_COLLISION_GAP <= second.left ||
+    second.right + FRAME_COMMENT_COLLISION_GAP <= first.left ||
+    first.bottom + FRAME_COMMENT_COLLISION_GAP <= second.top ||
+    second.bottom + FRAME_COMMENT_COLLISION_GAP <= first.top
+  );
+}
+
+function commentMarkerCollides(
+  rect: CommentMarkerRect,
+  occupiedRects: readonly CommentMarkerRect[],
+): boolean {
+  return occupiedRects.some((occupied) => {
+    return commentMarkerRectsOverlap(rect, occupied);
+  });
+}
+
+function targetIntersectsViewport(params: {
   readonly doc: Document;
   readonly target: Element;
-}): { readonly left: number; readonly top: number } {
+}): boolean {
   const rect = params.target.getBoundingClientRect();
+  if (
+    rect.bottom === 0 &&
+    rect.height === 0 &&
+    rect.left === 0 &&
+    rect.right === 0 &&
+    rect.top === 0 &&
+    rect.width === 0
+  ) {
+    return true;
+  }
+
+  const viewportWidth =
+    params.doc.documentElement.clientWidth ||
+    params.doc.defaultView?.innerWidth ||
+    320;
+  const viewportHeight =
+    params.doc.documentElement.clientHeight ||
+    params.doc.defaultView?.innerHeight ||
+    240;
+
+  return (
+    rect.bottom > 0 &&
+    rect.right > 0 &&
+    rect.left < viewportWidth &&
+    rect.top < viewportHeight
+  );
+}
+
+function markerCandidateRect(params: {
+  readonly labelHeight: number;
+  readonly nudge: number;
+  readonly placement: CommentMarkerPlacement;
+  readonly targetRect: DOMRect;
+  readonly viewportHeight: number;
+  readonly viewportWidth: number;
+}): CommentMarkerRect {
+  const targetCenterX = params.targetRect.left + params.targetRect.width / 2;
+  const targetCenterY = params.targetRect.top + params.targetRect.height / 2;
+  const horizontalWidth =
+    FRAME_COMMENT_CONNECTOR_GAP + FRAME_COMMENT_LABEL_MAX_WIDTH;
+  const verticalHeight = FRAME_COMMENT_CONNECTOR_GAP + params.labelHeight;
+
+  switch (params.placement) {
+    case "right": {
+      return commentMarkerRect({
+        height: params.labelHeight,
+        left: params.targetRect.right,
+        top: clamp(
+          targetCenterY - params.labelHeight / 2 + params.nudge,
+          FRAME_COMMENT_VIEWPORT_PADDING,
+          params.viewportHeight -
+            FRAME_COMMENT_VIEWPORT_PADDING -
+            params.labelHeight,
+        ),
+        width: horizontalWidth,
+      });
+    }
+    case "bottom": {
+      return commentMarkerRect({
+        height: verticalHeight,
+        left: clamp(
+          targetCenterX - FRAME_COMMENT_LABEL_MAX_WIDTH / 2 + params.nudge,
+          FRAME_COMMENT_VIEWPORT_PADDING,
+          params.viewportWidth -
+            FRAME_COMMENT_VIEWPORT_PADDING -
+            FRAME_COMMENT_LABEL_MAX_WIDTH,
+        ),
+        top: params.targetRect.bottom,
+        width: FRAME_COMMENT_LABEL_MAX_WIDTH,
+      });
+    }
+    case "left": {
+      return commentMarkerRect({
+        height: params.labelHeight,
+        left: params.targetRect.left - horizontalWidth,
+        top: clamp(
+          targetCenterY - params.labelHeight / 2 + params.nudge,
+          FRAME_COMMENT_VIEWPORT_PADDING,
+          params.viewportHeight -
+            FRAME_COMMENT_VIEWPORT_PADDING -
+            params.labelHeight,
+        ),
+        width: horizontalWidth,
+      });
+    }
+    case "top": {
+      return commentMarkerRect({
+        height: verticalHeight,
+        left: clamp(
+          targetCenterX - FRAME_COMMENT_LABEL_MAX_WIDTH / 2 + params.nudge,
+          FRAME_COMMENT_VIEWPORT_PADDING,
+          params.viewportWidth -
+            FRAME_COMMENT_VIEWPORT_PADDING -
+            FRAME_COMMENT_LABEL_MAX_WIDTH,
+        ),
+        top: params.targetRect.top - verticalHeight,
+        width: FRAME_COMMENT_LABEL_MAX_WIDTH,
+      });
+    }
+  }
+}
+
+function markerPlacementHasGap(params: {
+  readonly labelHeight: number;
+  readonly placement: CommentMarkerPlacement;
+  readonly targetRect: DOMRect;
+  readonly viewportHeight: number;
+  readonly viewportWidth: number;
+}): boolean {
+  switch (params.placement) {
+    case "right": {
+      return (
+        params.viewportWidth - params.targetRect.right >=
+        FRAME_COMMENT_CONNECTOR_GAP +
+          FRAME_COMMENT_LABEL_MAX_WIDTH +
+          FRAME_COMMENT_VIEWPORT_PADDING
+      );
+    }
+    case "bottom": {
+      return (
+        params.viewportHeight - params.targetRect.bottom >=
+        FRAME_COMMENT_CONNECTOR_GAP +
+          params.labelHeight +
+          FRAME_COMMENT_VIEWPORT_PADDING
+      );
+    }
+    case "left": {
+      return (
+        params.targetRect.left >=
+        FRAME_COMMENT_CONNECTOR_GAP +
+          FRAME_COMMENT_LABEL_MAX_WIDTH +
+          FRAME_COMMENT_VIEWPORT_PADDING
+      );
+    }
+    case "top": {
+      return (
+        params.targetRect.top >=
+        FRAME_COMMENT_CONNECTOR_GAP +
+          params.labelHeight +
+          FRAME_COMMENT_VIEWPORT_PADDING
+      );
+    }
+  }
+}
+
+function clampedMarkerRect(params: {
+  readonly rect: CommentMarkerRect;
+  readonly viewportHeight: number;
+  readonly viewportWidth: number;
+}): CommentMarkerRect {
+  return commentMarkerRect({
+    height: params.rect.height,
+    left: clamp(
+      params.rect.left,
+      FRAME_COMMENT_VIEWPORT_PADDING,
+      params.viewportWidth - FRAME_COMMENT_VIEWPORT_PADDING - params.rect.width,
+    ),
+    top: clamp(
+      params.rect.top,
+      FRAME_COMMENT_VIEWPORT_PADDING,
+      params.viewportHeight -
+        FRAME_COMMENT_VIEWPORT_PADDING -
+        params.rect.height,
+    ),
+    width: params.rect.width,
+  });
+}
+
+function commentMarkerPosition(params: {
+  readonly doc: Document;
+  readonly labelHeight: number;
+  readonly occupiedRects: readonly CommentMarkerRect[];
+  readonly target: Element;
+}): CommentMarkerPosition {
+  const targetRect = params.target.getBoundingClientRect();
   const viewportWidth = params.doc.documentElement.clientWidth || 320;
   const viewportHeight = params.doc.documentElement.clientHeight || 240;
-  return {
-    left: Math.max(8, Math.min(viewportWidth - 28, rect.right - 14)),
-    top: Math.max(8, Math.min(viewportHeight - 28, rect.top - 14)),
-  };
+  const placements: readonly CommentMarkerPlacement[] = [
+    "right",
+    "bottom",
+    "left",
+    "top",
+  ];
+  let fallback: CommentMarkerPosition | null = null;
+
+  for (const placement of placements) {
+    if (
+      !markerPlacementHasGap({
+        labelHeight: params.labelHeight,
+        placement,
+        targetRect,
+        viewportHeight,
+        viewportWidth,
+      })
+    ) {
+      continue;
+    }
+
+    for (const nudgeStep of FRAME_COMMENT_NUDGE_STEPS) {
+      const rect = markerCandidateRect({
+        labelHeight: params.labelHeight,
+        nudge: nudgeStep * FRAME_COMMENT_NUDGE_STEP,
+        placement,
+        targetRect,
+        viewportHeight,
+        viewportWidth,
+      });
+      if (!fallback) {
+        fallback = { placement, rect };
+      }
+      if (!commentMarkerCollides(rect, params.occupiedRects)) {
+        return { placement, rect };
+      }
+    }
+  }
+
+  for (const placement of placements) {
+    for (const nudgeStep of FRAME_COMMENT_NUDGE_STEPS) {
+      const rect = clampedMarkerRect({
+        rect: markerCandidateRect({
+          labelHeight: params.labelHeight,
+          nudge: nudgeStep * FRAME_COMMENT_NUDGE_STEP,
+          placement,
+          targetRect,
+          viewportHeight,
+          viewportWidth,
+        }),
+        viewportHeight,
+        viewportWidth,
+      });
+      if (!fallback) {
+        fallback = { placement, rect };
+      }
+      if (!commentMarkerCollides(rect, params.occupiedRects)) {
+        return { placement, rect };
+      }
+    }
+  }
+
+  return (
+    fallback ?? {
+      placement: "right",
+      rect: commentMarkerRect({
+        height: params.labelHeight,
+        left: FRAME_COMMENT_VIEWPORT_PADDING,
+        top: FRAME_COMMENT_VIEWPORT_PADDING,
+        width: FRAME_COMMENT_CONNECTOR_GAP + FRAME_COMMENT_LABEL_MAX_WIDTH,
+      }),
+    }
+  );
 }
 
 function removeFrameCommentLayer(doc: Document): void {
@@ -458,66 +788,422 @@ function ensureFrameCommentLayer(doc: Document): HTMLElement {
   return layer;
 }
 
-function createFrameCommentMarkerIcon(doc: Document): SVGElement {
-  const template = doc.createElement("template");
-  template.innerHTML = FRAME_COMMENT_MARKER_ICON_SVG;
-  const icon = template.content.firstElementChild;
-  const svgElement = doc.defaultView?.SVGElement;
-  if (svgElement && icon instanceof svgElement) {
-    return icon;
+function styleCommentMarkerLabel(label: HTMLElement): void {
+  label.dataset.testid = "html-dom-comment-tag";
+  label.style.position = "absolute";
+  label.style.display = "flex";
+  label.style.alignItems = "center";
+  label.style.boxSizing = "border-box";
+  label.style.maxWidth = `${FRAME_COMMENT_LABEL_MAX_WIDTH}px`;
+  label.style.width = `${FRAME_COMMENT_LABEL_MAX_WIDTH}px`;
+  label.style.height = `${FRAME_COMMENT_LABEL_HEIGHT}px`;
+  label.style.padding = "8px 14px";
+  label.style.borderRadius = "18px";
+  label.style.background = "rgb(37, 99, 235)";
+  label.style.border = "0";
+  label.style.color = "white";
+  label.style.cursor = "pointer";
+  label.style.fontFamily =
+    "Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif";
+  label.style.fontSize = "14px";
+  label.style.fontWeight = "600";
+  label.style.lineHeight = `${FRAME_COMMENT_LABEL_LINE_HEIGHT}px`;
+  label.style.overflow = "hidden";
+  label.style.boxShadow = "0 6px 16px rgba(15, 23, 42, 0.18)";
+  label.style.pointerEvents = "auto";
+}
+
+function styleCommentMarkerLabelText(labelText: HTMLElement): void {
+  labelText.dataset.testid = "html-dom-comment-tag-text";
+  labelText.style.display = "-webkit-box";
+  labelText.style.width = "100%";
+  labelText.style.lineHeight = `${FRAME_COMMENT_LABEL_LINE_HEIGHT}px`;
+  labelText.style.whiteSpace = "normal";
+  labelText.style.overflow = "hidden";
+  labelText.style.overflowWrap = "anywhere";
+  labelText.style.setProperty("-webkit-box-orient", "vertical");
+  labelText.style.setProperty(
+    "-webkit-line-clamp",
+    String(FRAME_COMMENT_LABEL_MAX_LINES),
+  );
+}
+
+function styleCommentMarkerDot(dot: HTMLElement): void {
+  dot.setAttribute("aria-hidden", "true");
+  dot.style.position = "absolute";
+  dot.style.width = `${FRAME_COMMENT_DOT_SIZE}px`;
+  dot.style.height = `${FRAME_COMMENT_DOT_SIZE}px`;
+  dot.style.borderRadius = "999px";
+  dot.style.background = "rgb(37, 99, 235)";
+  dot.style.pointerEvents = "none";
+}
+
+function styleCommentMarkerLeader(leader: HTMLElement): void {
+  leader.setAttribute("aria-hidden", "true");
+  leader.style.position = "absolute";
+  leader.style.pointerEvents = "none";
+}
+
+function styleCommentMarkerDeleteButton(params: {
+  readonly button: HTMLElement;
+  readonly commentId: string;
+}): void {
+  params.button.dataset.testid = "html-dom-comment-delete";
+  params.button.setAttribute(HTML_DOM_COMMENT_DELETE_ATTR, params.commentId);
+  params.button.setAttribute("aria-label", "Delete comment");
+  params.button.textContent = "x";
+  params.button.style.position = "absolute";
+  params.button.style.display = "inline-flex";
+  params.button.style.alignItems = "center";
+  params.button.style.justifyContent = "center";
+  params.button.style.width = "18px";
+  params.button.style.height = "18px";
+  params.button.style.border = "1px solid rgb(37, 99, 235)";
+  params.button.style.borderRadius = "999px";
+  params.button.style.background = "white";
+  params.button.style.color = "rgb(37, 99, 235)";
+  params.button.style.cursor = "pointer";
+  params.button.style.fontFamily =
+    "Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif";
+  params.button.style.fontSize = "13px";
+  params.button.style.fontWeight = "700";
+  params.button.style.lineHeight = "1";
+  params.button.style.opacity = "0";
+  params.button.style.padding = "0";
+  params.button.style.pointerEvents = "none";
+  params.button.style.boxShadow = "0 2px 6px rgba(15, 23, 42, 0.18)";
+  params.button.style.transition = "opacity 120ms ease, box-shadow 120ms ease";
+}
+
+function positionCommentMarkerParts(params: {
+  readonly deleteButton: HTMLElement;
+  readonly dot: HTMLElement;
+  readonly label: HTMLElement;
+  readonly leader: HTMLElement;
+  readonly placement: CommentMarkerPlacement;
+  readonly rect: CommentMarkerRect;
+}): void {
+  const dotCenterOffset = FRAME_COMMENT_DOT_SIZE / 2;
+  const labelHeight =
+    params.placement === "bottom" || params.placement === "top"
+      ? params.rect.height - FRAME_COMMENT_CONNECTOR_GAP
+      : params.rect.height;
+  const labelCenterOffset = labelHeight / 2;
+  const markerCenterY = params.rect.height / 2;
+  const markerCenterX = params.rect.width / 2;
+  const horizontalLeaderLeft = FRAME_COMMENT_DOT_SIZE + 4;
+  const horizontalLeaderWidth =
+    FRAME_COMMENT_CONNECTOR_GAP - FRAME_COMMENT_DOT_SIZE - 8;
+  const verticalLeaderTop = FRAME_COMMENT_DOT_SIZE + 4;
+  const verticalLeaderHeight =
+    FRAME_COMMENT_CONNECTOR_GAP - FRAME_COMMENT_DOT_SIZE - 8;
+
+  switch (params.placement) {
+    case "right": {
+      params.dot.style.left = "0";
+      params.dot.style.top = `${markerCenterY - dotCenterOffset}px`;
+      params.leader.style.left = `${horizontalLeaderLeft}px`;
+      params.leader.style.top = `${markerCenterY - 1}px`;
+      params.leader.style.width = `${horizontalLeaderWidth}px`;
+      params.leader.style.borderTop = "2px dashed rgb(37, 99, 235)";
+      params.label.style.left = `${FRAME_COMMENT_CONNECTOR_GAP}px`;
+      params.label.style.top = `${markerCenterY - labelCenterOffset}px`;
+      params.deleteButton.style.left = `${
+        FRAME_COMMENT_CONNECTOR_GAP + FRAME_COMMENT_LABEL_MAX_WIDTH - 10
+      }px`;
+      params.deleteButton.style.top = `${
+        markerCenterY - labelCenterOffset - 8
+      }px`;
+      break;
+    }
+    case "bottom": {
+      params.dot.style.left = `${markerCenterX - dotCenterOffset}px`;
+      params.dot.style.top = "0";
+      params.leader.style.left = `${markerCenterX - 1}px`;
+      params.leader.style.top = `${verticalLeaderTop}px`;
+      params.leader.style.height = `${verticalLeaderHeight}px`;
+      params.leader.style.borderLeft = "2px dashed rgb(37, 99, 235)";
+      params.label.style.left = "0";
+      params.label.style.top = `${FRAME_COMMENT_CONNECTOR_GAP}px`;
+      params.deleteButton.style.left = `${
+        FRAME_COMMENT_LABEL_MAX_WIDTH - 10
+      }px`;
+      params.deleteButton.style.top = `${FRAME_COMMENT_CONNECTOR_GAP - 8}px`;
+      break;
+    }
+    case "left": {
+      params.label.style.left = "0";
+      params.label.style.top = `${markerCenterY - labelCenterOffset}px`;
+      params.leader.style.left = `${FRAME_COMMENT_LABEL_MAX_WIDTH + 4}px`;
+      params.leader.style.top = `${markerCenterY - 1}px`;
+      params.leader.style.width = `${horizontalLeaderWidth}px`;
+      params.leader.style.borderTop = "2px dashed rgb(37, 99, 235)";
+      params.dot.style.left = `${params.rect.width - FRAME_COMMENT_DOT_SIZE}px`;
+      params.dot.style.top = `${markerCenterY - dotCenterOffset}px`;
+      params.deleteButton.style.left = `${
+        FRAME_COMMENT_LABEL_MAX_WIDTH - 10
+      }px`;
+      params.deleteButton.style.top = `${
+        markerCenterY - labelCenterOffset - 8
+      }px`;
+      break;
+    }
+    case "top": {
+      params.label.style.left = "0";
+      params.label.style.top = "0";
+      params.leader.style.left = `${markerCenterX - 1}px`;
+      params.leader.style.top = `${labelHeight + 4}px`;
+      params.leader.style.height = `${verticalLeaderHeight}px`;
+      params.leader.style.borderLeft = "2px dashed rgb(37, 99, 235)";
+      params.dot.style.left = `${markerCenterX - dotCenterOffset}px`;
+      params.dot.style.top = `${params.rect.height - FRAME_COMMENT_DOT_SIZE}px`;
+      params.deleteButton.style.left = `${
+        FRAME_COMMENT_LABEL_MAX_WIDTH - 10
+      }px`;
+      params.deleteButton.style.top = "-8px";
+      break;
+    }
   }
-  return doc.createElementNS("http://www.w3.org/2000/svg", "svg");
+}
+
+function createFrameCommentMarker(params: {
+  readonly comment: HtmlDomEditComment;
+  readonly doc: Document;
+  readonly nodeId: string;
+  readonly position: CommentMarkerPosition;
+}): HTMLElement {
+  const marker = params.doc.createElement("div");
+  marker.setAttribute(HTML_DOM_EDIT_OVERLAY_ATTR, "");
+  marker.setAttribute(HTML_DOM_COMMENT_MARKER_TARGET_ATTR, params.nodeId);
+  marker.setAttribute(
+    FRAME_COMMENT_MARKER_PLACEMENT_ATTR,
+    params.position.placement,
+  );
+  marker.dataset.testid = "html-dom-comment-marker";
+  marker.setAttribute("aria-label", `Comment: ${params.comment.comment}`);
+  marker.style.position = "absolute";
+  marker.style.left = `${params.position.rect.left}px`;
+  marker.style.top = `${params.position.rect.top}px`;
+  marker.style.width = `${params.position.rect.width}px`;
+  marker.style.height = `${params.position.rect.height}px`;
+  marker.style.border = "0";
+  marker.style.borderRadius = "0";
+  marker.style.background = "transparent";
+  marker.style.cursor = "pointer";
+  marker.style.pointerEvents = "auto";
+  marker.style.padding = "0";
+  marker.style.margin = "0";
+  marker.style.overflow = "visible";
+
+  const dot = params.doc.createElement("span");
+  const leader = params.doc.createElement("span");
+  const label = params.doc.createElement("button");
+  const labelText = params.doc.createElement("span");
+  const deleteButton = params.doc.createElement("button");
+  label.type = "button";
+  deleteButton.type = "button";
+  dot.dataset.testid = "html-dom-comment-anchor";
+  leader.dataset.testid = "html-dom-comment-leader";
+  labelText.textContent = params.comment.comment;
+  styleCommentMarkerDot(dot);
+  styleCommentMarkerLeader(leader);
+  styleCommentMarkerLabel(label);
+  styleCommentMarkerLabelText(labelText);
+  styleCommentMarkerDeleteButton({
+    button: deleteButton,
+    commentId: params.comment.id,
+  });
+  label.append(labelText);
+  positionCommentMarkerParts({
+    deleteButton,
+    dot,
+    label,
+    leader,
+    placement: params.position.placement,
+    rect: params.position.rect,
+  });
+  marker.append(dot, leader, label, deleteButton);
+  return marker;
 }
 
 function syncFrameCommentMarkers(
   doc: Document | null | undefined,
   comments: readonly HtmlDomEditComment[],
+  visibleCommentId?: string | null,
+  hideAll = false,
 ): void {
   if (!doc) {
     return;
   }
 
-  const commentedNodeIds = commentedTargetNodeIds(comments);
-  if (commentedNodeIds.size === 0) {
+  if (comments.length === 0 || hideAll) {
     removeFrameCommentLayer(doc);
     return;
   }
 
   const layer = ensureFrameCommentLayer(doc);
   layer.replaceChildren();
-  for (const nodeId of commentedNodeIds) {
-    const target = doc.querySelector(nodeSelector(nodeId));
-    if (!target) {
+  const occupiedRects: CommentMarkerRect[] = [];
+  const usedNodeIds = new Set<string>();
+  const commentsWithTargets = comments
+    .filter((comment) => {
+      return !visibleCommentId || comment.id === visibleCommentId;
+    })
+    .map((comment) => {
+      const nodeId = comment.targetNodeIds[0];
+      const target = nodeId ? doc.querySelector(nodeSelector(nodeId)) : null;
+      return nodeId && target ? { comment, nodeId, target } : null;
+    })
+    .filter(
+      (
+        entry,
+      ): entry is {
+        readonly comment: HtmlDomEditComment;
+        readonly nodeId: string;
+        readonly target: Element;
+      } => {
+        return entry !== null;
+      },
+    )
+    .filter((entry) => {
+      return targetIntersectsViewport({
+        doc,
+        target: entry.target,
+      });
+    })
+    .sort((first, second) => {
+      const firstRect = first.target.getBoundingClientRect();
+      const secondRect = second.target.getBoundingClientRect();
+      return firstRect.top - secondRect.top || firstRect.left - secondRect.left;
+    });
+
+  for (const { comment, nodeId, target } of commentsWithTargets) {
+    if (usedNodeIds.has(nodeId)) {
       continue;
     }
-
-    const position = commentMarkerPosition({ doc, target });
-    const marker = doc.createElement("button");
-    marker.type = "button";
-    marker.append(createFrameCommentMarkerIcon(doc));
-    marker.setAttribute(HTML_DOM_EDIT_OVERLAY_ATTR, "");
-    marker.setAttribute(HTML_DOM_COMMENT_MARKER_TARGET_ATTR, nodeId);
-    marker.dataset.testid = "html-dom-comment-marker";
-    marker.setAttribute("aria-label", "Comment");
-    marker.style.position = "absolute";
-    marker.style.left = `${position.left}px`;
-    marker.style.top = `${position.top}px`;
-    marker.style.display = "inline-flex";
-    marker.style.alignItems = "center";
-    marker.style.justifyContent = "center";
-    marker.style.width = "28px";
-    marker.style.height = "28px";
-    marker.style.border = "0";
-    marker.style.borderRadius = "0";
-    marker.style.background = "transparent";
-    marker.style.color = "rgb(59, 130, 246)";
-    marker.style.filter = "drop-shadow(0 1px 2px rgba(15, 23, 42, 0.35))";
-    marker.style.cursor = "pointer";
-    marker.style.pointerEvents = "auto";
-    marker.style.padding = "0";
-    layer.append(marker);
+    usedNodeIds.add(nodeId);
+    const position = commentMarkerPosition({
+      doc,
+      labelHeight: FRAME_COMMENT_LABEL_HEIGHT,
+      occupiedRects,
+      target,
+    });
+    occupiedRects.push(position.rect);
+    layer.append(
+      createFrameCommentMarker({
+        comment,
+        doc,
+        nodeId,
+        position,
+      }),
+    );
   }
 }
+
+function shouldHideCommittedCommentMarkers(params: {
+  readonly comments: readonly HtmlDomEditComment[];
+  readonly editingCommentId: string | null;
+  readonly selectedNodeIds: readonly string[];
+}): boolean {
+  return (
+    params.editingCommentId === null &&
+    params.selectedNodeIds.length > 0 &&
+    !hasCommentForSelectedNodes({
+      comments: params.comments,
+      selectedNodeIds: params.selectedNodeIds,
+    })
+  );
+}
+
+export const deleteHtmlDomComment$ = command(
+  ({ get, set }, commentId: string) => {
+    const comments = get(internalComments$);
+    const deletedComment = comments.find((comment) => {
+      return comment.id === commentId;
+    });
+    if (!deletedComment) {
+      return;
+    }
+
+    const nextComments = comments.filter((comment) => {
+      return comment.id !== commentId;
+    });
+    const editingCommentId = get(internalEditingCommentId$);
+    const selectedNodeIds = get(internalSelectedNodeIds$);
+    const shouldResetDraft =
+      editingCommentId === commentId ||
+      deletedComment.targetNodeIds.some((nodeId) => {
+        return selectedNodeIds.includes(nodeId);
+      });
+    const doc = currentFrameDocument(get(internalIframeElement$));
+
+    set(internalComments$, nextComments);
+    set(internalPreparedPayload$, null);
+
+    if (shouldResetDraft) {
+      set(internalCommentText$, "");
+      set(internalSelectedNodeIds$, []);
+      set(internalCommentPopoverAnchor$, null);
+      set(internalEditingCommentId$, null);
+      syncFrameEditState(doc, {
+        hoveredNodeId: get(internalHoveredNodeId$),
+        selectedNodeIds: [],
+      });
+      syncFrameCommentMarkers(doc, nextComments);
+      return;
+    }
+
+    syncFrameCommentMarkers(
+      doc,
+      nextComments,
+      editingCommentId,
+      shouldHideCommittedCommentMarkers({
+        comments: nextComments,
+        editingCommentId,
+        selectedNodeIds,
+      }),
+    );
+  },
+);
+
+function flashFrameCommentTarget(element: Element): void {
+  element.removeAttribute(HTML_DOM_COMMENT_FLASH_ATTR);
+  element.getBoundingClientRect();
+  element.setAttribute(HTML_DOM_COMMENT_FLASH_ATTR, "true");
+  element.ownerDocument.defaultView?.setTimeout(() => {
+    element.removeAttribute(HTML_DOM_COMMENT_FLASH_ATTR);
+  }, 900);
+}
+
+export const focusHtmlDomComment$ = command(
+  ({ get, set }, commentId: string) => {
+    const comment = get(internalComments$).find((candidate) => {
+      return candidate.id === commentId;
+    });
+    const nodeId = comment?.targetNodeIds[0];
+    const doc = currentFrameDocument(get(internalIframeElement$));
+    const target = nodeId ? doc?.querySelector(nodeSelector(nodeId)) : null;
+    if (!nodeId || !doc || !target) {
+      return;
+    }
+
+    set(internalHoveredNodeId$, null);
+    set(internalEditingCommentId$, null);
+    set(internalCommentPopoverAnchor$, null);
+    set(internalSelectedNodeIds$, [nodeId]);
+    syncFrameEditState(doc, {
+      hoveredNodeId: null,
+      selectedNodeIds: [nodeId],
+    });
+    syncFrameCommentMarkers(doc, get(internalComments$));
+    target.scrollIntoView?.({
+      behavior: "smooth",
+      block: "center",
+      inline: "center",
+    });
+    flashFrameCommentTarget(target);
+  },
+);
 
 function currentFrameDocument(
   iframe: HTMLIFrameElement | null,
@@ -593,6 +1279,7 @@ export const setHtmlDomCommentIframeRef$ = onRef(
 );
 
 interface FrameCommentBindingParams {
+  readonly deleteComment: (commentId: string) => void;
   readonly doc: Document;
   readonly getComments: () => readonly HtmlDomEditComment[];
   readonly getDisabled: () => boolean;
@@ -687,12 +1374,14 @@ function bindFrameCommentEvents(params: FrameCommentBindingParams): () => void {
     if (params.getDisabled()) {
       return;
     }
+    if (closestCommentDeleteButton(event.target)) {
+      return;
+    }
     const markerNodeId = closestCommentMarker(event.target)?.getAttribute(
       HTML_DOM_COMMENT_MARKER_TARGET_ATTR,
     );
     if (markerNodeId) {
       params.setHoveredNodeId(markerNodeId);
-      openPopoverForNode(markerNodeId, "view");
       return;
     }
 
@@ -729,6 +1418,16 @@ function bindFrameCommentEvents(params: FrameCommentBindingParams): () => void {
     if (params.getDisabled()) {
       return;
     }
+    const deleteCommentId = closestCommentDeleteButton(
+      event.target,
+    )?.getAttribute(HTML_DOM_COMMENT_DELETE_ATTR);
+    if (deleteCommentId) {
+      event.preventDefault();
+      event.stopPropagation();
+      params.deleteComment(deleteCommentId);
+      return;
+    }
+
     const markerNodeId = closestCommentMarker(event.target)?.getAttribute(
       HTML_DOM_COMMENT_MARKER_TARGET_ATTR,
     );
@@ -777,13 +1476,28 @@ export const bindHtmlDomCommentFrame$ = command(
     }
 
     const syncMarkers = () => {
-      syncFrameCommentMarkers(doc, get(internalComments$));
+      const comments = get(internalComments$);
+      const editingCommentId = get(internalEditingCommentId$);
+      const selectedNodeIds = get(internalSelectedNodeIds$);
+      syncFrameCommentMarkers(
+        doc,
+        comments,
+        editingCommentId,
+        shouldHideCommittedCommentMarkers({
+          comments,
+          editingCommentId,
+          selectedNodeIds,
+        }),
+      );
     };
     const view = doc.defaultView;
     view?.addEventListener("scroll", syncMarkers, true);
     view?.addEventListener("resize", syncMarkers);
 
     const eventCleanup = bindFrameCommentEvents({
+      deleteComment: (commentId) => {
+        set(deleteHtmlDomComment$, commentId);
+      },
       doc,
       getComments: () => {
         return get(internalComments$);
@@ -804,7 +1518,22 @@ export const bindHtmlDomCommentFrame$ = command(
         set(internalCommentPopoverAnchor$, value);
       },
       setEditingCommentId: (value) => {
+        if (get(internalEditingCommentId$) === value) {
+          return;
+        }
+        const comments = get(internalComments$);
+        const selectedNodeIds = get(internalSelectedNodeIds$);
         set(internalEditingCommentId$, value);
+        syncFrameCommentMarkers(
+          doc,
+          comments,
+          value,
+          shouldHideCommittedCommentMarkers({
+            comments,
+            editingCommentId: value,
+            selectedNodeIds,
+          }),
+        );
       },
       setHoveredNodeId: (value) => {
         set(internalHoveredNodeId$, value);
@@ -817,11 +1546,32 @@ export const bindHtmlDomCommentFrame$ = command(
         set(internalCommentText$, value);
       },
       setSelectedNodeIds: (value) => {
+        const comments = get(internalComments$);
+        const editingCommentId = get(internalEditingCommentId$);
+        const previousSelectedNodeIds = get(internalSelectedNodeIds$);
+        const wasHidingMarkers = shouldHideCommittedCommentMarkers({
+          comments,
+          editingCommentId,
+          selectedNodeIds: previousSelectedNodeIds,
+        });
+        const shouldHideMarkers = shouldHideCommittedCommentMarkers({
+          comments,
+          editingCommentId,
+          selectedNodeIds: value,
+        });
         set(internalSelectedNodeIds$, value);
         syncFrameEditState(doc, {
           hoveredNodeId: get(internalHoveredNodeId$),
           selectedNodeIds: value,
         });
+        if (wasHidingMarkers !== shouldHideMarkers) {
+          syncFrameCommentMarkers(
+            doc,
+            comments,
+            editingCommentId,
+            shouldHideMarkers,
+          );
+        }
       },
       stage,
     });
@@ -866,6 +1616,11 @@ export const beginEditingCurrentHtmlDomComment$ = command(({ get, set }) => {
   set(internalEditingCommentId$, currentComment.id);
   set(internalCommentText$, currentComment.comment);
   set(internalPreparedPayload$, null);
+  syncFrameCommentMarkers(
+    currentFrameDocument(get(internalIframeElement$)),
+    get(internalComments$),
+    currentComment.id,
+  );
 });
 
 const resetHtmlDomCommentDraft$ = command(({ get, set }) => {
@@ -878,6 +1633,10 @@ const resetHtmlDomCommentDraft$ = command(({ get, set }) => {
     hoveredNodeId: get(internalHoveredNodeId$),
     selectedNodeIds: [],
   });
+  syncFrameCommentMarkers(
+    currentFrameDocument(get(internalIframeElement$)),
+    get(internalComments$),
+  );
 });
 
 export const addHtmlDomComment$ = command(({ get, set }) => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -1653,7 +1653,8 @@ describe("zero attachment chips", () => {
       expect(heroCommentMarker).toBeDefined();
     });
 
-    fireEvent.click(listDeleteButtons[1]!);
+    listDeleteButtons[1]!.focus();
+    await user.keyboard("{Enter}");
     await waitFor(() => {
       expect(
         within(commentsList).queryByText("Make the body copy warmer"),

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -24,6 +24,7 @@ import {
 import { Markdown } from "../../components/markdown.tsx";
 import { mockChatLifecycle } from "./chat-test-helpers.ts";
 import {
+  HTML_DOM_EDIT_SELECTED_ATTR,
   HTML_DOM_EDIT_OVERLAY_ATTR,
   HTML_DOM_NODE_ID_ATTR,
 } from "../html-dom-edit-protocol.ts";
@@ -252,6 +253,35 @@ function mockElementBox(
         width,
         x: 0,
         y: 0,
+      };
+    },
+  });
+}
+
+function mockElementRect(
+  element: Element,
+  {
+    height,
+    left,
+    top,
+    width,
+  }: { height: number; left: number; top: number; width: number },
+) {
+  Object.defineProperty(element, "getBoundingClientRect", {
+    configurable: true,
+    value: () => {
+      return {
+        bottom: top + height,
+        height,
+        left,
+        right: left + width,
+        toJSON: () => {
+          return {};
+        },
+        top,
+        width,
+        x: left,
+        y: top,
       };
     },
   });
@@ -1173,6 +1203,11 @@ describe("zero attachment chips", () => {
             targetNodeIds: [expect.any(String)],
             comment: "Make the hero headline shorter",
           },
+          {
+            id: expect.any(String),
+            targetNodeIds: [expect.any(String)],
+            comment: "Make the body copy warmer",
+          },
         ]);
         expect(body.html).toContain("Launch faster");
         return respond(200, {
@@ -1301,9 +1336,43 @@ describe("zero attachment chips", () => {
       const marker = frame.contentDocument?.querySelector<HTMLElement>(
         "[data-testid='html-dom-comment-marker']",
       );
+      const tag = marker?.querySelector<HTMLElement>(
+        "[data-testid='html-dom-comment-tag']",
+      );
+      const tagText = tag?.querySelector<HTMLElement>(
+        "[data-testid='html-dom-comment-tag-text']",
+      );
+      const deleteButton = marker?.querySelector<HTMLElement>(
+        "[data-testid='html-dom-comment-delete']",
+      );
       expect(marker).not.toBeNull();
-      expect(marker?.querySelector("svg")).not.toBeNull();
       expect(marker).toHaveAttribute(HTML_DOM_EDIT_OVERLAY_ATTR);
+      expect(marker).not.toHaveAttribute("title");
+      expect(marker).toHaveAttribute(
+        "data-vm0-html-comment-placement",
+        "right",
+      );
+      expect(
+        marker?.querySelector("[data-testid='html-dom-comment-anchor']"),
+      ).not.toBeNull();
+      expect(
+        marker?.querySelector("[data-testid='html-dom-comment-leader']"),
+      ).not.toBeNull();
+      expect(deleteButton).not.toBeNull();
+      expect(deleteButton?.style.opacity).toBe("0");
+      expect(deleteButton?.style.pointerEvents).toBe("none");
+      expect(frame.contentDocument?.head.textContent).toContain(
+        "[data-vm0-html-comment-target-node-id]:hover [data-vm0-html-comment-delete-id]",
+      );
+      expect(frame.contentDocument?.head.textContent).toContain(":hover");
+      expect(tag).toHaveTextContent("Make the headline shorter");
+      expect(tagText).toHaveTextContent("Make the headline shorter");
+      expect(tag?.style.maxWidth).toBe("136px");
+      expect(tag?.style.height).toBe("56px");
+      expect(tag?.style.overflow).toBe("hidden");
+      expect(tagText?.style.whiteSpace).toBe("normal");
+      expect(tagText?.style.overflowWrap).toBe("anywhere");
+      expect(tagText?.style.getPropertyValue("-webkit-line-clamp")).toBe("2");
     });
     expect(screen.getByTestId("html-dom-comment-toolbar")).toBeInTheDocument();
     expect(screen.getByTestId("html-dom-toolbar-send")).toBeEnabled();
@@ -1334,6 +1403,12 @@ describe("zero attachment chips", () => {
 
     title = frame.contentDocument?.querySelector("h1");
     expect(title).not.toBeNull();
+    mockElementRect(title!, {
+      height: 32,
+      left: 284,
+      top: 24,
+      width: 32,
+    });
     fireEvent.click(title!);
     const nextCommentTextArea = await screen.findByTestId(
       "html-dom-comment-textarea",
@@ -1347,6 +1422,11 @@ describe("zero attachment chips", () => {
           "[data-testid='html-dom-comment-marker']",
         ),
       ).not.toBeNull();
+      expect(
+        frame.contentDocument?.querySelector(
+          "[data-testid='html-dom-comment-marker']",
+        ),
+      ).toHaveAttribute("data-vm0-html-comment-placement", "bottom");
     });
 
     fireEvent.mouseOver(title!);
@@ -1392,22 +1472,9 @@ describe("zero attachment chips", () => {
       frame.contentDocument?.querySelector<HTMLElement>(
         "[data-testid='html-dom-comment-marker']",
       );
+    expect(updatedCommentMarker).not.toHaveAttribute("title");
     fireEvent.mouseOver(updatedCommentMarker!);
-    await waitFor(() => {
-      expect(screen.getByTestId("html-dom-comment-textarea")).toHaveValue(
-        "Make the hero headline shorter",
-      );
-      expect(screen.getByTestId("html-dom-comment-textarea")).toHaveAttribute(
-        "readonly",
-      );
-      expect(screen.getByTestId("html-dom-comment-add")).toBeDisabled();
-    });
-    fireEvent.mouseOut(updatedCommentMarker!, {
-      relatedTarget: frame.contentDocument?.body,
-    });
-    await waitFor(() => {
-      expect(screen.queryByTestId("html-dom-comment-popover")).toBeNull();
-    });
+    expect(screen.queryByTestId("html-dom-comment-popover")).toBeNull();
     fireEvent.mouseOver(title!);
     await waitFor(() => {
       expect(screen.getByTestId("html-dom-comment-textarea")).toHaveValue(
@@ -1422,12 +1489,204 @@ describe("zero attachment chips", () => {
       expect(screen.queryByTestId("html-dom-comment-popover")).toBeNull();
     });
 
+    const bodyCopy = frame.contentDocument?.querySelector("p");
+    expect(bodyCopy).not.toBeNull();
+    mockElementRect(bodyCopy!, {
+      height: 28,
+      left: 48,
+      top: 96,
+      width: 180,
+    });
+    fireEvent.click(bodyCopy!);
+    await waitFor(() => {
+      expect(screen.getByTestId("html-dom-comment-textarea")).toHaveValue("");
+      expect(
+        frame.contentDocument?.querySelectorAll(
+          "[data-testid='html-dom-comment-marker']",
+        ),
+      ).toHaveLength(0);
+    });
+    await user.type(
+      await screen.findByTestId("html-dom-comment-textarea"),
+      "Make the body copy warmer",
+    );
+    fireEvent.keyDown(screen.getByTestId("html-dom-comment-textarea"), {
+      key: "Enter",
+    });
+    await waitFor(() => {
+      expect(
+        frame.contentDocument?.querySelectorAll(
+          "[data-testid='html-dom-comment-marker']",
+        ),
+      ).toHaveLength(2);
+    });
+    expect(
+      screen.getByTestId("html-dom-toolbar-comments-count"),
+    ).toHaveTextContent("2");
+
+    const bodyCommentMarker = Array.from(
+      frame.contentDocument?.querySelectorAll<HTMLElement>(
+        "[data-testid='html-dom-comment-marker']",
+      ) ?? [],
+    ).find((marker) => {
+      return marker.textContent?.includes("Make the body copy warmer");
+    });
+    expect(bodyCommentMarker).toBeDefined();
+    fireEvent.click(
+      bodyCommentMarker!.querySelector<HTMLElement>(
+        "[data-testid='html-dom-comment-delete']",
+      )!,
+    );
+    await waitFor(() => {
+      expect(
+        frame.contentDocument?.querySelectorAll(
+          "[data-testid='html-dom-comment-marker']",
+        ),
+      ).toHaveLength(1);
+      expect(
+        screen.getByTestId("html-dom-toolbar-comments-count"),
+      ).toHaveTextContent("1");
+    });
+
+    fireEvent.click(bodyCopy!);
+    await waitFor(() => {
+      expect(screen.getByTestId("html-dom-comment-textarea")).toHaveValue("");
+    });
+    await user.type(
+      await screen.findByTestId("html-dom-comment-textarea"),
+      "Make the body copy warmer",
+    );
+    fireEvent.keyDown(screen.getByTestId("html-dom-comment-textarea"), {
+      key: "Enter",
+    });
+    await waitFor(() => {
+      expect(
+        frame.contentDocument?.querySelectorAll(
+          "[data-testid='html-dom-comment-marker']",
+        ),
+      ).toHaveLength(2);
+    });
+
+    fireEvent.click(title!);
+    await waitFor(() => {
+      const visibleMarkers = frame.contentDocument?.querySelectorAll(
+        "[data-testid='html-dom-comment-marker']",
+      );
+      expect(visibleMarkers).toHaveLength(1);
+      expect(
+        visibleMarkers?.[0]?.querySelector(
+          "[data-testid='html-dom-comment-tag']",
+        ),
+      ).toHaveTextContent("Make the hero headline shorter");
+      expect(screen.getByTestId("html-dom-comment-textarea")).toHaveValue(
+        "Make the hero headline shorter",
+      );
+      expect(
+        screen.getByTestId("html-dom-comment-textarea"),
+      ).not.toHaveAttribute("readonly");
+    });
+    fireEvent.keyDown(screen.getByTestId("html-dom-comment-textarea"), {
+      key: "Enter",
+    });
+    await waitFor(() => {
+      expect(screen.queryByTestId("html-dom-comment-popover")).toBeNull();
+      expect(
+        frame.contentDocument?.querySelectorAll(
+          "[data-testid='html-dom-comment-marker']",
+        ),
+      ).toHaveLength(2);
+    });
+
     click(screen.getByTestId("html-dom-toolbar-comments"));
     const commentsList = await screen.findByTestId("html-dom-comments-list");
-    expect(within(commentsList).getByText("Comment 1")).toBeInTheDocument();
+    expect(within(commentsList).queryByText("Comment 1")).toBeNull();
+    const heroListItem = within(commentsList).getByText(
+      "Make the hero headline shorter",
+    );
+    expect(heroListItem).toBeInTheDocument();
     expect(
-      within(commentsList).getByText("Make the hero headline shorter"),
+      within(commentsList).getByText("Make the body copy warmer"),
     ).toBeInTheDocument();
+    const listDeleteButtons =
+      within(commentsList).getAllByLabelText("Delete comment");
+    expect(listDeleteButtons).toHaveLength(2);
+    expect(listDeleteButtons[0]).toHaveClass("opacity-0");
+    expect(listDeleteButtons[0]).toHaveClass("group-hover/comment:opacity-100");
+
+    fireEvent.click(heroListItem);
+    await waitFor(() => {
+      expect(title).toHaveAttribute(HTML_DOM_EDIT_SELECTED_ATTR, "true");
+      expect(title).toHaveAttribute("data-vm0-html-comment-flash", "true");
+    });
+    mockElementRect(title!, {
+      height: 32,
+      left: 284,
+      top: -80,
+      width: 32,
+    });
+    fireEvent.scroll(frame.contentDocument!);
+    await waitFor(() => {
+      const heroCommentMarker = Array.from(
+        frame.contentDocument?.querySelectorAll<HTMLElement>(
+          "[data-testid='html-dom-comment-marker']",
+        ) ?? [],
+      ).find((marker) => {
+        return marker.textContent?.includes("Make the hero headline shorter");
+      });
+      expect(heroCommentMarker).toBeUndefined();
+    });
+    mockElementRect(title!, {
+      height: 32,
+      left: 284,
+      top: 24,
+      width: 32,
+    });
+    fireEvent.scroll(frame.contentDocument!);
+    await waitFor(() => {
+      const heroCommentMarker = Array.from(
+        frame.contentDocument?.querySelectorAll<HTMLElement>(
+          "[data-testid='html-dom-comment-marker']",
+        ) ?? [],
+      ).find((marker) => {
+        return marker.textContent?.includes("Make the hero headline shorter");
+      });
+      expect(heroCommentMarker).toBeDefined();
+    });
+
+    fireEvent.click(listDeleteButtons[1]!);
+    await waitFor(() => {
+      expect(
+        within(commentsList).queryByText("Make the body copy warmer"),
+      ).toBeNull();
+      expect(
+        frame.contentDocument?.querySelectorAll(
+          "[data-testid='html-dom-comment-marker']",
+        ),
+      ).toHaveLength(1);
+      expect(
+        screen.getByTestId("html-dom-toolbar-comments-count"),
+      ).toHaveTextContent("1");
+    });
+
+    click(screen.getByTestId("html-dom-toolbar-comments"));
+    fireEvent.click(bodyCopy!);
+    await waitFor(() => {
+      expect(screen.getByTestId("html-dom-comment-textarea")).toHaveValue("");
+    });
+    await user.type(
+      await screen.findByTestId("html-dom-comment-textarea"),
+      "Make the body copy warmer",
+    );
+    fireEvent.keyDown(screen.getByTestId("html-dom-comment-textarea"), {
+      key: "Enter",
+    });
+    await waitFor(() => {
+      expect(
+        frame.contentDocument?.querySelectorAll(
+          "[data-testid='html-dom-comment-marker']",
+        ),
+      ).toHaveLength(2);
+    });
 
     click(screen.getByTestId("html-dom-toolbar-send"));
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/html-dom-comment-editor.tsx
+++ b/turbo/apps/platform/src/views/zero-page/html-dom-comment-editor.tsx
@@ -4,6 +4,7 @@ import {
   IconLoader2,
   IconMessageCircle,
   IconSend,
+  IconTrash,
 } from "@tabler/icons-react";
 import { useGet, useSet } from "ccstate-react";
 import { detach, Reason } from "../../signals/utils.ts";
@@ -11,7 +12,9 @@ import {
   addHtmlDomComment$,
   beginEditingCurrentHtmlDomComment$,
   bindHtmlDomCommentFrame$,
+  deleteHtmlDomComment$,
   discardHtmlDomComments$,
+  focusHtmlDomComment$,
   htmlDomCommentEditorModel$,
   sendHtmlDomEditRequest$,
   setHtmlDomCommentIframeRef$,
@@ -22,6 +25,7 @@ import {
   type HtmlDomCommentEditorModel,
 } from "../../signals/zero-page/html-dom-comment-editor.ts";
 import type {
+  HtmlDomEditComment,
   HtmlDomEditDraft,
   HtmlDomEditPayload,
 } from "./html-dom-edit-types.ts";
@@ -109,6 +113,76 @@ function HtmlDomCommentStage({
   );
 }
 
+function HtmlDomCommentsList({
+  comments,
+}: {
+  readonly comments: readonly HtmlDomEditComment[];
+}) {
+  const deleteComment = useSet(deleteHtmlDomComment$);
+  const focusComment = useSet(focusHtmlDomComment$);
+
+  return (
+    <div
+      className="absolute bottom-full left-0 mb-3 w-[min(360px,calc(100vw-32px))] overflow-hidden rounded-xl border border-border/80 bg-background/98 p-2 shadow-2xl ring-1 ring-black/5 backdrop-blur"
+      data-testid="html-dom-comments-list"
+    >
+      <div className="flex items-center justify-between px-2 pb-2 pt-1">
+        <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Comments
+        </div>
+        <div className="rounded-full bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-700">
+          {comments.length}
+        </div>
+      </div>
+      {comments.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-border/80 bg-muted/20 px-3 py-4 text-center text-sm text-muted-foreground">
+          No comments yet
+        </div>
+      ) : (
+        <div className="max-h-64 space-y-1.5 overflow-auto pr-1">
+          {comments.map((comment) => {
+            const focusCurrentComment = () => {
+              focusComment(comment.id);
+            };
+            return (
+              <div
+                key={comment.id}
+                role="button"
+                tabIndex={0}
+                className="group/comment relative cursor-pointer rounded-lg border border-transparent bg-muted/35 px-3 py-2.5 pr-10 text-left transition-colors hover:border-blue-200 hover:bg-blue-50/70 focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-500/30"
+                onClick={focusCurrentComment}
+                onKeyDown={(event: KeyboardEvent<HTMLDivElement>) => {
+                  if (event.key !== "Enter" && event.key !== " ") {
+                    return;
+                  }
+                  event.preventDefault();
+                  focusCurrentComment();
+                }}
+              >
+                <div className="line-clamp-3 whitespace-pre-wrap break-words text-sm leading-5 text-foreground">
+                  {comment.comment}
+                </div>
+                <button
+                  type="button"
+                  aria-label="Delete comment"
+                  className="absolute right-2 top-2 inline-flex h-7 w-7 items-center justify-center rounded-full border border-blue-200 bg-background text-blue-600 opacity-0 shadow-sm transition-opacity hover:bg-blue-600 hover:text-white focus:opacity-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1 group-hover/comment:opacity-100"
+                  data-testid="html-dom-comments-list-delete"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    deleteComment(comment.id);
+                  }}
+                >
+                  <IconTrash size={14} stroke={2} />
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
 function HtmlDomCommentToolbar({
   disabled,
   model,
@@ -134,34 +208,7 @@ function HtmlDomCommentToolbar({
     <div className="pointer-events-none absolute inset-x-0 bottom-4 z-30 flex justify-center px-4">
       <div className="relative pointer-events-auto">
         {!disabled && model.commentsOpen && (
-          <div
-            className="absolute bottom-full left-0 mb-2 w-[min(320px,calc(100vw-32px))] rounded-lg border border-border/70 bg-background p-3 shadow-xl"
-            data-testid="html-dom-comments-list"
-          >
-            {model.comments.length === 0 ? (
-              <div className="text-sm text-muted-foreground">
-                No comments yet
-              </div>
-            ) : (
-              <div className="max-h-56 space-y-2 overflow-auto">
-                {model.comments.map((comment, index) => {
-                  return (
-                    <div
-                      key={comment.id}
-                      className="rounded-md bg-muted/30 px-3 py-2"
-                    >
-                      <div className="mb-1 text-xs font-medium text-muted-foreground">
-                        Comment {index + 1}
-                      </div>
-                      <div className="whitespace-pre-wrap break-words text-sm text-foreground">
-                        {comment.comment}
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            )}
-          </div>
+          <HtmlDomCommentsList comments={model.comments} />
         )}
         <div
           className="flex items-center gap-2 rounded-full border border-border/70 bg-background/95 px-2 py-2 shadow-xl backdrop-blur"

--- a/turbo/apps/platform/src/views/zero-page/html-dom-comment-editor.tsx
+++ b/turbo/apps/platform/src/views/zero-page/html-dom-comment-editor.tsx
@@ -167,6 +167,9 @@ function HtmlDomCommentsList({
                   aria-label="Delete comment"
                   className="absolute right-2 top-2 inline-flex h-7 w-7 items-center justify-center rounded-full border border-blue-200 bg-background text-blue-600 opacity-0 shadow-sm transition-opacity hover:bg-blue-600 hover:text-white focus:opacity-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1 group-hover/comment:opacity-100"
                   data-testid="html-dom-comments-list-delete"
+                  onKeyDown={(event) => {
+                    event.stopPropagation();
+                  }}
                   onClick={(event) => {
                     event.stopPropagation();
                     deleteComment(comment.id);


### PR DESCRIPTION
## Summary
- Replace hosted-site HTML edit comment markers with inline comment tags connected to their targets.
- Add placement, collision avoidance, two-line clamping, viewport visibility handling, and hover-only delete controls.
- Improve the comments list UI with delete actions and click-to-focus behavior with scroll and flash feedback.

## Why
The previous icon-only markers made comments hard to scan and could become misleading when targets scrolled out of view. This makes comments visible near their targets while hiding markers whose targets are outside the current iframe viewport.

## Validation
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app exec vitest src/views/zero-page/__tests__/zero-attachment-chips.test.tsx`
- `git diff --check`