### PR TITLE
docs(connectors): describe strava firewall permissions

### DIFF
--- a/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
@@ -1,3 +1,4 @@
+import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { describe, expect, it } from "vitest";
@@ -54,12 +55,83 @@ const DEFAULT_FIREWALL_SECRET_PLACEHOLDER =
 const FULL_FIREWALL_SOURCE_TEST_TIMEOUT_MS = 60_000;
 type FirewallConnectorType =
   keyof typeof FIREWALL_PERMISSION_METADATA_SUMMARIES;
+interface KnownMissingPermissionDescriptionGap {
+  readonly issue: number;
+  readonly missingCount: number;
+  readonly missingNamesSha256: string;
+}
+const KNOWN_MISSING_PERMISSION_DESCRIPTION_GAPS: Partial<
+  Record<FirewallConnectorType, KnownMissingPermissionDescriptionGap>
+> = {
+  // Keep this list shrinking. Each entry tracks a follow-up issue for
+  // removing the connector from this legacy allowlist.
+  clerk: {
+    issue: 19609,
+    missingCount: 67,
+    missingNamesSha256:
+      "a78b992b48b034a9e826933355d7082cec11e449f90f2cc4ba3de6cb36dfb39f",
+  },
+  deel: {
+    issue: 19610,
+    missingCount: 55,
+    missingNamesSha256:
+      "f1aa9bde204742913cc515ce6c60870dcdee8df7ba8da4dd2d6c76264853f345",
+  },
+  dropbox: {
+    issue: 19611,
+    missingCount: 29,
+    missingNamesSha256:
+      "08c5f153d436ed1ec9be40b44f35fcb7c087a89cd26603b508eee2a8b176eb19",
+  },
+  "google-cloud": {
+    issue: 19566,
+    missingCount: 1189,
+    missingNamesSha256:
+      "29130e444cd58beaaa654c0207dbec064be945113ca97cf2d391f3614cb37cc1",
+  },
+  sentry: {
+    issue: 19612,
+    missingCount: 22,
+    missingNamesSha256:
+      "ddae869f18724903f394137a9a30186c0199c174c7a569bcb6f40349c0eaf904",
+  },
+  vercel: {
+    issue: 19613,
+    missingCount: 68,
+    missingNamesSha256:
+      "8ccddb8850744d7bdc07fc73a57b0cd5831cdc6a482c724a920abadd3317782e",
+  },
+  xero: {
+    issue: 19614,
+    missingCount: 35,
+    missingNamesSha256:
+      "0234b2bf557b118688656df62d5018f872195b32d3d8d04ff191cf8f0b9efca0",
+  },
+};
 let runtimeEntriesPromise: Promise<
   readonly (readonly [FirewallConnectorType, FirewallConfig])[]
 > | null = null;
 
 function compareStrings(a: string, b: string): number {
   return a < b ? -1 : a > b ? 1 : 0;
+}
+
+function permissionDescriptionGapHash(
+  permissionNames: readonly string[],
+): string {
+  return crypto
+    .createHash("sha256")
+    .update([...permissionNames].sort(compareStrings).join("\n"))
+    .digest("hex");
+}
+
+function formatPermissionDescriptionGapSample(
+  permissionNames: readonly string[],
+): string {
+  const sortedNames = [...permissionNames].sort(compareStrings);
+  const sample = sortedNames.slice(0, 10).join(", ");
+  const remaining = sortedNames.length - 10;
+  return remaining > 0 ? `${sample}, ... ${remaining} more` : sample;
 }
 
 function isConnectorType(type: string): type is ConnectorType {
@@ -728,6 +800,52 @@ describe("firewall metadata", () => {
         loadFirewallPermissionMetadata(unknownType),
       ).resolves.toBeNull();
     }
+  });
+
+  it("prevents new permission description gaps", async () => {
+    const failures: string[] = [];
+
+    for (const [type] of await runtimeEntries()) {
+      const detail = await loadFirewallPermissionMetadata(type);
+      if (detail === null) {
+        failures.push(`${type}: missing permission detail metadata`);
+        continue;
+      }
+
+      const missingDescriptions = detail.permissions
+        .filter((permission) => {
+          return (
+            permission.description === undefined ||
+            permission.description.trim().length === 0
+          );
+        })
+        .map((permission) => {
+          return permission.name;
+        });
+      const knownGap = KNOWN_MISSING_PERMISSION_DESCRIPTION_GAPS[type];
+      const missingNamesSha256 =
+        permissionDescriptionGapHash(missingDescriptions);
+
+      if (knownGap) {
+        if (
+          missingDescriptions.length !== knownGap.missingCount ||
+          missingNamesSha256 !== knownGap.missingNamesSha256
+        ) {
+          failures.push(
+            `${type}: expected ${knownGap.missingCount} missing descriptions tracked by #${knownGap.issue} with hash ${knownGap.missingNamesSha256}, got ${missingDescriptions.length} with hash ${missingNamesSha256}: ${formatPermissionDescriptionGapSample(missingDescriptions)}`,
+          );
+        }
+        continue;
+      }
+
+      if (missingDescriptions.length > 0) {
+        failures.push(
+          `${type}: missing descriptions without a tracked follow-up issue: ${formatPermissionDescriptionGapSample(missingDescriptions)}`,
+        );
+      }
+    }
+
+    expect(failures).toStrictEqual([]);
   });
 
   it("keeps execution metadata synchronized with runtime construction data", async () => {

--- a/turbo/packages/connectors/src/__tests__/firewalls/strava.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewalls/strava.test.ts
@@ -4,6 +4,10 @@ import { findMatchingPermissions } from "../../firewall-rule-matcher";
 import type { FirewallConfig } from "../../firewall-types";
 import { loadRequiredConnectorFirewall } from "../firewall-test-helpers";
 
+type FirewallPermission = NonNullable<
+  FirewallConfig["apis"][number]["permissions"]
+>[number];
+
 const RUNTIME_METHODS = [
   "GET",
   "POST",
@@ -57,6 +61,16 @@ function expectStravaMatches(
   );
 }
 
+function stravaPermissionsByName(): Map<string, FirewallPermission> {
+  return new Map(
+    firewall.apis.flatMap((api) => {
+      return (api.permissions ?? []).map((permission) => {
+        return [permission.name, permission] as const;
+      });
+    }),
+  );
+}
+
 function expandRuntimeRules(rule: string): string[] {
   const spaceIndex = rule.indexOf(" ");
   const method = rule.slice(0, spaceIndex);
@@ -85,6 +99,30 @@ describe("strava firewall", () => {
     for (const oldScopeGroup of STRAVA_REMOVED_OAUTH_SCOPE_GROUPS) {
       expect(permissions.has(oldScopeGroup)).toBe(false);
     }
+  });
+
+  it("describes every resource permission", () => {
+    const permissions = stravaPermissionsByName();
+
+    expect([...permissions.keys()].sort()).toStrictEqual(
+      [...STRAVA_RESOURCE_PERMISSIONS].sort(),
+    );
+    expect(
+      STRAVA_RESOURCE_PERMISSIONS.filter((name) => {
+        const description = permissions.get(name)?.description;
+        return description === undefined || description.trim().length === 0;
+      }),
+    ).toStrictEqual([]);
+    expect(permissions.get("activities:read")?.description).toContain(
+      "activity:read_all",
+    );
+    expect(permissions.get("routes:read")?.description).toContain("read_all");
+    expect(permissions.get("profile:read")?.description).toContain(
+      "profile:read_all",
+    );
+    expect(
+      permissions.get("segment_effort_streams:read")?.description,
+    ).toContain("read_all");
   });
 
   it("assigns one permission owner to every runtime route", () => {

--- a/turbo/packages/firewalls-generator/src/strava.ts
+++ b/turbo/packages/firewalls-generator/src/strava.ts
@@ -93,7 +93,7 @@ const SCOPE_MAP: Record<string, string[]> = {
 
 const STRAVA_PERMISSION_DESCRIPTIONS = {
   "activities:read":
-    "Read athlete activities, including activity details, streams, comments, kudos, laps, zones, and activity history. Only Me activities require Strava activity:read_all.",
+    "Read athlete activities, including activity details, streams, comments, kudos, laps, zones, and activity history. Privacy zone data and Only You activities require Strava activity:read_all.",
   "activities:write": "Create and update athlete activities.",
   "athlete_stats:read": "Read athlete activity statistics.",
   "clubs:read":

--- a/turbo/packages/firewalls-generator/src/strava.ts
+++ b/turbo/packages/firewalls-generator/src/strava.ts
@@ -14,6 +14,7 @@
 
 import {
   ALL_METHODS,
+  applyPermissionDescriptions,
   fetchSpec,
   logStats,
   renderPermissions,
@@ -89,6 +90,28 @@ const SCOPE_MAP: Record<string, string[]> = {
   "POST /api/v3/uploads": ["activity:write"],
   "GET /api/v3/uploads/{uploadId}": ["activity:write"],
 };
+
+const STRAVA_PERMISSION_DESCRIPTIONS = {
+  "activities:read":
+    "Read athlete activities, including activity details, streams, comments, kudos, laps, zones, and activity history. Only Me activities require Strava activity:read_all.",
+  "activities:write": "Create and update athlete activities.",
+  "athlete_stats:read": "Read athlete activity statistics.",
+  "clubs:read":
+    "Read athlete club memberships and club activity, admin, and member information.",
+  "gear:read": "Read athlete gear details.",
+  "profile:read":
+    "Read athlete profile and zone information. Restricted profile fields require Strava profile:read_all.",
+  "profile:write": "Update athlete profile fields.",
+  "routes:read":
+    "Read athlete routes, route details, route exports, and route streams. Private routes require Strava read_all.",
+  "segment_effort_streams:read":
+    "Read segment effort streams that require Strava read_all.",
+  "segment_efforts:read": "Read segment efforts and segment effort details.",
+  "segments:read":
+    "Read segment exploration, starred segments, segment details, and segment streams. Private segments require Strava read_all.",
+  "segments:write": "Star and unstar segments for the athlete.",
+  "uploads:write": "Upload activities and read upload processing status.",
+} satisfies Readonly<Record<string, string>>;
 
 // ── Route owners ────────────────────────────────────────────────────────
 
@@ -517,8 +540,13 @@ export async function generate(): Promise<void> {
     );
   }
 
-  const ts = generateTypeScript(permissions);
+  const describedPermissions = applyPermissionDescriptions(
+    "Strava",
+    permissions,
+    STRAVA_PERMISSION_DESCRIPTIONS,
+  );
+  const ts = generateTypeScript(describedPermissions);
 
-  logStats(permissions);
+  logStats(describedPermissions);
   writeOutput("strava", ts);
 }

--- a/turbo/packages/firewalls-generator/src/strava.ts
+++ b/turbo/packages/firewalls-generator/src/strava.ts
@@ -46,7 +46,7 @@ const SCOPE_MAP: Record<string, string[]> = {
   // Activities — write
   "POST /api/v3/activities": ["activity:write"],
   "PUT /api/v3/activities/{id}": ["activity:write"],
-  // Activities — read (activity:read for public, activity:read_all for Only Me)
+  // Activities — read (activity:read for Everyone/Followers, activity:read_all for privacy zone data and Only You)
   "GET /api/v3/activities/{id}": ["activity:read", "activity:read_all"],
   "GET /api/v3/activities/{id}/comments": [
     "activity:read",


### PR DESCRIPTION
## Summary

- add source-level descriptions for every Strava firewall resource permission
- guard firewall permission metadata against new missing-description gaps while allowing tracked legacy gaps
- keep Strava runtime firewall catalog free of UI-only descriptions

Fixes #19596

## Tests

- pnpm -F @vm0/firewalls-generator generate
- pnpm -F @vm0/firewalls-generator check-types
- pnpm -F @vm0/firewalls-generator exec vitest src/__tests__/strava.test.ts
- pnpm -F @vm0/connectors exec vitest src/__tests__/firewalls/strava.test.ts
- pnpm -F @vm0/connectors exec vitest src/__tests__/firewall-metadata.test.ts
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/connectors lint
- pnpm format
- git diff --check
- pre-commit: pnpm check-types