### PR TITLE
feat(platform): resume publishable HTML artifact edit drafts

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/html-dom-comment-editor.ts
+++ b/turbo/apps/platform/src/signals/zero-page/html-dom-comment-editor.ts
@@ -123,7 +123,7 @@ interface UploadHtmlSnapshotParams {
 
 interface SendHtmlDomEditRequestParams {
   readonly onFailed?: () => void;
-  readonly onGenerated?: (draft: HtmlDomEditDraft) => Promise<void>;
+  readonly onGenerated?: (draft: HtmlDomEditDraft) => void | Promise<void>;
   readonly onPrepared?: (payload: HtmlDomEditPayload) => Promise<void>;
   readonly onStarted?: () => void;
 }

--- a/turbo/apps/platform/src/signals/zero-page/zero-artifact-sidebar.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-artifact-sidebar.ts
@@ -1,4 +1,5 @@
 import { command, computed, state } from "ccstate";
+import { chatThreadArtifactsContract } from "@vm0/api-contracts/contracts/chat-threads";
 import { zeroHostContract } from "@vm0/api-contracts/contracts/zero-host";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import {
@@ -7,8 +8,14 @@ import {
   updateSearchParams$,
 } from "../route.ts";
 import { accept } from "../../lib/accept.ts";
-import { zeroClient$ } from "../api-client.ts";
-import { resetSignal, withCleanup } from "../utils.ts";
+import { zeroClient$, type ZeroClientFactory } from "../api-client.ts";
+import {
+  markDetachedErrorHandled,
+  onRef,
+  resetSignal,
+  tapError,
+  withCleanup,
+} from "../utils.ts";
 import { localStorageSignals } from "../external/local-storage.ts";
 import {
   classifyChatAttachment,
@@ -31,6 +38,7 @@ import {
   PRESENTATION_EDITOR_QUERY_PARAM,
 } from "./right-sidebar-search-params.ts";
 import { refreshPresentationHtmlPreviews$ } from "./presentation-html-cache-bust.ts";
+import { readableAttachmentResourceUrl } from "../../views/zero-page/zero-attachment-url.ts";
 
 // ---------------------------------------------------------------------------
 // Artifact sidebar — URL-routed page-level slot for previewing a single
@@ -56,6 +64,157 @@ const internalHtmlDomEditPreviewHtmlByUrl$ = state<
   Readonly<Record<string, string>>
 >({});
 const resetHtmlDomEditPublishSignal$ = resetSignal();
+const resetHtmlEditSnapshotLoadSignal$ = resetSignal();
+
+interface HtmlEditSnapshotRestoreDraft {
+  readonly threadId: string;
+  readonly updatedAt: string;
+  readonly url: string;
+  readonly snapshotUrl: string;
+}
+
+interface ActiveHtmlEditSnapshotTarget {
+  readonly threadId: string;
+  readonly url: string;
+}
+
+interface HtmlEditSnapshotSaveArgs {
+  readonly html: string;
+  readonly threadId: string;
+  readonly url: string;
+}
+
+const internalHtmlEditSnapshotRestoreDraft$ =
+  state<HtmlEditSnapshotRestoreDraft | null>(null);
+const internalActiveHtmlEditSnapshotTarget$ =
+  state<ActiveHtmlEditSnapshotTarget | null>(null);
+// In-flight save chain per `threadId\nurl`, so delete can await it.
+const internalHtmlEditSnapshotSaveByKey$ = state<
+  Readonly<Record<string, Promise<void>>>
+>({});
+// Draft HTML prefetched when a restorable draft is detected, so Resume applies
+// without a round-trip. Keyed by `threadId\nurl`; cleared on target change.
+const internalHtmlEditSnapshotContentByKey$ = state<
+  Readonly<Record<string, string>>
+>({});
+// Bumped whenever a snapshot is deleted, so a save enqueued before the delete
+// skips its upsert instead of resurrecting the just-deleted draft.
+const internalHtmlEditSnapshotDeleteEpochByKey$ = state<
+  Readonly<Record<string, number>>
+>({});
+
+function htmlEditSnapshotKey(threadId: string, url: string): string {
+  return `${threadId}\n${url}`;
+}
+
+async function upsertHtmlEditSnapshot(
+  createClient: ZeroClientFactory,
+  args: HtmlEditSnapshotSaveArgs,
+): Promise<void> {
+  const client = createClient(chatThreadArtifactsContract, { apiBase: "api" });
+  await accept(
+    client.upsertHtmlEditSnapshot({
+      params: { threadId: args.threadId },
+      body: { url: args.url, html: args.html },
+    }),
+    [200],
+  );
+}
+
+// Fetch the saved draft HTML from its snapshot URL, or null if it no longer
+// exists (404). The snapshot URL is a versioned CDN link returned by
+// getHtmlEditSnapshot.
+async function fetchHtmlEditSnapshotContent(
+  snapshotUrl: string,
+  signal: AbortSignal,
+): Promise<string | null> {
+  const response = await fetch(readableAttachmentResourceUrl(snapshotUrl), {
+    cache: "reload",
+    mode: "cors",
+    signal,
+  });
+  if (response.status === 404) {
+    return null;
+  }
+  if (!response.ok) {
+    throw new Error(`Failed to load saved draft (${response.status})`);
+  }
+  return response.text();
+}
+
+// Persist the Send-generated draft for its captured thread + url, fire-and-forget
+// (not gated on the active target) so it lands even if the agent returns after
+// the user switched chats. Saves for the same key chain so a slow older upload
+// can't clobber a newer draft, and the promise is tracked so delete can await it.
+export const saveCapturedHtmlEditSnapshotDraft$ = command(
+  ({ get, set }, args: HtmlEditSnapshotSaveArgs) => {
+    const createClient = get(zeroClient$);
+    const key = htmlEditSnapshotKey(args.threadId, args.url);
+    // A newer draft invalidates any content prefetched for the same target, so
+    // Resume never applies stale HTML.
+    if (key in get(internalHtmlEditSnapshotContentByKey$)) {
+      const nextContent = { ...get(internalHtmlEditSnapshotContentByKey$) };
+      delete nextContent[key];
+      set(internalHtmlEditSnapshotContentByKey$, nextContent);
+    }
+    const epoch = get(internalHtmlEditSnapshotDeleteEpochByKey$)[key] ?? 0;
+    const previous = get(internalHtmlEditSnapshotSaveByKey$)[key];
+
+    const run = async () => {
+      if (typeof previous !== "undefined") {
+        await previous;
+      }
+      // Skip if the snapshot was deleted after this save was enqueued, so a
+      // stale save can't resurrect a discarded/published draft.
+      if (
+        (get(internalHtmlEditSnapshotDeleteEpochByKey$)[key] ?? 0) !== epoch
+      ) {
+        return;
+      }
+      await tapError(
+        upsertHtmlEditSnapshot(createClient, args),
+        markDetachedErrorHandled,
+      );
+    };
+
+    const queue = withCleanup(run(), () => {
+      if (get(internalHtmlEditSnapshotSaveByKey$)[key] === queue) {
+        const next = { ...get(internalHtmlEditSnapshotSaveByKey$) };
+        delete next[key];
+        set(internalHtmlEditSnapshotSaveByKey$, next);
+      }
+    });
+    set(internalHtmlEditSnapshotSaveByKey$, {
+      ...get(internalHtmlEditSnapshotSaveByKey$),
+      [key]: queue,
+    });
+  },
+);
+
+const waitForHtmlEditSnapshotSaveQueue$ = command(
+  async (
+    { get },
+    args: { readonly threadId: string; readonly url: string },
+    signal: AbortSignal,
+  ) => {
+    const queue = get(internalHtmlEditSnapshotSaveByKey$)[
+      htmlEditSnapshotKey(args.threadId, args.url)
+    ];
+    if (typeof queue === "undefined") {
+      return;
+    }
+    // The chain never rejects (failures handled inside); just let it settle.
+    await queue;
+    signal.throwIfAborted();
+  },
+);
+
+function htmlEditSnapshotTargetMatches(
+  active: ActiveHtmlEditSnapshotTarget | null,
+  args: { readonly threadId: string; readonly url: string },
+): boolean {
+  return active?.threadId === args.threadId && active.url === args.url;
+}
 
 export type ArtifactPreviewKind =
   | "markdown"
@@ -307,6 +466,235 @@ export const htmlDomEditPreviewHtmlByUrl$ = computed((get) => {
   return get(internalHtmlDomEditPreviewHtmlByUrl$);
 });
 
+export const htmlEditSnapshotRestoreDraft$ = computed((get) => {
+  return get(internalHtmlEditSnapshotRestoreDraft$);
+});
+
+// Dismiss the restore prompt without acting on it (the draft stays in the DB and
+// is offered again next time the artifact is opened).
+export const dismissHtmlEditSnapshotRestoreDraft$ = command(({ set }) => {
+  set(internalHtmlEditSnapshotRestoreDraft$, null);
+});
+
+const setActiveHtmlEditSnapshotTarget$ = command(
+  (
+    { get, set },
+    target: { readonly threadId: string; readonly url: string } | null,
+  ) => {
+    const current = get(internalActiveHtmlEditSnapshotTarget$);
+    if (
+      current?.threadId === target?.threadId &&
+      current?.url === target?.url
+    ) {
+      return;
+    }
+
+    set(internalActiveHtmlEditSnapshotTarget$, target);
+    set(resetHtmlEditSnapshotLoadSignal$);
+    set(internalHtmlEditSnapshotContentByKey$, {});
+    if (
+      !target ||
+      get(internalHtmlEditSnapshotRestoreDraft$)?.threadId !==
+        target.threadId ||
+      get(internalHtmlEditSnapshotRestoreDraft$)?.url !== target.url
+    ) {
+      set(internalHtmlEditSnapshotRestoreDraft$, null);
+    }
+  },
+);
+
+export const loadHtmlEditSnapshotRestoreDraft$ = command(
+  async (
+    { get, set },
+    args: {
+      readonly threadId: string;
+      readonly url: string;
+    },
+    signal: AbortSignal,
+  ) => {
+    const active = get(internalActiveHtmlEditSnapshotTarget$);
+    if (!htmlEditSnapshotTargetMatches(active, args)) {
+      return;
+    }
+    const loadSignal = set(resetHtmlEditSnapshotLoadSignal$, signal);
+
+    const client = get(zeroClient$)(chatThreadArtifactsContract, {
+      apiBase: "api",
+    });
+    const response = await tapError(
+      accept(
+        client.getHtmlEditSnapshot({
+          params: { threadId: args.threadId },
+          query: { url: args.url },
+          fetchOptions: { signal: loadSignal },
+        }),
+        [200],
+        { toast: false },
+      ),
+      markDetachedErrorHandled,
+    );
+    signal.throwIfAborted();
+    loadSignal.throwIfAborted();
+    if (!response) {
+      return;
+    }
+    const current = get(internalActiveHtmlEditSnapshotTarget$);
+    if (!htmlEditSnapshotTargetMatches(current, args)) {
+      return;
+    }
+    if (!response.body.snapshot) {
+      set(internalHtmlEditSnapshotRestoreDraft$, null);
+      return;
+    }
+    const { snapshotUrl } = response.body.snapshot;
+    set(internalHtmlEditSnapshotRestoreDraft$, {
+      threadId: args.threadId,
+      updatedAt: response.body.snapshot.updatedAt,
+      url: args.url,
+      snapshotUrl,
+    });
+
+    // Prefetch the draft HTML in the background so Resume applies instantly.
+    const html = await tapError(
+      fetchHtmlEditSnapshotContent(snapshotUrl, loadSignal),
+      markDetachedErrorHandled,
+    );
+    signal.throwIfAborted();
+    loadSignal.throwIfAborted();
+    if (
+      typeof html === "string" &&
+      htmlEditSnapshotTargetMatches(
+        get(internalActiveHtmlEditSnapshotTarget$),
+        args,
+      )
+    ) {
+      set(internalHtmlEditSnapshotContentByKey$, {
+        ...get(internalHtmlEditSnapshotContentByKey$),
+        [htmlEditSnapshotKey(args.threadId, args.url)]: html,
+      });
+    }
+  },
+);
+
+export const deleteHtmlEditSnapshotDraft$ = command(
+  async (
+    { get, set },
+    args: { readonly threadId: string; readonly url: string },
+    signal: AbortSignal,
+  ) => {
+    const key = htmlEditSnapshotKey(args.threadId, args.url);
+    // Bump the epoch synchronously so any already-enqueued save skips its upsert
+    // rather than resurrecting this snapshot after we delete it.
+    set(internalHtmlEditSnapshotDeleteEpochByKey$, {
+      ...get(internalHtmlEditSnapshotDeleteEpochByKey$),
+      [key]: (get(internalHtmlEditSnapshotDeleteEpochByKey$)[key] ?? 0) + 1,
+    });
+    // Let any in-flight save settle first so its upsert can't land after the
+    // delete and resurrect a stale snapshot.
+    await set(
+      waitForHtmlEditSnapshotSaveQueue$,
+      {
+        threadId: args.threadId,
+        url: args.url,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    const client = get(zeroClient$)(chatThreadArtifactsContract, {
+      apiBase: "api",
+    });
+    await accept(
+      client.deleteHtmlEditSnapshot({
+        params: { threadId: args.threadId },
+        query: { url: args.url },
+        fetchOptions: { signal },
+      }),
+      [204],
+      { toast: false },
+    );
+    signal.throwIfAborted();
+
+    const nextContent = { ...get(internalHtmlEditSnapshotContentByKey$) };
+    delete nextContent[key];
+    set(internalHtmlEditSnapshotContentByKey$, nextContent);
+
+    const restoreDraft = get(internalHtmlEditSnapshotRestoreDraft$);
+    if (
+      restoreDraft?.threadId === args.threadId &&
+      restoreDraft.url === args.url
+    ) {
+      set(internalHtmlEditSnapshotRestoreDraft$, null);
+    }
+  },
+);
+
+export const continueHtmlEditSnapshotDraft$ = command(
+  async (
+    { get, set },
+    args: {
+      readonly threadId: string;
+      readonly url: string;
+    },
+    signal: AbortSignal,
+  ) => {
+    // Use the draft HTML prefetched at detection time when available; otherwise
+    // fetch it now from the restore draft's snapshot URL.
+    const cached = get(internalHtmlEditSnapshotContentByKey$)[
+      htmlEditSnapshotKey(args.threadId, args.url)
+    ];
+    let html: string | null;
+    if (typeof cached === "string") {
+      html = cached;
+    } else {
+      const restoreDraft = get(internalHtmlEditSnapshotRestoreDraft$);
+      const snapshotUrl =
+        restoreDraft?.threadId === args.threadId &&
+        restoreDraft.url === args.url
+          ? restoreDraft.snapshotUrl
+          : null;
+      html = snapshotUrl
+        ? await fetchHtmlEditSnapshotContent(snapshotUrl, signal)
+        : null;
+    }
+    signal.throwIfAborted();
+    // The user may have switched artifact/thread during the fetch; don't apply a
+    // draft preview to a target they navigated away from.
+    if (
+      !htmlEditSnapshotTargetMatches(
+        get(internalActiveHtmlEditSnapshotTarget$),
+        args,
+      )
+    ) {
+      return;
+    }
+    if (html === null) {
+      set(internalHtmlEditSnapshotRestoreDraft$, null);
+      toast.error("Saved draft is no longer available");
+      return;
+    }
+
+    // Restore the draft as a publishable preview: write it into the preview map
+    // and leave comment-edit mode so the Publish/Discard toolbar shows.
+    set(internalHtmlDomEditPreviewHtmlByUrl$, {
+      ...get(internalHtmlDomEditPreviewHtmlByUrl$),
+      [args.url]: html,
+    });
+    set(internalHtmlDomEditPendingUrl$, null);
+    const params = new URLSearchParams(get(searchParams$));
+    params.delete(ARTIFACT_HTML_EDIT_PARAM);
+    set(replaceSearchParams$, params);
+    await set(
+      deleteHtmlEditSnapshotDraft$,
+      {
+        threadId: args.threadId,
+        url: args.url,
+      },
+      signal,
+    );
+  },
+);
+
 export const markHtmlDomEditPending$ = command(({ set }, url: string) => {
   set(internalHtmlDomEditPendingUrl$, url);
 });
@@ -321,8 +709,48 @@ export const applyHtmlDomEditPreview$ = command(
   },
 );
 
+export const currentHtmlDomEditPreviewHtml$ = command(
+  ({ get }, url: string) => {
+    return get(internalHtmlDomEditPreviewHtmlByUrl$)[url] ?? null;
+  },
+);
+
+export const setHtmlEditSnapshotControllerRef$ = onRef(
+  command(async ({ set }, el: HTMLDivElement, signal: AbortSignal) => {
+    const threadId = el.dataset.htmlEditSnapshotThreadId;
+    const url = el.dataset.htmlEditSnapshotUrl;
+    if (!threadId || !url) {
+      set(setActiveHtmlEditSnapshotTarget$, null);
+      return;
+    }
+
+    const target = { threadId, url };
+    set(setActiveHtmlEditSnapshotTarget$, target);
+
+    signal.addEventListener(
+      "abort",
+      () => {
+        set(setActiveHtmlEditSnapshotTarget$, null);
+      },
+      { once: true },
+    );
+
+    await set(loadHtmlEditSnapshotRestoreDraft$, target, signal);
+  }),
+);
+
 export const discardHtmlDomEditPreviewDraft$ = command(
-  ({ get, set }, url: string) => {
+  async (
+    { get, set },
+    args:
+      | string
+      | {
+          readonly threadId?: string;
+          readonly url: string;
+        },
+    signal: AbortSignal,
+  ) => {
+    const url = typeof args === "string" ? args : args.url;
     const next = { ...get(internalHtmlDomEditPreviewHtmlByUrl$) };
     delete next[url];
     set(internalHtmlDomEditPreviewHtmlByUrl$, next);
@@ -330,17 +758,38 @@ export const discardHtmlDomEditPreviewDraft$ = command(
     const params = new URLSearchParams(get(searchParams$));
     params.set(ARTIFACT_HTML_EDIT_PARAM, "1");
     set(replaceSearchParams$, params);
+
+    if (typeof args !== "string" && args.threadId) {
+      await set(
+        deleteHtmlEditSnapshotDraft$,
+        {
+          threadId: args.threadId,
+          url,
+        },
+        signal,
+      );
+    }
   },
 );
 
 export const publishHtmlDomEditPreviewDraft$ = command(
-  async ({ get, set }, url: string, _parentSignal: AbortSignal) => {
+  async (
+    { get, set },
+    args:
+      | string
+      | {
+          readonly threadId?: string;
+          readonly url: string;
+        },
+    parentSignal: AbortSignal,
+  ) => {
+    const url = typeof args === "string" ? args : args.url;
     const html = get(internalHtmlDomEditPreviewHtmlByUrl$)[url];
     if (!html || get(internalHtmlDomEditPublishingUrl$) === url) {
       return;
     }
 
-    const signal = set(resetHtmlDomEditPublishSignal$);
+    const signal = set(resetHtmlDomEditPublishSignal$, parentSignal);
     set(internalHtmlDomEditPublishingUrl$, url);
     const publish = async () => {
       const client = get(zeroClient$)(zeroHostContract, { apiBase: "api" });
@@ -363,6 +812,22 @@ export const publishHtmlDomEditPreviewDraft$ = command(
       set(replaceSearchParams$, params);
       set(refreshPresentationHtmlPreviews$);
       toast.success("Site published");
+
+      // The site is already live; clearing the saved snapshot is best-effort and
+      // must not turn a successful publish into a reported failure.
+      if (typeof args !== "string" && args.threadId) {
+        await tapError(
+          set(
+            deleteHtmlEditSnapshotDraft$,
+            {
+              threadId: args.threadId,
+              url,
+            },
+            signal,
+          ),
+          markDetachedErrorHandled,
+        );
+      }
     };
 
     await withCleanup(publish(), () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -23,7 +23,12 @@ import {
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { artifactPanelWidth$ } from "../../../signals/zero-page/zero-artifact-sidebar.ts";
+import {
+  artifactPanelWidth$,
+  saveCapturedHtmlEditSnapshotDraft$,
+} from "../../../signals/zero-page/zero-artifact-sidebar.ts";
+import { ARTIFACT_HTML_EDIT_PARAM } from "../../../signals/zero-page/right-sidebar-search-params.ts";
+import { searchParams$ } from "../../../signals/route.ts";
 
 const context = testContext();
 const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
@@ -357,6 +362,34 @@ function setupPresentationArtifactThread(
   });
 }
 
+function setupHostedSiteArtifactThread(
+  siteUrl: string,
+  html = "<!doctype html><html><body><h1>Original site</h1></body></html>",
+): void {
+  const filename = new URL(siteUrl).pathname.split("/").pop() || "site.html";
+  context.mocks.http.get(siteUrl, () => {
+    return new Response(html, {
+      headers: { "Content-Type": "text/html" },
+    });
+  });
+  setupChatThread({
+    artifactFiles: [
+      artifactFile(siteUrl, {
+        id: "artifact-hosted-site",
+        filename,
+        contentType: "text/html",
+        artifactKind: "hosted-site",
+        size: html.length,
+      }),
+    ],
+    content: `[Hosted site](${siteUrl})`,
+    featureSwitches: {
+      [FeatureSwitchKey.HtmlArtifactCommentEditing]: true,
+    },
+    path: `${THREAD_PATH}?artifact=${encodeURIComponent(siteUrl)}`,
+  });
+}
+
 function assetBackedPresentationHtml(assetUrl: string): string {
   return `<!doctype html>
 <html>
@@ -574,6 +607,285 @@ describe("zero artifact sidebar", () => {
     await waitFor(() => {
       expect(screen.queryByTestId("artifact-sidebar")).not.toBeInTheDocument();
     });
+  });
+
+  it("offers to resume a saved HTML edit snapshot", async () => {
+    const user = userEvent.setup({ delay: null });
+    const siteUrl = "https://resume-draft.sites.vm7.io/index.html";
+    const snapshotUrl =
+      "https://cdn.vm7.io/artifacts/html-edit-drafts/resume-draft.html?v=1";
+    const restoredHtml =
+      "<!doctype html><html><body><h1>Saved draft</h1></body></html>";
+    const deletedUrls: string[] = [];
+    const savedBodies: string[] = [];
+    let contentFetches = 0;
+
+    context.mocks.api(
+      chatThreadArtifactsContract.getHtmlEditSnapshot,
+      ({ query, respond }) => {
+        expect(query.url).toBe(siteUrl);
+        return respond(200, {
+          snapshot: {
+            artifactUrl: siteUrl,
+            snapshotUrl,
+            updatedAt: "2026-03-10T00:05:00Z",
+          },
+        });
+      },
+    );
+    context.mocks.api(
+      chatThreadArtifactsContract.deleteHtmlEditSnapshot,
+      ({ query, respond }) => {
+        deletedUrls.push(query.url);
+        return respond(204);
+      },
+    );
+    context.mocks.http.get("*/__vm0-dev-artifact-fetch", ({ request }) => {
+      expect(new URL(request.url).searchParams.get("url")).toBe(snapshotUrl);
+      contentFetches += 1;
+      return new Response(restoredHtml, {
+        headers: { "Content-Type": "text/html" },
+      });
+    });
+    context.mocks.api(
+      chatThreadArtifactsContract.upsertHtmlEditSnapshot,
+      ({ body, respond }) => {
+        savedBodies.push(body.html);
+        return respond(200, {
+          artifactUrl: body.url,
+          snapshotUrl,
+          updatedAt: "2026-03-10T00:06:00Z",
+        });
+      },
+    );
+    setupHostedSiteArtifactThread(siteUrl);
+
+    // Content is prefetched once when the draft is detected, before Resume.
+    await waitFor(() => {
+      expect(screen.getByText("Resume HTML draft?")).toBeInTheDocument();
+      expect(contentFetches).toBe(1);
+    });
+    await user.click(screen.getByText("Resume"));
+
+    await waitFor(() => {
+      // Resume applies the draft as a publishable preview, not the comment editor.
+      expect(screen.getByTestId("artifact-sidebar-body-html")).toHaveAttribute(
+        "srcdoc",
+        expect.stringContaining("Saved draft"),
+      );
+      expect(screen.getByTestId("html-dom-draft-toolbar")).toBeInTheDocument();
+      expect(deletedUrls).toStrictEqual([siteUrl]);
+    });
+    // Resume reused the prefetched content instead of fetching again.
+    expect(contentFetches).toBe(1);
+    expect(
+      screen.queryByTestId("html-dom-comment-editor"),
+    ).not.toBeInTheDocument();
+    expect(
+      context.store.get(searchParams$).get(ARTIFACT_HTML_EDIT_PARAM),
+    ).toBeNull();
+    expect(savedBodies).toStrictEqual([]);
+  });
+
+  it("applies the resumed draft as a publishable preview state", async () => {
+    const user = userEvent.setup({ delay: null });
+    const siteUrl = "https://resume-apply.sites.vm7.io/index.html";
+    const snapshotUrl =
+      "https://cdn.vm7.io/artifacts/html-edit-drafts/resume-apply.html?v=1";
+    const restoredHtml =
+      "<!doctype html><html><body><h1>Saved draft</h1></body></html>";
+    let redeployedHtml: string | null = null;
+
+    context.mocks.api(
+      chatThreadArtifactsContract.getHtmlEditSnapshot,
+      ({ respond }) => {
+        return respond(200, {
+          snapshot: {
+            artifactUrl: siteUrl,
+            snapshotUrl,
+            updatedAt: "2026-03-10T00:05:00Z",
+          },
+        });
+      },
+    );
+    context.mocks.http.get("*/__vm0-dev-artifact-fetch", () => {
+      return new Response(restoredHtml, {
+        headers: { "Content-Type": "text/html" },
+      });
+    });
+    context.mocks.api(
+      chatThreadArtifactsContract.deleteHtmlEditSnapshot,
+      ({ respond }) => {
+        return respond(204);
+      },
+    );
+    context.mocks.api(zeroHostContract.redeployHtml, ({ body, respond }) => {
+      redeployedHtml = body.html;
+      return respond(200, {
+        siteId: "7c82da29-6280-4d65-b078-e233c8ad14bf",
+        deploymentId: "dc8b4d42-5dc1-4769-ad8b-17bdf1ad035a",
+        publicSlug: "resume-apply",
+        url: body.url,
+        status: "ready",
+      });
+    });
+    setupHostedSiteArtifactThread(siteUrl);
+
+    await waitFor(() => {
+      expect(screen.getByText("Resume HTML draft?")).toBeInTheDocument();
+    });
+    await user.click(screen.getByText("Resume"));
+
+    await waitFor(() => {
+      // Resume lands directly on the publishable draft preview.
+      expect(screen.getByTestId("artifact-sidebar-body-html")).toHaveAttribute(
+        "srcdoc",
+        expect.stringContaining("Saved draft"),
+      );
+      expect(screen.getByTestId("html-dom-draft-toolbar")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("html-dom-draft-publish"));
+
+    await waitFor(() => {
+      expect(redeployedHtml).toBe(restoredHtml);
+    });
+  });
+
+  it("persists the generated HTML draft even without an active edit target", async () => {
+    const siteUrl = "https://send-draft.sites.vm7.io/index.html";
+    const generatedHtml =
+      "<!doctype html><html><body><h1>Generated draft</h1></body></html>";
+    const savedBodies: string[] = [];
+
+    context.mocks.api(
+      chatThreadArtifactsContract.upsertHtmlEditSnapshot,
+      ({ body, params, respond }) => {
+        expect(params.threadId).toBe(THREAD_ID);
+        expect(body.url).toBe(siteUrl);
+        savedBodies.push(body.html);
+        return respond(200, {
+          artifactUrl: body.url,
+          snapshotUrl:
+            "https://cdn.vm7.io/artifacts/html-edit-drafts/send-draft.html?v=1",
+          updatedAt: "2026-03-10T00:06:00Z",
+        });
+      },
+    );
+
+    // No active target is set (mimics the agent returning after the user has
+    // switched away): the save must still persist using the captured values.
+    context.store.set(saveCapturedHtmlEditSnapshotDraft$, {
+      html: generatedHtml,
+      threadId: THREAD_ID,
+      url: siteUrl,
+    });
+    await waitFor(() => {
+      expect(savedBodies).toStrictEqual([generatedHtml]);
+    });
+  });
+
+  it("discards a saved HTML edit snapshot from the restore dialog", async () => {
+    const user = userEvent.setup({ delay: null });
+    const siteUrl = "https://discard-draft.sites.vm7.io/index.html";
+    const snapshotUrl =
+      "https://cdn.vm7.io/artifacts/html-edit-drafts/discard-draft.html?v=1";
+    const deletedUrls: string[] = [];
+
+    context.mocks.api(
+      chatThreadArtifactsContract.getHtmlEditSnapshot,
+      ({ respond }) => {
+        return respond(200, {
+          snapshot: {
+            artifactUrl: siteUrl,
+            snapshotUrl,
+            updatedAt: "2026-03-10T00:05:00Z",
+          },
+        });
+      },
+    );
+    context.mocks.http.get("*/__vm0-dev-artifact-fetch", () => {
+      return new Response(
+        "<!doctype html><html><body><h1>Discarded</h1></body></html>",
+        { headers: { "Content-Type": "text/html" } },
+      );
+    });
+    context.mocks.api(
+      chatThreadArtifactsContract.deleteHtmlEditSnapshot,
+      ({ query, respond }) => {
+        deletedUrls.push(query.url);
+        return respond(204);
+      },
+    );
+    setupHostedSiteArtifactThread(siteUrl);
+
+    await waitFor(() => {
+      expect(screen.getByText("Resume HTML draft?")).toBeInTheDocument();
+    });
+    await user.click(screen.getByText("Discard"));
+
+    await waitFor(() => {
+      expect(screen.queryByText("Resume HTML draft?")).not.toBeInTheDocument();
+      expect(deletedUrls).toStrictEqual([siteUrl]);
+    });
+    expect(
+      screen.queryByTestId("html-dom-draft-toolbar"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId("artifact-sidebar-body-html"),
+    ).not.toHaveAttribute("srcdoc");
+  });
+
+  it("dismisses the restore dialog with Escape without deleting the draft", async () => {
+    const user = userEvent.setup({ delay: null });
+    const siteUrl = "https://dismiss-draft.sites.vm7.io/index.html";
+    const snapshotUrl =
+      "https://cdn.vm7.io/artifacts/html-edit-drafts/dismiss-draft.html?v=1";
+    const deletedUrls: string[] = [];
+
+    context.mocks.api(
+      chatThreadArtifactsContract.getHtmlEditSnapshot,
+      ({ respond }) => {
+        return respond(200, {
+          snapshot: {
+            artifactUrl: siteUrl,
+            snapshotUrl,
+            updatedAt: "2026-03-10T00:05:00Z",
+          },
+        });
+      },
+    );
+    context.mocks.http.get("*/__vm0-dev-artifact-fetch", () => {
+      return new Response(
+        "<!doctype html><html><body><h1>Dismissed</h1></body></html>",
+        { headers: { "Content-Type": "text/html" } },
+      );
+    });
+    context.mocks.api(
+      chatThreadArtifactsContract.deleteHtmlEditSnapshot,
+      ({ query, respond }) => {
+        deletedUrls.push(query.url);
+        return respond(204);
+      },
+    );
+    setupHostedSiteArtifactThread(siteUrl);
+
+    await waitFor(() => {
+      expect(screen.getByText("Resume HTML draft?")).toBeInTheDocument();
+    });
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(screen.queryByText("Resume HTML draft?")).not.toBeInTheDocument();
+    });
+    // Dismiss keeps the draft in the DB (no delete) and shows the original.
+    expect(deletedUrls).toStrictEqual([]);
+    expect(
+      screen.queryByTestId("html-dom-draft-toolbar"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId("artifact-sidebar-body-html"),
+    ).not.toHaveAttribute("srcdoc");
   });
 
   it("resizes the artifact preview pane and persists the width", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -2200,6 +2200,111 @@ describe("zero attachment chips", () => {
     });
   });
 
+  it("saves an HTML edit snapshot when a comment draft is generated", async () => {
+    const htmlUrl = "https://save-on-send.sites.vm7.io";
+    const draftHtml =
+      "<!doctype html><html><body><main><h1>Launch sooner</h1></main></body></html>";
+    const savedBodies: string[] = [];
+    context.mocks.http.get("*/__vm0-dev-artifact-fetch", () => {
+      return new Response(
+        `<!doctype html><html><head><title>Save on send</title></head><body><main><h1>Launch faster</h1></main></body></html>`,
+        { headers: { "Content-Type": "text/html" } },
+      );
+    });
+    context.mocks.api(chatThreadArtifactsContract.list, ({ respond }) => {
+      return respond(200, {
+        runs: [
+          {
+            runId: "run-save-on-send",
+            files: [
+              artifactFile(htmlUrl, {
+                artifactKind: "hosted-site",
+                filename: "save-on-send.html",
+              }),
+            ],
+          },
+        ],
+      });
+    });
+    context.mocks.api(zeroHostContract.createHtmlEditDraft, ({ respond }) => {
+      return respond(200, {
+        kind: "html-edit-draft",
+        version: 1,
+        html: draftHtml,
+      });
+    });
+    context.mocks.api(
+      chatThreadArtifactsContract.upsertHtmlEditSnapshot,
+      ({ body, params, respond }) => {
+        expect(params.threadId).toBe(THREAD_ID);
+        expect(body.url).toBe(htmlUrl);
+        savedBodies.push(body.html);
+        return respond(200, {
+          artifactUrl: body.url,
+          snapshotUrl:
+            "https://cdn.vm7.io/artifacts/html-edit-drafts/save-on-send.html?v=1",
+          updatedAt: "2026-03-10T00:06:00Z",
+        });
+      },
+    );
+    mockChatLifecycle(context, {
+      threadId: THREAD_ID,
+      chatMessages: [
+        {
+          id: "msg-save-on-send",
+          role: "assistant",
+          content: `[Save on send](${htmlUrl})`,
+          runId: "run-save-on-send",
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      featureSwitches: {
+        [FeatureSwitchKey.HtmlArtifactCommentEditing]: true,
+      },
+      path: `/chats/${THREAD_ID}`,
+    });
+
+    click(await screen.findByLabelText("Open html preview for Save on send"));
+    await waitFor(() => {
+      expect(screen.getByLabelText("Edit page")).toBeInTheDocument();
+    });
+    click(screen.getByLabelText("Edit page"));
+
+    const frame = (await screen.findByTestId(
+      "html-dom-comment-frame",
+    )) as HTMLIFrameElement;
+    await waitFor(() => {
+      expect(
+        frame.contentDocument
+          ?.querySelector("h1")
+          ?.hasAttribute(HTML_DOM_NODE_ID_ATTR),
+      ).toBeTruthy();
+    });
+    fireEvent.click(frame.contentDocument!.querySelector("h1")!);
+
+    const user = userEvent.setup({ delay: null });
+    await user.type(
+      await screen.findByTestId("html-dom-comment-textarea"),
+      "Make the headline shorter",
+    );
+    fireEvent.keyDown(screen.getByTestId("html-dom-comment-textarea"), {
+      key: "Enter",
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("html-dom-toolbar-send")).toBeEnabled();
+    });
+
+    click(screen.getByTestId("html-dom-toolbar-send"));
+    await waitFor(() => {
+      expect(screen.getByTestId("html-dom-draft-toolbar")).toBeInTheDocument();
+      expect(savedBodies).toStrictEqual([draftHtml]);
+    });
+  });
+
   it("applies hosted-site HTML background and text color edits from the DOM popover", async () => {
     const htmlUrl = "https://color-launch-site.sites.vm7.io";
     let redeployedHtml: string | null = null;

--- a/turbo/apps/platform/src/views/zero-page/html-dom-comment-editor.tsx
+++ b/turbo/apps/platform/src/views/zero-page/html-dom-comment-editor.tsx
@@ -56,7 +56,7 @@ import type {
 
 interface HtmlDomCommentEditorProps {
   readonly filename: string;
-  readonly onApplyEditDraft?: (draft: HtmlDomEditDraft) => Promise<void>;
+  readonly onApplyEditDraft?: (draft: HtmlDomEditDraft) => void | Promise<void>;
   readonly onApplyStyleEdits?: (html: string) => Promise<void>;
   readonly onClose: () => void;
   readonly onEditRequestFailed?: () => void;
@@ -81,7 +81,7 @@ function HtmlDomCommentStage({
 }: {
   readonly filename: string;
   readonly model: HtmlDomCommentEditorModel;
-  readonly onApplyEditDraft?: (draft: HtmlDomEditDraft) => Promise<void>;
+  readonly onApplyEditDraft?: (draft: HtmlDomEditDraft) => void | Promise<void>;
   readonly onApplyStyleEdits?: (html: string) => Promise<void>;
   readonly onEditRequestFailed?: () => void;
   readonly onEditRequestStarted?: () => void;
@@ -229,7 +229,7 @@ function HtmlDomCommentToolbar({
 }: {
   readonly disabled: boolean;
   readonly model: HtmlDomCommentEditorModel;
-  readonly onApplyEditDraft?: (draft: HtmlDomEditDraft) => Promise<void>;
+  readonly onApplyEditDraft?: (draft: HtmlDomEditDraft) => void | Promise<void>;
   readonly onApplyStyleEdits?: (html: string) => Promise<void>;
   readonly onEditRequestFailed?: () => void;
   readonly onEditRequestStarted?: () => void;

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -22,7 +22,14 @@ import {
   useSet,
 } from "ccstate-react";
 import {
+  Button,
   cn,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -36,7 +43,11 @@ import {
   clearHtmlDomEditPending$,
   closeArtifactHtmlEditMode$,
   closeArtifact$,
+  deleteHtmlEditSnapshotDraft$,
+  dismissHtmlEditSnapshotRestoreDraft$,
   discardHtmlDomEditPreviewDraft$,
+  continueHtmlEditSnapshotDraft$,
+  htmlEditSnapshotRestoreDraft$,
   htmlDomEditPreviewHtmlByUrl$,
   htmlDomEditPendingUrl$,
   htmlDomEditPublishingUrl$,
@@ -45,6 +56,8 @@ import {
   openArtifactHtmlEditMode$,
   openPresentationEditor$,
   publishHtmlDomEditPreviewDraft$,
+  saveCapturedHtmlEditSnapshotDraft$,
+  setHtmlEditSnapshotControllerRef$,
   toggleArtifactFullscreen$,
 } from "../../signals/zero-page/zero-artifact-sidebar.ts";
 import {
@@ -154,6 +167,7 @@ type ArtifactSidebarContentProps = {
 };
 
 type HtmlArtifactHeaderState = "idle" | "editing" | "working" | "preview";
+type HtmlEditState = ReturnType<typeof createHtmlEditState>;
 
 function ArtifactSidebarWithThreadData({
   artifactRef,
@@ -220,6 +234,172 @@ function noop() {
   return undefined;
 }
 
+interface HtmlEditSnapshotRestoreDraftView {
+  readonly threadId: string;
+  readonly updatedAt: string;
+  readonly url: string;
+}
+
+type HtmlEditSnapshotTargetView = {
+  readonly threadId: string;
+  readonly url: string;
+};
+
+function HtmlEditSnapshotController({
+  previewHtml,
+  signal,
+  target,
+}: {
+  readonly previewHtml?: string;
+  readonly signal: AbortSignal;
+  readonly target: HtmlEditSnapshotTargetView | null;
+}) {
+  const restoreDraft = useGet(htmlEditSnapshotRestoreDraft$);
+  const continueHtmlEditSnapshotDraft = useSet(continueHtmlEditSnapshotDraft$);
+  const deleteHtmlEditSnapshotDraft = useSet(deleteHtmlEditSnapshotDraft$);
+  const dismissHtmlEditSnapshotRestoreDraft = useSet(
+    dismissHtmlEditSnapshotRestoreDraft$,
+  );
+  const setHtmlEditSnapshotControllerRef = useSet(
+    setHtmlEditSnapshotControllerRef$,
+  );
+
+  return (
+    <div
+      key={target ? `${target.threadId}\n${target.url}` : "none"}
+      ref={setHtmlEditSnapshotControllerRef}
+      data-html-edit-snapshot-thread-id={target?.threadId}
+      data-html-edit-snapshot-url={target?.url}
+      data-html-edit-snapshot-has-preview={previewHtml ? "1" : undefined}
+    >
+      <HtmlEditSnapshotRestoreDialog
+        restoreDraft={htmlEditSnapshotRestoreDraftForTarget(
+          restoreDraft,
+          target,
+        )}
+        signal={signal}
+        onContinue={continueHtmlEditSnapshotDraft}
+        onDismiss={dismissHtmlEditSnapshotRestoreDraft}
+        onDiscard={(currentDraft) => {
+          detach(
+            deleteHtmlEditSnapshotDraft(
+              {
+                threadId: currentDraft.threadId,
+                url: currentDraft.url,
+              },
+              signal,
+            ),
+            Reason.DomCallback,
+            "discardHtmlEditSnapshotDraft",
+          );
+        }}
+      />
+    </div>
+  );
+}
+
+function htmlEditSnapshotRestoreDraftForTarget(
+  restoreDraft: HtmlEditSnapshotRestoreDraftView | null,
+  target: HtmlEditSnapshotTargetView | null,
+): HtmlEditSnapshotRestoreDraftView | null {
+  return restoreDraft &&
+    target &&
+    restoreDraft.threadId === target.threadId &&
+    restoreDraft.url === target.url
+    ? restoreDraft
+    : null;
+}
+
+function htmlEditSnapshotTargetForDisplay({
+  display,
+  htmlEditEnabled,
+  threadId,
+}: {
+  readonly display: ArtifactDisplay | null;
+  readonly htmlEditEnabled: boolean;
+  readonly threadId?: string;
+}): HtmlEditSnapshotTargetView | null {
+  return threadId &&
+    htmlEditEnabled &&
+    display?.kind === "html" &&
+    display.artifactKind === "hosted-site"
+    ? { threadId, url: display.url }
+    : null;
+}
+
+function HtmlEditSnapshotRestoreDialog({
+  onContinue,
+  onDiscard,
+  onDismiss,
+  restoreDraft,
+  signal,
+}: {
+  readonly onContinue: (
+    args: {
+      readonly threadId: string;
+      readonly url: string;
+    },
+    signal: AbortSignal,
+  ) => Promise<void>;
+  readonly onDiscard: (restoreDraft: HtmlEditSnapshotRestoreDraftView) => void;
+  readonly onDismiss: () => void;
+  readonly restoreDraft: HtmlEditSnapshotRestoreDraftView | null;
+  readonly signal: AbortSignal;
+}) {
+  const open = Boolean(restoreDraft);
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) {
+          onDismiss();
+        }
+      }}
+    >
+      <DialogContent data-testid="html-edit-snapshot-restore-dialog">
+        <DialogHeader>
+          <DialogTitle>Resume HTML draft?</DialogTitle>
+          <DialogDescription>
+            A saved HTML draft is available for this artifact.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => {
+              if (restoreDraft) {
+                onDiscard(restoreDraft);
+              }
+            }}
+          >
+            Discard
+          </Button>
+          <Button
+            onClick={() => {
+              if (!restoreDraft) {
+                return;
+              }
+              detach(
+                onContinue(
+                  {
+                    threadId: restoreDraft.threadId,
+                    url: restoreDraft.url,
+                  },
+                  signal,
+                ),
+                Reason.DomCallback,
+                "continueHtmlEditSnapshotDraft",
+              );
+            }}
+          >
+            Resume
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 function artifactSidebarSyncTargetForItem({
   agentId,
   item,
@@ -282,6 +462,9 @@ function ArtifactSidebarContent({
   const publishHtmlDomEditPreviewDraft = useSet(
     publishHtmlDomEditPreviewDraft$,
   );
+  const saveCapturedHtmlEditSnapshotDraft = useSet(
+    saveCapturedHtmlEditSnapshotDraft$,
+  );
   const toggleFullscreen = useSet(toggleArtifactFullscreen$);
   const resetZoomableImageCanvasZoom = useSet(resetZoomableImageCanvasZoom$);
   const pageSignal = useGet(pageSignal$);
@@ -290,8 +473,14 @@ function ArtifactSidebarContent({
   const features = useLastResolved(featureSwitch$);
 
   const display = resolveArtifactDisplay(artifactRef, item);
+  const htmlEditEnabled = isHtmlEditFeatureEnabled(features);
+  const htmlEditSnapshotTarget = htmlEditSnapshotTargetForDisplay({
+    display,
+    htmlEditEnabled,
+    threadId,
+  });
   const htmlCommentMode =
-    isHtmlEditFeatureEnabled(features) &&
+    htmlEditEnabled &&
     shouldOpenHtmlCommentMode(display, requestedHtmlCommentMode);
   const syncTarget = artifactSidebarSyncTargetForItem({
     agentId,
@@ -299,6 +488,11 @@ function ArtifactSidebarContent({
     onSyncSuccess,
     threadId,
   });
+
+  if (!display) {
+    return null;
+  }
+
   const htmlEditState = createHtmlEditState({
     applyPreview: applyHtmlDomEditPreview,
     clearPending: clearHtmlDomEditPending,
@@ -308,6 +502,8 @@ function ArtifactSidebarContent({
     publishingUrl: htmlDomEditPublishingUrl,
     previewHtmlByUrl: htmlDomEditPreviewHtmlByUrl,
     markPending: markHtmlDomEditPending,
+    saveDraft: saveCapturedHtmlEditSnapshotDraft,
+    snapshotTarget: htmlEditSnapshotTarget,
   });
   const htmlHeaderState = htmlArtifactHeaderState({
     display,
@@ -316,10 +512,72 @@ function ArtifactSidebarContent({
     status: htmlEditState.status,
   });
 
-  if (!display) {
-    return null;
-  }
+  return (
+    <ArtifactSidebarResolvedContent
+      closeHtmlCommentMode={closeHtmlCommentMode}
+      closePreview={closePreview}
+      display={display}
+      fullscreen={fullscreen}
+      htmlCommentMode={htmlCommentMode}
+      htmlEditSnapshotTarget={htmlEditSnapshotTarget}
+      htmlEditState={htmlEditState}
+      htmlHeaderState={htmlHeaderState}
+      imageNavigation={imageNavigation}
+      onBack={onBack}
+      openHtmlCommentMode={openHtmlCommentMode}
+      openPresentationEditor={openPresentationEditor}
+      pageSignal={pageSignal}
+      publishHtmlDomEditPreviewDraft={publishHtmlDomEditPreviewDraft}
+      resetZoomableImageCanvasZoom={resetZoomableImageCanvasZoom}
+      syncTarget={syncTarget}
+      threadId={threadId}
+      toggleFullscreen={toggleFullscreen}
+    />
+  );
+}
 
+function ArtifactSidebarResolvedContent({
+  closeHtmlCommentMode,
+  closePreview,
+  display,
+  fullscreen,
+  htmlCommentMode,
+  htmlEditSnapshotTarget,
+  htmlEditState,
+  htmlHeaderState,
+  imageNavigation,
+  onBack,
+  openHtmlCommentMode,
+  openPresentationEditor,
+  pageSignal,
+  publishHtmlDomEditPreviewDraft,
+  resetZoomableImageCanvasZoom,
+  syncTarget,
+  threadId,
+  toggleFullscreen,
+}: {
+  readonly closeHtmlCommentMode: () => void;
+  readonly closePreview: () => void;
+  readonly display: ArtifactDisplay;
+  readonly fullscreen: boolean;
+  readonly htmlCommentMode: boolean;
+  readonly htmlEditSnapshotTarget: HtmlEditSnapshotTargetView | null;
+  readonly htmlEditState: HtmlEditState;
+  readonly htmlHeaderState: HtmlArtifactHeaderState | undefined;
+  readonly imageNavigation?: ArtifactImageNavigationActions;
+  readonly onBack?: () => void;
+  readonly openHtmlCommentMode: () => void;
+  readonly openPresentationEditor: (url: string) => void;
+  readonly pageSignal: AbortSignal;
+  readonly publishHtmlDomEditPreviewDraft: (
+    args: string | { readonly threadId?: string; readonly url: string },
+    signal: AbortSignal,
+  ) => Promise<void>;
+  readonly resetZoomableImageCanvasZoom: (key: string) => void;
+  readonly syncTarget?: ArtifactDownloadSyncTarget;
+  readonly threadId?: string;
+  readonly toggleFullscreen: () => void;
+}) {
   const applyHtmlStyleEdits = createHtmlStyleEditApplyAction({
     display,
     htmlEditState,
@@ -383,8 +641,14 @@ function ArtifactSidebarContent({
           onHtmlEditRequestFailed={htmlEditState.fail}
           onHtmlEditRequestStarted={htmlEditState.start}
           pageSignal={pageSignal}
+          threadId={threadId}
         />
       </div>
+      <HtmlEditSnapshotController
+        previewHtml={htmlEditState.previewHtml}
+        signal={pageSignal}
+        target={htmlEditSnapshotTarget}
+      />
     </ArtifactSidebarSurface>
   );
 }
@@ -454,6 +718,8 @@ function createHtmlEditState({
   pendingUrl,
   publishingUrl,
   previewHtmlByUrl,
+  saveDraft,
+  snapshotTarget,
 }: {
   applyPreview: (params: {
     readonly url: string;
@@ -461,15 +727,18 @@ function createHtmlEditState({
   }) => void;
   clearPending: (url: string) => void;
   closeCommentMode: () => void;
-  display: ArtifactDisplay | null;
+  display: ArtifactDisplay;
   markPending: (url: string) => void;
   pendingUrl: string | null;
   publishingUrl: string | null;
   previewHtmlByUrl: Readonly<Record<string, string>>;
+  saveDraft: (args: {
+    readonly html: string;
+    readonly threadId: string;
+    readonly url: string;
+  }) => void;
+  snapshotTarget: { readonly threadId: string; readonly url: string } | null;
 }) {
-  if (!display) {
-    return {};
-  }
   const status =
     display.kind === "html" &&
     (pendingUrl === display.url || publishingUrl === display.url)
@@ -479,9 +748,14 @@ function createHtmlEditState({
     display.kind === "html" ? previewHtmlByUrl[display.url] : undefined;
   return {
     apply: (draft: HtmlDomEditDraft) => {
+      // Persist the generated draft (fire-and-forget) so it survives navigation.
+      // Style edits carry no comments and publish immediately, so they skip the
+      // save and let publish success clear any existing snapshot.
+      if (snapshotTarget && draft.comments.length > 0) {
+        saveDraft({ ...snapshotTarget, html: draft.html });
+      }
       applyPreview({ url: display.url, html: draft.html });
       closeCommentMode();
-      return Promise.resolve();
     },
     fail: () => {
       clearPending(display.url);
@@ -490,6 +764,7 @@ function createHtmlEditState({
       markPending(display.url);
     },
     previewHtml,
+    snapshotTarget,
     status,
   };
 }
@@ -503,18 +778,29 @@ function createHtmlStyleEditApplyAction({
   display: ArtifactDisplay;
   htmlEditState: ReturnType<typeof createHtmlEditState>;
   pageSignal: AbortSignal;
-  publishPreviewDraft: (url: string, signal: AbortSignal) => Promise<void>;
+  publishPreviewDraft: (
+    args:
+      | string
+      | {
+          readonly threadId?: string;
+          readonly url: string;
+        },
+    signal: AbortSignal,
+  ) => Promise<void>;
 }) {
-  if (display.kind !== "html" || !htmlEditState.apply) {
+  if (display.kind !== "html") {
     return undefined;
   }
   return async (html: string) => {
-    await htmlEditState.apply({
+    htmlEditState.apply({
       comments: [],
       editRequestId: crypto.randomUUID(),
       html,
     });
-    await publishPreviewDraft(display.url, pageSignal);
+    await publishPreviewDraft(
+      htmlEditState.snapshotTarget ?? display.url,
+      pageSignal,
+    );
   };
 }
 
@@ -1061,6 +1347,7 @@ function ArtifactBody({
   onHtmlEditRequestFailed,
   onHtmlEditRequestStarted,
   pageSignal,
+  threadId,
 }: {
   url: string;
   kind: ArtifactKindForBody;
@@ -1071,11 +1358,12 @@ function ArtifactBody({
   htmlCommentMode: boolean;
   imageNavigation?: ArtifactImageNavigationActions;
   onCloseHtmlCommentMode: () => void;
-  onApplyHtmlEditDraft?: (draft: HtmlDomEditDraft) => Promise<void>;
+  onApplyHtmlEditDraft?: (draft: HtmlDomEditDraft) => void | Promise<void>;
   onApplyHtmlStyleEdits?: (html: string) => Promise<void>;
   onHtmlEditRequestFailed?: () => void;
   onHtmlEditRequestStarted?: () => void;
   pageSignal: AbortSignal;
+  threadId?: string;
 }) {
   if (kind === "markdown") {
     return <ArtifactMarkdownBody url={url} signal={pageSignal} />;
@@ -1126,6 +1414,7 @@ function ArtifactBody({
         artifactKind={artifactKind}
         htmlEditStatus={htmlEditStatus}
         htmlPreviewHtml={htmlPreviewHtml}
+        threadId={threadId}
       />
     );
   }
@@ -1553,6 +1842,7 @@ function ArtifactIframeBody({
   artifactKind,
   htmlEditStatus,
   htmlPreviewHtml,
+  threadId,
 }: {
   url: string;
   kind: "html" | "pdf";
@@ -1560,6 +1850,7 @@ function ArtifactIframeBody({
   artifactKind?: ChatThreadArtifactFile["artifactKind"];
   htmlEditStatus?: "working";
   htmlPreviewHtml?: string;
+  threadId?: string;
 }) {
   // PDF Open Parameters: #navpanes=0 hides Chromium's built-in left rail
   // (thumbnails / bookmarks) so the embedded preview shows just the page
@@ -1585,6 +1876,11 @@ function ArtifactIframeBody({
     return (
       <div className="relative h-full w-full">
         <AutoFocusedArtifactIframe
+          // Remount on live<->draft switch: swapping `src`<->`srcDoc` on the
+          // same iframe doesn't reliably reload it, leaving the original showing.
+          // (draft->draft updates fine via the srcDoc attribute, so presence is
+          // the only transition that needs a fresh element.)
+          key={htmlPreviewHtml ? "draft" : "live"}
           focusKey={`${versionedSrc}:${fullscreen ? "fullscreen" : "sidebar"}`}
           focusOnMount={fullscreen && !isPresentationHtml}
           {...(htmlPreviewHtml
@@ -1600,11 +1896,15 @@ function ArtifactIframeBody({
           <HtmlEditDraftToolbar
             disabled={htmlEditStatus === "working"}
             onDiscard={() => {
-              discardHtmlDomEditPreviewDraft(url);
+              detach(
+                discardHtmlDomEditPreviewDraft({ threadId, url }, pageSignal),
+                Reason.DomCallback,
+                "discardHtmlDomEditPreviewDraft",
+              );
             }}
             onPublish={() => {
               detach(
-                publishHtmlDomEditPreviewDraft(url, pageSignal),
+                publishHtmlDomEditPreviewDraft({ threadId, url }, pageSignal),
                 Reason.DomCallback,
                 "publishHtmlDomEditPreviewDraft",
               );


### PR DESCRIPTION
## Summary

Front-end for resuming an in-progress HTML artifact edit as a **publishable preview**. The backend (endpoints, schema, migration) already landed on main via #19618; this PR adds the hosted-site UI on top of it.

- **Save on Send only** — after the agent returns a comment-based HTML draft, persist it fire-and-forget with captured `threadId`+`url`, so it lands even if the user navigates to another chat before the agent responds.
- **Detect + prefetch** — on opening a hosted-site artifact with a saved draft, fetch its `snapshotUrl` in the background and show a **Discard / Resume** dialog (Escape-dismissable).
- **Resume** applies the draft as a preview with the Publish/Discard toolbar, then deletes the snapshot; Publish/Discard also delete it.
- Remount the preview iframe when switching between the live URL and a draft (swapping `src`↔`srcDoc` doesn't reliably reload).

## Notes
- Content is fetched from `getHtmlEditSnapshot`'s `snapshotUrl` (CDN), aligning with main's backend (no separate content endpoint).
- Delete uses a per-key epoch + in-flight-save await so a racing save can't resurrect a just-deleted snapshot.

## Test plan
- `zero-artifact-sidebar` + `zero-attachment-chips` integration tests (save-on-send, detect→prefetch, resume→preview→publish, discard, dismiss). check-types / lint / knip green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)