### PR TITLE
feat(chat): relax initial thinking prompt

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -2048,6 +2048,7 @@ describe("CHAT-02: initial thinking indicator", () => {
     });
     expect(upstreamAuthorization).toBe("Bearer thinking-key");
     expect(promptPayload).toContain("few short paragraphs");
+    expect(promptPayload).toContain("Match the current user's language");
     expect(promptPayload).toContain("Draft a launch checklist");
 
     await cancelChatRun(actor, run.runId);

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -1975,7 +1975,7 @@ describe("CHAT-02: incomplete-round context", () => {
 });
 
 describe("CHAT-02: initial thinking indicator", () => {
-  it("persists a fast assistant thinking marker for active web chat runs", async () => {
+  it("persists a fast assistant thinking marker with paragraphs for active web chat runs", async () => {
     const { actor, agentId } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
     mockOptionalEnv("OPENROUTER_API_KEY", "thinking-key");
@@ -1995,6 +1995,8 @@ describe("CHAT-02: initial thinking indicator", () => {
 
     let upstreamAuthorization: string | null = null;
     let promptPayload = "";
+    const thinkingResponse =
+      "Reviewing the launch request and recent context.\n\nOrganizing the checklist into practical sections before the main response starts.";
     server.use(
       http.post(
         "https://openrouter.ai/api/v1/chat/completions",
@@ -2010,7 +2012,7 @@ describe("CHAT-02: initial thinking indicator", () => {
             choices: [
               {
                 finish_reason: "stop",
-                message: { content: "Reviewing the request" },
+                message: { content: thinkingResponse },
               },
             ],
           });
@@ -2028,14 +2030,13 @@ describe("CHAT-02: initial thinking indicator", () => {
         return (
           message.runId === run.runId &&
           message.content === null &&
-          message.thinking === "Reviewing the request"
+          message.thinking === thinkingResponse
         );
       });
     });
     const marker = assistantMessages(page.messages).find((message) => {
       return (
-        message.runId === run.runId &&
-        message.thinking === "Reviewing the request"
+        message.runId === run.runId && message.thinking === thinkingResponse
       );
     });
     expect(marker).toMatchObject({
@@ -2043,9 +2044,10 @@ describe("CHAT-02: initial thinking indicator", () => {
       content: null,
       runId: run.runId,
       runEventId: "thinking:initial",
-      thinking: "Reviewing the request",
+      thinking: thinkingResponse,
     });
     expect(upstreamAuthorization).toBe("Bearer thinking-key");
+    expect(promptPayload).toContain("few short paragraphs");
     expect(promptPayload).toContain("Draft a launch checklist");
 
     await cancelChatRun(actor, run.runId);

--- a/turbo/apps/api/src/signals/services/zero-chat-initial-thinking.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-initial-thinking.service.ts
@@ -147,6 +147,7 @@ async function generateInitialThinkingText(args: {
           "Write user-visible progress copy for a chat UI while the assistant is preparing its response.",
           "Use the current user message and recent thread history to describe what is being prepared. It can be a few short paragraphs when useful, and should feel concrete, relevant, and specific rather than generic.",
           "Do not answer the user. Do not reveal hidden reasoning, chain-of-thought, private analysis, or internal steps. Do not mention tools unless the user explicitly asked for a tool-like task.",
+          "Match the current user's language.",
           "Return plain text only, with no markdown, headings, bullets, or quotes.",
         ].join("\n"),
       },

--- a/turbo/apps/api/src/signals/services/zero-chat-initial-thinking.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-initial-thinking.service.ts
@@ -19,8 +19,8 @@ const FAST_CHAT_MODEL = "google/gemini-3.1-flash-lite-preview";
 const INITIAL_THINKING_RUN_EVENT_ID = "thinking:initial";
 const THINKING_CONTEXT_MESSAGE_CAP = 8;
 const THINKING_CONTEXT_CHAR_CAP = 700;
-const THINKING_MAX_TOKENS = 48;
-const THINKING_TEXT_CHAR_CAP = 120;
+const THINKING_MAX_TOKENS = 160;
+const THINKING_TEXT_CHAR_CAP = 600;
 
 interface ThinkingContextMessage {
   readonly role: "user" | "assistant";
@@ -36,14 +36,25 @@ function sanitizeThinkingText(text: string | null): string | null {
     return null;
   }
   const normalized = text
-    .replace(/\s+/g, " ")
+    .replace(/\r\n?/g, "\n")
+    .replace(/[^\S\n]+/g, " ")
+    .split("\n")
+    .map((line) => {
+      return line.trim();
+    })
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim()
     .replace(/^["'`]+/, "")
-    .replace(/["'`.]+$/, "")
+    .replace(/["'`]+$/, "")
     .trim();
   if (!normalized) {
     return null;
   }
-  return graphemes(normalized).slice(0, THINKING_TEXT_CHAR_CAP).join("");
+  return graphemes(normalized)
+    .slice(0, THINKING_TEXT_CHAR_CAP)
+    .join("")
+    .trimEnd();
 }
 
 async function loadThinkingContextMessages(args: {
@@ -133,10 +144,10 @@ async function generateInitialThinkingText(args: {
       {
         role: "system",
         content: [
-          "Write one short user-visible status line for a chat UI while the assistant starts responding.",
-          "Use the current user message and recent history only to describe what is being prepared.",
-          "Do not answer the user. Do not reveal hidden reasoning or chain-of-thought. Do not mention tools unless the user explicitly asked for a tool-like task.",
-          "Match the user's language. Return plain text only, with no markdown, no quotes, and no trailing punctuation.",
+          "Write user-visible progress copy for a chat UI while the assistant is preparing its response.",
+          "Use the current user message and recent thread history to describe what is being prepared. It can be a few short paragraphs when useful, and should feel concrete, relevant, and specific rather than generic.",
+          "Do not answer the user. Do not reveal hidden reasoning, chain-of-thought, private analysis, or internal steps. Do not mention tools unless the user explicitly asked for a tool-like task.",
+          "Return plain text only, with no markdown, headings, bullets, or quotes.",
         ].join("\n"),
       },
       {


### PR DESCRIPTION
## Summary
- Relax the initial thinking prompt to allow the fast model to generate detailed progress copy.
- Preserve paragraph breaks in generated thinking text while still trimming excess whitespace and wrapping quotes
- Raise generation and storage caps for richer initial thinking copy

## Verification
- pnpm exec prettier --write apps/api/src/signals/services/zero-chat-initial-thinking.service.ts apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
- pnpm -F api exec oxlint src/signals/services/zero-chat-initial-thinking.service.ts src/signals/routes/__tests__/chat-messages.bdd.test.ts
- pnpm -F api exec eslint src/signals/services/zero-chat-initial-thinking.service.ts src/signals/routes/__tests__/chat-messages.bdd.test.ts --max-warnings 0
- NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types
- pnpm -F api lint
- DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm -F api exec vitest run src/signals/routes/__tests__/chat-messages.bdd.test.ts -t "initial thinking indicator"