### PR TITLE
feat: add website image edit controls

### DIFF
--- a/turbo/apps/platform/src/mocks/upload-helpers.ts
+++ b/turbo/apps/platform/src/mocks/upload-helpers.ts
@@ -4,6 +4,7 @@
  * Production uploads run in two steps:
  *   1. POST /api/zero/uploads/prepare  → JSON { id, uploadUrl, url, ... }
  *   2. PUT  <uploadUrl>                → 200 (direct to R2)
+ *   3. POST /api/zero/uploads/complete → JSON { id, url, ... }
  *
  * These helpers register MSW handlers for both steps so individual tests only
  * have to describe the resulting file metadata, not the wire protocol.
@@ -43,6 +44,9 @@ export function mockUploadSuccess(result: MockUploadResult): HttpHandler[] {
     }),
     http.put(uploadUrl, () => {
       return new HttpResponse(null, { status: 200 });
+    }),
+    http.post("*/api/zero/uploads/complete", () => {
+      return HttpResponse.json(result);
     }),
   ];
 }

--- a/turbo/apps/platform/src/signals/zero-page/html-dom-comment-editor.ts
+++ b/turbo/apps/platform/src/signals/zero-page/html-dom-comment-editor.ts
@@ -1,5 +1,5 @@
 import { createElement } from "react";
