### PR TITLE
test(mitm-addon): use diagnostic request lifecycle in hook tests

### DIFF
--- a/crates/runner/mitm-addon/tests/connector_diagnostic_helpers.py
+++ b/crates/runner/mitm-addon/tests/connector_diagnostic_helpers.py
@@ -1,0 +1,33 @@
+"""Helpers for connector diagnostic hook lifecycle tests."""
+
+from pathlib import Path
+
+from mitmproxy import http
+
+import mitm_addon
+from tests.request_handler_helpers import _vm_without_firewalls, _write_registry
+
+CONNECTOR_DIAGNOSTIC_REQUEST_CHUNK = b"partial request"
+
+
+def write_connector_diagnostic_capture_registry(tmp_path: Path) -> Path:
+    return _write_registry(
+        tmp_path,
+        vm_info=_vm_without_firewalls(
+            tmp_path,
+            vm_fields={"captureNetworkBodies": True},
+        ),
+    )
+
+
+def record_connector_diagnostic_requestheaders_context(
+    flow: http.HTTPFlow,
+    *,
+    request_chunk: bytes = CONNECTOR_DIAGNOSTIC_REQUEST_CHUNK,
+) -> bytes:
+    result = mitm_addon.requestheaders(flow)
+    assert result is None
+    stream = flow.request.stream
+    assert callable(stream)
+    assert stream(request_chunk) == request_chunk
+    return request_chunk

--- a/crates/runner/mitm-addon/tests/test_error_handler.py
+++ b/crates/runner/mitm-addon/tests/test_error_handler.py
@@ -14,6 +14,10 @@ import mitm_addon
 import request_streaming
 import upstream_destination_binding
 import usage
