### PR TITLE
test: harden Codex API-key auth setup coverage

### DIFF
--- a/crates/guest-agent/tests/codex_setup_api_key_reconcile.rs
+++ b/crates/guest-agent/tests/codex_setup_api_key_reconcile.rs
@@ -5,6 +5,8 @@
 
 use guest_agent::masker::SecretMasker;
 use serde_json::Value;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt as _;
 use std::path::Path;
 use std::time::Duration;
 
@@ -53,7 +55,23 @@ async fn api_key_setup_writes_auth_without_invoking_codex() -> TestResult {
     .await
     .expect("codex auth setup should return promptly")?;
 
-    let auth_path = tmp.path().join(".codex").join("auth.json");
+    let codex_home = tmp.path().join(".codex");
+    let auth_path = codex_home.join("auth.json");
+    assert!(codex_home.is_dir(), ".codex must be created");
+    #[cfg(unix)]
+    {
+        let codex_home_mode = std::fs::metadata(&codex_home)?.permissions().mode() & 0o7777;
+        assert_eq!(
+            codex_home_mode, 0o700,
+            ".codex must be mode 0o700 (got {codex_home_mode:o})"
+        );
+        let auth_mode = std::fs::metadata(&auth_path)?.permissions().mode() & 0o7777;
+        assert_eq!(
+            auth_mode, 0o600,
+            "auth.json must be mode 0o600 (got {auth_mode:o})"
+        );
+    }
+
     let auth: Value = serde_json::from_str(&std::fs::read_to_string(auth_path)?)?;
     assert_eq!(auth["auth_mode"], "apikey");
     assert_eq!(auth["OPENAI_API_KEY"], "sk-test-api-key-reconcile");


### PR DESCRIPTION
## Summary
- add API-key Codex setup assertions for .codex and auth.json permissions
- keep the coverage deterministic with the existing fake external codex binary
- avoid any real Codex CLI install or CI workflow changes

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all
- cargo test --manifest-path crates/Cargo.toml -p guest-agent --test codex_setup_api_key_reconcile
- cargo test --manifest-path crates/Cargo.toml -p guest-agent --test codex_setup_no_auth_reconcile --test codex_setup_fail_closed
- cargo test --manifest-path crates/Cargo.toml -p guest-agent codex_auth
- git diff --check

Closes #19474