### PR TITLE
chore: replace bloom runbook archive

### DIFF
--- a/turbo/apps/api/src/signals/routes/registry-resources-download.ts
+++ b/turbo/apps/api/src/signals/routes/registry-resources-download.ts
@@ -181,7 +181,7 @@ const PRIVATE_REGISTRY_RESOURCE_ARCHIVE_VERSION_IDS = {
   "template:html-ppt-playful-launch-runbook":
     "f6f83c0a080db0a5b9f568c7b2640c1d179b06e1946cc5c339560bc76ee5e966",
   "template:html-ppt-bloom-pitch-runbook":
-    "525f84ccfd25448284b1e668e2a036078a6aa6ad9da9d95497a2157b0f251b42",
+    "9fb64d950df17d8c9e65cdc5a717cae189154c8ae4dc97fe825452b319cd1ac2",
   "template:html-ppt-blueprint-academy-runbook":
     "444945a0bcb95e3267ec65539275bd0c366b658af0d345481b9f59a70854661a",
   "template:html-ppt-botane-organic-runbook":

--- a/turbo/packages/core/src/resource-registry.ts
+++ b/turbo/packages/core/src/resource-registry.ts
@@ -4369,7 +4369,7 @@ export interface PresentationRunbookPackage {
 const PRESENTATION_RUNBOOK_ARCHIVE_SHA256: Record<string, string> = {
   "playful-launch":
     "d39a2c6c42365613f5c3aedff56333e6bb0af7ce2df30da26f3c4f20f128e69e",
-  bloom: "1c815ce0dc091d965b2332ba672640b8d2c27fbdbdd89d43c14ed9702c2d42c2",
+  bloom: "ad8764eb812697b5079ad4f34f42b2014b10a3a86f0ee080242ca24e062568cc",
   "blueprint-academy":
     "abe24c3cbf0c2f4517657a7a08f185d3dd688f7e8a4e0dc0656960f84c085ed0",
   "botane-organic":


### PR DESCRIPTION
## Summary
- upload the replacement Bloom presentation runbook package from Drive to R2-backed storage
- point the Bloom runbook registry entry at the new storage version id
- update the Bloom runbook archive SHA-256 used by the presentationTemplateRunbook flow

## Uploaded archive
- storage name: `registry-resource@template:html-ppt-bloom-pitch-runbook`
- version id: `9fb64d950df17d8c9e65cdc5a717cae189154c8ae4dc97fe825452b319cd1ac2`
- archive sha256: `ad8764eb812697b5079ad4f34f42b2014b10a3a86f0ee080242ca24e062568cc`
- file count: 35

## Verification
- downloaded the uploaded archive back from the storage download API and verified the SHA-256 matches `ad8764eb812697b5079ad4f34f42b2014b10a3a86f0ee080242ca24e062568cc`
- extracted the archive and verified it contains `bloom/AGENT_RUNBOOK.md` and `bloom/template/build.mjs`
- ran `node --check` on the changed template/runtime files
- ran `git diff --check`

Note: local `turbo/node_modules` is not installed in this runtime, so package tests were not run locally.