### PR TITLE
perf: reduce host write-file frame copies

### DIFF
--- a/crates/vsock-host/src/file/write.rs
+++ b/crates/vsock-host/src/file/write.rs
@@ -5,16 +5,13 @@ use std::time::Duration;
 use std::{fmt, io};
 
 use shell_quote::quote_shell_arg;
-use vsock_proto::{
-    ExecTermination, MSG_ERROR, MSG_WRITE_FILE, MSG_WRITE_FILE_RESULT, MSG_WRITE_FILES,
-    MSG_WRITE_FILES_RESULT,
-};
+use vsock_proto::{ExecTermination, MSG_ERROR, MSG_WRITE_FILE_RESULT, MSG_WRITE_FILES_RESULT};
 
 use crate::{
     CompositeNormalOperation, ExecCaptureRequest, ExecOperationResult, ExecOwnedCapturedOutput,
     FrameWriteObserver, Shared, VsockHost, exec_operation,
-    normal_request_on_shared_with_write_observer,
-    request_on_shared_with_composite_operation_and_observer,
+    normal_request_on_shared_with_write_observer_frame_builder,
+    request_on_shared_with_composite_operation_and_observer_frame_builder,
 };
 
 use super::{normalize_file_exec_stderr, validate_guest_file_path};
@@ -43,6 +40,7 @@ enum WriteFileChunkTracking<'a> {
     Composite(&'a mut CompositeNormalOperation),
 }
 
+#[derive(Clone, Copy)]
 struct WriteFileChunkRequest<'a> {
     path: &'a str,
     content: &'a [u8],
@@ -95,6 +93,10 @@ impl std::error::Error for WriteFileGuestError {}
 
 fn write_file_guest_error(message: impl Into<String>) -> io::Error {
     io::Error::other(WriteFileGuestError(message.into()))
+}
+
+fn protocol_invalid_input(error: impl ToString) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, error.to_string())
 }
 
 fn error_is_write_file_guest_error(error: &io::Error) -> bool {
@@ -619,16 +621,16 @@ impl VsockHost {
             ));
         }
 
-        let payload = vsock_proto::encode_write_files(&proto_entries)
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
         let timeout = Duration::from_secs(300);
