### PR TITLE
feat: expose connector catalog status view models

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
@@ -16,9 +16,18 @@ import {
 } from "./helpers/zero-org-membership";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { assertPublicConnectorCatalogHasNoPrivateFields } from "./helpers/connector-catalog-public-leak";
+import { createBddApi } from "./helpers/api-bdd";
+import {
+  createConnectorBddApi,
+  mockGitHubConnectorOAuth,
+} from "./helpers/api-bdd-connectors";
+import { createAuthDeviceApiActions } from "./helpers/api-bdd-auth-device";
 
 const context = testContext();
 const mocks = createZeroRouteMocks(context);
+const bdd = createBddApi(context);
+const connectorsApi = createConnectorBddApi(context);
+const authDevice = createAuthDeviceApiActions(context);
 const store = createStore();
 
 async function enableFeatureSwitches(
@@ -51,6 +60,14 @@ async function deleteFeatureSwitches(
 
 function currentSecond(): number {
   return Math.floor(now() / 1000);
+}
+
+function stateFromAuthorizationUrl(authorizationUrl: string): string {
+  const state = new URL(authorizationUrl).searchParams.get("state");
+  if (!state) {
+    throw new Error("Expected connector authorization URL to include state");
+  }
+  return state;
 }
 
 describe("GET /api/zero/connector-catalog", () => {
@@ -214,6 +231,269 @@ describe("GET /api/zero/connector-catalog", () => {
     expect(response.body.error.message).toBe(
       "Missing required capability: connector:read",
     );
+  });
+
+  it("returns 401 for catalog status when not authenticated", async () => {
+    const client = setupApp({ context })(zeroConnectorCatalogContract);
+    const response = await accept(client.status({ headers: {} }), [401]);
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("returns 401 for catalog status when the session has no organization", async () => {
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+
+    const client = setupApp({ context })(zeroConnectorCatalogContract);
+    const response = await accept(
+      client.status({ headers: { authorization: "Bearer clerk-session" } }),
+      [401],
+    );
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("rejects catalog status ZERO_TOKEN calls without connector:read", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    seededOrgs.push(
+      await store.set(
+        seedOrgMembership$,
+        { orgId, userId, role: "admin" },
+        context.signal,
+      ),
+    );
+    const seconds = currentSecond();
+    const token = signSandboxJwtForTests({
+      scope: "zero",
+      userId,
+      orgId,
+      runId: `run_${randomUUID()}`,
+      capabilities: [],
+      iat: seconds,
+      exp: seconds + 600,
+    });
+
+    const client = setupApp({ context })(zeroConnectorCatalogContract);
+    const response = await accept(
+      client.status({ headers: { authorization: `Bearer ${token}` } }),
+      [403],
+    );
+
+    expect(response.body.error.code).toBe("FORBIDDEN");
+    expect(response.body.error.message).toBe(
+      "Missing required capability: connector:read",
+    );
+  });
+
+  it("returns public catalog status without private connector fields", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroConnectorCatalogContract);
+    const response = await accept(
+      client.status({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    assertPublicConnectorCatalogHasNoPrivateFields(response.body);
+    const openai = response.body.connectors.find((connector) => {
+      return connector.connectorRef === "openai";
+    });
+    expect(openai).toMatchObject({
+      connectorRef: "openai",
+      label: "OpenAI",
+      connected: false,
+      connection: null,
+      connectionStatus: "not-connected",
+      scopeMismatch: false,
+      authMethodSupportsRefresh: false,
+      tokenExpiresAt: null,
+      singleAuthCodeAuthMethodId: null,
+      connectNotice: null,
+    });
+    expect(openai?.authMethods).toStrictEqual([
+      {
+        id: "api-token",
+        label: "API Key",
+        description: expect.any(String),
+        grantKind: "manual",
+        manualFields: [
+          {
+            id: "apiKey",
+            label: "API Key",
+            required: true,
+            placeholder: "sk-...",
+            inputType: "password",
+          },
+        ],
+        startOptions: [],
+      },
+    ]);
+    const neon = response.body.connectors.find((connector) => {
+      return connector.connectorRef === "neon";
+    });
+    expect(
+      neon?.authMethods.map((authMethod) => {
+        return authMethod.id;
+      }),
+    ).toStrictEqual(["api-token"]);
+  });
+
+  it("returns connected manual grant status from public API-created state", async () => {
+    const actor = bdd.user();
+    await connectorsApi.connectManualGrant(actor, "openai", "api-token", {
+      apiKey: "sk-public-status",
+    });
+    mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+
+    const client = setupApp({ context })(zeroConnectorCatalogContract);
+    const response = await accept(
+      client.status({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    assertPublicConnectorCatalogHasNoPrivateFields(response.body);
+    const openai = response.body.connectors.find((connector) => {
+      return connector.connectorRef === "openai";
+    });
+    expect(openai).toMatchObject({
+      connectorRef: "openai",
+      connected: true,
+      connectionStatus: "connected",
+      scopeMismatch: false,
+      authMethodSupportsRefresh: false,
+      tokenExpiresAt: null,
+    });
+    expect(openai?.connection).toStrictEqual({
+      authMethod: "api-token",
+      externalId: null,
+      externalUsername: null,
+      externalEmail: null,
+      connectionStatus: "connected",
+      reconnectReason: null,
+      tokenExpiresAt: null,
+      createdAt: expect.any(String),
+      updatedAt: expect.any(String),
+    });
+    expect(openai?.connection).not.toHaveProperty("oauthScopes");
+  });
+
+  it("returns connected auth-code status without exposing stored scopes", async () => {
+    const actor = bdd.user();
+    mockGitHubConnectorOAuth();
+    const start = await connectorsApi.startOauth(actor, "github", "oauth");
+    await connectorsApi.completeOauthCallback("github", {
+      code: `github-${randomUUID()}`,
+      state: stateFromAuthorizationUrl(start.authorizationUrl),
+    });
+    mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+
+    const client = setupApp({ context })(zeroConnectorCatalogContract);
+    const response = await accept(
+      client.status({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    assertPublicConnectorCatalogHasNoPrivateFields(response.body);
+    const github = response.body.connectors.find((connector) => {
+      return connector.connectorRef === "github";
+    });
+    expect(github).toMatchObject({
+      connectorRef: "github",
+      connected: true,
+      connectionStatus: "connected",
+      scopeMismatch: false,
+      singleAuthCodeAuthMethodId: "oauth",
+    });
+    expect(github?.connection).toMatchObject({
+      authMethod: "oauth",
+      externalUsername: "bdd-github-user",
+      connectionStatus: "connected",
+    });
+    expect(github?.connection).not.toHaveProperty("oauthScopes");
+  });
+
+  it("returns scope mismatch status for connectors with missing stored scopes", async () => {
+    const actor = bdd.user();
+    await authDevice.provisionTestOrg(actor);
+    await authDevice.requestTestConnector(
+      { email: actor.email },
+      {
+        connectorName: "github",
+        authMethod: "oauth",
+        accessToken: "github-access-token",
+        expiresIn: 3600,
+      },
+      [200],
+    );
+    mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+
+    const client = setupApp({ context })(zeroConnectorCatalogContract);
+    const response = await accept(
+      client.status({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    assertPublicConnectorCatalogHasNoPrivateFields(response.body);
+    const github = response.body.connectors.find((connector) => {
+      return connector.connectorRef === "github";
+    });
+    expect(github).toMatchObject({
+      connectorRef: "github",
+      connected: true,
+      connectionStatus: "scope-mismatch",
+      scopeMismatch: true,
+      authMethodSupportsRefresh: false,
+    });
+    expect(github?.connection).toMatchObject({
+      authMethod: "oauth",
+      connectionStatus: "connected",
+      reconnectReason: null,
+    });
+    expect(github?.connection).not.toHaveProperty("oauthScopes");
+  });
+
+  it("returns reconnect-required status for expired non-refreshable connectors", async () => {
+    const actor = bdd.user();
+    await authDevice.provisionTestOrg(actor);
+    await authDevice.requestTestConnector(
+      { email: actor.email },
+      {
+        connectorName: "github",
+        authMethod: "oauth",
+        accessToken: "expired-github-access-token",
+        expiresIn: -60,
+      },
+      [200],
+    );
+    mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+
+    const client = setupApp({ context })(zeroConnectorCatalogContract);
+    const response = await accept(
+      client.status({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    assertPublicConnectorCatalogHasNoPrivateFields(response.body);
+    const github = response.body.connectors.find((connector) => {
+      return connector.connectorRef === "github";
+    });
+    expect(github).toMatchObject({
+      connectorRef: "github",
+      connected: true,
+      connectionStatus: "reconnect-required",
+      scopeMismatch: true,
+      authMethodSupportsRefresh: false,
+    });
+    expect(github?.connection).toMatchObject({
+      authMethod: "oauth",
+      connectionStatus: "reconnect-required",
+      reconnectReason: "credential_expired",
+    });
+    expect(github?.tokenExpiresAt).toStrictEqual(expect.any(String));
+    expect(Date.parse(github?.tokenExpiresAt ?? "")).toBeLessThan(now());
+    expect(github?.connection).not.toHaveProperty("oauthScopes");
   });
 
   it("returns connector detail without leaking manual field storage names", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
@@ -367,16 +367,14 @@ describe("GET /api/zero/connector-catalog", () => {
     });
     expect(openai?.connection).toStrictEqual({
       authMethod: "api-token",
-      externalId: null,
       externalUsername: null,
       externalEmail: null,
-      connectionStatus: "connected",
       reconnectReason: null,
-      tokenExpiresAt: null,
-      createdAt: expect.any(String),
-      updatedAt: expect.any(String),
     });
     expect(openai?.connection).not.toHaveProperty("oauthScopes");
+    expect(openai?.connection).not.toHaveProperty("externalId");
+    expect(openai?.connection).not.toHaveProperty("createdAt");
+    expect(openai?.connection).not.toHaveProperty("updatedAt");
   });
 
   it("returns connected auth-code status without exposing stored scopes", async () => {
@@ -409,7 +407,6 @@ describe("GET /api/zero/connector-catalog", () => {
     expect(github?.connection).toMatchObject({
       authMethod: "oauth",
       externalUsername: "bdd-github-user",
-      connectionStatus: "connected",
     });
     expect(github?.connection).not.toHaveProperty("oauthScopes");
   });
@@ -448,7 +445,6 @@ describe("GET /api/zero/connector-catalog", () => {
     });
     expect(github?.connection).toMatchObject({
       authMethod: "oauth",
-      connectionStatus: "connected",
       reconnectReason: null,
     });
     expect(github?.connection).not.toHaveProperty("oauthScopes");
@@ -488,7 +484,6 @@ describe("GET /api/zero/connector-catalog", () => {
     });
     expect(github?.connection).toMatchObject({
       authMethod: "oauth",
-      connectionStatus: "reconnect-required",
       reconnectReason: "credential_expired",
     });
     expect(github?.tokenExpiresAt).toStrictEqual(expect.any(String));

--- a/turbo/apps/api/src/signals/routes/zero-connector-catalog.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connector-catalog.ts
@@ -63,7 +63,11 @@ const listConnectorCatalogStatusInner$ = command(
     signal.throwIfAborted();
 
     const connectorState = await get(
-      zeroConnectorList({ orgId: auth.orgId, userId: auth.userId }),
+      zeroConnectorList({
+        orgId: auth.orgId,
+        userId: auth.userId,
+        featureStates: context.featureStates,
+      }),
     );
     signal.throwIfAborted();
 

--- a/turbo/apps/api/src/signals/routes/zero-connector-catalog.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connector-catalog.ts
@@ -11,7 +11,9 @@ import {
   getPublicConnectorCatalogDetail,
   getPublicConnectorCatalogPermissionDetail,
   listPublicConnectorCatalog,
+  listPublicConnectorCatalogStatus,
 } from "../services/connector-catalog-reader.service";
+import { zeroConnectorList } from "../services/zero-connector-data.service";
 import { notFound } from "../../lib/error";
 
 const connectorCatalogAuth = {
@@ -47,6 +49,28 @@ const listConnectorCatalogInner$ = command(
     const connectors = await listPublicConnectorCatalog({
       featureStates: context.featureStates,
       apiAuthMethodPolicy: "include",
+    });
+    signal.throwIfAborted();
+
+    return { status: 200 as const, body: { connectors } };
+  },
+);
+
+const listConnectorCatalogStatusInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    const context = await set(connectorCatalogRequestContext$);
+    signal.throwIfAborted();
+
+    const connectorState = await get(
+      zeroConnectorList({ orgId: auth.orgId, userId: auth.userId }),
+    );
+    signal.throwIfAborted();
+
+    const connectors = await listPublicConnectorCatalogStatus({
+      featureStates: context.featureStates,
+      apiAuthMethodPolicy: "include",
+      connectors: connectorState.connectors,
     });
     signal.throwIfAborted();
 
@@ -98,6 +122,10 @@ export const zeroConnectorCatalogRoutes: readonly RouteEntry[] = [
   {
     route: zeroConnectorCatalogContract.list,
     handler: authRoute(connectorCatalogAuth, listConnectorCatalogInner$),
+  },
+  {
+    route: zeroConnectorCatalogContract.status,
+    handler: authRoute(connectorCatalogAuth, listConnectorCatalogStatusInner$),
   },
   {
     route: zeroConnectorCatalogContract.get,

--- a/turbo/apps/api/src/signals/services/connector-catalog-reader.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-reader.service.ts
@@ -1,14 +1,19 @@
 import type {
   PublicConnectorCatalogAuthMethodDetail,
   PublicConnectorCatalogAuthMethodSummary,
+  PublicConnectorCatalogConnection,
+  PublicConnectorCatalogConnectionStatus,
   PublicConnectorCatalogDetail,
   PublicConnectorCatalogItem,
   PublicConnectorCatalogManualField,
   PublicConnectorCatalogPermissionDetail,
   PublicConnectorCatalogPermissionSummary,
   PublicConnectorCatalogStartOption,
+  PublicConnectorCatalogStatusItem,
 } from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
 import type { ConnectorSearchItem } from "@vm0/api-contracts/contracts/zero-connectors";
+import { isGoogleOAuthConnector } from "@vm0/connectors/auth-providers/oauth/google-connectors";
 import {
   CONNECTOR_TYPE_KEYS,
   CONNECTOR_TYPES,
@@ -18,10 +23,12 @@ import {
 } from "@vm0/connectors/connectors";
 import {
   getAvailableConnectorAuthMethodIds,
+  getConnectorAuthMethodAccessMetadata,
   getConnectorAuthMethod,
   getConnectorPrivateNames,
   getConnectorGenerationTypes,
   getConnectorTags,
+  hasRequiredConnectorAuthMethodScopes,
   type ApiAuthMethodPolicy,
   type ConnectorFeatureStates,
 } from "@vm0/connectors/connector-utils";
@@ -222,6 +229,92 @@ function connectorCatalogDetail(
   };
 }
 
+function connectionForCatalogStatus(
+  connector: ConnectorResponse | null,
+): PublicConnectorCatalogConnection | null {
+  if (!connector) {
+    return null;
+  }
+  return {
+    authMethod: connector.authMethod,
+    externalId: connector.externalId,
+    externalUsername: connector.externalUsername,
+    externalEmail: connector.externalEmail,
+    connectionStatus: connector.connectionStatus,
+    reconnectReason: connector.reconnectReason,
+    tokenExpiresAt: connector.tokenExpiresAt,
+    createdAt: connector.createdAt,
+    updatedAt: connector.updatedAt,
+  };
+}
+
+function singleAuthCodeAuthMethodId(
+  type: ConnectorType,
+  authMethods: readonly ConnectorAuthMethodId[],
+): ConnectorAuthMethodId | null {
+  const [authMethod] = authMethods;
+  if (authMethods.length !== 1 || !authMethod) {
+    return null;
+  }
+  return getConnectorAuthMethod(type, authMethod)?.grant.kind === "auth-code"
+    ? authMethod
+    : null;
+}
+
+function connectorAuthMethodSupportsRefresh(
+  type: ConnectorType,
+  authMethod: string,
+): boolean {
+  return (
+    getConnectorAuthMethodAccessMetadata(type, authMethod)?.kind ===
+    "refresh-token"
+  );
+}
+
+function connectorCatalogStatusItem(args: {
+  readonly type: ConnectorType;
+  readonly authMethods: readonly ConnectorAuthMethodId[];
+  readonly connector: ConnectorResponse | null;
+}): PublicConnectorCatalogStatusItem {
+  const detail = connectorCatalogDetail(args.type, args.authMethods);
+  const scopeMismatch =
+    args.connector !== null &&
+    !hasRequiredConnectorAuthMethodScopes(
+      args.type,
+      args.connector.authMethod,
+      args.connector.oauthScopes,
+    );
+  let connectionStatus: PublicConnectorCatalogConnectionStatus =
+    "not-connected";
+  if (args.connector !== null) {
+    connectionStatus =
+      args.connector.connectionStatus === "reconnect-required"
+        ? "reconnect-required"
+        : scopeMismatch
+          ? "scope-mismatch"
+          : "connected";
+  }
+
+  return {
+    ...detail,
+    connection: connectionForCatalogStatus(args.connector),
+    connected: args.connector !== null,
+    connectionStatus,
+    scopeMismatch,
+    authMethodSupportsRefresh:
+      args.connector !== null &&
+      connectorAuthMethodSupportsRefresh(args.type, args.connector.authMethod),
+    tokenExpiresAt: args.connector?.tokenExpiresAt ?? null,
+    singleAuthCodeAuthMethodId: singleAuthCodeAuthMethodId(
+      args.type,
+      args.authMethods,
+    ),
+    connectNotice: isGoogleOAuthConnector(args.type)
+      ? "google-security-warning"
+      : null,
+  };
+}
+
 export function searchConnectorCatalog(
   args: ConnectorCatalogSearchArgs,
 ): Promise<ConnectorSearchItem[]> {
@@ -275,6 +368,33 @@ export function listPublicConnectorCatalog(
       return [];
     }
     return [connectorCatalogItem(type, authMethods)];
+  });
+
+  return Promise.resolve(connectors);
+}
+
+export function listPublicConnectorCatalogStatus(
+  args: ConnectorCatalogReadArgs & {
+    readonly connectors: readonly ConnectorResponse[];
+  },
+): Promise<PublicConnectorCatalogStatusItem[]> {
+  const connectorsByType = new Map(
+    args.connectors.map((connector) => {
+      return [connector.type, connector];
+    }),
+  );
+  const connectors = CONNECTOR_TYPE_KEYS.flatMap((type) => {
+    const authMethods = availableAuthMethodsForCatalog(type, args);
+    if (authMethods.length === 0) {
+      return [];
+    }
+    return [
+      connectorCatalogStatusItem({
+        type,
+        authMethods,
+        connector: connectorsByType.get(type) ?? null,
+      }),
+    ];
   });
 
   return Promise.resolve(connectors);

--- a/turbo/apps/api/src/signals/services/connector-catalog-reader.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-reader.service.ts
@@ -237,14 +237,9 @@ function connectionForCatalogStatus(
   }
   return {
     authMethod: connector.authMethod,
-    externalId: connector.externalId,
     externalUsername: connector.externalUsername,
     externalEmail: connector.externalEmail,
-    connectionStatus: connector.connectionStatus,
     reconnectReason: connector.reconnectReason,
-    tokenExpiresAt: connector.tokenExpiresAt,
-    createdAt: connector.createdAt,
-    updatedAt: connector.updatedAt,
   };
 }
 

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -417,39 +417,49 @@ function omittedManualGrantFieldNames(
 export function zeroConnectorList(args: {
   readonly orgId: string;
   readonly userId: string;
+  readonly featureStates?: FeatureStates;
 }): Computed<Promise<ConnectorListResponse>> {
   return computed(async (get): Promise<ConnectorListResponse> => {
     const db = get(db$);
-    const [storedRows, overrides] = await Promise.all([
-      db
-        .select({
-          id: connectors.id,
-          type: connectors.type,
-          authMethod: connectors.authMethod,
-          externalId: connectors.externalId,
-          externalUsername: connectors.externalUsername,
-          externalEmail: connectors.externalEmail,
-          oauthScopes: connectors.oauthScopes,
-          needsReconnect: connectors.needsReconnect,
-          reconnectReason: connectors.reconnectReason,
-          tokenExpiresAt: connectors.tokenExpiresAt,
-          createdAt: connectors.createdAt,
-          updatedAt: connectors.updatedAt,
-        })
-        .from(connectors)
-        .where(
-          and(
-            eq(connectors.orgId, args.orgId),
-            eq(connectors.userId, args.userId),
-          ),
+    const storedRowsPromise = db
+      .select({
+        id: connectors.id,
+        type: connectors.type,
+        authMethod: connectors.authMethod,
+        externalId: connectors.externalId,
+        externalUsername: connectors.externalUsername,
+        externalEmail: connectors.externalEmail,
+        oauthScopes: connectors.oauthScopes,
+        needsReconnect: connectors.needsReconnect,
+        reconnectReason: connectors.reconnectReason,
+        tokenExpiresAt: connectors.tokenExpiresAt,
+        createdAt: connectors.createdAt,
+        updatedAt: connectors.updatedAt,
+      })
+      .from(connectors)
+      .where(
+        and(
+          eq(connectors.orgId, args.orgId),
+          eq(connectors.userId, args.userId),
         ),
-      get(userFeatureSwitchOverrides(args.orgId, args.userId)),
+      );
+    const featureStatesPromise = (async () => {
+      if (args.featureStates) {
+        return args.featureStates;
+      }
+      const overrides = await get(
+        userFeatureSwitchOverrides(args.orgId, args.userId),
+      );
+      return getAllFeatureStates({
+        userId: args.userId,
+        orgId: args.orgId,
+        overrides,
+      });
+    })();
+    const [storedRows, featureStates] = await Promise.all([
+      storedRowsPromise,
+      featureStatesPromise,
     ]);
-    const featureStates = getAllFeatureStates({
-      userId: args.userId,
-      orgId: args.orgId,
-      overrides,
-    });
 
     const now = nowDate();
     const connectorList: ConnectorResponse[] = storedRows.flatMap((row) => {

--- a/turbo/apps/platform/src/lib/google-security-warning.ts
+++ b/turbo/apps/platform/src/lib/google-security-warning.ts
@@ -6,7 +6,3 @@ export function shouldShowGoogleSecurityWarningNotice(
 ): boolean {
   return isGoogleOAuthConnector(type);
 }
-
-export function shouldShowConnectorConnectNotice(type: ConnectorType): boolean {
-  return shouldShowGoogleSecurityWarningNotice(type);
-}

--- a/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
@@ -2,6 +2,7 @@ import {
   CONNECTOR_TYPE_KEYS,
   type ConnectorAuthMethodId,
   type ConnectorType,
+  CONNECTOR_TYPES,
 } from "@vm0/connectors/connectors";
 import type {
   ConnectorExternalCodeSessionStartResponse,
@@ -10,6 +11,13 @@ import type {
   ConnectorResponse,
 } from "@vm0/api-contracts/contracts/connector-schemas";
 import {
+  zeroConnectorCatalogContract,
+  type PublicConnectorCatalogConnection,
+  type PublicConnectorCatalogConnectionStatus,
+  type PublicConnectorCatalogPermissionSummary,
+  type PublicConnectorCatalogStatusItem,
+} from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import {
   zeroConnectorExternalCodeSessionContract,
   zeroConnectorManualGrantContract,
   zeroConnectorOauthDeviceAuthSessionContract,
@@ -17,7 +25,21 @@ import {
   zeroConnectorScopeDiffContract,
   zeroConnectorsMainContract,
 } from "@vm0/api-contracts/contracts/zero-connectors";
+import { isGoogleOAuthConnector } from "@vm0/connectors/auth-providers/oauth/google-connectors";
+import {
+  getAvailableConnectorAuthMethodIds,
+  getConnectorAuthMethod,
+  getConnectorAuthMethodAccessMetadata,
+  getConnectorGenerationTypes,
+  getConnectorTags,
+  hasRequiredConnectorAuthMethodScopes,
+  type ConnectorFeatureStates,
+} from "@vm0/connectors/connector-utils";
+import { getFirewallPermissionSummary } from "@vm0/connectors/firewall-metadata";
+import { getAllFeatureStates } from "@vm0/core/feature-switch";
 import { mockApi } from "../msw-contract.ts";
+
+const FEATURE_SWITCH_CACHE_KEY = "vm0:feature-switch-cache:v1";
 
 let mockConnectors: ConnectorResponse[] = [];
 type MockOauthDeviceAuthSessionStartResponse = Omit<
@@ -151,6 +173,158 @@ function resetMockOauthDeviceAuth(): void {
   mockExternalCodeSessionStartResponse = undefined;
 }
 
+function mockFeatureStates(): ConnectorFeatureStates {
+  const raw = globalThis.localStorage?.getItem(FEATURE_SWITCH_CACHE_KEY);
+  return raw
+    ? (JSON.parse(raw) as Record<string, boolean>)
+    : getAllFeatureStates({});
+}
+
+function mockPermissionSummary(
+  type: ConnectorType,
+): PublicConnectorCatalogPermissionSummary {
+  const summary = getFirewallPermissionSummary(type);
+  return {
+    hasPermissions: summary?.hasPermissions ?? false,
+    permissionCount: summary?.permissionCount ?? 0,
+    hasCategories: summary?.hasCategories ?? false,
+    hasDefaultPolicyOverrides: summary?.hasDefaultPolicyOverrides ?? false,
+  };
+}
+
+function mockConnectionForCatalogStatus(
+  connector: ConnectorResponse | null,
+): PublicConnectorCatalogConnection | null {
+  if (!connector) {
+    return null;
+  }
+  return {
+    authMethod: connector.authMethod,
+    externalId: connector.externalId,
+    externalUsername: connector.externalUsername,
+    externalEmail: connector.externalEmail,
+    connectionStatus: connector.connectionStatus,
+    reconnectReason: connector.reconnectReason,
+    tokenExpiresAt: connector.tokenExpiresAt,
+    createdAt: connector.createdAt,
+    updatedAt: connector.updatedAt,
+  };
+}
+
+function mockSingleAuthCodeAuthMethodId(
+  type: ConnectorType,
+  authMethods: readonly ConnectorAuthMethodId[],
+): ConnectorAuthMethodId | null {
+  const [authMethod] = authMethods;
+  if (authMethods.length !== 1 || !authMethod) {
+    return null;
+  }
+  return getConnectorAuthMethod(type, authMethod)?.grant.kind === "auth-code"
+    ? authMethod
+    : null;
+}
+
+function mockConnectorAuthMethodSupportsRefresh(
+  type: ConnectorType,
+  authMethod: string,
+): boolean {
+  return (
+    getConnectorAuthMethodAccessMetadata(type, authMethod)?.kind ===
+    "refresh-token"
+  );
+}
+
+function mockConnectorCatalogStatusItem(
+  type: ConnectorType,
+  authMethods: readonly ConnectorAuthMethodId[],
+  connector: ConnectorResponse | null,
+): PublicConnectorCatalogStatusItem {
+  const config = CONNECTOR_TYPES[type];
+  const scopeMismatch =
+    connector !== null &&
+    !hasRequiredConnectorAuthMethodScopes(
+      type,
+      connector.authMethod,
+      connector.oauthScopes,
+    );
+  let connectionStatus: PublicConnectorCatalogConnectionStatus =
+    "not-connected";
+  if (connector !== null) {
+    connectionStatus =
+      connector.connectionStatus === "reconnect-required"
+        ? "reconnect-required"
+        : scopeMismatch
+          ? "scope-mismatch"
+          : "connected";
+  }
+
+  return {
+    connectorRef: type,
+    label: config.label,
+    description: config.helpText,
+    category: config.category,
+    generation: [...getConnectorGenerationTypes(type)],
+    tags: [...getConnectorTags(type)],
+    authMethods: authMethods.flatMap((authMethod) => {
+      const method = getConnectorAuthMethod(type, authMethod);
+      return method
+        ? [
+            {
+              id: authMethod,
+              label: method.label,
+              description: method.helpText ?? null,
+              grantKind: method.grant.kind,
+              manualFields: [],
+              startOptions: [],
+            },
+          ]
+        : [];
+    }),
+    permissionSummary: mockPermissionSummary(type),
+    connection: mockConnectionForCatalogStatus(connector),
+    connected: connector !== null,
+    connectionStatus,
+    scopeMismatch,
+    authMethodSupportsRefresh:
+      connector !== null &&
+      mockConnectorAuthMethodSupportsRefresh(type, connector.authMethod),
+    tokenExpiresAt: connector?.tokenExpiresAt ?? null,
+    singleAuthCodeAuthMethodId: mockSingleAuthCodeAuthMethodId(
+      type,
+      authMethods,
+    ),
+    connectNotice: isGoogleOAuthConnector(type)
+      ? "google-security-warning"
+      : null,
+  };
+}
+
+function mockConnectorCatalogStatus(): PublicConnectorCatalogStatusItem[] {
+  const connectorsByType = new Map(
+    mockConnectors.map((connector) => {
+      return [connector.type, connector];
+    }),
+  );
+  const featureStates = mockFeatureStates();
+  return CONNECTOR_TYPE_KEYS.flatMap((type) => {
+    const authMethods = getAvailableConnectorAuthMethodIds(
+      type,
+      featureStates,
+      { apiAuthMethodPolicy: "include" },
+    );
+    if (authMethods.length === 0) {
+      return [];
+    }
+    return [
+      mockConnectorCatalogStatusItem(
+        type,
+        authMethods,
+        connectorsByType.get(type) ?? null,
+      ),
+    ];
+  });
+}
+
 export const apiConnectorsHandlers = [
   mockApi(zeroConnectorsMainContract.list, ({ respond }) => {
     return respond(200, {
@@ -158,6 +332,10 @@ export const apiConnectorsHandlers = [
       configuredTypes: [...CONNECTOR_TYPE_KEYS],
       connectorProvidedBindings: [],
     });
+  }),
+
+  mockApi(zeroConnectorCatalogContract.status, ({ respond }) => {
+    return respond(200, { connectors: mockConnectorCatalogStatus() });
   }),
 
   mockApi(zeroConnectorsByTypeContract.delete, ({ params, respond }) => {

--- a/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
@@ -200,14 +200,9 @@ function mockConnectionForCatalogStatus(
   }
   return {
     authMethod: connector.authMethod,
-    externalId: connector.externalId,
     externalUsername: connector.externalUsername,
     externalEmail: connector.externalEmail,
-    connectionStatus: connector.connectionStatus,
     reconnectReason: connector.reconnectReason,
-    tokenExpiresAt: connector.tokenExpiresAt,
-    createdAt: connector.createdAt,
-    updatedAt: connector.updatedAt,
   };
 }
 

--- a/turbo/apps/platform/src/signals/external/connectors.ts
+++ b/turbo/apps/platform/src/signals/external/connectors.ts
@@ -3,6 +3,10 @@ import {
   zeroConnectorsMainContract,
   zeroConnectorsByTypeContract,
 } from "@vm0/api-contracts/contracts/zero-connectors";
+import {
+  zeroConnectorCatalogContract,
+  type PublicConnectorCatalogStatusResponse,
+} from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import type { ConnectorType } from "@vm0/connectors/connectors";
 import type { ConnectorListResponse } from "@vm0/api-contracts/contracts/connector-schemas";
 import { zeroClient$ } from "../api-client";
@@ -24,6 +28,18 @@ export const connectors$ = computed(async (get) => {
   const client = createClient(zeroConnectorsMainContract);
   const result = await accept(client.list(), [200]);
   return result.body as ConnectorListResponse;
+});
+
+/**
+ * Public connector catalog metadata joined with the current user's connector status.
+ */
+export const connectorCatalogStatus$ = computed(async (get) => {
+  get(internalReloadConnectors$);
+
+  const createClient = get(zeroClient$);
+  const client = createClient(zeroConnectorCatalogContract);
+  const result = await accept(client.status(), [200]);
+  return result.body as PublicConnectorCatalogStatusResponse;
 });
 
 /**

--- a/turbo/apps/platform/src/signals/external/connectors.ts
+++ b/turbo/apps/platform/src/signals/external/connectors.ts
@@ -24,6 +24,7 @@ const internalReloadConnectors$ = state(0);
  */
 export const connectors$ = computed(async (get) => {
   get(internalReloadConnectors$);
+  get(featureSwitch$);
 
   const createClient = get(zeroClient$);
   const client = createClient(zeroConnectorsMainContract);

--- a/turbo/apps/platform/src/signals/external/connectors.ts
+++ b/turbo/apps/platform/src/signals/external/connectors.ts
@@ -11,6 +11,7 @@ import type { ConnectorType } from "@vm0/connectors/connectors";
 import type { ConnectorListResponse } from "@vm0/api-contracts/contracts/connector-schemas";
 import { zeroClient$ } from "../api-client";
 import { accept } from "../../lib/accept.ts";
+import { featureSwitch$ } from "./feature-switch.ts";
 
 /**
  * Reload trigger for connector signals.
@@ -35,6 +36,7 @@ export const connectors$ = computed(async (get) => {
  */
 export const connectorCatalogStatus$ = computed(async (get) => {
   get(internalReloadConnectors$);
+  get(featureSwitch$);
 
   const createClient = get(zeroClient$);
   const client = createClient(zeroConnectorCatalogContract);

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -20,7 +20,6 @@ import {
   hasConnectorDeviceAuthGrant,
   hasConnectorExternalCodeGrant,
 } from "@vm0/connectors/connector-utils";
-import { shouldShowConnectorConnectNotice } from "../../../lib/google-security-warning.ts";
 import {
   zeroConnectorScopeDiffContract,
   zeroConnectorExternalCodeSessionContract,
@@ -120,60 +119,6 @@ const HOUR_MS = 60 * 60 * 1000;
 const DAY_MS = 24 * HOUR_MS;
 
 type ConnectorConnectLaunchMode = "oauth-auth-code" | "modal";
-
-export function getConnectorConnectLaunchMode({
-  type,
-  availableAuthMethods,
-  preferModalForConnectorNotice = false,
-}: {
-  readonly type: ConnectorType;
-  readonly availableAuthMethods: readonly ConnectorAuthMethodId[];
-  readonly preferModalForConnectorNotice?: boolean;
-}): ConnectorConnectLaunchMode {
-  const [authMethod] = availableAuthMethods;
-  if (availableAuthMethods.length !== 1 || !authMethod) {
-    return "modal";
-  }
-  if (getConnectorAuthMethod(type, authMethod)?.grant.kind !== "auth-code") {
-    return "modal";
-  }
-  if (preferModalForConnectorNotice && shouldShowConnectorConnectNotice(type)) {
-    return "modal";
-  }
-  return "oauth-auth-code";
-}
-
-export function getAvailableAuthCodeAuthMethod(
-  type: ConnectorType,
-  availableAuthMethods: readonly ConnectorAuthMethodId[],
-  authMethod: string,
-): ConnectorAuthMethodId | null {
-  const authMethodResult = connectorAuthMethodIdSchema.safeParse(authMethod);
-  if (!authMethodResult.success) {
-    return null;
-  }
-  if (!availableAuthMethods.includes(authMethodResult.data)) {
-    return null;
-  }
-  if (
-    getConnectorAuthMethod(type, authMethodResult.data)?.grant.kind !==
-    "auth-code"
-  ) {
-    return null;
-  }
-  return authMethodResult.data;
-}
-
-export function getOnlyAvailableAuthCodeAuthMethod(
-  type: ConnectorType,
-  availableAuthMethods: readonly ConnectorAuthMethodId[],
-): ConnectorAuthMethodId | null {
-  const [authMethod] = availableAuthMethods;
-  if (availableAuthMethods.length !== 1 || !authMethod) {
-    return null;
-  }
-  return getAvailableAuthCodeAuthMethod(type, availableAuthMethods, authMethod);
-}
 
 export function getConnectorStatusConnectLaunchMode(
   connector: ConnectorTypeWithStatus,

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -5,9 +5,10 @@ import { toast } from "@vm0/ui/components/ui/sonner";
 import { accept } from "../../../lib/accept.ts";
 import { now } from "../../../lib/time.ts";
 import {
-  CONNECTOR_TYPE_KEYS,
+  CONNECTOR_DISPLAY_CATEGORY_ORDER,
   CONNECTOR_TYPES,
   connectorAuthMethodIdSchema,
+  connectorTypeSchema,
   type ConnectorAuthMethodId,
   type ConnectorDeviceAuthStartOptions,
   type ConnectorType,
@@ -15,11 +16,7 @@ import {
 } from "@vm0/connectors/connectors";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
-  getConnectorAuthMethodAccessMetadata,
   getConnectorAuthMethod,
-  getAvailableConnectorAuthMethodIds,
-  getConnectorTags,
-  hasRequiredConnectorAuthMethodScopes,
   hasConnectorDeviceAuthGrant,
   hasConnectorExternalCodeGrant,
 } from "@vm0/connectors/connector-utils";
@@ -38,8 +35,14 @@ import type {
   ConnectorReconnectReason,
   ConnectorResponse,
 } from "@vm0/api-contracts/contracts/connector-schemas";
+import type {
+  PublicConnectorCatalogAuthMethodDetail,
+  PublicConnectorCatalogConnection,
+  PublicConnectorCatalogStatusItem,
+} from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { featureSwitch$ } from "../../external/feature-switch.ts";
 import {
+  connectorCatalogStatus$,
   connectors$,
   deleteConnector$,
   reloadConnectors$,
@@ -82,19 +85,25 @@ export type ConnectorConnectionStatus =
 
 /**
  * All connector types with their connection status.
- * Merges the static CONNECTOR_TYPES registry with live data from the API.
+ * Uses server-authored public catalog/status data.
  */
 export interface ConnectorTypeWithStatus {
   type: ConnectorType;
   label: string;
   helpText: string;
   category: ConnectorDisplayCategory;
-  /** Lowercase aliases/keywords used by connector search (from CONNECTOR_TYPES). */
+  /** Lowercase aliases/keywords used by connector search. */
   tags: readonly string[];
   connected: boolean;
-  connector: ConnectorResponse | null;
+  connector: PublicConnectorCatalogConnection | null;
+  /** Public auth method metadata available after server-side filtering. */
+  authMethods: readonly PublicConnectorCatalogAuthMethodDetail[];
   /** Auth methods available for this connector after availability filtering. */
   availableAuthMethods: ConnectorAuthMethodId[];
+  /** Single available auth-code method if direct OAuth can be considered. */
+  singleAuthCodeAuthMethodId: ConnectorAuthMethodId | null;
+  /** Public notice shown before direct connect flows. */
+  connectNotice: "google-security-warning" | null;
   /** True if at least one agent references this connector (env mapping). */
   usedByAgent?: boolean;
   /** True if stored grant scopes don't cover all currently required scopes. */
@@ -166,14 +175,53 @@ export function getOnlyAvailableAuthCodeAuthMethod(
   return getAvailableAuthCodeAuthMethod(type, availableAuthMethods, authMethod);
 }
 
-function connectorAuthMethodSupportsRefresh(
-  type: ConnectorType,
+export function getConnectorStatusConnectLaunchMode(
+  connector: ConnectorTypeWithStatus,
+  {
+    preferModalForConnectorNotice = false,
+  }: { readonly preferModalForConnectorNotice?: boolean } = {},
+): ConnectorConnectLaunchMode {
+  if (
+    connector.availableAuthMethods.length !== 1 ||
+    !connector.singleAuthCodeAuthMethodId
+  ) {
+    return "modal";
+  }
+  if (preferModalForConnectorNotice && connector.connectNotice) {
+    return "modal";
+  }
+  return "oauth-auth-code";
+}
+
+export function getAvailableStatusAuthCodeAuthMethod(
+  connector: ConnectorTypeWithStatus,
   authMethod: string,
-): boolean {
-  return (
-    getConnectorAuthMethodAccessMetadata(type, authMethod)?.kind ===
-    "refresh-token"
-  );
+): ConnectorAuthMethodId | null {
+  const parsed = connectorAuthMethodIdSchema.safeParse(authMethod);
+  if (!parsed.success) {
+    return null;
+  }
+  if (!connector.availableAuthMethods.includes(parsed.data)) {
+    return null;
+  }
+  if (
+    !connector.authMethods.some((method) => {
+      return method.id === parsed.data && method.grantKind === "auth-code";
+    })
+  ) {
+    return null;
+  }
+  return parsed.data;
+}
+
+export function getOnlyAvailableStatusAuthCodeAuthMethod(
+  connector: ConnectorTypeWithStatus,
+): ConnectorAuthMethodId | null {
+  const [authMethod] = connector.availableAuthMethods;
+  if (connector.availableAuthMethods.length !== 1 || !authMethod) {
+    return null;
+  }
+  return getAvailableStatusAuthCodeAuthMethod(connector, authMethod);
 }
 
 function connectorTokenExpiresAtMs(
@@ -245,66 +293,54 @@ export function connectorReconnectReasonTooltipText(
   return reason ? reconnectReasonTooltipText[reason] : null;
 }
 
-function buildConnectorTypeStatus(params: {
-  readonly type: ConnectorType;
-  readonly connector: ConnectorResponse | null;
-  readonly features: Record<string, boolean> | null | undefined;
-}): ConnectorTypeWithStatus {
-  const config = CONNECTOR_TYPES[params.type];
-  const availableAuthMethods = getAvailableConnectorAuthMethodIds(
-    params.type,
-    params.features,
-  );
-  const hasManualGrant = availableAuthMethods.some((authMethod) => {
-    return (
-      getConnectorAuthMethod(params.type, authMethod)?.grant.kind === "manual"
-    );
+function isConnectorDisplayCategory(
+  value: string,
+): value is ConnectorDisplayCategory {
+  return CONNECTOR_DISPLAY_CATEGORY_ORDER.some((category) => {
+    return category === value;
   });
-  const showExperimentalLabel = availableAuthMethods.some((authMethod) => {
-    const method = getConnectorAuthMethod(params.type, authMethod);
-    return !!method?.featureFlag && method.showExperimentalLabel !== false;
-  });
-  const connected = params.connector !== null;
-  const apiConnectionStatus = params.connector?.connectionStatus ?? null;
-  const authMethodSupportsRefresh =
-    params.connector !== null &&
-    connectorAuthMethodSupportsRefresh(
-      params.type,
-      params.connector.authMethod,
-    );
-  const scopeMismatch =
-    params.connector !== null &&
-    !hasRequiredConnectorAuthMethodScopes(
-      params.type,
-      params.connector.authMethod,
-      params.connector.oauthScopes,
-    );
-  let connectionStatus: ConnectorConnectionStatus = "not-connected";
-  if (params.connector !== null) {
-    connectionStatus = "connected";
-    if (apiConnectionStatus === "reconnect-required") {
-      connectionStatus = "reconnect-required";
-    } else if (scopeMismatch) {
-      connectionStatus = "scope-mismatch";
-    }
+}
+
+function parseConnectorAuthMethodId(
+  value: string | null,
+): ConnectorAuthMethodId | null {
+  if (!value) {
+    return null;
   }
+  const parsed = connectorAuthMethodIdSchema.safeParse(value);
+  return parsed.success ? parsed.data : null;
+}
+
+function connectorCatalogStatusItemToConnectorType(
+  item: PublicConnectorCatalogStatusItem,
+): ConnectorTypeWithStatus | null {
+  const type = connectorTypeSchema.safeParse(item.connectorRef);
+  if (!type.success || !isConnectorDisplayCategory(item.category)) {
+    return null;
+  }
+  const availableAuthMethods = item.authMethods.flatMap((authMethod) => {
+    const parsed = parseConnectorAuthMethodId(authMethod.id);
+    return parsed ? [parsed] : [];
+  });
 
   return {
-    type: params.type,
-    label:
-      showExperimentalLabel && !hasManualGrant
-        ? `[Experimental] ${config.label}`
-        : config.label,
-    helpText: config.helpText,
-    category: config.category,
-    tags: getConnectorTags(params.type),
-    connected,
-    connector: params.connector,
+    type: type.data,
+    label: item.label,
+    helpText: item.description,
+    category: item.category,
+    tags: item.tags,
+    connected: item.connected,
+    connector: item.connection,
+    authMethods: item.authMethods,
     availableAuthMethods,
-    scopeMismatch,
-    connectionStatus,
-    tokenExpiresAt: params.connector?.tokenExpiresAt ?? null,
-    authMethodSupportsRefresh,
+    singleAuthCodeAuthMethodId: parseConnectorAuthMethodId(
+      item.singleAuthCodeAuthMethodId,
+    ),
+    connectNotice: item.connectNotice,
+    scopeMismatch: item.scopeMismatch,
+    connectionStatus: item.connectionStatus,
+    tokenExpiresAt: item.tokenExpiresAt,
+    authMethodSupportsRefresh: item.authMethodSupportsRefresh,
   };
 }
 
@@ -345,23 +381,10 @@ export function matchesConnectorSearch(
 }
 
 export const allConnectorTypes$ = computed(async (get) => {
-  const connectorListPromise = get(connectors$);
-  const features = get(featureSwitch$);
-  const { connectors } = await connectorListPromise;
-  const connectorMap = new Map(
-    connectors.map((c) => {
-      return [c.type, c];
-    }),
-  );
-
-  const items = CONNECTOR_TYPE_KEYS.filter((type) => {
-    return getAvailableConnectorAuthMethodIds(type, features).length > 0;
-  }).map((type) => {
-    return buildConnectorTypeStatus({
-      type,
-      connector: connectorMap.get(type) ?? null,
-      features,
-    });
+  const { connectors } = await get(connectorCatalogStatus$);
+  const items = connectors.flatMap((connector) => {
+    const item = connectorCatalogStatusItemToConnectorType(connector);
+    return item ? [item] : [];
   });
 
   // Sort connected connectors to the top of the list

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -647,9 +647,9 @@ describe("connectors page", () => {
     const searchInput = await screen.findByPlaceholderText("Find connectors");
     await fill(searchInput, "nonexistent-connector-xyz");
 
-    await waitFor(() => {
-      expect(screen.getByText(/No connectors matching/)).toBeInTheDocument();
-    });
+    expect(
+      await screen.findByText(/No connectors matching/),
+    ).toBeInTheDocument();
   });
 
   it("hides a fully feature-gated connector when its switch is disabled", async () => {
@@ -664,9 +664,9 @@ describe("connectors page", () => {
     const searchInput = await screen.findByPlaceholderText("Find connectors");
     await fill(searchInput, "aws");
 
-    await waitFor(() => {
-      expect(screen.getByText(/No connectors matching/)).toBeInTheDocument();
-    });
+    expect(
+      await screen.findByText(/No connectors matching/),
+    ).toBeInTheDocument();
     expect(screen.queryByLabelText("Connect AWS")).not.toBeInTheDocument();
   });
 
@@ -682,9 +682,9 @@ describe("connectors page", () => {
     const searchInput = await screen.findByPlaceholderText("Find connectors");
     await fill(searchInput, "aws");
 
-    await waitFor(() => {
-      expect(screen.getByText(/No connectors matching/)).toBeInTheDocument();
-    });
+    expect(
+      await screen.findByText(/No connectors matching/),
+    ).toBeInTheDocument();
 
     context.mocks.api(zeroFeatureSwitchesContract.get, ({ respond }) => {
       return respond(200, {
@@ -697,9 +697,7 @@ describe("connectors page", () => {
       context.signal,
     );
 
-    await waitFor(() => {
-      expect(screen.getByLabelText("Connect AWS")).toBeInTheDocument();
-    });
+    expect(await screen.findByLabelText("Connect AWS")).toBeInTheDocument();
   });
 
   it("hides connector access management when its switch is disabled", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -647,9 +647,9 @@ describe("connectors page", () => {
     const searchInput = await screen.findByPlaceholderText("Find connectors");
     await fill(searchInput, "nonexistent-connector-xyz");
 
-    expect(
-      await screen.findByText(/No connectors matching/),
-    ).toBeInTheDocument();
+    await expect(
+      screen.findByText(/No connectors matching/),
+    ).resolves.toBeInTheDocument();
   });
 
   it("hides a fully feature-gated connector when its switch is disabled", async () => {
@@ -664,9 +664,9 @@ describe("connectors page", () => {
     const searchInput = await screen.findByPlaceholderText("Find connectors");
     await fill(searchInput, "aws");
 
-    expect(
-      await screen.findByText(/No connectors matching/),
-    ).toBeInTheDocument();
+    await expect(
+      screen.findByText(/No connectors matching/),
+    ).resolves.toBeInTheDocument();
     expect(screen.queryByLabelText("Connect AWS")).not.toBeInTheDocument();
   });
 
@@ -682,9 +682,9 @@ describe("connectors page", () => {
     const searchInput = await screen.findByPlaceholderText("Find connectors");
     await fill(searchInput, "aws");
 
-    expect(
-      await screen.findByText(/No connectors matching/),
-    ).toBeInTheDocument();
+    await expect(
+      screen.findByText(/No connectors matching/),
+    ).resolves.toBeInTheDocument();
 
     context.mocks.api(zeroFeatureSwitchesContract.get, ({ respond }) => {
       return respond(200, {
@@ -697,7 +697,9 @@ describe("connectors page", () => {
       context.signal,
     );
 
-    expect(await screen.findByLabelText("Connect AWS")).toBeInTheDocument();
+    await expect(
+      screen.findByLabelText("Connect AWS"),
+    ).resolves.toBeInTheDocument();
   });
 
   it("hides connector access management when its switch is disabled", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -8,6 +8,7 @@ import {
   zeroConnectorOauthStartContract,
   zeroConnectorScopeDiffContract,
 } from "@vm0/api-contracts/contracts/zero-connectors";
+import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import { zeroUserPermissionGrantsContract } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import type { TeamComposeItem } from "@vm0/api-contracts/contracts/zero-team";
@@ -29,6 +30,7 @@ import {
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import { search } from "../../../signals/location.ts";
+import { setFeatureSwitch$ } from "../../../signals/external/feature-switch.ts";
 import { detachedNavigateTo$ } from "../../../signals/route.ts";
 import { ROUTES } from "../../../signals/route-paths.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
@@ -666,6 +668,38 @@ describe("connectors page", () => {
       expect(screen.getByText(/No connectors matching/)).toBeInTheDocument();
     });
     expect(screen.queryByLabelText("Connect AWS")).not.toBeInTheDocument();
+  });
+
+  it("refreshes connector catalog status when connector feature switches change", async () => {
+    mockConnectors([]);
+
+    detachedSetupPage({
+      context,
+      path: "/connectors",
+      featureSwitches: { [FeatureSwitchKey.AwsConnector]: false },
+    });
+
+    const searchInput = await screen.findByPlaceholderText("Find connectors");
+    await fill(searchInput, "aws");
+
+    await waitFor(() => {
+      expect(screen.getByText(/No connectors matching/)).toBeInTheDocument();
+    });
+
+    context.mocks.api(zeroFeatureSwitchesContract.get, ({ respond }) => {
+      return respond(200, {
+        switches: { [FeatureSwitchKey.AwsConnector]: true },
+      });
+    });
+    await context.store.set(
+      setFeatureSwitch$,
+      { [FeatureSwitchKey.AwsConnector]: true },
+      context.signal,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Connect AWS")).toBeInTheDocument();
+    });
   });
 
   it("hides connector access management when its switch is disabled", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
@@ -1,3 +1,5 @@
+import { zeroConnectorOauthStartContract } from "@vm0/api-contracts/contracts/zero-connectors";
+import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
 import type { ConnectorType } from "@vm0/connectors/connectors";
 import { screen, waitFor, within } from "@testing-library/react";
@@ -46,6 +48,25 @@ function getButtonByText(text: string): HTMLElement {
   return button;
 }
 
+function mockConnectorOauthStart(): { readonly authWindow: Window } {
+  const authWindow = context.mocks.browser.authWindow();
+  Object.defineProperty(authWindow, "location", {
+    value: { href: "" },
+    configurable: true,
+  });
+
+  context.mocks.api(
+    zeroConnectorOauthStartContract.start,
+    ({ params, respond }) => {
+      return respond(200, {
+        authorizationUrl: `https://oauth.test/${params.type}/authorize`,
+      });
+    },
+  );
+  context.mocks.browser.open(authWindow);
+  return { authWindow };
+}
+
 describe("directed connector authorize page", () => {
   it("authorizes a connected connector and recognizes existing authorization", async () => {
     mockConnectedConnector("gmail");
@@ -92,5 +113,41 @@ describe("directed connector authorize page", () => {
       expect(screen.getByText("Axiom authorized")).toBeInTheDocument();
       expect(screen.getByText("Authorized")).toBeInTheDocument();
     });
+  });
+
+  it("does not authorize the agent when OAuth connection is cancelled", async () => {
+    const { authWindow } = mockConnectorOauthStart();
+    let updateCalls = 0;
+    context.mocks.api(zeroUserConnectorsContract.get, ({ respond }) => {
+      return respond(200, { enabledTypes: [] });
+    });
+    context.mocks.api(
+      zeroUserConnectorsContract.update,
+      ({ body, respond }) => {
+        updateCalls += 1;
+        return respond(200, { enabledTypes: body.enabledTypes });
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/connectors/github/authorize?agentId=${AGENT_ID}`,
+    });
+
+    await screen.findByText("Zero needs GitHub to proceed");
+    click(getButtonByText("Authorize Zero"));
+
+    await waitFor(() => {
+      expect(authWindow.location.href).toBe(
+        "https://oauth.test/github/authorize",
+      );
+    });
+    await screen.findByText("Connecting...");
+
+    authWindow.close();
+
+    await screen.findByText("Authorize Zero");
+    expect(updateCalls).toBe(0);
+    expect(screen.queryByText("GitHub authorized")).not.toBeInTheDocument();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -6652,6 +6652,7 @@ export function ZeroChatComposer({
             if (type && !authorizedSet.has(type)) {
               const authorized = await handleConnectSuccess(type);
               if (!authorized) {
+                setPendingConnectType(null);
                 return;
               }
             }
@@ -6665,6 +6666,7 @@ export function ZeroChatComposer({
           unconnected={unconnectedConnectors}
           pollingType={pollingConnType}
           onClose={() => {
+            setPendingConnectType(null);
             return setShowAddDialog(false);
           }}
           onSelect={(type) => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -6357,14 +6357,27 @@ export function ZeroChatComposer({
 
   const handleConnectSuccess = async (type: ConnectorType) => {
     const label = connectorMap.get(type)?.label ?? type;
-    await tapError(authorizeFn(type, pageSignal), () => {
-      toast.error(`${label} was authorized but could not be saved`, {
-        id: `connector-save-error-${type}`,
-      });
-    });
+    const authorized = await tapError(
+      (async () => {
+        await authorizeFn(type, pageSignal);
+        return true;
+      })(),
+      () => {
+        toast.error(
+          `${label} connected but could not be authorized for ${displayName}`,
+          {
+            id: `connector-save-error-${type}`,
+          },
+        );
+      },
+    );
+    if (authorized !== true) {
+      return false;
+    }
     toast.success(`${label} connected and authorized for ${displayName}`, {
       id: `connector-connected-${type}`,
     });
+    return true;
   };
 
   const handleToggle = async (type: ConnectorType, checked: boolean) => {
@@ -6637,7 +6650,10 @@ export function ZeroChatComposer({
           onSuccess={async () => {
             const type = pendingConnectType ?? selectedConnType;
             if (type && !authorizedSet.has(type)) {
-              await handleConnectSuccess(type);
+              const authorized = await handleConnectSuccess(type);
+              if (!authorized) {
+                return;
+              }
             }
             setPendingConnectType(null);
             setShowAddDialog(false);

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -6356,7 +6356,7 @@ export function ZeroChatComposer({
   });
 
   const handleConnectSuccess = async (type: ConnectorType) => {
-    const label = connectorMap.get(type)!.label;
+    const label = connectorMap.get(type)?.label ?? type;
     await tapError(authorizeFn(type, pageSignal), () => {
       toast.error(`${label} was authorized but could not be saved`, {
         id: `connector-save-error-${type}`,

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -55,9 +55,9 @@ import {
   permissionDialogType$,
   setPermissionDialogType$,
   isStandaloneMode,
-  getAvailableAuthCodeAuthMethod,
-  getOnlyAvailableAuthCodeAuthMethod,
-  getConnectorConnectLaunchMode,
+  getAvailableStatusAuthCodeAuthMethod,
+  getOnlyAvailableStatusAuthCodeAuthMethod,
+  getConnectorStatusConnectLaunchMode,
   connectorCurrentConnectionStatus,
   connectorExpiryCountdownText,
   connectorReconnectReasonTooltipText,
@@ -1006,18 +1006,13 @@ export function ZeroConnectorsPage() {
     if (!ct) {
       return;
     }
-    const launchMode = getConnectorConnectLaunchMode({
-      type,
-      availableAuthMethods: ct.availableAuthMethods,
+    const launchMode = getConnectorStatusConnectLaunchMode(ct, {
       preferModalForConnectorNotice: true,
     });
     if (launchMode === "modal") {
       setSelected(type);
     } else {
-      const authMethod = getOnlyAvailableAuthCodeAuthMethod(
-        type,
-        ct.availableAuthMethods,
-      );
+      const authMethod = getOnlyAvailableStatusAuthCodeAuthMethod(ct);
       if (!authMethod) {
         setSelected(type);
         return;
@@ -1183,13 +1178,14 @@ export function ZeroConnectorsPage() {
             const connector = allConnectors.find((connector) => {
               return connector.type === type;
             });
-            const authMethod = connector?.connector
-              ? getAvailableAuthCodeAuthMethod(
-                  type,
-                  connector.availableAuthMethods,
-                  connector.connector.authMethod,
-                )
-              : null;
+            const connection = connector?.connector ?? null;
+            const authMethod =
+              connector && connection
+                ? getAvailableStatusAuthCodeAuthMethod(
+                    connector,
+                    connection.authMethod,
+                  )
+                : null;
             if (!authMethod) {
               setSelected(type);
               return;

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
@@ -9,7 +9,7 @@ import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import {
   allConnectorTypes$,
   connectConnectorOAuthAuthCode$,
-  getOnlyAvailableAuthCodeAuthMethod,
+  getOnlyAvailableStatusAuthCodeAuthMethod,
   justConnectedTypes$,
   pollingOAuthAuthCodeConnectorType$,
   selectedConnectorType$,
@@ -174,10 +174,7 @@ function DirectedAuthorizeCard() {
   const isLoading = catalogLoading || permissionLoading;
   const canAuthorize = canAuthorizeConnector(item, isConnected);
   const selectedAuthMethod = item
-    ? getOnlyAvailableAuthCodeAuthMethod(
-        connectorType,
-        item.availableAuthMethods,
-      )
+    ? getOnlyAvailableStatusAuthCodeAuthMethod(item)
     : null;
   const showGoogleSecurityWarningNotice =
     !isAuthorized &&
@@ -193,7 +190,15 @@ function DirectedAuthorizeCard() {
     } else if (selectedAuthMethod) {
       detach(
         (async () => {
-          await connect(connectorType, selectedAuthMethod, {}, signal);
+          const connected = await connect(
+            connectorType,
+            selectedAuthMethod,
+            {},
+            signal,
+          );
+          if (!connected) {
+            return;
+          }
           await authorize(connectorType, agentId, signal);
         })(),
         Reason.DomCallback,

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -19,8 +19,8 @@ import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import {
   allConnectorTypes$,
   connectConnectorOAuthAuthCode$,
-  getOnlyAvailableAuthCodeAuthMethod,
-  getConnectorConnectLaunchMode,
+  getOnlyAvailableStatusAuthCodeAuthMethod,
+  getConnectorStatusConnectLaunchMode,
   justConnectedTypes$,
   pollingOAuthAuthCodeConnectorType$,
   pollingOAuthDeviceAuthConnectorType$,
@@ -32,6 +32,7 @@ import {
   clearManualGrantForm$,
   manualGrantFormValuesFor$,
   setManualGrantFormSubmitting$,
+  type ConnectorTypeWithStatus,
 } from "../../signals/zero-page/settings/connectors.ts";
 import { hasTokenInputValue } from "../../signals/zero-page/settings/token-input.ts";
 import {
@@ -115,7 +116,7 @@ function hasProviderDrivenConnectMethod(
 }
 
 function runDirectedConnect(params: {
-  authMethods: readonly ConnectorAuthMethodId[];
+  item: ConnectorTypeWithStatus;
   connectorType: ConnectorType;
   signal: AbortSignal;
   connect: (
@@ -128,13 +129,13 @@ function runDirectedConnect(params: {
   openConnectModal: () => void;
   openManualGrantDialog: () => void;
 }): void {
-  const launchMode = getConnectorConnectLaunchMode({
-    type: params.connectorType,
-    availableAuthMethods: params.authMethods,
-  });
+  const launchMode = getConnectorStatusConnectLaunchMode(params.item);
   if (
     launchMode === "modal" &&
-    hasProviderDrivenConnectMethod(params.connectorType, params.authMethods)
+    hasProviderDrivenConnectMethod(
+      params.connectorType,
+      params.item.availableAuthMethods,
+    )
   ) {
     params.openConnectModal();
     return;
@@ -142,7 +143,7 @@ function runDirectedConnect(params: {
 
   const manualGrantMethod = getOnlyManualGrantMethod(
     params.connectorType,
-    params.authMethods,
+    params.item.availableAuthMethods,
   );
 
   if (launchMode === "modal" && manualGrantMethod) {
@@ -154,10 +155,7 @@ function runDirectedConnect(params: {
     return;
   }
 
-  const authMethod = getOnlyAvailableAuthCodeAuthMethod(
-    params.connectorType,
-    params.authMethods,
-  );
+  const authMethod = getOnlyAvailableStatusAuthCodeAuthMethod(params.item);
   if (!authMethod) {
     params.openConnectModal();
     return;
@@ -506,11 +504,11 @@ function DirectedConnectCard() {
   };
 
   const handleConnect = () => {
-    if (!canConnect) {
+    if (!canConnect || !item) {
       return;
     }
     runDirectedConnect({
-      authMethods,
+      item,
       connectorType,
       signal,
       connect,

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -1144,6 +1144,8 @@ export {
   type PublicConnectorCatalogAuthMethodSummary,
   type PublicConnectorCatalogDetail,
   type PublicConnectorCatalogDetailResponse,
+  type PublicConnectorCatalogConnection,
+  type PublicConnectorCatalogConnectionStatus,
   type PublicConnectorCatalogItem,
   type PublicConnectorCatalogListResponse,
   type PublicConnectorCatalogManualField,
@@ -1151,6 +1153,8 @@ export {
   type PublicConnectorCatalogPermissionDetailResponse,
   type PublicConnectorCatalogPermissionSummary,
   type PublicConnectorCatalogStartOption,
+  type PublicConnectorCatalogStatusItem,
+  type PublicConnectorCatalogStatusResponse,
   type ZeroConnectorCatalogContract,
 } from "./zero-connector-catalog";
 export {

--- a/turbo/packages/api-contracts/src/contracts/zero-connector-catalog.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-connector-catalog.ts
@@ -1,10 +1,7 @@
 import { z } from "zod";
 
 import { authHeadersSchema, initContract } from "./base";
-import {
-  connectorReconnectReasonSchema,
-  connectorResponseConnectionStatusSchema,
-} from "./connector-schemas";
+import { connectorReconnectReasonSchema } from "./connector-schemas";
 import { apiErrorSchema } from "./errors";
 
 const c = initContract();
@@ -90,14 +87,9 @@ const publicConnectorCatalogConnectionStatusSchema = z.enum([
 
 const publicConnectorCatalogConnectionSchema = z.object({
   authMethod: z.string(),
-  externalId: z.string().nullable(),
   externalUsername: z.string().nullable(),
   externalEmail: z.string().nullable(),
-  connectionStatus: connectorResponseConnectionStatusSchema,
   reconnectReason: connectorReconnectReasonSchema.nullable(),
-  tokenExpiresAt: z.string().nullable(),
-  createdAt: z.string(),
-  updatedAt: z.string(),
 });
 
 const publicConnectorCatalogStatusItemSchema =

--- a/turbo/packages/api-contracts/src/contracts/zero-connector-catalog.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-connector-catalog.ts
@@ -1,6 +1,10 @@
 import { z } from "zod";
 
 import { authHeadersSchema, initContract } from "./base";
+import {
+  connectorReconnectReasonSchema,
+  connectorResponseConnectionStatusSchema,
+} from "./connector-schemas";
 import { apiErrorSchema } from "./errors";
 
 const c = initContract();
@@ -77,6 +81,41 @@ const publicConnectorCatalogDetailResponseSchema = z.object({
   connector: publicConnectorCatalogDetailSchema,
 });
 
+const publicConnectorCatalogConnectionStatusSchema = z.enum([
+  "not-connected",
+  "connected",
+  "scope-mismatch",
+  "reconnect-required",
+]);
+
+const publicConnectorCatalogConnectionSchema = z.object({
+  authMethod: z.string(),
+  externalId: z.string().nullable(),
+  externalUsername: z.string().nullable(),
+  externalEmail: z.string().nullable(),
+  connectionStatus: connectorResponseConnectionStatusSchema,
+  reconnectReason: connectorReconnectReasonSchema.nullable(),
+  tokenExpiresAt: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+const publicConnectorCatalogStatusItemSchema =
+  publicConnectorCatalogDetailSchema.extend({
+    connection: publicConnectorCatalogConnectionSchema.nullable(),
+    connected: z.boolean(),
+    connectionStatus: publicConnectorCatalogConnectionStatusSchema,
+    scopeMismatch: z.boolean(),
+    authMethodSupportsRefresh: z.boolean(),
+    tokenExpiresAt: z.string().nullable(),
+    singleAuthCodeAuthMethodId: z.string().nullable(),
+    connectNotice: z.enum(["google-security-warning"]).nullable(),
+  });
+
+const publicConnectorCatalogStatusResponseSchema = z.object({
+  connectors: z.array(publicConnectorCatalogStatusItemSchema),
+});
+
 const publicFirewallPolicyValueSchema = z.enum(["allow", "deny", "ask"]);
 
 const publicConnectorCatalogPermissionSchema = z.object({
@@ -139,6 +178,18 @@ export type PublicConnectorCatalogListResponse = z.infer<
 export type PublicConnectorCatalogDetailResponse = z.infer<
   typeof publicConnectorCatalogDetailResponseSchema
 >;
+export type PublicConnectorCatalogConnectionStatus = z.infer<
+  typeof publicConnectorCatalogConnectionStatusSchema
+>;
+export type PublicConnectorCatalogConnection = z.infer<
+  typeof publicConnectorCatalogConnectionSchema
+>;
+export type PublicConnectorCatalogStatusItem = z.infer<
+  typeof publicConnectorCatalogStatusItemSchema
+>;
+export type PublicConnectorCatalogStatusResponse = z.infer<
+  typeof publicConnectorCatalogStatusResponseSchema
+>;
 export type PublicConnectorCatalogPermissionDetail = z.infer<
   typeof publicConnectorCatalogPermissionDetailSchema
 >;
@@ -157,6 +208,17 @@ export const zeroConnectorCatalogContract = c.router({
       403: apiErrorSchema,
     },
     summary: "List public connector catalog metadata",
+  },
+  status: {
+    method: "GET",
+    path: "/api/zero/connector-catalog/status",
+    headers: authHeadersSchema,
+    responses: {
+      200: publicConnectorCatalogStatusResponseSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+    },
+    summary: "List public connector catalog metadata with connection status",
   },
   get: {
     method: "GET",


### PR DESCRIPTION
## Summary

- add `GET /api/zero/connector-catalog/status` with public catalog metadata joined to current connector status
- move the main platform connectors list to the server-authored status view model for availability, scope mismatch, refreshability, expiry, and connect notice facts
- add API and platform mock coverage for not-connected, connected, scope-mismatch, and reconnect-required connector states without exposing stored scopes or connector ids

Fixes #19549

## Verification

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connector-catalog.test.ts`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-connectors-page.test.tsx`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api check-types`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F api lint`
- `pnpm -F @vm0/app lint`
- pre-commit hook: `pnpm knip --cache`, `pnpm check-types`
