### PR TITLE
refactor: bootstrap guest-agent runtime explicitly

### DIFF
--- a/crates/guest-agent/src/complete.rs
+++ b/crates/guest-agent/src/complete.rs
@@ -62,12 +62,30 @@ pub async fn report_success(
     sandbox_reuse_result: &str,
     last_event_sequence: Option<u32>,
 ) {
+    report_success_for_run(
+        http,
+        env::run_id(),
+        sandbox_id,
+        sandbox_reuse_result,
+        last_event_sequence,
+    )
+    .await;
+}
+
+/// Report a successful run using an explicitly supplied run id.
+pub async fn report_success_for_run(
+    http: &HttpClient,
+    run_id: &str,
+    sandbox_id: &str,
+    sandbox_reuse_result: &str,
+    last_event_sequence: Option<u32>,
+) {
     if !http.has_api() {
         return;
     }
 
     let payload = CompletePayload {
-        run_id: env::run_id(),
+        run_id,
         exit_code: 0,
         last_event_sequence,
         sandbox_id: as_optional(sandbox_id),

--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -560,7 +560,9 @@ fn load_user_env_from_raw(raw: &GuestConfigRaw) -> Result<HashMap<String, String
     let runtime_dir = guest_runtime_dir_for_user_env_values(
         &raw.run_id,
         raw.guest_runtime_dir.as_deref(),
-        raw.home.as_deref(),
+        raw.runtime_home
+            .as_deref()
+            .or_else(|| raw.home.as_deref().map(Path::new)),
     )?;
     validate_user_env_file_path_for_runtime(path, &runtime_dir)?;
     load_user_env_from_path(path)
@@ -621,7 +623,7 @@ fn guest_runtime_dir_for_user_env_run_id(run_id: &str) -> Result<PathBuf, String
 fn guest_runtime_dir_for_user_env_values(
     run_id: &str,
     runtime_dir: Option<&Path>,
-    home: Option<&str>,
+    home: Option<&Path>,
 ) -> Result<PathBuf, String> {
     guest_contracts::runtime_paths::validate_run_id(run_id)
         .map_err(|e| format!("resolve guest runtime dir for {USER_ENV_FILE_ENV_KEY}: {e}"))?;
@@ -636,7 +638,7 @@ fn guest_runtime_dir_for_user_env_values(
         return Ok(runtime_dir.to_path_buf());
     }
 
-    let Some(home) = home.filter(|value| !value.is_empty()) else {
+    let Some(home) = home.filter(|value| !value.as_os_str().is_empty()) else {
         return Err(format!(
             "resolve guest runtime dir for {USER_ENV_FILE_ENV_KEY}: {}",
             guest_contracts::runtime_paths::RuntimePathError::MissingHome
@@ -1101,6 +1103,39 @@ mod tests {
         assert_eq!(
             config.user_env.get("OPENAI_MODEL").map(String::as_str),
             Some("gpt-test")
+        );
+        assert!(!user_env_path.exists());
+        assert!(!user_env_dir.exists());
+    }
+
+    #[test]
+    fn guest_config_from_raw_validates_user_env_with_runtime_home_when_home_string_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let runtime_home = tmp.path().join("home");
+        let runtime_dir =
+            guest_contracts::runtime_paths::run_dir_for_home(&runtime_home, "run-123").unwrap();
+        let user_env_dir = runtime_dir.join(USER_ENV_PRIVATE_DIR_NAME);
+        std::fs::create_dir_all(&user_env_dir).unwrap();
+        let user_env_path = user_env_dir.join(USER_ENV_FILENAME);
+        std::fs::write(
+            &user_env_path,
+            r#"{"HOME":"/home/from-user-env","OPENAI_MODEL":"gpt-runtime-home"}"#,
+        )
+        .unwrap();
+
+        let raw = GuestConfigRaw {
+            user_env_file: user_env_path.to_string_lossy().into_owned(),
+            home: None,
+            runtime_home: Some(runtime_home),
+            ..raw_config_fixture()
+        };
+
+        let config = GuestConfig::from_raw(raw).unwrap();
+
+        assert_eq!(config.home_dir, "/home/from-user-env");
+        assert_eq!(
+            config.user_env.get("OPENAI_MODEL").map(String::as_str),
+            Some("gpt-runtime-home")
         );
         assert!(!user_env_path.exists());
         assert!(!user_env_dir.exists());

--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -1,8 +1,8 @@
-//! Environment variable accessors — each value is read once via `LazyLock`.
+//! Environment variable accessors — each value is read once via process globals.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::LazyLock;
+use std::sync::{LazyLock, OnceLock};
 use std::time::Duration;
 
 use api_contracts::generated::types::runners::storage::ArtifactEntryMissingRootPolicy;
@@ -100,8 +100,7 @@ static MOCK_CLAUDE_PATH: LazyLock<String> = LazyLock::new(|| {
 
 static CLI_AGENT_TYPE: LazyLock<String> =
     LazyLock::new(|| env_or_empty(guest_contracts::env::CLI_AGENT_TYPE_ENV));
-static USER_ENV: LazyLock<Result<HashMap<String, String>, String>> =
-    LazyLock::new(load_user_env_from_process);
+static USER_ENV: OnceLock<Result<HashMap<String, String>, String>> = OnceLock::new();
 
 /// `USE_MOCK_CODEX` accepts both `"true"` and `"1"` (matches the Codex
 /// epic's documented invocation shape `USE_MOCK_CODEX=1`). The
@@ -299,6 +298,7 @@ pub struct GuestConfigRaw {
     pub use_codex_app_server_backend: String,
     pub mock_codex_path: Option<String>,
     pub home: Option<String>,
+    pub runtime_home: Option<PathBuf>,
     pub guest_runtime_dir: Option<PathBuf>,
     pub artifacts: String,
     pub stuck_tool_timeout_secs: String,
@@ -340,6 +340,7 @@ impl GuestConfigRaw {
             ),
             mock_codex_path: std::env::var(guest_contracts::env::MOCK_CODEX_PATH_ENV).ok(),
             home: std::env::var("HOME").ok(),
+            runtime_home: std::env::var_os("HOME").map(PathBuf::from),
             guest_runtime_dir,
             artifacts: env_or_empty(guest_contracts::env::ARTIFACTS_ENV),
             stuck_tool_timeout_secs: env_or_empty(
@@ -399,7 +400,7 @@ impl GuestConfig {
     /// existing accessors without racing on the private user-env file.
     pub fn from_process_env() -> Result<Self, String> {
         let raw = GuestConfigRaw::from_process_env();
-        let user_env = user_env_map_result()?.clone();
+        let user_env = init_user_env_from_raw(&raw)?.clone();
         Self::from_raw_with_user_env(raw, user_env)
     }
 
@@ -409,7 +410,7 @@ impl GuestConfig {
         Self::from_raw_with_user_env(raw, user_env)
     }
 
-    fn from_raw_with_user_env(
+    pub(crate) fn from_raw_with_user_env(
         raw: GuestConfigRaw,
         user_env: HashMap<String, String>,
     ) -> Result<Self, String> {
@@ -704,7 +705,13 @@ fn user_env_map() -> &'static HashMap<String, String> {
 }
 
 fn user_env_map_result() -> Result<&'static HashMap<String, String>, String> {
-    match &*USER_ENV {
+    user_env_result(USER_ENV.get_or_init(load_user_env_from_process))
+}
+
+fn user_env_result(
+    result: &'static Result<HashMap<String, String>, String>,
+) -> Result<&'static HashMap<String, String>, String> {
+    match result {
         Ok(user_env) => Ok(user_env),
         Err(message) => Err(message.clone()),
     }
@@ -782,10 +789,15 @@ pub fn settings() -> &'static str {
 }
 /// Load and validate the runner-provided user env payload once at startup.
 pub fn init_user_env() -> Result<(), AgentError> {
-    match &*USER_ENV {
-        Ok(_) => Ok(()),
-        Err(message) => Err(AgentError::Execution(message.clone())),
-    }
+    user_env_map_result()
+        .map(|_| ())
+        .map_err(AgentError::Execution)
+}
+
+pub(crate) fn init_user_env_from_raw(
+    raw: &GuestConfigRaw,
+) -> Result<&'static HashMap<String, String>, String> {
+    user_env_result(USER_ENV.get_or_init(|| load_user_env_from_raw(raw)))
 }
 /// User/model/connector environment loaded from `VM0_USER_ENV_FILE`.
 pub fn user_env() -> &'static HashMap<String, String> {

--- a/crates/guest-agent/src/heartbeat.rs
+++ b/crates/guest-agent/src/heartbeat.rs
@@ -26,7 +26,26 @@ pub async fn heartbeat_loop(
     http: HttpClient,
     shutdown: CancellationToken,
 ) -> Result<(), AgentError> {
-    heartbeat_loop_with_interval(
+    heartbeat_loop_for_run(env::run_id().to_string(), http, shutdown).await
+}
+
+/// Like [`heartbeat_loop`] but with a configurable interval.
+pub async fn heartbeat_loop_with_interval(
+    http: HttpClient,
+    shutdown: CancellationToken,
+    interval: Duration,
+) -> Result<(), AgentError> {
+    heartbeat_loop_for_run_with_interval(env::run_id().to_string(), http, shutdown, interval).await
+}
+
+/// Run the heartbeat loop for an explicitly supplied run id.
+pub async fn heartbeat_loop_for_run(
+    run_id: String,
+    http: HttpClient,
+    shutdown: CancellationToken,
+) -> Result<(), AgentError> {
+    heartbeat_loop_for_run_with_interval(
+        run_id,
         http,
         shutdown,
         Duration::from_secs(constants::HEARTBEAT_INTERVAL_SECS),
@@ -34,8 +53,9 @@ pub async fn heartbeat_loop(
     .await
 }
 
-/// Like [`heartbeat_loop`] but with a configurable interval.
-pub async fn heartbeat_loop_with_interval(
+/// Like [`heartbeat_loop_for_run`] but with a configurable interval.
+pub async fn heartbeat_loop_for_run_with_interval(
+    run_id: String,
     http: HttpClient,
     shutdown: CancellationToken,
     interval: Duration,
@@ -56,7 +76,7 @@ pub async fn heartbeat_loop_with_interval(
         tokio::select! {
             _ = shutdown.cancelled() => return Ok(()),
             _ = interval.tick() => {
-                let payload = json!({ "runId": env::run_id() });
+                let payload = json!({ "runId": run_id.as_str() });
                 match http.post_json(heartbeat_url, &payload, constants::HTTP_MAX_RETRIES).await {
                     Ok(_) => {
                         if is_first {

--- a/crates/guest-agent/src/http.rs
+++ b/crates/guest-agent/src/http.rs
@@ -117,11 +117,14 @@ impl HttpClient {
 
     /// Build the HTTP client appropriate for the current environment.
     ///
-    /// Production guest-agent initialization should use this constructor. When
-    /// `VM0_API_TOKEN` is non-empty, this captures `VM0_API_URL`, the API
-    /// token, and optional Vercel bypass header once and returns a webhook-ready
-    /// client. Otherwise it returns a disabled client whose request methods fail
-    /// with the disabled-client error before building or sending HTTP requests.
+    /// Compatibility wrapper for legacy callers that still read process env
+    /// directly. Production guest-agent bootstrap should prefer
+    /// [`Self::for_config`] so API settings come from the captured runtime
+    /// config. When `VM0_API_TOKEN` is non-empty, this captures `VM0_API_URL`,
+    /// the API token, and optional Vercel bypass header once and returns a
+    /// webhook-ready client. Otherwise it returns a disabled client whose
+    /// request methods fail with the disabled-client error before building or
+    /// sending HTTP requests.
     pub fn for_current_env() -> Result<Self, AgentError> {
         let Some(api) = Self::api_config_from_current_env()? else {
             return Ok(Self {

--- a/crates/guest-agent/src/http.rs
+++ b/crates/guest-agent/src/http.rs
@@ -133,6 +133,23 @@ impl HttpClient {
         Self::build(Some(api), DEFAULT_RETRY_DELAY)
     }
 
+    /// Build the HTTP client from an owned guest-agent config.
+    pub fn for_config(config: &env::GuestConfig) -> Result<Self, AgentError> {
+        let Some(api) = Self::api_config_from_values(
+            &config.api_url,
+            &config.api_token,
+            &config.vercel_bypass,
+        )?
+        else {
+            return Ok(Self {
+                inner: None,
+                retry_delay: DEFAULT_RETRY_DELAY,
+                api: None,
+            });
+        };
+        Self::build(Some(api), DEFAULT_RETRY_DELAY)
+    }
+
     pub fn has_api(&self) -> bool {
         self.api.is_some()
     }
@@ -157,15 +174,22 @@ impl HttpClient {
     }
 
     fn api_config_from_current_env() -> Result<Option<ApiHttpConfig>, AgentError> {
-        let token = env::api_token();
+        Self::api_config_from_values(env::api_url(), env::api_token(), env::vercel_bypass())
+    }
+
+    fn api_config_from_values(
+        base_url: &str,
+        token: &str,
+        vercel_bypass: &str,
+    ) -> Result<Option<ApiHttpConfig>, AgentError> {
         if token.is_empty() {
             return Ok(None);
         }
 
         Ok(Some(ApiHttpConfig::new(
-            env::api_url().to_string(),
+            base_url.to_string(),
             token.to_string(),
-            env::vercel_bypass().to_string(),
+            vercel_bypass.to_string(),
         )?))
     }
 

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -12,6 +12,7 @@ use guest_agent::http::HttpClient;
 use guest_agent::masker;
 use guest_agent::metrics;
 use guest_agent::paths;
+use guest_agent::run_context::GuestRuntime;
 use guest_agent::session_history_identity;
 use guest_agent::session_metadata;
 use guest_agent::telemetry::{Telemetry, UploadMode};
@@ -44,8 +45,15 @@ async fn main() {
     if let Some(exit_code) = helper_exit_code_from_args() {
         std::process::exit(exit_code);
     }
-    guest_common::log::enable_system_log_file();
-    let exit_code = run().await;
+    let runtime = match GuestRuntime::from_process_env() {
+        Ok(runtime) => runtime,
+        Err(e) => {
+            log_error!(LOG_TAG, "Fatal: {e}");
+            log_info!(LOG_TAG, "✗ Sandbox failed (exit code 1)");
+            std::process::exit(1);
+        }
+    };
+    let exit_code = run(runtime).await;
     std::process::exit(exit_code);
 }
 
@@ -127,45 +135,34 @@ fn parse_session_history_identity_expectation(
 /// Top-level orchestrator. Returns exit code directly (never panics/errors out).
 /// Final telemetry upload is attempted on all paths where the HTTP client can
 /// be initialized; when no API token is configured, that upload is a no-op.
-async fn run() -> i32 {
+async fn run(runtime: GuestRuntime) -> i32 {
     // Record API-to-agent E2E time (as early as possible)
-    guest_agent::timing::record_e2e_from_api("api_to_agent_start");
-
-    if let Err(e) = env::init_user_env() {
-        log_error!(LOG_TAG, "Fatal: {e}");
-        log_info!(LOG_TAG, "✗ Sandbox failed (exit code 1)");
-        return 1;
-    }
-
-    let http = match HttpClient::for_current_env() {
-        Ok(http) => http,
-        Err(e) => {
-            log_error!(LOG_TAG, "Fatal: {e}");
-            log_info!(LOG_TAG, "✗ Sandbox failed (exit code 1)");
-            return 1;
-        }
-    };
+    guest_agent::timing::record_e2e_from_api_start(
+        "api_to_agent_start",
+        &runtime.config.api_start_time,
+    );
 
     // Lifecycle: Header
-    log_info!(LOG_TAG, "▶ VM0 Sandbox {}", env::run_id());
+    log_info!(LOG_TAG, "▶ VM0 Sandbox {}", runtime.config.run_id);
 
     // Lifecycle: Initialization
     log_info!(LOG_TAG, "▷ Initialization");
 
-    let masker = Arc::new(masker::SecretMasker::from_env());
+    let http = runtime.http.clone();
+    let masker = Arc::new(masker::SecretMasker::from_config(&runtime.config));
     let shutdown = CancellationToken::new();
     let framework_supports_active_input = framework_supports_active_input(
-        env::Framework::from_env(),
-        env::use_codex_app_server_backend(),
+        runtime.config.framework,
+        runtime.config.use_codex_app_server_backend,
     );
     let has_process_control_endpoint = matches!(
         std::env::var(process_control_ipc::BOOTSTRAP_ENV),
         Ok(endpoint) if !endpoint.is_empty()
     );
     let active_input = guest_agent::active_input::ActiveInputRuntime::new_with_initial_prompt(
-        env::run_id(),
+        &runtime.config.run_id,
         framework_supports_active_input && has_process_control_endpoint,
-        env::prompt(),
+        &runtime.config.prompt,
     );
     let control_handle = control::ControlHandle::spawn(shutdown.clone(), active_input.controller());
     let start = Instant::now();
@@ -178,7 +175,12 @@ async fn run() -> i32 {
 
     let t = Instant::now();
     let (heartbeat_status_tx, heartbeat_status_rx) = tokio::sync::oneshot::channel();
-    let heartbeat_handle = spawn_heartbeat(shutdown.clone(), http.clone(), heartbeat_status_tx);
+    let heartbeat_handle = spawn_heartbeat(
+        runtime.config.run_id.clone(),
+        shutdown.clone(),
+        http.clone(),
+        heartbeat_status_tx,
+    );
     log_info!(LOG_TAG, "Heartbeat started");
     record_sandbox_op("heartbeat_start", t.elapsed(), true, None);
 
@@ -191,7 +193,12 @@ async fn run() -> i32 {
     record_sandbox_op("metrics_collector_start", t.elapsed(), true, None);
 
     let t = Instant::now();
-    let telemetry = Telemetry::spawn(masker.clone(), http.clone());
+    let telemetry = Telemetry::spawn_for_paths(
+        runtime.config.run_id.clone(),
+        &runtime.paths,
+        masker.clone(),
+        http.clone(),
+    );
     log_info!(LOG_TAG, "Telemetry upload started");
     record_sandbox_op("telemetry_upload_start", t.elapsed(), true, None);
 
@@ -207,6 +214,7 @@ async fn run() -> i32 {
         &telemetry,
         http,
         active_input.into_writer(),
+        &runtime.config,
     )
     .await;
 
@@ -247,11 +255,12 @@ async fn execute(
     telemetry: &Telemetry,
     http: HttpClient,
     active_input: guest_agent::active_input::ActiveInputWriter,
+    config: &env::GuestConfig,
 ) -> i32 {
     // Pre-warm kernel DNS cache for the CLI's API endpoint.
     // Fire-and-forget: runs in background so the cache is populated by the
     // time the CLI spawns and makes its first HTTPS request.
-    let dns_target = match env::Framework::from_env() {
+    let dns_target = match config.framework {
         env::Framework::ClaudeCode => "api.anthropic.com:443",
         env::Framework::Codex => "api.openai.com:443",
     };
@@ -265,7 +274,8 @@ async fn execute(
         let msg = format!("Working dir setup failed: {e}");
         log_error!(LOG_TAG, "{msg}");
         write_guest_error_file(&msg);
-        write_guest_failure_diagnostic(&base_failure_diagnostic(
+        write_guest_failure_diagnostic(&base_failure_diagnostic_for_config(
+            config,
             FailureClass::WorkingDirSetupFailed,
         ));
         record_sandbox_op("working_dir_setup", wd_start.elapsed(), false, Some(&msg));
@@ -275,7 +285,7 @@ async fn execute(
 
     // Codex setup: best-effort `codex login`. Failure is non-fatal —
     // `codex exec` also receives `OPENAI_API_KEY` through the curated CLI env.
-    if matches!(env::Framework::from_env(), env::Framework::Codex)
+    if matches!(config.framework, env::Framework::Codex)
         && let Err(e) = cli::setup_codex(masker).await
     {
         log_error!(LOG_TAG, "Codex setup failed (non-fatal, continuing): {e}");
@@ -316,17 +326,15 @@ async fn execute(
             let cli_exit_code = cli_result.exit_code;
             if let Some(control_error) = cli_result.control_error.as_ref() {
                 let msg = control_error.to_string();
-                let diagnostic = cli_result_failure_diagnostic(
+                let diagnostic = cli_result_failure_diagnostic_for_config(
+                    config,
                     FailureClass::CliExecutionError,
                     cli_exit_code,
                     cli_result.claude_result,
                 );
                 let diagnostic = with_cli_termination(diagnostic, cli_result.cli_termination);
                 (cli_exit_code, 1, msg, false, Some(diagnostic), false)
-            } else if preserves_successful_post_result_cleanup(
-                env::Framework::from_env(),
-                &cli_result,
-            ) {
+            } else if preserves_successful_post_result_cleanup(config.framework, &cli_result) {
                 (cli_exit_code, 0, String::new(), false, None, true)
             } else if cli_exit_code != 0 {
                 let failure_message = cli_failure_message(
@@ -334,7 +342,8 @@ async fn execute(
                     &cli_result.stderr_lines,
                     cli_result.failure_diagnostic.as_ref(),
                 );
-                let diagnostic = cli_result_failure_diagnostic(
+                let diagnostic = cli_result_failure_diagnostic_for_config(
+                    config,
                     FailureClass::CliNonzero,
                     cli_exit_code,
                     cli_result.claude_result,
@@ -350,9 +359,7 @@ async fn execute(
                     Some(diagnostic),
                     false,
                 )
-            } else if http.has_api()
-                && is_claude_zero_turn_result(env::Framework::from_env(), &cli_result)
-            {
+            } else if http.has_api() && is_claude_zero_turn_result(config.framework, &cli_result) {
                 let history_check_start = Instant::now();
                 let session_history_status = claude_history_target_status();
                 if session_history_unavailable(session_history_status) {
@@ -364,10 +371,13 @@ async fn execute(
                         Some(msg),
                     );
                     log_info!(LOG_TAG, "{msg}");
-                    let diagnostic = base_failure_diagnostic(FailureClass::ClaudeZeroTurnNoHistory)
-                        .with_cli_exit_code(cli_exit_code)
-                        .with_claude_num_turns(Some(0))
-                        .with_session_history_status(session_history_status);
+                    let diagnostic = base_failure_diagnostic_for_config(
+                        config,
+                        FailureClass::ClaudeZeroTurnNoHistory,
+                    )
+                    .with_cli_exit_code(cli_exit_code)
+                    .with_claude_num_turns(Some(0))
+                    .with_session_history_status(session_history_status);
                     (
                         cli_exit_code,
                         1,
@@ -391,7 +401,10 @@ async fn execute(
                 1,
                 msg,
                 false,
-                Some(base_failure_diagnostic(FailureClass::CliExecutionError)),
+                Some(base_failure_diagnostic_for_config(
+                    config,
+                    FailureClass::CliExecutionError,
+                )),
                 false,
             )
         }
@@ -420,6 +433,7 @@ async fn execute(
         },
         telemetry,
         &http,
+        config,
     )
     .await
 }
@@ -465,30 +479,44 @@ fn with_cli_termination(
     }
 }
 
-fn cli_result_failure_diagnostic(
+fn cli_result_failure_diagnostic_for_config(
+    config: &env::GuestConfig,
     failure_class: FailureClass,
     cli_exit_code: i32,
     claude_result: Option<cli::ClaudeResultSummary>,
 ) -> FailureDiagnostic {
-    let mut diagnostic = base_failure_diagnostic(failure_class)
+    let mut diagnostic = base_failure_diagnostic_for_config(config, failure_class)
         .with_cli_exit_code(cli_exit_code)
-        .with_session_history_status(diagnostic_session_history_status());
+        .with_session_history_status(diagnostic_session_history_status_for_framework(
+            config.framework,
+        ));
     if let Some(result) = claude_result {
         diagnostic = diagnostic.with_claude_num_turns(result.num_turns);
     }
     diagnostic
 }
 
-fn base_failure_diagnostic(failure_class: FailureClass) -> FailureDiagnostic {
+fn base_failure_diagnostic_for_config(
+    config: &env::GuestConfig,
+    failure_class: FailureClass,
+) -> FailureDiagnostic {
+    base_failure_diagnostic_from_parts(failure_class, config.framework, &config.prompt)
+}
+
+fn base_failure_diagnostic_from_parts(
+    failure_class: FailureClass,
+    framework: env::Framework,
+    prompt: &str,
+) -> FailureDiagnostic {
     FailureDiagnostic::new(
         failure_class,
-        diagnostic_framework(),
-        PromptMetadata::from_prompt(env::prompt()),
+        diagnostic_framework_from_framework(framework),
+        PromptMetadata::from_prompt(prompt),
     )
 }
 
-fn diagnostic_framework() -> AgentFramework {
-    match env::Framework::from_env() {
+fn diagnostic_framework_from_framework(framework: env::Framework) -> AgentFramework {
+    match framework {
         env::Framework::ClaudeCode => AgentFramework::ClaudeCode,
         env::Framework::Codex => AgentFramework::Codex,
     }
@@ -762,8 +790,10 @@ fn has_exact_codex_oauth_connector(value: &Value) -> bool {
         })
 }
 
-fn diagnostic_session_history_status() -> SessionHistoryStatus {
-    match env::Framework::from_env() {
+fn diagnostic_session_history_status_for_framework(
+    framework: env::Framework,
+) -> SessionHistoryStatus {
+    match framework {
         env::Framework::ClaudeCode => claude_history_target_status(),
         env::Framework::Codex => SessionHistoryStatus::NotApplicable,
     }
@@ -934,6 +964,7 @@ async fn complete_execution(
     state: CompletionState<'_>,
     telemetry: &Telemetry,
     http: &HttpClient,
+    config: &env::GuestConfig,
 ) -> i32 {
     let has_failure_message = state
         .failure_message
@@ -955,9 +986,12 @@ async fn complete_execution(
             write_guest_error_file(msg);
         }
         if !wrote_failure_diagnostic {
-            let diagnostic = base_failure_diagnostic(FailureClass::EventUploadFailed)
-                .with_cli_exit_code(cli_exit_code)
-                .with_session_history_status(diagnostic_session_history_status());
+            let diagnostic =
+                base_failure_diagnostic_for_config(config, FailureClass::EventUploadFailed)
+                    .with_cli_exit_code(cli_exit_code)
+                    .with_session_history_status(diagnostic_session_history_status_for_framework(
+                        config.framework,
+                    ));
             write_guest_failure_diagnostic(&diagnostic);
             wrote_failure_diagnostic = true;
         }
@@ -975,7 +1009,7 @@ async fn complete_execution(
     // its ~1s upload overlaps the ~4s checkpoint. The EOF-consuming final
     // pass runs from the top-level shutdown path after telemetry producers
     // stop, so it can safely catch checkpoint and `/complete` logs.
-    let agent_type = env::Framework::from_env().agent_type();
+    let agent_type = config.framework.agent_type();
     if should_create_success_checkpoint(exit_code) && http.has_api() {
         log_info!(LOG_TAG, "{agent_type} completed successfully");
 
@@ -1007,10 +1041,11 @@ async fn complete_execution(
                 // users because the host's status transition already happened
                 // the moment /complete returned.
                 log_info!(LOG_TAG, "▷ Cleanup");
-                complete::report_success(
+                complete::report_success_for_run(
                     http,
-                    env::sandbox_id(),
-                    env::sandbox_reuse_result(),
+                    &config.run_id,
+                    &config.sandbox_id,
+                    &config.sandbox_reuse_result,
                     state.last_event_sequence,
                 )
                 .await;
@@ -1025,9 +1060,12 @@ async fn complete_execution(
                 );
                 write_guest_error_file(&msg);
                 if !wrote_failure_diagnostic {
-                    let diagnostic = base_failure_diagnostic(FailureClass::CheckpointFailed)
-                        .with_cli_exit_code(cli_exit_code)
-                        .with_session_history_status(diagnostic_session_history_status());
+                    let diagnostic =
+                        base_failure_diagnostic_for_config(config, FailureClass::CheckpointFailed)
+                            .with_cli_exit_code(cli_exit_code)
+                            .with_session_history_status(
+                                diagnostic_session_history_status_for_framework(config.framework),
+                            );
                     write_guest_failure_diagnostic(&diagnostic);
                 }
                 exit_code = 1;
@@ -1093,12 +1131,14 @@ async fn stop_background_and_flush_final_telemetry(
 }
 
 fn spawn_heartbeat(
+    run_id: String,
     shutdown: CancellationToken,
     http: HttpClient,
     status_tx: tokio::sync::oneshot::Sender<cli::HeartbeatStatus>,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
-        let heartbeat_task = tokio::spawn(heartbeat::heartbeat_loop(http, shutdown));
+        let heartbeat_task =
+            tokio::spawn(heartbeat::heartbeat_loop_for_run(run_id, http, shutdown));
         let _abort_on_drop = AbortTaskOnDrop(heartbeat_task.abort_handle());
         let status = match heartbeat_task.await {
             Ok(Ok(())) => cli::HeartbeatStatus::Stopped,
@@ -1167,6 +1207,19 @@ mod tests {
 
     fn test_http_client(server: &MockServer) -> HttpClient {
         HttpClient::with_api_config(server.base_url(), "test-token", "", Duration::ZERO).unwrap()
+    }
+
+    fn test_guest_config(server: &MockServer, prompt: Option<&str>) -> env::GuestConfig {
+        env::GuestConfig::from_raw(env::GuestConfigRaw {
+            run_id: "main-recovery-checkpoint".to_string(),
+            api_url: server.base_url(),
+            api_token: "test-token".to_string(),
+            prompt: prompt.unwrap_or_default().to_string(),
+            home: Some("/home/vm0".to_string()),
+            guest_runtime_dir: Some(test_runtime_dir()),
+            ..env::GuestConfigRaw::default()
+        })
+        .unwrap()
     }
 
     fn test_runtime_dir() -> std::path::PathBuf {
@@ -2766,6 +2819,7 @@ mod tests {
         let masker = Arc::new(masker::SecretMasker::from_env());
         let http = test_http_client(server);
         let telemetry = Telemetry::spawn(masker, http.clone());
+        let config = test_guest_config(server, Some("/event-upload-failure"));
         let exit_code = complete_execution(
             0,
             0,
@@ -2778,6 +2832,7 @@ mod tests {
             },
             &telemetry,
             &http,
+            &config,
         )
         .await;
         telemetry.shutdown().await;
@@ -2833,6 +2888,7 @@ mod tests {
         let masker = Arc::new(masker::SecretMasker::from_env());
         let http = test_http_client(server);
         let telemetry = Telemetry::spawn(masker, http.clone());
+        let config = test_guest_config(server, Some("/checkpoint-failure"));
         let exit_code = complete_execution(
             0,
             0,
@@ -2845,6 +2901,7 @@ mod tests {
             },
             &telemetry,
             &http,
+            &config,
         )
         .await;
         telemetry.shutdown().await;
@@ -2899,6 +2956,7 @@ mod tests {
         let masker = Arc::new(masker::SecretMasker::from_env());
         let http = test_http_client(server);
         let telemetry = Telemetry::spawn(masker, http.clone());
+        let config = test_guest_config(server, Some("plain prompt"));
         let failure_message = "CLI failed before all events uploaded";
         let failure_diagnostic = FailureDiagnostic::new(
             FailureClass::CliNonzero,
@@ -2919,6 +2977,7 @@ mod tests {
             },
             &telemetry,
             &http,
+            &config,
         )
         .await;
         telemetry.shutdown().await;
@@ -2976,6 +3035,7 @@ mod tests {
         let masker = Arc::new(masker::SecretMasker::from_env());
         let http = test_http_client(server);
         let telemetry = Telemetry::spawn(masker, http.clone());
+        let config = test_guest_config(server, Some("/help"));
         let failure_message = "Claude Code emitted a zero-turn result without creating session history; skipping checkpoint";
         let failure_diagnostic = FailureDiagnostic::new(
             FailureClass::ClaudeZeroTurnNoHistory,
@@ -2997,6 +3057,7 @@ mod tests {
             },
             &telemetry,
             &http,
+            &config,
         )
         .await;
         telemetry.shutdown().await;
@@ -3086,6 +3147,7 @@ mod tests {
         let masker = Arc::new(masker::SecretMasker::from_env());
         let http = test_http_client(server);
         let telemetry = Telemetry::spawn(masker, http.clone());
+        let config = test_guest_config(server, Some("plain prompt"));
         let failure_message = "You've hit your usage limit.";
         let failure_diagnostic = FailureDiagnostic::new(
             FailureClass::CliNonzero,
@@ -3106,6 +3168,7 @@ mod tests {
             },
             &telemetry,
             &http,
+            &config,
         )
         .await;
         telemetry.shutdown().await;

--- a/crates/guest-agent/src/masker.rs
+++ b/crates/guest-agent/src/masker.rs
@@ -53,6 +53,13 @@ impl SecretMasker {
         masker
     }
 
+    /// Build a masker from an owned guest-agent config.
+    pub fn from_config(config: &env::GuestConfig) -> Self {
+        let masker = Self::from_raw(&config.secret_values);
+        masker.add_sensitive_value(&config.resume_session_id);
+        masker
+    }
+
     /// Build a masker from a raw comma-separated base64-encoded secret string.
     ///
     /// For each secret ≥ 5 chars, the normal matcher stores plain,

--- a/crates/guest-agent/src/paths.rs
+++ b/crates/guest-agent/src/paths.rs
@@ -88,7 +88,21 @@ impl GuestPaths {
     pub fn from_process_env(
         run_id: &str,
     ) -> Result<Self, guest_contracts::runtime_paths::RuntimePathError> {
-        guest_contracts::runtime_paths::run_dir_from_env(run_id).map(Self::from_runtime_dir)
+        let runtime_dir = std::env::var_os(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV)
+            .filter(|value| !value.is_empty())
+            .map(PathBuf::from);
+        let home = std::env::var_os("HOME").map(PathBuf::from);
+        Self::from_captured_env(run_id, runtime_dir.as_deref(), home.as_deref())
+    }
+
+    /// Build paths from values captured during bootstrap without rereading env.
+    pub fn from_captured_env(
+        run_id: &str,
+        runtime_dir: Option<&Path>,
+        process_home: Option<&Path>,
+    ) -> Result<Self, guest_contracts::runtime_paths::RuntimePathError> {
+        resolve_run_dir_from_captured_env(run_id, runtime_dir, process_home)
+            .map(Self::from_runtime_dir)
     }
 
     /// Build paths from a guest home and run id using the default layout.
@@ -162,6 +176,24 @@ fn default_run_dir() -> PathBuf {
     let run_id = std::env::var(guest_contracts::env::RUN_ID_ENV).unwrap_or_default();
     guest_contracts::runtime_paths::run_dir_from_env(&run_id)
         .unwrap_or_else(|error| panic!("failed to resolve guest runtime directory: {error}"))
+}
+
+fn resolve_run_dir_from_captured_env(
+    run_id: &str,
+    runtime_dir: Option<&Path>,
+    process_home: Option<&Path>,
+) -> Result<PathBuf, guest_contracts::runtime_paths::RuntimePathError> {
+    if let Some(runtime_dir) = runtime_dir {
+        if !runtime_dir.is_absolute() {
+            return Err(guest_contracts::runtime_paths::RuntimePathError::InvalidRuntimeDir);
+        }
+        return Ok(runtime_dir.to_path_buf());
+    }
+
+    let home = process_home
+        .filter(|value| !value.as_os_str().is_empty())
+        .ok_or(guest_contracts::runtime_paths::RuntimePathError::MissingHome)?;
+    guest_contracts::runtime_paths::run_dir_for_home(home, run_id)
 }
 
 pub fn runtime_dir() -> &'static Path {
@@ -316,6 +348,50 @@ mod tests {
         assert_eq!(
             paths.agent_log_file(),
             guest_contracts::runtime_paths::agent_log_file(&expected_runtime).to_string_lossy()
+        );
+    }
+
+    #[test]
+    fn guest_paths_from_captured_env_uses_absolute_runtime_dir() {
+        let runtime_dir = PathBuf::from("/tmp/vm0-runtime");
+        let paths = GuestPaths::from_captured_env("ignored/for-override", Some(&runtime_dir), None)
+            .unwrap();
+
+        assert_eq!(paths.runtime_dir(), runtime_dir.as_path());
+    }
+
+    #[test]
+    fn guest_paths_from_captured_env_rejects_relative_runtime_dir() {
+        let err = GuestPaths::from_captured_env(
+            "run-123",
+            Some(Path::new("relative-runtime")),
+            Some(Path::new("/home/vm0")),
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            err,
+            guest_contracts::runtime_paths::RuntimePathError::InvalidRuntimeDir
+        );
+    }
+
+    #[test]
+    fn guest_paths_from_captured_env_falls_back_to_process_home() {
+        let paths =
+            GuestPaths::from_captured_env("run-123", None, Some(Path::new("/home/vm0"))).unwrap();
+        let expected_runtime =
+            guest_contracts::runtime_paths::run_dir_for_home("/home/vm0", "run-123").unwrap();
+
+        assert_eq!(paths.runtime_dir(), expected_runtime.as_path());
+    }
+
+    #[test]
+    fn guest_paths_from_captured_env_rejects_missing_process_home() {
+        let err = GuestPaths::from_captured_env("run-123", None, Some(Path::new(""))).unwrap_err();
+
+        assert_eq!(
+            err,
+            guest_contracts::runtime_paths::RuntimePathError::MissingHome
         );
     }
 }

--- a/crates/guest-agent/src/run_context.rs
+++ b/crates/guest-agent/src/run_context.rs
@@ -1,6 +1,7 @@
 //! Explicit immutable guest-agent run context.
 
-use crate::env::GuestConfig;
+use crate::env::{self, GuestConfig, GuestConfigRaw};
+use crate::http::HttpClient;
 use crate::paths::GuestPaths;
 
 /// Immutable config and derived paths for one guest-agent run.
@@ -18,9 +19,49 @@ impl GuestContext {
 
     /// Build a run context from the current process environment.
     pub fn from_process_env() -> Result<Self, String> {
-        let config = GuestConfig::from_process_env()?;
-        let paths = GuestPaths::from_process_env(&config.run_id)
-            .map_err(|error| format!("failed to resolve guest runtime paths: {error}"))?;
+        let raw = GuestConfigRaw::from_process_env();
+        let paths = paths_from_raw(&raw)?;
+        let user_env = env::init_user_env_from_raw(&raw)?.clone();
+        let config = GuestConfig::from_raw_with_user_env(raw, user_env)?;
         Ok(Self::new(config, paths))
     }
+}
+
+/// Production runtime services for one guest-agent run.
+#[derive(Clone)]
+pub struct GuestRuntime {
+    pub config: GuestConfig,
+    pub paths: GuestPaths,
+    pub http: HttpClient,
+}
+
+impl GuestRuntime {
+    /// Build the production runtime from one raw process environment snapshot.
+    pub fn from_process_env() -> Result<Self, String> {
+        let raw = GuestConfigRaw::from_process_env();
+        let paths = paths_from_raw(&raw)?;
+        guest_common::log::set_system_log_file(paths.system_log_file());
+        guest_common::telemetry::set_sandbox_ops_log_file(paths.sandbox_ops_file());
+
+        let user_env = env::init_user_env_from_raw(&raw)?.clone();
+        let config = GuestConfig::from_raw_with_user_env(raw, user_env)?;
+        let http = HttpClient::for_config(&config).map_err(|error| error.to_string())?;
+
+        Ok(Self {
+            config,
+            paths,
+            http,
+        })
+    }
+}
+
+fn paths_from_raw(raw: &GuestConfigRaw) -> Result<GuestPaths, String> {
+    GuestPaths::from_captured_env(
+        &raw.run_id,
+        raw.guest_runtime_dir.as_deref(),
+        raw.runtime_home
+            .as_deref()
+            .or_else(|| raw.home.as_deref().map(std::path::Path::new)),
+    )
+    .map_err(|error| format!("failed to resolve guest runtime paths: {error}"))
 }

--- a/crates/guest-agent/src/telemetry.rs
+++ b/crates/guest-agent/src/telemetry.rs
@@ -19,7 +19,7 @@ use crate::env;
 use crate::error::AgentError;
 use crate::http::HttpClient;
 use crate::masker::SecretMasker;
-use crate::paths;
+use crate::paths::{self, GuestPaths};
 use guest_common::log_warn;
 use serde_json::json;
 use std::path::Path;
@@ -34,6 +34,42 @@ const LOG_TAG: &str = "sandbox:guest-agent";
 /// Buffer size for the command channel. Only one flush is in flight at a
 /// time during cleanup, so a small bounded queue is plenty.
 const COMMAND_CHANNEL_CAPACITY: usize = 8;
+
+/// Log and position files owned by one telemetry uploader.
+#[derive(Clone)]
+pub struct TelemetryPaths {
+    system_log_file: String,
+    metrics_log_file: String,
+    sandbox_ops_file: String,
+    system_log_pos_file: String,
+    metrics_pos_file: String,
+    sandbox_ops_pos_file: String,
+}
+
+impl TelemetryPaths {
+    /// Build telemetry paths from explicit guest runtime paths.
+    pub fn from_guest_paths(paths: &GuestPaths) -> Self {
+        Self {
+            system_log_file: paths.system_log_file().to_string(),
+            metrics_log_file: paths.metrics_log_file().to_string(),
+            sandbox_ops_file: paths.sandbox_ops_file().to_string(),
+            system_log_pos_file: paths.telemetry_system_log_pos_file().to_string(),
+            metrics_pos_file: paths.telemetry_metrics_pos_file().to_string(),
+            sandbox_ops_pos_file: paths.telemetry_sandbox_ops_pos_file().to_string(),
+        }
+    }
+
+    fn from_legacy_paths() -> Self {
+        Self {
+            system_log_file: paths::system_log_file().to_string(),
+            metrics_log_file: paths::metrics_log_file().to_string(),
+            sandbox_ops_file: paths::sandbox_ops_file().to_string(),
+            system_log_pos_file: paths::telemetry_system_log_pos_file().to_string(),
+            metrics_pos_file: paths::telemetry_metrics_pos_file().to_string(),
+            sandbox_ops_pos_file: paths::telemetry_sandbox_ops_pos_file().to_string(),
+        }
+    }
+}
 
 /// Whether an upload pass should defer a trailing fragment to the next
 /// pass, or consume it as-is because no next pass is coming.
@@ -68,22 +104,24 @@ fn save_position(pos_path: impl AsRef<Path>, pos: u64) {
 async fn upload_telemetry(
     http: &HttpClient,
     masker: &SecretMasker,
+    run_id: &str,
+    telemetry_paths: &TelemetryPaths,
     mode: UploadMode,
 ) -> Result<(), AgentError> {
     // Read deltas
     let system_log = read_file_delta(
-        paths::system_log_file(),
-        paths::telemetry_system_log_pos_file(),
+        &telemetry_paths.system_log_file,
+        &telemetry_paths.system_log_pos_file,
         mode,
     );
     let metrics = read_jsonl_delta(
-        paths::metrics_log_file(),
-        paths::telemetry_metrics_pos_file(),
+        &telemetry_paths.metrics_log_file,
+        &telemetry_paths.metrics_pos_file,
         mode,
     );
     let sandbox_ops = read_jsonl_delta(
-        paths::sandbox_ops_file(),
-        paths::telemetry_sandbox_ops_pos_file(),
+        &telemetry_paths.sandbox_ops_file,
+        &telemetry_paths.sandbox_ops_pos_file,
         mode,
     );
     let log_pos = system_log.new_pos;
@@ -96,9 +134,9 @@ async fn upload_telemetry(
     if system_log.content.is_empty() && metrics.entries.is_empty() && sandbox_ops.entries.is_empty()
     {
         if made_progress {
-            save_position(paths::telemetry_system_log_pos_file(), log_pos);
-            save_position(paths::telemetry_metrics_pos_file(), metrics_pos);
-            save_position(paths::telemetry_sandbox_ops_pos_file(), sandbox_ops_pos);
+            save_position(&telemetry_paths.system_log_pos_file, log_pos);
+            save_position(&telemetry_paths.metrics_pos_file, metrics_pos);
+            save_position(&telemetry_paths.sandbox_ops_pos_file, sandbox_ops_pos);
         }
         return Ok(());
     }
@@ -113,7 +151,7 @@ async fn upload_telemetry(
     let sandbox_ops_entries = sandbox_ops.entries;
 
     let payload = json!({
-        "runId": env::run_id(),
+        "runId": run_id,
         "systemLog": masked_log,
         "metrics": metrics_entries,
         "sandboxOperations": sandbox_ops_entries,
@@ -123,9 +161,9 @@ async fn upload_telemetry(
     let url = http.telemetry_url()?;
     match http.post_json(url, &payload, 1).await {
         Ok(_) => {
-            save_position(paths::telemetry_system_log_pos_file(), log_pos);
-            save_position(paths::telemetry_metrics_pos_file(), metrics_pos);
-            save_position(paths::telemetry_sandbox_ops_pos_file(), sandbox_ops_pos);
+            save_position(&telemetry_paths.system_log_pos_file, log_pos);
+            save_position(&telemetry_paths.metrics_pos_file, metrics_pos);
+            save_position(&telemetry_paths.sandbox_ops_pos_file, sandbox_ops_pos);
             Ok(())
         }
         Err(e) => {
@@ -164,16 +202,46 @@ pub struct Telemetry {
 impl Telemetry {
     /// Spawn the uploader task and return an owning handle.
     ///
-    /// Spawn **at most one instance per process.** The pos files
-    /// (`paths::telemetry_*_pos_file`) are process-global; two uploader
-    /// tasks would each call `upload_telemetry` on the same files,
-    /// reintroducing the multi-writer race that the channel was built
-    /// to eliminate (#11008). The type system can't enforce this — the
-    /// constraint is the shared pos paths, not the channel.
+    /// Spawn **at most one instance per telemetry path set.** Legacy callers
+    /// use process-global paths, while explicit runtime callers pass a single
+    /// run's paths. Two uploader tasks targeting the same pos files would
+    /// reintroduce the multi-writer race that the channel was built to
+    /// eliminate (#11008). The type system can't enforce this — the constraint
+    /// is the shared pos paths, not the channel.
     pub fn spawn(masker: Arc<SecretMasker>, http: HttpClient) -> Self {
+        Self::spawn_for_run(
+            env::run_id().to_string(),
+            TelemetryPaths::from_legacy_paths(),
+            masker,
+            http,
+        )
+    }
+
+    /// Spawn the uploader task using explicit run id and paths.
+    pub fn spawn_for_run(
+        run_id: String,
+        telemetry_paths: TelemetryPaths,
+        masker: Arc<SecretMasker>,
+        http: HttpClient,
+    ) -> Self {
         let (tx, rx) = mpsc::channel(COMMAND_CHANNEL_CAPACITY);
-        let handle = tokio::spawn(run(rx, masker, http));
+        let handle = tokio::spawn(run(rx, run_id, telemetry_paths, masker, http));
         Self { tx, handle }
+    }
+
+    /// Spawn the uploader task using explicit guest runtime paths.
+    pub fn spawn_for_paths(
+        run_id: String,
+        guest_paths: &GuestPaths,
+        masker: Arc<SecretMasker>,
+        http: HttpClient,
+    ) -> Self {
+        Self::spawn_for_run(
+            run_id,
+            TelemetryPaths::from_guest_paths(guest_paths),
+            masker,
+            http,
+        )
     }
 
     /// Trigger a telemetry upload and await completion.
@@ -234,7 +302,13 @@ impl Telemetry {
 /// select boundary, so a caller-driven flush is never blocked behind a
 /// tick that hasn't started yet. (A tick already in its `await` cannot
 /// be preempted; the worst-case wait for a flush is one in-flight tick.)
-async fn run(mut rx: mpsc::Receiver<Cmd>, masker: Arc<SecretMasker>, http: HttpClient) {
+async fn run(
+    mut rx: mpsc::Receiver<Cmd>,
+    run_id: String,
+    telemetry_paths: TelemetryPaths,
+    masker: Arc<SecretMasker>,
+    http: HttpClient,
+) {
     if !http.has_api() {
         // Drain commands so callers don't block on `reply_rx`. Flushes
         // are a no-op (no API to upload to); Shutdown ends the loop.
@@ -266,18 +340,25 @@ async fn run(mut rx: mpsc::Receiver<Cmd>, masker: Arc<SecretMasker>, http: HttpC
             biased;
             cmd = rx.recv() => match cmd {
                 Some(Cmd::Flush { mode, reply }) => {
-                    let result = upload_telemetry(&http, &masker, mode).await;
+                    let result = upload_telemetry(&http, &masker, &run_id, &telemetry_paths, mode).await;
                     let _ = reply.send(result);
                 }
                 Some(Cmd::FinalFlushAndShutdown { reply }) => {
-                    let result = upload_telemetry(&http, &masker, UploadMode::Final).await;
+                    let result = upload_telemetry(
+                        &http,
+                        &masker,
+                        &run_id,
+                        &telemetry_paths,
+                        UploadMode::Final,
+                    )
+                    .await;
                     let _ = reply.send(result);
                     break;
                 }
                 Some(Cmd::Shutdown) | None => break,
             },
             _ = interval.tick() => {
-                let _ = upload_telemetry(&http, &masker, UploadMode::Live).await;
+                let _ = upload_telemetry(&http, &masker, &run_id, &telemetry_paths, UploadMode::Live).await;
             }
         }
     }

--- a/crates/guest-agent/src/telemetry.rs
+++ b/crates/guest-agent/src/telemetry.rs
@@ -7,8 +7,9 @@
 //! the position file (#11008).
 //!
 //! Callers interact via [`Telemetry`]: spawn the task with
-//! [`Telemetry::spawn`], request uploads with [`Telemetry::flush`], and
-//! release with [`Telemetry::shutdown`] or
+//! [`Telemetry::spawn_for_paths`] for explicit runtime paths or
+//! [`Telemetry::spawn`] for legacy process-global paths, request uploads with
+//! [`Telemetry::flush`], and release with [`Telemetry::shutdown`] or
 //! [`Telemetry::final_flush_and_shutdown`].
 
 mod delta;
@@ -193,7 +194,8 @@ enum Cmd {
 ///
 /// Holds both the command channel and the spawned task's [`JoinHandle`],
 /// so callers see one lifecycle object rather than juggling two.
-/// Construct with [`Self::spawn`]; release with [`Self::shutdown`].
+/// Construct with [`Self::spawn_for_paths`] or [`Self::spawn`]; release with
+/// [`Self::shutdown`].
 pub struct Telemetry {
     tx: mpsc::Sender<Cmd>,
     handle: JoinHandle<()>,

--- a/crates/guest-agent/src/timing.rs
+++ b/crates/guest-agent/src/timing.rs
@@ -12,8 +12,12 @@ static INVALID_API_START_TIME_WARNED: AtomicBool = AtomicBool::new(false);
 
 /// Record an E2E duration from `VM0_API_START_TIME` to now under `op_name`.
 pub fn record_e2e_from_api(op_name: &str) {
+    record_e2e_from_api_start(op_name, env::api_start_time());
+}
+
+/// Record an E2E duration from an already captured API start timestamp.
+pub fn record_e2e_from_api_start(op_name: &str, api_start: &str) {
     let now_ms = current_epoch_ms();
-    let api_start = env::api_start_time();
     if let Some(duration) = e2e_duration_from_api_start(api_start, now_ms) {
         record_sandbox_op(op_name, duration, true, None);
         log_info!(LOG_TAG, "E2E {op_name}: {}ms", duration.as_millis());

--- a/crates/guest-agent/tests/guest_runtime_missing_api_url.rs
+++ b/crates/guest-agent/tests/guest_runtime_missing_api_url.rs
@@ -1,0 +1,35 @@
+//! Production runtime bootstrap should fail fast when API auth is incomplete.
+//!
+//! This test lives in its own binary because `guest_agent::env` caches
+//! environment values in process-wide once cells.
+
+#[test]
+fn runtime_bootstrap_requires_api_url_when_api_token_is_set() {
+    let tmp = tempfile::tempdir().unwrap();
+
+    unsafe {
+        std::env::set_var(
+            guest_contracts::env::RUN_ID_ENV,
+            "guest-runtime-missing-api-url",
+        );
+        std::env::set_var("HOME", tmp.path().join("home"));
+        std::env::set_var(
+            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+            tmp.path().join("runtime"),
+        );
+        std::env::set_var(guest_contracts::env::API_TOKEN_ENV, "test-token");
+        std::env::set_var(guest_contracts::env::API_URL_ENV, "");
+        std::env::remove_var(guest_contracts::env::USER_ENV_FILE_ENV);
+    }
+
+    let error = match guest_agent::run_context::GuestRuntime::from_process_env() {
+        Ok(_) => panic!("missing API URL should fail fast"),
+        Err(error) => error,
+    };
+
+    assert!(
+        error.contains(guest_contracts::env::API_URL_ENV),
+        "error should identify {}, got: {error}",
+        guest_contracts::env::API_URL_ENV
+    );
+}

--- a/crates/guest-agent/tests/guest_runtime_process_env.rs
+++ b/crates/guest-agent/tests/guest_runtime_process_env.rs
@@ -1,0 +1,49 @@
+//! Production runtime bootstrap should install explicit guest-common paths.
+//!
+//! This test lives in its own binary because `guest_agent::env` caches
+//! environment values in process-wide once cells.
+
+use std::time::Duration;
+
+#[test]
+fn runtime_bootstrap_installs_system_log_and_sandbox_ops_paths() {
+    let tmp = tempfile::tempdir().unwrap();
+    let runtime_dir = tmp.path().join("runtime");
+
+    unsafe {
+        std::env::set_var(
+            guest_contracts::env::RUN_ID_ENV,
+            "guest-runtime-process-env",
+        );
+        std::env::set_var("HOME", tmp.path().join("home"));
+        std::env::set_var(
+            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+            &runtime_dir,
+        );
+        std::env::set_var(guest_contracts::env::API_TOKEN_ENV, "");
+        std::env::remove_var(guest_contracts::env::USER_ENV_FILE_ENV);
+    }
+    guest_common::log::clear_system_log_file();
+    guest_common::telemetry::clear_sandbox_ops_log_file();
+
+    let runtime = guest_agent::run_context::GuestRuntime::from_process_env().unwrap();
+
+    assert_eq!(runtime.paths.runtime_dir(), runtime_dir.as_path());
+
+    guest_common::log_info!(
+        "sandbox:guest-agent-test",
+        "runtime bootstrap system log marker"
+    );
+    guest_common::telemetry::record_sandbox_op(
+        "runtime_bootstrap_sandbox_op",
+        Duration::from_millis(7),
+        true,
+        None,
+    );
+
+    let system_log = std::fs::read_to_string(runtime.paths.system_log_file()).unwrap();
+    assert!(system_log.contains("runtime bootstrap system log marker"));
+
+    let sandbox_ops = std::fs::read_to_string(runtime.paths.sandbox_ops_file()).unwrap();
+    assert!(sandbox_ops.contains("runtime_bootstrap_sandbox_op"));
+}

--- a/crates/guest-agent/tests/integration/telemetry.rs
+++ b/crates/guest-agent/tests/integration/telemetry.rs
@@ -23,6 +23,41 @@ fn ensure_parent_dir(path: &str) {
     let _ = std::fs::create_dir_all(parent);
 }
 
+#[tokio::test]
+async fn spawn_for_paths_uploads_explicit_runtime_files() {
+    let api = SharedApiMock::new().await;
+    let server = api.server();
+    let tmp = tempfile::tempdir().unwrap();
+    let paths = guest_agent::paths::GuestPaths::from_runtime_dir(tmp.path().join("runtime"));
+
+    let upload_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/telemetry")
+            .body_includes(r#""runId":"explicit-run""#)
+            .body_includes("explicit system log");
+        then.status(200);
+    });
+
+    guest_agent::paths::write_private(paths.system_log_file(), "explicit system log\n")
+        .expect("explicit system log should be written");
+
+    let masker = std::sync::Arc::new(SecretMasker::from_raw(""));
+    let telemetry = guest_agent::telemetry::Telemetry::spawn_for_paths(
+        "explicit-run".to_string(),
+        &paths,
+        masker,
+        http_client!(),
+    );
+    telemetry
+        .flush(guest_agent::telemetry::UploadMode::Final)
+        .await
+        .expect("explicit telemetry flush should succeed");
+    telemetry.shutdown().await;
+
+    upload_mock.assert_calls_async(1).await;
+    upload_mock.delete_async().await;
+}
+
 // =========================================================================
 // Telemetry flush delta semantics
 //

--- a/crates/guest-common/src/telemetry.rs
+++ b/crates/guest-common/src/telemetry.rs
@@ -144,16 +144,16 @@ pub fn record_sandbox_op(
     success: bool,
     error: Option<&str>,
 ) {
+    let Some(path) = configured_sandbox_ops_log() else {
+        return;
+    };
+
     let entry = SandboxOpEntry {
         ts: log::timestamp(),
         action_type: action_type.to_string(),
         duration_ms: duration_ms(duration),
         success,
         error: error.map(String::from),
-    };
-
-    let Some(path) = configured_sandbox_ops_log() else {
-        return;
     };
 
     let Ok(mut record) = serde_json::to_vec(&entry) else {
@@ -208,6 +208,38 @@ mod tests {
         }
     }
 
+    struct RuntimeDirEnvGuard {
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl RuntimeDirEnvGuard {
+        fn set(path: impl AsRef<Path>) -> Self {
+            let previous = std::env::var_os(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV);
+            unsafe {
+                std::env::set_var(
+                    guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+                    path.as_ref(),
+                );
+            }
+            Self { previous }
+        }
+    }
+
+    impl Drop for RuntimeDirEnvGuard {
+        fn drop(&mut self) {
+            unsafe {
+                if let Some(previous) = self.previous.as_ref() {
+                    std::env::set_var(
+                        guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+                        previous,
+                    );
+                } else {
+                    std::env::remove_var(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV);
+                }
+            }
+        }
+    }
+
     #[test]
     fn record_sandbox_op_writes_and_appends_jsonl() {
         let _guard = lock_test_state();
@@ -215,12 +247,7 @@ mod tests {
         clear_sandbox_ops_log_file();
         let dir = tempfile::tempdir().unwrap();
         let runtime_dir = dir.path().join("runtime");
-        unsafe {
-            std::env::set_var(
-                guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
-                &runtime_dir,
-            );
-        }
+        let _env_guard = RuntimeDirEnvGuard::set(&runtime_dir);
         let log_path = sandbox_ops_log();
         let _ = std::fs::remove_file(log_path);
 
@@ -285,9 +312,6 @@ mod tests {
         }
 
         let _ = std::fs::remove_file(log_path);
-        unsafe {
-            std::env::remove_var(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV);
-        }
     }
 
     #[test]

--- a/crates/guest-common/src/telemetry.rs
+++ b/crates/guest-common/src/telemetry.rs
@@ -26,16 +26,20 @@ static SANDBOX_OPS_LOG: LazyLock<String> = LazyLock::new(|| {
 static SANDBOX_OPS_APPEND_LOCK: Mutex<()> = Mutex::new(());
 static SANDBOX_OPS_LOG_OVERRIDE: Mutex<Option<PathBuf>> = Mutex::new(None);
 
-/// Path to the sandbox operations log file in JSONL format.
+/// Legacy process-env-derived sandbox operations log file in JSONL format.
 ///
 /// The path is resolved through the guest runtime path contract in
 /// `guest_contracts::runtime_paths`. An empty string means the guest runtime
 /// path could not be resolved and sandbox operation logging is unavailable.
+///
+/// This accessor does not report the explicit path installed through
+/// [`set_sandbox_ops_log_file`]; `record_sandbox_op` uses that override when it
+/// is present.
 pub fn sandbox_ops_log() -> &'static str {
     &SANDBOX_OPS_LOG
 }
 
-/// Set the sandbox operations log path explicitly for the current process.
+/// Set the sandbox operations log path used by future `record_sandbox_op` calls.
 pub fn set_sandbox_ops_log_file(path: impl AsRef<Path>) {
     let mut state = SANDBOX_OPS_LOG_OVERRIDE
         .lock()
@@ -130,10 +134,11 @@ struct SandboxOpEntry {
 
 /// Record a sandbox operation to the telemetry log on a best-effort basis.
 ///
-/// This helper is non-fatal: it no-ops when [`sandbox_ops_log`] is empty, and
-/// serialization or append/open/lock/write failures are not propagated to the
-/// caller. Guest operations should not treat a successful return from this
-/// function as proof that a telemetry entry was written.
+/// This helper is non-fatal: it no-ops when no explicit log path is configured
+/// and [`sandbox_ops_log`] is empty. Serialization or append/open/lock/write
+/// failures are not propagated to the caller. Guest operations should not treat
+/// a successful return from this function as proof that a telemetry entry was
+/// written.
 ///
 /// Each JSONL entry contains `ts`, `action_type`, `duration_ms`, `success`, and
 /// an optional `error` field. The format is compatible with the TypeScript

--- a/crates/guest-common/src/telemetry.rs
+++ b/crates/guest-common/src/telemetry.rs
@@ -4,6 +4,7 @@ use crate::log;
 use serde::Serialize;
 use std::fs::File;
 use std::io::{self, Write};
+use std::path::{Path, PathBuf};
 use std::sync::{LazyLock, Mutex};
 use std::time::Duration;
 
@@ -23,6 +24,7 @@ static SANDBOX_OPS_LOG: LazyLock<String> = LazyLock::new(|| {
 });
 
 static SANDBOX_OPS_APPEND_LOCK: Mutex<()> = Mutex::new(());
+static SANDBOX_OPS_LOG_OVERRIDE: Mutex<Option<PathBuf>> = Mutex::new(None);
 
 /// Path to the sandbox operations log file in JSONL format.
 ///
@@ -31,6 +33,39 @@ static SANDBOX_OPS_APPEND_LOCK: Mutex<()> = Mutex::new(());
 /// path could not be resolved and sandbox operation logging is unavailable.
 pub fn sandbox_ops_log() -> &'static str {
     &SANDBOX_OPS_LOG
+}
+
+/// Set the sandbox operations log path explicitly for the current process.
+pub fn set_sandbox_ops_log_file(path: impl AsRef<Path>) {
+    let mut state = SANDBOX_OPS_LOG_OVERRIDE
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    *state = Some(path.as_ref().to_path_buf());
+}
+
+/// Clear the explicit sandbox operations log path.
+pub fn clear_sandbox_ops_log_file() {
+    let mut state = SANDBOX_OPS_LOG_OVERRIDE
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    *state = None;
+}
+
+fn configured_sandbox_ops_log() -> Option<PathBuf> {
+    if let Some(path) = SANDBOX_OPS_LOG_OVERRIDE
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .clone()
+    {
+        return Some(path);
+    }
+
+    let path = sandbox_ops_log();
+    if path.is_empty() {
+        None
+    } else {
+        Some(PathBuf::from(path))
+    }
 }
 
 #[cfg(unix)]
@@ -117,24 +152,23 @@ pub fn record_sandbox_op(
         error: error.map(String::from),
     };
 
-    let path = sandbox_ops_log();
-    if path.is_empty() {
+    let Some(path) = configured_sandbox_ops_log() else {
         return;
-    }
+    };
 
     let Ok(mut record) = serde_json::to_vec(&entry) else {
         return;
     };
     record.push(b'\n');
 
-    let _ = append_sandbox_op_record(path, &record);
+    let _ = append_sandbox_op_record(&path, &record);
 }
 
 fn duration_ms(duration: Duration) -> u64 {
     u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
 }
 
-fn append_sandbox_op_record(path: &str, record: &[u8]) -> io::Result<()> {
+fn append_sandbox_op_record(path: impl AsRef<Path>, record: &[u8]) -> io::Result<()> {
     let mut file = guest_contracts::runtime_paths::open_private_append(path)?;
     let _append_guard = SANDBOX_OPS_APPEND_LOCK
         .lock()
@@ -148,11 +182,37 @@ fn append_sandbox_op_record(path: &str, record: &[u8]) -> io::Result<()> {
 mod tests {
     use super::*;
     use std::collections::HashSet;
+    use std::sync::{Mutex, MutexGuard};
     use std::time::Duration;
+
+    static TELEMETRY_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn lock_test_state() -> MutexGuard<'static, ()> {
+        TELEMETRY_TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    struct SandboxOpsOverrideGuard;
+
+    impl SandboxOpsOverrideGuard {
+        fn set(path: impl AsRef<Path>) -> Self {
+            set_sandbox_ops_log_file(path);
+            Self
+        }
+    }
+
+    impl Drop for SandboxOpsOverrideGuard {
+        fn drop(&mut self) {
+            clear_sandbox_ops_log_file();
+        }
+    }
 
     #[test]
     fn record_sandbox_op_writes_and_appends_jsonl() {
+        let _guard = lock_test_state();
         // Single test because all calls share the same static log path.
+        clear_sandbox_ops_log_file();
         let dir = tempfile::tempdir().unwrap();
         let runtime_dir = dir.path().join("runtime");
         unsafe {
@@ -228,5 +288,22 @@ mod tests {
         unsafe {
             std::env::remove_var(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV);
         }
+    }
+
+    #[test]
+    fn record_sandbox_op_uses_explicit_log_path_override() {
+        let _guard = lock_test_state();
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("runtime").join("logs").join("ops.jsonl");
+        let _override_guard = SandboxOpsOverrideGuard::set(&log_path);
+
+        record_sandbox_op("op_override", Duration::from_millis(12), true, None);
+
+        let content = std::fs::read_to_string(&log_path).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines.len(), 1);
+        let entry: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(entry["action_type"], "op_override");
+        assert_eq!(entry["duration_ms"], 12);
     }
 }


### PR DESCRIPTION
## Summary

- add `GuestRuntime` bootstrap that captures raw process env once, derives `GuestPaths`, initializes guest-common system log and sandbox ops paths, loads user env once, and builds `HttpClient`
- move guest-agent main startup, heartbeat, complete, masker, timing, and telemetry to explicit runtime/config/path inputs while keeping legacy wrappers for unmigrated call sites
- add explicit telemetry path support and guest-common sandbox ops override with tests

Closes #19461

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --lib`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --bin guest-agent`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test guest_config_process_env --test guest_config_process_env_legacy_first`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test http_env_missing_api_url --test no_api_mode`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test integration telemetry`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test integration heartbeat`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test integration complete`
- `cargo test --manifest-path crates/Cargo.toml -p guest-common telemetry::tests::`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features -- -D warnings`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-common --all-targets --all-features -- -D warnings`
