### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -198,9 +198,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -208,14 +208,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -3256,9 +3257,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.51"
+version = "0.3.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
+checksum = "0e48db7b415311b615f910b3dcaa4557bcd4bf1982379c95c223fd8c2a20e210"
 dependencies = [
  "deranged",
  "num-conv",
@@ -3276,9 +3277,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.30"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",


### PR DESCRIPTION
## Summary

- Updated 4 Rust lockfile dependencies in `crates/Cargo.lock`:
  - `aws-lc-rs` `1.17.0 -> 1.17.1`
  - `aws-lc-sys` `0.41.0 -> 0.42.0`
  - `time` `0.3.51 -> 0.3.52`
  - `time-macros` `0.2.30 -> 0.2.31`

## Dependencies not updated

- `generic-array` remains at `0.14.7` while `0.14.9` is available.
- Reason: transitive `crypto-common v0.1.7` requires `generic-array = "=0.14.7"` through the `digest 0.10.7` path used by `aws-sdk-s3`/`httpmock`/`tokio-tungstenite`. This is not constrained by this repository's `Cargo.toml` files.

## Manual version bumps

- None. No safe workspace `Cargo.toml` minor or patch bumps were needed.

## Tests

- Passed: `cargo test --workspace`
- Runtime adjustments used only to fit this environment: `CARGO_TARGET_DIR` on `/home/user/workspace`, single Cargo job, test debug info disabled, and an owner-only `TMPDIR`.
- An earlier run with a group-writable `TMPDIR` failed in `runner` path-safety tests; rerunning with `TMPDIR` mode `700` passed.