-        let resp = normal_request_on_shared_with_write_observer(
+        let resp = normal_request_on_shared_with_write_observer_frame_builder(
             &self.shared,
-            MSG_WRITE_FILES,
-            &payload,
             WRITE_FILES_TERMINAL_MSG_TYPES,
             timeout,
             write_observer,
+            move |seq, frame| {
+                vsock_proto::encode_write_files_frame_into(frame, seq, &proto_entries)
+                    .map_err(protocol_invalid_input)
+            },
         )
         .await?;
 
@@ -661,39 +663,26 @@ impl VsockHost {
         tracking: WriteFileChunkTracking<'_>,
         write_observer: FrameWriteObserver,
     ) -> io::Result<()> {
-        let payload = if request.private {
-            vsock_proto::encode_private_write_file(request.path, request.content, request.append)
-        } else {
-            vsock_proto::encode_write_file(
-                request.path,
-                request.content,
-                request.sudo,
-                request.append,
-            )
-        }
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
         let timeout = Duration::from_secs(300);
         let resp = match tracking {
             WriteFileChunkTracking::Tracked => {
-                normal_request_on_shared_with_write_observer(
+                normal_request_on_shared_with_write_observer_frame_builder(
                     &self.shared,
-                    MSG_WRITE_FILE,
-                    &payload,
                     WRITE_FILE_TERMINAL_MSG_TYPES,
                     timeout,
                     write_observer,
+                    move |seq, frame| encode_write_file_chunk_frame(frame, seq, request),
                 )
                 .await?
             }
             WriteFileChunkTracking::Composite(normal_operation) => {
-                request_on_shared_with_composite_operation_and_observer(
+                request_on_shared_with_composite_operation_and_observer_frame_builder(
                     &self.shared,
-                    MSG_WRITE_FILE,
-                    &payload,
                     WRITE_FILE_TERMINAL_MSG_TYPES,
                     timeout,
                     normal_operation,
                     write_observer,
+                    move |seq, frame| encode_write_file_chunk_frame(frame, seq, request),
                 )
                 .await?
             }
@@ -721,4 +710,30 @@ impl VsockHost {
 
         Ok(())
     }
+}
+
+fn encode_write_file_chunk_frame(
+    frame: &mut Vec<u8>,
+    seq: u32,
+    request: WriteFileChunkRequest<'_>,
+) -> io::Result<()> {
+    if request.private {
+        vsock_proto::encode_private_write_file_frame_into(
+            frame,
+            seq,
+            request.path,
+            request.content,
+            request.append,
+        )
+    } else {
+        vsock_proto::encode_write_file_frame_into(
+            frame,
+            seq,
+            request.path,
+            request.content,
+            request.sudo,
+            request.append,
+        )
+    }
+    .map_err(protocol_invalid_input)
 }

--- a/crates/vsock-host/src/file/write.rs
+++ b/crates/vsock-host/src/file/write.rs
@@ -620,6 +620,7 @@ impl VsockHost {
                 ),
             ));
         }
+        vsock_proto::validate_write_files(&proto_entries).map_err(protocol_invalid_input)?;
 
         let timeout = Duration::from_secs(300);
         let resp = normal_request_on_shared_with_write_observer_frame_builder(
@@ -663,6 +664,8 @@ impl VsockHost {
         tracking: WriteFileChunkTracking<'_>,
         write_observer: FrameWriteObserver,
     ) -> io::Result<()> {
+        validate_write_file_chunk_request(request)?;
+
         let timeout = Duration::from_secs(300);
         let resp = match tracking {
             WriteFileChunkTracking::Tracked => {
@@ -710,6 +713,20 @@ impl VsockHost {
 
         Ok(())
     }
+}
+
+fn validate_write_file_chunk_request(request: WriteFileChunkRequest<'_>) -> io::Result<()> {
+    if request.private {
+        vsock_proto::validate_private_write_file(request.path, request.content, request.append)
+    } else {
+        vsock_proto::validate_write_file(
+            request.path,
+            request.content,
+            request.sudo,
+            request.append,
+        )
+    }
+    .map_err(protocol_invalid_input)
 }
 
 fn encode_write_file_chunk_frame(

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -589,6 +589,29 @@ async fn write_request_frame(
     Ok(())
 }
 
+async fn write_request_frame_with_builder(
+    shared: &Arc<Shared>,
+    seq: u32,
+    build_frame: impl FnOnce(u32, &mut Vec<u8>) -> io::Result<()>,
+    before_write: impl FnOnce() -> io::Result<()>,
+) -> io::Result<()> {
+    let mut write_guard = RequestWriteGuard::new(Arc::clone(shared));
+    let mut writer = shared.writer.lock().await;
+    let mut frame = Vec::new();
+    build_frame(seq, &mut frame)?;
+    before_write()?;
+    write_guard.mark_started();
+    let result = writer.write_all(&frame).await;
+    drop(frame);
+    if let Err(error) = result {
+        write_guard.mark_returned();
+        shared.poison_connection();
+        return Err(error);
+    }
+    write_guard.mark_returned();
+    Ok(())
+}
+
 fn encode_request_frame(msg_type: u8, seq: u32, payload: &[u8]) -> io::Result<Vec<u8>> {
     vsock_proto::encode(msg_type, seq, payload)
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))
@@ -637,6 +660,21 @@ async fn write_registered_request_and_wait(
     await_pending_response(rx, timeout).await
 }
 
+async fn write_registered_request_and_wait_with_frame_builder(
+    shared: &Arc<Shared>,
+    seq: u32,
+    build_frame: impl FnOnce(u32, &mut Vec<u8>) -> io::Result<()>,
+    timeout: Duration,
+    before_write: impl FnOnce() -> io::Result<()>,
+    rx: oneshot::Receiver<RawMessage>,
+) -> io::Result<RawMessage> {
+    let _pending_guard = PendingRequestGuard::new(Arc::clone(shared), seq);
+
+    write_request_frame_with_builder(shared, seq, build_frame, before_write).await?;
+
+    await_pending_response(rx, timeout).await
+}
+
 async fn await_pending_response(
     rx: oneshot::Receiver<RawMessage>,
     timeout: Duration,
@@ -678,37 +716,14 @@ async fn request_raw_on_shared(
     write_registered_request_and_wait(shared, seq, &data, timeout, || Ok(()), rx).await
 }
 
-async fn normal_request_on_shared_with_write_observer(
+async fn normal_request_on_shared_with_write_observer_frame_builder(
     shared: &Arc<Shared>,
-    msg_type: u8,
-    payload: &[u8],
     terminal_msg_types: &'static [u8],
     timeout: Duration,
     write_observer: FrameWriteObserver,
-) -> io::Result<RawMessage> {
-    normal_request_on_shared_with_pre_write_observer(
-        shared,
-        msg_type,
-        payload,
-        terminal_msg_types,
-        timeout,
-        |_| Ok(()),
-        write_observer,
-    )
-    .await
-}
-
-async fn normal_request_on_shared_with_pre_write_observer(
-    shared: &Arc<Shared>,
-    msg_type: u8,
-    payload: &[u8],
-    terminal_msg_types: &'static [u8],
-    timeout: Duration,
-    pre_write: impl FnOnce(&mut ConnectionState) -> io::Result<()>,
-    write_observer: FrameWriteObserver,
+    build_frame: impl FnOnce(u32, &mut Vec<u8>) -> io::Result<()>,
 ) -> io::Result<RawMessage> {
     let seq = shared.next_seq();
-    let data = encode_request_frame(msg_type, seq, payload)?;
     let normal_operation = shared.reserve_normal_operation()?;
     let rx = register_pending_response(shared, seq, |tx| {
         Ok(PendingResponse {
@@ -718,13 +733,13 @@ async fn normal_request_on_shared_with_pre_write_observer(
         })
     })?;
 
-    write_registered_request_and_wait(
+    write_registered_request_and_wait_with_frame_builder(
         shared,
         seq,
-        &data,
+        build_frame,
         timeout,
         || {
-            mark_pending_normal_operation_possible_guest_write(shared, seq, pre_write)?;
+            mark_pending_normal_operation_possible_guest_write(shared, seq, |_| Ok(()))?;
             write_observer.record_write_start()
         },
         rx,
@@ -732,17 +747,15 @@ async fn normal_request_on_shared_with_pre_write_observer(
     .await
 }
 
-async fn request_on_shared_with_composite_operation_and_observer(
+async fn request_on_shared_with_composite_operation_and_observer_frame_builder(
     shared: &Arc<Shared>,
-    msg_type: u8,
-    payload: &[u8],
     terminal_msg_types: &'static [u8],
     timeout: Duration,
     normal_operation: &mut CompositeNormalOperation,
     write_observer: FrameWriteObserver,
+    build_frame: impl FnOnce(u32, &mut Vec<u8>) -> io::Result<()>,
 ) -> io::Result<RawMessage> {
     let seq = shared.next_seq();
-    let data = encode_request_frame(msg_type, seq, payload)?;
     let rx = register_pending_response(shared, seq, |tx| {
         Ok(PendingResponse {
             response_tx: tx,
@@ -753,10 +766,10 @@ async fn request_on_shared_with_composite_operation_and_observer(
         })
     })?;
 
-    write_registered_request_and_wait(
+    write_registered_request_and_wait_with_frame_builder(
         shared,
         seq,
-        &data,
+        build_frame,
         timeout,
         || {
             normal_operation.mark_possible_guest_write_started()?;

--- a/crates/vsock-host/src/tests/file/write.rs
+++ b/crates/vsock-host/src/tests/file/write.rs
@@ -15,7 +15,10 @@ use super::support::{
     send_write_file_success, send_write_files_failure, send_write_files_success, spawn_write_file,
     spawn_write_files,
 };
-use crate::{FrameWriteObserver, WriteFileEntry, operation_tracker::NormalOperationReadiness};
+use crate::{
+    FrameWriteObserver, WriteFileEntry, file::test_support::WRITE_FILE_CHUNK_LIMIT,
+    operation_tracker::NormalOperationReadiness,
+};
 
 #[tokio::test]
 async fn test_write_file() {
@@ -335,45 +338,35 @@ async fn write_file_cancelled_before_frame_write_does_not_poison_or_send_frame()
 }
 
 #[tokio::test]
-async fn write_file_frame_build_error_after_registration_cleans_pending_without_sending_frame() {
+async fn write_file_rejects_protocol_path_too_long_before_waiting_for_writer() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
     let write_start_count = Arc::new(AtomicUsize::new(0));
     let writer_guard = host.shared.writer.lock().await;
     let path = format!("/{}", "a".repeat(u16::MAX as usize));
-    let write_task = {
-        let host = Arc::clone(&host);
-        let write_start_count = Arc::clone(&write_start_count);
-        tokio::spawn(async move {
-            host.write_file_with_write_observer(
-                &path,
-                b"hello",
-                false,
-                FrameWriteObserver::new(move || {
-                    write_start_count.fetch_add(1, Ordering::SeqCst);
-                    Ok(())
-                }),
-            )
-            .await
-        })
-    };
 
-    tokio::time::timeout(Duration::from_secs(5), async {
-        while pending_request_count(&host) != 1 {
-            tokio::task::yield_now().await;
-        }
+    let err = tokio::time::timeout(Duration::from_secs(5), {
+        let write_start_count = Arc::clone(&write_start_count);
+        host.write_file_with_write_observer(
+            &path,
+            b"hello",
+            false,
+            FrameWriteObserver::new(move || {
+                write_start_count.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }),
+        )
     })
     .await
-    .unwrap();
+    .unwrap()
+    .unwrap_err();
 
-    drop(writer_guard);
-    let err = write_task.await.unwrap().unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
     assert_eq!(write_start_count.load(Ordering::SeqCst), 0);
     match guest.try_read(&mut [0u8; 1]) {
         Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
-        Ok(n) => panic!("frame-build error must not send write_file frame; read {n} bytes"),
-        Err(err) => panic!("unexpected read error after frame-build error: {err}"),
+        Ok(n) => panic!("protocol-invalid write_file must not send frame; read {n} bytes"),
+        Err(err) => panic!("unexpected read error after protocol-invalid write_file: {err}"),
     }
     assert_eq!(pending_request_count(&host), 0);
     assert_eq!(
@@ -381,6 +374,7 @@ async fn write_file_frame_build_error_after_registration_cleans_pending_without_
         NormalOperationReadiness::Idle
     );
 
+    drop(writer_guard);
     assert_connection_accepts_exec_operation(&host, &mut guest).await;
 }
 
@@ -420,46 +414,45 @@ async fn write_file_rejects_invalid_path_before_sending_frame() {
 }
 
 #[tokio::test]
-async fn write_files_frame_build_error_after_registration_cleans_pending_without_sending_frame() {
+async fn write_files_rejects_protocol_message_too_large_before_waiting_for_writer() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
     let write_start_count = Arc::new(AtomicUsize::new(0));
     let writer_guard = host.shared.writer.lock().await;
-    let path = format!("/{}", "a".repeat(u16::MAX as usize));
-    let write_task = {
-        let host = Arc::clone(&host);
-        let write_start_count = Arc::clone(&write_start_count);
-        tokio::spawn(async move {
-            host.write_files_with_write_observer(
-                &[WriteFileEntry {
-                    path: &path,
-                    content: b"hello",
-                }],
-                FrameWriteObserver::new(move || {
-                    write_start_count.fetch_add(1, Ordering::SeqCst);
-                    Ok(())
-                }),
-            )
-            .await
-        })
-    };
+    let path = format!("/{}", "a".repeat(u16::MAX as usize - 1));
+    let content = vec![0u8; WRITE_FILE_CHUNK_LIMIT];
+    let mut files = Vec::new();
+    files.push(WriteFileEntry {
+        path: &path,
+        content: &content,
+    });
+    for _ in 1..17 {
+        files.push(WriteFileEntry {
+            path: &path,
+            content: b"",
+        });
+    }
 
-    tokio::time::timeout(Duration::from_secs(5), async {
-        while pending_request_count(&host) != 1 {
-            tokio::task::yield_now().await;
-        }
+    let err = tokio::time::timeout(Duration::from_secs(5), {
+        let write_start_count = Arc::clone(&write_start_count);
+        host.write_files_with_write_observer(
+            &files,
+            FrameWriteObserver::new(move || {
+                write_start_count.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }),
+        )
     })
     .await
-    .unwrap();
+    .unwrap()
+    .unwrap_err();
 
-    drop(writer_guard);
-    let err = write_task.await.unwrap().unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
     assert_eq!(write_start_count.load(Ordering::SeqCst), 0);
     match guest.try_read(&mut [0u8; 1]) {
         Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
-        Ok(n) => panic!("frame-build error must not send write_files frame; read {n} bytes"),
-        Err(err) => panic!("unexpected read error after frame-build error: {err}"),
+        Ok(n) => panic!("protocol-invalid write_files must not send frame; read {n} bytes"),
+        Err(err) => panic!("unexpected read error after protocol-invalid write_files: {err}"),
     }
     assert_eq!(pending_request_count(&host), 0);
     assert_eq!(
@@ -467,6 +460,7 @@ async fn write_files_frame_build_error_after_registration_cleans_pending_without
         NormalOperationReadiness::Idle
     );
 
+    drop(writer_guard);
     assert_connection_accepts_exec_operation(&host, &mut guest).await;
 }
 

--- a/crates/vsock-host/src/tests/file/write.rs
+++ b/crates/vsock-host/src/tests/file/write.rs
@@ -335,6 +335,56 @@ async fn write_file_cancelled_before_frame_write_does_not_poison_or_send_frame()
 }
 
 #[tokio::test]
+async fn write_file_frame_build_error_after_registration_cleans_pending_without_sending_frame() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let write_start_count = Arc::new(AtomicUsize::new(0));
+    let writer_guard = host.shared.writer.lock().await;
+    let path = format!("/{}", "a".repeat(u16::MAX as usize));
+    let write_task = {
+        let host = Arc::clone(&host);
+        let write_start_count = Arc::clone(&write_start_count);
+        tokio::spawn(async move {
+            host.write_file_with_write_observer(
+                &path,
+                b"hello",
+                false,
+                FrameWriteObserver::new(move || {
+                    write_start_count.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                }),
+            )
+            .await
+        })
+    };
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while pending_request_count(&host) != 1 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+
+    drop(writer_guard);
+    let err = write_task.await.unwrap().unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    assert_eq!(write_start_count.load(Ordering::SeqCst), 0);
+    match guest.try_read(&mut [0u8; 1]) {
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+        Ok(n) => panic!("frame-build error must not send write_file frame; read {n} bytes"),
+        Err(err) => panic!("unexpected read error after frame-build error: {err}"),
+    }
+    assert_eq!(pending_request_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
+}
+
+#[tokio::test]
 async fn write_file_rejects_invalid_path_before_sending_frame() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
@@ -366,6 +416,57 @@ async fn write_file_rejects_invalid_path_before_sending_frame() {
         normal_operation_readiness(&host),
         NormalOperationReadiness::Idle
     );
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
+}
+
+#[tokio::test]
+async fn write_files_frame_build_error_after_registration_cleans_pending_without_sending_frame() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let write_start_count = Arc::new(AtomicUsize::new(0));
+    let writer_guard = host.shared.writer.lock().await;
+    let path = format!("/{}", "a".repeat(u16::MAX as usize));
+    let write_task = {
+        let host = Arc::clone(&host);
+        let write_start_count = Arc::clone(&write_start_count);
+        tokio::spawn(async move {
+            host.write_files_with_write_observer(
+                &[WriteFileEntry {
+                    path: &path,
+                    content: b"hello",
+                }],
+                FrameWriteObserver::new(move || {
+                    write_start_count.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                }),
+            )
+            .await
+        })
+    };
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while pending_request_count(&host) != 1 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+
+    drop(writer_guard);
+    let err = write_task.await.unwrap().unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    assert_eq!(write_start_count.load(Ordering::SeqCst), 0);
+    match guest.try_read(&mut [0u8; 1]) {
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+        Ok(n) => panic!("frame-build error must not send write_files frame; read {n} bytes"),
+        Err(err) => panic!("unexpected read error after frame-build error: {err}"),
+    }
+    assert_eq!(pending_request_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+
     assert_connection_accepts_exec_operation(&host, &mut guest).await;
 }
 

--- a/crates/vsock-proto/src/frame.rs
+++ b/crates/vsock-proto/src/frame.rs
@@ -64,16 +64,35 @@ pub enum DecodeWithError<E> {
 
 /// Encode a raw message: `[4-byte length][1-byte type][4-byte seq][payload]`.
 pub fn encode(msg_type: u8, seq: u32, payload: &[u8]) -> Result<Vec<u8>, ProtocolError> {
-    let body_len = 1 + 4 + payload.len();
+    let mut buf = Vec::new();
+    encode_into(&mut buf, msg_type, seq, payload.len(), |frame| {
+        frame.extend_from_slice(payload);
+    })?;
+    Ok(buf)
+}
+
+pub(crate) fn encode_into(
+    frame: &mut Vec<u8>,
+    msg_type: u8,
+    seq: u32,
+    payload_len: usize,
+    append_payload: impl FnOnce(&mut Vec<u8>),
+) -> Result<(), ProtocolError> {
+    frame.clear();
+    let body_len = MIN_BODY_SIZE
+        .checked_add(payload_len)
+        .ok_or(ProtocolError::MessageTooLarge(usize::MAX))?;
     if body_len > MAX_MESSAGE_SIZE {
         return Err(ProtocolError::MessageTooLarge(body_len));
     }
-    let mut buf = Vec::with_capacity(HEADER_SIZE + body_len);
-    buf.extend_from_slice(&(body_len as u32).to_be_bytes());
-    buf.push(msg_type);
-    buf.extend_from_slice(&seq.to_be_bytes());
-    buf.extend_from_slice(payload);
-    Ok(buf)
+
+    frame.reserve(HEADER_SIZE + body_len);
+    frame.extend_from_slice(&(body_len as u32).to_be_bytes());
+    frame.push(msg_type);
+    frame.extend_from_slice(&seq.to_be_bytes());
+    append_payload(frame);
+    debug_assert_eq!(frame.len(), HEADER_SIZE + body_len);
+    Ok(())
 }
 
 /// Buffered message decoder for streaming data.

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -177,7 +177,8 @@ pub use payloads::write_file::{
     WriteFileBatchEntry, decode_write_file, decode_write_file_result, decode_write_files,
     decode_write_files_result, encode_private_write_file, encode_private_write_file_frame_into,
     encode_write_file, encode_write_file_frame_into, encode_write_file_result, encode_write_files,
-    encode_write_files_frame_into, encode_write_files_result,
+    encode_write_files_frame_into, encode_write_files_result, validate_private_write_file,
+    validate_write_file, validate_write_files,
 };
 pub use wire::{
     EXEC_CAPTURED_OUTPUT_FLAG_TRUNCATED, EXEC_FLAG_SUDO, EXEC_OUTPUT_FLAG_TRUNCATED, HEADER_SIZE,

--- a/crates/vsock-proto/src/lib.rs
+++ b/crates/vsock-proto/src/lib.rs
@@ -175,8 +175,9 @@ pub use payloads::exec_operation::{
 };
 pub use payloads::write_file::{
     WriteFileBatchEntry, decode_write_file, decode_write_file_result, decode_write_files,
-    decode_write_files_result, encode_private_write_file, encode_write_file,
-    encode_write_file_result, encode_write_files, encode_write_files_result,
+    decode_write_files_result, encode_private_write_file, encode_private_write_file_frame_into,
+    encode_write_file, encode_write_file_frame_into, encode_write_file_result, encode_write_files,
+    encode_write_files_frame_into, encode_write_files_result,
 };
 pub use wire::{
     EXEC_CAPTURED_OUTPUT_FLAG_TRUNCATED, EXEC_FLAG_SUDO, EXEC_OUTPUT_FLAG_TRUNCATED, HEADER_SIZE,

--- a/crates/vsock-proto/src/payloads/exec_operation/output.rs
+++ b/crates/vsock-proto/src/payloads/exec_operation/output.rs
@@ -1,9 +1,10 @@
 use crate::error::ProtocolError;
+use crate::frame::encode_into;
 use crate::read::{
     checked_payload_len_add, ensure_payload_fits_message, ensure_u32_len, expect_consumed,
     read_slice, read_u8, read_u32,
 };
-use crate::wire::{EXEC_OUTPUT_FLAG_TRUNCATED, HEADER_SIZE, MIN_BODY_SIZE, MSG_EXEC_OUTPUT};
+use crate::wire::{EXEC_OUTPUT_FLAG_TRUNCATED, MSG_EXEC_OUTPUT};
 
 const EXEC_OUTPUT_STREAM_STDOUT: u8 = 0x00;
 const EXEC_OUTPUT_STREAM_STDERR: u8 = 0x01;
@@ -65,14 +66,9 @@ pub fn encode_exec_output_frame_into(
 ) -> Result<(), ProtocolError> {
     frame.clear();
     let (chunk_len, payload_len) = validate_exec_output_payload(chunk)?;
-    let body_len = MIN_BODY_SIZE + payload_len;
-
-    frame.reserve(HEADER_SIZE + body_len);
-    frame.extend_from_slice(&(body_len as u32).to_be_bytes());
-    frame.push(MSG_EXEC_OUTPUT);
-    frame.extend_from_slice(&seq.to_be_bytes());
-    append_exec_output_payload(frame, stream, output_seq, chunk, chunk_len, truncated);
-    Ok(())
+    encode_into(frame, MSG_EXEC_OUTPUT, seq, payload_len, |frame| {
+        append_exec_output_payload(frame, stream, output_seq, chunk, chunk_len, truncated);
+    })
 }
 
 fn validate_exec_output_payload(chunk: &[u8]) -> Result<(u32, usize), ProtocolError> {

--- a/crates/vsock-proto/src/payloads/write_file.rs
+++ b/crates/vsock-proto/src/payloads/write_file.rs
@@ -54,6 +54,16 @@ pub fn encode_write_file(
     encode_write_file_flags(path, content, sudo, append, false)
 }
 
+/// Validate a write_file payload without encoding it.
+pub fn validate_write_file(
+    path: &str,
+    content: &[u8],
+    sudo: bool,
+    append: bool,
+) -> Result<(), ProtocolError> {
+    validate_write_file_payload(path, content, sudo, append, false).map(|_| ())
+}
+
 /// Encode a full write_file frame into `frame`.
 ///
 /// The resulting frame uses the same bytes as
@@ -77,6 +87,15 @@ pub fn encode_private_write_file(
     append: bool,
 ) -> Result<Vec<u8>, ProtocolError> {
     encode_write_file_flags(path, content, false, append, true)
+}
+
+/// Validate a private write_file payload without encoding it.
+pub fn validate_private_write_file(
+    path: &str,
+    content: &[u8],
+    append: bool,
+) -> Result<(), ProtocolError> {
+    validate_write_file_payload(path, content, false, append, true).map(|_| ())
 }
 
 /// Encode a full private write_file frame into `frame`.
@@ -106,6 +125,11 @@ pub fn encode_write_files(files: &[WriteFileBatchEntry<'_>]) -> Result<Vec<u8>, 
     append_write_files_payload(&mut p, &encoded);
     debug_assert_eq!(p.len(), encoded.payload_len);
     Ok(p)
+}
+
+/// Validate a write_files payload without encoding it.
+pub fn validate_write_files(files: &[WriteFileBatchEntry<'_>]) -> Result<(), ProtocolError> {
+    validate_write_files_payload(files).map(|_| ())
 }
 
 /// Encode a full write_files frame into `frame`.

--- a/crates/vsock-proto/src/payloads/write_file.rs
+++ b/crates/vsock-proto/src/payloads/write_file.rs
@@ -1,10 +1,36 @@
 use super::truncate_utf8_to_u16_bytes;
 use crate::error::ProtocolError;
+use crate::frame::encode_into;
 use crate::read::{
     checked_payload_len_add, ensure_payload_fits_message, ensure_u16_len, ensure_u32_len,
     expect_consumed, read_slice, read_str, read_u8, read_u16, read_u32,
 };
-use crate::wire::{WRITE_FILE_FLAG_APPEND, WRITE_FILE_FLAG_PRIVATE, WRITE_FILE_FLAG_SUDO};
+use crate::wire::{
+    MSG_WRITE_FILE, MSG_WRITE_FILES, WRITE_FILE_FLAG_APPEND, WRITE_FILE_FLAG_PRIVATE,
+    WRITE_FILE_FLAG_SUDO,
+};
+
+struct EncodedWriteFilePayload<'a> {
+    path_len: u16,
+    path_bytes: &'a [u8],
+    content_len: u32,
+    content: &'a [u8],
+    flags: u8,
+    payload_len: usize,
+}
+
+struct EncodedWriteFilesEntry<'a> {
+    path_len: u16,
+    path_bytes: &'a [u8],
+    content_len: u32,
+    content: &'a [u8],
+}
+
+struct EncodedWriteFilesPayload<'a> {
+    file_count: u16,
+    entries: Vec<EncodedWriteFilesEntry<'a>>,
+    payload_len: usize,
+}
 
 /// One ordinary file write entry in a `write_files` batch payload.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -28,6 +54,22 @@ pub fn encode_write_file(
     encode_write_file_flags(path, content, sudo, append, false)
 }
 
+/// Encode a full write_file frame into `frame`.
+///
+/// The resulting frame uses the same bytes as
+/// `encode(MSG_WRITE_FILE, seq, &encode_write_file(...))` without allocating
+/// separate payload and frame vectors.
+pub fn encode_write_file_frame_into(
+    frame: &mut Vec<u8>,
+    seq: u32,
+    path: &str,
+    content: &[u8],
+    sudo: bool,
+    append: bool,
+) -> Result<(), ProtocolError> {
+    encode_write_file_frame_flags_into(frame, seq, path, content, sudo, append, false)
+}
+
 /// Encode a private write_file payload.
 pub fn encode_private_write_file(
     path: &str,
@@ -37,12 +79,55 @@ pub fn encode_private_write_file(
     encode_write_file_flags(path, content, false, append, true)
 }
 
+/// Encode a full private write_file frame into `frame`.
+///
+/// The resulting frame uses the same bytes as
+/// `encode(MSG_WRITE_FILE, seq, &encode_private_write_file(...))` without
+/// allocating separate payload and frame vectors.
+pub fn encode_private_write_file_frame_into(
+    frame: &mut Vec<u8>,
+    seq: u32,
+    path: &str,
+    content: &[u8],
+    append: bool,
+) -> Result<(), ProtocolError> {
+    encode_write_file_frame_flags_into(frame, seq, path, content, false, append, true)
+}
+
 /// Encode write_files payload:
 /// `[2B file_count]` followed by `[2B path_len][path][4B content_len][content]` for each file.
 ///
 /// Returns `Err` if the batch is empty, any path exceeds 65535 bytes, or the
 /// payload cannot fit in one protocol frame.
 pub fn encode_write_files(files: &[WriteFileBatchEntry<'_>]) -> Result<Vec<u8>, ProtocolError> {
+    let encoded = validate_write_files_payload(files)?;
+
+    let mut p = Vec::with_capacity(encoded.payload_len);
+    append_write_files_payload(&mut p, &encoded);
+    debug_assert_eq!(p.len(), encoded.payload_len);
+    Ok(p)
+}
+
+/// Encode a full write_files frame into `frame`.
+///
+/// The resulting frame uses the same bytes as
+/// `encode(MSG_WRITE_FILES, seq, &encode_write_files(...))` without allocating
+/// separate payload and frame vectors.
+pub fn encode_write_files_frame_into(
+    frame: &mut Vec<u8>,
+    seq: u32,
+    files: &[WriteFileBatchEntry<'_>],
+) -> Result<(), ProtocolError> {
+    frame.clear();
+    let encoded = validate_write_files_payload(files)?;
+    encode_into(frame, MSG_WRITE_FILES, seq, encoded.payload_len, |frame| {
+        append_write_files_payload(frame, &encoded);
+    })
+}
+
+fn validate_write_files_payload<'a>(
+    files: &[WriteFileBatchEntry<'a>],
+) -> Result<EncodedWriteFilesPayload<'a>, ProtocolError> {
     if files.is_empty() {
         return Err(ProtocolError::InvalidPayload(
             "write_files file count must be positive",
@@ -59,20 +144,29 @@ pub fn encode_write_files(files: &[WriteFileBatchEntry<'_>]) -> Result<Vec<u8>, 
         payload_len = checked_payload_len_add(payload_len, path_bytes.len())?;
         payload_len = checked_payload_len_add(payload_len, 4)?;
         payload_len = checked_payload_len_add(payload_len, file.content.len())?;
-        encoded_entries.push((path_len, path_bytes, content_len, file.content));
+        encoded_entries.push(EncodedWriteFilesEntry {
+            path_len,
+            path_bytes,
+            content_len,
+            content: file.content,
+        });
     }
     ensure_payload_fits_message(payload_len)?;
+    Ok(EncodedWriteFilesPayload {
+        file_count,
+        entries: encoded_entries,
+        payload_len,
+    })
+}
 
-    let mut p = Vec::with_capacity(payload_len);
-    p.extend_from_slice(&file_count.to_be_bytes());
-    for (path_len, path_bytes, content_len, content) in encoded_entries {
-        p.extend_from_slice(&path_len.to_be_bytes());
-        p.extend_from_slice(path_bytes);
-        p.extend_from_slice(&content_len.to_be_bytes());
-        p.extend_from_slice(content);
+fn append_write_files_payload(p: &mut Vec<u8>, encoded: &EncodedWriteFilesPayload<'_>) {
+    p.extend_from_slice(&encoded.file_count.to_be_bytes());
+    for entry in &encoded.entries {
+        p.extend_from_slice(&entry.path_len.to_be_bytes());
+        p.extend_from_slice(entry.path_bytes);
+        p.extend_from_slice(&entry.content_len.to_be_bytes());
+        p.extend_from_slice(entry.content);
     }
-    debug_assert_eq!(p.len(), payload_len);
-    Ok(p)
 }
 
 fn encode_write_file_flags(
@@ -82,6 +176,37 @@ fn encode_write_file_flags(
     append: bool,
     private: bool,
 ) -> Result<Vec<u8>, ProtocolError> {
+    let encoded = validate_write_file_payload(path, content, sudo, append, private)?;
+
+    let mut p = Vec::with_capacity(encoded.payload_len);
+    append_write_file_payload(&mut p, &encoded);
+    debug_assert_eq!(p.len(), encoded.payload_len);
+    Ok(p)
+}
+
+fn encode_write_file_frame_flags_into(
+    frame: &mut Vec<u8>,
+    seq: u32,
+    path: &str,
+    content: &[u8],
+    sudo: bool,
+    append: bool,
+    private: bool,
+) -> Result<(), ProtocolError> {
+    frame.clear();
+    let encoded = validate_write_file_payload(path, content, sudo, append, private)?;
+    encode_into(frame, MSG_WRITE_FILE, seq, encoded.payload_len, |frame| {
+        append_write_file_payload(frame, &encoded);
+    })
+}
+
+fn validate_write_file_payload<'a>(
+    path: &'a str,
+    content: &'a [u8],
+    sudo: bool,
+    append: bool,
+    private: bool,
+) -> Result<EncodedWriteFilePayload<'a>, ProtocolError> {
     let path_bytes = path.as_bytes();
     let path_len = ensure_u16_len("path", path_bytes.len())?;
     let content_len = ensure_u32_len("content", content.len())?;
@@ -100,14 +225,22 @@ fn encode_write_file_flags(
     if private {
         flags |= WRITE_FILE_FLAG_PRIVATE;
     }
-    let mut p = Vec::with_capacity(payload_len);
-    p.extend_from_slice(&path_len.to_be_bytes());
-    p.extend_from_slice(path_bytes);
-    p.push(flags);
-    p.extend_from_slice(&content_len.to_be_bytes());
-    p.extend_from_slice(content);
-    debug_assert_eq!(p.len(), payload_len);
-    Ok(p)
+    Ok(EncodedWriteFilePayload {
+        path_len,
+        path_bytes,
+        content_len,
+        content,
+        flags,
+        payload_len,
+    })
+}
+
+fn append_write_file_payload(p: &mut Vec<u8>, encoded: &EncodedWriteFilePayload<'_>) {
+    p.extend_from_slice(&encoded.path_len.to_be_bytes());
+    p.extend_from_slice(encoded.path_bytes);
+    p.push(encoded.flags);
+    p.extend_from_slice(&encoded.content_len.to_be_bytes());
+    p.extend_from_slice(encoded.content);
 }
 
 /// Encode write_file_result payload: `[1B success][2B error_len][error]`.
@@ -236,7 +369,8 @@ pub fn decode_write_files_result(payload: &[u8]) -> Result<(bool, &str), Protoco
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::wire::MAX_PAYLOAD_SIZE;
+    use crate::frame::encode;
+    use crate::wire::{HEADER_SIZE, MAX_MESSAGE_SIZE, MAX_PAYLOAD_SIZE};
 
     fn assert_invalid_payload(err: ProtocolError, expected: &'static str) {
         assert!(matches!(err, ProtocolError::InvalidPayload(msg) if msg == expected));
@@ -296,6 +430,30 @@ mod tests {
     }
 
     #[test]
+    fn write_file_frame_matches_payload_plus_frame() {
+        let payload = encode_write_file("/tmp/test.txt", b"content", true, true).unwrap();
+        let expected = encode(MSG_WRITE_FILE, 42, &payload).unwrap();
+        let mut frame = Vec::new();
+
+        encode_write_file_frame_into(&mut frame, 42, "/tmp/test.txt", b"content", true, true)
+            .unwrap();
+
+        assert_eq!(frame, expected);
+    }
+
+    #[test]
+    fn private_write_file_frame_matches_payload_plus_frame() {
+        let payload = encode_private_write_file("/tmp/private", b"secret", true).unwrap();
+        let expected = encode(MSG_WRITE_FILE, 43, &payload).unwrap();
+        let mut frame = Vec::new();
+
+        encode_private_write_file_frame_into(&mut frame, 43, "/tmp/private", b"secret", true)
+            .unwrap();
+
+        assert_eq!(frame, expected);
+    }
+
+    #[test]
     fn write_files_payload_roundtrip() {
         let files = [
             WriteFileBatchEntry {
@@ -315,10 +473,40 @@ mod tests {
     }
 
     #[test]
+    fn write_files_frame_matches_payload_plus_frame() {
+        let files = [
+            WriteFileBatchEntry {
+                path: "/tmp/a.txt",
+                content: b"alpha",
+            },
+            WriteFileBatchEntry {
+                path: "/tmp/b.txt",
+                content: b"beta",
+            },
+        ];
+        let payload = encode_write_files(&files).unwrap();
+        let expected = encode(MSG_WRITE_FILES, 44, &payload).unwrap();
+        let mut frame = Vec::new();
+
+        encode_write_files_frame_into(&mut frame, 44, &files).unwrap();
+
+        assert_eq!(frame, expected);
+    }
+
+    #[test]
     fn write_files_rejects_empty_batch() {
         let err = encode_write_files(&[]).unwrap_err();
 
         assert_invalid_payload(err, "write_files file count must be positive");
+    }
+
+    #[test]
+    fn write_files_frame_rejects_empty_batch() {
+        let mut frame = vec![0xFF];
+        let err = encode_write_files_frame_into(&mut frame, 1, &[]).unwrap_err();
+
+        assert_invalid_payload(err, "write_files file count must be positive");
+        assert!(frame.is_empty());
     }
 
     #[test]
@@ -334,6 +522,27 @@ mod tests {
         .unwrap_err();
 
         assert!(matches!(err, ProtocolError::MessageTooLarge(_)));
+    }
+
+    #[test]
+    fn write_files_frame_content_too_large() {
+        let path = "/tmp/f";
+        let payload_overhead = 2 + 2 + path.len() + 4;
+        let big = vec![0u8; MAX_PAYLOAD_SIZE - payload_overhead + 1];
+        let mut frame = vec![0xFF];
+
+        let err = encode_write_files_frame_into(
+            &mut frame,
+            1,
+            &[WriteFileBatchEntry {
+                path,
+                content: &big,
+            }],
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, ProtocolError::MessageTooLarge(_)));
+        assert!(frame.is_empty());
     }
 
     #[test]
@@ -356,10 +565,41 @@ mod tests {
     }
 
     #[test]
+    fn write_files_frame_content_at_message_limit() {
+        let path = "/tmp/f";
+        let payload_overhead = 2 + 2 + path.len() + 4;
+        let content = vec![0u8; MAX_PAYLOAD_SIZE - payload_overhead];
+        let mut frame = Vec::new();
+
+        encode_write_files_frame_into(
+            &mut frame,
+            1,
+            &[WriteFileBatchEntry {
+                path,
+                content: &content,
+            }],
+        )
+        .unwrap();
+
+        assert_eq!(frame.len(), HEADER_SIZE + MAX_MESSAGE_SIZE);
+    }
+
+    #[test]
     fn write_file_path_too_long() {
         let long_path = "a".repeat(65536);
         let err = encode_write_file(&long_path, b"", false, false).unwrap_err();
         assert!(matches!(err, ProtocolError::PayloadTooLarge("path", 65536)));
+    }
+
+    #[test]
+    fn write_file_frame_path_too_long() {
+        let long_path = "a".repeat(65536);
+        let mut frame = vec![0xFF];
+        let err =
+            encode_write_file_frame_into(&mut frame, 1, &long_path, b"", false, false).unwrap_err();
+
+        assert!(matches!(err, ProtocolError::PayloadTooLarge("path", 65536)));
+        assert!(frame.is_empty());
     }
 
     #[test]
@@ -370,6 +610,19 @@ mod tests {
         let err = encode_write_file(path, &big, false, false).unwrap_err();
 
         assert!(matches!(err, ProtocolError::MessageTooLarge(_)));
+    }
+
+    #[test]
+    fn write_file_frame_content_too_large() {
+        let path = "/tmp/f";
+        let payload_overhead = 2 + path.len() + 1 + 4;
+        let big = vec![0u8; MAX_PAYLOAD_SIZE - payload_overhead + 1];
+        let mut frame = vec![0xFF];
+        let err =
+            encode_write_file_frame_into(&mut frame, 1, path, &big, false, false).unwrap_err();
+
+        assert!(matches!(err, ProtocolError::MessageTooLarge(_)));
+        assert!(frame.is_empty());
     }
 
     #[test]
@@ -388,6 +641,18 @@ mod tests {
         assert!(!sudo);
         assert!(!append);
         assert!(!private);
+    }
+
+    #[test]
+    fn write_file_frame_content_at_message_limit() {
+        let path = "/tmp/f";
+        let payload_overhead = 2 + path.len() + 1 + 4;
+        let content = vec![0u8; MAX_PAYLOAD_SIZE - payload_overhead];
+        let mut frame = Vec::new();
+
+        encode_write_file_frame_into(&mut frame, 1, path, &content, false, false).unwrap();
+
+        assert_eq!(frame.len(), HEADER_SIZE + MAX_MESSAGE_SIZE);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add direct write-file/write-files frame encoders that share payload validation with existing payload encoders
- build host write-file frames at the writer-lock boundary so queued large writes do not hold final frame buffers
- keep pending cleanup, observer timing, and connection poisoning semantics covered by regression tests

Closes #19490

## Tests
- cargo test --manifest-path crates/Cargo.toml -p vsock-proto exec_output
- cargo test --manifest-path crates/Cargo.toml -p vsock-proto write_file
- cargo test --manifest-path crates/Cargo.toml -p vsock-host
- cargo test --manifest-path crates/Cargo.toml -p vsock-test write_file
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo clippy --manifest-path crates/Cargo.toml -p vsock-proto -p vsock-host --all-targets -- -D warnings