### PR TITLE
feat: show subscription usage in sidebar

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
+import type { ModelProviderResponse } from "@vm0/api-contracts/contracts/model-providers";
 import {
   chatThreadByIdContract,
   chatThreadArtifactsContract,
@@ -37,6 +38,82 @@ const ARCHIVED_THREAD_ID = "b0000000-0000-4000-a000-000000000004";
 const RESEARCH_THREAD_ID = "b0000000-0000-4000-a000-000000000005";
 
 type SidebarThread = Parameters<typeof splitChatThreadListResponse>[0][number];
+
+function connectedPersonalCodexProvider(
+  overrides: Partial<ModelProviderResponse> = {},
+): ModelProviderResponse {
+  return {
+    id: "00000000-0000-4000-a000-000000000301",
+    type: "codex-oauth-token",
+    framework: "codex",
+    secretName: null,
+    authMethod: "auth_json",
+    secretNames: ["CODEX_AUTH_JSON"],
+    isDefault: false,
+    selectedModel: null,
+    workspaceName: "Personal ChatGPT",
+    planType: "pro",
+    subscriptionResetPeriod: "Weekly",
+    subscriptionNextResetAt: "2030-01-07T00:00:00.000Z",
+    subscriptionUsage: {
+      fiveHour: {
+        usedPercent: 18,
+        remainingPercent: 82,
+        resetAt: "2030-01-01T05:00:00.000Z",
+        windowSeconds: 18_000,
+      },
+      weekly: {
+        usedPercent: 45,
+        remainingPercent: 55,
+        resetAt: "2030-01-07T00:00:00.000Z",
+        windowSeconds: 604_800,
+      },
+    },
+    needsReconnect: false,
+    lastRefreshErrorCode: null,
+    createdAt: "2026-03-01T00:00:00Z",
+    updatedAt: "2026-03-20T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function connectedPersonalClaudeCodeProvider(
+  overrides: Partial<ModelProviderResponse> = {},
+): ModelProviderResponse {
+  return {
+    id: "00000000-0000-4000-a000-000000000302",
+    type: "claude-code-oauth-token",
+    framework: "claude-code",
+    secretName: "CLAUDE_CODE_OAUTH_TOKEN",
+    authMethod: null,
+    secretNames: null,
+    isDefault: false,
+    selectedModel: null,
+    workspaceName: "claude.user@example.com",
+    planType: "pro",
+    subscriptionResetPeriod: "weekly",
+    subscriptionNextResetAt: "2030-01-07T00:00:00.000Z",
+    subscriptionUsage: {
+      fiveHour: {
+        usedPercent: 12,
+        remainingPercent: 88,
+        resetAt: "2030-01-01T05:00:00.000Z",
+        windowSeconds: 18_000,
+      },
+      weekly: {
+        usedPercent: 24,
+        remainingPercent: 76,
+        resetAt: "2030-01-07T00:00:00.000Z",
+        windowSeconds: 604_800,
+      },
+    },
+    needsReconnect: false,
+    lastRefreshErrorCode: null,
+    createdAt: "2026-03-01T00:00:00Z",
+    updatedAt: "2026-03-20T00:00:00Z",
+    ...overrides,
+  };
+}
 
 function prepareDefaultAgent(): void {
   context.mocks.data.team([
@@ -1504,6 +1581,125 @@ describe("zero sidebar", () => {
     await waitFor(() => {
       expect(within(nav).getByText("Agents")).toBeInTheDocument();
       expect(within(nav).getByText("Connectors")).toBeInTheDocument();
+    });
+  });
+
+  it("hides sidebar subscriptions when the feature switch is disabled", async () => {
+    prepareDefaultAgent();
+    context.mocks.data.personalModelProviders([
+      connectedPersonalCodexProvider(),
+      connectedPersonalClaudeCodeProvider(),
+    ]);
+    context.mocks.api(chatThreadsContract.list, ({ respond }) => {
+      return respond(200, splitChatThreadListResponse([]));
+    });
+
+    detachedSetupPage({ context, path: `/agents/${AGENT_ID}/chat` });
+
+    await waitFor(() => {
+      expect(screen.getByText("Where Zero works")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Subscriptions")).not.toBeInTheDocument();
+  });
+
+  it("shows sidebar subscriptions between where zero works and the account footer when enabled", async () => {
+    prepareDefaultAgent();
+    context.mocks.data.personalModelProviders([
+      connectedPersonalCodexProvider(),
+      connectedPersonalClaudeCodeProvider(),
+    ]);
+    context.mocks.api(chatThreadsContract.list, ({ respond }) => {
+      return respond(200, splitChatThreadListResponse([]));
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      featureSwitches: { [FeatureSwitchKey.SidebarSubscriptionUsage]: true },
+    });
+
+    const panel = await waitFor(() => {
+      return screen.getByTestId("sidebar-subscriptions");
+    });
+    expect(within(panel).getByText("Subscriptions")).toBeInTheDocument();
+    expect(within(panel).getByText("Codex")).toBeInTheDocument();
+    expect(within(panel).getByText("Claude Code")).toBeInTheDocument();
+    expect(within(panel).getByText("82%")).toBeInTheDocument();
+    expect(within(panel).getByText("55%")).toBeInTheDocument();
+    expect(within(panel).getByText("88%")).toBeInTheDocument();
+    expect(within(panel).getByText("76%")).toBeInTheDocument();
+
+    const codexFiveHour = within(panel).getByRole("progressbar", {
+      name: "Codex 5h remaining",
+    });
+    expect(codexFiveHour).toHaveAttribute("aria-valuenow", "82");
+    fireEvent.focus(codexFiveHour);
+    await waitFor(() => {
+      expect(screen.getAllByText(/resets Jan 1, 2030/).length).toBeGreaterThan(
+        0,
+      );
+    });
+
+    const works = screen.getByText("Where Zero works");
+    const subscriptions = within(panel).getByText("Subscriptions");
+    const account = screen.getByText("Test User");
+    expect(
+      works.compareDocumentPosition(subscriptions) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(
+      subscriptions.compareDocumentPosition(account) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+
+  it("refreshes sidebar subscriptions only when the refresh button is clicked", async () => {
+    prepareDefaultAgent();
+    context.mocks.data.personalModelProviders([
+      connectedPersonalCodexProvider(),
+      connectedPersonalClaudeCodeProvider(),
+    ]);
+    context.mocks.api(chatThreadsContract.list, ({ respond }) => {
+      return respond(200, splitChatThreadListResponse([]));
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      featureSwitches: { [FeatureSwitchKey.SidebarSubscriptionUsage]: true },
+    });
+
+    const panel = await waitFor(() => {
+      return screen.getByTestId("sidebar-subscriptions");
+    });
+    expect(within(panel).getByText("82%")).toBeInTheDocument();
+
+    context.mocks.data.personalModelProviders([
+      connectedPersonalCodexProvider({
+        subscriptionUsage: {
+          fiveHour: {
+            usedPercent: 36,
+            remainingPercent: 64,
+            resetAt: "2030-01-01T05:00:00.000Z",
+            windowSeconds: 18_000,
+          },
+          weekly: {
+            usedPercent: 70,
+            remainingPercent: 30,
+            resetAt: "2030-01-07T00:00:00.000Z",
+            windowSeconds: 604_800,
+          },
+        },
+      }),
+      connectedPersonalClaudeCodeProvider(),
+    ]);
+
+    expect(within(panel).queryByText("64%")).not.toBeInTheDocument();
+    click(screen.getByLabelText("Refresh subscriptions"));
+
+    await waitFor(() => {
+      expect(within(panel).getByText("64%")).toBeInTheDocument();
+      expect(within(panel).getByText("30%")).toBeInTheDocument();
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-subscriptions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-subscriptions.tsx
@@ -1,0 +1,345 @@
+import { useLastLoadable, useLastResolved, useSet } from "ccstate-react";
+import { IconRefresh } from "@tabler/icons-react";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import type {
+  ModelProviderResponse,
+  ModelProviderType,
+} from "@vm0/api-contracts/contracts/model-providers";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@vm0/ui";
+
+import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
+import { reloadPersonalModelProviders$ } from "../../signals/external/personal-model-providers.ts";
+import { personalConfiguredProviders$ } from "../../signals/zero-page/settings/personal-model-providers.ts";
+import { detach, Reason } from "../../signals/utils.ts";
+
+type SubscriptionUsage = NonNullable<
+  ModelProviderResponse["subscriptionUsage"]
+>;
+type SubscriptionUsageWindow = NonNullable<SubscriptionUsage["fiveHour"]>;
+
+const SIDEBAR_SUBSCRIPTION_PROVIDERS = [
+  { type: "codex-oauth-token", label: "Codex" },
+  { type: "claude-code-oauth-token", label: "Claude Code" },
+] as const satisfies readonly {
+  readonly type: ModelProviderType;
+  readonly label: string;
+}[];
+
+export function SidebarSubscriptionsGate() {
+  const features = useLastResolved(featureSwitch$);
+
+  if (!features?.[FeatureSwitchKey.SidebarSubscriptionUsage]) {
+    return null;
+  }
+
+  return <SidebarSubscriptionsPanel />;
+}
+
+function SidebarSubscriptionsPanel() {
+  const providersLoadable = useLastLoadable(personalConfiguredProviders$);
+  const refreshSubscriptions = useSet(reloadPersonalModelProviders$);
+  const providers =
+    providersLoadable.state === "hasData" ? providersLoadable.data : [];
+  const rows = sidebarSubscriptionRows(providers);
+  const loading = providersLoadable.state === "loading";
+
+  if (!loading && rows.length === 0) {
+    return null;
+  }
+
+  return (
+    <section
+      data-testid="sidebar-subscriptions"
+      className="mt-1 rounded-xl border border-border/60 bg-sidebar-accent/25 px-2.5 py-2"
+    >
+      <div className="mb-2 flex min-w-0 items-center justify-between gap-2">
+        <h3 className="truncate text-[11px] font-semibold leading-4 text-sidebar-foreground/70">
+          Subscriptions
+        </h3>
+        <TooltipProvider delayDuration={150}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-sidebar-foreground/55 transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground disabled:cursor-default disabled:opacity-60"
+                aria-label="Refresh subscriptions"
+                disabled={loading}
+                onClick={() => {
+                  detach(
+                    refreshSubscriptions(),
+                    Reason.DomCallback,
+                    "refresh sidebar subscriptions",
+                  );
+                }}
+              >
+                <IconRefresh
+                  size={13}
+                  className={loading ? "animate-spin" : undefined}
+                />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="right">
+              <p className="text-xs">Refresh subscriptions</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </div>
+      {loading && rows.length === 0 ? (
+        <SidebarSubscriptionsSkeleton />
+      ) : (
+        <TooltipProvider delayDuration={100}>
+          <div className="flex flex-col gap-1.5">
+            {rows.map((row) => {
+              return (
+                <SidebarSubscriptionProviderRow
+                  key={row.type}
+                  label={row.label}
+                  usage={row.usage}
+                />
+              );
+            })}
+          </div>
+        </TooltipProvider>
+      )}
+    </section>
+  );
+}
+
+function SidebarSubscriptionsSkeleton() {
+  return (
+    <div className="flex flex-col gap-1.5" aria-hidden="true">
+      {SIDEBAR_SUBSCRIPTION_PROVIDERS.map((provider) => {
+        return (
+          <div
+            key={provider.type}
+            className="rounded-lg border border-border/35 bg-background/55 px-2 py-1.5"
+          >
+            <div className="h-3 w-20 animate-pulse rounded bg-sidebar-foreground/10" />
+            <div className="mt-2 space-y-1.5">
+              <div className="h-1.5 animate-pulse rounded-full bg-sidebar-foreground/10" />
+              <div className="h-1.5 animate-pulse rounded-full bg-sidebar-foreground/10" />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function SidebarSubscriptionProviderRow({
+  label,
+  usage,
+}: {
+  readonly label: string;
+  readonly usage: SubscriptionUsage;
+}) {
+  const windows = usageWindows(usage);
+
+  return (
+    <div className="rounded-lg border border-border/40 bg-background/65 px-2 py-1.5">
+      <div className="mb-1.5 truncate text-[12px] font-medium leading-4 text-sidebar-foreground">
+        {label}
+      </div>
+      <div className="flex flex-col gap-1.5">
+        {windows.map(({ label: windowLabel, window }) => {
+          return (
+            <SidebarSubscriptionUsageBar
+              key={windowLabel}
+              providerLabel={label}
+              label={windowLabel}
+              window={window}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function SidebarSubscriptionUsageBar({
+  providerLabel,
+  label,
+  window,
+}: {
+  readonly providerLabel: string;
+  readonly label: string;
+  readonly window: SubscriptionUsageWindow;
+}) {
+  const rawRemainingPercent =
+    window.remainingPercent ??
+    (window.usedPercent === null ? null : 100 - window.usedPercent);
+  const remainingPercent =
+    rawRemainingPercent !== null && Number.isFinite(rawRemainingPercent)
+      ? rawRemainingPercent
+      : null;
+  const displayPercent = formatUsagePercent(remainingPercent);
+  const resetText = formatUsageReset(window.resetAt);
+  const tone = usageTone(remainingPercent);
+  const width =
+    remainingPercent === null
+      ? 0
+      : Math.min(100, Math.max(0, remainingPercent));
+
+  return (
+    <div className="grid grid-cols-[28px_minmax(0,1fr)_34px] items-center gap-1.5">
+      <span className="text-[10px] font-medium leading-none text-sidebar-foreground/55">
+        {label}
+      </span>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            tabIndex={0}
+            role="progressbar"
+            aria-label={`${providerLabel} ${label} remaining`}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={remainingPercent ?? undefined}
+            className={`block h-1.5 min-w-0 overflow-hidden rounded-full outline-none ring-offset-1 ring-offset-sidebar transition-shadow focus-visible:ring-2 focus-visible:ring-ring ${tone.trackClassName}`}
+          >
+            <span
+              className={`block h-full rounded-full transition-[width] ${tone.barClassName}`}
+              style={{ width: `${width}%` }}
+            />
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="right" align="center">
+          <p className="text-xs">{resetText ?? "Reset time unavailable"}</p>
+        </TooltipContent>
+      </Tooltip>
+      <span
+        className={`text-right text-[10px] font-medium leading-none ${tone.textClassName}`}
+      >
+        {displayPercent ?? "--"}
+      </span>
+    </div>
+  );
+}
+
+function sidebarSubscriptionRows(providers: readonly ModelProviderResponse[]) {
+  return SIDEBAR_SUBSCRIPTION_PROVIDERS.flatMap((definition) => {
+    const provider = providers.find((candidate) => {
+      return candidate.type === definition.type;
+    });
+    if (!provider) {
+      return [];
+    }
+    const usage = fallbackSubscriptionUsage(provider);
+    if (!usage || usageWindows(usage).length === 0) {
+      return [];
+    }
+    return [{ ...definition, usage }];
+  });
+}
+
+function hasUsageWindow(
+  window: SubscriptionUsage["fiveHour"],
+): window is SubscriptionUsageWindow {
+  return (
+    window !== null &&
+    (window.remainingPercent !== null ||
+      window.usedPercent !== null ||
+      window.resetAt !== null)
+  );
+}
+
+function formatUsagePercent(value: number | null): string | null {
+  if (value === null || !Number.isFinite(value)) {
+    return null;
+  }
+  const rounded = Math.round(value * 10) / 10;
+  return Number.isInteger(rounded) ? `${rounded}%` : `${rounded.toFixed(1)}%`;
+}
+
+function formatUsageReset(resetAt: string | null): string | null {
+  const text = resetAt?.trim();
+  if (!text) {
+    return null;
+  }
+  const date = new Date(text);
+  if (Number.isNaN(date.getTime())) {
+    return `resets ${text}`;
+  }
+  const options: Intl.DateTimeFormatOptions = {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZoneName: "short",
+  };
+  const browserTimeZone = new Intl.DateTimeFormat().resolvedOptions().timeZone;
+  if (browserTimeZone) {
+    options.timeZone = browserTimeZone;
+  }
+  return `resets ${date.toLocaleDateString("en-US", options)}`;
+}
+
+function fallbackSubscriptionUsage(
+  provider: ModelProviderResponse,
+): SubscriptionUsage | null {
+  if (usageWindows(provider.subscriptionUsage).length > 0) {
+    return provider.subscriptionUsage ?? null;
+  }
+
+  const resetAt = provider.subscriptionNextResetAt?.trim();
+  if (!resetAt) {
+    return null;
+  }
+
+  const resetPeriod = provider.subscriptionResetPeriod?.trim().toLowerCase();
+  const window = {
+    usedPercent: null,
+    remainingPercent: null,
+    resetAt,
+    windowSeconds: resetPeriod?.includes("5") ? 18_000 : 604_800,
+  };
+
+  return resetPeriod?.includes("5")
+    ? { fiveHour: window, weekly: null }
+    : { fiveHour: null, weekly: window };
+}
+
+function usageWindows(usage: SubscriptionUsage | null | undefined): readonly {
+  readonly label: string;
+  readonly window: SubscriptionUsageWindow;
+}[] {
+  return [
+    { label: "5h", window: usage?.fiveHour ?? null },
+    { label: "Week", window: usage?.weekly ?? null },
+  ].filter(
+    (item): item is { label: string; window: SubscriptionUsageWindow } => {
+      return hasUsageWindow(item.window);
+    },
+  );
+}
+
+function usageTone(remainingPercent: number | null): {
+  readonly barClassName: string;
+  readonly textClassName: string;
+  readonly trackClassName: string;
+} {
+  if (remainingPercent !== null && remainingPercent < 20) {
+    return {
+      barClassName: "bg-red-500",
+      textClassName: "text-red-600 dark:text-red-400",
+      trackClassName: "bg-red-500/15",
+    };
+  }
+  if (remainingPercent !== null && remainingPercent < 50) {
+    return {
+      barClassName: "bg-amber-500",
+      textClassName: "text-amber-600 dark:text-amber-400",
+      trackClassName: "bg-amber-500/15",
+    };
+  }
+  return {
+    barClassName: "bg-emerald-500",
+    textClassName: "text-emerald-600 dark:text-emerald-400",
+    trackClassName: "bg-emerald-500/15",
+  };
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -50,6 +50,7 @@ import { ChatThreadsSection } from "./sidebar-threads.tsx";
 import { PinnedAgentListSection } from "./zero-sidebar-pinned.tsx";
 import { OverlayScrollArea } from "./zero-sidebar-scroll.tsx";
 import { SidebarUpgradeCard } from "./zero-sidebar-upgrade.tsx";
+import { SidebarSubscriptionsGate } from "./zero-sidebar-subscriptions.tsx";
 
 export { AccountDropdown } from "./zero-sidebar-account.tsx";
 
@@ -563,6 +564,7 @@ function ExpandedFooter() {
             );
           },
         )}
+        <SidebarSubscriptionsGate />
         <div className="h-px bg-border/30 mx-1 my-1" />
         <ExpandedFooterAccountInsights />
       </div>

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -53,4 +53,5 @@ export enum FeatureSwitchKey {
   PresentationTemplateRunbook = "presentationTemplateRunbook",
   AgentUnreadIndicators = "agentUnreadIndicators",
   AgentsPageRedesign = "agentsPageRedesign",
+  SidebarSubscriptionUsage = "sidebarSubscriptionUsage",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -303,6 +303,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "New Agents page with Public/Private tabs, a public-slot indicator, a Created by footer on every card, a name-first create dialog with a visibility select, and a private empty state.",
     enabled: false,
   },
+  [FeatureSwitchKey.SidebarSubscriptionUsage]: {
+    maintainer: "ethan@vm0.ai",
+    description:
+      "Show Codex and Claude Code personal subscription usage in the Zero sidebar footer.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
 };
 
 interface ResolvedHashes {


### PR DESCRIPTION
## Summary
- add an org-enabled feature switch for sidebar subscription usage
- show Codex and Claude Code personal subscription usage under Where Zero works in the expanded sidebar footer
- add hover/focus reset-time tooltips on each usage bar and a manual refresh icon button for subscriptions

## Verification
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/core lint
- pnpm -F @vm0/core check-types
- pnpm -F @vm0/connectors lint
- pnpm -F @vm0/connectors check-types
- pnpm exec vitest run apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
- pnpm exec vitest run packages/core/src/__tests__/feature-switch.test.ts