### PR TITLE
feat: add connected connectors filter (bridge for external PR #19410)

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -13,7 +13,6 @@ import {
   type ConnectorType,
   type ConnectorDisplayCategory,
 } from "@vm0/connectors/connectors";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   getConnectorAuthMethodAccessMetadata,
   getConnectorAuthMethod,
@@ -406,16 +405,12 @@ export const connectorsSearch$ = computed((get) => {
 export const filteredConnectorTypes$ = computed(async (get) => {
   const keyword = get(connectorsSearch$);
   const connectionFilter = get(connectorsConnectionFilter$);
-  const features = get(featureSwitch$);
-  const shouldFilterConnected =
-    connectionFilter === "connected" &&
-    (features[FeatureSwitchKey.ConnectorAccessManagement] ?? false);
   const allConnectorTypes = await get(allConnectorTypes$);
   return allConnectorTypes.filter((connector) => {
     if (!matchesConnectorSearch(keyword, connector)) {
       return false;
     }
-    return !shouldFilterConnected || connector.connected;
+    return connectionFilter !== "connected" || connector.connected;
   });
 });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -430,16 +430,10 @@ describe("connectors page", () => {
     expect(screen.queryByText("GitHub")).not.toBeInTheDocument();
   });
 
-  it("filters connectors by connected status when access management is enabled", async () => {
+  it("filters connectors by connected status", async () => {
     mockConnectors([{ type: "github", externalUsername: "octocat" }]);
 
-    detachedSetupPage({
-      context,
-      path: "/connectors",
-      featureSwitches: {
-        [FeatureSwitchKey.ConnectorAccessManagement]: true,
-      },
-    });
+    detachedSetupPage({ context, path: "/connectors" });
 
     await waitFor(() => {
       expect(screen.getByText("GitHub")).toBeInTheDocument();
@@ -512,7 +506,7 @@ describe("connectors page", () => {
     expect(screen.queryByLabelText("Connect AWS")).not.toBeInTheDocument();
   });
 
-  it("hides connector access management when its switch is disabled", async () => {
+  it("shows the connection filter and hides access management when its switch is disabled", async () => {
     mockConnectors([{ type: "github", externalUsername: "octocat" }]);
 
     detachedSetupPage({
@@ -527,10 +521,10 @@ describe("connectors page", () => {
       expect(screen.getByText("GitHub")).toBeInTheDocument();
     });
     expect(
-      screen.queryByRole("group", {
+      screen.getByRole("group", {
         name: "Connector connection filter",
       }),
-    ).not.toBeInTheDocument();
+    ).toBeInTheDocument();
     expect(
       screen.queryByLabelText("Manage GitHub access"),
     ).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -910,7 +910,7 @@ export function ZeroConnectorsPage() {
     filteredCount: filteredConnectors.length,
     renderCard,
     search,
-    connectionFilter: showConnectorAccessManagement ? connectionFilter : "all",
+    connectionFilter,
   });
   return (
     <div
@@ -972,7 +972,7 @@ export function ZeroConnectorsPage() {
                 </TabsList>
               </Tabs>
               <div className="flex items-center gap-2">
-                {activeTab === "builtin" && showConnectorAccessManagement && (
+                {activeTab === "builtin" && (
                   <ConnectorConnectionFilter
                     value={connectionFilter}
                     onChange={setConnectionFilter}


### PR DESCRIPTION
Bridge PR for external contributor source PR: https://github.com/vm0-ai/vm0/pull/19410

Original contributor: @highestop
Source head: highestop/vm0 highestop-filter-connected-connectors
Audited source SHA: ebcdf0949dfd39fedf8e2664cbf10b23ae6284b0

Security audit summary:
- Prompt-injection audit: passed. Reviewed the PR title/body, commit message, absence of PR comments/reviews, full patch, and all changed textual files for agent-directed instruction manipulation; no blocking content found.
- CI/secret-exposure audit: passed. The diff only modifies three frontend/test TypeScript files. It does not change GitHub workflows, package scripts, lockfiles, lifecycle hooks, shell/Docker/Makefile entrypoints, env/secret reads, credential handling, network calls, dynamic evaluation, or shell execution.

This branch was created from vm0-ai/vm0:main at 84e0fc4efbf27c64e1db76d2e2a6378dd0d81e79 and merged from the exact audited source SHA above without squashing.

Preserve the original commits when merging if possible. If squash-merging, keep the Co-authored-by trailers below so the contributor receives credit.

Co-authored-by: highestop <highestop@qq.com>