### PR TITLE
fix: scope data export feature switch to org

### DIFF
--- a/.claude/skills/feature-switch/SKILL.md
+++ b/.claude/skills/feature-switch/SKILL.md
@@ -149,8 +149,16 @@ const CONDITIONAL_CAPABILITIES: ReadonlyMap<ZeroCapability, FeatureSwitchKey> =
 Evaluation has two layers (lowest to highest priority):
 
 1. **Core registry** — static config in source code, evaluated against `userId` / `email` / `orgId` hashes.
-2. **Per-user DB overrides** — row in `user_feature_switches` keyed by `(orgId, userId)`. Written via the Lab page toggles or `window._vm0.featureSwitches.myFeature = true` (both call `POST /api/zero/feature-switches`). Cleared via the Lab page "Reset all" button (`DELETE /api/zero/feature-switches`).
+2. **DB overrides** — most switches are per-user rows in
+   `user_feature_switches` keyed by `(orgId, userId)`. Some switches are
+   org-scoped and stored under the org sentinel user id (`__org__`); currently
+   `DataExport` is org-scoped. Written via the Lab page toggles or
+   `window._vm0.featureSwitches.myFeature = true` (both call
+   `POST /api/zero/feature-switches`). Cleared via the Lab page "Reset all"
+   button (`DELETE /api/zero/feature-switches`).
 
-The same two-layer resolution applies on the server: route handlers that call `isFeatureEnabled(..., { userId, orgId, overrides })` pass overrides loaded via `loadFeatureSwitchOverrides(orgId, userId)`.
+The same two-layer resolution applies on the server: route handlers that call
+`isFeatureEnabled(..., { userId, orgId, overrides })` pass overrides loaded via
+`loadFeatureSwitchOverrides(orgId, userId)`.
 
 There is **no** client-only layer. `window._vm0.featureSwitches` requires auth and persists across refreshes; there is no device-local override.

--- a/turbo/apps/api/src/signals/routes/__tests__/hooks-ops.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/hooks-ops.bdd.test.ts
@@ -152,6 +152,85 @@ describe("OPS-01: feature switches and report-error routes", () => {
     ).toBeUndefined();
   });
 
