### PR TITLE
fix: apply sandbox io limiters from host capacity

### DIFF
--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -141,10 +141,7 @@ pub(super) async fn handle_discovered_job(
     );
     info!(run_id = %run_id, profile = %profile_name, "job claimed, spawning executor");
     let started_at = Instant::now();
-    let device_rate_limits = crate::io_limits::device_rate_limits_for_context(
-        ctx.spawn_ctx.device_rate_limits.as_ref(),
-        claimed.context(),
-    );
+    let device_rate_limits = ctx.spawn_ctx.device_rate_limits.clone();
     pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::DeviceRateLimits, started_at);
 
     let (reuse_entry, active_lease, reuse_result, idle_snapshot, needs_session_affinity_refresh) =

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -476,8 +476,7 @@ async fn run_start_with_home(
                 disk_ops_per_sec = limits.block.ops_per_sec,
                 net_rx_bytes_per_sec = limits.network.rx_bytes_per_sec,
                 net_tx_bytes_per_sec = limits.network.tx_bytes_per_sec,
-                feature_flag = crate::io_limits::SANDBOX_IO_LIMITERS_FEATURE_FLAG,
-                "I/O limiter capacity configured; applying limiters only for flagged jobs"
+                "I/O limiter capacity configured; applying limiters to all jobs"
             );
         }
     }

--- a/crates/runner/src/cmd/start/tests/idle_reuse.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse.rs
@@ -35,23 +35,6 @@ fn context_with_session_opt(
     ctx
 }
 
