### PR TITLE
feat: enable codex local active input

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -735,7 +735,7 @@ jobs:
             --config "$RUNNER_DIR/runner.yaml" \
             --local
 
-          PROMPT='This is a CI smoke test for Claude Code active input. The initial prompt token is ci-initial-5k2. Run Bash command `sleep 3` before your final answer. During that sleep, two follow-up user messages will arrive, each containing one token. After the sleep and after reading both follow-up messages, reply with exactly RESULT=ci-initial-5k2+FIRST+SECOND, replacing FIRST and SECOND with the exact text of the first and second follow-up messages. If either follow-up message is missing, reply exactly RESULT=missing. Do not include any other text.'
+          PROMPT='This is a CI smoke test for Claude Code active input. The initial prompt token is ci-initial-5k2. Before your final answer, run Bash command `sleep 1` so two follow-up user messages can arrive, each containing one token. After the command and after reading both follow-up messages, reply with exactly RESULT=ci-initial-5k2+FIRST+SECOND, replacing FIRST and SECOND with the exact text of the first and second follow-up messages. If either follow-up message is missing, reply exactly RESULT=missing. Do not include any other text.'
           EXPECTED_RESULT='RESULT=ci-initial-5k2+ci-active-one-7f3+ci-active-two-9q4'
 
           echo "--- Submitting active-input smoke job ---"
@@ -746,8 +746,8 @@ jobs:
             --env ANTHROPIC_MODEL=claude-haiku-4-5 \
             --secret-env ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" \
             --prompt "$PROMPT" \
-            --active-input 'after=1s,text=ci-active-one-7f3' \
-            --active-input 'after=2s,text=ci-active-two-9q4' 2>&1); then
+            --active-input 'after=100ms,text=ci-active-one-7f3' \
+            --active-input 'after=300ms,text=ci-active-two-9q4' 2>&1); then
             echo "$SUBMIT_OUTPUT"
             print_service_logs
             fail "real Claude Code active-input local submit smoke failed"
@@ -878,7 +878,7 @@ jobs:
             --config "$RUNNER_DIR/runner.yaml" \
             --local
 
-          PROMPT='This is a CI smoke test for Codex active input. The initial prompt token is codex-initial-8m6. Run shell command `sleep 3` before your final answer. During that sleep, two follow-up user messages will arrive, each containing one token. After the sleep and after reading both follow-up messages, reply with exactly RESULT=codex-initial-8m6+FIRST+SECOND, replacing FIRST and SECOND with the exact text of the first and second follow-up messages. If either follow-up message is missing, reply exactly RESULT=missing. Do not include any other text.'
+          PROMPT='This is a CI smoke test for Codex active input. The initial prompt token is codex-initial-8m6. Before your final answer, run shell command `sleep 1` so two follow-up user messages can arrive, each containing one token. After the command and after reading both follow-up messages, reply with exactly RESULT=codex-initial-8m6+FIRST+SECOND, replacing FIRST and SECOND with the exact text of the first and second follow-up messages. If either follow-up message is missing, reply exactly RESULT=missing. Do not include any other text.'
           EXPECTED_RESULT='RESULT=codex-initial-8m6+codex-active-one-2p9+codex-active-two-6v1'
 
           echo "--- Submitting Codex active-input smoke job ---"
@@ -889,8 +889,8 @@ jobs:
             --env OPENAI_MODEL=gpt-5.4-mini \
             --secret-env OPENAI_API_KEY="$OPENAI_API_KEY" \
             --prompt "$PROMPT" \
-            --active-input 'after=1s,text=codex-active-one-2p9' \
-            --active-input 'after=2s,text=codex-active-two-6v1' 2>&1); then
+            --active-input 'after=100ms,text=codex-active-one-2p9' \
+            --active-input 'after=300ms,text=codex-active-two-6v1' 2>&1); then
             echo "$SUBMIT_OUTPUT"
             print_service_logs
             fail "real Codex active-input local submit smoke failed"

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -788,6 +788,159 @@ jobs:
             "$DEFAULT_SNAPSHOT_HASH" \
             "$OFFICIAL_RUNNER_SECRET"
 
