### PR TITLE
feat: add agent list shortcut

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
@@ -5,6 +5,7 @@ import { localStorageSignals } from "../external/local-storage.ts";
 import { openQueueDrawer$ } from "../queue-page/queue-drawer-state.ts";
 import { setupGlobalShortcut } from "../../lib/setup-global-shortcut.ts";
 import { currentChatAgentId$ } from "../agent-chat.ts";
+import { openAgentListDialog$ } from "./zero-sidebar-state.ts";
 
 export const navigateToChat$ = command(({ set }, chatThreadId: string) => {
   set(detachedNavigateTo$, "/chats/:threadId", {
@@ -52,6 +53,9 @@ export const setupGlobalKeyboardShortcuts$ = command(
         },
         "mod+shift+o": async () => {
           await set(navigateToNewChat$, signal);
+        },
+        "mod+shift+a": () => {
+          set(openAgentListDialog$);
         },
       },
       signal,

--- a/turbo/apps/platform/src/signals/zero-page/zero-sidebar-state.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-sidebar-state.ts
@@ -1,5 +1,6 @@
 import { command, computed, state } from "ccstate";
 import { localStorageSignals } from "../external/local-storage.ts";
+import { reloadAgents$ } from "../agent.ts";
 
 // ---------------------------------------------------------------------------
 // Chat list dialog search query
@@ -136,6 +137,11 @@ export const chatListOpen$ = computed((get) => {
 });
 export const setChatListOpen$ = command(({ set }, open: boolean) => {
   set(internalChatListOpen$, open);
+});
+
+export const openAgentListDialog$ = command(({ set }) => {
+  set(internalChatListOpen$, true);
+  set(reloadAgents$);
 });
 
 // ---------------------------------------------------------------------------

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -1153,6 +1153,29 @@ describe("zero sidebar", () => {
     expect(createRequests).toBe(0);
   });
 
+  it("opens the agent picker from the global shortcut", async () => {
+    prepareAgentTeam();
+    context.mocks.api(chatThreadsContract.list, ({ respond }) => {
+      return respond(200, splitChatThreadListResponse([]));
+    });
+
+    detachedSetupPage({ context, path: `/agents/${AGENT_ID}/chat` });
+
+    await waitFor(() => {
+      expect(sidebar()).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(document.body, {
+      key: "a",
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    const dialog = await screen.findByRole("dialog", { name: "Talk to" });
+    expect(within(dialog).getByText("Research Agent")).toBeInTheDocument();
+    expect(within(dialog).getByText("Support Agent")).toBeInTheDocument();
+  });
+
   it("shows agent unread indicators and dropdown actions behind the feature switch", async () => {
     prepareAgentTeam();
     context.mocks.data.userPreferences({

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -80,6 +80,7 @@ import {
   navigateToNewChat$,
   toggleSidebarOff$,
 } from "../../signals/zero-page/zero-nav.ts";
+import { openAgentListDialog$ } from "../../signals/zero-page/zero-sidebar-state.ts";
 import {
   activeGoalDialogGoal$,
   activeGoalDialogThreadId$,
@@ -6416,6 +6417,7 @@ export function ZeroChatComposer({
     sendModeLoadable.state === "hasData" ? sendModeLoadable.data : "enter";
   const toggleSidebar = useSet(toggleSidebarOff$);
   const newChat = useSet(navigateToNewChat$);
+  const openAgentListDialog = useSet(openAgentListDialog$);
 
   const handleKeyDown = (e: KeyboardEventLike) => {
     if (window.matchMedia("(pointer: coarse)").matches) {
@@ -6435,6 +6437,9 @@ export function ZeroChatComposer({
         },
         "mod+shift+o": () => {
           detach(newChat(pageSignal), Reason.DomCallback);
+        },
+        "mod+shift+a": () => {
+          openAgentListDialog();
         },
       },
       e,

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -342,6 +342,7 @@ const CHAT_SHORTCUT_SECTIONS = [
       { key: "shift+/", label: "Show shortcuts" },
       { key: "mod+b", label: "Toggle sidebar" },
       { key: "mod+shift+o", label: "New chat" },
+      { key: "mod+shift+a", label: "Open agent list" },
       { key: "f2", label: "Rename chat" },
       { key: "shift+f2", label: "Change emoji" },
     ],

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
@@ -30,11 +30,11 @@ import { detachedNavigateTo$, pathParams$ } from "../../signals/route.ts";
 import {
   chatListOpen$,
   setChatListOpen$,
+  openAgentListDialog$,
   agentCardCollapsed$,
   setAgentCardCollapsed$,
 } from "../../signals/zero-page/zero-sidebar-state.ts";
 import {
-  reloadAgents$,
   subagents$,
   defaultAgentId$,
   defaultAgentName$,
@@ -171,10 +171,9 @@ export function PinnedAgentListSection() {
     features[FeatureSwitchKey.AgentUnreadIndicators] ?? false;
   const unreadAgentIds = useLastResolved(unreadAgentIds$);
 
-  const setChatListOpenFn = useSet(setChatListOpen$);
+  const openAgentListDialog = useSet(openAgentListDialog$);
   const collapsed = useGet(agentCardCollapsed$);
   const setCollapsed = useSet(setAgentCardCollapsed$);
-  const reloadAgents = useSet(reloadAgents$);
   const defaultAgentId = useLastResolved(defaultAgentId$);
 
   return (
@@ -203,8 +202,7 @@ export function PinnedAgentListSection() {
                 type="button"
                 onClick={(e) => {
                   e.stopPropagation();
-                  setChatListOpenFn(true);
-                  reloadAgents();
+                  openAgentListDialog();
                 }}
                 className="relative z-10 flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-[hsl(var(--gray-200))] transition-colors"
                 aria-label="Open a conversation"


### PR DESCRIPTION
## Summary
- Add `mod+shift+a` as a global shortcut for opening the existing agent list dialog
- Route the pinned sidebar `+` button and shortcut through the same `openAgentListDialog$` command
- Show the shortcut in the chat shortcut help and support it from the composer

## Verification
- `pnpm exec vitest run apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx`
- `pnpm exec prettier --check apps/platform/src/signals/zero-page/zero-nav.ts apps/platform/src/signals/zero-page/zero-sidebar-state.ts apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx apps/platform/src/views/zero-page/zero-chat-composer.tsx apps/platform/src/views/zero-page/zero-chat-thread-page.tsx apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`