### PR TITLE
fix: classify codex context window failures

### DIFF
--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -21,6 +21,8 @@ const FAILURE_DIAGNOSTIC_TRUNCATED_SUFFIX: &str = "...[truncated]";
 const CODEX_OAUTH_TOKEN_CONNECTOR: &str = "codex-oauth-token";
 const CODEX_MODEL_CAPACITY_MESSAGE: &str =
     "selected model is at capacity. please try a different model.";
+const CODEX_CONTEXT_WINDOW_EXHAUSTED_PREFIX: &str =
+    "codex ran out of room in the model's context window.";
 
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct CodexFailureDiagnostic {
@@ -133,6 +135,14 @@ pub fn is_codex_model_capacity_message(message: &str) -> bool {
     message
         .to_ascii_lowercase()
         .contains(CODEX_MODEL_CAPACITY_MESSAGE)
+}
+
+pub fn is_codex_context_window_exceeded_message(message: &str) -> bool {
+    let message = message.to_ascii_lowercase();
+    message.contains(CODEX_CONTEXT_WINDOW_EXHAUSTED_PREFIX)
+        && (message.contains("start a new thread") || message.contains("start a new conversation"))
+        && message.contains("clear earlier history")
+        && message.contains("before retrying")
 }
 
 fn extract_codex_failure_diagnostic(event: &Value) -> Option<CodexFailureDiagnostic> {
@@ -291,6 +301,12 @@ fn codex_error_failure_reason(error: Option<&Value>) -> Option<FailureReason> {
         .is_some_and(is_codex_model_capacity_message)
     {
         return Some(FailureReason::ProviderOverloaded);
+    }
+    if codex_error_message(Some(error))
+        .as_deref()
+        .is_some_and(is_codex_context_window_exceeded_message)
+    {
+        return Some(FailureReason::ContextWindowExceeded);
     }
     None
 }
@@ -886,6 +902,23 @@ mod tests {
     }
 
     #[test]
+    fn codex_error_event_context_window_exceeded_yields_failure_reason() {
+        let event = serde_json::json!({
+            "type": "error",
+            "message": "Codex ran out of room in the model's context window. Start a new thread or clear earlier history before retrying."
+        });
+
+        assert_eq!(
+            masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(CodexFailureDiagnostic {
+                event_type: "error",
+                message: "Codex ran out of room in the model's context window. Start a new thread or clear earlier history before retrying.".to_string(),
+                failure_reason: Some(FailureReason::ContextWindowExceeded),
+            })
+        );
+    }
+
+    #[test]
     fn codex_error_event_error_string_invalid_api_key_remains_unclassified() {
         let event = serde_json::json!({
             "type": "error",
@@ -1244,6 +1277,25 @@ mod tests {
     }
 
     #[test]
+    fn codex_turn_failed_context_window_exceeded_yields_failure_reason() {
+        let event = serde_json::json!({
+            "type": "turn.failed",
+            "error": {
+                "message": "Codex ran out of room in the model's context window. Start a new thread or clear earlier history before retrying."
+            }
+        });
+
+        assert_eq!(
+            masked_codex_failure_diagnostic(&event, &SecretMasker::from_raw("")),
+            Some(CodexFailureDiagnostic {
+                event_type: "turn.failed",
+                message: "Codex ran out of room in the model's context window. Start a new thread or clear earlier history before retrying.".to_string(),
+                failure_reason: Some(FailureReason::ContextWindowExceeded),
+            })
+        );
+    }
+
+    #[test]
     fn codex_error_info_server_overloaded_yields_failure_reason() {
         let event = serde_json::json!({
             "type": "turn.failed",
@@ -1338,6 +1390,26 @@ mod tests {
     fn codex_model_capacity_matcher_ignores_generic_overload_text() {
         assert!(!is_codex_model_capacity_message(
             "API Error: 529 Overloaded. This is a server-side issue, usually temporary - try again in a moment."
+        ));
+    }
+
+    #[test]
+    fn codex_context_window_matcher_accepts_thread_and_conversation_variants() {
+        for message in [
+            "Codex ran out of room in the model's context window. Start a new thread or clear earlier history before retrying.",
+            "Codex ran out of room in the model's context window. Start a new conversation or clear earlier history before retrying.",
+        ] {
+            assert!(
+                is_codex_context_window_exceeded_message(message),
+                "message: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn codex_context_window_matcher_ignores_generic_context_window_text() {
+        assert!(!is_codex_context_window_exceeded_message(
+            "The prompt mentions the model context window but did not fail."
         ));
     }
 

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -610,6 +610,11 @@ fn classify_cli_failure_reason(
     {
         return Some(FailureReason::ProviderOverloaded);
     }
+    if matches!(framework, AgentFramework::Codex)
+        && guest_agent::events::is_codex_context_window_exceeded_message(failure_message)
+    {
+        return Some(FailureReason::ContextWindowExceeded);
+    }
     // Subscription/usage limits are an expected quota state for both Codex
     // (ChatGPT plan "usage limit") and Claude Code (Max plan "session limit" /
     // "weekly limit" / org monthly spend limit), so classify them regardless of
@@ -2051,6 +2056,26 @@ mod tests {
         let reason = classify_cli_failure_reason(
             AgentFramework::ClaudeCode,
             "Selected model is at capacity. Please try a different model.",
+        );
+
+        assert_eq!(reason, None);
+    }
+
+    #[test]
+    fn cli_failure_reason_classifies_codex_context_window_exceeded() {
+        let reason = classify_cli_failure_reason(
+            AgentFramework::Codex,
+            "Codex ran out of room in the model's context window. Start a new thread or clear earlier history before retrying.",
+        );
+
+        assert_eq!(reason, Some(FailureReason::ContextWindowExceeded));
+    }
+
+    #[test]
+    fn cli_failure_reason_ignores_non_codex_context_window_exceeded() {
+        let reason = classify_cli_failure_reason(
+            AgentFramework::ClaudeCode,
+            "Codex ran out of room in the model's context window. Start a new thread or clear earlier history before retrying.",
         );
 
         assert_eq!(reason, None);

--- a/crates/guest-contracts/src/diagnostics.rs
+++ b/crates/guest-contracts/src/diagnostics.rs
@@ -295,6 +295,8 @@ pub enum FailureReason {
     InvalidApiKey,
     /// The configured credentials are invalid.
     InvalidCredentials,
+    /// The model context window was exhausted.
+    ContextWindowExceeded,
     /// The provider stopped because an output-token limit was reached.
     OutputTokenLimit,
     /// The provider reported overload.
@@ -317,6 +319,7 @@ impl FailureReason {
             Self::InsufficientCredits => "insufficient_credits",
             Self::InvalidApiKey => "invalid_api_key",
             Self::InvalidCredentials => "invalid_credentials",
+            Self::ContextWindowExceeded => "context_window_exceeded",
             Self::OutputTokenLimit => "output_token_limit",
             Self::ProviderOverloaded => "provider_overloaded",
             Self::ProviderStreamTimeout => "provider_stream_timeout",
@@ -672,6 +675,28 @@ mod tests {
 
         let json = serde_json::to_value(&diagnostic).unwrap();
         assert_eq!(json["failureReason"], "invalid_credentials");
+
+        let round_trip: FailureDiagnostic = serde_json::from_value(json).unwrap();
+        assert_eq!(round_trip, diagnostic);
+    }
+
+    #[test]
+    fn failure_diagnostic_serializes_context_window_exceeded_reason() {
+        assert_eq!(
+            FailureReason::ContextWindowExceeded.as_str(),
+            "context_window_exceeded"
+        );
+
+        let diagnostic = FailureDiagnostic::new(
+            FailureClass::CliNonzero,
+            AgentFramework::Codex,
+            PromptMetadata::from_prompt("debug failure"),
+        )
+        .with_cli_exit_code(1)
+        .with_failure_reason(FailureReason::ContextWindowExceeded);
+
+        let json = serde_json::to_value(&diagnostic).unwrap();
+        assert_eq!(json["failureReason"], "context_window_exceeded");
 
         let round_trip: FailureDiagnostic = serde_json::from_value(json).unwrap();
         assert_eq!(round_trip, diagnostic);

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -904,6 +904,7 @@ fn is_info_level_job_failure(diagnostic: &FailureDiagnostic) -> bool {
                 FailureReason::InsufficientCredits
                     | FailureReason::InvalidApiKey
                     | FailureReason::InvalidCredentials
+                    | FailureReason::ContextWindowExceeded
                     | FailureReason::OutputTokenLimit
                     | FailureReason::ProviderOverloaded
                     | FailureReason::ProviderStreamTimeout
@@ -1277,6 +1278,7 @@ mod tests {
             FailureReason::InsufficientCredits,
             FailureReason::InvalidApiKey,
             FailureReason::InvalidCredentials,
+            FailureReason::ContextWindowExceeded,
             FailureReason::OutputTokenLimit,
             FailureReason::ProviderOverloaded,
             FailureReason::ProviderStreamTimeout,
@@ -1400,6 +1402,7 @@ mod tests {
         for reason in [
             FailureReason::InvalidApiKey,
             FailureReason::InvalidCredentials,
+            FailureReason::ContextWindowExceeded,
             FailureReason::OutputTokenLimit,
             FailureReason::ProviderOverloaded,
             FailureReason::ProviderStreamTimeout,


### PR DESCRIPTION
## Summary

- Add `context_window_exceeded` as a stable runner failure reason.
- Classify Codex context-window exhaustion JSONL/fallback messages into that reason.
- Treat classified Codex context-window `cli_nonzero` failures as expected info-level runner failures.

Closes #19589

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml --all`
- `cargo test --manifest-path crates/Cargo.toml -p guest-contracts`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::job_spawn`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `git diff --check`
- pre-commit: `cargo doc`, `cargo clippy`, file-size/generated checks
