### PR TITLE
test: guard guest-agent runtime api surface

### DIFF
--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -1,4 +1,8 @@
 //! Guest-agent startup configuration parsed from environment snapshots.
+//!
+//! `GuestConfigRaw::from_process_env` is the only process-env capture boundary
+//! in this module. After startup, callers should pass an owned [`GuestConfig`]
+//! instead of rereading process globals through run-scoped facade functions.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};

--- a/crates/guest-agent/src/lib.rs
+++ b/crates/guest-agent/src/lib.rs
@@ -1,4 +1,14 @@
-//! Guest agent library — exposes modules for the binary and integration tests.
+//! Guest agent library for the binary and integration tests.
+//!
+//! The production runtime model is explicit:
+//! - [`run_context::GuestRuntime::from_process_env`] is the startup boundary
+//!   that captures runner-provided process state.
+//! - [`env::GuestConfigRaw`] is the raw environment snapshot.
+//! - [`env::GuestConfig`] owns immutable run-scoped configuration.
+//! - [`paths::GuestPaths`] owns immutable run-scoped filesystem paths.
+//!
+//! Do not add process-global facade readers for run-scoped environment values
+//! or paths. Thread `GuestConfig` and `GuestPaths` through the caller instead.
 
 pub mod active_input;
 mod artifact;

--- a/crates/guest-agent/src/paths.rs
+++ b/crates/guest-agent/src/paths.rs
@@ -1,5 +1,10 @@
 //! Guest filesystem paths and derived runtime-file paths.
 //!
+//! [`GuestPaths`] is the owned path model for one guest-agent run. It is built
+//! from the runtime directory captured at bootstrap and then passed explicitly
+//! through callers. Avoid adding zero-argument facade readers that derive paths
+//! from process-global environment state.
+//!
 //! Naming conventions:
 //! - "system log" = guest-agent's own stderr (matches TS `SYSTEM_LOG_FILE` and API `systemLog`)
 //! - "agent log" = AI agent (Claude Code) stdout output

--- a/crates/guest-agent/tests/runtime_api_surface.rs
+++ b/crates/guest-agent/tests/runtime_api_surface.rs
@@ -48,8 +48,8 @@ fn env_and_paths_modules_do_not_reintroduce_run_scoped_facades() -> std::io::Res
     let env_rs = read_source(manifest_dir, "src/env.rs")?;
     let paths_rs = read_source(manifest_dir, "src/paths.rs")?;
 
-    assert_no_process_global_state(&env_rs, "src/env.rs");
-    assert_no_process_global_state(&paths_rs, "src/paths.rs");
+    assert_no_module_static_state(&env_rs, "src/env.rs");
+    assert_no_module_static_state(&paths_rs, "src/paths.rs");
 
     for name in RUN_SCOPED_ENV_READER_NAMES {
         assert_no_zero_arg_reader(&env_rs, "src/env.rs", name);
@@ -68,19 +68,41 @@ fn read_source(manifest_dir: &Path, relative_path: &str) -> Result<String, std::
     })
 }
 
