### PR TITLE
fix: update instatus widget integrity

### DIFF
--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -506,7 +506,7 @@
     </div>
     <script
       src="https://api.dashboard.instatus.com/widget?host=status.vm0.ai&code=02c0ef5a&locale=en"
-      integrity="sha384-PeueJ613SmtgegJQz/JL0K6uh1Q5Q4os+b/FZsvK9GoMFvyFlyBv8FiP62B3rilT"
+      integrity="sha384-ZW3eZwADOMdlg2fdvESPD7jguK16IC/edxNFakKs81D2lkNdi3BXRmx/g331lkD3"
       crossorigin="anonymous"
       defer
     ></script>


### PR DESCRIPTION
## Summary
- update the fixed SHA-384 SRI hash for the Instatus status widget script
- keep crossorigin and defer unchanged

## Context
The Instatus widget response changed, so the previous hardcoded integrity hash no longer matched and browsers blocked the script. The new hash was computed from the current widget response:

```
sha384-ZW3eZwADOMdlg2fdvESPD7jguK16IC/edxNFakKs81D2lkNdi3BXRmx/g331lkD3
```

## Verification
- fetched the widget twice and got the same SHA-384 digest
- pnpm exec prettier --check apps/platform/index.html
- pre-commit hook: prettier on apps/platform/index.html