### PR TITLE
refactor: update feature switch rollout scopes

### DIFF
--- a/.claude/skills/feature-switch/SKILL.md
+++ b/.claude/skills/feature-switch/SKILL.md
@@ -152,8 +152,8 @@ Evaluation has two layers (lowest to highest priority):
 2. **DB overrides** — most switches are per-user rows in
    `user_feature_switches` keyed by `(orgId, userId)`. Some switches are
    org-scoped and stored under the org sentinel user id (`__org__`); currently
-   `DataExport` is org-scoped. Written via the Lab page toggles or
-   `window._vm0.featureSwitches.myFeature = true` (both call
+   `DataExport` and `AgentUnreadIndicators` are org-scoped. Written via the Lab
+   page toggles or `window._vm0.featureSwitches.myFeature = true` (both call
    `POST /api/zero/feature-switches`). Cleared via the Lab page "Reset all"
    button (`DELETE /api/zero/feature-switches`).
 

--- a/turbo/apps/api/src/signals/routes/__tests__/hooks-ops.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/hooks-ops.bdd.test.ts
@@ -152,7 +152,7 @@ describe("OPS-01: feature switches and report-error routes", () => {
     ).toBeUndefined();
   });
 
-  it("stores data export as an org-scoped feature switch override", async () => {
+  it("stores org-scoped feature switch overrides", async () => {
     const orgId = `org_${randomUUID()}`;
     const owner = api.user({ orgId });
     const peer = api.user({ orgId });
@@ -164,6 +164,7 @@ describe("OPS-01: feature switches and report-error routes", () => {
         body: {
           switches: {
             [FeatureSwitchKey.DataExport]: true,
+            [FeatureSwitchKey.AgentUnreadIndicators]: true,
             [FeatureSwitchKey.Dummy]: false,
           },
         },
@@ -171,6 +172,9 @@ describe("OPS-01: feature switches and report-error routes", () => {
       [200],
     );
     expect(ownerUpdate.body.switches[FeatureSwitchKey.DataExport]).toBeTruthy();
+    expect(
+      ownerUpdate.body.switches[FeatureSwitchKey.AgentUnreadIndicators],
+    ).toBeTruthy();
     expect(ownerUpdate.body.switches[FeatureSwitchKey.Dummy]).toBeFalsy();
 
     const peerRead = await accept(
@@ -178,6 +182,9 @@ describe("OPS-01: feature switches and report-error routes", () => {
       [200],
     );
     expect(peerRead.body.switches[FeatureSwitchKey.DataExport]).toBeTruthy();
+    expect(
+      peerRead.body.switches[FeatureSwitchKey.AgentUnreadIndicators],
+    ).toBeTruthy();
     expect(peerRead.body.switches[FeatureSwitchKey.Dummy]).toBeUndefined();
 
     const outsiderRead = await accept(
@@ -187,6 +194,9 @@ describe("OPS-01: feature switches and report-error routes", () => {
     expect(
       outsiderRead.body.switches[FeatureSwitchKey.DataExport],
     ).toBeUndefined();
+    expect(
+      outsiderRead.body.switches[FeatureSwitchKey.AgentUnreadIndicators],
+    ).toBeUndefined();
 
     const peerUpdate = await accept(
       featureSwitchesClient().update({
@@ -194,12 +204,16 @@ describe("OPS-01: feature switches and report-error routes", () => {
         body: {
           switches: {
             [FeatureSwitchKey.DataExport]: false,
+            [FeatureSwitchKey.AgentUnreadIndicators]: false,
           },
         },
       }),
       [200],
     );
     expect(peerUpdate.body.switches[FeatureSwitchKey.DataExport]).toBeFalsy();
+    expect(
+      peerUpdate.body.switches[FeatureSwitchKey.AgentUnreadIndicators],
+    ).toBeFalsy();
     expect(peerUpdate.body.switches[FeatureSwitchKey.Dummy]).toBeUndefined();
 
     const ownerReadAfterPeerUpdate = await accept(
@@ -208,6 +222,11 @@ describe("OPS-01: feature switches and report-error routes", () => {
     );
     expect(
       ownerReadAfterPeerUpdate.body.switches[FeatureSwitchKey.DataExport],
+    ).toBeFalsy();
+    expect(
+      ownerReadAfterPeerUpdate.body.switches[
+        FeatureSwitchKey.AgentUnreadIndicators
+      ],
     ).toBeFalsy();
     expect(
       ownerReadAfterPeerUpdate.body.switches[FeatureSwitchKey.Dummy],
@@ -225,6 +244,9 @@ describe("OPS-01: feature switches and report-error routes", () => {
     );
     expect(
       peerReadAfterDelete.body.switches[FeatureSwitchKey.DataExport],
+    ).toBeUndefined();
+    expect(
+      peerReadAfterDelete.body.switches[FeatureSwitchKey.AgentUnreadIndicators],
     ).toBeUndefined();
     expect(
       peerReadAfterDelete.body.switches[FeatureSwitchKey.Dummy],

--- a/turbo/apps/api/src/signals/services/feature-switches.service.ts
+++ b/turbo/apps/api/src/signals/services/feature-switches.service.ts
@@ -10,7 +10,10 @@ import { nowDate } from "../external/time";
 const ORG_SENTINEL_USER_ID = "__org__";
 
 function isOrgScopedFeatureSwitchKey(key: string): boolean {
-  return key === FeatureSwitchKey.DataExport;
+  return (
+    key === FeatureSwitchKey.DataExport ||
+    key === FeatureSwitchKey.AgentUnreadIndicators
+  );
 }
 
 function splitFeatureSwitchesByScope(switches: Record<string, boolean>): {
@@ -249,6 +252,7 @@ async function removeOrgScopedFeatureSwitches(
 
   const next = { ...existingRow.switches };
   delete next[FeatureSwitchKey.DataExport];
+  delete next[FeatureSwitchKey.AgentUnreadIndicators];
 
   if (Object.keys(next).length === 0) {
     await writeDb

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -14,7 +14,6 @@ import {
   type ConnectorType,
   type ConnectorDisplayCategory,
 } from "@vm0/connectors/connectors";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   getConnectorAuthMethod,
   hasConnectorDeviceAuthGrant,
@@ -39,7 +38,6 @@ import type {
   PublicConnectorCatalogConnection,
   PublicConnectorCatalogStatusItem,
 } from "@vm0/api-contracts/contracts/zero-connector-catalog";
-import { featureSwitch$ } from "../../external/feature-switch.ts";
 import {
   connectorCatalogStatus$,
   connectors$,
@@ -396,14 +394,7 @@ export const connectorsSearch$ = computed((get) => {
 
 export const filteredConnectorTypes$ = computed(async (get) => {
   const keyword = get(connectorsSearch$);
-  const filter = get(connectorsConnectionFilter$);
-  const features = get(featureSwitch$);
-  const accessManagementEnabled =
-    features[FeatureSwitchKey.ConnectorAccessManagement] ?? false;
-  // The status/agent filter only applies when access management is enabled.
-  const effectiveFilter: ConnectorsConnectionFilter = accessManagementEnabled
-    ? filter
-    : { kind: "all" };
+  const effectiveFilter = get(connectorsConnectionFilter$);
 
   const agentEnabledTypes =
     effectiveFilter.kind === "agent"

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -287,9 +287,6 @@ function setupConnectorStatusFilterPage(path = "/connectors"): void {
   detachedSetupPage({
     context,
     path,
-    featureSwitches: {
-      [FeatureSwitchKey.ConnectorAccessManagement]: true,
-    },
   });
 }
 
@@ -584,7 +581,7 @@ describe("connectors page", () => {
     expect(params.has("connection")).toBeFalsy();
   });
 
-  it("filters connectors by agent when access management is enabled", async () => {
+  it("filters connectors by agent", async () => {
     const agentId = "c0000000-0000-4000-a000-000000000010";
     mockConnectors([{ type: "github", externalUsername: "octocat" }]);
     context.mocks.data.team([teamAgent(agentId, "Research Agent", "preset:0")]);
@@ -597,9 +594,6 @@ describe("connectors page", () => {
     detachedSetupPage({
       context,
       path: "/connectors",
-      featureSwitches: {
-        [FeatureSwitchKey.ConnectorAccessManagement]: true,
-      },
     });
 
     await waitFor(() => {
@@ -698,37 +692,7 @@ describe("connectors page", () => {
     ).resolves.toBeInTheDocument();
   });
 
-  it("hides connector access management when its switch is disabled", async () => {
-    mockConnectors([{ type: "github", externalUsername: "octocat" }]);
-
-    detachedSetupPage({
-      context,
-      path: "/connectors",
-      featureSwitches: {
-        [FeatureSwitchKey.ConnectorAccessManagement]: false,
-      },
-    });
-
-    await waitFor(() => {
-      expect(screen.getByText("GitHub")).toBeInTheDocument();
-    });
-    expect(
-      screen.queryByLabelText("Filter connectors"),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByLabelText("Manage GitHub access"),
-    ).not.toBeInTheDocument();
-    click(
-      within(connectorCardByLabel("GitHub")).getByLabelText("More options"),
-    );
-
-    await waitFor(() => {
-      expect(menuItemByText("Disconnect")).toBeInTheDocument();
-    });
-    expect(queryMenuItemByText("Manage")).not.toBeInTheDocument();
-  });
-
-  it("manages connector access for agents when its switch is enabled", async () => {
+  it("manages connector access for agents", async () => {
     const researchAgentId = "c0000000-0000-4000-a000-000000000001";
     const supportAgentId = "c0000000-0000-4000-a000-000000000002";
     const enabledByAgent = new Map<string, string[]>([
@@ -759,9 +723,6 @@ describe("connectors page", () => {
     detachedSetupPage({
       context,
       path: "/connectors",
-      featureSwitches: {
-        [FeatureSwitchKey.ConnectorAccessManagement]: true,
-      },
     });
 
     await waitFor(() => {
@@ -825,9 +786,6 @@ describe("connectors page", () => {
     detachedSetupPage({
       context,
       path: "/connectors",
-      featureSwitches: {
-        [FeatureSwitchKey.ConnectorAccessManagement]: true,
-      },
     });
 
     await waitFor(() => {
@@ -862,9 +820,6 @@ describe("connectors page", () => {
     detachedSetupPage({
       context,
       path: "/connectors",
-      featureSwitches: {
-        [FeatureSwitchKey.ConnectorAccessManagement]: true,
-      },
     });
 
     await waitFor(() => {
@@ -907,9 +862,6 @@ describe("connectors page", () => {
     detachedSetupPage({
       context,
       path: "/connectors",
-      featureSwitches: {
-        [FeatureSwitchKey.ConnectorAccessManagement]: true,
-      },
     });
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -7,7 +7,6 @@ import {
   useLastLoadable,
   useLastResolved,
 } from "ccstate-react";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { useLoadableSet } from "ccstate-react/experimental";
 import {
   IconSearch,
@@ -86,7 +85,6 @@ import { toast } from "@vm0/ui/components/ui/sonner";
 import { noConnectorImg } from "./platform-assets.ts";
 import { AvatarFromUrl } from "./zero-sidebar-shared.tsx";
 import { detach, onDomEventFn, Reason } from "../../signals/utils.ts";
-import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import {
   Button,
   DropdownMenu,
@@ -976,9 +974,6 @@ export function ZeroConnectorsPage() {
   const allConnectors =
     allTypesLoadable.state === "hasData" ? allTypesLoadable.data : [];
   const disconnecting = disconnectLoadable.state === "loading";
-  const features = useLastResolved(featureSwitch$);
-  const showConnectorAccessManagement =
-    features?.[FeatureSwitchKey.ConnectorAccessManagement] ?? false;
 
   const connectHandler = (type: ConnectorType) => {
     const ct = filteredConnectors.find((c) => {
@@ -1040,7 +1035,7 @@ export function ZeroConnectorsPage() {
         connector={optimisticConnector}
         isPolling={isPolling}
         isDisconnecting={disconnecting}
-        showManageAccess={showConnectorAccessManagement}
+        showManageAccess
         onConnect={() => {
           return connectHandler(c.type);
         }}
@@ -1067,9 +1062,7 @@ export function ZeroConnectorsPage() {
     filteredCount: filteredConnectors.length,
     renderCard,
     search,
-    connectionFilter: showConnectorAccessManagement
-      ? connectionFilter
-      : { kind: "all" },
+    connectionFilter,
   });
   return (
     <div
@@ -1116,7 +1109,7 @@ export function ZeroConnectorsPage() {
                 activeTab={activeTab}
                 search={search}
                 setSearch={setSearch}
-                showAccessManagement={showConnectorAccessManagement}
+                showAccessManagement
                 connectionFilter={connectionFilter}
                 agents={agents}
                 setConnectionFilter={setConnectionFilter}

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -49,7 +49,6 @@ export enum FeatureSwitchKey {
   MemoryViewer = "memoryViewer",
   HtmlArtifactCommentEditing = "htmlArtifactCommentEditing",
   ComputerUseDelegatedAuthorization = "computerUseDelegatedAuthorization",
-  ConnectorAccessManagement = "connectorAccessManagement",
   PresentationTemplateRunbook = "presentationTemplateRunbook",
   AgentUnreadIndicators = "agentUnreadIndicators",
   ImageArtifactKeyboardNavigation = "imageArtifactKeyboardNavigation",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -277,12 +277,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.ConnectorAccessManagement]: {
-    maintainer: "ethan@vm0.ai",
-    description:
-      "Show connected connector filtering and per-agent connector access management on connected connector cards.",
-    enabled: true,
-  },
   [FeatureSwitchKey.PresentationTemplateRunbook]: {
     maintainer: "bingjie@vm0.ai",
     description:


### PR DESCRIPTION
## Summary
- Remove the ConnectorAccessManagement feature switch now that connector access management is fully rolled out.
- Keep connector filtering and per-agent access management always available in the platform UI.
- Store AgentUnreadIndicators as an org-scoped feature switch override alongside DataExport.

## Verification
- pnpm exec prettier --write --ignore-unknown <changed files>
- pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts
- DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm -F api exec vitest run src/signals/routes/__tests__/hooks-ops.bdd.test.ts
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-connectors-page.test.tsx
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/core check-types
- NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types
- NODE_OPTIONS=--max-old-space-size=4096 pnpm -F @vm0/app check-types
- pnpm -F @vm0/connectors lint
- pnpm -F @vm0/core lint
- NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api lint
- NODE_OPTIONS=--max-old-space-size=4096 pnpm -F @vm0/app lint