-fn assert_no_process_global_state(source: &str, label: &str) {
-    for forbidden in ["LazyLock", "OnceLock"] {
-        assert!(
-            !source.contains(forbidden),
-            "{label} must not reintroduce {forbidden}; use explicit GuestConfig/GuestPaths ownership"
-        );
-    }
+fn assert_no_module_static_state(source: &str, label: &str) {
+    assert!(
+        !non_comment_lines(source).any(is_static_item),
+        "{label} must not reintroduce static module state; use explicit GuestConfig/GuestPaths ownership"
+    );
+    assert!(
+        !non_comment_lines(source).any(|line| line.contains("thread_local!")),
+        "{label} must not reintroduce thread-local module state; use explicit GuestConfig/GuestPaths ownership"
+    );
 }
 
 fn assert_no_zero_arg_reader(source: &str, label: &str, name: &str) {
-    let pattern = format!("fn {name}()");
+    let compact_source = non_comment_lines(source)
+        .flat_map(str::chars)
+        .filter(|c| !c.is_whitespace())
+        .collect::<String>();
+    let pattern = format!("fn{name}()");
     assert!(
-        !source.contains(&pattern),
+        !compact_source.contains(&pattern),
         "{label} must not expose zero-argument run-scoped reader {name}(); use GuestConfig/GuestPaths"
     );
+}
+
+fn non_comment_lines(source: &str) -> impl Iterator<Item = &str> {
+    source
+        .lines()
+        .map(str::trim_start)
+        .filter(|line| !line.starts_with("//"))
+}
+
+fn is_static_item(line: &str) -> bool {
+    let mut tokens = line.split_whitespace();
+    match tokens.next() {
+        Some("static") => true,
+        Some(vis) if vis.starts_with("pub") => matches!(tokens.next(), Some("static")),
+        _ => false,
+    }
 }

--- a/crates/guest-agent/tests/runtime_api_surface.rs
+++ b/crates/guest-agent/tests/runtime_api_surface.rs
@@ -1,0 +1,86 @@
+use std::fs;
+use std::path::Path;
+
+const RUN_SCOPED_ENV_READER_NAMES: &[&str] = &[
+    "run_id",
+    "api_url",
+    "api_token",
+    "sandbox_id",
+    "sandbox_reuse_result",
+    "prompt",
+    "append_system_prompt",
+    "resume_session_id",
+    "api_start_time",
+    "secret_values",
+    "disallowed_tools",
+    "tools",
+    "settings",
+    "user_env",
+    "openai_api_key",
+    "openai_model",
+    "anthropic_model",
+    "chatgpt_account_id",
+    "is_codex_oauth_mode",
+    "home_dir",
+    "artifacts",
+];
+
+const RUN_SCOPED_PATH_READER_NAMES: &[&str] = &[
+    "runtime_dir",
+    "session_id_file",
+    "session_history_path_file",
+    "event_error_flag",
+    "checkpoint_error_file",
+    "final_session_history_identity_file",
+    "failure_diagnostic_file",
+    "system_log_file",
+    "agent_log_file",
+    "metrics_log_file",
+    "sandbox_ops_file",
+    "telemetry_system_log_pos_file",
+    "telemetry_metrics_pos_file",
+    "telemetry_sandbox_ops_pos_file",
+];
+
+#[test]
+fn env_and_paths_modules_do_not_reintroduce_run_scoped_facades() -> std::io::Result<()> {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let env_rs = read_source(manifest_dir, "src/env.rs")?;
+    let paths_rs = read_source(manifest_dir, "src/paths.rs")?;
+
+    assert_no_process_global_state(&env_rs, "src/env.rs");
+    assert_no_process_global_state(&paths_rs, "src/paths.rs");
+
+    for name in RUN_SCOPED_ENV_READER_NAMES {
+        assert_no_zero_arg_reader(&env_rs, "src/env.rs", name);
+    }
+    for name in RUN_SCOPED_PATH_READER_NAMES {
+        assert_no_zero_arg_reader(&paths_rs, "src/paths.rs", name);
+    }
+
+    Ok(())
+}
+
+fn read_source(manifest_dir: &Path, relative_path: &str) -> Result<String, std::io::Error> {
+    let path = manifest_dir.join(relative_path);
+    fs::read_to_string(&path).map_err(|error| {
+        std::io::Error::new(error.kind(), format!("read {}: {error}", path.display()))
+    })
+}
+
+fn assert_no_process_global_state(source: &str, label: &str) {
+    for forbidden in ["LazyLock", "OnceLock"] {
+        assert!(
+            !source.contains(forbidden),
+            "{label} must not reintroduce {forbidden}; use explicit GuestConfig/GuestPaths ownership"
+        );
+    }
+}
+
+fn assert_no_zero_arg_reader(source: &str, label: &str, name: &str) {
+    let pattern = format!("fn {name}()");
+    assert!(
+        !source.contains(&pattern),
+        "{label} must not expose zero-argument run-scoped reader {name}(); use GuestConfig/GuestPaths"
+    );
+}


### PR DESCRIPTION
## Summary

- Document the explicit guest-agent runtime ownership model at the library/env/path boundaries.
- Add a focused integration guard that prevents `env.rs` and `paths.rs` from reintroducing process-global run-scoped facade state or zero-argument run-scoped readers.

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test runtime_api_surface`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --lib`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --all-targets`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets -- -D warnings`
- pre-commit cargo doc and workspace clippy

Closes #19597
Part of #19472