### PR TITLE
feat: make connector catalog api generally available

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
@@ -60,16 +60,13 @@ describe("GET /api/zero/connector-catalog", () => {
   }[] = [];
   const seededOrgs: OrgMembershipFixture[] = [];
 
-  async function enablePublicCatalog(
+  async function enableConnectorFeatureSwitches(
     orgId: string,
     userId: string,
-    switches: Partial<Record<FeatureSwitchKey, boolean>> = {},
+    switches: Partial<Record<FeatureSwitchKey, boolean>>,
   ): Promise<void> {
     seededFeatureSwitches.push({ orgId, userId });
-    await enableFeatureSwitches(orgId, userId, {
-      [FeatureSwitchKey.ConnectorCatalogApi]: true,
-      ...switches,
-    });
+    await enableFeatureSwitches(orgId, userId, switches);
   }
 
   afterEach(async () => {
@@ -106,24 +103,22 @@ describe("GET /api/zero/connector-catalog", () => {
     expect(response.body.error.code).toBe("UNAUTHORIZED");
   });
 
-  it("returns 403 while the public catalog feature is disabled", async () => {
+  it("returns public catalog metadata without a catalog feature switch", async () => {
     mocks.clerk.session(`user_${randomUUID()}`, `org_${randomUUID()}`);
 
     const client = setupApp({ context })(zeroConnectorCatalogContract);
     const response = await accept(
       client.list({ headers: { authorization: "Bearer clerk-session" } }),
-      [403],
+      [200],
     );
 
-    expect(response.body.error.message).toBe(
-      "Connector catalog API is not enabled",
-    );
+    assertPublicConnectorCatalogHasNoPrivateFields(response.body);
+    expect(response.body.connectors.length).toBeGreaterThan(0);
   });
 
-  it("returns compact public connector metadata when enabled", async () => {
+  it("returns compact public connector metadata", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
-    await enablePublicCatalog(orgId, userId);
     mocks.clerk.session(userId, orgId);
 
     const client = setupApp({ context })(zeroConnectorCatalogContract);
@@ -161,7 +156,6 @@ describe("GET /api/zero/connector-catalog", () => {
   it("accepts a ZERO_TOKEN carrying the connector:read capability", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
-    await enablePublicCatalog(orgId, userId);
     seededOrgs.push(
       await store.set(
         seedOrgMembership$,
@@ -192,7 +186,6 @@ describe("GET /api/zero/connector-catalog", () => {
   it("rejects a ZERO_TOKEN missing the connector:read capability with 403", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
-    await enablePublicCatalog(orgId, userId);
     seededOrgs.push(
       await store.set(
         seedOrgMembership$,
@@ -226,7 +219,6 @@ describe("GET /api/zero/connector-catalog", () => {
   it("returns connector detail without leaking manual field storage names", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
-    await enablePublicCatalog(orgId, userId);
     mocks.clerk.session(userId, orgId);
 
     const client = setupApp({ context })(zeroConnectorCatalogContract);
@@ -256,7 +248,6 @@ describe("GET /api/zero/connector-catalog", () => {
   it("omits auth text and placeholders derived from private names", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
-    await enablePublicCatalog(orgId, userId);
     mocks.clerk.session(userId, orgId);
 
     const client = setupApp({ context })(zeroConnectorCatalogContract);
@@ -287,7 +278,7 @@ describe("GET /api/zero/connector-catalog", () => {
   it("returns every visible connector detail without private metadata", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
-    await enablePublicCatalog(orgId, userId, {
+    await enableConnectorFeatureSwitches(orgId, userId, {
       [FeatureSwitchKey.NeonConnector]: true,
     });
     mocks.clerk.session(userId, orgId);
@@ -313,7 +304,6 @@ describe("GET /api/zero/connector-catalog", () => {
   it("returns 404 for hidden connector catalog refs", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
-    await enablePublicCatalog(orgId, userId);
     mocks.clerk.session(userId, orgId);
 
     const client = setupApp({ context })(zeroConnectorCatalogContract);
@@ -333,7 +323,7 @@ describe("GET /api/zero/connector-catalog", () => {
   it("returns semantic public ids for device-auth start options", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
-    await enablePublicCatalog(orgId, userId, {
+    await enableConnectorFeatureSwitches(orgId, userId, {
       [FeatureSwitchKey.TestOauthConnector]: true,
     });
     mocks.clerk.session(userId, orgId);
@@ -369,7 +359,6 @@ describe("GET /api/zero/connector-catalog", () => {
   it("hides feature-gated auth methods from connector detail", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
-    await enablePublicCatalog(orgId, userId);
     mocks.clerk.session(userId, orgId);
 
     const client = setupApp({ context })(zeroConnectorCatalogContract);
@@ -392,7 +381,7 @@ describe("GET /api/zero/connector-catalog", () => {
   it("shows feature-gated auth methods when their connector feature is enabled", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
-    await enablePublicCatalog(orgId, userId, {
+    await enableConnectorFeatureSwitches(orgId, userId, {
       [FeatureSwitchKey.NeonConnector]: true,
     });
     mocks.clerk.session(userId, orgId);
@@ -417,7 +406,6 @@ describe("GET /api/zero/connector-catalog", () => {
   it("returns public permission detail without firewall execution metadata", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
-    await enablePublicCatalog(orgId, userId);
     mocks.clerk.session(userId, orgId);
 
     const client = setupApp({ context })(zeroConnectorCatalogContract);

--- a/turbo/apps/api/src/signals/routes/zero-connector-catalog.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connector-catalog.ts
@@ -1,9 +1,5 @@
 import { zeroConnectorCatalogContract } from "@vm0/api-contracts/contracts/zero-connector-catalog";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import {
-  getAllFeatureStates,
-  isFeatureEnabled,
-} from "@vm0/core/feature-switch";
+import { getAllFeatureStates } from "@vm0/core/feature-switch";
 import { command } from "ccstate";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
@@ -24,16 +20,6 @@ const connectorCatalogAuth = {
   requiredCapability: "connector:read",
 } as const;
 
-const connectorCatalogApiDisabled = Object.freeze({
-  status: 403 as const,
-  body: Object.freeze({
-    error: Object.freeze({
-      message: "Connector catalog API is not enabled",
-      code: "FORBIDDEN",
-    }),
-  }),
-});
-
 function connectorCatalogNotFound() {
   return notFound("Connector catalog item not found");
 }
@@ -49,10 +35,6 @@ const connectorCatalogRequestContext$ = command(async ({ get }) => {
     overrides,
   };
   return {
-    enabled: isFeatureEnabled(
-      FeatureSwitchKey.ConnectorCatalogApi,
-      featureSwitchContext,
-    ),
     featureStates: getAllFeatureStates(featureSwitchContext),
   };
 });
@@ -61,9 +43,6 @@ const listConnectorCatalogInner$ = command(
   async ({ set }, signal: AbortSignal) => {
     const context = await set(connectorCatalogRequestContext$);
     signal.throwIfAborted();
-    if (!context.enabled) {
-      return connectorCatalogApiDisabled;
-    }
 
     const connectors = await listPublicConnectorCatalog({
       featureStates: context.featureStates,
@@ -79,9 +58,6 @@ const getConnectorCatalogInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const context = await set(connectorCatalogRequestContext$);
     signal.throwIfAborted();
-    if (!context.enabled) {
-      return connectorCatalogApiDisabled;
-    }
 
     const params = get(pathParamsOf(zeroConnectorCatalogContract.get));
     const connector = await getPublicConnectorCatalogDetail({
@@ -102,9 +78,6 @@ const getConnectorCatalogPermissionsInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const context = await set(connectorCatalogRequestContext$);
     signal.throwIfAborted();
-    if (!context.enabled) {
-      return connectorCatalogApiDisabled;
-    }
 
     const params = get(pathParamsOf(zeroConnectorCatalogContract.permissions));
     const permissions = await getPublicConnectorCatalogPermissionDetail({

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -51,7 +51,6 @@ export enum FeatureSwitchKey {
   HtmlArtifactCommentEditing = "htmlArtifactCommentEditing",
   ComputerUseDelegatedAuthorization = "computerUseDelegatedAuthorization",
   ConnectorAccessManagement = "connectorAccessManagement",
-  ConnectorCatalogApi = "connectorCatalogApi",
   PresentationTemplateRunbook = "presentationTemplateRunbook",
   AgentUnreadIndicators = "agentUnreadIndicators",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -291,13 +291,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.ConnectorCatalogApi]: {
-    maintainer: "liangyou@vm0.ai",
-    description:
-      "Expose the read-only public connector catalog API for frontend and CLI metadata migration.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.PresentationTemplateRunbook]: {
     maintainer: "bingjie@vm0.ai",
     description:


### PR DESCRIPTION
## Summary
- remove the connector catalog API feature switch gate from the list, detail, and permissions endpoints
- keep auth, org membership, ZERO_TOKEN connector:read, and connector-level feature switch filtering intact
- remove the retired connectorCatalogApi feature switch registry key

Closes #19548

## Testing
- pnpm -F @vm0/db db:migrate
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connector-catalog.test.ts
- pnpm -F api lint
- pnpm -F api check-types
- pnpm -F @vm0/core check-types
- pnpm -F @vm0/connectors check-types
- pnpm format
- pnpm lint
- pnpm check-types
- pnpm knip
- pnpm knip --cache

## Notes
- Full local pnpm test was attempted and failed in unrelated broad suite timeouts/test-environment pollution; the connector catalog test passed both targeted and within that full run.