### PR TITLE
fix: add telegram callback rate-limit retry

### DIFF
--- a/turbo/apps/api/src/__tests__/mocks.ts
+++ b/turbo/apps/api/src/__tests__/mocks.ts
@@ -6,6 +6,10 @@ import { mockStripeClient } from "../signals/external/stripe-client";
 
 type AsyncMock = Mock<(...args: unknown[]) => Promise<unknown>>;
 type BooleanMock = Mock<(...args: unknown[]) => boolean>;
+type SignalTimerDelayOptions = { readonly signal?: AbortSignal };
+type SignalTimerDelayMock = Mock<
+  (ms: number, options?: SignalTimerDelayOptions) => Promise<void>
+>;
 type SyncMock = Mock<(...args: unknown[]) => void>;
 type UnknownMock = Mock<(...args: unknown[]) => unknown>;
 
@@ -70,6 +74,9 @@ export interface ApiTestMocks {
     readonly get: AsyncMock;
     readonly receivingGet: AsyncMock;
     readonly attachmentsList: AsyncMock;
+  };
+  readonly signalTimers: {
+    readonly delay: SignalTimerDelayMock;
   };
   readonly slack: {
     readonly assistant: {
@@ -354,6 +361,12 @@ const apiTestMocks: ApiTestMocks = vi.hoisted((): ApiTestMocks => {
       receivingGet: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
       attachmentsList: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
     },
+    signalTimers: {
+      delay:
+        vi.fn<
+          (ms: number, options?: SignalTimerDelayOptions) => Promise<void>
+        >(),
+    },
     slack,
     stripe,
     vercelOidc: {
@@ -533,6 +546,19 @@ vi.mock("resend", () => {
         },
       };
     }),
+  };
+});
+
+vi.mock("signal-timers", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("signal-timers")>();
+  return {
+    ...actual,
+    delay: (ms: number, options?: SignalTimerDelayOptions): Promise<void> => {
+      if (apiTestMocks.signalTimers.delay.getMockImplementation()) {
+        return apiTestMocks.signalTimers.delay(ms, options);
+      }
+      return actual.delay(ms, options);
+    },
   };
 });
 
