### PR TITLE
refactor: reuse codex test setup helpers

### DIFF
--- a/crates/guest-agent/tests/codex_app_server_backend.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend.rs
@@ -8,22 +8,24 @@ mod common;
 use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
 use serde_json::Value;
-use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 #[tokio::test]
 async fn codex_app_server_backend_runs_initial_turn_and_synthesizes_thread_started()
 -> Result<(), Box<dyn std::error::Error>> {
-    let mock = build_and_locate_mock_codex()?;
+    let mock = common::build_and_locate_mock_codex()?;
     let tmp = tempfile::tempdir()?;
 
     unsafe {
-        setup_codex_app_server_env(
+        common::setup_codex_app_server_env(
             &mock,
             tmp.path(),
-            "codex-app-server-backend-test",
-            "runtime-turn-complete-without-thread-started",
-            None,
+            common::CodexAppServerEnvConfig {
+                run_id: "codex-app-server-backend-test",
+                prompt: "drive the app-server backend",
+                scenario: Some("runtime-turn-complete-without-thread-started"),
+                resume_session_id: None,
+            },
         )?;
     }
     let _run_files = common::RunFilesGuard::new();
@@ -137,79 +139,4 @@ fn assert_event_type_sequence(events: &[Value], expected: &[&str]) {
         .map(|value| Some(*value))
         .collect::<Vec<_>>();
     assert_eq!(actual, expected);
-}
-
-unsafe fn setup_codex_app_server_env(
-    mock_path: &Path,
-    home: &Path,
-    run_id: &str,
-    scenario: &str,
-    resume_session_id: Option<&str>,
-) -> Result<(), String> {
-    unsafe {
-        std::env::set_var("CLI_AGENT_TYPE", "codex");
-        std::env::set_var("VM0_CODEX_APP_SERVER_BACKEND", "1");
-        std::env::set_var("VM0_MOCK_CODEX_PATH", mock_path);
-        std::env::set_var("USE_MOCK_CODEX", "true");
-        std::env::remove_var("MOCK_CODEX_FIXTURE");
-        std::env::set_var("MOCK_CODEX_APP_SERVER_SCENARIO", scenario);
-        std::env::set_var("VM0_RUN_ID", run_id);
-        std::env::set_var("VM0_PROMPT", "drive the app-server backend");
-        std::env::set_var("VM0_API_URL", "http://127.0.0.1:1");
-        std::env::set_var("VM0_API_TOKEN", "");
-        std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");
-        std::env::set_var("VM0_SANDBOX_REUSE_RESULT", "reused");
-        std::env::set_var("HOME", home);
-        if let Some(resume_session_id) = resume_session_id {
-            std::env::set_var("VM0_RESUME_SESSION_ID", resume_session_id);
-        } else {
-            std::env::remove_var("VM0_RESUME_SESSION_ID");
-        }
-    }
-    std::fs::create_dir_all(home).map_err(|error| format!("create home: {error}"))?;
-    common::ensure_canonical_workspace_for_test()?;
-    std::env::set_current_dir(home).map_err(|error| format!("set_current_dir: {error}"))?;
-    Ok(())
-}
-
-fn build_and_locate_mock_codex() -> Result<PathBuf, String> {
-    let exe = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
-    let target_profile_dir = exe
-        .parent()
-        .and_then(|p| p.parent())
-        .ok_or_else(|| "target/<profile> dir".to_string())?;
-    let target_dir = target_profile_dir
-        .parent()
-        .ok_or_else(|| "target dir".to_string())?;
-    let profile_dir_name = target_profile_dir
-        .file_name()
-        .and_then(|n| n.to_str())
-        .ok_or_else(|| "profile dir name".to_string())?;
-
-    let mut cmd = std::process::Command::new("cargo");
-    cmd.args(["build", "-p", "guest-mock-codex", "--quiet"])
-        .arg("--target-dir")
-        .arg(target_dir);
-    match profile_dir_name {
-        "debug" => {}
-        "release" => {
-            cmd.arg("--release");
-        }
-        other => {
-            cmd.args(["--profile", other]);
-        }
-    }
-
-    let status = cmd
-        .status()
-        .map_err(|e| format!("invoke cargo build: {e}"))?;
-    if !status.success() {
-        return Err("cargo build -p guest-mock-codex failed".into());
-    }
-
-    let mock = target_profile_dir.join("guest-mock-codex");
-    if !mock.exists() {
-        return Err(format!("mock binary not found at {}", mock.display()));
-    }
-    Ok(mock)
 }

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input.rs
@@ -21,9 +21,12 @@ async fn codex_app_server_backend_steers_active_input_into_active_turn()
         common::setup_codex_app_server_env(
             &mock,
             tmp.path(),
-            "codex-app-server-backend-active-input-test",
-            "drive the app-server backend with active input",
-            "runtime-turn-started-before-steer",
+            common::CodexAppServerEnvConfig {
+                run_id: "codex-app-server-backend-active-input-test",
+                prompt: "drive the app-server backend with active input",
+                scenario: Some("runtime-turn-started-before-steer"),
+                resume_session_id: None,
+            },
         )?;
     }
     let _run_files = common::RunFilesGuard::new();

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_after_completion.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_after_completion.rs
@@ -20,9 +20,12 @@ async fn codex_app_server_backend_rejects_active_input_after_turn_completion()
         common::setup_codex_app_server_env(
             &mock,
             tmp.path(),
-            "codex-app-server-backend-active-input-after-completion-test",
-            "drive the app-server backend completion path",
-            "runtime-turn-complete",
+            common::CodexAppServerEnvConfig {
+                run_id: "codex-app-server-backend-active-input-after-completion-test",
+                prompt: "drive the app-server backend completion path",
+                scenario: Some("runtime-turn-complete"),
+                resume_session_id: None,
+            },
         )?;
     }
     let _run_files = common::RunFilesGuard::new();

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_before_buffered_completion.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_before_buffered_completion.rs
@@ -21,9 +21,12 @@ async fn codex_app_server_backend_steers_accepted_input_before_buffered_completi
         common::setup_codex_app_server_env(
             &mock,
             tmp.path(),
-            "codex-app-server-backend-active-input-before-buffered-completion-test",
-            "drive the app-server backend buffered completion path",
-            "runtime-turn-complete",
+            common::CodexAppServerEnvConfig {
+                run_id: "codex-app-server-backend-active-input-before-buffered-completion-test",
+                prompt: "drive the app-server backend buffered completion path",
+                scenario: Some("runtime-turn-complete"),
+                resume_session_id: None,
+            },
         )?;
     }
     let _run_files = common::RunFilesGuard::new();

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_child_exit.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_child_exit.rs
@@ -20,9 +20,12 @@ async fn codex_app_server_backend_fails_visible_when_child_exits_during_steer()
         common::setup_codex_app_server_env(
             &mock,
             tmp.path(),
-            "codex-app-server-backend-active-input-child-exit-test",
-            "drive the app-server backend child exit during steer path",
-            "exit-on-turn-steer",
+            common::CodexAppServerEnvConfig {
+                run_id: "codex-app-server-backend-active-input-child-exit-test",
+                prompt: "drive the app-server backend child exit during steer path",
+                scenario: Some("exit-on-turn-steer"),
+                resume_session_id: None,
+            },
         )?;
     }
     let _run_files = common::RunFilesGuard::new();

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_no_turn.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_no_turn.rs
@@ -20,9 +20,12 @@ async fn codex_app_server_backend_fails_visible_when_no_active_turn()
         common::setup_codex_app_server_env(
             &mock,
             tmp.path(),
-            "codex-app-server-backend-active-input-no-turn-test",
-            "drive the app-server backend no active turn path",
-            "no-active-turn",
+            common::CodexAppServerEnvConfig {
+                run_id: "codex-app-server-backend-active-input-no-turn-test",
+                prompt: "drive the app-server backend no active turn path",
+                scenario: Some("no-active-turn"),
+                resume_session_id: None,
+            },
         )?;
     }
     let _run_files = common::RunFilesGuard::new();

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_queued_terminal.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_queued_terminal.rs
@@ -21,9 +21,12 @@ async fn codex_app_server_backend_closes_input_before_ingesting_queued_terminal(
         common::setup_codex_app_server_env(
             &mock,
             tmp.path(),
-            "codex-app-server-backend-active-input-queued-terminal-test",
-            "drive the app-server backend queued terminal path",
-            "runtime-turn-complete-before-steer-response",
+            common::CodexAppServerEnvConfig {
+                run_id: "codex-app-server-backend-active-input-queued-terminal-test",
+                prompt: "drive the app-server backend queued terminal path",
+                scenario: Some("runtime-turn-complete-before-steer-response"),
+                resume_session_id: None,
+            },
         )?;
     }
     let _run_files = common::RunFilesGuard::new();

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_stale.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_stale.rs
@@ -21,9 +21,12 @@ async fn codex_app_server_backend_fails_visible_on_stale_active_turn()
         common::setup_codex_app_server_env(
             &mock,
             tmp.path(),
-            "codex-app-server-backend-active-input-stale-test",
-            "drive the app-server backend stale path",
-            "stale-turn",
+            common::CodexAppServerEnvConfig {
+                run_id: "codex-app-server-backend-active-input-stale-test",
+                prompt: "drive the app-server backend stale path",
+                scenario: Some("stale-turn"),
+                resume_session_id: None,
+            },
         )?;
     }
     let _run_files = common::RunFilesGuard::new();

