### PR TITLE
fix: remove workflow follow-up suggestions

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -2,7 +2,6 @@ import { createHash } from "node:crypto";
 
 import { WebPushError } from "web-push";
 import { PRESENTATION_TEMPLATE_ITEMS } from "@vm0/core";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import type {
   AttachFile,
   GenerationTemplateRequest,
@@ -25,7 +24,6 @@ import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
 import { createMiscRoutesApi } from "./helpers/api-bdd-misc";
 import { createRunsAutomationsApi } from "./helpers/api-bdd-runs-automations";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
-import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 import { testChatMessagesStateRoutes } from "../test-chat-messages-state";
 
 /**
@@ -808,102 +806,6 @@ describe("CHAT-02: completed chat callback", () => {
     await api.requestCancelRun(actor, claimed.runId, [200]);
     await waitForRunStatus(actor, claimed.runId, "cancelled");
   }, 90_000);
-
-  it("replaces a follow-up with a workflow automation discussion behind the workflow trigger switch", async () => {
-    const { actor, agentId, runnerGroup } = await entitledChatActor();
-    chatCallbacks.failIfChatCallbackRouteIsFetched();
-    if (!actor.orgId) {
-      throw new Error("Expected an org-scoped actor");
-    }
-    await updateFeatureSwitchesForUser(
-      context,
-      { userId: actor.userId, orgId: actor.orgId, orgRole: actor.orgRole },
-      {
-        [FeatureSwitchKey.WorkflowAutomation]: true,
-      },
-    );
-
-    const originalFollowups = [
-      { prompt: "Review the support summary", kind: "talk" },
-      { prompt: "Draft a customer update", kind: "talk" },
-      { prompt: "Check unresolved tickets", kind: "talk" },
-    ] as const;
-    const workflowFollowup = {
-      prompt:
-        "Discuss whether to save this as a workflow for daily support summaries.",
-      kind: "talk",
-    } as const;
-    const workflowSuggestionPrompts: string[] = [];
-    mockOptionalEnv("OPENROUTER_API_KEY", "bdd-openrouter-key");
-    chatCallbacks.mockOpenRouterCompletions((body) => {
-      const systemContent = body.messages[0]?.content ?? "";
-      if (systemContent.includes("Generate a short, descriptive title")) {
-        return "Daily Support Summary";
-      }
-      if (
-        systemContent.includes("Generate up to three concise follow-up prompts")
-      ) {
-        return JSON.stringify(originalFollowups);
-      }
-      if (systemContent.includes("reusable workflow or automation")) {
-        workflowSuggestionPrompts.push(body.messages[1]?.content ?? "");
-        return `[YES] ${workflowFollowup.prompt}`;
-      }
-      return "Generated summary";
-    });
-
-    const first = await startChatRun(actor, {
-      agentId,
-      prompt: "Summarize the daily support queue every morning.",
-      selectedModel: "claude-sonnet-4-6",
-    });
-    const sandboxHeaders = await claimChatRun(runnerGroup, first.runId);
-    chatCallbacks.mockChatOutputEvents([
-      assistantEvent(0, "Daily support queue summary is ready."),
-    ]);
-
-    await completeChatRunOk(first.runId, sandboxHeaders, {
-      lastEventSequence: 0,
-    });
-
-    const after = await waitForThreadMessages(
-      actor,
-      first.threadId,
-      (messages) => {
-        return lifecycleMarkers(messages, first.runId, "completed").some(
-          (message) => {
-            return (message.recommendedFollowups?.length ?? 0) === 3;
-          },
-        );
-      },
-    );
-    expect(workflowSuggestionPrompts).toHaveLength(1);
-    expect(workflowSuggestionPrompts[0]).toContain(
-      "Daily support queue summary is ready.",
-    );
-
-    const marker = lifecycleMarkers(
-      after.messages,
-      first.runId,
-      "completed",
-    )[0];
-    if (!marker) {
-      throw new Error("Expected a completed lifecycle marker");
-    }
-    const recommendedFollowups = marker.recommendedFollowups;
-    if (!recommendedFollowups) {
-      throw new Error("Expected completed marker follow-ups");
-    }
-    expect(recommendedFollowups).toHaveLength(3);
-    expect(recommendedFollowups).toContainEqual(workflowFollowup);
-    expect(
-      originalFollowups.filter((followup) => {
-        return recommendedFollowups.some((item) => {
-          return item.prompt === followup.prompt;
-        });
-      }),
-    ).toHaveLength(2);
-  });
 
   it("auto-sends the queued message before completed-run LLM side effects finish", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -9,7 +9,6 @@ import {
   chatMessages,
   type ChatMessageAttachFileMetadata,
   type ChatMessageGenerationTemplate,
-  type ChatMessageRecommendedFollowup,
   type ChatMessageRecommendedFollowups,
 } from "@vm0/db/schema/chat-message";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
@@ -68,7 +67,6 @@ import {
   type ChatCompletionContextMessage,
   generateAndPersistChatThreadTitleFromCallback,
   generateChatThreadRecommendedFollowupsFromContext,
-  generateChatThreadWorkflowAutomationSuggestionFromContext,
   generateChatNotificationSummary,
   loadChatThreadRecommendedFollowupContext,
 } from "./zero-chat-title.service";
@@ -968,60 +966,6 @@ async function generateRecommendedFollowupsForCompletedRun(args: {
   return suggestions.length > 0 ? suggestions : undefined;
 }
 
-async function generateWorkflowAutomationSuggestionForCompletedRun(args: {
-  readonly db: Db;
-  readonly orgId: string;
-  readonly userId: string;
-  readonly threadId: string;
-  readonly followupContext: readonly ChatCompletionContextMessage[];
-  readonly signal: AbortSignal;
-}): Promise<ChatMessageRecommendedFollowup | undefined> {
-  args.signal.throwIfAborted();
-  const enabled = isFeatureEnabled(
-    FeatureSwitchKey.WorkflowAutomation,
-    await loadUserFeatureSwitchContext(args.db, args.orgId, args.userId),
-  );
-  args.signal.throwIfAborted();
-  if (!enabled) {
-    return undefined;
-  }
-
-  const suggestion =
-    await generateChatThreadWorkflowAutomationSuggestionFromContext({
-      messages: args.followupContext,
-      threadId: args.threadId,
-    });
-  args.signal.throwIfAborted();
-  return suggestion ?? undefined;
-}
-
-function mergeRecommendedFollowups(
-  followups: ChatMessageRecommendedFollowups | undefined,
-  workflowAutomationSuggestion: ChatMessageRecommendedFollowup | undefined,
-): ChatMessageRecommendedFollowups | undefined {
-  const merged: ChatMessageRecommendedFollowups = followups
-    ? [...followups]
-    : [];
-  if (!workflowAutomationSuggestion) {
-    return merged.length > 0 ? merged : undefined;
-  }
-  if (
-    merged.some((item) => {
-      return item.prompt === workflowAutomationSuggestion.prompt;
-    })
-  ) {
-    return merged.length > 0 ? merged : undefined;
-  }
-
-  if (merged.length === 0) {
-    return [workflowAutomationSuggestion];
-  }
-
-  const replacementIndex = Math.floor(Math.random() * merged.length);
-  merged[replacementIndex] = workflowAutomationSuggestion;
-  return merged.length > 0 ? merged : undefined;
-}
-
 async function loadRecommendedFollowupContextForCompletedRun(args: {
   readonly db: Db;
   readonly threadId: string;
@@ -1182,27 +1126,13 @@ async function runCompletedChatCallbackSideEffects(args: {
   });
 
   const lifecycleMarkerStep = (async () => {
-    const [recommendedFollowups, workflowAutomationSuggestion] =
-      await Promise.all([
-        generateRecommendedFollowupsForCompletedRun({
-          followupContext: args.followupContext,
-          threadId: args.chatThread.chatThreadId,
-          signal: args.signal,
-        }),
-        generateWorkflowAutomationSuggestionForCompletedRun({
-          db: args.db,
-          orgId: args.chatThread.orgId,
-          userId: args.chatThread.userId,
-          threadId: args.chatThread.chatThreadId,
-          followupContext: args.followupContext,
-          signal: args.signal,
-        }),
-      ]);
-    const mergedRecommendedFollowups = mergeRecommendedFollowups(
-      recommendedFollowups,
-      workflowAutomationSuggestion,
-    );
-    if (!mergedRecommendedFollowups) {
+    const recommendedFollowups =
+      await generateRecommendedFollowupsForCompletedRun({
+        followupContext: args.followupContext,
+        threadId: args.chatThread.chatThreadId,
+        signal: args.signal,
+      });
+    if (!recommendedFollowups) {
       return;
     }
     await updateCompletedLifecycleMarkerFollowups({
@@ -1210,7 +1140,7 @@ async function runCompletedChatCallbackSideEffects(args: {
       runId: args.runId,
       threadId: args.chatThread.chatThreadId,
       userId: args.chatThread.userId,
-      recommendedFollowups: mergedRecommendedFollowups,
+      recommendedFollowups,
     });
   })();
 

--- a/turbo/apps/api/src/signals/services/zero-chat-title.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-title.service.ts
@@ -97,7 +97,6 @@ async function generateText(
   maxTokens = 30,
   options?: {
     readonly stripMarkdown?: boolean;
-    readonly allowEmpty?: boolean;
   },
 ): Promise<string | null> {
   const apiKey = optionalEnv("OPENROUTER_API_KEY");
@@ -131,7 +130,7 @@ async function generateText(
     throw new Error("OpenRouter returned empty content");
   }
   const content = rawContent.trim();
-  if (!content && !options?.allowEmpty) {
+  if (!content) {
     throw new Error("OpenRouter returned empty content");
   }
 
@@ -434,18 +433,6 @@ function parseRecommendedFollowups(
   return suggestions;
 }
 
-function parseWorkflowAutomationSuggestion(
-  text: string,
-): ChatMessageRecommendedFollowup | null {
-  const match = /^\[YES\]\s*[:：-]?\s*(.*)$/i.exec(text.trim());
-  if (!match) {
-    return null;
-  }
-
-  const prompt = sanitizeFollowup(match[1] ?? "");
-  return prompt === null ? null : { prompt, kind: "talk" };
-}
-
 async function getLatestFollowupContextMessages(
   db: SelectDb,
   threadId: string,
@@ -520,48 +507,6 @@ async function generateRecommendedFollowups(
   return text === null ? [] : parseRecommendedFollowups(text);
 }
 
-async function generateWorkflowAutomationSuggestion(
-  messages: readonly ChatCompletionContextMessage[],
-): Promise<ChatMessageRecommendedFollowup | null> {
-  const last = messages[messages.length - 1];
-  if (last?.role !== "assistant" || last.content.trim().length === 0) {
-    return null;
-  }
-
-  const context = messages
-    .map((message) => {
-      return `${message.role}: ${message.content.slice(0, FOLLOWUP_CONTEXT_CHAR_CAP)}`;
-    })
-    .join("\n\n");
-
-  const text = await generateText(
-    [
-      {
-        role: "system",
-        content: [
-          "Decide whether this completed VM0 chat task should be suggested as a reusable workflow or automation.",
-          "A workflow is reusable instructions or an SOP. An automation/trigger is when and how that workflow should run automatically.",
-          "Suggest only when the task is likely repeated, scheduled, triggered by an event, or has reusable SOP steps.",
-          "Do not suggest for one-off Q&A, broad brainstorming, tiny edits, or tasks that should just be continued manually.",
-          "If you do not recommend it, return an empty string.",
-          "If you recommend it, return exactly one line starting with [YES] followed by a short user prompt.",
-          "The prompt must invite discussion only. Do not ask the agent to create, enable, run, or schedule anything immediately.",
-          "Keep the text after [YES] under 100 characters. Match the user's language.",
-          "Example: [YES] Discuss whether to save this as a workflow for new support emails.",
-        ].join("\n"),
-      },
-      {
-        role: "user",
-        content: `Recent conversation:\n${context}`,
-      },
-    ],
-    80,
-    { stripMarkdown: false, allowEmpty: true },
-  );
-
-  return text === null ? null : parseWorkflowAutomationSuggestion(text);
-}
-
 export async function loadChatThreadRecommendedFollowupContext(args: {
   readonly db: SelectDb;
   readonly threadId: string;
@@ -580,23 +525,6 @@ export async function generateChatThreadRecommendedFollowupsFromContext(args: {
       err: result.error,
     });
     return [];
-  }
-  return result.value;
-}
-
-export async function generateChatThreadWorkflowAutomationSuggestionFromContext(args: {
-  readonly messages: readonly ChatCompletionContextMessage[];
-  readonly threadId?: string;
-}): Promise<ChatMessageRecommendedFollowup | null> {
-  const result = await settle(
-    generateWorkflowAutomationSuggestion(args.messages),
-  );
-  if (!result.ok) {
-    log.warn("Workflow automation suggestion generation failed", {
-      ...(args.threadId ? { threadId: args.threadId } : {}),
-      err: result.error,
-    });
-    return null;
   }
   return result.value;
 }


### PR DESCRIPTION
## Summary
- Remove the extra workflow automation follow-up generation call from completed chat callback side effects
- Stop merging workflow automation suggestions into recommended follow-ups
- Remove the BDD coverage for workflow suggestion replacement

## Verification
- pnpm format
- DATABASE_URL=postgresql://user@localhost:5432/vm0_test pnpm exec vitest run apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
- DATABASE_URL=postgresql://user@localhost:5432/vm0_test pnpm -F api lint
- DATABASE_URL=postgresql://user@localhost:5432/vm0_test NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types

Note: attempted full `pnpm turbo run lint --log-order grouped`; unrelated platform type-aware lint was SIGKILLed locally during `@vm0/app` tsgolint.