### PR TITLE
fix: move connector reconnect into menu

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -367,6 +367,52 @@ describe("connectors page", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("moves reconnect into the connector options menu", async () => {
+    mockConnectors([
+      {
+        type: "meta-ads",
+        connectionStatus: "reconnect-required",
+      },
+    ]);
+    const authWindow = createMockAuthWindow();
+    context.mocks.browser.open(authWindow);
+    context.mocks.api(
+      zeroConnectorOauthStartContract.start,
+      ({ params, respond }) => {
+        expect(params.type).toBe("meta-ads");
+        return respond(200, {
+          authorizationUrl: "https://oauth.test/meta-ads/authorize",
+        });
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/connectors",
+    });
+
+    await waitFor(() => {
+      const card = connectorCardByLabel("Meta Ads");
+      expect(within(card).getByText("Connection expired")).toBeInTheDocument();
+      expect(queryButtonByText("Reconnect", card)).not.toBeInTheDocument();
+    });
+
+    click(
+      within(connectorCardByLabel("Meta Ads")).getByLabelText("More options"),
+    );
+
+    await waitFor(() => {
+      expect(menuItemByText("Reconnect")).toBeInTheDocument();
+    });
+    click(menuItemByText("Reconnect"));
+
+    await waitFor(() => {
+      expect(authWindow.location.href).toBe(
+        "https://oauth.test/meta-ads/authorize",
+      );
+    });
+  });
+
   it("moves scope review into the connector options menu", async () => {
     const storedScopes = ["https://www.googleapis.com/auth/adwords"];
     const addedScopes = [

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -495,13 +495,6 @@ function GlobalConnectorCard({
               </TooltipProvider>
             ) : null}
           </span>
-          <button
-            type="button"
-            onClick={onConnect}
-            className="font-medium text-amber-600 hover:text-amber-700 dark:text-amber-400 dark:hover:text-amber-300 transition-colors"
-          >
-            Reconnect
-          </button>
         </span>
       );
     }
@@ -586,6 +579,11 @@ function GlobalConnectorCard({
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="w-44">
+                {connectionStatus === "reconnect-required" ? (
+                  <DropdownMenuItem onClick={onConnect}>
+                    Reconnect
+                  </DropdownMenuItem>
+                ) : null}
                 {connectionStatus === "scope-mismatch" && onReviewScopes ? (
                   <DropdownMenuItem onClick={onReviewScopes}>
                     Review permissions


### PR DESCRIPTION
## Summary
- Move the connector reconnect action from the expired status row into the existing connector options menu.
- Add coverage that expired connectors expose Reconnect only through the menu and still start OAuth.

Follow-up to #19488, which merged before this extra commit could be included.

## Tests
- pnpm -F @vm0/app test src/views/zero-page/__tests__/zero-connectors-page.test.tsx
- pnpm exec prettier --check apps/platform/src/views/zero-page/zero-connectors-page.tsx apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx