### PR TITLE
perf: move nbd cow io off dispatch workers

### DIFF
--- a/crates/nbd-cow/src/cow_io.rs
+++ b/crates/nbd-cow/src/cow_io.rs
@@ -8,6 +8,11 @@ use tokio::sync::Semaphore;
 use crate::cow::CowLayer;
 use crate::error::{NbdCowError, Result};
 
+/// Async handle for serialized COW storage operations.
+///
+/// `CowLayer` performs synchronous positioned file I/O. `CowIo` keeps that
+/// blocking work out of async dispatch tasks while preserving one active COW
+/// operation per device.
 #[derive(Clone)]
 pub struct CowIo {
     inner: Arc<CowIoInner>,
@@ -18,14 +23,19 @@ struct CowIoInner {
     operation_slot: Arc<Semaphore>,
 }
 
+/// Snapshot of COW state counters used for diagnostics and tests.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct CowIoStatus {
+    /// Blocks already materialized in the sparse COW file.
     pub dirty_blocks: usize,
+    /// Blocks currently buffered in memory and not yet flushed.
     pub buffered_blocks: usize,
+    /// Approximate memory used by the write buffer.
     pub buffer_bytes: usize,
 }
 
 impl CowIo {
+    /// Create a new async COW I/O boundary around a synchronous COW layer.
     pub fn new(cow: CowLayer) -> Self {
         Self {
             inner: Arc::new(CowIoInner {
@@ -35,6 +45,7 @@ impl CowIo {
         }
     }
 
+    /// Read data at `offset` into the provided buffer and return it.
     pub async fn read(&self, offset: u64, mut data: Vec<u8>) -> Result<Vec<u8>> {
         self.run("read", move |cow| {
             cow.read(offset, &mut data)?;
@@ -43,6 +54,7 @@ impl CowIo {
         .await
     }
 
+    /// Write `data` at `offset`, flushing buffered data when the threshold is reached.
     pub async fn write(&self, offset: u64, data: Vec<u8>) -> Result<Vec<u8>> {
         self.run("write", move |cow| {
             let needs_flush = cow.write(offset, &data)?;
@@ -54,15 +66,17 @@ impl CowIo {
         .await
     }
 
+    /// Flush pending data and sync the COW file when it exists.
     pub async fn sync(&self) -> Result<()> {
         self.run("sync", CowLayer::sync).await
     }
 
-    pub async fn save_bitmap(&self, path: PathBuf) -> Result<()> {
+    pub(crate) async fn save_bitmap(&self, path: PathBuf) -> Result<()> {
         self.run("save bitmap", move |cow| cow.save_bitmap(&path))
             .await
     }
 
+    /// Return a consistent snapshot of COW counters.
     pub async fn status(&self) -> Result<CowIoStatus> {
         self.run("status", |cow| {
             Ok(CowIoStatus {

--- a/crates/nbd-cow/src/cow_io.rs
+++ b/crates/nbd-cow/src/cow_io.rs
@@ -1,0 +1,122 @@
+//! Async boundary for synchronous COW storage operations.
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use tokio::sync::Semaphore;
+
+use crate::cow::CowLayer;
+use crate::error::{NbdCowError, Result};
+
+#[derive(Clone)]
+pub struct CowIo {
+    inner: Arc<CowIoInner>,
+}
+
+struct CowIoInner {
+    cow: Mutex<CowLayer>,
+    operation_slot: Arc<Semaphore>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CowIoStatus {
+    pub dirty_blocks: usize,
+    pub buffered_blocks: usize,
+    pub buffer_bytes: usize,
+}
+
+impl CowIo {
+    pub fn new(cow: CowLayer) -> Self {
+        Self {
+            inner: Arc::new(CowIoInner {
+                cow: Mutex::new(cow),
+                operation_slot: Arc::new(Semaphore::new(1)),
+            }),
+        }
+    }
+
+    pub async fn read(&self, offset: u64, mut data: Vec<u8>) -> Result<Vec<u8>> {
+        self.run("read", move |cow| {
+            cow.read(offset, &mut data)?;
+            Ok(data)
+        })
+        .await
+    }
+
+    pub async fn write(&self, offset: u64, data: Vec<u8>) -> Result<Vec<u8>> {
+        self.run("write", move |cow| {
+            let needs_flush = cow.write(offset, &data)?;
+            if needs_flush {
+                cow.flush()?;
+            }
+            Ok(data)
+        })
+        .await
+    }
+
+    pub async fn sync(&self) -> Result<()> {
+        self.run("sync", CowLayer::sync).await
+    }
+
+    pub async fn save_bitmap(&self, path: PathBuf) -> Result<()> {
+        self.run("save bitmap", move |cow| cow.save_bitmap(&path))
+            .await
+    }
+
+    pub async fn status(&self) -> Result<CowIoStatus> {
+        self.run("status", |cow| {
+            Ok(CowIoStatus {
+                dirty_blocks: cow.dirty_block_count(),
+                buffered_blocks: cow.buffered_block_count(),
+                buffer_bytes: cow.buffer_bytes(),
+            })
+        })
+        .await
+    }
+
+    async fn run<T>(
+        &self,
+        operation: &'static str,
+        f: impl FnOnce(&mut CowLayer) -> Result<T> + Send + 'static,
+    ) -> Result<T>
+    where
+        T: Send + 'static,
+    {
+        let permit = self
+            .inner
+            .operation_slot
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|_| closed_error(operation))?;
+        let inner = self.inner.clone();
+
+        match tokio::task::spawn_blocking(move || {
+            let _permit = permit;
+            let mut cow = lock_cow(&inner, operation)?;
+            f(&mut cow)
+        })
+        .await
+        {
+            Ok(result) => result,
+            Err(e) if e.is_panic() => std::panic::resume_unwind(e.into_panic()),
+            Err(e) => Err(NbdCowError::Io(std::io::Error::other(format!(
+                "COW I/O {operation} task was cancelled: {e}",
+            )))),
+        }
+    }
+}
+
+fn lock_cow<'a>(inner: &'a CowIoInner, operation: &str) -> Result<MutexGuard<'a, CowLayer>> {
+    inner.cow.lock().map_err(|_| {
+        NbdCowError::Io(std::io::Error::other(format!(
+            "COW layer mutex poisoned during {operation}",
+        )))
+    })
+}
+
+fn closed_error(operation: &str) -> NbdCowError {
+    NbdCowError::Io(std::io::Error::other(format!(
+        "COW I/O operation slot closed before {operation}",
+    )))
+}

--- a/crates/nbd-cow/src/device/create.rs
+++ b/crates/nbd-cow/src/device/create.rs
@@ -1,11 +1,11 @@
 use std::os::fd::OwnedFd;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::time::Duration;
 
 use crate::error::{self, Result};
-use crate::{BLOCK_SIZE, DEFAULT_FLUSH_THRESHOLD, NUM_CONNECTIONS, cow, netlink, pool, server};
-use tokio::sync::RwLock;
+use crate::{
+    BLOCK_SIZE, DEFAULT_FLUSH_THRESHOLD, NUM_CONNECTIONS, cow, cow_io, netlink, pool, server,
+};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
@@ -67,7 +67,7 @@ impl CreateDisconnectStatus {
 struct CreateContext<'a> {
     device_pool: &'a pool::DevicePoolHandle,
     cow_file: &'a Path,
-    cow_layer: Arc<RwLock<cow::CowLayer>>,
+    cow: cow_io::CowIo,
     size: u64,
 }
 
@@ -75,13 +75,13 @@ impl<'a> CreateContext<'a> {
     fn new(
         device_pool: &'a pool::DevicePoolHandle,
         cow_file: &'a Path,
-        cow_layer: Arc<RwLock<cow::CowLayer>>,
+        cow: cow_io::CowIo,
         size: u64,
     ) -> Self {
         Self {
             device_pool,
             cow_file,
-            cow_layer,
+            cow,
             size,
         }
     }
@@ -94,7 +94,7 @@ impl<'a> CreateContext<'a> {
             let device_index = attempt.device_index();
 
             if netlink::verify_device_size(device_index, self.size).await {
-                return attempt.into_device(self.cow_file, self.cow_layer.clone());
+                return attempt.into_device(self.cow_file, self.cow.clone());
             }
 
             tracing::info!(
@@ -189,7 +189,7 @@ impl<'a> CreateContext<'a> {
             let (client_fd, server_fd) = netlink::create_socketpair()?;
             client_fds.push(client_fd);
 
-            let cow = self.cow_layer.clone();
+            let cow = self.cow.clone();
             let token = attempt.shutdown_token();
             let handle = tokio::spawn(async move {
                 if let Err(e) = server::dispatch(server_fd, cow, token).await {
@@ -474,7 +474,7 @@ impl CreateAttemptGuard {
     fn into_device(
         mut self,
         cow_file: &Path,
-        cow_layer: Arc<RwLock<cow::CowLayer>>,
+        cow: cow_io::CowIo,
     ) -> Result<(NbdCowDevice, pool::DeviceLease)> {
         let Some(connected) = self.connected else {
             return Err(error::NbdCowError::Io(std::io::Error::other(
@@ -495,7 +495,7 @@ impl CreateAttemptGuard {
                 device_index: connected.index,
                 device_path: PathBuf::from(format!("/dev/nbd{}", connected.index)),
                 cow_file: cow_file.to_path_buf(),
-                cow: cow_layer,
+                cow,
                 server_handles,
                 shutdown,
                 disconnected: false,
@@ -648,8 +648,8 @@ impl NbdCowDevice {
             BLOCK_SIZE,
             DEFAULT_FLUSH_THRESHOLD,
         )?;
-        let cow_layer = Arc::new(RwLock::new(cow_layer));
-        let context = CreateContext::new(device_pool, cow_file, cow_layer, size);
+        let cow = cow_io::CowIo::new(cow_layer);
+        let context = CreateContext::new(device_pool, cow_file, cow, size);
 
         context.create_with_size_retries().await
     }

--- a/crates/nbd-cow/src/device/mod.rs
+++ b/crates/nbd-cow/src/device/mod.rs
@@ -1,9 +1,7 @@
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 
 use crate::error::Result;
-use crate::{cow, error, netlink};
-use tokio::sync::RwLock;
+use crate::{cow, cow_io, error, netlink};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
@@ -32,8 +30,8 @@ pub struct NbdCowDevice {
     device_path: PathBuf,
     /// Path to the sparse COW file.
     cow_file: PathBuf,
-    /// Shared COW layer (also held by dispatch tasks).
-    cow: Arc<RwLock<cow::CowLayer>>,
+    /// Shared COW I/O boundary (also held by dispatch tasks).
+    cow: cow_io::CowIo,
     /// Background server task handles (one per connection).
     server_handles: Vec<JoinHandle<()>>,
     /// Shutdown signal for all server tasks.
@@ -65,15 +63,25 @@ impl NbdCowDevice {
 
     /// Log COW device status for debugging.
     pub async fn log_status(&self) {
-        let cow = self.cow.read().await;
-        tracing::info!(
-            device_index = self.device_index,
-            device_path = %self.device_path.display(),
-            dirty_blocks = cow.dirty_block_count(),
-            buffered_blocks = cow.buffered_block_count(),
-            buffer_bytes = cow.buffer_bytes(),
-            "NBD COW device status"
-        );
+        match self.cow.status().await {
+            Ok(status) => {
+                tracing::info!(
+                    device_index = self.device_index,
+                    device_path = %self.device_path.display(),
+                    dirty_blocks = status.dirty_blocks,
+                    buffered_blocks = status.buffered_blocks,
+                    buffer_bytes = status.buffer_bytes,
+                    "NBD COW device status"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    device_index = self.device_index,
+                    device_path = %self.device_path.display(),
+                    "failed to read NBD COW device status: {e}"
+                );
+            }
+        }
     }
 
     /// Mark the device as abandoned without performing cleanup.
@@ -127,8 +135,7 @@ impl NbdCowDevice {
         // Tasks are stopped — we have exclusive logical access to the COW layer.
         // Save bitmap before disconnecting if keeping the COW file.
         if save_bitmap {
-            let cow = self.cow.read().await;
-            cow.save_bitmap(&self.bitmap_path())?;
+            self.cow.save_bitmap(self.bitmap_path()).await?;
         }
 
         Ok(())

--- a/crates/nbd-cow/src/device/pooled.rs
+++ b/crates/nbd-cow/src/device/pooled.rs
@@ -438,10 +438,8 @@ impl PooledNbdCowDevice {
 #[cfg(test)]
 mod tests {
     use std::path::{Path, PathBuf};
-    use std::sync::Arc;
 
-    use crate::{BLOCK_SIZE, DEFAULT_FLUSH_THRESHOLD, cow, pool};
-    use tokio::sync::RwLock;
+    use crate::{BLOCK_SIZE, DEFAULT_FLUSH_THRESHOLD, cow, cow_io, pool};
     use tokio_util::sync::CancellationToken;
 
     use super::*;
@@ -488,7 +486,7 @@ mod tests {
                     device_index: TEST_DEVICE_INDEX,
                     device_path: PathBuf::from(format!("/dev/nbd{TEST_DEVICE_INDEX}")),
                     cow_file: cow_file.clone(),
-                    cow: Arc::new(RwLock::new(cow)),
+                    cow: cow_io::CowIo::new(cow),
                     server_handles: Vec::new(),
                     shutdown: CancellationToken::new(),
                     disconnected: true,

--- a/crates/nbd-cow/src/lib.rs
+++ b/crates/nbd-cow/src/lib.rs
@@ -12,6 +12,7 @@
 //!
 //! The layered implementation is split across:
 //! - [`cow`] for COW storage and dirty bitmap persistence.
+//! - [`cow_io`] for the async boundary around blocking COW storage operations.
 //! - [`pool`] for host-locked `/dev/nbdN` device claim allocation.
 //! - [`netlink`] for Linux NBD generic netlink setup and disconnect.
 //! - [`server`] for the in-process NBD dispatch loop.

--- a/crates/nbd-cow/src/lib.rs
+++ b/crates/nbd-cow/src/lib.rs
@@ -23,6 +23,7 @@
 //! writes that were not flushed.
 
 pub mod cow;
+pub mod cow_io;
 mod device;
 pub mod device_lock;
 pub mod error;

--- a/crates/nbd-cow/src/server.rs
+++ b/crates/nbd-cow/src/server.rs
@@ -1,18 +1,16 @@
 //! In-process NBD request dispatch.
 //!
 //! [`dispatch`] owns one Unix socket connection passed to the kernel NBD device,
-//! decodes NBD requests, applies them to [`crate::cow::CowLayer`], and writes
+//! decodes NBD requests, applies them through [`crate::cow_io::CowIo`], and writes
 //! NBD replies back to the kernel.
 
 use std::os::unix::io::{FromRawFd, IntoRawFd, OwnedFd};
-use std::sync::Arc;
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::UnixStream;
-use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
 
-use crate::cow::CowLayer;
+use crate::cow_io::CowIo;
 use crate::error::{NbdCowError, Result};
 use crate::protocol_impl::{self as protocol, Command, NbdReply, NbdRequest, REQUEST_HEADER_SIZE};
 
@@ -120,22 +118,13 @@ impl DispatchReadObserver {
 ///
 /// Reads NBD requests from the socket, dispatches to the COW layer,
 /// and sends replies back. Handles graceful shutdown via the cancellation token.
-///
-/// NOTE: CowLayer uses synchronous file I/O (pread/pwrite) while holding the
-/// RwLock. This briefly blocks the tokio worker thread. For our workload
-/// (4KB blocks, fast NVMe/EBS storage) this is acceptable. If latency becomes
-/// an issue, consider `spawn_blocking` or async file I/O.
-pub async fn dispatch(
-    socket_fd: OwnedFd,
-    cow: Arc<RwLock<CowLayer>>,
-    shutdown: CancellationToken,
-) -> Result<()> {
+pub async fn dispatch(socket_fd: OwnedFd, cow: CowIo, shutdown: CancellationToken) -> Result<()> {
     dispatch_with_read_observer(socket_fd, cow, shutdown, DispatchReadObserver::none()).await
 }
 
 async fn dispatch_with_read_observer(
     socket_fd: OwnedFd,
-    cow: Arc<RwLock<CowLayer>>,
+    cow: CowIo,
     shutdown: CancellationToken,
     read_observer: DispatchReadObserver,
 ) -> Result<()> {
@@ -203,9 +192,8 @@ async fn dispatch_with_read_observer(
     }
 }
 
-async fn sync_cow_on_shutdown(cow: &Arc<RwLock<CowLayer>>) -> Result<()> {
-    let mut cow = cow.write().await;
-    cow.sync()
+async fn sync_cow_on_shutdown(cow: &CowIo) -> Result<()> {
+    cow.sync().await
 }
 
 fn handler_outcome(outcome: IoOutcome) -> HandlerOutcome {
@@ -280,7 +268,7 @@ async fn write_all_or_shutdown(
 
 async fn handle_read(
     request: &NbdRequest,
-    cow: &Arc<RwLock<CowLayer>>,
+    cow: &CowIo,
     writer: &mut tokio::net::unix::OwnedWriteHalf,
     payload_buf: &mut Vec<u8>,
     shutdown: &CancellationToken,
@@ -293,13 +281,12 @@ async fn handle_read(
     let len = request.length as usize;
     if len <= MAX_REUSABLE_PAYLOAD_LENGTH {
         resize_reusable_payload(payload_buf, len);
-        let result =
-            read_and_reply(request, cow, writer, payload_buf.as_mut_slice(), shutdown).await;
+        let result = read_and_reply(request, cow, writer, payload_buf, shutdown).await;
         reset_reusable_payload_if_oversized(payload_buf);
         result
     } else {
         let mut data = vec![0u8; len];
-        read_and_reply(request, cow, writer, data.as_mut_slice(), shutdown).await
+        read_and_reply(request, cow, writer, &mut data, shutdown).await
     }
 }
 
@@ -320,32 +307,34 @@ fn reset_reusable_payload_if_oversized(payload_buf: &mut Vec<u8>) {
 
 async fn read_and_reply(
     request: &NbdRequest,
-    cow: &Arc<RwLock<CowLayer>>,
+    cow: &CowIo,
     writer: &mut tokio::net::unix::OwnedWriteHalf,
-    data: &mut [u8],
+    data: &mut Vec<u8>,
     shutdown: &CancellationToken,
 ) -> Result<HandlerOutcome> {
-    let result = {
-        let cow = cow.read().await;
-        cow.read(request.offset, data)
+    let read_buffer = std::mem::take(data);
+    match cow.read(request.offset, read_buffer).await {
+        Ok(read_buffer) => {
+            *data = read_buffer;
+        }
+        Err(e) => {
+            tracing::warn!(
+                offset = request.offset,
+                len = request.length,
+                "read error: {e}"
+            );
+            return send_error_reply(writer, request.handle, libc::EIO as u32, shutdown)
+                .await
+                .map(handler_outcome);
+        }
     };
-    if let Err(e) = result {
-        tracing::warn!(
-            offset = request.offset,
-            len = request.length,
-            "read error: {e}"
-        );
-        return send_error_reply(writer, request.handle, libc::EIO as u32, shutdown)
-            .await
-            .map(handler_outcome);
-    }
 
     let reply = success_reply(request.handle);
     let reply_buf = protocol::serialize_reply(&reply);
     if let IoOutcome::Shutdown = write_all_or_shutdown(writer, &reply_buf, shutdown).await? {
         return Ok(HandlerOutcome::Shutdown);
     }
-    write_all_or_shutdown(writer, data, shutdown)
+    write_all_or_shutdown(writer, data.as_slice(), shutdown)
         .await
         .map(handler_outcome)
 }
@@ -353,7 +342,7 @@ async fn read_and_reply(
 async fn handle_write(
     request: &NbdRequest,
     reader: &mut tokio::net::unix::OwnedReadHalf,
-    cow: &Arc<RwLock<CowLayer>>,
+    cow: &CowIo,
     writer: &mut tokio::net::unix::OwnedWriteHalf,
     payload_buf: &mut Vec<u8>,
     shutdown: &CancellationToken,
@@ -384,7 +373,7 @@ async fn handle_write(
             reader,
             cow,
             writer,
-            payload_buf.as_mut_slice(),
+            payload_buf,
             shutdown,
             read_observer,
         )
@@ -398,7 +387,7 @@ async fn handle_write(
             reader,
             cow,
             writer,
-            data.as_mut_slice(),
+            &mut data,
             shutdown,
             read_observer,
         )
@@ -409,15 +398,15 @@ async fn handle_write(
 async fn read_and_apply_write(
     request: &NbdRequest,
     reader: &mut tokio::net::unix::OwnedReadHalf,
-    cow: &Arc<RwLock<CowLayer>>,
+    cow: &CowIo,
     writer: &mut tokio::net::unix::OwnedWriteHalf,
-    data: &mut [u8],
+    data: &mut Vec<u8>,
     shutdown: &CancellationToken,
     read_observer: &DispatchReadObserver,
 ) -> Result<HandlerOutcome> {
     if let IoOutcome::Shutdown = read_exact_or_shutdown(
         reader,
-        data,
+        data.as_mut_slice(),
         shutdown,
         ReadContext::WritePayload {
             handle: request.handle,
@@ -429,31 +418,21 @@ async fn read_and_apply_write(
         return Ok(HandlerOutcome::Shutdown);
     }
 
-    let failed = {
-        let mut cow = cow.write().await;
-        match cow.write(request.offset, data) {
-            Ok(needs_flush) => {
-                if needs_flush && let Err(e) = cow.flush() {
-                    tracing::warn!("flush error after write: {e}");
-                    true
-                } else {
-                    false
-                }
-            }
-            Err(e) => {
-                tracing::warn!(
-                    offset = request.offset,
-                    len = request.length,
-                    "write error: {e}"
-                );
-                true
-            }
+    let write_buffer = std::mem::take(data);
+    match cow.write(request.offset, write_buffer).await {
+        Ok(write_buffer) => {
+            *data = write_buffer;
         }
-    };
-    if failed {
-        return send_error_reply(writer, request.handle, libc::EIO as u32, shutdown)
-            .await
-            .map(handler_outcome);
+        Err(e) => {
+            tracing::warn!(
+                offset = request.offset,
+                len = request.length,
+                "write or flush error: {e}"
+            );
+            return send_error_reply(writer, request.handle, libc::EIO as u32, shutdown)
+                .await
+                .map(handler_outcome);
+        }
     }
 
     send_success_reply(writer, request.handle, shutdown)
@@ -463,15 +442,11 @@ async fn read_and_apply_write(
 
 async fn handle_flush(
     request: &NbdRequest,
-    cow: &Arc<RwLock<CowLayer>>,
+    cow: &CowIo,
     writer: &mut tokio::net::unix::OwnedWriteHalf,
     shutdown: &CancellationToken,
 ) -> Result<HandlerOutcome> {
-    let result = {
-        let mut cow = cow.write().await;
-        cow.sync()
-    };
-    if let Err(e) = result {
+    if let Err(e) = cow.sync().await {
         tracing::warn!("sync error: {e}");
         return send_error_reply(writer, request.handle, libc::EIO as u32, shutdown)
             .await

--- a/crates/nbd-cow/src/server/tests.rs
+++ b/crates/nbd-cow/src/server/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::cow::CowLayer;
+use crate::cow_io::CowIo;
 use crate::protocol_impl::{Command, NbdReply, NbdRequest, REPLY_MAGIC, serialize_request};
 use std::io::Write as _;
 use std::os::unix::io::{FromRawFd, IntoRawFd, OwnedFd};
@@ -32,7 +33,7 @@ fn create_test_cow(base_data: &[u8]) -> (NamedTempFile, NamedTempFile, CowLayer)
 }
 
 async fn setup_dispatch(
-    cow: Arc<RwLock<CowLayer>>,
+    cow: CowIo,
 ) -> (
     tokio::net::unix::OwnedReadHalf,
     tokio::net::unix::OwnedWriteHalf,
@@ -42,15 +43,14 @@ async fn setup_dispatch(
     let shutdown = CancellationToken::new();
     let (reader, writer, server_fd) = setup_dispatch_socket();
 
-    let cow_clone = cow.clone();
     let shutdown_clone = shutdown.clone();
-    let task = tokio::spawn(async move { dispatch(server_fd, cow_clone, shutdown_clone).await });
+    let task = tokio::spawn(async move { dispatch(server_fd, cow, shutdown_clone).await });
 
     (reader, writer, task, shutdown)
 }
 
 async fn setup_observed_dispatch(
-    cow: Arc<RwLock<CowLayer>>,
+    cow: CowIo,
 ) -> (
     tokio::net::unix::OwnedReadHalf,
     tokio::net::unix::OwnedWriteHalf,
@@ -62,12 +62,11 @@ async fn setup_observed_dispatch(
     let (reader, writer, server_fd) = setup_dispatch_socket();
     let (event_sender, read_events) = tokio::sync::mpsc::unbounded_channel();
 
-    let cow_clone = cow.clone();
     let shutdown_clone = shutdown.clone();
     let task = tokio::spawn(async move {
         dispatch_with_read_observer(
             server_fd,
-            cow_clone,
+            cow,
             shutdown_clone,
             DispatchReadObserver::new(event_sender),
         )
@@ -212,7 +211,7 @@ async fn dispatch_large_then_small_requests_keep_stream_aligned() {
     let mut base_data = vec![0x11; large_len + 2 * crate::BLOCK_SIZE];
     base_data[large_len + crate::BLOCK_SIZE..].fill(0x33);
     let (_base, _cow_file, cow) = create_test_cow(&base_data);
-    let cow = Arc::new(RwLock::new(cow));
+    let cow = CowIo::new(cow);
 
     let (mut reader, mut writer, task, _shutdown) = setup_dispatch(cow).await;
 
@@ -299,7 +298,7 @@ async fn dispatch_large_then_small_requests_keep_stream_aligned() {
 async fn dispatch_shutdown_flushes_data() {
     let base_data = vec![0x00; 2 * crate::BLOCK_SIZE];
     let (_base, _cow_file, cow) = create_test_cow(&base_data);
-    let cow = Arc::new(RwLock::new(cow));
+    let cow = CowIo::new(cow);
 
     let (mut reader, mut writer, task, shutdown) = setup_dispatch(cow.clone()).await;
 
@@ -313,29 +312,21 @@ async fn dispatch_shutdown_flushes_data() {
     let error = send_write_and_recv_reply(&mut reader, &mut writer, &write_req, &write_data).await;
     assert_eq!(error, 0, "write should succeed");
 
-    {
-        let cow = cow.read().await;
-        assert_eq!(cow.buffered_block_count(), 1);
-    }
+    let status = must(cow.status().await, "read COW status after write");
+    assert_eq!(status.buffered_blocks, 1);
 
     shutdown.cancel();
     wait_for_dispatch(task).await;
 
-    {
-        let cow = cow.read().await;
-        assert_eq!(
-            cow.buffered_block_count(),
-            0,
-            "shutdown should flush buffer"
-        );
-    }
+    let status = must(cow.status().await, "read COW status after shutdown");
+    assert_eq!(status.buffered_blocks, 0, "shutdown should flush buffer");
 }
 
 #[tokio::test]
 async fn dispatch_shutdown_while_write_payload_pending_exits() {
     let base_data = vec![0x00; 2 * crate::BLOCK_SIZE];
     let (_base, _cow_file, cow) = create_test_cow(&base_data);
-    let cow = Arc::new(RwLock::new(cow));
+    let cow = CowIo::new(cow);
 
     let (_reader, mut writer, task, shutdown, mut read_events) = setup_observed_dispatch(cow).await;
 
@@ -371,7 +362,7 @@ async fn dispatch_shutdown_while_write_payload_pending_exits() {
 async fn dispatch_shutdown_while_oversized_write_discard_pending_exits() {
     let base_data = vec![0x00; 2 * crate::BLOCK_SIZE];
     let (_base, _cow_file, cow) = create_test_cow(&base_data);
-    let cow = Arc::new(RwLock::new(cow));
+    let cow = CowIo::new(cow);
 
     let (_reader, mut writer, task, shutdown, mut read_events) = setup_observed_dispatch(cow).await;
 
@@ -407,7 +398,7 @@ async fn dispatch_shutdown_while_oversized_write_discard_pending_exits() {
 async fn dispatch_shutdown_during_partial_write_flushes_accepted_data() {
     let base_data = vec![0x00; 2 * crate::BLOCK_SIZE];
     let (_base, _cow_file, cow) = create_test_cow(&base_data);
-    let cow = Arc::new(RwLock::new(cow));
+    let cow = CowIo::new(cow);
 
     let (mut reader, mut writer, task, shutdown, mut read_events) =
         setup_observed_dispatch(cow.clone()).await;
@@ -422,10 +413,8 @@ async fn dispatch_shutdown_during_partial_write_flushes_accepted_data() {
     let error =
         send_write_and_recv_reply(&mut reader, &mut writer, &accepted_write, &accepted_data).await;
     assert_eq!(error, 0, "accepted write should succeed");
-    {
-        let cow = cow.read().await;
-        assert_eq!(cow.buffered_block_count(), 1);
-    }
+    let status = must(cow.status().await, "read COW status after accepted write");
+    assert_eq!(status.buffered_blocks, 1);
 
     let partial_write = NbdRequest {
         command: Command::Write,
@@ -454,7 +443,7 @@ async fn dispatch_shutdown_during_partial_write_flushes_accepted_data() {
     shutdown.cancel();
     assert_dispatch_exits_after_shutdown(task).await;
 
-    let cow = cow.read().await;
-    assert_eq!(cow.buffered_block_count(), 0);
-    assert_eq!(cow.dirty_block_count(), 1);
+    let status = must(cow.status().await, "read COW status after shutdown");
+    assert_eq!(status.buffered_blocks, 0);
+    assert_eq!(status.dirty_blocks, 1);
 }

--- a/crates/nbd-cow/tests/dispatch.rs
+++ b/crates/nbd-cow/tests/dispatch.rs
@@ -1,15 +1,14 @@
 mod support;
 
 use std::os::unix::fs::MetadataExt as _;
-use std::sync::Arc;
 
 use nbd_cow::BLOCK_SIZE;
+use nbd_cow::cow_io::CowIo;
 use support::dispatch_client::{
     Command, TestResult, assert_error, assert_error_code, assert_success, create_base_file,
     create_cow_with_full_device, create_test_cow, request, request_with_type_flags, spawn_dispatch,
     spawn_dispatch_with_shutdown, wait_for_dispatch,
 };
-use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
 
 const OVERSIZED_LENGTH: u32 = 33 * 1024 * 1024;
@@ -18,7 +17,7 @@ const OVERSIZED_LENGTH: u32 = 33 * 1024 * 1024;
 async fn dispatch_read_write_disconnect() -> TestResult<()> {
     let base_data = vec![0xAA; 2 * BLOCK_SIZE];
     let (_base, _cow_file, cow) = create_test_cow(&base_data)?;
-    let cow = Arc::new(RwLock::new(cow));
+    let cow = CowIo::new(cow);
 
     let (mut client, task, _shutdown) = spawn_dispatch(cow).await?;
 
@@ -41,7 +40,7 @@ async fn dispatch_read_write_disconnect() -> TestResult<()> {
 async fn dispatch_flush_persists_to_cow_file() -> TestResult<()> {
     let base_data = vec![0x00; 2 * BLOCK_SIZE];
     let (_base, cow_file, cow) = create_test_cow(&base_data)?;
-    let cow = Arc::new(RwLock::new(cow));
+    let cow = CowIo::new(cow);
 
     let (mut client, task, _shutdown) = spawn_dispatch(cow.clone()).await?;
 
@@ -52,18 +51,15 @@ async fn dispatch_flush_persists_to_cow_file() -> TestResult<()> {
     let reply = client.flush(2).await?;
     assert_success(&reply, 2);
 
-    {
-        let cow = cow.read().await;
-        assert_eq!(
-            cow.buffered_block_count(),
-            0,
-            "buffer should be empty after flush"
-        );
-        assert!(
-            cow.dirty_block_count() > 0,
-            "should have dirty blocks in COW file"
-        );
-    }
+    let status = cow.status().await?;
+    assert_eq!(
+        status.buffered_blocks, 0,
+        "buffer should be empty after flush"
+    );
+    assert!(
+        status.dirty_blocks > 0,
+        "should have dirty blocks in COW file"
+    );
 
     let cow_meta = std::fs::metadata(cow_file.path())?;
     assert!(
@@ -80,7 +76,7 @@ async fn dispatch_flush_persists_to_cow_file() -> TestResult<()> {
 async fn dispatch_trim_succeeds() -> TestResult<()> {
     let base_data = vec![0xAA; 2 * BLOCK_SIZE];
     let (_base, _cow_file, cow) = create_test_cow(&base_data)?;
-    let cow = Arc::new(RwLock::new(cow));
+    let cow = CowIo::new(cow);
 
     let (mut client, task, _shutdown) = spawn_dispatch(cow).await?;
 
@@ -98,7 +94,7 @@ async fn dispatch_masks_request_type_flags_from_command() -> TestResult<()> {
 
     let base_data = vec![0xAA; 2 * BLOCK_SIZE];
     let (_base, _cow_file, cow) = create_test_cow(&base_data)?;
-    let cow = Arc::new(RwLock::new(cow));
+    let cow = CowIo::new(cow);
 
     let (mut client, task, _shutdown) = spawn_dispatch(cow).await?;
 
@@ -127,7 +123,7 @@ async fn dispatch_masks_request_type_flags_from_command() -> TestResult<()> {
 async fn dispatch_oversized_read_returns_error() -> TestResult<()> {
     let base_data = vec![0xAA; 2 * BLOCK_SIZE];
     let (_base, _cow_file, cow) = create_test_cow(&base_data)?;
-    let cow = Arc::new(RwLock::new(cow));
+    let cow = CowIo::new(cow);
 
     let (mut client, task, _shutdown) = spawn_dispatch(cow).await?;
 
@@ -148,7 +144,7 @@ async fn dispatch_oversized_read_returns_error() -> TestResult<()> {
 async fn dispatch_oversized_write_discards_and_returns_error() -> TestResult<()> {
     let base_data = vec![0xAA; 2 * BLOCK_SIZE];
     let (_base, _cow_file, cow) = create_test_cow(&base_data)?;
-    let cow = Arc::new(RwLock::new(cow));
+    let cow = CowIo::new(cow);
 
     let (mut client, task, _shutdown) = spawn_dispatch(cow).await?;
 
@@ -173,7 +169,7 @@ async fn dispatch_oversized_write_discards_and_returns_error() -> TestResult<()>
 async fn dispatch_out_of_bounds_read_returns_error() -> TestResult<()> {
     let base_data = vec![0xAA; 2 * BLOCK_SIZE];
     let (_base, _cow_file, cow) = create_test_cow(&base_data)?;
-    let cow = Arc::new(RwLock::new(cow));
+    let cow = CowIo::new(cow);
 
     let (mut client, task, _shutdown) = spawn_dispatch(cow).await?;
 
@@ -194,7 +190,7 @@ async fn dispatch_out_of_bounds_read_returns_error() -> TestResult<()> {
 async fn dispatch_out_of_bounds_write_returns_error() -> TestResult<()> {
     let base_data = vec![0xAA; 2 * BLOCK_SIZE];
     let (_base, _cow_file, cow) = create_test_cow(&base_data)?;
-    let cow = Arc::new(RwLock::new(cow));
+    let cow = CowIo::new(cow);
 
     let (mut client, task, _shutdown) = spawn_dispatch(cow).await?;
 
@@ -214,7 +210,7 @@ async fn dispatch_out_of_bounds_write_returns_error() -> TestResult<()> {
 async fn dispatch_write_flush_failure_returns_error() -> TestResult<()> {
     let base_data = vec![0xAA; 2 * BLOCK_SIZE];
     let base = create_base_file(&base_data)?;
-    let cow = Arc::new(RwLock::new(create_cow_with_full_device(&base, BLOCK_SIZE)?));
+    let cow = CowIo::new(create_cow_with_full_device(&base, BLOCK_SIZE)?);
 
     let (mut client, task, _shutdown) = spawn_dispatch(cow).await?;
 
@@ -231,10 +227,7 @@ async fn dispatch_write_flush_failure_returns_error() -> TestResult<()> {
 async fn dispatch_sync_failure_returns_error() -> TestResult<()> {
     let base_data = vec![0xAA; 2 * BLOCK_SIZE];
     let base = create_base_file(&base_data)?;
-    let cow = Arc::new(RwLock::new(create_cow_with_full_device(
-        &base,
-        4 * 1024 * 1024,
-    )?));
+    let cow = CowIo::new(create_cow_with_full_device(&base, 4 * 1024 * 1024)?);
 
     let (mut client, task, _shutdown) = spawn_dispatch(cow).await?;
 
@@ -254,7 +247,7 @@ async fn dispatch_sync_failure_returns_error() -> TestResult<()> {
 async fn dispatch_concurrent_read_write() -> TestResult<()> {
     let base_data = vec![0xAA; 2 * BLOCK_SIZE];
     let (_base, _cow_file, cow) = create_test_cow(&base_data)?;
-    let cow = Arc::new(RwLock::new(cow));
+    let cow = CowIo::new(cow);
     let shutdown = CancellationToken::new();
 
     let (mut client0, task0) = spawn_dispatch_with_shutdown(cow.clone(), shutdown.clone()).await?;

--- a/crates/nbd-cow/tests/integration.rs
+++ b/crates/nbd-cow/tests/integration.rs
@@ -487,7 +487,7 @@ async fn connect_device_specific_index() {
         nbd_cow::DEFAULT_FLUSH_THRESHOLD,
     )
     .expect("cow layer");
-    let cow_layer = std::sync::Arc::new(tokio::sync::RwLock::new(cow_layer));
+    let cow = nbd_cow::cow_io::CowIo::new(cow_layer);
 
     let mut setup_result = Ok::<(), nbd_cow::error::NbdCowError>(());
     for _ in 0..nbd_cow::NUM_CONNECTIONS {
@@ -499,7 +499,7 @@ async fn connect_device_specific_index() {
             }
         };
         client_fds.push(client_fd);
-        let cow = cow_layer.clone();
+        let cow = cow.clone();
         let token = shutdown.clone();
         server_handles.push(tokio::spawn(async move {
             let _ = nbd_cow::server::dispatch(server_fd, cow, token).await;

--- a/crates/nbd-cow/tests/support/dispatch_client.rs
+++ b/crates/nbd-cow/tests/support/dispatch_client.rs
@@ -2,10 +2,10 @@ use std::error::Error;
 use std::io::Write as _;
 use std::os::unix::io::{FromRawFd, IntoRawFd, OwnedFd};
 use std::path::Path;
-use std::sync::Arc;
 use std::time::Duration;
 
 use nbd_cow::cow::CowLayer;
+use nbd_cow::cow_io::CowIo;
 use nbd_cow::error::Result as NbdResult;
 use nbd_cow::server::dispatch;
 use nbd_cow::{BLOCK_SIZE, DEFAULT_FLUSH_THRESHOLD};
@@ -13,7 +13,6 @@ use tempfile::NamedTempFile;
 use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 use tokio::net::UnixStream;
 use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
-use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
@@ -245,7 +244,7 @@ pub fn create_cow_with_full_device(
 }
 
 pub async fn spawn_dispatch(
-    cow: Arc<RwLock<CowLayer>>,
+    cow: CowIo,
 ) -> TestResult<(DispatchClient, JoinHandle<NbdResult<()>>, CancellationToken)> {
     let shutdown = CancellationToken::new();
     let (client, task) = spawn_dispatch_with_shutdown(cow, shutdown.clone()).await?;
@@ -253,7 +252,7 @@ pub async fn spawn_dispatch(
 }
 
 pub async fn spawn_dispatch_with_shutdown(
-    cow: Arc<RwLock<CowLayer>>,
+    cow: CowIo,
     shutdown: CancellationToken,
 ) -> TestResult<(DispatchClient, JoinHandle<NbdResult<()>>)> {
     let (client_fd, server_fd) = socketpair()?;
@@ -264,9 +263,8 @@ pub async fn spawn_dispatch_with_shutdown(
     let client_stream = UnixStream::from_std(client_std)?;
     let (reader, writer) = client_stream.into_split();
 
-    let cow_clone = cow.clone();
     let shutdown_clone = shutdown.clone();
-    let task = tokio::spawn(async move { dispatch(server_fd, cow_clone, shutdown_clone).await });
+    let task = tokio::spawn(async move { dispatch(server_fd, cow, shutdown_clone).await });
 
     Ok((DispatchClient { reader, writer }, task))
 }


### PR DESCRIPTION
## Summary
- add a `CowIo` boundary that serializes per-device COW operations before entering `spawn_blocking`
- route dispatch read/write/flush/shutdown sync through `CowIo` so synchronous COW file I/O no longer runs on async dispatch workers
- update device status, bitmap save, and dispatch tests to use the new COW I/O handle

Closes #19598

## Testing
- `cargo test --manifest-path crates/Cargo.toml -p nbd-cow --test dispatch`
- `cargo test --manifest-path crates/Cargo.toml -p nbd-cow`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p nbd-cow --all-targets -- -D warnings`
- pre-commit: crates cargo-fmt, cargo-doc, cargo-clippy