@@ -803,6 +829,7 @@ export function resetApiTestMocks(): void {
   apiTestMocks.resend.get.mockReset();
   apiTestMocks.resend.receivingGet.mockReset();
   apiTestMocks.resend.attachmentsList.mockReset();
+  apiTestMocks.signalTimers.delay.mockReset();
   apiTestMocks.slack.assistant.threads.setStatus.mockReset();
   apiTestMocks.slack.chat.postMessage.mockReset();
   apiTestMocks.slack.chat.postEphemeral.mockReset();

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-telegram.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-telegram.test.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 
 import { createStore } from "ccstate";
 import { HttpResponse, http } from "msw";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { OFFICIAL_TELEGRAM_BOT_ID } from "@vm0/api-contracts/contracts/zero-integrations-telegram";
 import type {
@@ -77,6 +77,11 @@ interface TelegramSendMessageBody {
   readonly reply_parameters?: { readonly message_id: number };
 }
 
+interface TelegramMockResponse {
+  readonly status?: number;
+  readonly body: Record<string, unknown>;
+}
+
 interface TelegramStateMessage {
   readonly text: string;
   readonly isBot: boolean;
@@ -89,7 +94,43 @@ interface TelegramStateRun {
   readonly selected_model: string | null;
 }
 
-function telegramApiMocks(token = TEST_BOT_TOKEN): {
+function runTelegramSendDelaysImmediately(): {
+  readonly delays: number[];
+  readonly restore: () => void;
+} {
+  const delays: number[] = [];
+  const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(((
+    handler: (...args: unknown[]) => void,
+    delay?: number,
+    ...args: unknown[]
+  ) => {
+    delays.push(delay ?? 0);
+    queueMicrotask(() => {
+      handler(...args);
+    });
+    const timeout = {
+      hasRef: () => false,
+      refresh: () => timeout,
+      ref: () => timeout,
+      unref: () => timeout,
+    };
+    return timeout as unknown as ReturnType<typeof setTimeout>;
+  }) as typeof setTimeout);
+
+  return {
+    delays,
+    restore: () => {
+      setTimeoutSpy.mockRestore();
+    },
+  };
+}
+
+function telegramApiMocks(
+  token = TEST_BOT_TOKEN,
+  options: {
+    readonly sendMessageResponses?: readonly TelegramMockResponse[];
+  } = {},
+): {
   readonly chatActions: unknown[];
   readonly deleteMessages: unknown[];
   readonly sentMessages: TelegramSendMessageBody[];
@@ -119,6 +160,13 @@ function telegramApiMocks(token = TEST_BOT_TOKEN): {
       async ({ request }) => {
         const body = (await request.json()) as TelegramSendMessageBody;
         sentMessages.push(body);
+        const mockResponse =
+          options.sendMessageResponses?.[sentMessages.length - 1];
+        if (mockResponse) {
+          return HttpResponse.json(mockResponse.body, {
+            status: mockResponse.status,
+          });
+        }
         return HttpResponse.json({
           ok: true,
           result: {
@@ -469,6 +517,8 @@ async function findThreadSession(args: {
 }
 
 afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
   context.mocks.axiom.query.mockReset();
   clearMockedEnv();
 });
@@ -541,6 +591,84 @@ describe("POST /api/internal/callbacks/telegram", () => {
       text: "**Done** with `code`",
       isBot: true,
     });
+  });
+
+  it("retries Telegram completion replies on 429 with Fibonacci backoff", async () => {
+    const fixture = await track(seedFixture());
+    const telegram = telegramApiMocks(TEST_BOT_TOKEN, {
+      sendMessageResponses: [
+        {
+          status: 429,
+          body: { ok: false, description: "Too Many Requests" },
+        },
+      ],
+    });
+    completedOutput("Retried result");
+
+    const timer = runTelegramSendDelaysImmediately();
+    const result = await dispatchTelegramCallback({
+      callbackId: fixture.callbackId,
+      runId: fixture.runId,
+      status: "completed",
+      payload: fixture.payload,
+    });
+    timer.restore();
+
+    expect(result).toStrictEqual({ success: true });
+    expect(timer.delays).toContain(1000);
+    expect(telegram.sentMessages).toHaveLength(2);
+    expect(telegram.sentMessages[1]?.text).toBe("Retried result");
+  });
+
+  it("returns the Telegram 429 after exhausting Fibonacci retries", async () => {
+    const fixture = await track(seedFixture());
+    const telegram = telegramApiMocks(TEST_BOT_TOKEN, {
+      sendMessageResponses: Array.from({ length: 6 }, () => ({
+        status: 429,
+        body: { ok: false, description: "Too Many Requests" },
+      })),
+    });
+    completedOutput("Still limited");
+
+    const timer = runTelegramSendDelaysImmediately();
+    const result = await dispatchTelegramCallback({
+      callbackId: fixture.callbackId,
+      runId: fixture.runId,
+      status: "completed",
+      payload: fixture.payload,
+    });
+    timer.restore();
+
+    expect(result).toStrictEqual({
+      success: false,
+      status: 400,
+      error: "Telegram API error: Too Many Requests",
+    });
+    expect(timer.delays).toStrictEqual(
+      expect.arrayContaining([1000, 1000, 2000, 3000, 5000]),
+    );
+    expect(telegram.sentMessages).toHaveLength(6);
+  });
+
+  it("throttles split completion reply chunks", async () => {
+    const fixture = await track(seedFixture());
+    const telegram = telegramApiMocks();
+    completedOutput("x".repeat(5000));
+
+    const timer = runTelegramSendDelaysImmediately();
+    const result = await dispatchTelegramCallback({
+      callbackId: fixture.callbackId,
+      runId: fixture.runId,
+      status: "completed",
+      payload: fixture.payload,
+    });
+    timer.restore();
+
+    expect(result).toStrictEqual({ success: true });
+    expect(timer.delays).toContain(1100);
+    expect(telegram.sentMessages).toHaveLength(2);
+    expect(telegram.sentMessages[0]?.text).toHaveLength(4096);
+    expect(telegram.sentMessages[1]?.text).toHaveLength(904);
   });
 
   it("renders markdown links in completed replies", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-telegram.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-telegram.test.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 
 import { createStore } from "ccstate";
 import { HttpResponse, http } from "msw";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { OFFICIAL_TELEGRAM_BOT_ID } from "@vm0/api-contracts/contracts/zero-integrations-telegram";
 import type {
@@ -99,28 +99,15 @@ function runTelegramSendDelaysImmediately(): {
   readonly restore: () => void;
 } {
   const delays: number[] = [];
-  const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(((
-    handler: (...args: unknown[]) => void,
-    delay?: number,
-    ...args: unknown[]
-  ) => {
-    delays.push(delay ?? 0);
-    queueMicrotask(() => {
-      handler(...args);
-    });
-    const timeout = {
-      hasRef: () => false,
-      refresh: () => timeout,
-      ref: () => timeout,
-      unref: () => timeout,
-    };
-    return timeout as unknown as ReturnType<typeof setTimeout>;
-  }) as typeof setTimeout);
+  context.mocks.signalTimers.delay.mockImplementation((delayMs) => {
+    delays.push(delayMs);
+    return Promise.resolve();
+  });
 
   return {
     delays,
     restore: () => {
-      setTimeoutSpy.mockRestore();
+      context.mocks.signalTimers.delay.mockReset();
     },
   };
 }
@@ -517,8 +504,6 @@ async function findThreadSession(args: {
 }
 
 afterEach(() => {
-  vi.restoreAllMocks();
-  vi.useRealTimers();
   context.mocks.axiom.query.mockReset();
   clearMockedEnv();
 });
@@ -623,10 +608,12 @@ describe("POST /api/internal/callbacks/telegram", () => {
   it("returns the Telegram 429 after exhausting Fibonacci retries", async () => {
     const fixture = await track(seedFixture());
     const telegram = telegramApiMocks(TEST_BOT_TOKEN, {
-      sendMessageResponses: Array.from({ length: 6 }, () => ({
-        status: 429,
-        body: { ok: false, description: "Too Many Requests" },
-      })),
+      sendMessageResponses: Array.from({ length: 6 }, () => {
+        return {
+          status: 429,
+          body: { ok: false, description: "Too Many Requests" },
+        };
+      }),
     });
     completedOutput("Still limited");
 

--- a/turbo/apps/api/src/signals/services/internal-telegram-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-telegram-run-callback.service.ts
@@ -7,6 +7,7 @@ import { telegramInstallations } from "@vm0/db/schema/telegram-installation";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { eq } from "drizzle-orm";
+import { delay } from "signal-timers";
 import { z } from "zod";
 
 import { buildTelegramResponse, splitMessage } from "../../lib/telegram-format";
@@ -40,7 +41,6 @@ import { settle } from "../utils";
 
 const L = logger("InternalCallbacksTelegram");
 const TELEGRAM_COMPLETION_CHUNK_THROTTLE_MS = 1100;
-const TELEGRAM_SEND_RETRY_DELAYS_MS = [1000, 1000, 2000, 3000, 5000];
 
 const telegramCallbackPayloadSchema = z
   .object({
@@ -81,38 +81,36 @@ type TelegramInternalCallbackResult =
       readonly status: 400 | 500 | 502;
     };
 
-function abortError(signal: AbortSignal): Error {
-  return signal.reason instanceof Error ? signal.reason : new Error("Aborted");
-}
-
-function waitForTelegramSendDelay(
+async function waitForTelegramSendDelay(
   delayMs: number,
   signal: AbortSignal,
 ): Promise<void> {
-  if (delayMs <= 0) {
-    signal.throwIfAborted();
-    return Promise.resolve();
-  }
-
   signal.throwIfAborted();
-  let onAbort: (() => void) | undefined;
-  return new Promise<void>((resolve, reject) => {
-    const timeout = setTimeout(resolve, delayMs);
-    onAbort = (): void => {
-      clearTimeout(timeout);
-      reject(abortError(signal));
-    };
+  if (delayMs > 0) {
+    await delay(delayMs, { signal });
+  }
+  signal.throwIfAborted();
+}
 
-    signal.addEventListener("abort", onAbort, { once: true });
-    if (signal.aborted) {
-      onAbort();
+function telegramSendRetryDelayMs(attempt: number): number | undefined {
+  switch (attempt) {
+    case 0:
+    case 1: {
+      return 1000;
     }
-  }).finally(() => {
-    if (onAbort) {
-      signal.removeEventListener("abort", onAbort);
+    case 2: {
+      return 2000;
     }
-    signal.throwIfAborted();
-  });
+    case 3: {
+      return 3000;
+    }
+    case 4: {
+      return 5000;
+    }
+    default: {
+      return undefined;
+    }
+  }
 }
 
 async function sendMessageWithTelegramRateLimitRetry(args: {
@@ -132,7 +130,7 @@ async function sendMessageWithTelegramRateLimitRetry(args: {
       return result;
     }
 
-    const retryDelayMs = TELEGRAM_SEND_RETRY_DELAYS_MS[attempt];
+    const retryDelayMs = telegramSendRetryDelayMs(attempt);
     if (retryDelayMs === undefined) {
       return result;
     }

--- a/turbo/apps/api/src/signals/services/internal-telegram-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-telegram-run-callback.service.ts
@@ -39,6 +39,8 @@ import { resolveTelegramAgentReplyFooterText } from "./zero-telegram-footer.serv
 import { settle } from "../utils";
 
 const L = logger("InternalCallbacksTelegram");
+const TELEGRAM_COMPLETION_CHUNK_THROTTLE_MS = 1100;
+const TELEGRAM_SEND_RETRY_DELAYS_MS = [1000, 1000, 2000, 3000, 5000];
 
 const telegramCallbackPayloadSchema = z
   .object({
@@ -78,6 +80,70 @@ type TelegramInternalCallbackResult =
       readonly error: string;
       readonly status: 400 | 500 | 502;
     };
+
+function abortError(signal: AbortSignal): Error {
+  return signal.reason instanceof Error ? signal.reason : new Error("Aborted");
+}
+
+function waitForTelegramSendDelay(
+  delayMs: number,
+  signal: AbortSignal,
+): Promise<void> {
+  if (delayMs <= 0) {
+    signal.throwIfAborted();
+    return Promise.resolve();
+  }
+
+  signal.throwIfAborted();
+  let onAbort: (() => void) | undefined;
+  return new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(resolve, delayMs);
+    onAbort = (): void => {
+      clearTimeout(timeout);
+      reject(abortError(signal));
+    };
+
+    signal.addEventListener("abort", onAbort, { once: true });
+    if (signal.aborted) {
+      onAbort();
+    }
+  }).finally(() => {
+    if (onAbort) {
+      signal.removeEventListener("abort", onAbort);
+    }
+    signal.throwIfAborted();
+  });
+}
+
+async function sendMessageWithTelegramRateLimitRetry(args: {
+  readonly botToken: string;
+  readonly chatId: string;
+  readonly text: string;
+  readonly replyToMessageId: number | undefined;
+  readonly signal: AbortSignal;
+}): Promise<SendTelegramMessageResult> {
+  for (let attempt = 0; ; attempt++) {
+    const result = await sendMessage(args.botToken, args.chatId, args.text, {
+      replyToMessageId: args.replyToMessageId,
+    });
+    args.signal.throwIfAborted();
+
+    if (result.kind !== "telegram-error" || result.status !== 429) {
+      return result;
+    }
+
+    const retryDelayMs = TELEGRAM_SEND_RETRY_DELAYS_MS[attempt];
+    if (retryDelayMs === undefined) {
+      return result;
+    }
+
+    L.warn("Telegram sendMessage rate limited; retrying", {
+      attempt: attempt + 1,
+      retryDelayMs,
+    });
+    await waitForTelegramSendDelay(retryDelayMs, args.signal);
+  }
+}
 
 function successResponse(): {
   readonly status: 200;
@@ -352,11 +418,22 @@ async function sendCompletionMessages(args: {
   | Extract<SendTelegramMessageResult, { kind: "telegram-error" }>
 > {
   let firstMessageId: number | undefined;
-  for (const chunk of splitMessage(args.htmlOutput)) {
-    const sent = await sendMessage(args.botToken, args.chatId, chunk, {
+  const chunks = splitMessage(args.htmlOutput);
+  for (const [index, chunk] of chunks.entries()) {
+    if (index > 0) {
+      await waitForTelegramSendDelay(
+        TELEGRAM_COMPLETION_CHUNK_THROTTLE_MS,
+        args.signal,
+      );
+    }
+
+    const sent = await sendMessageWithTelegramRateLimitRetry({
+      botToken: args.botToken,
+      chatId: args.chatId,
+      text: chunk,
       replyToMessageId: args.replyToMessageId,
+      signal: args.signal,
     });
-    args.signal.throwIfAborted();
     if (sent.kind === "telegram-error") {
       return sent;
     }


### PR DESCRIPTION
## Summary
- add Fibonacci retry for Telegram completion callback `sendMessage` 429s
- add a 1100ms fallback throttle between split Telegram completion chunks
- cover retry exhaustion and split-message throttle behavior in Telegram callback tests

## Verification
- `git diff --check`
- `pnpm exec prettier --check apps/api/src/signals/services/internal-telegram-run-callback.service.ts apps/api/src/signals/routes/__tests__/internal-callbacks-telegram.test.ts`
- `pnpm --filter api exec oxlint src/signals/services/internal-telegram-run-callback.service.ts src/signals/routes/__tests__/internal-callbacks-telegram.test.ts`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter api run check-types`
- `DATABASE_URL="postgresql://postgres@localhost:5432/vm0_test" pnpm exec vitest run src/signals/routes/__tests__/internal-callbacks-telegram.test.ts --config vitest.config.ts`