### PR TITLE
fix: restore default agent mark all read menu

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -1086,7 +1086,15 @@ describe("CHAT-01 chat thread list pagination and read state", () => {
       new Set([agentA.agentId, agentB.agentId]),
     );
 
+    context.mocks.ably.publish.mockClear();
     await chat.markAgentThreadsRead(owner, agentA.agentId);
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "chatThreadReadCursorUpdated",
+      {
+        agentId: agentA.agentId,
+        threadIds: expect.arrayContaining([firstThreadA, secondThreadA]),
+      },
+    );
 
     await expect(
       chat.listThreadUnreads(owner, agentA.agentId),

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -128,13 +128,19 @@ function createThread(
 }
 
 function menuItemByText(text: string): HTMLElement {
-  const item = queryAllByRoleFast("menuitem").find((candidate) => {
-    return candidate.textContent?.replace(/\s+/g, " ").trim() === text;
-  });
+  const item = queryMenuItemByText(text);
   if (!item) {
     throw new Error(`${text} menu item not found`);
   }
   return item;
+}
+
+function queryMenuItemByText(text: string): HTMLElement | null {
+  return (
+    queryAllByRoleFast("menuitem").find((candidate) => {
+      return candidate.textContent?.replace(/\s+/g, " ").trim() === text;
+    }) ?? null
+  );
 }
 
 function buttonByText(
@@ -1281,8 +1287,66 @@ describe("zero sidebar", () => {
 
     await waitFor(() => {
       expect(markedAgentIds).toStrictEqual([RESEARCH_AGENT_ID]);
+      expect(queryMenuItemByText("Mark all read")).not.toBeInTheDocument();
       expect(
         within(researchSidebarRow).queryByLabelText("Unread"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("marks all default agent chats read from the default agent menu", async () => {
+    prepareAgentTeam();
+    context.mocks.api(chatThreadsContract.list, ({ respond }) => {
+      return respond(200, splitChatThreadListResponse([]));
+    });
+
+    let unreadAgentIds = [AGENT_ID, SUPPORT_AGENT_ID];
+    const markedAgentIds: string[] = [];
+    context.mocks.api(chatThreadsContract.unreadAgents, ({ respond }) => {
+      return respond(200, { agentIds: unreadAgentIds });
+    });
+    context.mocks.api(
+      chatThreadMarkAgentReadContract.markAgentRead,
+      ({ body, respond }) => {
+        markedAgentIds.push(body.agentId);
+        unreadAgentIds = unreadAgentIds.filter((id) => {
+          return id !== body.agentId;
+        });
+        return respond(204);
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      featureSwitches: { [FeatureSwitchKey.AgentUnreadIndicators]: true },
+    });
+
+    const nav = await waitFor(() => {
+      const current = sidebar();
+      expect(within(current).getByText("Zero")).toBeInTheDocument();
+      return current;
+    });
+    const defaultSidebarRow = agentRowByName(nav, "Zero");
+    await waitFor(() => {
+      expect(
+        within(defaultSidebarRow).getByLabelText("Unread"),
+      ).toBeInTheDocument();
+      expect(
+        within(defaultSidebarRow).getByLabelText("Open agent menu"),
+      ).toBeInTheDocument();
+    });
+
+    click(within(defaultSidebarRow).getByLabelText("Open agent menu"));
+    expect(menuItemByText("Mark all read")).toBeInTheDocument();
+    expect(queryMenuItemByText("Unpin")).not.toBeInTheDocument();
+    click(menuItemByText("Mark all read"));
+
+    await waitFor(() => {
+      expect(markedAgentIds).toStrictEqual([AGENT_ID]);
+      expect(queryMenuItemByText("Mark all read")).not.toBeInTheDocument();
+      expect(
+        within(defaultSidebarRow).queryByLabelText("Unread"),
       ).not.toBeInTheDocument();
     });
   });

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-agent-row-actions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-agent-row-actions.tsx
@@ -143,7 +143,7 @@ export function AgentRowSideActions({
                   <DropdownMenuItem
                     key={menuAction.label}
                     className="gap-2"
-                    onSelect={menuAction.onSelect}
+                    onClick={menuAction.onSelect}
                     disabled={menuAction.disabled}
                   >
                     {menuAction.icon}

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
@@ -91,37 +91,35 @@ function PinnedAgentSideDecorator({
     );
   }
 
-  if (isDefaultAgent && !hasUnread) {
-    return null;
-  }
+  const actions = [
+    ...(hasUnread
+      ? [
+          {
+            label: "Mark all read",
+            disabled: markingRead,
+            icon: <IconChecks size={16} stroke={2} />,
+            onSelect: markAllRead,
+          },
+        ]
+      : []),
+    ...(!isDefaultAgent
+      ? [
+          {
+            label: "Unpin",
+            disabled: savingPinned,
+            icon: <IconPinnedOff size={16} stroke={2} />,
+            onSelect: unpinAgent,
+          },
+        ]
+      : []),
+  ];
 
   return (
     <AgentRowSideActions
       variant="sidebar"
       isPrimarySelected={isPrimarySelected}
       hasUnread={hasUnread}
-      actions={
-        isDefaultAgent
-          ? undefined
-          : [
-              ...(hasUnread
-                ? [
-                    {
-                      label: "Mark all read",
-                      disabled: markingRead,
-                      icon: <IconChecks size={16} stroke={2} />,
-                      onSelect: markAllRead,
-                    },
-                  ]
-                : []),
-              {
-                label: "Unpin",
-                disabled: savingPinned,
-                icon: <IconPinnedOff size={16} stroke={2} />,
-                onSelect: unpinAgent,
-              },
-            ]
-      }
+      actions={actions}
     />
   );
 }


### PR DESCRIPTION
## Summary
- show the pinned-agent menu for the default agent when unread-only actions are available
- keep pin/unpin actions hidden for the default agent while preserving Mark all read
- trigger agent menu actions via click so the dropdown closes after selection
- add frontend coverage for default-agent and pinned-agent mark-all-read flows, plus API realtime publish coverage

## Verification
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app exec oxlint src/views/zero-page/zero-sidebar-pinned.tsx src/views/zero-page/zero-sidebar-agent-row-actions.tsx src/views/zero-page/__tests__/zero-sidebar.test.tsx
- pnpm -F api exec oxlint src/signals/routes/__tests__/chat-threads.bdd.test.ts
- pnpm exec vitest run apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
- pnpm exec prettier --check apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx apps/platform/src/views/zero-page/zero-sidebar-agent-row-actions.tsx apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
- git diff --check

Note: full API BDD was not run locally because it requires the local Postgres BDD environment; the changed API file was linted and the PR pipeline should run the integration coverage.