### PR TITLE
refactor: centralize usage reporting context

### DIFF
--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -22,11 +22,11 @@ from body_limits import (
     REQUEST_BODY_BILLING_INSPECTION_LIMIT,
 )
 from logging_utils import log_proxy_entry
-from platform_api import get_api_url
 
 from ...buffer import UsageEvent, buffer_usage_events
 from ...idempotency import USAGE_EVENT_NAMESPACE_CONNECTOR, derive_usage_idempotency_key
 from ...json_selective import JsonExtractionResult, JsonSelectiveExtractor, ScalarField
+from ...reporting_context import usage_reporting_context
 from ...underbilling import log_usage_underbilling
 from .response_parser import ConnectorResponseParser
 from .x_billing import (
@@ -1059,22 +1059,20 @@ def report_usage(flow: http.HTTPFlow, run_id: str, original_url: str) -> None:
     if not billable_counts:
         return
 
-    sandbox_token = flow.metadata.get(metadata_keys.VM_SANDBOX_AUTH_KEY, "")
-    api_url = get_api_url()
-    if not sandbox_token or not api_url:
+    reporting_context = usage_reporting_context(flow)
+    if not reporting_context.is_complete:
         log_usage_underbilling(
-            proxy_log_path,
+            reporting_context.proxy_log_path,
             "Cannot report usage event: missing sandbox_token or api_url",
             "missing_reporting_context",
             "confirmed",
             run_id=run_id,
             firewall_name=firewall_name,
             permission=permission,
-            missing_sandbox_token=not bool(sandbox_token),
-            missing_api_url=not bool(api_url),
+            missing_sandbox_token=reporting_context.missing_sandbox_token,
+            missing_api_url=reporting_context.missing_api_url,
         )
         return
-    url = f"{api_url}/api/webhooks/agent/usage-event"
     events: list[UsageEvent] = []
     for category, qty in billable_counts.items():
         # UUIDv5 from stable source inputs. The usage buffer uses this key to
@@ -1092,4 +1090,10 @@ def report_usage(flow: http.HTTPFlow, run_id: str, original_url: str) -> None:
                 "quantity": qty,
             }
         )
-    buffer_usage_events(url, sandbox_token, run_id, events, proxy_log_path)
+    buffer_usage_events(
+        reporting_context.usage_event_url(),
+        reporting_context.sandbox_token,
+        run_id,
+        events,
+        reporting_context.proxy_log_path,
+    )

--- a/crates/runner/mitm-addon/src/usage/providers/model_provider.py
+++ b/crates/runner/mitm-addon/src/usage/providers/model_provider.py
@@ -23,7 +23,6 @@ from mitmproxy import http
 import flow_metadata
 import flow_metadata_keys as metadata_keys
 from logging_utils import log_proxy_entry
-from platform_api import get_api_url
 
 from ..buffer import (
     UsageEvent,
@@ -38,6 +37,7 @@ from ..idempotency import (
     derive_usage_idempotency_key,
 )
 from ..model_tokens import MODEL_USAGE_CATEGORIES
+from ..reporting_context import UsageReportingContext, usage_reporting_context
 from ..underbilling import log_usage_underbilling
 
 MODEL_USAGE_KIND = "model"
@@ -89,30 +89,7 @@ def report_model_provider_usage(flow: http.HTTPFlow, run_id: str) -> bool:
     events = _build_model_provider_usage_events(flow, run_id, USAGE_EVENT_NAMESPACE_MODEL)
     if not events:
         return False
-    sandbox_token = flow.metadata.get(metadata_keys.VM_SANDBOX_AUTH_KEY, "")
-    api_url = get_api_url() if sandbox_token else ""
-    proxy_log_path = flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, "")
-    if not sandbox_token or not api_url:
-        log_usage_underbilling(
-            proxy_log_path,
-            "Cannot report usage event: missing sandbox_token or api_url",
-            "missing_reporting_context",
-            "confirmed",
-            run_id=run_id,
-            firewall_name=firewall_name,
-            missing_sandbox_token=not bool(sandbox_token),
-            missing_api_url=not bool(api_url),
-        )
-        return False
-    url = f"{api_url}/api/webhooks/agent/usage-event"
-    buffer_usage_events(
-        url,
-        sandbox_token,
-        run_id,
-        events,
-        proxy_log_path,
-    )
-    return True
+    return _buffer_model_provider_usage_events(flow, run_id, firewall_name, events)
 
 
 def report_model_provider_usage_observation(flow: http.HTTPFlow, run_id: str) -> bool:
@@ -145,26 +122,7 @@ def report_model_provider_usage_observation(flow: http.HTTPFlow, run_id: str) ->
     events = _build_model_provider_usage_events(flow, run_id, USAGE_OBSERVATION_NAMESPACE_MODEL)
     if not events:
         return False
