### PR TITLE
perf: split runner storage manifest telemetry

### DIFF
--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -56,6 +56,8 @@ const AGENT_WRAPPER_STDERR_CAPTURE_LIMIT_BYTES: u32 = 64 * 1024;
 const SESSION_HISTORY_DOWNLOAD_TELEMETRY_ERROR: &str = "session history download failed";
 const SESSION_HISTORY_MATERIALIZATION_WAIT_TELEMETRY_ERROR: &str =
     "session history materialization failed";
+const STORAGE_CACHE_POPULATE_FAILED: &str = "storage-cache-populate-failed";
+const STORAGE_DOWNLOAD_FAILED: &str = "storage-download-failed";
 const SESSION_HISTORY_IDENTITY_VERIFY_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -693,12 +695,29 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
     if let Some(manifest) = &context.storage_manifest {
         let guest_manifest = GuestDownloadManifest::from(manifest);
         let mut effective: GuestDownloadManifest = match start.prev_storage {
-            Some(prev) => apply_storage_fingerprint_reuse(&guest_manifest, prev),
+            Some(prev) => {
+                let t = Instant::now();
+                let effective = apply_storage_fingerprint_reuse(&guest_manifest, prev);
+                telemetry.record(
+                    "runner_storage_manifest_fingerprint_reuse",
+                    t.elapsed(),
+                    true,
+                    None,
+                );
+                effective
+            }
             None => guest_manifest,
         };
         // Short-circuit: skip the vsock exec if no downloads, cleanup, or
         // guest-side instruction normalization remain.
+        let has_work_t = Instant::now();
         let has_work = guest_download_has_work(&effective);
+        telemetry.record(
+            "runner_storage_manifest_has_work",
+            has_work_t.elapsed(),
+            true,
+            None,
+        );
         if !has_work {
             info!(run_id = %context.run_id, "storage manifest has no download work, skipping download");
         }
@@ -708,14 +727,33 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
             // `archive_url` to `file:///tmp/vm0-storage-cache/...` so the guest
             // reads from its tmpfs instead of hitting R2 per turn.
             async {
-                crate::storage_cache::populate_cache(
+                let cache_t = Instant::now();
+                let cache_result = crate::storage_cache::populate_cache(
                     &mut effective,
                     sandbox,
                     &config.home,
                     telemetry,
                 )
-                .await?;
-                download_storages(sandbox, context, &effective).await
+                .await;
+                telemetry.record(
+                    "runner_storage_manifest_cache_populate",
+                    cache_t.elapsed(),
+                    cache_result.is_ok(),
+                    cache_result
+                        .is_err()
+                        .then_some(STORAGE_CACHE_POPULATE_FAILED),
+                );
+                cache_result?;
+
+                let download_t = Instant::now();
+                let download_result = download_storages(sandbox, context, &effective).await;
+                telemetry.record(
+                    "runner_storage_manifest_guest_download",
+                    download_t.elapsed(),
+                    download_result.is_ok(),
+                    download_result.is_err().then_some(STORAGE_DOWNLOAD_FAILED),
+                );
+                download_result
             }
             .await
         } else {

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -130,6 +130,21 @@ fn assert_successful_action(ops: &[(String, bool, Option<String>)], action: &str
     );
 }
 
+fn assert_failed_action_error(ops: &[(String, bool, Option<String>)], action: &str, error: &str) {
+    assert!(
+        ops.iter()
+            .any(|op| op.0 == action && !op.1 && op.2.as_deref() == Some(error)),
+        "expected failed {action} telemetry with {error:?}, got: {ops:?}"
+    );
+}
+
+fn assert_no_action(ops: &[(String, bool, Option<String>)], action: &str) {
+    assert!(
+        ops.iter().all(|op| op.0 != action),
+        "expected no {action} telemetry, got: {ops:?}"
+    );
+}
+
 async fn assert_checkpointed_final_identity_helper_failure_falls_back(
     session_id: &str,
     helper_result: ExecResult,
@@ -396,15 +411,130 @@ async fn run_in_sandbox_runs_guest_download_for_cached_instruction_normalization
         "cached instruction storage should still invoke guest-download; calls: {exec_calls:?}"
     );
     let ops = telemetry.pending_ops_snapshot();
-    assert!(
-        ops.iter()
-            .any(|(action, success, _)| action == "runner_storage_manifest_apply" && *success),
-        "runner storage manifest apply should be recorded with the disambiguated metric name: {ops:?}"
-    );
+    assert_successful_action(&ops, "runner_storage_manifest_fingerprint_reuse");
+    assert_successful_action(&ops, "runner_storage_manifest_has_work");
+    assert_successful_action(&ops, "runner_storage_manifest_cache_populate");
+    assert_successful_action(&ops, "runner_storage_manifest_guest_download");
+    assert_successful_action(&ops, "runner_storage_manifest_apply");
     assert!(
         ops.iter()
             .all(|(action, _, _)| action != "storage_download"),
         "runner telemetry should not use the guest-download per-entry metric name: {ops:?}"
+    );
+}
+
+#[tokio::test]
+async fn run_in_sandbox_records_storage_manifest_no_work_timing_without_guest_download() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let sandbox = sandbox_mock::MockSandbox::new("test");
+    let mut ctx = minimal_context();
+    ctx.storage_manifest = Some(StorageManifest {
+        storages: vec![api_storage(
+            "instructions",
+            "/home/user/.codex",
+            "v1",
+            "https://example.com/instructions.tar.gz",
+        )],
+        artifacts: vec![],
+    });
+    let prev_storage = StorageFingerprints {
+        storages: HashMap::from([(
+            "/home/user/.codex".into(),
+            StorageFingerprint::new("instructions", "v1"),
+        )]),
+        artifacts: HashMap::new(),
+    };
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    run_in_sandbox(
+        &sandbox,
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::Reused,
+            prev_storage: Some(&prev_storage),
+        },
+        &mut telemetry,
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None),
+    )
+    .await
+    .unwrap();
+
+    let exec_calls = sandbox.exec_calls();
+    assert!(
+        exec_calls
+            .iter()
+            .all(|call| call.cmd != guest_download_stdin_command()),
+        "fully cached storage without cleanup or instruction normalization should skip guest-download; calls: {exec_calls:?}"
+    );
+    let ops = telemetry.pending_ops_snapshot();
+    assert_successful_action(&ops, "runner_storage_manifest_fingerprint_reuse");
+    assert_successful_action(&ops, "runner_storage_manifest_has_work");
+    assert_successful_action(&ops, "runner_storage_manifest_apply");
+    assert_no_action(&ops, "runner_storage_manifest_cache_populate");
+    assert_no_action(&ops, "runner_storage_manifest_guest_download");
+}
+
+#[tokio::test]
+async fn run_in_sandbox_records_storage_manifest_guest_download_failure_timing() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let sandbox = sandbox_mock::MockSandbox::new("test");
+    sandbox.push_exec_result(Err(sandbox_exec_error("vsock exec failed")));
+    let mut ctx = minimal_context();
+    let mut storage = api_storage(
+        "instructions",
+        "/home/user/.codex",
+        "v1",
+        "https://example.com/instructions.tar.gz",
+    );
+    storage.instructions_target_filename = Some("AGENTS.md".into());
+    ctx.storage_manifest = Some(StorageManifest {
+        storages: vec![storage],
+        artifacts: vec![],
+    });
+    let prev_storage = StorageFingerprints {
+        storages: HashMap::from([(
+            "/home/user/.codex".into(),
+            StorageFingerprint::new("instructions", "v1"),
+        )]),
+        artifacts: HashMap::new(),
+    };
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let result = run_in_sandbox(
+        &sandbox,
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::Reused,
+            prev_storage: Some(&prev_storage),
+        },
+        &mut telemetry,
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None),
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "guest-download failure should still fail the storage manifest phase"
+    );
+    let ops = telemetry.pending_ops_snapshot();
+    assert_successful_action(&ops, "runner_storage_manifest_fingerprint_reuse");
+    assert_successful_action(&ops, "runner_storage_manifest_has_work");
+    assert_successful_action(&ops, "runner_storage_manifest_cache_populate");
+    assert_failed_action_error(
+        &ops,
+        "runner_storage_manifest_guest_download",
+        "storage-download-failed",
+    );
+    assert!(
+        ops.iter()
+            .any(|op| op.0 == "runner_storage_manifest_apply" && !op.1),
+        "top-level storage manifest apply failure should still be recorded, got: {ops:?}"
     );
 }
 

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -130,11 +130,26 @@ fn assert_successful_action(ops: &[(String, bool, Option<String>)], action: &str
     );
 }
 
