### PR TITLE
fix: keep chat F2 rename available

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
@@ -8,7 +8,8 @@ import {
 } from "./chat-thread-panes.ts";
 import type { ChatThreadSignals } from "./chat-thread-signals.ts";
 import type { ScrollStepDirection } from "../auto-scroll.ts";
-import { onRef } from "../utils.ts";
+import { onDomEventFn, onRef } from "../utils.ts";
+import { openRenameChatThreadDialog$ } from "../zero-page/zero-sidebar-state.ts";
 
 /**
  * Snapshot row shape consumed by `navigateToAdjacentThread$`. The caller
@@ -57,6 +58,13 @@ function isDocumentScrollTarget(root: HTMLElement, target: EventTarget | null) {
   const doc = root.ownerDocument;
   return (
     target === doc || target === doc.body || target === doc.documentElement
+  );
+}
+
+function isChatShortcutTarget(root: HTMLElement, target: EventTarget | null) {
+  return (
+    isDocumentScrollTarget(root, target) ||
+    (target instanceof Node && root.contains(target))
   );
 }
 
@@ -118,9 +126,36 @@ export const setChatKeyboardScrollRoot$ = onRef(
       }
     };
 
+    const onGlobalChatKeyDown = onDomEventFn(async (event: KeyboardEvent) => {
+      if (
+        event.defaultPrevented ||
+        !matchShortcut("f2", event) ||
+        hasOpenDialog(el.ownerDocument) ||
+        !isChatShortcutTarget(el, event.target)
+      ) {
+        return;
+      }
+      const mainThread = get(currentLeftThread$);
+      if (!mainThread) {
+        return;
+      }
+
+      event.preventDefault();
+      const threadData = await get(mainThread.threadData$);
+      signal.throwIfAborted();
+      set(openRenameChatThreadDialog$, {
+        threadId: mainThread.threadId,
+        title: threadData?.title,
+      });
+    });
+
     el.addEventListener("focusin", markActiveThread, { signal });
     el.addEventListener("pointerdown", markActiveThread, { signal });
     el.addEventListener("pointerover", markActiveThread, { signal });
+    document.addEventListener("keydown", onGlobalChatKeyDown, {
+      capture: true,
+      signal,
+    });
     document.addEventListener("keydown", onKeyDown, { signal });
   }),
 );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -843,6 +843,14 @@ function chatComposerTextarea(): HTMLTextAreaElement {
   return element;
 }
 
+function activeElementIsInside(element: HTMLElement): boolean {
+  return (
+    document.activeElement === element ||
+    (document.activeElement instanceof Node &&
+      element.contains(document.activeElement))
+  );
+}
+
 function setScrollMetrics(
   element: HTMLElement,
   metrics: { scrollHeight: number; clientHeight: number },
@@ -2876,7 +2884,7 @@ describe("chat lifecycle", () => {
     );
   });
 
-  it("returns document focus to the main chat thread after rename", async () => {
+  it("keeps F2 rename available after renaming the current chat", async () => {
     const user = userEvent.setup({ delay: null });
     mockResizeObserver();
     mockKeyboardNavigationThreads();
@@ -2910,20 +2918,9 @@ describe("chat lifecycle", () => {
       ).not.toBeInTheDocument();
     });
 
-    const previousBodyTabIndex = document.body.getAttribute("tabindex");
-    try {
-      document.body.tabIndex = -1;
-      document.body.focus();
-      await waitFor(() => {
-        expect(document.activeElement).toBe(threadRegion);
-      });
-    } finally {
-      if (previousBodyTabIndex === null) {
-        document.body.removeAttribute("tabindex");
-      } else {
-        document.body.setAttribute("tabindex", previousBodyTabIndex);
-      }
-    }
+    await waitFor(() => {
+      expect(activeElementIsInside(threadRegion)).toBeTruthy();
+    });
 
     await user.keyboard("{F2}");
 
@@ -2933,6 +2930,60 @@ describe("chat lifecycle", () => {
     expect(
       within(reopenedDialog).getByPlaceholderText("Chat title"),
     ).toHaveValue("Current keyboard thread");
+  });
+
+  it("keeps F2 rename available after creating a chat from the agent composer", async () => {
+    const user = userEvent.setup({ delay: null });
+    mockResizeObserver();
+    mockChatLifecycle(context);
+
+    detachedSetupPage({ context, path: AGENT_CHAT_PATH });
+
+    const textarea = await waitFor(() => {
+      return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
+    });
+    await sendMessageInUI(user, textarea, "Name this thread from F2");
+
+    await waitFor(() => {
+      expect(screen.getByText("Name this thread from F2")).toBeInTheDocument();
+    });
+
+    const threadRegion = screen.getByLabelText("Chat thread");
+    expect(activeElementIsInside(threadRegion)).toBeTruthy();
+
+    await user.keyboard("{F2}");
+
+    const dialog = await screen.findByRole("dialog", { name: "Rename chat" });
+    expect(within(dialog).getByPlaceholderText("Chat title")).toHaveValue("");
+  });
+
+  it("renames the main chat with F2 when a side chat is focused", async () => {
+    const user = userEvent.setup({ delay: null });
+    mockResizeObserver();
+    mockKeyboardNavigationThreads();
+
+    detachedSetupPage({
+      context,
+      path: "/chats/keyboard-current-thread?sidebar=keyboard-next-thread",
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Current thread launch note"),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Next thread launch note")).toBeInTheDocument();
+    });
+
+    const threadRegions = screen.getAllByLabelText("Chat thread");
+    expect(threadRegions).toHaveLength(2);
+    threadRegions[1]?.focus();
+
+    await user.keyboard("{F2}");
+
+    const dialog = await screen.findByRole("dialog", { name: "Rename chat" });
+    expect(within(dialog).getByPlaceholderText("Chat title")).toHaveValue(
+      "Current keyboard thread",
+    );
   });
 
   it("opens run logs from assistant message actions", async () => {

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -563,6 +563,33 @@ function ChatThreadRenameDialog() {
   const renameChatThread = useSet(renameChatThread$);
   const pageSignal = useGet(pageSignal$);
 
+  function chatThreadContainer(threadId: string) {
+    return (
+      Array.from(
+        document.querySelectorAll<HTMLElement>(
+          "[data-chat-thread-container-id]",
+        ),
+      ).find((candidate) => {
+        return candidate.dataset.chatThreadContainerId === threadId;
+      }) ?? null
+    );
+  }
+
+  function focusChatThreadContainer(threadId: string) {
+    chatThreadContainer(threadId)?.focus({ preventScroll: true });
+  }
+
+  function closeRenameDialog() {
+    const threadId = renameDialogThreadId;
+    setRenameDialogThreadId(null);
+    setRenameDialogInput("");
+    if (threadId) {
+      queueMicrotask(() => {
+        focusChatThreadContainer(threadId);
+      });
+    }
+  }
+
   function handleRename() {
     if (!renameDialogThreadId || !renameDialogInput.trim()) {
       return;
@@ -574,8 +601,7 @@ function ChatThreadRenameDialog() {
       ),
       Reason.DomCallback,
     );
-    setRenameDialogThreadId(null);
-    setRenameDialogInput("");
+    closeRenameDialog();
   }
 
   return (
@@ -583,12 +609,21 @@ function ChatThreadRenameDialog() {
       open={renameDialogThreadId !== null}
       onOpenChange={(open) => {
         if (!open) {
-          setRenameDialogThreadId(null);
-          setRenameDialogInput("");
+          closeRenameDialog();
         }
       }}
     >
-      <DialogContent>
+      <DialogContent
+        onCloseAutoFocus={(event) => {
+          const threadContainer = renameDialogThreadId
+            ? chatThreadContainer(renameDialogThreadId)
+            : null;
+          if (threadContainer) {
+            event.preventDefault();
+            threadContainer.focus({ preventScroll: true });
+          }
+        }}
+      >
         <DialogHeader>
           <DialogTitle>Rename chat</DialogTitle>
           <DialogDescription>
@@ -615,8 +650,7 @@ function ChatThreadRenameDialog() {
           <Button
             variant="outline"
             onClick={() => {
-              setRenameDialogThreadId(null);
-              setRenameDialogInput("");
+              closeRenameDialog();
             }}
           >
             Cancel
@@ -795,11 +829,15 @@ function ChatThreads() {
 
   if (visibleChatThreads.length === 0) {
     return (
-      <p className="px-2 py-2 text-xs text-muted-foreground/70 leading-relaxed">
-        {unreadOnly
-          ? "No unread chats"
-          : "Start a conversation and it'll show up here"}
-      </p>
+      <>
+        <p className="px-2 py-2 text-xs text-muted-foreground/70 leading-relaxed">
+          {unreadOnly
+            ? "No unread chats"
+            : "Start a conversation and it'll show up here"}
+        </p>
+        <ChatThreadRenameDialog />
+        <DeleteChatThreadDialog />
+      </>
     );
   }
   return (


### PR DESCRIPTION
## Summary
- handle chat F2 rename at the chat keyboard root so it still works after focus lands outside the thread section
- keep side chat threads from owning the global F2 shortcut; F2 always renames the main chat
- keep rename dialogs mounted for optimistic empty sidebar states and restore focus to the renamed thread on close

## Verification
- pnpm --filter @vm0/app check-types
- pnpm --filter @vm0/app lint
- pnpm exec vitest run apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
- pnpm exec vitest run apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx -t "F2|keeps F2 rename available|renames the main chat with F2"