-    sandbox_token = flow.metadata.get(metadata_keys.VM_SANDBOX_AUTH_KEY, "")
-    api_url = get_api_url() if sandbox_token else ""
-    proxy_log_path = flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, "")
-    if not sandbox_token or not api_url:
-        log_proxy_entry(
-            proxy_log_path,
-            "warn",
-            "Cannot report model usage observation: missing sandbox_token or api_url",
-            type="model_usage_observation",
-        )
-        return False
-    url = f"{api_url}/api/webhooks/agent/model-usage-observation"
-    buffer_model_usage_observations(
-        url,
-        sandbox_token,
-        run_id,
-        events,
-        proxy_log_path,
-    )
-    return True
+    return _buffer_model_provider_usage_observations(flow, run_id, events)
 
 
 def report_model_provider_usage_source(
@@ -205,50 +163,113 @@ def report_model_provider_usage_source(
             USAGE_OBSERVATION_NAMESPACE_MODEL,
         )
 
-    sandbox_token = flow.metadata.get(metadata_keys.VM_SANDBOX_AUTH_KEY, "")
-    api_url = get_api_url() if sandbox_token else ""
-    proxy_log_path = flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, "")
     if not usage_events and not observation_events:
         return
 
-    if not sandbox_token or not api_url:
+    context = usage_reporting_context(flow)
+    if not context.is_complete:
         if usage_events:
             firewall_name = flow_metadata.get_firewall_name_metadata(flow.metadata)
-            log_usage_underbilling(
-                proxy_log_path,
-                "Cannot report usage event: missing sandbox_token or api_url",
-                "missing_reporting_context",
-                "confirmed",
-                run_id=run_id,
-                firewall_name=firewall_name,
-                missing_sandbox_token=not bool(sandbox_token),
-                missing_api_url=not bool(api_url),
-            )
+            _log_usage_reporting_context_missing(context, run_id, firewall_name)
         if observation_events:
-            log_proxy_entry(
-                proxy_log_path,
-                "warn",
-                "Cannot report model usage observation: missing sandbox_token or api_url",
-                type="model_usage_observation",
-            )
+            _log_model_usage_observation_context_missing(context)
         return
 
     if usage_events:
-        buffer_source_usage_events(
-            f"{api_url}/api/webhooks/agent/usage-event",
-            sandbox_token,
-            run_id,
-            usage_events,
-            proxy_log_path,
-        )
+        _buffer_source_model_provider_usage_events(context, run_id, usage_events)
     if observation_events:
