### PR TITLE
docs: document runner snapshot publish contract

### DIFF
--- a/crates/runner/src/cmd/build/snapshot.rs
+++ b/crates/runner/src/cmd/build/snapshot.rs
@@ -76,10 +76,11 @@ async fn shielded_snapshot_publish(
     // Once the provider returns an uncommitted snapshot, publish must reach
     // either commit or discard even if the caller waiting on this result is
     // cancelled. Move the snapshot lock into the detached task so other
-    // builders and GC cannot observe this output directory until commit
-    // succeeds or discard finishes. This shields waiter cancellation only; it
-    // is not a process-exit or runtime-shutdown guarantee. The cancellation
-    // tests below cover the lock lifetime through both commit and discard.
+    // builders and GC cannot acquire the lock and act on this output directory
+    // until commit succeeds or discard finishes. This shields waiter
+    // cancellation only; it is not a process-exit or runtime-shutdown
+    // guarantee. The cancellation tests below cover the lock lifetime through
+    // both commit and discard.
     tokio::spawn(async move {
         let result =
             commit_or_discard_pending_snapshot(pending, &snapshot_hash, &snapshot_dir).await;

--- a/crates/runner/src/cmd/build/snapshot.rs
+++ b/crates/runner/src/cmd/build/snapshot.rs
@@ -73,6 +73,13 @@ async fn shielded_snapshot_publish(
     let (result_tx, result_rx) =
         tokio::sync::oneshot::channel::<Result<sandbox::SnapshotOutput, sandbox::SnapshotError>>();
 
+    // Once the provider returns an uncommitted snapshot, publish must reach
+    // either commit or discard even if the caller waiting on this result is
+    // cancelled. Move the snapshot lock into the detached task so other
+    // builders and GC cannot observe this output directory until commit
+    // succeeds or discard finishes. This shields waiter cancellation only; it
+    // is not a process-exit or runtime-shutdown guarantee. The cancellation
+    // tests below cover the lock lifetime through both commit and discard.
     tokio::spawn(async move {
         let result =
             commit_or_discard_pending_snapshot(pending, &snapshot_hash, &snapshot_dir).await;
@@ -116,6 +123,9 @@ async fn commit_or_discard_pending_snapshot(
     match pending.commit().await {
         Ok(output) => Ok(output),
         Err(err) => {
+            // Discard is best-effort cleanup after a failed publish. Preserve
+            // the original commit error so callers see the failure that made
+            // the snapshot unusable.
             if let Err(discard_err) = pending.discard().await {
                 tracing::warn!(
                     error = %discard_err,


### PR DESCRIPTION
## Summary

- Document the runner-side snapshot publish cancellation shield.
- Explain why the snapshot flock is moved into the detached publish task.
- Document best-effort discard while preserving the original commit error.

Closes #19470

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p runner snapshot`
- `git diff --check`
- pre-commit: `cargo-fmt`, `cargo-doc`, `cargo-clippy`

Note: `cargo test --manifest-path crates/Cargo.toml -p runner cmd::build::snapshot --lib` is not applicable because `runner` has no library target; the package-level `snapshot` filter ran the relevant tests.