+  it("stores data export as an org-scoped feature switch override", async () => {
+    const orgId = `org_${randomUUID()}`;
+    const owner = api.user({ orgId });
+    const peer = api.user({ orgId });
+    const outsider = api.user();
+
+    const ownerUpdate = await accept(
+      featureSwitchesClient().update({
+        headers: headersFor(owner),
+        body: {
+          switches: {
+            [FeatureSwitchKey.DataExport]: true,
+            [FeatureSwitchKey.Dummy]: false,
+          },
+        },
+      }),
+      [200],
+    );
+    expect(ownerUpdate.body.switches[FeatureSwitchKey.DataExport]).toBeTruthy();
+    expect(ownerUpdate.body.switches[FeatureSwitchKey.Dummy]).toBeFalsy();
+
+    const peerRead = await accept(
+      featureSwitchesClient().get({ headers: headersFor(peer) }),
+      [200],
+    );
+    expect(peerRead.body.switches[FeatureSwitchKey.DataExport]).toBeTruthy();
+    expect(peerRead.body.switches[FeatureSwitchKey.Dummy]).toBeUndefined();
+
+    const outsiderRead = await accept(
+      featureSwitchesClient().get({ headers: headersFor(outsider) }),
+      [200],
+    );
+    expect(
+      outsiderRead.body.switches[FeatureSwitchKey.DataExport],
+    ).toBeUndefined();
+
+    const peerUpdate = await accept(
+      featureSwitchesClient().update({
+        headers: headersFor(peer),
+        body: {
+          switches: {
+            [FeatureSwitchKey.DataExport]: false,
+          },
+        },
+      }),
+      [200],
+    );
+    expect(peerUpdate.body.switches[FeatureSwitchKey.DataExport]).toBeFalsy();
+    expect(peerUpdate.body.switches[FeatureSwitchKey.Dummy]).toBeUndefined();
+
+    const ownerReadAfterPeerUpdate = await accept(
+      featureSwitchesClient().get({ headers: headersFor(owner) }),
+      [200],
+    );
+    expect(
+      ownerReadAfterPeerUpdate.body.switches[FeatureSwitchKey.DataExport],
+    ).toBeFalsy();
+    expect(
+      ownerReadAfterPeerUpdate.body.switches[FeatureSwitchKey.Dummy],
+    ).toBeFalsy();
+
+    const deleted = await accept(
+      featureSwitchesClient().delete({ headers: headersFor(owner) }),
+      [200],
+    );
+    expect(deleted.body).toStrictEqual({ deleted: true });
+
+    const peerReadAfterDelete = await accept(
+      featureSwitchesClient().get({ headers: headersFor(peer) }),
+      [200],
+    );
+    expect(
+      peerReadAfterDelete.body.switches[FeatureSwitchKey.DataExport],
+    ).toBeUndefined();
+    expect(
+      peerReadAfterDelete.body.switches[FeatureSwitchKey.Dummy],
+    ).toBeUndefined();
+  });
+
   it("reports invalid or missing failed runs as visible API errors", async () => {
     const admin = api.user();
 

--- a/turbo/apps/api/src/signals/services/feature-switches.service.ts
+++ b/turbo/apps/api/src/signals/services/feature-switches.service.ts
@@ -1,12 +1,62 @@
 import { command, computed, type Computed } from "ccstate";
 import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
+import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 import { and, eq } from "drizzle-orm";
 
-import { db$, writeDb$, type ReadonlyDb } from "../external/db";
+import { db$, writeDb$, type Db, type ReadonlyDb } from "../external/db";
 import { nowDate } from "../external/time";
 
-async function loadUserFeatureSwitchOverrides(
+const ORG_SENTINEL_USER_ID = "__org__";
+
+function isOrgScopedFeatureSwitchKey(key: string): boolean {
+  return key === FeatureSwitchKey.DataExport;
+}
+
+function splitFeatureSwitchesByScope(switches: Record<string, boolean>): {
+  readonly userSwitches: Record<string, boolean>;
+  readonly orgSwitches: Record<string, boolean>;
+} {
+  const userSwitches: Record<string, boolean> = {};
+  const orgSwitches: Record<string, boolean> = {};
+
+  for (const [key, value] of Object.entries(switches)) {
+    if (isOrgScopedFeatureSwitchKey(key)) {
+      orgSwitches[key] = value;
+    } else {
+      userSwitches[key] = value;
+    }
+  }
+
+  return { userSwitches, orgSwitches };
+}
+
+function hasSwitches(switches: Record<string, boolean>): boolean {
+  return Object.keys(switches).length > 0;
+}
+
+function mergeScopedFeatureSwitches(
+  userSwitches: Record<string, boolean>,
+  orgSwitches: Record<string, boolean>,
+): Record<string, boolean> {
+  const merged: Record<string, boolean> = {};
+
+  for (const [key, value] of Object.entries(userSwitches)) {
+    if (!isOrgScopedFeatureSwitchKey(key)) {
+      merged[key] = value;
+    }
+  }
+
+  for (const [key, value] of Object.entries(orgSwitches)) {
+    if (isOrgScopedFeatureSwitchKey(key)) {
+      merged[key] = value;
+    }
+  }
+
+  return merged;
+}
+
+async function loadFeatureSwitchOverrideRow(
   db: ReadonlyDb,
   orgId: string,
   userId: string,
@@ -23,6 +73,19 @@ async function loadUserFeatureSwitchOverrides(
     .limit(1);
 
   return row?.switches ?? {};
+}
+
+async function loadUserFeatureSwitchOverrides(
+  db: ReadonlyDb,
+  orgId: string,
+  userId: string,
+): Promise<Record<string, boolean>> {
+  const [userSwitches, orgSwitches] = await Promise.all([
+    loadFeatureSwitchOverrideRow(db, orgId, userId),
+    loadFeatureSwitchOverrideRow(db, orgId, ORG_SENTINEL_USER_ID),
+  ]);
+
+  return mergeScopedFeatureSwitches(userSwitches, orgSwitches);
 }
 
 export function userFeatureSwitchOverrides(
@@ -71,41 +134,76 @@ export const updateUserFeatureSwitches$ = command(
     signal: AbortSignal,
   ): Promise<Record<string, boolean>> => {
     const writeDb = set(writeDb$);
+    const { userSwitches, orgSwitches } = splitFeatureSwitchesByScope(
+      args.switches,
+    );
 
-    const [existingRow] = await writeDb
-      .select({ switches: userFeatureSwitches.switches })
-      .from(userFeatureSwitches)
-      .where(
-        and(
-          eq(userFeatureSwitches.orgId, args.orgId),
-          eq(userFeatureSwitches.userId, args.userId),
-        ),
-      )
-      .limit(1);
-    signal.throwIfAborted();
+    if (hasSwitches(userSwitches)) {
+      await upsertFeatureSwitches(
+        writeDb,
+        args.orgId,
+        args.userId,
+        userSwitches,
+        signal,
+      );
+    }
 
-    const existing =
-      (existingRow?.switches as Record<string, boolean> | undefined) ?? {};
-    const merged: Record<string, boolean> = { ...existing, ...args.switches };
-    const now = nowDate();
+    if (hasSwitches(orgSwitches)) {
+      await upsertFeatureSwitches(
+        writeDb,
+        args.orgId,
+        ORG_SENTINEL_USER_ID,
+        orgSwitches,
+        signal,
+      );
+    }
 
-    await writeDb
-      .insert(userFeatureSwitches)
-      .values({
-        orgId: args.orgId,
-        userId: args.userId,
-        switches: merged,
-        updatedAt: now,
-      })
-      .onConflictDoUpdate({
-        target: [userFeatureSwitches.orgId, userFeatureSwitches.userId],
-        set: { switches: merged, updatedAt: now },
-      });
-    signal.throwIfAborted();
-
-    return merged;
+    return await loadUserFeatureSwitchOverrides(
+      writeDb,
+      args.orgId,
+      args.userId,
+    );
   },
 );
+
+async function upsertFeatureSwitches(
+  writeDb: Db,
+  orgId: string,
+  userId: string,
+  switches: Record<string, boolean>,
+  signal: AbortSignal,
+): Promise<void> {
+  const [existingRow] = await writeDb
+    .select({ switches: userFeatureSwitches.switches })
+    .from(userFeatureSwitches)
+    .where(
+      and(
+        eq(userFeatureSwitches.orgId, orgId),
+        eq(userFeatureSwitches.userId, userId),
+      ),
+    )
+    .limit(1);
+  signal.throwIfAborted();
+
+  const existing =
+    (existingRow?.switches as Record<string, boolean> | undefined) ?? {};
+  const merged: Record<string, boolean> = { ...existing, ...switches };
+  const now = nowDate();
+
+  await writeDb
+    .insert(userFeatureSwitches)
+    .values({
+      orgId,
+      userId,
+      switches: merged,
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: [userFeatureSwitches.orgId, userFeatureSwitches.userId],
+      set: { switches: merged, updatedAt: now },
+    });
+  signal.throwIfAborted();
+}
 
 export const deleteUserFeatureSwitches$ = command(
   async (
@@ -123,5 +221,56 @@ export const deleteUserFeatureSwitches$ = command(
         ),
       );
     signal.throwIfAborted();
+
+    await removeOrgScopedFeatureSwitches(writeDb, args.orgId, signal);
   },
 );
+
+async function removeOrgScopedFeatureSwitches(
+  writeDb: Db,
+  orgId: string,
+  signal: AbortSignal,
+): Promise<void> {
+  const [existingRow] = await writeDb
+    .select({ switches: userFeatureSwitches.switches })
+    .from(userFeatureSwitches)
+    .where(
+      and(
+        eq(userFeatureSwitches.orgId, orgId),
+        eq(userFeatureSwitches.userId, ORG_SENTINEL_USER_ID),
+      ),
+    )
+    .limit(1);
+  signal.throwIfAborted();
+
+  if (!existingRow) {
+    return;
+  }
+
+  const next = { ...existingRow.switches };
+  delete next[FeatureSwitchKey.DataExport];
+
+  if (Object.keys(next).length === 0) {
+    await writeDb
+      .delete(userFeatureSwitches)
+      .where(
+        and(
+          eq(userFeatureSwitches.orgId, orgId),
+          eq(userFeatureSwitches.userId, ORG_SENTINEL_USER_ID),
+        ),
+      );
+    signal.throwIfAborted();
+    return;
+  }
+
+  await writeDb
+    .update(userFeatureSwitches)
+    .set({ switches: next, updatedAt: nowDate() })
+    .where(
+      and(
+        eq(userFeatureSwitches.orgId, orgId),
+        eq(userFeatureSwitches.userId, ORG_SENTINEL_USER_ID),
+      ),
+    );
+  signal.throwIfAborted();
+}

--- a/turbo/packages/api-contracts/src/contracts/zero-feature-switches.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-feature-switches.ts
@@ -23,9 +23,11 @@ export type UpdateFeatureSwitchesRequest = z.infer<
 /**
  * Zero feature switches contract for /api/zero/feature-switches
  *
- * GET: Get current user's feature switch overrides
- * POST: Update user feature switch overrides (merge strategy)
- * DELETE: Remove all of the current user's feature switch overrides
+ * GET: Get current user's feature switch overrides plus org-scoped overrides.
+ * POST: Update feature switch overrides (merge strategy). Some switches may be
+ * stored at org scope.
+ * DELETE: Remove current user's overrides plus org-scoped overrides controlled
+ * by this endpoint.
  */
 export const zeroFeatureSwitchesContract = c.router({
   get: {
@@ -37,7 +39,7 @@ export const zeroFeatureSwitchesContract = c.router({
       401: apiErrorSchema,
       500: apiErrorSchema,
     },
-    summary: "Get user feature switch overrides",
+    summary: "Get feature switch overrides",
   },
   update: {
     method: "POST",
@@ -50,7 +52,7 @@ export const zeroFeatureSwitchesContract = c.router({
       401: apiErrorSchema,
       500: apiErrorSchema,
     },
-    summary: "Update user feature switch overrides",
+    summary: "Update feature switch overrides",
   },
   delete: {
     method: "DELETE",
@@ -62,7 +64,7 @@ export const zeroFeatureSwitchesContract = c.router({
       401: apiErrorSchema,
       500: apiErrorSchema,
     },
-    summary: "Delete all of the current user's feature switch overrides",
+    summary: "Delete feature switch overrides",
   },
 });
 


### PR DESCRIPTION
## Summary
- Store the DataExport feature switch override at org scope using the existing user_feature_switches storage with an org sentinel row.
- Merge org-scoped DataExport overrides into per-user feature switch reads while leaving other switches user-scoped.
- Add route coverage for same-org and cross-org DataExport behavior, and update feature-switch contract/docs wording.

## Validation
- pnpm prettier --check --ignore-unknown apps/api/src/signals/services/feature-switches.service.ts apps/api/src/signals/routes/__tests__/hooks-ops.bdd.test.ts packages/api-contracts/src/contracts/zero-feature-switches.ts ../.claude/skills/feature-switch/SKILL.md
- pnpm -F api exec oxlint src/signals/services/feature-switches.service.ts src/signals/routes/__tests__/hooks-ops.bdd.test.ts --deny-warnings
- pnpm -F api exec oxlint src/signals/services/feature-switches.service.ts src/signals/routes/__tests__/hooks-ops.bdd.test.ts --type-aware -c ../../.oxlintrc.typeaware.json --deny-warnings
- pnpm -F api exec eslint src/signals/services/feature-switches.service.ts src/signals/routes/__tests__/hooks-ops.bdd.test.ts --max-warnings 0
- pnpm -F @vm0/api-contracts exec oxlint src/contracts/zero-feature-switches.ts --deny-warnings
- pnpm -F @vm0/api-contracts exec oxlint src/contracts/zero-feature-switches.ts --type-aware -c ../../.oxlintrc.typeaware.json --deny-warnings
- pnpm -F @vm0/api-contracts exec eslint src/contracts/zero-feature-switches.ts --max-warnings 0
- pnpm -F @vm0/api-contracts check-types
- NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types
- git diff --check

Targeted API vitest was attempted with `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test`, but this local runtime has no reachable Postgres (`ECONNREFUSED`) and no local postgres binaries to start one. CI should cover the DB-backed route test.