### PR TITLE
chore(rust): update dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -3257,9 +3257,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.52"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e48db7b415311b615f910b3dcaa4557bcd4bf1982379c95c223fd8c2a20e210"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
  "num-conv",


### PR DESCRIPTION
## Summary

- Updated `time` from `0.3.52` to `0.3.53`.
- Changed only `crates/Cargo.lock`.

## Dependencies not updated

- `generic-array` remains at `0.14.7` even though `0.14.9` is available.
- Reason: transitive `crypto-common v0.1.7` requires `generic-array = "=0.14.7"` through the `digest` / `crc-fast` / `aws-smithy-checksums` / `aws-sdk-s3` / `runner` dependency path. This is not constrained by a workspace `Cargo.toml` version specifier.

## Manual version bumps

- None.

## Tests

- Passed: `cargo test --workspace`.
- The first full workspace run hit one transient `vsock-guest` integration failure in `exec_operation_connection_close_cancels_child`; the exact test passed on rerun, and a second full `cargo test --workspace` run passed.
- Runtime-only adjustments used for this environment: workspace-backed `CARGO_TARGET_DIR`, `TMPDIR` with `0700` permissions, `CARGO_BUILD_JOBS=1`, `CARGO_INCREMENTAL=0`, and `CARGO_PROFILE_TEST_DEBUG=0`.
- No tests were skipped or disabled.
