### PR TITLE
test: migrate guest-agent tests to explicit runtime apis

### DIFF
--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -1235,6 +1235,17 @@ mod tests {
 
     static TEST_STATE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
     static COMPLETE_EXECUTION_MOCK_SERVER: LazyLock<MockServer> = LazyLock::new(MockServer::start);
+    static MAIN_TEST_RUNTIME_ROOT: LazyLock<std::path::PathBuf> = LazyLock::new(|| {
+        let timestamp_nanos =
+            match std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
+                Ok(duration) => duration.as_nanos(),
+                Err(error) => error.duration().as_nanos(),
+            };
+        std::env::temp_dir().join(format!(
+            "vm0-guest-agent-main-tests-{}-{timestamp_nanos}",
+            std::process::id()
+        ))
+    });
 
     fn lock_test_state() -> std::sync::MutexGuard<'static, ()> {
         TEST_STATE_LOCK
@@ -1268,9 +1279,7 @@ mod tests {
     }
 
     fn test_runtime_dir() -> std::path::PathBuf {
-        std::env::temp_dir()
-            .join(format!("vm0-guest-agent-main-tests-{}", std::process::id()))
-            .join("main-recovery-checkpoint")
+        MAIN_TEST_RUNTIME_ROOT.join("main-recovery-checkpoint")
     }
 
     struct EnvVarRestoreGuard {

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -1235,16 +1235,11 @@ mod tests {
 
     static TEST_STATE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
     static COMPLETE_EXECUTION_MOCK_SERVER: LazyLock<MockServer> = LazyLock::new(MockServer::start);
-    static MAIN_TEST_RUNTIME_ROOT: LazyLock<std::path::PathBuf> = LazyLock::new(|| {
-        let timestamp_nanos =
-            match std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
-                Ok(duration) => duration.as_nanos(),
-                Err(error) => error.duration().as_nanos(),
-            };
-        std::env::temp_dir().join(format!(
-            "vm0-guest-agent-main-tests-{}-{timestamp_nanos}",
-            std::process::id()
-        ))
+    static MAIN_TEST_RUNTIME_ROOT: LazyLock<tempfile::TempDir> = LazyLock::new(|| {
+        tempfile::Builder::new()
+            .prefix("vm0-guest-agent-main-tests-")
+            .tempdir()
+            .expect("create guest-agent main test runtime root")
     });
 
     fn lock_test_state() -> std::sync::MutexGuard<'static, ()> {
@@ -1279,7 +1274,9 @@ mod tests {
     }
 
     fn test_runtime_dir() -> std::path::PathBuf {
-        MAIN_TEST_RUNTIME_ROOT.join("main-recovery-checkpoint")
+        MAIN_TEST_RUNTIME_ROOT
+            .path()
+            .join("main-recovery-checkpoint")
     }
 
     struct EnvVarRestoreGuard {

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -1236,13 +1236,15 @@ mod tests {
     static TEST_STATE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
     static COMPLETE_EXECUTION_MOCK_SERVER: LazyLock<MockServer> = LazyLock::new(MockServer::start);
     static MAIN_TEST_RUNTIME_ROOT: LazyLock<std::path::PathBuf> = LazyLock::new(|| {
-        tempfile::Builder::new()
-            .prefix("vm0-guest-agent-main-tests-")
-            .tempdir()
-            .expect("create guest-agent main test runtime root")
-            .keep()
+        let timestamp_nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or_default();
+        std::env::temp_dir().join(format!(
+            "vm0-guest-agent-main-tests-{}-{timestamp_nanos}",
+            std::process::id()
+        ))
     });
-
     fn lock_test_state() -> std::sync::MutexGuard<'static, ()> {
         TEST_STATE_LOCK
             .lock()
@@ -1322,7 +1324,16 @@ mod tests {
         assert!(framework_supports_active_input(env::Framework::Codex, true));
     }
 
-    unsafe fn set_test_env(server: &MockServer, prompt: Option<&str>) {
+    struct TestEnvGuard;
+
+    impl Drop for TestEnvGuard {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&*MAIN_TEST_RUNTIME_ROOT);
+        }
+    }
+
+    unsafe fn set_test_env(server: &MockServer, prompt: Option<&str>) -> TestEnvGuard {
+        let _ = std::fs::remove_dir_all(&*MAIN_TEST_RUNTIME_ROOT);
         unsafe {
             clear_test_env();
             std::env::set_var("VM0_API_URL", server.base_url());
@@ -1336,6 +1347,7 @@ mod tests {
                 std::env::set_var("VM0_PROMPT", prompt);
             }
         }
+        TestEnvGuard
     }
 
     unsafe fn clear_test_env() {
@@ -2720,9 +2732,7 @@ mod tests {
     async fn assert_final_telemetry_does_not_record_recursive_upload_op(status: u16) {
         let server = &*COMPLETE_EXECUTION_MOCK_SERVER;
         server.reset_async().await;
-        unsafe {
-            set_test_env(server, None);
-        }
+        let _env_guard = unsafe { set_test_env(server, None) };
 
         let tmp = tempfile::tempdir().unwrap();
         let system_log_path = tmp.path().join("system.log");
@@ -2782,9 +2792,7 @@ mod tests {
             .block_on(async {
                 let server = &*COMPLETE_EXECUTION_MOCK_SERVER;
                 server.reset_async().await;
-                unsafe {
-                    set_test_env(server, None);
-                }
+                let _env_guard = unsafe { set_test_env(server, None) };
 
                 let marker = "producer_after_shutdown_before_final_upload";
                 let cleanup_paths = [
@@ -2998,9 +3006,7 @@ mod tests {
     async fn complete_execution_writes_event_upload_failure_diagnostic_inner() {
         let server = &*COMPLETE_EXECUTION_MOCK_SERVER;
         server.reset_async().await;
-        unsafe {
-            set_test_env(server, Some("/event-upload-failure"));
-        }
+        let _env_guard = unsafe { set_test_env(server, Some("/event-upload-failure")) };
 
         let cleanup_paths = [
             paths::session_id_file().to_string(),
@@ -3068,9 +3074,7 @@ mod tests {
     async fn complete_execution_writes_checkpoint_failure_diagnostic_inner() {
         let server = &*COMPLETE_EXECUTION_MOCK_SERVER;
         server.reset_async().await;
-        unsafe {
-            set_test_env(server, Some("/checkpoint-failure"));
-        }
+        let _env_guard = unsafe { set_test_env(server, Some("/checkpoint-failure")) };
 
         let cleanup_paths = [
             paths::session_id_file().to_string(),
@@ -3135,9 +3139,7 @@ mod tests {
     async fn complete_execution_preserves_existing_failure_diagnostic_when_events_fail_inner() {
         let server = &*COMPLETE_EXECUTION_MOCK_SERVER;
         server.reset_async().await;
-        unsafe {
-            set_test_env(server, Some("plain prompt"));
-        }
+        let _env_guard = unsafe { set_test_env(server, Some("plain prompt")) };
 
         let cleanup_paths = [
             paths::session_id_file().to_string(),
@@ -3208,9 +3210,7 @@ mod tests {
     async fn complete_execution_skips_recovery_checkpoint_for_no_history_inner() {
         let server = &*COMPLETE_EXECUTION_MOCK_SERVER;
         server.reset_async().await;
-        unsafe {
-            set_test_env(server, Some("/help"));
-        }
+        let _env_guard = unsafe { set_test_env(server, Some("/help")) };
 
         let cleanup_paths = [
             paths::checkpoint_error_file().to_string(),
@@ -3291,9 +3291,7 @@ mod tests {
     async fn complete_execution_creates_recovery_checkpoint_after_cli_failure_inner() {
         let server = &*COMPLETE_EXECUTION_MOCK_SERVER;
         server.reset_async().await;
-        unsafe {
-            set_test_env(server, Some("plain prompt"));
-        }
+        let _env_guard = unsafe { set_test_env(server, Some("plain prompt")) };
 
         let cleanup_paths = [
             paths::session_id_file().to_string(),

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -1235,11 +1235,12 @@ mod tests {
 
     static TEST_STATE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
     static COMPLETE_EXECUTION_MOCK_SERVER: LazyLock<MockServer> = LazyLock::new(MockServer::start);
-    static MAIN_TEST_RUNTIME_ROOT: LazyLock<tempfile::TempDir> = LazyLock::new(|| {
+    static MAIN_TEST_RUNTIME_ROOT: LazyLock<std::path::PathBuf> = LazyLock::new(|| {
         tempfile::Builder::new()
             .prefix("vm0-guest-agent-main-tests-")
             .tempdir()
             .expect("create guest-agent main test runtime root")
+            .keep()
     });
 
     fn lock_test_state() -> std::sync::MutexGuard<'static, ()> {
@@ -1274,9 +1275,7 @@ mod tests {
     }
 
     fn test_runtime_dir() -> std::path::PathBuf {
-        MAIN_TEST_RUNTIME_ROOT
-            .path()
-            .join("main-recovery-checkpoint")
+        MAIN_TEST_RUNTIME_ROOT.join("main-recovery-checkpoint")
     }
 
     struct EnvVarRestoreGuard {

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -1324,6 +1324,7 @@ mod tests {
 
     unsafe fn set_test_env(server: &MockServer, prompt: Option<&str>) {
         unsafe {
+            clear_test_env();
             std::env::set_var("VM0_API_URL", server.base_url());
             std::env::set_var("VM0_API_TOKEN", "test-token");
             std::env::set_var("VM0_RUN_ID", "main-recovery-checkpoint");
@@ -1333,6 +1334,46 @@ mod tests {
             );
             if let Some(prompt) = prompt {
                 std::env::set_var("VM0_PROMPT", prompt);
+            }
+        }
+    }
+
+    unsafe fn clear_test_env() {
+        for key in [
+            guest_contracts::env::API_URL_ENV,
+            guest_contracts::env::RUN_ID_ENV,
+            guest_contracts::env::API_TOKEN_ENV,
+            guest_contracts::env::SANDBOX_ID_ENV,
+            guest_contracts::env::SANDBOX_REUSE_RESULT_ENV,
+            guest_contracts::env::PROMPT_ENV,
+            guest_contracts::env::APPEND_SYSTEM_PROMPT_ENV,
+            guest_contracts::env::VERCEL_PROTECTION_BYPASS_ENV,
+            guest_contracts::env::RESUME_SESSION_ID_ENV,
+            guest_contracts::env::API_START_TIME_ENV,
+            guest_contracts::env::SECRET_VALUES_ENV,
+            guest_contracts::env::DISALLOWED_TOOLS_ENV,
+            guest_contracts::env::TOOLS_ENV,
+            guest_contracts::env::SETTINGS_ENV,
+            guest_contracts::env::CLI_AGENT_TYPE_ENV,
+            guest_contracts::env::USER_ENV_FILE_ENV,
+            guest_contracts::env::ARTIFACTS_ENV,
+            guest_contracts::env::FEATURE_FLAGS_ENV,
+            guest_contracts::env::STUCK_TOOL_TIMEOUT_SECS_ENV,
+            guest_contracts::env::POST_RESULT_SIGTERM_GRACE_SECS_ENV,
+            guest_contracts::env::POST_RESULT_TOTAL_CAP_SECS_ENV,
+            guest_contracts::env::POST_RESULT_SIGKILL_GRACE_SECS_ENV,
+            guest_contracts::env::USE_MOCK_CLAUDE_ENV,
+            guest_contracts::env::USE_MOCK_CODEX_ENV,
+            guest_contracts::env::CODEX_APP_SERVER_BACKEND_ENV,
+            guest_contracts::env::MOCK_CLAUDE_PATH_ENV,
+            guest_contracts::env::MOCK_CODEX_PATH_ENV,
+            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+            process_control_ipc::BOOTSTRAP_ENV,
+            "MOCK_CODEX_FIXTURE",
+            "MOCK_CODEX_APP_SERVER_SCENARIO",
+        ] {
+            unsafe {
+                std::env::remove_var(key);
             }
         }
     }

--- a/crates/guest-agent/tests/artifact_checkpoint_content_hash.rs
+++ b/crates/guest-agent/tests/artifact_checkpoint_content_hash.rs
@@ -1,7 +1,7 @@
-//! Artifact checkpoint telemetry lives in its own test binary because
-//! guest-agent environment and runtime paths are captured in process-wide
-//! `LazyLock`s on first access.
-
+use guest_agent::env::{GuestConfig, GuestConfigRaw};
+use guest_agent::http::HttpClient;
+use guest_agent::paths::GuestPaths;
+use guest_agent::run_context::GuestRuntime;
 use httpmock::prelude::*;
 use serde_json::json;
 use sha2::{Digest, Sha256};
@@ -43,28 +43,53 @@ fn checkpoint_request_has_artifact_snapshot(
     })
 }
 
-unsafe fn setup_env(temp_dir: &Path, mount_path: &Path, version_id: &str) {
-    unsafe {
-        std::env::set_var("CLI_AGENT_TYPE", "claude-code");
-        std::env::set_var("VM0_RUN_ID", RUN_ID);
-        std::env::set_var(
-            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
-            temp_dir.join("runtime"),
-        );
-        std::env::set_var("HOME", temp_dir.join("home"));
-        std::env::set_var(
-            guest_contracts::env::ARTIFACTS_ENV,
-            json!([
-                {
-                    "name": "workspace",
-                    "mountPath": mount_path.to_string_lossy(),
-                    "storageId": STORAGE_ID,
-                    "versionId": version_id,
-                }
-            ])
-            .to_string(),
-        );
+struct SandboxOpsOverrideGuard;
+
+impl SandboxOpsOverrideGuard {
+    fn set(path: &str) -> Self {
+        guest_common::telemetry::set_sandbox_ops_log_file(path);
+        Self
     }
+}
+
+impl Drop for SandboxOpsOverrideGuard {
+    fn drop(&mut self) {
+        guest_common::telemetry::clear_sandbox_ops_log_file();
+    }
+}
+
+fn test_runtime(
+    temp_dir: &Path,
+    mount_path: &Path,
+    version_id: &str,
+    api_url: &str,
+) -> Result<GuestRuntime, Box<dyn std::error::Error>> {
+    let runtime_dir = temp_dir.join("runtime");
+    let paths = GuestPaths::from_runtime_dir(&runtime_dir);
+    let config = GuestConfig::from_raw(GuestConfigRaw {
+        run_id: RUN_ID.to_string(),
+        api_url: api_url.to_string(),
+        api_token: "test-token".to_string(),
+        cli_agent_type: "claude-code".to_string(),
+        home: Some(temp_dir.join("home").to_string_lossy().into_owned()),
+        guest_runtime_dir: Some(runtime_dir),
+        artifacts: json!([
+            {
+                "name": "workspace",
+                "mountPath": mount_path.to_string_lossy(),
+                "storageId": STORAGE_ID,
+                "versionId": version_id,
+            }
+        ])
+        .to_string(),
+        ..GuestConfigRaw::default()
+    })?;
+    let http = HttpClient::with_api_config(api_url, "test-token", "", Duration::ZERO)?;
+    Ok(GuestRuntime {
+        config,
+        paths,
+        http,
+    })
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -76,17 +101,20 @@ async fn unchanged_artifact_checkpoint_records_content_hash_timing()
     std::fs::write(mount_path.join("a.txt"), "hello")?;
     let version_id = content_hash_for_single_file(STORAGE_ID, "a.txt", "hello");
 
-    unsafe {
-        setup_env(temp_dir.path(), &mount_path, &version_id);
-    }
-
     let server = MockServer::start();
+    let runtime = test_runtime(
+        temp_dir.path(),
+        &mount_path,
+        &version_id,
+        &server.base_url(),
+    )?;
+    let _sandbox_ops_guard = SandboxOpsOverrideGuard::set(runtime.paths.sandbox_ops_file());
 
     let history_path = temp_dir.path().join("history.jsonl");
     std::fs::write(&history_path, r#"{"type":"system"}"#)?;
-    guest_agent::paths::write_private(guest_agent::paths::session_id_file(), "session-abc")?;
+    guest_agent::paths::write_private(runtime.paths.session_id_file(), "session-abc")?;
     guest_agent::paths::write_private(
-        guest_agent::paths::session_history_path_file(),
+        runtime.paths.session_history_path_file(),
         history_path.to_string_lossy().as_ref(),
     )?;
 
@@ -125,21 +153,14 @@ async fn unchanged_artifact_checkpoint_records_content_hash_timing()
             .json_body(json!({"checkpointId": "checkpoint-with-unchanged-artifact"}));
     });
 
-    let http = guest_agent::http::HttpClient::with_api_config(
-        server.base_url(),
-        "test-token",
-        "",
-        Duration::ZERO,
-    )?;
-
-    guest_agent::checkpoint::create_checkpoint(&http).await?;
+    guest_agent::checkpoint::create_checkpoint_for_runtime(&runtime).await?;
 
     history_prepare.assert_calls_async(1).await;
     storage_prepare.assert_calls_async(0).await;
     storage_commit.assert_calls_async(0).await;
     checkpoint.assert_calls_async(1).await;
 
-    let sandbox_ops = std::fs::read_to_string(guest_common::telemetry::sandbox_ops_log())?;
+    let sandbox_ops = std::fs::read_to_string(runtime.paths.sandbox_ops_file())?;
     assert!(sandbox_ops.contains(r#""action_type":"artifact_content_hash_compute""#));
     assert!(sandbox_ops.contains(r#""action_type":"artifact_snapshot_skipped""#));
 

--- a/crates/guest-agent/tests/claude_result_failure_logging.rs
+++ b/crates/guest-agent/tests/claude_result_failure_logging.rs
@@ -1,12 +1,11 @@
 //! Claude terminal result failures should be visible as bounded CLI diagnostics.
 //!
-//! This test lives in its own binary because `guest_agent::env` and
-//! `guest_agent::paths` cache values in process-wide `LazyLock`s.
+//! This test lives in its own binary to isolate process env, working directory,
+//! and guest runtime path overrides used during setup.
 
 mod common;
 
 use common::SystemLogOverrideGuard;
-use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
 use guest_contracts::diagnostics::FailureDetailSource;
 use std::time::Duration;
@@ -28,15 +27,13 @@ async fn claude_error_result_is_written_to_system_log() -> Result<(), Box<dyn st
         )?;
     }
 
+    let runtime = common::guest_runtime_from_process_env()?;
+
     let _system_log = SystemLogOverrideGuard::set(&system_log_path);
     let masker = SecretMasker::from_raw("");
     let cli_result = tokio::time::timeout(
         Duration::from_secs(5),
-        guest_agent::cli::execute_cli(
-            &masker,
-            common::spawn_dummy_heartbeat(),
-            HttpClient::for_current_env()?,
-        ),
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
     )
     .await
     .expect("execute_cli should return promptly")?;

--- a/crates/guest-agent/tests/cli_child_env.rs
+++ b/crates/guest-agent/tests/cli_child_env.rs
@@ -1,5 +1,5 @@
-//! This test lives in its own binary because `guest_agent::env` caches
-//! environment values in process-wide `LazyLock`s.
+//! This test lives in its own binary to isolate process env, working directory,
+//! and guest runtime path overrides used during setup.
 
 mod common;
 

--- a/crates/guest-agent/tests/cli_failure_diagnostic_session_id_masking.rs
+++ b/crates/guest-agent/tests/cli_failure_diagnostic_session_id_masking.rs
@@ -1,12 +1,11 @@
 //! Failure diagnostics must mask a session ID carried by the same JSONL event.
 //!
-//! This test lives in its own binary because `guest_agent::env` caches values
-//! in process-wide `LazyLock`s.
+//! This test lives in its own binary to isolate process env, working directory,
+//! and guest runtime path overrides used during setup.
 
 mod common;
 
 use common::SystemLogOverrideGuard;
-use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
 use serde_json::json;
 use std::time::Duration;
@@ -36,16 +35,14 @@ async fn cli_failure_diagnostic_masks_session_id_from_same_event()
         common::setup_env(&mock, tmp.path(), &prompt, 3, 1)?;
     }
 
+    let runtime = common::guest_runtime_from_process_env()?;
+
     let system_log_path = tmp.path().join("system.log");
     let _system_log_guard = SystemLogOverrideGuard::set(&system_log_path);
     let masker = SecretMasker::from_raw("");
     let cli_result = tokio::time::timeout(
         Duration::from_secs(5),
-        guest_agent::cli::execute_cli(
-            &masker,
-            common::spawn_dummy_heartbeat(),
-            HttpClient::for_current_env()?,
-        ),
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
     )
     .await
     .expect("execute_cli should return promptly")?;

--- a/crates/guest-agent/tests/cli_resume_id_stderr_masking.rs
+++ b/crates/guest-agent/tests/cli_resume_id_stderr_masking.rs
@@ -1,11 +1,10 @@
 //! Resume session IDs must be masked even when the CLI fails before emitting JSONL.
 //!
-//! This test lives in its own binary because `guest_agent::env` caches values
-//! in process-wide `LazyLock`s.
+//! This test lives in its own binary to isolate process env, working directory,
+//! and guest runtime path overrides used during setup.
 
 mod common;
 
-use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
 use std::time::Duration;
 
@@ -26,14 +25,12 @@ async fn cli_failure_masks_resume_session_id_in_stderr() -> Result<(), Box<dyn s
         std::env::set_var("VM0_RESUME_SESSION_ID", resume_id);
     }
 
+    let runtime = common::guest_runtime_from_process_env()?;
+
     let masker = SecretMasker::from_raw("");
     let cli_result = tokio::time::timeout(
         Duration::from_secs(5),
-        guest_agent::cli::execute_cli(
-            &masker,
-            common::spawn_dummy_heartbeat(),
-            HttpClient::for_current_env()?,
-        ),
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
     )
     .await
     .expect("execute_cli should return promptly")?;

--- a/crates/guest-agent/tests/cli_setup_failure.rs
+++ b/crates/guest-agent/tests/cli_setup_failure.rs
@@ -20,6 +20,7 @@ async fn agent_log_open_failure_happens_before_cli_spawn() -> Result<(), Box<dyn
     std::fs::write(&log_parent, b"not a directory")?;
 
     unsafe {
+        common::clear_guest_agent_bootstrap_env_for_test();
         std::env::set_var("VM0_RUN_ID", &run_id);
         std::env::set_var(
             guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,

--- a/crates/guest-agent/tests/cli_setup_failure.rs
+++ b/crates/guest-agent/tests/cli_setup_failure.rs
@@ -1,7 +1,7 @@
 //! CLI setup should fail before spawning the agent when local log setup fails.
 //!
-//! This test lives in its own binary because `guest_agent::env` and
-//! `guest_agent::paths` cache values in process-wide `LazyLock`s.
+//! This test lives in its own binary to isolate process env, working directory,
+//! and guest runtime path overrides used during setup.
 
 mod common;
 
@@ -38,16 +38,14 @@ async fn agent_log_open_failure_happens_before_cli_spawn() -> Result<(), Box<dyn
     }
     common::ensure_canonical_workspace_for_test()?;
 
+    let runtime = common::guest_runtime_from_process_env()?;
+
     let masker = guest_agent::masker::SecretMasker::from_raw("");
     let heartbeat = common::spawn_heartbeat_monitor(async { Ok::<(), AgentError>(()) });
 
     let result = tokio::time::timeout(
         Duration::from_secs(1),
-        guest_agent::cli::execute_cli(
-            &masker,
-            heartbeat,
-            guest_agent::http::HttpClient::for_current_env()?,
-        ),
+        common::execute_cli_for_runtime(&runtime, &masker, heartbeat),
     )
     .await
     .expect("log setup failure should return promptly");

--- a/crates/guest-agent/tests/cli_stderr_exact_limit_no_newline.rs
+++ b/crates/guest-agent/tests/cli_stderr_exact_limit_no_newline.rs
@@ -1,11 +1,10 @@
 //! CLI stderr diagnostics must preserve an exact-limit final line without `\n`.
 //!
-//! This test lives in its own binary because `guest_agent::env` and
-//! `guest_agent::paths` cache values in process-wide `LazyLock`s.
+//! This test lives in its own binary to isolate process env, working directory,
+//! and guest runtime path overrides used during setup.
 
 mod common;
 
-use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
 use std::time::Duration;
 
@@ -26,14 +25,12 @@ async fn cli_failure_keeps_exact_limit_stderr_without_newline()
         )?;
     }
 
+    let runtime = common::guest_runtime_from_process_env()?;
+
     let masker = SecretMasker::from_raw("");
     let cli_result = tokio::time::timeout(
         Duration::from_secs(5),
-        guest_agent::cli::execute_cli(
-            &masker,
-            common::spawn_dummy_heartbeat(),
-            HttpClient::for_current_env()?,
-        ),
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
     )
     .await
     .expect("execute_cli should return promptly")?;

--- a/crates/guest-agent/tests/cli_stderr_invalid_utf8.rs
+++ b/crates/guest-agent/tests/cli_stderr_invalid_utf8.rs
@@ -1,11 +1,10 @@
 //! CLI stderr diagnostics must tolerate invalid UTF-8 bytes.
 //!
-//! This test lives in its own binary because `guest_agent::env` and
-//! `guest_agent::paths` cache values in process-wide `LazyLock`s.
+//! This test lives in its own binary to isolate process env, working directory,
+//! and guest runtime path overrides used during setup.
 
 mod common;
 
-use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
 use std::time::Duration;
 
@@ -18,14 +17,12 @@ async fn cli_failure_decodes_invalid_stderr_lossily() -> Result<(), Box<dyn std:
         common::setup_env(&mock, tmp.path(), "@fail-invalid-utf8", 3, 1)?;
     }
 
+    let runtime = common::guest_runtime_from_process_env()?;
+
     let masker = SecretMasker::from_raw("");
     let cli_result = tokio::time::timeout(
         Duration::from_secs(5),
-        guest_agent::cli::execute_cli(
-            &masker,
-            common::spawn_dummy_heartbeat(),
-            HttpClient::for_current_env()?,
-        ),
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
     )
     .await
     .expect("execute_cli should return promptly")?;

--- a/crates/guest-agent/tests/cli_stderr_invalid_utf8_long.rs
+++ b/crates/guest-agent/tests/cli_stderr_invalid_utf8_long.rs
@@ -1,11 +1,10 @@
 //! CLI stderr diagnostics must bound lossy UTF-8 expansion.
 //!
-//! This test lives in its own binary because `guest_agent::env` and
-//! `guest_agent::paths` cache values in process-wide `LazyLock`s.
+//! This test lives in its own binary to isolate process env, working directory,
+//! and guest runtime path overrides used during setup.
 
 mod common;
 
-use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
 use std::time::Duration;
 
@@ -19,14 +18,12 @@ async fn cli_failure_omits_invalid_stderr_when_lossy_decode_exceeds_limit()
         common::setup_env(&mock, tmp.path(), "@fail-invalid-utf8-long", 3, 1)?;
     }
 
+    let runtime = common::guest_runtime_from_process_env()?;
+
     let masker = SecretMasker::from_raw("");
     let cli_result = tokio::time::timeout(
         Duration::from_secs(5),
-        guest_agent::cli::execute_cli(
-            &masker,
-            common::spawn_dummy_heartbeat(),
-            HttpClient::for_current_env()?,
-        ),
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
     )
     .await
     .expect("execute_cli should return promptly")?;

--- a/crates/guest-agent/tests/cli_stderr_logging.rs
+++ b/crates/guest-agent/tests/cli_stderr_logging.rs
@@ -1,12 +1,11 @@
 //! CLI stderr logging must preserve diagnostics without leaking secrets.
 //!
-//! This test lives in its own binary because `guest_agent::env` and
-//! `guest_agent::paths` cache values in process-wide `LazyLock`s.
+//! This test lives in its own binary to isolate process env, working directory,
+//! and guest runtime path overrides used during setup.
 
 mod common;
 
 use base64::Engine;
-use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
 use std::time::Duration;
 
@@ -78,6 +77,8 @@ async fn cli_failure_stderr_is_masked_in_result() -> Result<(), Box<dyn std::err
         common::setup_env(&mock, tmp.path(), &format!("@fail:{stderr_payload}"), 3, 1)?;
     }
 
+    let runtime = common::guest_runtime_from_process_env()?;
+
     let engine = base64::engine::general_purpose::STANDARD;
     let encoded_secret = engine.encode(secret);
     let encoded_multiline_secret = engine.encode(multiline_secret);
@@ -87,11 +88,7 @@ async fn cli_failure_stderr_is_masked_in_result() -> Result<(), Box<dyn std::err
     ));
     let cli_result = tokio::time::timeout(
         Duration::from_secs(5),
-        guest_agent::cli::execute_cli(
-            &masker,
-            common::spawn_dummy_heartbeat(),
-            HttpClient::for_current_env()?,
-        ),
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
     )
     .await
     .expect("execute_cli should return promptly")?;

--- a/crates/guest-agent/tests/cli_stderr_no_newline.rs
+++ b/crates/guest-agent/tests/cli_stderr_no_newline.rs
@@ -1,11 +1,10 @@
 //! CLI stderr diagnostics must include a final line even without `\n`.
 //!
-//! This test lives in its own binary because `guest_agent::env` and
-//! `guest_agent::paths` cache values in process-wide `LazyLock`s.
+//! This test lives in its own binary to isolate process env, working directory,
+//! and guest runtime path overrides used during setup.
 
 mod common;
 
-use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
 use std::time::Duration;
 
@@ -24,14 +23,12 @@ async fn cli_failure_keeps_stderr_without_newline() -> Result<(), Box<dyn std::e
         )?;
     }
 
+    let runtime = common::guest_runtime_from_process_env()?;
+
     let masker = SecretMasker::from_raw("");
     let cli_result = tokio::time::timeout(
         Duration::from_secs(5),
-        guest_agent::cli::execute_cli(
-            &masker,
-            common::spawn_dummy_heartbeat(),
-            HttpClient::for_current_env()?,
-        ),
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
     )
     .await
     .expect("execute_cli should return promptly")?;

--- a/crates/guest-agent/tests/cli_stderr_overlong_lone_cr_no_newline.rs
+++ b/crates/guest-agent/tests/cli_stderr_overlong_lone_cr_no_newline.rs
@@ -1,11 +1,10 @@
 //! CLI stderr diagnostics must not treat a lone final `\r` as CRLF.
 //!
-//! This test lives in its own binary because `guest_agent::env` and
-//! `guest_agent::paths` cache values in process-wide `LazyLock`s.
+//! This test lives in its own binary to isolate process env, working directory,
+//! and guest runtime path overrides used during setup.
 
 mod common;
 
-use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
 use std::time::Duration;
 
@@ -26,14 +25,12 @@ async fn cli_failure_omits_overlong_stderr_ending_in_lone_cr()
         )?;
     }
 
+    let runtime = common::guest_runtime_from_process_env()?;
+
     let masker = SecretMasker::from_raw("");
     let cli_result = tokio::time::timeout(
         Duration::from_secs(5),
-        guest_agent::cli::execute_cli(
-            &masker,
-            common::spawn_dummy_heartbeat(),
-            HttpClient::for_current_env()?,
-        ),
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
     )
     .await
     .expect("execute_cli should return promptly")?;

--- a/crates/guest-agent/tests/cli_stderr_overlong_no_newline.rs
+++ b/crates/guest-agent/tests/cli_stderr_overlong_no_newline.rs
@@ -1,11 +1,10 @@
 //! CLI stderr diagnostics must omit an overlong final line without `\n`.
 //!
-//! This test lives in its own binary because `guest_agent::env` and
-//! `guest_agent::paths` cache values in process-wide `LazyLock`s.
+//! This test lives in its own binary to isolate process env, working directory,
+//! and guest runtime path overrides used during setup.
 
 mod common;
 
-use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
 use std::time::Duration;
 
@@ -25,14 +24,12 @@ async fn cli_failure_omits_overlong_final_stderr() -> Result<(), Box<dyn std::er
         )?;
     }
 
+    let runtime = common::guest_runtime_from_process_env()?;
+
     let masker = SecretMasker::from_raw("");
     let cli_result = tokio::time::timeout(
         Duration::from_secs(5),
-        guest_agent::cli::execute_cli(
-            &masker,
-            common::spawn_dummy_heartbeat(),
-            HttpClient::for_current_env()?,
-        ),
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
     )
     .await
     .expect("execute_cli should return promptly")?;

--- a/crates/guest-agent/tests/cli_stdin_early_exit.rs
+++ b/crates/guest-agent/tests/cli_stdin_early_exit.rs
@@ -2,7 +2,6 @@
 
 mod common;
 
-use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
 use std::os::unix::fs::PermissionsExt;
 use std::time::Duration;
@@ -24,14 +23,12 @@ async fn claude_exit_before_stdin_read_preserves_stderr() -> Result<(), Box<dyn 
         common::setup_env(&mock, tmp.path(), "prompt written through stdin", 3, 1)?;
     }
 
+    let runtime = common::guest_runtime_from_process_env()?;
+
     let masker = SecretMasker::from_raw("");
     let cli_result = tokio::time::timeout(
         Duration::from_secs(5),
-        guest_agent::cli::execute_cli(
-            &masker,
-            common::spawn_dummy_heartbeat(),
-            HttpClient::for_current_env()?,
-        ),
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
     )
     .await
     .expect("execute_cli should return promptly")?;

--- a/crates/guest-agent/tests/cli_stdin_unread.rs
+++ b/crates/guest-agent/tests/cli_stdin_unread.rs
@@ -2,7 +2,6 @@
 
 mod common;
 
-use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
 use std::os::unix::fs::PermissionsExt;
 use std::time::Duration;
@@ -28,14 +27,12 @@ tail -f /dev/null
         common::setup_env(&mock, tmp.path(), &large_prompt, 1, 1)?;
     }
 
+    let runtime = common::guest_runtime_from_process_env()?;
+
     let masker = SecretMasker::from_raw("");
     let cli_result = tokio::time::timeout(
         Duration::from_secs(5),
-        guest_agent::cli::execute_cli(
-            &masker,
-            common::spawn_dummy_heartbeat(),
-            HttpClient::for_current_env()?,
-        ),
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
     )
     .await
     .expect("execute_cli should not block on unread stdin")?;

--- a/crates/guest-agent/tests/codex_app_server_backend.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend.rs
@@ -27,8 +27,8 @@ async fn codex_app_server_backend_runs_initial_turn_and_synthesizes_thread_start
             },
         )?;
     }
-    let _run_files = common::RunFilesGuard::new();
     let runtime = common::guest_runtime_from_process_env()?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
 
     let masker = SecretMasker::from_raw("");
     let cli_result = tokio::time::timeout(

--- a/crates/guest-agent/tests/codex_app_server_backend.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend.rs
@@ -1,11 +1,10 @@
 //! Integration coverage for the experimental Codex app-server backend.
 //!
-//! This test lives in its own binary because `guest_agent::env` caches values
-//! in process-wide `LazyLock`s.
+//! This test lives in its own binary to isolate process env, working directory,
+//! and guest runtime path overrides used during setup.
 
 mod common;
 
-use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
 use serde_json::Value;
 use std::time::Duration;
@@ -29,15 +28,12 @@ async fn codex_app_server_backend_runs_initial_turn_and_synthesizes_thread_start
         )?;
     }
     let _run_files = common::RunFilesGuard::new();
+    let runtime = common::guest_runtime_from_process_env()?;
 
     let masker = SecretMasker::from_raw("");
     let cli_result = tokio::time::timeout(
         Duration::from_secs(5),
-        guest_agent::cli::execute_cli(
-            &masker,
-            common::spawn_dummy_heartbeat(),
-            HttpClient::for_current_env()?,
-        ),
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
     )
     .await
     .expect("execute_cli should return promptly")?;
@@ -46,7 +42,7 @@ async fn codex_app_server_backend_runs_initial_turn_and_synthesizes_thread_start
     assert!(cli_result.failure_diagnostic.is_none());
     assert!(cli_result.last_event_sequence.is_none());
 
-    let events = read_agent_log_events()?;
+    let events = read_agent_log_events(&runtime.paths)?;
     assert_event_type_sequence(
         &events,
         &[
@@ -61,14 +57,14 @@ async fn codex_app_server_backend_runs_initial_turn_and_synthesizes_thread_start
         .get("thread_id")
         .and_then(Value::as_str)
         .ok_or("thread.started missing thread_id")?;
-    let stored_id = std::fs::read_to_string(guest_agent::paths::session_id_file())?;
+    let stored_id = std::fs::read_to_string(runtime.paths.session_id_file())?;
     assert_eq!(stored_id, thread_id);
-    let marker = std::fs::read_to_string(guest_agent::paths::session_history_path_file())?;
+    let marker = std::fs::read_to_string(runtime.paths.session_history_path_file())?;
     assert!(marker.starts_with("CODEX_SEARCH:"));
     assert!(marker.ends_with(&format!(":{thread_id}")));
     assert_eq!(masker.mask_string(thread_id), "***");
 
-    let session_events = read_codex_session_history_events()?;
+    let session_events = read_codex_session_history_events(&runtime.paths)?;
     let input_event = session_events
         .iter()
         .find(|event| event.get("type").and_then(Value::as_str) == Some("mock.app_server.input"))
@@ -111,17 +107,20 @@ async fn codex_app_server_backend_runs_initial_turn_and_synthesizes_thread_start
     Ok(())
 }
 
-fn read_agent_log_events() -> Result<Vec<Value>, Box<dyn std::error::Error>> {
-    let log = std::fs::read_to_string(guest_agent::paths::agent_log_file())?;
+fn read_agent_log_events(
+    paths: &guest_agent::paths::GuestPaths,
+) -> Result<Vec<Value>, Box<dyn std::error::Error>> {
+    let log = std::fs::read_to_string(paths.agent_log_file())?;
     log.lines()
         .map(|line| serde_json::from_str(line).map_err(Into::into))
         .collect()
 }
 
-fn read_codex_session_history_events() -> Result<Vec<Value>, Box<dyn std::error::Error>> {
-    let history = guest_agent::session_history::read_session_history(
-        guest_agent::paths::session_history_path_file(),
-    )?;
+fn read_codex_session_history_events(
+    paths: &guest_agent::paths::GuestPaths,
+) -> Result<Vec<Value>, Box<dyn std::error::Error>> {
+    let history =
+        guest_agent::session_history::read_session_history(paths.session_history_path_file())?;
     let history = String::from_utf8(history)?;
     history
         .lines()

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input.rs
@@ -28,8 +28,8 @@ async fn codex_app_server_backend_steers_active_input_into_active_turn()
             },
         )?;
     }
-    let _run_files = common::RunFilesGuard::new();
     let runtime = common::guest_runtime_from_process_env()?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
 
     let active_input = ActiveInputRuntime::new_with_initial_prompt(
         &runtime.config.run_id,

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input.rs
@@ -1,12 +1,11 @@
 //! Active-input success coverage for the experimental Codex app-server backend.
 //!
-//! This test lives in its own binary because `guest_agent::env` caches values
-//! in process-wide `LazyLock`s.
+//! This test lives in its own binary to isolate process env, working directory,
+//! and guest runtime path overrides used during setup.
 
 mod common;
 
 use guest_agent::active_input::{ActiveInputControlOutcome, ActiveInputRuntime};
-use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
 use serde_json::Value;
 use std::time::Duration;
@@ -30,11 +29,12 @@ async fn codex_app_server_backend_steers_active_input_into_active_turn()
         )?;
     }
     let _run_files = common::RunFilesGuard::new();
+    let runtime = common::guest_runtime_from_process_env()?;
 
     let active_input = ActiveInputRuntime::new_with_initial_prompt(
-        guest_agent::env::run_id(),
+        &runtime.config.run_id,
         true,
-        guest_agent::env::prompt(),
+        &runtime.config.prompt,
     );
     let controller = active_input.controller();
     let payload = common::active_input_payload("follow-up prompt")?;
@@ -51,10 +51,10 @@ async fn codex_app_server_backend_steers_active_input_into_active_turn()
     let masker = SecretMasker::from_raw("");
     let cli_result = tokio::time::timeout(
         Duration::from_secs(5),
-        guest_agent::cli::execute_cli_with_active_input(
+        common::execute_cli_with_active_input_for_runtime(
+            &runtime,
             &masker,
             common::spawn_dummy_heartbeat(),
-            HttpClient::for_current_env()?,
             active_input.into_writer(),
         ),
     )
@@ -64,7 +64,7 @@ async fn codex_app_server_backend_steers_active_input_into_active_turn()
     assert_eq!(cli_result.exit_code, common::CLEAN_EXIT);
     assert!(cli_result.failure_diagnostic.is_none());
 
-    let input_events = common::read_codex_session_history_events()?
+    let input_events = common::read_codex_session_history_events_for_paths(&runtime.paths)?
         .into_iter()
         .filter(|event| event.get("type").and_then(Value::as_str) == Some("mock.app_server.input"))
         .collect::<Vec<_>>();

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_after_completion.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_after_completion.rs
@@ -27,8 +27,8 @@ async fn codex_app_server_backend_rejects_active_input_after_turn_completion()
             },
         )?;
     }
-    let _run_files = common::RunFilesGuard::new();
     let runtime = common::guest_runtime_from_process_env()?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
 
     let active_input = ActiveInputRuntime::new_with_initial_prompt(
         &runtime.config.run_id,

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_after_completion.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_after_completion.rs
@@ -1,12 +1,11 @@
 //! Late active-input coverage for the experimental Codex app-server backend.
 //!
-//! This test lives in its own binary because `guest_agent::env` caches values
-//! in process-wide `LazyLock`s.
+//! This test lives in its own binary to isolate process env, working directory,
+//! and guest runtime path overrides used during setup.
 
 mod common;
 
 use guest_agent::active_input::{ActiveInputControlOutcome, ActiveInputRuntime};
-use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
 use std::time::Duration;
 
@@ -29,21 +28,22 @@ async fn codex_app_server_backend_rejects_active_input_after_turn_completion()
         )?;
     }
     let _run_files = common::RunFilesGuard::new();
+    let runtime = common::guest_runtime_from_process_env()?;
 
     let active_input = ActiveInputRuntime::new_with_initial_prompt(
-        guest_agent::env::run_id(),
+        &runtime.config.run_id,
         true,
-        guest_agent::env::prompt(),
+        &runtime.config.prompt,
     );
     let controller = active_input.controller();
 
     let masker = SecretMasker::from_raw("");
     let cli_result = tokio::time::timeout(
         Duration::from_secs(5),
-        guest_agent::cli::execute_cli_with_active_input(
+        common::execute_cli_with_active_input_for_runtime(
+            &runtime,
             &masker,
             common::spawn_dummy_heartbeat(),
-            HttpClient::for_current_env()?,
             active_input.into_writer(),
         ),
     )

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_before_buffered_completion.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_before_buffered_completion.rs
@@ -28,8 +28,8 @@ async fn codex_app_server_backend_steers_accepted_input_before_buffered_completi
             },
         )?;
     }
-    let _run_files = common::RunFilesGuard::new();
     let runtime = common::guest_runtime_from_process_env()?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
 
     let active_input = ActiveInputRuntime::new_with_initial_prompt(
         &runtime.config.run_id,

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_before_buffered_completion.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_before_buffered_completion.rs
@@ -1,12 +1,11 @@
 //! Active-input ordering coverage for the experimental Codex app-server backend.
 //!
-//! This test lives in its own binary because `guest_agent::env` caches values
-//! in process-wide `LazyLock`s.
+//! This test lives in its own binary to isolate process env, working directory,
+//! and guest runtime path overrides used during setup.
 
 mod common;
 
 use guest_agent::active_input::{ActiveInputControlOutcome, ActiveInputRuntime};
-use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
 use serde_json::Value;
 use std::time::Duration;
@@ -30,11 +29,12 @@ async fn codex_app_server_backend_steers_accepted_input_before_buffered_completi
         )?;
     }
     let _run_files = common::RunFilesGuard::new();
+    let runtime = common::guest_runtime_from_process_env()?;
 
     let active_input = ActiveInputRuntime::new_with_initial_prompt(
-        guest_agent::env::run_id(),
+        &runtime.config.run_id,
         true,
-        guest_agent::env::prompt(),
+        &runtime.config.prompt,
     );
     let payload = common::active_input_payload("follow-up before buffered completion")?;
     assert_eq!(
@@ -47,10 +47,10 @@ async fn codex_app_server_backend_steers_accepted_input_before_buffered_completi
     let masker = SecretMasker::from_raw("");
     let cli_result = tokio::time::timeout(
         Duration::from_secs(5),
-        guest_agent::cli::execute_cli_with_active_input(
+        common::execute_cli_with_active_input_for_runtime(
+            &runtime,
             &masker,
             common::spawn_dummy_heartbeat(),
-            HttpClient::for_current_env()?,
             active_input.into_writer(),
         ),
     )
@@ -59,7 +59,7 @@ async fn codex_app_server_backend_steers_accepted_input_before_buffered_completi
 
     assert_eq!(cli_result.exit_code, common::CLEAN_EXIT);
 
-    let input_events = common::read_codex_session_history_events()?
+    let input_events = common::read_codex_session_history_events_for_paths(&runtime.paths)?
         .into_iter()
         .filter(|event| event.get("type").and_then(Value::as_str) == Some("mock.app_server.input"))
         .collect::<Vec<_>>();

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_child_exit.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_child_exit.rs
@@ -1,12 +1,11 @@
 //! Active-input child-exit coverage for the experimental Codex app-server backend.
 //!
-//! This test lives in its own binary because `guest_agent::env` caches values
-//! in process-wide `LazyLock`s.
+//! This test lives in its own binary to isolate process env, working directory,
+//! and guest runtime path overrides used during setup.
 
 mod common;
 
 use guest_agent::active_input::{ActiveInputControlOutcome, ActiveInputRuntime};
-use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
 use std::time::Duration;
 
@@ -29,11 +28,12 @@ async fn codex_app_server_backend_fails_visible_when_child_exits_during_steer()
         )?;
     }
     let _run_files = common::RunFilesGuard::new();
+    let runtime = common::guest_runtime_from_process_env()?;
 
     let active_input = ActiveInputRuntime::new_with_initial_prompt(
-        guest_agent::env::run_id(),
+        &runtime.config.run_id,
         true,
-        guest_agent::env::prompt(),
+        &runtime.config.prompt,
     );
     let payload = common::active_input_payload("child-exit follow-up prompt")?;
     assert_eq!(
@@ -46,10 +46,10 @@ async fn codex_app_server_backend_fails_visible_when_child_exits_during_steer()
     let masker = SecretMasker::from_raw("");
     let result = tokio::time::timeout(
         Duration::from_secs(5),
-        guest_agent::cli::execute_cli_with_active_input(
+        common::execute_cli_with_active_input_for_runtime(
+            &runtime,
             &masker,
             common::spawn_dummy_heartbeat(),
-            HttpClient::for_current_env()?,
             active_input.into_writer(),
         ),
     )

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_child_exit.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_child_exit.rs
@@ -27,8 +27,8 @@ async fn codex_app_server_backend_fails_visible_when_child_exits_during_steer()
             },
         )?;
     }
-    let _run_files = common::RunFilesGuard::new();
     let runtime = common::guest_runtime_from_process_env()?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
 
     let active_input = ActiveInputRuntime::new_with_initial_prompt(
         &runtime.config.run_id,

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_no_turn.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_no_turn.rs
@@ -27,8 +27,8 @@ async fn codex_app_server_backend_fails_visible_when_no_active_turn()
             },
         )?;
     }
-    let _run_files = common::RunFilesGuard::new();
     let runtime = common::guest_runtime_from_process_env()?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
 
     let active_input = ActiveInputRuntime::new_with_initial_prompt(
         &runtime.config.run_id,

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_no_turn.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_no_turn.rs
@@ -1,12 +1,11 @@
 //! No-active-turn coverage for the experimental Codex app-server backend.
 //!
-//! This test lives in its own binary because `guest_agent::env` caches values
-//! in process-wide `LazyLock`s.
+//! This test lives in its own binary to isolate process env, working directory,
+//! and guest runtime path overrides used during setup.
 
 mod common;
 
 use guest_agent::active_input::{ActiveInputControlOutcome, ActiveInputRuntime};
-use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
 use std::time::Duration;
 
@@ -29,11 +28,12 @@ async fn codex_app_server_backend_fails_visible_when_no_active_turn()
         )?;
     }
     let _run_files = common::RunFilesGuard::new();
+    let runtime = common::guest_runtime_from_process_env()?;
 
     let active_input = ActiveInputRuntime::new_with_initial_prompt(
-        guest_agent::env::run_id(),
+        &runtime.config.run_id,
         true,
-        guest_agent::env::prompt(),
+        &runtime.config.prompt,
     );
     let payload = common::active_input_payload("no-active-turn follow-up prompt")?;
     assert_eq!(
@@ -46,10 +46,10 @@ async fn codex_app_server_backend_fails_visible_when_no_active_turn()
     let masker = SecretMasker::from_raw("");
     let result = tokio::time::timeout(
         Duration::from_secs(5),
-        guest_agent::cli::execute_cli_with_active_input(
+        common::execute_cli_with_active_input_for_runtime(
+            &runtime,
             &masker,
             common::spawn_dummy_heartbeat(),
-            HttpClient::for_current_env()?,
             active_input.into_writer(),
         ),
     )

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_queued_terminal.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_queued_terminal.rs
@@ -28,8 +28,8 @@ async fn codex_app_server_backend_closes_input_before_ingesting_queued_terminal(
             },
         )?;
     }
-    let _run_files = common::RunFilesGuard::new();
     let runtime = common::guest_runtime_from_process_env()?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
 
     let active_input = ActiveInputRuntime::new_with_initial_prompt(
         &runtime.config.run_id,

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_queued_terminal.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_queued_terminal.rs
@@ -1,12 +1,11 @@
 //! Queued-terminal active-input coverage for the experimental Codex app-server backend.
 //!
-//! This test lives in its own binary because `guest_agent::env` caches values
-//! in process-wide `LazyLock`s.
+//! This test lives in its own binary to isolate process env, working directory,
+//! and guest runtime path overrides used during setup.
 
 mod common;
 
 use guest_agent::active_input::{ActiveInputControlOutcome, ActiveInputRuntime};
-use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
 use serde_json::Value;
 use std::time::Duration;
@@ -30,11 +29,12 @@ async fn codex_app_server_backend_closes_input_before_ingesting_queued_terminal(
         )?;
     }
     let _run_files = common::RunFilesGuard::new();
+    let runtime = common::guest_runtime_from_process_env()?;
 
     let active_input = ActiveInputRuntime::new_with_initial_prompt(
-        guest_agent::env::run_id(),
+        &runtime.config.run_id,
         true,
-        guest_agent::env::prompt(),
+        &runtime.config.prompt,
     );
     let payload = common::active_input_payload("follow-up before queued terminal")?;
     assert_eq!(
@@ -47,10 +47,10 @@ async fn codex_app_server_backend_closes_input_before_ingesting_queued_terminal(
     let masker = SecretMasker::from_raw("");
     let cli_result = tokio::time::timeout(
         Duration::from_secs(5),
-        guest_agent::cli::execute_cli_with_active_input(
+        common::execute_cli_with_active_input_for_runtime(
+            &runtime,
             &masker,
             common::spawn_dummy_heartbeat(),
-            HttpClient::for_current_env()?,
             active_input.into_writer(),
         ),
     )
@@ -59,7 +59,7 @@ async fn codex_app_server_backend_closes_input_before_ingesting_queued_terminal(
 
     assert_eq!(cli_result.exit_code, common::CLEAN_EXIT);
 
-    let input_events = common::read_codex_session_history_events()?
+    let input_events = common::read_codex_session_history_events_for_paths(&runtime.paths)?
         .into_iter()
         .filter(|event| event.get("type").and_then(Value::as_str) == Some("mock.app_server.input"))
         .collect::<Vec<_>>();

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_stale.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_stale.rs
@@ -1,12 +1,11 @@
 //! Stale-turn active-input coverage for the experimental Codex app-server backend.
 //!
-//! This test lives in its own binary because `guest_agent::env` caches values
-//! in process-wide `LazyLock`s.
+//! This test lives in its own binary to isolate process env, working directory,
+//! and guest runtime path overrides used during setup.
 
 mod common;
 
 use guest_agent::active_input::{ActiveInputControlOutcome, ActiveInputRuntime};
-use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
 use serde_json::Value;
 use std::time::Duration;
@@ -30,11 +29,12 @@ async fn codex_app_server_backend_fails_visible_on_stale_active_turn()
         )?;
     }
     let _run_files = common::RunFilesGuard::new();
+    let runtime = common::guest_runtime_from_process_env()?;
 
     let active_input = ActiveInputRuntime::new_with_initial_prompt(
-        guest_agent::env::run_id(),
+        &runtime.config.run_id,
         true,
-        guest_agent::env::prompt(),
+        &runtime.config.prompt,
     );
     let payload = common::active_input_payload("stale follow-up prompt")?;
     assert_eq!(
@@ -47,10 +47,10 @@ async fn codex_app_server_backend_fails_visible_on_stale_active_turn()
     let masker = SecretMasker::from_raw("");
     let result = tokio::time::timeout(
         Duration::from_secs(5),
-        guest_agent::cli::execute_cli_with_active_input(
+        common::execute_cli_with_active_input_for_runtime(
+            &runtime,
             &masker,
             common::spawn_dummy_heartbeat(),
-            HttpClient::for_current_env()?,
             active_input.into_writer(),
         ),
     )
@@ -64,7 +64,7 @@ async fn codex_app_server_backend_fails_visible_on_stale_active_turn()
         "unexpected error: {message}"
     );
 
-    let input_events = common::read_codex_session_history_events()?
+    let input_events = common::read_codex_session_history_events_for_paths(&runtime.paths)?
         .into_iter()
         .filter(|event| event.get("type").and_then(Value::as_str) == Some("mock.app_server.input"))
         .collect::<Vec<_>>();

--- a/crates/guest-agent/tests/codex_app_server_backend_active_input_stale.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_active_input_stale.rs
@@ -28,8 +28,8 @@ async fn codex_app_server_backend_fails_visible_on_stale_active_turn()
             },
         )?;
     }
-    let _run_files = common::RunFilesGuard::new();
     let runtime = common::guest_runtime_from_process_env()?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
 
     let active_input = ActiveInputRuntime::new_with_initial_prompt(
         &runtime.config.run_id,

--- a/crates/guest-agent/tests/codex_app_server_backend_child_env.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_child_env.rs
@@ -1,7 +1,7 @@
 //! Child-env snapshot coverage for the experimental Codex app-server backend.
 //!
-//! This test lives in its own binary because `guest_agent::env` caches values
-//! in process-wide `LazyLock`s.
+//! This test lives in its own binary to isolate process env, working directory,
+//! and guest runtime path overrides used during setup.
 
 mod common;
 

--- a/crates/guest-agent/tests/codex_app_server_backend_error_masking.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_error_masking.rs
@@ -28,8 +28,8 @@ async fn codex_app_server_backend_masks_resume_id_in_rpc_errors()
             },
         )?;
     }
-    let _run_files = common::RunFilesGuard::new();
     let runtime = common::guest_runtime_from_process_env()?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
 
     let masker = SecretMasker::from_raw("");
     let result = tokio::time::timeout(

--- a/crates/guest-agent/tests/codex_app_server_backend_error_masking.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_error_masking.rs
@@ -1,11 +1,10 @@
 //! Error masking coverage for the experimental Codex app-server backend.
 //!
-//! This test lives in its own binary because `guest_agent::env` caches values
-//! in process-wide `LazyLock`s.
+//! This test lives in its own binary to isolate process env, working directory,
+//! and guest runtime path overrides used during setup.
 
 mod common;
 
-use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
 use std::time::Duration;
 
@@ -30,15 +29,12 @@ async fn codex_app_server_backend_masks_resume_id_in_rpc_errors()
         )?;
     }
     let _run_files = common::RunFilesGuard::new();
