### PR TITLE
perf(runner): attribute session history fallback

### DIFF
--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -31,7 +31,9 @@ use crate::ids::RunId;
 use crate::paths::diagnostic_session_fingerprint;
 use crate::provider::{ClaimedJob, JobCandidate};
 use crate::resource_budget::{BudgetLease, ResourceBudget};
-use crate::restored_session_identity::RestoredSessionIdentity;
+use crate::restored_session_identity::{
+    RestoredSessionIdentity, RestoredSessionIdentityMismatchReason,
+};
 use crate::run_cancellation::{RunCancellationHandle, SharedRunCancellationMap};
 use crate::status::{RunnerMode, StatusTracker};
 use crate::types::{ExecutionContext, SandboxReuseResult};
@@ -248,16 +250,24 @@ fn build_session_history_restore_plan(
                     }
                     Some(restored_identity) if restored_identity == &requested_identity => {
                         if restored_identity.has_final_metadata_verification() {
-                            Some(SessionHistoryRestoreFallback::IdentityMismatch)
+                            Some(SessionHistoryRestoreFallback::IdentityMismatch(
+                                restored_identity.mismatch_reason_for_request(&requested_identity),
+                            ))
                         } else {
                             Some(SessionHistoryRestoreFallback::UnverifiedIdleIdentity)
                         }
                     }
-                    Some(_) => Some(SessionHistoryRestoreFallback::IdentityMismatch),
+                    Some(restored_identity) => {
+                        Some(SessionHistoryRestoreFallback::IdentityMismatch(
+                            restored_identity.mismatch_reason_for_request(&requested_identity),
+                        ))
+                    }
                     None => Some(SessionHistoryRestoreFallback::MissingIdleIdentity),
                 }
             } else {
-                Some(SessionHistoryRestoreFallback::IdentityMismatch)
+                Some(SessionHistoryRestoreFallback::IdentityMismatch(Some(
+                    RestoredSessionIdentityMismatchReason::MissingRequestedIdentity,
+                )))
             }
         }
         SandboxReuseResult::NoSessionId
