### PR TITLE
feat: add birefnet and clarity-upscaler transform image models

### DIFF
--- a/turbo/apps/api/src/scripts/dev-seed.ts
+++ b/turbo/apps/api/src/scripts/dev-seed.ts
@@ -401,6 +401,12 @@ const USAGE_PRICING: readonly (typeof usagePricing.$inferInsert)[] = [
   ...usageGroup("image", "fal-ai/nano-banana-2", [
     ["output_image", usd(0.08 * 1.2), 1],
   ]),
+  // Background removal transform (fal cost is $0).
+  ...usageGroup("image", "fal-ai/birefnet/v2", [["output_image", usd(0), 1]]),
+  // Upscale/HD transform, billed per output megapixel.
+  ...usageGroup("image", "fal-ai/clarity-upscaler", [
+    ["output_megapixel", usd(0.036), 1],
+  ]),
 
   // BytePlus ModelArk video generation with a 200% provider-price multiplier.
   ...usageGroup("video", "dreamina-seedance-2-0-260128", [

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-image-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-image-io-generate.test.ts
@@ -69,6 +69,12 @@ const FAL_NANO_BANANA_2_EDIT_URL =
   "https://queue.fal.run/fal-ai/nano-banana-2/edit";
 const FAL_NANO_BANANA_2_MEDIA_URL =
   "https://fal.media/files/test/nano-banana-2.webp";
+const FAL_BIREFNET_URL = "https://queue.fal.run/fal-ai/birefnet/v2";
+const FAL_BIREFNET_MEDIA_URL = "https://fal.media/files/test/birefnet.png";
+const FAL_CLARITY_UPSCALER_URL =
+  "https://queue.fal.run/fal-ai/clarity-upscaler";
+const FAL_CLARITY_UPSCALER_MEDIA_URL =
+  "https://fal.media/files/test/clarity-upscaler.png";
 const MOCKUP_IMAGE_URL = "https://example.com/mockup.png";
 const SECOND_MOCKUP_IMAGE_URL = "https://example.com/mockup-2.png";
 const IMAGE_PRICING_MARKUP_MULTIPLIER = 1.2;
@@ -359,6 +365,30 @@ async function upsertNanoBanana2ImagePricing(): Promise<void> {
       provider: "fal-ai/nano-banana-2",
       category: "output_image",
       unitPrice: FAL_NANO_BANANA_2_MARKED_UP_CREDITS_PER_IMAGE,
+      unitSize: 1,
+    },
+  ]);
+}
+
+async function upsertBirefnetImagePricing(): Promise<void> {
+  await upsertGenerationPricingRows(context.signal, [
+    {
+      kind: "image",
+      provider: "fal-ai/birefnet/v2",
+      category: "output_image",
+      unitPrice: 0,
+      unitSize: 1,
+    },
+  ]);
+}
+
+async function upsertClarityUpscalerImagePricing(): Promise<void> {
+  await upsertGenerationPricingRows(context.signal, [
+    {
+      kind: "image",
+      provider: "fal-ai/clarity-upscaler",
+      category: "output_megapixel",
+      unitPrice: 30,
       unitSize: 1,
     },
   ]);
@@ -1535,6 +1565,190 @@ describe("POST /api/zero/image-io/generate", () => {
       safety_tolerance: "4",
       image_urls: sourceImageUrls,
     });
+  });
+
+  it("removes backgrounds with birefnet through fal without a prompt", async () => {
+    const fixture = await track(seedImageFixture({ credits: 1000 }));
+    await upsertBirefnetImagePricing();
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    let observedAuthorization: string | null = null;
+    let observedBody: Record<string, unknown> | null = null;
+    let observedRequestUrl: string | null = null;
+    server.use(
+      http.post(FAL_BIREFNET_URL, async ({ request }) => {
+        observedAuthorization = request.headers.get("authorization");
+        observedRequestUrl = request.url;
+        observedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json(falQueueHandle("birefnet-request"));
+      }),
+      http.get(FAL_BIREFNET_MEDIA_URL, () => {
+        return new HttpResponse(IMAGE_BYTES, {
+          headers: { "Content-Type": "image/png" },
+        });
+      }),
+    );
+
+    const app = createImageIoTestApp();
+    const response = await app.request("/api/zero/image-io/generate", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        model: "birefnet",
+        sourceImageUrls: [MOCKUP_IMAGE_URL],
+      }),
+    });
+
+    expect(response.status).toBe(202);
+    const generationId = readAcceptedGenerationId(
+      await response.json(),
+      "image",
+      fixture.userId,
+    );
+
+    await postFalWebhook(app, observedRequestUrl, {
+      images: [
+        {
+          url: FAL_BIREFNET_MEDIA_URL,
+          width: 1024,
+          height: 1024,
+          content_type: "image/png",
+        },
+      ],
+    });
+    await flushWaitUntilForTest();
+
+    expect(observedRequestUrl).not.toBeNull();
+    expect(new URL(observedRequestUrl ?? "").pathname).toBe(
+      "/fal-ai/birefnet/v2",
+    );
+
+    const statusResponse = await app.request(
+      `/api/zero/built-in-generations/${generationId}`,
+      { headers: authHeaders() },
+    );
+    expect(statusResponse.status).toBe(200);
+    const body = readGenerationResult(await statusResponse.json());
+    expect(body).toMatchObject({
+      contentType: "image/png",
+      model: "fal-ai/birefnet/v2",
+      provider: "fal",
+      outputFormat: "png",
+      billingCategory: "output_image",
+      billingQuantity: 1,
+      sourceUrl: FAL_BIREFNET_MEDIA_URL,
+      sourceImageUrls: [MOCKUP_IMAGE_URL],
+    });
+    expect(observedAuthorization).toBe("Key test-fal-key");
+    expect(observedBody).toStrictEqual({ image_url: MOCKUP_IMAGE_URL });
+    expect(observedBody).not.toHaveProperty("prompt");
+  });
+
+  it("upscales images with clarity-upscaler through fal without a prompt", async () => {
+    const fixture = await track(seedImageFixture({ credits: 1000 }));
+    await upsertClarityUpscalerImagePricing();
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+
+    let observedAuthorization: string | null = null;
+    let observedBody: Record<string, unknown> | null = null;
+    let observedRequestUrl: string | null = null;
+    server.use(
+      http.post(FAL_CLARITY_UPSCALER_URL, async ({ request }) => {
+        observedAuthorization = request.headers.get("authorization");
+        observedRequestUrl = request.url;
+        observedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json(falQueueHandle("clarity-upscaler-request"));
+      }),
+      http.get(FAL_CLARITY_UPSCALER_MEDIA_URL, () => {
+        return new HttpResponse(IMAGE_BYTES, {
+          headers: { "Content-Type": "image/png" },
+        });
+      }),
+    );
+
+    const app = createImageIoTestApp();
+    const response = await app.request("/api/zero/image-io/generate", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        model: "clarity-upscaler",
+        imageUrl: MOCKUP_IMAGE_URL,
+      }),
+    });
+
+    expect(response.status).toBe(202);
+    const generationId = readAcceptedGenerationId(
+      await response.json(),
+      "image",
+      fixture.userId,
+    );
+
+    await postFalWebhook(app, observedRequestUrl, {
+      images: [
+        {
+          url: FAL_CLARITY_UPSCALER_MEDIA_URL,
+          width: 2048,
+          height: 2048,
+          content_type: "image/png",
+        },
+      ],
+    });
+    await flushWaitUntilForTest();
+
+    expect(observedRequestUrl).not.toBeNull();
+    expect(new URL(observedRequestUrl ?? "").pathname).toBe(
+      "/fal-ai/clarity-upscaler",
+    );
+
+    const statusResponse = await app.request(
+      `/api/zero/built-in-generations/${generationId}`,
+      { headers: authHeaders() },
+    );
+    expect(statusResponse.status).toBe(200);
+    const body = readGenerationResult(await statusResponse.json());
+    expect(body).toMatchObject({
+      contentType: "image/png",
+      model: "fal-ai/clarity-upscaler",
+      provider: "fal",
+      imageSize: "2048x2048",
+      outputFormat: "png",
+      billingCategory: "output_megapixel",
+      billingQuantity: 5,
+      sourceUrl: FAL_CLARITY_UPSCALER_MEDIA_URL,
+      sourceImageUrls: [MOCKUP_IMAGE_URL],
+    });
+    expect(observedAuthorization).toBe("Key test-fal-key");
+    expect(observedBody).toStrictEqual({ image_url: MOCKUP_IMAGE_URL });
+    expect(observedBody).not.toHaveProperty("prompt");
+  });
+
+  it("rejects promptless models without a source image", async () => {
+    const fixture = await track(seedImageFixture({ credits: 1000 }));
+    await upsertBirefnetImagePricing();
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    let calledFal = false;
+    server.use(
+      http.post(FAL_BIREFNET_URL, () => {
+        calledFal = true;
+        return HttpResponse.json({});
+      }),
+    );
+
+    const app = createImageIoTestApp();
+    const response = await app.request("/api/zero/image-io/generate", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ model: "birefnet" }),
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        message: "birefnet requires imageUrl",
+        code: "BAD_REQUEST",
+      },
+    });
+    expect(calledFal).toBeFalsy();
   });
 
   it("generates GPT Image 1.5 through fal without returned usage", async () => {

--- a/turbo/apps/api/src/signals/services/zero-image-io-generate.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-image-io-generate.service.ts
@@ -28,6 +28,8 @@ const IMAGE_IO_EDGE_MULTIPLE = 16;
 const IMAGE_IO_MAX_ASPECT_RATIO = 3;
 const NANO_BANANA_2_MODEL = "fal-ai/nano-banana-2";
 const NANO_BANANA_2_MAX_SOURCE_IMAGE_URLS = 14;
+const BIREFNET_MODEL = "fal-ai/birefnet/v2";
+const CLARITY_UPSCALER_MODEL = "fal-ai/clarity-upscaler";
 
 const USAGE_KIND = "image";
 const FAL_OUTPUT_IMAGE_CATEGORY = "output_image";
@@ -83,11 +85,14 @@ const IMAGE_MODEL_ALIASES = {
   seedream4: "fal-ai/bytedance/seedream/v4/text-to-image",
   "nano-banana-2": NANO_BANANA_2_MODEL,
   "nano-banana2": NANO_BANANA_2_MODEL,
+  birefnet: BIREFNET_MODEL,
+  "clarity-upscaler": CLARITY_UPSCALER_MODEL,
 } as const;
 
 const IMAGE_MODEL_CONFIGS = {
   "gpt-image-2": {
     alias: "gpt-image-2",
+    promptless: false,
     endpointId: "openai/gpt-image-2",
     imageToImageEndpointId: "openai/gpt-image-2/edit",
     sourceImageInput: "image_urls",
@@ -112,6 +117,7 @@ const IMAGE_MODEL_CONFIGS = {
   },
   "gpt-image-1.5": {
     alias: "gpt-image-1.5",
+    promptless: false,
     endpointId: "fal-ai/gpt-image-1.5",
     imageToImageEndpointId: "fal-ai/gpt-image-1.5/edit",
     sourceImageInput: "image_urls",
@@ -136,6 +142,7 @@ const IMAGE_MODEL_CONFIGS = {
   },
   "gpt-image-1": {
     alias: "gpt-image-1",
+    promptless: false,
     endpointId: "fal-ai/gpt-image-1/text-to-image",
     imageToImageEndpointId: "fal-ai/gpt-image-1/edit-image",
     sourceImageInput: "image_urls",
@@ -160,6 +167,7 @@ const IMAGE_MODEL_CONFIGS = {
   },
   "gpt-image-1-mini": {
     alias: "gpt-image-1-mini",
+    promptless: false,
     endpointId: "fal-ai/gpt-image-1-mini",
     imageToImageEndpointId: "fal-ai/gpt-image-1-mini/edit",
     sourceImageInput: "image_urls",
@@ -184,6 +192,7 @@ const IMAGE_MODEL_CONFIGS = {
   },
   "fal-ai/flux-pro/v1.1": {
     alias: "flux-pro-1.1",
+    promptless: false,
     endpointId: "fal-ai/flux-pro/v1.1",
     imageToImageEndpointId: "fal-ai/flux-pro/v1.1/redux",
     sourceImageInput: "image_url",
@@ -208,6 +217,7 @@ const IMAGE_MODEL_CONFIGS = {
   },
   "fal-ai/flux-pro/v1.1-ultra": {
     alias: "flux-pro-1.1-ultra",
+    promptless: false,
     endpointId: "fal-ai/flux-pro/v1.1-ultra",
     imageToImageEndpointId: "fal-ai/flux-pro/v1.1-ultra/redux",
     sourceImageInput: "image_url",
@@ -232,6 +242,7 @@ const IMAGE_MODEL_CONFIGS = {
   },
   "fal-ai/qwen-image": {
     alias: "qwen-image",
+    promptless: false,
     endpointId: "fal-ai/qwen-image",
     imageToImageEndpointId: "fal-ai/qwen-image-2/edit",
     sourceImageInput: "image_url",
@@ -256,6 +267,7 @@ const IMAGE_MODEL_CONFIGS = {
   },
   "fal-ai/bytedance/seedream/v4/text-to-image": {
     alias: "seedream4",
+    promptless: false,
     endpointId: "fal-ai/bytedance/seedream/v4/text-to-image",
     imageToImageEndpointId: "fal-ai/bytedance/seedream/v4/edit",
     sourceImageInput: "image_urls",
@@ -280,6 +292,7 @@ const IMAGE_MODEL_CONFIGS = {
   },
   [NANO_BANANA_2_MODEL]: {
     alias: "nano-banana-2",
+    promptless: false,
     endpointId: NANO_BANANA_2_MODEL,
     imageToImageEndpointId: "fal-ai/nano-banana-2/edit",
     sourceImageInput: "image_urls",
@@ -297,6 +310,56 @@ const IMAGE_MODEL_CONFIGS = {
     usesOpenAiByok: false,
     supportsSeed: true,
     supportsSafetyTolerance: true,
+    supportsEnhancePrompt: false,
+    supportsMaskImage: false,
+    supportsInputFidelity: false,
+    supportsImagePromptStrength: false,
+  },
+  [BIREFNET_MODEL]: {
+    alias: "birefnet",
+    promptless: true,
+    endpointId: BIREFNET_MODEL,
+    imageToImageEndpointId: BIREFNET_MODEL,
+    sourceImageInput: "image_url",
+    provider: "fal",
+    sizeMode: "flexible",
+    sizeParameter: undefined,
+    outputFormats: ["png"],
+    pricingCategories: [FAL_OUTPUT_IMAGE_CATEGORY],
+    billingMode: "image",
+    supportsTransparentBackground: true,
+    supportsOutputCompression: false,
+    supportsModeration: false,
+    supportsQuality: false,
+    supportsBackground: false,
+    usesOpenAiByok: false,
+    supportsSeed: false,
+    supportsSafetyTolerance: false,
+    supportsEnhancePrompt: false,
+    supportsMaskImage: false,
+    supportsInputFidelity: false,
+    supportsImagePromptStrength: false,
+  },
+  [CLARITY_UPSCALER_MODEL]: {
+    alias: "clarity-upscaler",
+    promptless: true,
+    endpointId: CLARITY_UPSCALER_MODEL,
+    imageToImageEndpointId: CLARITY_UPSCALER_MODEL,
+    sourceImageInput: "image_url",
+    provider: "fal",
+    sizeMode: "flexible",
+    sizeParameter: undefined,
+    outputFormats: FAL_IMAGE_OUTPUT_FORMATS,
+    pricingCategories: [FAL_OUTPUT_MEGAPIXEL_CATEGORY],
+    billingMode: "megapixel",
+    supportsTransparentBackground: false,
+    supportsOutputCompression: false,
+    supportsModeration: false,
+    supportsQuality: false,
+    supportsBackground: false,
+    usesOpenAiByok: false,
+    supportsSeed: false,
+    supportsSafetyTolerance: false,
     supportsEnhancePrompt: false,
     supportsMaskImage: false,
     supportsInputFidelity: false,
@@ -677,9 +740,15 @@ function readBoolean(
   return typeof value === "boolean" ? value : fallback;
 }
 
-function parsePrompt(body: Record<string, unknown>): string | ErrorResponse {
+function parsePrompt(
+  body: Record<string, unknown>,
+  modelConfig: ImageModelConfig,
+): string | ErrorResponse {
   const prompt = typeof body.prompt === "string" ? body.prompt.trim() : "";
   if (prompt.length === 0) {
+    if (modelConfig.promptless) {
+      return prompt;
+    }
     return badRequest("prompt is required");
   }
   if (prompt.length > IMAGE_IO_MAX_PROMPT_LENGTH) {
@@ -884,6 +953,9 @@ function parseSourceImageUrls(
   }
 
   if (sourceImageUrls.length === 0) {
+    if (modelConfig.promptless) {
+      return badRequest(`${modelConfig.alias} requires imageUrl`);
+    }
     return sourceImageUrls;
   }
   const maxSourceImageUrls =
@@ -992,16 +1064,16 @@ export function parseImageOptions(body: unknown): ImageOptions | ErrorResponse {
     return badRequest("Invalid JSON body");
   }
 
-  const prompt = parsePrompt(body);
-  if (typeof prompt === "object") {
-    return prompt;
-  }
-
   const model = parseImageModel(body);
   if (typeof model === "object") {
     return model;
   }
   const modelConfig = IMAGE_MODEL_CONFIGS[model];
+
+  const prompt = parsePrompt(body, modelConfig);
+  if (typeof prompt === "object") {
+    return prompt;
+  }
 
   const sourceImageUrls = parseSourceImageUrls(body, modelConfig);
   if (typeof sourceImageUrls === "object" && "status" in sourceImageUrls) {
@@ -1309,8 +1381,20 @@ function falAspectRatio(options: ImageOptions): string {
   return nearestFalAspectRatio(parsed.width, parsed.height);
 }
 
+function falSourceImageInput(
+  modelConfig: ImageModelConfig,
+  sourceImageUrls: readonly string[],
+): Record<string, unknown> {
+  return modelConfig.sourceImageInput === "image_url"
+    ? { image_url: sourceImageUrls[0] }
+    : { image_urls: sourceImageUrls };
+}
+
 function falImageInput(options: ImageOptions): Record<string, unknown> {
   const modelConfig = IMAGE_MODEL_CONFIGS[options.model];
+  if (modelConfig.promptless) {
+    return falSourceImageInput(modelConfig, options.sourceImageUrls);
+  }
   return {
     prompt: options.prompt,
     ...(modelConfig.sizeParameter === "aspect_ratio"
@@ -1339,9 +1423,7 @@ function falImageInput(options: ImageOptions): Record<string, unknown> {
       ? { enhance_prompt: options.enhancePrompt }
       : {}),
     ...(options.sourceImageUrls.length > 0
-      ? modelConfig.sourceImageInput === "image_url"
-        ? { image_url: options.sourceImageUrls[0] }
-        : { image_urls: options.sourceImageUrls }
+      ? falSourceImageInput(modelConfig, options.sourceImageUrls)
       : {}),
     ...(modelConfig.supportsMaskImage && options.maskImageUrl
       ? { mask_image_url: options.maskImageUrl }


### PR DESCRIPTION
## What

Adds two dedicated **single-image transform** models to the built-in image generation pipeline, so image editing can use purpose-built models instead of a general prompt model:

- **Background removal** → `fal-ai/birefnet/v2` (alias `birefnet`) — real cutout, transparent PNG output.
- **Upscale / HD** → `fal-ai/clarity-upscaler` (alias `clarity-upscaler`) — true super-resolution.

Both are **promptless**: they require a source image and take no prompt.

## How

- New `promptless` flag on the model config (set `false` on all existing models, `true` on the two new ones).
- Prompt validation is skipped for promptless models; a source image is **required**; the fal input carries **only** the source image (no prompt/size params).
- Endpoint selection reuses the existing "source image present → edit endpoint" routing (both endpoint ids point at the transform endpoint).
- Output/download/storage/billing paths are unchanged (generic). Clarity bills per **output** megapixel (same path as qwen-image).

## Pricing

Dev-seed rows added so the models work on a local dev DB, following the existing dev-seed pricing convention:
- `fal-ai/birefnet/v2` → `output_image` (fal cost is $0).
- `fal-ai/clarity-upscaler` → `output_megapixel` (fal cost is $0.03 per output megapixel).

Production pricing is maintained through the team's private pricing process (not seeded from this repo). Before these models are enabled in prod, their two `usage_pricing` rows must be added there — a missing row makes the endpoint return **503** (`getMissingImagePricing`). @lancy can you add / confirm the prod rows for these two models?

## Verification

- Real fal call verified against the live API: `fal-ai/birefnet/v2` with a source image returns a 1024×1024 transparent PNG (free), confirming the endpoint + output shape.
- Route-level integration tests (fal mocked): birefnet + clarity-upscaler accept a source image with **no prompt** and route to the right fal endpoint with `image_url`; a promptless request **without** a source image returns 400. `pnpm -F @vm0/api exec vitest run` on the route test → 19 passing (17 existing + 3 new). Type-check + lint green. Full suite left to the pipeline per team convention.

## Concurrency note

fal enforces an account-level **concurrency limit** (queues rather than rejects; 429s auto-retry), shared across all endpoints — not a per-request rate limit. These two models share the existing fal account pool; no new limit to manage up front. This is a monitor-after-launch item, not a blocker.

## Follow-up

This is the backend half. The frontend image editor (#19697) currently uses `nano-banana-2`; once this merges (and prod pricing is in place) we switch it to `birefnet` / `clarity-upscaler`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)