### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -111,7 +111,7 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.4"
-CLAUDE_CODE_VERSION="2.1.197"
+CLAUDE_CODE_VERSION="2.1.198"
 CODEX_CLI_VERSION="0.142.5"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.2.2"


### PR DESCRIPTION
## Summary

Updates pinned rootfs tool versions in `crates/runner/scripts/build-template.sh`:

- Claude Code CLI: `2.1.197` -> `2.1.198`

## Validation

- `bash -n crates/runner/scripts/build-template.sh`
- `shellcheck` not run because it is not installed in this runtime