-fn context_with_io_limiter_flag_value(
-    run_id: RunId,
-    session_id: &str,
-    enabled: bool,
-) -> crate::types::ExecutionContext {
-    let mut ctx = context_with_session(run_id, session_id);
-    ctx.feature_flags = Some(std::collections::HashMap::from([(
-        crate::io_limits::SANDBOX_IO_LIMITERS_FEATURE_FLAG.to_string(),
-        enabled,
-    )]));
-    ctx
-}
-
-fn context_with_io_limiter_flag(run_id: RunId, session_id: &str) -> crate::types::ExecutionContext {
-    context_with_io_limiter_flag_value(run_id, session_id, true)
-}
-
 fn device_rate_limits() -> sandbox::DeviceRateLimits {
     sandbox::DeviceRateLimits {
         block: sandbox::BlockRateLimits {
@@ -633,11 +616,12 @@ async fn reuse_take_preserves_cached_workspace_held_session_state() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn disabled_io_limiter_feature_omits_limits_on_fresh_create() {
+async fn configured_io_limiter_capacity_applies_limits_on_fresh_create() {
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     let (mut config, env) =
         mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, Arc::clone(&overrides));
-    config.capacity.device_rate_limits = Some(device_rate_limits());
+    let limits = device_rate_limits();
+    config.capacity.device_rate_limits = Some(limits.clone());
 
     let run_handle = tokio::spawn(run(config));
     let run_id = RunId::new_v4();
@@ -645,11 +629,7 @@ async fn disabled_io_limiter_feature_omits_limits_on_fresh_create() {
         &env,
         run_id,
         "vm0/default",
-        Some(context_with_io_limiter_flag_value(
-            run_id,
-            "sess-disabled-io-limit",
-            false,
-        )),
+        Some(context_with_session(run_id, "sess-io-limit")),
     );
 
     let completion = env
@@ -661,111 +641,13 @@ async fn disabled_io_limiter_feature_omits_limits_on_fresh_create() {
 
     let create_configs = overrides.create_configs();
     assert_eq!(create_configs.len(), 1);
-    assert_eq!(create_configs[0].device_rate_limits, None);
+    assert_eq!(create_configs[0].device_rate_limits, Some(limits));
 
     shutdown(&env, run_handle).await;
 }
 
 #[tokio::test(start_paused = true)]
-async fn disabled_io_limiter_feature_reuses_unlimited_idle_vm() {
-    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
-    let (mut config, env) =
-        mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, Arc::clone(&overrides));
-    let idle_pool = Arc::clone(&config.shared.idle_pool);
-    let budget = Arc::clone(&config.capacity.budget);
-    config.capacity.device_rate_limits = Some(device_rate_limits());
-
-    let seeded_sandbox_id = seed_idle_pool_with_overrides(
-        &idle_pool,
-        &budget,
-        &overrides,
-        "sess-disabled-io-reuse",
-        "vm0/default",
-        2,
-        4096,
-    )
-    .await;
-
-    let run_handle = tokio::spawn(run(config));
-    let run_id = RunId::new_v4();
-    push_job(
-        &env,
-        run_id,
-        "vm0/default",
-        Some(context_with_io_limiter_flag_value(
-            run_id,
-            "sess-disabled-io-reuse",
-            false,
-        )),
-    );
-
-    let completion = env
-        .handle
-        .wait_completion(run_id, Duration::from_secs(5))
-        .await
-        .expect("job should complete");
-    assert_eq!(completion.reuse_result, Some(SandboxReuseResult::Reused));
-    assert_eq!(completion.sandbox_id, Some(seeded_sandbox_id));
-    assert!(
-        overrides
-            .create_configs()
-            .iter()
-            .all(|config| config.device_rate_limits.is_none()),
-        "disabled feature should never pass limiter config to sandbox create"
-    );
-
-    shutdown(&env, run_handle).await;
-}
-
-#[tokio::test(start_paused = true)]
-async fn missing_io_limiter_feature_reuses_unlimited_idle_vm() {
-    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
-    let (mut config, env) =
-        mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, Arc::clone(&overrides));
-    let idle_pool = Arc::clone(&config.shared.idle_pool);
-    let budget = Arc::clone(&config.capacity.budget);
-    config.capacity.device_rate_limits = Some(device_rate_limits());
-
-    let seeded_sandbox_id = seed_idle_pool_with_overrides(
-        &idle_pool,
-        &budget,
-        &overrides,
-        "sess-missing-io-flag",
-        "vm0/default",
-        2,
-        4096,
-    )
-    .await;
-
-    let run_handle = tokio::spawn(run(config));
-    let run_id = RunId::new_v4();
-    push_job(
-        &env,
-        run_id,
-        "vm0/default",
-        Some(context_with_session(run_id, "sess-missing-io-flag")),
-    );
-
-    let completion = env
-        .handle
-        .wait_completion(run_id, Duration::from_secs(5))
-        .await
-        .expect("job should complete");
-    assert_eq!(completion.reuse_result, Some(SandboxReuseResult::Reused));
-    assert_eq!(completion.sandbox_id, Some(seeded_sandbox_id));
-    assert!(
-        overrides
-            .create_configs()
-            .iter()
-            .all(|config| config.device_rate_limits.is_none()),
-        "missing feature flag should never pass limiter config to sandbox create"
-    );
-
-    shutdown(&env, run_handle).await;
-}
-
-#[tokio::test(start_paused = true)]
-async fn enabled_io_limiter_feature_without_host_capacity_reuses_unlimited_idle_vm() {
+async fn absent_io_limiter_capacity_reuses_unlimited_idle_vm() {
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
     let (config, env) =
         mock_run_config_with_overrides(test_profiles(), 8, 32768, 4, Arc::clone(&overrides));
@@ -776,7 +658,7 @@ async fn enabled_io_limiter_feature_without_host_capacity_reuses_unlimited_idle_
         &idle_pool,
         &budget,
         &overrides,
-        "sess-enabled-io-no-capacity",
+        "sess-absent-io-capacity",
         "vm0/default",
         2,
         4096,
@@ -789,10 +671,7 @@ async fn enabled_io_limiter_feature_without_host_capacity_reuses_unlimited_idle_
         &env,
         run_id,
         "vm0/default",
-        Some(context_with_io_limiter_flag(
-            run_id,
-            "sess-enabled-io-no-capacity",
-        )),
+        Some(context_with_session(run_id, "sess-absent-io-capacity")),
     );
 
     let completion = env
@@ -807,7 +686,7 @@ async fn enabled_io_limiter_feature_without_host_capacity_reuses_unlimited_idle_
             .create_configs()
             .iter()
             .all(|config| config.device_rate_limits.is_none()),
-        "enabled feature without host capacity should not apply limiter config"
+        "absent host capacity should not apply limiter config"
     );
 
     shutdown(&env, run_handle).await;
@@ -840,7 +719,7 @@ async fn device_limit_mismatch_destroys_idle_vm_and_fresh_creates() {
         &env,
         run_id,
         "vm0/default",
-        Some(context_with_io_limiter_flag(run_id, "sess-io-limit")),
+        Some(context_with_session(run_id, "sess-io-limit")),
     );
 
     let completion = env
@@ -864,7 +743,7 @@ async fn device_limit_mismatch_destroys_idle_vm_and_fresh_creates() {
         create_configs
             .iter()
             .any(|config| config.device_rate_limits == Some(limits.clone())),
-        "fresh create should receive the enabled limiter config"
+        "fresh create should receive the configured limiter"
     );
 
     shutdown(&env, run_handle).await;

--- a/crates/runner/src/io_limits.rs
+++ b/crates/runner/src/io_limits.rs
@@ -3,17 +3,15 @@
 //! Host-local capacity is optional and belongs at the runner boundary. This
 //! module converts that capacity into provider-neutral per-sandbox limits.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 
 use sandbox::{BlockRateLimits, DeviceRateLimits, NetworkRateLimits};
 
 use crate::config::ProfileConfig;
 use crate::host_env::{self, HostEnvValue, RunnerHostEnv, RunnerIoEnvValues};
 use crate::resource_budget::ResourceBudget;
-use crate::types::ExecutionContext;
 
 const MIB: f64 = 1024.0 * 1024.0;
-pub(crate) const SANDBOX_IO_LIMITERS_FEATURE_FLAG: &str = "sandboxIoLimiters";
 // Keep host-level headroom outside Firecracker token buckets for system daemons,
 // filesystem metadata bursts, and other non-sandbox traffic.
 const IO_CAPACITY_PERCENT: u128 = 100;
@@ -42,24 +40,6 @@ impl IoLimitResolution {
             Self::Disabled | Self::Misconfigured { .. } => None,
         }
     }
-}
-
-pub(crate) fn device_rate_limits_for_context(
-    configured_limits: Option<&DeviceRateLimits>,
-    context: &ExecutionContext,
-) -> Option<DeviceRateLimits> {
-    if !io_limit_feature_enabled(context.feature_flags.as_ref()) {
-        return None;
-    }
-
-    configured_limits.cloned()
-}
-
-fn io_limit_feature_enabled(feature_flags: Option<&HashMap<String, bool>>) -> bool {
-    feature_flags
-        .and_then(|flags| flags.get(SANDBOX_IO_LIMITERS_FEATURE_FLAG))
-        .copied()
-        .unwrap_or(false)
 }
 
 pub(crate) fn resolve_io_limits(
@@ -379,18 +359,6 @@ mod tests {
             net_rx_mib_per_sec: Some(value("1250")),
             net_tx_mib_per_sec: Some(value("1000")),
         }
-    }
-
-    #[test]
-    fn io_limit_feature_enabled_requires_explicit_true_flag() {
-        let enabled = HashMap::from([(SANDBOX_IO_LIMITERS_FEATURE_FLAG.to_string(), true)]);
-        let disabled = HashMap::from([(SANDBOX_IO_LIMITERS_FEATURE_FLAG.to_string(), false)]);
-        let unrelated = HashMap::from([("otherFlag".to_string(), true)]);
-
-        assert!(io_limit_feature_enabled(Some(&enabled)));
-        assert!(!io_limit_feature_enabled(Some(&disabled)));
-        assert!(!io_limit_feature_enabled(Some(&unrelated)));
-        assert!(!io_limit_feature_enabled(None));
     }
 
     #[test]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -205,8 +205,7 @@ profiles:
   logs a warning and disables I/O limiter capacity. Valid I/O capacity keeps a
   fixed 20% host reserve and splits the remainder evenly across admitted
   sandboxes.