--- a/crates/guest-agent/tests/codex_app_server_backend_child_env.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_child_env.rs
@@ -24,9 +24,12 @@ async fn codex_app_server_backend_child_env_uses_runtime_snapshot()
         common::setup_codex_app_server_env(
             &mock,
             tmp.path(),
-            run_id,
-            prompt,
-            "runtime-turn-complete-without-thread-started",
+            common::CodexAppServerEnvConfig {
+                run_id,
+                prompt,
+                scenario: Some("runtime-turn-complete-without-thread-started"),
+                resume_session_id: None,
+            },
         )?;
     }
 

--- a/crates/guest-agent/tests/codex_app_server_backend_error_masking.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_error_masking.rs
@@ -7,19 +7,27 @@ mod common;
 
 use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
-use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 #[tokio::test]
 async fn codex_app_server_backend_masks_resume_id_in_rpc_errors()
 -> Result<(), Box<dyn std::error::Error>> {
-    let mock = build_and_locate_mock_codex()?;
+    let mock = common::build_and_locate_mock_codex()?;
     let tmp = tempfile::tempdir()?;
     let resume_thread_id = "0193ABCDEF01723489ABCDEF01234567";
     let canonical_resume_thread_id = "0193abcd-ef01-7234-89ab-cdef01234567";
 
     unsafe {
-        setup_codex_app_server_env(&mock, tmp.path(), resume_thread_id)?;
+        common::setup_codex_app_server_env(
+            &mock,
+            tmp.path(),
+            common::CodexAppServerEnvConfig {
+                run_id: "codex-app-server-backend-error-masking-test",
+                prompt: "drive the app-server backend error masking path",
+                scenario: Some("resume-rpc-error-with-thread-id"),
+                resume_session_id: Some(resume_thread_id),
+            },
+        )?;
     }
     let _run_files = common::RunFilesGuard::new();
 
@@ -51,79 +59,4 @@ async fn codex_app_server_backend_masks_resume_id_in_rpc_errors()
     );
 
     Ok(())
