### PR TITLE
fix: move workflows above connectors in sidebar

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -1522,7 +1522,12 @@ describe("zero sidebar", () => {
     });
 
     expect(within(nav).getByText("Agents")).toBeInTheDocument();
-    expect(within(nav).getByText("Workflows")).toBeInTheDocument();
+    const workflows = within(nav).getByText("Workflows");
+    const connectors = within(nav).getByText("Connectors");
+    expect(
+      workflows.compareDocumentPosition(connectors) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
     expect(within(nav).queryByText("Automations")).not.toBeInTheDocument();
   });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -74,6 +74,20 @@ const MANAGE_NAV: readonly ManageNavItem[] = [
     icon: IconUsers as NavIcon,
   },
   {
+    id: "workflows",
+    activeKeys: [
+      "workflows",
+      "workflowDetail",
+      "workflowDetailAutomations",
+      "workflowDetailInstructions",
+      "workflowDetailInfo",
+    ],
+    pathname: "/workflows",
+    label: "Workflows",
+    icon: IconRoute as NavIcon,
+    featureGate: FeatureSwitchKey.WorkflowAutomation,
+  },
+  {
     id: "connectors",
     activeKeys: ["connectors"],
     pathname: "/connectors",
@@ -87,20 +101,6 @@ const MANAGE_NAV: readonly ManageNavItem[] = [
     label: "Automations",
     icon: IconCalendar as NavIcon,
     hideWhenFeatureEnabled: FeatureSwitchKey.WorkflowAutomation,
-  },
-  {
-    id: "workflows",
-    activeKeys: [
-      "workflows",
-      "workflowDetail",
-      "workflowDetailAutomations",
-      "workflowDetailInstructions",
-      "workflowDetailInfo",
-    ],
-    pathname: "/workflows",
-    label: "Workflows",
-    icon: IconRoute as NavIcon,
-    featureGate: FeatureSwitchKey.WorkflowAutomation,
   },
   {
     id: "activities",


### PR DESCRIPTION
Summary:
- Move Workflows above Connectors in the sidebar Manage navigation when workflow automation is enabled.
- Add a sidebar test assertion for the Workflows-before-Connectors ordering.

Verification:
- pnpm exec prettier --write apps/platform/src/views/zero-page/zero-sidebar.tsx apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
- pnpm exec vitest run apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx