### PR TITLE
refactor: share mock claude process-group lifecycle

### DIFF
--- a/crates/guest-mock-claude/src/lib.rs
+++ b/crates/guest-mock-claude/src/lib.rs
@@ -1,2 +1,6 @@
 // This file exists so that guest-mock-claude can be used as a dev-dependency
 // by other crates in the workspace for release-please version tracking.
+
+// Workspace-internal support for the mock binary and its integration tests.
+// This is not a stable external API.
+pub mod process_group_child;

--- a/crates/guest-mock-claude/src/lib.rs
+++ b/crates/guest-mock-claude/src/lib.rs
@@ -3,4 +3,5 @@
 
 // Workspace-internal support for the mock binary and its integration tests.
 // This is not a stable external API.
+#[doc(hidden)]
 pub mod process_group_child;

--- a/crates/guest-mock-claude/src/process.rs
+++ b/crates/guest-mock-claude/src/process.rs
@@ -5,6 +5,7 @@ use crate::transcript::{
     is_valid_session_history_id, replayed_user_event, result_event, tool_result_event,
     tool_use_event,
 };
+use guest_mock_claude::process_group_child::ProcessGroupChild;
 use serde_json::Value;
 use serde_json::json;
 use std::collections::BTreeMap;
@@ -12,7 +13,7 @@ use std::io::{BufRead, BufReader, ErrorKind, Read, Write};
 #[cfg(unix)]
 use std::os::fd::AsRawFd;
 use std::path::Path;
-use std::process::{Child, Command, ExitCode, ExitStatus, Stdio};
+use std::process::{Command, ExitCode, Stdio};
 #[cfg(unix)]
 use std::sync::{
     Arc,
@@ -20,9 +21,6 @@ use std::sync::{
 };
 use std::thread;
 use std::time::Duration;
-
-#[cfg(unix)]
-use std::os::unix::process::CommandExt;
 
 const REAPABLE_HANG_DURATION: Duration = Duration::from_secs(3600);
 const ACTIVE_INPUT_READY_RESULT: &str = "READY_FOR_ACTIVE_INPUT";
@@ -652,102 +650,14 @@ fn join_captured_shell_stream(
     }
 }
 
