### PR TITLE
fix: keep emoji shortcuts out of chat inputs

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
@@ -143,12 +143,15 @@ export const setChatKeyboardScrollRoot$ = onRef(
       const emojiShortcut = matchShortcut("shift+f2", event);
       const emojiOptionIndex = chatThreadEmojiShortcutIndex(event);
       const emojiClearShortcut = isChatThreadEmojiClearShortcut(event);
+      const emojiKeyboardShortcut =
+        emojiShortcut || emojiOptionIndex !== null || emojiClearShortcut;
       if (
         event.defaultPrevented ||
         (!renameShortcut &&
           !emojiShortcut &&
           emojiOptionIndex === null &&
           !emojiClearShortcut) ||
+        (emojiKeyboardShortcut && isEditableTarget(event.target)) ||
         hasOpenDialog(el.ownerDocument) ||
         !isChatShortcutTarget(el, event.target)
       ) {
@@ -156,7 +159,7 @@ export const setChatKeyboardScrollRoot$ = onRef(
       }
       const features = get(featureSwitch$);
       if (
-        (emojiShortcut || emojiOptionIndex !== null || emojiClearShortcut) &&
+        emojiKeyboardShortcut &&
         !features[FeatureSwitchKey.ChatThreadEmoji]
       ) {
         return;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -3131,6 +3131,39 @@ describe("chat lifecycle", () => {
     expect(screen.queryByRole("menu")).not.toBeInTheDocument();
   });
 
+  it("keeps shifted digit input editable in the chat composer", async () => {
+    const user = userEvent.setup({ delay: null });
+    const renameRequest = vi.fn();
+    mockResizeObserver();
+    mockKeyboardNavigationThreads({ currentDetailTitle: null });
+    context.mocks.api(
+      chatThreadRenameContract.rename,
+      ({ body, params, respond }) => {
+        renameRequest(params.id, body.title);
+        return respond(204);
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/chats/keyboard-current-thread",
+      featureSwitches: { [FeatureSwitchKey.ChatThreadEmoji]: true },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Current thread launch note"),
+      ).toBeInTheDocument();
+    });
+
+    const composer = chatComposerTextarea();
+    await user.type(composer, "!");
+
+    expect(composer).toHaveValue("!");
+    expect(renameRequest).not.toHaveBeenCalled();
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
   it("does not refocus the chat emoji button or show its tooltip after closing the picker from outside", async () => {
     const user = userEvent.setup({ delay: null });
     mockResizeObserver();

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -3077,7 +3077,7 @@ function ChatThread({
     if (event.defaultPrevented) {
       return;
     }
-    if (chatThreadEmojiEnabled) {
+    if (chatThreadEmojiEnabled && !isEditableTarget(event.target)) {
       const emojiOptionIndex = chatThreadEmojiShortcutIndex(event);
       if (emojiOptionIndex !== null) {
         const option = CHAT_THREAD_EMOJI_OPTIONS[emojiOptionIndex];
@@ -3093,7 +3093,11 @@ function ChatThread({
         return;
       }
     }
-    if (chatThreadEmojiEnabled && matchShortcut("shift+f2", event)) {
+    if (
+      chatThreadEmojiEnabled &&
+      !isEditableTarget(event.target) &&
+      matchShortcut("shift+f2", event)
+    ) {
       event.preventDefault();
       openEmojiMenu();
       return;


### PR DESCRIPTION
## Summary
- Skip chat thread emoji keyboard shortcuts when the event target is editable
- Keep the chat thread container handler aligned with the global keyboard guard
- Add a regression test that typing shifted digits in the composer does not change the thread emoji

## Tests
- pnpm format
- pnpm lint
- pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx
- pnpm check-types (api package hit Node heap OOM after 11 packages passed)
- NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter api run check-types