### PR TITLE
feat: add workflow trigger run now toast

### DIFF
--- a/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
+++ b/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
@@ -1022,7 +1022,11 @@ export const pauseWorkflowTriggers$ = command(
 );
 
 export const runWorkflowTriggerNow$ = command(
-  async ({ get, set }, triggerId: string, signal: AbortSignal) => {
+  async (
+    { get },
+    triggerId: string,
+    signal: AbortSignal,
+  ): Promise<{ chatThreadId: string; runId: string }> => {
     const client = get(zeroClient$)(zeroWorkflowTriggersContract);
     const result = await accept(
       client.run({
@@ -1032,9 +1036,7 @@ export const runWorkflowTriggerNow$ = command(
       [201],
     );
     signal.throwIfAborted();
-    set(detachedNavigateTo$, ROUTES.chat, {
-      pathParams: { threadId: result.body.chatThreadId },
-    });
+    return result.body;
   },
 );
 

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -13,7 +13,8 @@ import {
 import { zeroAgentsByIdContract } from "@vm0/api-contracts/contracts/zero-agents";
 import type { TeamComposeItem } from "@vm0/api-contracts/contracts/zero-team";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { describe, expect, it } from "vitest";
+import { toast } from "@vm0/ui/components/ui/sonner";
+import { afterEach, describe, expect, it } from "vitest";
 
 import {
   click,
@@ -48,6 +49,10 @@ const WORKFLOW_CHAT_THREAD_ID = "00000000-0000-4000-a000-000000000300";
 const TRIGGER_RUN_THREAD_ID = "00000000-0000-4000-a000-000000000301";
 
 type WorkflowDetailTestTab = "automations" | "instructions" | "info";
+
+afterEach(() => {
+  toast.dismiss();
+});
 
 function workflowDetailPath(tab: WorkflowDetailTestTab): string {
   return `/workflows/${SALES_WORKFLOW_ID}/${tab}`;
@@ -138,6 +143,23 @@ function weekdayWorkflowTrigger(): WorkflowScheduleTriggerSummary {
     chatThreadId: "thread_weekday_brief",
     nextRunAt: "2026-06-19T01:00:00.000Z",
     lastRunAt: "2026-06-18T01:00:00.000Z",
+  };
+}
+
+function intervalWorkflowTrigger(): WorkflowScheduleTriggerSummary {
+  return {
+    id: "workflow-trigger-interval-brief",
+    kind: "schedule",
+    schedule: {
+      type: "loop",
+      intervalSeconds: 15 * 60,
+    },
+    scheduleSummary: "Every 15 minutes",
+    ownerUserId: CURRENT_USER_ID,
+    enabled: true,
+    chatThreadId: "thread_interval_brief",
+    nextRunAt: "2026-06-19T01:15:00.000Z",
+    lastRunAt: "2026-06-19T01:00:00.000Z",
   };
 }
 
@@ -994,6 +1016,49 @@ describe("workflows routes", () => {
       expect(pathname()).toBe(`/agents/${AGENT_ID}/chat`);
     });
     await expectComposerText(CREATE_WORKFLOW_WITH_CHAT_PROMPT);
+  });
+
+  it("runs a fixed interval trigger from the workflows page and links to the chat in a toast", async () => {
+    const runTriggerIds: string[] = [];
+    context.mocks.data.userPreferences({ timezone: "UTC" });
+    mockAgentPageApis();
+    mockChatLifecycle(context, { threadId: TRIGGER_RUN_THREAD_ID });
+    mockWorkflowApis([
+      { ...salesResearch(), triggers: [intervalWorkflowTrigger()] },
+    ]);
+    mockRunWorkflowTrigger((triggerId) => {
+      runTriggerIds.push(triggerId);
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/workflows",
+      featureSwitches: { [FeatureSwitchKey.WorkflowAutomation]: true },
+    });
+
+    await waitFor(() => {
+      expect(linkByAriaLabel("Open Sales Research")).toBeInTheDocument();
+    });
+    const salesCard = articleByText("Sales Research");
+    expect(within(salesCard).getByText("Every 15 minutes")).toBeInTheDocument();
+
+    click(buttonByText("Run now", salesCard));
+
+    await waitFor(() => {
+      expect(runTriggerIds).toStrictEqual(["workflow-trigger-interval-brief"]);
+    });
+    expect(pathname()).toBe("/workflows");
+    expect(search()).toBe("");
+    await expect(
+      screen.findByText("Workflow started"),
+    ).resolves.toBeInTheDocument();
+
+    click(buttonByText("View in chat"));
+
+    await waitFor(() => {
+      expect(pathname()).toBe(`/chats/${TRIGGER_RUN_THREAD_ID}`);
+    });
+    expect(search()).toBe("");
   });
 
   it("redirects the legacy agent workflows tab when workflow automation is enabled", async () => {

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -4327,6 +4327,7 @@ function TriggerControls({
   readonly displayTimezone: string;
 }) {
   const pageSignal = useGet(pageSignal$);
+  const navigate = useSet(detachedNavigateTo$);
   const setEditingTriggerId = useSet(setEditingWorkflowTriggerId$);
   const setEditingScheduleCronFields = useSet(setEditingScheduleCronFields$);
   const [enabledLoadable, setEnabled] = useLoadableSet(
@@ -4374,7 +4375,12 @@ function TriggerControls({
           className="zero-btn-morandi h-8 gap-1.5 rounded-lg px-3 text-xs font-medium"
           onClick={() => {
             detach(
-              runNow(trigger.id, pageSignal),
+              (async () => {
+                const result = await runNow(trigger.id, pageSignal);
+                navigate(ROUTES.chat, {
+                  pathParams: { threadId: result.chatThreadId },
+                });
+              })(),
               Reason.DomCallback,
               "run workflow trigger now",
             );

--- a/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
@@ -5,20 +5,27 @@ import {
   useLastResolved,
   useSet,
 } from "ccstate-react";
+import { useLoadableSet } from "ccstate-react/experimental";
 import type { ZeroWorkflowSummary } from "@vm0/api-contracts/contracts/zero-workflows";
+import { IconLoader2, IconPlayerPlay } from "@tabler/icons-react";
 import { Button, Tabs, TabsList, TabsTrigger, cn } from "@vm0/ui";
+import { toast } from "@vm0/ui/components/ui/sonner";
 
 import { openCreateWorkflowDialog$ } from "../../signals/automation-page/workflow-trigger-automation-dialog.ts";
+import { pageSignal$ } from "../../signals/page-signal.ts";
+import { detachedNavigateTo$ } from "../../signals/route.ts";
 import { ROUTES } from "../../signals/route-paths.ts";
 import {
   allVisibleWorkflows$,
   allWorkflowTriggerEntries$,
+  runWorkflowTriggerNow$,
   setWorkflowIndexFilterTab$,
   workflowIndexFilterTab$,
   type WorkflowIndexFilterTab,
   type WorkflowTriggerAutomationEntry,
 } from "../../signals/workflows-page/workflows-signals.ts";
 import { userPreferences$ } from "../../signals/zero-page/settings/user-preferences.ts";
+import { detach, Reason } from "../../signals/utils.ts";
 import { Link } from "../router/link.tsx";
 import {
   CreateWorkflowAutomationDialog,
@@ -305,6 +312,67 @@ function WorkflowIndexCard({
   );
 }
 
+function isFixedIntervalWorkflowTrigger(
+  entry: WorkflowTriggerAutomationEntry,
+): boolean {
+  return (
+    entry.trigger.kind === "schedule" && entry.trigger.schedule.type === "loop"
+  );
+}
+
+function WorkflowIndexRunNowButton({
+  entry,
+}: {
+  readonly entry: WorkflowTriggerAutomationEntry;
+}) {
+  const pageSignal = useGet(pageSignal$);
+  const navigate = useSet(detachedNavigateTo$);
+  const [runNowLoadable, runNow] = useLoadableSet(runWorkflowTriggerNow$);
+  const running = runNowLoadable.state === "loading";
+  const title = workflowTitle(entry.workflow);
+
+  if (!entry.workflow.canManage || !isFixedIntervalWorkflowTrigger(entry)) {
+    return null;
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      aria-label={`Run ${title} now`}
+      className="zero-btn-morandi h-8 shrink-0 gap-1.5 rounded-lg px-3 text-xs font-medium"
+      disabled={running}
+      onClick={() => {
+        detach(
+          (async () => {
+            const result = await runNow(entry.trigger.id, pageSignal);
+            toast.success("Workflow started", {
+              action: {
+                label: "View in chat",
+                onClick: () => {
+                  navigate(ROUTES.chat, {
+                    pathParams: { threadId: result.chatThreadId },
+                  });
+                },
+              },
+            });
+          })(),
+          Reason.DomCallback,
+          "run workflow trigger from workflows page",
+        );
+      }}
+    >
+      {running ? (
+        <IconLoader2 size={13} className="animate-spin" />
+      ) : (
+        <IconPlayerPlay size={13} stroke={1.5} />
+      )}
+      <span>{running ? "Starting..." : "Run now"}</span>
+    </Button>
+  );
+}
+
 function WorkflowCardTriggerFooter({
   entries,
   displayTimezone,
@@ -342,7 +410,8 @@ function WorkflowCardTriggerFooter({
             </span>
           ) : null}
         </div>
-        <div className="pointer-events-auto relative z-20 shrink-0">
+        <div className="pointer-events-auto relative z-20 flex shrink-0 items-center gap-2">
+          <WorkflowIndexRunNowButton entry={primaryEntry} />
           <WorkflowTriggerEnabledSwitch entry={primaryEntry} />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add a Run now button to fixed interval workflow triggers on /workflows
- show a success toast with a View in chat action instead of navigating immediately from the workflow index
- keep workflow detail Run now navigation behavior unchanged

## Tests
- pnpm test apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- git diff --check
