### PR TITLE
refactor: remove guest-agent path facades

### DIFF
--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -18,6 +18,7 @@ use guest_common::telemetry::record_sandbox_op;
 use guest_common::{log_error, log_info, log_warn};
 use serde_json::json;
 use sha2::{Digest, Sha256};
+use std::borrow::Cow;
 use std::io::ErrorKind;
 use std::time::Duration;
 
@@ -103,9 +104,9 @@ struct CheckpointInputs<'a> {
     framework: env::Framework,
     home_dir: &'a str,
     artifact_entries: &'a [env::ArtifactEnv],
-    session_id_file: &'a str,
-    session_history_path_file: &'a str,
-    final_session_history_identity_file: &'a str,
+    session_id_file: Cow<'a, str>,
+    session_history_path_file: Cow<'a, str>,
+    final_session_history_identity_file: Cow<'a, str>,
 }
 
 impl<'a> CheckpointInputs<'a> {
@@ -115,23 +116,26 @@ impl<'a> CheckpointInputs<'a> {
             framework: runtime.config.framework,
             home_dir: &runtime.config.home_dir,
             artifact_entries: &runtime.config.artifacts,
-            session_id_file: runtime.paths.session_id_file(),
-            session_history_path_file: runtime.paths.session_history_path_file(),
-            final_session_history_identity_file: runtime
-                .paths
-                .final_session_history_identity_file(),
+            session_id_file: Cow::Borrowed(runtime.paths.session_id_file()),
+            session_history_path_file: Cow::Borrowed(runtime.paths.session_history_path_file()),
+            final_session_history_identity_file: Cow::Borrowed(
+                runtime.paths.final_session_history_identity_file(),
+            ),
         }
     }
 
     fn from_legacy_env() -> Self {
+        let paths = paths::legacy_paths_from_process_env();
         Self {
             run_id: env::run_id(),
             framework: env::Framework::from_env(),
             home_dir: env::home_dir(),
             artifact_entries: env::artifacts(),
-            session_id_file: paths::session_id_file(),
-            session_history_path_file: paths::session_history_path_file(),
-            final_session_history_identity_file: paths::final_session_history_identity_file(),
+            session_id_file: Cow::Owned(paths.session_id_file().to_string()),
+            session_history_path_file: Cow::Owned(paths.session_history_path_file().to_string()),
+            final_session_history_identity_file: Cow::Owned(
+                paths.final_session_history_identity_file().to_string(),
+            ),
         }
     }
 }
