### PR TITLE
feat: add public connector catalog api

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -85,6 +85,7 @@ import { zeroComposesRoutes } from "./routes/zero-composes";
 import { zeroComputerUseAuthorizationRoutes } from "./routes/zero-computer-use-authorization";
 import { zeroComputerUseRoutes } from "./routes/zero-computer-use";
 import { zeroCodexDeviceAuthRoutes } from "./routes/zero-codex-device-auth";
+import { zeroConnectorCatalogRoutes } from "./routes/zero-connector-catalog";
 import { zeroConnectorsExternalCodeRoutes } from "./routes/zero-connectors-external-code";
 import { zeroConnectorsOauthDeviceAuthRoutes } from "./routes/zero-connectors-oauth-device-auth";
 import { zeroConnectorsRoutes } from "./routes/zero-connectors";
@@ -267,6 +268,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroComputerUseAuthorizationRoutes,
   ...zeroComputerUseRoutes,
   ...zeroCodexDeviceAuthRoutes,
+  ...zeroConnectorCatalogRoutes,
   ...zeroConnectorsExternalCodeRoutes,
   ...zeroConnectorsOauthDeviceAuthRoutes,
   ...zeroConnectorsRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/connector-catalog-public-leak.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/connector-catalog-public-leak.ts
@@ -120,22 +120,46 @@ function addAuthMethodSensitiveNames(
   addAuthMethodClientNames(method, values);
 }
 
