### PR TITLE
test: split connector status filter page test

### DIFF
--- a/turbo/apps/platform/src/signals/automation-page/workflow-trigger-automation-dialog.ts
+++ b/turbo/apps/platform/src/signals/automation-page/workflow-trigger-automation-dialog.ts
@@ -1,6 +1,6 @@
 import { command, computed, state } from "ccstate";
 
-export type WorkflowAutomationDialogIntent =
+type WorkflowAutomationDialogIntent =
   | "automation"
   | "automation-chat"
   | "workflow";
@@ -52,28 +52,12 @@ export const openCreateWorkflowDialog$ = command(({ set }) => {
   set(workflowAutomationDialogIntentState$, "workflow");
 });
 
-export const openWorkflowAutomationDialogForAgent$ = command(
-  ({ set }, agentId: string) => {
-    set(workflowAutomationDialogOpenState$, true);
-    set(selectedWorkflowAutomationAgentIdState$, agentId);
-    set(workflowAutomationAgentQueryState$, "");
-    set(workflowAutomationAgentSelectionLockedState$, true);
-    set(workflowAutomationDialogIntentState$, "automation-chat");
-  },
-);
-
 export const startCreateWorkflowFromAutomationDialog$ = command(({ set }) => {
   set(selectedWorkflowAutomationAgentIdState$, "");
   set(workflowAutomationAgentQueryState$, "");
   set(workflowAutomationAgentSelectionLockedState$, false);
   set(workflowAutomationDialogIntentState$, "automation-chat");
 });
