### PR TITLE
fix: update bloom runbook archive

### DIFF
--- a/turbo/apps/api/src/signals/routes/registry-resources-download.ts
+++ b/turbo/apps/api/src/signals/routes/registry-resources-download.ts
@@ -181,7 +181,7 @@ const PRIVATE_REGISTRY_RESOURCE_ARCHIVE_VERSION_IDS = {
   "template:html-ppt-playful-launch-runbook":
     "f6f83c0a080db0a5b9f568c7b2640c1d179b06e1946cc5c339560bc76ee5e966",
   "template:html-ppt-bloom-pitch-runbook":
-    "9fb64d950df17d8c9e65cdc5a717cae189154c8ae4dc97fe825452b319cd1ac2",
+    "b954fb48fc033346561cec4e8e877927e14af4b7d6d4ee9cc695dccceb46b732",
   "template:html-ppt-blueprint-academy-runbook":
     "444945a0bcb95e3267ec65539275bd0c366b658af0d345481b9f59a70854661a",
   "template:html-ppt-botane-organic-runbook":

--- a/turbo/packages/core/src/resource-registry.ts
+++ b/turbo/packages/core/src/resource-registry.ts
@@ -4369,7 +4369,7 @@ export interface PresentationRunbookPackage {
 const PRESENTATION_RUNBOOK_ARCHIVE_SHA256: Record<string, string> = {
   "playful-launch":
     "d39a2c6c42365613f5c3aedff56333e6bb0af7ce2df30da26f3c4f20f128e69e",
-  bloom: "ad8764eb812697b5079ad4f34f42b2014b10a3a86f0ee080242ca24e062568cc",
+  bloom: "9f2241da0c267dd886b21dd028fa5ca8238ce6d35597d39e4c2c6fbd2ca333b7",
   "blueprint-academy":
     "abe24c3cbf0c2f4517657a7a08f185d3dd688f7e8a4e0dc0656960f84c085ed0",
   "botane-organic":


### PR DESCRIPTION
## Summary
- Uploaded the refreshed Bloom presentation runbook bundle from Google Drive to the registry-resource volume in R2.
- Updated the Bloom runbook archive digest in the resource registry.
- Updated the API private archive allowlist to the new Bloom runbook storage version.

## Uploaded artifact
- Storage: `registry-resource@template:html-ppt-bloom-pitch-runbook`
- Version ID: `b954fb48fc033346561cec4e8e877927e14af4b7d6d4ee9cc695dccceb46b732`
- Archive sha256: `9f2241da0c267dd886b21dd028fa5ca8238ce6d35597d39e4c2c6fbd2ca333b7`
- File count: 36

## Verification
- `pnpm exec prettier --check apps/api/src/signals/routes/registry-resources-download.ts packages/core/src/resource-registry.ts`
- `pnpm exec vitest run packages/core/src/__tests__/presentation-template-items.spec.ts`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm exec vitest run apps/api/src/signals/routes/__tests__/registry-resources-download.test.ts`
- Confirmed uploaded R2 archive file list matches the downloaded Drive bundle.