### PR TITLE
feat: surface workflow automations on workflows page

### DIFF
--- a/turbo/apps/platform/src/signals/automation-page/automation-detail-page-setup.ts
+++ b/turbo/apps/platform/src/signals/automation-page/automation-detail-page-setup.ts
@@ -1,10 +1,8 @@
 import { command } from "ccstate";
 import { createElement } from "react";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { ZeroAutomationDetailPage } from "../../views/zero-page/zero-automation-detail-page.tsx";
 import { updatePage$ } from "../react-router.ts";
-import { detachedNavigateTo$, pathParams$ } from "../route.ts";
-import { ROUTES } from "../route-paths.ts";
+import { pathParams$ } from "../route.ts";
 import { reloadChatThreads$ } from "../chat-page/chat-message.ts";
 import { fetchAllOrgAutomations$ } from "../zero-page/zero-automations.ts";
 import { fetchSlackChannels$ } from "../zero-page/slack-channels.ts";
@@ -15,17 +13,10 @@ import {
 import { initAutomationDetailTab$ } from "./automation-detail-tab.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
-import { featureSwitch$ } from "../external/feature-switch.ts";
 
 export const setupAutomationDetailPage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     if (await set(onboardGuard$, signal)) {
-      return;
-    }
-
-    const features = get(featureSwitch$);
-    if (features[FeatureSwitchKey.WorkflowAutomation]) {
-      set(detachedNavigateTo$, ROUTES.automations, { replace: true });
       return;
     }
 

--- a/turbo/apps/platform/src/signals/automation-page/automation-page-setup.ts
+++ b/turbo/apps/platform/src/signals/automation-page/automation-page-setup.ts
@@ -8,21 +8,13 @@ import { reloadChatThreads$ } from "../chat-page/chat-message.ts";
 import { fetchAllOrgAutomations$ } from "../zero-page/zero-automations.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import { initAutomationListTab$ } from "./automation-list-tab.ts";
-import { featureSwitch$ } from "../external/feature-switch.ts";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { reloadWorkflows$ } from "../workflows-page/workflows-signals.ts";
 
 export const setupAutomationsPage$ = command(
-  async ({ get, set }, signal: AbortSignal) => {
+  async ({ set }, signal: AbortSignal) => {
     set(updatePage$, createElement(ZeroAutomationsPage), "sidebar");
     set(updateDocumentTitle$, "Automations");
-    const features = get(featureSwitch$);
-    if (features[FeatureSwitchKey.WorkflowAutomation]) {
-      set(reloadWorkflows$);
-    } else {
-      set(initAutomationListTab$);
-      await set(fetchAllOrgAutomations$, signal);
-    }
+    set(initAutomationListTab$);
+    await set(fetchAllOrgAutomations$, signal);
     signal.throwIfAborted();
     await set(hideAppSkeleton$, signal);
 

--- a/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
+++ b/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
@@ -24,6 +24,7 @@ import {
   detachedNavigateTo$,
   pathParams$,
   replacePathSilently$,
+  replaceSearchParams$,
   searchParams$,
 } from "../route.ts";
 import {
@@ -36,6 +37,7 @@ import { ensureDraft$ } from "../chat-page/create-chat-thread.ts";
 
 type WorkflowDetailActionDialog = "copy" | "delete" | null;
 export type WorkflowDetailTab = "automations" | "instructions" | "info";
+export type WorkflowIndexFilterTab = "automations" | "all";
 export type WorkflowCopyDialogAgent = {
   readonly id: string;
   readonly displayName: string | null;
@@ -196,6 +198,34 @@ export const workflowActionDialog$ = computed((get) => {
 export const workflowCopyDialogState$ = computed((get) => {
   return get(internalWorkflowCopyDialogState$);
 });
+
+const WORKFLOW_INDEX_FILTER_TAB_PARAM = "tab";
+const DEFAULT_WORKFLOW_INDEX_FILTER_TAB: WorkflowIndexFilterTab = "automations";
+
+function isWorkflowIndexFilterTab(tab: string): tab is WorkflowIndexFilterTab {
+  return tab === "automations" || tab === "all";
+}
+
+export const workflowIndexFilterTab$ = computed(
+  (get): WorkflowIndexFilterTab => {
+    const tab = get(searchParams$).get(WORKFLOW_INDEX_FILTER_TAB_PARAM) ?? "";
+    return isWorkflowIndexFilterTab(tab)
+      ? tab
+      : DEFAULT_WORKFLOW_INDEX_FILTER_TAB;
+  },
+);
+
+export const setWorkflowIndexFilterTab$ = command(
+  ({ get, set }, tab: WorkflowIndexFilterTab) => {
+    const params = new URLSearchParams(get(searchParams$));
+    if (tab === DEFAULT_WORKFLOW_INDEX_FILTER_TAB) {
+      params.delete(WORKFLOW_INDEX_FILTER_TAB_PARAM);
+    } else {
+      params.set(WORKFLOW_INDEX_FILTER_TAB_PARAM, tab);
+    }
+    set(replaceSearchParams$, params);
+  },
+);
 
 export const setWorkflowActionDialog$ = command(
   ({ set }, dialog: WorkflowDetailActionDialog) => {

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -489,6 +489,28 @@ function mockWorkflowApis(
   workflows: ZeroWorkflowDetailResponse[],
   onUpdate?: (body: ZeroWorkflowUpdateRequest) => void,
 ): void {
+  const setTriggerEnabled = (
+    triggerId: string,
+    enabled: boolean,
+  ): ZeroWorkflowTriggerSummary | null => {
+    for (const workflow of workflows) {
+      const triggerIndex = workflow.triggers.findIndex((trigger) => {
+        return trigger.id === triggerId;
+      });
+      if (triggerIndex === -1) {
+        continue;
+      }
+      const currentTrigger = workflow.triggers[triggerIndex];
+      if (!currentTrigger) {
+        continue;
+      }
+      const updatedTrigger = { ...currentTrigger, enabled };
+      workflow.triggers[triggerIndex] = updatedTrigger;
+      return updatedTrigger;
+    }
+    return null;
+  };
+
   context.mocks.api(
     zeroWorkflowsCollectionContract.list,
     ({ query, respond }) => {
@@ -511,6 +533,43 @@ function mockWorkflowApis(
     }
     return respond(200, detail);
   });
+  context.mocks.api(
+    zeroWorkflowTriggersContract.listWorkspace,
+    ({ respond }) => {
+      return respond(
+        200,
+        workflows.flatMap((workflow) => {
+          return workflow.triggers.map((trigger) => {
+            return { workflow: summary(workflow), trigger };
+          });
+        }),
+      );
+    },
+  );
+  context.mocks.api(
+    zeroWorkflowTriggersContract.enable,
+    ({ params, respond }) => {
+      const trigger = setTriggerEnabled(params.id, true);
+      if (!trigger) {
+        return respond(404, {
+          error: { code: "NOT_FOUND", message: "missing" },
+        });
+      }
+      return respond(200, trigger);
+    },
+  );
+  context.mocks.api(
+    zeroWorkflowTriggersContract.disable,
+    ({ params, respond }) => {
+      const trigger = setTriggerEnabled(params.id, false);
+      if (!trigger) {
+        return respond(404, {
+          error: { code: "NOT_FOUND", message: "missing" },
+        });
+      }
+      return respond(200, trigger);
+    },
+  );
   context.mocks.api(
     zeroWorkflowsDetailContract.update,
     ({ params, body, respond }) => {
@@ -753,6 +812,46 @@ function menuItemByText(text: RoleTextMatch): HTMLElement {
   return item;
 }
 
+function articleByText(text: string): HTMLElement {
+  const article = screen
+    .getAllByText(text)
+    .map((element) => {
+      return element.closest("article");
+    })
+    .find((candidate): candidate is HTMLElement => {
+      return candidate instanceof HTMLElement;
+    });
+  if (!article) {
+    throw new Error(`${text} card not found`);
+  }
+  return article;
+}
+
+function linkByAriaLabel(label: string): HTMLAnchorElement {
+  const link = queryAllByRoleFast("link").find(
+    (candidate): candidate is HTMLAnchorElement => {
+      return (
+        candidate instanceof HTMLAnchorElement &&
+        candidate.getAttribute("aria-label") === label
+      );
+    },
+  );
+  if (!link) {
+    throw new Error(`${label} link not found`);
+  }
+  return link;
+}
+
+function tabByText(text: string): HTMLElement {
+  const tab = queryAllByRoleFast("tab").find((candidate) => {
+    return textFor(candidate) === text;
+  });
+  if (!tab) {
+    throw new Error(`${text} tab not found`);
+  }
+  return tab;
+}
+
 function selectOptionByLabel(
   label: string,
   option: string | RegExp,
@@ -799,7 +898,8 @@ describe("workflows routes", () => {
     expect(screen.queryByText("Workflow not found.")).not.toBeInTheDocument();
   });
 
-  it("shows all visible workflows on the workspace workflows page", async () => {
+  it("shows triggered workflows first on the workspace workflows page", async () => {
+    context.mocks.data.userPreferences({ timezone: "UTC" });
     mockAgentPageApis();
     mockChatLifecycle(context);
     mockWorkflowApis([
@@ -816,17 +916,56 @@ describe("workflows routes", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText("Sales Research")).toBeInTheDocument();
+      expect(linkByAriaLabel("Open Sales Research")).toBeInTheDocument();
     });
-    expect(screen.getByText("Ops Playbook")).toBeInTheDocument();
-    expect(screen.getByText("Launch Checklist")).toBeInTheDocument();
-    expect(screen.getByText("Support Intake")).toBeInTheDocument();
+    expect(search()).toBe("");
+    expect(tabByText("Automations")).toHaveAttribute("aria-selected", "true");
+    expect(screen.queryByText("Ops Playbook")).not.toBeInTheDocument();
+    expect(screen.queryByText("Launch Checklist")).not.toBeInTheDocument();
+    expect(screen.queryByText("Support Intake")).not.toBeInTheDocument();
 
-    const supportLink = screen.getByText("Support Intake").closest("a");
+    const salesCard = articleByText("Sales Research");
+    expect(within(salesCard).getByText("Schedule")).toBeInTheDocument();
+    expect(
+      within(salesCard).getByText("Every weekday at 9:00 AM"),
+    ).toBeInTheDocument();
+    const switchControl = within(salesCard).getByRole("switch", {
+      name: "Disable Sales Research",
+    });
+    expect(switchControl).toHaveAttribute("aria-checked", "true");
+
+    click(switchControl);
+    await waitFor(() => {
+      expect(
+        within(articleByText("Sales Research")).getByRole("switch", {
+          name: "Enable Sales Research",
+        }),
+      ).toHaveAttribute("aria-checked", "false");
+    });
+
+    click(tabByText("All"));
+    await waitFor(() => {
+      expect(search()).toBe("?tab=all");
+    });
+    expect(tabByText("All")).toHaveAttribute("aria-selected", "true");
+    await waitFor(() => {
+      expect(linkByAriaLabel("Open Ops Playbook")).toBeInTheDocument();
+    });
+    expect(linkByAriaLabel("Open Launch Checklist")).toBeInTheDocument();
+    expect(linkByAriaLabel("Open Support Intake")).toBeInTheDocument();
+
+    const supportLink = linkByAriaLabel("Open Support Intake");
     expect(supportLink).toHaveAttribute(
       "href",
       `/workflows/${OTHER_WORKFLOW_ID}/automations`,
     );
+
+    click(tabByText("Automations"));
+    await waitFor(() => {
+      expect(search()).toBe("");
+    });
+    expect(tabByText("Automations")).toHaveAttribute("aria-selected", "true");
+    expect(screen.queryByText("Ops Playbook")).not.toBeInTheDocument();
 
     expect(CREATE_WORKFLOW_WITH_CHAT_PROMPT).toContain(
       "Help me create a workflow for this agent.",

--- a/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
@@ -1,16 +1,39 @@
 // Workflow list surfaces for agent-scoped tabs and the workspace index page.
-import { useLastLoadable, useSet } from "ccstate-react";
+import {
+  useGet,
+  useLastLoadable,
+  useLastResolved,
+  useSet,
+} from "ccstate-react";
 import type { ZeroWorkflowSummary } from "@vm0/api-contracts/contracts/zero-workflows";
-import { Button } from "@vm0/ui";
+import { Button, Tabs, TabsList, TabsTrigger, cn } from "@vm0/ui";
 
 import { openCreateWorkflowDialog$ } from "../../signals/automation-page/workflow-trigger-automation-dialog.ts";
 import { ROUTES } from "../../signals/route-paths.ts";
-import { allVisibleWorkflows$ } from "../../signals/workflows-page/workflows-signals.ts";
+import {
+  allVisibleWorkflows$,
+  allWorkflowTriggerEntries$,
+  setWorkflowIndexFilterTab$,
+  workflowIndexFilterTab$,
+  type WorkflowIndexFilterTab,
+  type WorkflowTriggerAutomationEntry,
+} from "../../signals/workflows-page/workflows-signals.ts";
+import { userPreferences$ } from "../../signals/zero-page/settings/user-preferences.ts";
 import { Link } from "../router/link.tsx";
-import { CreateWorkflowAutomationDialog } from "../zero-page/workflow-trigger-automations-page.tsx";
+import {
+  CreateWorkflowAutomationDialog,
+  humanReadableTriggerRuleLabel,
+  TriggerListIcon,
+  triggerTypeLabel,
+  WorkflowTriggerEnabledSwitch,
+} from "../zero-page/workflow-trigger-automations-page.tsx";
 import { agentLabel, workflowTitle } from "./workflow-shared.tsx";
 
 type WorkflowGroupKey = "pending" | "public" | "private";
+type WorkflowTriggerEntryMap = ReadonlyMap<
+  string,
+  readonly WorkflowTriggerAutomationEntry[]
+>;
 
 const WORKFLOW_GROUPS: readonly {
   readonly key: WorkflowGroupKey;
@@ -40,6 +63,46 @@ function groupWorkflows(
   );
 }
 
+function workflowTriggerEntryMap(
+  entries: readonly WorkflowTriggerAutomationEntry[],
+): WorkflowTriggerEntryMap {
+  const grouped = new Map<string, WorkflowTriggerAutomationEntry[]>();
+  for (const entry of entries) {
+    const workflowEntries = grouped.get(entry.workflow.id) ?? [];
+    workflowEntries.push(entry);
+    grouped.set(entry.workflow.id, workflowEntries);
+  }
+  return grouped;
+}
+
+function hasWorkflowTriggers(
+  workflow: ZeroWorkflowSummary,
+  triggerEntriesByWorkflowId: WorkflowTriggerEntryMap,
+): boolean {
+  return (triggerEntriesByWorkflowId.get(workflow.id)?.length ?? 0) > 0;
+}
+
+function filterWorkflows(
+  workflows: readonly ZeroWorkflowSummary[],
+  triggerEntriesByWorkflowId: WorkflowTriggerEntryMap,
+  filterTab: WorkflowIndexFilterTab,
+): readonly ZeroWorkflowSummary[] {
+  if (filterTab === "automations") {
+    return workflows.filter((workflow) => {
+      return hasWorkflowTriggers(workflow, triggerEntriesByWorkflowId);
+    });
+  }
+
+  return [...workflows].sort((a, b) => {
+    const aHasTriggers = hasWorkflowTriggers(a, triggerEntriesByWorkflowId);
+    const bHasTriggers = hasWorkflowTriggers(b, triggerEntriesByWorkflowId);
+    if (aHasTriggers !== bHasTriggers) {
+      return aHasTriggers ? -1 : 1;
+    }
+    return 0;
+  });
+}
+
 function pluralizeWorkflow(count: number): string {
   return `${count} workflow${count === 1 ? "" : "s"}`;
 }
@@ -61,12 +124,20 @@ export function WorkflowListPanel({
   loading,
   showAgentColumn,
   emptyDescription,
+  triggerEntriesByWorkflowId,
+  displayTimezone = new Intl.DateTimeFormat().resolvedOptions().timeZone,
 }: {
   readonly workflows: readonly ZeroWorkflowSummary[] | null;
   readonly loading: boolean;
   readonly showAgentColumn: boolean;
   readonly emptyDescription: string;
+  readonly triggerEntriesByWorkflowId?: WorkflowTriggerEntryMap;
+  readonly displayTimezone?: string;
 }) {
+  const resolvedTriggerEntriesByWorkflowId =
+    triggerEntriesByWorkflowId ??
+    new Map<string, readonly WorkflowTriggerAutomationEntry[]>();
+
   return (
     <section className="min-h-[520px]">
       {loading ? (
@@ -75,6 +146,8 @@ export function WorkflowListPanel({
         <WorkflowGroups
           workflows={workflows}
           showAgentColumn={showAgentColumn}
+          triggerEntriesByWorkflowId={resolvedTriggerEntriesByWorkflowId}
+          displayTimezone={displayTimezone}
         />
       ) : (
         <div className="zero-card flex min-h-[20rem] flex-col items-center justify-center px-6 text-center">
@@ -91,9 +164,13 @@ export function WorkflowListPanel({
 function WorkflowGroups({
   workflows,
   showAgentColumn,
+  triggerEntriesByWorkflowId,
+  displayTimezone,
 }: {
   readonly workflows: readonly ZeroWorkflowSummary[];
   readonly showAgentColumn: boolean;
+  readonly triggerEntriesByWorkflowId: WorkflowTriggerEntryMap;
+  readonly displayTimezone: string;
 }) {
   const groups = groupWorkflows(workflows);
 
@@ -122,6 +199,10 @@ function WorkflowGroups({
                     key={workflow.id}
                     workflow={workflow}
                     showAgentColumn={showAgentColumn}
+                    triggerEntries={
+                      triggerEntriesByWorkflowId.get(workflow.id) ?? []
+                    }
+                    displayTimezone={displayTimezone}
                   />
                 );
               })}
@@ -172,43 +253,160 @@ function WorkflowSlug({ name }: { readonly name: string }) {
 function WorkflowIndexCard({
   workflow,
   showAgentColumn,
+  triggerEntries,
+  displayTimezone,
 }: {
   readonly workflow: ZeroWorkflowSummary;
   readonly showAgentColumn: boolean;
+  readonly triggerEntries: readonly WorkflowTriggerAutomationEntry[];
+  readonly displayTimezone: string;
 }) {
+  const title = workflowTitle(workflow);
+
   return (
-    <Link
-      pathname={ROUTES.workflowDetailAutomations}
-      options={{
-        pathParams: {
-          workflowId: workflow.id,
-        },
-      }}
-      className="zero-card block px-5 py-4 text-left text-foreground no-underline transition-colors hover:bg-gray-50"
+    <article
+      className={cn(
+        "zero-card relative px-5 py-4 text-left text-foreground transition-colors hover:bg-gray-50",
+        triggerEntries.some((entry) => {
+          return !entry.trigger.enabled;
+        }) && "opacity-90",
+      )}
     >
-      <div className="flex items-start justify-between gap-4">
+      <Link
+        pathname={ROUTES.workflowDetailAutomations}
+        options={{
+          pathParams: {
+            workflowId: workflow.id,
+          },
+        }}
+        aria-label={`Open ${title}`}
+        className="absolute inset-0 z-0 rounded-[inherit] focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring"
+      >
+        <span className="sr-only">{title}</span>
+      </Link>
+      <div className="pointer-events-none relative z-10 flex items-start justify-between gap-4">
         <div className="min-w-0 flex flex-wrap items-center gap-x-2 gap-y-1">
           <span className="min-w-0 truncate text-sm font-medium text-foreground">
-            {workflowTitle(workflow)}
+            {title}
           </span>
           <WorkflowSlug name={workflow.name} />
           {showAgentColumn && <WorkflowSlug name={agentLabel(workflow)} />}
         </div>
         <WorkflowOwner workflow={workflow} />
       </div>
-      <div className="mt-3 text-sm leading-6 text-muted-foreground">
+      <div className="pointer-events-none relative z-10 mt-3 text-sm leading-6 text-muted-foreground">
         {workflow.description ?? workflow.name}
       </div>
-    </Link>
+      <WorkflowCardTriggerFooter
+        entries={triggerEntries}
+        displayTimezone={displayTimezone}
+      />
+    </article>
+  );
+}
+
+function WorkflowCardTriggerFooter({
+  entries,
+  displayTimezone,
+}: {
+  readonly entries: readonly WorkflowTriggerAutomationEntry[];
+  readonly displayTimezone: string;
+}) {
+  const [primaryEntry] = entries;
+  if (!primaryEntry) {
+    return null;
+  }
+  const remainingCount = entries.length - 1;
+  const trigger = primaryEntry.trigger;
+
+  return (
+    <div className="pointer-events-none relative z-10 mt-4 border-t border-border/60 pt-3">
+      <div
+        className={cn(
+          "flex min-w-0 items-center gap-3",
+          !trigger.enabled && "opacity-75",
+        )}
+      >
+        <TriggerListIcon trigger={trigger} />
+        <div className="flex min-w-0 flex-1 items-center gap-1.5 text-sm leading-5 text-muted-foreground">
+          <span className="shrink-0">{triggerTypeLabel(trigger)}</span>
+          <span className="shrink-0 select-none text-muted-foreground/50">
+            ·
+          </span>
+          <span className="min-w-0 truncate font-medium text-foreground/85">
+            {humanReadableTriggerRuleLabel(trigger, displayTimezone)}
+          </span>
+          {remainingCount > 0 ? (
+            <span className="shrink-0 text-xs text-muted-foreground">
+              +{remainingCount} more
+            </span>
+          ) : null}
+        </div>
+        <div className="pointer-events-auto relative z-20 shrink-0">
+          <WorkflowTriggerEnabledSwitch entry={primaryEntry} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function WorkflowFilterTabs({
+  value,
+  onValueChange,
+}: {
+  readonly value: WorkflowIndexFilterTab;
+  readonly onValueChange: (value: WorkflowIndexFilterTab) => void;
+}) {
+  return (
+    <Tabs
+      value={value}
+      onValueChange={(nextValue) => {
+        if (nextValue === "automations" || nextValue === "all") {
+          onValueChange(nextValue);
+        }
+      }}
+    >
+      <TabsList className="zero-tabs h-9 gap-1 px-1 py-1">
+        <TabsTrigger
+          value="automations"
+          className="px-3 text-sm data-[state=active]:bg-background"
+        >
+          Automations
+        </TabsTrigger>
+        <TabsTrigger
+          value="all"
+          className="px-3 text-sm data-[state=active]:bg-background"
+        >
+          All
+        </TabsTrigger>
+      </TabsList>
+    </Tabs>
   );
 }
 
 export function WorkflowsPage() {
+  const filterTab = useGet(workflowIndexFilterTab$);
+  const setFilterTab = useSet(setWorkflowIndexFilterTab$);
   const workflowsLoadable = useLastLoadable(allVisibleWorkflows$);
+  const triggerEntriesLoadable = useLastLoadable(allWorkflowTriggerEntries$);
+  const preferences = useLastResolved(userPreferences$);
   const openCreateWorkflowDialog = useSet(openCreateWorkflowDialog$);
-  const loading = workflowsLoadable.state === "loading";
+  const loading =
+    workflowsLoadable.state === "loading" ||
+    triggerEntriesLoadable.state === "loading";
   const workflows =
     workflowsLoadable.state === "hasData" ? workflowsLoadable.data : null;
+  const triggerEntries =
+    triggerEntriesLoadable.state === "hasData"
+      ? triggerEntriesLoadable.data
+      : [];
+  const triggerEntriesByWorkflowId = workflowTriggerEntryMap(triggerEntries);
+  const displayTimezone =
+    preferences?.timezone ??
+    new Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const filteredWorkflows = workflows
+    ? filterWorkflows(workflows, triggerEntriesByWorkflowId, filterTab)
+    : null;
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -236,12 +434,19 @@ export function WorkflowsPage() {
       </header>
 
       <main className="flex-1 overflow-auto px-4 pb-8 pt-3 sm:px-6">
-        <div className="mx-auto max-w-[900px]">
+        <div className="mx-auto flex max-w-[900px] flex-col gap-3">
+          <WorkflowFilterTabs value={filterTab} onValueChange={setFilterTab} />
           <WorkflowListPanel
-            workflows={workflows}
+            workflows={filteredWorkflows}
             loading={loading}
             showAgentColumn
-            emptyDescription="Create a workflow from chat or save one from a useful run."
+            emptyDescription={
+              filterTab === "automations"
+                ? "Add a trigger to a workflow and it will show up here."
+                : "Create a workflow from chat or save one from a useful run."
+            }
+            triggerEntriesByWorkflowId={triggerEntriesByWorkflowId}
+            displayTimezone={displayTimezone}
           />
         </div>
       </main>

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-automations-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-automations-page.test.tsx
@@ -4,14 +4,6 @@ import {
   automationsByRefContract,
   automationsMainContract,
 } from "@vm0/api-contracts/contracts/automations";
-import {
-  zeroWorkflowsCollectionContract,
-  zeroWorkflowsDetailContract,
-  zeroWorkflowTriggersContract,
-  type ZeroWorkflowDetailResponse,
-  type ZeroWorkflowSummary,
-  type ZeroWorkflowTriggerSummary,
-} from "@vm0/api-contracts/contracts/zero-workflows";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { describe, expect, it } from "vitest";
 
@@ -24,28 +16,12 @@ import {
 import { mockNow } from "../../../__tests__/time.ts";
 import { toMockAutomationResponse } from "../../../mocks/handlers/api-automations.ts";
 import { createMockAutomationView } from "../../../mocks/handlers/automations-store.ts";
-import { pathname, search } from "../../../signals/location.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 
 const context = testContext();
 
 const zeroAgentId = "c0000000-0000-4000-a000-000000000001";
 const researchAgentId = "a0000000-0000-4000-a000-000000000301";
-const workflowId = "d0000000-0000-4000-a000-000000000301";
-const supportWorkflowId = "d0000000-0000-4000-a000-000000000302";
-
-type ScheduleWorkflowTrigger = Extract<
-  ZeroWorkflowTriggerSummary,
-  { kind: "schedule" }
->;
-type GmailWorkflowTrigger = Extract<
-  ZeroWorkflowTriggerSummary,
-  { kind: "event"; eventType: "gmail-new-message" }
->;
-type WebhookWorkflowTrigger = Extract<
-  ZeroWorkflowTriggerSummary,
-  { kind: "event"; eventType: "webhook-received" }
->;
 
 function createAgent(id: string, displayName: string): TeamComposeItem {
   return {
@@ -59,231 +35,6 @@ function createAgent(id: string, displayName: string): TeamComposeItem {
     headVersionId: "version_1",
     updatedAt: "2026-03-10T00:00:00Z",
   };
-}
-
-function workflowSummary(
-  workflow: ZeroWorkflowDetailResponse,
-): ZeroWorkflowSummary {
-  return {
-    id: workflow.id,
-    agentId: workflow.agentId,
-    agentName: workflow.agentName,
-    agentDisplayName: workflow.agentDisplayName,
-    name: workflow.name,
-    displayName: workflow.displayName,
-    description: workflow.description,
-    visibility: workflow.visibility,
-    requestToPublish: workflow.requestToPublish,
-    ownerUserId: workflow.ownerUserId,
-    ownerUserDisplayName: "Test User",
-    ownerUserImageUrl: null,
-    canManage: workflow.canManage,
-  };
-}
-
-async function findComposerEditor(): Promise<HTMLElement> {
-  return await waitFor(() => {
-    const editor = document.querySelector(
-      '.zero-composer [contenteditable="true"]',
-    );
-    if (!(editor instanceof HTMLElement)) {
-      throw new Error("Composer editor not found");
-    }
-    return editor;
-  });
-}
-
-async function expectComposerText(text: string): Promise<void> {
-  const editor = await findComposerEditor();
-  await waitFor(() => {
-    expect(editor.textContent).toContain(text);
-  });
-}
-
-function intervalWorkflowTrigger(): ScheduleWorkflowTrigger {
-  return {
-    id: "e0000000-0000-4000-a000-000000000301",
-    kind: "schedule",
-    schedule: { type: "loop", intervalSeconds: 900 },
-    scheduleSummary: "Every 15 minutes",
-    ownerUserId: "test-user-123",
-    enabled: true,
-    chatThreadId: "thread-interval",
-    nextRunAt: "2026-06-28T10:15:00.000Z",
-    lastRunAt: "2026-06-28T10:00:00.000Z",
-  };
-}
-
-function gmailWorkflowTrigger(): GmailWorkflowTrigger {
-  return {
-    id: "e0000000-0000-4000-a000-000000000302",
-    kind: "event",
-    eventType: "gmail-new-message",
-    eventConfig: {
-      provider: "gmail",
-      event: "new_message",
-      match: {
-        from: { contains: "@acme.com" },
-      },
-    },
-    schedule: null,
-    scheduleSummary: null,
-    ownerUserId: "test-user-123",
-    enabled: true,
-    chatThreadId: "thread-gmail",
-    nextRunAt: null,
-    lastRunAt: null,
-  };
-}
-
-function webhookWorkflowTrigger(): WebhookWorkflowTrigger {
-  return {
-    id: "e0000000-0000-4000-a000-000000000303",
-    kind: "event",
-    eventType: "webhook-received",
-    eventConfig: {
-      provider: "webhook",
-      event: "received",
-      auth: { mode: "hmac-sha256" },
-    },
-    schedule: null,
-    scheduleSummary: null,
-    ownerUserId: "test-user-123",
-    enabled: false,
-    chatThreadId: "thread-webhook",
-    nextRunAt: null,
-    lastRunAt: "2026-06-27T10:00:00.000Z",
-    webhookUrl: "https://api.vm0.test/api/webhooks/workflow-triggers/whk_test",
-    secretLastFour: "abcd",
-    lastReceivedAt: "2026-06-27T10:00:00.000Z",
-  };
-}
-
-function workflowDetail(
-  overrides?: Partial<ZeroWorkflowDetailResponse>,
-): ZeroWorkflowDetailResponse {
-  return {
-    id: workflowId,
-    agentId: zeroAgentId,
-    agentName: "zero",
-    agentDisplayName: "Zero",
-    name: "ops-brief",
-    displayName: "Ops brief",
-    description: "Keeps the team updated",
-    visibility: "public",
-    requestToPublish: false,
-    ownerUserId: "test-user-123",
-    canManage: true,
-    createdByUserId: "test-user-123",
-    updatedByUserId: "test-user-123",
-    createdAt: "2026-06-28T00:00:00.000Z",
-    updatedAt: "2026-06-28T00:00:00.000Z",
-    instruction: "Send the operations brief.",
-    files: [],
-    fileContents: [],
-    triggers: [intervalWorkflowTrigger(), gmailWorkflowTrigger()],
-    ...overrides,
-  };
-}
-
-function supportWorkflowDetail(): ZeroWorkflowDetailResponse {
-  return workflowDetail({
-    id: supportWorkflowId,
-    agentId: researchAgentId,
-    agentName: "research",
-    agentDisplayName: "Research Agent",
-    name: "support-intake",
-    displayName: "Support intake",
-    triggers: [webhookWorkflowTrigger()],
-  });
-}
-
-function mockWorkflowTriggerStory(): void {
-  let workflows = [workflowDetail(), supportWorkflowDetail()];
-  const setTriggerEnabled = (
-    triggerId: string,
-    enabled: boolean,
-  ): ZeroWorkflowTriggerSummary | null => {
-    let updated: ZeroWorkflowTriggerSummary | null = null;
-    workflows = workflows.map((workflow) => {
-      return {
-        ...workflow,
-        triggers: workflow.triggers.map((trigger) => {
-          if (trigger.id !== triggerId) {
-            return trigger;
-          }
-          const next = { ...trigger, enabled };
-          updated = next;
-          return next;
-        }),
-      };
-    });
-    return updated;
-  };
-  context.mocks.data.team([
-    createAgent(zeroAgentId, "Zero"),
-    createAgent(researchAgentId, "Research Agent"),
-  ]);
-  context.mocks.data.userPreferences({ timezone: "UTC" });
-  context.mocks.api(
-    zeroWorkflowsCollectionContract.list,
-    ({ query, respond }) => {
-      const visible = query.agentId
-        ? workflows.filter((workflow) => {
-            return workflow.agentId === query.agentId;
-          })
-        : workflows;
-      return respond(200, visible.map(workflowSummary));
-    },
-  );
-  context.mocks.api(zeroWorkflowsDetailContract.get, ({ params, respond }) => {
-    const detail = workflows.find((workflow) => {
-      return workflow.id === params.workflowId;
-    });
-    if (!detail) {
-      return respond(404, {
-        error: { code: "NOT_FOUND", message: "missing" },
-      });
-    }
-    return respond(200, detail);
-  });
-  context.mocks.api(
-    zeroWorkflowTriggersContract.listWorkspace,
-    ({ respond }) => {
-      return respond(
-        200,
-        workflows.flatMap((workflow) => {
-          return workflow.triggers.map((trigger) => {
-            return { workflow: workflowSummary(workflow), trigger };
-          });
-        }),
-      );
-    },
-  );
-  context.mocks.api(
-    zeroWorkflowTriggersContract.enable,
-    ({ params, respond }) => {
-      const trigger = setTriggerEnabled(params.id, true);
-      if (!trigger) {
-        return respond(404, {
-          error: { code: "NOT_FOUND", message: "missing" },
-        });
-      }
-      return respond(200, trigger);
-    },
-  );
-  context.mocks.api(
-    zeroWorkflowTriggersContract.disable,
-    ({ params, respond }) => {
-      const trigger = setTriggerEnabled(params.id, false);
-      if (!trigger) {
-        return respond(404, {
-          error: { code: "NOT_FOUND", message: "missing" },
-        });
-      }
-      return respond(200, trigger);
-    },
-  );
 }
 
 function buttonByText(
@@ -317,27 +68,6 @@ function tabByText(text: string): HTMLElement {
     throw new Error(`${text} tab not found`);
   }
   return tab;
-}
-
-function linkByNameAndPath(name: string, path: string): HTMLAnchorElement {
-  for (const candidate of queryAllByRoleFast("link")) {
-    if (
-      candidate instanceof HTMLAnchorElement &&
-      candidate.textContent?.replace(/\s+/g, " ").trim() === name &&
-      new URL(candidate.href).pathname === path
-    ) {
-      return candidate;
-    }
-  }
-  throw new Error(`${name} link to ${path} not found`);
-}
-
-function articleByText(text: string): HTMLElement {
-  const article = screen.getByText(text).closest("article");
-  if (!article) {
-    throw new Error(`${text} card not found`);
-  }
-  return article;
 }
 
 function selectOptionByLabel(
@@ -500,95 +230,8 @@ async function openCreateDialog(): Promise<HTMLElement> {
 }
 
 describe("zero automations page", () => {
-  it("shows workflow triggers when the workflow-trigger switch is enabled", async () => {
-    mockWorkflowTriggerStory();
-
-    detachedSetupPage({
-      context,
-      path: "/automations",
-      featureSwitches: {
-        [FeatureSwitchKey.WorkflowAutomation]: true,
-      },
-    });
-
-    await waitFor(() => {
-      expect(
-        screen.getByRole("heading", { name: "Automations" }),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText("Workflow triggers running across your workspace."),
-      ).toBeInTheDocument();
-    });
-
-    expect(screen.queryByText("Calendar")).not.toBeInTheDocument();
-    expect(screen.queryByText("List")).not.toBeInTheDocument();
-    expect(screen.queryByText("Run now")).not.toBeInTheDocument();
-
-    const opsLink = linkByNameAndPath(
-      "Ops brief",
-      `/workflows/${workflowId}/automations`,
-    );
-    const opsCard = articleByText("Every 15 minutes");
-    expect(opsLink.closest("article")).toBe(opsCard);
-    expect(within(opsCard).getByText("Zero")).toBeInTheDocument();
-    expect(within(opsCard).getByText("Schedule")).toBeInTheDocument();
-    expect(within(opsCard).getByText("Every 15 minutes")).toBeInTheDocument();
-    expect(
-      within(opsCard).getByRole("switch", { name: "Disable Ops brief" }),
-    ).toHaveAttribute("aria-checked", "true");
-
-    const gmailRule = screen.getByText(
-      'When Gmail message matches from contains "@acme.com"',
-    );
-    const gmailCard = gmailRule.closest("article");
-    if (!gmailCard) {
-      throw new Error("Ops brief Gmail card not found");
-    }
-    expect(within(gmailCard).getByText("Gmail")).toBeInTheDocument();
-
-    linkByNameAndPath(
-      "Support intake",
-      `/workflows/${supportWorkflowId}/automations`,
-    );
-    expect(screen.getByText("Webhook")).toBeInTheDocument();
-    expect(
-      screen.getByText("When an inbound webhook is received"),
-    ).toBeInTheDocument();
-
-    click(within(opsCard).getByRole("switch", { name: "Disable Ops brief" }));
-    await waitFor(() => {
-      const updatedOpsCard = articleByText("Every 15 minutes");
-      expect(
-        within(updatedOpsCard).getByRole("switch", {
-          name: "Enable Ops brief",
-        }),
-      ).toHaveAttribute("aria-checked", "false");
-    });
-  });
-
-  it("redirects workflow-trigger automation detail paths back to the list", async () => {
-    mockWorkflowTriggerStory();
-
-    detachedSetupPage({
-      context,
-      path: `/automations/${intervalWorkflowTrigger().id}`,
-      featureSwitches: {
-        [FeatureSwitchKey.WorkflowAutomation]: true,
-      },
-    });
-
-    await waitFor(() => {
-      expect(pathname()).toBe("/automations");
-    });
-    expect(
-      screen.getByRole("heading", { name: "Automations" }),
-    ).toBeInTheDocument();
-  });
-
-  it("starts automation creation in chat after choosing an agent", async () => {
-    const prompt =
-      "Help me create a workflow automation for this agent. Use the workflow-setup skill, then ask me for the desired outcome, automation, and action before creating the workflow and automation.";
-    mockWorkflowTriggerStory();
+  it("keeps the legacy automations page when workflow automation is enabled", async () => {
+    mockAutomationsPageStory();
 
     detachedSetupPage({
       context,
@@ -604,57 +247,23 @@ describe("zero automations page", () => {
       ).toBeInTheDocument();
     });
 
-    click(buttonByText("Add automation"));
-    const dialog = await screen.findByRole("dialog");
     expect(
-      within(dialog).getByText(
-        "Choose a workflow to automate, or create one in chat.",
-      ),
-    ).toBeInTheDocument();
-    expect(within(dialog).getByText("Create in chat")).toBeInTheDocument();
+      screen.queryByText("Workflow triggers running across your workspace."),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Calendar")).toBeInTheDocument();
+    expect(screen.getByText("List")).toBeInTheDocument();
+    expect(screen.getAllByText("Morning brief")[0]).toBeInTheDocument();
     expect(
-      within(dialog).getByText(
-        "Start from a conversation when no workflow fits yet.",
-      ),
-    ).toBeInTheDocument();
-    expect(within(dialog).queryByText("Create with Zero")).toBeNull();
-    expect(within(dialog).queryByText("Choose")).toBeNull();
-    expect(within(dialog).getByText("Ops brief")).toBeInTheDocument();
-    click(within(dialog).getByText("Create in chat"));
-
-    await waitFor(() => {
-      expect(
-        screen.getByRole("dialog", { name: "Create Automation" }),
-      ).toBeInTheDocument();
-    });
-    const createDialog = screen.getByRole("dialog", {
-      name: "Create Automation",
-    });
-    expect(
-      within(createDialog).getByText("Choose the agent for this automation"),
-    ).toBeInTheDocument();
-    expect(within(createDialog).getByText("Zero")).toBeInTheDocument();
-    expect(within(createDialog).queryByText("Manual run")).toBeNull();
-    expect(
-      within(createDialog).queryByText("What do you want me to do?"),
-    ).toBeNull();
-
-    click(buttonByText("Zero", createDialog));
-
-    await waitFor(() => {
-      expect(pathname()).toBe(`/agents/${zeroAgentId}/chat`);
-    });
-    await expectComposerText(prompt);
-    expect(prompt).not.toContain("when an email arrives");
-    expect(prompt).not.toContain("trigger");
+      screen.queryByText("When an inbound webhook is received"),
+    ).not.toBeInTheDocument();
   });
 
-  it("opens the selected workflow when adding an automation to an existing workflow", async () => {
-    mockWorkflowTriggerStory();
+  it("opens legacy automation detail paths when workflow automation is enabled", async () => {
+    mockAutomationsPageStory();
 
     detachedSetupPage({
       context,
-      path: "/automations",
+      path: "/automations/f0000001-0000-4000-a000-000000000301",
       featureSwitches: {
         [FeatureSwitchKey.WorkflowAutomation]: true,
       },
@@ -662,18 +271,13 @@ describe("zero automations page", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole("heading", { name: "Automations" }),
+        screen.getByRole("heading", { name: "Morning brief" }),
       ).toBeInTheDocument();
     });
-
-    click(buttonByText("Add automation"));
-    const dialog = await screen.findByRole("dialog");
-    click(within(dialog).getByText("Ops brief"));
-
-    await waitFor(() => {
-      expect(pathname()).toBe(`/workflows/${workflowId}/automations`);
-      expect(search()).toBe("");
-    });
+    expect(
+      screen.queryByText("Workflow triggers running across your workspace."),
+    ).not.toBeInTheDocument();
+    expect(tabByText("Settings")).toHaveAttribute("aria-selected", "true");
   });
 
   it("shows scheduled work in the calendar", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -1523,6 +1523,7 @@ describe("zero sidebar", () => {
 
     expect(within(nav).getByText("Agents")).toBeInTheDocument();
     expect(within(nav).getByText("Workflows")).toBeInTheDocument();
+    expect(within(nav).queryByText("Automations")).not.toBeInTheDocument();
   });
 
   it("hides workflows in the sidebar manage navigation when disabled", async () => {
@@ -1541,6 +1542,7 @@ describe("zero sidebar", () => {
     });
 
     expect(within(nav).getByText("Agents")).toBeInTheDocument();
+    expect(within(nav).getByText("Automations")).toBeInTheDocument();
     expect(within(nav).queryByText("Workflows")).not.toBeInTheDocument();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx
@@ -196,7 +196,7 @@ function quote(value: string): string {
   return `"${value}"`;
 }
 
-function humanReadableTriggerRuleLabel(
+export function humanReadableTriggerRuleLabel(
   trigger: ZeroWorkflowTriggerSummary,
   displayTimezone: string,
 ): string {
@@ -243,7 +243,7 @@ function humanReadableTriggerRuleLabel(
   return gmailTriggerTitle(trigger);
 }
 
-function triggerTypeLabel(trigger: ZeroWorkflowTriggerSummary): string {
+export function triggerTypeLabel(trigger: ZeroWorkflowTriggerSummary): string {
   if (trigger.kind === "schedule") {
     return "Schedule";
   }
@@ -483,7 +483,7 @@ function WorkflowAgentAvatar({
   );
 }
 
-function TriggerListIcon({
+export function TriggerListIcon({
   trigger,
 }: {
   readonly trigger: ZeroWorkflowTriggerSummary;
@@ -529,7 +529,7 @@ function TriggerListIcon({
   );
 }
 
-function WorkflowTriggerEnabledSwitch({
+export function WorkflowTriggerEnabledSwitch({
   entry,
 }: {
   readonly entry: WorkflowTriggerAutomationEntry;

--- a/turbo/apps/platform/src/views/zero-page/zero-automations-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-automations-page.tsx
@@ -3,7 +3,6 @@
 import { useGet, useSet, useLastLoadable } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { pageSignal$ } from "../../signals/page-signal.ts";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { IconList, IconLayoutGrid, IconPlus } from "@tabler/icons-react";
 import {
   Tabs,
@@ -70,8 +69,6 @@ import {
   automationListTab$,
   setAutomationListTab$,
 } from "../../signals/automation-page/automation-list-tab.ts";
-import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
-import { WorkflowTriggerAutomationsPage } from "./workflow-trigger-automations-page.tsx";
 
 export type { CombinedEntry } from "./automation-utils";
 
@@ -523,10 +520,6 @@ const AUTOMATIONS_LABELS = {
 // ---------------------------------------------------------------------------
 
 export function ZeroAutomationsPage() {
-  const features = useGet(featureSwitch$);
-  if (features[FeatureSwitchKey.WorkflowAutomation]) {
-    return <WorkflowTriggerAutomationsPage />;
-  }
   return <LegacyZeroAutomationsPage />;
 }
 

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -62,6 +62,7 @@ interface ManageNavItem {
   readonly label: string;
   readonly icon: NavIcon;
   readonly featureGate?: FeatureSwitchKey;
+  readonly hideWhenFeatureEnabled?: FeatureSwitchKey;
 }
 
 const MANAGE_NAV: readonly ManageNavItem[] = [
@@ -85,6 +86,7 @@ const MANAGE_NAV: readonly ManageNavItem[] = [
     pathname: "/automations",
     label: "Automations",
     icon: IconCalendar as NavIcon,
+    hideWhenFeatureEnabled: FeatureSwitchKey.WorkflowAutomation,
   },
   {
     id: "workflows",
@@ -145,6 +147,12 @@ function useResolvedNavItems() {
   const features = useLastResolved(featureSwitch$);
   const defaultDisplayName = useLastResolved(defaultAgentName$) ?? "Zero";
   const manageNav = MANAGE_NAV.filter((item) => {
+    if (
+      item.hideWhenFeatureEnabled &&
+      features?.[item.hideWhenFeatureEnabled]
+    ) {
+      return false;
+    }
     if (item.featureGate && !features?.[item.featureGate]) {
       return false;
     }


### PR DESCRIPTION
## Summary
- hide the legacy Automations sidebar entry when workflow automation is enabled
- keep /automations on the legacy automations page instead of rendering workflow trigger automations
- add Automations / All URL-backed filtering to /workflows and show trigger details with pause/resume controls on workflow cards

## Verification
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app exec vitest run src/views/workflows-page/__tests__/workflows-page.test.tsx src/views/zero-page/__tests__/zero-automations-page.test.tsx src/views/zero-page/__tests__/zero-sidebar.test.tsx
- git diff --check