+  runner-local-codex-active-input-smoke:
+    runs-on: ubuntu-latest
+    needs: [runner-build]
+    timeout-minutes: 8
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup SSH via Cloudflare Tunnel
+        uses: ./.github/actions/setup-ssh-tunnel
+        with:
+          ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
+          cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+
+      - name: Test local active input with real Codex
+        env:
+          METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
+          OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          HOST: ${{ needs.runner-build.outputs.host }}
+          JOB_REF: ${{ needs.runner-build.outputs.job-ref }}
+          BIN_DIR: ${{ needs.runner-build.outputs.bin-dir }}
+          DEFAULT_ROOTFS_HASH: ${{ needs.runner-build.outputs.default-rootfs-hash }}
+          DEFAULT_SNAPSHOT_HASH: ${{ needs.runner-build.outputs.default-snapshot-hash }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${OPENAI_API_KEY:-}" ]; then
+            echo "::error::OPENAI_API_KEY is required for real Codex active-input smoke"
+            exit 1
+          fi
+
+          REMOTE="${METAL_USER}@${HOST}"
+          {
+            # Keep the CI provider key off SSH/bash argv; the runner CLI still
+            # receives it through --secret-env because that is the behavior
+            # under test.
+            printf 'OPENAI_API_KEY=%q\n' "$OPENAI_API_KEY"
+            cat <<'REMOTE_SCRIPT'
+          set -euo pipefail
+
+          BIN_DIR=$1
+          JOB_REF=$2
+          ROOTFS_HASH=$3
+          SNAPSHOT_HASH=$4
+          OFFICIAL_RUNNER_SECRET=$5
+
+          SVC="${JOB_REF}-local-codex-active-input"
+          RUNNER_DIR="/var/lib/vm0-runner/runners/${SVC}"
+          GROUP="vm0/local-codex-active-input-${JOB_REF}"
+          GROUP_DIR="/var/lib/vm0-runner/groups/vm0/local-codex-active-input-${JOB_REF}"
+
+          fail() {
+            echo "FAIL: $1" >&2
+            exit 1
+          }
+
+          print_service_logs() {
+            echo "--- ${SVC} service logs ---"
+            sudo "$BIN_DIR/runner" service logs --name "$SVC" --lines 200 || true
+          }
+
+          cleanup() {
+            echo "--- Cleanup local Codex active-input smoke runner ---"
+            sudo "$BIN_DIR/runner" service stop --name "$SVC" --force || true
+            sudo rm -rf "$GROUP_DIR" "$RUNNER_DIR"
+          }
+          trap cleanup EXIT
+
+          sudo "$BIN_DIR/runner" service stop --name "$SVC" --force
+          sudo rm -rf "$GROUP_DIR" "$RUNNER_DIR"
+
+          echo "--- Generating local runner config ---"
+          sudo "$BIN_DIR/runner" config \
+            --profile vm0/default \
+            --rootfs-hash "$ROOTFS_HASH" \
+            --snapshot-hash "$SNAPSHOT_HASH" \
+            --name "$SVC" \
+            --group "$GROUP" \
+            --runner-dirname "$SVC" \
+            --max-concurrent 1 \
+            --api-url https://not-a-real-server.test \
+            --token "vm0_official_${OFFICIAL_RUNNER_SECRET}"
+
+          echo "--- Starting local runner ---"
+          sudo "$BIN_DIR/runner" service start \
+            --name "$SVC" \
+            --config "$RUNNER_DIR/runner.yaml" \
+            --local
+
+          PROMPT='This is a CI smoke test for Codex active input. The initial prompt token is codex-initial-8m6. Run shell command `sleep 3` before your final answer. During that sleep, two follow-up user messages will arrive, each containing one token. After the sleep and after reading both follow-up messages, reply with exactly RESULT=codex-initial-8m6+FIRST+SECOND, replacing FIRST and SECOND with the exact text of the first and second follow-up messages. If either follow-up message is missing, reply exactly RESULT=missing. Do not include any other text.'
+          EXPECTED_RESULT='RESULT=codex-initial-8m6+codex-active-one-2p9+codex-active-two-6v1'
+
+          echo "--- Submitting Codex active-input smoke job ---"
+          if ! SUBMIT_OUTPUT=$(sudo "$BIN_DIR/runner" local submit \
+            --group "$GROUP" \
+            --timeout 240 \
+            --cli-agent-type codex \
+            --env OPENAI_MODEL=gpt-5.4-mini \
+            --secret-env OPENAI_API_KEY="$OPENAI_API_KEY" \
+            --prompt "$PROMPT" \
+            --active-input 'after=1s,text=codex-active-one-2p9' \
+            --active-input 'after=2s,text=codex-active-two-6v1' 2>&1); then
+            echo "$SUBMIT_OUTPUT"
+            print_service_logs
+            fail "real Codex active-input local submit smoke failed"
+          fi
+          echo "$SUBMIT_OUTPUT"
+
+          SUBMIT_JSON="$(awk '/^\{/{line=$0} END{print line}' <<<"$SUBMIT_OUTPUT")"
+          [ -n "$SUBMIT_JSON" ] || fail "local submit output did not include a JSON response"
+          RUN_ID="$(jq -r '.run_id // empty' <<<"$SUBMIT_JSON")"
+          [ -n "$RUN_ID" ] || fail "local submit output did not include run_id"
+          STREAM_LOG="/var/lib/vm0-runner/logs/system-stream-${RUN_ID}.log"
+
+          print_failure_context() {
+            echo "--- Guest stdout stream tail ---"
+            sudo tail -200 "$STREAM_LOG" || true
+            print_service_logs
+          }
+
+          if sudo grep -q 'Using mock-codex for testing' "$STREAM_LOG"; then
+            print_failure_context
+            fail "real Codex active-input smoke used mock Codex"
+          fi
+
+          sudo grep -F -q 'Codex active input steer:' "$STREAM_LOG" || {
+            print_failure_context
+            fail "Codex active-input smoke did not use turn/steer"
+          }
+
+          sudo grep -F -q 'outcome=active_turn_advanced' "$STREAM_LOG" || {
+            print_failure_context
+            fail "Codex active-input turn/steer did not report success"
+          }
+
+          echo "--- Real Codex active-input result lines from guest stdout ---"
+          sudo grep -E 'RESULT=|Codex active input steer|Codex Completed' "$STREAM_LOG" || true
+
+          sudo grep -F -q "$EXPECTED_RESULT" "$STREAM_LOG" || {
+            print_failure_context
+            fail "real Codex output did not include initial and active-input tokens"
+          }
+
+          echo "PASS: local active input reached real Codex and returned ${EXPECTED_RESULT}"
+          REMOTE_SCRIPT
+          } | ssh "$REMOTE" bash -s -- \
+            "$BIN_DIR" \
+            "$JOB_REF" \
+            "$DEFAULT_ROOTFS_HASH" \
+            "$DEFAULT_SNAPSHOT_HASH" \
+            "$OFFICIAL_RUNNER_SECRET"
+
   runner-benchmark:
     runs-on: ubuntu-latest
     needs: [runner-build]
@@ -2025,6 +2178,7 @@ jobs:
       - runner-build
       - runner-image-architecture-manifest
       - runner-local-active-input-smoke
+      - runner-local-codex-active-input-smoke
       - runner-benchmark
       - runner-exec
       - runner-cancel
@@ -2078,6 +2232,7 @@ jobs:
           check_result "runner-build" "${{ needs.runner-build.result }}" "true"
           check_result "runner-image-architecture-manifest" "${{ needs.runner-image-architecture-manifest.result }}" "true"
           check_result "runner-local-active-input-smoke" "${{ needs.runner-local-active-input-smoke.result }}" "true"
+          check_result "runner-local-codex-active-input-smoke" "${{ needs.runner-local-codex-active-input-smoke.result }}" "true"
           check_result "runner-benchmark" "${{ needs.runner-benchmark.result }}" "true"
           check_result "runner-exec" "${{ needs.runner-exec.result }}" "true"
           check_result "runner-cancel" "${{ needs.runner-cancel.result }}" "true"

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -645,7 +645,7 @@ jobs:
           PROFILE: vm0/default
         run: .github/scripts/wait-runner-image.sh
 
-  runner-local-active-input-smoke:
+  runner-local-claude-active-input-smoke:
     runs-on: ubuntu-latest
     needs: [runner-build]
     timeout-minutes: 5
@@ -692,10 +692,10 @@ jobs:
           SNAPSHOT_HASH=$4
           OFFICIAL_RUNNER_SECRET=$5
 
-          SVC="${JOB_REF}-local-active-input"
+          SVC="${JOB_REF}-local-claude-active-input"
           RUNNER_DIR="/var/lib/vm0-runner/runners/${SVC}"
-          GROUP="vm0/local-active-input-${JOB_REF}"
-          GROUP_DIR="/var/lib/vm0-runner/groups/vm0/local-active-input-${JOB_REF}"
+          GROUP="vm0/local-claude-active-input-${JOB_REF}"
+          GROUP_DIR="/var/lib/vm0-runner/groups/vm0/local-claude-active-input-${JOB_REF}"
 
           fail() {
             echo "FAIL: $1" >&2
@@ -708,7 +708,7 @@ jobs:
           }
 
           cleanup() {
-            echo "--- Cleanup local active-input smoke runner ---"
+            echo "--- Cleanup local Claude active-input smoke runner ---"
             sudo "$BIN_DIR/runner" service stop --name "$SVC" --force || true
             sudo rm -rf "$GROUP_DIR" "$RUNNER_DIR"
           }
@@ -2177,7 +2177,7 @@ jobs:
       - runner-host-groups
       - runner-build
       - runner-image-architecture-manifest
-      - runner-local-active-input-smoke
+      - runner-local-claude-active-input-smoke
       - runner-local-codex-active-input-smoke
       - runner-benchmark
       - runner-exec
@@ -2231,7 +2231,7 @@ jobs:
           check_result "runner-host-groups" "${{ needs.runner-host-groups.result }}" "true"
           check_result "runner-build" "${{ needs.runner-build.result }}" "true"
           check_result "runner-image-architecture-manifest" "${{ needs.runner-image-architecture-manifest.result }}" "true"
-          check_result "runner-local-active-input-smoke" "${{ needs.runner-local-active-input-smoke.result }}" "true"
+          check_result "runner-local-claude-active-input-smoke" "${{ needs.runner-local-claude-active-input-smoke.result }}" "true"
           check_result "runner-local-codex-active-input-smoke" "${{ needs.runner-local-codex-active-input-smoke.result }}" "true"
           check_result "runner-benchmark" "${{ needs.runner-benchmark.result }}" "true"
           check_result "runner-exec" "${{ needs.runner-exec.result }}" "true"

--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -798,12 +798,26 @@ async fn ingest_event(event: Value, sink: &mut EventIngestSink<'_>) -> Result<()
         .await?
     {
         ParsedEventAction::Forward => {
+            if let Some(text) = codex_agent_message_text(&event) {
+                println!("{}", sink.masker.mask_string(text));
+            }
             sink.ingestor
                 .enqueue_event(event, sink.masker, sink.should_send_events, sink.event_tx);
         }
         ParsedEventAction::Skip => {}
     }
     Ok(())
+}
+
+fn codex_agent_message_text(event: &Value) -> Option<&str> {
+    if event.get("type").and_then(Value::as_str) != Some("item.completed") {
+        return None;
+    }
+    let item = event.get("item")?;
+    if item.get("type").and_then(Value::as_str) != Some("agent_message") {
+        return None;
+    }
+    item.get("text").and_then(Value::as_str)
 }
 
 fn is_duplicate_thread_started(
@@ -996,5 +1010,34 @@ mod tests {
             &thread_started_notification,
             "turn-1"
         ));
+    }
+
+    #[test]
+    fn codex_agent_message_text_reads_completed_agent_message_only() {
+        let agent_message = json!({
+            "type": "item.completed",
+            "item": {
+                "type": "agent_message",
+                "text": "RESULT=ok"
+            }
+        });
+        let plan_message = json!({
+            "type": "item.completed",
+            "item": {
+                "type": "plan",
+                "text": "not final output"
+            }
+        });
+        let started_agent_message = json!({
+            "type": "item.started",
+            "item": {
+                "type": "agent_message",
+                "text": "not completed"
+            }
+        });
+
+        assert_eq!(codex_agent_message_text(&agent_message), Some("RESULT=ok"));
+        assert_eq!(codex_agent_message_text(&plan_message), None);
+        assert_eq!(codex_agent_message_text(&started_agent_message), None);
     }
 }

