### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2640,9 +2640,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "web-time",
  "zeroize",


### PR DESCRIPTION
## Summary

- Updated `rustls-pki-types` from `1.14.1` to `1.15.0`.
- Changed only `crates/Cargo.lock`.

## Dependencies not updated

- `generic-array` remains at `0.14.7` even though `0.14.9` is available.
- Reason: transitive `crypto-common v0.1.7` requires `generic-array = "=0.14.7"` through the `digest` / `crc-fast` / `aws-smithy-checksums` / `aws-sdk-s3` / `runner` dependency path. This is not constrained by a workspace `Cargo.toml` version specifier.

## Manual version bumps

- None.

## Tests

- Passed: `cargo test --workspace -j 1`
- Runtime-only adjustments used in this constrained environment: `umask 077`, workspace-backed `CARGO_TARGET_DIR`, private `TMPDIR`, `CARGO_INCREMENTAL=0`, `CARGO_PROFILE_TEST_DEBUG=0`, and `RUSTFLAGS="-C link-arg=-Wl,--no-keep-memory"`.
- Initial unadjusted workspace runs were blocked by local environment limits (`/tmp` disk exhaustion, then GNU ld SIGKILL while linking `runner`); no tests were skipped or disabled.
