### PR TITLE
fix: keep agent command unread indicators visible

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -203,6 +203,17 @@ function openAgentRowMenu(container: HTMLElement, name: string): void {
   );
 }
 
+function agentRowActionRootForMenuTrigger(trigger: HTMLElement): HTMLElement {
+  let current = trigger.parentElement;
+  while (current instanceof HTMLElement) {
+    if (current.style.getPropertyValue("--agent-row-trigger-opacity")) {
+      return current;
+    }
+    current = current.parentElement;
+  }
+  throw new Error("Agent row action root not found");
+}
+
 function openThreadMenu(title: string): void {
   click(
     within(threadRowByTitle(title)).getByTestId("chat-thread-menu-trigger"),
@@ -1354,19 +1365,32 @@ describe("zero sidebar", () => {
     const dialog = await screen.findByRole("dialog", { name: "Talk to" });
     const researchDialogRow = agentRowByName(dialog, "Research Agent");
     const supportDialogRow = agentRowByName(dialog, "Support Agent");
-    expect(
-      within(researchDialogRow).getByLabelText("Unread"),
-    ).toBeInTheDocument();
-    expect(
-      within(supportDialogRow).getByLabelText("Unread"),
-    ).toBeInTheDocument();
+    const researchDialogUnread =
+      within(researchDialogRow).getByLabelText("Unread");
+    const supportDialogUnread =
+      within(supportDialogRow).getByLabelText("Unread");
+    expect(researchDialogUnread).toBeInTheDocument();
+    expect(researchDialogUnread).toBeVisible();
+    expect(supportDialogUnread).toBeInTheDocument();
+    expect(supportDialogUnread).toBeVisible();
     expect(
       within(supportDialogRow).queryByLabelText("Pin to sidebar"),
     ).not.toBeInTheDocument();
 
-    click(within(supportDialogRow).getByLabelText("Open agent menu"));
+    const supportMenuTrigger =
+      within(supportDialogRow).getByLabelText("Open agent menu");
+    const supportActionRoot =
+      agentRowActionRootForMenuTrigger(supportMenuTrigger);
+    fireEvent.pointerEnter(supportActionRoot);
+    expect(supportDialogUnread).not.toBeVisible();
+    fireEvent.pointerLeave(supportActionRoot);
+    expect(supportDialogUnread).toBeVisible();
+
+    click(supportMenuTrigger);
+    expect(supportDialogUnread).not.toBeVisible();
     expect(menuItemByText("Pin to sidebar")).toBeInTheDocument();
     fireEvent.keyDown(document.body, { key: "Escape" });
+    expect(supportDialogUnread).toBeVisible();
 
     await waitFor(() => {
       expect(
@@ -1389,6 +1413,7 @@ describe("zero sidebar", () => {
       expect(
         within(supportDialogRow).getByLabelText("Unread"),
       ).toBeInTheDocument();
+      expect(within(supportDialogRow).getByLabelText("Unread")).toBeVisible();
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-agent-row-actions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-agent-row-actions.tsx
@@ -39,11 +39,6 @@ function triggerClassName(
   return "peer absolute inset-0 z-10 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors duration-150 hover:bg-muted-foreground/12 hover:text-foreground dark:hover:bg-muted-foreground/18 disabled:cursor-not-allowed disabled:opacity-50";
 }
 
-const actionVisibilityStyle = {
-  "--agent-row-trigger-opacity": 0,
-  "--agent-row-unread-opacity": 1,
-} as CSSProperties;
-
 const triggerOpacityStyle = {
   opacity: "var(--agent-row-trigger-opacity)",
 } as CSSProperties;
@@ -52,9 +47,50 @@ const unreadOpacityStyle = {
   opacity: "var(--agent-row-unread-opacity)",
 } as CSSProperties;
 
+const hiddenActionStyle = {
+  "--agent-row-trigger-opacity": 0,
+  "--agent-row-unread-opacity": 1,
+} as CSSProperties;
+
+const actionRootSelector = "[data-agent-row-actions-root]";
+
 function setActionVisibility(element: HTMLElement, visible: boolean) {
   element.style.setProperty("--agent-row-trigger-opacity", visible ? "1" : "0");
   element.style.setProperty("--agent-row-unread-opacity", visible ? "0" : "1");
+}
+
+function actionRootFromElement(element: Element | null): HTMLElement | null {
+  const root = element?.closest(actionRootSelector);
+  return root instanceof HTMLElement ? root : null;
+}
+
+function currentMenuActionRoot(): HTMLElement | null {
+  const activeRoot = actionRootFromElement(document.activeElement);
+  if (activeRoot) {
+    return activeRoot;
+  }
+  const openRoot = document.querySelector(
+    `${actionRootSelector}[data-agent-row-menu-open="true"]`,
+  );
+  return openRoot instanceof HTMLElement ? openRoot : null;
+}
+
+function updateMenuActionVisibility(open: boolean) {
+  const root = currentMenuActionRoot();
+  if (!root) {
+    return;
+  }
+  root.dataset.agentRowMenuOpen = open ? "true" : "false";
+  setActionVisibility(root, open || root.matches(":hover"));
+}
+
+function showMenuActionForTrigger(trigger: Element) {
+  const root = actionRootFromElement(trigger);
+  if (!root) {
+    return;
+  }
+  root.dataset.agentRowMenuOpen = "true";
+  setActionVisibility(root, true);
 }
 
 export function AgentRowSideActions({
@@ -82,25 +118,24 @@ export function AgentRowSideActions({
   });
 
   function handleMenuTriggerClick(e: MouseEvent<HTMLButtonElement>) {
+    showMenuActionForTrigger(e.currentTarget);
     e.preventDefault();
     e.stopPropagation();
   }
 
   return (
     <div
+      data-agent-row-actions-root
+      data-agent-row-menu-open="false"
       onPointerEnter={(e) => {
         setActionVisibility(e.currentTarget, true);
       }}
       onPointerLeave={(e) => {
-        setActionVisibility(e.currentTarget, false);
+        if (e.currentTarget.dataset.agentRowMenuOpen !== "true") {
+          setActionVisibility(e.currentTarget, false);
+        }
       }}
-      onFocusCapture={(e) => {
-        setActionVisibility(e.currentTarget, true);
-      }}
-      onBlurCapture={(e) => {
-        setActionVisibility(e.currentTarget, false);
-      }}
-      style={hasMenuActions ? actionVisibilityStyle : undefined}
+      style={hasMenuActions ? hiddenActionStyle : undefined}
       className={
         variant === "sidebar"
           ? `absolute right-0 top-0 flex h-8 w-8 items-center justify-center ${
@@ -113,12 +148,15 @@ export function AgentRowSideActions({
     >
       {hasMenuActions ? (
         <TooltipProvider delayDuration={200}>
-          <DropdownMenu>
+          <DropdownMenu onOpenChange={updateMenuActionVisibility}>
             <DropdownMenuTrigger asChild>
               <button
                 type="button"
                 className={triggerClassName(variant, isPrimarySelected)}
                 style={triggerOpacityStyle}
+                onPointerDownCapture={(e) => {
+                  showMenuActionForTrigger(e.currentTarget);
+                }}
                 onClick={handleMenuTriggerClick}
                 aria-label="Open agent menu"
                 disabled={triggerDisabled}

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-dialogs.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-dialogs.tsx
@@ -237,7 +237,7 @@ function AgentCommandAgentContent({
 }) {
   const label = agentDialogLabel(agent);
   return (
-    <>
+    <span className="flex min-w-0 flex-1 items-center gap-2 text-left">
       {avatar ?? (
         <AgentAvatarImg
           name={agent.id}
@@ -245,7 +245,7 @@ function AgentCommandAgentContent({
           className="h-8 w-8 shrink-0 rounded-lg object-cover object-top"
         />
       )}
-      <span className="min-w-0 flex-1 text-left">
+      <span className="min-w-0 flex-1">
         <span className="block truncate text-sm text-foreground">{label}</span>
         {subtitle ? (
           <span className="block truncate text-xs text-muted-foreground">
@@ -253,7 +253,7 @@ function AgentCommandAgentContent({
           </span>
         ) : null}
       </span>
-    </>
+    </span>
   );
 }
 
@@ -271,6 +271,7 @@ function AgentCommandSideActions({
       onPointerDown={stopCommandItemEvent}
       onMouseDown={stopCommandItemEvent}
       onClick={stopCommandItemEvent}
+      className="ml-auto shrink-0"
     >
       {children}
     </div>
@@ -305,7 +306,7 @@ function SortablePinnedAgent({
       value={agent.id}
       onSelect={onChat}
       style={style}
-      className="group gap-2 px-1 py-2"
+      className="group w-full gap-2 px-1 py-2"
     >
       <AgentCommandAgentContent agent={agent} />
       <div className="flex shrink-0 items-center gap-0.5">
@@ -456,7 +457,7 @@ export function AgentListDialog({
               onSelect={() => {
                 return handleChat(null);
               }}
-              className="group gap-2 px-1 py-2"
+              className="group w-full gap-2 px-1 py-2"
             >
               <AgentCommandAgentContent
                 agent={{ id: "lead", displayName }}
@@ -533,7 +534,7 @@ export function AgentListDialog({
                   onSelect={() => {
                     return handleChat(agent.id);
                   }}
-                  className="group gap-2 px-1 py-2"
+                  className="group w-full gap-2 px-1 py-2"
                 >
                   <AgentCommandAgentContent agent={agent} />
                   <AgentCommandSideActions>


### PR DESCRIPTION
## Summary
- Keep unread indicators visible in the cmd+shift+a agent command dialog even when a row also has menu actions.
- Stabilize command dialog agent rows with explicit full-width rows, a flexing content region, and a fixed right-side action slot.
- Strengthen the existing unread indicator test to assert visible dots, including after closing the row menu.

## Verification
- `pnpm exec prettier --write apps/platform/src/views/zero-page/zero-sidebar-agent-row-actions.tsx apps/platform/src/views/zero-page/zero-sidebar-dialogs.tsx apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-sidebar.test.tsx -t "shows agent unread indicators"`