+    let runtime = common::guest_runtime_from_process_env()?;
 
     let masker = SecretMasker::from_raw("");
     let result = tokio::time::timeout(
         Duration::from_secs(5),
-        guest_agent::cli::execute_cli(
-            &masker,
-            common::spawn_dummy_heartbeat(),
-            HttpClient::for_current_env()?,
-        ),
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
     )
     .await
     .expect("execute_cli should return promptly");

--- a/crates/guest-agent/tests/codex_app_server_backend_failure.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_failure.rs
@@ -1,11 +1,10 @@
 //! Failure-path integration coverage for the experimental Codex app-server backend.
 //!
-//! This test lives in its own binary because `guest_agent::env` caches values
-//! in process-wide `LazyLock`s.
+//! This test lives in its own binary to isolate process env, working directory,
+//! and guest runtime path overrides used during setup.
 
 mod common;
 
-use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
 use std::time::Duration;
 
@@ -28,15 +27,12 @@ async fn codex_app_server_backend_child_exit_before_turn_response_fails_promptly
         )?;
     }
     let _run_files = common::RunFilesGuard::new();
+    let runtime = common::guest_runtime_from_process_env()?;
 
     let masker = SecretMasker::from_raw("");
     let result = tokio::time::timeout(
         Duration::from_secs(5),
-        guest_agent::cli::execute_cli(
-            &masker,
-            common::spawn_dummy_heartbeat(),
-            HttpClient::for_current_env()?,
-        ),
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
     )
     .await
     .expect("execute_cli should return promptly");