-fn spawn_captured_shell(prompt: &str) -> std::io::Result<Child> {
+fn spawn_captured_shell(prompt: &str) -> std::io::Result<ProcessGroupChild> {
     let mut command = Command::new("bash");
     command
         .args(["-c", prompt])
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
-    spawn_shell_process(&mut command)
-}
-
-#[cfg(unix)]
-fn spawn_shell_process(command: &mut Command) -> std::io::Result<Child> {
-    command.process_group(0).spawn()
-}
-
-#[cfg(not(unix))]
-fn spawn_shell_process(command: &mut Command) -> std::io::Result<Child> {
-    command.spawn()
-}
-
-fn terminate_shell_child(mut child: Child) {
-    terminate_shell_process_group(child.id());
-    let _ = child.kill();
-    let _ = child.wait();
-}
-
-#[cfg(unix)]
-fn wait_shell_child_and_cleanup_group(mut child: Child) -> std::io::Result<ExitStatus> {
-    let pid = child.id();
-    if let Err(error) = observe_shell_child_exit_without_reaping(pid) {
-        terminate_shell_process_group(pid);
-        let _ = child.kill();
-        let _ = child.wait();
-        return Err(error);
-    }
-
-    terminate_shell_process_group(pid);
-    child.wait()
-}
-
-#[cfg(not(unix))]
-fn wait_shell_child_and_cleanup_group(mut child: Child) -> std::io::Result<ExitStatus> {
-    child.wait()
-}
-
-#[cfg(unix)]
-fn observe_shell_child_exit_without_reaping(pid: u32) -> std::io::Result<()> {
-    let pid = i32::try_from(pid).map_err(|_| {
-        std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "shell child PID does not fit in i32",
-        )
-    })?;
-
-    loop {
-        let mut info = std::mem::MaybeUninit::<libc::siginfo_t>::uninit();
-        let result = unsafe {
-            libc::waitid(
-                libc::P_PID,
-                pid as libc::id_t,
-                info.as_mut_ptr(),
-                libc::WEXITED | libc::WNOWAIT,
-            )
-        };
-        if result == 0 {
-            return Ok(());
-        }
-
-        let error = std::io::Error::last_os_error();
-        if error.kind() != ErrorKind::Interrupted {
-            return Err(error);
-        }
-    }
-}
-
-#[cfg(unix)]
-fn terminate_shell_process_group(child_pid: u32) {
-    if let Some(pgid) = signalable_shell_process_group(child_pid) {
-        unsafe {
-            libc::kill(-pgid, libc::SIGKILL);
-        }
-    }
-}
-
-#[cfg(not(unix))]
-fn terminate_shell_process_group(_child_pid: u32) {}
-
-#[cfg(unix)]
-fn signalable_shell_process_group(child_pid: u32) -> Option<libc::pid_t> {
-    let pgid = i32::try_from(child_pid).ok()?;
-    (pgid > 1 && pgid != current_process_group()).then_some(pgid as libc::pid_t)
-}
-
-#[cfg(unix)]
-fn current_process_group() -> i32 {
-    unsafe { libc::getpgrp() }
+    ProcessGroupChild::spawn(&mut command)
 }
 
 fn capture_shell_output(prompt: &str) -> CapturedShellOutput {
@@ -756,12 +666,12 @@ fn capture_shell_output(prompt: &str) -> CapturedShellOutput {
         Err(_) => return CapturedShellOutput::failed(),
     };
 
-    let Some(stdout) = child.stdout.take() else {
-        terminate_shell_child(child);
+    let Some(stdout) = child.child_mut().stdout.take() else {
+        child.terminate();
         return CapturedShellOutput::failed();
     };
-    let Some(stderr) = child.stderr.take() else {
-        terminate_shell_child(child);
+    let Some(stderr) = child.child_mut().stderr.take() else {
+        child.terminate();
         return CapturedShellOutput::failed();
     };
     #[cfg(unix)]
@@ -783,8 +693,9 @@ fn capture_shell_output(prompt: &str) -> CapturedShellOutput {
     #[cfg(not(unix))]
     let stderr_thread = thread::spawn(move || capture_shell_stream(stderr));
 
-    let exit_code =
-        wait_shell_child_and_cleanup_group(child).map_or(1, |status| status.code().unwrap_or(1));
+    let exit_code = child
+        .wait_with_group_cleanup()
+        .map_or(1, |status| status.code().unwrap_or(1));
     #[cfg(unix)]
     cancel_streams.store(true, Ordering::Release);
 
@@ -868,19 +779,4 @@ fn run_stream_json_mode(prompt: &str, session_id: &str) -> ExitCode {
     }
 
     ExitCode::from(exit_code as u8)
-}
-
-#[cfg(all(test, unix))]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn signalable_shell_process_group_rejects_dangerous_values() {
-        assert_eq!(signalable_shell_process_group(0), None);
-        assert_eq!(signalable_shell_process_group(1), None);
-        assert_eq!(signalable_shell_process_group((i32::MAX as u32) + 1), None);
-        if let Ok(current_pgid) = u32::try_from(current_process_group()) {
-            assert_eq!(signalable_shell_process_group(current_pgid), None);
-        }
-    }
 }

--- a/crates/guest-mock-claude/src/process.rs
+++ b/crates/guest-mock-claude/src/process.rs
@@ -666,11 +666,11 @@ fn capture_shell_output(prompt: &str) -> CapturedShellOutput {
         Err(_) => return CapturedShellOutput::failed(),
     };
 
-    let Some(stdout) = child.child_mut().stdout.take() else {
+    let Some(stdout) = child.take_stdout() else {
         child.terminate();
         return CapturedShellOutput::failed();
     };
-    let Some(stderr) = child.child_mut().stderr.take() else {
+    let Some(stderr) = child.take_stderr() else {
         child.terminate();
         return CapturedShellOutput::failed();
     };

--- a/crates/guest-mock-claude/src/process_group_child.rs
+++ b/crates/guest-mock-claude/src/process_group_child.rs
@@ -1,0 +1,206 @@
+use std::io;
+#[cfg(unix)]
+use std::io::ErrorKind;
+use std::process::{Child, Command, ExitStatus};
+
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
+
+/// Child process spawned as its own process-group leader.
+pub struct ProcessGroupChild {
+    child: Child,
+    child_pid: u32,
+}
+
+impl ProcessGroupChild {
+    /// Spawn `command`, placing it in a new process group where supported.
+    pub fn spawn(command: &mut Command) -> io::Result<Self> {
+        spawn_in_process_group(command).map(Self::new)
+    }
+
+    fn new(child: Child) -> Self {
+        let child_pid = child.id();
+
+        Self { child, child_pid }
+    }
+
+    /// Return the direct child PID. On Unix this is also the expected PGID.
+    pub fn id(&self) -> u32 {
+        self.child_pid
+    }
+
+    /// Borrow the underlying child so callers can take configured stdio pipes.
+    pub fn child_mut(&mut self) -> &mut Child {
+        &mut self.child
+    }
+
+    /// Wait for the direct child, then clean up the process group.
+    pub fn wait_with_group_cleanup(mut self) -> io::Result<ExitStatus> {
+        wait_child_and_cleanup_group(&mut self.child, self.child_pid)
+    }
+
+    /// Wait for only the direct child.
+    pub fn wait_direct_child(mut self) -> io::Result<ExitStatus> {
+        self.child.wait()
+    }
+
+    /// Best-effort termination for error or drop cleanup.
+    pub fn terminate(mut self) {
+        terminate_process_group(self.child_pid);
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+#[cfg(unix)]
+fn spawn_in_process_group(command: &mut Command) -> io::Result<Child> {
+    command.process_group(0).spawn()
+}
+
+#[cfg(not(unix))]
+fn spawn_in_process_group(command: &mut Command) -> io::Result<Child> {
+    command.spawn()
+}
+
+#[cfg(unix)]
+fn wait_child_and_cleanup_group(child: &mut Child, child_pid: u32) -> io::Result<ExitStatus> {
+    if let Err(error) = observe_child_exit_without_reaping(child_pid) {
+        terminate_process_group(child_pid);
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err(error);
+    }
+
+    terminate_process_group(child_pid);
+    child.wait()
+}
+
+#[cfg(not(unix))]
+fn wait_child_and_cleanup_group(child: &mut Child, _child_pid: u32) -> io::Result<ExitStatus> {
+    child.wait()
+}
+
+/// Best-effort termination by child PID for timeout paths that cannot own `Child`.
+pub fn terminate_child_by_pid(child_pid: u32) {
+    terminate_process_group(child_pid);
+    terminate_direct_child_by_pid(child_pid);
+}
+
+/// Best-effort process-group termination for a group-leader child PID.
+pub fn terminate_process_group(child_pid: u32) {
+    #[cfg(unix)]
+    if let Some(process_group) = ChildProcessGroup::from_group_leader_child_id(child_pid) {
+        process_group.sigkill();
+    }
+
+    #[cfg(not(unix))]
+    let _ = child_pid;
+}
+
+#[cfg(unix)]
+fn terminate_direct_child_by_pid(child_pid: u32) {
+    if let Ok(pid) = libc::pid_t::try_from(child_pid) {
+        unsafe {
+            libc::kill(pid, libc::SIGKILL);
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn terminate_direct_child_by_pid(_child_pid: u32) {}
+
+#[cfg(unix)]
+pub fn observe_child_exit_without_reaping(child_pid: u32) -> io::Result<()> {
+    let pid = libc::pid_t::try_from(child_pid).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "child PID does not fit in pid_t",
+        )
+    })?;
+
+    loop {
+        let mut info = std::mem::MaybeUninit::<libc::siginfo_t>::uninit();
+        let result = unsafe {
+            libc::waitid(
+                libc::P_PID,
+                pid as libc::id_t,
+                info.as_mut_ptr(),
+                libc::WEXITED | libc::WNOWAIT,
+            )
+        };
+        if result == 0 {
+            return Ok(());
+        }
+
+        let error = io::Error::last_os_error();
+        if error.kind() != ErrorKind::Interrupted {
+            return Err(error);
+        }
+    }
+}
+
+#[cfg(unix)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ChildProcessGroup {
+    pgid: libc::pid_t,
+}
+
+#[cfg(unix)]
+impl ChildProcessGroup {
+    fn from_group_leader_child_id(child_pid: u32) -> Option<Self> {
+        libc::pid_t::try_from(child_pid)
+            .ok()
+            .and_then(Self::from_raw_pgid)
+    }
+
+    fn from_raw_pgid(pgid: libc::pid_t) -> Option<Self> {
+        (pgid > 1 && pgid != current_process_group()).then_some(Self { pgid })
+    }
+
+    fn sigkill(self) {
+        unsafe {
+            libc::kill(-self.pgid, libc::SIGKILL);
+        }
+    }
+}
+
+#[cfg(unix)]
+fn current_process_group() -> libc::pid_t {
+    unsafe { libc::getpgrp() }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::ChildProcessGroup;
+
+    #[test]
+    fn child_process_group_rejects_dangerous_values() {
+        assert_eq!(ChildProcessGroup::from_raw_pgid(0), None);
+        assert_eq!(ChildProcessGroup::from_raw_pgid(1), None);
+        assert_eq!(
+            ChildProcessGroup::from_raw_pgid(super::current_process_group()),
+            None
+        );
+    }
+
+    #[test]
+    fn child_process_group_rejects_child_id_overflow() {
+        let overflowing_child_id = (libc::pid_t::MAX as u32).saturating_add(1);
+
+        assert_eq!(
+            ChildProcessGroup::from_group_leader_child_id(overflowing_child_id),
+            None
+        );
+    }
+
+    #[test]
+    fn child_process_group_preserves_signalable_child_id() {
+        let current_pgid = super::current_process_group();
+        let child_id = if current_pgid == 42 { 43 } else { 42 };
+
+        let process_group =
+            ChildProcessGroup::from_raw_pgid(child_id).expect("signalable process group");
+
+        assert_eq!(process_group.pgid, child_id);
+    }
+}

--- a/crates/guest-mock-claude/src/process_group_child.rs
+++ b/crates/guest-mock-claude/src/process_group_child.rs
@@ -1,7 +1,7 @@
 use std::io;
 #[cfg(unix)]
 use std::io::ErrorKind;
-use std::process::{Child, Command, ExitStatus};
+use std::process::{Child, ChildStderr, ChildStdin, ChildStdout, Command, ExitStatus};
 
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
@@ -29,9 +29,19 @@ impl ProcessGroupChild {
         self.child_pid
     }
 
-    /// Borrow the underlying child so callers can take configured stdio pipes.
-    pub fn child_mut(&mut self) -> &mut Child {
-        &mut self.child
+    /// Take the configured stdin pipe from the direct child.
+    pub fn take_stdin(&mut self) -> Option<ChildStdin> {
+        self.child.stdin.take()
+    }
+
+    /// Take the configured stdout pipe from the direct child.
+    pub fn take_stdout(&mut self) -> Option<ChildStdout> {
+        self.child.stdout.take()
+    }
+
+    /// Take the configured stderr pipe from the direct child.
+    pub fn take_stderr(&mut self) -> Option<ChildStderr> {
+        self.child.stderr.take()
     }
 
     /// Wait for the direct child, then clean up the process group.
@@ -40,6 +50,8 @@ impl ProcessGroupChild {
     }
 
     /// Wait for only the direct child.
+    ///
+    /// Callers must handle process-group cleanup before using this.
     pub fn wait_direct_child(mut self) -> io::Result<ExitStatus> {
         self.child.wait()
     }
@@ -99,7 +111,7 @@ pub fn terminate_process_group(child_pid: u32) {
 
 #[cfg(unix)]
 fn terminate_direct_child_by_pid(child_pid: u32) {
-    if let Ok(pid) = libc::pid_t::try_from(child_pid) {
+    if let Some(pid) = signalable_child_pid(child_pid) {
         unsafe {
             libc::kill(pid, libc::SIGKILL);
         }
@@ -108,6 +120,12 @@ fn terminate_direct_child_by_pid(child_pid: u32) {
 
 #[cfg(not(unix))]
 fn terminate_direct_child_by_pid(_child_pid: u32) {}
+
+#[cfg(unix)]
+fn signalable_child_pid(child_pid: u32) -> Option<libc::pid_t> {
+    let pid = libc::pid_t::try_from(child_pid).ok()?;
+    (pid > 1 && pid != current_process_id()).then_some(pid)
+}
 
 #[cfg(unix)]
 pub fn observe_child_exit_without_reaping(child_pid: u32) -> io::Result<()> {
@@ -169,6 +187,11 @@ fn current_process_group() -> libc::pid_t {
     unsafe { libc::getpgrp() }
 }
 
+#[cfg(unix)]
+fn current_process_id() -> libc::pid_t {
+    unsafe { libc::getpid() }
+}
+
 #[cfg(all(test, unix))]
 mod tests {
     use super::ChildProcessGroup;
@@ -202,5 +225,22 @@ mod tests {
             ChildProcessGroup::from_raw_pgid(child_id).expect("signalable process group");
 
         assert_eq!(process_group.pgid, child_id);
+    }
+
+    #[test]
+    fn signalable_child_pid_rejects_dangerous_values() {
+        assert_eq!(super::signalable_child_pid(0), None);
+        assert_eq!(super::signalable_child_pid(1), None);
+        assert_eq!(
+            super::signalable_child_pid(super::current_process_id() as u32),
+            None
+        );
+    }
+
+    #[test]
+    fn signalable_child_pid_rejects_overflow() {
+        let overflowing_child_id = (libc::pid_t::MAX as u32).saturating_add(1);
+
+        assert_eq!(super::signalable_child_pid(overflowing_child_id), None);
     }
 }

--- a/crates/guest-mock-claude/tests/echo_jsonl.rs
+++ b/crates/guest-mock-claude/tests/echo_jsonl.rs
@@ -1,14 +1,14 @@
 use std::collections::HashSet;
 use std::fs;
 use std::io::{BufRead, BufReader, Read, Write};
-use std::process::{Child, ChildStdin, Command, ExitStatus, Output, Stdio};
+use std::process::{ChildStdin, Command, ExitStatus, Output, Stdio};
 use std::sync::mpsc::{self, Receiver};
 use std::thread::JoinHandle;
 use std::time::Duration;
 
 #[cfg(unix)]
-use std::os::unix::process::CommandExt;
-
+use guest_mock_claude::process_group_child::observe_child_exit_without_reaping;
+use guest_mock_claude::process_group_child::{self, ProcessGroupChild};
 use serde_json::Value;
 
 const ACTIVE_INPUT_READY_RESULT: &str = "READY_FOR_ACTIVE_INPUT";
@@ -21,7 +21,7 @@ const STDOUT_TRUNCATION_MARKER: &str = "[stdout truncated after 1048576 bytes]";
 const STDERR_TRUNCATION_MARKER: &str = "[stderr truncated after 1048576 bytes]";
 
 struct StreamJsonChild {
-    child: Option<Child>,
+    child: Option<ProcessGroupChild>,
     stdin: Option<ChildStdin>,
     rx: Receiver<Result<Value, String>>,
     stdout_thread: Option<JoinHandle<()>>,
@@ -55,10 +55,8 @@ impl StreamJsonChild {
 impl Drop for StreamJsonChild {
     fn drop(&mut self) {
         self.close_stdin();
-        if let Some(mut child) = self.child.take() {
-            terminate_child(child.id());
-            let _ = child.kill();
-            let _ = child.wait();
+        if let Some(child) = self.child.take() {
+            child.terminate();
         }
         if let Some(stdout_thread) = self.stdout_thread.take() {
             let _ = stdout_thread.join();
@@ -70,66 +68,13 @@ fn mock_claude() -> Command {
     Command::new(env!("CARGO_BIN_EXE_guest-mock-claude"))
 }
 
-fn spawn_managed_mock_child(command: &mut Command) -> std::io::Result<Child> {
-    #[cfg(unix)]
-    command.process_group(0);
-
-    command.spawn()
+fn spawn_managed_mock_child(command: &mut Command) -> std::io::Result<ProcessGroupChild> {
+    ProcessGroupChild::spawn(command)
 }
 
 fn run_mock_output(command: &mut Command) -> Result<Output, Box<dyn std::error::Error>> {
     command.stdout(Stdio::piped()).stderr(Stdio::piped());
     wait_child_output(spawn_managed_mock_child(command)?)
-}
-
-fn terminate_child(pid: u32) {
-    #[cfg(unix)]
-    {
-        terminate_child_process_group(pid);
-
-        if let Ok(pid) = i32::try_from(pid) {
-            unsafe {
-                libc::kill(pid as libc::pid_t, libc::SIGKILL);
-            }
-        }
-    }
-
-    #[cfg(not(unix))]
-    let _ = pid;
-}
-
-#[cfg(unix)]
-fn terminate_child_process_group(pid: u32) {
-    if let Some(pgid) = signalable_child_pgid(pid) {
-        unsafe {
-            libc::kill(-pgid, libc::SIGKILL);
-        }
-    }
-}
-
-#[cfg(not(unix))]
-fn terminate_child_process_group(_pid: u32) {}
-
-#[cfg(unix)]
-fn signalable_child_pgid(child_pid: u32) -> Option<libc::pid_t> {
-    let pgid = i32::try_from(child_pid).ok()?;
-    (pgid > 1 && pgid != current_process_group()).then_some(pgid as libc::pid_t)
-}
-
-#[cfg(unix)]
-fn current_process_group() -> i32 {
-    unsafe { libc::getpgrp() }
-}
-
-#[cfg(unix)]
-#[test]
-fn signalable_child_pgid_rejects_dangerous_values() {
-    assert_eq!(signalable_child_pgid(0), None);
-    assert_eq!(signalable_child_pgid(1), None);
-    assert_eq!(signalable_child_pgid((i32::MAX as u32) + 1), None);
-    if let Ok(current_pgid) = u32::try_from(current_process_group()) {
-        assert_eq!(signalable_child_pgid(current_pgid), None);
-    }
 }
 
 fn expected_history_path(home: &std::path::Path, session_id: &str) -> std::path::PathBuf {
@@ -246,8 +191,8 @@ fn spawn_stream_json_child(
         .stderr(Stdio::piped());
 
     let mut child = spawn_managed_mock_child(&mut command)?;
-    let stdin = child.stdin.take().ok_or("missing stdin")?;
-    let stdout = child.stdout.take().ok_or("missing stdout")?;
+    let stdin = child.child_mut().stdin.take().ok_or("missing stdin")?;
+    let stdout = child.child_mut().stdout.take().ok_or("missing stdout")?;
     let (tx, rx) = mpsc::channel();
     let stdout_thread = std::thread::spawn(move || {
         let reader = BufReader::new(stdout);
@@ -312,10 +257,10 @@ fn recv_until_result(
 }
 
 fn wait_child(
-    mut child: Child,
+    mut child: ProcessGroupChild,
     stdout_thread: JoinHandle<()>,
 ) -> Result<(ExitStatus, String), Box<dyn std::error::Error>> {
-    let child_stderr = child.stderr.take();
+    let child_stderr = child.child_mut().stderr.take();
     let stderr_thread = std::thread::spawn(move || -> Result<String, std::io::Error> {
         let mut stderr = String::new();
         if let Some(mut child_stderr) = child_stderr {
@@ -335,22 +280,9 @@ fn wait_child(
     Ok((status, stderr))
 }
 
-#[cfg(any(
-    target_os = "linux",
-    target_vendor = "apple",
-    target_os = "freebsd",
-    target_os = "dragonfly",
-    target_os = "openbsd",
-    target_os = "netbsd",
-    target_os = "solaris",
-    target_os = "illumos",
-    target_os = "aix",
-    target_os = "haiku",
-    target_os = "hurd",
-    target_os = "nto",
-))]
+#[cfg(unix)]
 fn wait_child_status_and_cleanup_group(
-    mut child: Child,
+    child: ProcessGroupChild,
 ) -> Result<ExitStatus, Box<dyn std::error::Error>> {
     let pid = child.id();
     let (tx, rx) = mpsc::channel();
@@ -362,7 +294,7 @@ fn wait_child_status_and_cleanup_group(
     let child_observed = match rx.recv_timeout(CHILD_EXIT_TIMEOUT) {
         Ok(result) => result,
         Err(mpsc::RecvTimeoutError::Timeout) => {
-            terminate_child(pid);
+            process_group_child::terminate_child_by_pid(pid);
             rx.recv_timeout(CHILD_EXIT_TIMEOUT).map_err(|error| {
                 std::io::Error::new(
                     std::io::ErrorKind::TimedOut,
@@ -379,99 +311,30 @@ fn wait_child_status_and_cleanup_group(
         .join()
         .map_err(|_| std::io::Error::other("child wait thread panicked"))?;
     child_observed?;
-    terminate_child_process_group(pid);
-    Ok(child.wait()?)
+    process_group_child::terminate_process_group(pid);
+    Ok(child.wait_direct_child()?)
 }
 
-#[cfg(not(any(
-    target_os = "linux",
-    target_vendor = "apple",
-    target_os = "freebsd",
-    target_os = "dragonfly",
-    target_os = "openbsd",
-    target_os = "netbsd",
-    target_os = "solaris",
-    target_os = "illumos",
-    target_os = "aix",
-    target_os = "haiku",
-    target_os = "hurd",
-    target_os = "nto",
-)))]
+#[cfg(not(unix))]
 fn wait_child_status_and_cleanup_group(
-    child: Child,
+    child: ProcessGroupChild,
 ) -> Result<ExitStatus, Box<dyn std::error::Error>> {
     wait_child_status(child)
 }
 
-#[cfg(any(
-    target_os = "linux",
-    target_vendor = "apple",
-    target_os = "freebsd",
-    target_os = "dragonfly",
-    target_os = "openbsd",
-    target_os = "netbsd",
-    target_os = "solaris",
-    target_os = "illumos",
-    target_os = "aix",
-    target_os = "haiku",
-    target_os = "hurd",
-    target_os = "nto",
-))]
-fn observe_child_exit_without_reaping(pid: u32) -> std::io::Result<()> {
-    let pid = i32::try_from(pid).map_err(|_| {
-        std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "mock child PID does not fit in i32",
-        )
-    })?;
-
-    loop {
-        let mut info = std::mem::MaybeUninit::<libc::siginfo_t>::uninit();
-        let result = unsafe {
-            libc::waitid(
-                libc::P_PID,
-                pid as libc::id_t,
-                info.as_mut_ptr(),
-                libc::WEXITED | libc::WNOWAIT,
-            )
-        };
-        if result == 0 {
-            return Ok(());
-        }
-
-        let error = std::io::Error::last_os_error();
-        if error.kind() != std::io::ErrorKind::Interrupted {
-            return Err(error);
-        }
-    }
-}
-
-#[cfg(not(any(
-    target_os = "linux",
-    target_vendor = "apple",
-    target_os = "freebsd",
-    target_os = "dragonfly",
-    target_os = "openbsd",
-    target_os = "netbsd",
-    target_os = "solaris",
-    target_os = "illumos",
-    target_os = "aix",
-    target_os = "haiku",
-    target_os = "hurd",
-    target_os = "nto",
-)))]
-fn wait_child_status(mut child: Child) -> Result<ExitStatus, Box<dyn std::error::Error>> {
+#[cfg(not(unix))]
+fn wait_child_status(child: ProcessGroupChild) -> Result<ExitStatus, Box<dyn std::error::Error>> {
     let pid = child.id();
     let (tx, rx) = mpsc::channel();
     let wait_thread = std::thread::spawn(move || {
-        let result = child.wait();
+        let result = child.wait_direct_child();
         let _ = tx.send(result);
     });
 
     let child_result = match rx.recv_timeout(CHILD_EXIT_TIMEOUT) {
         Ok(result) => result,
         Err(mpsc::RecvTimeoutError::Timeout) => {
-            terminate_child(pid);
+            process_group_child::terminate_child_by_pid(pid);
             rx.recv_timeout(CHILD_EXIT_TIMEOUT).map_err(|error| {
                 std::io::Error::new(
                     std::io::ErrorKind::TimedOut,
@@ -490,9 +353,9 @@ fn wait_child_status(mut child: Child) -> Result<ExitStatus, Box<dyn std::error:
     Ok(child_result?)
 }
 
-fn wait_child_output(mut child: Child) -> Result<Output, Box<dyn std::error::Error>> {
-    let mut child_stdout = child.stdout.take().ok_or("missing stdout")?;
-    let mut child_stderr = child.stderr.take().ok_or("missing stderr")?;
+fn wait_child_output(mut child: ProcessGroupChild) -> Result<Output, Box<dyn std::error::Error>> {
+    let mut child_stdout = child.child_mut().stdout.take().ok_or("missing stdout")?;
+    let mut child_stderr = child.child_mut().stderr.take().ok_or("missing stderr")?;
     let stdout_thread = std::thread::spawn(move || -> Result<Vec<u8>, std::io::Error> {
         let mut stdout = Vec::new();
         child_stdout.read_to_end(&mut stdout)?;
@@ -789,7 +652,7 @@ fn stream_json_input_reads_prompt_from_stdin() -> Result<(), Box<dyn std::error:
         .stderr(Stdio::piped());
     let mut child = spawn_managed_mock_child(&mut command)?;
 
-    let mut stdin = child.stdin.take().ok_or("missing stdin")?;
+    let mut stdin = child.child_mut().stdin.take().ok_or("missing stdin")?;
     stdin.write_all(stream_json_user_frame("printf stdin-ok").as_bytes())?;
     drop(stdin);
 

--- a/crates/guest-mock-claude/tests/echo_jsonl.rs
+++ b/crates/guest-mock-claude/tests/echo_jsonl.rs
@@ -269,14 +269,17 @@ fn wait_child(
         Ok(stderr)
     });
 
-    let status = wait_child_status_and_cleanup_group(child)?;
+    let status = wait_child_status_and_cleanup_group(child);
+    let stdout_result = stdout_thread
+        .join()
+        .map_err(|_| std::io::Error::other("stdout reader thread panicked"));
+    let stderr_result = stderr_thread
+        .join()
+        .map_err(|_| std::io::Error::other("stderr reader thread panicked"));
 
-    stdout_thread
-        .join()
-        .map_err(|_| std::io::Error::other("stdout reader thread panicked"))?;
-    let stderr = stderr_thread
-        .join()
-        .map_err(|_| std::io::Error::other("stderr reader thread panicked"))??;
+    let status = status?;
+    stdout_result?;
+    let stderr = stderr_result??;
     Ok((status, stderr))
 }
 
@@ -370,13 +373,17 @@ fn wait_child_output(mut child: ProcessGroupChild) -> Result<Output, Box<dyn std
         Ok(stderr)
     });
 
-    let status = wait_child_status_and_cleanup_group(child)?;
-    let stdout = stdout_thread
+    let status = wait_child_status_and_cleanup_group(child);
+    let stdout_result = stdout_thread
         .join()
-        .map_err(|_| std::io::Error::other("stdout reader thread panicked"))??;
-    let stderr = stderr_thread
+        .map_err(|_| std::io::Error::other("stdout reader thread panicked"));
+    let stderr_result = stderr_thread
         .join()
-        .map_err(|_| std::io::Error::other("stderr reader thread panicked"))??;
+        .map_err(|_| std::io::Error::other("stderr reader thread panicked"));
+
+    let status = status?;
+    let stdout = stdout_result??;
+    let stderr = stderr_result??;
 
     Ok(Output {
         status,

--- a/crates/guest-mock-claude/tests/echo_jsonl.rs
+++ b/crates/guest-mock-claude/tests/echo_jsonl.rs
@@ -72,6 +72,16 @@ fn spawn_managed_mock_child(command: &mut Command) -> std::io::Result<ProcessGro
     ProcessGroupChild::spawn(command)
 }
 
+fn missing_child_pipe(pipe_name: &str) -> std::io::Error {
+    std::io::Error::other(format!("mock child missing {pipe_name} pipe"))
+}
+
+fn child_exit_timed_out(error: &(dyn std::error::Error + 'static)) -> bool {
+    error
+        .downcast_ref::<std::io::Error>()
+        .is_some_and(|error| error.kind() == std::io::ErrorKind::TimedOut)
+}
+
 fn run_mock_output(command: &mut Command) -> Result<Output, Box<dyn std::error::Error>> {
     command.stdout(Stdio::piped()).stderr(Stdio::piped());
     wait_child_output(spawn_managed_mock_child(command)?)
@@ -191,8 +201,14 @@ fn spawn_stream_json_child(
         .stderr(Stdio::piped());
 
     let mut child = spawn_managed_mock_child(&mut command)?;
-    let stdin = child.take_stdin().ok_or("missing stdin")?;
-    let stdout = child.take_stdout().ok_or("missing stdout")?;
+    let Some(stdin) = child.take_stdin() else {
+        child.terminate();
+        return Err(missing_child_pipe("stdin").into());
+    };
+    let Some(stdout) = child.take_stdout() else {
+        child.terminate();
+        return Err(missing_child_pipe("stdout").into());
+    };
     let (tx, rx) = mpsc::channel();
     let stdout_thread = std::thread::spawn(move || {
         let reader = BufReader::new(stdout);
@@ -269,7 +285,10 @@ fn wait_child(
         Ok(stderr)
     });
 
-    let status = wait_child_status_and_cleanup_group(child);
+    let status = match wait_child_status_and_cleanup_group(child) {
+        Err(error) if child_exit_timed_out(error.as_ref()) => return Err(error),
+        result => result,
+    };
     let stdout_result = stdout_thread
         .join()
         .map_err(|_| std::io::Error::other("stdout reader thread panicked"));
@@ -360,8 +379,14 @@ fn wait_child_status(child: ProcessGroupChild) -> Result<ExitStatus, Box<dyn std
 }
 
 fn wait_child_output(mut child: ProcessGroupChild) -> Result<Output, Box<dyn std::error::Error>> {
-    let mut child_stdout = child.take_stdout().ok_or("missing stdout")?;
-    let mut child_stderr = child.take_stderr().ok_or("missing stderr")?;
+    let Some(mut child_stdout) = child.take_stdout() else {
+        child.terminate();
+        return Err(missing_child_pipe("stdout").into());
+    };
+    let Some(mut child_stderr) = child.take_stderr() else {
+        child.terminate();
+        return Err(missing_child_pipe("stderr").into());
+    };
     let stdout_thread = std::thread::spawn(move || -> Result<Vec<u8>, std::io::Error> {
         let mut stdout = Vec::new();
         child_stdout.read_to_end(&mut stdout)?;
@@ -373,7 +398,10 @@ fn wait_child_output(mut child: ProcessGroupChild) -> Result<Output, Box<dyn std
         Ok(stderr)
     });
 
-    let status = wait_child_status_and_cleanup_group(child);
+    let status = match wait_child_status_and_cleanup_group(child) {
+        Err(error) if child_exit_timed_out(error.as_ref()) => return Err(error),
+        result => result,
+    };
     let stdout_result = stdout_thread
         .join()
         .map_err(|_| std::io::Error::other("stdout reader thread panicked"));

--- a/crates/guest-mock-claude/tests/echo_jsonl.rs
+++ b/crates/guest-mock-claude/tests/echo_jsonl.rs
@@ -191,8 +191,8 @@ fn spawn_stream_json_child(
         .stderr(Stdio::piped());
 
     let mut child = spawn_managed_mock_child(&mut command)?;
-    let stdin = child.child_mut().stdin.take().ok_or("missing stdin")?;
-    let stdout = child.child_mut().stdout.take().ok_or("missing stdout")?;
+    let stdin = child.take_stdin().ok_or("missing stdin")?;
+    let stdout = child.take_stdout().ok_or("missing stdout")?;
     let (tx, rx) = mpsc::channel();
     let stdout_thread = std::thread::spawn(move || {
         let reader = BufReader::new(stdout);
@@ -260,7 +260,7 @@ fn wait_child(
     mut child: ProcessGroupChild,
     stdout_thread: JoinHandle<()>,
 ) -> Result<(ExitStatus, String), Box<dyn std::error::Error>> {
-    let child_stderr = child.child_mut().stderr.take();
+    let child_stderr = child.take_stderr();
     let stderr_thread = std::thread::spawn(move || -> Result<String, std::io::Error> {
         let mut stderr = String::new();
         if let Some(mut child_stderr) = child_stderr {
@@ -310,7 +310,10 @@ fn wait_child_status_and_cleanup_group(
     wait_thread
         .join()
         .map_err(|_| std::io::Error::other("child wait thread panicked"))?;
-    child_observed?;
+    if let Err(error) = child_observed {
+        child.terminate();
+        return Err(error.into());
+    }
     process_group_child::terminate_process_group(pid);
     Ok(child.wait_direct_child()?)
 }
@@ -354,8 +357,8 @@ fn wait_child_status(child: ProcessGroupChild) -> Result<ExitStatus, Box<dyn std
 }
 
 fn wait_child_output(mut child: ProcessGroupChild) -> Result<Output, Box<dyn std::error::Error>> {
-    let mut child_stdout = child.child_mut().stdout.take().ok_or("missing stdout")?;
-    let mut child_stderr = child.child_mut().stderr.take().ok_or("missing stderr")?;
+    let mut child_stdout = child.take_stdout().ok_or("missing stdout")?;
+    let mut child_stderr = child.take_stderr().ok_or("missing stderr")?;
     let stdout_thread = std::thread::spawn(move || -> Result<Vec<u8>, std::io::Error> {
         let mut stdout = Vec::new();
         child_stdout.read_to_end(&mut stdout)?;
@@ -652,7 +655,7 @@ fn stream_json_input_reads_prompt_from_stdin() -> Result<(), Box<dyn std::error:
         .stderr(Stdio::piped());
     let mut child = spawn_managed_mock_child(&mut command)?;
 
-    let mut stdin = child.child_mut().stdin.take().ok_or("missing stdin")?;
+    let mut stdin = child.take_stdin().ok_or("missing stdin")?;
     stdin.write_all(stream_json_user_frame("printf stdin-ok").as_bytes())?;
     drop(stdin);
 


### PR DESCRIPTION
## Summary

- Add a narrow `guest-mock-claude` process-group child helper for group-leader spawning, no-reap observation, safe pgid signaling, and wait cleanup ordering.
- Move production stream-json shell capture onto the shared lifecycle helper without moving bounded stdout/stderr capture or adding timeouts.
- Move the `echo_jsonl` integration harness onto the same low-level helper while keeping test-local timeout and output collection behavior.

Closes #19466

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo test --manifest-path crates/Cargo.toml -p guest-mock-claude`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-mock-claude --all-targets --all-features -- -D warnings`
- pre-commit hook: `cargo-fmt`, `cargo-doc`, `cargo-clippy`, `commitlint`