-}
-
-unsafe fn setup_codex_app_server_env(
-    mock_path: &Path,
-    home: &Path,
-    resume_thread_id: &str,
-) -> Result<(), String> {
-    unsafe {
-        std::env::set_var("CLI_AGENT_TYPE", "codex");
-        std::env::set_var("VM0_CODEX_APP_SERVER_BACKEND", "1");
-        std::env::set_var("VM0_MOCK_CODEX_PATH", mock_path);
-        std::env::set_var("USE_MOCK_CODEX", "true");
-        std::env::remove_var("MOCK_CODEX_FIXTURE");
-        std::env::set_var(
-            "MOCK_CODEX_APP_SERVER_SCENARIO",
-            "resume-rpc-error-with-thread-id",
-        );
-        std::env::set_var("VM0_RESUME_SESSION_ID", resume_thread_id);
-        std::env::set_var("VM0_RUN_ID", "codex-app-server-backend-error-masking-test");
-        std::env::set_var(
-            "VM0_PROMPT",
-            "drive the app-server backend error masking path",
-        );
-        std::env::set_var("VM0_API_URL", "http://127.0.0.1:1");
-        std::env::set_var("VM0_API_TOKEN", "");
-        std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");
-        std::env::set_var("VM0_SANDBOX_REUSE_RESULT", "reused");
-        std::env::set_var("HOME", home);
-    }
-    std::fs::create_dir_all(home).map_err(|error| format!("create home: {error}"))?;
-    common::ensure_canonical_workspace_for_test()?;
-    std::env::set_current_dir(home).map_err(|error| format!("set_current_dir: {error}"))?;
-    Ok(())
-}
-
-fn build_and_locate_mock_codex() -> Result<PathBuf, String> {
-    let exe = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
-    let target_profile_dir = exe
-        .parent()
-        .and_then(|p| p.parent())
-        .ok_or_else(|| "target/<profile> dir".to_string())?;
-    let target_dir = target_profile_dir
-        .parent()
-        .ok_or_else(|| "target dir".to_string())?;
-    let profile_dir_name = target_profile_dir
-        .file_name()
-        .and_then(|n| n.to_str())
-        .ok_or_else(|| "profile dir name".to_string())?;
-
-    let mut cmd = std::process::Command::new("cargo");
-    cmd.args(["build", "-p", "guest-mock-codex", "--quiet"])
-        .arg("--target-dir")
-        .arg(target_dir);
-    match profile_dir_name {
-        "debug" => {}
-        "release" => {
-            cmd.arg("--release");
-        }
-        other => {
-            cmd.args(["--profile", other]);
-        }
-    }
-
-    let status = cmd
-        .status()
-        .map_err(|e| format!("invoke cargo build: {e}"))?;
-    if !status.success() {
-        return Err("cargo build -p guest-mock-codex failed".into());
-    }
-
-    let mock = target_profile_dir.join("guest-mock-codex");
-    if !mock.exists() {
-        return Err(format!("mock binary not found at {}", mock.display()));
-    }
-    Ok(mock)
 }

--- a/crates/guest-agent/tests/codex_app_server_backend_failure.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_failure.rs
@@ -7,17 +7,25 @@ mod common;
 
 use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
-use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 #[tokio::test]
 async fn codex_app_server_backend_child_exit_before_turn_response_fails_promptly()
 -> Result<(), Box<dyn std::error::Error>> {
-    let mock = build_and_locate_mock_codex()?;
+    let mock = common::build_and_locate_mock_codex()?;
     let tmp = tempfile::tempdir()?;
 
     unsafe {
-        setup_codex_app_server_env(&mock, tmp.path())?;
+        common::setup_codex_app_server_env(
+            &mock,
+            tmp.path(),
+            common::CodexAppServerEnvConfig {
+                run_id: "codex-app-server-backend-failure-test",
+                prompt: "drive the app-server backend failure path",
+                scenario: Some("exit-on-turn-start"),
+                resume_session_id: None,
+            },
+        )?;
     }
     let _run_files = common::RunFilesGuard::new();
 
@@ -42,69 +50,4 @@ async fn codex_app_server_backend_child_exit_before_turn_response_fails_promptly
     );
 
     Ok(())
-}
-
-unsafe fn setup_codex_app_server_env(mock_path: &Path, home: &Path) -> Result<(), String> {
-    unsafe {
-        std::env::set_var("CLI_AGENT_TYPE", "codex");
-        std::env::set_var("VM0_CODEX_APP_SERVER_BACKEND", "1");
-        std::env::set_var("VM0_MOCK_CODEX_PATH", mock_path);
-        std::env::set_var("USE_MOCK_CODEX", "true");
-        std::env::remove_var("MOCK_CODEX_FIXTURE");
-        std::env::set_var("MOCK_CODEX_APP_SERVER_SCENARIO", "exit-on-turn-start");
-        std::env::set_var("VM0_RUN_ID", "codex-app-server-backend-failure-test");
-        std::env::set_var("VM0_PROMPT", "drive the app-server backend failure path");
-        std::env::set_var("VM0_API_URL", "http://127.0.0.1:1");
-        std::env::set_var("VM0_API_TOKEN", "");
-        std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");
-        std::env::set_var("VM0_SANDBOX_REUSE_RESULT", "reused");
-        std::env::set_var("HOME", home);
-        std::env::remove_var("VM0_RESUME_SESSION_ID");
-    }
-    std::fs::create_dir_all(home).map_err(|error| format!("create home: {error}"))?;
-    common::ensure_canonical_workspace_for_test()?;
-    std::env::set_current_dir(home).map_err(|error| format!("set_current_dir: {error}"))?;
-    Ok(())
-}
-
-fn build_and_locate_mock_codex() -> Result<PathBuf, String> {
-    let exe = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
-    let target_profile_dir = exe
-        .parent()
-        .and_then(|p| p.parent())
-        .ok_or_else(|| "target/<profile> dir".to_string())?;
-    let target_dir = target_profile_dir
-        .parent()
-        .ok_or_else(|| "target dir".to_string())?;
-    let profile_dir_name = target_profile_dir
-        .file_name()
-        .and_then(|n| n.to_str())
-        .ok_or_else(|| "profile dir name".to_string())?;
-
-    let mut cmd = std::process::Command::new("cargo");
-    cmd.args(["build", "-p", "guest-mock-codex", "--quiet"])
-        .arg("--target-dir")
-        .arg(target_dir);
-    match profile_dir_name {
-        "debug" => {}
-        "release" => {
-            cmd.arg("--release");
-        }
-        other => {
-            cmd.args(["--profile", other]);
-        }
-    }
-
-    let status = cmd
-        .status()
-        .map_err(|e| format!("invoke cargo build: {e}"))?;
-    if !status.success() {
-        return Err("cargo build -p guest-mock-codex failed".into());
-    }
-
-    let mock = target_profile_dir.join("guest-mock-codex");
-    if !mock.exists() {
-        return Err(format!("mock binary not found at {}", mock.display()));
-    }
-    Ok(mock)
 }

