### PR TITLE
fix: open chat thread emoji for staff orgs

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -2893,6 +2893,10 @@ describe("chat lifecycle", () => {
         screen.getAllByText("Current keyboard thread").length,
       ).toBeGreaterThan(0);
     });
+    const emojiButton = screen.getByLabelText("Change emoji");
+    expect(emojiButton).toHaveTextContent("");
+    expect(emojiButton.querySelector("svg")).not.toBeInTheDocument();
+    expect(emojiButton).toHaveClass("h-7", "w-7");
 
     const threadRegion = screen.getByLabelText("Chat thread");
     threadRegion.focus();

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -50,7 +50,6 @@ import {
   IconClock,
   IconCoins,
   IconHourglass,
-  IconMoodSmile,
 } from "@tabler/icons-react";
 import {
   cn,
@@ -1229,12 +1228,10 @@ function ChatThreadEmojiMenuButton({
                 aria-label="Change emoji"
                 className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
               >
-                {emoji ? (
+                {emoji && (
                   <span aria-hidden="true" className="text-base leading-none">
                     {emoji}
                   </span>
-                ) : (
-                  <IconMoodSmile size={16} stroke={1.8} />
                 )}
               </button>
             </UiDropdownMenuTrigger>

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -119,7 +119,7 @@ describe("getAllFeatureStates", () => {
       true,
     );
     expect(staffOrgStates[FeatureSwitchKey.ChatGithubPrTracking]).toBe(false);
-    expect(staffOrgStates[FeatureSwitchKey.ChatThreadEmoji]).toBe(false);
+    expect(staffOrgStates[FeatureSwitchKey.ChatThreadEmoji]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.AgentUnreadIndicators]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.HtmlArtifactCommentEditing]).toBe(
       false,
@@ -161,11 +161,9 @@ describe("getAllFeatureStates", () => {
     expect(states[FeatureSwitchKey.ChatGithubPrTracking]).toBe(true);
   });
 
-  it("should let individuals opt in to chat thread emoji", () => {
+  it("should enable chat thread emoji for staff orgs", () => {
     const states = getAllFeatureStates({
-      overrides: {
-        [FeatureSwitchKey.ChatThreadEmoji]: true,
-      },
+      orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
     });
     expect(states[FeatureSwitchKey.ChatThreadEmoji]).toBe(true);
   });

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -253,8 +253,9 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.ChatThreadEmoji]: {
     maintainer: "ethan@vm0.ai",
     description:
-      "Show the chat thread emoji icon in chat headers and enable the Shift+F2 emoji picker shortcut. Individuals opt in via feature-switch overrides.",
+      "Show the chat thread emoji icon in chat headers and enable the Shift+F2 emoji picker shortcut for staff orgs.",
     enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.MemoryViewer]: {
     maintainer: "lancy@vm0.ai",


### PR DESCRIPTION
## Summary
- enable `ChatThreadEmoji` for staff orgs via the existing org hash rollout path
- render an empty fixed-size emoji button when a thread has no emoji instead of showing a placeholder icon
- update feature switch and chat lifecycle coverage

## Verification
- `pnpm exec prettier --write packages/core/src/feature-switch.ts packages/core/src/__tests__/feature-switch.test.ts apps/platform/src/views/zero-page/zero-chat-thread-page.tsx apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx`
- `pnpm -F @vm0/core test src/__tests__/feature-switch.test.ts`
- `pnpm -F @vm0/app test src/views/zero-page/__tests__/chat-lifecycle.test.tsx -- --runInBand`
- `pnpm -F @vm0/core lint`
- `pnpm -F @vm0/core check-types`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app lint`

Note: the first concurrent `pnpm -F @vm0/app lint` attempt was killed during type-aware oxlint (`SIGKILL`); rerunning it by itself passed.