-        buffer_source_model_usage_observations(
-            f"{api_url}/api/webhooks/agent/model-usage-observation",
-            sandbox_token,
-            run_id,
-            observation_events,
-            proxy_log_path,
-        )
+        _buffer_source_model_provider_usage_observations(context, run_id, observation_events)
+
+
+def _buffer_model_provider_usage_events(
+    flow: http.HTTPFlow,
+    run_id: str,
+    firewall_name: str,
+    events: list[UsageEvent],
+) -> bool:
+    context = usage_reporting_context(flow)
+    if not context.is_complete:
+        _log_usage_reporting_context_missing(context, run_id, firewall_name)
+        return False
+    buffer_usage_events(
+        context.usage_event_url(),
+        context.sandbox_token,
+        run_id,
+        events,
+        context.proxy_log_path,
+    )
+    return True
+
+
+def _buffer_model_provider_usage_observations(
+    flow: http.HTTPFlow,
+    run_id: str,
+    events: list[UsageEvent],
+) -> bool:
+    context = usage_reporting_context(flow)
+    if not context.is_complete:
+        _log_model_usage_observation_context_missing(context)
+        return False
+    buffer_model_usage_observations(
+        context.model_usage_observation_url(),
+        context.sandbox_token,
+        run_id,
+        events,
+        context.proxy_log_path,
+    )
+    return True
+
+
+def _buffer_source_model_provider_usage_events(
+    context: UsageReportingContext,
+    run_id: str,
+    events: list[UsageEvent],
+) -> None:
+    buffer_source_usage_events(
+        context.usage_event_url(),
+        context.sandbox_token,
+        run_id,
+        events,
+        context.proxy_log_path,
+    )
+
+
+def _buffer_source_model_provider_usage_observations(
+    context: UsageReportingContext,
+    run_id: str,
+    events: list[UsageEvent],
+) -> None:
+    buffer_source_model_usage_observations(
+        context.model_usage_observation_url(),
+        context.sandbox_token,
+        run_id,
+        events,
+        context.proxy_log_path,
+    )
+
+
+def _log_usage_reporting_context_missing(
+    context: UsageReportingContext, run_id: str, firewall_name: str
+) -> None:
+    log_usage_underbilling(
+        context.proxy_log_path,
+        "Cannot report usage event: missing sandbox_token or api_url",
+        "missing_reporting_context",
+        "confirmed",
+        run_id=run_id,
+        firewall_name=firewall_name,
+        missing_sandbox_token=context.missing_sandbox_token,
+        missing_api_url=context.missing_api_url,
+    )
+
+
+def _log_model_usage_observation_context_missing(context: UsageReportingContext) -> None:
+    log_proxy_entry(
+        context.proxy_log_path,
+        "warn",
+        "Cannot report model usage observation: missing sandbox_token or api_url",
+        type="model_usage_observation",
+    )
 
 
 def _build_model_provider_usage_events(

--- a/crates/runner/mitm-addon/src/usage/reporting_context.py
+++ b/crates/runner/mitm-addon/src/usage/reporting_context.py
@@ -19,14 +19,6 @@ class UsageReportingContext:
         self.api_url = api_url
         self.proxy_log_path = proxy_log_path
 
-    def __repr__(self) -> str:
-        return (
-            "UsageReportingContext("
-            f"sandbox_token={'<present>' if self.sandbox_token else '<missing>'}, "
-            f"api_url={self.api_url!r}, "
-            f"proxy_log_path={self.proxy_log_path!r})"
-        )
-
     @property
     def missing_sandbox_token(self) -> bool:
         return not bool(self.sandbox_token)

--- a/crates/runner/mitm-addon/src/usage/reporting_context.py
+++ b/crates/runner/mitm-addon/src/usage/reporting_context.py
@@ -1,0 +1,62 @@
+"""Shared destination and context helpers for usage webhook reporting."""
+
+from mitmproxy import http
+
+import flow_metadata_keys as metadata_keys
+from platform_api import get_api_url
+
+USAGE_EVENT_WEBHOOK_PATH = "/api/webhooks/agent/usage-event"
+MODEL_USAGE_OBSERVATION_WEBHOOK_PATH = "/api/webhooks/agent/model-usage-observation"
+
+
+class UsageReportingContext:
+    """Flow-local platform reporting context for usage webhook uploads."""
+
+    __slots__ = ("api_url", "proxy_log_path", "sandbox_token")
+
+    def __init__(self, *, sandbox_token: str, api_url: str, proxy_log_path: str) -> None:
+        self.sandbox_token = sandbox_token
+        self.api_url = api_url
+        self.proxy_log_path = proxy_log_path
+
+    def __repr__(self) -> str:
+        return (
+            "UsageReportingContext("
+            f"sandbox_token={'<present>' if self.sandbox_token else '<missing>'}, "
+            f"api_url={self.api_url!r}, "
+            f"proxy_log_path={self.proxy_log_path!r})"
+        )
+
+    @property
+    def missing_sandbox_token(self) -> bool:
+        return not bool(self.sandbox_token)
+
+    @property
+    def missing_api_url(self) -> bool:
+        return not bool(self.api_url)
+
+    @property
+    def is_complete(self) -> bool:
+        return not self.missing_sandbox_token and not self.missing_api_url
+
+    def _url_for(self, path: str) -> str:
+        return f"{self.api_url}{path}"
+
+    def usage_event_url(self) -> str:
+        return self._url_for(USAGE_EVENT_WEBHOOK_PATH)
+
+    def model_usage_observation_url(self) -> str:
+        return self._url_for(MODEL_USAGE_OBSERVATION_WEBHOOK_PATH)
+
+
+def usage_reporting_context(flow: http.HTTPFlow) -> UsageReportingContext:
+    return UsageReportingContext(
+        sandbox_token=_metadata_string(flow, metadata_keys.VM_SANDBOX_AUTH_KEY),
+        api_url=get_api_url(),
+        proxy_log_path=_metadata_string(flow, metadata_keys.VM_PROXY_LOG_PATH),
+    )
+
+
+def _metadata_string(flow: http.HTTPFlow, key: str) -> str:
+    value = flow.metadata.get(key, "")
+    return value if isinstance(value, str) else ""

--- a/crates/runner/mitm-addon/tests/test_model_provider_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_usage.py
@@ -250,6 +250,31 @@ class TestReportModelProviderUsage:
         assert observed is False
         assert webhook.request_count == 0
 
+    def test_logs_warning_when_observation_missing_sandbox_token(
+        self, tmp_path, real_flow, mitm_ctx
+    ):
+        flow = real_flow(with_response=False, host="api.anthropic.com")
+        flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = False
+        flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = ""
+        flow.metadata[metadata_keys.MODEL_USAGE_PROVIDER] = "claude-sonnet-4-6"
+        flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {"tokens.input": 50}
+        proxy_log = tmp_path / "proxy-run-abc-123.jsonl"
+        flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = str(proxy_log)
+
+        with mitm_ctx(api_url="https://api.vm0.ai"):
+            observed = usage.report_model_provider_usage_observation(flow, "run-abc-123")
+
+        assert observed is False
+        assert jsonl_exists_after_flush(proxy_log)
+        [entry] = read_jsonl_entries_after_flush(proxy_log)
+        assert entry["level"] == "warn"
+        assert (
+            entry["message"]
+            == "Cannot report model usage observation: missing sandbox_token or api_url"
+        )
+        assert entry["type"] == "model_usage_observation"
+
     def test_skips_non_model_provider(self, real_flow, fresh_usage_executor, usage_webhook_api):
         """Should NOT reach the webhook boundary for non-model-provider requests."""
         flow = real_flow(with_response=False, host="api.github.com")

--- a/crates/runner/mitm-addon/tests/test_model_provider_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_usage.py
@@ -334,6 +334,7 @@ class TestReportModelProviderUsage:
         assert entry["run_id"] == "run-abc-123"
         assert entry["firewall_name"] == "model-provider:anthropic-api-key"
         assert entry["missing_sandbox_token"] is True
+        assert entry["missing_api_url"] is False
 
     def test_logs_underbilling_when_missing_api_url(
         self, tmp_path, real_flow, fresh_usage_executor, mitm_ctx

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
@@ -190,26 +190,29 @@ class TestModelProviderWebSocketUsage:
             "tokens.cache_read": 10,
         }
 
-    def test_model_websocket_missing_context_releases_positive_source(self, tmp_path, real_flow):
+    def test_model_websocket_missing_context_releases_positive_source(
+        self, tmp_path, real_flow, mitm_ctx
+    ):
         flow = _openai_model_websocket_flow(tmp_path, real_flow)
         mitm_addon.responseheaders(flow)
         flow.metadata[metadata_keys.VM_SANDBOX_AUTH_KEY] = ""
         proxy_log = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
 
-        _feed_websocket_server_message(
-            flow,
-            _openai_websocket_usage_frame(
-                "resp_ws_missing_context",
-                input_tokens=10,
-                output_tokens=4,
-            ),
-        )
+        with mitm_ctx(api_url="https://api.vm0.ai"):
+            _feed_websocket_server_message(
+                flow,
+                _openai_websocket_usage_frame(
+                    "resp_ws_missing_context",
+                    input_tokens=10,
+                    output_tokens=4,
+                ),
+            )
 
         assert _model_websocket_usage_sources(flow) == {}
-        [entry] = [
-            entry
-            for entry in read_jsonl_entries_after_flush(proxy_log)
-            if entry.get("type") == "usage_underbilling"
+        entries = read_jsonl_entries_after_flush(proxy_log)
+        [entry] = [entry for entry in entries if entry.get("type") == "usage_underbilling"]
+        [observation_entry] = [
+            entry for entry in entries if entry.get("type") == "model_usage_observation"
         ]
         assert entry["type"] == "usage_underbilling"
         assert entry["reason"] == "missing_reporting_context"
@@ -217,6 +220,12 @@ class TestModelProviderWebSocketUsage:
         assert entry["run_id"] == "run-abc-123"
         assert entry["firewall_name"] == "model-provider:openai-api-key"
         assert entry["missing_sandbox_token"] is True
+        assert entry["missing_api_url"] is False
+        assert observation_entry["level"] == "warn"
+        assert (
+            observation_entry["message"]
+            == "Cannot report model usage observation: missing sandbox_token or api_url"
+        )
 
     def test_model_websocket_missing_api_url_releases_positive_source(
         self, tmp_path, real_flow, mitm_ctx


### PR DESCRIPTION
## Summary

- add a shared mitm-addon usage reporting context for webhook destinations and sandbox/API/proxy-log lookup
- refactor model-provider usage, observation, and source-preserving reporters to reuse the shared destination/context layer
- refactor X connector usage upload context to reuse the same usage-event destination/context helper
- document the corrected model-provider missing-context diagnostic where a missing sandbox token no longer implies a missing API URL

## Tests

- `cd crates/runner/mitm-addon && .venv/bin/ruff format --check src/usage/reporting_context.py src/usage/providers/model_provider.py src/usage/providers/connectors/x.py tests/test_model_provider_usage.py tests/test_model_provider_websocket_usage.py`
- `cd crates/runner/mitm-addon && .venv/bin/ruff check src/usage/reporting_context.py src/usage/providers/model_provider.py src/usage/providers/connectors/x.py tests/test_model_provider_usage.py tests/test_model_provider_websocket_usage.py`
- `cd crates/runner/mitm-addon && .venv/bin/python -m pytest tests/test_model_provider_usage.py tests/test_model_provider_websocket_usage.py tests/x_connector_usage/test_guards.py tests/test_usage_buffer_aggregation.py`

Closes #19525