### PR TITLE
fix: update account menu subscription usage

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor, within } from "@testing-library/react";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { chatThreadsContract } from "@vm0/api-contracts/contracts/chat-threads";
@@ -252,7 +252,7 @@ describe("zero sidebar account menu", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("shows compact subscriptions below credits in the account menu", async () => {
+  it("shows subscription usage grouped below credits in the account menu", async () => {
     mockAdminAccountSidebar();
     context.mocks.data.personalModelProviders([
       connectedPersonalCodexProvider(),
@@ -273,9 +273,18 @@ describe("zero sidebar account menu", () => {
     const menu = await openAccountMenu();
     const panel = await within(menu).findByTestId("account-menu-subscriptions");
 
-    expect(within(panel).getByText("Subscriptions")).toBeInTheDocument();
-    expect(within(panel).getByText("Codex")).toBeInTheDocument();
-    expect(within(panel).getByText("Claude Code")).toBeInTheDocument();
+    expect(within(panel).queryByText("Subscriptions")).not.toBeInTheDocument();
+    expect(
+      within(panel).queryByLabelText("Refresh subscriptions"),
+    ).not.toBeInTheDocument();
+    expect(
+      within(panel).getByRole("heading", { name: "Codex" }),
+    ).toBeInTheDocument();
+    expect(
+      within(panel).getByRole("heading", { name: "Claude Code" }),
+    ).toBeInTheDocument();
+    expect(within(panel).getAllByText("5h")).toHaveLength(2);
+    expect(within(panel).getAllByText("week")).toHaveLength(2);
     expect(within(panel).getByText("82%")).toBeInTheDocument();
     expect(within(panel).getByText("55%")).toBeInTheDocument();
     expect(within(panel).getByText("88%")).toBeInTheDocument();
@@ -287,14 +296,13 @@ describe("zero sidebar account menu", () => {
     expect(codexFiveHour).toHaveAttribute("aria-valuenow", "82");
 
     const credits = within(menu).getByText("12,500 credits");
-    const subscriptions = within(panel).getByText("Subscriptions");
+    const codex = within(panel).getByRole("heading", { name: "Codex" });
     expect(
-      credits.compareDocumentPosition(subscriptions) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
+      credits.compareDocumentPosition(codex) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
   });
 
-  it("refreshes account menu subscriptions only when the refresh button is clicked", async () => {
+  it("refreshes account menu subscriptions when the menu opens", async () => {
     mockAdminAccountSidebar();
     context.mocks.data.personalModelProviders([
       connectedPersonalCodexProvider(),
@@ -312,8 +320,8 @@ describe("zero sidebar account menu", () => {
       featureSwitches: { [FeatureSwitchKey.SidebarSubscriptionUsage]: true },
     });
 
-    const menu = await openAccountMenu();
-    const panel = await within(menu).findByTestId("account-menu-subscriptions");
+    let menu = await openAccountMenu();
+    let panel = await within(menu).findByTestId("account-menu-subscriptions");
     expect(within(panel).getByText("82%")).toBeInTheDocument();
 
     context.mocks.data.personalModelProviders([
@@ -337,7 +345,13 @@ describe("zero sidebar account menu", () => {
     ]);
 
     expect(within(panel).queryByText("64%")).not.toBeInTheDocument();
-    click(within(panel).getByLabelText("Refresh subscriptions"));
+    fireEvent.keyDown(document.body, { key: "Escape" });
+    await waitFor(() => {
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    });
+
+    menu = await openAccountMenu();
+    panel = await within(menu).findByTestId("account-menu-subscriptions");
 
     await waitFor(() => {
       expect(within(panel).getByText("64%")).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
@@ -41,6 +41,7 @@ import {
   type ZeroAccountAction,
 } from "../../signals/zero-page/zero-nav.ts";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
+import { reloadPersonalModelProviders$ } from "../../signals/external/personal-model-providers.ts";
 import { openSettingsDialogAt$ } from "../../signals/zero-page/settings/settings-dialog.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { isOrgAdmin$ } from "../../signals/org.ts";
@@ -264,11 +265,7 @@ function AccountUsageGroupWithCredit({
   onOpenCreditBalance: () => void;
 }) {
   const billingLoadable = useLastLoadable(billingStatusAsync$);
-  const {
-    loading: subscriptionsLoading,
-    refreshSubscriptions,
-    rows,
-  } = useSubscriptionUsageRows();
+  const { loading: subscriptionsLoading, rows } = useSubscriptionUsageRows();
   const credits =
     billingLoadable.state === "hasData" ? billingLoadable.data.credits : null;
   const creditLoading = billingLoadable.state === "loading" && credits === null;
@@ -292,16 +289,10 @@ function AccountUsageGroupWithCredit({
           onOpenCreditBalance={onOpenCreditBalance}
         />
       )}
+      {showCredit && showSubscriptions && <DropdownMenuSeparator />}
       {showSubscriptions && (
         <AccountMenuSubscriptionsPanel
           loading={subscriptionsLoading}
-          onRefresh={() => {
-            detach(
-              refreshSubscriptions(),
-              Reason.DomCallback,
-              "refresh account menu subscriptions",
-            );
-          }}
           rows={rows}
         />
       )}
@@ -311,7 +302,7 @@ function AccountUsageGroupWithCredit({
 }
 
 function AccountSubscriptionsGroup() {
-  const { loading, refreshSubscriptions, rows } = useSubscriptionUsageRows();
+  const { loading, rows } = useSubscriptionUsageRows();
   const showSubscriptions = loading || rows.length > 0;
 
   if (!showSubscriptions) {
@@ -320,17 +311,7 @@ function AccountSubscriptionsGroup() {
 
   return (
     <>
-      <AccountMenuSubscriptionsPanel
-        loading={loading}
-        onRefresh={() => {
-          detach(
-            refreshSubscriptions(),
-            Reason.DomCallback,
-            "refresh account menu subscriptions",
-          );
-        }}
-        rows={rows}
-      />
+      <AccountMenuSubscriptionsPanel loading={loading} rows={rows} />
       <DropdownMenuSeparator />
     </>
   );
@@ -547,6 +528,7 @@ export function AccountDropdown({
     features?.[FeatureSwitchKey.SidebarSubscriptionUsage] ?? false;
   const selectNav = useSet(handleZeroNavSelect$);
   const openSettings = useSet(openSettingsDialogAt$);
+  const reloadSubscriptions = useSet(reloadPersonalModelProviders$);
   const setSidebarExpanded = useSet(setSidebarExpanded$);
   const pageSignal = useGet(pageSignal$);
 
@@ -606,8 +588,22 @@ export function AccountDropdown({
     detach(openSettings("usage", pageSignal), Reason.DomCallback);
   };
 
+  const handleMenuOpenChange = (open: boolean) => {
+    if (!open || hidePreferences || !subscriptionsEnabled) {
+      return;
+    }
+
+    queueMicrotask(() => {
+      detach(
+        reloadSubscriptions(),
+        Reason.DomCallback,
+        "reload account menu subscriptions",
+      );
+    });
+  };
+
   return (
-    <DropdownMenu>
+    <DropdownMenu onOpenChange={handleMenuOpenChange}>
       <DropdownMenuTrigger asChild>
         {renderAccountTrigger(accountDisplay, collapsed)}
       </DropdownMenuTrigger>

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-subscriptions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-subscriptions.tsx
@@ -1,5 +1,4 @@
-import { useLastLoadable, useSet } from "ccstate-react";
-import { IconRefresh } from "@tabler/icons-react";
+import { useLastLoadable } from "ccstate-react";
 import type {
   ModelProviderResponse,
   ModelProviderType,
@@ -11,7 +10,6 @@ import {
   TooltipTrigger,
 } from "@vm0/ui";
 
-import { reloadPersonalModelProviders$ } from "../../signals/external/personal-model-providers.ts";
 import { personalConfiguredProviders$ } from "../../signals/zero-page/settings/personal-model-providers.ts";
 
 export type SubscriptionUsage = NonNullable<
@@ -35,61 +33,33 @@ export interface SubscriptionUsageRow {
 
 export function useSubscriptionUsageRows() {
   const providersLoadable = useLastLoadable(personalConfiguredProviders$);
-  const refreshSubscriptions = useSet(reloadPersonalModelProviders$);
   const providers =
     providersLoadable.state === "hasData" ? providersLoadable.data : [];
   const rows = subscriptionUsageRows(providers);
   const loading = providersLoadable.state === "loading";
 
-  return { loading, refreshSubscriptions, rows };
+  return { loading, rows };
 }
 
 export function AccountMenuSubscriptionsPanel({
   loading,
-  onRefresh,
   rows,
 }: {
   readonly loading: boolean;
-  readonly onRefresh: () => void;
   readonly rows: readonly SubscriptionUsageRow[];
 }) {
   return (
     <div data-testid="account-menu-subscriptions" className="px-3 py-2.5">
-      <div className="mb-2 flex min-w-0 items-center justify-between gap-2">
-        <h3 className="truncate text-[11px] font-semibold leading-4 text-muted-foreground">
-          Subscriptions
-        </h3>
-        <TooltipProvider delayDuration={150}>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:cursor-default disabled:opacity-60"
-                aria-label="Refresh subscriptions"
-                disabled={loading}
-                onClick={onRefresh}
-              >
-                <IconRefresh
-                  size={13}
-                  className={loading ? "animate-spin" : undefined}
-                />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent side="right">
-              <p className="text-xs">Refresh subscriptions</p>
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-      </div>
       {loading && rows.length === 0 ? (
         <AccountMenuSubscriptionsSkeleton />
       ) : (
         <TooltipProvider delayDuration={100}>
-          <div className="flex flex-col gap-1">
-            {rows.map((row) => {
+          <div className="flex flex-col gap-2.5">
+            {rows.map((row, index) => {
               return (
-                <AccountMenuSubscriptionProviderRows
+                <AccountMenuSubscriptionProviderSection
                   key={row.type}
+                  divided={index > 0}
                   label={row.label}
                   usage={row.usage}
                 />
@@ -104,16 +74,24 @@ export function AccountMenuSubscriptionsPanel({
 
 function AccountMenuSubscriptionsSkeleton() {
   return (
-    <div className="flex flex-col gap-1.5" aria-hidden="true">
-      {SUBSCRIPTION_PROVIDERS.map((provider) => {
+    <div className="flex flex-col gap-2.5" aria-hidden="true">
+      {SUBSCRIPTION_PROVIDERS.map((provider, index) => {
         return (
-          <div
-            key={provider.type}
-            className="grid grid-cols-[68px_minmax(0,1fr)_34px] items-center gap-1.5"
-          >
-            <div className="h-2.5 animate-pulse rounded bg-muted/60" />
-            <div className="h-1.5 animate-pulse rounded-full bg-muted/60" />
-            <div className="h-2.5 animate-pulse rounded bg-muted/60" />
+          <div key={provider.type} className="flex flex-col gap-1.5">
+            {index > 0 && <div className="-mx-3 h-px bg-border" />}
+            <div className="h-3 w-20 animate-pulse rounded bg-muted/60" />
+            {["5h", "week"].map((label) => {
+              return (
+                <div
+                  key={label}
+                  className="grid grid-cols-[34px_minmax(0,1fr)_34px] items-center gap-1.5"
+                >
+                  <div className="h-2.5 animate-pulse rounded bg-muted/60" />
+                  <div className="h-1.5 animate-pulse rounded-full bg-muted/60" />
+                  <div className="h-2.5 animate-pulse rounded bg-muted/60" />
+                </div>
+              );
+            })}
           </div>
         );
       })}
@@ -121,39 +99,44 @@ function AccountMenuSubscriptionsSkeleton() {
   );
 }
 
-function AccountMenuSubscriptionProviderRows({
+function AccountMenuSubscriptionProviderSection({
+  divided,
   label,
   usage,
 }: {
+  readonly divided: boolean;
   readonly label: string;
   readonly usage: SubscriptionUsage;
 }) {
   const windows = usageWindows(usage);
 
   return (
-    <>
-      {windows.map(({ label: windowLabel, window }, index) => {
-        return (
-          <AccountMenuSubscriptionUsageBar
-            key={windowLabel}
-            displayLabel={index === 0 ? label : windowLabel}
-            providerLabel={label}
-            windowLabel={windowLabel}
-            window={window}
-          />
-        );
-      })}
-    </>
+    <section className="flex flex-col gap-1.5" aria-label={`${label} usage`}>
+      {divided && <div className="-mx-3 h-px bg-border" />}
+      <h3 className="truncate text-xs font-medium leading-4 text-foreground">
+        {label}
+      </h3>
+      <div className="flex flex-col gap-1">
+        {windows.map(({ label: windowLabel, window }) => {
+          return (
+            <AccountMenuSubscriptionUsageBar
+              key={windowLabel}
+              providerLabel={label}
+              windowLabel={windowLabel}
+              window={window}
+            />
+          );
+        })}
+      </div>
+    </section>
   );
 }
 
 function AccountMenuSubscriptionUsageBar({
-  displayLabel,
   providerLabel,
   windowLabel,
   window,
 }: {
-  readonly displayLabel: string;
   readonly providerLabel: string;
   readonly windowLabel: string;
   readonly window: SubscriptionUsageWindow;
@@ -174,9 +157,9 @@ function AccountMenuSubscriptionUsageBar({
       : Math.min(100, Math.max(0, remainingPercent));
 
   return (
-    <div className="grid grid-cols-[68px_minmax(0,1fr)_34px] items-center gap-1.5">
+    <div className="grid grid-cols-[34px_minmax(0,1fr)_34px] items-center gap-1.5">
       <span className="truncate text-[10px] font-medium leading-none text-muted-foreground">
-        {displayLabel}
+        {windowLabel}
       </span>
       <Tooltip>
         <TooltipTrigger asChild>
@@ -300,7 +283,7 @@ function usageWindows(usage: SubscriptionUsage | null | undefined): readonly {
 }[] {
   return [
     { label: "5h", window: usage?.fiveHour ?? null },
-    { label: "Week", window: usage?.weekly ?? null },
+    { label: "week", window: usage?.weekly ?? null },
   ].filter(
     (item): item is { label: string; window: SubscriptionUsageWindow } => {
       return hasUsageWindow(item.window);


### PR DESCRIPTION
## Summary
- Remove the visible Subscriptions header row and manual refresh button from the account menu usage block
- Reload personal subscription usage whenever the account menu opens, while keeping prior loadable content visible during refresh
- Rework the usage layout into credit, Codex, and Claude Code grouped sections with per-window rows

## Tests
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm exec vitest run apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx