### PR TITLE
feat: add agent chat first thread shortcut

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/agent-chat-keyboard.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-chat-keyboard.ts
@@ -1,0 +1,30 @@
+import { command } from "ccstate";
+import { matchShortcut } from "@vm0/ui";
+import { sidebarChatThreads$ } from "../chat-page/optimistic-chat-thread-page.ts";
+import { onDomEventFn } from "../utils.ts";
+import { navigateToChat$ } from "./zero-nav.ts";
+
+export const setupAgentChatKeyboardShortcuts$ = command(
+  ({ get, set }, signal: AbortSignal) => {
+    document.addEventListener(
+      "keydown",
+      onDomEventFn(async (event: KeyboardEvent) => {
+        if (
+          event.defaultPrevented ||
+          !matchShortcut("mod+shift+arrowdown", event)
+        ) {
+          return;
+        }
+
+        event.preventDefault();
+        const [firstThread] = await get(sidebarChatThreads$);
+        signal.throwIfAborted();
+        if (!firstThread) {
+          return;
+        }
+        set(navigateToChat$, firstThread.id);
+      }),
+      { signal },
+    );
+  },
+);

--- a/turbo/apps/platform/src/signals/zero-page/agent-chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-chat-page-setup.ts
@@ -30,6 +30,7 @@ import {
 import { reloadUserModelPreference$ } from "../external/user-model-preference.ts";
 import { openQueueDrawer$ } from "../queue-page/queue-drawer-state.ts";
 import { checkUnifiedSettingsParam$ } from "./settings/settings-dialog.ts";
+import { setupAgentChatKeyboardShortcuts$ } from "./agent-chat-keyboard.ts";
 
 export const setupAgentChatPage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
@@ -82,6 +83,7 @@ export const setupAgentChatPage$ = command(
 
     set(rememberLastUsedAgentId$, agentId);
     set(updateDocumentTitle$, agent.displayName ?? "Chat");
+    set(setupAgentChatKeyboardShortcuts$, signal);
 
     await set(checkUnifiedSettingsParam$, signal);
 

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -2,7 +2,11 @@ import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import type { ConnectorType } from "@vm0/connectors/connectors";
 import { loadFirewallPermissionMetadata } from "@vm0/connectors/firewall-metadata";
 import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
-import { chatThreadsContract } from "@vm0/api-contracts/contracts/chat-threads";
+import {
+  chatThreadByIdContract,
+  chatThreadMessagesContract,
+  chatThreadsContract,
+} from "@vm0/api-contracts/contracts/chat-threads";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import { zeroAgentCustomConnectorsContract } from "@vm0/api-contracts/contracts/zero-agent-custom-connectors";
 import {
@@ -29,6 +33,7 @@ import {
   fill,
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
+import { pathname } from "../../../signals/location.ts";
 import { isoFromNowMs, mockNow } from "../../../__tests__/time.ts";
 import { createMockAutomationView } from "../../../mocks/handlers/automations-store.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
@@ -454,6 +459,130 @@ describe("team page navigation", () => {
         screen.getByPlaceholderText(
           "Ask me to automate workflows, manage tasks...",
         ),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("opens the first chat thread from an agent chat page shortcut", async () => {
+    mockTeamAPIs();
+    const firstThreadId = "agent-chat-shortcut-first-thread";
+    const secondThreadId = "agent-chat-shortcut-second-thread";
+    const firstMessageId = "b0000000-0000-4000-a000-000000000501";
+    context.mocks.api(chatThreadsContract.list, ({ respond }) => {
+      return respond(200, {
+        pinned: [],
+        threads: [
+          {
+            id: firstThreadId,
+            title: "First shortcut thread",
+            agent: { id: researchAgentId, avatarUrl: null },
+            createdAt: "2026-06-01T00:00:00Z",
+            updatedAt: "2026-06-01T00:02:00Z",
+            running: false,
+            pinnedAt: null,
+          },
+          {
+            id: secondThreadId,
+            title: "Second shortcut thread",
+            agent: { id: researchAgentId, avatarUrl: null },
+            createdAt: "2026-06-01T00:00:00Z",
+            updatedAt: "2026-06-01T00:01:00Z",
+            running: false,
+            pinnedAt: null,
+          },
+        ],
+        hasMore: false,
+        nextCursor: null,
+      });
+    });
+    context.mocks.api(chatThreadByIdContract.get, ({ params, respond }) => {
+      return respond(200, {
+        id: params.id,
+        title:
+          params.id === firstThreadId
+            ? "First shortcut thread"
+            : "Second shortcut thread",
+        agentId: researchAgentId,
+        activeRunIds: [],
+        createdAt: "2026-06-01T00:00:00Z",
+        updatedAt: "2026-06-01T00:02:00Z",
+        lastReadMessageId: null,
+        lastReadAt: null,
+        lastMessageAt: "2026-06-01T00:02:00Z",
+        pinnedAt: null,
+        draftContent: null,
+        draftAttachments: null,
+        computerUseHostId: null,
+        modelProviderId: null,
+        selectedModel: null,
+      });
+    });
+    context.mocks.api(
+      chatThreadMessagesContract.list,
+      ({ params, query, respond }) => {
+        if (query.sinceId) {
+          return respond(200, { messages: [] });
+        }
+        return respond(200, {
+          messages:
+            params.threadId === firstThreadId
+              ? [
+                  {
+                    id: firstMessageId,
+                    role: "user",
+                    content: "First shortcut thread message",
+                    createdAt: "2026-06-01T00:02:00Z",
+                  },
+                ]
+              : [],
+          hasHistoryBefore: false,
+        });
+      },
+    );
+    context.mocks.api(chatThreadMessagesContract.get, ({ params, respond }) => {
+      if (
+        params.threadId === firstThreadId &&
+        params.messageId === firstMessageId
+      ) {
+        return respond(200, {
+          id: firstMessageId,
+          role: "user",
+          content: "First shortcut thread message",
+          createdAt: "2026-06-01T00:02:00Z",
+        });
+      }
+      return respond(404, {
+        error: { message: "Message not found", code: "NOT_FOUND" },
+      });
+    });
+
+    detachedSetupPage({ context, path: `/agents/${researchAgentId}/chat` });
+
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText(
+          "Ask me to automate workflows, manage tasks...",
+        ),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(
+      screen.getByPlaceholderText(
+        "Ask me to automate workflows, manage tasks...",
+      ),
+      {
+        key: "ArrowDown",
+        ctrlKey: true,
+        shiftKey: true,
+      },
+    );
+
+    await waitFor(() => {
+      expect(pathname()).toBe(`/chats/${firstThreadId}`);
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByText("First shortcut thread message"),
       ).toBeInTheDocument();
     });
   });


### PR DESCRIPTION
## Summary
- Register a route-scoped `mod+shift+arrowdown` shortcut on `/agents/:agentId/chat`.
- Navigate to the first item in the sidebar chat thread list for the current agent when the shortcut is pressed.
- Cover the shortcut with a page-level team navigation test that triggers the shortcut from the agent chat composer.

## Tests
- `pnpm exec prettier --write apps/platform/src/signals/zero-page/agent-chat-keyboard.ts apps/platform/src/signals/zero-page/agent-chat-page-setup.ts apps/platform/src/signals/agents-page/agent-detail-page-setup.ts apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx`
- `pnpm exec vitest run apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx`
- `pnpm --filter @vm0/app lint`
- `pnpm --filter @vm0/app check-types`