### PR TITLE
feat: dispatch teams messages to runs

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-teams-bot.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-teams-bot.test.ts
@@ -5,20 +5,33 @@ import { HttpResponse, http } from "msw";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { createAppWithRoutes } from "../../../app-factory-core";
+import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { now } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { zeroTeamsBotRoutes } from "../zero-teams-bot";
+import { createAuthOrgAgentsBddApi } from "./helpers/api-bdd-auth-org";
+import { createRunsAutomationsApi } from "./helpers/api-bdd-runs-automations";
 import {
   removeTeamsForTest,
   setupTeamsConnectTestEnv,
   teamsConnectFixture,
   type TeamsConnectFixture,
 } from "./helpers/zero-teams-connect";
-import { createZeroRouteMocks } from "./helpers/zero-route-test";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
 
 const context = testContext();
 const mocks = createZeroRouteMocks(context);
+const authOrgApi = createAuthOrgAgentsBddApi(context);
+const runsApi = createRunsAutomationsApi(context);
+const trackTeamsFixture = createFixtureTracker<TeamsConnectFixture>(
+  async (fixture) => {
+    await removeTeamsForTest(context.signal, fixture);
+  },
+);
 const TEAMS_BOT_PATH = "http://api.test/api/zero/teams/bot";
 const BOT_APP_ID = "00000000-0000-0000-0000-000000000001";
 const SERVICE_URL = "https://smba.trafficmanager.net/amer/";
