### PR TITLE
feat: add teams installation connect flow

### DIFF
--- a/turbo/apps/api/src/lib/teams-bot-activity.ts
+++ b/turbo/apps/api/src/lib/teams-bot-activity.ts
@@ -20,6 +20,8 @@ type TeamsActivityNormalizationResult =
 interface ActivityBase {
   readonly activityId: string | null;
   readonly tenantId: string;
+  readonly tenantName: string | null;
+  readonly teamsAppId: string | null;
   readonly serviceUrl: string;
   readonly conversationId: string;
   readonly conversationType: string | null;
@@ -146,6 +148,8 @@ function activityBase(
   return {
     activityId,
     tenantId,
+    tenantName: tenant ? readString(tenant, "name") : null,
+    teamsAppId: channelData ? readString(channelData, "teamsAppId") : null,
     serviceUrl,
     conversationId,
     conversationType: conversation
@@ -209,6 +213,7 @@ function conversationUpdateActivity(
       ...base,
       kind: "bot_removed",
       reason: "members_removed",
+      recipient,
       membersRemoved,
     };
   }
@@ -224,6 +229,7 @@ function conversationUpdateActivity(
     ...base,
     kind: "conversation_update",
     action,
+    recipient,
     membersAdded,
     membersRemoved,
   };
@@ -239,14 +245,16 @@ function installationUpdateActivity(
       ...base,
       kind: "bot_removed",
       reason: "installation_remove",
+      recipient: activity.recipient ? normalizeActor(activity.recipient) : null,
       membersRemoved: [],
     };
   }
 
   return {
-    kind: "unsupported",
-    activityType: `installationUpdate:${action ?? "unknown"}`,
-    idempotencyKey: base.idempotencyKey,
+    ...base,
+    kind: "installation_update",
+    action: action === "add" ? "add" : "unknown",
+    recipient: activity.recipient ? normalizeActor(activity.recipient) : null,
   };
 }
 

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -153,7 +153,9 @@ import { zeroSlackConnectRoutes } from "./routes/zero-slack-connect";
 import { zeroSlackEventsRoutes } from "./routes/zero-slack-events";
 import { zeroSlackInteractiveRoutes } from "./routes/zero-slack-interactive";
 import { zeroSlackOauthRoutes } from "./routes/zero-slack-oauth";
+import { zeroTeamsBrowserConnectRoutes } from "./routes/zero-teams-browser-connect";
 import { zeroTeamsBotRoutes } from "./routes/zero-teams-bot";
+import { zeroTeamsConnectRoutes } from "./routes/zero-teams-connect";
 import { zeroTeamRoutes } from "./routes/zero-team";
 import { zeroUploadsCompleteRoutes } from "./routes/zero-uploads-complete";
 import { zeroUploadsHtmlDomEditSnapshotRoutes } from "./routes/zero-uploads-html-dom-edit-snapshot";
@@ -339,7 +341,9 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroSlackCommandsRoutes,
   ...zeroSlackEventsRoutes,
   ...zeroSlackInteractiveRoutes,
+  ...zeroTeamsBrowserConnectRoutes,
   ...zeroTeamsBotRoutes,
+  ...zeroTeamsConnectRoutes,
   ...zeroIntegrationsAgentPhoneRoutes,
   ...zeroIntegrationsPhoneDownloadFileRoutes,
   ...zeroIntegrationsPhoneMessageRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-teams-connect.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-teams-connect.ts
@@ -1,0 +1,235 @@
+import {
+  createSign,
+  generateKeyPairSync,
+  randomUUID,
+  type KeyObject,
+} from "node:crypto";
+
+import { HttpResponse, http } from "msw";
+
+import { createAppWithRoutes } from "../../../../app-factory-core";
+import { mockEnv } from "../../../../lib/env";
+import { now } from "../../../../lib/time";
+import { server } from "../../../../mocks/server";
+import { clearTeamsBotAuthCacheForTest } from "../../../../lib/teams-bot-auth";
+import { zeroTeamsBotRoutes } from "../../zero-teams-bot";
+
+const BOT_APP_ID = "00000000-0000-0000-0000-000000000001";
+const SERVICE_URL = "https://smba.trafficmanager.net/amer/";
+const KEY_ID = "teams-test-key";
+const BOT_FRAMEWORK_METADATA_URL =
+  "https://login.botframework.com/v1/.well-known/openidconfiguration";
+const BOT_FRAMEWORK_KEYS_URL =
+  "https://login.botframework.com/v1/.well-known/keys";
+
+const keyPair = generateKeyPairSync("rsa", { modulusLength: 2048 });
+const publicJwk = keyPair.publicKey.export({ format: "jwk" });
+
+export interface TeamsConnectFixture {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly teamsTenantId: string;
+  readonly teamsTenantName: string;
+  readonly teamsTeamId: string;
+  readonly teamsTeamName: string;
+  readonly teamsUserId: string;
+  readonly serviceUrl: string;
+}
+
+export function setupTeamsConnectTestEnv(
+  appUrl = "https://app.vm0.test",
+): void {
+  clearTeamsBotAuthCacheForTest();
+  mockEnv("MICROSOFT_TEAMS_BOT_APP_ID", BOT_APP_ID);
+  mockEnv("APP_URL", appUrl);
+}
+
+export function teamsConnectFixture(
+  overrides: Partial<TeamsConnectFixture> = {},
+): TeamsConnectFixture {
+  return {
+    orgId: overrides.orgId ?? `org_${randomUUID()}`,
+    userId: overrides.userId ?? `user_${randomUUID()}`,
+    teamsTenantId:
+      overrides.teamsTenantId ??
+      `tenant_${randomUUID().replace(/-/g, "").slice(0, 10)}`,
+    teamsTenantName: overrides.teamsTenantName ?? "Test Tenant",
+    teamsTeamId:
+      overrides.teamsTeamId ??
+      `team_${randomUUID().replace(/-/g, "").slice(0, 10)}`,
+    teamsTeamName: overrides.teamsTeamName ?? "Test Team",
+    teamsUserId: overrides.teamsUserId ?? `29:user-${randomUUID().slice(0, 8)}`,
+    serviceUrl: overrides.serviceUrl ?? SERVICE_URL,
+  };
+}
+
+function botFrameworkHandlers(): void {
+  server.use(
+    http.get(BOT_FRAMEWORK_METADATA_URL, () => {
+      return HttpResponse.json({
+        issuer: "https://api.botframework.com",
+        jwks_uri: BOT_FRAMEWORK_KEYS_URL,
+        id_token_signing_alg_values_supported: ["RS256"],
+      });
+    }),
+    http.get(BOT_FRAMEWORK_KEYS_URL, () => {
+      return HttpResponse.json({
+        keys: [
+          {
+            ...publicJwk,
+            kid: KEY_ID,
+            use: "sig",
+            alg: "RS256",
+            endorsements: ["msteams"],
+          },
+        ],
+      });
+    }),
+  );
+}
+
+function encodeJwtPart(value: unknown): string {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64url");
+}
+
+function signJwt(args: {
+  readonly payload: Record<string, unknown>;
+  readonly privateKey: KeyObject;
+}): string {
+  const header = encodeJwtPart({
+    alg: "RS256",
+    typ: "JWT",
+    kid: KEY_ID,
+  });
+  const payload = encodeJwtPart(args.payload);
+  const signingInput = `${header}.${payload}`;
+  const signer = createSign("RSA-SHA256");
+  signer.update(signingInput);
+  const signature = signer.sign(args.privateKey).toString("base64url");
+  return `${signingInput}.${signature}`;
+}
+
+function teamsToken(): string {
+  const seconds = Math.floor(now() / 1000);
+  return signJwt({
+    privateKey: keyPair.privateKey,
+    payload: {
+      iss: "https://api.botframework.com",
+      aud: BOT_APP_ID,
+      exp: seconds + 600,
+      nbf: seconds - 30,
+      serviceurl: SERVICE_URL,
+    },
+  });
+}
+
+function teamsMessageActivity(
+  fixture: TeamsConnectFixture,
+  overrides: Readonly<Record<string, unknown>> = {},
+): Record<string, unknown> {
+  return {
+    type: "message",
+    id: "activity-1",
+    timestamp: "2026-06-30T09:10:00.000Z",
+    serviceUrl: fixture.serviceUrl,
+    channelId: "msteams",
+    conversation: {
+      id: "19:thread@thread.tacv2",
+      conversationType: "channel",
+    },
+    channelData: {
+      tenant: { id: fixture.teamsTenantId, name: fixture.teamsTenantName },
+      team: { id: fixture.teamsTeamId, name: fixture.teamsTeamName },
+      channel: { id: "19:channel@thread.tacv2", name: "General" },
+      teamsAppId: "teams-app-test",
+    },
+    from: {
+      id: fixture.teamsUserId,
+      name: "Ada Lovelace",
+      aadObjectId: "aad-user-1",
+      userPrincipalName: "ada@example.com",
+    },
+    recipient: { id: "28:bot-1", name: "Zero" },
+    text: "<at>Zero</at> deploy the preview",
+    entities: [
+      {
+        type: "mention",
+        text: "<at>Zero</at>",
+        mentioned: { id: "28:bot-1", name: "Zero" },
+      },
+    ],
+    replyToId: "root-activity",
+    ...overrides,
+  };
+}
+
+function teamsBotRemovedActivity(
+  fixture: TeamsConnectFixture,
+): Record<string, unknown> {
+  return {
+    type: "conversationUpdate",
+    id: "activity-remove-1",
+    timestamp: "2026-06-30T09:20:00.000Z",
+    serviceUrl: fixture.serviceUrl,
+    channelId: "msteams",
+    conversation: {
+      id: "19:thread@thread.tacv2",
+      conversationType: "channel",
+    },
+    channelData: {
+      tenant: { id: fixture.teamsTenantId, name: fixture.teamsTenantName },
+      team: { id: fixture.teamsTeamId, name: fixture.teamsTeamName },
+      channel: { id: "19:channel@thread.tacv2", name: "General" },
+      teamsAppId: "teams-app-test",
+    },
+    recipient: { id: "28:bot-1", name: "Zero" },
+    membersRemoved: [{ id: "28:bot-1", name: "Zero" }],
+  };
+}
+
+async function postTeamsActivityForTest(args: {
+  readonly signal: AbortSignal;
+  readonly activity: Record<string, unknown>;
+}): Promise<Response> {
+  clearTeamsBotAuthCacheForTest();
+  mockEnv("MICROSOFT_TEAMS_BOT_APP_ID", BOT_APP_ID);
+  botFrameworkHandlers();
+  const app = createAppWithRoutes({
+    signal: args.signal,
+    routes: zeroTeamsBotRoutes,
+  });
+  return await app.request("http://api.test/api/zero/teams/bot", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${teamsToken()}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(args.activity),
+  });
+}
+
+export async function installTeamsForTest(
+  signal: AbortSignal,
+  fixture: TeamsConnectFixture,
+): Promise<void> {
+  const response = await postTeamsActivityForTest({
+    signal,
+    activity: teamsMessageActivity(fixture),
+  });
+  if (!response.ok) {
+    throw new Error(`Teams install seed failed with ${response.status}`);
+  }
+}
+
+export async function removeTeamsForTest(
+  signal: AbortSignal,
+  fixture: TeamsConnectFixture,
+): Promise<void> {
+  const response = await postTeamsActivityForTest({
+    signal,
+    activity: teamsBotRemovedActivity(fixture),
+  });
+  if (!response.ok) {
+    throw new Error(`Teams cleanup failed with ${response.status}`);
+  }
+}

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-teams-bot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-teams-bot.test.ts
@@ -1,20 +1,28 @@
 import { createSign, generateKeyPairSync, type KeyObject } from "node:crypto";
 