--- a/crates/guest-agent/tests/codex_app_server_backend_failure.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_failure.rs
@@ -26,8 +26,8 @@ async fn codex_app_server_backend_child_exit_before_turn_response_fails_promptly
             },
         )?;
     }
-    let _run_files = common::RunFilesGuard::new();
     let runtime = common::guest_runtime_from_process_env()?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
 
     let masker = SecretMasker::from_raw("");
     let result = tokio::time::timeout(

--- a/crates/guest-agent/tests/codex_app_server_backend_heartbeat.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_heartbeat.rs
@@ -28,8 +28,8 @@ async fn codex_app_server_backend_heartbeat_interrupts_hung_turn_start()
             },
         )?;
     }
-    let _run_files = common::RunFilesGuard::new();
     let runtime = common::guest_runtime_from_process_env()?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
     let session_id_path = PathBuf::from(runtime.paths.session_id_file());
     if let Some(parent) = session_id_path.parent() {
         std::fs::create_dir_all(parent)?;

--- a/crates/guest-agent/tests/codex_app_server_backend_heartbeat.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_heartbeat.rs
@@ -1,12 +1,11 @@
 //! Heartbeat race coverage for the experimental Codex app-server backend.
 //!
-//! This test lives in its own binary because `guest_agent::env` caches values
-//! in process-wide `LazyLock`s.
+//! This test lives in its own binary to isolate process env, working directory,
+//! and guest runtime path overrides used during setup.
 
 mod common;
 
 use guest_agent::error::AgentError;
-use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
 use std::path::PathBuf;
 use std::time::Duration;
@@ -30,7 +29,8 @@ async fn codex_app_server_backend_heartbeat_interrupts_hung_turn_start()
         )?;
     }
     let _run_files = common::RunFilesGuard::new();
-    let session_id_path = PathBuf::from(guest_agent::paths::session_id_file());
+    let runtime = common::guest_runtime_from_process_env()?;
+    let session_id_path = PathBuf::from(runtime.paths.session_id_file());
     if let Some(parent) = session_id_path.parent() {
         std::fs::create_dir_all(parent)?;
     }
@@ -48,7 +48,7 @@ async fn codex_app_server_backend_heartbeat_interrupts_hung_turn_start()
     let masker = SecretMasker::from_raw("");
     let result = tokio::time::timeout(
         Duration::from_millis(1500),
-        guest_agent::cli::execute_cli(&masker, heartbeat, HttpClient::for_current_env()?),
+        common::execute_cli_for_runtime(&runtime, &masker, heartbeat),
     )
     .await
     .expect("execute_cli should return promptly");

--- a/crates/guest-agent/tests/codex_app_server_backend_invalid_resume_id.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_invalid_resume_id.rs
@@ -1,11 +1,10 @@
 //! Resume id validation for the experimental Codex app-server backend.
 //!
-//! This test lives in its own binary because `guest_agent::env` caches values
-//! in process-wide `LazyLock`s.
+//! This test lives in its own binary to isolate process env, working directory,
+//! and guest runtime path overrides used during setup.
 
 mod common;
 
-use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
 use std::time::Duration;
 
@@ -28,15 +27,12 @@ async fn codex_app_server_backend_rejects_invalid_resume_id_before_spawn()
         )?;
     }
     let _run_files = common::RunFilesGuard::new();
+    let runtime = common::guest_runtime_from_process_env()?;
 
     let masker = SecretMasker::from_raw("");
     let result = tokio::time::timeout(
         Duration::from_secs(5),
-        guest_agent::cli::execute_cli(
-            &masker,
-            common::spawn_dummy_heartbeat(),
-            HttpClient::for_current_env()?,
-        ),
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
     )
     .await
     .expect("execute_cli should return promptly");
@@ -51,7 +47,7 @@ async fn codex_app_server_backend_rejects_invalid_resume_id_before_spawn()
         !message.contains("failed to spawn codex app-server"),
         "invalid resume id should fail before app-server spawn: {message}"
     );
-    let session_id_path = guest_agent::paths::session_id_file();
+    let session_id_path = runtime.paths.session_id_file();
     assert!(
         !std::path::Path::new(session_id_path).exists(),
         "invalid resume id should not write a session id"

--- a/crates/guest-agent/tests/codex_app_server_backend_invalid_resume_id.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_invalid_resume_id.rs
@@ -26,8 +26,8 @@ async fn codex_app_server_backend_rejects_invalid_resume_id_before_spawn()
             },
         )?;
     }
-    let _run_files = common::RunFilesGuard::new();
     let runtime = common::guest_runtime_from_process_env()?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
 
     let masker = SecretMasker::from_raw("");
     let result = tokio::time::timeout(

--- a/crates/guest-agent/tests/codex_app_server_backend_invalid_thread_id.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_invalid_thread_id.rs
@@ -1,11 +1,10 @@
 //! Thread identity validation for the experimental Codex app-server backend.
 //!
-//! This test lives in its own binary because `guest_agent::env` caches values
-//! in process-wide `LazyLock`s.
+//! This test lives in its own binary to isolate process env, working directory,
+//! and guest runtime path overrides used during setup.
 
 mod common;
 
-use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
 use std::time::Duration;
 
@@ -28,15 +27,12 @@ async fn codex_app_server_backend_rejects_invalid_thread_start_id()
         )?;
     }
     let _run_files = common::RunFilesGuard::new();
+    let runtime = common::guest_runtime_from_process_env()?;
 
     let masker = SecretMasker::from_raw("");
     let result = tokio::time::timeout(
         Duration::from_secs(5),
-        guest_agent::cli::execute_cli(
-            &masker,
-            common::spawn_dummy_heartbeat(),
-            HttpClient::for_current_env()?,
-        ),
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
     )
     .await
     .expect("execute_cli should return promptly");
@@ -47,7 +43,7 @@ async fn codex_app_server_backend_rejects_invalid_thread_start_id()
         message.contains("thread response returned an invalid Codex thread id"),
         "unexpected error: {message}"
     );
-    let session_id_path = guest_agent::paths::session_id_file();
+    let session_id_path = runtime.paths.session_id_file();
     assert!(
         !std::path::Path::new(session_id_path).exists(),
         "invalid thread response should not write a session id"

--- a/crates/guest-agent/tests/codex_app_server_backend_invalid_thread_id.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_invalid_thread_id.rs
@@ -26,8 +26,8 @@ async fn codex_app_server_backend_rejects_invalid_thread_start_id()
             },
         )?;
     }
-    let _run_files = common::RunFilesGuard::new();
     let runtime = common::guest_runtime_from_process_env()?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
 
     let masker = SecretMasker::from_raw("");
     let result = tokio::time::timeout(

--- a/crates/guest-agent/tests/codex_app_server_backend_resume.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_resume.rs
@@ -29,8 +29,8 @@ async fn codex_app_server_backend_resumes_existing_thread_id()
             },
         )?;
     }
-    let _run_files = common::RunFilesGuard::new();
     let runtime = common::guest_runtime_from_process_env()?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
 
     let masker = SecretMasker::from_raw("");
     let cli_result = tokio::time::timeout(

--- a/crates/guest-agent/tests/codex_app_server_backend_resume.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_resume.rs
@@ -1,11 +1,10 @@
 //! Resume-path integration coverage for the experimental Codex app-server backend.
 //!
 //! This is separate from `codex_app_server_backend.rs` because `guest_agent::env`
-//! caches `VM0_RESUME_SESSION_ID` in a process-wide `LazyLock`.
+//! uses resume-session process env setup that must stay isolated.
 
 mod common;
 
-use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
 use serde_json::Value;
 use std::time::Duration;
@@ -31,15 +30,12 @@ async fn codex_app_server_backend_resumes_existing_thread_id()
         )?;
     }
     let _run_files = common::RunFilesGuard::new();
+    let runtime = common::guest_runtime_from_process_env()?;
 
     let masker = SecretMasker::from_raw("");
     let cli_result = tokio::time::timeout(
         Duration::from_secs(5),
-        guest_agent::cli::execute_cli(
-            &masker,
-            common::spawn_dummy_heartbeat(),
-            HttpClient::for_current_env()?,
-        ),
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
     )
     .await
     .expect("execute_cli should return promptly")?;
@@ -47,7 +43,7 @@ async fn codex_app_server_backend_resumes_existing_thread_id()
     assert_eq!(cli_result.exit_code, common::CLEAN_EXIT);
     assert!(cli_result.failure_diagnostic.is_none());
 
-    let events = read_agent_log_events()?;
+    let events = read_agent_log_events(&runtime.paths)?;
     assert_eq!(
         events[0].get("type").and_then(Value::as_str),
         Some("thread.started")
@@ -57,16 +53,18 @@ async fn codex_app_server_backend_resumes_existing_thread_id()
         Some(canonical_resume_thread_id)
     );
 
-    let stored_id = std::fs::read_to_string(guest_agent::paths::session_id_file())?;
+    let stored_id = std::fs::read_to_string(runtime.paths.session_id_file())?;
     assert_eq!(stored_id, canonical_resume_thread_id);
-    let marker = std::fs::read_to_string(guest_agent::paths::session_history_path_file())?;
+    let marker = std::fs::read_to_string(runtime.paths.session_history_path_file())?;
     assert!(marker.ends_with(&format!(":{canonical_resume_thread_id}")));
 
     Ok(())
 }
 