@@ -602,6 +612,7 @@ mod tests {
     use crate::network_log_drain::NetworkLogDrainCoordinator;
     use crate::provider::CompletionAuth;
     use crate::resource_budget::ResourceBudget;
+    use crate::restored_session_identity::RestoredSessionFramework;
     use crate::status::IdleVm;
     use crate::test_fixtures::execution_context_for_test;
     use crate::types::{ResumeSession, ResumeSessionHistory, ResumeSessionHistoryRef};
@@ -1061,7 +1072,9 @@ mod tests {
             SessionHistoryRestorePlan::Prestarted { fallback, .. } => {
                 assert_eq!(
                     fallback,
-                    Some(SessionHistoryRestoreFallback::IdentityMismatch)
+                    Some(SessionHistoryRestoreFallback::IdentityMismatch(Some(
+                        RestoredSessionIdentityMismatchReason::HistorySize
+                    )))
                 );
             }
             _ => panic!("reused identity with mismatched size should fall back to restore"),
@@ -1149,10 +1162,90 @@ mod tests {
             SessionHistoryRestorePlan::Prestarted { fallback, .. } => {
                 assert_eq!(
                     fallback,
-                    Some(SessionHistoryRestoreFallback::IdentityMismatch)
+                    Some(SessionHistoryRestoreFallback::IdentityMismatch(Some(
+                        RestoredSessionIdentityMismatchReason::HistoryHash
+                    )))
                 );
             }
             _ => panic!("mismatched reused identity should fall back to restore"),
+        }
+    }
+
+    #[tokio::test]
+    async fn restore_plan_classifies_session_identity_mismatch() {
+        let http = test_http_client();
+        let history_hash = "a".repeat(64);
+        let context = context_with_history_ref(&history_hash);
+        let restored_identity = RestoredSessionIdentity::new(
+            RestoredSessionFramework::ClaudeCode,
+            "sess-other",
+            crate::types::ResumeSessionHistoryRefKind::Blob,
+            history_hash,
+            Some(12),
+        );
+        let reusable_sandbox = reusable_sandbox_with_identity(Some(restored_identity)).await;
+        let cancel = RunCancellationHandle::new();
+        let mut timing = RunnerPreSpawnTiming::start_after_claim();
+
+        let plan = build_session_history_restore_plan(
+            &http,
+            &context,
+            true,
+            &cancel,
+            Some(&reusable_sandbox),
+            SandboxReuseResult::Reused,
+            &mut timing,
+        );
+
+        match plan {
+            SessionHistoryRestorePlan::Prestarted { fallback, .. } => {
+                assert_eq!(
+                    fallback,
+                    Some(SessionHistoryRestoreFallback::IdentityMismatch(Some(
+                        RestoredSessionIdentityMismatchReason::SessionIdentity
+                    )))
+                );
+            }
+            _ => panic!("mismatched session identity should fall back to restore"),
+        }
+    }
+
+    #[tokio::test]
+    async fn restore_plan_classifies_framework_mismatch() {
+        let http = test_http_client();
+        let history_hash = "a".repeat(64);
+        let context = context_with_history_ref(&history_hash);
+        let restored_identity = RestoredSessionIdentity::new(
+            RestoredSessionFramework::Codex,
+            "sess-restore-plan",
+            crate::types::ResumeSessionHistoryRefKind::Blob,
+            history_hash,
+            Some(12),
+        );
+        let reusable_sandbox = reusable_sandbox_with_identity(Some(restored_identity)).await;
+        let cancel = RunCancellationHandle::new();
+        let mut timing = RunnerPreSpawnTiming::start_after_claim();
+
+        let plan = build_session_history_restore_plan(
+            &http,
+            &context,
+            true,
+            &cancel,
+            Some(&reusable_sandbox),
+            SandboxReuseResult::Reused,
+            &mut timing,
+        );
+
+        match plan {
+            SessionHistoryRestorePlan::Prestarted { fallback, .. } => {
+                assert_eq!(
+                    fallback,
+                    Some(SessionHistoryRestoreFallback::IdentityMismatch(Some(
+                        RestoredSessionIdentityMismatchReason::Framework
+                    )))
+                );
+            }
+            _ => panic!("mismatched framework should fall back to restore"),
         }
     }
 }

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -260,8 +260,8 @@ fn record_session_history_materializer_state(
         telemetry.record(
             "session_history_materializer_completed_before_restore",
             Duration::ZERO,
-            true,
-            None,
+            success,
+            (!success).then_some(SESSION_HISTORY_MATERIALIZATION_WAIT_TELEMETRY_ERROR),
         );
     } else {
         telemetry.record(

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -31,7 +31,10 @@ use super::diagnostics::{
 };
 use super::env::{build_env_json_for_run, build_user_env_json, write_user_env_file};
 use super::guest_state::{restore_guest_state, sync_guest_timezone};
-use super::session_history_download::{SessionHistoryMaterialization, SessionHistoryMaterializer};
+use super::session_history_download::{
+    SessionHistoryDownloadPhaseTiming, SessionHistoryDownloadTimings,
+    SessionHistoryMaterialization, SessionHistoryMaterializer,
+};
 use super::session_restore::{MaterializedResumeSession, restore_session};
 use super::storage::{apply_storage_fingerprint_reuse, download_storages, guest_download_has_work};
 use super::telemetry::{RunnerSpawnTiming, record_api_latency};
@@ -47,13 +50,15 @@ use crate::helper_exec::{helper_exec_succeeded, helper_exec_termination_label};
 use crate::paths::guest;
 use crate::restored_session_identity::{
     FINAL_SESSION_HISTORY_IDENTITY_READ_LIMIT, RestoredSessionFinalMetadataVerification,
-    RestoredSessionIdentity,
+    RestoredSessionIdentity, RestoredSessionIdentityMismatchReason,
 };
 use crate::telemetry::JobTelemetry;
 use crate::types::{ExecutionContext, GuestDownloadManifest};
 
 const AGENT_WRAPPER_STDERR_CAPTURE_LIMIT_BYTES: u32 = 64 * 1024;
 const SESSION_HISTORY_DOWNLOAD_TELEMETRY_ERROR: &str = "session history download failed";
+const SESSION_HISTORY_DOWNLOAD_PHASE_TELEMETRY_ERROR: &str =
+    "session history download phase failed";
 const SESSION_HISTORY_MATERIALIZATION_WAIT_TELEMETRY_ERROR: &str =
     "session history materialization failed";
 const STORAGE_CACHE_POPULATE_FAILED: &str = "storage-cache-populate-failed";
@@ -66,7 +71,7 @@ pub(crate) enum SessionHistoryRestoreFallback {
     MissingIdleIdentity,
     UnverifiedIdleIdentity,
     StaleIdleIdentity,
-    IdentityMismatch,
+    IdentityMismatch(Option<RestoredSessionIdentityMismatchReason>),
 }
 
 impl SessionHistoryRestoreFallback {
@@ -78,7 +83,14 @@ impl SessionHistoryRestoreFallback {
                 "session_history_restore_fallback_unverified_idle_identity"
             }
             Self::StaleIdleIdentity => "session_history_restore_fallback_stale_idle_identity",
-            Self::IdentityMismatch => "session_history_restore_fallback_identity_mismatch",
+            Self::IdentityMismatch(_) => "session_history_restore_fallback_identity_mismatch",
+        }
+    }
+
+    const fn identity_mismatch_reason(self) -> Option<RestoredSessionIdentityMismatchReason> {
+        match self {
+            Self::IdentityMismatch(reason) => reason,
+            _ => None,
         }
     }
 }