-- Even with valid host capacity, the runner only applies limiter fields to jobs
-  whose evaluated `sandboxIoLimiters` feature flag is true.
+- With valid host capacity, the runner applies limiter fields to all jobs.
 - I/O capacity is resolved per runner process. If multiple runner services share
   one host, split the host capacity across those services in their host env
   values; the runner does not coordinate I/O budgets across processes.

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -3398,7 +3398,7 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
     const connectors = createConnectorBddApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
     await connectors.updateFeatureSwitches(actor, {
-      [FeatureSwitchKey.SandboxIoLimiters]: true,
+      [FeatureSwitchKey.MemoryViewer]: true,
     });
 
     const firstStartedAt = now();
@@ -3438,7 +3438,7 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
     await api.heartbeatRunner(runnerGroup);
     const claim = await api.claimRunnerJob(queued.runId);
     expect(claim.featureFlags).toMatchObject({
-      [FeatureSwitchKey.SandboxIoLimiters]: true,
+      [FeatureSwitchKey.MemoryViewer]: true,
     });
     expect(claim.apiStartTime).toBe(promotedAt);
 

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -2942,7 +2942,7 @@ describe("RUN-04: agent run telemetry families", () => {
             },
             featureFlags: { legacyIgnored: true },
             featureFlagEntries: [
-              { name: "sandboxIoLimiters", enabled: true },
+              { name: "memoryViewer", enabled: true },
               { name: "dummy", enabled: null },
               { enabled: true },
             ],
@@ -2997,7 +2997,7 @@ describe("RUN-04: agent run telemetry families", () => {
           unknownPolicy: "allow",
         },
       },
-      featureFlags: { sandboxIoLimiters: true },
+      featureFlags: { memoryViewer: true },
       artifact: { vasStorageName: "art-1" },
     });
     expect(contextRead.body.environment).toStrictEqual({

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -43,7 +43,6 @@ export enum FeatureSwitchKey {
   ApiKeys = "apiKeys",
 
   ZapierConnector = "zapierConnector",
-  SandboxIoLimiters = "sandboxIoLimiters",
   ChatGithubPrTracking = "chatGithubPrTracking",
   ChatThreadEmoji = "chatThreadEmoji",
   MemoryViewer = "memoryViewer",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -237,13 +237,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Enable the Zapier connector. When disabled, Zapier is hidden from the connectors list and cannot be connected.",
     enabled: false,
   },
-  [FeatureSwitchKey.SandboxIoLimiters]: {
-    maintainer: "liangyou@vm0.ai",
-    description:
-      "Enable runner-provided disk and network device rate limiters for sandbox VMs.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.ChatGithubPrTracking]: {
     maintainer: "linghan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary
- remove the sandboxIoLimiters feature switch key and registry entry
- apply runner I/O limiters to every job when valid host capacity is configured
- update runner reuse tests, API feature-flag snapshot tests, and architecture docs

## Validation
- pnpm format
- pnpm lint
- pnpm check-types
- pnpm -F api exec vitest src/signals/routes/__tests__/run-lifecycle.bdd.test.ts src/signals/routes/__tests__/run-reads.bdd.test.ts
- cargo test -p runner io_limit
- cargo test -p runner device_limit_mismatch
- pre-commit hook: prettier, knip, check-types, cargo fmt, cargo clippy, cargo doc, commitlint

Note: ran pnpm -F @vm0/db db:migrate before API tests because the local test database was missing a recent model_providers column.