### PR TITLE
fix: block Intel Mac Computer Use downloads

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/computer-use-hosts.ts
+++ b/turbo/apps/platform/src/signals/zero-page/computer-use-hosts.ts
@@ -7,7 +7,7 @@ import { accept } from "../../lib/accept.ts";
 import { resolveApiBaseForNavigation } from "../api-base.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { setAblyLoop$ } from "../realtime.ts";
-import { onRef } from "../utils.ts";
+import { onRef, settle } from "../utils.ts";
 
 const ZERO_DESKTOP_DMG_DOWNLOAD_PATH =
   "/api/zero/desktop/updates/stable/darwin/arm64/dmg";
@@ -16,6 +16,86 @@ export const ZERO_DESKTOP_DOWNLOAD_URL = new URL(
   ZERO_DESKTOP_DMG_DOWNLOAD_PATH,
   resolveApiBaseForNavigation("api"),
 ).toString();
+
+export const ZERO_DESKTOP_APPLE_SILICON_REQUIREMENT =
+  "Zero Computer Use currently supports Apple Silicon Macs only.";
+
+export type ZeroDesktopDownloadSupportStatus =
+  | "available"
+  | "unsupported-intel-mac";
+
+interface UserAgentDataValues {
+  readonly architecture?: string;
+  readonly platform?: string;
+}
+
+interface ZeroDesktopNavigator {
+  readonly platform?: string;
+  readonly userAgent?: string;
+  readonly userAgentData?: {
+    readonly platform?: string;
+    readonly getHighEntropyValues?: (
+      hints: readonly string[],
+    ) => Promise<UserAgentDataValues>;
+  };
+}
+
+function isMacPlatform(
+  platform: string | undefined,
+  userAgent: string | undefined,
+): boolean {
+  return (
+    Boolean(platform?.toLowerCase().includes("mac")) ||
+    /Macintosh/i.test(userAgent ?? "")
+  );
+}
+
+function isIntelArchitecture(architecture: string | undefined): boolean {
+  const normalized = architecture?.toLowerCase();
+  return (
+    normalized === "x86" ||
+    normalized === "x86_64" ||
+    normalized === "amd64" ||
+    normalized === "ia32"
+  );
+}
+
+export async function isUnsupportedIntelMacForZeroDesktop(
+  navigatorRef: ZeroDesktopNavigator | null | undefined = typeof navigator ===
+  "undefined"
+    ? undefined
+    : navigator,
+): Promise<boolean> {
+  const userAgentData = navigatorRef?.userAgentData;
+  if (!navigatorRef || !userAgentData?.getHighEntropyValues) {
+    return false;
+  }
+
+  const highEntropyValuesResult = await settle(
+    userAgentData.getHighEntropyValues(["architecture", "platform"]),
+  );
+  if (!highEntropyValuesResult.ok) {
+    return false;
+  }
+  const highEntropyValues = highEntropyValuesResult.value;
+
+  const platform =
+    highEntropyValues.platform ??
+    userAgentData.platform ??
+    navigatorRef.platform;
+  return (
+    isMacPlatform(platform, navigatorRef.userAgent) &&
+    isIntelArchitecture(highEntropyValues.architecture)
+  );
+}
+
+export const zeroDesktopDownloadSupportStatus$ = computed(
+  async (): Promise<ZeroDesktopDownloadSupportStatus> => {
+    return (await isUnsupportedIntelMacForZeroDesktop())
+      ? "unsupported-intel-mac"
+      : "available";
+  },
+);
 
 const computerUseHostsReload$ = state(0);
 

--- a/turbo/apps/platform/src/signals/zero-page/computer-use-hosts.ts
+++ b/turbo/apps/platform/src/signals/zero-page/computer-use-hosts.ts
@@ -17,8 +17,8 @@ export const ZERO_DESKTOP_DOWNLOAD_URL = new URL(
   resolveApiBaseForNavigation("api"),
 ).toString();
 