@@ -428,7 +432,7 @@ async fn create_checkpoint_impl(
     // directly — an explicit `exists()` check would be a redundant stat plus a
     // TOCTOU race between check and read.
     let session_id_start = std::time::Instant::now();
-    let cli_agent_session_id = match std::fs::read_to_string(inputs.session_id_file) {
+    let cli_agent_session_id = match std::fs::read_to_string(inputs.session_id_file.as_ref()) {
         Ok(s) => s.trim().to_string(),
         Err(e) if e.kind() == ErrorKind::NotFound => {
             return Err(fail(
@@ -464,7 +468,7 @@ async fn create_checkpoint_impl(
     let history_marker_payload = match crate::session_metadata::resolve_history_marker_payload_from(
         inputs.framework,
         inputs.home_dir,
-        inputs.session_history_path_file,
+        inputs.session_history_path_file.as_ref(),
         &cli_agent_session_id,
     ) {
         Ok(payload) => payload,
@@ -605,7 +609,7 @@ async fn create_checkpoint_impl(
             history_size,
             &history_marker_payload,
             inputs.framework,
-            inputs.final_session_history_identity_file,
+            inputs.final_session_history_identity_file.as_ref(),
         );
         log_info!(LOG_TAG, "{} created successfully: {id}", mode.log_label());
         record_sandbox_op("checkpoint_api_call", api_start.elapsed(), true, None);
@@ -742,8 +746,9 @@ mod tests {
     }
 
     fn cleanup_checkpoint_files() {
-        let _ = std::fs::remove_file(paths::session_id_file());
-        let _ = std::fs::remove_file(paths::session_history_path_file());
+        let guest_paths = paths::legacy_paths_from_process_env();
+        let _ = std::fs::remove_file(guest_paths.session_id_file());
+        let _ = std::fs::remove_file(guest_paths.session_history_path_file());
     }
 
     #[test]
@@ -997,11 +1002,16 @@ mod tests {
             );
         }
         let _files_guard = CheckpointFilesGuard::new();
+        let guest_paths = paths::legacy_paths_from_process_env();
         let history_path = dir.path().join("history.jsonl");
         std::fs::write(&history_path, r#"{"type":"system"}"#).unwrap();
-        paths::write_private(paths::session_id_file(), "session-with-missing-artifact").unwrap();
         paths::write_private(
-            paths::session_history_path_file(),
+            guest_paths.session_id_file(),
+            "session-with-missing-artifact",
+        )
+        .unwrap();
+        paths::write_private(
+            guest_paths.session_history_path_file(),
             history_path.to_string_lossy().as_ref(),
         )
         .unwrap();
@@ -1042,9 +1052,11 @@ mod tests {
             framework: env::Framework::ClaudeCode,
             home_dir: env::home_dir(),
             artifact_entries: &entries,
-            session_id_file: paths::session_id_file(),
-            session_history_path_file: paths::session_history_path_file(),
-            final_session_history_identity_file: paths::final_session_history_identity_file(),
+            session_id_file: guest_paths.session_id_file().into(),
+            session_history_path_file: guest_paths.session_history_path_file().into(),
+            final_session_history_identity_file: guest_paths
+                .final_session_history_identity_file()
+                .into(),
         };
 
         let err = create_checkpoint_impl(&http, CheckpointMode::Success, &inputs)

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -321,6 +321,7 @@ impl<'a> CliRuntimeConfig<'a> {
         let use_mock_claude = is_claude && env::use_mock_claude();
         let use_mock_codex = is_codex && env::use_mock_codex();
         let use_codex_app_server_backend = is_codex && env::use_codex_app_server_backend();
+        let paths = paths::legacy_paths_from_process_env();
         Self {
             framework,
             run_id: Cow::Borrowed(env::run_id()),
@@ -373,10 +374,10 @@ impl<'a> CliRuntimeConfig<'a> {
             } else {
                 constants::STUCK_TOOL_TIMEOUT_SECS
             },
-            agent_log_file: Cow::Borrowed(paths::agent_log_file()),
-            session_id_file: Cow::Borrowed(paths::session_id_file()),
-            session_history_path_file: Cow::Borrowed(paths::session_history_path_file()),
-            event_error_flag: Cow::Borrowed(paths::event_error_flag()),
+            agent_log_file: Cow::Owned(paths.agent_log_file().to_string()),
+            session_id_file: Cow::Owned(paths.session_id_file().to_string()),
+            session_history_path_file: Cow::Owned(paths.session_history_path_file().to_string()),
+            event_error_flag: Cow::Owned(paths.event_error_flag().to_string()),
             user_env: env::user_env(),
         }
     }

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -412,7 +412,8 @@ fn truncate_diagnostic_message(message: &str) -> String {
 
 /// POST a prepared event payload to the webhook endpoint.
 pub async fn post_event(http: &HttpClient, payload: &Value) -> Result<(), AgentError> {
-    post_event_with_error_flag(http, payload, paths::event_error_flag()).await
+    let paths = paths::legacy_paths_from_process_env();
+    post_event_with_error_flag(http, payload, paths.event_error_flag()).await
 }
 
 pub async fn post_event_with_error_flag(
@@ -508,11 +509,12 @@ pub(crate) struct SessionMetadataCapture {
 
 impl SessionMetadataCapture {
     pub(crate) fn new() -> Self {
+        let paths = paths::legacy_paths_from_process_env();
         Self::from_values(
             Framework::from_env(),
             env::home_dir(),
-            paths::session_id_file(),
-            paths::session_history_path_file(),
+            paths.session_id_file(),
+            paths.session_history_path_file(),
         )
     }
 

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -66,7 +66,7 @@ fn helper_exit_code_from_args() -> Option<i32> {
     }
     let metadata_path = args
         .next()
-        .unwrap_or_else(|| paths::final_session_history_identity_file().into());
+        .unwrap_or_else(final_session_history_identity_path_from_process_env);
     let remaining = args.collect::<Vec<_>>();
     let expected = match parse_session_history_identity_expectation(&remaining) {
         Ok(expected) => expected,
@@ -88,6 +88,15 @@ fn helper_exit_code_from_args() -> Option<i32> {
             }
         },
     )
+}
+
+#[allow(clippy::panic)]
+fn final_session_history_identity_path_from_process_env() -> std::ffi::OsString {
+    let run_id = std::env::var(guest_contracts::env::RUN_ID_ENV).unwrap_or_default();
+    paths::GuestPaths::from_process_env(&run_id)
+        .unwrap_or_else(|error| panic!("failed to resolve guest runtime directory: {error}"))
+        .final_session_history_identity_file()
+        .into()
 }
 
 fn parse_session_history_identity_expectation(
@@ -1283,6 +1292,28 @@ mod tests {
 
     fn test_runtime_dir() -> std::path::PathBuf {
         MAIN_TEST_RUNTIME_ROOT.join("main-recovery-checkpoint")
+    }
+
+    fn test_guest_paths() -> paths::GuestPaths {
+        paths::GuestPaths::from_runtime_dir(test_runtime_dir())
+    }
+
+    fn run_scoped_cleanup_paths(paths: &paths::GuestPaths, include_session: bool) -> Vec<String> {
+        let mut cleanup_paths = Vec::new();
+        if include_session {
+            cleanup_paths.push(paths.session_id_file().to_string());
+            cleanup_paths.push(paths.session_history_path_file().to_string());
+        }
+        cleanup_paths.extend([
+            paths.checkpoint_error_file().to_string(),
+            paths.failure_diagnostic_file().to_string(),
+            paths.event_error_flag().to_string(),
+            paths.sandbox_ops_file().to_string(),
+            paths.telemetry_system_log_pos_file().to_string(),
+            paths.telemetry_metrics_pos_file().to_string(),
+            paths.telemetry_sandbox_ops_pos_file().to_string(),
+        ]);
+        cleanup_paths
     }
 
     struct EnvVarRestoreGuard {
@@ -2758,16 +2789,17 @@ mod tests {
         let server = &*COMPLETE_EXECUTION_MOCK_SERVER;
         server.reset_async().await;
         let _env_guard = unsafe { set_test_env(server, None) };
+        let guest_paths = test_guest_paths();
 
         let tmp = tempfile::tempdir().unwrap();
         let system_log_path = tmp.path().join("system.log");
         let _system_log_guard = SystemLogOverrideGuard::set(&system_log_path);
-        let cleanup_paths = [
+        let cleanup_paths = vec![
             system_log_path.to_string_lossy().into_owned(),
-            paths::sandbox_ops_file().to_string(),
-            paths::telemetry_system_log_pos_file().to_string(),
-            paths::telemetry_metrics_pos_file().to_string(),
-            paths::telemetry_sandbox_ops_pos_file().to_string(),
+            guest_paths.sandbox_ops_file().to_string(),
+            guest_paths.telemetry_system_log_pos_file().to_string(),
+            guest_paths.telemetry_metrics_pos_file().to_string(),
+            guest_paths.telemetry_sandbox_ops_pos_file().to_string(),
         ];
         for path in &cleanup_paths {
             let _ = std::fs::remove_file(path);
@@ -2796,7 +2828,8 @@ mod tests {
 
         telemetry_mock.assert_calls_async(1).await;
         telemetry_mock.delete_async().await;
-        let sandbox_ops = std::fs::read_to_string(paths::sandbox_ops_file()).unwrap_or_default();
+        let sandbox_ops =
+            std::fs::read_to_string(guest_paths.sandbox_ops_file()).unwrap_or_default();
         assert!(
             !sandbox_ops.contains("final_telemetry_upload"),
             "final telemetry must not record telemetry-upload telemetry through the same stream"
@@ -2818,13 +2851,14 @@ mod tests {
                 let server = &*COMPLETE_EXECUTION_MOCK_SERVER;
                 server.reset_async().await;
                 let _env_guard = unsafe { set_test_env(server, None) };
+                let guest_paths = test_guest_paths();
 
                 let marker = "producer_after_shutdown_before_final_upload";
-                let cleanup_paths = [
-                    paths::sandbox_ops_file().to_string(),
-                    paths::telemetry_system_log_pos_file().to_string(),
-                    paths::telemetry_metrics_pos_file().to_string(),
-                    paths::telemetry_sandbox_ops_pos_file().to_string(),
+                let cleanup_paths = vec![
+                    guest_paths.sandbox_ops_file().to_string(),
+                    guest_paths.telemetry_system_log_pos_file().to_string(),
+                    guest_paths.telemetry_metrics_pos_file().to_string(),
+                    guest_paths.telemetry_sandbox_ops_pos_file().to_string(),
                 ];
                 for path in &cleanup_paths {
                     let _ = std::fs::remove_file(path);
@@ -3032,22 +3066,13 @@ mod tests {
         let server = &*COMPLETE_EXECUTION_MOCK_SERVER;
         server.reset_async().await;
         let _env_guard = unsafe { set_test_env(server, Some("/event-upload-failure")) };
+        let guest_paths = test_guest_paths();
 
-        let cleanup_paths = [
-            paths::session_id_file().to_string(),
-            paths::session_history_path_file().to_string(),
-            paths::checkpoint_error_file().to_string(),
-            paths::failure_diagnostic_file().to_string(),
-            paths::event_error_flag().to_string(),
-            paths::sandbox_ops_file().to_string(),
-            paths::telemetry_system_log_pos_file().to_string(),
-            paths::telemetry_metrics_pos_file().to_string(),
-            paths::telemetry_sandbox_ops_pos_file().to_string(),
-        ];
+        let cleanup_paths = run_scoped_cleanup_paths(&guest_paths, true);
         for path in &cleanup_paths {
             let _ = std::fs::remove_file(path);
         }
-        paths::write_private(paths::event_error_flag(), "").unwrap();
+        paths::write_private(guest_paths.event_error_flag(), "").unwrap();
 
         let _telemetry_mock = server.mock(|when, then| {
             when.method(POST).path("/api/webhooks/agent/telemetry");
@@ -3079,11 +3104,11 @@ mod tests {
 
         assert_eq!(exit_code, 1);
         assert_eq!(
-            std::fs::read_to_string(paths::checkpoint_error_file()).unwrap(),
+            std::fs::read_to_string(guest_paths.checkpoint_error_file()).unwrap(),
             "Some events failed to send, marking run as failed"
         );
         let diagnostic: FailureDiagnostic =
-            serde_json::from_slice(&std::fs::read(paths::failure_diagnostic_file()).unwrap())
+            serde_json::from_slice(&std::fs::read(guest_paths.failure_diagnostic_file()).unwrap())
                 .unwrap();
         assert_eq!(diagnostic.failure_class, FailureClass::EventUploadFailed);
         assert_eq!(diagnostic.cli_exit_code, Some(0));
@@ -3100,18 +3125,9 @@ mod tests {
         let server = &*COMPLETE_EXECUTION_MOCK_SERVER;
         server.reset_async().await;
         let _env_guard = unsafe { set_test_env(server, Some("/checkpoint-failure")) };
+        let guest_paths = test_guest_paths();
 
-        let cleanup_paths = [
-            paths::session_id_file().to_string(),
-            paths::session_history_path_file().to_string(),
-            paths::checkpoint_error_file().to_string(),
-            paths::failure_diagnostic_file().to_string(),
-            paths::event_error_flag().to_string(),
-            paths::sandbox_ops_file().to_string(),
-            paths::telemetry_system_log_pos_file().to_string(),
-            paths::telemetry_metrics_pos_file().to_string(),
-            paths::telemetry_sandbox_ops_pos_file().to_string(),
-        ];
+        let cleanup_paths = run_scoped_cleanup_paths(&guest_paths, true);
         for path in &cleanup_paths {
             let _ = std::fs::remove_file(path);
         }
@@ -3145,10 +3161,10 @@ mod tests {
         telemetry.shutdown().await;
 
         assert_eq!(exit_code, 1);
-        let error = std::fs::read_to_string(paths::checkpoint_error_file()).unwrap();
+        let error = std::fs::read_to_string(guest_paths.checkpoint_error_file()).unwrap();
         assert!(error.contains("Checkpoint failed"), "got: {error}");
         let diagnostic: FailureDiagnostic =
-            serde_json::from_slice(&std::fs::read(paths::failure_diagnostic_file()).unwrap())
+            serde_json::from_slice(&std::fs::read(guest_paths.failure_diagnostic_file()).unwrap())
                 .unwrap();
         assert_eq!(diagnostic.failure_class, FailureClass::CheckpointFailed);
         assert_eq!(diagnostic.cli_exit_code, Some(0));
@@ -3165,22 +3181,13 @@ mod tests {
         let server = &*COMPLETE_EXECUTION_MOCK_SERVER;
         server.reset_async().await;
         let _env_guard = unsafe { set_test_env(server, Some("plain prompt")) };
+        let guest_paths = test_guest_paths();
 
-        let cleanup_paths = [
-            paths::session_id_file().to_string(),
-            paths::session_history_path_file().to_string(),
-            paths::checkpoint_error_file().to_string(),
-            paths::failure_diagnostic_file().to_string(),
-            paths::event_error_flag().to_string(),
-            paths::sandbox_ops_file().to_string(),
-            paths::telemetry_system_log_pos_file().to_string(),
-            paths::telemetry_metrics_pos_file().to_string(),
-            paths::telemetry_sandbox_ops_pos_file().to_string(),
-        ];
+        let cleanup_paths = run_scoped_cleanup_paths(&guest_paths, true);
         for path in &cleanup_paths {
             let _ = std::fs::remove_file(path);
         }
-        paths::write_private(paths::event_error_flag(), "").unwrap();
+        paths::write_private(guest_paths.event_error_flag(), "").unwrap();
 
         let _telemetry_mock = server.mock(|when, then| {
             when.method(POST).path("/api/webhooks/agent/telemetry");
@@ -3220,11 +3227,11 @@ mod tests {
 
         assert_eq!(exit_code, 1);
         assert_eq!(
-            std::fs::read_to_string(paths::checkpoint_error_file()).unwrap(),
+            std::fs::read_to_string(guest_paths.checkpoint_error_file()).unwrap(),
             failure_message
         );
         let diagnostic: FailureDiagnostic =
-            serde_json::from_slice(&std::fs::read(paths::failure_diagnostic_file()).unwrap())
+            serde_json::from_slice(&std::fs::read(guest_paths.failure_diagnostic_file()).unwrap())
                 .unwrap();
         assert_eq!(diagnostic, failure_diagnostic);
         for path in cleanup_paths {
@@ -3236,16 +3243,9 @@ mod tests {
         let server = &*COMPLETE_EXECUTION_MOCK_SERVER;
         server.reset_async().await;
         let _env_guard = unsafe { set_test_env(server, Some("/help")) };
+        let guest_paths = test_guest_paths();
 
-        let cleanup_paths = [
-            paths::checkpoint_error_file().to_string(),
-            paths::failure_diagnostic_file().to_string(),
-            paths::event_error_flag().to_string(),
-            paths::sandbox_ops_file().to_string(),
-            paths::telemetry_system_log_pos_file().to_string(),
-            paths::telemetry_metrics_pos_file().to_string(),
-            paths::telemetry_sandbox_ops_pos_file().to_string(),
-        ];
+        let cleanup_paths = run_scoped_cleanup_paths(&guest_paths, false);
         for path in &cleanup_paths {
             let _ = std::fs::remove_file(path);
         }
@@ -3298,11 +3298,11 @@ mod tests {
 
         assert_eq!(exit_code, 1);
         assert_eq!(
-            std::fs::read_to_string(paths::checkpoint_error_file()).unwrap(),
+            std::fs::read_to_string(guest_paths.checkpoint_error_file()).unwrap(),
             failure_message
         );
         let diagnostic: FailureDiagnostic =
-            serde_json::from_slice(&std::fs::read(paths::failure_diagnostic_file()).unwrap())
+            serde_json::from_slice(&std::fs::read(guest_paths.failure_diagnostic_file()).unwrap())
                 .unwrap();
         assert_eq!(diagnostic, failure_diagnostic);
         assert_eq!(prepare_mock.calls_async().await, 0);
@@ -3317,18 +3317,9 @@ mod tests {
         let server = &*COMPLETE_EXECUTION_MOCK_SERVER;
         server.reset_async().await;
         let _env_guard = unsafe { set_test_env(server, Some("plain prompt")) };
+        let guest_paths = test_guest_paths();
 
-        let cleanup_paths = [
-            paths::session_id_file().to_string(),
-            paths::session_history_path_file().to_string(),
-            paths::checkpoint_error_file().to_string(),
-            paths::failure_diagnostic_file().to_string(),
-            paths::event_error_flag().to_string(),
-            paths::sandbox_ops_file().to_string(),
-            paths::telemetry_system_log_pos_file().to_string(),
-            paths::telemetry_metrics_pos_file().to_string(),
-            paths::telemetry_sandbox_ops_pos_file().to_string(),
-        ];
+        let cleanup_paths = run_scoped_cleanup_paths(&guest_paths, true);
         for path in &cleanup_paths {
             let _ = std::fs::remove_file(path);
         }
@@ -3337,9 +3328,9 @@ mod tests {
         let history_path = dir.path().join("history.jsonl");
         let history = r#"{"type":"system"}"#.to_string() + "\n" + r#"{"type":"assistant"}"# + "\n";
         std::fs::write(&history_path, &history).unwrap();
-        paths::write_private(paths::session_id_file(), "recovery-session-from-main").unwrap();
+        paths::write_private(guest_paths.session_id_file(), "recovery-session-from-main").unwrap();
         paths::write_private(
-            paths::session_history_path_file(),
+            guest_paths.session_history_path_file(),
             history_path.to_string_lossy().as_ref(),
         )
         .unwrap();
@@ -3407,11 +3398,11 @@ mod tests {
 
         assert_eq!(exit_code, 1);
         assert_eq!(
-            std::fs::read_to_string(paths::checkpoint_error_file()).unwrap(),
+            std::fs::read_to_string(guest_paths.checkpoint_error_file()).unwrap(),
             failure_message
         );
         let diagnostic: FailureDiagnostic =
-            serde_json::from_slice(&std::fs::read(paths::failure_diagnostic_file()).unwrap())
+            serde_json::from_slice(&std::fs::read(guest_paths.failure_diagnostic_file()).unwrap())
                 .unwrap();
         assert_eq!(diagnostic, failure_diagnostic);
         prepare_mock.assert_calls_async(1).await;

--- a/crates/guest-agent/src/metrics.rs
+++ b/crates/guest-agent/src/metrics.rs
@@ -177,7 +177,8 @@ fn write_metrics_entry(metrics_log_file: &str, entry: &MetricsEntry) {
 
 /// Background loop writing metrics JSONL every `METRICS_INTERVAL_SECS`.
 pub async fn metrics_loop(shutdown: CancellationToken) {
-    metrics_loop_for_path(shutdown, paths::metrics_log_file().to_string()).await;
+    let paths = paths::legacy_paths_from_process_env();
+    metrics_loop_for_path(shutdown, paths.metrics_log_file().to_string()).await;
 }
 
 /// Background loop writing metrics JSONL to an explicit runtime metrics file.

--- a/crates/guest-agent/src/paths.rs
+++ b/crates/guest-agent/src/paths.rs
@@ -12,10 +12,6 @@ pub use api_contracts::generated::constants::runners::paths::{
 };
 use std::io;
 use std::path::{Path, PathBuf};
-use std::sync::LazyLock;
-
-static GUEST_PATHS: LazyLock<GuestPaths> =
-    LazyLock::new(|| GuestPaths::from_runtime_dir(default_run_dir()));
 
 /// Immutable run-scoped guest paths derived from one runtime directory.
 #[derive(Clone, Debug)]
@@ -171,13 +167,6 @@ impl GuestPaths {
     }
 }
 
-#[allow(clippy::panic)]
-fn default_run_dir() -> PathBuf {
-    let run_id = std::env::var(guest_contracts::env::RUN_ID_ENV).unwrap_or_default();
-    guest_contracts::runtime_paths::run_dir_from_env(&run_id)
-        .unwrap_or_else(|error| panic!("failed to resolve guest runtime directory: {error}"))
-}
-
 fn resolve_run_dir_from_captured_env(
     run_id: &str,
     runtime_dir: Option<&Path>,
@@ -196,8 +185,11 @@ fn resolve_run_dir_from_captured_env(
     guest_contracts::runtime_paths::run_dir_for_home(home, run_id)
 }
 
-pub fn runtime_dir() -> &'static Path {
-    GUEST_PATHS.runtime_dir()
+#[allow(clippy::panic)]
+pub(crate) fn legacy_paths_from_process_env() -> GuestPaths {
+    let run_id = std::env::var(guest_contracts::env::RUN_ID_ENV).unwrap_or_default();
+    GuestPaths::from_process_env(&run_id)
+        .unwrap_or_else(|error| panic!("failed to resolve guest runtime directory: {error}"))
 }
 
 fn path_to_string(path: PathBuf) -> String {
@@ -210,62 +202,6 @@ pub fn ensure_parent_dir(path: impl AsRef<Path>) -> io::Result<()> {
 
 pub fn write_private(path: impl AsRef<Path>, bytes: impl AsRef<[u8]>) -> io::Result<()> {
     guest_contracts::runtime_paths::write_private(path, bytes)
-}
-
-// ---------------------------------------------------------------------------
-// Session
-// ---------------------------------------------------------------------------
-
-pub fn session_id_file() -> &'static str {
-    GUEST_PATHS.session_id_file()
-}
-pub fn session_history_path_file() -> &'static str {
-    GUEST_PATHS.session_history_path_file()
-}
-
-// ---------------------------------------------------------------------------
-// Log files
-// ---------------------------------------------------------------------------
-
-pub fn event_error_flag() -> &'static str {
-    GUEST_PATHS.event_error_flag()
-}
-pub fn checkpoint_error_file() -> &'static str {
-    GUEST_PATHS.checkpoint_error_file()
-}
-pub fn final_session_history_identity_file() -> &'static str {
-    GUEST_PATHS.final_session_history_identity_file()
-}
-pub fn failure_diagnostic_file() -> &'static str {
-    GUEST_PATHS.failure_diagnostic_file()
-}
-pub fn system_log_file() -> &'static str {
-    GUEST_PATHS.system_log_file()
-}
-pub fn agent_log_file() -> &'static str {
-    GUEST_PATHS.agent_log_file()
-}
-pub fn metrics_log_file() -> &'static str {
-    GUEST_PATHS.metrics_log_file()
-}
-
-/// Re-export sandbox ops log path from guest-common for consistent access.
-pub fn sandbox_ops_file() -> &'static str {
-    guest_common::telemetry::sandbox_ops_log()
-}
-
-// ---------------------------------------------------------------------------
-// Telemetry position tracking
-// ---------------------------------------------------------------------------
-
-pub fn telemetry_system_log_pos_file() -> &'static str {
-    GUEST_PATHS.telemetry_system_log_pos_file()
-}
-pub fn telemetry_metrics_pos_file() -> &'static str {
-    GUEST_PATHS.telemetry_metrics_pos_file()
-}
-pub fn telemetry_sandbox_ops_pos_file() -> &'static str {
-    GUEST_PATHS.telemetry_sandbox_ops_pos_file()
 }
 
 #[cfg(test)]

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -2,8 +2,8 @@
 //! codex (`CODEX_SEARCH:{dir_len}:{dir}:{id}` marker → bounded layout scan +
 //! optional zstd decode).
 //!
-//! The event metadata capture path writes one of two payloads to
-//! `paths::session_history_path_file()`:
+//! The event metadata capture path writes one of two payloads to the
+//! `GuestPaths::session_history_path_file()` runtime file:
 //!
 //! - Claude: a literal filesystem path to the `.jsonl` history file.
 //! - Codex:  a length-prefixed

--- a/crates/guest-agent/src/telemetry.rs
+++ b/crates/guest-agent/src/telemetry.rs
@@ -61,14 +61,7 @@ impl TelemetryPaths {
     }
 
     fn from_legacy_paths() -> Self {
-        Self {
-            system_log_file: paths::system_log_file().to_string(),
-            metrics_log_file: paths::metrics_log_file().to_string(),
-            sandbox_ops_file: paths::sandbox_ops_file().to_string(),
-            system_log_pos_file: paths::telemetry_system_log_pos_file().to_string(),
-            metrics_pos_file: paths::telemetry_metrics_pos_file().to_string(),
-            sandbox_ops_pos_file: paths::telemetry_sandbox_ops_pos_file().to_string(),
-        }
+        Self::from_guest_paths(&paths::legacy_paths_from_process_env())
     }
 }
 

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -26,11 +26,14 @@ mod common;
 use common::SystemLogOverrideGuard;
 use httpmock::prelude::*;
 use serde_json::json;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{LazyLock, Mutex, Once};
 use std::time::Duration;
 
 use guest_agent::masker::SecretMasker;
+
+static CODEX_RESUME_HOME: LazyLock<PathBuf> =
+    LazyLock::new(|| common::unique_temp_path("codex-resume-home"));
 
 /// Configure the process env BEFORE any `guest_agent::env` LazyLock
 /// initialiser runs. Idempotent — only the first call wins.
@@ -54,7 +57,7 @@ fn setup_env_once() {
             std::env::set_var("VM0_PROMPT", "test prompt");
             // `home_dir` is loaded eagerly via `expect`. Keep it stable within
             // this process while avoiding cross-runner and stale /tmp collisions.
-            std::env::set_var("HOME", common::unique_temp_path("codex-resume-home"));
+            std::env::set_var("HOME", CODEX_RESUME_HOME.as_os_str());
         }
     });
 }
@@ -81,12 +84,32 @@ fn send_event_for_test(
     runtime.block_on(guest_agent::events::send_event(&http, event, seq, masker))
 }
 
+fn codex_resume_paths() -> guest_agent::paths::GuestPaths {
+    setup_env_once();
+    guest_agent::paths::GuestPaths::from_runtime_dir(
+        CODEX_RESUME_HOME
+            .join(".vm0")
+            .join("guest-agent")
+            .join("runs")
+            .join(guest_agent::env::run_id()),
+    )
+}
+
+fn session_file_paths() -> (String, String) {
+    let paths = codex_resume_paths();
+    (
+        paths.session_id_file().to_string(),
+        paths.session_history_path_file().to_string(),
+    )
+}
+
 /// Wipe the per-run session-id / history-path files so each test starts
 /// from a clean slate. Session metadata capture is idempotent (first id wins),
 /// so leaving stale files would mask real failures.
 fn reset_session_files() {
-    let _ = std::fs::remove_file(guest_agent::paths::session_id_file());
-    let _ = std::fs::remove_file(guest_agent::paths::session_history_path_file());
+    let (session_id_file, session_history_path_file) = session_file_paths();
+    let _ = std::fs::remove_file(session_id_file);
+    let _ = std::fs::remove_file(session_history_path_file);
 }
 
 struct CodexResumeFilesGuard;
@@ -171,12 +194,12 @@ fn send_event_extracts_codex_thread_id_and_writes_marker() {
         "send_event should succeed when no API token"
     );
 
-    let stored_id =
-        std::fs::read_to_string(guest_agent::paths::session_id_file()).expect("session id written");
+    let (session_id_file, session_history_path_file) = session_file_paths();
+    let stored_id = std::fs::read_to_string(&session_id_file).expect("session id written");
     assert_eq!(stored_id, thread_id);
 
-    let marker = std::fs::read_to_string(guest_agent::paths::session_history_path_file())
-        .expect("history-path file written");
+    let marker =
+        std::fs::read_to_string(&session_history_path_file).expect("history-path file written");
     assert!(
         marker.starts_with("CODEX_SEARCH:"),
         "codex framework should write a marker, got: {marker}"
@@ -229,12 +252,12 @@ fn send_event_canonicalizes_codex_thread_id_before_writing_marker() {
         "send_event should succeed when no API token"
     );
 
-    let stored_id =
-        std::fs::read_to_string(guest_agent::paths::session_id_file()).expect("session id written");
+    let (session_id_file, session_history_path_file) = session_file_paths();
+    let stored_id = std::fs::read_to_string(&session_id_file).expect("session id written");
     assert_eq!(stored_id, expected);
 
-    let marker = std::fs::read_to_string(guest_agent::paths::session_history_path_file())
-        .expect("history-path file written");
+    let marker =
+        std::fs::read_to_string(&session_history_path_file).expect("history-path file written");
     assert!(
         marker.ends_with(&format!(":{expected}")),
         "marker should use canonical thread id, got: {marker}"
@@ -250,14 +273,15 @@ fn send_event_seeds_existing_codex_thread_id_without_repairing_history_marker() 
     let thread_id = "0193abcd-ef01-7234-89ab-cdef01234567";
     for seed_empty_marker in [false, true] {
         reset_session_files();
-        guest_agent::paths::write_private(guest_agent::paths::session_id_file(), thread_id)
+        let (session_id_file, session_history_path_file) = session_file_paths();
+        guest_agent::paths::write_private(&session_id_file, thread_id)
             .expect("seed existing session id");
         if seed_empty_marker {
-            guest_agent::paths::write_private(guest_agent::paths::session_history_path_file(), "")
+            guest_agent::paths::write_private(&session_history_path_file, "")
                 .expect("seed empty history marker");
         } else {
             assert!(
-                !Path::new(guest_agent::paths::session_history_path_file()).exists(),
+                !Path::new(&session_history_path_file).exists(),
                 "history marker should start missing"
             );
         }
@@ -268,18 +292,17 @@ fn send_event_seeds_existing_codex_thread_id_without_repairing_history_marker() 
         let result = send_event_for_test(event, 1, &masker);
         assert!(result.is_ok());
 
-        let stored_id = std::fs::read_to_string(guest_agent::paths::session_id_file())
-            .expect("session id kept");
+        let stored_id = std::fs::read_to_string(&session_id_file).expect("session id kept");
         assert_eq!(stored_id, thread_id);
         if seed_empty_marker {
             assert_eq!(
-                std::fs::read_to_string(guest_agent::paths::session_history_path_file()).unwrap(),
+                std::fs::read_to_string(&session_history_path_file).unwrap(),
                 "",
                 "ordinary events must not repair empty history markers"
             );
         } else {
             assert!(
-                !Path::new(guest_agent::paths::session_history_path_file()).exists(),
+                !Path::new(&session_history_path_file).exists(),
                 "ordinary events must not create missing history markers"
             );
         }
@@ -295,7 +318,8 @@ fn legacy_recovery_checkpoint_derives_missing_codex_history_marker() {
 
     let thread_id = "0193abcd-ef01-7234-89ab-cdef01234567";
     let history = r#"{"type":"thread.started"}"#.to_string() + "\n";
-    guest_agent::paths::write_private(guest_agent::paths::session_id_file(), thread_id)
+    let (session_id_file, _) = session_file_paths();
+    guest_agent::paths::write_private(&session_id_file, thread_id)
         .expect("seed existing session id");
     write_codex_session_file(thread_id, &history).unwrap();
 
@@ -349,8 +373,9 @@ fn send_event_codex_ignores_non_thread_started_event() {
     let result = send_event_for_test(event, 1, &masker);
     assert!(result.is_ok());
 
+    let (session_id_file, _) = session_file_paths();
     assert!(
-        !Path::new(guest_agent::paths::session_id_file()).exists(),
+        !Path::new(&session_id_file).exists(),
         "session id file must not be written for non-thread.started events"
     );
 }
@@ -366,8 +391,9 @@ fn send_event_codex_ignores_empty_thread_id() {
     let result = send_event_for_test(event, 1, &masker);
     assert!(result.is_ok());
 
+    let (session_id_file, _) = session_file_paths();
     assert!(
-        !Path::new(guest_agent::paths::session_id_file()).exists(),
+        !Path::new(&session_id_file).exists(),
         "empty thread_id must not be persisted"
     );
 }
@@ -391,8 +417,9 @@ fn send_event_codex_ignores_malformed_thread_id() {
         let result = send_event_for_test(event, 1, &masker);
         assert!(result.is_ok());
 
+        let (session_id_file, _) = session_file_paths();
         assert!(
-            !Path::new(guest_agent::paths::session_id_file()).exists(),
+            !Path::new(&session_id_file).exists(),
             "malformed thread_id must not be persisted: {thread_id}"
         );
         if thread_id.len() >= 5 {

--- a/crates/guest-agent/tests/integration/checkpoint.rs
+++ b/crates/guest-agent/tests/integration/checkpoint.rs
@@ -13,6 +13,14 @@ fn runtime_from_process_env() -> Result<guest_agent::run_context::GuestRuntime, 
     guest_agent::run_context::GuestRuntime::from_process_env()
 }
 
+fn session_file_paths() -> (String, String) {
+    let paths = shared_guest_paths();
+    (
+        paths.session_id_file().to_string(),
+        paths.session_history_path_file().to_string(),
+    )
+}
+
 struct EnvVarRestore {
     key: &'static str,
     value: Option<OsString>,
@@ -39,7 +47,8 @@ impl Drop for EnvVarRestore {
 }
 
 fn write_derived_claude_history(session_id: &str, history: &str) -> Result<(), String> {
-    guest_agent::paths::write_private(guest_agent::paths::session_id_file(), session_id)
+    let (session_id_file, _) = session_file_paths();
+    guest_agent::paths::write_private(&session_id_file, session_id)
         .map_err(|e| format!("write session id: {e}"))?;
     let project_name = guest_agent::paths::CANONICAL_WORKING_DIR
         .strip_prefix('/')
@@ -64,14 +73,15 @@ fn write_literal_session_history(
     session_id: &str,
     history: &[u8],
 ) -> Result<tempfile::TempDir, String> {
+    let (session_id_file, session_history_path_file) = session_file_paths();
     let dir = tempfile::tempdir().map_err(|e| format!("create temp history dir: {e}"))?;
     let history_path = dir.path().join(format!("{session_id}.jsonl"));
     std::fs::write(&history_path, history)
         .map_err(|e| format!("write history {}: {e}", history_path.display()))?;
-    guest_agent::paths::write_private(guest_agent::paths::session_id_file(), session_id)
+    guest_agent::paths::write_private(&session_id_file, session_id)
         .map_err(|e| format!("write session id: {e}"))?;
     guest_agent::paths::write_private(
-        guest_agent::paths::session_history_path_file(),
+        &session_history_path_file,
         history_path.to_string_lossy().as_ref(),
     )
     .map_err(|e| format!("write session history marker: {e}"))?;
@@ -338,10 +348,10 @@ async fn recovery_checkpoint_uploads_valid_session_history() {
     let history_path = dir.path().join("history.jsonl");
     let history = r#"{"type":"system"}"#.to_string() + "\n" + r#"{"type":"assistant"}"# + "\n";
     std::fs::write(&history_path, &history).unwrap();
-    guest_agent::paths::write_private(guest_agent::paths::session_id_file(), "recovery-session")
-        .unwrap();
+    let (session_id_file, session_history_path_file) = session_file_paths();
+    guest_agent::paths::write_private(&session_id_file, "recovery-session").unwrap();
     guest_agent::paths::write_private(
-        guest_agent::paths::session_history_path_file(),
+        &session_history_path_file,
         history_path.to_string_lossy().as_ref(),
     )
     .unwrap();
@@ -401,7 +411,8 @@ async fn assert_recovery_checkpoint_derives_claude_history_marker(
     };
     let history = r#"{"type":"system"}"#.to_string() + "\n" + r#"{"type":"assistant"}"# + "\n";
     if seed_empty_marker {
-        guest_agent::paths::write_private(guest_agent::paths::session_history_path_file(), "")
+        let (_, session_history_path_file) = session_file_paths();
+        guest_agent::paths::write_private(&session_history_path_file, "")
             .map_err(|e| format!("write empty history marker: {e}"))?;
     }
     write_derived_claude_history(session_id, &history)?;
@@ -476,10 +487,10 @@ async fn recovery_checkpoint_rejects_partial_jsonl_without_error_file() {
         r#"{"type":"system"}"#.to_string() + "\n" + r#"{"type":"assistant""#,
     )
     .unwrap();
-    guest_agent::paths::write_private(guest_agent::paths::session_id_file(), "partial-session")
-        .unwrap();
+    let (session_id_file, session_history_path_file) = session_file_paths();
+    guest_agent::paths::write_private(&session_id_file, "partial-session").unwrap();
     guest_agent::paths::write_private(
-        guest_agent::paths::session_history_path_file(),
+        &session_history_path_file,
         history_path.to_string_lossy().as_ref(),
     )
     .unwrap();
@@ -589,8 +600,8 @@ async fn recovery_checkpoint_skips_when_derived_history_is_missing() {
 
     let runtime = runtime_from_process_env().unwrap();
     let _files_guard = SessionCheckpointFilesGuard::new();
-    guest_agent::paths::write_private(guest_agent::paths::session_id_file(), "missing-history")
-        .unwrap();
+    let (session_id_file, _) = session_file_paths();
+    guest_agent::paths::write_private(&session_id_file, "missing-history").unwrap();
 
     let prepare_mock = server.mock(|when, then| {
         when.method(POST)
@@ -624,8 +635,8 @@ async fn recovery_checkpoint_rejects_invalid_session_id_without_marker() {
 
     let runtime = runtime_from_process_env().unwrap();
     let _files_guard = SessionCheckpointFilesGuard::new();
-    guest_agent::paths::write_private(guest_agent::paths::session_id_file(), "../unsafe-session")
-        .unwrap();
+    let (session_id_file, _) = session_file_paths();
+    guest_agent::paths::write_private(&session_id_file, "../unsafe-session").unwrap();
 
     let prepare_mock = server.mock(|when, then| {
         when.method(POST)

--- a/crates/guest-agent/tests/integration/events.rs
+++ b/crates/guest-agent/tests/integration/events.rs
@@ -4,6 +4,14 @@ use guest_agent::masker::SecretMasker;
 use httpmock::prelude::*;
 use serde_json::json;
 
+fn session_file_paths() -> (String, String) {
+    let paths = shared_guest_paths();
+    (
+        paths.session_id_file().to_string(),
+        paths.session_history_path_file().to_string(),
+    )
+}
+
 // =========================================================================
 // Events
 // =========================================================================
@@ -84,8 +92,7 @@ async fn send_event_captures_session_metadata_before_masking() {
     let system_log_path = tmp.path().join("system.log");
     let _system_log_guard = SystemLogOverrideGuard::set(&system_log_path);
 
-    let sid_file = guest_agent::paths::session_id_file();
-    let hist_file = guest_agent::paths::session_history_path_file();
+    let (sid_file, hist_file) = session_file_paths();
 
     let mock = server.mock(|when, then| {
         when.method(POST)
@@ -107,12 +114,12 @@ async fn send_event_captures_session_metadata_before_masking() {
     assert!(result.is_ok());
     mock.assert_calls_async(1).await;
 
-    let stored = std::fs::read_to_string(sid_file).unwrap();
+    let stored = std::fs::read_to_string(&sid_file).unwrap();
     assert_eq!(
         stored, session_id,
         "checkpoint metadata should capture the unmasked session id"
     );
-    let history = std::fs::read_to_string(hist_file).unwrap();
+    let history = std::fs::read_to_string(&hist_file).unwrap();
     assert!(
         history.contains(session_id),
         "history path should contain the unmasked session id, got: {history}"
@@ -145,8 +152,7 @@ async fn prepare_event_does_not_capture_session_metadata() {
     let _api = SharedApiMock::new().await;
     let _session_files = SessionCheckpointFilesGuard::new();
 
-    let sid_file = guest_agent::paths::session_id_file();
-    let hist_file = guest_agent::paths::session_history_path_file();
+    let (sid_file, hist_file) = session_file_paths();
 
     let masker = SecretMasker::from_raw("");
     let event = json!({
@@ -159,11 +165,11 @@ async fn prepare_event_does_not_capture_session_metadata() {
     assert_eq!(payload["runId"], "test-run-001");
     assert_eq!(payload["events"][0]["sequenceNumber"], 1);
     assert!(
-        !std::path::Path::new(sid_file).exists(),
+        !std::path::Path::new(&sid_file).exists(),
         "prepare_event must not write the session ID file"
     );
     assert!(
-        !std::path::Path::new(hist_file).exists(),
+        !std::path::Path::new(&hist_file).exists(),
         "prepare_event must not write the session history path file"
     );
 }
@@ -174,8 +180,7 @@ async fn send_event_masks_invalid_session_id_without_checkpoint_metadata() {
     let server = api.server();
     let _session_files = SessionCheckpointFilesGuard::new();
 
-    let sid_file = guest_agent::paths::session_id_file();
-    let hist_file = guest_agent::paths::session_history_path_file();
+    let (sid_file, hist_file) = session_file_paths();
 
     let mock = server.mock(|when, then| {
         when.method(POST)
@@ -197,11 +202,11 @@ async fn send_event_masks_invalid_session_id_without_checkpoint_metadata() {
     mock.assert_calls_async(1).await;
     assert_eq!(masker.mask_string(session_id), "***");
     assert!(
-        !std::path::Path::new(sid_file).exists(),
+        !std::path::Path::new(&sid_file).exists(),
         "invalid session id must not be persisted"
     );
     assert!(
-        !std::path::Path::new(hist_file).exists(),
+        !std::path::Path::new(&hist_file).exists(),
         "invalid session id must not create a history marker"
     );
 }
@@ -212,10 +217,9 @@ async fn send_event_keeps_existing_session_metadata() {
     let server = api.server();
     let _session_files = SessionCheckpointFilesGuard::new();
 
-    let sid_file = guest_agent::paths::session_id_file();
-    let hist_file = guest_agent::paths::session_history_path_file();
-    guest_agent::paths::write_private(sid_file, "first-session").unwrap();
-    guest_agent::paths::write_private(hist_file, "/tmp/first-session.jsonl").unwrap();
+    let (sid_file, hist_file) = session_file_paths();
+    guest_agent::paths::write_private(&sid_file, "first-session").unwrap();
+    guest_agent::paths::write_private(&hist_file, "/tmp/first-session.jsonl").unwrap();
 
     let mock = server.mock(|when, then| {
         when.method(POST)
@@ -235,12 +239,12 @@ async fn send_event_keeps_existing_session_metadata() {
     assert!(result.is_ok());
     mock.assert_calls_async(1).await;
     assert_eq!(
-        std::fs::read_to_string(sid_file).unwrap(),
+        std::fs::read_to_string(&sid_file).unwrap(),
         "first-session",
         "later id-bearing events must not replace checkpoint session metadata"
     );
     assert_eq!(
-        std::fs::read_to_string(hist_file).unwrap(),
+        std::fs::read_to_string(&hist_file).unwrap(),
         "/tmp/first-session.jsonl",
         "later id-bearing events must not replace checkpoint history metadata"
     );
@@ -254,8 +258,7 @@ async fn send_event_seeds_existing_claude_session_id_without_repairing_history_m
     let server = api.server();
     let _session_files = SessionCheckpointFilesGuard::new();
 
-    let sid_file = guest_agent::paths::session_id_file();
-    let hist_file = guest_agent::paths::session_history_path_file();
+    let (sid_file, hist_file) = session_file_paths();
     let session_id = "session-repair";
 
     let mock = server.mock(|when, then| {
@@ -264,14 +267,14 @@ async fn send_event_seeds_existing_claude_session_id_without_repairing_history_m
     });
 
     for seed_empty_marker in [false, true] {
-        let _ = std::fs::remove_file(sid_file);
-        let _ = std::fs::remove_file(hist_file);
-        guest_agent::paths::write_private(sid_file, session_id).unwrap();
+        let _ = std::fs::remove_file(&sid_file);
+        let _ = std::fs::remove_file(&hist_file);
+        guest_agent::paths::write_private(&sid_file, session_id).unwrap();
         if seed_empty_marker {
-            guest_agent::paths::write_private(hist_file, "").unwrap();
+            guest_agent::paths::write_private(&hist_file, "").unwrap();
         } else {
             assert!(
-                !std::path::Path::new(hist_file).exists(),
+                !std::path::Path::new(&hist_file).exists(),
                 "history marker should start missing"
             );
         }
@@ -282,19 +285,19 @@ async fn send_event_seeds_existing_claude_session_id_without_repairing_history_m
 
         assert!(result.is_ok());
         assert_eq!(
-            std::fs::read_to_string(sid_file).unwrap(),
+            std::fs::read_to_string(&sid_file).unwrap(),
             session_id,
             "later events must keep the existing session id"
         );
         if seed_empty_marker {
             assert_eq!(
-                std::fs::read_to_string(hist_file).unwrap(),
+                std::fs::read_to_string(&hist_file).unwrap(),
                 "",
                 "ordinary events must not repair empty history markers"
             );
         } else {
             assert!(
-                !std::path::Path::new(hist_file).exists(),
+                !std::path::Path::new(&hist_file).exists(),
                 "ordinary events must not create missing history markers"
             );
         }
@@ -314,8 +317,7 @@ async fn send_event_extracts_claude_session_id() {
     let server = api.server();
     let _session_files = SessionCheckpointFilesGuard::new();
 
-    let sid_file = guest_agent::paths::session_id_file();
-    let hist_file = guest_agent::paths::session_history_path_file();
+    let (sid_file, hist_file) = session_file_paths();
 
     let mock = server.mock(|when, then| {
         when.method(POST).path("/api/webhooks/agent/events");
@@ -336,11 +338,11 @@ async fn send_event_extracts_claude_session_id() {
     mock.assert_calls_async(1).await;
 
     // Session ID persisted
-    let stored = std::fs::read_to_string(sid_file).unwrap();
+    let stored = std::fs::read_to_string(&sid_file).unwrap();
     assert_eq!(stored, "ses-abc-123");
 
     // Session history path written and contains the session ID
-    let history = std::fs::read_to_string(hist_file).unwrap();
+    let history = std::fs::read_to_string(&hist_file).unwrap();
     assert!(
         history.contains("ses-abc-123"),
         "history path should contain the session ID, got: {history}"
@@ -357,8 +359,7 @@ async fn send_event_rejects_unsafe_claude_session_id() {
     let server = api.server();
     let _session_files = SessionCheckpointFilesGuard::new();
 
-    let sid_file = guest_agent::paths::session_id_file();
-    let hist_file = guest_agent::paths::session_history_path_file();
+    let (sid_file, hist_file) = session_file_paths();
     let invalid_session_ids = ["../escape", "nested/id", "nested\\id", ".", "..", "bad\nid"];
 
     let mock = server.mock(|when, then| {
@@ -367,8 +368,8 @@ async fn send_event_rejects_unsafe_claude_session_id() {
     });
 
     for session_id in invalid_session_ids {
-        let _ = std::fs::remove_file(sid_file);
-        let _ = std::fs::remove_file(hist_file);
+        let _ = std::fs::remove_file(&sid_file);
+        let _ = std::fs::remove_file(&hist_file);
 
         let masker = SecretMasker::from_raw("");
         let event = json!({
@@ -380,11 +381,11 @@ async fn send_event_rejects_unsafe_claude_session_id() {
 
         assert!(result.is_ok());
         assert!(
-            !std::path::Path::new(sid_file).exists(),
+            !std::path::Path::new(&sid_file).exists(),
             "unsafe session_id must not be persisted: {session_id:?}"
         );
         assert!(
-            !std::path::Path::new(hist_file).exists(),
+            !std::path::Path::new(&hist_file).exists(),
             "unsafe session_id must not write a history marker: {session_id:?}"
         );
     }
@@ -398,7 +399,7 @@ async fn send_event_skips_session_id_for_non_init() {
     let server = api.server();
     let _session_files = SessionCheckpointFilesGuard::new();
 
-    let sid_file = guest_agent::paths::session_id_file();
+    let (sid_file, _) = session_file_paths();
 
     let mock = server.mock(|when, then| {
         when.method(POST).path("/api/webhooks/agent/events");
@@ -413,7 +414,7 @@ async fn send_event_skips_session_id_for_non_init() {
     mock.assert_calls_async(1).await;
 
     assert!(
-        !std::path::Path::new(sid_file).exists(),
+        !std::path::Path::new(&sid_file).exists(),
         "session ID file should NOT be written for non-init events"
     );
 }

--- a/crates/guest-agent/tests/integration/support.rs
+++ b/crates/guest-agent/tests/integration/support.rs
@@ -10,6 +10,12 @@ use tokio::sync::Notify;
 
 pub(crate) use crate::common::SystemLogOverrideGuard;
 
+pub(crate) static MOCK_RUNTIME_DIR: LazyLock<PathBuf> = LazyLock::new(|| {
+    crate::common::unique_temp_path("vm0-guest-agent-integration")
+        .join("runs")
+        .join("test-run-001")
+});
+
 /// Shared mock server - env vars are set once before any `LazyLock` in the
 /// library is accessed, so environment-backed guest-agent state resolves to
 /// test values.
@@ -22,9 +28,7 @@ pub(crate) static MOCK_SERVER: LazyLock<MockServer> = LazyLock::new(|| {
         std::env::set_var("VM0_RUN_ID", "test-run-001");
         std::env::set_var(
             guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
-            crate::common::unique_temp_path("vm0-guest-agent-integration")
-                .join("runs")
-                .join("test-run-001"),
+            MOCK_RUNTIME_DIR.as_os_str(),
         );
         std::env::set_var("VM0_PROMPT", "test prompt");
         std::env::set_var("VERCEL_PROTECTION_BYPASS", "test-bypass-value");
@@ -117,6 +121,11 @@ pub(crate) fn test_http_client(retry_delay: Duration) -> guest_agent::http::Http
         retry_delay,
     )
     .expect("build test http client")
+}
+
+pub(crate) fn shared_guest_paths() -> guest_agent::paths::GuestPaths {
+    let _server = &*MOCK_SERVER;
+    guest_agent::paths::GuestPaths::from_runtime_dir(MOCK_RUNTIME_DIR.as_path())
 }
 
 pub(crate) fn http_status(status: u16) -> HttpMockResponse {
@@ -219,12 +228,13 @@ impl MockCallObserver {
 }
 
 fn cleanup_session_checkpoint_files() {
-    let _ = std::fs::remove_file(guest_agent::paths::session_id_file());
-    let _ = std::fs::remove_file(guest_agent::paths::session_history_path_file());
-    let _ = std::fs::remove_file(guest_agent::paths::final_session_history_identity_file());
-    let _ = std::fs::remove_file(guest_agent::paths::checkpoint_error_file());
-    let _ = std::fs::remove_file(guest_agent::paths::failure_diagnostic_file());
-    let _ = std::fs::remove_file(guest_agent::paths::event_error_flag());
+    let paths = shared_guest_paths();
+    let _ = std::fs::remove_file(paths.session_id_file());
+    let _ = std::fs::remove_file(paths.session_history_path_file());
+    let _ = std::fs::remove_file(paths.final_session_history_identity_file());
+    let _ = std::fs::remove_file(paths.checkpoint_error_file());
+    let _ = std::fs::remove_file(paths.failure_diagnostic_file());
+    let _ = std::fs::remove_file(paths.event_error_flag());
 }
 
 pub(crate) struct SessionCheckpointFilesGuard;


### PR DESCRIPTION
## Summary
- remove public run-scoped guest-agent path reader facades and the LazyLock-backed default path cache
- keep legacy env callers behind a crate-private process-env path helper while runtime code continues to use explicit GuestPaths
- update guest-agent tests to derive paths from explicit runtime fixtures

Closes #19594

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all -- --check
- git diff --check
- cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets -- -D warnings
- cargo test --manifest-path crates/Cargo.toml -p guest-agent --lib paths
- cargo test --manifest-path crates/Cargo.toml -p guest-agent --test integration -- --test-threads=1
- cargo test --manifest-path crates/Cargo.toml -p guest-agent --test codex_session_resume -- --test-threads=1
- cargo test --manifest-path crates/Cargo.toml -p guest-agent --bin guest-agent -- --test-threads=1
- cargo test --manifest-path crates/Cargo.toml -p guest-agent --all-targets