### PR TITLE
fix: ignore thinking-only messages in work folds

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -2341,6 +2341,48 @@ describe("chat lifecycle", () => {
     });
   });
 
+  it("does not fold a completed run when the only prior assistant message is thinking", async () => {
+    mockChatLifecycle(context, {
+      threadId: "thread-work-folding-thinking-only",
+      chatMessages: [
+        {
+          role: "user",
+          content: "Summarize the launch status",
+          runId: "run-work-folding-thinking-only",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          role: "assistant",
+          content: null,
+          thinking: "Reviewing launch context",
+          runId: "run-work-folding-thinking-only",
+          createdAt: "2026-06-09T10:00:05Z",
+        },
+        {
+          role: "assistant",
+          content: "Launch status is ready.",
+          runId: "run-work-folding-thinking-only",
+          runLifecycleEvent: "completed",
+          createdAt: "2026-06-09T10:00:05Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-work-folding-thinking-only",
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Summarize the launch status"),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Launch status is ready.")).toBeInTheDocument();
+      expect(screen.queryByText("Worked for 5s")).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("Expand work history")).toBeNull();
+    });
+  });
+
   it("does not fold a completed run with a single message", async () => {
     mockChatLifecycle(context, {
       threadId: "thread-work-folding-single-message",

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -3901,6 +3901,16 @@ function isRenderableAssistantMessage(message: EnrichedChatMessage): boolean {
   );
 }
 
+function isThinkingOnlyAssistantMessage(message: EnrichedChatMessage): boolean {
+  return (
+    message.role === "assistant" &&
+    message.content === null &&
+    message.error === undefined &&
+    typeof message.thinking === "string" &&
+    message.thinking.trim().length > 0
+  );
+}
+
 type ThinkingIndicatorMarkerMessage = EnrichedChatMessage & {
   readonly role: "assistant";
   readonly content: null;
@@ -4004,7 +4014,9 @@ function buildCompletedWorkFolding(
     const precedingMessages =
       finalMessageIndex > 0 ? runMessages.slice(0, finalMessageIndex) : [];
     const hiddenMessages = precedingMessages.filter((message) => {
-      return message.role !== "user";
+      return (
+        message.role !== "user" && !isThinkingOnlyAssistantMessage(message)
+      );
     });
     const trailingMessages =
       finalMessageIndex >= 0 ? runMessages.slice(finalMessageIndex + 1) : [];


### PR DESCRIPTION
## Summary
- exclude assistant messages that only contain thinking text from completed work fold history
- keep the final assistant response visible without rendering an empty "Worked for ..." toggle
- add a regression test for the thinking-only marker case

## Test
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx -t "does not fold a completed run when the only prior assistant message is thinking"