### PR TITLE
fix: align session history verification cap

### DIFF
--- a/crates/api-contracts/src/generated/constants.rs
+++ b/crates/api-contracts/src/generated/constants.rs
@@ -61,8 +61,8 @@ pub mod model_provider_env {
 
 /// Runner contract constants shared by TypeScript and Rust.
 pub mod runners {
-    /// Maximum resume session history blob size accepted by the API and runner.
-    /// Rust and TypeScript components use this shared contract value when validating resume history refs and downloads.
+    /// Maximum resume session history blob size accepted by the API, runner, and guest verifier.
+    /// Rust and TypeScript components use this shared contract value when validating resume history refs, downloads, and idle-reuse verification.
     pub const RESUME_SESSION_HISTORY_MAX_BYTES: u64 = 134217728;
 
     /// Runner and guest filesystem path constants shared across Rust and TypeScript.

--- a/crates/guest-agent/src/session_history_identity.rs
+++ b/crates/guest-agent/src/session_history_identity.rs
@@ -3,12 +3,12 @@
 use crate::env;
 use crate::error::AgentError;
 use crate::session_history;
+use api_contracts::generated::constants::runners::RESUME_SESSION_HISTORY_MAX_BYTES;
 use guest_contracts::codex_thread_id::canonical_codex_thread_id;
 use guest_contracts::session_history_identity::{
     FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES, FinalSessionHistoryFramework,
     FinalSessionHistoryIdentity, FinalSessionHistoryIdentityError,
     FinalSessionHistoryIdentityExpectation, FinalSessionHistoryRefKind,
-    SESSION_HISTORY_IDENTITY_GUEST_VERIFY_MAX_BYTES,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_EXPECTED_MISMATCH,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_FRAMEWORK_MISMATCH,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_MISMATCH,
@@ -108,7 +108,7 @@ fn verify_final_session_history_identity(
         }
     }
 
-    if identity.history_size_bytes > SESSION_HISTORY_IDENTITY_GUEST_VERIFY_MAX_BYTES {
+    if identity.history_size_bytes > RESUME_SESSION_HISTORY_MAX_BYTES {
         return Err(FinalSessionHistoryIdentityVerifyError::HistoryTooLarge);
     }
     let digest = match session_history::digest_session_history_from_payload_bounded(
@@ -218,6 +218,7 @@ mod tests {
     use std::io::Write;
 
     const LARGE_SESSION_HISTORY_SIZE_BYTES: usize = 1024 * 1024 + 1;
+    const PREVIOUS_GUEST_VERIFY_CAP_BYTES: u64 = 32 * 1024 * 1024;
 
     fn write_metadata(
         dir: &tempfile::TempDir,
@@ -226,6 +227,18 @@ mod tests {
         let path = dir.path().join("identity.json");
         std::fs::write(&path, identity.to_json_vec().unwrap()).unwrap();
         path
+    }
+
+    fn repeated_byte_sha256(byte: u8, len: u64) -> String {
+        let mut hasher = Sha256::new();
+        let buffer = [byte; 8192];
+        let mut remaining = len;
+        while remaining > 0 {
+            let chunk_len = remaining.min(buffer.len() as u64) as usize;
+            hasher.update(&buffer[..chunk_len]);
+            remaining -= chunk_len as u64;
+        }
+        hex::encode(hasher.finalize())
     }
 
     #[test]
@@ -388,6 +401,31 @@ mod tests {
     }
 
     #[test]
+    fn verifies_history_above_previous_guest_verify_cap() {
+        let history_size = PREVIOUS_GUEST_VERIFY_CAP_BYTES + 1;
+        assert!(history_size < RESUME_SESSION_HISTORY_MAX_BYTES);
+
+        let dir = tempfile::tempdir().unwrap();
+        let history_path = dir.path().join("history.jsonl");
+        std::fs::File::create(&history_path)
+            .unwrap()
+            .set_len(history_size)
+            .unwrap();
+        let identity = FinalSessionHistoryIdentity::new(
+            FinalSessionHistoryFramework::ClaudeCode,
+            "a".repeat(64),
+            FinalSessionHistoryRefKind::Blob,
+            repeated_byte_sha256(0, history_size),
+            history_size,
+            history_path.to_string_lossy(),
+        )
+        .unwrap();
+        let metadata_path = write_metadata(&dir, &identity);
+
+        verify_final_session_history_identity_file(metadata_path, None).unwrap();
+    }
+
+    #[test]
     fn rejects_current_history_larger_than_identity_size() {
         let dir = tempfile::tempdir().unwrap();
         let history_path = dir.path().join("history.jsonl");
@@ -413,7 +451,7 @@ mod tests {
     }
 
     #[test]
-    fn rejects_history_above_guest_verify_cap() {
+    fn rejects_history_above_resume_cap() {
         let dir = tempfile::tempdir().unwrap();
         let history_path = dir.path().join("history.jsonl");
         std::fs::write(&history_path, b"small").unwrap();
@@ -422,7 +460,7 @@ mod tests {
             "a".repeat(64),
             FinalSessionHistoryRefKind::Blob,
             "b".repeat(64),
-            SESSION_HISTORY_IDENTITY_GUEST_VERIFY_MAX_BYTES + 1,
+            RESUME_SESSION_HISTORY_MAX_BYTES + 1,
             history_path.to_string_lossy(),
         )
         .unwrap();

--- a/crates/guest-contracts/src/session_history_identity.rs
+++ b/crates/guest-contracts/src/session_history_identity.rs
@@ -294,6 +294,10 @@ pub enum FinalSessionHistoryIdentityError {
     /// History size is zero.
     InvalidHistorySize,
     /// History size exceeds a verifier work budget.
+    ///
+    /// Final identity metadata no longer owns this runtime policy, but the
+    /// variant remains part of the shared error contract for callers that may
+    /// still classify older validator results.
     HistoryTooLarge,
     /// History marker payload is missing.
     MissingHistoryMarker,

--- a/crates/guest-contracts/src/session_history_identity.rs
+++ b/crates/guest-contracts/src/session_history_identity.rs
@@ -13,9 +13,6 @@ pub const FINAL_SESSION_HISTORY_IDENTITY_VERSION: u8 = 1;
 /// Maximum size of the serialized final identity metadata file.
 pub const FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES: u64 = 16 * 1024;
 
-/// Maximum decoded session-history bytes the guest helper may verify locally.
-pub const SESSION_HISTORY_IDENTITY_GUEST_VERIFY_MAX_BYTES: u64 = 32 * 1024 * 1024;
-
 /// Guest helper exit code for successful final identity verification.
 pub const SESSION_HISTORY_IDENTITY_VERIFY_EXIT_SUCCESS: i32 = 0;
 /// Guest helper exit code for uncategorized final identity verification failure.
@@ -417,15 +414,12 @@ mod tests {
             "a".repeat(64),
             FinalSessionHistoryRefKind::Blob,
             "b".repeat(64),
-            SESSION_HISTORY_IDENTITY_GUEST_VERIFY_MAX_BYTES + 1,
+            u64::MAX,
             "/history.jsonl",
         )
         .unwrap();
 
-        assert_eq!(
-            identity.history_size_bytes,
-            SESSION_HISTORY_IDENTITY_GUEST_VERIFY_MAX_BYTES + 1
-        );
+        assert_eq!(identity.history_size_bytes, u64::MAX);
         assert_eq!(
             FinalSessionHistoryIdentity::from_json_slice(&identity.to_json_vec().unwrap()).unwrap(),
             identity
@@ -479,14 +473,11 @@ mod tests {
             "a".repeat(64),
             FinalSessionHistoryRefKind::Blob,
             "b".repeat(64),
-            SESSION_HISTORY_IDENTITY_GUEST_VERIFY_MAX_BYTES + 1,
+            u64::MAX,
         )
         .unwrap();
 
-        assert_eq!(
-            expectation.history_size_bytes,
-            SESSION_HISTORY_IDENTITY_GUEST_VERIFY_MAX_BYTES + 1
-        );
+        assert_eq!(expectation.history_size_bytes, u64::MAX);
     }
 
     #[test]

--- a/turbo/packages/api-contracts/src/rust-bindings/__tests__/constants.test.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/__tests__/constants.test.ts
@@ -33,8 +33,8 @@ const canonicalWorkingDirDoc = [
 ] as const;
 
 const resumeSessionHistoryMaxBytesDoc = [
-  "Maximum resume session history blob size accepted by the API and runner.",
-  "Rust and TypeScript components use this shared contract value when validating resume history refs and downloads.",
+  "Maximum resume session history blob size accepted by the API, runner, and guest verifier.",
+  "Rust and TypeScript components use this shared contract value when validating resume history refs, downloads, and idle-reuse verification.",
 ] as const;
 
 function rustString(value: string): RustConstantValue {
@@ -226,7 +226,7 @@ describe("Rust constant bindings", () => {
       `pub const CANONICAL_WORKING_DIR: &str = "${CANONICAL_WORKING_DIR}";`,
     );
     expect(firstRender).toContain(
-      "/// Maximum resume session history blob size accepted by the API and runner.",
+      "/// Maximum resume session history blob size accepted by the API, runner, and guest verifier.",
     );
     expect(firstRender).toContain(
       `pub const RESUME_SESSION_HISTORY_MAX_BYTES: u64 = ${RESUME_SESSION_HISTORY_MAX_BYTES};`,

--- a/turbo/packages/api-contracts/src/rust-bindings/constants.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/constants.ts
@@ -153,8 +153,8 @@ export const rustConstantBindings = [
     rustConstName: "RESUME_SESSION_HISTORY_MAX_BYTES",
     value: rustU64(RESUME_SESSION_HISTORY_MAX_BYTES),
     rustDoc: [
-      "Maximum resume session history blob size accepted by the API and runner.",
-      "Rust and TypeScript components use this shared contract value when validating resume history refs and downloads.",
+      "Maximum resume session history blob size accepted by the API, runner, and guest verifier.",
+      "Rust and TypeScript components use this shared contract value when validating resume history refs, downloads, and idle-reuse verification.",
     ],
   },
   {


### PR DESCRIPTION
## Summary
- generate `RESUME_SESSION_HISTORY_MAX_BYTES` into Rust constants from the TypeScript API contract
- use the generated 128 MiB cap for runner session-history download and guest final identity verification
- remove the old guest-contracts verifier-only cap so metadata contracts do not own runtime policy
- add a regression test for verified history just above the previous 32 MiB guest cap

## Problem
Verified idle reuse could fall back to full session-history restore for histories between 32 MiB and 128 MiB because the runner/API accepted the 128 MiB contract limit while the guest identity verifier rejected anything above its old 32 MiB local cap.

## Edge Cases Covered
- history larger than the old 32 MiB guest verifier cap now verifies when it is still within the 128 MiB resume cap
- history above the 128 MiB resume cap still fails closed with `HistoryTooLarge`
- metadata contracts accept large `history_size_bytes` values without owning runtime verifier policy
- oversized or mismatched actual history bytes still fall back through verifier mismatch/too-large outcomes

## Verification
- `pnpm exec prettier --write packages/api-contracts/src/rust-bindings/constants.ts packages/api-contracts/src/rust-bindings/generate.ts packages/api-contracts/src/rust-bindings/__tests__/constants.test.ts`
- `pnpm -F @vm0/api-contracts generate:rust`
- `pnpm -F @vm0/api-contracts exec vitest run src/rust-bindings/__tests__/constants.test.ts`
- `pnpm -F @vm0/api-contracts check-types`
- `cargo fmt --all`
- `cargo test -p guest-contracts session_history_identity`
- `cargo test -p guest-agent session_history_identity`
- `cargo test -p runner session_history_download`
- pre-commit Rust fmt/clippy/doc checks passed on the follow-up docs commit

Closes #19546
