### PR TITLE
fix: materialize presentation theme applied via setPalette/setFont calls

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/presentation-html-edit-protocol.test.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/presentation-html-edit-protocol.test.ts
@@ -61,6 +61,66 @@ describe("previewPresentationHtml", () => {
     expect(injectedCss).toContain("--fb:'Quicksand'");
   });
 
+  it("materializes theme applied via setPalette/setFont calls", () => {
+    const previewHtml = previewPresentationHtml({
+      activeSlideId: "slide-1",
+      html: `
+        <!doctype html>
+        <html>
+          <head>
+            <style>
+              :root {
+                --bg:#FFFFFF;
+                --accent:#7257E6;
+                --s1:#FF6B4A;
+                --s2:#AEE63E;
+                --s3:#3FA9F5;
+              }
+            </style>
+          </head>
+          <body>
+            <div class="slide" data-slide-id="slide-1">
+              <div class="stage">
+                <h1 style="color:var(--accent)">Slide</h1>
+              </div>
+            </div>
+            <script>
+              var MONO={
+                "Warm Sand":["#FFFDF8","#FFFFFF","#262626","#5A5A5A","#ECECEC",["#F19B3A","#8DACE5","#DDB8D9","#516049"]]
+              };
+              var VIB={
+                "Prism":["#FFFFFF","#F7F7FA","#1A1726","#5C5870","#ECECF2",["#7257E6","#FF6B4A","#AEE63E","#3FA9F5"]]
+              };
+              var FONTS={
+                "Archivo / Manrope":["Archivo","Manrope"]
+              };
+              function setPalette(v){}
+              function setFont(n){}
+              var sp={value:'V:Prism'},sf={value:'Poppins / Figtree'};
+              sp.value='M:Warm Sand';sf.value='Archivo / Manrope';
+              setPalette(sp.value);setFont(sf.value);
+            </script>
+          </body>
+        </html>
+      `,
+    });
+    const doc = new DOMParser().parseFromString(previewHtml, "text/html");
+    const injectedCss = Array.from(doc.querySelectorAll("style"))
+      .map((style) => {
+        return style.textContent ?? "";
+      })
+      .join("\n");
+
+    expect(doc.querySelector("script")).toBeNull();
+    expect(injectedCss).toContain("--bg:#FFFDF8");
+    expect(injectedCss).toContain("--accent:#F19B3A");
+    expect(injectedCss).toContain("--s1:#8DACE5");
+    expect(injectedCss).toContain("--s2:#DDB8D9");
+    expect(injectedCss).toContain("--s3:#516049");
+    expect(injectedCss).toContain("--fd:'Archivo'");
+    expect(injectedCss).toContain("--fb:'Manrope'");
+  });
+
   it("normalizes nested slide stages to fill the preview frame", () => {
     const previewHtml = previewPresentationHtml({
       activeSlideId: "slide-1",

--- a/turbo/apps/platform/src/views/zero-page/presentation-html-edit-protocol.ts
+++ b/turbo/apps/platform/src/views/zero-page/presentation-html-edit-protocol.ts
@@ -423,12 +423,10 @@ const SW_FONT_QUERY_SELECTOR_PATTERN =
 const SELECT_VALUE_ASSIGNMENT_PATTERN =
   /\b([A-Za-z_$][\w$]*)\.value\s*=\s*(['"])(.*?)\2/g;
 
-const SET_PALETTE_CALL_PATTERN = /\bsetPalette\s*\(\s*([^)]*?)\s*\)/g;
-const SET_FONT_CALL_PATTERN = /\bsetFont\s*\(\s*([^)]*?)\s*\)/g;
-
-const THEME_CALL_ARGUMENT_LITERAL_PATTERN = /^(['"])(.*)\1$/;
-const THEME_CALL_ARGUMENT_IDENTIFIER_PATTERN =
-  /^([A-Za-z_$][\w$]*)(?:\.value)?$/;
+const SET_PALETTE_CALL_PATTERN =
+  /\bsetPalette\s*\(\s*([A-Za-z_$][\w$]*)\.value\s*\)/g;
+const SET_FONT_CALL_PATTERN =
+  /\bsetFont\s*\(\s*([A-Za-z_$][\w$]*)\.value\s*\)/g;
 
 function collectPatternVariableNames(
   scriptText: string,
@@ -454,11 +452,13 @@ function extractSelectVariableNames(
     ? collectPatternVariableNames(scriptText, [
         SW_PAL_GET_BY_ID_PATTERN,
         SW_PAL_QUERY_SELECTOR_PATTERN,
+        SET_PALETTE_CALL_PATTERN,
       ])
     : selectId === THEME_SWITCHER_SELECT_IDS.font
       ? collectPatternVariableNames(scriptText, [
           SW_FONT_GET_BY_ID_PATTERN,
           SW_FONT_QUERY_SELECTOR_PATTERN,
+          SET_FONT_CALL_PATTERN,
         ])
       : new Set<string>();
 }
@@ -477,63 +477,13 @@ function extractAssignedString(
   return null;
 }
 
-function resolveThemeCallArgument(
-  scriptText: string,
-  argument: string,
-): string | null {
-  const literalMatch = THEME_CALL_ARGUMENT_LITERAL_PATTERN.exec(argument);
-  if (literalMatch) {
-    return literalMatch[2] ?? null;
-  }
-  const identifierMatch = THEME_CALL_ARGUMENT_IDENTIFIER_PATTERN.exec(argument);
-  if (!identifierMatch?.[1]) {
-    return null;
-  }
-  return extractAssignedString(scriptText, new Set([identifierMatch[1]]));
-}
-
-function extractAppliedThemeValue(
-  scriptText: string,
-  callPattern: RegExp,
-): string | null {
-  callPattern.lastIndex = 0;
-  let resolved: string | null = null;
-  for (const match of scriptText.matchAll(callPattern)) {
-    const argument = match[1]?.trim();
-    if (!argument) {
-      continue;
-    }
-    const value = resolveThemeCallArgument(scriptText, argument);
-    if (value) {
-      resolved = value;
-    }
-  }
-  return resolved;
-}
-
-function selectedThemeValueFromScript(
-  scriptText: string,
-  target: "font" | "palette",
-): string | null {
-  const applyPattern =
-    target === "palette" ? SET_PALETTE_CALL_PATTERN : SET_FONT_CALL_PATTERN;
-  const selectId =
-    target === "palette"
-      ? THEME_SWITCHER_SELECT_IDS.palette
-      : THEME_SWITCHER_SELECT_IDS.font;
-  return (
-    extractAppliedThemeValue(scriptText, applyPattern) ??
-    extractAssignedString(
-      scriptText,
-      extractSelectVariableNames(scriptText, selectId),
-    )
-  );
-}
-
 function selectedPaletteFromScript(
   scriptText: string,
 ): PresentationPalette | null {
-  const selectedPalette = selectedThemeValueFromScript(scriptText, "palette");
+  const selectedPalette = extractAssignedString(
+    scriptText,
+    extractSelectVariableNames(scriptText, THEME_SWITCHER_SELECT_IDS.palette),
+  );
   const paletteMatch = /^([MV]):(.+)$/.exec(selectedPalette ?? "");
   if (!paletteMatch?.[1] || !paletteMatch[2]) {
     return null;
@@ -548,7 +498,10 @@ function selectedPaletteFromScript(
 function selectedFontPairFromScript(
   scriptText: string,
 ): PresentationFontPair | null {
-  const selectedFont = selectedThemeValueFromScript(scriptText, "font");
+  const selectedFont = extractAssignedString(
+    scriptText,
+    extractSelectVariableNames(scriptText, THEME_SWITCHER_SELECT_IDS.font),
+  );
   if (!selectedFont) {
     return null;
   }

--- a/turbo/apps/platform/src/views/zero-page/presentation-html-edit-protocol.ts
+++ b/turbo/apps/platform/src/views/zero-page/presentation-html-edit-protocol.ts
@@ -423,6 +423,13 @@ const SW_FONT_QUERY_SELECTOR_PATTERN =
 const SELECT_VALUE_ASSIGNMENT_PATTERN =
   /\b([A-Za-z_$][\w$]*)\.value\s*=\s*(['"])(.*?)\2/g;
 
+const SET_PALETTE_CALL_PATTERN = /\bsetPalette\s*\(\s*([^)]*?)\s*\)/g;
+const SET_FONT_CALL_PATTERN = /\bsetFont\s*\(\s*([^)]*?)\s*\)/g;
+
+const THEME_CALL_ARGUMENT_LITERAL_PATTERN = /^(['"])(.*)\1$/;
+const THEME_CALL_ARGUMENT_IDENTIFIER_PATTERN =
+  /^([A-Za-z_$][\w$]*)(?:\.value)?$/;
+
 function collectPatternVariableNames(
   scriptText: string,
   patterns: readonly RegExp[],
@@ -470,13 +477,63 @@ function extractAssignedString(
   return null;
 }
 
+function resolveThemeCallArgument(
+  scriptText: string,
+  argument: string,
+): string | null {
+  const literalMatch = THEME_CALL_ARGUMENT_LITERAL_PATTERN.exec(argument);
+  if (literalMatch) {
+    return literalMatch[2] ?? null;
+  }
+  const identifierMatch = THEME_CALL_ARGUMENT_IDENTIFIER_PATTERN.exec(argument);
+  if (!identifierMatch?.[1]) {
+    return null;
+  }
+  return extractAssignedString(scriptText, new Set([identifierMatch[1]]));
+}
+
+function extractAppliedThemeValue(
+  scriptText: string,
+  callPattern: RegExp,
+): string | null {
+  callPattern.lastIndex = 0;
+  let resolved: string | null = null;
+  for (const match of scriptText.matchAll(callPattern)) {
+    const argument = match[1]?.trim();
+    if (!argument) {
+      continue;
+    }
+    const value = resolveThemeCallArgument(scriptText, argument);
+    if (value) {
+      resolved = value;
+    }
+  }
+  return resolved;
+}
+
+function selectedThemeValueFromScript(
+  scriptText: string,
+  target: "font" | "palette",
+): string | null {
+  const applyPattern =
+    target === "palette" ? SET_PALETTE_CALL_PATTERN : SET_FONT_CALL_PATTERN;
+  const selectId =
+    target === "palette"
+      ? THEME_SWITCHER_SELECT_IDS.palette
+      : THEME_SWITCHER_SELECT_IDS.font;
+  return (
+    extractAppliedThemeValue(scriptText, applyPattern) ??
+    extractAssignedString(
+      scriptText,
+      extractSelectVariableNames(scriptText, selectId),
+    )
+  );
+}
+
 function selectedPaletteFromScript(
   scriptText: string,
 ): PresentationPalette | null {
-  const selectedPalette = extractAssignedString(
-    scriptText,
-    extractSelectVariableNames(scriptText, THEME_SWITCHER_SELECT_IDS.palette),
-  );
+  const selectedPalette = selectedThemeValueFromScript(scriptText, "palette");
   const paletteMatch = /^([MV]):(.+)$/.exec(selectedPalette ?? "");
   if (!paletteMatch?.[1] || !paletteMatch[2]) {
     return null;
@@ -491,10 +548,7 @@ function selectedPaletteFromScript(
 function selectedFontPairFromScript(
   scriptText: string,
 ): PresentationFontPair | null {
-  const selectedFont = extractAssignedString(
-    scriptText,
-    extractSelectVariableNames(scriptText, THEME_SWITCHER_SELECT_IDS.font),
-  );
+  const selectedFont = selectedThemeValueFromScript(scriptText, "font");
   if (!selectedFont) {
     return null;
   }


### PR DESCRIPTION
## Problem

When editing a presentation or exporting it to PPTX, the runtime `<script>` tags are stripped, so the selected theme must be **statically materialized** first (`materializePresentationThemeSwitcherDefaults`). Materialization works in two steps: (1) discover which variable holds the selected palette/font, then (2) read that variable's `.value = '...'` assignment.

Step 1 only recognized the old `swPal`/`swFont` `<select>` switcher, where the variable is revealed by a DOM lookup:

```js
var el = document.getElementById('swPal'); el.value = 'M:...';
```

Newer generated decks have no `<select>`. They apply the theme by calling `setPalette(sp.value)` / `setFont(sf.value)` on plain `{value}` objects:

```js
var sp = {value:'V:Prism'}, sf = {value:'Poppins / Figtree'};
sp.value = 'M:Warm Sand'; sf.value = 'Archivo / Manrope';
setPalette(sp.value); setFont(sf.value);
```

Here step 1 found nothing (no `getElementById('swPal')`), so materialization returned nothing and the deck fell back to the **source default palette** (e.g. Prism) instead of the runtime-selected one (e.g. Warm Sand). Result: slide backgrounds render with the wrong colors in the editor preview and PPTX export, even though the live site looks correct.

Repro: https://england-news-june-30-2026-715f6d07-59201106.sites.vm0.io — live slide 1 background is Warm Sand `#DDB8D9` (via `--g2`), but editing/exporting falls back to the Prism default.

## Fix

The variable holding the selection is revealed by the `setPalette(sp.value)` / `setFont(sf.value)` call. Add two regexes that capture that identifier and feed it into the **existing** variable-name collector (`extractSelectVariableNames`), so the unchanged step-2 resolver then reads `sp.value = 'M:Warm Sand'`.

This reuses the existing `.value` assignment resolver — the new patterns are just a third source of variable names alongside the existing `swPal`/`swFont` lookups. The old select format keeps working unchanged; when no `setPalette`/`setFont` call is present, nothing new matches. Net change: 2 constants + 2 wiring lines.

## Test

Added a test exercising the `setPalette(sp.value)` / `setFont(sf.value)` format (including decoy `function setPalette(v){}` definitions) and asserting the materialized CSS carries the runtime-selected Warm Sand palette + Archivo/Manrope fonts rather than the Prism source default. The existing `swPal`/`swFont` test remains green. Both the editor preview and PPTX export share `materializePresentationThemeSwitcherDefaults`, so this one path covers both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
