### PR TITLE
fix: disable Claude Code attachments for incompatible providers

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -1485,8 +1485,7 @@ describe("CHAT-02: explicit provider pins", () => {
       });
     };
     const cleanupRunAndKeys = async () => {
-      await deleteVm0KimiKeys();
-      await cancelRunIfCreated();
+      await Promise.all([deleteVm0KimiKeys(), cancelRunIfCreated()]);
     };
 
     await (async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -1471,35 +1471,52 @@ describe("CHAT-02: explicit provider pins", () => {
       ],
     });
 
-    const { providerId } = await upsertOrgModelProvider(actor, {
-      type: "vm0",
-    });
+    let runId: string | null = null;
+    const cancelRunIfCreated = async () => {
+      if (runId) {
+        await api.requestCancelRun(actor, runId, [200]);
+      }
+    };
+    const deleteVm0KimiKeys = async () => {
+      await postChatMessagesStateAction({
+        action: "delete-vm0-api-keys",
+        vendor: "moonshot",
+        model: "kimi-k2.7-code",
+      });
+    };
+    const cleanupRunAndKeys = async () => {
+      await deleteVm0KimiKeys();
+      await cancelRunIfCreated();
+    };
 
-    const run = await sendChatRun(actor, {
-      agentId,
-      prompt: "run with the selected vm0 kimi provider",
-      modelSelection: {
-        modelProviderId: providerId,
-        selectedModel: "kimi-k2.7-code",
-      },
-    });
+    await (async () => {
+      const { providerId } = await upsertOrgModelProvider(actor, {
+        type: "vm0",
+      });
 
-    const { claim } = await claimChatRun(runnerGroup, run.runId);
-    const environment = claimEnvironment(claim);
-    expect(environment.ANTHROPIC_AUTH_TOKEN).toBe(
-      modelProviderSecretPlaceholder("moonshot-api-key", "MOONSHOT_API_KEY"),
-    );
-    expect(environment.ANTHROPIC_BASE_URL).toBe(
-      "https://api.moonshot.ai/anthropic",
-    );
-    expect(environment.ANTHROPIC_MODEL).toBe("kimi-k2.7-code");
-    expect(environment.CLAUDE_CODE_DISABLE_ATTACHMENTS).toBe("1");
+      const run = await sendChatRun(actor, {
+        agentId,
+        prompt: "run with the selected vm0 kimi provider",
+        modelSelection: {
+          modelProviderId: providerId,
+          selectedModel: "kimi-k2.7-code",
+        },
+      });
+      runId = run.runId;
 
-    await api.requestCancelRun(actor, run.runId, [200]);
-    await postChatMessagesStateAction({
-      action: "delete-vm0-api-keys",
-      vendor: "moonshot",
-      model: "kimi-k2.7-code",
+      const { claim } = await claimChatRun(runnerGroup, run.runId);
+      const environment = claimEnvironment(claim);
+      expect(environment.ANTHROPIC_AUTH_TOKEN).toBe(
+        modelProviderSecretPlaceholder("moonshot-api-key", "MOONSHOT_API_KEY"),
+      );
+      expect(environment.ANTHROPIC_BASE_URL).toBe(
+        "https://api.moonshot.ai/anthropic",
+      );
+      expect(environment.ANTHROPIC_MODEL).toBe("kimi-k2.7-code");
+      expect(environment.CLAUDE_CODE_DISABLE_ATTACHMENTS).toBe("1");
+    })().then(cleanupRunAndKeys, async (error: unknown) => {
+      await cleanupRunAndKeys();
+      throw error;
     });
   }, 90_000);
 

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -1343,6 +1343,7 @@ describe("CHAT-02: explicit provider pins", () => {
       "https://api.deepseek.com/anthropic",
     );
     expect(environment.ANTHROPIC_MODEL).toBe("deepseek-v4-pro");
+    expect(environment.CLAUDE_CODE_DISABLE_ATTACHMENTS).toBe("1");
     expect(environment.ANTHROPIC_API_KEY).toBeUndefined();
 
     // Explicit pins persist on the thread as model-only state.
@@ -1421,6 +1422,7 @@ describe("CHAT-02: explicit provider pins", () => {
     expect(environment.CLAUDE_CODE_SUBAGENT_MODEL).toBe(
       "anthropic/claude-opus-4.7",
     );
+    expect(environment.CLAUDE_CODE_DISABLE_ATTACHMENTS).toBeUndefined();
 
     if (!claim.encryptedSecrets) {
       throw new Error("Expected OpenRouter claim to carry encrypted secrets");
@@ -1451,6 +1453,54 @@ describe("CHAT-02: explicit provider pins", () => {
     expect(thread.modelProviderId ?? null).toBeNull();
 
     await api.requestCancelRun(actor, run.runId, [200]);
+  }, 90_000);
+
+  it("routes vm0 Kimi through Moonshot attachment-disabled env bindings", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    const keySuffix = randomUUID();
+
+    await postChatMessagesStateAction({
+      action: "replace-vm0-api-keys",
+      vendor: "moonshot",
+      model: "kimi-k2.7-code",
+      keys: [
+        {
+          api_key: `vm0-key-bdd-dev-seed-${keySuffix}`,
+          label: "dev-seed",
+        },
+      ],
+    });
+
+    const { providerId } = await upsertOrgModelProvider(actor, {
+      type: "vm0",
+    });
+
+    const run = await sendChatRun(actor, {
+      agentId,
+      prompt: "run with the selected vm0 kimi provider",
+      modelSelection: {
+        modelProviderId: providerId,
+        selectedModel: "kimi-k2.7-code",
+      },
+    });
+
+    const { claim } = await claimChatRun(runnerGroup, run.runId);
+    const environment = claimEnvironment(claim);
+    expect(environment.ANTHROPIC_AUTH_TOKEN).toBe(
+      modelProviderSecretPlaceholder("moonshot-api-key", "MOONSHOT_API_KEY"),
+    );
+    expect(environment.ANTHROPIC_BASE_URL).toBe(
+      "https://api.moonshot.ai/anthropic",
+    );
+    expect(environment.ANTHROPIC_MODEL).toBe("kimi-k2.7-code");
+    expect(environment.CLAUDE_CODE_DISABLE_ATTACHMENTS).toBe("1");
+
+    await api.requestCancelRun(actor, run.runId, [200]);
+    await postChatMessagesStateAction({
+      action: "delete-vm0-api-keys",
+      vendor: "moonshot",
+      model: "kimi-k2.7-code",
+    });
   }, 90_000);
 
   it("prefers dev-seed vm0 managed keys over concurrent test keys", async () => {

--- a/turbo/apps/api/src/signals/routes/test-chat-messages-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-chat-messages-state.ts
@@ -1,6 +1,7 @@
 import { command } from "ccstate";
 import {
   testChatMessagesStateContract,
+  VM0_BDD_API_KEY_PREFIXES,
   type TestChatMessagesStateActionBody,
 } from "@vm0/api-contracts/contracts/test-chat-messages-state";
 import { agentRuns } from "@vm0/db/schema/agent-run";
@@ -34,12 +35,13 @@ function actionOk(extra: Record<string, unknown> = {}) {
 }
 
 function bddVm0ApiKeyFilter(vendor: string, model: string) {
+  const [fakePrefix, devSeedPrefix] = VM0_BDD_API_KEY_PREFIXES;
   return and(
     eq(vm0ApiKeys.vendor, vendor),
     eq(vm0ApiKeys.model, model),
     or(
-      like(vm0ApiKeys.apiKey, "vm0-key-bdd-fake-%"),
-      like(vm0ApiKeys.apiKey, "vm0-key-bdd-dev-seed-%"),
+      like(vm0ApiKeys.apiKey, `${fakePrefix}%`),
+      like(vm0ApiKeys.apiKey, `${devSeedPrefix}%`),
     ),
   );
 }
@@ -111,23 +113,25 @@ async function replaceVm0ApiKeysForAction(
   body: ChatMessagesAction<"replace-vm0-api-keys">,
   signal: AbortSignal,
 ) {
-  await db
-    .delete(vm0ApiKeys)
-    .where(bddVm0ApiKeyFilter(body.vendor, body.model));
-  signal.throwIfAborted();
-  if (body.keys.length > 0) {
-    await db.insert(vm0ApiKeys).values(
-      body.keys.map((key) => {
-        return {
-          vendor: body.vendor,
-          model: body.model,
-          apiKey: key.api_key,
-          label: key.label,
-        };
-      }),
-    );
+  await db.transaction(async (tx) => {
+    await tx
+      .delete(vm0ApiKeys)
+      .where(bddVm0ApiKeyFilter(body.vendor, body.model));
     signal.throwIfAborted();
-  }
+    if (body.keys.length > 0) {
+      await tx.insert(vm0ApiKeys).values(
+        body.keys.map((key) => {
+          return {
+            vendor: body.vendor,
+            model: body.model,
+            apiKey: key.api_key,
+            label: key.label,
+          };
+        }),
+      );
+      signal.throwIfAborted();
+    }
+  });
   return actionOk();
 }
 

--- a/turbo/apps/api/src/signals/routes/test-chat-messages-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-chat-messages-state.ts
@@ -33,9 +33,9 @@ function actionOk(extra: Record<string, unknown> = {}) {
   return { status: 200 as const, body: { ok: true as const, ...extra } };
 }
 
-function bddVm0OpenRouterKeyFilter(model: string) {
+function bddVm0ApiKeyFilter(vendor: string, model: string) {
   return and(
-    eq(vm0ApiKeys.vendor, "openrouter"),
+    eq(vm0ApiKeys.vendor, vendor),
     eq(vm0ApiKeys.model, model),
     or(
       like(vm0ApiKeys.apiKey, "vm0-key-bdd-fake-%"),
@@ -94,13 +94,32 @@ async function replaceOpenRouterVm0ApiKeysForAction(
   body: ChatMessagesAction<"replace-openrouter-vm0-api-keys">,
   signal: AbortSignal,
 ) {
-  await db.delete(vm0ApiKeys).where(bddVm0OpenRouterKeyFilter(body.model));
+  return await replaceVm0ApiKeysForAction(
+    db,
+    {
+      action: "replace-vm0-api-keys",
+      vendor: "openrouter",
+      model: body.model,
+      keys: body.keys,
+    },
+    signal,
+  );
+}
+
+async function replaceVm0ApiKeysForAction(
+  db: Db,
+  body: ChatMessagesAction<"replace-vm0-api-keys">,
+  signal: AbortSignal,
+) {
+  await db
+    .delete(vm0ApiKeys)
+    .where(bddVm0ApiKeyFilter(body.vendor, body.model));
   signal.throwIfAborted();
   if (body.keys.length > 0) {
     await db.insert(vm0ApiKeys).values(
       body.keys.map((key) => {
         return {
-          vendor: "openrouter",
+          vendor: body.vendor,
           model: body.model,
           apiKey: key.api_key,
           label: key.label,
@@ -117,7 +136,25 @@ async function deleteOpenRouterVm0ApiKeysForAction(
   body: ChatMessagesAction<"delete-openrouter-vm0-api-keys">,
   signal: AbortSignal,
 ) {
-  await db.delete(vm0ApiKeys).where(bddVm0OpenRouterKeyFilter(body.model));
+  return await deleteVm0ApiKeysForAction(
+    db,
+    {
+      action: "delete-vm0-api-keys",
+      vendor: "openrouter",
+      model: body.model,
+    },
+    signal,
+  );
+}
+
+async function deleteVm0ApiKeysForAction(
+  db: Db,
+  body: ChatMessagesAction<"delete-vm0-api-keys">,
+  signal: AbortSignal,
+) {
+  await db
+    .delete(vm0ApiKeys)
+    .where(bddVm0ApiKeyFilter(body.vendor, body.model));
   signal.throwIfAborted();
   return actionOk();
 }
@@ -171,6 +208,12 @@ const mutateChatMessagesState$ = command(
       }
       case "delete-openrouter-vm0-api-keys": {
         return await deleteOpenRouterVm0ApiKeysForAction(db, body, signal);
+      }
+      case "replace-vm0-api-keys": {
+        return await replaceVm0ApiKeysForAction(db, body, signal);
+      }
+      case "delete-vm0-api-keys": {
+        return await deleteVm0ApiKeysForAction(db, body, signal);
       }
       case "attach-pre-dispatch-cancelled-run-to-thread": {
         return await attachPreDispatchCancelledRunToThreadForAction(

--- a/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
@@ -515,6 +515,27 @@ describe("model selection for Claude-compatible gateway providers", () => {
       );
     },
   );
+
+  it.each(["moonshot-api-key", "minimax-api-key", "deepseek-api-key"] as const)(
+    "%s disables Claude Code attachments",
+    (type) => {
+      const envBindings = getModelProviderEnvBindings(type);
+      expect(envBindings).toBeDefined();
+      expect(envBindings!["CLAUDE_CODE_DISABLE_ATTACHMENTS"]).toBe("1");
+    },
+  );
+
+  it.each([
+    "anthropic-api-key",
+    "claude-code-oauth-token",
+    "openrouter-api-key",
+    "vercel-ai-gateway",
+    "zai-api-key",
+  ] as const)("%s keeps Claude Code attachments enabled", (type) => {
+    const envBindings = getModelProviderEnvBindings(type);
+    expect(envBindings).toBeDefined();
+    expect(envBindings!["CLAUDE_CODE_DISABLE_ATTACHMENTS"]).toBeUndefined();
+  });
 });
 
 describe("getVm0VisibleModels", () => {

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -442,6 +442,8 @@ export const MODEL_PROVIDER_TYPES = {
       ANTHROPIC_DEFAULT_SONNET_MODEL: "$model",
       ANTHROPIC_DEFAULT_HAIKU_MODEL: "$model",
       CLAUDE_CODE_SUBAGENT_MODEL: "$model",
+      // Moonshot rejects Anthropic document blocks; keep attachments as text.
+      CLAUDE_CODE_DISABLE_ATTACHMENTS: "1",
     } satisfies ModelProviderEnvBindings,
     models: [
       "kimi-k2.7-code",
@@ -467,6 +469,8 @@ export const MODEL_PROVIDER_TYPES = {
       CLAUDE_CODE_SUBAGENT_MODEL: "$model",
       API_TIMEOUT_MS: "3000000",
       CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
+      // MiniMax does not document support for Anthropic document blocks.
+      CLAUDE_CODE_DISABLE_ATTACHMENTS: "1",
     } satisfies ModelProviderEnvBindings,
     models: ["MiniMax-M3", "MiniMax-M2.1"] as string[],
     defaultModel: "MiniMax-M3",
@@ -487,6 +491,8 @@ export const MODEL_PROVIDER_TYPES = {
       CLAUDE_CODE_SUBAGENT_MODEL: "$model",
       API_TIMEOUT_MS: "600000",
       CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
+      // DeepSeek explicitly rejects Anthropic document blocks.
+      CLAUDE_CODE_DISABLE_ATTACHMENTS: "1",
     } satisfies ModelProviderEnvBindings,
     models: ["deepseek-v4-pro"] as string[],
     defaultModel: "deepseek-v4-pro",

--- a/turbo/packages/api-contracts/src/contracts/test-chat-messages-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-chat-messages-state.ts
@@ -8,12 +8,16 @@ export const testChatMessagesStateErrorSchema = z.object({
   error: z.string(),
 });
 
+export const VM0_BDD_API_KEY_PREFIXES = [
+  "vm0-key-bdd-fake-",
+  "vm0-key-bdd-dev-seed-",
+] as const;
+
 const vm0BddApiKeySchema = z.string().refine(
   (apiKey) => {
-    return (
-      apiKey.startsWith("vm0-key-bdd-fake-") ||
-      apiKey.startsWith("vm0-key-bdd-dev-seed-")
-    );
+    return VM0_BDD_API_KEY_PREFIXES.some((prefix) => {
+      return apiKey.length > prefix.length && apiKey.startsWith(prefix);
+    });
   },
   { message: "Expected a bdd-scoped vm0 API key" },
 );

--- a/turbo/packages/api-contracts/src/contracts/test-chat-messages-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-chat-messages-state.ts
@@ -36,6 +36,17 @@ export const testChatMessagesStateActionBodySchema = z.discriminatedUnion(
       model: z.string(),
     }),
     z.object({
+      action: z.literal("replace-vm0-api-keys"),
+      vendor: z.string(),
+      model: z.string(),
+      keys: z.array(vm0ApiKeySeedSchema),
+    }),
+    z.object({
+      action: z.literal("delete-vm0-api-keys"),
+      vendor: z.string(),
+      model: z.string(),
+    }),
+    z.object({
       action: z.literal("attach-pre-dispatch-cancelled-run-to-thread"),
       run_id: z.uuid(),
       thread_id: z.uuid(),

--- a/turbo/packages/api-contracts/src/contracts/test-chat-messages-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-chat-messages-state.ts
@@ -8,8 +8,18 @@ export const testChatMessagesStateErrorSchema = z.object({
   error: z.string(),
 });
 
+const vm0BddApiKeySchema = z.string().refine(
+  (apiKey) => {
+    return (
+      apiKey.startsWith("vm0-key-bdd-fake-") ||
+      apiKey.startsWith("vm0-key-bdd-dev-seed-")
+    );
+  },
+  { message: "Expected a bdd-scoped vm0 API key" },
+);
+
 const vm0ApiKeySeedSchema = z.object({
-  api_key: z.string(),
+  api_key: vm0BddApiKeySchema,
   label: z.string(),
 });
 

--- a/turbo/packages/api-contracts/src/contracts/test-chat-messages-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-chat-messages-state.ts
@@ -13,6 +13,15 @@ const vm0ApiKeySeedSchema = z.object({
   label: z.string(),
 });
 
+const vm0ApiKeyVendorSchema = z.enum([
+  "anthropic",
+  "deepseek",
+  "minimax",
+  "moonshot",
+  "openai",
+  "openrouter",
+]);
+
 export const testChatMessagesStateActionBodySchema = z.discriminatedUnion(
   "action",
   [
@@ -37,13 +46,13 @@ export const testChatMessagesStateActionBodySchema = z.discriminatedUnion(
     }),
     z.object({
       action: z.literal("replace-vm0-api-keys"),
-      vendor: z.string(),
+      vendor: vm0ApiKeyVendorSchema,
       model: z.string(),
       keys: z.array(vm0ApiKeySeedSchema),
     }),
     z.object({
       action: z.literal("delete-vm0-api-keys"),
-      vendor: z.string(),
+      vendor: vm0ApiKeyVendorSchema,
       model: z.string(),
     }),
     z.object({


### PR DESCRIPTION
## Summary
- Set `CLAUDE_CODE_DISABLE_ATTACHMENTS=1` for Moonshot, MiniMax, and DeepSeek model provider env bindings because these Claude-compatible gateways do not support Anthropic document blocks.
- Keep attachments enabled for Anthropic, Claude Code OAuth, OpenRouter, Vercel AI Gateway, and Z.ai.
- Add vm0-managed Moonshot Kimi coverage so `kimi-k2.7-code` inherits the attachment-disabled env binding through provider resolution.

## Tests
- `pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/model-providers.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-messages.bdd.test.ts`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- pre-commit: prettier, knip, `pnpm check-types`

Closes #19377