### PR TITLE
fix: clean up run launch orphans

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts
@@ -370,6 +370,35 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
     await expect(findRunnerJob(fixture.runId)).resolves.toBeNull();
   });
 
+  it("cleans up pending runs without runner jobs after the pending timeout", async () => {
+    const fixture = await trackRun(
+      insertRunFixture({ status: "pending", createdAt: minutesAgo(6) }),
+    );
+
+    const response = await accept(
+      apiClient().cleanup({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body.cleaned).toBe(1);
+    expect(response.body.results).toContainEqual(
+      expect.objectContaining({
+        runId: fixture.runId,
+        status: "cleaned",
+        reason: "Run timed out while pending (never started)",
+      }),
+    );
+    await expect(findRun(fixture.runId)).resolves.toMatchObject({
+      status: "timeout",
+      error: "Run timed out while pending (never started)",
+    });
+    await expect(findRunnerJob(fixture.runId)).resolves.toBeNull();
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      `run:changed:${fixture.runId}`,
+      { status: "failed" },
+    );
+  });
+
   it("deletes expired runner job queue entries", async () => {
     const expired = await trackRun(
       insertRunFixture({ status: "completed", createdAt: minutesAgo(1) }),
@@ -506,12 +535,85 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
       [200],
     );
 
-    expect(response.body.cleaned).toBe(0);
+    expect(response.body.cleaned).toBe(1);
+    expect(response.body.results).toContainEqual(
+      expect.objectContaining({
+        runId: fixture.runId,
+        sandboxId: null,
+        status: "cleaned",
+        reason: "Queued run expired (exceeded queue TTL)",
+      }),
+    );
     await expect(findRun(fixture.runId)).resolves.toMatchObject({
       status: "timeout",
       error: "Queued run expired (exceeded queue TTL)",
     });
     await expect(findQueueEntry(fixture.runId)).resolves.toBeNull();
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      `run:changed:${fixture.runId}`,
+      { status: "failed" },
+    );
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "queue:changed",
+      null,
+    );
+  });
+
+  it("cleans up queued runs missing queue entries after the grace threshold", async () => {
+    const fixture = await trackRun(
+      insertRunFixture({ status: "queued", createdAt: minutesAgo(6) }),
+    );
+
+    const response = await accept(
+      apiClient().cleanup({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body.cleaned).toBe(1);
+    expect(response.body.results).toContainEqual(
+      expect.objectContaining({
+        runId: fixture.runId,
+        sandboxId: null,
+        status: "cleaned",
+        reason: "Queued run timed out before queue entry was persisted",
+      }),
+    );
+    await expect(findRun(fixture.runId)).resolves.toMatchObject({
+      status: "timeout",
+      error: "Queued run timed out before queue entry was persisted",
+    });
+    await expect(findQueueEntry(fixture.runId)).resolves.toBeNull();
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      `run:changed:${fixture.runId}`,
+      { status: "failed" },
+    );
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "queue:changed",
+      null,
+    );
+  });
+
+  it("does not clean up fresh queued runs missing queue entries", async () => {
+    const fixture = await trackRun(
+      insertRunFixture({ status: "queued", createdAt: minutesAgo(1) }),
+    );
+
+    const response = await accept(
+      apiClient().cleanup({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body.cleaned).toBe(0);
+    expect(response.body.results).toHaveLength(0);
+    await expect(findRun(fixture.runId)).resolves.toMatchObject({
+      status: "queued",
+      error: null,
+    });
+    await expect(findQueueEntry(fixture.runId)).resolves.toBeNull();
+    expect(context.mocks.ably.publish).not.toHaveBeenCalledWith(
+      `run:changed:${fixture.runId}`,
+      expect.anything(),
+    );
   });
 
   it("deletes expired stale queue entries without changing terminal runs", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts
@@ -34,6 +34,17 @@ interface ExportJobFixture {
   readonly id: string;
 }
 
+interface QueueMarkerFixture {
+  readonly markerId: string;
+  readonly threadId: string;
+}
+
+interface QueueMarkerRevoker {
+  readonly id: string;
+  readonly revokesMessageId: string;
+  readonly runEventId: string | null;
+}
+
 function apiClient() {
   return setupApp({ context })(cronCleanupSandboxesContract);
 }
@@ -165,6 +176,19 @@ async function insertQueueEntry(
   });
 }
 
+async function insertQueueMarker(
+  fixture: RunFixture,
+): Promise<QueueMarkerFixture> {
+  const response = await postCronCleanupState({
+    action: "seed-queue-marker",
+    run_id: fixture.runId,
+  });
+  return {
+    markerId: stringField(response, "marker_id"),
+    threadId: stringField(response, "thread_id"),
+  };
+}
+
 async function insertRunnerJobEntry(
   fixture: RunFixture,
   expiresAt: Date,
@@ -232,6 +256,23 @@ async function findQueueEntry(runId: string): Promise<{
   });
   const row = recordField(response, "queue_entry");
   return row ? { runId: stringField(row, "runId") } : null;
+}
+
+async function findQueueMarkerRevoker(
+  markerId: string,
+): Promise<QueueMarkerRevoker | null> {
+  const response = await postCronCleanupState({
+    action: "get-queue-marker-revoker",
+    marker_id: markerId,
+  });
+  const row = recordField(response, "queue_marker_revoker");
+  return row
+    ? {
+        id: stringField(row, "id"),
+        revokesMessageId: stringField(row, "revokesMessageId"),
+        runEventId: nullableString(row.runEventId),
+      }
+    : null;
 }
 
 async function findExportJob(jobId: string): Promise<{
@@ -563,6 +604,7 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
     const fixture = await trackRun(
       insertRunFixture({ status: "queued", createdAt: minutesAgo(6) }),
     );
+    const marker = await insertQueueMarker(fixture);
 
     const response = await accept(
       apiClient().cleanup({ headers: cronHeaders() }),
@@ -583,12 +625,26 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
       error: "Queued run timed out before queue entry was persisted",
     });
     await expect(findQueueEntry(fixture.runId)).resolves.toBeNull();
