### PR TITLE
feat: add command dialog agent picker

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -1224,15 +1224,7 @@ describe("zero sidebar", () => {
       expect(within(sidebar).getByText("Research Agent")).toBeInTheDocument();
     });
 
-    const researchAgentButton = queryAllByRoleFast("button", dialog).find(
-      (element) => {
-        return element.textContent?.trim() === "Research Agent";
-      },
-    );
-    if (!researchAgentButton) {
-      throw new Error("Research Agent button not found");
-    }
-    click(researchAgentButton);
+    click(within(dialog).getByRole("option", { name: /Research Agent/ }));
 
     await waitFor(() => {
       expect(
@@ -1269,6 +1261,49 @@ describe("zero sidebar", () => {
     const dialog = await screen.findByRole("dialog", { name: "Talk to" });
     expect(within(dialog).getByText("Research Agent")).toBeInTheDocument();
     expect(within(dialog).getByText("Support Agent")).toBeInTheDocument();
+  });
+
+  it("selects an agent from the picker with arrow keys and enter", async () => {
+    prepareAgentTeam();
+    context.mocks.api(chatThreadsContract.list, ({ respond }) => {
+      return respond(200, splitChatThreadListResponse([]));
+    });
+
+    detachedSetupPage({ context, path: `/agents/${AGENT_ID}/chat` });
+
+    await waitFor(() => {
+      expect(sidebar()).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(document.body, {
+      key: "a",
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    const dialog = await screen.findByRole("dialog", { name: "Talk to" });
+    const search = within(dialog).getByPlaceholderText("Search agents...");
+
+    await fill(search, "support");
+
+    await waitFor(() => {
+      expect(
+        within(dialog).queryByText("Research Agent"),
+      ).not.toBeInTheDocument();
+      expect(within(dialog).getByText("Support Agent")).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(search, { key: "ArrowDown" });
+    fireEvent.keyDown(search, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Talk to" }),
+      ).not.toBeInTheDocument();
+      expect(
+        within(sidebar()).getByText("Chats with Support Agent"),
+      ).toBeInTheDocument();
+    });
   });
 
   it("shows agent unread indicators and dropdown actions behind the feature switch", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-dialogs.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-dialogs.tsx
@@ -1,6 +1,6 @@
 // TODO(#8609): split large components to comply with max-lines-per-function (128)
 // oxlint-disable max-lines-per-function
-import type { ReactNode } from "react";
+import type { ReactNode, SyntheticEvent } from "react";
 import { useGet, useSet, useLastResolved } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import {
@@ -28,8 +28,11 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import {
-  Dialog,
-  DialogContent,
+  CommandDialog,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
   DialogDescription,
   DialogHeader,
   DialogTitle,
@@ -171,6 +174,109 @@ export function AgentDialogAgentButton({
   );
 }
 
+function AgentCommandSearch({
+  query,
+  setQuery,
+}: {
+  readonly query: string;
+  readonly setQuery: (query: string) => void;
+}) {
+  return (
+    <div className="px-5 pb-3">
+      <div className="relative w-full">
+        <CommandInput
+          value={query}
+          onValueChange={setQuery}
+          placeholder="Search agents..."
+          className={query ? "pr-7" : ""}
+        />
+        {query && (
+          <button
+            type="button"
+            onClick={() => {
+              return setQuery("");
+            }}
+            className="absolute right-1.5 top-1/2 flex h-7 w-7 shrink-0 -translate-y-1/2 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            aria-label="Clear search"
+          >
+            <IconX size={14} stroke={2} />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function AgentCommandSection({
+  label,
+  children,
+  className = "pb-2",
+}: {
+  readonly label: string;
+  readonly children: ReactNode;
+  readonly className?: string;
+}) {
+  return (
+    <CommandGroup
+      heading={label}
+      className={`px-5 ${className} [&_[cmdk-group-items]]:mt-1 [&_[cmdk-group-items]]:flex [&_[cmdk-group-items]]:flex-col`}
+    >
+      {children}
+    </CommandGroup>
+  );
+}
+
+function AgentCommandAgentContent({
+  agent,
+  avatar,
+  subtitle,
+}: {
+  readonly agent: AgentDialogItem;
+  readonly avatar?: ReactNode;
+  readonly subtitle?: ReactNode;
+}) {
+  const label = agentDialogLabel(agent);
+  return (
+    <>
+      {avatar ?? (
+        <AgentAvatarImg
+          name={agent.id}
+          alt={label}
+          className="h-8 w-8 shrink-0 rounded-lg object-cover object-top"
+        />
+      )}
+      <span className="min-w-0 flex-1 text-left">
+        <span className="block truncate text-sm text-foreground">{label}</span>
+        {subtitle ? (
+          <span className="block truncate text-xs text-muted-foreground">
+            {subtitle}
+          </span>
+        ) : null}
+      </span>
+    </>
+  );
+}
+
+function stopCommandItemEvent(e: SyntheticEvent) {
+  e.stopPropagation();
+}
+
+function AgentCommandSideActions({
+  children,
+}: {
+  readonly children: ReactNode;
+}) {
+  return (
+    <div
+      onPointerDown={stopCommandItemEvent}
+      onMouseDown={stopCommandItemEvent}
+      onClick={stopCommandItemEvent}
+    >
+      {children}
+    </div>
+  );
+}
+
 function SortablePinnedAgent({
   agent,
   onUnpin,
@@ -194,47 +300,42 @@ function SortablePinnedAgent({
   };
 
   return (
-    <div
+    <CommandItem
       ref={setNodeRef}
+      value={agent.id}
+      onSelect={onChat}
       style={style}
-      className="group flex items-center gap-2 rounded-lg px-1 py-2 transition-colors hover:bg-accent"
+      className="group gap-2 px-1 py-2"
     >
-      {onChat ? (
-        <AgentDialogAgentButton agent={agent} onSelect={onChat} />
-      ) : (
-        <>
-          <AgentAvatarImg
-            name={agent.id}
-            alt={agent.displayName ?? agent.id}
-            className="h-8 w-8 shrink-0 rounded-lg object-cover object-top"
-          />
-          <span className="min-w-0 flex-1 truncate text-sm text-foreground">
-            {agent.displayName ?? agent.id}
-          </span>
-        </>
-      )}
+      <AgentCommandAgentContent agent={agent} />
       <div className="flex shrink-0 items-center gap-0.5">
         <button
           type="button"
           className="flex h-8 w-8 shrink-0 cursor-grab touch-none items-center justify-center rounded-lg text-muted-foreground opacity-0 transition-colors duration-150 group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-muted-foreground/12 hover:text-foreground active:cursor-grabbing disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-muted-foreground/18"
           aria-label={`Reorder ${agent.displayName ?? agent.id}`}
           disabled={disabled}
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+          }}
           {...attributes}
           {...listeners}
         >
           <IconArrowsMove size={16} stroke={2} />
         </button>
-        <AgentRowSideActions
-          hasUnread={unreadIndicatorsEnabled && hasUnread}
-          action={{
-            label: "Unpin",
-            disabled,
-            icon: <IconPinnedOff size={16} stroke={2} />,
-            onSelect: onUnpin,
-          }}
-        />
+        <AgentCommandSideActions>
+          <AgentRowSideActions
+            hasUnread={unreadIndicatorsEnabled && hasUnread}
+            action={{
+              label: "Unpin",
+              disabled,
+              icon: <IconPinnedOff size={16} stroke={2} />,
+              onSelect: onUnpin,
+            }}
+          />
+        </AgentCommandSideActions>
       </div>
-    </div>
+    </CommandItem>
   );
 }
 
@@ -331,37 +432,46 @@ export function AgentListDialog({
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="zero-app sm:max-w-xl w-[calc(100vw-2rem)] p-0 gap-0">
-        <DialogHeader className="px-5 pt-5 pb-3">
-          <DialogTitle className="text-base font-semibold">Talk to</DialogTitle>
-          <DialogDescription className="text-sm text-muted-foreground mt-1">
-            Pick an agent to start a conversation.
-          </DialogDescription>
-        </DialogHeader>
+    <CommandDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      className="zero-app sm:max-w-xl w-[calc(100vw-2rem)] gap-0"
+      commandClassName="gap-0"
+      commandProps={{ shouldFilter: false, loop: true }}
+    >
+      <DialogHeader className="px-5 pt-5 pb-3">
+        <DialogTitle className="text-base font-semibold">Talk to</DialogTitle>
+        <DialogDescription className="text-sm text-muted-foreground mt-1">
+          Pick an agent to start a conversation.
+        </DialogDescription>
+      </DialogHeader>
 
-        <AgentDialogSearch query={query} setQuery={setQuery} />
+      <AgentCommandSearch query={query} setQuery={setQuery} />
 
-        <div className="max-h-[min(520px,65vh)] overflow-y-auto">
-          {/* Lead agent */}
-          {showLead && (
-            <AgentDialogSection label="Lead">
-              <div className="flex items-center gap-2 rounded-lg px-1 py-2 transition-colors hover:bg-accent">
-                <AgentDialogAgentButton
-                  agent={{ id: "lead", displayName }}
-                  onSelect={() => {
-                    return handleChat(null);
-                  }}
-                  avatar={
-                    <AvatarFromUrl
-                      avatarUrl={zeroAvatarUrl}
-                      alt={displayName}
-                      className="h-8 w-8 shrink-0 rounded-lg object-cover object-top"
-                    />
-                  }
-                  subtitle="Your lead assistant, always here for you"
-                />
-                {unreadIndicatorsEnabled && (
+      <CommandList>
+        {/* Lead agent */}
+        {showLead && (
+          <AgentCommandSection label="Lead">
+            <CommandItem
+              value="lead"
+              onSelect={() => {
+                return handleChat(null);
+              }}
+              className="group gap-2 px-1 py-2"
+            >
+              <AgentCommandAgentContent
+                agent={{ id: "lead", displayName }}
+                avatar={
+                  <AvatarFromUrl
+                    avatarUrl={zeroAvatarUrl}
+                    alt={displayName}
+                    className="h-8 w-8 shrink-0 rounded-lg object-cover object-top"
+                  />
+                }
+                subtitle="Your lead assistant, always here for you"
+              />
+              {unreadIndicatorsEnabled && (
+                <AgentCommandSideActions>
                   <AgentRowSideActions
                     hasUnread={
                       defaultAgentId
@@ -369,64 +479,65 @@ export function AgentListDialog({
                         : false
                     }
                   />
-                )}
-              </div>
-            </AgentDialogSection>
-          )}
+                </AgentCommandSideActions>
+              )}
+            </CommandItem>
+          </AgentCommandSection>
+        )}
 
-          {/* Pinned agents */}
-          {filteredPinned.length > 0 && (
-            <AgentDialogSection label="Pinned">
-              <DndContext
-                sensors={sensors}
-                collisionDetection={closestCenter}
-                onDragEnd={handleDragEnd}
+        {/* Pinned agents */}
+        {filteredPinned.length > 0 && (
+          <AgentCommandSection label="Pinned">
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={handleDragEnd}
+            >
+              <SortableContext
+                items={filteredPinned.map((a) => {
+                  return a.id;
+                })}
+                strategy={verticalListSortingStrategy}
               >
-                <SortableContext
-                  items={filteredPinned.map((a) => {
-                    return a.id;
+                <>
+                  {filteredPinned.map((agent) => {
+                    return (
+                      <SortablePinnedAgent
+                        key={agent.id}
+                        agent={agent}
+                        onUnpin={() => {
+                          return togglePin(agent.id);
+                        }}
+                        onChat={() => {
+                          return handleChat(agent.id);
+                        }}
+                        disabled={saving}
+                        unreadIndicatorsEnabled={unreadIndicatorsEnabled}
+                        hasUnread={unreadAgentIds?.has(agent.id) ?? false}
+                      />
+                    );
                   })}
-                  strategy={verticalListSortingStrategy}
-                >
-                  <>
-                    {filteredPinned.map((agent) => {
-                      return (
-                        <SortablePinnedAgent
-                          key={agent.id}
-                          agent={agent}
-                          onUnpin={() => {
-                            return togglePin(agent.id);
-                          }}
-                          onChat={() => {
-                            return handleChat(agent.id);
-                          }}
-                          disabled={saving}
-                          unreadIndicatorsEnabled={unreadIndicatorsEnabled}
-                          hasUnread={unreadAgentIds?.has(agent.id) ?? false}
-                        />
-                      );
-                    })}
-                  </>
-                </SortableContext>
-              </DndContext>
-            </AgentDialogSection>
-          )}
+                </>
+              </SortableContext>
+            </DndContext>
+          </AgentCommandSection>
+        )}
 
-          {/* Unpinned agents */}
-          {filteredUnpinned.length > 0 && (
-            <AgentDialogSection label="Others" className="pb-3">
-              {filteredUnpinned.map((agent) => {
-                return (
-                  <div
-                    key={agent.id}
-                    className="group flex items-center gap-2 rounded-lg px-1 py-2 transition-colors hover:bg-accent"
-                  >
-                    <AgentDialogAgentButton
-                      agent={agent}
-                      onSelect={() => {
-                        return handleChat(agent.id);
-                      }}
-                    />
+        {/* Unpinned agents */}
+        {filteredUnpinned.length > 0 && (
+          <AgentCommandSection label="Others" className="pb-3">
+            {filteredUnpinned.map((agent) => {
+              return (
+                <CommandItem
+                  key={agent.id}
+                  value={agent.id}
+                  onSelect={() => {
+                    return handleChat(agent.id);
+                  }}
+                  className="group gap-2 px-1 py-2"
+                >
+                  <AgentCommandAgentContent agent={agent} />
+                  <AgentCommandSideActions>
                     <AgentRowSideActions
                       hasUnread={
                         unreadIndicatorsEnabled
@@ -442,32 +553,32 @@ export function AgentListDialog({
                         },
                       }}
                     />
-                  </div>
-                );
-              })}
-            </AgentDialogSection>
-          )}
+                  </AgentCommandSideActions>
+                </CommandItem>
+              );
+            })}
+          </AgentCommandSection>
+        )}
 
-          {subagents.length === 0 && (
+        {subagents.length === 0 && (
+          <div className="px-5 pb-5">
+            <p className="text-xs text-muted-foreground px-1 py-2">
+              No sub-agents available yet.
+            </p>
+          </div>
+        )}
+
+        {trimmedQuery &&
+          !showLead &&
+          filteredPinned.length === 0 &&
+          filteredUnpinned.length === 0 && (
             <div className="px-5 pb-5">
               <p className="text-xs text-muted-foreground px-1 py-2">
-                No sub-agents available yet.
+                No agents found
               </p>
             </div>
           )}
-
-          {trimmedQuery &&
-            !showLead &&
-            filteredPinned.length === 0 &&
-            filteredUnpinned.length === 0 && (
-              <div className="px-5 pb-5">
-                <p className="text-xs text-muted-foreground px-1 py-2">
-                  No agents found
-                </p>
-              </div>
-            )}
-        </div>
-      </DialogContent>
-    </Dialog>
+      </CommandList>
+    </CommandDialog>
   );
 }

--- a/turbo/packages/ui/package.json
+++ b/turbo/packages/ui/package.json
@@ -49,6 +49,7 @@
     "@tabler/icons-react": "^3.31.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "sonner": "^2.0.7",

--- a/turbo/packages/ui/src/components/ui/command.tsx
+++ b/turbo/packages/ui/src/components/ui/command.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import * as React from "react";
+import { Command as CommandPrimitive } from "cmdk";
+import { IconSearch } from "@tabler/icons-react";
+
+import { cn } from "../../lib/utils";
+import { Dialog, DialogContent } from "./dialog";
+
+const Command = React.forwardRef<
+  React.ComponentRef<typeof CommandPrimitive>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive>
+>(({ className, ...props }, ref) => {
+  return (
+    <CommandPrimitive
+      ref={ref}
+      className={cn(
+        "flex h-full w-full flex-col overflow-hidden rounded-xl bg-card text-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+});
+Command.displayName = CommandPrimitive.displayName;
+
+interface CommandDialogProps extends React.ComponentPropsWithoutRef<
+  typeof Dialog
+> {
+  readonly className?: string | undefined;
+  readonly commandClassName?: string | undefined;
+  readonly commandProps?:
+    | React.ComponentPropsWithoutRef<typeof Command>
+    | undefined;
+}
+
+function CommandDialog({
+  children,
+  className,
+  commandClassName,
+  commandProps,
+  ...props
+}: CommandDialogProps) {
+  return (
+    <Dialog {...props}>
+      <DialogContent className={cn("overflow-hidden p-0", className)}>
+        <Command
+          {...commandProps}
+          className={cn(commandClassName, commandProps?.className)}
+        >
+          {children}
+        </Command>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface CommandInputProps extends React.ComponentPropsWithoutRef<
+  typeof CommandPrimitive.Input
+> {
+  readonly wrapperClassName?: string | undefined;
+}
+
+const CommandInput = React.forwardRef<
+  React.ComponentRef<typeof CommandPrimitive.Input>,
+  CommandInputProps
+>(({ className, wrapperClassName, ...props }, ref) => {
+  return (
+    <div
+      className={cn(
+        "flex h-9 items-center gap-2 rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-input px-3 py-2 text-sm transition-colors focus-within:border-primary focus-within:ring-[3px] focus-within:ring-primary/10",
+        wrapperClassName,
+      )}
+    >
+      <IconSearch
+        size={16}
+        stroke={2}
+        className="shrink-0 text-muted-foreground"
+      />
+      <CommandPrimitive.Input
+        ref={ref}
+        className={cn(
+          "flex h-full w-full rounded-md bg-transparent text-sm text-foreground placeholder:text-sm placeholder:text-muted-foreground outline-none disabled:cursor-not-allowed disabled:opacity-50",
+          className,
+        )}
+        {...props}
+      />
+    </div>
+  );
+});
+CommandInput.displayName = CommandPrimitive.Input.displayName;
+
+const CommandList = React.forwardRef<
+  React.ComponentRef<typeof CommandPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.List>
+>(({ className, ...props }, ref) => {
+  return (
+    <CommandPrimitive.List
+      ref={ref}
+      className={cn("max-h-[min(520px,65vh)] overflow-y-auto", className)}
+      {...props}
+    />
+  );
+});
+CommandList.displayName = CommandPrimitive.List.displayName;
+
+const CommandEmpty = React.forwardRef<
+  React.ComponentRef<typeof CommandPrimitive.Empty>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
+>(({ className, ...props }, ref) => {
+  return (
+    <CommandPrimitive.Empty
+      ref={ref}
+      className={cn(
+        "py-4 text-center text-sm text-muted-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+});
+CommandEmpty.displayName = CommandPrimitive.Empty.displayName;
+
+const CommandGroup = React.forwardRef<
+  React.ComponentRef<typeof CommandPrimitive.Group>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Group>
+>(({ className, ...props }, ref) => {
+  return (
+    <CommandPrimitive.Group
+      ref={ref}
+      className={cn(
+        "overflow-hidden text-foreground [&_[cmdk-group-heading]]:px-1 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+});
+CommandGroup.displayName = CommandPrimitive.Group.displayName;
+
+const CommandSeparator = React.forwardRef<
+  React.ComponentRef<typeof CommandPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Separator>
+>(({ className, ...props }, ref) => {
+  return (
+    <CommandPrimitive.Separator
+      ref={ref}
+      className={cn("-mx-1 h-px bg-border", className)}
+      {...props}
+    />
+  );
+});
+CommandSeparator.displayName = CommandPrimitive.Separator.displayName;
+
+const CommandItem = React.forwardRef<
+  React.ComponentRef<typeof CommandPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Item>
+>(({ className, ...props }, ref) => {
+  return (
+    <CommandPrimitive.Item
+      ref={ref}
+      className={cn(
+        "relative flex cursor-pointer select-none items-center rounded-lg text-sm outline-none transition-colors data-[disabled=true]:pointer-events-none data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  );
+});
+CommandItem.displayName = CommandPrimitive.Item.displayName;
+
+const CommandShortcut = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) => {
+  return (
+    <span
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+};
+CommandShortcut.displayName = "CommandShortcut";
+
+export {
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandSeparator,
+  CommandShortcut,
+};

--- a/turbo/packages/ui/src/index.ts
+++ b/turbo/packages/ui/src/index.ts
@@ -33,6 +33,17 @@ export {
   DialogDescription,
 } from "./components/ui/dialog";
 export {
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandSeparator,
+  CommandShortcut,
+} from "./components/ui/command";
+export {
   DropdownMenu,
   DropdownMenuTrigger,
   DropdownMenuContent,

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -977,6 +977,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      cmdk:
+        specifier: ^1.1.1
+        version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -5350,6 +5353,12 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  cmdk@1.1.1:
+    resolution: {integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^18 || ^19 || ^19.0.0-rc
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -14230,6 +14239,18 @@ snapshots:
   clsx@1.2.1: {}
 
   clsx@2.1.1: {}
+
+  cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
 
   color-convert@2.0.1:
     dependencies:


### PR DESCRIPTION
## Summary
- add a shared shadcn-style Command primitive backed by cmdk
- rebuild the sidebar agent picker as a CommandDialog while preserving search, pinning, unread indicators, and pinned-agent drag reorder
- support quick-switcher keyboard selection with ArrowUp/ArrowDown and Enter

## Verification
- pnpm -F @vm0/ui check-types
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-sidebar.test.tsx --testTimeout=15000
- pnpm -F @vm0/ui exec oxlint src/components/ui/command.tsx src/index.ts
- pnpm -F @vm0/app exec oxlint src/views/zero-page/zero-sidebar-dialogs.tsx src/views/zero-page/__tests__/zero-sidebar.test.tsx
- pnpm install --frozen-lockfile --ignore-scripts
- git diff --check
