### PR TITLE
refactor: migrate guest-agent CLI runtime inputs

### DIFF
--- a/crates/guest-agent/src/cli/child_env.rs
+++ b/crates/guest-agent/src/cli/child_env.rs
@@ -34,13 +34,6 @@ pub(super) fn apply_to_tokio_command(cmd: &mut tokio::process::Command) {
     apply_to_tokio_command_with_values(cmd, env::home_dir(), env::user_env(), &api_url);
 }
 
-pub(super) fn apply_to_tokio_command_for_config(
-    cmd: &mut tokio::process::Command,
-    config: &env::GuestConfig,
-) {
-    apply_to_tokio_command_with_values(cmd, &config.home_dir, &config.user_env, &config.api_url);
-}
-
 pub(super) fn apply_to_tokio_command_for_runtime(
     cmd: &mut tokio::process::Command,
     runtime: &CliRuntimeConfig<'_>,

--- a/crates/guest-agent/src/cli/child_env.rs
+++ b/crates/guest-agent/src/cli/child_env.rs
@@ -53,7 +53,7 @@ pub(super) fn apply_to_tokio_command_for_runtime(
     );
 }
 
-fn apply_to_tokio_command_with_values(
+pub(super) fn apply_to_tokio_command_with_values(
     cmd: &mut tokio::process::Command,
     home_dir: &str,
     user_env: &HashMap<String, String>,
@@ -106,7 +106,7 @@ fn apply_runner_visible_env(api_url: &str, mut apply: impl FnMut(&'static str, S
     }
 }
 
-fn runner_visible_api_url_from_process_env() -> String {
+pub(super) fn runner_visible_api_url_from_process_env() -> String {
     std::env::var(RUNNER_VISIBLE_API_URL_ENV_KEY)
         .ok()
         .filter(|value| !value.is_empty())

--- a/crates/guest-agent/src/cli/child_env.rs
+++ b/crates/guest-agent/src/cli/child_env.rs
@@ -1,15 +1,17 @@
 //! Curated environment for CLI children.
 
+use std::collections::HashMap;
+
 use crate::env;
+
+use super::CliRuntimeConfig;
 
 const DEFAULT_PATH: &str = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
 const DEFAULT_SHELL: &str = "/bin/bash";
-const RUNNER_VISIBLE_CHILD_ENV_KEYS: &[&str] = &[
-    // The sandbox CLI needs the same API origin as the guest-agent in local
-    // development. Keep this list intentionally narrow: tokens and other VM0
-    // bootstrap controls must stay private to the guest-agent.
-    guest_contracts::env::API_URL_ENV,
-];
+// The sandbox CLI needs the same API origin as the guest-agent in local
+// development. Keep runner-visible env intentionally narrow: tokens and other
+// VM0 bootstrap controls must stay private to the guest-agent.
+const RUNNER_VISIBLE_API_URL_ENV_KEY: &str = guest_contracts::env::API_URL_ENV;
 const OPTIONAL_BASE_ENV_KEYS: &[&str] = &[
     "USER",
     "LOGNAME",
@@ -28,21 +30,50 @@ const OPTIONAL_BASE_ENV_KEYS: &[&str] = &[
 ];
 
 pub(super) fn apply_to_tokio_command(cmd: &mut tokio::process::Command) {
+    let api_url = runner_visible_api_url_from_process_env();
+    apply_to_tokio_command_with_values(cmd, env::home_dir(), env::user_env(), &api_url);
+}
+
+pub(super) fn apply_to_tokio_command_for_config(
+    cmd: &mut tokio::process::Command,
+    config: &env::GuestConfig,
+) {
+    apply_to_tokio_command_with_values(cmd, &config.home_dir, &config.user_env, &config.api_url);
+}
+
+pub(super) fn apply_to_tokio_command_for_runtime(
+    cmd: &mut tokio::process::Command,
+    runtime: &CliRuntimeConfig<'_>,
+) {
+    apply_to_tokio_command_with_values(
+        cmd,
+        runtime.home_dir.as_ref(),
+        runtime.user_env,
+        runtime.api_url.as_ref(),
+    );
+}
+
+fn apply_to_tokio_command_with_values(
+    cmd: &mut tokio::process::Command,
+    home_dir: &str,
+    user_env: &HashMap<String, String>,
+    api_url: &str,
+) {
     cmd.env_clear();
-    for (key, value) in base_child_env() {
+    for (key, value) in base_child_env(home_dir) {
         cmd.env(key, value);
     }
-    for (key, value) in env::user_env() {
+    for (key, value) in user_env {
         cmd.env(key, value);
     }
-    apply_runner_visible_env(|key, value| {
+    apply_runner_visible_env(api_url, |key, value| {
         cmd.env(key, value);
     });
 }
 
-fn base_child_env() -> Vec<(&'static str, String)> {
+fn base_child_env(home_dir: &str) -> Vec<(&'static str, String)> {
     let mut base = Vec::with_capacity(OPTIONAL_BASE_ENV_KEYS.len() + 3);
-    base.push(("HOME", env::home_dir().to_string()));
+    base.push(("HOME", home_dir.to_string()));
     base.push((
         "PATH",
         std::env::var("PATH")
@@ -69,14 +100,17 @@ fn base_child_env() -> Vec<(&'static str, String)> {
     base
 }
 
-fn apply_runner_visible_env(mut apply: impl FnMut(&'static str, String)) {
-    for key in RUNNER_VISIBLE_CHILD_ENV_KEYS {
-        if let Ok(value) = std::env::var(key)
-            && !value.is_empty()
-        {
-            apply(key, value);
-        }
+fn apply_runner_visible_env(api_url: &str, mut apply: impl FnMut(&'static str, String)) {
+    if !api_url.is_empty() {
+        apply(RUNNER_VISIBLE_API_URL_ENV_KEY, api_url.to_string());
     }
+}
+
+fn runner_visible_api_url_from_process_env() -> String {
+    std::env::var(RUNNER_VISIBLE_API_URL_ENV_KEY)
+        .ok()
+        .filter(|value| !value.is_empty())
+        .unwrap_or_default()
 }
 
 #[cfg(test)]
@@ -85,7 +119,10 @@ mod tests {
 
     #[test]
     fn base_child_env_includes_stable_minimum() {
-        let keys: Vec<&str> = base_child_env().into_iter().map(|(key, _)| key).collect();
+        let keys: Vec<&str> = base_child_env("/tmp/home")
+            .into_iter()
+            .map(|(key, _)| key)
+            .collect();
 
         assert!(keys.contains(&"HOME"));
         assert!(keys.contains(&"PATH"));

--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -5,7 +5,7 @@
 //! thread or turn semantics; later runtime code can build those policies on
 //! top of this generic request/notification layer.
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::path::PathBuf;
 use std::process::{ExitStatus, Stdio};
 use std::time::Duration;
@@ -34,9 +34,17 @@ const STDERR_DRAIN_GRACE: Duration = Duration::from_secs(2);
 pub struct CodexAppServerConfig {
     binary: PathBuf,
     codex_home: PathBuf,
+    child_env: Option<CodexAppServerChildEnv>,
     extra_env: Vec<(String, String)>,
     current_dir: Option<PathBuf>,
     opt_out_notification_methods: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct CodexAppServerChildEnv {
+    home_dir: String,
+    user_env: HashMap<String, String>,
+    api_url: String,
 }
 
 impl CodexAppServerConfig {
@@ -44,10 +52,25 @@ impl CodexAppServerConfig {
         Self {
             binary: binary.into(),
             codex_home: codex_home.into(),
+            child_env: None,
             extra_env: Vec::new(),
             current_dir: None,
             opt_out_notification_methods: Vec::new(),
         }
+    }
+
+    pub fn with_child_env(
+        mut self,
+        home_dir: impl Into<String>,
+        user_env: &HashMap<String, String>,
+        api_url: impl Into<String>,
+    ) -> Self {
+        self.child_env = Some(CodexAppServerChildEnv {
+            home_dir: home_dir.into(),
+            user_env: user_env.clone(),
+            api_url: api_url.into(),
+        });
+        self
     }
 
     pub fn with_env(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
@@ -177,7 +200,16 @@ impl CodexAppServerClient {
         std::fs::create_dir_all(&config.codex_home)?;
 
         let mut cmd = tokio::process::Command::new(&config.binary);
-        child_env::apply_to_tokio_command(&mut cmd);
+        if let Some(child_env_config) = &config.child_env {
+            child_env::apply_to_tokio_command_with_values(
+                &mut cmd,
+                &child_env_config.home_dir,
+                &child_env_config.user_env,
+                &child_env_config.api_url,
+            );
+        } else {
+            child_env::apply_to_tokio_command(&mut cmd);
+        }
         cmd.args(["app-server", "--listen", "stdio://"])
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())

--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -5,12 +5,12 @@
 //! guest env flag selects this backend.
 
 use std::future::Future;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use serde_json::{Map, Value, json};
 use tokio::sync::oneshot;
 
-use crate::env;
+use crate::env::Framework;
 use crate::error::AgentError;
 use crate::events;
 use crate::http::HttpClient;
@@ -22,8 +22,8 @@ use super::codex_app_server::{
 };
 use super::event_delivery::{AckedEventPrefix, PreparedEvent};
 use super::{
-    CliEventIngestor, CliExecutionResult, HeartbeatMonitor, HeartbeatStatus, LOG_TAG,
-    ParsedEventAction, codex_app_server_events::IGNORED_NOTIFICATION_METHODS, command,
+    CliEventIngestor, CliExecutionResult, CliRuntimeConfig, HeartbeatMonitor, HeartbeatStatus,
+    LOG_TAG, ParsedEventAction, codex_app_server_events::IGNORED_NOTIFICATION_METHODS, command,
     notification_to_codex_event,
 };
 use crate::active_input::{ActiveInputFrame, ActiveInputWriter};
@@ -64,13 +64,14 @@ enum CodexRunEvent {
     ActiveInput(Option<ActiveInputFrame>),
 }
 
-pub(super) async fn execute_codex_app_server(
+pub(super) async fn execute_codex_app_server_for_runtime(
     masker: &SecretMasker,
     mut heartbeat_monitor: HeartbeatMonitor,
     http: HttpClient,
     active_input: ActiveInputWriter,
+    runtime: &CliRuntimeConfig<'_>,
 ) -> Result<CliExecutionResult, AgentError> {
-    masker.add_sensitive_value(env::resume_session_id());
+    masker.add_sensitive_value(runtime.resume_session_id.as_ref());
     log_info!(LOG_TAG, "Starting codex app-server execution...");
 
     let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel::<PreparedEvent>();
@@ -102,6 +103,7 @@ pub(super) async fn execute_codex_app_server(
         should_send_events,
         &event_tx,
         active_input,
+        runtime,
     )
     .await;
 
@@ -133,15 +135,16 @@ async fn run_codex_app_server(
     should_send_events: bool,
     event_tx: &tokio::sync::mpsc::UnboundedSender<PreparedEvent>,
     mut active_input: ActiveInputWriter,
+    runtime: &CliRuntimeConfig<'_>,
 ) -> Result<CliExecutionResult, AgentError> {
-    let log_file = guest_contracts::runtime_paths::create_private(paths::agent_log_file())?;
+    let log_file = guest_contracts::runtime_paths::create_private(runtime.agent_log_file.as_ref())?;
     let mut log_file = tokio::fs::File::from_std(log_file);
     let mut ingestor = CliEventIngestor::new();
-    let resume_thread_id = resume_thread_id_from_env()?;
+    let resume_thread_id = resume_thread_id_from_runtime(runtime)?;
     if let Some(resume_thread_id) = &resume_thread_id {
         masker.add_sensitive_value(resume_thread_id);
     }
-    let mut client = CodexAppServerClient::spawn(codex_app_server_config())
+    let mut client = CodexAppServerClient::spawn(codex_app_server_config(runtime))
         .map_err(|error| app_server_error(masker, error))?;
     let mut heartbeat_done = false;
 
@@ -154,7 +157,7 @@ async fn run_codex_app_server(
         )
         .await?;
         let thread_response = race_with_heartbeat(
-            start_or_resume_thread(&mut client, resume_thread_id.as_deref()),
+            start_or_resume_thread(&mut client, resume_thread_id.as_deref(), runtime),
             heartbeat_monitor,
             &mut heartbeat_done,
             masker,
@@ -201,7 +204,10 @@ async fn run_codex_app_server(
         }
 
         let turn_response = race_with_heartbeat(
-            client.request_value("turn/start", turn_start_params(&thread_identity.wire_id)),
+            client.request_value(
+                "turn/start",
+                turn_start_params(&thread_identity.wire_id, runtime),
+            ),
             heartbeat_monitor,
             &mut heartbeat_done,
             masker,
@@ -339,23 +345,23 @@ async fn run_codex_app_server(
     }
 }
 
-fn codex_app_server_config() -> CodexAppServerConfig {
-    let binary = if env::use_mock_codex() {
+fn codex_app_server_config(runtime: &CliRuntimeConfig<'_>) -> CodexAppServerConfig {
+    let binary = if runtime.use_mock_codex {
         log_info!(LOG_TAG, "Using mock-codex app-server for testing");
-        PathBuf::from(env::mock_codex_path())
+        PathBuf::from(runtime.mock_codex_path.as_ref())
     } else {
         PathBuf::from("codex")
     };
-    let codex_home = crate::codex_auth::codex_home_path(Path::new(env::home_dir()));
+    let codex_home = PathBuf::from(runtime.codex_home());
     let mut config = CodexAppServerConfig::new(binary, codex_home)
         .with_current_dir(paths::CANONICAL_WORKING_DIR)
         .with_opt_out_notification_methods(IGNORED_NOTIFICATION_METHODS.iter().copied());
-    if env::use_mock_codex()
+    if runtime.use_mock_codex
         && let Ok(scenario) = std::env::var("MOCK_CODEX_APP_SERVER_SCENARIO")
     {
         config = config.with_env("MOCK_CODEX_APP_SERVER_SCENARIO", scenario);
     }
-    if env::is_codex_oauth_mode() {
+    if runtime.codex_oauth_mode {
         config = config.with_env(
             "CODEX_REFRESH_TOKEN_URL_OVERRIDE",
             crate::codex_auth::REFRESH_TOKEN_NOOP_URL,
@@ -367,10 +373,11 @@ fn codex_app_server_config() -> CodexAppServerConfig {
 async fn start_or_resume_thread(
     client: &mut CodexAppServerClient,
     resume_thread_id: Option<&str>,
+    runtime: &CliRuntimeConfig<'_>,
 ) -> Result<Value, CodexAppServerError> {
     match resume_thread_id {
         Some(resume_thread_id) => {
-            let mut params = thread_param_fields();
+            let mut params = thread_param_fields(runtime);
             params.insert(
                 "threadId".to_string(),
                 Value::String(resume_thread_id.to_string()),
@@ -379,15 +386,19 @@ async fn start_or_resume_thread(
                 .request_value("thread/resume", Value::Object(params))
                 .await
         }
-        None => client.request_value("thread/start", thread_params()).await,
+        None => {
+            client
+                .request_value("thread/start", thread_params(runtime))
+                .await
+        }
     }
 }
 
-fn thread_params() -> Value {
-    Value::Object(thread_param_fields())
+fn thread_params(runtime: &CliRuntimeConfig<'_>) -> Value {
+    Value::Object(thread_param_fields(runtime))
 }
 
-fn thread_param_fields() -> Map<String, Value> {
+fn thread_param_fields(runtime: &CliRuntimeConfig<'_>) -> Map<String, Value> {
     let mut params = Map::new();
     params.insert(
         "cwd".to_string(),
@@ -411,29 +422,29 @@ fn thread_param_fields() -> Map<String, Value> {
             "features.memories": true,
         }),
     );
-    if !env::openai_model().is_empty() {
+    if !runtime.openai_model.is_empty() {
         params.insert(
             "model".to_string(),
-            Value::String(env::openai_model().to_string()),
+            Value::String(runtime.openai_model.to_string()),
         );
     }
-    if !env::append_system_prompt().is_empty() {
+    if !runtime.append_system_prompt.is_empty() {
         params.insert(
             "developerInstructions".to_string(),
-            Value::String(env::append_system_prompt().to_string()),
+            Value::String(runtime.append_system_prompt.to_string()),
         );
     }
     params
 }
 
-fn turn_start_params(thread_id: &str) -> Value {
+fn turn_start_params(thread_id: &str, runtime: &CliRuntimeConfig<'_>) -> Value {
     let mut params = Map::new();
     params.insert("threadId".to_string(), Value::String(thread_id.to_string()));
     params.insert(
         "input".to_string(),
         Value::Array(vec![json!({
             "type": "text",
-            "text": env::prompt(),
+            "text": runtime.prompt.as_ref(),
             "text_elements": [],
         })]),
     );
@@ -453,13 +464,15 @@ fn turn_start_params(thread_id: &str) -> Value {
         "sandboxPolicy".to_string(),
         json!({ "type": "dangerFullAccess" }),
     );
-    if !env::openai_model().is_empty() {
+    if !runtime.openai_model.is_empty() {
         params.insert(
             "model".to_string(),
-            Value::String(env::openai_model().to_string()),
+            Value::String(runtime.openai_model.to_string()),
         );
     }
-    if let Some(effort) = command::default_codex_reasoning_effort_for_model(env::openai_model()) {
+    if let Some(effort) =
+        command::default_codex_reasoning_effort_for_model(runtime.openai_model.as_ref())
+    {
         params.insert("effort".to_string(), Value::String(effort.to_string()));
     }
     Value::Object(params)
@@ -793,7 +806,7 @@ async fn ingest_event(event: Value, sink: &mut EventIngestSink<'_>) -> Result<()
             raw_line,
             &event,
             sink.masker,
-            super::framework::CliFrameworkBehavior::new(env::Framework::Codex),
+            super::framework::CliFrameworkBehavior::new(Framework::Codex),
         )
         .await?
     {
@@ -902,8 +915,10 @@ fn thread_identity_from_response(response: &Value) -> Result<ThreadIdentity, Age
     })
 }
 
-fn resume_thread_id_from_env() -> Result<Option<String>, AgentError> {
-    let resume_id = env::resume_session_id();
+fn resume_thread_id_from_runtime(
+    runtime: &CliRuntimeConfig<'_>,
+) -> Result<Option<String>, AgentError> {
+    let resume_id = runtime.resume_session_id.as_ref();
     if resume_id.is_empty() {
         return Ok(None);
     }

--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -354,6 +354,11 @@ fn codex_app_server_config(runtime: &CliRuntimeConfig<'_>) -> CodexAppServerConf
     };
     let codex_home = PathBuf::from(runtime.codex_home());
     let mut config = CodexAppServerConfig::new(binary, codex_home)
+        .with_child_env(
+            runtime.home_dir.as_ref(),
+            runtime.user_env,
+            runtime.api_url.as_ref(),
+        )
         .with_current_dir(paths::CANONICAL_WORKING_DIR)
         .with_opt_out_notification_methods(IGNORED_NOTIFICATION_METHODS.iter().copied());
     if runtime.use_mock_codex

--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -139,7 +139,7 @@ async fn run_codex_app_server(
 ) -> Result<CliExecutionResult, AgentError> {
     let log_file = guest_contracts::runtime_paths::create_private(runtime.agent_log_file.as_ref())?;
     let mut log_file = tokio::fs::File::from_std(log_file);
-    let mut ingestor = CliEventIngestor::new();
+    let mut ingestor = CliEventIngestor::new(runtime);
     let resume_thread_id = resume_thread_id_from_runtime(runtime)?;
     if let Some(resume_thread_id) = &resume_thread_id {
         masker.add_sensitive_value(resume_thread_id);

--- a/crates/guest-agent/src/cli/codex_setup.rs
+++ b/crates/guest-agent/src/cli/codex_setup.rs
@@ -31,10 +31,43 @@ const LOG_TAG: &str = "sandbox:guest-agent";
 /// - **No auth**: remove any stale auth.json left by a previous reused
 ///   sandbox run so Codex cannot inherit credentials from another run.
 pub async fn setup_codex(_masker: &SecretMasker) -> Result<(), AgentError> {
+    setup_codex_with_values(
+        env::is_codex_oauth_mode(),
+        env::home_dir(),
+        env::openai_api_key(),
+    )
+}
+
+/// Reconcile Codex auth using the config captured during guest-agent bootstrap.
+///
+/// Production should use this instead of [`setup_codex`] so OAuth/API-key mode
+/// and child `HOME` come from the same immutable [`env::GuestConfig`] as CLI
+/// execution. The legacy wrapper remains for tests and transitional callers
+/// that still use process-env facades.
+pub async fn setup_codex_for_config(
+    _masker: &SecretMasker,
+    config: &env::GuestConfig,
+) -> Result<(), AgentError> {
+    let codex_oauth_mode = config
+        .user_env
+        .get("CHATGPT_ACCOUNT_ID")
+        .is_some_and(|value| !value.is_empty());
+    let api_key = config
+        .user_env
+        .get("OPENAI_API_KEY")
+        .map(String::as_str)
+        .unwrap_or("");
+    setup_codex_with_values(codex_oauth_mode, &config.home_dir, api_key)
+}
+
+fn setup_codex_with_values(
+    codex_oauth_mode: bool,
+    home_dir: &str,
+    api_key: &str,
+) -> Result<(), AgentError> {
     let setup_start = Instant::now();
-    let home = std::path::PathBuf::from(env::home_dir());
-    let api_key = env::openai_api_key();
-    let (desired, mode_label) = if env::is_codex_oauth_mode() {
+    let home = std::path::PathBuf::from(home_dir);
+    let (desired, mode_label) = if codex_oauth_mode {
         (
             DesiredCodexAuth::ChatGpt {
                 now: chrono::Utc::now(),

--- a/crates/guest-agent/src/cli/codex_setup.rs
+++ b/crates/guest-agent/src/cli/codex_setup.rs
@@ -40,10 +40,10 @@ pub async fn setup_codex(_masker: &SecretMasker) -> Result<(), AgentError> {
 
 /// Reconcile Codex auth using the config captured during guest-agent bootstrap.
 ///
-/// Production should use this instead of [`setup_codex`] so OAuth/API-key mode
-/// and child `HOME` come from the same immutable [`env::GuestConfig`] as CLI
-/// execution. The legacy wrapper remains for tests and transitional callers
-/// that still use process-env facades.
+/// Production should use this instead of [`setup_codex`] so OAuth/API-key mode,
+/// child `HOME`, and loaded user env come from the same immutable
+/// [`env::GuestConfig`] as CLI execution. The legacy wrapper remains for tests
+/// and transitional callers that still rely on process-env facades.
 pub async fn setup_codex_for_config(
     _masker: &SecretMasker,
     config: &env::GuestConfig,

--- a/crates/guest-agent/src/cli/command.rs
+++ b/crates/guest-agent/src/cli/command.rs
@@ -121,10 +121,10 @@ fn build_claude_args(config: ClaudeArgsConfig<'_>) -> Vec<String> {
 }
 
 fn build_claude_command(use_mock: bool, replay_user_messages: bool) -> Vec<String> {
-    let mock_claude_path = env::mock_claude_path();
+    let mock_claude_path = use_mock.then(env::mock_claude_path);
     build_claude_command_with_config(
         use_mock,
-        &mock_claude_path,
+        mock_claude_path.as_deref().unwrap_or(""),
         ClaudeArgsConfig {
             resume_id: env::resume_session_id(),
             append_system_prompt: env::append_system_prompt(),
@@ -253,10 +253,10 @@ fn build_codex_args(
 }
 
 fn build_codex_command(use_mock: bool) -> Vec<String> {
-    let mock_codex_path = env::mock_codex_path();
+    let mock_codex_path = use_mock.then(env::mock_codex_path);
     build_codex_command_with_config(
         use_mock,
-        &mock_codex_path,
+        mock_codex_path.as_deref().unwrap_or(""),
         env::openai_model(),
         env::resume_session_id(),
         env::append_system_prompt(),

--- a/crates/guest-agent/src/cli/command.rs
+++ b/crates/guest-agent/src/cli/command.rs
@@ -8,7 +8,7 @@ use crate::error::AgentError;
 use crate::{env, paths};
 use guest_common::log_info;
 
-use super::LOG_TAG;
+use super::{CliRuntimeConfig, LOG_TAG};
 
 /// Build the CLI command + args based on `CLI_AGENT_TYPE`.
 pub fn build_cli_command() -> Result<Vec<String>, AgentError> {
@@ -25,6 +25,34 @@ pub(super) fn build_cli_command_for_framework(
             replay_user_messages,
         )),
         env::Framework::Codex => Ok(build_codex_command(env::use_mock_codex())),
+    }
+}
+
+pub(super) fn build_cli_command_for_runtime(
+    runtime: &CliRuntimeConfig<'_>,
+    replay_user_messages: bool,
+) -> Result<Vec<String>, AgentError> {
+    match runtime.framework {
+        env::Framework::ClaudeCode => Ok(build_claude_command_with_config(
+            runtime.use_mock_claude,
+            runtime.mock_claude_path.as_ref(),
+            ClaudeArgsConfig {
+                resume_id: runtime.resume_session_id.as_ref(),
+                append_system_prompt: runtime.append_system_prompt.as_ref(),
+                disallowed_tools: runtime.disallowed_tools.as_ref(),
+                tools: runtime.tools.as_ref(),
+                settings: runtime.settings.as_ref(),
+                replay_user_messages,
+            },
+        )),
+        env::Framework::Codex => Ok(build_codex_command_with_config(
+            runtime.use_mock_codex,
+            runtime.mock_codex_path.as_ref(),
+            runtime.openai_model.as_ref(),
+            runtime.resume_session_id.as_ref(),
+            runtime.append_system_prompt.as_ref(),
+            runtime.prompt.as_ref(),
+        )),
     }
 }
 
@@ -93,20 +121,32 @@ fn build_claude_args(config: ClaudeArgsConfig<'_>) -> Vec<String> {
 }
 
 fn build_claude_command(use_mock: bool, replay_user_messages: bool) -> Vec<String> {
-    let args = build_claude_args(ClaudeArgsConfig {
-        resume_id: env::resume_session_id(),
-        append_system_prompt: env::append_system_prompt(),
-        disallowed_tools: env::disallowed_tools(),
-        tools: env::tools(),
-        settings: env::settings(),
-        replay_user_messages,
-    });
+    let mock_claude_path = env::mock_claude_path();
+    build_claude_command_with_config(
+        use_mock,
+        &mock_claude_path,
+        ClaudeArgsConfig {
+            resume_id: env::resume_session_id(),
+            append_system_prompt: env::append_system_prompt(),
+            disallowed_tools: env::disallowed_tools(),
+            tools: env::tools(),
+            settings: env::settings(),
+            replay_user_messages,
+        },
+    )
+}
 
+fn build_claude_command_with_config(
+    use_mock: bool,
+    mock_claude_path: &str,
+    config: ClaudeArgsConfig<'_>,
+) -> Vec<String> {
+    let args = build_claude_args(config);
     let bin = if use_mock {
         log_info!(LOG_TAG, "Using mock-claude for testing");
         // Tests can override the path so they target a cargo-built
         // artifact rather than the sandbox's baked-in `/usr/local/bin`.
-        env::mock_claude_path()
+        mock_claude_path.to_string()
     } else {
         "claude".to_string()
     };
@@ -213,19 +253,38 @@ fn build_codex_args(
 }
 
 fn build_codex_command(use_mock: bool) -> Vec<String> {
+    let mock_codex_path = env::mock_codex_path();
+    build_codex_command_with_config(
+        use_mock,
+        &mock_codex_path,
+        env::openai_model(),
+        env::resume_session_id(),
+        env::append_system_prompt(),
+        env::prompt(),
+    )
+}
+
+fn build_codex_command_with_config(
+    use_mock: bool,
+    mock_codex_path: &str,
+    model: &str,
+    resume_id: &str,
+    append_system_prompt: &str,
+    prompt: &str,
+) -> Vec<String> {
     let bin = if use_mock {
         log_info!(LOG_TAG, "Using mock-codex for testing");
-        env::mock_codex_path()
+        mock_codex_path.to_string()
     } else {
         "codex".to_string()
     };
 
     let mut cmd = vec![bin];
     cmd.extend(build_codex_args(
-        env::openai_model(),
-        env::resume_session_id(),
-        env::append_system_prompt(),
-        env::prompt(),
+        model,
+        resume_id,
+        append_system_prompt,
+        prompt,
     ));
     cmd
 }

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -353,7 +353,7 @@ impl<'a> CliRuntimeConfig<'a> {
             },
             home_dir: Cow::Borrowed(env::home_dir()),
             api_url: if use_codex_app_server_backend {
-                Cow::Borrowed("")
+                Cow::Owned(child_env::runner_visible_api_url_from_process_env())
             } else {
                 Cow::Borrowed(env::api_url())
             },

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -352,11 +352,7 @@ impl<'a> CliRuntimeConfig<'a> {
                 Cow::Borrowed("")
             },
             home_dir: Cow::Borrowed(env::home_dir()),
-            api_url: if use_codex_app_server_backend {
-                Cow::Owned(child_env::runner_visible_api_url_from_process_env())
-            } else {
-                Cow::Borrowed(env::api_url())
-            },
+            api_url: Cow::Owned(child_env::runner_visible_api_url_from_process_env()),
             openai_model: if is_codex {
                 Cow::Borrowed(env::openai_model())
             } else {

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -29,7 +29,7 @@ mod process_group;
 mod termination;
 
 pub use codex_app_server_events::{CodexAppServerEventError, notification_to_codex_event};
-pub use codex_setup::setup_codex;
+pub use codex_setup::{setup_codex, setup_codex_for_config};
 pub use command::build_cli_command;
 pub use framework::{ClaudeResultStatus, ClaudeResultSummary};
 
@@ -50,6 +50,7 @@ use guest_common::telemetry::record_sandbox_op;
 use guest_common::{log_info, log_warn};
 use guest_contracts::diagnostics::{CliTerminationDiagnostic, FailureDetailSource, FailureReason};
 use process_group::ChildProcessGroup;
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::path::Path;
 use std::pin::Pin;
@@ -257,6 +258,89 @@ pub enum HeartbeatStatus {
 /// callers that do not own a heartbeat task.
 pub type HeartbeatMonitor = Option<oneshot::Receiver<HeartbeatStatus>>;
 
+pub(super) struct CliRuntimeConfig<'a> {
+    framework: env::Framework,
+    run_id: Cow<'a, str>,
+    prompt: Cow<'a, str>,
+    resume_session_id: Cow<'a, str>,
+    append_system_prompt: Cow<'a, str>,
+    disallowed_tools: Cow<'a, str>,
+    tools: Cow<'a, str>,
+    settings: Cow<'a, str>,
+    use_mock_claude: bool,
+    mock_claude_path: Cow<'a, str>,
+    use_mock_codex: bool,
+    use_codex_app_server_backend: bool,
+    mock_codex_path: Cow<'a, str>,
+    home_dir: Cow<'a, str>,
+    api_url: Cow<'a, str>,
+    openai_model: Cow<'a, str>,
+    codex_oauth_mode: bool,
+    stuck_tool_timeout_secs: u64,
+    agent_log_file: Cow<'a, str>,
+    user_env: &'a HashMap<String, String>,
+}
+
+impl<'a> CliRuntimeConfig<'a> {
+    fn from_config(config: &'a env::GuestConfig, paths: &'a paths::GuestPaths) -> Self {
+        Self {
+            framework: config.framework,
+            run_id: Cow::Borrowed(&config.run_id),
+            prompt: Cow::Borrowed(&config.prompt),
+            resume_session_id: Cow::Borrowed(&config.resume_session_id),
+            append_system_prompt: Cow::Borrowed(&config.append_system_prompt),
+            disallowed_tools: Cow::Borrowed(&config.disallowed_tools),
+            tools: Cow::Borrowed(&config.tools),
+            settings: Cow::Borrowed(&config.settings),
+            use_mock_claude: config.use_mock_claude,
+            mock_claude_path: Cow::Borrowed(&config.mock_claude_path),
+            use_mock_codex: config.use_mock_codex,
+            use_codex_app_server_backend: config.use_codex_app_server_backend,
+            mock_codex_path: Cow::Borrowed(&config.mock_codex_path),
+            home_dir: Cow::Borrowed(&config.home_dir),
+            api_url: Cow::Borrowed(&config.api_url),
+            openai_model: Cow::Borrowed(user_env_value(&config.user_env, "OPENAI_MODEL")),
+            codex_oauth_mode: !user_env_value(&config.user_env, "CHATGPT_ACCOUNT_ID").is_empty(),
+            stuck_tool_timeout_secs: config.stuck_tool_timeout_secs,
+            agent_log_file: Cow::Borrowed(paths.agent_log_file()),
+            user_env: &config.user_env,
+        }
+    }
+
+    fn from_legacy_env(framework: env::Framework) -> Self {
+        Self {
+            framework,
+            run_id: Cow::Borrowed(env::run_id()),
+            prompt: Cow::Borrowed(env::prompt()),
+            resume_session_id: Cow::Borrowed(env::resume_session_id()),
+            append_system_prompt: Cow::Borrowed(env::append_system_prompt()),
+            disallowed_tools: Cow::Borrowed(env::disallowed_tools()),
+            tools: Cow::Borrowed(env::tools()),
+            settings: Cow::Borrowed(env::settings()),
+            use_mock_claude: env::use_mock_claude(),
+            mock_claude_path: Cow::Owned(env::mock_claude_path()),
+            use_mock_codex: env::use_mock_codex(),
+            use_codex_app_server_backend: env::use_codex_app_server_backend(),
+            mock_codex_path: Cow::Owned(env::mock_codex_path()),
+            home_dir: Cow::Borrowed(env::home_dir()),
+            api_url: Cow::Borrowed(env::api_url()),
+            openai_model: Cow::Borrowed(env::openai_model()),
+            codex_oauth_mode: env::is_codex_oauth_mode(),
+            stuck_tool_timeout_secs: env::stuck_tool_timeout_secs(),
+            agent_log_file: Cow::Borrowed(paths::agent_log_file()),
+            user_env: env::user_env(),
+        }
+    }
+
+    fn codex_home(&self) -> String {
+        format!("{}/.codex", self.home_dir)
+    }
+}
+
+fn user_env_value<'a>(user_env: &'a HashMap<String, String>, key: &str) -> &'a str {
+    user_env.get(key).map(String::as_str).unwrap_or("")
+}
+
 enum ParsedEventAction {
     Forward,
     Skip,
@@ -381,12 +465,13 @@ pub async fn execute_cli(
     let framework = env::Framework::from_env();
     let active_input =
         ActiveInputRuntime::new_with_initial_prompt(env::run_id(), false, env::prompt());
+    let runtime = CliRuntimeConfig::from_legacy_env(framework);
     execute_cli_inner(
         masker,
         heartbeat_monitor,
         http,
-        framework,
         active_input.into_writer(),
+        &runtime,
     )
     .await
 }
@@ -420,32 +505,46 @@ pub async fn execute_cli_with_active_input(
     active_input: ActiveInputWriter,
 ) -> Result<CliExecutionResult, AgentError> {
     let framework = env::Framework::from_env();
-    execute_cli_inner(masker, heartbeat_monitor, http, framework, active_input).await
+    let runtime = CliRuntimeConfig::from_legacy_env(framework);
+    execute_cli_inner(masker, heartbeat_monitor, http, active_input, &runtime).await
+}
+
+pub async fn execute_cli_with_active_input_for_config(
+    masker: &SecretMasker,
+    heartbeat_monitor: HeartbeatMonitor,
+    http: HttpClient,
+    active_input: ActiveInputWriter,
+    config: &env::GuestConfig,
+    paths: &paths::GuestPaths,
+) -> Result<CliExecutionResult, AgentError> {
+    let runtime = CliRuntimeConfig::from_config(config, paths);
+    execute_cli_inner(masker, heartbeat_monitor, http, active_input, &runtime).await
 }
 
 async fn execute_cli_inner(
     masker: &SecretMasker,
     mut heartbeat_monitor: HeartbeatMonitor,
     http: HttpClient,
-    framework: env::Framework,
     active_input: ActiveInputWriter,
+    runtime: &CliRuntimeConfig<'_>,
 ) -> Result<CliExecutionResult, AgentError> {
-    if matches!(framework, env::Framework::Codex) && env::use_codex_app_server_backend() {
-        return codex_app_server_backend::execute_codex_app_server(
+    if matches!(runtime.framework, env::Framework::Codex) && runtime.use_codex_app_server_backend {
+        return codex_app_server_backend::execute_codex_app_server_for_runtime(
             masker,
             heartbeat_monitor,
             http,
             active_input,
+            runtime,
         )
         .await;
     }
 
-    let behavior = CliFrameworkBehavior::new(framework);
+    let behavior = CliFrameworkBehavior::new(runtime.framework);
     let replay_user_messages = active_input.is_enabled();
-    masker.add_sensitive_value(env::resume_session_id());
+    masker.add_sensitive_value(runtime.resume_session_id.as_ref());
     log_info!(LOG_TAG, "Starting {} execution...", behavior.agent_type());
 
-    let cmd = command::build_cli_command_for_framework(framework, replay_user_messages)?;
+    let cmd = command::build_cli_command_for_runtime(runtime, replay_user_messages)?;
     let (bin, args) = cmd
         .split_first()
         .ok_or_else(|| AgentError::Execution("empty command".into()))?;
@@ -463,12 +562,12 @@ async fn execute_cli_inner(
         // If a future setup step fails after spawn, dropping `Child` must not
         // leave a CLI process running in the VM.
         .kill_on_drop(true);
-    child_env::apply_to_tokio_command(&mut cmd);
+    child_env::apply_to_tokio_command_for_runtime(&mut cmd, runtime);
     // Set the child cwd explicitly at spawn time so the CLI observes the
     // current canonical workspace mount instead of relying on inherited cwd.
     set_cli_current_dir(&mut cmd, paths::CANONICAL_WORKING_DIR)?;
 
-    match framework {
+    match runtime.framework {
         env::Framework::ClaudeCode => {
             // Suppress Claude CLI features that are unnecessary or harmful in a
             // sandbox: startup network calls (statsig, Datadog, Segment, GCS
@@ -487,18 +586,15 @@ async fn execute_cli_inner(
         env::Framework::Codex => {
             // Auth reconciliation and `codex exec` both honor CODEX_HOME;
             // pin it to $HOME/.codex so setup_codex state is visible to exec.
-            cmd.env(
-                "CODEX_HOME",
-                crate::codex_auth::codex_home_path(std::path::Path::new(env::home_dir())),
-            );
+            cmd.env("CODEX_HOME", runtime.codex_home());
             // Test-only mock fixture selector; keep it explicit instead of
             // reopening inherited env for Codex children.
-            if env::use_mock_codex()
+            if runtime.use_mock_codex
                 && let Ok(fixture) = std::env::var("MOCK_CODEX_FIXTURE")
             {
                 cmd.env("MOCK_CODEX_FIXTURE", fixture);
             }
-            if env::is_codex_oauth_mode() {
+            if runtime.codex_oauth_mode {
                 cmd.env(
                     "CODEX_REFRESH_TOKEN_URL_OVERRIDE",
                     crate::codex_auth::REFRESH_TOKEN_NOOP_URL,
@@ -509,7 +605,7 @@ async fn execute_cli_inner(
 
     // Open the run log before spawning the CLI. If the run-id-scoped path is
     // invalid or unavailable, fail without starting a child process.
-    let log_file = guest_contracts::runtime_paths::create_private(paths::agent_log_file())?;
+    let log_file = guest_contracts::runtime_paths::create_private(runtime.agent_log_file.as_ref())?;
     let mut log_file = tokio::fs::File::from_std(log_file);
 
     let mut child = cmd.spawn()?;
@@ -539,10 +635,10 @@ async fn execute_cli_inner(
 
     let active_input_controller = active_input.controller();
     let mut claude_stdin_write_handle = claude_stdin.map(|stdin| {
-        let run_id = env::run_id();
-        let prompt = env::prompt();
+        let run_id = runtime.run_id.to_string();
+        let prompt = runtime.prompt.to_string();
         tokio::spawn(async move {
-            write_claude_stream_json_to_stdin(stdin, run_id, prompt, active_input).await
+            write_claude_stream_json_to_stdin(stdin, &run_id, &prompt, active_input).await
         })
     });
 
@@ -875,7 +971,7 @@ async fn execute_cli_inner(
                 break Ok(());
             }
             _ = tick_optional_interval(&mut stuck_tool_check), if cli_status.is_none() => {
-                let timeout_secs = env::stuck_tool_timeout_secs();
+                let timeout_secs = runtime.stuck_tool_timeout_secs;
                 // Find the oldest network tool that has exceeded the timeout.
                 let stuck = stuck_tool_tracker
                     .values()

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -278,6 +278,8 @@ pub(super) struct CliRuntimeConfig<'a> {
     codex_oauth_mode: bool,
     stuck_tool_timeout_secs: u64,
     agent_log_file: Cow<'a, str>,
+    session_id_file: Cow<'a, str>,
+    session_history_path_file: Cow<'a, str>,
     user_env: &'a HashMap<String, String>,
 }
 
@@ -303,6 +305,8 @@ impl<'a> CliRuntimeConfig<'a> {
             codex_oauth_mode: !user_env_value(&config.user_env, "CHATGPT_ACCOUNT_ID").is_empty(),
             stuck_tool_timeout_secs: config.stuck_tool_timeout_secs,
             agent_log_file: Cow::Borrowed(paths.agent_log_file()),
+            session_id_file: Cow::Borrowed(paths.session_id_file()),
+            session_history_path_file: Cow::Borrowed(paths.session_history_path_file()),
             user_env: &config.user_env,
         }
     }
@@ -315,11 +319,7 @@ impl<'a> CliRuntimeConfig<'a> {
         let use_codex_app_server_backend = is_codex && env::use_codex_app_server_backend();
         Self {
             framework,
-            run_id: if is_claude {
-                Cow::Borrowed(env::run_id())
-            } else {
-                Cow::Borrowed("")
-            },
+            run_id: Cow::Borrowed(env::run_id()),
             prompt: Cow::Borrowed(env::prompt()),
             resume_session_id: Cow::Borrowed(env::resume_session_id()),
             append_system_prompt: Cow::Borrowed(env::append_system_prompt()),
@@ -365,6 +365,8 @@ impl<'a> CliRuntimeConfig<'a> {
                 constants::STUCK_TOOL_TIMEOUT_SECS
             },
             agent_log_file: Cow::Borrowed(paths::agent_log_file()),
+            session_id_file: Cow::Borrowed(paths::session_id_file()),
+            session_history_path_file: Cow::Borrowed(paths::session_history_path_file()),
             user_env: env::user_env(),
         }
     }
@@ -385,17 +387,24 @@ enum ParsedEventAction {
 
 struct CliEventIngestor {
     seq: u32,
+    run_id: String,
     last_read_event_at: Option<Instant>,
     session_metadata_capture: events::SessionMetadataCapture,
     failure_diagnostic: Option<CliFailureDiagnostic>,
 }
 
 impl CliEventIngestor {
-    fn new() -> Self {
+    fn new(runtime: &CliRuntimeConfig<'_>) -> Self {
         Self {
             seq: 0,
+            run_id: runtime.run_id.to_string(),
             last_read_event_at: None,
-            session_metadata_capture: events::SessionMetadataCapture::new(),
+            session_metadata_capture: events::SessionMetadataCapture::from_values(
+                runtime.framework,
+                runtime.home_dir.as_ref(),
+                runtime.session_id_file.as_ref(),
+                runtime.session_history_path_file.as_ref(),
+            ),
             failure_diagnostic: None,
         }
     }
@@ -416,7 +425,8 @@ impl CliEventIngestor {
         Self::write_raw_line(log_file, raw_line).await;
 
         if event.get("type").and_then(serde_json::Value::as_str) == Some("stream_event") {
-            events::register_event_session_identifier(event, masker);
+            self.session_metadata_capture
+                .register_event_session_identifier(event, masker);
             return Ok(ParsedEventAction::Skip);
         }
         self.last_read_event_at = Some(Instant::now());
@@ -466,7 +476,8 @@ impl CliEventIngestor {
         event_tx: &tokio::sync::mpsc::UnboundedSender<PreparedEvent>,
     ) {
         if should_send_events {
-            let payload = events::prepare_event_payload(event, self.seq, masker);
+            let payload =
+                events::prepare_event_payload_for_run_id(event, self.seq, masker, &self.run_id);
             if event_tx
                 .send(PreparedEvent::Webhook {
                     sequence: self.seq,
@@ -770,7 +781,7 @@ async fn execute_cli_inner(
     let mut cli_exit_at: Option<Instant> = None;
     let mut claude_result = None;
     let mut post_result_cleanup_result = None;
-    let mut event_ingestor = CliEventIngestor::new();
+    let mut event_ingestor = CliEventIngestor::new(runtime);
     let event_result: Result<(), AgentError> = loop {
         tokio::select! {
             stdin_write_result = async {

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -372,8 +372,14 @@ impl<'a> CliRuntimeConfig<'a> {
     }
 
     fn codex_home(&self) -> String {
-        format!("{}/.codex", self.home_dir)
+        codex_home_for_home_dir(self.home_dir.as_ref())
     }
+}
+
+fn codex_home_for_home_dir(home_dir: &str) -> String {
+    crate::codex_auth::codex_home_path(Path::new(home_dir))
+        .to_string_lossy()
+        .into_owned()
 }
 
 fn user_env_value<'a>(user_env: &'a HashMap<String, String>, key: &str) -> &'a str {
@@ -1390,8 +1396,9 @@ fn with_carried_failure_reason(
 mod tests {
     use super::termination::CliTerminationRuntime;
     use super::{
-        CliExitObservation, CliFailureDiagnostic, claude_initial_prompt_frame, record_cli_exit,
-        select_failure_diagnostic, set_cli_current_dir, with_carried_failure_reason,
+        CliExitObservation, CliFailureDiagnostic, claude_initial_prompt_frame,
+        codex_home_for_home_dir, record_cli_exit, select_failure_diagnostic, set_cli_current_dir,
+        with_carried_failure_reason,
     };
     use crate::active_input::ActiveInputRuntime;
     use guest_contracts::diagnostics::{FailureDetailSource, FailureReason};
@@ -1430,6 +1437,12 @@ mod tests {
             .and_then(serde_json::Value::as_str)
             .expect("uuid");
         uuid::Uuid::parse_str(uuid).expect("valid uuid");
+    }
+
+    #[test]
+    fn codex_home_uses_shared_path_semantics_for_empty_home() {
+        assert_eq!(codex_home_for_home_dir(""), ".codex");
+        assert_eq!(codex_home_for_home_dir("/tmp/home"), "/tmp/home/.codex");
     }
 
     #[tokio::test]

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -308,25 +308,66 @@ impl<'a> CliRuntimeConfig<'a> {
     }
 
     fn from_legacy_env(framework: env::Framework) -> Self {
+        let is_claude = matches!(framework, env::Framework::ClaudeCode);
+        let is_codex = matches!(framework, env::Framework::Codex);
+        let use_mock_claude = is_claude && env::use_mock_claude();
+        let use_mock_codex = is_codex && env::use_mock_codex();
+        let use_codex_app_server_backend = is_codex && env::use_codex_app_server_backend();
         Self {
             framework,
-            run_id: Cow::Borrowed(env::run_id()),
+            run_id: if is_claude {
+                Cow::Borrowed(env::run_id())
+            } else {
+                Cow::Borrowed("")
+            },
             prompt: Cow::Borrowed(env::prompt()),
             resume_session_id: Cow::Borrowed(env::resume_session_id()),
             append_system_prompt: Cow::Borrowed(env::append_system_prompt()),
-            disallowed_tools: Cow::Borrowed(env::disallowed_tools()),
-            tools: Cow::Borrowed(env::tools()),
-            settings: Cow::Borrowed(env::settings()),
-            use_mock_claude: env::use_mock_claude(),
-            mock_claude_path: Cow::Owned(env::mock_claude_path()),
-            use_mock_codex: env::use_mock_codex(),
-            use_codex_app_server_backend: env::use_codex_app_server_backend(),
-            mock_codex_path: Cow::Owned(env::mock_codex_path()),
+            disallowed_tools: if is_claude {
+                Cow::Borrowed(env::disallowed_tools())
+            } else {
+                Cow::Borrowed("")
+            },
+            tools: if is_claude {
+                Cow::Borrowed(env::tools())
+            } else {
+                Cow::Borrowed("")
+            },
+            settings: if is_claude {
+                Cow::Borrowed(env::settings())
+            } else {
+                Cow::Borrowed("")
+            },
+            use_mock_claude,
+            mock_claude_path: if use_mock_claude {
+                Cow::Owned(env::mock_claude_path())
+            } else {
+                Cow::Borrowed("")
+            },
+            use_mock_codex,
+            use_codex_app_server_backend,
+            mock_codex_path: if use_mock_codex {
+                Cow::Owned(env::mock_codex_path())
+            } else {
+                Cow::Borrowed("")
+            },
             home_dir: Cow::Borrowed(env::home_dir()),
-            api_url: Cow::Borrowed(env::api_url()),
-            openai_model: Cow::Borrowed(env::openai_model()),
-            codex_oauth_mode: env::is_codex_oauth_mode(),
-            stuck_tool_timeout_secs: env::stuck_tool_timeout_secs(),
+            api_url: if use_codex_app_server_backend {
+                Cow::Borrowed("")
+            } else {
+                Cow::Borrowed(env::api_url())
+            },
+            openai_model: if is_codex {
+                Cow::Borrowed(env::openai_model())
+            } else {
+                Cow::Borrowed("")
+            },
+            codex_oauth_mode: is_codex && env::is_codex_oauth_mode(),
+            stuck_tool_timeout_secs: if is_claude {
+                env::stuck_tool_timeout_secs()
+            } else {
+                constants::STUCK_TOOL_TIMEOUT_SECS
+            },
             agent_log_file: Cow::Borrowed(paths::agent_log_file()),
             user_env: env::user_env(),
         }
@@ -509,6 +550,14 @@ pub async fn execute_cli_with_active_input(
     execute_cli_inner(masker, heartbeat_monitor, http, active_input, &runtime).await
 }
 
+/// Execute the CLI process using values captured in a [`env::GuestConfig`] and
+/// [`paths::GuestPaths`].
+///
+/// Production guest-agent bootstrap should prefer this entry point so CLI
+/// setup observes the same immutable runtime snapshot as the rest of the run.
+/// The legacy [`execute_cli`] and [`execute_cli_with_active_input`] wrappers
+/// remain for transitional tests and callers that still use process env
+/// facades.
 pub async fn execute_cli_with_active_input_for_config(
     masker: &SecretMasker,
     heartbeat_monitor: HeartbeatMonitor,

--- a/crates/guest-agent/src/codex_auth.rs
+++ b/crates/guest-agent/src/codex_auth.rs
@@ -252,8 +252,9 @@ fn write_auth_json_atomic(codex_home: &Path, serialized: &str) -> Result<(), Age
 // Setup function
 //
 // Inputs are explicit so file-state transitions remain testable without
-// touching env or the real clock. The thin wrapper in `cli::codex_setup`
-// reads env and selects the desired auth state.
+// touching env or the real clock. Thin wrappers in `cli::codex_setup`
+// provide either a legacy env-derived home or the production runtime-config
+// home plus desired auth state.
 // ---------------------------------------------------------------------------
 
 pub(crate) fn reconcile_codex_auth_state(

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -62,7 +62,16 @@ pub async fn send_event(
 /// This function does not perform filesystem or network I/O; session metadata
 /// capture is handled separately before payload preparation, and network
 /// delivery happens in `post_event` / `send_event`.
-pub fn prepare_event_payload(mut event: Value, seq: u32, masker: &SecretMasker) -> Value {
+pub fn prepare_event_payload(event: Value, seq: u32, masker: &SecretMasker) -> Value {
+    prepare_event_payload_for_run_id(event, seq, masker, env::run_id())
+}
+
+pub(crate) fn prepare_event_payload_for_run_id(
+    mut event: Value,
+    seq: u32,
+    masker: &SecretMasker,
+    run_id: &str,
+) -> Value {
     // Add sequence number
     if let Some(obj) = event.as_object_mut() {
         obj.insert("sequenceNumber".to_string(), json!(seq));
@@ -72,10 +81,7 @@ pub fn prepare_event_payload(mut event: Value, seq: u32, masker: &SecretMasker) 
     masker.mask_value(&mut event);
 
     let mut payload = Map::new();
-    payload.insert(
-        "runId".to_string(),
-        Value::String(env::run_id().to_string()),
-    );
+    payload.insert("runId".to_string(), Value::String(run_id.to_string()));
     payload.insert("events".to_string(), Value::Array(vec![event]));
     Value::Object(payload)
 }
@@ -470,23 +476,55 @@ pub(crate) fn extract_claude_tool_info(event: &Value) -> Vec<ClaudeToolEvent<'_>
 ///   resolution is deferred to checkpoint time.
 pub(crate) struct SessionMetadataCapture {
     existing_session_id_seeded: bool,
+    framework: Framework,
+    home_dir: String,
+    session_id_file: String,
+    session_history_path_file: String,
 }
 
 impl SessionMetadataCapture {
     pub(crate) fn new() -> Self {
+        Self::from_values(
+            Framework::from_env(),
+            env::home_dir(),
+            paths::session_id_file(),
+            paths::session_history_path_file(),
+        )
+    }
+
+    pub(crate) fn from_values(
+        framework: Framework,
+        home_dir: &str,
+        session_id_file: &str,
+        session_history_path_file: &str,
+    ) -> Self {
         Self {
             existing_session_id_seeded: false,
+            framework,
+            home_dir: home_dir.to_string(),
+            session_id_file: session_id_file.to_string(),
+            session_history_path_file: session_history_path_file.to_string(),
         }
     }
 
     pub(crate) fn capture_event(&mut self, event: &Value, masker: &SecretMasker) {
-        register_event_session_identifier(event, masker);
+        self.register_event_session_identifier(event, masker);
 
-        let parsed = match Framework::from_env() {
+        let session_id = match self.framework {
             Framework::ClaudeCode => extract_claude_session_id(event),
             Framework::Codex => extract_codex_thread_id(event),
         };
-        let Some((session_id, history_path_payload)) = parsed else {
+        let Some(session_id) = session_id else {
+            self.seed_existing_session_id(masker);
+            return;
+        };
+        let Some(history_path_payload) =
+            session_metadata::history_marker_payload_for_session_id_with_home(
+                self.framework,
+                &self.home_dir,
+                &session_id,
+            )
+        else {
             self.seed_existing_session_id(masker);
             return;
         };
@@ -495,7 +533,7 @@ impl SessionMetadataCapture {
         // Idempotency: only the first id-bearing event of the run wins, but allow
         // a retry of the same session to repair a missing history marker after a
         // partial metadata write.
-        match std::fs::read_to_string(paths::session_id_file()) {
+        match std::fs::read_to_string(&self.session_id_file) {
             Ok(existing_session_id) => {
                 let existing_session_id = existing_session_id.trim();
                 if !existing_session_id.is_empty() {
@@ -503,7 +541,10 @@ impl SessionMetadataCapture {
                     self.existing_session_id_seeded = true;
                 }
                 if existing_session_id == session_id {
-                    session_metadata::ensure_history_marker_payload(&history_path_payload);
+                    session_metadata::ensure_history_marker_payload_at(
+                        &self.session_history_path_file,
+                        &history_path_payload,
+                    );
                 }
                 return;
             }
@@ -512,27 +553,30 @@ impl SessionMetadataCapture {
                 log_error!(
                     LOG_TAG,
                     "Failed to read existing session ID from {}: {e}",
-                    paths::session_id_file()
+                    self.session_id_file
                 );
                 return;
             }
         }
 
         log_info!(LOG_TAG, "Captured session ID");
-        match paths::write_private(paths::session_id_file(), &session_id) {
-            Ok(()) => log_info!(
-                LOG_TAG,
-                "Session ID written to {}",
-                paths::session_id_file()
-            ),
+        match paths::write_private(&self.session_id_file, &session_id) {
+            Ok(()) => log_info!(LOG_TAG, "Session ID written to {}", self.session_id_file),
             Err(e) => log_error!(
                 LOG_TAG,
                 "Failed to write session ID to {}: {e}",
-                paths::session_id_file()
+                self.session_id_file
             ),
         }
         self.existing_session_id_seeded = true;
-        session_metadata::write_session_history_marker(&history_path_payload);
+        session_metadata::write_session_history_marker_at(
+            &self.session_history_path_file,
+            &history_path_payload,
+        );
+    }
+
+    pub(crate) fn register_event_session_identifier(&self, event: &Value, masker: &SecretMasker) {
+        register_event_session_identifier_for_framework(event, masker, self.framework);
     }
 
     fn seed_existing_session_id(&mut self, masker: &SecretMasker) {
@@ -541,7 +585,7 @@ impl SessionMetadataCapture {
         }
         self.existing_session_id_seeded = true;
 
-        match std::fs::read_to_string(paths::session_id_file()) {
+        match std::fs::read_to_string(&self.session_id_file) {
             Ok(session_id) => {
                 let session_id = session_id.trim();
                 if !session_id.is_empty() {
@@ -552,14 +596,18 @@ impl SessionMetadataCapture {
             Err(e) => log_error!(
                 LOG_TAG,
                 "Failed to read existing session ID from {}: {e}",
-                paths::session_id_file()
+                self.session_id_file
             ),
         }
     }
 }
 
-pub(crate) fn register_event_session_identifier(event: &Value, masker: &SecretMasker) {
-    let id = match Framework::from_env() {
+fn register_event_session_identifier_for_framework(
+    event: &Value,
+    masker: &SecretMasker,
+    framework: Framework,
+) {
+    let id = match framework {
         Framework::ClaudeCode => string_field(event, "session_id"),
         Framework::Codex => string_field(event, "thread_id"),
     };
@@ -575,13 +623,9 @@ fn string_field<'a>(event: &'a Value, field: &str) -> Option<&'a str> {
         .filter(|value| !value.is_empty())
 }
 
-/// Claude variant — matches `system/init` and computes the project-scoped
-/// jsonl path under `$HOME/.claude/projects/-{cwd}/`.
-fn extract_claude_session_id(event: &Value) -> Option<(String, String)> {
-    let session_id = raw_claude_session_id(event)?;
-    let history_path_payload = session_metadata::claude_history_path_payload(session_id)?;
-
-    Some((session_id.to_string(), history_path_payload))
+/// Claude variant — matches `system/init` and returns the raw Claude session id.
+fn extract_claude_session_id(event: &Value) -> Option<String> {
+    raw_claude_session_id(event).map(ToString::to_string)
 }
 
 fn raw_claude_session_id(event: &Value) -> Option<&str> {
@@ -593,14 +637,11 @@ fn raw_claude_session_id(event: &Value) -> Option<&str> {
     string_field(event, "session_id")
 }
 
-/// Codex variant — matches `thread.started` and emits a session-history
-/// marker pointing at the Codex home sessions directory plus the thread_id.
-fn extract_codex_thread_id(event: &Value) -> Option<(String, String)> {
+/// Codex variant — matches `thread.started` and returns the canonical Codex
+/// thread id.
+fn extract_codex_thread_id(event: &Value) -> Option<String> {
     let thread_id = raw_codex_thread_id(event)?;
-    let thread_id = guest_contracts::codex_thread_id::canonical_codex_thread_id(thread_id)?;
-    let marker = session_metadata::codex_history_marker_payload(&thread_id);
-
-    Some((thread_id, marker))
+    guest_contracts::codex_thread_id::canonical_codex_thread_id(thread_id)
 }
 
 fn raw_codex_thread_id(event: &Value) -> Option<&str> {

--- a/crates/guest-agent/src/http.rs
+++ b/crates/guest-agent/src/http.rs
@@ -64,9 +64,10 @@ impl HttpClient {
     ///
     /// This constructor always initializes the underlying `reqwest` client and
     /// does not check `VM0_API_TOKEN`. It can send presigned uploads, but
-    /// webhook JSON posts require API config from [`Self::with_api_config`] or
-    /// [`Self::for_current_env`]. Production guest-agent initialization should
-    /// use [`Self::for_current_env`] so no-API runs can use a disabled client.
+    /// webhook JSON posts require API config from [`Self::with_api_config`],
+    /// [`Self::for_config`], or the legacy [`Self::for_current_env`] wrapper.
+    /// Production guest-agent initialization should use [`Self::for_config`]
+    /// so API settings come from the captured runtime config.
     pub fn new() -> Result<Self, AgentError> {
         Self::with_retry_delay(DEFAULT_RETRY_DELAY)
     }
@@ -76,7 +77,7 @@ impl HttpClient {
     /// Integration tests use this to cover real retry behavior without paying
     /// production backoff time. This constructor does not enable API webhook
     /// auth by itself; use [`Self::with_api_config`] for explicit API tests or
-    /// [`Self::for_current_env`] for production guest-agent initialization.
+    /// [`Self::for_config`] for production guest-agent initialization.
     #[doc(hidden)]
     pub fn with_retry_delay(retry_delay: Duration) -> Result<Self, AgentError> {
         Self::build(None, retry_delay)

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -212,9 +212,8 @@ async fn run(runtime: GuestRuntime) -> i32 {
         start,
         Some(heartbeat_status_rx),
         &telemetry,
-        http,
         active_input.into_writer(),
-        &runtime.config,
+        &runtime,
     )
     .await;
 
@@ -253,10 +252,13 @@ async fn execute(
     start: Instant,
     heartbeat_monitor: cli::HeartbeatMonitor,
     telemetry: &Telemetry,
-    http: HttpClient,
     active_input: guest_agent::active_input::ActiveInputWriter,
-    config: &env::GuestConfig,
+    runtime: &GuestRuntime,
 ) -> i32 {
+    let config = &runtime.config;
+    let runtime_paths = &runtime.paths;
+    let http = runtime.http.clone();
+
     // Pre-warm kernel DNS cache for the CLI's API endpoint.
     // Fire-and-forget: runs in background so the cache is populated by the
     // time the CLI spawns and makes its first HTTPS request.
@@ -287,7 +289,7 @@ async fn execute(
     // sandboxes, continuing after a setup failure can inherit stale auth state
     // from an earlier run.
     if matches!(config.framework, env::Framework::Codex)
-        && let Err(e) = cli::setup_codex(masker).await
+        && let Err(e) = cli::setup_codex_for_config(masker, config).await
     {
         let msg = format!(
             "Codex auth setup failed: {}",
@@ -324,11 +326,13 @@ async fn execute(
         skip_recovery_checkpoint_for_no_history,
         failure_diagnostic,
         cli_execution_succeeded,
-    ) = match cli::execute_cli_with_active_input(
+    ) = match cli::execute_cli_with_active_input_for_config(
         masker,
         heartbeat_monitor,
         http.clone(),
         active_input,
+        config,
+        runtime_paths,
     )
     .await
     {

--- a/crates/guest-agent/src/session_metadata.rs
+++ b/crates/guest-agent/src/session_metadata.rs
@@ -16,21 +16,35 @@ use std::path::{Component, Path, PathBuf};
 const LOG_TAG: &str = "sandbox:guest-agent";
 
 pub(crate) fn history_marker_payload_for_session_id(session_id: &str) -> Option<String> {
-    match Framework::from_env() {
-        Framework::ClaudeCode => claude_history_path_payload(session_id),
+    history_marker_payload_for_session_id_with_home(
+        Framework::from_env(),
+        env::home_dir(),
+        session_id,
+    )
+}
+
+pub(crate) fn history_marker_payload_for_session_id_with_home(
+    framework: Framework,
+    home_dir: &str,
+    session_id: &str,
+) -> Option<String> {
+    match framework {
+        Framework::ClaudeCode => claude_history_path_payload_for_home(home_dir, session_id),
         Framework::Codex => {
             let thread_id = canonical_codex_thread_id(session_id)?;
-            Some(codex_history_marker_payload(&thread_id))
+            Some(codex_history_marker_payload_for_home(
+                Path::new(home_dir),
+                &thread_id,
+            ))
         }
     }
 }
 
-pub(crate) fn claude_history_path_payload(session_id: &str) -> Option<String> {
+fn claude_history_path_payload_for_home(home: &str, session_id: &str) -> Option<String> {
     if !is_valid_session_history_id(session_id) {
         return None;
     }
 
-    let home = env::home_dir();
     let project_name = paths::CANONICAL_WORKING_DIR
         .strip_prefix('/')
         .unwrap_or(paths::CANONICAL_WORKING_DIR)
@@ -77,7 +91,13 @@ pub(crate) fn session_history_marker_kind(history_path_payload: &str) -> &'stati
 }
 
 pub(crate) fn read_existing_history_marker_payload() -> io::Result<Option<String>> {
-    match std::fs::read_to_string(paths::session_history_path_file()) {
+    read_existing_history_marker_payload_from(paths::session_history_path_file())
+}
+
+pub(crate) fn read_existing_history_marker_payload_from(
+    session_history_path_file: &str,
+) -> io::Result<Option<String>> {
+    match std::fs::read_to_string(session_history_path_file) {
         Ok(existing) => {
             let existing = existing.trim();
             if existing.is_empty() {
@@ -91,14 +111,19 @@ pub(crate) fn read_existing_history_marker_payload() -> io::Result<Option<String
     }
 }
 
-pub(crate) fn ensure_history_marker_payload(history_path_payload: &str) {
-    match read_existing_history_marker_payload() {
+pub(crate) fn ensure_history_marker_payload_at(
+    session_history_path_file: &str,
+    history_path_payload: &str,
+) {
+    match read_existing_history_marker_payload_from(session_history_path_file) {
         Ok(Some(_)) => {}
-        Ok(None) => write_session_history_marker(history_path_payload),
+        Ok(None) => {
+            write_session_history_marker_at(session_history_path_file, history_path_payload)
+        }
         Err(e) => log_error!(
             LOG_TAG,
             "Failed to read existing session history marker from {}: {e}",
-            paths::session_history_path_file()
+            session_history_path_file
         ),
     }
 }
@@ -144,17 +169,24 @@ pub fn resolve_history_marker_payload_for_diagnostics() -> io::Result<Option<Str
 }
 
 pub(crate) fn write_session_history_marker(history_path_payload: &str) {
-    match paths::write_private(paths::session_history_path_file(), history_path_payload) {
+    write_session_history_marker_at(paths::session_history_path_file(), history_path_payload);
+}
+
+pub(crate) fn write_session_history_marker_at(
+    session_history_path_file: &str,
+    history_path_payload: &str,
+) {
+    match paths::write_private(session_history_path_file, history_path_payload) {
         Ok(()) => log_info!(
             LOG_TAG,
             "Session history marker written to {} ({})",
-            paths::session_history_path_file(),
+            session_history_path_file,
             session_history_marker_kind(history_path_payload)
         ),
         Err(e) => log_error!(
             LOG_TAG,
             "Failed to write session history marker to {}: {e}",
-            paths::session_history_path_file()
+            session_history_path_file
         ),
     }
 }

--- a/crates/guest-agent/src/session_metadata.rs
+++ b/crates/guest-agent/src/session_metadata.rs
@@ -54,10 +54,6 @@ fn claude_history_path_payload_for_home(home: &str, session_id: &str) -> Option<
     ))
 }
 
-pub(crate) fn codex_history_marker_payload(thread_id: &str) -> String {
-    codex_history_marker_payload_for_home(Path::new(env::home_dir()), thread_id)
-}
-
 fn codex_history_marker_payload_for_home(home_dir: &Path, thread_id: &str) -> String {
     let sessions_dir = codex_sessions_dir(home_dir);
     session_history::codex_marker_payload(&sessions_dir, thread_id)

--- a/crates/guest-agent/src/session_metadata.rs
+++ b/crates/guest-agent/src/session_metadata.rs
@@ -49,9 +49,15 @@ fn claude_history_path_payload_for_home(home: &str, session_id: &str) -> Option<
         .strip_prefix('/')
         .unwrap_or(paths::CANONICAL_WORKING_DIR)
         .replace('/', "-");
-    Some(format!(
-        "{home}/.claude/projects/-{project_name}/{session_id}.jsonl"
-    ))
+    Some(
+        Path::new(home)
+            .join(".claude")
+            .join("projects")
+            .join(format!("-{project_name}"))
+            .join(format!("{session_id}.jsonl"))
+            .to_string_lossy()
+            .into_owned(),
+    )
 }
 
 fn codex_history_marker_payload_for_home(home_dir: &Path, thread_id: &str) -> String {
@@ -201,6 +207,21 @@ mod tests {
         assert!(
             marker.starts_with("CODEX_SEARCH:15:.codex/sessions:"),
             "marker should use relative .codex sessions dir for empty HOME, got {marker}"
+        );
+    }
+
+    #[test]
+    fn claude_history_marker_payload_for_empty_home_uses_path_join_semantics() {
+        let marker = history_marker_payload_for_session_id_with_home(
+            Framework::ClaudeCode,
+            "",
+            "session-123",
+        )
+        .expect("safe Claude session id should produce marker");
+
+        assert_eq!(
+            marker, ".claude/projects/-home-user-workspace/session-123.jsonl",
+            "marker should use relative .claude history dir for empty HOME"
         );
     }
 }

--- a/crates/guest-agent/tests/cli_child_env.rs
+++ b/crates/guest-agent/tests/cli_child_env.rs
@@ -4,8 +4,8 @@
 mod common;
 
 use guest_agent::cli;
-use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
+use guest_agent::run_context::GuestRuntime;
 use std::collections::BTreeMap;
 
 #[tokio::test]
@@ -58,15 +58,29 @@ async fn execute_cli_injects_user_env_without_runner_owned_bootstrap_env()
         std::env::set_var("VM0_USER_ENV_FILE", &user_env_path);
     }
 
-    guest_agent::env::init_user_env()?;
+    let runtime = GuestRuntime::from_process_env()?;
     assert!(!user_env_path.exists());
     assert!(!user_env_dir.exists());
-    assert_eq!(guest_agent::env::home_dir(), user_home_str);
+    assert_eq!(runtime.config.home_dir, user_home_str);
 
-    let result = cli::execute_cli(
+    unsafe {
+        std::env::set_var("VM0_PROMPT", "stale prompt after runtime construction");
+        std::env::set_var("VM0_API_URL", "https://stale-api.example.invalid");
+        std::env::set_var("HOME", tmp.path().join("stale-home"));
+    }
+
+    let active_input = guest_agent::active_input::ActiveInputRuntime::new_with_initial_prompt(
+        &runtime.config.run_id,
+        false,
+        &runtime.config.prompt,
+    );
+    let result = cli::execute_cli_with_active_input_for_config(
         &SecretMasker::from_raw(""),
         common::spawn_dummy_heartbeat(),
-        HttpClient::for_current_env()?,
+        runtime.http.clone(),
+        active_input.into_writer(),
+        &runtime.config,
+        &runtime.paths,
     )
     .await?;
 

--- a/crates/guest-agent/tests/cli_legacy_child_env.rs
+++ b/crates/guest-agent/tests/cli_legacy_child_env.rs
@@ -1,0 +1,44 @@
+//! Legacy child-env coverage for callers that still use process-env facades.
+//!
+//! This test lives in its own binary because `guest_agent::env` caches values
+//! in process-wide `LazyLock`s.
+
+mod common;
+
+use guest_agent::http::HttpClient;
+use guest_agent::masker::SecretMasker;
+use std::collections::BTreeMap;
+
+#[tokio::test]
+async fn legacy_execute_cli_reads_runner_visible_api_url_from_process_env()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock()?;
+    let tmp = tempfile::tempdir()?;
+    let cli_env_path = tmp.path().join("legacy-cli-env.json");
+    let prompt = format!("@write-env-json:{}", cli_env_path.display());
+
+    unsafe {
+        common::setup_env(&mock, tmp.path(), &prompt, 3, 1)?;
+    }
+
+    assert_eq!(guest_agent::env::api_url(), "http://127.0.0.1:1");
+    unsafe {
+        std::env::set_var("VM0_API_URL", "https://late-api.example.invalid");
+    }
+
+    let result = guest_agent::cli::execute_cli(
+        &SecretMasker::from_raw(""),
+        common::spawn_dummy_heartbeat(),
+        HttpClient::new()?,
+    )
+    .await?;
+
+    assert_eq!(result.exit_code, common::CLEAN_EXIT);
+    let cli_env: BTreeMap<String, String> = serde_json::from_slice(&std::fs::read(cli_env_path)?)?;
+    assert_eq!(
+        cli_env.get("VM0_API_URL").map(String::as_str),
+        Some("https://late-api.example.invalid")
+    );
+
+    Ok(())
+}

--- a/crates/guest-agent/tests/codex_app_server_backend_child_env.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_child_env.rs
@@ -76,6 +76,15 @@ async fn codex_app_server_backend_child_env_uses_runtime_snapshot()
     .await
     .expect("execute_cli should return promptly")?;
     assert_eq!(cli_result.exit_code, common::CLEAN_EXIT);
+    let stored_session_id = std::fs::read_to_string(runtime.paths.session_id_file())?;
+    assert!(!stored_session_id.trim().is_empty());
+    assert!(Path::new(runtime.paths.session_history_path_file()).exists());
+    let stale_paths = guest_agent::paths::GuestPaths::from_home(
+        tmp.path().join("stale-home"),
+        &runtime.config.run_id,
+    )?;
+    assert!(!Path::new(stale_paths.session_id_file()).exists());
+    assert!(!Path::new(stale_paths.session_history_path_file()).exists());
 
     let input_event = find_mock_input_event(&Path::new(&runtime.config.home_dir).join(".codex"))?;
     assert_eq!(

--- a/crates/guest-agent/tests/codex_app_server_backend_child_env.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_child_env.rs
@@ -1,0 +1,136 @@
+//! Child-env snapshot coverage for the experimental Codex app-server backend.
+//!
+//! This test lives in its own binary because `guest_agent::env` caches values
+//! in process-wide `LazyLock`s.
+
+mod common;
+
+use guest_agent::masker::SecretMasker;
+use guest_agent::run_context::GuestRuntime;
+use serde_json::{Value, json};
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+#[tokio::test]
+async fn codex_app_server_backend_child_env_uses_runtime_snapshot()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mock = common::build_and_locate_mock_codex()?;
+    let tmp = tempfile::tempdir()?;
+    let run_id = "codex-app-server-backend-child-env-test";
+    let prompt = "runtime child env prompt";
+
+    unsafe {
+        common::setup_codex_app_server_env(
+            &mock,
+            tmp.path(),
+            run_id,
+            prompt,
+            "runtime-turn-complete-without-thread-started",
+        )?;
+    }
+
+    let runtime_dir = guest_contracts::runtime_paths::run_dir_from_env(run_id)?;
+    let user_env_dir = runtime_dir.join("user-env");
+    std::fs::create_dir_all(&user_env_dir)?;
+    let user_env_path = user_env_dir.join("env.json");
+    std::fs::write(
+        &user_env_path,
+        serde_json::to_vec(&json!({
+            "CUSTOM_USER_ENV": "visible-to-app-server",
+            "OPENAI_MODEL": "gpt-runtime-model",
+            "VM0_API_URL": "https://user-env.example.invalid"
+        }))?,
+    )?;
+    unsafe {
+        std::env::set_var("VM0_USER_ENV_FILE", &user_env_path);
+    }
+
+    let runtime = GuestRuntime::from_process_env()?;
+    assert!(!user_env_path.exists());
+    assert!(!user_env_dir.exists());
+
+    unsafe {
+        std::env::set_var("HOME", tmp.path().join("stale-home"));
+        std::env::set_var("VM0_API_URL", "https://stale-api.example.invalid");
+        std::env::set_var("VM0_PROMPT", "stale prompt after runtime construction");
+        std::env::set_var("CUSTOM_USER_ENV", "stale-process-user-env");
+    }
+
+    let active_input = guest_agent::active_input::ActiveInputRuntime::new_with_initial_prompt(
+        &runtime.config.run_id,
+        false,
+        &runtime.config.prompt,
+    );
+    let cli_result = tokio::time::timeout(
+        Duration::from_secs(5),
+        guest_agent::cli::execute_cli_with_active_input_for_config(
+            &SecretMasker::from_config(&runtime.config),
+            common::spawn_dummy_heartbeat(),
+            runtime.http.clone(),
+            active_input.into_writer(),
+            &runtime.config,
+            &runtime.paths,
+        ),
+    )
+    .await
+    .expect("execute_cli should return promptly")?;
+    assert_eq!(cli_result.exit_code, common::CLEAN_EXIT);
+
+    let input_event = find_mock_input_event(&Path::new(&runtime.config.home_dir).join(".codex"))?;
+    assert_eq!(
+        input_event.get("text").and_then(Value::as_str),
+        Some(prompt)
+    );
+    assert_eq!(
+        input_event.get("child_env_home").and_then(Value::as_str),
+        Some(runtime.config.home_dir.as_str())
+    );
+    assert_eq!(
+        input_event.get("child_env_api_url").and_then(Value::as_str),
+        Some(runtime.config.api_url.as_str())
+    );
+    assert_eq!(
+        input_event
+            .get("child_env_custom_user_env")
+            .and_then(Value::as_str),
+        Some("visible-to-app-server")
+    );
+    assert_eq!(
+        input_event
+            .get("child_env_openai_model")
+            .and_then(Value::as_str),
+        Some("gpt-runtime-model")
+    );
+
+    Ok(())
+}
+
+fn find_mock_input_event(codex_home: &Path) -> Result<Value, Box<dyn std::error::Error>> {
+    for path in session_jsonl_files(&codex_home.join("sessions"))? {
+        let decoded = std::fs::read_to_string(path)?;
+        for line in decoded.lines().filter(|line| !line.is_empty()) {
+            let event: Value = serde_json::from_str(line)?;
+            if event.get("type").and_then(Value::as_str) == Some("mock.app_server.input") {
+                return Ok(event);
+            }
+        }
+    }
+    Err("missing mock app-server input event".into())
+}
+
+fn session_jsonl_files(root: &Path) -> Result<Vec<PathBuf>, Box<dyn std::error::Error>> {
+    let mut files = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        for entry in std::fs::read_dir(dir)? {
+            let path = entry?.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if path.extension() == Some(OsStr::new("jsonl")) {
+                files.push(path);
+            }
+        }
+    }
+    Ok(files)
+}

--- a/crates/guest-agent/tests/execute_cli_api_mode.rs
+++ b/crates/guest-agent/tests/execute_cli_api_mode.rs
@@ -91,10 +91,15 @@ async fn api_mode_execute_cli_captures_session_metadata_and_sends_events()
     }
     let runtime = GuestRuntime::from_process_env()?;
     let _run_files = RunFilesGuard::new();
+    let expected_run_id = runtime.config.run_id.clone();
+    unsafe {
+        std::env::set_var("VM0_RUN_ID", "stale-run-id-after-runtime-construction");
+    }
 
     let init_event = server.mock(|when, then| {
         when.method(POST)
             .path("/api/webhooks/agent/events")
+            .body_includes(format!(r#""runId":"{expected_run_id}""#))
             .body_includes(r#""subtype":"init""#)
             .body_includes(r#""session_id":"***"#);
         then.status(200);

--- a/crates/guest-agent/tests/execute_cli_api_mode.rs
+++ b/crates/guest-agent/tests/execute_cli_api_mode.rs
@@ -6,8 +6,8 @@
 
 mod common;
 
-use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
+use guest_agent::run_context::GuestRuntime;
 use httpmock::prelude::*;
 use std::path::Path;
 use std::time::Duration;
@@ -89,6 +89,7 @@ async fn api_mode_execute_cli_captures_session_metadata_and_sends_events()
     unsafe {
         setup_api_env(&mock_cli, tmp.path(), &server.base_url(), &prompt)?;
     }
+    let runtime = GuestRuntime::from_process_env()?;
     let _run_files = RunFilesGuard::new();
 
     let init_event = server.mock(|when, then| {
@@ -114,17 +115,19 @@ async fn api_mode_execute_cli_captures_session_metadata_and_sends_events()
 
     let masker = SecretMasker::from_raw("");
     let active_input = guest_agent::active_input::ActiveInputRuntime::new_with_initial_prompt(
-        guest_agent::env::run_id(),
+        &runtime.config.run_id,
         true,
-        guest_agent::env::prompt(),
+        &runtime.config.prompt,
     );
     let cli_result = tokio::time::timeout(
         Duration::from_secs(5),
-        guest_agent::cli::execute_cli_with_active_input(
+        guest_agent::cli::execute_cli_with_active_input_for_config(
             &masker,
             common::spawn_dummy_heartbeat(),
-            HttpClient::with_api_config(server.base_url(), "test-token", "", Duration::ZERO)?,
+            runtime.http.clone(),
             active_input.into_writer(),
+            &runtime.config,
+            &runtime.paths,
         ),
     )
     .await

--- a/crates/guest-mock-codex/src/app_server.rs
+++ b/crates/guest-mock-codex/src/app_server.rs
@@ -963,6 +963,10 @@ fn persist_input_events(
                 "turn_request_approvals_reviewer": turn_params.get("approvalsReviewer"),
                 "turn_request_sandbox_policy": turn_params.get("sandboxPolicy"),
                 "turn_request_client_user_message_id": turn_params.get("clientUserMessageId"),
+                "child_env_home": std::env::var("HOME").ok(),
+                "child_env_api_url": std::env::var("VM0_API_URL").ok(),
+                "child_env_custom_user_env": std::env::var("CUSTOM_USER_ENV").ok(),
+                "child_env_openai_model": std::env::var("OPENAI_MODEL").ok(),
             })
         })
         .collect::<Vec<_>>();


### PR DESCRIPTION
## Summary

- add explicit guest-agent CLI execution/setup entry points backed by `GuestConfig` and `GuestPaths`
- move command construction, child env, Codex setup, and Codex app-server backend runtime values off production legacy facades
- update focused integration tests to exercise the explicit production CLI path

## Tests

- `cargo test --quiet --manifest-path crates/Cargo.toml -p guest-agent --lib cli::command::tests -- --test-threads=1`
- `cargo test --quiet --manifest-path crates/Cargo.toml -p guest-agent --test cli_child_env -- --test-threads=1`
- `cargo test --quiet --manifest-path crates/Cargo.toml -p guest-agent --test execute_cli_api_mode -- --test-threads=1`
- `cargo test --quiet --manifest-path crates/Cargo.toml -p guest-agent --test codex_setup_stderr_masking -- --test-threads=1`
- `cargo test --quiet --manifest-path crates/Cargo.toml -p guest-agent --test codex_app_server_backend -- --test-threads=1`
- `cargo test --quiet --manifest-path crates/Cargo.toml -p guest-agent --test codex_app_server_backend_active_input -- --test-threads=1`
- `cargo test --quiet --manifest-path crates/Cargo.toml -p guest-agent --tests`
- `cargo fmt --manifest-path crates/guest-agent/Cargo.toml --check`
- pre-commit: cargo fmt, cargo doc, cargo clippy

Closes #19501