### PR TITLE
perf: reduce artifact storage manifest presigning

### DIFF
--- a/crates/api-contracts/src/generated/types.rs
+++ b/crates/api-contracts/src/generated/types.rs
@@ -35,9 +35,6 @@ pub mod runners {
             pub vas_version_id: String,
             /// Presigned URL for downloading the artifact archive.
             pub archive_url: String,
-            /// Optional presigned URL for downloading the artifact manifest.
-            #[serde(default, skip_serializing_if = "Option::is_none")]
-            pub manifest_url: Option<String>,
             /// Optional policy for a missing artifact root; absence behaves like `fail`.
             #[serde(default, skip_serializing_if = "Option::is_none")]
             pub missing_root_policy: Option<ArtifactEntryMissingRootPolicy>,

--- a/crates/api-contracts/tests/types.rs
+++ b/crates/api-contracts/tests/types.rs
@@ -183,7 +183,7 @@ fn generated_commit_response_deserializes_success_shape() {
 }
 
 #[test]
-fn generated_storage_manifest_deserializes_web_claim_shape() {
+fn generated_storage_manifest_ignores_legacy_artifact_manifest_url() {
     let manifest: runner_storage::StorageManifest = serde_json::from_value(json!({
         "storages": [{
             "name": "workspace",

--- a/crates/api-contracts/tests/types.rs
+++ b/crates/api-contracts/tests/types.rs
@@ -212,14 +212,10 @@ fn generated_storage_manifest_deserializes_web_claim_shape() {
         Some("AGENTS.md")
     );
     assert_eq!(manifest.artifacts[0].vas_storage_id, "storage-id-1");
-    assert_eq!(
-        manifest.artifacts[0].manifest_url.as_deref(),
-        Some("https://storage.example/manifest.json")
-    );
 }
 
 #[test]
-fn generated_storage_manifest_serializes_without_absent_manifest_url() {
+fn generated_storage_manifest_serializes_claim_shape() {
     let manifest = runner_storage::StorageManifest {
         storages: vec![runner_storage::StorageEntry {
             name: "workspace".to_string(),
@@ -235,7 +231,6 @@ fn generated_storage_manifest_serializes_without_absent_manifest_url() {
             vas_storage_id: "storage-id-1".to_string(),
             vas_version_id: "version-2".to_string(),
             archive_url: "https://storage.example/artifact.tar.gz".to_string(),
-            manifest_url: None,
             missing_root_policy: None,
         }],
     };

--- a/crates/runner/src/executor/tests/support/manifest.rs
+++ b/crates/runner/src/executor/tests/support/manifest.rs
@@ -29,7 +29,6 @@ pub(in crate::executor::tests) fn api_artifact(
         vas_storage_name: name.into(),
         vas_storage_id: storage_id.into(),
         vas_version_id: version.into(),
-        manifest_url: None,
         missing_root_policy: None,
     }
 }

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -795,7 +795,6 @@ fn is_static_json_field(field: &str) -> bool {
             | "keyName"
             | "kind"
             | "mac"
-            | "manifestUrl"
             | "metadataKey"
             | "missingRootPolicy"
             | "modelUsageProvider"

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -855,8 +855,7 @@ mod tests {
                 "archiveUrl": "https://example.com/artifacts.tar.gz",
                 "vasStorageName": "my-artifact",
                 "vasStorageId": "sid-1",
-                "vasVersionId": "v1",
-                "manifestUrl": "https://example.com/manifest.json"
+                "vasVersionId": "v1"
             }]
         });
         let manifest: StorageManifest = serde_json::from_value(json).unwrap();
@@ -864,10 +863,6 @@ mod tests {
         assert_eq!(manifest.storages[0].name, "workspace");
         assert_eq!(manifest.artifacts.len(), 1);
         assert_eq!(manifest.artifacts[0].vas_storage_name, "my-artifact");
-        assert_eq!(
-            manifest.artifacts[0].manifest_url.as_deref(),
-            Some("https://example.com/manifest.json")
-        );
     }
 
     #[test]
@@ -922,7 +917,6 @@ mod tests {
                 vas_storage_name: "memory".into(),
                 vas_storage_id: "sid-1".into(),
                 vas_version_id: "v2".into(),
-                manifest_url: Some("https://example.com/manifest.json".into()),
                 missing_root_policy: Some(ArtifactEntryMissingRootPolicy::PreserveParentVersion),
             }],
         };
@@ -969,7 +963,6 @@ mod tests {
                 vas_storage_name: "memory".into(),
                 vas_storage_id: "sid-1".into(),
                 vas_version_id: "v2".into(),
-                manifest_url: Some("https://example.com/manifest.json".into()),
                 missing_root_policy: None,
             }],
         };

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -117,6 +117,22 @@ function countSessionHistoryBlobReads(hash: string): number {
   }).length;
 }
 
+function presignedUrlKeysSince(
+  startIndex: number,
+): readonly (string | undefined)[] {
+  return context.mocks.s3.getSignedUrl.mock.calls
+    .slice(startIndex)
+    .map(([, command]) => {
+      return s3CommandKey(command);
+    });
+}
+
+function hasManifestPresign(keys: readonly (string | undefined)[]): boolean {
+  return keys.some((key) => {
+    return key?.endsWith("/manifest.json") ?? false;
+  });
+}
+
 function s3TextBody(text: string): AsyncIterable<Buffer> {
   return {
     async *[Symbol.asyncIterator]() {
@@ -767,6 +783,8 @@ describe("RUN-04: session and checkpoint reads", () => {
     });
     const plainCompose = await createClaudeCompose(actor, "bdd-plain");
 
+    const presignCallsBeforeRun =
+      context.mocks.s3.getSignedUrl.mock.calls.length;
     const r1 = await api.createDirectRun(actor, {
       agentComposeId: secretCompose.composeId,
       prompt: "produce a session with artifacts",
@@ -783,6 +801,9 @@ describe("RUN-04: session and checkpoint reads", () => {
     expect(outArtifact.vasStorageId).toStrictEqual(expect.any(String));
     expect(outArtifact.vasVersionId).toStrictEqual(expect.any(String));
     expect("manifestUrl" in outArtifact).toBeFalsy();
+    expect(
+      hasManifestPresign(presignedUrlKeysSince(presignCallsBeforeRun)),
+    ).toBeFalsy();
 
     const headers1 = sandboxHeaders(claim1.sandboxToken);
     const withArtifacts = await webhooks.requestAgentCheckpoint(
@@ -1013,6 +1034,8 @@ describe("RUN-01/RUN-02: checkpoint resume, memory policies, and volume pinning"
     });
 
     const versionPrefix = volumeVersion.slice(0, 16);
+    const presignCallsBeforeRun =
+      context.mocks.s3.getSignedUrl.mock.calls.length;
     const r1 = await api.createDirectRun(actor, {
       agentComposeId: compose.composeId,
       prompt: "pin the volume by version prefix",
@@ -1039,6 +1062,9 @@ describe("RUN-01/RUN-02: checkpoint resume, memory policies, and volume pinning"
       throw new Error("Expected the claim manifest to mount memory");
     }
     expect("manifestUrl" in memory1).toBeFalsy();
+    expect(
+      hasManifestPresign(presignedUrlKeysSince(presignCallsBeforeRun)),
+    ).toBeFalsy();
 
     const headers1 = sandboxHeaders(claim1.sandboxToken);
     const checkpointed = await webhooks.requestAgentCheckpoint(

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -779,6 +779,10 @@ describe("RUN-04: session and checkpoint reads", () => {
     if (!outArtifact) {
       throw new Error("Expected the claim manifest to mount bdd-out");
     }
+    expect(outArtifact.archiveUrl).toStrictEqual(expect.any(String));
+    expect(outArtifact.vasStorageId).toStrictEqual(expect.any(String));
+    expect(outArtifact.vasVersionId).toStrictEqual(expect.any(String));
+    expect("manifestUrl" in outArtifact).toBeFalsy();
 
     const headers1 = sandboxHeaders(claim1.sandboxToken);
     const withArtifacts = await webhooks.requestAgentCheckpoint(
@@ -1026,11 +1030,15 @@ describe("RUN-01/RUN-02: checkpoint resume, memory policies, and volume pinning"
     });
     expect(memory1).toMatchObject({
       mountPath: CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
+      archiveUrl: expect.any(String),
+      vasStorageId: expect.any(String),
+      vasVersionId: expect.any(String),
       missingRootPolicy: "preserveParentVersion",
     });
     if (!memory1) {
       throw new Error("Expected the claim manifest to mount memory");
     }
+    expect("manifestUrl" in memory1).toBeFalsy();
 
     const headers1 = sandboxHeaders(claim1.sandboxToken);
     const checkpointed = await webhooks.requestAgentCheckpoint(

--- a/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
@@ -843,26 +843,15 @@ async function buildArtifactEntryFromInput(
   },
 ): Promise<ManifestArtifact> {
   const { artifact, resolved } = args.input;
-  const [archiveUrl, manifestUrl] = await Promise.all([
-    get(
-      generatePresignedGetUrl(
-        args.bucket,
-        `${resolved.s3Key}/archive.tar.gz`,
-        DOWNLOAD_URL_TTL_SECONDS,
-        undefined,
-        true,
-      ),
+  const archiveUrl = await get(
+    generatePresignedGetUrl(
+      args.bucket,
+      `${resolved.s3Key}/archive.tar.gz`,
+      DOWNLOAD_URL_TTL_SECONDS,
+      undefined,
+      true,
     ),
-    get(
-      generatePresignedGetUrl(
-        args.bucket,
-        `${resolved.s3Key}/manifest.json`,
-        DOWNLOAD_URL_TTL_SECONDS,
-        undefined,
-        true,
-      ),
-    ),
-  ]);
+  );
 
   return {
     mountPath: artifact.mountPath,
@@ -870,7 +859,6 @@ async function buildArtifactEntryFromInput(
     vasStorageId: resolved.storageId,
     vasVersionId: resolved.versionId,
     archiveUrl,
-    manifestUrl,
     ...(artifact.missingRootPolicy
       ? { missingRootPolicy: artifact.missingRootPolicy }
       : {}),

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -31,7 +31,6 @@ describe("runner storage manifest contract", () => {
             vasStorageId: "storage-id-1",
             vasVersionId: "version-2",
             archiveUrl: "https://storage.example/artifact.tar.gz",
-            manifestUrl: "https://storage.example/manifest.json",
           },
         ],
       }),
@@ -52,13 +51,12 @@ describe("runner storage manifest contract", () => {
           vasStorageId: "storage-id-1",
           vasVersionId: "version-2",
           archiveUrl: "https://storage.example/artifact.tar.gz",
-          manifestUrl: "https://storage.example/manifest.json",
         },
       ],
     });
   });
 
-  it("accepts artifact entries without manifest urls", () => {
+  it("strips legacy artifact manifest urls", () => {
     expect(
       storageManifestSchema.parse({
         storages: [],
@@ -69,6 +67,7 @@ describe("runner storage manifest contract", () => {
             vasStorageId: "storage-id-1",
             vasVersionId: "version-2",
             archiveUrl: "https://storage.example/artifact.tar.gz",
+            manifestUrl: "https://storage.example/manifest.json",
           },
         ],
       }),
@@ -113,7 +112,6 @@ describe("runner storage manifest contract", () => {
           vasStorageId: "storage-id-1",
           vasVersionId: "version-2",
           archiveUrl: "https://storage.example/artifact.tar.gz",
-          manifestUrl: "https://storage.example/manifest.json",
           missingRootPolicy: "preserveParentVersion",
         },
       ],

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -58,6 +58,34 @@ describe("runner storage manifest contract", () => {
     });
   });
 
+  it("accepts artifact entries without manifest urls", () => {
+    expect(
+      storageManifestSchema.parse({
+        storages: [],
+        artifacts: [
+          {
+            mountPath: "/home/user/.claude/projects/project",
+            vasStorageName: "memory",
+            vasStorageId: "storage-id-1",
+            vasVersionId: "version-2",
+            archiveUrl: "https://storage.example/artifact.tar.gz",
+          },
+        ],
+      }),
+    ).toEqual({
+      storages: [],
+      artifacts: [
+        {
+          mountPath: "/home/user/.claude/projects/project",
+          vasStorageName: "memory",
+          vasStorageId: "storage-id-1",
+          vasVersionId: "version-2",
+          archiveUrl: "https://storage.example/artifact.tar.gz",
+        },
+      ],
+    });
+  });
+
   it("rejects guest-download-only nullable archive urls", () => {
     const result = storageManifestSchema.safeParse({
       storages: [

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -155,7 +155,6 @@ export const artifactEntrySchema = z.object({
   vasStorageId: z.string(),
   vasVersionId: z.string(),
   archiveUrl: z.string(),
-  manifestUrl: z.string().optional(),
   missingRootPolicy: artifactMissingRootPolicySchema.optional(),
 });
 

--- a/turbo/packages/api-contracts/src/rust-bindings/types.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/types.ts
@@ -102,9 +102,6 @@ export const rustTypeBindings = [
           vasStorageId: ["VAS storage identifier for the artifact."],
           vasVersionId: ["VAS version identifier for the artifact contents."],
           archiveUrl: ["Presigned URL for downloading the artifact archive."],
-          manifestUrl: [
-            "Optional presigned URL for downloading the artifact manifest.",
-          ],
           missingRootPolicy: [
             "Optional policy for a missing artifact root; absence behaves like `fail`.",
           ],


### PR DESCRIPTION
## Summary

- Stop generating artifact `manifestUrl` presigned URLs in create-run storage manifests.
- Remove `manifestUrl` from the runner storage manifest contract and regenerated Rust DTOs.
- Keep legacy JSON with `manifestUrl` parse-compatible by relying on normal unknown-field stripping/ignoring.
- Add route, contract, and Rust coverage for artifact entries without `manifestUrl`.

Closes #19062

## Validation

- `pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/runners.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-reads.bdd.test.ts -t "exposes sessions and checkpoints created through run and webhook flows"`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-reads.bdd.test.ts -t "checkpoint resume, memory policies, and volume pinning"`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/api-contracts generate:rust`
- `cargo test --manifest-path crates/Cargo.toml -p api-contracts`
- `cargo test --manifest-path crates/Cargo.toml -p runner storage_manifest`
- `cargo test --manifest-path crates/Cargo.toml -p runner guest_download_manifest_serialization_omits_api_only_fields`
- `git diff --check`
- pre-commit hook: prettier, cargo fmt, cargo clippy, cargo doc, knip, full `pnpm check-types`

## Post-Deploy Metrics

Compare:

- `api_dispatch_build_runner_job_payload`
- `api_dispatch_prepare_storage_manifest`
- `api_dispatch_prepare_storage_manifest_build_entries`
- `api_dispatch_prepare_storage_manifest_generate_artifact_urls`
- `api_to_runner_queue`
- `api_to_claim`
- `api_to_spawn`