+from tests.connector_diagnostic_helpers import (
+    record_connector_diagnostic_requestheaders_context,
+    write_connector_diagnostic_capture_registry,
+)
 from tests.flow_helpers import header_map, response_stream
 from tests.jsonl_log_helpers import (
     jsonl_exists_after_flush,
@@ -25,19 +29,6 @@ from tests.request_handler_helpers import (
     _write_registry,
 )
 from tests.timestamp_helpers import assert_utc_millisecond_timestamp
-
-
-def _prepare_legacy_connector_diagnostic_flow(tmp_path, flow, *, capture_body: bool = False):
-    flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
-    flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = str(tmp_path / "net.jsonl")
-    flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = str(tmp_path / "proxy.jsonl")
-    flow.metadata[metadata_keys.CAPTURE_BODY] = capture_body
-    flow.metadata[metadata_keys.ORIGINAL_URL] = (
-        f"https://{flow.request.pretty_host}{flow.request.path}"
-    )
-    flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
-    flow.metadata[mitm_addon._CONNECTOR_DIAGNOSTIC_ELIGIBLE] = True
-    flow.metadata[mitm_addon._CONNECTOR_DIAGNOSTIC_ACTIVE_FIREWALL_NAMES] = ()
 
 
 class TestErrorHandler:
@@ -112,6 +103,7 @@ class TestErrorHandler:
     async def test_connector_candidate_error_gets_local_diagnostic_response(
         self, tmp_path, real_flow, mitm_ctx
     ):
+        reg_path = write_connector_diagnostic_capture_registry(tmp_path)
         flow = real_flow(
             with_response=False,
             client_ip="10.200.0.5",
@@ -119,9 +111,9 @@ class TestErrorHandler:
             path="/fal-ai/nano-banana-pro",
             method="POST",
         )
-        _prepare_legacy_connector_diagnostic_flow(tmp_path, flow)
 
-        with mitm_ctx():
+        with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+            record_connector_diagnostic_requestheaders_context(flow)
             flow.error = Error("connection reset by peer")
             mitm_addon.error(flow)
 
@@ -152,10 +144,7 @@ class TestErrorHandler:
     def test_streamed_connector_candidate_error_before_request_gets_diagnostic(
         self, tmp_path, real_flow, mitm_ctx
     ):
-        reg_path = _write_registry(
-            tmp_path,
-            vm_info=_vm_without_firewalls(tmp_path, vm_fields={"captureNetworkBodies": True}),
-        )
+        reg_path = write_connector_diagnostic_capture_registry(tmp_path)
         flow = real_flow(
             with_response=False,
             client_ip="10.200.0.5",
@@ -165,10 +154,7 @@ class TestErrorHandler:
         )
 
         with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
-            mitm_addon.requestheaders(flow)
-            stream = flow.request.stream
-            assert callable(stream)
-            assert stream(b"partial request") == b"partial request"
+            request_chunk = record_connector_diagnostic_requestheaders_context(flow)
             flow.error = Error("connection reset by peer")
             mitm_addon.error(flow)
 
@@ -182,7 +168,7 @@ class TestErrorHandler:
 
         [entry] = read_jsonl_entries_after_flush(tmp_path / "net.jsonl")
         assert entry["status"] == 0
-        assert entry["request_size"] == len(b"partial request")
+        assert entry["request_size"] == len(request_chunk)
         assert entry["error"] == "connection reset by peer"
         assert entry["firewall_error"] == "connector_not_configured_for_run"
         assert entry["connector_diagnostic_type"] == "fal"
@@ -194,6 +180,7 @@ class TestErrorHandler:
     def test_header_phase_connector_diagnostic_error_keeps_connection_error(
         self, tmp_path, real_flow, mitm_ctx
     ):
+        reg_path = write_connector_diagnostic_capture_registry(tmp_path)
         flow = real_flow(
             with_response=False,
             client_ip="10.200.0.5",
@@ -201,9 +188,9 @@ class TestErrorHandler:
             path="/fal-ai/nano-banana-pro",
             method="POST",
         )
-        _prepare_legacy_connector_diagnostic_flow(tmp_path, flow)
 
-        with mitm_ctx():
+        with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+            record_connector_diagnostic_requestheaders_context(flow)
             flow.response = tutils.tresp(
                 status_code=401,
                 headers=header_map({"content-type": "text/plain"}),

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -22,6 +22,10 @@ from tests.auth_state_helpers import (
     set_cached_headers,
     set_last_force_refresh_monotonic_at,
 )
+from tests.connector_diagnostic_helpers import (
+    record_connector_diagnostic_requestheaders_context,
+    write_connector_diagnostic_capture_registry,
+)
 from tests.flow_helpers import header_map, response_stream
 from tests.jsonl_log_helpers import (
     jsonl_exists_after_flush,
@@ -36,19 +40,6 @@ from tests.requestheaders_helpers import await_requestheaders_result
 from tests.timestamp_helpers import assert_utc_millisecond_timestamp
 
 
-def _prepare_legacy_connector_diagnostic_flow(tmp_path, flow, *, capture_body: bool = False):
-    flow.metadata[metadata_keys.VM_RUN_ID] = "run-abc-123"
-    flow.metadata[metadata_keys.VM_NETWORK_LOG_PATH] = str(tmp_path / "net.jsonl")
-    flow.metadata[metadata_keys.VM_PROXY_LOG_PATH] = str(tmp_path / "proxy.jsonl")
-    flow.metadata[metadata_keys.CAPTURE_BODY] = capture_body
-    flow.metadata[metadata_keys.ORIGINAL_URL] = (
-        f"https://{flow.request.pretty_host}{flow.request.path}"
-    )
-    flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
-    flow.metadata[mitm_addon._CONNECTOR_DIAGNOSTIC_ELIGIBLE] = True
-    flow.metadata[mitm_addon._CONNECTOR_DIAGNOSTIC_ACTIVE_FIREWALL_NAMES] = ()
-
-
 def _drain_connector_diagnostic_response_stream(flow, *, upstream_chunk: bytes = b"upstream"):
     stream = response_stream(flow)
     assert stream(upstream_chunk) == ()
@@ -61,6 +52,7 @@ def _drain_connector_diagnostic_response_stream(flow, *, upstream_chunk: bytes =
 
 class TestResponseHandler:
     async def test_replaces_unauthenticated_connector_401_body(self, tmp_path, real_flow, mitm_ctx):
+        reg_path = write_connector_diagnostic_capture_registry(tmp_path)
         flow = real_flow(
             with_response=False,
             client_ip="10.200.0.5",
@@ -68,9 +60,9 @@ class TestResponseHandler:
             path="/fal-ai/nano-banana-pro",
             method="POST",
         )
-        _prepare_legacy_connector_diagnostic_flow(tmp_path, flow)
 
-        with mitm_ctx():
+        with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+            record_connector_diagnostic_requestheaders_context(flow)
             flow.response = tutils.tresp(
                 status_code=401,
                 headers=header_map({"content-type": "text/plain", "content-length": "8"}),
@@ -111,6 +103,7 @@ class TestResponseHandler:
     async def test_streams_unauthenticated_connector_401_diagnostic_without_upstream_body(
         self, tmp_path, real_flow, mitm_ctx
     ):
+        reg_path = write_connector_diagnostic_capture_registry(tmp_path)
         flow = real_flow(
             with_response=False,
             client_ip="10.200.0.5",
@@ -118,10 +111,10 @@ class TestResponseHandler:
             path="/fal-ai/nano-banana-pro",
             method="POST",
         )
-        _prepare_legacy_connector_diagnostic_flow(tmp_path, flow, capture_body=True)
         upstream_chunk = b"discarded-upstream-body-" * 1024
 
-        with mitm_ctx():
+        with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+            record_connector_diagnostic_requestheaders_context(flow)
             flow.response = tutils.tresp(
                 status_code=401,
                 headers=header_map(
@@ -171,6 +164,7 @@ class TestResponseHandler:
     async def test_restores_connector_diagnostic_body_when_headers_end_stream(
         self, tmp_path, real_flow, mitm_ctx
     ):
+        reg_path = write_connector_diagnostic_capture_registry(tmp_path)
         flow = real_flow(
             with_response=False,
             client_ip="10.200.0.5",
@@ -178,9 +172,9 @@ class TestResponseHandler:
             path="/fal-ai/nano-banana-pro",
             method="POST",
         )
-        _prepare_legacy_connector_diagnostic_flow(tmp_path, flow, capture_body=True)
 
-        with mitm_ctx():
+        with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+            record_connector_diagnostic_requestheaders_context(flow)
             flow.response = tutils.tresp(
                 status_code=401,
                 headers=header_map({"content-type": "text/plain"}),
@@ -526,6 +520,7 @@ class TestResponseHandler:
     async def test_replaces_connector_401_body_when_auth_header_has_empty_bearer_token(
         self, tmp_path, real_flow, mitm_ctx, headers
     ):
+        reg_path = write_connector_diagnostic_capture_registry(tmp_path)
         flow = real_flow(
             with_response=False,
             client_ip="10.200.0.5",
@@ -537,9 +532,9 @@ class TestResponseHandler:
                 ("Authorization", "Bearer "),
             ),
         )
-        _prepare_legacy_connector_diagnostic_flow(tmp_path, flow)
 
-        with mitm_ctx():
+        with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+            record_connector_diagnostic_requestheaders_context(flow)
             flow.response = tutils.tresp(
                 status_code=401,
                 headers=header_map({"content-type": "text/plain"}),
@@ -560,6 +555,7 @@ class TestResponseHandler:
     async def test_replaces_connector_401_body_when_only_proxy_authorization_is_present(
         self, tmp_path, real_flow, mitm_ctx, headers
     ):
+        reg_path = write_connector_diagnostic_capture_registry(tmp_path)
         flow = real_flow(
             with_response=False,
             client_ip="10.200.0.5",
@@ -571,9 +567,9 @@ class TestResponseHandler:
                 ("Proxy-Authorization", "Basic proxy-secret"),
             ),
         )
-        _prepare_legacy_connector_diagnostic_flow(tmp_path, flow)
 
-        with mitm_ctx():
+        with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+            record_connector_diagnostic_requestheaders_context(flow)
             flow.response = tutils.tresp(
                 status_code=401,
                 headers=header_map({"content-type": "text/plain"}),
@@ -594,6 +590,7 @@ class TestResponseHandler:
     async def test_replaces_connector_401_body_when_auth_header_has_empty_key_token(
         self, tmp_path, real_flow, mitm_ctx, headers
     ):
+        reg_path = write_connector_diagnostic_capture_registry(tmp_path)
         flow = real_flow(
             with_response=False,
             client_ip="10.200.0.5",
@@ -605,9 +602,9 @@ class TestResponseHandler:
                 ("Authorization", "Key "),
             ),
         )
-        _prepare_legacy_connector_diagnostic_flow(tmp_path, flow)
 
-        with mitm_ctx():
+        with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+            record_connector_diagnostic_requestheaders_context(flow)
             flow.response = tutils.tresp(
                 status_code=401,
                 headers=header_map({"content-type": "text/plain"}),
@@ -628,6 +625,7 @@ class TestResponseHandler:
     async def test_replaces_connector_401_body_when_auth_query_param_is_empty(
         self, tmp_path, real_flow, mitm_ctx
     ):
+        reg_path = write_connector_diagnostic_capture_registry(tmp_path)
         flow = real_flow(
             with_response=False,
             client_ip="10.200.0.5",
@@ -635,9 +633,9 @@ class TestResponseHandler:
             path="/fal-ai/nano-banana-pro?api_key=",
             method="POST",
         )
-        _prepare_legacy_connector_diagnostic_flow(tmp_path, flow)
 
-        with mitm_ctx():
+        with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+            record_connector_diagnostic_requestheaders_context(flow)
             flow.response = tutils.tresp(
                 status_code=401,
                 headers=header_map({"content-type": "text/plain"}),


### PR DESCRIPTION
## Summary

- replace connector diagnostic private metadata seeding in response/error hook tests with a registry-backed `requestheaders()` setup
- add a narrow connector diagnostic test helper that drives the real requestheaders lifecycle and request stream
- remove duplicated `_prepare_legacy_connector_diagnostic_flow()` helpers from error/response tests

Closes #19657

## Tests

- `.venv/bin/python -m pytest tests/test_error_handler.py tests/test_response_handler.py tests/test_request_handler_firewall_dispatch.py tests/test_builtin_connector_diagnostics.py`
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/basedpyright -p .`
