### PR TITLE
feat: export user-owned data files

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-misc.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-misc.ts
@@ -174,6 +174,10 @@ export function createMiscRoutesApi(context: TestContext) {
   });
 
   return {
+    putS3Object(key: string, body: Buffer | string | Uint8Array): void {
+      s3Objects.set(key, bodyBuffer(body));
+    },
+
     setOrgLogoRead(org: ClerkOrg): void {
       context.mocks.clerk.organizations.getOrganization.mockResolvedValue(org);
     },
@@ -332,7 +336,10 @@ export function createMiscRoutesApi(context: TestContext) {
       actor: ApiTestUser,
       agentId: string,
       name: string,
-      content: string,
+      input: {
+        readonly content: string;
+        readonly files?: readonly WorkflowFileEntry[];
+      },
       statuses: readonly (201 | 400 | 401 | 403 | 409)[],
     ) {
       return await accept(
@@ -343,7 +350,8 @@ export function createMiscRoutesApi(context: TestContext) {
             name,
             displayName: "BDD Workflow",
             description: "Created through public workflow API",
-            instruction: content,
+            instruction: input.content,
+            ...(input.files === undefined ? {} : { files: [...input.files] }),
           },
         }),
         statuses,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-ops-logs.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-ops-logs.ts
@@ -88,6 +88,19 @@ export async function cleanupUserExportState(
   });
 }
 
