### PR TITLE
fix: show users icon for empty connector access

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -667,7 +667,7 @@ describe("connectors page", () => {
     expect(dialog).toBeInTheDocument();
   });
 
-  it("shows a stable placeholder when no agents are authorized", async () => {
+  it("shows a users icon when no agents are authorized", async () => {
     const agentId = "c0000000-0000-4000-a000-000000000001";
     mockConnectors([{ type: "github", externalUsername: "octocat" }]);
     context.mocks.data.team([teamAgent(agentId, "Research Agent", "preset:0")]);
@@ -688,8 +688,20 @@ describe("connectors page", () => {
       const placeholder = within(card).getByTestId(
         "connector-card-agent-avatar-placeholder",
       );
-      expect(placeholder).toHaveClass("block", "h-7", "w-7");
+      expect(placeholder).toHaveClass("flex", "h-7", "w-7");
+      expect(placeholder.querySelector(".tabler-icon-users")).not.toBeNull();
     });
+
+    click(
+      within(connectorCardByLabel("GitHub")).getByLabelText(
+        "Manage GitHub access",
+      ),
+    );
+
+    const dialog = await screen.findByRole("dialog", {
+      name: "Manage GitHub access",
+    });
+    expect(dialog).toBeInTheDocument();
   });
 
   it("hides permission controls for connectors without firewall rules", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -16,6 +16,7 @@ import {
   IconLoader2,
   IconDotsVertical,
   IconInfoCircle,
+  IconUsers,
 } from "@tabler/icons-react";
 import {
   CONNECTOR_TYPES,
@@ -419,9 +420,11 @@ function ConnectorAccessAvatarButton({
               </span>
             ) : (
               <span
-                className="block h-7 w-7 rounded-full bg-muted/80 zero-border"
+                className="flex h-7 w-7 items-center justify-center rounded-full bg-muted/80 text-muted-foreground zero-border"
                 data-testid="connector-card-agent-avatar-placeholder"
-              />
+              >
+                <IconUsers size={15} stroke={1.7} aria-hidden="true" />
+              </span>
             )}
           </button>
         </TooltipTrigger>


### PR DESCRIPTION
## Summary
- Replace the empty connector access placeholder with the Tabler users icon when no agents are authorized
- Keep the compact 28px circular affordance and existing manage-access click behavior
- Update the connectors page test to cover the icon fallback and dialog opening

## Verification
- pnpm exec prettier --check apps/platform/src/views/zero-page/zero-connectors-page.tsx apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-connectors-page.test.tsx
- pnpm knip --cache
- NODE_OPTIONS=--max-old-space-size=4096 pnpm check-types

Note: local lefthook pre-commit hit a lefthook timeout parsing issue for the knip job (reported as 60ns); the same hook commands above were run manually and passed.