### PR TITLE
feat: open connectorAccessManagement to all users

### DIFF
--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -118,9 +118,6 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.CodexFrameworkForMinimax]).toBe(
       true,
     );
-    expect(staffOrgStates[FeatureSwitchKey.ConnectorAccessManagement]).toBe(
-      true,
-    );
     expect(staffOrgStates[FeatureSwitchKey.ChatGithubPrTracking]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.ChatThreadEmoji]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.AgentUnreadIndicators]).toBe(false);
@@ -135,9 +132,6 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.WorkflowAutomation]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ApiKeys]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.CodexFrameworkForMinimax]).toBe(
-      false,
-    );
-    expect(otherOrgStates[FeatureSwitchKey.ConnectorAccessManagement]).toBe(
       false,
     );
     expect(otherOrgStates[FeatureSwitchKey.ChatGithubPrTracking]).toBe(false);

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -281,8 +281,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "ethan@vm0.ai",
     description:
       "Show connected connector filtering and per-agent connector access management on connected connector cards.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
   [FeatureSwitchKey.PresentationTemplateRunbook]: {
     maintainer: "bingjie@vm0.ai",


### PR DESCRIPTION
## Summary

- Drop the staff-only rollout gating on `FeatureSwitchKey.ConnectorAccessManagement` so the per-agent connector access management UI ships to every org.
- Flip the switch to `enabled: true` in `packages/core/feature-switch.ts` and remove the matching `enabledOrgIdHashes: STAFF_ORG_ID_HASHES`.
- Remove the two now-stale assertions from the `getAllFeatureStates` rollout-matrix test, since this switch is no longer part of the staff-only matrix.

## Why

The connector access management flow (filter connected connectors and toggle per-agent access) is ready to be available to every organization, not just staff orgs.

## Changes

```diff
 [FeatureSwitchKey.ConnectorAccessManagement]: {
   maintainer: "ethan@vm0.ai",
   description:
     "Show connected connector filtering and per-agent connector access management on connected connector cards.",
-  enabled: false,
-  enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  enabled: true,
 },
```

## Testing

- Platform test `zero-connectors-page.test.tsx` already covers both states (switch on / switch off) via explicit `featureSwitches` fixtures, so it continues to validate the off-path after the flip.