### PR TITLE
feat: add in-canvas image editing (remove background, enhance)

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/right-sidebar-search-params.ts
+++ b/turbo/apps/platform/src/signals/zero-page/right-sidebar-search-params.ts
@@ -2,6 +2,7 @@ export const ARTIFACT_QUERY_PARAM = "artifact";
 export const ARTIFACT_INBOX_QUERY_PARAM = "artifacts";
 export const ARTIFACT_FULLSCREEN_PARAM = "artifact-fullscreen";
 export const ARTIFACT_HTML_EDIT_PARAM = "artifact-html-edit";
+export const ARTIFACT_IMAGE_EDIT_PARAM = "artifact-image-edit";
 export const PRESENTATION_EDITOR_QUERY_PARAM = "presentation-editor";
 export const CHAT_AUTOMATIONS_QUERY_PARAM = "automations";
 
@@ -10,6 +11,7 @@ export function clearArtifactSidebarParams(params: URLSearchParams): void {
   params.delete(ARTIFACT_INBOX_QUERY_PARAM);
   params.delete(ARTIFACT_FULLSCREEN_PARAM);
   params.delete(ARTIFACT_HTML_EDIT_PARAM);
+  params.delete(ARTIFACT_IMAGE_EDIT_PARAM);
   params.delete(PRESENTATION_EDITOR_QUERY_PARAM);
 }
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-image-edit.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-image-edit.ts
@@ -1,0 +1,160 @@
+import { command, computed, state } from "ccstate";
+import { delay } from "signal-timers";
+import { zeroImageIoGenerateContract } from "@vm0/api-contracts/contracts/zero-image-io-generate";
+import { zeroBuiltInGenerationContract } from "@vm0/api-contracts/contracts/zero-built-in-generation";
+import { toast } from "@vm0/ui/components/ui/sonner";
+import {
+  searchParams$,
+  replaceSearchParams$,
+  updateSearchParams$,
+} from "../route.ts";
+import { accept } from "../../lib/accept.ts";
+import { now } from "../../lib/time.ts";
+import { zeroClient$ } from "../api-client.ts";
+import { resetSignal, withCleanup } from "../utils.ts";
+import { publicAttachmentUrl } from "../../views/zero-page/zero-attachment-url.ts";
+import {
+  ARTIFACT_FULLSCREEN_PARAM,
+  ARTIFACT_HTML_EDIT_PARAM,
+  ARTIFACT_IMAGE_EDIT_PARAM,
+  ARTIFACT_INBOX_QUERY_PARAM,
+  ARTIFACT_QUERY_PARAM,
+  clearChatAutomationSidebarParams,
+} from "./right-sidebar-search-params.ts";
+
+// ---------------------------------------------------------------------------
+// Image editing — an EDIT mode of the artifact sidebar that shows a single
+// image on a canvas with a floating toolbar. Each toolbar action calls the
+// image-generation API with model `nano-banana-2` and a canned prompt, polls
+// for completion, then swaps the shown image for the result while staying in
+// edit mode. Gated by the `imageEditing` feature switch.
+// ---------------------------------------------------------------------------
+
+export type ImageEditOperation = "removeBackground" | "enhance";
+
+const IMAGE_EDIT_MODEL = "nano-banana-2";
+const POLL_INTERVAL_MS = 1500;
+const POLL_TIMEOUT_MS = 90_000;
+
+const IMAGE_EDIT_PROMPTS = {
+  removeBackground:
+    "Remove the background completely. Keep only the main subject on a plain solid white background. Do not alter the subject.",
+  enhance:
+    "Enhance this image to high definition. Increase sharpness, clarity and fine detail while faithfully preserving the original content, composition and colors.",
+} as const satisfies Record<ImageEditOperation, string>;
+
+const IMAGE_EDIT_SUCCESS_TOAST = {
+  removeBackground: "Background removed",
+  enhance: "Image enhanced",
+} as const satisfies Record<ImageEditOperation, string>;
+
+const internalImageEditProcessing$ = state<null | ImageEditOperation>(null);
+const resetImageEditSignal$ = resetSignal();
+
+export const artifactImageEditMode$ = computed((get) => {
+  return get(searchParams$).get(ARTIFACT_IMAGE_EDIT_PARAM) === "1";
+});
+
+export const imageEditProcessing$ = computed((get) => {
+  return get(internalImageEditProcessing$);
+});
+
+export const openArtifactImageEdit$ = command(({ get, set }, url: string) => {
+  const params = new URLSearchParams(get(searchParams$));
+  params.set(ARTIFACT_QUERY_PARAM, url);
+  params.set(ARTIFACT_IMAGE_EDIT_PARAM, "1");
+  params.delete(ARTIFACT_INBOX_QUERY_PARAM);
+  params.delete(ARTIFACT_HTML_EDIT_PARAM);
+  params.delete(ARTIFACT_FULLSCREEN_PARAM);
+  clearChatAutomationSidebarParams(params);
+  set(updateSearchParams$, params);
+});
+
+export const closeArtifactImageEdit$ = command(({ get, set }) => {
+  const params = new URLSearchParams(get(searchParams$));
+  params.delete(ARTIFACT_IMAGE_EDIT_PARAM);
+  set(replaceSearchParams$, params);
+});
+
+function readResultImageUrl(
+  result: Record<string, unknown> | undefined,
+): string {
+  const url = result?.url;
+  if (typeof url !== "string" || !url) {
+    throw new Error("Image edit result is missing a url");
+  }
+  return url;
+}
+
+export const runImageEdit$ = command(
+  async (
+    { get, set },
+    args: { url: string; operation: ImageEditOperation },
+    parentSignal: AbortSignal,
+  ) => {
+    if (get(internalImageEditProcessing$) !== null) {
+      return;
+    }
+
+    const signal = set(resetImageEditSignal$, parentSignal);
+    set(internalImageEditProcessing$, args.operation);
+
+    const run = async () => {
+      const absoluteUrl = publicAttachmentUrl(args.url);
+      const generateClient = get(zeroClient$)(zeroImageIoGenerateContract, {
+        apiBase: "api",
+      });
+      const accepted = await accept(
+        generateClient.post({
+          body: {
+            model: IMAGE_EDIT_MODEL,
+            prompt: IMAGE_EDIT_PROMPTS[args.operation],
+            sourceImageUrls: [absoluteUrl],
+          },
+          fetchOptions: { signal },
+        }),
+        [202],
+      );
+      signal.throwIfAborted();
+
+      const generationId = accepted.body.generationId;
+      const generationClient = get(zeroClient$)(zeroBuiltInGenerationContract, {
+        apiBase: "api",
+      });
+
+      const deadline = now() + POLL_TIMEOUT_MS;
+      while (now() < deadline) {
+        const polled = await accept(
+          generationClient.get({
+            params: { generationId },
+            fetchOptions: { signal },
+          }),
+          [200],
+        );
+        signal.throwIfAborted();
+
+        if (polled.body.status === "completed") {
+          const resultUrl = readResultImageUrl(polled.body.result);
+          const params = new URLSearchParams(get(searchParams$));
+          params.set(ARTIFACT_QUERY_PARAM, resultUrl);
+          params.set(ARTIFACT_IMAGE_EDIT_PARAM, "1");
+          set(updateSearchParams$, params);
+          toast.success(IMAGE_EDIT_SUCCESS_TOAST[args.operation]);
+          return;
+        }
+        if (polled.body.status === "failed") {
+          toast.error("Couldn't edit the image, try again");
+          return;
+        }
+
+        await delay(POLL_INTERVAL_MS, { signal });
+      }
+
+      toast.error("Couldn't edit the image, try again");
+    };
+
+    await withCleanup(run(), () => {
+      set(internalImageEditProcessing$, null);
+    });
+  },
+);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-image-edit.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-image-edit.test.tsx
@@ -1,0 +1,213 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { describe, expect, it } from "vitest";
+
+import {
+  chatThreadByIdContract,
+  chatThreadMessagesContract,
+  chatThreadsContract,
+  type PagedChatMessage,
+} from "@vm0/api-contracts/contracts/chat-threads";
+import { zeroImageIoGenerateContract } from "@vm0/api-contracts/contracts/zero-image-io-generate";
+import { zeroBuiltInGenerationContract } from "@vm0/api-contracts/contracts/zero-built-in-generation";
+
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+
+const context = testContext();
+const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
+const THREAD_ID = "b0000000-0000-4000-a000-000000000041";
+const THREAD_PATH = `/chats/${THREAD_ID}`;
+const GENERATION_ID = "d0000000-0000-4000-a000-000000000099";
+const SOURCE_IMAGE_URL =
+  "https://cdn.vm7.io/artifacts/test/image-edit/source.png";
+const EDITED_IMAGE_URL =
+  "https://cdn.vm7.io/artifacts/test/image-edit/edited.png";
+
+function setupChatThread({
+  featureSwitches,
+}: {
+  featureSwitches?: Parameters<typeof detachedSetupPage>[0]["featureSwitches"];
+}): void {
+  context.mocks.data.team([
+    {
+      id: AGENT_ID,
+      ownerId: "test-user-123",
+      displayName: "Zero",
+      description: null,
+      sound: null,
+      avatarUrl: null,
+      visibility: "public",
+      headVersionId: "version_1",
+      updatedAt: "2024-01-01T00:00:00Z",
+    },
+  ]);
+
+  const messages: PagedChatMessage[] = [
+    {
+      id: "msg-image-user",
+      role: "user",
+      content: "Here is the image",
+      runId: "run-image",
+      createdAt: "2026-03-10T00:00:00Z",
+      attachFiles: [
+        {
+          id: "artifact-image-edit-source",
+          filename: "source.png",
+          contentType: "image/png",
+          size: 128,
+          url: SOURCE_IMAGE_URL,
+        },
+      ],
+    },
+    {
+      id: "msg-image-assistant",
+      role: "assistant",
+      content: "Image is ready.",
+      runId: "run-image",
+      createdAt: "2026-03-10T00:00:01Z",
+    },
+    {
+      id: "msg-image-completed",
+      role: "assistant",
+      content: null,
+      runId: "run-image",
+      runLifecycleEvent: "completed",
+      createdAt: "2026-03-10T00:00:02Z",
+    },
+  ];
+
+  context.mocks.api(chatThreadByIdContract.get, ({ respond }) => {
+    return respond(200, {
+      id: THREAD_ID,
+      title: null,
+      agentId: AGENT_ID,
+      activeRunIds: [],
+      draftContent: null,
+      draftAttachments: null,
+      createdAt: "2026-03-10T00:00:00Z",
+      updatedAt: "2026-03-10T00:00:00Z",
+    });
+  });
+  context.mocks.api(chatThreadMessagesContract.list, ({ query, respond }) => {
+    if (query.sinceId || query.beforeId) {
+      return respond(200, { messages: [] });
+    }
+    return respond(200, { messages, hasHistoryBefore: false });
+  });
+  context.mocks.api(chatThreadsContract.list, ({ respond }) => {
+    return respond(200, {
+      pinned: [],
+      threads: [],
+      hasMore: false,
+      nextCursor: null,
+    });
+  });
+
+  detachedSetupPage({
+    context,
+    featureSwitches,
+    path: `${THREAD_PATH}?artifact=${encodeURIComponent(SOURCE_IMAGE_URL)}`,
+  });
+}
+
+function mockImageEditGeneration(): void {
+  context.mocks.api(zeroImageIoGenerateContract.post, ({ respond }) => {
+    return respond(202, {
+      generationId: GENERATION_ID,
+      type: "image",
+      status: "queued",
+      realtime: {
+        channelName: "gen:image",
+        eventName: "update",
+        tokenRequest: {
+          keyName: "test-key",
+          timestamp: 0,
+          capability: "{}",
+          nonce: "test-nonce",
+          mac: "test-mac",
+        },
+      },
+    });
+  });
+  context.mocks.api(zeroBuiltInGenerationContract.get, ({ respond }) => {
+    return respond(200, {
+      generationId: GENERATION_ID,
+      type: "image",
+      status: "completed",
+      result: { url: EDITED_IMAGE_URL },
+      createdAt: "2026-03-10T00:00:00Z",
+      startedAt: "2026-03-10T00:00:01Z",
+      completedAt: "2026-03-10T00:00:02Z",
+    });
+  });
+}
+
+describe("image editing", () => {
+  it("opens edit mode from the lightbox and applies remove background", async () => {
+    const user = userEvent.setup({ delay: null });
+    mockImageEditGeneration();
+    setupChatThread({
+      featureSwitches: { [FeatureSwitchKey.ImageEditing]: true },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("artifact-sidebar-body-image")).toHaveAttribute(
+        "alt",
+        "source.png",
+      );
+    });
+
+    await user.click(screen.getByLabelText("Preview source.png"));
+    await waitFor(() => {
+      expect(screen.getByTestId("attachment-lightbox-image")).toHaveAttribute(
+        "alt",
+        "source.png",
+      );
+    });
+
+    await user.click(screen.getByTestId("image-edit-open"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("image-edit-toolbar")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByTestId("image-edit-remove-background"),
+    ).toHaveTextContent("Remove background");
+    expect(screen.getByTestId("image-edit-enhance")).toHaveTextContent(
+      "Enhance",
+    );
+
+    await user.click(screen.getByTestId("image-edit-remove-background"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("artifact-sidebar-body-image")).toHaveAttribute(
+        "src",
+        EDITED_IMAGE_URL,
+      );
+    });
+  });
+
+  it("hides the edit action when the feature switch is off", async () => {
+    const user = userEvent.setup({ delay: null });
+    setupChatThread({});
+
+    await waitFor(() => {
+      expect(screen.getByTestId("artifact-sidebar-body-image")).toHaveAttribute(
+        "alt",
+        "source.png",
+      );
+    });
+
+    await user.click(screen.getByLabelText("Preview source.png"));
+    await waitFor(() => {
+      expect(screen.getByTestId("attachment-lightbox-image")).toHaveAttribute(
+        "alt",
+        "source.png",
+      );
+    });
+
+    expect(screen.queryByTestId("image-edit-open")).toBeNull();
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -22,6 +22,7 @@ import {
   useSet,
 } from "ccstate-react";
 import {
+  Button,
   cn,
   DropdownMenu,
   DropdownMenuContent,
@@ -54,6 +55,13 @@ import {
   TextPreviewLoader,
 } from "./zero-attachment-chips.tsx";
 import { lightboxDialogVisible$ } from "../../signals/zero-page/zero-attachment-chips.ts";
+import {
+  artifactImageEditMode$,
+  closeArtifactImageEdit$,
+  imageEditProcessing$,
+  runImageEdit$,
+  type ImageEditOperation,
+} from "../../signals/zero-page/zero-image-edit.ts";
 import { Markdown } from "../components/markdown.tsx";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detach, jsonParseOr, Reason } from "../../signals/utils.ts";
@@ -1088,10 +1096,11 @@ function ArtifactBody({
   }
   if (kind === "image") {
     return (
-      <ArtifactImageBody
+      <ArtifactImageBodyDispatch
         imageNavigation={imageNavigation}
         url={url}
         filename={filename}
+        pageSignal={pageSignal}
       />
     );
   }
@@ -1362,6 +1371,37 @@ function ArtifactCsvBody({
   );
 }
 
+function ArtifactImageBodyDispatch({
+  imageNavigation,
+  url,
+  filename,
+  pageSignal,
+}: {
+  imageNavigation?: ArtifactImageNavigationActions;
+  url: string;
+  filename: string;
+  pageSignal: AbortSignal;
+}) {
+  const editMode = useGet(artifactImageEditMode$);
+  if (editMode) {
+    return (
+      <ArtifactImageEditBody
+        imageNavigation={imageNavigation}
+        url={url}
+        filename={filename}
+        pageSignal={pageSignal}
+      />
+    );
+  }
+  return (
+    <ArtifactImageBody
+      imageNavigation={imageNavigation}
+      url={url}
+      filename={filename}
+    />
+  );
+}
+
 function ArtifactImageBody({
   imageNavigation,
   url,
@@ -1399,6 +1439,128 @@ function ArtifactImageBody({
             }}
           </ZoomableArtifactImageCanvas>
           <ArtifactImageNavigationControls navigation={imageNavigation} />
+        </div>
+      </ArtifactStageCard>
+    </ArtifactStageShell>
+  );
+}
+
+function ArtifactImageEditToolbarButton({
+  activeOperation,
+  label,
+  onClick,
+  operation,
+  testId,
+}: {
+  activeOperation: ImageEditOperation | null;
+  label: string;
+  onClick: () => void;
+  operation: ImageEditOperation;
+  testId: string;
+}) {
+  const processing = activeOperation !== null;
+  const active = activeOperation === operation;
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      className="h-8 gap-1.5 rounded-lg border-border/70 bg-gray-50 px-3 text-xs font-medium hover:bg-gray-100"
+      disabled={processing}
+      data-testid={testId}
+      onClick={onClick}
+    >
+      {active && <IconLoader2 size={14} className="animate-spin" />}
+      {label}
+    </Button>
+  );
+}
+
+function ArtifactImageEditBody({
+  imageNavigation,
+  url,
+  filename,
+  pageSignal,
+}: {
+  imageNavigation?: ArtifactImageNavigationActions;
+  url: string;
+  filename: string;
+  pageSignal: AbortSignal;
+}) {
+  const fullscreen = useGet(artifactFullscreen$);
+  const modalOpen = useGet(lightboxDialogVisible$);
+  const activeOperation = useGet(imageEditProcessing$);
+  const runImageEdit = useSet(runImageEdit$);
+  const closeImageEdit = useSet(closeArtifactImageEdit$);
+
+  const onOperation = (operation: ImageEditOperation) => {
+    detach(
+      runImageEdit({ url, operation }, pageSignal),
+      Reason.DomCallback,
+      "runImageEdit",
+    );
+  };
+
+  return (
+    <ArtifactStageShell flush scrollable={false}>
+      <ArtifactStageCard fillHeight>
+        <div className="relative h-full min-h-0">
+          <ArtifactSidebarImageNavigationKeydown
+            fullscreen={fullscreen}
+            modalOpen={modalOpen}
+            navigation={imageNavigation}
+          />
+          <ZoomableArtifactImageCanvas
+            src={publicAttachmentUrl(url)}
+            alt={filename}
+            zoomKey={zoomableArtifactImageKey(
+              "artifact-sidebar",
+              url,
+              fullscreen ? "fullscreen" : "sidebar",
+            )}
+            imageTestId="artifact-sidebar-body-image"
+            contentClassName="p-6"
+          >
+            {(controls) => {
+              return <ArtifactImageZoomControls controls={controls} />;
+            }}
+          </ZoomableArtifactImageCanvas>
+          <div
+            data-testid="image-edit-toolbar"
+            className="absolute bottom-4 left-1/2 flex -translate-x-1/2 items-center gap-2 rounded-2xl border border-border/70 bg-gray-50/95 px-2 py-2 backdrop-blur"
+          >
+            <ArtifactImageEditToolbarButton
+              activeOperation={activeOperation}
+              label="Remove background"
+              onClick={() => {
+                onOperation("removeBackground");
+              }}
+              operation="removeBackground"
+              testId="image-edit-remove-background"
+            />
+            <ArtifactImageEditToolbarButton
+              activeOperation={activeOperation}
+              label="Enhance"
+              onClick={() => {
+                onOperation("enhance");
+              }}
+              operation="enhance"
+              testId="image-edit-enhance"
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-8 rounded-lg px-3 text-xs font-medium"
+              disabled={activeOperation !== null}
+              data-testid="image-edit-done"
+              onClick={() => {
+                closeImageEdit();
+              }}
+            >
+              Done
+            </Button>
+          </div>
         </div>
       </ArtifactStageCard>
     </ArtifactStageShell>

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -16,6 +16,7 @@ import {
   IconFileMusic,
   IconPhoto,
   IconPencil,
+  IconWand,
   IconLoader2,
   IconZoomReset,
   IconX,
@@ -62,6 +63,7 @@ import {
   openArtifactSidebarPreview$,
   openPresentationEditor$,
 } from "../../signals/zero-page/zero-artifact-sidebar.ts";
+import { openArtifactImageEdit$ } from "../../signals/zero-page/zero-image-edit.ts";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import {
   presentationHtmlPreviewUrl,
@@ -274,10 +276,12 @@ function LightboxBodyScrollLock() {
 function DialogIconButton({
   ariaLabel,
   children,
+  dataTestId,
   onClick,
 }: {
   ariaLabel: string;
   children: ReactNode;
+  dataTestId?: string;
   onClick: () => void;
 }) {
   return (
@@ -287,6 +291,7 @@ function DialogIconButton({
       className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
       aria-label={ariaLabel}
       title={ariaLabel}
+      data-testid={dataTestId}
     >
       {children}
     </button>
@@ -338,6 +343,18 @@ function ArtifactDialogEditHtmlButton({ onClick }: { onClick: () => void }) {
   return (
     <DialogIconButton ariaLabel="Edit page" onClick={onClick}>
       <IconPencil size={18} stroke={1.8} />
+    </DialogIconButton>
+  );
+}
+
+function ArtifactDialogEditImageButton({ onClick }: { onClick: () => void }) {
+  return (
+    <DialogIconButton
+      ariaLabel="Edit image"
+      dataTestId="image-edit-open"
+      onClick={onClick}
+    >
+      <IconWand size={18} stroke={1.8} />
     </DialogIconButton>
   );
 }
@@ -1057,6 +1074,7 @@ function ArtifactPreviewDialogActions({
 }) {
   const closeLightboxWithDialogExit = useSet(closeLightboxWithDialogExit$);
   const openArtifactSidebarHtmlEdit = useSet(openArtifactSidebarHtmlEdit$);
+  const openArtifactImageEdit = useSet(openArtifactImageEdit$);
   const openArtifactSidebarPreview = useSet(openArtifactSidebarPreview$);
   const openPresentationEditor = useSet(openPresentationEditor$);
   const resetZoomableImageCanvasZoom = useSet(resetZoomableImageCanvasZoom$);
@@ -1070,6 +1088,9 @@ function ArtifactPreviewDialogActions({
     preview.kind === "html" &&
     artifact?.artifactKind === "hosted-site" &&
     Boolean(features?.[FeatureSwitchKey.HtmlArtifactCommentEditing]);
+  const showImageEdit =
+    preview.kind === "image" &&
+    Boolean(features?.[FeatureSwitchKey.ImageEditing]);
   const resetDialogImageZoom = (targetFullscreen: boolean) => {
     resetArtifactDialogImageZoom({
       fullscreen,
@@ -1090,6 +1111,14 @@ function ArtifactPreviewDialogActions({
   };
   const openHtmlEditInSplitView = () => {
     openArtifactSidebarHtmlEdit({ fullscreen, url: preview.url });
+    closeLightboxWithDialogExit();
+  };
+  const openImageEditInSplitView = () => {
+    resetDialogImageZoom(fullscreen);
+    resetZoomableImageCanvasZoom(
+      zoomableArtifactImageKey("artifact-sidebar", preview.url, "sidebar"),
+    );
+    openArtifactImageEdit(preview.url);
     closeLightboxWithDialogExit();
   };
 
@@ -1119,6 +1148,12 @@ function ArtifactPreviewDialogActions({
       {showHtmlEdit && (
         <>
           <ArtifactDialogEditHtmlButton onClick={openHtmlEditInSplitView} />
+          <ArtifactActionSeparator />
+        </>
+      )}
+      {showImageEdit && (
+        <>
+          <ArtifactDialogEditImageButton onClick={openImageEditInSplitView} />
           <ArtifactActionSeparator />
         </>
       )}

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -56,4 +56,5 @@ export enum FeatureSwitchKey {
   AgentsPageRedesign = "agentsPageRedesign",
   SidebarSubscriptionUsage = "sidebarSubscriptionUsage",
   TeamsIntegration = "teamsIntegration",
+  ImageEditing = "imageEditing",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -323,6 +323,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.ImageEditing]: {
+    maintainer: "bingjie@vm0.ai",
+    description:
+      "Enable in-canvas image editing (remove background, enhance) from the image preview and artifact sidebar.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
 };
 
 interface ResolvedHashes {


### PR DESCRIPTION
## What

Adds an **image editing mode** reachable from the image preview, behind a new `imageEditing` feature switch (off by default, staff orgs only).

- The image lightbox gains an **Edit image** action.
- Clicking it moves the image into the artifact sidebar on a **canvas**, in edit mode.
- A floating toolbar offers two operations: **Remove background** and **Enhance**.
- Each calls the existing `POST /api/zero/image-io/generate` with model `nano-banana-2` + a canned prompt, polls `GET /api/zero/built-in-generations/:id` until completion, then swaps the shown image for the result (URL-as-source-of-truth, so the canvas refreshes) while staying in edit mode.

## Why nano-banana (interim)

This is the **quick path**: it reuses the existing fal.ai image pipeline, so there is **no backend or billing change** in this PR. Known tradeoffs of using nano-banana with canned prompts:

- Remove background produces a **white background**, not true alpha transparency.
- Enhance **repaints** the image (no real resolution increase) and may slightly alter detail.

A follow-up backend PR will add dedicated models (`birefnet/v2` for true cutout, `clarity-upscaler` for real upscaling) + pricing; once both are ready we swap the frontend `model` over. Tracking that PR separately.

## Changes

- `feature-switch-key.ts` / `feature-switch.ts` — new `ImageEditing` switch.
- `right-sidebar-search-params.ts` — new `artifact-image-edit` URL param.
- `signals/zero-page/zero-image-edit.ts` (new) — edit-mode commands + `runImageEdit$` (generate → poll → swap).
- `zero-attachment-chips.tsx` — Edit image action in the lightbox (gated).
- `zero-artifact-sidebar.tsx` — canvas edit body + floating toolbar.
- Tests — golden path (enter edit mode, remove background swaps the image) + switch-off hides the action.

## Verification

- Type-check + lint pass (connectors, core, platform).
- New view test passes locally; full suite/dev server left to the pipeline per team convention.
- Feature is switch-gated, so main behavior is unchanged when off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)