-fn read_agent_log_events() -> Result<Vec<Value>, Box<dyn std::error::Error>> {
-    let log = std::fs::read_to_string(guest_agent::paths::agent_log_file())?;
+fn read_agent_log_events(
+    paths: &guest_agent::paths::GuestPaths,
+) -> Result<Vec<Value>, Box<dyn std::error::Error>> {
+    let log = std::fs::read_to_string(paths.agent_log_file())?;
     log.lines()
         .map(|line| serde_json::from_str(line).map_err(Into::into))
         .collect()

--- a/crates/guest-agent/tests/codex_app_server_backend_resume_mismatch.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_resume_mismatch.rs
@@ -27,8 +27,8 @@ async fn codex_app_server_backend_rejects_mismatched_resume_thread_id()
             },
         )?;
     }
-    let _run_files = common::RunFilesGuard::new();
     let runtime = common::guest_runtime_from_process_env()?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
 
     let masker = SecretMasker::from_raw("");
     let result = tokio::time::timeout(

--- a/crates/guest-agent/tests/codex_app_server_backend_resume_mismatch.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_resume_mismatch.rs
@@ -1,11 +1,10 @@
 //! Resume response validation for the experimental Codex app-server backend.
 //!
-//! This test lives in its own binary because `guest_agent::env` caches values
-//! in process-wide `LazyLock`s.
+//! This test lives in its own binary to isolate process env, working directory,
+//! and guest runtime path overrides used during setup.
 
 mod common;
 
-use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
 use std::time::Duration;
 
@@ -29,15 +28,12 @@ async fn codex_app_server_backend_rejects_mismatched_resume_thread_id()
         )?;
     }
     let _run_files = common::RunFilesGuard::new();
+    let runtime = common::guest_runtime_from_process_env()?;
 
     let masker = SecretMasker::from_raw("");
     let result = tokio::time::timeout(
         Duration::from_secs(5),
-        guest_agent::cli::execute_cli(
-            &masker,
-            common::spawn_dummy_heartbeat(),
-            HttpClient::for_current_env()?,
-        ),
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
     )
     .await
     .expect("execute_cli should return promptly");
@@ -48,7 +44,7 @@ async fn codex_app_server_backend_rejects_mismatched_resume_thread_id()
         message.contains("thread/resume returned a different thread id"),
         "unexpected error: {message}"
     );
-    let session_id_path = guest_agent::paths::session_id_file();
+    let session_id_path = runtime.paths.session_id_file();
     assert!(
         !std::path::Path::new(session_id_path).exists(),
         "mismatched resume response should not write a session id"

--- a/crates/guest-agent/tests/codex_app_server_backend_scope.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_scope.rs
@@ -27,8 +27,8 @@ async fn codex_app_server_backend_rejects_unexpected_thread_event_scope()
             },
         )?;
     }
-    let _run_files = common::RunFilesGuard::new();
     let runtime = common::guest_runtime_from_process_env()?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
 
     let masker = SecretMasker::from_raw("");
     let result = tokio::time::timeout(

--- a/crates/guest-agent/tests/codex_app_server_backend_scope.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_scope.rs
@@ -1,11 +1,10 @@
 //! Scope validation coverage for the experimental Codex app-server backend.
 //!
-//! This test lives in its own binary because `guest_agent::env` caches values
-//! in process-wide `LazyLock`s.
+//! This test lives in its own binary to isolate process env, working directory,
+//! and guest runtime path overrides used during setup.
 
 mod common;
 
-use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
 use serde_json::Value;
 use std::time::Duration;
@@ -29,15 +28,12 @@ async fn codex_app_server_backend_rejects_unexpected_thread_event_scope()
         )?;
     }
     let _run_files = common::RunFilesGuard::new();
+    let runtime = common::guest_runtime_from_process_env()?;
 
     let masker = SecretMasker::from_raw("");
     let result = tokio::time::timeout(
         Duration::from_secs(5),
-        guest_agent::cli::execute_cli(
-            &masker,
-            common::spawn_dummy_heartbeat(),
-            HttpClient::for_current_env()?,
-        ),
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
     )
     .await
     .expect("execute_cli should return promptly");
@@ -49,7 +45,7 @@ async fn codex_app_server_backend_rejects_unexpected_thread_event_scope()
         "unexpected error: {message}"
     );
 
-    let events = read_agent_log_events()?;
+    let events = read_agent_log_events(&runtime.paths)?;
     assert!(
         events.iter().all(|event| {
             event.get("thread_id").and_then(Value::as_str) != Some("unexpected-thread-id")
@@ -60,8 +56,10 @@ async fn codex_app_server_backend_rejects_unexpected_thread_event_scope()
     Ok(())
 }
 
-fn read_agent_log_events() -> Result<Vec<Value>, Box<dyn std::error::Error>> {
-    let log = std::fs::read_to_string(guest_agent::paths::agent_log_file())?;
+fn read_agent_log_events(
+    paths: &guest_agent::paths::GuestPaths,
+) -> Result<Vec<Value>, Box<dyn std::error::Error>> {
+    let log = std::fs::read_to_string(paths.agent_log_file())?;
     log.lines()
         .map(|line| serde_json::from_str(line).map_err(Into::into))
         .collect()

--- a/crates/guest-agent/tests/codex_jsonl_failure_logging.rs
+++ b/crates/guest-agent/tests/codex_jsonl_failure_logging.rs
@@ -86,6 +86,7 @@ unsafe fn setup_codex_env(
     fixture_name: &str,
 ) -> Result<(), String> {
     unsafe {
+        common::clear_guest_agent_bootstrap_env_for_test();
         std::env::set_var("CLI_AGENT_TYPE", "codex");
         std::env::set_var("VM0_MOCK_CODEX_PATH", mock_path);
         std::env::set_var("USE_MOCK_CODEX", "true");
@@ -105,7 +106,6 @@ unsafe fn setup_codex_env(
         std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");
         std::env::set_var("VM0_SANDBOX_REUSE_RESULT", "reused");
         std::env::set_var("HOME", workdir);
-        std::env::remove_var(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV);
     }
     std::fs::create_dir_all(workdir).map_err(|e| format!("create workdir: {e}"))?;
     common::ensure_canonical_workspace_for_test()?;

--- a/crates/guest-agent/tests/codex_jsonl_failure_logging.rs
+++ b/crates/guest-agent/tests/codex_jsonl_failure_logging.rs
@@ -105,6 +105,7 @@ unsafe fn setup_codex_env(
         std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");
         std::env::set_var("VM0_SANDBOX_REUSE_RESULT", "reused");
         std::env::set_var("HOME", workdir);
+        std::env::remove_var(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV);
     }
     std::fs::create_dir_all(workdir).map_err(|e| format!("create workdir: {e}"))?;
     common::ensure_canonical_workspace_for_test()?;

--- a/crates/guest-agent/tests/codex_jsonl_failure_logging.rs
+++ b/crates/guest-agent/tests/codex_jsonl_failure_logging.rs
@@ -1,12 +1,11 @@
 //! Codex stdout JSONL failure events should be visible in the system log.
 //!
-//! This test lives in its own binary because `guest_agent::env` caches
-//! environment values in process-wide `LazyLock`s.
+//! This test lives in its own binary to isolate process env, working directory,
+//! and guest runtime path overrides used during setup.
 
 mod common;
 
 use common::SystemLogOverrideGuard;
-use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
 use guest_contracts::diagnostics::{FailureDetailSource, FailureReason};
 use std::path::Path;
@@ -22,15 +21,12 @@ async fn codex_jsonl_failure_events_are_reported() -> Result<(), Box<dyn std::er
         setup_codex_env(&mock, tmp.path(), "error-event")?;
     }
 
+    let runtime = common::guest_runtime_from_process_env()?;
     let _system_log = SystemLogOverrideGuard::set(&system_log_path);
     let masker = SecretMasker::from_raw("");
     let cli_result = tokio::time::timeout(
         Duration::from_secs(5),
-        guest_agent::cli::execute_cli(
-            &masker,
-            common::spawn_dummy_heartbeat(),
-            HttpClient::for_current_env()?,
-        ),
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
     )
     .await
     .expect("execute_cli should return promptly")?;
@@ -64,11 +60,7 @@ async fn codex_jsonl_failure_events_are_reported() -> Result<(), Box<dyn std::er
 
     let cli_result = tokio::time::timeout(
         Duration::from_secs(5),
-        guest_agent::cli::execute_cli(
-            &masker,
-            common::spawn_dummy_heartbeat(),
-            HttpClient::for_current_env()?,
-        ),
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
     )
     .await
     .expect("execute_cli should return promptly")?;

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -41,6 +41,7 @@ fn setup_env_once() {
         // body has read `guest_agent::env::*`. No other thread is
         // touching the env at this point.
         unsafe {
+            common::clear_guest_agent_bootstrap_env_for_test();
             std::env::set_var("CLI_AGENT_TYPE", "codex");
             // Empty API token → `send_event` skips the HTTP POST after
             // running session-id extraction (which is the part we want
@@ -54,7 +55,6 @@ fn setup_env_once() {
             // `home_dir` is loaded eagerly via `expect`. The marker
             // payload embeds it, so set a stable dummy.
             std::env::set_var("HOME", "/tmp/codex-resume-home");
-            std::env::remove_var(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV);
         }
     });
 }

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -12,7 +12,7 @@
 //!
 //! Each test still serialises behind a `std::sync::Mutex` because they share
 //! that single set of LazyLocks and because they touch the same on-disk
-//! session-id / history-path files (run-id-scoped under `/tmp`).
+//! session-id / history-path files.
 //!
 //! # Coverage
 //!
@@ -52,9 +52,12 @@ fn setup_env_once() {
             std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");
             std::env::set_var("VM0_SANDBOX_REUSE_RESULT", "reused");
             std::env::set_var("VM0_PROMPT", "test prompt");
-            // `home_dir` is loaded eagerly via `expect`. The marker
-            // payload embeds it, so set a stable dummy.
-            std::env::set_var("HOME", "/tmp/codex-resume-home");
+            // `home_dir` is loaded eagerly via `expect`. Keep it stable within
+            // this process while avoiding cross-runner collisions on /tmp.
+            std::env::set_var(
+                "HOME",
+                std::env::temp_dir().join(format!("codex-resume-home-{}", std::process::id())),
+            );
         }
     });
 }

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -54,6 +54,7 @@ fn setup_env_once() {
             // `home_dir` is loaded eagerly via `expect`. The marker
             // payload embeds it, so set a stable dummy.
             std::env::set_var("HOME", "/tmp/codex-resume-home");
+            std::env::remove_var(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV);
         }
     });
 }

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -53,11 +53,8 @@ fn setup_env_once() {
             std::env::set_var("VM0_SANDBOX_REUSE_RESULT", "reused");
             std::env::set_var("VM0_PROMPT", "test prompt");
             // `home_dir` is loaded eagerly via `expect`. Keep it stable within
-            // this process while avoiding cross-runner collisions on /tmp.
-            std::env::set_var(
-                "HOME",
-                std::env::temp_dir().join(format!("codex-resume-home-{}", std::process::id())),
-            );
+            // this process while avoiding cross-runner and stale /tmp collisions.
+            std::env::set_var("HOME", common::unique_temp_path("codex-resume-home"));
         }
     });
 }

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -258,7 +258,7 @@ fn send_event_seeds_existing_codex_thread_id_without_repairing_history_marker() 
 }
 
 #[test]
