### PR TITLE
fix: surface usage pending counter underflows

### DIFF
--- a/crates/runner/mitm-addon/src/usage/counters.py
+++ b/crates/runner/mitm-addon/src/usage/counters.py
@@ -25,6 +25,7 @@ _buffered_usage_events = 0
 _pending_reports = 0
 _pending_path = ""
 _usage_state_id = str(uuid.uuid4())
+_counter_underflow_logged: set[str] = set()
 # One-shot guard: sustained pending snapshot write failure makes the runner
 # hit the bounded usage-drain timeout without any local signal pointing at
 # filesystem trouble.  Emit one error signal per addon process on first failure —
@@ -36,6 +37,8 @@ _usage_state_id = str(uuid.uuid4())
 # leading key=value fields and re-emits them as structured tracing fields.
 _pending_write_error_logged = False
 _FLUSH_REQUEST_FILE = "usage-flush-request"
+_COUNTER_FLOWS = "flows"
+_COUNTER_REPORTS = "reports"
 
 
 def reset_for_tests() -> None:
@@ -49,6 +52,7 @@ def reset_for_tests() -> None:
         _pending_path = ""
         _usage_state_id = str(uuid.uuid4())
         _pending_write_error_logged = False
+        _counter_underflow_logged.clear()
 
 
 def set_pending_path(path: str, usage_state_id: str | None = None) -> None:
@@ -157,8 +161,14 @@ def increment_in_flight_flows() -> None:
 def decrement_in_flight_flows() -> None:
     """Mark a tracked in-flight flow as complete (call from response/error)."""
     global _in_flight_flows
+    should_log = False
     with _counter_lock:
-        _in_flight_flows = max(0, _in_flight_flows - 1)
+        if _in_flight_flows > 0:
+            _in_flight_flows -= 1
+        else:
+            should_log = _mark_counter_underflow_locked(_COUNTER_FLOWS)
+    if should_log:
+        _log_counter_underflow(_COUNTER_FLOWS)
 
 
 def increment_pending_reports() -> None:
@@ -167,13 +177,68 @@ def increment_pending_reports() -> None:
         _pending_reports += 1
 
 
+class PendingReportLease:
+    """One-shot ownership token for an admitted pending usage report."""
+
+    def __init__(self) -> None:
+        self._released = False
+        self._lock = threading.Lock()
+
+    def release(self) -> None:
+        should_release = False
+        should_log = False
+        with self._lock:
+            if self._released:
+                should_log = True
+            else:
+                self._released = True
+                should_release = True
+
+        if should_release:
+            decrement_pending_reports()
+        if should_log and _mark_counter_underflow(_COUNTER_REPORTS):
+            _log_counter_underflow(_COUNTER_REPORTS)
+
+
+def admit_pending_report() -> PendingReportLease:
+    increment_pending_reports()
+    return PendingReportLease()
+
+
 def decrement_pending_reports() -> None:
     global _pending_reports
+    should_log = False
     with _counter_lock:
-        _pending_reports = max(0, _pending_reports - 1)
+        if _pending_reports > 0:
+            _pending_reports -= 1
+        else:
+            should_log = _mark_counter_underflow_locked(_COUNTER_REPORTS)
+    if should_log:
+        _log_counter_underflow(_COUNTER_REPORTS)
 
 
 def set_buffered_usage_events(count: int) -> None:
     global _buffered_usage_events
     with _counter_lock:
         _buffered_usage_events = max(0, count)
+
+
+def _mark_counter_underflow(counter: str) -> bool:
+    with _counter_lock:
+        return _mark_counter_underflow_locked(counter)
+
+
+def _mark_counter_underflow_locked(counter: str) -> bool:
+    if counter in _counter_underflow_logged:
+        return False
+    _counter_underflow_logged.add(counter)
+    return True
+
+
+def _log_counter_underflow(counter: str) -> None:
+    ctx.log.error(
+        "type=usage_underbilling reason=usage_pending_counter_underflow "
+        "underbilling_class=risk component=mitm_addon "
+        f"counter={counter} Usage pending counter release had no matching admission; "
+        "keeping counter non-negative."
+    )

