### PR TITLE
feat: hide creator attribution on private agents tab

### DIFF
--- a/turbo/apps/platform/src/views/agents-page/__tests__/agents-page-tabs.test.tsx
+++ b/turbo/apps/platform/src/views/agents-page/__tests__/agents-page-tabs.test.tsx
@@ -64,7 +64,7 @@ function tab(label: "Public" | "Private"): HTMLElement {
 }
 
 describe("agents page (redesign)", () => {
-  it("filters agents by tab and shows the creator on every card", async () => {
+  it("filters agents by tab and shows creator only on public cards", async () => {
     const user = userEvent.setup();
     context.mocks.data.team(agents);
     context.mocks.data.orgMembers({
@@ -100,15 +100,15 @@ describe("agents page (redesign)", () => {
       expect(tab("Private")).toBeInTheDocument();
     });
 
-    // Private tab: only private agents, each with a creator footer.
+    // Private tab: only private agents, no creator footer.
     await user.click(tab("Private"));
     await waitFor(() => {
       expect(agentCard("Private Ops")).toBeInTheDocument();
     });
     expect(findAgentCard("Research Agent")).toBeNull();
     expect(
-      within(agentCard("Private Ops")).getByText("Created by Bob Builder"),
-    ).toBeInTheDocument();
+      within(agentCard("Private Ops")).queryByText("Created by Bob Builder"),
+    ).not.toBeInTheDocument();
 
     // Public tab: only public agents, each with a creator footer.
     await user.click(tab("Public"));

--- a/turbo/apps/platform/src/views/agents-page/agents-page-tabs.tsx
+++ b/turbo/apps/platform/src/views/agents-page/agents-page-tabs.tsx
@@ -243,6 +243,7 @@ function AgentTabsView({
           membersById={membersById}
           unreadAgentIds={unreadAgentIds}
           unreadIndicatorsEnabled={agentUnreadIndicatorsEnabled}
+          showCreator={activeTab !== "private"}
         />
       ) : activeTab === "private" ? (
         <PrivateEmptyState
@@ -325,11 +326,13 @@ function AgentGrid({
   membersById,
   unreadAgentIds,
   unreadIndicatorsEnabled,
+  showCreator,
 }: {
   agents: AgentProps["agent"][];
   membersById: ReadonlyMap<string, OrgMember>;
   unreadAgentIds: ReadonlySet<string> | undefined;
   unreadIndicatorsEnabled: boolean;
+  showCreator: boolean;
 }) {
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
@@ -348,6 +351,7 @@ function AgentGrid({
                 unreadIndicatorsEnabled &&
                 (unreadAgentIds?.has(agent.id) ?? false)
               }
+              showCreator={showCreator}
             />
           </Link>
         );
@@ -588,6 +592,7 @@ type AgentProps = {
   };
   creator: AgentCreator;
   hasUnread: boolean;
+  showCreator: boolean;
 };
 
 interface AgentCreator {
@@ -646,7 +651,7 @@ function AgentUnreadIndicator() {
   );
 }
 
-function AgentCard({ agent, creator, hasUnread }: AgentProps) {
+function AgentCard({ agent, creator, hasUnread, showCreator }: AgentProps) {
   const defaultAgentId = useLastResolved(defaultAgentId$);
   const lead = agent.id === defaultAgentId;
   const displayName = agent.displayName ?? agent.id;
@@ -674,14 +679,16 @@ function AgentCard({ agent, creator, hasUnread }: AgentProps) {
             </p>
           </div>
         </div>
-        <div className="mt-auto flex items-center gap-2 border-t border-border/60 pt-3">
-          <span className="flex h-5 w-5 shrink-0 items-center justify-center overflow-hidden rounded-full">
-            <CreatorAvatar creator={creator} />
-          </span>
-          <span className="truncate text-xs text-muted-foreground">
-            Created by {creator.name}
-          </span>
-        </div>
+        {showCreator && (
+          <div className="mt-auto flex items-center gap-2 border-t border-border/60 pt-3">
+            <span className="flex h-5 w-5 shrink-0 items-center justify-center overflow-hidden rounded-full">
+              <CreatorAvatar creator={creator} />
+            </span>
+            <span className="truncate text-xs text-muted-foreground">
+              Created by {creator.name}
+            </span>
+          </div>
+        )}
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## Summary

- On the Private tab, the "Created by [name]" footer was redundant — all private agents belong to the viewing user
- The creator footer is now conditionally rendered: shown on Public tab, hidden on Private tab
- Updated the test description and assertion to match the new behavior

Closes #19723