### PR TITLE
fix: preserve sidebar thread order during optimistic chat creation

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
@@ -467,11 +467,11 @@ function threadToSidebarListItem(thread: ChatThread): ChatThreadListItem {
   };
 }
 
-function mergeMissingActiveThreads(
+function mergeMissingSidebarThreads(
   threads: readonly ChatThreadListItem[],
-  activeThreads: readonly ChatThreadListItem[],
+  missingThreads: readonly ChatThreadListItem[],
 ): ChatThreadListItem[] {
-  if (activeThreads.length === 0) {
+  if (missingThreads.length === 0) {
     return [...threads];
   }
 
@@ -480,22 +480,22 @@ function mergeMissingActiveThreads(
       return thread.id;
     }),
   );
-  const seenActiveIds = new Set<string>();
-  const missingActiveThreads = activeThreads.filter((thread) => {
-    if (existingIds.has(thread.id) || seenActiveIds.has(thread.id)) {
+  const seenMissingIds = new Set<string>();
+  const dedupedMissingThreads = missingThreads.filter((thread) => {
+    if (existingIds.has(thread.id) || seenMissingIds.has(thread.id)) {
       return false;
     }
-    seenActiveIds.add(thread.id);
+    seenMissingIds.add(thread.id);
     return true;
   });
-  if (missingActiveThreads.length === 0) {
+  if (dedupedMissingThreads.length === 0) {
     return [...threads];
   }
 
-  const missingPinned = missingActiveThreads.filter((thread) => {
+  const missingPinned = dedupedMissingThreads.filter((thread) => {
     return thread.pinnedAt !== null && thread.pinnedAt !== undefined;
   });
-  const missingUnpinned = missingActiveThreads.filter((thread) => {
+  const missingUnpinned = dedupedMissingThreads.filter((thread) => {
     return thread.pinnedAt === null || thread.pinnedAt === undefined;
   });
   const firstUnpinnedIndex = threads.findIndex((thread) => {
@@ -515,9 +515,8 @@ function mergeMissingActiveThreads(
 }
 
 /**
- * Unified sidebar list: persisted threads merged with the optimistic-only
- * pending threads for the current agent, deduped by id, sorted (pinned first
- * then most-recent activity desc).
+ * Unified sidebar list: server-ordered persisted threads merged with the
+ * optimistic-only pending threads for the current agent, deduped by id.
  *
  * Returning a single signal — instead of letting the sidebar read persisted
  * and optimistic separately — guarantees that the optimistic→persisted
@@ -525,13 +524,10 @@ function mergeMissingActiveThreads(
  * window where two `useLastResolved` subscribers update one after the other
  * and briefly emit two `<ChatThreadItem>` siblings sharing the same `key`.
  *
- * Sort key:
- * - When the persisted version exists, dedupe drops the optimistic entry and
- *   the server's `updatedAt` decides position.
- * - While only the optimistic exists, its browser-side `createdAt` (captured
- *   when `createNewChatThread$` minted the threadId) participates in the
- *   same sort, so a freshly-created thread lands at the top of the unpinned
- *   section without being pinned to a fixed slot.
+ * The server orders each pinned/non-pinned segment by lastMessageAt desc and
+ * id desc, but the list item contract does not expose lastMessageAt. Preserve
+ * the server order for existing rows and insert optimistic rows at the front
+ * of their pinned/non-pinned segment. The frontend must not sort this list.
  */
 export const sidebarChatThreads$ = computed(
   async (get): Promise<ChatThreadListItem[]> => {
@@ -566,20 +562,13 @@ export const sidebarChatThreads$ = computed(
         };
       });
 
-    const sortedThreads =
-      optimisticItems.length === 0
-        ? [...persisted, ...extraPersisted]
-        : [...persisted, ...extraPersisted, ...optimisticItems].sort((a, b) => {
-            const aPinned = a.pinnedAt ? 0 : 1;
-            const bPinned = b.pinnedAt ? 0 : 1;
-            if (aPinned !== bPinned) {
-              return aPinned - bPinned;
-            }
-            return b.updatedAt.localeCompare(a.updatedAt);
-          });
+    const mergedThreads = mergeMissingSidebarThreads(
+      [...persisted, ...extraPersisted],
+      optimisticItems,
+    );
 
-    const sortedThreadIds = new Set(
-      sortedThreads.map((thread) => {
+    const mergedThreadIds = new Set(
+      mergedThreads.map((thread) => {
         return thread.id;
       }),
     );
@@ -587,11 +576,11 @@ export const sidebarChatThreads$ = computed(
       get(currentLeftThread$),
       get(currentRightThread$),
     ].filter((thread): thread is ChatThreadSignals => {
-      return thread !== null && !sortedThreadIds.has(thread.threadId);
+      return thread !== null && !mergedThreadIds.has(thread.threadId);
     });
 
     if (activePaneThreads.length === 0) {
-      return sortedThreads;
+      return mergedThreads;
     }
 
     const activeItems = (
@@ -608,7 +597,7 @@ export const sidebarChatThreads$ = computed(
       return thread !== null;
     });
 
-    return mergeMissingActiveThreads(sortedThreads, activeItems);
+    return mergeMissingSidebarThreads(mergedThreads, activeItems);
   },
 );
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -345,6 +345,101 @@ describe("zero sidebar", () => {
     createDeferred.resolve();
   });
 
+  it("preserves server thread order while creating an optimistic new chat", async () => {
+    prepareDefaultAgent();
+    const createDeferred = context.mocks.deferred<void>();
+    const serverOrderedThreads = [
+      {
+        id: EXISTING_THREAD_ID,
+        title: "A server first",
+        agent: { id: AGENT_ID, avatarUrl: null },
+        createdAt: "2026-03-10T00:00:00Z",
+        updatedAt: "2026-03-10T00:00:00Z",
+        running: false,
+        pinnedAt: null,
+      },
+      {
+        id: INCIDENT_THREAD_ID,
+        title: "B server second",
+        agent: { id: AGENT_ID, avatarUrl: null },
+        createdAt: "2026-03-10T00:00:00Z",
+        updatedAt: "2026-03-11T00:00:00Z",
+        running: false,
+        pinnedAt: null,
+      },
+      {
+        id: AUTOMATION_THREAD_ID,
+        title: "C server third",
+        agent: { id: AGENT_ID, avatarUrl: null },
+        createdAt: "2026-03-10T00:00:00Z",
+        updatedAt: "2026-03-12T00:00:00Z",
+        running: false,
+        pinnedAt: null,
+      },
+    ];
+
+    context.mocks.api(chatThreadsContract.list, ({ respond }) => {
+      return respond(200, splitChatThreadListResponse(serverOrderedThreads));
+    });
+    context.mocks.api(chatThreadsContract.create, async ({ body, respond }) => {
+      await createDeferred.promise;
+      return respond(201, {
+        id: body.clientThreadId ?? "created-thread-id",
+        title: null,
+        createdAt: "2026-03-12T12:00:00Z",
+      });
+    });
+    context.mocks.api(chatThreadByIdContract.get, ({ params, respond }) => {
+      const thread = serverOrderedThreads.find((candidate) => {
+        return candidate.id === params.id;
+      });
+      return respond(200, {
+        id: params.id,
+        title: thread?.title ?? null,
+        agentId: AGENT_ID,
+        activeRunIds: [],
+        draftContent: null,
+        draftAttachments: null,
+        createdAt: thread?.createdAt ?? "2026-03-12T12:00:00Z",
+        updatedAt: thread?.updatedAt ?? "2026-03-12T12:00:00Z",
+      });
+    });
+
+    detachedSetupPage({ context, path: `/agents/${AGENT_ID}/chat` });
+
+    const newChatButton = await waitFor(() => {
+      expect(
+        visibleThreadTitles([
+          "A server first",
+          "B server second",
+          "C server third",
+        ]),
+      ).toStrictEqual(["A server first", "B server second", "C server third"]);
+      return screen.getByLabelText("Open chat list menu");
+    });
+
+    click(newChatButton);
+    click(menuItemByText("New chat"));
+
+    await waitFor(() => {
+      expect(
+        visibleThreadTitles([
+          "New chat",
+          "A server first",
+          "B server second",
+          "C server third",
+        ]),
+      ).toStrictEqual([
+        "New chat",
+        "A server first",
+        "B server second",
+        "C server third",
+      ]);
+    });
+
+    createDeferred.resolve();
+  });
+
   it("closes the artifact sidebar when creating a new main chat", async () => {
     prepareDefaultAgent();
     const artifactUrl = encodeURIComponent(


### PR DESCRIPTION
## Summary
- preserve the server-returned sidebar thread order when optimistic chat threads are present
- insert optimistic sidebar rows at the front of their pinned or unpinned segment instead of sorting by updatedAt
- add a regression test where server order differs from updatedAt order

## Verification
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-sidebar.test.tsx -t "preserves server thread order" --reporter=verbose --testTimeout=10000 --hookTimeout=10000
- pnpm -F @vm0/app exec eslint src/signals/chat-page/optimistic-chat-thread-page.ts src/views/zero-page/__tests__/zero-sidebar.test.tsx --max-warnings 0
- pnpm -F @vm0/app check-types
- git diff --check