-
-export const setSelectedWorkflowAutomationAgentId$ = command(
-  ({ set }, agentId: string) => {
-    set(selectedWorkflowAutomationAgentIdState$, agentId);
-  },
-);
 
 export const setWorkflowAutomationAgentQuery$ = command(
   ({ set }, query: string) => {

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-title.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-title.ts
@@ -11,7 +11,7 @@ export const CHAT_THREAD_EMOJI_OPTIONS = [
 const CHAT_THREAD_EMOJI_PATTERN =
   /(?:[\u{1f1e6}-\u{1f1ff}]{2}|[#*0-9]\ufe0f?\u20e3|\p{Extended_Pictographic}(?:\ufe0f|\ufe0e)?(?:[\u{1f3fb}-\u{1f3ff}])?(?:\u200d\p{Extended_Pictographic}(?:\ufe0f|\ufe0e)?(?:[\u{1f3fb}-\u{1f3ff}])?)*)/u;
 
-export interface ChatThreadTitleParts {
+interface ChatThreadTitleParts {
   readonly emoji: string | null;
   readonly text: string;
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -82,13 +82,21 @@ function menuItemByText(text: string): HTMLElement {
   return menuItem;
 }
 
-function connectorCardByLabel(label: string): HTMLElement {
+function queryConnectorCardByLabel(label: string): HTMLElement | null {
   const labelElement = screen
-    .getAllByTestId("connector-card-label")
+    .queryAllByTestId("connector-card-label")
     .find((element) => {
       return element.textContent === label;
     });
   const card = labelElement?.closest(".zero-card");
+  if (labelElement && !(card instanceof HTMLElement)) {
+    throw new Error(`${label} connector card label has no card container`);
+  }
+  return card instanceof HTMLElement ? card : null;
+}
+
+function connectorCardByLabel(label: string): HTMLElement {
+  const card = queryConnectorCardByLabel(label);
   if (!(card instanceof HTMLElement)) {
     throw new Error(`${label} connector card not found`);
   }
@@ -289,15 +297,15 @@ async function expectConnectorCardsVisible(expected: {
 }): Promise<void> {
   await waitFor(() => {
     if (expected.github) {
-      expect(screen.getByText("GitHub")).toBeInTheDocument();
+      expect(queryConnectorCardByLabel("GitHub")).toBeInTheDocument();
     } else {
-      expect(screen.queryByText("GitHub")).not.toBeInTheDocument();
+      expect(queryConnectorCardByLabel("GitHub")).not.toBeInTheDocument();
     }
 
     if (expected.asana) {
-      expect(screen.getByText("Asana")).toBeInTheDocument();
+      expect(queryConnectorCardByLabel("Asana")).toBeInTheDocument();
     } else {
-      expect(screen.queryByText("Asana")).not.toBeInTheDocument();
+      expect(queryConnectorCardByLabel("Asana")).not.toBeInTheDocument();
     }
   });
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -265,6 +265,43 @@ function mockCustomConnectorStory(): void {
   );
 }
 
+function setupConnectorStatusFilterPage(path = "/connectors"): void {
+  mockConnectors([{ type: "github", externalUsername: "octocat" }]);
+  context.mocks.data.team([
+    teamAgent("c0000000-0000-4000-a000-000000000020", "Research", "preset:0"),
+  ]);
+  context.mocks.api(zeroUserConnectorsContract.get, ({ respond }) => {
+    return respond(200, { enabledTypes: ["github"] });
+  });
+
+  detachedSetupPage({
+    context,
+    path,
+    featureSwitches: {
+      [FeatureSwitchKey.ConnectorAccessManagement]: true,
+    },
+  });
+}
+
+async function expectConnectorCardsVisible(expected: {
+  readonly github: boolean;
+  readonly asana: boolean;
+}): Promise<void> {
+  await waitFor(() => {
+    if (expected.github) {
+      expect(screen.getByText("GitHub")).toBeInTheDocument();
+    } else {
+      expect(screen.queryByText("GitHub")).not.toBeInTheDocument();
+    }
+
+    if (expected.asana) {
+      expect(screen.getByText("Asana")).toBeInTheDocument();
+    } else {
+      expect(screen.queryByText("Asana")).not.toBeInTheDocument();
+    }
+  });
+}
+
 describe("connectors page", () => {
   const restoreConnectorRegistry: (() => void)[] = [];
 
@@ -535,54 +572,38 @@ describe("connectors page", () => {
   });
 
   it("filters connectors by connected status", async () => {
-    mockConnectors([{ type: "github", externalUsername: "octocat" }]);
-    context.mocks.data.team([
-      teamAgent("c0000000-0000-4000-a000-000000000020", "Research", "preset:0"),
-    ]);
-    context.mocks.api(zeroUserConnectorsContract.get, ({ respond }) => {
-      return respond(200, { enabledTypes: ["github"] });
-    });
-
-    detachedSetupPage({
-      context,
-      path: "/connectors",
-      featureSwitches: {
-        [FeatureSwitchKey.ConnectorAccessManagement]: true,
-      },
-    });
-
-    await waitFor(() => {
-      expect(screen.getByText("GitHub")).toBeInTheDocument();
-      expect(screen.getByText("Asana")).toBeInTheDocument();
-    });
+    setupConnectorStatusFilterPage();
+    await expectConnectorCardsVisible({ github: true, asana: true });
 
     const filterTrigger = screen.getByLabelText("Filter connectors");
-
     click(filterTrigger);
     click(menuItemByText("Connected"));
 
-    await waitFor(() => {
-      expect(screen.getByText("GitHub")).toBeInTheDocument();
-      expect(screen.queryByText("Asana")).not.toBeInTheDocument();
-    });
+    await expectConnectorCardsVisible({ github: true, asana: false });
     expect(search()).toBe("?connection=connected");
+  });
 
+  it("filters connectors by not connected status", async () => {
+    setupConnectorStatusFilterPage();
+    await expectConnectorCardsVisible({ github: true, asana: true });
+
+    const filterTrigger = screen.getByLabelText("Filter connectors");
     click(filterTrigger);
     click(menuItemByText("Not connected"));
 
-    await waitFor(() => {
-      expect(screen.getByText("Asana")).toBeInTheDocument();
-      expect(screen.queryByText("GitHub")).not.toBeInTheDocument();
-    });
+    await expectConnectorCardsVisible({ github: false, asana: true });
     expect(search()).toBe("?connection=not-connected");
+  });
 
+  it("clears connector status filter", async () => {
+    setupConnectorStatusFilterPage("/connectors?connection=connected");
+    await expectConnectorCardsVisible({ github: true, asana: false });
+
+    const filterTrigger = screen.getByLabelText("Filter connectors");
     click(filterTrigger);
     click(menuItemByText("All"));
 
-    await waitFor(() => {
-      expect(screen.getByText("GitHub")).toBeInTheDocument();
-      expect(screen.getByText("Asana")).toBeInTheDocument();
-    });
+    await expectConnectorCardsVisible({ github: true, asana: true });
     expect(search()).toBe("");
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -614,7 +614,9 @@ describe("connectors page", () => {
     click(menuItemByText("All"));
 
     await expectConnectorCardsVisible({ github: true, asana: true });
-    expect(search()).toBe("?keywords=connect");
+    const params = new URLSearchParams(search());
+    expect(params.get("keywords")).toBe("connect");
+    expect(params.has("connection")).toBe(false);
   });
 
   it("filters connectors by agent when access management is enabled", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -604,7 +604,9 @@ describe("connectors page", () => {
   });
 
   it("clears connector status filter", async () => {
-    setupConnectorStatusFilterPage("/connectors?connection=not-connected");
+    setupConnectorStatusFilterPage(
+      "/connectors?debug=1&connection=not-connected",
+    );
     await expectConnectorCardsVisible({ github: false, asana: true });
 
     const filterTrigger = screen.getByLabelText("Filter connectors");
@@ -612,7 +614,7 @@ describe("connectors page", () => {
     click(menuItemByText("All"));
 
     await expectConnectorCardsVisible({ github: true, asana: true });
-    expect(search()).toBe("");
+    expect(search()).toBe("?debug=1");
   });
 
   it("filters connectors by agent when access management is enabled", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -592,8 +592,8 @@ describe("connectors page", () => {
   });
 
   it("filters connectors by not connected status", async () => {
-    setupConnectorStatusFilterPage();
-    await expectConnectorCardsVisible({ github: true, asana: true });
+    setupConnectorStatusFilterPage("/connectors?connection=connected");
+    await expectConnectorCardsVisible({ github: true, asana: false });
 
     const filterTrigger = screen.getByLabelText("Filter connectors");
     click(filterTrigger);
@@ -604,8 +604,8 @@ describe("connectors page", () => {
   });
 
   it("clears connector status filter", async () => {
-    setupConnectorStatusFilterPage("/connectors?connection=connected");
-    await expectConnectorCardsVisible({ github: true, asana: false });
+    setupConnectorStatusFilterPage("/connectors?connection=not-connected");
+    await expectConnectorCardsVisible({ github: false, asana: true });
 
     const filterTrigger = screen.getByLabelText("Filter connectors");
     click(filterTrigger);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -616,7 +616,7 @@ describe("connectors page", () => {
     await expectConnectorCardsVisible({ github: true, asana: true });
     const params = new URLSearchParams(search());
     expect(params.get("keywords")).toBe("connect");
-    expect(params.has("connection")).toBe(false);
+    expect(params.has("connection")).toBeFalsy();
   });
 
   it("filters connectors by agent when access management is enabled", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -605,7 +605,7 @@ describe("connectors page", () => {
 
   it("clears connector status filter", async () => {
     setupConnectorStatusFilterPage(
-      "/connectors?debug=1&connection=not-connected",
+      "/connectors?keywords=connect&connection=not-connected",
     );
     await expectConnectorCardsVisible({ github: false, asana: true });
 
@@ -614,7 +614,7 @@ describe("connectors page", () => {
     click(menuItemByText("All"));
 
     await expectConnectorCardsVisible({ github: true, asana: true });
-    expect(search()).toBe("?debug=1");
+    expect(search()).toBe("?keywords=connect");
   });
 
   it("filters connectors by agent when access management is enabled", async () => {

--- a/turbo/apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx
@@ -11,15 +11,12 @@ import type {
   ZeroWorkflowTriggerSummary,
 } from "@vm0/api-contracts/contracts/zero-workflows";
 import {
-  IconArrowUpRight,
   IconBrandGithub,
   IconCalendarTime,
   IconClock,
   IconLink,
-  IconLoader2,
   IconMail,
   IconMessageCircle,
-  IconPlayerPlay,
   IconPlus,
   IconRepeat,
   IconTag,
@@ -52,7 +49,6 @@ import { ROUTES } from "../../signals/route-paths.ts";
 import {
   allWorkflowTriggerEntries$,
   allVisibleWorkflows$,
-  runWorkflowTriggerNow$,
   setWorkflowTriggerEnabled$,
   type WorkflowTriggerAutomationEntry,
 } from "../../signals/workflows-page/workflows-signals.ts";
@@ -78,10 +74,6 @@ import {
   gmailTriggerTitle,
   workflowTitle,
 } from "../workflows-page/workflow-shared.tsx";
-import {
-  WorkflowTriggerCard,
-  type WorkflowTriggerCardRow,
-} from "../workflows-page/workflow-trigger-card.tsx";
 
 export const CREATE_WORKFLOW_WITH_CHAT_PROMPT =
   "Help me create a workflow for this agent. Use the workflow-setup skill, then ask me for the desired outcome, automation, and action before creating the workflow and automation.";
@@ -93,31 +85,6 @@ function formatClockTime(hour: number, minute: number): string {
   const ampm = hour >= 12 ? "PM" : "AM";
   const h12 = hour === 0 ? 12 : hour > 12 ? hour - 12 : hour;
   return `${h12}:${String(minute).padStart(2, "0")} ${ampm}`;
-}
-
-function formatTriggerDate(
-  value: string | null,
-  displayTimezone: string,
-): string {
-  if (!value) {
-    return "No runs yet";
-  }
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) {
-    return "No runs yet";
-  }
-  return date.toLocaleString("en-US", {
-    dateStyle: "medium",
-    timeStyle: "short",
-    timeZone: displayTimezone,
-  });
-}
-
-function formatNextRun(value: string | null, displayTimezone: string): string {
-  if (!value) {
-    return "No upcoming run";
-  }
-  return formatTriggerDate(value, displayTimezone);
 }
 
 function cronRuleLabel(
@@ -165,31 +132,6 @@ function cronRuleLabel(
     return days ? `Every week on ${days} at ${time}` : `Every week at ${time}`;
   }
   return `Every day at ${time}`;
-}
-
-function legacyTriggerRuleLabel(
-  trigger: ZeroWorkflowTriggerSummary,
-  displayTimezone: string,
-): string {
-  if (trigger.kind !== "schedule") {
-    return gmailTriggerTitle(trigger);
-  }
-  const schedule = trigger.schedule;
-  if (schedule.type === "loop") {
-    return `Every ${formatWorkflowIntervalSeconds(schedule.intervalSeconds)}`;
-  }
-  if (schedule.type === "once") {
-    const { date, hour, minute } = atTimeInTimezone(
-      schedule.atTime,
-      displayTimezone,
-    );
-    return `Once on ${date} at ${formatClockTime(hour, minute)}`;
-  }
-  return cronRuleLabel(
-    schedule.cronExpression,
-    schedule.timezone,
-    displayTimezone,
-  );
 }
 
 function quote(value: string): string {
@@ -266,161 +208,6 @@ function triggerTypeLabel(trigger: ZeroWorkflowTriggerSummary): string {
     return "Webhook";
   }
   return "Trigger";
-}
-
-function triggerRows(
-  trigger: ZeroWorkflowTriggerSummary,
-  displayTimezone: string,
-): readonly WorkflowTriggerCardRow[] {
-  const rows: WorkflowTriggerCardRow[] = [
-    {
-      label: trigger.kind === "schedule" ? "Schedule" : "Trigger",
-      value: legacyTriggerRuleLabel(trigger, displayTimezone),
-    },
-    {
-      label: "Last run",
-      value: formatTriggerDate(trigger.lastRunAt, displayTimezone),
-    },
-    {
-      label: "Next run",
-      value: formatNextRun(trigger.nextRunAt, displayTimezone),
-    },
-  ];
-
-  const matchSummary = gmailTriggerSummary(trigger);
-  if (matchSummary) {
-    rows.splice(1, 0, { label: "Match", value: matchSummary });
-  }
-  if (trigger.kind === "event" && trigger.eventType === "webhook-received") {
-    rows.splice(1, 0, { label: "Webhook", value: trigger.webhookUrl });
-  }
-  return rows;
-}
-
-function TriggerCardHeader({
-  entry,
-}: {
-  readonly entry: WorkflowTriggerAutomationEntry;
-}) {
-  return (
-    <div className="mb-2 flex min-w-0 items-center justify-between gap-3">
-      <div className="min-w-0">
-        <p className="min-w-0 truncate text-sm font-normal leading-snug text-muted-foreground">
-          {workflowTitle(entry.workflow)}
-        </p>
-        <p className="mt-0.5 min-w-0 truncate text-xs text-muted-foreground/80">
-          {agentLabel(entry.workflow)}
-        </p>
-      </div>
-      <Link
-        pathname={ROUTES.workflowDetailAutomations}
-        options={{
-          pathParams: {
-            workflowId: entry.workflow.id,
-          },
-        }}
-        className="inline-flex h-7 shrink-0 items-center gap-1 rounded-md px-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-gray-50 hover:text-foreground"
-      >
-        View
-        <IconArrowUpRight size={12} stroke={1.5} />
-      </Link>
-    </div>
-  );
-}
-
-function WorkflowAutomationTriggerCard({
-  entry,
-  displayTimezone,
-}: {
-  readonly entry: WorkflowTriggerAutomationEntry;
-  readonly displayTimezone: string;
-}) {
-  const pageSignal = useGet(pageSignal$);
-  const [runLoadable, runNow] = useLoadableSet(runWorkflowTriggerNow$);
-  const running = runLoadable.state === "loading";
-  const editLink = (
-    <Link
-      pathname={ROUTES.workflowDetailAutomations}
-      options={{
-        pathParams: {
-          workflowId: entry.workflow.id,
-        },
-      }}
-      className="rounded-md px-1 py-1 text-sm font-medium text-muted-foreground underline-offset-4 transition-colors hover:text-foreground hover:underline"
-    >
-      Edit
-    </Link>
-  );
-
-  return (
-    <div className="min-w-0">
-      <TriggerCardHeader entry={entry} />
-      <WorkflowTriggerCard
-        rows={triggerRows(entry.trigger, displayTimezone)}
-        dimmed={!entry.trigger.enabled}
-        actions={
-          <>
-            {entry.workflow.canManage ? editLink : <span />}
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="zero-btn-morandi h-8 shrink-0 gap-1.5 rounded-lg px-3 text-xs font-medium"
-              disabled={running}
-              onClick={() => {
-                detach(
-                  runNow(entry.trigger.id, pageSignal),
-                  Reason.DomCallback,
-                  "run workflow trigger from automations",
-                );
-              }}
-            >
-              {running ? (
-                <IconLoader2 size={13} className="animate-spin" />
-              ) : (
-                <IconPlayerPlay size={13} stroke={1.5} />
-              )}
-              {running ? "Starting..." : "Run now"}
-            </Button>
-          </>
-        }
-      />
-    </div>
-  );
-}
-
-function TriggerGridSkeleton() {
-  return (
-    <div
-      className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3"
-      data-testid="workflow-trigger-grid-skeleton"
-    >
-      {["a", "b", "c"].map((key) => {
-        return (
-          <div key={key} className="min-w-0">
-            <div className="mb-2 flex items-center justify-between gap-3">
-              <div className="grid min-w-0 flex-1 gap-1">
-                <Skeleton className="h-4 w-32 rounded-md" />
-                <Skeleton className="h-3 w-20 rounded-md" />
-              </div>
-              <Skeleton className="h-7 w-14 rounded-md" />
-            </div>
-            <div className="zero-card overflow-hidden">
-              <div className="grid gap-0 px-5 py-1">
-                <Skeleton className="my-3 h-4 w-full rounded-md" />
-                <Skeleton className="my-3 h-4 w-4/5 rounded-md" />
-                <Skeleton className="my-3 h-4 w-3/4 rounded-md" />
-              </div>
-              <div className="flex items-center justify-between px-5 pb-4 pt-2">
-                <Skeleton className="h-6 w-10 rounded-md" />
-                <Skeleton className="h-8 w-24 rounded-lg" />
-              </div>
-            </div>
-          </div>
-        );
-      })}
-    </div>
-  );
 }
 
 function TriggerListSkeleton() {
@@ -948,40 +735,6 @@ export function CreateWorkflowAutomationDialog() {
         />
       </DialogContent>
     </Dialog>
-  );
-}
-
-export function WorkflowTriggerAutomationList({
-  entries,
-  displayTimezone,
-  loading,
-  onAdd,
-}: {
-  readonly entries: readonly WorkflowTriggerAutomationEntry[];
-  readonly displayTimezone: string;
-  readonly loading: boolean;
-  readonly onAdd: () => void;
-}) {
-  if (loading) {
-    return <TriggerGridSkeleton />;
-  }
-
-  if (entries.length === 0) {
-    return <EmptyTriggers onAdd={onAdd} />;
-  }
-
-  return (
-    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-      {entries.map((entry) => {
-        return (
-          <WorkflowAutomationTriggerCard
-            key={entry.trigger.id}
-            entry={entry}
-            displayTimezone={displayTimezone}
-          />
-        );
-      })}
-    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

- Split the connector status filter page test into separate connected, not connected, and clear-filter cases so each test performs fewer UI transitions under the 5s timeout.
- Add small shared setup/assertion helpers for the connector status filter tests.
- Remove unused platform exports and dead workflow automation list code discovered by knip after rebasing onto latest main.

## Testing

- pnpm knip
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-connectors-page.test.tsx