-export const ZERO_DESKTOP_APPLE_SILICON_REQUIREMENT =
-  "Zero Computer Use currently supports Apple Silicon Macs only.";
+export const ZERO_DESKTOP_UNSUPPORTED_INTEL_MAC_LABEL =
+  "Requires Apple Silicon Mac";
 
 export type ZeroDesktopDownloadSupportStatus =
   | "available"

--- a/turbo/apps/platform/src/views/computer-use-authorization/__tests__/computer-use-authorization-page.test.tsx
+++ b/turbo/apps/platform/src/views/computer-use-authorization/__tests__/computer-use-authorization-page.test.tsx
@@ -11,6 +11,62 @@ import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 
 const context = testContext();
 
+function replaceNavigatorProperty(property: string, value: unknown): void {
+  const descriptor = Object.getOwnPropertyDescriptor(navigator, property);
+  Object.defineProperty(navigator, property, {
+    configurable: true,
+    value,
+  });
+  context.signal.addEventListener(
+    "abort",
+    () => {
+      if (descriptor) {
+        Object.defineProperty(navigator, property, descriptor);
+        return;
+      }
+      Reflect.deleteProperty(navigator, property);
+    },
+    { once: true },
+  );
+}
+
+function mockMacUserAgentData(architecture: string): void {
+  replaceNavigatorProperty("userAgentData", {
+    platform: "macOS",
+    getHighEntropyValues: () => {
+      return Promise.resolve({ architecture, platform: "macOS" });
+    },
+  });
+}
+
+function linkByText(text: string): HTMLElement {
+  const link = queryAllByRoleFast("link").find((candidate) => {
+    return candidate.textContent?.replace(/\s+/g, " ").trim() === text;
+  });
+  if (!link) {
+    throw new Error(`${text} link not found`);
+  }
+  return link;
+}
+
+function queryLinkByText(text: string): HTMLElement | null {
+  return (
+    queryAllByRoleFast("link").find((candidate) => {
+      return candidate.textContent?.replace(/\s+/g, " ").trim() === text;
+    }) ?? null
+  );
+}
+
+function buttonByText(text: string): HTMLElement {
+  const button = queryAllByRoleFast("button").find((candidate) => {
+    return candidate.textContent?.replace(/\s+/g, " ").trim() === text;
+  });
+  if (!button) {
+    throw new Error(`${text} button not found`);
+  }
+  return button;
+}
+
 function computerUsePermissions() {
   return {
     accessibility: true,
@@ -166,8 +222,13 @@ describe("computer use authorization page", () => {
         "Open Zero Computer Use on your Mac and refresh this page when it comes online.",
       ),
     ).toBeInTheDocument();
-    const downloadLink = queryAllByRoleFast("link").find((link) => {
-      return link.textContent === "Download for macOS";
+    expect(
+      screen.getByText(
+        "Zero Computer Use currently supports Apple Silicon Macs only.",
+      ),
+    ).toBeInTheDocument();
+    const downloadLink = await waitFor(() => {
+      return linkByText("Download for macOS");
     });
     expect(downloadLink).toHaveAttribute(
       "href",
@@ -176,5 +237,35 @@ describe("computer use authorization page", () => {
       ),
     );
     expect(screen.queryByText("Offline Desktop")).not.toBeInTheDocument();
+  });
+
+  it("blocks the desktop download when the browser identifies an Intel Mac", async () => {
+    mockMacUserAgentData("x86");
+    context.mocks.api(
+      zeroComputerUseAuthorizationRequestsContract.get,
+      ({ respond }) => {
+        return respond(200, {
+          source: "slack",
+          expiresAt: "2026-06-25T12:00:00Z",
+          completedAt: null,
+          computerUseHostId: null,
+          hosts: [],
+        });
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/computer-use/authorize/vm0_computer_use_authorization_request_intel",
+    });
+
+    await expect(
+      screen.findByText("No online computers"),
+    ).resolves.toBeInTheDocument();
+    const requiredButton = await waitFor(() => {
+      return buttonByText("Apple Silicon Mac required");
+    });
+    expect(requiredButton).toBeDisabled();
+    expect(queryLinkByText("Download for macOS")).not.toBeInTheDocument();
   });
 });

--- a/turbo/apps/platform/src/views/computer-use-authorization/__tests__/computer-use-authorization-page.test.tsx
+++ b/turbo/apps/platform/src/views/computer-use-authorization/__tests__/computer-use-authorization-page.test.tsx
@@ -222,11 +222,6 @@ describe("computer use authorization page", () => {
         "Open Zero Computer Use on your Mac and refresh this page when it comes online.",
       ),
     ).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        "Zero Computer Use currently supports Apple Silicon Macs only.",
-      ),
-    ).toBeInTheDocument();
     const downloadLink = await waitFor(() => {
       return linkByText("Download for macOS");
     });
