### PR TITLE
feat: add chat thread emoji shortcut

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
@@ -9,7 +9,10 @@ import {
 import type { ChatThreadSignals } from "./chat-thread-signals.ts";
 import type { ScrollStepDirection } from "../auto-scroll.ts";
 import { onDomEventFn, onRef } from "../utils.ts";
-import { openRenameChatThreadDialog$ } from "../zero-page/zero-sidebar-state.ts";
+import {
+  openChatThreadEmojiDialog$,
+  openRenameChatThreadDialog$,
+} from "../zero-page/zero-sidebar-state.ts";
 
 /**
  * Snapshot row shape consumed by `navigateToAdjacentThread$`. The caller
@@ -129,7 +132,7 @@ export const setChatKeyboardScrollRoot$ = onRef(
     const onGlobalChatKeyDown = onDomEventFn(async (event: KeyboardEvent) => {
       if (
         event.defaultPrevented ||
-        !matchShortcut("f2", event) ||
+        (!matchShortcut("f2", event) && !matchShortcut("shift+f2", event)) ||
         hasOpenDialog(el.ownerDocument) ||
         !isChatShortcutTarget(el, event.target)
       ) {
@@ -143,10 +146,15 @@ export const setChatKeyboardScrollRoot$ = onRef(
       event.preventDefault();
       const threadData = await get(mainThread.threadData$);
       signal.throwIfAborted();
-      set(openRenameChatThreadDialog$, {
+      const dialogPayload = {
         threadId: mainThread.threadId,
         title: threadData?.title,
-      });
+      };
+      if (matchShortcut("shift+f2", event)) {
+        set(openChatThreadEmojiDialog$, dialogPayload);
+      } else {
+        set(openRenameChatThreadDialog$, dialogPayload);
+      }
     });
 
     el.addEventListener("focusin", markActiveThread, { signal });

--- a/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
@@ -6,6 +6,7 @@ import {
   loadLeftThread$,
   loadRightThread$,
 } from "./chat-thread-panes.ts";
+import { sidebarChatThreads$ } from "./optimistic-chat-thread-page.ts";
 import type { ChatThreadSignals } from "./chat-thread-signals.ts";
 import type { ScrollStepDirection } from "../auto-scroll.ts";
 import { onDomEventFn, onRef } from "../utils.ts";
@@ -73,6 +74,21 @@ function isChatShortcutTarget(root: HTMLElement, target: EventTarget | null) {
 
 function hasOpenDialog(doc: Document): boolean {
   return doc.querySelector('[role="dialog"]') !== null;
+}
+
+function resolveChatThreadShortcutTitle(
+  threadId: string,
+  threadDataTitle: string | null | undefined,
+  sidebarThreads: readonly { id: string; title: string | null }[],
+): string | null | undefined {
+  if (threadDataTitle?.trim()) {
+    return threadDataTitle;
+  }
+  return (
+    sidebarThreads.find((thread) => {
+      return thread.id === threadId;
+    })?.title ?? threadDataTitle
+  );
 }
 
 function isKeyboardScrollAllowedTarget(
@@ -145,10 +161,15 @@ export const setChatKeyboardScrollRoot$ = onRef(
 
       event.preventDefault();
       const threadData = await get(mainThread.threadData$);
+      const sidebarThreads = await get(sidebarChatThreads$);
       signal.throwIfAborted();
       const dialogPayload = {
         threadId: mainThread.threadId,
-        title: threadData?.title,
+        title: resolveChatThreadShortcutTitle(
+          mainThread.threadId,
+          threadData?.title,
+          sidebarThreads,
+        ),
       };
       if (matchShortcut("shift+f2", event)) {
         set(openChatThreadEmojiDialog$, dialogPayload);

--- a/turbo/apps/platform/src/signals/zero-page/zero-sidebar-state.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-sidebar-state.ts
@@ -57,6 +57,35 @@ export const openRenameChatThreadDialog$ = command(
 );
 
 // ---------------------------------------------------------------------------
+// Emoji picker dialog state (RecentChatList)
+// ---------------------------------------------------------------------------
+const internalEmojiDialogThreadId$ = state<string | null>(null);
+export const emojiDialogThreadId$ = computed((get) => {
+  return get(internalEmojiDialogThreadId$);
+});
+export const setEmojiDialogThreadId$ = command(({ set }, id: string | null) => {
+  set(internalEmojiDialogThreadId$, id);
+});
+
+const internalEmojiDialogTitle$ = state<string | null>(null);
+export const emojiDialogTitle$ = computed((get) => {
+  return get(internalEmojiDialogTitle$);
+});
+export const setEmojiDialogTitle$ = command(({ set }, title: string | null) => {
+  set(internalEmojiDialogTitle$, title);
+});
+
+export const openChatThreadEmojiDialog$ = command(
+  (
+    { set },
+    { threadId, title }: { threadId: string; title: string | null | undefined },
+  ) => {
+    set(internalEmojiDialogTitle$, title?.trim() || null);
+    set(internalEmojiDialogThreadId$, threadId);
+  },
+);
+
+// ---------------------------------------------------------------------------
 // Session list collapse state (RecentChatSection) — persisted in localStorage
 // ---------------------------------------------------------------------------
 const {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -261,7 +261,9 @@ function makeMessage(id: string, text: string): PagedChatMessage {
   };
 }
 
-function mockKeyboardNavigationThreads(): void {
+function mockKeyboardNavigationThreads({
+  currentTitle = "Current keyboard thread",
+}: { currentTitle?: string } = {}): void {
   const threadFixtures = [
     {
       id: "keyboard-prev-thread",
@@ -270,7 +272,7 @@ function mockKeyboardNavigationThreads(): void {
     },
     {
       id: "keyboard-current-thread",
-      title: "Current keyboard thread",
+      title: currentTitle,
       message: "Current thread launch note",
     },
     {
@@ -2837,7 +2839,9 @@ describe("chat lifecycle", () => {
       expect(screen.getByText("Previous thread")).toBeInTheDocument();
       expect(screen.getByText("Next thread")).toBeInTheDocument();
       expect(screen.getByText("Rename chat")).toBeInTheDocument();
-      expect(screen.getByText("F2")).toBeInTheDocument();
+      expect(screen.getByText("Change emoji")).toBeInTheDocument();
+      expect(screen.getAllByText("F2")).toHaveLength(2);
+      expect(screen.getAllByText("Shift").length).toBeGreaterThan(0);
     });
   });
 
@@ -2984,6 +2988,87 @@ describe("chat lifecycle", () => {
     expect(within(dialog).getByPlaceholderText("Chat title")).toHaveValue(
       "Current keyboard thread",
     );
+  });
+
+  it("adds an emoji to the current chat with Shift+F2", async () => {
+    const renameRequest = vi.fn();
+    mockResizeObserver();
+    mockKeyboardNavigationThreads();
+    context.mocks.api(
+      chatThreadRenameContract.rename,
+      ({ body, params, respond }) => {
+        renameRequest(params.id, body.title);
+        return respond(204);
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/chats/keyboard-current-thread",
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Current thread launch note"),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Current keyboard thread")).toBeInTheDocument();
+    });
+
+    const threadRegion = screen.getByLabelText("Chat thread");
+    threadRegion.focus();
+    fireEvent.keyDown(threadRegion, { key: "F2", shiftKey: true });
+
+    const dialog = await screen.findByRole("dialog", { name: "Change emoji" });
+    expect(dialog).toBeInTheDocument();
+    click(buttonByLabel("Done ✅"));
+
+    await waitFor(() => {
+      expect(renameRequest).toHaveBeenCalledWith(
+        "keyboard-current-thread",
+        "✅ Current keyboard thread",
+      );
+    });
+  });
+
+  it("replaces the current chat emoji from the Shift+F2 picker", async () => {
+    const renameRequest = vi.fn();
+    mockResizeObserver();
+    mockKeyboardNavigationThreads({
+      currentTitle: "🔥   Current keyboard thread",
+    });
+    context.mocks.api(
+      chatThreadRenameContract.rename,
+      ({ body, params, respond }) => {
+        renameRequest(params.id, body.title);
+        return respond(204);
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/chats/keyboard-current-thread",
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Current thread launch note"),
+      ).toBeInTheDocument();
+      expect(document.title).toBe("🔥   Current keyboard thread | VM0");
+    });
+
+    const threadRegion = screen.getByLabelText("Chat thread");
+    threadRegion.focus();
+    fireEvent.keyDown(threadRegion, { key: "F2", shiftKey: true });
+
+    const dialog = await screen.findByRole("dialog", { name: "Change emoji" });
+    fireEvent.keyDown(dialog, { key: "@", code: "Digit2", shiftKey: true });
+
+    await waitFor(() => {
+      expect(renameRequest).toHaveBeenCalledWith(
+        "keyboard-current-thread",
+        "👀 Current keyboard thread",
+      );
+    });
   });
 
   it("opens run logs from assistant message actions", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -263,21 +263,28 @@ function makeMessage(id: string, text: string): PagedChatMessage {
 
 function mockKeyboardNavigationThreads({
   currentTitle = "Current keyboard thread",
-}: { currentTitle?: string } = {}): void {
+  currentDetailTitle = currentTitle,
+}: {
+  currentTitle?: string;
+  currentDetailTitle?: string | null;
+} = {}): void {
   const threadFixtures = [
     {
       id: "keyboard-prev-thread",
       title: "Previous keyboard thread",
+      detailTitle: "Previous keyboard thread",
       message: "Previous thread launch note",
     },
     {
       id: "keyboard-current-thread",
       title: currentTitle,
+      detailTitle: currentDetailTitle,
       message: "Current thread launch note",
     },
     {
       id: "keyboard-next-thread",
       title: "Next keyboard thread",
+      detailTitle: "Next keyboard thread",
       message: "Next thread launch note",
     },
   ];
@@ -314,7 +321,7 @@ function mockKeyboardNavigationThreads({
     }
     return respond(200, {
       id: thread.id,
-      title: thread.title,
+      title: thread.detailTitle,
       agentId: AGENT_ID,
       activeRunIds: [],
       createdAt: "2026-06-01T00:00:00Z",
@@ -2993,7 +3000,7 @@ describe("chat lifecycle", () => {
   it("adds an emoji to the current chat with Shift+F2", async () => {
     const renameRequest = vi.fn();
     mockResizeObserver();
-    mockKeyboardNavigationThreads();
+    mockKeyboardNavigationThreads({ currentDetailTitle: null });
     context.mocks.api(
       chatThreadRenameContract.rename,
       ({ body, params, respond }) => {

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -15,6 +15,7 @@ import {
   IconLoader2,
   IconPin,
   IconPinnedOff,
+  IconMoodSmile,
 } from "@tabler/icons-react";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import type { ChatThreadListItem } from "@vm0/api-contracts/contracts/chat-threads";
@@ -92,11 +93,16 @@ import {
   setChatThreadOnlyUnread$,
 } from "../../signals/chat-page/chat-thread-only-unread.ts";
 import {
+  emojiDialogThreadId$,
+  emojiDialogTitle$,
+  openChatThreadEmojiDialog$,
   openRenameChatThreadDialog$,
   pendingDeleteThreadId$,
   setPendingDeleteThreadId$,
   renameDialogThreadId$,
   renameDialogInput$,
+  setEmojiDialogThreadId$,
+  setEmojiDialogTitle$,
   setRenameDialogThreadId$,
   setRenameDialogInput$,
   sessionListCollapsed$,
@@ -106,6 +112,50 @@ import { Link } from "../router/link.tsx";
 
 type IndicatorState = "running" | "unread" | "draft";
 type ChatThreadPaneIndicator = "main" | "sidebar";
+
+const PRIMARY_CHAT_THREAD_EMOJI_OPTIONS = [
+  { emoji: "✅", label: "Done" },
+  { emoji: "🔥", label: "Urgent" },
+  { emoji: "❌", label: "No" },
+  { emoji: "⚠️", label: "Risk" },
+  { emoji: "💡", label: "Idea" },
+  { emoji: "❓", label: "Question" },
+  { emoji: "⏳", label: "Waiting" },
+] as const;
+
+const SECONDARY_CHAT_THREAD_EMOJI_OPTIONS = [
+  { emoji: "📌", label: "Important" },
+  { emoji: "👀", label: "Review" },
+  { emoji: "🧪", label: "Test" },
+  { emoji: "📝", label: "Notes" },
+  { emoji: "🚧", label: "Building" },
+  { emoji: "📣", label: "Announcement" },
+  { emoji: "🔒", label: "Private" },
+] as const;
+
+const CHAT_THREAD_EMOJI_PATTERN =
+  /(?:[\u{1f1e6}-\u{1f1ff}]{2}|[#*0-9]\ufe0f?\u20e3|\p{Extended_Pictographic}(?:\ufe0f|\ufe0e)?(?:[\u{1f3fb}-\u{1f3ff}])?(?:\u200d\p{Extended_Pictographic}(?:\ufe0f|\ufe0e)?(?:[\u{1f3fb}-\u{1f3ff}])?)*)/u;
+
+function applyChatThreadEmoji(
+  title: string | null | undefined,
+  emoji: string,
+): string {
+  const trimmedTitle = title?.trim() ?? "";
+  if (!trimmedTitle) {
+    return emoji;
+  }
+  const match = trimmedTitle.match(CHAT_THREAD_EMOJI_PATTERN);
+  if (!match || match.index === undefined) {
+    return `${emoji} ${trimmedTitle}`;
+  }
+  const beforeEmoji = trimmedTitle.slice(0, match.index);
+  const afterEmoji = trimmedTitle
+    .slice(match.index + match[0].length)
+    .trimStart();
+  return afterEmoji
+    ? `${beforeEmoji}${emoji} ${afterEmoji}`
+    : `${beforeEmoji}${emoji}`;
+}
 
 function SessionStateIndicator({ state }: { state: IndicatorState }) {
   if (state === "running") {
@@ -265,6 +315,7 @@ function ChatThreadMenu({
   const pinChatThread = useSet(pinChatThread$);
   const unpinChatThread = useSet(unpinChatThread$);
   const openRenameChatThreadDialog = useSet(openRenameChatThreadDialog$);
+  const openChatThreadEmojiDialog = useSet(openChatThreadEmojiDialog$);
   const pageSignal = useGet(pageSignal$);
 
   function handleTogglePin() {
@@ -282,6 +333,10 @@ function ChatThreadMenu({
 
   function openRenameDialog() {
     openRenameChatThreadDialog({ threadId, title });
+  }
+
+  function openEmojiDialog() {
+    openChatThreadEmojiDialog({ threadId, title });
   }
 
   const showMobileTrigger = !hasOtherIndicator || usePinnedIndicatorTrigger;
@@ -351,6 +406,10 @@ function ChatThreadMenu({
           <DropdownMenuItem onSelect={openRenameDialog}>
             <IconPencil size={16} stroke={2} className="mr-2" />
             Rename chat
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={openEmojiDialog}>
+            <IconMoodSmile size={16} stroke={2} className="mr-2" />
+            Change emoji
           </DropdownMenuItem>
           <DropdownMenuItem
             onSelect={() => {
@@ -559,6 +618,20 @@ function ChatThreadItem({ session }: { session: ChatThreadListItem }) {
   );
 }
 
+function chatThreadContainer(threadId: string) {
+  return (
+    Array.from(
+      document.querySelectorAll<HTMLElement>("[data-chat-thread-container-id]"),
+    ).find((candidate) => {
+      return candidate.dataset.chatThreadContainerId === threadId;
+    }) ?? null
+  );
+}
+
+function focusChatThreadContainer(threadId: string) {
+  chatThreadContainer(threadId)?.focus({ preventScroll: true });
+}
+
 function ChatThreadRenameDialog() {
   const renameDialogThreadId = useGet(renameDialogThreadId$);
   const renameDialogInput = useGet(renameDialogInput$);
@@ -566,22 +639,6 @@ function ChatThreadRenameDialog() {
   const setRenameDialogThreadId = useSet(setRenameDialogThreadId$);
   const renameChatThread = useSet(renameChatThread$);
   const pageSignal = useGet(pageSignal$);
-
-  function chatThreadContainer(threadId: string) {
-    return (
-      Array.from(
-        document.querySelectorAll<HTMLElement>(
-          "[data-chat-thread-container-id]",
-        ),
-      ).find((candidate) => {
-        return candidate.dataset.chatThreadContainerId === threadId;
-      }) ?? null
-    );
-  }
-
-  function focusChatThreadContainer(threadId: string) {
-    chatThreadContainer(threadId)?.focus({ preventScroll: true });
-  }
 
   function closeRenameDialog() {
     const threadId = renameDialogThreadId;
@@ -665,6 +722,156 @@ function ChatThreadRenameDialog() {
         </DialogFooter>
       </DialogContent>
     </Dialog>
+  );
+}
+
+function emojiShortcutIndex(event: {
+  key: string;
+  code?: string;
+}): number | null {
+  const codeMatch = event.code?.match(/^(?:Digit|Numpad)([1-7])$/);
+  const key = codeMatch?.[1] ?? event.key;
+  const fallbackShiftedKeys: Record<string, string> = {
+    "!": "1",
+    "@": "2",
+    "#": "3",
+    $: "4",
+    "%": "5",
+    "^": "6",
+    "&": "7",
+  };
+  const digit = fallbackShiftedKeys[key] ?? key;
+  if (!/^[1-7]$/.test(digit)) {
+    return null;
+  }
+  return Number(digit) - 1;
+}
+
+function ChatThreadEmojiDialog() {
+  const emojiDialogThreadId = useGet(emojiDialogThreadId$);
+  const emojiDialogTitle = useGet(emojiDialogTitle$);
+  const setEmojiDialogThreadId = useSet(setEmojiDialogThreadId$);
+  const setEmojiDialogTitle = useSet(setEmojiDialogTitle$);
+  const renameChatThread = useSet(renameChatThread$);
+  const pageSignal = useGet(pageSignal$);
+
+  function closeEmojiDialog() {
+    const threadId = emojiDialogThreadId;
+    setEmojiDialogThreadId(null);
+    setEmojiDialogTitle(null);
+    if (threadId) {
+      queueMicrotask(() => {
+        focusChatThreadContainer(threadId);
+      });
+    }
+  }
+
+  function selectEmoji(emoji: string) {
+    if (!emojiDialogThreadId) {
+      return;
+    }
+    detach(
+      renameChatThread(
+        {
+          threadId: emojiDialogThreadId,
+          title: applyChatThreadEmoji(emojiDialogTitle, emoji),
+        },
+        pageSignal,
+      ),
+      Reason.DomCallback,
+    );
+    closeEmojiDialog();
+  }
+
+  return (
+    <Dialog
+      open={emojiDialogThreadId !== null}
+      onOpenChange={(open) => {
+        if (!open) {
+          closeEmojiDialog();
+        }
+      }}
+    >
+      <DialogContent
+        className="max-w-sm"
+        onCloseAutoFocus={(event) => {
+          const threadContainer = emojiDialogThreadId
+            ? chatThreadContainer(emojiDialogThreadId)
+            : null;
+          if (threadContainer) {
+            event.preventDefault();
+            threadContainer.focus({ preventScroll: true });
+          }
+        }}
+        onKeyDown={(event) => {
+          const index = emojiShortcutIndex(event);
+          if (index === null) {
+            return;
+          }
+          event.preventDefault();
+          const options = event.shiftKey
+            ? SECONDARY_CHAT_THREAD_EMOJI_OPTIONS
+            : PRIMARY_CHAT_THREAD_EMOJI_OPTIONS;
+          const option = options[index];
+          if (option) {
+            selectEmoji(option.emoji);
+          }
+        }}
+      >
+        <DialogHeader>
+          <DialogTitle>Change emoji</DialogTitle>
+          <DialogDescription className="sr-only">
+            Choose an emoji for this chat.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-2">
+          <EmojiOptionGrid
+            options={PRIMARY_CHAT_THREAD_EMOJI_OPTIONS}
+            shortcutPrefix=""
+            onSelect={selectEmoji}
+          />
+          <EmojiOptionGrid
+            options={SECONDARY_CHAT_THREAD_EMOJI_OPTIONS}
+            shortcutPrefix="Shift+"
+            onSelect={selectEmoji}
+          />
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function EmojiOptionGrid({
+  onSelect,
+  options,
+  shortcutPrefix,
+}: {
+  onSelect: (emoji: string) => void;
+  options: readonly { emoji: string; label: string }[];
+  shortcutPrefix: string;
+}) {
+  return (
+    <div className="grid grid-cols-7 gap-1.5">
+      {options.map((option, index) => {
+        const shortcut = `${shortcutPrefix}${index + 1}`;
+        return (
+          <button
+            key={option.emoji}
+            type="button"
+            aria-label={`${option.label} ${option.emoji}`}
+            onClick={() => {
+              onSelect(option.emoji);
+            }}
+            className="flex h-14 min-w-0 flex-col items-center justify-center rounded-lg border border-border bg-background text-2xl leading-none transition-colors hover:bg-gray-50 hover:text-foreground"
+          >
+            <span aria-hidden="true">{option.emoji}</span>
+            <span className="mt-1 text-[9px] leading-none text-muted-foreground">
+              {shortcut}
+            </span>
+          </button>
+        );
+      })}
+    </div>
   );
 }
 
@@ -825,6 +1032,7 @@ function ChatThreads() {
             : "Start a conversation and it'll show up here"}
         </p>
         <ChatThreadRenameDialog />
+        <ChatThreadEmojiDialog />
         <DeleteChatThreadDialog />
       </>
     );
@@ -841,6 +1049,7 @@ function ChatThreads() {
         />
       )}
       <ChatThreadRenameDialog />
+      <ChatThreadEmojiDialog />
       <DeleteChatThreadDialog />
     </>
   );

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -2914,24 +2914,39 @@ function ChatThread({
 
 function useOpenCurrentChatThreadRenameDialog(thread: ChatThreadSignals) {
   const openRenameChatThreadDialog = useSet(openRenameChatThreadDialog$);
-  const threadData = useLastResolved(thread.threadData$);
+  const title = useCurrentChatThreadDialogTitle(thread);
   return () => {
     openRenameChatThreadDialog({
       threadId: thread.threadId,
-      title: threadData?.title,
+      title,
     });
   };
 }
 
 function useOpenCurrentChatThreadEmojiDialog(thread: ChatThreadSignals) {
   const openChatThreadEmojiDialog = useSet(openChatThreadEmojiDialog$);
-  const threadData = useLastResolved(thread.threadData$);
+  const title = useCurrentChatThreadDialogTitle(thread);
   return () => {
     openChatThreadEmojiDialog({
       threadId: thread.threadId,
-      title: threadData?.title,
+      title,
     });
   };
+}
+
+function useCurrentChatThreadDialogTitle(
+  thread: ChatThreadSignals,
+): string | null | undefined {
+  const threadData = useLastResolved(thread.threadData$);
+  const sidebarThreads = useLastResolved(sidebarChatThreads$) ?? [];
+  if (threadData?.title?.trim()) {
+    return threadData.title;
+  }
+  return (
+    sidebarThreads.find((sidebarThread) => {
+      return sidebarThread.id === thread.threadId;
+    })?.title ?? threadData?.title
+  );
 }
 
 // Drag the divider to resize the artifact preview against the chat thread.

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -230,7 +230,10 @@ import {
 } from "../../signals/zero-page/zero-automations.ts";
 import { openQueueDrawer$ } from "../../signals/queue-page/queue-drawer-state.ts";
 import { ShortcutHelpDialog } from "../components/shortcut-help-dialog.tsx";
-import { openRenameChatThreadDialog$ } from "../../signals/zero-page/zero-sidebar-state.ts";
+import {
+  openChatThreadEmojiDialog$,
+  openRenameChatThreadDialog$,
+} from "../../signals/zero-page/zero-sidebar-state.ts";
 import { LoadingSwitch } from "../components/loading-switch.tsx";
 import { Link } from "../router/link.tsx";
 import { ROUTES } from "../../signals/route-paths.ts";
@@ -346,6 +349,7 @@ const CHAT_SHORTCUT_SECTIONS = [
       { key: "mod+b", label: "Toggle sidebar" },
       { key: "mod+shift+o", label: "New chat" },
       { key: "f2", label: "Rename chat" },
+      { key: "shift+f2", label: "Change emoji" },
     ],
   },
   {
@@ -2876,8 +2880,14 @@ function ChatThread({
   onFocusFallbackRef?: (el: HTMLElement | null) => void;
 }) {
   const openRenameDialog = useOpenCurrentChatThreadRenameDialog(thread);
+  const openEmojiDialog = useOpenCurrentChatThreadEmojiDialog(thread);
   const handleKeyDown = (event: ReactKeyboardEvent<HTMLElement>) => {
     if (event.defaultPrevented) {
+      return;
+    }
+    if (matchShortcut("shift+f2", event)) {
+      event.preventDefault();
+      openEmojiDialog();
       return;
     }
     if (matchShortcut("f2", event)) {
@@ -2907,6 +2917,17 @@ function useOpenCurrentChatThreadRenameDialog(thread: ChatThreadSignals) {
   const threadData = useLastResolved(thread.threadData$);
   return () => {
     openRenameChatThreadDialog({
+      threadId: thread.threadId,
+      title: threadData?.title,
+    });
+  };
+}
+
+function useOpenCurrentChatThreadEmojiDialog(thread: ChatThreadSignals) {
+  const openChatThreadEmojiDialog = useSet(openChatThreadEmojiDialog$);
+  const threadData = useLastResolved(thread.threadData$);
+  return () => {
+    openChatThreadEmojiDialog({
       threadId: thread.threadId,
       title: threadData?.title,
     });


### PR DESCRIPTION
Summary:
- add Shift+F2 chat shortcut to open a predefined emoji picker
- replace the first emoji in a chat title, or add one when absent, with exactly one following space when text remains
- expose the action in shortcut help and the sidebar chat menu

Verification:
- pnpm test src/views/zero-page/__tests__/chat-lifecycle.test.tsx
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types