+export async function seedUserExportChatMessages(args: {
+  readonly userId: string;
+  readonly agentId: string;
+  readonly threadId: string;
+}): Promise<void> {
+  await postUserExportState({
+    action: "seed-chat-messages",
+    user_id: args.userId,
+    agent_id: args.agentId,
+    thread_id: args.threadId,
+  });
+}
+
 export function createOpsLogsApi(context: TestContext) {
   return {
     async requestSearchLogs<TStatus extends 200 | 400 | 401>(

--- a/turbo/apps/api/src/signals/routes/__tests__/misc-routes.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/misc-routes.bdd.test.ts
@@ -244,7 +244,7 @@ describe("MISC-03: workflows lifecycle through public API", () => {
       member,
       memberAgent.agentId,
       memberWorkflowName,
-      "# Member private workflow",
+      { content: "# Member private workflow" },
       [201],
     );
     expect(memberCreated.body).toMatchObject({
@@ -271,7 +271,7 @@ describe("MISC-03: workflows lifecycle through public API", () => {
       admin,
       agent.agentId,
       workflowName,
-      "# BDD Workflow\n\nCreated through API.",
+      { content: "# BDD Workflow\n\nCreated through API." },
       [201],
     );
     if (created.status !== 201) {

--- a/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
@@ -1,12 +1,17 @@
 import { createHmac, randomUUID } from "node:crypto";
+import { gzipSync } from "node:zlib";
 
+import AdmZip from "adm-zip";
+import { createStore } from "ccstate";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { MAX_EVENT_SEQUENCE_NUMBER } from "@vm0/api-contracts/contracts/runs";
+import { zeroAgentInstructionsContract } from "@vm0/api-contracts/contracts/zero-agents";
 
 import { env } from "../../../lib/env";
 import { clearMockNow, mockNow } from "../../../lib/time";
 import { testContext } from "../../../__tests__/test-context";
+import { accept, setupApp } from "../../../__tests__/test-helpers";
 import {
   createBddApi,
   expectApiError,
@@ -16,9 +21,11 @@ import { createMiscRoutesApi } from "./helpers/api-bdd-misc";
 import {
   cleanupUserExportState,
   createOpsLogsApi,
+  seedUserExportChatMessages,
 } from "./helpers/api-bdd-ops-logs";
 import { createRunsAutomationsApi } from "./helpers/api-bdd-runs-automations";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
+import { seedMemoryStorage$ } from "./helpers/zero-memory";
 import { createFixtureTracker } from "./helpers/zero-route-test";
 
 /*
@@ -56,6 +63,7 @@ async function createUserExportActor(
 }
 
 const context = testContext();
+const store = createStore();
 const trackDeferredS3Put = createFixtureTracker<DeferredS3Put>((pendingPut) => {
   pendingPut.resolve();
   return Promise.resolve();
@@ -131,6 +139,120 @@ function commandInput(command: unknown): Record<string, unknown> {
     return command.input as Record<string, unknown>;
   }
   return {};
+}
+
+function exportZip(exportKey: string): AdmZip {
+  const putInput = context.mocks.s3.send.mock.calls
+    .map(([command]) => {
+      return commandInput(command);
+    })
+    .find((input) => {
+      return input.Key === exportKey;
+    });
+
+  const body = putInput?.Body;
+  if (!Buffer.isBuffer(body)) {
+    throw new Error(`Expected export ZIP upload for ${exportKey}`);
+  }
+  return new AdmZip(body);
+}
+
+function zipEntryNames(zip: AdmZip): string[] {
+  return zip.getEntries().map((entry) => {
+    return entry.entryName;
+  });
+}
+
+function zipText(zip: AdmZip, name: string): string {
+  const entry = zip.getEntry(name);
+  if (!entry) {
+    throw new Error(`Expected ZIP entry ${name}`);
+  }
+  return entry.getData().toString("utf8");
+}
+
+function singleZipEntry(
+  names: readonly string[],
+  predicate: (name: string) => boolean,
+): string {
+  const matches = names.filter(predicate);
+  expect(matches).toHaveLength(1);
+  const [match] = matches;
+  if (!match) {
+    throw new Error("Expected one ZIP entry match");
+  }
+  return match;
+}
+
+const TAR_BLOCK_SIZE = 512;
+
+function octal(value: number, length: number): string {
+  return value.toString(8).padStart(length - 1, "0") + "\0";
+}
+
+function createTarEntry(filename: string, content: Buffer): Buffer {
+  const header = Buffer.alloc(TAR_BLOCK_SIZE);
+  header.write(filename, 0, 100, "utf8");
+  header.write("0000644\0", 100);
+  header.write("0000000\0", 108);
+  header.write("0000000\0", 116);
+  header.write(octal(content.length, 12), 124);
+  header.write(octal(0, 12), 136);
+  header.write("        ", 148);
+  header.write("0", 156);
+
+  let checksum = 0;
+  for (const byte of header) {
+    checksum += byte;
+  }
+  header.write(checksum.toString(8).padStart(6, "0") + "\0 ", 148);
+
+  const padding = content.length % TAR_BLOCK_SIZE;
+  const data =
+    padding === 0
+      ? content
+      : Buffer.concat([content, Buffer.alloc(TAR_BLOCK_SIZE - padding)]);
+  return Buffer.concat([header, data]);
+}
+
+function createTarGz(
+  files: readonly { readonly path: string; readonly content: string }[],
+): Buffer {
+  return gzipSync(
+    Buffer.concat([
+      ...files.map((file) => {
+        return createTarEntry(file.path, Buffer.from(file.content, "utf8"));
+      }),
+      Buffer.alloc(TAR_BLOCK_SIZE * 2),
+    ]),
+  );
+}
+
+function putMemoryArchive(
+  misc: ReturnType<typeof createMiscRoutesApi>,
+  s3Key: string,
+  files: readonly { readonly path: string; readonly content: string }[],
+): void {
+  const manifestFiles = files.map((file) => {
+    return {
+      path: file.path,
+      hash: `bdd-${file.path}`,
+      size: Buffer.byteLength(file.content, "utf8"),
+    };
+  });
+  misc.putS3Object(
+    `${s3Key}/manifest.json`,
+    JSON.stringify({
+      version: "bdd-memory",
+      createdAt: new Date(0).toISOString(),
+      files: manifestFiles,
+      totalSize: manifestFiles.reduce((sum, file) => {
+        return sum + file.size;
+      }, 0),
+      fileCount: manifestFiles.length,
+    }),
+  );
+  misc.putS3Object(`${s3Key}/archive.tar.gz`, createTarGz(files));
 }
 
 function unsubscribeToken(userId: string): string {
@@ -845,6 +967,160 @@ describe("OPS-01: user data export", () => {
       canExport: true,
       nextExportAt: null,
     });
+  });
+
+  it("exports only agent instruction files, workflow files, memory files, and text chat messages", async () => {
+    const api = createOpsLogsApi(context);
+    const bdd = createBddApi(context);
+    const misc = createMiscRoutesApi(context);
+    const actor = await createUserExportActor(bdd);
+    const exportStartAt = Date.UTC(2026, 4, 12, 5);
+    const downloadUrl =
+      "https://r2.example.com/bdd-export-content.zip?sig=test";
+    if (!actor.orgId) {
+      throw new Error("Expected export test actor to have an org");
+    }
+
+    const agent = await bdd.createAgent(actor, {
+      displayName: "BDD Export Agent",
+      visibility: "private",
+    });
+    await accept(
+      setupApp({ context })(zeroAgentInstructionsContract).update({
+        params: { id: agent.agentId },
+        headers: { authorization: "Bearer clerk-session" },
+        body: { content: "Use the exported agent instructions." },
+      }),
+      [200],
+    );
+
+    const workflow = await misc.createWorkflow(
+      actor,
+      agent.agentId,
+      "bdd-export-workflow",
+      {
+        content: "Use the exported workflow instructions.",
+        files: [
+          {
+            path: "notes/checklist.md",
+            content: "Workflow supporting file",
+          },
+        ],
+      },
+      [201],
+    );
+    expect("id" in workflow.body).toBeTruthy();
+    if (!("id" in workflow.body)) {
+      throw new Error("Expected workflow creation to return a workflow id");
+    }
+    const workflowId = workflow.body.id;
+    const threadId = randomUUID();
+    await seedUserExportChatMessages({
+      userId: actor.userId,
+      agentId: agent.agentId,
+      threadId,
+    });
+    const memoryVersionId = `bdd-memory-${randomUUID()}`;
+    const memoryS3Key = `${actor.orgId}/artifact/memory/${memoryVersionId}`;
+    const memoryFiles = [
+      { path: "MEMORY.md", content: "# Exported memory" },
+      {
+        path: "notes/profile.md",
+        content: "Memory supporting note",
+      },
+    ];
+    putMemoryArchive(misc, memoryS3Key, memoryFiles);
+    await store.set(
+      seedMemoryStorage$,
+      {
+        orgId: actor.orgId,
+        userId: actor.userId,
+        s3Key: memoryS3Key,
+        headVersionId: memoryVersionId,
+        fileCount: memoryFiles.length,
+        size: memoryFiles.reduce((sum, file) => {
+          return sum + Buffer.byteLength(file.content, "utf8");
+        }, 0),
+        updatedAt: new Date(exportStartAt),
+      },
+      context.signal,
+    );
+
+    mockNow(exportStartAt);
+    context.mocks.s3.getSignedUrl.mockResolvedValue(downloadUrl);
+    const started = await api.requestPostUserExport(actor, [202]);
+    const jobId = started.body.jobId;
+    const exportKey = `exports/${actor.userId}/${jobId}.zip`;
+
+    await waitForUserExportJobStatus(api, actor, jobId, "completed");
+    const zip = exportZip(exportKey);
+    const names = zipEntryNames(zip);
+
+    const agentClaude = singleZipEntry(names, (name) => {
+      return name.startsWith("agents/") && name.endsWith("/CLAUDE.md");
+    });
+    const agentCodex = singleZipEntry(names, (name) => {
+      return name.startsWith("agents/") && name.endsWith("/AGENTS.md");
+    });
+    expect(zipText(zip, agentClaude)).toContain(
+      "Use the exported agent instructions.",
+    );
+    expect(zipText(zip, agentCodex)).toContain(
+      "Use the exported agent instructions.",
+    );
+
+    const workflowPrefix = `workflows/bdd-export-workflow-${workflowId}/`;
+    const workflowSkill = singleZipEntry(names, (name) => {
+      return name.startsWith(workflowPrefix) && name.endsWith("/SKILL.md");
+    });
+    const workflowNote = `${workflowPrefix}notes/checklist.md`;
+    expect(zipText(zip, workflowSkill)).toContain(
+      "Use the exported workflow instructions.",
+    );
+    expect(zipText(zip, workflowNote)).toBe("Workflow supporting file");
+    expect(zipText(zip, `memory/${actor.orgId}/MEMORY.md`)).toBe(
+      "# Exported memory",
+    );
+    expect(zipText(zip, `memory/${actor.orgId}/notes/profile.md`)).toBe(
+      "Memory supporting note",
+    );
+
+    const conversation = JSON.parse(
+      zipText(zip, `conversations/chat-thread-${threadId}.json`),
+    ) as unknown;
+    expect(conversation).toStrictEqual([
+      {
+        role: "user",
+        content: "exported user text",
+        createdAt: "2026-05-12T05:02:00.000Z",
+      },
+      {
+        role: "assistant",
+        content: "exported assistant text",
+        createdAt: "2026-05-12T05:03:00.000Z",
+      },
+    ]);
+
+    const manifest = JSON.parse(zipText(zip, "export-manifest.json")) as {
+      readonly counts: {
+        readonly agentInstructionFiles: number;
+        readonly workflowFiles: number;
+        readonly memoryFiles: number;
+        readonly conversationThreads: number;
+      };
+    };
+    expect(manifest.counts).toStrictEqual({
+      agentInstructionFiles: 2,
+      workflowFiles: 2,
+      memoryFiles: 2,
+      conversationThreads: 1,
+    });
+    expect(names).not.toContain("artifacts-manifest.json");
+    expect(
+      names.some((name) => {
+        return name.endsWith(".tar.gz") || name.endsWith("-history.jsonl");
+      }),
+    ).toBeFalsy();
   });
 
   it("surfaces failed exports and allows an immediate retry", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1758,7 +1758,7 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
       actor,
       agent.agentId,
       workflowName,
-      "# BDD codex kit\nUse this workflow for codex runs.",
+      { content: "# BDD codex kit\nUse this workflow for codex runs." },
       [201],
     );
     const thread = await chat.createThread(actor, { agentId: agent.agentId });
@@ -3477,7 +3477,7 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
       actor,
       agent.agentId,
       workflowName,
-      "# BDD claude kit\nUse this workflow in claude runs.",
+      { content: "# BDD claude kit\nUse this workflow in claude runs." },
       [201],
     );
 

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-gmail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-gmail.test.ts
@@ -451,7 +451,7 @@ async function setupFixture(): Promise<GmailTestFixture> {
     actor,
     agent.agentId,
     WORKFLOW_NAME,
-    "Handle Gmail webhook events.",
+    { content: "Handle Gmail webhook events." },
     [201],
   );
   if (!("id" in workflow.body)) {

--- a/turbo/apps/api/src/signals/routes/test-user-export-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-user-export-state.ts
@@ -9,6 +9,8 @@ import { users } from "@vm0/db/schema/user";
 import { command } from "ccstate";
 import { and, eq, sql } from "drizzle-orm";
 
+import { chatMessages } from "@vm0/db/schema/chat-message";
+import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { request$ } from "../context/hono";
 import { bodyResultOf } from "../context/request";
 import { writeDb$, type Db } from "../external/db";
@@ -83,8 +85,65 @@ async function deleteUserExportStateForAction(
   return actionOk();
 }
 
+async function seedChatMessagesForAction(
+  db: Db,
+  body: Record<string, unknown>,
+  signal: AbortSignal,
+) {
+  const userId = readString(body, "user_id");
+  const agentId = readString(body, "agent_id");
+  const threadId = readString(body, "thread_id");
+  if (!userId || !agentId || !threadId) {
+    return actionBadRequest("user_id, agent_id, and thread_id are required");
+  }
+
+  const createdAt = new Date("2026-05-12T05:01:00.000Z");
+  await db.insert(chatThreads).values({
+    id: threadId,
+    userId,
+    agentComposeId: agentId,
+    title: "BDD export thread",
+    lastMessageAt: createdAt,
+    createdAt,
+    updatedAt: createdAt,
+  });
+  signal.throwIfAborted();
+
+  await db.insert(chatMessages).values([
+    {
+      chatThreadId: threadId,
+      role: "user",
+      content: "exported user text",
+      createdAt: new Date("2026-05-12T05:02:00.000Z"),
+    },
+    {
+      chatThreadId: threadId,
+      role: "assistant",
+      content: "exported assistant text",
+      createdAt: new Date("2026-05-12T05:03:00.000Z"),
+    },
+    {
+      chatThreadId: threadId,
+      role: "assistant",
+      content: null,
+      error: "hidden assistant error",
+      createdAt: new Date("2026-05-12T05:04:00.000Z"),
+    },
+    {
+      chatThreadId: threadId,
+      role: "system",
+      content: "hidden system text",
+      createdAt: new Date("2026-05-12T05:05:00.000Z"),
+    },
+  ]);
+  signal.throwIfAborted();
+
+  return actionOk({ thread_id: threadId });
+}
+
 const userExportStateActionHandlers = {
   "delete-user-export-state": deleteUserExportStateForAction,
+  "seed-chat-messages": seedChatMessagesForAction,
 } satisfies Record<UserExportStateAction, UserExportStateActionHandler>;
 
 const mutateTestUserExportState$ = command(

--- a/turbo/apps/api/src/signals/services/user-export.service.ts
+++ b/turbo/apps/api/src/signals/services/user-export.service.ts
@@ -1,37 +1,41 @@
 import { createHmac } from "node:crypto";
 import archiver from "archiver";
 import { command, computed, type Computed } from "ccstate";
-import { and, desc, eq, gt, inArray } from "drizzle-orm";
+import { and, asc, desc, eq, gt, inArray } from "drizzle-orm";
 import type {
   UserExportJob,
   UserExportStartResponse,
   UserExportStatusResponse,
 } from "@vm0/api-contracts/contracts/user-export";
 import {
-  agentComposes,
-  agentComposeVersions,
-} from "@vm0/db/schema/agent-compose";
-import { agentSessions } from "@vm0/db/schema/agent-session";
+  getInstructionsStorageName,
+  MEMORY_ARTIFACT_NAME,
+  VOLUME_ORG_USER_ID,
+} from "@vm0/core/storage-names";
+import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { chatMessages } from "@vm0/db/schema/chat-message";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
-import { conversations } from "@vm0/db/schema/conversation";
-import { exportJobs, type ExportArtifactUrl } from "@vm0/db/schema/export-job";
+import { exportJobs } from "@vm0/db/schema/export-job";
 import { emailOutbox } from "@vm0/db/schema/email-outbox";
 import { storages, storageVersions } from "@vm0/db/schema/storage";
 import { userCache } from "@vm0/db/schema/user-cache";
 import { users } from "@vm0/db/schema/user";
+import { zeroWorkflows } from "@vm0/db/schema/zero-workflow";
 
 import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
+import { extractFilesFromTarGz } from "../../lib/tar";
 import { db$, writeDb$, type Db } from "../external/db";
 import { clerk$ } from "../external/clerk";
 import {
+  downloadManifest,
   downloadS3Buffer,
   generatePresignedGetUrl,
   putS3Object,
 } from "../external/s3";
 import { nowDate } from "../external/time";
 import { settle } from "../utils";
+import { loadWorkflowVolumeFiles } from "./zero-workflow-volume.service";
 
 const RATE_LIMIT_MS = 24 * 60 * 60 * 1000;
 const DOWNLOAD_URL_EXPIRY_SECONDS = 3600;
@@ -72,7 +76,6 @@ interface ZipEntry {
 
 interface CollectedData {
   readonly zipEntries: readonly ZipEntry[];
-  readonly artifactUrls: readonly ExportArtifactUrl[];
 }
 
 interface ExportRuntime {
@@ -93,6 +96,18 @@ interface ClerkEmailProfile {
   readonly primaryEmailAddressId: string | null;
   readonly firstName?: string | null;
   readonly lastName?: string | null;
+}
+
+interface VolumeFile {
+  readonly path: string;
+  readonly content: string;
+  readonly size: number;
+}
+
+interface ExportTextMessage {
+  readonly role: "user" | "assistant";
+  readonly content: string;
+  readonly createdAt: string;
 }
 
 const EXPORT_JOB_STATUSES = [
@@ -340,204 +355,232 @@ export const startUserExport$ = command(
   },
 );
 
-async function collectInstructions(
+function sanitizePathSegment(value: string): string {
+  return value.replace(/[\\/]+/g, "-").trim() || "unnamed";
+}
+
+function normalizeExportFilePath(path: string): string {
+  const parts = path
+    .replace(/\\/g, "/")
+    .replace(/^\/+/, "")
+    .split("/")
+    .filter((part) => {
+      return part.length > 0 && part !== ".";
+    });
+
+  if (
+    parts.some((part) => {
+      return part === "..";
+    })
+  ) {
+    throw new Error(`Invalid export file path: ${path}`);
+  }
+
+  return parts.join("/") || "file";
+}
+
+function scopedExportPath(args: {
+  readonly scope: string;
+  readonly name: string;
+  readonly id: string;
+  readonly filePath: string;
+}): string {
+  const folder = `${sanitizePathSegment(args.name)}-${args.id}`;
+  return `${args.scope}/${folder}/${normalizeExportFilePath(args.filePath)}`;
+}
+
+async function loadStorageVolumeFiles(
+  runtime: ExportRuntime,
+  args: {
+    readonly orgId: string;
+    readonly storageName: string;
+  },
+): Promise<readonly VolumeFile[]> {
+  const [storage] = await runtime.db
+    .select({ id: storages.id, headVersionId: storages.headVersionId })
+    .from(storages)
+    .where(
+      and(
+        eq(storages.orgId, args.orgId),
+        eq(storages.userId, VOLUME_ORG_USER_ID),
+        eq(storages.name, args.storageName),
+        eq(storages.type, "volume"),
+      ),
+    )
+    .limit(1);
+  runtime.signal.throwIfAborted();
+
+  if (!storage?.headVersionId) {
+    return [];
+  }
+
+  return await loadStorageVersionFiles(runtime, {
+    storageId: storage.id,
+    headVersionId: storage.headVersionId,
+  });
+}
+
+async function loadStorageVersionFiles(
+  runtime: ExportRuntime,
+  args: {
+    readonly storageId: string;
+    readonly headVersionId: string | null;
+  },
+): Promise<readonly VolumeFile[]> {
+  if (!args.headVersionId) {
+    return [];
+  }
+
+  const [version] = await runtime.db
+    .select({ s3Key: storageVersions.s3Key })
+    .from(storageVersions)
+    .where(
+      and(
+        eq(storageVersions.storageId, args.storageId),
+        eq(storageVersions.id, args.headVersionId),
+      ),
+    )
+    .limit(1);
+  runtime.signal.throwIfAborted();
+
+  if (!version) {
+    return [];
+  }
+
+  const manifest = await runtime.get(
+    downloadManifest(runtime.bucket, version.s3Key),
+  );
+  runtime.signal.throwIfAborted();
+
+  const filesList = manifest.files.map((file) => {
+    return {
+      path: normalizeExportFilePath(file.path),
+      size: file.size,
+    };
+  });
+  const archiveBuffer = await runtime.get(
+    downloadS3Buffer(runtime.bucket, `${version.s3Key}/archive.tar.gz`),
+  );
+  runtime.signal.throwIfAborted();
+
+  const contents = extractFilesFromTarGz(
+    archiveBuffer,
+    filesList.map((file) => {
+      return file.path;
+    }),
+  );
+  const sizeByPath = new Map(
+    filesList.map((file) => {
+      return [file.path, file.size];
+    }),
+  );
+
+  return contents.map((file) => {
+    const path = normalizeExportFilePath(file.path);
+    return {
+      path,
+      content: file.content,
+      size: sizeByPath.get(path) ?? Buffer.byteLength(file.content, "utf8"),
+    };
+  });
+}
+
+async function collectAgentInstructionFiles(
   runtime: ExportRuntime,
   userId: string,
-  orgId: string,
 ): Promise<{ readonly entries: readonly ZipEntry[]; readonly count: number }> {
   const entries: ZipEntry[] = [];
-  let count = 0;
 
   const composes = await runtime.db
     .select({
       id: agentComposes.id,
+      orgId: agentComposes.orgId,
       name: agentComposes.name,
-      headVersionId: agentComposes.headVersionId,
     })
     .from(agentComposes)
-    .where(
-      and(eq(agentComposes.userId, userId), eq(agentComposes.orgId, orgId)),
-    );
+    .where(eq(agentComposes.userId, userId))
+    .orderBy(asc(agentComposes.orgId), asc(agentComposes.name));
   runtime.signal.throwIfAborted();
 
   for (const compose of composes) {
-    if (!compose.headVersionId) {
-      continue;
-    }
-
-    const [version] = await runtime.db
-      .select({ content: agentComposeVersions.content })
-      .from(agentComposeVersions)
-      .where(eq(agentComposeVersions.id, compose.headVersionId))
-      .limit(1);
+    const files = await loadStorageVolumeFiles(runtime, {
+      orgId: compose.orgId,
+      storageName: getInstructionsStorageName(compose.name),
+    });
     runtime.signal.throwIfAborted();
 
-    if (version) {
+    for (const file of files) {
       entries.push({
-        path: `instructions/${compose.name}/vm0.yaml`,
-        content: JSON.stringify(version.content, null, 2),
+        path: scopedExportPath({
+          scope: "agents",
+          name: compose.name,
+          id: compose.id,
+          filePath: file.path,
+        }),
+        content: file.content,
       });
-      count += 1;
-    }
-
-    const instructionsStorageName = `agent-instructions@${compose.name}`;
-    const [instructionsStorage] = await runtime.db
-      .select({ headVersionId: storages.headVersionId })
-      .from(storages)
-      .where(
-        and(
-          eq(storages.orgId, orgId),
-          eq(storages.name, instructionsStorageName),
-          eq(storages.type, "volume"),
-        ),
-      )
-      .limit(1);
-    runtime.signal.throwIfAborted();
-
-    if (instructionsStorage?.headVersionId) {
-      const [storageVersion] = await runtime.db
-        .select({ s3Key: storageVersions.s3Key })
-        .from(storageVersions)
-        .where(eq(storageVersions.id, instructionsStorage.headVersionId))
-        .limit(1);
-      runtime.signal.throwIfAborted();
-
-      if (storageVersion) {
-        const archiveBuffer = await runtime.get(
-          downloadS3Buffer(
-            runtime.bucket,
-            `${storageVersion.s3Key}/archive.tar.gz`,
-          ),
-        );
-        runtime.signal.throwIfAborted();
-        entries.push({
-          path: `instructions/${compose.name}/instructions.tar.gz`,
-          content: archiveBuffer,
-        });
-      }
     }
   }
 
-  return { entries, count };
+  return { entries, count: entries.length };
 }
 
-async function resolveSessionHistory(
-  runtime: ExportRuntime,
-  hash: string | null,
-  legacyText: string | null,
-): Promise<string | null> {
-  if (hash) {
-    const result = await settle(
-      runtime.get(downloadS3Buffer(runtime.bucket, `blobs/${hash}.blob`)),
-    );
-    runtime.signal.throwIfAborted();
-
-    if (result.ok) {
-      return result.value.toString("utf8");
-    }
-
-    if (legacyText) {
-      log.warn("session history blob fetch failed, using legacy text", {
-        hash,
-        error: result.error,
-      });
-      return legacyText;
-    }
-
-    throw result.error;
-  }
-
-  return legacyText;
-}
-
-async function collectConversations(
+async function collectWorkflowFiles(
   runtime: ExportRuntime,
   userId: string,
 ): Promise<{ readonly entries: readonly ZipEntry[]; readonly count: number }> {
   const entries: ZipEntry[] = [];
-  let count = 0;
 
-  const threads = await runtime.db
-    .select({ id: chatThreads.id })
-    .from(chatThreads)
-    .where(eq(chatThreads.userId, userId));
-  runtime.signal.throwIfAborted();
-
-  for (const thread of threads) {
-    const messages = await runtime.db
-      .select({
-        role: chatMessages.role,
-        content: chatMessages.content,
-        runId: chatMessages.runId,
-        error: chatMessages.error,
-        createdAt: chatMessages.createdAt,
-      })
-      .from(chatMessages)
-      .where(eq(chatMessages.chatThreadId, thread.id))
-      .orderBy(chatMessages.createdAt);
-    runtime.signal.throwIfAborted();
-
-    if (messages.length > 0) {
-      entries.push({
-        path: `conversations/chat-thread-${thread.id}.json`,
-        content: JSON.stringify(messages, null, 2),
-      });
-      count += 1;
-    }
-  }
-
-  const sessionsWithConversations = await runtime.db
+  const workflows = await runtime.db
     .select({
-      id: agentSessions.id,
-      conversationId: agentSessions.conversationId,
+      id: zeroWorkflows.id,
+      orgId: zeroWorkflows.orgId,
+      name: zeroWorkflows.name,
+      createdAt: zeroWorkflows.createdAt,
     })
-    .from(agentSessions)
-    .where(eq(agentSessions.userId, userId));
+    .from(zeroWorkflows)
+    .where(eq(zeroWorkflows.ownerUserId, userId))
+    .orderBy(
+      asc(zeroWorkflows.orgId),
+      asc(zeroWorkflows.name),
+      asc(zeroWorkflows.createdAt),
+    );
   runtime.signal.throwIfAborted();
 
-  for (const session of sessionsWithConversations) {
-    if (!session.conversationId) {
-      continue;
-    }
-
-    const [conversation] = await runtime.db
-      .select({
-        cliAgentSessionHistoryHash: conversations.cliAgentSessionHistoryHash,
-        cliAgentSessionHistory: conversations.cliAgentSessionHistory,
-      })
-      .from(conversations)
-      .where(eq(conversations.id, session.conversationId))
-      .limit(1);
+  for (const workflow of workflows) {
+    const files =
+      (await loadWorkflowVolumeFiles(runtime.get, {
+        orgId: workflow.orgId,
+        workflowId: workflow.id,
+      })) ?? [];
     runtime.signal.throwIfAborted();
 
-    if (conversation) {
-      const history = await resolveSessionHistory(
-        runtime,
-        conversation.cliAgentSessionHistoryHash,
-        conversation.cliAgentSessionHistory,
-      );
-
-      if (history) {
-        entries.push({
-          path: `conversations/${session.id}-history.jsonl`,
-          content: history,
-        });
-      }
+    for (const file of files) {
+      entries.push({
+        path: scopedExportPath({
+          scope: "workflows",
+          name: workflow.name,
+          id: workflow.id,
+          filePath: file.path,
+        }),
+        content: file.content,
+      });
     }
   }
 
-  return { entries, count };
+  return { entries, count: entries.length };
 }
 
-async function collectArtifacts(
+async function collectMemoryFiles(
   runtime: ExportRuntime,
   userId: string,
-  orgId: string,
-  expiresAt: Date,
-): Promise<readonly ExportArtifactUrl[]> {
-  const artifactStorages = await runtime.db
+): Promise<{ readonly entries: readonly ZipEntry[]; readonly count: number }> {
+  const entries: ZipEntry[] = [];
+
+  const memoryStorages = await runtime.db
     .select({
-      name: storages.name,
+      id: storages.id,
+      orgId: storages.orgId,
       headVersionId: storages.headVersionId,
       fileCount: storages.fileCount,
     })
@@ -545,75 +588,117 @@ async function collectArtifacts(
     .where(
       and(
         eq(storages.userId, userId),
-        eq(storages.orgId, orgId),
+        eq(storages.name, MEMORY_ARTIFACT_NAME),
         eq(storages.type, "artifact"),
       ),
-    );
+    )
+    .orderBy(asc(storages.orgId));
   runtime.signal.throwIfAborted();
 
-  const artifactUrls: ExportArtifactUrl[] = [];
-
-  for (const artifact of artifactStorages) {
-    if (!artifact.headVersionId || artifact.fileCount === 0) {
+  for (const memoryStorage of memoryStorages) {
+    if (memoryStorage.fileCount === 0) {
       continue;
     }
 
-    const [storageVersion] = await runtime.db
-      .select({ s3Key: storageVersions.s3Key })
-      .from(storageVersions)
-      .where(eq(storageVersions.id, artifact.headVersionId))
-      .limit(1);
+    const files = await loadStorageVersionFiles(runtime, {
+      storageId: memoryStorage.id,
+      headVersionId: memoryStorage.headVersionId,
+    });
     runtime.signal.throwIfAborted();
 
-    if (storageVersion) {
-      const archiveKey = `${storageVersion.s3Key}/archive.tar.gz`;
-      const presignedUrl = await runtime.get(
-        generatePresignedGetUrl(
-          runtime.bucket,
-          archiveKey,
-          EXPORT_DOWNLOAD_EXPIRY_SECONDS,
-          `${artifact.name}.tar.gz`,
-          true,
-        ),
-      );
-      runtime.signal.throwIfAborted();
-
-      artifactUrls.push({
-        name: artifact.name,
-        downloadUrl: presignedUrl,
-        expiresAt: expiresAt.toISOString(),
+    for (const file of files) {
+      entries.push({
+        path: `memory/${sanitizePathSegment(
+          memoryStorage.orgId,
+        )}/${normalizeExportFilePath(file.path)}`,
+        content: file.content,
       });
     }
   }
 
-  return artifactUrls;
+  return { entries, count: entries.length };
+}
+
+function exportMessageRole(role: string): "user" | "assistant" | null {
+  if (role === "user" || role === "assistant") {
+    return role;
+  }
+  return null;
+}
+
+async function collectConversationMessages(
+  runtime: ExportRuntime,
+  userId: string,
+): Promise<{ readonly entries: readonly ZipEntry[]; readonly count: number }> {
+  const entries: ZipEntry[] = [];
+
+  const threads = await runtime.db
+    .select({ id: chatThreads.id, createdAt: chatThreads.createdAt })
+    .from(chatThreads)
+    .where(eq(chatThreads.userId, userId))
+    .orderBy(asc(chatThreads.createdAt));
+  runtime.signal.throwIfAborted();
+
+  for (const thread of threads) {
+    const rows = await runtime.db
+      .select({
+        role: chatMessages.role,
+        content: chatMessages.content,
+        createdAt: chatMessages.createdAt,
+      })
+      .from(chatMessages)
+      .where(
+        and(
+          eq(chatMessages.chatThreadId, thread.id),
+          inArray(chatMessages.role, ["user", "assistant"]),
+        ),
+      )
+      .orderBy(asc(chatMessages.createdAt));
+    runtime.signal.throwIfAborted();
+
+    const messages: ExportTextMessage[] = rows.flatMap((message) => {
+      const role = exportMessageRole(message.role);
+      if (!role || !message.content) {
+        return [];
+      }
+      return [
+        {
+          role,
+          content: message.content,
+          createdAt: message.createdAt.toISOString(),
+        },
+      ];
+    });
+
+    if (messages.length > 0) {
+      entries.push({
+        path: `conversations/chat-thread-${thread.id}.json`,
+        content: JSON.stringify(messages, null, 2),
+      });
+    }
+  }
+
+  return { entries, count: entries.length };
 }
 
 async function collectUserData(
   runtime: ExportRuntime,
   userId: string,
   orgId: string,
-  expiresAt: Date,
 ): Promise<CollectedData> {
-  const instructions = await collectInstructions(runtime, userId, orgId);
-  const conversationsResult = await collectConversations(runtime, userId);
-  const artifactUrls = await collectArtifacts(
+  const agentInstructions = await collectAgentInstructionFiles(runtime, userId);
+  const workflows = await collectWorkflowFiles(runtime, userId);
+  const memory = await collectMemoryFiles(runtime, userId);
+  const conversationsResult = await collectConversationMessages(
     runtime,
     userId,
-    orgId,
-    expiresAt,
   );
   const zipEntries: ZipEntry[] = [
-    ...instructions.entries,
+    ...agentInstructions.entries,
+    ...workflows.entries,
+    ...memory.entries,
     ...conversationsResult.entries,
   ];
-
-  if (artifactUrls.length > 0) {
-    zipEntries.push({
-      path: "artifacts-manifest.json",
-      content: JSON.stringify(artifactUrls, null, 2),
-    });
-  }
 
   zipEntries.push({
     path: "export-manifest.json",
@@ -621,11 +706,12 @@ async function collectUserData(
       {
         exportedAt: nowDate().toISOString(),
         userId,
-        orgId,
+        requestOrgId: orgId,
         counts: {
-          instructions: instructions.count,
-          conversations: conversationsResult.count,
-          artifacts: artifactUrls.length,
+          agentInstructionFiles: agentInstructions.count,
+          workflowFiles: workflows.count,
+          memoryFiles: memory.count,
+          conversationThreads: conversationsResult.count,
         },
       },
       null,
@@ -633,7 +719,7 @@ async function collectUserData(
     ),
   });
 
-  return { zipEntries, artifactUrls };
+  return { zipEntries };
 }
 
 async function assembleZip(entries: readonly ZipEntry[]): Promise<Buffer> {
@@ -794,11 +880,10 @@ async function runExportJob(
   runtime.signal.throwIfAborted();
 
   const expiresAt = new Date(nowDate().getTime() + EXPORT_DOWNLOAD_EXPIRY_MS);
-  const { zipEntries, artifactUrls } = await collectUserData(
+  const { zipEntries } = await collectUserData(
     runtime,
     args.userId,
     args.orgId,
-    expiresAt,
   );
   runtime.signal.throwIfAborted();
 
@@ -827,7 +912,7 @@ async function runExportJob(
     .set({
       status: "completed",
       s3Key,
-      artifactUrls: artifactUrls.length > 0 ? [...artifactUrls] : null,
+      artifactUrls: null,
       completedAt: nowDate(),
       expiresAt,
     })
@@ -838,7 +923,7 @@ async function runExportJob(
     userId: args.userId,
     downloadUrl,
     expiresAt,
-    artifactCount: artifactUrls.length,
+    artifactCount: 0,
   });
   runtime.signal.throwIfAborted();
 

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -56,6 +56,7 @@ import { setupReportErrorPage$ } from "./report-error/report-error-page-setup.ts
 import { setupLabPage$ } from "./lab-page/lab-page-setup.ts";
 import { setupNetworkInsightsPage$ } from "./network-insights/network-insights-page-setup.ts";
 import { setupUsagePage$ } from "./usage-page/usage-page-setup.ts";
+import { setupExportPage$ } from "./export-page/export-page-setup.ts";
 import { initSlackOrg$ as handleSlackRedirect$ } from "./zero-page/zero-slack.ts";
 import { setupSkeletonPage$, setupErrorPage$ } from "./skeleton-page-setup.ts";
 import { hideAppSkeleton$, startSkeletonCycling$ } from "./app-skeleton.ts";
@@ -283,6 +284,10 @@ const ROUTE_CONFIG = [
   {
     path: ROUTES.usage,
     setup: setupAuthSidebarPageWrapper(setupUsagePage$),
+  },
+  {
+    path: ROUTES.exportData,
+    setup: setupAuthPageWrapper(setupExportPage$),
   },
   {
     path: ROUTES.onboarding,

--- a/turbo/apps/platform/src/signals/export-page/export-page-setup.ts
+++ b/turbo/apps/platform/src/signals/export-page/export-page-setup.ts
@@ -1,0 +1,23 @@
+import { command } from "ccstate";
+import { createElement } from "react";
+import { ExportPage } from "../../views/export-page/export-page.tsx";
+import { hideAppSkeleton$ } from "../app-skeleton.ts";
+import { updateDocumentTitle$ } from "../document-title.ts";
+import { updatePage$ } from "../react-router.ts";
+import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
+import { detach, Reason } from "../utils.ts";
+import { watchUserExportStatus$ } from "./export-page-signals.ts";
+
+export const setupExportPage$ = command(
+  async ({ set }, signal: AbortSignal) => {
+    if (await set(onboardGuard$, signal)) {
+      return;
+    }
+
+    set(updatePage$, createElement(ExportPage));
+    set(updateDocumentTitle$, "Export data");
+    // eslint-disable-next-line ccstate/no-detach-in-signals -- page-scoped polling must not block route setup.
+    detach(set(watchUserExportStatus$, signal), Reason.Daemon);
+    await set(hideAppSkeleton$, signal);
+  },
+);

--- a/turbo/apps/platform/src/signals/export-page/export-page-setup.ts
+++ b/turbo/apps/platform/src/signals/export-page/export-page-setup.ts
@@ -5,8 +5,6 @@ import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
 import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
-import { detach, Reason } from "../utils.ts";
-import { watchUserExportStatus$ } from "./export-page-signals.ts";
 
 export const setupExportPage$ = command(
   async ({ set }, signal: AbortSignal) => {
@@ -16,8 +14,6 @@ export const setupExportPage$ = command(
 
     set(updatePage$, createElement(ExportPage));
     set(updateDocumentTitle$, "Export data");
-    // eslint-disable-next-line ccstate/no-detach-in-signals -- page-scoped polling must not block route setup.
-    detach(set(watchUserExportStatus$, signal), Reason.Daemon);
     await set(hideAppSkeleton$, signal);
   },
 );

--- a/turbo/apps/platform/src/signals/export-page/export-page-signals.ts
+++ b/turbo/apps/platform/src/signals/export-page/export-page-signals.ts
@@ -3,28 +3,14 @@ import {
   userExportContract,
   type UserExportStatusResponse,
 } from "@vm0/api-contracts/contracts/user-export";
+import { accept } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
-import { setLoop } from "../utils.ts";
+import { onRef, setLoop } from "../utils.ts";
 
 const POLL_INTERVAL_MS = 5000;
 
 const statusReload$ = state(0);
 const exportStartError$ = state<string | null>(null);
-
-function errorMessageFromBody(body: unknown, fallback: string): string {
-  if (
-    body &&
-    typeof body === "object" &&
-    "error" in body &&
-    body.error &&
-    typeof body.error === "object" &&
-    "message" in body.error &&
-    typeof body.error.message === "string"
-  ) {
-    return body.error.message;
-  }
-  return fallback;
-}
 
 function isStatusInProgress(status: UserExportStatusResponse): boolean {
   return status.job?.status === "pending" || status.job?.status === "running";
@@ -38,12 +24,7 @@ export const userExportStatus$ = computed(
   async (get): Promise<UserExportStatusResponse> => {
     get(statusReload$);
     const client = get(zeroClient$)(userExportContract);
-    const result = await client.get();
-    if (result.status !== 200) {
-      throw new Error(
-        errorMessageFromBody(result.body, "Failed to load export"),
-      );
-    }
+    const result = await accept(client.get(), [200], { toast: false });
     return result.body;
   },
 );
@@ -74,27 +55,28 @@ export const startUserExport$ = command(
     set(exportStartError$, null);
 
     const client = get(zeroClient$)(userExportContract);
-    const result = await client.post({
-      body: undefined,
-      fetchOptions: { signal },
-    });
+    const result = await accept(
+      client.post({
+        body: undefined,
+        fetchOptions: { signal },
+      }),
+      [202, 429],
+      { toast: false },
+    );
     signal.throwIfAborted();
 
     if (result.status === 202) {
       set(reloadUserExportStatus$);
-      await set(watchUserExportStatus$, signal);
       return;
     }
 
-    if (result.status === 429) {
-      set(exportStartError$, "You can export once every 24 hours.");
-      set(reloadUserExportStatus$);
-      return;
-    }
-
-    set(
-      exportStartError$,
-      errorMessageFromBody(result.body, "Failed to start export"),
-    );
+    set(exportStartError$, "You can export once every 24 hours.");
+    set(reloadUserExportStatus$);
   },
+);
+
+export const userExportStatusPollingRef$ = onRef(
+  command(async ({ set }, _el: HTMLElement, signal: AbortSignal) => {
+    await set(watchUserExportStatus$, signal);
+  }),
 );

--- a/turbo/apps/platform/src/signals/export-page/export-page-signals.ts
+++ b/turbo/apps/platform/src/signals/export-page/export-page-signals.ts
@@ -1,0 +1,100 @@
+import { command, computed, state } from "ccstate";
+import {
+  userExportContract,
+  type UserExportStatusResponse,
+} from "@vm0/api-contracts/contracts/user-export";
+import { zeroClient$ } from "../api-client.ts";
+import { setLoop } from "../utils.ts";
+
+const POLL_INTERVAL_MS = 5000;
+
+const statusReload$ = state(0);
+const exportStartError$ = state<string | null>(null);
+
+function errorMessageFromBody(body: unknown, fallback: string): string {
+  if (
+    body &&
+    typeof body === "object" &&
+    "error" in body &&
+    body.error &&
+    typeof body.error === "object" &&
+    "message" in body.error &&
+    typeof body.error.message === "string"
+  ) {
+    return body.error.message;
+  }
+  return fallback;
+}
+
+function isStatusInProgress(status: UserExportStatusResponse): boolean {
+  return status.job?.status === "pending" || status.job?.status === "running";
+}
+
+export const userExportStartError$ = computed((get) => {
+  return get(exportStartError$);
+});
+
+export const userExportStatus$ = computed(
+  async (get): Promise<UserExportStatusResponse> => {
+    get(statusReload$);
+    const client = get(zeroClient$)(userExportContract);
+    const result = await client.get();
+    if (result.status !== 200) {
+      throw new Error(
+        errorMessageFromBody(result.body, "Failed to load export"),
+      );
+    }
+    return result.body;
+  },
+);
+
+export const reloadUserExportStatus$ = command(({ set }) => {
+  set(statusReload$, (value) => {
+    return value + 1;
+  });
+});
+
+export const watchUserExportStatus$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<void> => {
+    await setLoop(
+      async (loopSignal) => {
+        set(reloadUserExportStatus$);
+        const status = await get(userExportStatus$);
+        loopSignal.throwIfAborted();
+        return !isStatusInProgress(status);
+      },
+      POLL_INTERVAL_MS,
+      signal,
+    );
+  },
+);
+
+export const startUserExport$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<void> => {
+    set(exportStartError$, null);
+
+    const client = get(zeroClient$)(userExportContract);
+    const result = await client.post({
+      body: undefined,
+      fetchOptions: { signal },
+    });
+    signal.throwIfAborted();
+
+    if (result.status === 202) {
+      set(reloadUserExportStatus$);
+      await set(watchUserExportStatus$, signal);
+      return;
+    }
+
+    if (result.status === 429) {
+      set(exportStartError$, "You can export once every 24 hours.");
+      set(reloadUserExportStatus$);
+      return;
+    }
+
+    set(
+      exportStartError$,
+      errorMessageFromBody(result.body, "Failed to start export"),
+    );
+  },
+);

--- a/turbo/apps/platform/src/signals/route-paths.ts
+++ b/turbo/apps/platform/src/signals/route-paths.ts
@@ -42,6 +42,7 @@ export const ROUTES = {
   lab: "/_/lab",
   insights: "/insights",
   usage: "/usage",
+  exportData: "/export",
   reportError: "/runs/:runId/report-error",
   redeemCampaign: "/redeem/:campaign",
   skeleton: "/_/skeleton",

--- a/turbo/apps/platform/src/views/export-page/export-page.tsx
+++ b/turbo/apps/platform/src/views/export-page/export-page.tsx
@@ -1,4 +1,4 @@
-import { useGet, useLoadable } from "ccstate-react";
+import { useGet, useLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import {
   IconAlertCircle,
@@ -17,6 +17,7 @@ import {
   startUserExport$,
   userExportStartError$,
   userExportStatus$,
+  userExportStatusPollingRef$,
 } from "../../signals/export-page/export-page-signals.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { Link } from "../router/link.tsx";
@@ -319,6 +320,7 @@ export function ExportPage() {
       : null;
   const startError = useGet(userExportStartError$);
   const [startLoadable, startExport] = useLoadableSet(startUserExport$);
+  const statusPollingRef = useSet(userExportStatusPollingRef$);
   const pageSignal = useGet(pageSignal$);
   const triggering = startLoadable.state === "loading";
   const startActionError =
@@ -366,6 +368,10 @@ export function ExportPage() {
             </div>
 
             <ExportScopeList />
+
+            {viewState === "in-progress" ? (
+              <span ref={statusPollingRef} hidden />
+            ) : null}
 
             <div className="rounded-xl border border-border/70 bg-card p-4">
               <div

--- a/turbo/apps/platform/src/views/export-page/export-page.tsx
+++ b/turbo/apps/platform/src/views/export-page/export-page.tsx
@@ -1,0 +1,404 @@
+import { useGet, useLoadable } from "ccstate-react";
+import { useLoadableSet } from "ccstate-react/experimental";
+import {
+  IconAlertCircle,
+  IconArrowLeft,
+  IconCircleCheck,
+  IconDatabaseExport,
+  IconDownload,
+  IconLoader2,
+  IconRefresh,
+} from "@tabler/icons-react";
+import type { UserExportStatusResponse } from "@vm0/api-contracts/contracts/user-export";
+import { Button } from "@vm0/ui";
+import { now } from "../../lib/time.ts";
+import { pageSignal$ } from "../../signals/page-signal.ts";
+import {
+  startUserExport$,
+  userExportStartError$,
+  userExportStatus$,
+} from "../../signals/export-page/export-page-signals.ts";
+import { detach, Reason } from "../../signals/utils.ts";
+import { Link } from "../router/link.tsx";
+
+type ExportViewState =
+  | "loading"
+  | "ready"
+  | "in-progress"
+  | "download"
+  | "expired"
+  | "failed"
+  | "rate-limited";
+
+function formatRelativeTime(dateStr: string): string {
+  const diffMs = new Date(dateStr).getTime() - now();
+  if (!Number.isFinite(diffMs) || diffMs <= 0) {
+    return "soon";
+  }
+
+  const totalMinutes = Math.ceil(diffMs / (1000 * 60));
+  const days = Math.floor(totalMinutes / (60 * 24));
+  const hours = Math.floor((totalMinutes - days * 60 * 24) / 60);
+  const minutes = totalMinutes % 60;
+
+  if (days > 0) {
+    return hours > 0 ? `${days}d ${hours}h` : `${days}d`;
+  }
+  if (hours > 0) {
+    return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+  }
+  return `${minutes}m`;
+}
+
+function deriveViewState(
+  data: UserExportStatusResponse | null,
+  loading: boolean,
+): ExportViewState {
+  if (loading) {
+    return "loading";
+  }
+
+  const job = data?.job;
+  if (!job) {
+    return data?.canExport ? "ready" : "rate-limited";
+  }
+
+  if (job.status === "pending" || job.status === "running") {
+    return "in-progress";
+  }
+
+  if (job.status === "failed") {
+    return "failed";
+  }
+
+  if (job.status === "completed") {
+    const expired =
+      job.expiresAt !== null && new Date(job.expiresAt).getTime() <= now();
+    if (expired) {
+      return "expired";
+    }
+    if (job.downloadUrl) {
+      return "download";
+    }
+  }
+
+  return data?.canExport ? "ready" : "rate-limited";
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Failed to load export";
+}
+
+function StatusIcon({ viewState }: { readonly viewState: ExportViewState }) {
+  if (viewState === "loading" || viewState === "in-progress") {
+    return <IconLoader2 size={22} className="animate-spin" stroke={1.8} />;
+  }
+  if (viewState === "download") {
+    return <IconCircleCheck size={22} stroke={1.8} />;
+  }
+  if (viewState === "failed") {
+    return <IconAlertCircle size={22} stroke={1.8} />;
+  }
+  return <IconDatabaseExport size={22} stroke={1.8} />;
+}
+
+function StatusText({
+  viewState,
+  data,
+}: {
+  readonly viewState: ExportViewState;
+  readonly data: UserExportStatusResponse | null;
+}) {
+  if (viewState === "loading") {
+    return (
+      <>
+        <h2 className="text-base font-semibold text-foreground">
+          Checking export status
+        </h2>
+        <p className="text-sm leading-6 text-muted-foreground">
+          Your latest export state will appear here.
+        </p>
+      </>
+    );
+  }
+
+  if (viewState === "in-progress") {
+    return (
+      <>
+        <h2 className="text-base font-semibold text-foreground">
+          Preparing your export
+        </h2>
+        <p className="text-sm leading-6 text-muted-foreground">
+          This can take a few minutes. You can leave this page open.
+        </p>
+      </>
+    );
+  }
+
+  if (viewState === "download") {
+    return (
+      <>
+        <h2 className="text-base font-semibold text-foreground">
+          Your export is ready
+        </h2>
+        <p className="text-sm leading-6 text-muted-foreground">
+          {data?.job?.expiresAt
+            ? `The download link expires in ${formatRelativeTime(data.job.expiresAt)}.`
+            : "Download it before the link expires."}
+        </p>
+      </>
+    );
+  }
+
+  if (viewState === "expired") {
+    return (
+      <>
+        <h2 className="text-base font-semibold text-foreground">
+          Previous export expired
+        </h2>
+        <p className="text-sm leading-6 text-muted-foreground">
+          Start a new export to get a fresh download link.
+        </p>
+      </>
+    );
+  }
+
+  if (viewState === "failed") {
+    return (
+      <>
+        <h2 className="text-base font-semibold text-foreground">
+          Export did not finish
+        </h2>
+        <p className="text-sm leading-6 text-muted-foreground">
+          Try again, or contact support if this keeps happening.
+        </p>
+      </>
+    );
+  }
+
+  if (viewState === "rate-limited") {
+    return (
+      <>
+        <h2 className="text-base font-semibold text-foreground">
+          Export recently requested
+        </h2>
+        <p className="text-sm leading-6 text-muted-foreground">
+          {data?.nextExportAt
+            ? `You can start another export in ${formatRelativeTime(data.nextExportAt)}.`
+            : "You can start another export after the cooldown ends."}
+        </p>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <h2 className="text-base font-semibold text-foreground">
+        Ready to export
+      </h2>
+      <p className="text-sm leading-6 text-muted-foreground">
+        Create a ZIP file with your workspace data.
+      </p>
+    </>
+  );
+}
+
+function ExportActions({
+  viewState,
+  data,
+  triggering,
+  onTrigger,
+}: {
+  readonly viewState: ExportViewState;
+  readonly data: UserExportStatusResponse | null;
+  readonly triggering: boolean;
+  readonly onTrigger: () => void;
+}) {
+  const canExport = data?.canExport ?? false;
+  const downloadUrl = data?.job?.downloadUrl;
+
+  if (viewState === "download" && downloadUrl) {
+    return (
+      <div className="flex w-full flex-col gap-2">
+        <Button asChild className="h-9 w-full gap-2">
+          <a href={downloadUrl} download>
+            <IconDownload size={16} stroke={1.8} />
+            Download export
+          </a>
+        </Button>
+        {canExport && (
+          <Button
+            type="button"
+            variant="outline"
+            className="zero-btn-morandi h-9 w-full gap-2 rounded-lg border"
+            disabled={triggering}
+            onClick={onTrigger}
+          >
+            {triggering ? (
+              <IconLoader2 size={16} className="animate-spin" stroke={1.8} />
+            ) : (
+              <IconRefresh size={16} stroke={1.8} />
+            )}
+            Export again
+          </Button>
+        )}
+      </div>
+    );
+  }
+
+  if (viewState === "loading" || viewState === "in-progress") {
+    return null;
+  }
+
+  if (!canExport) {
+    return null;
+  }
+
+  return (
+    <Button
+      type="button"
+      className="h-9 w-full gap-2"
+      disabled={triggering}
+      onClick={onTrigger}
+    >
+      {triggering ? (
+        <IconLoader2 size={16} className="animate-spin" stroke={1.8} />
+      ) : (
+        <IconDatabaseExport size={16} stroke={1.8} />
+      )}
+      {triggering ? "Starting export" : "Export my data"}
+    </Button>
+  );
+}
+
+function ExportScopeList() {
+  const items = [
+    "Agent instruction documents",
+    "Workflow SKILL.md instructions and files",
+    "Memory files",
+    "User and assistant text chat messages",
+  ];
+
+  return (
+    <div className="grid gap-2 rounded-xl border border-border/70 bg-gray-50 p-3 text-sm dark:bg-gray-900/30">
+      {items.map((item) => {
+        return (
+          <div key={item} className="flex items-center gap-2 text-foreground">
+            <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground/70" />
+            <span>{item}</span>
+          </div>
+        );
+      })}
+      <p className="pt-1 text-xs leading-5 text-muted-foreground">
+        Artifacts are not included in this export.
+      </p>
+    </div>
+  );
+}
+
+function iconTone(viewState: ExportViewState): string {
+  if (viewState === "failed") {
+    return "bg-destructive/10 text-destructive";
+  }
+  if (viewState === "download") {
+    return "bg-emerald-500/10 text-emerald-600";
+  }
+  return "bg-gray-50 text-muted-foreground";
+}
+
+export function ExportPage() {
+  const statusLoadable = useLoadable(userExportStatus$);
+  const data = statusLoadable.state === "hasData" ? statusLoadable.data : null;
+  const loading = statusLoadable.state === "loading";
+  const loadError =
+    statusLoadable.state === "hasError"
+      ? errorMessage(statusLoadable.error)
+      : null;
+  const startError = useGet(userExportStartError$);
+  const [startLoadable, startExport] = useLoadableSet(startUserExport$);
+  const pageSignal = useGet(pageSignal$);
+  const triggering = startLoadable.state === "loading";
+  const startActionError =
+    startLoadable.state === "hasError"
+      ? errorMessage(startLoadable.error)
+      : null;
+  const error = startError ?? startActionError ?? loadError;
+  const viewState = deriveViewState(data, loading);
+  const handleTrigger = () => {
+    detach(startExport(pageSignal), Reason.DomCallback);
+  };
+
+  return (
+    <div className="zero-app zero-viewport-shell flex w-full bg-background zero-workspace-bg">
+      <main className="flex min-h-0 flex-1 items-center justify-center overflow-auto px-4 py-8">
+        <section className="zero-card w-full max-w-[440px] p-5 sm:p-7">
+          <div className="mb-6 flex items-center justify-between gap-4">
+            <Link
+              pathname="/"
+              className="inline-flex items-center gap-1.5 text-sm text-muted-foreground no-underline transition-colors hover:text-foreground"
+            >
+              <IconArrowLeft size={14} stroke={1.8} />
+              Back to Zero
+            </Link>
+            <img
+              src="/assets/vm0-logo-dark.svg"
+              alt="VM0"
+              className="h-4 w-auto dark:hidden"
+            />
+            <img
+              src="/assets/vm0-logo.svg"
+              alt="VM0"
+              className="hidden h-4 w-auto dark:block"
+            />
+          </div>
+
+          <div className="space-y-6">
+            <div className="space-y-2">
+              <h1 className="text-xl font-semibold tracking-tight text-foreground">
+                Export data
+              </h1>
+              <p className="text-sm leading-6 text-muted-foreground">
+                Download the files and text records you created in Zero.
+              </p>
+            </div>
+
+            <ExportScopeList />
+
+            <div className="rounded-xl border border-border/70 bg-card p-4">
+              <div
+                className="flex items-start gap-3"
+                aria-live={viewState === "in-progress" ? "polite" : undefined}
+              >
+                <div
+                  className={`mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-xl ${iconTone(
+                    viewState,
+                  )}`}
+                >
+                  <StatusIcon viewState={viewState} />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <StatusText viewState={viewState} data={data} />
+                </div>
+              </div>
+
+              {error ? (
+                <div className="mt-4 rounded-lg border border-destructive/20 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                  {error}
+                </div>
+              ) : null}
+
+              <div className="mt-4">
+                <ExportActions
+                  viewState={viewState}
+                  data={data}
+                  triggering={triggering}
+                  onTrigger={handleTrigger}
+                />
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/export-page/export-page.tsx
+++ b/turbo/apps/platform/src/views/export-page/export-page.tsx
@@ -30,6 +30,9 @@ type ExportViewState =
   | "failed"
   | "rate-limited";
 
+const PRIMARY_ACTION_BUTTON_CLASS =
+  "h-9 w-full gap-2 bg-foreground text-background hover:bg-foreground/90 active:bg-foreground/80";
+
 function formatRelativeTime(dateStr: string): string {
   const diffMs = new Date(dateStr).getTime() - now();
   if (!Number.isFinite(diffMs) || diffMs <= 0) {
@@ -220,7 +223,7 @@ function ExportActions({
   if (viewState === "download" && downloadUrl) {
     return (
       <div className="flex w-full flex-col gap-2">
-        <Button asChild className="h-9 w-full gap-2">
+        <Button asChild className={PRIMARY_ACTION_BUTTON_CLASS}>
           <a href={downloadUrl} download>
             <IconDownload size={16} stroke={1.8} />
             Download export
@@ -257,7 +260,7 @@ function ExportActions({
   return (
     <Button
       type="button"
-      className="h-9 w-full gap-2"
+      className={PRIMARY_ACTION_BUTTON_CLASS}
       disabled={triggering}
       onClick={onTrigger}
     >

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
@@ -43,7 +43,6 @@ import {
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { openSettingsDialogAt$ } from "../../signals/zero-page/settings/settings-dialog.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
-import { webBaseForNavigation$ } from "../../signals/fetch.ts";
 import { isOrgAdmin$ } from "../../signals/org.ts";
 import { billingStatusAsync$ } from "../../signals/zero-page/billing.ts";
 
@@ -382,24 +381,14 @@ function AccountManagementGroup({
   );
 }
 
-function ExtraAccountActions({
-  showExportData,
-  webBase,
-}: {
-  showExportData: boolean;
-  webBase: string | undefined;
-}) {
+function ExtraAccountActions({ showExportData }: { showExportData: boolean }) {
   if (!showExportData) {
     return null;
   }
   return (
     <DropdownMenuItem
-      disabled={!webBase}
       onClick={() => {
-        if (!webBase) {
-          return;
-        }
-        return window.open(`${webBase}/export`, "_blank");
+        return window.open(`${window.location.origin}/export`, "_blank");
       }}
       className="gap-3 px-3 py-2.5 rounded-lg"
     >
@@ -445,7 +434,6 @@ export function AccountDropdown({
   const user =
     userInfoLoadable.state === "hasData" ? userInfoLoadable.data : undefined;
   const features = useLastResolved(featureSwitch$);
-  const webBase = useLastResolved(webBaseForNavigation$);
   const showExportData = features?.[FeatureSwitchKey.DataExport] ?? false;
   const memoryEnabled = features?.[FeatureSwitchKey.MemoryViewer] ?? false;
   const labEnabled = features?.[FeatureSwitchKey.Lab] ?? false;
@@ -545,10 +533,7 @@ export function AccountDropdown({
           onSwitchSession={handleSwitchSession}
           onAddAccount={handleAddAccount}
         />
-        <ExtraAccountActions
-          showExportData={showExportData}
-          webBase={webBase}
-        />
+        <ExtraAccountActions showExportData={showExportData} />
         <DropdownMenuSeparator />
         <SignOutItem onAccountAction={handleAccountAction} />
       </DropdownMenuContent>

--- a/turbo/packages/api-contracts/src/contracts/test-user-export-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-user-export-state.ts
@@ -6,7 +6,7 @@ const c = initContract();
 
 export const testUserExportStateActionBodySchema = z
   .object({
-    action: z.enum(["delete-user-export-state"]),
+    action: z.enum(["delete-user-export-state", "seed-chat-messages"]),
   })
   .passthrough();
 


### PR DESCRIPTION
## Summary
- Rewrite user data export payload collection to include agent instruction files, workflow files, memory files, and text-only chat messages.
- Remove artifact export manifests, session history exports, agent compose YAML, and instruction tarball entries while preserving the existing async export job/R2/email flow.
- Add the data export page back under the platform app at `/export`, and update the account menu entry to open the platform route instead of the removed `www/export` page.
- Add focused BDD coverage that opens the uploaded ZIP and verifies the new file set and manifest counts.

## Testing
- `./node_modules/.bin/prettier --check apps/platform/src/signals/bootstrap.ts apps/platform/src/signals/route-paths.ts apps/platform/src/views/zero-page/zero-sidebar-account.tsx apps/platform/src/signals/export-page/export-page-setup.ts apps/platform/src/signals/export-page/export-page-signals.ts apps/platform/src/views/export-page/export-page.tsx`
- `pnpm -F @vm0/app exec oxlint src/signals/bootstrap.ts src/signals/route-paths.ts src/views/zero-page/zero-sidebar-account.tsx src/signals/export-page/export-page-setup.ts src/signals/export-page/export-page-signals.ts src/views/export-page/export-page.tsx`
- `pnpm -F @vm0/app exec eslint src/signals/bootstrap.ts src/signals/route-paths.ts src/views/zero-page/zero-sidebar-account.tsx src/signals/export-page/export-page-setup.ts src/signals/export-page/export-page-signals.ts src/views/export-page/export-page.tsx --max-warnings 0`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx -t "opens credit balance and export data from the account menu"`
- `pnpm -F @vm0/app lint`
- API exact `ops-logs.bdd.test.ts` vitest run was attempted earlier and blocked by missing local Postgres (`ECONNREFUSED`).
- API full `tsc` attempts were blocked by local resource limits after fixing the TypeScript diagnostics they surfaced.