### PR TITLE
fix: defer run launch side effects until persistence

### DIFF
--- a/turbo/apps/api/src/signals/external/sandbox-op-log.ts
+++ b/turbo/apps/api/src/signals/external/sandbox-op-log.ts
@@ -5,7 +5,7 @@ import { logger } from "../../lib/log";
 import { singleton } from "../../lib/singleton";
 import { nowDate } from "../../lib/time";
 import { waitUntil } from "../context/wait-until";
-import { tapError } from "../utils";
+import { safeSync, tapError } from "../utils";
 
 interface AxiomIngestClient {
   readonly ingest: (
@@ -53,28 +53,31 @@ export function recordSandboxOperations(
   }
 
   const dataset = `vm0-sandbox-op-log-${env("AXIOM_DATASET_SUFFIX")}`;
+  const events = attrsList.map((attrs) => {
+    return {
+      _time: attrs.timestamp ?? nowDate().toISOString(),
+      source: "api",
+      op_type: attrs.actionType,
+      sandbox_type: attrs.sandboxType,
+      duration_ms: attrs.durationMs,
+      success: attrs.success,
+      run_id: attrs.runId,
+      ...attrs.dimensions,
+    };
+  });
+  const ingestResult = safeSync(() => {
+    return client.ingest(dataset, events);
+  });
+  if ("error" in ingestResult) {
+    L.warn("Failed to ingest sandbox operation log", {
+      error: ingestResult.error,
+    });
+    return;
+  }
+
   waitUntil(
-    tapError(
-      Promise.resolve(
-        client.ingest(
-          dataset,
-          attrsList.map((attrs) => {
-            return {
-              _time: attrs.timestamp ?? nowDate().toISOString(),
-              source: "api",
-              op_type: attrs.actionType,
-              sandbox_type: attrs.sandboxType,
-              duration_ms: attrs.durationMs,
-              success: attrs.success,
-              run_id: attrs.runId,
-              ...attrs.dimensions,
-            };
-          }),
-        ),
-      ),
-      (error) => {
-        L.warn("Failed to ingest sandbox operation log", { error });
-      },
-    ),
+    tapError(Promise.resolve(ingestResult.ok), (error) => {
+      L.warn("Failed to ingest sandbox operation log", { error });
+    }),
   );
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -264,6 +264,20 @@ async function waitForRunStatus(
     .toBe(status);
 }
 
+async function waitForRunContext(actor: ApiTestUser, runId: string) {
+  let response: Awaited<ReturnType<typeof api.requestRunContext>> | undefined;
+  await expect
+    .poll(async () => {
+      response = await api.requestRunContext(actor, runId, [200, 404]);
+      return response.status;
+    })
+    .toBe(200);
+  if (!response || response.status !== 200) {
+    throw new Error("Expected the auto-send run context to be readable");
+  }
+  return response;
+}
+
 /**
  * Checkpoint + exitCode-0 complete. Completing without a checkpoint routes to
  * the missing-checkpoint handler and FAILS the run, so every successful chat
@@ -765,14 +779,7 @@ describe("CHAT-02: completed chat callback", () => {
       null,
     );
 
-    const autoContext = await api.requestRunContext(
-      actor,
-      claimed.runId,
-      [200],
-    );
-    if (autoContext.status !== 200) {
-      throw new Error("Expected the auto-send run context to be readable");
-    }
+    const autoContext = await waitForRunContext(actor, claimed.runId);
     expect(autoContext.body.prompt).toBe("queued next turn");
     const appended = autoContext.body.appendSystemPrompt ?? "";
     expect(appended).toContain(
@@ -1752,14 +1759,7 @@ describe("CHAT-02: auto-send after failures", () => {
       })
       .toBe(true);
 
-    const autoContext = await api.requestRunContext(
-      actor,
-      claimed.runId,
-      [200],
-    );
-    if (autoContext.status !== 200) {
-      throw new Error("Expected the auto-send run context to be readable");
-    }
+    const autoContext = await waitForRunContext(actor, claimed.runId);
     expect(autoContext.body.prompt).toContain("queued with files");
     expect(autoContext.body.prompt).toContain(
       "[Web file] queued-notes.txt (text/plain)",
@@ -1920,14 +1920,7 @@ describe("CHAT-02: auto-send across a model switch", () => {
       );
     }
 
-    const autoContext = await api.requestRunContext(
-      actor,
-      claimed.runId,
-      [200],
-    );
-    if (autoContext.status !== 200) {
-      throw new Error("Expected the auto-send run context to be readable");
-    }
+    const autoContext = await waitForRunContext(actor, claimed.runId);
     const appended = autoContext.body.appendSystemPrompt ?? "";
     expect(appended).toContain("# Web Chat Run Context");
     expect(appended).toContain(`- RUN_ID: ${second.runId}`);

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -828,19 +828,35 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
   it("keeps a direct launch claimable when run-context ingest fails", async () => {
     const api = createRunsAutomationsApi(context);
     const { actor, agentId } = await entitledRunActor();
-    context.mocks.axiom.ingest.mockImplementationOnce(() => {
-      throw new Error("run-context ingest failed");
+    const prompt = "run-context ingest should not block launch";
+    context.mocks.axiom.ingest.mockImplementation((dataset, events) => {
+      if (
+        dataset === "run-context" &&
+        Array.isArray(events) &&
+        events.some((event) => {
+          return isRecord(event) && event.prompt === prompt;
+        })
+      ) {
+        throw new Error("run-context ingest failed");
+      }
+      return true;
     });
 
     const created = await api.createRun(actor, {
       agentId,
-      prompt: "run-context ingest should not block launch",
+      prompt,
       modelProvider: "anthropic-api-key",
     });
 
     expect(created.status).toBe("pending");
     const claim = await api.claimRunnerJob(created.runId);
-    expect(claim.prompt).toBe("run-context ingest should not block launch");
+    expect(claim.prompt).toBe(prompt);
+    expect(context.mocks.axiom.ingest).toHaveBeenCalledWith("run-context", [
+      expect.objectContaining({
+        runId: created.runId,
+        prompt,
+      }),
+    ]);
 
     await api.requestCancelRun(actor, created.runId, [200]);
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1234,6 +1234,41 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
     expect(emptied.body.concurrency.active).toBe(0);
   });
 
+  it("keeps a queued launch visible when enqueue telemetry fails", async () => {
+    const api = createRunsAutomationsApi(context);
+    const { actor, agentId } = await entitledRunActor();
+
+    const first = await api.createRun(actor, {
+      agentId,
+      prompt: "active run before telemetry failure one",
+      modelProvider: "anthropic-api-key",
+    });
+    const second = await api.createRun(actor, {
+      agentId,
+      prompt: "active run before telemetry failure two",
+      modelProvider: "anthropic-api-key",
+    });
+    context.mocks.axiom.sdkIngest.mockImplementationOnce(() => {
+      throw new Error("enqueue telemetry failed");
+    });
+
+    const queued = await api.createRun(actor, {
+      agentId,
+      prompt: "queued run should survive telemetry failure",
+      modelProvider: "anthropic-api-key",
+    });
+
+    expect(queued.status).toBe("queued");
+    const queue = await api.readRunQueue(actor);
+    expect(queue.body.queue).toContainEqual(
+      expect.objectContaining({ runId: queued.runId }),
+    );
+
+    await api.requestCancelRun(actor, queued.runId, [200]);
+    await api.requestCancelRun(actor, first.runId, [200]);
+    await api.requestCancelRun(actor, second.runId, [200]);
+  });
+
   it("removes cancelled runs from the claimable queue", async () => {
     const api = createRunsAutomationsApi(context);
     const { actor, agentId } = await entitledRunActor();

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1274,6 +1274,7 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
       ) {
         throw new Error("enqueue telemetry failed");
       }
+      return true;
     });
 
     const queued = await api.createRun(actor, {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1248,8 +1248,16 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
       prompt: "active run before telemetry failure two",
       modelProvider: "anthropic-api-key",
     });
-    context.mocks.axiom.sdkIngest.mockImplementationOnce(() => {
-      throw new Error("enqueue telemetry failed");
+    context.mocks.axiom.sdkIngest.mockImplementation((dataset, events) => {
+      if (
+        dataset === "vm0-sandbox-op-log-dev" &&
+        Array.isArray(events) &&
+        events.some((event) => {
+          return isRecord(event) && event.op_type === "enqueue_zero_run";
+        })
+      ) {
+        throw new Error("enqueue telemetry failed");
+      }
     });
 
     const queued = await api.createRun(actor, {
@@ -1262,6 +1270,12 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
     const queue = await api.readRunQueue(actor);
     expect(queue.body.queue).toContainEqual(
       expect.objectContaining({ runId: queued.runId }),
+    );
+    expect(sandboxOperationEventsForRun(queued.runId)).toContainEqual(
+      expect.objectContaining({
+        op_type: "enqueue_zero_run",
+        run_id: queued.runId,
+      }),
     );
 
     await api.requestCancelRun(actor, queued.runId, [200]);

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -861,6 +861,30 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     await api.requestCancelRun(actor, created.runId, [200]);
   });
 
+  it("keeps a direct launch claimable when sandbox telemetry ingest fails", async () => {
+    const api = createRunsAutomationsApi(context);
+    const { actor, agentId } = await entitledRunActor();
+    const prompt = "sandbox telemetry should not block launch";
+    context.mocks.axiom.sdkIngest.mockImplementation((dataset) => {
+      if (dataset === "vm0-sandbox-op-log-dev") {
+        throw new Error("sandbox telemetry ingest failed");
+      }
+      return true;
+    });
+
+    const created = await api.createRun(actor, {
+      agentId,
+      prompt,
+      modelProvider: "anthropic-api-key",
+    });
+
+    expect(created.status).toBe("pending");
+    const claim = await api.claimRunnerJob(created.runId);
+    expect(claim.prompt).toBe(prompt);
+
+    await api.requestCancelRun(actor, created.runId, [200]);
+  });
+
   it("emits compose resolution timing for direct compose version runs", async () => {
     const api = createRunsAutomationsApi(context);
     const { actor } = await entitledRunActor();

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1300,6 +1300,43 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
     await api.requestCancelRun(actor, second.runId, [200]);
   });
 
+  it("keeps a queued launch visible when queue changed publish fails", async () => {
+    const api = createRunsAutomationsApi(context);
+    const { actor, agentId } = await entitledRunActor();
+
+    const first = await api.createRun(actor, {
+      agentId,
+      prompt: "active run before queue publish failure one",
+      modelProvider: "anthropic-api-key",
+    });
+    const second = await api.createRun(actor, {
+      agentId,
+      prompt: "active run before queue publish failure two",
+      modelProvider: "anthropic-api-key",
+    });
+    context.mocks.ably.publish.mockRejectedValueOnce(
+      new Error("queue changed publish failed"),
+    );
+
+    const queued = await api.createRun(actor, {
+      agentId,
+      prompt: "queued run should survive queue publish failure",
+      modelProvider: "anthropic-api-key",
+    });
+
+    expect(queued.status).toBe("queued");
+    const stored = await api.readRun(actor, queued.runId);
+    expect(stored.status).toBe("queued");
+    const queue = await api.readRunQueue(actor);
+    expect(queue.body.queue).toContainEqual(
+      expect.objectContaining({ runId: queued.runId }),
+    );
+
+    await api.requestCancelRun(actor, queued.runId, [200]);
+    await api.requestCancelRun(actor, first.runId, [200]);
+    await api.requestCancelRun(actor, second.runId, [200]);
+  });
+
   it("removes cancelled runs from the claimable queue", async () => {
     const api = createRunsAutomationsApi(context);
     const { actor, agentId } = await entitledRunActor();

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -825,6 +825,26 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     await api.requestCancelRun(actor, created.runId, [200]);
   });
 
+  it("keeps a direct launch claimable when run-context ingest fails", async () => {
+    const api = createRunsAutomationsApi(context);
+    const { actor, agentId } = await entitledRunActor();
+    context.mocks.axiom.ingest.mockImplementationOnce(() => {
+      throw new Error("run-context ingest failed");
+    });
+
+    const created = await api.createRun(actor, {
+      agentId,
+      prompt: "run-context ingest should not block launch",
+      modelProvider: "anthropic-api-key",
+    });
+
+    expect(created.status).toBe("pending");
+    const claim = await api.claimRunnerJob(created.runId);
+    expect(claim.prompt).toBe("run-context ingest should not block launch");
+
+    await api.requestCancelRun(actor, created.runId, [200]);
+  });
+
   it("emits compose resolution timing for direct compose version runs", async () => {
     const api = createRunsAutomationsApi(context);
     const { actor } = await entitledRunActor();

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -4497,6 +4497,19 @@ function recordQueuedRunEnqueueTelemetry(args: {
   }
 }
 
+async function publishQueueChangedSafely(args: {
+  readonly orgId: string;
+  readonly runId: string;
+}): Promise<void> {
+  await tapError(publishOrgSignal(args.orgId, "queue:changed"), (error) => {
+    L.warn("Failed to publish queue changed signal after queued launch", {
+      orgId: args.orgId,
+      runId: args.runId,
+      error,
+    });
+  });
+}
+
 function buildStoredExecutionSecrets(args: {
   readonly connectorContext: ConnectorRuntimeContext;
   readonly modelProvider: ResolvedModelProviderEnvironment | null;
@@ -5035,7 +5048,10 @@ function enqueueRunForConcurrency(
         timestamp: queuedPersistence.telemetryTimestamp,
       });
       ingestRunContextSnapshot(launch.runContextSnapshot);
-      await publishOrgSignal(args.orgId, "queue:changed");
+      await publishQueueChangedSafely({
+        orgId: args.orgId,
+        runId: args.run.id,
+      });
     }
 
     return queuedPersistence;

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -343,6 +343,18 @@ interface DerivedPersistenceResult {
   readonly sandboxId?: string;
 }
 
+type RunnerJobPayload = ReturnType<typeof queuedRunnerJobPayload>;
+
+interface PreparedRunnerLaunch {
+  readonly runnerJobPayload: RunnerJobPayload;
+  readonly runContextSnapshot: RunContextAxiomSnapshot;
+}
+
+interface QueuedPersistenceResult {
+  readonly persisted: DerivedPersistenceResult;
+  readonly queueDepth: number | null;
+}
+
 interface HttpRunCallback {
   readonly url: string;
   readonly secret: string;
@@ -4394,12 +4406,12 @@ function firewallSnapshots(
   });
 }
 
-function ingestRunContextSnapshot(args: {
+function buildRunContextSnapshot(args: {
   readonly runId: string;
   readonly userId: string;
   readonly body: CreateRunBody;
   readonly builtContext: BuiltStoredExecutionContext;
-}): void {
+}): RunContextAxiomSnapshot {
   const storedContext = args.builtContext.context;
   const manifest = storedContext.storageManifest;
   const sanitizedEnvironment = sanitizeEnvironment(
@@ -4438,8 +4450,43 @@ function ingestRunContextSnapshot(args: {
         : null,
     featureFlagEntries: featureFlagsRecordToEntries(storedContext.featureFlags),
   };
+  return snapshot;
+}
 
-  ingestToAxiom(getDatasetName("run-context"), [snapshot]);
+function ingestRunContextSnapshot(snapshot: RunContextAxiomSnapshot): void {
+  const result = safeSync(() => {
+    return ingestToAxiom(getDatasetName("run-context"), [snapshot]);
+  });
+  if ("error" in result) {
+    L.warn("Failed to ingest run context snapshot", {
+      runId: snapshot.runId,
+      error: result.error,
+    });
+  }
+}
+
+function recordQueuedRunEnqueueTelemetry(args: {
+  readonly runId: string;
+  readonly queueDepth: number;
+}): void {
+  const result = safeSync(() => {
+    recordSandboxOperation({
+      sandboxType: "runner",
+      actionType: "enqueue_zero_run",
+      durationMs: 0,
+      success: true,
+      runId: args.runId,
+      dimensions: {
+        queue_depth: args.queueDepth,
+      },
+    });
+  });
+  if ("error" in result) {
+    L.warn("Failed to record queued run enqueue telemetry", {
+      runId: args.runId,
+      error: result.error,
+    });
+  }
 }
 
 function buildStoredExecutionSecrets(args: {
@@ -4654,96 +4701,96 @@ function buildRunnerJobPayload(
     readonly featureSwitchContext: FeatureSwitchContext;
     readonly timing?: ApiDispatchTimingCollector;
   },
-): Computed<Promise<ReturnType<typeof queuedRunnerJobPayload>>> {
-  return computed(
-    async (get): Promise<ReturnType<typeof queuedRunnerJobPayload>> => {
-      const group =
-        runnerGroup(args.resolved.content) ??
-        optionalEnv("RUNNER_DEFAULT_GROUP");
-      if (!group) {
-        throw new Error("No executor configured: set RUNNER_DEFAULT_GROUP");
-      }
-      if (!isOfficialRunnerGroup(group)) {
-        throw new Error("Only vm0/* runner groups are supported");
-      }
+): Computed<Promise<PreparedRunnerLaunch>> {
+  return computed(async (get): Promise<PreparedRunnerLaunch> => {
+    const group =
+      runnerGroup(args.resolved.content) ?? optionalEnv("RUNNER_DEFAULT_GROUP");
+    if (!group) {
+      throw new Error("No executor configured: set RUNNER_DEFAULT_GROUP");
+    }
+    if (!isOfficialRunnerGroup(group)) {
+      throw new Error("Only vm0/* runner groups are supported");
+    }
 
-      const profile = runnerProfile(args.resolved.content);
-      const featureSwitchOverrides = args.includeZeroTokenSecret
-        ? args.featureSwitchContext.overrides
-        : undefined;
-      const body = args.includeZeroTokenSecret
-        ? withZeroTokenSecret(
-            args.body,
-            generateZeroToken(
-              args.userId,
-              args.run.id,
-              args.orgId,
-              featureSwitchOverrides,
-              {
-                ...(args.zeroTokenComputerUseHostId
-                  ? { computerUseHostId: args.zeroTokenComputerUseHostId }
-                  : {}),
-                ...(args.body.triggerSource
-                  ? { triggerSource: args.body.triggerSource }
-                  : {}),
-              },
-            ),
-          )
-        : args.body;
-      const storageManifest = await measureApiDispatchTiming(
-        args.timing,
-        "api_dispatch_prepare_storage_manifest",
-        "nested",
-        async () => {
-          return await get(
-            prepareAgentRunStorageManifest({
-              db,
-              content: args.resolved.content,
-              vars: body.vars,
-              agentOrgId: args.resolved.orgId,
-              runtimeOrgId: args.orgId,
-              userId: args.userId,
-              artifacts: args.artifacts,
-              volumeVersionOverrides: body.volumeVersions,
-              additionalVolumes: args.additionalVolumes,
-              framework: args.framework,
-              timing: args.timing,
-            }),
-          );
-        },
-      );
-      const builtContext = await measureApiDispatchTiming(
-        args.timing,
-        "api_dispatch_build_stored_execution_context",
-        "nested",
-        async () => {
-          return await buildStoredExecutionContext({
-            ...args,
-            body,
-            runId: args.run.id,
-            chatThreadId: args.chatThreadId,
-            storageManifest,
-            userTimezone: args.userTimezone,
-            featureSwitchContext: args.featureSwitchContext,
-          });
-        },
-      );
-      ingestRunContextSnapshot({
-        runId: args.run.id,
-        userId: args.userId,
-        body,
-        builtContext,
-      });
-      const storedContext = builtContext.context;
-      const cliAgentSessionId = storedContext.resumeSession?.sessionId ?? null;
-      return queuedRunnerJobPayload({
+    const profile = runnerProfile(args.resolved.content);
+    const featureSwitchOverrides = args.includeZeroTokenSecret
+      ? args.featureSwitchContext.overrides
+      : undefined;
+    const body = args.includeZeroTokenSecret
+      ? withZeroTokenSecret(
+          args.body,
+          generateZeroToken(
+            args.userId,
+            args.run.id,
+            args.orgId,
+            featureSwitchOverrides,
+            {
+              ...(args.zeroTokenComputerUseHostId
+                ? { computerUseHostId: args.zeroTokenComputerUseHostId }
+                : {}),
+              ...(args.body.triggerSource
+                ? { triggerSource: args.body.triggerSource }
+                : {}),
+            },
+          ),
+        )
+      : args.body;
+    const storageManifest = await measureApiDispatchTiming(
+      args.timing,
+      "api_dispatch_prepare_storage_manifest",
+      "nested",
+      async () => {
+        return await get(
+          prepareAgentRunStorageManifest({
+            db,
+            content: args.resolved.content,
+            vars: body.vars,
+            agentOrgId: args.resolved.orgId,
+            runtimeOrgId: args.orgId,
+            userId: args.userId,
+            artifacts: args.artifacts,
+            volumeVersionOverrides: body.volumeVersions,
+            additionalVolumes: args.additionalVolumes,
+            framework: args.framework,
+            timing: args.timing,
+          }),
+        );
+      },
+    );
+    const builtContext = await measureApiDispatchTiming(
+      args.timing,
+      "api_dispatch_build_stored_execution_context",
+      "nested",
+      async () => {
+        return await buildStoredExecutionContext({
+          ...args,
+          body,
+          runId: args.run.id,
+          chatThreadId: args.chatThreadId,
+          storageManifest,
+          userTimezone: args.userTimezone,
+          featureSwitchContext: args.featureSwitchContext,
+        });
+      },
+    );
+    const runContextSnapshot = buildRunContextSnapshot({
+      runId: args.run.id,
+      userId: args.userId,
+      body,
+      builtContext,
+    });
+    const storedContext = builtContext.context;
+    const cliAgentSessionId = storedContext.resumeSession?.sessionId ?? null;
+    return {
+      runnerJobPayload: queuedRunnerJobPayload({
         runnerGroup: group,
         profile,
         cliAgentSessionId,
         executionContext: storedContext,
-      });
-    },
-  );
+      }),
+      runContextSnapshot,
+    };
+  });
 }
 
 async function lockRunForDerivedPersistence(
@@ -4809,7 +4856,7 @@ function dispatchRun(
       },
     );
 
-    const payload = await measureApiDispatchTiming(
+    const launch = await measureApiDispatchTiming(
       args.timing,
       "api_dispatch_build_runner_job_payload",
       "top_level",
@@ -4817,6 +4864,7 @@ function dispatchRun(
         return await get(buildRunnerJobPayload(db, args));
       },
     );
+    const payload = launch.runnerJobPayload;
 
     const persisted = await measureApiDispatchTiming(
       args.timing,
@@ -4878,6 +4926,7 @@ function dispatchRun(
     );
 
     if (persisted.status === "pending") {
+      ingestRunContextSnapshot(launch.runContextSnapshot);
       await notifyRunnerJob(db, {
         runnerGroup: payload.runnerGroup,
         runId: args.run.id,
@@ -4927,58 +4976,57 @@ function enqueueRunForConcurrency(
   },
 ): Computed<Promise<DerivedPersistenceResult>> {
   return computed(async (get): Promise<DerivedPersistenceResult> => {
-    const payload = await get(buildRunnerJobPayload(db, args));
+    const launch = await get(buildRunnerJobPayload(db, args));
+    const payload = launch.runnerJobPayload;
     const encryptedParams = await encryptQueuedRunnerJobPayload(
       payload,
       args.featureSwitchContext,
     );
 
-    const persisted = await db.transaction(async (tx) => {
-      const currentRun = await lockRunForDerivedPersistence(tx, args.run.id);
-      if (!currentRun) {
-        throw new Error("Run disappeared before queue persistence");
-      }
-      if (currentRun.status !== "queued") {
-        return currentRun;
-      }
+    const queuedPersistence = await db.transaction(
+      async (tx): Promise<QueuedPersistenceResult> => {
+        const currentRun = await lockRunForDerivedPersistence(tx, args.run.id);
+        if (!currentRun) {
+          throw new Error("Run disappeared before queue persistence");
+        }
+        if (currentRun.status !== "queued") {
+          return { persisted: currentRun, queueDepth: null };
+        }
 
-      await tx.insert(agentRunQueue).values({
+        await tx.insert(agentRunQueue).values({
+          runId: args.run.id,
+          userId: args.userId,
+          orgId: args.orgId,
+          encryptedParams,
+          createdAt: args.run.createdAt,
+          expiresAt: sql`now() + interval '2 hours'`,
+        });
+        const [depthRow] = await tx
+          .select({ depth: count() })
+          .from(agentRunQueue)
+          .where(eq(agentRunQueue.orgId, args.orgId));
+        const queueDepth = Number(depthRow?.depth ?? 0);
+        await tx
+          .update(agentRuns)
+          .set({ runnerGroup: payload.runnerGroup })
+          .where(
+            and(eq(agentRuns.id, args.run.id), eq(agentRuns.status, "queued")),
+          );
+
+        return { persisted: { status: "queued" as const }, queueDepth };
+      },
+    );
+
+    if (queuedPersistence.persisted.status === "queued") {
+      recordQueuedRunEnqueueTelemetry({
         runId: args.run.id,
-        userId: args.userId,
-        orgId: args.orgId,
-        encryptedParams,
-        createdAt: args.run.createdAt,
-        expiresAt: sql`now() + interval '2 hours'`,
+        queueDepth: queuedPersistence.queueDepth ?? 0,
       });
-      const [depthRow] = await tx
-        .select({ depth: count() })
-        .from(agentRunQueue)
-        .where(eq(agentRunQueue.orgId, args.orgId));
-      recordSandboxOperation({
-        sandboxType: "runner",
-        actionType: "enqueue_zero_run",
-        durationMs: 0,
-        success: true,
-        runId: args.run.id,
-        dimensions: {
-          queue_depth: Number(depthRow?.depth ?? 0),
-        },
-      });
-      await tx
-        .update(agentRuns)
-        .set({ runnerGroup: payload.runnerGroup })
-        .where(
-          and(eq(agentRuns.id, args.run.id), eq(agentRuns.status, "queued")),
-        );
-
-      return { status: "queued" as const };
-    });
-
-    if (persisted.status === "queued") {
+      ingestRunContextSnapshot(launch.runContextSnapshot);
       await publishOrgSignal(args.orgId, "queue:changed");
     }
 
-    return persisted;
+    return queuedPersistence.persisted;
   });
 }
 

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -350,10 +350,15 @@ interface PreparedRunnerLaunch {
   readonly runContextSnapshot: RunContextAxiomSnapshot;
 }
 
-interface QueuedPersistenceResult {
-  readonly persisted: DerivedPersistenceResult;
-  readonly queueDepth: number | null;
-}
+type QueuedPersistenceResult =
+  | {
+      readonly status: "queued";
+      readonly queueDepth: number;
+    }
+  | {
+      readonly status: Exclude<RunStatus, "queued">;
+      readonly sandboxId?: string;
+    };
 
 interface HttpRunCallback {
   readonly url: string;
@@ -4990,7 +4995,9 @@ function enqueueRunForConcurrency(
           throw new Error("Run disappeared before queue persistence");
         }
         if (currentRun.status !== "queued") {
-          return { persisted: currentRun, queueDepth: null };
+          return currentRun.sandboxId
+            ? { status: currentRun.status, sandboxId: currentRun.sandboxId }
+            : { status: currentRun.status };
         }
 
         await tx.insert(agentRunQueue).values({
@@ -5013,20 +5020,20 @@ function enqueueRunForConcurrency(
             and(eq(agentRuns.id, args.run.id), eq(agentRuns.status, "queued")),
           );
 
-        return { persisted: { status: "queued" as const }, queueDepth };
+        return { status: "queued" as const, queueDepth };
       },
     );
 
-    if (queuedPersistence.persisted.status === "queued") {
+    if (queuedPersistence.status === "queued") {
       recordQueuedRunEnqueueTelemetry({
         runId: args.run.id,
-        queueDepth: queuedPersistence.queueDepth ?? 0,
+        queueDepth: queuedPersistence.queueDepth,
       });
       ingestRunContextSnapshot(launch.runContextSnapshot);
       await publishOrgSignal(args.orgId, "queue:changed");
     }
 
-    return queuedPersistence.persisted;
+    return queuedPersistence;
   });
 }
 

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -354,6 +354,7 @@ type QueuedPersistenceResult =
   | {
       readonly status: "queued";
       readonly queueDepth: number;
+      readonly telemetryTimestamp: string;
     }
   | {
       readonly status: Exclude<RunStatus, "queued">;
@@ -4473,6 +4474,7 @@ function ingestRunContextSnapshot(snapshot: RunContextAxiomSnapshot): void {
 function recordQueuedRunEnqueueTelemetry(args: {
   readonly runId: string;
   readonly queueDepth: number;
+  readonly timestamp: string;
 }): void {
   const result = safeSync(() => {
     recordSandboxOperation({
@@ -4481,6 +4483,7 @@ function recordQueuedRunEnqueueTelemetry(args: {
       durationMs: 0,
       success: true,
       runId: args.runId,
+      timestamp: args.timestamp,
       dimensions: {
         queue_depth: args.queueDepth,
       },
@@ -5013,6 +5016,7 @@ function enqueueRunForConcurrency(
           .from(agentRunQueue)
           .where(eq(agentRunQueue.orgId, args.orgId));
         const queueDepth = Number(depthRow?.depth ?? 0);
+        const telemetryTimestamp = nowDate().toISOString();
         await tx
           .update(agentRuns)
           .set({ runnerGroup: payload.runnerGroup })
@@ -5020,7 +5024,7 @@ function enqueueRunForConcurrency(
             and(eq(agentRuns.id, args.run.id), eq(agentRuns.status, "queued")),
           );
 
-        return { status: "queued" as const, queueDepth };
+        return { status: "queued" as const, queueDepth, telemetryTimestamp };
       },
     );
 
@@ -5028,6 +5032,7 @@ function enqueueRunForConcurrency(
       recordQueuedRunEnqueueTelemetry({
         runId: args.run.id,
         queueDepth: queuedPersistence.queueDepth,
+        timestamp: queuedPersistence.telemetryTimestamp,
       });
       ingestRunContextSnapshot(launch.runContextSnapshot);
       await publishOrgSignal(args.orgId, "queue:changed");


### PR DESCRIPTION
## Summary
- split runner launch payload preparation from run-context Axiom ingestion
- move direct and queued run-context ingestion after the derived launch row is persisted
- move queued enqueue telemetry out of the queue persistence transaction and keep telemetry failures non-fatal
- add a regression test proving a direct launch remains claimable when run-context ingest fails

## Testing
- cd turbo && pnpm -F @vm0/db db:migrate
- cd turbo && pnpm -F api check-types
- cd turbo && pnpm -F api lint
- cd turbo && pnpm -F api exec vitest src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --run
- cd turbo && pnpm knip --workspace api

Note: the full pre-commit hook currently fails on an unrelated existing knip finding in apps/platform: ChatThreadTitleParts in apps/platform/src/signals/chat-page/chat-thread-title.ts.

Refs #19439