### PR TITLE
test: bound guest-mock-codex cli runner

### DIFF
--- a/crates/guest-mock-codex/tests/integration.rs
+++ b/crates/guest-mock-codex/tests/integration.rs
@@ -8,7 +8,7 @@
 use std::collections::BTreeSet;
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Child, ChildStdin, Command, ExitStatus, Stdio};
+use std::process::{Child, ChildStdin, Command, ExitStatus, Output, Stdio};
 use std::sync::mpsc::{self, Receiver};
 use std::thread::JoinHandle;
 use std::time::Duration;
@@ -22,6 +22,8 @@ use serde_json::{Value, json};
 use tempfile::TempDir;
 
 const BIN: &str = env!("CARGO_BIN_EXE_guest-mock-codex");
+const CLI_RUN_TIMEOUT: Duration = Duration::from_secs(10);
+const CLI_RUN_KILL_TIMEOUT: Duration = Duration::from_secs(5);
 const APP_SERVER_READ_TIMEOUT: Duration = Duration::from_secs(5);
 const APP_SERVER_EXIT_TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -47,7 +49,7 @@ fn run_with_env(
     for (k, v) in env {
         cmd.env(k, v);
     }
-    let output = cmd.output()?;
+    let output = output_with_timeout(cmd, args)?;
 
     let stdout = String::from_utf8(output.stdout)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
@@ -68,6 +70,96 @@ fn run_with_env(
         status: output.status.code().unwrap_or(-1),
         stderr,
     })
+}
+
+fn output_with_timeout(mut cmd: Command, args: &[&str]) -> std::io::Result<Output> {
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let child = cmd.spawn()?;
+    let pid = child.id();
+    let (tx, rx) = mpsc::channel();
+    let wait_thread = std::thread::spawn(move || {
+        let result = child.wait_with_output();
+        let _ = tx.send(result);
+    });
+
+    match rx.recv_timeout(CLI_RUN_TIMEOUT) {
+        Ok(result) => {
+            wait_thread
+                .join()
+                .map_err(|_| std::io::Error::other("guest-mock-codex CLI wait thread panicked"))?;
+            result
+        }
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            // SAFETY: this is test cleanup for the child process spawned by this helper.
+            unsafe {
+                libc::kill(pid as libc::pid_t, libc::SIGKILL);
+            }
+            match rx.recv_timeout(CLI_RUN_KILL_TIMEOUT) {
+                Ok(Ok(output)) => {
+                    wait_thread.join().map_err(|_| {
+                        std::io::Error::other("guest-mock-codex CLI wait thread panicked")
+                    })?;
+                    Err(cli_run_timeout_error(args, Some(&output), None))
+                }
+                Ok(Err(err)) => {
+                    wait_thread.join().map_err(|_| {
+                        std::io::Error::other("guest-mock-codex CLI wait thread panicked")
+                    })?;
+                    Err(cli_run_timeout_error(args, None, Some(&err)))
+                }
+                Err(mpsc::RecvTimeoutError::Timeout) => Err(cli_run_timeout_error_after_kill(args)),
+                Err(mpsc::RecvTimeoutError::Disconnected) => {
+                    wait_thread.join().map_err(|_| {
+                        std::io::Error::other("guest-mock-codex CLI wait thread panicked")
+                    })?;
+                    Err(std::io::Error::other(
+                        "guest-mock-codex CLI wait thread exited without output",
+                    ))
+                }
+            }
+        }
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            wait_thread
+                .join()
+                .map_err(|_| std::io::Error::other("guest-mock-codex CLI wait thread panicked"))?;
+            Err(std::io::Error::other(
+                "guest-mock-codex CLI wait thread exited without output",
+            ))
+        }
+    }
+}
+
+fn cli_run_timeout_error(
+    args: &[&str],
+    output: Option<&Output>,
+    wait_error: Option<&std::io::Error>,
+) -> std::io::Error {
+    let mut message =
+        format!("guest-mock-codex CLI timed out after {CLI_RUN_TIMEOUT:?}: args={args:?}");
+    if let Some(output) = output {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        message.push_str(&format!(
+            "; status={:?}; stdout={stdout:?}; stderr={stderr:?}",
+            output.status
+        ));
+    }
+    if let Some(err) = wait_error {
+        message.push_str(&format!("; wait_with_output after kill failed: {err}"));
+    }
+    std::io::Error::new(std::io::ErrorKind::TimedOut, message)
+}
+
+fn cli_run_timeout_error_after_kill(args: &[&str]) -> std::io::Error {
+    std::io::Error::new(
+        std::io::ErrorKind::TimedOut,
+        format!(
+            "guest-mock-codex CLI timed out after {CLI_RUN_TIMEOUT:?} and did not exit within \
+             {CLI_RUN_KILL_TIMEOUT:?} after SIGKILL: args={args:?}"
+        ),
+    )
 }
 
 fn spawn(codex_home: &Path, args: &[&str]) -> std::io::Result<Child> {


### PR DESCRIPTION
## Summary
- replace the one-shot guest-mock-codex integration helper's unbounded Command::output() call with a bounded output runner
- preserve existing stdout JSONL parsing and stderr/status behavior on successful runs
- kill and reap timed-out CLI children and include args/stdout/stderr diagnostics when available

## Tests
- cargo test --manifest-path crates/Cargo.toml -p guest-mock-codex resume_rejects_special_session_file_without_hanging
- cargo test --manifest-path crates/Cargo.toml -p guest-mock-codex resume_rejects_special_lock_file_without_events
- cargo test --manifest-path crates/Cargo.toml -p guest-mock-codex
- cargo fmt --manifest-path crates/Cargo.toml -p guest-mock-codex -- --check
- cargo clippy --manifest-path crates/Cargo.toml -p guest-mock-codex --all-targets -- -D warnings
- git diff --check

Closes #19658