@@ -263,7 +258,7 @@ describe("computer use authorization page", () => {
       screen.findByText("No online computers"),
     ).resolves.toBeInTheDocument();
     const requiredButton = await waitFor(() => {
-      return buttonByText("Apple Silicon Mac required");
+      return buttonByText("Requires Apple Silicon Mac");
     });
     expect(requiredButton).toBeDisabled();
     expect(queryLinkByText("Download for macOS")).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/computer-use-authorization/computer-use-authorization-page.tsx
+++ b/turbo/apps/platform/src/views/computer-use-authorization/computer-use-authorization-page.tsx
@@ -1,6 +1,7 @@
 import { useGet, useLoadable } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import {
+  IconAlertTriangle,
   IconCheck,
   IconDeviceDesktop,
   IconDownload,
@@ -13,6 +14,8 @@ import {
   computerUseAuthorizationRequest$,
 } from "../../signals/computer-use-authorization/computer-use-authorization.ts";
 import {
+  ZERO_DESKTOP_APPLE_SILICON_REQUIREMENT,
+  zeroDesktopDownloadSupportStatus$,
   visibleComputerUseHosts,
   ZERO_DESKTOP_DOWNLOAD_URL,
 } from "../../signals/zero-page/computer-use-hosts.ts";
@@ -82,6 +85,14 @@ function HostOption({
 }
 
 function EmptyHosts() {
+  const downloadSupportLoadable = useLoadable(
+    zeroDesktopDownloadSupportStatus$,
+  );
+  const downloadSupportStatus =
+    downloadSupportLoadable.state === "hasData"
+      ? downloadSupportLoadable.data
+      : "checking";
+
   return (
     <div className="flex flex-col items-center gap-4 rounded-lg border border-border bg-muted/30 px-4 py-6 text-center">
       <div className="flex h-24 w-24 items-center justify-center">
@@ -99,16 +110,30 @@ function EmptyHosts() {
           Open Zero Computer Use on your Mac and refresh this page when it comes
           online.
         </p>
+        <p className="text-xs leading-4 text-muted-foreground">
+          {ZERO_DESKTOP_APPLE_SILICON_REQUIREMENT}
+        </p>
       </div>
-      <a
-        href={ZERO_DESKTOP_DOWNLOAD_URL}
-        target="_blank"
-        rel="noreferrer"
-        className="inline-flex h-9 items-center justify-center gap-2 rounded-lg border border-border bg-background px-3 text-sm font-medium text-foreground transition-colors hover:bg-accent"
-      >
-        <IconDownload size={16} />
-        Download for macOS
-      </a>
+      {downloadSupportStatus === "unsupported-intel-mac" ? (
+        <Button type="button" variant="outline" disabled className="h-9">
+          <IconAlertTriangle size={16} />
+          Apple Silicon Mac required
+        </Button>
+      ) : downloadSupportStatus === "checking" ? (
+        <Button type="button" variant="outline" disabled className="h-9">
+          Checking compatibility
+        </Button>
+      ) : (
+        <a
+          href={ZERO_DESKTOP_DOWNLOAD_URL}
+          target="_blank"
+          rel="noreferrer"
+          className="inline-flex h-9 items-center justify-center gap-2 rounded-lg border border-border bg-background px-3 text-sm font-medium text-foreground transition-colors hover:bg-accent"
+        >
+          <IconDownload size={16} />
+          Download for macOS
+        </a>
+      )}
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/computer-use-authorization/computer-use-authorization-page.tsx
+++ b/turbo/apps/platform/src/views/computer-use-authorization/computer-use-authorization-page.tsx
@@ -14,10 +14,10 @@ import {
   computerUseAuthorizationRequest$,
 } from "../../signals/computer-use-authorization/computer-use-authorization.ts";
 import {
-  ZERO_DESKTOP_APPLE_SILICON_REQUIREMENT,
   zeroDesktopDownloadSupportStatus$,
   visibleComputerUseHosts,
   ZERO_DESKTOP_DOWNLOAD_URL,
+  ZERO_DESKTOP_UNSUPPORTED_INTEL_MAC_LABEL,
 } from "../../signals/zero-page/computer-use-hosts.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
@@ -110,14 +110,11 @@ function EmptyHosts() {
           Open Zero Computer Use on your Mac and refresh this page when it comes
           online.
         </p>
-        <p className="text-xs leading-4 text-muted-foreground">
-          {ZERO_DESKTOP_APPLE_SILICON_REQUIREMENT}
-        </p>
       </div>
       {downloadSupportStatus === "unsupported-intel-mac" ? (
         <Button type="button" variant="outline" disabled className="h-9">
           <IconAlertTriangle size={16} />
-          Apple Silicon Mac required
+          {ZERO_DESKTOP_UNSUPPORTED_INTEL_MAC_LABEL}
         </Button>
       ) : downloadSupportStatus === "checking" ? (
         <Button type="button" variant="outline" disabled className="h-9">

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -5596,11 +5596,6 @@ describe("chat lifecycle", () => {
         "So Zero can work in your browser and apps for you, even ones with no connector like LinkedIn or Reddit.",
       ),
     ).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        "Zero Computer Use currently supports Apple Silicon Macs only.",
-      ),
-    ).toBeInTheDocument();
     const downloadLink = await waitFor(() => {
       return linkByText("Download for macOS");
     });
@@ -5630,7 +5625,7 @@ describe("chat lifecycle", () => {
     await user.click(await screen.findByText("Connect my computer"));
 
     const requiredButton = await waitFor(() => {
-      return buttonByText("Apple Silicon Mac required");
+      return buttonByText("Requires Apple Silicon Mac");
     });
     expect(requiredButton).toBeDisabled();
     expect(queryLinkByText("Download for macOS")).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -68,6 +68,34 @@ const FOLLOWUP_THREAD_ID = "b0000000-0000-4000-a000-000000000704";
 const HISTORY_THREAD_ID = "b0000000-0000-4000-a000-000000000705";
 const AGENT_CHAT_PATH = `/agents/${AGENT_ID}/chat`;
 
+function replaceNavigatorProperty(property: string, value: unknown): void {
+  const descriptor = Object.getOwnPropertyDescriptor(navigator, property);
+  Object.defineProperty(navigator, property, {
+    configurable: true,
+    value,
+  });
+  context.signal.addEventListener(
+    "abort",
+    () => {
+      if (descriptor) {
+        Object.defineProperty(navigator, property, descriptor);
+        return;
+      }
+      Reflect.deleteProperty(navigator, property);
+    },
+    { once: true },
+  );
+}
+
+function mockMacUserAgentData(architecture: string): void {
+  replaceNavigatorProperty("userAgentData", {
+    platform: "macOS",
+    getHighEntropyValues: () => {
+      return Promise.resolve({ architecture, platform: "macOS" });
+    },
+  });
+}
+
 function computerUsePermissions() {
   return {
     accessibility: true,
@@ -839,6 +867,14 @@ function linkByText(text: string): HTMLElement {
     throw new Error(`${text} link not found`);
   }
   return link;
+}
+
+function queryLinkByText(text: string): HTMLElement | null {
+  return (
+    queryAllByRoleFast("link").find((candidate) => {
+      return candidate.textContent?.replace(/\s+/g, " ").trim() === text;
+    }) ?? null
+  );
 }
 
 function queryButtonByText(text: string): HTMLElement | null {
@@ -5560,12 +5596,44 @@ describe("chat lifecycle", () => {
         "So Zero can work in your browser and apps for you, even ones with no connector like LinkedIn or Reddit.",
       ),
     ).toBeInTheDocument();
-    expect(linkByText("Download for macOS")).toHaveAttribute(
+    expect(
+      screen.getByText(
+        "Zero Computer Use currently supports Apple Silicon Macs only.",
+      ),
+    ).toBeInTheDocument();
+    const downloadLink = await waitFor(() => {
+      return linkByText("Download for macOS");
+    });
+    expect(downloadLink).toHaveAttribute(
       "href",
       expect.stringContaining(
         "/api/zero/desktop/updates/stable/darwin/arm64/dmg",
       ),
     );
+  });
+
+  it("blocks the Computer Use download dialog on Intel Macs", async () => {
+    mockMacUserAgentData("x86");
+    const user = userEvent.setup({ delay: null });
+    const threadId = "computer-use-download-intel";
+    mockChatLifecycle(context, { threadId });
+    context.mocks.api(zeroComputerUseHostsContract.list, ({ respond }) => {
+      return respond(200, { hosts: [] });
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+    });
+
+    await user.click(await screen.findByLabelText("Connectors"));
+    await user.click(await screen.findByText("Connect my computer"));
+
+    const requiredButton = await waitFor(() => {
+      return buttonByText("Apple Silicon Mac required");
+    });
+    expect(requiredButton).toBeDisabled();
+    expect(queryLinkByText("Download for macOS")).not.toBeInTheDocument();
   });
 
   it("does not auto-select the only online Computer Use host", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -154,8 +154,8 @@ import { pageSignal$ } from "../../signals/page-signal.ts";
 import { rootSignal$ } from "../../signals/root-signal.ts";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import {
-  ZERO_DESKTOP_APPLE_SILICON_REQUIREMENT,
   zeroDesktopDownloadSupportStatus$,
+  ZERO_DESKTOP_UNSUPPORTED_INTEL_MAC_LABEL,
 } from "../../signals/zero-page/computer-use-hosts.ts";
 import {
   zeroAuthorizedConnectors$,
@@ -5844,21 +5844,16 @@ function ComputerUseDownloadDialog({
           <DialogTitle className="text-xl leading-7">
             Let Zero use your computer
           </DialogTitle>
-          <DialogDescription className="flex flex-col gap-2 leading-6">
-            <span>
-              So Zero can work in your browser and apps for you, even ones with
-              no connector like LinkedIn or Reddit.
-            </span>
-            <span className="text-xs leading-4">
-              {ZERO_DESKTOP_APPLE_SILICON_REQUIREMENT}
-            </span>
+          <DialogDescription className="leading-6">
+            So Zero can work in your browser and apps for you, even ones with no
+            connector like LinkedIn or Reddit.
           </DialogDescription>
         </DialogHeader>
         <div className="px-6 pb-6 pt-4">
           {downloadSupportStatus === "unsupported-intel-mac" ? (
             <Button type="button" size="lg" className="w-full" disabled>
               <IconAlertTriangle size={16} stroke={1.5} />
-              Apple Silicon Mac required
+              {ZERO_DESKTOP_UNSUPPORTED_INTEL_MAC_LABEL}
             </Button>
           ) : downloadSupportStatus === "checking" ? (
             <Button type="button" size="lg" className="w-full" disabled>

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -154,6 +154,10 @@ import { pageSignal$ } from "../../signals/page-signal.ts";
 import { rootSignal$ } from "../../signals/root-signal.ts";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import {
+  ZERO_DESKTOP_APPLE_SILICON_REQUIREMENT,
+  zeroDesktopDownloadSupportStatus$,
+} from "../../signals/zero-page/computer-use-hosts.ts";
+import {
   zeroAuthorizedConnectors$,
   authorizeConnector$,
   deauthorizeConnector$,
@@ -5818,6 +5822,14 @@ function ComputerUseDownloadDialog({
   onOpenChange: (open: boolean) => void;
   downloadUrl: string;
 }) {
+  const downloadSupportLoadable = useLoadable(
+    zeroDesktopDownloadSupportStatus$,
+  );
+  const downloadSupportStatus =
+    downloadSupportLoadable.state === "hasData"
+      ? downloadSupportLoadable.data
+      : "checking";
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-md gap-0 overflow-hidden p-0">
@@ -5832,25 +5844,41 @@ function ComputerUseDownloadDialog({
           <DialogTitle className="text-xl leading-7">
             Let Zero use your computer
           </DialogTitle>
-          <DialogDescription className="leading-6">
-            So Zero can work in your browser and apps for you, even ones with no
-            connector like LinkedIn or Reddit.
+          <DialogDescription className="flex flex-col gap-2 leading-6">
+            <span>
+              So Zero can work in your browser and apps for you, even ones with
+              no connector like LinkedIn or Reddit.
+            </span>
+            <span className="text-xs leading-4">
+              {ZERO_DESKTOP_APPLE_SILICON_REQUIREMENT}
+            </span>
           </DialogDescription>
         </DialogHeader>
         <div className="px-6 pb-6 pt-4">
-          <Button asChild size="lg" className="w-full">
-            <a
-              href={downloadUrl}
-              target="_blank"
-              rel="noreferrer"
-              onClick={() => {
-                onOpenChange(false);
-              }}
-            >
-              <IconDownload size={16} stroke={1.5} />
-              Download for macOS
-            </a>
-          </Button>
+          {downloadSupportStatus === "unsupported-intel-mac" ? (
+            <Button type="button" size="lg" className="w-full" disabled>
+              <IconAlertTriangle size={16} stroke={1.5} />
+              Apple Silicon Mac required
+            </Button>
+          ) : downloadSupportStatus === "checking" ? (
+            <Button type="button" size="lg" className="w-full" disabled>
+              Checking compatibility
+            </Button>
+          ) : (
+            <Button asChild size="lg" className="w-full">
+              <a
+                href={downloadUrl}
+                target="_blank"
+                rel="noreferrer"
+                onClick={() => {
+                  onOpenChange(false);
+                }}
+              >
+                <IconDownload size={16} stroke={1.5} />
+                Download for macOS
+              </a>
+            </Button>
+          )}
         </div>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
## Summary
- add a shared best-effort Apple Silicon support signal for the Zero Computer Use desktop download
- block direct macOS DMG downloads when Client Hints identify an Intel Mac
- show a concise disabled CTA instead of the macOS DMG link for unsupported Intel Macs

Closes #19742

## Verification
- pnpm exec prettier --write apps/platform/src/signals/zero-page/computer-use-hosts.ts apps/platform/src/views/computer-use-authorization/computer-use-authorization-page.tsx apps/platform/src/views/zero-page/zero-chat-composer.tsx apps/platform/src/views/computer-use-authorization/__tests__/computer-use-authorization-page.test.tsx apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
- pnpm exec oxlint src/signals/zero-page/computer-use-hosts.ts src/views/computer-use-authorization/computer-use-authorization-page.tsx src/views/computer-use-authorization/__tests__/computer-use-authorization-page.test.tsx src/views/zero-page/zero-chat-composer.tsx src/views/zero-page/__tests__/chat-lifecycle.test.tsx
- pnpm exec eslint src/signals/zero-page/computer-use-hosts.ts src/views/computer-use-authorization/computer-use-authorization-page.tsx src/views/computer-use-authorization/__tests__/computer-use-authorization-page.test.tsx src/views/zero-page/zero-chat-composer.tsx src/views/zero-page/__tests__/chat-lifecycle.test.tsx --max-warnings 0
- pnpm -F @vm0/app check-types
- pnpm exec vitest run src/views/computer-use-authorization/__tests__/computer-use-authorization-page.test.tsx --reporter=verbose --testTimeout=15000
- pnpm exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx --testNamePattern "Computer Use download" --reporter=verbose --testTimeout=15000