### PR TITLE
perf: avoid guest write-file payload copy

### DIFF
--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -730,6 +730,7 @@ mod tests {
             MSG_EXEC_CANCEL,
             MSG_EXEC_CONTROL,
             MSG_WRITE_FILE,
+            MSG_WRITE_FILES,
             MSG_QUIESCE_OPERATIONS,
             MSG_RESUME_OPERATIONS,
         ] {

--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -6,9 +6,9 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use vsock_proto::{
-    self, MSG_EXEC_CANCEL, MSG_EXEC_CONTROL, MSG_EXEC_START, MSG_OPERATIONS_QUIESCED,
-    MSG_OPERATIONS_RESUMED, MSG_QUIESCE_OPERATIONS, MSG_READY, MSG_RESUME_OPERATIONS,
-    MSG_WRITE_FILE, MSG_WRITE_FILES, RawMessage,
+    self, BorrowedRawMessage, DecodeWithError, MSG_EXEC_CANCEL, MSG_EXEC_CONTROL, MSG_EXEC_START,
+    MSG_OPERATIONS_QUIESCED, MSG_OPERATIONS_RESUMED, MSG_QUIESCE_OPERATIONS, MSG_READY,
+    MSG_RESUME_OPERATIONS, MSG_WRITE_FILE, MSG_WRITE_FILES,
 };
 
 use crate::error::to_io_error;
@@ -49,6 +49,11 @@ enum ReconnectFailure {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DispatchOutcome {
     Continue,
+    Shutdown,
+}
+
+enum DecodeDispatchError {
+    Dispatch(io::Error),
     Shutdown,
 }
 
@@ -252,7 +257,7 @@ impl ConnectionDispatcher {
         }
     }
 
-    fn dispatch(&self, msg: &RawMessage) -> io::Result<DispatchOutcome> {
+    fn dispatch(&self, msg: BorrowedRawMessage<'_>) -> io::Result<DispatchOutcome> {
         match msg.msg_type {
             MSG_EXEC_START => self.handle_exec_start(msg)?,
             MSG_EXEC_CANCEL => self.handle_exec_cancel(msg)?,
@@ -267,14 +272,14 @@ impl ConnectionDispatcher {
         Ok(DispatchOutcome::Continue)
     }
 
-    fn handle_exec_start(&self, msg: &RawMessage) -> io::Result<()> {
+    fn handle_exec_start(&self, msg: BorrowedRawMessage<'_>) -> io::Result<()> {
         if !require_non_zero_sequence(msg.seq, "exec start", &self.writer)? {
             return Ok(());
         }
         if reject_operation_if_quiescing(&self.operation_state, msg.seq, &self.writer)? {
             return Ok(());
         }
-        let decoded = match vsock_proto::decode_exec_start(&msg.payload) {
+        let decoded = match vsock_proto::decode_exec_start(msg.payload) {
             Ok(decoded) => decoded,
             Err(error) => {
                 send_error_response(msg.seq, &error.to_string(), &self.writer)?;
@@ -330,11 +335,11 @@ impl ConnectionDispatcher {
         )
     }
 
-    fn handle_exec_cancel(&self, msg: &RawMessage) -> io::Result<()> {
+    fn handle_exec_cancel(&self, msg: BorrowedRawMessage<'_>) -> io::Result<()> {
         if !require_non_zero_sequence(msg.seq, "exec cancel", &self.writer)? {
             return Ok(());
         }
-        if let Err(error) = vsock_proto::decode_exec_cancel(&msg.payload) {
+        if let Err(error) = vsock_proto::decode_exec_cancel(msg.payload) {
             log(
                 "WARN",
                 &format!(
@@ -347,11 +352,11 @@ impl ConnectionDispatcher {
         Ok(())
     }
 
-    fn handle_exec_control(&self, msg: &RawMessage) -> io::Result<()> {
+    fn handle_exec_control(&self, msg: BorrowedRawMessage<'_>) -> io::Result<()> {
         if !require_non_zero_sequence(msg.seq, "exec control", &self.writer)? {
             return Ok(());
         }
-        let decoded = match vsock_proto::decode_exec_control(&msg.payload) {
+        let decoded = match vsock_proto::decode_exec_control(msg.payload) {
             Ok(decoded) => decoded,
             Err(error) => {
                 send_error_response(msg.seq, &error.to_string(), &self.writer)?;
@@ -361,14 +366,14 @@ impl ConnectionDispatcher {
         route_exec_control(msg.seq, decoded, &self.exec_control_registry, &self.writer)
     }
 
-    fn handle_write_file(&self, msg: &RawMessage) -> io::Result<()> {
+    fn handle_write_file(&self, msg: BorrowedRawMessage<'_>) -> io::Result<()> {
         if !require_non_zero_sequence(msg.seq, "write_file", &self.writer)? {
             return Ok(());
         }
         if reject_operation_if_quiescing(&self.operation_state, msg.seq, &self.writer)? {
             return Ok(());
         }
-        let decoded = match decode_write_file_message(msg) {
+        let decoded = match decode_write_file_message(msg.payload) {
             Ok(decoded) => decoded,
             Err(error) => {
                 send_error_response(msg.seq, &error.to_string(), &self.writer)?;
@@ -386,14 +391,14 @@ impl ConnectionDispatcher {
         })
     }
 
-    fn handle_write_files(&self, msg: &RawMessage) -> io::Result<()> {
+    fn handle_write_files(&self, msg: BorrowedRawMessage<'_>) -> io::Result<()> {
         if !require_non_zero_sequence(msg.seq, "write_files", &self.writer)? {
             return Ok(());
         }
         if reject_operation_if_quiescing(&self.operation_state, msg.seq, &self.writer)? {
             return Ok(());
         }
-        let decoded = match decode_write_files_message(msg) {
+        let decoded = match decode_write_files_message(msg.payload) {
             Ok(decoded) => decoded,
             Err(error) => {
                 send_error_response(msg.seq, &error.to_string(), &self.writer)?;
@@ -411,15 +416,15 @@ impl ConnectionDispatcher {
         })
     }
 
-    fn handle_quiesce_operations(&self, msg: &RawMessage) -> io::Result<()> {
-        handle_quiesce_operations(msg.seq, &msg.payload, &self.operation_state, &self.writer)
+    fn handle_quiesce_operations(&self, msg: BorrowedRawMessage<'_>) -> io::Result<()> {
+        handle_quiesce_operations(msg.seq, msg.payload, &self.operation_state, &self.writer)
     }
 
-    fn handle_resume_operations(&self, msg: &RawMessage) -> io::Result<()> {
-        handle_resume_operations(msg.seq, &msg.payload, &self.operation_state, &self.writer)
+    fn handle_resume_operations(&self, msg: BorrowedRawMessage<'_>) -> io::Result<()> {
+        handle_resume_operations(msg.seq, msg.payload, &self.operation_state, &self.writer)
     }
 
-    fn handle_basic_message(&self, msg: &RawMessage) -> io::Result<DispatchOutcome> {
+    fn handle_basic_message(&self, msg: BorrowedRawMessage<'_>) -> io::Result<DispatchOutcome> {
         match handle_basic_message(msg)? {
             MessageOutcome::Response(response) => {
                 self.writer.write_frame(&response)?;
@@ -533,19 +538,26 @@ fn handle_connection_with_outcome(stream: UnixStream) -> Result<ConnectionEnd, C
         }
 
         // n <= buf.len() is guaranteed by read()
-        for msg in decoder
-            .decode(buf.get(..n).unwrap_or_default())
-            .map_err(to_io_error)
-            .map_err(|error| session.failure(error))?
-        {
-            if dispatcher
-                .dispatch(&msg)
-                .map_err(|error| session.failure(error))?
-                == DispatchOutcome::Shutdown
-            {
+        match decoder.decode_with(buf.get(..n).unwrap_or_default(), |msg| {
+            match dispatcher.dispatch(msg) {
+                Ok(DispatchOutcome::Continue) => {
+                    session.mark_real_host_work(msg.msg_type);
+                    Ok(())
+                }
+                Ok(DispatchOutcome::Shutdown) => Err(DecodeDispatchError::Shutdown),
+                Err(error) => Err(DecodeDispatchError::Dispatch(error)),
+            }
+        }) {
+            Ok(()) => {}
+            Err(DecodeWithError::Protocol(error)) => {
+                return Err(session.failure(to_io_error(error)));
+            }
+            Err(DecodeWithError::Visitor(DecodeDispatchError::Dispatch(error))) => {
+                return Err(session.failure(error));
+            }
+            Err(DecodeWithError::Visitor(DecodeDispatchError::Shutdown)) => {
                 return Ok(ConnectionEnd::Shutdown);
             }
-            session.mark_real_host_work(msg.msg_type);
         }
     }
 

--- a/crates/vsock-guest/src/handlers.rs
+++ b/crates/vsock-guest/src/handlers.rs
@@ -7,8 +7,8 @@ use std::sync::Mutex;
 use std::sync::atomic::AtomicBool;
 
 use vsock_proto::{
-    self, MSG_ERROR, MSG_PING, MSG_PONG, MSG_SHUTDOWN, MSG_WRITE_FILE_RESULT,
-    MSG_WRITE_FILES_RESULT, RawMessage,
+    self, BorrowedRawMessage, MSG_ERROR, MSG_PING, MSG_PONG, MSG_SHUTDOWN, MSG_WRITE_FILE_RESULT,
+    MSG_WRITE_FILES_RESULT,
 };
 
 use crate::drain::drain_into_vec_cancellable;
@@ -289,9 +289,9 @@ pub(crate) fn set_debug_guest_write_file_path(path: PathBuf) {
 }
 
 pub(crate) fn decode_write_file_message(
-    msg: &RawMessage,
+    payload: &[u8],
 ) -> Result<DecodedWriteFileMessage<'_>, vsock_proto::ProtocolError> {
-    let (path, content, use_sudo, append, private) = vsock_proto::decode_write_file(&msg.payload)?;
+    let (path, content, use_sudo, append, private) = vsock_proto::decode_write_file(payload)?;
     Ok(DecodedWriteFileMessage {
         path,
         content,
@@ -302,12 +302,12 @@ pub(crate) fn decode_write_file_message(
 }
 
 pub(crate) fn decode_write_files_message(
-    msg: &RawMessage,
+    payload: &[u8],
 ) -> Result<DecodedWriteFilesMessage<'_>, vsock_proto::ProtocolError> {
-    let files = vsock_proto::decode_write_files(&msg.payload)?;
+    let files = vsock_proto::decode_write_files(payload)?;
     let content_bytes = files.iter().map(|file| file.content.len()).sum();
     Ok(DecodedWriteFilesMessage {
-        payload: &msg.payload,
+        payload,
         file_count: files.len(),
         content_bytes,
     })
@@ -342,7 +342,7 @@ pub(crate) fn handle_decoded_write_files_message(
 ///
 /// Exec operation and guarded write-file operations are handled separately by
 /// the connection dispatcher.
-pub(crate) fn handle_basic_message(msg: &RawMessage) -> io::Result<MessageOutcome> {
+pub(crate) fn handle_basic_message(msg: BorrowedRawMessage<'_>) -> io::Result<MessageOutcome> {
     log(
         "INFO",
         &format!("Received: type=0x{:02X} seq={}", msg.msg_type, msg.seq),
@@ -354,7 +354,7 @@ pub(crate) fn handle_basic_message(msg: &RawMessage) -> io::Result<MessageOutcom
         )),
         MSG_SHUTDOWN => {
             if let Err(error) =
-                vsock_proto::decode_empty_payload("shutdown payload must be empty", &msg.payload)
+                vsock_proto::decode_empty_payload("shutdown payload must be empty", msg.payload)
             {
                 return encode_error_response(msg.seq, &error.to_string());
             }

--- a/crates/vsock-guest/tests/connection/shutdown.rs
+++ b/crates/vsock-guest/tests/connection/shutdown.rs
@@ -1,13 +1,14 @@
 use std::io::Write;
+use std::path::Path;
 use std::thread;
 use std::time::Duration;
 
 use vsock_guest::run;
-use vsock_proto::{self, MSG_PING, MSG_PONG, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK};
+use vsock_proto::{self, MSG_PING, MSG_PONG, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_WRITE_FILE};
 
 use super::support::{
-    finish_guest_connection, read_and_discard_message, read_error_response, read_message,
-    start_guest_connection, unique_socket_path,
+    finish_guest_connection, join_guest_connection, read_and_discard_message, read_error_response,
+    read_message, start_guest_connection, unique_socket_path, unique_tmp_path,
 };
 
 #[test]
@@ -99,4 +100,25 @@ fn shutdown_rejects_non_empty_payload_without_exiting() {
     assert_eq!(pong.seq, 43);
 
     finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn shutdown_ignores_later_frames_in_same_read_buffer() {
+    let (handle, mut host_stream) = start_guest_connection();
+    let path = unique_tmp_path("shutdown-followed-by-write-file", ".txt");
+    let write_payload =
+        vsock_proto::encode_write_file(path.as_str(), b"should-not-write", false, false)
+            .expect("encode write_file");
+
+    let mut batch = vsock_proto::encode(MSG_SHUTDOWN, 50, &[]).unwrap();
+    batch.extend_from_slice(&vsock_proto::encode(MSG_WRITE_FILE, 51, &write_payload).unwrap());
+    host_stream.write_all(&batch).unwrap();
+
+    let ack = read_message(&mut host_stream);
+    assert_eq!(ack.msg_type, MSG_SHUTDOWN_ACK);
+    assert_eq!(ack.seq, 50);
+
+    drop(host_stream);
+    join_guest_connection(handle);
+    assert!(!Path::new(path.as_str()).exists());
 }

--- a/crates/vsock-guest/tests/connection/write_file.rs
+++ b/crates/vsock-guest/tests/connection/write_file.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use vsock_proto::{self, MSG_WRITE_FILE};
+use vsock_proto::{self, MSG_WRITE_FILE, MSG_WRITE_FILES, WriteFileBatchEntry};
 
 use super::support::{
     assert_ping_pong, finish_guest_connection, read_error_response, send_control_payload,
@@ -34,6 +34,24 @@ fn write_file_seq_zero_does_not_write_valid_payload() {
 }
 
 #[test]
+fn write_files_seq_zero_does_not_write_valid_payload() {
+    let (handle, mut host_stream) = start_guest_connection();
+    let path = unique_tmp_path("write-files-seq-zero", ".txt");
+    let payload = vsock_proto::encode_write_files(&[WriteFileBatchEntry {
+        path: path.as_str(),
+        content: b"should-not-write",
+    }])
+    .expect("encode write_files");
+
+    send_control_payload(&mut host_stream, MSG_WRITE_FILES, 0, &payload);
+    let error = read_error_response(&mut host_stream, 0);
+    assert_eq!(error, "write_files requires non-zero sequence");
+    assert!(!Path::new(path.as_str()).exists());
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
 fn malformed_write_file_payload_returns_error_and_keeps_connection_open() {
     let (handle, mut host_stream) = start_guest_connection();
 
@@ -42,6 +60,19 @@ fn malformed_write_file_payload_returns_error_and_keeps_connection_open() {
     assert_eq!(error, "invalid payload: write_file path truncated");
 
     assert_ping_pong(&mut host_stream, 32);
+
+    finish_guest_connection(handle, host_stream);
+}
+
+#[test]
+fn malformed_write_files_payload_returns_error_and_keeps_connection_open() {
+    let (handle, mut host_stream) = start_guest_connection();
+
+    send_control_payload(&mut host_stream, MSG_WRITE_FILES, 41, &[0, 1]);
+    let error = read_error_response(&mut host_stream, 41);
+    assert_eq!(error, "invalid payload: write_files path_len truncated");
+
+    assert_ping_pong(&mut host_stream, 42);
 
     finish_guest_connection(handle, host_stream);
 }

--- a/crates/vsock-test/tests/integration/write_file.rs
+++ b/crates/vsock-test/tests/integration/write_file.rs
@@ -1,5 +1,6 @@
 use crate::support::{Harness, captured_output_bytes, exec_exit_code, run_exec, shell_quote};
 use std::fs;
+use vsock_host::WriteFileEntry;
 
 #[test]
 fn shell_quote_escapes_single_quotes() {
@@ -33,6 +34,42 @@ async fn test_write_file() {
 
     assert_eq!(exec_exit_code(&result), Some(0));
     assert_eq!(captured_output_bytes(&result.stdout), content);
+    h.finish();
+}
+
+#[tokio::test]
+async fn test_write_files() {
+    let h = Harness::new().await;
+
+    let first_path = h.dir.join("batch-first.txt");
+    let second_path = h.dir.join("batch/nested/second.bin");
+    let first_path_str = first_path.to_string_lossy().to_string();
+    let second_path_str = second_path.to_string_lossy().to_string();
+    let first_content = b"first batch file";
+    let second_content = b"second\0batch\nfile";
+
+    h.host()
+        .write_files(&[
+            WriteFileEntry {
+                path: &first_path_str,
+                content: first_content,
+            },
+            WriteFileEntry {
+                path: &second_path_str,
+                content: second_content,
+            },
+        ])
+        .await
+        .expect("write_files failed");
+
+    assert_eq!(
+        std::fs::read(&first_path).expect("failed to read first batch file"),
+        first_content
+    );
+    assert_eq!(
+        std::fs::read(&second_path).expect("failed to read second batch file"),
+        second_content
+    );
     h.finish();
 }
 


### PR DESCRIPTION
## Summary
- dispatch guest connection frames directly from borrowed decoder messages
- decode write_file and write_files payloads from borrowed slices instead of owned RawMessage payloads
- add coverage for shutdown followed by later frames in one read buffer and write_files integration

Closes #19464.

Follow-up issues: #19490, #19491.

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all
- cargo test --manifest-path crates/Cargo.toml -p vsock-guest --test connection
- cargo test --manifest-path crates/Cargo.toml -p vsock-test write_file
- cargo test --manifest-path crates/Cargo.toml -p vsock-proto
- pre-commit cargo-doc
- pre-commit cargo-clippy