### PR TITLE
refactor: use guest runtime for checkpoint metadata

### DIFF
--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -7,6 +7,7 @@ use crate::env;
 use crate::error::AgentError;
 use crate::http::HttpClient;
 use crate::paths;
+use crate::run_context::GuestRuntime;
 use crate::session_history;
 use crate::session_history_identity::{
     FinalSessionHistoryIdentityBuildError, build_final_session_history_identity,
@@ -97,12 +98,51 @@ enum ArtifactSnapshotPlan<'a> {
     },
 }
 
+struct CheckpointInputs<'a> {
+    run_id: &'a str,
+    framework: env::Framework,
+    home_dir: &'a str,
+    artifact_entries: &'a [env::ArtifactEnv],
+    session_id_file: &'a str,
+    session_history_path_file: &'a str,
+    final_session_history_identity_file: &'a str,
+}
+
+impl<'a> CheckpointInputs<'a> {
+    fn from_runtime(runtime: &'a GuestRuntime) -> Self {
+        Self {
+            run_id: &runtime.config.run_id,
+            framework: runtime.config.framework,
+            home_dir: &runtime.config.home_dir,
+            artifact_entries: &runtime.config.artifacts,
+            session_id_file: runtime.paths.session_id_file(),
+            session_history_path_file: runtime.paths.session_history_path_file(),
+            final_session_history_identity_file: runtime
+                .paths
+                .final_session_history_identity_file(),
+        }
+    }
+
+    fn from_legacy_env() -> Self {
+        Self {
+            run_id: env::run_id(),
+            framework: env::Framework::from_env(),
+            home_dir: env::home_dir(),
+            artifact_entries: env::artifacts(),
+            session_id_file: paths::session_id_file(),
+            session_history_path_file: paths::session_history_path_file(),
+            final_session_history_identity_file: paths::final_session_history_identity_file(),
+        }
+    }
+}
+
 /// Prepare + upload the session history to S3 via a presigned URL. If the
 /// prepare endpoint reports `existing=true`, skip the upload (content-addressed
 /// dedup). Telemetry is recorded under `session_history_prepare` and
 /// `session_history_s3_upload` to match the pre-parallelization op names.
 async fn upload_session_history(
     http: &HttpClient,
+    run_id: &str,
     history_hash: &str,
     history_size: u64,
     history_bytes: Vec<u8>,
@@ -113,7 +153,7 @@ async fn upload_session_history(
         .post_json(
             url,
             &json!({
-                "runId": env::run_id(),
+                "runId": run_id,
                 "hash": history_hash,
                 "size": history_size,
             }),
@@ -190,6 +230,7 @@ async fn upload_session_history(
 /// receiver's canonical artifact snapshot schema.
 async fn snapshot_artifact_entries(
     http: &HttpClient,
+    run_id: &str,
     entries: &[env::ArtifactEnv],
 ) -> Result<Option<serde_json::Value>, AgentError> {
     if entries.is_empty() {
@@ -290,7 +331,7 @@ async fn snapshot_artifact_entries(
             "Creating VAS snapshot for artifact '{}'",
             entry.name
         );
-        let message = format!("Checkpoint from run {}", env::run_id());
+        let message = format!("Checkpoint from run {run_id}");
         let snapshot = artifact::create_snapshot(
             http,
             artifact::CreateSnapshotRequest {
@@ -298,7 +339,7 @@ async fn snapshot_artifact_entries(
                 files,
                 storage_name: &entry.name,
                 storage_type: "artifact",
-                run_id: env::run_id(),
+                run_id,
                 message: &message,
                 parent_version_id: &entry.version_id,
             },
@@ -322,8 +363,36 @@ async fn snapshot_artifact_entries(
 
 /// Create a checkpoint after a successful run.
 pub async fn create_checkpoint(http: &HttpClient) -> Result<(), AgentError> {
+    let inputs = CheckpointInputs::from_legacy_env();
+    create_checkpoint_with_inputs(http, &inputs).await
+}
+
+/// Create a checkpoint after a successful run using the explicit runtime snapshot.
+pub async fn create_checkpoint_for_runtime(runtime: &GuestRuntime) -> Result<(), AgentError> {
+    let inputs = CheckpointInputs::from_runtime(runtime);
+    create_checkpoint_with_inputs(&runtime.http, &inputs).await
+}
+
+/// Create a best-effort recovery checkpoint after an abnormal CLI exit.
+pub async fn create_recovery_checkpoint(http: &HttpClient) -> Result<(), AgentError> {
+    let inputs = CheckpointInputs::from_legacy_env();
+    create_recovery_checkpoint_with_inputs(http, &inputs).await
+}
+
+/// Create a best-effort recovery checkpoint using the explicit runtime snapshot.
+pub async fn create_recovery_checkpoint_for_runtime(
+    runtime: &GuestRuntime,
+) -> Result<(), AgentError> {
+    let inputs = CheckpointInputs::from_runtime(runtime);
+    create_recovery_checkpoint_with_inputs(&runtime.http, &inputs).await
+}
+
+async fn create_checkpoint_with_inputs(
+    http: &HttpClient,
+    inputs: &CheckpointInputs<'_>,
+) -> Result<(), AgentError> {
     let start = std::time::Instant::now();
-    let result = create_checkpoint_impl(http, CheckpointMode::Success).await;
+    let result = create_checkpoint_impl(http, CheckpointMode::Success, inputs).await;
     record_sandbox_op(
         CheckpointMode::Success.total_op(),
         start.elapsed(),
@@ -333,10 +402,12 @@ pub async fn create_checkpoint(http: &HttpClient) -> Result<(), AgentError> {
     result
 }
 
-/// Create a best-effort recovery checkpoint after an abnormal CLI exit.
-pub async fn create_recovery_checkpoint(http: &HttpClient) -> Result<(), AgentError> {
+async fn create_recovery_checkpoint_with_inputs(
+    http: &HttpClient,
+    inputs: &CheckpointInputs<'_>,
+) -> Result<(), AgentError> {
     let start = std::time::Instant::now();
-    let result = create_checkpoint_impl(http, CheckpointMode::Recovery).await;
+    let result = create_checkpoint_impl(http, CheckpointMode::Recovery, inputs).await;
     record_sandbox_op(
         CheckpointMode::Recovery.total_op(),
         start.elapsed(),
@@ -346,14 +417,10 @@ pub async fn create_recovery_checkpoint(http: &HttpClient) -> Result<(), AgentEr
     result
 }
 
-async fn create_checkpoint_impl(http: &HttpClient, mode: CheckpointMode) -> Result<(), AgentError> {
-    create_checkpoint_impl_with_artifacts(http, mode, env::artifacts()).await
-}
-
-async fn create_checkpoint_impl_with_artifacts(
+async fn create_checkpoint_impl(
     http: &HttpClient,
     mode: CheckpointMode,
-    artifact_entries: &[env::ArtifactEnv],
+    inputs: &CheckpointInputs<'_>,
 ) -> Result<(), AgentError> {
     log_info!(LOG_TAG, "Creating {}...", mode.log_label());
 
@@ -361,7 +428,7 @@ async fn create_checkpoint_impl_with_artifacts(
     // directly — an explicit `exists()` check would be a redundant stat plus a
     // TOCTOU race between check and read.
     let session_id_start = std::time::Instant::now();
-    let cli_agent_session_id = match std::fs::read_to_string(paths::session_id_file()) {
+    let cli_agent_session_id = match std::fs::read_to_string(inputs.session_id_file) {
         Ok(s) => s.trim().to_string(),
         Err(e) if e.kind() == ErrorKind::NotFound => {
             return Err(fail(
@@ -394,18 +461,22 @@ async fn create_checkpoint_impl_with_artifacts(
     // a literal jsonl path (Claude) or a codex marker. `session_history`
     // abstracts the difference and decompresses zstd-compressed codex sessions.
     let history_read_start = std::time::Instant::now();
-    let history_marker_payload =
-        match crate::session_metadata::resolve_history_marker_payload(&cli_agent_session_id) {
-            Ok(payload) => payload,
-            Err(e) => {
-                return Err(fail(
-                    mode,
-                    "session_history_read",
-                    history_read_start,
-                    e.to_string(),
-                ));
-            }
-        };
+    let history_marker_payload = match crate::session_metadata::resolve_history_marker_payload_from(
+        inputs.framework,
+        inputs.home_dir,
+        inputs.session_history_path_file,
+        &cli_agent_session_id,
+    ) {
+        Ok(payload) => payload,
+        Err(e) => {
+            return Err(fail(
+                mode,
+                "session_history_read",
+                history_read_start,
+                e.to_string(),
+            ));
+        }
+    };
     let history_bytes =
         match session_history::read_session_history_from_payload(&history_marker_payload) {
             Ok(b) => b,
@@ -481,14 +552,20 @@ async fn create_checkpoint_impl_with_artifacts(
     // (prepare + HEAD update). Serial, wall time was dominated by whichever
     // was longer plus the other; concurrent, it's just the longer one.
     let (_, artifact_snapshots) = tokio::try_join!(
-        upload_session_history(http, &history_hash, history_size, history_bytes),
-        snapshot_artifact_entries(http, artifact_entries),
+        upload_session_history(
+            http,
+            inputs.run_id,
+            &history_hash,
+            history_size,
+            history_bytes
+        ),
+        snapshot_artifact_entries(http, inputs.run_id, inputs.artifact_entries),
     )?;
 
     // Build and send checkpoint payload (session history hash only, content uploaded to S3)
-    let cli_agent_type = env::Framework::from_env().agent_type();
+    let cli_agent_type = inputs.framework.agent_type();
     let mut payload = json!({
-        "runId": env::run_id(),
+        "runId": inputs.run_id,
         "cliAgentType": cli_agent_type,
         "cliAgentSessionId": cli_agent_session_id,
         "cliAgentSessionHistoryHash": history_hash,
@@ -527,6 +604,8 @@ async fn create_checkpoint_impl_with_artifacts(
             &history_hash,
             history_size,
             &history_marker_payload,
+            inputs.framework,
+            inputs.final_session_history_identity_file,
         );
         log_info!(LOG_TAG, "{} created successfully: {id}", mode.log_label());
         record_sandbox_op("checkpoint_api_call", api_start.elapsed(), true, None);
@@ -547,12 +626,14 @@ fn write_final_session_history_identity(
     history_hash: &str,
     history_size: u64,
     history_marker_payload: &str,
+    framework: env::Framework,
+    final_session_history_identity_file: &str,
 ) {
     if !matches!(mode, CheckpointMode::Success) {
         return;
     }
     let identity = match build_final_session_history_identity(
-        env::Framework::from_env(),
+        framework,
         cli_agent_session_id,
         history_hash,
         history_size,
@@ -591,7 +672,7 @@ fn write_final_session_history_identity(
             return;
         }
     };
-    match paths::write_private(paths::final_session_history_identity_file(), bytes) {
+    match paths::write_private(final_session_history_identity_file, bytes) {
         Ok(()) => {
             record_sandbox_op(
                 "session_history_identity_written",
@@ -723,7 +804,7 @@ mod tests {
             missing_root_policy: None,
         }];
 
-        let err = snapshot_artifact_entries(&http, &entries)
+        let err = snapshot_artifact_entries(&http, "test-run", &entries)
             .await
             .unwrap_err();
 
@@ -760,7 +841,7 @@ mod tests {
             missing_root_policy: Some(ArtifactEntryMissingRootPolicy::Fail),
         }];
 
-        let err = snapshot_artifact_entries(&http, &entries)
+        let err = snapshot_artifact_entries(&http, "test-run", &entries)
             .await
             .unwrap_err();
 
@@ -809,7 +890,7 @@ mod tests {
             },
         ];
 
-        let err = snapshot_artifact_entries(&http, &entries)
+        let err = snapshot_artifact_entries(&http, "test-run", &entries)
             .await
             .unwrap_err();
 
@@ -846,7 +927,7 @@ mod tests {
             missing_root_policy: Some(ArtifactEntryMissingRootPolicy::PreserveParentVersion),
         }];
 
-        let snapshots = snapshot_artifact_entries(&http, &entries)
+        let snapshots = snapshot_artifact_entries(&http, "test-run", &entries)
             .await
             .unwrap()
             .unwrap();
@@ -892,7 +973,7 @@ mod tests {
             missing_root_policy: Some(ArtifactEntryMissingRootPolicy::PreserveParentVersion),
         }];
 
-        let err = snapshot_artifact_entries(&http, &entries)
+        let err = snapshot_artifact_entries(&http, "test-run", &entries)
             .await
             .unwrap_err();
 
@@ -956,7 +1037,17 @@ mod tests {
             missing_root_policy: None,
         }];
 
-        let err = create_checkpoint_impl_with_artifacts(&http, CheckpointMode::Success, &entries)
+        let inputs = CheckpointInputs {
+            run_id: "checkpoint-missing-mount",
+            framework: env::Framework::ClaudeCode,
+            home_dir: env::home_dir(),
+            artifact_entries: &entries,
+            session_id_file: paths::session_id_file(),
+            session_history_path_file: paths::session_history_path_file(),
+            final_session_history_identity_file: paths::final_session_history_identity_file(),
+        };
+
+        let err = create_checkpoint_impl(&http, CheckpointMode::Success, &inputs)
             .await
             .unwrap_err();
 

--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -77,12 +77,19 @@ pub(super) async fn execute_codex_app_server_for_runtime(
     let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel::<PreparedEvent>();
     let should_send_events = http.has_api();
     let event_http = http.clone();
+    let event_error_flag = runtime.event_error_flag.to_string();
     let event_sender = tokio::spawn(async move {
         let mut acked_prefix = AckedEventPrefix::default();
         while let Some(event) = event_rx.recv().await {
             match event {
                 PreparedEvent::Webhook { sequence, payload } => {
-                    match events::post_event(&event_http, &payload).await {
+                    match events::post_event_with_error_flag(
+                        &event_http,
+                        &payload,
+                        &event_error_flag,
+                    )
+                    .await
+                    {
                         Ok(()) => {
                             acked_prefix.record_success(sequence);
                         }

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -280,6 +280,7 @@ pub(super) struct CliRuntimeConfig<'a> {
     agent_log_file: Cow<'a, str>,
     session_id_file: Cow<'a, str>,
     session_history_path_file: Cow<'a, str>,
+    event_error_flag: Cow<'a, str>,
     user_env: &'a HashMap<String, String>,
 }
 
@@ -307,6 +308,7 @@ impl<'a> CliRuntimeConfig<'a> {
             agent_log_file: Cow::Borrowed(paths.agent_log_file()),
             session_id_file: Cow::Borrowed(paths.session_id_file()),
             session_history_path_file: Cow::Borrowed(paths.session_history_path_file()),
+            event_error_flag: Cow::Borrowed(paths.event_error_flag()),
             user_env: &config.user_env,
         }
     }
@@ -367,6 +369,7 @@ impl<'a> CliRuntimeConfig<'a> {
             agent_log_file: Cow::Borrowed(paths::agent_log_file()),
             session_id_file: Cow::Borrowed(paths::session_id_file()),
             session_history_path_file: Cow::Borrowed(paths::session_history_path_file()),
+            event_error_flag: Cow::Borrowed(paths::event_error_flag()),
             user_env: env::user_env(),
         }
     }
@@ -763,12 +766,19 @@ async fn execute_cli_inner(
     let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel::<PreparedEvent>();
     let should_send_events = http.has_api();
     let event_http = http.clone();
+    let event_error_flag = runtime.event_error_flag.to_string();
     let event_sender = tokio::spawn(async move {
         let mut acked_prefix = AckedEventPrefix::default();
         while let Some(event) = event_rx.recv().await {
             match event {
                 PreparedEvent::Webhook { sequence, payload } => {
-                    match events::post_event(&event_http, &payload).await {
+                    match events::post_event_with_error_flag(
+                        &event_http,
+                        &payload,
+                        &event_error_flag,
+                    )
+                    .await
+                    {
                         Ok(()) => {
                             acked_prefix.record_success(sequence);
                         }

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -396,6 +396,14 @@ fn truncate_diagnostic_message(message: &str) -> String {
 
 /// POST a prepared event payload to the webhook endpoint.
 pub async fn post_event(http: &HttpClient, payload: &Value) -> Result<(), AgentError> {
+    post_event_with_error_flag(http, payload, paths::event_error_flag()).await
+}
+
+pub async fn post_event_with_error_flag(
+    http: &HttpClient,
+    payload: &Value,
+    event_error_flag: &str,
+) -> Result<(), AgentError> {
     let url = http.events_url()?;
     match http
         .post_json(url, payload, constants::HTTP_MAX_RETRIES)
@@ -404,7 +412,7 @@ pub async fn post_event(http: &HttpClient, payload: &Value) -> Result<(), AgentE
         Ok(_) => Ok(()),
         Err(e) => {
             log_error!(LOG_TAG, "Failed to send event after retries");
-            let _ = paths::write_private(paths::event_error_flag(), "1");
+            let _ = paths::write_private(event_error_flag, "1");
             Err(e)
         }
     }

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -275,11 +275,11 @@ async fn execute(
     if let Err(e) = setup_working_dir(paths::CANONICAL_WORKING_DIR) {
         let msg = format!("Working dir setup failed: {e}");
         log_error!(LOG_TAG, "{msg}");
-        write_guest_error_file(&msg);
-        write_guest_failure_diagnostic(&base_failure_diagnostic_for_config(
-            config,
-            FailureClass::WorkingDirSetupFailed,
-        ));
+        write_guest_error_file(runtime_paths.checkpoint_error_file(), &msg);
+        write_guest_failure_diagnostic(
+            runtime_paths.failure_diagnostic_file(),
+            &base_failure_diagnostic_for_config(config, FailureClass::WorkingDirSetupFailed),
+        );
         record_sandbox_op("working_dir_setup", wd_start.elapsed(), false, Some(&msg));
         return 1;
     }
@@ -296,11 +296,11 @@ async fn execute(
             masker.mask_string(&e.to_string())
         );
         log_error!(LOG_TAG, "{msg}");
-        write_guest_error_file(&msg);
-        write_guest_failure_diagnostic(&base_failure_diagnostic_for_config(
-            config,
-            FailureClass::CliExecutionError,
-        ));
+        write_guest_error_file(runtime_paths.checkpoint_error_file(), &msg);
+        write_guest_failure_diagnostic(
+            runtime_paths.failure_diagnostic_file(),
+            &base_failure_diagnostic_for_config(config, FailureClass::CliExecutionError),
+        );
         return 1;
     }
 
@@ -343,6 +343,7 @@ async fn execute(
                 let msg = control_error.to_string();
                 let diagnostic = cli_result_failure_diagnostic_for_config(
                     config,
+                    runtime_paths,
                     FailureClass::CliExecutionError,
                     cli_exit_code,
                     cli_result.claude_result,
@@ -359,6 +360,7 @@ async fn execute(
                 );
                 let diagnostic = cli_result_failure_diagnostic_for_config(
                     config,
+                    runtime_paths,
                     FailureClass::CliNonzero,
                     cli_exit_code,
                     cli_result.claude_result,
@@ -376,7 +378,8 @@ async fn execute(
                 )
             } else if http.has_api() && is_claude_zero_turn_result(config.framework, &cli_result) {
                 let history_check_start = Instant::now();
-                let session_history_status = claude_history_target_status();
+                let session_history_status =
+                    claude_history_target_status_for_config(config, runtime_paths);
                 if session_history_unavailable(session_history_status) {
                     let msg = "Claude Code emitted a zero-turn result without creating session history; skipping checkpoint";
                     record_sandbox_op(
@@ -447,8 +450,7 @@ async fn execute(
             skip_recovery_checkpoint_for_no_history,
         },
         telemetry,
-        &http,
-        config,
+        runtime,
     )
     .await
 }
@@ -496,14 +498,16 @@ fn with_cli_termination(
 
 fn cli_result_failure_diagnostic_for_config(
     config: &env::GuestConfig,
+    runtime_paths: &paths::GuestPaths,
     failure_class: FailureClass,
     cli_exit_code: i32,
     claude_result: Option<cli::ClaudeResultSummary>,
 ) -> FailureDiagnostic {
     let mut diagnostic = base_failure_diagnostic_for_config(config, failure_class)
         .with_cli_exit_code(cli_exit_code)
-        .with_session_history_status(diagnostic_session_history_status_for_framework(
-            config.framework,
+        .with_session_history_status(diagnostic_session_history_status_for_config(
+            config,
+            runtime_paths,
         ));
     if let Some(result) = claude_result {
         diagnostic = diagnostic.with_claude_num_turns(result.num_turns);
@@ -805,11 +809,14 @@ fn has_exact_codex_oauth_connector(value: &Value) -> bool {
         })
 }
 
-fn diagnostic_session_history_status_for_framework(
-    framework: env::Framework,
+fn diagnostic_session_history_status_for_config(
+    config: &env::GuestConfig,
+    runtime_paths: &paths::GuestPaths,
 ) -> SessionHistoryStatus {
-    match framework {
-        env::Framework::ClaudeCode => claude_history_target_status(),
+    match config.framework {
+        env::Framework::ClaudeCode => {
+            claude_history_target_status_for_config(config, runtime_paths)
+        }
         env::Framework::Codex => SessionHistoryStatus::NotApplicable,
     }
 }
@@ -821,8 +828,16 @@ fn session_history_unavailable(status: SessionHistoryStatus) -> bool {
     )
 }
 
-fn claude_history_target_status() -> SessionHistoryStatus {
-    let marker = match session_metadata::resolve_history_marker_payload_for_diagnostics() {
+fn claude_history_target_status_for_config(
+    config: &env::GuestConfig,
+    runtime_paths: &paths::GuestPaths,
+) -> SessionHistoryStatus {
+    let marker = match session_metadata::resolve_history_marker_payload_for_diagnostics_from(
+        config.framework,
+        &config.home_dir,
+        runtime_paths.session_id_file(),
+        runtime_paths.session_history_path_file(),
+    ) {
         Ok(Some(marker)) => marker,
         Ok(None) => return SessionHistoryStatus::Missing,
         Err(_) => return SessionHistoryStatus::Unknown,
@@ -844,18 +859,18 @@ fn history_target_status(path: &Path) -> SessionHistoryStatus {
     }
 }
 
-fn write_guest_error_file(message: &str) {
+fn write_guest_error_file(checkpoint_error_file: &str, message: &str) {
     let message = message.trim();
     if message.is_empty() {
         return;
     }
 
-    if let Err(e) = paths::write_private(paths::checkpoint_error_file(), message) {
+    if let Err(e) = paths::write_private(checkpoint_error_file, message) {
         log_warn!(LOG_TAG, "Failed to write guest error file: {e}");
     }
 }
 
-fn write_guest_failure_diagnostic(diagnostic: &FailureDiagnostic) {
+fn write_guest_failure_diagnostic(failure_diagnostic_file: &str, diagnostic: &FailureDiagnostic) {
     let bytes = match serde_json::to_vec(diagnostic) {
         Ok(bytes) => bytes,
         Err(e) => {
@@ -864,7 +879,7 @@ fn write_guest_failure_diagnostic(diagnostic: &FailureDiagnostic) {
         }
     };
 
-    if let Err(e) = paths::write_private(paths::failure_diagnostic_file(), bytes) {
+    if let Err(e) = paths::write_private(failure_diagnostic_file, bytes) {
         log_warn!(
             LOG_TAG,
             "Failed to write guest failure diagnostic file: {e}"
@@ -978,36 +993,39 @@ async fn complete_execution(
     cli_elapsed: Duration,
     state: CompletionState<'_>,
     telemetry: &Telemetry,
-    http: &HttpClient,
-    config: &env::GuestConfig,
+    runtime: &GuestRuntime,
 ) -> i32 {
+    let config = &runtime.config;
+    let runtime_paths = &runtime.paths;
+    let http = &runtime.http;
     let has_failure_message = state
         .failure_message
         .is_some_and(|message| !message.trim().is_empty());
     if let Some(message) = state.failure_message {
-        write_guest_error_file(message);
+        write_guest_error_file(runtime_paths.checkpoint_error_file(), message);
     }
     let mut wrote_failure_diagnostic = false;
     if let Some(diagnostic) = &state.failure_diagnostic {
-        write_guest_failure_diagnostic(diagnostic);
+        write_guest_failure_diagnostic(runtime_paths.failure_diagnostic_file(), diagnostic);
         wrote_failure_diagnostic = true;
     }
 
     // Check if any events failed to send (before logging execution result)
-    if std::path::Path::new(paths::event_error_flag()).exists() {
+    if std::path::Path::new(runtime_paths.event_error_flag()).exists() {
         let msg = "Some events failed to send, marking run as failed";
         log_error!(LOG_TAG, "{msg}");
         if !has_failure_message {
-            write_guest_error_file(msg);
+            write_guest_error_file(runtime_paths.checkpoint_error_file(), msg);
         }
         if !wrote_failure_diagnostic {
             let diagnostic =
                 base_failure_diagnostic_for_config(config, FailureClass::EventUploadFailed)
                     .with_cli_exit_code(cli_exit_code)
-                    .with_session_history_status(diagnostic_session_history_status_for_framework(
-                        config.framework,
+                    .with_session_history_status(diagnostic_session_history_status_for_config(
+                        config,
+                        runtime_paths,
                     ));
-            write_guest_failure_diagnostic(&diagnostic);
+            write_guest_failure_diagnostic(runtime_paths.failure_diagnostic_file(), &diagnostic);
             wrote_failure_diagnostic = true;
         }
         exit_code = 1;
@@ -1031,7 +1049,7 @@ async fn complete_execution(
         log_info!(LOG_TAG, "▷ Checkpoint");
         let cp_start = Instant::now();
         let (cp_result, _) = tokio::join!(
-            checkpoint::create_checkpoint(http),
+            checkpoint::create_checkpoint_for_runtime(runtime),
             telemetry.flush(UploadMode::Live),
         );
         match cp_result {
@@ -1073,15 +1091,18 @@ async fn complete_execution(
                     "✗ Checkpoint failed ({}s)",
                     cp_start.elapsed().as_secs()
                 );
-                write_guest_error_file(&msg);
+                write_guest_error_file(runtime_paths.checkpoint_error_file(), &msg);
                 if !wrote_failure_diagnostic {
                     let diagnostic =
                         base_failure_diagnostic_for_config(config, FailureClass::CheckpointFailed)
                             .with_cli_exit_code(cli_exit_code)
                             .with_session_history_status(
-                                diagnostic_session_history_status_for_framework(config.framework),
+                                diagnostic_session_history_status_for_config(config, runtime_paths),
                             );
-                    write_guest_failure_diagnostic(&diagnostic);
+                    write_guest_failure_diagnostic(
+                        runtime_paths.failure_diagnostic_file(),
+                        &diagnostic,
+                    );
                 }
                 exit_code = 1;
 
@@ -1114,7 +1135,7 @@ async fn complete_execution(
                 );
             } else {
                 log_info!(LOG_TAG, "Attempting best-effort recovery checkpoint");
-                match checkpoint::create_recovery_checkpoint(http).await {
+                match checkpoint::create_recovery_checkpoint_for_runtime(runtime).await {
                     Ok(()) => log_info!(LOG_TAG, "Recovery checkpoint created"),
                     Err(e) => log_warn!(LOG_TAG, "Recovery checkpoint skipped: {e}"),
                 }
@@ -1235,6 +1256,14 @@ mod tests {
             ..env::GuestConfigRaw::default()
         })
         .unwrap()
+    }
+
+    fn test_guest_runtime(config: env::GuestConfig, http: HttpClient) -> GuestRuntime {
+        GuestRuntime {
+            config,
+            paths: paths::GuestPaths::from_runtime_dir(test_runtime_dir()),
+            http,
+        }
     }
 
     fn test_runtime_dir() -> std::path::PathBuf {
@@ -2835,6 +2864,7 @@ mod tests {
         let http = test_http_client(server);
         let telemetry = Telemetry::spawn(masker, http.clone());
         let config = test_guest_config(server, Some("/event-upload-failure"));
+        let runtime = test_guest_runtime(config, http.clone());
         let exit_code = complete_execution(
             0,
             0,
@@ -2846,8 +2876,7 @@ mod tests {
                 skip_recovery_checkpoint_for_no_history: false,
             },
             &telemetry,
-            &http,
-            &config,
+            &runtime,
         )
         .await;
         telemetry.shutdown().await;
@@ -2904,6 +2933,7 @@ mod tests {
         let http = test_http_client(server);
         let telemetry = Telemetry::spawn(masker, http.clone());
         let config = test_guest_config(server, Some("/checkpoint-failure"));
+        let runtime = test_guest_runtime(config, http.clone());
         let exit_code = complete_execution(
             0,
             0,
@@ -2915,8 +2945,7 @@ mod tests {
                 skip_recovery_checkpoint_for_no_history: false,
             },
             &telemetry,
-            &http,
-            &config,
+            &runtime,
         )
         .await;
         telemetry.shutdown().await;
@@ -2972,6 +3001,7 @@ mod tests {
         let http = test_http_client(server);
         let telemetry = Telemetry::spawn(masker, http.clone());
         let config = test_guest_config(server, Some("plain prompt"));
+        let runtime = test_guest_runtime(config, http.clone());
         let failure_message = "CLI failed before all events uploaded";
         let failure_diagnostic = FailureDiagnostic::new(
             FailureClass::CliNonzero,
@@ -2991,8 +3021,7 @@ mod tests {
                 skip_recovery_checkpoint_for_no_history: false,
             },
             &telemetry,
-            &http,
-            &config,
+            &runtime,
         )
         .await;
         telemetry.shutdown().await;
@@ -3051,6 +3080,7 @@ mod tests {
         let http = test_http_client(server);
         let telemetry = Telemetry::spawn(masker, http.clone());
         let config = test_guest_config(server, Some("/help"));
+        let runtime = test_guest_runtime(config, http.clone());
         let failure_message = "Claude Code emitted a zero-turn result without creating session history; skipping checkpoint";
         let failure_diagnostic = FailureDiagnostic::new(
             FailureClass::ClaudeZeroTurnNoHistory,
@@ -3071,8 +3101,7 @@ mod tests {
                 skip_recovery_checkpoint_for_no_history: true,
             },
             &telemetry,
-            &http,
-            &config,
+            &runtime,
         )
         .await;
         telemetry.shutdown().await;
@@ -3163,6 +3192,7 @@ mod tests {
         let http = test_http_client(server);
         let telemetry = Telemetry::spawn(masker, http.clone());
         let config = test_guest_config(server, Some("plain prompt"));
+        let runtime = test_guest_runtime(config, http.clone());
         let failure_message = "You've hit your usage limit.";
         let failure_diagnostic = FailureDiagnostic::new(
             FailureClass::CliNonzero,
@@ -3182,8 +3212,7 @@ mod tests {
                 skip_recovery_checkpoint_for_no_history: false,
             },
             &telemetry,
-            &http,
-            &config,
+            &runtime,
         )
         .await;
         telemetry.shutdown().await;

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -187,7 +187,8 @@ async fn run(runtime: GuestRuntime) -> i32 {
     let t = Instant::now();
     let metrics_handle = tokio::spawn({
         let shutdown = shutdown.clone();
-        async move { metrics::metrics_loop(shutdown).await }
+        let metrics_log_file = runtime.paths.metrics_log_file().to_string();
+        async move { metrics::metrics_loop_for_path(shutdown, metrics_log_file).await }
     });
     log_info!(LOG_TAG, "Metrics collector started");
     record_sandbox_op("metrics_collector_start", t.elapsed(), true, None);

--- a/crates/guest-agent/src/metrics.rs
+++ b/crates/guest-agent/src/metrics.rs
@@ -167,6 +167,14 @@ fn collect_metrics(cpu_tracker: &mut CpuTracker) -> MetricsEntry {
     }
 }
 
+fn write_metrics_entry(metrics_log_file: &str, entry: &MetricsEntry) {
+    if let Ok(json) = serde_json::to_string(entry)
+        && let Ok(mut f) = guest_contracts::runtime_paths::open_private_append(metrics_log_file)
+    {
+        let _ = writeln!(f, "{json}");
+    }
+}
+
 /// Background loop writing metrics JSONL every `METRICS_INTERVAL_SECS`.
 pub async fn metrics_loop(shutdown: CancellationToken) {
     metrics_loop_for_path(shutdown, paths::metrics_log_file().to_string()).await;
@@ -181,12 +189,7 @@ pub async fn metrics_loop_for_path(shutdown: CancellationToken, metrics_log_file
             _ = shutdown.cancelled() => break,
             _ = interval.tick() => {
                 let entry = collect_metrics(&mut cpu_tracker);
-                if let Ok(json) = serde_json::to_string(&entry)
-                    && let Ok(mut f) =
-                        guest_contracts::runtime_paths::open_private_append(&metrics_log_file)
-                {
-                    let _ = writeln!(f, "{json}");
-                }
+                write_metrics_entry(&metrics_log_file, &entry);
             }
         }
     }
@@ -399,8 +402,8 @@ mod tests {
         assert!(parsed["disk_total"].is_u64());
     }
 
-    #[tokio::test]
-    async fn metrics_loop_for_path_writes_to_explicit_path() {
+    #[test]
+    fn write_metrics_entry_writes_to_explicit_path() {
         let temp = tempfile::tempdir().unwrap();
         let metrics_log_file = temp
             .path()
@@ -409,27 +412,9 @@ mod tests {
             .to_string_lossy()
             .into_owned();
 
-        let shutdown = CancellationToken::new();
-        let handle = tokio::spawn(metrics_loop_for_path(
-            shutdown.clone(),
-            metrics_log_file.clone(),
-        ));
-
-        tokio::time::timeout(Duration::from_secs(1), async {
-            loop {
-                if let Ok(content) = std::fs::read_to_string(&metrics_log_file)
-                    && !content.trim().is_empty()
-                {
-                    break;
-                }
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .unwrap();
-
-        shutdown.cancel();
-        handle.await.unwrap();
+        let mut tracker = CpuTracker::new();
+        let entry = collect_metrics(&mut tracker);
+        write_metrics_entry(&metrics_log_file, &entry);
 
         let content = std::fs::read_to_string(metrics_log_file).unwrap();
         let first_line = content.lines().next().unwrap();

--- a/crates/guest-agent/src/metrics.rs
+++ b/crates/guest-agent/src/metrics.rs
@@ -169,6 +169,11 @@ fn collect_metrics(cpu_tracker: &mut CpuTracker) -> MetricsEntry {
 
 /// Background loop writing metrics JSONL every `METRICS_INTERVAL_SECS`.
 pub async fn metrics_loop(shutdown: CancellationToken) {
+    metrics_loop_for_path(shutdown, paths::metrics_log_file().to_string()).await;
+}
+
+/// Background loop writing metrics JSONL to an explicit runtime metrics file.
+pub async fn metrics_loop_for_path(shutdown: CancellationToken, metrics_log_file: String) {
     let mut interval = tokio::time::interval(Duration::from_secs(constants::METRICS_INTERVAL_SECS));
     let mut cpu_tracker = CpuTracker::new();
     loop {
@@ -176,11 +181,11 @@ pub async fn metrics_loop(shutdown: CancellationToken) {
             _ = shutdown.cancelled() => break,
             _ = interval.tick() => {
                 let entry = collect_metrics(&mut cpu_tracker);
-                if let Ok(json) = serde_json::to_string(&entry) {
-                    let path = paths::metrics_log_file();
-                    if let Ok(mut f) = guest_contracts::runtime_paths::open_private_append(path) {
-                        let _ = writeln!(f, "{json}");
-                    }
+                if let Ok(json) = serde_json::to_string(&entry)
+                    && let Ok(mut f) =
+                        guest_contracts::runtime_paths::open_private_append(&metrics_log_file)
+                {
+                    let _ = writeln!(f, "{json}");
                 }
             }
         }
@@ -392,5 +397,44 @@ mod tests {
         assert!(parsed["cpu"].is_f64());
         assert!(parsed["mem_total"].is_u64());
         assert!(parsed["disk_total"].is_u64());
+    }
+
+    #[tokio::test]
+    async fn metrics_loop_for_path_writes_to_explicit_path() {
+        let temp = tempfile::tempdir().unwrap();
+        let metrics_log_file = temp
+            .path()
+            .join("runtime")
+            .join("metrics.jsonl")
+            .to_string_lossy()
+            .into_owned();
+
+        let shutdown = CancellationToken::new();
+        let handle = tokio::spawn(metrics_loop_for_path(
+            shutdown.clone(),
+            metrics_log_file.clone(),
+        ));
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if let Ok(content) = std::fs::read_to_string(&metrics_log_file)
+                    && !content.trim().is_empty()
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+
+        shutdown.cancel();
+        handle.await.unwrap();
+
+        let content = std::fs::read_to_string(metrics_log_file).unwrap();
+        let first_line = content.lines().next().unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(first_line).unwrap();
+        assert!(parsed["ts"].is_string());
+        assert!(parsed["cpu"].is_f64());
     }
 }

--- a/crates/guest-agent/src/session_metadata.rs
+++ b/crates/guest-agent/src/session_metadata.rs
@@ -3,7 +3,6 @@
 //! Event capture writes run-scoped metadata files. Checkpoint and diagnostics
 //! resolve missing history markers from the stored session id when needed.
 
-use crate::env;
 use crate::env::Framework;
 use crate::error::AgentError;
 use crate::paths;
@@ -14,14 +13,6 @@ use std::io;
 use std::path::{Component, Path, PathBuf};
 
 const LOG_TAG: &str = "sandbox:guest-agent";
-
-pub(crate) fn history_marker_payload_for_session_id(session_id: &str) -> Option<String> {
-    history_marker_payload_for_session_id_with_home(
-        Framework::from_env(),
-        env::home_dir(),
-        session_id,
-    )
-}
 
 pub(crate) fn history_marker_payload_for_session_id_with_home(
     framework: Framework,
@@ -92,10 +83,6 @@ pub(crate) fn session_history_marker_kind(history_path_payload: &str) -> &'stati
     }
 }
 
-pub(crate) fn read_existing_history_marker_payload() -> io::Result<Option<String>> {
-    read_existing_history_marker_payload_from(paths::session_history_path_file())
-}
-
 pub(crate) fn read_existing_history_marker_payload_from(
     session_history_path_file: &str,
 ) -> io::Result<Option<String>> {
@@ -130,48 +117,57 @@ pub(crate) fn ensure_history_marker_payload_at(
     }
 }
 
-pub(crate) fn resolve_history_marker_payload(session_id: &str) -> Result<String, AgentError> {
-    match read_existing_history_marker_payload() {
+pub(crate) fn resolve_history_marker_payload_from(
+    framework: Framework,
+    home_dir: &str,
+    session_history_path_file: &str,
+    session_id: &str,
+) -> Result<String, AgentError> {
+    match read_existing_history_marker_payload_from(session_history_path_file) {
         Ok(Some(payload)) => return Ok(payload),
         Ok(None) => {}
         Err(e) => {
             return Err(AgentError::Checkpoint(format!(
                 "Failed to read history-path file {}: {e}",
-                paths::session_history_path_file()
+                session_history_path_file
             )));
         }
     }
 
-    let payload = history_marker_payload_for_session_id(session_id).ok_or_else(|| {
-        AgentError::Checkpoint(
-            "Failed to derive session history marker from session ID".to_string(),
-        )
-    })?;
-    write_session_history_marker(&payload);
+    let payload = history_marker_payload_for_session_id_with_home(framework, home_dir, session_id)
+        .ok_or_else(|| {
+            AgentError::Checkpoint(
+                "Failed to derive session history marker from session ID".to_string(),
+            )
+        })?;
+    write_session_history_marker_at(session_history_path_file, &payload);
     Ok(payload)
 }
 
-pub fn resolve_history_marker_payload_for_diagnostics() -> io::Result<Option<String>> {
-    if let Some(payload) = read_existing_history_marker_payload()? {
+pub fn resolve_history_marker_payload_for_diagnostics_from(
+    framework: Framework,
+    home_dir: &str,
+    session_id_file: &str,
+    session_history_path_file: &str,
+) -> io::Result<Option<String>> {
+    if let Some(payload) = read_existing_history_marker_payload_from(session_history_path_file)? {
         return Ok(Some(payload));
     }
 
-    match std::fs::read_to_string(paths::session_id_file()) {
+    match std::fs::read_to_string(session_id_file) {
         Ok(session_id) => {
             let session_id = session_id.trim();
             if session_id.is_empty() {
                 Ok(None)
             } else {
-                Ok(history_marker_payload_for_session_id(session_id))
+                Ok(history_marker_payload_for_session_id_with_home(
+                    framework, home_dir, session_id,
+                ))
             }
         }
         Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
         Err(e) => Err(e),
     }
-}
-
-pub(crate) fn write_session_history_marker(history_path_payload: &str) {
-    write_session_history_marker_at(paths::session_history_path_file(), history_path_payload);
 }
 
 pub(crate) fn write_session_history_marker_at(

--- a/crates/guest-agent/tests/integration/checkpoint.rs
+++ b/crates/guest-agent/tests/integration/checkpoint.rs
@@ -5,8 +5,34 @@ use guest_contracts::session_history_identity::{
 use httpmock::prelude::*;
 use serde_json::json;
 use sha2::{Digest, Sha256};
+use std::ffi::OsString;
 
 const LARGE_SESSION_HISTORY_SIZE_BYTES: usize = 1024 * 1024 + 1;
+
+struct EnvVarRestore {
+    key: &'static str,
+    value: Option<OsString>,
+}
+
+impl EnvVarRestore {
+    fn capture(key: &'static str) -> Self {
+        Self {
+            key,
+            value: std::env::var_os(key),
+        }
+    }
+}
+
+impl Drop for EnvVarRestore {
+    fn drop(&mut self) {
+        unsafe {
+            match &self.value {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
 
 fn write_derived_claude_history(session_id: &str, history: &str) -> Result<(), String> {
     guest_agent::paths::write_private(guest_agent::paths::session_id_file(), session_id)
@@ -189,6 +215,105 @@ async fn success_checkpoint_writes_large_final_identity_metadata() {
     assert_eq!(
         std::fs::read(&identity.history_marker_payload).unwrap(),
         history
+    );
+}
+
+#[tokio::test]
+async fn success_checkpoint_uses_explicit_runtime_after_process_env_changes() {
+    let api = SharedApiMock::new().await;
+    let server = api.server();
+    let _run_id_guard = EnvVarRestore::capture("VM0_RUN_ID");
+    let _runtime_dir_guard =
+        EnvVarRestore::capture(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV);
+
+    let tmp = tempfile::tempdir().unwrap();
+    let runtime_dir = tmp.path().join("captured-runtime");
+    let stale_runtime_dir = tmp.path().join("stale-runtime");
+    let home_dir = tmp.path().join("home");
+    let paths = guest_agent::paths::GuestPaths::from_runtime_dir(&runtime_dir);
+    let config = guest_agent::env::GuestConfig::from_raw(guest_agent::env::GuestConfigRaw {
+        run_id: "captured-run".to_string(),
+        api_url: server.base_url(),
+        api_token: "test-token-abc123".to_string(),
+        cli_agent_type: "claude-code".to_string(),
+        home: Some(home_dir.to_string_lossy().into_owned()),
+        guest_runtime_dir: Some(runtime_dir.clone()),
+        ..guest_agent::env::GuestConfigRaw::default()
+    })
+    .unwrap();
+    let final_identity_file = paths.final_session_history_identity_file().to_string();
+    let stale_paths = guest_agent::paths::GuestPaths::from_runtime_dir(&stale_runtime_dir);
+
+    let history = r#"{"type":"system"}"#.to_string() + "\n";
+    let history_path = tmp.path().join("history.jsonl");
+    std::fs::write(&history_path, &history).unwrap();
+    guest_agent::paths::write_private(paths.session_id_file(), "captured-session").unwrap();
+    guest_agent::paths::write_private(
+        paths.session_history_path_file(),
+        history_path.to_string_lossy().as_ref(),
+    )
+    .unwrap();
+
+    let runtime = guest_agent::run_context::GuestRuntime {
+        config,
+        paths,
+        http: http_client!(),
+    };
+
+    unsafe {
+        std::env::set_var("VM0_RUN_ID", "stale-run-after-runtime");
+        std::env::set_var(
+            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+            &stale_runtime_dir,
+        );
+    }
+
+    let history_hash = hex::encode(Sha256::digest(history.as_bytes()));
+    let prepare_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history")
+            .json_body(json!({
+                "runId": "captured-run",
+                "hash": history_hash,
+                "size": history.len(),
+            }));
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({
+                "presignedUrl": server.url("/test/explicit-runtime-history-upload"),
+                "existing": false
+            }));
+    });
+    let upload_mock = server.mock(|when, then| {
+        when.method(PUT)
+            .path("/test/explicit-runtime-history-upload")
+            .body(history.as_str());
+        then.status(200);
+    });
+    let checkpoint_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints")
+            .json_body_includes(r#"{"runId":"captured-run"}"#)
+            .json_body_includes(r#"{"cliAgentType":"claude-code"}"#)
+            .json_body_includes(r#"{"cliAgentSessionId":"captured-session"}"#);
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({"checkpointId": "checkpoint-explicit-runtime"}));
+    });
+
+    let result = guest_agent::checkpoint::create_checkpoint_for_runtime(&runtime).await;
+
+    assert!(result.is_ok());
+    prepare_mock.assert_calls_async(1).await;
+    upload_mock.assert_calls_async(1).await;
+    checkpoint_mock.assert_calls_async(1).await;
+    assert!(
+        std::path::Path::new(&final_identity_file).exists(),
+        "final identity should be written under explicit runtime paths"
+    );
+    assert!(
+        !std::path::Path::new(stale_paths.final_session_history_identity_file()).exists(),
+        "stale process env runtime path must not receive final identity"
     );
 }
 

--- a/crates/guest-agent/tests/integration/support.rs
+++ b/crates/guest-agent/tests/integration/support.rs
@@ -199,6 +199,7 @@ fn cleanup_session_checkpoint_files() {
     let _ = std::fs::remove_file(guest_agent::paths::final_session_history_identity_file());
     let _ = std::fs::remove_file(guest_agent::paths::checkpoint_error_file());
     let _ = std::fs::remove_file(guest_agent::paths::failure_diagnostic_file());
+    let _ = std::fs::remove_file(guest_agent::paths::event_error_flag());
 }
 
 pub(crate) struct SessionCheckpointFilesGuard;


### PR DESCRIPTION
## Summary
- Route checkpoint, recovery checkpoint, failure diagnostics, and event error flag writes through captured `GuestRuntime` paths/config.
- Add explicit session metadata helpers that accept framework, home dir, and runtime file paths, and remove unused legacy facades.
- Cover runtime path capture with an integration test that mutates process env after runtime construction.

## Tests
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --quiet --manifest-path crates/Cargo.toml -p guest-agent --lib session_metadata::tests -- --test-threads=1`
- `cargo test --quiet --manifest-path crates/Cargo.toml -p guest-agent --test integration checkpoint -- --test-threads=1`
- `cargo test --quiet --manifest-path crates/Cargo.toml -p guest-agent --test integration events -- --test-threads=1`
- `cargo test --quiet --manifest-path crates/Cargo.toml -p guest-agent --tests`
- pre-commit: cargo fmt, cargo doc, cargo clippy

Closes #19502