-fn recovery_checkpoint_derives_missing_codex_history_marker() {
+fn legacy_recovery_checkpoint_derives_missing_codex_history_marker() {
     setup_env_once();
     let _guard = TEST_MUTEX.lock().unwrap();
     reset_session_files();

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -89,6 +89,34 @@ fn reset_session_files() {
     let _ = std::fs::remove_file(guest_agent::paths::session_history_path_file());
 }
 
+struct CodexResumeFilesGuard;
+
+impl CodexResumeFilesGuard {
+    fn new() -> Self {
+        cleanup_codex_resume_files();
+        Self
+    }
+}
+
+impl Drop for CodexResumeFilesGuard {
+    fn drop(&mut self) {
+        cleanup_codex_resume_files();
+    }
+}
+
+fn cleanup_codex_resume_files() {
+    reset_session_files();
+    let home = Path::new(guest_agent::env::home_dir());
+    let is_test_home = home
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| name.starts_with("codex-resume-home-"))
+        .unwrap_or(false);
+    if is_test_home {
+        let _ = std::fs::remove_dir_all(home);
+    }
+}
+
 fn write_codex_session_file(thread_id: &str, history: &str) -> Result<(), String> {
     let id_no_dashes = thread_id.replace('-', "");
     let path = Path::new(guest_agent::env::home_dir())
@@ -123,7 +151,7 @@ fn checkpoint_http_client(
 fn send_event_extracts_codex_thread_id_and_writes_marker() {
     setup_env_once();
     let _guard = TEST_MUTEX.lock().unwrap();
-    reset_session_files();
+    let _files_guard = CodexResumeFilesGuard::new();
     let tmp = tempfile::tempdir().unwrap();
     let system_log_path = tmp.path().join("system.log");
     let _system_log_guard = SystemLogOverrideGuard::set(&system_log_path);
@@ -186,7 +214,7 @@ fn send_event_extracts_codex_thread_id_and_writes_marker() {
 fn send_event_canonicalizes_codex_thread_id_before_writing_marker() {
     setup_env_once();
     let _guard = TEST_MUTEX.lock().unwrap();
-    reset_session_files();
+    let _files_guard = CodexResumeFilesGuard::new();
 
     let masker = SecretMasker::from_raw("");
     let event = json!({
@@ -217,6 +245,7 @@ fn send_event_canonicalizes_codex_thread_id_before_writing_marker() {
 fn send_event_seeds_existing_codex_thread_id_without_repairing_history_marker() {
     setup_env_once();
     let _guard = TEST_MUTEX.lock().unwrap();
+    let _files_guard = CodexResumeFilesGuard::new();
 
     let thread_id = "0193abcd-ef01-7234-89ab-cdef01234567";
     for seed_empty_marker in [false, true] {
@@ -262,7 +291,7 @@ fn send_event_seeds_existing_codex_thread_id_without_repairing_history_marker() 
 fn legacy_recovery_checkpoint_derives_missing_codex_history_marker() {
     setup_env_once();
     let _guard = TEST_MUTEX.lock().unwrap();
-    reset_session_files();
+    let _files_guard = CodexResumeFilesGuard::new();
 
     let thread_id = "0193abcd-ef01-7234-89ab-cdef01234567";
     let history = r#"{"type":"thread.started"}"#.to_string() + "\n";
@@ -313,7 +342,7 @@ fn legacy_recovery_checkpoint_derives_missing_codex_history_marker() {
 fn send_event_codex_ignores_non_thread_started_event() {
     setup_env_once();
     let _guard = TEST_MUTEX.lock().unwrap();
-    reset_session_files();
+    let _files_guard = CodexResumeFilesGuard::new();
 
     let masker = SecretMasker::from_raw("");
     let event = json!({"type": "turn.completed"});
@@ -330,7 +359,7 @@ fn send_event_codex_ignores_non_thread_started_event() {
 fn send_event_codex_ignores_empty_thread_id() {
     setup_env_once();
     let _guard = TEST_MUTEX.lock().unwrap();
-    reset_session_files();
+    let _files_guard = CodexResumeFilesGuard::new();
 
     let masker = SecretMasker::from_raw("");
     let event = json!({"type": "thread.started", "thread_id": ""});
@@ -347,6 +376,7 @@ fn send_event_codex_ignores_empty_thread_id() {
 fn send_event_codex_ignores_malformed_thread_id() {
     setup_env_once();
     let _guard = TEST_MUTEX.lock().unwrap();
+    let _files_guard = CodexResumeFilesGuard::new();
 
     for thread_id in [
         "abc",

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -112,7 +112,7 @@ fn cleanup_codex_resume_files() {
         .and_then(|name| name.to_str())
         .map(|name| name.starts_with("codex-resume-home-"))
         .unwrap_or(false);
-    if is_test_home {
+    if is_test_home && home.starts_with(std::env::temp_dir()) {
         let _ = std::fs::remove_dir_all(home);
     }
 }

--- a/crates/guest-agent/tests/codex_setup_api_key_reconcile.rs
+++ b/crates/guest-agent/tests/codex_setup_api_key_reconcile.rs
@@ -3,6 +3,8 @@
 //! This test lives in its own binary because `guest_agent::env` caches values
 //! in process-wide `LazyLock`s.
 
+mod common;
+
 use guest_agent::masker::SecretMasker;
 use serde_json::Value;
 #[cfg(unix)]
@@ -36,6 +38,7 @@ async fn api_key_setup_writes_auth_without_invoking_codex() -> TestResult {
     let path = format!("{}:{original_path}", bin_dir.display());
 
     unsafe {
+        common::clear_guest_agent_bootstrap_env_for_test();
         std::env::set_var("CLI_AGENT_TYPE", "codex");
         std::env::set_var(guest_contracts::env::RUN_ID_ENV, "codex-setup-api-key");
         std::env::set_var(guest_contracts::env::USER_ENV_FILE_ENV, &user_env_path);

--- a/crates/guest-agent/tests/codex_setup_no_auth_reconcile.rs
+++ b/crates/guest-agent/tests/codex_setup_no_auth_reconcile.rs
@@ -3,6 +3,8 @@
 //! This test lives in its own binary because `guest_agent::env` caches values
 //! in process-wide `LazyLock`s.
 
+mod common;
+
 use guest_agent::masker::SecretMasker;
 use std::time::Duration;
 
@@ -26,6 +28,7 @@ async fn codex_setup_no_auth_removes_stale_auth_json() -> TestResult {
     )?;
 
     unsafe {
+        common::clear_guest_agent_bootstrap_env_for_test();
         std::env::set_var("CLI_AGENT_TYPE", "codex");
         std::env::set_var(guest_contracts::env::RUN_ID_ENV, "codex-setup-no-auth");
         std::env::set_var(guest_contracts::env::USER_ENV_FILE_ENV, &user_env_path);

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -442,6 +442,52 @@ pub struct CodexAppServerEnvConfig<'a> {
     pub resume_session_id: Option<&'a str>,
 }
 
+/// Clear runner/bootstrap environment that could be inherited from a parent
+/// runner process. Test setup helpers then write the exact env snapshot they
+/// want `GuestRuntime::from_process_env` to capture.
+///
+/// # Safety
+/// Call before any other test thread reads process environment.
+pub unsafe fn clear_guest_agent_bootstrap_env_for_test() {
+    for key in [
+        guest_contracts::env::API_URL_ENV,
+        guest_contracts::env::RUN_ID_ENV,
+        guest_contracts::env::API_TOKEN_ENV,
+        guest_contracts::env::SANDBOX_ID_ENV,
+        guest_contracts::env::SANDBOX_REUSE_RESULT_ENV,
+        guest_contracts::env::PROMPT_ENV,
+        guest_contracts::env::APPEND_SYSTEM_PROMPT_ENV,
+        guest_contracts::env::VERCEL_PROTECTION_BYPASS_ENV,
+        guest_contracts::env::RESUME_SESSION_ID_ENV,
+        guest_contracts::env::API_START_TIME_ENV,
+        guest_contracts::env::SECRET_VALUES_ENV,
+        guest_contracts::env::DISALLOWED_TOOLS_ENV,
+        guest_contracts::env::TOOLS_ENV,
+        guest_contracts::env::SETTINGS_ENV,
+        guest_contracts::env::CLI_AGENT_TYPE_ENV,
+        guest_contracts::env::USER_ENV_FILE_ENV,
+        guest_contracts::env::ARTIFACTS_ENV,
+        guest_contracts::env::FEATURE_FLAGS_ENV,
+        guest_contracts::env::STUCK_TOOL_TIMEOUT_SECS_ENV,
+        guest_contracts::env::POST_RESULT_SIGTERM_GRACE_SECS_ENV,
+        guest_contracts::env::POST_RESULT_TOTAL_CAP_SECS_ENV,
+        guest_contracts::env::POST_RESULT_SIGKILL_GRACE_SECS_ENV,
+        guest_contracts::env::USE_MOCK_CLAUDE_ENV,
+        guest_contracts::env::USE_MOCK_CODEX_ENV,
+        guest_contracts::env::CODEX_APP_SERVER_BACKEND_ENV,
+        guest_contracts::env::MOCK_CLAUDE_PATH_ENV,
+        guest_contracts::env::MOCK_CODEX_PATH_ENV,
+        guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+        process_control_ipc::BOOTSTRAP_ENV,
+        "MOCK_CODEX_FIXTURE",
+        "MOCK_CODEX_APP_SERVER_SCENARIO",
+    ] {
+        unsafe {
+            std::env::remove_var(key);
+        }
+    }
+}
+
 /// Configure one test binary for the experimental Codex app-server backend.
 ///
 /// Must be called before building a `GuestRuntime` or using legacy env accessors
@@ -456,11 +502,11 @@ pub unsafe fn setup_codex_app_server_env(
     config: CodexAppServerEnvConfig<'_>,
 ) -> Result<(), String> {
     unsafe {
+        clear_guest_agent_bootstrap_env_for_test();
         std::env::set_var("CLI_AGENT_TYPE", "codex");
         std::env::set_var("VM0_CODEX_APP_SERVER_BACKEND", "1");
         std::env::set_var("VM0_MOCK_CODEX_PATH", mock_path);
         std::env::set_var("USE_MOCK_CODEX", "true");
-        std::env::remove_var("MOCK_CODEX_FIXTURE");
         if let Some(scenario) = config.scenario {
             std::env::set_var("MOCK_CODEX_APP_SERVER_SCENARIO", scenario);
         } else {
@@ -473,7 +519,6 @@ pub unsafe fn setup_codex_app_server_env(
         std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");
         std::env::set_var("VM0_SANDBOX_REUSE_RESULT", "reused");
         std::env::set_var("HOME", home);
-        std::env::remove_var(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV);
         if let Some(resume_session_id) = config.resume_session_id {
             std::env::set_var("VM0_RESUME_SESSION_ID", resume_session_id);
         } else {
@@ -551,6 +596,7 @@ pub unsafe fn setup_env(
     sigkill_grace_secs: u64,
 ) -> Result<(), String> {
     unsafe {
+        clear_guest_agent_bootstrap_env_for_test();
         // Route the CLI binary resolution to the cargo-built mock.
         std::env::set_var("CLI_AGENT_TYPE", "claude-code");
         std::env::set_var("VM0_MOCK_CLAUDE_PATH", mock_path);
@@ -586,7 +632,6 @@ pub unsafe fn setup_env(
         // the tempdir and gets cleaned up with it, instead of
         // accumulating in the dev's real ~/.claude on every run.
         std::env::set_var("HOME", workdir);
-        std::env::remove_var(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV);
     }
     std::fs::create_dir_all(workdir).map_err(|e| format!("create workdir: {e}"))?;
     ensure_canonical_workspace_for_test()?;

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -473,6 +473,7 @@ pub unsafe fn setup_codex_app_server_env(
         std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");
         std::env::set_var("VM0_SANDBOX_REUSE_RESULT", "reused");
         std::env::set_var("HOME", home);
+        std::env::remove_var(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV);
         if let Some(resume_session_id) = config.resume_session_id {
             std::env::set_var("VM0_RESUME_SESSION_ID", resume_session_id);
         } else {
@@ -585,6 +586,7 @@ pub unsafe fn setup_env(
         // the tempdir and gets cleaned up with it, instead of
         // accumulating in the dev's real ~/.claude on every run.
         std::env::set_var("HOME", workdir);
+        std::env::remove_var(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV);
     }
     std::fs::create_dir_all(workdir).map_err(|e| format!("create workdir: {e}"))?;
     ensure_canonical_workspace_for_test()?;

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -492,10 +492,6 @@ pub fn active_input_payload(text: &str) -> Result<Vec<u8>, serde_json::Error> {
     }))
 }
 
-pub fn read_codex_session_history_events() -> Result<Vec<Value>, Box<dyn std::error::Error>> {
-    read_codex_session_history_events_for_path(guest_agent::paths::session_history_path_file())
-}
-
 pub fn read_codex_session_history_events_for_paths(
     paths: &guest_agent::paths::GuestPaths,
 ) -> Result<Vec<Value>, Box<dyn std::error::Error>> {

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -24,13 +24,18 @@ use serde_json::{Value, json};
 use std::io;
 use std::os::fd::{AsFd, AsRawFd, OwnedFd};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicU64, Ordering},
+};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::io::unix::AsyncFd;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 
 pub type SystemLogOverrideGuard = system_log::SystemLogOverrideGuard;
+
+static UNIQUE_TEMP_PATH_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// 128 + SIGTERM(15). Rust / glibc's default signal handler maps a
 /// SIGTERM-terminated process to this exit code.
@@ -53,6 +58,18 @@ pub const CLI_STDERR_RESULT_MAX_LINE_BYTES: usize = 16 * 1024;
 /// Documented replacement for a stderr line that exceeds the diagnostic limit.
 pub const CLI_STDERR_OMITTED_LONG_LINE: &str =
     "[stderr line omitted: exceeded diagnostic size limit]";
+
+pub fn unique_temp_path(prefix: &str) -> PathBuf {
+    let timestamp_nanos = match SystemTime::now().duration_since(UNIX_EPOCH) {
+        Ok(duration) => duration.as_nanos(),
+        Err(error) => error.duration().as_nanos(),
+    };
+    let counter = UNIQUE_TEMP_PATH_COUNTER.fetch_add(1, Ordering::SeqCst);
+    std::env::temp_dir().join(format!(
+        "{prefix}-{}-{timestamp_nanos}-{counter}",
+        std::process::id()
+    ))
+}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RecordedRequest {

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -2,13 +2,11 @@
 //!
 //! # Why separate test binaries instead of cases in one
 //!
-//! `guest_agent::env` caches all `VM0_*` values in process-wide
-//! `LazyLock`s on first read. Consolidating scenarios with different
-//! prompts or grace windows into one `#[tokio::test]` binary would
-//! require each test to see its own `VM0_PROMPT`, which is impossible
-//! once the `LazyLock` is initialised. Splitting into separate binaries
-//! gives each one a fresh process + fresh LazyLock state, paid for by
-//! a small cargo build-cache hit (idempotent).
+//! Many CLI tests mutate process env, current directory, and guest runtime path
+//! overrides as setup input. Consolidating scenarios with different prompts or
+//! grace windows into one `#[tokio::test]` binary would make those process-wide
+//! side effects race. Splitting into separate binaries gives each scenario a
+//! fresh process, paid for by a small cargo build-cache hit (idempotent).
 //!
 //! # Error handling
 //!
@@ -447,8 +445,8 @@ pub struct CodexAppServerEnvConfig<'a> {
 
 /// Configure one test binary for the experimental Codex app-server backend.
 ///
-/// Must be called before any `guest_agent::env::*` accessor because those
-/// values are cached in process-wide `LazyLock`s.
+/// Must be called before building a `GuestRuntime` or using legacy env accessors
+/// because those APIs capture process env at initialization time.
 ///
 /// # Safety
 /// Callers must use this from a single-test integration binary before any other
@@ -496,9 +494,19 @@ pub fn active_input_payload(text: &str) -> Result<Vec<u8>, serde_json::Error> {
 }
 
 pub fn read_codex_session_history_events() -> Result<Vec<Value>, Box<dyn std::error::Error>> {
-    let history = guest_agent::session_history::read_session_history(
-        guest_agent::paths::session_history_path_file(),
-    )?;
+    read_codex_session_history_events_for_path(guest_agent::paths::session_history_path_file())
+}
+
+pub fn read_codex_session_history_events_for_paths(
+    paths: &guest_agent::paths::GuestPaths,
+) -> Result<Vec<Value>, Box<dyn std::error::Error>> {
+    read_codex_session_history_events_for_path(paths.session_history_path_file())
+}
+
+fn read_codex_session_history_events_for_path(
+    session_history_path_file: &str,
+) -> Result<Vec<Value>, Box<dyn std::error::Error>> {
+    let history = guest_agent::session_history::read_session_history(session_history_path_file)?;
     let history = String::from_utf8(history)?;
     history
         .lines()
@@ -506,9 +514,9 @@ pub fn read_codex_session_history_events() -> Result<Vec<Value>, Box<dyn std::er
         .collect()
 }
 
-/// Configure the process environment for a reap test. Must be called
-/// BEFORE any `guest_agent::env::*` accessor — the library's LazyLocks
-/// capture these values on first read.
+/// Configure the process environment for a reap test. Must be called before
+/// building a `GuestRuntime` or using legacy env accessors because those APIs
+/// capture process env at initialization time.
 ///
 /// `prompt` decides which mock-claude test prefix runs:
 /// - `@hang-after-result` → SIGTERM path
@@ -535,7 +543,7 @@ pub fn read_codex_session_history_events() -> Result<Vec<Value>, Box<dyn std::er
 /// - Mutates the process-wide working directory (`set_current_dir`).
 ///
 /// Call AT MOST ONCE per test binary; calling from multiple `#[test]`s
-/// in the same binary races on CWD and on `LazyLock` capture order.
+/// in the same binary races on CWD and runtime capture order.
 ///
 /// SAFETY: callers run in a single-test test binary, so no other thread
 /// is reading the process env concurrently.
@@ -612,6 +620,46 @@ where
 /// code path entirely.
 pub fn spawn_dummy_heartbeat() -> guest_agent::cli::HeartbeatMonitor {
     None
+}
+
+pub fn guest_runtime_from_process_env() -> Result<guest_agent::run_context::GuestRuntime, String> {
+    guest_agent::run_context::GuestRuntime::from_process_env()
+}
+
+pub async fn execute_cli_for_runtime(
+    runtime: &guest_agent::run_context::GuestRuntime,
+    masker: &guest_agent::masker::SecretMasker,
+    heartbeat: guest_agent::cli::HeartbeatMonitor,
+) -> Result<guest_agent::cli::CliExecutionResult, guest_agent::error::AgentError> {
+    let active_input = guest_agent::active_input::ActiveInputRuntime::new_with_initial_prompt(
+        &runtime.config.run_id,
+        false,
+        &runtime.config.prompt,
+    );
+    execute_cli_with_active_input_for_runtime(
+        runtime,
+        masker,
+        heartbeat,
+        active_input.into_writer(),
+    )
+    .await
+}
+
+pub async fn execute_cli_with_active_input_for_runtime(
+    runtime: &guest_agent::run_context::GuestRuntime,
+    masker: &guest_agent::masker::SecretMasker,
+    heartbeat: guest_agent::cli::HeartbeatMonitor,
+    active_input: guest_agent::active_input::ActiveInputWriter,
+) -> Result<guest_agent::cli::CliExecutionResult, guest_agent::error::AgentError> {
+    guest_agent::cli::execute_cli_with_active_input_for_config(
+        masker,
+        heartbeat,
+        runtime.http.clone(),
+        active_input,
+        &runtime.config,
+        &runtime.paths,
+    )
+    .await
 }
 
 pub async fn wait_for_path(path: &Path, timeout: Duration) -> io::Result<()> {

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -177,35 +177,30 @@ impl Drop for RecordingServer {
 
 #[derive(Debug)]
 pub struct RunFilesGuard {
-    ops_file: String,
+    paths: guest_agent::paths::GuestPaths,
 }
 
 impl RunFilesGuard {
-    pub fn new() -> Self {
-        let ops_file = guest_common::telemetry::sandbox_ops_log().to_string();
-        cleanup_run_files(&ops_file);
-        Self { ops_file }
-    }
-}
-
-impl Default for RunFilesGuard {
-    fn default() -> Self {
-        Self::new()
+    pub fn new_for_paths(paths: &guest_agent::paths::GuestPaths) -> Self {
+        cleanup_run_files_for_paths(paths);
+        Self {
+            paths: paths.clone(),
+        }
     }
 }
 
 impl Drop for RunFilesGuard {
     fn drop(&mut self) {
-        cleanup_run_files(&self.ops_file);
+        cleanup_run_files_for_paths(&self.paths);
     }
 }
 
-fn cleanup_run_files(ops_file: &str) {
-    let _ = std::fs::remove_file(guest_agent::paths::agent_log_file());
-    let _ = std::fs::remove_file(guest_agent::paths::event_error_flag());
-    let _ = std::fs::remove_file(guest_agent::paths::session_id_file());
-    let _ = std::fs::remove_file(guest_agent::paths::session_history_path_file());
-    let _ = std::fs::remove_file(ops_file);
+fn cleanup_run_files_for_paths(paths: &guest_agent::paths::GuestPaths) {
+    let _ = std::fs::remove_file(paths.agent_log_file());
+    let _ = std::fs::remove_file(paths.event_error_flag());
+    let _ = std::fs::remove_file(paths.session_id_file());
+    let _ = std::fs::remove_file(paths.session_history_path_file());
+    let _ = std::fs::remove_file(paths.sandbox_ops_file());
 }
 
 async fn read_http_request(socket: &mut tokio::net::TcpStream) -> Result<RecordedRequest, String> {

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -187,6 +187,10 @@ impl RunFilesGuard {
             paths: paths.clone(),
         }
     }
+
+    pub fn sandbox_ops_file(&self) -> &str {
+        self.paths.sandbox_ops_file()
+    }
 }
 
 impl Drop for RunFilesGuard {

--- a/crates/guest-agent/tests/execute_cli_api_mode.rs
+++ b/crates/guest-agent/tests/execute_cli_api_mode.rs
@@ -37,6 +37,7 @@ unsafe fn setup_api_env(
         std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");
         std::env::set_var("VM0_SANDBOX_REUSE_RESULT", "reused");
         std::env::set_var("HOME", workdir);
+        std::env::remove_var(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV);
     }
     std::fs::create_dir_all(workdir).map_err(|e| format!("create workdir: {e}"))?;
     common::ensure_canonical_workspace_for_test()?;

--- a/crates/guest-agent/tests/execute_cli_api_mode.rs
+++ b/crates/guest-agent/tests/execute_cli_api_mode.rs
@@ -19,6 +19,7 @@ unsafe fn setup_api_env(
     prompt: &str,
 ) -> Result<(), String> {
     unsafe {
+        common::clear_guest_agent_bootstrap_env_for_test();
         std::env::set_var("CLI_AGENT_TYPE", "claude-code");
         std::env::set_var("VM0_MOCK_CLAUDE_PATH", mock_path);
         std::env::set_var("USE_MOCK_CLAUDE", "true");
@@ -37,7 +38,6 @@ unsafe fn setup_api_env(
         std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");
         std::env::set_var("VM0_SANDBOX_REUSE_RESULT", "reused");
         std::env::set_var("HOME", workdir);
-        std::env::remove_var(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV);
     }
     std::fs::create_dir_all(workdir).map_err(|e| format!("create workdir: {e}"))?;
     common::ensure_canonical_workspace_for_test()?;

--- a/crates/guest-agent/tests/execute_cli_api_mode.rs
+++ b/crates/guest-agent/tests/execute_cli_api_mode.rs
@@ -7,38 +7,10 @@
 mod common;
 
 use guest_agent::masker::SecretMasker;
-use guest_agent::paths::GuestPaths;
 use guest_agent::run_context::GuestRuntime;
 use httpmock::prelude::*;
 use std::path::Path;
 use std::time::Duration;
-
-struct RunFilesGuard {
-    paths: GuestPaths,
-}
-
-impl RunFilesGuard {
-    fn new(paths: &GuestPaths) -> Self {
-        cleanup_run_files(paths);
-        Self {
-            paths: paths.clone(),
-        }
-    }
-}
-
-impl Drop for RunFilesGuard {
-    fn drop(&mut self) {
-        cleanup_run_files(&self.paths);
-    }
-}
-
-fn cleanup_run_files(paths: &GuestPaths) {
-    let _ = std::fs::remove_file(paths.agent_log_file());
-    let _ = std::fs::remove_file(paths.event_error_flag());
-    let _ = std::fs::remove_file(paths.session_id_file());
-    let _ = std::fs::remove_file(paths.session_history_path_file());
-    let _ = std::fs::remove_file(paths.sandbox_ops_file());
-}
 
 unsafe fn setup_api_env(
     mock_path: &Path,
@@ -92,7 +64,7 @@ async fn api_mode_execute_cli_captures_session_metadata_and_sends_events()
         setup_api_env(&mock_cli, tmp.path(), &server.base_url(), &prompt)?;
     }
     let runtime = GuestRuntime::from_process_env()?;
-    let _run_files = RunFilesGuard::new(&runtime.paths);
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
     let expected_run_id = runtime.config.run_id.clone();
     unsafe {
         std::env::set_var("VM0_RUN_ID", "stale-run-id-after-runtime-construction");

--- a/crates/guest-agent/tests/execute_cli_api_mode.rs
+++ b/crates/guest-agent/tests/execute_cli_api_mode.rs
@@ -1,41 +1,43 @@
 //! API-enabled `execute_cli` should capture session metadata from stdout events
 //! while still delivering webhook events.
 //!
-//! This test lives in its own binary because `guest_agent::env` and
-//! `guest_agent::paths` cache process-wide `VM0_*` values in `LazyLock`s.
+//! This test lives in its own binary to isolate process env, working directory,
+//! and guest runtime path overrides used during setup.
 
 mod common;
 
 use guest_agent::masker::SecretMasker;
+use guest_agent::paths::GuestPaths;
 use guest_agent::run_context::GuestRuntime;
 use httpmock::prelude::*;
 use std::path::Path;
 use std::time::Duration;
 
 struct RunFilesGuard {
-    ops_file: String,
+    paths: GuestPaths,
 }
 
 impl RunFilesGuard {
-    fn new() -> Self {
-        let ops_file = guest_common::telemetry::sandbox_ops_log().to_string();
-        cleanup_run_files(&ops_file);
-        Self { ops_file }
+    fn new(paths: &GuestPaths) -> Self {
+        cleanup_run_files(paths);
+        Self {
+            paths: paths.clone(),
+        }
     }
 }
 
 impl Drop for RunFilesGuard {
     fn drop(&mut self) {
-        cleanup_run_files(&self.ops_file);
+        cleanup_run_files(&self.paths);
     }
 }
 
-fn cleanup_run_files(ops_file: &str) {
-    let _ = std::fs::remove_file(guest_agent::paths::agent_log_file());
-    let _ = std::fs::remove_file(guest_agent::paths::event_error_flag());
-    let _ = std::fs::remove_file(guest_agent::paths::session_id_file());
-    let _ = std::fs::remove_file(guest_agent::paths::session_history_path_file());
-    let _ = std::fs::remove_file(ops_file);
+fn cleanup_run_files(paths: &GuestPaths) {
+    let _ = std::fs::remove_file(paths.agent_log_file());
+    let _ = std::fs::remove_file(paths.event_error_flag());
+    let _ = std::fs::remove_file(paths.session_id_file());
+    let _ = std::fs::remove_file(paths.session_history_path_file());
+    let _ = std::fs::remove_file(paths.sandbox_ops_file());
 }
 
 unsafe fn setup_api_env(
@@ -90,7 +92,7 @@ async fn api_mode_execute_cli_captures_session_metadata_and_sends_events()
         setup_api_env(&mock_cli, tmp.path(), &server.base_url(), &prompt)?;
     }
     let runtime = GuestRuntime::from_process_env()?;
-    let _run_files = RunFilesGuard::new();
+    let _run_files = RunFilesGuard::new(&runtime.paths);
     let expected_run_id = runtime.config.run_id.clone();
     unsafe {
         std::env::set_var("VM0_RUN_ID", "stale-run-id-after-runtime-construction");
@@ -148,9 +150,9 @@ async fn api_mode_execute_cli_captures_session_metadata_and_sends_events()
     result_event.assert_calls_async(1).await;
     replayed_user_event.assert_calls_async(0).await;
 
-    let captured_session_id = std::fs::read_to_string(guest_agent::paths::session_id_file())?;
+    let captured_session_id = std::fs::read_to_string(runtime.paths.session_id_file())?;
     assert_eq!(captured_session_id, session_id);
-    let history_path = std::fs::read_to_string(guest_agent::paths::session_history_path_file())?;
+    let history_path = std::fs::read_to_string(runtime.paths.session_history_path_file())?;
     assert!(
         history_path.contains(session_id),
         "history path should contain the captured session id, got {history_path}"

--- a/crates/guest-agent/tests/guest_config_process_env.rs
+++ b/crates/guest-agent/tests/guest_config_process_env.rs
@@ -3,6 +3,8 @@
 //! This test lives in its own binary because `guest_agent::env` caches
 //! environment values in process-wide `LazyLock`s.
 
+mod common;
+
 #[test]
 fn process_env_config_and_legacy_accessors_share_user_env_load() {
     let tmp = tempfile::tempdir().unwrap();
@@ -17,6 +19,7 @@ fn process_env_config_and_legacy_accessors_share_user_env_load() {
     .unwrap();
 
     unsafe {
+        common::clear_guest_agent_bootstrap_env_for_test();
         std::env::set_var(guest_contracts::env::RUN_ID_ENV, "guest-config-process-env");
         std::env::set_var("HOME", "/home/from-process-env");
         std::env::set_var(guest_contracts::env::USER_ENV_FILE_ENV, &user_env_path);

--- a/crates/guest-agent/tests/guest_config_process_env_legacy_first.rs
+++ b/crates/guest-agent/tests/guest_config_process_env_legacy_first.rs
@@ -3,6 +3,8 @@
 //! This test lives in its own binary because `guest_agent::env` caches
 //! environment values in process-wide `LazyLock`s.
 
+mod common;
+
 #[test]
 fn legacy_accessors_and_process_env_config_share_user_env_load() {
     let tmp = tempfile::tempdir().unwrap();
@@ -17,6 +19,7 @@ fn legacy_accessors_and_process_env_config_share_user_env_load() {
     .unwrap();
 
     unsafe {
+        common::clear_guest_agent_bootstrap_env_for_test();
         std::env::set_var(
             guest_contracts::env::RUN_ID_ENV,
             "guest-config-legacy-first",

--- a/crates/guest-agent/tests/guest_runtime_missing_api_url.rs
+++ b/crates/guest-agent/tests/guest_runtime_missing_api_url.rs
@@ -3,11 +3,14 @@
 //! This test lives in its own binary because `guest_agent::env` caches
 //! environment values in process-wide once cells.
 
+mod common;
+
 #[test]
 fn runtime_bootstrap_requires_api_url_when_api_token_is_set() {
     let tmp = tempfile::tempdir().unwrap();
 
     unsafe {
+        common::clear_guest_agent_bootstrap_env_for_test();
         std::env::set_var(
             guest_contracts::env::RUN_ID_ENV,
             "guest-runtime-missing-api-url",

--- a/crates/guest-agent/tests/guest_runtime_process_env.rs
+++ b/crates/guest-agent/tests/guest_runtime_process_env.rs
@@ -3,6 +3,8 @@
 //! This test lives in its own binary because `guest_agent::env` caches
 //! environment values in process-wide once cells.
 
+mod common;
+
 use std::time::Duration;
 
 #[test]
@@ -11,6 +13,7 @@ fn runtime_bootstrap_installs_system_log_and_sandbox_ops_paths() {
     let runtime_dir = tmp.path().join("runtime");
 
     unsafe {
+        common::clear_guest_agent_bootstrap_env_for_test();
         std::env::set_var(
             guest_contracts::env::RUN_ID_ENV,
             "guest-runtime-process-env",

--- a/crates/guest-agent/tests/heartbeat_panic_reap_sigkill.rs
+++ b/crates/guest-agent/tests/heartbeat_panic_reap_sigkill.rs
@@ -18,6 +18,8 @@ async fn heartbeat_panic_reap_escalates_to_sigkill_when_sigterm_ignored()
         common::setup_env(&mock, tmp.path(), "@stuck-tool-deaf", 1, 1)?;
     }
 
+    let runtime = common::guest_runtime_from_process_env()?;
+
     let masker = guest_agent::masker::SecretMasker::from_raw("");
     let sigterm_ignored_marker = tmp.path().join(".vm0-mock-sigterm-ignored");
     let heartbeat = common::spawn_heartbeat_monitor(async move {
@@ -31,11 +33,7 @@ async fn heartbeat_panic_reap_escalates_to_sigkill_when_sigterm_ignored()
     // + sigkill grace (1s, unignorable) + stdout drain (5s) + slack.
     let result = tokio::time::timeout(
         Duration::from_secs(15),
-        guest_agent::cli::execute_cli(
-            &masker,
-            heartbeat,
-            guest_agent::http::HttpClient::new().unwrap(),
-        ),
+        common::execute_cli_for_runtime(&runtime, &masker, heartbeat),
     )
     .await
     .expect("execute_cli did not return within 15s - heartbeat panic reap likely broken");

--- a/crates/guest-agent/tests/heartbeat_reap_sigkill.rs
+++ b/crates/guest-agent/tests/heartbeat_reap_sigkill.rs
@@ -18,6 +18,8 @@ async fn heartbeat_failure_reap_escalates_to_sigkill_when_sigterm_ignored()
         common::setup_env(&mock, tmp.path(), "@stuck-tool-deaf", 1, 1)?;
     }
 
+    let runtime = common::guest_runtime_from_process_env()?;
+
     let masker = guest_agent::masker::SecretMasker::from_raw("");
     let sigterm_ignored_marker = tmp.path().join(".vm0-mock-sigterm-ignored");
     let heartbeat = common::spawn_heartbeat_monitor(async move {
@@ -34,11 +36,7 @@ async fn heartbeat_failure_reap_escalates_to_sigkill_when_sigterm_ignored()
     // + sigkill grace (1s, unignorable) + stdout drain (5s) + slack.
     let result = tokio::time::timeout(
         Duration::from_secs(15),
-        guest_agent::cli::execute_cli(
-            &masker,
-            heartbeat,
-            guest_agent::http::HttpClient::new().unwrap(),
-        ),
+        common::execute_cli_for_runtime(&runtime, &masker, heartbeat),
     )
     .await
     .expect("execute_cli did not return within 15s - heartbeat reap escalation likely broken");

--- a/crates/guest-agent/tests/http_env_missing_api_url.rs
+++ b/crates/guest-agent/tests/http_env_missing_api_url.rs
@@ -1,8 +1,11 @@
+mod common;
+
 use guest_agent::http::HttpClient;
 
 #[test]
 fn for_current_env_requires_api_url_when_api_token_is_set() {
     unsafe {
+        common::clear_guest_agent_bootstrap_env_for_test();
         std::env::set_var("VM0_API_TOKEN", "test-token");
         std::env::set_var("VM0_API_URL", "");
     }

--- a/crates/guest-agent/tests/initial_prompt_stdin_reap_sigkill.rs
+++ b/crates/guest-agent/tests/initial_prompt_stdin_reap_sigkill.rs
@@ -2,7 +2,6 @@
 
 mod common;
 
-use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
 use guest_contracts::diagnostics::{CliTerminationReason, CliTerminationSignal};
 use std::os::unix::fs::PermissionsExt;
@@ -30,14 +29,12 @@ tail -f /dev/null
         common::setup_env(&mock, tmp.path(), &large_prompt, 3, 1)?;
     }
 
+    let runtime = common::guest_runtime_from_process_env()?;
+
     let masker = SecretMasker::from_raw("");
     let result = tokio::time::timeout(
         Duration::from_secs(15),
-        guest_agent::cli::execute_cli(
-            &masker,
-            common::spawn_dummy_heartbeat(),
-            HttpClient::for_current_env()?,
-        ),
+        common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
     )
     .await
     .expect("execute_cli did not return within 15s - stdin failure reap likely broken");

--- a/crates/guest-agent/tests/integration/checkpoint.rs
+++ b/crates/guest-agent/tests/integration/checkpoint.rs
@@ -9,6 +9,10 @@ use std::ffi::OsString;
 
 const LARGE_SESSION_HISTORY_SIZE_BYTES: usize = 1024 * 1024 + 1;
 
+fn runtime_from_process_env() -> Result<guest_agent::run_context::GuestRuntime, String> {
+    guest_agent::run_context::GuestRuntime::from_process_env()
+}
+
 struct EnvVarRestore {
     key: &'static str,
     value: Option<OsString>,
@@ -83,6 +87,7 @@ async fn success_checkpoint_uploads_non_utf8_session_history() {
     let api = SharedApiMock::new().await;
     let server = api.server();
 
+    let runtime = runtime_from_process_env().unwrap();
     let _files_guard = SessionCheckpointFilesGuard::new();
     let history = b"{\"type\":\"system\"}\nnon-utf8:\xC3(\n".to_vec();
     let _history_dir = write_literal_session_history("success-non-utf8-session", &history).unwrap();
@@ -124,7 +129,7 @@ async fn success_checkpoint_uploads_non_utf8_session_history() {
             .json_body(json!({"checkpointId": "checkpoint-success-non-utf8"}));
     });
 
-    let result = guest_agent::checkpoint::create_checkpoint(&http_client!()).await;
+    let result = guest_agent::checkpoint::create_checkpoint_for_runtime(&runtime).await;
 
     assert!(result.is_ok());
     prepare_mock.assert_calls_async(1).await;
@@ -132,7 +137,7 @@ async fn success_checkpoint_uploads_non_utf8_session_history() {
     checkpoint_mock.assert_calls_async(1).await;
 
     let identity_bytes =
-        std::fs::read(guest_agent::paths::final_session_history_identity_file()).unwrap();
+        std::fs::read(runtime.paths.final_session_history_identity_file()).unwrap();
     let identity = FinalSessionHistoryIdentity::from_json_slice(&identity_bytes).unwrap();
     assert_eq!(identity.framework, FinalSessionHistoryFramework::ClaudeCode);
     assert_eq!(identity.history_ref_kind, FinalSessionHistoryRefKind::Blob);
@@ -153,6 +158,7 @@ async fn success_checkpoint_writes_large_final_identity_metadata() {
     let api = SharedApiMock::new().await;
     let server = api.server();
 
+    let runtime = runtime_from_process_env().unwrap();
     let _files_guard = SessionCheckpointFilesGuard::new();
     let history = vec![b'a'; LARGE_SESSION_HISTORY_SIZE_BYTES];
     let _history_dir = write_literal_session_history("success-large-session", &history).unwrap();
@@ -194,7 +200,7 @@ async fn success_checkpoint_writes_large_final_identity_metadata() {
             .json_body(json!({"checkpointId": "checkpoint-success-large"}));
     });
 
-    let result = guest_agent::checkpoint::create_checkpoint(&http_client!()).await;
+    let result = guest_agent::checkpoint::create_checkpoint_for_runtime(&runtime).await;
 
     assert!(result.is_ok());
     prepare_mock.assert_calls_async(1).await;
@@ -202,7 +208,7 @@ async fn success_checkpoint_writes_large_final_identity_metadata() {
     checkpoint_mock.assert_calls_async(1).await;
 
     let identity_bytes =
-        std::fs::read(guest_agent::paths::final_session_history_identity_file()).unwrap();
+        std::fs::read(runtime.paths.final_session_history_identity_file()).unwrap();
     let identity = FinalSessionHistoryIdentity::from_json_slice(&identity_bytes).unwrap();
     assert_eq!(identity.framework, FinalSessionHistoryFramework::ClaudeCode);
     assert_eq!(identity.history_ref_kind, FinalSessionHistoryRefKind::Blob);
@@ -326,6 +332,7 @@ async fn recovery_checkpoint_uploads_valid_session_history() {
     let api = SharedApiMock::new().await;
     let server = api.server();
 
+    let runtime = runtime_from_process_env().unwrap();
     let _files_guard = SessionCheckpointFilesGuard::new();
     let dir = tempfile::tempdir().unwrap();
     let history_path = dir.path().join("history.jsonl");
@@ -366,14 +373,14 @@ async fn recovery_checkpoint_uploads_valid_session_history() {
             .json_body(json!({"checkpointId": "checkpoint-recovery"}));
     });
 
-    let result = guest_agent::checkpoint::create_recovery_checkpoint(&http_client!()).await;
+    let result = guest_agent::checkpoint::create_recovery_checkpoint_for_runtime(&runtime).await;
 
     assert!(result.is_ok());
     prepare_mock.assert_calls_async(1).await;
     upload_mock.assert_calls_async(1).await;
     checkpoint_mock.assert_calls_async(1).await;
     assert!(
-        !std::path::Path::new(guest_agent::paths::final_session_history_identity_file()).exists(),
+        !std::path::Path::new(runtime.paths.final_session_history_identity_file()).exists(),
         "recovery checkpoint must not write final session history identity metadata"
     );
 }
@@ -385,6 +392,7 @@ async fn assert_recovery_checkpoint_derives_claude_history_marker(
     let api = SharedApiMock::new().await;
     let server = api.server();
 
+    let runtime = runtime_from_process_env()?;
     let _files_guard = SessionCheckpointFilesGuard::new();
     let session_id = if seed_empty_marker {
         "derived-empty-marker-session"
@@ -425,7 +433,7 @@ async fn assert_recovery_checkpoint_derives_claude_history_marker(
             .json_body(json!({"checkpointId": "checkpoint-derived-history"}));
     });
 
-    let result = guest_agent::checkpoint::create_recovery_checkpoint(&http_client!()).await;
+    let result = guest_agent::checkpoint::create_recovery_checkpoint_for_runtime(&runtime).await;
 
     assert!(result.is_ok());
     prepare_mock.assert_calls_async(1).await;
@@ -459,6 +467,7 @@ async fn recovery_checkpoint_rejects_partial_jsonl_without_error_file() {
     let api = SharedApiMock::new().await;
     let server = api.server();
 
+    let runtime = runtime_from_process_env().unwrap();
     let _files_guard = SessionCheckpointFilesGuard::new();
     let dir = tempfile::tempdir().unwrap();
     let history_path = dir.path().join("partial.jsonl");
@@ -485,7 +494,7 @@ async fn recovery_checkpoint_rejects_partial_jsonl_without_error_file() {
         then.status(200);
     });
 
-    let result = guest_agent::checkpoint::create_recovery_checkpoint(&http_client!()).await;
+    let result = guest_agent::checkpoint::create_recovery_checkpoint_for_runtime(&runtime).await;
 
     let err = result.unwrap_err();
     assert!(
@@ -494,7 +503,7 @@ async fn recovery_checkpoint_rejects_partial_jsonl_without_error_file() {
         "expected recovery checkpoint to fail on partial JSONL history, got: {err}"
     );
     assert!(
-        !std::path::Path::new(guest_agent::paths::checkpoint_error_file()).exists(),
+        !std::path::Path::new(runtime.paths.checkpoint_error_file()).exists(),
         "recovery checkpoint must not write the success-path checkpoint error file"
     );
     prepare_mock.assert_calls_async(0).await;
@@ -506,6 +515,7 @@ async fn recovery_checkpoint_rejects_non_utf8_session_history() {
     let api = SharedApiMock::new().await;
     let server = api.server();
 
+    let runtime = runtime_from_process_env().unwrap();
     let _files_guard = SessionCheckpointFilesGuard::new();
     let _history_dir = write_literal_session_history(
         "recovery-non-utf8-session",
@@ -523,7 +533,7 @@ async fn recovery_checkpoint_rejects_non_utf8_session_history() {
         then.status(200);
     });
 
-    let result = guest_agent::checkpoint::create_recovery_checkpoint(&http_client!()).await;
+    let result = guest_agent::checkpoint::create_recovery_checkpoint_for_runtime(&runtime).await;
 
     let err = result.unwrap_err();
     assert!(
@@ -532,7 +542,7 @@ async fn recovery_checkpoint_rejects_non_utf8_session_history() {
         "expected recovery checkpoint to fail on invalid UTF-8 history, got: {err}"
     );
     assert!(
-        !std::path::Path::new(guest_agent::paths::checkpoint_error_file()).exists(),
+        !std::path::Path::new(runtime.paths.checkpoint_error_file()).exists(),
         "recovery checkpoint must not write the success-path checkpoint error file"
     );
     prepare_mock.assert_calls_async(0).await;
@@ -544,6 +554,7 @@ async fn recovery_checkpoint_skips_when_session_id_is_missing() {
     let api = SharedApiMock::new().await;
     let server = api.server();
 
+    let runtime = runtime_from_process_env().unwrap();
     let _files_guard = SessionCheckpointFilesGuard::new();
 
     let prepare_mock = server.mock(|when, then| {
@@ -556,7 +567,7 @@ async fn recovery_checkpoint_skips_when_session_id_is_missing() {
         then.status(200);
     });
 
-    let result = guest_agent::checkpoint::create_recovery_checkpoint(&http_client!()).await;
+    let result = guest_agent::checkpoint::create_recovery_checkpoint_for_runtime(&runtime).await;
 
     let err = result.unwrap_err();
     assert!(
@@ -564,7 +575,7 @@ async fn recovery_checkpoint_skips_when_session_id_is_missing() {
         "expected recovery checkpoint to fail on missing session ID, got: {err}"
     );
     assert!(
-        !std::path::Path::new(guest_agent::paths::checkpoint_error_file()).exists(),
+        !std::path::Path::new(runtime.paths.checkpoint_error_file()).exists(),
         "recovery checkpoint must not write the success-path checkpoint error file"
     );
     prepare_mock.assert_calls_async(0).await;
@@ -576,6 +587,7 @@ async fn recovery_checkpoint_skips_when_derived_history_is_missing() {
     let api = SharedApiMock::new().await;
     let server = api.server();
 
+    let runtime = runtime_from_process_env().unwrap();
     let _files_guard = SessionCheckpointFilesGuard::new();
     guest_agent::paths::write_private(guest_agent::paths::session_id_file(), "missing-history")
         .unwrap();
@@ -590,7 +602,7 @@ async fn recovery_checkpoint_skips_when_derived_history_is_missing() {
         then.status(200);
     });
 
-    let result = guest_agent::checkpoint::create_recovery_checkpoint(&http_client!()).await;
+    let result = guest_agent::checkpoint::create_recovery_checkpoint_for_runtime(&runtime).await;
 
     let err = result.unwrap_err();
     assert!(
@@ -598,7 +610,7 @@ async fn recovery_checkpoint_skips_when_derived_history_is_missing() {
         "expected recovery checkpoint to fail on missing derived history, got: {err}"
     );
     assert!(
-        !std::path::Path::new(guest_agent::paths::checkpoint_error_file()).exists(),
+        !std::path::Path::new(runtime.paths.checkpoint_error_file()).exists(),
         "recovery checkpoint must not write the success-path checkpoint error file"
     );
     prepare_mock.assert_calls_async(0).await;
@@ -610,6 +622,7 @@ async fn recovery_checkpoint_rejects_invalid_session_id_without_marker() {
     let api = SharedApiMock::new().await;
     let server = api.server();
 
+    let runtime = runtime_from_process_env().unwrap();
     let _files_guard = SessionCheckpointFilesGuard::new();
     guest_agent::paths::write_private(guest_agent::paths::session_id_file(), "../unsafe-session")
         .unwrap();
@@ -624,7 +637,7 @@ async fn recovery_checkpoint_rejects_invalid_session_id_without_marker() {
         then.status(200);
     });
 
-    let result = guest_agent::checkpoint::create_recovery_checkpoint(&http_client!()).await;
+    let result = guest_agent::checkpoint::create_recovery_checkpoint_for_runtime(&runtime).await;
 
     let err = result.unwrap_err();
     assert!(
@@ -633,7 +646,7 @@ async fn recovery_checkpoint_rejects_invalid_session_id_without_marker() {
         "expected recovery checkpoint to fail on invalid session ID, got: {err}"
     );
     assert!(
-        !std::path::Path::new(guest_agent::paths::checkpoint_error_file()).exists(),
+        !std::path::Path::new(runtime.paths.checkpoint_error_file()).exists(),
         "recovery checkpoint must not write the success-path checkpoint error file"
     );
     prepare_mock.assert_calls_async(0).await;

--- a/crates/guest-agent/tests/integration/complete.rs
+++ b/crates/guest-agent/tests/integration/complete.rs
@@ -2,6 +2,10 @@ use crate::support::*;
 use httpmock::prelude::*;
 use serde_json::json;
 
+const TEST_RUN_ID: &str = "test-run-001";
+const TEST_SANDBOX_ID: &str = "00000000-0000-4000-8000-000000000abc";
+const TEST_SANDBOX_REUSE_RESULT: &str = "reused";
+
 // =========================================================================
 // Complete webhook
 //
@@ -16,17 +20,16 @@ async fn complete_report_success_posts_full_payload_when_metadata_present() {
     let api = SharedApiMock::new().await;
     let server = api.server();
 
-    // VM0_SANDBOX_ID / VM0_SANDBOX_REUSE_RESULT come from shared API mock init.
     let mock = server.mock(|when, then| {
         when.method(POST)
             .path("/api/webhooks/agent/complete")
             .header("Authorization", "Bearer test-token-abc123")
             .json_body(json!({
-                "runId": "test-run-001",
+                "runId": TEST_RUN_ID,
                 "exitCode": 0,
                 "lastEventSequence": 7,
-                "sandboxId": "00000000-0000-4000-8000-000000000abc",
-                "sandboxReuseResult": "reused",
+                "sandboxId": TEST_SANDBOX_ID,
+                "sandboxReuseResult": TEST_SANDBOX_REUSE_RESULT,
             }));
         then.status(200).json_body(json!({
             "success": true,
@@ -34,10 +37,11 @@ async fn complete_report_success_posts_full_payload_when_metadata_present() {
         }));
     });
 
-    guest_agent::complete::report_success(
+    guest_agent::complete::report_success_for_run(
         &http_client!(),
-        guest_agent::env::sandbox_id(),
-        guest_agent::env::sandbox_reuse_result(),
+        TEST_RUN_ID,
+        TEST_SANDBOX_ID,
+        TEST_SANDBOX_REUSE_RESULT,
         Some(7),
     )
     .await;
@@ -59,13 +63,13 @@ async fn complete_report_success_omits_metadata_when_env_absent() {
         when.method(POST)
             .path("/api/webhooks/agent/complete")
             .json_body(json!({
-                "runId": "test-run-001",
+                "runId": TEST_RUN_ID,
                 "exitCode": 0,
             }));
         then.status(200).json_body(json!({"success": true}));
     });
 
-    guest_agent::complete::report_success(&http_client!(), "", "", None).await;
+    guest_agent::complete::report_success_for_run(&http_client!(), TEST_RUN_ID, "", "", None).await;
 
     mock.assert_calls_async(1).await;
 }
@@ -82,10 +86,11 @@ async fn complete_report_success_swallows_server_error() {
 
     // 1 attempt — no retry, no panic. Fire-and-forget semantics mean the
     // runner fallback is the correctness guarantee.
-    guest_agent::complete::report_success(
+    guest_agent::complete::report_success_for_run(
         &http_client!(),
-        guest_agent::env::sandbox_id(),
-        guest_agent::env::sandbox_reuse_result(),
+        TEST_RUN_ID,
+        TEST_SANDBOX_ID,
+        TEST_SANDBOX_REUSE_RESULT,
         None,
     )
     .await;
@@ -110,10 +115,11 @@ async fn complete_report_success_swallows_4xx_auth_error() {
         }));
     });
 
-    guest_agent::complete::report_success(
+    guest_agent::complete::report_success_for_run(
         &http_client!(),
-        guest_agent::env::sandbox_id(),
-        guest_agent::env::sandbox_reuse_result(),
+        TEST_RUN_ID,
+        TEST_SANDBOX_ID,
+        TEST_SANDBOX_REUSE_RESULT,
         None,
     )
     .await;

--- a/crates/guest-agent/tests/integration/events.rs
+++ b/crates/guest-agent/tests/integration/events.rs
@@ -426,25 +426,25 @@ async fn send_event_skips_session_id_for_non_init() {
 async fn send_event_failure_writes_error_flag() {
     let api = SharedApiMock::new().await;
     let server = api.server();
-
-    let flag_path = guest_agent::paths::event_error_flag();
-    let _ = std::fs::remove_file(flag_path);
+    let tmp = tempfile::tempdir().unwrap();
+    let paths = guest_agent::paths::GuestPaths::from_runtime_dir(tmp.path().join("runtime"));
+    let flag_path = paths.event_error_flag();
 
     let _mock = server.mock(|when, then| {
         when.method(POST).path("/api/webhooks/agent/events");
         then.status(500);
     });
 
-    let masker = SecretMasker::from_raw("");
-    let event = json!({"type": "test"});
-    let result = guest_agent::events::send_event(&http_client!(), event, 1, &masker).await;
+    let payload = json!({
+        "runId": "test-run-001",
+        "events": [{"type": "test", "sequenceNumber": 1}]
+    });
+    let result =
+        guest_agent::events::post_event_with_error_flag(&http_client!(), &payload, flag_path).await;
 
     assert!(result.is_err());
     assert!(
         std::path::Path::new(flag_path).exists(),
         "event error flag should be written on failure"
     );
-
-    // Clean up
-    let _ = std::fs::remove_file(flag_path);
 }

--- a/crates/guest-agent/tests/integration/support.rs
+++ b/crates/guest-agent/tests/integration/support.rs
@@ -15,6 +15,7 @@ pub(crate) use crate::common::SystemLogOverrideGuard;
 pub(crate) static MOCK_SERVER: LazyLock<MockServer> = LazyLock::new(|| {
     let server = MockServer::start();
     unsafe {
+        crate::common::clear_guest_agent_bootstrap_env_for_test();
         std::env::set_var("VM0_API_URL", server.base_url());
         std::env::set_var("VM0_API_TOKEN", "test-token-abc123");
         std::env::set_var("VM0_RUN_ID", "test-run-001");

--- a/crates/guest-agent/tests/integration/support.rs
+++ b/crates/guest-agent/tests/integration/support.rs
@@ -1,5 +1,6 @@
 use httpmock::prelude::*;
 use serde_json::Value;
+use std::path::{Path, PathBuf};
 use std::sync::{
     Arc, LazyLock, Mutex, MutexGuard,
     atomic::{AtomicUsize, Ordering},
@@ -50,6 +51,7 @@ impl SharedApiMock {
         };
         let server = &*MOCK_SERVER;
         server.reset_async().await;
+        cleanup_integration_runtime_root();
         Self {
             _guard: guard,
             server,
@@ -66,6 +68,32 @@ impl SharedApiMock {
             "shared API mock path must be absolute"
         );
         format!("{}{}", self.server.base_url(), path)
+    }
+}
+
+impl Drop for SharedApiMock {
+    fn drop(&mut self) {
+        cleanup_integration_runtime_root();
+    }
+}
+
+fn cleanup_integration_runtime_root() {
+    let Some(runtime_dir) =
+        std::env::var_os(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV).map(PathBuf::from)
+    else {
+        return;
+    };
+    let root = runtime_dir
+        .parent()
+        .and_then(Path::parent)
+        .unwrap_or(runtime_dir.as_path());
+    let is_test_root = root
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| name.starts_with("vm0-guest-agent-integration-"))
+        .unwrap_or(false);
+    if is_test_root && root.starts_with(std::env::temp_dir()) {
+        let _ = std::fs::remove_dir_all(root);
     }
 }
 

--- a/crates/guest-agent/tests/integration/support.rs
+++ b/crates/guest-agent/tests/integration/support.rs
@@ -21,11 +21,7 @@ pub(crate) static MOCK_SERVER: LazyLock<MockServer> = LazyLock::new(|| {
         std::env::set_var("VM0_RUN_ID", "test-run-001");
         std::env::set_var(
             guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
-            std::env::temp_dir()
-                .join(format!(
-                    "vm0-guest-agent-integration-{}",
-                    std::process::id()
-                ))
+            crate::common::unique_temp_path("vm0-guest-agent-integration")
                 .join("runs")
                 .join("test-run-001"),
         );

--- a/crates/guest-agent/tests/integration/telemetry.rs
+++ b/crates/guest-agent/tests/integration/telemetry.rs
@@ -7,13 +7,48 @@ const TELEMETRY_DELTA_READ_LIMIT: usize = 256 * 1024;
 const OVERSIZED_SYSTEM_LOG_LINE_MARKER_FRAGMENT: &str =
     "vm0 telemetry omitted oversized system log line";
 
-fn remove_telemetry_files() {
-    let _ = std::fs::remove_file(guest_agent::paths::system_log_file());
-    let _ = std::fs::remove_file(guest_agent::paths::metrics_log_file());
-    let _ = std::fs::remove_file(guest_agent::paths::sandbox_ops_file());
-    let _ = std::fs::remove_file(guest_agent::paths::telemetry_system_log_pos_file());
-    let _ = std::fs::remove_file(guest_agent::paths::telemetry_metrics_pos_file());
-    let _ = std::fs::remove_file(guest_agent::paths::telemetry_sandbox_ops_pos_file());
+struct SandboxOpsOverrideGuard;
+
+impl SandboxOpsOverrideGuard {
+    fn set(path: &str) -> Self {
+        guest_common::telemetry::set_sandbox_ops_log_file(path);
+        Self
+    }
+}
+
+impl Drop for SandboxOpsOverrideGuard {
+    fn drop(&mut self) {
+        guest_common::telemetry::clear_sandbox_ops_log_file();
+    }
+}
+
+struct ExplicitTelemetryFiles {
+    _tmp: tempfile::TempDir,
+    paths: guest_agent::paths::GuestPaths,
+    _sandbox_ops_override: SandboxOpsOverrideGuard,
+}
+
+impl ExplicitTelemetryFiles {
+    fn new(name: &str) -> std::io::Result<Self> {
+        let tmp = tempfile::tempdir()?;
+        let paths = guest_agent::paths::GuestPaths::from_runtime_dir(tmp.path().join(name));
+        let sandbox_ops_override = SandboxOpsOverrideGuard::set(paths.sandbox_ops_file());
+        remove_telemetry_files(&paths);
+        Ok(Self {
+            _tmp: tmp,
+            paths,
+            _sandbox_ops_override: sandbox_ops_override,
+        })
+    }
+}
+
+fn remove_telemetry_files(paths: &guest_agent::paths::GuestPaths) {
+    let _ = std::fs::remove_file(paths.system_log_file());
+    let _ = std::fs::remove_file(paths.metrics_log_file());
+    let _ = std::fs::remove_file(paths.sandbox_ops_file());
+    let _ = std::fs::remove_file(paths.telemetry_system_log_pos_file());
+    let _ = std::fs::remove_file(paths.telemetry_metrics_pos_file());
+    let _ = std::fs::remove_file(paths.telemetry_sandbox_ops_pos_file());
 }
 
 fn ensure_parent_dir(path: &str) {
@@ -27,8 +62,8 @@ fn ensure_parent_dir(path: &str) {
 async fn spawn_for_paths_uploads_explicit_runtime_files() {
     let api = SharedApiMock::new().await;
     let server = api.server();
-    let tmp = tempfile::tempdir().unwrap();
-    let paths = guest_agent::paths::GuestPaths::from_runtime_dir(tmp.path().join("runtime"));
+    let files = ExplicitTelemetryFiles::new("spawn-for-paths").unwrap();
+    let paths = &files.paths;
 
     let upload_mock = server.mock(|when, then| {
         when.method(POST)
@@ -44,7 +79,7 @@ async fn spawn_for_paths_uploads_explicit_runtime_files() {
     let masker = std::sync::Arc::new(SecretMasker::from_raw(""));
     let telemetry = guest_agent::telemetry::Telemetry::spawn_for_paths(
         "explicit-run".to_string(),
-        &paths,
+        paths,
         masker,
         http_client!(),
     );
@@ -75,14 +110,8 @@ async fn spawn_for_paths_uploads_explicit_runtime_files() {
 async fn flush_is_incremental_between_calls() {
     let api = SharedApiMock::new().await;
     let server = api.server();
-
-    // Reset per-run telemetry state so this test drives sandbox_ops
-    // deterministically (other tests in this file don't record sandbox_ops,
-    // but be defensive against cross-test leakage).
-    let ops_file = guest_common::telemetry::sandbox_ops_log();
-    let pos_file = guest_agent::paths::telemetry_sandbox_ops_pos_file();
-    let _ = std::fs::remove_file(ops_file);
-    let _ = std::fs::remove_file(pos_file);
+    let files = ExplicitTelemetryFiles::new("flush-incremental").unwrap();
+    let paths = &files.paths;
 
     // Two mocks, registered in this order. httpmock matches by ID ascending
     // and returns the first hit, so `first_op_mock` wins when the payload
@@ -99,7 +128,12 @@ async fn flush_is_incremental_between_calls() {
     });
 
     let masker = std::sync::Arc::new(SecretMasker::from_raw(""));
-    let telemetry = guest_agent::telemetry::Telemetry::spawn(masker, http_client!());
+    let telemetry = guest_agent::telemetry::Telemetry::spawn_for_paths(
+        "test-run-001".to_string(),
+        paths,
+        masker,
+        http_client!(),
+    );
 
     // Pre-checkpoint record → first flush captures it.
     guest_common::telemetry::record_sandbox_op("first_op", Duration::from_millis(10), true, None);
@@ -127,19 +161,16 @@ async fn flush_is_incremental_between_calls() {
 
     first_op_mock.delete_async().await;
     catchup_mock.delete_async().await;
-    let _ = std::fs::remove_file(ops_file);
-    let _ = std::fs::remove_file(pos_file);
+    remove_telemetry_files(paths);
 }
 
 #[tokio::test]
 async fn final_flush_and_shutdown_uploads_log_emitted_immediately_before_it() {
     let api = SharedApiMock::new().await;
     let server = api.server();
-
-    let system_log = guest_agent::paths::system_log_file();
-    let pos_file = guest_agent::paths::telemetry_system_log_pos_file();
-    let _ = std::fs::remove_file(system_log);
-    let _ = std::fs::remove_file(pos_file);
+    let files = ExplicitTelemetryFiles::new("final-flush-tail").unwrap();
+    let paths = &files.paths;
+    let system_log = paths.system_log_file();
 
     let marker = "fatal-tail-before-final-telemetry";
     let upload_mock = server.mock(|when, then| {
@@ -151,7 +182,12 @@ async fn final_flush_and_shutdown_uploads_log_emitted_immediately_before_it() {
 
     let system_log_guard = SystemLogOverrideGuard::set(system_log);
     let masker = std::sync::Arc::new(SecretMasker::from_raw(""));
-    let telemetry = guest_agent::telemetry::Telemetry::spawn(masker, http_client!());
+    let telemetry = guest_agent::telemetry::Telemetry::spawn_for_paths(
+        "test-run-001".to_string(),
+        paths,
+        masker,
+        http_client!(),
+    );
 
     guest_common::log_warn!("sandbox:guest-agent", "{marker}");
     telemetry
@@ -162,19 +198,18 @@ async fn final_flush_and_shutdown_uploads_log_emitted_immediately_before_it() {
 
     upload_mock.assert_calls_async(1).await;
     upload_mock.delete_async().await;
-    let _ = std::fs::remove_file(system_log);
-    let _ = std::fs::remove_file(pos_file);
+    remove_telemetry_files(paths);
 }
 
 #[tokio::test]
 async fn telemetry_masks_runtime_session_id_registered_after_spawn() {
     let api = SharedApiMock::new().await;
     let server = api.server();
-    remove_telemetry_files();
+    let files = ExplicitTelemetryFiles::new("runtime-session-mask").unwrap();
+    let paths = &files.paths;
     let _session_files = SessionCheckpointFilesGuard::new();
 
-    let system_log = guest_agent::paths::system_log_file();
-    let pos_file = guest_agent::paths::telemetry_system_log_pos_file();
+    let system_log = paths.system_log_file();
     ensure_parent_dir(system_log);
 
     let session_id = "telemetry-session-secret";
@@ -198,8 +233,12 @@ async fn telemetry_masks_runtime_session_id_registered_after_spawn() {
     });
 
     let masker = std::sync::Arc::new(SecretMasker::from_raw(""));
-    let telemetry =
-        guest_agent::telemetry::Telemetry::spawn(std::sync::Arc::clone(&masker), http_client!());
+    let telemetry = guest_agent::telemetry::Telemetry::spawn_for_paths(
+        "test-run-001".to_string(),
+        paths,
+        std::sync::Arc::clone(&masker),
+        http_client!(),
+    );
     let event = serde_json::json!({
         "type": "system",
         "subtype": "init",
@@ -224,8 +263,7 @@ async fn telemetry_masks_runtime_session_id_registered_after_spawn() {
     event_mock.delete_async().await;
     raw_telemetry_mock.delete_async().await;
     masked_telemetry_mock.delete_async().await;
-    let _ = std::fs::remove_file(system_log);
-    let _ = std::fs::remove_file(pos_file);
+    remove_telemetry_files(paths);
 }
 
 /// Regression for #11008. Combines two distinct guarantees that
@@ -249,11 +287,10 @@ async fn telemetry_masks_runtime_session_id_registered_after_spawn() {
 async fn concurrent_flushes_do_not_regress_pos_file() {
     let api = SharedApiMock::new().await;
     let server = api.server();
-
-    let ops_file = guest_common::telemetry::sandbox_ops_log();
-    let pos_file = guest_agent::paths::telemetry_sandbox_ops_pos_file();
-    let _ = std::fs::remove_file(ops_file);
-    let _ = std::fs::remove_file(pos_file);
+    let files = ExplicitTelemetryFiles::new("concurrent-flushes").unwrap();
+    let paths = &files.paths;
+    let ops_file = paths.sandbox_ops_file();
+    let pos_file = paths.telemetry_sandbox_ops_pos_file();
 
     let upload_mock = server.mock(|when, then| {
         when.method(POST).path("/api/webhooks/agent/telemetry");
@@ -261,7 +298,12 @@ async fn concurrent_flushes_do_not_regress_pos_file() {
     });
 
     let masker = std::sync::Arc::new(SecretMasker::from_raw(""));
-    let telemetry = guest_agent::telemetry::Telemetry::spawn(masker, http_client!());
+    let telemetry = guest_agent::telemetry::Telemetry::spawn_for_paths(
+        "test-run-001".to_string(),
+        paths,
+        masker,
+        http_client!(),
+    );
 
     // Record one op, then fire several concurrent flushes. Pre-refactor a
     // tick + final could both read the same pos and race on save_position;
@@ -293,8 +335,7 @@ async fn concurrent_flushes_do_not_regress_pos_file() {
     upload_mock.assert_calls_async(1).await;
 
     upload_mock.delete_async().await;
-    let _ = std::fs::remove_file(ops_file);
-    let _ = std::fs::remove_file(pos_file);
+    remove_telemetry_files(paths);
 }
 
 /// Pins three invariants that have no other test coverage:
@@ -309,14 +350,16 @@ async fn concurrent_flushes_do_not_regress_pos_file() {
 async fn flush_propagates_error_then_loop_recovers() {
     let api = SharedApiMock::new().await;
     let server = api.server();
-
-    let ops_file = guest_common::telemetry::sandbox_ops_log();
-    let pos_file = guest_agent::paths::telemetry_sandbox_ops_pos_file();
-    let _ = std::fs::remove_file(ops_file);
-    let _ = std::fs::remove_file(pos_file);
+    let files = ExplicitTelemetryFiles::new("flush-error-recovery").unwrap();
+    let paths = &files.paths;
 
     let masker = std::sync::Arc::new(SecretMasker::from_raw(""));
-    let telemetry = guest_agent::telemetry::Telemetry::spawn(masker, http_client!());
+    let telemetry = guest_agent::telemetry::Telemetry::spawn_for_paths(
+        "test-run-001".to_string(),
+        paths,
+        masker,
+        http_client!(),
+    );
 
     // Force upload_telemetry to fire HTTP by writing a delta.
     guest_common::telemetry::record_sandbox_op(
@@ -361,18 +404,18 @@ async fn flush_propagates_error_then_loop_recovers() {
     telemetry.shutdown().await;
 
     success_mock.delete_async().await;
-    let _ = std::fs::remove_file(ops_file);
-    let _ = std::fs::remove_file(pos_file);
+    remove_telemetry_files(paths);
 }
 
 #[tokio::test]
 async fn skip_only_metrics_progress_saves_position_without_posting_empty_payload() {
     let api = SharedApiMock::new().await;
     let server = api.server();
-    remove_telemetry_files();
+    let files = ExplicitTelemetryFiles::new("skip-only-metrics").unwrap();
+    let paths = &files.paths;
 
-    let metrics_file = guest_agent::paths::metrics_log_file();
-    let metrics_pos_file = guest_agent::paths::telemetry_metrics_pos_file();
+    let metrics_file = paths.metrics_log_file();
+    let metrics_pos_file = paths.telemetry_metrics_pos_file();
     ensure_parent_dir(metrics_file);
     assert!(
         std::fs::write(metrics_file, "x".repeat(TELEMETRY_DELTA_READ_LIMIT + 1)).is_ok(),
@@ -385,7 +428,12 @@ async fn skip_only_metrics_progress_saves_position_without_posting_empty_payload
     });
 
     let masker = std::sync::Arc::new(SecretMasker::from_raw(""));
-    let telemetry = guest_agent::telemetry::Telemetry::spawn(masker, http_client!());
+    let telemetry = guest_agent::telemetry::Telemetry::spawn_for_paths(
+        "test-run-001".to_string(),
+        paths,
+        masker,
+        http_client!(),
+    );
 
     telemetry
         .flush(guest_agent::telemetry::UploadMode::Live)
@@ -403,17 +451,18 @@ async fn skip_only_metrics_progress_saves_position_without_posting_empty_payload
     assert_eq!(pos, TELEMETRY_DELTA_READ_LIMIT as u64);
 
     upload_mock.delete_async().await;
-    remove_telemetry_files();
+    remove_telemetry_files(paths);
 }
 
 #[tokio::test]
 async fn oversized_system_log_uploads_marker_without_raw_line_fragment() {
     let api = SharedApiMock::new().await;
     let server = api.server();
-    remove_telemetry_files();
+    let files = ExplicitTelemetryFiles::new("oversized-system-log").unwrap();
+    let paths = &files.paths;
 
-    let system_log = guest_agent::paths::system_log_file();
-    let system_log_pos_file = guest_agent::paths::telemetry_system_log_pos_file();
+    let system_log = paths.system_log_file();
+    let system_log_pos_file = paths.telemetry_system_log_pos_file();
     let raw_token = "raw-secret-token";
     ensure_parent_dir(system_log);
     assert!(
@@ -439,7 +488,12 @@ async fn oversized_system_log_uploads_marker_without_raw_line_fragment() {
     });
 
     let masker = std::sync::Arc::new(SecretMasker::from_raw(""));
-    let telemetry = guest_agent::telemetry::Telemetry::spawn(masker, http_client!());
+    let telemetry = guest_agent::telemetry::Telemetry::spawn_for_paths(
+        "test-run-001".to_string(),
+        paths,
+        masker,
+        http_client!(),
+    );
 
     telemetry
         .flush(guest_agent::telemetry::UploadMode::Live)
@@ -459,5 +513,5 @@ async fn oversized_system_log_uploads_marker_without_raw_line_fragment() {
 
     raw_fragment_mock.delete_async().await;
     marker_mock.delete_async().await;
-    remove_telemetry_files();
+    remove_telemetry_files(paths);
 }

--- a/crates/guest-agent/tests/no_api_mode.rs
+++ b/crates/guest-agent/tests/no_api_mode.rs
@@ -1,50 +1,55 @@
 //! No-API mode is used by local/reap tests and skips all webhook calls.
 //!
-//! This test lives in its own binary because `guest_agent::env` caches
-//! environment values in process-wide `LazyLock`s.
+//! This test captures an explicit runtime from process env, then exercises
+//! disabled-HTTP users through explicit runtime/config/path entry points. The
+//! `send_event` call intentionally remains legacy compatibility coverage for
+//! no-API session metadata capture.
 
 mod common;
 
 use common::SystemLogOverrideGuard;
+use guest_agent::active_input::ActiveInputRuntime;
 use guest_agent::error::AgentError;
-use guest_agent::http::HttpClient;
 use guest_agent::masker::SecretMasker;
+use guest_agent::paths::GuestPaths;
+use guest_agent::run_context::GuestRuntime;
 use serde_json::json;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 
-fn cleanup_session_files() {
-    let _ = std::fs::remove_file(guest_agent::paths::session_id_file());
-    let _ = std::fs::remove_file(guest_agent::paths::session_history_path_file());
+fn cleanup_session_files(paths: &GuestPaths) {
+    let _ = std::fs::remove_file(paths.session_id_file());
+    let _ = std::fs::remove_file(paths.session_history_path_file());
 }
 
-fn cleanup_run_files(ops_file: &str) {
-    let _ = std::fs::remove_file(guest_agent::paths::agent_log_file());
-    let _ = std::fs::remove_file(guest_agent::paths::event_error_flag());
-    cleanup_session_files();
-    let _ = std::fs::remove_file(ops_file);
+fn cleanup_run_files(paths: &GuestPaths) {
+    let _ = std::fs::remove_file(paths.agent_log_file());
+    let _ = std::fs::remove_file(paths.event_error_flag());
+    cleanup_session_files(paths);
+    let _ = std::fs::remove_file(paths.sandbox_ops_file());
 }
 
 struct RunFilesGuard {
-    ops_file: String,
+    paths: GuestPaths,
 }
 
 impl RunFilesGuard {
-    fn new() -> Self {
-        let ops_file = guest_common::telemetry::sandbox_ops_log().to_string();
-        cleanup_run_files(&ops_file);
-        Self { ops_file }
+    fn new(paths: &GuestPaths) -> Self {
+        cleanup_run_files(paths);
+        Self {
+            paths: paths.clone(),
+        }
     }
 
     fn ops_file(&self) -> &str {
-        &self.ops_file
+        self.paths.sandbox_ops_file()
     }
 }
 
 impl Drop for RunFilesGuard {
     fn drop(&mut self) {
-        cleanup_run_files(&self.ops_file);
+        cleanup_run_files(&self.paths);
     }
 }
 
@@ -57,8 +62,9 @@ async fn no_api_mode_drains_background_webhook_users_without_network_client()
         common::setup_env(&mock, tmp.path(), "@exit-after-result", 3, 1)?;
     }
 
-    let http = HttpClient::for_current_env()?;
-    let run_files = RunFilesGuard::new();
+    let runtime = GuestRuntime::from_process_env()?;
+    let http = runtime.http.clone();
+    let run_files = RunFilesGuard::new(&runtime.paths);
     let ops_file = run_files.ops_file();
 
     let disabled = http
@@ -70,7 +76,12 @@ async fn no_api_mode_drains_background_webhook_users_without_network_client()
     assert!(message.contains("HTTP client is disabled"));
 
     let masker = Arc::new(SecretMasker::from_raw(""));
-    let telemetry = guest_agent::telemetry::Telemetry::spawn(Arc::clone(&masker), http.clone());
+    let telemetry = guest_agent::telemetry::Telemetry::spawn_for_paths(
+        runtime.config.run_id.clone(),
+        &runtime.paths,
+        Arc::clone(&masker),
+        http.clone(),
+    );
     telemetry.final_flush_and_shutdown().await?;
 
     let shutdown = CancellationToken::new();
@@ -92,14 +103,21 @@ async fn no_api_mode_drains_background_webhook_users_without_network_client()
     });
     guest_agent::events::send_event(&http, event, 1, &masker).await?;
     assert_eq!(
-        std::fs::read_to_string(guest_agent::paths::session_id_file())?,
+        std::fs::read_to_string(runtime.paths.session_id_file())?,
         "session-no-api"
     );
-    cleanup_session_files();
+    cleanup_session_files(&runtime.paths);
 
     let complete_log_path = tmp.path().join("complete-system.log");
     let complete_log_guard = SystemLogOverrideGuard::set(&complete_log_path);
-    guest_agent::complete::report_success(&http, "sandbox-no-api", "reused", Some(1)).await;
+    guest_agent::complete::report_success_for_run(
+        &http,
+        &runtime.config.run_id,
+        "sandbox-no-api",
+        "reused",
+        Some(1),
+    )
+    .await;
     drop(complete_log_guard);
     let complete_log = std::fs::read_to_string(&complete_log_path).unwrap_or_default();
     assert!(
@@ -107,9 +125,21 @@ async fn no_api_mode_drains_background_webhook_users_without_network_client()
         "no-API complete path must return before touching the disabled HTTP client: {complete_log}"
     );
 
+    let active_input = ActiveInputRuntime::new_with_initial_prompt(
+        &runtime.config.run_id,
+        false,
+        &runtime.config.prompt,
+    );
     let cli_result = tokio::time::timeout(
         Duration::from_secs(5),
-        guest_agent::cli::execute_cli(&masker, common::spawn_dummy_heartbeat(), http.clone()),
+        guest_agent::cli::execute_cli_with_active_input_for_config(
+            &masker,
+            common::spawn_dummy_heartbeat(),
+            http.clone(),
+            active_input.into_writer(),
+            &runtime.config,
+            &runtime.paths,
+        ),
     )
     .await
     .expect("no-API execute_cli should return promptly with disabled HTTP client")?;
@@ -119,16 +149,15 @@ async fn no_api_mode_drains_background_webhook_users_without_network_client()
         "no-API execute_cli must not enqueue webhook events"
     );
     assert!(
-        !std::path::Path::new(guest_agent::paths::event_error_flag()).exists(),
+        !std::path::Path::new(runtime.paths.event_error_flag()).exists(),
         "no-API execute_cli must not write event error flag"
     );
-    let cli_session_id = std::fs::read_to_string(guest_agent::paths::session_id_file())?;
+    let cli_session_id = std::fs::read_to_string(runtime.paths.session_id_file())?;
     assert!(
         cli_session_id.starts_with("mock-"),
         "no-API execute_cli should capture session metadata from stdout events, got {cli_session_id}"
     );
-    let cli_history_path =
-        std::fs::read_to_string(guest_agent::paths::session_history_path_file())?;
+    let cli_history_path = std::fs::read_to_string(runtime.paths.session_history_path_file())?;
     assert!(
         cli_history_path.contains(cli_session_id.trim()),
         "history path should contain the captured CLI session id, got {cli_history_path}"

--- a/crates/guest-agent/tests/no_api_mode.rs
+++ b/crates/guest-agent/tests/no_api_mode.rs
@@ -11,47 +11,11 @@ use common::SystemLogOverrideGuard;
 use guest_agent::active_input::ActiveInputRuntime;
 use guest_agent::error::AgentError;
 use guest_agent::masker::SecretMasker;
-use guest_agent::paths::GuestPaths;
 use guest_agent::run_context::GuestRuntime;
 use serde_json::json;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio_util::sync::CancellationToken;
-
-fn cleanup_session_files(paths: &GuestPaths) {
-    let _ = std::fs::remove_file(paths.session_id_file());
-    let _ = std::fs::remove_file(paths.session_history_path_file());
-}
-
-fn cleanup_run_files(paths: &GuestPaths) {
-    let _ = std::fs::remove_file(paths.agent_log_file());
-    let _ = std::fs::remove_file(paths.event_error_flag());
-    cleanup_session_files(paths);
-    let _ = std::fs::remove_file(paths.sandbox_ops_file());
-}
-
-struct RunFilesGuard {
-    paths: GuestPaths,
-}
-
-impl RunFilesGuard {
-    fn new(paths: &GuestPaths) -> Self {
-        cleanup_run_files(paths);
-        Self {
-            paths: paths.clone(),
-        }
-    }
-
-    fn ops_file(&self) -> &str {
-        self.paths.sandbox_ops_file()
-    }
-}
-
-impl Drop for RunFilesGuard {
-    fn drop(&mut self) {
-        cleanup_run_files(&self.paths);
-    }
-}
 
 #[tokio::test]
 async fn no_api_mode_drains_background_webhook_users_without_network_client()
@@ -64,8 +28,8 @@ async fn no_api_mode_drains_background_webhook_users_without_network_client()
 
     let runtime = GuestRuntime::from_process_env()?;
     let http = runtime.http.clone();
-    let run_files = RunFilesGuard::new(&runtime.paths);
-    let ops_file = run_files.ops_file();
+    let run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
+    let ops_file = run_files.sandbox_ops_file();
 
     let disabled = http
         .post_json("http://127.0.0.1:1/should-not-send", &json!({}), 1)
@@ -106,7 +70,8 @@ async fn no_api_mode_drains_background_webhook_users_without_network_client()
         std::fs::read_to_string(runtime.paths.session_id_file())?,
         "session-no-api"
     );
-    cleanup_session_files(&runtime.paths);
+    let _ = std::fs::remove_file(runtime.paths.session_id_file());
+    let _ = std::fs::remove_file(runtime.paths.session_history_path_file());
 
     let complete_log_path = tmp.path().join("complete-system.log");
     let complete_log_guard = SystemLogOverrideGuard::set(&complete_log_path);

--- a/crates/guest-agent/tests/post_result_reap.rs
+++ b/crates/guest-agent/tests/post_result_reap.rs
@@ -20,6 +20,8 @@ async fn post_result_reap_sigterm_kills_hung_cli() -> Result<(), Box<dyn std::er
         common::setup_env(&mock, tmp.path(), "@hang-after-result", 1, 5)?;
     }
 
+    let runtime = common::guest_runtime_from_process_env()?;
+
     let masker = guest_agent::masker::SecretMasker::from_raw("");
     let heartbeat = common::spawn_dummy_heartbeat();
 
@@ -29,11 +31,7 @@ async fn post_result_reap_sigterm_kills_hung_cli() -> Result<(), Box<dyn std::er
     // reap. Locally runs in ~1s.
     let result = tokio::time::timeout(
         Duration::from_secs(15),
-        guest_agent::cli::execute_cli(
-            &masker,
-            heartbeat,
-            guest_agent::http::HttpClient::new().unwrap(),
-        ),
+        common::execute_cli_for_runtime(&runtime, &masker, heartbeat),
     )
     .await
     .expect("execute_cli did not return within 15s — reap likely broken");

--- a/crates/guest-agent/tests/post_result_reap_error_result.rs
+++ b/crates/guest-agent/tests/post_result_reap_error_result.rs
@@ -18,16 +18,14 @@ async fn post_result_reap_preserves_error_diagnostic() -> Result<(), Box<dyn std
     }
     let _run_files = common::RunFilesGuard::new();
 
+    let runtime = common::guest_runtime_from_process_env()?;
+
     let masker = guest_agent::masker::SecretMasker::from_raw("");
     let heartbeat = common::spawn_dummy_heartbeat();
 
     let result = tokio::time::timeout(
         Duration::from_secs(8),
-        guest_agent::cli::execute_cli(
-            &masker,
-            heartbeat,
-            guest_agent::http::HttpClient::new().unwrap(),
-        ),
+        common::execute_cli_for_runtime(&runtime, &masker, heartbeat),
     )
     .await
     .expect("execute_cli did not return within 8s");

--- a/crates/guest-agent/tests/post_result_reap_error_result.rs
+++ b/crates/guest-agent/tests/post_result_reap_error_result.rs
@@ -16,9 +16,8 @@ async fn post_result_reap_preserves_error_diagnostic() -> Result<(), Box<dyn std
     unsafe {
         common::setup_env(&mock, tmp.path(), "@hang-after-error-result", 1, 1)?;
     }
-    let _run_files = common::RunFilesGuard::new();
-
     let runtime = common::guest_runtime_from_process_env()?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
 
     let masker = guest_agent::masker::SecretMasker::from_raw("");
     let heartbeat = common::spawn_dummy_heartbeat();

--- a/crates/guest-agent/tests/post_result_reap_happy.rs
+++ b/crates/guest-agent/tests/post_result_reap_happy.rs
@@ -26,6 +26,8 @@ async fn post_result_reap_stays_silent_on_clean_exit() -> Result<(), Box<dyn std
         common::setup_env(&mock, tmp.path(), "@exit-after-result", 60, 1)?;
     }
 
+    let runtime = common::guest_runtime_from_process_env()?;
+
     let masker = guest_agent::masker::SecretMasker::from_raw("");
     let heartbeat = common::spawn_dummy_heartbeat();
 
@@ -34,11 +36,7 @@ async fn post_result_reap_stays_silent_on_clean_exit() -> Result<(), Box<dyn std
     // assertion on fork/exec or async scheduling.
     let result = tokio::time::timeout(
         Duration::from_secs(15),
-        guest_agent::cli::execute_cli(
-            &masker,
-            heartbeat,
-            guest_agent::http::HttpClient::new().unwrap(),
-        ),
+        common::execute_cli_for_runtime(&runtime, &masker, heartbeat),
     )
     .await
     .expect("execute_cli did not return within 15s on the happy path");

--- a/crates/guest-agent/tests/post_result_reap_refresh.rs
+++ b/crates/guest-agent/tests/post_result_reap_refresh.rs
@@ -17,16 +17,14 @@ async fn post_result_reap_refreshes_quiet_deadline_on_meaningful_event()
     }
     let _run_files = common::RunFilesGuard::new();
 
+    let runtime = common::guest_runtime_from_process_env()?;
+
     let masker = guest_agent::masker::SecretMasker::from_raw("");
     let heartbeat = common::spawn_dummy_heartbeat();
 
     let result = tokio::time::timeout(
         Duration::from_secs(12),
-        guest_agent::cli::execute_cli(
-            &masker,
-            heartbeat,
-            guest_agent::http::HttpClient::new().unwrap(),
-        ),
+        common::execute_cli_for_runtime(&runtime, &masker, heartbeat),
     )
     .await
     .expect("execute_cli did not return within 12s");

--- a/crates/guest-agent/tests/post_result_reap_refresh.rs
+++ b/crates/guest-agent/tests/post_result_reap_refresh.rs
@@ -15,9 +15,8 @@ async fn post_result_reap_refreshes_quiet_deadline_on_meaningful_event()
         common::setup_env(&mock, tmp.path(), "@hang-after-result-then-event", 2, 1)?;
         std::env::set_var("VM0_POST_RESULT_TOTAL_CAP_SECS", "10");
     }
-    let _run_files = common::RunFilesGuard::new();
-
     let runtime = common::guest_runtime_from_process_env()?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
 
     let masker = guest_agent::masker::SecretMasker::from_raw("");
     let heartbeat = common::spawn_dummy_heartbeat();
@@ -37,7 +36,7 @@ async fn post_result_reap_refreshes_quiet_deadline_on_meaningful_event()
     assert_eq!(termination.reason, CliTerminationReason::PostResultReap);
     assert_eq!(termination.signal_sent, Some(CliTerminationSignal::Sigterm));
 
-    let ops = std::fs::read_to_string(guest_common::telemetry::sandbox_ops_log())?;
+    let ops = std::fs::read_to_string(runtime.paths.sandbox_ops_file())?;
     assert!(ops.contains("trigger=quiet_timeout"), "{ops}");
     assert!(ops.contains("meaningful_events=1"), "{ops}");
     Ok(())

--- a/crates/guest-agent/tests/post_result_reap_sigkill.rs
+++ b/crates/guest-agent/tests/post_result_reap_sigkill.rs
@@ -23,6 +23,8 @@ async fn post_result_reap_escalates_to_sigkill_when_sigterm_ignored()
         common::setup_env(&mock, tmp.path(), "@hang-after-result-deaf", 1, 1)?;
     }
 
+    let runtime = common::guest_runtime_from_process_env()?;
+
     let masker = guest_agent::masker::SecretMasker::from_raw("");
     let heartbeat = common::spawn_dummy_heartbeat();
 
@@ -30,11 +32,7 @@ async fn post_result_reap_escalates_to_sigkill_when_sigterm_ignored()
     // stdout drain (5s) + slack = 15s.
     let result = tokio::time::timeout(
         Duration::from_secs(15),
-        guest_agent::cli::execute_cli(
-            &masker,
-            heartbeat,
-            guest_agent::http::HttpClient::new().unwrap(),
-        ),
+        common::execute_cli_for_runtime(&runtime, &masker, heartbeat),
     )
     .await
     .expect("execute_cli did not return within 15s — sigkill escalation likely broken");

--- a/crates/guest-agent/tests/post_result_reap_total_cap.rs
+++ b/crates/guest-agent/tests/post_result_reap_total_cap.rs
@@ -21,9 +21,8 @@ async fn post_result_reap_total_cap_bounds_periodic_meaningful_events()
         )?;
         std::env::set_var("VM0_POST_RESULT_TOTAL_CAP_SECS", "3");
     }
-    let _run_files = common::RunFilesGuard::new();
-
     let runtime = common::guest_runtime_from_process_env()?;
+    let _run_files = common::RunFilesGuard::new_for_paths(&runtime.paths);
 
     let masker = guest_agent::masker::SecretMasker::from_raw("");
     let heartbeat = common::spawn_dummy_heartbeat();
@@ -43,7 +42,7 @@ async fn post_result_reap_total_cap_bounds_periodic_meaningful_events()
     assert_eq!(termination.reason, CliTerminationReason::PostResultReap);
     assert_eq!(termination.signal_sent, Some(CliTerminationSignal::Sigterm));
 
-    let ops = std::fs::read_to_string(guest_common::telemetry::sandbox_ops_log())?;
+    let ops = std::fs::read_to_string(runtime.paths.sandbox_ops_file())?;
     let cleanup_line = ops
         .lines()
         .find(|line| line.contains("post_result_cleanup_terminated"))

--- a/crates/guest-agent/tests/post_result_reap_total_cap.rs
+++ b/crates/guest-agent/tests/post_result_reap_total_cap.rs
@@ -23,16 +23,14 @@ async fn post_result_reap_total_cap_bounds_periodic_meaningful_events()
     }
     let _run_files = common::RunFilesGuard::new();
 
+    let runtime = common::guest_runtime_from_process_env()?;
+
     let masker = guest_agent::masker::SecretMasker::from_raw("");
     let heartbeat = common::spawn_dummy_heartbeat();
 
     let result = tokio::time::timeout(
         Duration::from_secs(8),
-        guest_agent::cli::execute_cli(
-            &masker,
-            heartbeat,
-            guest_agent::http::HttpClient::new().unwrap(),
-        ),
+        common::execute_cli_for_runtime(&runtime, &masker, heartbeat),
     )
     .await
     .expect("execute_cli did not return within 8s");

--- a/crates/guest-agent/tests/process_control_channel.rs
+++ b/crates/guest-agent/tests/process_control_channel.rs
@@ -407,22 +407,7 @@ fn join_guest(guest: thread::JoinHandle<io::Result<()>>) -> TestResult<()> {
 }
 
 fn guest_agent_wrapper_command(guest_agent: &str) -> String {
-    format!(
-        "cleanup_home_user=0; \
-         cleanup_workspace=0; \
-         if [ ! -e /home/user ]; then cleanup_home_user=1; fi; \
-         if [ ! -e /home/user/workspace ]; then cleanup_workspace=1; fi; \
-         {}; \
-         status=$?; \
-         if [ \"$cleanup_workspace\" = 1 ]; then \
-           rmdir /home/user/workspace 2>/dev/null || true; \
-         fi; \
-         if [ \"$cleanup_home_user\" = 1 ]; then \
-           rmdir /home/user 2>/dev/null || true; \
-        fi; \
-         exit $status",
-        quote_shell_arg(guest_agent)
-    )
+    quote_shell_arg(guest_agent)
 }
 
 fn needs_sudo_for_canonical_workspace() -> bool {

--- a/crates/guest-agent/tests/process_control_channel.rs
+++ b/crates/guest-agent/tests/process_control_channel.rs
@@ -92,6 +92,7 @@ async fn process_control_channel_reaches_guest_agent() -> TestResult<()> {
         ("HOME", workdir.as_str()),
     ];
 
+    common::ensure_canonical_workspace_for_test()?;
     let connection = start_host_and_guest(tmp.path()).await?;
     let command = guest_agent_wrapper_command(guest_agent);
     let sudo = needs_sudo_for_canonical_workspace();
@@ -196,6 +197,7 @@ async fn process_control_enabled_plain_run_does_not_wait_for_stdin_eof() -> Test
         ("HOME", workdir.as_str()),
     ];
 
+    common::ensure_canonical_workspace_for_test()?;
     let connection = start_host_and_guest(tmp.path()).await?;
     let command = guest_agent_wrapper_command(guest_agent);
     let sudo = needs_sudo_for_canonical_workspace();

--- a/crates/guest-agent/tests/process_control_env.rs
+++ b/crates/guest-agent/tests/process_control_env.rs
@@ -1,8 +1,8 @@
 //! The guest-agent process receives the process-control bootstrap endpoint, but
 //! the child CLI must not inherit it.
 //!
-//! This test lives in its own binary because `guest_agent::env` caches
-//! environment values in process-wide `LazyLock`s.
+//! This test lives in its own binary to isolate process env, working directory,
+//! and guest runtime path overrides used during setup.
 
 mod common;
 
@@ -27,16 +27,14 @@ async fn process_control_endpoint_is_not_inherited_by_cli_child()
         );
     }
 
+    let runtime = common::guest_runtime_from_process_env()?;
+
     let masker = guest_agent::masker::SecretMasker::from_raw("");
     let heartbeat = common::spawn_dummy_heartbeat();
 
     let result = tokio::time::timeout(
         Duration::from_secs(15),
-        guest_agent::cli::execute_cli(
-            &masker,
-            heartbeat,
-            guest_agent::http::HttpClient::new().unwrap(),
-        ),
+        common::execute_cli_for_runtime(&runtime, &masker, heartbeat),
     )
     .await
     .expect("execute_cli did not return within 15s");

--- a/crates/guest-agent/tests/stuck_tool_reap_sigkill.rs
+++ b/crates/guest-agent/tests/stuck_tool_reap_sigkill.rs
@@ -18,6 +18,8 @@ async fn stuck_tool_reap_escalates_to_sigkill_when_sigterm_ignored()
         common::setup_env(&mock, tmp.path(), "@stuck-tool-deaf", 1, 1)?;
     }
 
+    let runtime = common::guest_runtime_from_process_env()?;
+
     let masker = guest_agent::masker::SecretMasker::from_raw("");
     let heartbeat = common::spawn_dummy_heartbeat();
 
@@ -26,11 +28,7 @@ async fn stuck_tool_reap_escalates_to_sigkill_when_sigterm_ignored()
     // + slack.
     let result = tokio::time::timeout(
         Duration::from_secs(15),
-        guest_agent::cli::execute_cli(
-            &masker,
-            heartbeat,
-            guest_agent::http::HttpClient::new().unwrap(),
-        ),
+        common::execute_cli_for_runtime(&runtime, &masker, heartbeat),
     )
     .await
     .expect("execute_cli did not return within 15s - forced SIGKILL escalation likely broken");

--- a/crates/guest-agent/tests/stuck_tool_reap_sigkill.rs
+++ b/crates/guest-agent/tests/stuck_tool_reap_sigkill.rs
@@ -14,8 +14,8 @@ async fn stuck_tool_reap_escalates_to_sigkill_when_sigterm_ignored()
     let mock = common::build_and_locate_mock()?;
     let tmp = tempfile::tempdir()?;
     unsafe {
-        std::env::set_var("VM0_STUCK_TOOL_TIMEOUT_SECS", "1");
         common::setup_env(&mock, tmp.path(), "@stuck-tool-deaf", 1, 1)?;
+        std::env::set_var("VM0_STUCK_TOOL_TIMEOUT_SECS", "1");
     }
 
     let runtime = common::guest_runtime_from_process_env()?;

--- a/crates/guest-agent/tests/stuck_tool_stdout_eof_reap_sigkill.rs
+++ b/crates/guest-agent/tests/stuck_tool_stdout_eof_reap_sigkill.rs
@@ -18,6 +18,8 @@ async fn stuck_tool_reap_survives_stdout_eof_before_child_exit()
         common::setup_env(&mock, tmp.path(), "@stuck-tool-closed-stdout-deaf", 1, 1)?;
     }
 
+    let runtime = common::guest_runtime_from_process_env()?;
+
     let masker = guest_agent::masker::SecretMasker::from_raw("");
     let heartbeat = common::spawn_dummy_heartbeat();
 
@@ -25,11 +27,7 @@ async fn stuck_tool_reap_survives_stdout_eof_before_child_exit()
     // + sigkill grace (1s, unignorable) + slack.
     let result = tokio::time::timeout(
         Duration::from_secs(15),
-        guest_agent::cli::execute_cli(
-            &masker,
-            heartbeat,
-            guest_agent::http::HttpClient::new().unwrap(),
-        ),
+        common::execute_cli_for_runtime(&runtime, &masker, heartbeat),
     )
     .await
     .expect("execute_cli did not return within 15s - stdout EOF forced reap likely broken");

--- a/crates/guest-agent/tests/stuck_tool_stdout_eof_reap_sigkill.rs
+++ b/crates/guest-agent/tests/stuck_tool_stdout_eof_reap_sigkill.rs
@@ -14,8 +14,8 @@ async fn stuck_tool_reap_survives_stdout_eof_before_child_exit()
     let mock = common::build_and_locate_mock()?;
     let tmp = tempfile::tempdir()?;
     unsafe {
-        std::env::set_var("VM0_STUCK_TOOL_TIMEOUT_SECS", "1");
         common::setup_env(&mock, tmp.path(), "@stuck-tool-closed-stdout-deaf", 1, 1)?;
+        std::env::set_var("VM0_STUCK_TOOL_TIMEOUT_SECS", "1");
     }
 
     let runtime = common::guest_runtime_from_process_env()?;


### PR DESCRIPTION
## Summary

- migrate normal guest-agent CLI, telemetry, complete, checkpoint, no-API, and Codex app-server tests to explicit GuestRuntime/GuestPaths/run-id APIs
- add narrow common test helpers that pass captured runtime values into existing explicit CLI entry points
- make shared run-file cleanup accept captured GuestPaths so migrated tests do not clean legacy process-global paths
- keep remaining legacy coverage intentionally scoped to legacy/env/http-client/event-metadata compatibility tests

## Remaining intentional legacy coverage

- `cli_legacy_child_env.rs` still exercises `execute_cli(...)` legacy env capture behavior
- `http_env_missing_api_url.rs` and `integration/http_client.rs` still exercise `HttpClient::for_current_env(...)`
- `integration/events.rs` still exercises `send_event(...)` for event delivery and session metadata side effects; only the error-flag-only case moved to `post_event_with_error_flag(...)`
- `integration/telemetry.rs`, `no_api_mode.rs`, and `codex_session_resume.rs` keep targeted `send_event(...)` coverage where session metadata capture is the behavior under test
- `codex_session_resume.rs` keeps legacy checkpoint coverage for Codex env/framework metadata capture

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test integration --test no_api_mode --test execute_cli_api_mode --test artifact_checkpoint_content_hash --test codex_session_resume --test codex_app_server_backend --test codex_app_server_backend_active_input`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test codex_app_server_backend --test codex_app_server_backend_active_input --test codex_app_server_backend_resume --test codex_app_server_backend_scope --test post_result_reap_error_result --test post_result_reap_refresh --test post_result_reap_total_cap --test no_api_mode`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --no-run`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --tests -- -D warnings`
- pre-commit `cargo-doc`, `cargo-clippy`, `cargo-fmt`

Closes #19593
