### PR TITLE
refactor: reduce fallback slop in runtime guards

### DIFF
--- a/turbo/apps/api/src/lib/log.ts
+++ b/turbo/apps/api/src/lib/log.ts
@@ -214,11 +214,9 @@ export async function flushLogs(): Promise<void> {
   if (!axiomLogger) {
     return;
   }
-  try {
-    await axiomLogger.flush();
-  } catch (error) {
-    console.error("Failed to flush Axiom logs", error);
-  }
+  await axiomLogger.flush().catch((error: unknown) => {
+    writeError("Failed to flush Axiom logs", error);
+  });
 }
 
 // ── Logger creation ──────────────────────────────────────────────────────

--- a/turbo/apps/api/src/lib/log.ts
+++ b/turbo/apps/api/src/lib/log.ts
@@ -214,7 +214,7 @@ export async function flushLogs(): Promise<void> {
   if (!axiomLogger) {
     return;
   }
-  await axiomLogger.flush().catch((error: unknown) => {
+  await axiomLogger.flush()?.catch((error: unknown) => {
     writeError("Failed to flush Axiom logs", error);
   });
 }

--- a/turbo/apps/api/src/lib/log.ts
+++ b/turbo/apps/api/src/lib/log.ts
@@ -210,9 +210,15 @@ function logToAxiom(level: Level, name: string, args: unknown[]): void {
 }
 
 export async function flushLogs(): Promise<void> {
-  await getAxiomLogger()
-    ?.flush()
-    ?.catch(() => {});
+  const axiomLogger = getAxiomLogger();
+  if (!axiomLogger) {
+    return;
+  }
+  try {
+    await axiomLogger.flush();
+  } catch (error) {
+    console.error("Failed to flush Axiom logs", error);
+  }
 }
 
 // ── Logger creation ──────────────────────────────────────────────────────

--- a/turbo/apps/api/src/signals/routes/test-slack-dispatch-probe.ts
+++ b/turbo/apps/api/src/signals/routes/test-slack-dispatch-probe.ts
@@ -67,7 +67,10 @@ function readOptionalErrorString(
   error: Error,
   key: string,
 ): string | undefined {
-  const value = (error as unknown as Record<string, unknown>)[key];
+  if (!isRecord(error)) {
+    return undefined;
+  }
+  const value = error[key];
   return typeof value === "string" ? value : undefined;
 }
 

--- a/turbo/apps/api/src/signals/routes/webhooks-clerk.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-clerk.ts
@@ -115,7 +115,7 @@ const postClerkWebhook$ = command(
 
     // "user.banned" is not yet in the Clerk SDK WebhookEvent type union
     if ((event.type as string) === "user.banned") {
-      const { data } = event as unknown as { data: unknown };
+      const data = propertyOf(event, "data");
       const userId = eventDataId(data);
       if (!userId) {
         L.error("user.banned event missing user ID", { data });

--- a/turbo/apps/api/src/signals/services/webhooks-github.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-github.service.ts
@@ -55,13 +55,15 @@ const gitHubLabelSchema = z.object({
   name: z.string(),
 });
 
+const gitHubPullRequestMarkerSchema = z.object({}).passthrough();
+
 const gitHubIssueSchema = z.object({
   number: z.number(),
   title: z.string(),
   body: z.string().nullable(),
   labels: z.array(gitHubLabelSchema),
   user: gitHubUserSchema,
-  pull_request: z.unknown().optional(),
+  pull_request: gitHubPullRequestMarkerSchema.optional(),
 });
 
 const gitHubCommentSchema = z.object({

--- a/turbo/apps/api/src/signals/services/zero-agent-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-agent-data.service.ts
@@ -23,9 +23,14 @@ export function agentResponse(row: {
   readonly preferPersonalProvider: boolean;
   readonly visibility: "public" | "private";
 }): ZeroAgentResponse {
+  const ownerId = row.owner ?? row.composeUserId;
+  if (!ownerId) {
+    throw new Error(`Zero agent ${row.agentId} is missing an owner`);
+  }
+
   return {
     agentId: row.agentId,
-    ownerId: row.owner ?? row.composeUserId ?? "",
+    ownerId,
     displayName: row.displayName,
     description: row.description,
     sound: row.sound,

--- a/turbo/apps/cli/src/lib/domain/yaml-validator.ts
+++ b/turbo/apps/cli/src/lib/domain/yaml-validator.ts
@@ -98,7 +98,9 @@ function formatInvalidTypeIssue(
   issue: z.ZodIssue & { expected?: string },
 ): string | null {
   // Zod 4 uses 'input' instead of 'received' in types, but runtime has 'received'
-  const received = (issue as unknown as { received?: string }).received;
+  const runtimeReceived = Reflect.get(issue, "received");
+  const received =
+    typeof runtimeReceived === "string" ? runtimeReceived : undefined;
 
   // Missing required fields (handles both "Required" and "Invalid input:" messages)
   const isMissing =

--- a/turbo/apps/desktop/scripts/create-styled-dmg.mjs
+++ b/turbo/apps/desktop/scripts/create-styled-dmg.mjs
@@ -257,7 +257,7 @@ async function createStyledDmg({
       try {
         await run("hdiutil", ["detach", mountPath]);
       } catch (error) {
-        console.warn(`Failed to detach DMG mount ${mountPath}:`, error);
+        console.warn("Failed to detach DMG mount", { mountPath, error });
       }
     }
     if (process.env.ZERO_DESKTOP_KEEP_DMG_TEMP !== "true") {

--- a/turbo/apps/desktop/scripts/create-styled-dmg.mjs
+++ b/turbo/apps/desktop/scripts/create-styled-dmg.mjs
@@ -254,7 +254,11 @@ async function createStyledDmg({
     await run("hdiutil", ["verify", outPath]);
   } finally {
     if (mounted) {
-      await run("hdiutil", ["detach", mountPath]).catch(() => {});
+      try {
+        await run("hdiutil", ["detach", mountPath]);
+      } catch (error) {
+        console.warn(`Failed to detach DMG mount ${mountPath}:`, error);
+      }
     }
     if (process.env.ZERO_DESKTOP_KEEP_DMG_TEMP !== "true") {
       await rm(tempDir, { force: true, recursive: true });

--- a/turbo/packages/db/scripts/migrations/007-agent-scoped-workflow-volumes/backfill.ts
+++ b/turbo/packages/db/scripts/migrations/007-agent-scoped-workflow-volumes/backfill.ts
@@ -258,6 +258,15 @@ async function deleteObjects(
   }
 }
 
+function isAsyncIterableByteStream(
+  value: unknown,
+): value is AsyncIterable<Uint8Array> {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  return typeof Reflect.get(value, Symbol.asyncIterator) === "function";
+}
+
 async function downloadBuffer(
   client: S3Client,
   bucket: string,
@@ -270,8 +279,10 @@ async function downloadBuffer(
     throw new Error(`S3 object body is empty: ${key}`);
   }
   const chunks: Buffer[] = [];
-  const stream = response.Body as unknown as AsyncIterable<Uint8Array>;
-  for await (const chunk of stream) {
+  if (!isAsyncIterableByteStream(response.Body)) {
+    throw new Error(`S3 object body is not streamable: ${key}`);
+  }
+  for await (const chunk of response.Body) {
     chunks.push(Buffer.from(chunk));
   }
   return Buffer.concat(chunks);


### PR DESCRIPTION
## Summary

Daily AI-slop fallback cleanup for runtime guards and cleanup paths.

## Scan

- Scan timestamp: `2026-07-01T20:01:33.329Z`
- Base commit: `dc56030baa32d7452c906edb3ec36d14543c9ac5`
- Total matches: `17065`
- High-confidence production-actionable total: `217`
- Suggested 5% edit budget: `11`
- Candidates changed: `8`

## Match Totals By Category

- `nullish`: 5030
- `nullish-chain`: 117
- `field-fallback-chain`: 92
- `optional-prop`: 5279
- `zod-optional`: 1993
- `zod-loose-optional`: 9
- `loose-record`: 1163
- `loose-index-signature`: 5
- `as-any`: 0
- `as-unknown-as`: 34
- `empty-fallback`: 561
- `string-fallback`: 650
- `null-undefined-fallback`: 1411
- `empty-catch`: 3
- `promise-catch-swallow`: 16
- `rust-unwrap-or`: 562
- `rust-ok-discard`: 140

## Changes

- `turbo/apps/api/src/signals/routes/test-slack-dispatch-probe.ts`: replaced a double cast on `Error` with the route's existing record guard before reading optional error fields.
- `turbo/apps/api/src/signals/routes/webhooks-clerk.ts`: replaced the `user.banned` event double cast with the existing `propertyOf` runtime reader; this preserves handling for the Clerk event not yet present in the SDK type union.
- `turbo/apps/api/src/signals/services/webhooks-github.service.ts`: changed the issue `pull_request` marker from `z.unknown().optional()` to an object passthrough schema; downstream code only checks marker presence.
- `turbo/apps/api/src/signals/services/zero-agent-data.service.ts`: replaced an empty owner fallback with a fail-fast guard when both `owner` and joined compose owner are missing.
- `turbo/apps/api/src/lib/log.ts`: replaced swallowed Axiom flush failures with direct `console.error` reporting while preserving non-throwing flush behavior.
- `turbo/apps/cli/src/lib/domain/yaml-validator.ts`: replaced a double cast for Zod's runtime `received` field with `Reflect.get` and a string guard.
- `turbo/apps/desktop/scripts/create-styled-dmg.mjs`: replaced a swallowed cleanup detach failure with `console.warn` while preserving best-effort cleanup behavior.
- `turbo/packages/db/scripts/migrations/007-agent-scoped-workflow-volumes/backfill.ts`: replaced the S3 body double cast with an async-iterable byte-stream guard before reading chunks.

## Verification

- `git diff --check` passed.
- `node --check turbo/apps/desktop/scripts/create-styled-dmg.mjs` passed.
- Post-edit scanner pass completed; selected categories reduced: `as-unknown-as` 34 -> 30, `zod-loose-optional` 9 -> 8, `promise-catch-swallow` 16 -> 14, `field-fallback-chain` 92 -> 91.
- Targeted package type checks were attempted for `api`, `@vm0/cli`, `@vm0/db`, and `@vm0/desktop`, but this fresh clone has no `node_modules`; each failed to start because `tsc` was not installed locally. The PR pipeline will run the full checks.

This workflow intentionally leaves the remaining candidates for later daily runs.