@@ -184,6 +196,81 @@ fn record_session_history_identity_reason(
     reason: SessionHistoryIdentityReason,
 ) {
     telemetry.record(reason.action_type(), Duration::ZERO, true, None);
+}
+
+fn record_session_history_identity_mismatch_reason(
+    telemetry: &mut JobTelemetry,
+    reason: RestoredSessionIdentityMismatchReason,
+) {
+    telemetry.record(reason.action_type(), Duration::ZERO, true, None);
+}
+
+fn record_session_history_download_timings(
+    telemetry: &mut JobTelemetry,
+    timings: &SessionHistoryDownloadTimings,
+) {
+    record_session_history_download_phase(
+        telemetry,
+        "session_history_download_request_status",
+        timings.request_status(),
+    );
+    record_session_history_download_phase(
+        telemetry,
+        "session_history_download_body_read",
+        timings.body_read(),
+    );
+    record_session_history_download_phase(
+        telemetry,
+        "session_history_download_validation",
+        timings.validation(),
+    );
+    record_session_history_download_phase(
+        telemetry,
+        "session_history_download_hash_verification",
+        timings.hash_verification(),
+    );
+}
+
+fn record_session_history_download_phase(
+    telemetry: &mut JobTelemetry,
+    action_type: &'static str,
+    phase: Option<SessionHistoryDownloadPhaseTiming>,
+) {
+    if let Some(phase) = phase {
+        telemetry.record(
+            action_type,
+            phase.elapsed(),
+            phase.success(),
+            (!phase.success()).then_some(SESSION_HISTORY_DOWNLOAD_PHASE_TELEMETRY_ERROR),
+        );
+    }
+}
+
+fn record_session_history_materializer_state(
+    telemetry: &mut JobTelemetry,
+    was_downloading: bool,
+    completed_before_restore: bool,
+    wait: Duration,
+    success: bool,
+) {
+    if !was_downloading {
+        return;
+    }
+    if completed_before_restore {
+        telemetry.record(
+            "session_history_materializer_completed_before_restore",
+            Duration::ZERO,
+            true,
+            None,
+        );
+    } else {
+        telemetry.record(
+            "session_history_materializer_waited_at_restore",
+            wait,
+            success,
+            (!success).then_some(SESSION_HISTORY_MATERIALIZATION_WAIT_TELEMETRY_ERROR),
+        );
+    }
 }
 
 #[derive(Default)]
