### PR TITLE
feat: add workflow prompt action to chat messages

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/workflow-prompt-action.ts
+++ b/turbo/apps/platform/src/signals/chat-page/workflow-prompt-action.ts
@@ -1,0 +1,13 @@
+import { command, computed, state } from "ccstate";
+
+const replaceWorkflowPromptDraftTargetState$ = state<string | null>(null);
+
+export const replaceWorkflowPromptDraftTarget$ = computed((get) => {
+  return get(replaceWorkflowPromptDraftTargetState$);
+});
+
+export const setReplaceWorkflowPromptDraftTarget$ = command(
+  ({ set }, target: string | null) => {
+    set(replaceWorkflowPromptDraftTargetState$, target);
+  },
+);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -32,6 +32,7 @@ import {
 import { zeroQueuePositionContract } from "@vm0/api-contracts/contracts/zero-queue-position";
 import { zeroGoalsContract } from "@vm0/api-contracts/contracts/zero-goals";
 import {
+  zeroWorkflowsCollectionContract,
   zeroWorkflowTriggersContract,
   type ZeroWorkflowTriggerUpdateRequest,
 } from "@vm0/api-contracts/contracts/zero-workflows";
@@ -56,6 +57,7 @@ import {
   sendMessageInUI,
   splitChatThreadListResponse,
 } from "./chat-test-helpers.ts";
+import { CREATE_WORKFLOW_WITH_CHAT_PROMPT } from "../workflow-chat-prompts.ts";
 
 const context = testContext();
 
@@ -747,6 +749,24 @@ function buttonByText(text: string, container?: ParentNode): HTMLElement {
     throw new Error(`${text} button not found`);
   }
   return button;
+}
+
+async function findWorkflowComposerEditor(): Promise<HTMLElement> {
+  return await waitFor(() => {
+    const editor = document.querySelector(
+      '.zero-composer [contenteditable="true"]',
+    );
+    if (!(editor instanceof HTMLElement)) {
+      throw new Error("Composer editor not found");
+    }
+    return editor;
+  });
+}
+
+function mockWorkflowComposerWorkflows(): void {
+  context.mocks.api(zeroWorkflowsCollectionContract.list, ({ respond }) => {
+    return respond(200, []);
+  });
 }
 
 function selectOptionByLabel(
@@ -3256,6 +3276,184 @@ describe("chat lifecycle", () => {
     await waitFor(() => {
       expect(clipboard.writes).toStrictEqual([assistantReply]);
     });
+  });
+
+  it("starts a workflow prompt from an assistant message when the composer is empty", async () => {
+    const threadId = "assistant-message-create-workflow-empty";
+    const assistantReply = "We can turn this into a workflow.";
+    mockWorkflowComposerWorkflows();
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Assistant workflow",
+      chatMessages: [
+        {
+          id: "msg-workflow-empty-user",
+          role: "user",
+          content: "Make this repeatable",
+          runId: "run-workflow-empty",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          id: "msg-workflow-empty-assistant",
+          role: "assistant",
+          content: assistantReply,
+          runId: "run-workflow-empty",
+          createdAt: "2026-06-09T10:01:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: {
+        [FeatureSwitchKey.WorkflowAutomation]: true,
+      },
+    });
+
+    const assistantMessage = await screen.findByText(assistantReply);
+    const assistantGroup = assistantMessage.closest('[data-role="assistant"]');
+    if (!(assistantGroup instanceof HTMLElement)) {
+      throw new Error("assistant message group not found");
+    }
+    const copyButton = within(assistantGroup).getByLabelText("Copy message");
+    const workflowButton =
+      within(assistantGroup).getByLabelText("Create workflow");
+    expect(
+      copyButton.compareDocumentPosition(workflowButton) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+
+    click(workflowButton);
+
+    const editor = await findWorkflowComposerEditor();
+    await waitFor(() => {
+      expect(editor).toHaveTextContent(CREATE_WORKFLOW_WITH_CHAT_PROMPT);
+    });
+    expect(
+      screen.queryByRole("dialog", { name: "Replace composer draft?" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("confirms before replacing an existing composer draft with a workflow prompt", async () => {
+    const threadId = "assistant-message-create-workflow-draft";
+    const assistantReply = "This is a good workflow candidate.";
+    const draft = "Keep this draft";
+    mockWorkflowComposerWorkflows();
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Assistant workflow draft",
+      chatMessages: [
+        {
+          id: "msg-workflow-draft-user",
+          role: "user",
+          content: "Can this be automated?",
+          runId: "run-workflow-draft",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          id: "msg-workflow-draft-assistant",
+          role: "assistant",
+          content: assistantReply,
+          runId: "run-workflow-draft",
+          createdAt: "2026-06-09T10:01:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: {
+        [FeatureSwitchKey.WorkflowAutomation]: true,
+      },
+    });
+
+    const editor = await findWorkflowComposerEditor();
+    await fill(editor, draft);
+    await waitFor(() => {
+      expect(editor).toHaveTextContent(draft);
+    });
+
+    const assistantMessage = await screen.findByText(assistantReply);
+    const assistantGroup = assistantMessage.closest('[data-role="assistant"]');
+    if (!(assistantGroup instanceof HTMLElement)) {
+      throw new Error("assistant message group not found");
+    }
+    const workflowButton =
+      within(assistantGroup).getByLabelText("Create workflow");
+
+    click(workflowButton);
+
+    const dialog = await screen.findByRole("dialog", {
+      name: "Replace composer draft?",
+    });
+    expect(
+      within(dialog).getByText(
+        "Continuing will clear your current composer draft and start a workflow prompt.",
+      ),
+    ).toBeInTheDocument();
+
+    click(buttonByText("Cancel", dialog));
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Replace composer draft?" }),
+      ).not.toBeInTheDocument();
+      expect(editor).toHaveTextContent(draft);
+    });
+
+    click(workflowButton);
+    const confirmDialog = await screen.findByRole("dialog", {
+      name: "Replace composer draft?",
+    });
+    click(buttonByText("Continue", confirmDialog));
+
+    await waitFor(() => {
+      expect(editor).toHaveTextContent(CREATE_WORKFLOW_WITH_CHAT_PROMPT);
+      expect(editor).not.toHaveTextContent(draft);
+    });
+  });
+
+  it("hides the workflow prompt action when workflow automation is disabled", async () => {
+    const threadId = "assistant-message-create-workflow-disabled";
+    const assistantReply = "This could be automated later.";
+    mockChatLifecycle(context, {
+      threadId,
+      threadTitle: "Assistant workflow disabled",
+      chatMessages: [
+        {
+          id: "msg-workflow-disabled-user",
+          role: "user",
+          content: "Can this repeat?",
+          runId: "run-workflow-disabled",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          id: "msg-workflow-disabled-assistant",
+          role: "assistant",
+          content: assistantReply,
+          runId: "run-workflow-disabled",
+          createdAt: "2026-06-09T10:01:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: {
+        [FeatureSwitchKey.WorkflowAutomation]: false,
+      },
+    });
+
+    const assistantMessage = await screen.findByText(assistantReply);
+    const assistantGroup = assistantMessage.closest('[data-role="assistant"]');
+    if (!(assistantGroup instanceof HTMLElement)) {
+      throw new Error("assistant message group not found");
+    }
+    expect(
+      within(assistantGroup).queryByLabelText("Create workflow"),
+    ).not.toBeInTheDocument();
   });
 
   it("shows linked automations from the chat header sidebar", async () => {

--- a/turbo/apps/platform/src/views/zero-page/workflow-chat-prompts.ts
+++ b/turbo/apps/platform/src/views/zero-page/workflow-chat-prompts.ts
@@ -1,0 +1,2 @@
+export const CREATE_WORKFLOW_WITH_CHAT_PROMPT =
+  "Help me create a workflow for this agent. Use the workflow-setup skill, then ask me for the desired outcome, automation, and action before creating the workflow and automation.";

--- a/turbo/apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx
@@ -74,9 +74,9 @@ import {
   gmailTriggerTitle,
   workflowTitle,
 } from "../workflows-page/workflow-shared.tsx";
+import { CREATE_WORKFLOW_WITH_CHAT_PROMPT } from "./workflow-chat-prompts.ts";
 
-export const CREATE_WORKFLOW_WITH_CHAT_PROMPT =
-  "Help me create a workflow for this agent. Use the workflow-setup skill, then ask me for the desired outcome, automation, and action before creating the workflow and automation.";
+export { CREATE_WORKFLOW_WITH_CHAT_PROMPT };
 
 const CREATE_AUTOMATION_CHAT_PROMPT =
   "Help me create a workflow automation for this agent. Use the workflow-setup skill, then ask me for the desired outcome, automation, and action before creating the workflow and automation.";

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -23,6 +23,10 @@ import {
   setRunUsagePopoverOpenRunId$,
 } from "../../signals/chat-page/run-usage-popover.ts";
 import {
+  replaceWorkflowPromptDraftTarget$,
+  setReplaceWorkflowPromptDraftTarget$,
+} from "../../signals/chat-page/workflow-prompt-action.ts";
+import {
   IconAlertCircle,
   IconArrowsDiagonal,
   IconArrowsDiagonalMinimize2,
@@ -255,6 +259,7 @@ import {
   WorkflowTriggerCard,
   type WorkflowTriggerCardRow,
 } from "../workflows-page/workflow-trigger-card.tsx";
+import { CREATE_WORKFLOW_WITH_CHAT_PROMPT } from "./workflow-chat-prompts.ts";
 
 import {
   renameChatThread$,
@@ -7524,12 +7529,16 @@ function PagedGroupPrimaryActions({
   usage,
   copied,
   onCopy,
+  workflowAutomationEnabled,
+  onCreateWorkflow,
 }: {
   firstRunId: string | undefined;
   hasContent: boolean;
   usage: ChatMessageUsagePayload | undefined;
   copied: boolean;
   onCopy: () => void;
+  workflowAutomationEnabled: boolean;
+  onCreateWorkflow: () => void;
 }) {
   return (
     <div className="flex items-center gap-1" data-testid="chat-message-actions">
@@ -7575,8 +7584,59 @@ function PagedGroupPrimaryActions({
           </Tooltip>
         </TooltipProvider>
       )}
+      {workflowAutomationEnabled && (
+        <button
+          type="button"
+          onClick={onCreateWorkflow}
+          className="inline-flex h-[26px] items-center overflow-hidden rounded-md p-1 text-muted-foreground/60 transition-colors duration-150 hover:bg-accent hover:text-foreground [&:focus-visible>span]:ml-1.5 [&:focus-visible>span]:max-w-24 [&:focus-visible>span]:opacity-100 [&:hover>span]:ml-1.5 [&:hover>span]:max-w-24 [&:hover>span]:opacity-100"
+          aria-label="Create workflow"
+        >
+          <IconRoute size={18} stroke={1.5} className="shrink-0" />
+          <span className="ml-0 max-w-0 overflow-hidden whitespace-nowrap text-xs font-medium opacity-0 transition-all duration-150">
+            Create workflow
+          </span>
+        </button>
+      )}
       {usage && firstRunId && <RunUsageChip runId={firstRunId} usage={usage} />}
     </div>
+  );
+}
+
+function ReplaceComposerDraftDialog({
+  open,
+  onOpenChange,
+  onConfirm,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="zero-app sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Replace composer draft?</DialogTitle>
+          <DialogDescription>
+            Continuing will clear your current composer draft and start a
+            workflow prompt.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => {
+              onOpenChange(false);
+            }}
+          >
+            Cancel
+          </Button>
+          <Button type="button" onClick={onConfirm}>
+            Continue
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -7593,12 +7653,26 @@ function PagedGroupActions({
   const copiedId = useGet(thread.copiedMessageId$);
   const copied = copiedId === group.beginMessageId;
   const copyMessage = useSet(thread.copyMessage$);
+  const composerInput = useGet(thread.draft.input$);
+  const composerAttachments = useGet(thread.draft.attachments$);
+  const setComposerInput = useSet(thread.draft.setInput$);
+  const clearComposerDraft = useSet(thread.draft.clear$);
+  const queueDraftSync = useSet(thread.queueDraftSync$);
+  const focusComposer = useSet(thread.focusInput$);
+  const features = useGet(featureSwitch$);
+  const replaceDraftTarget = useGet(replaceWorkflowPromptDraftTarget$);
+  const setReplaceDraftTarget = useSet(setReplaceWorkflowPromptDraftTarget$);
 
   const firstRunId = group.messages.find((m) => {
     return m.runId;
   })?.runId;
   const usage = group.usage;
   const hasContent = content.length > 0;
+  const workflowAutomationEnabled =
+    features[FeatureSwitchKey.WorkflowAutomation] ?? false;
+  const hasComposerDraft =
+    composerInput.trim().length > 0 || composerAttachments.length > 0;
+  const replaceDraftDialogOpen = replaceDraftTarget === group.beginMessageId;
 
   if (group.role === "user") {
     return null;
@@ -7618,18 +7692,51 @@ function PagedGroupActions({
     );
   };
 
+  const applyWorkflowPrompt = () => {
+    clearComposerDraft();
+    setComposerInput(CREATE_WORKFLOW_WITH_CHAT_PROMPT);
+    detach(queueDraftSync(pageSignal), Reason.DomCallback);
+    focusComposer();
+  };
+
+  const handleCreateWorkflow = () => {
+    if (hasComposerDraft) {
+      setReplaceDraftTarget(group.beginMessageId);
+      return;
+    }
+    applyWorkflowPrompt();
+  };
+
+  const handleConfirmReplaceDraft = () => {
+    setReplaceDraftTarget(null);
+    applyWorkflowPrompt();
+  };
+
+  const handleReplaceDialogOpenChange = (open: boolean) => {
+    setReplaceDraftTarget(open ? group.beginMessageId : null);
+  };
+
   return (
-    <div className="@[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px]">
-      <div className="hidden @[900px]:block" />
-      <div className="flex items-center justify-between pt-2 pb-1 gap-2 -ml-1">
-        <PagedGroupPrimaryActions
-          firstRunId={firstRunId}
-          hasContent={hasContent}
-          usage={usage}
-          copied={copied}
-          onCopy={handleCopy}
-        />
+    <>
+      <div className="@[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px]">
+        <div className="hidden @[900px]:block" />
+        <div className="flex items-center justify-between pt-2 pb-1 gap-2 -ml-1">
+          <PagedGroupPrimaryActions
+            firstRunId={firstRunId}
+            hasContent={hasContent}
+            usage={usage}
+            copied={copied}
+            onCopy={handleCopy}
+            workflowAutomationEnabled={workflowAutomationEnabled}
+            onCreateWorkflow={handleCreateWorkflow}
+          />
+        </div>
       </div>
-    </div>
+      <ReplaceComposerDraftDialog
+        open={replaceDraftDialogOpen}
+        onOpenChange={handleReplaceDialogOpenChange}
+        onConfirm={handleConfirmReplaceDraft}
+      />
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- Add a workflow action after the assistant message copy action when workflowAutomation is enabled
- Reuse the existing create-workflow chat prompt and fill it into the composer when empty
- Confirm before replacing an existing composer draft, including attachment-only drafts
- Cover enabled, confirmation, and disabled feature-switch behavior in chat lifecycle tests

## Verification
- pnpm exec prettier --write apps/platform/src/signals/chat-page/workflow-prompt-action.ts apps/platform/src/views/zero-page/workflow-chat-prompts.ts apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx apps/platform/src/views/zero-page/zero-chat-thread-page.tsx apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx
- pnpm -F @vm0/app check-types

## Browser verification
- Local dev server opened, but agent-browser was stopped by the app browser-upgrade gate and local env was missing VITE_API_URL. Per request, staging preview screenshots will be captured once the PR preview is ready.
