### PR TITLE
fix: enforce network policy allow grants

### DIFF
--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -211,6 +211,7 @@ UnknownPolicy = Literal["allow", "deny", "ask"]
 
 
 class _CompiledNetworkPolicy(NamedTuple):
+    allowed_permissions: frozenset[str]
     blocked_permissions: frozenset[str]
     unknown_policy: UnknownPolicy
     permission_malformed: bool
@@ -607,6 +608,9 @@ def _compile_rule(rule_str: str) -> _CompiledRule | None:
 # non-object top-level networkPolicies payload, non-object per-firewall grants,
 # malformed allow/deny/ask permission sets, and malformed unknownPolicy. It
 # skips non-string policy keys because they cannot address a firewall name.
+# A present per-firewall policy is an explicit grant list for known permission
+# rules; uncategorized known permissions fail closed at match time. Firewall
+# names absent from networkPolicies remain fully permissive.
 #
 # match_compiled_firewall_request applies retained malformed state only after a
 # request matches a compiled base. The relevant fail-closed reasons are
@@ -792,13 +796,14 @@ def compile_network_policies(raw_network_policies: object | None) -> CompiledNet
         if not isinstance(grant, dict):
             compiled[fw_name] = _CompiledNetworkPolicy(
                 frozenset(),
+                frozenset(),
                 "allow",
                 True,
                 False,
             )
             continue
 
-        _allow, allow_malformed = _compile_permission_set(grant.get("allow"))
+        allow, allow_malformed = _compile_permission_set(grant.get("allow"))
         deny, deny_malformed = _compile_permission_set(grant.get("deny"))
         ask, ask_malformed = _compile_permission_set(grant.get("ask"))
 
