### PR TITLE
perf: cache held-session state for runner claim

### DIFF
--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -30,6 +30,7 @@ pub(super) struct HeartbeatContext<'a> {
     provider: &'a dyn JobProvider,
     workspace_cache: Option<SessionWorkspaceCache>,
     active_cli_agent_sessions: &'a ActiveCliAgentSessions,
+    held_session_snapshot: HeldSessionStateSnapshot,
 }
 
 pub(super) struct HeartbeatContextInit<'a> {
@@ -42,6 +43,7 @@ pub(super) struct HeartbeatContextInit<'a> {
     pub(super) provider: &'a dyn JobProvider,
     pub(super) workspace_cache: Option<SessionWorkspaceCache>,
     pub(super) active_cli_agent_sessions: &'a ActiveCliAgentSessions,
+    pub(super) held_session_snapshot: HeldSessionStateSnapshot,
 }
 
 impl<'a> HeartbeatContext<'a> {
@@ -56,7 +58,38 @@ impl<'a> HeartbeatContext<'a> {
             provider: init.provider,
             workspace_cache: init.workspace_cache,
             active_cli_agent_sessions: init.active_cli_agent_sessions,
+            held_session_snapshot: init.held_session_snapshot,
         }
+    }
+}
+
+#[derive(Clone, Default)]
+pub(super) struct HeldSessionStateSnapshot {
+    workspace_cache_states: Arc<tokio::sync::Mutex<Vec<HeldSessionState>>>,
+}
+
+impl HeldSessionStateSnapshot {
+    pub(super) fn new() -> Self {
+        Self::default()
+    }
+
+    async fn update_workspace_cache_states(&self, states: Vec<HeldSessionState>) {
+        *self.workspace_cache_states.lock().await = states;
+    }
+
+    pub(super) async fn current_held_session_states(
+        &self,
+        idle_states: Vec<HeldSessionState>,
+        active_cli_agent_sessions: &ActiveCliAgentSessions,
+        extra_active_session: Option<&str>,
+    ) -> Vec<HeldSessionState> {
+        let workspace_cache_states = self.workspace_cache_states.lock().await.clone();
+        merge_current_held_session_states(
+            idle_states,
+            workspace_cache_states,
+            active_cli_agent_sessions,
+            extra_active_session,
+        )
     }
 }
 
@@ -74,13 +107,17 @@ pub(super) async fn send_heartbeat(hb: &HeartbeatContext<'_>, mode: RunnerMode) 
         mode,
     );
     drop(pool);
