### PR TITLE
fix: stabilize slash workflow menu on mobile keyboard

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/slash-workflow.tsx
+++ b/turbo/apps/platform/src/views/zero-page/slash-workflow.tsx
@@ -123,6 +123,7 @@ export function SlashWorkflowMenu({
       align="start"
       sideOffset={8}
       collisionPadding={12}
+      updatePositionStrategy="always"
       // Keep focus in the TipTap editor: the menu's keyboard navigation is
       // handled there, so the popover must never steal focus when it opens.
       onOpenAutoFocus={(event) => {

--- a/turbo/apps/platform/src/views/zero-page/tiptap-workflow-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/tiptap-workflow-composer.tsx
@@ -295,6 +295,15 @@ interface SlashCaretPosition {
   readonly height: number;
 }
 
+interface SlashCaretVirtualElement {
+  readonly contextElement: HTMLElement;
+  getBoundingClientRect(): DOMRect;
+}
+
+interface SlashCaretVirtualRef {
+  current: SlashCaretVirtualElement;
+}
+
 function slashCaretPosition(
   editor: Editor,
   slashRange: SlashWorkflowRange,
@@ -311,9 +320,34 @@ function slashCaretPosition(
   };
 }
 
-// Zero-size Popover anchor pinned to the active slash so the suggestion menu opens
-// at the `/` the user typed rather than a fixed corner. Falls back to the viewport
-// origin when there is no active slash (the menu is closed then anyway).
+function slashCaretRect(caret: SlashCaretPosition): DOMRect {
+  const viewport = window.visualViewport;
+  const left = caret.left + (viewport?.offsetLeft ?? 0);
+  const top = caret.top + (viewport?.offsetTop ?? 0);
+  return new DOMRect(left, top, 0, caret.height);
+}
+
+function slashCaretVirtualRef(
+  editor: Editor | null,
+  slashRange: SlashWorkflowRange | null,
+): SlashCaretVirtualRef | null {
+  if (!editor || !slashRange) {
+    return null;
+  }
+
+  return {
+    current: {
+      contextElement: editor.view.dom,
+      getBoundingClientRect() {
+        return slashCaretRect(slashCaretPosition(editor, slashRange));
+      },
+    },
+  };
+}
+
+// Virtual Popover anchor pinned to the active slash so the suggestion menu opens
+// at the `/` the user typed. Reading the rect lazily lets Floating UI remeasure
+// after mobile visual viewport changes without translating through a fixed DOM node.
 function SlashCaretAnchor({
   editor,
   slashRange,
@@ -321,22 +355,8 @@ function SlashCaretAnchor({
   readonly editor: Editor | null;
   readonly slashRange: SlashWorkflowRange | null;
 }) {
-  const caret =
-    editor && slashRange ? slashCaretPosition(editor, slashRange) : null;
-  return (
-    <PopoverAnchor asChild>
-      <div
-        aria-hidden="true"
-        className="pointer-events-none fixed"
-        style={{
-          left: caret?.left ?? 0,
-          top: caret?.top ?? 0,
-          width: 0,
-          height: caret?.height ?? 0,
-        }}
-      />
-    </PopoverAnchor>
-  );
+  const virtualRef = slashCaretVirtualRef(editor, slashRange);
+  return virtualRef ? <PopoverAnchor virtualRef={virtualRef} /> : null;
 }
 
 interface SlashMenuKeyContext {


### PR DESCRIPTION
## Summary
- replace the slash workflow menu's hidden fixed DOM anchor with a Radix virtual anchor
- fold visual viewport offsets into the caret rect so iOS keyboard viewport shifts are measured correctly
- force Floating UI to remeasure while the short-lived workflow suggestion menu is open

## Verification
- pnpm exec prettier --write apps/platform/src/views/zero-page/tiptap-workflow-composer.tsx apps/platform/src/views/zero-page/slash-workflow.tsx
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