+import { zeroTeamsConnectContract } from "@vm0/api-contracts/contracts/zero-teams-connect";
 import { HttpResponse, http } from "msw";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { createAppWithRoutes } from "../../../app-factory-core";
-import { mockEnv } from "../../../lib/env";
 import { now } from "../../../lib/time";
 import { server } from "../../../mocks/server";
-import { testContext } from "../../../__tests__/test-context";
-import { clearTeamsBotAuthCacheForTest } from "../../../lib/teams-bot-auth";
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { zeroTeamsBotRoutes } from "../zero-teams-bot";
+import {
+  removeTeamsForTest,
+  setupTeamsConnectTestEnv,
+  teamsConnectFixture,
+  type TeamsConnectFixture,
+} from "./helpers/zero-teams-connect";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
 
 const context = testContext();
+const mocks = createZeroRouteMocks(context);
 const TEAMS_BOT_PATH = "http://api.test/api/zero/teams/bot";
 const BOT_APP_ID = "00000000-0000-0000-0000-000000000001";
 const SERVICE_URL = "https://smba.trafficmanager.net/amer/";
+const APP_ORIGIN = "https://app.vm0.test";
 const KEY_ID = "teams-test-key";
 const BOT_FRAMEWORK_METADATA_URL =
   "https://login.botframework.com/v1/.well-known/openidconfiguration";
@@ -23,6 +31,19 @@ const BOT_FRAMEWORK_KEYS_URL =
 
 const keyPair = generateKeyPairSync("rsa", { modulusLength: 2048 });
 const publicJwk = keyPair.publicKey.export({ format: "jwk" });
