### PR TITLE
fix: remove workflow detail audit metadata

### DIFF
--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -431,31 +431,6 @@ function mockAgentPageApis(): void {
   });
 }
 
-function mockWorkflowAuditMembers(): void {
-  context.mocks.data.orgMembers({
-    members: [
-      {
-        userId: CURRENT_USER_ID,
-        email: "ethan@example.com",
-        firstName: "Ethan",
-        lastName: "Zhang",
-        imageUrl: "",
-        role: "admin",
-        joinedAt: "2024-01-01T00:00:00Z",
-      },
-      {
-        userId: UPDATED_USER_ID,
-        email: "lancy@example.com",
-        firstName: "Lancy",
-        lastName: "Lan",
-        imageUrl: "",
-        role: "member",
-        joinedAt: "2024-01-01T00:00:00Z",
-      },
-    ],
-  });
-}
-
 function applyWorkflowUpdate(
   workflow: ZeroWorkflowDetailResponse,
   body: ZeroWorkflowUpdateRequest,
@@ -994,8 +969,7 @@ describe("workflow detail page", () => {
     await expectComposerText("/sales-research");
   });
 
-  it("orders workflow info sections with audit metadata last", async () => {
-    mockWorkflowAuditMembers();
+  it("orders workflow info sections without audit metadata", async () => {
     mockWorkflowApis([salesResearch()]);
 
     detachedSetupWorkflowDetailPage(workflowDetailPath("info"));
@@ -1004,14 +978,11 @@ describe("workflow detail page", () => {
       expect(screen.getAllByText("Visibility").length).toBeGreaterThan(0);
     });
 
-    await waitFor(() => {
-      expect(textFor(document.body)).toContain("Created by Ethan Zhang");
-    });
     const pageText = textFor(document.body);
-    expect(pageText).toContain("Created by Ethan Zhang");
-    expect(pageText).toContain("Last updated by Lancy Lan");
-    expect(pageText).toContain("Jun 17, 2026");
-    expect(pageText).toContain("Jun 20, 2026");
+    expect(pageText).not.toContain("Created by");
+    expect(pageText).not.toContain("Last updated by");
+    expect(pageText).not.toContain("Jun 17, 2026");
+    expect(pageText).not.toContain("Jun 20, 2026");
     expect(pageText.indexOf("Slug")).toBeLessThan(
       pageText.indexOf("Visibility"),
     );
@@ -1020,9 +991,6 @@ describe("workflow detail page", () => {
     );
     expect(pageText.indexOf("Copy workflow")).toBeLessThan(
       pageText.indexOf("Delete workflow"),
-    );
-    expect(pageText.indexOf("Delete workflow")).toBeLessThan(
-      pageText.indexOf("Created by"),
     );
   });
 

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -124,10 +124,6 @@ import {
   workflowMetadataPatch$,
 } from "../../signals/workflows-page/workflows-signals.ts";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
-import {
-  orgMembers$,
-  type OrgMember,
-} from "../../signals/external/org-members.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { ROUTES } from "../../signals/route-paths.ts";
 import { detachedNavigateTo$ } from "../../signals/route.ts";
@@ -624,9 +620,6 @@ function WorkflowInfoTab({
           </div>
         </div>
       ) : null}
-      <div className="zero-card px-5 py-4">
-        <WorkflowAuditMetadata detail={detail} />
-      </div>
       <WorkflowCopyDialog
         detail={detail}
         open={actionDialog === "copy"}
@@ -877,66 +870,6 @@ function ShadowWarning({
       </p>
     </div>
   );
-}
-
-function WorkflowAuditMetadata({
-  detail,
-}: {
-  readonly detail: ZeroWorkflowDetailResponse;
-}) {
-  const membersLoadable = useLoadable(orgMembers$);
-  const members =
-    membersLoadable.state === "hasData" ? membersLoadable.data : [];
-  const membersById = new Map(
-    members.map((member) => {
-      return [member.userId, member];
-    }),
-  );
-
-  return (
-    <div className="px-3 py-2 text-xs leading-5 text-muted-foreground">
-      <div>
-        <p>
-          Created by {workflowUserLabel(detail.createdByUserId, membersById)}
-        </p>
-        <p>{formatWorkflowAuditDate(detail.createdAt)}</p>
-      </div>
-      <div className="mt-2">
-        <p>
-          Last updated by{" "}
-          {workflowUserLabel(detail.updatedByUserId, membersById)}
-        </p>
-        <p>{formatWorkflowAuditDate(detail.updatedAt)}</p>
-      </div>
-    </div>
-  );
-}
-
-function workflowUserLabel(
-  userId: string,
-  membersById: ReadonlyMap<string, OrgMember>,
-): string {
-  const member = membersById.get(userId);
-  return member ? orgMemberDisplayName(member) : userId;
-}
-
-function orgMemberDisplayName(member: OrgMember): string {
-  const fullName = [member.firstName, member.lastName]
-    .filter((part): part is string => {
-      return Boolean(part);
-    })
-    .join(" ");
-  return fullName || member.email || member.userId;
-}
-
-function formatWorkflowAuditDate(value: string): string {
-  return new Intl.DateTimeFormat("en-US", {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-  }).format(new Date(value));
 }
 
 function WorkflowPublicToggle({


### PR DESCRIPTION
## Summary
- remove the workflow detail info-page audit metadata card
- delete the now-unused workflow audit member/date formatting helpers
- update the workflow detail test to assert the audit metadata stays hidden

## Verification
- pnpm exec prettier --check apps/platform/src/views/workflows-page/workflow-detail-page.tsx apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
- pnpm -F @vm0/app exec oxlint src/views/workflows-page/workflow-detail-page.tsx src/views/workflows-page/__tests__/workflows-page.test.tsx
- pnpm -F @vm0/app exec vitest run src/views/workflows-page/__tests__/workflows-page.test.tsx
- pnpm -F @vm0/app check-types