### PR TITLE
refactor(guest-agent): add explicit run config and paths

### DIFF
--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -393,13 +393,26 @@ pub struct GuestConfig {
 
 impl GuestConfig {
     /// Build an owned config from the current process environment.
+    ///
+    /// This shares the one-time user-env loader with the legacy `env::*`
+    /// facade so transitional callers can build a `GuestConfig` and still use
+    /// existing accessors without racing on the private user-env file.
     pub fn from_process_env() -> Result<Self, String> {
-        Self::from_raw(GuestConfigRaw::from_process_env())
+        let raw = GuestConfigRaw::from_process_env();
+        let user_env = user_env_map_result()?.clone();
+        Self::from_raw_with_user_env(raw, user_env)
     }
 
     /// Build an owned config from explicit startup values.
     pub fn from_raw(raw: GuestConfigRaw) -> Result<Self, String> {
         let user_env = load_user_env_from_raw(&raw)?;
+        Self::from_raw_with_user_env(raw, user_env)
+    }
+
+    fn from_raw_with_user_env(
+        raw: GuestConfigRaw,
+        user_env: HashMap<String, String>,
+    ) -> Result<Self, String> {
         let home_dir = resolve_home_dir(&user_env, raw.home.as_deref())?;
         let artifacts = parse_artifacts_value(&raw.artifacts)
             .map_err(|e| format!("parse {} JSON: {e}", guest_contracts::env::ARTIFACTS_ENV))?;
@@ -685,11 +698,15 @@ fn resolve_home_dir(
 
 #[allow(clippy::panic)] // Entry points must call init_user_env; bypassing it is a code bug.
 fn user_env_map() -> &'static HashMap<String, String> {
+    user_env_map_result().unwrap_or_else(|message| {
+        panic!("{USER_ENV_FILE_ENV_KEY} failed to load before accessor use: {message}")
+    })
+}
+
+fn user_env_map_result() -> Result<&'static HashMap<String, String>, String> {
     match &*USER_ENV {
-        Ok(user_env) => user_env,
-        Err(message) => {
-            panic!("{USER_ENV_FILE_ENV_KEY} failed to load before accessor use: {message}")
-        }
+        Ok(user_env) => Ok(user_env),
+        Err(message) => Err(message.clone()),
     }
 }
 

--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -273,7 +273,8 @@ pub struct ArtifactEnv {
 /// Raw startup values used to build an owned guest-agent run config.
 ///
 /// Empty strings represent unset runner bootstrap values, matching the legacy
-/// `env::*` facade.
+/// `env::*` facade. Optional override fields preserve the difference between
+/// an unset variable and an explicitly empty variable.
 #[derive(Clone, Default)]
 pub struct GuestConfigRaw {
     pub run_id: String,
@@ -291,12 +292,12 @@ pub struct GuestConfigRaw {
     pub tools: String,
     pub settings: String,
     pub use_mock_claude: String,
-    pub mock_claude_path: String,
+    pub mock_claude_path: Option<String>,
     pub cli_agent_type: String,
     pub user_env_file: String,
     pub use_mock_codex: String,
     pub use_codex_app_server_backend: String,
-    pub mock_codex_path: String,
+    pub mock_codex_path: Option<String>,
     pub home: Option<String>,
     pub guest_runtime_dir: Option<PathBuf>,
     pub artifacts: String,
@@ -330,16 +331,14 @@ impl GuestConfigRaw {
             tools: env_or_empty(guest_contracts::env::TOOLS_ENV),
             settings: env_or_empty(guest_contracts::env::SETTINGS_ENV),
             use_mock_claude: env_or_empty(guest_contracts::env::USE_MOCK_CLAUDE_ENV),
-            mock_claude_path: std::env::var(guest_contracts::env::MOCK_CLAUDE_PATH_ENV)
-                .unwrap_or_else(|_| DEFAULT_MOCK_CLAUDE_PATH.to_string()),
+            mock_claude_path: std::env::var(guest_contracts::env::MOCK_CLAUDE_PATH_ENV).ok(),
             cli_agent_type: env_or_empty(guest_contracts::env::CLI_AGENT_TYPE_ENV),
             user_env_file: env_or_empty(USER_ENV_FILE_ENV_KEY),
             use_mock_codex: env_or_empty(guest_contracts::env::USE_MOCK_CODEX_ENV),
             use_codex_app_server_backend: env_or_empty(
                 guest_contracts::env::CODEX_APP_SERVER_BACKEND_ENV,
             ),
-            mock_codex_path: std::env::var(guest_contracts::env::MOCK_CODEX_PATH_ENV)
-                .unwrap_or_else(|_| DEFAULT_MOCK_CODEX_PATH.to_string()),
+            mock_codex_path: std::env::var(guest_contracts::env::MOCK_CODEX_PATH_ENV).ok(),
             home: std::env::var("HOME").ok(),
             guest_runtime_dir,
             artifacts: env_or_empty(guest_contracts::env::ARTIFACTS_ENV),
@@ -421,7 +420,10 @@ impl GuestConfig {
             tools: raw.tools,
             settings: raw.settings,
             use_mock_claude: bool_true_value(Some(&raw.use_mock_claude)),
-            mock_claude_path: default_mock_path(&raw.mock_claude_path, DEFAULT_MOCK_CLAUDE_PATH),
+            mock_claude_path: default_mock_path(
+                raw.mock_claude_path.as_deref(),
+                DEFAULT_MOCK_CLAUDE_PATH,
+            ),
             framework: framework_from_cli_agent_type(&raw.cli_agent_type),
             cli_agent_type: raw.cli_agent_type,
             user_env,
@@ -429,7 +431,10 @@ impl GuestConfig {
             use_codex_app_server_backend: bool_true_or_one_value(Some(
                 &raw.use_codex_app_server_backend,
             )),
-            mock_codex_path: default_mock_path(&raw.mock_codex_path, DEFAULT_MOCK_CODEX_PATH),
+            mock_codex_path: default_mock_path(
+                raw.mock_codex_path.as_deref(),
+                DEFAULT_MOCK_CODEX_PATH,
+            ),
             home_dir,
             artifacts,
             stuck_tool_timeout_secs: u64_value_or(
@@ -510,12 +515,8 @@ fn bool_true_or_one_value(value: Option<&str>) -> bool {
     matches!(value, Some("true" | "1"))
 }
 
-fn default_mock_path(value: &str, default: &str) -> String {
-    if value.is_empty() {
-        default.to_string()
-    } else {
-        value.to_string()
-    }
+fn default_mock_path(value: Option<&str>, default: &str) -> String {
+    value.map_or_else(|| default.to_string(), str::to_string)
 }
 
 fn parse_artifacts_value(raw: &str) -> Result<Vec<ArtifactEnv>, serde_json::Error> {
@@ -1086,6 +1087,20 @@ mod tests {
         let config = GuestConfig::from_raw(raw).unwrap();
 
         assert_eq!(config.home_dir, "");
+    }
+
+    #[test]
+    fn guest_config_from_raw_preserves_explicit_empty_mock_paths() {
+        let raw = GuestConfigRaw {
+            mock_claude_path: Some(String::new()),
+            mock_codex_path: Some(String::new()),
+            ..raw_config_fixture()
+        };
+
+        let config = GuestConfig::from_raw(raw).unwrap();
+
+        assert_eq!(config.mock_claude_path, "");
+        assert_eq!(config.mock_codex_path, "");
     }
 
     #[test]

--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -47,17 +47,8 @@ impl Framework {
     }
 }
 
-static FRAMEWORK: LazyLock<Framework> = LazyLock::new(|| match cli_agent_type() {
-    "codex" => Framework::Codex,
-    "" | "claude-code" => Framework::ClaudeCode,
-    other => {
-        log_warn!(
-            LOG_TAG,
-            "Unknown CLI_AGENT_TYPE={other:?}, defaulting to claude-code"
-        );
-        Framework::ClaudeCode
-    }
-});
+static FRAMEWORK: LazyLock<Framework> =
+    LazyLock::new(|| framework_from_cli_agent_type(cli_agent_type()));
 
 // ---------------------------------------------------------------------------
 // Core
@@ -88,11 +79,8 @@ static DISALLOWED_TOOLS: LazyLock<String> =
 static TOOLS: LazyLock<String> = LazyLock::new(|| env_or_empty(guest_contracts::env::TOOLS_ENV));
 static SETTINGS: LazyLock<String> =
     LazyLock::new(|| env_or_empty(guest_contracts::env::SETTINGS_ENV));
-static USE_MOCK_CLAUDE: LazyLock<bool> = LazyLock::new(|| {
-    std::env::var(guest_contracts::env::USE_MOCK_CLAUDE_ENV)
-        .map(|v| v == "true")
-        .unwrap_or(false)
-});
+static USE_MOCK_CLAUDE: LazyLock<bool> =
+    LazyLock::new(|| bool_true_env(guest_contracts::env::USE_MOCK_CLAUDE_ENV));
 /// Production install location for the mock-claude binary. Exposed so
 /// tests can assert against a single source of truth when the
 /// `VM0_MOCK_CLAUDE_PATH` env override is unset.
@@ -119,16 +107,10 @@ static USER_ENV: LazyLock<Result<HashMap<String, String>, String>> =
 /// epic's documented invocation shape `USE_MOCK_CODEX=1`). The
 /// claude-side `USE_MOCK_CLAUDE` historically only accepts `"true"`;
 /// the asymmetry is intentional.
-static USE_MOCK_CODEX: LazyLock<bool> = LazyLock::new(|| {
-    std::env::var(guest_contracts::env::USE_MOCK_CODEX_ENV)
-        .map(|v| v == "true" || v == "1")
-        .unwrap_or(false)
-});
-static USE_CODEX_APP_SERVER_BACKEND: LazyLock<bool> = LazyLock::new(|| {
-    std::env::var(guest_contracts::env::CODEX_APP_SERVER_BACKEND_ENV)
-        .map(|v| v == "true" || v == "1")
-        .unwrap_or(false)
-});
+static USE_MOCK_CODEX: LazyLock<bool> =
+    LazyLock::new(|| bool_true_or_one_env(guest_contracts::env::USE_MOCK_CODEX_ENV));
+static USE_CODEX_APP_SERVER_BACKEND: LazyLock<bool> =
+    LazyLock::new(|| bool_true_or_one_env(guest_contracts::env::CODEX_APP_SERVER_BACKEND_ENV));
 
 /// Production install location for the mock-codex binary, mirroring
 /// `DEFAULT_MOCK_CLAUDE_PATH`.
@@ -152,10 +134,9 @@ static MOCK_CODEX_PATH: LazyLock<String> = LazyLock::new(|| {
 /// (`VM0_ARTIFACTS`).
 #[allow(clippy::expect_used)]
 fn load_home_dir() -> String {
-    if let Some(home) = user_env_map().get("HOME") {
-        return home.clone();
-    }
-    std::env::var("HOME").expect("HOME must be set in guest sandbox (rootfs init contract)")
+    let process_home = std::env::var("HOME").ok();
+    resolve_home_dir(user_env_map(), process_home.as_deref())
+        .expect("HOME must be set in guest sandbox (rootfs init contract)")
 }
 
 static HOME_DIR: LazyLock<String> = LazyLock::new(load_home_dir);
@@ -163,25 +144,28 @@ static HOME_DIR: LazyLock<String> = LazyLock::new(load_home_dir);
 /// unset or unparseable. Emits a stderr warning on the unparseable case so
 /// the mistake is visible in runner logs rather than silently absorbed.
 fn u64_env_or(name: &str, default: u64) -> u64 {
-    match std::env::var(name) {
-        Ok(v) => v.parse().unwrap_or_else(|_| {
+    let value = std::env::var(name).ok();
+    u64_value_or(name, value.as_deref(), default)
+}
+
+fn u64_value_or(name: &str, value: Option<&str>, default: u64) -> u64 {
+    match value {
+        Some(v) => v.parse().unwrap_or_else(|_| {
             log_warn!(
                 LOG_TAG,
                 "{name}={v:?} is not a valid u64, using default {default}s"
             );
             default
         }),
-        Err(_) => default,
+        None => default,
     }
 }
 
 /// Read an optional bounded seconds env var as `Duration`, falling back to
 /// `default_secs` when unset, unparseable, or outside the supported range.
 fn bounded_duration_secs_env_or(name: &str, default_secs: u64, max_secs: u64) -> Duration {
-    match std::env::var(name) {
-        Ok(v) => bounded_duration_secs_value_or(name, Some(&v), default_secs, max_secs),
-        Err(_) => Duration::from_secs(default_secs),
-    }
+    let value = std::env::var(name).ok();
+    bounded_duration_secs_value_or(name, value.as_deref(), default_secs, max_secs)
 }
 
 fn bounded_duration_secs_value_or(
@@ -286,6 +270,195 @@ pub struct ArtifactEnv {
     pub missing_root_policy: Option<ArtifactEntryMissingRootPolicy>,
 }
 
+/// Raw startup values used to build an owned guest-agent run config.
+///
+/// Empty strings represent unset runner bootstrap values, matching the legacy
+/// `env::*` facade.
+#[derive(Clone, Default)]
+pub struct GuestConfigRaw {
+    pub run_id: String,
+    pub api_url: String,
+    pub api_token: String,
+    pub sandbox_id: String,
+    pub sandbox_reuse_result: String,
+    pub prompt: String,
+    pub append_system_prompt: String,
+    pub vercel_bypass: String,
+    pub resume_session_id: String,
+    pub api_start_time: String,
+    pub secret_values: String,
+    pub disallowed_tools: String,
+    pub tools: String,
+    pub settings: String,
+    pub use_mock_claude: String,
+    pub mock_claude_path: String,
+    pub cli_agent_type: String,
+    pub user_env_file: String,
+    pub use_mock_codex: String,
+    pub use_codex_app_server_backend: String,
+    pub mock_codex_path: String,
+    pub home: Option<String>,
+    pub guest_runtime_dir: Option<PathBuf>,
+    pub artifacts: String,
+    pub stuck_tool_timeout_secs: String,
+    pub post_result_sigterm_grace_secs: String,
+    pub post_result_total_cap_secs: String,
+    pub post_result_sigkill_grace_secs: String,
+}
+
+impl GuestConfigRaw {
+    /// Capture raw startup values from the current process environment.
+    pub fn from_process_env() -> Self {
+        let guest_runtime_dir =
+            std::env::var_os(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV)
+                .filter(|value| !value.is_empty())
+                .map(PathBuf::from);
+
+        Self {
+            run_id: env_or_empty(guest_contracts::env::RUN_ID_ENV),
+            api_url: env_or_empty(guest_contracts::env::API_URL_ENV),
+            api_token: env_or_empty(guest_contracts::env::API_TOKEN_ENV),
+            sandbox_id: env_or_empty(guest_contracts::env::SANDBOX_ID_ENV),
+            sandbox_reuse_result: env_or_empty(guest_contracts::env::SANDBOX_REUSE_RESULT_ENV),
+            prompt: env_or_empty(guest_contracts::env::PROMPT_ENV),
+            append_system_prompt: env_or_empty(guest_contracts::env::APPEND_SYSTEM_PROMPT_ENV),
+            vercel_bypass: env_or_empty(guest_contracts::env::VERCEL_PROTECTION_BYPASS_ENV),
+            resume_session_id: env_or_empty(guest_contracts::env::RESUME_SESSION_ID_ENV),
+            api_start_time: env_or_empty(guest_contracts::env::API_START_TIME_ENV),
+            secret_values: env_or_empty(guest_contracts::env::SECRET_VALUES_ENV),
+            disallowed_tools: env_or_empty(guest_contracts::env::DISALLOWED_TOOLS_ENV),
+            tools: env_or_empty(guest_contracts::env::TOOLS_ENV),
+            settings: env_or_empty(guest_contracts::env::SETTINGS_ENV),
+            use_mock_claude: env_or_empty(guest_contracts::env::USE_MOCK_CLAUDE_ENV),
+            mock_claude_path: std::env::var(guest_contracts::env::MOCK_CLAUDE_PATH_ENV)
+                .unwrap_or_else(|_| DEFAULT_MOCK_CLAUDE_PATH.to_string()),
+            cli_agent_type: env_or_empty(guest_contracts::env::CLI_AGENT_TYPE_ENV),
+            user_env_file: env_or_empty(USER_ENV_FILE_ENV_KEY),
+            use_mock_codex: env_or_empty(guest_contracts::env::USE_MOCK_CODEX_ENV),
+            use_codex_app_server_backend: env_or_empty(
+                guest_contracts::env::CODEX_APP_SERVER_BACKEND_ENV,
+            ),
+            mock_codex_path: std::env::var(guest_contracts::env::MOCK_CODEX_PATH_ENV)
+                .unwrap_or_else(|_| DEFAULT_MOCK_CODEX_PATH.to_string()),
+            home: std::env::var("HOME").ok(),
+            guest_runtime_dir,
+            artifacts: env_or_empty(guest_contracts::env::ARTIFACTS_ENV),
+            stuck_tool_timeout_secs: env_or_empty(
+                guest_contracts::env::STUCK_TOOL_TIMEOUT_SECS_ENV,
+            ),
+            post_result_sigterm_grace_secs: env_or_empty(
+                guest_contracts::env::POST_RESULT_SIGTERM_GRACE_SECS_ENV,
+            ),
+            post_result_total_cap_secs: env_or_empty(
+                guest_contracts::env::POST_RESULT_TOTAL_CAP_SECS_ENV,
+            ),
+            post_result_sigkill_grace_secs: env_or_empty(
+                guest_contracts::env::POST_RESULT_SIGKILL_GRACE_SECS_ENV,
+            ),
+        }
+    }
+}
+
+/// Immutable guest-agent startup configuration for a single run.
+#[derive(Clone)]
+pub struct GuestConfig {
+    pub run_id: String,
+    pub api_url: String,
+    pub api_token: String,
+    pub sandbox_id: String,
+    pub sandbox_reuse_result: String,
+    pub prompt: String,
+    pub append_system_prompt: String,
+    pub vercel_bypass: String,
+    pub resume_session_id: String,
+    pub api_start_time: String,
+    pub secret_values: String,
+    pub disallowed_tools: String,
+    pub tools: String,
+    pub settings: String,
+    pub use_mock_claude: bool,
+    pub mock_claude_path: String,
+    pub cli_agent_type: String,
+    pub framework: Framework,
+    pub user_env: HashMap<String, String>,
+    pub use_mock_codex: bool,
+    pub use_codex_app_server_backend: bool,
+    pub mock_codex_path: String,
+    pub home_dir: String,
+    pub artifacts: Vec<ArtifactEnv>,
+    pub stuck_tool_timeout_secs: u64,
+    pub post_result_sigterm_grace: Duration,
+    pub post_result_total_cap: Duration,
+    pub post_result_sigkill_grace: Duration,
+}
+
+impl GuestConfig {
+    /// Build an owned config from the current process environment.
+    pub fn from_process_env() -> Result<Self, String> {
+        Self::from_raw(GuestConfigRaw::from_process_env())
+    }
+
+    /// Build an owned config from explicit startup values.
+    pub fn from_raw(raw: GuestConfigRaw) -> Result<Self, String> {
+        let user_env = load_user_env_from_raw(&raw)?;
+        let home_dir = resolve_home_dir(&user_env, raw.home.as_deref())?;
+        let artifacts = parse_artifacts_value(&raw.artifacts)
+            .map_err(|e| format!("parse {} JSON: {e}", guest_contracts::env::ARTIFACTS_ENV))?;
+
+        Ok(Self {
+            run_id: raw.run_id,
+            api_url: raw.api_url,
+            api_token: raw.api_token,
+            sandbox_id: raw.sandbox_id,
+            sandbox_reuse_result: raw.sandbox_reuse_result,
+            prompt: raw.prompt,
+            append_system_prompt: raw.append_system_prompt,
+            vercel_bypass: raw.vercel_bypass,
+            resume_session_id: raw.resume_session_id,
+            api_start_time: raw.api_start_time,
+            secret_values: raw.secret_values,
+            disallowed_tools: raw.disallowed_tools,
+            tools: raw.tools,
+            settings: raw.settings,
+            use_mock_claude: bool_true_value(Some(&raw.use_mock_claude)),
+            mock_claude_path: default_mock_path(&raw.mock_claude_path, DEFAULT_MOCK_CLAUDE_PATH),
+            framework: framework_from_cli_agent_type(&raw.cli_agent_type),
+            cli_agent_type: raw.cli_agent_type,
+            user_env,
+            use_mock_codex: bool_true_or_one_value(Some(&raw.use_mock_codex)),
+            use_codex_app_server_backend: bool_true_or_one_value(Some(
+                &raw.use_codex_app_server_backend,
+            )),
+            mock_codex_path: default_mock_path(&raw.mock_codex_path, DEFAULT_MOCK_CODEX_PATH),
+            home_dir,
+            artifacts,
+            stuck_tool_timeout_secs: u64_value_or(
+                guest_contracts::env::STUCK_TOOL_TIMEOUT_SECS_ENV,
+                non_empty(&raw.stuck_tool_timeout_secs),
+                constants::STUCK_TOOL_TIMEOUT_SECS,
+            ),
+            post_result_sigterm_grace: bounded_duration_secs_value_or(
+                guest_contracts::env::POST_RESULT_SIGTERM_GRACE_SECS_ENV,
+                non_empty(&raw.post_result_sigterm_grace_secs),
+                constants::POST_RESULT_SIGTERM_GRACE_SECS,
+                POST_RESULT_CLEANUP_MAX_SECS,
+            ),
+            post_result_total_cap: bounded_duration_secs_value_or(
+                guest_contracts::env::POST_RESULT_TOTAL_CAP_SECS_ENV,
+                non_empty(&raw.post_result_total_cap_secs),
+                constants::POST_RESULT_TOTAL_CAP_SECS,
+                POST_RESULT_CLEANUP_MAX_SECS,
+            ),
+            post_result_sigkill_grace: bounded_duration_secs_value_or(
+                guest_contracts::env::POST_RESULT_SIGKILL_GRACE_SECS_ENV,
+                non_empty(&raw.post_result_sigkill_grace_secs),
+                constants::POST_RESULT_SIGKILL_GRACE_SECS,
+                POST_RESULT_CLEANUP_MAX_SECS,
+            ),
+        })
+    }
+}
+
 /// Parse `VM0_ARTIFACTS`, which the runner writes as a JSON array.
 ///
 /// # Panics
@@ -296,14 +469,61 @@ pub struct ArtifactEnv {
 #[allow(clippy::expect_used)]
 fn load_artifacts() -> Vec<ArtifactEnv> {
     let raw = std::env::var(guest_contracts::env::ARTIFACTS_ENV).unwrap_or_default();
-    if raw.is_empty() {
-        return Vec::new();
-    }
-    serde_json::from_str::<Vec<ArtifactEnv>>(&raw)
-        .expect("VM0_ARTIFACTS must be a valid JSON array")
+    parse_artifacts_value(&raw).expect("VM0_ARTIFACTS must be a valid JSON array")
 }
 
 static ARTIFACTS: LazyLock<Vec<ArtifactEnv>> = LazyLock::new(load_artifacts);
+
+fn framework_from_cli_agent_type(value: &str) -> Framework {
+    match value {
+        "codex" => Framework::Codex,
+        "" | "claude-code" => Framework::ClaudeCode,
+        other => {
+            log_warn!(
+                LOG_TAG,
+                "Unknown CLI_AGENT_TYPE={other:?}, defaulting to claude-code"
+            );
+            Framework::ClaudeCode
+        }
+    }
+}
+
+fn non_empty(value: &str) -> Option<&str> {
+    if value.is_empty() { None } else { Some(value) }
+}
+
+fn bool_true_env(name: &str) -> bool {
+    let value = std::env::var(name).ok();
+    bool_true_value(value.as_deref())
+}
+
+fn bool_true_value(value: Option<&str>) -> bool {
+    matches!(value, Some("true"))
+}
+
+fn bool_true_or_one_env(name: &str) -> bool {
+    let value = std::env::var(name).ok();
+    bool_true_or_one_value(value.as_deref())
+}
+
+fn bool_true_or_one_value(value: Option<&str>) -> bool {
+    matches!(value, Some("true" | "1"))
+}
+
+fn default_mock_path(value: &str, default: &str) -> String {
+    if value.is_empty() {
+        default.to_string()
+    } else {
+        value.to_string()
+    }
+}
+
+fn parse_artifacts_value(raw: &str) -> Result<Vec<ArtifactEnv>, serde_json::Error> {
+    if raw.is_empty() {
+        return Ok(Vec::new());
+    }
+    serde_json::from_str::<Vec<ArtifactEnv>>(raw)
+}
 
 fn load_user_env_from_process() -> Result<HashMap<String, String>, String> {
     let path = env_or_empty(USER_ENV_FILE_ENV_KEY);
@@ -313,6 +533,21 @@ fn load_user_env_from_process() -> Result<HashMap<String, String>, String> {
 
     let path = Path::new(&path);
     validate_user_env_file_path(path)?;
+    load_user_env_from_path(path)
+}
+
+fn load_user_env_from_raw(raw: &GuestConfigRaw) -> Result<HashMap<String, String>, String> {
+    if raw.user_env_file.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let path = Path::new(&raw.user_env_file);
+    let runtime_dir = guest_runtime_dir_for_user_env_values(
+        &raw.run_id,
+        raw.guest_runtime_dir.as_deref(),
+        raw.home.as_deref(),
+    )?;
+    validate_user_env_file_path_for_runtime(path, &runtime_dir)?;
     load_user_env_from_path(path)
 }
 
@@ -368,6 +603,35 @@ fn guest_runtime_dir_for_user_env_run_id(run_id: &str) -> Result<PathBuf, String
         .map_err(|e| format!("resolve guest runtime dir for {USER_ENV_FILE_ENV_KEY}: {e}"))
 }
 
+fn guest_runtime_dir_for_user_env_values(
+    run_id: &str,
+    runtime_dir: Option<&Path>,
+    home: Option<&str>,
+) -> Result<PathBuf, String> {
+    guest_contracts::runtime_paths::validate_run_id(run_id)
+        .map_err(|e| format!("resolve guest runtime dir for {USER_ENV_FILE_ENV_KEY}: {e}"))?;
+
+    if let Some(runtime_dir) = runtime_dir {
+        if !runtime_dir.is_absolute() {
+            return Err(format!(
+                "resolve guest runtime dir for {USER_ENV_FILE_ENV_KEY}: {}",
+                guest_contracts::runtime_paths::RuntimePathError::InvalidRuntimeDir
+            ));
+        }
+        return Ok(runtime_dir.to_path_buf());
+    }
+
+    let Some(home) = home.filter(|value| !value.is_empty()) else {
+        return Err(format!(
+            "resolve guest runtime dir for {USER_ENV_FILE_ENV_KEY}: {}",
+            guest_contracts::runtime_paths::RuntimePathError::MissingHome
+        ));
+    };
+
+    guest_contracts::runtime_paths::run_dir_for_home(home, run_id)
+        .map_err(|e| format!("resolve guest runtime dir for {USER_ENV_FILE_ENV_KEY}: {e}"))
+}
+
 fn user_env_file_path_for_runtime(runtime_dir: &Path) -> PathBuf {
     runtime_dir
         .join(USER_ENV_PRIVATE_DIR_NAME)
@@ -404,6 +668,18 @@ fn validate_user_env(user_env: &HashMap<String, String>) -> Result<(), String> {
     }
 
     Ok(())
+}
+
+fn resolve_home_dir(
+    user_env: &HashMap<String, String>,
+    process_home: Option<&str>,
+) -> Result<String, String> {
+    if let Some(home) = user_env.get("HOME") {
+        return Ok(home.clone());
+    }
+    process_home
+        .map(str::to_string)
+        .ok_or_else(|| "HOME must be set in guest sandbox (rootfs init contract)".to_string())
 }
 
 #[allow(clippy::panic)] // Entry points must call init_user_env; bypassing it is a code bug.
@@ -613,6 +889,14 @@ mod tests {
     const TEST_DEFAULT_SECS: u64 = 10;
     const TEST_MAX_SECS: u64 = 60;
 
+    fn raw_config_fixture() -> GuestConfigRaw {
+        GuestConfigRaw {
+            run_id: "run-123".to_string(),
+            home: Some("/home/vm0".to_string()),
+            ..GuestConfigRaw::default()
+        }
+    }
+
     fn write_user_env_fixture(json: &str) -> (tempfile::TempDir, std::path::PathBuf) {
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path().join(USER_ENV_PRIVATE_DIR_NAME);
@@ -680,6 +964,158 @@ mod tests {
             ),
             Duration::from_secs(TEST_MAX_SECS)
         );
+    }
+
+    #[test]
+    fn framework_from_cli_agent_type_accepts_known_values_and_defaults_unknown() {
+        assert_eq!(framework_from_cli_agent_type(""), Framework::ClaudeCode);
+        assert_eq!(
+            framework_from_cli_agent_type("claude-code"),
+            Framework::ClaudeCode
+        );
+        assert_eq!(framework_from_cli_agent_type("codex"), Framework::Codex);
+        assert_eq!(
+            framework_from_cli_agent_type("unexpected"),
+            Framework::ClaudeCode
+        );
+    }
+
+    #[test]
+    fn guest_config_from_raw_builds_owned_config_without_process_env_mutation() {
+        let raw = GuestConfigRaw {
+            api_url: "https://api.example.test".to_string(),
+            api_token: String::new(),
+            sandbox_id: "sandbox-1".to_string(),
+            sandbox_reuse_result: "reused".to_string(),
+            prompt: "hello".to_string(),
+            append_system_prompt: "extra system".to_string(),
+            vercel_bypass: "bypass".to_string(),
+            resume_session_id: "session-1".to_string(),
+            api_start_time: "123".to_string(),
+            secret_values: "encoded-secret".to_string(),
+            disallowed_tools: "WebFetch".to_string(),
+            tools: "Bash".to_string(),
+            settings: "{}".to_string(),
+            use_mock_claude: "true".to_string(),
+            cli_agent_type: "codex".to_string(),
+            use_mock_codex: "1".to_string(),
+            use_codex_app_server_backend: "true".to_string(),
+            artifacts:
+                r#"[{"name":"artifact","mountPath":"/mnt/a","storageId":"storage","versionId":"v1"}]"#
+                    .to_string(),
+            stuck_tool_timeout_secs: "7".to_string(),
+            post_result_sigterm_grace_secs: "8".to_string(),
+            post_result_total_cap_secs: "9".to_string(),
+            post_result_sigkill_grace_secs: "10".to_string(),
+            ..raw_config_fixture()
+        };
+
+        let config = GuestConfig::from_raw(raw).unwrap();
+
+        assert_eq!(config.run_id, "run-123");
+        assert_eq!(config.api_url, "https://api.example.test");
+        assert_eq!(config.api_token, "");
+        assert_eq!(config.sandbox_id, "sandbox-1");
+        assert_eq!(config.sandbox_reuse_result, "reused");
+        assert_eq!(config.prompt, "hello");
+        assert_eq!(config.append_system_prompt, "extra system");
+        assert_eq!(config.vercel_bypass, "bypass");
+        assert_eq!(config.resume_session_id, "session-1");
+        assert_eq!(config.api_start_time, "123");
+        assert_eq!(config.secret_values, "encoded-secret");
+        assert_eq!(config.disallowed_tools, "WebFetch");
+        assert_eq!(config.tools, "Bash");
+        assert_eq!(config.settings, "{}");
+        assert!(config.use_mock_claude);
+        assert_eq!(config.mock_claude_path, DEFAULT_MOCK_CLAUDE_PATH);
+        assert_eq!(config.cli_agent_type, "codex");
+        assert_eq!(config.framework, Framework::Codex);
+        assert!(config.use_mock_codex);
+        assert!(config.use_codex_app_server_backend);
+        assert_eq!(config.mock_codex_path, DEFAULT_MOCK_CODEX_PATH);
+        assert_eq!(config.home_dir, "/home/vm0");
+        assert_eq!(config.stuck_tool_timeout_secs, 7);
+        assert_eq!(config.post_result_sigterm_grace, Duration::from_secs(8));
+        assert_eq!(config.post_result_total_cap, Duration::from_secs(9));
+        assert_eq!(config.post_result_sigkill_grace, Duration::from_secs(10));
+        let artifact = config.artifacts.first().unwrap();
+        assert_eq!(artifact.name, "artifact");
+        assert_eq!(artifact.mount_path, "/mnt/a");
+        assert_eq!(artifact.storage_id, "storage");
+        assert_eq!(artifact.version_id, "v1");
+    }
+
+    #[test]
+    fn guest_config_from_raw_loads_user_env_and_removes_private_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let runtime_dir = tmp.path().join("runtime");
+        let user_env_dir = runtime_dir.join(USER_ENV_PRIVATE_DIR_NAME);
+        std::fs::create_dir_all(&user_env_dir).unwrap();
+        let user_env_path = user_env_dir.join(USER_ENV_FILENAME);
+        std::fs::write(
+            &user_env_path,
+            r#"{"HOME":"/home/from-user-env","OPENAI_MODEL":"gpt-test"}"#,
+        )
+        .unwrap();
+
+        let raw = GuestConfigRaw {
+            user_env_file: user_env_path.to_string_lossy().into_owned(),
+            guest_runtime_dir: Some(runtime_dir),
+            home: Some("/home/from-process".to_string()),
+            ..raw_config_fixture()
+        };
+
+        let config = GuestConfig::from_raw(raw).unwrap();
+
+        assert_eq!(config.home_dir, "/home/from-user-env");
+        assert_eq!(
+            config.user_env.get("OPENAI_MODEL").map(String::as_str),
+            Some("gpt-test")
+        );
+        assert!(!user_env_path.exists());
+        assert!(!user_env_dir.exists());
+    }
+
+    #[test]
+    fn guest_config_from_raw_preserves_empty_process_home() {
+        let raw = GuestConfigRaw {
+            home: Some(String::new()),
+            ..raw_config_fixture()
+        };
+
+        let config = GuestConfig::from_raw(raw).unwrap();
+
+        assert_eq!(config.home_dir, "");
+    }
+
+    #[test]
+    fn guest_config_from_raw_reports_invalid_artifacts() {
+        let raw = GuestConfigRaw {
+            artifacts: "{not-json".to_string(),
+            ..raw_config_fixture()
+        };
+
+        let err = GuestConfig::from_raw(raw).err().unwrap();
+
+        assert!(err.contains(guest_contracts::env::ARTIFACTS_ENV));
+    }
+
+    #[test]
+    fn guest_config_from_raw_rejects_user_env_outside_runtime_dir_without_path_leak() {
+        let tmp = tempfile::tempdir().unwrap();
+        let runtime_dir = tmp.path().join("runtime");
+        let unexpected = tmp.path().join("other").join("user-env").join("env.json");
+
+        let raw = GuestConfigRaw {
+            user_env_file: unexpected.to_string_lossy().into_owned(),
+            guest_runtime_dir: Some(runtime_dir),
+            ..raw_config_fixture()
+        };
+
+        let err = GuestConfig::from_raw(raw).err().unwrap();
+
+        assert!(err.contains("user-env/env.json"));
+        assert!(!err.contains(unexpected.to_string_lossy().as_ref()));
     }
 
     #[test]

--- a/crates/guest-agent/src/lib.rs
+++ b/crates/guest-agent/src/lib.rs
@@ -18,6 +18,7 @@ pub mod masker;
 pub mod metrics;
 mod nofollow_fs;
 pub mod paths;
+pub mod run_context;
 pub mod session_history;
 pub mod session_history_identity;
 pub mod session_metadata;

--- a/crates/guest-agent/src/paths.rs
+++ b/crates/guest-agent/src/paths.rs
@@ -14,7 +14,148 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 
-static RUNTIME_DIR: LazyLock<PathBuf> = LazyLock::new(default_run_dir);
+static GUEST_PATHS: LazyLock<GuestPaths> =
+    LazyLock::new(|| GuestPaths::from_runtime_dir(default_run_dir()));
+
+/// Immutable run-scoped guest paths derived from one runtime directory.
+#[derive(Clone, Debug)]
+pub struct GuestPaths {
+    runtime_dir: PathBuf,
+    session_id_file: String,
+    session_history_path_file: String,
+    event_error_flag: String,
+    checkpoint_error_file: String,
+    final_session_history_identity_file: String,
+    failure_diagnostic_file: String,
+    system_log_file: String,
+    agent_log_file: String,
+    metrics_log_file: String,
+    sandbox_ops_file: String,
+    telemetry_system_log_pos_file: String,
+    telemetry_metrics_pos_file: String,
+    telemetry_sandbox_ops_pos_file: String,
+}
+
+impl GuestPaths {
+    /// Build all run-scoped paths from an explicit runtime directory.
+    pub fn from_runtime_dir(runtime_dir: impl Into<PathBuf>) -> Self {
+        let runtime_dir = runtime_dir.into();
+        Self {
+            session_id_file: path_to_string(guest_contracts::runtime_paths::session_id_file(
+                &runtime_dir,
+            )),
+            session_history_path_file: path_to_string(
+                guest_contracts::runtime_paths::session_history_marker_file(&runtime_dir),
+            ),
+            event_error_flag: path_to_string(guest_contracts::runtime_paths::event_error_file(
+                &runtime_dir,
+            )),
+            checkpoint_error_file: path_to_string(
+                guest_contracts::runtime_paths::checkpoint_error_file(&runtime_dir),
+            ),
+            final_session_history_identity_file: path_to_string(
+                guest_contracts::runtime_paths::final_session_history_identity_file(&runtime_dir),
+            ),
+            failure_diagnostic_file: path_to_string(
+                guest_contracts::runtime_paths::failure_diagnostic_file(&runtime_dir),
+            ),
+            system_log_file: path_to_string(guest_contracts::runtime_paths::system_log_file(
+                &runtime_dir,
+            )),
+            agent_log_file: path_to_string(guest_contracts::runtime_paths::agent_log_file(
+                &runtime_dir,
+            )),
+            metrics_log_file: path_to_string(guest_contracts::runtime_paths::metrics_log_file(
+                &runtime_dir,
+            )),
+            sandbox_ops_file: path_to_string(guest_contracts::runtime_paths::sandbox_ops_log_file(
+                &runtime_dir,
+            )),
+            telemetry_system_log_pos_file: path_to_string(
+                guest_contracts::runtime_paths::telemetry_system_log_pos_file(&runtime_dir),
+            ),
+            telemetry_metrics_pos_file: path_to_string(
+                guest_contracts::runtime_paths::telemetry_metrics_pos_file(&runtime_dir),
+            ),
+            telemetry_sandbox_ops_pos_file: path_to_string(
+                guest_contracts::runtime_paths::telemetry_sandbox_ops_pos_file(&runtime_dir),
+            ),
+            runtime_dir,
+        }
+    }
+
+    /// Build paths by resolving the current process runtime-dir contract.
+    pub fn from_process_env(
+        run_id: &str,
+    ) -> Result<Self, guest_contracts::runtime_paths::RuntimePathError> {
+        guest_contracts::runtime_paths::run_dir_from_env(run_id).map(Self::from_runtime_dir)
+    }
+
+    /// Build paths from a guest home and run id using the default layout.
+    pub fn from_home(
+        guest_home: impl AsRef<Path>,
+        run_id: &str,
+    ) -> Result<Self, guest_contracts::runtime_paths::RuntimePathError> {
+        guest_contracts::runtime_paths::run_dir_for_home(guest_home, run_id)
+            .map(Self::from_runtime_dir)
+    }
+
+    pub fn runtime_dir(&self) -> &Path {
+        &self.runtime_dir
+    }
+
+    pub fn session_id_file(&self) -> &str {
+        &self.session_id_file
+    }
+
+    pub fn session_history_path_file(&self) -> &str {
+        &self.session_history_path_file
+    }
+
+    pub fn event_error_flag(&self) -> &str {
+        &self.event_error_flag
+    }
+
+    pub fn checkpoint_error_file(&self) -> &str {
+        &self.checkpoint_error_file
+    }
+
+    pub fn final_session_history_identity_file(&self) -> &str {
+        &self.final_session_history_identity_file
+    }
+
+    pub fn failure_diagnostic_file(&self) -> &str {
+        &self.failure_diagnostic_file
+    }
+
+    pub fn system_log_file(&self) -> &str {
+        &self.system_log_file
+    }
+
+    pub fn agent_log_file(&self) -> &str {
+        &self.agent_log_file
+    }
+
+    pub fn metrics_log_file(&self) -> &str {
+        &self.metrics_log_file
+    }
+
+    pub fn sandbox_ops_file(&self) -> &str {
+        &self.sandbox_ops_file
+    }
+
+    pub fn telemetry_system_log_pos_file(&self) -> &str {
+        &self.telemetry_system_log_pos_file
+    }
+
+    pub fn telemetry_metrics_pos_file(&self) -> &str {
+        &self.telemetry_metrics_pos_file
+    }
+
+    pub fn telemetry_sandbox_ops_pos_file(&self) -> &str {
+        &self.telemetry_sandbox_ops_pos_file
+    }
+}
 
 #[allow(clippy::panic)]
 fn default_run_dir() -> PathBuf {
@@ -24,7 +165,7 @@ fn default_run_dir() -> PathBuf {
 }
 
 pub fn runtime_dir() -> &'static Path {
-    &RUNTIME_DIR
+    GUEST_PATHS.runtime_dir()
 }
 
 fn path_to_string(path: PathBuf) -> String {
@@ -43,81 +184,37 @@ pub fn write_private(path: impl AsRef<Path>, bytes: impl AsRef<[u8]>) -> io::Res
 // Session
 // ---------------------------------------------------------------------------
 
-static SESSION_ID_FILE: LazyLock<String> = LazyLock::new(|| {
-    path_to_string(guest_contracts::runtime_paths::session_id_file(
-        runtime_dir(),
-    ))
-});
-static SESSION_HISTORY_PATH_FILE: LazyLock<String> = LazyLock::new(|| {
-    path_to_string(guest_contracts::runtime_paths::session_history_marker_file(
-        runtime_dir(),
-    ))
-});
-
 pub fn session_id_file() -> &'static str {
-    &SESSION_ID_FILE
+    GUEST_PATHS.session_id_file()
 }
 pub fn session_history_path_file() -> &'static str {
-    &SESSION_HISTORY_PATH_FILE
+    GUEST_PATHS.session_history_path_file()
 }
 
 // ---------------------------------------------------------------------------
 // Log files
 // ---------------------------------------------------------------------------
 
-static EVENT_ERROR_FLAG: LazyLock<String> = LazyLock::new(|| {
-    path_to_string(guest_contracts::runtime_paths::event_error_file(
-        runtime_dir(),
-    ))
-});
-static CHECKPOINT_ERROR_FILE: LazyLock<String> = LazyLock::new(|| {
-    path_to_string(guest_contracts::runtime_paths::checkpoint_error_file(
-        runtime_dir(),
-    ))
-});
-static FINAL_SESSION_HISTORY_IDENTITY_FILE: LazyLock<String> = LazyLock::new(|| {
-    path_to_string(
-        guest_contracts::runtime_paths::final_session_history_identity_file(runtime_dir()),
-    )
-});
-static FAILURE_DIAGNOSTIC_FILE: LazyLock<String> = LazyLock::new(|| {
-    path_to_string(guest_contracts::runtime_paths::failure_diagnostic_file(
-        runtime_dir(),
-    ))
-});
-static SYSTEM_LOG_FILE: LazyLock<String> = LazyLock::new(|| {
-    path_to_string(guest_contracts::runtime_paths::system_log_file(
-        runtime_dir(),
-    ))
-});
-static AGENT_LOG_FILE: LazyLock<String> =
-    LazyLock::new(|| path_to_string(guest_contracts::runtime_paths::agent_log_file(runtime_dir())));
-static METRICS_LOG_FILE: LazyLock<String> = LazyLock::new(|| {
-    path_to_string(guest_contracts::runtime_paths::metrics_log_file(
-        runtime_dir(),
-    ))
-});
-
 pub fn event_error_flag() -> &'static str {
-    &EVENT_ERROR_FLAG
+    GUEST_PATHS.event_error_flag()
 }
 pub fn checkpoint_error_file() -> &'static str {
-    &CHECKPOINT_ERROR_FILE
+    GUEST_PATHS.checkpoint_error_file()
 }
 pub fn final_session_history_identity_file() -> &'static str {
-    &FINAL_SESSION_HISTORY_IDENTITY_FILE
+    GUEST_PATHS.final_session_history_identity_file()
 }
 pub fn failure_diagnostic_file() -> &'static str {
-    &FAILURE_DIAGNOSTIC_FILE
+    GUEST_PATHS.failure_diagnostic_file()
 }
 pub fn system_log_file() -> &'static str {
-    &SYSTEM_LOG_FILE
+    GUEST_PATHS.system_log_file()
 }
 pub fn agent_log_file() -> &'static str {
-    &AGENT_LOG_FILE
+    GUEST_PATHS.agent_log_file()
 }
 pub fn metrics_log_file() -> &'static str {
-    &METRICS_LOG_FILE
+    GUEST_PATHS.metrics_log_file()
 }
 
 /// Re-export sandbox ops log path from guest-common for consistent access.
@@ -129,24 +226,96 @@ pub fn sandbox_ops_file() -> &'static str {
 // Telemetry position tracking
 // ---------------------------------------------------------------------------
 
-static TELEMETRY_SYSTEM_LOG_POS_FILE: LazyLock<String> = LazyLock::new(|| {
-    path_to_string(guest_contracts::runtime_paths::telemetry_system_log_pos_file(runtime_dir()))
-});
-static TELEMETRY_METRICS_POS_FILE: LazyLock<String> = LazyLock::new(|| {
-    path_to_string(guest_contracts::runtime_paths::telemetry_metrics_pos_file(
-        runtime_dir(),
-    ))
-});
-static TELEMETRY_SANDBOX_OPS_POS_FILE: LazyLock<String> = LazyLock::new(|| {
-    path_to_string(guest_contracts::runtime_paths::telemetry_sandbox_ops_pos_file(runtime_dir()))
-});
-
 pub fn telemetry_system_log_pos_file() -> &'static str {
-    &TELEMETRY_SYSTEM_LOG_POS_FILE
+    GUEST_PATHS.telemetry_system_log_pos_file()
 }
 pub fn telemetry_metrics_pos_file() -> &'static str {
-    &TELEMETRY_METRICS_POS_FILE
+    GUEST_PATHS.telemetry_metrics_pos_file()
 }
 pub fn telemetry_sandbox_ops_pos_file() -> &'static str {
-    &TELEMETRY_SANDBOX_OPS_POS_FILE
+    GUEST_PATHS.telemetry_sandbox_ops_pos_file()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn guest_paths_derives_runtime_files_from_run_dir() {
+        let runtime_dir = PathBuf::from("/tmp/vm0-run");
+        let paths = GuestPaths::from_runtime_dir(runtime_dir.clone());
+
+        assert_eq!(paths.runtime_dir(), runtime_dir.as_path());
+        assert_eq!(
+            paths.session_id_file(),
+            guest_contracts::runtime_paths::session_id_file(&runtime_dir).to_string_lossy()
+        );
+        assert_eq!(
+            paths.session_history_path_file(),
+            guest_contracts::runtime_paths::session_history_marker_file(&runtime_dir)
+                .to_string_lossy()
+        );
+        assert_eq!(
+            paths.event_error_flag(),
+            guest_contracts::runtime_paths::event_error_file(&runtime_dir).to_string_lossy()
+        );
+        assert_eq!(
+            paths.checkpoint_error_file(),
+            guest_contracts::runtime_paths::checkpoint_error_file(&runtime_dir).to_string_lossy()
+        );
+        assert_eq!(
+            paths.final_session_history_identity_file(),
+            guest_contracts::runtime_paths::final_session_history_identity_file(&runtime_dir)
+                .to_string_lossy()
+        );
+        assert_eq!(
+            paths.failure_diagnostic_file(),
+            guest_contracts::runtime_paths::failure_diagnostic_file(&runtime_dir).to_string_lossy()
+        );
+        assert_eq!(
+            paths.system_log_file(),
+            guest_contracts::runtime_paths::system_log_file(&runtime_dir).to_string_lossy()
+        );
+        assert_eq!(
+            paths.agent_log_file(),
+            guest_contracts::runtime_paths::agent_log_file(&runtime_dir).to_string_lossy()
+        );
+        assert_eq!(
+            paths.metrics_log_file(),
+            guest_contracts::runtime_paths::metrics_log_file(&runtime_dir).to_string_lossy()
+        );
+        assert_eq!(
+            paths.sandbox_ops_file(),
+            guest_contracts::runtime_paths::sandbox_ops_log_file(&runtime_dir).to_string_lossy()
+        );
+        assert_eq!(
+            paths.telemetry_system_log_pos_file(),
+            guest_contracts::runtime_paths::telemetry_system_log_pos_file(&runtime_dir)
+                .to_string_lossy()
+        );
+        assert_eq!(
+            paths.telemetry_metrics_pos_file(),
+            guest_contracts::runtime_paths::telemetry_metrics_pos_file(&runtime_dir)
+                .to_string_lossy()
+        );
+        assert_eq!(
+            paths.telemetry_sandbox_ops_pos_file(),
+            guest_contracts::runtime_paths::telemetry_sandbox_ops_pos_file(&runtime_dir)
+                .to_string_lossy()
+        );
+    }
+
+    #[test]
+    fn guest_paths_from_home_uses_default_runtime_layout() {
+        let home = PathBuf::from("/home/vm0");
+        let paths = GuestPaths::from_home(&home, "run-123").unwrap();
+        let expected_runtime =
+            guest_contracts::runtime_paths::run_dir_for_home(&home, "run-123").unwrap();
+
+        assert_eq!(paths.runtime_dir(), expected_runtime.as_path());
+        assert_eq!(
+            paths.agent_log_file(),
+            guest_contracts::runtime_paths::agent_log_file(&expected_runtime).to_string_lossy()
+        );
+    }
 }

--- a/crates/guest-agent/src/run_context.rs
+++ b/crates/guest-agent/src/run_context.rs
@@ -1,0 +1,26 @@
+//! Explicit immutable guest-agent run context.
+
+use crate::env::GuestConfig;
+use crate::paths::GuestPaths;
+
+/// Immutable config and derived paths for one guest-agent run.
+#[derive(Clone)]
+pub struct GuestContext {
+    pub config: GuestConfig,
+    pub paths: GuestPaths,
+}
+
+impl GuestContext {
+    /// Build a run context from explicit config and paths.
+    pub fn new(config: GuestConfig, paths: GuestPaths) -> Self {
+        Self { config, paths }
+    }
+
+    /// Build a run context from the current process environment.
+    pub fn from_process_env() -> Result<Self, String> {
+        let config = GuestConfig::from_process_env()?;
+        let paths = GuestPaths::from_process_env(&config.run_id)
+            .map_err(|error| format!("failed to resolve guest runtime paths: {error}"))?;
+        Ok(Self::new(config, paths))
+    }
+}

--- a/crates/guest-agent/tests/guest_config_process_env.rs
+++ b/crates/guest-agent/tests/guest_config_process_env.rs
@@ -1,0 +1,39 @@
+//! Process-env config construction must coexist with legacy env accessors.
+//!
+//! This test lives in its own binary because `guest_agent::env` caches
+//! environment values in process-wide `LazyLock`s.
+
+#[test]
+fn process_env_config_and_legacy_accessors_share_user_env_load() {
+    let tmp = tempfile::tempdir().unwrap();
+    let runtime_dir = tmp.path().join("runtime");
+    let user_env_dir = runtime_dir.join("user-env");
+    let user_env_path = user_env_dir.join("env.json");
+    std::fs::create_dir_all(&user_env_dir).unwrap();
+    std::fs::write(
+        &user_env_path,
+        r#"{"OPENAI_MODEL":"gpt-process-env","HOME":"/home/from-user-env"}"#,
+    )
+    .unwrap();
+
+    unsafe {
+        std::env::set_var(guest_contracts::env::RUN_ID_ENV, "guest-config-process-env");
+        std::env::set_var("HOME", "/home/from-process-env");
+        std::env::set_var(guest_contracts::env::USER_ENV_FILE_ENV, &user_env_path);
+        std::env::set_var(
+            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+            &runtime_dir,
+        );
+    }
+
+    let config = guest_agent::env::GuestConfig::from_process_env().unwrap();
+
+    assert_eq!(config.user_env["OPENAI_MODEL"], "gpt-process-env");
+    assert_eq!(config.home_dir, "/home/from-user-env");
+    assert!(!user_env_path.exists());
+    assert!(!user_env_dir.exists());
+
+    guest_agent::env::init_user_env().unwrap();
+    assert_eq!(guest_agent::env::openai_model(), "gpt-process-env");
+    assert_eq!(guest_agent::env::home_dir(), "/home/from-user-env");
+}

--- a/crates/guest-agent/tests/guest_config_process_env_legacy_first.rs
+++ b/crates/guest-agent/tests/guest_config_process_env_legacy_first.rs
@@ -1,0 +1,42 @@
+//! Legacy env initialization must coexist with process-env config construction.
+//!
+//! This test lives in its own binary because `guest_agent::env` caches
+//! environment values in process-wide `LazyLock`s.
+
+#[test]
+fn legacy_accessors_and_process_env_config_share_user_env_load() {
+    let tmp = tempfile::tempdir().unwrap();
+    let runtime_dir = tmp.path().join("runtime");
+    let user_env_dir = runtime_dir.join("user-env");
+    let user_env_path = user_env_dir.join("env.json");
+    std::fs::create_dir_all(&user_env_dir).unwrap();
+    std::fs::write(
+        &user_env_path,
+        r#"{"OPENAI_MODEL":"gpt-legacy-first","HOME":"/home/from-user-env"}"#,
+    )
+    .unwrap();
+
+    unsafe {
+        std::env::set_var(
+            guest_contracts::env::RUN_ID_ENV,
+            "guest-config-legacy-first",
+        );
+        std::env::set_var("HOME", "/home/from-process-env");
+        std::env::set_var(guest_contracts::env::USER_ENV_FILE_ENV, &user_env_path);
+        std::env::set_var(
+            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+            &runtime_dir,
+        );
+    }
+
+    guest_agent::env::init_user_env().unwrap();
+    assert_eq!(guest_agent::env::openai_model(), "gpt-legacy-first");
+    assert_eq!(guest_agent::env::home_dir(), "/home/from-user-env");
+    assert!(!user_env_path.exists());
+    assert!(!user_env_dir.exists());
+
+    let config = guest_agent::env::GuestConfig::from_process_env().unwrap();
+
+    assert_eq!(config.user_env["OPENAI_MODEL"], "gpt-legacy-first");
+    assert_eq!(config.home_dir, "/home/from-user-env");
+}


### PR DESCRIPTION
## Summary

- add owned `GuestConfigRaw` / `GuestConfig` builders for guest-agent startup values
- add owned `GuestPaths` plus a thin `GuestContext` grouping type
- keep existing `env::*` and `paths::*` facades intact while sharing parsing/path derivation logic
- add focused tests for framework parsing, user-env cleanup, artifact parsing, duration parsing, and path derivation

Refs #19401

## Test plan

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent env::tests`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent paths::tests`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --lib`
- pre-commit hook: `cargo-doc`, `cargo-clippy`, `commitlint`