### PR TITLE
fix: simplify workflow chat creation

### DIFF
--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -766,12 +766,12 @@ describe("agent workflows tab", () => {
       `/workflows/${OTHER_WORKFLOW_ID}`,
     );
 
-    click(buttonByText(/create with chat/i));
-    await waitFor(() => {
-      expect(menuItemByText(/create with Zero/i)).toBeInTheDocument();
-    });
-    click(menuItemByText(/create with Zero/i));
+    expect(CREATE_WORKFLOW_WITH_CHAT_PROMPT).toContain(
+      "Help me create a workflow for this agent.",
+    );
+    expect(CREATE_WORKFLOW_WITH_CHAT_PROMPT).not.toContain("Zero workflow");
 
+    click(buttonByText(/create with chat/i));
     const dialog = await screen.findByRole("dialog", {
       name: "Create workflow",
     });

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -770,8 +770,10 @@ describe("agent workflows tab", () => {
       "Help me create a workflow for this agent.",
     );
     expect(CREATE_WORKFLOW_WITH_CHAT_PROMPT).toContain("desired outcome");
+    expect(CREATE_WORKFLOW_WITH_CHAT_PROMPT).toContain("automation");
     expect(CREATE_WORKFLOW_WITH_CHAT_PROMPT).not.toContain("Zero workflow");
     expect(CREATE_WORKFLOW_WITH_CHAT_PROMPT).not.toContain("side effects");
+    expect(CREATE_WORKFLOW_WITH_CHAT_PROMPT).not.toContain("trigger");
 
     click(buttonByText(/create with chat/i));
     const dialog = await screen.findByRole("dialog", {

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -769,7 +769,9 @@ describe("agent workflows tab", () => {
     expect(CREATE_WORKFLOW_WITH_CHAT_PROMPT).toContain(
       "Help me create a workflow for this agent.",
     );
+    expect(CREATE_WORKFLOW_WITH_CHAT_PROMPT).toContain("desired outcome");
     expect(CREATE_WORKFLOW_WITH_CHAT_PROMPT).not.toContain("Zero workflow");
+    expect(CREATE_WORKFLOW_WITH_CHAT_PROMPT).not.toContain("side effects");
 
     click(buttonByText(/create with chat/i));
     const dialog = await screen.findByRole("dialog", {

--- a/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
@@ -1,14 +1,7 @@
 // Workflow list surfaces for agent-scoped tabs and the workspace index page.
 import { useLastLoadable, useSet } from "ccstate-react";
 import type { ZeroWorkflowSummary } from "@vm0/api-contracts/contracts/zero-workflows";
-import { IconChevronDown, IconMessageCircle } from "@tabler/icons-react";
-import {
-  Button,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@vm0/ui";
+import { Button } from "@vm0/ui";
 
 import { openCreateWorkflowDialog$ } from "../../signals/automation-page/workflow-trigger-automation-dialog.ts";
 import { ROUTES } from "../../signals/route-paths.ts";
@@ -253,29 +246,16 @@ export function WorkflowsPage() {
               Reusable instructions your team can run, edit, or trigger.
             </p>
           </div>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                type="button"
-                size="sm"
-                className="h-9 shrink-0 gap-2 rounded-lg bg-foreground px-3 text-background hover:bg-foreground/90"
-              >
-                Create with chat
-                <IconChevronDown size={14} stroke={1.5} />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-56">
-              <DropdownMenuItem
-                className="gap-2"
-                onClick={() => {
-                  openCreateWorkflowDialog();
-                }}
-              >
-                <IconMessageCircle size={14} stroke={1.5} />
-                Create with Zero
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <Button
+            type="button"
+            size="sm"
+            className="h-9 shrink-0 rounded-lg bg-foreground px-3 text-background hover:bg-foreground/90"
+            onClick={() => {
+              openCreateWorkflowDialog();
+            }}
+          >
+            Create with chat
+          </Button>
         </div>
       </header>
 

--- a/turbo/apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx
@@ -106,7 +106,7 @@ interface WorkflowAutomationOption {
 }
 
 export const CREATE_WORKFLOW_WITH_CHAT_PROMPT =
-  "Help me create a workflow for this agent. Use the workflow-setup skill, then ask me for the desired outcome, trigger, and action before creating the workflow and trigger.";
+  "Help me create a workflow for this agent. Use the workflow-setup skill, then ask me for the desired outcome, automation, and action before creating the workflow and automation.";
 
 const WORKFLOW_AUTOMATION_OPTIONS: readonly WorkflowAutomationOption[] = [
   {

--- a/turbo/apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx
@@ -106,7 +106,7 @@ interface WorkflowAutomationOption {
 }
 
 export const CREATE_WORKFLOW_WITH_CHAT_PROMPT =
-  "Help me create a workflow for this agent. Use the workflow-setup skill, then ask me for the automation goal, trigger, action, and allowed side effects before creating the workflow and trigger.";
+  "Help me create a workflow for this agent. Use the workflow-setup skill, then ask me for the desired outcome, trigger, and action before creating the workflow and trigger.";
 
 const WORKFLOW_AUTOMATION_OPTIONS: readonly WorkflowAutomationOption[] = [
   {

--- a/turbo/apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx
@@ -106,7 +106,7 @@ interface WorkflowAutomationOption {
 }
 
 export const CREATE_WORKFLOW_WITH_CHAT_PROMPT =
-  "Help me create a Zero workflow for this agent. Use the workflow-setup skill, then ask me for the automation goal, trigger, action, and allowed side effects before creating the workflow and trigger.";
+  "Help me create a workflow for this agent. Use the workflow-setup skill, then ask me for the automation goal, trigger, action, and allowed side effects before creating the workflow and trigger.";
 
 const WORKFLOW_AUTOMATION_OPTIONS: readonly WorkflowAutomationOption[] = [
   {


### PR DESCRIPTION
## Summary
- replace the workflows page Create with chat dropdown with a direct button action
- update the create-workflow chat prompt to say workflow for this agent instead of Zero workflow
- update the workflows page test for the direct dialog flow

## Tests
- pnpm -F @vm0/app exec vitest run src/views/workflows-page/__tests__/workflows-page.test.tsx