-fn assert_failed_action_error(ops: &[(String, bool, Option<String>)], action: &str, error: &str) {
-    assert!(
-        ops.iter()
-            .any(|op| op.0 == action && !op.1 && op.2.as_deref() == Some(error)),
-        "expected failed {action} telemetry with {error:?}, got: {ops:?}"
+fn assert_successful_action_once(ops: &[(String, bool, Option<String>)], action: &str) {
+    let matches = ops.iter().filter(|op| op.0 == action && op.1).count();
+    assert_eq!(
+        matches, 1,
+        "expected exactly one successful {action} telemetry, got: {ops:?}"
+    );
+}
+
+fn assert_failed_action_error_once(
+    ops: &[(String, bool, Option<String>)],
+    action: &str,
+    error: &str,
+) {
+    let matches = ops
+        .iter()
+        .filter(|op| op.0 == action && !op.1 && op.2.as_deref() == Some(error))
+        .count();
+    assert_eq!(
+        matches, 1,
+        "expected exactly one failed {action} telemetry with {error:?}, got: {ops:?}"
     );
 }
 
@@ -411,11 +426,11 @@ async fn run_in_sandbox_runs_guest_download_for_cached_instruction_normalization
         "cached instruction storage should still invoke guest-download; calls: {exec_calls:?}"
     );
     let ops = telemetry.pending_ops_snapshot();
-    assert_successful_action(&ops, "runner_storage_manifest_fingerprint_reuse");
-    assert_successful_action(&ops, "runner_storage_manifest_has_work");
-    assert_successful_action(&ops, "runner_storage_manifest_cache_populate");
-    assert_successful_action(&ops, "runner_storage_manifest_guest_download");
-    assert_successful_action(&ops, "runner_storage_manifest_apply");
+    assert_successful_action_once(&ops, "runner_storage_manifest_fingerprint_reuse");
+    assert_successful_action_once(&ops, "runner_storage_manifest_has_work");
+    assert_successful_action_once(&ops, "runner_storage_manifest_cache_populate");
+    assert_successful_action_once(&ops, "runner_storage_manifest_guest_download");
+    assert_successful_action_once(&ops, "runner_storage_manifest_apply");
     assert!(
         ops.iter()
             .all(|(action, _, _)| action != "storage_download"),
@@ -470,9 +485,9 @@ async fn run_in_sandbox_records_storage_manifest_no_work_timing_without_guest_do
         "fully cached storage without cleanup or instruction normalization should skip guest-download; calls: {exec_calls:?}"
     );
     let ops = telemetry.pending_ops_snapshot();
-    assert_successful_action(&ops, "runner_storage_manifest_fingerprint_reuse");
-    assert_successful_action(&ops, "runner_storage_manifest_has_work");
-    assert_successful_action(&ops, "runner_storage_manifest_apply");
+    assert_successful_action_once(&ops, "runner_storage_manifest_fingerprint_reuse");
+    assert_successful_action_once(&ops, "runner_storage_manifest_has_work");
+    assert_successful_action_once(&ops, "runner_storage_manifest_apply");
     assert_no_action(&ops, "runner_storage_manifest_cache_populate");
     assert_no_action(&ops, "runner_storage_manifest_guest_download");
 }
