### PR TITLE
refactor: restrict www api base to oauth flows

### DIFF
--- a/turbo/apps/platform/src/signals/api-client.ts
+++ b/turbo/apps/platform/src/signals/api-client.ts
@@ -24,8 +24,20 @@ export type ZeroClientFactory = <T extends AppRouter>(
   options?: ZeroClientOptions,
 ) => InitClientReturn<T, InitClientArgs>;
 
+declare const oauthWebApiBaseBrand: unique symbol;
+
+type OAuthWebApiBase = "www" & {
+  readonly [oauthWebApiBaseBrand]: true;
+};
+
+/**
+ * Web-origin API base is reserved for OAuth and web-origin handoff flows only.
+ * Normal platform API calls should use the default API backend or `apiBase: "api"`.
+ */
+export const OAUTH_WEB_API_BASE = "www" as OAuthWebApiBase;
+
 export interface ZeroClientOptions {
-  readonly apiBase?: "auto" | "api" | "www";
+  readonly apiBase?: "auto" | "api" | OAuthWebApiBase;
 }
 
 function rebaseApiPath(path: string, apiBase: string): string {
@@ -62,8 +74,11 @@ export const zeroClient$ = computed((get) => {
         if (options?.apiBase === "api") {
           return rebaseApiPath(path, resolveApiBaseForTarget("api"));
         }
-        if (options?.apiBase === "www") {
-          return rebaseApiPath(path, resolveApiBaseForTarget("www"));
+        if (options?.apiBase === OAUTH_WEB_API_BASE) {
+          return rebaseApiPath(
+            path,
+            resolveApiBaseForTarget(OAUTH_WEB_API_BASE),
+          );
         }
         return rebaseApiPath(path, resolveApiBase());
       },

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -13,11 +13,11 @@ export const FEATURE_SWITCH_CACHE_KEY = "vm0:feature-switch-cache:v1";
 const { set$: setFeatureSwitchLocalStorage$, get$: featureSwitchCache$ } =
   localStorageSignals(FEATURE_SWITCH_CACHE_KEY);
 
-// Pinned to the web backend: feature switches bootstrap before the platform API
-// client is available, and this keeps Lab overrides on the web origin.
-const webFeatureSwitchClient$ = computed((get) => {
+// Pinned to the API backend: feature switches bootstrap before the platform API
+// client is available.
+const apiFeatureSwitchClient$ = computed((get) => {
   return createAuthedContractClient(zeroFeatureSwitchesContract, {
-    baseUrl: resolveApiBaseForTarget("www"),
+    baseUrl: resolveApiBaseForTarget("api"),
     getClerk: () => {
       return get(clerk$);
     },
@@ -59,7 +59,7 @@ export const reloadFeatureSwitch$ = command(
       return;
     }
 
-    const client = get(webFeatureSwitchClient$);
+    const client = get(apiFeatureSwitchClient$);
     const result = await accept(
       client.get({ fetchOptions: { signal } }),
       [200],
@@ -83,7 +83,7 @@ export const setFeatureSwitch$ = command(
     overrides: Partial<Record<FeatureSwitchKey, boolean>>,
     signal: AbortSignal,
   ) => {
-    const client = get(webFeatureSwitchClient$);
+    const client = get(apiFeatureSwitchClient$);
     signal.throwIfAborted();
     await accept(
       client.update({
@@ -99,7 +99,7 @@ export const setFeatureSwitch$ = command(
 
 export const resetFeatureSwitches$ = command(
   async ({ get, set }, signal: AbortSignal) => {
-    const client = get(webFeatureSwitchClient$);
+    const client = get(apiFeatureSwitchClient$);
     signal.throwIfAborted();
     await accept(client.delete({ fetchOptions: { signal } }), [200]);
     signal.throwIfAborted();

--- a/turbo/apps/platform/src/signals/fetch.ts
+++ b/turbo/apps/platform/src/signals/fetch.ts
@@ -3,14 +3,16 @@ import { clerk$ } from "./auth.ts";
 import { fetchFreshToken, handleUnauthorizedRedirect } from "./auth-retry.ts";
 import { resolveApiBase, resolveApiBaseForNavigation } from "./api-base.ts";
 
+const OAUTH_WEB_NAVIGATION_TARGET = "www";
+
 /**
- * Web base URL for opening external navigation (e.g. connector OAuth popup).
+ * Web base URL for OAuth and web-origin handoff navigation only.
  * - On localhost: use VITE_API_URL so the popup hits the configured API (e.g. :3000).
  * - On a non-localhost host (e.g. app.vm7.ai): derive from current origin
  *   (e.g. www.vm7.ai) so we never open a localhost URL when the user is remote.
  */
 export const webBaseForNavigation$ = computed(() => {
-  return resolveApiBaseForNavigation("www");
+  return resolveApiBaseForNavigation(OAUTH_WEB_NAVIGATION_TARGET);
 });
 
 /**

--- a/turbo/apps/platform/src/signals/zero-page/html-dom-comment-editor.ts
+++ b/turbo/apps/platform/src/signals/zero-page/html-dom-comment-editor.ts
@@ -1,5 +1,5 @@
 import { createElement } from "react";
-import { IconPointer2 } from "@tabler/icons-react";
+import { IconPointer } from "@tabler/icons-react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { command, computed, state } from "ccstate";
 import {
@@ -120,7 +120,7 @@ const FRAME_COMMENT_COLLISION_GAP = 6;
 const FRAME_COMMENT_NUDGE_STEP = 12;
 const FRAME_COMMENT_NUDGE_STEPS = [0, 1, -1, 2, -2] as const;
 const FRAME_NAVIGATION_CURSOR_SVG = renderToStaticMarkup(
-  createElement(IconPointer2, {
+  createElement(IconPointer, {
     "aria-hidden": "true",
     color: "#2563eb",
     size: 20,

--- a/turbo/apps/platform/src/signals/zero-page/settings/claude-code-device-auth.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/claude-code-device-auth.ts
@@ -100,7 +100,7 @@ function isActive(
 const startClaudeCodeDeviceAuth$ = command(
   async ({ get }, scope: ClaudeCodeDeviceAuthScope, signal: AbortSignal) => {
     const client = get(zeroClient$)(zeroClaudeCodeDeviceAuthContract, {
-      apiBase: "www",
+      apiBase: "api",
     });
     const result = await accept(
       client.start({
@@ -122,7 +122,7 @@ const completeClaudeCodeDeviceAuth$ = command(
     signal: AbortSignal,
   ) => {
     const client = get(zeroClient$)(zeroClaudeCodeDeviceAuthContract, {
-      apiBase: "www",
+      apiBase: "api",
     });
     const result = await accept(
       client.complete({
@@ -143,7 +143,7 @@ const completeClaudeCodeDeviceAuth$ = command(
 const cancelClaudeCodeDeviceAuth$ = command(
   async ({ get }, sessionToken: string, signal: AbortSignal) => {
     const client = get(zeroClient$)(zeroClaudeCodeDeviceAuthContract, {
-      apiBase: "www",
+      apiBase: "api",
     });
     const result = await accept(
       client.cancel({

--- a/turbo/apps/platform/src/signals/zero-page/settings/codex-device-auth.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/codex-device-auth.ts
@@ -142,7 +142,7 @@ function activeFlowOrExpired(
 const startCodexDeviceAuth$ = command(
   async ({ get }, scope: CodexDeviceAuthScope, signal: AbortSignal) => {
     const client = get(zeroClient$)(zeroCodexDeviceAuthContract, {
-      apiBase: "www",
+      apiBase: "api",
     });
     const result = await accept(
       client.start({
@@ -159,7 +159,7 @@ const startCodexDeviceAuth$ = command(
 const completeCodexDeviceAuth$ = command(
   async ({ get }, sessionToken: string, signal: AbortSignal) => {
     const client = get(zeroClient$)(zeroCodexDeviceAuthContract, {
-      apiBase: "www",
+      apiBase: "api",
     });
     const result = await accept(
       client.complete({
@@ -177,7 +177,7 @@ const completeCodexDeviceAuth$ = command(
 const cancelCodexDeviceAuth$ = command(
   async ({ get }, sessionToken: string, signal: AbortSignal) => {
     const client = get(zeroClient$)(zeroCodexDeviceAuthContract, {
-      apiBase: "www",
+      apiBase: "api",
     });
     const result = await accept(
       client.cancel({

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -45,7 +45,11 @@ import {
   reloadConnectors$,
 } from "../../external/connectors.ts";
 import { replaceSearchParams$, searchParams$ } from "../../route.ts";
-import { zeroClient$, type ZeroClientFactory } from "../../api-client.ts";
+import {
+  OAUTH_WEB_API_BASE,
+  zeroClient$,
+  type ZeroClientFactory,
+} from "../../api-client.ts";
 import {
   jsonParseOr,
   resetSignal,
@@ -1026,7 +1030,7 @@ const pollConnectorOAuthDeviceAuth$ = command(
     signal: AbortSignal,
   ): Promise<boolean> => {
     const client = createClient(zeroConnectorOauthDeviceAuthSessionContract, {
-      apiBase: "www",
+      apiBase: OAUTH_WEB_API_BASE,
     });
     const isCurrentRequest = (state: ConnectorOAuthDeviceAuthState) => {
       return isCurrentConnectorOAuthDeviceAuthRequest(
@@ -1181,7 +1185,7 @@ const connectConnectorOAuthDeviceAuth$ = command(
         const createClient = get(zeroClient$);
         const client = createClient(
           zeroConnectorOauthDeviceAuthSessionContract,
-          { apiBase: "www" },
+          { apiBase: OAUTH_WEB_API_BASE },
         );
         const startOptionEntries = Object.entries(startOptions ?? {});
         const startSettled = await settle(
@@ -1434,7 +1438,7 @@ export const connectConnectorExternalCode$ = command(
 
         const createClient = get(zeroClient$);
         const client = createClient(zeroConnectorExternalCodeSessionContract, {
-          apiBase: "www",
+          apiBase: OAUTH_WEB_API_BASE,
         });
         const startSettled = await settle(
           accept(
@@ -1549,7 +1553,7 @@ const completeConnectorExternalCode$ = command(
     const flowSignal = set(resetConnectorExternalCodeFlowSignal$, signal);
     const createClient = get(zeroClient$);
     const client = createClient(zeroConnectorExternalCodeSessionContract, {
-      apiBase: "www",
+      apiBase: OAUTH_WEB_API_BASE,
     });
     const completeSettled = await settle(
       accept(
@@ -1774,7 +1778,7 @@ const openConnectorOAuthAuthCodeWindow$ = command(
     }
 
     const startClient = get(zeroClient$)(zeroConnectorOauthStartContract, {
-      apiBase: "www",
+      apiBase: OAUTH_WEB_API_BASE,
     });
     const startResult = await accept(
       startClient.start({

--- a/turbo/apps/platform/src/views/zero-page/html-dom-edit-protocol.ts
+++ b/turbo/apps/platform/src/views/zero-page/html-dom-edit-protocol.ts
@@ -73,13 +73,13 @@ const STRUCTURAL_SELECTOR = [
   "ul",
 ].join(",");
 
-export interface InstrumentHtmlDomEditDocumentParams {
+interface InstrumentHtmlDomEditDocumentParams {
   readonly baseHref?: string;
   readonly html: string;
   readonly nodeIdPrefix?: string;
 }
 
-export interface InstrumentedHtmlDomEditDocument {
+interface InstrumentedHtmlDomEditDocument {
   readonly html: string;
   readonly nodeIds: readonly string[];
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
@@ -22,6 +22,7 @@ import type { ChatThreadArtifactFile } from "@vm0/api-contracts/contracts/chat-t
 import { useGet, useLastResolved, useSet } from "ccstate-react";
 import { accept } from "../../lib/accept.ts";
 import {
+  OAUTH_WEB_API_BASE,
   zeroClient$,
   type ZeroClientFactory,
 } from "../../signals/api-client.ts";
@@ -147,7 +148,7 @@ function startGoogleDriveConnectAndSync(params: {
   detach(
     (async () => {
       const client = params.createClient(zeroConnectorOauthStartContract, {
-        apiBase: "www",
+        apiBase: OAUTH_WEB_API_BASE,
       });
       const result = await accept(
         client.start({


### PR DESCRIPTION
## Summary
- route feature switch overrides and Codex/Claude device auth calls to the API backend
- introduce OAUTH_WEB_API_BASE so www-origin API calls are explicit OAuth/web-origin handoff exceptions
- keep connector OAuth and Google Drive OAuth on the web-origin constant
- clean up platform type issues surfaced by pre-commit

## Verification
- lefthook pre-commit: prettier, knip, check-types
- pnpm -F @vm0/app exec oxlint src/signals/api-client.ts src/signals/fetch.ts src/signals/external/feature-switch.ts src/signals/zero-page/settings/codex-device-auth.ts src/signals/zero-page/settings/claude-code-device-auth.ts src/signals/zero-page/settings/connectors.ts src/views/zero-page/zero-artifact-actions.tsx
- pnpm -F @vm0/app check-types