### PR TITLE
docs(connectors): describe dropbox firewall permissions

### DIFF
--- a/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
@@ -65,24 +65,6 @@ const KNOWN_MISSING_PERMISSION_DESCRIPTION_GAPS: Partial<
 > = {
   // Keep this list shrinking. Each entry tracks a follow-up issue for
   // removing the connector from this legacy allowlist.
-  clerk: {
-    issue: 19609,
-    missingCount: 67,
-    missingNamesSha256:
-      "a78b992b48b034a9e826933355d7082cec11e449f90f2cc4ba3de6cb36dfb39f",
-  },
-  deel: {
-    issue: 19610,
-    missingCount: 55,
-    missingNamesSha256:
-      "f1aa9bde204742913cc515ce6c60870dcdee8df7ba8da4dd2d6c76264853f345",
-  },
-  dropbox: {
-    issue: 19611,
-    missingCount: 29,
-    missingNamesSha256:
-      "08c5f153d436ed1ec9be40b44f35fcb7c087a89cd26603b508eee2a8b176eb19",
-  },
   "google-cloud": {
     issue: 19566,
     missingCount: 1189,

--- a/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
@@ -868,6 +868,38 @@ describe("firewall metadata", () => {
     expect(failures).toStrictEqual([]);
   });
 
+  it("describes Dropbox permissions", async () => {
+    const detail = await loadFirewallPermissionMetadata("dropbox");
+    expect(detail).not.toBeNull();
+    expect(detail!.permissionCount).toBe(29);
+    expect(
+      detail!.permissions.filter((permission) => {
+        return (
+          permission.description === undefined ||
+          permission.description.trim().length === 0
+        );
+      }),
+    ).toStrictEqual([]);
+
+    const permissions = new Map(
+      detail!.permissions.map((permission) => {
+        return [permission.name, permission] as const;
+      }),
+    );
+    expect(permissions.get("files.content.read")?.description).toBe(
+      "Download, export, preview, and read Dropbox file content.",
+    );
+    expect(permissions.get("files.metadata.write")?.description).toBe(
+      "Create, update, and remove Dropbox file tags, templates, and custom properties.",
+    );
+    expect(permissions.get("members.write")?.description).toBe(
+      "Add, update, suspend, unsuspend, and manage Dropbox team members and member quotas.",
+    );
+    expect(permissions.get("team_data.governance.write")?.description).toBe(
+      "Create, update, release, and inspect Dropbox team legal hold policies and held revisions.",
+    );
+  });
+
   it("keeps execution metadata synchronized with runtime construction data", async () => {
     expect(getFirewallExecutionMetadata("x")?.billable).toBe(true);
 

--- a/turbo/packages/firewalls-generator/src/__tests__/metadata.test.ts
+++ b/turbo/packages/firewalls-generator/src/__tests__/metadata.test.ts
@@ -95,6 +95,23 @@ function dynamicImportSpecifiers(source: string): string[] {
   return specifiers;
 }
 
+function missingPermissionDescriptions(
+  source: ConnectorFirewallSource,
+): string[] {
+  return source.firewall.apis.flatMap((api) => {
+    return (api.permissions ?? [])
+      .filter((permission) => {
+        return (
+          permission.rules.length > 0 &&
+          (permission.description?.trim() ?? "") === ""
+        );
+      })
+      .map((permission) => {
+        return permission.name;
+      });
+  });
+}
+
 function compareStrings(a: string, b: string): number {
   return a < b ? -1 : a > b ? 1 : 0;
 }
@@ -522,20 +539,33 @@ describe("firewall metadata generator", () => {
       const source = await loadGeneratedConnectorFirewallSource("deel", {
         connectorsDir: CONNECTORS_DIR,
       });
-      const missingDescriptions = source.firewall.apis.flatMap((api) => {
-        return (api.permissions ?? [])
-          .filter((permission) => {
-            return (
-              permission.rules.length > 0 &&
-              (permission.description?.trim() ?? "") === ""
-            );
-          })
-          .map((permission) => {
-            return permission.name;
-          });
-      });
 
-      expect(missingDescriptions).toStrictEqual([]);
+      expect(missingPermissionDescriptions(source)).toStrictEqual([]);
+    },
+    FULL_FIREWALL_SOURCE_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "keeps Dropbox permission descriptions complete at the source boundary",
+    async () => {
+      const source = await loadGeneratedConnectorFirewallSource("dropbox", {
+        connectorsDir: CONNECTORS_DIR,
+      });
+      const permissions = new Map(
+        source.firewall.apis.flatMap((api) => {
+          return (api.permissions ?? []).map((permission) => {
+            return [permission.name, permission] as const;
+          });
+        }),
+      );
+
+      expect(missingPermissionDescriptions(source)).toStrictEqual([]);
+      expect(permissions.get("files.content.read")?.description).toBe(
+        "Download, export, preview, and read Dropbox file content.",
+      );
+      expect(permissions.get("team_data.governance.write")?.description).toBe(
+        "Create, update, release, and inspect Dropbox team legal hold policies and held revisions.",
+      );
     },
     FULL_FIREWALL_SOURCE_TEST_TIMEOUT_MS,
   );

--- a/turbo/packages/firewalls-generator/src/dropbox.ts
+++ b/turbo/packages/firewalls-generator/src/dropbox.ts
@@ -15,6 +15,7 @@
  */
 
 import {
+  applyPermissionDescriptions,
   listCachedSpecs,
   logStats,
   renderPermissions,
@@ -49,6 +50,59 @@ const ROUTE_PERMISSION_OVERRIDES: Readonly<Record<string, string>> = {
   // Dropbox labels this mutating admin route as members.read in Stone.
   "team/member_space_limits/set_custom_quota": "members.write",
 };
+
+const DROPBOX_PERMISSION_DESCRIPTIONS = {
+  "account_info.read":
+    "Read Dropbox account profile, account IDs, and linked account metadata.",
+  "account_info.write": "Update the current Dropbox account profile photo.",
+  "contacts.write": "Delete manually added Dropbox contacts.",
+  "events.read": "Read Dropbox team event log entries.",
+  "file_requests.read": "List, retrieve, and count Dropbox file requests.",
+  "file_requests.write": "Create, update, and delete Dropbox file requests.",
+  "files.content.read":
+    "Download, export, preview, and read Dropbox file content.",
+  "files.content.write":
+    "Create, upload, move, copy, lock, and delete Dropbox files and folders.",
+  "files.metadata.read":
+    "Read Dropbox file, folder, tag, and property metadata.",
+  "files.metadata.write":
+    "Create, update, and remove Dropbox file tags, templates, and custom properties.",
+  "files.permanent_delete":
+    "Permanently delete Dropbox files, folders, and Paper docs.",
+  "files.team_metadata.write":
+    "Create, update, and remove team file property templates and metadata.",
+  "groups.read": "Read Dropbox team groups and group memberships.",
+  "groups.write":
+    "Create, update, delete, and manage Dropbox team groups and group members.",
+  "members.delete":
+    "Remove, recover, and complete deletion workflows for Dropbox team members.",
+  "members.read":
+    "Read Dropbox team member profiles, roles, quotas, and membership state.",
+  "members.write":
+    "Add, update, suspend, unsuspend, and manage Dropbox team members and member quotas.",
+  openid: "Read OpenID Connect identity information from Dropbox.",
+  "private:sharing.write":
+    "Relinquish the current user's removable access to files and folders.",
+  "sessions.list":
+    "List Dropbox team member devices, web sessions, and linked apps.",
+  "sessions.modify":
+    "Revoke Dropbox team member devices, web sessions, and linked apps.",
+  "sharing.read":
+    "Read Dropbox shared links, shared files, shared folders, and membership details.",
+  "sharing.write":
+    "Create, update, revoke, mount, unmount, and manage Dropbox sharing.",
+  "team_data.content.read":
+    "Read Dropbox team folders, namespaces, and team-owned content metadata.",
+  "team_data.content.write":
+    "Create, rename, activate, archive, restore, and delete Dropbox team folders.",
+  "team_data.governance.write":
+    "Create, update, release, and inspect Dropbox team legal hold policies and held revisions.",
+  "team_data.member":
+    "List Dropbox team namespaces and member folder structure.",
+  "team_info.read":
+    "Read Dropbox team profile, features, reports, and team settings.",
+  "team_info.write": "Update Dropbox team-level sharing allowlist settings.",
+} satisfies Readonly<Record<string, string>>;
 
 function parseStoneRoutes(content: string): StoneRoute[] {
   const routes: StoneRoute[] = [];
@@ -190,6 +244,67 @@ function buildGroups(routes: StoneRoute[]): Map<DropboxHost, HostPermissions> {
   return result;
 }
 
+function allPermissionGroups(
+  hostGroups: Map<DropboxHost, HostPermissions>,
+): PermissionGroup[] {
+  const permissionsByName = new Map<string, PermissionGroup>();
+
+  for (const { permissions } of hostGroups.values()) {
+    for (const permission of permissions) {
+      const existing = permissionsByName.get(permission.name);
+      if (existing) {
+        existing.rules.push(...permission.rules);
+        continue;
+      }
+      permissionsByName.set(permission.name, {
+        name: permission.name,
+        rules: [...permission.rules],
+      });
+    }
+  }
+
+  return [...permissionsByName.values()].sort((a, b) =>
+    a.name.localeCompare(b.name),
+  );
+}
+
+function applyDropboxPermissionDescriptions(
+  hostGroups: Map<DropboxHost, HostPermissions>,
+): Map<DropboxHost, HostPermissions> {
+  const describedPermissions = applyPermissionDescriptions(
+    "Dropbox",
+    allPermissionGroups(hostGroups),
+    DROPBOX_PERMISSION_DESCRIPTIONS,
+  );
+  const descriptions = new Map(
+    describedPermissions.map((permission) => {
+      return [permission.name, permission.description] as const;
+    }),
+  );
+
+  return new Map(
+    [...hostGroups.entries()].map(([host, { permissions }]) => {
+      return [
+        host,
+        {
+          permissions: permissions.map((permission) => {
+            const description = descriptions.get(permission.name);
+            if (!description) {
+              throw new Error(
+                `Missing Dropbox permission description after validation: ${permission.name}`,
+              );
+            }
+            return {
+              ...permission,
+              description,
+            };
+          }),
+        },
+      ];
+    }),
+  );
+}
+
 // ── TypeScript generation ────────────────────────────────────────────────
 
 function generateTypeScript(
@@ -248,7 +363,7 @@ export async function generate(): Promise<void> {
   );
   console.error(`  Parsed ${allRoutes.length} routes`);
 
-  const hostGroups = buildGroups(allRoutes);
+  const hostGroups = applyDropboxPermissionDescriptions(buildGroups(allRoutes));
   const ts = generateTypeScript(hostGroups);
 
   // Log stats for the main API host


### PR DESCRIPTION
## Summary
- add source-level Dropbox firewall permission descriptions with generator-time missing/stale validation
- apply descriptions across all Dropbox API hosts before metadata extraction
- add focused tests for Dropbox source-boundary and metadata descriptions

Fixes #19611

## Tests
- pnpm -F @vm0/firewalls-generator generate:dropbox
- pnpm -F @vm0/firewalls-generator exec vitest src/__tests__/metadata.test.ts
- pnpm -F @vm0/connectors exec vitest src/__tests__/firewall-metadata.test.ts
- pnpm -F @vm0/firewalls-generator check-types
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/connectors lint
- pnpm format
- git diff --check

## Notes
- The full pre-commit hook was blocked by an unrelated existing knip finding in apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx:782.