--- a/crates/runner/mitm-addon/src/usage/webhook.py
+++ b/crates/runner/mitm-addon/src/usage/webhook.py
@@ -19,7 +19,7 @@ from typing import Literal
 from logging_utils import log_proxy_entry
 from platform_api import make_api_request
 
-from .counters import decrement_pending_reports, increment_pending_reports
+from .counters import PendingReportLease, admit_pending_report
 
 WebhookDeliveryOutcome = Literal["success", "retryable_failure", "permanent_failure"]
 _DeliveryOutcomeCallback = Callable[[WebhookDeliveryOutcome], None]
@@ -104,6 +104,7 @@ def _post_webhook_with_retry(
     payload: dict,
     proxy_log_path: str,
     log_type: str,
+    pending_report: PendingReportLease,
     max_retries: int = 1,
     delivery_outcome_callback: _DeliveryOutcomeCallback | None = None,
 ) -> None:
@@ -127,7 +128,7 @@ def _post_webhook_with_retry(
         if delivery_outcome_callback is not None:
             delivery_outcome_callback(outcome)
     finally:
-        decrement_pending_reports()
+        pending_report.release()
 
 
 def _handle_retryable_webhook_failure(
@@ -326,6 +327,7 @@ def _post_admitted_webhook_with_retry(
     payload: dict,
     proxy_log_path: str,
     log_type: str,
+    pending_report: PendingReportLease,
     delivery_outcome_callback: _DeliveryOutcomeCallback | None,
 ) -> None:
     try:
@@ -335,6 +337,7 @@ def _post_admitted_webhook_with_retry(
             payload,
             proxy_log_path,
             log_type,
+            pending_report,
             delivery_outcome_callback=delivery_outcome_callback,
         )
     finally:
@@ -394,7 +397,7 @@ def _enqueue_webhook(
         _release_delivery_capacity()
         raise
 
-    increment_pending_reports()
+    pending_report = admit_pending_report()
     try:
         usage_executor.submit(
             _post_admitted_webhook_with_retry,
@@ -403,6 +406,7 @@ def _enqueue_webhook(
             payload,
             proxy_log_path,
             log_type,
+            pending_report,
             delivery_outcome_callback,
         )
     except RuntimeError:
@@ -423,16 +427,17 @@ def _enqueue_webhook(
                 payload,
                 proxy_log_path,
                 log_type,
+                pending_report,
                 delivery_outcome_callback=delivery_outcome_callback,
             )
         except Exception:
             if not fallback_started:
-                decrement_pending_reports()
+                pending_report.release()
             raise
         finally:
             _release_delivery_capacity()
     except Exception:
-        decrement_pending_reports()
+        pending_report.release()
         _release_delivery_capacity()
         raise
     return True

--- a/crates/runner/mitm-addon/tests/test_counters.py
+++ b/crates/runner/mitm-addon/tests/test_counters.py
@@ -11,6 +11,14 @@ from tests.pending_helpers import assert_current_pending, assert_pending
 from tests.usage_buffer_helpers import RecordingEnqueue, event
 
 
+def assert_counter_underflow_message(message: str, counter: str) -> None:
+    assert "type=usage_underbilling" in message
+    assert "reason=usage_pending_counter_underflow" in message
+    assert "underbilling_class=risk" in message
+    assert "component=mitm_addon" in message
+    assert f"counter={counter}" in message
+
+
 class TestUsagePendingCounter:
     """Tests for usage pending counters."""
 
@@ -99,6 +107,38 @@ class TestUsagePendingCounter:
         usage.counters.decrement_pending_reports()
         assert_current_pending(
             pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-2"
+        )
+
+    def test_pending_report_lease_release_drains_report(self, tmp_path):
+        pending_path = tmp_path / "usage-pending"
+        usage.set_pending_path(str(pending_path))
+        lease = usage.counters.admit_pending_report()
+        assert_current_pending(
+            pending_path, flows=0, buffered=0, reports=1, flush_request_id="admitted"
+        )
+
+        lease.release()
+
+        assert_current_pending(
+            pending_path, flows=0, buffered=0, reports=0, flush_request_id="released"
+        )
+
+    def test_balanced_counter_releases_do_not_log_underflow(self, tmp_path):
+        pending_path = tmp_path / "usage-pending"
+        usage.set_pending_path(str(pending_path))
+
+        mock_log = MagicMock()
+        with patch.object(usage.counters.ctx, "log", mock_log, create=True):
+            usage.increment_in_flight_flows()
+            usage.decrement_in_flight_flows()
+            usage.counters.increment_pending_reports()
+            usage.counters.decrement_pending_reports()
+            lease = usage.counters.admit_pending_report()
+            lease.release()
+
+        assert mock_log.error.call_count == 0
+        assert_current_pending(
+            pending_path, flows=0, buffered=0, reports=0, flush_request_id="balanced"
         )
 
     def test_set_buffered_usage_events(self, tmp_path):
@@ -243,14 +283,68 @@ class TestUsagePendingCounter:
 
         assert usage.read_usage_flush_request_id() is None
 
-    def test_decrement_does_not_go_negative(self, tmp_path):
+    def test_decrement_underflow_stays_non_negative_and_logs_once_per_counter(self, tmp_path):
         pending_path = tmp_path / "usage-pending"
         usage.set_pending_path(str(pending_path))
-        usage.decrement_in_flight_flows()
-        usage.counters.decrement_pending_reports()
+
+        mock_log = MagicMock()
+        with patch.object(usage.counters.ctx, "log", mock_log, create=True):
+            usage.decrement_in_flight_flows()
+            usage.decrement_in_flight_flows()
+            usage.counters.decrement_pending_reports()
+            usage.counters.decrement_pending_reports()
+
         assert_current_pending(
             pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-1"
         )
+
+        assert mock_log.error.call_count == 2
+        messages = [call.args[0] for call in mock_log.error.call_args_list]
+        assert_counter_underflow_message(messages[0], "flows")
+        assert_counter_underflow_message(messages[1], "reports")
+        assert mock_log.warn.call_count == 0
+
+    def test_pending_report_lease_double_release_logs_without_decrementing_other_reports(
+        self, tmp_path
+    ):
+        pending_path = tmp_path / "usage-pending"
+        usage.set_pending_path(str(pending_path))
+        first = usage.counters.admit_pending_report()
+        second = usage.counters.admit_pending_report()
+        assert_current_pending(
+            pending_path, flows=0, buffered=0, reports=2, flush_request_id="admitted"
+        )
+
+        mock_log = MagicMock()
+        with patch.object(usage.counters.ctx, "log", mock_log, create=True):
+            first.release()
+            first.release()
+
+        assert_current_pending(
+            pending_path, flows=0, buffered=0, reports=1, flush_request_id="first-released"
+        )
+        assert mock_log.error.call_count == 1
+        assert_counter_underflow_message(mock_log.error.call_args[0][0], "reports")
+
+        second.release()
+        assert_current_pending(
+            pending_path, flows=0, buffered=0, reports=0, flush_request_id="all-released"
+        )
+
+    def test_reset_for_tests_reenables_counter_underflow_signal(self, tmp_path):
+        usage.set_pending_path(str(tmp_path / "usage-pending-before-reset"))
+
+        mock_log = MagicMock()
+        with patch.object(usage.counters.ctx, "log", mock_log, create=True):
+            usage.decrement_in_flight_flows()
+            usage.counters.reset_for_tests()
+            usage.set_pending_path(str(tmp_path / "usage-pending-after-reset"))
+            usage.decrement_in_flight_flows()
+
+        assert mock_log.error.call_count == 2
+        messages = [call.args[0] for call in mock_log.error.call_args_list]
+        assert_counter_underflow_message(messages[0], "flows")
+        assert_counter_underflow_message(messages[1], "flows")
 
     def test_no_op_when_path_not_set(self, tmp_path):
         usage.set_pending_path("")

--- a/crates/runner/mitm-addon/tests/test_webhook.py
+++ b/crates/runner/mitm-addon/tests/test_webhook.py
@@ -30,6 +30,13 @@ class _QueuedUsageExecutor:
         return future
 
 
+def _release_queued_pending_reports(executor: _QueuedUsageExecutor) -> None:
+    for _, args, _ in executor.submissions:
+        pending_report = args[5]
+        assert isinstance(pending_report, usage.counters.PendingReportLease)
+        pending_report.release()
+
+
 def _assert_body_free_webhook_entry(
     entry: dict,
     *,
@@ -407,7 +414,7 @@ class TestUsageWebhookDelivery:
                 )
             assert len(executor.submissions) == 1
         finally:
-            usage.counters.decrement_pending_reports()
+            _release_queued_pending_reports(executor)
             usage.webhook.reset_delivery_capacity_for_tests()
 
         [entry] = read_jsonl_entries_after_flush(proxy_log)

--- a/crates/runner/mitm-addon/tests/test_webhook.py
+++ b/crates/runner/mitm-addon/tests/test_webhook.py
@@ -660,6 +660,39 @@ class TestUsageWebhookDelivery:
             flush_request_id="success",
         )
 
+    def test_delivery_capacity_released_when_outcome_callback_fails(
+        self, tmp_path, sync_usage_executor, usage_webhook_server
+    ):
+        proxy_log = tmp_path / "proxy.jsonl"
+        pending_path = tmp_path / "usage-pending"
+        usage.set_pending_path(str(pending_path))
+        usage_webhook_server.queue_response(204)
+
+        def fail_callback(_outcome: usage.webhook.WebhookDeliveryOutcome) -> None:
+            raise RuntimeError("callback failed")
+
+        assert usage.webhook._enqueue_webhook(
+            usage_webhook_server.url("/usage"),
+            "tok",
+            {"runId": "run-1", "events": []},
+            str(proxy_log),
+            "usage_event",
+            delivery_outcome_callback=fail_callback,
+        )
+
+        with pytest.raises(RuntimeError, match="callback failed"):
+            sync_usage_executor.shutdown(wait=True)
+
+        assert usage_webhook_server.request_count == 1
+        assert usage.webhook._pending_delivery_payload_count_for_tests() == 0
+        assert_current_pending(
+            pending_path,
+            flows=0,
+            buffered=0,
+            reports=0,
+            flush_request_id="callback-failed",
+        )
+
     def test_delivery_capacity_released_after_retry_exhaustion(
         self, tmp_path, sync_usage_executor, usage_webhook_server
     ):

--- a/crates/runner/src/proxy/stderr.rs
+++ b/crates/runner/src/proxy/stderr.rs
@@ -7,6 +7,7 @@ struct MitmdumpUsageUnderbillingStderr<'a> {
     reason: &'a str,
     underbilling_class: &'a str,
     component: &'a str,
+    counter: Option<&'a str>,
 }
 
 fn mitmdump_underbilling_fields(line: &str) -> Option<&str> {
@@ -46,6 +47,7 @@ fn parse_mitmdump_usage_underbilling_stderr(
     let mut reason = None;
     let mut underbilling_class = None;
     let mut component = None;
+    let mut counter = None;
 
     for token in tokens {
         let Some((key, value)) = token.split_once('=') else {
@@ -58,6 +60,7 @@ fn parse_mitmdump_usage_underbilling_stderr(
                 underbilling_class = Some(value);
             }
             "component" if !value.is_empty() => component = Some(value),
+            "counter" if !value.is_empty() => counter = Some(value),
             _ => {}
         }
     }
@@ -66,20 +69,34 @@ fn parse_mitmdump_usage_underbilling_stderr(
         reason: reason?,
         underbilling_class: underbilling_class?,
         component: component?,
+        counter,
     })
 }
 
 pub(super) fn log_mitmdump_stderr_line(line: &str) {
     if let Some(signal) = parse_mitmdump_usage_underbilling_stderr(line) {
-        error!(
-            target: "mitmdump",
-            r#type = "usage_underbilling",
-            reason = signal.reason,
-            underbilling_class = signal.underbilling_class,
-            component = signal.component,
-            mitmdump_stderr = %line,
-            "mitmdump usage underbilling signal"
-        );
+        if let Some(counter) = signal.counter {
+            error!(
+                target: "mitmdump",
+                r#type = "usage_underbilling",
+                reason = signal.reason,
+                underbilling_class = signal.underbilling_class,
+                component = signal.component,
+                counter = counter,
+                mitmdump_stderr = %line,
+                "mitmdump usage underbilling signal"
+            );
+        } else {
+            error!(
+                target: "mitmdump",
+                r#type = "usage_underbilling",
+                reason = signal.reason,
+                underbilling_class = signal.underbilling_class,
+                component = signal.component,
+                mitmdump_stderr = %line,
+                "mitmdump usage underbilling signal"
+            );
+        }
         return;
     }
 
@@ -127,6 +144,26 @@ mod tests {
                 reason: "pending_snapshot_write_failed",
                 underbilling_class: "risk",
                 component: "mitm_addon",
+                counter: None,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_mitmdump_usage_underbilling_stderr_extracts_counter() {
+        let signal = parse_mitmdump_usage_underbilling_stderr(
+            "[error] type=usage_underbilling reason=usage_pending_counter_underflow \
+             underbilling_class=risk component=mitm_addon counter=reports unmatched release",
+        )
+        .unwrap();
+
+        assert_eq!(
+            signal,
+            MitmdumpUsageUnderbillingStderr {
+                reason: "usage_pending_counter_underflow",
+                underbilling_class: "risk",
+                component: "mitm_addon",
+                counter: Some("reports"),
             }
         );
     }
@@ -146,6 +183,7 @@ mod tests {
                 reason: "pending_snapshot_write_failed",
                 underbilling_class: "risk",
                 component: "mitm_addon",
+                counter: None,
             }
         );
     }
@@ -165,6 +203,7 @@ mod tests {
                 reason: "pending_snapshot_write_failed",
                 underbilling_class: "risk",
                 component: "mitm_addon",
+                counter: None,
             }
         );
     }
