### PR TITLE
test: isolate zero email outbox assertion

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -195,6 +195,7 @@ import { testOnboardingStatusStateRoutes } from "./routes/test-onboarding-status
 import { testMemoryStateRoutes } from "./routes/test-memory-state";
 import { testUsageInsightStateRoutes } from "./routes/test-usage-insight-state";
 import { testUsageStateRoutes } from "./routes/test-usage-state";
+import { testUserExportStateRoutes } from "./routes/test-user-export-state";
 import { testWorkflowTriggerStateRoutes } from "./routes/test-workflow-trigger-state";
 import { testChatMessagesStateRoutes } from "./routes/test-chat-messages-state";
 import { testWebhooksStateRoutes } from "./routes/test-webhooks-state";
@@ -398,6 +399,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...testMemoryStateRoutes,
   ...testUsageInsightStateRoutes,
   ...testUsageStateRoutes,
+  ...testUserExportStateRoutes,
   ...testWorkflowTriggerStateRoutes,
   ...testChatMessagesStateRoutes,
   ...testWebhooksStateRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-ops-logs.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-ops-logs.ts
@@ -1,6 +1,7 @@
 import type { z } from "zod";
 import { cronAggregateModelStatsContract } from "@vm0/api-contracts/contracts/cron";
 import { logsSearchContract } from "@vm0/api-contracts/contracts/runs";
+import type { TestUserExportStateActionBody } from "@vm0/api-contracts/contracts/test-user-export-state";
 import { userExportContract } from "@vm0/api-contracts/contracts/user-export";
 
 import { createApp } from "../../../../app-factory";
@@ -17,6 +18,7 @@ type AuthHeaders = { readonly authorization?: string };
 type LogsSearchQuery = z.input<(typeof logsSearchContract.searchLogs)["query"]>;
 
 const CRON_AUTHORIZATION = "Bearer test-cron-secret";
+const USER_EXPORT_STATE_ROUTE = "/api/test/user-export-state/action";
 
 interface ClerkUserProfile {
   readonly id: string;
@@ -60,6 +62,30 @@ function authenticate(
     data: [clerkUserProfile(nextActor)],
   });
   return { authorization: "Bearer clerk-session" };