@@ -111,26 +124,27 @@ function teamsToken(
 }
 
 function teamsMessageActivity(
+  fixture: TeamsConnectFixture = botFixture(),
   overrides: Readonly<Record<string, unknown>> = {},
 ): Record<string, unknown> {
   return {
     type: "message",
     id: "activity-1",
     timestamp: "2026-06-30T09:10:00.000Z",
-    serviceUrl: SERVICE_URL,
+    serviceUrl: fixture.serviceUrl,
     channelId: "msteams",
     conversation: {
       id: "19:thread@thread.tacv2",
       conversationType: "channel",
     },
     channelData: {
-      tenant: { id: "tenant-1", name: "Tenant One" },
-      team: { id: "team-1", name: "Team One" },
+      tenant: { id: fixture.teamsTenantId, name: fixture.teamsTenantName },
+      team: { id: fixture.teamsTeamId, name: fixture.teamsTeamName },
       channel: { id: "19:channel@thread.tacv2", name: "General" },
       teamsAppId: "teams-app-test",
     },
     from: {
-      id: "29:user-1",
+      id: fixture.teamsUserId,
       name: "Ada Lovelace",
       aadObjectId: "aad-user-1",
       userPrincipalName: "ada@example.com",
@@ -149,20 +163,22 @@ function teamsMessageActivity(
   };
 }
 
-function teamsBotRemovedActivity(): Record<string, unknown> {
+function teamsBotRemovedActivity(
+  fixture: TeamsConnectFixture = botFixture(),
+): Record<string, unknown> {
   return {
     type: "conversationUpdate",
     id: "activity-remove-1",
     timestamp: "2026-06-30T09:20:00.000Z",
-    serviceUrl: SERVICE_URL,
+    serviceUrl: fixture.serviceUrl,
     channelId: "msteams",
     conversation: {
       id: "19:thread@thread.tacv2",
       conversationType: "channel",
     },
     channelData: {
-      tenant: { id: "tenant-1", name: "Tenant One" },
-      team: { id: "team-1", name: "Team One" },
+      tenant: { id: fixture.teamsTenantId, name: fixture.teamsTenantName },
+      team: { id: fixture.teamsTeamId, name: fixture.teamsTeamName },
       channel: { id: "19:channel@thread.tacv2", name: "General" },
       teamsAppId: "teams-app-test",
     },
@@ -192,9 +208,44 @@ async function postTeamsActivity(args: {
   });
 }
 
+async function connectTeamsFixture(
+  fixture: TeamsConnectFixture,
+): Promise<void> {
+  mocks.clerk.session(fixture.userId, fixture.orgId, "org:admin");
+  const client = setupApp({ context })(zeroTeamsConnectContract);
+  await accept(
+    client.connect({
+      headers: { authorization: "Bearer clerk-session" },
+      body: {
+        tenantId: fixture.teamsTenantId,
+        teamsUserId: fixture.teamsUserId,
+        teamsUserDisplayName: "Ada Lovelace",
+        teamsUserPrincipalName: "ada@example.com",
+      },
+    }),
+    [200],
+  );
+}
+
+function dispatchRunId(dispatch: unknown): string {
+  if (typeof dispatch !== "object" || dispatch === null) {
+    throw new Error("Expected Teams dispatch object");
+  }
+  const kind = Reflect.get(dispatch, "kind");
+  expect(kind === "accepted" || kind === "queued").toBeTruthy();
+  const runId = Reflect.get(dispatch, "runId");
+  if (typeof runId !== "string") {
+    throw new Error("Expected Teams dispatch run id");
+  }
+  return runId;
+}
+
 describe("POST /api/zero/teams/bot", () => {
   beforeEach(() => {
     setupTeamsConnectTestEnv(APP_ORIGIN);
+    mockEnv("VM0_WEB_URL", "https://www.vm0.test");
+    mockEnv("VM0_API_URL", "https://api.vm0.test");
+    mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
   });
 
   afterEach(async () => {
@@ -277,6 +328,13 @@ describe("POST /api/zero/teams/bot", () => {
     expect(body.connectUrl).toContain(`${APP_ORIGIN}/api/zero/teams/connect`);
     expect(body.connectUrl).toContain("tenantId=tenant-1");
     expect(body.connectUrl).toContain("teamsUserId=29%3Auser-1");
+    expect(body.dispatch).toMatchObject({
+      kind: "notice",
+      connectUrl: expect.stringContaining(
+        `${APP_ORIGIN}/api/zero/teams/connect`,
+      ),
+      replyText: expect.stringContaining("Please connect"),
+    });
 
     mocks.clerk.session(
       "user_teams_bot_test",
@@ -309,6 +367,106 @@ describe("POST /api/zero/teams/bot", () => {
       tenantName: "Tenant One",
       teamId: "team-1",
       teamName: "Team One",
+    });
+  });
+
+  it("dispatches connected Teams messages to the org default agent", async () => {
+    const fixture = await trackTeamsFixture(
+      Promise.resolve(teamsConnectFixture()),
+    );
+    const actor = authOrgApi.user({
+      userId: fixture.userId,
+      orgId: fixture.orgId,
+      orgRole: "org:admin",
+    });
+    const runnerGroup = runsApi.configureRunnerGroup();
+    authOrgApi.acceptAgentStorageWrites();
+    const agent = await authOrgApi.createAgent(actor, {
+      displayName: "Teams default agent",
+      visibility: "public",
+    });
+    await authOrgApi.setDefaultAgent(actor, agent.agentId);
+    await runsApi.grantProEntitlement(actor);
+    await runsApi.ensureOrgModelProvider(actor);
+    botFrameworkHandlers();
+
+    const installResponse = await postTeamsActivity({
+      activity: teamsMessageActivity(fixture),
+      token: teamsToken(),
+    });
+    expect(installResponse.status).toBe(200);
+    await connectTeamsFixture(fixture);
+
+    const response = await postTeamsActivity({
+      activity: teamsMessageActivity(fixture, {
+        id: "activity-dispatch-1",
+        replyToId: "root-dispatch",
+        text: "<at>Zero</at> ship the Teams dispatch",
+      }),
+      token: teamsToken(),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.dispatch).toMatchObject({
+      kind: expect.stringMatching(/^(accepted|queued)$/u),
+      runId: expect.any(String),
+    });
+
+    const runId = dispatchRunId(body.dispatch);
+    await runsApi.heartbeatRunner(runnerGroup);
+    const claim = await runsApi.claimRunnerJob(runId);
+    const appendSystemPrompt = claim.appendSystemPrompt ?? "";
+    expect(claim.prompt).toBe("ship the Teams dispatch");
+    expect(appendSystemPrompt).toContain(
+      "You are currently running inside: Microsoft Teams",
+    );
+    expect(appendSystemPrompt).toContain("Microsoft Teams messaging and files");
+    expect(appendSystemPrompt).toContain(`Tenant ID: ${fixture.teamsTenantId}`);
+    expect(appendSystemPrompt).toContain(`Team ID: ${fixture.teamsTeamId}`);
+    expect(appendSystemPrompt).toContain(
+      "Conversation ID: 19:thread@thread.tacv2",
+    );
+    expect(appendSystemPrompt).toContain("Thread ID: root-dispatch");
+    expect(appendSystemPrompt).toContain(
+      `Teams user ID: ${fixture.teamsUserId}`,
+    );
+    expect(appendSystemPrompt).toContain(
+      "Teams user principal name: ada@example.com",
+    );
+    expect(appendSystemPrompt).toContain("# Current User Info");
+    expect(appendSystemPrompt).toContain(
+      "Teams user display name: Ada Lovelace",
+    );
+  });
+
+  it("asks connected Teams users to configure a default agent", async () => {
+    const fixture = await trackTeamsFixture(
+      Promise.resolve(teamsConnectFixture()),
+    );
+    botFrameworkHandlers();
+
+    const installResponse = await postTeamsActivity({
+      activity: teamsMessageActivity(fixture),
+      token: teamsToken(),
+    });
+    expect(installResponse.status).toBe(200);
+    await connectTeamsFixture(fixture);
+
+    const response = await postTeamsActivity({
+      activity: teamsMessageActivity(fixture, {
+        id: "activity-no-default",
+        text: "<at>Zero</at> hello",
+      }),
+      token: teamsToken(),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      dispatch: {
+        kind: "notice",
+        replyText: expect.stringContaining("No agent is configured"),
+      },
     });
   });
 

--- a/turbo/apps/api/src/signals/routes/zero-teams-bot.ts
+++ b/turbo/apps/api/src/signals/routes/zero-teams-bot.ts
@@ -8,13 +8,15 @@ import {
 } from "../../lib/teams-bot-activity";
 import { verifyTeamsBotAuthorization } from "../../lib/teams-bot-auth";
 import { authorization$, request$ } from "../context/hono";
+import { now } from "../external/time";
+import type { RouteEntry } from "../route-entry";
 import {
   buildTeamsConnectUrlForActivity,
   publishTeamsChanged$,
   recordTeamsInstallationActivity$,
 } from "../services/zero-teams-connect.service";
+import { dispatchTeamsMessageToAgent$ } from "../services/zero-teams-dispatch.service";
 import { safeJsonParse } from "../utils";
-import type { RouteEntry } from "../route-entry";
 
 function errorResponse(
   status: 400 | 401 | 403 | 503,
@@ -96,6 +98,16 @@ const handleZeroTeamsBot$ = command(
 
     const installation =
       activityResult.kind === "upserted" ? activityResult.installation : null;
+    const dispatch = await set(
+      dispatchTeamsMessageToAgent$,
+      {
+        activity: normalized.activity,
+        installation,
+        apiStartTime: now(),
+      },
+      signal,
+    );
+    signal.throwIfAborted();
 
     return {
       status: 200 as const,
@@ -106,6 +118,7 @@ const handleZeroTeamsBot$ = command(
           activity: normalized.activity,
           installation,
         }),
+        dispatch,
       },
     };
   },

--- a/turbo/apps/api/src/signals/services/agent-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-callback.service.ts
@@ -30,6 +30,10 @@ import {
   handleSlackOrgInternalCallbackWithoutCcstate,
 } from "./internal-slack-org-run-callback.service";
 import {
+  handleTeamsOrgInternalCallback$,
+  handleTeamsOrgInternalCallbackWithoutCcstate,
+} from "./internal-teams-org-run-callback.service";
+import {
   handleTelegramInternalCallback$,
   handleTelegramInternalCallbackWithoutCcstate,
 } from "./internal-telegram-run-callback.service";
@@ -131,6 +135,13 @@ const dispatchInternalCallback$ = command(
       case "slack:org": {
         return await set(
           handleSlackOrgInternalCallback$,
+          input.envelope,
+          signal,
+        );
+      }
+      case "teams:org": {
+        return await set(
+          handleTeamsOrgInternalCallback$,
           input.envelope,
           signal,
         );
@@ -481,6 +492,12 @@ async function dispatchInternalCallbackWithoutCcstate(
     }
     case "slack:org": {
       return await handleSlackOrgInternalCallbackWithoutCcstate(
+        input.db,
+        callbackEnvelope(input),
+      );
+    }
+    case "teams:org": {
+      return await handleTeamsOrgInternalCallbackWithoutCcstate(
         input.db,
         callbackEnvelope(input),
       );

--- a/turbo/apps/api/src/signals/services/internal-run-callback.ts
+++ b/turbo/apps/api/src/signals/services/internal-run-callback.ts
@@ -4,6 +4,7 @@ export const internalRunCallbackKinds = [
   "chat",
   "github:issues",
   "slack:org",
+  "teams:org",
   "telegram",
   "trigger:cron",
   "trigger:loop",
@@ -41,6 +42,7 @@ function isInternalRunCallbackKind(
     case "chat":
     case "github:issues":
     case "slack:org":
+    case "teams:org":
     case "telegram":
     case "trigger:cron":
     case "trigger:loop":

--- a/turbo/apps/api/src/signals/services/internal-teams-org-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-teams-org-run-callback.service.ts
@@ -1,0 +1,25 @@
+import { command } from "ccstate";
+
+import type { Db } from "../external/db";
+import type {
+  InternalRunCallbackDispatchResult,
+  InternalRunCallbackEnvelope,
+} from "./internal-run-callback";
+
+export const handleTeamsOrgInternalCallback$ = command(
+  (
+    _getters,
+    _callback: InternalRunCallbackEnvelope,
+    _signal: AbortSignal,
+  ): InternalRunCallbackDispatchResult => {
+    return { success: true, skipped: true };
+  },
+);
+
+export function handleTeamsOrgInternalCallbackWithoutCcstate(
+  _db: Db,
+  _callback: InternalRunCallbackEnvelope,
+  _signal?: AbortSignal,
+): InternalRunCallbackDispatchResult {
+  return { success: true, skipped: true };
+}

--- a/turbo/apps/api/src/signals/services/teams-org-callback-payload.ts
+++ b/turbo/apps/api/src/signals/services/teams-org-callback-payload.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+
+export const teamsOrgCallbackPayloadSchema = z
+  .object({
+    tenantId: z.string(),
+    tenantName: z.string().nullable(),
+    teamId: z.string().nullable(),
+    teamName: z.string().nullable(),
+    channelId: z.string().nullable(),
+    conversationId: z.string(),
+    conversationType: z.string().nullable(),
+    threadId: z.string(),
+    activityId: z.string().nullable(),
+    serviceUrl: z.string(),
+    connectionId: z.string(),
+    teamsUserId: z.string(),
+    teamsUserDisplayName: z.string().nullable(),
+    teamsUserPrincipalName: z.string().nullable(),
+    botId: z.string().nullable(),
+    botName: z.string().nullable(),
+    agentId: z.string(),
+    existingSessionId: z.string().nullable(),
+  })
+  .passthrough();
+
+export type TeamsOrgCallbackPayload = z.infer<
+  typeof teamsOrgCallbackPayloadSchema
+>;

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -86,6 +86,9 @@ interface UserInfo {
   readonly timezone: string | null;
   readonly slackDisplayName?: string;
   readonly slackUserId?: string;
+  readonly teamsUserDisplayName?: string;
+  readonly teamsUserPrincipalName?: string;
+  readonly teamsUserId?: string;
   readonly telegramDisplayName?: string;
   readonly telegramUsername?: string;
   readonly telegramUserId?: string;
@@ -136,6 +139,9 @@ interface CreateZeroRunCommandArgs {
     UserInfo,
     | "slackDisplayName"
     | "slackUserId"
+    | "teamsUserDisplayName"
+    | "teamsUserPrincipalName"
+    | "teamsUserId"
     | "telegramDisplayName"
     | "telegramUsername"
     | "telegramUserId"
@@ -167,6 +173,9 @@ interface CreateZeroIntegrationRunCommandArgs {
     UserInfo,
     | "slackDisplayName"
     | "slackUserId"
+    | "teamsUserDisplayName"
+    | "teamsUserPrincipalName"
+    | "teamsUserId"
     | "telegramDisplayName"
     | "telegramUsername"
     | "telegramUserId"
@@ -243,6 +252,12 @@ function buildIntegrationToolsPrompt(
         ...localFileContextLines,
       ];
     }
+    case "teams": {
+      return [
+        "- Microsoft Teams messaging and files: normal replies are automatically sent to the originating conversation, so extra messaging commands are only for explicit additional delivery targets. Do not use Slack or Telegram commands for Microsoft Teams delivery.",
+        ...localFileContextLines,
+      ];
+    }
     case "github": {
       return [
         "- GitHub issue/PR files: use `zero github --help`. Normal replies are automatically sent to the originating issue or pull request, so GitHub commands are for explicit extra file delivery. Use `zero github download-file -h` for `[GitHub file]` blocks. `zero github upload-file -h` can share a local file back to the issue or pull request when file delivery is needed.",
@@ -311,6 +326,15 @@ function buildCurrentUserPrompt(userInfo: UserInfo): string {
   }
   if (userInfo.slackUserId) {
     lines.push(`Slack user ID: ${userInfo.slackUserId}`);
+  }
+  if (userInfo.teamsUserDisplayName) {
+    lines.push(`Teams display name: ${userInfo.teamsUserDisplayName}`);
+  }
+  if (userInfo.teamsUserPrincipalName) {
+    lines.push(`Teams user principal name: ${userInfo.teamsUserPrincipalName}`);
+  }
+  if (userInfo.teamsUserId) {
+    lines.push(`Teams user ID: ${userInfo.teamsUserId}`);
   }
   if (userInfo.telegramDisplayName) {
     lines.push(`Telegram display name: ${userInfo.telegramDisplayName}`);

--- a/turbo/apps/api/src/signals/services/zero-teams-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-teams-dispatch.service.ts
@@ -1,0 +1,587 @@
+import { randomBytes } from "node:crypto";
+
+import { command } from "ccstate";
+import { agentSessions } from "@vm0/db/schema/agent-session";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { teamsOrgConnections } from "@vm0/db/schema/teams-org-connection";
+import { teamsOrgInstallations } from "@vm0/db/schema/teams-org-installation";
+import { teamsOrgThreadSessions } from "@vm0/db/schema/teams-org-thread-session";
+import { teamsUserAgentPreferences } from "@vm0/db/schema/teams-user-agent-preference";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import type { TeamsInboundActivity } from "@vm0/api-contracts/contracts/zero-teams-bot";
+import { and, eq, or } from "drizzle-orm";
+
+import { logger } from "../../lib/log";
+import { writeDb$, type Db } from "../external/db";
+import { dispatchFailedRunCallbacks } from "./agent-run-callback.service";
+import { formatIntegrationRunError$ } from "./integration-run-errors.service";
+import {
+  resolveIntegrationModelRouteForUser$,
+  type IntegrationModelRoutePin,
+} from "./integration-model-route.service";
+import { canReuseIntegrationSessionForModelRoute } from "./integration-session-model-compatibility.service";
+import {
+  teamsOrgCallbackPayloadSchema,
+  type TeamsOrgCallbackPayload,
+} from "./teams-org-callback-payload";
+import { buildTeamsConnectUrlForActivity } from "./zero-teams-connect.service";
+import { createZeroRun$ } from "./zero-runs-create.service";
+
+const L = logger("TeamsDispatch");
+
+type TeamsInstallation = typeof teamsOrgInstallations.$inferSelect;
+type BoundTeamsInstallation = TeamsInstallation & { readonly orgId: string };
+type TeamsConnection = typeof teamsOrgConnections.$inferSelect;
+type TeamsMessageActivity = Extract<TeamsInboundActivity, { kind: "message" }>;
+
+interface TeamsAgent {
+  readonly id: string;
+  readonly name: string;
+  readonly displayName: string | null;
+}
+
+type EffectiveComposeResolution =
+  | {
+      readonly status: "resolved";
+      readonly composeId: string;
+      readonly agent: TeamsAgent;
+    }
+  | {
+      readonly status: "not_configured" | "not_found" | "not_accessible";
+    };
+
+type TeamsMessageDispatchResult =
+  | { readonly kind: "ignored" }
+  | {
+      readonly kind: "notice";
+      readonly replyText: string;
+      readonly connectUrl?: string;
+    }
+  | {
+      readonly kind: "accepted" | "queued";
+      readonly runId: string;
+    }
+  | {
+      readonly kind: "failed";
+      readonly replyText: string;
+      readonly runId?: string;
+    };
+
+function callbackSecret(): string {
+  return randomBytes(32).toString("hex");
+}
+
+function nonEmpty(value: string | null | undefined): string | undefined {
+  return value && value.length > 0 ? value : undefined;
+}
+
+function optionalLine(
+  label: string,
+  value: string | null | undefined,
+): string[] {
+  const normalized = nonEmpty(value);
+  return normalized ? [`${label}: ${normalized}`] : [];
+}
+
+async function installationForTenant(
+  db: Db,
+  tenantId: string,
+): Promise<TeamsInstallation | undefined> {
+  const [installation] = await db
+    .select()
+    .from(teamsOrgInstallations)
+    .where(eq(teamsOrgInstallations.teamsTenantId, tenantId))
+    .limit(1);
+  return installation;
+}
+
+async function connectionForTeamsUser(
+  db: Db,
+  tenantId: string,
+  teamsUserId: string,
+): Promise<TeamsConnection | undefined> {
+  const [connection] = await db
+    .select()
+    .from(teamsOrgConnections)
+    .where(
+      and(
+        eq(teamsOrgConnections.teamsTenantId, tenantId),
+        eq(teamsOrgConnections.teamsUserId, teamsUserId),
+      ),
+    )
+    .limit(1);
+  return connection;
+}
+
+async function resolveDefaultComposeId(
+  db: Db,
+  orgId: string,
+): Promise<string | null> {
+  const [metadata] = await db
+    .select({ defaultAgentId: orgMetadata.defaultAgentId })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, orgId))
+    .limit(1);
+  return metadata?.defaultAgentId ?? null;
+}
+
+async function getUserAgentPreference(
+  db: Db,
+  vm0UserId: string,
+  orgId: string,
+): Promise<string | null> {
+  const [preference] = await db
+    .select({ selectedComposeId: teamsUserAgentPreferences.selectedComposeId })
+    .from(teamsUserAgentPreferences)
+    .where(
+      and(
+        eq(teamsUserAgentPreferences.vm0UserId, vm0UserId),
+        eq(teamsUserAgentPreferences.orgId, orgId),
+      ),
+    )
+    .limit(1);
+  return preference?.selectedComposeId ?? null;
+}
+
+async function getWorkspaceAgent(
+  db: Db,
+  composeId: string,
+  orgId: string,
+): Promise<TeamsAgent | undefined> {
+  const [agent] = await db
+    .select({
+      id: zeroAgents.id,
+      name: zeroAgents.name,
+      displayName: zeroAgents.displayName,
+    })
+    .from(zeroAgents)
+    .where(and(eq(zeroAgents.id, composeId), eq(zeroAgents.orgId, orgId)))
+    .limit(1);
+  return agent;
+}
+
+async function getVisibleWorkspaceAgent(args: {
+  readonly db: Db;
+  readonly composeId: string;
+  readonly orgId: string;
+  readonly userId: string;
+}): Promise<TeamsAgent | undefined> {
+  const [agent] = await args.db
+    .select({
+      id: zeroAgents.id,
+      name: zeroAgents.name,
+      displayName: zeroAgents.displayName,
+    })
+    .from(zeroAgents)
+    .where(
+      and(
+        eq(zeroAgents.id, args.composeId),
+        eq(zeroAgents.orgId, args.orgId),
+        or(
+          eq(zeroAgents.visibility, "public"),
+          eq(zeroAgents.owner, args.userId),
+        ),
+      ),
+    )
+    .limit(1);
+  return agent;
+}
+
+async function resolveEffectiveCompose(args: {
+  readonly db: Db;
+  readonly vm0UserId: string;
+  readonly orgId: string;
+}): Promise<EffectiveComposeResolution> {
+  const override = await getUserAgentPreference(
+    args.db,
+    args.vm0UserId,
+    args.orgId,
+  );
+  if (override) {
+    const agent = await getVisibleWorkspaceAgent({
+      db: args.db,
+      composeId: override,
+      orgId: args.orgId,
+      userId: args.vm0UserId,
+    });
+    if (agent) {
+      return { status: "resolved", composeId: override, agent };
+    }
+  }
+
+  const defaultComposeId = await resolveDefaultComposeId(args.db, args.orgId);
+  if (!defaultComposeId) {
+    return { status: "not_configured" };
+  }
+  const configuredDefaultAgent = await getWorkspaceAgent(
+    args.db,
+    defaultComposeId,
+    args.orgId,
+  );
+  if (!configuredDefaultAgent) {
+    return { status: "not_found" };
+  }
+  const visibleDefaultAgent = await getVisibleWorkspaceAgent({
+    db: args.db,
+    composeId: defaultComposeId,
+    orgId: args.orgId,
+    userId: args.vm0UserId,
+  });
+  if (!visibleDefaultAgent) {
+    return { status: "not_accessible" };
+  }
+  return {
+    status: "resolved",
+    composeId: defaultComposeId,
+    agent: visibleDefaultAgent,
+  };
+}
+
+async function resolveCompatibleTeamsThreadSession(args: {
+  readonly db: Db;
+  readonly connectionId: string;
+  readonly conversationId: string;
+  readonly threadId: string;
+  readonly userId: string;
+  readonly composeId: string;
+  readonly modelRoute: IntegrationModelRoutePin | undefined;
+}): Promise<string | undefined> {
+  const [threadSession] = await args.db
+    .select({ agentSessionId: teamsOrgThreadSessions.agentSessionId })
+    .from(teamsOrgThreadSessions)
+    .where(
+      and(
+        eq(teamsOrgThreadSessions.connectionId, args.connectionId),
+        eq(teamsOrgThreadSessions.teamsConversationId, args.conversationId),
+        eq(teamsOrgThreadSessions.teamsThreadId, args.threadId),
+      ),
+    )
+    .limit(1);
+  if (!threadSession?.agentSessionId) {
+    return undefined;
+  }
+
+  const [agentSession] = await args.db
+    .select({ agentComposeId: agentSessions.agentComposeId })
+    .from(agentSessions)
+    .where(
+      and(
+        eq(agentSessions.id, threadSession.agentSessionId),
+        eq(agentSessions.userId, args.userId),
+      ),
+    )
+    .limit(1);
+  if (agentSession?.agentComposeId !== args.composeId) {
+    return undefined;
+  }
+
+  if (args.modelRoute) {
+    const canReuseSession = await canReuseIntegrationSessionForModelRoute({
+      db: args.db,
+      sessionId: threadSession.agentSessionId,
+      modelRoute: args.modelRoute,
+    });
+    if (!canReuseSession) {
+      return undefined;
+    }
+  }
+
+  return threadSession.agentSessionId;
+}
+
+function buildTeamsPrompt(args: {
+  readonly activity: TeamsMessageActivity;
+  readonly installation: TeamsInstallation;
+}): string {
+  const recipient = args.activity.recipient;
+  return [
+    "# Current Integration",
+    "You are currently running inside: Microsoft Teams",
+    `Tenant ID: ${args.activity.tenantId}`,
+    ...optionalLine("Tenant name", args.activity.tenantName),
+    ...optionalLine("Team ID", args.activity.teamId),
+    ...optionalLine("Team name", args.activity.teamName),
+    ...optionalLine("Channel ID", args.activity.channelId),
+    `Conversation ID: ${args.activity.conversationId}`,
+    ...optionalLine("Conversation type", args.activity.conversationType),
+    `Thread ID: ${args.activity.threadId}`,
+    ...optionalLine("Activity ID", args.activity.activityId),
+    ...optionalLine("Teams app ID", args.activity.teamsAppId),
+    ...optionalLine("Bot ID", recipient?.id ?? args.installation.botId),
+    ...optionalLine("Bot name", recipient?.name ?? args.installation.botName),
+    `Teams user ID: ${args.activity.sender.id}`,
+    ...optionalLine("Teams user display name", args.activity.sender.name),
+    ...optionalLine(
+      "Teams user principal name",
+      args.activity.sender.userPrincipalName,
+    ),
+  ].join("\n");
+}
+
+function callbackPayload(args: {
+  readonly activity: TeamsMessageActivity;
+  readonly installation: TeamsInstallation;
+  readonly connection: TeamsConnection;
+  readonly composeId: string;
+  readonly existingSessionId: string | undefined;
+}): TeamsOrgCallbackPayload {
+  return teamsOrgCallbackPayloadSchema.parse({
+    tenantId: args.activity.tenantId,
+    tenantName: args.activity.tenantName,
+    teamId: args.activity.teamId,
+    teamName: args.activity.teamName,
+    channelId: args.activity.channelId,
+    conversationId: args.activity.conversationId,
+    conversationType: args.activity.conversationType,
+    threadId: args.activity.threadId,
+    activityId: args.activity.activityId,
+    serviceUrl: args.activity.serviceUrl,
+    connectionId: args.connection.id,
+    teamsUserId: args.activity.sender.id,
+    teamsUserDisplayName: args.activity.sender.name,
+    teamsUserPrincipalName: args.activity.sender.userPrincipalName,
+    botId: args.activity.recipient?.id ?? args.installation.botId,
+    botName: args.activity.recipient?.name ?? args.installation.botName,
+    agentId: args.composeId,
+    existingSessionId: args.existingSessionId ?? null,
+  });
+}
+
+const runAgentForTeams$ = command(
+  async (
+    { set },
+    args: {
+      readonly activity: TeamsMessageActivity;
+      readonly installation: BoundTeamsInstallation;
+      readonly connection: TeamsConnection;
+      readonly composeId: string;
+      readonly sessionId: string | undefined;
+      readonly apiStartTime: number;
+      readonly modelRoute: IntegrationModelRoutePin | undefined;
+    },
+    signal: AbortSignal,
+  ): Promise<TeamsMessageDispatchResult> => {
+    const result = await set(
+      createZeroRun$,
+      {
+        auth: {
+          tokenType: "session",
+          userId: args.connection.vm0UserId,
+          orgId: args.installation.orgId,
+          orgRole: "member",
+        },
+        body: {
+          prompt: args.activity.text,
+          agentId: args.composeId,
+          sessionId: args.sessionId,
+          ...(args.modelRoute?.modelProviderType
+            ? { modelProvider: args.modelRoute.modelProviderType }
+            : {}),
+        },
+        apiStartTime: args.apiStartTime,
+        triggerSource: "teams",
+        appendSystemPrompt: buildTeamsPrompt({
+          activity: args.activity,
+          installation: args.installation,
+        }),
+        userInfoExtras: {
+          teamsUserDisplayName: args.activity.sender.name ?? undefined,
+          teamsUserPrincipalName:
+            args.activity.sender.userPrincipalName ?? undefined,
+          teamsUserId: args.activity.sender.id,
+        },
+        modelProviderId: args.modelRoute?.modelProviderId ?? undefined,
+        modelProviderCredentialScope:
+          args.modelRoute?.modelProviderCredentialScope ?? undefined,
+        selectedModelOverride: args.modelRoute?.selectedModel ?? undefined,
+        dispatchFailedCallbacks: dispatchFailedRunCallbacks,
+        callbacks: [
+          {
+            internalKind: "teams:org",
+            secret: callbackSecret(),
+            payload: callbackPayload({
+              activity: args.activity,
+              installation: args.installation,
+              connection: args.connection,
+              composeId: args.composeId,
+              existingSessionId: args.sessionId,
+            }),
+          },
+        ],
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    if (result.status === 201) {
+      return {
+        kind: result.body.status === "queued" ? "queued" : "accepted",
+        runId: result.body.runId,
+      };
+    }
+
+    return {
+      kind: "failed",
+      replyText: await set(
+        formatIntegrationRunError$,
+        {
+          orgId: args.installation.orgId,
+          userId: args.connection.vm0UserId,
+          code: result.body.error.code,
+          message: result.body.error.message,
+        },
+        signal,
+      ),
+    };
+  },
+);
+
+function connectNotice(
+  activity: TeamsMessageActivity,
+  installation: TeamsInstallation | null,
+): TeamsMessageDispatchResult {
+  const connectUrl = buildTeamsConnectUrlForActivity({
+    activity,
+    installation,
+  });
+  return {
+    kind: "notice",
+    replyText: connectUrl
+      ? `Please connect your Microsoft Teams account to Zero first: ${connectUrl}`
+      : "Please connect your Microsoft Teams account to Zero first.",
+    ...(connectUrl ? { connectUrl } : {}),
+  };
+}
+
+export const dispatchTeamsMessageToAgent$ = command(
+  async (
+    { set },
+    args: {
+      readonly activity: TeamsInboundActivity;
+      readonly installation?: TeamsInstallation | null;
+      readonly apiStartTime: number;
+    },
+    signal: AbortSignal,
+  ): Promise<TeamsMessageDispatchResult> => {
+    if (args.activity.kind !== "message") {
+      return { kind: "ignored" };
+    }
+
+    const activity = args.activity;
+    const prompt = activity.text.trim();
+    if (!prompt) {
+      return {
+        kind: "notice",
+        replyText: "Please include a message for Zero.",
+      };
+    }
+
+    const db = set(writeDb$);
+    const installation =
+      args.installation ??
+      (await installationForTenant(db, activity.tenantId)) ??
+      null;
+    signal.throwIfAborted();
+
+    if (!installation?.orgId) {
+      return connectNotice(activity, installation);
+    }
+    const boundInstallation: BoundTeamsInstallation = {
+      ...installation,
+      orgId: installation.orgId,
+    };
+
+    const connection = await connectionForTeamsUser(
+      db,
+      activity.tenantId,
+      activity.sender.id,
+    );
+    signal.throwIfAborted();
+
+    if (!connection) {
+      return connectNotice(activity, installation);
+    }
+
+    const effectiveCompose = await resolveEffectiveCompose({
+      db,
+      vm0UserId: connection.vm0UserId,
+      orgId: boundInstallation.orgId,
+    });
+    signal.throwIfAborted();
+
+    switch (effectiveCompose.status) {
+      case "not_configured": {
+        return {
+          kind: "notice",
+          replyText:
+            "No agent is configured for this org. Please ask your org admin to set a default agent.",
+        };
+      }
+      case "not_found": {
+        return {
+          kind: "notice",
+          replyText:
+            "The configured agent could not be found. Please contact your org admin.",
+        };
+      }
+      case "not_accessible": {
+        return {
+          kind: "notice",
+          replyText:
+            "The configured agent is not available to your Microsoft Teams account.",
+        };
+      }
+      case "resolved": {
+        break;
+      }
+    }
+
+    const modelRoute = await set(
+      resolveIntegrationModelRouteForUser$,
+      {
+        orgId: boundInstallation.orgId,
+        userId: connection.vm0UserId,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    const existingSessionId = await resolveCompatibleTeamsThreadSession({
+      db,
+      connectionId: connection.id,
+      conversationId: activity.conversationId,
+      threadId: activity.threadId,
+      userId: connection.vm0UserId,
+      composeId: effectiveCompose.composeId,
+      modelRoute,
+    });
+    signal.throwIfAborted();
+
+    const result = await set(
+      runAgentForTeams$,
+      {
+        activity: { ...activity, text: prompt },
+        installation: boundInstallation,
+        connection,
+        composeId: effectiveCompose.composeId,
+        sessionId: existingSessionId,
+        apiStartTime: args.apiStartTime,
+        modelRoute,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    if (result.kind === "failed") {
+      L.warn("Teams agent dispatch failed", {
+        tenantId: activity.tenantId,
+        conversationId: activity.conversationId,
+        threadId: activity.threadId,
+        userId: connection.vm0UserId,
+        runId: result.runId,
+      });
+    }
+
+    return result;
+  },
+);

--- a/turbo/apps/api/src/signals/services/zero-usage-record.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage-record.service.ts
@@ -30,6 +30,7 @@ const USAGE_RECORD_KINDS = ["model", "image", "video", "connector"] as const;
 const PASSTHROUGH_TRIGGER_SOURCES = [
   "automation",
   "slack",
+  "teams",
   "telegram",
   "email",
   "agentphone",

--- a/turbo/apps/platform/src/signals/zero-page/log-types.ts
+++ b/turbo/apps/platform/src/signals/zero-page/log-types.ts
@@ -12,6 +12,7 @@ export const TRIGGER_SOURCE_LABELS: Readonly<Record<TriggerSource, string>> = {
   automation: "Automation",
   web: "Web",
   slack: "Slack",
+  teams: "Teams",
   email: "Email",
   telegram: "Telegram",
   agentphone: "AgentPhone",

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-usage-record.tsx
@@ -54,6 +54,7 @@ const SOURCE_META = {
   chat: { label: "Chat", Icon: IconMessageCircle },
   automation: { label: "Automation", Icon: IconClock },
   slack: { label: "Slack", Icon: IconBrandSlack },
+  teams: { label: "Teams", Icon: IconMessageCircle },
   telegram: { label: "Telegram", Icon: IconBrandTelegram },
   email: { label: "Email", Icon: IconMail },
   agentphone: { label: "Phone", Icon: IconPhone },

--- a/turbo/packages/api-contracts/src/contracts/logs.ts
+++ b/turbo/packages/api-contracts/src/contracts/logs.ts
@@ -47,6 +47,7 @@ export const triggerSourceSchema = z.enum([
   "automation",
   "web",
   "slack",
+  "teams",
   "email",
   "telegram",
   "agentphone",

--- a/turbo/packages/api-contracts/src/contracts/zero-teams-bot.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-teams-bot.ts
@@ -75,10 +75,33 @@ export const teamsInboundActivitySchema = z.discriminatedUnion("kind", [
   teamsUnsupportedActivitySchema,
 ]);
 
+const teamsBotDispatchResponseSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("ignored") }),
+  z.object({
+    kind: z.literal("notice"),
+    replyText: z.string(),
+    connectUrl: z.string().optional(),
+  }),
+  z.object({
+    kind: z.literal("accepted"),
+    runId: z.string(),
+  }),
+  z.object({
+    kind: z.literal("queued"),
+    runId: z.string(),
+  }),
+  z.object({
+    kind: z.literal("failed"),
+    replyText: z.string(),
+    runId: z.string().optional(),
+  }),
+]);
+
 export const teamsBotIngressResponseSchema = z.object({
   ok: z.literal(true),
   activity: teamsInboundActivitySchema,
   connectUrl: z.string().nullable().optional(),
+  dispatch: teamsBotDispatchResponseSchema.optional(),
 });
 
 export const zeroTeamsBotContract = c.router({
@@ -101,5 +124,8 @@ export type TeamsActor = z.infer<typeof teamsActorSchema>;
 export type TeamsInboundActivity = z.infer<typeof teamsInboundActivitySchema>;
 export type TeamsBotIngressResponse = z.infer<
   typeof teamsBotIngressResponseSchema
+>;
+export type TeamsBotDispatchResponse = z.infer<
+  typeof teamsBotDispatchResponseSchema
 >;
 export type ZeroTeamsBotContract = typeof zeroTeamsBotContract;

--- a/turbo/packages/api-contracts/src/contracts/zero-usage-record.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-usage-record.ts
@@ -11,6 +11,7 @@ export const usageRecordSourceSchema = z.enum([
   "chat",
   "automation",
   "slack",
+  "teams",
   "telegram",
   "email",
   "agentphone",


### PR DESCRIPTION
## Summary
- add Teams message dispatch from bot ingress through org installation/user connection resolution
- resolve Teams agent selection from user preference and org default, then create runs with Teams trigger source, model route override, Teams user info, and teams:org callback payload
- add Teams run/usage source labels in contracts and platform maps
- cover unlinked, connected dispatch, and missing-default-agent bot ingress paths

## Tests
- pnpm -F api lint
- pnpm -F api check-types
- pnpm -F @vm0/api-contracts check-types
- pnpm -F @vm0/api-contracts lint
- pnpm -F @vm0/app check-types
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-teams-bot.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-usage-record.test.ts
- pnpm knip
- pre-commit: pnpm check-types

Closes #19448