### PR TITLE
fix: publish workflow trigger automation refreshes

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-triggers.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-triggers.test.ts
@@ -326,6 +326,7 @@ describe("zero workflow triggers", () => {
   it("creates a cron trigger and eagerly binds a chat thread", async () => {
     const { workflowId } = await setupFixture();
 
+    context.mocks.ably.publish.mockClear();
     const created = await accept(
       triggersClient().create({
         headers: authHeaders(),
@@ -353,6 +354,10 @@ describe("zero workflow triggers", () => {
     expect(created.body.chatThreadId).toBeTruthy();
     expect(created.body.nextRunAt).toBeTruthy();
     expect(created.body.kind).toBe("schedule");
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      `chatThreadAutomationsChanged:${created.body.chatThreadId}`,
+      null,
+    );
     if (created.body.kind !== "schedule") {
       throw new Error("Expected a schedule trigger");
     }
@@ -1475,12 +1480,17 @@ describe("zero workflow triggers", () => {
     const threadId = created.body.chatThreadId;
     expect(threadId).toBeTruthy();
 
+    context.mocks.ably.publish.mockClear();
     await accept(
       triggersClient().delete({
         headers: authHeaders(),
         params: { id: created.body.id },
       }),
       [204],
+    );
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      `chatThreadAutomationsChanged:${threadId}`,
+      null,
     );
 
     const threadState = await workflowTriggerStateAction({

--- a/turbo/apps/api/src/signals/services/zero-workflow-trigger.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-trigger.service.ts
@@ -1363,7 +1363,7 @@ export const createWorkflowTrigger$ = command(
     const workflowTitle = workflow.displayName ?? workflow.name;
 
     if (!triggerCreateInputIsSchedule(args)) {
-      return await set(
+      const result = await set(
         createEventTriggerForWorkflow$,
         {
           db: writeDb,
@@ -1374,6 +1374,15 @@ export const createWorkflowTrigger$ = command(
         },
         signal,
       );
+      signal.throwIfAborted();
+      if (result.kind === "ok") {
+        await publishThreadBoundWorkflowTriggerChanged(
+          result.summary.ownerUserId,
+          result.summary.chatThreadId,
+        );
+        signal.throwIfAborted();
+      }
+      return result;
     }
 
     const now = nowDate();
@@ -1394,6 +1403,11 @@ export const createWorkflowTrigger$ = command(
       nextRunAt,
       currentTime: now,
     });
+    signal.throwIfAborted();
+    await publishThreadBoundWorkflowTriggerChanged(
+      summary.ownerUserId,
+      summary.chatThreadId,
+    );
     signal.throwIfAborted();
     return { kind: "ok", summary };
   },


### PR DESCRIPTION
## Summary
- publish chat-thread automation refresh signals after workflow trigger creation
- keep delete refresh behavior covered with a regression assertion
- add create-path coverage for the `chatThreadAutomationsChanged:<threadId>` Ably topic

## Checks
- `pnpm --dir turbo --filter api exec eslint src/signals/services/zero-workflow-trigger.service.ts src/signals/routes/__tests__/zero-workflow-triggers.test.ts --max-warnings 0`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --dir turbo --filter api check-types`

## Notes
- Local route test execution could not complete because this fresh runtime has no local Postgres available; the workflow trigger route test fails during fixture DB seeding with `ECONNREFUSED` before reaching the changed assertions.