@@ -207,6 +246,28 @@ mod tests {
         assert_event_field(&event, "reason", "pending_snapshot_write_failed");
         assert_event_field(&event, "underbilling_class", "risk");
         assert_event_field(&event, "component", "mitm_addon");
+        assert_event_field(&event, "mitmdump_stderr", line);
+        assert!(
+            !event.fields.contains_key("counter"),
+            "unexpected counter field; event={event:#?}"
+        );
+    }
+
+    #[test]
+    fn mitmdump_underbilling_stderr_reemits_counter_when_present() {
+        let line = "[error] type=usage_underbilling \
+                    reason=usage_pending_counter_underflow underbilling_class=risk \
+                    component=mitm_addon counter=reports unmatched release";
+
+        let event = capture_mitmdump_stderr_log(line);
+
+        assert_eq!(event.level, Level::ERROR);
+        assert_event_field(&event, "message", "mitmdump usage underbilling signal");
+        assert_event_field(&event, "type", "usage_underbilling");
+        assert_event_field(&event, "reason", "usage_pending_counter_underflow");
+        assert_event_field(&event, "underbilling_class", "risk");
+        assert_event_field(&event, "component", "mitm_addon");
+        assert_event_field(&event, "counter", "reports");
         assert_event_field(&event, "mitmdump_stderr", line);
     }
 }


### PR DESCRIPTION
## Summary

- emit structured mitmdump underbilling diagnostics when usage pending counters are released without matching admission
- add a one-shot pending-report lease for admitted webhook delivery ownership
- preserve the optional `counter` field when runner re-emits mitmdump underbilling stderr

Closes #19600

## Tests

- `pytest tests/test_counters.py`
- `pytest tests/test_webhook.py`
- `pytest tests/test_request_handler_usage_tracking.py`
- `cargo test --manifest-path crates/Cargo.toml -p runner proxy::stderr`
- `git diff --check`
- pre-commit hook: ruff-fmt, ruff-check, cargo-fmt, cargo-clippy, cargo-doc