-    state.held_session_states = current_held_session_states(
+    let workspace_cache_states =
+        workspace_cache_held_session_states(hb.workspace_cache.as_ref()).await;
+    hb.held_session_snapshot
+        .update_workspace_cache_states(workspace_cache_states.clone())
+        .await;
+    state.held_session_states = merge_current_held_session_states(
         state.held_session_states,
-        hb.workspace_cache.as_ref(),
+        workspace_cache_states,
         hb.active_cli_agent_sessions,
         None,
-    )
-    .await;
+    );
     info!(
         mode = ?mode,
         running = state.running_count,
@@ -97,21 +134,42 @@ pub(super) async fn send_heartbeat(hb: &HeartbeatContext<'_>, mode: RunnerMode) 
     hb.provider.heartbeat(&state).await;
 }
 
+#[cfg(test)]
 pub(super) async fn current_held_session_states(
     idle_states: Vec<HeldSessionState>,
     workspace_cache: Option<&SessionWorkspaceCache>,
     active_cli_agent_sessions: &ActiveCliAgentSessions,
     extra_active_session: Option<&str>,
 ) -> Vec<HeldSessionState> {
+    let cache_states = workspace_cache_held_session_states(workspace_cache).await;
+    merge_current_held_session_states(
+        idle_states,
+        cache_states,
+        active_cli_agent_sessions,
+        extra_active_session,
+    )
+}
+
+async fn workspace_cache_held_session_states(
+    workspace_cache: Option<&SessionWorkspaceCache>,
+) -> Vec<HeldSessionState> {
     let Some(cache) = workspace_cache else {
-        return idle_states;
+        return Vec::new();
     };
 
+    cache.held_session_states().await
+}
+
+fn merge_current_held_session_states(
+    idle_states: Vec<HeldSessionState>,
+    cache_states: Vec<HeldSessionState>,
+    active_cli_agent_sessions: &ActiveCliAgentSessions,
+    extra_active_session: Option<&str>,
+) -> Vec<HeldSessionState> {
     let mut active_cli_agent_sessions = active_cli_agent_session_ids(active_cli_agent_sessions);
     if let Some(session_id) = extra_active_session {
         active_cli_agent_sessions.insert(session_id.to_owned());
     }
-    let cache_states = cache.held_session_states().await;
     merge_held_session_states(idle_states, cache_states, &active_cli_agent_sessions)
 }
 
@@ -344,6 +402,7 @@ mod tests {
             super::super::active_sessions::new_active_cli_agent_sessions();
         let (provider, provider_handle) =
             MockJobProvider::new(tokio_util::sync::CancellationToken::new());
+        let held_session_snapshot = HeldSessionStateSnapshot::new();
         let hb = HeartbeatContext::new(HeartbeatContextInit {
             idle_pool: &idle_pool,
             runner_id: "runner-1",
@@ -354,6 +413,7 @@ mod tests {
             provider: provider.as_ref(),
             workspace_cache: Some(cache),
             active_cli_agent_sessions: &active_cli_agent_sessions,
+            held_session_snapshot: held_session_snapshot.clone(),
         });
 
         let ((), events) = capture_heartbeat_events(send_heartbeat(&hb, RunnerMode::Running)).await;
@@ -374,6 +434,11 @@ mod tests {
         let updates = provider_handle.held_session_state_updates();
         assert_eq!(updates.len(), 1);
         assert_eq!(updates[0][0].session_id, session_id);
+        let cached_states = held_session_snapshot
+            .current_held_session_states(Vec::new(), &active_cli_agent_sessions, None)
+            .await;
+        assert_eq!(cached_states.len(), 1);
+        assert_eq!(cached_states[0].session_id, session_id);
     }
 
     #[tokio::test]
@@ -413,6 +478,61 @@ mod tests {
                 .iter()
                 .any(|state| state.session_id == "sess-claimed"),
             "currently claimed session should be filtered until the run finishes"
+        );
+    }
+
+    #[tokio::test]
+    async fn held_session_snapshot_merges_cached_states_and_filters_active_sessions() {
+        let snapshot = HeldSessionStateSnapshot::new();
+        snapshot
+            .update_workspace_cache_states(vec![
+                HeldSessionState {
+                    session_id: "sess-cache".into(),
+                    last_completed_at: "2026-06-01T00:00:02.000Z".into(),
+                },
+                HeldSessionState {
+                    session_id: "sess-claimed".into(),
+                    last_completed_at: "2026-06-01T00:00:03.000Z".into(),
+                },
+                HeldSessionState {
+                    session_id: "sess-active".into(),
+                    last_completed_at: "2026-06-01T00:00:04.000Z".into(),
+                },
+            ])
+            .await;
+        let active_cli_agent_sessions =
+            super::super::active_sessions::new_active_cli_agent_sessions();
+        super::super::active_sessions::insert_active_cli_agent_session(
+            &active_cli_agent_sessions,
+            "sess-active",
+        );
+        let idle = vec![
+            HeldSessionState {
+                session_id: "sess-cache".into(),
+                last_completed_at: "2026-06-01T00:00:01.000Z".into(),
+            },
+            HeldSessionState {
+                session_id: "sess-idle".into(),
+                last_completed_at: "2026-06-01T00:00:05.000Z".into(),
+            },
+        ];
+
+        let states = snapshot
+            .current_held_session_states(idle, &active_cli_agent_sessions, Some("sess-claimed"))
+            .await;
+
+        assert_eq!(
+            states,
+            vec![
+                HeldSessionState {
+                    session_id: "sess-cache".into(),
+                    last_completed_at: "2026-06-01T00:00:02.000Z".into(),
+                },
+                HeldSessionState {
+                    session_id: "sess-idle".into(),
+                    last_completed_at: "2026-06-01T00:00:05.000Z".into(),
+                },
+            ]
         );
     }
 

--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -134,22 +134,6 @@ pub(super) async fn send_heartbeat(hb: &HeartbeatContext<'_>, mode: RunnerMode) 
     hb.provider.heartbeat(&state).await;
 }
 
-#[cfg(test)]
-pub(super) async fn current_held_session_states(
-    idle_states: Vec<HeldSessionState>,
-    workspace_cache: Option<&SessionWorkspaceCache>,
-    active_cli_agent_sessions: &ActiveCliAgentSessions,
-    extra_active_session: Option<&str>,
-) -> Vec<HeldSessionState> {
-    let cache_states = workspace_cache_held_session_states(workspace_cache).await;
-    merge_current_held_session_states(
-        idle_states,
-        cache_states,
-        active_cli_agent_sessions,
-        extra_active_session,
-    )
-}
-
 async fn workspace_cache_held_session_states(
     workspace_cache: Option<&SessionWorkspaceCache>,
 ) -> Vec<HeldSessionState> {
@@ -442,7 +426,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn current_held_session_states_keeps_cache_sessions_and_filters_claimed_session() {
+    async fn workspace_cache_held_session_states_filters_claimed_session_after_merge() {
         let dir = tempfile::tempdir().unwrap();
         let paths = RunnerPaths::new(dir.path().join("runner"));
         tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
@@ -457,13 +441,13 @@ mod tests {
             last_completed_at: "2026-06-01T00:00:02.000Z".into(),
         }];
 
-        let states = current_held_session_states(
+        let cache_states = workspace_cache_held_session_states(Some(&cache)).await;
+        let states = merge_current_held_session_states(
             idle,
-            Some(&cache),
+            cache_states,
             &active_cli_agent_sessions,
             Some("sess-claimed"),
-        )
-        .await;
+        );
 
         assert!(
             states.iter().any(|state| state.session_id == "sess-idle"),

--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -65,7 +65,13 @@ impl<'a> HeartbeatContext<'a> {
 
 #[derive(Clone, Default)]
 pub(super) struct HeldSessionStateSnapshot {
-    workspace_cache_states: Arc<Mutex<Vec<HeldSessionState>>>,
+    inner: Arc<Mutex<HeldSessionStateSnapshotInner>>,
+}
+
+#[derive(Default)]
+struct HeldSessionStateSnapshotInner {
+    workspace_cache_states: Vec<HeldSessionState>,
+    workspace_cache_loaded: bool,
 }
 
 impl HeldSessionStateSnapshot {
@@ -74,13 +80,18 @@ impl HeldSessionStateSnapshot {
     }
 
     fn update_workspace_cache_states(&self, states: Vec<HeldSessionState>) {
-        *self.lock_workspace_cache_states() = states;
+        let mut inner = self.lock_inner();
+        inner.workspace_cache_states = states;
+        inner.workspace_cache_loaded = true;
     }
 
-    pub(super) fn contains_workspace_cache_session(&self, session_id: &str) -> bool {
-        self.lock_workspace_cache_states()
-            .iter()
-            .any(|state| state.session_id == session_id)
+    pub(super) fn might_contain_workspace_cache_session(&self, session_id: &str) -> bool {
+        let inner = self.lock_inner();
+        !inner.workspace_cache_loaded
+            || inner
+                .workspace_cache_states
+                .iter()
+                .any(|state| state.session_id == session_id)
     }
 
     pub(super) fn current_held_session_states(
@@ -89,7 +100,7 @@ impl HeldSessionStateSnapshot {
         active_cli_agent_sessions: &ActiveCliAgentSessions,
         extra_active_session: Option<&str>,
     ) -> Vec<HeldSessionState> {
-        let workspace_cache_states = self.lock_workspace_cache_states().clone();
+        let workspace_cache_states = self.lock_inner().workspace_cache_states.clone();
         merge_current_held_session_states(
             idle_states,
             workspace_cache_states,
@@ -98,8 +109,8 @@ impl HeldSessionStateSnapshot {
         )
     }
 
-    fn lock_workspace_cache_states(&self) -> MutexGuard<'_, Vec<HeldSessionState>> {
-        self.workspace_cache_states
+    fn lock_inner(&self) -> MutexGuard<'_, HeldSessionStateSnapshotInner> {
+        self.inner
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
     }
@@ -533,6 +544,31 @@ mod tests {
                     last_completed_at: "2026-06-01T00:00:05.000Z".into(),
                 },
             ]
+        );
+    }
+
+    #[test]
+    fn held_session_snapshot_treats_unloaded_workspace_cache_as_unknown() {
+        let snapshot = HeldSessionStateSnapshot::new();
+
+        assert!(
+            snapshot.might_contain_workspace_cache_session("sess-cache"),
+            "unloaded snapshot should trigger one refresh for cache-enabled runners"
+        );
+
+        snapshot.update_workspace_cache_states(Vec::new());
+        assert!(
+            !snapshot.might_contain_workspace_cache_session("sess-cache"),
+            "loaded empty snapshot should not keep triggering cache refreshes"
+        );
+
+        snapshot.update_workspace_cache_states(vec![HeldSessionState {
+            session_id: "sess-cache".into(),
+            last_completed_at: "2026-06-01T00:00:02.000Z".into(),
+        }]);
+        assert!(
+            snapshot.might_contain_workspace_cache_session("sess-cache"),
+            "loaded matching snapshot should trigger refresh when that session is claimed"
         );
     }
 

--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Duration;
 
 use tracing::{debug, info};
@@ -65,7 +65,7 @@ impl<'a> HeartbeatContext<'a> {
 
 #[derive(Clone, Default)]
 pub(super) struct HeldSessionStateSnapshot {
-    workspace_cache_states: Arc<tokio::sync::Mutex<Vec<HeldSessionState>>>,
+    workspace_cache_states: Arc<Mutex<Vec<HeldSessionState>>>,
 }
 
 impl HeldSessionStateSnapshot {
@@ -73,23 +73,29 @@ impl HeldSessionStateSnapshot {
         Self::default()
     }
 
-    async fn update_workspace_cache_states(&self, states: Vec<HeldSessionState>) {
-        *self.workspace_cache_states.lock().await = states;
+    fn update_workspace_cache_states(&self, states: Vec<HeldSessionState>) {
+        *self.lock_workspace_cache_states() = states;
     }
 
-    pub(super) async fn current_held_session_states(
+    pub(super) fn current_held_session_states(
         &self,
         idle_states: Vec<HeldSessionState>,
         active_cli_agent_sessions: &ActiveCliAgentSessions,
         extra_active_session: Option<&str>,
     ) -> Vec<HeldSessionState> {
-        let workspace_cache_states = self.workspace_cache_states.lock().await.clone();
+        let workspace_cache_states = self.lock_workspace_cache_states().clone();
         merge_current_held_session_states(
             idle_states,
             workspace_cache_states,
             active_cli_agent_sessions,
             extra_active_session,
         )
+    }
+
+    fn lock_workspace_cache_states(&self) -> MutexGuard<'_, Vec<HeldSessionState>> {
+        self.workspace_cache_states
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 }
 
@@ -110,8 +116,7 @@ pub(super) async fn send_heartbeat(hb: &HeartbeatContext<'_>, mode: RunnerMode) 
     let workspace_cache_states =
         workspace_cache_held_session_states(hb.workspace_cache.as_ref()).await;
     hb.held_session_snapshot
-        .update_workspace_cache_states(workspace_cache_states.clone())
-        .await;
+        .update_workspace_cache_states(workspace_cache_states.clone());
     state.held_session_states = merge_current_held_session_states(
         state.held_session_states,
         workspace_cache_states,
@@ -418,9 +423,11 @@ mod tests {
         let updates = provider_handle.held_session_state_updates();
         assert_eq!(updates.len(), 1);
         assert_eq!(updates[0][0].session_id, session_id);
-        let cached_states = held_session_snapshot
-            .current_held_session_states(Vec::new(), &active_cli_agent_sessions, None)
-            .await;
+        let cached_states = held_session_snapshot.current_held_session_states(
+            Vec::new(),
+            &active_cli_agent_sessions,
+            None,
+        );
         assert_eq!(cached_states.len(), 1);
         assert_eq!(cached_states[0].session_id, session_id);
     }
@@ -468,22 +475,20 @@ mod tests {
     #[tokio::test]
     async fn held_session_snapshot_merges_cached_states_and_filters_active_sessions() {
         let snapshot = HeldSessionStateSnapshot::new();
-        snapshot
-            .update_workspace_cache_states(vec![
-                HeldSessionState {
-                    session_id: "sess-cache".into(),
-                    last_completed_at: "2026-06-01T00:00:02.000Z".into(),
-                },
-                HeldSessionState {
-                    session_id: "sess-claimed".into(),
-                    last_completed_at: "2026-06-01T00:00:03.000Z".into(),
-                },
-                HeldSessionState {
-                    session_id: "sess-active".into(),
-                    last_completed_at: "2026-06-01T00:00:04.000Z".into(),
-                },
-            ])
-            .await;
+        snapshot.update_workspace_cache_states(vec![
+            HeldSessionState {
+                session_id: "sess-cache".into(),
+                last_completed_at: "2026-06-01T00:00:02.000Z".into(),
+            },
+            HeldSessionState {
+                session_id: "sess-claimed".into(),
+                last_completed_at: "2026-06-01T00:00:03.000Z".into(),
+            },
+            HeldSessionState {
+                session_id: "sess-active".into(),
+                last_completed_at: "2026-06-01T00:00:04.000Z".into(),
+            },
+        ]);
         let active_cli_agent_sessions =
             super::super::active_sessions::new_active_cli_agent_sessions();
         super::super::active_sessions::insert_active_cli_agent_session(
@@ -501,9 +506,11 @@ mod tests {
             },
         ];
 
-        let states = snapshot
-            .current_held_session_states(idle, &active_cli_agent_sessions, Some("sess-claimed"))
-            .await;
+        let states = snapshot.current_held_session_states(
+            idle,
+            &active_cli_agent_sessions,
+            Some("sess-claimed"),
+        );
 
         assert_eq!(
             states,

--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -77,6 +77,12 @@ impl HeldSessionStateSnapshot {
         *self.lock_workspace_cache_states() = states;
     }
 
+    pub(super) fn contains_workspace_cache_session(&self, session_id: &str) -> bool {
+        self.lock_workspace_cache_states()
+            .iter()
+            .any(|state| state.session_id == session_id)
+    }
+
     pub(super) fn current_held_session_states(
         &self,
         idle_states: Vec<HeldSessionState>,

--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -169,6 +169,9 @@ fn merge_held_session_states(
 ) -> Vec<HeldSessionState> {
     let mut by_session = std::collections::BTreeMap::<String, HeldSessionState>::new();
     for state in idle_states {
+        if active_cli_agent_sessions.contains(&state.session_id) {
+            continue;
+        }
         by_session.insert(state.session_id.clone(), state);
     }
     for state in cache_states {
@@ -528,13 +531,19 @@ mod tests {
     }
 
     #[test]
-    fn merge_held_session_states_filters_active_cache_sessions() {
-        let idle = vec![];
+    fn merge_held_session_states_filters_active_sessions() {
+        let idle = vec![HeldSessionState {
+            session_id: "sess-active-idle".into(),
+            last_completed_at: "2026-06-01T00:00:01.000Z".into(),
+        }];
         let cache = vec![HeldSessionState {
             session_id: "sess-active".into(),
             last_completed_at: "2026-06-01T00:00:00.000Z".into(),
         }];
-        let active = std::collections::HashSet::from(["sess-active".to_string()]);
+        let active = std::collections::HashSet::from([
+            "sess-active".to_string(),
+            "sess-active-idle".to_string(),
+        ]);
 
         let merged = merge_held_session_states(idle, cache, &active);
 

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -416,8 +416,7 @@ async fn try_reuse_from_pool(
             held_session_states,
             &ctx.spawn_ctx.active_cli_agent_sessions,
             Some(cli_agent_session_id),
-        )
-        .await;
+        );
     pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::HeldSessionStateRefresh, started_at);
     let started_at = Instant::now();
     ctx.spawn_ctx

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -94,14 +94,17 @@ impl LocalAdmission {
     }
 }
 
-pub(super) async fn handle_discovered_job(job: DiscoveredJob, mut ctx: DiscoveredJobContext<'_>) {
+pub(super) async fn handle_discovered_job(
+    job: DiscoveredJob,
+    mut ctx: DiscoveredJobContext<'_>,
+) -> bool {
     let DiscoveredJob { candidate } = job;
     let run_id = candidate.run_id();
     let profile_name = candidate.profile_name().to_owned();
     // Look up profile config for resource requirements.
     let Some(profile_config) = ctx.profiles.get(&profile_name) else {
         warn!(run_id = %run_id, profile = %profile_name, "unknown profile, skipping");
-        return;
+        return false;
     };
     let job_vcpu = profile_config.vcpu;
     let job_memory = profile_config.memory_mb;
@@ -109,13 +112,13 @@ pub(super) async fn handle_discovered_job(job: DiscoveredJob, mut ctx: Discovere
     // Look up factory for this profile.
     let Some((factory, restore_guest_state)) = ctx.factories.get(&profile_name) else {
         warn!(run_id = %run_id, profile = %profile_name, "no factory for profile, skipping");
-        return;
+        return false;
     };
 
     let Some(admission) =
         claim_with_local_admission(candidate, run_id, job_vcpu, job_memory, &ctx).await
     else {
-        return;
+        return false;
     };
     let AdmittedClaim {
         claimed,
@@ -142,20 +145,21 @@ pub(super) async fn handle_discovered_job(job: DiscoveredJob, mut ctx: Discovere
     );
     pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::DeviceRateLimits, started_at);
 
-    let (reuse_entry, active_lease, reuse_result, idle_snapshot) = try_reuse_from_pool(
-        run_id,
-        ReuseAdmissionRequest {
-            profile_name: &profile_name,
-            device_rate_limits: &device_rate_limits,
-            workspace_disk_mb: job_workspace_disk_mb,
-            context: claimed.context(),
-            resume_session_valid,
-            job_lease,
-        },
-        &mut ctx,
-        &mut pre_spawn_timing,
-    )
-    .await;
+    let (reuse_entry, active_lease, reuse_result, idle_snapshot, needs_session_affinity_refresh) =
+        try_reuse_from_pool(
+            run_id,
+            ReuseAdmissionRequest {
+                profile_name: &profile_name,
+                device_rate_limits: &device_rate_limits,
+                workspace_disk_mb: job_workspace_disk_mb,
+                context: claimed.context(),
+                resume_session_valid,
+                job_lease,
+            },
+            &mut ctx,
+            &mut pre_spawn_timing,
+        )
+        .await;
 
     let session_history_restore_plan = build_session_history_restore_plan(
         &ctx.spawn_ctx.exec_config.http,
@@ -210,6 +214,7 @@ pub(super) async fn handle_discovered_job(job: DiscoveredJob, mut ctx: Discovere
         ctx.spawn_ctx,
         ctx.jobs,
     );
+    needs_session_affinity_refresh
 }
 
 fn build_session_history_restore_plan(
@@ -377,6 +382,7 @@ async fn try_reuse_from_pool(
     BudgetLease,
     SandboxReuseResult,
     Option<IdlePoolSnapshot>,
+    bool,
 ) {
     let ReuseAdmissionRequest {
         profile_name,
@@ -390,11 +396,23 @@ async fn try_reuse_from_pool(
     let started_at = Instant::now();
     if !resume_session_valid {
         pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::IdleReuseLookup, started_at);
-        return (None, job_lease, SandboxReuseResult::NoSessionId, None);
+        return (
+            None,
+            job_lease,
+            SandboxReuseResult::NoSessionId,
+            None,
+            false,
+        );
     }
     let Some(cli_agent_session_id) = context.cli_agent_session_id() else {
         pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::IdleReuseLookup, started_at);
-        return (None, job_lease, SandboxReuseResult::NoSessionId, None);
+        return (
+            None,
+            job_lease,
+            SandboxReuseResult::NoSessionId,
+            None,
+            false,
+        );
     };
     let session_fingerprint = diagnostic_session_fingerprint(cli_agent_session_id);
 
@@ -429,9 +447,7 @@ async fn try_reuse_from_pool(
         .provider
         .set_held_session_states(held_session_states)
         .await;
-    if took_idle_session || claimed_workspace_cache_session {
-        ctx.spawn_ctx.park_notify.notify_one();
-    }
+    let needs_session_affinity_refresh = took_idle_session || claimed_workspace_cache_session;
     pre_spawn_timing
         .record_phase_elapsed(RunnerPreSpawnPhase::ProviderHeldSessionUpdate, started_at);
     match taken {
@@ -463,7 +479,13 @@ async fn try_reuse_from_pool(
                         entry.into_destroy_job_without_workspace_promotion_for_mismatch(),
                         "reuse_workspace_promotion_mismatch",
                     );
-                    return (None, job_lease, SandboxReuseResult::PoolMiss, snapshot);
+                    return (
+                        None,
+                        job_lease,
+                        SandboxReuseResult::PoolMiss,
+                        snapshot,
+                        needs_session_affinity_refresh,
+                    );
                 }
             }
             let started_at = Instant::now();
@@ -488,6 +510,7 @@ async fn try_reuse_from_pool(
                         budget_lease,
                         SandboxReuseResult::Reused,
                         snapshot,
+                        needs_session_affinity_refresh,
                     )
                 }
                 IdleUnparkResult::Failed { destroy_job, error } => {
@@ -498,7 +521,13 @@ async fn try_reuse_from_pool(
                         "unpark failed, destroying idle VM and falling through to fresh create"
                     );
                     spawn_idle_destroy_job(ctx.destroy_tasks, *destroy_job, "reuse_unpark_failed");
-                    (None, job_lease, SandboxReuseResult::UnparkFailed, snapshot)
+                    (
+                        None,
+                        job_lease,
+                        SandboxReuseResult::UnparkFailed,
+                        snapshot,
+                        needs_session_affinity_refresh,
+                    )
                 }
             }
         }
@@ -519,6 +548,7 @@ async fn try_reuse_from_pool(
                 job_lease,
                 SandboxReuseResult::DeviceLimitMismatch,
                 snapshot,
+                needs_session_affinity_refresh,
             )
         }
         Some(stale) => {
@@ -539,6 +569,7 @@ async fn try_reuse_from_pool(
                 job_lease,
                 SandboxReuseResult::ProfileMismatch,
                 snapshot,
+                needs_session_affinity_refresh,
             )
         }
         None => {
@@ -547,7 +578,13 @@ async fn try_reuse_from_pool(
                 session_fingerprint = %session_fingerprint,
                 "no idle VM found for session"
             );
-            (None, job_lease, SandboxReuseResult::PoolMiss, None)
+            (
+                None,
+                job_lease,
+                SandboxReuseResult::PoolMiss,
+                None,
+                needs_session_affinity_refresh,
+            )
         }
     }
 }

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -410,6 +410,10 @@ async fn try_reuse_from_pool(
     let took_idle_session = taken.is_some();
     pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::IdleReuseLookup, started_at);
     let started_at = Instant::now();
+    let claimed_workspace_cache_session = ctx
+        .spawn_ctx
+        .held_session_snapshot
+        .contains_workspace_cache_session(cli_agent_session_id);
     let held_session_states = ctx
         .spawn_ctx
         .held_session_snapshot
@@ -424,7 +428,7 @@ async fn try_reuse_from_pool(
         .provider
         .set_held_session_states(held_session_states)
         .await;
-    if took_idle_session {
+    if took_idle_session || claimed_workspace_cache_session {
         ctx.spawn_ctx.park_notify.notify_one();
     }
     pre_spawn_timing

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -407,6 +407,7 @@ async fn try_reuse_from_pool(
         let held_session_states = pool.held_session_states();
         (taken, snapshot, held_session_states)
     };
+    let took_idle_session = taken.is_some();
     pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::IdleReuseLookup, started_at);
     let started_at = Instant::now();
     let held_session_states = ctx
@@ -423,6 +424,9 @@ async fn try_reuse_from_pool(
         .provider
         .set_held_session_states(held_session_states)
         .await;
+    if took_idle_session {
+        ctx.spawn_ctx.park_notify.notify_one();
+    }
     pre_spawn_timing
         .record_phase_elapsed(RunnerPreSpawnPhase::ProviderHeldSessionUpdate, started_at);
     match taken {

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -15,7 +15,6 @@ use tracing::{info, warn};
 
 use super::active_sessions::ActiveCliAgentSessionGuard;
 use super::factory_lifecycle::SharedFactory;
-use super::heartbeat::current_held_session_states;
 use super::idle_lifecycle::{
     SharedIdlePool, add_preparing_run_with_idle_status_snapshot,
     add_running_run_with_idle_status_snapshot, spawn_idle_destroy_job,
@@ -410,13 +409,15 @@ async fn try_reuse_from_pool(
     };
     pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::IdleReuseLookup, started_at);
     let started_at = Instant::now();
-    let held_session_states = current_held_session_states(
-        held_session_states,
-        ctx.spawn_ctx.exec_config.workspace_cache.as_ref(),
-        &ctx.spawn_ctx.active_cli_agent_sessions,
-        Some(cli_agent_session_id),
-    )
-    .await;
+    let held_session_states = ctx
+        .spawn_ctx
+        .held_session_snapshot
+        .current_held_session_states(
+            held_session_states,
+            &ctx.spawn_ctx.active_cli_agent_sessions,
+            Some(cli_agent_session_id),
+        )
+        .await;
     pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::HeldSessionStateRefresh, started_at);
     let started_at = Instant::now();
     ctx.spawn_ctx

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -410,10 +410,11 @@ async fn try_reuse_from_pool(
     let took_idle_session = taken.is_some();
     pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::IdleReuseLookup, started_at);
     let started_at = Instant::now();
-    let claimed_workspace_cache_session = ctx
-        .spawn_ctx
-        .held_session_snapshot
-        .contains_workspace_cache_session(cli_agent_session_id);
+    let claimed_workspace_cache_session = ctx.spawn_ctx.exec_config.workspace_cache.is_some()
+        && ctx
+            .spawn_ctx
+            .held_session_snapshot
+            .might_contain_workspace_cache_session(cli_agent_session_id);
     let held_session_states = ctx
         .spawn_ctx
         .held_session_snapshot

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -20,6 +20,7 @@ use tracing::{error, info, warn};
 
 use super::active_sessions::{ActiveCliAgentSessionGuard, ActiveCliAgentSessions};
 use super::factory_lifecycle::SharedFactory;
+use super::heartbeat::HeldSessionStateSnapshot;
 use super::idle_lifecycle::SharedIdlePool;
 use super::job_lifecycle::{
     ActiveBudgetLease, CompletionPayload, CompletionReady, RunCleanupDisposition, RunCleanupState,
@@ -78,6 +79,7 @@ pub(super) struct SpawnContext {
     /// Best-effort signal for the main loop to ask mitmproxy to flush usage.
     pub(super) usage_flush_tx: mpsc::Sender<()>,
     pub(super) active_cli_agent_sessions: ActiveCliAgentSessions,
+    pub(super) held_session_snapshot: HeldSessionStateSnapshot,
     pub(super) device_rate_limits: Option<sandbox::DeviceRateLimits>,
     #[cfg(test)]
     pub(super) outer_job_panic: Option<OuterJobPanicPoint>,

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -33,7 +33,6 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use clap::Args;
-use futures_util::FutureExt;
 use sandbox::{RuntimeProvider, SandboxRuntime};
 use tokio::sync::mpsc;
 use tokio::task::JoinSet;
@@ -1392,7 +1391,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                 let Some(candidate) = discovered else { break };
                 // Future completed — create a new one for the next discovery.
                 discover_fut = Box::pin(provider_state.provider.discover());
-                handle_discovered_job(
+                let needs_session_affinity_refresh = handle_discovered_job(
                     DiscoveredJob { candidate },
                     DiscoveredJobContext {
                         profiles: &runner.profiles,
@@ -1407,14 +1406,15 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                         jobs: &mut jobs,
                     },
                 ).await;
-                if park_notify.notified().now_or_never().is_some()
-                    && matches!(current_mode, RunnerMode::Running | RunnerMode::Draining)
+                let live_mode = *mode_rx.borrow();
+                if needs_session_affinity_refresh
+                    && matches!(live_mode, RunnerMode::Running | RunnerMode::Draining)
                 {
                     info!(
                         source = "post_discovery",
                         "session affinity state triggered immediate heartbeat"
                     );
-                    send_heartbeat(&hb_ctx, current_mode).await;
+                    send_heartbeat(&hb_ctx, live_mode).await;
                 }
             }
             // Mode changes (signals)

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -1498,8 +1498,13 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
             }
             // Immediate heartbeat after session affinity state changes —
             // eliminates the up-to-10s blind spot for affinity routing.
-            _ = park_notify.notified(), if matches!(mode, RunnerMode::Running) => {
-                let source = if can_discover { "main" } else { "budget_exhausted" };
+            _ = park_notify.notified(), if matches!(mode, RunnerMode::Running | RunnerMode::Draining) => {
+                let source = match mode {
+                    RunnerMode::Running if can_discover => "main",
+                    RunnerMode::Running => "budget_exhausted",
+                    RunnerMode::Draining => "draining",
+                    RunnerMode::Stopping | RunnerMode::Stopped => "inactive",
+                };
                 info!(source, "session affinity state triggered immediate heartbeat");
                 send_heartbeat(&hb_ctx, current_mode).await;
             }

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -81,8 +81,8 @@ mod signals;
 use active_sessions::new_active_cli_agent_sessions;
 use factory_lifecycle::{shutdown_factories, start_factories};
 use heartbeat::{
-    HEARTBEAT_PERIOD, HeartbeatContext, HeartbeatContextInit, collect_heartbeat_state,
-    send_heartbeat,
+    HEARTBEAT_PERIOD, HeartbeatContext, HeartbeatContextInit, HeldSessionStateSnapshot,
+    collect_heartbeat_state, send_heartbeat,
 };
 use identity::load_or_generate_runner_id;
 use idle_lifecycle::{
@@ -1242,6 +1242,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     let park_notify = Arc::new(tokio::sync::Notify::new());
     let orphaned_active_runs = OrphanedActiveRuns::new();
     let active_cli_agent_sessions = new_active_cli_agent_sessions();
+    let held_session_snapshot = HeldSessionStateSnapshot::new();
     let mut orphan_reap_tick = tokio::time::interval_at(
         tokio::time::Instant::now() + Duration::from_secs(10),
         Duration::from_secs(10),
@@ -1258,6 +1259,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         provider: &*provider_state.provider,
         workspace_cache: exec_config.workspace_cache.clone(),
         active_cli_agent_sessions: &active_cli_agent_sessions,
+        held_session_snapshot: held_session_snapshot.clone(),
     });
 
     // Pin the discover future so it survives cancellation by other select!
@@ -1278,6 +1280,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         park_notify: Arc::clone(&park_notify),
         usage_flush_tx,
         active_cli_agent_sessions: active_cli_agent_sessions.clone(),
+        held_session_snapshot,
         device_rate_limits: capacity.device_rate_limits.clone(),
         #[cfg(test)]
         outer_job_panic: test_hooks.outer_job_panic,

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -33,6 +33,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use clap::Args;
+use futures_util::FutureExt;
 use sandbox::{RuntimeProvider, SandboxRuntime};
 use tokio::sync::mpsc;
 use tokio::task::JoinSet;
@@ -1406,6 +1407,15 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                         jobs: &mut jobs,
                     },
                 ).await;
+                if park_notify.notified().now_or_never().is_some()
+                    && matches!(current_mode, RunnerMode::Running | RunnerMode::Draining)
+                {
+                    info!(
+                        source = "post_discovery",
+                        "session affinity state triggered immediate heartbeat"
+                    );
+                    send_heartbeat(&hb_ctx, current_mode).await;
+                }
             }
             // Mode changes (signals)
             _ = mode_rx.changed() => {}

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -1504,19 +1504,23 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
             }
             // Heartbeat: report runner state to the server
             _ = heartbeat_tick.tick() => {
-                send_heartbeat(&hb_ctx, current_mode).await;
+                let live_mode = *mode_rx.borrow();
+                send_heartbeat(&hb_ctx, live_mode).await;
             }
             // Immediate heartbeat after session affinity state changes —
             // eliminates the up-to-10s blind spot for affinity routing.
             _ = park_notify.notified(), if matches!(mode, RunnerMode::Running | RunnerMode::Draining) => {
-                let source = match mode {
+                let live_mode = *mode_rx.borrow();
+                let source = match live_mode {
                     RunnerMode::Running if can_discover => "main",
                     RunnerMode::Running => "budget_exhausted",
                     RunnerMode::Draining => "draining",
                     RunnerMode::Stopping | RunnerMode::Stopped => "inactive",
                 };
-                info!(source, "session affinity state triggered immediate heartbeat");
-                send_heartbeat(&hb_ctx, current_mode).await;
+                if matches!(live_mode, RunnerMode::Running | RunnerMode::Draining) {
+                    info!(source, "session affinity state triggered immediate heartbeat");
+                    send_heartbeat(&hb_ctx, live_mode).await;
+                }
             }
         }
     }

--- a/crates/runner/src/cmd/start/tests/idle_reuse.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse.rs
@@ -314,6 +314,53 @@ async fn workspace_cache_promotion_triggers_immediate_heartbeat_without_park() {
         "immediate heartbeat should advertise the promoted workspace cache session",
     );
 
+    let second_gate = sandbox_mock::MockLifecycleGate::new();
+    overrides.set_wait_process_lifecycle_gate(second_gate.clone());
+    overrides.push_wait_process_exit(sandbox::ProcessExit::new(1, 1, Vec::new(), Vec::new()));
+    let second_before = env.handle.heartbeat_count();
+    let second_run_id = RunId::new_v4();
+    push_job(
+        &env,
+        second_run_id,
+        "vm0/default",
+        Some(context_with_session(second_run_id, session_id)),
+    );
+    second_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .expect("second wait_process should enter before heartbeat assertion");
+    assert!(
+        env.handle
+            .wait_heartbeat_past(second_before, Duration::from_secs(5))
+            .await,
+        "claiming a workspace-cache-only session should trigger an immediate heartbeat",
+    );
+    let post_claim_heartbeats = {
+        let heartbeats = env
+            .handle
+            .heartbeats
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        heartbeats[second_before..].to_vec()
+    };
+    assert!(
+        post_claim_heartbeats.iter().any(|heartbeat| {
+            heartbeat
+                .held_session_states
+                .iter()
+                .all(|state| state.session_id != session_id)
+        }),
+        "post-claim heartbeat should stop advertising the active workspace cache session; heartbeats: {post_claim_heartbeats:?}",
+    );
+    overrides.clear_wait_process_lifecycle_gate();
+    second_gate.release_one();
+    let second_completion = env
+        .handle
+        .wait_completion(second_run_id, Duration::from_secs(5))
+        .await
+        .expect("second job should complete");
+    assert_eq!(second_completion.exit_code, 1);
+
     shutdown(&env, run_handle).await;
 }
 

--- a/crates/runner/src/cmd/start/tests/idle_reuse.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse.rs
@@ -11,13 +11,8 @@ use super::support::{
 
 use crate::idle_pool::ParkingState;
 use crate::paths::RunnerPaths;
-use crate::storage_fingerprints::StorageFingerprints;
 use crate::types::SandboxReuseResult;
-use crate::workspace_image_cache::{
-    SessionWorkspaceCache, WorkspaceCacheTerminalStatus, WorkspaceImageLeaseIdentity,
-    WorkspaceImagePrepareRequest,
-};
-use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
+use crate::workspace_image_cache::SessionWorkspaceCache;
 
 // -----------------------------------------------------------------------
 // Test 9: idle pool park/take is gated on session ID availability
@@ -68,48 +63,6 @@ fn device_rate_limits() -> sandbox::DeviceRateLimits {
             tx_bytes_per_sec: 25 * 1024 * 1024,
         },
     }
-}
-
-async fn promote_workspace_cache_session(
-    cache: &SessionWorkspaceCache,
-    paths: &RunnerPaths,
-    session_id: &str,
-) {
-    let run_id = RunId::new_v4();
-    let sandbox_id = sandbox::SandboxId::new_v4();
-    let image_size_bytes = 4 * 1024;
-    let lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
-            identity: WorkspaceImageLeaseIdentity {
-                run_id,
-                sandbox_id,
-                profile_name: "vm0/default",
-                cli_agent_session_id: Some(session_id),
-                working_dir: CANONICAL_WORKING_DIR,
-                image_size_bytes,
-            },
-            workspace_drive_required: false,
-        })
-        .await;
-    let active_image = paths.active_workspace_image(&sandbox_id);
-    tokio::fs::create_dir_all(active_image.parent().unwrap())
-        .await
-        .unwrap();
-    let file = tokio::fs::File::create(&active_image).await.unwrap();
-    file.set_len(image_size_bytes).await.unwrap();
-    drop(file);
-    assert!(
-        lease
-            .promote(
-                run_id,
-                None,
-                WorkspaceCacheTerminalStatus::Success,
-                super::support::TEST_SESSION_LAST_COMPLETED_AT.into(),
-                &StorageFingerprints::default(),
-            )
-            .await
-            .unwrap()
-    );
 }
 
 #[tokio::test(start_paused = true)]
@@ -518,9 +471,17 @@ async fn reuse_take_refreshes_provider_held_session_states() {
     shutdown(&env, run_handle).await;
 }
 
-#[tokio::test(start_paused = true)]
+#[tokio::test]
 async fn reuse_take_preserves_cached_workspace_held_session_state() {
-    let (mut config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+    let wait_gate = sandbox_mock::MockLifecycleGate::new();
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
+    overrides.push_wait_process_exit(sandbox::ProcessExit::new(1, 1, Vec::new(), Vec::new()));
+
+    let mut profiles = test_profiles();
+    profiles.get_mut("vm0/default").unwrap().workspace_disk_mb = 16;
+    let (mut config, env) =
+        mock_run_config_with_overrides(profiles, 8, 32768, 4, Arc::clone(&overrides));
     let idle_pool = Arc::clone(&config.shared.idle_pool);
     let budget = Arc::clone(&config.capacity.budget);
     let runner_paths = RunnerPaths::new(config.paths.base_dir.clone());
@@ -532,30 +493,52 @@ async fn reuse_take_preserves_cached_workspace_held_session_state() {
     Arc::get_mut(&mut config.exec_config)
         .unwrap()
         .workspace_cache = Some(workspace_cache.clone());
-    tokio::time::resume();
-    promote_workspace_cache_session(&workspace_cache, &runner_paths, "sess-cached").await;
-    tokio::time::pause();
-    assert!(
-        workspace_cache
-            .held_session_states()
-            .await
-            .iter()
-            .any(|state| state.session_id == "sess-cached"),
-        "workspace cache should expose the promoted held session before runner starts"
-    );
 
     seed_idle_pool(&idle_pool, &budget, "sess-refresh", "vm0/default", 2, 4096).await;
 
     let run_handle = tokio::spawn(run(config));
     wait_discover_entered(&env, Duration::from_secs(5)).await;
     let heartbeat_count = env.handle.heartbeat_count();
-    tokio::time::advance(HEARTBEAT_PERIOD).await;
-    tokio::task::yield_now().await;
+
+    let cache_run_id = RunId::new_v4();
+    push_job(
+        &env,
+        cache_run_id,
+        "vm0/default",
+        Some(context_with_session(cache_run_id, "sess-cached")),
+    );
+
+    wait_gate
+        .wait_entered(1, Duration::from_secs(5))
+        .await
+        .expect("wait_process should enter before test writes active workspace image");
+    let sandbox_id = overrides
+        .create_configs()
+        .into_iter()
+        .next()
+        .expect("sandbox create config should be recorded before wait_process entry")
+        .id;
+    let active_image = runner_paths.active_workspace_image(&sandbox_id);
+    tokio::fs::create_dir_all(active_image.parent().unwrap())
+        .await
+        .unwrap();
+    let file = tokio::fs::File::create(&active_image).await.unwrap();
+    file.set_len(16 * 1024 * 1024).await.unwrap();
+    drop(file);
+
+    overrides.clear_wait_process_lifecycle_gate();
+    wait_gate.release_one();
+    let cache_completion = env
+        .handle
+        .wait_completion(cache_run_id, Duration::from_secs(5))
+        .await
+        .expect("cache seed job should complete");
+    assert_eq!(cache_completion.exit_code, 1);
     assert!(
         env.handle
-            .wait_heartbeat_past(heartbeat_count, Duration::from_secs(1))
+            .wait_heartbeat_past(heartbeat_count, Duration::from_secs(5))
             .await,
-        "heartbeat should refresh the held-session snapshot before claim"
+        "workspace cache promotion should refresh the held-session snapshot before claim"
     );
 
     let run_id = RunId::new_v4();

--- a/crates/runner/src/cmd/start/tests/idle_reuse.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse.rs
@@ -540,6 +540,7 @@ async fn reuse_take_preserves_cached_workspace_held_session_state() {
             .await,
         "workspace cache promotion should refresh the held-session snapshot before claim"
     );
+    let updates_before_claim = env.handle.held_session_state_updates().len();
 
     let run_id = RunId::new_v4();
     push_job(
@@ -558,14 +559,15 @@ async fn reuse_take_preserves_cached_workspace_held_session_state() {
     wait_idle_pool_session_states(&idle_pool, &["sess-refresh"], Duration::from_secs(5)).await;
 
     let updates = env.handle.held_session_state_updates();
+    let claim_updates = &updates[updates_before_claim..];
     assert!(
-        updates.iter().any(|states| {
+        claim_updates.iter().any(|states| {
             states.iter().any(|state| state.session_id == "sess-cached")
                 && states
                     .iter()
                     .all(|state| state.session_id != "sess-refresh")
         }),
-        "provider should keep cached workspace state while filtering the claimed idle session; updates: {updates:?}"
+        "provider should keep cached workspace state while filtering the claimed idle session after claim; updates: {updates:?}"
     );
 
     shutdown(&env, run_handle).await;

--- a/crates/runner/src/cmd/start/tests/idle_reuse.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse.rs
@@ -11,8 +11,13 @@ use super::support::{
 
 use crate::idle_pool::ParkingState;
 use crate::paths::RunnerPaths;
+use crate::storage_fingerprints::StorageFingerprints;
 use crate::types::SandboxReuseResult;
-use crate::workspace_image_cache::SessionWorkspaceCache;
+use crate::workspace_image_cache::{
+    SessionWorkspaceCache, WorkspaceCacheTerminalStatus, WorkspaceImageLeaseIdentity,
+    WorkspaceImagePrepareRequest,
+};
+use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 
 // -----------------------------------------------------------------------
 // Test 9: idle pool park/take is gated on session ID availability
@@ -63,6 +68,48 @@ fn device_rate_limits() -> sandbox::DeviceRateLimits {
             tx_bytes_per_sec: 25 * 1024 * 1024,
         },
     }
+}
+
+async fn promote_workspace_cache_session(
+    cache: &SessionWorkspaceCache,
+    paths: &RunnerPaths,
+    session_id: &str,
+) {
+    let run_id = RunId::new_v4();
+    let sandbox_id = sandbox::SandboxId::new_v4();
+    let image_size_bytes = 4 * 1024;
+    let lease = cache
+        .prepare(WorkspaceImagePrepareRequest {
+            identity: WorkspaceImageLeaseIdentity {
+                run_id,
+                sandbox_id,
+                profile_name: "vm0/default",
+                cli_agent_session_id: Some(session_id),
+                working_dir: CANONICAL_WORKING_DIR,
+                image_size_bytes,
+            },
+            workspace_drive_required: false,
+        })
+        .await;
+    let active_image = paths.active_workspace_image(&sandbox_id);
+    tokio::fs::create_dir_all(active_image.parent().unwrap())
+        .await
+        .unwrap();
+    let file = tokio::fs::File::create(&active_image).await.unwrap();
+    file.set_len(image_size_bytes).await.unwrap();
+    drop(file);
+    assert!(
+        lease
+            .promote(
+                run_id,
+                None,
+                WorkspaceCacheTerminalStatus::Success,
+                super::support::TEST_SESSION_LAST_COMPLETED_AT.into(),
+                &StorageFingerprints::default(),
+            )
+            .await
+            .unwrap()
+    );
 }
 
 #[tokio::test(start_paused = true)]
@@ -466,6 +513,76 @@ async fn reuse_take_refreshes_provider_held_session_states() {
     assert!(
         updates.iter().any(Vec::is_empty),
         "provider should observe an empty held-session state after idle take; updates: {updates:?}"
+    );
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn reuse_take_preserves_cached_workspace_held_session_state() {
+    let (mut config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let budget = Arc::clone(&config.capacity.budget);
+    let runner_paths = RunnerPaths::new(config.paths.base_dir.clone());
+    let workspace_cache = SessionWorkspaceCache::shared(
+        runner_paths.clone(),
+        &config.paths.home,
+        &config.runner.group,
+    );
+    Arc::get_mut(&mut config.exec_config)
+        .unwrap()
+        .workspace_cache = Some(workspace_cache.clone());
+    tokio::time::resume();
+    promote_workspace_cache_session(&workspace_cache, &runner_paths, "sess-cached").await;
+    tokio::time::pause();
+    assert!(
+        workspace_cache
+            .held_session_states()
+            .await
+            .iter()
+            .any(|state| state.session_id == "sess-cached"),
+        "workspace cache should expose the promoted held session before runner starts"
+    );
+
+    seed_idle_pool(&idle_pool, &budget, "sess-refresh", "vm0/default", 2, 4096).await;
+
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+    let heartbeat_count = env.handle.heartbeat_count();
+    tokio::time::advance(HEARTBEAT_PERIOD).await;
+    tokio::task::yield_now().await;
+    assert!(
+        env.handle
+            .wait_heartbeat_past(heartbeat_count, Duration::from_secs(1))
+            .await,
+        "heartbeat should refresh the held-session snapshot before claim"
+    );
+
+    let run_id = RunId::new_v4();
+    push_job(
+        &env,
+        run_id,
+        "vm0/default",
+        Some(context_with_session(run_id, "sess-refresh")),
+    );
+
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("job should complete");
+    assert_eq!(completion.reuse_result, Some(SandboxReuseResult::Reused));
+    wait_idle_pool_session_states(&idle_pool, &["sess-refresh"], Duration::from_secs(5)).await;
+
+    let updates = env.handle.held_session_state_updates();
+    assert!(
+        updates.iter().any(|states| {
+            states.iter().any(|state| state.session_id == "sess-cached")
+                && states
+                    .iter()
+                    .all(|state| state.session_id != "sess-refresh")
+        }),
+        "provider should keep cached workspace state while filtering the claimed idle session; updates: {updates:?}"
     );
 
     shutdown(&env, run_handle).await;

--- a/crates/runner/src/cmd/start/tests/idle_reuse.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse.rs
@@ -847,6 +847,7 @@ async fn reuse_take_clears_idle_status_while_job_is_active() {
     );
 
     let run_handle = tokio::spawn(run(config));
+    let heartbeat_count = env.handle.heartbeat_count();
     let run_id = RunId::new_v4();
     push_job(
         &env,
@@ -857,6 +858,29 @@ async fn reuse_take_clears_idle_status_while_job_is_active() {
 
     wait_idle_pool_len(&idle_pool, 0, Duration::from_secs(5)).await;
     wait_status_idle_empty_with_active_run(&status_path, run_id, Duration::from_secs(5)).await;
+    assert!(
+        env.handle
+            .wait_heartbeat_past(heartbeat_count, Duration::from_secs(5))
+            .await,
+        "idle take should trigger an immediate heartbeat while the reused job is active"
+    );
+    let post_take_heartbeats = {
+        let heartbeats = env
+            .handle
+            .heartbeats
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        heartbeats[heartbeat_count..].to_vec()
+    };
+    assert!(
+        post_take_heartbeats.iter().any(|heartbeat| {
+            heartbeat
+                .held_session_states
+                .iter()
+                .all(|state| state.session_id != "sess-reuse-status")
+        }),
+        "post-take heartbeat should stop advertising the active session; heartbeats: {post_take_heartbeats:?}"
+    );
 
     gate.notify_one();
     let completion = env

--- a/crates/runner/src/cmd/start/tests/idle_reuse.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse.rs
@@ -65,6 +65,34 @@ fn device_rate_limits() -> sandbox::DeviceRateLimits {
     }
 }
 
+async fn wait_heartbeat_with_session_after(
+    handle: &crate::provider::mock::MockProviderHandle,
+    mut cursor: usize,
+    session_id: &str,
+    timeout: Duration,
+) -> bool {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        {
+            let heartbeats = handle.heartbeats.lock().unwrap_or_else(|e| e.into_inner());
+            if heartbeats[cursor..].iter().any(|state| {
+                state
+                    .held_session_states
+                    .iter()
+                    .any(|state| state.session_id == session_id)
+            }) {
+                return true;
+            }
+            cursor = heartbeats.len();
+        }
+
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() || !handle.wait_heartbeat_past(cursor, remaining).await {
+            return false;
+        }
+    }
+}
+
 #[tokio::test(start_paused = true)]
 async fn job_with_session_parks_vm() {
     let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
@@ -293,24 +321,8 @@ async fn workspace_cache_promotion_triggers_immediate_heartbeat_without_park() {
     );
 
     assert!(
-        env.handle
-            .wait_heartbeat_past(before, Duration::from_secs(5))
+        wait_heartbeat_with_session_after(&env.handle, before, session_id, Duration::from_secs(5))
             .await,
-        "workspace cache promotion should trigger an immediate heartbeat after baseline={before}",
-    );
-    let heartbeats = env
-        .handle
-        .heartbeats
-        .lock()
-        .unwrap_or_else(|e| e.into_inner())
-        .clone();
-    assert!(
-        heartbeats[before..].iter().any(|state| {
-            state
-                .held_session_states
-                .iter()
-                .any(|state| state.session_id == session_id)
-        }),
         "immediate heartbeat should advertise the promoted workspace cache session",
     );
 

--- a/crates/runner/src/cmd/start/tests/main_loop/heartbeat.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/heartbeat.rs
@@ -173,6 +173,60 @@ async fn heartbeat_fires_while_budget_exhausted() {
     shutdown(&env, run_handle).await;
 }
 
+/// Regression guard: heartbeat branches must read the live watch value at send
+/// time. If a mode transition lands while the reactor is already parked in a
+/// different select arm, using the loop-start `current_mode` sends one stale
+/// heartbeat before the mode-change arm runs.
+#[tokio::test(start_paused = true)]
+async fn heartbeat_tick_uses_live_mode_after_silent_mode_flip() {
+    let gate = Arc::new(tokio::sync::Notify::new());
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_process_gate(
+        Arc::clone(&gate),
+    ));
+    let (config, env) = mock_run_config_with_overrides(test_profiles(), 2, 4096, 1, overrides);
+    let budget = Arc::clone(&config.capacity.budget);
+    let run_handle = tokio::spawn(run(config));
+
+    let run_id = RunId::new_v4();
+    push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
+    wait_budget_count(&budget, 1, Duration::from_secs(5)).await;
+    wait_budget_exhausted_reactor(&env, Duration::from_secs(5)).await;
+
+    let before = env.handle.heartbeat_count();
+    env.mode_tx.send_if_modified(|mode| {
+        *mode = RunnerMode::Draining;
+        false
+    });
+
+    tokio::time::advance(HEARTBEAT_PERIOD + Duration::from_secs(5)).await;
+    assert!(
+        env.handle
+            .wait_heartbeat_past(before, Duration::from_secs(5))
+            .await,
+        "heartbeat tick should fire after silent mode flip"
+    );
+
+    {
+        let heartbeats = env
+            .handle
+            .heartbeats
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        assert_eq!(
+            heartbeats[before].mode, "draining",
+            "heartbeat tick must use live mode, not stale loop-start mode"
+        );
+    }
+
+    env.trigger_stopping().await;
+    assert_run_exits_within(
+        run_handle,
+        Duration::from_secs(5),
+        "hard shutdown should exit after live-mode heartbeat regression check",
+    )
+    .await;
+}
+
 /// Regression for #10146 / #10223: the main-loop `idle_cleanup` and
 /// `heartbeat_tick` intervals must defer their first tick past the
 /// configured period, so neither tick branch is Ready on the first `select!`


### PR DESCRIPTION
## Summary
- add a runner-local held-session snapshot refreshed by heartbeat after the existing workspace-cache validation scan
- make idle reuse claim publish held-session state from the snapshot plus current idle-pool state, filtering active and currently claimed sessions without scanning the workspace cache
- cover snapshot merge/filter behavior and claim-side preservation of unrelated workspace-cache affinity

## Telemetry
- `runner_claim_held_session_state_refresh` is kept, but now measures only in-memory snapshot merge/filter work on the claim path

## Tests
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::heartbeat`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::tests::idle_reuse::reuse_take`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::start`
- pre-commit: cargo-fmt, cargo-doc, cargo-clippy

Closes #19431