### PR TITLE
fix: render thread model before defaults resolve

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -1190,10 +1190,10 @@ describe("chat composer models", () => {
 
     detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
 
-    await waitFor(() => {
-      expect(preferenceRequestStarted).toBeTruthy();
-    });
     try {
+      await waitFor(() => {
+        expect(preferenceRequestStarted).toBeTruthy();
+      });
       await expectComposerModel("GLM-5.1");
     } finally {
       pendingPreference.resolve();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -1159,7 +1159,8 @@ describe("chat composer models", () => {
     await expectComposerModel("Claude Sonnet 4.6");
   });
 
-  it("renders thread override before user default model selection resolves", async () => {
+  it("edits thread override before user default model selection resolves", async () => {
+    const user = userEvent.setup({ delay: null });
     const pendingPreference = context.mocks.deferred<void>();
     let preferenceRequestStarted = false;
 
@@ -1195,6 +1196,11 @@ describe("chat composer models", () => {
         expect(preferenceRequestStarted).toBeTruthy();
       });
       await expectComposerModel("GLM-5.1");
+      await user.click(screen.getByRole("combobox", { name: "GLM-5.1" }));
+      await user.click(
+        await screen.findByRole("option", { name: /Claude Sonnet 4\.6/ }),
+      );
+      await expectComposerModel("Claude Sonnet 4.6");
     } finally {
       pendingPreference.resolve();
     }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -1159,6 +1159,47 @@ describe("chat composer models", () => {
     await expectComposerModel("Claude Sonnet 4.6");
   });
 
+  it("renders thread override before user default model selection resolves", async () => {
+    const pendingPreference = context.mocks.deferred<void>();
+    let preferenceRequestStarted = false;
+
+    mockOrgModelRoutes("kimi-k2.7-code");
+    context.mocks.api(
+      zeroUserModelPreferenceContract.get,
+      async ({ respond, withSignal }) => {
+        preferenceRequestStarted = true;
+        await withSignal(pendingPreference.promise);
+        return respond(200, {
+          selectedModel: "claude-opus-4-7",
+          updatedAt: "2026-03-10T00:00:00Z",
+        });
+      },
+    );
+    mockAgent();
+    mockThread({
+      selectedModel: "glm-5.1",
+      messages: [
+        {
+          id: "msg-user",
+          role: "user",
+          content: "Use GLM",
+          createdAt: "2026-03-10T00:01:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+
+    await waitFor(() => {
+      expect(preferenceRequestStarted).toBeTruthy();
+    });
+    try {
+      await expectComposerModel("GLM-5.1");
+    } finally {
+      pendingPreference.resolve();
+    }
+  });
+
   it("opens compare plans from limited-free-1 Pro composer model items", async () => {
     const user = userEvent.setup({ delay: null });
     mockBillingTier("limited-free-1");

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -4684,8 +4684,8 @@ function useChatComposerModel(
     disabled: false,
     defaultSelection: defaultModelSelection,
   });
-  // Skeleton only on cold start (nothing has ever resolved). Once we have any
-  // resolved value, refetches reuse the cached value instead of flashing.
+  // Explicit thread selections can render before default model selection
+  // resolves; only inherited selections need that fallback before showing.
   const modelPickerLoading =
     threadDataResolved === undefined ||
     modelSelectionResolved === undefined ||

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -4689,7 +4689,8 @@ function useChatComposerModel(
   const modelPickerLoading =
     threadDataResolved === undefined ||
     modelSelectionResolved === undefined ||
-    defaultModelSelectionResolved === undefined;
+    (modelSelectionResolved === null &&
+      defaultModelSelectionResolved === undefined);
   const submitBlockerProps = resolveChatComposerSubmitBlocker({
     state: modelFirstOauthState,
     modelSelection,


### PR DESCRIPTION
## Summary
- Render explicit thread model selections without waiting for default model preference resolution.
- Keep default selection loading required only when the thread inherits the default model.
- Add a page-level regression test that holds user model preference loading while a thread override renders and remains editable.

Closes #19672

## Tests
- pnpm -F @vm0/app exec vitest src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx --run -t "edits thread override before user default model selection resolves"
- pnpm -F @vm0/app exec vitest src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx --run -t "thread override"
- pnpm -F @vm0/app exec vitest src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx --run
- pnpm vitest run --project=@vm0/app --shard=4/8 --coverage.enabled --coverage.reporter=json
- pnpm -F @vm0/app run --if-present lint
- pnpm -F @vm0/app run --if-present check-types
- pre-commit hook: prettier, knip, turbo check-types