@@ -813,6 +818,7 @@ def compile_network_policies(raw_network_policies: object | None) -> CompiledNet
             unknown_policy_malformed = True
 
         compiled[fw_name] = _CompiledNetworkPolicy(
+            allow,
             deny | ask,
             unknown_policy,
             allow_malformed or deny_malformed or ask_malformed,
@@ -1121,8 +1127,11 @@ def _evaluate_rule_entries(
         if not decision.can_rule_specificity_affect_decision(rule.specificity):
             continue
 
-        permission_blocked = policy is not None and entry.permission in policy.blocked_permissions
-        if permission_blocked:
+        permission_denied = policy is not None and (
+            entry.permission in policy.blocked_permissions
+            or entry.permission not in policy.allowed_permissions
+        )
+        if permission_denied:
             if not _compiled_path_segments_match(rel_path_segs, rule.path.segments):
                 continue
             if not decision.accept_rule_specificity(rule.specificity):
@@ -1306,7 +1315,9 @@ def match_compiled_firewall_request(
     base, or auth config do not evaluate their rules; malformed permission/rule
     config can still leave valid compiled rules eligible. Malformed top-level
     policies or malformed allow/deny/ask permission sets skip rule evaluation
-    for the matched API. Recorded allow/deny rule decisions keep their current
+    for the matched API. Present per-firewall policies are explicit grants for
+    known permission rules; matched permissions absent from ``allow`` fail closed
+    as denied permissions. Recorded allow/deny rule decisions keep their current
     precedence over retained malformed state, and malformed ``unknownPolicy``
     only affects unknown-endpoint resolution.
 

--- a/crates/runner/mitm-addon/tests/test_compiled_firewall_malformed_policies.py
+++ b/crates/runner/mitm-addon/tests/test_compiled_firewall_malformed_policies.py
@@ -43,8 +43,8 @@ def test_direct_compile_firewalls_ignores_missing_empty_or_non_list_payloads(fir
 @pytest.mark.parametrize(
     "policies",
     [
-        {"github": {"deny": None, "ask": [], "unknownPolicy": "deny"}},
-        {"github": {"deny": [], "ask": None, "unknownPolicy": "deny"}},
+        {"github": {"allow": ["repo-read"], "deny": None, "ask": [], "unknownPolicy": "deny"}},
+        {"github": {"allow": ["repo-read"], "deny": [], "ask": None, "unknownPolicy": "deny"}},
     ],
 )
 def test_null_permission_lists_behave_as_empty(policies):
@@ -84,7 +84,9 @@ def test_malformed_permission_policy_fails_closed_after_base_match(policies):
 
 
 def test_invalid_unknown_policy_only_blocks_unknown_endpoint_branch():
-    policies = {"github": {"deny": [], "ask": [], "unknownPolicy": "broken"}}
+    policies = {
+        "github": {"allow": ["repo-read"], "deny": [], "ask": [], "unknownPolicy": "broken"}
+    }
     compiled_policies = matching.compile_network_policies(policies)
     compiled_firewalls = compile_firewalls_or_fail(_github_firewalls())
 

--- a/crates/runner/mitm-addon/tests/test_compiled_firewall_permission_aggregation.py
+++ b/crates/runner/mitm-addon/tests/test_compiled_firewall_permission_aggregation.py
@@ -36,6 +36,79 @@ def test_later_allowed_permission_still_wins_after_earlier_denied_match():
     assert compiled.permission == "repo-admin"
 
 
+def test_later_allowed_permission_still_wins_after_earlier_uncategorized_match():
+    fws = wrap_firewalls(
+        [
+            {
+                "base": "https://api.github.com",
+                "auth": {"headers": {"Authorization": "Bearer token"}},
+                "permissions": [
+                    {"name": "repo-read", "rules": ["GET /repos/{owner}/{repo}"]},
+                    {"name": "repo-admin", "rules": ["GET /repos/{owner}/{repo}"]},
+                ],
+            }
+        ],
+        name="github",
+    )
+    policies = {
+        "github": {
+            "allow": ["repo-admin"],
+            "deny": [],
+            "ask": [],
+            "unknownPolicy": "deny",
+        }
+    }
+    url = "https://api.github.com/repos/org/repo"
+    compiled = matching.match_compiled_firewall_request(
+        url,
+        "GET",
+        compile_firewalls_or_fail(fws),
+        policies,
+    )
+    assert isinstance(compiled, matching.FirewallAllow)
+    assert compiled.permission == "repo-admin"
+
+
+def test_uncategorized_permission_names_keep_encounter_order_and_deduplicate():
+    fws = wrap_firewalls(
+        [
+            {
+                "base": "https://api.github.com",
+                "auth": {"headers": {"Authorization": "Bearer token"}},
+                "permissions": [
+                    {
+                        "name": "repo-read",
+                        "rules": [
+                            "GET /repos/{owner}/{repo}",
+                            "ANY /repos/{owner}/{repo}",
+                        ],
+                    },
+                    {"name": "repo-admin", "rules": ["GET /repos/{owner}/{repo}"]},
+                ],
+            }
+        ],
+        name="github",
+    )
+    policies = {
+        "github": {
+            "allow": [],
+            "deny": [],
+            "ask": [],
+            "unknownPolicy": "deny",
+        }
+    }
+    url = "https://api.github.com/repos/org/repo"
+    compiled = matching.match_compiled_firewall_request(
+        url,
+        "GET",
+        compile_firewalls_or_fail(fws),
+        policies,
+    )
+    assert isinstance(compiled, matching.FirewallBlock)
+    assert compiled.permissions == ("repo-read", "repo-admin")
+    assert compiled.reason == "permission_denied"
+
+
 def test_denied_permission_names_keep_encounter_order_and_deduplicate():
     fws = wrap_firewalls(
         [

--- a/crates/runner/mitm-addon/tests/test_compiled_firewall_rule_specificity_precedence.py
+++ b/crates/runner/mitm-addon/tests/test_compiled_firewall_rule_specificity_precedence.py
@@ -72,7 +72,7 @@ def test_literal_rule_wins_over_earlier_parameter_rule():
         ],
     }
     fws = wrap_firewalls([api_entry], name="x")
-    policies = {"x": {"allow": [], "deny": [], "unknownPolicy": "deny"}}
+    policies = {"x": {"allow": ["community-search"], "deny": [], "unknownPolicy": "deny"}}
 
     result = matching.match_compiled_firewall_request(
         "https://api.x.com/2/communities/search",
@@ -97,7 +97,13 @@ def test_denied_parameter_rule_does_not_block_more_specific_literal_allow():
         ],
     }
     fws = wrap_firewalls([api_entry], name="x")
-    policies = {"x": {"allow": [], "deny": ["community-by-id"], "unknownPolicy": "deny"}}
+    policies = {
+        "x": {
+            "allow": ["community-search"],
+            "deny": ["community-by-id"],
+            "unknownPolicy": "deny",
+        }
+    }
 
     result = matching.match_compiled_firewall_request(
         "https://api.x.com/2/communities/search",
@@ -146,7 +152,7 @@ def test_more_specific_parameter_shape_wins(
         ],
     }
     fws = wrap_firewalls([api_entry], name="example")
-    policies = {"example": {"allow": [], "deny": [], "unknownPolicy": "deny"}}
+    policies = {"example": {"allow": ["later"], "deny": [], "unknownPolicy": "deny"}}
 
     result = matching.match_compiled_firewall_request(
         url,
@@ -216,7 +222,7 @@ def test_many_lower_specificity_denies_do_not_shadow_later_literal_allow():
     fws = wrap_firewalls([api_entry], name="example")
     policies = {
         "example": {
-            "allow": [],
+            "allow": ["admin-read"],
             "deny": [permission["name"] for permission in broad_permissions],
             "unknownPolicy": "deny",
         }

--- a/crates/runner/mitm-addon/tests/test_firewall_network_policy_decisions.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_network_policy_decisions.py
@@ -280,8 +280,8 @@ class TestFirewallNetworkPolicyDecisions:
         assert result.permissions == ("repo-read",)
         assert result.reason == "permission_denied"
 
-    def test_uncategorized_permission_allowed(self):
-        """Permission not in allow/deny/ask defaults to allowed."""
+    def test_permission_absent_from_present_policy_is_blocked(self):
+        """Permission not in allow/deny/ask fails closed for a present policy."""
         policies = {"github": {"allow": [], "deny": [], "ask": [], "unknownPolicy": "deny"}}
         result = match_request_with_raw_firewalls(
             "https://api.github.com/repos/org/repo",
@@ -289,8 +289,23 @@ class TestFirewallNetworkPolicyDecisions:
             self._firewalls(),
             network_policies=policies,
         )
-        assert isinstance(result, matching.FirewallAllow)
-        assert result.permission == "repo-read"
+        assert isinstance(result, matching.FirewallBlock)
+        assert result.permissions == ("repo-read",)
+        assert result.reason == "permission_denied"
+
+    def test_permission_absent_from_allow_is_blocked_even_when_other_permission_allowed(self):
+        policies = {
+            "github": {"allow": ["repo-read"], "deny": [], "ask": [], "unknownPolicy": "deny"}
+        }
+        result = match_request_with_raw_firewalls(
+            "https://api.github.com/repos/org/repo",
+            "PUT",
+            self._firewalls(),
+            network_policies=policies,
+        )
+        assert isinstance(result, matching.FirewallBlock)
+        assert result.permissions == ("repo-write",)
+        assert result.reason == "permission_denied"
 
     def test_ask_permission_blocked(self):
         """Permission in ask list is treated as denied at proxy level."""
@@ -444,8 +459,8 @@ class TestFirewallNetworkPolicyDecisions:
     @pytest.mark.parametrize(
         "policies",
         [
-            {"github": {"deny": None, "ask": [], "unknownPolicy": "deny"}},
-            {"github": {"deny": [], "ask": None, "unknownPolicy": "deny"}},
+            {"github": {"allow": ["repo-read"], "deny": None, "ask": [], "unknownPolicy": "deny"}},
+            {"github": {"allow": ["repo-read"], "deny": [], "ask": None, "unknownPolicy": "deny"}},
         ],
     )
     def test_null_permission_lists_behave_as_empty(self, policies):
@@ -500,7 +515,9 @@ class TestFirewallNetworkPolicyDecisions:
         assert matched.reason == "malformed_network_policy"
 
     def test_invalid_unknown_policy_only_blocks_unknown_endpoint_branch(self):
-        policies = {"github": {"deny": [], "ask": [], "unknownPolicy": "broken"}}
+        policies = {
+            "github": {"allow": ["repo-read"], "deny": [], "ask": [], "unknownPolicy": "broken"}
+        }
 
         allowed = match_request_with_raw_firewalls(
             "https://api.github.com/repos/org/repo",

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -14,8 +14,12 @@ import {
   UNKNOWN_PERMISSION_GRANT,
   type ExecutionFirewallEntry,
   type FirewallApi,
+  type NetworkPolicies,
 } from "@vm0/connectors/firewall-types";
-import { getFirewallExecutionMetadata } from "@vm0/connectors/firewall-metadata/server";
+import {
+  getFirewallExecutionMetadata,
+  loadFirewallPermissionIndex,
+} from "@vm0/connectors/firewall-metadata/server";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
 import { createStore } from "ccstate";
@@ -82,6 +86,35 @@ const CLAIM_ROUTE_TOP_LEVEL_TIMING_ACTION_TYPES = [
   "claim_route_response_assembly",
   "claim_route_transition_running",
 ] as const;
+
+async function expectCompleteBuiltinNetworkPolicy(
+  connectorType: string,
+  policy: NetworkPolicies[string],
+): Promise<void> {
+  const index = await loadFirewallPermissionIndex(connectorType);
+  if (!index) {
+    throw new Error(
+      `Expected firewall permission metadata for ${connectorType}`,
+    );
+  }
+
+  const categorized = new Map<string, string>();
+  for (const [action, names] of [
+    ["allow", policy.allow],
+    ["deny", policy.deny],
+    ["ask", policy.ask],
+  ] as const) {
+    for (const name of names) {
+      expect(index.hasPermission(name)).toBeTruthy();
+      expect(categorized.get(name)).toBeUndefined();
+      categorized.set(name, action);
+    }
+  }
+
+  expect([...categorized.keys()].sort()).toStrictEqual(
+    [...index.permissionNames].sort(),
+  );
+}
 const CLAIM_ROUTE_TRANSITION_TIMING_ACTION_TYPES = [
   "claim_route_transition_lock_run",
   "claim_route_transition_lock_queue_job",
@@ -2924,11 +2957,9 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     });
     await api.enableAgentConnectors(actor, agentId, ["slack"]);
 
-    async function claimSlackPolicy(prompt: string): Promise<{
-      readonly allow: readonly string[];
-      readonly deny: readonly string[];
-      readonly unknownPolicy?: string;
-    }> {
+    async function claimSlackPolicy(
+      prompt: string,
+    ): Promise<NetworkPolicies[string]> {
       const run = await api.createRun(actor, {
         agentId,
         prompt,
@@ -2945,6 +2976,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
 
     await api.heartbeatRunner(runnerGroup);
     const defaults = await claimSlackPolicy("no grants yet");
+    await expectCompleteBuiltinNetworkPolicy("slack", defaults);
     expect(defaults.allow).toContain("conversations:read");
     expect(defaults.allow).toContain("users:read");
     expect(defaults.deny).toContain("chat:write");
@@ -3048,10 +3080,13 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       action: "deny",
     });
     const snapshotClaim = await api.claimRunnerJob(snapshotRun.runId);
-    expect(snapshotClaim.networkPolicies?.slack?.allow).toContain("chat:write");
-    expect(snapshotClaim.networkPolicies?.slack?.deny).not.toContain(
-      "chat:write",
-    );
+    const snapshotPolicy = snapshotClaim.networkPolicies?.slack;
+    if (!snapshotPolicy) {
+      throw new Error("Expected a slack network policy on the snapshot claim");
+    }
+    await expectCompleteBuiltinNetworkPolicy("slack", snapshotPolicy);
+    expect(snapshotPolicy.allow).toContain("chat:write");
+    expect(snapshotPolicy.deny).not.toContain("chat:write");
 
     await api.requestCancelRun(actor, snapshotRun.runId, [200]);
     const drained = await api.readRunQueue(actor);
@@ -3075,11 +3110,9 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     });
     await api.enableAgentConnectors(actor, agentId, ["cloudflare"]);
 
-    async function claimCloudflarePolicy(prompt: string): Promise<{
-      readonly allow: readonly string[];
-      readonly deny: readonly string[];
-      readonly unknownPolicy?: string;
-    }> {
+    async function claimCloudflarePolicy(
+      prompt: string,
+    ): Promise<NetworkPolicies[string]> {
       const run = await api.createRun(actor, {
         agentId,
         prompt,
@@ -3096,6 +3129,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
 
     await api.heartbeatRunner(runnerGroup);
     const defaults = await claimCloudflarePolicy("default unknown policy");
+    await expectCompleteBuiltinNetworkPolicy("cloudflare", defaults);
     expect(defaults.allow).toContain("dns-firewall.read");
     expect(defaults.deny).toContain("dns-firewall.write");
     expect(defaults.unknownPolicy).toBe("deny");
@@ -3108,6 +3142,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     });
 
     const overridden = await claimCloudflarePolicy("allow unknown endpoints");
+    await expectCompleteBuiltinNetworkPolicy("cloudflare", overridden);
     expect(overridden.allow).toContain("dns-firewall.read");
     expect(overridden.deny).toContain("dns-firewall.write");
     expect(overridden.unknownPolicy).toBe("allow");
@@ -3177,8 +3212,61 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     if (!policy) {
       throw new Error("Expected a cloudflare network policy on the claim");
     }
+    await expectCompleteBuiltinNetworkPolicy("cloudflare", policy);
     expect(policy.allow).toContain("dns-firewall.read");
     expect(policy.deny).toContain("dns-firewall.write");
+    expect(policy.unknownPolicy).toBe("deny");
+
+    await api.requestCancelRun(actor, run.runId, [200]);
+  });
+
+  it("resolves sparse direct-run permission policies into complete execution policies", async () => {
+    const bdd = createBddApi(context);
+    const api = createRunsAutomationsApi(context);
+    const fw = createFirewallApi(context);
+    const actor = bdd.user();
+    bdd.acceptAgentStorageWrites();
+    api.acceptStorageDownloads();
+    api.acceptTelemetryIngest();
+    const runnerGroup = api.configureRunnerGroup();
+    await api.grantProEntitlement(actor);
+
+    await fw.seedTestConnector(actor, {
+      connectorName: "cloudflare",
+      authMethod: "oauth",
+      accessToken: "cloudflare-direct-sparse-policy-bdd-token",
+    });
+    const composeName = `bdd-cloudflare-sparse-policy-${randomUUID().slice(0, 8)}`;
+    const compose = await api.createCompose(actor, {
+      version: "1",
+      agents: {
+        [composeName]: {
+          framework: "claude-code",
+          environment: { ANTHROPIC_API_KEY: "bdd-inline-key" },
+        },
+      },
+    });
+
+    const run = await api.createDirectRun(actor, {
+      agentComposeId: compose.composeId,
+      prompt: "direct run cloudflare sparse policy",
+      permissionPolicies: {
+        cloudflare: {
+          policies: { "dns-firewall.write": "allow" },
+        },
+      },
+    });
+
+    await api.heartbeatRunner(runnerGroup);
+    const claim = await api.claimRunnerJob(run.runId);
+    const policy = claim.networkPolicies?.cloudflare;
+    if (!policy) {
+      throw new Error("Expected a cloudflare network policy on the claim");
+    }
+    await expectCompleteBuiltinNetworkPolicy("cloudflare", policy);
+    expect(policy.allow).toContain("dns-firewall.read");
+    expect(policy.allow).toContain("dns-firewall.write");
+    expect(policy.deny).not.toContain("dns-firewall.write");
     expect(policy.unknownPolicy).toBe("deny");
 
     await api.requestCancelRun(actor, run.runId, [200]);

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -3025,6 +3025,10 @@ function networkPolicyForFirewallPolicy(
       deny.push(name);
     } else if (value === "ask") {
       ask.push(name);
+    } else {
+      throw new Error(
+        `Missing firewall policy action for permission "${name}"`,
+      );
     }
   }
 
@@ -3172,7 +3176,7 @@ function applyConnectorPolicies(
     networkPolicies[firewall.name] = networkPolicyForFirewallPolicy(
       permissionNames,
       {
-        ...policy,
+        policies: { ...defaultPolicy.policies, ...policy.policies },
         unknownPolicy: policy.unknownPolicy ?? defaultPolicy.unknownPolicy,
       },
     );
@@ -3258,7 +3262,7 @@ function applyBuiltinConnectorMetadataPolicies(
     }
 
     networkPolicies[name] = networkPolicyForFirewallPolicy(permissionNames, {
-      ...policy,
+      policies: { ...defaultPolicy.policies, ...policy.policies },
       unknownPolicy: policy.unknownPolicy ?? defaultPolicy.unknownPolicy,
     });
   }


### PR DESCRIPTION
## Summary
- enforce `networkPolicies.<firewall>.allow` as explicit known-permission grants in the mitm matcher
- keep absent firewall policies permissive and keep unknown endpoints governed by `unknownPolicy`
- resolve sparse API permission-policy overlays against default policies before emitting complete execution `networkPolicies`

Fixes #19423

## Tests
- `cd crates/runner/mitm-addon && python3 -m ruff check src tests && python3 -m basedpyright src tests`
- `cd crates/runner/mitm-addon && pytest tests/test_compiled_firewall_malformed_policies.py tests/test_firewall_network_policy_decisions.py tests/test_compiled_firewall_permission_aggregation.py tests/test_compiled_firewall_rule_specificity_precedence.py && pytest tests/`
- `cd turbo && pnpm -F @vm0/db db:migrate`
- `cd turbo && pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `cd turbo && pnpm -F api lint && pnpm -F api check-types`
- pre-commit hook: ruff, prettier, knip, full `turbo run check-types --concurrency=1`