### PR TITLE
feat: add html dom color controls

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/html-dom-comment-editor.ts
+++ b/turbo/apps/platform/src/signals/zero-page/html-dom-comment-editor.ts
@@ -50,18 +50,43 @@ interface FrameCleanup {
   readonly run: () => void;
 }
 
+export type HtmlDomStyleProperty = "backgroundColor" | "color";
+
+export interface HtmlDomSelectedStyle {
+  readonly backgroundColor: string;
+  readonly color: string;
+}
+
+export interface HtmlDomColorPopoverOffset {
+  readonly left: number;
+  readonly top: number;
+}
+
+type HtmlDomStyleEdits = Partial<Record<HtmlDomStyleProperty, string>>;
+
+type HtmlDomOriginalInlineStyles = Partial<
+  Record<HtmlDomStyleProperty, string>
+>;
+type FrameStyleElement = HTMLElement | SVGElement;
+
 export interface HtmlDomCommentEditorModel {
+  readonly activeColorPanelProperty: HtmlDomStyleProperty | null;
+  readonly canApplyStyleEdits: boolean;
   readonly canAddComment: boolean;
+  readonly canEditSelectedStyle: boolean;
   readonly canSend: boolean;
+  readonly colorPopoverOffset: HtmlDomColorPopoverOffset;
   readonly commentsOpen: boolean;
   readonly commentText: string;
   readonly commentPopoverAnchor: CommentPopoverAnchor | null;
   readonly comments: readonly HtmlDomEditComment[];
   readonly currentComment: HtmlDomEditComment | null;
+  readonly editableStyleProperties: readonly HtmlDomStyleProperty[];
   readonly editingCommentId: string | null;
   readonly loadState: EditorLoadState;
   readonly popoverTextAreaKey: string;
   readonly prepared: boolean;
+  readonly selectedStyle: HtmlDomSelectedStyle;
   readonly submitting: boolean;
 }
 
@@ -80,6 +105,12 @@ interface SendHtmlDomEditRequestParams {
   readonly onFailed?: () => void;
   readonly onGenerated?: (draft: HtmlDomEditDraft) => Promise<void>;
   readonly onPrepared?: (payload: HtmlDomEditPayload) => Promise<void>;
+  readonly onStarted?: () => void;
+}
+
+interface ApplyHtmlDomStyleEditsParams {
+  readonly onApplied?: (html: string) => Promise<void>;
+  readonly onFailed?: () => void;
   readonly onStarted?: () => void;
 }
 