--- a/crates/guest-agent/tests/codex_app_server_backend_heartbeat.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_heartbeat.rs
@@ -8,17 +8,26 @@ mod common;
 use guest_agent::error::AgentError;
 use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::time::Duration;
 
 #[tokio::test]
 async fn codex_app_server_backend_heartbeat_interrupts_hung_turn_start()
 -> Result<(), Box<dyn std::error::Error>> {
-    let mock = build_and_locate_mock_codex()?;
+    let mock = common::build_and_locate_mock_codex()?;
     let tmp = tempfile::tempdir()?;
 
     unsafe {
-        setup_codex_app_server_env(&mock, tmp.path())?;
+        common::setup_codex_app_server_env(
+            &mock,
+            tmp.path(),
+            common::CodexAppServerEnvConfig {
+                run_id: "codex-app-server-backend-heartbeat-test",
+                prompt: "drive the app-server backend heartbeat path",
+                scenario: Some("hang-on-turn-start"),
+                resume_session_id: None,
+            },
+        )?;
     }
     let _run_files = common::RunFilesGuard::new();
     let session_id_path = PathBuf::from(guest_agent::paths::session_id_file());
@@ -52,69 +61,4 @@ async fn codex_app_server_backend_heartbeat_interrupts_hung_turn_start()
     );
 
     Ok(())
-}
-
-unsafe fn setup_codex_app_server_env(mock_path: &Path, home: &Path) -> Result<(), String> {
-    unsafe {
-        std::env::set_var("CLI_AGENT_TYPE", "codex");
-        std::env::set_var("VM0_CODEX_APP_SERVER_BACKEND", "1");
-        std::env::set_var("VM0_MOCK_CODEX_PATH", mock_path);
-        std::env::set_var("USE_MOCK_CODEX", "true");
-        std::env::remove_var("MOCK_CODEX_FIXTURE");
-        std::env::set_var("MOCK_CODEX_APP_SERVER_SCENARIO", "hang-on-turn-start");
-        std::env::set_var("VM0_RUN_ID", "codex-app-server-backend-heartbeat-test");
-        std::env::set_var("VM0_PROMPT", "drive the app-server backend heartbeat path");
-        std::env::set_var("VM0_API_URL", "http://127.0.0.1:1");
-        std::env::set_var("VM0_API_TOKEN", "");
-        std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");
-        std::env::set_var("VM0_SANDBOX_REUSE_RESULT", "reused");
-        std::env::set_var("HOME", home);
-        std::env::remove_var("VM0_RESUME_SESSION_ID");
-    }
-    std::fs::create_dir_all(home).map_err(|error| format!("create home: {error}"))?;
-    common::ensure_canonical_workspace_for_test()?;
-    std::env::set_current_dir(home).map_err(|error| format!("set_current_dir: {error}"))?;
-    Ok(())
-}
-
-fn build_and_locate_mock_codex() -> Result<PathBuf, String> {
-    let exe = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
-    let target_profile_dir = exe
-        .parent()
-        .and_then(|p| p.parent())
-        .ok_or_else(|| "target/<profile> dir".to_string())?;
-    let target_dir = target_profile_dir
-        .parent()
-        .ok_or_else(|| "target dir".to_string())?;
-    let profile_dir_name = target_profile_dir
-        .file_name()
-        .and_then(|n| n.to_str())
-        .ok_or_else(|| "profile dir name".to_string())?;
-
-    let mut cmd = std::process::Command::new("cargo");
-    cmd.args(["build", "-p", "guest-mock-codex", "--quiet"])
-        .arg("--target-dir")
-        .arg(target_dir);
-    match profile_dir_name {
-        "debug" => {}
-        "release" => {
-            cmd.arg("--release");
-        }
-        other => {
-            cmd.args(["--profile", other]);
-        }
-    }
-
-    let status = cmd
-        .status()
-        .map_err(|e| format!("invoke cargo build: {e}"))?;
-    if !status.success() {
-        return Err("cargo build -p guest-mock-codex failed".into());
-    }
-
-    let mock = target_profile_dir.join("guest-mock-codex");
-    if !mock.exists() {
-        return Err(format!("mock binary not found at {}", mock.display()));
-    }
-    Ok(mock)
 }

--- a/crates/guest-agent/tests/codex_app_server_backend_invalid_resume_id.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_invalid_resume_id.rs
@@ -7,7 +7,6 @@ mod common;
 
 use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
-use std::path::Path;
 use std::time::Duration;
 
 #[tokio::test]
@@ -17,7 +16,16 @@ async fn codex_app_server_backend_rejects_invalid_resume_id_before_spawn()
     let missing_mock = tmp.path().join("missing-mock-codex");
 
     unsafe {
-        setup_codex_app_server_env(&missing_mock, tmp.path())?;
+        common::setup_codex_app_server_env(
+            &missing_mock,
+            tmp.path(),
+            common::CodexAppServerEnvConfig {
+                run_id: "codex-app-server-backend-invalid-resume-id-test",
+                prompt: "drive the app-server backend invalid resume id path",
+                scenario: None,
+                resume_session_id: Some("not-a-valid-codex-thread-id"),
+            },
+        )?;
     }
     let _run_files = common::RunFilesGuard::new();
 
@@ -49,34 +57,5 @@ async fn codex_app_server_backend_rejects_invalid_resume_id_before_spawn()
         "invalid resume id should not write a session id"
     );
 
-    Ok(())
-}
-
-unsafe fn setup_codex_app_server_env(mock_path: &Path, home: &Path) -> Result<(), String> {
-    unsafe {
-        std::env::set_var("CLI_AGENT_TYPE", "codex");
-        std::env::set_var("VM0_CODEX_APP_SERVER_BACKEND", "1");
-        std::env::set_var("VM0_MOCK_CODEX_PATH", mock_path);
-        std::env::set_var("USE_MOCK_CODEX", "true");
-        std::env::remove_var("MOCK_CODEX_FIXTURE");
-        std::env::remove_var("MOCK_CODEX_APP_SERVER_SCENARIO");
-        std::env::set_var("VM0_RESUME_SESSION_ID", "not-a-valid-codex-thread-id");
-        std::env::set_var(
-            "VM0_RUN_ID",
-            "codex-app-server-backend-invalid-resume-id-test",
-        );
-        std::env::set_var(
-            "VM0_PROMPT",
-            "drive the app-server backend invalid resume id path",
-        );
-        std::env::set_var("VM0_API_URL", "http://127.0.0.1:1");
-        std::env::set_var("VM0_API_TOKEN", "");
-        std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");
-        std::env::set_var("VM0_SANDBOX_REUSE_RESULT", "reused");
-        std::env::set_var("HOME", home);
-    }
-    std::fs::create_dir_all(home).map_err(|error| format!("create home: {error}"))?;
-    common::ensure_canonical_workspace_for_test()?;
-    std::env::set_current_dir(home).map_err(|error| format!("set_current_dir: {error}"))?;
     Ok(())
 }