@@ -523,18 +538,21 @@ async fn run_in_sandbox_records_storage_manifest_guest_download_failure_timing()
         "guest-download failure should still fail the storage manifest phase"
     );
     let ops = telemetry.pending_ops_snapshot();
-    assert_successful_action(&ops, "runner_storage_manifest_fingerprint_reuse");
-    assert_successful_action(&ops, "runner_storage_manifest_has_work");
-    assert_successful_action(&ops, "runner_storage_manifest_cache_populate");
-    assert_failed_action_error(
+    assert_successful_action_once(&ops, "runner_storage_manifest_fingerprint_reuse");
+    assert_successful_action_once(&ops, "runner_storage_manifest_has_work");
+    assert_successful_action_once(&ops, "runner_storage_manifest_cache_populate");
+    assert_failed_action_error_once(
         &ops,
         "runner_storage_manifest_guest_download",
         "storage-download-failed",
     );
-    assert!(
-        ops.iter()
-            .any(|op| op.0 == "runner_storage_manifest_apply" && !op.1),
-        "top-level storage manifest apply failure should still be recorded, got: {ops:?}"
+    let apply_failures = ops
+        .iter()
+        .filter(|op| op.0 == "runner_storage_manifest_apply" && !op.1)
+        .count();
+    assert_eq!(
+        apply_failures, 1,
+        "top-level storage manifest apply failure should still be recorded once, got: {ops:?}"
     );
 }
 


### PR DESCRIPTION
## Summary
- add runner-side storage manifest phase telemetry for fingerprint reuse, has-work checks, cache population, and guest download wrapper timing
- preserve the existing runner_storage_manifest_apply timing boundary for historical dashboard continuity
- add coverage for success, no-work, and guest-download failure telemetry paths

## Tests
- cargo test --manifest-path crates/Cargo.toml -p runner storage_manifest
- cargo test --manifest-path crates/Cargo.toml -p runner run_in_sandbox_runs_guest_download_for_cached_instruction_normalization
- cargo test --manifest-path crates/Cargo.toml -p runner executor::tests::agent_run_tests
- cargo fmt --manifest-path crates/Cargo.toml --all --check

Closes #19505