-import { IconPointer } from "@tabler/icons-react";
+import { IconPointer2 } from "@tabler/icons-react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { command, computed, state } from "ccstate";
 import {
@@ -11,14 +11,7 @@ import { toast } from "@vm0/ui/components/ui/sonner";
 import { accept } from "../../lib/accept.ts";
 import { now } from "../../lib/time.ts";
 import { zeroClient$, type ZeroClientFactory } from "../api-client.ts";
-import {
-  createDeferredPromise,
-  onRef,
-  resetSignal,
-  settle,
-  tapError,
-  withCleanup,
-} from "../utils.ts";
+import { onRef, resetSignal, settle, tapError, withCleanup } from "../utils.ts";
 import {
   createHtmlDomEditPayload,
   HTML_DOM_EDIT_HOVER_ATTR,
@@ -59,6 +52,7 @@ interface FrameCleanup {
 
 export type HtmlDomStyleProperty = "backgroundColor" | "color";
 export type HtmlDomImageLayout = "contain" | "cover" | "fill";
+export type HtmlDomImagePendingAction = "link" | "upload";
 
 type HtmlDomInlineStyleProperty = HtmlDomStyleProperty | "objectFit";
 
@@ -105,6 +99,9 @@ export interface HtmlDomCommentEditorModel {
   readonly editableStyleProperties: readonly HtmlDomStyleProperty[];
   readonly editingCommentId: string | null;
   readonly imageBusy: boolean;
+  readonly imageLinkOpen: boolean;
+  readonly imageLinkValue: string;
+  readonly imagePendingAction: HtmlDomImagePendingAction | null;
   readonly loadState: EditorLoadState;
   readonly popoverTextAreaKey: string;
   readonly prepared: boolean;
@@ -154,6 +151,7 @@ interface CommentMarkerPosition {
 }
 
 const HTML_DOM_COMMENT_LAYER_ID = "vm0-html-edit-comment-layer";
+const HTML_DOM_EDIT_BOX_LAYER_ID = "vm0-html-edit-box-layer";
 const MAX_DIRECT_HTML_EDIT_DRAFT_BYTES = 500_000;
 const HTML_DOM_COMMENT_MARKER_TARGET_ATTR =
   "data-vm0-html-comment-target-node-id";
@@ -174,7 +172,7 @@ const FRAME_COMMENT_COLLISION_GAP = 6;
 const FRAME_COMMENT_NUDGE_STEP = 12;
 const FRAME_COMMENT_NUDGE_STEPS = [0, 1, -1, 2, -2] as const;
 const FRAME_NAVIGATION_CURSOR_SVG = renderToStaticMarkup(
-  createElement(IconPointer, {
+  createElement(IconPointer2, {
     "aria-hidden": "true",
     color: "#2563eb",
     size: 20,
@@ -184,7 +182,6 @@ const FRAME_NAVIGATION_CURSOR_SVG = renderToStaticMarkup(
 const FRAME_NAVIGATION_CURSOR = `url("data:image/svg+xml,${encodeURIComponent(
   FRAME_NAVIGATION_CURSOR_SVG,
 )}") 3 3, pointer`;
-const IMAGE_LINK_LOAD_TIMEOUT_MS = 8_000;
 const IMAGE_UPLOAD_CONTENT_TYPE_BY_EXTENSION: Readonly<Record<string, string>> =
   {
     avif: "image/avif",
@@ -233,6 +230,11 @@ const internalImageEditsByNodeId$ = state<
   Readonly<Record<string, HtmlDomImageEdits>>
 >({});
 const internalImageBusy$ = state(false);
+const internalImageLinkOpen$ = state(false);
+const internalImageLinkValue$ = state("");
+const internalImagePendingAction$ = state<HtmlDomImagePendingAction | null>(
+  null,
+);
 const resetHtmlDomEditRequestSignal$ = resetSignal();
 const resetHtmlDomImageEditSignal$ = resetSignal();
 
@@ -309,7 +311,19 @@ async function uploadHtmlDomImage(params: {
     );
   }
 
-  return prepared.body.url;
+  const completed = await accept(
+    client.complete({
+      body: {
+        id: prepared.body.id,
+        contentType: prepared.body.contentType,
+      },
+      fetchOptions: { signal: params.signal },
+    }),
+    [200],
+  );
+  params.signal.throwIfAborted();
+
+  return completed.body.url;
 }
 
 function normalizeImageLinkUrl(value: string): string | null {
@@ -326,43 +340,6 @@ function normalizeImageLinkUrl(value: string): string | null {
   return parsed.protocol === "http:" || parsed.protocol === "https:"
     ? parsed.toString()
     : null;
-}
-
-async function ensureImageUrlLoads(
-  url: string,
-  signal: AbortSignal,
-): Promise<void> {
-  const ImageConstructor = globalThis.Image;
-  if (!ImageConstructor) {
-    throw new Error("Image loading is not available in this browser");
-  }
-
-  const deferred = createDeferredPromise<void>(signal);
-  const image = new ImageConstructor();
-  const timeout = setTimeout(() => {
-    if (!deferred.settled()) {
-      deferred.reject(new Error("Image did not load in time"));
-    }
-  }, IMAGE_LINK_LOAD_TIMEOUT_MS);
-  const cleanup = () => {
-    image.onload = null;
-    image.onerror = null;
-    clearTimeout(timeout);
-  };
-
-  image.onload = () => {
-    if (!deferred.settled()) {
-      deferred.resolve();
-    }
-  };
-  image.onerror = () => {
-    if (!deferred.settled()) {
-      deferred.reject(new Error("Image could not be loaded"));
-    }
-  };
-  image.src = url;
-
-  await withCleanup(deferred.promise, cleanup);
 }
 
 async function requestHtmlEditDraft(params: {
@@ -518,6 +495,29 @@ function isFrameImageElement(
     : element instanceof HTMLImageElement;
 }
 
+const IMAGE_WRAPPER_SELECTOR = ["a[href]", "figure", "picture"].join(",");
+
+function descendantImageForImageWrapper(
+  element: Element | null | undefined,
+): HTMLImageElement | null {
+  if (!element?.matches(IMAGE_WRAPPER_SELECTOR)) {
+    return null;
+  }
+
+  const images = Array.from(element.querySelectorAll("img")).filter(
+    isFrameImageElement,
+  );
+  return images.length === 1 ? images[0] : null;
+}
+
+function imageElementForCommentCandidate(
+  element: Element | null | undefined,
+): HTMLImageElement | null {
+  return isFrameImageElement(element)
+    ? element
+    : descendantImageForImageWrapper(element);
+}
+
 function selectedImageElementForNodes(params: {
   readonly doc: Document | null;
   readonly selectedNodeIds: readonly string[];
@@ -527,7 +527,15 @@ function selectedImageElementForNodes(params: {
     return null;
   }
   const element = params.doc?.querySelector(nodeSelector(nodeId));
-  return isFrameImageElement(element) ? { element, nodeId } : null;
+  if (isFrameImageElement(element)) {
+    return { element, nodeId };
+  }
+
+  const descendantImage = imageElementForCommentCandidate(element);
+  const descendantNodeId = descendantImage?.getAttribute(HTML_DOM_NODE_ID_ATTR);
+  return descendantImage && descendantNodeId
+    ? { element: descendantImage, nodeId: descendantNodeId }
+    : null;
 }
 
 function imageLayoutForElement(element: HTMLImageElement): HtmlDomImageLayout {
@@ -586,6 +594,11 @@ function smallestCommentNodeAtPoint(event: MouseEvent): Element | null {
       return element !== null;
     });
   const uniqueCandidates = Array.from(new Set(candidates));
+  const imageCandidate = uniqueCandidates.find(isFrameImageElement);
+  if (imageCandidate) {
+    return imageCandidate;
+  }
+
   return (
     uniqueCandidates.sort((first, second) => {
       const firstRect = first.getBoundingClientRect();
@@ -616,6 +629,118 @@ function closestCommentDeleteButton(
   return (target as Element).closest<HTMLElement>(
     `[${HTML_DOM_COMMENT_DELETE_ATTR}]`,
   );
+}
+
+function removeFrameEditBoxLayer(doc: Document): void {
+  doc.getElementById(HTML_DOM_EDIT_BOX_LAYER_ID)?.remove();
+}
+
+function ensureFrameEditBoxLayer(doc: Document): HTMLElement {
+  let layer: HTMLElement | null = null;
+  for (const candidate of Array.from(
+    doc.querySelectorAll(`#${HTML_DOM_EDIT_BOX_LAYER_ID}`),
+  )) {
+    if (isFrameHtmlElement(candidate) && layer === null) {
+      layer = candidate;
+      continue;
+    }
+    candidate.remove();
+  }
+
+  if (layer) {
+    return layer;
+  }
+
+  layer = doc.createElement("div");
+  layer.id = HTML_DOM_EDIT_BOX_LAYER_ID;
+  layer.setAttribute(HTML_DOM_EDIT_OVERLAY_ATTR, "");
+  layer.setAttribute("aria-hidden", "true");
+  layer.style.position = "fixed";
+  layer.style.setProperty("inset", "0");
+  layer.style.zIndex = "2147483646";
+  layer.style.pointerEvents = "none";
+  doc.body.append(layer);
+  return layer;
+}
+
+function createFrameEditBox(params: {
+  readonly element: HTMLElement;
+  readonly kind: "hover" | "selected";
+}): HTMLElement | null {
+  const rect = params.element.getBoundingClientRect();
+  if (rect.width <= 0 || rect.height <= 0) {
+    return null;
+  }
+
+  const doc = params.element.ownerDocument;
+  const view = doc.defaultView;
+  const computedStyle = view?.getComputedStyle(params.element);
+  const box = doc.createElement("div");
+  box.setAttribute(HTML_DOM_EDIT_OVERLAY_ATTR, "");
+  box.dataset.testid =
+    params.kind === "hover" ? "html-dom-hover-box" : "html-dom-selected-box";
+  box.style.position = "absolute";
+  box.style.left = `${rect.left}px`;
+  box.style.top = `${rect.top}px`;
+  box.style.width = `${rect.width}px`;
+  box.style.height = `${rect.height}px`;
+  box.style.boxSizing = "border-box";
+  box.style.border =
+    params.kind === "hover"
+      ? "2px dashed rgba(37, 99, 235, 0.85)"
+      : "2px solid rgb(37, 99, 235)";
+  box.style.borderRadius = computedStyle?.borderRadius || "0";
+  box.style.boxShadow =
+    params.kind === "selected" ? "0 0 0 4px rgba(37, 99, 235, 0.16)" : "none";
+  box.style.pointerEvents = "none";
+  return box;
+}
+
+function syncFrameEditBoxes(
+  doc: Document,
+  params: {
+    readonly hoveredNodeId: string | null;
+    readonly selectedNodeIds: readonly string[];
+  },
+): void {
+  const boxes: HTMLElement[] = [];
+  const selectedNodeIds = new Set(params.selectedNodeIds);
+
+  if (params.hoveredNodeId && !selectedNodeIds.has(params.hoveredNodeId)) {
+    const hoveredElement = doc.querySelector(
+      nodeSelector(params.hoveredNodeId),
+    );
+    if (isFrameImageElement(hoveredElement)) {
+      const box = createFrameEditBox({
+        element: hoveredElement,
+        kind: "hover",
+      });
+      if (box) {
+        boxes.push(box);
+      }
+    }
+  }
+
+  for (const nodeId of params.selectedNodeIds) {
+    const selectedElement = doc.querySelector(nodeSelector(nodeId));
+    if (!isFrameImageElement(selectedElement)) {
+      continue;
+    }
+    const box = createFrameEditBox({
+      element: selectedElement,
+      kind: "selected",
+    });
+    if (box) {
+      boxes.push(box);
+    }
+  }
+
+  if (boxes.length === 0) {
+    removeFrameEditBoxLayer(doc);
+    return;
+  }
+
+  ensureFrameEditBoxLayer(doc).replaceChildren(...boxes);
 }
 
 function syncFrameEditState(
@@ -649,6 +774,68 @@ function syncFrameEditState(
       .querySelector(nodeSelector(nodeId))
       ?.setAttribute(HTML_DOM_EDIT_SELECTED_ATTR, "true");
   }
+
+  syncFrameEditBoxes(doc, params);
+}
+
+function isTrackableRunningFrameEditAnimation(animation: Animation): boolean {
+  if (animation.playState !== "running") {
+    return false;
+  }
+
+  const iterations = animation.effect?.getTiming().iterations;
+  return iterations === undefined || Number.isFinite(iterations);
+}
+
+function hasTrackableRunningFrameEditAnimation(
+  doc: Document,
+  params: {
+    readonly hoveredNodeId: string | null;
+    readonly selectedNodeIds: readonly string[];
+  },
+): boolean {
+  const nodeIds = [
+    ...(params.hoveredNodeId ? [params.hoveredNodeId] : []),
+    ...params.selectedNodeIds,
+  ];
+  return nodeIds.some((nodeId) => {
+    const element = doc.querySelector(nodeSelector(nodeId));
+    if (!isFrameImageElement(element)) {
+      return false;
+    }
+    return (element.getAnimations?.() ?? []).some((animation) => {
+      return isTrackableRunningFrameEditAnimation(animation);
+    });
+  });
+}
+
+function trackFrameEditState(params: {
+  readonly doc: Document;
+  readonly state: () => {
+    readonly hoveredNodeId: string | null;
+    readonly selectedNodeIds: readonly string[];
+  };
+}): void {
+  const view = params.doc.defaultView;
+  if (!view) {
+    return;
+  }
+
+  let frameCount = 0;
+  const tick = () => {
+    const state = params.state();
+    frameCount += 1;
+    syncFrameEditState(params.doc, state);
+    // Run two frames before relying on getAnimations() so newly-started CSS
+    // transitions are visible after style/layout has settled.
+    if (
+      frameCount < 2 ||
+      hasTrackableRunningFrameEditAnimation(params.doc, state)
+    ) {
+      view.requestAnimationFrame(tick);
+    }
+  };
+  view.requestAnimationFrame(tick);
 }
 
 function installFrameStyles(doc: Document): void {
@@ -666,10 +853,18 @@ function installFrameStyles(doc: Document): void {
       outline: 2px dashed rgba(37, 99, 235, 0.75) !important;
       outline-offset: 2px !important;
     }
+    img[${HTML_DOM_EDIT_HOVER_ATTR}="true"] {
+      outline: none !important;
+      box-shadow: none !important;
+    }
     [${HTML_DOM_EDIT_SELECTED_ATTR}="true"] {
       outline: 2px solid rgb(37, 99, 235) !important;
       outline-offset: 2px !important;
       box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.16) !important;
+    }
+    img[${HTML_DOM_EDIT_SELECTED_ATTR}="true"] {
+      outline: none !important;
+      box-shadow: none !important;
     }
     [${HTML_DOM_COMMENT_MARKER_TARGET_ATTR}]:hover [${HTML_DOM_COMMENT_DELETE_ATTR}],
     [${HTML_DOM_COMMENT_DELETE_ATTR}]:focus-visible {
@@ -713,6 +908,25 @@ function commentPopoverAnchorForElement(params: {
     left: Math.max(180, Math.min(stageRect.width - 180, preferredLeft)),
     top: Math.max(12, Math.min(stageRect.height - 260, preferredTop)),
   };
+}
+
+function isElementInsideFrameViewport(element: Element): boolean {
+  const view = element.ownerDocument.defaultView;
+  if (!view) {
+    return false;
+  }
+
+  const rect = element.getBoundingClientRect();
+  if (rect.width <= 0 || rect.height <= 0) {
+    return false;
+  }
+
+  return (
+    rect.bottom > 0 &&
+    rect.right > 0 &&
+    rect.top < view.innerHeight &&
+    rect.left < view.innerWidth
+  );
 }
 
 function htmlWithEditOverlaysRemoved(params: {
@@ -1931,6 +2145,9 @@ const resetHtmlDomCommentEditor$ = command(({ set }) => {
   set(internalOriginalStylesByNodeId$, {});
   set(internalImageEditsByNodeId$, {});
   set(internalImageBusy$, false);
+  set(internalImageLinkOpen$, false);
+  set(internalImageLinkValue$, "");
+  set(internalImagePendingAction$, null);
 });
 
 export const setHtmlDomCommentStageRef$ = onRef(
@@ -1995,6 +2212,57 @@ interface FrameCommentBindingParams {
   readonly stage: HTMLElement;
 }
 
+interface CommentPopoverTarget {
+  readonly element: Element;
+  readonly existingComment: HtmlDomEditComment | null;
+  readonly nodeId: string;
+  readonly selectedNodeIds: readonly string[];
+}
+
+function commentPopoverTargetForNode(params: {
+  readonly doc: Document;
+  readonly getComments: () => readonly HtmlDomEditComment[];
+  readonly nodeId: string;
+  readonly preferImage: boolean;
+}): CommentPopoverTarget | null {
+  const element = params.doc.querySelector(nodeSelector(params.nodeId));
+  if (!element) {
+    return null;
+  }
+
+  const existingCommentForNode = commentForNodeId(
+    params.getComments(),
+    params.nodeId,
+  );
+  const selectedImage = params.preferImage
+    ? imageElementForCommentCandidate(element)
+    : null;
+  const selectedImageNodeId = selectedImage?.getAttribute(
+    HTML_DOM_NODE_ID_ATTR,
+  );
+  if (!existingCommentForNode && selectedImage && selectedImageNodeId) {
+    return {
+      element: selectedImage,
+      existingComment: commentForNodeId(
+        params.getComments(),
+        selectedImageNodeId,
+      ),
+      nodeId: selectedImageNodeId,
+      selectedNodeIds: [selectedImageNodeId],
+    };
+  }
+
+  return {
+    element,
+    existingComment: existingCommentForNode,
+    nodeId: params.nodeId,
+    selectedNodeIds:
+      selectedImageNodeId && selectedImageNodeId !== params.nodeId
+        ? [params.nodeId, selectedImageNodeId]
+        : [params.nodeId],
+  };
+}
+
 function frameCommentNodeIdForTarget(
   params: Pick<FrameCommentBindingParams, "getComments">,
   target: EventTarget | null,
@@ -2039,33 +2307,51 @@ function closeFrameHoverPopoverForNode(
   params.setCommentText("");
 }
 
+function openFrameCommentPopoverForNode(
+  params: FrameCommentBindingParams,
+  args: {
+    nodeId: string;
+    mode: "edit" | "view";
+    preferImage?: boolean;
+  },
+): void {
+  const target = commentPopoverTargetForNode({
+    doc: params.doc,
+    getComments: params.getComments,
+    nodeId: args.nodeId,
+    preferImage: args.preferImage ?? false,
+  });
+  if (!target) {
+    return;
+  }
+  const {
+    element,
+    existingComment,
+    nodeId: selectedNodeId,
+    selectedNodeIds,
+  } = target;
+  if (args.mode === "edit" && existingComment) {
+    params.setEditingCommentId(existingComment.id);
+    params.setCommentText(existingComment.comment);
+  } else {
+    params.setEditingCommentId(null);
+    if (!existingComment) {
+      params.setCommentText("");
+    }
+  }
+  params.setHoveredNodeId(selectedNodeId);
+  params.setSelectedNodeIds(selectedNodeIds);
+  params.setCommentPopoverAnchor(
+    commentPopoverAnchorForElement({
+      element,
+      iframe: params.iframe,
+      stage: params.stage,
+    }),
+  );
+}
+
 function bindFrameCommentEvents(params: FrameCommentBindingParams): () => void {
   installFrameStyles(params.doc);
-
-  const openPopoverForNode = (nodeId: string, mode: "edit" | "view"): void => {
-    const element = params.doc.querySelector(nodeSelector(nodeId));
-    if (!element) {
-      return;
-    }
-    const existingComment = commentForNodeId(params.getComments(), nodeId);
-    if (mode === "edit" && existingComment) {
-      params.setEditingCommentId(existingComment.id);
-      params.setCommentText(existingComment.comment);
-    } else {
-      params.setEditingCommentId(null);
-      if (!existingComment) {
-        params.setCommentText("");
-      }
-    }
-    params.setSelectedNodeIds([nodeId]);
-    params.setCommentPopoverAnchor(
-      commentPopoverAnchorForElement({
-        element,
-        iframe: params.iframe,
-        stage: params.stage,
-      }),
-    );
-  };
 
   const handleMouseOver = (event: Event) => {
     if (params.getDisabled()) {
@@ -2090,7 +2376,7 @@ function bindFrameCommentEvents(params: FrameCommentBindingParams): () => void {
     )?.getAttribute(HTML_DOM_NODE_ID_ATTR);
     params.setHoveredNodeId(nodeId ?? null);
     if (nodeId && commentForNodeId(params.getComments(), nodeId)) {
-      openPopoverForNode(nodeId, "view");
+      openFrameCommentPopoverForNode(params, { nodeId, mode: "view" });
     }
   };
   const handleMouseOut = (event: MouseEvent) => {
@@ -2134,7 +2420,10 @@ function bindFrameCommentEvents(params: FrameCommentBindingParams): () => void {
     if (markerNodeId) {
       event.preventDefault();
       event.stopPropagation();
-      openPopoverForNode(markerNodeId, "edit");
+      openFrameCommentPopoverForNode(params, {
+        nodeId: markerNodeId,
+        mode: "edit",
+      });
       return;
     }
 
@@ -2147,7 +2436,11 @@ function bindFrameCommentEvents(params: FrameCommentBindingParams): () => void {
     }
     event.preventDefault();
     event.stopPropagation();
-    openPopoverForNode(nodeId, "edit");
+    openFrameCommentPopoverForNode(params, {
+      nodeId,
+      mode: "edit",
+      preferImage: true,
+    });
   };
 
   params.doc.addEventListener("mouseover", handleMouseOver, true);
@@ -2167,6 +2460,119 @@ function bindFrameCommentEvents(params: FrameCommentBindingParams): () => void {
   };
 }
 
+function syncFrameBindingPresentation(params: {
+  readonly commentPopoverAnchor: CommentPopoverAnchor | null;
+  readonly comments: readonly HtmlDomEditComment[];
+  readonly doc: Document;
+  readonly editingCommentId: string | null;
+  readonly hoveredNodeId: string | null;
+  readonly iframe: HTMLIFrameElement;
+  readonly onTargetUnavailable: () => void;
+  readonly selectedNodeIds: readonly string[];
+  readonly setCommentPopoverAnchor: (
+    value: CommentPopoverAnchor | null,
+  ) => void;
+  readonly stage: HTMLElement;
+}): void {
+  const selectedElement = params.selectedNodeIds[0]
+    ? params.doc.querySelector(nodeSelector(params.selectedNodeIds[0]))
+    : null;
+  if (params.commentPopoverAnchor && params.selectedNodeIds.length > 0) {
+    if (!selectedElement || !isElementInsideFrameViewport(selectedElement)) {
+      params.onTargetUnavailable();
+      return;
+    }
+
+    params.setCommentPopoverAnchor(
+      commentPopoverAnchorForElement({
+        element: selectedElement,
+        iframe: params.iframe,
+        stage: params.stage,
+      }),
+    );
+  }
+
+  syncFrameEditState(params.doc, {
+    hoveredNodeId: params.hoveredNodeId,
+    selectedNodeIds: params.selectedNodeIds,
+  });
+  syncFrameCommentMarkers(
+    params.doc,
+    params.comments,
+    params.editingCommentId,
+    shouldHideCommittedCommentMarkers({
+      comments: params.comments,
+      editingCommentId: params.editingCommentId,
+      selectedNodeIds: params.selectedNodeIds,
+    }),
+  );
+}
+
+function updateFrameEditingComment(params: {
+  readonly comments: readonly HtmlDomEditComment[];
+  readonly currentEditingCommentId: string | null;
+  readonly doc: Document;
+  readonly nextEditingCommentId: string | null;
+  readonly selectedNodeIds: readonly string[];
+  readonly setEditingCommentId: (value: string | null) => void;
+}): void {
+  if (params.currentEditingCommentId === params.nextEditingCommentId) {
+    return;
+  }
+  params.setEditingCommentId(params.nextEditingCommentId);
+  syncFrameCommentMarkers(
+    params.doc,
+    params.comments,
+    params.nextEditingCommentId,
+    shouldHideCommittedCommentMarkers({
+      comments: params.comments,
+      editingCommentId: params.nextEditingCommentId,
+      selectedNodeIds: params.selectedNodeIds,
+    }),
+  );
+}
+
+function updateFrameSelectedNodeIds(params: {
+  readonly comments: readonly HtmlDomEditComment[];
+  readonly doc: Document;
+  readonly editingCommentId: string | null;
+  readonly hoveredNodeId: string | null;
+  readonly nextSelectedNodeIds: readonly string[];
+  readonly previousSelectedNodeIds: readonly string[];
+  readonly resetFloatingStyleControls: () => void;
+  readonly setSelectedNodeIds: (value: readonly string[]) => void;
+}): void {
+  const wasHidingMarkers = shouldHideCommittedCommentMarkers({
+    comments: params.comments,
+    editingCommentId: params.editingCommentId,
+    selectedNodeIds: params.previousSelectedNodeIds,
+  });
+  const shouldHideMarkers = shouldHideCommittedCommentMarkers({
+    comments: params.comments,
+    editingCommentId: params.editingCommentId,
+    selectedNodeIds: params.nextSelectedNodeIds,
+  });
+  if (
+    params.previousSelectedNodeIds.join(":") !==
+    params.nextSelectedNodeIds.join(":")
+  ) {
+    params.resetFloatingStyleControls();
+  }
+  params.setSelectedNodeIds(params.nextSelectedNodeIds);
+  syncFrameEditState(params.doc, {
+    hoveredNodeId: params.hoveredNodeId,
+    selectedNodeIds: params.nextSelectedNodeIds,
+  });
+  if (wasHidingMarkers !== shouldHideMarkers) {
+    syncFrameCommentMarkers(
+      params.doc,
+      params.comments,
+      params.editingCommentId,
+      shouldHideMarkers,
+    );
+  }
+}
+
 export const bindHtmlDomCommentFrame$ = command(
   ({ get, set }, iframe: HTMLIFrameElement) => {
     set(cleanupCurrentFrameBinding$);
@@ -2178,23 +2584,32 @@ export const bindHtmlDomCommentFrame$ = command(
     }
 
     const syncMarkers = () => {
-      const comments = get(internalComments$);
-      const editingCommentId = get(internalEditingCommentId$);
-      const selectedNodeIds = get(internalSelectedNodeIds$);
-      syncFrameCommentMarkers(
+      syncFrameBindingPresentation({
+        commentPopoverAnchor: get(internalCommentPopoverAnchor$),
+        comments: get(internalComments$),
         doc,
-        comments,
-        editingCommentId,
-        shouldHideCommittedCommentMarkers({
-          comments,
-          editingCommentId,
-          selectedNodeIds,
-        }),
-      );
+        editingCommentId: get(internalEditingCommentId$),
+        hoveredNodeId: get(internalHoveredNodeId$),
+        iframe,
+        onTargetUnavailable: () => {
+          set(resetHtmlDomCommentDraft$);
+        },
+        selectedNodeIds: get(internalSelectedNodeIds$),
+        setCommentPopoverAnchor: (value) => {
+          set(internalCommentPopoverAnchor$, value);
+        },
+        stage,
+      });
     };
     const view = doc.defaultView;
     view?.addEventListener("scroll", syncMarkers, true);
     view?.addEventListener("resize", syncMarkers);
+    const currentFrameEditState = () => {
+      return {
+        hoveredNodeId: get(internalHoveredNodeId$),
+        selectedNodeIds: get(internalSelectedNodeIds$),
+      };
+    };
 
     const eventCleanup = bindFrameCommentEvents({
       deleteComment: (commentId) => {
@@ -2220,22 +2635,16 @@ export const bindHtmlDomCommentFrame$ = command(
         set(internalCommentPopoverAnchor$, value);
       },
       setEditingCommentId: (value) => {
-        if (get(internalEditingCommentId$) === value) {
-          return;
-        }
-        const comments = get(internalComments$);
-        const selectedNodeIds = get(internalSelectedNodeIds$);
-        set(internalEditingCommentId$, value);
-        syncFrameCommentMarkers(
+        updateFrameEditingComment({
+          comments: get(internalComments$),
           doc,
-          comments,
-          value,
-          shouldHideCommittedCommentMarkers({
-            comments,
-            editingCommentId: value,
-            selectedNodeIds,
-          }),
-        );
+          currentEditingCommentId: get(internalEditingCommentId$),
+          nextEditingCommentId: value,
+          selectedNodeIds: get(internalSelectedNodeIds$),
+          setEditingCommentId: (nextValue) => {
+            set(internalEditingCommentId$, nextValue);
+          },
+        });
       },
       setHoveredNodeId: (value) => {
         set(internalHoveredNodeId$, value);
@@ -2243,41 +2652,37 @@ export const bindHtmlDomCommentFrame$ = command(
           hoveredNodeId: value,
           selectedNodeIds: get(internalSelectedNodeIds$),
         });
+        trackFrameEditState({
+          doc,
+          state: currentFrameEditState,
+        });
       },
       setCommentText: (value) => {
         set(internalCommentText$, value);
       },
       setSelectedNodeIds: (value) => {
-        const comments = get(internalComments$);
-        const editingCommentId = get(internalEditingCommentId$);
-        const previousSelectedNodeIds = get(internalSelectedNodeIds$);
-        const wasHidingMarkers = shouldHideCommittedCommentMarkers({
-          comments,
-          editingCommentId,
-          selectedNodeIds: previousSelectedNodeIds,
-        });
-        const shouldHideMarkers = shouldHideCommittedCommentMarkers({
-          comments,
-          editingCommentId,
-          selectedNodeIds: value,
-        });
-        if (previousSelectedNodeIds.join(":") !== value.join(":")) {
-          set(internalActiveColorPanelProperty$, null);
-          set(internalColorPopoverOffset$, { left: 0, top: 0 });
-        }
-        set(internalSelectedNodeIds$, value);
-        syncFrameEditState(doc, {
+        updateFrameSelectedNodeIds({
+          comments: get(internalComments$),
+          doc,
+          editingCommentId: get(internalEditingCommentId$),
           hoveredNodeId: get(internalHoveredNodeId$),
-          selectedNodeIds: value,
+          nextSelectedNodeIds: value,
+          previousSelectedNodeIds: get(internalSelectedNodeIds$),
+          resetFloatingStyleControls: () => {
+            set(internalActiveColorPanelProperty$, null);
+            set(internalColorPopoverOffset$, { left: 0, top: 0 });
+            set(internalImageLinkOpen$, false);
+            set(internalImageLinkValue$, "");
+            set(internalImagePendingAction$, null);
+          },
+          setSelectedNodeIds: (nextValue) => {
+            set(internalSelectedNodeIds$, nextValue);
+          },
         });
-        if (wasHidingMarkers !== shouldHideMarkers) {
-          syncFrameCommentMarkers(
-            doc,
-            comments,
-            editingCommentId,
-            shouldHideMarkers,
-          );
-        }
+        trackFrameEditState({
+          doc,
+          state: currentFrameEditState,
+        });
       },
       stage,
     });
@@ -2359,6 +2764,20 @@ function setImageElementSource(element: HTMLImageElement, url: string): void {
   element.removeAttribute("sizes");
 }
 
+function applyImageSourceEdit(params: {
+  readonly element: HTMLImageElement;
+  readonly imageEditsByNodeId: Readonly<Record<string, HtmlDomImageEdits>>;
+  readonly nodeId: string;
+  readonly url: string;
+}): Readonly<Record<string, HtmlDomImageEdits>> {
+  setImageElementSource(params.element, params.url);
+  return imageSourceEditState({
+    imageEditsByNodeId: params.imageEditsByNodeId,
+    nodeId: params.nodeId,
+    url: params.url,
+  });
+}
+
 export const uploadSelectedHtmlDomImage$ = command(
   async ({ get, set }, file: File, parentSignal: AbortSignal) => {
     const doc = currentFrameDocument(get(internalIframeElement$));
@@ -2396,12 +2815,12 @@ export const uploadSelectedHtmlDomImage$ = command(
             throw new Error("Selected image is no longer available");
           }
 
-          const nextState = imageSourceEditState({
+          const nextState = applyImageSourceEdit({
+            element: nextElement,
             imageEditsByNodeId: get(internalImageEditsByNodeId$),
             nodeId: selected.nodeId,
             url,
           });
-          setImageElementSource(nextElement, url);
           set(internalImageEditsByNodeId$, nextState);
           set(internalPreparedPayload$, null);
           toast.success("Image replaced");
@@ -2425,7 +2844,7 @@ export const uploadSelectedHtmlDomImage$ = command(
 );
 
 export const replaceSelectedHtmlDomImageUrl$ = command(
-  async ({ get, set }, value: string, parentSignal: AbortSignal) => {
+  ({ get, set }, value: string, parentSignal: AbortSignal) => {
     const url = normalizeImageLinkUrl(value);
     if (!url) {
       toast.error("Enter a valid image URL");
@@ -2446,44 +2865,29 @@ export const replaceSelectedHtmlDomImageUrl$ = command(
     set(internalImageBusy$, true);
     set(internalPreparedPayload$, null);
 
-    const replaced = await withCleanup(
-      tapError(
-        (async () => {
-          await ensureImageUrlLoads(url, signal);
-          signal.throwIfAborted();
-          const nextDoc = currentFrameDocument(get(internalIframeElement$));
-          const nextElement = nextDoc?.querySelector(
-            nodeSelector(selected.nodeId),
-          );
-          if (!isFrameImageElement(nextElement)) {
-            throw new Error("Selected image is no longer available");
-          }
+    const nextDoc = currentFrameDocument(get(internalIframeElement$));
+    const nextElement = nextDoc?.querySelector(nodeSelector(selected.nodeId));
+    if (!isFrameImageElement(nextElement)) {
+      toast.error("Selected image is no longer available");
+      if (!signal.aborted) {
+        set(internalImageBusy$, false);
+      }
+      return false;
+    }
 
-          const nextState = imageSourceEditState({
-            imageEditsByNodeId: get(internalImageEditsByNodeId$),
-            nodeId: selected.nodeId,
-            url,
-          });
-          setImageElementSource(nextElement, url);
-          set(internalImageEditsByNodeId$, nextState);
-          set(internalPreparedPayload$, null);
-          toast.success("Image replaced");
-          return true;
-        })(),
-        (error) => {
-          toast.error(
-            htmlDomEditErrorMessage(error, "Image could not be loaded"),
-          );
-        },
-      ),
-      () => {
-        if (!signal.aborted) {
-          set(internalImageBusy$, false);
-        }
-      },
-    );
-
-    return replaced ?? false;
+    const nextState = applyImageSourceEdit({
+      element: nextElement,
+      imageEditsByNodeId: get(internalImageEditsByNodeId$),
+      nodeId: selected.nodeId,
+      url,
+    });
+    set(internalImageEditsByNodeId$, nextState);
+    set(internalPreparedPayload$, null);
+    toast.success("Image replaced");
+    if (!signal.aborted) {
+      set(internalImageBusy$, false);
+    }
+    return true;
   },
 );
 
@@ -2623,6 +3027,9 @@ const resetHtmlDomCommentDraft$ = command(({ get, set }) => {
   set(internalEditingCommentId$, null);
   set(internalActiveColorPanelProperty$, null);
   set(internalColorPopoverOffset$, { left: 0, top: 0 });
+  set(internalImageLinkOpen$, false);
+  set(internalImageLinkValue$, "");
+  set(internalImagePendingAction$, null);
   set(internalPreparedPayload$, null);
   syncFrameEditState(currentFrameDocument(get(internalIframeElement$)), {
     hoveredNodeId: get(internalHoveredNodeId$),
@@ -2681,6 +3088,20 @@ export const toggleHtmlDomCommentsOpen$ = command(({ get, set }) => {
   set(internalCommentsOpen$, !get(internalCommentsOpen$));
 });
 
+export const toggleHtmlDomImageLinkOpen$ = command(({ get, set }) => {
+  set(internalImageLinkOpen$, !get(internalImageLinkOpen$));
+});
+
+export const setHtmlDomImageLinkValue$ = command(({ set }, value: string) => {
+  set(internalImageLinkValue$, value);
+});
+
+export const setHtmlDomImagePendingAction$ = command(
+  ({ set }, value: HtmlDomImagePendingAction | null) => {
+    set(internalImagePendingAction$, value);
+  },
+);
+
 export const discardHtmlDomComments$ = command(({ get, set }) => {
   const readyLoadState = get(internalLoadState$);
   const doc = currentFrameDocument(get(internalIframeElement$));
@@ -2694,6 +3115,9 @@ export const discardHtmlDomComments$ = command(({ get, set }) => {
   set(internalOriginalStylesByNodeId$, {});
   set(internalImageEditsByNodeId$, {});
   set(internalImageBusy$, false);
+  set(internalImageLinkOpen$, false);
+  set(internalImageLinkValue$, "");
+  set(internalImagePendingAction$, null);
   if (readyLoadState.status === "ready" && doc) {
     restoreFrameDocumentHtml({
       doc,
@@ -2907,6 +3331,9 @@ export const htmlDomCommentEditorModel$ = computed(
       editableStyleProperties,
       editingCommentId,
       imageBusy,
+      imageLinkOpen: get(internalImageLinkOpen$),
+      imageLinkValue: get(internalImageLinkValue$),
+      imagePendingAction: get(internalImagePendingAction$),
       loadState,
       popoverTextAreaKey: [
         selectedNodeIds.join(":"),

--- a/turbo/apps/platform/src/signals/zero-page/html-dom-comment-editor.ts
+++ b/turbo/apps/platform/src/signals/zero-page/html-dom-comment-editor.ts
@@ -11,7 +11,14 @@ import { toast } from "@vm0/ui/components/ui/sonner";
 import { accept } from "../../lib/accept.ts";
 import { now } from "../../lib/time.ts";
 import { zeroClient$, type ZeroClientFactory } from "../api-client.ts";
-import { onRef, resetSignal, settle, tapError, withCleanup } from "../utils.ts";
+import {
+  createDeferredPromise,
+  onRef,
+  resetSignal,
+  settle,
+  tapError,
+  withCleanup,
+} from "../utils.ts";
 import {
   createHtmlDomEditPayload,
   HTML_DOM_EDIT_HOVER_ATTR,
@@ -51,6 +58,16 @@ interface FrameCleanup {
 }
 
 export type HtmlDomStyleProperty = "backgroundColor" | "color";
+export type HtmlDomImageLayout = "contain" | "cover" | "fill";
+
+type HtmlDomInlineStyleProperty = HtmlDomStyleProperty | "objectFit";
+
+export interface HtmlDomSelectedImage {
+  readonly layout: HtmlDomImageLayout;
+  readonly renderedSize: string | null;
+  readonly resolvedSrc: string;
+  readonly src: string;
+}
 
 export interface HtmlDomSelectedStyle {
   readonly backgroundColor: string;
@@ -62,12 +79,16 @@ export interface HtmlDomColorPopoverOffset {
   readonly top: number;
 }
 
-type HtmlDomStyleEdits = Partial<Record<HtmlDomStyleProperty, string>>;
+type HtmlDomStyleEdits = Partial<Record<HtmlDomInlineStyleProperty, string>>;
 
 type HtmlDomOriginalInlineStyles = Partial<
-  Record<HtmlDomStyleProperty, string>
+  Record<HtmlDomInlineStyleProperty, string>
 >;
 type FrameStyleElement = HTMLElement | SVGElement;
+
+interface HtmlDomImageEdits {
+  readonly src?: string;
+}
 
 export interface HtmlDomCommentEditorModel {
   readonly activeColorPanelProperty: HtmlDomStyleProperty | null;
@@ -83,9 +104,11 @@ export interface HtmlDomCommentEditorModel {
   readonly currentComment: HtmlDomEditComment | null;
   readonly editableStyleProperties: readonly HtmlDomStyleProperty[];
   readonly editingCommentId: string | null;
+  readonly imageBusy: boolean;
   readonly loadState: EditorLoadState;
   readonly popoverTextAreaKey: string;
   readonly prepared: boolean;
+  readonly selectedImage: HtmlDomSelectedImage | null;
   readonly selectedStyle: HtmlDomSelectedStyle;
   readonly submitting: boolean;
 }
@@ -161,6 +184,25 @@ const FRAME_NAVIGATION_CURSOR_SVG = renderToStaticMarkup(
 const FRAME_NAVIGATION_CURSOR = `url("data:image/svg+xml,${encodeURIComponent(
   FRAME_NAVIGATION_CURSOR_SVG,
 )}") 3 3, pointer`;
+const IMAGE_LINK_LOAD_TIMEOUT_MS = 8_000;
+const IMAGE_UPLOAD_CONTENT_TYPE_BY_EXTENSION: Readonly<Record<string, string>> =
+  {
+    avif: "image/avif",
+    bmp: "image/bmp",
+    gif: "image/gif",
+    jpeg: "image/jpeg",
+    jpg: "image/jpeg",
+    png: "image/png",
+    webp: "image/webp",
+  };
+const SUPPORTED_IMAGE_UPLOAD_CONTENT_TYPES = [
+  "image/avif",
+  "image/bmp",
+  "image/gif",
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+] as const;
 const internalLoadState$ = state<EditorLoadState>({ status: "loading" });
 const internalStageElement$ = state<HTMLDivElement | null>(null);
 const internalIframeElement$ = state<HTMLIFrameElement | null>(null);
@@ -187,7 +229,12 @@ const internalStyleEditsByNodeId$ = state<
 const internalOriginalStylesByNodeId$ = state<
   Readonly<Record<string, HtmlDomOriginalInlineStyles>>
 >({});
+const internalImageEditsByNodeId$ = state<
+  Readonly<Record<string, HtmlDomImageEdits>>
+>({});
+const internalImageBusy$ = state(false);
 const resetHtmlDomEditRequestSignal$ = resetSignal();
+const resetHtmlDomImageEditSignal$ = resetSignal();
 
 async function uploadHtmlDomEditSnapshot(
   params: UploadHtmlSnapshotParams,
@@ -207,6 +254,115 @@ async function uploadHtmlDomEditSnapshot(
   params.signal.throwIfAborted();
 
   return uploaded.body.url;
+}
+
+function inferImageUploadContentType(file: File): string | null {
+  const explicitType = file.type.split(";")[0]?.trim().toLowerCase();
+  if (
+    SUPPORTED_IMAGE_UPLOAD_CONTENT_TYPES.includes(
+      explicitType as (typeof SUPPORTED_IMAGE_UPLOAD_CONTENT_TYPES)[number],
+    )
+  ) {
+    return explicitType;
+  }
+  const extension = file.name.split(".").pop()?.toLowerCase();
+  return extension
+    ? (IMAGE_UPLOAD_CONTENT_TYPE_BY_EXTENSION[extension] ?? null)
+    : null;
+}
+
+async function uploadHtmlDomImage(params: {
+  readonly createClient: ZeroClientFactory;
+  readonly file: File;
+  readonly signal: AbortSignal;
+}): Promise<string> {
+  const contentType = inferImageUploadContentType(params.file);
+  if (!contentType) {
+    throw new Error("Choose a PNG, JPEG, GIF, WebP, AVIF, or BMP image");
+  }
+
+  const client = params.createClient(zeroUploadsContract);
+  const prepared = await accept(
+    client.prepare({
+      body: {
+        filename: params.file.name,
+        contentType,
+        size: params.file.size,
+      },
+      fetchOptions: { signal: params.signal },
+    }),
+    [200],
+  );
+  params.signal.throwIfAborted();
+
+  const putResponse = await fetch(prepared.body.uploadUrl, {
+    method: "PUT",
+    body: params.file,
+    headers: { "content-type": prepared.body.contentType },
+    signal: params.signal,
+  });
+  params.signal.throwIfAborted();
+
+  if (!putResponse.ok) {
+    throw new Error(
+      `storage returned ${putResponse.status} ${putResponse.statusText}`,
+    );
+  }
+
+  return prepared.body.url;
+}
+
+function normalizeImageLinkUrl(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  if (!URL.canParse(trimmed)) {
+    return null;
+  }
+
+  const parsed = new URL(trimmed);
+  return parsed.protocol === "http:" || parsed.protocol === "https:"
+    ? parsed.toString()
+    : null;
+}
+
+async function ensureImageUrlLoads(
+  url: string,
+  signal: AbortSignal,
+): Promise<void> {
+  const ImageConstructor = globalThis.Image;
+  if (!ImageConstructor) {
+    throw new Error("Image loading is not available in this browser");
+  }
+
+  const deferred = createDeferredPromise<void>(signal);
+  const image = new ImageConstructor();
+  const timeout = setTimeout(() => {
+    if (!deferred.settled()) {
+      deferred.reject(new Error("Image did not load in time"));
+    }
+  }, IMAGE_LINK_LOAD_TIMEOUT_MS);
+  const cleanup = () => {
+    image.onload = null;
+    image.onerror = null;
+    clearTimeout(timeout);
+  };
+
+  image.onload = () => {
+    if (!deferred.settled()) {
+      deferred.resolve();
+    }
+  };
+  image.onerror = () => {
+    if (!deferred.settled()) {
+      deferred.reject(new Error("Image could not be loaded"));
+    }
+  };
+  image.src = url;
+
+  await withCleanup(deferred.promise, cleanup);
 }
 
 async function requestHtmlEditDraft(params: {
@@ -347,6 +503,74 @@ function isFrameStyleElement(
   element: Element | null | undefined,
 ): element is FrameStyleElement {
   return isFrameHtmlElement(element) || isFrameSvgElement(element);
+}
+
+function isFrameImageElement(
+  element: Element | null | undefined,
+): element is HTMLImageElement {
+  if (!element) {
+    return false;
+  }
+  const FrameHTMLImageElement =
+    element.ownerDocument.defaultView?.HTMLImageElement;
+  return FrameHTMLImageElement
+    ? element instanceof FrameHTMLImageElement
+    : element instanceof HTMLImageElement;
+}
+
+function selectedImageElementForNodes(params: {
+  readonly doc: Document | null;
+  readonly selectedNodeIds: readonly string[];
+}): { readonly element: HTMLImageElement; readonly nodeId: string } | null {
+  const nodeId = params.selectedNodeIds[0];
+  if (!nodeId) {
+    return null;
+  }
+  const element = params.doc?.querySelector(nodeSelector(nodeId));
+  return isFrameImageElement(element) ? { element, nodeId } : null;
+}
+
+function imageLayoutForElement(element: HTMLImageElement): HtmlDomImageLayout {
+  const view = element.ownerDocument.defaultView;
+  const objectFit =
+    element.style.getPropertyValue("object-fit") ||
+    view?.getComputedStyle(element).getPropertyValue("object-fit");
+  switch (objectFit?.trim()) {
+    case "contain":
+    case "cover":
+    case "fill": {
+      return objectFit.trim() as HtmlDomImageLayout;
+    }
+    default: {
+      return "fill";
+    }
+  }
+}
+
+function imageRenderedSize(element: HTMLImageElement): string | null {
+  const rect = element.getBoundingClientRect();
+  const width = Math.round(rect.width || element.width || element.naturalWidth);
+  const height = Math.round(
+    rect.height || element.height || element.naturalHeight,
+  );
+  return width > 0 && height > 0 ? `${width} x ${height}` : null;
+}
+
+function selectedImageForNodes(params: {
+  readonly doc: Document | null;
+  readonly selectedNodeIds: readonly string[];
+}): HtmlDomSelectedImage | null {
+  const selected = selectedImageElementForNodes(params);
+  if (!selected) {
+    return null;
+  }
+  const src = selected.element.getAttribute("src") ?? "";
+  return {
+    layout: imageLayoutForElement(selected.element),
+    renderedSize: imageRenderedSize(selected.element),
+    resolvedSrc: selected.element.currentSrc || selected.element.src || src,
+    src,
+  };
 }
 
 function smallestCommentNodeAtPoint(event: MouseEvent): Element | null {
@@ -505,7 +729,17 @@ function hasStyleEdits(
   styleEditsByNodeId: Readonly<Record<string, HtmlDomStyleEdits>>,
 ): boolean {
   return Object.values(styleEditsByNodeId).some((edits) => {
-    return edits.backgroundColor !== undefined || edits.color !== undefined;
+    return Object.values(edits).some((value) => {
+      return value !== undefined;
+    });
+  });
+}
+
+function hasImageEdits(
+  imageEditsByNodeId: Readonly<Record<string, HtmlDomImageEdits>>,
+): boolean {
+  return Object.values(imageEditsByNodeId).some((edits) => {
+    return edits.src !== undefined;
   });
 }
 
@@ -695,12 +929,18 @@ function elementBackgroundColor(element: FrameStyleElement): string {
 
 function stylePropertyNameForElement(
   element: FrameStyleElement,
-  property: HtmlDomStyleProperty,
+  property: HtmlDomInlineStyleProperty,
 ): string {
   if (property === "color" && isFrameSvgElement(element)) {
     return "fill";
   }
-  return property === "backgroundColor" ? "background-color" : "color";
+  if (property === "backgroundColor") {
+    return "background-color";
+  }
+  if (property === "objectFit") {
+    return "object-fit";
+  }
+  return "color";
 }
 
 function cssColorToHex(
@@ -1543,7 +1783,7 @@ const restoreOriginalStylesForNodes$ = command(
       if (isFrameStyleElement(element)) {
         for (const property of Object.keys(
           originalStyles,
-        ) as HtmlDomStyleProperty[]) {
+        ) as HtmlDomInlineStyleProperty[]) {
           const styleProperty = stylePropertyNameForElement(element, property);
           const originalValue = originalStyles[property];
           if (originalValue) {
@@ -1672,6 +1912,7 @@ const cleanupCurrentFrameBinding$ = command(({ get, set }) => {
 
 const resetHtmlDomCommentEditor$ = command(({ set }) => {
   set(cleanupCurrentFrameBinding$);
+  set(resetHtmlDomImageEditSignal$);
   set(internalLoadState$, { status: "loading" });
   set(internalStageElement$, null);
   set(internalIframeElement$, null);
@@ -1688,6 +1929,8 @@ const resetHtmlDomCommentEditor$ = command(({ set }) => {
   set(internalColorPopoverOffset$, { left: 0, top: 0 });
   set(internalStyleEditsByNodeId$, {});
   set(internalOriginalStylesByNodeId$, {});
+  set(internalImageEditsByNodeId$, {});
+  set(internalImageBusy$, false);
 });
 
 export const setHtmlDomCommentStageRef$ = onRef(
@@ -1962,7 +2205,7 @@ export const bindHtmlDomCommentFrame$ = command(
         return get(internalComments$);
       },
       getDisabled: () => {
-        return get(internalSubmitting$);
+        return get(internalSubmitting$) || get(internalImageBusy$);
       },
       getEditingCommentId: () => {
         return get(internalEditingCommentId$);
@@ -2095,6 +2338,193 @@ export const closeHtmlDomColorPanel$ = command(({ set }) => {
   set(internalActiveColorPanelProperty$, null);
   set(internalColorPopoverOffset$, { left: 0, top: 0 });
 });
+
+function imageSourceEditState(params: {
+  readonly imageEditsByNodeId: Readonly<Record<string, HtmlDomImageEdits>>;
+  readonly nodeId: string;
+  readonly url: string;
+}): Readonly<Record<string, HtmlDomImageEdits>> {
+  return {
+    ...params.imageEditsByNodeId,
+    [params.nodeId]: {
+      ...params.imageEditsByNodeId[params.nodeId],
+      src: params.url,
+    },
+  };
+}
+
+function setImageElementSource(element: HTMLImageElement, url: string): void {
+  element.setAttribute("src", url);
+  element.removeAttribute("srcset");
+  element.removeAttribute("sizes");
+}
+
+export const uploadSelectedHtmlDomImage$ = command(
+  async ({ get, set }, file: File, parentSignal: AbortSignal) => {
+    const doc = currentFrameDocument(get(internalIframeElement$));
+    const selected = selectedImageElementForNodes({
+      doc,
+      selectedNodeIds: get(internalSelectedNodeIds$),
+    });
+    if (!selected) {
+      toast.error("Select an image first");
+      return false;
+    }
+    if (!inferImageUploadContentType(file)) {
+      toast.error("Choose a PNG, JPEG, GIF, WebP, AVIF, or BMP image");
+      return false;
+    }
+
+    const signal = set(resetHtmlDomImageEditSignal$, parentSignal);
+    set(internalImageBusy$, true);
+    set(internalPreparedPayload$, null);
+
+    const replaced = await withCleanup(
+      tapError(
+        (async () => {
+          const url = await uploadHtmlDomImage({
+            createClient: get(zeroClient$),
+            file,
+            signal,
+          });
+          signal.throwIfAborted();
+          const nextDoc = currentFrameDocument(get(internalIframeElement$));
+          const nextElement = nextDoc?.querySelector(
+            nodeSelector(selected.nodeId),
+          );
+          if (!isFrameImageElement(nextElement)) {
+            throw new Error("Selected image is no longer available");
+          }
+
+          const nextState = imageSourceEditState({
+            imageEditsByNodeId: get(internalImageEditsByNodeId$),
+            nodeId: selected.nodeId,
+            url,
+          });
+          setImageElementSource(nextElement, url);
+          set(internalImageEditsByNodeId$, nextState);
+          set(internalPreparedPayload$, null);
+          toast.success("Image replaced");
+          return true;
+        })(),
+        (error) => {
+          toast.error(
+            htmlDomEditErrorMessage(error, "Failed to replace image"),
+          );
+        },
+      ),
+      () => {
+        if (!signal.aborted) {
+          set(internalImageBusy$, false);
+        }
+      },
+    );
+
+    return replaced ?? false;
+  },
+);
+
+export const replaceSelectedHtmlDomImageUrl$ = command(
+  async ({ get, set }, value: string, parentSignal: AbortSignal) => {
+    const url = normalizeImageLinkUrl(value);
+    if (!url) {
+      toast.error("Enter a valid image URL");
+      return false;
+    }
+
+    const doc = currentFrameDocument(get(internalIframeElement$));
+    const selected = selectedImageElementForNodes({
+      doc,
+      selectedNodeIds: get(internalSelectedNodeIds$),
+    });
+    if (!selected) {
+      toast.error("Select an image first");
+      return false;
+    }
+
+    const signal = set(resetHtmlDomImageEditSignal$, parentSignal);
+    set(internalImageBusy$, true);
+    set(internalPreparedPayload$, null);
+
+    const replaced = await withCleanup(
+      tapError(
+        (async () => {
+          await ensureImageUrlLoads(url, signal);
+          signal.throwIfAborted();
+          const nextDoc = currentFrameDocument(get(internalIframeElement$));
+          const nextElement = nextDoc?.querySelector(
+            nodeSelector(selected.nodeId),
+          );
+          if (!isFrameImageElement(nextElement)) {
+            throw new Error("Selected image is no longer available");
+          }
+
+          const nextState = imageSourceEditState({
+            imageEditsByNodeId: get(internalImageEditsByNodeId$),
+            nodeId: selected.nodeId,
+            url,
+          });
+          setImageElementSource(nextElement, url);
+          set(internalImageEditsByNodeId$, nextState);
+          set(internalPreparedPayload$, null);
+          toast.success("Image replaced");
+          return true;
+        })(),
+        (error) => {
+          toast.error(
+            htmlDomEditErrorMessage(error, "Image could not be loaded"),
+          );
+        },
+      ),
+      () => {
+        if (!signal.aborted) {
+          set(internalImageBusy$, false);
+        }
+      },
+    );
+
+    return replaced ?? false;
+  },
+);
+
+export const applySelectedHtmlDomImageLayout$ = command(
+  ({ get, set }, layout: HtmlDomImageLayout) => {
+    const doc = currentFrameDocument(get(internalIframeElement$));
+    const selected = selectedImageElementForNodes({
+      doc,
+      selectedNodeIds: get(internalSelectedNodeIds$),
+    });
+    if (!selected) {
+      return;
+    }
+    if (imageLayoutForElement(selected.element) === layout) {
+      return;
+    }
+
+    const styleEditsByNodeId = { ...get(internalStyleEditsByNodeId$) };
+    const originalStylesByNodeId = { ...get(internalOriginalStylesByNodeId$) };
+    const styleProperty = stylePropertyNameForElement(
+      selected.element,
+      "objectFit",
+    );
+
+    originalStylesByNodeId[selected.nodeId] = {
+      ...originalStylesByNodeId[selected.nodeId],
+      objectFit:
+        originalStylesByNodeId[selected.nodeId]?.objectFit ??
+        selected.element.style.getPropertyValue(styleProperty),
+    };
+    selected.element.style.setProperty(styleProperty, layout);
+    styleEditsByNodeId[selected.nodeId] = {
+      ...styleEditsByNodeId[selected.nodeId],
+      objectFit: layout,
+    };
+
+    set(internalOriginalStylesByNodeId$, originalStylesByNodeId);
+    set(internalStyleEditsByNodeId$, styleEditsByNodeId);
+    set(internalPreparedPayload$, null);
+  },
+);
 
 export const setHtmlDomColorPopoverOffset$ = command(
   ({ set }, offset: HtmlDomColorPopoverOffset) => {
@@ -2255,12 +2685,15 @@ export const discardHtmlDomComments$ = command(({ get, set }) => {
   const readyLoadState = get(internalLoadState$);
   const doc = currentFrameDocument(get(internalIframeElement$));
 
+  set(resetHtmlDomImageEditSignal$);
   set(internalComments$, []);
   set(internalCommentsOpen$, false);
   set(internalActiveColorPanelProperty$, null);
   set(internalColorPopoverOffset$, { left: 0, top: 0 });
   set(internalStyleEditsByNodeId$, {});
   set(internalOriginalStylesByNodeId$, {});
+  set(internalImageEditsByNodeId$, {});
+  set(internalImageBusy$, false);
   if (readyLoadState.status === "ready" && doc) {
     restoreFrameDocumentHtml({
       doc,
@@ -2374,10 +2807,13 @@ export const applyHtmlDomStyleEdits$ = command(
     _parentSignal: AbortSignal,
   ) => {
     const readyLoadState = get(internalLoadState$);
+    const hasPendingDomEdits =
+      hasStyleEdits(get(internalStyleEditsByNodeId$)) ||
+      hasImageEdits(get(internalImageEditsByNodeId$));
     if (
       readyLoadState.status !== "ready" ||
       get(internalComments$).length > 0 ||
-      !hasStyleEdits(get(internalStyleEditsByNodeId$)) ||
+      !hasPendingDomEdits ||
       get(internalSubmitting$)
     ) {
       return;
@@ -2429,6 +2865,8 @@ export const htmlDomCommentEditorModel$ = computed(
     const loadState = get(internalLoadState$);
     const submitting = get(internalSubmitting$);
     const styleEditsByNodeId = get(internalStyleEditsByNodeId$);
+    const imageEditsByNodeId = get(internalImageEditsByNodeId$);
+    const imageBusy = get(internalImageBusy$);
     const doc = currentFrameDocument(get(internalIframeElement$));
     const editableStyleProperties = editableStylePropertiesForSelectedNodes({
       doc,
@@ -2444,16 +2882,22 @@ export const htmlDomCommentEditorModel$ = computed(
       canApplyStyleEdits:
         loadState.status === "ready" &&
         comments.length === 0 &&
-        hasStyleEdits(styleEditsByNodeId) &&
-        !submitting,
+        (hasStyleEdits(styleEditsByNodeId) ||
+          hasImageEdits(imageEditsByNodeId)) &&
+        !submitting &&
+        !imageBusy,
       canAddComment: editingCommentId
-        ? commentText.trim() !== ""
+        ? commentText.trim() !== "" && !imageBusy
         : selectedNodeIds.length > 0 &&
           commentText.trim() !== "" &&
-          !hasCommentForSelectedNodes({ comments, selectedNodeIds }),
+          !hasCommentForSelectedNodes({ comments, selectedNodeIds }) &&
+          !imageBusy,
       canEditSelectedStyle: editableStyleProperties.length > 0,
       canSend:
-        loadState.status === "ready" && comments.length > 0 && !submitting,
+        loadState.status === "ready" &&
+        comments.length > 0 &&
+        !submitting &&
+        !imageBusy,
       colorPopoverOffset: get(internalColorPopoverOffset$),
       commentsOpen: get(internalCommentsOpen$),
       commentText,
@@ -2462,6 +2906,7 @@ export const htmlDomCommentEditorModel$ = computed(
       currentComment,
       editableStyleProperties,
       editingCommentId,
+      imageBusy,
       loadState,
       popoverTextAreaKey: [
         selectedNodeIds.join(":"),
@@ -2469,6 +2914,7 @@ export const htmlDomCommentEditorModel$ = computed(
         currentComment?.id ?? "draft",
       ].join("|"),
       prepared: get(internalPreparedPayload$) !== null,
+      selectedImage: selectedImageForNodes({ doc, selectedNodeIds }),
       selectedStyle: selectedStyleForNodes({ doc, selectedNodeIds }),
       submitting,
     };

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -1571,6 +1571,18 @@ describe("zero attachment chips", () => {
       ).toHaveLength(2);
     });
 
+    mockElementRect(frame, {
+      height: 640,
+      left: 0,
+      top: 0,
+      width: 960,
+    });
+    mockElementRect(frame.parentElement!, {
+      height: 720,
+      left: 0,
+      top: 0,
+      width: 960,
+    });
     fireEvent.click(title!);
     await waitFor(() => {
       const visibleMarkers = frame.contentDocument?.querySelectorAll(
@@ -1585,6 +1597,53 @@ describe("zero attachment chips", () => {
       expect(screen.getByTestId("html-dom-comment-textarea")).toHaveValue(
         "Make the hero headline shorter",
       );
+      expect(
+        screen.getByTestId("html-dom-comment-textarea"),
+      ).not.toHaveAttribute("readonly");
+    });
+    const editedPopover = screen.getByTestId("html-dom-comment-popover");
+    const initialEditedPopoverTop = Number.parseFloat(editedPopover.style.top);
+    mockElementRect(title!, {
+      height: 32,
+      left: 284,
+      top: 72,
+      width: 32,
+    });
+    fireEvent.scroll(frame.contentDocument!);
+    await waitFor(() => {
+      expect(Number.parseFloat(editedPopover.style.top)).toBeGreaterThan(
+        initialEditedPopoverTop,
+      );
+    });
+    mockElementRect(title!, {
+      height: 32,
+      left: 284,
+      top: -80,
+      width: 32,
+    });
+    fireEvent.scroll(frame.contentDocument!);
+    await waitFor(() => {
+      expect(screen.queryByTestId("html-dom-comment-popover")).toBeNull();
+      expect(title).not.toHaveAttribute(HTML_DOM_EDIT_SELECTED_ATTR);
+      expect(
+        frame.contentDocument?.querySelectorAll(
+          "[data-testid='html-dom-comment-marker']",
+        ),
+      ).toHaveLength(1);
+      expect(
+        frame.contentDocument?.querySelector(
+          "[data-testid='html-dom-comment-marker']",
+        ),
+      ).toHaveTextContent("Make the body copy warmer");
+    });
+    mockElementRect(title!, {
+      height: 32,
+      left: 284,
+      top: 24,
+      width: 32,
+    });
+    fireEvent.click(title!);
+    await waitFor(() => {
       expect(
         screen.getByTestId("html-dom-comment-textarea"),
       ).not.toHaveAttribute("readonly");
@@ -1815,7 +1874,17 @@ describe("zero attachment chips", () => {
 
     await waitFor(() => {
       expect(screen.getByTestId("html-dom-color-controls")).toBeInTheDocument();
+      expect(screen.getByTestId("html-dom-color-controls")).toHaveClass(
+        "grid-cols-2",
+      );
       expect(screen.queryByTestId("html-dom-color-popover")).toBeNull();
+      expect(
+        screen
+          .getByTestId("html-dom-color-controls")
+          .compareDocumentPosition(
+            screen.getByTestId("html-dom-comment-textarea"),
+          ),
+      ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
       expect(
         screen.getByTestId("html-dom-color-control-color"),
       ).toHaveTextContent("#ff0000");
@@ -2007,6 +2076,140 @@ describe("zero attachment chips", () => {
     });
   });
 
+  it("shows hosted-site HTML image controls when selecting image wrappers", async () => {
+    const htmlUrl = "https://wrapped-image-launch-site.sites.vm7.io";
+
+    setupHostedSiteArtifactPreview({
+      filename: "wrapped-image-launch-site.html",
+      html: `<!doctype html>
+      <html>
+        <head><title>Wrapped image launch site</title></head>
+        <body>
+          <main>
+            <h1>Launch faster</h1>
+            <figure>
+              <a href="/hero">
+                <img src="/hero.png" alt="Hero" />
+              </a>
+            </figure>
+          </main>
+        </body>
+      </html>`,
+      htmlUrl,
+      label: "Wrapped image launch site",
+      runId: "run-hosted-site-wrapped-image",
+    });
+
+    click(
+      await screen.findByLabelText(
+        "Open html preview for Wrapped image launch site",
+      ),
+    );
+    click(await screen.findByLabelText("Edit page"));
+
+    const frame = (await screen.findByTestId(
+      "html-dom-comment-frame",
+    )) as HTMLIFrameElement;
+    await waitFor(() => {
+      expect(
+        frame.contentDocument
+          ?.querySelector("img")
+          ?.hasAttribute(HTML_DOM_NODE_ID_ATTR),
+      ).toBeTruthy();
+      expect(
+        frame.contentDocument
+          ?.querySelector("a")
+          ?.hasAttribute(HTML_DOM_NODE_ID_ATTR),
+      ).toBeTruthy();
+    });
+
+    const link = frame.contentDocument!.querySelector("a")!;
+    const image = frame.contentDocument!.querySelector("img")!;
+    mockElementRect(image, {
+      height: 80,
+      left: 10,
+      top: 20,
+      width: 120,
+    });
+    fireEvent.mouseOver(image);
+
+    await waitFor(() => {
+      expect(
+        within(frame.contentDocument!.body).getByTestId("html-dom-hover-box"),
+      ).toHaveStyle({ border: "2px dashed rgba(37, 99, 235, 0.85)" });
+    });
+
+    let imageAnimationRunning = true;
+    Object.defineProperty(image, "getAnimations", {
+      configurable: true,
+      value: () => {
+        return imageAnimationRunning
+          ? [
+              {
+                effect: {
+                  getTiming: () => {
+                    return { iterations: 1 };
+                  },
+                },
+                playState: "running",
+              },
+            ]
+          : [];
+      },
+    });
+
+    fireEvent.click(link);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("html-dom-image-tools")).toBeInTheDocument();
+      expect(screen.queryByTestId("html-dom-color-controls")).toBeNull();
+      expect(image).toHaveAttribute(HTML_DOM_EDIT_SELECTED_ATTR, "true");
+      expect(link).not.toHaveAttribute(HTML_DOM_EDIT_SELECTED_ATTR);
+      expect(
+        within(frame.contentDocument!.body).getByTestId(
+          "html-dom-selected-box",
+        ),
+      ).toHaveStyle({ border: "2px solid rgb(37, 99, 235)" });
+    });
+
+    mockElementRect(image, {
+      height: 80,
+      left: 42,
+      top: 36,
+      width: 120,
+    });
+
+    await waitFor(() => {
+      expect(
+        within(frame.contentDocument!.body).getByTestId(
+          "html-dom-selected-box",
+        ),
+      ).toHaveStyle({ left: "42px", top: "36px" });
+    });
+
+    mockElementRect(image, {
+      height: 80,
+      left: 64,
+      top: 58,
+      width: 120,
+    });
+
+    await waitFor(() => {
+      expect(
+        within(frame.contentDocument!.body).getByTestId(
+          "html-dom-selected-box",
+        ),
+      ).toHaveStyle({ left: "64px", top: "58px" });
+    });
+    imageAnimationRunning = false;
+
+    click(screen.getByTestId("html-dom-image-layout-cover"));
+
+    await waitFor(() => {
+      expect(image.style.objectFit).toBe("cover");
+    });
+  });
+
   it("uploads and applies a hosted-site HTML image replacement", async () => {
     const htmlUrl = "https://upload-image-launch-site.sites.vm7.io";
     const uploadedImageUrl =
@@ -2081,8 +2284,8 @@ describe("zero attachment chips", () => {
 
     await waitFor(() => {
       expect(image.getAttribute("src")).toBe(uploadedImageUrl);
-      expect(image.hasAttribute("srcset")).toBe(false);
-      expect(image.hasAttribute("sizes")).toBe(false);
+      expect(image.hasAttribute("srcset")).toBeFalsy();
+      expect(image.hasAttribute("sizes")).toBeFalsy();
       expect(screen.getByTestId("html-dom-toolbar-send")).toBeEnabled();
       expect(screen.getByTestId("html-dom-toolbar-send")).toHaveTextContent(
         "Apply",
@@ -2096,23 +2299,9 @@ describe("zero attachment chips", () => {
     });
   });
 
-  it("replaces a hosted-site HTML image with a verified URL", async () => {
+  it("replaces a hosted-site HTML image with a URL", async () => {
     const htmlUrl = "https://link-image-launch-site.sites.vm7.io";
     const linkedImageUrl = "https://images.example.com/replacement.png";
-
-    vi.stubGlobal(
-      "Image",
-      class {
-        onerror: (() => void) | null = null;
-        onload: (() => void) | null = null;
-
-        set src(_value: string) {
-          queueMicrotask(() => {
-            this.onload?.();
-          });
-        }
-      },
-    );
 
     setupHostedSiteArtifactPreview({
       filename: "link-image-launch-site.html",
@@ -2277,6 +2466,9 @@ describe("zero attachment chips", () => {
     fireEvent.click(frame.contentDocument!.querySelector("input")!);
     await waitFor(() => {
       expect(screen.getByTestId("html-dom-color-controls")).toBeInTheDocument();
+      expect(screen.getByTestId("html-dom-color-controls")).toHaveClass(
+        "grid-cols-2",
+      );
       expect(
         screen.getByTestId("html-dom-color-control-color"),
       ).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -1932,7 +1932,7 @@ describe("zero attachment chips", () => {
     });
   });
 
-  it("hides hosted-site HTML color controls for selected images", async () => {
+  it("shows hosted-site HTML image controls for selected images", async () => {
     const htmlUrl = "https://image-launch-site.sites.vm7.io";
 
     setupHostedSiteArtifactPreview({
@@ -1973,7 +1973,263 @@ describe("zero attachment chips", () => {
       expect(
         screen.getByTestId("html-dom-comment-popover"),
       ).toBeInTheDocument();
+      expect(screen.getByTestId("html-dom-image-tools")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("html-dom-image-source-upload"),
+      ).toHaveTextContent("Upload");
+      expect(
+        screen.getByTestId("html-dom-image-source-link"),
+      ).toHaveTextContent("Link");
+      expect(
+        screen.getByTestId("html-dom-image-layout-cover"),
+      ).toHaveTextContent("Cover");
+      expect(
+        screen.getByTestId("html-dom-image-layout-contain"),
+      ).toHaveTextContent("Contain");
+      expect(screen.getByTestId("html-dom-image-layout-fill")).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+      expect(screen.getByTestId("html-dom-image-upload-input")).toHaveAttribute(
+        "accept",
+        expect.stringContaining("image/png"),
+      );
+      expect(
+        screen
+          .getByTestId("html-dom-image-upload-input")
+          .getAttribute("accept"),
+      ).not.toContain("svg");
+      expect(screen.getByTestId("html-dom-comment-textarea")).toHaveAttribute(
+        "placeholder",
+        "Ask Zero to adjust this image",
+      );
       expect(screen.queryByTestId("html-dom-color-controls")).toBeNull();
+    });
+  });
+
+  it("uploads and applies a hosted-site HTML image replacement", async () => {
+    const htmlUrl = "https://upload-image-launch-site.sites.vm7.io";
+    const uploadedImageUrl =
+      "https://cdn.vm7.io/artifacts/test/html-image/new-hero.png";
+    let redeployedHtml: string | null = null;
+
+    context.mocks.upload.success({
+      id: "upload-html-hero-image",
+      filename: "new-hero.png",
+      contentType: "image/png",
+      size: 2048,
+      url: uploadedImageUrl,
+    });
+    setupHostedSiteArtifactPreview({
+      filename: "upload-image-launch-site.html",
+      html: `<!doctype html>
+      <html>
+        <head><title>Upload image launch site</title></head>
+        <body>
+          <main>
+            <img src="/hero.png" srcset="/hero-small.png 1x, /hero-large.png 2x" sizes="100vw" alt="Hero" />
+          </main>
+        </body>
+      </html>`,
+      htmlUrl,
+      label: "Upload image launch site",
+      runId: "run-hosted-site-upload-image",
+    });
+    context.mocks.api(zeroHostContract.redeployHtml, ({ body, respond }) => {
+      expect(body.url).toBe(htmlUrl);
+      expect(body.html).toContain(uploadedImageUrl);
+      expect(body.html).not.toContain("srcset=");
+      expect(body.html).not.toContain("sizes=");
+      redeployedHtml = body.html;
+      return respond(200, {
+        siteId: "7c82da29-6280-4d65-b078-e233c8ad14bf",
+        deploymentId: "dc8b4d42-5dc1-4769-ad8b-17bdf1ad035a",
+        publicSlug: "upload-image-launch-site",
+        url: htmlUrl,
+        status: "ready",
+      });
+    });
+
+    click(
+      await screen.findByLabelText(
+        "Open html preview for Upload image launch site",
+      ),
+    );
+    click(await screen.findByLabelText("Edit page"));
+
+    const frame = (await screen.findByTestId(
+      "html-dom-comment-frame",
+    )) as HTMLIFrameElement;
+    await waitFor(() => {
+      expect(
+        frame.contentDocument
+          ?.querySelector("img")
+          ?.hasAttribute(HTML_DOM_NODE_ID_ATTR),
+      ).toBeTruthy();
+    });
+    const image = frame.contentDocument!.querySelector("img")!;
+    fireEvent.click(image);
+    await waitFor(() => {
+      expect(screen.getByTestId("html-dom-image-tools")).toBeInTheDocument();
+    });
+
+    const user = userEvent.setup({ delay: null });
+    await user.upload(
+      screen.getByTestId("html-dom-image-upload-input"),
+      new File(["new image"], "new-hero.png", { type: "image/png" }),
+    );
+
+    await waitFor(() => {
+      expect(image.getAttribute("src")).toBe(uploadedImageUrl);
+      expect(image.hasAttribute("srcset")).toBe(false);
+      expect(image.hasAttribute("sizes")).toBe(false);
+      expect(screen.getByTestId("html-dom-toolbar-send")).toBeEnabled();
+      expect(screen.getByTestId("html-dom-toolbar-send")).toHaveTextContent(
+        "Apply",
+      );
+    });
+
+    click(screen.getByTestId("html-dom-toolbar-send"));
+    await waitFor(() => {
+      expect(redeployedHtml).not.toBeNull();
+      expect(screen.queryByTestId("html-dom-comment-frame")).toBeNull();
+    });
+  });
+
+  it("replaces a hosted-site HTML image with a verified URL", async () => {
+    const htmlUrl = "https://link-image-launch-site.sites.vm7.io";
+    const linkedImageUrl = "https://images.example.com/replacement.png";
+
+    vi.stubGlobal(
+      "Image",
+      class {
+        onerror: (() => void) | null = null;
+        onload: (() => void) | null = null;
+
+        set src(_value: string) {
+          queueMicrotask(() => {
+            this.onload?.();
+          });
+        }
+      },
+    );
+
+    setupHostedSiteArtifactPreview({
+      filename: "link-image-launch-site.html",
+      html: `<!doctype html>
+      <html>
+        <head><title>Link image launch site</title></head>
+        <body>
+          <main>
+            <img src="/hero.png" alt="Hero" />
+          </main>
+        </body>
+      </html>`,
+      htmlUrl,
+      label: "Link image launch site",
+      runId: "run-hosted-site-link-image",
+    });
+
+    click(
+      await screen.findByLabelText(
+        "Open html preview for Link image launch site",
+      ),
+    );
+    click(await screen.findByLabelText("Edit page"));
+
+    const frame = (await screen.findByTestId(
+      "html-dom-comment-frame",
+    )) as HTMLIFrameElement;
+    await waitFor(() => {
+      expect(
+        frame.contentDocument
+          ?.querySelector("img")
+          ?.hasAttribute(HTML_DOM_NODE_ID_ATTR),
+      ).toBeTruthy();
+    });
+    const image = frame.contentDocument!.querySelector("img")!;
+    fireEvent.click(image);
+    click(await screen.findByTestId("html-dom-image-source-link"));
+
+    const user = userEvent.setup({ delay: null });
+    await user.type(
+      await screen.findByTestId("html-dom-image-link-input"),
+      linkedImageUrl,
+    );
+    click(screen.getByTestId("html-dom-image-link-submit"));
+
+    await waitFor(() => {
+      expect(image.getAttribute("src")).toBe(linkedImageUrl);
+      expect(screen.queryByTestId("html-dom-image-link-form")).toBeNull();
+      expect(screen.getByTestId("html-dom-toolbar-send")).toBeEnabled();
+    });
+  });
+
+  it("applies hosted-site HTML image layout edits from the DOM popover", async () => {
+    const htmlUrl = "https://layout-image-launch-site.sites.vm7.io";
+    let redeployedHtml: string | null = null;
+
+    setupHostedSiteArtifactPreview({
+      filename: "layout-image-launch-site.html",
+      html: `<!doctype html>
+      <html>
+        <head><title>Layout image launch site</title></head>
+        <body>
+          <main>
+            <img src="/hero.png" alt="Hero" />
+          </main>
+        </body>
+      </html>`,
+      htmlUrl,
+      label: "Layout image launch site",
+      runId: "run-hosted-site-layout-image",
+    });
+    context.mocks.api(zeroHostContract.redeployHtml, ({ body, respond }) => {
+      expect(body.url).toBe(htmlUrl);
+      expect(body.html).toContain("object-fit: cover");
+      redeployedHtml = body.html;
+      return respond(200, {
+        siteId: "7c82da29-6280-4d65-b078-e233c8ad14bf",
+        deploymentId: "dc8b4d42-5dc1-4769-ad8b-17bdf1ad035a",
+        publicSlug: "layout-image-launch-site",
+        url: htmlUrl,
+        status: "ready",
+      });
+    });
+
+    click(
+      await screen.findByLabelText(
+        "Open html preview for Layout image launch site",
+      ),
+    );
+    click(await screen.findByLabelText("Edit page"));
+
+    const frame = (await screen.findByTestId(
+      "html-dom-comment-frame",
+    )) as HTMLIFrameElement;
+    await waitFor(() => {
+      expect(
+        frame.contentDocument
+          ?.querySelector("img")
+          ?.hasAttribute(HTML_DOM_NODE_ID_ATTR),
+      ).toBeTruthy();
+    });
+    const image = frame.contentDocument!.querySelector("img")!;
+    fireEvent.click(image);
+    click(await screen.findByTestId("html-dom-image-layout-cover"));
+
+    await waitFor(() => {
+      expect(image.style.objectFit).toBe("cover");
+      expect(screen.getByTestId("html-dom-toolbar-send")).toHaveTextContent(
+        "Apply",
+      );
+      expect(screen.getByTestId("html-dom-toolbar-send")).toBeEnabled();
+    });
+
+    click(screen.getByTestId("html-dom-toolbar-send"));
+    await waitFor(() => {
+      expect(redeployedHtml).not.toBeNull();
+      expect(screen.queryByTestId("html-dom-comment-frame")).toBeNull();
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/html-dom-comment-editor.tsx
+++ b/turbo/apps/platform/src/views/zero-page/html-dom-comment-editor.tsx
@@ -1,11 +1,9 @@
-import {
-  useRef,
-  useState,
-  type ChangeEvent,
-  type FormEvent,
-  type KeyboardEvent,
-  type PointerEvent,
-  type ReactNode,
+import type {
+  ChangeEvent,
+  FormEvent,
+  KeyboardEvent,
+  PointerEvent,
+  ReactNode,
 } from "react";
 import {
   IconArrowUp,
@@ -20,7 +18,7 @@ import {
   IconUpload,
 } from "@tabler/icons-react";
 import { useGet, useSet } from "ccstate-react";
-import { detach, Reason, tapError } from "../../signals/utils.ts";
+import { detach, Reason, tapError, withCleanup } from "../../signals/utils.ts";
 import {
   addHtmlDomComment$,
   applySelectedHtmlDomImageLayout$,
@@ -38,13 +36,17 @@ import {
   setHtmlDomCommentStageRef$,
   setHtmlDomCommentTextareaRef$,
   setHtmlDomCommentText$,
+  setHtmlDomImageLinkValue$,
+  setHtmlDomImagePendingAction$,
   replaceSelectedHtmlDomImageUrl$,
   toggleHtmlDomColorPanel$,
   toggleHtmlDomCommentsOpen$,
+  toggleHtmlDomImageLinkOpen$,
   uploadSelectedHtmlDomImage$,
   type HtmlDomImageLayout,
   type HtmlDomStyleProperty,
   type HtmlDomCommentEditorModel,
+  type HtmlDomSelectedImage,
 } from "../../signals/zero-page/html-dom-comment-editor.ts";
 import type {
   HtmlDomEditComment,
@@ -480,22 +482,19 @@ function HtmlDomColorControl({
       type="button"
       aria-expanded={active}
       aria-label={`Open ${property === "color" ? "text" : "background"} color panel`}
-      className={`flex h-16 w-[168px] shrink-0 items-center justify-between gap-2 rounded-lg px-3 py-2 text-left transition focus:outline-none focus:ring-2 focus:ring-blue-500/30 ${
-        active ? "bg-muted" : "bg-muted/55 hover:bg-muted/80"
+      className={`inline-flex h-9 w-full min-w-0 items-center justify-between gap-2 overflow-hidden rounded-full border px-3 text-left transition focus:outline-none focus:ring-2 focus:ring-blue-500/25 ${
+        active
+          ? "border-blue-500/45 bg-blue-500/10 text-foreground ring-2 ring-blue-500/15"
+          : "border-border/70 bg-background text-foreground hover:bg-muted/45"
       }`}
       data-testid={`html-dom-color-control-${property}`}
       onClick={onClick}
     >
-      <span className="min-w-0">
-        <span className="block text-[11px] font-medium leading-3 text-muted-foreground">
-          {colorControlLabel(property)}
-        </span>
-        <span className="mt-0.5 block truncate font-mono text-[12px] font-medium text-foreground">
-          {value.toLowerCase()}
-        </span>
+      <span className="min-w-0 truncate font-mono text-xs font-medium">
+        {value.toLowerCase()}
       </span>
       <span
-        className={`h-7 w-7 shrink-0 rounded-full border shadow-sm transition ${
+        className={`h-6 w-6 shrink-0 rounded-full border shadow-sm transition ${
           active
             ? "border-foreground ring-2 ring-foreground/20 ring-offset-1"
             : "border-border/80"
@@ -838,18 +837,30 @@ function HtmlDomColorControls({
 }) {
   const toggleColorPanel = useSet(toggleHtmlDomColorPanel$);
   const activeProperty = model.activeColorPanelProperty;
-  if (model.editableStyleProperties.length === 0) {
+  if (model.selectedImage || model.editableStyleProperties.length === 0) {
     return null;
   }
 
+  const columns =
+    model.editableStyleProperties.length === 1 ? "grid-cols-1" : "grid-cols-2";
+
   return (
-    <div className="mt-2" data-testid="html-dom-color-controls">
-      <div className="flex flex-wrap gap-1.5">
-        {model.editableStyleProperties.map((property) => {
-          const active = activeProperty === property;
-          return (
+    <div
+      className={`grid ${columns} gap-2`}
+      data-testid="html-dom-color-controls"
+    >
+      {model.editableStyleProperties.map((property) => {
+        const active = activeProperty === property;
+        return (
+          <div
+            key={property}
+            className="min-w-0 space-y-1"
+            data-testid={`html-dom-color-row-${property}`}
+          >
+            <div className="px-1 text-xs font-medium text-muted-foreground">
+              {colorControlLabel(property)}
+            </div>
             <HtmlDomColorControl
-              key={property}
               active={active}
               model={model}
               property={property}
@@ -857,9 +868,9 @@ function HtmlDomColorControls({
                 toggleColorPanel(property);
               }}
             />
-          );
-        })}
-      </div>
+          </div>
+        );
+      })}
     </div>
   );
 }
@@ -954,6 +965,185 @@ function HtmlDomImageGroupButton({
   );
 }
 
+type PendingImageAction = "link" | "upload";
+
+function HtmlDomImageSummary({
+  image,
+}: {
+  readonly image: HtmlDomSelectedImage;
+}) {
+  return (
+    <div className="flex min-w-0 items-center gap-2 rounded-2xl bg-muted/35 px-2.5 py-2">
+      <div className="flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-background text-muted-foreground">
+        {image.resolvedSrc ? (
+          <img
+            src={image.resolvedSrc}
+            alt=""
+            className="h-full w-full object-cover"
+            draggable={false}
+          />
+        ) : (
+          <IconPhoto size={17} stroke={1.7} />
+        )}
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-sm font-medium text-foreground">
+          Image
+        </div>
+        <div className="truncate text-xs text-muted-foreground">
+          {[image.renderedSize, image.layout].filter(Boolean).join(" · ")}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function HtmlDomImageSourceControls({
+  disabled,
+  linkOpen,
+  onToggleLink,
+  onUploadChange,
+  pendingAction,
+}: {
+  readonly disabled: boolean;
+  readonly linkOpen: boolean;
+  readonly onToggleLink: () => void;
+  readonly onUploadChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  readonly pendingAction: PendingImageAction | null;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <div className="text-xs font-medium text-muted-foreground">Source</div>
+      <div className="inline-flex overflow-hidden rounded-full border border-border/70 bg-background">
+        <label
+          aria-disabled={disabled}
+          className={`inline-flex h-8 items-center justify-center gap-1.5 px-3 text-xs font-medium transition-colors first:rounded-l-full last:rounded-r-full ${
+            disabled
+              ? "cursor-not-allowed opacity-45"
+              : "cursor-pointer text-muted-foreground hover:bg-muted hover:text-foreground"
+          }`}
+          data-testid="html-dom-image-source-upload"
+          htmlFor="html-dom-image-upload-input-control"
+          title="Upload image"
+        >
+          {pendingAction === "upload" ? (
+            <IconLoader2 size={14} className="animate-spin" />
+          ) : (
+            <IconUpload size={14} stroke={1.9} />
+          )}
+          Upload
+        </label>
+        <HtmlDomImageGroupButton
+          active={linkOpen}
+          disabled={disabled}
+          onClick={onToggleLink}
+          testId="html-dom-image-source-link"
+          title="Use image URL"
+        >
+          {pendingAction === "link" ? (
+            <IconLoader2 size={14} className="animate-spin" />
+          ) : (
+            <IconLink size={14} stroke={1.9} />
+          )}
+          Link
+        </HtmlDomImageGroupButton>
+      </div>
+      <input
+        id="html-dom-image-upload-input-control"
+        type="file"
+        accept={IMAGE_UPLOAD_ACCEPT}
+        disabled={disabled}
+        className="hidden"
+        data-testid="html-dom-image-upload-input"
+        onChange={onUploadChange}
+      />
+    </div>
+  );
+}
+
+function HtmlDomImageLinkForm({
+  disabled,
+  linkValue,
+  onChange,
+  onSubmit,
+  pendingAction,
+}: {
+  readonly disabled: boolean;
+  readonly linkValue: string;
+  readonly onChange: (value: string) => void;
+  readonly onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  readonly pendingAction: PendingImageAction | null;
+}) {
+  return (
+    <form
+      className="flex h-9 items-center gap-1 rounded-full border border-border/70 bg-muted/25 px-2 focus-within:border-blue-500 focus-within:bg-background focus-within:ring-2 focus-within:ring-blue-500/15"
+      onSubmit={onSubmit}
+      data-testid="html-dom-image-link-form"
+    >
+      <IconLink size={14} className="shrink-0 text-muted-foreground" />
+      <input
+        autoFocus
+        type="url"
+        value={linkValue}
+        disabled={disabled}
+        placeholder="Paste image URL"
+        className="min-w-0 flex-1 border-0 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+        data-testid="html-dom-image-link-input"
+        onChange={(event) => {
+          onChange(event.currentTarget.value);
+        }}
+      />
+      <button
+        type="submit"
+        disabled={disabled || linkValue.trim() === ""}
+        aria-label="Replace image from URL"
+        className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-blue-600 text-white transition-colors hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-45"
+        data-testid="html-dom-image-link-submit"
+      >
+        {pendingAction === "link" ? (
+          <IconLoader2 size={14} className="animate-spin" />
+        ) : (
+          <IconCheck size={15} stroke={2.2} />
+        )}
+      </button>
+    </form>
+  );
+}
+
+function HtmlDomImageLayoutControls({
+  disabled,
+  image,
+  onApplyLayout,
+}: {
+  readonly disabled: boolean;
+  readonly image: HtmlDomSelectedImage;
+  readonly onApplyLayout: (layout: HtmlDomImageLayout) => void;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <div className="text-xs font-medium text-muted-foreground">Layout</div>
+      <div className="inline-flex overflow-hidden rounded-full border border-border/70 bg-background">
+        {IMAGE_LAYOUT_OPTIONS.map((option) => {
+          return (
+            <HtmlDomImageGroupButton
+              key={option.value}
+              active={image.layout === option.value}
+              disabled={disabled}
+              onClick={() => {
+                onApplyLayout(option.value);
+              }}
+              testId={`html-dom-image-layout-${option.value}`}
+              title={`${option.label} image`}
+            >
+              {option.label}
+            </HtmlDomImageGroupButton>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 function HtmlDomImageTools({
   model,
   pageSignal,
@@ -965,28 +1155,23 @@ function HtmlDomImageTools({
   const uploadImage = useSet(uploadSelectedHtmlDomImage$);
   const replaceImageUrl = useSet(replaceSelectedHtmlDomImageUrl$);
   const applyImageLayout = useSet(applySelectedHtmlDomImageLayout$);
-  const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const [linkOpen, setLinkOpen] = useState(false);
-  const [linkValue, setLinkValue] = useState("");
-  const [pendingAction, setPendingAction] = useState<"link" | "upload" | null>(
-    null,
-  );
+  const toggleLinkOpen = useSet(toggleHtmlDomImageLinkOpen$);
+  const setLinkValue = useSet(setHtmlDomImageLinkValue$);
+  const setPendingAction = useSet(setHtmlDomImagePendingAction$);
 
   if (!image) {
     return null;
   }
 
   const runPendingAction = (
-    action: "link" | "upload",
+    action: PendingImageAction,
     promise: Promise<boolean>,
     description: string,
   ): void => {
     setPendingAction(action);
     detach(
-      promise.finally(() => {
-        setPendingAction((current) => {
-          return current === action ? null : current;
-        });
+      withCleanup(promise, () => {
+        setPendingAction(null);
       }),
       Reason.DomCallback,
       description,
@@ -1009,9 +1194,9 @@ function HtmlDomImageTools({
   const handleLinkSubmit = (event: FormEvent<HTMLFormElement>): void => {
     event.preventDefault();
     const replace = async (): Promise<boolean> => {
-      const replaced = await replaceImageUrl(linkValue, pageSignal);
+      const replaced = await replaceImageUrl(model.imageLinkValue, pageSignal);
       if (replaced) {
-        setLinkOpen(false);
+        toggleLinkOpen();
         setLinkValue("");
       }
       return replaced;
@@ -1020,133 +1205,33 @@ function HtmlDomImageTools({
   };
 
   return (
-    <div className="mb-2 space-y-2" data-testid="html-dom-image-tools">
-      <div className="flex min-w-0 items-center gap-2 rounded-2xl bg-muted/35 px-2.5 py-2">
-        <div className="flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-background text-muted-foreground">
-          {image.resolvedSrc ? (
-            <img
-              src={image.resolvedSrc}
-              alt=""
-              className="h-full w-full object-cover"
-              draggable={false}
-            />
-          ) : (
-            <IconPhoto size={17} stroke={1.7} />
-          )}
-        </div>
-        <div className="min-w-0 flex-1">
-          <div className="truncate text-sm font-medium text-foreground">
-            Image
-          </div>
-          <div className="truncate text-xs text-muted-foreground">
-            {[image.renderedSize, image.layout].filter(Boolean).join(" · ")}
-          </div>
-        </div>
-      </div>
+    <div className="space-y-2" data-testid="html-dom-image-tools">
+      <HtmlDomImageSummary image={image} />
+      <HtmlDomImageSourceControls
+        disabled={model.imageBusy}
+        linkOpen={model.imageLinkOpen}
+        pendingAction={model.imagePendingAction}
+        onToggleLink={() => {
+          toggleLinkOpen();
+        }}
+        onUploadChange={handleUploadChange}
+      />
 
-      <div className="flex items-center justify-between gap-2">
-        <div className="text-xs font-medium text-muted-foreground">Source</div>
-        <div className="inline-flex overflow-hidden rounded-full border border-border/70 bg-background">
-          <HtmlDomImageGroupButton
-            disabled={model.imageBusy}
-            onClick={() => {
-              fileInputRef.current?.click();
-            }}
-            testId="html-dom-image-source-upload"
-            title="Upload image"
-          >
-            {pendingAction === "upload" ? (
-              <IconLoader2 size={14} className="animate-spin" />
-            ) : (
-              <IconUpload size={14} stroke={1.9} />
-            )}
-            Upload
-          </HtmlDomImageGroupButton>
-          <HtmlDomImageGroupButton
-            active={linkOpen}
-            disabled={model.imageBusy}
-            onClick={() => {
-              setLinkOpen((open) => {
-                return !open;
-              });
-            }}
-            testId="html-dom-image-source-link"
-            title="Use image URL"
-          >
-            {pendingAction === "link" ? (
-              <IconLoader2 size={14} className="animate-spin" />
-            ) : (
-              <IconLink size={14} stroke={1.9} />
-            )}
-            Link
-          </HtmlDomImageGroupButton>
-        </div>
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept={IMAGE_UPLOAD_ACCEPT}
-          className="hidden"
-          data-testid="html-dom-image-upload-input"
-          onChange={handleUploadChange}
-        />
-      </div>
-
-      {linkOpen && (
-        <form
-          className="flex h-9 items-center gap-1 rounded-full border border-border/70 bg-muted/25 px-2 focus-within:border-blue-500 focus-within:bg-background focus-within:ring-2 focus-within:ring-blue-500/15"
+      {model.imageLinkOpen && (
+        <HtmlDomImageLinkForm
+          disabled={model.imageBusy}
+          linkValue={model.imageLinkValue}
+          pendingAction={model.imagePendingAction}
+          onChange={setLinkValue}
           onSubmit={handleLinkSubmit}
-          data-testid="html-dom-image-link-form"
-        >
-          <IconLink size={14} className="shrink-0 text-muted-foreground" />
-          <input
-            autoFocus
-            type="url"
-            value={linkValue}
-            disabled={model.imageBusy}
-            placeholder="Paste image URL"
-            className="min-w-0 flex-1 border-0 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
-            data-testid="html-dom-image-link-input"
-            onChange={(event) => {
-              setLinkValue(event.currentTarget.value);
-            }}
-          />
-          <button
-            type="submit"
-            disabled={model.imageBusy || linkValue.trim() === ""}
-            aria-label="Replace image from URL"
-            className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-blue-600 text-white transition-colors hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-45"
-            data-testid="html-dom-image-link-submit"
-          >
-            {pendingAction === "link" ? (
-              <IconLoader2 size={14} className="animate-spin" />
-            ) : (
-              <IconCheck size={15} stroke={2.2} />
-            )}
-          </button>
-        </form>
+        />
       )}
 
-      <div className="flex items-center justify-between gap-2">
-        <div className="text-xs font-medium text-muted-foreground">Layout</div>
-        <div className="inline-flex overflow-hidden rounded-full border border-border/70 bg-background">
-          {IMAGE_LAYOUT_OPTIONS.map((option) => {
-            return (
-              <HtmlDomImageGroupButton
-                key={option.value}
-                active={image.layout === option.value}
-                disabled={model.imageBusy}
-                onClick={() => {
-                  applyImageLayout(option.value);
-                }}
-                testId={`html-dom-image-layout-${option.value}`}
-                title={`${option.label} image`}
-              >
-                {option.label}
-              </HtmlDomImageGroupButton>
-            );
-          })}
-        </div>
-      </div>
+      <HtmlDomImageLayoutControls
+        disabled={model.imageBusy}
+        image={image}
+        onApplyLayout={applyImageLayout}
+      />
     </div>
   );
 }
@@ -1198,8 +1283,11 @@ function HtmlDomCommentPopover({
       }}
       data-testid="html-dom-comment-popover"
     >
-      <HtmlDomImageTools model={model} pageSignal={pageSignal} />
-      <div className="flex items-end gap-2">
+      <div className="space-y-2">
+        <HtmlDomImageTools model={model} pageSignal={pageSignal} />
+        <HtmlDomColorControls model={model} />
+      </div>
+      <div className="mt-2 flex items-end gap-2">
         <textarea
           key={model.popoverTextAreaKey}
           ref={setTextAreaRef}
@@ -1242,7 +1330,6 @@ function HtmlDomCommentPopover({
           <IconArrowUp size={19} stroke={2.2} />
         </button>
       </div>
-      <HtmlDomColorControls model={model} />
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/html-dom-comment-editor.tsx
+++ b/turbo/apps/platform/src/views/zero-page/html-dom-comment-editor.tsx
@@ -1,16 +1,29 @@
-import type { KeyboardEvent, PointerEvent } from "react";
+import {
+  useRef,
+  useState,
+  type ChangeEvent,
+  type FormEvent,
+  type KeyboardEvent,
+  type PointerEvent,
+  type ReactNode,
+} from "react";
 import {
   IconArrowUp,
+  IconCheck,
   IconColorPicker,
+  IconLink,
   IconLoader2,
   IconMessageCircle,
+  IconPhoto,
   IconSend,
   IconTrash,
+  IconUpload,
 } from "@tabler/icons-react";
 import { useGet, useSet } from "ccstate-react";
 import { detach, Reason, tapError } from "../../signals/utils.ts";
 import {
   addHtmlDomComment$,
+  applySelectedHtmlDomImageLayout$,
   applyHtmlDomColorStyle$,
   applyHtmlDomStyleEdits$,
   beginEditingCurrentHtmlDomComment$,
@@ -25,8 +38,11 @@ import {
   setHtmlDomCommentStageRef$,
   setHtmlDomCommentTextareaRef$,
   setHtmlDomCommentText$,
+  replaceSelectedHtmlDomImageUrl$,
   toggleHtmlDomColorPanel$,
   toggleHtmlDomCommentsOpen$,
+  uploadSelectedHtmlDomImage$,
+  type HtmlDomImageLayout,
   type HtmlDomStyleProperty,
   type HtmlDomCommentEditorModel,
 } from "../../signals/zero-page/html-dom-comment-editor.ts";
@@ -108,7 +124,9 @@ function HtmlDomCommentStage({
           }}
         />
       )}
-      {!working && <HtmlDomCommentPopover model={model} />}
+      {!working && (
+        <HtmlDomCommentPopover model={model} pageSignal={pageSignal} />
+      )}
       {!working && <HtmlDomFloatingColorPopover model={model} />}
       <HtmlDomCommentToolbar
         disabled={working}
@@ -877,10 +895,268 @@ function HtmlDomFloatingColorPopover({
   );
 }
 
-function HtmlDomCommentPopover({
+const IMAGE_UPLOAD_ACCEPT = [
+  "image/avif",
+  "image/bmp",
+  "image/gif",
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  ".avif",
+  ".bmp",
+  ".gif",
+  ".jpeg",
+  ".jpg",
+  ".png",
+  ".webp",
+].join(",");
+
+const IMAGE_LAYOUT_OPTIONS: readonly {
+  readonly label: string;
+  readonly value: HtmlDomImageLayout;
+}[] = [
+  { label: "Cover", value: "cover" },
+  { label: "Contain", value: "contain" },
+  { label: "Fill", value: "fill" },
+];
+
+function HtmlDomImageGroupButton({
+  active = false,
+  children,
+  disabled,
+  onClick,
+  testId,
+  title,
+}: {
+  readonly active?: boolean;
+  readonly children: ReactNode;
+  readonly disabled?: boolean;
+  readonly onClick: () => void;
+  readonly testId: string;
+  readonly title: string;
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      title={title}
+      disabled={disabled}
+      onClick={onClick}
+      className={`inline-flex h-8 items-center justify-center gap-1.5 px-3 text-xs font-medium transition-colors first:rounded-l-full last:rounded-r-full disabled:cursor-not-allowed disabled:opacity-45 ${
+        active
+          ? "bg-foreground text-background"
+          : "text-muted-foreground hover:bg-muted hover:text-foreground"
+      }`}
+      data-testid={testId}
+    >
+      {children}
+    </button>
+  );
+}
+
+function HtmlDomImageTools({
   model,
+  pageSignal,
 }: {
   readonly model: HtmlDomCommentEditorModel;
+  readonly pageSignal: AbortSignal;
+}) {
+  const image = model.selectedImage;
+  const uploadImage = useSet(uploadSelectedHtmlDomImage$);
+  const replaceImageUrl = useSet(replaceSelectedHtmlDomImageUrl$);
+  const applyImageLayout = useSet(applySelectedHtmlDomImageLayout$);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [linkOpen, setLinkOpen] = useState(false);
+  const [linkValue, setLinkValue] = useState("");
+  const [pendingAction, setPendingAction] = useState<"link" | "upload" | null>(
+    null,
+  );
+
+  if (!image) {
+    return null;
+  }
+
+  const runPendingAction = (
+    action: "link" | "upload",
+    promise: Promise<boolean>,
+    description: string,
+  ): void => {
+    setPendingAction(action);
+    detach(
+      promise.finally(() => {
+        setPendingAction((current) => {
+          return current === action ? null : current;
+        });
+      }),
+      Reason.DomCallback,
+      description,
+    );
+  };
+
+  const handleUploadChange = (event: ChangeEvent<HTMLInputElement>): void => {
+    const file = event.currentTarget.files?.[0];
+    event.currentTarget.value = "";
+    if (!file) {
+      return;
+    }
+    runPendingAction(
+      "upload",
+      uploadImage(file, pageSignal),
+      "uploadSelectedHtmlDomImage",
+    );
+  };
+
+  const handleLinkSubmit = (event: FormEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+    const replace = async (): Promise<boolean> => {
+      const replaced = await replaceImageUrl(linkValue, pageSignal);
+      if (replaced) {
+        setLinkOpen(false);
+        setLinkValue("");
+      }
+      return replaced;
+    };
+    runPendingAction("link", replace(), "replaceSelectedHtmlDomImageUrl");
+  };
+
+  return (
+    <div className="mb-2 space-y-2" data-testid="html-dom-image-tools">
+      <div className="flex min-w-0 items-center gap-2 rounded-2xl bg-muted/35 px-2.5 py-2">
+        <div className="flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-background text-muted-foreground">
+          {image.resolvedSrc ? (
+            <img
+              src={image.resolvedSrc}
+              alt=""
+              className="h-full w-full object-cover"
+              draggable={false}
+            />
+          ) : (
+            <IconPhoto size={17} stroke={1.7} />
+          )}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-sm font-medium text-foreground">
+            Image
+          </div>
+          <div className="truncate text-xs text-muted-foreground">
+            {[image.renderedSize, image.layout].filter(Boolean).join(" · ")}
+          </div>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between gap-2">
+        <div className="text-xs font-medium text-muted-foreground">Source</div>
+        <div className="inline-flex overflow-hidden rounded-full border border-border/70 bg-background">
+          <HtmlDomImageGroupButton
+            disabled={model.imageBusy}
+            onClick={() => {
+              fileInputRef.current?.click();
+            }}
+            testId="html-dom-image-source-upload"
+            title="Upload image"
+          >
+            {pendingAction === "upload" ? (
+              <IconLoader2 size={14} className="animate-spin" />
+            ) : (
+              <IconUpload size={14} stroke={1.9} />
+            )}
+            Upload
+          </HtmlDomImageGroupButton>
+          <HtmlDomImageGroupButton
+            active={linkOpen}
+            disabled={model.imageBusy}
+            onClick={() => {
+              setLinkOpen((open) => {
+                return !open;
+              });
+            }}
+            testId="html-dom-image-source-link"
+            title="Use image URL"
+          >
+            {pendingAction === "link" ? (
+              <IconLoader2 size={14} className="animate-spin" />
+            ) : (
+              <IconLink size={14} stroke={1.9} />
+            )}
+            Link
+          </HtmlDomImageGroupButton>
+        </div>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept={IMAGE_UPLOAD_ACCEPT}
+          className="hidden"
+          data-testid="html-dom-image-upload-input"
+          onChange={handleUploadChange}
+        />
+      </div>
+
+      {linkOpen && (
+        <form
+          className="flex h-9 items-center gap-1 rounded-full border border-border/70 bg-muted/25 px-2 focus-within:border-blue-500 focus-within:bg-background focus-within:ring-2 focus-within:ring-blue-500/15"
+          onSubmit={handleLinkSubmit}
+          data-testid="html-dom-image-link-form"
+        >
+          <IconLink size={14} className="shrink-0 text-muted-foreground" />
+          <input
+            autoFocus
+            type="url"
+            value={linkValue}
+            disabled={model.imageBusy}
+            placeholder="Paste image URL"
+            className="min-w-0 flex-1 border-0 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+            data-testid="html-dom-image-link-input"
+            onChange={(event) => {
+              setLinkValue(event.currentTarget.value);
+            }}
+          />
+          <button
+            type="submit"
+            disabled={model.imageBusy || linkValue.trim() === ""}
+            aria-label="Replace image from URL"
+            className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-blue-600 text-white transition-colors hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-45"
+            data-testid="html-dom-image-link-submit"
+          >
+            {pendingAction === "link" ? (
+              <IconLoader2 size={14} className="animate-spin" />
+            ) : (
+              <IconCheck size={15} stroke={2.2} />
+            )}
+          </button>
+        </form>
+      )}
+
+      <div className="flex items-center justify-between gap-2">
+        <div className="text-xs font-medium text-muted-foreground">Layout</div>
+        <div className="inline-flex overflow-hidden rounded-full border border-border/70 bg-background">
+          {IMAGE_LAYOUT_OPTIONS.map((option) => {
+            return (
+              <HtmlDomImageGroupButton
+                key={option.value}
+                active={image.layout === option.value}
+                disabled={model.imageBusy}
+                onClick={() => {
+                  applyImageLayout(option.value);
+                }}
+                testId={`html-dom-image-layout-${option.value}`}
+                title={`${option.label} image`}
+              >
+                {option.label}
+              </HtmlDomImageGroupButton>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function HtmlDomCommentPopover({
+  model,
+  pageSignal,
+}: {
+  readonly model: HtmlDomCommentEditorModel;
+  readonly pageSignal: AbortSignal;
 }) {
   const addComment = useSet(addHtmlDomComment$);
   const beginEditingCurrentComment = useSet(beginEditingCurrentHtmlDomComment$);
@@ -915,20 +1191,21 @@ function HtmlDomCommentPopover({
 
   return (
     <div
-      className="absolute z-30 w-[min(380px,calc(100%-24px))] -translate-x-1/2 rounded-[28px] border border-border/60 bg-background p-2.5 shadow-lg"
+      className="absolute z-30 w-[min(400px,calc(100%-24px))] -translate-x-1/2 rounded-[28px] border border-border/60 bg-background p-2.5 shadow-lg"
       style={{
         left: model.commentPopoverAnchor.left,
         top: model.commentPopoverAnchor.top,
       }}
       data-testid="html-dom-comment-popover"
     >
+      <HtmlDomImageTools model={model} pageSignal={pageSignal} />
       <div className="flex items-end gap-2">
         <textarea
           key={model.popoverTextAreaKey}
           ref={setTextAreaRef}
           rows={1}
           value={visibleCommentText}
-          readOnly={isShowingExistingComment}
+          readOnly={isShowingExistingComment || model.imageBusy}
           onClick={() => {
             if (isShowingExistingComment) {
               beginEditingCurrentComment();
@@ -946,7 +1223,11 @@ function HtmlDomCommentPopover({
             setCommentText(event.currentTarget.value);
           }}
           onKeyDown={handleTextAreaKeyDown}
-          placeholder="Describe the change you want"
+          placeholder={
+            model.selectedImage
+              ? "Ask Zero to adjust this image"
+              : "Describe the change you want"
+          }
           className="max-h-32 min-h-9 min-w-0 flex-1 resize-none overflow-y-auto border-0 bg-transparent px-1 py-2 text-sm leading-5 outline-none [field-sizing:content] placeholder:text-muted-foreground"
           data-testid="html-dom-comment-textarea"
         />


### PR DESCRIPTION
## Summary
- show image-specific Source and Layout controls in the hosted-site DOM edit popover
- support image-only local upload through the existing direct-to-R2 upload flow and replace selected img src with the returned CDN URL
- support verified external image URL replacement and inline object-fit layout edits for Cover, Contain, and Fill
- keep the existing comment input in the same popover and reuse Apply/Send serialization for persistence

## Verification
- pnpm exec eslint src/signals/zero-page/html-dom-comment-editor.ts src/views/zero-page/html-dom-comment-editor.tsx src/views/zero-page/__tests__/zero-attachment-chips.test.tsx --max-warnings 0
- pnpm exec vitest run src/views/zero-page/__tests__/zero-attachment-chips.test.tsx --pool=threads --maxWorkers=1
- pnpm exec tsc -p tsconfig.tests.json --noEmit --pretty false