### PR TITLE
refactor: remove guest-common runtime path fallbacks

### DIFF
--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -1441,6 +1441,21 @@ mod tests {
         }
     }
 
+    struct SandboxOpsOverrideGuard;
+
+    impl SandboxOpsOverrideGuard {
+        fn set(path: &std::path::Path) -> Self {
+            guest_common::telemetry::set_sandbox_ops_log_file(path);
+            Self
+        }
+    }
+
+    impl Drop for SandboxOpsOverrideGuard {
+        fn drop(&mut self) {
+            guest_common::telemetry::clear_sandbox_ops_log_file();
+        }
+    }
+
     fn cli_diagnostic(message: &str, source: FailureDetailSource) -> cli::CliFailureDiagnostic {
         cli::CliFailureDiagnostic {
             message: message.to_string(),
@@ -2794,6 +2809,8 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let system_log_path = tmp.path().join("system.log");
         let _system_log_guard = SystemLogOverrideGuard::set(&system_log_path);
+        let _sandbox_ops_guard =
+            SandboxOpsOverrideGuard::set(std::path::Path::new(guest_paths.sandbox_ops_file()));
         let cleanup_paths = vec![
             system_log_path.to_string_lossy().into_owned(),
             guest_paths.sandbox_ops_file().to_string(),
@@ -2854,6 +2871,9 @@ mod tests {
                 server.reset_async().await;
                 let _env_guard = unsafe { set_test_env(server, None) };
                 let guest_paths = test_guest_paths();
+                let _sandbox_ops_guard = SandboxOpsOverrideGuard::set(std::path::Path::new(
+                    guest_paths.sandbox_ops_file(),
+                ));
 
                 let marker = "producer_after_shutdown_before_final_upload";
                 let cleanup_paths = vec![

--- a/crates/guest-common/src/log.rs
+++ b/crates/guest-common/src/log.rs
@@ -3,30 +3,9 @@
 use std::fs::File;
 use std::io::{self, IoSlice, Write};
 use std::path::{Path, PathBuf};
-use std::sync::{LazyLock, Mutex};
+use std::sync::Mutex;
 
-#[allow(clippy::panic)]
-static RUN_ID: LazyLock<String> =
-    LazyLock::new(|| match std::env::var(guest_contracts::env::RUN_ID_ENV) {
-        Ok(run_id) if !run_id.is_empty() => run_id,
-        _ => panic!("VM0_RUN_ID is required for guest system logging"),
-    });
-static DEFAULT_SYSTEM_LOG_FILE: LazyLock<String> = LazyLock::new(|| {
-    path_to_string(guest_contracts::runtime_paths::system_log_file(
-        default_run_dir(),
-    ))
-});
 static SYSTEM_LOG: Mutex<SystemLogState> = Mutex::new(SystemLogState::disabled());
-
-#[allow(clippy::panic)]
-fn default_run_dir() -> PathBuf {
-    guest_contracts::runtime_paths::run_dir_from_env(&RUN_ID)
-        .unwrap_or_else(|error| panic!("failed to resolve guest system log path: {error}"))
-}
-
-fn path_to_string(path: PathBuf) -> String {
-    path.to_string_lossy().into_owned()
-}
 
 /// Process-global guest system log state.
 ///
@@ -109,20 +88,6 @@ fn open_system_log_file(path: &Path) -> std::io::Result<File> {
 /// Get current timestamp in RFC3339 format with milliseconds.
 pub fn timestamp() -> String {
     chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
-}
-
-/// Enable writes to the guest-side system log file for the current run.
-///
-/// # Panics
-///
-/// Panics when `VM0_RUN_ID` is missing or empty. Guest binaries require a run
-/// ID before writing run-scoped logs.
-pub fn enable_system_log_file() {
-    set_system_log_file(default_system_log_file());
-}
-
-fn default_system_log_file() -> &'static str {
-    &DEFAULT_SYSTEM_LOG_FILE
 }
 
 /// Override the system log file used by future log lines.

--- a/crates/guest-common/src/telemetry.rs
+++ b/crates/guest-common/src/telemetry.rs
@@ -5,39 +5,14 @@ use serde::Serialize;
 use std::fs::File;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
-use std::sync::{LazyLock, Mutex};
+use std::sync::Mutex;
 use std::time::Duration;
 
 #[cfg(unix)]
 use std::os::fd::{AsRawFd, RawFd};
 
-static RUN_ID: LazyLock<String> =
-    LazyLock::new(|| std::env::var(guest_contracts::env::RUN_ID_ENV).unwrap_or_default());
-
-static SANDBOX_OPS_LOG: LazyLock<String> = LazyLock::new(|| {
-    let Ok(run_dir) = guest_contracts::runtime_paths::run_dir_from_env(&RUN_ID) else {
-        return String::new();
-    };
-    guest_contracts::runtime_paths::sandbox_ops_log_file(run_dir)
-        .to_string_lossy()
-        .into_owned()
-});
-
 static SANDBOX_OPS_APPEND_LOCK: Mutex<()> = Mutex::new(());
 static SANDBOX_OPS_LOG_OVERRIDE: Mutex<Option<PathBuf>> = Mutex::new(None);
-
-/// Legacy process-env-derived sandbox operations log file in JSONL format.
-///
-/// The path is resolved through the guest runtime path contract in
-/// `guest_contracts::runtime_paths`. An empty string means the guest runtime
-/// path could not be resolved and sandbox operation logging is unavailable.
-///
-/// This accessor does not report the explicit path installed through
-/// [`set_sandbox_ops_log_file`]; `record_sandbox_op` uses that override when it
-/// is present.
-pub fn sandbox_ops_log() -> &'static str {
-    &SANDBOX_OPS_LOG
-}
 
 /// Set the sandbox operations log path used by future `record_sandbox_op` calls.
 pub fn set_sandbox_ops_log_file(path: impl AsRef<Path>) {
@@ -56,20 +31,10 @@ pub fn clear_sandbox_ops_log_file() {
 }
 
 fn configured_sandbox_ops_log() -> Option<PathBuf> {
-    if let Some(path) = SANDBOX_OPS_LOG_OVERRIDE
+    SANDBOX_OPS_LOG_OVERRIDE
         .lock()
         .unwrap_or_else(|e| e.into_inner())
         .clone()
-    {
-        return Some(path);
-    }
-
-    let path = sandbox_ops_log();
-    if path.is_empty() {
-        None
-    } else {
-        Some(PathBuf::from(path))
-    }
 }
 
 #[cfg(unix)]
@@ -134,11 +99,10 @@ struct SandboxOpEntry {
 
 /// Record a sandbox operation to the telemetry log on a best-effort basis.
 ///
-/// This helper is non-fatal: it no-ops when no explicit log path is configured
-/// and [`sandbox_ops_log`] is empty. Serialization or append/open/lock/write
-/// failures are not propagated to the caller. Guest operations should not treat
-/// a successful return from this function as proof that a telemetry entry was
-/// written.
+/// This helper is non-fatal: it no-ops when no explicit log path is configured.
+/// Serialization or append/open/lock/write failures are not propagated to the
+/// caller. Guest operations should not treat a successful return from this
+/// function as proof that a telemetry entry was written.
 ///
 /// Each JSONL entry contains `ts`, `action_type`, `duration_ms`, `success`, and
 /// an optional `error` field. The format is compatible with the TypeScript
@@ -213,48 +177,17 @@ mod tests {
         }
     }
 
-    struct RuntimeDirEnvGuard {
-        previous: Option<std::ffi::OsString>,
-    }
-
-    impl RuntimeDirEnvGuard {
-        fn set(path: impl AsRef<Path>) -> Self {
-            let previous = std::env::var_os(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV);
-            unsafe {
-                std::env::set_var(
-                    guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
-                    path.as_ref(),
-                );
-            }
-            Self { previous }
-        }
-    }
-
-    impl Drop for RuntimeDirEnvGuard {
-        fn drop(&mut self) {
-            unsafe {
-                if let Some(previous) = self.previous.as_ref() {
-                    std::env::set_var(
-                        guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
-                        previous,
-                    );
-                } else {
-                    std::env::remove_var(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV);
-                }
-            }
-        }
-    }
-
     #[test]
     fn record_sandbox_op_writes_and_appends_jsonl() {
         let _guard = lock_test_state();
-        // Single test because all calls share the same static log path.
         clear_sandbox_ops_log_file();
         let dir = tempfile::tempdir().unwrap();
-        let runtime_dir = dir.path().join("runtime");
-        let _env_guard = RuntimeDirEnvGuard::set(&runtime_dir);
-        let log_path = sandbox_ops_log();
-        let _ = std::fs::remove_file(log_path);
+        let log_path = dir
+            .path()
+            .join("runtime")
+            .join("logs")
+            .join("sandbox-ops.jsonl");
+        let _override_guard = SandboxOpsOverrideGuard::set(&log_path);
 
         record_sandbox_op("op_a", Duration::from_millis(10), true, None);
         record_sandbox_op("op_b", Duration::from_millis(20), false, Some("fail"));
@@ -280,7 +213,7 @@ mod tests {
             }
         });
 
-        let content = std::fs::read_to_string(log_path).unwrap();
+        let content = std::fs::read_to_string(&log_path).unwrap();
         let lines: Vec<&str> = content.lines().collect();
         assert_eq!(lines.len(), 3 + THREAD_COUNT * RECORDS_PER_THREAD);
 
@@ -316,7 +249,7 @@ mod tests {
             }
         }
 
-        let _ = std::fs::remove_file(log_path);
+        let _ = std::fs::remove_file(&log_path);
     }
 
     #[test]
@@ -334,5 +267,24 @@ mod tests {
         let entry: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
         assert_eq!(entry["action_type"], "op_override");
         assert_eq!(entry["duration_ms"], 12);
+    }
+
+    #[test]
+    fn record_sandbox_op_noops_without_explicit_log_path() {
+        let _guard = lock_test_state();
+        clear_sandbox_ops_log_file();
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir
+            .path()
+            .join("runtime")
+            .join("logs")
+            .join("sandbox-ops.jsonl");
+
+        record_sandbox_op("op_without_path", Duration::from_millis(1), true, None);
+
+        assert!(
+            !log_path.exists(),
+            "sandbox op logging should not create a file without an explicit path"
+        );
     }
 }

--- a/crates/guest-common/tests/runtime_path_fallback_surface.rs
+++ b/crates/guest-common/tests/runtime_path_fallback_surface.rs
@@ -22,12 +22,16 @@ fn read_source(manifest_dir: &Path, relative_path: &str) -> Result<String, std::
 fn assert_no_fallback_surface(source: &str, label: &str) {
     let source = non_comment_lines(source).collect::<Vec<_>>().join("\n");
     assert!(
-        !source.contains("LazyLock"),
-        "{label} must not derive runtime log paths from process-global lazy state"
-    );
-    assert!(
         !source.contains("static RUN_ID"),
         "{label} must not cache VM0_RUN_ID in process-global state"
+    );
+    assert!(
+        !source.contains("RUN_ID_ENV"),
+        "{label} must not read VM0_RUN_ID to derive runtime log paths"
+    );
+    assert!(
+        !source.contains("run_dir_from_env"),
+        "{label} must not derive runtime log paths from process env"
     );
     assert!(
         !source.contains("enable_system_log_file"),

--- a/crates/guest-common/tests/runtime_path_fallback_surface.rs
+++ b/crates/guest-common/tests/runtime_path_fallback_surface.rs
@@ -1,0 +1,52 @@
+use std::path::Path;
+
+#[test]
+fn log_and_telemetry_do_not_reintroduce_runtime_path_env_fallbacks() -> std::io::Result<()> {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let log_rs = read_source(manifest_dir, "src/log.rs")?;
+    let telemetry_rs = read_source(manifest_dir, "src/telemetry.rs")?;
+
+    assert_no_fallback_surface(&log_rs, "src/log.rs");
+    assert_no_fallback_surface(&telemetry_rs, "src/telemetry.rs");
+
+    Ok(())
+}
+
+fn read_source(manifest_dir: &Path, relative_path: &str) -> Result<String, std::io::Error> {
+    let path = manifest_dir.join(relative_path);
+    std::fs::read_to_string(&path).map_err(|error| {
+        std::io::Error::new(error.kind(), format!("read {}: {error}", path.display()))
+    })
+}
+
+fn assert_no_fallback_surface(source: &str, label: &str) {
+    let source = non_comment_lines(source).collect::<Vec<_>>().join("\n");
+    assert!(
+        !source.contains("LazyLock"),
+        "{label} must not derive runtime log paths from process-global lazy state"
+    );
+    assert!(
+        !source.contains("static RUN_ID"),
+        "{label} must not cache VM0_RUN_ID in process-global state"
+    );
+    assert!(
+        !source.contains("enable_system_log_file"),
+        "{label} must not expose env-derived system log setup"
+    );
+
+    let compact_source = source
+        .chars()
+        .filter(|character| !character.is_whitespace())
+        .collect::<String>();
+    assert!(
+        !compact_source.contains("fnsandbox_ops_log()"),
+        "{label} must not expose env-derived sandbox ops path lookup"
+    );
+}
+
+fn non_comment_lines(source: &str) -> impl Iterator<Item = &str> {
+    source
+        .lines()
+        .map(str::trim_start)
+        .filter(|line| !line.starts_with("//"))
+}

--- a/crates/guest-download/Cargo.toml
+++ b/crates/guest-download/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 
 [dependencies]
 flate2.workspace = true
+guest-contracts.workspace = true
 libc.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
@@ -13,7 +14,6 @@ ureq = { workspace = true, features = ["platform-verifier"] }
 guest-common.workspace = true
 
 [dev-dependencies]
-guest-contracts.workspace = true
 httpmock.workspace = true
 tempfile.workspace = true
 

--- a/crates/guest-download/src/main.rs
+++ b/crates/guest-download/src/main.rs
@@ -1,4 +1,5 @@
 use guest_common::{log_error, log_info, telemetry::record_sandbox_op};
+use guest_contracts::{env, runtime_paths};
 use std::fs::File;
 #[cfg(unix)]
 use std::fs::OpenOptions;
@@ -16,7 +17,10 @@ enum ManifestInput {
 }
 
 fn main() {
-    guest_common::log::enable_system_log_file();
+    if let Err(error) = install_runtime_log_paths() {
+        log_error!(LOG_TAG, "{error}");
+        std::process::exit(1);
+    }
 
     let Some(input) = manifest_input_from_args() else {
         log_error!(LOG_TAG, "{USAGE}");
@@ -34,6 +38,27 @@ fn main() {
         log_error!(LOG_TAG, "Download failed");
         std::process::exit(1);
     }
+}
+
+fn install_runtime_log_paths() -> Result<(), String> {
+    let run_id = std::env::var(env::RUN_ID_ENV).map_err(|_| {
+        format!(
+            "{} is required for guest-download runtime paths",
+            env::RUN_ID_ENV
+        )
+    })?;
+    if run_id.is_empty() {
+        return Err(format!(
+            "{} is required for guest-download runtime paths",
+            env::RUN_ID_ENV
+        ));
+    }
+
+    let run_dir = runtime_paths::run_dir_from_env(&run_id)
+        .map_err(|error| format!("failed to resolve guest-download runtime paths: {error}"))?;
+    guest_common::log::set_system_log_file(runtime_paths::system_log_file(&run_dir));
+    guest_common::telemetry::set_sandbox_ops_log_file(runtime_paths::sandbox_ops_log_file(run_dir));
+    Ok(())
 }
 
 fn manifest_input_from_args() -> Option<ManifestInput> {

--- a/crates/guest-download/tests/integration/binary_logging.rs
+++ b/crates/guest-download/tests/integration/binary_logging.rs
@@ -335,6 +335,50 @@ fn binary_fails_with_relative_runtime_dir_for_runtime_log_setup() {
 }
 
 #[test]
+fn binary_fails_with_invalid_run_id_for_runtime_log_setup() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest_path = write_manifest(&dir, &[], None).unwrap();
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_guest-download"))
+        .arg(&manifest_path)
+        .env("VM0_RUN_ID", "invalid/run/id")
+        .env_remove(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(
+            "failed to resolve guest-download runtime paths: VM0_RUN_ID must be a single safe path segment"
+        ),
+        "unexpected stderr: {stderr}"
+    );
+}
+
+#[test]
+fn binary_fails_without_home_or_runtime_dir_for_runtime_log_setup() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest_path = write_manifest(&dir, &[], None).unwrap();
+    let run_id = unique_run_id("missing-home");
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_guest-download"))
+        .arg(&manifest_path)
+        .env("VM0_RUN_ID", run_id)
+        .env_remove(guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV)
+        .env_remove("HOME")
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("failed to resolve guest-download runtime paths: HOME is required for guest runtime paths"),
+        "unexpected stderr: {stderr}"
+    );
+}
+
+#[test]
 fn binary_does_not_log_http_archive_url_on_success() {
     let server = MockServer::start();
     let tar_gz = create_tar_gz(&[("secret.txt", b"downloaded")]).unwrap();

--- a/crates/guest-download/tests/integration/binary_logging.rs
+++ b/crates/guest-download/tests/integration/binary_logging.rs
@@ -47,7 +47,7 @@ fn run_binary_with_manifest_stdin(
 }
 
 #[test]
-fn binary_writes_system_log_to_guest_common_default_path() {
+fn binary_writes_system_log_to_explicit_runtime_path() {
     let dir = tempfile::tempdir().unwrap();
     let manifest_path = write_manifest(&dir, &[], None).unwrap();
     let run_id = unique_run_id("success");
@@ -271,7 +271,7 @@ fn binary_without_manifest_path_logs_usage() {
 }
 
 #[test]
-fn binary_panics_without_run_id_for_default_system_log() {
+fn binary_fails_without_run_id_for_runtime_log_setup() {
     let dir = tempfile::tempdir().unwrap();
     let manifest_path = write_manifest(&dir, &[], None).unwrap();
 
@@ -284,13 +284,13 @@ fn binary_panics_without_run_id_for_default_system_log() {
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("VM0_RUN_ID is required for guest system logging"),
+        stderr.contains("VM0_RUN_ID is required for guest-download runtime paths"),
         "unexpected stderr: {stderr}"
     );
 }
 
 #[test]
-fn binary_panics_with_empty_run_id_for_default_system_log() {
+fn binary_fails_with_empty_run_id_for_runtime_log_setup() {
     let dir = tempfile::tempdir().unwrap();
     let manifest_path = write_manifest(&dir, &[], None).unwrap();
 
@@ -303,7 +303,33 @@ fn binary_panics_with_empty_run_id_for_default_system_log() {
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("VM0_RUN_ID is required for guest system logging"),
+        stderr.contains("VM0_RUN_ID is required for guest-download runtime paths"),
+        "unexpected stderr: {stderr}"
+    );
+}
+
+#[test]
+fn binary_fails_with_relative_runtime_dir_for_runtime_log_setup() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest_path = write_manifest(&dir, &[], None).unwrap();
+    let run_id = unique_run_id("relative-runtime-dir");
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_guest-download"))
+        .arg(&manifest_path)
+        .env("VM0_RUN_ID", run_id)
+        .env(
+            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+            "relative-runtime-dir",
+        )
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(
+            "failed to resolve guest-download runtime paths: VM0_GUEST_RUNTIME_DIR must be an absolute path"
+        ),
         "unexpected stderr: {stderr}"
     );
 }

--- a/crates/guest-download/tests/integration/binary_logging.rs
+++ b/crates/guest-download/tests/integration/binary_logging.rs
@@ -357,6 +357,34 @@ fn binary_fails_with_invalid_run_id_for_runtime_log_setup() {
 }
 
 #[test]
+fn binary_uses_absolute_runtime_dir_without_validating_run_id_as_path_segment() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest_path = write_manifest(&dir, &[], None).unwrap();
+    let logs = RuntimeLogPaths::new(&dir);
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_guest-download"))
+        .arg(&manifest_path)
+        .env("VM0_RUN_ID", "ignored/when/runtime-dir/is-set")
+        .env(
+            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+            &logs.runtime_dir,
+        )
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let content = std::fs::read_to_string(&logs.system_log).unwrap();
+    assert!(
+        content.contains("[INFO] [sandbox:download] Download completed"),
+        "unexpected system log: {content:?}"
+    );
+}
+
+#[test]
 fn binary_fails_without_home_or_runtime_dir_for_runtime_log_setup() {
     let dir = tempfile::tempdir().unwrap();
     let manifest_path = write_manifest(&dir, &[], None).unwrap();


### PR DESCRIPTION
## Summary

- remove env-derived runtime path fallbacks from `guest-common` log and sandbox-op telemetry
- make `guest-download` explicitly resolve runtime paths and install system/sandbox-op log paths at startup
- update binary logging tests and add a guard against reintroducing the fallback surface

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p guest-common --all-targets`
- `cargo test --manifest-path crates/Cargo.toml -p guest-download --all-targets`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test guest_runtime_process_env -- --test-threads=1`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test runtime_api_surface`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`

Closes #19716
