### PR TITLE
fix: update workflow automation tab routing

### DIFF
--- a/turbo/apps/platform/src/signals/automation-page/automation-detail-page-setup.ts
+++ b/turbo/apps/platform/src/signals/automation-page/automation-detail-page-setup.ts
@@ -3,7 +3,8 @@ import { createElement } from "react";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { ZeroAutomationDetailPage } from "../../views/zero-page/zero-automation-detail-page.tsx";
 import { updatePage$ } from "../react-router.ts";
-import { pathParams$ } from "../route.ts";
+import { detachedNavigateTo$, pathParams$ } from "../route.ts";
+import { ROUTES } from "../route-paths.ts";
 import { reloadChatThreads$ } from "../chat-page/chat-message.ts";
 import { fetchAllOrgAutomations$ } from "../zero-page/zero-automations.ts";
 import { fetchSlackChannels$ } from "../zero-page/slack-channels.ts";
@@ -15,7 +16,6 @@ import { initAutomationDetailTab$ } from "./automation-detail-tab.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
 import { featureSwitch$ } from "../external/feature-switch.ts";
-import { reloadWorkflows$ } from "../workflows-page/workflows-signals.ts";
 
 export const setupAutomationDetailPage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
@@ -23,16 +23,13 @@ export const setupAutomationDetailPage$ = command(
       return;
     }
 
-    set(updatePage$, createElement(ZeroAutomationDetailPage), "sidebar");
     const features = get(featureSwitch$);
     if (features[FeatureSwitchKey.WorkflowAutomation]) {
-      set(reloadWorkflows$);
-      signal.throwIfAborted();
-      await set(hideAppSkeleton$, signal);
-      set(reloadChatThreads$);
+      set(detachedNavigateTo$, ROUTES.automations, { replace: true });
       return;
     }
 
+    set(updatePage$, createElement(ZeroAutomationDetailPage), "sidebar");
     set(initAutomationDetailTab$);
     // Initialize run history with the current automation ID from the URL
     const params = get(pathParams$);

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -193,6 +193,18 @@ const ROUTE_CONFIG = [
     setup: setupAuthSidebarPageWrapper(setupWorkflowDetailPage$),
   },
   {
+    path: ROUTES.workflowDetailAutomations,
+    setup: setupAuthSidebarPageWrapper(setupWorkflowDetailPage$),
+  },
+  {
+    path: ROUTES.workflowDetailInstructions,
+    setup: setupAuthSidebarPageWrapper(setupWorkflowDetailPage$),
+  },
+  {
+    path: ROUTES.workflowDetailInfo,
+    setup: setupAuthSidebarPageWrapper(setupWorkflowDetailPage$),
+  },
+  {
     path: ROUTES.workflows,
     setup: setupAuthSidebarPageWrapper(setupWorkflowsPage$),
   },