@@ -130,7 +161,6 @@ const FRAME_NAVIGATION_CURSOR_SVG = renderToStaticMarkup(
 const FRAME_NAVIGATION_CURSOR = `url("data:image/svg+xml,${encodeURIComponent(
   FRAME_NAVIGATION_CURSOR_SVG,
 )}") 3 3, pointer`;
-
 const internalLoadState$ = state<EditorLoadState>({ status: "loading" });
 const internalStageElement$ = state<HTMLDivElement | null>(null);
 const internalIframeElement$ = state<HTMLIFrameElement | null>(null);
@@ -144,6 +174,19 @@ const internalCommentsOpen$ = state(false);
 const internalSubmitting$ = state(false);
 const internalPreparedPayload$ = state<HtmlDomEditPayload | null>(null);
 const internalFrameCleanup$ = state<FrameCleanup | null>(null);
+const internalActiveColorPanelProperty$ = state<HtmlDomStyleProperty | null>(
+  null,
+);
+const internalColorPopoverOffset$ = state<HtmlDomColorPopoverOffset>({
+  left: 0,
+  top: 0,
+});
+const internalStyleEditsByNodeId$ = state<
+  Readonly<Record<string, HtmlDomStyleEdits>>
+>({});
+const internalOriginalStylesByNodeId$ = state<
+  Readonly<Record<string, HtmlDomOriginalInlineStyles>>
+>({});
 const resetHtmlDomEditRequestSignal$ = resetSignal();
 
 async function uploadHtmlDomEditSnapshot(
@@ -264,6 +307,71 @@ function closestCommentNode(target: EventTarget | null): Element | null {
     return null;
   }
   return (target as Element).closest(`[${HTML_DOM_NODE_ID_ATTR}]`);
+}
+
+function isElementLike(value: EventTarget | null): value is Element {
+  return (
+    value !== null && typeof value === "object" && "ownerDocument" in value
+  );
+}
+
+function isMousePointEvent(event: Event): event is MouseEvent {
+  return "clientX" in event && "clientY" in event;
+}
+
+function isFrameHtmlElement(
+  element: Element | null | undefined,
+): element is HTMLElement {
+  if (!element) {
+    return false;
+  }
+  const FrameHTMLElement = element.ownerDocument.defaultView?.HTMLElement;
+  return FrameHTMLElement
+    ? element instanceof FrameHTMLElement
+    : element instanceof HTMLElement;
+}
+
+function isFrameSvgElement(
+  element: Element | null | undefined,
+): element is SVGElement {
+  if (!element) {
+    return false;
+  }
+  const FrameSVGElement = element.ownerDocument.defaultView?.SVGElement;
+  return FrameSVGElement
+    ? element instanceof FrameSVGElement
+    : typeof SVGElement !== "undefined" && element instanceof SVGElement;
+}
+
+function isFrameStyleElement(
+  element: Element | null | undefined,
+): element is FrameStyleElement {
+  return isFrameHtmlElement(element) || isFrameSvgElement(element);
+}
+
+function smallestCommentNodeAtPoint(event: MouseEvent): Element | null {
+  const doc =
+    event.view?.document ??
+    (isElementLike(event.target) ? event.target.ownerDocument : null);
+  const elements = doc?.elementsFromPoint?.(event.clientX, event.clientY) ?? [];
+  const candidates = elements
+    .map((element) => {
+      return element.closest(`[${HTML_DOM_NODE_ID_ATTR}]`);
+    })
+    .filter((element): element is Element => {
+      return element !== null;
+    });
+  const uniqueCandidates = Array.from(new Set(candidates));
+  return (
+    uniqueCandidates.sort((first, second) => {
+      const firstRect = first.getBoundingClientRect();
+      const secondRect = second.getBoundingClientRect();
+      return (
+        firstRect.width * firstRect.height -
+        secondRect.width * secondRect.height
+      );
+    })[0] ?? null
+  );
 }
 
 function closestCommentMarker(target: EventTarget | null): HTMLElement | null {
@@ -391,6 +499,305 @@ function htmlWithEditOverlaysRemoved(params: {
     return params.fallbackHtml;
   }
   return stripHtmlDomEditOverlaysFromDocument(params.frameDocument);
+}
+
+function hasStyleEdits(
+  styleEditsByNodeId: Readonly<Record<string, HtmlDomStyleEdits>>,
+): boolean {
+  return Object.values(styleEditsByNodeId).some((edits) => {
+    return edits.backgroundColor !== undefined || edits.color !== undefined;
+  });
+}
+
+function selectedStyleForNodes(params: {
+  readonly doc: Document | null;
+  readonly selectedNodeIds: readonly string[];
+}): HtmlDomSelectedStyle {
+  const firstNodeId = params.selectedNodeIds[0];
+  const element = firstNodeId
+    ? params.doc?.querySelector(nodeSelector(firstNodeId))
+    : null;
+  return {
+    backgroundColor: isFrameStyleElement(element)
+      ? elementBackgroundColor(element)
+      : "#FFFFFF",
+    color: isFrameStyleElement(element) ? elementTextColor(element) : "#111827",
+  };
+}
+
+function editableStylePropertiesForSelectedNodes(params: {
+  readonly doc: Document | null;
+  readonly selectedNodeIds: readonly string[];
+}): readonly HtmlDomStyleProperty[] {
+  const properties: HtmlDomStyleProperty[] = [];
+  if (
+    canEditStylePropertyForSelectedNodes({
+      ...params,
+      property: "color",
+    })
+  ) {
+    properties.push("color");
+  }
+  if (
+    canEditStylePropertyForSelectedNodes({
+      ...params,
+      property: "backgroundColor",
+    })
+  ) {
+    properties.push("backgroundColor");
+  }
+  return properties;
+}
+
+function canEditStylePropertyForSelectedNodes(params: {
+  readonly doc: Document | null;
+  readonly property: HtmlDomStyleProperty;
+  readonly selectedNodeIds: readonly string[];
+}): boolean {
+  const firstNodeId = params.selectedNodeIds[0];
+  const element = firstNodeId
+    ? params.doc?.querySelector(nodeSelector(firstNodeId))
+    : null;
+  if (
+    !isFrameStyleElement(element) ||
+    isStyleControlUnsupportedTagName(element.tagName)
+  ) {
+    return false;
+  }
+  if (params.property === "backgroundColor") {
+    return isFrameHtmlElement(element);
+  }
+  return editableTextColorTargets(element).length > 0;
+}
+
+function isStyleControlUnsupportedTagName(tagName: string): boolean {
+  switch (tagName.toUpperCase()) {
+    case "AUDIO":
+    case "BR":
+    case "CANVAS":
+    case "EMBED":
+    case "HR":
+    case "IFRAME":
+    case "IMG":
+    case "OBJECT":
+    case "PICTURE":
+    case "SOURCE":
+    case "TRACK":
+    case "VIDEO": {
+      return true;
+    }
+    default: {
+      return false;
+    }
+  }
+}
+
+function elementTextColor(element: FrameStyleElement): string {
+  const textTarget = editableTextColorTargets(element)[0] ?? element;
+  const computedStyle =
+    textTarget.ownerDocument.defaultView?.getComputedStyle(textTarget);
+  if (isFrameSvgElement(textTarget)) {
+    const fillColor = cssColorToHex(
+      computedStyle?.getPropertyValue("fill") ||
+        textTarget.style.getPropertyValue("fill") ||
+        textTarget.getAttribute("fill") ||
+        undefined,
+      "",
+      textTarget.ownerDocument,
+    );
+    if (fillColor) {
+      return fillColor;
+    }
+  }
+
+  return cssColorToHex(
+    computedStyle?.getPropertyValue("color") ||
+      textTarget.style.getPropertyValue("color"),
+    "#111827",
+    textTarget.ownerDocument,
+  );
+}
+
+function editableTextColorTargets(
+  element: FrameStyleElement,
+): readonly FrameStyleElement[] {
+  const candidates = [
+    element,
+    ...Array.from(element.querySelectorAll("*")),
+  ].filter(isFrameStyleElement);
+  return candidates.filter((candidate) => {
+    return (
+      !isStyleControlUnsupportedTagName(candidate.tagName) &&
+      hasEditableTextColor(candidate)
+    );
+  });
+}
+
+function hasEditableTextColor(element: FrameStyleElement): boolean {
+  if (isFrameSvgElement(element)) {
+    return hasUsefulTextContent(element);
+  }
+  if (isTextControlElement(element)) {
+    return true;
+  }
+  return hasDirectUsefulText(element);
+}
+
+function hasUsefulTextContent(element: Element): boolean {
+  return (element.textContent ?? "").replace(/\s+/g, " ").trim().length > 0;
+}
+
+function hasDirectUsefulText(element: Element): boolean {
+  return Array.from(element.childNodes).some((node) => {
+    return (
+      node.nodeType === 3 &&
+      (node.textContent ?? "").replace(/\s+/g, " ").trim().length > 0
+    );
+  });
+}
+
+function isTextControlElement(element: HTMLElement): boolean {
+  switch (element.tagName.toUpperCase()) {
+    case "BUTTON":
+    case "INPUT":
+    case "SELECT":
+    case "TEXTAREA": {
+      return true;
+    }
+    default: {
+      return false;
+    }
+  }
+}
+
+function elementBackgroundColor(element: FrameStyleElement): string {
+  let current: Element | null = element;
+  while (current) {
+    if (!isFrameStyleElement(current)) {
+      current = current.parentElement;
+      continue;
+    }
+    const computedStyle =
+      current.ownerDocument.defaultView?.getComputedStyle(current);
+    const color = cssColorToHex(
+      computedStyle?.getPropertyValue("background-color") ||
+        current.style.getPropertyValue("background-color"),
+      "",
+      current.ownerDocument,
+    );
+    if (color) {
+      return color;
+    }
+    current = current.parentElement;
+  }
+  return "#FFFFFF";
+}
+
+function stylePropertyNameForElement(
+  element: FrameStyleElement,
+  property: HtmlDomStyleProperty,
+): string {
+  if (property === "color" && isFrameSvgElement(element)) {
+    return "fill";
+  }
+  return property === "backgroundColor" ? "background-color" : "color";
+}
+
+function cssColorToHex(
+  value: string | undefined,
+  fallback: string,
+  doc: Document | undefined,
+): string {
+  const color = value?.trim();
+  if (!color) {
+    return fallback;
+  }
+  if (/^#[0-9a-f]{6}$/i.test(color)) {
+    return color.toUpperCase();
+  }
+  if (/^#[0-9a-f]{3}$/i.test(color)) {
+    return `#${color
+      .slice(1)
+      .split("")
+      .map((char) => {
+        return `${char}${char}`;
+      })
+      .join("")
+      .toUpperCase()}`;
+  }
+
+  const rgb = rgbColorToHex(color);
+  if (rgb) {
+    return rgb;
+  }
+
+  return browserParsedCssColorToHex(color, doc) ?? fallback;
+}
+
+function rgbColorToHex(color: string): string | null {
+  const rgbMatch = /^rgba?\(([^)]+)\)$/i.exec(color);
+  if (!rgbMatch) {
+    return null;
+  }
+
+  const [channelsSource, alphaSource] = rgbMatch[1].split("/");
+  const parts = channelsSource
+    ?.trim()
+    .split(/[,\s]+/)
+    .filter(Boolean);
+  const [red, green, blue, commaAlpha] = parts ?? [];
+  const alpha = alphaSource?.trim() ?? commaAlpha;
+  if (alpha !== undefined && Number(alpha) === 0) {
+    return null;
+  }
+  if (red === undefined || green === undefined || blue === undefined) {
+    return null;
+  }
+  const channels = [red, green, blue].map((channel) => {
+    return Number(channel);
+  });
+  if (
+    channels.some((channel) => {
+      return !Number.isFinite(channel);
+    })
+  ) {
+    return null;
+  }
+
+  return rgbChannelsToHex(channels[0], channels[1], channels[2]);
+}
+
+function browserParsedCssColorToHex(
+  color: string,
+  doc: Document | undefined,
+): string | null {
+  const parent = doc?.body ?? doc?.documentElement;
+  const view = doc?.defaultView;
+  if (!parent || !view) {
+    return null;
+  }
+
+  const probe = doc.createElement("span");
+  probe.style.color = color;
+  if (!probe.style.color) {
+    return null;
+  }
+  probe.style.display = "none";
+  parent.append(probe);
+  const parsed = rgbColorToHex(view.getComputedStyle(probe).color);
+  probe.remove();
+  return parsed;
+}
+
+function rgbChannelsToHex(red: number, green: number, blue: number): string {
+  return `#${[red, green, blue]
+    .map((channel) => {
+      return Math.max(0, Math.min(255, Math.round(channel)))
+        .toString(16)
+        .padStart(2, "0");
+    })
+    .join("")
+    .toUpperCase()}`;
 }
 
 function restoreFrameDocumentHtml(params: {
@@ -765,7 +1172,7 @@ function ensureFrameCommentLayer(doc: Document): HTMLElement {
   for (const candidate of Array.from(
     doc.querySelectorAll(`#${HTML_DOM_COMMENT_LAYER_ID}`),
   )) {
-    if (candidate instanceof HTMLElement && layer === null) {
+    if (isFrameHtmlElement(candidate) && layer === null) {
       layer = candidate;
       continue;
     }
@@ -1115,6 +1522,48 @@ function shouldHideCommittedCommentMarkers(params: {
   );
 }
 
+const restoreOriginalStylesForNodes$ = command(
+  ({ get, set }, nodeIds: readonly string[]) => {
+    if (nodeIds.length === 0) {
+      return;
+    }
+
+    const doc = currentFrameDocument(get(internalIframeElement$));
+    const originalStylesByNodeId = get(internalOriginalStylesByNodeId$);
+    const nextStyleEditsByNodeId = { ...get(internalStyleEditsByNodeId$) };
+    const nextOriginalStylesByNodeId = { ...originalStylesByNodeId };
+
+    for (const nodeId of nodeIds) {
+      const originalStyles = originalStylesByNodeId[nodeId];
+      if (!originalStyles) {
+        continue;
+      }
+
+      const element = doc?.querySelector(nodeSelector(nodeId));
+      if (isFrameStyleElement(element)) {
+        for (const property of Object.keys(
+          originalStyles,
+        ) as HtmlDomStyleProperty[]) {
+          const styleProperty = stylePropertyNameForElement(element, property);
+          const originalValue = originalStyles[property];
+          if (originalValue) {
+            element.style.setProperty(styleProperty, originalValue);
+          } else {
+            element.style.removeProperty(styleProperty);
+          }
+        }
+      }
+
+      delete nextStyleEditsByNodeId[nodeId];
+      delete nextOriginalStylesByNodeId[nodeId];
+    }
+
+    set(internalStyleEditsByNodeId$, nextStyleEditsByNodeId);
+    set(internalOriginalStylesByNodeId$, nextOriginalStylesByNodeId);
+    set(internalPreparedPayload$, null);
+  },
+);
+
 export const deleteHtmlDomComment$ = command(
   ({ get, set }, commentId: string) => {
     const comments = get(internalComments$);
@@ -1137,6 +1586,7 @@ export const deleteHtmlDomComment$ = command(
       });
     const doc = currentFrameDocument(get(internalIframeElement$));
 
+    set(restoreOriginalStylesForNodes$, deletedComment.targetNodeIds);
     set(internalComments$, nextComments);
     set(internalPreparedPayload$, null);
 
@@ -1234,6 +1684,10 @@ const resetHtmlDomCommentEditor$ = command(({ set }) => {
   set(internalCommentsOpen$, false);
   set(internalSubmitting$, false);
   set(internalPreparedPayload$, null);
+  set(internalActiveColorPanelProperty$, null);
+  set(internalColorPopoverOffset$, { left: 0, top: 0 });
+  set(internalStyleEditsByNodeId$, {});
+  set(internalOriginalStylesByNodeId$, {});
 });
 
 export const setHtmlDomCommentStageRef$ = onRef(
@@ -1385,9 +1839,12 @@ function bindFrameCommentEvents(params: FrameCommentBindingParams): () => void {
       return;
     }
 
-    const nodeId = closestCommentNode(event.target)?.getAttribute(
-      HTML_DOM_NODE_ID_ATTR,
-    );
+    const nodeId = (
+      isMousePointEvent(event)
+        ? (smallestCommentNodeAtPoint(event) ??
+          closestCommentNode(event.target))
+        : closestCommentNode(event.target)
+    )?.getAttribute(HTML_DOM_NODE_ID_ATTR);
     params.setHoveredNodeId(nodeId ?? null);
     if (nodeId && commentForNodeId(params.getComments(), nodeId)) {
       openPopoverForNode(nodeId, "view");
@@ -1438,7 +1895,9 @@ function bindFrameCommentEvents(params: FrameCommentBindingParams): () => void {
       return;
     }
 
-    const element = closestCommentNode(event.target);
+    const element = isMousePointEvent(event)
+      ? (smallestCommentNodeAtPoint(event) ?? closestCommentNode(event.target))
+      : closestCommentNode(event.target);
     const nodeId = element?.getAttribute(HTML_DOM_NODE_ID_ATTR);
     if (!element || !nodeId) {
       return;
@@ -1559,6 +2018,10 @@ export const bindHtmlDomCommentFrame$ = command(
           editingCommentId,
           selectedNodeIds: value,
         });
+        if (previousSelectedNodeIds.join(":") !== value.join(":")) {
+          set(internalActiveColorPanelProperty$, null);
+          set(internalColorPopoverOffset$, { left: 0, top: 0 });
+        }
         set(internalSelectedNodeIds$, value);
         syncFrameEditState(doc, {
           hoveredNodeId: get(internalHoveredNodeId$),
@@ -1604,6 +2067,106 @@ export const setHtmlDomCommentText$ = command(({ set }, value: string) => {
   set(internalPreparedPayload$, null);
 });
 
+export const toggleHtmlDomColorPanel$ = command(
+  ({ get, set }, property: HtmlDomStyleProperty) => {
+    const doc = currentFrameDocument(get(internalIframeElement$));
+    const selectedNodeIds = get(internalSelectedNodeIds$);
+    if (
+      !canEditStylePropertyForSelectedNodes({
+        doc,
+        property,
+        selectedNodeIds,
+      })
+    ) {
+      set(internalActiveColorPanelProperty$, null);
+      set(internalColorPopoverOffset$, { left: 0, top: 0 });
+      return;
+    }
+    const activeProperty = get(internalActiveColorPanelProperty$);
+    set(
+      internalActiveColorPanelProperty$,
+      activeProperty === property ? null : property,
+    );
+    set(internalColorPopoverOffset$, { left: 0, top: 0 });
+  },
+);
+
+export const closeHtmlDomColorPanel$ = command(({ set }) => {
+  set(internalActiveColorPanelProperty$, null);
+  set(internalColorPopoverOffset$, { left: 0, top: 0 });
+});
+
+export const setHtmlDomColorPopoverOffset$ = command(
+  ({ set }, offset: HtmlDomColorPopoverOffset) => {
+    set(internalColorPopoverOffset$, offset);
+  },
+);
+
+export const applyHtmlDomColorStyle$ = command(
+  (
+    { get, set },
+    params: {
+      readonly property: HtmlDomStyleProperty;
+      readonly value: string;
+    },
+  ) => {
+    const selectedNodeIds = get(internalSelectedNodeIds$);
+    if (selectedNodeIds.length === 0) {
+      return;
+    }
+
+    const iframe = get(internalIframeElement$);
+    const doc = currentFrameDocument(iframe);
+    if (
+      !canEditStylePropertyForSelectedNodes({
+        doc,
+        property: params.property,
+        selectedNodeIds,
+      })
+    ) {
+      set(internalActiveColorPanelProperty$, null);
+      return;
+    }
+    const styleEditsByNodeId = { ...get(internalStyleEditsByNodeId$) };
+    const originalStylesByNodeId = { ...get(internalOriginalStylesByNodeId$) };
+
+    for (const nodeId of selectedNodeIds) {
+      const element = doc?.querySelector(nodeSelector(nodeId));
+      if (!isFrameStyleElement(element)) {
+        continue;
+      }
+      const targets =
+        params.property === "color"
+          ? editableTextColorTargets(element)
+          : [element];
+      for (const target of targets) {
+        const targetNodeId =
+          target.getAttribute(HTML_DOM_NODE_ID_ATTR) ?? nodeId;
+        const styleProperty = stylePropertyNameForElement(
+          target,
+          params.property,
+        );
+
+        originalStylesByNodeId[targetNodeId] = {
+          ...originalStylesByNodeId[targetNodeId],
+          [params.property]:
+            originalStylesByNodeId[targetNodeId]?.[params.property] ??
+            target.style.getPropertyValue(styleProperty),
+        };
+        target.style.setProperty(styleProperty, params.value);
+        styleEditsByNodeId[targetNodeId] = {
+          ...styleEditsByNodeId[targetNodeId],
+          [params.property]: params.value,
+        };
+      }
+    }
+
+    set(internalOriginalStylesByNodeId$, originalStylesByNodeId);
+    set(internalStyleEditsByNodeId$, styleEditsByNodeId);
+    set(internalPreparedPayload$, null);
+  },
+);
+
 export const beginEditingCurrentHtmlDomComment$ = command(({ get, set }) => {
   const currentComment = commentForSelectedNodes({
     comments: get(internalComments$),
@@ -1628,6 +2191,8 @@ const resetHtmlDomCommentDraft$ = command(({ get, set }) => {
   set(internalSelectedNodeIds$, []);
   set(internalCommentPopoverAnchor$, null);
   set(internalEditingCommentId$, null);
+  set(internalActiveColorPanelProperty$, null);
+  set(internalColorPopoverOffset$, { left: 0, top: 0 });
   set(internalPreparedPayload$, null);
   syncFrameEditState(currentFrameDocument(get(internalIframeElement$)), {
     hoveredNodeId: get(internalHoveredNodeId$),
@@ -1692,6 +2257,10 @@ export const discardHtmlDomComments$ = command(({ get, set }) => {
 
   set(internalComments$, []);
   set(internalCommentsOpen$, false);
+  set(internalActiveColorPanelProperty$, null);
+  set(internalColorPopoverOffset$, { left: 0, top: 0 });
+  set(internalStyleEditsByNodeId$, {});
+  set(internalOriginalStylesByNodeId$, {});
   if (readyLoadState.status === "ready" && doc) {
     restoreFrameDocumentHtml({
       doc,
@@ -1798,6 +2367,59 @@ export const sendHtmlDomEditRequest$ = command(
   },
 );
 
+export const applyHtmlDomStyleEdits$ = command(
+  async (
+    { get, set },
+    params: ApplyHtmlDomStyleEditsParams,
+    _parentSignal: AbortSignal,
+  ) => {
+    const readyLoadState = get(internalLoadState$);
+    if (
+      readyLoadState.status !== "ready" ||
+      get(internalComments$).length > 0 ||
+      !hasStyleEdits(get(internalStyleEditsByNodeId$)) ||
+      get(internalSubmitting$)
+    ) {
+      return;
+    }
+
+    const signal = set(resetHtmlDomEditRequestSignal$);
+    set(internalSubmitting$, true);
+    set(internalPreparedPayload$, null);
+
+    const apply = async () => {
+      const html = htmlWithEditOverlaysRemoved({
+        fallbackHtml: readyLoadState.html,
+        frameDocument: currentFrameDocument(get(internalIframeElement$)),
+      });
+      params.onStarted?.();
+      if (params.onApplied) {
+        const applied = await tapError(
+          (async () => {
+            await params.onApplied?.(html);
+            return true;
+          })(),
+          (error) => {
+            toast.error(htmlDomEditErrorMessage(error, "Failed to apply edit"));
+          },
+        );
+        signal.throwIfAborted();
+        if (!applied) {
+          params.onFailed?.();
+        }
+        return;
+      }
+      toast.success("Edit applied");
+    };
+
+    await withCleanup(apply(), () => {
+      if (!signal.aborted) {
+        set(internalSubmitting$, false);
+      }
+    });
+  },
+);
+
 export const htmlDomCommentEditorModel$ = computed(
   (get): HtmlDomCommentEditorModel => {
     const comments = get(internalComments$);
@@ -1806,24 +2428,39 @@ export const htmlDomCommentEditorModel$ = computed(
     const selectedNodeIds = get(internalSelectedNodeIds$);
     const loadState = get(internalLoadState$);
     const submitting = get(internalSubmitting$);
+    const styleEditsByNodeId = get(internalStyleEditsByNodeId$);
+    const doc = currentFrameDocument(get(internalIframeElement$));
+    const editableStyleProperties = editableStylePropertiesForSelectedNodes({
+      doc,
+      selectedNodeIds,
+    });
     const currentComment = commentForSelectedNodes({
       comments,
       selectedNodeIds,
     });
 
     return {
+      activeColorPanelProperty: get(internalActiveColorPanelProperty$),
+      canApplyStyleEdits:
+        loadState.status === "ready" &&
+        comments.length === 0 &&
+        hasStyleEdits(styleEditsByNodeId) &&
+        !submitting,
       canAddComment: editingCommentId
         ? commentText.trim() !== ""
         : selectedNodeIds.length > 0 &&
           commentText.trim() !== "" &&
           !hasCommentForSelectedNodes({ comments, selectedNodeIds }),
+      canEditSelectedStyle: editableStyleProperties.length > 0,
       canSend:
         loadState.status === "ready" && comments.length > 0 && !submitting,
+      colorPopoverOffset: get(internalColorPopoverOffset$),
       commentsOpen: get(internalCommentsOpen$),
       commentText,
       commentPopoverAnchor: get(internalCommentPopoverAnchor$),
       comments,
       currentComment,
+      editableStyleProperties,
       editingCommentId,
       loadState,
       popoverTextAreaKey: [
@@ -1832,6 +2469,7 @@ export const htmlDomCommentEditorModel$ = computed(
         currentComment?.id ?? "draft",
       ].join("|"),
       prepared: get(internalPreparedPayload$) !== null,
+      selectedStyle: selectedStyleForNodes({ doc, selectedNodeIds }),
       submitting,
     };
   },

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -680,23 +680,11 @@ describe("zero artifact sidebar", () => {
     });
   });
 
-  it("shows an unavailable pane for unsupported artifact deep links", async () => {
+  it("hides the sidebar for unsupported artifact deep links", async () => {
     setupChatThread({
       content: "Artifacts are ready.",
       path: `${THREAD_PATH}?artifact=image%3Agenerated-1&artifact-fullscreen=1`,
     });
-
-    await waitFor(() => {
-      expect(screen.getByTestId("artifact-sidebar")).toBeInTheDocument();
-      expect(screen.getByText("Artifact unavailable")).toBeInTheDocument();
-      expect(
-        screen.getByText("Unsupported artifact reference."),
-      ).toBeInTheDocument();
-      expect(screen.getByLabelText("Exit fullscreen")).toBeInTheDocument();
-      expectFullscreenSafeAreaClass(screen.getByTestId("artifact-sidebar"));
-    });
-
-    click(screen.getByLabelText("Close artifact"));
 
     await waitFor(() => {
       expect(screen.queryByTestId("artifact-sidebar")).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -14,7 +14,7 @@ import {
 } from "@testing-library/react";
 import { StoreProvider } from "ccstate-react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import {
   click,
@@ -79,6 +79,7 @@ function setupHostedSiteArtifactPreview({
     [FeatureSwitchKey.HtmlArtifactCommentEditing]: true,
   },
   filename,
+  html,
   htmlUrl,
   label,
   path = `/chats/${THREAD_ID}`,
@@ -86,6 +87,7 @@ function setupHostedSiteArtifactPreview({
 }: {
   featureSwitches?: Parameters<typeof detachedSetupPage>[0]["featureSwitches"];
   filename: string;
+  html?: string;
   htmlUrl: string;
   label: string;
   path?: string;
@@ -94,7 +96,8 @@ function setupHostedSiteArtifactPreview({
   context.mocks.http.get("*/__vm0-dev-artifact-fetch", ({ request }) => {
     expect(new URL(request.url).searchParams.get("url")).toBe(htmlUrl);
     return new Response(
-      `<!doctype html>
+      html ??
+        `<!doctype html>
       <html>
         <head><title>${label}</title></head>
         <body>
@@ -1446,8 +1449,9 @@ describe("zero attachment chips", () => {
         screen.queryByLabelText("Close comment popover"),
       ).not.toBeInTheDocument();
       expect(popover.querySelectorAll("textarea")).toHaveLength(1);
-      expect(popover.querySelectorAll("button")).toHaveLength(1);
-      expect(popover).toHaveClass("flex");
+      expect(screen.getByTestId("html-dom-color-controls")).toBeInTheDocument();
+      expect(screen.queryByTestId("html-dom-color-popover")).toBeNull();
+      expect(popover).toHaveClass("rounded-[28px]");
     });
     fireEvent.click(screen.getByTestId("html-dom-comment-textarea"));
     await waitFor(() => {
@@ -1743,6 +1747,426 @@ describe("zero attachment chips", () => {
       expect(restoredEditFrame.contentDocument?.body.textContent).not.toContain(
         "Launch sooner",
       );
+    });
+  });
+
+  it("applies hosted-site HTML background and text color edits from the DOM popover", async () => {
+    const htmlUrl = "https://color-launch-site.sites.vm7.io";
+    let redeployedHtml: string | null = null;
+    vi.stubGlobal(
+      "EyeDropper",
+      class {
+        open(): Promise<{ readonly sRGBHex: string }> {
+          return Promise.resolve({ sRGBHex: "#123456" });
+        }
+      },
+    );
+
+    setupHostedSiteArtifactPreview({
+      filename: "color-launch-site.html",
+      htmlUrl,
+      label: "Color launch site",
+      runId: "run-hosted-site-color",
+    });
+    context.mocks.api(zeroHostContract.redeployHtml, ({ body, respond }) => {
+      expect(body.url).toBe(htmlUrl);
+      expect(body.html).toContain("background-color");
+      expect(body.html).toContain("color");
+      expect(body.html).toMatch(/#FDE68A|rgb\(253, 230, 138\)/i);
+      expect(body.html).toMatch(/#2563EB|rgb\(37, 99, 235\)/i);
+      redeployedHtml = body.html;
+      return respond(200, {
+        siteId: "7c82da29-6280-4d65-b078-e233c8ad14bf",
+        deploymentId: "dc8b4d42-5dc1-4769-ad8b-17bdf1ad035a",
+        publicSlug: "color-launch-site",
+        url: htmlUrl,
+        status: "ready",
+      });
+    });
+
+    click(
+      await screen.findByLabelText("Open html preview for Color launch site"),
+    );
+    click(await screen.findByLabelText("Edit page"));
+
+    const frame = (await screen.findByTestId(
+      "html-dom-comment-frame",
+    )) as HTMLIFrameElement;
+    await waitFor(() => {
+      expect(
+        frame.contentDocument
+          ?.querySelector("h1")
+          ?.hasAttribute(HTML_DOM_NODE_ID_ATTR),
+      ).toBeTruthy();
+    });
+    const title = frame.contentDocument?.querySelector("h1");
+    expect(title).not.toBeNull();
+    const main = frame.contentDocument?.querySelector("main");
+    expect(main).not.toBeNull();
+    title!.style.color = "#ff0000";
+    title!.style.backgroundColor = "rgb(0, 0, 0)";
+    const originalElementsFromPoint =
+      frame.contentDocument?.elementsFromPoint?.bind(frame.contentDocument);
+    frame.contentDocument!.elementsFromPoint = () => {
+      return [title!, main!, frame.contentDocument!.body];
+    };
+    fireEvent.click(main!, { clientX: 10, clientY: 10 });
+    frame.contentDocument!.elementsFromPoint = originalElementsFromPoint!;
+
+    await waitFor(() => {
+      expect(screen.getByTestId("html-dom-color-controls")).toBeInTheDocument();
+      expect(screen.queryByTestId("html-dom-color-popover")).toBeNull();
+      expect(
+        screen.getByTestId("html-dom-color-control-color"),
+      ).toHaveTextContent("#ff0000");
+      expect(
+        screen.getByTestId("html-dom-color-control-backgroundColor"),
+      ).toHaveTextContent("#000000");
+    });
+    click(screen.getByTestId("html-dom-color-control-backgroundColor"));
+    expect(screen.getByTestId("html-dom-color-popover")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("html-dom-floating-color-popover"),
+    ).toContainElement(screen.getByTestId("html-dom-color-popover"));
+    expect(screen.getByTestId("html-dom-comment-popover")).not.toContainElement(
+      screen.getByTestId("html-dom-color-popover"),
+    );
+    const colorPopover = screen.getByTestId("html-dom-floating-color-popover");
+    const initialColorPopoverLeft = Number.parseFloat(colorPopover.style.left);
+    const initialColorPopoverTop = Number.parseFloat(colorPopover.style.top);
+    fireEvent.pointerDown(
+      screen.getByTestId("html-dom-color-popover-drag-handle"),
+      {
+        buttons: 1,
+        clientX: 10,
+        clientY: 10,
+        pointerId: 3,
+      },
+    );
+    fireEvent.pointerMove(
+      screen.getByTestId("html-dom-color-popover-drag-handle"),
+      {
+        buttons: 1,
+        clientX: 34,
+        clientY: 28,
+        pointerId: 3,
+      },
+    );
+    await waitFor(() => {
+      expect(Number.parseFloat(colorPopover.style.left)).toBe(
+        initialColorPopoverLeft + 24,
+      );
+      expect(Number.parseFloat(colorPopover.style.top)).toBe(
+        initialColorPopoverTop + 18,
+      );
+    });
+    expect(screen.getByTestId("html-dom-color-field")).toBeInTheDocument();
+    expect(screen.getByTestId("html-dom-color-hue-slider")).toBeInTheDocument();
+    mockElementRect(screen.getByTestId("html-dom-color-field"), {
+      height: 100,
+      left: 0,
+      top: 0,
+      width: 100,
+    });
+    fireEvent.pointerDown(screen.getByTestId("html-dom-color-field"), {
+      buttons: 1,
+      clientX: 100,
+      clientY: 0,
+      pointerId: 1,
+    });
+    await waitFor(() => {
+      expect(title?.style.backgroundColor).toBe("#FF0000");
+    });
+    fireEvent.change(screen.getByLabelText("R"), { target: { value: "253" } });
+    fireEvent.change(screen.getByLabelText("G"), { target: { value: "230" } });
+    fireEvent.change(screen.getByLabelText("B"), { target: { value: "138" } });
+    await waitFor(() => {
+      expect(title?.style.backgroundColor).toBe("#FDE68A");
+    });
+    click(screen.getByTestId("html-dom-color-control-color"));
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("html-dom-color-control-color"),
+      ).toHaveAttribute("aria-expanded", "true");
+      expect(screen.getByTestId("html-dom-color-popover")).toBeInTheDocument();
+    });
+    mockElementRect(screen.getByTestId("html-dom-color-hue-slider"), {
+      height: 28,
+      left: 0,
+      top: 0,
+      width: 360,
+    });
+    fireEvent.pointerDown(screen.getByTestId("html-dom-color-hue-slider"), {
+      buttons: 1,
+      clientX: 180,
+      clientY: 14,
+      pointerId: 2,
+    });
+    await waitFor(() => {
+      expect(title?.style.color).toBe("#00FFFF");
+    });
+    click(screen.getByTestId("html-dom-color-eyedropper"));
+    await waitFor(() => {
+      expect(title?.style.color).toBe("#123456");
+    });
+    fireEvent.change(screen.getByLabelText("R"), { target: { value: "37" } });
+    fireEvent.change(screen.getByLabelText("G"), { target: { value: "99" } });
+    fireEvent.change(screen.getByLabelText("B"), { target: { value: "235" } });
+
+    await waitFor(() => {
+      expect(title?.style.backgroundColor).toBe("#FDE68A");
+      expect(title?.style.color).toBe("#2563EB");
+      expect(screen.getByTestId("html-dom-comment-textarea")).toHaveValue("");
+      expect(
+        screen.queryByTestId("html-dom-toolbar-comments-count"),
+      ).toBeNull();
+      expect(screen.getByTestId("html-dom-toolbar-send")).toHaveTextContent(
+        "Apply",
+      );
+    });
+
+    click(screen.getByTestId("html-dom-toolbar-send"));
+    await waitFor(() => {
+      expect(redeployedHtml).not.toBeNull();
+      expect(screen.queryByTestId("html-dom-comment-frame")).toBeNull();
+    });
+  });
+
+  it("hides hosted-site HTML color controls for selected images", async () => {
+    const htmlUrl = "https://image-launch-site.sites.vm7.io";
+
+    setupHostedSiteArtifactPreview({
+      filename: "image-launch-site.html",
+      html: `<!doctype html>
+      <html>
+        <head><title>Image launch site</title></head>
+        <body>
+          <main>
+            <h1>Launch faster</h1>
+            <img src="/hero.png" alt="Hero" />
+          </main>
+        </body>
+      </html>`,
+      htmlUrl,
+      label: "Image launch site",
+      runId: "run-hosted-site-image",
+    });
+
+    click(
+      await screen.findByLabelText("Open html preview for Image launch site"),
+    );
+    click(await screen.findByLabelText("Edit page"));
+
+    const frame = (await screen.findByTestId(
+      "html-dom-comment-frame",
+    )) as HTMLIFrameElement;
+    await waitFor(() => {
+      expect(
+        frame.contentDocument
+          ?.querySelector("img")
+          ?.hasAttribute(HTML_DOM_NODE_ID_ATTR),
+      ).toBeTruthy();
+    });
+    fireEvent.click(frame.contentDocument!.querySelector("img")!);
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("html-dom-comment-popover"),
+      ).toBeInTheDocument();
+      expect(screen.queryByTestId("html-dom-color-controls")).toBeNull();
+    });
+  });
+
+  it("shows hosted-site HTML color controls for text inputs and textareas", async () => {
+    const htmlUrl = "https://form-launch-site.sites.vm7.io";
+
+    setupHostedSiteArtifactPreview({
+      filename: "form-launch-site.html",
+      html: `<!doctype html>
+      <html>
+        <head><title>Form launch site</title></head>
+        <body>
+          <main>
+            <input type="text" value="Launch faster" />
+            <textarea>Ship the first version today.</textarea>
+          </main>
+        </body>
+      </html>`,
+      htmlUrl,
+      label: "Form launch site",
+      runId: "run-hosted-site-form",
+    });
+
+    click(
+      await screen.findByLabelText("Open html preview for Form launch site"),
+    );
+    click(await screen.findByLabelText("Edit page"));
+
+    const frame = (await screen.findByTestId(
+      "html-dom-comment-frame",
+    )) as HTMLIFrameElement;
+    await waitFor(() => {
+      expect(
+        frame.contentDocument
+          ?.querySelector("input")
+          ?.hasAttribute(HTML_DOM_NODE_ID_ATTR),
+      ).toBeTruthy();
+      expect(
+        frame.contentDocument
+          ?.querySelector("textarea")
+          ?.hasAttribute(HTML_DOM_NODE_ID_ATTR),
+      ).toBeTruthy();
+    });
+
+    fireEvent.click(frame.contentDocument!.querySelector("input")!);
+    await waitFor(() => {
+      expect(screen.getByTestId("html-dom-color-controls")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("html-dom-color-control-color"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId("html-dom-color-control-backgroundColor"),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(frame.contentDocument!.querySelector("textarea")!);
+    await waitFor(() => {
+      expect(screen.getByTestId("html-dom-color-controls")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("html-dom-color-control-color"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId("html-dom-color-control-backgroundColor"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows hosted-site HTML color controls for semantic, select, and SVG text elements", async () => {
+    const htmlUrl = "https://styleable-launch-site.sites.vm7.io";
+
+    setupHostedSiteArtifactPreview({
+      filename: "styleable-launch-site.html",
+      html: `<!doctype html>
+      <html>
+        <head><title>Styleable launch site</title></head>
+        <body>
+          <main>
+            <figure>
+              <figcaption>Launch metrics</figcaption>
+            </figure>
+            <div class="text-card">
+              <h2 style="color: #111827;">Nested title</h2>
+            </div>
+            <select>
+              <option>Weekly plan</option>
+            </select>
+            <svg viewBox="0 0 200 40" width="200" height="40">
+              <text x="0" y="24" style="fill: #ff0000;">SVG label</text>
+            </svg>
+          </main>
+        </body>
+      </html>`,
+      htmlUrl,
+      label: "Styleable launch site",
+      runId: "run-hosted-site-styleable",
+    });
+
+    click(
+      await screen.findByLabelText(
+        "Open html preview for Styleable launch site",
+      ),
+    );
+    click(await screen.findByLabelText("Edit page"));
+
+    const frame = (await screen.findByTestId(
+      "html-dom-comment-frame",
+    )) as HTMLIFrameElement;
+    await waitFor(() => {
+      expect(
+        frame.contentDocument
+          ?.querySelector("figure")
+          ?.hasAttribute(HTML_DOM_NODE_ID_ATTR),
+      ).toBeTruthy();
+      expect(
+        frame.contentDocument
+          ?.querySelector(".text-card")
+          ?.hasAttribute(HTML_DOM_NODE_ID_ATTR),
+      ).toBeTruthy();
+      expect(
+        frame.contentDocument
+          ?.querySelector("select")
+          ?.hasAttribute(HTML_DOM_NODE_ID_ATTR),
+      ).toBeTruthy();
+      expect(
+        frame.contentDocument
+          ?.querySelector("text")
+          ?.hasAttribute(HTML_DOM_NODE_ID_ATTR),
+      ).toBeTruthy();
+    });
+
+    fireEvent.click(frame.contentDocument!.querySelector("figure")!);
+    await waitFor(() => {
+      expect(screen.getByTestId("html-dom-color-controls")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("html-dom-color-control-color"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId("html-dom-color-control-backgroundColor"),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(frame.contentDocument!.querySelector("select")!);
+    await waitFor(() => {
+      expect(screen.getByTestId("html-dom-color-controls")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("html-dom-color-control-color"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId("html-dom-color-control-backgroundColor"),
+      ).toBeInTheDocument();
+    });
+
+    const textCard = frame.contentDocument!.querySelector(".text-card");
+    const nestedTitle = frame.contentDocument!.querySelector("h2");
+    expect(textCard).not.toBeNull();
+    expect(nestedTitle).not.toBeNull();
+    fireEvent.click(textCard!);
+    await waitFor(() => {
+      expect(screen.getByTestId("html-dom-color-controls")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("html-dom-color-control-color"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId("html-dom-color-control-backgroundColor"),
+      ).toBeInTheDocument();
+    });
+    click(screen.getByTestId("html-dom-color-control-color"));
+    fireEvent.change(screen.getByLabelText("R"), { target: { value: "37" } });
+    fireEvent.change(screen.getByLabelText("G"), { target: { value: "99" } });
+    fireEvent.change(screen.getByLabelText("B"), { target: { value: "235" } });
+    await waitFor(() => {
+      expect(nestedTitle?.style.color).toBe("#2563EB");
+    });
+
+    const svgText = frame.contentDocument!.querySelector("text");
+    expect(svgText).not.toBeNull();
+    fireEvent.click(svgText!);
+    await waitFor(() => {
+      expect(screen.getByTestId("html-dom-color-controls")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("html-dom-color-control-color"),
+      ).toHaveTextContent("#ff0000");
+      expect(
+        screen.queryByTestId("html-dom-color-control-backgroundColor"),
+      ).toBeNull();
+    });
+
+    click(screen.getByTestId("html-dom-color-control-color"));
+    fireEvent.change(screen.getByLabelText("R"), { target: { value: "37" } });
+    fireEvent.change(screen.getByLabelText("G"), { target: { value: "99" } });
+    fireEvent.change(screen.getByLabelText("B"), { target: { value: "235" } });
+    await waitFor(() => {
+      expect(svgText?.style.getPropertyValue("fill")).toBe("#2563EB");
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/html-dom-comment-editor.tsx
+++ b/turbo/apps/platform/src/views/zero-page/html-dom-comment-editor.tsx
@@ -1,15 +1,18 @@
-import type { KeyboardEvent } from "react";
+import type { KeyboardEvent, PointerEvent } from "react";
 import {
   IconArrowUp,
+  IconColorPicker,
   IconLoader2,
   IconMessageCircle,
   IconSend,
   IconTrash,
 } from "@tabler/icons-react";
 import { useGet, useSet } from "ccstate-react";
-import { detach, Reason } from "../../signals/utils.ts";
+import { detach, Reason, tapError } from "../../signals/utils.ts";
 import {
   addHtmlDomComment$,
+  applyHtmlDomColorStyle$,
+  applyHtmlDomStyleEdits$,
   beginEditingCurrentHtmlDomComment$,
   bindHtmlDomCommentFrame$,
   deleteHtmlDomComment$,
@@ -17,11 +20,14 @@ import {
   focusHtmlDomComment$,
   htmlDomCommentEditorModel$,
   sendHtmlDomEditRequest$,
+  setHtmlDomColorPopoverOffset$,
   setHtmlDomCommentIframeRef$,
   setHtmlDomCommentStageRef$,
   setHtmlDomCommentTextareaRef$,
   setHtmlDomCommentText$,
+  toggleHtmlDomColorPanel$,
   toggleHtmlDomCommentsOpen$,
+  type HtmlDomStyleProperty,
   type HtmlDomCommentEditorModel,
 } from "../../signals/zero-page/html-dom-comment-editor.ts";
 import type {
@@ -33,6 +39,7 @@ import type {
 interface HtmlDomCommentEditorProps {
   readonly filename: string;
   readonly onApplyEditDraft?: (draft: HtmlDomEditDraft) => Promise<void>;
+  readonly onApplyStyleEdits?: (html: string) => Promise<void>;
   readonly onClose: () => void;
   readonly onEditRequestFailed?: () => void;
   readonly onEditRequestStarted?: () => void;
@@ -46,6 +53,7 @@ function HtmlDomCommentStage({
   filename,
   model,
   onApplyEditDraft,
+  onApplyStyleEdits,
   onEditRequestFailed,
   onEditRequestStarted,
   onSubmitEditRequest,
@@ -56,6 +64,7 @@ function HtmlDomCommentStage({
   readonly filename: string;
   readonly model: HtmlDomCommentEditorModel;
   readonly onApplyEditDraft?: (draft: HtmlDomEditDraft) => Promise<void>;
+  readonly onApplyStyleEdits?: (html: string) => Promise<void>;
   readonly onEditRequestFailed?: () => void;
   readonly onEditRequestStarted?: () => void;
   readonly onSubmitEditRequest?: (payload: HtmlDomEditPayload) => Promise<void>;
@@ -100,10 +109,12 @@ function HtmlDomCommentStage({
         />
       )}
       {!working && <HtmlDomCommentPopover model={model} />}
+      {!working && <HtmlDomFloatingColorPopover model={model} />}
       <HtmlDomCommentToolbar
         disabled={working}
         model={model}
         onApplyEditDraft={onApplyEditDraft}
+        onApplyStyleEdits={onApplyStyleEdits}
         onEditRequestFailed={onEditRequestFailed}
         onEditRequestStarted={onEditRequestStarted}
         onSubmitEditRequest={onSubmitEditRequest}
@@ -190,6 +201,7 @@ function HtmlDomCommentToolbar({
   disabled,
   model,
   onApplyEditDraft,
+  onApplyStyleEdits,
   onEditRequestFailed,
   onEditRequestStarted,
   onSubmitEditRequest,
@@ -198,14 +210,19 @@ function HtmlDomCommentToolbar({
   readonly disabled: boolean;
   readonly model: HtmlDomCommentEditorModel;
   readonly onApplyEditDraft?: (draft: HtmlDomEditDraft) => Promise<void>;
+  readonly onApplyStyleEdits?: (html: string) => Promise<void>;
   readonly onEditRequestFailed?: () => void;
   readonly onEditRequestStarted?: () => void;
   readonly onSubmitEditRequest?: (payload: HtmlDomEditPayload) => Promise<void>;
   readonly pageSignal: AbortSignal;
 }) {
+  const applyStyleEdits = useSet(applyHtmlDomStyleEdits$);
   const discardComments = useSet(discardHtmlDomComments$);
   const sendEditRequest = useSet(sendHtmlDomEditRequest$);
   const toggleCommentsOpen = useSet(toggleHtmlDomCommentsOpen$);
+  const primaryAction = model.comments.length > 0 ? "send" : "apply";
+  const canRunPrimaryAction =
+    primaryAction === "send" ? model.canSend : model.canApplyStyleEdits;
 
   return (
     <div className="pointer-events-none absolute inset-x-0 bottom-4 z-30 flex justify-center px-4">
@@ -247,8 +264,23 @@ function HtmlDomCommentToolbar({
           <button
             type="button"
             className="inline-flex h-9 items-center justify-center gap-2 rounded-full bg-blue-600 px-4 text-sm font-medium text-white transition-colors hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-45"
-            disabled={disabled || !model.canSend}
+            disabled={disabled || !canRunPrimaryAction}
             onClick={() => {
+              if (primaryAction === "apply") {
+                detach(
+                  applyStyleEdits(
+                    {
+                      onApplied: onApplyStyleEdits,
+                      onFailed: onEditRequestFailed,
+                      onStarted: onEditRequestStarted,
+                    },
+                    pageSignal,
+                  ),
+                  Reason.DomCallback,
+                  "applyHtmlDomStyleEdits",
+                );
+                return;
+              }
               detach(
                 sendEditRequest(
                   {
@@ -270,10 +302,577 @@ function HtmlDomCommentToolbar({
             ) : (
               <IconSend size={16} stroke={1.9} />
             )}
-            {model.submitting || disabled ? "Working" : "Send"}
+            {model.submitting || disabled
+              ? "Working"
+              : primaryAction === "apply"
+                ? "Apply"
+                : "Send"}
           </button>
         </div>
       </div>
+    </div>
+  );
+}
+
+function colorControlLabel(property: HtmlDomStyleProperty): string {
+  return property === "color" ? "Text" : "Background";
+}
+
+function colorControlValue({
+  model,
+  property,
+}: {
+  readonly model: HtmlDomCommentEditorModel;
+  readonly property: HtmlDomStyleProperty;
+}): string {
+  return property === "color"
+    ? model.selectedStyle.color
+    : model.selectedStyle.backgroundColor;
+}
+
+interface RgbColor {
+  readonly blue: number;
+  readonly green: number;
+  readonly red: number;
+}
+
+interface HsvColor {
+  readonly hue: number;
+  readonly saturation: number;
+  readonly value: number;
+}
+
+interface BrowserEyeDropper {
+  readonly open: () => Promise<{ readonly sRGBHex: string }>;
+}
+
+type BrowserEyeDropperConstructor = new () => BrowserEyeDropper;
+
+type EyeDropperGlobal = typeof globalThis & {
+  readonly EyeDropper?: BrowserEyeDropperConstructor;
+};
+
+function browserEyeDropperConstructor(): BrowserEyeDropperConstructor | null {
+  return (globalThis as EyeDropperGlobal).EyeDropper ?? null;
+}
+
+function clampColorChannel(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(0, Math.min(255, Math.round(value)));
+}
+
+function hexToRgb(hex: string): RgbColor {
+  const normalized = /^#[0-9a-f]{6}$/i.test(hex) ? hex.slice(1) : "111827";
+  return {
+    red: Number.parseInt(normalized.slice(0, 2), 16),
+    green: Number.parseInt(normalized.slice(2, 4), 16),
+    blue: Number.parseInt(normalized.slice(4, 6), 16),
+  };
+}
+
+function rgbToHex(color: RgbColor): string {
+  return `#${[color.red, color.green, color.blue]
+    .map((channel) => {
+      return clampColorChannel(channel).toString(16).padStart(2, "0");
+    })
+    .join("")
+    .toUpperCase()}`;
+}
+
+function rgbToHsv(color: RgbColor): HsvColor {
+  const red = color.red / 255;
+  const green = color.green / 255;
+  const blue = color.blue / 255;
+  const max = Math.max(red, green, blue);
+  const min = Math.min(red, green, blue);
+  const delta = max - min;
+  let hue = 0;
+
+  if (delta !== 0) {
+    if (max === red) {
+      hue = ((green - blue) / delta) % 6;
+    } else if (max === green) {
+      hue = (blue - red) / delta + 2;
+    } else {
+      hue = (red - green) / delta + 4;
+    }
+    hue *= 60;
+  }
+
+  return {
+    hue: hue < 0 ? hue + 360 : hue,
+    saturation: max === 0 ? 0 : delta / max,
+    value: max,
+  };
+}
+
+function hsvToRgb(color: HsvColor): RgbColor {
+  const chroma = color.value * color.saturation;
+  const hueSegment = color.hue / 60;
+  const secondary = chroma * (1 - Math.abs((hueSegment % 2) - 1));
+  const match = color.value - chroma;
+  let red = 0;
+  let green = 0;
+  let blue = 0;
+
+  if (hueSegment >= 0 && hueSegment < 1) {
+    red = chroma;
+    green = secondary;
+  } else if (hueSegment < 2) {
+    red = secondary;
+    green = chroma;
+  } else if (hueSegment < 3) {
+    green = chroma;
+    blue = secondary;
+  } else if (hueSegment < 4) {
+    green = secondary;
+    blue = chroma;
+  } else if (hueSegment < 5) {
+    red = secondary;
+    blue = chroma;
+  } else {
+    red = chroma;
+    blue = secondary;
+  }
+
+  return {
+    red: clampColorChannel((red + match) * 255),
+    green: clampColorChannel((green + match) * 255),
+    blue: clampColorChannel((blue + match) * 255),
+  };
+}
+
+function HtmlDomColorControl({
+  active,
+  model,
+  onClick,
+  property,
+}: {
+  readonly active: boolean;
+  readonly model: HtmlDomCommentEditorModel;
+  readonly onClick: () => void;
+  readonly property: HtmlDomStyleProperty;
+}) {
+  const value = colorControlValue({ model, property });
+
+  return (
+    <button
+      type="button"
+      aria-expanded={active}
+      aria-label={`Open ${property === "color" ? "text" : "background"} color panel`}
+      className={`flex h-16 w-[168px] shrink-0 items-center justify-between gap-2 rounded-lg px-3 py-2 text-left transition focus:outline-none focus:ring-2 focus:ring-blue-500/30 ${
+        active ? "bg-muted" : "bg-muted/55 hover:bg-muted/80"
+      }`}
+      data-testid={`html-dom-color-control-${property}`}
+      onClick={onClick}
+    >
+      <span className="min-w-0">
+        <span className="block text-[11px] font-medium leading-3 text-muted-foreground">
+          {colorControlLabel(property)}
+        </span>
+        <span className="mt-0.5 block truncate font-mono text-[12px] font-medium text-foreground">
+          {value.toLowerCase()}
+        </span>
+      </span>
+      <span
+        className={`h-7 w-7 shrink-0 rounded-full border shadow-sm transition ${
+          active
+            ? "border-foreground ring-2 ring-foreground/20 ring-offset-1"
+            : "border-border/80"
+        }`}
+        style={{ backgroundColor: value }}
+      />
+    </button>
+  );
+}
+
+function HtmlDomColorField({
+  activeProperty,
+  hsv,
+  hueHex,
+  onPick,
+}: {
+  readonly activeProperty: HtmlDomStyleProperty;
+  readonly hsv: HsvColor;
+  readonly hueHex: string;
+  readonly onPick: (hsv: HsvColor) => void;
+}) {
+  const handlePick = (event: PointerEvent<HTMLButtonElement>): void => {
+    const rect = event.currentTarget.getBoundingClientRect();
+    onPick({
+      hue: hsv.hue,
+      saturation: Math.max(
+        0,
+        Math.min(1, (event.clientX - rect.left) / rect.width),
+      ),
+      value:
+        1 - Math.max(0, Math.min(1, (event.clientY - rect.top) / rect.height)),
+    });
+  };
+
+  return (
+    <button
+      type="button"
+      aria-label={`Pick ${activeProperty === "backgroundColor" ? "background" : "text"} color saturation and brightness`}
+      className="relative block h-28 w-full cursor-crosshair border-0 p-0 focus:outline-none focus:ring-2 focus:ring-blue-500"
+      data-testid="html-dom-color-field"
+      style={{ backgroundColor: hueHex }}
+      onPointerDown={(event) => {
+        event.preventDefault();
+        event.currentTarget.setPointerCapture?.(event.pointerId);
+        handlePick(event);
+      }}
+      onPointerMove={(event) => {
+        if (event.buttons !== 1) {
+          return;
+        }
+        handlePick(event);
+      }}
+    >
+      <span className="absolute inset-0 bg-gradient-to-r from-white to-transparent" />
+      <span className="absolute inset-0 bg-gradient-to-t from-black to-transparent" />
+      <span
+        className="absolute h-5 w-5 -translate-x-1/2 -translate-y-1/2 rounded-full border-[3px] border-white shadow-[0_0_0_1px_rgba(0,0,0,0.55),0_2px_8px_rgba(0,0,0,0.25)]"
+        style={{
+          left: `${hsv.saturation * 100}%`,
+          top: `${(1 - hsv.value) * 100}%`,
+        }}
+      />
+    </button>
+  );
+}
+
+function HtmlDomHueSlider({
+  hsv,
+  hueHex,
+  onChange,
+}: {
+  readonly hsv: HsvColor;
+  readonly hueHex: string;
+  readonly onChange: (hue: number) => void;
+}) {
+  const handlePick = (event: PointerEvent<HTMLButtonElement>): void => {
+    const rect = event.currentTarget.getBoundingClientRect();
+    const percent = Math.max(
+      0,
+      Math.min(1, (event.clientX - rect.left) / rect.width),
+    );
+    onChange(percent * 360);
+  };
+
+  return (
+    <button
+      type="button"
+      aria-label="Hue"
+      className="relative h-7 min-w-0 flex-1 cursor-pointer border-0 bg-transparent p-0 focus:outline-none focus:ring-2 focus:ring-blue-500/25"
+      data-testid="html-dom-color-hue-slider"
+      onPointerDown={(event) => {
+        event.preventDefault();
+        event.currentTarget.setPointerCapture?.(event.pointerId);
+        handlePick(event);
+      }}
+      onPointerMove={(event) => {
+        if (event.buttons !== 1) {
+          return;
+        }
+        handlePick(event);
+      }}
+    >
+      <div
+        className="absolute left-0 right-0 top-1/2 h-3 -translate-y-1/2 rounded-full shadow-inner"
+        style={{
+          background:
+            "linear-gradient(90deg, #ff0000, #ffff00, #00ff00, #00ffff, #0000ff, #ff00ff, #ff0000)",
+        }}
+      />
+      <span
+        className="pointer-events-none absolute top-1/2 h-5 w-5 -translate-x-1/2 -translate-y-1/2 rounded-full border-[3px] border-white shadow-[0_0_0_1px_rgba(15,23,42,0.25),0_2px_5px_rgba(15,23,42,0.18)]"
+        style={{
+          left: `${(hsv.hue / 360) * 100}%`,
+          backgroundColor: hueHex,
+        }}
+      />
+    </button>
+  );
+}
+
+function HtmlDomRgbInputs({
+  onChange,
+  rgb,
+}: {
+  readonly onChange: (channel: keyof RgbColor, value: string) => void;
+  readonly rgb: RgbColor;
+}) {
+  return (
+    <div className="grid grid-cols-3 gap-1.5">
+      {(
+        [
+          ["red", "R", rgb.red],
+          ["green", "G", rgb.green],
+          ["blue", "B", rgb.blue],
+        ] as const
+      ).map(([channel, label, value]) => {
+        return (
+          <label
+            key={channel}
+            className="flex h-8 min-w-0 items-center rounded-lg border border-border/70 bg-muted/45 px-2 focus-within:border-blue-500 focus-within:bg-background focus-within:ring-2 focus-within:ring-blue-500/15"
+          >
+            <span className="w-4 text-[11px] font-semibold text-muted-foreground">
+              {label}
+            </span>
+            <input
+              type="number"
+              min={0}
+              max={255}
+              value={value}
+              aria-label={label}
+              className="h-full min-w-0 flex-1 border-0 bg-transparent px-1 text-right text-sm font-medium tabular-nums text-foreground outline-none"
+              onInput={(event) => {
+                onChange(channel, event.currentTarget.value);
+              }}
+              onChange={(event) => {
+                onChange(channel, event.currentTarget.value);
+              }}
+            />
+          </label>
+        );
+      })}
+    </div>
+  );
+}
+
+function HtmlDomEyeDropperButton({
+  onPick,
+}: {
+  readonly onPick: (value: string) => void;
+}) {
+  const EyeDropper = browserEyeDropperConstructor();
+  if (!EyeDropper) {
+    return null;
+  }
+
+  const pickColor = async (): Promise<void> => {
+    const result = await tapError(new EyeDropper().open(), () => {
+      return undefined;
+    });
+    if (result) {
+      onPick(result.sRGBHex.toUpperCase());
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      aria-label="Pick color from screen"
+      title="Pick color from screen"
+      className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-border/70 bg-muted/45 text-muted-foreground transition hover:bg-muted/80 hover:text-foreground focus:outline-none focus:ring-2 focus:ring-blue-500/25"
+      data-testid="html-dom-color-eyedropper"
+      onClick={() => {
+        detach(pickColor(), Reason.DomCallback, "pickHtmlDomColor");
+      }}
+    >
+      <IconColorPicker size={15} stroke={1.9} />
+    </button>
+  );
+}
+
+function numericDragValue(value: string | undefined): number {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : 0;
+}
+
+function HtmlDomColorPopoverDragHandle({
+  model,
+}: {
+  readonly model: HtmlDomCommentEditorModel;
+}) {
+  const setOffset = useSet(setHtmlDomColorPopoverOffset$);
+
+  return (
+    <button
+      type="button"
+      aria-label="Drag color panel"
+      className="flex h-4 w-full cursor-grab items-center justify-center border-0 bg-transparent p-0 active:cursor-grabbing"
+      data-testid="html-dom-color-popover-drag-handle"
+      onPointerDown={(event) => {
+        event.preventDefault();
+        event.currentTarget.setPointerCapture?.(event.pointerId);
+        event.currentTarget.dataset.dragStartX = String(event.clientX);
+        event.currentTarget.dataset.dragStartY = String(event.clientY);
+        event.currentTarget.dataset.dragStartLeft = String(
+          model.colorPopoverOffset.left,
+        );
+        event.currentTarget.dataset.dragStartTop = String(
+          model.colorPopoverOffset.top,
+        );
+      }}
+      onPointerMove={(event) => {
+        if (
+          event.buttons !== 1 ||
+          event.currentTarget.dataset.dragStartX === undefined
+        ) {
+          return;
+        }
+        setOffset({
+          left:
+            numericDragValue(event.currentTarget.dataset.dragStartLeft) +
+            event.clientX -
+            numericDragValue(event.currentTarget.dataset.dragStartX),
+          top:
+            numericDragValue(event.currentTarget.dataset.dragStartTop) +
+            event.clientY -
+            numericDragValue(event.currentTarget.dataset.dragStartY),
+        });
+      }}
+      onPointerUp={(event) => {
+        event.currentTarget.releasePointerCapture?.(event.pointerId);
+        delete event.currentTarget.dataset.dragStartX;
+      }}
+    >
+      <span className="h-1 w-10 rounded-full bg-muted-foreground/25" />
+    </button>
+  );
+}
+
+function HtmlDomColorPopover({
+  activeProperty,
+  model,
+}: {
+  readonly activeProperty: HtmlDomStyleProperty;
+  readonly model: HtmlDomCommentEditorModel;
+}) {
+  const applyColorStyle = useSet(applyHtmlDomColorStyle$);
+  const activeValue = colorControlValue({
+    model,
+    property: activeProperty,
+  }).toUpperCase();
+  const rgb = hexToRgb(activeValue);
+  const hsv = rgbToHsv(rgb);
+  const hueHex = rgbToHex(
+    hsvToRgb({
+      hue: hsv.hue,
+      saturation: 1,
+      value: 1,
+    }),
+  );
+  const applyHex = (value: string) => {
+    applyColorStyle({ property: activeProperty, value });
+  };
+  const handleHueChange = (hue: number): void => {
+    applyHex(
+      rgbToHex(
+        hsvToRgb({
+          hue,
+          saturation: hsv.saturation,
+          value: hsv.value,
+        }),
+      ),
+    );
+  };
+  const handleRgbChange = (channel: keyof RgbColor, value: string): void => {
+    applyHex(
+      rgbToHex({
+        ...rgb,
+        [channel]: clampColorChannel(Number(value)),
+      }),
+    );
+  };
+
+  return (
+    <div
+      className="overflow-hidden rounded-xl border border-border/70 bg-background/98 shadow-lg"
+      data-testid="html-dom-color-popover"
+    >
+      <HtmlDomColorPopoverDragHandle model={model} />
+      <HtmlDomColorField
+        activeProperty={activeProperty}
+        hsv={hsv}
+        hueHex={hueHex}
+        onPick={(nextHsv) => {
+          applyHex(rgbToHex(hsvToRgb(nextHsv)));
+        }}
+      />
+      <div className="space-y-2 p-2.5">
+        <div className="flex items-center gap-2">
+          <HtmlDomEyeDropperButton onPick={applyHex} />
+          <div
+            className="h-7 w-7 shrink-0 rounded-full border border-border/80 shadow-sm"
+            style={{ backgroundColor: activeValue }}
+          />
+          <HtmlDomHueSlider
+            hsv={hsv}
+            hueHex={hueHex}
+            onChange={handleHueChange}
+          />
+        </div>
+        <HtmlDomRgbInputs rgb={rgb} onChange={handleRgbChange} />
+      </div>
+    </div>
+  );
+}
+
+function HtmlDomColorControls({
+  model,
+}: {
+  readonly model: HtmlDomCommentEditorModel;
+}) {
+  const toggleColorPanel = useSet(toggleHtmlDomColorPanel$);
+  const activeProperty = model.activeColorPanelProperty;
+  if (model.editableStyleProperties.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mt-2" data-testid="html-dom-color-controls">
+      <div className="flex flex-wrap gap-1.5">
+        {model.editableStyleProperties.map((property) => {
+          const active = activeProperty === property;
+          return (
+            <HtmlDomColorControl
+              key={property}
+              active={active}
+              model={model}
+              property={property}
+              onClick={() => {
+                toggleColorPanel(property);
+              }}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function HtmlDomFloatingColorPopover({
+  model,
+}: {
+  readonly model: HtmlDomCommentEditorModel;
+}) {
+  const activeProperty = model.activeColorPanelProperty;
+  if (
+    activeProperty === null ||
+    !model.editableStyleProperties.includes(activeProperty) ||
+    !model.commentPopoverAnchor
+  ) {
+    return null;
+  }
+
+  return (
+    <div
+      className="absolute z-40 w-[min(280px,calc(100%-24px))] -translate-x-1/2"
+      style={{
+        left: model.commentPopoverAnchor.left + model.colorPopoverOffset.left,
+        top: Math.max(
+          12,
+          model.commentPopoverAnchor.top + 104 + model.colorPopoverOffset.top,
+        ),
+      }}
+      data-testid="html-dom-floating-color-popover"
+    >
+      <HtmlDomColorPopover activeProperty={activeProperty} model={model} />
     </div>
   );
 }
@@ -316,50 +915,53 @@ function HtmlDomCommentPopover({
 
   return (
     <div
-      className="absolute z-30 flex w-[min(380px,calc(100%-24px))] -translate-x-1/2 items-end gap-2 rounded-[28px] border border-border/60 bg-background px-3 py-2 shadow-lg"
+      className="absolute z-30 w-[min(380px,calc(100%-24px))] -translate-x-1/2 rounded-[28px] border border-border/60 bg-background p-2.5 shadow-lg"
       style={{
         left: model.commentPopoverAnchor.left,
         top: model.commentPopoverAnchor.top,
       }}
       data-testid="html-dom-comment-popover"
     >
-      <textarea
-        key={model.popoverTextAreaKey}
-        ref={setTextAreaRef}
-        rows={1}
-        value={visibleCommentText}
-        readOnly={isShowingExistingComment}
-        onClick={() => {
-          if (isShowingExistingComment) {
-            beginEditingCurrentComment();
-          }
-        }}
-        onFocus={() => {
-          if (isShowingExistingComment) {
-            beginEditingCurrentComment();
-          }
-        }}
-        onChange={(event) => {
-          if (isShowingExistingComment) {
-            return;
-          }
-          setCommentText(event.currentTarget.value);
-        }}
-        onKeyDown={handleTextAreaKeyDown}
-        placeholder="Describe the change you want"
-        className="max-h-32 min-h-9 min-w-0 flex-1 resize-none overflow-y-auto border-0 bg-transparent px-1 py-2 text-sm leading-5 outline-none [field-sizing:content] placeholder:text-muted-foreground"
-        data-testid="html-dom-comment-textarea"
-      />
-      <button
-        type="button"
-        disabled={!model.canAddComment}
-        onClick={addComment}
-        className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-blue-600 text-white transition-colors hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-45"
-        data-testid="html-dom-comment-add"
-        aria-label="Add comment"
-      >
-        <IconArrowUp size={19} stroke={2.2} />
-      </button>
+      <div className="flex items-end gap-2">
+        <textarea
+          key={model.popoverTextAreaKey}
+          ref={setTextAreaRef}
+          rows={1}
+          value={visibleCommentText}
+          readOnly={isShowingExistingComment}
+          onClick={() => {
+            if (isShowingExistingComment) {
+              beginEditingCurrentComment();
+            }
+          }}
+          onFocus={() => {
+            if (isShowingExistingComment) {
+              beginEditingCurrentComment();
+            }
+          }}
+          onChange={(event) => {
+            if (isShowingExistingComment) {
+              return;
+            }
+            setCommentText(event.currentTarget.value);
+          }}
+          onKeyDown={handleTextAreaKeyDown}
+          placeholder="Describe the change you want"
+          className="max-h-32 min-h-9 min-w-0 flex-1 resize-none overflow-y-auto border-0 bg-transparent px-1 py-2 text-sm leading-5 outline-none [field-sizing:content] placeholder:text-muted-foreground"
+          data-testid="html-dom-comment-textarea"
+        />
+        <button
+          type="button"
+          disabled={!model.canAddComment}
+          onClick={addComment}
+          className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-blue-600 text-white transition-colors hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-45"
+          data-testid="html-dom-comment-add"
+          aria-label="Add comment"
+        >
+          <IconArrowUp size={19} stroke={2.2} />
+        </button>
+      </div>
+      <HtmlDomColorControls model={model} />
     </div>
   );
 }
@@ -367,6 +969,7 @@ function HtmlDomCommentPopover({
 export function HtmlDomCommentEditor({
   filename,
   onApplyEditDraft,
+  onApplyStyleEdits,
   onEditRequestFailed,
   onEditRequestStarted,
   onSubmitEditRequest,
@@ -391,6 +994,7 @@ export function HtmlDomCommentEditor({
         pageSignal={pageSignal}
         status={status}
         url={url}
+        onApplyStyleEdits={onApplyStyleEdits}
       />
     </div>
   );

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -205,6 +205,12 @@ function shouldOpenHtmlCommentMode(
   );
 }
 
+function isHtmlEditFeatureEnabled(
+  features: Record<string, boolean> | null | undefined,
+): boolean {
+  return Boolean(features?.[FeatureSwitchKey.HtmlArtifactCommentEditing]);
+}
+
 function ArtifactSidebarContent({
   agentId,
   artifactRef,
@@ -225,19 +231,19 @@ function ArtifactSidebarContent({
   const closeHtmlCommentMode = useSet(closeArtifactHtmlEditMode$);
   const markHtmlDomEditPending = useSet(markHtmlDomEditPending$);
   const openHtmlCommentMode = useSet(openArtifactHtmlEditMode$);
+  const publishHtmlDomEditPreviewDraft = useSet(
+    publishHtmlDomEditPreviewDraft$,
+  );
   const toggleFullscreen = useSet(toggleArtifactFullscreen$);
   const resetZoomableImageCanvasZoom = useSet(resetZoomableImageCanvasZoom$);
   const pageSignal = useGet(pageSignal$);
   const closePreview = onClose ?? close;
   const openPresentationEditor = useSet(openPresentationEditor$);
   const features = useLastResolved(featureSwitch$);
-  const htmlEditFeatureEnabled = Boolean(
-    features?.[FeatureSwitchKey.HtmlArtifactCommentEditing],
-  );
 
   const display = resolveArtifactDisplay(artifactRef, item);
   const htmlCommentMode =
-    htmlEditFeatureEnabled &&
+    isHtmlEditFeatureEnabled(features) &&
     shouldOpenHtmlCommentMode(display, requestedHtmlCommentMode);
   const syncTarget = artifactSidebarSyncTargetForItem({
     agentId,
@@ -263,16 +269,15 @@ function ArtifactSidebarContent({
   });
 
   if (!display) {
-    return (
-      <ArtifactUnavailableSidebar
-        fullscreen={fullscreen}
-        onBack={onBack}
-        onClose={closePreview}
-        onToggleFullscreen={toggleFullscreen}
-      />
-    );
+    return null;
   }
 
+  const applyHtmlStyleEdits = createHtmlStyleEditApplyAction({
+    display,
+    htmlEditState,
+    pageSignal,
+    publishPreviewDraft: publishHtmlDomEditPreviewDraft,
+  });
   const editPresentation =
     display.artifactKind === "presentation-html"
       ? () => {
@@ -286,14 +291,6 @@ function ArtifactSidebarContent({
     htmlHeaderState === "idle"
       ? openHtmlCommentMode
       : undefined;
-  const toggleFullscreenWithImageReset = () => {
-    resetArtifactSidebarImageZoom({
-      display,
-      fullscreen,
-      resetZoomableImageCanvasZoom,
-    });
-    toggleFullscreen();
-  };
   const exitHtmlEdit = htmlEditExitAction(
     htmlHeaderState,
     closeHtmlCommentMode,
@@ -314,7 +311,14 @@ function ArtifactSidebarContent({
         onEditHtml={editHtml}
         onExitHtmlEdit={exitHtmlEdit}
         onBack={onBack}
-        onToggleFullscreen={toggleFullscreenWithImageReset}
+        onToggleFullscreen={() => {
+          resetArtifactSidebarImageZoom({
+            display,
+            fullscreen,
+            resetZoomableImageCanvasZoom,
+          });
+          toggleFullscreen();
+        }}
         onClose={closePreview}
       />
       <div className="min-h-0 flex-1 overflow-hidden bg-background">
@@ -328,38 +332,11 @@ function ArtifactSidebarContent({
           htmlCommentMode={htmlCommentMode}
           onCloseHtmlCommentMode={closeHtmlCommentMode}
           onApplyHtmlEditDraft={htmlEditState.apply}
+          onApplyHtmlStyleEdits={applyHtmlStyleEdits}
           onHtmlEditRequestFailed={htmlEditState.fail}
           onHtmlEditRequestStarted={htmlEditState.start}
           pageSignal={pageSignal}
         />
-      </div>
-    </ArtifactSidebarSurface>
-  );
-}
-
-function ArtifactUnavailableSidebar({
-  fullscreen,
-  onBack,
-  onClose,
-  onToggleFullscreen,
-}: {
-  fullscreen: boolean;
-  onBack?: () => void;
-  onClose: () => void;
-  onToggleFullscreen: () => void;
-}) {
-  return (
-    <ArtifactSidebarSurface fullscreen={fullscreen}>
-      <ArtifactSidebarHeader
-        title="Artifact unavailable"
-        subtitle="Unavailable"
-        fullscreen={fullscreen}
-        onBack={onBack}
-        onToggleFullscreen={onToggleFullscreen}
-        onClose={onClose}
-      />
-      <div className="flex flex-1 items-center justify-center p-6 text-sm text-muted-foreground">
-        Unsupported artifact reference.
       </div>
     </ArtifactSidebarSurface>
   );
@@ -411,6 +388,30 @@ function createHtmlEditState({
     },
     previewHtml,
     status,
+  };
+}
+
+function createHtmlStyleEditApplyAction({
+  display,
+  htmlEditState,
+  pageSignal,
+  publishPreviewDraft,
+}: {
+  display: ArtifactDisplay;
+  htmlEditState: ReturnType<typeof createHtmlEditState>;
+  pageSignal: AbortSignal;
+  publishPreviewDraft: (url: string, signal: AbortSignal) => Promise<void>;
+}) {
+  if (display.kind !== "html" || !htmlEditState.apply) {
+    return undefined;
+  }
+  return async (html: string) => {
+    await htmlEditState.apply({
+      comments: [],
+      editRequestId: crypto.randomUUID(),
+      html,
+    });
+    await publishPreviewDraft(display.url, pageSignal);
   };
 }
 
@@ -931,6 +932,7 @@ function ArtifactBody({
   htmlCommentMode,
   onCloseHtmlCommentMode,
   onApplyHtmlEditDraft,
+  onApplyHtmlStyleEdits,
   onHtmlEditRequestFailed,
   onHtmlEditRequestStarted,
   pageSignal,
@@ -944,6 +946,7 @@ function ArtifactBody({
   htmlCommentMode: boolean;
   onCloseHtmlCommentMode: () => void;
   onApplyHtmlEditDraft?: (draft: HtmlDomEditDraft) => Promise<void>;
+  onApplyHtmlStyleEdits?: (html: string) => Promise<void>;
   onHtmlEditRequestFailed?: () => void;
   onHtmlEditRequestStarted?: () => void;
   pageSignal: AbortSignal;
@@ -973,6 +976,7 @@ function ArtifactBody({
           key={url}
           filename={filename}
           onApplyEditDraft={onApplyHtmlEditDraft}
+          onApplyStyleEdits={onApplyHtmlStyleEdits}
           onClose={onCloseHtmlCommentMode}
           onEditRequestFailed={onHtmlEditRequestFailed}
           onEditRequestStarted={onHtmlEditRequestStarted}


### PR DESCRIPTION
## Summary
- add contextual Text/Background color controls for hosted-site DOM editing
- add a compact draggable color picker with eyedropper, hue, color field, RGB inputs, and instant preview
- apply color-only edits through direct redeploy while comment edits keep the existing agent flow
- hide unsupported artifact deep-link sidebars instead of showing an unavailable pane

## Validation
- `pnpm format`
- `pnpm lint`
- `pnpm check-types`
- `pnpm knip`
- `pnpm -F @vm0/app exec vitest`
- `pnpm -F @vm0/app exec vitest src/views/zero-page/__tests__/zero-attachment-chips.test.tsx src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx`

## Notes
- Full monorepo `pnpm test` was attempted locally and failed in unrelated API/firewall suites; the frontend `@vm0/app` workspace test suite passes.