--- a/crates/guest-agent/tests/codex_app_server_backend_invalid_thread_id.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_invalid_thread_id.rs
@@ -7,17 +7,25 @@ mod common;
 
 use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
-use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 #[tokio::test]
 async fn codex_app_server_backend_rejects_invalid_thread_start_id()
 -> Result<(), Box<dyn std::error::Error>> {
-    let mock = build_and_locate_mock_codex()?;
+    let mock = common::build_and_locate_mock_codex()?;
     let tmp = tempfile::tempdir()?;
 
     unsafe {
-        setup_codex_app_server_env(&mock, tmp.path())?;
+        common::setup_codex_app_server_env(
+            &mock,
+            tmp.path(),
+            common::CodexAppServerEnvConfig {
+                run_id: "codex-app-server-backend-invalid-thread-id-test",
+                prompt: "drive the app-server backend invalid thread id path",
+                scenario: Some("thread-start-invalid-thread-id"),
+                resume_session_id: None,
+            },
+        )?;
     }
     let _run_files = common::RunFilesGuard::new();
 
@@ -46,78 +54,4 @@ async fn codex_app_server_backend_rejects_invalid_thread_start_id()
     );
 
     Ok(())
-}
-
-unsafe fn setup_codex_app_server_env(mock_path: &Path, home: &Path) -> Result<(), String> {
-    unsafe {
-        std::env::set_var("CLI_AGENT_TYPE", "codex");
-        std::env::set_var("VM0_CODEX_APP_SERVER_BACKEND", "1");
-        std::env::set_var("VM0_MOCK_CODEX_PATH", mock_path);
-        std::env::set_var("USE_MOCK_CODEX", "true");
-        std::env::remove_var("MOCK_CODEX_FIXTURE");
-        std::env::set_var(
-            "MOCK_CODEX_APP_SERVER_SCENARIO",
-            "thread-start-invalid-thread-id",
-        );
-        std::env::remove_var("VM0_RESUME_SESSION_ID");
-        std::env::set_var(
-            "VM0_RUN_ID",
-            "codex-app-server-backend-invalid-thread-id-test",
-        );
-        std::env::set_var(
-            "VM0_PROMPT",
-            "drive the app-server backend invalid thread id path",
-        );
-        std::env::set_var("VM0_API_URL", "http://127.0.0.1:1");
-        std::env::set_var("VM0_API_TOKEN", "");
-        std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");
-        std::env::set_var("VM0_SANDBOX_REUSE_RESULT", "reused");
-        std::env::set_var("HOME", home);
-    }
-    std::fs::create_dir_all(home).map_err(|error| format!("create home: {error}"))?;
-    common::ensure_canonical_workspace_for_test()?;
-    std::env::set_current_dir(home).map_err(|error| format!("set_current_dir: {error}"))?;
-    Ok(())
-}
-
-fn build_and_locate_mock_codex() -> Result<PathBuf, String> {
-    let exe = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
-    let target_profile_dir = exe
-        .parent()
-        .and_then(|p| p.parent())
-        .ok_or_else(|| "target/<profile> dir".to_string())?;
-    let target_dir = target_profile_dir
-        .parent()
-        .ok_or_else(|| "target dir".to_string())?;
-    let profile_dir_name = target_profile_dir
-        .file_name()
-        .and_then(|n| n.to_str())
-        .ok_or_else(|| "profile dir name".to_string())?;
-
-    let mut cmd = std::process::Command::new("cargo");
-    cmd.args(["build", "-p", "guest-mock-codex", "--quiet"])
-        .arg("--target-dir")
-        .arg(target_dir);
-    match profile_dir_name {
-        "debug" => {}
-        "release" => {
-            cmd.arg("--release");
-        }
-        other => {
-            cmd.args(["--profile", other]);
-        }
-    }
-
-    let status = cmd
-        .status()
-        .map_err(|e| format!("invoke cargo build: {e}"))?;
-    if !status.success() {
-        return Err("cargo build -p guest-mock-codex failed".into());
-    }
-
-    let mock = target_profile_dir.join("guest-mock-codex");
-    if !mock.exists() {
-        return Err(format!("mock binary not found at {}", mock.display()));
-    }
-    Ok(mock)
 }

--- a/crates/guest-agent/tests/codex_app_server_backend_resume.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_resume.rs
@@ -8,24 +8,26 @@ mod common;
 use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
 use serde_json::Value;
