### PR TITLE
fix: clear agent list dialog search query on open instead of on select

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-sidebar-state.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-sidebar-state.ts
@@ -139,6 +139,7 @@ export const setChatListOpen$ = command(({ set }, open: boolean) => {
 });
 
 export const openAgentListDialog$ = command(({ set }) => {
+  set(internalChatListQuery$, "");
   set(internalChatListOpen$, true);
   set(reloadAgents$);
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-dialogs.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-dialogs.tsx
@@ -427,7 +427,6 @@ export function AgentListDialog({
 
   const handleChat = (agentId: string | null) => {
     onOpenChange(false);
-    setQuery("");
     onSelectChatAgent?.(agentId);
   };
 


### PR DESCRIPTION
## Summary
Pressing Enter (or clicking) to pick an agent in the cmd+shift+a "Talk to" dialog cleared the search query immediately, so the agent list flashed back to the unfiltered state while the dialog was still animating closed.

This moves the query reset from `handleChat` (selection time) to `openAgentListDialog$` (open time). All entry points — the cmd+shift+a shortcut in `zero-nav.ts`, the sidebar pinned section, and the chat composer — go through `openAgentListDialog$`, so the dialog still always opens with an empty search box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)