@@ -812,6 +899,9 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         } => {
             if let Some(fallback) = fallback {
                 telemetry.record(fallback.action_type(), Duration::ZERO, true, None);
+                if let Some(reason) = fallback.identity_mismatch_reason() {
+                    record_session_history_identity_mismatch_reason(telemetry, reason);
+                }
                 if matches!(fallback, SessionHistoryRestoreFallback::MissingIdleIdentity) {
                     telemetry.record(
                         "session_history_identity_reuse_missing",
@@ -832,13 +922,26 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         // 4. Restore session history. Hash-backed history downloads can start
         // before sandbox preparation, then materialize here right before restore.
         let should_record_materialization_wait = session_history_materializer.is_downloading();
+        let materializer_completed_before_restore =
+            session_history_materializer.is_download_finished();
         let materialization_wait_started = Instant::now();
         let materialization = session_history_materializer.finish(&cancel).await;
         let materialization_wait = materialization_wait_started.elapsed();
         let downloaded_resume_session = match materialization {
             SessionHistoryMaterialization::Missing => None,
             SessionHistoryMaterialization::NoDownloadNeeded => None,
-            SessionHistoryMaterialization::Downloaded { session, elapsed } => {
+            SessionHistoryMaterialization::Downloaded {
+                session,
+                elapsed,
+                timings,
+            } => {
+                record_session_history_materializer_state(
+                    telemetry,
+                    should_record_materialization_wait,
+                    materializer_completed_before_restore,
+                    materialization_wait,
+                    true,
+                );
                 if should_record_materialization_wait {
                     telemetry.record(
                         "session_history_materialization_wait",
@@ -848,9 +951,21 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                     );
                 }
                 telemetry.record("session_history_download", elapsed, true, None);
+                record_session_history_download_timings(telemetry, &timings);
                 Some(session)
             }
-            SessionHistoryMaterialization::Failed { elapsed, error } => {
+            SessionHistoryMaterialization::Failed {
+                elapsed,
+                timings,
+                error,
+            } => {
+                record_session_history_materializer_state(
+                    telemetry,
+                    should_record_materialization_wait,
+                    materializer_completed_before_restore,
+                    materialization_wait,
+                    false,
+                );
                 if should_record_materialization_wait {
                     telemetry.record(
                         "session_history_materialization_wait",
@@ -865,6 +980,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                     false,
                     Some(SESSION_HISTORY_DOWNLOAD_TELEMETRY_ERROR),
                 );
+                record_session_history_download_timings(telemetry, &timings);
                 return Err(error);
             }
         };

--- a/crates/runner/src/executor/session_history_download.rs
+++ b/crates/runner/src/executor/session_history_download.rs
@@ -48,16 +48,93 @@ pub(super) enum SessionHistoryMaterialization {
     Downloaded {
         session: MaterializedResumeSession<'static>,
         elapsed: Duration,
+        timings: SessionHistoryDownloadTimings,
     },
     Failed {
         elapsed: Duration,
+        timings: SessionHistoryDownloadTimings,
         error: RunnerError,
     },
 }
 
 struct SessionHistoryDownloadTaskResult {
     elapsed: Duration,
+    timings: SessionHistoryDownloadTimings,
     result: RunnerResult<MaterializedResumeSession<'static>>,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub(super) struct SessionHistoryDownloadTimings {
+    request_status: Option<SessionHistoryDownloadPhaseTiming>,
+    body_read: Option<SessionHistoryDownloadPhaseTiming>,
+    validation: Option<SessionHistoryDownloadPhaseTiming>,
+    hash_verification: Option<SessionHistoryDownloadPhaseTiming>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(super) struct SessionHistoryDownloadPhaseTiming {
+    elapsed: Duration,
+    success: bool,
+}
+
+impl SessionHistoryDownloadTimings {
+    pub(super) fn request_status(&self) -> Option<SessionHistoryDownloadPhaseTiming> {
+        self.request_status
+    }
+
+    pub(super) fn body_read(&self) -> Option<SessionHistoryDownloadPhaseTiming> {
+        self.body_read
+    }
+
+    pub(super) fn validation(&self) -> Option<SessionHistoryDownloadPhaseTiming> {
+        self.validation
+    }
+
+    pub(super) fn hash_verification(&self) -> Option<SessionHistoryDownloadPhaseTiming> {
+        self.hash_verification
+    }
+
+    fn record_request_status(&mut self, elapsed: Duration, success: bool) {
+        self.request_status = Some(SessionHistoryDownloadPhaseTiming { elapsed, success });
+    }
+
+    fn record_body_read(&mut self, elapsed: Duration, success: bool) {
+        self.body_read = Some(SessionHistoryDownloadPhaseTiming { elapsed, success });
+    }
+
+    fn record_hash_verification(&mut self, elapsed: Duration, success: bool) {
+        self.hash_verification = Some(SessionHistoryDownloadPhaseTiming { elapsed, success });
+    }
+
+    fn add_validation(&mut self, elapsed: Duration, success: bool) {
+        merge_phase_timing(&mut self.validation, elapsed, success);
+    }
+}
+
+impl SessionHistoryDownloadPhaseTiming {
+    pub(super) fn elapsed(self) -> Duration {
+        self.elapsed
+    }
+
+    pub(super) fn success(self) -> bool {
+        self.success
+    }
+}
+
+fn merge_phase_timing(
+    phase: &mut Option<SessionHistoryDownloadPhaseTiming>,
+    elapsed: Duration,
+    success: bool,
+) {
+    match phase {
+        Some(phase) => {
+            phase.elapsed += elapsed;
+            phase.success &= success;
+        }
+        None => {
+            *phase = Some(SessionHistoryDownloadPhaseTiming { elapsed, success });
+        }
+    }
 }
 
 impl SessionHistoryMaterializer {
@@ -105,6 +182,16 @@ impl SessionHistoryMaterializer {
         )
     }
 
+    pub(super) fn is_download_finished(&self) -> bool {
+        matches!(
+            &self.state,
+            SessionHistoryMaterializerState::Downloading {
+                task: Some(task),
+                ..
+            } if task.is_finished()
+        )
+    }
+
     pub(super) async fn finish(
         mut self,
         cancel: &CancellationToken,
@@ -129,6 +216,7 @@ impl SessionHistoryMaterializer {
                 let Some(mut task) = task.take() else {
                     return SessionHistoryMaterialization::Failed {
                         elapsed: Duration::ZERO,
+                        timings: SessionHistoryDownloadTimings::default(),
                         error: RunnerError::Internal(
                             "session history materializer lost download task".into(),
                         ),
@@ -145,6 +233,7 @@ impl SessionHistoryMaterializer {
                         joined.unwrap_or_else(|error| {
                             SessionHistoryDownloadTaskResult {
                                 elapsed: started_at.elapsed(),
+                                timings: SessionHistoryDownloadTimings::default(),
                                 result: Err(RunnerError::Internal(format!(
                                     "session history download task failed: {error}"
                                 ))),
@@ -170,9 +259,11 @@ impl SessionHistoryDownloadTaskResult {
             Ok(session) => SessionHistoryMaterialization::Downloaded {
                 session,
                 elapsed: self.elapsed,
+                timings: self.timings,
             },
             Err(error) => SessionHistoryMaterialization::Failed {
                 elapsed: self.elapsed,
+                timings: self.timings,
                 error,
             },
         }
@@ -181,6 +272,7 @@ impl SessionHistoryDownloadTaskResult {
     fn cancelled(started_at: Instant) -> Self {
         Self {
             elapsed: started_at.elapsed(),
+            timings: SessionHistoryDownloadTimings::default(),
             result: Err(RunnerError::Internal(
                 "session history download cancelled".into(),
             )),
@@ -206,9 +298,11 @@ async fn download_resume_session_history_timed(
     session: ResumeSession,
 ) -> SessionHistoryDownloadTaskResult {
     let started_at = Instant::now();
-    let result = download_resume_session_history(http, session).await;
+    let mut timings = SessionHistoryDownloadTimings::default();
+    let result = download_resume_session_history(http, session, &mut timings).await;
     SessionHistoryDownloadTaskResult {
         elapsed: started_at.elapsed(),
+        timings,
         result,
     }
 }
@@ -216,6 +310,7 @@ async fn download_resume_session_history_timed(
 async fn download_resume_session_history(
     http: HttpClient,
     session: ResumeSession,
+    timings: &mut SessionHistoryDownloadTimings,
 ) -> RunnerResult<MaterializedResumeSession<'static>> {
     // The history ref is treated as untrusted input. The request timeout and
     // 128 MiB cap bound resource use; declared size, HTTP content-length, final
@@ -229,30 +324,40 @@ async fn download_resume_session_history(
     match history_ref.kind {
         ResumeSessionHistoryRefKind::Blob => {}
     }
+    let validation_started = Instant::now();
     if let Some(expected_size) = history_ref.size
         && expected_size > RESUME_SESSION_HISTORY_MAX_BYTES
     {
+        timings.add_validation(validation_started.elapsed(), false);
         return Err(RunnerError::Internal(format!(
             "session history is too large: {expected_size} bytes exceeds {RESUME_SESSION_HISTORY_MAX_BYTES} bytes"
         )));
     }
+    timings.add_validation(validation_started.elapsed(), true);
 
-    let bytes = download_body(&http, &history_ref.url, history_ref.size).await?;
+    let bytes = download_body(&http, &history_ref.url, history_ref.size, timings).await?;
+
+    let validation_started = Instant::now();
     if let Some(expected_size) = history_ref.size
         && bytes.len() as u64 != expected_size
     {
+        timings.add_validation(validation_started.elapsed(), false);
         return Err(RunnerError::Internal(format!(
             "session history size mismatch: expected {expected_size} bytes, got {} bytes",
             bytes.len()
         )));
     }
+    timings.add_validation(validation_started.elapsed(), true);
 
+    let hash_started = Instant::now();
     let actual_hash = hex::encode(Sha256::digest(&bytes));
     if actual_hash != history_ref.hash {
+        timings.record_hash_verification(hash_started.elapsed(), false);
         return Err(RunnerError::Internal(
             "session history hash mismatch".into(),
         ));
     }
+    timings.record_hash_verification(hash_started.elapsed(), true);
 
     Ok(MaterializedResumeSession::new(
         session.cli_agent_session_id,
@@ -264,8 +369,10 @@ async fn download_body(
     http: &HttpClient,
     url: &str,
     expected_size: Option<u64>,
+    timings: &mut SessionHistoryDownloadTimings,
 ) -> RunnerResult<Vec<u8>> {
-    let mut response = http
+    let request_started = Instant::now();
+    let response_result = http
         .get(url)
         .timeout(DOWNLOAD_TIMEOUT)
         .send()
@@ -284,10 +391,22 @@ async fn download_body(
                 redact_url_query(url),
                 error.without_url()
             ))
-        })?;
+        });
+    let mut response = match response_result {
+        Ok(response) => {
+            timings.record_request_status(request_started.elapsed(), true);
+            response
+        }
+        Err(error) => {
+            timings.record_request_status(request_started.elapsed(), false);
+            return Err(error);
+        }
+    };
 
+    let validation_started = Instant::now();
     if let Some(content_length) = response.content_length() {
         if content_length > RESUME_SESSION_HISTORY_MAX_BYTES {
+            timings.add_validation(validation_started.elapsed(), false);
             return Err(RunnerError::Internal(format!(
                 "session history is too large: {content_length} bytes exceeds {RESUME_SESSION_HISTORY_MAX_BYTES} bytes"
             )));
@@ -295,11 +414,13 @@ async fn download_body(
         if let Some(expected_size) = expected_size
             && content_length != expected_size
         {
+            timings.add_validation(validation_started.elapsed(), false);
             return Err(RunnerError::Internal(format!(
                 "session history content-length mismatch: expected {expected_size} bytes, got {content_length} bytes"
             )));
         }
     }
+    timings.add_validation(validation_started.elapsed(), true);
 
     let capacity = expected_size
         .unwrap_or(64 * 1024)
@@ -307,21 +428,28 @@ async fn download_body(
         .min(usize::MAX as u64) as usize;
     let mut body = Vec::with_capacity(capacity);
     let mut downloaded = 0u64;
-    while let Some(chunk) = response.chunk().await.map_err(|error| {
-        RunnerError::Internal(format!(
-            "read {}: {}",
-            redact_url_query(url),
-            error.without_url()
-        ))
-    })? {
+    let body_started = Instant::now();
+    while let Some(chunk) = match response.chunk().await {
+        Ok(chunk) => chunk,
+        Err(error) => {
+            timings.record_body_read(body_started.elapsed(), false);
+            return Err(RunnerError::Internal(format!(
+                "read {}: {}",
+                redact_url_query(url),
+                error.without_url()
+            )));
+        }
+    } {
         downloaded += chunk.len() as u64;
         if downloaded > RESUME_SESSION_HISTORY_MAX_BYTES {
+            timings.record_body_read(body_started.elapsed(), false);
             return Err(RunnerError::Internal(format!(
                 "session history is too large: {downloaded} bytes exceeds {RESUME_SESSION_HISTORY_MAX_BYTES} bytes"
             )));
         }
         body.extend_from_slice(&chunk);
     }
+    timings.record_body_read(body_started.elapsed(), true);
 
     Ok(body)
 }
@@ -384,6 +512,20 @@ mod tests {
         )
     }
 
+    fn assert_phase_success(phase: Option<SessionHistoryDownloadPhaseTiming>) {
+        let phase = phase.expect("phase should be recorded");
+        assert!(phase.success(), "phase should succeed: {phase:?}");
+    }
+
+    fn assert_phase_failure(phase: Option<SessionHistoryDownloadPhaseTiming>) {
+        let phase = phase.expect("phase should be recorded");
+        assert!(!phase.success(), "phase should fail: {phase:?}");
+    }
+
+    fn assert_no_phase(phase: Option<SessionHistoryDownloadPhaseTiming>) {
+        assert!(phase.is_none(), "phase should not be recorded: {phase:?}");
+    }
+
     async fn serve_once(
         status: &'static str,
         body: &'static [u8],
@@ -419,9 +561,15 @@ mod tests {
         let result = materializer.finish(&CancellationToken::new()).await;
 
         match result {
-            SessionHistoryMaterialization::Downloaded { session, .. } => {
+            SessionHistoryMaterialization::Downloaded {
+                session, timings, ..
+            } => {
                 assert_eq!(session.cli_agent_session_id(), "sess-123");
                 assert_eq!(session.history_bytes(), body);
+                assert_phase_success(timings.request_status());
+                assert_phase_success(timings.body_read());
+                assert_phase_success(timings.validation());
+                assert_phase_success(timings.hash_verification());
             }
             _ => panic!("expected downloaded session"),
         }
@@ -442,12 +590,16 @@ mod tests {
             .await;
 
         match result {
-            SessionHistoryMaterialization::Failed { error, .. } => {
+            SessionHistoryMaterialization::Failed { error, timings, .. } => {
                 let message = error.to_string();
                 assert!(message.contains("hash mismatch"));
                 assert!(!message.contains("token=secret"));
                 assert!(!message.contains(&expected_hash));
                 assert!(!message.contains(&actual_hash));
+                assert_phase_success(timings.request_status());
+                assert_phase_success(timings.body_read());
+                assert_phase_success(timings.validation());
+                assert_phase_failure(timings.hash_verification());
             }
             _ => panic!("expected failed download"),
         }
@@ -466,10 +618,14 @@ mod tests {
             .await;
 
         match result {
-            SessionHistoryMaterialization::Failed { error, .. } => {
+            SessionHistoryMaterialization::Failed { error, timings, .. } => {
                 let message = error.to_string();
                 assert!(message.contains("history.blob?<redacted>"));
                 assert!(!message.contains("token=secret"));
+                assert_phase_failure(timings.request_status());
+                assert_no_phase(timings.body_read());
+                assert_phase_success(timings.validation());
+                assert_no_phase(timings.hash_verification());
             }
             _ => panic!("expected failed download"),
         }
@@ -488,8 +644,35 @@ mod tests {
             .await;
 
         match result {
-            SessionHistoryMaterialization::Failed { error, .. } => {
+            SessionHistoryMaterialization::Failed { error, timings, .. } => {
                 assert!(error.to_string().contains("too large"));
+                assert_phase_success(timings.request_status());
+                assert_no_phase(timings.body_read());
+                assert_phase_failure(timings.validation());
+                assert_no_phase(timings.hash_verification());
+            }
+            _ => panic!("expected failed download"),
+        }
+    }
+
+    #[tokio::test]
+    async fn materializer_records_body_read_failure_timing() {
+        let session = ref_session(
+            serve_once("200 OK", b"short", Some(999)).await,
+            hex::encode(Sha256::digest(b"short")),
+            None,
+        );
+
+        let result = start_materializer(&session)
+            .finish(&CancellationToken::new())
+            .await;
+
+        match result {
+            SessionHistoryMaterialization::Failed { timings, .. } => {
+                assert_phase_success(timings.request_status());
+                assert_phase_failure(timings.body_read());
+                assert_phase_success(timings.validation());
+                assert_no_phase(timings.hash_verification());
             }
             _ => panic!("expected failed download"),
         }
@@ -529,8 +712,12 @@ mod tests {
         let result = start_materializer(&session).finish(&cancel).await;
 
         match result {
-            SessionHistoryMaterialization::Failed { error, .. } => {
+            SessionHistoryMaterialization::Failed { error, timings, .. } => {
                 assert!(error.to_string().contains("cancelled"));
+                assert_no_phase(timings.request_status());
+                assert_no_phase(timings.body_read());
+                assert_no_phase(timings.validation());
+                assert_no_phase(timings.hash_verification());
             }
             _ => panic!("expected cancelled download"),
         }
@@ -615,8 +802,12 @@ mod tests {
         assert_eq!(closed, 0);
         let result = materializer.finish(&CancellationToken::new()).await;
         match result {
-            SessionHistoryMaterialization::Failed { error, .. } => {
+            SessionHistoryMaterialization::Failed { error, timings, .. } => {
                 assert!(error.to_string().contains("cancelled"));
+                assert_no_phase(timings.request_status());
+                assert_no_phase(timings.body_read());
+                assert_no_phase(timings.validation());
+                assert_no_phase(timings.hash_verification());
             }
             _ => panic!("expected cancelled download"),
         }
@@ -642,8 +833,12 @@ mod tests {
         );
         let result = materializer.finish(&cancel).await;
         match result {
-            SessionHistoryMaterialization::Failed { error, .. } => {
+            SessionHistoryMaterialization::Failed { error, timings, .. } => {
                 assert!(error.to_string().contains("cancelled"));
+                assert_no_phase(timings.request_status());
+                assert_no_phase(timings.body_read());
+                assert_no_phase(timings.validation());
+                assert_no_phase(timings.hash_verification());
             }
             _ => panic!("expected cancelled download"),
         }
@@ -656,6 +851,7 @@ mod tests {
         let task = tokio::spawn(async {
             SessionHistoryDownloadTaskResult {
                 elapsed: Duration::from_millis(1),
+                timings: SessionHistoryDownloadTimings::default(),
                 result: Ok(MaterializedResumeSession::new(
                     "sess-123".to_string(),
                     br#"{"type":"init"}"#.to_vec(),
@@ -691,6 +887,7 @@ mod tests {
             cancel_for_task.cancel();
             SessionHistoryDownloadTaskResult {
                 elapsed: Duration::from_millis(1),
+                timings: SessionHistoryDownloadTimings::default(),
                 result: Ok(MaterializedResumeSession::new(
                     "sess-123".to_string(),
                     br#"{"type":"init"}"#.to_vec(),

--- a/crates/runner/src/executor/session_history_download.rs
+++ b/crates/runner/src/executor/session_history_download.rs
@@ -333,7 +333,6 @@ async fn download_resume_session_history(
             "session history is too large: {expected_size} bytes exceeds {RESUME_SESSION_HISTORY_MAX_BYTES} bytes"
         )));
     }
-    timings.add_validation(validation_started.elapsed(), true);
 
     let bytes = download_body(&http, &history_ref.url, history_ref.size, timings).await?;
 
@@ -624,7 +623,7 @@ mod tests {
                 assert!(!message.contains("token=secret"));
                 assert_phase_failure(timings.request_status());
                 assert_no_phase(timings.body_read());
-                assert_phase_success(timings.validation());
+                assert_no_phase(timings.validation());
                 assert_no_phase(timings.hash_verification());
             }
             _ => panic!("expected failed download"),

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -40,6 +40,7 @@ use super::support::{
 };
 use crate::active_input::ActiveInputSource;
 use crate::local_queue::{ActiveInputEntry, LocalQueue};
+use crate::restored_session_identity::RestoredSessionIdentityMismatchReason;
 use crate::storage_fingerprints::{StorageFingerprint, StorageFingerprints};
 use crate::types::{
     ResumeSession, ResumeSessionHistory, ResumeSessionHistoryRef, ResumeSessionHistoryRefKind,
@@ -637,6 +638,13 @@ async fn run_in_sandbox_uses_prestarted_session_history_materializer() {
         .unwrap()
         .unwrap();
     release_response.notify_one();
+    tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, async {
+        while !materializer.is_download_finished() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
 
     let mut telemetry = test_telemetry(&config, &ctx);
     let result = run_in_sandbox(
@@ -667,16 +675,16 @@ async fn run_in_sandbox_uses_prestarted_session_history_materializer() {
     );
     assert_eq!(writes[0].content, history);
     let ops = telemetry.pending_ops_snapshot();
-    assert!(
-        ops.iter()
-            .any(|op| op.0 == "session_history_materialization_wait" && op.1),
-        "expected session history wait telemetry, got: {ops:?}"
+    assert_successful_action(
+        &ops,
+        "session_history_materializer_completed_before_restore",
     );
-    assert!(
-        ops.iter()
-            .any(|op| op.0 == "session_history_download" && op.1),
-        "expected session history download telemetry, got: {ops:?}"
-    );
+    assert_successful_action(&ops, "session_history_materialization_wait");
+    assert_successful_action(&ops, "session_history_download");
+    assert_successful_action(&ops, "session_history_download_request_status");
+    assert_successful_action(&ops, "session_history_download_body_read");
+    assert_successful_action(&ops, "session_history_download_validation");
+    assert_successful_action(&ops, "session_history_download_hash_verification");
 }
 
 #[tokio::test]
@@ -1123,7 +1131,9 @@ async fn run_in_sandbox_records_fallback_and_restores_prestarted_history() {
         RunControls::new(tokio_util::sync::CancellationToken::new(), None)
             .with_session_history_restore_plan(SessionHistoryRestorePlan::Prestarted {
                 materializer,
-                fallback: Some(SessionHistoryRestoreFallback::IdentityMismatch),
+                fallback: Some(SessionHistoryRestoreFallback::IdentityMismatch(Some(
+                    RestoredSessionIdentityMismatchReason::HistoryHash,
+                ))),
             }),
     )
     .await
@@ -1145,6 +1155,7 @@ async fn run_in_sandbox_records_fallback_and_restores_prestarted_history() {
             .any(|op| op.0 == "session_history_restore_fallback_identity_mismatch" && op.1),
         "expected fallback telemetry, got: {ops:?}"
     );
+    assert_successful_action(&ops, "session_history_identity_mismatch_history_hash");
     assert!(
         ops.iter()
             .any(|op| op.0 == "session_history_download" && op.1),
@@ -1555,6 +1566,11 @@ async fn run_in_sandbox_redacts_session_history_download_details_from_telemetry(
         }),
         "expected redacted session history wait telemetry, got: {ops:?}"
     );
+    assert_failed_action_error_once(
+        &ops,
+        "session_history_materializer_waited_at_restore",
+        "session history materialization failed",
+    );
     assert!(
         ops.iter().any(|op| {
             op.0 == "session_history_download"
@@ -1562,6 +1578,14 @@ async fn run_in_sandbox_redacts_session_history_download_details_from_telemetry(
                 && op.2.as_deref() == Some("session history download failed")
         }),
         "expected redacted session history download telemetry, got: {ops:?}"
+    );
+    assert_successful_action(&ops, "session_history_download_request_status");
+    assert_successful_action(&ops, "session_history_download_body_read");
+    assert_successful_action(&ops, "session_history_download_validation");
+    assert_failed_action_error_once(
+        &ops,
+        "session_history_download_hash_verification",
+        "session history download phase failed",
     );
     let telemetry_debug = format!("{ops:?}");
     assert!(!telemetry_debug.contains(&expected_hash));

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -688,6 +688,80 @@ async fn run_in_sandbox_uses_prestarted_session_history_materializer() {
 }
 
 #[tokio::test]
+async fn run_in_sandbox_records_completed_prestarted_materializer_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let sandbox = sandbox_mock::MockSandbox::new("test");
+    let history = br#"{"type":"init"}"#;
+    let mut ctx = minimal_context();
+    ctx.resume_session = Some(ResumeSession {
+        cli_agent_session_id: "sess-prestarted-failed-123".into(),
+        history: ResumeSessionHistory::Ref {
+            history_ref: ResumeSessionHistoryRef {
+                kind: ResumeSessionHistoryRefKind::Blob,
+                hash: hex::encode(Sha256::digest(b"different")),
+                url: serve_history_once(history).await,
+                size: Some(history.len() as u64),
+            },
+        },
+    });
+
+    let materializer = SessionHistoryMaterializer::start_cancellable(
+        &config.http,
+        ctx.resume_session.as_ref(),
+        tokio_util::sync::CancellationToken::new(),
+    );
+    tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, async {
+        while !materializer.is_download_finished() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+
+    let mut telemetry = test_telemetry(&config, &ctx);
+    let result = run_in_sandbox(
+        &sandbox,
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::PoolMiss,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None)
+            .with_session_history_restore_plan(SessionHistoryRestorePlan::Prestarted {
+                materializer,
+                fallback: None,
+            }),
+    )
+    .await;
+
+    let error = match result {
+        Ok(_) => panic!("expected completed prestarted materializer failure"),
+        Err(error) => error,
+    };
+    assert!(error.to_string().contains("hash mismatch"));
+    let ops = telemetry.pending_ops_snapshot();
+    assert_failed_action_error_once(
+        &ops,
+        "session_history_materializer_completed_before_restore",
+        "session history materialization failed",
+    );
+    assert_failed_action_error_once(
+        &ops,
+        "session_history_download",
+        "session history download failed",
+    );
+    assert_failed_action_error_once(
+        &ops,
+        "session_history_download_hash_verification",
+        "session history download phase failed",
+    );
+}
+
+#[tokio::test]
 async fn run_in_sandbox_skips_checkpointed_final_session_history_restore() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;

--- a/crates/runner/src/restored_session_identity.rs
+++ b/crates/runner/src/restored_session_identity.rs
@@ -26,6 +26,35 @@ impl RestoredSessionFramework {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum RestoredSessionIdentityMismatchReason {
+    Framework,
+    RestoreFormatVersion,
+    SessionIdentity,
+    HistoryRefKind,
+    HistoryHash,
+    HistorySize,
+    MissingRequestedIdentity,
+}
+
+impl RestoredSessionIdentityMismatchReason {
+    pub(crate) const fn action_type(self) -> &'static str {
+        match self {
+            Self::Framework => "session_history_identity_mismatch_framework",
+            Self::RestoreFormatVersion => {
+                "session_history_identity_mismatch_restore_format_version"
+            }
+            Self::SessionIdentity => "session_history_identity_mismatch_session_identity",
+            Self::HistoryRefKind => "session_history_identity_mismatch_history_ref_kind",
+            Self::HistoryHash => "session_history_identity_mismatch_history_hash",
+            Self::HistorySize => "session_history_identity_mismatch_history_size",
+            Self::MissingRequestedIdentity => {
+                "session_history_identity_mismatch_missing_requested_identity"
+            }
+        }
+    }
+}
+
 #[derive(Clone, Eq)]
 pub(crate) struct RestoredSessionIdentity {
     framework: RestoredSessionFramework,
@@ -167,6 +196,33 @@ impl RestoredSessionIdentity {
             && requested
                 .history_size_bytes
                 .is_none_or(|requested_size| self.history_size_bytes == Some(requested_size))
+    }
+
+    pub(crate) fn mismatch_reason_for_request(
+        &self,
+        requested: &Self,
+    ) -> Option<RestoredSessionIdentityMismatchReason> {
+        if self.framework != requested.framework {
+            return Some(RestoredSessionIdentityMismatchReason::Framework);
+        }
+        if self.restore_format_version != requested.restore_format_version {
+            return Some(RestoredSessionIdentityMismatchReason::RestoreFormatVersion);
+        }
+        if self.session_id_hash != requested.session_id_hash {
+            return Some(RestoredSessionIdentityMismatchReason::SessionIdentity);
+        }
+        if self.history_ref_kind != requested.history_ref_kind {
+            return Some(RestoredSessionIdentityMismatchReason::HistoryRefKind);
+        }
+        if self.history_hash != requested.history_hash {
+            return Some(RestoredSessionIdentityMismatchReason::HistoryHash);
+        }
+        if let Some(requested_size) = requested.history_size_bytes
+            && self.history_size_bytes != Some(requested_size)
+        {
+            return Some(RestoredSessionIdentityMismatchReason::HistorySize);
+        }
+        None
     }
 }
 


### PR DESCRIPTION
## Summary

- Add low-cardinality timing breakdowns for hash-backed session history materialization: request/status, body read, validation, and hash verification.
- Record whether a session history materializer had already completed before the restore point or still blocked restore.
- Classify identity-mismatch fallback reasons while preserving the existing generic fallback telemetry action.

Closes #19577
Part of #18746

## Production validation

After deploy, compare these runner telemetry actions for #18746:

- `runner_executor_start_to_spawn`
- `session_history_materialization_wait`
- `session_history_download`
- `session_history_download_request_status`
- `session_history_download_body_read`
- `session_history_download_validation`
- `session_history_download_hash_verification`
- `session_history_materializer_completed_before_restore`
- `session_history_materializer_waited_at_restore`
- `session_restore`
- `session_history_restore_fallback_identity_mismatch`
- `session_history_identity_mismatch_*`
- `session_history_restore_skip`

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner session_history_download`
- `cargo test --manifest-path crates/Cargo.toml -p runner executor::tests::agent_run_tests`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::job_discovery`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- pre-commit: `cargo-fmt`, `cargo-clippy`, `cargo-doc`