### PR TITLE
fix: sanitize runner api urls in webhook logs

### DIFF
--- a/crates/runner/mitm-addon/src/usage/webhook.py
+++ b/crates/runner/mitm-addon/src/usage/webhook.py
@@ -16,6 +16,7 @@ from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from typing import Literal
 
+import network_log_sanitization
 from logging_utils import log_proxy_entry
 from platform_api import make_api_request
 
@@ -63,7 +64,7 @@ def _payload_log_summary(payload: dict) -> dict:
 def _log_webhook_entry(
     proxy_log_path: str,
     level: str,
-    message: str,
+    message_detail: str,
     url: str,
     log_type: str,
     payload: dict,
@@ -72,6 +73,9 @@ def _log_webhook_entry(
     error: str | None = None,
     extra_fields: dict[str, object] | None = None,
 ) -> None:
+    display_url = network_log_sanitization.sanitize_url_for_network_log(url)
+    safe_message_detail = _sanitize_webhook_log_text(message_detail, url, display_url)
+    message = f"Webhook POST to {display_url} {safe_message_detail}"
     extra: dict = {"type": log_type, "url": url}
     extra.update(_payload_log_summary(payload))
     if payload_bytes is not None:
@@ -79,10 +83,16 @@ def _log_webhook_entry(
     if attempt is not None:
         extra["attempt"] = attempt
     if error is not None:
-        extra["error"] = error
+        extra["error"] = _sanitize_webhook_log_text(error, url, display_url)
     if extra_fields is not None:
         extra.update(extra_fields)
     log_proxy_entry(proxy_log_path, level, message, **extra)
+
+
+def _sanitize_webhook_log_text(value: str, raw_url: str, display_url: str) -> str:
+    if not raw_url:
+        return value
+    return value.replace(raw_url, display_url)
 
 
 def _post_webhook(url: str, sandbox_token: str, data: bytes) -> None:
@@ -147,7 +157,7 @@ def _handle_retryable_webhook_failure(
         _log_webhook_entry(
             proxy_log_path,
             "info",
-            f"Webhook POST to {url} attempt {attempt_number} failed, retrying: {exc}",
+            f"attempt {attempt_number} failed, retrying: {exc}",
             url,
             log_type,
             payload,
@@ -161,7 +171,7 @@ def _handle_retryable_webhook_failure(
     _log_webhook_entry(
         proxy_log_path,
         "info",
-        f"Webhook POST to {url} failed after {attempt_number} attempts: {exc}",
+        f"failed after {attempt_number} attempts: {exc}",
         url,
         log_type,
         payload,
@@ -187,7 +197,7 @@ def _do_post_webhook_attempts(
         _log_webhook_entry(
             proxy_log_path,
             "error",
-            f"Webhook POST to {url} failed with non-retryable error: {exc}",
+            f"failed with non-retryable error: {exc}",
             url,
             log_type,
             payload,
@@ -203,7 +213,7 @@ def _do_post_webhook_attempts(
             _log_webhook_entry(
                 proxy_log_path,
                 "info",
-                f"Webhook POST to {url} succeeded",
+                "succeeded",
                 url,
                 log_type,
                 payload,
@@ -216,7 +226,7 @@ def _do_post_webhook_attempts(
                 _log_webhook_entry(
                     proxy_log_path,
                     "error",
-                    f"Webhook POST to {url} failed with permanent HTTP error: {exc}",
+                    f"failed with permanent HTTP error: {exc}",
                     url,
                     log_type,
                     payload,
@@ -260,7 +270,7 @@ def _do_post_webhook_attempts(
             _log_webhook_entry(
                 proxy_log_path,
                 "error",
-                f"Webhook POST to {url} failed with non-retryable error: {exc}",
+                f"failed with non-retryable error: {exc}",
                 url,
                 log_type,
                 payload,
@@ -368,7 +378,7 @@ def _enqueue_webhook(
         _log_webhook_entry(
             proxy_log_path,
             "info",
-            f"Webhook POST to {url} was not admitted because usage delivery is saturated",
+            "was not admitted because usage delivery is saturated",
             url,
             log_type,
             payload,
@@ -384,7 +394,7 @@ def _enqueue_webhook(
         _log_webhook_entry(
             proxy_log_path,
             "info",
-            f"Webhook POST to {url} enqueued",
+            "enqueued",
             url,
             log_type,
             payload,

--- a/crates/runner/mitm-addon/src/usage/webhook.py
+++ b/crates/runner/mitm-addon/src/usage/webhook.py
@@ -11,6 +11,7 @@ import json
 import threading
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
@@ -92,7 +93,27 @@ def _log_webhook_entry(
 def _sanitize_webhook_log_text(value: str, raw_url: str, display_url: str) -> str:
     if not raw_url:
         return value
-    return value.replace(raw_url, display_url)
+    for url_variant in _raw_webhook_url_log_text_variants(raw_url):
+        value = value.replace(url_variant, display_url)
+    return value
+
+
+def _raw_webhook_url_log_text_variants(raw_url: str) -> tuple[str, ...]:
+    variants = {raw_url}
+    try:
+        parts = urllib.parse.urlsplit(raw_url)
+    except ValueError:
+        variants.add(raw_url.split("#", 1)[0])
+        variants.add(raw_url.split("?", 1)[0])
+    else:
+        if parts.fragment:
+            variants.add(
+                urllib.parse.urlunsplit((parts.scheme, parts.netloc, parts.path, parts.query, ""))
+            )
+        if parts.query or parts.fragment:
+            variants.add(urllib.parse.urlunsplit((parts.scheme, parts.netloc, parts.path, "", "")))
+    variants.discard("")
+    return tuple(sorted(variants, key=len, reverse=True))
 
 
 def _post_webhook(url: str, sandbox_token: str, data: bytes) -> None:

--- a/crates/runner/mitm-addon/tests/test_webhook.py
+++ b/crates/runner/mitm-addon/tests/test_webhook.py
@@ -364,7 +364,9 @@ class TestUsageWebhookDelivery:
         with patch.object(
             usage.webhook._opener,
             "open",
-            side_effect=urllib.error.URLError(f"failed {SENSITIVE_WEBHOOK_URL}"),
+            side_effect=urllib.error.URLError(
+                f"failed {SENSITIVE_WEBHOOK_URL} and {SENSITIVE_WEBHOOK_URL.removesuffix('#frag')}"
+            ),
         ):
             outcome = usage.webhook._do_post_webhook_attempts(
                 SENSITIVE_WEBHOOK_URL,

--- a/crates/runner/mitm-addon/tests/test_webhook.py
+++ b/crates/runner/mitm-addon/tests/test_webhook.py
@@ -55,6 +55,20 @@ def _assert_body_free_webhook_entry(
         assert "payload_bytes" not in entry
 
 
+SENSITIVE_WEBHOOK_URL = (
+    "https://user:pass@api.vm0.ai/api/webhooks/agent/usage-event?token=secret#frag"
+)
+SANITIZED_WEBHOOK_URL = "https://api.vm0.ai/api/webhooks/agent/usage-event"
+
+
+def _assert_sensitive_webhook_url_parts_absent(entry: dict) -> None:
+    serialized = json.dumps(entry)
+    assert "user:pass" not in serialized
+    assert "token=secret" not in serialized
+    assert "#frag" not in serialized
+    assert "pass@api.vm0.ai" not in serialized
+
+
 class TestUsageWebhookDelivery:
     """Webhook delivery behavior observed through the HTTP boundary."""
 
@@ -342,6 +356,39 @@ class TestUsageWebhookDelivery:
                 payload_bytes=payload_bytes,
             )
 
+    def test_retry_failure_sanitizes_sensitive_webhook_url_in_message_and_error(self, tmp_path):
+        proxy_log = tmp_path / "proxy.jsonl"
+        payload = {"runId": "run-1", "events": []}
+        payload_bytes = len(json.dumps(payload).encode())
+
+        with patch.object(
+            usage.webhook._opener,
+            "open",
+            side_effect=urllib.error.URLError(f"failed {SENSITIVE_WEBHOOK_URL}"),
+        ):
+            outcome = usage.webhook._do_post_webhook_attempts(
+                SENSITIVE_WEBHOOK_URL,
+                "tok",
+                payload,
+                str(proxy_log),
+                "usage",
+                max_retries=0,
+            )
+
+        assert outcome == "retryable_failure"
+        [entry] = read_jsonl_entries_after_flush(proxy_log)
+        assert entry["url"] == SANITIZED_WEBHOOK_URL
+        assert SANITIZED_WEBHOOK_URL in entry["message"]
+        assert SANITIZED_WEBHOOK_URL in entry["error"]
+        assert "failed after 1 attempts" in entry["message"]
+        _assert_body_free_webhook_entry(
+            entry,
+            run_id="run-1",
+            event_count=0,
+            payload_bytes=payload_bytes,
+        )
+        _assert_sensitive_webhook_url_parts_absent(entry)
+
     def test_http_400_is_permanent(self, tmp_path, usage_webhook_server):
         proxy_log = tmp_path / "proxy.jsonl"
         usage_webhook_server.queue_response(400)
@@ -422,6 +469,32 @@ class TestUsageWebhookDelivery:
         assert entry["type"] == "usage_event"
         _assert_body_free_webhook_entry(entry, run_id="run-1", event_count=0)
         assert "payload_bytes" not in entry
+
+    def test_enqueue_sanitizes_sensitive_webhook_url_in_message(self, tmp_path):
+        proxy_log = tmp_path / "proxy.jsonl"
+        executor = _QueuedUsageExecutor()
+        payload = {"runId": "run-1", "events": []}
+
+        try:
+            with patch.object(usage.webhook, "usage_executor", executor):
+                assert usage.webhook._enqueue_webhook(
+                    SENSITIVE_WEBHOOK_URL,
+                    "tok",
+                    payload,
+                    str(proxy_log),
+                    "usage_event",
+                )
+            assert len(executor.submissions) == 1
+        finally:
+            _release_queued_pending_reports(executor)
+            usage.webhook.reset_delivery_capacity_for_tests()
+
+        [entry] = read_jsonl_entries_after_flush(proxy_log)
+        assert entry["url"] == SANITIZED_WEBHOOK_URL
+        assert entry["message"] == f"Webhook POST to {SANITIZED_WEBHOOK_URL} enqueued"
+        assert entry["type"] == "usage_event"
+        _assert_body_free_webhook_entry(entry, run_id="run-1", event_count=0)
+        _assert_sensitive_webhook_url_parts_absent(entry)
 
     def test_submit_failure_rolls_back_pending_report(self, tmp_path):
         pending_path = tmp_path / "usage-pending"

--- a/crates/runner/src/cmd/config.rs
+++ b/crates/runner/src/cmd/config.rs
@@ -67,6 +67,7 @@ pub async fn run_config(args: ConfigArgs) -> RunnerResult<()> {
     for h in args.rootfs_hash.iter().chain(args.snapshot_hash.iter()) {
         crate::image_hash::validate_or_err(h)?;
     }
+    let api_url = config::normalize_api_base_url(&args.api_url)?;
 
     let paths = HomePaths::new()?;
 
@@ -126,7 +127,7 @@ pub async fn run_config(args: ConfigArgs) -> RunnerResult<()> {
             ..SandboxConfig::default()
         },
         server: Some(ServerConfig {
-            url: args.api_url,
+            url: api_url,
             token: args.token,
         }),
     };
@@ -155,6 +156,15 @@ mod tests {
             api_url: "http://localhost".into(),
             token: "x".into(),
         }
+    }
+
+    fn args_with_valid_image_hashes() -> ConfigArgs {
+        let mut args = args_with_dirname("runner-01");
+        args.rootfs_hash =
+            vec!["0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".into()];
+        args.snapshot_hash =
+            vec!["fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210".into()];
+        args
     }
 
     /// Asserts that `--runner-dirname` validation is wired into `run_config`.
@@ -214,6 +224,25 @@ mod tests {
         assert!(
             !msg.contains(&dirname),
             "overlong dirname should be previewed, not echoed in full: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_config_rejects_invalid_api_url_before_filesystem_setup() {
+        let mut args = args_with_valid_image_hashes();
+        args.api_url = "https://user:pass@api.example.com?token=secret".into();
+
+        let err = run_config(args).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("server.url"), "got: {msg}");
+        assert!(msg.contains("credentials"), "got: {msg}");
+        assert!(
+            !msg.contains("user:pass") && !msg.contains("token=secret"),
+            "error should not echo sensitive URL components: {msg}"
+        );
+        assert!(
+            !msg.contains("rootfs not found"),
+            "API URL validation should happen before rootfs checks: {msg}"
         );
     }
 

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -269,6 +269,7 @@ async fn run_start_with_home(
             "server.url is required (set in config or via --api-url / VM0_API_URL)".into(),
         ));
     }
+    server.url = config::normalize_api_base_url(&server.url)?;
     if server.token.is_empty() {
         return Err(RunnerError::Config(
             "server.token is required (set in config or via --token / VM0_RUNNER_TOKEN)".into(),

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -243,7 +243,7 @@ async fn run_start_with_home(
     let signals = EarlySignals::register()
         .map_err(|e| RunnerError::Internal(format!("register signal handlers: {e}")))?;
 
-    let mut runner_config = config::load(&args.config).await?;
+    let mut runner_config = config::load_for_start(&args.config, args.api_url.as_deref()).await?;
     let registry_config_path = tokio::fs::canonicalize(&args.config).await.map_err(|e| {
         RunnerError::Config(format!(
             "canonicalize config path {} for live runner registry: {e}",

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -174,7 +174,17 @@ pub async fn load(path: &Path) -> RunnerResult<RunnerConfig> {
     let home = HomePaths::new()?;
     // Image artifacts are mutable cache outputs. Runtime callers validate
     // them only after acquiring the matching shared rootfs/snapshot locks.
-    load_with_home(path, &home, false).await
+    load_with_home_inner(path, &home, false, None).await
+}
+
+/// Load a runner config for `runner start`, applying the API URL override
+/// before validating `server.url`.
+pub(crate) async fn load_for_start(
+    path: &Path,
+    api_url_override: Option<&str>,
+) -> RunnerResult<RunnerConfig> {
+    let home = HomePaths::new()?;
+    load_with_home_inner(path, &home, false, api_url_override).await
 }
 
 /// Read a runner config selected by diagnostic/discovery code.
@@ -191,10 +201,20 @@ pub(crate) async fn read_diagnostic_config_to_string(path: &Path) -> RunnerResul
     .await
 }
 
+#[cfg(test)]
 async fn load_with_home(
     path: &Path,
     home: &HomePaths,
     validate_image_artifacts: bool,
+) -> RunnerResult<RunnerConfig> {
+    load_with_home_inner(path, home, validate_image_artifacts, None).await
+}
+
+async fn load_with_home_inner(
+    path: &Path,
+    home: &HomePaths,
+    validate_image_artifacts: bool,
+    api_url_override: Option<&str>,
 ) -> RunnerResult<RunnerConfig> {
     let content = tokio::fs::read_to_string(path)
         .await
@@ -203,6 +223,13 @@ async fn load_with_home(
         .map_err(|e| RunnerError::Config(format!("parse {}: {e}", path.display())))?;
     if let Some(config_dir) = path.parent() {
         config.resolve_relative_paths(config_dir);
+    }
+    if let Some(api_url) = api_url_override {
+        let server = config.server.get_or_insert_with(|| ServerConfig {
+            url: String::new(),
+            token: String::new(),
+        });
+        server.url = api_url.to_string();
     }
     if let Some(server) = &mut config.server
         && !server.url.is_empty()

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -204,6 +204,11 @@ async fn load_with_home(
     if let Some(config_dir) = path.parent() {
         config.resolve_relative_paths(config_dir);
     }
+    if let Some(server) = &mut config.server
+        && !server.url.is_empty()
+    {
+        server.url = normalize_api_base_url(&server.url)?;
+    }
     validate(&config, home, validate_image_artifacts).await?;
     Ok(config)
 }
@@ -232,6 +237,59 @@ pub(crate) fn validate_concurrency_factor(value: f64) -> RunnerResult<()> {
         ));
     }
     Ok(())
+}
+
+/// Validate and normalize the runner API base URL.
+///
+/// The URL is later copied into guest-visible config and log-adjacent paths,
+/// so reject components that can carry credentials or other sensitive values.
+pub(crate) fn normalize_api_base_url(value: &str) -> RunnerResult<String> {
+    let parsed = url::Url::parse(value)
+        .map_err(|_| RunnerError::Config("server.url must be an absolute http(s) URL".into()))?;
+
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return Err(RunnerError::Config(
+            "server.url must use the http or https scheme".into(),
+        ));
+    }
+    if parsed.host_str().is_none() {
+        return Err(RunnerError::Config("server.url must include a host".into()));
+    }
+    if parsed_has_userinfo(value, &parsed) {
+        return Err(RunnerError::Config(
+            "server.url must not include credentials".into(),
+        ));
+    }
+    if parsed.query().is_some() {
+        return Err(RunnerError::Config(
+            "server.url must not include a query string".into(),
+        ));
+    }
+    if parsed.fragment().is_some() {
+        return Err(RunnerError::Config(
+            "server.url must not include a fragment".into(),
+        ));
+    }
+
+    Ok(parsed.as_str().trim_end_matches('/').to_string())
+}
+
+fn parsed_has_userinfo(raw_value: &str, url: &url::Url) -> bool {
+    !url.username().is_empty()
+        || url.password().is_some()
+        || authority_has_userinfo_marker(raw_value)
+        || authority_has_userinfo_marker(url.as_str())
+}
+
+fn authority_has_userinfo_marker(value: &str) -> bool {
+    let Some((_, after_scheme)) = value.split_once("://") else {
+        return false;
+    };
+    let authority = after_scheme
+        .split(['/', '?', '#'])
+        .next()
+        .unwrap_or(after_scheme);
+    authority.contains('@')
 }
 
 async fn check_path_exists(path: &Path, label: &str) -> RunnerResult<()> {

--- a/crates/runner/src/config_tests.rs
+++ b/crates/runner/src/config_tests.rs
@@ -167,6 +167,59 @@ fn mode_of(path: &std::path::Path) -> u32 {
     std::fs::metadata(path).unwrap().permissions().mode() & 0o777
 }
 
+#[track_caller]
+fn assert_invalid_api_base_url(value: &str, expected: &str) {
+    let error = normalize_api_base_url(value).unwrap_err();
+    let message = error.to_string();
+    assert!(
+        message.contains("server.url"),
+        "error should identify server.url, got: {message}"
+    );
+    assert!(
+        message.contains(expected),
+        "error should mention {expected}, got: {message}"
+    );
+    assert!(
+        !message.contains(value),
+        "error should not echo the raw URL: {message}"
+    );
+}
+
+#[test]
+fn normalize_api_base_url_accepts_http_https_and_preserves_path_prefix() {
+    let cases = [
+        ("https://api.example.com", "https://api.example.com"),
+        ("https://api.example.com/", "https://api.example.com"),
+        ("http://localhost:3000/api/", "http://localhost:3000/api"),
+        (
+            "https://api.example.com/prefix/v1",
+            "https://api.example.com/prefix/v1",
+        ),
+        ("http://[::1]:8080/base/", "http://[::1]:8080/base"),
+    ];
+
+    for (input, expected) in cases {
+        assert_eq!(normalize_api_base_url(input).unwrap(), expected);
+    }
+}
+
+#[test]
+fn normalize_api_base_url_rejects_sensitive_or_non_base_components() {
+    let cases = [
+        ("https://user:pass@api.example.com", "credentials"),
+        ("https://@api.example.com", "credentials"),
+        ("https://api.example.com?token=secret", "query"),
+        ("https://api.example.com#access-token", "fragment"),
+        ("ftp://api.example.com", "http or https"),
+        ("https://", "absolute http(s) URL"),
+        ("api.example.com", "absolute http(s) URL"),
+    ];
+
+    for (input, expected) in cases {
+        assert_invalid_api_base_url(input, expected);
+    }
+}
+
 #[tokio::test]
 async fn diagnostic_config_read_accepts_regular_yaml() {
     let dir = tempfile::tempdir().unwrap();
@@ -299,6 +352,51 @@ server:
     let server = config.server.unwrap();
     assert_eq!(server.url, "https://api.example.com");
     assert_eq!(server.token, "secret");
+}
+
+#[tokio::test]
+async fn load_normalizes_server_url() {
+    let fixture = ConfigFixture::new().await;
+    let yaml = fixture.yaml_with_default_profile(
+        r#"server:
+  url: https://api.example.com/prefix/
+  token: secret
+"#,
+    );
+
+    let config = fixture.load_config(&yaml, true).await.unwrap();
+    let server = config.server.unwrap();
+    assert_eq!(server.url, "https://api.example.com/prefix");
+}
+
+#[tokio::test]
+async fn load_rejects_server_url_with_sensitive_components() {
+    let fixture = ConfigFixture::new().await;
+    let cases = [
+        ("https://user:pass@api.example.com", "credentials"),
+        ("https://api.example.com?token=secret", "query"),
+        ("https://api.example.com#access-token", "fragment"),
+    ];
+
+    for (url, expected) in cases {
+        let yaml = fixture.yaml_with_default_profile(&format!(
+            r#"server:
+  url: "{url}"
+  token: secret
+"#
+        ));
+
+        let error = fixture.load_config(&yaml, true).await.unwrap_err();
+        let message = error.to_string();
+        assert!(
+            message.contains(expected),
+            "expected {expected} error for {url}, got: {message}"
+        );
+        assert!(
+            !message.contains(url),
+            "error should not echo raw URL for {url}: {message}"
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/runner/src/config_tests.rs
+++ b/crates/runner/src/config_tests.rs
@@ -370,6 +370,26 @@ async fn load_normalizes_server_url() {
 }
 
 #[tokio::test]
+async fn load_for_start_applies_api_url_override_before_server_url_validation() {
+    let fixture = ConfigFixture::new().await;
+    let yaml = fixture.yaml_with_default_profile(
+        r#"server:
+  url: "https://user:pass@stale.example.com?token=secret#frag"
+  token: secret
+"#,
+    );
+    let config_path = fixture.write_config(&yaml).await;
+
+    let config = load_for_start(&config_path, Some("https://api.example.com/prefix/"))
+        .await
+        .unwrap();
+
+    let server = config.server.unwrap();
+    assert_eq!(server.url, "https://api.example.com/prefix");
+    assert_eq!(server.token, "secret");
+}
+
+#[tokio::test]
 async fn load_rejects_server_url_with_sensitive_components() {
     let fixture = ConfigFixture::new().await;
     let cases = [

--- a/crates/runner/src/http.rs
+++ b/crates/runner/src/http.rs
@@ -5,6 +5,7 @@ use api_contracts::{Method, ResolvedRoute, Route};
 use reqwest::Client;
 use tracing::info;
 
+use crate::config::normalize_api_base_url;
 use crate::error::{RunnerError, RunnerResult};
 
 /// Default timeout for API requests (covers large claim payloads).
@@ -40,9 +41,10 @@ impl HttpClient {
     /// Returns an error if the underlying HTTP client cannot be built.
     pub fn new(config: HttpClientConfig) -> RunnerResult<Self> {
         let HttpClientConfig {
-            api_url,
+            api_url: raw_api_url,
             vercel_bypass,
         } = config;
+        let api_url = normalize_api_base_url(&raw_api_url)?;
 
         let client = Client::builder()
             .timeout(DEFAULT_TIMEOUT)
@@ -155,6 +157,41 @@ mod tests {
                 .to_str()
                 .unwrap(),
             "Bearer sandbox-token"
+        );
+    }
+
+    #[test]
+    fn new_normalizes_api_url_before_building_routes() {
+        let http = http_client("https://api.vm0.dev/prefix/");
+
+        let request = http
+            .request_route(routes::webhooks::agent::telemetry::SEND, "sandbox-token")
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            request.url().as_str(),
+            "https://api.vm0.dev/prefix/api/webhooks/agent/telemetry"
+        );
+    }
+
+    #[test]
+    fn new_rejects_api_url_with_sensitive_components() {
+        let result = HttpClient::new(HttpClientConfig {
+            api_url: "https://user:pass@api.vm0.dev?token=secret".to_string(),
+            vercel_bypass: None,
+        });
+        let error = match result {
+            Ok(_) => panic!("expected invalid API URL to be rejected"),
+            Err(error) => error,
+        };
+        let message = error.to_string();
+
+        assert!(message.contains("server.url"), "got: {message}");
+        assert!(message.contains("credentials"), "got: {message}");
+        assert!(
+            !message.contains("user:pass") && !message.contains("token=secret"),
+            "error should not echo sensitive URL components: {message}"
         );
     }
 


### PR DESCRIPTION
## Summary
- sanitize usage webhook proxy-log messages and error text with the same URL sanitizer used for structured proxy-log URLs
- validate and normalize runner API base URLs before config generation, runner start, and HttpClient storage/logging
- add regression coverage for URL userinfo, query strings, fragments, and path-prefix preservation

## Tests
- cargo test --manifest-path crates/Cargo.toml -p runner api_url
- cargo test --manifest-path crates/Cargo.toml -p runner config
- cd crates/runner/mitm-addon && .venv/bin/ruff format --check src/usage/webhook.py tests/test_webhook.py && .venv/bin/ruff check src/usage/webhook.py tests/test_webhook.py && .venv/bin/pytest tests/test_webhook.py
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- git diff --check

Fixes #19659