### PR TITLE
refactor: use public connector catalog in platform ui

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -1506,6 +1506,54 @@ describe("CONN-03: custom connectors and connector-owned secrets", () => {
     await bdd.deleteAgent(admin, agent.agentId);
   });
 
+  it("saves a connector proposal without authorizing when required values are missing", async () => {
+    const bdd = createBddApi(context);
+    bdd.acceptAgentStorageWrites();
+    const admin = bdd.user({ orgRole: "org:admin" });
+    const agent = await bdd.createAgent(admin, {
+      displayName: "BDD Missing Proposal Value Agent",
+    });
+    const rand = randomUUID().replace(/-/g, "").slice(0, 8);
+
+    const saved = await connectorsApi.saveCustomConnectorProposal(admin, {
+      proposal: {
+        operation: "create",
+        displayName: "BDD Missing Proposal Value API",
+        prefixTemplates: [`https://${rand}.example.test/v1/`],
+        fields: [
+          {
+            key: "api_key",
+            label: "API key",
+            kind: "secret",
+            required: true,
+          },
+        ],
+        headerInjections: [
+          {
+            name: "Authorization",
+            valueTemplate: "Bearer {{secrets.api_key}}",
+          },
+        ],
+        queryInjections: [],
+      },
+      values: [],
+      agentId: agent.agentId,
+    });
+
+    expect(saved.authorizedAgentId).toBeUndefined();
+    expect(saved.connector).toMatchObject({
+      connected: false,
+      missingRequiredFields: ["api_key"],
+      configuredFieldKeys: [],
+    });
+    await expect(
+      connectorsApi.readAgentCustomConnectors(admin, agent.agentId),
+    ).resolves.toStrictEqual([]);
+
+    await connectorsApi.deleteCustomConnector(admin, saved.connector.id);
+    await bdd.deleteAgent(admin, agent.agentId);
+  });
+
   it("rejects connector proposal host variables that change URL structure", async () => {
     const bdd = createBddApi(context);
     const admin = bdd.user({ orgRole: "org:admin" });

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
@@ -1731,13 +1731,18 @@ export function createConnectorBddApi(context: TestContext) {
       agentId: string,
       enabledIds: readonly string[],
       statuses: readonly (200 | 400 | 401 | 403 | 404)[],
+      operation?: "replace" | "add" | "remove",
     ) {
       const client = setupApp({ context })(zeroAgentCustomConnectorsContract);
+      const body =
+        operation === undefined
+          ? { enabledIds: [...enabledIds] }
+          : { enabledIds: [...enabledIds], operation };
       return await accept(
         client.update({
           params: { id: agentId },
           headers: authenticate(actor),
-          body: { enabledIds: [...enabledIds] },
+          body,
         }),
         statuses,
       );
@@ -1747,12 +1752,14 @@ export function createConnectorBddApi(context: TestContext) {
       actor: ApiTestUser,
       agentId: string,
       enabledIds: readonly string[],
+      operation?: "replace" | "add" | "remove",
     ): Promise<readonly string[]> {
       const response = await api.requestUpdateAgentCustomConnectors(
         actor,
         agentId,
         enabledIds,
         [200],
+        operation,
       );
       expectStatus(response, 200);
       return response.body.enabledIds;

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-user-config.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-user-config.ts
@@ -298,15 +298,20 @@ export function createUserConfigBddApi(context: TestContext) {
       credential: Credential,
       agentId: string,
       enabledTypes: readonly string[],
+      operation?: "replace" | "add" | "remove",
     ): Promise<{ readonly enabledTypes: string[] }> {
       const client = setupAppWithRoutes({ context, routes: userConfigRoutes })(
         zeroUserConnectorsContract,
       );
+      const body =
+        operation === undefined
+          ? { enabledTypes: [...enabledTypes] }
+          : { enabledTypes: [...enabledTypes], operation };
       const response = await accept(
         client.update({
           headers: authenticate(credential),
           params: { id: agentId },
-          body: { enabledTypes: [...enabledTypes] },
+          body,
         }),
         [200],
       );
@@ -318,15 +323,20 @@ export function createUserConfigBddApi(context: TestContext) {
       agentId: string,
       enabledTypes: readonly string[],
       statuses: readonly (200 | 400 | 401 | 403 | 404)[],
+      operation?: "replace" | "add" | "remove",
     ) {
       const client = setupAppWithRoutes({ context, routes: userConfigRoutes })(
         zeroUserConnectorsContract,
       );
+      const body =
+        operation === undefined
+          ? { enabledTypes: [...enabledTypes] }
+          : { enabledTypes: [...enabledTypes], operation };
       return await accept(
         client.update({
           headers: authenticate(credential),
           params: { id: agentId },
-          body: { enabledTypes: [...enabledTypes] },
+          body,
         }),
         statuses,
       );

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -3467,6 +3467,105 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     expect(cancelled.status).toBe("cancelled");
   });
 
+  it("omits custom connector auth entries backed only by missing optional fields", async () => {
+    const api = createRunsAutomationsApi(context);
+    const connectors = createConnectorBddApi(context);
+    const fw = createFirewallApi(context);
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+    const rand = randomUUID().replace(/-/g, "").slice(0, 8);
+
+    const saved = await connectors.saveCustomConnectorProposal(actor, {
+      proposal: {
+        operation: "create",
+        displayName: "BDD Optional Runtime",
+        prefixTemplates: [`https://${rand}.optional.test/v1/`],
+        fields: [
+          {
+            key: "api_key",
+            label: "API key",
+            kind: "secret",
+            required: true,
+          },
+          {
+            key: "secondary_token",
+            label: "Secondary token",
+            kind: "secret",
+            required: false,
+          },
+          {
+            key: "tenant_id",
+            label: "Tenant ID",
+            kind: "variable",
+            required: false,
+          },
+        ],
+        headerInjections: [
+          {
+            name: "Authorization",
+            valueTemplate: "Bearer {{secrets.api_key}}",
+          },
+          {
+            name: "X-Secondary",
+            valueTemplate: "{{secrets.secondary_token}}",
+          },
+        ],
+        queryInjections: [
+          {
+            name: "tenant",
+            valueTemplate: "{{variables.tenant_id}}",
+          },
+        ],
+      },
+      values: [{ key: "api_key", kind: "secret", value: "optional-primary" }],
+      agentId,
+    });
+
+    const run = await api.createRun(actor, {
+      agentId,
+      prompt: "use the optional custom connector",
+      modelProvider: "anthropic-api-key",
+    });
+    await api.heartbeatRunner(runnerGroup);
+    const claim = await api.claimRunnerJob(run.runId);
+
+    const idPart = saved.connector.id.replaceAll("-", "");
+    const internalName = `custom_connector_${idPart}`;
+    const secretKey = `CUSTOM_${idPart}_S_API_KEY`;
+    const secondarySecretKey = `CUSTOM_${idPart}_S_SECONDARY_TOKEN`;
+    const tenantVarKey = `CUSTOM_${idPart}_V_TENANT_ID`;
+    const customApis = inlineFirewallApis(claim.firewalls, internalName);
+    expect(customApis[0]?.auth?.headers).toStrictEqual({
+      Authorization: `Bearer \${{ secrets.${secretKey} }}`,
+    });
+    expect(customApis[0]?.auth?.query).toStrictEqual({});
+    expect(JSON.stringify(customApis)).not.toContain(secondarySecretKey);
+    expect(JSON.stringify(customApis)).not.toContain(tenantVarKey);
+
+    if (!claim.encryptedSecrets) {
+      throw new Error("Expected the custom claim to carry encrypted secrets");
+    }
+    const resolved = await fw.requestFirewallAuth(
+      { authorization: `Bearer ${claim.sandboxToken}` },
+      {
+        encryptedSecrets: claim.encryptedSecrets,
+        authHeaders: {
+          Authorization: `Bearer \${{ secrets.${secretKey} }}`,
+        },
+      },
+      [200],
+    );
+    if (resolved.status !== 200) {
+      throw new Error("Expected the optional custom firewall auth to resolve");
+    }
+    expect(resolved.body.headers).toStrictEqual({
+      Authorization: "Bearer optional-primary",
+    });
+
+    await api.requestCancelRun(actor, run.runId, [200]);
+    const cancelled = await api.readRun(actor, run.runId);
+    expect(cancelled.status).toBe("cancelled");
+  });
+
   it("keeps connector-owned vars out of custom connector base urls", async () => {
     const api = createRunsAutomationsApi(context);
     const authOrg = createAuthOrgAgentsBddApi(context);

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -3566,6 +3566,62 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     expect(cancelled.status).toBe("cancelled");
   });
 
+  it("skips custom connectors when all auth entries require missing optional fields", async () => {
+    const api = createRunsAutomationsApi(context);
+    const connectors = createConnectorBddApi(context);
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+    const rand = randomUUID().replace(/-/g, "").slice(0, 8);
+
+    const saved = await connectors.saveCustomConnectorProposal(actor, {
+      proposal: {
+        operation: "create",
+        displayName: "BDD Optional Only Runtime",
+        prefixTemplates: [`https://${rand}.optional-only.test/v1/`],
+        fields: [
+          {
+            key: "secret",
+            label: "API key",
+            kind: "secret",
+            required: false,
+          },
+        ],
+        headerInjections: [
+          {
+            name: "Authorization",
+            valueTemplate: "Bearer {{secrets.secret}}",
+          },
+        ],
+        queryInjections: [],
+      },
+      values: [
+        {
+          key: "secret",
+          kind: "secret",
+          value: "optional-only-secret",
+        },
+      ],
+      agentId,
+    });
+    expect(saved.authorizedAgentId).toBe(agentId);
+    await connectors.deleteCustomConnectorSecret(actor, saved.connector.id);
+
+    const run = await api.createRun(actor, {
+      agentId,
+      prompt: "use the optional-only custom connector",
+      modelProvider: "anthropic-api-key",
+    });
+    await api.heartbeatRunner(runnerGroup);
+    const claim = await api.claimRunnerJob(run.runId);
+
+    const internalName = `custom_connector_${saved.connector.id.replaceAll("-", "")}`;
+    expect(findFirewallEntry(claim.firewalls, internalName)).toBeUndefined();
+    expect(claim.networkPolicies ?? {}).not.toHaveProperty(internalName);
+
+    await api.requestCancelRun(actor, run.runId, [200]);
+    const cancelled = await api.readRun(actor, run.runId);
+    expect(cancelled.status).toBe("cancelled");
+  });
+
   it("keeps connector-owned vars out of custom connector base urls", async () => {
     const api = createRunsAutomationsApi(context);
     const authOrg = createAuthOrgAgentsBddApi(context);

--- a/turbo/apps/api/src/signals/routes/__tests__/user-config.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/user-config.bdd.test.ts
@@ -313,6 +313,14 @@ describe("AUTH-03 agent user connectors", () => {
     );
     expectApiError(missingUpdate.body);
     expect(missingUpdate.body.error.code).toBe("NOT_FOUND");
+    const missingEmptyUpdate = await cfg.requestUpdateUserConnectors(
+      admin,
+      missingAgentId,
+      [],
+      [404],
+    );
+    expectApiError(missingEmptyUpdate.body);
+    expect(missingEmptyUpdate.body.error.code).toBe("NOT_FOUND");
 
     const crossOrgRead = await cfg.requestReadUserConnectors(
       otherAdmin,

--- a/turbo/apps/api/src/signals/routes/__tests__/user-config.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/user-config.bdd.test.ts
@@ -337,6 +337,34 @@ describe("AUTH-03 agent user connectors", () => {
     expect(readAfterPat.enabledTypes).toStrictEqual(["github"]);
   });
 
+  it("serializes concurrent user-connector replaces for the same agent", async () => {
+    const admin = api.user();
+    await onboardAdmin(admin, { slug: slug("bdd-uc-b1r") });
+    api.acceptAgentStorageWrites();
+    const agent = await api.createAgent(admin, {
+      displayName: "BDD Concurrent Connector Agent",
+    });
+
+    const sameSetUpdates = await Promise.all([
+      cfg.updateUserConnectors(admin, agent.agentId, ["github", "slack"]),
+      cfg.updateUserConnectors(admin, agent.agentId, ["github", "slack"]),
+    ]);
+    for (const update of sameSetUpdates) {
+      expect(new Set(update.enabledTypes)).toStrictEqual(
+        new Set(["github", "slack"]),
+      );
+    }
+
+    await Promise.all([
+      cfg.updateUserConnectors(admin, agent.agentId, ["github"]),
+      cfg.updateUserConnectors(admin, agent.agentId, ["slack"]),
+    ]);
+    const readBack = await cfg.readUserConnectors(admin, agent.agentId);
+    expect(readBack.enabledTypes).toHaveLength(1);
+    const enabledType = readBack.enabledTypes[0];
+    expect(["github", "slack"]).toContain(enabledType);
+  });
+
   it("recomposes a stale compose-target on user-connector updates through public APIs", async () => {
     const admin = api.user();
     await onboardAdmin(admin, { slug: slug("bdd-uc-b1c") });

--- a/turbo/apps/api/src/signals/routes/__tests__/user-config.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/user-config.bdd.test.ts
@@ -371,6 +371,26 @@ describe("AUTH-03 agent user connectors", () => {
     expect(readBack.enabledTypes).toHaveLength(1);
     const enabledType = readBack.enabledTypes[0];
     expect(["github", "slack"]).toContain(enabledType);
+
+    await cfg.updateUserConnectors(admin, agent.agentId, [], "replace");
+    await Promise.all([
+      cfg.updateUserConnectors(admin, agent.agentId, ["github"], "add"),
+      cfg.updateUserConnectors(admin, agent.agentId, ["slack"], "add"),
+    ]);
+    const readAfterAdds = await cfg.readUserConnectors(admin, agent.agentId);
+    expect(new Set(readAfterAdds.enabledTypes)).toStrictEqual(
+      new Set(["github", "slack"]),
+    );
+
+    await Promise.all([
+      cfg.updateUserConnectors(admin, agent.agentId, ["github"], "remove"),
+      cfg.updateUserConnectors(admin, agent.agentId, ["slack"], "add"),
+    ]);
+    const readAfterRemoveAdd = await cfg.readUserConnectors(
+      admin,
+      agent.agentId,
+    );
+    expect(readAfterRemoveAdd.enabledTypes).toStrictEqual(["slack"]);
   });
 
   it("recomposes a stale compose-target on user-connector updates through public APIs", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-agent-custom-connectors.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-agent-custom-connectors.test.ts
@@ -288,6 +288,52 @@ describe("PUT /api/zero/agents/:id/custom-connectors", () => {
     );
     expect(readBack).toHaveLength(1);
     expect([c1.id, c2.id]).toContain(readBack[0]);
+
+    await connectors.updateAgentCustomConnectors(
+      actor,
+      agent.agentId,
+      [],
+      "replace",
+    );
+    await Promise.all([
+      connectors.updateAgentCustomConnectors(
+        actor,
+        agent.agentId,
+        [c1.id],
+        "add",
+      ),
+      connectors.updateAgentCustomConnectors(
+        actor,
+        agent.agentId,
+        [c2.id],
+        "add",
+      ),
+    ]);
+    const readAfterAdds = await connectors.readAgentCustomConnectors(
+      actor,
+      agent.agentId,
+    );
+    expect(new Set(readAfterAdds)).toStrictEqual(new Set([c1.id, c2.id]));
+
+    await Promise.all([
+      connectors.updateAgentCustomConnectors(
+        actor,
+        agent.agentId,
+        [c1.id],
+        "remove",
+      ),
+      connectors.updateAgentCustomConnectors(
+        actor,
+        agent.agentId,
+        [c2.id],
+        "add",
+      ),
+    ]);
+    const readAfterRemoveAdd = await connectors.readAgentCustomConnectors(
+      actor,
+      agent.agentId,
+    );
+    expect(readAfterRemoveAdd).toStrictEqual([c2.id]);
   });
 
   it("clears authorizations with empty array", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-agent-custom-connectors.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-agent-custom-connectors.test.ts
@@ -234,9 +234,11 @@ describe("PUT /api/zero/agents/:id/custom-connectors", () => {
     );
 
     expect(new Set(response)).toStrictEqual(new Set([c1.id, c2.id]));
-    await expect(
-      connectors.readAgentCustomConnectors(actor, agent.agentId),
-    ).resolves.toStrictEqual(response);
+    const readBack = await connectors.readAgentCustomConnectors(
+      actor,
+      agent.agentId,
+    );
+    expect([...readBack].sort()).toStrictEqual([...response].sort());
   });
 
   it("replaces the list atomically", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-agent-custom-connectors.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-agent-custom-connectors.test.ts
@@ -63,7 +63,10 @@ function zeroTokenFor(
   });
 }
 
-async function createCustomConnector(actor: ApiTestUser, slug: string) {
+async function createUnconfiguredCustomConnector(
+  actor: ApiTestUser,
+  slug: string,
+) {
   return await connectors.createCustomConnector(actor, {
     displayName: `Connector ${slug}`,
     slug,
@@ -71,6 +74,16 @@ async function createCustomConnector(actor: ApiTestUser, slug: string) {
     headerName: "Authorization",
     headerTemplate: "Bearer {{secret}}",
   });
+}
+
+async function createCustomConnector(actor: ApiTestUser, slug: string) {
+  const connector = await createUnconfiguredCustomConnector(actor, slug);
+  await connectors.setCustomConnectorSecret(
+    actor,
+    connector.id,
+    `${slug}-secret`,
+  );
+  return connector;
 }
 
 describe("GET /api/zero/agents/:id/custom-connectors", () => {
@@ -241,6 +254,32 @@ describe("PUT /api/zero/agents/:id/custom-connectors", () => {
     expect([...readBack].sort()).toStrictEqual([...response].sort());
   });
 
+  it("rejects enabling custom connectors without required user values", async () => {
+    const actor = bdd.user();
+    const agent = await createAgent(actor, { displayName: "Test Agent" });
+    const connector = await createUnconfiguredCustomConnector(
+      actor,
+      "missing-secret",
+    );
+
+    const response = await connectors.requestUpdateAgentCustomConnectors(
+      actor,
+      agent.agentId,
+      [connector.id],
+      [400],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: `Custom connector ids are not configured for this user: ${connector.id}`,
+        code: "VALIDATION_ERROR",
+      },
+    });
+    await expect(
+      connectors.readAgentCustomConnectors(actor, agent.agentId),
+    ).resolves.toStrictEqual([]);
+  });
+
   it("replaces the list atomically", async () => {
     const actor = bdd.user();
     const agent = await createAgent(actor, { displayName: "Test Agent" });
@@ -353,6 +392,29 @@ describe("PUT /api/zero/agents/:id/custom-connectors", () => {
     );
 
     expect(cleared).toStrictEqual([]);
+    await expect(
+      connectors.readAgentCustomConnectors(actor, agent.agentId),
+    ).resolves.toStrictEqual([]);
+  });
+
+  it("allows removing an enabled custom connector after its secret is deleted", async () => {
+    const actor = bdd.user();
+    const agent = await createAgent(actor, { displayName: "Test Agent" });
+    const connector = await createCustomConnector(actor, "remove-unconfigured");
+
+    await connectors.updateAgentCustomConnectors(actor, agent.agentId, [
+      connector.id,
+    ]);
+    await connectors.deleteCustomConnectorSecret(actor, connector.id);
+
+    const updated = await connectors.updateAgentCustomConnectors(
+      actor,
+      agent.agentId,
+      [connector.id],
+      "remove",
+    );
+
+    expect(updated).toStrictEqual([]);
     await expect(
       connectors.readAgentCustomConnectors(actor, agent.agentId),
     ).resolves.toStrictEqual([]);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-agent-custom-connectors.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-agent-custom-connectors.test.ts
@@ -112,6 +112,44 @@ async function createOptionalOnlyCustomConnector(
   });
 }
 
+async function createCustomConnectorWithOptionalPrefixVariable(
+  actor: ApiTestUser,
+  slug: string,
+) {
+  const connector = await connectors.createCustomConnector(actor, {
+    displayName: `Connector ${slug}`,
+    slug,
+    prefixTemplates: [`https://{{variables.subdomain}}.${slug}.example.test`],
+    fields: [
+      {
+        key: "secret",
+        label: "API key",
+        kind: "secret",
+        required: true,
+      },
+      {
+        key: "subdomain",
+        label: "Subdomain",
+        kind: "variable",
+        required: false,
+      },
+    ],
+    headerInjections: [
+      {
+        name: "Authorization",
+        valueTemplate: "Bearer {{secrets.secret}}",
+      },
+    ],
+    queryInjections: [],
+  });
+  await connectors.setCustomConnectorSecret(
+    actor,
+    connector.id,
+    `${slug}-secret`,
+  );
+  return connector;
+}
+
 describe("GET /api/zero/agents/:id/custom-connectors", () => {
   it("returns 401 when the request is unauthenticated", async () => {
     const response = await connectors.requestAgentCustomConnectors(
@@ -339,6 +377,32 @@ describe("PUT /api/zero/agents/:id/custom-connectors", () => {
     const connector = await createOptionalOnlyCustomConnector(
       actor,
       "missing-optional-auth",
+    );
+
+    const response = await connectors.requestUpdateAgentCustomConnectors(
+      actor,
+      agent.agentId,
+      [connector.id],
+      [400],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: `Custom connector ids are not configured for this user: ${connector.id}`,
+        code: "VALIDATION_ERROR",
+      },
+    });
+    await expect(
+      connectors.readAgentCustomConnectors(actor, agent.agentId),
+    ).resolves.toStrictEqual([]);
+  });
+
+  it("rejects enabling custom connectors without any configured base urls", async () => {
+    const actor = bdd.user();
+    const agent = await createAgent(actor, { displayName: "Test Agent" });
+    const connector = await createCustomConnectorWithOptionalPrefixVariable(
+      actor,
+      "missing-prefix-variable",
     );
 
     const response = await connectors.requestUpdateAgentCustomConnectors(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-agent-custom-connectors.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-agent-custom-connectors.test.ts
@@ -280,6 +280,33 @@ describe("PUT /api/zero/agents/:id/custom-connectors", () => {
     ).resolves.toStrictEqual([]);
   });
 
+  it("returns agent not found before connector configuration errors", async () => {
+    const owner = bdd.user();
+    const requester = bdd.user({ orgId: owner.orgId });
+    const agent = await createAgent(owner, {
+      displayName: "Private Agent",
+      visibility: "private",
+    });
+    const connector = await createUnconfiguredCustomConnector(
+      requester,
+      "hidden-agent-order",
+    );
+
+    const response = await connectors.requestUpdateAgentCustomConnectors(
+      requester,
+      agent.agentId,
+      [connector.id],
+      [404],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: `Agent not found: ${agent.agentId}`,
+        code: "NOT_FOUND",
+      },
+    });
+  });
+
   it("replaces the list atomically", async () => {
     const actor = bdd.user();
     const agent = await createAgent(actor, { displayName: "Test Agent" });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-agent-custom-connectors.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-agent-custom-connectors.test.ts
@@ -258,6 +258,38 @@ describe("PUT /api/zero/agents/:id/custom-connectors", () => {
     ).resolves.toStrictEqual([c2.id]);
   });
 
+  it("serializes concurrent custom connector replaces for the same agent", async () => {
+    const actor = bdd.user();
+    const agent = await createAgent(actor, { displayName: "Concurrent Agent" });
+    const c1 = await createCustomConnector(actor, "conc-1");
+    const c2 = await createCustomConnector(actor, "conc-2");
+
+    const sameSetUpdates = await Promise.all([
+      connectors.updateAgentCustomConnectors(actor, agent.agentId, [
+        c1.id,
+        c2.id,
+      ]),
+      connectors.updateAgentCustomConnectors(actor, agent.agentId, [
+        c1.id,
+        c2.id,
+      ]),
+    ]);
+    for (const update of sameSetUpdates) {
+      expect(new Set(update)).toStrictEqual(new Set([c1.id, c2.id]));
+    }
+
+    await Promise.all([
+      connectors.updateAgentCustomConnectors(actor, agent.agentId, [c1.id]),
+      connectors.updateAgentCustomConnectors(actor, agent.agentId, [c2.id]),
+    ]);
+    const readBack = await connectors.readAgentCustomConnectors(
+      actor,
+      agent.agentId,
+    );
+    expect(readBack).toHaveLength(1);
+    expect([c1.id, c2.id]).toContain(readBack[0]);
+  });
+
   it("clears authorizations with empty array", async () => {
     const actor = bdd.user();
     const agent = await createAgent(actor, { displayName: "Test Agent" });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-agent-custom-connectors.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-agent-custom-connectors.test.ts
@@ -86,6 +86,32 @@ async function createCustomConnector(actor: ApiTestUser, slug: string) {
   return connector;
 }
 
+async function createOptionalOnlyCustomConnector(
+  actor: ApiTestUser,
+  slug: string,
+) {
+  return await connectors.createCustomConnector(actor, {
+    displayName: `Connector ${slug}`,
+    slug,
+    prefixTemplates: [`https://${slug}.example.test`],
+    fields: [
+      {
+        key: "api_key",
+        label: "API key",
+        kind: "secret",
+        required: false,
+      },
+    ],
+    headerInjections: [
+      {
+        name: "Authorization",
+        valueTemplate: "Bearer {{secrets.api_key}}",
+      },
+    ],
+    queryInjections: [],
+  });
+}
+
 describe("GET /api/zero/agents/:id/custom-connectors", () => {
   it("returns 401 when the request is unauthenticated", async () => {
     const response = await connectors.requestAgentCustomConnectors(
@@ -305,6 +331,32 @@ describe("PUT /api/zero/agents/:id/custom-connectors", () => {
         code: "NOT_FOUND",
       },
     });
+  });
+
+  it("rejects enabling custom connectors without any configured auth entries", async () => {
+    const actor = bdd.user();
+    const agent = await createAgent(actor, { displayName: "Test Agent" });
+    const connector = await createOptionalOnlyCustomConnector(
+      actor,
+      "missing-optional-auth",
+    );
+
+    const response = await connectors.requestUpdateAgentCustomConnectors(
+      actor,
+      agent.agentId,
+      [connector.id],
+      [400],
+    );
+
+    expect(response.body).toStrictEqual({
+      error: {
+        message: `Custom connector ids are not configured for this user: ${connector.id}`,
+        code: "VALIDATION_ERROR",
+      },
+    });
+    await expect(
+      connectors.readAgentCustomConnectors(actor, agent.agentId),
+    ).resolves.toStrictEqual([]);
   });
 
   it("replaces the list atomically", async () => {

--- a/turbo/apps/api/src/signals/routes/zero-agents.ts
+++ b/turbo/apps/api/src/signals/routes/zero-agents.ts
@@ -742,12 +742,14 @@ const updateAgentCustomConnectorsInner$ = command(
 
     const writeDb = set(writeDb$);
     const enabledIds = Array.from(new Set(body.data.enabledIds));
+    const operation = body.data.operation ?? "replace";
 
     const replaced = await replaceUserCustomConnectors(writeDb, {
       orgId: auth.orgId,
       userId: auth.userId,
       agentId: params.id,
       enabledIds,
+      operation,
     });
     signal.throwIfAborted();
     if (replaced.status === "agentNotFound") {
@@ -767,7 +769,7 @@ const updateAgentCustomConnectorsInner$ = command(
 
     return {
       status: 200 as const,
-      body: { enabledIds: [...enabledIds] },
+      body: { enabledIds: [...replaced.enabledIds] },
     };
   },
 );

--- a/turbo/apps/api/src/signals/routes/zero-agents.ts
+++ b/turbo/apps/api/src/signals/routes/zero-agents.ts
@@ -827,18 +827,21 @@ const updateAgentUserConnectorsInner$ = command(
       );
     }
 
-    const availability = await get(
-      userConnectorAvailability(auth.orgId, auth.userId),
-    );
-    signal.throwIfAborted();
-    const unavailableTypes = unavailableUserConnectorTypes(
-      availability,
-      parsedTypes,
-    );
-    if (unavailableTypes.length > 0) {
-      return validationError(
-        `Connector types are not available: ${unavailableTypes.join(", ")}`,
+    const operation = body.data.operation ?? "replace";
+    if (operation !== "remove") {
+      const availability = await get(
+        userConnectorAvailability(auth.orgId, auth.userId),
       );
+      signal.throwIfAborted();
+      const unavailableTypes = unavailableUserConnectorTypes(
+        availability,
+        parsedTypes,
+      );
+      if (unavailableTypes.length > 0) {
+        return validationError(
+          `Connector types are not available: ${unavailableTypes.join(", ")}`,
+        );
+      }
     }
 
     const replaced = await replaceUserConnectors(writeDb, {
@@ -846,8 +849,11 @@ const updateAgentUserConnectorsInner$ = command(
       userId: auth.userId,
       agentId: params.id,
       enabledTypes: parsedTypes,
+      operation,
       allowMissingZeroAgentForEmptyReplace:
-        agent.zeroAgentId === null && parsedTypes.length === 0,
+        operation === "replace" &&
+        agent.zeroAgentId === null &&
+        parsedTypes.length === 0,
     });
     signal.throwIfAborted();
     if (replaced.status === "agentNotFound") {
@@ -870,7 +876,7 @@ const updateAgentUserConnectorsInner$ = command(
 
     return {
       status: 200 as const,
-      body: { enabledTypes: parsedTypes },
+      body: { enabledTypes: [...replaced.enabledTypes] },
     };
   },
 );

--- a/turbo/apps/api/src/signals/routes/zero-agents.ts
+++ b/turbo/apps/api/src/signals/routes/zero-agents.ts
@@ -47,8 +47,8 @@ import {
   userConnectorAvailability,
 } from "../services/connector-availability.service";
 import {
-  replaceUserConnectors,
-  replaceUserCustomConnectors,
+  updateUserConnectors,
+  updateUserCustomConnectors,
 } from "../services/user-connectors.service";
 import type { RouteEntry } from "../route-entry";
 
@@ -744,7 +744,7 @@ const updateAgentCustomConnectorsInner$ = command(
     const enabledIds = Array.from(new Set(body.data.enabledIds));
     const operation = body.data.operation ?? "replace";
 
-    const replaced = await replaceUserCustomConnectors(writeDb, {
+    const updated = await updateUserCustomConnectors(writeDb, {
       orgId: auth.orgId,
       userId: auth.userId,
       agentId: params.id,
@@ -752,15 +752,15 @@ const updateAgentCustomConnectorsInner$ = command(
       operation,
     });
     signal.throwIfAborted();
-    if (replaced.status === "agentNotFound") {
+    if (updated.status === "agentNotFound") {
       return agentNotFound(params.id);
     }
-    if (replaced.status === "customConnectorsNotFound") {
+    if (updated.status === "customConnectorsNotFound") {
       return {
         status: 400 as const,
         body: {
           error: {
-            message: `Unknown custom connector ids: ${replaced.missingIds.join(", ")}`,
+            message: `Unknown custom connector ids: ${updated.missingIds.join(", ")}`,
             code: "VALIDATION_ERROR",
           },
         },
@@ -769,7 +769,7 @@ const updateAgentCustomConnectorsInner$ = command(
 
     return {
       status: 200 as const,
-      body: { enabledIds: [...replaced.enabledIds] },
+      body: { enabledIds: [...updated.enabledIds] },
     };
   },
 );
@@ -846,7 +846,7 @@ const updateAgentUserConnectorsInner$ = command(
       }
     }
 
-    const replaced = await replaceUserConnectors(writeDb, {
+    const updated = await updateUserConnectors(writeDb, {
       orgId: auth.orgId,
       userId: auth.userId,
       agentId: params.id,
@@ -858,7 +858,7 @@ const updateAgentUserConnectorsInner$ = command(
         parsedTypes.length === 0,
     });
     signal.throwIfAborted();
-    if (replaced.status === "agentNotFound") {
+    if (updated.status === "agentNotFound") {
       return agentNotFound(params.id);
     }
 
@@ -878,7 +878,7 @@ const updateAgentUserConnectorsInner$ = command(
 
     return {
       status: 200 as const,
-      body: { enabledTypes: [...replaced.enabledTypes] },
+      body: { enabledTypes: [...updated.enabledTypes] },
     };
   },
 );

--- a/turbo/apps/api/src/signals/routes/zero-agents.ts
+++ b/turbo/apps/api/src/signals/routes/zero-agents.ts
@@ -15,7 +15,6 @@ import {
 } from "@vm0/connectors/connectors";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { orgCustomConnectors } from "@vm0/db/schema/org-custom-connector";
-import { userCustomConnectors } from "@vm0/db/schema/user-custom-connector";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
@@ -48,7 +47,10 @@ import {
   unavailableUserConnectorTypes,
   userConnectorAvailability,
 } from "../services/connector-availability.service";
-import { replaceUserConnectors } from "../services/user-connectors.service";
+import {
+  replaceUserConnectors,
+  replaceUserCustomConnectors,
+} from "../services/user-connectors.service";
 import type { RouteEntry } from "../route-entry";
 
 const PUBLIC_AGENT_LIMIT = 7;
@@ -740,7 +742,7 @@ const updateAgentCustomConnectorsInner$ = command(
     }
 
     const writeDb = set(writeDb$);
-    const enabledIds = body.data.enabledIds;
+    const enabledIds = Array.from(new Set(body.data.enabledIds));
 
     if (enabledIds.length > 0) {
       const found = await writeDb
@@ -774,31 +776,16 @@ const updateAgentCustomConnectorsInner$ = command(
       }
     }
 
-    await writeDb.transaction(async (tx) => {
-      await tx
-        .delete(userCustomConnectors)
-        .where(
-          and(
-            eq(userCustomConnectors.orgId, auth.orgId),
-            eq(userCustomConnectors.userId, auth.userId),
-            eq(userCustomConnectors.agentId, params.id),
-          ),
-        );
-
-      if (enabledIds.length > 0) {
-        await tx.insert(userCustomConnectors).values(
-          enabledIds.map((customConnectorId) => {
-            return {
-              orgId: auth.orgId,
-              userId: auth.userId,
-              agentId: params.id,
-              customConnectorId,
-            };
-          }),
-        );
-      }
+    const replaced = await replaceUserCustomConnectors(writeDb, {
+      orgId: auth.orgId,
+      userId: auth.userId,
+      agentId: params.id,
+      enabledIds,
     });
     signal.throwIfAborted();
+    if (!replaced) {
+      return agentNotFound(params.id);
+    }
 
     return {
       status: 200 as const,
@@ -875,13 +862,16 @@ const updateAgentUserConnectorsInner$ = command(
       );
     }
 
-    await replaceUserConnectors(writeDb, {
+    const replaced = await replaceUserConnectors(writeDb, {
       orgId: auth.orgId,
       userId: auth.userId,
       agentId: params.id,
       enabledTypes: parsedTypes,
     });
     signal.throwIfAborted();
+    if (!replaced) {
+      return agentNotFound(params.id);
+    }
 
     await set(
       recomposeAgentIfStale$,

--- a/turbo/apps/api/src/signals/routes/zero-agents.ts
+++ b/turbo/apps/api/src/signals/routes/zero-agents.ts
@@ -15,7 +15,6 @@ import {
 } from "@vm0/connectors/connectors";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { orgCustomConnectors } from "@vm0/db/schema/org-custom-connector";
-import { userConnectors } from "@vm0/db/schema/user-connector";
 import { userCustomConnectors } from "@vm0/db/schema/user-custom-connector";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 
@@ -49,6 +48,7 @@ import {
   unavailableUserConnectorTypes,
   userConnectorAvailability,
 } from "../services/connector-availability.service";
+import { replaceUserConnectors } from "../services/user-connectors.service";
 import type { RouteEntry } from "../route-entry";
 
 const PUBLIC_AGENT_LIMIT = 7;
@@ -875,29 +875,11 @@ const updateAgentUserConnectorsInner$ = command(
       );
     }
 
-    await writeDb.transaction(async (tx) => {
-      await tx
-        .delete(userConnectors)
-        .where(
-          and(
-            eq(userConnectors.orgId, auth.orgId),
-            eq(userConnectors.userId, auth.userId),
-            eq(userConnectors.agentId, params.id),
-          ),
-        );
-
-      if (parsedTypes.length > 0) {
-        await tx.insert(userConnectors).values(
-          parsedTypes.map((connectorType) => {
-            return {
-              orgId: auth.orgId,
-              userId: auth.userId,
-              agentId: params.id,
-              connectorType,
-            };
-          }),
-        );
-      }
+    await replaceUserConnectors(writeDb, {
+      orgId: auth.orgId,
+      userId: auth.userId,
+      agentId: params.id,
+      enabledTypes: parsedTypes,
     });
     signal.throwIfAborted();
 

--- a/turbo/apps/api/src/signals/routes/zero-agents.ts
+++ b/turbo/apps/api/src/signals/routes/zero-agents.ts
@@ -766,6 +766,11 @@ const updateAgentCustomConnectorsInner$ = command(
         },
       };
     }
+    if (updated.status === "customConnectorsNotConfigured") {
+      return validationError(
+        `Custom connector ids are not configured for this user: ${updated.unconfiguredIds.join(", ")}`,
+      );
+    }
 
     return {
       status: 200 as const,

--- a/turbo/apps/api/src/signals/routes/zero-agents.ts
+++ b/turbo/apps/api/src/signals/routes/zero-agents.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import { command, computed } from "ccstate";
-import { and, count, eq, inArray } from "drizzle-orm";
+import { and, count, eq } from "drizzle-orm";
 import { zeroAgentCustomConnectorsContract } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
 import {
   zeroAgentsByIdContract,
@@ -14,7 +14,6 @@ import {
   type ConnectorType,
 } from "@vm0/connectors/connectors";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
-import { orgCustomConnectors } from "@vm0/db/schema/org-custom-connector";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
@@ -744,38 +743,6 @@ const updateAgentCustomConnectorsInner$ = command(
     const writeDb = set(writeDb$);
     const enabledIds = Array.from(new Set(body.data.enabledIds));
 
-    if (enabledIds.length > 0) {
-      const found = await writeDb
-        .select({ id: orgCustomConnectors.id })
-        .from(orgCustomConnectors)
-        .where(
-          and(
-            eq(orgCustomConnectors.orgId, auth.orgId),
-            inArray(orgCustomConnectors.id, enabledIds),
-          ),
-        );
-      signal.throwIfAborted();
-      const foundSet = new Set(
-        found.map((row) => {
-          return row.id;
-        }),
-      );
-      const missing = enabledIds.filter((id) => {
-        return !foundSet.has(id);
-      });
-      if (missing.length > 0) {
-        return {
-          status: 400 as const,
-          body: {
-            error: {
-              message: `Unknown custom connector ids: ${missing.join(", ")}`,
-              code: "VALIDATION_ERROR",
-            },
-          },
-        };
-      }
-    }
-
     const replaced = await replaceUserCustomConnectors(writeDb, {
       orgId: auth.orgId,
       userId: auth.userId,
@@ -783,8 +750,19 @@ const updateAgentCustomConnectorsInner$ = command(
       enabledIds,
     });
     signal.throwIfAborted();
-    if (!replaced) {
+    if (replaced.status === "agentNotFound") {
       return agentNotFound(params.id);
+    }
+    if (replaced.status === "customConnectorsNotFound") {
+      return {
+        status: 400 as const,
+        body: {
+          error: {
+            message: `Unknown custom connector ids: ${replaced.missingIds.join(", ")}`,
+            code: "VALIDATION_ERROR",
+          },
+        },
+      };
     }
 
     return {

--- a/turbo/apps/api/src/signals/routes/zero-agents.ts
+++ b/turbo/apps/api/src/signals/routes/zero-agents.ts
@@ -792,6 +792,7 @@ const updateAgentUserConnectorsInner$ = command(
         id: agentComposes.id,
         name: agentComposes.name,
         headVersionId: agentComposes.headVersionId,
+        zeroAgentId: zeroAgents.id,
       })
       .from(agentComposes)
       .leftJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
@@ -845,13 +846,15 @@ const updateAgentUserConnectorsInner$ = command(
       userId: auth.userId,
       agentId: params.id,
       enabledTypes: parsedTypes,
+      allowMissingZeroAgentForEmptyReplace:
+        agent.zeroAgentId === null && parsedTypes.length === 0,
     });
     signal.throwIfAborted();
-    if (!replaced) {
+    if (replaced.status === "agentNotFound") {
       return agentNotFound(params.id);
     }
 
-    await set(
+    const recomposed = await set(
       recomposeAgentIfStale$,
       {
         userId: auth.userId,
@@ -861,6 +864,9 @@ const updateAgentUserConnectorsInner$ = command(
       },
       signal,
     );
+    if (recomposed.status === "missing") {
+      return agentNotFound(params.id);
+    }
 
     return {
       status: 200 as const,

--- a/turbo/apps/api/src/signals/services/agent-compose.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-compose.service.ts
@@ -103,12 +103,10 @@ function computeComposeVersionId(content: Record<string, unknown>): string {
  *    `(orgId, id)` and 404 if missing before calling here. We go straight
  *    to the version INSERT + head-pointer UPDATE.
  *
- * Like web, runs OUTSIDE any transaction the caller may be holding —
- * web's `serverSideCompose` is also called outside the user-connectors
- * DELETE+INSERT transaction. We mirror to preserve identical observable
- * behavior, including the same crash window: if recompose throws after
- * the caller's transaction commits, `agent_composes.head` stays stale
- * until the next mutation.
+ * Runs outside the caller's connector transaction, but guards the final head
+ * update with a row lock and the head value that the caller observed. If
+ * another runner updates the compose first, this command leaves that newer head
+ * intact instead of overwriting it with stale connector-save work.
  */
 export const recomposeAgentIfStale$ = command(
   async (
@@ -128,24 +126,36 @@ export const recomposeAgentIfStale$ = command(
     }
 
     const writeDb = set(writeDb$);
-    await writeDb
-      .insert(agentComposeVersions)
-      .values({
-        id: versionId,
-        composeId: args.agentComposeId,
-        content,
-        createdBy: args.userId,
-      })
-      .onConflictDoNothing();
+    const recomposed = await writeDb.transaction(async (tx) => {
+      const [compose] = await tx
+        .select({ headVersionId: agentComposes.headVersionId })
+        .from(agentComposes)
+        .where(eq(agentComposes.id, args.agentComposeId))
+        .for("update")
+        .limit(1);
+      if (!compose || compose.headVersionId !== args.currentHeadVersionId) {
+        return false;
+      }
+
+      await tx
+        .insert(agentComposeVersions)
+        .values({
+          id: versionId,
+          composeId: args.agentComposeId,
+          content,
+          createdBy: args.userId,
+        })
+        .onConflictDoNothing();
+
+      await tx
+        .update(agentComposes)
+        .set({ headVersionId: versionId, updatedAt: nowDate() })
+        .where(eq(agentComposes.id, args.agentComposeId));
+      return true;
+    });
     signal.throwIfAborted();
 
-    await writeDb
-      .update(agentComposes)
-      .set({ headVersionId: versionId, updatedAt: nowDate() })
-      .where(eq(agentComposes.id, args.agentComposeId));
-    signal.throwIfAborted();
-
-    return { recomposed: true, versionId };
+    return { recomposed, versionId };
   },
 );
 

--- a/turbo/apps/api/src/signals/services/agent-compose.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-compose.service.ts
@@ -85,6 +85,12 @@ function computeComposeVersionId(content: Record<string, unknown>): string {
   return createHash("sha256").update(canonical).digest("hex");
 }
 
+type RecomposeAgentIfStaleResult =
+  | { readonly status: "unchanged"; readonly versionId: string }
+  | { readonly status: "recomposed"; readonly versionId: string }
+  | { readonly status: "changed"; readonly versionId: string }
+  | { readonly status: "missing"; readonly versionId: string };
+
 /**
  * Rebuild the agent's compose head if its current head version is stale.
  *
@@ -118,23 +124,26 @@ export const recomposeAgentIfStale$ = command(
       readonly currentHeadVersionId: string | null;
     },
     signal: AbortSignal,
-  ): Promise<{ recomposed: boolean; versionId: string }> => {
+  ): Promise<RecomposeAgentIfStaleResult> => {
     const content = buildZeroAgentComposeContent(args.agentName);
     const versionId = computeComposeVersionId(content);
     if (versionId === args.currentHeadVersionId) {
-      return { recomposed: false, versionId };
+      return { status: "unchanged", versionId };
     }
 
     const writeDb = set(writeDb$);
-    const recomposed = await writeDb.transaction(async (tx) => {
+    const result = await writeDb.transaction(async (tx) => {
       const [compose] = await tx
         .select({ headVersionId: agentComposes.headVersionId })
         .from(agentComposes)
         .where(eq(agentComposes.id, args.agentComposeId))
         .for("update")
         .limit(1);
-      if (!compose || compose.headVersionId !== args.currentHeadVersionId) {
-        return false;
+      if (!compose) {
+        return { status: "missing" as const, versionId };
+      }
+      if (compose.headVersionId !== args.currentHeadVersionId) {
+        return { status: "changed" as const, versionId };
       }
 
       await tx
@@ -151,11 +160,11 @@ export const recomposeAgentIfStale$ = command(
         .update(agentComposes)
         .set({ headVersionId: versionId, updatedAt: nowDate() })
         .where(eq(agentComposes.id, args.agentComposeId));
-      return true;
+      return { status: "recomposed" as const, versionId };
     });
     signal.throwIfAborted();
 
-    return { recomposed, versionId };
+    return result;
   },
 );
 

--- a/turbo/apps/api/src/signals/services/agent-compose.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-compose.service.ts
@@ -127,9 +127,6 @@ export const recomposeAgentIfStale$ = command(
   ): Promise<RecomposeAgentIfStaleResult> => {
     const content = buildZeroAgentComposeContent(args.agentName);
     const versionId = computeComposeVersionId(content);
-    if (versionId === args.currentHeadVersionId) {
-      return { status: "unchanged", versionId };
-    }
 
     const writeDb = set(writeDb$);
     const result = await writeDb.transaction(async (tx) => {
@@ -141,6 +138,9 @@ export const recomposeAgentIfStale$ = command(
         .limit(1);
       if (!compose) {
         return { status: "missing" as const, versionId };
+      }
+      if (compose.headVersionId === versionId) {
+        return { status: "unchanged" as const, versionId };
       }
       if (compose.headVersionId !== args.currentHeadVersionId) {
         return { status: "changed" as const, versionId };

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -3013,6 +3013,9 @@ async function buildCustomConnectorRuntimeContext(args: {
         return rendered === null ? [] : [[queryInjection.name, rendered]];
       }),
     );
+    if (Object.keys(headers).length === 0 && Object.keys(query).length === 0) {
+      continue;
+    }
     for (const prefixTemplate of row.connector.prefixTemplates) {
       const renderedPrefix = renderCustomConnectorRuntimePrefix({
         template: prefixTemplate,

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -2991,6 +2991,28 @@ async function buildCustomConnectorRuntimeContext(args: {
       featureSwitchContext: args.featureSwitchContext,
     });
     const apis: ExpandedFirewallConfig["apis"] = [];
+    const headers = Object.fromEntries(
+      row.connector.headerInjections.flatMap((header) => {
+        const rendered = renderTemplateForRuntime({
+          template: header.valueTemplate,
+          connectorId: row.connector.id,
+          fields: row.connector.fields,
+          configuredValueMarkers: valueMarkers,
+        });
+        return rendered === null ? [] : [[header.name, rendered]];
+      }),
+    );
+    const query = Object.fromEntries(
+      row.connector.queryInjections.flatMap((queryInjection) => {
+        const rendered = renderTemplateForRuntime({
+          template: queryInjection.valueTemplate,
+          connectorId: row.connector.id,
+          fields: row.connector.fields,
+          configuredValueMarkers: valueMarkers,
+        });
+        return rendered === null ? [] : [[queryInjection.name, rendered]];
+      }),
+    );
     for (const prefixTemplate of row.connector.prefixTemplates) {
       const renderedPrefix = renderCustomConnectorRuntimePrefix({
         template: prefixTemplate,
@@ -3002,30 +3024,8 @@ async function buildCustomConnectorRuntimeContext(args: {
       apis.push({
         base: renderedPrefix,
         auth: {
-          headers: Object.fromEntries(
-            row.connector.headerInjections.map((header) => {
-              return [
-                header.name,
-                renderTemplateForRuntime({
-                  template: header.valueTemplate,
-                  connectorId: row.connector.id,
-                  fields: row.connector.fields,
-                }),
-              ];
-            }),
-          ),
-          query: Object.fromEntries(
-            row.connector.queryInjections.map((query) => {
-              return [
-                query.name,
-                renderTemplateForRuntime({
-                  template: query.valueTemplate,
-                  connectorId: row.connector.id,
-                  fields: row.connector.fields,
-                }),
-              ];
-            }),
-          ),
+          headers,
+          query,
         },
       });
     }

--- a/turbo/apps/api/src/signals/services/onboarding.service.ts
+++ b/turbo/apps/api/src/signals/services/onboarding.service.ts
@@ -431,12 +431,15 @@ async function replaceSelectedConnectors(
     return;
   }
 
-  await replaceUserConnectors(db, {
+  const replaced = await replaceUserConnectors(db, {
     orgId: args.orgId,
     userId: args.userId,
     agentId: args.agentId,
     enabledTypes: args.selectedConnectors,
   });
+  if (!replaced) {
+    throw new Error(`Default agent not found: ${args.agentId}`);
+  }
 }
 
 async function updateOnboardingPaymentPending(

--- a/turbo/apps/api/src/signals/services/onboarding.service.ts
+++ b/turbo/apps/api/src/signals/services/onboarding.service.ts
@@ -436,8 +436,9 @@ async function replaceSelectedConnectors(
     userId: args.userId,
     agentId: args.agentId,
     enabledTypes: args.selectedConnectors,
+    allowMissingZeroAgentForEmptyReplace: false,
   });
-  if (!replaced) {
+  if (replaced.status === "agentNotFound") {
     throw new Error(`Default agent not found: ${args.agentId}`);
   }
 }

--- a/turbo/apps/api/src/signals/services/onboarding.service.ts
+++ b/turbo/apps/api/src/signals/services/onboarding.service.ts
@@ -10,7 +10,6 @@ import { orgCache } from "@vm0/db/schema/org-cache";
 import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
 import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
-import { userConnectors } from "@vm0/db/schema/user-connector";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { and, eq, inArray, sql } from "drizzle-orm";
 
@@ -25,6 +24,7 @@ import {
   unavailableUserConnectorTypes,
   userConnectorAvailability,
 } from "./connector-availability.service";
+import { replaceUserConnectors } from "./user-connectors.service";
 import { upsertOrgNoSecretModelProvider$ } from "./zero-model-provider.service";
 
 const L = logger("onboarding.service");
@@ -431,26 +431,11 @@ async function replaceSelectedConnectors(
     return;
   }
 
-  await db.transaction(async (tx) => {
-    await tx
-      .delete(userConnectors)
-      .where(
-        and(
-          eq(userConnectors.orgId, args.orgId),
-          eq(userConnectors.userId, args.userId),
-          eq(userConnectors.agentId, args.agentId),
-        ),
-      );
-    await tx.insert(userConnectors).values(
-      args.selectedConnectors.map((connectorType) => {
-        return {
-          orgId: args.orgId,
-          userId: args.userId,
-          agentId: args.agentId,
-          connectorType,
-        };
-      }),
-    );
+  await replaceUserConnectors(db, {
+    orgId: args.orgId,
+    userId: args.userId,
+    agentId: args.agentId,
+    enabledTypes: args.selectedConnectors,
   });
 }
 

--- a/turbo/apps/api/src/signals/services/onboarding.service.ts
+++ b/turbo/apps/api/src/signals/services/onboarding.service.ts
@@ -24,7 +24,7 @@ import {
   unavailableUserConnectorTypes,
   userConnectorAvailability,
 } from "./connector-availability.service";
-import { replaceUserConnectors } from "./user-connectors.service";
+import { updateUserConnectors } from "./user-connectors.service";
 import { upsertOrgNoSecretModelProvider$ } from "./zero-model-provider.service";
 
 const L = logger("onboarding.service");
@@ -431,14 +431,14 @@ async function replaceSelectedConnectors(
     return;
   }
 
-  const replaced = await replaceUserConnectors(db, {
+  const updated = await updateUserConnectors(db, {
     orgId: args.orgId,
     userId: args.userId,
     agentId: args.agentId,
     enabledTypes: args.selectedConnectors,
     allowMissingZeroAgentForEmptyReplace: false,
   });
-  if (replaced.status === "agentNotFound") {
+  if (updated.status === "agentNotFound") {
     throw new Error(`Default agent not found: ${args.agentId}`);
   }
 }

--- a/turbo/apps/api/src/signals/services/user-connectors.service.ts
+++ b/turbo/apps/api/src/signals/services/user-connectors.service.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import type { ConnectorType } from "@vm0/connectors/connectors";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { orgCustomConnectors } from "@vm0/db/schema/org-custom-connector";
@@ -70,22 +70,25 @@ async function lockCustomConnectorsForReplace(
     return [];
   }
 
-  const lockedRows = await db
-    .select({ id: orgCustomConnectors.id })
-    .from(orgCustomConnectors)
-    .where(
-      and(
-        eq(orgCustomConnectors.orgId, args.orgId),
-        inArray(orgCustomConnectors.id, [...args.enabledIds]),
-      ),
-    )
-    .orderBy(orgCustomConnectors.id)
-    .for("update");
-  const lockedIds = new Set(
-    lockedRows.map((row) => {
-      return row.id;
-    }),
-  );
+  const sortedIds = [...args.enabledIds].sort();
+  const lockedIds = new Set<string>();
+  for (const id of sortedIds) {
+    const [locked] = await db
+      .select({ id: orgCustomConnectors.id })
+      .from(orgCustomConnectors)
+      .where(
+        and(
+          eq(orgCustomConnectors.orgId, args.orgId),
+          eq(orgCustomConnectors.id, id),
+        ),
+      )
+      .for("update")
+      .limit(1);
+    if (locked) {
+      lockedIds.add(locked.id);
+    }
+  }
+
   return args.enabledIds.filter((id) => {
     return !lockedIds.has(id);
   });
@@ -157,6 +160,11 @@ export async function replaceUserCustomConnectors(
   const enabledIds = Array.from(new Set(args.enabledIds));
 
   return await db.transaction(async (tx) => {
+    const composeLocked = await lockAgentComposeForConnectorReplace(tx, args);
+    if (!composeLocked) {
+      return { status: "agentNotFound" };
+    }
+
     const missingIds = await lockCustomConnectorsForReplace(tx, {
       orgId: args.orgId,
       enabledIds,

--- a/turbo/apps/api/src/signals/services/user-connectors.service.ts
+++ b/turbo/apps/api/src/signals/services/user-connectors.service.ts
@@ -1,0 +1,55 @@
+import { and, eq } from "drizzle-orm";
+import type { ConnectorType } from "@vm0/connectors/connectors";
+import { userConnectors } from "@vm0/db/schema/user-connector";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
+
+import type { Db } from "../external/db";
+
+export async function replaceUserConnectors(
+  db: Db,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly agentId: string;
+    readonly enabledTypes: readonly ConnectorType[];
+  },
+): Promise<void> {
+  const enabledTypes = Array.from(new Set(args.enabledTypes));
+
+  await db.transaction(async (tx) => {
+    // Serialize replace semantics for concurrent saves of the same agent.
+    await tx
+      .select({ id: zeroAgents.id })
+      .from(zeroAgents)
+      .where(
+        and(eq(zeroAgents.orgId, args.orgId), eq(zeroAgents.id, args.agentId)),
+      )
+      .for("update")
+      .limit(1);
+
+    await tx
+      .delete(userConnectors)
+      .where(
+        and(
+          eq(userConnectors.orgId, args.orgId),
+          eq(userConnectors.userId, args.userId),
+          eq(userConnectors.agentId, args.agentId),
+        ),
+      );
+
+    if (enabledTypes.length === 0) {
+      return;
+    }
+
+    await tx.insert(userConnectors).values(
+      enabledTypes.map((connectorType) => {
+        return {
+          orgId: args.orgId,
+          userId: args.userId,
+          agentId: args.agentId,
+          connectorType,
+        };
+      }),
+    );
+  });
+}

--- a/turbo/apps/api/src/signals/services/user-connectors.service.ts
+++ b/turbo/apps/api/src/signals/services/user-connectors.service.ts
@@ -18,7 +18,20 @@ type ReplaceUserConnectorsResult =
 export type UserConnectorUpdateOperation = "replace" | "add" | "remove";
 
 type ReplaceUserCustomConnectorsResult =
-  | { readonly status: "replaced" }
+  | {
+      readonly status: "replaced";
+      readonly enabledIds: readonly string[];
+    }
+  | { readonly status: "agentNotFound" }
+  | {
+      readonly status: "customConnectorsNotFound";
+      readonly missingIds: readonly string[];
+    };
+
+export type UserCustomConnectorUpdateOperation = "replace" | "add" | "remove";
+
+type AddUserCustomConnectorResult =
+  | { readonly status: "added" }
   | { readonly status: "agentNotFound" }
   | {
       readonly status: "customConnectorsNotFound";
@@ -194,9 +207,11 @@ export async function replaceUserCustomConnectors(
     readonly userId: string;
     readonly agentId: string;
     readonly enabledIds: readonly string[];
+    readonly operation?: UserCustomConnectorUpdateOperation;
   },
 ): Promise<ReplaceUserCustomConnectorsResult> {
   const enabledIds = Array.from(new Set(args.enabledIds));
+  const operation = args.operation ?? "replace";
 
   return await db.transaction(async (tx) => {
     const composeLocked = await lockAgentComposeForConnectorReplace(tx, args);
@@ -204,44 +219,91 @@ export async function replaceUserCustomConnectors(
       return { status: "agentNotFound" };
     }
 
-    const missingIds = await lockCustomConnectorsForReplace(tx, {
-      orgId: args.orgId,
-      enabledIds,
-    });
-    if (missingIds.length > 0) {
-      return { status: "customConnectorsNotFound", missingIds };
+    if (operation !== "remove") {
+      const missingIds = await lockCustomConnectorsForReplace(tx, {
+        orgId: args.orgId,
+        enabledIds,
+      });
+      if (missingIds.length > 0) {
+        return { status: "customConnectorsNotFound", missingIds };
+      }
     }
 
-    // Serialize replace semantics for concurrent saves of the same agent.
     const agentLocked = await lockZeroAgentForConnectorReplace(tx, args);
     if (!agentLocked) {
       return { status: "agentNotFound" };
     }
 
-    await tx
-      .delete(userCustomConnectors)
-      .where(
-        and(
-          eq(userCustomConnectors.orgId, args.orgId),
-          eq(userCustomConnectors.userId, args.userId),
-          eq(userCustomConnectors.agentId, args.agentId),
-        ),
-      );
+    const connectorScope = and(
+      eq(userCustomConnectors.orgId, args.orgId),
+      eq(userCustomConnectors.userId, args.userId),
+      eq(userCustomConnectors.agentId, args.agentId),
+    );
 
-    if (enabledIds.length === 0) {
-      return { status: "replaced" };
+    if (operation === "replace") {
+      await tx.delete(userCustomConnectors).where(connectorScope);
+    } else if (operation === "remove" && enabledIds.length > 0) {
+      await tx
+        .delete(userCustomConnectors)
+        .where(
+          and(
+            connectorScope,
+            inArray(userCustomConnectors.customConnectorId, enabledIds),
+          ),
+        );
     }
 
-    await tx.insert(userCustomConnectors).values(
-      enabledIds.map((customConnectorId) => {
-        return {
-          orgId: args.orgId,
-          userId: args.userId,
-          agentId: args.agentId,
-          customConnectorId,
-        };
+    if (operation !== "remove" && enabledIds.length > 0) {
+      await tx
+        .insert(userCustomConnectors)
+        .values(
+          enabledIds.map((customConnectorId) => {
+            return {
+              orgId: args.orgId,
+              userId: args.userId,
+              agentId: args.agentId,
+              customConnectorId,
+            };
+          }),
+        )
+        .onConflictDoNothing();
+    }
+
+    if (operation === "replace") {
+      return { status: "replaced", enabledIds };
+    }
+
+    const rows = await tx
+      .select({ customConnectorId: userCustomConnectors.customConnectorId })
+      .from(userCustomConnectors)
+      .where(connectorScope);
+    return {
+      status: "replaced",
+      enabledIds: rows.map((row) => {
+        return row.customConnectorId;
       }),
-    );
-    return { status: "replaced" };
+    };
   });
+}
+
+export async function addUserCustomConnector(
+  db: Db,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly agentId: string;
+    readonly customConnectorId: string;
+  },
+): Promise<AddUserCustomConnectorResult> {
+  const result = await replaceUserCustomConnectors(db, {
+    orgId: args.orgId,
+    userId: args.userId,
+    agentId: args.agentId,
+    enabledIds: [args.customConnectorId],
+    operation: "add",
+  });
+  if (result.status === "replaced") {
+    return { status: "added" };
+  }
+  return result;
 }

--- a/turbo/apps/api/src/signals/services/user-connectors.service.ts
+++ b/turbo/apps/api/src/signals/services/user-connectors.service.ts
@@ -10,7 +10,7 @@ import type { Db } from "../external/db";
 
 type UpdateUserConnectorsResult =
   | {
-      readonly status: "replaced";
+      readonly status: "updated";
       readonly enabledTypes: readonly ConnectorType[];
     }
   | { readonly status: "agentNotFound" };
@@ -19,7 +19,7 @@ export type UserConnectorUpdateOperation = "replace" | "add" | "remove";
 
 type UpdateUserCustomConnectorsResult =
   | {
-      readonly status: "replaced";
+      readonly status: "updated";
       readonly enabledIds: readonly string[];
     }
   | { readonly status: "agentNotFound" }
@@ -184,7 +184,7 @@ export async function updateUserConnectors(
     }
 
     if (operation === "replace") {
-      return { status: "replaced", enabledTypes };
+      return { status: "updated", enabledTypes };
     }
 
     const rows = await tx
@@ -192,7 +192,7 @@ export async function updateUserConnectors(
       .from(userConnectors)
       .where(connectorScope);
     return {
-      status: "replaced",
+      status: "updated",
       enabledTypes: rows.map((row) => {
         return row.connectorType as ConnectorType;
       }),
@@ -270,7 +270,7 @@ export async function updateUserCustomConnectors(
     }
 
     if (operation === "replace") {
-      return { status: "replaced", enabledIds };
+      return { status: "updated", enabledIds };
     }
 
     const rows = await tx
@@ -278,7 +278,7 @@ export async function updateUserCustomConnectors(
       .from(userCustomConnectors)
       .where(connectorScope);
     return {
-      status: "replaced",
+      status: "updated",
       enabledIds: rows.map((row) => {
         return row.customConnectorId;
       }),
@@ -302,7 +302,7 @@ export async function addUserCustomConnector(
     enabledIds: [args.customConnectorId],
     operation: "add",
   });
-  if (result.status === "replaced") {
+  if (result.status === "updated") {
     return { status: "added" };
   }
   return result;

--- a/turbo/apps/api/src/signals/services/user-connectors.service.ts
+++ b/turbo/apps/api/src/signals/services/user-connectors.service.ts
@@ -168,6 +168,57 @@ function customConnectorAuthTemplates(row: {
   ];
 }
 
+function customConnectorPrefixTemplates(row: {
+  readonly prefixes: readonly string[];
+  readonly prefixTemplates: readonly string[];
+}): readonly string[] {
+  return row.prefixTemplates.length > 0 ? row.prefixTemplates : row.prefixes;
+}
+
+function customConnectorPrefixTemplateConfigured(args: {
+  readonly connectorId: string;
+  readonly fields: readonly OrgCustomConnectorField[];
+  readonly configuredMarkers: ReadonlySet<string>;
+  readonly template: string;
+}): boolean {
+  const variableFieldByKey = new Map(
+    args.fields
+      .filter((field) => {
+        return field.kind === "variable";
+      })
+      .map((field) => {
+        return [field.key, field] as const;
+      }),
+  );
+
+  for (const match of args.template.matchAll(
+    CUSTOM_CONNECTOR_TEMPLATE_REFERENCE_REGEX,
+  )) {
+    const namespace = match[1];
+    const key = match[2];
+    if (!namespace || !key) {
+      continue;
+    }
+    if (namespace !== "variables") {
+      return false;
+    }
+    const field = variableFieldByKey.get(key);
+    if (!field) {
+      return false;
+    }
+    if (
+      !customConnectorFieldConfigured({
+        connectorId: args.connectorId,
+        field,
+        configuredMarkers: args.configuredMarkers,
+      })
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
 async function loadCustomConnectorGrantValueMarkers(
   db: Pick<Db, "select">,
   args: {
@@ -293,6 +344,8 @@ async function lockCustomConnectorsForReplace(
   const sortedIds = [...args.enabledIds].sort();
   const lockedRows: {
     readonly id: string;
+    readonly prefixes: readonly string[];
+    readonly prefixTemplates: readonly string[];
     readonly headerTemplate: string;
     readonly fields: readonly OrgCustomConnectorField[];
     readonly headerInjections: readonly OrgCustomConnectorHeaderInjection[];
@@ -302,6 +355,8 @@ async function lockCustomConnectorsForReplace(
     const [locked] = await db
       .select({
         id: orgCustomConnectors.id,
+        prefixes: orgCustomConnectors.prefixes,
+        prefixTemplates: orgCustomConnectors.prefixTemplates,
         headerTemplate: orgCustomConnectors.headerTemplate,
         fields: orgCustomConnectors.fields,
         headerInjections: orgCustomConnectors.headerInjections,
@@ -360,7 +415,19 @@ async function lockCustomConnectorsForReplace(
         });
       },
     );
-    return missingRequired || !hasConfiguredAuth ? [row.id] : [];
+    const hasConfiguredPrefix = customConnectorPrefixTemplates(row).some(
+      (template) => {
+        return customConnectorPrefixTemplateConfigured({
+          connectorId: row.id,
+          fields,
+          configuredMarkers,
+          template,
+        });
+      },
+    );
+    return missingRequired || !hasConfiguredAuth || !hasConfiguredPrefix
+      ? [row.id]
+      : [];
   });
   return { missingIds: [], unconfiguredIds };
 }

--- a/turbo/apps/api/src/signals/services/user-connectors.service.ts
+++ b/turbo/apps/api/src/signals/services/user-connectors.service.ts
@@ -8,7 +8,7 @@ import { zeroAgents } from "@vm0/db/schema/zero-agent";
 
 import type { Db } from "../external/db";
 
-type ReplaceUserConnectorsResult =
+type UpdateUserConnectorsResult =
   | {
       readonly status: "replaced";
       readonly enabledTypes: readonly ConnectorType[];
@@ -17,7 +17,7 @@ type ReplaceUserConnectorsResult =
 
 export type UserConnectorUpdateOperation = "replace" | "add" | "remove";
 
-type ReplaceUserCustomConnectorsResult =
+type UpdateUserCustomConnectorsResult =
   | {
       readonly status: "replaced";
       readonly enabledIds: readonly string[];
@@ -120,7 +120,7 @@ async function lockCustomConnectorsForReplace(
   });
 }
 
-export async function replaceUserConnectors(
+export async function updateUserConnectors(
   db: Db,
   args: {
     readonly orgId: string;
@@ -130,7 +130,7 @@ export async function replaceUserConnectors(
     readonly operation?: UserConnectorUpdateOperation;
     readonly allowMissingZeroAgentForEmptyReplace: boolean;
   },
-): Promise<ReplaceUserConnectorsResult> {
+): Promise<UpdateUserConnectorsResult> {
   const enabledTypes = Array.from(new Set(args.enabledTypes));
   const operation = args.operation ?? "replace";
 
@@ -200,7 +200,7 @@ export async function replaceUserConnectors(
   });
 }
 
-export async function replaceUserCustomConnectors(
+export async function updateUserCustomConnectors(
   db: Db,
   args: {
     readonly orgId: string;
@@ -209,7 +209,7 @@ export async function replaceUserCustomConnectors(
     readonly enabledIds: readonly string[];
     readonly operation?: UserCustomConnectorUpdateOperation;
   },
-): Promise<ReplaceUserCustomConnectorsResult> {
+): Promise<UpdateUserCustomConnectorsResult> {
   const enabledIds = Array.from(new Set(args.enabledIds));
   const operation = args.operation ?? "replace";
 
@@ -295,7 +295,7 @@ export async function addUserCustomConnector(
     readonly customConnectorId: string;
   },
 ): Promise<AddUserCustomConnectorResult> {
-  const result = await replaceUserCustomConnectors(db, {
+  const result = await updateUserCustomConnectors(db, {
     orgId: args.orgId,
     userId: args.userId,
     agentId: args.agentId,

--- a/turbo/apps/api/src/signals/services/user-connectors.service.ts
+++ b/turbo/apps/api/src/signals/services/user-connectors.service.ts
@@ -15,7 +15,7 @@ type UpdateUserConnectorsResult =
     }
   | { readonly status: "agentNotFound" };
 
-export type UserConnectorUpdateOperation = "replace" | "add" | "remove";
+type UserConnectorUpdateOperation = "replace" | "add" | "remove";
 
 type UpdateUserCustomConnectorsResult =
   | {
@@ -28,7 +28,7 @@ type UpdateUserCustomConnectorsResult =
       readonly missingIds: readonly string[];
     };
 
-export type UserCustomConnectorUpdateOperation = "replace" | "add" | "remove";
+type UserCustomConnectorUpdateOperation = "replace" | "add" | "remove";
 
 type AddUserCustomConnectorResult =
   | { readonly status: "added" }

--- a/turbo/apps/api/src/signals/services/user-connectors.service.ts
+++ b/turbo/apps/api/src/signals/services/user-connectors.service.ts
@@ -358,6 +358,11 @@ export async function updateUserCustomConnectors(
       return { status: "agentNotFound" };
     }
 
+    const agentLocked = await lockZeroAgentForConnectorReplace(tx, args);
+    if (!agentLocked) {
+      return { status: "agentNotFound" };
+    }
+
     if (operation !== "remove") {
       const validation = await lockCustomConnectorsForReplace(tx, {
         orgId: args.orgId,
@@ -376,11 +381,6 @@ export async function updateUserCustomConnectors(
           unconfiguredIds: validation.unconfiguredIds,
         };
       }
-    }
-
-    const agentLocked = await lockZeroAgentForConnectorReplace(tx, args);
-    if (!agentLocked) {
-      return { status: "agentNotFound" };
     }
 
     const connectorScope = and(

--- a/turbo/apps/api/src/signals/services/user-connectors.service.ts
+++ b/turbo/apps/api/src/signals/services/user-connectors.service.ts
@@ -4,6 +4,8 @@ import { agentComposes } from "@vm0/db/schema/agent-compose";
 import {
   orgCustomConnectors,
   type OrgCustomConnectorField,
+  type OrgCustomConnectorHeaderInjection,
+  type OrgCustomConnectorQueryInjection,
 } from "@vm0/db/schema/org-custom-connector";
 import { orgCustomConnectorSecrets } from "@vm0/db/schema/org-custom-connector-secret";
 import { orgCustomConnectorValues } from "@vm0/db/schema/org-custom-connector-value";
@@ -52,6 +54,9 @@ type AddUserCustomConnectorResult =
     };
 
 const LEGACY_SECRET_KEY = "secret";
+const LEGACY_SECRET_PLACEHOLDER = "{{secret}}";
+const CUSTOM_CONNECTOR_TEMPLATE_REFERENCE_REGEX =
+  /\{\{\s*(secrets|variables)\.([a-z][a-z0-9_]*)\s*\}\}/g;
 
 function legacyCustomConnectorFields(): readonly OrgCustomConnectorField[] {
   return [
@@ -76,6 +81,91 @@ function customConnectorValueMarkerKey(marker: {
   readonly key: string;
 }): string {
   return `${marker.kind}:${marker.key}`;
+}
+
+function customConnectorFieldConfigured(args: {
+  readonly connectorId: string;
+  readonly field: OrgCustomConnectorField;
+  readonly configuredMarkers: ReadonlySet<string>;
+}): boolean {
+  return args.configuredMarkers.has(
+    `${args.connectorId}:${customConnectorValueMarkerKey(args.field)}`,
+  );
+}
+
+function customConnectorAuthTemplateConfigured(args: {
+  readonly connectorId: string;
+  readonly fields: readonly OrgCustomConnectorField[];
+  readonly configuredMarkers: ReadonlySet<string>;
+  readonly template: string;
+}): boolean {
+  const fieldByReference = new Map<string, OrgCustomConnectorField>(
+    args.fields.map((field) => {
+      return [
+        `${field.kind === "secret" ? "secrets" : "variables"}.${field.key}`,
+        field,
+      ] as const;
+    }),
+  );
+
+  const legacyField = args.fields.find((field) => {
+    return field.kind === "secret" && field.key === LEGACY_SECRET_KEY;
+  });
+  if (args.template.includes(LEGACY_SECRET_PLACEHOLDER)) {
+    if (!legacyField) {
+      return false;
+    }
+    if (
+      !customConnectorFieldConfigured({
+        connectorId: args.connectorId,
+        field: legacyField,
+        configuredMarkers: args.configuredMarkers,
+      })
+    ) {
+      return false;
+    }
+  }
+
+  for (const match of args.template.matchAll(
+    CUSTOM_CONNECTOR_TEMPLATE_REFERENCE_REGEX,
+  )) {
+    const namespace = match[1];
+    const key = match[2];
+    if (!namespace || !key) {
+      continue;
+    }
+    const field = fieldByReference.get(`${namespace}.${key}`);
+    if (!field) {
+      return false;
+    }
+    if (
+      !customConnectorFieldConfigured({
+        connectorId: args.connectorId,
+        field,
+        configuredMarkers: args.configuredMarkers,
+      })
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function customConnectorAuthTemplates(row: {
+  readonly headerTemplate: string;
+  readonly headerInjections: readonly OrgCustomConnectorHeaderInjection[];
+  readonly queryInjections: readonly OrgCustomConnectorQueryInjection[];
+}): readonly string[] {
+  return [
+    ...(row.headerInjections.length > 0
+      ? row.headerInjections.map((injection) => {
+          return injection.valueTemplate;
+        })
+      : [row.headerTemplate]),
+    ...row.queryInjections.map((injection) => {
+      return injection.valueTemplate;
+    }),
+  ];
 }
 
 async function loadCustomConnectorGrantValueMarkers(
@@ -203,13 +293,19 @@ async function lockCustomConnectorsForReplace(
   const sortedIds = [...args.enabledIds].sort();
   const lockedRows: {
     readonly id: string;
+    readonly headerTemplate: string;
     readonly fields: readonly OrgCustomConnectorField[];
+    readonly headerInjections: readonly OrgCustomConnectorHeaderInjection[];
+    readonly queryInjections: readonly OrgCustomConnectorQueryInjection[];
   }[] = [];
   for (const id of sortedIds) {
     const [locked] = await db
       .select({
         id: orgCustomConnectors.id,
+        headerTemplate: orgCustomConnectors.headerTemplate,
         fields: orgCustomConnectors.fields,
+        headerInjections: orgCustomConnectors.headerInjections,
+        queryInjections: orgCustomConnectors.queryInjections,
       })
       .from(orgCustomConnectors)
       .where(
@@ -254,7 +350,17 @@ async function lockCustomConnectorsForReplace(
         )
       );
     });
-    return missingRequired ? [row.id] : [];
+    const hasConfiguredAuth = customConnectorAuthTemplates(row).some(
+      (template) => {
+        return customConnectorAuthTemplateConfigured({
+          connectorId: row.id,
+          fields,
+          configuredMarkers,
+          template,
+        });
+      },
+    );
+    return missingRequired || !hasConfiguredAuth ? [row.id] : [];
   });
   return { missingIds: [], unconfiguredIds };
 }

--- a/turbo/apps/api/src/signals/services/user-connectors.service.ts
+++ b/turbo/apps/api/src/signals/services/user-connectors.service.ts
@@ -1,11 +1,16 @@
 import { and, eq, inArray } from "drizzle-orm";
 import type { ConnectorType } from "@vm0/connectors/connectors";
+import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { orgCustomConnectors } from "@vm0/db/schema/org-custom-connector";
 import { userCustomConnectors } from "@vm0/db/schema/user-custom-connector";
 import { userConnectors } from "@vm0/db/schema/user-connector";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 
 import type { Db } from "../external/db";
+
+type ReplaceUserConnectorsResult =
+  | { readonly status: "replaced" }
+  | { readonly status: "agentNotFound" };
 
 type ReplaceUserCustomConnectorsResult =
   | { readonly status: "replaced" }
@@ -15,7 +20,28 @@ type ReplaceUserCustomConnectorsResult =
       readonly missingIds: readonly string[];
     };
 
-async function lockAgentForConnectorReplace(
+async function lockAgentComposeForConnectorReplace(
+  db: Pick<Db, "select">,
+  args: {
+    readonly orgId: string;
+    readonly agentId: string;
+  },
+): Promise<boolean> {
+  const [compose] = await db
+    .select({ id: agentComposes.id })
+    .from(agentComposes)
+    .where(
+      and(
+        eq(agentComposes.orgId, args.orgId),
+        eq(agentComposes.id, args.agentId),
+      ),
+    )
+    .for("update")
+    .limit(1);
+  return compose !== undefined;
+}
+
+async function lockZeroAgentForConnectorReplace(
   db: Pick<Db, "select">,
   args: {
     readonly orgId: string;
@@ -72,15 +98,23 @@ export async function replaceUserConnectors(
     readonly userId: string;
     readonly agentId: string;
     readonly enabledTypes: readonly ConnectorType[];
+    readonly allowMissingZeroAgentForEmptyReplace: boolean;
   },
-): Promise<boolean> {
+): Promise<ReplaceUserConnectorsResult> {
   const enabledTypes = Array.from(new Set(args.enabledTypes));
 
   return await db.transaction(async (tx) => {
-    // Serialize replace semantics for concurrent saves of the same agent.
-    const agentLocked = await lockAgentForConnectorReplace(tx, args);
-    if (!agentLocked && enabledTypes.length > 0) {
-      return false;
+    const composeLocked = await lockAgentComposeForConnectorReplace(tx, args);
+    if (!composeLocked) {
+      return { status: "agentNotFound" };
+    }
+
+    const agentLocked = await lockZeroAgentForConnectorReplace(tx, args);
+    if (
+      !agentLocked &&
+      (enabledTypes.length > 0 || !args.allowMissingZeroAgentForEmptyReplace)
+    ) {
+      return { status: "agentNotFound" };
     }
 
     await tx
@@ -94,7 +128,7 @@ export async function replaceUserConnectors(
       );
 
     if (enabledTypes.length === 0) {
-      return true;
+      return { status: "replaced" };
     }
 
     await tx.insert(userConnectors).values(
@@ -107,7 +141,7 @@ export async function replaceUserConnectors(
         };
       }),
     );
-    return true;
+    return { status: "replaced" };
   });
 }
 
@@ -132,7 +166,7 @@ export async function replaceUserCustomConnectors(
     }
 
     // Serialize replace semantics for concurrent saves of the same agent.
-    const agentLocked = await lockAgentForConnectorReplace(tx, args);
+    const agentLocked = await lockZeroAgentForConnectorReplace(tx, args);
     if (!agentLocked) {
       return { status: "agentNotFound" };
     }

--- a/turbo/apps/api/src/signals/services/user-connectors.service.ts
+++ b/turbo/apps/api/src/signals/services/user-connectors.service.ts
@@ -1,10 +1,19 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import type { ConnectorType } from "@vm0/connectors/connectors";
+import { orgCustomConnectors } from "@vm0/db/schema/org-custom-connector";
 import { userCustomConnectors } from "@vm0/db/schema/user-custom-connector";
 import { userConnectors } from "@vm0/db/schema/user-connector";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 
 import type { Db } from "../external/db";
+
+type ReplaceUserCustomConnectorsResult =
+  | { readonly status: "replaced" }
+  | { readonly status: "agentNotFound" }
+  | {
+      readonly status: "customConnectorsNotFound";
+      readonly missingIds: readonly string[];
+    };
 
 async function lockAgentForConnectorReplace(
   db: Pick<Db, "select">,
@@ -22,6 +31,38 @@ async function lockAgentForConnectorReplace(
     .for("update")
     .limit(1);
   return agent !== undefined;
+}
+
+async function lockCustomConnectorsForReplace(
+  db: Pick<Db, "select">,
+  args: {
+    readonly orgId: string;
+    readonly enabledIds: readonly string[];
+  },
+): Promise<readonly string[]> {
+  if (args.enabledIds.length === 0) {
+    return [];
+  }
+
+  const lockedRows = await db
+    .select({ id: orgCustomConnectors.id })
+    .from(orgCustomConnectors)
+    .where(
+      and(
+        eq(orgCustomConnectors.orgId, args.orgId),
+        inArray(orgCustomConnectors.id, [...args.enabledIds]),
+      ),
+    )
+    .orderBy(orgCustomConnectors.id)
+    .for("update");
+  const lockedIds = new Set(
+    lockedRows.map((row) => {
+      return row.id;
+    }),
+  );
+  return args.enabledIds.filter((id) => {
+    return !lockedIds.has(id);
+  });
 }
 
 export async function replaceUserConnectors(
@@ -78,14 +119,22 @@ export async function replaceUserCustomConnectors(
     readonly agentId: string;
     readonly enabledIds: readonly string[];
   },
-): Promise<boolean> {
+): Promise<ReplaceUserCustomConnectorsResult> {
   const enabledIds = Array.from(new Set(args.enabledIds));
 
   return await db.transaction(async (tx) => {
+    const missingIds = await lockCustomConnectorsForReplace(tx, {
+      orgId: args.orgId,
+      enabledIds,
+    });
+    if (missingIds.length > 0) {
+      return { status: "customConnectorsNotFound", missingIds };
+    }
+
     // Serialize replace semantics for concurrent saves of the same agent.
     const agentLocked = await lockAgentForConnectorReplace(tx, args);
     if (!agentLocked) {
-      return false;
+      return { status: "agentNotFound" };
     }
 
     await tx
@@ -99,7 +148,7 @@ export async function replaceUserCustomConnectors(
       );
 
     if (enabledIds.length === 0) {
-      return true;
+      return { status: "replaced" };
     }
 
     await tx.insert(userCustomConnectors).values(
@@ -112,6 +161,6 @@ export async function replaceUserCustomConnectors(
         };
       }),
     );
-    return true;
+    return { status: "replaced" };
   });
 }

--- a/turbo/apps/api/src/signals/services/user-connectors.service.ts
+++ b/turbo/apps/api/src/signals/services/user-connectors.service.ts
@@ -1,9 +1,28 @@
 import { and, eq } from "drizzle-orm";
 import type { ConnectorType } from "@vm0/connectors/connectors";
+import { userCustomConnectors } from "@vm0/db/schema/user-custom-connector";
 import { userConnectors } from "@vm0/db/schema/user-connector";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 
 import type { Db } from "../external/db";
+
+async function lockAgentForConnectorReplace(
+  db: Pick<Db, "select">,
+  args: {
+    readonly orgId: string;
+    readonly agentId: string;
+  },
+): Promise<boolean> {
+  const [agent] = await db
+    .select({ id: zeroAgents.id })
+    .from(zeroAgents)
+    .where(
+      and(eq(zeroAgents.orgId, args.orgId), eq(zeroAgents.id, args.agentId)),
+    )
+    .for("update")
+    .limit(1);
+  return agent !== undefined;
+}
 
 export async function replaceUserConnectors(
   db: Db,
@@ -13,19 +32,15 @@ export async function replaceUserConnectors(
     readonly agentId: string;
     readonly enabledTypes: readonly ConnectorType[];
   },
-): Promise<void> {
+): Promise<boolean> {
   const enabledTypes = Array.from(new Set(args.enabledTypes));
 
-  await db.transaction(async (tx) => {
+  return await db.transaction(async (tx) => {
     // Serialize replace semantics for concurrent saves of the same agent.
-    await tx
-      .select({ id: zeroAgents.id })
-      .from(zeroAgents)
-      .where(
-        and(eq(zeroAgents.orgId, args.orgId), eq(zeroAgents.id, args.agentId)),
-      )
-      .for("update")
-      .limit(1);
+    const agentLocked = await lockAgentForConnectorReplace(tx, args);
+    if (!agentLocked && enabledTypes.length > 0) {
+      return false;
+    }
 
     await tx
       .delete(userConnectors)
@@ -38,7 +53,7 @@ export async function replaceUserConnectors(
       );
 
     if (enabledTypes.length === 0) {
-      return;
+      return true;
     }
 
     await tx.insert(userConnectors).values(
@@ -51,5 +66,52 @@ export async function replaceUserConnectors(
         };
       }),
     );
+    return true;
+  });
+}
+
+export async function replaceUserCustomConnectors(
+  db: Db,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly agentId: string;
+    readonly enabledIds: readonly string[];
+  },
+): Promise<boolean> {
+  const enabledIds = Array.from(new Set(args.enabledIds));
+
+  return await db.transaction(async (tx) => {
+    // Serialize replace semantics for concurrent saves of the same agent.
+    const agentLocked = await lockAgentForConnectorReplace(tx, args);
+    if (!agentLocked) {
+      return false;
+    }
+
+    await tx
+      .delete(userCustomConnectors)
+      .where(
+        and(
+          eq(userCustomConnectors.orgId, args.orgId),
+          eq(userCustomConnectors.userId, args.userId),
+          eq(userCustomConnectors.agentId, args.agentId),
+        ),
+      );
+
+    if (enabledIds.length === 0) {
+      return true;
+    }
+
+    await tx.insert(userCustomConnectors).values(
+      enabledIds.map((customConnectorId) => {
+        return {
+          orgId: args.orgId,
+          userId: args.userId,
+          agentId: args.agentId,
+          customConnectorId,
+        };
+      }),
+    );
+    return true;
   });
 }

--- a/turbo/apps/api/src/signals/services/user-connectors.service.ts
+++ b/turbo/apps/api/src/signals/services/user-connectors.service.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray, or } from "drizzle-orm";
 import type { ConnectorType } from "@vm0/connectors/connectors";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { orgCustomConnectors } from "@vm0/db/schema/org-custom-connector";
@@ -9,8 +9,13 @@ import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import type { Db } from "../external/db";
 
 type ReplaceUserConnectorsResult =
-  | { readonly status: "replaced" }
+  | {
+      readonly status: "replaced";
+      readonly enabledTypes: readonly ConnectorType[];
+    }
   | { readonly status: "agentNotFound" };
+
+export type UserConnectorUpdateOperation = "replace" | "add" | "remove";
 
 type ReplaceUserCustomConnectorsResult =
   | { readonly status: "replaced" }
@@ -45,6 +50,7 @@ async function lockZeroAgentForConnectorReplace(
   db: Pick<Db, "select">,
   args: {
     readonly orgId: string;
+    readonly userId: string;
     readonly agentId: string;
   },
 ): Promise<boolean> {
@@ -52,7 +58,14 @@ async function lockZeroAgentForConnectorReplace(
     .select({ id: zeroAgents.id })
     .from(zeroAgents)
     .where(
-      and(eq(zeroAgents.orgId, args.orgId), eq(zeroAgents.id, args.agentId)),
+      and(
+        eq(zeroAgents.orgId, args.orgId),
+        eq(zeroAgents.id, args.agentId),
+        or(
+          eq(zeroAgents.visibility, "public"),
+          eq(zeroAgents.owner, args.userId),
+        ),
+      ),
     )
     .for("update")
     .limit(1);
@@ -101,10 +114,12 @@ export async function replaceUserConnectors(
     readonly userId: string;
     readonly agentId: string;
     readonly enabledTypes: readonly ConnectorType[];
+    readonly operation?: UserConnectorUpdateOperation;
     readonly allowMissingZeroAgentForEmptyReplace: boolean;
   },
 ): Promise<ReplaceUserConnectorsResult> {
   const enabledTypes = Array.from(new Set(args.enabledTypes));
+  const operation = args.operation ?? "replace";
 
   return await db.transaction(async (tx) => {
     const composeLocked = await lockAgentComposeForConnectorReplace(tx, args);
@@ -120,31 +135,55 @@ export async function replaceUserConnectors(
       return { status: "agentNotFound" };
     }
 
-    await tx
-      .delete(userConnectors)
-      .where(
-        and(
-          eq(userConnectors.orgId, args.orgId),
-          eq(userConnectors.userId, args.userId),
-          eq(userConnectors.agentId, args.agentId),
-        ),
-      );
+    const connectorScope = and(
+      eq(userConnectors.orgId, args.orgId),
+      eq(userConnectors.userId, args.userId),
+      eq(userConnectors.agentId, args.agentId),
+    );
 
-    if (enabledTypes.length === 0) {
-      return { status: "replaced" };
+    if (operation === "replace") {
+      await tx.delete(userConnectors).where(connectorScope);
+    } else if (operation === "remove" && enabledTypes.length > 0) {
+      await tx
+        .delete(userConnectors)
+        .where(
+          and(
+            connectorScope,
+            inArray(userConnectors.connectorType, enabledTypes),
+          ),
+        );
     }
 
-    await tx.insert(userConnectors).values(
-      enabledTypes.map((connectorType) => {
-        return {
-          orgId: args.orgId,
-          userId: args.userId,
-          agentId: args.agentId,
-          connectorType,
-        };
+    if (operation !== "remove" && enabledTypes.length > 0) {
+      await tx
+        .insert(userConnectors)
+        .values(
+          enabledTypes.map((connectorType) => {
+            return {
+              orgId: args.orgId,
+              userId: args.userId,
+              agentId: args.agentId,
+              connectorType,
+            };
+          }),
+        )
+        .onConflictDoNothing();
+    }
+
+    if (operation === "replace") {
+      return { status: "replaced", enabledTypes };
+    }
+
+    const rows = await tx
+      .select({ connectorType: userConnectors.connectorType })
+      .from(userConnectors)
+      .where(connectorScope);
+    return {
+      status: "replaced",
+      enabledTypes: rows.map((row) => {
+        return row.connectorType as ConnectorType;
       }),
-    );
-    return { status: "replaced" };
+    };
   });
 }
 

--- a/turbo/apps/api/src/signals/services/user-connectors.service.ts
+++ b/turbo/apps/api/src/signals/services/user-connectors.service.ts
@@ -1,7 +1,12 @@
 import { and, eq, inArray, or } from "drizzle-orm";
 import type { ConnectorType } from "@vm0/connectors/connectors";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
-import { orgCustomConnectors } from "@vm0/db/schema/org-custom-connector";
+import {
+  orgCustomConnectors,
+  type OrgCustomConnectorField,
+} from "@vm0/db/schema/org-custom-connector";
+import { orgCustomConnectorSecrets } from "@vm0/db/schema/org-custom-connector-secret";
+import { orgCustomConnectorValues } from "@vm0/db/schema/org-custom-connector-value";
 import { userCustomConnectors } from "@vm0/db/schema/user-custom-connector";
 import { userConnectors } from "@vm0/db/schema/user-connector";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
@@ -26,6 +31,10 @@ type UpdateUserCustomConnectorsResult =
   | {
       readonly status: "customConnectorsNotFound";
       readonly missingIds: readonly string[];
+    }
+  | {
+      readonly status: "customConnectorsNotConfigured";
+      readonly unconfiguredIds: readonly string[];
     };
 
 type UserCustomConnectorUpdateOperation = "replace" | "add" | "remove";
@@ -36,7 +45,98 @@ type AddUserCustomConnectorResult =
   | {
       readonly status: "customConnectorsNotFound";
       readonly missingIds: readonly string[];
+    }
+  | {
+      readonly status: "customConnectorsNotConfigured";
+      readonly unconfiguredIds: readonly string[];
     };
+
+const LEGACY_SECRET_KEY = "secret";
+
+function legacyCustomConnectorFields(): readonly OrgCustomConnectorField[] {
+  return [
+    {
+      key: LEGACY_SECRET_KEY,
+      label: "Secret",
+      kind: "secret",
+      required: true,
+      description: "API credential",
+    },
+  ];
+}
+
+function customConnectorGrantFields(
+  fields: readonly OrgCustomConnectorField[],
+): readonly OrgCustomConnectorField[] {
+  return fields.length > 0 ? fields : legacyCustomConnectorFields();
+}
+
+function customConnectorValueMarkerKey(marker: {
+  readonly kind: "secret" | "variable";
+  readonly key: string;
+}): string {
+  return `${marker.kind}:${marker.key}`;
+}
+
+async function loadCustomConnectorGrantValueMarkers(
+  db: Pick<Db, "select">,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly connectorIds: readonly string[];
+  },
+): Promise<ReadonlySet<string>> {
+  if (args.connectorIds.length === 0) {
+    return new Set();
+  }
+
+  const valueRows = await db
+    .select({
+      connectorId: orgCustomConnectorValues.connectorId,
+      kind: orgCustomConnectorValues.kind,
+      key: orgCustomConnectorValues.key,
+    })
+    .from(orgCustomConnectorValues)
+    .where(
+      and(
+        eq(orgCustomConnectorValues.orgId, args.orgId),
+        eq(orgCustomConnectorValues.userId, args.userId),
+        inArray(orgCustomConnectorValues.connectorId, [...args.connectorIds]),
+      ),
+    );
+  const legacyRows = await db
+    .select({ connectorId: orgCustomConnectorSecrets.connectorId })
+    .from(orgCustomConnectorSecrets)
+    .where(
+      and(
+        eq(orgCustomConnectorSecrets.orgId, args.orgId),
+        eq(orgCustomConnectorSecrets.userId, args.userId),
+        inArray(orgCustomConnectorSecrets.connectorId, [...args.connectorIds]),
+      ),
+    );
+
+  const markers = new Set<string>();
+  for (const row of valueRows) {
+    if (row.kind !== "secret" && row.kind !== "variable") {
+      continue;
+    }
+    markers.add(
+      `${row.connectorId}:${customConnectorValueMarkerKey({
+        kind: row.kind,
+        key: row.key,
+      })}`,
+    );
+  }
+  for (const row of legacyRows) {
+    markers.add(
+      `${row.connectorId}:${customConnectorValueMarkerKey({
+        kind: "secret",
+        key: LEGACY_SECRET_KEY,
+      })}`,
+    );
+  }
+  return markers;
+}
 
 async function lockAgentComposeForConnectorReplace(
   db: Pick<Db, "select">,
@@ -89,18 +189,28 @@ async function lockCustomConnectorsForReplace(
   db: Pick<Db, "select">,
   args: {
     readonly orgId: string;
+    readonly userId: string;
     readonly enabledIds: readonly string[];
   },
-): Promise<readonly string[]> {
+): Promise<{
+  readonly missingIds: readonly string[];
+  readonly unconfiguredIds: readonly string[];
+}> {
   if (args.enabledIds.length === 0) {
-    return [];
+    return { missingIds: [], unconfiguredIds: [] };
   }
 
   const sortedIds = [...args.enabledIds].sort();
-  const lockedIds = new Set<string>();
+  const lockedRows: {
+    readonly id: string;
+    readonly fields: readonly OrgCustomConnectorField[];
+  }[] = [];
   for (const id of sortedIds) {
     const [locked] = await db
-      .select({ id: orgCustomConnectors.id })
+      .select({
+        id: orgCustomConnectors.id,
+        fields: orgCustomConnectors.fields,
+      })
       .from(orgCustomConnectors)
       .where(
         and(
@@ -111,13 +221,42 @@ async function lockCustomConnectorsForReplace(
       .for("update")
       .limit(1);
     if (locked) {
-      lockedIds.add(locked.id);
+      lockedRows.push(locked);
     }
   }
 
-  return args.enabledIds.filter((id) => {
+  const lockedIds = new Set(
+    lockedRows.map((row) => {
+      return row.id;
+    }),
+  );
+  const missingIds = args.enabledIds.filter((id) => {
     return !lockedIds.has(id);
   });
+  if (missingIds.length > 0) {
+    return { missingIds, unconfiguredIds: [] };
+  }
+
+  const configuredMarkers = await loadCustomConnectorGrantValueMarkers(db, {
+    orgId: args.orgId,
+    userId: args.userId,
+    connectorIds: lockedRows.map((row) => {
+      return row.id;
+    }),
+  });
+  const unconfiguredIds = lockedRows.flatMap((row) => {
+    const fields = customConnectorGrantFields(row.fields);
+    const missingRequired = fields.some((field) => {
+      return (
+        field.required &&
+        !configuredMarkers.has(
+          `${row.id}:${customConnectorValueMarkerKey(field)}`,
+        )
+      );
+    });
+    return missingRequired ? [row.id] : [];
+  });
+  return { missingIds: [], unconfiguredIds };
 }
 
 export async function updateUserConnectors(
@@ -220,12 +359,22 @@ export async function updateUserCustomConnectors(
     }
 
     if (operation !== "remove") {
-      const missingIds = await lockCustomConnectorsForReplace(tx, {
+      const validation = await lockCustomConnectorsForReplace(tx, {
         orgId: args.orgId,
+        userId: args.userId,
         enabledIds,
       });
-      if (missingIds.length > 0) {
-        return { status: "customConnectorsNotFound", missingIds };
+      if (validation.missingIds.length > 0) {
+        return {
+          status: "customConnectorsNotFound",
+          missingIds: validation.missingIds,
+        };
+      }
+      if (validation.unconfiguredIds.length > 0) {
+        return {
+          status: "customConnectorsNotConfigured",
+          unconfiguredIds: validation.unconfiguredIds,
+        };
       }
     }
 

--- a/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
@@ -1383,12 +1383,15 @@ export function renderTemplateForRuntime(args: {
 
   if (
     args.configuredValueMarkers &&
-    args.template.includes(LEGACY_SECRET_PLACEHOLDER) &&
-    !args.configuredValueMarkers.has(
-      valueMarkerKey({ kind: "secret", key: LEGACY_SECRET_KEY }),
-    )
+    args.template.includes(LEGACY_SECRET_PLACEHOLDER)
   ) {
-    return null;
+    const legacyField = fieldByReference.get(`secrets.${LEGACY_SECRET_KEY}`);
+    if (
+      !legacyField ||
+      !args.configuredValueMarkers.has(valueMarkerKey(legacyField))
+    ) {
+      return null;
+    }
   }
   for (const match of args.template.matchAll(TEMPLATE_REFERENCE_REGEX)) {
     const namespace = match[1];
@@ -1397,8 +1400,10 @@ export function renderTemplateForRuntime(args: {
       continue;
     }
     const field = fieldByReference.get(`${namespace}.${key}`);
+    if (!field) {
+      return null;
+    }
     if (
-      field &&
       args.configuredValueMarkers &&
       !args.configuredValueMarkers.has(valueMarkerKey(field))
     ) {

--- a/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
@@ -1370,7 +1370,8 @@ export function renderTemplateForRuntime(args: {
   readonly template: string;
   readonly connectorId: string;
   readonly fields: readonly CustomConnectorField[];
-}): string {
+  readonly configuredValueMarkers?: ReadonlySet<string>;
+}): string | null {
   const fieldByReference = new Map<string, CustomConnectorField>(
     args.fields.map((field) => {
       return [
@@ -1379,6 +1380,32 @@ export function renderTemplateForRuntime(args: {
       ] as const;
     }),
   );
+
+  if (
+    args.configuredValueMarkers &&
+    args.template.includes(LEGACY_SECRET_PLACEHOLDER) &&
+    !args.configuredValueMarkers.has(
+      valueMarkerKey({ kind: "secret", key: LEGACY_SECRET_KEY }),
+    )
+  ) {
+    return null;
+  }
+  for (const match of args.template.matchAll(TEMPLATE_REFERENCE_REGEX)) {
+    const namespace = match[1];
+    const key = match[2];
+    if (!namespace || !key) {
+      continue;
+    }
+    const field = fieldByReference.get(`${namespace}.${key}`);
+    if (
+      field &&
+      args.configuredValueMarkers &&
+      !args.configuredValueMarkers.has(valueMarkerKey(field))
+    ) {
+      return null;
+    }
+  }
+
   return args.template
     .replaceAll(
       LEGACY_SECRET_PLACEHOLDER,

--- a/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
@@ -20,8 +20,6 @@ import {
 import { orgCustomConnectors } from "@vm0/db/schema/org-custom-connector";
 import { orgCustomConnectorSecrets } from "@vm0/db/schema/org-custom-connector-secret";
 import { orgCustomConnectorValues } from "@vm0/db/schema/org-custom-connector-value";
-import { userCustomConnectors } from "@vm0/db/schema/user-custom-connector";
-import { zeroAgents } from "@vm0/db/schema/zero-agent";
 
 import { db$, writeDb$, type ReadonlyDb } from "../external/db";
 import { badRequestMessage, notFound } from "../../lib/error";
@@ -33,6 +31,7 @@ import {
   decryptStoredSecretValue,
 } from "./crypto.utils";
 import { userFeatureSwitchContext } from "./feature-switches.service";
+import { addUserCustomConnector } from "./user-connectors.service";
 
 const L = logger("CustomConnectorService");
 
@@ -1617,27 +1616,19 @@ const authorizeProposalAgent$ = command(
       return undefined;
     }
     const writeDb = set(writeDb$);
-    const [agent] = await writeDb
-      .select({ id: zeroAgents.id })
-      .from(zeroAgents)
-      .where(
-        and(eq(zeroAgents.id, args.agentId), eq(zeroAgents.orgId, args.orgId)),
-      )
-      .limit(1);
+    const added = await addUserCustomConnector(writeDb, {
+      orgId: args.orgId,
+      userId: args.userId,
+      agentId: args.agentId,
+      customConnectorId: args.connectorId,
+    });
     signal.throwIfAborted();
-    if (!agent) {
+    if (added.status === "agentNotFound") {
       return notFound("Agent not found");
     }
-    await writeDb
-      .insert(userCustomConnectors)
-      .values({
-        orgId: args.orgId,
-        userId: args.userId,
-        agentId: args.agentId,
-        customConnectorId: args.connectorId,
-      })
-      .onConflictDoNothing();
-    signal.throwIfAborted();
+    if (added.status === "customConnectorsNotFound") {
+      return notFound("Custom connector not found");
+    }
     return args.agentId;
   },
 );

--- a/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
@@ -1629,6 +1629,9 @@ const authorizeProposalAgent$ = command(
     if (added.status === "customConnectorsNotFound") {
       return notFound("Custom connector not found");
     }
+    if (added.status === "customConnectorsNotConfigured") {
+      return undefined;
+    }
     return args.agentId;
   },
 );

--- a/turbo/apps/platform/src/lib/google-security-warning.ts
+++ b/turbo/apps/platform/src/lib/google-security-warning.ts
@@ -1,8 +1,0 @@
-import type { ConnectorType } from "@vm0/connectors/connectors";
-import { isGoogleOAuthConnector } from "@vm0/connectors/auth-providers/oauth/google-connectors";
-
-export function shouldShowGoogleSecurityWarningNotice(
-  type: ConnectorType,
-): boolean {
-  return isGoogleOAuthConnector(type);
-}

--- a/turbo/apps/platform/src/mocks/handlers/api-agents.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-agents.ts
@@ -70,6 +70,16 @@ export function resetMockComposesList(): void {
   mockComposesList = [...DEFAULT_COMPOSES_LIST];
 }
 
+function mockUserConnectorUpdateResponse(body: {
+  readonly enabledTypes: readonly string[];
+  readonly operation?: "replace" | "add" | "remove";
+}): string[] {
+  if (body.operation === "remove") {
+    return [];
+  }
+  return [...body.enabledTypes];
+}
+
 export const apiAgentsHandlers = [
   // GET /api/zero/team
   mockApi(zeroTeamContract.list, ({ respond }) => {
@@ -103,7 +113,9 @@ export const apiAgentsHandlers = [
 
   // PUT /api/zero/agents/:id/user-connectors
   mockApi(zeroUserConnectorsContract.update, ({ body, respond }) => {
-    return respond(200, { enabledTypes: body.enabledTypes });
+    return respond(200, {
+      enabledTypes: mockUserConnectorUpdateResponse(body),
+    });
   }),
 
   // GET /api/zero/agents/:id

--- a/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
@@ -1,5 +1,6 @@
 import {
   CONNECTOR_TYPE_KEYS,
+  type ConnectorAuthMethodConfig,
   type ConnectorAuthMethodId,
   type ConnectorType,
   CONNECTOR_TYPES,
@@ -12,6 +13,7 @@ import type {
 } from "@vm0/api-contracts/contracts/connector-schemas";
 import {
   zeroConnectorCatalogContract,
+  type PublicConnectorCatalogAuthMethodDetail,
   type PublicConnectorCatalogConnection,
   type PublicConnectorCatalogConnectionStatus,
   type PublicConnectorCatalogPermissionSummary,
@@ -229,6 +231,43 @@ function mockConnectorAuthMethodSupportsRefresh(
   );
 }
 
+function mockManualFieldsForCatalog(
+  method: ConnectorAuthMethodConfig,
+): PublicConnectorCatalogAuthMethodDetail["manualFields"] {
+  if (method.grant.kind !== "manual") {
+    return [];
+  }
+  return Object.values(method.grant.fields).map((field) => {
+    return {
+      id: field.publicId,
+      label: field.label,
+      required: field.required,
+      placeholder: field.placeholder ?? null,
+      inputType: field.storage === "variable" ? "text" : "password",
+    };
+  });
+}
+
+function mockStartOptionsForCatalog(
+  method: ConnectorAuthMethodConfig,
+): PublicConnectorCatalogAuthMethodDetail["startOptions"] {
+  if (method.grant.kind !== "device-auth") {
+    return [];
+  }
+  return Object.values(method.grant.startOptions ?? {}).map((option) => {
+    return {
+      id: option.publicId,
+      kind: option.kind,
+      label: option.label,
+      required: option.required,
+      defaultValue: option.defaultValue ?? null,
+      options: option.options.map((choice) => {
+        return { value: choice.value, label: choice.label };
+      }),
+    };
+  });
+}
+
 function mockConnectorCatalogStatusItem(
   type: ConnectorType,
   authMethods: readonly ConnectorAuthMethodId[],
@@ -269,8 +308,8 @@ function mockConnectorCatalogStatusItem(
               label: method.label,
               description: method.helpText ?? null,
               grantKind: method.grant.kind,
-              manualFields: [],
-              startOptions: [],
+              manualFields: mockManualFieldsForCatalog(method),
+              startOptions: mockStartOptionsForCatalog(method),
             },
           ]
         : [];

--- a/turbo/apps/platform/src/signals/chat-page/artifact-google-drive-sync.ts
+++ b/turbo/apps/platform/src/signals/chat-page/artifact-google-drive-sync.ts
@@ -1,10 +1,7 @@
 import { command } from "ccstate";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { chatThreadArtifactsContract } from "@vm0/api-contracts/contracts/chat-threads";
-import {
-  zeroUserConnectorsContract,
-  type UserConnectorEnabledTypes,
-} from "@vm0/api-contracts/contracts/user-connectors";
+import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$, type ZeroClientFactory } from "../api-client.ts";
 import { connectors$, reloadConnectors$ } from "../external/connectors.ts";
@@ -145,23 +142,10 @@ async function authorizeGoogleDriveForAgent(params: {
   readonly signal: AbortSignal;
 }): Promise<void> {
   const client = params.createClient(zeroUserConnectorsContract);
-  const current = (await accept(
-    client.get({
-      params: { id: params.agentId },
-      fetchOptions: { signal: params.signal },
-    }),
-    [200],
-  )) as { body: UserConnectorEnabledTypes };
-  params.signal.throwIfAborted();
-
-  if (current.body.enabledTypes.includes("google-drive")) {
-    return;
-  }
-
   await accept(
     client.update({
       params: { id: params.agentId },
-      body: { enabledTypes: [...current.body.enabledTypes, "google-drive"] },
+      body: { enabledTypes: ["google-drive"], operation: "add" },
       fetchOptions: { signal: params.signal },
     }),
     [200],

--- a/turbo/apps/platform/src/signals/chat-page/artifact-google-drive-sync.ts
+++ b/turbo/apps/platform/src/signals/chat-page/artifact-google-drive-sync.ts
@@ -6,7 +6,7 @@ import { accept } from "../../lib/accept.ts";
 import { zeroClient$, type ZeroClientFactory } from "../api-client.ts";
 import { connectors$, reloadConnectors$ } from "../external/connectors.ts";
 import { setAblyLoop$ } from "../realtime.ts";
-import { settle } from "../utils.ts";
+import { settle, withCleanup } from "../utils.ts";
 
 type ArtifactGoogleDriveSyncParams = {
   readonly agentId?: string;
@@ -63,57 +63,68 @@ async function syncArtifactFilesToGoogleDrive(
     readonly signal?: AbortSignal;
   },
 ): Promise<boolean> {
+  params.signal?.throwIfAborted();
   if (params.files.length === 0) {
     toast.error("No artifacts to sync");
     return false;
   }
 
   const toastId = toast.loading(googleDriveSyncLoadingMessage(params.files));
-  const client = params.createClient(chatThreadArtifactsContract);
-  const results: ArtifactGoogleDriveSyncResult[] = [];
-  for (const file of params.files) {
+  const sync = async (): Promise<boolean> => {
+    const client = params.createClient(chatThreadArtifactsContract);
+    const results: ArtifactGoogleDriveSyncResult[] = [];
+    for (const file of params.files) {
+      params.signal?.throwIfAborted();
+      const settled = await settle(
+        accept(
+          client.syncGoogleDrive({
+            params: { threadId: params.threadId },
+            body: {
+              runId: file.runId,
+              fileId: file.fileId,
+            },
+            fetchOptions: params.signal ? { signal: params.signal } : undefined,
+          }),
+          [200],
+          { toast: false },
+        ),
+        params.signal,
+      );
+      const result: ArtifactGoogleDriveSyncResult = settled.ok
+        ? { ok: true }
+        : {
+            ok: false,
+            message: googleDriveSyncErrorMessage(settled.error),
+          };
+      results.push(result);
+    }
     params.signal?.throwIfAborted();
-    const settled = await settle(
-      accept(
-        client.syncGoogleDrive({
-          params: { threadId: params.threadId },
-          body: {
-            runId: file.runId,
-            fileId: file.fileId,
-          },
-          fetchOptions: params.signal ? { signal: params.signal } : undefined,
-        }),
-        [200],
-        { toast: false },
-      ),
+    const syncedCount = results.filter((result) => {
+      return result.ok;
+    }).length;
+
+    if (syncedCount === params.files.length) {
+      toast.success(googleDriveSyncSuccessMessage(params.files.length), {
+        id: toastId,
+      });
+      return true;
+    }
+
+    const firstFailure = results.find(isArtifactGoogleDriveSyncFailure);
+    toast.error(
+      syncedCount > 0
+        ? `Synced ${syncedCount} of ${params.files.length} files to Google Drive`
+        : (firstFailure?.message ?? "Failed to sync to Google Drive"),
+      { id: toastId },
     );
-    const result: ArtifactGoogleDriveSyncResult = settled.ok
-      ? { ok: true }
-      : {
-          ok: false,
-          message: googleDriveSyncErrorMessage(settled.error),
-        };
-    results.push(result);
-  }
-  const syncedCount = results.filter((result) => {
-    return result.ok;
-  }).length;
+    return syncedCount > 0;
+  };
 
-  if (syncedCount === params.files.length) {
-    toast.success(googleDriveSyncSuccessMessage(params.files.length), {
-      id: toastId,
-    });
-    return true;
-  }
-
-  const firstFailure = results.find(isArtifactGoogleDriveSyncFailure);
-  toast.error(
-    syncedCount > 0
-      ? `Synced ${syncedCount} of ${params.files.length} files to Google Drive`
-      : (firstFailure?.message ?? "Failed to sync to Google Drive"),
-    { id: toastId },
-  );
-  return syncedCount > 0;
+  return await withCleanup(sync(), () => {
+    if (params.signal?.aborted) {
+      toast.dismiss(toastId);
+    }
+  });
 }
 
 export async function syncArtifactFileToGoogleDrive(

--- a/turbo/apps/platform/src/signals/connectors-page/directed-authorize-type.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/directed-authorize-type.ts
@@ -66,30 +66,15 @@ export const authorizeConnector$ = command(
     const createClient = get(zeroClient$);
     const client = createClient(zeroUserConnectorsContract);
 
-    // Get current enabled types for this agent
-    const current = await accept(
-      client.get({
+    await accept(
+      client.update({
         params: { id: agentId },
+        body: { enabledTypes: [connectorType], operation: "add" },
         fetchOptions: { signal },
       }),
       [200],
     );
     signal.throwIfAborted();
-
-    const currentTypes = current.body.enabledTypes;
-
-    // Add the new type if not already present
-    if (!currentTypes.includes(connectorType)) {
-      await accept(
-        client.update({
-          params: { id: agentId },
-          body: { enabledTypes: [...currentTypes, connectorType] },
-          fetchOptions: { signal },
-        }),
-        [200],
-      );
-      signal.throwIfAborted();
-    }
 
     // Optimistic update
     set(internalAuthorized$, (prev) => {

--- a/turbo/apps/platform/src/signals/connectors-page/directed-authorize-type.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/directed-authorize-type.ts
@@ -48,10 +48,17 @@ export const agentEnabledTypes$ = computed(async (get) => {
   return result.body.enabledTypes;
 });
 
+function connectorAgentAuthorizationKey(args: {
+  readonly connectorType: ConnectorType;
+  readonly agentId: string;
+}): string {
+  return `${args.agentId}:${args.connectorType}`;
+}
+
 const internalAuthorized$ = state<Set<string>>(new Set());
 
 /** Whether the connector has just been authorized (optimistic). */
-export const justAuthorizedTypes$ = computed((get) => {
+export const justAuthorizedConnectorAgentKeys$ = computed((get) => {
   return get(internalAuthorized$);
 });
 
@@ -78,8 +85,21 @@ export const authorizeConnector$ = command(
 
     // Optimistic update
     set(internalAuthorized$, (prev) => {
-      return new Set([...prev, connectorType]);
+      return new Set([
+        ...prev,
+        connectorAgentAuthorizationKey({ connectorType, agentId }),
+      ]);
     });
     set(reloadAgentConnectorAuthorizations$);
   },
 );
+
+export function isJustAuthorizedConnectorAgent(
+  justAuthorizedKeys: ReadonlySet<string>,
+  args: {
+    readonly connectorType: ConnectorType;
+    readonly agentId: string;
+  },
+): boolean {
+  return justAuthorizedKeys.has(connectorAgentAuthorizationKey(args));
+}

--- a/turbo/apps/platform/src/signals/connectors-page/directed-authorize-type.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/directed-authorize-type.ts
@@ -48,6 +48,23 @@ export const agentEnabledTypes$ = computed(async (get) => {
   return { agentId, enabledTypes: result.body.enabledTypes };
 });
 
+export type DirectedAuthorizeConnectModalKey = {
+  readonly connectorType: ConnectorType;
+  readonly agentId: string;
+  readonly signal: AbortSignal;
+};
+
+const internalDirectedAuthorizeConnectModalKey$ =
+  state<DirectedAuthorizeConnectModalKey | null>(null);
+export const directedAuthorizeConnectModalKey$ = computed((get) => {
+  return get(internalDirectedAuthorizeConnectModalKey$);
+});
+export const setDirectedAuthorizeConnectModalKey$ = command(
+  ({ set }, key: DirectedAuthorizeConnectModalKey | null) => {
+    set(internalDirectedAuthorizeConnectModalKey$, key);
+  },
+);
+
 function connectorAgentAuthorizationKey(args: {
   readonly connectorType: ConnectorType;
   readonly agentId: string;

--- a/turbo/apps/platform/src/signals/connectors-page/directed-authorize-type.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/directed-authorize-type.ts
@@ -27,25 +27,25 @@ export const directedAuthorizeAgentId$ = computed((get): string | null => {
 export const directedAuthorizeAgentName$ = computed(async (get) => {
   const agentId = get(directedAuthorizeAgentId$);
   if (!agentId) {
-    return null;
+    return { agentId: null, displayName: null };
   }
   const agents = await get(agents$);
   const agent = agents.find((a) => {
     return a.id === agentId;
   });
-  return agent?.displayName ?? null;
+  return { agentId, displayName: agent?.displayName ?? null };
 });
 
 /** Fetch enabled connector types for the agent from the API. */
 export const agentEnabledTypes$ = computed(async (get) => {
   const agentId = get(directedAuthorizeAgentId$);
   if (!agentId) {
-    return [];
+    return { agentId: null, enabledTypes: [] };
   }
   const createClient = get(zeroClient$);
   const client = createClient(zeroUserConnectorsContract);
   const result = await accept(client.get({ params: { id: agentId } }), [200]);
-  return result.body.enabledTypes;
+  return { agentId, enabledTypes: result.body.enabledTypes };
 });
 
 function connectorAgentAuthorizationKey(args: {

--- a/turbo/apps/platform/src/signals/connectors-page/directed-connect-type.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/directed-connect-type.ts
@@ -39,13 +39,30 @@ export type DirectedConnectManualGrantDialogKey = {
   readonly signal: AbortSignal;
 };
 
+export type DirectedConnectModalKey = {
+  readonly connectorType: ConnectorType;
+  readonly agentId: string | null;
+  readonly signal: AbortSignal;
+};
+
 const internalManualGrantDialogKey$ =
   state<DirectedConnectManualGrantDialogKey | null>(null);
+const internalDirectedConnectModalKey$ = state<DirectedConnectModalKey | null>(
+  null,
+);
 export const manualGrantDialogKey$ = computed((get) => {
   return get(internalManualGrantDialogKey$);
+});
+export const directedConnectModalKey$ = computed((get) => {
+  return get(internalDirectedConnectModalKey$);
 });
 export const setManualGrantDialogKey$ = command(
   ({ set }, key: DirectedConnectManualGrantDialogKey | null) => {
     set(internalManualGrantDialogKey$, key);
+  },
+);
+export const setDirectedConnectModalKey$ = command(
+  ({ set }, key: DirectedConnectModalKey | null) => {
+    set(internalDirectedConnectModalKey$, key);
   },
 );

--- a/turbo/apps/platform/src/signals/connectors-page/directed-connect-type.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/directed-connect-type.ts
@@ -1,4 +1,5 @@
 import { command, computed, state } from "ccstate";
+import type { ConnectorType } from "@vm0/connectors/connectors";
 import { pathParams$, searchParams$ } from "../route.ts";
 import { agents$ } from "../agent.ts";
 
@@ -32,10 +33,19 @@ export const directedConnectAgentName$ = computed(async (get) => {
   return { agentId, displayName: agent?.displayName ?? null };
 });
 
-const internalManualGrantDialogOpen$ = state(false);
-export const manualGrantDialogOpen$ = computed((get) => {
-  return get(internalManualGrantDialogOpen$);
+export type DirectedConnectManualGrantDialogKey = {
+  readonly connectorType: ConnectorType;
+  readonly agentId: string | null;
+  readonly signal: AbortSignal;
+};
+
+const internalManualGrantDialogKey$ =
+  state<DirectedConnectManualGrantDialogKey | null>(null);
+export const manualGrantDialogKey$ = computed((get) => {
+  return get(internalManualGrantDialogKey$);
 });
-export const setManualGrantDialogOpen$ = command(({ set }, open: boolean) => {
-  set(internalManualGrantDialogOpen$, open);
-});
+export const setManualGrantDialogKey$ = command(
+  ({ set }, key: DirectedConnectManualGrantDialogKey | null) => {
+    set(internalManualGrantDialogKey$, key);
+  },
+);

--- a/turbo/apps/platform/src/signals/connectors-page/directed-connect-type.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/directed-connect-type.ts
@@ -23,13 +23,13 @@ export const directedConnectAgentId$ = computed((get): string | null => {
 export const directedConnectAgentName$ = computed(async (get) => {
   const agentId = get(directedConnectAgentId$);
   if (!agentId) {
-    return null;
+    return { agentId: null, displayName: null };
   }
   const agents = await get(agents$);
   const agent = agents.find((a) => {
     return a.id === agentId;
   });
-  return agent?.displayName ?? null;
+  return { agentId, displayName: agent?.displayName ?? null };
 });
 
 const internalManualGrantDialogOpen$ = state(false);

--- a/turbo/apps/platform/src/signals/zero-page/job-detail/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/job-detail/connectors.ts
@@ -87,6 +87,7 @@ export const saveAgentConnectors$ = command(
       client.update({
         params: { id: detail.agentId },
         body: { enabledTypes },
+        fetchOptions: { signal },
       }),
       [200],
     );

--- a/turbo/apps/platform/src/signals/zero-page/job-detail/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/job-detail/connectors.ts
@@ -1,6 +1,7 @@
 import { command, computed, state } from "ccstate";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import { zeroClient$ } from "../../api-client.ts";
+import { withCleanup } from "../../utils.ts";
 import { accept } from "../../../lib/accept.ts";
 import { agentDetail$ } from "./detail.ts";
 
@@ -33,39 +34,77 @@ const authorizedConnectors$ = computed(async (get): Promise<string[]> => {
   return result.body.enabledTypes;
 });
 
-const internalAuthorizedConnectors$ = state<string[] | null>(null);
+type AuthorizedConnectorsDraft = {
+  readonly agentId: string;
+  readonly enabledTypes: readonly string[];
+};
+
+const internalAuthorizedConnectors$ = state<AuthorizedConnectorsDraft | null>(
+  null,
+);
 
 export const agentAuthorizedConnectors$ = computed(
   async (get): Promise<string[]> => {
+    const detail = await get(agentDetail$);
+    if (!detail?.agentId) {
+      return [];
+    }
     const local = get(internalAuthorizedConnectors$);
-    if (local !== null) {
-      return local;
+    if (local?.agentId === detail.agentId) {
+      return [...local.enabledTypes];
     }
     return await get(authorizedConnectors$);
   },
 );
 
-export const authorizeAgentConnector$ = command(
-  async ({ get, set }, name: string, _signal: AbortSignal) => {
-    if (get(internalAuthorizedConnectors$) === null) {
-      set(internalAuthorizedConnectors$, await get(authorizedConnectors$));
+const setAgentConnectorDraft$ = command(
+  async (
+    { get, set },
+    args: {
+      readonly name: string;
+      readonly operation: "add" | "remove";
+    },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const detail = await get(agentDetail$);
+    signal.throwIfAborted();
+    if (!detail?.agentId) {
+      return;
     }
-    set(internalAuthorizedConnectors$, (prev) => {
-      return Array.from(new Set([...(prev ?? []), name]));
+    const current = get(internalAuthorizedConnectors$);
+    const base =
+      current?.agentId === detail.agentId
+        ? current.enabledTypes
+        : await get(authorizedConnectors$);
+    signal.throwIfAborted();
+    const enabledTypes =
+      args.operation === "add"
+        ? Array.from(new Set([...base, args.name]))
+        : base.filter((s) => {
+            return s !== args.name;
+          });
+    set(internalAuthorizedConnectors$, {
+      agentId: detail.agentId,
+      enabledTypes,
     });
   },
 );
 
+const clearAgentConnectorDraft$ = command(({ set }, agentId: string): void => {
+  set(internalAuthorizedConnectors$, (current) => {
+    return current?.agentId === agentId ? null : current;
+  });
+});
+
+export const authorizeAgentConnector$ = command(
+  async ({ set }, name: string, signal: AbortSignal) => {
+    await set(setAgentConnectorDraft$, { name, operation: "add" }, signal);
+  },
+);
+
 export const deauthorizeAgentConnector$ = command(
-  async ({ get, set }, name: string, _signal: AbortSignal) => {
-    if (get(internalAuthorizedConnectors$) === null) {
-      set(internalAuthorizedConnectors$, await get(authorizedConnectors$));
-    }
-    set(internalAuthorizedConnectors$, (prev) => {
-      return (prev ?? []).filter((s) => {
-        return s !== name;
-      });
-    });
+  async ({ set }, name: string, signal: AbortSignal) => {
+    await set(setAgentConnectorDraft$, { name, operation: "remove" }, signal);
   },
 );
 
@@ -87,17 +126,22 @@ export const saveAgentConnectors$ = command(
     }
 
     const client = get(zeroClient$)(zeroUserConnectorsContract);
-    await accept(
-      client.update({
-        params: { id: detail.agentId },
-        body: { enabledTypes: [name], operation },
-        fetchOptions: { signal },
-      }),
-      [200],
+    await withCleanup(
+      (async () => {
+        await accept(
+          client.update({
+            params: { id: detail.agentId },
+            body: { enabledTypes: [name], operation },
+            fetchOptions: { signal },
+          }),
+          [200],
+        );
+        signal.throwIfAborted();
+      })(),
+      () => {
+        set(clearAgentConnectorDraft$, detail.agentId);
+        set(reloadAgentConnectors$);
+      },
     );
-    signal.throwIfAborted();
-
-    set(internalAuthorizedConnectors$, null);
-    set(reloadAgentConnectors$);
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/job-detail/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/job-detail/connectors.ts
@@ -51,7 +51,7 @@ export const authorizeAgentConnector$ = command(
       set(internalAuthorizedConnectors$, await get(authorizedConnectors$));
     }
     set(internalAuthorizedConnectors$, (prev) => {
-      return [...(prev ?? []), name];
+      return Array.from(new Set([...(prev ?? []), name]));
     });
   },
 );
@@ -74,19 +74,23 @@ export const discardAgentConnectorsDraft$ = command(({ set }) => {
 });
 
 export const saveAgentConnectors$ = command(
-  async ({ get, set }, signal: AbortSignal) => {
+  async (
+    { get, set },
+    name: string,
+    operation: "add" | "remove",
+    signal: AbortSignal,
+  ) => {
     const detail = await get(agentDetail$);
     signal.throwIfAborted();
     if (!detail?.agentId) {
       throw new Error("No agent detail loaded");
     }
 
-    const enabledTypes = get(internalAuthorizedConnectors$) ?? [];
     const client = get(zeroClient$)(zeroUserConnectorsContract);
     await accept(
       client.update({
         params: { id: detail.agentId },
-        body: { enabledTypes },
+        body: { enabledTypes: [name], operation },
         fetchOptions: { signal },
       }),
       [200],

--- a/turbo/apps/platform/src/signals/zero-page/job-detail/custom-connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/job-detail/custom-connectors.ts
@@ -32,14 +32,23 @@ const seededCustomConnectors$ = computed(async (get): Promise<string[]> => {
   return result.body.enabledIds;
 });
 
-const internalAdded$ = state<string[] | null>(null);
+type CustomConnectorsDraft = {
+  readonly agentId: string;
+  readonly enabledIds: readonly string[];
+};
+
+const internalAdded$ = state<CustomConnectorsDraft | null>(null);
 const internalToggleSaving$ = state(false);
 
 export const agentAddedCustomConnectors$ = computed(
   async (get): Promise<string[]> => {
+    const detail = await get(agentDetail$);
+    if (!detail?.agentId) {
+      return [];
+    }
     const local = get(internalAdded$);
-    if (local !== null) {
-      return local;
+    if (local?.agentId === detail.agentId) {
+      return [...local.enabledIds];
     }
     return await get(seededCustomConnectors$);
   },
@@ -49,27 +58,60 @@ export const agentCustomConnectorToggleSaving$ = computed((get): boolean => {
   return get(internalToggleSaving$);
 });
 
-const addAgentCustomConnector$ = command(
-  async ({ get, set }, id: string, _signal: AbortSignal) => {
-    if (get(internalAdded$) === null) {
-      set(internalAdded$, await get(seededCustomConnectors$));
+const setAgentCustomConnectorDraft$ = command(
+  async (
+    { get, set },
+    args: {
+      readonly id: string;
+      readonly operation: "add" | "remove";
+    },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const detail = await get(agentDetail$);
+    signal.throwIfAborted();
+    if (!detail?.agentId) {
+      return;
     }
-    set(internalAdded$, (prev) => {
-      return Array.from(new Set([...(prev ?? []), id]));
+    const current = get(internalAdded$);
+    const base =
+      current?.agentId === detail.agentId
+        ? current.enabledIds
+        : await get(seededCustomConnectors$);
+    signal.throwIfAborted();
+    const enabledIds =
+      args.operation === "add"
+        ? Array.from(new Set([...base, args.id]))
+        : base.filter((s) => {
+            return s !== args.id;
+          });
+    set(internalAdded$, {
+      agentId: detail.agentId,
+      enabledIds,
     });
   },
 );
 
-const removeAgentCustomConnector$ = command(
-  async ({ get, set }, id: string, _signal: AbortSignal) => {
-    if (get(internalAdded$) === null) {
-      set(internalAdded$, await get(seededCustomConnectors$));
-    }
-    set(internalAdded$, (prev) => {
-      return (prev ?? []).filter((s) => {
-        return s !== id;
-      });
+const clearAgentCustomConnectorDraft$ = command(
+  ({ set }, agentId: string): void => {
+    set(internalAdded$, (current) => {
+      return current?.agentId === agentId ? null : current;
     });
+  },
+);
+
+const addAgentCustomConnector$ = command(
+  async ({ set }, id: string, signal: AbortSignal) => {
+    await set(setAgentCustomConnectorDraft$, { id, operation: "add" }, signal);
+  },
+);
+
+const removeAgentCustomConnector$ = command(
+  async ({ set }, id: string, signal: AbortSignal) => {
+    await set(
+      setAgentCustomConnectorDraft$,
+      { id, operation: "remove" },
+      signal,
+    );
   },
 );
 
@@ -87,18 +129,23 @@ const saveAgentCustomConnectors$ = command(
     }
 
     const client = get(zeroClient$)(zeroAgentCustomConnectorsContract);
-    await accept(
-      client.update({
-        params: { id: detail.agentId },
-        body: { enabledIds: [id], operation },
-        fetchOptions: { signal },
-      }),
-      [200],
+    await withCleanup(
+      (async () => {
+        await accept(
+          client.update({
+            params: { id: detail.agentId },
+            body: { enabledIds: [id], operation },
+            fetchOptions: { signal },
+          }),
+          [200],
+        );
+        signal.throwIfAborted();
+      })(),
+      () => {
+        set(clearAgentCustomConnectorDraft$, detail.agentId);
+        set(reloadAgentCustomConnectors$);
+      },
     );
-    signal.throwIfAborted();
-
-    set(internalAdded$, null);
-    set(reloadAgentCustomConnectors$);
   },
 );
 

--- a/turbo/apps/platform/src/signals/zero-page/job-detail/custom-connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/job-detail/custom-connectors.ts
@@ -81,6 +81,7 @@ export const saveAgentCustomConnectors$ = command(
       client.update({
         params: { id: detail.agentId },
         body: { enabledIds },
+        fetchOptions: { signal },
       }),
       [200],
     );

--- a/turbo/apps/platform/src/signals/zero-page/job-detail/custom-connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/job-detail/custom-connectors.ts
@@ -49,7 +49,7 @@ export const addAgentCustomConnector$ = command(
       set(internalAdded$, await get(seededCustomConnectors$));
     }
     set(internalAdded$, (prev) => {
-      return [...(prev ?? []), id];
+      return Array.from(new Set([...(prev ?? []), id]));
     });
   },
 );
@@ -68,19 +68,23 @@ export const removeAgentCustomConnector$ = command(
 );
 
 export const saveAgentCustomConnectors$ = command(
-  async ({ get, set }, signal: AbortSignal) => {
+  async (
+    { get, set },
+    id: string,
+    operation: "add" | "remove",
+    signal: AbortSignal,
+  ) => {
     const detail = await get(agentDetail$);
     signal.throwIfAborted();
     if (!detail?.agentId) {
       throw new Error("No agent detail loaded");
     }
 
-    const enabledIds = get(internalAdded$) ?? [];
     const client = get(zeroClient$)(zeroAgentCustomConnectorsContract);
     await accept(
       client.update({
         params: { id: detail.agentId },
-        body: { enabledIds },
+        body: { enabledIds: [id], operation },
         fetchOptions: { signal },
       }),
       [200],

--- a/turbo/apps/platform/src/signals/zero-page/job-detail/custom-connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/job-detail/custom-connectors.ts
@@ -1,6 +1,7 @@
 import { command, computed, state } from "ccstate";
 import { zeroAgentCustomConnectorsContract } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
 import { zeroClient$ } from "../../api-client.ts";
+import { withCleanup } from "../../utils.ts";
 import { accept } from "../../../lib/accept.ts";
 import { agentDetail$ } from "./detail.ts";
 
@@ -32,6 +33,7 @@ const seededCustomConnectors$ = computed(async (get): Promise<string[]> => {
 });
 
 const internalAdded$ = state<string[] | null>(null);
+const internalToggleSaving$ = state(false);
 
 export const agentAddedCustomConnectors$ = computed(
   async (get): Promise<string[]> => {
@@ -43,7 +45,11 @@ export const agentAddedCustomConnectors$ = computed(
   },
 );
 
-export const addAgentCustomConnector$ = command(
+export const agentCustomConnectorToggleSaving$ = computed((get): boolean => {
+  return get(internalToggleSaving$);
+});
+
+const addAgentCustomConnector$ = command(
   async ({ get, set }, id: string, _signal: AbortSignal) => {
     if (get(internalAdded$) === null) {
       set(internalAdded$, await get(seededCustomConnectors$));
@@ -54,7 +60,7 @@ export const addAgentCustomConnector$ = command(
   },
 );
 
-export const removeAgentCustomConnector$ = command(
+const removeAgentCustomConnector$ = command(
   async ({ get, set }, id: string, _signal: AbortSignal) => {
     if (get(internalAdded$) === null) {
       set(internalAdded$, await get(seededCustomConnectors$));
@@ -67,7 +73,7 @@ export const removeAgentCustomConnector$ = command(
   },
 );
 
-export const saveAgentCustomConnectors$ = command(
+const saveAgentCustomConnectors$ = command(
   async (
     { get, set },
     id: string,
@@ -93,5 +99,39 @@ export const saveAgentCustomConnectors$ = command(
 
     set(internalAdded$, null);
     set(reloadAgentCustomConnectors$);
+  },
+);
+
+export const toggleAgentCustomConnector$ = command(
+  async (
+    { get, set },
+    id: string,
+    checked: boolean,
+    signal: AbortSignal,
+  ): Promise<boolean> => {
+    if (get(internalToggleSaving$)) {
+      return false;
+    }
+    set(internalToggleSaving$, true);
+    await withCleanup(
+      (async () => {
+        if (checked) {
+          await set(addAgentCustomConnector$, id, signal);
+        } else {
+          await set(removeAgentCustomConnector$, id, signal);
+        }
+        await set(
+          saveAgentCustomConnectors$,
+          id,
+          checked ? "add" : "remove",
+          signal,
+        );
+      })(),
+      () => {
+        set(internalToggleSaving$, false);
+      },
+    );
+    signal.throwIfAborted();
+    return true;
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/settings/connector-access-management.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connector-access-management.ts
@@ -186,27 +186,13 @@ export const setConnectorAgentAuthorization$ = command(
     signal: AbortSignal,
   ): Promise<void> => {
     const client = get(zeroClient$)(zeroUserConnectorsContract);
-    const current = await accept(
-      client.get({
-        params: { id: params.agentId },
-        fetchOptions: { signal },
-      }),
-      [200],
-    );
-    signal.throwIfAborted();
-
-    const nextEnabledTypes = params.authorized
-      ? Array.from(
-          new Set([...current.body.enabledTypes, params.connectorType]),
-        )
-      : current.body.enabledTypes.filter((type) => {
-          return type !== params.connectorType;
-        });
-
     await accept(
       client.update({
         params: { id: params.agentId },
-        body: { enabledTypes: nextEnabledTypes },
+        body: {
+          enabledTypes: [params.connectorType],
+          operation: params.authorized ? "add" : "remove",
+        },
         fetchOptions: { signal },
       }),
       [200],

--- a/turbo/apps/platform/src/signals/zero-page/settings/connector-access-management.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connector-access-management.ts
@@ -5,9 +5,10 @@ import type { TeamComposeItem } from "@vm0/api-contracts/contracts/zero-team";
 import type { UserPermissionGrantResponse } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import { zeroClient$ } from "../../api-client.ts";
 import { agents$ } from "../../agent.ts";
-import { accept } from "../../../lib/accept.ts";
+import { ApiError, accept } from "../../../lib/accept.ts";
 import { userPermissionGrantsByAgent } from "../../permission-allow/permission-allow-signals.ts";
 import { reloadAgentConnectorAuthorizations$ } from "../agent-connector-authorizations.ts";
+import { settle } from "../../utils.ts";
 
 export interface ConnectorAgentAccessRow {
   readonly agent: TeamComposeItem;
@@ -162,19 +163,40 @@ function createConnectorAgentAccessRowsFactory(): (
     const atom$ = computed(
       async (get): Promise<readonly ConnectorAgentAccessRow[]> => {
         const authorizations = await get(connectorAgentAuthorizations$);
-        return await Promise.all(
-          authorizations.map(async ({ agent, enabledTypes }) => {
-            const authorized = enabledTypes.includes(params.connectorType);
-            const grants = authorized
-              ? await get(userPermissionGrantsByAgent({ agentId: agent.id }))
-              : [];
-            return {
+        const rows = await Promise.all(
+          authorizations.map(
+            async ({
               agent,
-              authorized,
-              grants,
-            };
-          }),
+              enabledTypes,
+            }): Promise<ConnectorAgentAccessRow | null> => {
+              const authorized = enabledTypes.includes(params.connectorType);
+              let grants: readonly UserPermissionGrantResponse[] = [];
+              if (authorized) {
+                const grantsResult = await settle(
+                  get(userPermissionGrantsByAgent({ agentId: agent.id })),
+                );
+                if (!grantsResult.ok) {
+                  if (
+                    grantsResult.error instanceof ApiError &&
+                    grantsResult.error.status === 404
+                  ) {
+                    return null;
+                  }
+                  throw grantsResult.error;
+                }
+                grants = grantsResult.value;
+              }
+              return {
+                agent,
+                authorized,
+                grants,
+              };
+            },
+          ),
         );
+        return rows.filter((row): row is ConnectorAgentAccessRow => {
+          return row !== null;
+        });
       },
     );
     cache.set(params.connectorType, atom$);

--- a/turbo/apps/platform/src/signals/zero-page/settings/connector-access-management.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connector-access-management.ts
@@ -96,19 +96,27 @@ export const connectorAgentAuthorizations$ = computed(
     get(internalConnectorAccessManagementReload$);
     const allAgents = await get(agents$);
     const client = get(zeroClient$)(zeroUserConnectorsContract);
-    return await Promise.all(
-      allAgents.map(async (agent) => {
-        const result = await accept(
-          client.get({ params: { id: agent.id } }),
-          [200],
-          { toast: false },
-        );
-        return {
-          agent,
-          enabledTypes: result.body.enabledTypes,
-        };
-      }),
+    const rows = await Promise.all(
+      allAgents.map(
+        async (agent): Promise<ConnectorAgentAuthorizationRow | null> => {
+          const result = await accept(
+            client.get({ params: { id: agent.id } }),
+            [200, 404],
+            { toast: false },
+          );
+          if (result.status === 404) {
+            return null;
+          }
+          return {
+            agent,
+            enabledTypes: result.body.enabledTypes,
+          };
+        },
+      ),
     );
+    return rows.filter((row): row is ConnectorAgentAuthorizationRow => {
+      return row !== null;
+    });
   },
 );
 

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -817,6 +817,7 @@ const finishConnectorConnection$ = command(
     }
     if (options.showPermissionDialog) {
       set(internalPermissionDialogType$, type);
+      set(internalPermissionDialogLabel$, options.connectorLabel ?? type);
     }
     if (options.clearSelectedConnector) {
       set(internalSelectedConnectorType$, null);
@@ -970,10 +971,15 @@ export const disconnectConnector$ = command(
 // ---------------------------------------------------------------------------
 
 const internalPermissionDialogType$ = state<ConnectorType | null>(null);
+const internalPermissionDialogLabel$ = state<string | null>(null);
 
 /** Connector type to show the permission dialog for (null = hidden). */
 export const permissionDialogType$ = computed((get) => {
   return get(internalPermissionDialogType$);
+});
+
+export const permissionDialogLabel$ = computed((get) => {
+  return get(internalPermissionDialogLabel$);
 });
 
 export const setPermissionDialogType$ = command(
@@ -982,6 +988,7 @@ export const setPermissionDialogType$ = command(
       set(resetPermissionDialog$);
     }
     set(internalPermissionDialogType$, type);
+    set(internalPermissionDialogLabel$, type);
   },
 );
 

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -672,6 +672,45 @@ export const connectorExternalCodeState$ = computed((get) => {
   return get(internalConnectorExternalCodeState$);
 });
 
+function connectorOAuthDeviceAuthStateIsActive(
+  state: ConnectorOAuthDeviceAuthState,
+): boolean {
+  return (
+    state.status === "starting" ||
+    state.status === "pending" ||
+    state.status === "polling"
+  );
+}
+
+function connectorExternalCodeStateIsActive(
+  state: ConnectorExternalCodeState,
+): boolean {
+  return (
+    state.status === "starting" ||
+    state.status === "pending" ||
+    state.status === "completing"
+  );
+}
+
+function connectorConnectOperationIsActive({
+  authCodeConnectorType,
+  connectFlow,
+  deviceAuthState,
+  externalCodeState,
+}: {
+  readonly authCodeConnectorType: ConnectorType | null;
+  readonly connectFlow: ConnectorConnectFlowState | null;
+  readonly deviceAuthState: ConnectorOAuthDeviceAuthState;
+  readonly externalCodeState: ConnectorExternalCodeState;
+}): boolean {
+  return (
+    authCodeConnectorType !== null ||
+    connectFlow !== null ||
+    connectorOAuthDeviceAuthStateIsActive(deviceAuthState) ||
+    connectorExternalCodeStateIsActive(externalCodeState)
+  );
+}
+
 function connectorOAuthDeviceAuthStartOptionsKey(
   type: ConnectorType,
   authMethod: ConnectorAuthMethodId,
@@ -845,7 +884,18 @@ export const submitManualGrant$ = command(
     { get, set },
     { type, authMethod, inputValues, options }: SubmitManualGrantParams,
     signal: AbortSignal,
-  ) => {
+  ): Promise<boolean> => {
+    if (
+      connectorConnectOperationIsActive({
+        authCodeConnectorType: get(internalPollingOAuthAuthCodeConnectorType$),
+        connectFlow: get(internalConnectFlowState$),
+        deviceAuthState: get(internalConnectorOAuthDeviceAuthState$),
+        externalCodeState: get(internalConnectorExternalCodeState$),
+      })
+    ) {
+      return false;
+    }
+
     const flow = createConnectorConnectFlowState(type);
     set(internalConnectFlowState$, flow);
     return await withCleanup(
@@ -868,6 +918,7 @@ export const submitManualGrant$ = command(
           ...options,
           toastMessage: `${options.connectorLabel ?? type} connected successfully`,
         });
+        return true;
       })(),
       () => {
         set(internalConnectFlowState$, (current) => {
@@ -1258,6 +1309,17 @@ const connectConnectorOAuthDeviceAuth$ = command(
     signal: AbortSignal,
   ): Promise<boolean> => {
     const { type, authMethod, options, startOptions } = args;
+    if (
+      connectorConnectOperationIsActive({
+        authCodeConnectorType: get(internalPollingOAuthAuthCodeConnectorType$),
+        connectFlow: get(internalConnectFlowState$),
+        deviceAuthState: get(internalConnectorOAuthDeviceAuthState$),
+        externalCodeState: get(internalConnectorExternalCodeState$),
+      })
+    ) {
+      return false;
+    }
+
     const flow = createConnectorConnectFlowState(type);
     set(internalConnectFlowState$, flow);
     let requestId: string | null = null;
@@ -1510,6 +1572,17 @@ export const connectConnectorExternalCode$ = command(
     signal: AbortSignal,
   ): Promise<boolean> => {
     const { type, authMethod } = args;
+    if (
+      connectorConnectOperationIsActive({
+        authCodeConnectorType: get(internalPollingOAuthAuthCodeConnectorType$),
+        connectFlow: get(internalConnectFlowState$),
+        deviceAuthState: get(internalConnectorOAuthDeviceAuthState$),
+        externalCodeState: get(internalConnectorExternalCodeState$),
+      })
+    ) {
+      return false;
+    }
+
     const flow = createConnectorConnectFlowState(type);
     set(internalConnectFlowState$, flow);
     let requestId: string | null = null;
@@ -1801,6 +1874,45 @@ function connectorMatchesAuthMethod(
   return connector.type === type && connector.authMethod === authMethod;
 }
 
+function createConnectorOAuthAuthCodeChangedCommand(
+  type: ConnectorType,
+  authMethod: ConnectorAuthMethodId,
+) {
+  // Snapshot taken on the first body invocation: `null` marks "no connector
+  // yet" and an `updatedAt` value marks "reconnect scenario — wait for it to
+  // change". The snapshot must happen inside the loop body so we start from the
+  // freshest server state, not a cached signal value.
+  let initialUpdatedAt: string | null | undefined;
+
+  return command(async ({ get }, sig: AbortSignal): Promise<boolean> => {
+    const client = get(zeroClient$)(zeroConnectorsMainContract);
+    const result = await accept(
+      client.list({ fetchOptions: { signal: sig } }),
+      [200],
+    );
+    const polled = (result.body as ConnectorListResponse).connectors;
+    const current = polled.find((c) => {
+      return connectorMatchesAuthMethod(c, type, authMethod);
+    });
+
+    if (initialUpdatedAt === undefined) {
+      initialUpdatedAt = current?.updatedAt ?? null;
+      return false;
+    }
+    if (current) {
+      // initialUpdatedAt === null means the connector didn't exist on the first
+      // fetch; any subsequent appearance signals completion.
+      if (initialUpdatedAt === null) {
+        return true;
+      }
+      if (current.updatedAt !== initialUpdatedAt) {
+        return true;
+      }
+    }
+    return false;
+  });
+}
+
 const openConnectorOAuthAuthCodeWindow$ = command(
   async (
     { get },
@@ -1866,7 +1978,14 @@ export const connectConnectorOAuthAuthCode$ = command(
     signal: AbortSignal,
   ) => {
     signal.throwIfAborted();
-    if (get(internalPollingOAuthAuthCodeConnectorType$) !== null) {
+    if (
+      connectorConnectOperationIsActive({
+        authCodeConnectorType: get(internalPollingOAuthAuthCodeConnectorType$),
+        connectFlow: get(internalConnectFlowState$),
+        deviceAuthState: get(internalConnectorOAuthDeviceAuthState$),
+        externalCodeState: get(internalConnectorExternalCodeState$),
+      })
+    ) {
       return false;
     }
 
@@ -1886,41 +2005,9 @@ export const connectConnectorOAuthAuthCode$ = command(
 
         // Wait for the auth-code OAuth flow to complete. The callback publishes
         // `connector:changed`, and the subscription rechecks the server state.
-        // Snapshot taken on the first body invocation: `null` marks "no
-        // connector yet" and an `updatedAt` value marks "reconnect scenario —
-        // wait for it to change". The snapshot must happen *inside* the loop
-        // body so we start from the freshest server state, not a cached signal
-        // value.
-        let initialUpdatedAt: string | null | undefined;
-
-        const onConnectorChanged$ = command(
-          async ({ get }, sig: AbortSignal): Promise<boolean> => {
-            const client = get(zeroClient$)(zeroConnectorsMainContract);
-            const result = await accept(
-              client.list({ fetchOptions: { signal: sig } }),
-              [200],
-            );
-            const polled = (result.body as ConnectorListResponse).connectors;
-            const current = polled.find((c) => {
-              return connectorMatchesAuthMethod(c, type, authMethod);
-            });
-
-            if (initialUpdatedAt === undefined) {
-              initialUpdatedAt = current?.updatedAt ?? null;
-              return false;
-            }
-            if (current) {
-              // initialUpdatedAt === null means the connector didn't exist on
-              // the first fetch; any subsequent appearance signals completion.
-              if (initialUpdatedAt === null) {
-                return true;
-              }
-              if (current.updatedAt !== initialUpdatedAt) {
-                return true;
-              }
-            }
-            return false;
-          },
+        const onConnectorChanged$ = createConnectorOAuthAuthCodeChangedCommand(
+          type,
+          authMethod,
         );
 
         // Prime once so `initialUpdatedAt` snapshots the current server state.

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -1455,6 +1455,7 @@ export const connectConnectorOAuthDeviceAuthAndSettle$ = command(
       signal,
     );
     if (connected) {
+      signal.throwIfAborted();
       await args.onSuccess();
     }
   },
@@ -1784,6 +1785,7 @@ export const completeConnectorExternalCodeAndSettle$ = command(
       signal,
     );
     if (connected) {
+      signal.throwIfAborted();
       await args.onSuccess();
     }
   },
@@ -2123,6 +2125,7 @@ export const connectConnectorOAuthAuthCodeAndSettle$ = command(
       signal,
     );
     if (connected) {
+      signal.throwIfAborted();
       await args.onSuccess();
     }
   },

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -6,7 +6,6 @@ import { accept } from "../../../lib/accept.ts";
 import { now } from "../../../lib/time.ts";
 import {
   CONNECTOR_DISPLAY_CATEGORY_ORDER,
-  CONNECTOR_TYPES,
   connectorAuthMethodIdSchema,
   connectorTypeSchema,
   type ConnectorAuthMethodId,
@@ -14,11 +13,6 @@ import {
   type ConnectorType,
   type ConnectorDisplayCategory,
 } from "@vm0/connectors/connectors";
-import {
-  getConnectorAuthMethod,
-  hasConnectorDeviceAuthGrant,
-  hasConnectorExternalCodeGrant,
-} from "@vm0/connectors/connector-utils";
 import {
   zeroConnectorScopeDiffContract,
   zeroConnectorExternalCodeSessionContract,
@@ -69,6 +63,7 @@ const { get$: hiddenConnectorTypesRaw$, set$: setHiddenConnectorTypes$ } =
   localStorageSignals(HIDDEN_CONNECTIONS_STORAGE_KEY);
 type PostConnectOptions = {
   readonly showPermissionDialog?: boolean;
+  readonly connectorLabel?: string;
 };
 export type ConnectorConnectionStatus =
   | "not-connected"
@@ -118,6 +113,87 @@ const DAY_MS = 24 * HOUR_MS;
 
 type ConnectorConnectLaunchMode = "oauth-auth-code" | "modal";
 
+export type ConnectorStatusAuthMethodDetail = Omit<
+  PublicConnectorCatalogAuthMethodDetail,
+  "id"
+> & {
+  readonly id: ConnectorAuthMethodId;
+};
+
+type ConnectorStatusGrantKind =
+  PublicConnectorCatalogAuthMethodDetail["grantKind"];
+
+function parseConnectorStatusAuthMethodDetail(
+  connector: ConnectorTypeWithStatus,
+  method: PublicConnectorCatalogAuthMethodDetail,
+): ConnectorStatusAuthMethodDetail | null {
+  const id = parseConnectorAuthMethodId(method.id);
+  if (!id || !connector.availableAuthMethods.includes(id)) {
+    return null;
+  }
+  return { ...method, id };
+}
+
+export function getConnectorStatusAuthMethod(
+  connector: ConnectorTypeWithStatus,
+  authMethod: ConnectorAuthMethodId,
+): ConnectorStatusAuthMethodDetail | null {
+  for (const method of connector.authMethods) {
+    if (method.id !== authMethod) {
+      continue;
+    }
+    return parseConnectorStatusAuthMethodDetail(connector, method);
+  }
+  return null;
+}
+
+export function getConnectorStatusAuthMethodsByGrantKind(
+  connector: ConnectorTypeWithStatus,
+  grantKind: ConnectorStatusGrantKind,
+): ConnectorStatusAuthMethodDetail[] {
+  return connector.authMethods.flatMap((method) => {
+    if (method.grantKind !== grantKind) {
+      return [];
+    }
+    const parsed = parseConnectorStatusAuthMethodDetail(connector, method);
+    return parsed ? [parsed] : [];
+  });
+}
+
+export function getOnlyManualConnectorStatusAuthMethod(
+  connector: ConnectorTypeWithStatus,
+): ConnectorStatusAuthMethodDetail | null {
+  const methods = getConnectorStatusAuthMethodsByGrantKind(connector, "manual");
+  return methods.length === 1 ? (methods[0] ?? null) : null;
+}
+
+export function hasConnectorStatusProviderDrivenConnectMethod(
+  connector: ConnectorTypeWithStatus,
+): boolean {
+  return connector.authMethods.some((method) => {
+    const parsed = parseConnectorStatusAuthMethodDetail(connector, method);
+    if (!parsed) {
+      return false;
+    }
+    return (
+      parsed.grantKind === "auth-code" ||
+      parsed.grantKind === "device-auth" ||
+      parsed.grantKind === "external-code" ||
+      parsed.grantKind === "managed"
+    );
+  });
+}
+
+export function hasConnectorStatusAuthCodeGrant(
+  connector: ConnectorTypeWithStatus,
+): boolean {
+  return getConnectorStatusAuthMethodsByGrantKind(connector, "auth-code").some(
+    () => {
+      return true;
+    },
+  );
+}
+
 export function getConnectorStatusConnectLaunchMode(
   connector: ConnectorTypeWithStatus,
   {
@@ -144,14 +220,8 @@ export function getAvailableStatusAuthCodeAuthMethod(
   if (!parsed.success) {
     return null;
   }
-  if (!connector.availableAuthMethods.includes(parsed.data)) {
-    return null;
-  }
-  if (
-    !connector.authMethods.some((method) => {
-      return method.id === parsed.data && method.grantKind === "auth-code";
-    })
-  ) {
+  const method = getConnectorStatusAuthMethod(connector, parsed.data);
+  if (method?.grantKind !== "auth-code") {
     return null;
   }
   return parsed.data;
@@ -726,7 +796,7 @@ const finishConnectorConnection$ = command(
 
     if (options.toastMessage !== null) {
       toast.success(
-        options.toastMessage ?? `${CONNECTOR_TYPES[type].label} connected`,
+        options.toastMessage ?? `${options.connectorLabel ?? type} connected`,
         {
           id: `connector-connected-${type}`,
         },
@@ -779,7 +849,7 @@ export const submitManualGrant$ = command(
         signal.throwIfAborted();
         set(finishConnectorConnection$, type, {
           ...options,
-          toastMessage: `${CONNECTOR_TYPES[type].label} connected successfully`,
+          toastMessage: `${options.connectorLabel ?? type} connected successfully`,
         });
       })(),
       () => {
@@ -860,7 +930,12 @@ export const justConnectedTypes$ = computed((get) => {
  * `connected = false` from the API (regression #10272).
  */
 export const disconnectConnector$ = command(
-  async ({ set }, type: ConnectorType, signal: AbortSignal): Promise<void> => {
+  async (
+    { set },
+    type: ConnectorType,
+    connectorLabel: string,
+    signal: AbortSignal,
+  ): Promise<void> => {
     await set(deleteConnector$, type, signal);
     signal.throwIfAborted();
     set(internalJustConnectedTypes$, (prev) => {
@@ -871,7 +946,7 @@ export const disconnectConnector$ = command(
       next.delete(type);
       return next;
     });
-    toast.success(`${CONNECTOR_TYPES[type].label} disconnected`, {
+    toast.success(`${connectorLabel} disconnected`, {
       id: `connector-disconnected-${type}`,
     });
   },
@@ -1165,11 +1240,6 @@ const connectConnectorOAuthDeviceAuth$ = command(
     signal: AbortSignal,
   ): Promise<boolean> => {
     const { type, authMethod, options, startOptions } = args;
-    if (!hasConnectorDeviceAuthGrant(type)) {
-      throw new Error(`${type} does not use device authorization OAuth`);
-    }
-    assertConnectorUsesDeviceAuthMethod(type, authMethod);
-
     const flow = createConnectorConnectFlowState(type);
     set(internalConnectFlowState$, flow);
     let requestId: string | null = null;
@@ -1422,11 +1492,6 @@ export const connectConnectorExternalCode$ = command(
     signal: AbortSignal,
   ): Promise<boolean> => {
     const { type, authMethod } = args;
-    if (!hasConnectorExternalCodeGrant(type)) {
-      throw new Error(`${type} does not use external-code authorization`);
-    }
-    assertConnectorUsesExternalCodeMethod(type, authMethod);
-
     const flow = createConnectorConnectFlowState(type);
     set(internalConnectFlowState$, flow);
     let requestId: string | null = null;
@@ -1518,8 +1583,6 @@ const completeConnectorExternalCode$ = command(
     signal: AbortSignal,
   ): Promise<boolean> => {
     const { type, authMethod, options } = args;
-    assertConnectorUsesExternalCodeMethod(type, authMethod);
-
     const current = get(internalConnectorExternalCodeState$);
     if (
       current.status !== "pending" ||
@@ -1540,10 +1603,9 @@ const completeConnectorExternalCode$ = command(
 
     const code = current.code.trim();
     if (!code) {
-      const connectorLabel = CONNECTOR_TYPES[type].label;
       set(internalConnectorExternalCodeState$, {
         ...current,
-        errorMessage: `Enter the authorization code from ${connectorLabel}.`,
+        errorMessage: `Enter the authorization code from ${options.connectorLabel ?? type}.`,
       });
       return false;
     }
@@ -1713,47 +1775,6 @@ const resetOAuthAuthCodeConnectorPopupSignal$ = resetSignal();
 // Connect command
 // ---------------------------------------------------------------------------
 
-function assertConnectorUsesAuthCodeMethod(
-  type: ConnectorType,
-  authMethod: ConnectorAuthMethodId,
-): void {
-  const method = getConnectorAuthMethod(type, authMethod);
-  if (!method) {
-    throw new Error(`${type} does not have ${authMethod} auth method`);
-  }
-  if (method.grant.kind !== "auth-code") {
-    throw new Error(`${type} ${authMethod} does not use an auth-code grant`);
-  }
-}
-
-function assertConnectorUsesDeviceAuthMethod(
-  type: ConnectorType,
-  authMethod: ConnectorAuthMethodId,
-): void {
-  const method = getConnectorAuthMethod(type, authMethod);
-  if (!method) {
-    throw new Error(`${type} does not have ${authMethod} auth method`);
-  }
-  if (method.grant.kind !== "device-auth") {
-    throw new Error(`${type} ${authMethod} does not use a device-auth grant`);
-  }
-}
-
-function assertConnectorUsesExternalCodeMethod(
-  type: ConnectorType,
-  authMethod: ConnectorAuthMethodId,
-): void {
-  const method = getConnectorAuthMethod(type, authMethod);
-  if (!method) {
-    throw new Error(`${type} does not have ${authMethod} auth method`);
-  }
-  if (method.grant.kind !== "external-code") {
-    throw new Error(
-      `${type} ${authMethod} does not use an external-code grant`,
-    );
-  }
-}
-
 function connectorMatchesAuthMethod(
   connector: ConnectorResponse,
   type: ConnectorType,
@@ -1769,8 +1790,6 @@ const openConnectorOAuthAuthCodeWindow$ = command(
     authMethod: ConnectorAuthMethodId,
     signal: AbortSignal,
   ) => {
-    assertConnectorUsesAuthCodeMethod(type, authMethod);
-
     const standalone = isStandaloneMode();
 
     // In standalone (PWA) mode, omit popup features so iOS Safari opens the
@@ -1813,8 +1832,6 @@ export const connectConnectorOAuthAuthCode$ = command(
     options: PostConnectOptions,
     signal: AbortSignal,
   ) => {
-    assertConnectorUsesAuthCodeMethod(type, authMethod);
-
     const flow = createConnectorConnectFlowState(type);
     set(internalConnectFlowState$, flow);
     set(internalPollingOAuthAuthCodeConnectorType$, type);

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -816,8 +816,11 @@ const finishConnectorConnection$ = command(
       );
     }
     if (options.showPermissionDialog) {
-      set(internalPermissionDialogType$, type);
-      set(internalPermissionDialogLabel$, options.connectorLabel ?? type);
+      set(resetPermissionDialog$);
+      set(internalPermissionDialog$, {
+        type,
+        label: options.connectorLabel ?? type,
+      });
     }
     if (options.clearSelectedConnector) {
       set(internalSelectedConnectorType$, null);
@@ -970,27 +973,22 @@ export const disconnectConnector$ = command(
 // Post-connect permission dialog state
 // ---------------------------------------------------------------------------
 
-const internalPermissionDialogType$ = state<ConnectorType | null>(null);
-const internalPermissionDialogLabel$ = state<string | null>(null);
+interface PermissionDialogState {
+  readonly type: ConnectorType;
+  readonly label: string;
+}
 
-/** Connector type to show the permission dialog for (null = hidden). */
-export const permissionDialogType$ = computed((get) => {
-  return get(internalPermissionDialogType$);
+const internalPermissionDialog$ = state<PermissionDialogState | null>(null);
+
+/** Connector permission dialog to show after a successful connection. */
+export const permissionDialog$ = computed((get) => {
+  return get(internalPermissionDialog$);
 });
 
-export const permissionDialogLabel$ = computed((get) => {
-  return get(internalPermissionDialogLabel$);
+export const closePermissionDialog$ = command(({ set }) => {
+  set(resetPermissionDialog$);
+  set(internalPermissionDialog$, null);
 });
-
-export const setPermissionDialogType$ = command(
-  ({ set }, type: ConnectorType | null) => {
-    if (type !== null) {
-      set(resetPermissionDialog$);
-    }
-    set(internalPermissionDialogType$, type);
-    set(internalPermissionDialogLabel$, type);
-  },
-);
 
 function createConnectorConnectFlowState(
   type: ConnectorType,

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -1818,6 +1818,9 @@ const openConnectorOAuthAuthCodeWindow$ = command(
     if (!authWindow && !standalone) {
       throw new Error("Failed to open authorization window");
     }
+    if (authWindow) {
+      authWindow.opener = null;
+    }
 
     let navigated = false;
     await withCleanup(

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -1803,7 +1803,7 @@ export function isStandaloneMode(): boolean {
   return window.matchMedia("(display-mode: standalone)").matches;
 }
 
-const OAUTH_AUTH_CODE_POPUP_CLOSED_POLL_MS = 250;
+const OAUTH_AUTH_CODE_POPUP_CLOSED_POLL_MS = IN_VITEST ? 10 : 250;
 
 function waitForOAuthAuthCodePopupClosed(
   authWindow: Pick<Window, "closed">,

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -212,10 +212,7 @@ export function getConnectorStatusConnectLaunchMode(
     preferModalForConnectorNotice = false,
   }: { readonly preferModalForConnectorNotice?: boolean } = {},
 ): ConnectorConnectLaunchMode {
-  if (
-    connector.availableAuthMethods.length !== 1 ||
-    !connector.singleAuthCodeAuthMethodId
-  ) {
+  if (!getOnlyAvailableStatusAuthCodeAuthMethod(connector)) {
     return "modal";
   }
   if (preferModalForConnectorNotice && connector.connectNotice) {
@@ -242,8 +239,12 @@ export function getAvailableStatusAuthCodeAuthMethod(
 export function getOnlyAvailableStatusAuthCodeAuthMethod(
   connector: ConnectorTypeWithStatus,
 ): ConnectorAuthMethodId | null {
-  const [authMethod] = connector.availableAuthMethods;
-  if (connector.availableAuthMethods.length !== 1 || !authMethod) {
+  const authMethod = connector.singleAuthCodeAuthMethodId;
+  if (
+    connector.availableAuthMethods.length !== 1 ||
+    !authMethod ||
+    connector.availableAuthMethods[0] !== authMethod
+  ) {
     return null;
   }
   return getAvailableStatusAuthCodeAuthMethod(connector, authMethod);

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -120,6 +120,18 @@ export type ConnectorStatusAuthMethodDetail = Omit<
   readonly id: ConnectorAuthMethodId;
 };
 
+export function manualGrantInputValuesForMethod(
+  method: Pick<ConnectorStatusAuthMethodDetail, "manualFields">,
+  values: Readonly<Record<string, string>>,
+): Record<string, string> {
+  return Object.fromEntries(
+    method.manualFields.flatMap((field) => {
+      const value = values[field.id];
+      return value === undefined ? [] : ([[field.id, value]] as const);
+    }),
+  );
+}
+
 type ConnectorStatusGrantKind =
   PublicConnectorCatalogAuthMethodDetail["grantKind"];
 

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -1844,6 +1844,11 @@ export const connectConnectorOAuthAuthCode$ = command(
     options: PostConnectOptions,
     signal: AbortSignal,
   ) => {
+    signal.throwIfAborted();
+    if (get(internalPollingOAuthAuthCodeConnectorType$) !== null) {
+      return false;
+    }
+
     const flow = createConnectorConnectFlowState(type);
     set(internalConnectFlowState$, flow);
     set(internalPollingOAuthAuthCodeConnectorType$, type);

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -1813,24 +1813,36 @@ const openConnectorOAuthAuthCodeWindow$ = command(
       throw new Error("Failed to open authorization window");
     }
 
-    const startClient = get(zeroClient$)(zeroConnectorOauthStartContract, {
-      apiBase: OAUTH_WEB_API_BASE,
-    });
-    const startResult = await accept(
-      startClient.start({
-        params: { type },
-        body: { authMethod },
-        fetchOptions: { signal },
-      }),
-      [200],
+    let navigated = false;
+    await withCleanup(
+      (async () => {
+        const startClient = get(zeroClient$)(zeroConnectorOauthStartContract, {
+          apiBase: OAUTH_WEB_API_BASE,
+        });
+        const startResult = await accept(
+          startClient.start({
+            params: { type },
+            body: { authMethod },
+            fetchOptions: { signal },
+          }),
+          [200],
+        );
+        signal.throwIfAborted();
+
+        if (authWindow) {
+          authWindow.location.href = startResult.body.authorizationUrl;
+          navigated = true;
+        } else if (standalone) {
+          window.location.href = startResult.body.authorizationUrl;
+        }
+      })(),
+      () => {
+        if (authWindow && !navigated) {
+          authWindow.close();
+        }
+      },
     );
     signal.throwIfAborted();
-
-    if (authWindow) {
-      authWindow.location.href = startResult.body.authorizationUrl;
-    } else if (standalone) {
-      window.location.href = startResult.body.authorizationUrl;
-    }
 
     return authWindow;
   },

--- a/turbo/apps/platform/src/signals/zero-page/settings/permission-dialog.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/permission-dialog.ts
@@ -61,22 +61,10 @@ export const confirmPermissionDialog$ = command(
     const results = await Promise.allSettled(
       [...selected].map(async (agentId) => {
         signal.throwIfAborted();
-        const existing = await accept(
-          client.get({
-            params: { id: agentId },
-            fetchOptions: { signal },
-          }),
-          [200],
-        );
-        signal.throwIfAborted();
-        const current = existing.body.enabledTypes;
-        if (current.includes(connectorType)) {
-          return;
-        }
         await accept(
           client.update({
             params: { id: agentId },
-            body: { enabledTypes: [...current, connectorType] },
+            body: { enabledTypes: [connectorType], operation: "add" },
             fetchOptions: { signal },
           }),
           [200],

--- a/turbo/apps/platform/src/signals/zero-page/settings/permission-dialog.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/permission-dialog.ts
@@ -61,14 +61,15 @@ export const confirmPermissionDialog$ = command(
     const results = await Promise.allSettled(
       [...selected].map(async (agentId) => {
         signal.throwIfAborted();
-        await accept(
+        const result = await accept(
           client.update({
             params: { id: agentId },
             body: { enabledTypes: [connectorType], operation: "add" },
             fetchOptions: { signal },
           }),
-          [200],
+          [200, 404],
         );
+        return result.status === 200;
       }),
     );
     signal.throwIfAborted();
@@ -78,9 +79,14 @@ export const confirmPermissionDialog$ = command(
     if (failed) {
       throw failed.reason;
     }
-    toast.success(
-      `${connectorLabel} enabled for ${selected.size} agent${selected.size > 1 ? "s" : ""}`,
-    );
+    const enabledCount = results.filter((result) => {
+      return result.status === "fulfilled" && result.value;
+    }).length;
+    if (enabledCount > 0) {
+      toast.success(
+        `${connectorLabel} enabled for ${enabledCount} agent${enabledCount > 1 ? "s" : ""}`,
+      );
+    }
     set(reloadAgentConnectorAuthorizations$);
     onClose();
   },

--- a/turbo/apps/platform/src/signals/zero-page/settings/permission-dialog.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/permission-dialog.ts
@@ -58,7 +58,7 @@ export const confirmPermissionDialog$ = command(
     }
     const createClient = get(zeroClient$);
     const client = createClient(zeroUserConnectorsContract);
-    await Promise.allSettled(
+    const results = await Promise.allSettled(
       [...selected].map(async (agentId) => {
         signal.throwIfAborted();
         const existing = await accept(
@@ -84,6 +84,12 @@ export const confirmPermissionDialog$ = command(
       }),
     );
     signal.throwIfAborted();
+    const failed = results.find((result): result is PromiseRejectedResult => {
+      return result.status === "rejected";
+    });
+    if (failed) {
+      throw failed.reason;
+    }
     toast.success(
       `${connectorLabel} enabled for ${selected.size} agent${selected.size > 1 ? "s" : ""}`,
     );

--- a/turbo/apps/platform/src/signals/zero-page/settings/permission-dialog.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/permission-dialog.ts
@@ -1,8 +1,5 @@
 import { command, computed, state } from "ccstate";
-import {
-  CONNECTOR_TYPES,
-  type ConnectorType,
-} from "@vm0/connectors/connectors";
+import type { ConnectorType } from "@vm0/connectors/connectors";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import { zeroClient$ } from "../../api-client.ts";
 import { toast } from "@vm0/ui/components/ui/sonner";
@@ -50,6 +47,7 @@ export const confirmPermissionDialog$ = command(
   async (
     { get, set },
     connectorType: ConnectorType,
+    connectorLabel: string,
     onClose: () => void,
     signal: AbortSignal,
   ): Promise<void> => {
@@ -86,9 +84,8 @@ export const confirmPermissionDialog$ = command(
       }),
     );
     signal.throwIfAborted();
-    const config = CONNECTOR_TYPES[connectorType];
     toast.success(
-      `${config.label} enabled for ${selected.size} agent${selected.size > 1 ? "s" : ""}`,
+      `${connectorLabel} enabled for ${selected.size} agent${selected.size > 1 ? "s" : ""}`,
     );
     set(reloadAgentConnectorAuthorizations$);
     onClose();

--- a/turbo/apps/platform/src/signals/zero-page/zero-connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-connectors.ts
@@ -34,34 +34,26 @@ export const zeroAuthorizedConnectors$ = computed(async (get) => {
 
 /** Grant the current agent access to a connector. */
 export const authorizeConnector$ = command(
-  async ({ get, set }, name: string, signal: AbortSignal) => {
-    const current = await get(authorizedConnectors$);
-    signal.throwIfAborted();
-    if (current.includes(name)) {
-      return;
-    }
-    await set(syncAuthorizedConnectors$, [...current, name], signal);
+  async ({ set }, name: string, signal: AbortSignal) => {
+    await set(updateAuthorizedConnectors$, "add", name, signal);
   },
 );
 
 /** Revoke the current agent's access to a connector. */
 export const deauthorizeConnector$ = command(
-  async ({ get, set }, name: string, signal: AbortSignal) => {
-    const current = await get(authorizedConnectors$);
-    signal.throwIfAborted();
-    await set(
-      syncAuthorizedConnectors$,
-      current.filter((n) => {
-        return n !== name;
-      }),
-      signal,
-    );
+  async ({ set }, name: string, signal: AbortSignal) => {
+    await set(updateAuthorizedConnectors$, "remove", name, signal);
   },
 );
 
-/** Persist the authorized connectors list to the server. */
-const syncAuthorizedConnectors$ = command(
-  async ({ get, set }, connectorValues: string[], signal: AbortSignal) => {
+/** Atomically add/remove an authorized connector on the server. */
+const updateAuthorizedConnectors$ = command(
+  async (
+    { get, set },
+    operation: "add" | "remove",
+    connectorValue: string,
+    signal: AbortSignal,
+  ) => {
     const agentId = await get(currentChatAgentRecordId$);
     signal.throwIfAborted();
     if (!agentId) {
@@ -72,7 +64,8 @@ const syncAuthorizedConnectors$ = command(
     await accept(
       client.update({
         params: { id: agentId },
-        body: { enabledTypes: connectorValues },
+        body: { enabledTypes: [connectorValue], operation },
+        fetchOptions: { signal },
       }),
       [200],
     );

--- a/turbo/apps/platform/src/views/components/loading-switch.tsx
+++ b/turbo/apps/platform/src/views/components/loading-switch.tsx
@@ -8,6 +8,7 @@ const compactSwitchClassName =
 interface LoadingSwitchProps {
   checked: boolean;
   loading?: boolean;
+  disabled?: boolean;
   onCheckedChange: (checked: boolean) => void;
   ariaLabel?: string;
   size?: "default" | "sm";
@@ -16,6 +17,7 @@ interface LoadingSwitchProps {
 export function LoadingSwitch({
   checked,
   loading = false,
+  disabled = false,
   onCheckedChange,
   ariaLabel,
   size = "default",
@@ -29,7 +31,7 @@ export function LoadingSwitch({
     >
       <Switch
         checked={checked}
-        disabled={loading}
+        disabled={loading || disabled}
         onCheckedChange={onCheckedChange}
         aria-label={ariaLabel}
         size={size}

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -60,6 +60,24 @@ function applyUserConnectorUpdate(
   return [...body.enabledTypes];
 }
 
+function applyCustomConnectorUpdate(
+  current: readonly string[],
+  body: {
+    readonly enabledIds: readonly string[];
+    readonly operation?: "replace" | "add" | "remove";
+  },
+): string[] {
+  if (body.operation === "add") {
+    return Array.from(new Set([...current, ...body.enabledIds]));
+  }
+  if (body.operation === "remove") {
+    return current.filter((id) => {
+      return !body.enabledIds.includes(id);
+    });
+  }
+  return [...body.enabledIds];
+}
+
 function createAgent(id: string, displayName: string): TeamComposeItem {
   return {
     id,
@@ -296,7 +314,10 @@ function mockTeamAPIs(): void {
   context.mocks.api(
     zeroAgentCustomConnectorsContract.update,
     ({ body, respond }) => {
-      enabledCustomConnectorIds = body.enabledIds;
+      enabledCustomConnectorIds = applyCustomConnectorUpdate(
+        enabledCustomConnectorIds,
+        body,
+      );
       return respond(200, { enabledIds: enabledCustomConnectorIds });
     },
   );

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -42,6 +42,24 @@ const context = testContext();
 const zeroAgentId = "c0000000-0000-4000-a000-000000000001";
 const researchAgentId = "a0000000-0000-4000-a000-000000000401";
 
+function applyUserConnectorUpdate(
+  current: readonly string[],
+  body: {
+    readonly enabledTypes: readonly string[];
+    readonly operation?: "replace" | "add" | "remove";
+  },
+): string[] {
+  if (body.operation === "add") {
+    return Array.from(new Set([...current, ...body.enabledTypes]));
+  }
+  if (body.operation === "remove") {
+    return current.filter((type) => {
+      return !body.enabledTypes.includes(type);
+    });
+  }
+  return [...body.enabledTypes];
+}
+
 function createAgent(id: string, displayName: string): TeamComposeItem {
   return {
     id,
@@ -266,7 +284,7 @@ function mockTeamAPIs(): void {
     return respond(200, { enabledTypes });
   });
   context.mocks.api(zeroUserConnectorsContract.update, ({ body, respond }) => {
-    enabledTypes = body.enabledTypes;
+    enabledTypes = applyUserConnectorUpdate(enabledTypes, body);
     return respond(200, { enabledTypes });
   });
   context.mocks.api(zeroCustomConnectorsContract.list, ({ respond }) => {

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -270,7 +270,13 @@ async function connectorCategoryLabel(
   return `${category} (${count})`;
 }
 
-function mockTeamAPIs(): void {
+function mockTeamAPIs({
+  customConnector = createCustomConnector(),
+  onCustomConnectorUpdate,
+}: {
+  readonly customConnector?: CustomConnectorResponse;
+  readonly onCustomConnectorUpdate?: () => void;
+} = {}): void {
   context.mocks.data.team([
     createAgent(zeroAgentId, "Zero"),
     createAgent(researchAgentId, "Research Agent"),
@@ -299,7 +305,6 @@ function mockTeamAPIs(): void {
   ]);
   const enabledTypesByAgent = new Map<string, string[]>();
   const enabledCustomConnectorIdsByAgent = new Map<string, string[]>();
-  const customConnector = createCustomConnector();
   context.mocks.api(zeroUserConnectorsContract.get, ({ params, respond }) => {
     return respond(200, {
       enabledTypes: enabledTypesByAgent.get(params.id) ?? [],
@@ -330,6 +335,7 @@ function mockTeamAPIs(): void {
   context.mocks.api(
     zeroAgentCustomConnectorsContract.update,
     ({ body, params, respond }) => {
+      onCustomConnectorUpdate?.();
       const enabledCustomConnectorIds = applyCustomConnectorUpdate(
         enabledCustomConnectorIdsByAgent.get(params.id) ?? [],
         body,
@@ -427,6 +433,43 @@ describe("team page navigation", () => {
         screen.queryByText("Custom connectors saved"),
       ).not.toBeInTheDocument();
     });
+  });
+
+  it("does not allow enabling custom connectors without a secret", async () => {
+    let updateCalls = 0;
+    mockTeamAPIs({
+      customConnector: {
+        ...createCustomConnector(),
+        connected: false,
+        missingRequiredFields: ["secret"],
+        configuredFieldKeys: [],
+        hasSecret: false,
+      },
+      onCustomConnectorUpdate: () => {
+        updateCalls += 1;
+      },
+    });
+
+    detachedSetupPage({ context, path: `/agents/${researchAgentId}` });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Research Agent" }),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Acme Search")).toBeInTheDocument();
+      expect(screen.getByText(/no secret set/)).toBeInTheDocument();
+    });
+
+    const toggle = screen.getByLabelText(
+      "Authorize Acme Search for this agent",
+    );
+    expect(toggle).toBeDisabled();
+
+    fireEvent.click(toggle);
+    expect(updateCalls).toBe(0);
+    expect(
+      screen.queryByText("Custom connectors saved"),
+    ).not.toBeInTheDocument();
   });
 
   it("does not reuse a failed connector authorization draft across agents", async () => {

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -37,6 +37,8 @@ import { pathname } from "../../../signals/location.ts";
 import { isoFromNowMs, mockNow } from "../../../__tests__/time.ts";
 import { createMockAutomationView } from "../../../mocks/handlers/automations-store.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { detachedNavigateTo$ } from "../../../signals/route.ts";
+import { ROUTES } from "../../../signals/route-paths.ts";
 
 const context = testContext();
 const zeroAgentId = "c0000000-0000-4000-a000-000000000001";
@@ -295,28 +297,46 @@ function mockTeamAPIs(): void {
       updatedAt: "2026-03-02T00:00:00Z",
     }),
   ]);
-  let enabledTypes: string[] = [];
-  let enabledCustomConnectorIds: string[] = [];
+  const enabledTypesByAgent = new Map<string, string[]>();
+  const enabledCustomConnectorIdsByAgent = new Map<string, string[]>();
   const customConnector = createCustomConnector();
-  context.mocks.api(zeroUserConnectorsContract.get, ({ respond }) => {
-    return respond(200, { enabledTypes });
+  context.mocks.api(zeroUserConnectorsContract.get, ({ params, respond }) => {
+    return respond(200, {
+      enabledTypes: enabledTypesByAgent.get(params.id) ?? [],
+    });
   });
-  context.mocks.api(zeroUserConnectorsContract.update, ({ body, respond }) => {
-    enabledTypes = applyUserConnectorUpdate(enabledTypes, body);
-    return respond(200, { enabledTypes });
-  });
+  context.mocks.api(
+    zeroUserConnectorsContract.update,
+    ({ body, params, respond }) => {
+      const enabledTypes = applyUserConnectorUpdate(
+        enabledTypesByAgent.get(params.id) ?? [],
+        body,
+      );
+      enabledTypesByAgent.set(params.id, enabledTypes);
+      return respond(200, { enabledTypes });
+    },
+  );
   context.mocks.api(zeroCustomConnectorsContract.list, ({ respond }) => {
     return respond(200, { connectors: [customConnector] });
   });
-  context.mocks.api(zeroAgentCustomConnectorsContract.get, ({ respond }) => {
-    return respond(200, { enabledIds: enabledCustomConnectorIds });
-  });
+  context.mocks.api(
+    zeroAgentCustomConnectorsContract.get,
+    ({ params, respond }) => {
+      return respond(200, {
+        enabledIds: enabledCustomConnectorIdsByAgent.get(params.id) ?? [],
+      });
+    },
+  );
   context.mocks.api(
     zeroAgentCustomConnectorsContract.update,
-    ({ body, respond }) => {
-      enabledCustomConnectorIds = applyCustomConnectorUpdate(
-        enabledCustomConnectorIds,
+    ({ body, params, respond }) => {
+      const enabledCustomConnectorIds = applyCustomConnectorUpdate(
+        enabledCustomConnectorIdsByAgent.get(params.id) ?? [],
         body,
+      );
+      enabledCustomConnectorIdsByAgent.set(
+        params.id,
+        enabledCustomConnectorIds,
       );
       return respond(200, { enabledIds: enabledCustomConnectorIds });
     },
@@ -330,10 +350,11 @@ function mockTeamAPIs(): void {
     });
   });
   context.mocks.api(zeroAgentsByIdContract.get, ({ params, respond }) => {
+    const agent = params.id === zeroAgentId ? "Zero" : "Research Agent";
     return respond(200, {
       agentId: params.id,
       ownerId: "test-owner-id",
-      displayName: "Research Agent",
+      displayName: agent,
       description: "Finds and summarizes information",
       sound: null,
       avatarUrl: null,
@@ -404,6 +425,48 @@ describe("team page navigation", () => {
     await waitFor(() => {
       expect(
         screen.queryByText("Custom connectors saved"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("does not reuse a failed connector authorization draft across agents", async () => {
+    mockTeamAPIs();
+    let updateCalls = 0;
+    context.mocks.api(zeroUserConnectorsContract.update, ({ respond }) => {
+      updateCalls += 1;
+      return respond(400, {
+        error: {
+          message: "Connector authorization save failed",
+          code: "VALIDATION_ERROR",
+        },
+      });
+    });
+
+    detachedSetupPage({ context, path: `/agents/${researchAgentId}` });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Research Agent" }),
+      ).toBeInTheDocument();
+      expect(screen.getByText("@octocat")).toBeInTheDocument();
+    });
+
+    click(screen.getByLabelText("Grant GitHub access"));
+    await waitFor(() => {
+      expect(updateCalls).toBe(1);
+    });
+
+    context.store.set(detachedNavigateTo$, ROUTES.agentDetail, {
+      pathParams: { agentId: zeroAgentId },
+      searchParams: new URLSearchParams(),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Zero" })).toBeInTheDocument();
+      expect(screen.getByText("@octocat")).toBeInTheDocument();
+      expect(screen.getByLabelText("Grant GitHub access")).toBeInTheDocument();
+      expect(
+        screen.queryByLabelText("Revoke GitHub access"),
       ).not.toBeInTheDocument();
     });
   });

--- a/turbo/apps/platform/src/views/team-page/job-custom-connectors-section.tsx
+++ b/turbo/apps/platform/src/views/team-page/job-custom-connectors-section.tsx
@@ -90,7 +90,7 @@ export function JobCustomConnectorsSection() {
     detach(
       (async () => {
         await mutate;
-        await save(pageSignal);
+        await save(id, checked ? "add" : "remove", pageSignal);
         toast.success("Custom connectors saved");
       })(),
       Reason.DomCallback,

--- a/turbo/apps/platform/src/views/team-page/job-custom-connectors-section.tsx
+++ b/turbo/apps/platform/src/views/team-page/job-custom-connectors-section.tsx
@@ -17,12 +17,14 @@ function CustomConnectorPermissionRow({
   connector,
   enabled,
   loading,
+  disabled,
   isLast,
   onToggle,
 }: {
   connector: CustomConnectorResponse;
   enabled: boolean;
   loading: boolean;
+  disabled: boolean;
   isLast: boolean;
   onToggle: (checked: boolean) => void;
 }) {
@@ -51,6 +53,7 @@ function CustomConnectorPermissionRow({
       <LoadingSwitch
         checked={enabled}
         loading={loading}
+        disabled={disabled}
         onCheckedChange={onToggle}
         ariaLabel={`Authorize ${connector.displayName} for this agent`}
       />
@@ -94,12 +97,14 @@ export function JobCustomConnectorsSection() {
         supplied a secret for can be toggled on.
       </div>
       {connectors.map((c, i) => {
+        const enabled = addedSet.has(c.id);
         return (
           <CustomConnectorPermissionRow
             key={c.id}
             connector={c}
-            enabled={addedSet.has(c.id)}
+            enabled={enabled}
             loading={saving}
+            disabled={!c.hasSecret && !enabled}
             isLast={i === connectors.length - 1}
             onToggle={(checked) => {
               return handleToggle(c.id, checked);

--- a/turbo/apps/platform/src/views/team-page/job-custom-connectors-section.tsx
+++ b/turbo/apps/platform/src/views/team-page/job-custom-connectors-section.tsx
@@ -1,19 +1,13 @@
-import {
-  useGet,
-  useLastLoadable,
-  useLastResolved,
-  useSet,
-} from "ccstate-react";
+import { useGet, useLastLoadable, useLastResolved } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import type { CustomConnectorResponse } from "@vm0/api-contracts/contracts/zero-custom-connectors";
 import { LoadingSwitch } from "../components/loading-switch.tsx";
 import { customConnectors$ } from "../../signals/zero-page/settings/custom-connectors.ts";
 import {
-  addAgentCustomConnector$,
-  removeAgentCustomConnector$,
-  saveAgentCustomConnectors$,
+  agentCustomConnectorToggleSaving$,
   agentAddedCustomConnectors$,
+  toggleAgentCustomConnector$,
 } from "../../signals/zero-page/job-detail/custom-connectors.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
@@ -70,11 +64,9 @@ export function JobCustomConnectorsSection() {
   const addedLoadable = useLastLoadable(agentAddedCustomConnectors$);
   const added = addedLoadable.state === "hasData" ? addedLoadable.data : [];
   const addedSet = new Set(added);
-  const addCustom = useSet(addAgentCustomConnector$);
-  const removeCustom = useSet(removeAgentCustomConnector$);
-  const [saveLoadable, save] = useLoadableSet(saveAgentCustomConnectors$);
+  const [, toggle] = useLoadableSet(toggleAgentCustomConnector$);
   const pageSignal = useGet(pageSignal$);
-  const saving = saveLoadable.state === "loading";
+  const saving = useGet(agentCustomConnectorToggleSaving$);
 
   if (!connectors || connectors.length === 0) {
     return null;
@@ -84,14 +76,12 @@ export function JobCustomConnectorsSection() {
     if (saving) {
       return;
     }
-    const mutate = checked
-      ? addCustom(id, pageSignal)
-      : removeCustom(id, pageSignal);
     detach(
       (async () => {
-        await mutate;
-        await save(id, checked ? "add" : "remove", pageSignal);
-        toast.success("Custom connectors saved");
+        const saved = await toggle(id, checked, pageSignal);
+        if (saved) {
+          toast.success("Custom connectors saved");
+        }
       })(),
       Reason.DomCallback,
     );

--- a/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
@@ -759,7 +759,7 @@ function JobPermissionsTab({
     await bestEffort(
       (async () => {
         await modify;
-        await saveConnectors(pageSignal);
+        await saveConnectors(type, checked ? "add" : "remove", pageSignal);
         toast.success("Connectors saved");
       })(),
     );

--- a/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
@@ -629,6 +629,7 @@ export function AgentPermissionsDrawer({
   targetId,
   targetKind = "agent",
   connectorType,
+  connectorLabel,
   displayName,
   initialPolicies,
   initialGrants,
@@ -643,6 +644,7 @@ export function AgentPermissionsDrawer({
   targetId: string;
   targetKind?: "agent" | "workflow";
   connectorType: ConnectorType | null;
+  connectorLabel: string;
   displayName: string;
   initialPolicies: FirewallPolicies;
   initialGrants: readonly UserPermissionGrantResponse[];
@@ -667,6 +669,7 @@ export function AgentPermissionsDrawer({
       agentId={targetId}
       targetKind={targetKind}
       connectorType={connectorType}
+      connectorLabel={connectorLabel}
       displayName={displayName}
       initialPolicies={initialPolicies}
       initialGrants={initialGrants}
@@ -735,6 +738,11 @@ function JobPermissionsTab({
   const connectedConnectors = allConnectors.filter((c) => {
     return c.connected;
   });
+  const connectorLabel = connectorType
+    ? (allConnectors.find((connector) => {
+        return connector.type === connectorType;
+      })?.label ?? connectorType)
+    : "";
   const filteredConnectors = connectedConnectors.filter((c) => {
     return matchesConnectorSearch(search, c);
   });
@@ -791,6 +799,7 @@ function JobPermissionsTab({
           <AgentPermissionsDrawer
             targetId={agentId}
             connectorType={connectorType}
+            connectorLabel={connectorLabel}
             displayName={displayName}
             initialPolicies={drawerInitialPolicies}
             initialGrants={userGrants}

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -68,6 +68,24 @@ const THREAD_ID = "thread-model-template-1";
 const ANTHROPIC_PROVIDER_ID = "00000000-0000-4000-a000-000000000001";
 const MOONSHOT_PROVIDER_ID = "00000000-0000-4000-a000-000000000002";
 const ZAI_PROVIDER_ID = "00000000-0000-4000-a000-000000000003";
+
+function applyUserConnectorUpdate(
+  current: readonly string[],
+  body: {
+    readonly enabledTypes: readonly string[];
+    readonly operation?: "replace" | "add" | "remove";
+  },
+): string[] {
+  if (body.operation === "add") {
+    return Array.from(new Set([...current, ...body.enabledTypes]));
+  }
+  if (body.operation === "remove") {
+    return current.filter((type) => {
+      return !body.enabledTypes.includes(type);
+    });
+  }
+  return [...body.enabledTypes];
+}
 const NOW = "2026-05-08T00:00:00.000Z";
 
 function connectorSearchFixtureTypes(): readonly ConnectorType[] {
@@ -383,13 +401,15 @@ function mockManyConnectedConnectors(): void {
   ]);
 }
 
-function mockAgentConnectorAuthorizations(initialTypes: string[]): void {
-  let enabledTypes = initialTypes;
+function mockAgentConnectorAuthorizations(
+  initialTypes: readonly string[],
+): void {
+  let enabledTypes: string[] = [...initialTypes];
   context.mocks.api(zeroUserConnectorsContract.get, ({ respond }) => {
     return respond(200, { enabledTypes });
   });
   context.mocks.api(zeroUserConnectorsContract.update, ({ body, respond }) => {
-    enabledTypes = body.enabledTypes;
+    enabledTypes = applyUserConnectorUpdate(enabledTypes, body);
     return respond(200, { enabledTypes });
   });
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -23,6 +23,24 @@ const context = testContext();
 const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
 const THREAD_ID = "thread-action-cards";
 
+function applyUserConnectorUpdate(
+  current: readonly string[],
+  body: {
+    readonly enabledTypes: readonly string[];
+    readonly operation?: "replace" | "add" | "remove";
+  },
+): string[] {
+  if (body.operation === "add") {
+    return Array.from(new Set([...current, ...body.enabledTypes]));
+  }
+  if (body.operation === "remove") {
+    return current.filter((type) => {
+      return !body.enabledTypes.includes(type);
+    });
+  }
+  return [...body.enabledTypes];
+}
+
 function connectedConnector(
   overrides: Pick<ConnectorResponse, "type" | "authMethod"> &
     Partial<ConnectorResponse>,
@@ -42,13 +60,15 @@ function connectedConnector(
   };
 }
 
-function mockAgentConnectorAuthorizations(initialTypes: string[]): void {
-  let enabledTypes = initialTypes;
+function mockAgentConnectorAuthorizations(
+  initialTypes: readonly string[],
+): void {
+  let enabledTypes: string[] = [...initialTypes];
   context.mocks.api(zeroUserConnectorsContract.get, ({ respond }) => {
     return respond(200, { enabledTypes });
   });
   context.mocks.api(zeroUserConnectorsContract.update, ({ body, respond }) => {
-    enabledTypes = body.enabledTypes;
+    enabledTypes = applyUserConnectorUpdate(enabledTypes, body);
     return respond(200, { enabledTypes });
   });
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import JSZip from "jszip";
 
 import {
@@ -22,7 +22,10 @@ import {
   fill,
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
+import type { ZeroClientFactory } from "../../../signals/api-client.ts";
+import { syncArtifactFileToGoogleDrive } from "../../../signals/chat-page/artifact-google-drive-sync.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { resetSignal } from "../../../signals/utils.ts";
 import {
   artifactPanelWidth$,
   saveCapturedHtmlEditSnapshotDraft$,
@@ -1392,6 +1395,43 @@ describe("zero artifact sidebar", () => {
     await waitFor(() => {
       expect(menuItemByText("Synced to Google Drive")).toBeInTheDocument();
     });
+  });
+
+  it("does not finish a Google Drive upload after the page signal is aborted", async () => {
+    const resetUploadSignal$ = resetSignal();
+    const uploadSignal = context.store.set(resetUploadSignal$, context.signal);
+    const dismissToast = vi.spyOn(toast, "dismiss");
+    const createClient = (() => {
+      return {
+        syncGoogleDrive: () => {
+          context.store.set(resetUploadSignal$, context.signal);
+          return Promise.resolve({
+            status: 200 as const,
+            body: {
+              id: "drive-file-release-notes",
+              name: "drive-release-notes.md",
+              webViewLink: null,
+            },
+          });
+        },
+      };
+    }) as ZeroClientFactory;
+
+    try {
+      await expect(
+        syncArtifactFileToGoogleDrive({
+          createClient,
+          threadId: THREAD_ID,
+          runId: "run-artifact",
+          fileId: "artifact-drive-release-notes",
+          filename: "drive-release-notes.md",
+          signal: uploadSignal,
+        }),
+      ).rejects.toMatchObject({ name: "AbortError" });
+      expect(dismissToast).toHaveBeenCalledTimes(1);
+    } finally {
+      dismissToast.mockRestore();
+    }
   });
 
   it("downloads a presentation artifact as PPTX from the sidebar", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -986,6 +986,55 @@ describe("connectors page", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("ignores duplicate direct OAuth starts while a connector is polling", async () => {
+    mockConnectors([]);
+    mockPublicConnectorStatus([
+      publicStatusItem({
+        connectorRef: "stripe",
+        label: "Public Stripe",
+        description: "Public Stripe description",
+        authMethods: [
+          {
+            id: "oauth",
+            label: "Public OAuth",
+            description: null,
+            grantKind: "auth-code",
+            manualFields: [],
+            startOptions: [],
+          },
+        ],
+        singleAuthCodeAuthMethodId: "oauth",
+      }),
+    ]);
+    const authWindow = createMockAuthWindow();
+    const openMock = context.mocks.browser.open(authWindow);
+    let startCount = 0;
+    context.mocks.api(
+      zeroConnectorOauthStartContract.start,
+      ({ params, respond }) => {
+        startCount += 1;
+        return respond(200, {
+          authorizationUrl: `https://oauth.test/${params.type}/authorize`,
+        });
+      },
+    );
+
+    detachedSetupPage({ context, path: "/connectors" });
+
+    await fill(await screen.findByPlaceholderText("Find connectors"), "stripe");
+    const connectButton = await screen.findByLabelText("Connect Public Stripe");
+    click(connectButton);
+    click(connectButton);
+
+    await waitFor(() => {
+      expect(startCount).toBe(1);
+      expect(openMock.calls).toHaveLength(1);
+      expect(authWindow.location.href).toBe(
+        "https://oauth.test/stripe/authorize",
+      );
+    });
+  });
+
   it("starts Stripe OAuth from the connect dialog", async () => {
     mockConnectors([]);
     mockPublicConnectorStatus([

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -852,13 +852,7 @@ describe("connectors page", () => {
       return respond(200, { enabledTypes: ["github"] });
     });
 
-    detachedSetupPage({
-      context,
-      path: "/connectors",
-      featureSwitches: {
-        [FeatureSwitchKey.ConnectorAccessManagement]: true,
-      },
-    });
+    detachedSetupPage({ context, path: "/connectors" });
 
     await waitFor(() => {
       expect(screen.getByText("GitHub")).toBeInTheDocument();
@@ -902,13 +896,7 @@ describe("connectors page", () => {
       },
     );
 
-    detachedSetupPage({
-      context,
-      path: "/connectors",
-      featureSwitches: {
-        [FeatureSwitchKey.ConnectorAccessManagement]: true,
-      },
-    });
+    detachedSetupPage({ context, path: "/connectors" });
 
     await waitFor(() => {
       expect(screen.getByText("GitHub")).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -6,8 +6,14 @@ import {
 } from "@vm0/api-contracts/contracts/zero-custom-connectors";
 import {
   zeroConnectorOauthStartContract,
+  zeroConnectorManualGrantContract,
+  zeroConnectorOauthDeviceAuthSessionContract,
   zeroConnectorScopeDiffContract,
 } from "@vm0/api-contracts/contracts/zero-connectors";
+import {
+  zeroConnectorCatalogContract,
+  type PublicConnectorCatalogStatusItem,
+} from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import { zeroUserPermissionGrantsContract } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
@@ -198,6 +204,48 @@ function customConnector(
     updatedAt: "2026-02-01T00:00:00Z",
     ...overrides,
   };
+}
+
+function publicStatusItem(args: {
+  readonly connectorRef: ConnectorType;
+  readonly label: string;
+  readonly description?: string;
+  readonly category?: string;
+  readonly authMethods: PublicConnectorCatalogStatusItem["authMethods"];
+  readonly singleAuthCodeAuthMethodId?: string | null;
+  readonly connectNotice?: PublicConnectorCatalogStatusItem["connectNotice"];
+}): PublicConnectorCatalogStatusItem {
+  return {
+    connectorRef: args.connectorRef,
+    label: args.label,
+    description: args.description ?? `${args.label} public description`,
+    category: args.category ?? "data-automation-infrastructure",
+    generation: [],
+    tags: [],
+    authMethods: args.authMethods,
+    permissionSummary: {
+      hasPermissions: false,
+      permissionCount: 0,
+      hasCategories: false,
+      hasDefaultPolicyOverrides: false,
+    },
+    connection: null,
+    connected: false,
+    connectionStatus: "not-connected",
+    scopeMismatch: false,
+    authMethodSupportsRefresh: false,
+    tokenExpiresAt: null,
+    singleAuthCodeAuthMethodId: args.singleAuthCodeAuthMethodId ?? null,
+    connectNotice: args.connectNotice ?? null,
+  };
+}
+
+function mockPublicConnectorStatus(
+  connectors: readonly PublicConnectorCatalogStatusItem[],
+): void {
+  context.mocks.api(zeroConnectorCatalogContract.status, ({ respond }) => {
+    return respond(200, { connectors: [...connectors] });
+  });
 }
 
 function mockCustomConnectorStory(): void {
@@ -940,6 +988,43 @@ describe("connectors page", () => {
 
   it("starts Stripe OAuth from the connect dialog", async () => {
     mockConnectors([]);
+    mockPublicConnectorStatus([
+      publicStatusItem({
+        connectorRef: "stripe",
+        label: "Public Stripe",
+        description: "Public Stripe description",
+        authMethods: [
+          {
+            id: "oauth",
+            label: "Public OAuth",
+            description: "Public OAuth description",
+            grantKind: "auth-code",
+            manualFields: [],
+            startOptions: [],
+          },
+          {
+            id: "cli",
+            label: "Public CLI",
+            description: "Public CLI description",
+            grantKind: "device-auth",
+            manualFields: [],
+            startOptions: [
+              {
+                id: "mode",
+                kind: "select",
+                label: "Public Mode",
+                required: true,
+                defaultValue: "test",
+                options: [
+                  { value: "test", label: "Test" },
+                  { value: "live", label: "Live" },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    ]);
     const authWindow = createMockAuthWindow();
     context.mocks.browser.open(authWindow);
     context.mocks.api(
@@ -960,10 +1045,14 @@ describe("connectors page", () => {
     });
 
     const searchInput = await screen.findByPlaceholderText("Find connectors");
-    await fill(searchInput, "stripe");
-    click(await screen.findByLabelText("Connect Stripe"));
+    await fill(searchInput, "public stripe");
+    click(await screen.findByLabelText("Connect Public Stripe"));
 
-    const dialog = await screen.findByRole("dialog", { name: "Stripe" });
+    const dialog = await screen.findByRole("dialog", {
+      name: "Public Stripe",
+    });
+    expect(within(dialog).getByText("Public OAuth")).toBeInTheDocument();
+    expect(within(dialog).getByText("Public CLI")).toBeInTheDocument();
     click(buttonByText("Connect", dialog));
 
     await waitFor(() => {
@@ -1065,27 +1154,144 @@ describe("connectors page", () => {
     });
   });
 
+  it("submits public device-auth start option ids", async () => {
+    mockConnectors([]);
+    mockPublicConnectorStatus([
+      publicStatusItem({
+        connectorRef: "stripe",
+        label: "Stripe",
+        authMethods: [
+          {
+            id: "cli",
+            label: "Stripe CLI",
+            description: "Approve access with Stripe CLI.",
+            grantKind: "device-auth",
+            manualFields: [],
+            startOptions: [
+              {
+                id: "mode",
+                kind: "select",
+                label: "Mode",
+                required: true,
+                defaultValue: "test",
+                options: [
+                  { value: "test", label: "Test" },
+                  { value: "live", label: "Live" },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    ]);
+    let capturedOptions: Record<string, string> | null = null;
+    context.mocks.api(
+      zeroConnectorOauthDeviceAuthSessionContract.create,
+      ({ body, params, respond }) => {
+        expect(params.type).toBe("stripe");
+        capturedOptions = body.options ?? null;
+        return respond(200, {
+          sessionId: "00000000-0000-4000-8000-000000000010",
+          sessionToken: "stripe-device-session-token",
+          type: "stripe",
+          status: "pending",
+          userCode: "STRIPE-DEVICE",
+          verificationUri: "https://oauth.test/stripe/device",
+          verificationUriComplete:
+            "https://oauth.test/stripe/device?user_code=STRIPE-DEVICE",
+          expiresIn: 300,
+          interval: 1,
+        });
+      },
+    );
+
+    detachedSetupPage({ context, path: "/connectors" });
+
+    await fill(await screen.findByPlaceholderText("Find connectors"), "stripe");
+    click(await screen.findByLabelText("Connect Stripe"));
+
+    const dialog = await screen.findByRole("dialog", { name: "Stripe" });
+    click(buttonByText("Connect Stripe", dialog));
+
+    await waitFor(() => {
+      expect(capturedOptions).toStrictEqual({ mode: "test" });
+    });
+  });
+
   it("connects a manual token connector", async () => {
     mockConnectors([]);
+    mockPublicConnectorStatus([
+      publicStatusItem({
+        connectorRef: "axiom",
+        label: "Public Axiom",
+        description: "Public Axiom description",
+        authMethods: [
+          {
+            id: "api-token",
+            label: "Public API Token",
+            description: null,
+            grantKind: "manual",
+            manualFields: [
+              {
+                id: "apiToken",
+                label: "Public API token",
+                required: true,
+                placeholder: "public-xaat",
+                inputType: "password",
+              },
+            ],
+            startOptions: [],
+          },
+        ],
+      }),
+    ]);
+    let submittedValues: Record<string, string> | null = null;
+    context.mocks.api(
+      zeroConnectorManualGrantContract.connect,
+      ({ body, params, respond }) => {
+        expect(params.type).toBe("axiom");
+        submittedValues = body.values;
+        return respond(200, {
+          id: crypto.randomUUID(),
+          type: "axiom",
+          authMethod: body.authMethod,
+          externalId: null,
+          externalUsername: null,
+          externalEmail: null,
+          oauthScopes: null,
+          connectionStatus: "connected",
+          reconnectReason: null,
+          tokenExpiresAt: null,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        });
+      },
+    );
 
     detachedSetupPage({ context, path: "/connectors" });
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Connect Axiom")).toBeInTheDocument();
+      expect(screen.getByLabelText("Connect Public Axiom")).toBeInTheDocument();
     });
 
-    click(screen.getByLabelText("Connect Axiom"));
+    click(screen.getByLabelText("Connect Public Axiom"));
 
-    const axiomDialog = await screen.findByRole("dialog", { name: "Axiom" });
+    const axiomDialog = await screen.findByRole("dialog", {
+      name: "Public Axiom",
+    });
+    expect(
+      within(axiomDialog).queryByText(/Settings > API Tokens/u),
+    ).not.toBeInTheDocument();
     await fill(
-      within(axiomDialog).getByPlaceholderText("xaat-..."),
+      within(axiomDialog).getByPlaceholderText("public-xaat"),
       "xaat-test",
     );
     click(buttonByText("Save", axiomDialog));
 
     await waitFor(() => {
+      expect(submittedValues).toStrictEqual({ apiToken: "xaat-test" });
       expect(
-        within(connectorCardByLabel("Axiom")).getByText("Connected"),
+        within(connectorCardByLabel("Public Axiom")).getByText("Connected"),
       ).toBeInTheDocument();
     });
   });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -119,6 +119,24 @@ function connectorCardByLabel(label: string): HTMLElement {
   return card;
 }
 
+function applyUserConnectorUpdate(
+  current: readonly string[],
+  body: {
+    readonly enabledTypes: readonly string[];
+    readonly operation?: "replace" | "add" | "remove";
+  },
+): string[] {
+  if (body.operation === "add") {
+    return Array.from(new Set([...current, ...body.enabledTypes]));
+  }
+  if (body.operation === "remove") {
+    return current.filter((type) => {
+      return !body.enabledTypes.includes(type);
+    });
+  }
+  return [...body.enabledTypes];
+}
+
 function reconnectReasonHelpButton(container: ParentNode): HTMLElement | null {
   return (
     queryAllByRoleFast("button", container).find((button) => {
@@ -768,8 +786,12 @@ describe("connectors page", () => {
     context.mocks.api(
       zeroUserConnectorsContract.update,
       ({ params, body, respond }) => {
-        enabledByAgent.set(params.id, body.enabledTypes);
-        return respond(200, { enabledTypes: body.enabledTypes });
+        const nextEnabledTypes = applyUserConnectorUpdate(
+          enabledByAgent.get(params.id) ?? [],
+          body,
+        );
+        enabledByAgent.set(params.id, nextEnabledTypes);
+        return respond(200, { enabledTypes: nextEnabledTypes });
       },
     );
     context.mocks.api(zeroUserPermissionGrantsContract.list, ({ respond }) => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -835,6 +835,50 @@ describe("connectors page", () => {
     });
   });
 
+  it("ignores stale agents when loading connector access rows", async () => {
+    const activeAgentId = "c0000000-0000-4000-a000-000000000001";
+    const staleAgentId = "c0000000-0000-4000-a000-000000000002";
+    mockConnectors([{ type: "github", externalUsername: "octocat" }]);
+    context.mocks.data.team([
+      teamAgent(activeAgentId, "Research Agent"),
+      teamAgent(staleAgentId, "Deleted Agent"),
+    ]);
+    context.mocks.api(zeroUserConnectorsContract.get, ({ params, respond }) => {
+      if (params.id === staleAgentId) {
+        return respond(404, {
+          error: { message: "Agent not found", code: "NOT_FOUND" },
+        });
+      }
+      return respond(200, { enabledTypes: ["github"] });
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/connectors",
+      featureSwitches: {
+        [FeatureSwitchKey.ConnectorAccessManagement]: true,
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("GitHub")).toBeInTheDocument();
+    });
+    click(
+      within(connectorCardByLabel("GitHub")).getByLabelText(
+        "Manage GitHub access",
+      ),
+    );
+
+    const dialog = await screen.findByRole("dialog", {
+      name: "Manage GitHub access",
+    });
+    expect(within(dialog).getByText("Research Agent")).toBeInTheDocument();
+    expect(within(dialog).queryByText("Deleted Agent")).not.toBeInTheDocument();
+    expect(
+      within(dialog).queryByText("Loading agents..."),
+    ).not.toBeInTheDocument();
+  });
+
   it("shows authorized agent names with an overflow count on connector cards", async () => {
     const agentIds = [
       "c0000000-0000-4000-a000-000000000001",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -1630,6 +1630,99 @@ describe("connectors page", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("keeps the post-connect permission dialog open when authorization fails", async () => {
+    const researchAgentId = "c0000000-0000-4000-a000-000000000001";
+    mockConnectors([]);
+    context.mocks.data.team([teamAgent(researchAgentId, "Research Agent")]);
+    mockPublicConnectorStatus([
+      publicStatusItem({
+        connectorRef: "axiom",
+        label: "Public Axiom",
+        authMethods: [
+          {
+            id: "api-token",
+            label: "Public API Token",
+            description: null,
+            grantKind: "manual",
+            manualFields: [
+              {
+                id: "apiToken",
+                label: "Public API token",
+                required: true,
+                placeholder: "public-xaat",
+                inputType: "password",
+              },
+            ],
+            startOptions: [],
+          },
+        ],
+      }),
+    ]);
+    context.mocks.api(
+      zeroConnectorManualGrantContract.connect,
+      ({ body, params, respond }) => {
+        return respond(200, {
+          id: crypto.randomUUID(),
+          type: params.type,
+          authMethod: body.authMethod,
+          externalId: null,
+          externalUsername: null,
+          externalEmail: null,
+          oauthScopes: null,
+          connectionStatus: "connected",
+          reconnectReason: null,
+          tokenExpiresAt: null,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        });
+      },
+    );
+    context.mocks.api(zeroUserConnectorsContract.get, ({ respond }) => {
+      return respond(200, { enabledTypes: [] });
+    });
+    context.mocks.api(zeroUserConnectorsContract.update, ({ respond }) => {
+      return respond(400, {
+        error: {
+          code: "CONNECTOR_ACCESS_UPDATE_FAILED",
+          message: "Could not update connector access",
+        },
+      });
+    });
+
+    detachedSetupPage({ context, path: "/connectors" });
+
+    await fill(await screen.findByPlaceholderText("Find connectors"), "axiom");
+    click(await screen.findByLabelText("Connect Public Axiom"));
+    const axiomDialog = await screen.findByRole("dialog", {
+      name: "Public Axiom",
+    });
+    await fill(
+      within(axiomDialog).getByPlaceholderText("public-xaat"),
+      "xaat-test",
+    );
+    click(buttonByText("Save", axiomDialog));
+
+    const permissionDialog = dialogForElement(
+      await screen.findByText(
+        "You've successfully connected with Public Axiom!",
+      ),
+    );
+    click(buttonByText("Research Agent", permissionDialog));
+    click(buttonByText("Confirm", permissionDialog));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Could not update connector access"),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText("You've successfully connected with Public Axiom!"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Public Axiom enabled for 1 agent"),
+    ).not.toBeInTheDocument();
+  });
+
   it("connects AWS with an authorization code and authorizes an agent", async () => {
     mockConnectors([]);
     context.mocks.data.team([

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -1849,6 +1849,111 @@ describe("connectors page", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("skips stale agents when confirming the post-connect permission dialog", async () => {
+    const researchAgentId = "c0000000-0000-4000-a000-000000000001";
+    const staleAgentId = "c0000000-0000-4000-a000-000000000002";
+    mockConnectors([]);
+    context.mocks.data.team([
+      teamAgent(researchAgentId, "Research Agent"),
+      teamAgent(staleAgentId, "Deleted Agent"),
+    ]);
+    mockPublicConnectorStatus([
+      publicStatusItem({
+        connectorRef: "axiom",
+        label: "Public Axiom",
+        authMethods: [
+          {
+            id: "api-token",
+            label: "Public API Token",
+            description: null,
+            grantKind: "manual",
+            manualFields: [
+              {
+                id: "apiToken",
+                label: "Public API token",
+                required: true,
+                placeholder: "public-xaat",
+                inputType: "password",
+              },
+            ],
+            startOptions: [],
+          },
+        ],
+      }),
+    ]);
+    context.mocks.api(
+      zeroConnectorManualGrantContract.connect,
+      ({ body, params, respond }) => {
+        return respond(200, {
+          id: crypto.randomUUID(),
+          type: params.type,
+          authMethod: body.authMethod,
+          externalId: null,
+          externalUsername: null,
+          externalEmail: null,
+          oauthScopes: null,
+          connectionStatus: "connected",
+          reconnectReason: null,
+          tokenExpiresAt: null,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        });
+      },
+    );
+    context.mocks.api(zeroUserConnectorsContract.get, ({ respond }) => {
+      return respond(200, { enabledTypes: [] });
+    });
+    const authorizedAgentIds: string[] = [];
+    context.mocks.api(
+      zeroUserConnectorsContract.update,
+      ({ params, respond }) => {
+        if (params.id === staleAgentId) {
+          return respond(404, {
+            error: {
+              code: "NOT_FOUND",
+              message: "Agent not found",
+            },
+          });
+        }
+        authorizedAgentIds.push(params.id);
+        return respond(200, { enabledTypes: ["axiom"] });
+      },
+    );
+
+    detachedSetupPage({ context, path: "/connectors" });
+
+    await fill(await screen.findByPlaceholderText("Find connectors"), "axiom");
+    click(await screen.findByLabelText("Connect Public Axiom"));
+    const axiomDialog = await screen.findByRole("dialog", {
+      name: "Public Axiom",
+    });
+    await fill(
+      within(axiomDialog).getByPlaceholderText("public-xaat"),
+      "xaat-test",
+    );
+    click(buttonByText("Save", axiomDialog));
+
+    const permissionDialog = dialogForElement(
+      await screen.findByText(
+        "You've successfully connected with Public Axiom!",
+      ),
+    );
+    click(buttonByText("Research Agent", permissionDialog));
+    click(buttonByText("Deleted Agent", permissionDialog));
+    click(buttonByText("Confirm", permissionDialog));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText("You've successfully connected with Public Axiom!"),
+      ).not.toBeInTheDocument();
+    });
+    expect(
+      screen.getByText("Public Axiom enabled for 1 agent"),
+    ).toBeInTheDocument();
+    expect(authorizedAgentIds).toStrictEqual([researchAgentId]);
+    expect(screen.queryByText("Agent not found")).not.toBeInTheDocument();
+  });
+
   it("connects AWS with an authorization code and authorizes an agent", async () => {
     mockConnectors([]);
     context.mocks.data.team([

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -1296,6 +1296,107 @@ describe("connectors page", () => {
     });
   });
 
+  it("submits only current public manual grant fields", async () => {
+    mockConnectors([]);
+    mockPublicConnectorStatus([
+      publicStatusItem({
+        connectorRef: "axiom",
+        label: "Public Axiom",
+        authMethods: [
+          {
+            id: "api-token",
+            label: "Public API Token",
+            description: null,
+            grantKind: "manual",
+            manualFields: [
+              {
+                id: "apiToken",
+                label: "Public API token",
+                required: true,
+                placeholder: "public-xaat",
+                inputType: "password",
+              },
+            ],
+            startOptions: [],
+          },
+          {
+            id: "api",
+            label: "Public API Key",
+            description: null,
+            grantKind: "manual",
+            manualFields: [
+              {
+                id: "apiKey",
+                label: "Public API key",
+                required: true,
+                placeholder: "public-api-key",
+                inputType: "password",
+              },
+            ],
+            startOptions: [],
+          },
+        ],
+      }),
+    ]);
+    let submittedAuthMethod: string | null = null;
+    let submittedValues: Record<string, string> | null = null;
+    context.mocks.api(
+      zeroConnectorManualGrantContract.connect,
+      ({ body, respond }) => {
+        submittedAuthMethod = body.authMethod;
+        submittedValues = body.values;
+        return respond(200, {
+          id: crypto.randomUUID(),
+          type: "axiom",
+          authMethod: body.authMethod,
+          externalId: null,
+          externalUsername: null,
+          externalEmail: null,
+          oauthScopes: null,
+          connectionStatus: "connected",
+          reconnectReason: null,
+          tokenExpiresAt: null,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        });
+      },
+    );
+
+    detachedSetupPage({ context, path: "/connectors" });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Connect Public Axiom")).toBeInTheDocument();
+    });
+
+    click(screen.getByLabelText("Connect Public Axiom"));
+
+    const axiomDialog = await screen.findByRole("dialog", {
+      name: "Public Axiom",
+    });
+    await fill(
+      within(axiomDialog).getByPlaceholderText("public-xaat"),
+      "xaat-test",
+    );
+    await fill(
+      within(axiomDialog).getByPlaceholderText("public-api-key"),
+      "api-key-test",
+    );
+    const secondSaveButton = queryAllByRoleFast("button", axiomDialog).filter(
+      (button) => {
+        return button.textContent?.trim() === "Save";
+      },
+    )[1];
+    if (!secondSaveButton) {
+      throw new Error("Second manual grant save button not found");
+    }
+    click(secondSaveButton);
+
+    await waitFor(() => {
+      expect(submittedAuthMethod).toBe("api");
+      expect(submittedValues).toStrictEqual({ apiKey: "api-key-test" });
+    });
+  });
+
   it("connects AWS with an authorization code and authorizes an agent", async () => {
     mockConnectors([]);
     context.mocks.data.team([

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -1285,9 +1285,11 @@ describe("connectors page", () => {
       }),
     ]);
     let capturedOptions: Record<string, string> | null = null;
+    let startCount = 0;
     context.mocks.api(
       zeroConnectorOauthDeviceAuthSessionContract.create,
       ({ body, params, respond }) => {
+        startCount += 1;
         expect(params.type).toBe("stripe");
         capturedOptions = body.options ?? null;
         return respond(200, {
@@ -1311,11 +1313,14 @@ describe("connectors page", () => {
     click(await screen.findByLabelText("Connect Stripe"));
 
     const dialog = await screen.findByRole("dialog", { name: "Stripe" });
-    click(buttonByText("Connect Stripe", dialog));
+    const connectButton = buttonByText("Connect Stripe", dialog);
+    click(connectButton);
+    click(connectButton);
 
     await waitFor(() => {
       expect(capturedOptions).toStrictEqual({ mode: "test" });
     });
+    expect(startCount).toBe(1);
   });
 
   it("connects a manual token connector", async () => {
@@ -1346,9 +1351,11 @@ describe("connectors page", () => {
       }),
     ]);
     let submittedValues: Record<string, string> | null = null;
+    let submitCount = 0;
     context.mocks.api(
       zeroConnectorManualGrantContract.connect,
       ({ body, params, respond }) => {
+        submitCount += 1;
         expect(params.type).toBe("axiom");
         submittedValues = body.values;
         return respond(200, {
@@ -1386,10 +1393,13 @@ describe("connectors page", () => {
       within(axiomDialog).getByPlaceholderText("public-xaat"),
       "xaat-test",
     );
-    click(buttonByText("Save", axiomDialog));
+    const saveButton = buttonByText("Save", axiomDialog);
+    click(saveButton);
+    click(saveButton);
 
     await waitFor(() => {
       expect(submittedValues).toStrictEqual({ apiToken: "xaat-test" });
+      expect(submitCount).toBe(1);
       expect(
         within(connectorCardByLabel("Public Axiom")).getByText("Connected"),
       ).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -19,15 +19,13 @@ import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-co
 import { zeroUserPermissionGrantsContract } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import type { TeamComposeItem } from "@vm0/api-contracts/contracts/zero-team";
 import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
-import {
-  CONNECTOR_TYPES,
-  type ConnectorAuthMethodConfig,
-  type ConnectorAuthMethodId,
-  type ConnectorType,
+import type {
+  ConnectorAuthMethodId,
+  ConnectorType,
 } from "@vm0/connectors/connectors";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { fireEvent, screen, waitFor, within } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import {
   click,
@@ -384,14 +382,6 @@ async function expectConnectorCardsVisible(expected: {
 }
 
 describe("connectors page", () => {
-  const restoreConnectorRegistry: (() => void)[] = [];
-
-  afterEach(() => {
-    while (restoreConnectorRegistry.length > 0) {
-      restoreConnectorRegistry.pop()?.();
-    }
-  });
-
   it("lets users browse connectors by grouped categories", async () => {
     mockConnectors([{ type: "github", externalUsername: "octocat" }]);
 
@@ -1266,54 +1256,9 @@ describe("connectors page", () => {
     });
   });
 
-  it("hides Stripe when all its auth methods are statically hidden", async () => {
+  it("hides Stripe when public catalog status omits it", async () => {
     mockConnectors([]);
-    const authMethods = CONNECTOR_TYPES.stripe.authMethods;
-    const originalOauth = authMethods.oauth;
-    const originalApiToken = authMethods["api-token"];
-    const originalCli = authMethods.cli;
-
-    restoreConnectorRegistry.push(() => {
-      Object.defineProperty(authMethods, "oauth", {
-        value: originalOauth,
-        configurable: true,
-        enumerable: true,
-      });
-      Object.defineProperty(authMethods, "api-token", {
-        value: originalApiToken,
-        configurable: true,
-        enumerable: true,
-      });
-      Object.defineProperty(authMethods, "cli", {
-        value: originalCli,
-        configurable: true,
-        enumerable: true,
-      });
-    });
-    Object.defineProperty(authMethods, "oauth", {
-      value: {
-        ...originalOauth,
-        visible: false,
-      } satisfies ConnectorAuthMethodConfig,
-      configurable: true,
-      enumerable: true,
-    });
-    Object.defineProperty(authMethods, "api-token", {
-      value: {
-        ...originalApiToken,
-        visible: false,
-      } satisfies ConnectorAuthMethodConfig,
-      configurable: true,
-      enumerable: true,
-    });
-    Object.defineProperty(authMethods, "cli", {
-      value: {
-        ...originalCli,
-        visible: false,
-      } satisfies ConnectorAuthMethodConfig,
-      configurable: true,
-      enumerable: true,
-    });
+    mockPublicConnectorStatus([]);
 
     detachedSetupPage({
       context,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -879,6 +879,56 @@ describe("connectors page", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("ignores stale authorized agents when loading connector access grants", async () => {
+    const activeAgentId = "c0000000-0000-4000-a000-000000000001";
+    const staleAgentId = "c0000000-0000-4000-a000-000000000002";
+    mockConnectors([{ type: "github", externalUsername: "octocat" }]);
+    context.mocks.data.team([
+      teamAgent(activeAgentId, "Research Agent"),
+      teamAgent(staleAgentId, "Deleted Agent"),
+    ]);
+    context.mocks.api(zeroUserConnectorsContract.get, ({ respond }) => {
+      return respond(200, { enabledTypes: ["github"] });
+    });
+    context.mocks.api(
+      zeroUserPermissionGrantsContract.list,
+      ({ query, respond }) => {
+        if (query.agentId === staleAgentId) {
+          return respond(404, {
+            error: { message: "Agent not found", code: "NOT_FOUND" },
+          });
+        }
+        return respond(200, []);
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/connectors",
+      featureSwitches: {
+        [FeatureSwitchKey.ConnectorAccessManagement]: true,
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("GitHub")).toBeInTheDocument();
+    });
+    click(
+      within(connectorCardByLabel("GitHub")).getByLabelText(
+        "Manage GitHub access",
+      ),
+    );
+
+    const dialog = await screen.findByRole("dialog", {
+      name: "Manage GitHub access",
+    });
+    expect(within(dialog).getByText("Research Agent")).toBeInTheDocument();
+    expect(within(dialog).queryByText("Deleted Agent")).not.toBeInTheDocument();
+    expect(
+      within(dialog).queryByText("Loading agents..."),
+    ).not.toBeInTheDocument();
+  });
+
   it("shows authorized agent names with an overflow count on connector cards", async () => {
     const agentIds = [
       "c0000000-0000-4000-a000-000000000001",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -90,6 +90,14 @@ function menuItemByText(text: string): HTMLElement {
   return menuItem;
 }
 
+function dialogForElement(element: HTMLElement): HTMLElement {
+  const dialog = element.closest('[role="dialog"]');
+  if (!(dialog instanceof HTMLElement)) {
+    throw new Error("dialog not found for element");
+  }
+  return dialog;
+}
+
 function queryConnectorCardByLabel(label: string): HTMLElement | null {
   const labelElement = screen
     .queryAllByTestId("connector-card-label")
@@ -1486,6 +1494,139 @@ describe("connectors page", () => {
       expect(submittedAuthMethod).toBe("api");
       expect(submittedValues).toStrictEqual({ apiKey: "api-key-test" });
     });
+  });
+
+  it("clears post-connect permission selections between connector dialogs", async () => {
+    const researchAgentId = "c0000000-0000-4000-a000-000000000001";
+    mockConnectors([]);
+    context.mocks.data.team([teamAgent(researchAgentId, "Research Agent")]);
+    mockPublicConnectorStatus([
+      publicStatusItem({
+        connectorRef: "axiom",
+        label: "Public Axiom",
+        authMethods: [
+          {
+            id: "api-token",
+            label: "Public API Token",
+            description: null,
+            grantKind: "manual",
+            manualFields: [
+              {
+                id: "apiToken",
+                label: "Public API token",
+                required: true,
+                placeholder: "public-xaat",
+                inputType: "password",
+              },
+            ],
+            startOptions: [],
+          },
+        ],
+      }),
+      publicStatusItem({
+        connectorRef: "stripe",
+        label: "Public Stripe",
+        authMethods: [
+          {
+            id: "api-token",
+            label: "Public API Token",
+            description: null,
+            grantKind: "manual",
+            manualFields: [
+              {
+                id: "apiKey",
+                label: "Public API key",
+                required: true,
+                placeholder: "public-stripe-key",
+                inputType: "password",
+              },
+            ],
+            startOptions: [],
+          },
+        ],
+      }),
+    ]);
+    context.mocks.api(
+      zeroConnectorManualGrantContract.connect,
+      ({ body, params, respond }) => {
+        return respond(200, {
+          id: crypto.randomUUID(),
+          type: params.type,
+          authMethod: body.authMethod,
+          externalId: null,
+          externalUsername: null,
+          externalEmail: null,
+          oauthScopes: null,
+          connectionStatus: "connected",
+          reconnectReason: null,
+          tokenExpiresAt: null,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        });
+      },
+    );
+    let authorizationUpdateCount = 0;
+    context.mocks.api(zeroUserConnectorsContract.get, ({ respond }) => {
+      return respond(200, { enabledTypes: [] });
+    });
+    context.mocks.api(zeroUserConnectorsContract.update, ({ respond }) => {
+      authorizationUpdateCount += 1;
+      return respond(200, { enabledTypes: [] });
+    });
+
+    detachedSetupPage({ context, path: "/connectors" });
+
+    await fill(await screen.findByPlaceholderText("Find connectors"), "axiom");
+    click(await screen.findByLabelText("Connect Public Axiom"));
+    const axiomDialog = await screen.findByRole("dialog", {
+      name: "Public Axiom",
+    });
+    await fill(
+      within(axiomDialog).getByPlaceholderText("public-xaat"),
+      "xaat-test",
+    );
+    click(buttonByText("Save", axiomDialog));
+
+    const axiomPermissionDialog = dialogForElement(
+      await screen.findByText(
+        "You've successfully connected with Public Axiom!",
+      ),
+    );
+    click(buttonByText("Research Agent", axiomPermissionDialog));
+    click(buttonByText("Later", axiomPermissionDialog));
+    await waitFor(() => {
+      expect(
+        screen.queryByText("You've successfully connected with Public Axiom!"),
+      ).not.toBeInTheDocument();
+    });
+
+    await fill(screen.getByPlaceholderText("Find connectors"), "stripe");
+    click(await screen.findByLabelText("Connect Public Stripe"));
+    const stripeDialog = await screen.findByRole("dialog", {
+      name: "Public Stripe",
+    });
+    await fill(
+      within(stripeDialog).getByPlaceholderText("public-stripe-key"),
+      "sk-test",
+    );
+    click(buttonByText("Save", stripeDialog));
+
+    const stripePermissionDialog = dialogForElement(
+      await screen.findByText(
+        "You've successfully connected with Public Stripe!",
+      ),
+    );
+    click(buttonByText("Confirm", stripePermissionDialog));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText("You've successfully connected with Public Stripe!"),
+      ).not.toBeInTheDocument();
+    });
+    expect(authorizationUpdateCount).toBe(0);
+    expect(
+      screen.queryByText("Public Stripe enabled for 1 agent"),
+    ).not.toBeInTheDocument();
   });
 
   it("connects AWS with an authorization code and authorizes an agent", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -1037,6 +1037,7 @@ describe("connectors page", () => {
     await waitFor(() => {
       expect(startCount).toBe(1);
       expect(openMock.calls).toHaveLength(1);
+      expect(authWindow.opener).toBeNull();
       expect(authWindow.location.href).toBe(
         "https://oauth.test/stripe/authorize",
       );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -1035,6 +1035,48 @@ describe("connectors page", () => {
     });
   });
 
+  it("closes an unopened direct OAuth popup when the start request is aborted", async () => {
+    mockConnectors([]);
+    mockPublicConnectorStatus([
+      publicStatusItem({
+        connectorRef: "stripe",
+        label: "Public Stripe",
+        description: "Public Stripe description",
+        authMethods: [
+          {
+            id: "oauth",
+            label: "Public OAuth",
+            description: null,
+            grantKind: "auth-code",
+            manualFields: [],
+            startOptions: [],
+          },
+        ],
+        singleAuthCodeAuthMethodId: "oauth",
+      }),
+    ]);
+    const authWindow = createMockAuthWindow();
+    const openMock = context.mocks.browser.open(authWindow);
+    context.mocks.api(zeroConnectorOauthStartContract.start, ({ never }) => {
+      return never();
+    });
+
+    detachedSetupPage({ context, path: "/connectors" });
+
+    await fill(await screen.findByPlaceholderText("Find connectors"), "stripe");
+    click(await screen.findByLabelText("Connect Public Stripe"));
+
+    await waitFor(() => {
+      expect(openMock.calls).toHaveLength(1);
+    });
+
+    context.store.set(detachedNavigateTo$, ROUTES.settings);
+
+    await waitFor(() => {
+      expect(authWindow.closed).toBeTruthy();
+    });
+  });
+
   it("starts Stripe OAuth from the connect dialog", async () => {
     mockConnectors([]);
     mockPublicConnectorStatus([

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
@@ -364,6 +364,17 @@ describe("directed connector authorize page", () => {
 
     await screen.findByRole("dialog", { name: "Public GitHub" });
     expect(startCalls).toBe(0);
+
+    context.store.set(detachedNavigateTo$, ROUTES.directedAuthorize, {
+      pathParams: { type: "github" },
+      searchParams: new URLSearchParams({ agentId: SECOND_AGENT_ID }),
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Public GitHub" }),
+      ).not.toBeInTheDocument();
+    });
   });
 
   it("does not authorize the agent when OAuth connection is cancelled", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
@@ -1,4 +1,11 @@
-import { zeroConnectorOauthStartContract } from "@vm0/api-contracts/contracts/zero-connectors";
+import {
+  zeroConnectorManualGrantContract,
+  zeroConnectorOauthStartContract,
+} from "@vm0/api-contracts/contracts/zero-connectors";
+import {
+  zeroConnectorCatalogContract,
+  type PublicConnectorCatalogStatusItem,
+} from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
 import type { ConnectorType } from "@vm0/connectors/connectors";
@@ -16,6 +23,50 @@ import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 const context = testContext();
 
 const AGENT_ID = "00000000-0000-0000-0000-000000000001";
+
+function publicStatusItem(args: {
+  readonly connectorRef: ConnectorType;
+  readonly label: string;
+  readonly description?: string;
+  readonly category?: string;
+  readonly authMethods: PublicConnectorCatalogStatusItem["authMethods"];
+  readonly connection?: PublicConnectorCatalogStatusItem["connection"];
+  readonly connected?: boolean;
+  readonly singleAuthCodeAuthMethodId?: string | null;
+}): PublicConnectorCatalogStatusItem {
+  const connected = args.connected ?? false;
+  return {
+    connectorRef: args.connectorRef,
+    label: args.label,
+    description: args.description ?? `${args.label} public description`,
+    category: args.category ?? "data-automation-infrastructure",
+    generation: [],
+    tags: [],
+    authMethods: args.authMethods,
+    permissionSummary: {
+      hasPermissions: false,
+      permissionCount: 0,
+      hasCategories: false,
+      hasDefaultPolicyOverrides: false,
+    },
+    connection: args.connection ?? null,
+    connected,
+    connectionStatus: connected ? "connected" : "not-connected",
+    scopeMismatch: false,
+    authMethodSupportsRefresh: false,
+    tokenExpiresAt: null,
+    singleAuthCodeAuthMethodId: args.singleAuthCodeAuthMethodId ?? null,
+    connectNotice: null,
+  };
+}
+
+function mockPublicConnectorStatus(
+  connectors: readonly PublicConnectorCatalogStatusItem[],
+): void {
+  context.mocks.api(zeroConnectorCatalogContract.status, ({ respond }) => {
+    return respond(200, { connectors: [...connectors] });
+  });
+}
 
 function connectorResponse(type: ConnectorType): ConnectorResponse {
   return {
@@ -89,6 +140,53 @@ describe("directed connector authorize page", () => {
   });
 
   it("connects a manual-token connector before authorizing the agent", async () => {
+    mockPublicConnectorStatus([
+      publicStatusItem({
+        connectorRef: "axiom",
+        label: "Public Axiom",
+        authMethods: [
+          {
+            id: "api-token",
+            label: "Public API Token",
+            description: null,
+            grantKind: "manual",
+            manualFields: [
+              {
+                id: "apiToken",
+                label: "Public API token",
+                required: true,
+                placeholder: "public-xaat",
+                inputType: "password",
+              },
+            ],
+            startOptions: [],
+          },
+        ],
+      }),
+    ]);
+    let submittedValues: Record<string, string> | null = null;
+    context.mocks.api(
+      zeroConnectorManualGrantContract.connect,
+      ({ body, params, respond }) => {
+        expect(params.type).toBe("axiom");
+        submittedValues = body.values;
+        return respond(200, {
+          id: crypto.randomUUID(),
+          type: "axiom",
+          authMethod: body.authMethod,
+          externalId: null,
+          externalUsername: null,
+          externalEmail: null,
+          oauthScopes: null,
+          connectionStatus: "connected",
+          reconnectReason: null,
+          tokenExpiresAt: null,
+          createdAt: "2026-01-01T00:00:00Z",
+          updatedAt: "2026-01-01T00:00:00Z",
+        });
+      },
+    );
+
     detachedSetupPage({
       context,
       path: `/connectors/axiom/authorize?agentId=${AGENT_ID}`,
@@ -96,21 +194,26 @@ describe("directed connector authorize page", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText("Zero needs Axiom to proceed"),
+        screen.getByText("Zero needs Public Axiom to proceed"),
       ).toBeInTheDocument();
     });
 
     click(getButtonByText("Authorize Zero"));
 
-    const axiomDialog = await screen.findByRole("dialog", { name: "Axiom" });
+    const axiomDialog = await screen.findByRole("dialog", {
+      name: "Public Axiom",
+    });
     await fill(
-      within(axiomDialog).getByPlaceholderText("xaat-..."),
+      within(axiomDialog).getByPlaceholderText("public-xaat"),
       "xaat-directed-authorize",
     );
     click(getButtonByText("Save"));
 
     await waitFor(() => {
-      expect(screen.getByText("Axiom authorized")).toBeInTheDocument();
+      expect(submittedValues).toStrictEqual({
+        apiToken: "xaat-directed-authorize",
+      });
+      expect(screen.getByText("Public Axiom authorized")).toBeInTheDocument();
       expect(screen.getByText("Authorized")).toBeInTheDocument();
     });
   });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
@@ -19,10 +19,12 @@ import {
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { pushState } from "../../../signals/location.ts";
 
 const context = testContext();
 
 const AGENT_ID = "00000000-0000-0000-0000-000000000001";
+const SECOND_AGENT_ID = "00000000-0000-0000-0000-000000000002";
 
 function publicStatusItem(args: {
   readonly connectorRef: ConnectorType;
@@ -136,6 +138,40 @@ describe("directed connector authorize page", () => {
     await waitFor(() => {
       expect(screen.getByText("Gmail authorized")).toBeInTheDocument();
       expect(screen.getByText("Authorized")).toBeInTheDocument();
+    });
+  });
+
+  it("does not reuse optimistic authorization across agents", async () => {
+    mockConnectedConnector("gmail");
+    context.mocks.api(zeroUserConnectorsContract.get, ({ respond }) => {
+      return respond(200, { enabledTypes: [] });
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/connectors/gmail/authorize?agentId=${AGENT_ID}`,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Authorize Zero")).toBeInTheDocument();
+    });
+
+    click(screen.getByText("Authorize Zero"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Gmail authorized")).toBeInTheDocument();
+      expect(screen.getByText("Authorized")).toBeInTheDocument();
+    });
+
+    pushState({}, "", `/connectors/gmail/authorize?agentId=${SECOND_AGENT_ID}`);
+    window.dispatchEvent(new PopStateEvent("popstate"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Zero needs Gmail to proceed"),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Authorize Zero")).toBeInTheDocument();
+      expect(screen.queryByText("Gmail authorized")).not.toBeInTheDocument();
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
@@ -19,7 +19,8 @@ import {
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { pushState } from "../../../signals/location.ts";
+import { detachedNavigateTo$ } from "../../../signals/route.ts";
+import { ROUTES } from "../../../signals/route-paths.ts";
 
 const context = testContext();
 
@@ -163,8 +164,10 @@ describe("directed connector authorize page", () => {
       expect(screen.getByText("Authorized")).toBeInTheDocument();
     });
 
-    pushState({}, "", `/connectors/gmail/authorize?agentId=${SECOND_AGENT_ID}`);
-    window.dispatchEvent(new PopStateEvent("popstate"));
+    context.store.set(detachedNavigateTo$, ROUTES.directedAuthorize, {
+      pathParams: { type: "gmail" },
+      searchParams: new URLSearchParams({ agentId: SECOND_AGENT_ID }),
+    });
 
     await waitFor(() => {
       expect(
@@ -201,8 +204,10 @@ describe("directed connector authorize page", () => {
       expect(screen.getByText("Authorized")).toBeInTheDocument();
     });
 
-    pushState({}, "", `/connectors/gmail/authorize?agentId=${SECOND_AGENT_ID}`);
-    window.dispatchEvent(new PopStateEvent("popstate"));
+    context.store.set(detachedNavigateTo$, ROUTES.directedAuthorize, {
+      pathParams: { type: "gmail" },
+      searchParams: new URLSearchParams({ agentId: SECOND_AGENT_ID }),
+    });
 
     await waitFor(() => {
       expect(secondAgentRequested).toBeTruthy();
@@ -211,6 +216,27 @@ describe("directed connector authorize page", () => {
     expect(screen.queryByText("Authorized")).not.toBeInTheDocument();
 
     secondAgentResponse.resolve();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Zero needs Gmail to proceed"),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Authorize Zero")).toBeInTheDocument();
+    });
+  });
+
+  it("does not stay loading when the authorization lookup fails", async () => {
+    mockConnectedConnector("gmail");
+    context.mocks.api(zeroUserConnectorsContract.get, ({ respond }) => {
+      return respond(404, {
+        error: { message: "Agent not found", code: "NOT_FOUND" },
+      });
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/connectors/gmail/authorize?agentId=${AGENT_ID}`,
+    });
 
     await waitFor(() => {
       expect(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
@@ -175,6 +175,51 @@ describe("directed connector authorize page", () => {
     });
   });
 
+  it("does not reuse stale loaded authorization across agents", async () => {
+    mockConnectedConnector("gmail");
+    const secondAgentResponse = Promise.withResolvers<void>();
+    let secondAgentRequested = false;
+    context.mocks.api(
+      zeroUserConnectorsContract.get,
+      async ({ params, respond }) => {
+        if (params.id === SECOND_AGENT_ID) {
+          secondAgentRequested = true;
+          await secondAgentResponse.promise;
+          return respond(200, { enabledTypes: [] });
+        }
+        return respond(200, { enabledTypes: ["gmail"] });
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/connectors/gmail/authorize?agentId=${AGENT_ID}`,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Gmail authorized")).toBeInTheDocument();
+      expect(screen.getByText("Authorized")).toBeInTheDocument();
+    });
+
+    pushState({}, "", `/connectors/gmail/authorize?agentId=${SECOND_AGENT_ID}`);
+    window.dispatchEvent(new PopStateEvent("popstate"));
+
+    await waitFor(() => {
+      expect(secondAgentRequested).toBeTruthy();
+    });
+    expect(screen.queryByText("Gmail authorized")).not.toBeInTheDocument();
+    expect(screen.queryByText("Authorized")).not.toBeInTheDocument();
+
+    secondAgentResponse.resolve();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Zero needs Gmail to proceed"),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Authorize Zero")).toBeInTheDocument();
+    });
+  });
+
   it("connects a manual-token connector before authorizing the agent", async () => {
     mockPublicConnectorStatus([
       publicStatusItem({

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
@@ -269,7 +269,9 @@ describe("directed connector authorize page", () => {
       zeroUserConnectorsContract.update,
       ({ body, respond }) => {
         updateCalls += 1;
-        return respond(200, { enabledTypes: body.enabledTypes });
+        return respond(200, {
+          enabledTypes: body.operation === "remove" ? [] : body.enabledTypes,
+        });
       },
     );
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
@@ -218,6 +218,47 @@ describe("directed connector authorize page", () => {
     });
   });
 
+  it("opens the connect dialog when catalog does not expose direct OAuth", async () => {
+    let startCalls = 0;
+    context.mocks.api(
+      zeroConnectorOauthStartContract.start,
+      ({ params, respond }) => {
+        startCalls += 1;
+        return respond(200, {
+          authorizationUrl: `https://oauth.test/${params.type}/authorize`,
+        });
+      },
+    );
+    mockPublicConnectorStatus([
+      publicStatusItem({
+        connectorRef: "github",
+        label: "Public GitHub",
+        authMethods: [
+          {
+            id: "oauth",
+            label: "Public OAuth",
+            description: null,
+            grantKind: "auth-code",
+            manualFields: [],
+            startOptions: [],
+          },
+        ],
+        singleAuthCodeAuthMethodId: null,
+      }),
+    ]);
+
+    detachedSetupPage({
+      context,
+      path: `/connectors/github/authorize?agentId=${AGENT_ID}`,
+    });
+
+    await screen.findByText("Zero needs Public GitHub to proceed");
+    click(getButtonByText("Authorize Zero"));
+
+    await screen.findByRole("dialog", { name: "Public GitHub" });
+    expect(startCalls).toBe(0);
+  });
+
   it("does not authorize the agent when OAuth connection is cancelled", async () => {
     const { authWindow } = mockConnectorOauthStart();
     let updateCalls = 0;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
@@ -17,16 +17,72 @@ import {
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { detachedNavigateTo$ } from "../../../signals/route.ts";
+import { ROUTES } from "../../../signals/route-paths.ts";
 
 const context = testContext();
 const AGENT_ID = "00000000-0000-0000-0000-000000000001";
+const SECOND_AGENT_ID = "00000000-0000-0000-0000-000000000002";
 
 function mockPublicConnectorStatus(
   connector: PublicConnectorCatalogStatusItem,
 ): void {
+  mockPublicConnectorStatuses([connector]);
+}
+
+function mockPublicConnectorStatuses(
+  connectors: readonly PublicConnectorCatalogStatusItem[],
+): void {
   context.mocks.api(zeroConnectorCatalogContract.status, ({ respond }) => {
-    return respond(200, { connectors: [connector] });
+    return respond(200, { connectors: [...connectors] });
   });
+}
+
+function publicManualTokenConnectorStatus(args: {
+  readonly connectorRef: PublicConnectorCatalogStatusItem["connectorRef"];
+  readonly label: string;
+  readonly placeholder: string;
+}): PublicConnectorCatalogStatusItem {
+  return {
+    connectorRef: args.connectorRef,
+    label: args.label,
+    description: `${args.label} description`,
+    category: "data-automation-infrastructure",
+    generation: [],
+    tags: [],
+    authMethods: [
+      {
+        id: "api-token",
+        label: "Public API Token",
+        description: null,
+        grantKind: "manual",
+        manualFields: [
+          {
+            id: "apiToken",
+            label: "Public API token",
+            required: true,
+            placeholder: args.placeholder,
+            inputType: "password",
+          },
+        ],
+        startOptions: [],
+      },
+    ],
+    permissionSummary: {
+      hasPermissions: false,
+      permissionCount: 0,
+      hasCategories: false,
+      hasDefaultPolicyOverrides: false,
+    },
+    connection: null,
+    connected: false,
+    connectionStatus: "not-connected",
+    scopeMismatch: false,
+    authMethodSupportsRefresh: false,
+    tokenExpiresAt: null,
+    singleAuthCodeAuthMethodId: null,
+    connectNotice: null,
+  };
 }
 
 function mockConnectorOauthStart(): { readonly authWindow: Window } {
@@ -112,46 +168,13 @@ describe("directed connector connect page", () => {
   });
 
   it("waits for manual grant agent authorization before closing", async () => {
-    mockPublicConnectorStatus({
-      connectorRef: "axiom",
-      label: "Public Axiom",
-      description: "Public Axiom description",
-      category: "data-automation-infrastructure",
-      generation: [],
-      tags: [],
-      authMethods: [
-        {
-          id: "api-token",
-          label: "Public API Token",
-          description: null,
-          grantKind: "manual",
-          manualFields: [
-            {
-              id: "apiToken",
-              label: "Public API token",
-              required: true,
-              placeholder: "public-xaat",
-              inputType: "password",
-            },
-          ],
-          startOptions: [],
-        },
-      ],
-      permissionSummary: {
-        hasPermissions: false,
-        permissionCount: 0,
-        hasCategories: false,
-        hasDefaultPolicyOverrides: false,
-      },
-      connection: null,
-      connected: false,
-      connectionStatus: "not-connected",
-      scopeMismatch: false,
-      authMethodSupportsRefresh: false,
-      tokenExpiresAt: null,
-      singleAuthCodeAuthMethodId: null,
-      connectNotice: null,
-    });
+    mockPublicConnectorStatus(
+      publicManualTokenConnectorStatus({
+        connectorRef: "axiom",
+        label: "Public Axiom",
+        placeholder: "public-xaat",
+      }),
+    );
     let submittedValues: Record<string, string> | null = null;
     context.mocks.api(
       zeroConnectorManualGrantContract.connect,
@@ -228,6 +251,94 @@ describe("directed connector connect page", () => {
       expect(
         screen.queryByRole("dialog", { name: "Public Axiom" }),
       ).not.toBeInTheDocument();
+    });
+  });
+
+  it("does not reuse an open manual grant dialog across routed connector types", async () => {
+    mockPublicConnectorStatuses([
+      publicManualTokenConnectorStatus({
+        connectorRef: "axiom",
+        label: "Public Axiom",
+        placeholder: "public-xaat",
+      }),
+      publicManualTokenConnectorStatus({
+        connectorRef: "stripe",
+        label: "Public Stripe",
+        placeholder: "public-stripe-key",
+      }),
+    ]);
+
+    detachedSetupPage({
+      context,
+      path: `/connectors/axiom/connect?agentId=${AGENT_ID}`,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Zero needs Public Axiom to proceed"),
+      ).toBeInTheDocument();
+    });
+    click(getButtonByText("Connect"));
+
+    await screen.findByRole("dialog", {
+      name: "Public Axiom",
+    });
+
+    context.store.set(detachedNavigateTo$, ROUTES.directedConnect, {
+      pathParams: { type: "stripe" },
+      searchParams: new URLSearchParams({ agentId: AGENT_ID }),
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Public Axiom" }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("dialog", { name: "Public Stripe" }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByText("Zero needs Public Stripe to proceed"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("does not reuse an open manual grant dialog across routed agent ids", async () => {
+    mockPublicConnectorStatus(
+      publicManualTokenConnectorStatus({
+        connectorRef: "axiom",
+        label: "Public Axiom",
+        placeholder: "public-xaat",
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/connectors/axiom/connect?agentId=${AGENT_ID}`,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Zero needs Public Axiom to proceed"),
+      ).toBeInTheDocument();
+    });
+    click(getButtonByText("Connect"));
+
+    await screen.findByRole("dialog", {
+      name: "Public Axiom",
+    });
+
+    context.store.set(detachedNavigateTo$, ROUTES.directedConnect, {
+      pathParams: { type: "axiom" },
+      searchParams: new URLSearchParams({ agentId: SECOND_AGENT_ID }),
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Public Axiom" }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByText("Zero needs Public Axiom to proceed"),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
@@ -1,19 +1,25 @@
-import { zeroConnectorOauthStartContract } from "@vm0/api-contracts/contracts/zero-connectors";
+import {
+  zeroConnectorManualGrantContract,
+  zeroConnectorOauthStartContract,
+} from "@vm0/api-contracts/contracts/zero-connectors";
 import {
   zeroConnectorCatalogContract,
   type PublicConnectorCatalogStatusItem,
 } from "@vm0/api-contracts/contracts/zero-connector-catalog";
-import { screen, waitFor } from "@testing-library/react";
+import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
+import { screen, waitFor, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import {
   click,
   detachedSetupPage,
+  fill,
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 
 const context = testContext();
+const AGENT_ID = "00000000-0000-0000-0000-000000000001";
 
 function mockPublicConnectorStatus(
   connector: PublicConnectorCatalogStatusItem,
@@ -102,6 +108,124 @@ describe("directed connector connect page", () => {
       expect(authWindow.location.href).toBe(
         "https://oauth.test/github/authorize",
       );
+    });
+  });
+
+  it("waits for manual grant agent authorization before closing", async () => {
+    mockPublicConnectorStatus({
+      connectorRef: "axiom",
+      label: "Public Axiom",
+      description: "Public Axiom description",
+      category: "data-automation-infrastructure",
+      generation: [],
+      tags: [],
+      authMethods: [
+        {
+          id: "api-token",
+          label: "Public API Token",
+          description: null,
+          grantKind: "manual",
+          manualFields: [
+            {
+              id: "apiToken",
+              label: "Public API token",
+              required: true,
+              placeholder: "public-xaat",
+              inputType: "password",
+            },
+          ],
+          startOptions: [],
+        },
+      ],
+      permissionSummary: {
+        hasPermissions: false,
+        permissionCount: 0,
+        hasCategories: false,
+        hasDefaultPolicyOverrides: false,
+      },
+      connection: null,
+      connected: false,
+      connectionStatus: "not-connected",
+      scopeMismatch: false,
+      authMethodSupportsRefresh: false,
+      tokenExpiresAt: null,
+      singleAuthCodeAuthMethodId: null,
+      connectNotice: null,
+    });
+    let submittedValues: Record<string, string> | null = null;
+    context.mocks.api(
+      zeroConnectorManualGrantContract.connect,
+      ({ body, params, respond }) => {
+        expect(params.type).toBe("axiom");
+        submittedValues = body.values;
+        return respond(200, {
+          id: crypto.randomUUID(),
+          type: "axiom",
+          authMethod: body.authMethod,
+          externalId: null,
+          externalUsername: null,
+          externalEmail: null,
+          oauthScopes: null,
+          connectionStatus: "connected",
+          reconnectReason: null,
+          tokenExpiresAt: null,
+          createdAt: "2026-01-01T00:00:00Z",
+          updatedAt: "2026-01-01T00:00:00Z",
+        });
+      },
+    );
+    const authorizationResponse = Promise.withResolvers<void>();
+    let authorizedAgentId: string | null = null;
+    context.mocks.api(
+      zeroUserConnectorsContract.update,
+      async ({ body, params, respond }) => {
+        authorizedAgentId = params.id;
+        expect(body).toStrictEqual({
+          enabledTypes: ["axiom"],
+          operation: "add",
+        });
+        await authorizationResponse.promise;
+        return respond(200, { enabledTypes: body.enabledTypes });
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/connectors/axiom/connect?agentId=${AGENT_ID}`,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Zero needs Public Axiom to proceed"),
+      ).toBeInTheDocument();
+    });
+    click(getButtonByText("Connect"));
+
+    const axiomDialog = await screen.findByRole("dialog", {
+      name: "Public Axiom",
+    });
+    await fill(
+      within(axiomDialog).getByPlaceholderText("public-xaat"),
+      "xaat-directed-connect",
+    );
+    click(getButtonByText("Save"));
+
+    await waitFor(() => {
+      expect(submittedValues).toStrictEqual({
+        apiToken: "xaat-directed-connect",
+      });
+      expect(authorizedAgentId).toBe(AGENT_ID);
+    });
+    expect(
+      screen.getByRole("dialog", { name: "Public Axiom" }),
+    ).toBeInTheDocument();
+
+    authorizationResponse.resolve();
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Public Axiom" }),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
@@ -210,17 +210,19 @@ describe("directed connector connect page", () => {
     );
     click(getButtonByText("Save"));
 
-    await waitFor(() => {
-      expect(submittedValues).toStrictEqual({
-        apiToken: "xaat-directed-connect",
+    try {
+      await waitFor(() => {
+        expect(submittedValues).toStrictEqual({
+          apiToken: "xaat-directed-connect",
+        });
+        expect(authorizedAgentId).toBe(AGENT_ID);
       });
-      expect(authorizedAgentId).toBe(AGENT_ID);
-    });
-    expect(
-      screen.getByRole("dialog", { name: "Public Axiom" }),
-    ).toBeInTheDocument();
-
-    authorizationResponse.resolve();
+      expect(
+        screen.getByRole("dialog", { name: "Public Axiom" }),
+      ).toBeInTheDocument();
+    } finally {
+      authorizationResponse.resolve();
+    }
 
     await waitFor(() => {
       expect(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
@@ -1,4 +1,8 @@
 import { zeroConnectorOauthStartContract } from "@vm0/api-contracts/contracts/zero-connectors";
+import {
+  zeroConnectorCatalogContract,
+  type PublicConnectorCatalogStatusItem,
+} from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
@@ -10,6 +14,14 @@ import {
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 
 const context = testContext();
+
+function mockPublicConnectorStatus(
+  connector: PublicConnectorCatalogStatusItem,
+): void {
+  context.mocks.api(zeroConnectorCatalogContract.status, ({ respond }) => {
+    return respond(200, { connectors: [connector] });
+  });
+}
 
 function mockConnectorOauthStart(): { readonly authWindow: Window } {
   const authWindow = context.mocks.browser.authWindow();
@@ -44,12 +56,44 @@ function getButtonByText(text: string): HTMLElement {
 describe("directed connector connect page", () => {
   it("starts an OAuth flow from a directed link", async () => {
     const { authWindow } = mockConnectorOauthStart();
+    mockPublicConnectorStatus({
+      connectorRef: "github",
+      label: "Public GitHub",
+      description: "Public GitHub description",
+      category: "engineering-team-execution",
+      generation: [],
+      tags: [],
+      authMethods: [
+        {
+          id: "oauth",
+          label: "Public OAuth",
+          description: "Public OAuth description",
+          grantKind: "auth-code",
+          manualFields: [],
+          startOptions: [],
+        },
+      ],
+      permissionSummary: {
+        hasPermissions: false,
+        permissionCount: 0,
+        hasCategories: false,
+        hasDefaultPolicyOverrides: false,
+      },
+      connection: null,
+      connected: false,
+      connectionStatus: "not-connected",
+      scopeMismatch: false,
+      authMethodSupportsRefresh: false,
+      tokenExpiresAt: null,
+      singleAuthCodeAuthMethodId: "oauth",
+      connectNotice: null,
+    });
 
     detachedSetupPage({ context, path: "/connectors/github/connect" });
 
     await waitFor(() => {
       expect(
-        screen.getByText("Zero needs GitHub to proceed"),
+        screen.getByText("Zero needs Public GitHub to proceed"),
       ).toBeInTheDocument();
     });
     click(getButtonByText("Connect"));

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
@@ -85,6 +85,45 @@ function publicManualTokenConnectorStatus(args: {
   };
 }
 
+function publicOAuthConnectorStatus(args: {
+  readonly connectorRef: PublicConnectorCatalogStatusItem["connectorRef"];
+  readonly label: string;
+  readonly singleAuthCodeAuthMethodId: string | null;
+}): PublicConnectorCatalogStatusItem {
+  return {
+    connectorRef: args.connectorRef,
+    label: args.label,
+    description: `${args.label} description`,
+    category: "engineering-team-execution",
+    generation: [],
+    tags: [],
+    authMethods: [
+      {
+        id: "oauth",
+        label: "Public OAuth",
+        description: "Public OAuth description",
+        grantKind: "auth-code",
+        manualFields: [],
+        startOptions: [],
+      },
+    ],
+    permissionSummary: {
+      hasPermissions: false,
+      permissionCount: 0,
+      hasCategories: false,
+      hasDefaultPolicyOverrides: false,
+    },
+    connection: null,
+    connected: false,
+    connectionStatus: "not-connected",
+    scopeMismatch: false,
+    authMethodSupportsRefresh: false,
+    tokenExpiresAt: null,
+    singleAuthCodeAuthMethodId: args.singleAuthCodeAuthMethodId,
+    connectNotice: null,
+  };
+}
+
 function mockConnectorOauthStart(): { readonly authWindow: Window } {
   const authWindow = context.mocks.browser.authWindow();
   authWindow.closed = true;
@@ -164,6 +203,44 @@ describe("directed connector connect page", () => {
       expect(authWindow.location.href).toBe(
         "https://oauth.test/github/authorize",
       );
+    });
+  });
+
+  it("does not reuse an open provider connect dialog across routed agent ids", async () => {
+    mockPublicConnectorStatus(
+      publicOAuthConnectorStatus({
+        connectorRef: "github",
+        label: "Public GitHub",
+        singleAuthCodeAuthMethodId: null,
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/connectors/github/connect?agentId=${AGENT_ID}`,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Zero needs Public GitHub to proceed"),
+      ).toBeInTheDocument();
+    });
+    click(getButtonByText("Connect"));
+
+    await screen.findByRole("dialog", { name: "Public GitHub" });
+
+    context.store.set(detachedNavigateTo$, ROUTES.directedConnect, {
+      pathParams: { type: "github" },
+      searchParams: new URLSearchParams({ agentId: SECOND_AGENT_ID }),
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Public GitHub" }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByText("Zero needs Public GitHub to proceed"),
+      ).toBeInTheDocument();
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -100,7 +100,7 @@ type SubmitManualGrantFn = (
   inputValues: Record<string, string>,
   options: PostConnectOptions,
   signal: AbortSignal,
-) => Promise<void>;
+) => Promise<boolean>;
 
 type ConnectOAuthAuthCodeAndSettleFn = (
   type: ConnectorType,
@@ -256,7 +256,7 @@ function ManualGrantForm({
       if (!allFilled || submitting) {
         return;
       }
-      await submit(
+      const connected = await submit(
         type,
         authMethod,
         manualGrantInputValuesForMethod(method, fieldValues),
@@ -266,6 +266,9 @@ function ManualGrantForm({
         },
         pageSignal,
       );
+      if (!connected) {
+        return;
+      }
       clearForm(type);
       await onSuccess();
     },
@@ -1088,7 +1091,7 @@ function ConnectModalContent({
     options,
     signal,
   ) => {
-    await submitManualGrantCommand(
+    return await submitManualGrantCommand(
       { type, authMethod, inputValues, options },
       signal,
     );

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -16,17 +16,13 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@vm0/ui/components/ui/dialog";
-import {
-  CONNECTOR_TYPES,
-  type ConnectorAuthMethodConfig,
-  type ConnectorAuthMethodId,
-  type ConnectorDeviceAuthStartOptions,
-  type ConnectorDeviceAuthStartOptionsConfig,
-  type ConnectorManualGrantConfig,
-  type ConnectorType,
+import type {
+  ConnectorAuthMethodId,
+  ConnectorDeviceAuthStartOptions,
+  ConnectorType,
 } from "@vm0/connectors/connectors";
 import type { FormEvent, ReactElement } from "react";
-import { getConnectorAuthMethod } from "@vm0/connectors/connector-utils";
+import type { PublicConnectorCatalogStartOption } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import {
   allConnectorTypes$,
   connectFlowType$,
@@ -53,6 +49,9 @@ import {
   isStandaloneMode,
   connectorCurrentConnectionStatus,
   connectorExpiryCountdownText,
+  getConnectorStatusAuthMethod,
+  hasConnectorStatusAuthCodeGrant,
+  type ConnectorStatusAuthMethodDetail,
   type ConnectorExternalCodeState,
   type ConnectorOAuthDeviceAuthState,
   type ConnectorTypeWithStatus,
@@ -61,7 +60,6 @@ import { hasTokenInputValue } from "../../../../signals/zero-page/settings/token
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import { ConnectorIcon } from "./connector-icons.tsx";
 import { detach, onDomEventFn, Reason } from "../../../../signals/utils.ts";
-import { shouldShowGoogleSecurityWarningNotice } from "../../../../lib/google-security-warning.ts";
 import { GoogleSecurityWarningNotice } from "../../zero-directed-shared.tsx";
 import { ConnectorHelpText } from "./connector-help-text.tsx";
 
@@ -92,6 +90,7 @@ function connectedStatusText(item: ConnectorTypeWithStatus): string {
 
 type PostConnectOptions = {
   readonly showPermissionDialog?: boolean;
+  readonly connectorLabel?: string;
 };
 
 type SubmitManualGrantFn = (
@@ -147,7 +146,7 @@ type ConnectModalContentProps = {
 
 type ConnectMethodContentProps = ConnectModalContentProps & {
   authMethod: ConnectorAuthMethodId;
-  method: ConnectorAuthMethodConfig;
+  method: ConnectorStatusAuthMethodDetail;
   connectOAuthAuthCodeAndSettle: ConnectOAuthAuthCodeAndSettleFn;
   connectOAuthDeviceAuthAndSettle: ConnectOAuthDeviceAuthAndSettleFn;
   connectExternalCode: ConnectExternalCodeFn;
@@ -168,7 +167,7 @@ type ConnectMethodContentComponent = (
 
 type ConnectMethodContentEntry = {
   authMethod: ConnectorAuthMethodId;
-  method: ConnectorAuthMethodConfig;
+  method: ConnectorStatusAuthMethodDetail;
   Content: ConnectMethodContentComponent;
 };
 
@@ -224,18 +223,18 @@ function connectorExternalCodeStateForMethod(
 
 function ManualGrantForm({
   type,
+  connectorLabel,
   authMethod,
   method,
-  grant,
   onSuccess,
   showPermissionDialogOnConnect,
   submit,
   submitting,
 }: {
   type: ConnectorType;
+  connectorLabel: string;
   authMethod: ConnectorAuthMethodId;
-  method: ConnectorAuthMethodConfig;
-  grant: ConnectorManualGrantConfig;
+  method: ConnectorStatusAuthMethodDetail;
   onSuccess: () => void | Promise<void>;
   showPermissionDialogOnConnect: boolean;
   submit: SubmitManualGrantFn;
@@ -246,9 +245,8 @@ function ManualGrantForm({
   const pageSignal = useGet(pageSignal$);
   const fieldValues = useGet(manualGrantFormValuesFor$(type));
 
-  const fieldEntries = Object.entries(grant.fields);
-  const allFilled = fieldEntries.every(([name, cfg]) => {
-    return !cfg.required || hasTokenInputValue(fieldValues[name]);
+  const allFilled = method.manualFields.every((field) => {
+    return !field.required || hasTokenInputValue(fieldValues[field.id]);
   });
 
   const handleSubmit = onDomEventFn(
@@ -263,6 +261,7 @@ function ManualGrantForm({
         fieldValues,
         {
           showPermissionDialog: showPermissionDialogOnConnect,
+          connectorLabel,
         },
         pageSignal,
       );
@@ -273,19 +272,19 @@ function ManualGrantForm({
 
   return (
     <form className="flex flex-col gap-3" onSubmit={handleSubmit}>
-      {method.helpText && <ConnectorHelpText text={method.helpText} />}
-      {fieldEntries.map(([name, fieldConfig]) => {
+      {method.description && <ConnectorHelpText text={method.description} />}
+      {method.manualFields.map((fieldConfig) => {
         return (
-          <div key={name} className="flex flex-col gap-1.5">
+          <div key={fieldConfig.id} className="flex flex-col gap-1.5">
             <label className="text-sm font-medium text-foreground">
               {fieldConfig.label}
             </label>
             <Input
-              type="password"
-              placeholder={fieldConfig.placeholder}
-              value={fieldValues[name] ?? ""}
+              type={fieldConfig.inputType}
+              placeholder={fieldConfig.placeholder ?? undefined}
+              value={fieldValues[fieldConfig.id] ?? ""}
               onChange={(e) => {
-                return setFormValue(type, name, e.target.value);
+                return setFormValue(type, fieldConfig.id, e.target.value);
               }}
             />
           </div>
@@ -462,16 +461,13 @@ function OAuthDeviceAuthCodePanel({
 }
 
 function defaultDeviceAuthStartOptionValues(
-  startOptions: ConnectorDeviceAuthStartOptionsConfig | undefined,
+  startOptions: readonly PublicConnectorCatalogStartOption[],
 ): Record<string, string> {
-  if (!startOptions) {
-    return {};
-  }
   return Object.fromEntries(
-    Object.entries(startOptions).flatMap(([name, config]) => {
-      return config.defaultValue === undefined
+    startOptions.flatMap((option) => {
+      return option.defaultValue === null
         ? []
-        : ([[name, config.defaultValue]] as const);
+        : ([[option.id, option.defaultValue]] as const);
     }),
   );
 }
@@ -484,35 +480,34 @@ function deviceAuthStartOptionValue(
 }
 
 function selectedDeviceAuthStartOptions(
-  startOptions: ConnectorDeviceAuthStartOptionsConfig | undefined,
+  startOptions: readonly PublicConnectorCatalogStartOption[],
   values: Record<string, string>,
 ): ConnectorDeviceAuthStartOptions | undefined {
-  if (!startOptions) {
+  if (startOptions.length === 0) {
     return undefined;
   }
-  const selectedEntries = Object.entries(startOptions).flatMap(
-    ([name, config]) => {
-      const value =
-        deviceAuthStartOptionValue(values, name) ?? config.defaultValue;
-      return value === undefined ? [] : ([[name, value]] as const);
-    },
-  );
+  const selectedEntries = startOptions.flatMap((option) => {
+    const value =
+      deviceAuthStartOptionValue(values, option.id) ??
+      option.defaultValue ??
+      undefined;
+    return value === undefined ? [] : ([[option.id, value]] as const);
+  });
   return selectedEntries.length === 0
     ? undefined
     : Object.fromEntries(selectedEntries);
 }
 
 function deviceAuthStartOptionsFilled(
-  startOptions: ConnectorDeviceAuthStartOptionsConfig | undefined,
+  startOptions: readonly PublicConnectorCatalogStartOption[],
   values: Record<string, string>,
 ): boolean {
-  if (!startOptions) {
-    return true;
-  }
-  return Object.entries(startOptions).every(([name, config]) => {
+  return startOptions.every((option) => {
     return (
-      !config.required ||
-      Boolean(deviceAuthStartOptionValue(values, name) ?? config.defaultValue)
+      !option.required ||
+      Boolean(
+        deviceAuthStartOptionValue(values, option.id) ?? option.defaultValue,
+      )
     );
   });
 }
@@ -526,42 +521,44 @@ function OAuthDeviceAuthStartOptionsForm({
 }: {
   type: ConnectorType;
   authMethod: ConnectorAuthMethodId;
-  startOptions: ConnectorDeviceAuthStartOptionsConfig | undefined;
+  startOptions: readonly PublicConnectorCatalogStartOption[];
   values: Record<string, string>;
   setValue: (name: string, value: string) => void;
 }) {
-  if (!startOptions) {
+  if (startOptions.length === 0) {
     return null;
   }
 
   return (
     <>
-      {Object.entries(startOptions).map(([name, config]) => {
-        const inputId = `connector-device-auth-option-${type}-${authMethod}-${name}`;
+      {startOptions.map((option) => {
+        const inputId = `connector-device-auth-option-${type}-${authMethod}-${option.id}`;
         return (
-          <div key={name} className="flex flex-col gap-1.5">
+          <div key={option.id} className="flex flex-col gap-1.5">
             <label
               htmlFor={inputId}
               className="text-sm font-medium text-foreground"
             >
-              {config.label}
+              {option.label}
             </label>
             <Select
               value={
-                deviceAuthStartOptionValue(values, name) ?? config.defaultValue
+                deviceAuthStartOptionValue(values, option.id) ??
+                option.defaultValue ??
+                undefined
               }
               onValueChange={(value) => {
-                setValue(name, value);
+                setValue(option.id, value);
               }}
             >
               <SelectTrigger id={inputId} className="h-9">
-                <SelectValue placeholder={`Select ${config.label}`} />
+                <SelectValue placeholder={`Select ${option.label}`} />
               </SelectTrigger>
               <SelectContent>
-                {config.options.map((option) => {
+                {option.options.map((choice) => {
                   return (
-                    <SelectItem key={option.value} value={option.value}>
-                      {option.label}
+                    <SelectItem key={choice.value} value={choice.value}>
+                      {choice.label}
                     </SelectItem>
                   );
                 })}
@@ -583,9 +580,7 @@ function OAuthDeviceAuthConnectMethodContent(props: ConnectMethodContentProps) {
     setConnectorOAuthDeviceAuthStartOptionValue$,
   );
   const startOptions =
-    props.method.grant.kind === "device-auth"
-      ? props.method.grant.startOptions
-      : undefined;
+    props.method.grantKind === "device-auth" ? props.method.startOptions : [];
   const startOptionValues = useGet(
     connectorOAuthDeviceAuthStartOptionValuesFor$(
       props.item.type,
@@ -623,6 +618,7 @@ function OAuthDeviceAuthConnectMethodContent(props: ConnectMethodContentProps) {
         onSuccess: props.onSuccess,
         options: {
           showPermissionDialog: props.showPermissionDialogOnConnect,
+          connectorLabel: props.item.label,
         },
         startOptions: selectedDeviceAuthStartOptions(
           startOptions,
@@ -700,9 +696,7 @@ function OAuthDeviceAuthConnectMethodContent(props: ConnectMethodContentProps) {
         disabled={starting || !startOptionsFilled}
         className="w-full"
       >
-        {starting
-          ? "Starting..."
-          : `Connect ${CONNECTOR_TYPES[props.item.type].label}`}
+        {starting ? "Starting..." : `Connect ${props.item.label}`}
       </Button>
     </div>
   );
@@ -716,14 +710,14 @@ type ExternalCodeButtonHandler = (event: unknown) => void;
 type ExternalCodeSubmitHandler = (event: FormEvent<HTMLFormElement>) => void;
 
 function ExternalCodeStartContent({
-  type,
+  connectorLabel,
   method,
   current,
   starting,
   onStart,
 }: {
-  type: ConnectorType;
-  method: ConnectorAuthMethodConfig;
+  connectorLabel: string;
+  method: ConnectorStatusAuthMethodDetail;
   current: ConnectorExternalCodeState | null;
   starting: boolean;
   onStart: ExternalCodeButtonHandler;
@@ -734,7 +728,7 @@ function ExternalCodeStartContent({
       : null;
   return (
     <div className="flex flex-col gap-3">
-      {method.helpText && <ConnectorHelpText text={method.helpText} />}
+      {method.description && <ConnectorHelpText text={method.description} />}
       {terminalMessage ? (
         <p className="text-sm text-destructive" role="alert">
           {terminalMessage}
@@ -747,34 +741,31 @@ function ExternalCodeStartContent({
         disabled={starting}
         className="w-full"
       >
-        {starting
-          ? "Starting..."
-          : `Start ${CONNECTOR_TYPES[type].label} sign-in`}
+        {starting ? "Starting..." : `Start ${connectorLabel} sign-in`}
       </Button>
     </div>
   );
 }
 
 function ExternalCodePendingContent({
-  type,
+  connectorLabel,
   method,
   current,
   onOpen,
   onCodeChange,
   onComplete,
 }: {
-  type: ConnectorType;
-  method: ConnectorAuthMethodConfig;
+  connectorLabel: string;
+  method: ConnectorStatusAuthMethodDetail;
   current: PendingConnectorExternalCodeState;
   onOpen: ExternalCodeButtonHandler;
   onCodeChange: (code: string) => void;
   onComplete: ExternalCodeSubmitHandler;
 }) {
   const completing = current.status === "completing";
-  const connectorLabel = CONNECTOR_TYPES[type].label;
   return (
     <form className="flex flex-col gap-3" onSubmit={onComplete}>
-      {method.helpText && <ConnectorHelpText text={method.helpText} />}
+      {method.description && <ConnectorHelpText text={method.description} />}
       <p className="text-sm text-muted-foreground">
         Open {connectorLabel} sign-in, then paste the authorization code
         displayed by {connectorLabel}.
@@ -852,6 +843,7 @@ function ExternalCodeConnectMethodContent(props: ConnectMethodContentProps) {
         onSuccess: props.onSuccess,
         options: {
           showPermissionDialog: props.showPermissionDialogOnConnect,
+          connectorLabel: props.item.label,
         },
       },
       props.signal,
@@ -867,7 +859,7 @@ function ExternalCodeConnectMethodContent(props: ConnectMethodContentProps) {
   if (current?.status === "pending" || current?.status === "completing") {
     return (
       <ExternalCodePendingContent
-        type={props.item.type}
+        connectorLabel={props.item.label}
         method={props.method}
         current={current}
         onOpen={() => {
@@ -887,7 +879,7 @@ function ExternalCodeConnectMethodContent(props: ConnectMethodContentProps) {
 
   return (
     <ExternalCodeStartContent
-      type={props.item.type}
+      connectorLabel={props.item.label}
       method={props.method}
       current={current}
       starting={starting}
@@ -897,15 +889,15 @@ function ExternalCodeConnectMethodContent(props: ConnectMethodContentProps) {
 }
 
 function ManualGrantConnectMethodContent(props: ConnectMethodContentProps) {
-  if (props.method.grant.kind !== "manual") {
+  if (props.method.grantKind !== "manual") {
     return null;
   }
   return (
     <ManualGrantForm
       type={props.item.type}
+      connectorLabel={props.item.label}
       authMethod={props.authMethod}
       method={props.method}
-      grant={props.method.grant}
       onSuccess={props.onSuccess}
       showPermissionDialogOnConnect={props.showPermissionDialogOnConnect}
       submit={props.submitManualGrant}
@@ -915,9 +907,9 @@ function ManualGrantConnectMethodContent(props: ConnectMethodContentProps) {
 }
 
 function getConnectMethodContentComponent(
-  method: ConnectorAuthMethodConfig,
+  method: ConnectorStatusAuthMethodDetail,
 ): ConnectMethodContentComponent | null {
-  switch (method.grant.kind) {
+  switch (method.grantKind) {
     case "auth-code": {
       return OAuthAuthCodeConnectMethodContent;
     }
@@ -940,21 +932,12 @@ function getConnectMethodContentEntries(
   item: ConnectorTypeWithStatus,
 ): ConnectMethodContentEntry[] {
   return item.availableAuthMethods.flatMap((authMethod) => {
-    const method = getConnectorAuthMethod(item.type, authMethod);
+    const method = getConnectorStatusAuthMethod(item, authMethod);
     if (!method) {
       return [];
     }
     const Content = getConnectMethodContentComponent(method);
     return Content ? [{ authMethod, method, Content }] : [];
-  });
-}
-
-function hasAuthCodeGrant(
-  type: ConnectorType,
-  authMethods: readonly ConnectorAuthMethodId[],
-): boolean {
-  return authMethods.some((authMethod) => {
-    return getConnectorAuthMethod(type, authMethod)?.grant.kind === "auth-code";
   });
 }
 
@@ -975,7 +958,7 @@ function ConnectMethodHeading({
   method,
   show,
 }: {
-  method: ConnectorAuthMethodConfig;
+  method: ConnectorStatusAuthMethodDetail;
   show: boolean;
 }) {
   if (!show) {
@@ -1050,12 +1033,8 @@ function StandardConnectMethodsContent({
   entries: readonly ConnectMethodContentEntry[];
 }) {
   const showGoogleSecurityWarningNotice =
-    hasAuthCodeGrant(
-      item.type,
-      entries.map((entry) => {
-        return entry.authMethod;
-      }),
-    ) && shouldShowGoogleSecurityWarningNotice(item.type);
+    hasConnectorStatusAuthCodeGrant(item) &&
+    item.connectNotice === "google-security-warning";
 
   return (
     <div className="flex flex-col gap-4">
@@ -1157,7 +1136,7 @@ function ConnectModalContent({
     await completeExternalCodeAndSettleCommand(args, signal);
   };
 
-  const progressContent = hasAuthCodeGrant(item.type, item.availableAuthMethods)
+  const progressContent = hasConnectorStatusAuthCodeGrant(item)
     ? getOAuthAuthCodeProgressContent({
         isPolling,
         settling,
@@ -1214,7 +1193,6 @@ export function ConnectModal({
     return null;
   }
 
-  const config = CONNECTOR_TYPES[selectedType];
   const connectFlowActive =
     connectFlowType === selectedType ||
     pollingType === selectedType ||
@@ -1249,7 +1227,7 @@ export function ConnectModal({
             <div className="flex h-5 w-5 shrink-0 items-center justify-center">
               <ConnectorIcon type={selectedType} size={20} />
             </div>
-            <DialogTitle>{config.label}</DialogTitle>
+            <DialogTitle>{item.label}</DialogTitle>
           </div>
         </DialogHeader>
 

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -1176,12 +1176,18 @@ export function ConnectModal({
   onClose,
   onSuccess,
   showPermissionDialogOnConnect = false,
+  selectedType: selectedTypeOverride,
 }: {
   onClose: () => void;
   onSuccess?: () => void | Promise<void>;
   showPermissionDialogOnConnect?: boolean;
+  selectedType?: ConnectorType | null;
 }) {
-  const selectedType = useGet(selectedConnectorType$);
+  const globalSelectedType = useGet(selectedConnectorType$);
+  const selectedType =
+    selectedTypeOverride === undefined
+      ? globalSelectedType
+      : selectedTypeOverride;
   const connectorTypes = useLastResolved(allConnectorTypes$);
   const clearConnectorOAuthDeviceAuth = useSet(clearConnectorOAuthDeviceAuth$);
   const clearConnectorExternalCode = useSet(clearConnectorExternalCode$);

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -51,6 +51,7 @@ import {
   connectorExpiryCountdownText,
   getConnectorStatusAuthMethod,
   hasConnectorStatusAuthCodeGrant,
+  manualGrantInputValuesForMethod,
   type ConnectorStatusAuthMethodDetail,
   type ConnectorExternalCodeState,
   type ConnectorOAuthDeviceAuthState,
@@ -258,7 +259,7 @@ function ManualGrantForm({
       await submit(
         type,
         authMethod,
-        fieldValues,
+        manualGrantInputValuesForMethod(method, fieldValues),
         {
           showPermissionDialog: showPermissionDialogOnConnect,
           connectorLabel,
@@ -364,6 +365,7 @@ function OAuthAuthCodeConnectButton({
             onSuccess,
             {
               showPermissionDialog: showPermissionDialogOnConnect,
+              connectorLabel: item.label,
             },
             signal,
           ),

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-access-management-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-access-management-dialog.tsx
@@ -18,10 +18,7 @@ import {
   TooltipTrigger,
   cn,
 } from "@vm0/ui";
-import {
-  CONNECTOR_TYPES,
-  type ConnectorType,
-} from "@vm0/connectors/connectors";
+import type { ConnectorType } from "@vm0/connectors/connectors";
 import {
   hasFirewallMetadataPermissions,
   permissionGrantsToFirewallPolicies,
@@ -52,6 +49,7 @@ import { toast } from "@vm0/ui/components/ui/sonner";
 import { AvatarFromUrl } from "../../zero-sidebar-shared.tsx";
 import { ConnectorIcon } from "./connector-icons.tsx";
 import { PermissionsDialog } from "./permissions-dialog.tsx";
+import { allConnectorTypes$ } from "../../../../signals/zero-page/settings/connectors.ts";
 
 interface ConnectorAccessManagementDialogProps {
   readonly connectorType: ConnectorType;
@@ -329,6 +327,7 @@ function AgentPermissionDialog({
   row,
   metadata,
   connectorType,
+  connectorLabel,
   pageSignal,
   applyGrantPolicies,
   onClose,
@@ -336,6 +335,7 @@ function AgentPermissionDialog({
   readonly row: ConnectorAgentAccessRow | undefined;
   readonly metadata: FirewallPermissionDetailMetadata | null;
   readonly connectorType: ConnectorType;
+  readonly connectorLabel: string;
   readonly pageSignal: AbortSignal;
   readonly applyGrantPolicies: ApplyUserPermissionGrants;
   readonly onClose: () => void;
@@ -349,6 +349,7 @@ function AgentPermissionDialog({
     <PermissionsDialog
       agentId={row.agent.id}
       connectorType={connectorType}
+      connectorLabel={connectorLabel}
       displayName={agentName(row.agent)}
       initialPolicies={initialPolicies}
       initialGrants={row.grants}
@@ -376,7 +377,13 @@ export function ConnectorAccessManagementDialog({
   connectorType,
   onClose,
 }: ConnectorAccessManagementDialogProps) {
-  const connector = CONNECTOR_TYPES[connectorType];
+  const connectorTypes = useLastLoadable(allConnectorTypes$);
+  const connectorLabel =
+    connectorTypes.state === "hasData"
+      ? (connectorTypes.data.find((connector) => {
+          return connector.type === connectorType;
+        })?.label ?? connectorType)
+      : connectorType;
   const rowsLoadable = useLastLoadable(
     connectorAgentAccessRows({ connectorType }),
   );
@@ -418,7 +425,7 @@ export function ConnectorAccessManagementDialog({
           { agentId: row.agent.id, connectorType, authorized },
           pageSignal,
         );
-        toast.success(`${connector.label} access updated`);
+        toast.success(`${connectorLabel} access updated`);
         setSavingAgentId(null);
       })(),
       Reason.DomCallback,
@@ -430,7 +437,7 @@ export function ConnectorAccessManagementDialog({
       <ConnectorAccessDialog
         onClose={onClose}
         connectorType={connectorType}
-        connectorLabel={connector.label}
+        connectorLabel={connectorLabel}
         rows={filterRows(rows, search)}
         rowsLoaded={rowsLoadable.state === "hasData"}
         metadata={metadata}
@@ -446,6 +453,7 @@ export function ConnectorAccessManagementDialog({
         row={selectedPermissionRow}
         metadata={metadata}
         connectorType={connectorType}
+        connectorLabel={connectorLabel}
         pageSignal={pageSignal}
         applyGrantPolicies={applyGrantPolicies}
         onClose={() => {

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-access-management-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-access-management-dialog.tsx
@@ -43,7 +43,7 @@ import {
   savePermissionDraftPolicies,
   type ApplyUserPermissionGrants,
 } from "../../../../signals/zero-page/settings/permission-grant-save.ts";
-import { detach, Reason } from "../../../../signals/utils.ts";
+import { detach, Reason, withCleanup } from "../../../../signals/utils.ts";
 import { LoadingSwitch } from "../../../components/loading-switch.tsx";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { AvatarFromUrl } from "../../zero-sidebar-shared.tsx";
@@ -414,14 +414,18 @@ export function ConnectorAccessManagementDialog({
     }
     setSavingAgentId(row.agent.id);
     detach(
-      (async () => {
-        await setAuthorization(
-          { agentId: row.agent.id, connectorType, authorized },
-          pageSignal,
-        );
-        toast.success(`${connectorLabel} access updated`);
-        setSavingAgentId(null);
-      })(),
+      withCleanup(
+        (async () => {
+          await setAuthorization(
+            { agentId: row.agent.id, connectorType, authorized },
+            pageSignal,
+          );
+          toast.success(`${connectorLabel} access updated`);
+        })(),
+        () => {
+          setSavingAgentId(null);
+        },
+      ),
       Reason.DomCallback,
     );
   };

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-access-management-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-access-management-dialog.tsx
@@ -49,10 +49,10 @@ import { toast } from "@vm0/ui/components/ui/sonner";
 import { AvatarFromUrl } from "../../zero-sidebar-shared.tsx";
 import { ConnectorIcon } from "./connector-icons.tsx";
 import { PermissionsDialog } from "./permissions-dialog.tsx";
-import { allConnectorTypes$ } from "../../../../signals/zero-page/settings/connectors.ts";
 
 interface ConnectorAccessManagementDialogProps {
   readonly connectorType: ConnectorType;
+  readonly connectorLabel: string;
   readonly onClose: () => void;
 }
 
@@ -375,15 +375,9 @@ function AgentPermissionDialog({
 
 export function ConnectorAccessManagementDialog({
   connectorType,
+  connectorLabel,
   onClose,
 }: ConnectorAccessManagementDialogProps) {
-  const connectorTypes = useLastLoadable(allConnectorTypes$);
-  const connectorLabel =
-    connectorTypes.state === "hasData"
-      ? (connectorTypes.data.find((connector) => {
-          return connector.type === connectorType;
-        })?.label ?? connectorType)
-      : connectorType;
   const rowsLoadable = useLastLoadable(
     connectorAgentAccessRows({ connectorType }),
   );

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-permission-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-permission-dialog.tsx
@@ -11,10 +11,7 @@ import {
   DialogFooter,
 } from "@vm0/ui/components/ui/dialog";
 import { Button } from "@vm0/ui/components/ui/button";
-import {
-  CONNECTOR_TYPES,
-  type ConnectorType,
-} from "@vm0/connectors/connectors";
+import type { ConnectorType } from "@vm0/connectors/connectors";
 import { agents$ } from "../../../../signals/agent.ts";
 import { detach, Reason } from "../../../../signals/utils.ts";
 import { AvatarFromUrl } from "../../zero-sidebar-shared.tsx";
@@ -27,6 +24,7 @@ import {
   confirmPermissionDialog$,
 } from "../../../../signals/zero-page/settings/permission-dialog.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
+import { allConnectorTypes$ } from "../../../../signals/zero-page/settings/connectors.ts";
 
 const VISIBLE_AGENT_COUNT = 16;
 
@@ -46,10 +44,13 @@ export function ConnectorPermissionDialog({
   const setSearch = useSet(setPermissionDialogSearch$);
   const [confirmLoadable, confirm] = useLoadableSet(confirmPermissionDialog$);
   const pageSignal = useGet(pageSignal$);
+  const connectorTypes = useLastResolved(allConnectorTypes$);
 
   const submitting = confirmLoadable.state === "loading";
-
-  const config = CONNECTOR_TYPES[connectorType];
+  const connectorLabel =
+    connectorTypes?.find((connector) => {
+      return connector.type === connectorType;
+    })?.label ?? connectorType;
 
   const filtered = (() => {
     if (!allAgents) {
@@ -85,7 +86,7 @@ export function ConnectorPermissionDialog({
             <ConnectorIcon type={connectorType} size={20} />
           </div>
           <DialogTitle className="text-base font-medium">
-            {config.label}
+            {connectorLabel}
           </DialogTitle>
         </DialogHeader>
 
@@ -95,7 +96,7 @@ export function ConnectorPermissionDialog({
             <div className="flex flex-col items-center gap-6">
               <div className="flex flex-col items-center gap-2.5 text-center text-foreground">
                 <p className="text-lg font-medium leading-7">
-                  You&apos;ve successfully connected with {config.label}!
+                  You&apos;ve successfully connected with {connectorLabel}!
                 </p>
                 <p className="text-sm leading-5">
                   You can now let some of your agents to use this connector
@@ -179,7 +180,7 @@ export function ConnectorPermissionDialog({
             <Button
               onClick={() => {
                 detach(
-                  confirm(connectorType, onClose, pageSignal),
+                  confirm(connectorType, connectorLabel, onClose, pageSignal),
                   Reason.DomCallback,
                 );
               }}

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-permission-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-permission-dialog.tsx
@@ -24,17 +24,18 @@ import {
   confirmPermissionDialog$,
 } from "../../../../signals/zero-page/settings/permission-dialog.ts";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
-import { allConnectorTypes$ } from "../../../../signals/zero-page/settings/connectors.ts";
 
 const VISIBLE_AGENT_COUNT = 16;
 
 interface ConnectorPermissionDialogProps {
   connectorType: ConnectorType;
+  connectorLabel: string;
   onClose: () => void;
 }
 
 export function ConnectorPermissionDialog({
   connectorType,
+  connectorLabel,
   onClose,
 }: ConnectorPermissionDialogProps) {
   const allAgents = useLastResolved(agents$);
@@ -44,13 +45,8 @@ export function ConnectorPermissionDialog({
   const setSearch = useSet(setPermissionDialogSearch$);
   const [confirmLoadable, confirm] = useLoadableSet(confirmPermissionDialog$);
   const pageSignal = useGet(pageSignal$);
-  const connectorTypes = useLastResolved(allConnectorTypes$);
 
   const submitting = confirmLoadable.state === "loading";
-  const connectorLabel =
-    connectorTypes?.find((connector) => {
-      return connector.type === connectorType;
-    })?.label ?? connectorType;
 
   const filtered = (() => {
     if (!allAgents) {

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -104,7 +104,7 @@ interface PermissionsDrawerProps {
   agentId: string;
   targetKind?: "agent" | "workflow";
   connectorType: ConnectorType;
-  connectorLabel?: string;
+  connectorLabel: string;
   displayName: string;
   initialPolicies: FirewallPolicies;
   initialGrants: readonly UserPermissionGrantResponse[];
@@ -196,10 +196,9 @@ function PermissionsDrawerHeader({
 > & {
   readonly surface: PermissionsSurface;
 }) {
-  const label = connectorLabel ?? connectorType;
   const title = (
     <>
-      {label} permissions
+      {connectorLabel} permissions
       <span className="text-sm font-normal text-muted-foreground ml-1">
         for {displayName}
       </span>

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -22,10 +22,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
 } from "@vm0/ui";
-import {
-  CONNECTOR_TYPES,
-  type ConnectorType,
-} from "@vm0/connectors/connectors";
+import type { ConnectorType } from "@vm0/connectors/connectors";
 import {
   groupFirewallMetadataPermissionsByCategory,
   type FirewallPermissionDetailMetadata,
@@ -107,6 +104,7 @@ interface PermissionsDrawerProps {
   agentId: string;
   targetKind?: "agent" | "workflow";
   connectorType: ConnectorType;
+  connectorLabel?: string;
   displayName: string;
   initialPolicies: FirewallPolicies;
   initialGrants: readonly UserPermissionGrantResponse[];
@@ -188,19 +186,20 @@ function buildInitialPermissionDrawerState({
 
 function PermissionsDrawerHeader({
   connectorType,
+  connectorLabel,
   displayName,
   targetKind = "agent",
   surface,
 }: Pick<
   PermissionsDrawerProps,
-  "connectorType" | "displayName" | "targetKind"
+  "connectorType" | "connectorLabel" | "displayName" | "targetKind"
 > & {
   readonly surface: PermissionsSurface;
 }) {
-  const connectorLabel = CONNECTOR_TYPES[connectorType].label;
+  const label = connectorLabel ?? connectorType;
   const title = (
     <>
-      {connectorLabel} permissions
+      {label} permissions
       <span className="text-sm font-normal text-muted-foreground ml-1">
         for {displayName}
       </span>
@@ -1549,6 +1548,7 @@ function PermissionsContent({
     <>
       <PermissionsDrawerHeader
         connectorType={props.connectorType}
+        connectorLabel={props.connectorLabel}
         displayName={props.displayName}
         targetKind={props.targetKind}
         surface={surface}

--- a/turbo/apps/platform/src/views/zero-page/components/settings/scope-review-modal.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/scope-review-modal.tsx
@@ -1,16 +1,16 @@
-import { useLoadable } from "ccstate-react";
+import { useLastResolved, useLoadable } from "ccstate-react";
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
 } from "@vm0/ui/components/ui/dialog";
-import {
-  CONNECTOR_TYPES,
-  type ConnectorType,
-} from "@vm0/connectors/connectors";
+import type { ConnectorType } from "@vm0/connectors/connectors";
 import { ConnectorIcon } from "./connector-icons.tsx";
-import { scopeDiff$ } from "../../../../signals/zero-page/settings/connectors.ts";
+import {
+  allConnectorTypes$,
+  scopeDiff$,
+} from "../../../../signals/zero-page/settings/connectors.ts";
 
 interface ScopeReviewModalProps {
   connectorType: ConnectorType | null;
@@ -24,6 +24,7 @@ export function ScopeReviewModal({
   onReconnect,
 }: ScopeReviewModalProps) {
   const scopeDiffLoadable = useLoadable(scopeDiff$);
+  const connectorTypes = useLastResolved(allConnectorTypes$);
   const loading = scopeDiffLoadable.state === "loading";
   const scopeDiff =
     scopeDiffLoadable.state === "hasData" ? scopeDiffLoadable.data : null;
@@ -32,7 +33,10 @@ export function ScopeReviewModal({
     return null;
   }
 
-  const config = CONNECTOR_TYPES[connectorType];
+  const connectorLabel =
+    connectorTypes?.find((connector) => {
+      return connector.type === connectorType;
+    })?.label ?? connectorType;
 
   return (
     <Dialog
@@ -47,7 +51,7 @@ export function ScopeReviewModal({
             <div className="flex h-5 w-5 shrink-0 items-center justify-center">
               <ConnectorIcon type={connectorType} size={20} />
             </div>
-            <DialogTitle>{config.label} permissions update</DialogTitle>
+            <DialogTitle>{connectorLabel} permissions update</DialogTitle>
           </div>
         </DialogHeader>
 

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -79,8 +79,7 @@ import {
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { noConnectorImg } from "./platform-assets.ts";
 import { AvatarFromUrl } from "./zero-sidebar-shared.tsx";
-import { detach, onDomEventFn, Reason } from "../../signals/utils.ts";
-import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
+import { detach, Reason } from "../../signals/utils.ts";
 import {
   Button,
   DropdownMenu,

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -1141,19 +1141,28 @@ export function ZeroConnectorsPage() {
               return connector.type === type;
             });
             const connection = connector?.connector ?? null;
-            const authMethod =
-              connector && connection
-                ? getAvailableStatusAuthCodeAuthMethod(
-                    connector,
-                    connection.authMethod,
-                  )
-                : null;
+            if (!connector || !connection) {
+              setSelected(type);
+              return;
+            }
+            const authMethod = getAvailableStatusAuthCodeAuthMethod(
+              connector,
+              connection.authMethod,
+            );
             if (!authMethod) {
               setSelected(type);
               return;
             }
             detach(
-              connect(type, authMethod, { showPermissionDialog: true }, signal),
+              connect(
+                type,
+                authMethod,
+                {
+                  showPermissionDialog: true,
+                  connectorLabel: connector.label,
+                },
+                signal,
+              ),
               Reason.DomCallback,
             );
           }}

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -34,6 +34,7 @@ import {
   connectConnectorOAuthAuthCode$,
   connectorsSearch$,
   connectorsConnectionFilter$,
+  closePermissionDialog$,
   disconnectConnector$,
   filteredConnectorTypes$,
   setConnectorsConnectionFilter$,
@@ -45,9 +46,7 @@ import {
   justConnectedTypes$,
   scopeReviewType$,
   setScopeReviewType$,
-  permissionDialogLabel$,
-  permissionDialogType$,
-  setPermissionDialogType$,
+  permissionDialog$,
   isStandaloneMode,
   getAvailableStatusAuthCodeAuthMethod,
   getOnlyAvailableStatusAuthCodeAuthMethod,
@@ -944,9 +943,8 @@ export function ZeroConnectorsPage() {
   const setSelected = useSet(setSelectedConnectorType$);
   const scopeReviewType = useGet(scopeReviewType$);
   const setScopeReviewType = useSet(setScopeReviewType$);
-  const permissionDialogType = useGet(permissionDialogType$);
-  const permissionDialogLabel = useGet(permissionDialogLabel$);
-  const setPermissionDialogType = useSet(setPermissionDialogType$);
+  const permissionDialog = useGet(permissionDialog$);
+  const closePermissionDialog = useSet(closePermissionDialog$);
   const managedConnectorType = useGet(managedConnectorAccessType$);
   const setManagedConnectorType = useSet(setManagedConnectorAccessType$);
   const closeManagedConnector = useSet(closeConnectorAccessManagement$);
@@ -1197,13 +1195,11 @@ export function ZeroConnectorsPage() {
         />
       )}
 
-      {permissionDialogType && (
+      {permissionDialog && (
         <ConnectorPermissionDialog
-          connectorType={permissionDialogType}
-          connectorLabel={permissionDialogLabel ?? permissionDialogType}
-          onClose={() => {
-            setPermissionDialogType(null);
-          }}
+          connectorType={permissionDialog.type}
+          connectorLabel={permissionDialog.label}
+          onClose={closePermissionDialog}
         />
       )}
 

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -10,7 +10,6 @@ import {
 import { useLoadableSet } from "ccstate-react/experimental";
 import {
   IconSearch,
-  IconPlug,
   IconPlus,
   IconLoader2,
   IconDotsVertical,
@@ -18,10 +17,7 @@ import {
   IconChevronDown,
   IconCheck,
 } from "@tabler/icons-react";
-import {
-  CONNECTOR_TYPES,
-  type ConnectorType,
-} from "@vm0/connectors/connectors";
+import type { ConnectorType } from "@vm0/connectors/connectors";
 import type { TeamComposeItem } from "@vm0/api-contracts/contracts/zero-team";
 import { Tabs, TabsList, TabsTrigger } from "@vm0/ui/components/ui/tabs";
 import {
@@ -31,7 +27,6 @@ import {
 } from "../../signals/zero-page/settings/custom-connectors.ts";
 import { isOrgAdmin$ } from "../../signals/org.ts";
 import { agents$ } from "../../signals/agent.ts";
-import { shouldShowGoogleSecurityWarningNotice } from "../../lib/google-security-warning.ts";
 import { CustomConnectorsPanel } from "./components/settings/custom-connectors-panel.tsx";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import {
@@ -85,6 +80,7 @@ import { toast } from "@vm0/ui/components/ui/sonner";
 import { noConnectorImg } from "./platform-assets.ts";
 import { AvatarFromUrl } from "./zero-sidebar-shared.tsx";
 import { detach, onDomEventFn, Reason } from "../../signals/utils.ts";
+import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import {
   Button,
   DropdownMenu,
@@ -687,15 +683,7 @@ function GlobalConnectorCard({
     <div className="zero-card flex flex-col">
       <div className="flex h-14 items-center gap-2.5 px-5">
         <span className="flex h-5 w-5 shrink-0 items-center justify-center">
-          {connector.type in CONNECTOR_TYPES ? (
-            <ConnectorIcon type={connector.type} size={20} />
-          ) : (
-            <IconPlug
-              size={18}
-              stroke={1.5}
-              className="text-muted-foreground"
-            />
-          )}
+          <ConnectorIcon type={connector.type} size={20} />
         </span>
         <span
           data-testid="connector-card-label"
@@ -779,15 +767,7 @@ function AvailableConnectorCard({
     >
       <div className="flex items-center gap-2.5 px-5 pt-4 pb-1">
         <span className="flex h-5 w-5 shrink-0 items-center justify-center">
-          {connector.type in CONNECTOR_TYPES ? (
-            <ConnectorIcon type={connector.type} size={20} />
-          ) : (
-            <IconPlug
-              size={18}
-              stroke={1.5}
-              className="text-muted-foreground"
-            />
-          )}
+          <ConnectorIcon type={connector.type} size={20} />
         </span>
         <span
           data-testid="connector-card-label"
@@ -816,7 +796,7 @@ function AvailableConnectorCard({
           data-testid="connector-help-text"
           className="text-xs text-muted-foreground line-clamp-2"
         >
-          {shouldShowGoogleSecurityWarningNotice(connector.type) ? (
+          {connector.connectNotice === "google-security-warning" ? (
             <>
               <TooltipProvider delayDuration={200}>
                 <Tooltip>
@@ -994,18 +974,26 @@ export function ZeroConnectorsPage() {
         return;
       }
       detach(
-        connect(type, authMethod, { showPermissionDialog: true }, signal),
+        connect(
+          type,
+          authMethod,
+          { showPermissionDialog: true, connectorLabel: ct.label },
+          signal,
+        ),
         Reason.DomCallback,
       );
     }
   };
 
-  const disconnectHandler = onDomEventFn(async (type: ConnectorType) => {
+  const disconnectHandler = async (
+    type: ConnectorType,
+    connectorLabel: string,
+  ) => {
     if (disconnecting) {
       return;
     }
-    await disconnect(type, signal);
-  });
+    await disconnect(type, connectorLabel, signal);
+  };
 
   const getOptimisticConnector = (c: ConnectorTypeWithStatus) => {
     return optimisticConnected.has(c.type) && !c.connected
@@ -1040,7 +1028,7 @@ export function ZeroConnectorsPage() {
           return connectHandler(c.type);
         }}
         onDisconnect={() => {
-          return disconnectHandler(c.type);
+          detach(disconnectHandler(c.type, c.label), Reason.DomCallback);
         }}
         onManageAccess={() => {
           setManagedConnectorType(c.type);

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -751,17 +751,25 @@ function AvailableConnectorCard({
   isPolling: boolean;
   onConnect: () => void;
 }) {
+  const handleConnect = () => {
+    if (isPolling) {
+      return;
+    }
+    onConnect();
+  };
+
   return (
     <div
       role="button"
-      tabIndex={0}
+      tabIndex={isPolling ? -1 : 0}
       aria-label={`Connect ${connector.label}`}
-      className="zero-card cursor-pointer overflow-hidden"
-      onClick={onConnect}
+      aria-disabled={isPolling}
+      className={`zero-card overflow-hidden ${isPolling ? "cursor-default" : "cursor-pointer"}`}
+      onClick={handleConnect}
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault();
-          onConnect();
+          handleConnect();
         }
       }}
     >

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -45,6 +45,7 @@ import {
   justConnectedTypes$,
   scopeReviewType$,
   setScopeReviewType$,
+  permissionDialogLabel$,
   permissionDialogType$,
   setPermissionDialogType$,
   isStandaloneMode,
@@ -917,6 +918,20 @@ function renderBuiltinList({
   });
 }
 
+function connectorLabelForType(
+  connectors: readonly ConnectorTypeWithStatus[],
+  type: ConnectorType | null,
+): string | null {
+  if (!type) {
+    return null;
+  }
+  return (
+    connectors.find((connector) => {
+      return connector.type === type;
+    })?.label ?? type
+  );
+}
+
 export function ZeroConnectorsPage() {
   const allTypesLoadable = useLastLoadable(allConnectorTypes$);
   const filteredTypesLoadable = useLastLoadable(filteredConnectorTypes$);
@@ -930,6 +945,7 @@ export function ZeroConnectorsPage() {
   const scopeReviewType = useGet(scopeReviewType$);
   const setScopeReviewType = useSet(setScopeReviewType$);
   const permissionDialogType = useGet(permissionDialogType$);
+  const permissionDialogLabel = useGet(permissionDialogLabel$);
   const setPermissionDialogType = useSet(setPermissionDialogType$);
   const managedConnectorType = useGet(managedConnectorAccessType$);
   const setManagedConnectorType = useSet(setManagedConnectorAccessType$);
@@ -961,6 +977,10 @@ export function ZeroConnectorsPage() {
     filteredTypesLoadable.state === "hasData" ? filteredTypesLoadable.data : [];
   const allConnectors =
     allTypesLoadable.state === "hasData" ? allTypesLoadable.data : [];
+  const managedConnectorLabel = connectorLabelForType(
+    allConnectors,
+    managedConnectorType,
+  );
   const disconnecting = disconnectLoadable.state === "loading";
 
   const connectHandler = (type: ConnectorType) => {
@@ -1180,15 +1200,17 @@ export function ZeroConnectorsPage() {
       {permissionDialogType && (
         <ConnectorPermissionDialog
           connectorType={permissionDialogType}
+          connectorLabel={permissionDialogLabel ?? permissionDialogType}
           onClose={() => {
             setPermissionDialogType(null);
           }}
         />
       )}
 
-      {managedConnectorType && (
+      {managedConnectorType && managedConnectorLabel && (
         <ConnectorAccessManagementDialog
           connectorType={managedConnectorType}
+          connectorLabel={managedConnectorLabel}
           onClose={closeManagedConnector}
         />
       )}

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
@@ -21,8 +21,9 @@ import {
   directedAuthorizeAgentId$,
   directedAuthorizeAgentName$,
   agentEnabledTypes$,
-  justAuthorizedTypes$,
+  justAuthorizedConnectorAgentKeys$,
   authorizeConnector$,
+  isJustAuthorizedConnectorAgent,
 } from "../../signals/connectors-page/directed-authorize-type.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { IconCheck, IconLoader2 } from "@tabler/icons-react";
@@ -117,15 +118,20 @@ function useDirectedAuthorizeCatalogState(connectorType: ConnectorType | null) {
 
 function useDirectedAuthorizePermissionState(
   connectorType: ConnectorType | null,
+  agentId: string | null,
 ) {
-  const justAuthorized = useGet(justAuthorizedTypes$);
+  const justAuthorizedKeys = useGet(justAuthorizedConnectorAgentKeys$);
   const enabledLoadable = useLastLoadable(agentEnabledTypes$);
   const enabledTypes =
     enabledLoadable.state === "hasData" ? enabledLoadable.data : [];
   return {
     isAuthorized:
       connectorType !== null &&
-      (justAuthorized.has(connectorType) ||
+      agentId !== null &&
+      (isJustAuthorizedConnectorAgent(justAuthorizedKeys, {
+        connectorType,
+        agentId,
+      }) ||
         enabledTypes.includes(connectorType)),
     permissionLoading: enabledLoadable.state === "loading",
   };
@@ -225,7 +231,10 @@ function DirectedAuthorizeCard() {
   const { item, isConnected, catalogLoading, unavailable } =
     useDirectedAuthorizeCatalogState(connectorTypeForState);
   const { isAuthorized, permissionLoading } =
-    useDirectedAuthorizePermissionState(connectorTypeForState);
+    useDirectedAuthorizePermissionState(
+      connectorTypeForState,
+      params?.agentId ?? null,
+    );
 
   if (!params) {
     return null;

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
@@ -11,8 +11,6 @@ import {
   getOnlyAvailableStatusAuthCodeAuthMethod,
   justConnectedTypes$,
   pollingOAuthAuthCodeConnectorType$,
-  selectedConnectorType$,
-  setSelectedConnectorType$,
   type ConnectorTypeWithStatus,
 } from "../../signals/zero-page/settings/connectors.ts";
 import { detach, Reason } from "../../signals/utils.ts";
@@ -24,6 +22,9 @@ import {
   justAuthorizedConnectorAgentKeys$,
   authorizeConnector$,
   isJustAuthorizedConnectorAgent,
+  directedAuthorizeConnectModalKey$,
+  setDirectedAuthorizeConnectModalKey$,
+  type DirectedAuthorizeConnectModalKey,
 } from "../../signals/connectors-page/directed-authorize-type.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { IconCheck, IconLoader2 } from "@tabler/icons-react";
@@ -178,6 +179,91 @@ function shouldShowDirectedAuthorizeGoogleSecurityWarning(args: {
   );
 }
 
+function directedAuthorizeConnectModalOpen(
+  key: DirectedAuthorizeConnectModalKey | null,
+  args: {
+    readonly connectorType: ConnectorType | null;
+    readonly agentId: string | null;
+    readonly signal: AbortSignal;
+  },
+): boolean {
+  return (
+    key?.connectorType === args.connectorType &&
+    key.agentId === args.agentId &&
+    key.signal === args.signal
+  );
+}
+
+function DirectedAuthorizeCardContent({
+  connectorType,
+  connectorLabel,
+  connectorDescription,
+  agentName,
+  isAuthorized,
+  isConnecting,
+  isLoading,
+  canAuthorize,
+  showGoogleSecurityWarningNotice,
+  onAuthorize,
+}: {
+  readonly connectorType: ConnectorType;
+  readonly connectorLabel: string;
+  readonly connectorDescription: string;
+  readonly agentName: string;
+  readonly isAuthorized: boolean;
+  readonly isConnecting: boolean;
+  readonly isLoading: boolean;
+  readonly canAuthorize: boolean;
+  readonly showGoogleSecurityWarningNotice: boolean;
+  readonly onAuthorize: () => void;
+}) {
+  return (
+    <div className="fixed inset-0 z-10 flex items-center justify-center pointer-events-none">
+      <div className="pointer-events-auto flex w-[430px] max-w-[calc(100%-48px)] flex-col items-center gap-12 rounded-[20px] border border-border bg-background px-6 py-12 text-center">
+        <Vm0LogoLink />
+        <div className="flex w-full flex-col gap-4">
+          <div className="flex flex-col items-center gap-2.5">
+            {isLoading ? (
+              <IconLoader2
+                size={20}
+                className="animate-spin text-muted-foreground"
+              />
+            ) : (
+              <>
+                <h1 className="text-lg font-medium text-foreground">
+                  {isAuthorized
+                    ? `${connectorLabel} authorized`
+                    : `${agentName} needs ${connectorLabel} to proceed`}
+                </h1>
+                <div className="flex items-center justify-center rounded-[10px] bg-muted p-2.5">
+                  <ConnectorIcon type={connectorType} size={20} />
+                </div>
+                <p className="w-60 text-sm text-muted-foreground">
+                  {connectorDescription}
+                </p>
+                {showGoogleSecurityWarningNotice && (
+                  <GoogleSecurityWarningNotice />
+                )}
+              </>
+            )}
+          </div>
+          {!isLoading && (
+            <div className="flex items-center justify-center">
+              <AuthorizeAction
+                isAuthorized={isAuthorized}
+                isConnecting={isConnecting}
+                disabled={!canAuthorize}
+                agentName={agentName}
+                onAuthorize={onAuthorize}
+              />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function runDirectedAuthorize(params: {
   readonly canAuthorize: boolean;
   readonly isConnected: boolean;
@@ -244,8 +330,10 @@ function DirectedAuthorizeCard() {
   const connect = useSet(connectConnectorOAuthAuthCode$);
   const authorize = useSet(authorizeConnector$);
   const signal = useGet(pageSignal$);
-  const selectedConnectorType = useGet(selectedConnectorType$);
-  const setSelectedConnectorType = useSet(setSelectedConnectorType$);
+  const connectModalKey = useGet(directedAuthorizeConnectModalKey$);
+  const setDirectedAuthorizeConnectModalKey = useSet(
+    setDirectedAuthorizeConnectModalKey$,
+  );
   const connectorTypeForState = params?.connectorType ?? null;
   const agentName = useDirectedAuthorizeAgentName(params?.agentId ?? null);
   const { item, isConnected, catalogLoading, unavailable } =
@@ -255,6 +343,11 @@ function DirectedAuthorizeCard() {
       connectorTypeForState,
       params?.agentId ?? null,
     );
+  const connectModalOpen = directedAuthorizeConnectModalOpen(connectModalKey, {
+    connectorType: connectorTypeForState,
+    agentId: params?.agentId ?? null,
+    signal,
+  });
 
   if (!params) {
     return null;
@@ -293,60 +386,30 @@ function DirectedAuthorizeCard() {
       authorize,
       connect,
       openConnectModal: () => {
-        setSelectedConnectorType(connectorType);
+        setDirectedAuthorizeConnectModalKey({ connectorType, agentId, signal });
       },
     });
   };
 
   return (
     <>
-      <div className="fixed inset-0 z-10 flex items-center justify-center pointer-events-none">
-        <div className="pointer-events-auto flex w-[430px] max-w-[calc(100%-48px)] flex-col items-center gap-12 rounded-[20px] border border-border bg-background px-6 py-12 text-center">
-          <Vm0LogoLink />
-          <div className="flex w-full flex-col gap-4">
-            <div className="flex flex-col items-center gap-2.5">
-              {isLoading ? (
-                <IconLoader2
-                  size={20}
-                  className="animate-spin text-muted-foreground"
-                />
-              ) : (
-                <>
-                  <h1 className="text-lg font-medium text-foreground">
-                    {isAuthorized
-                      ? `${connectorLabel} authorized`
-                      : `${agentName} needs ${connectorLabel} to proceed`}
-                  </h1>
-                  <div className="flex items-center justify-center rounded-[10px] bg-muted p-2.5">
-                    <ConnectorIcon type={connectorType} size={20} />
-                  </div>
-                  <p className="w-60 text-sm text-muted-foreground">
-                    {connectorDescription}
-                  </p>
-                  {showGoogleSecurityWarningNotice && (
-                    <GoogleSecurityWarningNotice />
-                  )}
-                </>
-              )}
-            </div>
-            {!isLoading && (
-              <div className="flex items-center justify-center">
-                <AuthorizeAction
-                  isAuthorized={isAuthorized}
-                  isConnecting={isConnecting}
-                  disabled={!canAuthorize}
-                  agentName={agentName}
-                  onAuthorize={handleAuthorize}
-                />
-              </div>
-            )}
-          </div>
-        </div>
-      </div>
-      {selectedConnectorType === connectorType && (
+      <DirectedAuthorizeCardContent
+        connectorType={connectorType}
+        connectorLabel={connectorLabel}
+        connectorDescription={connectorDescription}
+        agentName={agentName}
+        isAuthorized={isAuthorized}
+        isConnecting={isConnecting}
+        isLoading={isLoading}
+        canAuthorize={canAuthorize}
+        showGoogleSecurityWarningNotice={showGoogleSecurityWarningNotice}
+        onAuthorize={handleAuthorize}
+      />
+      {connectModalOpen && (
         <ConnectModal
+          selectedType={connectorType}
           onClose={() => {
-            setSelectedConnectorType(null);
+            setDirectedAuthorizeConnectModalKey(null);
           }}
           onSuccess={async () => {
             await authorize(connectorType, agentId, signal);

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
@@ -140,7 +140,8 @@ function useDirectedAuthorizePermissionState(
         enabledTypes.includes(connectorType)),
     permissionLoading:
       agentId !== null &&
-      (enabledLoadable.state === "loading" || enabledData === null),
+      (enabledLoadable.state === "loading" ||
+        (enabledLoadable.state === "hasData" && enabledData === null)),
   };
 }
 

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
@@ -122,8 +122,13 @@ function useDirectedAuthorizePermissionState(
 ) {
   const justAuthorizedKeys = useGet(justAuthorizedConnectorAgentKeys$);
   const enabledLoadable = useLastLoadable(agentEnabledTypes$);
-  const enabledTypes =
-    enabledLoadable.state === "hasData" ? enabledLoadable.data : [];
+  const enabledData =
+    agentId !== null &&
+    enabledLoadable.state === "hasData" &&
+    enabledLoadable.data.agentId === agentId
+      ? enabledLoadable.data
+      : null;
+  const enabledTypes = enabledData === null ? [] : enabledData.enabledTypes;
   return {
     isAuthorized:
       connectorType !== null &&
@@ -133,8 +138,22 @@ function useDirectedAuthorizePermissionState(
         agentId,
       }) ||
         enabledTypes.includes(connectorType)),
-    permissionLoading: enabledLoadable.state === "loading",
+    permissionLoading:
+      agentId !== null &&
+      (enabledLoadable.state === "loading" || enabledData === null),
   };
+}
+
+function useDirectedAuthorizeAgentName(agentId: string | null): string {
+  const agentNameLoadable = useLastLoadable(directedAuthorizeAgentName$);
+  if (
+    agentNameLoadable.state !== "hasData" ||
+    agentNameLoadable.data.agentId !== agentId ||
+    !agentNameLoadable.data.displayName
+  ) {
+    return "Zero";
+  }
+  return agentNameLoadable.data.displayName;
 }
 
 function canAuthorizeConnector(
@@ -220,7 +239,6 @@ function runDirectedAuthorize(params: {
 
 function DirectedAuthorizeCard() {
   const params = useDirectedAuthorizeParams();
-  const agentNameLoadable = useLastLoadable(directedAuthorizeAgentName$);
   const pollingType = useGet(pollingOAuthAuthCodeConnectorType$);
   const connect = useSet(connectConnectorOAuthAuthCode$);
   const authorize = useSet(authorizeConnector$);
@@ -228,6 +246,7 @@ function DirectedAuthorizeCard() {
   const selectedConnectorType = useGet(selectedConnectorType$);
   const setSelectedConnectorType = useSet(setSelectedConnectorType$);
   const connectorTypeForState = params?.connectorType ?? null;
+  const agentName = useDirectedAuthorizeAgentName(params?.agentId ?? null);
   const { item, isConnected, catalogLoading, unavailable } =
     useDirectedAuthorizeCatalogState(connectorTypeForState);
   const { isAuthorized, permissionLoading } =
@@ -241,10 +260,6 @@ function DirectedAuthorizeCard() {
   }
 
   const { connectorType, agentId } = params;
-  const agentName =
-    agentNameLoadable.state === "hasData" && agentNameLoadable.data
-      ? agentNameLoadable.data
-      : "Zero";
   const isConnecting = pollingType === connectorType;
   if (unavailable) {
     return null;

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
@@ -1,6 +1,5 @@
 import { useGet, useSet, useLastLoadable } from "ccstate-react";
 import {
-  CONNECTOR_TYPES,
   connectorTypeSchema,
   type ConnectorAuthMethodId,
   type ConnectorType,
@@ -14,6 +13,7 @@ import {
   pollingOAuthAuthCodeConnectorType$,
   selectedConnectorType$,
   setSelectedConnectorType$,
+  type ConnectorTypeWithStatus,
 } from "../../signals/zero-page/settings/connectors.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import {
@@ -26,7 +26,6 @@ import {
 } from "../../signals/connectors-page/directed-authorize-type.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { IconCheck, IconLoader2 } from "@tabler/icons-react";
-import { shouldShowGoogleSecurityWarningNotice } from "../../lib/google-security-warning.ts";
 import {
   Vm0LogoLink,
   GoogleSecurityWarningNotice,
@@ -141,6 +140,78 @@ function canAuthorizeConnector(
   return isConnected || (item ? item.availableAuthMethods.length > 0 : false);
 }
 
+function shouldShowDirectedAuthorizeGoogleSecurityWarning(args: {
+  readonly isAuthorized: boolean;
+  readonly isConnected: boolean;
+  readonly item: ConnectorTypeWithStatus | undefined;
+}): boolean {
+  return (
+    !args.isAuthorized &&
+    !args.isConnected &&
+    args.item?.connectNotice === "google-security-warning"
+  );
+}
+
+function runDirectedAuthorize(params: {
+  readonly canAuthorize: boolean;
+  readonly isConnected: boolean;
+  readonly item: ConnectorTypeWithStatus | undefined;
+  readonly connectorType: ConnectorType;
+  readonly connectorLabel: string;
+  readonly agentId: string;
+  readonly authMethod: ConnectorAuthMethodId | null;
+  readonly signal: AbortSignal;
+  readonly authorize: (
+    connectorType: ConnectorType,
+    agentId: string,
+    signal: AbortSignal,
+  ) => Promise<void>;
+  readonly connect: (
+    connectorType: ConnectorType,
+    authMethod: ConnectorAuthMethodId,
+    options: { readonly connectorLabel?: string },
+    signal: AbortSignal,
+  ) => Promise<boolean>;
+  readonly openConnectModal: () => void;
+}): void {
+  if (!params.canAuthorize) {
+    return;
+  }
+  if (params.isConnected) {
+    detach(
+      params.authorize(params.connectorType, params.agentId, params.signal),
+      Reason.DomCallback,
+    );
+    return;
+  }
+  const authMethod = params.authMethod;
+  if (authMethod) {
+    detach(
+      (async () => {
+        const connected = await params.connect(
+          params.connectorType,
+          authMethod,
+          { connectorLabel: params.connectorLabel },
+          params.signal,
+        );
+        if (!connected) {
+          return;
+        }
+        await params.authorize(
+          params.connectorType,
+          params.agentId,
+          params.signal,
+        );
+      })(),
+      Reason.DomCallback,
+    );
+    return;
+  }
+  if (params.item && params.item.availableAuthMethods.length > 0) {
+    params.openConnectModal();
+  }
+}
+
 function DirectedAuthorizeCard() {
   const params = useDirectedAuthorizeParams();
   const agentNameLoadable = useLastLoadable(directedAuthorizeAgentName$);
@@ -161,7 +232,6 @@ function DirectedAuthorizeCard() {
   }
 
   const { connectorType, agentId } = params;
-  const config = CONNECTOR_TYPES[connectorType];
   const agentName =
     agentNameLoadable.state === "hasData" && agentNameLoadable.data
       ? agentNameLoadable.data
@@ -177,37 +247,30 @@ function DirectedAuthorizeCard() {
     ? getOnlyAvailableStatusAuthCodeAuthMethod(item)
     : null;
   const showGoogleSecurityWarningNotice =
-    !isAuthorized &&
-    !isConnected &&
-    shouldShowGoogleSecurityWarningNotice(connectorType);
+    shouldShowDirectedAuthorizeGoogleSecurityWarning({
+      isAuthorized,
+      isConnected,
+      item,
+    });
+  const connectorLabel = item?.label ?? connectorType;
+  const connectorDescription = item?.helpText ?? "";
 
   const handleAuthorize = () => {
-    if (!canAuthorize) {
-      return;
-    }
-    if (isConnected) {
-      detach(authorize(connectorType, agentId, signal), Reason.DomCallback);
-    } else if (selectedAuthMethod) {
-      detach(
-        (async () => {
-          const connected = await connect(
-            connectorType,
-            selectedAuthMethod,
-            {},
-            signal,
-          );
-          if (!connected) {
-            return;
-          }
-          await authorize(connectorType, agentId, signal);
-        })(),
-        Reason.DomCallback,
-      );
-    } else if (item && item.availableAuthMethods.length > 0) {
-      setSelectedConnectorType(connectorType);
-    } else {
-      return;
-    }
+    runDirectedAuthorize({
+      canAuthorize,
+      isConnected,
+      item,
+      connectorType,
+      connectorLabel,
+      agentId,
+      authMethod: selectedAuthMethod,
+      signal,
+      authorize,
+      connect,
+      openConnectModal: () => {
+        setSelectedConnectorType(connectorType);
+      },
+    });
   };
 
   return (
@@ -226,14 +289,14 @@ function DirectedAuthorizeCard() {
                 <>
                   <h1 className="text-lg font-medium text-foreground">
                     {isAuthorized
-                      ? `${config.label} authorized`
-                      : `${agentName} needs ${config.label} to proceed`}
+                      ? `${connectorLabel} authorized`
+                      : `${agentName} needs ${connectorLabel} to proceed`}
                   </h1>
                   <div className="flex items-center justify-center rounded-[10px] bg-muted p-2.5">
                     <ConnectorIcon type={connectorType} size={20} />
                   </div>
                   <p className="w-60 text-sm text-muted-foreground">
-                    {config.helpText}
+                    {connectorDescription}
                   </p>
                   {showGoogleSecurityWarningNotice && (
                     <GoogleSecurityWarningNotice />

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -443,8 +443,10 @@ function DirectedConnectCard() {
   }
 
   const agentName =
-    agentNameLoadable.state === "hasData" && agentNameLoadable.data
-      ? agentNameLoadable.data
+    agentNameLoadable.state === "hasData" &&
+    agentNameLoadable.data.agentId === agentId &&
+    agentNameLoadable.data.displayName
+      ? agentNameLoadable.data.displayName
       : "Zero";
   const isConnecting =
     pollingAuthCodeType === connectorType ||

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -30,6 +30,7 @@ import {
   setManualGrantFormSubmitting$,
   getOnlyManualConnectorStatusAuthMethod,
   hasConnectorStatusProviderDrivenConnectMethod,
+  manualGrantInputValuesForMethod,
   type ConnectorTypeWithStatus,
   type ConnectorStatusAuthMethodDetail,
 } from "../../signals/zero-page/settings/connectors.ts";
@@ -155,7 +156,10 @@ function ManualGrantForm({
             {
               type,
               authMethod: manualGrantMethod.id,
-              inputValues: fieldValues,
+              inputValues: manualGrantInputValuesForMethod(
+                manualGrantMethod,
+                fieldValues,
+              ),
               options: { connectorLabel },
             },
             pageSignal,

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -129,7 +129,7 @@ function ManualGrantForm({
   type: ConnectorType;
   connectorLabel: string;
   manualGrantMethod: ConnectorStatusAuthMethodDetail;
-  onSuccess: () => void;
+  onSuccess: () => void | Promise<void>;
 }) {
   const submit = useSet(submitManualGrant$);
   const setFormValue = useSet(setManualGrantFormValue$);
@@ -169,8 +169,8 @@ function ManualGrantForm({
             if (!connected) {
               return;
             }
+            await onSuccess();
             clearForm(type);
-            onSuccess();
           })(),
         ),
         () => {
@@ -230,7 +230,7 @@ function ManualGrantDialog({
   manualGrantMethod: ConnectorStatusAuthMethodDetail | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onConnected?: () => void;
+  onConnected?: () => void | Promise<void>;
 }) {
   if (!manualGrantMethod) {
     return null;
@@ -248,9 +248,9 @@ function ManualGrantDialog({
           type={type}
           connectorLabel={connectorLabel}
           manualGrantMethod={manualGrantMethod}
-          onSuccess={() => {
+          onSuccess={async () => {
+            await onConnected?.();
             onOpenChange(false);
-            onConnected?.();
           }}
         />
       </DialogContent>
@@ -345,13 +345,7 @@ function DirectedConnectDialogs({
         manualGrantMethod={manualGrantMethod}
         open={manualGrantDialogOpen}
         onOpenChange={setManualGrantDialogOpen}
-        onConnected={
-          agentId
-            ? () => {
-                detach(runPostConnectActions(), Reason.DomCallback);
-              }
-            : undefined
-        }
+        onConnected={agentId ? runPostConnectActions : undefined}
       />
       <DirectedConnectModal
         open={selectedConnectorType === connectorType}

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -40,6 +40,7 @@ import {
   detach,
   onDomEventFn,
   Reason,
+  withCleanup,
 } from "../../signals/utils.ts";
 import {
   directedConnectType$,
@@ -150,25 +151,32 @@ function ManualGrantForm({
         return;
       }
       setSubmitting(type);
-      await bestEffort(
-        (async () => {
-          await submit(
-            {
-              type,
-              authMethod: manualGrantMethod.id,
-              inputValues: manualGrantInputValuesForMethod(
-                manualGrantMethod,
-                fieldValues,
-              ),
-              options: { connectorLabel },
-            },
-            pageSignal,
-          );
-          clearForm(type);
-          onSuccess();
-        })(),
+      await withCleanup(
+        bestEffort(
+          (async () => {
+            const connected = await submit(
+              {
+                type,
+                authMethod: manualGrantMethod.id,
+                inputValues: manualGrantInputValuesForMethod(
+                  manualGrantMethod,
+                  fieldValues,
+                ),
+                options: { connectorLabel },
+              },
+              pageSignal,
+            );
+            if (!connected) {
+              return;
+            }
+            clearForm(type);
+            onSuccess();
+          })(),
+        ),
+        () => {
+          setSubmitting(null);
+        },
       );
-      setSubmitting(null);
     },
   );
 

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -20,8 +20,6 @@ import {
   justConnectedTypes$,
   pollingOAuthAuthCodeConnectorType$,
   pollingOAuthDeviceAuthConnectorType$,
-  selectedConnectorType$,
-  setSelectedConnectorType$,
   submitManualGrant$,
   manualGrantFormSubmitting$,
   setManualGrantFormValue$,
@@ -48,6 +46,9 @@ import {
   directedConnectAgentName$,
   manualGrantDialogKey$,
   setManualGrantDialogKey$,
+  directedConnectModalKey$,
+  setDirectedConnectModalKey$,
+  type DirectedConnectModalKey,
   type DirectedConnectManualGrantDialogKey,
 } from "../../signals/connectors-page/directed-connect-type.ts";
 import { authorizeConnector$ } from "../../signals/connectors-page/directed-authorize-type.ts";
@@ -304,17 +305,25 @@ function ConnectActions({
 
 function DirectedConnectModal({
   open,
+  connectorType,
   onClose,
   onSuccess,
 }: {
   readonly open: boolean;
+  readonly connectorType: ConnectorType;
   readonly onClose: () => void;
   readonly onSuccess: () => Promise<void>;
 }) {
   if (!open) {
     return null;
   }
-  return <ConnectModal onClose={onClose} onSuccess={onSuccess} />;
+  return (
+    <ConnectModal
+      selectedType={connectorType}
+      onClose={onClose}
+      onSuccess={onSuccess}
+    />
+  );
 }
 
 function DirectedConnectDialogs({
@@ -325,8 +334,8 @@ function DirectedConnectDialogs({
   setManualGrantDialogOpen,
   agentId,
   runPostConnectActions,
-  selectedConnectorType,
-  setSelectedConnectorType,
+  connectModalOpen,
+  setConnectModalOpen,
 }: {
   readonly connectorType: ConnectorType;
   readonly connectorLabel: string;
@@ -335,8 +344,8 @@ function DirectedConnectDialogs({
   readonly setManualGrantDialogOpen: (open: boolean) => void;
   readonly agentId: string | null | undefined;
   readonly runPostConnectActions: () => Promise<void>;
-  readonly selectedConnectorType: ConnectorType | null;
-  readonly setSelectedConnectorType: (type: ConnectorType | null) => void;
+  readonly connectModalOpen: boolean;
+  readonly setConnectModalOpen: (open: boolean) => void;
 }) {
   return (
     <>
@@ -349,9 +358,10 @@ function DirectedConnectDialogs({
         onConnected={agentId ? runPostConnectActions : undefined}
       />
       <DirectedConnectModal
-        open={selectedConnectorType === connectorType}
+        open={connectModalOpen}
+        connectorType={connectorType}
         onClose={() => {
-          setSelectedConnectorType(null);
+          setConnectModalOpen(false);
         }}
         onSuccess={runPostConnectActions}
       />
@@ -432,6 +442,91 @@ function directedConnectManualGrantDialogOpen(
   );
 }
 
+function directedConnectModalOpen(
+  key: DirectedConnectModalKey | null,
+  args: {
+    readonly connectorType: ConnectorType | null;
+    readonly agentId: string | null;
+    readonly signal: AbortSignal;
+  },
+): boolean {
+  return (
+    key?.connectorType === args.connectorType &&
+    key.agentId === args.agentId &&
+    key.signal === args.signal
+  );
+}
+
+function DirectedConnectCardContent({
+  connectorType,
+  connectorLabel,
+  connectorDescription,
+  connectNotice,
+  agentName,
+  isLoading,
+  isConnected,
+  isConnecting,
+  canConnect,
+  onConnect,
+}: {
+  readonly connectorType: ConnectorType;
+  readonly connectorLabel: string;
+  readonly connectorDescription: string;
+  readonly connectNotice: ConnectorTypeWithStatus["connectNotice"] | null;
+  readonly agentName: string;
+  readonly isLoading: boolean;
+  readonly isConnected: boolean;
+  readonly isConnecting: boolean;
+  readonly canConnect: boolean;
+  readonly onConnect: () => void;
+}) {
+  return (
+    <div className="fixed inset-0 z-10 flex items-center justify-center pointer-events-none">
+      <div className="pointer-events-auto flex w-[430px] max-w-[calc(100%-48px)] flex-col items-center gap-12 rounded-[20px] border border-border bg-background px-6 py-12 text-center">
+        <Vm0LogoLink />
+        <div className="flex w-full flex-col gap-4">
+          <div className="flex flex-col items-center gap-2.5">
+            {isLoading ? (
+              <IconLoader2
+                size={20}
+                className="animate-spin text-muted-foreground"
+              />
+            ) : (
+              <>
+                <h1 className="text-lg font-medium text-foreground">
+                  {isConnected
+                    ? `${connectorLabel} connected`
+                    : `${agentName} needs ${connectorLabel} to proceed`}
+                </h1>
+                <div className="flex items-center justify-center rounded-[10px] bg-muted p-2.5">
+                  <ConnectorIcon type={connectorType} size={20} />
+                </div>
+                <p className="w-60 text-sm text-muted-foreground">
+                  {connectorDescription}
+                </p>
+                <ConnectorConnectNotices
+                  connectNotice={connectNotice}
+                  isConnected={isConnected}
+                />
+              </>
+            )}
+          </div>
+          {!isLoading && (
+            <div className="flex flex-col items-center justify-center gap-2">
+              <ConnectActions
+                isConnected={isConnected}
+                isConnecting={isConnecting}
+                disabled={!canConnect}
+                onConnect={onConnect}
+              />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function DirectedConnectCard() {
   const connectorType = useDirectedConnectConnectorType();
   const agentId = useGet(directedConnectAgentId$);
@@ -445,12 +540,17 @@ function DirectedConnectCard() {
     useDirectedConnectCatalogState(connectorType);
   const manualGrantDialogKey = useGet(manualGrantDialogKey$);
   const setManualGrantDialogKey = useSet(setManualGrantDialogKey$);
-  const selectedConnectorType = useGet(selectedConnectorType$);
-  const setSelectedConnectorType = useSet(setSelectedConnectorType$);
+  const connectModalKey = useGet(directedConnectModalKey$);
+  const setDirectedConnectModalKey = useSet(setDirectedConnectModalKey$);
   const manualGrantDialogOpen = directedConnectManualGrantDialogOpen(
     manualGrantDialogKey,
     { connectorType, agentId, signal },
   );
+  const connectModalOpen = directedConnectModalOpen(connectModalKey, {
+    connectorType,
+    agentId,
+    signal,
+  });
 
   if (!connectorType) {
     return null;
@@ -496,56 +596,25 @@ function DirectedConnectCard() {
         return setManualGrantDialogKey({ connectorType, agentId, signal });
       },
       openConnectModal: () => {
-        setSelectedConnectorType(connectorType);
+        setDirectedConnectModalKey({ connectorType, agentId, signal });
       },
     });
   };
 
   return (
     <>
-      <div className="fixed inset-0 z-10 flex items-center justify-center pointer-events-none">
-        <div className="pointer-events-auto flex w-[430px] max-w-[calc(100%-48px)] flex-col items-center gap-12 rounded-[20px] border border-border bg-background px-6 py-12 text-center">
-          <Vm0LogoLink />
-          <div className="flex w-full flex-col gap-4">
-            <div className="flex flex-col items-center gap-2.5">
-              {isLoading ? (
-                <IconLoader2
-                  size={20}
-                  className="animate-spin text-muted-foreground"
-                />
-              ) : (
-                <>
-                  <h1 className="text-lg font-medium text-foreground">
-                    {isConnected
-                      ? `${connectorLabel} connected`
-                      : `${agentName} needs ${connectorLabel} to proceed`}
-                  </h1>
-                  <div className="flex items-center justify-center rounded-[10px] bg-muted p-2.5">
-                    <ConnectorIcon type={connectorType} size={20} />
-                  </div>
-                  <p className="w-60 text-sm text-muted-foreground">
-                    {connectorDescription}
-                  </p>
-                  <ConnectorConnectNotices
-                    connectNotice={item?.connectNotice ?? null}
-                    isConnected={isConnected}
-                  />
-                </>
-              )}
-            </div>
-            {!isLoading && (
-              <div className="flex flex-col items-center justify-center gap-2">
-                <ConnectActions
-                  isConnected={isConnected}
-                  isConnecting={isConnecting}
-                  disabled={!canConnect}
-                  onConnect={handleConnect}
-                />
-              </div>
-            )}
-          </div>
-        </div>
-      </div>
+      <DirectedConnectCardContent
+        connectorType={connectorType}
+        connectorLabel={connectorLabel}
+        connectorDescription={connectorDescription}
+        connectNotice={item?.connectNotice ?? null}
+        agentName={agentName}
+        isLoading={isLoading}
+        isConnected={isConnected}
+        isConnecting={isConnecting}
+        canConnect={canConnect}
+        onConnect={handleConnect}
+      />
       <DirectedConnectDialogs
         connectorType={connectorType}
         connectorLabel={connectorLabel}
@@ -558,8 +627,12 @@ function DirectedConnectCard() {
         }}
         agentId={agentId}
         runPostConnectActions={runPostConnectActions}
-        selectedConnectorType={selectedConnectorType}
-        setSelectedConnectorType={setSelectedConnectorType}
+        connectModalOpen={connectModalOpen}
+        setConnectModalOpen={(open) => {
+          setDirectedConnectModalKey(
+            open ? { connectorType, agentId, signal } : null,
+          );
+        }}
       />
     </>
   );

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -1,13 +1,9 @@
 import { useGet, useSet, useLastLoadable } from "ccstate-react";
 import {
-  CONNECTOR_TYPES,
   connectorTypeSchema,
-  type ConnectorAuthMethodConfig,
   type ConnectorAuthMethodId,
-  type ConnectorManualGrantConfig,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
-import { getConnectorAuthMethod } from "@vm0/connectors/connector-utils";
 import { Input } from "@vm0/ui/components/ui/input";
 import {
   Dialog,
@@ -32,7 +28,10 @@ import {
   clearManualGrantForm$,
   manualGrantFormValuesFor$,
   setManualGrantFormSubmitting$,
+  getOnlyManualConnectorStatusAuthMethod,
+  hasConnectorStatusProviderDrivenConnectMethod,
   type ConnectorTypeWithStatus,
+  type ConnectorStatusAuthMethodDetail,
 } from "../../signals/zero-page/settings/connectors.ts";
 import { hasTokenInputValue } from "../../signals/zero-page/settings/token-input.ts";
 import {
@@ -51,70 +50,13 @@ import {
 import { authorizeConnector$ } from "../../signals/connectors-page/directed-authorize-type.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { IconCheck, IconLoader2 } from "@tabler/icons-react";
-import { shouldShowGoogleSecurityWarningNotice } from "../../lib/google-security-warning.ts";
 import {
   Vm0LogoLink,
   GoogleSecurityWarningNotice,
 } from "./zero-directed-shared.tsx";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
 import type { FormEvent } from "react";
-
-type ManualGrantMethod = {
-  readonly authMethod: ConnectorAuthMethodId;
-  readonly method: ConnectorAuthMethodConfig;
-  readonly grant: ConnectorManualGrantConfig;
-};
-
-function getOnlyManualGrantMethod(
-  connectorType: ConnectorType,
-  authMethods: readonly ConnectorAuthMethodId[],
-): ManualGrantMethod | null {
-  let manualGrantMethod: ManualGrantMethod | null = null;
-  for (const authMethod of authMethods) {
-    const method = getConnectorAuthMethod(connectorType, authMethod);
-    switch (method?.grant.kind) {
-      case "manual": {
-        if (manualGrantMethod) {
-          return null;
-        }
-        manualGrantMethod = {
-          authMethod,
-          method,
-          grant: method.grant,
-        };
-        continue;
-      }
-      case "auth-code":
-      case "device-auth":
-      case "managed":
-      case undefined: {
-        continue;
-      }
-    }
-  }
-  return manualGrantMethod;
-}
-
-function hasProviderDrivenConnectMethod(
-  connectorType: ConnectorType,
-  authMethods: readonly ConnectorAuthMethodId[],
-): boolean {
-  return authMethods.some((authMethod) => {
-    const method = getConnectorAuthMethod(connectorType, authMethod);
-    switch (method?.grant.kind) {
-      case "auth-code":
-      case "device-auth":
-      case "managed": {
-        return true;
-      }
-      case "manual":
-      case undefined: {
-        return false;
-      }
-    }
-    return false;
-  });
-}
+import { ConnectorHelpText } from "./components/settings/connector-help-text.tsx";
 
 function runDirectedConnect(params: {
   item: ConnectorTypeWithStatus;
@@ -123,7 +65,10 @@ function runDirectedConnect(params: {
   connect: (
     type: ConnectorType,
     authMethod: ConnectorAuthMethodId,
-    options: { readonly showPermissionDialog?: boolean },
+    options: {
+      readonly showPermissionDialog?: boolean;
+      readonly connectorLabel?: string;
+    },
     signal: AbortSignal,
   ) => Promise<boolean>;
   onConnected: () => Promise<void>;
@@ -133,19 +78,13 @@ function runDirectedConnect(params: {
   const launchMode = getConnectorStatusConnectLaunchMode(params.item);
   if (
     launchMode === "modal" &&
-    hasProviderDrivenConnectMethod(
-      params.connectorType,
-      params.item.availableAuthMethods,
-    )
+    hasConnectorStatusProviderDrivenConnectMethod(params.item)
   ) {
     params.openConnectModal();
     return;
   }
 
-  const manualGrantMethod = getOnlyManualGrantMethod(
-    params.connectorType,
-    params.item.availableAuthMethods,
-  );
+  const manualGrantMethod = getOnlyManualConnectorStatusAuthMethod(params.item);
 
   if (launchMode === "modal" && manualGrantMethod) {
     params.openManualGrantDialog();
@@ -168,7 +107,7 @@ function runDirectedConnect(params: {
       connected = await params.connect(
         params.connectorType,
         authMethod,
-        {},
+        { connectorLabel: params.item.label },
         params.signal,
       );
       if (connected) {
@@ -179,30 +118,15 @@ function runDirectedConnect(params: {
   );
 }
 
-// Only intended for trusted, source-controlled help text from
-// `CONNECTOR_TYPES[*].authMethods.*.helpText`. Do NOT feed user-supplied
-// strings into this renderer — the `[text]` and `**bold**` captures are
-// verbatim-injected and would permit HTML smuggling.
-function renderMarkdown(text: string): string {
-  return text
-    .replace(
-      // Only http(s) URLs are turned into anchors; other schemes fall through
-      // as literal text. `"` is also excluded from the href charclass so a
-      // stray quote cannot break out of the href attribute and inject
-      // siblings like `onclick` when feeding `dangerouslySetInnerHTML`.
-      /\[([^\]]+)\]\((https?:\/\/[^)"]+)\)/g,
-      '<a href="$2" target="_blank" rel="noopener noreferrer" class="text-primary underline">$1</a>',
-    )
-    .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
-}
-
 function ManualGrantForm({
   type,
+  connectorLabel,
   manualGrantMethod,
   onSuccess,
 }: {
   type: ConnectorType;
-  manualGrantMethod: ManualGrantMethod;
+  connectorLabel: string;
+  manualGrantMethod: ConnectorStatusAuthMethodDetail;
   onSuccess: () => void;
 }) {
   const submit = useSet(submitManualGrant$);
@@ -214,9 +138,8 @@ function ManualGrantForm({
   const setSubmitting = useSet(setManualGrantFormSubmitting$);
   const submitting = submittingType === type;
 
-  const fieldEntries = Object.entries(manualGrantMethod.grant.fields);
-  const allFilled = fieldEntries.every(([name, cfg]) => {
-    return !cfg.required || hasTokenInputValue(fieldValues[name]);
+  const allFilled = manualGrantMethod.manualFields.every((field) => {
+    return !field.required || hasTokenInputValue(fieldValues[field.id]);
   });
 
   const handleSubmit = onDomEventFn(
@@ -231,9 +154,9 @@ function ManualGrantForm({
           await submit(
             {
               type,
-              authMethod: manualGrantMethod.authMethod,
+              authMethod: manualGrantMethod.id,
               inputValues: fieldValues,
-              options: {},
+              options: { connectorLabel },
             },
             pageSignal,
           );
@@ -250,26 +173,21 @@ function ManualGrantForm({
       className="flex w-full flex-col gap-3 text-left"
       onSubmit={handleSubmit}
     >
-      {manualGrantMethod.method.helpText && (
-        <div
-          className="text-sm text-muted-foreground leading-relaxed whitespace-pre-line [&_a]:text-primary [&_a]:underline"
-          dangerouslySetInnerHTML={{
-            __html: renderMarkdown(manualGrantMethod.method.helpText),
-          }}
-        />
+      {manualGrantMethod.description && (
+        <ConnectorHelpText text={manualGrantMethod.description} />
       )}
-      {fieldEntries.map(([name, fieldConfig]) => {
+      {manualGrantMethod.manualFields.map((fieldConfig) => {
         return (
-          <div key={name} className="flex flex-col gap-1.5">
+          <div key={fieldConfig.id} className="flex flex-col gap-1.5">
             <label className="text-sm font-medium text-foreground">
               {fieldConfig.label}
             </label>
             <Input
-              type="password"
-              placeholder={fieldConfig.placeholder}
-              value={fieldValues[name] ?? ""}
+              type={fieldConfig.inputType}
+              placeholder={fieldConfig.placeholder ?? undefined}
+              value={fieldValues[fieldConfig.id] ?? ""}
               onChange={(e) => {
-                return setFormValue(type, name, e.target.value);
+                return setFormValue(type, fieldConfig.id, e.target.value);
               }}
             />
           </div>
@@ -289,18 +207,19 @@ function ManualGrantForm({
 
 function ManualGrantDialog({
   type,
+  connectorLabel,
   manualGrantMethod,
   open,
   onOpenChange,
   onConnected,
 }: {
   type: ConnectorType;
-  manualGrantMethod: ManualGrantMethod | null;
+  connectorLabel: string;
+  manualGrantMethod: ConnectorStatusAuthMethodDetail | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onConnected?: () => void;
 }) {
-  const config = CONNECTOR_TYPES[type];
   if (!manualGrantMethod) {
     return null;
   }
@@ -310,11 +229,12 @@ function ManualGrantDialog({
         <DialogHeader>
           <div className="flex items-center gap-3">
             <ConnectorIcon type={type} size={20} />
-            <DialogTitle>{config.label}</DialogTitle>
+            <DialogTitle>{connectorLabel}</DialogTitle>
           </div>
         </DialogHeader>
         <ManualGrantForm
           type={type}
+          connectorLabel={connectorLabel}
           manualGrantMethod={manualGrantMethod}
           onSuccess={() => {
             onOpenChange(false);
@@ -386,6 +306,7 @@ function DirectedConnectModal({
 
 function DirectedConnectDialogs({
   connectorType,
+  connectorLabel,
   manualGrantMethod,
   manualGrantDialogOpen,
   setManualGrantDialogOpen,
@@ -395,7 +316,8 @@ function DirectedConnectDialogs({
   setSelectedConnectorType,
 }: {
   readonly connectorType: ConnectorType;
-  readonly manualGrantMethod: ManualGrantMethod | null;
+  readonly connectorLabel: string;
+  readonly manualGrantMethod: ConnectorStatusAuthMethodDetail | null;
   readonly manualGrantDialogOpen: boolean;
   readonly setManualGrantDialogOpen: (open: boolean) => void;
   readonly agentId: string | null | undefined;
@@ -407,6 +329,7 @@ function DirectedConnectDialogs({
     <>
       <ManualGrantDialog
         type={connectorType}
+        connectorLabel={connectorLabel}
         manualGrantMethod={manualGrantMethod}
         open={manualGrantDialogOpen}
         onOpenChange={setManualGrantDialogOpen}
@@ -439,19 +362,52 @@ function useDirectedConnectConnectorType(): ConnectorType | null {
 }
 
 function ConnectorConnectNotices({
-  connectorType,
+  connectNotice,
   isConnected,
 }: {
-  readonly connectorType: ConnectorType;
+  readonly connectNotice: ConnectorTypeWithStatus["connectNotice"] | null;
   readonly isConnected: boolean;
 }) {
   if (isConnected) {
     return null;
   }
-  if (shouldShowGoogleSecurityWarningNotice(connectorType)) {
+  if (connectNotice === "google-security-warning") {
     return <GoogleSecurityWarningNotice />;
   }
   return null;
+}
+
+function useDirectedConnectCatalogState(connectorType: ConnectorType | null): {
+  readonly item: ConnectorTypeWithStatus | undefined;
+  readonly isConnected: boolean;
+  readonly isLoading: boolean;
+  readonly unavailable: boolean;
+} {
+  const justConnected = useGet(justConnectedTypes$);
+  const allLoadable = useLastLoadable(allConnectorTypes$);
+  const catalogLoaded = allLoadable.state === "hasData";
+  const allData = catalogLoaded ? allLoadable.data : [];
+  const item = connectorType
+    ? allData.find((connector) => {
+        return connector.type === connectorType;
+      })
+    : undefined;
+  const optimisticallyConnected =
+    connectorType !== null && justConnected.has(connectorType);
+  const isConnected = optimisticallyConnected || (item?.connected ?? false);
+  return {
+    item,
+    isConnected,
+    isLoading:
+      connectorType !== null &&
+      !optimisticallyConnected &&
+      allLoadable.state === "loading",
+    unavailable:
+      connectorType !== null &&
+      catalogLoaded &&
+      !item &&
+      !optimisticallyConnected,
+  };
 }
 
 function DirectedConnectCard() {
@@ -463,8 +419,8 @@ function DirectedConnectCard() {
   const connect = useSet(connectConnectorOAuthAuthCode$);
   const authorize = useSet(authorizeConnector$);
   const signal = useGet(pageSignal$);
-  const justConnected = useGet(justConnectedTypes$);
-  const allLoadable = useLastLoadable(allConnectorTypes$);
+  const { item, isConnected, isLoading, unavailable } =
+    useDirectedConnectCatalogState(connectorType);
   const manualGrantDialogOpen = useGet(manualGrantDialogOpen$);
   const setManualGrantDialogOpen = useSet(setManualGrantDialogOpen$);
   const selectedConnectorType = useGet(selectedConnectorType$);
@@ -474,7 +430,6 @@ function DirectedConnectCard() {
     return null;
   }
 
-  const config = CONNECTOR_TYPES[connectorType];
   const agentName =
     agentNameLoadable.state === "hasData" && agentNameLoadable.data
       ? agentNameLoadable.data
@@ -482,26 +437,16 @@ function DirectedConnectCard() {
   const isConnecting =
     pollingAuthCodeType === connectorType ||
     pollingDeviceAuthType === connectorType;
-  const isLoading =
-    !justConnected.has(connectorType) && allLoadable.state === "loading";
-  const catalogLoaded = allLoadable.state === "hasData";
-  const allData = catalogLoaded ? allLoadable.data : [];
-  const item = allData.find((c) => {
-    return c.type === connectorType;
-  });
-  const unavailable =
-    catalogLoaded && !item && !justConnected.has(connectorType);
   if (unavailable) {
     return null;
   }
-  const isConnected =
-    justConnected.has(connectorType) || (item?.connected ?? false);
   const authMethods = item?.availableAuthMethods ?? [];
-  const manualGrantMethod = getOnlyManualGrantMethod(
-    connectorType,
-    authMethods,
-  );
+  const manualGrantMethod = item
+    ? getOnlyManualConnectorStatusAuthMethod(item)
+    : null;
   const canConnect = authMethods.length > 0;
+  const connectorLabel = item?.label ?? connectorType;
+  const connectorDescription = item?.helpText ?? "";
 
   const runPostConnectActions = async () => {
     if (agentId) {
@@ -544,17 +489,17 @@ function DirectedConnectCard() {
                 <>
                   <h1 className="text-lg font-medium text-foreground">
                     {isConnected
-                      ? `${config.label} connected`
-                      : `${agentName} needs ${config.label} to proceed`}
+                      ? `${connectorLabel} connected`
+                      : `${agentName} needs ${connectorLabel} to proceed`}
                   </h1>
                   <div className="flex items-center justify-center rounded-[10px] bg-muted p-2.5">
                     <ConnectorIcon type={connectorType} size={20} />
                   </div>
                   <p className="w-60 text-sm text-muted-foreground">
-                    {config.helpText}
+                    {connectorDescription}
                   </p>
                   <ConnectorConnectNotices
-                    connectorType={connectorType}
+                    connectNotice={item?.connectNotice ?? null}
                     isConnected={isConnected}
                   />
                 </>
@@ -575,6 +520,7 @@ function DirectedConnectCard() {
       </div>
       <DirectedConnectDialogs
         connectorType={connectorType}
+        connectorLabel={connectorLabel}
         manualGrantMethod={manualGrantMethod}
         manualGrantDialogOpen={manualGrantDialogOpen}
         setManualGrantDialogOpen={setManualGrantDialogOpen}

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -46,8 +46,9 @@ import {
   directedConnectType$,
   directedConnectAgentId$,
   directedConnectAgentName$,
-  manualGrantDialogOpen$,
-  setManualGrantDialogOpen$,
+  manualGrantDialogKey$,
+  setManualGrantDialogKey$,
+  type DirectedConnectManualGrantDialogKey,
 } from "../../signals/connectors-page/directed-connect-type.ts";
 import { authorizeConnector$ } from "../../signals/connectors-page/directed-authorize-type.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
@@ -416,6 +417,21 @@ function useDirectedConnectCatalogState(connectorType: ConnectorType | null): {
   };
 }
 
+function directedConnectManualGrantDialogOpen(
+  key: DirectedConnectManualGrantDialogKey | null,
+  args: {
+    readonly connectorType: ConnectorType | null;
+    readonly agentId: string | null;
+    readonly signal: AbortSignal;
+  },
+): boolean {
+  return (
+    key?.connectorType === args.connectorType &&
+    key.agentId === args.agentId &&
+    key.signal === args.signal
+  );
+}
+
 function DirectedConnectCard() {
   const connectorType = useDirectedConnectConnectorType();
   const agentId = useGet(directedConnectAgentId$);
@@ -427,10 +443,14 @@ function DirectedConnectCard() {
   const signal = useGet(pageSignal$);
   const { item, isConnected, isLoading, unavailable } =
     useDirectedConnectCatalogState(connectorType);
-  const manualGrantDialogOpen = useGet(manualGrantDialogOpen$);
-  const setManualGrantDialogOpen = useSet(setManualGrantDialogOpen$);
+  const manualGrantDialogKey = useGet(manualGrantDialogKey$);
+  const setManualGrantDialogKey = useSet(setManualGrantDialogKey$);
   const selectedConnectorType = useGet(selectedConnectorType$);
   const setSelectedConnectorType = useSet(setSelectedConnectorType$);
+  const manualGrantDialogOpen = directedConnectManualGrantDialogOpen(
+    manualGrantDialogKey,
+    { connectorType, agentId, signal },
+  );
 
   if (!connectorType) {
     return null;
@@ -473,7 +493,7 @@ function DirectedConnectCard() {
       connect,
       onConnected: runPostConnectActions,
       openManualGrantDialog: () => {
-        return setManualGrantDialogOpen(true);
+        return setManualGrantDialogKey({ connectorType, agentId, signal });
       },
       openConnectModal: () => {
         setSelectedConnectorType(connectorType);
@@ -531,7 +551,11 @@ function DirectedConnectCard() {
         connectorLabel={connectorLabel}
         manualGrantMethod={manualGrantMethod}
         manualGrantDialogOpen={manualGrantDialogOpen}
-        setManualGrantDialogOpen={setManualGrantDialogOpen}
+        setManualGrantDialogOpen={(open) => {
+          setManualGrantDialogKey(
+            open ? { connectorType, agentId, signal } : null,
+          );
+        }}
         agentId={agentId}
         runPostConnectActions={runPostConnectActions}
         selectedConnectorType={selectedConnectorType}

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -1294,7 +1294,9 @@ export {
 export {
   zeroAgentCustomConnectorsContract,
   agentCustomConnectorEnabledIdsSchema,
+  agentCustomConnectorUpdateSchema,
   type AgentCustomConnectorEnabledIds,
+  type AgentCustomConnectorUpdate,
   type ZeroAgentCustomConnectorsContract,
 } from "./zero-agent-custom-connectors";
 export {

--- a/turbo/packages/api-contracts/src/contracts/user-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/user-connectors.ts
@@ -53,7 +53,7 @@ export const zeroUserConnectorsContract = c.router({
       403: apiErrorSchema,
       404: apiErrorSchema,
     },
-    summary: "Replace enabled connector types for user on agent",
+    summary: "Update enabled connector types for user on agent",
   },
 });
 export type ZeroUserConnectorsContract = typeof zeroUserConnectorsContract;

--- a/turbo/packages/api-contracts/src/contracts/user-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/user-connectors.ts
@@ -16,6 +16,13 @@ export type UserConnectorEnabledTypes = z.infer<
   typeof userConnectorEnabledTypesSchema
 >;
 
+export const userConnectorUpdateSchema = userConnectorEnabledTypesSchema.extend(
+  {
+    operation: z.enum(["replace", "add", "remove"]).optional(),
+  },
+);
+export type UserConnectorUpdate = z.infer<typeof userConnectorUpdateSchema>;
+
 /**
  * Contract for GET/PUT /api/zero/agents/:id/user-connectors
  */
@@ -38,7 +45,7 @@ export const zeroUserConnectorsContract = c.router({
     path: "/api/zero/agents/:id/user-connectors",
     headers: authHeadersSchema,
     pathParams: z.object({ id: z.string().uuid() }),
-    body: userConnectorEnabledTypesSchema,
+    body: userConnectorUpdateSchema,
     responses: {
       200: userConnectorEnabledTypesSchema,
       400: apiErrorSchema,

--- a/turbo/packages/api-contracts/src/contracts/zero-agent-custom-connectors.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-agent-custom-connectors.ts
@@ -16,6 +16,14 @@ export type AgentCustomConnectorEnabledIds = z.infer<
   typeof agentCustomConnectorEnabledIdsSchema
 >;
 
+export const agentCustomConnectorUpdateSchema =
+  agentCustomConnectorEnabledIdsSchema.extend({
+    operation: z.enum(["replace", "add", "remove"]).optional(),
+  });
+export type AgentCustomConnectorUpdate = z.infer<
+  typeof agentCustomConnectorUpdateSchema
+>;
+
 /**
  * Contract for GET/PUT /api/zero/agents/:id/custom-connectors
  *
@@ -43,7 +51,7 @@ export const zeroAgentCustomConnectorsContract = c.router({
     path: "/api/zero/agents/:id/custom-connectors",
     headers: authHeadersSchema,
     pathParams: z.object({ id: z.string().uuid() }),
-    body: agentCustomConnectorEnabledIdsSchema,
+    body: agentCustomConnectorUpdateSchema,
     responses: {
       200: agentCustomConnectorEnabledIdsSchema,
       400: apiErrorSchema,
@@ -51,7 +59,7 @@ export const zeroAgentCustomConnectorsContract = c.router({
       403: apiErrorSchema,
       404: apiErrorSchema,
     },
-    summary: "Replace enabled custom connector ids for user on agent",
+    summary: "Update enabled custom connector ids for user on agent",
   },
 });
 export type ZeroAgentCustomConnectorsContract =


### PR DESCRIPTION
## Summary

- migrate connector settings, add-connection dialog, directed connect/authorize, and permission label surfaces to server-authored public connector catalog/status metadata
- render and submit manual grant fields and device-auth start options with public ids from the status model
- remove browser-side raw connector grant helper assertions and the old directed-connect HTML markdown renderer
- tighten connect flows so OAuth success/reconnect toasts use public connector labels and manual grant submits only the current public method fields
- update platform connector mocks and page tests so public metadata drives labels, method details, manual fields, and device-auth options

## Verification

- pnpm format
- pnpm exec prettier --write --ignore-unknown apps/platform/src/signals/zero-page/settings/connectors.ts apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx apps/platform/src/views/zero-page/zero-connectors-page.tsx apps/platform/src/views/zero-page/zero-directed-connect-page.tsx apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-connectors-page.test.tsx
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
- pnpm knip --cache
- pre-commit full turbo check-types

## Follow-up boundaries

- static connector icons still use local connector keys and bundled assets
- connector action API contracts and chat action parsing still accept local ConnectorType values
- display-only/unrelated surfaces still read local connector config and should be migrated separately if they need public labels: historical chat connector blocks, network insights, and permission-allow labels
- platform test mocks still derive public catalog/status responses from static connector config
- firewall permission metadata remains separate from connector catalog/status metadata

Closes #19391