+    await expect(
+      findQueueMarkerRevoker(marker.markerId),
+    ).resolves.toMatchObject({
+      revokesMessageId: marker.markerId,
+      runEventId: "queue:dequeued",
+    });
     expect(context.mocks.ably.publish).toHaveBeenCalledWith(
       `run:changed:${fixture.runId}`,
       { status: "failed" },
     );
     expect(context.mocks.ably.publish).toHaveBeenCalledWith(
       "queue:changed",
+      null,
+    );
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      `chatThreadMessageCreated:${marker.threadId}`,
+      null,
+    );
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "threadListChanged",
       null,
     );
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts
@@ -649,6 +649,38 @@ describe("GET /api/cron/cleanup-sandboxes", () => {
     );
   });
 
+  it("keeps queued timeout cleanup successful when queue realtime publish fails", async () => {
+    const fixture = await trackRun(
+      insertRunFixture({ status: "queued", createdAt: minutesAgo(6) }),
+    );
+    context.mocks.ably.publish.mockImplementation((topic) => {
+      if (topic === "queue:changed") {
+        return Promise.reject(new Error("queue realtime unavailable"));
+      }
+      return Promise.resolve();
+    });
+
+    const response = await accept(
+      apiClient().cleanup({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body.cleaned).toBe(1);
+    expect(response.body.errors).toBe(0);
+    expect(response.body.results).toContainEqual(
+      expect.objectContaining({
+        runId: fixture.runId,
+        sandboxId: null,
+        status: "cleaned",
+        reason: "Queued run timed out before queue entry was persisted",
+      }),
+    );
+    await expect(findRun(fixture.runId)).resolves.toMatchObject({
+      status: "timeout",
+      error: "Queued run timed out before queue entry was persisted",
+    });
+  });
+
   it("does not clean up fresh queued runs missing queue entries", async () => {
     const fixture = await trackRun(
       insertRunFixture({ status: "queued", createdAt: minutesAgo(1) }),

--- a/turbo/apps/api/src/signals/routes/test-cron-cleanup-sandboxes-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-cron-cleanup-sandboxes-state.ts
@@ -17,7 +17,7 @@ import { exportJobs } from "@vm0/db/schema/export-job";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
 import { command } from "ccstate";
-import { eq, inArray } from "drizzle-orm";
+import { eq, inArray, sql } from "drizzle-orm";
 
 import { request$ } from "../context/hono";
 import { bodyResultOf } from "../context/request";
@@ -205,7 +205,13 @@ async function deleteRunForAction(
   if (runThreadIds.length > 0) {
     await db.delete(chatMessages).where(eq(chatMessages.runId, runId));
     signal.throwIfAborted();
-    await db.delete(chatThreads).where(inArray(chatThreads.id, runThreadIds));
+    await db.delete(chatThreads).where(
+      sql`${inArray(chatThreads.id, runThreadIds)} AND NOT EXISTS (
+        SELECT 1
+        FROM ${chatMessages}
+        WHERE ${chatMessages.chatThreadId} = ${chatThreads.id}
+      )`,
+    );
     signal.throwIfAborted();
   }
   await db.delete(agentRunQueue).where(eq(agentRunQueue.runId, runId));

--- a/turbo/apps/api/src/signals/routes/test-cron-cleanup-sandboxes-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-cron-cleanup-sandboxes-state.ts
@@ -11,6 +11,8 @@ import {
 import { agentRunQueue } from "@vm0/db/schema/agent-run-queue";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
+import { chatMessages } from "@vm0/db/schema/chat-message";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { exportJobs } from "@vm0/db/schema/export-job";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
@@ -282,6 +284,65 @@ async function seedQueueEntryForAction(
   return actionOk();
 }
 
+async function seedQueueMarkerForAction(
+  db: Db,
+  body: Record<string, unknown>,
+  signal: AbortSignal,
+) {
+  const runId = readString(body, "run_id");
+  if (!runId) {
+    return actionBadRequest("run_id is required");
+  }
+  const [run] = await db
+    .select({
+      userId: agentRuns.userId,
+      sessionId: agentRuns.sessionId,
+    })
+    .from(agentRuns)
+    .where(eq(agentRuns.id, runId))
+    .limit(1);
+  signal.throwIfAborted();
+  if (!run) {
+    return actionBadRequest("run not found");
+  }
+  const [session] = await db
+    .select({ composeId: agentSessions.agentComposeId })
+    .from(agentSessions)
+    .where(eq(agentSessions.id, run.sessionId))
+    .limit(1);
+  signal.throwIfAborted();
+  if (!session) {
+    return actionBadRequest("session not found");
+  }
+  const [thread] = await db
+    .insert(chatThreads)
+    .values({
+      userId: run.userId,
+      agentComposeId: session.composeId,
+      title: "cron cleanup marker test",
+    })
+    .returning({ id: chatThreads.id });
+  signal.throwIfAborted();
+  if (!thread) {
+    return actionBadRequest("failed to seed chat thread");
+  }
+  const [marker] = await db
+    .insert(chatMessages)
+    .values({
+      chatThreadId: thread.id,
+      role: "assistant",
+      content: "Waiting in queue...",
+      runId,
+      runEventId: "queue:queued",
+    })
+    .returning({ id: chatMessages.id });
+  signal.throwIfAborted();
+  if (!marker) {
+    return actionBadRequest("failed to seed queue marker");
+  }
+  return actionOk({ marker_id: marker.id, thread_id: thread.id });
+}
+
 async function seedExportJobForAction(
   db: Db,
   body: Record<string, unknown>,
@@ -377,6 +438,28 @@ async function getQueueEntryForAction(
   return actionOk({ queue_entry: entry ?? null });
 }
 
+async function getQueueMarkerRevokerForAction(
+  db: Db,
+  body: Record<string, unknown>,
+  signal: AbortSignal,
+) {
+  const markerId = readString(body, "marker_id");
+  if (!markerId) {
+    return actionBadRequest("marker_id is required");
+  }
+  const [revoker] = await db
+    .select({
+      id: chatMessages.id,
+      revokesMessageId: chatMessages.revokesMessageId,
+      runEventId: chatMessages.runEventId,
+    })
+    .from(chatMessages)
+    .where(eq(chatMessages.revokesMessageId, markerId))
+    .limit(1);
+  signal.throwIfAborted();
+  return actionOk({ queue_marker_revoker: revoker ?? null });
+}
+
 async function getExportJobForAction(
   db: Db,
   body: Record<string, unknown>,
@@ -400,11 +483,13 @@ const cronCleanupSandboxesActionHandlers = {
   "delete-run": deleteRunForAction,
   "seed-runner-job": seedRunnerJobForAction,
   "seed-queue-entry": seedQueueEntryForAction,
+  "seed-queue-marker": seedQueueMarkerForAction,
   "seed-export-job": seedExportJobForAction,
   "delete-export-job": deleteExportJobForAction,
   "get-run": getRunForAction,
   "get-runner-job": getRunnerJobForAction,
   "get-queue-entry": getQueueEntryForAction,
+  "get-queue-marker-revoker": getQueueMarkerRevokerForAction,
   "get-export-job": getExportJobForAction,
 } satisfies Record<
   CronCleanupSandboxesAction,

--- a/turbo/apps/api/src/signals/routes/test-cron-cleanup-sandboxes-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-cron-cleanup-sandboxes-state.ts
@@ -17,7 +17,7 @@ import { exportJobs } from "@vm0/db/schema/export-job";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
 import { command } from "ccstate";
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 
 import { request$ } from "../context/hono";
 import { bodyResultOf } from "../context/request";
@@ -194,6 +194,20 @@ async function deleteRunForAction(
         .limit(1)
     : [];
   signal.throwIfAborted();
+  const runThreadRows = await db
+    .select({ id: chatMessages.chatThreadId })
+    .from(chatMessages)
+    .where(eq(chatMessages.runId, runId));
+  signal.throwIfAborted();
+  const runThreadIds = runThreadRows.map((row) => {
+    return row.id;
+  });
+  if (runThreadIds.length > 0) {
+    await db.delete(chatMessages).where(eq(chatMessages.runId, runId));
+    signal.throwIfAborted();
+    await db.delete(chatThreads).where(inArray(chatThreads.id, runThreadIds));
+    signal.throwIfAborted();
+  }
   await db.delete(agentRunQueue).where(eq(agentRunQueue.runId, runId));
   signal.throwIfAborted();
   await db.delete(runnerJobQueue).where(eq(runnerJobQueue.runId, runId));

--- a/turbo/apps/api/src/signals/services/cron-cleanup-sandboxes.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-cleanup-sandboxes.service.ts
@@ -12,13 +12,22 @@ import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { now, nowDate } from "../external/time";
 import { writeDb$, type Db } from "../external/db";
+import {
+  publishOrgSignal,
+  publishRunChangedForUserSafely,
+  publishThreadListChanged,
+  publishUserSignal,
+} from "../external/realtime";
 import { deleteS3Objects } from "../external/s3";
 import { settle } from "../utils";
 import { dispatchCompleteSideEffects$ } from "./agent-webhook-complete.service";
 import {
   cleanupExpiredQueueEntries$,
+  cleanupQueuedRunLaunchOrphans$,
   drainStaleQueues$,
+  type QueuedRunMaintenanceTimeout,
 } from "./zero-run-queue.service";
+import type { QueueMarkerRevokeNotification } from "./zero-chat-queue-marker.service";
 
 const L = logger("CronCleanupSandboxes");
 
@@ -47,6 +56,7 @@ interface CleanupSandboxesResult {
 interface StaleRun {
   readonly id: string;
   readonly orgId: string;
+  readonly userId: string;
   readonly status: string;
   readonly sandboxId: string | null;
   readonly lastHeartbeatAt: Date | null;
@@ -58,6 +68,15 @@ interface CleanupCutoffs {
   readonly running: Date;
   readonly debug: Date;
   readonly pending: Date;
+}
+
+interface MaintenanceTerminalSideEffectsInput {
+  readonly runId: string;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly error: string;
+  readonly queueChanged: boolean;
+  readonly queueMarkerNotification: QueueMarkerRevokeNotification | null;
 }
 
 function staleRunCutoff(run: StaleRun, cutoffs: CleanupCutoffs): Date {
@@ -72,6 +91,19 @@ function staleRunCutoff(run: StaleRun, cutoffs: CleanupCutoffs): Date {
 function isExpiredRun(run: StaleRun, cutoffs: CleanupCutoffs): boolean {
   const referenceTime = run.lastHeartbeatAt ?? run.createdAt;
   return referenceTime < staleRunCutoff(run, cutoffs);
+}
+
+async function publishQueueMarkerNotification(
+  notification: QueueMarkerRevokeNotification,
+  signal: AbortSignal,
+): Promise<void> {
+  await publishUserSignal(
+    [notification.userId],
+    `chatThreadMessageCreated:${notification.chatThreadId}`,
+  );
+  signal.throwIfAborted();
+  await publishThreadListChanged(notification.userId);
+  signal.throwIfAborted();
 }
 
 const cleanupExportJobs$ = command(
@@ -164,6 +196,43 @@ const cleanupExportJobs$ = command(
   },
 );
 
+const dispatchMaintenanceTerminalSideEffects$ = command(
+  async (
+    { set },
+    input: MaintenanceTerminalSideEffectsInput,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    await publishRunChangedForUserSafely(input.userId, input.runId, {
+      status: "failed",
+    });
+    signal.throwIfAborted();
+
+    if (input.queueChanged) {
+      await publishOrgSignal(input.orgId, "queue:changed");
+      signal.throwIfAborted();
+    }
+
+    if (input.queueMarkerNotification) {
+      await publishQueueMarkerNotification(
+        input.queueMarkerNotification,
+        signal,
+      );
+    }
+
+    await set(
+      dispatchCompleteSideEffects$,
+      {
+        runId: input.runId,
+        orgId: input.orgId,
+        status: "failed",
+        error: input.error,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+  },
+);
+
 const cleanupSingleRun$ = command(
   async (
     { set },
@@ -216,12 +285,14 @@ const cleanupSingleRun$ = command(
     }
 
     await set(
-      dispatchCompleteSideEffects$,
+      dispatchMaintenanceTerminalSideEffects$,
       {
         runId: run.id,
         orgId: run.orgId,
-        status: "failed",
+        userId: run.userId,
         error: timeoutReason,
+        queueChanged: false,
+        queueMarkerNotification: null,
       },
       signal,
     );
@@ -244,6 +315,100 @@ const cleanupSingleRun$ = command(
       status: "cleaned",
       reason: timeoutReason,
     };
+  },
+);
+
+const cleanupQueuedTerminalRuns$ = command(
+  async (
+    { set },
+    runs: readonly QueuedRunMaintenanceTimeout[],
+    signal: AbortSignal,
+  ): Promise<CleanupResult[]> => {
+    const results: CleanupResult[] = [];
+    for (const run of runs) {
+      const cleanupResult = await settle(
+        set(
+          dispatchMaintenanceTerminalSideEffects$,
+          {
+            runId: run.runId,
+            orgId: run.orgId,
+            userId: run.userId,
+            error: run.error,
+            queueChanged: true,
+            queueMarkerNotification: run.queueMarkerNotification,
+          },
+          signal,
+        ),
+      );
+      signal.throwIfAborted();
+
+      if (cleanupResult.ok) {
+        results.push({
+          runId: run.runId,
+          sandboxId: null,
+          status: "cleaned",
+          reason: run.error,
+        });
+        continue;
+      }
+
+      const errorMessage =
+        cleanupResult.error instanceof Error
+          ? cleanupResult.error.message
+          : "Unknown error";
+      L.error("Failed to dispatch queued run timeout side effects", {
+        runId: run.runId,
+        error: errorMessage,
+      });
+      results.push({
+        runId: run.runId,
+        sandboxId: null,
+        status: "error",
+        error: errorMessage,
+      });
+    }
+    return results;
+  },
+);
+
+const cleanupExpiredRuns$ = command(
+  async (
+    { set },
+    db: Db,
+    runs: readonly StaleRun[],
+    cutoffs: CleanupCutoffs,
+    signal: AbortSignal,
+  ): Promise<CleanupResult[]> => {
+    const results: CleanupResult[] = [];
+    for (const run of runs) {
+      const cleanupResult = await settle(
+        set(cleanupSingleRun$, db, run, cutoffs, signal),
+      );
+      signal.throwIfAborted();
+
+      if (cleanupResult.ok) {
+        if (cleanupResult.value) {
+          results.push(cleanupResult.value);
+        }
+        continue;
+      }
+
+      const errorMessage =
+        cleanupResult.error instanceof Error
+          ? cleanupResult.error.message
+          : "Unknown error";
+      L.error("Failed to cleanup run", {
+        runId: run.id,
+        error: errorMessage,
+      });
+      results.push({
+        runId: run.id,
+        sandboxId: run.sandboxId,
+        status: "error",
+        error: errorMessage,
+      });
+    }
+    return results;
   },
 );
 
@@ -286,6 +451,7 @@ export const cleanupSandboxes$ = command(
       .select({
         id: agentRuns.id,
         orgId: agentRuns.orgId,
+        userId: agentRuns.userId,
         status: agentRuns.status,
         sandboxId: agentRuns.sandboxId,
         lastHeartbeatAt: agentRuns.lastHeartbeatAt,
@@ -308,25 +474,37 @@ export const cleanupSandboxes$ = command(
       return isExpiredRun(run, cutoffs);
     });
 
-    const expiredQueueCount = await set(cleanupExpiredQueueEntries$, signal);
+    const expiredQueueResult = await set(cleanupExpiredQueueEntries$, signal);
+    signal.throwIfAborted();
+    const queuedOrphanResult = await set(
+      cleanupQueuedRunLaunchOrphans$,
+      cutoffs.pending,
+      signal,
+    );
     signal.throwIfAborted();
     const expiredRunnerJobCount = await cleanupExpiredRunnerJobs(db, signal);
     signal.throwIfAborted();
     const drainedCount = await set(drainStaleQueues$, signal);
     signal.throwIfAborted();
+    const queuedTerminalRuns = [
+      ...expiredQueueResult.timedOutRuns,
+      ...queuedOrphanResult.timedOutRuns,
+    ];
     if (
-      expiredQueueCount > 0 ||
+      expiredQueueResult.deletedCount > 0 ||
+      queuedTerminalRuns.length > 0 ||
       expiredRunnerJobCount > 0 ||
       drainedCount > 0
     ) {
       L.debug("Queue maintenance completed", {
-        expired: expiredQueueCount,
+        expired: expiredQueueResult.deletedCount,
+        expiredTimedOut: expiredQueueResult.timedOutRuns.length,
+        launchOrphansTimedOut: queuedOrphanResult.timedOutRuns.length,
         expiredRunnerJobs: expiredRunnerJobCount,
         drained: drainedCount,
       });
     }
 
-    const results: CleanupResult[] = [];
     if (expiredRuns.length === 0) {
       L.debug("No expired sandboxes found");
     } else {
@@ -335,33 +513,21 @@ export const cleanupSandboxes$ = command(
       });
     }
 
-    for (const run of expiredRuns) {
-      const cleanupResult = await settle(
-        set(cleanupSingleRun$, db, run, cutoffs, signal),
-      );
-      signal.throwIfAborted();
-
-      if (cleanupResult.ok) {
-        if (cleanupResult.value) {
-          results.push(cleanupResult.value);
-        }
-      } else {
-        const errorMessage =
-          cleanupResult.error instanceof Error
-            ? cleanupResult.error.message
-            : "Unknown error";
-        L.error("Failed to cleanup run", {
-          runId: run.id,
-          error: errorMessage,
-        });
-        results.push({
-          runId: run.id,
-          sandboxId: run.sandboxId,
-          status: "error",
-          error: errorMessage,
-        });
-      }
-    }
+    const queuedResults = await set(
+      cleanupQueuedTerminalRuns$,
+      queuedTerminalRuns,
+      signal,
+    );
+    signal.throwIfAborted();
+    const expiredRunResults = await set(
+      cleanupExpiredRuns$,
+      db,
+      expiredRuns,
+      cutoffs,
+      signal,
+    );
+    signal.throwIfAborted();
+    const results = [...queuedResults, ...expiredRunResults];
 
     const { exportJobsCleaned, exportJobsStuck } = await set(
       cleanupExportJobs$,

--- a/turbo/apps/api/src/signals/services/cron-cleanup-sandboxes.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-cleanup-sandboxes.service.ts
@@ -93,17 +93,49 @@ function isExpiredRun(run: StaleRun, cutoffs: CleanupCutoffs): boolean {
   return referenceTime < staleRunCutoff(run, cutoffs);
 }
 
-async function publishQueueMarkerNotification(
+async function publishQueueChangedSafely(
+  orgId: string,
+  signal: AbortSignal,
+): Promise<void> {
+  const result = await settle(publishOrgSignal(orgId, "queue:changed"), signal);
+  if (!result.ok) {
+    L.warn("Failed to publish queue changed signal", {
+      orgId,
+      error: result.error,
+    });
+  }
+}
+
+async function publishQueueMarkerNotificationSafely(
   notification: QueueMarkerRevokeNotification,
   signal: AbortSignal,
 ): Promise<void> {
-  await publishUserSignal(
-    [notification.userId],
-    `chatThreadMessageCreated:${notification.chatThreadId}`,
+  const messageResult = await settle(
+    publishUserSignal(
+      [notification.userId],
+      `chatThreadMessageCreated:${notification.chatThreadId}`,
+    ),
+    signal,
   );
-  signal.throwIfAborted();
-  await publishThreadListChanged(notification.userId);
-  signal.throwIfAborted();
+  if (!messageResult.ok) {
+    L.warn("Failed to publish queue marker revocation signal", {
+      userId: notification.userId,
+      chatThreadId: notification.chatThreadId,
+      error: messageResult.error,
+    });
+  }
+
+  const threadListResult = await settle(
+    publishThreadListChanged(notification.userId),
+    signal,
+  );
+  if (!threadListResult.ok) {
+    L.warn("Failed to publish queue marker thread list signal", {
+      userId: notification.userId,
+      chatThreadId: notification.chatThreadId,
+      error: threadListResult.error,
+    });
+  }
 }
 
 const cleanupExportJobs$ = command(
@@ -208,12 +240,11 @@ const dispatchMaintenanceTerminalSideEffects$ = command(
     signal.throwIfAborted();
 
     if (input.queueChanged) {
-      await publishOrgSignal(input.orgId, "queue:changed");
-      signal.throwIfAborted();
+      await publishQueueChangedSafely(input.orgId, signal);
     }
 
     if (input.queueMarkerNotification) {
-      await publishQueueMarkerNotification(
+      await publishQueueMarkerNotificationSafely(
         input.queueMarkerNotification,
         signal,
       );

--- a/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
@@ -581,6 +581,38 @@ export const cleanupQueuedRunLaunchOrphans$ = command(
     const currentTime = nowDate();
 
     const result = await writeDb.transaction(async (tx) => {
+      const candidates = await tx
+        .select({
+          runId: agentRuns.id,
+          orgId: agentRuns.orgId,
+          userId: agentRuns.userId,
+        })
+        .from(agentRuns)
+        .where(
+          and(
+            eq(agentRuns.status, "queued"),
+            lt(agentRuns.createdAt, cutoff),
+            sql<boolean>`NOT EXISTS (
+              SELECT 1
+              FROM ${agentRunQueue}
+              WHERE ${agentRunQueue.runId} = ${agentRuns.id}
+            )`,
+          ),
+        )
+        .for("update");
+      signal.throwIfAborted();
+
+      if (candidates.length === 0) {
+        return { deletedCount: 0, timedOutRuns: [] };
+      }
+
+      const candidateRunIds = candidates.map((candidate) => {
+        return candidate.runId;
+      });
+
+      // Queue persistence locks the run before inserting agent_run_queue. If
+      // this transaction waited for that lock, re-check the queue table with a
+      // fresh statement before timing out the run.
       const timedOut = await tx
         .update(agentRuns)
         .set({
@@ -591,7 +623,7 @@ export const cleanupQueuedRunLaunchOrphans$ = command(
         .where(
           and(
             eq(agentRuns.status, "queued"),
-            lt(agentRuns.createdAt, cutoff),
+            inArray(agentRuns.id, candidateRunIds),
             sql<boolean>`NOT EXISTS (
               SELECT 1
               FROM ${agentRunQueue}

--- a/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
@@ -42,6 +42,9 @@ import {
 const L = logger("ZeroRunQueue");
 
 const PENDING_RUN_TTL_MS = 15 * 60 * 1000;
+const QUEUED_RUN_EXPIRED_REASON = "Queued run expired (exceeded queue TTL)";
+const QUEUED_RUN_LAUNCH_ORPHAN_REASON =
+  "Queued run timed out before queue entry was persisted";
 
 const TIER_CONCURRENCY_LIMITS: Readonly<Record<OrgTier, number>> =
   Object.freeze({
@@ -96,8 +99,46 @@ type PromoteQueuedCandidateResult =
   | { readonly status: "removed-stale" }
   | { readonly status: "lost" };
 
+interface TimedOutQueuedRunRow {
+  readonly runId: string;
+  readonly orgId: string;
+  readonly userId: string;
+}
+
+export interface QueuedRunMaintenanceTimeout {
+  readonly runId: string;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly error: string;
+  readonly queueMarkerNotification: QueueMarkerRevokeNotification | null;
+}
+
+interface QueuedRunMaintenanceResult {
+  readonly deletedCount: number;
+  readonly timedOutRuns: readonly QueuedRunMaintenanceTimeout[];
+}
+
 interface LockedQueueRunRow extends Record<string, unknown> {
   readonly status: string;
+}
+
+async function timedOutQueuedRunsWithMarkerNotifications(
+  tx: DbTransaction,
+  rows: readonly TimedOutQueuedRunRow[],
+  error: string,
+): Promise<QueuedRunMaintenanceTimeout[]> {
+  const timedOutRuns: QueuedRunMaintenanceTimeout[] = [];
+  for (const row of rows) {
+    timedOutRuns.push({
+      ...row,
+      error,
+      queueMarkerNotification: await revokeQueuedRunAssistantMarkers(tx, {
+        runId: row.runId,
+        userId: row.userId,
+      }),
+    });
+  }
+  return timedOutRuns;
 }
 
 async function activeConcurrencyCount(
@@ -452,7 +493,7 @@ export const drainOrgQueueToCapacity$ = command(
 );
 
 export const cleanupExpiredQueueEntries$ = command(
-  async ({ set }, signal: AbortSignal): Promise<number> => {
+  async ({ set }, signal: AbortSignal): Promise<QueuedRunMaintenanceResult> => {
     const writeDb = set(writeDb$);
     const currentTime = nowDate();
 
@@ -467,7 +508,7 @@ export const cleanupExpiredQueueEntries$ = command(
         .set({
           status: "timeout",
           completedAt: currentTime,
-          error: "Queued run expired (exceeded queue TTL)",
+          error: QUEUED_RUN_EXPIRED_REASON,
         })
         .where(
           and(
@@ -475,7 +516,16 @@ export const cleanupExpiredQueueEntries$ = command(
             eq(agentRuns.status, "queued"),
           ),
         )
-        .returning({ runId: agentRuns.id });
+        .returning({
+          runId: agentRuns.id,
+          orgId: agentRuns.orgId,
+          userId: agentRuns.userId,
+        });
+      const timedOutRuns = await timedOutQueuedRunsWithMarkerNotifications(
+        tx,
+        timedOut,
+        QUEUED_RUN_EXPIRED_REASON,
+      );
 
       const deletableRows = await tx
         .select({ runId: agentRunQueue.runId })
@@ -489,7 +539,7 @@ export const cleanupExpiredQueueEntries$ = command(
         );
 
       if (deletableRows.length === 0) {
-        return { deletedCount: 0, timedOutCount: timedOut.length };
+        return { deletedCount: 0, timedOutRuns };
       }
 
       const deleted = await tx
@@ -506,20 +556,70 @@ export const cleanupExpiredQueueEntries$ = command(
 
       return {
         deletedCount: deleted.length,
-        timedOutCount: timedOut.length,
+        timedOutRuns,
       };
     });
     signal.throwIfAborted();
 
-    if (result.deletedCount === 0) {
-      return 0;
+    if (result.deletedCount > 0 || result.timedOutRuns.length > 0) {
+      L.debug("Cleaned up expired queue entries", {
+        count: result.deletedCount,
+        timedOut: result.timedOutRuns.length,
+      });
     }
+    return result;
+  },
+);
 
-    L.debug("Cleaned up expired queue entries", {
-      count: result.deletedCount,
-      timedOut: result.timedOutCount,
+export const cleanupQueuedRunLaunchOrphans$ = command(
+  async (
+    { set },
+    cutoff: Date,
+    signal: AbortSignal,
+  ): Promise<QueuedRunMaintenanceResult> => {
+    const writeDb = set(writeDb$);
+    const currentTime = nowDate();
+
+    const result = await writeDb.transaction(async (tx) => {
+      const timedOut = await tx
+        .update(agentRuns)
+        .set({
+          status: "timeout",
+          completedAt: currentTime,
+          error: QUEUED_RUN_LAUNCH_ORPHAN_REASON,
+        })
+        .where(
+          and(
+            eq(agentRuns.status, "queued"),
+            lt(agentRuns.createdAt, cutoff),
+            sql<boolean>`NOT EXISTS (
+              SELECT 1
+              FROM ${agentRunQueue}
+              WHERE ${agentRunQueue.runId} = ${agentRuns.id}
+            )`,
+          ),
+        )
+        .returning({
+          runId: agentRuns.id,
+          orgId: agentRuns.orgId,
+          userId: agentRuns.userId,
+        });
+      const timedOutRuns = await timedOutQueuedRunsWithMarkerNotifications(
+        tx,
+        timedOut,
+        QUEUED_RUN_LAUNCH_ORPHAN_REASON,
+      );
+
+      return { deletedCount: 0, timedOutRuns };
     });
-    return result.deletedCount;
+    signal.throwIfAborted();
+
+    if (result.timedOutRuns.length > 0) {
+      L.debug("Cleaned up queued run launch orphans", {
+        timedOut: result.timedOutRuns.length,
+      });
+    }
+    return result;
   },
 );
 

--- a/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
@@ -503,24 +503,46 @@ export const cleanupExpiredQueueEntries$ = command(
         .from(agentRunQueue)
         .where(lt(agentRunQueue.expiresAt, currentTime));
 
-      const timedOut = await tx
-        .update(agentRuns)
-        .set({
-          status: "timeout",
-          completedAt: currentTime,
-          error: QUEUED_RUN_EXPIRED_REASON,
+      const candidates = await tx
+        .select({
+          runId: agentRuns.id,
         })
+        .from(agentRuns)
         .where(
           and(
             inArray(agentRuns.id, expiredRunIds),
             eq(agentRuns.status, "queued"),
           ),
         )
-        .returning({
-          runId: agentRuns.id,
-          orgId: agentRuns.orgId,
-          userId: agentRuns.userId,
-        });
+        .orderBy(agentRuns.createdAt, agentRuns.id)
+        .for("update");
+      signal.throwIfAborted();
+
+      const candidateRunIds = candidates.map((candidate) => {
+        return candidate.runId;
+      });
+
+      const timedOut =
+        candidateRunIds.length === 0
+          ? []
+          : await tx
+              .update(agentRuns)
+              .set({
+                status: "timeout",
+                completedAt: currentTime,
+                error: QUEUED_RUN_EXPIRED_REASON,
+              })
+              .where(
+                and(
+                  inArray(agentRuns.id, candidateRunIds),
+                  eq(agentRuns.status, "queued"),
+                ),
+              )
+              .returning({
+                runId: agentRuns.id,
+                orgId: agentRuns.orgId,
+                userId: agentRuns.userId,
+              });
       const timedOutRuns = await timedOutQueuedRunsWithMarkerNotifications(
         tx,
         timedOut,
@@ -599,6 +621,7 @@ export const cleanupQueuedRunLaunchOrphans$ = command(
             )`,
           ),
         )
+        .orderBy(agentRuns.createdAt, agentRuns.id)
         .for("update");
       signal.throwIfAborted();
 

--- a/turbo/packages/api-contracts/src/contracts/test-cron-cleanup-sandboxes-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-cron-cleanup-sandboxes-state.ts
@@ -11,11 +11,13 @@ export const testCronCleanupSandboxesStateActionBodySchema = z
       "delete-run",
       "seed-runner-job",
       "seed-queue-entry",
+      "seed-queue-marker",
       "seed-export-job",
       "delete-export-job",
       "get-run",
       "get-runner-job",
       "get-queue-entry",
+      "get-queue-marker-revoker",
       "get-export-job",
     ]),
   })


### PR DESCRIPTION
## Summary

- Add queued launch-orphan cleanup for stale `queued` runs missing `agentRunQueue`.
- Align queued timeout cleanup with terminal side effects: run realtime updates, queue changed signal, queued chat marker revocation, and existing completion side effects.
- Add regression coverage for queued launch orphans, fresh queued rows within the grace window, and pending runs missing runner jobs.

Closes #19529

## Tests

- `pnpm --filter api exec vitest src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts --run`
- `pnpm turbo run lint --filter=api`
- `pnpm check-types`
- `pnpm knip --workspace api`
