### PR TITLE
refactor: generate resume history limit for rust

### DIFF
--- a/crates/api-contracts/src/generated/constants.rs
+++ b/crates/api-contracts/src/generated/constants.rs
@@ -1,4 +1,4 @@
-//! Generated Rust string constants for `@vm0/api-contracts`.
+//! Generated Rust constants for `@vm0/api-contracts`.
 //! Do not edit by hand; regenerate with `cd turbo && pnpm -F @vm0/api-contracts generate:rust`.
 //! These constants are shared TypeScript/Rust contract values.
 //! Token-shaped placeholder values in this module are fake marker bytes, not secrets.
@@ -61,6 +61,10 @@ pub mod model_provider_env {
 
 /// Runner contract constants shared by TypeScript and Rust.
 pub mod runners {
+    /// Maximum resume session history blob size accepted by the API and runner.
+    /// Rust and TypeScript components use this shared contract value when validating resume history refs and downloads.
+    pub const RESUME_SESSION_HISTORY_MAX_BYTES: u64 = 134217728;
+
     /// Runner and guest filesystem path constants shared across Rust and TypeScript.
     pub mod paths {
         /// Canonical home directory path expected for the sandbox user inside runner guests.

--- a/crates/runner/src/executor/session_history_download.rs
+++ b/crates/runner/src/executor/session_history_download.rs
@@ -17,6 +17,7 @@
 
 use std::time::{Duration, Instant};
 
+use api_contracts::generated::constants::runners::RESUME_SESSION_HISTORY_MAX_BYTES;
 use sha2::{Digest, Sha256};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
@@ -27,8 +28,6 @@ use crate::http::HttpClient;
 use crate::types::{ResumeSession, ResumeSessionHistoryRefKind};
 
 const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(30);
-// Must stay in sync with RESUME_SESSION_HISTORY_MAX_BYTES in the API contracts.
-const MAX_SESSION_HISTORY_BYTES: u64 = 128 * 1024 * 1024;
 
 pub(crate) struct SessionHistoryMaterializer {
     state: SessionHistoryMaterializerState,
@@ -231,10 +230,10 @@ async fn download_resume_session_history(
         ResumeSessionHistoryRefKind::Blob => {}
     }
     if let Some(expected_size) = history_ref.size
-        && expected_size > MAX_SESSION_HISTORY_BYTES
+        && expected_size > RESUME_SESSION_HISTORY_MAX_BYTES
     {
         return Err(RunnerError::Internal(format!(
-            "session history is too large: {expected_size} bytes exceeds {MAX_SESSION_HISTORY_BYTES} bytes"
+            "session history is too large: {expected_size} bytes exceeds {RESUME_SESSION_HISTORY_MAX_BYTES} bytes"
         )));
     }
 
@@ -288,9 +287,9 @@ async fn download_body(
         })?;
 
     if let Some(content_length) = response.content_length() {
-        if content_length > MAX_SESSION_HISTORY_BYTES {
+        if content_length > RESUME_SESSION_HISTORY_MAX_BYTES {
             return Err(RunnerError::Internal(format!(
-                "session history is too large: {content_length} bytes exceeds {MAX_SESSION_HISTORY_BYTES} bytes"
+                "session history is too large: {content_length} bytes exceeds {RESUME_SESSION_HISTORY_MAX_BYTES} bytes"
             )));
         }
         if let Some(expected_size) = expected_size
@@ -304,7 +303,7 @@ async fn download_body(
 
     let capacity = expected_size
         .unwrap_or(64 * 1024)
-        .min(MAX_SESSION_HISTORY_BYTES)
+        .min(RESUME_SESSION_HISTORY_MAX_BYTES)
         .min(usize::MAX as u64) as usize;
     let mut body = Vec::with_capacity(capacity);
     let mut downloaded = 0u64;
@@ -316,9 +315,9 @@ async fn download_body(
         ))
     })? {
         downloaded += chunk.len() as u64;
-        if downloaded > MAX_SESSION_HISTORY_BYTES {
+        if downloaded > RESUME_SESSION_HISTORY_MAX_BYTES {
             return Err(RunnerError::Internal(format!(
-                "session history is too large: {downloaded} bytes exceeds {MAX_SESSION_HISTORY_BYTES} bytes"
+                "session history is too large: {downloaded} bytes exceeds {RESUME_SESSION_HISTORY_MAX_BYTES} bytes"
             )));
         }
         body.extend_from_slice(&chunk);
@@ -479,7 +478,7 @@ mod tests {
     #[tokio::test]
     async fn materializer_rejects_oversized_content_length() {
         let session = ref_session(
-            serve_once("200 OK", b"", Some(MAX_SESSION_HISTORY_BYTES + 1)).await,
+            serve_once("200 OK", b"", Some(RESUME_SESSION_HISTORY_MAX_BYTES + 1)).await,
             hex::encode(Sha256::digest(b"")),
             None,
         );

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -19,8 +19,8 @@ const CANONICAL_CLAUDE_PROJECT_NAME = CANONICAL_WORKING_DIR.replace(
 ).replace(/\//g, "-");
 export const CANONICAL_CLAUDE_MEMORY_MOUNT_PATH = `${CANONICAL_GUEST_HOME_DIR}/.claude/projects/-${CANONICAL_CLAUDE_PROJECT_NAME}/memory`;
 export const CANONICAL_CODEX_MEMORY_MOUNT_PATH = `${CANONICAL_GUEST_HOME_DIR}/.codex/memories`;
-// Must stay in sync with the runner download cap:
-// crates/runner/src/executor/session_history_download.rs.
+// Shared resume history size contract. Rust consumers import the generated
+// binding from `api_contracts::generated::constants`.
 export const RESUME_SESSION_HISTORY_MAX_BYTES = 128 * 1024 * 1024;
 
 export function elapsedSinceApiStartMs(

--- a/turbo/packages/api-contracts/src/rust-bindings/__tests__/constants.test.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/__tests__/constants.test.ts
@@ -1,12 +1,13 @@
 import {
-  normalizeStringConstantBindings,
-  renderRustStringConstants,
-  type NormalizedStringConstantBinding,
+  normalizeConstantBindings,
+  renderRustConstants,
+  type NormalizedConstantBinding,
 } from "../generate";
 import {
-  type RustStringConstantModuleDoc,
-  type RustStringConstantBinding,
-  rustStringConstantBindings,
+  type RustConstantModuleDoc,
+  type RustConstantBinding,
+  type RustConstantValue,
+  rustConstantBindings,
 } from "../constants";
 import {
   MODEL_PROVIDER_ENV_PLACEHOLDERS,
@@ -15,6 +16,7 @@ import {
 import {
   CANONICAL_GUEST_HOME_DIR,
   CANONICAL_WORKING_DIR,
+  RESUME_SESSION_HISTORY_MAX_BYTES,
 } from "../../contracts/runners";
 
 const codexOauthPlaceholders =
@@ -30,6 +32,19 @@ const canonicalWorkingDirDoc = [
   "Rust and TypeScript components use this shared contract value when building runner commands and paths.",
 ] as const;
 
+const resumeSessionHistoryMaxBytesDoc = [
+  "Maximum resume session history blob size accepted by the API and runner.",
+  "Rust and TypeScript components use this shared contract value when validating resume history refs and downloads.",
+] as const;
+
+function rustString(value: string): RustConstantValue {
+  return { kind: "string", value };
+}
+
+function rustU64(value: number): RustConstantValue {
+  return { kind: "u64", value };
+}
+
 function placeholderRustDoc(name: string): readonly string[] {
   return [
     `Fake marker bytes for the \`${name}\` placeholder.`,
@@ -39,75 +54,81 @@ function placeholderRustDoc(name: string): readonly string[] {
 
 const expectedBindings = [
   {
+    rustModulePath: ["runners"],
+    rustConstName: "RESUME_SESSION_HISTORY_MAX_BYTES",
+    value: rustU64(RESUME_SESSION_HISTORY_MAX_BYTES),
+    rustDoc: resumeSessionHistoryMaxBytesDoc,
+  },
+  {
     rustModulePath: ["runners", "paths"],
     rustConstName: "CANONICAL_GUEST_HOME_DIR",
-    value: CANONICAL_GUEST_HOME_DIR,
+    value: rustString(CANONICAL_GUEST_HOME_DIR),
     rustDoc: canonicalGuestHomeDirDoc,
   },
   {
     rustModulePath: ["runners", "paths"],
     rustConstName: "CANONICAL_WORKING_DIR",
-    value: CANONICAL_WORKING_DIR,
+    value: rustString(CANONICAL_WORKING_DIR),
     rustDoc: canonicalWorkingDirDoc,
   },
   {
     rustModulePath: ["codex_oauth_token", "placeholders"],
     rustConstName: "CHATGPT_ACCESS_TOKEN",
-    value: codexOauthPlaceholders.CHATGPT_ACCESS_TOKEN,
+    value: rustString(codexOauthPlaceholders.CHATGPT_ACCESS_TOKEN),
     rustDoc: placeholderRustDoc("CHATGPT_ACCESS_TOKEN"),
   },
   {
     rustModulePath: ["codex_oauth_token", "placeholders"],
     rustConstName: "CHATGPT_ACCOUNT_ID",
-    value: codexOauthPlaceholders.CHATGPT_ACCOUNT_ID,
+    value: rustString(codexOauthPlaceholders.CHATGPT_ACCOUNT_ID),
     rustDoc: placeholderRustDoc("CHATGPT_ACCOUNT_ID"),
   },
   {
     rustModulePath: ["codex_oauth_token", "placeholders"],
     rustConstName: "CHATGPT_REFRESH_TOKEN",
-    value: codexOauthPlaceholders.CHATGPT_REFRESH_TOKEN,
+    value: rustString(codexOauthPlaceholders.CHATGPT_REFRESH_TOKEN),
     rustDoc: placeholderRustDoc("CHATGPT_REFRESH_TOKEN"),
   },
   {
     rustModulePath: ["model_provider_env", "placeholders"],
     rustConstName: "ANTHROPIC_API_KEY",
-    value: MODEL_PROVIDER_ENV_PLACEHOLDERS.ANTHROPIC_API_KEY,
+    value: rustString(MODEL_PROVIDER_ENV_PLACEHOLDERS.ANTHROPIC_API_KEY),
     rustDoc: placeholderRustDoc("ANTHROPIC_API_KEY"),
   },
   {
     rustModulePath: ["model_provider_env", "placeholders"],
     rustConstName: "ANTHROPIC_AUTH_TOKEN",
-    value: MODEL_PROVIDER_ENV_PLACEHOLDERS.ANTHROPIC_AUTH_TOKEN,
+    value: rustString(MODEL_PROVIDER_ENV_PLACEHOLDERS.ANTHROPIC_AUTH_TOKEN),
     rustDoc: placeholderRustDoc("ANTHROPIC_AUTH_TOKEN"),
   },
   {
     rustModulePath: ["model_provider_env", "placeholders"],
     rustConstName: "CLAUDE_CODE_OAUTH_TOKEN",
-    value: MODEL_PROVIDER_ENV_PLACEHOLDERS.CLAUDE_CODE_OAUTH_TOKEN,
+    value: rustString(MODEL_PROVIDER_ENV_PLACEHOLDERS.CLAUDE_CODE_OAUTH_TOKEN),
     rustDoc: placeholderRustDoc("CLAUDE_CODE_OAUTH_TOKEN"),
   },
   {
     rustModulePath: ["model_provider_env", "placeholders"],
     rustConstName: "OPENAI_API_KEY",
-    value: MODEL_PROVIDER_ENV_PLACEHOLDERS.OPENAI_API_KEY,
+    value: rustString(MODEL_PROVIDER_ENV_PLACEHOLDERS.OPENAI_API_KEY),
     rustDoc: placeholderRustDoc("OPENAI_API_KEY"),
   },
   {
     rustModulePath: ["model_provider_env", "placeholders"],
     rustConstName: "CHATGPT_ACCESS_TOKEN",
-    value: MODEL_PROVIDER_ENV_PLACEHOLDERS.CHATGPT_ACCESS_TOKEN,
+    value: rustString(MODEL_PROVIDER_ENV_PLACEHOLDERS.CHATGPT_ACCESS_TOKEN),
     rustDoc: placeholderRustDoc("CHATGPT_ACCESS_TOKEN"),
   },
   {
     rustModulePath: ["model_provider_env", "placeholders"],
     rustConstName: "CHATGPT_ACCOUNT_ID",
-    value: MODEL_PROVIDER_ENV_PLACEHOLDERS.CHATGPT_ACCOUNT_ID,
+    value: rustString(MODEL_PROVIDER_ENV_PLACEHOLDERS.CHATGPT_ACCOUNT_ID),
     rustDoc: placeholderRustDoc("CHATGPT_ACCOUNT_ID"),
   },
   {
     rustModulePath: ["model_provider_env", "placeholders"],
     rustConstName: "CHATGPT_REFRESH_TOKEN",
-    value: MODEL_PROVIDER_ENV_PLACEHOLDERS.CHATGPT_REFRESH_TOKEN,
+    value: rustString(MODEL_PROVIDER_ENV_PLACEHOLDERS.CHATGPT_REFRESH_TOKEN),
     rustDoc: placeholderRustDoc("CHATGPT_REFRESH_TOKEN"),
   },
 ] as const;
@@ -117,21 +138,21 @@ const exampleModuleDocs = [
     rustModulePath: ["example"],
     rustDoc: ["Example generated constants."],
   },
-] satisfies readonly RustStringConstantModuleDoc[];
+] satisfies readonly RustConstantModuleDoc[];
 
 function validBinding(
-  overrides: Partial<RustStringConstantBinding> = {},
-): RustStringConstantBinding {
+  overrides: Partial<RustConstantBinding> = {},
+): RustConstantBinding {
   return {
     rustModulePath: ["example"],
     rustConstName: "EXAMPLE",
-    value: "example-value",
+    value: rustString("example-value"),
     rustDoc: ["Example generated constant."],
     ...overrides,
   };
 }
 
-function summarizeBinding(binding: NormalizedStringConstantBinding) {
+function summarizeBinding(binding: NormalizedConstantBinding) {
   return {
     rustModulePath: [...binding.rustModulePath],
     rustConstName: binding.rustConstName,
@@ -140,28 +161,37 @@ function summarizeBinding(binding: NormalizedStringConstantBinding) {
   };
 }
 
-describe("Rust string constant bindings", () => {
-  it("contains exactly the supported Rust string constant set", () => {
-    const actualBindings = normalizeStringConstantBindings(
-      rustStringConstantBindings,
-    ).map((binding) => {
-      return summarizeBinding(binding);
-    });
+function compareRustNames(
+  left: (typeof expectedBindings)[number],
+  right: (typeof expectedBindings)[number],
+): number {
+  const leftName = [...left.rustModulePath, left.rustConstName].join("::");
+  const rightName = [...right.rustModulePath, right.rustConstName].join("::");
+  if (leftName < rightName) {
+    return -1;
+  }
+  if (leftName > rightName) {
+    return 1;
+  }
+  return 0;
+}
+
+describe("Rust constant bindings", () => {
+  it("contains exactly the supported Rust constant set", () => {
+    const actualBindings = normalizeConstantBindings(rustConstantBindings).map(
+      (binding) => {
+        return summarizeBinding(binding);
+      },
+    );
 
     expect(actualBindings).toEqual(
-      [...expectedBindings].sort((left, right) => {
-        return [...left.rustModulePath, left.rustConstName]
-          .join("::")
-          .localeCompare(
-            [...right.rustModulePath, right.rustConstName].join("::"),
-          );
-      }),
+      [...expectedBindings].sort(compareRustNames),
     );
   });
 
   it("renders deterministic Rust constants for the supported registry", () => {
-    const firstRender = renderRustStringConstants(rustStringConstantBindings);
-    const secondRender = renderRustStringConstants(rustStringConstantBindings);
+    const firstRender = renderRustConstants(rustConstantBindings);
+    const secondRender = renderRustConstants(rustConstantBindings);
 
     expect(secondRender).toBe(firstRender);
     expect(firstRender).toContain("pub mod codex_oauth_token {");
@@ -169,7 +199,7 @@ describe("Rust string constant bindings", () => {
     expect(firstRender).toContain("pub mod runners {");
     expect(firstRender).toContain("pub mod placeholders {");
     expect(firstRender).toContain(
-      "//! Generated Rust string constants for `@vm0/api-contracts`.",
+      "//! Generated Rust constants for `@vm0/api-contracts`.",
     );
     expect(firstRender).toContain(
       "//! Do not edit by hand; regenerate with `cd turbo && pnpm -F @vm0/api-contracts generate:rust`.",
@@ -196,6 +226,12 @@ describe("Rust string constant bindings", () => {
       `pub const CANONICAL_WORKING_DIR: &str = "${CANONICAL_WORKING_DIR}";`,
     );
     expect(firstRender).toContain(
+      "/// Maximum resume session history blob size accepted by the API and runner.",
+    );
+    expect(firstRender).toContain(
+      `pub const RESUME_SESSION_HISTORY_MAX_BYTES: u64 = ${RESUME_SESSION_HISTORY_MAX_BYTES};`,
+    );
+    expect(firstRender).toContain(
       `pub const CHATGPT_ACCOUNT_ID: &str = "${codexOauthPlaceholders.CHATGPT_ACCOUNT_ID}";`,
     );
     expect(firstRender).toContain("pub const OPENAI_API_KEY: &str =");
@@ -209,10 +245,12 @@ describe("Rust string constant bindings", () => {
   });
 
   it("escapes Rust string literals", () => {
-    const rendered = renderRustStringConstants(
+    const rendered = renderRustConstants(
       [
         validBinding({
-          value: 'quote" backslash\\ newline\n carriage\r tab\t control\x01',
+          value: rustString(
+            'quote" backslash\\ newline\n carriage\r tab\t control\x01',
+          ),
         }),
       ],
       exampleModuleDocs,
@@ -226,7 +264,7 @@ describe("Rust string constant bindings", () => {
 
   it("fails clearly when a Rust constant name is invalid", () => {
     expect(() => {
-      normalizeStringConstantBindings([
+      normalizeConstantBindings([
         validBinding({
           rustConstName: "bad_name",
         }),
@@ -236,7 +274,7 @@ describe("Rust string constant bindings", () => {
 
   it("fails clearly when Rust doc lines are empty", () => {
     expect(() => {
-      normalizeStringConstantBindings([
+      normalizeConstantBindings([
         validBinding({
           rustDoc: [],
         }),
@@ -244,24 +282,34 @@ describe("Rust string constant bindings", () => {
     }).toThrow("missing Rust doc lines");
   });
 
+  it("fails clearly when a u64 constant value is invalid", () => {
+    expect(() => {
+      normalizeConstantBindings([
+        validBinding({
+          value: rustU64(-1),
+        }),
+      ]);
+    }).toThrow("invalid u64 constant value");
+  });
+
   it("fails clearly when Rust module docs are missing", () => {
     expect(() => {
-      renderRustStringConstants(
+      renderRustConstants(
         [validBinding()],
         [],
         ["Example generated constants root."],
       );
-    }).toThrow("missing Rust docs for string constant module example");
+    }).toThrow("missing Rust docs for constant module example");
   });
 
   it("fails clearly when Rust constant names collide", () => {
     expect(() => {
-      normalizeStringConstantBindings([
+      normalizeConstantBindings([
         validBinding(),
         validBinding({
-          value: "different-value",
+          value: rustU64(42),
         }),
       ]);
-    }).toThrow("duplicate Rust string constant binding");
+    }).toThrow("duplicate Rust constant binding");
   });
 });

--- a/turbo/packages/api-contracts/src/rust-bindings/constants.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/constants.ts
@@ -5,16 +5,27 @@ import {
 import {
   CANONICAL_GUEST_HOME_DIR,
   CANONICAL_WORKING_DIR,
+  RESUME_SESSION_HISTORY_MAX_BYTES,
 } from "../contracts/runners";
 
-export interface RustStringConstantBinding {
+export type RustConstantValue =
+  | {
+      readonly kind: "string";
+      readonly value: string;
+    }
+  | {
+      readonly kind: "u64";
+      readonly value: number;
+    };
+
+export interface RustConstantBinding {
   readonly rustModulePath: readonly string[];
   readonly rustConstName: string;
-  readonly value: string;
+  readonly value: RustConstantValue;
   readonly rustDoc: readonly string[];
 }
 
-export interface RustStringConstantModuleDoc {
+export interface RustConstantModuleDoc {
   readonly rustModulePath: readonly string[];
   readonly rustDoc: readonly string[];
 }
@@ -51,14 +62,14 @@ const modelProviderEnvPlaceholderModule = [
 ] as const;
 const runnerPathsModule = ["runners", "paths"] as const;
 
-export const rustStringConstantRootDoc = [
-  "Generated Rust string constants for `@vm0/api-contracts`.",
+export const rustConstantRootDoc = [
+  "Generated Rust constants for `@vm0/api-contracts`.",
   "Do not edit by hand; regenerate with `cd turbo && pnpm -F @vm0/api-contracts generate:rust`.",
   "These constants are shared TypeScript/Rust contract values.",
   "Token-shaped placeholder values in this module are fake marker bytes, not secrets.",
 ] as const;
 
-export const rustStringConstantModuleDocs = [
+export const rustConstantModuleDocs = [
   {
     rustModulePath: ["codex_oauth_token"],
     rustDoc: [
@@ -95,7 +106,7 @@ export const rustStringConstantModuleDocs = [
       "Runner and guest filesystem path constants shared across Rust and TypeScript.",
     ],
   },
-] satisfies readonly RustStringConstantModuleDoc[];
+] satisfies readonly RustConstantModuleDoc[];
 
 function codexOauthPlaceholder(name: CodexOauthPlaceholderName): string {
   const value =
@@ -128,11 +139,28 @@ function placeholderRustDoc(name: string): readonly string[] {
   ];
 }
 
-export const rustStringConstantBindings = [
+function rustString(value: string): RustConstantValue {
+  return { kind: "string", value };
+}
+
+function rustU64(value: number): RustConstantValue {
+  return { kind: "u64", value };
+}
+
+export const rustConstantBindings = [
+  {
+    rustModulePath: ["runners"],
+    rustConstName: "RESUME_SESSION_HISTORY_MAX_BYTES",
+    value: rustU64(RESUME_SESSION_HISTORY_MAX_BYTES),
+    rustDoc: [
+      "Maximum resume session history blob size accepted by the API and runner.",
+      "Rust and TypeScript components use this shared contract value when validating resume history refs and downloads.",
+    ],
+  },
   {
     rustModulePath: runnerPathsModule,
     rustConstName: "CANONICAL_GUEST_HOME_DIR",
-    value: CANONICAL_GUEST_HOME_DIR,
+    value: rustString(CANONICAL_GUEST_HOME_DIR),
     rustDoc: [
       "Canonical home directory path expected for the sandbox user inside runner guests.",
       "Rust and TypeScript components use this shared contract value when building runner guest paths.",
@@ -141,7 +169,7 @@ export const rustStringConstantBindings = [
   {
     rustModulePath: runnerPathsModule,
     rustConstName: "CANONICAL_WORKING_DIR",
-    value: CANONICAL_WORKING_DIR,
+    value: rustString(CANONICAL_WORKING_DIR),
     rustDoc: [
       "Canonical working directory path expected inside runner guests.",
       "Rust and TypeScript components use this shared contract value when building runner commands and paths.",
@@ -151,7 +179,7 @@ export const rustStringConstantBindings = [
     return {
       rustModulePath: codexOauthPlaceholderModule,
       rustConstName: name,
-      value: codexOauthPlaceholder(name),
+      value: rustString(codexOauthPlaceholder(name)),
       rustDoc: placeholderRustDoc(name),
     };
   }),
@@ -159,8 +187,8 @@ export const rustStringConstantBindings = [
     return {
       rustModulePath: modelProviderEnvPlaceholderModule,
       rustConstName: name,
-      value: modelProviderEnvPlaceholder(name),
+      value: rustString(modelProviderEnvPlaceholder(name)),
       rustDoc: placeholderRustDoc(name),
     };
   }),
-] satisfies readonly RustStringConstantBinding[];
+] satisfies readonly RustConstantBinding[];

--- a/turbo/packages/api-contracts/src/rust-bindings/generate.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/generate.ts
@@ -3,11 +3,12 @@ import { dirname } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { z } from "zod";
 import {
-  type RustStringConstantModuleDoc,
-  type RustStringConstantBinding,
-  rustStringConstantModuleDocs,
-  rustStringConstantRootDoc,
-  rustStringConstantBindings,
+  type RustConstantValue,
+  type RustConstantModuleDoc,
+  type RustConstantBinding,
+  rustConstantModuleDocs,
+  rustConstantRootDoc,
+  rustConstantBindings,
 } from "./constants";
 import { type RustRouteBinding, rustRouteBindings } from "./routes";
 import {
@@ -97,10 +98,10 @@ export interface NormalizedTypeBinding {
   readonly declarationDocs: ReadonlyMap<string, NormalizedTypeDeclarationDoc>;
 }
 
-export interface NormalizedStringConstantBinding {
+export interface NormalizedConstantBinding {
   readonly rustModulePath: readonly string[];
   readonly rustConstName: string;
-  readonly value: string;
+  readonly value: RustConstantValue;
   readonly rustDoc: readonly string[];
 }
 
@@ -113,7 +114,7 @@ interface TypeModuleNode {
 
 interface ConstModuleNode {
   readonly rustDoc: readonly string[];
-  readonly constants: NormalizedStringConstantBinding[];
+  readonly constants: NormalizedConstantBinding[];
   readonly children: Map<string, ConstModuleNode>;
 }
 
@@ -336,14 +337,14 @@ export async function generateRustTypesFile(
   await writeFile(outputPath, renderRustTypes(rustTypeBindings));
 }
 
-export function normalizeStringConstantBindings(
-  bindings: readonly RustStringConstantBinding[],
-): readonly NormalizedStringConstantBinding[] {
+export function normalizeConstantBindings(
+  bindings: readonly RustConstantBinding[],
+): readonly NormalizedConstantBinding[] {
   const seenRustNames = new Set<string>();
-  const normalized: NormalizedStringConstantBinding[] = [];
+  const normalized: NormalizedConstantBinding[] = [];
 
   for (const binding of bindings) {
-    const label = stringConstantLabel(binding);
+    const label = constantLabel(binding);
     const rustModulePath = validateRustModulePath(
       binding.rustModulePath,
       label,
@@ -352,31 +353,31 @@ export function normalizeStringConstantBindings(
     const rustName = [...rustModulePath, rustConstName].join("::");
 
     if (seenRustNames.has(rustName)) {
-      throw new Error(`duplicate Rust string constant binding: ${rustName}`);
+      throw new Error(`duplicate Rust constant binding: ${rustName}`);
     }
     seenRustNames.add(rustName);
 
     normalized.push({
       rustModulePath,
       rustConstName,
-      value: validateStringConstantValue(binding.value, label),
+      value: validateConstantValue(binding.value, label),
       rustDoc: validateRustDoc(binding.rustDoc, label),
     });
   }
 
-  return [...normalized].sort(compareStringConstantBindings);
+  return [...normalized].sort(compareConstantBindings);
 }
 
-export function renderRustStringConstants(
-  bindings: readonly RustStringConstantBinding[],
-  moduleDocs: readonly RustStringConstantModuleDoc[] = rustStringConstantModuleDocs,
-  rootDoc: readonly string[] = rustStringConstantRootDoc,
+export function renderRustConstants(
+  bindings: readonly RustConstantBinding[],
+  moduleDocs: readonly RustConstantModuleDoc[] = rustConstantModuleDocs,
+  rootDoc: readonly string[] = rustConstantRootDoc,
 ): string {
-  const constants = normalizeStringConstantBindings(bindings);
+  const constants = normalizeConstantBindings(bindings);
   const root = buildConstTree(
     constants,
-    normalizeStringConstantModuleDocs(moduleDocs),
-    validateRustDoc(rootDoc, "Rust string constants root docs"),
+    normalizeConstantModuleDocs(moduleDocs),
+    validateRustDoc(rootDoc, "Rust constants root docs"),
   );
   const lines = [
     ...renderInnerRustDoc(root.rustDoc),
@@ -391,10 +392,7 @@ export async function generateRustConstantsFile(
   outputPath = generatedConstantsPath,
 ): Promise<void> {
   await mkdir(dirname(outputPath), { recursive: true });
-  await writeFile(
-    outputPath,
-    renderRustStringConstants(rustStringConstantBindings),
-  );
+  await writeFile(outputPath, renderRustConstants(rustConstantBindings));
 }
 
 export function renderGeneratedMod(): string {
@@ -429,11 +427,11 @@ function typeLabel(binding: RustTypeBinding): string {
   return rustName.length > 0 ? rustName : "<unnamed type binding>";
 }
 
-function stringConstantLabel(binding: RustStringConstantBinding): string {
+function constantLabel(binding: RustConstantBinding): string {
   const rustName = [...binding.rustModulePath, binding.rustConstName].join(
     "::",
   );
-  return rustName.length > 0 ? rustName : "<unnamed string constant binding>";
+  return rustName.length > 0 ? rustName : "<unnamed Rust constant binding>";
 }
 
 function validateHttpMethod(value: unknown, label: string): HttpMethod {
@@ -557,12 +555,34 @@ function validateRustTypeName(value: string, label: string): string {
   return value;
 }
 
-function validateStringConstantValue(value: unknown, label: string): string {
-  if (typeof value !== "string") {
-    throw new Error(`${label} is missing a string constant value`);
+function validateConstantValue(
+  value: unknown,
+  label: string,
+): RustConstantValue {
+  if (!isRecord(value)) {
+    throw new Error(`${label} is missing a supported Rust constant value`);
   }
 
-  return value;
+  const kind = value["kind"];
+  const rawValue = value["value"];
+  switch (kind) {
+    case "string":
+      if (typeof rawValue !== "string") {
+        throw new Error(`${label} is missing a string constant value`);
+      }
+      return { kind, value: rawValue };
+    case "u64":
+      if (
+        typeof rawValue !== "number" ||
+        !Number.isSafeInteger(rawValue) ||
+        rawValue < 0
+      ) {
+        throw new Error(`${label} has invalid u64 constant value`);
+      }
+      return { kind, value: rawValue };
+    default:
+      throw new Error(`${label} uses unsupported Rust constant kind`);
+  }
 }
 
 function validateRustDoc(value: unknown, label: string): readonly string[] {
@@ -586,6 +606,10 @@ function isHttpMethod(value: string): value is HttpMethod {
   return httpMethods.some((method) => {
     return method === value;
   });
+}
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null;
 }
 
 function toRustMethodVariant(method: HttpMethod): RustMethodVariant {
@@ -657,36 +681,29 @@ function rustTypeName(binding: NormalizedTypeBinding): string {
   return [...binding.rustModulePath, binding.rustTypeName].join("::");
 }
 
-function compareStringConstantBindings(
-  left: NormalizedStringConstantBinding,
-  right: NormalizedStringConstantBinding,
+function compareConstantBindings(
+  left: NormalizedConstantBinding,
+  right: NormalizedConstantBinding,
 ): number {
-  return compareAscii(
-    rustStringConstantName(left),
-    rustStringConstantName(right),
-  );
+  return compareAscii(rustConstantName(left), rustConstantName(right));
 }
 
-function rustStringConstantName(
-  binding: NormalizedStringConstantBinding,
-): string {
+function rustConstantName(binding: NormalizedConstantBinding): string {
   return [...binding.rustModulePath, binding.rustConstName].join("::");
 }
 
-function normalizeStringConstantModuleDocs(
-  docs: readonly RustStringConstantModuleDoc[],
+function normalizeConstantModuleDocs(
+  docs: readonly RustConstantModuleDoc[],
 ): ReadonlyMap<string, readonly string[]> {
   const moduleDocs = new Map<string, readonly string[]>();
 
   for (const doc of docs) {
-    const label = stringConstantModuleDocLabel(doc);
+    const label = constantModuleDocLabel(doc);
     const rustModulePath = validateRustModulePath(doc.rustModulePath, label);
     const rustName = rustModuleKey(rustModulePath);
 
     if (moduleDocs.has(rustName)) {
-      throw new Error(
-        `duplicate Rust string constant module docs: ${rustName}`,
-      );
+      throw new Error(`duplicate Rust constant module docs: ${rustName}`);
     }
 
     moduleDocs.set(rustName, validateRustDoc(doc.rustDoc, label));
@@ -695,13 +712,11 @@ function normalizeStringConstantModuleDocs(
   return moduleDocs;
 }
 
-function stringConstantModuleDocLabel(
-  doc: RustStringConstantModuleDoc,
-): string {
+function constantModuleDocLabel(doc: RustConstantModuleDoc): string {
   const rustName = rustModuleKey(doc.rustModulePath);
   return rustName.length > 0
     ? `${rustName} module docs`
-    : "<unnamed string constant module docs>";
+    : "<unnamed Rust constant module docs>";
 }
 
 function normalizeTypeModuleDocs(
@@ -849,7 +864,7 @@ function createTypeModuleNode(rustDoc: readonly string[]): TypeModuleNode {
 }
 
 function buildConstTree(
-  constants: readonly NormalizedStringConstantBinding[],
+  constants: readonly NormalizedConstantBinding[],
   moduleDocs: ReadonlyMap<string, readonly string[]>,
   rootDoc: readonly string[],
 ): ConstModuleNode {
@@ -866,9 +881,7 @@ function buildConstTree(
       if (child === undefined) {
         const moduleDoc = moduleDocs.get(moduleKey);
         if (moduleDoc === undefined) {
-          throw new Error(
-            `missing Rust docs for string constant module ${moduleKey}`,
-          );
+          throw new Error(`missing Rust docs for constant module ${moduleKey}`);
         }
         child = createConstModuleNode(moduleDoc);
         node.children.set(segment, child);
@@ -895,7 +908,7 @@ function renderConstModuleNode(
   indent: string,
 ): string[] {
   const lines: string[] = [];
-  const constants = [...node.constants].sort(compareStringConstantBindings);
+  const constants = [...node.constants].sort(compareConstantBindings);
   const children = [...node.children.entries()].sort(
     ([leftName], [rightName]) => {
       return compareAscii(leftName, rightName);
@@ -904,7 +917,7 @@ function renderConstModuleNode(
 
   for (const constant of constants) {
     appendBlankLineIfNeeded(lines);
-    lines.push(...renderStringConstant(constant, indent));
+    lines.push(...renderConstant(constant, indent));
   }
 
   for (const [moduleName, child] of children) {
@@ -918,11 +931,24 @@ function renderConstModuleNode(
   return lines;
 }
 
-function renderStringConstant(
-  constant: NormalizedStringConstantBinding,
+function renderConstant(
+  constant: NormalizedConstantBinding,
   indent: string,
 ): string[] {
-  const literal = rustStringLiteral(constant.value);
+  switch (constant.value.kind) {
+    case "string":
+      return renderStringConstant(constant, indent, constant.value.value);
+    case "u64":
+      return renderU64Constant(constant, indent, constant.value.value);
+  }
+}
+
+function renderStringConstant(
+  constant: NormalizedConstantBinding,
+  indent: string,
+  value: string,
+): string[] {
+  const literal = rustStringLiteral(value);
   const singleLine = `${indent}pub const ${constant.rustConstName}: &str = ${literal};`;
   const splitValueLine = `${indent}    ${literal};`;
   if (singleLine.length <= 100 || splitValueLine.length > 100) {
@@ -933,6 +959,17 @@ function renderStringConstant(
     ...renderOuterRustDoc(constant.rustDoc, indent),
     `${indent}pub const ${constant.rustConstName}: &str =`,
     splitValueLine,
+  ];
+}
+
+function renderU64Constant(
+  constant: NormalizedConstantBinding,
+  indent: string,
+  value: number,
+): string[] {
+  return [
+    ...renderOuterRustDoc(constant.rustDoc, indent),
+    `${indent}pub const ${constant.rustConstName}: u64 = ${value};`,
   ];
 }
 


### PR DESCRIPTION
## Summary

- generalize Rust API contract constants from string-only bindings to a small typed constant registry
- generate `RESUME_SESSION_HISTORY_MAX_BYTES` into `api_contracts::generated::constants::runners`
- switch runner session history download checks to the generated `u64` contract constant

Fixes #19492

## Tests

- `pnpm -F @vm0/api-contracts exec vitest run src/rust-bindings/__tests__/constants.test.ts`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts test`
- `pnpm -F @vm0/api-contracts generate:rust`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo test --manifest-path crates/Cargo.toml -p api-contracts`
- `cargo test --manifest-path crates/Cargo.toml -p runner session_history_download`
- `git diff --check`

Pre-commit also passed prettier, cargo-doc, cargo-clippy, knip, and full `pnpm check-types` through lefthook.
