### PR TITLE
test: wait for thread content before model picker assertions

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -1166,8 +1166,7 @@ describe("chat composer models", () => {
     detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
 
     await screen.findByText("Use GLM");
-    await expectComposerModel("GLM-5.1");
-    await user.click(screen.getByRole("combobox", { name: "GLM-5.1" }));
+    await user.click(await findComposerModel("GLM-5.1"));
     await user.click(
       await screen.findByRole("option", { name: /Claude Sonnet 4\.6/ }),
     );
@@ -1211,8 +1210,7 @@ describe("chat composer models", () => {
         expect(preferenceRequestStarted).toBeTruthy();
       });
       await screen.findByText("Use GLM");
-      await expectComposerModel("GLM-5.1");
-      await user.click(screen.getByRole("combobox", { name: "GLM-5.1" }));
+      await user.click(await findComposerModel("GLM-5.1"));
       await user.click(
         await screen.findByRole("option", { name: /Claude Sonnet 4\.6/ }),
       );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -1208,9 +1208,9 @@ describe("chat composer models", () => {
 
     try {
       await waitFor(() => {
-        expect(document.title).toContain("My thread");
         expect(preferenceRequestStarted).toBeTruthy();
       });
+      await screen.findByText("Use GLM");
       await expectComposerModel("GLM-5.1");
       await user.click(screen.getByRole("combobox", { name: "GLM-5.1" }));
       await user.click(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -1165,10 +1165,9 @@ describe("chat composer models", () => {
 
     detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
 
-    await waitFor(() => {
-      expect(document.title).toBe("My thread | VM0");
-    });
-    await user.click(await findComposerModel("GLM-5.1"));
+    await screen.findByText("Use GLM");
+    await expectComposerModel("GLM-5.1");
+    await user.click(screen.getByRole("combobox", { name: "GLM-5.1" }));
     await user.click(
       await screen.findByRole("option", { name: /Claude Sonnet 4\.6/ }),
     );
@@ -1209,6 +1208,7 @@ describe("chat composer models", () => {
 
     try {
       await waitFor(() => {
+        expect(document.title).toContain("My thread");
         expect(preferenceRequestStarted).toBeTruthy();
       });
       await expectComposerModel("GLM-5.1");


### PR DESCRIPTION
## Summary
- wait for the current chat thread content before asserting the thread model picker label
- keep the pending user preference regression test synchronized on current page-rendered state before checking the picker

## Why
The merge-queue run https://github.com/vm0-ai/vm0/actions/runs/28511750872/job/84513587684 failed because the thread override test used one Testing Library wait window for page startup plus model picker rendering. Under the CI shard load, that occasionally hit the default timeout before the GLM-5.1 picker was visible.

Waiting for the mocked thread message first gives the test a current-DOM page readiness point without relying on stale document title state from a previous test.

## Validation
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx --testNamePattern "shows thread override over user and workspace defaults, then remains editable|edits thread override before user default model selection resolves"
- pnpm vitest run --project=@vm0/app --shard=4/8 --coverage.enabled --coverage.reporter=json
- pnpm -F @vm0/app run lint
- pnpm -F @vm0/app run check-types
- pre-commit: pnpm check-types