### PR TITLE
fix: commit create-run launch rows atomically

### DIFF
--- a/turbo/apps/api/src/__tests__/test-app.ts
+++ b/turbo/apps/api/src/__tests__/test-app.ts
@@ -14,6 +14,7 @@ import type { TestContext } from "./test-context";
 interface SetupAppWithRoutesOptions {
   readonly context: TestContext;
   readonly routes: readonly RouteEntry[];
+  readonly signal?: AbortSignal;
 }
 
 function parseResponseBody(response: Response): Promise<unknown> | undefined {
@@ -54,8 +55,9 @@ async function requestApp(
 function createAppFetcher(
   context: TestContext,
   routes: readonly RouteEntry[],
+  signal?: AbortSignal,
 ): ApiFetcher {
-  const app = createAppWithRoutes({ signal: context.signal, routes });
+  const app = createAppWithRoutes({ signal: signal ?? context.signal, routes });
 
   return (args) => {
     return requestApp(app, args);
@@ -65,8 +67,9 @@ function createAppFetcher(
 export function setupAppWithRoutes({
   context,
   routes,
+  signal,
 }: SetupAppWithRoutesOptions) {
-  const app = createAppFetcher(context, routes);
+  const app = createAppFetcher(context, routes, signal);
 
   return <TContract extends AppRouter>(
     contract: TContract,

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -1055,6 +1055,62 @@ describe("CHAT-02: queueing and recalling messages", () => {
 });
 
 describe("CHAT-02: org queue markers", () => {
+  it("drains queued chat runs when an interrupt request aborts post-cancel", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+    mockEnv("CONCURRENT_RUN_LIMIT_CAP", "1");
+    const controller = new AbortController();
+
+    const blocker = await chat.requestSendMessage(
+      actor,
+      { agentId, prompt: "occupy org concurrency before interrupt abort" },
+      [201],
+    );
+    if (blocker.status !== 201 || blocker.body.runId === null) {
+      throw new Error("Expected the blocking send to create a run");
+    }
+    expect(blocker.body.status).toBe("pending");
+
+    const queued = await chat.requestSendMessage(
+      actor,
+      { agentId, prompt: "drain after interrupt abort" },
+      [201],
+    );
+    if (queued.status !== 201 || queued.body.runId === null) {
+      throw new Error("Expected the second send to create a queued run");
+    }
+    expect(queued.body.status).toBe("queued");
+
+    context.mocks.ably.publish.mockImplementation((topic: unknown) => {
+      if (topic === "queue:changed") {
+        const error = new Error("abort after interrupt cancel commit");
+        error.name = "AbortError";
+        controller.abort(error);
+      }
+      return Promise.resolve(undefined);
+    });
+
+    await chat.requestSendMessage(
+      actor,
+      {
+        agentId,
+        threadId: blocker.body.threadId,
+        interruptsRunId: blocker.body.runId,
+        clientMessageId: randomUUID(),
+      },
+      [201],
+      controller.signal,
+    );
+
+    await waitForRunStatus(actor, blocker.body.runId, "cancelled");
+    await waitForRunStatus(actor, queued.body.runId, "pending");
+    await api.heartbeatRunner(runnerGroup);
+    const claim = await api.claimRunnerJob(queued.body.runId);
+    expect(claim.prompt).toBe("drain after interrupt abort");
+
+    await api.requestCancelRun(actor, queued.body.runId, [200]);
+  });
+
   it("marks queued chat runs and revokes the marker on dequeue", async () => {
     const { actor, agentId } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
@@ -1042,7 +1042,13 @@ export function createChatFilesBddApi(context: TestContext) {
       actor: ApiTestUser | null,
       body: BddSendMessageBody,
       statuses: readonly (201 | 400 | 401 | 402 | 403 | 404 | 409 | 422)[],
+      signal?: AbortSignal,
     ) {
+      const client = signal
+        ? setupAppWithRoutes({ context, routes: chatFilesRoutes, signal })(
+            chatMessagesContract,
+          )
+        : chatMessagesClient();
       const requestBody =
         "prompt" in body
           ? {
@@ -1100,7 +1106,7 @@ export function createChatFilesBddApi(context: TestContext) {
               };
 
       return await accept(
-        chatMessagesClient().send({
+        client.send({
           headers: authenticate(context, actor),
           body: requestBody,
         }),

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs-automations.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs-automations.ts
@@ -1008,6 +1008,24 @@ export function createRunsAutomationsApi(context: TestContext) {
       );
     },
 
+    async requestCancelRunWithSignal(
+      actor: ApiTestUser,
+      runId: string,
+      signal: AbortSignal,
+    ): Promise<{ readonly status: number; readonly body: unknown }> {
+      const { authorization } = authenticate(context, actor);
+      const app = createAppWithRoutes({
+        signal,
+        routes: runsAutomationRoutes,
+      });
+      const response = await app.request(`/api/zero/runs/${runId}/cancel`, {
+        method: "POST",
+        headers: authorization === undefined ? {} : { authorization },
+      });
+      const body: unknown = await response.json();
+      return { status: response.status, body };
+    },
+
     async heartbeatRunner(group?: string) {
       return await accept(
         runsAutomationApp(context)(runnersHeartbeatContract).heartbeat({

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -3910,6 +3910,19 @@ describe("RUN-03: cancellation of dispatched and terminal runs", () => {
     await api.requestCancelRun(actor, run.runId, [200]);
     const cancelled = await api.readRun(actor, run.runId);
     expect(cancelled.status).toBe("cancelled");
+    await expect
+      .poll(() => {
+        return context.mocks.ably.publish.mock.calls.some(
+          ([topic, payload]) => {
+            return (
+              topic === `run:changed:${run.runId}` &&
+              isRecord(payload) &&
+              payload.status === "cancelled"
+            );
+          },
+        );
+      })
+      .toBe(true);
 
     const repeated = await api.requestCancelRun(actor, run.runId, [200]);
     expect(repeated.status).toBe(200);

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1511,6 +1511,60 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
     await api.requestCancelRun(actor, queued.runId, [200]);
   });
 
+  it("drains queued runs when queue changed publish fails after cancellation", async () => {
+    const api = createRunsAutomationsApi(context);
+    const { actor, agentId } = await entitledRunActor();
+
+    const first = await api.createRun(actor, {
+      agentId,
+      prompt: "active run before publish failure one",
+      modelProvider: "anthropic-api-key",
+    });
+    const second = await api.createRun(actor, {
+      agentId,
+      prompt: "active run before publish failure two",
+      modelProvider: "anthropic-api-key",
+    });
+    const queued = await api.createRun(actor, {
+      agentId,
+      prompt: "queued run should drain despite queue publish failure",
+      modelProvider: "anthropic-api-key",
+    });
+    expect(queued.status).toBe("queued");
+
+    context.mocks.ably.publish.mockImplementation((topic: unknown) => {
+      if (topic === "queue:changed") {
+        return Promise.reject(new Error("queue changed publish failed"));
+      }
+      return Promise.resolve(undefined);
+    });
+
+    await api.requestCancelRun(actor, first.runId, [200]);
+    const promoted = await waitForRunStatus(
+      api,
+      actor,
+      queued.runId,
+      "pending",
+    );
+    expect(promoted.status).toBe("pending");
+    await expect
+      .poll(() => {
+        return context.mocks.ably.publish.mock.calls.some(
+          ([topic, payload]) => {
+            return (
+              topic === "job" &&
+              isRecord(payload) &&
+              payload.runId === queued.runId
+            );
+          },
+        );
+      })
+      .toBe(true);
+
+    await api.requestCancelRun(actor, second.runId, [200]);
+    await api.requestCancelRun(actor, queued.runId, [200]);
+  });
+
   it("keeps a queued launch visible when enqueue telemetry fails", async () => {
     const api = createRunsAutomationsApi(context);
     const { actor, agentId } = await entitledRunActor();

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1511,6 +1511,68 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
     await api.requestCancelRun(actor, queued.runId, [200]);
   });
 
+  it("drains queued runs after a cancel request aborts post-commit", async () => {
+    const api = createRunsAutomationsApi(context);
+    const { actor, agentId } = await entitledRunActor();
+    const controller = new AbortController();
+
+    const first = await api.createRun(actor, {
+      agentId,
+      prompt: "active run before post-commit abort one",
+      modelProvider: "anthropic-api-key",
+    });
+    const second = await api.createRun(actor, {
+      agentId,
+      prompt: "active run before post-commit abort two",
+      modelProvider: "anthropic-api-key",
+    });
+    const queued = await api.createRun(actor, {
+      agentId,
+      prompt: "queued run should drain after cancel abort",
+      modelProvider: "anthropic-api-key",
+    });
+    expect(queued.status).toBe("queued");
+
+    context.mocks.ably.publish.mockImplementation((topic: unknown) => {
+      if (topic === "queue:changed") {
+        const error = new Error("abort after cancel commit");
+        error.name = "AbortError";
+        controller.abort(error);
+      }
+      return Promise.resolve(undefined);
+    });
+
+    const cancelled = await api.requestCancelRunWithSignal(
+      actor,
+      first.runId,
+      controller.signal,
+    );
+    expect(cancelled.status).toBe(200);
+    const promoted = await waitForRunStatus(
+      api,
+      actor,
+      queued.runId,
+      "pending",
+    );
+    expect(promoted.status).toBe("pending");
+    await expect
+      .poll(() => {
+        return context.mocks.ably.publish.mock.calls.some(
+          ([topic, payload]) => {
+            return (
+              topic === "job" &&
+              isRecord(payload) &&
+              payload.runId === queued.runId
+            );
+          },
+        );
+      })
+      .toBe(true);
+
+    await api.requestCancelRun(actor, second.runId, [200]);
+    await api.requestCancelRun(actor, queued.runId, [200]);
+  });
+
   it("drains queued runs when queue changed publish fails after cancellation", async () => {
     const api = createRunsAutomationsApi(context);
     const { actor, agentId } = await entitledRunActor();

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1,6 +1,12 @@
 import { createHash, randomUUID } from "node:crypto";
 
 import {
+  DecryptCommand,
+  type DecryptCommandOutput,
+  GenerateDataKeyCommand,
+  type GenerateDataKeyCommandOutput,
+} from "@aws-sdk/client-kms";
+import {
   getModelProviderFirewall,
   getVm0ConcreteProviderType,
   type ModelProviderType,
@@ -44,6 +50,10 @@ import {
   resetAutomationsFakeKms,
   seedVm0ManagedDefaultModelKey as seedVm0ManagedDefaultModelKeyState,
 } from "./helpers/automations";
+import {
+  setSecretKmsClientForTests,
+  type SecretKmsClient,
+} from "../../../lib/secret-kms-client";
 
 /**
  * RUN-01..04 and CHAIN-RUN: successful run dispatch and lifecycle.
@@ -55,6 +65,7 @@ import {
 
 const context = testContext();
 const ASSISTANT_MESSAGE_ID_NAMESPACE = "bfec4fb6-d5b8-43e4-a72a-9f58f87d7e01";
+const TEST_DATA_KEY = Buffer.from("0123456789abcdef0123456789abcdef", "utf8");
 
 // Sentinel provider id for model-first thread selections (the wire-protocol
 // value the chat composer sends when picking a model instead of a provider).
@@ -325,6 +336,40 @@ async function seedVm0ManagedDefaultModelKey(): Promise<string> {
     await deleteVm0ManagedDefaultModelKey(context);
   });
   return await seedVm0ManagedDefaultModelKeyState(context);
+}
+
+function failKmsAfterGenerateDataKeys(limit: number): void {
+  let generateDataKeyCalls = 0;
+  function send(
+    command: GenerateDataKeyCommand,
+  ): Promise<GenerateDataKeyCommandOutput>;
+  function send(command: DecryptCommand): Promise<DecryptCommandOutput>;
+  function send(
+    command: GenerateDataKeyCommand | DecryptCommand,
+  ): Promise<GenerateDataKeyCommandOutput | DecryptCommandOutput> {
+    if (command instanceof GenerateDataKeyCommand) {
+      generateDataKeyCalls += 1;
+      if (generateDataKeyCalls > limit) {
+        return Promise.reject(
+          new Error("unexpected queued payload encryption"),
+        );
+      }
+      return Promise.resolve({
+        $metadata: {},
+        KeyId: command.input.KeyId,
+        CiphertextBlob: Buffer.from(
+          `encrypted-data-key:${command.input.KeyId}`,
+          "utf8",
+        ),
+        Plaintext: TEST_DATA_KEY,
+      });
+    }
+
+    return Promise.resolve({ $metadata: {}, Plaintext: TEST_DATA_KEY });
+  }
+
+  const client: SecretKmsClient = { send };
+  setSecretKmsClientForTests(client);
 }
 
 function inlineFirewallApis(
@@ -1227,6 +1272,22 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
     );
     expectApiError(vm0Rejected.body);
     expect(vm0Rejected.body.error.code).toBe("INSUFFICIENT_CREDITS");
+  });
+
+  it("does not require queued payload encryption while capacity is available", async () => {
+    const api = createRunsAutomationsApi(context);
+    const { actor, agentId } = await entitledRunActor();
+    failKmsAfterGenerateDataKeys(1);
+
+    const run = await api.createRun(actor, {
+      agentId,
+      prompt: "capacity available run should not encrypt queued payload",
+      modelProvider: "anthropic-api-key",
+    });
+
+    expect(run.status).toBe("pending");
+
+    await api.requestCancelRun(actor, run.runId, [200]);
   });
 
   it("queues runs over the concurrency limit and promotes them after cancellation", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -338,7 +338,10 @@ async function seedVm0ManagedDefaultModelKey(): Promise<string> {
   return await seedVm0ManagedDefaultModelKeyState(context);
 }
 
-function failKmsAfterGenerateDataKeys(limit: number): void {
+function useSecretKmsClientForTests(args: {
+  readonly failAfterGenerateDataKeys?: number;
+  readonly onGenerateDataKey?: (callNumber: number) => void;
+}): void {
   let generateDataKeyCalls = 0;
   function send(
     command: GenerateDataKeyCommand,
@@ -349,7 +352,11 @@ function failKmsAfterGenerateDataKeys(limit: number): void {
   ): Promise<GenerateDataKeyCommandOutput | DecryptCommandOutput> {
     if (command instanceof GenerateDataKeyCommand) {
       generateDataKeyCalls += 1;
-      if (generateDataKeyCalls > limit) {
+      args.onGenerateDataKey?.(generateDataKeyCalls);
+      if (
+        args.failAfterGenerateDataKeys !== undefined &&
+        generateDataKeyCalls > args.failAfterGenerateDataKeys
+      ) {
         return Promise.reject(
           new Error("unexpected queued payload encryption"),
         );
@@ -370,6 +377,20 @@ function failKmsAfterGenerateDataKeys(limit: number): void {
 
   const client: SecretKmsClient = { send };
   setSecretKmsClientForTests(client);
+}
+
+function failKmsAfterGenerateDataKeys(limit: number): void {
+  useSecretKmsClientForTests({ failAfterGenerateDataKeys: limit });
+}
+
+function advanceNowOnFirstGenerateDataKey(timestamp: number): void {
+  useSecretKmsClientForTests({
+    onGenerateDataKey: (callNumber) => {
+      if (callNumber === 1) {
+        mockNow(timestamp);
+      }
+    },
+  });
 }
 
 function inlineFirewallApis(
@@ -1286,6 +1307,35 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
     });
 
     expect(run.status).toBe("pending");
+
+    await api.requestCancelRun(actor, run.runId, [200]);
+  });
+
+  it("timestamps pending launches when the durable row is inserted", async () => {
+    const api = createRunsAutomationsApi(context);
+    const { actor, agentId } = await entitledRunActor();
+    const requestStartedAt = Date.UTC(2026, 0, 1, 12, 0, 0);
+    const payloadPreparedAt = requestStartedAt + 6 * 60_000;
+    mockNow(requestStartedAt);
+    advanceNowOnFirstGenerateDataKey(payloadPreparedAt);
+
+    const run = await api.createRun(actor, {
+      agentId,
+      prompt: "pending launch timestamp should reflect durable insert",
+      modelProvider: "anthropic-api-key",
+    });
+
+    expect(run.status).toBe("pending");
+    if (!run.createdAt) {
+      throw new Error("Expected created run createdAt");
+    }
+    expect(new Date(run.createdAt).getTime()).toBe(payloadPreparedAt);
+
+    const stored = await api.readRun(actor, run.runId);
+    if (!stored.createdAt) {
+      throw new Error("Expected stored run createdAt");
+    }
+    expect(new Date(stored.createdAt).getTime()).toBe(payloadPreparedAt);
 
     await api.requestCancelRun(actor, run.runId, [200]);
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1445,6 +1445,72 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
     await api.requestCancelRun(actor, second.runId, [200]);
   });
 
+  it("finishes promoted queued run notifications after request abort", async () => {
+    const api = createRunsAutomationsApi(context);
+    const { actor, agentId } = await entitledRunActor();
+    const controller = new AbortController();
+    let queueChangedPublishes = 0;
+
+    const first = await api.createRun(actor, {
+      agentId,
+      prompt: "active run before abort promotion one",
+      modelProvider: "anthropic-api-key",
+    });
+    const second = await api.createRun(actor, {
+      agentId,
+      prompt: "active run before abort promotion two",
+      modelProvider: "anthropic-api-key",
+    });
+    const queued = await api.createRun(actor, {
+      agentId,
+      prompt: "queued run should still notify after abort",
+      modelProvider: "anthropic-api-key",
+    });
+    expect(queued.status).toBe("queued");
+
+    context.mocks.ably.publish.mockImplementation((topic: unknown) => {
+      if (topic === "queue:changed") {
+        queueChangedPublishes++;
+        if (queueChangedPublishes === 2) {
+          const error = new Error("abort after queued promotion commit");
+          error.name = "AbortError";
+          controller.abort(error);
+        }
+      }
+      return Promise.resolve(undefined);
+    });
+
+    const cancelled = await api.requestCancelRunWithSignal(
+      actor,
+      first.runId,
+      controller.signal,
+    );
+    expect(cancelled.status).toBe(200);
+    const promoted = await waitForRunStatus(
+      api,
+      actor,
+      queued.runId,
+      "pending",
+    );
+    expect(promoted.status).toBe("pending");
+    await expect
+      .poll(() => {
+        return context.mocks.ably.publish.mock.calls.some(
+          ([topic, payload]) => {
+            return (
+              topic === "job" &&
+              isRecord(payload) &&
+              payload.runId === queued.runId
+            );
+          },
+        );
+      })
+      .toBe(true);
+
+    await api.requestCancelRun(actor, second.runId, [200]);
+    await api.requestCancelRun(actor, queued.runId, [200]);
+  });
+
   it("keeps a queued launch visible when enqueue telemetry fails", async () => {
     const api = createRunsAutomationsApi(context);
     const { actor, agentId } = await entitledRunActor();

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -61,9 +61,7 @@ const ASSISTANT_MESSAGE_ID_NAMESPACE = "bfec4fb6-d5b8-43e4-a72a-9f58f87d7e01";
 const MODEL_FIRST_SELECTION_PROVIDER_ID =
   "00000000-0000-4000-8000-000000000000";
 const API_DISPATCH_QUEUE_PERSISTENCE_ACTION_TYPES = [
-  "api_dispatch_lock_run_for_queue_persistence",
   "api_dispatch_insert_runner_job_queue",
-  "api_dispatch_update_run_runner_group",
 ] as const;
 const CLAIM_ROUTE_TOP_LEVEL_TIMING_ACTION_TYPES = [
   "claim_route_request_prepare",
@@ -120,7 +118,6 @@ const API_DISPATCH_TIMING_ACTION_TYPES = [
   "api_dispatch_prepare_context_load_user_timezone",
   "api_dispatch_prepare_context_prepare_output_metadata",
   "api_dispatch_insert_run_with_concurrency",
-  "api_dispatch_mark_pending_heartbeat",
   "api_dispatch_build_runner_job_payload",
   "api_dispatch_persist_runner_job_queue",
   ...API_DISPATCH_QUEUE_PERSISTENCE_ACTION_TYPES,
@@ -1234,7 +1231,7 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
 
   it("queues runs over the concurrency limit and promotes them after cancellation", async () => {
     const api = createRunsAutomationsApi(context);
-    const { actor, agentId } = await entitledRunActor();
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
 
     const first = await api.createRun(actor, {
       agentId,
@@ -1267,6 +1264,9 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
     expect(promoted.status).toBe("pending");
     const drained = await waitForRunQueueLength(api, actor, 0);
     expect(drained.body.queue).toHaveLength(0);
+    await api.heartbeatRunner(runnerGroup);
+    const thirdClaim = await api.claimRunnerJob(third.runId);
+    expect(thirdClaim.prompt).toBe("queued run three");
 
     await api.requestCancelRun(actor, second.runId, [200]);
     await api.requestCancelRun(actor, third.runId, [200]);
@@ -3949,6 +3949,37 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
     });
     expect(failedRun.status).toBe("failed");
     expect(failedRun.error).toBe("Only vm0/* runner groups are supported");
+    const storedFailedRun = await api.readRun(actor, failedRun.runId);
+    expect(storedFailedRun.status).toBe("failed");
+    const failedClaim = await api.requestClaimRunnerJob(
+      true,
+      failedRun.runId,
+      [404],
+    );
+    expectApiError(failedClaim.body);
+    expect(failedClaim.body.error.message).toBe("Job not found in queue");
+
+    const firstActive = await api.createDirectRun(actor, {
+      agentComposeId: compose.composeId,
+      prompt: "active direct run one",
+    });
+    const secondActive = await api.createDirectRun(actor, {
+      agentComposeId: compose.composeId,
+      prompt: "active direct run two",
+    });
+    const rejected = await api.requestDirectRun(
+      actor,
+      {
+        agentComposeId: foreignCompose.composeId,
+        prompt: "concurrency should win before runner payload validation",
+      },
+      [429],
+    );
+    expectApiError(rejected.body);
+    expect(rejected.body.error.code).toBe("CONCURRENT_RUN_LIMIT");
+
+    await api.requestCancelRun(actor, firstActive.runId, [200]);
+    await api.requestCancelRun(actor, secondActive.runId, [200]);
   });
 });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -16,7 +16,7 @@ import { HttpResponse, http } from "msw";
 import { describe, expect, it, onTestFinished } from "vitest";
 import { v5 as uuidv5 } from "uuid";
 
-import { mockOptionalEnv } from "../../../lib/env";
+import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { mockNow, now, nowDate } from "../../../lib/time";
 import { testContext } from "../../../__tests__/test-context";
 import { server } from "../../../mocks/server";
@@ -1357,6 +1357,43 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
     );
 
     await api.requestCancelRun(actor, queued.runId, [200]);
+    await api.requestCancelRun(actor, first.runId, [200]);
+    await api.requestCancelRun(actor, second.runId, [200]);
+  });
+
+  it("records a failed queued launch when queue payload encryption fails", async () => {
+    const api = createRunsAutomationsApi(context);
+    const { actor, agentId } = await entitledRunActor();
+
+    const first = await api.createRun(actor, {
+      agentId,
+      prompt: "active run before queued encryption failure one",
+      modelProvider: "anthropic-api-key",
+    });
+    const second = await api.createRun(actor, {
+      agentId,
+      prompt: "active run before queued encryption failure two",
+      modelProvider: "anthropic-api-key",
+    });
+
+    mockEnv("SECRETS_KMS_KEY_ID", undefined);
+    const failed = await api.createRun(actor, {
+      agentId,
+      prompt: "queued run should fail when payload encryption fails",
+      modelProvider: "anthropic-api-key",
+    });
+
+    expect(failed.status).toBe("failed");
+    expect(failed.error).toBe(
+      "SECRETS_KMS_KEY_ID is required for KMS secret encryption",
+    );
+    const stored = await api.readRun(actor, failed.runId);
+    expect(stored.status).toBe("failed");
+    const queue = await api.readRunQueue(actor);
+    expect(queue.body.queue).not.toContainEqual(
+      expect.objectContaining({ runId: failed.runId }),
+    );
+
     await api.requestCancelRun(actor, first.runId, [200]);
     await api.requestCancelRun(actor, second.runId, [200]);
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1385,6 +1385,66 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
     expect(emptied.body.concurrency.active).toBe(0);
   });
 
+  it("counts promoted queued runs by promotion heartbeat for admission", async () => {
+    const api = createRunsAutomationsApi(context);
+    const { actor, agentId } = await entitledRunActor();
+
+    const first = await api.createRun(actor, {
+      agentId,
+      prompt: "active run before old queue promotion one",
+      modelProvider: "anthropic-api-key",
+    });
+    expect(first.status).toBe("pending");
+    const second = await api.createRun(actor, {
+      agentId,
+      prompt: "active run before old queue promotion two",
+      modelProvider: "anthropic-api-key",
+    });
+    expect(second.status).toBe("pending");
+
+    const queued = await api.createRun(actor, {
+      agentId,
+      prompt: "queued run promoted after pending ttl",
+      modelProvider: "anthropic-api-key",
+    });
+    expect(queued.status).toBe("queued");
+
+    mockNow(now() + 16 * 60_000);
+    await api.requestCancelRun(actor, first.runId, [200]);
+    const promoted = await waitForRunStatus(
+      api,
+      actor,
+      queued.runId,
+      "pending",
+    );
+    expect(promoted.status).toBe("pending");
+
+    const fresh = await api.createRun(actor, {
+      agentId,
+      prompt: "fresh run beside promoted queue item",
+      modelProvider: "anthropic-api-key",
+    });
+    expect(fresh.status).toBe("pending");
+
+    const overLimit = await api.createRun(actor, {
+      agentId,
+      prompt: "run should queue behind promoted active item",
+      modelProvider: "anthropic-api-key",
+    });
+    expect(overLimit.status).toBe("queued");
+
+    const queue = await api.readRunQueue(actor);
+    expect(queue.body.concurrency.active).toBe(2);
+    expect(queue.body.queue).toContainEqual(
+      expect.objectContaining({ runId: overLimit.runId }),
+    );
+
+    await api.requestCancelRun(actor, overLimit.runId, [200]);
+    await api.requestCancelRun(actor, fresh.runId, [200]);
+    await api.requestCancelRun(actor, queued.runId, [200]);
+    await api.requestCancelRun(actor, second.runId, [200]);
+  });
+
   it("keeps a queued launch visible when enqueue telemetry fails", async () => {
     const api = createRunsAutomationsApi(context);
     const { actor, agentId } = await entitledRunActor();

--- a/turbo/apps/api/src/signals/routes/agent-runs-cancel.ts
+++ b/turbo/apps/api/src/signals/routes/agent-runs-cancel.ts
@@ -86,13 +86,17 @@ const cancelRunInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   }
 
   if (!result.alreadyCancelled) {
+    const backgroundSignal = new AbortController().signal;
     waitUntil(
-      tapError(set(dispatchCancelSideEffects$, result, signal), (error) => {
-        L.error("dispatchCancelSideEffects failed", {
-          runId: result.runId,
-          error,
-        });
-      }),
+      tapError(
+        set(dispatchCancelSideEffects$, result, backgroundSignal),
+        (error) => {
+          L.error("dispatchCancelSideEffects failed", {
+            runId: result.runId,
+            error,
+          });
+        },
+      ),
     );
   }
 

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -2021,8 +2021,11 @@ const handleInterruptSend$ = command(
       return cancelResult;
     }
     if (!cancelResult.alreadyCancelled) {
+      const backgroundSignal = new AbortController().signal;
       waitUntil(
-        bestEffort(set(dispatchCancelSideEffects$, cancelResult, signal)),
+        bestEffort(
+          set(dispatchCancelSideEffects$, cancelResult, backgroundSignal),
+        ),
       );
     }
 

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads-delete.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads-delete.ts
@@ -37,13 +37,17 @@ const deleteInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   // Dispatch post-cancel side effects (runner halt, queue drain, credit
   // reconciliation) for every run we stopped while tearing down the thread.
   for (const cancelled of result.cancelledRuns) {
+    const backgroundSignal = new AbortController().signal;
     waitUntil(
-      tapError(set(dispatchCancelSideEffects$, cancelled, signal), (error) => {
-        L.error("dispatchCancelSideEffects failed", {
-          runId: cancelled.runId,
-          error,
-        });
-      }),
+      tapError(
+        set(dispatchCancelSideEffects$, cancelled, backgroundSignal),
+        (error) => {
+          L.error("dispatchCancelSideEffects failed", {
+            runId: cancelled.runId,
+            error,
+          });
+        },
+      ),
     );
   }
 

--- a/turbo/apps/api/src/signals/routes/zero-runs-cancel.ts
+++ b/turbo/apps/api/src/signals/routes/zero-runs-cancel.ts
@@ -40,13 +40,17 @@ const cancelInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   }
 
   if (!result.alreadyCancelled) {
+    const backgroundSignal = new AbortController().signal;
     waitUntil(
-      tapError(set(dispatchCancelSideEffects$, result, signal), (error) => {
-        L.error("dispatchCancelSideEffects failed", {
-          runId: result.runId,
-          error,
-        });
-      }),
+      tapError(
+        set(dispatchCancelSideEffects$, result, backgroundSignal),
+        (error) => {
+          L.error("dispatchCancelSideEffects failed", {
+            runId: result.runId,
+            error,
+          });
+        },
+      ),
     );
   }
 

--- a/turbo/apps/api/src/signals/services/agent-run-activity.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-activity.service.ts
@@ -2,8 +2,11 @@ import { agentRuns } from "@vm0/db/schema/agent-run";
 import { sql, type SQL } from "drizzle-orm";
 
 export function activePendingRunPredicate(staleThreshold: Date): SQL<boolean> {
-  return sql<boolean>`COALESCE(${agentRuns.lastHeartbeatAt}, ${agentRuns.createdAt}) > ${sql.param(
-    staleThreshold,
-    agentRuns.createdAt,
-  )}`;
+  return sql<boolean>`(
+    ${agentRuns.lastHeartbeatAt} > ${sql.param(staleThreshold, agentRuns.lastHeartbeatAt)}
+    OR (
+      ${agentRuns.lastHeartbeatAt} IS NULL
+      AND ${agentRuns.createdAt} > ${sql.param(staleThreshold, agentRuns.createdAt)}
+    )
+  )`;
 }

--- a/turbo/apps/api/src/signals/services/agent-run-activity.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-activity.service.ts
@@ -1,0 +1,9 @@
+import { agentRuns } from "@vm0/db/schema/agent-run";
+import { sql, type SQL } from "drizzle-orm";
+
+export function activePendingRunPredicate(staleThreshold: Date): SQL<boolean> {
+  return sql<boolean>`COALESCE(${agentRuns.lastHeartbeatAt}, ${agentRuns.createdAt}) > ${sql.param(
+    staleThreshold,
+    agentRuns.createdAt,
+  )}`;
+}

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -339,7 +339,6 @@ interface RunRecord {
 
 interface LaunchRunIdentity {
   readonly runId: string;
-  readonly createdAt: Date;
   readonly sessionId: string;
   readonly shouldCreateSession: boolean;
 }
@@ -4199,7 +4198,6 @@ function prepareLaunchRunIdentity(args: {
 }): LaunchRunIdentity {
   return {
     runId: randomUUID(),
-    createdAt: nowDate(),
     sessionId: args.resolved.agentSessionId ?? randomUUID(),
     shouldCreateSession: !args.resolved.agentSessionId,
   };
@@ -4208,10 +4206,11 @@ function prepareLaunchRunIdentity(args: {
 function runRecordFromLaunchIdentity(
   identity: LaunchRunIdentity,
   status: RunRecord["status"],
+  createdAt: Date,
 ): RunRecord {
   return {
     id: identity.runId,
-    createdAt: identity.createdAt,
+    createdAt,
     sessionId: identity.sessionId,
     status,
   };
@@ -4290,7 +4289,7 @@ async function insertLaunchRunRows(
     readonly runnerGroup: string | undefined;
     readonly error: string | undefined;
   },
-): Promise<void> {
+): Promise<{ readonly createdAt: Date }> {
   if (args.identity.shouldCreateSession) {
     await tx.insert(agentSessions).values({
       id: args.identity.sessionId,
@@ -4302,10 +4301,11 @@ async function insertLaunchRunRows(
     });
   }
 
-  const completedAt = args.status === "failed" ? nowDate() : undefined;
+  const createdAt = nowDate();
+  const completedAt = args.status === "failed" ? createdAt : undefined;
   const runValues: typeof agentRuns.$inferInsert = {
     id: args.identity.runId,
-    createdAt: args.identity.createdAt,
+    createdAt,
     userId: args.userId,
     orgId: args.orgId,
     agentComposeVersionId: args.resolved.agentComposeVersionId,
@@ -4320,7 +4320,7 @@ async function insertLaunchRunRows(
     resumedFromCheckpointId: args.resolved.resumedFromCheckpointId ?? null,
     continuedFromSessionId: args.resolved.continuedFromAgentSessionId ?? null,
     sessionId: args.identity.sessionId,
-    lastHeartbeatAt: args.identity.createdAt,
+    lastHeartbeatAt: createdAt,
     runnerGroup: args.runnerGroup ?? null,
     completedAt: completedAt ?? null,
     error: args.error ?? null,
@@ -4338,6 +4338,8 @@ async function insertLaunchRunRows(
   if (args.callbackRows.length > 0) {
     await tx.insert(agentRunCallbacks).values([...args.callbackRows]);
   }
+
+  return { createdAt };
 }
 
 async function insertRunRecord(
@@ -4362,7 +4364,7 @@ async function insertRunRecord(
     callbacks: args.callbacks,
     featureSwitchContext: args.featureSwitchContext,
   });
-  await insertLaunchRunRows(tx, {
+  const { createdAt } = await insertLaunchRunRows(tx, {
     userId: args.userId,
     orgId: args.orgId,
     identity,
@@ -4378,7 +4380,7 @@ async function insertRunRecord(
     runnerGroup: undefined,
     error: undefined,
   });
-  return runRecordFromLaunchIdentity(identity, "pending");
+  return runRecordFromLaunchIdentity(identity, "pending", createdAt);
 }
 
 async function insertQueuedRunRecord(
@@ -4403,7 +4405,7 @@ async function insertQueuedRunRecord(
     callbacks: args.callbacks,
     featureSwitchContext: args.featureSwitchContext,
   });
-  await insertLaunchRunRows(tx, {
+  const { createdAt } = await insertLaunchRunRows(tx, {
     userId: args.userId,
     orgId: args.orgId,
     identity,
@@ -4419,7 +4421,7 @@ async function insertQueuedRunRecord(
     runnerGroup: undefined,
     error: undefined,
   });
-  return runRecordFromLaunchIdentity(identity, "queued");
+  return runRecordFromLaunchIdentity(identity, "queued", createdAt);
 }
 
 async function buildStoredExecutionContext(args: {
@@ -5242,8 +5244,8 @@ async function commitFailedLaunch(args: {
   readonly error: unknown;
 }): Promise<Extract<CreateRunRouteResult, { readonly status: 201 }>> {
   const message = runFailureMessage(args.error);
-  await args.db.transaction(async (tx) => {
-    await insertLaunchRunRows(tx, {
+  const { createdAt } = await args.db.transaction(async (tx) => {
+    return await insertLaunchRunRows(tx, {
       userId: args.createArgs.userId,
       orgId: args.createArgs.orgId,
       identity: args.identity,
@@ -5284,7 +5286,7 @@ async function commitFailedLaunch(args: {
     );
   }
   return failedRunResponse(
-    runRecordFromLaunchIdentity(args.identity, "pending"),
+    runRecordFromLaunchIdentity(args.identity, "pending", createdAt),
     args.error,
   );
 }
@@ -5295,11 +5297,11 @@ async function insertAtomicLaunchRunRecord(args: {
   readonly status: Extract<LaunchRunStatus, "pending" | "queued">;
   readonly runnerGroup: string;
 }): Promise<RunRecord> {
-  await args.commit.timing.measure(
+  const { createdAt } = await args.commit.timing.measure(
     "api_dispatch_insert_run_record",
     "nested",
     async () => {
-      await insertLaunchRunRows(args.tx, {
+      return await insertLaunchRunRows(args.tx, {
         userId: args.commit.createArgs.userId,
         orgId: args.commit.createArgs.orgId,
         identity: args.commit.identity,
@@ -5317,7 +5319,11 @@ async function insertAtomicLaunchRunRecord(args: {
       });
     },
   );
-  return runRecordFromLaunchIdentity(args.commit.identity, args.status);
+  return runRecordFromLaunchIdentity(
+    args.commit.identity,
+    args.status,
+    createdAt,
+  );
 }
 
 async function commitQueuedPreparedLaunch(
@@ -5340,7 +5346,7 @@ async function commitQueuedPreparedLaunch(
     userId: args.createArgs.userId,
     orgId: args.createArgs.orgId,
     encryptedParams: args.encryptedQueuedParams,
-    createdAt: args.identity.createdAt,
+    createdAt: run.createdAt,
     expiresAt: sql`now() + interval '2 hours'`,
   });
   const [depthRow] = await tx

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -378,7 +378,14 @@ type AtomicLaunchCommitResult =
       readonly queueDepth: number;
       readonly telemetryTimestamp: string;
       readonly runContextSnapshot: RunContextAxiomSnapshot;
+    }
+  | {
+      readonly kind: "queue-payload-required";
     };
+type CommittedAtomicLaunchResult = Exclude<
+  AtomicLaunchCommitResult,
+  { readonly kind: "queue-payload-required" }
+>;
 
 interface CommitPreparedLaunchArgs {
   readonly db: Db;
@@ -5403,6 +5410,9 @@ async function commitPreparedLaunch(
       if (!args.createArgs.queueOnConcurrencyLimit) {
         return concurrency;
       }
+      if (!args.encryptedQueuedParams) {
+        return { kind: "queue-payload-required" };
+      }
       return await commitQueuedPreparedLaunch(tx, args, payload);
     }
 
@@ -6589,7 +6599,7 @@ function createLegacyBeforeDispatchRun(input: {
 async function committedAtomicLaunchResponse(args: {
   readonly db: Db;
   readonly createArgs: CreateAgentRunArgs;
-  readonly committed: AtomicLaunchCommitResult;
+  readonly committed: CommittedAtomicLaunchResult;
   readonly timing: ApiDispatchTimingCollector;
 }): Promise<Extract<CreateRunRouteResult, { readonly status: 201 }>> {
   if (args.committed.kind === "queued") {
@@ -6686,8 +6696,32 @@ function createAtomicLaunchRun(input: {
       });
     }
 
-    let encryptedQueuedParams: string | undefined;
-    if (input.args.queueOnConcurrencyLimit) {
+    const commitLaunch = async (encryptedQueuedParams: string | undefined) => {
+      return await input.timing.measure(
+        "api_dispatch_insert_run_with_concurrency",
+        "top_level",
+        async () => {
+          return await commitPreparedLaunch({
+            db: input.db,
+            createArgs: input.args,
+            context: input.context,
+            identity,
+            callbackRows,
+            launch: launchResult.value,
+            encryptedQueuedParams,
+            timing: input.timing,
+          });
+        },
+      );
+    };
+
+    let committed = await commitLaunch(undefined);
+    input.signal.throwIfAborted();
+    if (isRouteError(committed)) {
+      return committed;
+    }
+
+    if (committed.kind === "queue-payload-required") {
       const encryptedQueuedParamsResult = await settle(
         encryptQueuedRunnerJobPayload(
           launchResult.value.runnerJobPayload,
@@ -6696,6 +6730,19 @@ function createAtomicLaunchRun(input: {
       );
       input.signal.throwIfAborted();
       if (!encryptedQueuedParamsResult.ok) {
+        const retryWithoutQueuedPayload = await commitLaunch(undefined);
+        input.signal.throwIfAborted();
+        if (isRouteError(retryWithoutQueuedPayload)) {
+          return retryWithoutQueuedPayload;
+        }
+        if (retryWithoutQueuedPayload.kind !== "queue-payload-required") {
+          return await committedAtomicLaunchResponse({
+            db: input.db,
+            createArgs: input.args,
+            committed: retryWithoutQueuedPayload,
+            timing: input.timing,
+          });
+        }
         return await commitFailedLaunch({
           db: input.db,
           createArgs: input.args,
@@ -6705,30 +6752,17 @@ function createAtomicLaunchRun(input: {
           error: encryptedQueuedParamsResult.error,
         });
       }
-      encryptedQueuedParams = encryptedQueuedParamsResult.value;
+
+      committed = await commitLaunch(encryptedQueuedParamsResult.value);
+      input.signal.throwIfAborted();
+      if (isRouteError(committed)) {
+        return committed;
+      }
+      if (committed.kind === "queue-payload-required") {
+        throw new Error("Queued launch still required encrypted payload");
+      }
     }
 
-    const committed = await input.timing.measure(
-      "api_dispatch_insert_run_with_concurrency",
-      "top_level",
-      async () => {
-        return await commitPreparedLaunch({
-          db: input.db,
-          createArgs: input.args,
-          context: input.context,
-          identity,
-          callbackRows,
-          launch: launchResult.value,
-          encryptedQueuedParams,
-          timing: input.timing,
-        });
-      },
-    );
-    input.signal.throwIfAborted();
-
-    if (isRouteError(committed)) {
-      return committed;
-    }
     return await committedAtomicLaunchResponse({
       db: input.db,
       createArgs: input.args,

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { command, computed, type Computed } from "ccstate";
 import {
   CANONICAL_CODEX_MEMORY_MOUNT_PATH,
@@ -336,6 +337,15 @@ interface RunRecord {
   readonly status: "pending" | "queued";
 }
 
+interface LaunchRunIdentity {
+  readonly runId: string;
+  readonly createdAt: Date;
+  readonly sessionId: string;
+  readonly shouldCreateSession: boolean;
+}
+
+type LaunchRunStatus = "pending" | "queued" | "failed";
+
 interface LockedRunPersistenceRow extends Record<string, unknown> {
   readonly status: string;
   readonly sandboxId: string | null;
@@ -351,6 +361,34 @@ type RunnerJobPayload = ReturnType<typeof queuedRunnerJobPayload>;
 interface PreparedRunnerLaunch {
   readonly runnerJobPayload: RunnerJobPayload;
   readonly runContextSnapshot: RunContextAxiomSnapshot;
+}
+
+type AgentRunCallbackInsert = typeof agentRunCallbacks.$inferInsert;
+
+type AtomicLaunchCommitResult =
+  | {
+      readonly kind: "pending";
+      readonly run: RunRecord;
+      readonly runnerJobPayload: RunnerJobPayload;
+      readonly runContextSnapshot: RunContextAxiomSnapshot;
+    }
+  | {
+      readonly kind: "queued";
+      readonly run: RunRecord;
+      readonly queueDepth: number;
+      readonly telemetryTimestamp: string;
+      readonly runContextSnapshot: RunContextAxiomSnapshot;
+    };
+
+interface CommitPreparedLaunchArgs {
+  readonly db: Db;
+  readonly createArgs: CreateAgentRunArgs;
+  readonly context: PreparedRunContext;
+  readonly identity: LaunchRunIdentity;
+  readonly callbackRows: readonly AgentRunCallbackInsert[];
+  readonly launch: PreparedRunnerLaunch;
+  readonly encryptedQueuedParams: string | undefined;
+  readonly timing: ApiDispatchTimingCollector;
 }
 
 type QueuedPersistenceResult =
@@ -4138,6 +4176,58 @@ function zeroRunModelProviderValues(
   };
 }
 
+function prepareLaunchRunIdentity(args: {
+  readonly resolved: ResolvedCompose;
+}): LaunchRunIdentity {
+  return {
+    runId: randomUUID(),
+    createdAt: nowDate(),
+    sessionId: args.resolved.agentSessionId ?? randomUUID(),
+    shouldCreateSession: !args.resolved.agentSessionId,
+  };
+}
+
+function runRecordFromLaunchIdentity(
+  identity: LaunchRunIdentity,
+  status: RunRecord["status"],
+): RunRecord {
+  return {
+    id: identity.runId,
+    createdAt: identity.createdAt,
+    sessionId: identity.sessionId,
+    status,
+  };
+}
+
+function runFailureMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Run failed";
+}
+
+async function prepareRunCallbackRows(args: {
+  readonly runId: string;
+  readonly callbacks: readonly RunCallback[] | undefined;
+  readonly featureSwitchContext: FeatureSwitchContext;
+}): Promise<readonly AgentRunCallbackInsert[]> {
+  if (!args.callbacks || args.callbacks.length === 0) {
+    return [];
+  }
+
+  return await Promise.all(
+    args.callbacks.map(async (callback): Promise<AgentRunCallbackInsert> => {
+      return {
+        runId: args.runId,
+        url: "url" in callback ? callback.url : null,
+        internalKind: "internalKind" in callback ? callback.internalKind : null,
+        encryptedSecret: await encryptPersistentSecretValue(
+          callback.secret,
+          args.featureSwitchContext,
+        ),
+        payload: callback.payload,
+      };
+    }),
+  );
+}
+
 async function insertZeroRunRecord(
   tx: Db,
   args: {
@@ -4164,6 +4254,74 @@ async function insertZeroRunRecord(
   });
 }
 
+async function insertLaunchRunRows(
+  tx: Db,
+  args: {
+    readonly userId: string;
+    readonly orgId: string;
+    readonly identity: LaunchRunIdentity;
+    readonly status: LaunchRunStatus;
+    readonly resolved: ResolvedCompose;
+    readonly body: CreateRunBody;
+    readonly artifacts: readonly ContextArtifact[];
+    readonly additionalVolumes: readonly AdditionalVolume[] | undefined;
+    readonly modelProvider: ResolvedModelProviderEnvironment | null;
+    readonly callbackRows: readonly AgentRunCallbackInsert[];
+    readonly chatThreadId: string | undefined;
+    readonly zeroRunMetadata: ZeroRunMetadata | undefined;
+    readonly runnerGroup: string | undefined;
+    readonly error: string | undefined;
+  },
+): Promise<void> {
+  if (args.identity.shouldCreateSession) {
+    await tx.insert(agentSessions).values({
+      id: args.identity.sessionId,
+      userId: args.userId,
+      orgId: args.orgId,
+      agentComposeId: args.resolved.composeId,
+      artifacts: [...args.artifacts],
+      conversationId: null,
+    });
+  }
+
+  const completedAt = args.status === "failed" ? nowDate() : undefined;
+  const runValues: typeof agentRuns.$inferInsert = {
+    id: args.identity.runId,
+    createdAt: args.identity.createdAt,
+    userId: args.userId,
+    orgId: args.orgId,
+    agentComposeVersionId: args.resolved.agentComposeVersionId,
+    status: args.status,
+    prompt: args.body.prompt,
+    appendSystemPrompt: args.body.appendSystemPrompt ?? null,
+    vars: args.body.vars ?? null,
+    secretNames: args.body.secrets ? Object.keys(args.body.secrets) : null,
+    additionalVolumes: args.additionalVolumes
+      ? [...args.additionalVolumes]
+      : null,
+    resumedFromCheckpointId: args.resolved.resumedFromCheckpointId ?? null,
+    continuedFromSessionId: args.resolved.continuedFromAgentSessionId ?? null,
+    sessionId: args.identity.sessionId,
+    lastHeartbeatAt: args.identity.createdAt,
+    runnerGroup: args.runnerGroup ?? null,
+    completedAt: completedAt ?? null,
+    error: args.error ?? null,
+  };
+  await tx.insert(agentRuns).values(runValues);
+
+  await insertZeroRunRecord(tx, {
+    runId: args.identity.runId,
+    body: args.body,
+    modelProvider: args.modelProvider,
+    chatThreadId: args.chatThreadId,
+    zeroRunMetadata: args.zeroRunMetadata,
+  });
+
+  if (args.callbackRows.length > 0) {
+    await tx.insert(agentRunCallbacks).values([...args.callbackRows]);
+  }
+}
+
 async function insertRunRecord(
   tx: Db,
   args: {
@@ -4180,82 +4338,29 @@ async function insertRunRecord(
     readonly featureSwitchContext: FeatureSwitchContext;
   },
 ): Promise<RunRecord> {
-  const agentSessionId =
-    args.resolved.agentSessionId ??
-    (
-      await tx
-        .insert(agentSessions)
-        .values({
-          userId: args.userId,
-          orgId: args.orgId,
-          agentComposeId: args.resolved.composeId,
-          artifacts: [...args.artifacts],
-          conversationId: null,
-        })
-        .returning({ id: agentSessions.id })
-    )[0]?.id;
-
-  if (!agentSessionId) {
-    throw new Error("Failed to create agent session");
-  }
-
-  const [run] = await tx
-    .insert(agentRuns)
-    .values({
-      userId: args.userId,
-      orgId: args.orgId,
-      agentComposeVersionId: args.resolved.agentComposeVersionId,
-      status: "pending",
-      prompt: args.body.prompt,
-      appendSystemPrompt: args.body.appendSystemPrompt ?? null,
-      vars: args.body.vars ?? null,
-      secretNames: args.body.secrets ? Object.keys(args.body.secrets) : null,
-      additionalVolumes: args.additionalVolumes
-        ? [...args.additionalVolumes]
-        : null,
-      resumedFromCheckpointId: args.resolved.resumedFromCheckpointId ?? null,
-      continuedFromSessionId: args.resolved.continuedFromAgentSessionId ?? null,
-      sessionId: agentSessionId,
-      lastHeartbeatAt: nowDate(),
-    })
-    .returning({
-      id: agentRuns.id,
-      createdAt: agentRuns.createdAt,
-      sessionId: agentRuns.sessionId,
-    });
-
-  if (!run) {
-    throw new Error("Failed to create run record");
-  }
-
-  await insertZeroRunRecord(tx, {
-    runId: run.id,
+  const identity = prepareLaunchRunIdentity({ resolved: args.resolved });
+  const callbackRows = await prepareRunCallbackRows({
+    runId: identity.runId,
+    callbacks: args.callbacks,
+    featureSwitchContext: args.featureSwitchContext,
+  });
+  await insertLaunchRunRows(tx, {
+    userId: args.userId,
+    orgId: args.orgId,
+    identity,
+    status: "pending",
+    resolved: args.resolved,
     body: args.body,
+    artifacts: args.artifacts,
+    additionalVolumes: args.additionalVolumes,
     modelProvider: args.modelProvider,
+    callbackRows,
     chatThreadId: args.chatThreadId,
     zeroRunMetadata: args.zeroRunMetadata,
+    runnerGroup: undefined,
+    error: undefined,
   });
-
-  if (args.callbacks && args.callbacks.length > 0) {
-    const callbackRows = await Promise.all(
-      args.callbacks.map(async (callback) => {
-        return {
-          runId: run.id,
-          url: "url" in callback ? callback.url : null,
-          internalKind:
-            "internalKind" in callback ? callback.internalKind : null,
-          encryptedSecret: await encryptPersistentSecretValue(
-            callback.secret,
-            args.featureSwitchContext,
-          ),
-          payload: callback.payload,
-        };
-      }),
-    );
-    await tx.insert(agentRunCallbacks).values(callbackRows);
-  }
-
-  return { ...run, status: "pending" };
+  return runRecordFromLaunchIdentity(identity, "pending");
 }
 
 async function insertQueuedRunRecord(
@@ -4274,82 +4379,29 @@ async function insertQueuedRunRecord(
     readonly featureSwitchContext: FeatureSwitchContext;
   },
 ): Promise<RunRecord> {
-  const agentSessionId =
-    args.resolved.agentSessionId ??
-    (
-      await tx
-        .insert(agentSessions)
-        .values({
-          userId: args.userId,
-          orgId: args.orgId,
-          agentComposeId: args.resolved.composeId,
-          artifacts: [...args.artifacts],
-          conversationId: null,
-        })
-        .returning({ id: agentSessions.id })
-    )[0]?.id;
-
-  if (!agentSessionId) {
-    throw new Error("Failed to create queued agent session");
-  }
-
-  const [run] = await tx
-    .insert(agentRuns)
-    .values({
-      userId: args.userId,
-      orgId: args.orgId,
-      agentComposeVersionId: args.resolved.agentComposeVersionId,
-      status: "queued",
-      prompt: args.body.prompt,
-      appendSystemPrompt: args.body.appendSystemPrompt ?? null,
-      vars: args.body.vars ?? null,
-      secretNames: args.body.secrets ? Object.keys(args.body.secrets) : null,
-      additionalVolumes: args.additionalVolumes
-        ? [...args.additionalVolumes]
-        : null,
-      resumedFromCheckpointId: args.resolved.resumedFromCheckpointId ?? null,
-      continuedFromSessionId: args.resolved.continuedFromAgentSessionId ?? null,
-      sessionId: agentSessionId,
-      lastHeartbeatAt: nowDate(),
-    })
-    .returning({
-      id: agentRuns.id,
-      createdAt: agentRuns.createdAt,
-      sessionId: agentRuns.sessionId,
-    });
-
-  if (!run) {
-    throw new Error("Failed to create queued run record");
-  }
-
-  await insertZeroRunRecord(tx, {
-    runId: run.id,
+  const identity = prepareLaunchRunIdentity({ resolved: args.resolved });
+  const callbackRows = await prepareRunCallbackRows({
+    runId: identity.runId,
+    callbacks: args.callbacks,
+    featureSwitchContext: args.featureSwitchContext,
+  });
+  await insertLaunchRunRows(tx, {
+    userId: args.userId,
+    orgId: args.orgId,
+    identity,
+    status: "queued",
+    resolved: args.resolved,
     body: args.body,
+    artifacts: args.artifacts,
+    additionalVolumes: args.additionalVolumes,
     modelProvider: args.modelProvider,
+    callbackRows,
     chatThreadId: args.chatThreadId,
     zeroRunMetadata: args.zeroRunMetadata,
+    runnerGroup: undefined,
+    error: undefined,
   });
-
-  if (args.callbacks && args.callbacks.length > 0) {
-    const callbackRows = await Promise.all(
-      args.callbacks.map(async (callback) => {
-        return {
-          runId: run.id,
-          url: "url" in callback ? callback.url : null,
-          internalKind:
-            "internalKind" in callback ? callback.internalKind : null,
-          encryptedSecret: await encryptPersistentSecretValue(
-            callback.secret,
-            args.featureSwitchContext,
-          ),
-          payload: callback.payload,
-        };
-      }),
-    );
-    await tx.insert(agentRunCallbacks).values(callbackRows);
-  }
-
-  return { ...run, status: "queued" };
+  return runRecordFromLaunchIdentity(identity, "queued");
 }
 
 async function buildStoredExecutionContext(args: {
@@ -4779,7 +4831,7 @@ async function markRunFailed(
 function buildRunnerJobPayload(
   db: Db,
   args: {
-    readonly run: RunRecord;
+    readonly run: Pick<RunRecord, "id">;
     readonly userId: string;
     readonly orgId: string;
     readonly resolved: ResolvedCompose;
@@ -5138,6 +5190,261 @@ function enqueueRunForConcurrency(
   });
 }
 
+async function checkRunConcurrencyPreflight(args: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly timing: ApiDispatchTimingCollector;
+}): Promise<CreateRunErrorResult | null> {
+  return await args.db.transaction(async (tx) => {
+    await args.timing.measure(
+      "api_dispatch_concurrency_preflight_lock_wait",
+      "nested",
+      async () => {
+        await tx.execute(
+          sql`SELECT pg_advisory_xact_lock(hashtext(${args.orgId}))`,
+        );
+      },
+    );
+    return await args.timing.measure(
+      "api_dispatch_concurrency_preflight_check",
+      "nested",
+      async () => {
+        return await checkRunConcurrencyLimit(tx, args.orgId);
+      },
+    );
+  });
+}
+
+async function commitFailedLaunch(args: {
+  readonly db: Db;
+  readonly createArgs: CreateAgentRunArgs;
+  readonly context: PreparedRunContext;
+  readonly identity: LaunchRunIdentity;
+  readonly callbackRows: readonly AgentRunCallbackInsert[];
+  readonly error: unknown;
+}): Promise<Extract<CreateRunRouteResult, { readonly status: 201 }>> {
+  const message = runFailureMessage(args.error);
+  await args.db.transaction(async (tx) => {
+    await insertLaunchRunRows(tx, {
+      userId: args.createArgs.userId,
+      orgId: args.createArgs.orgId,
+      identity: args.identity,
+      status: "failed",
+      resolved: args.context.resolved,
+      body: args.context.body,
+      artifacts: args.context.artifacts,
+      additionalVolumes: args.context.additionalVolumes,
+      modelProvider: args.context.modelProvider,
+      callbackRows: args.callbackRows,
+      chatThreadId: args.createArgs.chatThreadId,
+      zeroRunMetadata: args.createArgs.zeroRunMetadata,
+      runnerGroup: undefined,
+      error: message,
+    });
+  });
+
+  await publishRunChangedForUserSafely(
+    args.createArgs.userId,
+    args.identity.runId,
+    {
+      status: "failed",
+    },
+  );
+  if (args.createArgs.dispatchFailedCallbacks) {
+    await tapError(
+      args.createArgs.dispatchFailedCallbacks(
+        args.db,
+        args.identity.runId,
+        message,
+      ),
+      (error) => {
+        L.error("Failed to dispatch failed-run callbacks", {
+          runId: args.identity.runId,
+          error,
+        });
+      },
+    );
+  }
+  return failedRunResponse(
+    runRecordFromLaunchIdentity(args.identity, "pending"),
+    args.error,
+  );
+}
+
+async function insertAtomicLaunchRunRecord(args: {
+  readonly tx: DbTransaction;
+  readonly commit: CommitPreparedLaunchArgs;
+  readonly status: Extract<LaunchRunStatus, "pending" | "queued">;
+  readonly runnerGroup: string;
+}): Promise<RunRecord> {
+  await args.commit.timing.measure(
+    "api_dispatch_insert_run_record",
+    "nested",
+    async () => {
+      await insertLaunchRunRows(args.tx, {
+        userId: args.commit.createArgs.userId,
+        orgId: args.commit.createArgs.orgId,
+        identity: args.commit.identity,
+        status: args.status,
+        resolved: args.commit.context.resolved,
+        body: args.commit.context.body,
+        artifacts: args.commit.context.artifacts,
+        additionalVolumes: args.commit.context.additionalVolumes,
+        modelProvider: args.commit.context.modelProvider,
+        callbackRows: args.commit.callbackRows,
+        chatThreadId: args.commit.createArgs.chatThreadId,
+        zeroRunMetadata: args.commit.createArgs.zeroRunMetadata,
+        runnerGroup: args.runnerGroup,
+        error: undefined,
+      });
+    },
+  );
+  return runRecordFromLaunchIdentity(args.commit.identity, args.status);
+}
+
+async function commitQueuedPreparedLaunch(
+  tx: DbTransaction,
+  args: CommitPreparedLaunchArgs,
+  payload: RunnerJobPayload,
+): Promise<Extract<AtomicLaunchCommitResult, { readonly kind: "queued" }>> {
+  if (!args.encryptedQueuedParams) {
+    throw new Error("Missing encrypted queued runner job payload");
+  }
+
+  const run = await insertAtomicLaunchRunRecord({
+    tx,
+    commit: args,
+    status: "queued",
+    runnerGroup: payload.runnerGroup,
+  });
+  await tx.insert(agentRunQueue).values({
+    runId: args.identity.runId,
+    userId: args.createArgs.userId,
+    orgId: args.createArgs.orgId,
+    encryptedParams: args.encryptedQueuedParams,
+    createdAt: args.identity.createdAt,
+    expiresAt: sql`now() + interval '2 hours'`,
+  });
+  const [depthRow] = await tx
+    .select({ depth: count() })
+    .from(agentRunQueue)
+    .where(eq(agentRunQueue.orgId, args.createArgs.orgId));
+  return {
+    kind: "queued",
+    run,
+    queueDepth: Number(depthRow?.depth ?? 0),
+    telemetryTimestamp: nowDate().toISOString(),
+    runContextSnapshot: args.launch.runContextSnapshot,
+  };
+}
+
+async function commitPendingPreparedLaunch(
+  tx: DbTransaction,
+  args: CommitPreparedLaunchArgs,
+  payload: RunnerJobPayload,
+): Promise<Extract<AtomicLaunchCommitResult, { readonly kind: "pending" }>> {
+  const run = await insertAtomicLaunchRunRecord({
+    tx,
+    commit: args,
+    status: "pending",
+    runnerGroup: payload.runnerGroup,
+  });
+  await args.timing.measure(
+    "api_dispatch_persist_runner_job_queue",
+    "top_level",
+    async () => {
+      await args.timing.measure(
+        "api_dispatch_insert_runner_job_queue",
+        "nested",
+        async () => {
+          await tx.insert(runnerJobQueue).values({
+            runId: args.identity.runId,
+            runnerGroup: payload.runnerGroup,
+            profile: payload.profile,
+            cliAgentSessionId: payload.cliAgentSessionId,
+            executionContext: payload.executionContext,
+            expiresAt: sql`now() + interval '2 hours'`,
+          });
+        },
+      );
+    },
+  );
+  return {
+    kind: "pending",
+    run,
+    runnerJobPayload: payload,
+    runContextSnapshot: args.launch.runContextSnapshot,
+  };
+}
+
+async function commitPreparedLaunch(
+  args: CommitPreparedLaunchArgs,
+): Promise<AtomicLaunchCommitResult | CreateRunErrorResult> {
+  const payload = args.launch.runnerJobPayload;
+  return await args.db.transaction(async (tx) => {
+    await args.timing.measure(
+      "api_dispatch_admission_lock_wait",
+      "nested",
+      async () => {
+        await tx.execute(
+          sql`SELECT pg_advisory_xact_lock(hashtext(${args.createArgs.orgId}))`,
+        );
+      },
+    );
+    const concurrency = await args.timing.measure(
+      "api_dispatch_check_concurrency_limit",
+      "nested",
+      async () => {
+        return await checkRunConcurrencyLimit(tx, args.createArgs.orgId);
+      },
+    );
+
+    if (concurrency) {
+      if (!args.createArgs.queueOnConcurrencyLimit) {
+        return concurrency;
+      }
+      return await commitQueuedPreparedLaunch(tx, args, payload);
+    }
+
+    return await commitPendingPreparedLaunch(tx, args, payload);
+  });
+}
+
+function buildAtomicLaunchPayload(
+  db: Db,
+  args: {
+    readonly createArgs: CreateAgentRunArgs;
+    readonly context: PreparedRunContext;
+    readonly run: Pick<RunRecord, "id">;
+    readonly timing: ApiDispatchTimingCollector;
+  },
+): Computed<Promise<PreparedRunnerLaunch>> {
+  return buildRunnerJobPayload(db, {
+    run: args.run,
+    userId: args.createArgs.userId,
+    orgId: args.createArgs.orgId,
+    resolved: args.context.resolved,
+    body: args.context.body,
+    artifacts: args.context.artifacts,
+    framework: args.context.framework,
+    modelProvider: args.context.modelProvider,
+    connectorContext: args.context.connectorContext,
+    customConnectorContext: args.context.customConnectorContext,
+    permissionManifest: args.context.permissionManifest,
+    billableFirewalls: args.context.billableFirewalls,
+    modelUsageProvider: args.context.modelUsageProvider,
+    apiStartTime: args.createArgs.apiStartTime,
+    additionalVolumes: args.context.additionalVolumes,
+    includeZeroTokenSecret: args.createArgs.includeZeroTokenSecret,
+    zeroTokenComputerUseHostId: args.createArgs.zeroTokenComputerUseHostId,
+    chatThreadId: args.createArgs.chatThreadId,
+    extraEnvironment: args.createArgs.extraEnvironment,
+    userTimezone: args.context.userTimezone,
+    featureSwitchContext: args.context.featureSwitchContext,
+    timing: args.timing,
+  });
+}
+
 function createdRunResponse(
   run: RunRecord,
   dispatchResult: { readonly status: RunStatus; readonly sandboxId?: string },
@@ -5164,7 +5471,7 @@ function failedRunResponse(
       runId: run.id,
       status: "failed",
       sessionId: run.sessionId,
-      error: error instanceof Error ? error.message : "Run failed",
+      error: runFailureMessage(error),
       createdAt: run.createdAt.toISOString(),
     },
   };
@@ -6213,6 +6520,210 @@ async function beforeDispatchResponse(args: {
   return cancelledBeforeDispatchRunResponse(args.run);
 }
 
+function createLegacyBeforeDispatchRun(input: {
+  readonly db: Db;
+  readonly args: CreateAgentRunArgs;
+  readonly context: PreparedRunContext;
+  readonly signal: AbortSignal;
+  readonly timing: ApiDispatchTimingCollector;
+  readonly drainOrgQueue: () => Promise<void>;
+}): Computed<Promise<CreateRunRouteResult>> {
+  return computed(async (get): Promise<CreateRunRouteResult> => {
+    // The chat auto-send pre-dispatch gate is intentionally left on the
+    // legacy split persistence path until #19530 migrates message claims.
+    const transactionResult = await input.timing.measure(
+      "api_dispatch_insert_run_with_concurrency",
+      "top_level",
+      async () => {
+        return await insertRunWithConcurrency(
+          input.db,
+          input.args,
+          input.context,
+          input.timing,
+        );
+      },
+    );
+    input.signal.throwIfAborted();
+
+    if (isRouteError(transactionResult)) {
+      return transactionResult;
+    }
+
+    const beforeDispatch = await beforeDispatchResponse({
+      db: input.db,
+      run: transactionResult,
+      createArgs: input.args,
+      signal: input.signal,
+      drainOrgQueue: input.drainOrgQueue,
+    });
+    if (beforeDispatch) {
+      return beforeDispatch;
+    }
+
+    if (transactionResult.status === "queued") {
+      return await get(
+        completeQueuedRun({
+          db: input.db,
+          args: input.args,
+          context: input.context,
+          run: transactionResult,
+          signal: input.signal,
+        }),
+      );
+    }
+
+    return await get(
+      completePendingRun({
+        db: input.db,
+        args: input.args,
+        context: input.context,
+        run: transactionResult,
+        drainOrgQueue: input.drainOrgQueue,
+        signal: input.signal,
+        timing: input.timing,
+      }),
+    );
+  });
+}
+
+async function committedAtomicLaunchResponse(args: {
+  readonly db: Db;
+  readonly createArgs: CreateAgentRunArgs;
+  readonly committed: AtomicLaunchCommitResult;
+  readonly timing: ApiDispatchTimingCollector;
+}): Promise<Extract<CreateRunRouteResult, { readonly status: 201 }>> {
+  if (args.committed.kind === "queued") {
+    recordQueuedRunEnqueueTelemetry({
+      runId: args.committed.run.id,
+      queueDepth: args.committed.queueDepth,
+      timestamp: args.committed.telemetryTimestamp,
+    });
+    ingestRunContextSnapshot(args.committed.runContextSnapshot);
+    await publishQueueChangedSafely({
+      orgId: args.createArgs.orgId,
+      runId: args.committed.run.id,
+    });
+    return createdRunResponse(args.committed.run, { status: "queued" });
+  }
+
+  ingestRunContextSnapshot(args.committed.runContextSnapshot);
+  await notifyRunnerJob(args.db, {
+    runnerGroup: args.committed.runnerJobPayload.runnerGroup,
+    runId: args.committed.run.id,
+    profile: args.committed.runnerJobPayload.profile,
+    cliAgentSessionId: args.committed.runnerJobPayload.cliAgentSessionId,
+  });
+  args.timing.flush({
+    runId: args.committed.run.id,
+    runnerGroup: args.committed.runnerJobPayload.runnerGroup,
+    profile: args.committed.runnerJobPayload.profile,
+    dispatchPath: "direct",
+    ...(args.createArgs.timingDimensions
+      ? { dimensions: args.createArgs.timingDimensions }
+      : {}),
+    ...(args.createArgs.body.triggerSource
+      ? { triggerSource: args.createArgs.body.triggerSource }
+      : {}),
+  });
+  return createdRunResponse(args.committed.run, { status: "pending" });
+}
+
+function createAtomicLaunchRun(input: {
+  readonly db: Db;
+  readonly args: CreateAgentRunArgs;
+  readonly context: PreparedRunContext;
+  readonly signal: AbortSignal;
+  readonly timing: ApiDispatchTimingCollector;
+}): Computed<Promise<CreateRunRouteResult>> {
+  return computed(async (get): Promise<CreateRunRouteResult> => {
+    const identity = prepareLaunchRunIdentity({
+      resolved: input.context.resolved,
+    });
+    if (!input.args.queueOnConcurrencyLimit) {
+      const preflightConcurrency = await checkRunConcurrencyPreflight({
+        db: input.db,
+        orgId: input.args.orgId,
+        timing: input.timing,
+      });
+      input.signal.throwIfAborted();
+      if (preflightConcurrency) {
+        return preflightConcurrency;
+      }
+    }
+
+    const callbackRows = await prepareRunCallbackRows({
+      runId: identity.runId,
+      callbacks: input.args.callbacks,
+      featureSwitchContext: input.context.featureSwitchContext,
+    });
+    input.signal.throwIfAborted();
+
+    const launchResult = await settle(
+      input.timing.measure(
+        "api_dispatch_build_runner_job_payload",
+        "top_level",
+        async () => {
+          return await get(
+            buildAtomicLaunchPayload(input.db, {
+              createArgs: input.args,
+              context: input.context,
+              run: { id: identity.runId },
+              timing: input.timing,
+            }),
+          );
+        },
+      ),
+    );
+    input.signal.throwIfAborted();
+    if (!launchResult.ok) {
+      return await commitFailedLaunch({
+        db: input.db,
+        createArgs: input.args,
+        context: input.context,
+        identity,
+        callbackRows,
+        error: launchResult.error,
+      });
+    }
+
+    const encryptedQueuedParams = input.args.queueOnConcurrencyLimit
+      ? await encryptQueuedRunnerJobPayload(
+          launchResult.value.runnerJobPayload,
+          input.context.featureSwitchContext,
+        )
+      : undefined;
+    input.signal.throwIfAborted();
+
+    const committed = await input.timing.measure(
+      "api_dispatch_insert_run_with_concurrency",
+      "top_level",
+      async () => {
+        return await commitPreparedLaunch({
+          db: input.db,
+          createArgs: input.args,
+          context: input.context,
+          identity,
+          callbackRows,
+          launch: launchResult.value,
+          encryptedQueuedParams,
+          timing: input.timing,
+        });
+      },
+    );
+    input.signal.throwIfAborted();
+
+    if (isRouteError(committed)) {
+      return committed;
+    }
+    return await committedAtomicLaunchResponse({
+      db: input.db,
+      createArgs: input.args,
+      committed,
+      timing: input.timing,
+    });
+  });
+}
+
 export const createAgentRun$ = command(
   async (
     { get, set },
@@ -6275,53 +6786,26 @@ export const createAgentRun$ = command(
       }
     }
 
-    const transactionResult = await timing.measure(
-      "api_dispatch_insert_run_with_concurrency",
-      "top_level",
-      async () => {
-        return await insertRunWithConcurrency(db, args, context, timing);
-      },
-    );
-    signal.throwIfAborted();
-
-    if (isRouteError(transactionResult)) {
-      return transactionResult;
-    }
-
-    const beforeDispatch = await beforeDispatchResponse({
-      db,
-      run: transactionResult,
-      createArgs: args,
-      signal,
-      drainOrgQueue: async () => {
-        await set(drainOrgQueue$, { orgId: args.orgId }, signal);
-      },
-    });
-    if (beforeDispatch) {
-      return beforeDispatch;
-    }
-
-    if (transactionResult.status === "queued") {
+    if (args.beforeDispatch) {
       return await get(
-        completeQueuedRun({
+        createLegacyBeforeDispatchRun({
           db,
           args,
           context,
-          run: transactionResult,
           signal,
+          timing,
+          drainOrgQueue: async () => {
+            await set(drainOrgQueue$, { orgId: args.orgId }, signal);
+          },
         }),
       );
     }
 
     return await get(
-      completePendingRun({
+      createAtomicLaunchRun({
         db,
         args,
         context,
-        run: transactionResult,
-        drainOrgQueue: async () => {
-          await set(drainOrgQueue$, { orgId: args.orgId }, signal);
-        },
         signal,
         timing,
       }),

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -108,7 +108,7 @@ import { userCache } from "@vm0/db/schema/user-cache";
 import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
 import { variables } from "@vm0/db/schema/variable";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
-import { and, count, eq, gt, inArray, or, sql } from "drizzle-orm";
+import { and, count, eq, inArray, or, sql } from "drizzle-orm";
 import type { z } from "zod";
 
 import { env, optionalEnv } from "../../lib/env";
@@ -145,6 +145,7 @@ import {
   renderCustomConnectorRuntimePrefix,
   renderTemplateForRuntime,
 } from "./zero-custom-connector.service";
+import { activePendingRunPredicate } from "./agent-run-activity.service";
 import { prepareAgentRunStorageManifest } from "./agent-run-storage.service";
 import {
   encryptQueuedRunnerJobPayload,
@@ -3647,7 +3648,7 @@ async function checkRunConcurrencyLimit(
           eq(agentRuns.status, "running"),
           and(
             eq(agentRuns.status, "pending"),
-            gt(agentRuns.createdAt, staleThreshold),
+            activePendingRunPredicate(staleThreshold),
           ),
         ),
       ),

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -6686,13 +6686,27 @@ function createAtomicLaunchRun(input: {
       });
     }
 
-    const encryptedQueuedParams = input.args.queueOnConcurrencyLimit
-      ? await encryptQueuedRunnerJobPayload(
+    let encryptedQueuedParams: string | undefined;
+    if (input.args.queueOnConcurrencyLimit) {
+      const encryptedQueuedParamsResult = await settle(
+        encryptQueuedRunnerJobPayload(
           launchResult.value.runnerJobPayload,
           input.context.featureSwitchContext,
-        )
-      : undefined;
-    input.signal.throwIfAborted();
+        ),
+      );
+      input.signal.throwIfAborted();
+      if (!encryptedQueuedParamsResult.ok) {
+        return await commitFailedLaunch({
+          db: input.db,
+          createArgs: input.args,
+          context: input.context,
+          identity,
+          callbackRows,
+          error: encryptedQueuedParamsResult.error,
+        });
+      }
+      encryptedQueuedParams = encryptedQueuedParamsResult.value;
+    }
 
     const committed = await input.timing.measure(
       "api_dispatch_insert_run_with_concurrency",

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -728,6 +728,17 @@ function isRouteError(value: unknown): value is CreateRunErrorResult {
   );
 }
 
+function isReturnableRouteError(
+  value: AtomicLaunchCommitResult | CreateRunErrorResult,
+  signal: AbortSignal,
+): value is CreateRunErrorResult {
+  if (!isRouteError(value)) {
+    return false;
+  }
+  signal.throwIfAborted();
+  return true;
+}
+
 function firstAgent(content: AgentComposeContent): AgentConfig | undefined {
   if (content.agent) {
     return content.agent;
@@ -6716,12 +6727,12 @@ function createAtomicLaunchRun(input: {
     };
 
     let committed = await commitLaunch(undefined);
-    input.signal.throwIfAborted();
-    if (isRouteError(committed)) {
+    if (isReturnableRouteError(committed, input.signal)) {
       return committed;
     }
 
     if (committed.kind === "queue-payload-required") {
+      input.signal.throwIfAborted();
       const encryptedQueuedParamsResult = await settle(
         encryptQueuedRunnerJobPayload(
           launchResult.value.runnerJobPayload,
@@ -6731,8 +6742,7 @@ function createAtomicLaunchRun(input: {
       input.signal.throwIfAborted();
       if (!encryptedQueuedParamsResult.ok) {
         const retryWithoutQueuedPayload = await commitLaunch(undefined);
-        input.signal.throwIfAborted();
-        if (isRouteError(retryWithoutQueuedPayload)) {
+        if (isReturnableRouteError(retryWithoutQueuedPayload, input.signal)) {
           return retryWithoutQueuedPayload;
         }
         if (retryWithoutQueuedPayload.kind !== "queue-payload-required") {
@@ -6743,6 +6753,7 @@ function createAtomicLaunchRun(input: {
             timing: input.timing,
           });
         }
+        input.signal.throwIfAborted();
         return await commitFailedLaunch({
           db: input.db,
           createArgs: input.args,
@@ -6754,11 +6765,11 @@ function createAtomicLaunchRun(input: {
       }
 
       committed = await commitLaunch(encryptedQueuedParamsResult.value);
-      input.signal.throwIfAborted();
-      if (isRouteError(committed)) {
+      if (isReturnableRouteError(committed, input.signal)) {
         return committed;
       }
       if (committed.kind === "queue-payload-required") {
+        input.signal.throwIfAborted();
         throw new Error("Queued launch still required encrypted payload");
       }
     }

--- a/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
+++ b/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
@@ -81,6 +81,8 @@ export type ApiDispatchTimingActionType =
   | "api_dispatch_update_run_runner_group"
   | "api_dispatch_admission_lock_wait"
   | "api_dispatch_check_concurrency_limit"
+  | "api_dispatch_concurrency_preflight_lock_wait"
+  | "api_dispatch_concurrency_preflight_check"
   | "api_dispatch_insert_run_record"
   | "api_dispatch_prepare_storage_manifest"
   | "api_dispatch_prepare_storage_manifest_resolve_inputs"

--- a/turbo/apps/api/src/signals/services/zero-run-cancel.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-cancel.service.ts
@@ -160,8 +160,8 @@ export const cancelRun$ = command(
  *    run-creation migration.
  *  - `triggerAutoRecharge` (Stripe top-up) — sibling follow-up.
  *
- * Fire-and-forget caller: invoke from the route handler via
- * `waitUntil(tapError(set(dispatchCancelSideEffects$, result, signal), log))`.
+ * Fire-and-forget caller: invoke from the route handler via `waitUntil(...)`
+ * with a detached background signal after `cancelRun$` commits.
  */
 export const dispatchCancelSideEffects$ = command(
   async (

--- a/turbo/apps/api/src/signals/services/zero-run-cancel.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-cancel.service.ts
@@ -174,14 +174,38 @@ export const dispatchCancelSideEffects$ = command(
     }
     const db = set(writeDb$);
     if (result.previousStatus === "running" && result.runnerGroup) {
-      await publishCancelToRunnerGroup(result.runnerGroup, result.runId);
+      await tapError(
+        publishCancelToRunnerGroup(result.runnerGroup, result.runId),
+        (error) => {
+          L.error("Failed to publish cancel to runner group", {
+            runId: result.runId,
+            runnerGroup: result.runnerGroup,
+            error,
+          });
+        },
+      );
       signal.throwIfAborted();
     }
-    await publishOrgSignal(result.orgId, "queue:changed");
-    signal.throwIfAborted();
-    await publishUserSignal([result.userId], `runChanged:${result.runId}`, {
-      status: "cancelled",
+    await tapError(publishOrgSignal(result.orgId, "queue:changed"), (error) => {
+      L.error("Failed to publish queue changed after run cancellation", {
+        runId: result.runId,
+        orgId: result.orgId,
+        error,
+      });
     });
+    signal.throwIfAborted();
+    await tapError(
+      publishUserSignal([result.userId], `runChanged:${result.runId}`, {
+        status: "cancelled",
+      }),
+      (error) => {
+        L.error("Failed to publish cancelled run changed signal", {
+          runId: result.runId,
+          userId: result.userId,
+          error,
+        });
+      },
+    );
     signal.throwIfAborted();
 
     await tapError(

--- a/turbo/apps/api/src/signals/services/zero-run-cancel.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-cancel.service.ts
@@ -147,7 +147,7 @@ export const cancelRun$ = command(
  * Post-cancel side effects:
  *  - Notify the runner group to halt the cancelled run (if it was
  *    running on a runner).
- *  - Publish org-level `queue:changed` and user-level `runChanged`.
+ *  - Publish org-level `queue:changed` and user-level `run:changed`.
  *  - Drain the org queue: promote one queued run to pending. The
  *    runner picks up pending runs on its existing poll loop.
  *  - Reconcile credits via `processOrgUsageEvents$` when the cancelled
@@ -195,7 +195,7 @@ export const dispatchCancelSideEffects$ = command(
     });
     signal.throwIfAborted();
     await tapError(
-      publishUserSignal([result.userId], `runChanged:${result.runId}`, {
+      publishUserSignal([result.userId], `run:changed:${result.runId}`, {
         status: "cancelled",
       }),
       (error) => {

--- a/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
@@ -28,6 +28,7 @@ import {
   cappedBaseConcurrencyLimit,
   totalConcurrencyLimit,
 } from "./org-concurrency-entitlements.service";
+import { tapError } from "../utils";
 
 const L = logger("ZeroRunQueue");
 
@@ -380,7 +381,12 @@ async function loadQueuedRunnerJobPayload(
 async function publishRemovedStaleQueueSideEffects(
   orgId: string,
 ): Promise<void> {
-  await publishOrgSignal(orgId, "queue:changed");
+  await tapError(publishOrgSignal(orgId, "queue:changed"), (error) => {
+    L.error("Failed to publish queue changed after stale queue removal", {
+      orgId,
+      error,
+    });
+  });
 }
 
 async function publishPromotedQueueSideEffects(
@@ -391,18 +397,46 @@ async function publishPromotedQueueSideEffects(
     readonly runnerNotification: RunnerNotification | null;
   },
 ): Promise<void> {
-  await publishOrgSignal(args.orgId, "queue:changed");
+  await tapError(publishOrgSignal(args.orgId, "queue:changed"), (error) => {
+    L.error("Failed to publish queue changed after queued run promotion", {
+      orgId: args.orgId,
+      error,
+    });
+  });
 
   if (args.queueMarkerNotification) {
-    await publishUserSignal(
-      [args.queueMarkerNotification.userId],
-      `chatThreadMessageCreated:${args.queueMarkerNotification.chatThreadId}`,
+    await tapError(
+      publishUserSignal(
+        [args.queueMarkerNotification.userId],
+        `chatThreadMessageCreated:${args.queueMarkerNotification.chatThreadId}`,
+      ),
+      (error) => {
+        L.error("Failed to publish queued marker notification", {
+          userId: args.queueMarkerNotification?.userId,
+          chatThreadId: args.queueMarkerNotification?.chatThreadId,
+          error,
+        });
+      },
     );
-    await publishThreadListChanged(args.queueMarkerNotification.userId);
+    await tapError(
+      publishThreadListChanged(args.queueMarkerNotification.userId),
+      (error) => {
+        L.error("Failed to publish thread list changed after queue promotion", {
+          userId: args.queueMarkerNotification?.userId,
+          error,
+        });
+      },
+    );
   }
 
   if (args.runnerNotification) {
-    await notifyRunnerJob(db, args.runnerNotification);
+    await tapError(notifyRunnerJob(db, args.runnerNotification), (error) => {
+      L.error("Failed to notify runner after queued run promotion", {
+        runId: args.runnerNotification?.runId,
+        runnerGroup: args.runnerNotification?.runnerGroup,
+        error,
+      });
+    });
   }
 }
 

--- a/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
@@ -4,18 +4,7 @@ import { agentRunQueue } from "@vm0/db/schema/agent-run-queue";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
-import {
-  and,
-  count,
-  eq,
-  gt,
-  inArray,
-  isNull,
-  lt,
-  ne,
-  or,
-  sql,
-} from "drizzle-orm";
+import { and, count, eq, inArray, isNull, lt, ne, or, sql } from "drizzle-orm";
 
 import { writeDb$, type Db } from "../external/db";
 import { now, nowDate } from "../external/time";
@@ -25,6 +14,7 @@ import {
   publishUserSignal,
 } from "../external/realtime";
 import { logger } from "../../lib/log";
+import { activePendingRunPredicate } from "./agent-run-activity.service";
 import { decryptQueuedRunnerJobPayload } from "./agent-run-queue-payload.service";
 import { loadUserFeatureSwitchContext } from "./feature-switches.service";
 import { notifyRunnerJob } from "./runner-dispatch.service";
@@ -156,7 +146,7 @@ async function activeConcurrencyCount(
           eq(agentRuns.status, "running"),
           and(
             eq(agentRuns.status, "pending"),
-            gt(agentRuns.createdAt, staleThreshold),
+            activePendingRunPredicate(staleThreshold),
           ),
         ),
       ),
@@ -700,7 +690,7 @@ export const drainStaleQueues$ = command(
               eq(agentRuns.status, "running"),
               and(
                 eq(agentRuns.status, "pending"),
-                gt(agentRuns.createdAt, staleThreshold),
+                activePendingRunPredicate(staleThreshold),
               ),
             ),
           ),

--- a/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
@@ -377,6 +377,66 @@ async function loadQueuedRunnerJobPayload(
   return payload;
 }
 
+async function publishRemovedStaleQueueSideEffects(
+  orgId: string,
+): Promise<void> {
+  await publishOrgSignal(orgId, "queue:changed");
+}
+
+async function publishPromotedQueueSideEffects(
+  db: Db,
+  args: {
+    readonly orgId: string;
+    readonly queueMarkerNotification: QueueMarkerRevokeNotification | null;
+    readonly runnerNotification: RunnerNotification | null;
+  },
+): Promise<void> {
+  await publishOrgSignal(args.orgId, "queue:changed");
+
+  if (args.queueMarkerNotification) {
+    await publishUserSignal(
+      [args.queueMarkerNotification.userId],
+      `chatThreadMessageCreated:${args.queueMarkerNotification.chatThreadId}`,
+    );
+    await publishThreadListChanged(args.queueMarkerNotification.userId);
+  }
+
+  if (args.runnerNotification) {
+    await notifyRunnerJob(db, args.runnerNotification);
+  }
+}
+
+async function promoteQueuedCandidateWithSideEffects(
+  db: Db,
+  args: {
+    readonly orgId: string;
+    readonly row: QueueCandidate;
+    readonly payload: QueuedRunnerJobPayload | null;
+  },
+): Promise<"drained" | "full" | "skipped"> {
+  const result = await promoteQueuedCandidate(db, args);
+  if (result.status === "removed-stale") {
+    await publishRemovedStaleQueueSideEffects(args.orgId);
+    return "skipped";
+  }
+  if (result.status === "full") {
+    return "full";
+  }
+  if (result.status === "lost") {
+    L.debug("drainOrgQueue: queued run already transitioned, skipping", {
+      runId: args.row.runId,
+    });
+    return "skipped";
+  }
+
+  await publishPromotedQueueSideEffects(db, {
+    orgId: args.orgId,
+    queueMarkerNotification: result.queueMarkerNotification,
+    runnerNotification: result.runnerNotification,
+  });
+  return "drained";
+}
+
 /**
  * Drain the org's queued runs after a concurrency slot frees up.
  *
@@ -418,45 +478,18 @@ export const drainOrgQueue$ = command(
             )
           : null;
 
-      const result = await promoteQueuedCandidate(writeDb, {
+      const result = await promoteQueuedCandidateWithSideEffects(writeDb, {
         orgId: args.orgId,
         row,
         payload,
       });
       signal.throwIfAborted();
-      if (result.status === "removed-stale") {
-        await publishOrgSignal(args.orgId, "queue:changed");
-        signal.throwIfAborted();
-        continue;
-      }
-      if (result.status === "full") {
+      if (result === "full") {
         return 0;
       }
-      if (result.status === "lost") {
-        L.debug("drainOrgQueue: queued run already transitioned, skipping", {
-          runId: row.runId,
-        });
+      if (result === "skipped") {
         continue;
       }
-
-      await publishOrgSignal(args.orgId, "queue:changed");
-      signal.throwIfAborted();
-
-      if (result.queueMarkerNotification) {
-        await publishUserSignal(
-          [result.queueMarkerNotification.userId],
-          `chatThreadMessageCreated:${result.queueMarkerNotification.chatThreadId}`,
-        );
-        signal.throwIfAborted();
-        await publishThreadListChanged(result.queueMarkerNotification.userId);
-        signal.throwIfAborted();
-      }
-
-      if (result.runnerNotification) {
-        await notifyRunnerJob(writeDb, result.runnerNotification);
-        signal.throwIfAborted();
-      }
-
       return 1;
     }
 

--- a/turbo/apps/api/src/signals/services/zero-runs.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs.service.ts
@@ -31,7 +31,6 @@ import {
   count,
   desc,
   eq,
-  gt,
   gte,
   inArray,
   isNotNull,
@@ -42,6 +41,7 @@ import {
 
 import { now } from "../../lib/time";
 import { db$, type Db } from "../external/db";
+import { activePendingRunPredicate } from "./agent-run-activity.service";
 import {
   activePaidConcurrencySlots,
   cappedBaseConcurrencyLimit,
@@ -112,7 +112,7 @@ async function activeRunCount(db: ReadDb, orgId: string): Promise<number> {
           eq(agentRuns.status, "running"),
           and(
             eq(agentRuns.status, "pending"),
-            gt(agentRuns.createdAt, staleThreshold),
+            activePendingRunPredicate(staleThreshold),
           ),
         ),
       ),

--- a/turbo/packages/db/src/schema/agent-run-queue.ts
+++ b/turbo/packages/db/src/schema/agent-run-queue.ts
@@ -4,8 +4,9 @@ import { agentRuns } from "./agent-run";
 /**
  * Agent Run Queue table
  * Temporary storage for runs waiting on concurrency slots.
- * Stores encrypted CreateRunParams (including secrets).
- * Records are deleted after dequeue — secrets never persist long-term.
+ * API-created rows store an encrypted prepared runner job payload.
+ * Legacy/test rows may omit the payload and use SQL-only promotion.
+ * Records are deleted after dequeue.
  * Follows the same pattern as runner_job_queue.
  */
 export const agentRunQueue = pgTable(
@@ -27,7 +28,7 @@ export const agentRunQueue = pgTable(
     // Denormalized for efficient per-org queue queries (partition key for dequeue)
     orgId: text("org_id").notNull(),
 
-    // Persistent-secret encrypted CreateRunParams JSON
+    // Persistent-secret encrypted prepared runner job payload.
     encryptedParams: text("encrypted_params"),
 
     // Lifecycle management


### PR DESCRIPTION
## Summary
- generate create-run launch identity before runner payload construction so non-chat launches can commit durable rows atomically
- commit pending runs with runner_job_queue, or queued runs with agent_run_queue, in one final advisory-locked transaction
- preserve the legacy beforeDispatch chat path for #19530 and add regression coverage for promoted queued claims and direct 429 priority

Closes #19623

## Tests
- cd turbo && pnpm -F api check-types
- cd turbo && pnpm -F api lint
- cd turbo && pnpm -F api exec vitest src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --run
- cd turbo && pnpm -F api exec vitest src/signals/routes/__tests__/cron-cleanup-sandboxes.test.ts --run
- pre-commit hook: pnpm format, pnpm knip --cache, pnpm check-types