+
+function botFixture(): TeamsConnectFixture {
+  return teamsConnectFixture({
+    orgId: "org_teams_bot_test",
+    userId: "user_teams_bot_test",
+    teamsTenantId: "tenant-1",
+    teamsTenantName: "Tenant One",
+    teamsTeamId: "team-1",
+    teamsTeamName: "Team One",
+    teamsUserId: "29:user-1",
+    serviceUrl: SERVICE_URL,
+  });
+}
 
 function botFrameworkHandlers(): void {
   server.use(
@@ -103,9 +124,10 @@ function teamsMessageActivity(
       conversationType: "channel",
     },
     channelData: {
-      tenant: { id: "tenant-1" },
+      tenant: { id: "tenant-1", name: "Tenant One" },
       team: { id: "team-1", name: "Team One" },
       channel: { id: "19:channel@thread.tacv2", name: "General" },
+      teamsAppId: "teams-app-test",
     },
     from: {
       id: "29:user-1",
@@ -139,9 +161,10 @@ function teamsBotRemovedActivity(): Record<string, unknown> {
       conversationType: "channel",
     },
     channelData: {
-      tenant: { id: "tenant-1" },
+      tenant: { id: "tenant-1", name: "Tenant One" },
       team: { id: "team-1", name: "Team One" },
       channel: { id: "19:channel@thread.tacv2", name: "General" },
+      teamsAppId: "teams-app-test",
     },
     recipient: { id: "28:bot-1", name: "Zero" },
     membersRemoved: [{ id: "28:bot-1", name: "Zero" }],
@@ -171,8 +194,11 @@ async function postTeamsActivity(args: {
 
 describe("POST /api/zero/teams/bot", () => {
   beforeEach(() => {
-    clearTeamsBotAuthCacheForTest();
-    mockEnv("MICROSOFT_TEAMS_BOT_APP_ID", BOT_APP_ID);
+    setupTeamsConnectTestEnv(APP_ORIGIN);
+  });
+
+  afterEach(async () => {
+    await removeTeamsForTest(context.signal, botFixture());
   });
 
   it("rejects missing Teams authorization", async () => {
@@ -217,7 +243,8 @@ describe("POST /api/zero/teams/bot", () => {
     });
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toMatchObject({
+    const body = await response.json();
+    expect(body).toMatchObject({
       ok: true,
       activity: {
         kind: "message",
@@ -246,6 +273,42 @@ describe("POST /api/zero/teams/bot", () => {
         text: "deploy the preview",
         idempotencyKey: "19:thread@thread.tacv2:message:activity-1",
       },
+    });
+    expect(body.connectUrl).toContain(`${APP_ORIGIN}/api/zero/teams/connect`);
+    expect(body.connectUrl).toContain("tenantId=tenant-1");
+    expect(body.connectUrl).toContain("teamsUserId=29%3Auser-1");
+
+    mocks.clerk.session(
+      "user_teams_bot_test",
+      "org_teams_bot_test",
+      "org:admin",
+    );
+    const client = setupApp({ context })(zeroTeamsConnectContract);
+    await accept(
+      client.connect({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          tenantId: "tenant-1",
+          teamsUserId: "29:user-1",
+          teamsUserDisplayName: "Ada Lovelace",
+          teamsUserPrincipalName: "ada@example.com",
+        },
+      }),
+      [200],
+    );
+    const status = await accept(
+      client.getStatus({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(status.body).toMatchObject({
+      isInstalled: true,
+      isConnected: true,
+      tenantId: "tenant-1",
+      tenantName: "Tenant One",
+      teamId: "team-1",
+      teamName: "Team One",
     });
   });
 
@@ -277,6 +340,45 @@ describe("POST /api/zero/teams/bot", () => {
         idempotencyKey:
           "19:thread@thread.tacv2:conversationUpdate:activity-remove-1",
       },
+    });
+  });
+
+  it("cleans up installation and dependent connections on Teams bot removal", async () => {
+    const fixture = botFixture();
+    botFrameworkHandlers();
+    await postTeamsActivity({
+      activity: teamsMessageActivity(),
+      token: teamsToken(),
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+    const client = setupApp({ context })(zeroTeamsConnectContract);
+    await accept(
+      client.connect({
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          tenantId: fixture.teamsTenantId,
+          teamsUserId: fixture.teamsUserId,
+        },
+      }),
+      [200],
+    );
+
+    const response = await postTeamsActivity({
+      activity: teamsBotRemovedActivity(),
+      token: teamsToken(),
+    });
+
+    expect(response.status).toBe(200);
+    const status = await accept(
+      client.getStatus({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(status.body).toStrictEqual({
+      isInstalled: false,
+      isConnected: false,
+      isAdmin: true,
     });
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-teams-browser-connect.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-teams-browser-connect.test.ts
@@ -1,0 +1,250 @@
+import { zeroTeamsConnectContract } from "@vm0/api-contracts/contracts/zero-teams-connect";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { createAppWithRoutes } from "../../../app-factory-core";
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { zeroTeamsBrowserConnectRoutes } from "../zero-teams-browser-connect";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+import {
+  installTeamsForTest,
+  removeTeamsForTest,
+  setupTeamsConnectTestEnv,
+  teamsConnectFixture,
+  type TeamsConnectFixture,
+} from "./helpers/zero-teams-connect";
+
+const context = testContext();
+const mocks = createZeroRouteMocks(context);
+const CONNECT_PATH = "http://api.test/api/zero/teams/connect";
+const APP_ORIGIN = "https://app.vm0.test";
+
+function connectUrl(params: {
+  readonly tenantId?: string;
+  readonly teamsUserId?: string;
+  readonly displayName?: string;
+  readonly upn?: string;
+  readonly orgId?: string;
+}): string {
+  const url = new URL(CONNECT_PATH);
+  if (params.tenantId) {
+    url.searchParams.set("tenantId", params.tenantId);
+  }
+  if (params.teamsUserId) {
+    url.searchParams.set("teamsUserId", params.teamsUserId);
+  }
+  if (params.displayName) {
+    url.searchParams.set("displayName", params.displayName);
+  }
+  if (params.upn) {
+    url.searchParams.set("upn", params.upn);
+  }
+  if (params.orgId) {
+    url.searchParams.set("orgId", params.orgId);
+  }
+  return url.toString();
+}
+
+async function requestConnect(
+  url: string,
+  headers?: HeadersInit,
+): Promise<Response> {
+  const app = createAppWithRoutes({
+    signal: context.signal,
+    routes: zeroTeamsBrowserConnectRoutes,
+  });
+  const requestHeaders = headers ?? { cookie: "__session=opaque" };
+  return await app.request(url, { method: "GET", headers: requestHeaders });
+}
+
+function connectBody(
+  fixture: TeamsConnectFixture,
+  teamsUserId = fixture.teamsUserId,
+) {
+  return {
+    tenantId: fixture.teamsTenantId,
+    teamsUserId,
+    teamsUserDisplayName: "Ada Lovelace",
+    teamsUserPrincipalName: "ada@example.com",
+    teamId: fixture.teamsTeamId,
+    teamName: fixture.teamsTeamName,
+    serviceUrl: fixture.serviceUrl,
+  };
+}
+
+async function seedTeamsInstallation(
+  track: (
+    fixturePromise: Promise<TeamsConnectFixture>,
+  ) => Promise<TeamsConnectFixture>,
+): Promise<TeamsConnectFixture> {
+  const fixture = await track(Promise.resolve(teamsConnectFixture()));
+  await installTeamsForTest(context.signal, fixture);
+  return fixture;
+}
+
+async function bindTeamsInstallation(
+  fixture: TeamsConnectFixture,
+  userId: string,
+): Promise<void> {
+  mocks.clerk.session(userId, fixture.orgId, "org:admin");
+  const client = setupApp({ context })(zeroTeamsConnectContract);
+  await accept(
+    client.connect({
+      headers: { authorization: "Bearer clerk-session" },
+      body: connectBody(fixture, "29:admin-user"),
+    }),
+    [200],
+  );
+}
+
+async function expectTeamsConnected(
+  fixture: TeamsConnectFixture,
+): Promise<void> {
+  const client = setupApp({ context })(zeroTeamsConnectContract);
+  const status = await accept(
+    client.getStatus({
+      headers: { authorization: "Bearer clerk-session" },
+    }),
+    [200],
+  );
+  expect(status.body).toMatchObject({
+    isInstalled: true,
+    isConnected: true,
+    tenantId: fixture.teamsTenantId,
+  });
+}
+
+describe("GET /api/zero/teams/connect", () => {
+  const track = createFixtureTracker<TeamsConnectFixture>((fixture) => {
+    return removeTeamsForTest(context.signal, fixture);
+  });
+
+  beforeEach(() => {
+    setupTeamsConnectTestEnv(APP_ORIGIN);
+  });
+
+  it("redirects unauthenticated users to sign-in with redirect_url", async () => {
+    const response = await requestConnect(CONNECT_PATH, {});
+
+    expect(response.status).toBe(307);
+    const location = response.headers.get("location");
+    expect(location).not.toBeNull();
+    const url = new URL(location!);
+    expect(url.pathname).toBe("/sign-in");
+    expect(url.searchParams.get("redirect_url")).toBe(CONNECT_PATH);
+  });
+
+  it("redirects invalid connect links to the Teams connect error page", async () => {
+    mocks.clerk.session("user_invalid", "org_invalid", "org:admin");
+
+    const response = await requestConnect(CONNECT_PATH);
+
+    expect(response.status).toBe(307);
+    const location = response.headers.get("location");
+    expect(location).toContain(`${APP_ORIGIN}/settings/teams?error=`);
+    expect(decodeURIComponent(location ?? "")).toContain(
+      "Invalid connect link.",
+    );
+  });
+
+  it("binds an unbound installation for an admin and creates one connection", async () => {
+    const fixture = await seedTeamsInstallation(track);
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const response = await requestConnect(
+      connectUrl({
+        tenantId: fixture.teamsTenantId,
+        teamsUserId: fixture.teamsUserId,
+        displayName: "Ada Lovelace",
+        upn: "ada@example.com",
+      }),
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toContain(
+      `${APP_ORIGIN}/settings/teams?status=connected`,
+    );
+    await expectTeamsConnected(fixture);
+  });
+
+  it("rejects a member connecting an unbound installation", async () => {
+    const fixture = await seedTeamsInstallation(track);
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+
+    const response = await requestConnect(
+      connectUrl({
+        tenantId: fixture.teamsTenantId,
+        teamsUserId: fixture.teamsUserId,
+      }),
+    );
+
+    expect(response.status).toBe(307);
+    const location = response.headers.get("location");
+    expect(location).toContain(`${APP_ORIGIN}/settings/teams?error=`);
+    expect(decodeURIComponent(location ?? "")).toContain("admin");
+  });
+
+  it("keeps reconnecting the same Teams user idempotent", async () => {
+    const fixture = await seedTeamsInstallation(track);
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+    const url = connectUrl({
+      tenantId: fixture.teamsTenantId,
+      teamsUserId: fixture.teamsUserId,
+    });
+
+    const first = await requestConnect(url);
+    const second = await requestConnect(url);
+
+    expect(first.status).toBe(307);
+    expect(first.headers.get("location")).toContain(
+      `${APP_ORIGIN}/settings/teams?status=connected`,
+    );
+    expect(second.status).toBe(307);
+    expect(second.headers.get("location")).toContain(
+      `${APP_ORIGIN}/settings/teams?status=connected`,
+    );
+    await expectTeamsConnected(fixture);
+  });
+
+  it("allows a member to connect to a bound installation", async () => {
+    const fixture = await seedTeamsInstallation(track);
+    const memberUserId = `member_${fixture.userId}`;
+    await bindTeamsInstallation(fixture, `admin_${fixture.userId}`);
+    mocks.clerk.session(memberUserId, fixture.orgId, "org:member");
+
+    const response = await requestConnect(
+      connectUrl({
+        tenantId: fixture.teamsTenantId,
+        teamsUserId: "29:member-user",
+        orgId: fixture.orgId,
+      }),
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toContain(
+      `${APP_ORIGIN}/settings/teams?status=connected`,
+    );
+    await expectTeamsConnected(fixture);
+  });
+
+  it("redirects org mismatch to the organization error", async () => {
+    const fixture = await seedTeamsInstallation(track);
+    await bindTeamsInstallation(fixture, fixture.userId);
+    mocks.clerk.session(fixture.userId, "org_other", "org:admin");
+
+    const response = await requestConnect(
+      connectUrl({
+        tenantId: fixture.teamsTenantId,
+        teamsUserId: fixture.teamsUserId,
+        orgId: "org_other",
+      }),
+    );
+
+    expect(response.status).toBe(307);
+    const location = response.headers.get("location");
+    expect(location).toContain(`${APP_ORIGIN}/settings/teams?error=`);
+    expect(decodeURIComponent(location ?? "")).toContain("active organization");
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-teams-connect.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-teams-connect.test.ts
@@ -1,0 +1,341 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { zeroTeamsConnectContract } from "@vm0/api-contracts/contracts/zero-teams-connect";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+import {
+  installTeamsForTest,
+  removeTeamsForTest,
+  setupTeamsConnectTestEnv,
+  teamsConnectFixture,
+  type TeamsConnectFixture,
+} from "./helpers/zero-teams-connect";
+
+const context = testContext();
+const mocks = createZeroRouteMocks(context);
+
+function connectBody(
+  fixture: TeamsConnectFixture,
+  teamsUserId = fixture.teamsUserId,
+) {
+  return {
+    tenantId: fixture.teamsTenantId,
+    teamsUserId,
+    teamsUserDisplayName: "Ada Lovelace",
+    teamsUserPrincipalName: "ada@example.com",
+    teamId: fixture.teamsTeamId,
+    teamName: fixture.teamsTeamName,
+    serviceUrl: fixture.serviceUrl,
+  };
+}
+
+async function seedTeamsInstallation(
+  track: (
+    fixturePromise: Promise<TeamsConnectFixture>,
+  ) => Promise<TeamsConnectFixture>,
+  values: Partial<TeamsConnectFixture> = {},
+): Promise<TeamsConnectFixture> {
+  const fixture = await track(Promise.resolve(teamsConnectFixture(values)));
+  await installTeamsForTest(context.signal, fixture);
+  return fixture;
+}
+
+describe("GET /api/zero/integrations/teams/connect", () => {
+  const track = createFixtureTracker<TeamsConnectFixture>((fixture) => {
+    return removeTeamsForTest(context.signal, fixture);
+  });
+
+  beforeEach(() => {
+    setupTeamsConnectTestEnv();
+  });
+
+  it("returns 401 when the request is unauthenticated", async () => {
+    const client = setupApp({ context })(zeroTeamsConnectContract);
+
+    const response = await accept(client.getStatus({ headers: {} }), [401]);
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: "Not authenticated",
+        code: "UNAUTHORIZED",
+      },
+    });
+  });
+
+  it("returns uninstalled status when the org has no Teams installation", async () => {
+    mocks.clerk.session("user_empty", "org_empty", "org:admin");
+
+    const client = setupApp({ context })(zeroTeamsConnectContract);
+
+    const response = await accept(
+      client.getStatus({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      isInstalled: false,
+      isConnected: false,
+      isAdmin: true,
+    });
+  });
+
+  it("returns installed but disconnected status for an unlinked user", async () => {
+    const fixture = await seedTeamsInstallation(track);
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroTeamsConnectContract);
+    await accept(
+      client.connect({
+        headers: { authorization: "Bearer clerk-session" },
+        body: connectBody(fixture),
+      }),
+      [200],
+    );
+    await accept(
+      client.disconnect({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    const response = await accept(
+      client.getStatus({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      isInstalled: true,
+      isConnected: false,
+      isAdmin: true,
+      tenantId: fixture.teamsTenantId,
+      tenantName: fixture.teamsTenantName,
+      teamId: fixture.teamsTeamId,
+      teamName: fixture.teamsTeamName,
+      defaultAgentName: null,
+    });
+  });
+
+  it("returns connected status when the user has a Teams connection", async () => {
+    const fixture = await seedTeamsInstallation(track);
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+
+    const client = setupApp({ context })(zeroTeamsConnectContract);
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+    await accept(
+      client.connect({
+        headers: { authorization: "Bearer clerk-session" },
+        body: connectBody(fixture),
+      }),
+      [200],
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+
+    const response = await accept(
+      client.getStatus({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      isInstalled: true,
+      isConnected: true,
+      isAdmin: false,
+      tenantId: fixture.teamsTenantId,
+      tenantName: fixture.teamsTenantName,
+      teamId: fixture.teamsTeamId,
+      teamName: fixture.teamsTeamName,
+      defaultAgentName: null,
+    });
+  });
+});
+
+describe("POST /api/zero/integrations/teams/connect", () => {
+  const track = createFixtureTracker<TeamsConnectFixture>((fixture) => {
+    return removeTeamsForTest(context.signal, fixture);
+  });
+
+  beforeEach(() => {
+    setupTeamsConnectTestEnv();
+  });
+
+  it("binds an unbound Teams installation for an admin and creates one connection", async () => {
+    const fixture = await seedTeamsInstallation(track);
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroTeamsConnectContract);
+    const response = await accept(
+      client.connect({
+        headers: { authorization: "Bearer clerk-session" },
+        body: connectBody(fixture),
+      }),
+      [200],
+    );
+
+    expect(response.body).toMatchObject({
+      success: true,
+      role: "admin",
+    });
+
+    const status = await accept(
+      client.getStatus({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(status.body).toMatchObject({
+      isInstalled: true,
+      isConnected: true,
+      tenantId: fixture.teamsTenantId,
+    });
+  });
+
+  it("rejects a member connecting an unbound Teams installation", async () => {
+    const fixture = await seedTeamsInstallation(track);
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+
+    const client = setupApp({ context })(zeroTeamsConnectContract);
+    const response = await accept(
+      client.connect({
+        headers: { authorization: "Bearer clerk-session" },
+        body: connectBody(fixture),
+      }),
+      [403],
+    );
+
+    expect(response.body.error.message).toContain("org admins");
+  });
+
+  it("allows a member to connect to a bound Teams installation", async () => {
+    const fixture = await seedTeamsInstallation(track);
+    const adminUserId = `admin_${fixture.userId}`;
+    const memberUserId = `member_${fixture.userId}`;
+
+    const client = setupApp({ context })(zeroTeamsConnectContract);
+    mocks.clerk.session(adminUserId, fixture.orgId, "org:admin");
+    await accept(
+      client.connect({
+        headers: { authorization: "Bearer clerk-session" },
+        body: connectBody(fixture, "29:admin-user"),
+      }),
+      [200],
+    );
+
+    mocks.clerk.session(memberUserId, fixture.orgId, "org:member");
+    const response = await accept(
+      client.connect({
+        headers: { authorization: "Bearer clerk-session" },
+        body: connectBody(fixture, "29:member-user"),
+      }),
+      [200],
+    );
+
+    expect(response.body.role).toBe("member");
+    const status = await accept(
+      client.getStatus({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(status.body.isConnected).toBeTruthy();
+  });
+
+  it("rejects users from the wrong org with a clear error", async () => {
+    const fixture = await seedTeamsInstallation(track);
+    const client = setupApp({ context })(zeroTeamsConnectContract);
+
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+    await accept(
+      client.connect({
+        headers: { authorization: "Bearer clerk-session" },
+        body: connectBody(fixture),
+      }),
+      [200],
+    );
+
+    mocks.clerk.session(fixture.userId, "org_other", "org:admin");
+    const response = await accept(
+      client.connect({
+        headers: { authorization: "Bearer clerk-session" },
+        body: connectBody(fixture),
+      }),
+      [403],
+    );
+
+    expect(response.body.error.message).toContain("active organization");
+  });
+
+  it("keeps repeated connects for the same Teams user idempotent", async () => {
+    const fixture = await seedTeamsInstallation(track);
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroTeamsConnectContract);
+    const first = await accept(
+      client.connect({
+        headers: { authorization: "Bearer clerk-session" },
+        body: connectBody(fixture),
+      }),
+      [200],
+    );
+    const second = await accept(
+      client.connect({
+        headers: { authorization: "Bearer clerk-session" },
+        body: connectBody(fixture),
+      }),
+      [200],
+    );
+
+    expect(second.body.connectionId).toBe(first.body.connectionId);
+  });
+});
+
+describe("DELETE /api/zero/integrations/teams/connect", () => {
+  const track = createFixtureTracker<TeamsConnectFixture>((fixture) => {
+    return removeTeamsForTest(context.signal, fixture);
+  });
+
+  beforeEach(() => {
+    setupTeamsConnectTestEnv();
+  });
+
+  it("disconnects the current user without uninstalling Teams", async () => {
+    const fixture = await seedTeamsInstallation(track);
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+
+    const client = setupApp({ context })(zeroTeamsConnectContract);
+    await accept(
+      client.connect({
+        headers: { authorization: "Bearer clerk-session" },
+        body: connectBody(fixture),
+      }),
+      [200],
+    );
+    const response = await accept(
+      client.disconnect({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ success: true });
+
+    const status = await accept(
+      client.getStatus({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(status.body).toMatchObject({
+      isInstalled: true,
+      isConnected: false,
+      tenantId: fixture.teamsTenantId,
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-teams-bot.ts
+++ b/turbo/apps/api/src/signals/routes/zero-teams-bot.ts
@@ -8,6 +8,11 @@ import {
 } from "../../lib/teams-bot-activity";
 import { verifyTeamsBotAuthorization } from "../../lib/teams-bot-auth";
 import { authorization$, request$ } from "../context/hono";
+import {
+  buildTeamsConnectUrlForActivity,
+  publishTeamsChanged$,
+  recordTeamsInstallationActivity$,
+} from "../services/zero-teams-connect.service";
 import { safeJsonParse } from "../utils";
 import type { RouteEntry } from "../route-entry";
 
@@ -34,48 +39,77 @@ function authErrorCode(status: 401 | 403 | 503): string {
   return "UNAUTHORIZED";
 }
 
-const handleZeroTeamsBot$ = command(async ({ get }, signal: AbortSignal) => {
-  const request = get(request$);
-  const bodyText = await request.text();
-  signal.throwIfAborted();
+const handleZeroTeamsBot$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const request = get(request$);
+    const bodyText = await request.text();
+    signal.throwIfAborted();
 
-  const body = safeJsonParse(bodyText);
-  const normalized = normalizeTeamsActivity(body);
-  if (!normalized.ok) {
-    return errorResponse(400, normalized.error, "BAD_REQUEST");
-  }
+    const body = safeJsonParse(bodyText);
+    const normalized = normalizeTeamsActivity(body);
+    if (!normalized.ok) {
+      return errorResponse(400, normalized.error, "BAD_REQUEST");
+    }
 
-  const serviceUrl =
-    normalized.activity.kind === "unsupported"
-      ? readTeamsActivityServiceUrl(body)
-      : normalized.activity.serviceUrl;
-  if (!serviceUrl) {
-    return errorResponse(
-      400,
-      "Missing Teams activity serviceUrl",
-      "BAD_REQUEST",
+    const serviceUrl =
+      normalized.activity.kind === "unsupported"
+        ? readTeamsActivityServiceUrl(body)
+        : normalized.activity.serviceUrl;
+    if (!serviceUrl) {
+      return errorResponse(
+        400,
+        "Missing Teams activity serviceUrl",
+        "BAD_REQUEST",
+      );
+    }
+
+    const auth = await verifyTeamsBotAuthorization({
+      authorization: get(authorization$),
+      serviceUrl,
+      channelId: readTeamsActivityChannelId(body),
+    });
+    signal.throwIfAborted();
+
+    if (!auth.ok) {
+      return errorResponse(
+        auth.status,
+        auth.message,
+        authErrorCode(auth.status),
+      );
+    }
+
+    const activityResult = await set(
+      recordTeamsInstallationActivity$,
+      normalized.activity,
+      signal,
     );
-  }
+    signal.throwIfAborted();
 
-  const auth = await verifyTeamsBotAuthorization({
-    authorization: get(authorization$),
-    serviceUrl,
-    channelId: readTeamsActivityChannelId(body),
-  });
-  signal.throwIfAborted();
+    if (activityResult.kind === "removed" && activityResult.orgId) {
+      await set(
+        publishTeamsChanged$,
+        { orgId: activityResult.orgId, userIds: activityResult.userIds },
+        signal,
+      );
+      signal.throwIfAborted();
+    }
 
-  if (!auth.ok) {
-    return errorResponse(auth.status, auth.message, authErrorCode(auth.status));
-  }
+    const installation =
+      activityResult.kind === "upserted" ? activityResult.installation : null;
 
-  return {
-    status: 200 as const,
-    body: {
-      ok: true as const,
-      activity: normalized.activity,
-    },
-  };
-});
+    return {
+      status: 200 as const,
+      body: {
+        ok: true as const,
+        activity: normalized.activity,
+        connectUrl: buildTeamsConnectUrlForActivity({
+          activity: normalized.activity,
+          installation,
+        }),
+      },
+    };
+  },
+);
 
 export const zeroTeamsBotRoutes: readonly RouteEntry[] = [
   {

--- a/turbo/apps/api/src/signals/routes/zero-teams-browser-connect.ts
+++ b/turbo/apps/api/src/signals/routes/zero-teams-browser-connect.ts
@@ -1,0 +1,139 @@
+import { command } from "ccstate";
+import { zeroTeamsBrowserConnectContract } from "@vm0/api-contracts/contracts/zero-teams-browser-connect";
+import { teamsOrgInstallations } from "@vm0/db/schema/teams-org-installation";
+import { eq } from "drizzle-orm";
+
+import { env } from "../../lib/env";
+import { logger } from "../../lib/log";
+import { requiredAuthContext$ } from "../auth/auth-context";
+import { request$ } from "../context/hono";
+import { queryOf } from "../context/request";
+import { db$ } from "../external/db";
+import {
+  connectTeamsInstallation$,
+  publishTeamsChanged$,
+} from "../services/zero-teams-connect.service";
+import type { RouteEntry } from "../route-entry";
+
+const L = logger("TeamsBrowserConnect");
+const REDIRECT_STATUS = 307;
+
+function redirectResponse(url: string): Response {
+  return new Response(null, {
+    status: REDIRECT_STATUS,
+    headers: { location: url },
+  });
+}
+
+function appRedirect(path: string): Response {
+  return redirectResponse(`${env("APP_URL")}${path}`);
+}
+
+function connectError(message: string): Response {
+  return appRedirect(`/settings/teams?error=${encodeURIComponent(message)}`);
+}
+
+function connectSuccess(): Response {
+  return appRedirect("/settings/teams?status=connected");
+}
+
+function signInRedirect(requestUrl: string): Response {
+  const signInUrl = new URL("/sign-in", requestUrl);
+  signInUrl.searchParams.set("redirect_url", requestUrl);
+  return redirectResponse(signInUrl.toString());
+}
+
+const invalidConnectLinkMessage = "Invalid connect link.";
+const installationNotFoundMessage =
+  "Teams installation not found. Please install the Teams app first.";
+const adminRequiredMessage = "Ask your org admin to connect first.";
+const orgMismatchMessage =
+  "Your active organization doesn't match this Teams installation. Please switch to the correct organization in the platform sidebar before connecting.";
+
+const browserConnect$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const request = get(request$);
+  const auth = await set(requiredAuthContext$, {}, signal);
+  signal.throwIfAborted();
+
+  if ("status" in auth) {
+    return signInRedirect(request.url);
+  }
+
+  const query = get(queryOf(zeroTeamsBrowserConnectContract.connect));
+  const tenantId = query.tenantId;
+  const teamsUserId = query.teamsUserId;
+
+  if (!tenantId || !teamsUserId) {
+    return connectError(invalidConnectLinkMessage);
+  }
+
+  const db = get(db$);
+  const [installation] = await db
+    .select()
+    .from(teamsOrgInstallations)
+    .where(eq(teamsOrgInstallations.teamsTenantId, tenantId))
+    .limit(1);
+  signal.throwIfAborted();
+
+  if (!installation) {
+    return connectError(installationNotFoundMessage);
+  }
+
+  const effectiveOrgId = query.orgId ?? auth.orgId;
+  if (!installation.orgId) {
+    if (!effectiveOrgId || auth.orgRole !== "admin") {
+      return connectError(adminRequiredMessage);
+    }
+  } else if (!effectiveOrgId || effectiveOrgId !== installation.orgId) {
+    L.debug("Org check failed", {
+      activeOrgId: auth.orgId,
+      explicitOrgId: query.orgId,
+      installationOrgId: installation.orgId,
+      userId: auth.userId,
+    });
+    return connectError(orgMismatchMessage);
+  }
+
+  const orgId = installation.orgId ?? effectiveOrgId;
+  if (!orgId) {
+    return connectError(adminRequiredMessage);
+  }
+
+  const result = await set(
+    connectTeamsInstallation$,
+    {
+      userId: auth.userId,
+      orgId,
+      orgRole: auth.orgRole === "admin" ? "admin" : "member",
+      tenantId,
+      teamsUserId,
+      teamsUserDisplayName: query.displayName,
+      teamsUserPrincipalName: query.upn,
+      teamId: installation.teamsTeamId ?? undefined,
+      teamName: installation.teamsTeamName ?? undefined,
+      serviceUrl: installation.serviceUrl ?? undefined,
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  if (result.kind === "not_found") {
+    return connectError(result.message);
+  }
+
+  if (result.kind === "forbidden") {
+    return connectError(result.message);
+  }
+
+  await set(publishTeamsChanged$, { orgId, userIds: [auth.userId] }, signal);
+  signal.throwIfAborted();
+
+  return connectSuccess();
+});
+
+export const zeroTeamsBrowserConnectRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroTeamsBrowserConnectContract.connect,
+    handler: browserConnect$,
+  },
+];

--- a/turbo/apps/api/src/signals/routes/zero-teams-connect.ts
+++ b/turbo/apps/api/src/signals/routes/zero-teams-connect.ts
@@ -1,0 +1,139 @@
+import { command, computed } from "ccstate";
+import { zeroTeamsConnectContract } from "@vm0/api-contracts/contracts/zero-teams-connect";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf } from "../context/request";
+import {
+  connectTeamsInstallation$,
+  disconnectTeamsConnection$,
+  publishTeamsChanged$,
+  zeroTeamsConnectStatus,
+} from "../services/zero-teams-connect.service";
+import type { RouteEntry } from "../route-entry";
+
+function errorResponse(
+  status: 403 | 404,
+  message: string,
+  code: "FORBIDDEN" | "NOT_FOUND",
+) {
+  return {
+    status,
+    body: {
+      error: { message, code },
+    },
+  };
+}
+
+const getTeamsConnectStatusInner$ = computed(async (get) => {
+  const auth = get(organizationAuthContext$);
+  const body = await get(
+    zeroTeamsConnectStatus({
+      orgId: auth.orgId,
+      userId: auth.userId,
+      isAdmin: "orgRole" in auth && auth.orgRole === "admin",
+    }),
+  );
+  return { status: 200 as const, body };
+});
+
+const connectInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  signal.throwIfAborted();
+
+  const bodyResult = await get(bodyResultOf(zeroTeamsConnectContract.connect));
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+  const body = bodyResult.data;
+
+  const result = await set(
+    connectTeamsInstallation$,
+    {
+      userId: auth.userId,
+      orgId: auth.orgId,
+      orgRole:
+        "orgRole" in auth && auth.orgRole === "admin" ? "admin" : "member",
+      tenantId: body.tenantId,
+      teamsUserId: body.teamsUserId,
+      teamsUserDisplayName: body.teamsUserDisplayName,
+      teamsUserPrincipalName: body.teamsUserPrincipalName,
+      teamId: body.teamId,
+      teamName: body.teamName,
+      serviceUrl: body.serviceUrl,
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  if (result.kind === "not_found") {
+    return errorResponse(404, result.message, "NOT_FOUND");
+  }
+
+  if (result.kind === "forbidden") {
+    return errorResponse(403, result.message, "FORBIDDEN");
+  }
+
+  await set(
+    publishTeamsChanged$,
+    { orgId: auth.orgId, userIds: [auth.userId] },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  return {
+    status: 200 as const,
+    body: {
+      success: true as const,
+      connectionId: result.connectionId,
+      role: result.role,
+    },
+  };
+});
+
+const disconnectInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  const result = await set(
+    disconnectTeamsConnection$,
+    { orgId: auth.orgId, userId: auth.userId },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  if (result.kind === "not_found") {
+    return errorResponse(404, result.message, "NOT_FOUND");
+  }
+
+  await set(
+    publishTeamsChanged$,
+    { orgId: result.orgId, userIds: [result.userId] },
+    signal,
+  );
+  signal.throwIfAborted();
+
+  return {
+    status: 200 as const,
+    body: { success: true as const },
+  };
+});
+
+const teamsConnectAuth = {
+  requireOrganization: true,
+  missingOrganizationStatus: 401,
+} as const;
+
+export const zeroTeamsConnectRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroTeamsConnectContract.getStatus,
+    handler: authRoute(teamsConnectAuth, getTeamsConnectStatusInner$),
+  },
+  {
+    route: zeroTeamsConnectContract.connect,
+    handler: authRoute(teamsConnectAuth, connectInner$),
+  },
+  {
+    route: zeroTeamsConnectContract.disconnect,
+    handler: authRoute(teamsConnectAuth, disconnectInner$),
+  },
+];

--- a/turbo/apps/api/src/signals/services/zero-teams-connect.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-teams-connect.service.ts
@@ -1,0 +1,674 @@
+import { command, computed, type Computed } from "ccstate";
+import { agentComposes } from "@vm0/db/schema/agent-compose";
+import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { teamsOrgConnections } from "@vm0/db/schema/teams-org-connection";
+import { teamsOrgInstallations } from "@vm0/db/schema/teams-org-installation";
+import { teamsUserAgentPreferences } from "@vm0/db/schema/teams-user-agent-preference";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import type { TeamsInboundActivity } from "@vm0/api-contracts/contracts/zero-teams-bot";
+import { and, eq, isNull, sql } from "drizzle-orm";
+
+import { env } from "../../lib/env";
+import { db$, writeDb$, type Db, type ReadonlyDb } from "../external/db";
+import { publishUserSignal } from "../external/realtime";
+import { nowDate } from "../external/time";
+import { settle } from "../utils";
+import { ensureUserArtifactStorage } from "./agent-run-storage.service";
+
+type TeamsInstallation = typeof teamsOrgInstallations.$inferSelect;
+
+type TeamsConnectResult =
+  | { readonly kind: "not_found"; readonly message: string }
+  | { readonly kind: "forbidden"; readonly message: string }
+  | {
+      readonly kind: "ok";
+      readonly connectionId: string;
+      readonly role: "admin" | "member";
+      readonly installation: TeamsInstallation;
+    };
+
+type TeamsDisconnectResult =
+  | { readonly kind: "not_found"; readonly message: string }
+  | {
+      readonly kind: "ok";
+      readonly orgId: string;
+      readonly userId: string;
+    };
+
+type TeamsInstallationActivityResult =
+  | { readonly kind: "ignored" }
+  | { readonly kind: "upserted"; readonly installation: TeamsInstallation }
+  | {
+      readonly kind: "removed";
+      readonly orgId: string | null;
+      readonly userIds: readonly string[];
+    };
+
+const installationNotFoundMessage =
+  "Teams installation not found. Please install the Teams app first.";
+const adminRequiredMessage =
+  "Only org admins can connect an unconfigured Teams installation. Ask your org admin to connect first.";
+const orgMismatchMessage =
+  "Your active organization doesn't match this Teams installation. Please switch to the correct organization in the platform sidebar before connecting.";
+const connectionNotFoundMessage = "Teams connection not found.";
+
+function nonEmpty(value: string | null | undefined): string | undefined {
+  return value && value.length > 0 ? value : undefined;
+}
+
+function setOptionalParam(
+  params: URLSearchParams,
+  key: string,
+  value: string | null | undefined,
+): void {
+  const normalized = nonEmpty(value);
+  if (normalized) {
+    params.set(key, normalized);
+  }
+}
+
+function buildTeamsBrowserConnectUrl(args: {
+  readonly tenantId: string;
+  readonly teamsUserId: string;
+  readonly teamsUserDisplayName?: string | null;
+  readonly teamsUserPrincipalName?: string | null;
+  readonly conversationId?: string | null;
+  readonly channelId?: string | null;
+  readonly threadId?: string | null;
+  readonly orgId?: string | null;
+}): string {
+  const params = new URLSearchParams({
+    tenantId: args.tenantId,
+    teamsUserId: args.teamsUserId,
+  });
+  setOptionalParam(params, "displayName", args.teamsUserDisplayName);
+  setOptionalParam(params, "upn", args.teamsUserPrincipalName);
+  setOptionalParam(params, "conversationId", args.conversationId);
+  setOptionalParam(params, "channelId", args.channelId);
+  setOptionalParam(params, "threadId", args.threadId);
+  setOptionalParam(params, "orgId", args.orgId);
+  return `${env("APP_URL")}/api/zero/teams/connect?${params.toString()}`;
+}
+
+export function buildTeamsConnectUrlForActivity(args: {
+  readonly activity: TeamsInboundActivity;
+  readonly installation?: TeamsInstallation | null;
+}): string | null {
+  if (
+    args.activity.kind !== "message" ||
+    args.activity.sender.id.length === 0
+  ) {
+    return null;
+  }
+
+  return buildTeamsBrowserConnectUrl({
+    tenantId: args.activity.tenantId,
+    teamsUserId: args.activity.sender.id,
+    teamsUserDisplayName: args.activity.sender.name,
+    teamsUserPrincipalName: args.activity.sender.userPrincipalName,
+    conversationId: args.activity.conversationId,
+    channelId: args.activity.channelId,
+    threadId: args.activity.threadId,
+    orgId: args.installation?.orgId,
+  });
+}
+
+async function upsertTeamsConnection(
+  writeDb: Db,
+  args: {
+    readonly teamsUserId: string;
+    readonly teamsTenantId: string;
+    readonly vm0UserId: string;
+    readonly teamsUserDisplayName?: string;
+    readonly teamsUserPrincipalName?: string;
+  },
+): Promise<string> {
+  const [connection] = await writeDb
+    .insert(teamsOrgConnections)
+    .values({
+      teamsUserId: args.teamsUserId,
+      teamsTenantId: args.teamsTenantId,
+      vm0UserId: args.vm0UserId,
+      teamsUserDisplayName: args.teamsUserDisplayName,
+      teamsUserPrincipalName: args.teamsUserPrincipalName,
+    })
+    .onConflictDoNothing({
+      target: [
+        teamsOrgConnections.teamsUserId,
+        teamsOrgConnections.teamsTenantId,
+      ],
+    })
+    .returning({ id: teamsOrgConnections.id });
+
+  if (connection) {
+    return connection.id;
+  }
+
+  const [existing] = await writeDb
+    .select({ id: teamsOrgConnections.id })
+    .from(teamsOrgConnections)
+    .where(
+      and(
+        eq(teamsOrgConnections.teamsUserId, args.teamsUserId),
+        eq(teamsOrgConnections.teamsTenantId, args.teamsTenantId),
+      ),
+    )
+    .limit(1);
+
+  if (!existing) {
+    throw new Error("Teams connection upsert did not return a row");
+  }
+
+  return existing.id;
+}
+
+async function resolveDefaultComposeId(
+  db: ReadonlyDb,
+  orgId: string,
+): Promise<string | null> {
+  const [metadata] = await db
+    .select({ defaultAgentId: orgMetadata.defaultAgentId })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, orgId))
+    .limit(1);
+  return metadata?.defaultAgentId ?? null;
+}
+
+async function getUserAgentPreference(
+  db: ReadonlyDb,
+  vm0UserId: string,
+  orgId: string,
+): Promise<string | null> {
+  const [preference] = await db
+    .select({ selectedComposeId: teamsUserAgentPreferences.selectedComposeId })
+    .from(teamsUserAgentPreferences)
+    .where(
+      and(
+        eq(teamsUserAgentPreferences.vm0UserId, vm0UserId),
+        eq(teamsUserAgentPreferences.orgId, orgId),
+      ),
+    )
+    .limit(1);
+  return preference?.selectedComposeId ?? null;
+}
+
+async function resolveEffectiveComposeId(
+  db: ReadonlyDb,
+  vm0UserId: string,
+  orgId: string,
+): Promise<string | null> {
+  const override = await getUserAgentPreference(db, vm0UserId, orgId);
+  if (override) {
+    const [agent] = await db
+      .select({ id: zeroAgents.id })
+      .from(zeroAgents)
+      .where(and(eq(zeroAgents.id, override), eq(zeroAgents.orgId, orgId)))
+      .limit(1);
+    if (agent?.id) {
+      return override;
+    }
+  }
+  return resolveDefaultComposeId(db, orgId);
+}
+
+async function getTeamsAgentName(
+  db: ReadonlyDb,
+  composeId: string,
+): Promise<string | undefined> {
+  const [agent] = await db
+    .select({ name: zeroAgents.name, displayName: zeroAgents.displayName })
+    .from(agentComposes)
+    .innerJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
+    .where(eq(agentComposes.id, composeId))
+    .limit(1);
+  return agent?.displayName ?? agent?.name;
+}
+
+export function zeroTeamsConnectStatus(args: {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly isAdmin: boolean;
+}): Computed<
+  Promise<{
+    readonly isInstalled: boolean;
+    readonly isConnected: boolean;
+    readonly isAdmin: boolean;
+    readonly tenantId?: string | null;
+    readonly tenantName?: string | null;
+    readonly teamId?: string | null;
+    readonly teamName?: string | null;
+    readonly defaultAgentName?: string | null;
+  }>
+> {
+  return computed(async (get) => {
+    const db = get(db$);
+    const [installation] = await db
+      .select()
+      .from(teamsOrgInstallations)
+      .where(eq(teamsOrgInstallations.orgId, args.orgId))
+      .limit(1);
+
+    if (!installation) {
+      return {
+        isInstalled: false,
+        isConnected: false,
+        isAdmin: args.isAdmin,
+      };
+    }
+
+    const [connection] = await db
+      .select()
+      .from(teamsOrgConnections)
+      .where(
+        and(
+          eq(teamsOrgConnections.vm0UserId, args.userId),
+          eq(teamsOrgConnections.teamsTenantId, installation.teamsTenantId),
+        ),
+      )
+      .limit(1);
+
+    let defaultAgentName: string | null = null;
+    if (connection) {
+      const composeId = await resolveEffectiveComposeId(
+        db,
+        args.userId,
+        args.orgId,
+      );
+      defaultAgentName = composeId
+        ? ((await getTeamsAgentName(db, composeId)) ?? null)
+        : null;
+    }
+
+    return {
+      isInstalled: true,
+      isConnected: Boolean(connection),
+      isAdmin: args.isAdmin,
+      tenantId: installation.teamsTenantId,
+      tenantName: installation.teamsTenantName,
+      teamId: installation.teamsTeamId,
+      teamName: installation.teamsTeamName,
+      defaultAgentName,
+    };
+  });
+}
+
+function installationMetadataPatch(args: {
+  readonly tenantName?: string | null;
+  readonly teamId?: string | null;
+  readonly teamName?: string | null;
+  readonly teamsAppId?: string | null;
+  readonly botId?: string | null;
+  readonly botName?: string | null;
+  readonly serviceUrl?: string | null;
+}): Partial<typeof teamsOrgInstallations.$inferInsert> {
+  return {
+    ...(nonEmpty(args.tenantName) ? { teamsTenantName: args.tenantName } : {}),
+    ...(nonEmpty(args.teamId) ? { teamsTeamId: args.teamId } : {}),
+    ...(nonEmpty(args.teamName) ? { teamsTeamName: args.teamName } : {}),
+    ...(nonEmpty(args.teamsAppId) ? { teamsAppId: args.teamsAppId } : {}),
+    ...(nonEmpty(args.botId) ? { botId: args.botId } : {}),
+    ...(nonEmpty(args.botName) ? { botName: args.botName } : {}),
+    ...(nonEmpty(args.serviceUrl) ? { serviceUrl: args.serviceUrl } : {}),
+    updatedAt: nowDate(),
+  };
+}
+
+async function updateTeamsInstallationMetadata(
+  writeDb: Db,
+  tenantId: string,
+  args: Parameters<typeof installationMetadataPatch>[0],
+): Promise<void> {
+  const patch = installationMetadataPatch(args);
+  await writeDb
+    .update(teamsOrgInstallations)
+    .set(patch)
+    .where(eq(teamsOrgInstallations.teamsTenantId, tenantId));
+}
+
+export const connectTeamsInstallation$ = command(
+  async (
+    { get, set },
+    args: {
+      readonly userId: string;
+      readonly orgId: string;
+      readonly orgRole: "admin" | "member";
+      readonly tenantId: string;
+      readonly teamsUserId: string;
+      readonly teamsUserDisplayName?: string;
+      readonly teamsUserPrincipalName?: string;
+      readonly teamId?: string;
+      readonly teamName?: string;
+      readonly serviceUrl?: string;
+    },
+    signal: AbortSignal,
+  ): Promise<TeamsConnectResult> => {
+    const writeDb = set(writeDb$);
+    const [installation] = await writeDb
+      .select()
+      .from(teamsOrgInstallations)
+      .where(eq(teamsOrgInstallations.teamsTenantId, args.tenantId))
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!installation) {
+      return { kind: "not_found", message: installationNotFoundMessage };
+    }
+
+    if (installation.orgId === null) {
+      if (args.orgRole !== "admin") {
+        return { kind: "forbidden", message: adminRequiredMessage };
+      }
+
+      await updateTeamsInstallationMetadata(writeDb, args.tenantId, {
+        teamId: args.teamId,
+        teamName: args.teamName,
+        serviceUrl: args.serviceUrl,
+      });
+      signal.throwIfAborted();
+
+      const [updated] = await writeDb
+        .update(teamsOrgInstallations)
+        .set({
+          orgId: args.orgId,
+          installedByUserId: args.userId,
+          updatedAt: nowDate(),
+        })
+        .where(
+          and(
+            eq(teamsOrgInstallations.teamsTenantId, args.tenantId),
+            isNull(teamsOrgInstallations.orgId),
+          ),
+        )
+        .returning();
+      signal.throwIfAborted();
+
+      let boundInstallation = updated;
+      if (!boundInstallation) {
+        const [existing] = await writeDb
+          .select()
+          .from(teamsOrgInstallations)
+          .where(eq(teamsOrgInstallations.teamsTenantId, args.tenantId))
+          .limit(1);
+        signal.throwIfAborted();
+        if (!existing) {
+          return { kind: "not_found", message: installationNotFoundMessage };
+        }
+        if (existing.orgId !== args.orgId) {
+          return { kind: "forbidden", message: orgMismatchMessage };
+        }
+        boundInstallation = existing;
+      }
+
+      const connectionId = await upsertTeamsConnection(writeDb, {
+        teamsUserId: args.teamsUserId,
+        teamsTenantId: args.tenantId,
+        vm0UserId: args.userId,
+        teamsUserDisplayName: args.teamsUserDisplayName,
+        teamsUserPrincipalName: args.teamsUserPrincipalName,
+      });
+      signal.throwIfAborted();
+
+      await get(
+        ensureUserArtifactStorage({
+          db: writeDb,
+          orgId: args.orgId,
+          userId: args.userId,
+          name: "artifact",
+          bucket: env("R2_USER_STORAGES_BUCKET_NAME"),
+        }),
+      );
+      signal.throwIfAborted();
+
+      return {
+        kind: "ok",
+        connectionId,
+        role: "admin",
+        installation: boundInstallation,
+      };
+    }
+
+    if (installation.orgId !== args.orgId) {
+      return { kind: "forbidden", message: orgMismatchMessage };
+    }
+
+    await updateTeamsInstallationMetadata(writeDb, args.tenantId, {
+      teamId: args.teamId,
+      teamName: args.teamName,
+      serviceUrl: args.serviceUrl,
+    });
+    signal.throwIfAborted();
+
+    const connectionId = await upsertTeamsConnection(writeDb, {
+      teamsUserId: args.teamsUserId,
+      teamsTenantId: args.tenantId,
+      vm0UserId: args.userId,
+      teamsUserDisplayName: args.teamsUserDisplayName,
+      teamsUserPrincipalName: args.teamsUserPrincipalName,
+    });
+    signal.throwIfAborted();
+
+    await get(
+      ensureUserArtifactStorage({
+        db: writeDb,
+        orgId: args.orgId,
+        userId: args.userId,
+        name: "artifact",
+        bucket: env("R2_USER_STORAGES_BUCKET_NAME"),
+      }),
+    );
+    signal.throwIfAborted();
+
+    return {
+      kind: "ok",
+      connectionId,
+      role: args.orgRole,
+      installation,
+    };
+  },
+);
+
+export const disconnectTeamsConnection$ = command(
+  async (
+    { set },
+    args: {
+      readonly orgId: string;
+      readonly userId: string;
+    },
+    signal: AbortSignal,
+  ): Promise<TeamsDisconnectResult> => {
+    const writeDb = set(writeDb$);
+    const [installation] = await writeDb
+      .select()
+      .from(teamsOrgInstallations)
+      .where(eq(teamsOrgInstallations.orgId, args.orgId))
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!installation) {
+      return { kind: "not_found", message: connectionNotFoundMessage };
+    }
+
+    const [connection] = await writeDb
+      .select({ id: teamsOrgConnections.id })
+      .from(teamsOrgConnections)
+      .where(
+        and(
+          eq(teamsOrgConnections.vm0UserId, args.userId),
+          eq(teamsOrgConnections.teamsTenantId, installation.teamsTenantId),
+        ),
+      )
+      .limit(1);
+    signal.throwIfAborted();
+
+    if (!connection) {
+      return { kind: "not_found", message: connectionNotFoundMessage };
+    }
+
+    await writeDb
+      .delete(teamsOrgConnections)
+      .where(eq(teamsOrgConnections.id, connection.id));
+    signal.throwIfAborted();
+
+    return { kind: "ok", orgId: args.orgId, userId: args.userId };
+  },
+);
+
+export const publishTeamsChanged$ = command(
+  async (
+    { get },
+    args: {
+      readonly orgId?: string | null;
+      readonly userIds?: readonly string[];
+      readonly payload?: unknown;
+    },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const userIds = new Set(args.userIds ?? []);
+
+    if (args.orgId) {
+      const db = get(db$);
+      const admins = await db
+        .select({ userId: orgMembersCache.userId })
+        .from(orgMembersCache)
+        .where(
+          and(
+            eq(orgMembersCache.orgId, args.orgId),
+            eq(orgMembersCache.role, "admin"),
+          ),
+        );
+      signal.throwIfAborted();
+      for (const admin of admins) {
+        userIds.add(admin.userId);
+      }
+    }
+
+    if (userIds.size === 0) {
+      return;
+    }
+
+    const publishResult = await settle(
+      publishUserSignal([...userIds], "teams:changed", args.payload),
+    );
+    signal.throwIfAborted();
+    if (!publishResult.ok) {
+      throw publishResult.error;
+    }
+  },
+);
+
+function activityRecipient(activity: TeamsInboundActivity): {
+  readonly id: string | null;
+  readonly name: string | null;
+} {
+  if (activity.kind === "message") {
+    return {
+      id: activity.recipient?.id ?? null,
+      name: activity.recipient?.name ?? null,
+    };
+  }
+  if (
+    activity.kind === "conversation_update" ||
+    activity.kind === "installation_update" ||
+    activity.kind === "bot_removed"
+  ) {
+    return {
+      id: activity.recipient?.id ?? null,
+      name: activity.recipient?.name ?? null,
+    };
+  }
+  return { id: null, name: null };
+}
+
+export const recordTeamsInstallationActivity$ = command(
+  async (
+    { set },
+    activity: TeamsInboundActivity,
+    signal: AbortSignal,
+  ): Promise<TeamsInstallationActivityResult> => {
+    if (activity.kind === "unsupported") {
+      return { kind: "ignored" };
+    }
+
+    const writeDb = set(writeDb$);
+
+    if (activity.kind === "bot_removed") {
+      const [installation] = await writeDb
+        .select()
+        .from(teamsOrgInstallations)
+        .where(eq(teamsOrgInstallations.teamsTenantId, activity.tenantId))
+        .limit(1);
+      signal.throwIfAborted();
+
+      if (!installation) {
+        return { kind: "removed", orgId: null, userIds: [] };
+      }
+
+      const connections = await writeDb
+        .select({ userId: teamsOrgConnections.vm0UserId })
+        .from(teamsOrgConnections)
+        .where(eq(teamsOrgConnections.teamsTenantId, activity.tenantId));
+      signal.throwIfAborted();
+
+      await writeDb
+        .delete(teamsOrgConnections)
+        .where(eq(teamsOrgConnections.teamsTenantId, activity.tenantId));
+      signal.throwIfAborted();
+
+      if (installation.orgId) {
+        await writeDb
+          .delete(teamsUserAgentPreferences)
+          .where(eq(teamsUserAgentPreferences.orgId, installation.orgId));
+        signal.throwIfAborted();
+      }
+
+      await writeDb
+        .delete(teamsOrgInstallations)
+        .where(eq(teamsOrgInstallations.teamsTenantId, activity.tenantId));
+      signal.throwIfAborted();
+
+      return {
+        kind: "removed",
+        orgId: installation.orgId,
+        userIds: connections.map((connection) => {
+          return connection.userId;
+        }),
+      };
+    }
+
+    const recipient = activityRecipient(activity);
+    const [installation] = await writeDb
+      .insert(teamsOrgInstallations)
+      .values({
+        teamsTenantId: activity.tenantId,
+        teamsTenantName: activity.tenantName,
+        teamsTeamId: activity.teamId,
+        teamsTeamName: activity.teamName,
+        teamsAppId: activity.teamsAppId,
+        botId: recipient.id,
+        botName: recipient.name,
+        serviceUrl: activity.serviceUrl,
+      })
+      .onConflictDoUpdate({
+        target: teamsOrgInstallations.teamsTenantId,
+        set: {
+          teamsTenantName: sql`coalesce(excluded.teams_tenant_name, ${teamsOrgInstallations.teamsTenantName})`,
+          teamsTeamId: sql`coalesce(excluded.teams_team_id, ${teamsOrgInstallations.teamsTeamId})`,
+          teamsTeamName: sql`coalesce(excluded.teams_team_name, ${teamsOrgInstallations.teamsTeamName})`,
+          teamsAppId: sql`coalesce(excluded.teams_app_id, ${teamsOrgInstallations.teamsAppId})`,
+          botId: sql`coalesce(excluded.bot_id, ${teamsOrgInstallations.botId})`,
+          botName: sql`coalesce(excluded.bot_name, ${teamsOrgInstallations.botName})`,
+          serviceUrl: sql`coalesce(excluded.service_url, ${teamsOrgInstallations.serviceUrl})`,
+          updatedAt: nowDate(),
+        },
+      })
+      .returning();
+    signal.throwIfAborted();
+
+    if (!installation) {
+      throw new Error("Failed to upsert Teams installation");
+    }
+
+    return { kind: "upserted", installation };
+  },
+);

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-agent-row-actions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-agent-row-actions.tsx
@@ -11,7 +11,7 @@ import {
   DropdownMenuItem,
 } from "@vm0/ui";
 
-export interface AgentRowMenuAction {
+interface AgentRowMenuAction {
   readonly label: string;
   readonly disabled?: boolean | undefined;
   readonly icon: ReactNode;

--- a/turbo/apps/platform/vercel.json
+++ b/turbo/apps/platform/vercel.json
@@ -57,6 +57,10 @@
       "destination": "https://api.vm0.ai/api/zero/teams/bot"
     },
     {
+      "source": "/api/zero/teams/connect",
+      "destination": "https://api.vm0.ai/api/zero/teams/connect"
+    },
+    {
       "source": "/((?!assets/|.*\\..*).*)",
       "destination": "/index.html"
     }

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -1456,6 +1456,20 @@ export {
   type ZeroTeamsBotContract,
 } from "./zero-teams-bot";
 export {
+  zeroTeamsConnectContract,
+  type TeamsConnectBody,
+  type TeamsConnectResponse,
+  type TeamsConnectStatus,
+  type TeamsDisconnectResponse,
+  type ZeroTeamsConnectContract,
+} from "./zero-teams-connect";
+export {
+  zeroTeamsBrowserConnectContract,
+  zeroTeamsBrowserConnectQuerySchema,
+  type ZeroTeamsBrowserConnectContract,
+  type ZeroTeamsBrowserConnectQuery,
+} from "./zero-teams-browser-connect";
+export {
   zeroSlackInteractiveContract,
   type ZeroSlackInteractiveContract,
 } from "./zero-slack-interactive";

--- a/turbo/packages/api-contracts/src/contracts/zero-teams-bot.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-teams-bot.ts
@@ -15,6 +15,8 @@ const teamsActorSchema = z.object({
 const teamsActivityBaseSchema = z.object({
   activityId: z.string().nullable(),
   tenantId: z.string(),
+  tenantName: z.string().nullable(),
+  teamsAppId: z.string().nullable(),
   serviceUrl: z.string(),
   conversationId: z.string(),
   conversationType: z.string().nullable(),
@@ -40,6 +42,7 @@ export const teamsConversationUpdateActivitySchema =
   teamsActivityBaseSchema.extend({
     kind: z.literal("conversation_update"),
     action: z.enum(["members_added", "members_removed", "unknown"]),
+    recipient: teamsActorSchema,
     membersAdded: z.array(teamsActorSchema),
     membersRemoved: z.array(teamsActorSchema),
   });
@@ -47,8 +50,16 @@ export const teamsConversationUpdateActivitySchema =
 export const teamsBotRemovedActivitySchema = teamsActivityBaseSchema.extend({
   kind: z.literal("bot_removed"),
   reason: z.enum(["members_removed", "installation_remove"]),
+  recipient: teamsActorSchema.nullable(),
   membersRemoved: z.array(teamsActorSchema),
 });
+
+export const teamsInstallationUpdateActivitySchema =
+  teamsActivityBaseSchema.extend({
+    kind: z.literal("installation_update"),
+    action: z.enum(["add", "unknown"]),
+    recipient: teamsActorSchema.nullable(),
+  });
 
 export const teamsUnsupportedActivitySchema = z.object({
   kind: z.literal("unsupported"),
@@ -60,12 +71,14 @@ export const teamsInboundActivitySchema = z.discriminatedUnion("kind", [
   teamsInboundMessageActivitySchema,
   teamsConversationUpdateActivitySchema,
   teamsBotRemovedActivitySchema,
+  teamsInstallationUpdateActivitySchema,
   teamsUnsupportedActivitySchema,
 ]);
 
 export const teamsBotIngressResponseSchema = z.object({
   ok: z.literal(true),
   activity: teamsInboundActivitySchema,
+  connectUrl: z.string().nullable().optional(),
 });
 
 export const zeroTeamsBotContract = c.router({

--- a/turbo/packages/api-contracts/src/contracts/zero-teams-browser-connect.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-teams-browser-connect.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+
+import { initContract } from "./base";
+
+const c = initContract();
+
+export const zeroTeamsBrowserConnectQuerySchema = z.object({
+  tenantId: z.string().optional(),
+  teamsUserId: z.string().optional(),
+  displayName: z.string().optional(),
+  upn: z.string().optional(),
+  conversationId: z.string().optional(),
+  channelId: z.string().optional(),
+  threadId: z.string().optional(),
+  orgId: z.string().optional(),
+});
+
+export const zeroTeamsBrowserConnectContract = c.router({
+  connect: {
+    method: "GET",
+    path: "/api/zero/teams/connect",
+    query: zeroTeamsBrowserConnectQuerySchema,
+    responses: {
+      307: c.noBody(),
+      500: z.object({ error: z.string() }),
+    },
+    summary: "Browser Microsoft Teams connect flow",
+  },
+});
+
+export type ZeroTeamsBrowserConnectContract =
+  typeof zeroTeamsBrowserConnectContract;
+export type ZeroTeamsBrowserConnectQuery = z.infer<
+  typeof zeroTeamsBrowserConnectQuerySchema
+>;

--- a/turbo/packages/api-contracts/src/contracts/zero-teams-connect.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-teams-connect.ts
@@ -1,0 +1,88 @@
+import { z } from "zod";
+
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+const nullableStringSchema = z.string().nullable();
+
+const teamsConnectStatusSchema = z.object({
+  isInstalled: z.boolean(),
+  isConnected: z.boolean(),
+  isAdmin: z.boolean(),
+  tenantId: nullableStringSchema.optional(),
+  tenantName: nullableStringSchema.optional(),
+  teamId: nullableStringSchema.optional(),
+  teamName: nullableStringSchema.optional(),
+  defaultAgentName: nullableStringSchema.optional(),
+});
+
+const teamsConnectBodySchema = z.object({
+  tenantId: z.string().min(1),
+  teamsUserId: z.string().min(1),
+  teamsUserDisplayName: z.string().min(1).optional(),
+  teamsUserPrincipalName: z.string().min(1).optional(),
+  teamId: z.string().min(1).optional(),
+  teamName: z.string().min(1).optional(),
+  serviceUrl: z.string().min(1).optional(),
+  conversationId: z.string().min(1).optional(),
+  channelId: z.string().min(1).optional(),
+  threadId: z.string().min(1).optional(),
+});
+
+const teamsConnectResponseSchema = z.object({
+  success: z.literal(true),
+  connectionId: z.string(),
+  role: z.enum(["admin", "member"]),
+});
+
+const teamsDisconnectResponseSchema = z.object({
+  success: z.literal(true),
+});
+
+export const zeroTeamsConnectContract = c.router({
+  getStatus: {
+    method: "GET",
+    path: "/api/zero/integrations/teams/connect",
+    headers: authHeadersSchema,
+    responses: {
+      200: teamsConnectStatusSchema,
+      401: apiErrorSchema,
+    },
+    summary: "Check user Microsoft Teams connection status",
+  },
+  connect: {
+    method: "POST",
+    path: "/api/zero/integrations/teams/connect",
+    headers: authHeadersSchema,
+    body: teamsConnectBodySchema,
+    responses: {
+      200: teamsConnectResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Connect user to Microsoft Teams installation",
+  },
+  disconnect: {
+    method: "DELETE",
+    path: "/api/zero/integrations/teams/connect",
+    headers: authHeadersSchema,
+    responses: {
+      200: teamsDisconnectResponseSchema,
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Disconnect user from Microsoft Teams installation",
+  },
+});
+
+export type TeamsConnectStatus = z.infer<typeof teamsConnectStatusSchema>;
+export type TeamsConnectBody = z.infer<typeof teamsConnectBodySchema>;
+export type TeamsConnectResponse = z.infer<typeof teamsConnectResponseSchema>;
+export type TeamsDisconnectResponse = z.infer<
+  typeof teamsDisconnectResponseSchema
+>;
+export type ZeroTeamsConnectContract = typeof zeroTeamsConnectContract;


### PR DESCRIPTION
## Summary
- add Teams connect/status/disconnect contracts, API routes, and browser connect flow for org binding and user linking
- persist Teams installation metadata from bot activities, generate Teams connect URLs, and clean up installation-dependent connections on bot removal
- publish `teams:changed`, add the web-origin rewrite for `/api/zero/teams/connect`, and cover the flow with route tests
- remove one unused internal platform type export that knip surfaced during pre-commit

Closes #19447

## Tests
- `pnpm -F ./apps/api lint`
- `pnpm -F ./apps/api check-types`
- `pnpm -F ./apps/api exec tsc -p tsconfig.routes-zero-s-z.json --noEmit`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F ./apps/api exec vitest run src/signals/routes/__tests__/zero-teams-connect.test.ts src/signals/routes/__tests__/zero-teams-browser-connect.test.ts src/signals/routes/__tests__/zero-teams-bot.test.ts`
- `pnpm knip`
- pre-commit hook: prettier, knip, monorepo `pnpm check-types`