+}
+
+async function postUserExportState(
+  body: TestUserExportStateActionBody,
+): Promise<void> {
+  const app = createApp({ signal: new AbortController().signal });
+  const response = await app.request(USER_EXPORT_STATE_ROUTE, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    throw new Error(`user export state action failed with ${response.status}`);
+  }
+}
+
+export async function cleanupUserExportState(
+  actor: ApiTestUser,
+): Promise<void> {
+  await postUserExportState({
+    action: "delete-user-export-state",
+    user_id: actor.userId,
+    email: actor.email,
+  });
 }
 
 export function createOpsLogsApi(context: TestContext) {

--- a/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
@@ -45,6 +45,10 @@ const trackUserExportActor = createFixtureTracker<ApiTestUser>(
   cleanupUserExportState,
 );
 
+interface DeferredS3Put {
+  readonly resolve: () => void;
+}
+
 async function createUserExportActor(
   bdd: ReturnType<typeof createBddApi>,
 ): Promise<ApiTestUser> {
@@ -52,6 +56,10 @@ async function createUserExportActor(
 }
 
 const context = testContext();
+const trackDeferredS3Put = createFixtureTracker<DeferredS3Put>((pendingPut) => {
+  pendingPut.resolve();
+  return Promise.resolve();
+});
 
 type UserExportStatusBody = Extract<
   Awaited<
@@ -723,7 +731,9 @@ describe("OPS-01: user data export", () => {
     });
 
     context.mocks.s3.getSignedUrl.mockResolvedValue(downloadUrl);
-    const pendingPut = api.deferS3PutOnce();
+    const pendingPut = await trackDeferredS3Put(
+      Promise.resolve(api.deferS3PutOnce()),
+    );
 
     const started = await api.requestPostUserExport(actor, [202]);
     expect(started.body.status).toBe("pending");

--- a/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
@@ -13,9 +13,13 @@ import {
   type ApiTestUser,
 } from "./helpers/api-bdd";
 import { createMiscRoutesApi } from "./helpers/api-bdd-misc";
-import { createOpsLogsApi } from "./helpers/api-bdd-ops-logs";
+import {
+  cleanupUserExportState,
+  createOpsLogsApi,
+} from "./helpers/api-bdd-ops-logs";
 import { createRunsAutomationsApi } from "./helpers/api-bdd-runs-automations";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
+import { createFixtureTracker } from "./helpers/zero-route-test";
 
 /*
  * OPS-01 run log search, BILL-02 model stats, and OPS-01 user export.
@@ -33,9 +37,22 @@ import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
  * from interrupted past runs in a colliding window cannot flake assertions.
  */
 
-const context = testContext();
 const HOUR_MS = 60 * 60_000;
 const DAY_MS = 24 * HOUR_MS;
+// Register before testContext(): Vitest runs afterEach hooks in stack order, so
+// this cleanup runs after testContext drains detached user-export work.
+const trackUserExportActor = createFixtureTracker<ApiTestUser>(
+  cleanupUserExportState,
+);
+
+async function createUserExportActor(
+  bdd: ReturnType<typeof createBddApi>,
+): Promise<ApiTestUser> {
+  return await trackUserExportActor(Promise.resolve(bdd.user()));
+}
+
+const context = testContext();
+
 type UserExportStatusBody = Extract<
   Awaited<
     ReturnType<ReturnType<typeof createOpsLogsApi>["requestGetUserExport"]>
@@ -693,7 +710,7 @@ describe("OPS-01: user data export", () => {
   it("exports user data end to end with active, cooldown, refresh, and latest-job visibility", async () => {
     const api = createOpsLogsApi(context);
     const bdd = createBddApi(context);
-    const actor = bdd.user();
+    const actor = await createUserExportActor(bdd);
     const exportStartAt = Date.UTC(2026, 4, 12, 5);
     const downloadUrl = "https://r2.example.com/bdd-export.zip?sig=test";
 
@@ -823,7 +840,7 @@ describe("OPS-01: user data export", () => {
   it("surfaces failed exports and allows an immediate retry", async () => {
     const api = createOpsLogsApi(context);
     const bdd = createBddApi(context);
-    const actor = bdd.user();
+    const actor = await createUserExportActor(bdd);
     const failedStartAt = Date.UTC(2026, 4, 20, 9);
 
     mockNow(failedStartAt);
@@ -869,7 +886,7 @@ describe("OPS-01: user data export", () => {
     const api = createOpsLogsApi(context);
     const bdd = createBddApi(context);
     const misc = createMiscRoutesApi(context);
-    const actor = bdd.user();
+    const actor = await createUserExportActor(bdd);
 
     await misc.requestEmailUnsubscribe(unsubscribeToken(actor.userId), [200]);
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-email.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-email.test.ts
@@ -1076,11 +1076,20 @@ describe("POST /api/zero/email/inbound", () => {
       from_address: "Zero <vm0@mail.example.com>",
     });
     expect(Array.isArray(outbox)).toBeTruthy();
-    const outboxItem = (outbox as EmailOutboxState[]).find((item) => {
+    const outboxItems = outbox as EmailOutboxState[];
+    const outboxItem = outboxItems.find((item) => {
+      const toAddresses = Array.isArray(item.toAddresses)
+        ? item.toAddresses
+        : [item.toAddresses];
       return (
-        item.toAddresses === fx.userEmail && item.subject === "Re: Continue"
+        item.subject === "Re: Continue" && toAddresses.includes(fx.userEmail)
       );
     });
+    if (!outboxItem) {
+      throw new Error(
+        `Expected invalid reply outbox email for ${fx.userEmail}`,
+      );
+    }
     expect(outboxItem).toMatchObject({
       toAddresses: fx.userEmail,
       subject: "Re: Continue",

--- a/turbo/apps/api/src/signals/routes/test-email-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-email-state.ts
@@ -23,7 +23,7 @@ import { userCache } from "@vm0/db/schema/user-cache";
 import { users } from "@vm0/db/schema/user";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
-import { and, asc, desc, eq, inArray, or } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, or, sql } from "drizzle-orm";
 
 import { request$ } from "../context/hono";
 import { bodyResultOf } from "../context/request";
@@ -109,18 +109,6 @@ function readStringArray(
   }
   return value.filter((item): item is string => {
     return typeof item === "string";
-  });
-}
-
-function includesEmailAddress(value: unknown, emailAddress: string): boolean {
-  if (typeof value === "string") {
-    return value === emailAddress;
-  }
-  if (!Array.isArray(value)) {
-    return false;
-  }
-  return value.some((item) => {
-    return item === emailAddress;
   });
 }
 
@@ -399,36 +387,18 @@ async function deleteOutboxForFixture(
   db: Db,
   fixture: EmailFixture,
 ): Promise<void> {
-  const fixtureOutboxRows = await db
-    .select({
-      id: emailOutbox.id,
-      fromAddress: emailOutbox.fromAddress,
-      toAddresses: emailOutbox.toAddresses,
-    })
-    .from(emailOutbox)
-    .where(
-      or(
-        eq(
-          emailOutbox.fromAddress,
-          `Zero <${fixture.orgSlug}@mail.example.com>`,
-        ),
+  await db.delete(emailOutbox).where(
+    or(
+      eq(emailOutbox.fromAddress, `Zero <${fixture.orgSlug}@mail.example.com>`),
+      and(
         eq(emailOutbox.fromAddress, VM0_OUTBOX_FROM),
+        sql`(
+            ${emailOutbox.toAddresses} = ${JSON.stringify(fixture.userEmail)}::jsonb
+            OR ${emailOutbox.toAddresses} @> ${JSON.stringify([fixture.userEmail])}::jsonb
+          )`,
       ),
-    );
-  const fixtureOutboxIds = fixtureOutboxRows
-    .filter((row) => {
-      return (
-        row.fromAddress !== VM0_OUTBOX_FROM ||
-        includesEmailAddress(row.toAddresses, fixture.userEmail)
-      );
-    })
-    .map((row) => {
-      return row.id;
-    });
-  if (fixtureOutboxIds.length === 0) {
-    return;
-  }
-  await db.delete(emailOutbox).where(inArray(emailOutbox.id, fixtureOutboxIds));
+    ),
+  );
 }
 
 async function deleteFixtureForAction(

--- a/turbo/apps/api/src/signals/routes/test-email-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-email-state.ts
@@ -41,6 +41,7 @@ const actionBody$ = bodyResultOf(testEmailStateContract.action);
 const CALLBACK_SECRET = "test-callback-secret";
 const REPLY_PATH = "/api/zero/email/callbacks/reply";
 const TRIGGER_PATH = "/api/zero/email/callbacks/trigger";
+const VM0_OUTBOX_FROM = "Zero <vm0@mail.example.com>";
 const OUTBOX_TEST_FROM = "Zero <bdd-outbox@mail.example.com>";
 const OUTBOX_TEST_CREATED_AT_OFFSET_MS = 10 * 60 * 1000;
 
@@ -108,6 +109,18 @@ function readStringArray(
   }
   return value.filter((item): item is string => {
     return typeof item === "string";
+  });
+}
+
+function includesEmailAddress(value: unknown, emailAddress: string): boolean {
+  if (typeof value === "string") {
+    return value === emailAddress;
+  }
+  if (!Array.isArray(value)) {
+    return false;
+  }
+  return value.some((item) => {
+    return item === emailAddress;
   });
 }
 
@@ -382,6 +395,42 @@ async function seedFixtureForAction(db: Db, signal: AbortSignal) {
   });
 }
 
+async function deleteOutboxForFixture(
+  db: Db,
+  fixture: EmailFixture,
+): Promise<void> {
+  const fixtureOutboxRows = await db
+    .select({
+      id: emailOutbox.id,
+      fromAddress: emailOutbox.fromAddress,
+      toAddresses: emailOutbox.toAddresses,
+    })
+    .from(emailOutbox)
+    .where(
+      or(
+        eq(
+          emailOutbox.fromAddress,
+          `Zero <${fixture.orgSlug}@mail.example.com>`,
+        ),
+        eq(emailOutbox.fromAddress, VM0_OUTBOX_FROM),
+      ),
+    );
+  const fixtureOutboxIds = fixtureOutboxRows
+    .filter((row) => {
+      return (
+        row.fromAddress !== VM0_OUTBOX_FROM ||
+        includesEmailAddress(row.toAddresses, fixture.userEmail)
+      );
+    })
+    .map((row) => {
+      return row.id;
+    });
+  if (fixtureOutboxIds.length === 0) {
+    return;
+  }
+  await db.delete(emailOutbox).where(inArray(emailOutbox.id, fixtureOutboxIds));
+}
+
 async function deleteFixtureForAction(
   db: Db,
   body: Record<string, unknown>,
@@ -392,17 +441,7 @@ async function deleteFixtureForAction(
     return actionBadRequest("fixture is required");
   }
 
-  await db
-    .delete(emailOutbox)
-    .where(
-      or(
-        eq(
-          emailOutbox.fromAddress,
-          `Zero <${fixture.orgSlug}@mail.example.com>`,
-        ),
-        eq(emailOutbox.fromAddress, "Zero <vm0@mail.example.com>"),
-      ),
-    );
+  await deleteOutboxForFixture(db, fixture);
   signal.throwIfAborted();
   await db
     .delete(emailSuppressions)

--- a/turbo/apps/api/src/signals/routes/test-user-export-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-user-export-state.ts
@@ -1,0 +1,115 @@
+import {
+  type TestUserExportStateActionBody,
+  testUserExportStateContract,
+} from "@vm0/api-contracts/contracts/test-user-export-state";
+import { emailOutbox } from "@vm0/db/schema/email-outbox";
+import { exportJobs } from "@vm0/db/schema/export-job";
+import { userCache } from "@vm0/db/schema/user-cache";
+import { users } from "@vm0/db/schema/user";
+import { command } from "ccstate";
+import { and, eq, sql } from "drizzle-orm";
+
+import { request$ } from "../context/hono";
+import { bodyResultOf } from "../context/request";
+import { writeDb$, type Db } from "../external/db";
+import type { RouteEntry } from "../route-entry";
+import {
+  isTestEndpointAllowed,
+  testEndpointNotFoundResponse,
+} from "./test-oauth-provider-helpers";
+
+const actionBody$ = bodyResultOf(testUserExportStateContract.action);
+const DATA_EXPORT_READY_SUBJECT = "Your data export is ready";
+const VM0_OUTBOX_FROM = "Zero <vm0@mail.example.com>";
+
+function actionOk(extra: Record<string, unknown> = {}) {
+  return {
+    status: 200 as const,
+    body: { ok: true as const, ...extra },
+  };
+}
+
+function actionBadRequest(error: string) {
+  return { status: 400 as const, body: { error } };
+}
+
+type UserExportStateAction = TestUserExportStateActionBody["action"];
+type UserExportStateActionResponse =
+  | ReturnType<typeof actionOk>
+  | ReturnType<typeof actionBadRequest>;
+type UserExportStateActionHandler = (
+  db: Db,
+  body: Record<string, unknown>,
+  signal: AbortSignal,
+) => Promise<UserExportStateActionResponse>;
+
+function readString(body: Record<string, unknown>, key: string): string | null {
+  const value = body[key];
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+async function deleteUserExportStateForAction(
+  db: Db,
+  body: Record<string, unknown>,
+  signal: AbortSignal,
+) {
+  const userId = readString(body, "user_id");
+  const email = readString(body, "email");
+  if (!userId || !email) {
+    return actionBadRequest("user_id and email are required");
+  }
+
+  await db.delete(emailOutbox).where(
+    and(
+      eq(emailOutbox.fromAddress, VM0_OUTBOX_FROM),
+      eq(emailOutbox.subject, DATA_EXPORT_READY_SUBJECT),
+      sql`(
+        ${emailOutbox.toAddresses} = ${JSON.stringify(email)}::jsonb
+        OR ${emailOutbox.toAddresses} @> ${JSON.stringify([email])}::jsonb
+      )`,
+    ),
+  );
+  signal.throwIfAborted();
+
+  await db.delete(exportJobs).where(eq(exportJobs.userId, userId));
+  signal.throwIfAborted();
+
+  await db.delete(userCache).where(eq(userCache.userId, userId));
+  signal.throwIfAborted();
+
+  await db.delete(users).where(eq(users.id, userId));
+  signal.throwIfAborted();
+
+  return actionOk();
+}
+
+const userExportStateActionHandlers = {
+  "delete-user-export-state": deleteUserExportStateForAction,
+} satisfies Record<UserExportStateAction, UserExportStateActionHandler>;
+
+const mutateTestUserExportState$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    if (!isTestEndpointAllowed(get(request$))) {
+      return testEndpointNotFoundResponse();
+    }
+    const bodyResult = await get(actionBody$);
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+
+    const body = bodyResult.data as Record<string, unknown>;
+    return await userExportStateActionHandlers[bodyResult.data.action](
+      set(writeDb$),
+      body,
+      signal,
+    );
+  },
+);
+
+export const testUserExportStateRoutes: readonly RouteEntry[] = [
+  {
+    route: testUserExportStateContract.action,
+    handler: mutateTestUserExportState$,
+  },
+];

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -455,6 +455,15 @@ export {
   type TestEmailStateContract,
 } from "./test-email-state";
 export {
+  testUserExportStateActionBodySchema,
+  testUserExportStateActionResponseSchema,
+  testUserExportStateContract,
+  testUserExportStateErrorSchema,
+  type TestUserExportStateActionBody,
+  type TestUserExportStateActionResponse,
+  type TestUserExportStateContract,
+} from "./test-user-export-state";
+export {
   testOnboardingStatusStateActionBodySchema,
   testOnboardingStatusStateActionResponseSchema,
   testOnboardingStatusStateContract,

--- a/turbo/packages/api-contracts/src/contracts/test-user-export-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-user-export-state.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+
+import { initContract } from "./base";
+
+const c = initContract();
+
+export const testUserExportStateActionBodySchema = z
+  .object({
+    action: z.enum(["delete-user-export-state"]),
+  })
+  .passthrough();
+
+export const testUserExportStateActionResponseSchema = z
+  .object({
+    ok: z.literal(true),
+  })
+  .passthrough();
+
+export const testUserExportStateErrorSchema = z.object({
+  error: z.string(),
+});
+
+export const testUserExportStateContract = c.router({
+  action: {
+    method: "POST",
+    path: "/api/test/user-export-state/action",
+    body: testUserExportStateActionBodySchema,
+    responses: {
+      200: testUserExportStateActionResponseSchema,
+      400: testUserExportStateErrorSchema,
+      404: z.string(),
+    },
+    summary: "Mutate or inspect user export test state",
+  },
+});
+
+export type TestUserExportStateActionBody = z.infer<
+  typeof testUserExportStateActionBodySchema
+>;
+export type TestUserExportStateActionResponse = z.infer<
+  typeof testUserExportStateActionResponseSchema
+>;
+export type TestUserExportStateContract = typeof testUserExportStateContract;


### PR DESCRIPTION
## Summary
- make the invalid reply-token test select the outbox row for its fixture recipient and subject
- avoid relying on the first row from the shared `Zero <vm0@mail.example.com>` outbox list
- narrow Zero email fixture cleanup with one atomic DB delete so concurrent tests do not lose unrelated `vm0` outbox rows

## Problem
The test could race with other API tests that enqueue data-export emails from the same sender address. When that row had a newer `createdAt`, the assertion picked the wrong outbox item and failed intermittently. The fixture cleanup also used to delete every `vm0` outbox row, which could pollute unrelated concurrent tests.

## Verification
- `pnpm -F @vm0/db db:migrate`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-email.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-email.test.ts src/signals/routes/__tests__/ops-logs.bdd.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- pre-commit hook: prettier, knip --cache, turbo check-types
