### PR TITLE
perf: preload avatar maker svg layers

### DIFF
--- a/turbo/apps/platform/src/signals/automation-page/workflow-trigger-automation-dialog.ts
+++ b/turbo/apps/platform/src/signals/automation-page/workflow-trigger-automation-dialog.ts
@@ -1,7 +1,7 @@
 import { command, computed, state } from "ccstate";
 
 type WorkflowAutomationDialogStep = 1 | 2;
-export type WorkflowAutomationDialogIntent =
+type WorkflowAutomationDialogIntent =
   | "automation"
   | "workflow"
   | "workflow-chat";
@@ -60,17 +60,6 @@ export const openCreateWorkflowDialog$ = command(({ set }) => {
   set(workflowAutomationAgentSelectionLockedState$, false);
   set(workflowAutomationDialogIntentState$, "workflow-chat");
 });
-
-export const openWorkflowAutomationDialogForAgent$ = command(
-  ({ set }, agentId: string) => {
-    set(workflowAutomationDialogOpenState$, true);
-    set(workflowAutomationDialogStepState$, 2);
-    set(selectedWorkflowAutomationAgentIdState$, agentId);
-    set(workflowAutomationAgentQueryState$, "");
-    set(workflowAutomationAgentSelectionLockedState$, true);
-    set(workflowAutomationDialogIntentState$, "workflow");
-  },
-);
 
 export const startCreateWorkflowFromAutomationDialog$ = command(({ set }) => {
   set(workflowAutomationDialogStepState$, 1);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-settings-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-settings-tab.test.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
   zeroAgentInstructionsContract,
@@ -17,6 +17,127 @@ import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 const context = testContext();
 
 const AGENT_ID = "a0000000-0000-4000-a000-000000000020";
+const AVATAR_SVG_PRELOAD_CACHE_KEY = "vm0AvatarSvgPreloadCache";
+
+function resetAvatarSvgPreloadCache(): void {
+  Reflect.deleteProperty(globalThis, AVATAR_SVG_PRELOAD_CACHE_KEY);
+}
+
+function trackAvatarSvgImagePreloads(): {
+  readonly srcs: readonly string[];
+  readonly restore: () => void;
+} {
+  const srcs: string[] = [];
+  const originalGlobalImage = Object.getOwnPropertyDescriptor(
+    globalThis,
+    "Image",
+  );
+  const originalWindowImage = Object.getOwnPropertyDescriptor(window, "Image");
+
+  class TestImagePreload {
+    decoding = "";
+    fetchPriority = "";
+    #src = "";
+
+    get src(): string {
+      return this.#src;
+    }
+
+    set src(value: string) {
+      this.#src = value;
+      srcs.push(value);
+    }
+  }
+
+  const imageConstructor = TestImagePreload as unknown as typeof Image;
+  Object.defineProperty(globalThis, "Image", {
+    configurable: true,
+    value: imageConstructor,
+    writable: true,
+  });
+  Object.defineProperty(window, "Image", {
+    configurable: true,
+    value: imageConstructor,
+    writable: true,
+  });
+
+  return {
+    srcs,
+    restore: () => {
+      if (originalGlobalImage) {
+        Object.defineProperty(globalThis, "Image", originalGlobalImage);
+      } else {
+        Reflect.deleteProperty(globalThis, "Image");
+      }
+      if (originalWindowImage) {
+        Object.defineProperty(window, "Image", originalWindowImage);
+      } else {
+        Reflect.deleteProperty(window, "Image");
+      }
+    },
+  };
+}
+
+function mockImmediateIdleCallback(): () => void {
+  const originalRequestIdleCallback = Object.getOwnPropertyDescriptor(
+    window,
+    "requestIdleCallback",
+  );
+  Object.defineProperty(window, "requestIdleCallback", {
+    configurable: true,
+    value: (callback: IdleRequestCallback): number => {
+      callback({
+        didTimeout: false,
+        timeRemaining: () => {
+          return 50;
+        },
+      });
+      return 1;
+    },
+    writable: true,
+  });
+
+  return () => {
+    if (originalRequestIdleCallback) {
+      Object.defineProperty(
+        window,
+        "requestIdleCallback",
+        originalRequestIdleCallback,
+      );
+    } else {
+      Reflect.deleteProperty(window, "requestIdleCallback");
+    }
+  };
+}
+
+function mockSaveDataPreference(saveData: boolean): () => void {
+  const originalConnection = Object.getOwnPropertyDescriptor(
+    navigator,
+    "connection",
+  );
+  Object.defineProperty(navigator, "connection", {
+    configurable: true,
+    value: { saveData },
+  });
+
+  return () => {
+    if (originalConnection) {
+      Object.defineProperty(navigator, "connection", originalConnection);
+    } else {
+      Reflect.deleteProperty(navigator, "connection");
+    }
+  };
+}
+
+function avatarSvgPreloadSrcs(srcs: readonly string[]): string[] {
+  return srcs.filter((src) => {
+    return src.includes("/platform/views/zero-page/assets/avatar-svg/");
+  });
+}
+
+function uniqueAvatarSvgPreloadSrcs(srcs: readonly string[]): string[] {
+  return Array.from(new Set(avatarSvgPreloadSrcs(srcs)));
+}
 
 function prepareAgentProfile(): void {
   let detail: ZeroAgentResponse = {
@@ -72,6 +193,101 @@ function prepareAgentProfile(): void {
 }
 
 describe("zero settings tab", () => {
+  beforeEach(() => {
+    resetAvatarSvgPreloadCache();
+  });
+
+  afterEach(() => {
+    resetAvatarSvgPreloadCache();
+  });
+
+  it("preloads avatar SVG layers after opening Avatar Maker", async () => {
+    prepareAgentProfile();
+    const imagePreloads = trackAvatarSvgImagePreloads();
+    const restoreIdleCallback = mockImmediateIdleCallback();
+
+    try {
+      detachedSetupPage({ context, path: `/agents/${AGENT_ID}?tab=profile` });
+
+      const trigger = await screen.findByLabelText("Create custom avatar");
+      expect(avatarSvgPreloadSrcs(imagePreloads.srcs)).toHaveLength(0);
+
+      click(trigger);
+
+      await waitFor(() => {
+        expect(uniqueAvatarSvgPreloadSrcs(imagePreloads.srcs)).toHaveLength(
+          225,
+        );
+      });
+
+      const allAvatarSrcs = avatarSvgPreloadSrcs(imagePreloads.srcs);
+      const uniqueAvatarSrcs = uniqueAvatarSvgPreloadSrcs(imagePreloads.srcs);
+      expect(allAvatarSrcs).toHaveLength(225);
+      expect(
+        uniqueAvatarSrcs.filter((src) => {
+          return src.includes("/head-r");
+        }),
+      ).toHaveLength(25);
+      expect(
+        uniqueAvatarSrcs.filter((src) => {
+          return src.includes("/face-r");
+        }),
+      ).toHaveLength(75);
+      expect(
+        uniqueAvatarSrcs.filter((src) => {
+          return src.includes("/hair-r");
+        }),
+      ).toHaveLength(125);
+      expect(
+        uniqueAvatarSrcs.some((src) => {
+          return src.includes("/web/assets/avatar-svg/");
+        }),
+      ).toBeFalsy();
+
+      click(screen.getByText("Cancel"));
+
+      await waitFor(() => {
+        expect(screen.queryAllByText("Give your agent a face")).toHaveLength(0);
+      });
+
+      click(screen.getByLabelText("Create custom avatar"));
+
+      await waitFor(() => {
+        expect(
+          screen.getAllByText("Give your agent a face").length,
+        ).toBeGreaterThan(0);
+      });
+      expect(avatarSvgPreloadSrcs(imagePreloads.srcs)).toHaveLength(225);
+    } finally {
+      restoreIdleCallback();
+      imagePreloads.restore();
+    }
+  });
+
+  it("does not preload the full avatar SVG catalog when save-data is enabled", async () => {
+    prepareAgentProfile();
+    const imagePreloads = trackAvatarSvgImagePreloads();
+    const restoreIdleCallback = mockImmediateIdleCallback();
+    const restoreSaveDataPreference = mockSaveDataPreference(true);
+
+    try {
+      detachedSetupPage({ context, path: `/agents/${AGENT_ID}?tab=profile` });
+
+      click(await screen.findByLabelText("Create custom avatar"));
+
+      await waitFor(() => {
+        expect(
+          screen.getAllByText("Give your agent a face").length,
+        ).toBeGreaterThan(0);
+      });
+      expect(avatarSvgPreloadSrcs(imagePreloads.srcs)).toHaveLength(0);
+    } finally {
+      restoreSaveDataPreference();
+      restoreIdleCallback();
+      imagePreloads.restore();
+    }
+  });
+
   it("creates and saves a custom avatar from the profile page", async () => {
     prepareAgentProfile();
 

--- a/turbo/apps/platform/src/views/zero-page/avatar-maker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/avatar-maker.tsx
@@ -19,7 +19,10 @@ import {
   IconChevronRight,
   IconDice,
 } from "@tabler/icons-react";
-import type { AvatarSvgConfig } from "./avatar-svg-utils.ts";
+import {
+  preloadAvatarSvgLayerAssets,
+  type AvatarSvgConfig,
+} from "./avatar-svg-utils.ts";
 import { AvatarSvgPreview } from "./avatar-svg-preview.tsx";
 import {
   bestEffort,
@@ -395,6 +398,16 @@ interface AvatarMakerProps {
   trigger?: (openMaker: () => void) => React.ReactNode;
 }
 
+function preloadAvatarSvgLayerAssetsOnRef(element: HTMLSpanElement | null) {
+  if (element) {
+    preloadAvatarSvgLayerAssets();
+  }
+}
+
+function AvatarSvgLayerPreloadTrigger() {
+  return <span hidden ref={preloadAvatarSvgLayerAssetsOnRef} />;
+}
+
 export function AvatarMaker({ onConfirm, trigger }: AvatarMakerProps) {
   const open = useGet(avatarMakerOpen$);
   const openMaker = useSet(openAvatarMaker$);
@@ -449,6 +462,7 @@ export function AvatarMaker({ onConfirm, trigger }: AvatarMakerProps) {
           }
         }}
       >
+        {open ? <AvatarSvgLayerPreloadTrigger /> : null}
         <AvatarMakerDialogBody onConfirm={onConfirm} />
       </Dialog>
     </>

--- a/turbo/apps/platform/src/views/zero-page/avatar-svg-utils.ts
+++ b/turbo/apps/platform/src/views/zero-page/avatar-svg-utils.ts
@@ -11,11 +11,34 @@ export interface AvatarSvgConfig {
   intensity: "d" | "m" | "h"; // default, medium, high
 }
 
+const AVATAR_ROTATIONS = [1, 2, 3, 4, 5] as const;
+const AVATAR_SKINS = [0, 1, 2, 3, 4] as const;
+const AVATAR_HAIR_STYLES = [1, 2, 3, 4, 5] as const;
+const AVATAR_HAIR_COLORS = [1, 2, 3, 4, 5] as const;
+const AVATAR_EXPRESSIONS = [1, 2, 3, 4, 5] as const;
+const AVATAR_INTENSITIES = ["d", "m", "h"] as const;
+const AVATAR_SVG_PRELOAD_BATCH_SIZE = 12;
+const AVATAR_SVG_PRELOAD_IDLE_TIMEOUT_MS = 1000;
+const AVATAR_SVG_PRELOAD_CACHE_KEY = "vm0AvatarSvgPreloadCache";
+
 const INTENSITY_MAP = {
   d: "d",
   m: "m",
   h: "h",
 } as const;
+
+interface AvatarSvgPreloadCache {
+  readonly preloads: Map<string, HTMLImageElement>;
+  readonly scheduledUrls: Set<string>;
+}
+
+interface NavigatorConnectionLike {
+  readonly saveData?: boolean;
+}
+
+interface NavigatorWithConnection extends Navigator {
+  readonly connection?: NavigatorConnectionLike;
+}
 
 /**
  * Serialize an avatar config to a storable string like `svg:r1s0h3c2f1d`.
@@ -65,17 +88,160 @@ export function avatarSvgLayerUrls(config: AvatarSvgConfig): {
   };
 }
 
+export function allAvatarSvgLayerUrls(): string[] {
+  const urls: string[] = [];
+  for (const rotation of AVATAR_ROTATIONS) {
+    for (const skin of AVATAR_SKINS) {
+      urls.push(avatarSvgAssetUrl(`head-r${rotation}-s${skin}.svg`));
+    }
+    for (const expression of AVATAR_EXPRESSIONS) {
+      for (const intensity of AVATAR_INTENSITIES) {
+        urls.push(
+          avatarSvgAssetUrl(
+            `face-r${rotation}-f${expression}-${intensity}.svg`,
+          ),
+        );
+      }
+    }
+    for (const hairStyle of AVATAR_HAIR_STYLES) {
+      for (const hairColor of AVATAR_HAIR_COLORS) {
+        urls.push(
+          avatarSvgAssetUrl(
+            `hair-r${rotation}-h${hairStyle}-c${hairColor}.svg`,
+          ),
+        );
+      }
+    }
+  }
+  return Array.from(new Set(urls));
+}
+
+function avatarSvgPreloadCache(): AvatarSvgPreloadCache {
+  const existingCache = Reflect.get(
+    globalThis,
+    AVATAR_SVG_PRELOAD_CACHE_KEY,
+  ) as AvatarSvgPreloadCache | undefined;
+  if (existingCache !== undefined) {
+    return existingCache;
+  }
+
+  const cache: AvatarSvgPreloadCache = {
+    preloads: new Map<string, HTMLImageElement>(),
+    scheduledUrls: new Set<string>(),
+  };
+  Reflect.set(globalThis, AVATAR_SVG_PRELOAD_CACHE_KEY, cache);
+  return cache;
+}
+
+function prefersReducedData(): boolean {
+  if (typeof navigator === "undefined") {
+    return false;
+  }
+  const connection = (navigator as NavigatorWithConnection).connection;
+  return connection?.saveData === true;
+}
+
+function preloadAvatarSvgLayerUrl(
+  url: string,
+  cache: AvatarSvgPreloadCache,
+): void {
+  if (cache.preloads.has(url)) {
+    return;
+  }
+
+  const image = new Image();
+  image.decoding = "async";
+  image.fetchPriority = "low";
+  image.src = url;
+  cache.preloads.set(url, image);
+}
+
+function scheduleAvatarSvgPreloadBatch(callback: IdleRequestCallback): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  if (typeof window.requestIdleCallback === "function") {
+    window.requestIdleCallback(callback, {
+      timeout: AVATAR_SVG_PRELOAD_IDLE_TIMEOUT_MS,
+    });
+    return;
+  }
+
+  window.setTimeout(() => {
+    callback({
+      didTimeout: true,
+      timeRemaining: () => {
+        return 0;
+      },
+    });
+  }, 16);
+}
+
+function scheduleAvatarSvgPreloadBatches(
+  urls: readonly string[],
+  cache: AvatarSvgPreloadCache,
+): void {
+  let nextIndex = 0;
+
+  const preloadBatch: IdleRequestCallback = (deadline) => {
+    let processed = 0;
+    while (
+      nextIndex < urls.length &&
+      processed < AVATAR_SVG_PRELOAD_BATCH_SIZE
+    ) {
+      if (
+        !deadline.didTimeout &&
+        processed > 0 &&
+        deadline.timeRemaining() < 4
+      ) {
+        break;
+      }
+      preloadAvatarSvgLayerUrl(urls[nextIndex]!, cache);
+      nextIndex += 1;
+      processed += 1;
+    }
+
+    if (nextIndex < urls.length) {
+      scheduleAvatarSvgPreloadBatch(preloadBatch);
+    }
+  };
+
+  scheduleAvatarSvgPreloadBatch(preloadBatch);
+}
+
+export function preloadAvatarSvgLayerAssets(): void {
+  if (
+    typeof Image === "undefined" ||
+    typeof window === "undefined" ||
+    prefersReducedData()
+  ) {
+    return;
+  }
+
+  const cache = avatarSvgPreloadCache();
+  const urlsToPreload = allAvatarSvgLayerUrls().filter((url) => {
+    return !cache.scheduledUrls.has(url);
+  });
+  if (urlsToPreload.length === 0) {
+    return;
+  }
+
+  for (const url of urlsToPreload) {
+    cache.scheduledUrls.add(url);
+  }
+  scheduleAvatarSvgPreloadBatches(urlsToPreload, cache);
+}
+
 export function randomAvatarSvgConfig(): AvatarSvgConfig {
   const rand = (min: number, max: number) => {
     return Math.floor(Math.random() * (max - min + 1)) + min;
   };
-  const intensities = ["d", "m", "h"] as const;
   return {
     rotation: rand(1, 5),
     skin: rand(0, 4),
     hairStyle: rand(1, 5),
     hairColor: rand(1, 5),
     expression: rand(1, 5),
-    intensity: intensities[rand(0, 2)]!,
+    intensity: AVATAR_INTENSITIES[rand(0, AVATAR_INTENSITIES.length - 1)]!,
   };
 }

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permission-policy-toggle.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permission-policy-toggle.tsx
@@ -1,7 +1,7 @@
 import { IconBan, IconCheck, IconCircleHalf2 } from "@tabler/icons-react";
 
-export type PermissionPolicyToggleValue = "allow" | "deny";
-export type PermissionPolicyToggleState =
+type PermissionPolicyToggleValue = "allow" | "deny";
+type PermissionPolicyToggleState =
   | PermissionPolicyToggleValue
   | "ask"
   | "mixed";
@@ -15,7 +15,7 @@ export function PermissionPolicyMixedBadge() {
   );
 }
 
-export function permissionPolicyButtonClass({
+function permissionPolicyButtonClass({
   active,
   disabled,
   tone,

--- a/turbo/apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx
@@ -862,7 +862,7 @@ export function CreateWorkflowAutomationDialog() {
   );
 }
 
-export function WorkflowTriggerAutomationList({
+function WorkflowTriggerAutomationList({
   entries,
   displayTimezone,
   loading,


### PR DESCRIPTION
## Summary

- Add a generated avatar SVG layer catalog and low-priority idle preloader for Avatar Maker.
- Trigger preloading only when Avatar Maker opens, using a hidden callback-ref trigger so normal page render does not fetch the full catalog.
- Deduplicate scheduled/preloaded URLs across repeated opens and skip full-catalog preloading when save-data is enabled.
- Remove stale exported-only symbols that blocked the required knip pre-commit check.

## Tests

- `cd turbo && pnpm -F @vm0/app exec vitest src/views/zero-page/__tests__/zero-settings-tab.test.tsx`
- `cd turbo && pnpm -F @vm0/app run check-types`
- `cd turbo && pnpm -F @vm0/app run lint`
- `cd turbo && pnpm knip --cache`
- pre-commit hook: prettier, knip, full turbo check-types

Closes #19408