-function sensitiveStringValues(): Set<string> {
-  const values = new Set<string>();
+interface SensitiveStringValues {
+  readonly byConnector: ReadonlyMap<string, ReadonlySet<string>>;
+  readonly global: ReadonlySet<string>;
+}
+
+function sensitiveStringValues(): SensitiveStringValues {
+  const valuesByConnector = new Map<string, Set<string>>();
 
   for (const connectorType of CONNECTOR_TYPE_KEYS) {
+    const values = new Set<string>();
     for (const authMethodId of CONNECTOR_AUTH_METHOD_IDS) {
       const method = getConnectorAuthMethod(connectorType, authMethodId);
       if (method) {
         addAuthMethodSensitiveNames(method, values);
       }
     }
+    valuesByConnector.set(connectorType, values);
   }
 
-  return values;
+  return {
+    byConnector: valuesByConnector,
+    global: new Set(
+      [...valuesByConnector.values()].flatMap((values) => {
+        return [...values];
+      }),
+    ),
+  };
 }
 
-const SENSITIVE_STRING_VALUES = sensitiveStringValues();
+function normalizeSensitiveString(value: string): string {
+  return value.replace(/[^a-zA-Z0-9]/g, "").toLowerCase();
+}
+
+function shouldCheckDerivedSensitiveValue(path: string): boolean {
+  return (
+    path.endsWith(".placeholder") ||
+    path.endsWith(".defaultValue") ||
+    path.endsWith(".value")
+  );
+}
 
 function isSensitivePropertyName(key: string): boolean {
   return [
@@ -169,9 +193,30 @@ function isSensitivePropertyName(key: string): boolean {
   ].includes(key);
 }
 
-function assertNoSensitiveString(value: string, path: string): void {
-  for (const sensitiveValue of SENSITIVE_STRING_VALUES) {
+function assertNoSensitiveString(
+  value: string,
+  path: string,
+  sensitiveValues: SensitiveStringValues,
+  connectorSensitiveValues: ReadonlySet<string> | undefined,
+): void {
+  const normalizedValue = normalizeSensitiveString(value);
+  for (const sensitiveValue of sensitiveValues.global) {
     if (value.includes(sensitiveValue)) {
+      throw new Error(
+        `Public connector catalog response leaked ${sensitiveValue} at ${path}`,
+      );
+    }
+  }
+  if (!connectorSensitiveValues || !shouldCheckDerivedSensitiveValue(path)) {
+    return;
+  }
+  for (const sensitiveValue of connectorSensitiveValues) {
+    const normalizedSensitiveValue = normalizeSensitiveString(sensitiveValue);
+    if (
+      sensitiveValue.includes("_") &&
+      normalizedSensitiveValue.length >= 8 &&
+      normalizedValue.includes(normalizedSensitiveValue)
+    ) {
       throw new Error(
         `Public connector catalog response leaked ${sensitiveValue} at ${path}`,
       );
@@ -179,23 +224,45 @@ function assertNoSensitiveString(value: string, path: string): void {
   }
 }
 
-function assertNoSensitiveProperties(value: object, path: string): void {
+function assertNoSensitiveProperties(
+  value: object,
+  path: string,
+  sensitiveValues: SensitiveStringValues,
+  connectorSensitiveValues: ReadonlySet<string> | undefined,
+): void {
+  const nextConnectorSensitiveValues =
+    "connectorRef" in value && typeof value.connectorRef === "string"
+      ? sensitiveValues.byConnector.get(value.connectorRef)
+      : connectorSensitiveValues;
+
   for (const [key, child] of Object.entries(value)) {
     if (isSensitivePropertyName(key)) {
       throw new Error(
         `Public connector catalog response leaked private property ${key} at ${path}`,
       );
     }
-    assertPublicConnectorCatalogHasNoPrivateFields(child, `${path}.${key}`);
+    assertPublicConnectorCatalogHasNoPrivateFields(
+      child,
+      `${path}.${key}`,
+      sensitiveValues,
+      nextConnectorSensitiveValues,
+    );
   }
 }
 
 export function assertPublicConnectorCatalogHasNoPrivateFields(
   value: unknown,
   path = "$",
+  sensitiveValues: SensitiveStringValues = sensitiveStringValues(),
+  connectorSensitiveValues?: ReadonlySet<string>,
 ): void {
   if (typeof value === "string") {
-    assertNoSensitiveString(value, path);
+    assertNoSensitiveString(
+      value,
+      path,
+      sensitiveValues,
+      connectorSensitiveValues,
+    );
     return;
   }
   if (Array.isArray(value)) {
@@ -203,11 +270,18 @@ export function assertPublicConnectorCatalogHasNoPrivateFields(
       assertPublicConnectorCatalogHasNoPrivateFields(
         child,
         `${path}[${index}]`,
+        sensitiveValues,
+        connectorSensitiveValues,
       );
     }
     return;
   }
   if (typeof value === "object" && value !== null) {
-    assertNoSensitiveProperties(value, path);
+    assertNoSensitiveProperties(
+      value,
+      path,
+      sensitiveValues,
+      connectorSensitiveValues,
+    );
   }
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/connector-catalog-public-leak.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/connector-catalog-public-leak.ts
@@ -1,3 +1,142 @@
+import {
+  CONNECTOR_AUTH_METHOD_IDS,
+  CONNECTOR_TYPE_KEYS,
+  type ConnectorAuthMethodConfig,
+} from "@vm0/connectors/connectors";
+import { getConnectorAuthMethod } from "@vm0/connectors/connector-utils";
+
+function addValueRefName(valueRef: string, values: Set<string>): void {
+  const match = /^\$(?:secrets|vars)\.(.+)$/.exec(valueRef);
+  if (match?.[1]) {
+    values.add(match[1]);
+  }
+}
+
+function addAuthMethodStorageNames(
+  method: ConnectorAuthMethodConfig,
+  values: Set<string>,
+): void {
+  for (const secret of method.storage.secrets) {
+    values.add(secret);
+  }
+  for (const variable of method.storage.variables) {
+    values.add(variable);
+  }
+}
+
+function addAuthMethodGrantNames(
+  method: ConnectorAuthMethodConfig,
+  values: Set<string>,
+): void {
+  if (method.grant.kind === "manual") {
+    for (const fieldName of Object.keys(method.grant.fields)) {
+      values.add(fieldName);
+    }
+  }
+  if ("outputs" in method.grant) {
+    for (const valueRef of Object.values(method.grant.outputs)) {
+      addValueRefName(valueRef, values);
+    }
+  }
+}
+
+function addAuthMethodAccessNames(
+  method: ConnectorAuthMethodConfig,
+  values: Set<string>,
+): void {
+  if (method.access.kind === "none") {
+    return;
+  }
+
+  for (const [envName, binding] of Object.entries(method.access.envBindings)) {
+    values.add(envName);
+    addValueRefName(
+      typeof binding === "string" ? binding : binding.valueRef,
+      values,
+    );
+  }
+  for (const platformSecret of method.access.platformSecrets ?? []) {
+    values.add(platformSecret);
+  }
+}
+
+function addAuthMethodRefreshNames(
+  method: ConnectorAuthMethodConfig,
+  values: Set<string>,
+): void {
+  if (method.access.kind !== "refresh-token") {
+    return;
+  }
+
+  for (const valueRef of Object.values(method.access.inputs)) {
+    addValueRefName(valueRef, values);
+  }
+  for (const valueRef of Object.values(method.access.outputs)) {
+    addValueRefName(valueRef, values);
+  }
+  for (const refreshableSecret of method.access.refreshableSecrets) {
+    values.add(refreshableSecret);
+  }
+}
+
+function addAuthMethodRevokeNames(
+  method: ConnectorAuthMethodConfig,
+  values: Set<string>,
+): void {
+  if (method.revoke.kind !== "token-revoke") {
+    return;
+  }
+
+  for (const valueRef of Object.values(method.revoke.inputs)) {
+    addValueRefName(valueRef, values);
+  }
+}
+
+function addAuthMethodClientNames(
+  method: ConnectorAuthMethodConfig,
+  values: Set<string>,
+): void {
+  if (!("client" in method) || !method.client) {
+    return;
+  }
+
+  if ("clientIdEnv" in method.client) {
+    values.add(method.client.clientIdEnv);
+  }
+  if ("clientSecretEnv" in method.client) {
+    values.add(method.client.clientSecretEnv);
+  }
+}
+
+function addAuthMethodSensitiveNames(
+  method: ConnectorAuthMethodConfig,
+  values: Set<string>,
+): void {
+  addAuthMethodStorageNames(method, values);
+  addAuthMethodGrantNames(method, values);
+  addAuthMethodAccessNames(method, values);
+  addAuthMethodRefreshNames(method, values);
+  addAuthMethodRevokeNames(method, values);
+  addAuthMethodClientNames(method, values);
+}
+
+function sensitiveStringValues(): Set<string> {
+  const values = new Set<string>();
+
+  for (const connectorType of CONNECTOR_TYPE_KEYS) {
+    for (const authMethodId of CONNECTOR_AUTH_METHOD_IDS) {
+      const method = getConnectorAuthMethod(connectorType, authMethodId);
+      if (method) {
+        addAuthMethodSensitiveNames(method, values);
+      }
+    }
+  }
+
+  return values;
+}
+
+const SENSITIVE_STRING_VALUES = sensitiveStringValues();
+
 function isSensitivePropertyName(key: string): boolean {
   return [
     "storage",
@@ -31,12 +170,7 @@ function isSensitivePropertyName(key: string): boolean {
 }
 
 function assertNoSensitiveString(value: string, path: string): void {
-  for (const sensitiveValue of [
-    "OPENAI_TOKEN",
-    "NEON_TOKEN",
-    "NEON_ACCESS_TOKEN",
-    "NEON_REFRESH_TOKEN",
-  ]) {
+  for (const sensitiveValue of SENSITIVE_STRING_VALUES) {
     if (value.includes(sensitiveValue)) {
       throw new Error(
         `Public connector catalog response leaked ${sensitiveValue} at ${path}`,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/connector-catalog-public-leak.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/connector-catalog-public-leak.ts
@@ -1,0 +1,79 @@
+function isSensitivePropertyName(key: string): boolean {
+  return [
+    "storage",
+    "secrets",
+    "variables",
+    "envBindings",
+    "valueRef",
+    "source",
+    "target",
+    "platformSecrets",
+    "client",
+    "clientIdEnv",
+    "clientSecretEnv",
+    "clientSecret",
+    "scopes",
+    "outputs",
+    "inputs",
+    "refreshableSecrets",
+    "revoke",
+    "access",
+    "featureFlag",
+    "showExperimentalLabel",
+    "placeholderValues",
+    "baseUrlTemplates",
+    "secretPlaceholderNames",
+    "manifestKey",
+    "bucket",
+    "objectKey",
+    "signedUrl",
+  ].includes(key);
+}
+
+function assertNoSensitiveString(value: string, path: string): void {
+  for (const sensitiveValue of [
+    "OPENAI_TOKEN",
+    "NEON_TOKEN",
+    "NEON_ACCESS_TOKEN",
+    "NEON_REFRESH_TOKEN",
+  ]) {
+    if (value.includes(sensitiveValue)) {
+      throw new Error(
+        `Public connector catalog response leaked ${sensitiveValue} at ${path}`,
+      );
+    }
+  }
+}
+
+function assertNoSensitiveProperties(value: object, path: string): void {
+  for (const [key, child] of Object.entries(value)) {
+    if (isSensitivePropertyName(key)) {
+      throw new Error(
+        `Public connector catalog response leaked private property ${key} at ${path}`,
+      );
+    }
+    assertPublicConnectorCatalogHasNoPrivateFields(child, `${path}.${key}`);
+  }
+}
+
+export function assertPublicConnectorCatalogHasNoPrivateFields(
+  value: unknown,
+  path = "$",
+): void {
+  if (typeof value === "string") {
+    assertNoSensitiveString(value, path);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const [index, child] of value.entries()) {
+      assertPublicConnectorCatalogHasNoPrivateFields(
+        child,
+        `${path}[${index}]`,
+      );
+    }
+    return;
+  }
+  if (typeof value === "object" && value !== null) {
+    assertNoSensitiveProperties(value, path);
+  }
+}

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
@@ -244,6 +244,37 @@ describe("GET /api/zero/connector-catalog", () => {
     ]);
   });
 
+  it("omits auth text and placeholders derived from private names", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    await enablePublicCatalog(orgId, userId);
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroConnectorCatalogContract);
+    const response = await accept(
+      client.get({
+        params: { connectorRef: "parallel" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    assertPublicConnectorCatalogHasNoPrivateFields(response.body);
+    const apiToken = response.body.connector.authMethods.find((method) => {
+      return method.id === "api-token";
+    });
+    expect(apiToken?.description).toBeNull();
+    expect(apiToken?.manualFields).toStrictEqual([
+      {
+        id: "field-1",
+        label: "API Key",
+        required: true,
+        placeholder: null,
+        inputType: "password",
+      },
+    ]);
+  });
+
   it("returns 404 for hidden connector catalog refs", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
@@ -54,7 +54,7 @@ describe("GET /api/zero/connector-catalog", () => {
   ): Promise<void> {
     seededFeatureSwitches.push({ orgId, userId });
     await enableFeatureSwitches(orgId, userId, {
-      [FeatureSwitchKey.PublicConnectorCatalog]: true,
+      [FeatureSwitchKey.ConnectorCatalogApi]: true,
       ...switches,
     });
   }
@@ -111,7 +111,7 @@ describe("GET /api/zero/connector-catalog", () => {
     );
 
     expect(response.body.error.message).toBe(
-      "Public connector catalog is not enabled",
+      "Connector catalog API is not enabled",
     );
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
@@ -187,6 +187,7 @@ describe("GET /api/zero/connector-catalog", () => {
   it("rejects a ZERO_TOKEN missing the connector:read capability with 403", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
+    await enablePublicCatalog(orgId, userId);
     seededOrgs.push(
       await store.set(
         seedOrgMembership$,
@@ -212,6 +213,9 @@ describe("GET /api/zero/connector-catalog", () => {
     );
 
     expect(response.body.error.code).toBe("FORBIDDEN");
+    expect(response.body.error.message).toBe(
+      "Missing required capability: connector:read",
+    );
   });
 
   it("returns connector detail without leaking manual field storage names", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
@@ -275,6 +275,32 @@ describe("GET /api/zero/connector-catalog", () => {
     ]);
   });
 
+  it("returns every visible connector detail without private metadata", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    await enablePublicCatalog(orgId, userId, {
+      [FeatureSwitchKey.NeonConnector]: true,
+    });
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroConnectorCatalogContract);
+    const listResponse = await accept(
+      client.list({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    for (const connector of listResponse.body.connectors) {
+      const detailResponse = await accept(
+        client.get({
+          params: { connectorRef: connector.connectorRef },
+          headers: { authorization: "Bearer clerk-session" },
+        }),
+        [200],
+      );
+      assertPublicConnectorCatalogHasNoPrivateFields(detailResponse.body);
+    }
+  });
+
   it("returns 404 for hidden connector catalog refs", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
@@ -1,16 +1,14 @@
 import { randomUUID } from "node:crypto";
 
+import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
 import { zeroConnectorCatalogContract } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 import { createStore } from "ccstate";
-import { and, eq } from "drizzle-orm";
 import { afterEach } from "vitest";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { now } from "../../../lib/time";
 import { signSandboxJwtForTests } from "../../auth/tokens";
-import { writeDb$ } from "../../external/db";
 import {
   deleteOrgMembership$,
   seedOrgMembership$,
@@ -28,12 +26,27 @@ async function enableFeatureSwitches(
   userId: string,
   switches: Partial<Record<FeatureSwitchKey, boolean>>,
 ): Promise<void> {
-  const writeDb = store.set(writeDb$);
-  await writeDb.insert(userFeatureSwitches).values({
-    orgId,
-    userId,
-    switches,
-  });
+  mocks.clerk.session(userId, orgId);
+  const client = setupApp({ context })(zeroFeatureSwitchesContract);
+  await accept(
+    client.update({
+      headers: { authorization: "Bearer clerk-session" },
+      body: { switches },
+    }),
+    [200],
+  );
+}
+
+async function deleteFeatureSwitches(
+  orgId: string,
+  userId: string,
+): Promise<void> {
+  mocks.clerk.session(userId, orgId);
+  const client = setupApp({ context })(zeroFeatureSwitchesContract);
+  await accept(
+    client.delete({ headers: { authorization: "Bearer clerk-session" } }),
+    [200],
+  );
 }
 
 function currentSecond(): number {
@@ -60,18 +73,10 @@ describe("GET /api/zero/connector-catalog", () => {
   }
 
   afterEach(async () => {
-    const writeDb = store.set(writeDb$);
     while (seededFeatureSwitches.length > 0) {
       const fixture = seededFeatureSwitches.pop();
       if (fixture) {
-        await writeDb
-          .delete(userFeatureSwitches)
-          .where(
-            and(
-              eq(userFeatureSwitches.orgId, fixture.orgId),
-              eq(userFeatureSwitches.userId, fixture.userId),
-            ),
-          );
+        await deleteFeatureSwitches(fixture.orgId, fixture.userId);
       }
     }
     while (seededOrgs.length > 0) {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
@@ -1,0 +1,340 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroConnectorCatalogContract } from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
+import { createStore } from "ccstate";
+import { and, eq } from "drizzle-orm";
+import { afterEach } from "vitest";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { now } from "../../../lib/time";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+import { writeDb$ } from "../../external/db";
+import {
+  deleteOrgMembership$,
+  seedOrgMembership$,
+  type OrgMembershipFixture,
+} from "./helpers/zero-org-membership";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
+import { assertPublicConnectorCatalogHasNoPrivateFields } from "./helpers/connector-catalog-public-leak";
+
+const context = testContext();
+const mocks = createZeroRouteMocks(context);
+const store = createStore();
+
+async function enableFeatureSwitches(
+  orgId: string,
+  userId: string,
+  switches: Partial<Record<FeatureSwitchKey, boolean>>,
+): Promise<void> {
+  const writeDb = store.set(writeDb$);
+  await writeDb.insert(userFeatureSwitches).values({
+    orgId,
+    userId,
+    switches,
+  });
+}
+
+function currentSecond(): number {
+  return Math.floor(now() / 1000);
+}
+
+describe("GET /api/zero/connector-catalog", () => {
+  const seededFeatureSwitches: {
+    readonly orgId: string;
+    readonly userId: string;
+  }[] = [];
+  const seededOrgs: OrgMembershipFixture[] = [];
+
+  async function enablePublicCatalog(
+    orgId: string,
+    userId: string,
+    switches: Partial<Record<FeatureSwitchKey, boolean>> = {},
+  ): Promise<void> {
+    seededFeatureSwitches.push({ orgId, userId });
+    await enableFeatureSwitches(orgId, userId, {
+      [FeatureSwitchKey.PublicConnectorCatalog]: true,
+      ...switches,
+    });
+  }
+
+  afterEach(async () => {
+    const writeDb = store.set(writeDb$);
+    while (seededFeatureSwitches.length > 0) {
+      const fixture = seededFeatureSwitches.pop();
+      if (fixture) {
+        await writeDb
+          .delete(userFeatureSwitches)
+          .where(
+            and(
+              eq(userFeatureSwitches.orgId, fixture.orgId),
+              eq(userFeatureSwitches.userId, fixture.userId),
+            ),
+          );
+      }
+    }
+    while (seededOrgs.length > 0) {
+      const fixture = seededOrgs.pop();
+      if (fixture) {
+        await store.set(deleteOrgMembership$, fixture, context.signal);
+      }
+    }
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const client = setupApp({ context })(zeroConnectorCatalogContract);
+    const response = await accept(client.list({ headers: {} }), [401]);
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 401 when the session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+
+    const client = setupApp({ context })(zeroConnectorCatalogContract);
+    const response = await accept(
+      client.list({ headers: { authorization: "Bearer clerk-session" } }),
+      [401],
+    );
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 403 while the public catalog feature is disabled", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
+
+    const client = setupApp({ context })(zeroConnectorCatalogContract);
+    const response = await accept(
+      client.list({ headers: { authorization: "Bearer clerk-session" } }),
+      [403],
+    );
+
+    expect(response.body.error.message).toBe(
+      "Public connector catalog is not enabled",
+    );
+  });
+
+  it("returns compact public connector metadata when enabled", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    await enablePublicCatalog(orgId, userId);
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroConnectorCatalogContract);
+    const response = await accept(
+      client.list({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    assertPublicConnectorCatalogHasNoPrivateFields(response.body);
+    expect(response.body.connectors.length).toBeGreaterThan(0);
+    const openai = response.body.connectors.find((connector) => {
+      return connector.connectorRef === "openai";
+    });
+    expect(openai).toBeDefined();
+    expect(openai?.label).toBe("OpenAI");
+    expect(openai?.generation).toContain("text");
+    expect(openai?.tags).toContain("llm");
+    expect(openai?.authMethods).toStrictEqual([
+      {
+        id: "api-token",
+        label: "API Key",
+        description: expect.any(String),
+        grantKind: "manual",
+      },
+    ]);
+    expect(openai?.permissionSummary).toStrictEqual({
+      hasPermissions: false,
+      permissionCount: 0,
+      hasCategories: false,
+      hasDefaultPolicyOverrides: false,
+    });
+    expect(openai?.permissionSummary).not.toHaveProperty("permissions");
+  });
+
+  it("accepts a ZERO_TOKEN carrying the connector:read capability", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    await enablePublicCatalog(orgId, userId);
+    seededOrgs.push(
+      await store.set(
+        seedOrgMembership$,
+        { orgId, userId, role: "admin" },
+        context.signal,
+      ),
+    );
+    const seconds = currentSecond();
+    const token = signSandboxJwtForTests({
+      scope: "zero",
+      userId,
+      orgId,
+      runId: `run_${randomUUID()}`,
+      capabilities: ["connector:read"],
+      iat: seconds,
+      exp: seconds + 600,
+    });
+
+    const client = setupApp({ context })(zeroConnectorCatalogContract);
+    const response = await accept(
+      client.list({ headers: { authorization: `Bearer ${token}` } }),
+      [200],
+    );
+
+    expect(response.body.connectors.length).toBeGreaterThan(0);
+  });
+
+  it("rejects a ZERO_TOKEN missing the connector:read capability with 403", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    seededOrgs.push(
+      await store.set(
+        seedOrgMembership$,
+        { orgId, userId, role: "admin" },
+        context.signal,
+      ),
+    );
+    const seconds = currentSecond();
+    const token = signSandboxJwtForTests({
+      scope: "zero",
+      userId,
+      orgId,
+      runId: `run_${randomUUID()}`,
+      capabilities: [],
+      iat: seconds,
+      exp: seconds + 600,
+    });
+
+    const client = setupApp({ context })(zeroConnectorCatalogContract);
+    const response = await accept(
+      client.list({ headers: { authorization: `Bearer ${token}` } }),
+      [403],
+    );
+
+    expect(response.body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("returns connector detail without leaking manual field storage names", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    await enablePublicCatalog(orgId, userId);
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroConnectorCatalogContract);
+    const response = await accept(
+      client.get({
+        params: { connectorRef: "openai" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    assertPublicConnectorCatalogHasNoPrivateFields(response.body);
+    const apiToken = response.body.connector.authMethods.find((method) => {
+      return method.id === "api-token";
+    });
+    expect(apiToken?.manualFields).toStrictEqual([
+      {
+        id: "field-1",
+        label: "API Key",
+        required: true,
+        placeholder: "sk-...",
+        inputType: "password",
+      },
+    ]);
+  });
+
+  it("returns 404 for hidden connector catalog refs", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    await enablePublicCatalog(orgId, userId);
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroConnectorCatalogContract);
+    const response = await accept(
+      client.get({
+        params: { connectorRef: "test-oauth-device" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [404],
+    );
+
+    expect(response.body.error.message).toBe(
+      "Connector catalog item not found",
+    );
+  });
+
+  it("hides feature-gated auth methods from connector detail", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    await enablePublicCatalog(orgId, userId);
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroConnectorCatalogContract);
+    const response = await accept(
+      client.get({
+        params: { connectorRef: "neon" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    assertPublicConnectorCatalogHasNoPrivateFields(response.body);
+    expect(
+      response.body.connector.authMethods.map((authMethod) => {
+        return authMethod.id;
+      }),
+    ).toStrictEqual(["api-token"]);
+  });
+
+  it("shows feature-gated auth methods when their connector feature is enabled", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    await enablePublicCatalog(orgId, userId, {
+      [FeatureSwitchKey.NeonConnector]: true,
+    });
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroConnectorCatalogContract);
+    const response = await accept(
+      client.get({
+        params: { connectorRef: "neon" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    assertPublicConnectorCatalogHasNoPrivateFields(response.body);
+    expect(
+      response.body.connector.authMethods.map((authMethod) => {
+        return authMethod.id;
+      }),
+    ).toStrictEqual(["oauth", "api-token"]);
+  });
+
+  it("returns public permission detail without firewall execution metadata", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    await enablePublicCatalog(orgId, userId);
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroConnectorCatalogContract);
+    const response = await accept(
+      client.permissions({
+        params: { connectorRef: "google-docs" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    assertPublicConnectorCatalogHasNoPrivateFields(response.body);
+    expect(response.body.permissions.connectorRef).toBe("google-docs");
+    expect(response.body.permissions.permissionCount).toBeGreaterThan(0);
+    expect(response.body.permissions.permissions).toHaveLength(
+      response.body.permissions.permissionCount,
+    );
+    expect(response.body.permissions.permissions[0]).not.toHaveProperty(
+      "rules",
+    );
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-connector-catalog.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connector-catalog.ts
@@ -1,0 +1,140 @@
+import { zeroConnectorCatalogContract } from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import {
+  getAllFeatureStates,
+  isFeatureEnabled,
+} from "@vm0/core/feature-switch";
+import { command } from "ccstate";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { pathParamsOf } from "../context/request";
+import type { RouteEntry } from "../route-entry";
+import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
+import {
+  getPublicConnectorCatalogDetail,
+  getPublicConnectorCatalogPermissionDetail,
+  listPublicConnectorCatalog,
+} from "../services/connector-catalog-reader.service";
+import { notFound } from "../../lib/error";
+
+const connectorCatalogAuth = {
+  requireOrganization: true,
+  missingOrganizationStatus: 401,
+  requiredCapability: "connector:read",
+} as const;
+
+const publicConnectorCatalogDisabled = Object.freeze({
+  status: 403 as const,
+  body: Object.freeze({
+    error: Object.freeze({
+      message: "Public connector catalog is not enabled",
+      code: "FORBIDDEN",
+    }),
+  }),
+});
+
+function connectorCatalogNotFound() {
+  return notFound("Connector catalog item not found");
+}
+
+const connectorCatalogRequestContext$ = command(async ({ get }) => {
+  const auth = get(organizationAuthContext$);
+  const overrides = await get(
+    userFeatureSwitchOverrides(auth.orgId, auth.userId),
+  );
+  const featureSwitchContext = {
+    orgId: auth.orgId,
+    userId: auth.userId,
+    overrides,
+  };
+  return {
+    enabled: isFeatureEnabled(
+      FeatureSwitchKey.PublicConnectorCatalog,
+      featureSwitchContext,
+    ),
+    featureStates: getAllFeatureStates(featureSwitchContext),
+  };
+});
+
+const listConnectorCatalogInner$ = command(
+  async ({ set }, signal: AbortSignal) => {
+    const context = await set(connectorCatalogRequestContext$);
+    signal.throwIfAborted();
+    if (!context.enabled) {
+      return publicConnectorCatalogDisabled;
+    }
+
+    const connectors = await listPublicConnectorCatalog({
+      featureStates: context.featureStates,
+      apiAuthMethodPolicy: "include",
+    });
+    signal.throwIfAborted();
+
+    return { status: 200 as const, body: { connectors } };
+  },
+);
+
+const getConnectorCatalogInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const context = await set(connectorCatalogRequestContext$);
+    signal.throwIfAborted();
+    if (!context.enabled) {
+      return publicConnectorCatalogDisabled;
+    }
+
+    const params = get(pathParamsOf(zeroConnectorCatalogContract.get));
+    const connector = await getPublicConnectorCatalogDetail({
+      connectorRef: params.connectorRef,
+      featureStates: context.featureStates,
+      apiAuthMethodPolicy: "include",
+    });
+    signal.throwIfAborted();
+    if (!connector) {
+      return connectorCatalogNotFound();
+    }
+
+    return { status: 200 as const, body: { connector } };
+  },
+);
+
+const getConnectorCatalogPermissionsInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const context = await set(connectorCatalogRequestContext$);
+    signal.throwIfAborted();
+    if (!context.enabled) {
+      return publicConnectorCatalogDisabled;
+    }
+
+    const params = get(pathParamsOf(zeroConnectorCatalogContract.permissions));
+    const permissions = await getPublicConnectorCatalogPermissionDetail({
+      connectorRef: params.connectorRef,
+      featureStates: context.featureStates,
+      apiAuthMethodPolicy: "include",
+    });
+    signal.throwIfAborted();
+    if (!permissions) {
+      return connectorCatalogNotFound();
+    }
+
+    return { status: 200 as const, body: { permissions } };
+  },
+);
+
+export const zeroConnectorCatalogRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroConnectorCatalogContract.list,
+    handler: authRoute(connectorCatalogAuth, listConnectorCatalogInner$),
+  },
+  {
+    route: zeroConnectorCatalogContract.get,
+    handler: authRoute(connectorCatalogAuth, getConnectorCatalogInner$),
+  },
+  {
+    route: zeroConnectorCatalogContract.permissions,
+    handler: authRoute(
+      connectorCatalogAuth,
+      getConnectorCatalogPermissionsInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/routes/zero-connector-catalog.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connector-catalog.ts
@@ -24,11 +24,11 @@ const connectorCatalogAuth = {
   requiredCapability: "connector:read",
 } as const;
 
-const publicConnectorCatalogDisabled = Object.freeze({
+const connectorCatalogApiDisabled = Object.freeze({
   status: 403 as const,
   body: Object.freeze({
     error: Object.freeze({
-      message: "Public connector catalog is not enabled",
+      message: "Connector catalog API is not enabled",
       code: "FORBIDDEN",
     }),
   }),
@@ -50,7 +50,7 @@ const connectorCatalogRequestContext$ = command(async ({ get }) => {
   };
   return {
     enabled: isFeatureEnabled(
-      FeatureSwitchKey.PublicConnectorCatalog,
+      FeatureSwitchKey.ConnectorCatalogApi,
       featureSwitchContext,
     ),
     featureStates: getAllFeatureStates(featureSwitchContext),
@@ -62,7 +62,7 @@ const listConnectorCatalogInner$ = command(
     const context = await set(connectorCatalogRequestContext$);
     signal.throwIfAborted();
     if (!context.enabled) {
-      return publicConnectorCatalogDisabled;
+      return connectorCatalogApiDisabled;
     }
 
     const connectors = await listPublicConnectorCatalog({
@@ -80,7 +80,7 @@ const getConnectorCatalogInner$ = command(
     const context = await set(connectorCatalogRequestContext$);
     signal.throwIfAborted();
     if (!context.enabled) {
-      return publicConnectorCatalogDisabled;
+      return connectorCatalogApiDisabled;
     }
 
     const params = get(pathParamsOf(zeroConnectorCatalogContract.get));
@@ -103,7 +103,7 @@ const getConnectorCatalogPermissionsInner$ = command(
     const context = await set(connectorCatalogRequestContext$);
     signal.throwIfAborted();
     if (!context.enabled) {
-      return publicConnectorCatalogDisabled;
+      return connectorCatalogApiDisabled;
     }
 
     const params = get(pathParamsOf(zeroConnectorCatalogContract.permissions));

--- a/turbo/apps/api/src/signals/services/connector-catalog-reader.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-reader.service.ts
@@ -76,14 +76,22 @@ function addValueRefName(valueRef: string, privateNames: Set<string>): void {
   }
 }
 
-function privateNamesForAuthMethod(
+function addStoragePrivateNames(
   method: ConnectorAuthMethodConfig,
-): ReadonlySet<string> {
-  const privateNames = new Set([
-    ...method.storage.secrets,
-    ...method.storage.variables,
-  ]);
+  privateNames: Set<string>,
+): void {
+  for (const secret of method.storage.secrets) {
+    privateNames.add(secret);
+  }
+  for (const variable of method.storage.variables) {
+    privateNames.add(variable);
+  }
+}
 
+function addGrantPrivateNames(
+  method: ConnectorAuthMethodConfig,
+  privateNames: Set<string>,
+): void {
   if (method.grant.kind === "manual") {
     for (const fieldName of Object.keys(method.grant.fields)) {
       privateNames.add(fieldName);
@@ -95,49 +103,99 @@ function privateNamesForAuthMethod(
       addValueRefName(valueRef, privateNames);
     }
   }
+}
 
-  if (method.access.kind !== "none") {
-    for (const [envName, binding] of Object.entries(
-      method.access.envBindings,
-    )) {
-      privateNames.add(envName);
-      addValueRefName(
-        typeof binding === "string" ? binding : binding.valueRef,
-        privateNames,
-      );
-    }
-    for (const platformSecret of method.access.platformSecrets ?? []) {
-      privateNames.add(platformSecret);
-    }
+function addAccessPrivateNames(
+  method: ConnectorAuthMethodConfig,
+  privateNames: Set<string>,
+): void {
+  if (method.access.kind === "none") {
+    return;
   }
 
-  if (method.access.kind === "refresh-token") {
-    for (const valueRef of Object.values(method.access.inputs)) {
-      addValueRefName(valueRef, privateNames);
-    }
-    for (const valueRef of Object.values(method.access.outputs)) {
-      addValueRefName(valueRef, privateNames);
-    }
-    for (const refreshableSecret of method.access.refreshableSecrets) {
-      privateNames.add(refreshableSecret);
-    }
+  for (const [envName, binding] of Object.entries(method.access.envBindings)) {
+    privateNames.add(envName);
+    addValueRefName(
+      typeof binding === "string" ? binding : binding.valueRef,
+      privateNames,
+    );
+  }
+  for (const platformSecret of method.access.platformSecrets ?? []) {
+    privateNames.add(platformSecret);
+  }
+}
+
+function addRefreshPrivateNames(
+  method: ConnectorAuthMethodConfig,
+  privateNames: Set<string>,
+): void {
+  if (method.access.kind !== "refresh-token") {
+    return;
   }
 
-  if (method.revoke.kind === "token-revoke") {
-    for (const valueRef of Object.values(method.revoke.inputs)) {
-      addValueRefName(valueRef, privateNames);
-    }
+  for (const valueRef of Object.values(method.access.inputs)) {
+    addValueRefName(valueRef, privateNames);
+  }
+  for (const valueRef of Object.values(method.access.outputs)) {
+    addValueRefName(valueRef, privateNames);
+  }
+  for (const refreshableSecret of method.access.refreshableSecrets) {
+    privateNames.add(refreshableSecret);
+  }
+}
+
+function addRevokePrivateNames(
+  method: ConnectorAuthMethodConfig,
+  privateNames: Set<string>,
+): void {
+  if (method.revoke.kind !== "token-revoke") {
+    return;
   }
 
-  if ("client" in method && method.client) {
-    if ("clientIdEnv" in method.client) {
-      privateNames.add(method.client.clientIdEnv);
-    }
-    if ("clientSecretEnv" in method.client) {
-      privateNames.add(method.client.clientSecretEnv);
-    }
+  for (const valueRef of Object.values(method.revoke.inputs)) {
+    addValueRefName(valueRef, privateNames);
+  }
+}
+
+function addClientPrivateNames(
+  method: ConnectorAuthMethodConfig,
+  privateNames: Set<string>,
+): void {
+  if (!("client" in method) || !method.client) {
+    return;
   }
 
+  if ("clientIdEnv" in method.client) {
+    privateNames.add(method.client.clientIdEnv);
+  }
+  if ("clientSecretEnv" in method.client) {
+    privateNames.add(method.client.clientSecretEnv);
+  }
+}
+
+function addPrivateNamesForAuthMethod(
+  method: ConnectorAuthMethodConfig,
+  privateNames: Set<string>,
+): void {
+  addStoragePrivateNames(method, privateNames);
+  addGrantPrivateNames(method, privateNames);
+  addAccessPrivateNames(method, privateNames);
+  addRefreshPrivateNames(method, privateNames);
+  addRevokePrivateNames(method, privateNames);
+  addClientPrivateNames(method, privateNames);
+}
+
+function privateNamesForConnector(
+  type: ConnectorType,
+  authMethods: readonly ConnectorAuthMethodId[],
+): ReadonlySet<string> {
+  const privateNames = new Set<string>();
+  for (const authMethod of authMethods) {
+    const method = getConnectorAuthMethod(type, authMethod);
+    if (method) {
+      addPrivateNamesForAuthMethod(method, privateNames);
+    }
+  }
   return privateNames;
 }
 
@@ -148,6 +206,7 @@ function normalizePublicText(value: string): string {
 function publicTextOrNull(
   value: string | undefined,
   privateNames: ReadonlySet<string>,
+  options: { readonly checkDerivedPrivateNames?: boolean } = {},
 ): string | null {
   if (!value) {
     return null;
@@ -156,7 +215,8 @@ function publicTextOrNull(
   const normalizedValue = normalizePublicText(value);
   for (const privateName of privateNames) {
     const normalizedPrivateName = normalizePublicText(privateName);
-    const checkDerivedPrivateName = privateName.includes("_");
+    const checkDerivedPrivateName =
+      options.checkDerivedPrivateNames === true && privateName.includes("_");
     if (
       privateName.length > 0 &&
       (value.includes(privateName) ||
@@ -174,8 +234,8 @@ function publicTextOrNull(
 function authMethodSummaryForCatalog(
   id: ConnectorAuthMethodId,
   method: ConnectorAuthMethodConfig,
+  privateNames: ReadonlySet<string>,
 ): PublicConnectorCatalogAuthMethodSummary {
-  const privateNames = privateNamesForAuthMethod(method);
   return {
     id,
     label: method.label,
@@ -186,17 +246,19 @@ function authMethodSummaryForCatalog(
 
 function manualFieldsForCatalog(
   method: ConnectorAuthMethodConfig,
+  privateNames: ReadonlySet<string>,
 ): PublicConnectorCatalogManualField[] {
   if (method.grant.kind !== "manual") {
     return [];
   }
-  const privateNames = privateNamesForAuthMethod(method);
   return Object.values(method.grant.fields).map((field, index) => {
     return {
       id: `field-${index + 1}`,
       label: field.label,
       required: field.required,
-      placeholder: publicTextOrNull(field.placeholder, privateNames),
+      placeholder: publicTextOrNull(field.placeholder, privateNames, {
+        checkDerivedPrivateNames: true,
+      }),
       inputType: field.storage === "variable" ? "text" : "password",
     };
   });
@@ -225,10 +287,11 @@ function startOptionsForCatalog(
 function authMethodDetailForCatalog(
   id: ConnectorAuthMethodId,
   method: ConnectorAuthMethodConfig,
+  privateNames: ReadonlySet<string>,
 ): PublicConnectorCatalogAuthMethodDetail {
   return {
-    ...authMethodSummaryForCatalog(id, method),
-    manualFields: manualFieldsForCatalog(method),
+    ...authMethodSummaryForCatalog(id, method, privateNames),
+    manualFields: manualFieldsForCatalog(method, privateNames),
     startOptions: startOptionsForCatalog(method),
   };
 }
@@ -238,6 +301,7 @@ function connectorCatalogItem(
   authMethods: readonly ConnectorAuthMethodId[],
 ): PublicConnectorCatalogItem {
   const config = CONNECTOR_TYPES[type];
+  const privateNames = privateNamesForConnector(type, authMethods);
   return {
     connectorRef: type,
     label: config.label,
@@ -247,7 +311,9 @@ function connectorCatalogItem(
     tags: [...getConnectorTags(type)],
     authMethods: authMethods.flatMap((authMethod) => {
       const method = getConnectorAuthMethod(type, authMethod);
-      return method ? [authMethodSummaryForCatalog(authMethod, method)] : [];
+      return method
+        ? [authMethodSummaryForCatalog(authMethod, method, privateNames)]
+        : [];
     }),
     permissionSummary: permissionSummaryForCatalog(type),
   };
@@ -258,11 +324,14 @@ function connectorCatalogDetail(
   authMethods: readonly ConnectorAuthMethodId[],
 ): PublicConnectorCatalogDetail {
   const item = connectorCatalogItem(type, authMethods);
+  const privateNames = privateNamesForConnector(type, authMethods);
   return {
     ...item,
     authMethods: authMethods.flatMap((authMethod) => {
       const method = getConnectorAuthMethod(type, authMethod);
-      return method ? [authMethodDetailForCatalog(authMethod, method)] : [];
+      return method
+        ? [authMethodDetailForCatalog(authMethod, method, privateNames)]
+        : [];
     }),
   };
 }

--- a/turbo/apps/api/src/signals/services/connector-catalog-reader.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-reader.service.ts
@@ -1,19 +1,166 @@
+import type {
+  PublicConnectorCatalogAuthMethodDetail,
+  PublicConnectorCatalogAuthMethodSummary,
+  PublicConnectorCatalogDetail,
+  PublicConnectorCatalogItem,
+  PublicConnectorCatalogManualField,
+  PublicConnectorCatalogPermissionDetail,
+  PublicConnectorCatalogPermissionSummary,
+  PublicConnectorCatalogStartOption,
+} from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import type { ConnectorSearchItem } from "@vm0/api-contracts/contracts/zero-connectors";
 import {
   CONNECTOR_TYPE_KEYS,
   CONNECTOR_TYPES,
+  type ConnectorAuthMethodConfig,
+  type ConnectorAuthMethodId,
+  type ConnectorType,
 } from "@vm0/connectors/connectors";
 import {
   getAvailableConnectorAuthMethodIds,
+  getConnectorAuthMethod,
+  getConnectorGenerationTypes,
   getConnectorTags,
   type ApiAuthMethodPolicy,
   type ConnectorFeatureStates,
 } from "@vm0/connectors/connector-utils";
+import {
+  getFirewallPermissionSummary,
+  loadFirewallPermissionMetadata,
+} from "@vm0/connectors/firewall-metadata";
 
 interface ConnectorCatalogSearchArgs {
   readonly keyword: string | undefined;
   readonly featureStates: ConnectorFeatureStates;
   readonly apiAuthMethodPolicy?: ApiAuthMethodPolicy;
+}
+
+interface ConnectorCatalogReadArgs {
+  readonly featureStates: ConnectorFeatureStates;
+  readonly apiAuthMethodPolicy?: ApiAuthMethodPolicy;
+}
+
+interface ConnectorCatalogConnectorReadArgs extends ConnectorCatalogReadArgs {
+  readonly connectorRef: string;
+}
+
+function isConnectorType(connectorRef: string): connectorRef is ConnectorType {
+  return Object.prototype.hasOwnProperty.call(CONNECTOR_TYPES, connectorRef);
+}
+
+function availableAuthMethodsForCatalog(
+  type: ConnectorType,
+  args: ConnectorCatalogReadArgs,
+): ConnectorAuthMethodId[] {
+  return getAvailableConnectorAuthMethodIds(type, args.featureStates, {
+    apiAuthMethodPolicy: args.apiAuthMethodPolicy ?? "include",
+  });
+}
+
+function permissionSummaryForCatalog(
+  type: ConnectorType,
+): PublicConnectorCatalogPermissionSummary {
+  const summary = getFirewallPermissionSummary(type);
+  return {
+    hasPermissions: summary?.hasPermissions ?? false,
+    permissionCount: summary?.permissionCount ?? 0,
+    hasCategories: summary?.hasCategories ?? false,
+    hasDefaultPolicyOverrides: summary?.hasDefaultPolicyOverrides ?? false,
+  };
+}
+
+function authMethodSummaryForCatalog(
+  id: ConnectorAuthMethodId,
+  method: ConnectorAuthMethodConfig,
+): PublicConnectorCatalogAuthMethodSummary {
+  return {
+    id,
+    label: method.label,
+    description: method.helpText ?? null,
+    grantKind: method.grant.kind,
+  };
+}
+
+function manualFieldsForCatalog(
+  method: ConnectorAuthMethodConfig,
+): PublicConnectorCatalogManualField[] {
+  if (method.grant.kind !== "manual") {
+    return [];
+  }
+  return Object.values(method.grant.fields).map((field, index) => {
+    return {
+      id: `field-${index + 1}`,
+      label: field.label,
+      required: field.required,
+      placeholder: field.placeholder ?? null,
+      inputType: field.storage === "variable" ? "text" : "password",
+    };
+  });
+}
+
+function startOptionsForCatalog(
+  method: ConnectorAuthMethodConfig,
+): PublicConnectorCatalogStartOption[] {
+  if (method.grant.kind !== "device-auth") {
+    return [];
+  }
+  return Object.values(method.grant.startOptions ?? {}).map((option, index) => {
+    return {
+      id: `option-${index + 1}`,
+      kind: option.kind,
+      label: option.label,
+      required: option.required,
+      defaultValue: option.defaultValue ?? null,
+      options: option.options.map((choice) => {
+        return { value: choice.value, label: choice.label };
+      }),
+    };
+  });
+}
+
+function authMethodDetailForCatalog(
+  id: ConnectorAuthMethodId,
+  method: ConnectorAuthMethodConfig,
+): PublicConnectorCatalogAuthMethodDetail {
+  return {
+    ...authMethodSummaryForCatalog(id, method),
+    manualFields: manualFieldsForCatalog(method),
+    startOptions: startOptionsForCatalog(method),
+  };
+}
+
+function connectorCatalogItem(
+  type: ConnectorType,
+  authMethods: readonly ConnectorAuthMethodId[],
+): PublicConnectorCatalogItem {
+  const config = CONNECTOR_TYPES[type];
+  return {
+    connectorRef: type,
+    label: config.label,
+    description: config.helpText,
+    category: config.category,
+    generation: [...getConnectorGenerationTypes(type)],
+    tags: [...getConnectorTags(type)],
+    authMethods: authMethods.flatMap((authMethod) => {
+      const method = getConnectorAuthMethod(type, authMethod);
+      return method ? [authMethodSummaryForCatalog(authMethod, method)] : [];
+    }),
+    permissionSummary: permissionSummaryForCatalog(type),
+  };
+}
+
+function connectorCatalogDetail(
+  type: ConnectorType,
+  authMethods: readonly ConnectorAuthMethodId[],
+): PublicConnectorCatalogDetail {
+  const item = connectorCatalogItem(type, authMethods);
+  return {
+    ...item,
+    authMethods: authMethods.flatMap((authMethod) => {
+      const method = getConnectorAuthMethod(type, authMethod);
+      return method ? [authMethodDetailForCatalog(authMethod, method)] : [];
+    }),
+  };
 }
 
 export function searchConnectorCatalog(
@@ -58,4 +205,85 @@ export function searchConnectorCatalog(
   });
 
   return Promise.resolve(connectors);
+}
+
+export function listPublicConnectorCatalog(
+  args: ConnectorCatalogReadArgs,
+): Promise<PublicConnectorCatalogItem[]> {
+  const connectors = CONNECTOR_TYPE_KEYS.flatMap((type) => {
+    const authMethods = availableAuthMethodsForCatalog(type, args);
+    if (authMethods.length === 0) {
+      return [];
+    }
+    return [connectorCatalogItem(type, authMethods)];
+  });
+
+  return Promise.resolve(connectors);
+}
+
+export function getPublicConnectorCatalogDetail(
+  args: ConnectorCatalogConnectorReadArgs,
+): Promise<PublicConnectorCatalogDetail | null> {
+  if (!isConnectorType(args.connectorRef)) {
+    return Promise.resolve(null);
+  }
+  const authMethods = availableAuthMethodsForCatalog(args.connectorRef, args);
+  if (authMethods.length === 0) {
+    return Promise.resolve(null);
+  }
+  return Promise.resolve(
+    connectorCatalogDetail(args.connectorRef, authMethods),
+  );
+}
+
+export async function getPublicConnectorCatalogPermissionDetail(
+  args: ConnectorCatalogConnectorReadArgs,
+): Promise<PublicConnectorCatalogPermissionDetail | null> {
+  if (!isConnectorType(args.connectorRef)) {
+    return null;
+  }
+  const authMethods = availableAuthMethodsForCatalog(args.connectorRef, args);
+  if (authMethods.length === 0) {
+    return null;
+  }
+
+  const metadata = await loadFirewallPermissionMetadata(args.connectorRef);
+  if (!metadata) {
+    return null;
+  }
+
+  return {
+    connectorRef: args.connectorRef,
+    label: metadata.label,
+    permissionCount: metadata.permissionCount,
+    permissions: metadata.permissions.map((permission) => {
+      return {
+        name: permission.name,
+        ...(permission.description
+          ? { description: permission.description }
+          : {}),
+      };
+    }),
+    categories: metadata.categories
+      ? {
+          categories: { ...metadata.categories.categories },
+          displayOrder: [...metadata.categories.displayOrder],
+        }
+      : null,
+    defaultPolicy: {
+      permissionDefault: metadata.defaultPolicy.permissionDefault,
+      ...(metadata.defaultPolicy.permissionOverrides
+        ? {
+            permissionOverrides: Object.fromEntries(
+              Object.entries(metadata.defaultPolicy.permissionOverrides).map(
+                ([policy, permissions]) => {
+                  return [policy, [...permissions]];
+                },
+              ),
+            ),
+          }
+        : {}),
+      unknownPolicy: metadata.defaultPolicy.unknownPolicy,
+    },
+  };
 }

--- a/turbo/apps/api/src/signals/services/connector-catalog-reader.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-reader.service.ts
@@ -69,14 +69,117 @@ function permissionSummaryForCatalog(
   };
 }
 
+function addValueRefName(valueRef: string, privateNames: Set<string>): void {
+  const match = /^\$(?:secrets|vars)\.(.+)$/.exec(valueRef);
+  if (match?.[1]) {
+    privateNames.add(match[1]);
+  }
+}
+
+function privateNamesForAuthMethod(
+  method: ConnectorAuthMethodConfig,
+): ReadonlySet<string> {
+  const privateNames = new Set([
+    ...method.storage.secrets,
+    ...method.storage.variables,
+  ]);
+
+  if (method.grant.kind === "manual") {
+    for (const fieldName of Object.keys(method.grant.fields)) {
+      privateNames.add(fieldName);
+    }
+  }
+
+  if ("outputs" in method.grant) {
+    for (const valueRef of Object.values(method.grant.outputs)) {
+      addValueRefName(valueRef, privateNames);
+    }
+  }
+
+  if (method.access.kind !== "none") {
+    for (const [envName, binding] of Object.entries(
+      method.access.envBindings,
+    )) {
+      privateNames.add(envName);
+      addValueRefName(
+        typeof binding === "string" ? binding : binding.valueRef,
+        privateNames,
+      );
+    }
+    for (const platformSecret of method.access.platformSecrets ?? []) {
+      privateNames.add(platformSecret);
+    }
+  }
+
+  if (method.access.kind === "refresh-token") {
+    for (const valueRef of Object.values(method.access.inputs)) {
+      addValueRefName(valueRef, privateNames);
+    }
+    for (const valueRef of Object.values(method.access.outputs)) {
+      addValueRefName(valueRef, privateNames);
+    }
+    for (const refreshableSecret of method.access.refreshableSecrets) {
+      privateNames.add(refreshableSecret);
+    }
+  }
+
+  if (method.revoke.kind === "token-revoke") {
+    for (const valueRef of Object.values(method.revoke.inputs)) {
+      addValueRefName(valueRef, privateNames);
+    }
+  }
+
+  if ("client" in method && method.client) {
+    if ("clientIdEnv" in method.client) {
+      privateNames.add(method.client.clientIdEnv);
+    }
+    if ("clientSecretEnv" in method.client) {
+      privateNames.add(method.client.clientSecretEnv);
+    }
+  }
+
+  return privateNames;
+}
+
+function normalizePublicText(value: string): string {
+  return value.replace(/[^a-zA-Z0-9]/g, "").toLowerCase();
+}
+
+function publicTextOrNull(
+  value: string | undefined,
+  privateNames: ReadonlySet<string>,
+): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const normalizedValue = normalizePublicText(value);
+  for (const privateName of privateNames) {
+    const normalizedPrivateName = normalizePublicText(privateName);
+    const checkDerivedPrivateName = privateName.includes("_");
+    if (
+      privateName.length > 0 &&
+      (value.includes(privateName) ||
+        (checkDerivedPrivateName &&
+          normalizedPrivateName.length > 0 &&
+          normalizedValue.includes(normalizedPrivateName)))
+    ) {
+      return null;
+    }
+  }
+
+  return value;
+}
+
 function authMethodSummaryForCatalog(
   id: ConnectorAuthMethodId,
   method: ConnectorAuthMethodConfig,
 ): PublicConnectorCatalogAuthMethodSummary {
+  const privateNames = privateNamesForAuthMethod(method);
   return {
     id,
     label: method.label,
-    description: method.helpText ?? null,
+    description: publicTextOrNull(method.helpText, privateNames),
     grantKind: method.grant.kind,
   };
 }
@@ -87,12 +190,13 @@ function manualFieldsForCatalog(
   if (method.grant.kind !== "manual") {
     return [];
   }
+  const privateNames = privateNamesForAuthMethod(method);
   return Object.values(method.grant.fields).map((field, index) => {
     return {
       id: `field-${index + 1}`,
       label: field.label,
       required: field.required,
-      placeholder: field.placeholder ?? null,
+      placeholder: publicTextOrNull(field.placeholder, privateNames),
       inputType: field.storage === "variable" ? "text" : "password",
     };
   });

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -968,6 +968,21 @@ export {
   type ZeroConnectorsSearchContract,
 } from "./zero-connectors";
 export {
+  zeroConnectorCatalogContract,
+  type PublicConnectorCatalogAuthMethodDetail,
+  type PublicConnectorCatalogAuthMethodSummary,
+  type PublicConnectorCatalogDetail,
+  type PublicConnectorCatalogDetailResponse,
+  type PublicConnectorCatalogItem,
+  type PublicConnectorCatalogListResponse,
+  type PublicConnectorCatalogManualField,
+  type PublicConnectorCatalogPermissionDetail,
+  type PublicConnectorCatalogPermissionDetailResponse,
+  type PublicConnectorCatalogPermissionSummary,
+  type PublicConnectorCatalogStartOption,
+  type ZeroConnectorCatalogContract,
+} from "./zero-connector-catalog";
+export {
   codexDeviceAuthScopeSchema,
   zeroCodexDeviceAuthContract,
   type CodexDeviceAuthScope,

--- a/turbo/packages/api-contracts/src/contracts/zero-connector-catalog.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-connector-catalog.ts
@@ -1,0 +1,189 @@
+import { z } from "zod";
+
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+const publicConnectorCatalogAuthMethodSummarySchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  description: z.string().nullable(),
+  grantKind: z.enum([
+    "manual",
+    "auth-code",
+    "external-code",
+    "device-auth",
+    "managed",
+  ]),
+});
+
+const publicConnectorCatalogPermissionSummarySchema = z.object({
+  hasPermissions: z.boolean(),
+  permissionCount: z.number().int().nonnegative(),
+  hasCategories: z.boolean(),
+  hasDefaultPolicyOverrides: z.boolean(),
+});
+
+const publicConnectorCatalogItemSchema = z.object({
+  connectorRef: z.string(),
+  label: z.string(),
+  description: z.string(),
+  category: z.string(),
+  generation: z.array(z.string()),
+  tags: z.array(z.string()),
+  authMethods: z.array(publicConnectorCatalogAuthMethodSummarySchema),
+  permissionSummary: publicConnectorCatalogPermissionSummarySchema,
+});
+
+const publicConnectorCatalogManualFieldSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  required: z.boolean(),
+  placeholder: z.string().nullable(),
+  inputType: z.enum(["password", "text"]),
+});
+
+const publicConnectorCatalogStartOptionChoiceSchema = z.object({
+  value: z.string(),
+  label: z.string(),
+});
+
+const publicConnectorCatalogStartOptionSchema = z.object({
+  id: z.string(),
+  kind: z.literal("select"),
+  label: z.string(),
+  required: z.boolean(),
+  defaultValue: z.string().nullable(),
+  options: z.array(publicConnectorCatalogStartOptionChoiceSchema),
+});
+
+const publicConnectorCatalogAuthMethodDetailSchema =
+  publicConnectorCatalogAuthMethodSummarySchema.extend({
+    manualFields: z.array(publicConnectorCatalogManualFieldSchema),
+    startOptions: z.array(publicConnectorCatalogStartOptionSchema),
+  });
+
+const publicConnectorCatalogDetailSchema =
+  publicConnectorCatalogItemSchema.extend({
+    authMethods: z.array(publicConnectorCatalogAuthMethodDetailSchema),
+  });
+
+const publicConnectorCatalogListResponseSchema = z.object({
+  connectors: z.array(publicConnectorCatalogItemSchema),
+});
+
+const publicConnectorCatalogDetailResponseSchema = z.object({
+  connector: publicConnectorCatalogDetailSchema,
+});
+
+const publicFirewallPolicyValueSchema = z.enum(["allow", "deny", "ask"]);
+
+const publicConnectorCatalogPermissionSchema = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+});
+
+const publicConnectorCatalogPermissionCategoriesSchema = z.object({
+  categories: z.record(z.string(), z.string()),
+  displayOrder: z.array(z.string()),
+});
+
+const publicConnectorCatalogDefaultPolicySchema = z.object({
+  permissionDefault: publicFirewallPolicyValueSchema,
+  permissionOverrides: z.record(z.string(), z.array(z.string())).optional(),
+  unknownPolicy: publicFirewallPolicyValueSchema,
+});
+
+const publicConnectorCatalogPermissionDetailSchema = z.object({
+  connectorRef: z.string(),
+  label: z.string(),
+  permissionCount: z.number().int().nonnegative(),
+  permissions: z.array(publicConnectorCatalogPermissionSchema),
+  categories: publicConnectorCatalogPermissionCategoriesSchema.nullable(),
+  defaultPolicy: publicConnectorCatalogDefaultPolicySchema,
+});
+
+const publicConnectorCatalogPermissionDetailResponseSchema = z.object({
+  permissions: publicConnectorCatalogPermissionDetailSchema,
+});
+
+const connectorCatalogPathParamsSchema = z.object({
+  connectorRef: z.string().min(1),
+});
+
+export type PublicConnectorCatalogAuthMethodSummary = z.infer<
+  typeof publicConnectorCatalogAuthMethodSummarySchema
+>;
+export type PublicConnectorCatalogPermissionSummary = z.infer<
+  typeof publicConnectorCatalogPermissionSummarySchema
+>;
+export type PublicConnectorCatalogItem = z.infer<
+  typeof publicConnectorCatalogItemSchema
+>;
+export type PublicConnectorCatalogManualField = z.infer<
+  typeof publicConnectorCatalogManualFieldSchema
+>;
+export type PublicConnectorCatalogStartOption = z.infer<
+  typeof publicConnectorCatalogStartOptionSchema
+>;
+export type PublicConnectorCatalogAuthMethodDetail = z.infer<
+  typeof publicConnectorCatalogAuthMethodDetailSchema
+>;
+export type PublicConnectorCatalogDetail = z.infer<
+  typeof publicConnectorCatalogDetailSchema
+>;
+export type PublicConnectorCatalogListResponse = z.infer<
+  typeof publicConnectorCatalogListResponseSchema
+>;
+export type PublicConnectorCatalogDetailResponse = z.infer<
+  typeof publicConnectorCatalogDetailResponseSchema
+>;
+export type PublicConnectorCatalogPermissionDetail = z.infer<
+  typeof publicConnectorCatalogPermissionDetailSchema
+>;
+export type PublicConnectorCatalogPermissionDetailResponse = z.infer<
+  typeof publicConnectorCatalogPermissionDetailResponseSchema
+>;
+
+export const zeroConnectorCatalogContract = c.router({
+  list: {
+    method: "GET",
+    path: "/api/zero/connector-catalog",
+    headers: authHeadersSchema,
+    responses: {
+      200: publicConnectorCatalogListResponseSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+    },
+    summary: "List public connector catalog metadata",
+  },
+  get: {
+    method: "GET",
+    path: "/api/zero/connector-catalog/:connectorRef",
+    headers: authHeadersSchema,
+    pathParams: connectorCatalogPathParamsSchema,
+    responses: {
+      200: publicConnectorCatalogDetailResponseSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Get public connector catalog metadata",
+  },
+  permissions: {
+    method: "GET",
+    path: "/api/zero/connector-catalog/:connectorRef/permissions",
+    headers: authHeadersSchema,
+    pathParams: connectorCatalogPathParamsSchema,
+    responses: {
+      200: publicConnectorCatalogPermissionDetailResponseSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Get public connector permission metadata",
+  },
+});
+
+export type ZeroConnectorCatalogContract = typeof zeroConnectorCatalogContract;

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -57,7 +57,7 @@ export enum FeatureSwitchKey {
   GoalWorkflows = "goalWorkflows",
   ComputerUseDelegatedAuthorization = "computerUseDelegatedAuthorization",
   ConnectorAccessManagement = "connectorAccessManagement",
-  PublicConnectorCatalog = "publicConnectorCatalog",
+  ConnectorCatalogApi = "connectorCatalogApi",
   PresentationTemplateRunbook = "presentationTemplateRunbook",
   AgentUnreadIndicators = "agentUnreadIndicators",
 }

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -57,6 +57,7 @@ export enum FeatureSwitchKey {
   GoalWorkflows = "goalWorkflows",
   ComputerUseDelegatedAuthorization = "computerUseDelegatedAuthorization",
   ConnectorAccessManagement = "connectorAccessManagement",
+  PublicConnectorCatalog = "publicConnectorCatalog",
   PresentationTemplateRunbook = "presentationTemplateRunbook",
   AgentUnreadIndicators = "agentUnreadIndicators",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -333,6 +333,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.PublicConnectorCatalog]: {
+    maintainer: "liangyou@vm0.ai",
+    description:
+      "Expose the read-only public connector catalog API for frontend and CLI metadata migration.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.PresentationTemplateRunbook]: {
     maintainer: "bingjie@vm0.ai",
     description:

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -333,7 +333,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.PublicConnectorCatalog]: {
+  [FeatureSwitchKey.ConnectorCatalogApi]: {
     maintainer: "liangyou@vm0.ai",
     description:
       "Expose the read-only public connector catalog API for frontend and CLI metadata migration.",


### PR DESCRIPTION
## Summary
- Add a feature-gated public connector catalog contract and API route family for list, detail, and permission metadata.
- Extend the static-backed server-side connector catalog reader with explicit frontend-safe public view models.
- Add route integration tests and recursive leak checks for private connector/runtime/firewall fields.

Closes #19390

## Tests
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connector-catalog.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connectors-search.test.ts
- pnpm -F api lint
- pnpm -F api check-types
- pnpm -F @vm0/api-contracts lint
- pnpm -F @vm0/api-contracts check-types
- pnpm -F @vm0/connectors lint
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/core lint
- pnpm -F @vm0/core check-types
- pnpm knip
- pre-commit: prettier, knip, check-types