### PR TITLE
feat: navigate human-uploaded images, not only agent artifacts

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -1295,6 +1295,85 @@ describe("zero attachment chips", () => {
     });
   });
 
+  it("navigates human-uploaded images that are not run artifacts", async () => {
+    const user = userEvent.setup({ delay: null });
+    const firstImageUrl =
+      "https://cdn.vm7.io/artifacts/test/user-image-navigation/first.png";
+    const secondImageUrl =
+      "https://cdn.vm7.io/artifacts/test/user-image-navigation/second.png";
+    // The images the user attached are NOT part of the thread's run artifacts;
+    // they resolve from the user artifacts bucket. Navigation must still work.
+    context.mocks.api(chatThreadArtifactsContract.list, ({ respond }) => {
+      return respond(200, { runs: [] });
+    });
+    mockChatLifecycle(context, {
+      threadId: THREAD_ID,
+      chatMessages: [
+        {
+          id: "msg-user-image-navigation",
+          role: "user",
+          content: "Here are my photos",
+          attachFiles: [
+            {
+              id: "user-first-image",
+              filename: "first.png",
+              contentType: "image/png",
+              size: 128,
+              url: firstImageUrl,
+            },
+            {
+              id: "user-second-image",
+              filename: "second.png",
+              contentType: "image/png",
+              size: 256,
+              url: secondImageUrl,
+            },
+          ],
+          runId: "run-user-image-navigation",
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ImageArtifactKeyboardNavigation]: true,
+      },
+    });
+
+    click(await screen.findByLabelText("Preview first.png"));
+    await waitFor(() => {
+      expect(screen.getByTestId("attachment-lightbox-image")).toHaveAttribute(
+        "alt",
+        "first.png",
+      );
+    });
+    expect(screen.queryByLabelText("Previous image artifact")).toBeNull();
+    expect(screen.getByLabelText("Next image artifact")).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText("Next image artifact"));
+    await waitFor(() => {
+      expect(screen.getByTestId("attachment-lightbox-image")).toHaveAttribute(
+        "alt",
+        "second.png",
+      );
+    });
+    expect(
+      screen.getByLabelText("Previous image artifact"),
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText("Next image artifact")).toBeNull();
+
+    fireEvent.keyDown(document, { key: "ArrowLeft" });
+    await waitFor(() => {
+      expect(screen.getByTestId("attachment-lightbox-image")).toHaveAttribute(
+        "alt",
+        "first.png",
+      );
+    });
+  });
+
   it("keeps the modal fullscreen state while navigating images", async () => {
     const user = userEvent.setup({ delay: null });
     const firstImageUrl =

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-image-navigation.ts
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-image-navigation.ts
@@ -8,8 +8,18 @@ import {
 } from "../../signals/chat-page/parse-body-blocks.ts";
 
 export type ImageArtifactNavigationItem = {
-  readonly file: ChatThreadArtifactFile;
-  readonly runId: string;
+  readonly url: string;
+  readonly filename: string;
+  /**
+   * Present when the image is a run artifact (agent-generated / hosted): carries
+   * the artifact file and its run so the lightbox keeps full download/share/sync
+   * metadata. Absent for human-uploaded images, which resolve from the user
+   * artifacts bucket and are not part of the thread's run artifacts.
+   */
+  readonly artifact?: {
+    readonly file: ChatThreadArtifactFile;
+    readonly runId: string;
+  };
 };
 
 export type ImageArtifactNavigation = {
@@ -46,48 +56,68 @@ function isImageDescriptor(descriptor: {
   );
 }
 
-// Matches a markdown image `![alt](url)`, allowing escaped characters in the
-// alt text. Agent-generated images render as markdown image lines rather than
-// dedicated preview blocks (see renderExtractedPreviewLine).
-const MARKDOWN_IMAGE_PATTERN = /!\[(?:\\.|[^\]\\])*\]\(([^)]+)\)/g;
+type MessageImage = {
+  readonly url: string;
+  readonly filename: string;
+};
 
-/** Ordered, de-duplicated image URLs shown in a single message. */
-function messageImageUrls(message: MessageImageSource): string[] {
-  const urls: string[] = [];
+// Matches a markdown image `![alt](url)`, capturing the alt (filename) and url
+// while allowing escaped characters in the alt text. Agent-generated images
+// render as markdown image lines rather than dedicated preview blocks (see
+// renderExtractedPreviewLine).
+const MARKDOWN_IMAGE_PATTERN = /!\[((?:\\.|[^\]\\])*)\]\(([^)]+)\)/g;
+
+function unescapeMarkdownAlt(alt: string): string {
+  return alt.replace(/\\([\]\\])/g, "$1");
+}
+
+function filenameFromImageUrl(url: string): string {
+  const path = url.split("?")[0].split("#")[0];
+  return path.split("/").pop() || "image";
+}
+
+/** Ordered, de-duplicated images (url + filename) shown in a single message. */
+function messageImages(message: MessageImageSource): MessageImage[] {
+  const images: MessageImage[] = [];
   const seen = new Set<string>();
-  const add = (url: string): void => {
+  const add = (url: string, filename: string): void => {
     if (!seen.has(url)) {
       seen.add(url);
-      urls.push(url);
+      images.push({ url, filename });
     }
   };
 
   for (const file of message.attachFiles ?? []) {
     if (isImageDescriptor(file)) {
-      add(file.url);
+      add(file.url, file.filename);
     }
   }
   for (const block of message.blocks ?? []) {
     if (block.type === "preview") {
       if (block.preview.kind === "image") {
-        add(block.preview.url);
+        add(block.preview.url, block.preview.filename);
       }
       continue;
     }
     if (block.type === "markdown") {
       for (const match of block.content.matchAll(MARKDOWN_IMAGE_PATTERN)) {
-        add(match[1]);
+        const url = match[2];
+        const alt = unescapeMarkdownAlt(match[1] ?? "");
+        add(url, alt || filenameFromImageUrl(url));
       }
     }
   }
-  return urls;
+  return images;
 }
 
 /**
- * Navigate image previews strictly within the images attached to the same chat
- * message as `currentUrl`. Generated/hosted artifacts that live in the run but
- * were not attached to the message are excluded. File metadata is sourced from
- * the run artifacts so the lightbox keeps download/share/sync capabilities.
+ * Navigate image previews strictly within the images shown in the same chat
+ * message as `currentUrl`. The message is the source of truth (both attached
+ * files and body-rendered images), so both human-uploaded and agent-generated
+ * images navigate. Run artifacts only enrich metadata when available; images
+ * that are not run artifacts (human uploads) still navigate with url + filename.
+ * Generated/hosted artifacts that live in the run but are not shown in the
+ * message are excluded.
  */
 export function currentMessageImageArtifactNavigation(
   runs: readonly ChatThreadArtifactRun[],
@@ -95,14 +125,19 @@ export function currentMessageImageArtifactNavigation(
   currentUrl: string,
 ): ImageArtifactNavigation {
   const message = messages.find((candidate) => {
-    return messageImageUrls(candidate).includes(currentUrl);
+    return messageImages(candidate).some((image) => {
+      return image.url === currentUrl;
+    });
   });
 
   if (!message) {
     return {};
   }
 
-  const artifactByUrl = new Map<string, ImageArtifactNavigationItem>();
+  const artifactByUrl = new Map<
+    string,
+    { file: ChatThreadArtifactFile; runId: string }
+  >();
   for (const run of runs) {
     for (const file of run.files) {
       if (!artifactByUrl.has(file.url)) {
@@ -111,15 +146,21 @@ export function currentMessageImageArtifactNavigation(
     }
   }
 
-  const images = messageImageUrls(message)
-    .map((url) => {
-      return artifactByUrl.get(url);
-    })
-    .filter((item): item is ImageArtifactNavigationItem => {
-      return item !== undefined;
-    });
+  const images: ImageArtifactNavigationItem[] = messageImages(message).map(
+    (image) => {
+      const artifact = artifactByUrl.get(image.url);
+      if (artifact) {
+        return {
+          url: image.url,
+          filename: artifact.file.filename,
+          artifact,
+        };
+      }
+      return { url: image.url, filename: image.filename };
+    },
+  );
   const currentIndex = images.findIndex((item) => {
-    return item.file.url === currentUrl;
+    return item.url === currentUrl;
   });
 
   if (currentIndex === -1) {

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -193,7 +193,7 @@ function ArtifactSidebarWithThreadData({
       return undefined;
     }
     return () => {
-      navigateArtifactSidebarImage(navigationItem.file.url);
+      navigateArtifactSidebarImage(navigationItem.url);
     };
   };
 

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -960,16 +960,18 @@ function ArtifactPreviewDialogThreadResolver({
     navigationItem: ImageArtifactNavigationItem,
   ) => {
     navigateImageLightbox({
-      artifact: artifactDialogMetadataFromItem({
-        agentId,
-        item: navigationItem,
-        onSyncSuccess: () => {
-          reloadArtifacts();
-        },
-        threadId: thread.threadId,
-      }),
-      filename: navigationItem.file.filename,
-      url: navigationItem.file.url,
+      artifact: navigationItem.artifact
+        ? artifactDialogMetadataFromItem({
+            agentId,
+            item: navigationItem.artifact,
+            onSyncSuccess: () => {
+              reloadArtifacts();
+            },
+            threadId: thread.threadId,
+          })
+        : undefined,
+      filename: navigationItem.filename,
+      url: navigationItem.url,
     });
   };
   const imageNavigationAction = (
@@ -1012,9 +1014,16 @@ function ArtifactPreviewDialogThreadResolver({
     );
   }
 
+  // The previewed image is not a run artifact (e.g. a human-uploaded image that
+  // resolves from the user artifacts bucket). It still navigates among the other
+  // images in its message.
   return (
     <ArtifactPreviewDialogContent
       artifact={preview.artifact}
+      imageNavigation={{
+        onNext: imageNavigationAction(imageNavigation.next),
+        onPrevious: imageNavigationAction(imageNavigation.previous),
+      }}
       preview={preview}
     />
   );


### PR DESCRIPTION
Follow-up to #19694, implementing #19739.

The image keyboard/button navigation shipped in #19694 only appeared for **agent-generated** images. Human-user-sent messages with multiple attached images had no switch controls, because the nav helper resolved every image against `thread.artifacts$` (run artifacts) for metadata — and human uploads resolve from the user artifacts bucket, so they were dropped.

## Change
Make the **chat message the source of truth** for the image set and treat run artifacts as optional metadata enrichment.

- `ImageArtifactNavigationItem` now carries `{ url, filename, artifact? }`; `artifact` (file + runId) is populated only when the image is a run artifact.
- The lightbox modal opens siblings with full artifact metadata when available and falls back to `url + filename` otherwise (parity with how these images already open). The non-artifact render branch now also receives `imageNavigation`.
- Sidebar caller updated for the new item shape (user images don't use the sidebar, so no behavior change there).

## Feature switch
Same existing switch — `FeatureSwitchKey.ImageArtifactKeyboardNavigation`. No new flag. Enabling it turns on navigation for both agent-generated and human-uploaded images.

## Tests
- New: `navigates human-uploaded images that are not run artifacts` — user `attachFiles` **not** seeded into `artifacts$`, asserting nav cycles them (prev/next, boundaries).
- Existing agent-image, fullscreen-preservation, focus, modal-owns-arrows, and feature-switch-off tests still pass (60 total).

Closes #19739

🤖 Generated with [Claude Code](https://claude.com/claude-code)