-use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 #[tokio::test]
 async fn codex_app_server_backend_resumes_existing_thread_id()
 -> Result<(), Box<dyn std::error::Error>> {
-    let mock = build_and_locate_mock_codex()?;
+    let mock = common::build_and_locate_mock_codex()?;
     let tmp = tempfile::tempdir()?;
     let resume_thread_id = "0193ABCDEF01723489ABCDEF01234567";
     let canonical_resume_thread_id = "0193abcd-ef01-7234-89ab-cdef01234567";
 
     unsafe {
-        setup_codex_app_server_env(
+        common::setup_codex_app_server_env(
             &mock,
             tmp.path(),
-            "codex-app-server-backend-resume-test",
-            "runtime-turn-complete",
-            resume_thread_id,
+            common::CodexAppServerEnvConfig {
+                run_id: "codex-app-server-backend-resume-test",
+                prompt: "drive the app-server resume backend",
+                scenario: Some("runtime-turn-complete"),
+                resume_session_id: Some(resume_thread_id),
+            },
         )?;
     }
     let _run_files = common::RunFilesGuard::new();
@@ -68,75 +70,4 @@ fn read_agent_log_events() -> Result<Vec<Value>, Box<dyn std::error::Error>> {
     log.lines()
         .map(|line| serde_json::from_str(line).map_err(Into::into))
         .collect()
-}
-
-unsafe fn setup_codex_app_server_env(
-    mock_path: &Path,
-    home: &Path,
-    run_id: &str,
-    scenario: &str,
-    resume_session_id: &str,
-) -> Result<(), String> {
-    unsafe {
-        std::env::set_var("CLI_AGENT_TYPE", "codex");
-        std::env::set_var("VM0_CODEX_APP_SERVER_BACKEND", "1");
-        std::env::set_var("VM0_MOCK_CODEX_PATH", mock_path);
-        std::env::set_var("USE_MOCK_CODEX", "true");
-        std::env::remove_var("MOCK_CODEX_FIXTURE");
-        std::env::set_var("MOCK_CODEX_APP_SERVER_SCENARIO", scenario);
-        std::env::set_var("VM0_RESUME_SESSION_ID", resume_session_id);
-        std::env::set_var("VM0_RUN_ID", run_id);
-        std::env::set_var("VM0_PROMPT", "drive the app-server resume backend");
-        std::env::set_var("VM0_API_URL", "http://127.0.0.1:1");
-        std::env::set_var("VM0_API_TOKEN", "");
-        std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");
-        std::env::set_var("VM0_SANDBOX_REUSE_RESULT", "reused");
-        std::env::set_var("HOME", home);
-    }
-    std::fs::create_dir_all(home).map_err(|error| format!("create home: {error}"))?;
-    common::ensure_canonical_workspace_for_test()?;
-    std::env::set_current_dir(home).map_err(|error| format!("set_current_dir: {error}"))?;
-    Ok(())
-}
-
-fn build_and_locate_mock_codex() -> Result<PathBuf, String> {
-    let exe = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
-    let target_profile_dir = exe
-        .parent()
-        .and_then(|p| p.parent())
-        .ok_or_else(|| "target/<profile> dir".to_string())?;
-    let target_dir = target_profile_dir
-        .parent()
-        .ok_or_else(|| "target dir".to_string())?;
-    let profile_dir_name = target_profile_dir
-        .file_name()
-        .and_then(|n| n.to_str())
-        .ok_or_else(|| "profile dir name".to_string())?;
-
-    let mut cmd = std::process::Command::new("cargo");
-    cmd.args(["build", "-p", "guest-mock-codex", "--quiet"])
-        .arg("--target-dir")
-        .arg(target_dir);
-    match profile_dir_name {
-        "debug" => {}
-        "release" => {
-            cmd.arg("--release");
-        }
-        other => {
-            cmd.args(["--profile", other]);
-        }
-    }
-
-    let status = cmd
-        .status()
-        .map_err(|e| format!("invoke cargo build: {e}"))?;
-    if !status.success() {
-        return Err("cargo build -p guest-mock-codex failed".into());
-    }
-
-    let mock = target_profile_dir.join("guest-mock-codex");
-    if !mock.exists() {
-        return Err(format!("mock binary not found at {}", mock.display()));
-    }
-    Ok(mock)
 }

--- a/crates/guest-agent/tests/codex_app_server_backend_resume_mismatch.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_resume_mismatch.rs
@@ -7,18 +7,26 @@ mod common;
 
 use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
-use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 #[tokio::test]
 async fn codex_app_server_backend_rejects_mismatched_resume_thread_id()
 -> Result<(), Box<dyn std::error::Error>> {
-    let mock = build_and_locate_mock_codex()?;
+    let mock = common::build_and_locate_mock_codex()?;
     let tmp = tempfile::tempdir()?;
     let resume_thread_id = "0193abcd-ef01-7234-89ab-cdef01234567";
 
     unsafe {
-        setup_codex_app_server_env(&mock, tmp.path(), resume_thread_id)?;
+        common::setup_codex_app_server_env(
+            &mock,
+            tmp.path(),
+            common::CodexAppServerEnvConfig {
+                run_id: "codex-app-server-backend-resume-mismatch-test",
+                prompt: "drive the app-server backend resume mismatch path",
+                scenario: Some("resume-different-thread-id"),
+                resume_session_id: Some(resume_thread_id),
+            },
+        )?;
     }
     let _run_files = common::RunFilesGuard::new();
 
@@ -47,82 +55,4 @@ async fn codex_app_server_backend_rejects_mismatched_resume_thread_id()
     );
 
     Ok(())
-}
-
-unsafe fn setup_codex_app_server_env(
-    mock_path: &Path,
-    home: &Path,
-    resume_thread_id: &str,
-) -> Result<(), String> {
-    unsafe {
-        std::env::set_var("CLI_AGENT_TYPE", "codex");
-        std::env::set_var("VM0_CODEX_APP_SERVER_BACKEND", "1");
-        std::env::set_var("VM0_MOCK_CODEX_PATH", mock_path);
-        std::env::set_var("USE_MOCK_CODEX", "true");
-        std::env::remove_var("MOCK_CODEX_FIXTURE");
-        std::env::set_var(
-            "MOCK_CODEX_APP_SERVER_SCENARIO",
-            "resume-different-thread-id",
-        );
-        std::env::set_var("VM0_RESUME_SESSION_ID", resume_thread_id);
-        std::env::set_var(
-            "VM0_RUN_ID",
-            "codex-app-server-backend-resume-mismatch-test",
-        );
-        std::env::set_var(
-            "VM0_PROMPT",
-            "drive the app-server backend resume mismatch path",
-        );
-        std::env::set_var("VM0_API_URL", "http://127.0.0.1:1");
-        std::env::set_var("VM0_API_TOKEN", "");
-        std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");
-        std::env::set_var("VM0_SANDBOX_REUSE_RESULT", "reused");
-        std::env::set_var("HOME", home);
-    }
-    std::fs::create_dir_all(home).map_err(|error| format!("create home: {error}"))?;
-    common::ensure_canonical_workspace_for_test()?;
-    std::env::set_current_dir(home).map_err(|error| format!("set_current_dir: {error}"))?;
-    Ok(())
-}
-
-fn build_and_locate_mock_codex() -> Result<PathBuf, String> {
-    let exe = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
-    let target_profile_dir = exe
-        .parent()
-        .and_then(|p| p.parent())
-        .ok_or_else(|| "target/<profile> dir".to_string())?;
-    let target_dir = target_profile_dir
-        .parent()
-        .ok_or_else(|| "target dir".to_string())?;
-    let profile_dir_name = target_profile_dir
-        .file_name()
-        .and_then(|n| n.to_str())
-        .ok_or_else(|| "profile dir name".to_string())?;
-
-    let mut cmd = std::process::Command::new("cargo");
-    cmd.args(["build", "-p", "guest-mock-codex", "--quiet"])
-        .arg("--target-dir")
-        .arg(target_dir);
-    match profile_dir_name {
-        "debug" => {}
-        "release" => {
-            cmd.arg("--release");
-        }
-        other => {
-            cmd.args(["--profile", other]);
-        }
-    }
-
-    let status = cmd
-        .status()
-        .map_err(|e| format!("invoke cargo build: {e}"))?;
-    if !status.success() {
-        return Err("cargo build -p guest-mock-codex failed".into());
-    }
-
-    let mock = target_profile_dir.join("guest-mock-codex");
-    if !mock.exists() {
-        return Err(format!("mock binary not found at {}", mock.display()));
-    }
-    Ok(mock)
 }

--- a/crates/guest-agent/tests/codex_app_server_backend_scope.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_scope.rs
@@ -8,17 +8,25 @@ mod common;
 use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
 use serde_json::Value;
-use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 #[tokio::test]
 async fn codex_app_server_backend_rejects_unexpected_thread_event_scope()
 -> Result<(), Box<dyn std::error::Error>> {
-    let mock = build_and_locate_mock_codex()?;
+    let mock = common::build_and_locate_mock_codex()?;
     let tmp = tempfile::tempdir()?;
 
     unsafe {
-        setup_codex_app_server_env(&mock, tmp.path())?;
+        common::setup_codex_app_server_env(
+            &mock,
+            tmp.path(),
+            common::CodexAppServerEnvConfig {
+                run_id: "codex-app-server-backend-scope-test",
+                prompt: "drive the app-server backend scope failure path",
+                scenario: Some("unexpected-thread-turn-completed"),
+                resume_session_id: None,
+            },
+        )?;
     }
     let _run_files = common::RunFilesGuard::new();
 
@@ -57,75 +65,4 @@ fn read_agent_log_events() -> Result<Vec<Value>, Box<dyn std::error::Error>> {
     log.lines()
         .map(|line| serde_json::from_str(line).map_err(Into::into))
         .collect()
-}
-
-unsafe fn setup_codex_app_server_env(mock_path: &Path, home: &Path) -> Result<(), String> {
-    unsafe {
-        std::env::set_var("CLI_AGENT_TYPE", "codex");
-        std::env::set_var("VM0_CODEX_APP_SERVER_BACKEND", "1");
-        std::env::set_var("VM0_MOCK_CODEX_PATH", mock_path);
-        std::env::set_var("USE_MOCK_CODEX", "true");
-        std::env::remove_var("MOCK_CODEX_FIXTURE");
-        std::env::set_var(
-            "MOCK_CODEX_APP_SERVER_SCENARIO",
-            "unexpected-thread-turn-completed",
-        );
-        std::env::set_var("VM0_RUN_ID", "codex-app-server-backend-scope-test");
-        std::env::set_var(
-            "VM0_PROMPT",
-            "drive the app-server backend scope failure path",
-        );
-        std::env::set_var("VM0_API_URL", "http://127.0.0.1:1");
-        std::env::set_var("VM0_API_TOKEN", "");
-        std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");
-        std::env::set_var("VM0_SANDBOX_REUSE_RESULT", "reused");
-        std::env::set_var("HOME", home);
-        std::env::remove_var("VM0_RESUME_SESSION_ID");
-    }
-    std::fs::create_dir_all(home).map_err(|error| format!("create home: {error}"))?;
-    common::ensure_canonical_workspace_for_test()?;
-    std::env::set_current_dir(home).map_err(|error| format!("set_current_dir: {error}"))?;
-    Ok(())
-}
-
-fn build_and_locate_mock_codex() -> Result<PathBuf, String> {
-    let exe = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
-    let target_profile_dir = exe
-        .parent()
-        .and_then(|p| p.parent())
-        .ok_or_else(|| "target/<profile> dir".to_string())?;
-    let target_dir = target_profile_dir
-        .parent()
-        .ok_or_else(|| "target dir".to_string())?;
-    let profile_dir_name = target_profile_dir
-        .file_name()
-        .and_then(|n| n.to_str())
-        .ok_or_else(|| "profile dir name".to_string())?;
-
-    let mut cmd = std::process::Command::new("cargo");
-    cmd.args(["build", "-p", "guest-mock-codex", "--quiet"])
-        .arg("--target-dir")
-        .arg(target_dir);
-    match profile_dir_name {
-        "debug" => {}
-        "release" => {
-            cmd.arg("--release");
-        }
-        other => {
-            cmd.args(["--profile", other]);
-        }
-    }
-
-    let status = cmd
-        .status()
-        .map_err(|e| format!("invoke cargo build: {e}"))?;
-    if !status.success() {
-        return Err("cargo build -p guest-mock-codex failed".into());
-    }
-
-    let mock = target_profile_dir.join("guest-mock-codex");
-    if !mock.exists() {
-        return Err(format!("mock binary not found at {}", mock.display()));
-    }
-    Ok(mock)
 }

--- a/crates/guest-agent/tests/codex_app_server_client.rs
+++ b/crates/guest-agent/tests/codex_app_server_client.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use std::future::{Future, poll_fn};
 use std::ops::{Deref, DerefMut};
 use std::path::PathBuf;
@@ -903,50 +905,8 @@ fn spawn_client(scenario: Option<&str>) -> Result<ClientFixture, String> {
 
 fn mock_codex_path() -> Result<PathBuf, String> {
     MOCK_CODEX_BUILD
-        .get_or_init(build_and_locate_mock_codex)
+        .get_or_init(common::build_and_locate_mock_codex)
         .clone()
-}
-
-fn build_and_locate_mock_codex() -> Result<PathBuf, String> {
-    let exe = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
-    let target_profile_dir = exe
-        .parent()
-        .and_then(|p| p.parent())
-        .ok_or_else(|| "target/<profile> dir".to_string())?;
-    let target_dir = target_profile_dir
-        .parent()
-        .ok_or_else(|| "target dir".to_string())?;
-    let profile_dir_name = target_profile_dir
-        .file_name()
-        .and_then(|n| n.to_str())
-        .ok_or_else(|| "profile dir name".to_string())?;
-
-    let mut cmd = std::process::Command::new("cargo");
-    cmd.args(["build", "-p", "guest-mock-codex", "--quiet"])
-        .arg("--target-dir")
-        .arg(target_dir);
-    match profile_dir_name {
-        "debug" => {}
-        "release" => {
-            cmd.arg("--release");
-        }
-        other => {
-            cmd.args(["--profile", other]);
-        }
-    }
-
-    let status = cmd
-        .status()
-        .map_err(|e| format!("invoke cargo build: {e}"))?;
-    if !status.success() {
-        return Err("cargo build -p guest-mock-codex failed".into());
-    }
-
-    let mock = target_profile_dir.join("guest-mock-codex");
-    if !mock.exists() {
-        return Err(format!("mock binary not found at {}", mock.display()));
-    }
-    Ok(mock)
 }
 
 async fn wait_result<T>(

--- a/crates/guest-agent/tests/codex_jsonl_failure_logging.rs
+++ b/crates/guest-agent/tests/codex_jsonl_failure_logging.rs
@@ -9,12 +9,12 @@ use common::SystemLogOverrideGuard;
 use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
 use guest_contracts::diagnostics::{FailureDetailSource, FailureReason};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::time::Duration;
 
 #[tokio::test]
 async fn codex_jsonl_failure_events_are_reported() -> Result<(), Box<dyn std::error::Error>> {
-    let mock = build_and_locate_mock_codex()?;
+    let mock = common::build_and_locate_mock_codex()?;
     let tmp = tempfile::tempdir()?;
     let system_log_path = tmp.path().join("system.log");
 
@@ -86,48 +86,6 @@ async fn codex_jsonl_failure_events_are_reported() -> Result<(), Box<dyn std::er
     );
 
     Ok(())
-}
-
-fn build_and_locate_mock_codex() -> Result<PathBuf, String> {
-    let exe = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
-    let target_profile_dir = exe
-        .parent()
-        .and_then(|p| p.parent())
-        .ok_or_else(|| "target/<profile> dir".to_string())?;
-    let target_dir = target_profile_dir
-        .parent()
-        .ok_or_else(|| "target dir".to_string())?;
-    let profile_dir_name = target_profile_dir
-        .file_name()
-        .and_then(|n| n.to_str())
-        .ok_or_else(|| "profile dir name".to_string())?;
-
-    let mut cmd = std::process::Command::new("cargo");
-    cmd.args(["build", "-p", "guest-mock-codex", "--quiet"])
-        .arg("--target-dir")
-        .arg(target_dir);
-    match profile_dir_name {
-        "debug" => {}
-        "release" => {
-            cmd.arg("--release");
-        }
-        other => {
-            cmd.args(["--profile", other]);
-        }
-    }
-
-    let status = cmd
-        .status()
-        .map_err(|e| format!("invoke cargo build: {e}"))?;
-    if !status.success() {
-        return Err("cargo build -p guest-mock-codex failed".into());
-    }
-
-    let mock = target_profile_dir.join("guest-mock-codex");
-    if !mock.exists() {
-        return Err(format!("mock binary not found at {}", mock.display()));
-    }
-    Ok(mock)
 }
 
 unsafe fn setup_codex_env(

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -437,6 +437,14 @@ fn build_and_locate_mock_package(package: &str, binary: &str) -> Result<PathBuf,
     Ok(mock)
 }
 
+/// Test-specific values for the experimental Codex app-server backend env.
+pub struct CodexAppServerEnvConfig<'a> {
+    pub run_id: &'a str,
+    pub prompt: &'a str,
+    pub scenario: Option<&'a str>,
+    pub resume_session_id: Option<&'a str>,
+}
+
 /// Configure one test binary for the experimental Codex app-server backend.
 ///
 /// Must be called before any `guest_agent::env::*` accessor because those
@@ -448,9 +456,7 @@ fn build_and_locate_mock_package(package: &str, binary: &str) -> Result<PathBuf,
 pub unsafe fn setup_codex_app_server_env(
     mock_path: &Path,
     home: &Path,
-    run_id: &str,
-    prompt: &str,
-    scenario: &str,
+    config: CodexAppServerEnvConfig<'_>,
 ) -> Result<(), String> {
     unsafe {
         std::env::set_var("CLI_AGENT_TYPE", "codex");
@@ -458,15 +464,23 @@ pub unsafe fn setup_codex_app_server_env(
         std::env::set_var("VM0_MOCK_CODEX_PATH", mock_path);
         std::env::set_var("USE_MOCK_CODEX", "true");
         std::env::remove_var("MOCK_CODEX_FIXTURE");
-        std::env::set_var("MOCK_CODEX_APP_SERVER_SCENARIO", scenario);
-        std::env::set_var("VM0_RUN_ID", run_id);
-        std::env::set_var("VM0_PROMPT", prompt);
+        if let Some(scenario) = config.scenario {
+            std::env::set_var("MOCK_CODEX_APP_SERVER_SCENARIO", scenario);
+        } else {
+            std::env::remove_var("MOCK_CODEX_APP_SERVER_SCENARIO");
+        }
+        std::env::set_var("VM0_RUN_ID", config.run_id);
+        std::env::set_var("VM0_PROMPT", config.prompt);
         std::env::set_var("VM0_API_URL", "http://127.0.0.1:1");
         std::env::set_var("VM0_API_TOKEN", "");
         std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");
         std::env::set_var("VM0_SANDBOX_REUSE_RESULT", "reused");
         std::env::set_var("HOME", home);
-        std::env::remove_var("VM0_RESUME_SESSION_ID");
+        if let Some(resume_session_id) = config.resume_session_id {
+            std::env::set_var("VM0_RESUME_SESSION_ID", resume_session_id);
+        } else {
+            std::env::remove_var("VM0_RESUME_SESSION_ID");
+        }
     }
     std::fs::create_dir_all(home).map_err(|error| format!("create home: {error}"))?;
     ensure_canonical_workspace_for_test()?;


### PR DESCRIPTION
## Summary
- Add a named Codex app-server test env config that preserves scenario and resume-id absence with env removal.
- Migrate Codex app-server backend tests to the shared env setup and mock Codex build helper.
- Reuse the shared mock Codex build helper in the JSONL failure logging and app-server client tests while keeping their local test semantics.

## Tests
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent codex_app_server_backend`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test codex_jsonl_failure_logging`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test codex_app_server_client`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --quiet`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `git diff --check`
- pre-commit: `cargo clippy --all-targets --all-features`

Closes #19526