--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -1,4 +1,4 @@
-//! Disabled Codex app-server execution backend.
+//! Experimental Codex app-server execution backend.
 //!
 //! This module owns only the experimental app-server runtime path. Ordinary
 //! Codex execution continues to use `codex exec --json` unless the explicit
@@ -209,12 +209,14 @@ async fn run_codex_app_server(
         .await?;
         let turn_id = turn_id_from_response(&turn_response)?;
         let mut active_input_open = active_input.is_enabled();
+        let mut turn_started_observed = false;
 
         let exit_code = loop {
             let event = next_codex_run_event(
                 &mut client,
                 &mut active_input,
                 active_input_open,
+                turn_started_observed,
                 heartbeat_monitor,
                 &mut heartbeat_done,
                 masker,
@@ -233,6 +235,8 @@ async fn run_codex_app_server(
                         thread_id: &thread_identity.canonical_id,
                         turn_id: &turn_id,
                     };
+                    let notification_ready_for_active_input =
+                        is_active_input_ready_notification(&notification, &turn_id);
                     let terminal_exit_code = ingest_run_notification(
                         notification,
                         &mut sink,
@@ -241,6 +245,8 @@ async fn run_codex_app_server(
                         &notification_scope,
                     )
                     .await?;
+                    turn_started_observed =
+                        turn_started_observed || notification_ready_for_active_input;
                     if let Some(exit_code) = terminal_exit_code {
                         active_input.close_terminal();
                         break exit_code;
@@ -463,13 +469,15 @@ async fn next_codex_run_event(
     client: &mut CodexAppServerClient,
     active_input: &mut ActiveInputWriter,
     active_input_open: bool,
+    active_input_ready: bool,
     heartbeat_monitor: &mut HeartbeatMonitor,
     heartbeat_done: &mut bool,
     masker: &SecretMasker,
 ) -> Result<CodexRunEvent, AgentError> {
+    let active_input_can_be_read = can_read_active_input(active_input_open, active_input_ready);
     // Do not let buffered terminal notifications overtake input the control
     // path already accepted.
-    if active_input_open && let Some(frame) = active_input.try_next_frame() {
+    if active_input_can_be_read && let Some(frame) = active_input.try_next_frame() {
         return Ok(CodexRunEvent::ActiveInput(Some(frame)));
     }
     if let Some(notification) = client.pop_notification() {
@@ -478,7 +486,7 @@ async fn next_codex_run_event(
 
     tokio::select! {
         biased;
-        frame = active_input.next_frame(), if active_input_open => {
+        frame = active_input.next_frame(), if active_input_can_be_read => {
             Ok(CodexRunEvent::ActiveInput(frame))
         }
         notification = client.next_notification(TURN_NOTIFICATION_LABEL) => {
@@ -491,6 +499,20 @@ async fn next_codex_run_event(
             Err(heartbeat_error(heartbeat_result))
         }
     }
+}
+
+fn can_read_active_input(active_input_open: bool, active_input_ready: bool) -> bool {
+    active_input_open && active_input_ready
+}
+
+fn is_active_input_ready_notification(notification: &ServerNotification, turn_id: &str) -> bool {
+    notification.method == "turn/started"
+        && notification
+            .params
+            .as_ref()
+            .and_then(|params| params.pointer("/turn/id"))
+            .and_then(Value::as_str)
+            == Some(turn_id)
 }
 
 async fn steer_active_input(
@@ -917,4 +939,62 @@ fn non_empty_string_at(
         .filter(|value| !value.is_empty())
         .map(ToString::to_string)
         .ok_or_else(|| AgentError::Execution(message.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn active_input_is_read_only_after_source_and_turn_are_ready() {
+        assert!(!can_read_active_input(false, false));
+        assert!(!can_read_active_input(false, true));
+        assert!(!can_read_active_input(true, false));
+        assert!(can_read_active_input(true, true));
+    }
+
+    #[test]
+    fn turn_started_notification_enables_active_input_for_matching_turn() {
+        let matching_notification = ServerNotification {
+            method: "turn/started".to_string(),
+            params: Some(json!({
+                "threadId": "thread-1",
+                "turn": {
+                    "id": "turn-1",
+                    "status": "inProgress"
+                }
+            })),
+        };
+        let wrong_turn_notification = ServerNotification {
+            method: "turn/started".to_string(),
+            params: Some(json!({
+                "threadId": "thread-1",
+                "turn": {
+                    "id": "turn-2",
+                    "status": "inProgress"
+                }
+            })),
+        };
+        let thread_started_notification = ServerNotification {
+            method: "thread/started".to_string(),
+            params: Some(json!({
+                "thread": {
+                    "id": "thread-1"
+                }
+            })),
+        };
+
+        assert!(is_active_input_ready_notification(
+            &matching_notification,
+            "turn-1"
+        ));
+        assert!(!is_active_input_ready_notification(
+            &wrong_turn_notification,
+            "turn-1"
+        ));
+        assert!(!is_active_input_ready_notification(
+            &thread_started_notification,
+            "turn-1"
+        ));
+    }
 }

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -406,7 +406,7 @@ pub async fn execute_cli(
 /// enabled, internally replayed initial-prompt and follow-up user events are
 /// filtered from outbound API event delivery.
 ///
-/// For the disabled Codex app-server backend, active input is delivered through
+/// For the experimental Codex app-server backend, active input is delivered through
 /// `turn/steer` for the active turn. Ordinary Codex execution still uses
 /// `codex exec --json` and does not consume active input.
 ///

--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -541,7 +541,7 @@ pub fn is_codex_oauth_mode() -> bool {
 pub fn use_mock_codex() -> bool {
     *USE_MOCK_CODEX
 }
-/// Whether the disabled Codex app-server backend is explicitly enabled.
+/// Whether the Codex app-server backend is explicitly enabled.
 pub fn use_codex_app_server_backend() -> bool {
     *USE_CODEX_APP_SERVER_BACKEND
 }

--- a/crates/guest-agent/tests/codex_app_server_backend.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend.rs
@@ -1,4 +1,4 @@
-//! Integration coverage for the disabled Codex app-server backend.
+//! Integration coverage for the experimental Codex app-server backend.
 //!
 //! This test lives in its own binary because `guest_agent::env` caches values
 //! in process-wide `LazyLock`s.

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input.rs
@@ -1,4 +1,4 @@
-//! Active-input success coverage for the disabled Codex app-server backend.
+//! Active-input success coverage for the experimental Codex app-server backend.
 //!
 //! This test lives in its own binary because `guest_agent::env` caches values
 //! in process-wide `LazyLock`s.
@@ -23,7 +23,7 @@ async fn codex_app_server_backend_steers_active_input_into_active_turn()
             tmp.path(),
             "codex-app-server-backend-active-input-test",
             "drive the app-server backend with active input",
-            "runtime-turn-complete-after-steer",
+            "runtime-turn-started-before-steer",
         )?;
     }
     let _run_files = common::RunFilesGuard::new();

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_after_completion.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_after_completion.rs
@@ -1,4 +1,4 @@
-//! Late active-input coverage for the disabled Codex app-server backend.
+//! Late active-input coverage for the experimental Codex app-server backend.
 //!
 //! This test lives in its own binary because `guest_agent::env` caches values
 //! in process-wide `LazyLock`s.

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_before_buffered_completion.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_before_buffered_completion.rs
@@ -1,4 +1,4 @@
-//! Active-input ordering coverage for the disabled Codex app-server backend.
+//! Active-input ordering coverage for the experimental Codex app-server backend.
 //!
 //! This test lives in its own binary because `guest_agent::env` caches values
 //! in process-wide `LazyLock`s.

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_child_exit.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_child_exit.rs
@@ -1,4 +1,4 @@
-//! Active-input child-exit coverage for the disabled Codex app-server backend.
+//! Active-input child-exit coverage for the experimental Codex app-server backend.
 //!
 //! This test lives in its own binary because `guest_agent::env` caches values
 //! in process-wide `LazyLock`s.

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_no_turn.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_no_turn.rs
@@ -1,4 +1,4 @@
-//! No-active-turn coverage for the disabled Codex app-server backend.
+//! No-active-turn coverage for the experimental Codex app-server backend.
 //!
 //! This test lives in its own binary because `guest_agent::env` caches values
 //! in process-wide `LazyLock`s.

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_queued_terminal.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_queued_terminal.rs
@@ -1,4 +1,4 @@
-//! Queued-terminal active-input coverage for the disabled Codex app-server backend.
+//! Queued-terminal active-input coverage for the experimental Codex app-server backend.
 //!
 //! This test lives in its own binary because `guest_agent::env` caches values
 //! in process-wide `LazyLock`s.

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_stale.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_stale.rs
@@ -1,4 +1,4 @@
-//! Stale-turn active-input coverage for the disabled Codex app-server backend.
+//! Stale-turn active-input coverage for the experimental Codex app-server backend.
 //!
 //! This test lives in its own binary because `guest_agent::env` caches values
 //! in process-wide `LazyLock`s.

--- a/crates/guest-agent/tests/codex_app_server_backend_error_masking.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_error_masking.rs
@@ -1,4 +1,4 @@
-//! Error masking coverage for the disabled Codex app-server backend.
+//! Error masking coverage for the experimental Codex app-server backend.
 //!
 //! This test lives in its own binary because `guest_agent::env` caches values
 //! in process-wide `LazyLock`s.

--- a/crates/guest-agent/tests/codex_app_server_backend_failure.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_failure.rs
@@ -1,4 +1,4 @@
-//! Failure-path integration coverage for the disabled Codex app-server backend.
+//! Failure-path integration coverage for the experimental Codex app-server backend.
 //!
 //! This test lives in its own binary because `guest_agent::env` caches values
 //! in process-wide `LazyLock`s.

--- a/crates/guest-agent/tests/codex_app_server_backend_heartbeat.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_heartbeat.rs
@@ -1,4 +1,4 @@
-//! Heartbeat race coverage for the disabled Codex app-server backend.
+//! Heartbeat race coverage for the experimental Codex app-server backend.
 //!
 //! This test lives in its own binary because `guest_agent::env` caches values
 //! in process-wide `LazyLock`s.

--- a/crates/guest-agent/tests/codex_app_server_backend_invalid_resume_id.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_invalid_resume_id.rs
@@ -1,4 +1,4 @@
-//! Resume id validation for the disabled Codex app-server backend.
+//! Resume id validation for the experimental Codex app-server backend.
 //!
 //! This test lives in its own binary because `guest_agent::env` caches values
 //! in process-wide `LazyLock`s.

--- a/crates/guest-agent/tests/codex_app_server_backend_invalid_thread_id.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_invalid_thread_id.rs
@@ -1,4 +1,4 @@
-//! Thread identity validation for the disabled Codex app-server backend.
+//! Thread identity validation for the experimental Codex app-server backend.
 //!
 //! This test lives in its own binary because `guest_agent::env` caches values
 //! in process-wide `LazyLock`s.

--- a/crates/guest-agent/tests/codex_app_server_backend_resume.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_resume.rs
@@ -1,4 +1,4 @@
-//! Resume-path integration coverage for the disabled Codex app-server backend.
+//! Resume-path integration coverage for the experimental Codex app-server backend.
 //!
 //! This is separate from `codex_app_server_backend.rs` because `guest_agent::env`
 //! caches `VM0_RESUME_SESSION_ID` in a process-wide `LazyLock`.

--- a/crates/guest-agent/tests/codex_app_server_backend_resume_mismatch.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_resume_mismatch.rs
@@ -1,4 +1,4 @@
-//! Resume response validation for the disabled Codex app-server backend.
+//! Resume response validation for the experimental Codex app-server backend.
 //!
 //! This test lives in its own binary because `guest_agent::env` caches values
 //! in process-wide `LazyLock`s.

--- a/crates/guest-agent/tests/codex_app_server_backend_scope.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_scope.rs
@@ -1,4 +1,4 @@
-//! Scope validation coverage for the disabled Codex app-server backend.
+//! Scope validation coverage for the experimental Codex app-server backend.
 //!
 //! This test lives in its own binary because `guest_agent::env` caches values
 //! in process-wide `LazyLock`s.

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -437,7 +437,7 @@ fn build_and_locate_mock_package(package: &str, binary: &str) -> Result<PathBuf,
     Ok(mock)
 }
 
-/// Configure one test binary for the disabled Codex app-server backend.
+/// Configure one test binary for the experimental Codex app-server backend.
 ///
 /// Must be called before any `guest_agent::env::*` accessor because those
 /// values are cached in process-wide `LazyLock`s.

--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -169,7 +169,7 @@ pub const USE_MOCK_CLAUDE_ENV: &str = "USE_MOCK_CLAUDE";
 /// guest-agent treats `true` or `1` as enabled.
 pub const USE_MOCK_CODEX_ENV: &str = "USE_MOCK_CODEX";
 
-/// Experimental bootstrap switch for the disabled Codex app-server backend.
+/// Experimental bootstrap switch for the Codex app-server backend.
 ///
 /// The runner sets this only for local Codex active-input runs. Product/API
 /// provider paths do not set it; user-provided env cannot override it because

--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -171,9 +171,9 @@ pub const USE_MOCK_CODEX_ENV: &str = "USE_MOCK_CODEX";
 
 /// Experimental bootstrap switch for the disabled Codex app-server backend.
 ///
-/// The runner does not set this key in product paths. Tests and future rollout
-/// PRs may set it explicitly; user-provided env cannot override it because the
-/// `VM0_` namespace is runner-owned.
+/// The runner sets this only for local Codex active-input runs. Product/API
+/// provider paths do not set it; user-provided env cannot override it because
+/// the `VM0_` namespace is runner-owned.
 pub const CODEX_APP_SERVER_BACKEND_ENV: &str = "VM0_CODEX_APP_SERVER_BACKEND";
 
 /// Optional test/debug override for the mock Claude binary path.

--- a/crates/guest-mock-codex/src/app_server.rs
+++ b/crates/guest-mock-codex/src/app_server.rs
@@ -42,6 +42,7 @@ enum Scenario {
     RuntimeTurnComplete,
     RuntimeTurnCompleteAfterSteer,
     RuntimeTurnCompleteBeforeSteerResponse,
+    RuntimeTurnStartedBeforeSteer,
     RuntimeTurnCompleteWithoutThreadStarted,
     ResumeDifferentThreadId,
     ResumeRpcErrorWithThreadId,
@@ -86,6 +87,7 @@ impl Scenario {
                 "runtime-turn-complete-before-steer-response" => {
                     Ok(Self::RuntimeTurnCompleteBeforeSteerResponse)
                 }
+                "runtime-turn-started-before-steer" => Ok(Self::RuntimeTurnStartedBeforeSteer),
                 "runtime-turn-complete-without-thread-started" => {
                     Ok(Self::RuntimeTurnCompleteWithoutThreadStarted)
                 }
@@ -101,6 +103,17 @@ impl Scenario {
             Err(_) => Ok(Self::Success),
         }
     }
+}
+
+fn writes_turn_started_before_steer(scenario: Scenario) -> bool {
+    matches!(
+        scenario,
+        Scenario::ExitOnTurnSteer
+            | Scenario::NoActiveTurn
+            | Scenario::RuntimeTurnCompleteBeforeSteerResponse
+            | Scenario::RuntimeTurnStartedBeforeSteer
+            | Scenario::StaleTurn
+    )
 }
 
 pub fn run_app_server(listen: &str) -> io::Result<()> {
@@ -422,8 +435,10 @@ impl AppServerState {
                 };
 
                 let turn_id = Uuid::now_v7().to_string();
-                if self.scenario != Scenario::NoActiveTurn
-                    && let Some(current_thread) = &mut self.current_thread
+                if !matches!(
+                    self.scenario,
+                    Scenario::NoActiveTurn | Scenario::RuntimeTurnStartedBeforeSteer
+                ) && let Some(current_thread) = &mut self.current_thread
                 {
                     current_thread.active_turn_id = Some(turn_id.clone());
                 }
@@ -444,6 +459,14 @@ impl AppServerState {
                         &turn_completed_notification("unexpected-thread-id", &turn_id),
                     )?;
                     return Ok(ServerAction::Stop);
+                }
+                if writes_turn_started_before_steer(self.scenario) {
+                    if let Some(current_thread) = &mut self.current_thread
+                        && self.scenario == Scenario::RuntimeTurnStartedBeforeSteer
+                    {
+                        current_thread.active_turn_id = Some(turn_id.clone());
+                    }
+                    write_json_line(output, &turn_started_notification(&thread_id, &turn_id))?;
                 }
                 if matches!(
                     self.scenario,
@@ -517,11 +540,14 @@ impl AppServerState {
                     params,
                 )?;
                 if self.scenario == Scenario::RuntimeTurnCompleteBeforeSteerResponse {
-                    write_turn_notifications(output, &thread_id, &active_turn_id)?;
+                    write_turn_completion_notifications(output, &thread_id, &active_turn_id)?;
                 }
                 write_success(output, id, json!({ "turnId": active_turn_id }))?;
                 if self.scenario == Scenario::RuntimeTurnCompleteAfterSteer {
                     write_turn_notifications(output, &thread_id, &active_turn_id)?;
+                }
+                if self.scenario == Scenario::RuntimeTurnStartedBeforeSteer {
+                    write_turn_completion_notifications(output, &thread_id, &active_turn_id)?;
                 }
                 Ok(ServerAction::Continue)
             }
@@ -792,6 +818,14 @@ fn write_turn_notifications<W: Write>(
     turn_id: &str,
 ) -> io::Result<()> {
     write_json_line(output, &turn_started_notification(thread_id, turn_id))?;
+    write_turn_completion_notifications(output, thread_id, turn_id)
+}
+
+fn write_turn_completion_notifications<W: Write>(
+    output: &mut W,
+    thread_id: &str,
+    turn_id: &str,
+) -> io::Result<()> {
     write_json_line(
         output,
         &assistant_item_completed_notification(thread_id, turn_id),

--- a/crates/guest-mock-codex/tests/integration.rs
+++ b/crates/guest-mock-codex/tests/integration.rs
@@ -479,6 +479,62 @@ fn app_server_turn_steer_can_complete_runtime_turn_after_success() -> std::io::R
 }
 
 #[test]
+fn app_server_can_start_runtime_turn_before_steer_completion() -> std::io::Result<()> {
+    let dir = TempDir::new().unwrap();
+    let mut server = spawn_app_server(
+        dir.path(),
+        &["app-server", "--listen", "stdio://"],
+        Some("runtime-turn-started-before-steer"),
+    )?;
+
+    server.request(1, "initialize", initialize_params())?;
+    let started = server.request(2, "thread/start", json!({ "cwd": "/tmp" }))?;
+    let thread_id = started["result"]["thread"]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let turn_started = server.request(
+        3,
+        "turn/start",
+        json!({
+            "threadId": thread_id,
+            "input": [text_input("initial prompt")]
+        }),
+    )?;
+    let turn_id = turn_started["result"]["turn"]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let turn_started_notification = server.read_required()?;
+    assert_eq!(turn_started_notification["method"], "turn/started");
+    assert_eq!(
+        turn_started_notification["params"]["turn"]["id"]
+            .as_str()
+            .unwrap(),
+        turn_id
+    );
+
+    let steered = server.request(
+        4,
+        "turn/steer",
+        json!({
+            "threadId": thread_id,
+            "expectedTurnId": turn_id,
+            "clientUserMessageId": "active-msg-1",
+            "input": [text_input("follow-up prompt")]
+        }),
+    )?;
+    assert_eq!(steered["result"]["turnId"], turn_id);
+
+    let item_completed_notification = server.read_required()?;
+    let turn_completed_notification = server.read_required()?;
+    assert_eq!(item_completed_notification["method"], "item/completed");
+    assert_eq!(turn_completed_notification["method"], "turn/completed");
+    assert_eq!(server.close_and_wait()?, 0);
+    Ok(())
+}
+
+#[test]
 fn app_server_exit_on_turn_steer_closes_without_response() -> std::io::Result<()> {
     let dir = TempDir::new().unwrap();
     let mut server = spawn_app_server(
@@ -505,6 +561,8 @@ fn app_server_exit_on_turn_steer_closes_without_response() -> std::io::Result<()
         .as_str()
         .unwrap()
         .to_string();
+    let turn_started_notification = server.read_required()?;
+    assert_eq!(turn_started_notification["method"], "turn/started");
 
     let error = server
         .request(
@@ -1172,6 +1230,8 @@ fn app_server_stale_turn_scenario_returns_protocol_error() -> std::io::Result<()
         .as_str()
         .unwrap()
         .to_string();
+    let turn_started_notification = server.read_required()?;
+    assert_eq!(turn_started_notification["method"], "turn/started");
 
     let error = server.request(
         4,
@@ -1222,6 +1282,8 @@ fn app_server_no_active_turn_scenario_returns_protocol_error() -> std::io::Resul
         .as_str()
         .unwrap()
         .to_string();
+    let turn_started_notification = server.read_required()?;
+    assert_eq!(turn_started_notification["method"], "turn/started");
 
     let error = server.request(
         4,

--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -1414,13 +1414,13 @@ mod tests {
                 DelayedActiveInput {
                     sequence: 1,
                     message_id: "msg-1".to_string(),
-                    after: Duration::from_millis(1),
+                    after: Duration::ZERO,
                     text: "first".to_string(),
                 },
                 DelayedActiveInput {
                     sequence: 2,
                     message_id: "msg-2".to_string(),
-                    after: Duration::from_millis(1),
+                    after: Duration::ZERO,
                     text: "second".to_string(),
                 },
             ],

--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -374,7 +374,6 @@ impl SubmitPlan {
         let secret_environment = Self::parse_env_entries("--secret-env", &secret_env, false)?;
         Self::validate_disjoint_env_keys(&environment, &secret_environment)?;
         let timeout = Self::validate_timeout(timeout)?;
-        Self::validate_active_input_agent(&cli_agent_type, &active_inputs)?;
         let group_dir = home.groups_dir().join(&group);
         local_queue::ensure_profile_jobs_dir(&group_dir, &profile).map_err(|e| {
             RunnerError::Config(format!("create job dir for profile {profile}: {e}"))
@@ -515,21 +514,6 @@ impl SubmitPlan {
         } else {
             Duration::from_secs(amount)
         })
-    }
-
-    fn validate_active_input_agent(
-        cli_agent_type: &str,
-        active_inputs: &[String],
-    ) -> RunnerResult<()> {
-        // Guest-agent treats unknown CLI_AGENT_TYPE values as Claude Code.
-        // Keep local submit validation aligned and only reject the known
-        // non-Claude framework.
-        if active_inputs.is_empty() || cli_agent_type != "codex" {
-            return Ok(());
-        }
-        Err(RunnerError::Config(format!(
-            "invalid --active-input: active input is not supported with {cli_agent_type}"
-        )))
     }
 
     fn validate_timeout(timeout: u64) -> RunnerResult<Duration> {
@@ -1331,19 +1315,18 @@ mod tests {
     }
 
     #[test]
-    fn rejects_active_input_for_non_claude_agent() {
+    fn accepts_active_input_for_codex_agent() {
         let dir = tempfile::tempdir().unwrap();
         let home = HomePaths::with_root(dir.path().to_path_buf());
         let mut args = submit_args_for_test();
         args.cli_agent_type = "codex".to_string();
         args.active_inputs = vec!["after=1ms,text=hello".to_string()];
 
-        let err = match SubmitPlan::from_args(args, home) {
-            Ok(_) => panic!("codex active input should be rejected"),
-            Err(error) => error,
-        };
-
-        assert!(err.to_string().contains("not supported with codex"));
+        let plan = SubmitPlan::from_args(args, home).unwrap();
+        let request: JobRequest = serde_json::from_slice(&plan.request_json).unwrap();
+        assert_eq!(request.cli_agent_type, "codex");
+        assert_eq!(request.active_input, Some(true));
+        assert_eq!(plan.active_inputs.len(), 1);
     }
 
     #[test]

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -29,7 +29,7 @@ use super::diagnostics::{
     should_collect_agent_abnormal_exit_diagnostics,
     should_log_agent_bootstrap_abnormal_exit_diagnostics,
 };
-use super::env::{build_env_json, build_user_env_json, write_user_env_file};
+use super::env::{build_env_json_for_run, build_user_env_json, write_user_env_file};
 use super::guest_state::{restore_guest_state, sync_guest_timezone};
 use super::session_history_download::{SessionHistoryMaterialization, SessionHistoryMaterializer};
 use super::session_restore::{MaterializedResumeSession, restore_session};
@@ -665,6 +665,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         spawn_timing,
         session_history_restore_plan,
     } = controls;
+    let has_active_input_source = active_input_source.is_some();
 
     // 1. Fix guest clock and reseed entropy (must happen before HTTPS calls).
     //    Needed after snapshot restore (frozen clock) and after idle reuse (drifted clock).
@@ -879,19 +880,24 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         }
     };
     let env_build_started = Instant::now();
-    let mut env_map =
-        match build_env_json(context, &config.api_url, sandbox.id(), start.reuse_result) {
-            Ok(env_map) => env_map,
-            Err(error) => {
-                telemetry.record(
-                    "runner_agent_env_build",
-                    env_build_started.elapsed(),
-                    false,
-                    None,
-                );
-                return Err(error);
-            }
-        };
+    let mut env_map = match build_env_json_for_run(
+        context,
+        &config.api_url,
+        sandbox.id(),
+        start.reuse_result,
+        has_active_input_source,
+    ) {
+        Ok(env_map) => env_map,
+        Err(error) => {
+            telemetry.record(
+                "runner_agent_env_build",
+                env_build_started.elapsed(),
+                false,
+                None,
+            );
+            return Err(error);
+        }
+    };
     if let Some(path) = user_env_file {
         env_map.insert(USER_ENV_FILE_ENV_KEY.into(), path);
     }

--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -261,25 +261,51 @@ pub(super) async fn write_user_env_file(
     Ok(Some(file_path))
 }
 
-/// Build the guest-agent bootstrap environment.
-///
-/// This intentionally excludes `context.environment`. User/model/connector
-/// environment is transferred separately and injected only into the CLI child.
-pub(super) fn build_env_json(
-    context: &ExecutionContext,
-    api_url: &str,
-    sandbox_id: &str,
-    reuse_result: SandboxReuseResult,
-) -> RunnerResult<HashMap<String, String>> {
-    let host_env = HostEnv::from_process();
-    build_env_json_with_host_env(context, api_url, sandbox_id, reuse_result, &host_env)
-}
-
 pub(super) fn build_env_json_with_host_env(
     context: &ExecutionContext,
     api_url: &str,
     sandbox_id: &str,
     reuse_result: SandboxReuseResult,
+    host_env: &HostEnv,
+) -> RunnerResult<HashMap<String, String>> {
+    build_env_json_with_host_env_for_run(
+        context,
+        api_url,
+        sandbox_id,
+        reuse_result,
+        false,
+        host_env,
+    )
+}
+
+/// Build the guest-agent bootstrap environment.
+///
+/// This intentionally excludes `context.environment`. User/model/connector
+/// environment is transferred separately and injected only into the CLI child.
+pub(super) fn build_env_json_for_run(
+    context: &ExecutionContext,
+    api_url: &str,
+    sandbox_id: &str,
+    reuse_result: SandboxReuseResult,
+    has_active_input_source: bool,
+) -> RunnerResult<HashMap<String, String>> {
+    let host_env = HostEnv::from_process();
+    build_env_json_with_host_env_for_run(
+        context,
+        api_url,
+        sandbox_id,
+        reuse_result,
+        has_active_input_source,
+        &host_env,
+    )
+}
+
+pub(super) fn build_env_json_with_host_env_for_run(
+    context: &ExecutionContext,
+    api_url: &str,
+    sandbox_id: &str,
+    reuse_result: SandboxReuseResult,
+    has_active_input_source: bool,
     host_env: &HostEnv,
 ) -> RunnerResult<HashMap<String, String>> {
     let mut env = HashMap::new();
@@ -421,7 +447,9 @@ pub(super) fn build_env_json_with_host_env(
 
     match effective_cli_framework(&context.cli_agent_type) {
         EffectiveCliFramework::ClaudeCode => insert_claude_code_env(&mut env, context, host_env)?,
-        EffectiveCliFramework::Codex => insert_codex_env(&mut env, context, host_env),
+        EffectiveCliFramework::Codex => {
+            insert_codex_env(&mut env, context, host_env, has_active_input_source);
+        }
     }
 
     // Feature flags (JSON-encoded map of flag name → enabled)
@@ -560,7 +588,15 @@ pub(super) fn insert_codex_env(
     env: &mut HashMap<String, String>,
     context: &ExecutionContext,
     host_env: &HostEnv,
+    has_active_input_source: bool,
 ) {
+    if has_active_input_source {
+        env.insert(
+            guest_contracts::env::CODEX_APP_SERVER_BACKEND_ENV.into(),
+            "1".into(),
+        );
+    }
+
     // Pass USE_MOCK_CODEX from host environment for testing
     // (skip if debugNoMockCodex is set in execution context).
     if let Some(val) = &host_env.use_mock_codex

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -1606,6 +1606,50 @@ async fn run_in_sandbox_forwards_local_active_inputs_in_order_and_dedupes() {
 }
 
 #[tokio::test]
+async fn run_in_sandbox_sets_codex_app_server_backend_for_active_input_source() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+    let mut ctx = minimal_context();
+    ctx.cli_agent_type = "codex".into();
+    let group_dir = dir.path().join("active-inputs");
+    let source = ActiveInputSource::local_queue(group_dir, ctx.run_id);
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let result = run_in_sandbox(
+        &*sandbox,
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::PoolMiss,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        RunControls::new(cancel, Some(source)),
+    )
+    .await
+    .unwrap();
+
+    assert!(result.failure.is_none());
+    let start_calls = overrides.start_process_calls();
+    assert_eq!(start_calls.len(), 1);
+    let env = start_calls[0]
+        .env
+        .iter()
+        .cloned()
+        .collect::<std::collections::HashMap<_, _>>();
+    assert_eq!(env.get("CLI_AGENT_TYPE").unwrap(), "codex");
+    assert_eq!(
+        env.get(guest_contracts::env::CODEX_APP_SERVER_BACKEND_ENV)
+            .unwrap(),
+        "1"
+    );
+}
+
+#[tokio::test]
 async fn run_in_sandbox_retries_active_input_after_control_error() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -18,7 +18,8 @@ use super::super::env::{
 use super::super::{USER_ENV_FILE_ENV_KEY, guest_runtime_dir};
 use super::support::{
     api_artifact, api_storage, build_env_for_test, build_env_for_test_result,
-    build_env_for_test_with_host_env, context_with_env, minimal_context, sandbox_write_file_error,
+    build_env_for_test_with_active_input, build_env_for_test_with_host_env, context_with_env,
+    minimal_context, sandbox_write_file_error,
 };
 use crate::error::{RunnerError, RunnerResult};
 use crate::host_env::{
@@ -434,10 +435,47 @@ fn build_env_json_codex_gets_only_codex_framework_env() {
 
     assert_eq!(env.get("CLI_AGENT_TYPE").unwrap(), "codex");
     assert_eq!(env.get("USE_MOCK_CODEX").unwrap(), "1");
+    assert!(!env.contains_key(guest_contracts::env::CODEX_APP_SERVER_BACKEND_ENV));
     assert!(!env.contains_key("USE_MOCK_CLAUDE"));
     assert!(!env.contains_key("VM0_DISALLOWED_TOOLS"));
     assert!(!env.contains_key("VM0_TOOLS"));
     assert!(!env.contains_key("VM0_SETTINGS"));
+}
+
+#[test]
+fn build_env_json_codex_without_active_input_does_not_enable_app_server_backend() {
+    let mut ctx = minimal_context();
+    ctx.cli_agent_type = "codex".into();
+
+    let env = build_env_for_test(&ctx, "http://localhost");
+
+    assert_eq!(env.get("CLI_AGENT_TYPE").unwrap(), "codex");
+    assert!(!env.contains_key(guest_contracts::env::CODEX_APP_SERVER_BACKEND_ENV));
+}
+
+#[test]
+fn build_env_json_codex_with_active_input_enables_app_server_backend() {
+    let mut ctx = minimal_context();
+    ctx.cli_agent_type = "codex".into();
+
+    let env = build_env_for_test_with_active_input(&ctx, "http://localhost");
+
+    assert_eq!(env.get("CLI_AGENT_TYPE").unwrap(), "codex");
+    assert_eq!(
+        env.get(guest_contracts::env::CODEX_APP_SERVER_BACKEND_ENV)
+            .unwrap(),
+        "1"
+    );
+}
+
+#[test]
+fn build_env_json_claude_with_active_input_does_not_enable_codex_app_server_backend() {
+    let ctx = minimal_context();
+
+    let env = build_env_for_test_with_active_input(&ctx, "http://localhost");
+
+    assert_eq!(env.get("CLI_AGENT_TYPE").unwrap(), "claude-code");
+    assert!(!env.contains_key(guest_contracts::env::CODEX_APP_SERVER_BACKEND_ENV));
 }
 
 #[test]
@@ -488,6 +526,10 @@ fn build_env_json_scrubs_user_provided_runner_owned_env() {
         (
             guest_contracts::env::FEATURE_FLAGS_ENV.into(),
             r#"{"bad":true}"#.into(),
+        ),
+        (
+            guest_contracts::env::CODEX_APP_SERVER_BACKEND_ENV.into(),
+            "1".into(),
         ),
         ("VM0_FUTURE_RUNNER_KEY".into(), "future".into()),
         (RUNNER_CONCURRENCY_FACTOR_ENV.into(), "99".into()),
@@ -548,6 +590,7 @@ fn build_env_json_scrubs_user_provided_runner_owned_env() {
         guest_contracts::env::WORKING_DIR_ENV,
         guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
         guest_contracts::env::FEATURE_FLAGS_ENV,
+        guest_contracts::env::CODEX_APP_SERVER_BACKEND_ENV,
         "VM0_FUTURE_RUNNER_KEY",
         RUNNER_CONCURRENCY_FACTOR_ENV,
         RUNNER_DISK_BANDWIDTH_MIB_PER_SEC_ENV,

--- a/crates/runner/src/executor/tests/support/env.rs
+++ b/crates/runner/src/executor/tests/support/env.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use sandbox::SandboxId;
 
-use super::super::super::env::{HostEnv, build_env_json_with_host_env};
+use super::super::super::env::{HostEnv, build_env_json_with_host_env_for_run};
 use crate::error::RunnerResult;
 use crate::types::{ExecutionContext, SandboxReuseResult};
 
@@ -28,11 +28,35 @@ pub(in crate::executor::tests) fn build_env_for_test_with_host_env(
     build_env_for_test_with_host_env_result(ctx, api_url, host_env).expect("test env should build")
 }
 
+pub(in crate::executor::tests) fn build_env_for_test_with_active_input(
+    ctx: &ExecutionContext,
+    api_url: &str,
+) -> HashMap<String, String> {
+    build_env_for_test_with_host_env_for_run_result(ctx, api_url, &HostEnv::default(), true)
+        .expect("test env should build")
+}
+
 pub(in crate::executor::tests) fn build_env_for_test_with_host_env_result(
     ctx: &ExecutionContext,
     api_url: &str,
     host_env: &HostEnv,
 ) -> RunnerResult<HashMap<String, String>> {
+    build_env_for_test_with_host_env_for_run_result(ctx, api_url, host_env, false)
+}
+
+pub(in crate::executor::tests) fn build_env_for_test_with_host_env_for_run_result(
+    ctx: &ExecutionContext,
+    api_url: &str,
+    host_env: &HostEnv,
+    has_active_input_source: bool,
+) -> RunnerResult<HashMap<String, String>> {
     let sid = SandboxId::new_v4().to_string();
-    build_env_json_with_host_env(ctx, api_url, &sid, SandboxReuseResult::Reused, host_env)
+    build_env_json_with_host_env_for_run(
+        ctx,
+        api_url,
+        &sid,
+        SandboxReuseResult::Reused,
+        has_active_input_source,
+        host_env,
+    )
 }

--- a/crates/runner/src/executor/tests/support/mod.rs
+++ b/crates/runner/src/executor/tests/support/mod.rs
@@ -13,7 +13,8 @@ pub(super) use self::config::{
 };
 pub(super) use self::context::{context_with_env, minimal_context};
 pub(super) use self::env::{
-    build_env_for_test, build_env_for_test_result, build_env_for_test_with_host_env,
+    build_env_for_test, build_env_for_test_result, build_env_for_test_with_active_input,
+    build_env_for_test_with_host_env,
 };
 pub(super) use self::execution::{
     RUN_IN_SANDBOX_TEST_TIMEOUT, run_new_sandbox_outcome, run_new_sandbox_status,


### PR DESCRIPTION
## Summary
- allow `runner local submit --active-input --cli-agent-type codex`
- set `VM0_CODEX_APP_SERVER_BACKEND=1` only for Codex runs that actually have an active-input source
- keep user-provided runner-owned env scrubbed, including `VM0_CODEX_APP_SERVER_BACKEND`
- add a real Codex local active-input smoke job to crates CI gate

## Tests
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --quiet --manifest-path crates/Cargo.toml -p runner cmd::local::submit`
- `cargo test --quiet --manifest-path crates/Cargo.toml -p runner executor::tests::env_tests`
- `cargo test --quiet --manifest-path crates/Cargo.toml -p runner executor::tests::agent_run_tests::run_in_sandbox_sets_codex_app_server_backend_for_active_input_source`
- `cargo test --quiet --manifest-path crates/Cargo.toml -p runner`
- parsed `.github/workflows/crates.yml` with PyYAML
- `git diff --check`
- pre-commit hook: cargo fmt, cargo doc, cargo clippy

Closes #18374