### PR TITLE
docs: add Sentry firewall permission descriptions

### DIFF
--- a/turbo/packages/firewalls-generator/src/__tests__/metadata.test.ts
+++ b/turbo/packages/firewalls-generator/src/__tests__/metadata.test.ts
@@ -275,6 +275,29 @@ describe("firewall metadata generator", () => {
   );
 
   it(
+    "keeps Sentry permission descriptions complete at the source boundary",
+    async () => {
+      const source = await loadGeneratedConnectorFirewallSource("sentry", {
+        connectorsDir: CONNECTORS_DIR,
+      });
+      const missingDescriptions = source.firewall.apis.flatMap((api) => {
+        return (api.permissions ?? [])
+          .filter((permission) => {
+            return (
+              permission.rules.length > 0 && !permission.description?.trim()
+            );
+          })
+          .map((permission) => {
+            return permission.name;
+          });
+      });
+
+      expect(missingDescriptions).toStrictEqual([]);
+    },
+    FULL_FIREWALL_SOURCE_TEST_TIMEOUT_MS,
+  );
+
+  it(
     "validates generated firewall config shape before deriving metadata",
     async () => {
       await loadGeneratedConnectorFirewallSource("github", {

--- a/turbo/packages/firewalls-generator/src/sentry.ts
+++ b/turbo/packages/firewalls-generator/src/sentry.ts
@@ -115,7 +115,7 @@ const SENTRY_SCOPE_DESCRIPTIONS: Readonly<Record<string, string>> = {
   "member:read": "Read organization member and SCIM user records.",
   "member:write": "Create and update organization members and SCIM users.",
   "org:admin":
-    "Administer organization-level resources, including destructive organization actions.",
+    "Delete and administer organization-level resources such as dashboards, saved queries, notifications, external users, and Sentry apps.",
   "org:ci":
     "Use CI and deployment workflows, including releases, deploys, and build artifacts.",
   "org:integrations":
@@ -125,7 +125,7 @@ const SENTRY_SCOPE_DESCRIPTIONS: Readonly<Record<string, string>> = {
   "org:write":
     "Create and update organization-level resources such as dashboards, saved queries, forwarding, teams, workflows, and Sentry apps.",
   "project:admin":
-    "Administer project resources, including destructive project-level changes.",
+    "Delete and administer project-level resources such as projects, keys, hooks, filters, monitors, releases, rules, and symbol sources.",
   "project:distribution": "Read project build distribution artifacts.",
   "project:read":
     "Read project settings, events, environments, releases, monitors, replays, rules, keys, teams, and user feedback.",

--- a/turbo/packages/firewalls-generator/src/sentry.ts
+++ b/turbo/packages/firewalls-generator/src/sentry.ts
@@ -13,6 +13,7 @@
 import {
   ALL_METHODS,
   OPENAPI_PATH_KEYS,
+  applyPermissionDescriptions,
   fetchSpec,
   logStats,
   renderPermissions,
@@ -95,6 +96,49 @@ const RUNTIME_METHODS = [
   "HEAD",
   "OPTIONS",
 ] as const;
+
+const SENTRY_SCOPE_DESCRIPTIONS: Readonly<Record<string, string>> = {
+  "alerts:read":
+    "Read alert rules, detectors, monitors, workflows, and check-in status.",
+  "alerts:write":
+    "Create, update, or delete alert rules, detectors, monitors, and workflows.",
+  "event:admin":
+    "Administer Sentry issues, including deleting issues and external issue links.",
+  "event:read":
+    "Read Sentry issues, events, tags, hashes, short IDs, and replay viewer data.",
+  "event:write":
+    "Update Sentry issues, run issue autofix actions, and create external issue links.",
+  "member:admin":
+    "Administer organization members and SCIM users, including removals.",
+  "member:invite":
+    "Invite organization members and update pending member invitations.",
+  "member:read": "Read organization member and SCIM user records.",
+  "member:write": "Create and update organization members and SCIM users.",
+  "org:admin":
+    "Administer organization-level resources, including destructive organization actions.",
+  "org:ci":
+    "Use CI and deployment workflows, including releases, deploys, and build artifacts.",
+  "org:integrations":
+    "Read and manage organization integrations and Sentry app installations.",
+  "org:read":
+    "Read organization metadata, dashboards, discoveries, projects, teams, replays, events, stats, and related resources.",
+  "org:write":
+    "Create and update organization-level resources such as dashboards, saved queries, forwarding, teams, workflows, and Sentry apps.",
+  "project:admin":
+    "Administer project resources, including destructive project-level changes.",
+  "project:distribution": "Read project build distribution artifacts.",
+  "project:read":
+    "Read project settings, events, environments, releases, monitors, replays, rules, keys, teams, and user feedback.",
+  "project:releases":
+    "Read and manage Sentry releases, deploys, release files, commits, and debug symbol files.",
+  "project:write":
+    "Create and update project settings, events, environments, debug files, hooks, keys, monitors, ownership, rules, symbol sources, teams, and user feedback.",
+  "team:admin":
+    "Administer teams, SCIM groups, external teams, and team memberships.",
+  "team:read": "Read teams, SCIM groups, and team memberships.",
+  "team:write":
+    "Create and update teams, SCIM groups, external teams, and team memberships.",
+};
 
 function preferScope(scope: string): SentryOwnerScopePreference {
   return { kind: "scope", scope };
@@ -577,7 +621,11 @@ export async function generate(): Promise<void> {
   );
   const permissionsDoc = await permissionsDocRes.text();
   const policies = parsePermissionsDoc(permissionsDoc);
-  const permissions = buildGroups(spec, policies);
+  const permissions = applyPermissionDescriptions(
+    "Sentry",
+    buildGroups(spec, policies),
+    SENTRY_SCOPE_DESCRIPTIONS,
+  );
   const ts = generateTypeScript(permissions);
 
   logStats(permissions);


### PR DESCRIPTION
## Summary

- Add source-level descriptions for every generated Sentry firewall permission.
- Apply the existing permission-description guard so missing or stale Sentry descriptions fail generation.
- Add a focused generator metadata test for Sentry description completeness.

## Tests

- `pnpm -F @vm0/firewalls-generator generate:sentry`
- `pnpm -F @vm0/firewalls-generator exec vitest src/__tests__/metadata.test.ts`
- `pnpm -F @vm0/connectors exec vitest src/__tests__/firewalls/sentry.test.ts`
- `pytest tests/test_builtin_firewalls_catalog.py::test_builtin_runtime_permissions_exclude_descriptions`
- `pnpm -F @vm0/firewalls-generator check-types`
- `pnpm format`
- `git diff --check`

Closes #19612