--- a/turbo/apps/platform/src/signals/route-paths.ts
+++ b/turbo/apps/platform/src/signals/route-paths.ts
@@ -8,6 +8,9 @@ export const ROUTES = {
   agentPermissions: "/agents/:agentId/permissions",
   workflows: "/workflows",
   workflowDetail: "/workflows/:workflowId",
+  workflowDetailAutomations: "/workflows/:workflowId/automations",
+  workflowDetailInstructions: "/workflows/:workflowId/instructions",
+  workflowDetailInfo: "/workflows/:workflowId/info",
   activities: "/activities",
   activityInspect: "/activities/inspect",
   activityDetail: "/activities/:activityRunId",
@@ -47,3 +50,20 @@ export const ROUTES = {
 
 export type RouteKey = keyof typeof ROUTES;
 export type RoutePath = (typeof ROUTES)[RouteKey] | `/projects/${string}`;
+
+export type WorkflowDetailRouteKey =
+  | "workflowDetail"
+  | "workflowDetailAutomations"
+  | "workflowDetailInstructions"
+  | "workflowDetailInfo";
+
+export function isWorkflowDetailRouteKey(
+  route: RouteKey | null,
+): route is WorkflowDetailRouteKey {
+  return (
+    route === "workflowDetail" ||
+    route === "workflowDetailAutomations" ||
+    route === "workflowDetailInstructions" ||
+    route === "workflowDetailInfo"
+  );
+}

--- a/turbo/apps/platform/src/signals/workflows-page/workflow-detail-page-setup.ts
+++ b/turbo/apps/platform/src/signals/workflows-page/workflow-detail-page-setup.ts
@@ -9,7 +9,7 @@ import { updateDocumentTitle$ } from "../document-title.ts";
 import { featureSwitch$ } from "../external/feature-switch.ts";
 import { updatePage$ } from "../react-router.ts";
 import { detachedNavigateTo$ } from "../route.ts";
-import { ROUTES } from "../route-paths.ts";
+import { isWorkflowDetailRouteKey, ROUTES } from "../route-paths.ts";
 import { resetWorkflowDetailUiState$ } from "./workflows-signals.ts";
 import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
 
@@ -19,7 +19,7 @@ export const setupWorkflowDetailPage$ = command(
     const features = await get(featureSwitch$);
     signal.throwIfAborted();
     if (
-      route === "workflowDetail" &&
+      isWorkflowDetailRouteKey(route) &&
       !features[FeatureSwitchKey.WorkflowAutomation]
     ) {
       set(detachedNavigateTo$, ROUTES.home, { replace: true });

--- a/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
+++ b/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
@@ -22,10 +22,14 @@ import { activeRoute$ } from "../active-route.ts";
 import {
   detachedNavigateTo$,
   pathParams$,
-  replaceSearchParams$,
+  replacePathSilently$,
   searchParams$,
 } from "../route.ts";
-import { ROUTES } from "../route-paths.ts";
+import {
+  isWorkflowDetailRouteKey,
+  ROUTES,
+  type RouteKey,
+} from "../route-paths.ts";
 import { currentChatAgentRecordId$ } from "../agent-chat.ts";
 import { ensureDraft$ } from "../chat-page/create-chat-thread.ts";
 
@@ -62,21 +66,41 @@ type WorkflowWebhookTriggerSummary = Extract<
 type WorkflowGithubLabelActor =
   GithubLabelAppliedEventConfig["filters"]["actor"]["type"];
 export type WorkflowTriggerAutomationEntry = ZeroWorkflowTriggerAutomationEntry;
-export const WORKFLOW_DETAIL_TAB_PARAM = "tab";
 export const WORKFLOW_DETAIL_FILE_PARAM = "file";
 
-function workflowDetailTabFromSearchParams(
-  params: URLSearchParams,
-): WorkflowDetailTab | null {
-  const value = params.get(WORKFLOW_DETAIL_TAB_PARAM);
-  switch (value) {
-    case "automations":
-    case "instructions":
-    case "info": {
-      return value;
+function workflowDetailTabFromRoute(route: RouteKey | null): WorkflowDetailTab {
+  switch (route) {
+    case "workflowDetail":
+    case "workflowDetailAutomations": {
+      return "automations";
+    }
+    case "workflowDetailInstructions": {
+      return "instructions";
+    }
+    case "workflowDetailInfo": {
+      return "info";
     }
     default: {
-      return null;
+      return "automations";
+    }
+  }
+}
+
+export function workflowDetailRouteForTab(
+  tab: WorkflowDetailTab,
+):
+  | typeof ROUTES.workflowDetailAutomations
+  | typeof ROUTES.workflowDetailInstructions
+  | typeof ROUTES.workflowDetailInfo {
+  switch (tab) {
+    case "automations": {
+      return ROUTES.workflowDetailAutomations;
+    }
+    case "instructions": {
+      return ROUTES.workflowDetailInstructions;
+    }
+    case "info": {
+      return ROUTES.workflowDetailInfo;
     }
   }
 }
@@ -127,7 +151,7 @@ interface WorkflowMetadataPatch {
  */
 export const currentWorkflowId$ = computed((get): string | null => {
   const route = get(activeRoute$);
-  if (route !== "workflowDetail") {
+  if (!isWorkflowDetailRouteKey(route)) {
     return null;
   }
   const workflowId = get(pathParams$)?.workflowId;
@@ -238,18 +262,26 @@ export const resetWorkflowDetailUiState$ = command(({ set }) => {
 });
 
 export const workflowDetailActiveTab$ = computed((get) => {
-  return (
-    workflowDetailTabFromSearchParams(get(searchParams$)) ??
-    get(internalWorkflowDetailActiveTab$)
-  );
+  const route = get(activeRoute$);
+  if (isWorkflowDetailRouteKey(route)) {
+    return workflowDetailTabFromRoute(route);
+  }
+  return get(internalWorkflowDetailActiveTab$);
 });
 
 export const setWorkflowDetailActiveTab$ = command(
   ({ get, set }, tab: WorkflowDetailTab) => {
     set(internalWorkflowDetailActiveTab$, tab);
-    const params = new URLSearchParams(get(searchParams$));
-    params.set(WORKFLOW_DETAIL_TAB_PARAM, tab);
-    set(replaceSearchParams$, params);
+    const workflowId = get(currentWorkflowId$);
+    if (!workflowId) {
+      return;
+    }
+    set(
+      replacePathSilently$,
+      workflowDetailRouteForTab(tab),
+      { workflowId },
+      new URLSearchParams(),
+    );
   },
 );
 
@@ -354,14 +386,21 @@ export const selectedWorkflowFilePath$ = computed((get) => {
 export const setSelectedWorkflowFilePath$ = command(
   ({ get, set }, path: string | null) => {
     set(internalSelectedFilePath$, path);
-    const params = new URLSearchParams(get(searchParams$));
+    set(internalWorkflowDetailActiveTab$, "instructions");
+    const workflowId = get(currentWorkflowId$);
+    if (!workflowId) {
+      return;
+    }
+    const params = new URLSearchParams();
     if (path) {
       params.set(WORKFLOW_DETAIL_FILE_PARAM, path);
-    } else {
-      params.delete(WORKFLOW_DETAIL_FILE_PARAM);
     }
-    params.set(WORKFLOW_DETAIL_TAB_PARAM, "instructions");
-    set(replaceSearchParams$, params);
+    set(
+      replacePathSilently$,
+      ROUTES.workflowDetailInstructions,
+      { workflowId },
+      params,
+    );
   },
 );
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-mobile-breadcrumb.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-mobile-breadcrumb.ts
@@ -1,6 +1,6 @@
 import { computed } from "ccstate";
 import type { RoutePath } from "../../types/route.ts";
-import { ROUTES } from "../route-paths.ts";
+import { isWorkflowDetailRouteKey, ROUTES } from "../route-paths.ts";
 import { pathParams$, type RouterPathParams } from "../route.ts";
 import { activeRoute$ } from "../active-route.ts";
 import { agents$, defaultAgentId$ } from "../agent.ts";
@@ -169,7 +169,7 @@ export const mobileBreadcrumb$ = computed(
       return await get(automationBreadcrumb$);
     }
 
-    if (route === "workflows" || route === "workflowDetail") {
+    if (route === "workflows" || isWorkflowDetailRouteKey(route)) {
       return await get(workflowsBreadcrumb$);
     }
 

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -50,7 +50,7 @@ const TRIGGER_RUN_THREAD_ID = "00000000-0000-4000-a000-000000000301";
 type WorkflowDetailTestTab = "automations" | "instructions" | "info";
 
 function workflowDetailPath(tab: WorkflowDetailTestTab): string {
-  return `/workflows/${SALES_WORKFLOW_ID}?tab=${tab}`;
+  return `/workflows/${SALES_WORKFLOW_ID}/${tab}`;
 }
 
 function detachedSetupWorkflowDetailPage(
@@ -757,12 +757,14 @@ describe("workflows routes", () => {
   it("redirects the workspace workflow detail when workflows are disabled", async () => {
     detachedSetupPage({
       context,
-      path: `/workflows/${SALES_WORKFLOW_ID}`,
+      path: `/workflows/${SALES_WORKFLOW_ID}/automations`,
       featureSwitches: { [FeatureSwitchKey.WorkflowAutomation]: false },
     });
 
     await waitFor(() => {
-      expect(pathname()).not.toBe(`/workflows/${SALES_WORKFLOW_ID}`);
+      expect(pathname()).not.toBe(
+        `/workflows/${SALES_WORKFLOW_ID}/automations`,
+      );
     });
     expect(screen.queryByText("Workflow not found.")).not.toBeInTheDocument();
   });
@@ -793,7 +795,7 @@ describe("workflows routes", () => {
     const supportLink = screen.getByText("Support Intake").closest("a");
     expect(supportLink).toHaveAttribute(
       "href",
-      `/workflows/${OTHER_WORKFLOW_ID}`,
+      `/workflows/${OTHER_WORKFLOW_ID}/automations`,
     );
 
     expect(CREATE_WORKFLOW_WITH_CHAT_PROMPT).toContain(
@@ -873,7 +875,8 @@ describe("workflow detail page", () => {
     await waitFor(() => {
       expect(screen.getByText("Every weekday at 9:00 AM")).toBeInTheDocument();
     });
-    expect(search()).toBe("?tab=automations");
+    expect(pathname()).toBe(`/workflows/${SALES_WORKFLOW_ID}/automations`);
+    expect(search()).toBe("");
     expect(screen.getByText("Schedule")).toBeInTheDocument();
     expect(screen.getAllByText("Last run").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Next run").length).toBeGreaterThan(0);
@@ -891,7 +894,8 @@ describe("workflow detail page", () => {
         screen.getByText("Gather CRM context before outreach."),
       ).toBeInTheDocument();
     });
-    expect(search()).toBe("?tab=instructions");
+    expect(pathname()).toBe(`/workflows/${SALES_WORKFLOW_ID}/instructions`);
+    expect(search()).toBe("");
     click(screen.getByLabelText("Workflow files"));
     click(menuItemByText(/config\/settings\.json/));
     await waitFor(() => {
@@ -902,7 +906,8 @@ describe("workflow detail page", () => {
     expect(screen.getByLabelText("Workflow file content")).toHaveValue(
       '{ "risk": "low", "tone": "direct" }',
     );
-    expect(search()).toBe("?tab=instructions&file=config%2Fsettings.json");
+    expect(pathname()).toBe(`/workflows/${SALES_WORKFLOW_ID}/instructions`);
+    expect(search()).toBe("?file=config%2Fsettings.json");
   });
 
   it("ignores stale workflow instruction drafts without edit permission", async () => {
@@ -1081,7 +1086,7 @@ describe("workflow detail page", () => {
 
     click(buttonByText(/View target workflow/));
     await waitFor(() => {
-      expect(pathname()).toBe(`/workflows/${COPIED_WORKFLOW_ID}`);
+      expect(pathname()).toBe(`/workflows/${COPIED_WORKFLOW_ID}/automations`);
     });
   });
 
@@ -1270,14 +1275,16 @@ describe("workflow detail page", () => {
     await waitFor(() => {
       expect(screen.getAllByText("Visibility").length).toBeGreaterThan(0);
     });
-    expect(search()).toBe("?tab=info");
+    expect(pathname()).toBe(`/workflows/${SALES_WORKFLOW_ID}/info`);
+    expect(search()).toBe("");
     click(buttonByText("Instructions"));
     await waitFor(() => {
       expect(
         screen.getByText("Gather CRM context before outreach."),
       ).toBeInTheDocument();
     });
-    expect(search()).toBe("?tab=instructions");
+    expect(pathname()).toBe(`/workflows/${SALES_WORKFLOW_ID}/instructions`);
+    expect(search()).toBe("");
   });
 
   it("renders Gmail new message trigger match summaries", async () => {

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -1324,7 +1324,7 @@ function WorkflowCopySuccessState({
           description={`Open ${workflowTitle(copyState.workflow)} on ${workflowCopyAgentName(copyState.agent)}`}
           onClick={() => {
             onOpenChange(false);
-            navigate(ROUTES.workflowDetail, {
+            navigate(ROUTES.workflowDetailAutomations, {
               pathParams: {
                 workflowId: copyState.workflow.id,
               },

--- a/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
@@ -178,7 +178,7 @@ function WorkflowIndexCard({
 }) {
   return (
     <Link
-      pathname={ROUTES.workflowDetail}
+      pathname={ROUTES.workflowDetailAutomations}
       options={{
         pathParams: {
           workflowId: workflow.id,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-automations-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-automations-page.test.tsx
@@ -332,6 +332,14 @@ function linkByNameAndPath(name: string, path: string): HTMLAnchorElement {
   throw new Error(`${name} link to ${path} not found`);
 }
 
+function articleByText(text: string): HTMLElement {
+  const article = screen.getByText(text).closest("article");
+  if (!article) {
+    throw new Error(`${text} card not found`);
+  }
+  return article;
+}
+
 function selectOptionByLabel(
   label: string,
   option: string,
@@ -518,12 +526,10 @@ describe("zero automations page", () => {
 
     const opsLink = linkByNameAndPath(
       "Ops brief",
-      `/automations/${intervalWorkflowTrigger().id}`,
+      `/workflows/${workflowId}/automations`,
     );
-    const opsCard = opsLink.closest("article");
-    if (!opsCard) {
-      throw new Error("Ops brief card not found");
-    }
+    const opsCard = articleByText("Every 15 minutes");
+    expect(opsLink.closest("article")).toBe(opsCard);
     expect(within(opsCard).getByText("Zero")).toBeInTheDocument();
     expect(within(opsCard).getByText("Schedule")).toBeInTheDocument();
     expect(within(opsCard).getByText("Every 15 minutes")).toBeInTheDocument();
@@ -542,7 +548,7 @@ describe("zero automations page", () => {
 
     linkByNameAndPath(
       "Support intake",
-      `/automations/${webhookWorkflowTrigger().id}`,
+      `/workflows/${supportWorkflowId}/automations`,
     );
     expect(screen.getByText("Webhook")).toBeInTheDocument();
     expect(
@@ -551,13 +557,7 @@ describe("zero automations page", () => {
 
     click(within(opsCard).getByRole("switch", { name: "Disable Ops brief" }));
     await waitFor(() => {
-      const updatedOpsCard = linkByNameAndPath(
-        "Ops brief",
-        `/automations/${intervalWorkflowTrigger().id}`,
-      ).closest("article");
-      if (!updatedOpsCard) {
-        throw new Error("Updated ops brief card not found");
-      }
+      const updatedOpsCard = articleByText("Every 15 minutes");
       expect(
         within(updatedOpsCard).getByRole("switch", {
           name: "Enable Ops brief",
@@ -566,7 +566,7 @@ describe("zero automations page", () => {
     });
   });
 
-  it("opens a workflow-trigger automation detail when the workflow-trigger switch is enabled", async () => {
+  it("redirects workflow-trigger automation detail paths back to the list", async () => {
     mockWorkflowTriggerStory();
 
     detachedSetupPage({
@@ -578,18 +578,11 @@ describe("zero automations page", () => {
     });
 
     await waitFor(() => {
-      expect(
-        screen.getByRole("heading", { name: "Ops brief" }),
-      ).toBeInTheDocument();
+      expect(pathname()).toBe("/automations");
     });
-
-    expect(screen.queryByText("Automation not found")).not.toBeInTheDocument();
-    expect(screen.getByText("Active")).toBeInTheDocument();
-    expect(screen.getAllByText("Zero").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Schedule").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Every 15 minutes").length).toBeGreaterThan(0);
-    expect(screen.getByText(intervalWorkflowTrigger().id)).toBeInTheDocument();
-    linkByNameAndPath("View workflow", `/workflows/${workflowId}`);
+    expect(
+      screen.getByRole("heading", { name: "Automations" }),
+    ).toBeInTheDocument();
   });
 
   it("starts automation creation in chat after choosing an agent", async () => {
@@ -678,8 +671,8 @@ describe("zero automations page", () => {
     click(within(dialog).getByText("Ops brief"));
 
     await waitFor(() => {
-      expect(pathname()).toBe(`/workflows/${workflowId}`);
-      expect(search()).toBe("?tab=automations");
+      expect(pathname()).toBe(`/workflows/${workflowId}/automations`);
+      expect(search()).toBe("");
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx
@@ -19,12 +19,10 @@ import {
   IconLoader2,
   IconMail,
   IconMessageCircle,
-  IconPlayerPause,
   IconPlayerPlay,
   IconPlus,
   IconRepeat,
   IconTag,
-  IconTrash,
 } from "@tabler/icons-react";
 import { Button, Switch, cn } from "@vm0/ui";
 import {
@@ -49,15 +47,13 @@ import {
   workflowAutomationDialogOpen$,
 } from "../../signals/automation-page/workflow-trigger-automation-dialog.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
-import { detachedNavigateTo$, pathParams$ } from "../../signals/route.ts";
+import { detachedNavigateTo$ } from "../../signals/route.ts";
 import { ROUTES } from "../../signals/route-paths.ts";
 import {
   allWorkflowTriggerEntries$,
   allVisibleWorkflows$,
-  deleteWorkflowTrigger$,
   runWorkflowTriggerNow$,
   setWorkflowTriggerEnabled$,
-  WORKFLOW_DETAIL_TAB_PARAM,
   type WorkflowTriggerAutomationEntry,
 } from "../../signals/workflows-page/workflows-signals.ts";
 import {
@@ -68,12 +64,6 @@ import { userPreferences$ } from "../../signals/zero-page/settings/user-preferen
 import { pinnedAgentIds$ } from "../../signals/zero-page/zero-pinned-agents.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { Link } from "../router/link.tsx";
-import {
-  DetailPageBreadcrumbBar,
-  DetailPageHeader,
-  DetailPageMain,
-  DetailPageShell,
-} from "../components/detail-page-layout.tsx";
 import {
   AgentDialogAgentButton,
   agentDialogMatchesQuery,
@@ -317,14 +307,11 @@ function TriggerCardHeader({
         </p>
       </div>
       <Link
-        pathname={ROUTES.workflowDetail}
+        pathname={ROUTES.workflowDetailAutomations}
         options={{
           pathParams: {
             workflowId: entry.workflow.id,
           },
-          searchParams: new URLSearchParams({
-            [WORKFLOW_DETAIL_TAB_PARAM]: "automations",
-          }),
         }}
         className="inline-flex h-7 shrink-0 items-center gap-1 rounded-md px-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-gray-50 hover:text-foreground"
       >
@@ -347,14 +334,11 @@ function WorkflowAutomationTriggerCard({
   const running = runLoadable.state === "loading";
   const editLink = (
     <Link
-      pathname={ROUTES.workflowDetail}
+      pathname={ROUTES.workflowDetailAutomations}
       options={{
         pathParams: {
           workflowId: entry.workflow.id,
         },
-        searchParams: new URLSearchParams({
-          [WORKFLOW_DETAIL_TAB_PARAM]: "automations",
-        }),
       }}
       className="rounded-md px-1 py-1 text-sm font-medium text-muted-foreground underline-offset-4 transition-colors hover:text-foreground hover:underline"
     >
@@ -529,7 +513,7 @@ function TriggerListIcon({
   return (
     <span
       className={cn(
-        "row-span-2 flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-border/60",
+        "flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-border/60",
         tone,
       )}
       aria-hidden="true"
@@ -556,7 +540,7 @@ function WorkflowTriggerEnabledSwitch({
       checked={entry.trigger.enabled}
       disabled={busy || !entry.workflow.canManage}
       aria-label={`${entry.trigger.enabled ? "Disable" : "Enable"} ${title}`}
-      className="row-span-2 h-5 w-9 data-[state=checked]:bg-primary data-[state=unchecked]:bg-muted [&>span]:h-4 [&>span]:w-4 [&>span]:data-[state=checked]:translate-x-4"
+      className="h-6 w-11 data-[state=checked]:bg-primary data-[state=unchecked]:bg-muted [&>span]:h-5 [&>span]:w-5 [&>span]:data-[state=checked]:translate-x-5"
       onCheckedChange={(enabled) => {
         detach(
           setEnabled({ triggerId: entry.trigger.id, enabled }, pageSignal),
@@ -585,353 +569,40 @@ function WorkflowTriggerIndexCard({
   return (
     <article
       className={cn(
-        "zero-card grid min-w-0 grid-cols-[2.75rem_minmax(0,1fr)_auto] items-center gap-x-4 gap-y-1 px-5 py-4 transition-colors hover:bg-gray-50",
+        "zero-card relative flex min-w-0 items-center gap-4 px-5 py-5 transition-colors hover:bg-gray-50",
         !entry.trigger.enabled && "opacity-75",
       )}
     >
-      <TriggerListIcon trigger={entry.trigger} />
       <Link
-        pathname={ROUTES.automationDetail}
-        options={{ pathParams: { automationId: entry.trigger.id } }}
-        className="min-w-0 truncate text-sm font-medium text-foreground no-underline underline-offset-4 hover:underline"
+        pathname={ROUTES.workflowDetailAutomations}
+        options={{ pathParams: { workflowId: entry.workflow.id } }}
+        aria-label={`Open ${title} automations`}
+        className="absolute inset-0 z-0 rounded-[inherit] focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring"
       >
-        {title}
+        <span className="sr-only">{title}</span>
       </Link>
-      <WorkflowTriggerEnabledSwitch entry={entry} />
-      <div className="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-1 text-sm leading-5 text-muted-foreground">
-        <WorkflowAgentAvatar agent={agent} label={label} />
-        <span className="max-w-[10rem] truncate">{label}</span>
-        <span className="select-none text-muted-foreground/50">·</span>
-        <span>{triggerTypeLabel(entry.trigger)}</span>
-        <span className="select-none text-muted-foreground/50">·</span>
-        <span className="min-w-0 font-medium text-foreground/85">
-          {humanReadableTriggerRuleLabel(entry.trigger, displayTimezone)}
-        </span>
+      <div className="pointer-events-none relative z-10 shrink-0">
+        <TriggerListIcon trigger={entry.trigger} />
+      </div>
+      <div className="pointer-events-none relative z-10 min-w-0 flex-1">
+        <p className="min-w-0 truncate text-base font-semibold leading-6 text-foreground">
+          {title}
+        </p>
+        <div className="mt-1 flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-1 text-sm leading-5 text-muted-foreground">
+          <WorkflowAgentAvatar agent={agent} label={label} />
+          <span className="max-w-[10rem] truncate">{label}</span>
+          <span className="select-none text-muted-foreground/50">·</span>
+          <span>{triggerTypeLabel(entry.trigger)}</span>
+          <span className="select-none text-muted-foreground/50">·</span>
+          <span className="min-w-0 font-medium text-foreground/85">
+            {humanReadableTriggerRuleLabel(entry.trigger, displayTimezone)}
+          </span>
+        </div>
+      </div>
+      <div className="relative z-20 ml-auto shrink-0 pl-3">
+        <WorkflowTriggerEnabledSwitch entry={entry} />
       </div>
     </article>
-  );
-}
-
-function WorkflowTriggerDetailSkeleton() {
-  return (
-    <DetailPageShell>
-      <DetailPageBreadcrumbBar>
-        <Skeleton className="h-5 w-40 rounded-md" />
-        <span className="select-none text-muted-foreground/40">/</span>
-        <Skeleton className="h-5 w-32 rounded-md" />
-      </DetailPageBreadcrumbBar>
-      <DetailPageHeader>
-        <div className="flex min-w-0 items-center gap-4">
-          <Skeleton className="h-12 w-12 shrink-0 rounded-xl" />
-          <div className="min-w-0 flex-1 space-y-2">
-            <Skeleton className="h-5 w-56 max-w-full rounded-md" />
-            <Skeleton className="h-4 w-96 max-w-full rounded-md" />
-          </div>
-        </div>
-      </DetailPageHeader>
-      <DetailPageMain constrainContent>
-        <div className="grid gap-4">
-          <Skeleton className="h-40 w-full rounded-xl" />
-          <Skeleton className="h-28 w-full rounded-xl" />
-        </div>
-      </DetailPageMain>
-    </DetailPageShell>
-  );
-}
-
-function WorkflowTriggerAutomationNotFound() {
-  return (
-    <DetailPageShell>
-      <DetailPageBreadcrumbBar>
-        <Link
-          pathname={ROUTES.automations}
-          className="inline-flex min-w-0 items-center gap-1 rounded-md px-1.5 py-0.5 text-inherit no-underline transition-colors hover:bg-muted hover:text-foreground"
-        >
-          Automations
-        </Link>
-        <span className="select-none text-muted-foreground/40">/</span>
-        <span className="rounded-md px-1.5 py-0.5 font-medium text-foreground">
-          Automation
-        </span>
-      </DetailPageBreadcrumbBar>
-      <div className="flex flex-1 flex-col items-center justify-center gap-3 px-4 pb-20">
-        <p className="text-lg font-semibold text-foreground">
-          Automation not found
-        </p>
-        <p className="max-w-sm text-center text-sm text-muted-foreground">
-          This automation doesn&apos;t exist or was removed.
-        </p>
-        <Link
-          pathname={ROUTES.automations}
-          className="zero-btn-morandi mt-2 inline-flex items-center justify-center rounded-md border px-3 py-1.5 text-sm font-medium text-inherit no-underline hover:bg-accent"
-        >
-          Back to automations
-        </Link>
-      </div>
-    </DetailPageShell>
-  );
-}
-
-function WorkflowTriggerStatusDot({ enabled }: { readonly enabled: boolean }) {
-  return (
-    <span
-      className={cn(
-        "h-1.5 w-1.5 shrink-0 rounded-full",
-        enabled ? "bg-emerald-500" : "bg-muted-foreground/50",
-      )}
-      aria-hidden="true"
-    />
-  );
-}
-
-function WorkflowTriggerDetailActions({
-  entry,
-}: {
-  readonly entry: WorkflowTriggerAutomationEntry;
-}) {
-  const pageSignal = useGet(pageSignal$);
-  const navigate = useSet(detachedNavigateTo$);
-  const [runLoadable, runNow] = useLoadableSet(runWorkflowTriggerNow$);
-  const [enabledLoadable, setEnabled] = useLoadableSet(
-    setWorkflowTriggerEnabled$,
-  );
-  const [deleteLoadable, deleteTrigger] = useLoadableSet(
-    deleteWorkflowTrigger$,
-  );
-  const running = runLoadable.state === "loading";
-  const toggling = enabledLoadable.state === "loading";
-  const deleting = deleteLoadable.state === "loading";
-  const busy = running || toggling || deleting;
-  const canManage = entry.workflow.canManage;
-
-  return (
-    <div className="flex min-w-0 flex-wrap items-center gap-2">
-      <Link
-        pathname={ROUTES.workflowDetail}
-        options={{
-          pathParams: { workflowId: entry.workflow.id },
-          searchParams: new URLSearchParams({
-            [WORKFLOW_DETAIL_TAB_PARAM]: "automations",
-          }),
-        }}
-        className="zero-btn-morandi inline-flex h-9 shrink-0 items-center justify-center rounded-lg border px-3 text-sm font-medium text-inherit no-underline transition-colors hover:bg-accent"
-      >
-        View workflow
-      </Link>
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        className="zero-btn-morandi h-9 shrink-0 gap-2 rounded-lg border px-3"
-        disabled={busy}
-        onClick={() => {
-          detach(
-            runNow(entry.trigger.id, pageSignal),
-            Reason.DomCallback,
-            "run workflow trigger from automation detail",
-          );
-        }}
-      >
-        {running ? (
-          <IconLoader2 size={14} className="animate-spin" />
-        ) : (
-          <IconPlayerPlay size={14} stroke={1.5} />
-        )}
-        {running ? "Starting..." : "Run now"}
-      </Button>
-      {canManage ? (
-        <>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className="zero-btn-morandi h-9 shrink-0 gap-2 rounded-lg border px-3"
-            disabled={busy}
-            onClick={() => {
-              detach(
-                setEnabled(
-                  {
-                    triggerId: entry.trigger.id,
-                    enabled: !entry.trigger.enabled,
-                  },
-                  pageSignal,
-                ),
-                Reason.DomCallback,
-              );
-            }}
-          >
-            {toggling ? (
-              <IconLoader2 size={14} className="animate-spin" />
-            ) : entry.trigger.enabled ? (
-              <IconPlayerPause size={14} stroke={1.5} />
-            ) : (
-              <IconPlayerPlay size={14} stroke={1.5} />
-            )}
-            {entry.trigger.enabled ? "Pause" : "Resume"}
-          </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            className="h-9 shrink-0 gap-2 rounded-lg px-3 text-destructive/80 hover:bg-destructive/10 hover:text-destructive"
-            disabled={busy}
-            onClick={() => {
-              detach(
-                (async () => {
-                  await deleteTrigger(entry.trigger.id, pageSignal);
-                  navigate(ROUTES.automations);
-                })(),
-                Reason.DomCallback,
-              );
-            }}
-          >
-            {deleting ? (
-              <IconLoader2 size={14} className="animate-spin" />
-            ) : (
-              <IconTrash size={14} stroke={1.5} />
-            )}
-            {deleting ? "Deleting..." : "Delete"}
-          </Button>
-        </>
-      ) : null}
-    </div>
-  );
-}
-
-function WorkflowTriggerAutomationDetail({
-  entry,
-  displayTimezone,
-}: {
-  readonly entry: WorkflowTriggerAutomationEntry;
-  readonly displayTimezone: string;
-}) {
-  const title = workflowTitle(entry.workflow);
-  const agent = agentLabel(entry.workflow);
-  const triggerLabel = humanReadableTriggerRuleLabel(
-    entry.trigger,
-    displayTimezone,
-  );
-
-  return (
-    <DetailPageShell>
-      <DetailPageBreadcrumbBar>
-        <Link
-          pathname={ROUTES.automations}
-          className="inline-flex min-w-0 items-center gap-1 rounded-md px-1.5 py-0.5 text-inherit no-underline transition-colors hover:bg-muted hover:text-foreground"
-        >
-          Automations
-        </Link>
-        <span className="select-none text-muted-foreground/40">/</span>
-        <span className="min-w-0 truncate rounded-md px-1.5 py-0.5 font-medium text-foreground">
-          {title}
-        </span>
-      </DetailPageBreadcrumbBar>
-
-      <DetailPageHeader>
-        <div className="flex min-w-0 flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-          <div className="flex min-w-0 items-start gap-4">
-            <TriggerListIcon trigger={entry.trigger} />
-            <div className="min-w-0">
-              <h1 className="truncate text-lg font-semibold tracking-tight text-foreground sm:text-xl">
-                {title}
-              </h1>
-              <div className="mt-1.5 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-sm text-muted-foreground">
-                <span className="inline-flex items-center gap-1.5">
-                  <WorkflowTriggerStatusDot enabled={entry.trigger.enabled} />
-                  <span className="font-medium text-foreground">
-                    {entry.trigger.enabled ? "Active" : "Paused"}
-                  </span>
-                </span>
-                <span className="select-none text-muted-foreground/40">·</span>
-                <span className="truncate">{agent}</span>
-                <span className="select-none text-muted-foreground/40">·</span>
-                <span>{triggerTypeLabel(entry.trigger)}</span>
-              </div>
-              <p className="mt-1.5 line-clamp-2 text-sm text-muted-foreground">
-                {triggerLabel}
-              </p>
-            </div>
-          </div>
-          <WorkflowTriggerDetailActions entry={entry} />
-        </div>
-      </DetailPageHeader>
-
-      <DetailPageMain constrainContent>
-        <div className="grid gap-4">
-          <WorkflowTriggerCard
-            rows={triggerRows(entry.trigger, displayTimezone)}
-            dimmed={!entry.trigger.enabled}
-          />
-          <div className="zero-card overflow-hidden">
-            <dl className="px-5 py-1">
-              <div className="flex min-w-0 items-center justify-between gap-3 border-b border-border/50 py-3">
-                <dt className="shrink-0 text-sm text-muted-foreground">
-                  Workflow
-                </dt>
-                <dd className="min-w-0 truncate text-right text-sm font-medium text-foreground">
-                  {title}
-                </dd>
-              </div>
-              <div className="flex min-w-0 items-center justify-between gap-3 border-b border-border/50 py-3">
-                <dt className="shrink-0 text-sm text-muted-foreground">
-                  Agent
-                </dt>
-                <dd className="min-w-0 truncate text-right text-sm font-medium text-foreground">
-                  {agent}
-                </dd>
-              </div>
-              <div className="flex min-w-0 items-center justify-between gap-3 py-3">
-                <dt className="shrink-0 text-sm text-muted-foreground">
-                  Trigger ID
-                </dt>
-                <dd className="min-w-0 truncate text-right text-sm font-medium text-foreground">
-                  {entry.trigger.id}
-                </dd>
-              </div>
-            </dl>
-          </div>
-        </div>
-      </DetailPageMain>
-    </DetailPageShell>
-  );
-}
-
-export function WorkflowTriggerAutomationDetailPage() {
-  const params = useGet(pathParams$);
-  const triggerId =
-    params && typeof params === "object" && "automationId" in params
-      ? String(params.automationId)
-      : null;
-  const entriesLoadable = useLastLoadable(allWorkflowTriggerEntries$);
-  const prefsLoadable = useLastLoadable(userPreferences$);
-  const entries =
-    entriesLoadable.state === "hasData" ? entriesLoadable.data : [];
-  const displayTimezone =
-    prefsLoadable.state === "hasData" && prefsLoadable.data?.timezone
-      ? prefsLoadable.data.timezone
-      : new Intl.DateTimeFormat().resolvedOptions().timeZone;
-
-  if (!triggerId) {
-    return <WorkflowTriggerAutomationNotFound />;
-  }
-
-  if (entriesLoadable.state !== "hasData") {
-    return <WorkflowTriggerDetailSkeleton />;
-  }
-
-  const entry = entries.find((item) => {
-    return item.trigger.id === triggerId;
-  });
-
-  if (!entry) {
-    return <WorkflowTriggerAutomationNotFound />;
-  }
-
-  return (
-    <WorkflowTriggerAutomationDetail
-      entry={entry}
-      displayTimezone={displayTimezone}
-    />
   );
 }
 
@@ -1218,11 +889,8 @@ export function CreateWorkflowAutomationDialog() {
 
   const openWorkflowTriggers = (workflow: ZeroWorkflowSummary) => {
     setOpen(false);
-    navigate(ROUTES.workflowDetail, {
+    navigate(ROUTES.workflowDetailAutomations, {
       pathParams: { workflowId: workflow.id },
-      searchParams: new URLSearchParams({
-        [WORKFLOW_DETAIL_TAB_PARAM]: "automations",
-      }),
     });
   };
 

--- a/turbo/apps/platform/src/views/zero-page/zero-automation-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-automation-detail-page.tsx
@@ -3,7 +3,6 @@
 import { useGet, useSet, useLastLoadable } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { pageSignal$ } from "../../signals/page-signal.ts";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   IconCalendar,
   IconCircleDot,
@@ -102,8 +101,6 @@ import {
   automationTitle,
   automationTitleExcerpt,
 } from "../../signals/zero-page/automation-title.ts";
-import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
-import { WorkflowTriggerAutomationDetailPage } from "./workflow-trigger-automations-page.tsx";
 
 const AUTOMATION_DETAIL_TAB_TRIGGER_CLASS =
   "gap-1.5 text-sm data-[state=active]:bg-background px-3";
@@ -1020,11 +1017,6 @@ function AutomationActionsContainer({
 }
 
 export function ZeroAutomationDetailPage() {
-  const features = useGet(featureSwitch$);
-  if (features[FeatureSwitchKey.WorkflowAutomation]) {
-    return <WorkflowTriggerAutomationDetailPage />;
-  }
-
   return <LegacyZeroAutomationDetailPage />;
 }
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -238,7 +238,6 @@ import {
 import { LoadingSwitch } from "../components/loading-switch.tsx";
 import { Link } from "../router/link.tsx";
 import { ROUTES } from "../../signals/route-paths.ts";
-import { WORKFLOW_DETAIL_TAB_PARAM } from "../../signals/workflows-page/workflows-signals.ts";
 import {
   atTimeInTimezone,
   cronWallTimeInTimezone,
@@ -2433,14 +2432,11 @@ function HeaderWorkflowTriggerCard({
           {title}
         </p>
         <Link
-          pathname={ROUTES.workflowDetail}
+          pathname={ROUTES.workflowDetailAutomations}
           options={{
             pathParams: {
               workflowId: trigger.workflowId,
             },
-            searchParams: new URLSearchParams({
-              [WORKFLOW_DETAIL_TAB_PARAM]: "automations",
-            }),
           }}
           className="inline-flex h-7 shrink-0 items-center gap-1 rounded-md px-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-gray-50 hover:text-foreground"
         >
@@ -7035,7 +7031,7 @@ function WorkflowUserMessage({
           </div>
           {linked ? (
             <Link
-              pathname={ROUTES.workflowDetail}
+              pathname={ROUTES.workflowDetailAutomations}
               options={{
                 pathParams: {
                   workflowId,

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -88,7 +88,13 @@ const MANAGE_NAV: readonly ManageNavItem[] = [
   },
   {
     id: "workflows",
-    activeKeys: ["workflows", "workflowDetail"],
+    activeKeys: [
+      "workflows",
+      "workflowDetail",
+      "workflowDetailAutomations",
+      "workflowDetailInstructions",
+      "workflowDetailInfo",
+    ],
     pathname: "/workflows",
     label: "Workflows",
     icon: IconRoute as NavIcon,


### PR DESCRIPTION
## Summary
- route workflow detail tabs through path-style URLs: /workflows/:workflowId/automations, /instructions, and /info
- send workflow automation list cards and related workflow trigger links to the workflow detail automations tab
- remove the WorkflowAutomation-specific automation detail page and redirect /automations/:id back to the automation list when the switch is enabled

## Verification
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app exec vitest run src/views/workflows-page/__tests__/workflows-page.test.tsx src/views/zero-page/__tests__/zero-automations-page.test.tsx
- pnpm -F @vm0/app lint