### PR TITLE
fix: expose runner session ids in diagnostics

### DIFF
--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -71,7 +71,6 @@ pub(super) async fn execute_codex_app_server_for_runtime(
     active_input: ActiveInputWriter,
     runtime: &CliRuntimeConfig<'_>,
 ) -> Result<CliExecutionResult, AgentError> {
-    masker.add_sensitive_value(runtime.resume_session_id.as_ref());
     log_info!(LOG_TAG, "Starting codex app-server execution...");
 
     let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel::<PreparedEvent>();
@@ -148,9 +147,6 @@ async fn run_codex_app_server(
     let mut log_file = tokio::fs::File::from_std(log_file);
     let mut ingestor = CliEventIngestor::new(runtime);
     let resume_thread_id = resume_thread_id_from_runtime(runtime)?;
-    if let Some(resume_thread_id) = &resume_thread_id {
-        masker.add_sensitive_value(resume_thread_id);
-    }
     let mut client = CodexAppServerClient::spawn(codex_app_server_config(runtime))
         .map_err(|error| app_server_error(masker, error))?;
     let mut heartbeat_done = false;

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -387,15 +387,13 @@ impl CliEventIngestor {
         Self::write_raw_line(log_file, raw_line).await;
 
         if event.get("type").and_then(serde_json::Value::as_str) == Some("stream_event") {
-            self.session_metadata_capture
-                .register_event_session_identifier(event, masker);
             return Ok(ParsedEventAction::Skip);
         }
         self.last_read_event_at = Some(Instant::now());
         if self.seq == 0 {
             timing::record_e2e_from_api_start("api_to_cli_init", &self.api_start_time);
         }
-        self.session_metadata_capture.capture_event(event, masker);
+        self.session_metadata_capture.capture_event(event);
 
         if behavior.logs_codex_failure_diagnostics()
             && let Some(diagnostic) = events::masked_codex_failure_diagnostic(event, masker)
@@ -503,7 +501,6 @@ async fn execute_cli_inner(
 
     let behavior = CliFrameworkBehavior::new(runtime.framework);
     let replay_user_messages = active_input.is_enabled();
-    masker.add_sensitive_value(runtime.resume_session_id.as_ref());
     log_info!(LOG_TAG, "Starting {} execution...", behavior.agent_type());
 
     let cmd = command::build_cli_command_for_runtime(runtime, replay_user_messages)?;

--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -48,13 +48,13 @@ pub async fn send_event_for_config(
     config: &GuestConfig,
     paths: &paths::GuestPaths,
 ) -> Result<(), AgentError> {
-    let mut capture = SessionMetadataCapture::from_values(
+    let capture = SessionMetadataCapture::from_values(
         config.framework,
         &config.home_dir,
         paths.session_id_file(),
         paths.session_history_path_file(),
     );
-    capture.capture_event(&event, masker);
+    capture.capture_event(&event);
 
     if !http.has_api() {
         return Ok(());
@@ -480,9 +480,7 @@ pub(crate) fn extract_claude_tool_info(event: &Value) -> Vec<ClaudeToolEvent<'_>
 /// - Claude Code: `{type: system, subtype: init, session_id: <uuid>}`
 /// - Codex:       `{type: thread.started, thread_id: <uuid>}`
 ///
-/// Ordinary events only seed the masker from an existing session id once; they
-/// do not repair the history marker. Checkpoint resolves missing markers when
-/// it consumes session metadata.
+/// Checkpoint resolves missing markers when it consumes session metadata.
 ///
 /// The on-disk format of `session_history_path_file()` differs by framework:
 /// - Claude: literal `~/.claude/projects/-{cwd}/{session_id}.jsonl` path.
@@ -490,7 +488,6 @@ pub(crate) fn extract_claude_tool_info(event: &Value) -> Vec<ClaudeToolEvent<'_>
 ///   marker — codex doesn't write the session file until turn-completion, so
 ///   resolution is deferred to checkpoint time.
 pub(crate) struct SessionMetadataCapture {
-    existing_session_id_seeded: bool,
     framework: Framework,
     home_dir: String,
     session_id_file: String,
@@ -505,7 +502,6 @@ impl SessionMetadataCapture {
         session_history_path_file: &str,
     ) -> Self {
         Self {
-            existing_session_id_seeded: false,
             framework,
             home_dir: home_dir.to_string(),
             session_id_file: session_id_file.to_string(),
@@ -513,15 +509,12 @@ impl SessionMetadataCapture {
         }
     }
 
-    pub(crate) fn capture_event(&mut self, event: &Value, masker: &SecretMasker) {
-        self.register_event_session_identifier(event, masker);
-
+    pub(crate) fn capture_event(&self, event: &Value) {
         let session_id = match self.framework {
             Framework::ClaudeCode => extract_claude_session_id(event),
             Framework::Codex => extract_codex_thread_id(event),
         };
         let Some(session_id) = session_id else {
-            self.seed_existing_session_id(masker);
             return;
         };
         let Some(history_path_payload) =
@@ -531,10 +524,8 @@ impl SessionMetadataCapture {
                 &session_id,
             )
         else {
-            self.seed_existing_session_id(masker);
             return;
         };
-        masker.add_sensitive_value(&session_id);
 
         // Idempotency: only the first id-bearing event of the run wins, but allow
         // a retry of the same session to repair a missing history marker after a
@@ -542,10 +533,6 @@ impl SessionMetadataCapture {
         match std::fs::read_to_string(&self.session_id_file) {
             Ok(existing_session_id) => {
                 let existing_session_id = existing_session_id.trim();
-                if !existing_session_id.is_empty() {
-                    masker.add_sensitive_value(existing_session_id);
-                    self.existing_session_id_seeded = true;
-                }
                 if existing_session_id == session_id {
                     session_metadata::ensure_history_marker_payload_at(
                         &self.session_history_path_file,
@@ -574,51 +561,10 @@ impl SessionMetadataCapture {
                 self.session_id_file
             ),
         }
-        self.existing_session_id_seeded = true;
         session_metadata::write_session_history_marker_at(
             &self.session_history_path_file,
             &history_path_payload,
         );
-    }
-
-    pub(crate) fn register_event_session_identifier(&self, event: &Value, masker: &SecretMasker) {
-        register_event_session_identifier_for_framework(event, masker, self.framework);
-    }
-
-    fn seed_existing_session_id(&mut self, masker: &SecretMasker) {
-        if self.existing_session_id_seeded {
-            return;
-        }
-        self.existing_session_id_seeded = true;
-
-        match std::fs::read_to_string(&self.session_id_file) {
-            Ok(session_id) => {
-                let session_id = session_id.trim();
-                if !session_id.is_empty() {
-                    masker.add_sensitive_value(session_id);
-                }
-            }
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-            Err(e) => log_error!(
-                LOG_TAG,
-                "Failed to read existing session ID from {}: {e}",
-                self.session_id_file
-            ),
-        }
-    }
-}
-
-fn register_event_session_identifier_for_framework(
-    event: &Value,
-    masker: &SecretMasker,
-    framework: Framework,
-) {
-    let id = match framework {
-        Framework::ClaudeCode => string_field(event, "session_id"),
-        Framework::Codex => string_field(event, "thread_id"),
-    };
-    if let Some(id) = id {
-        masker.add_sensitive_value(id);
     }
 }
 

--- a/crates/guest-agent/src/masker.rs
+++ b/crates/guest-agent/src/masker.rs
@@ -31,7 +31,6 @@ struct MaskerState {
     diagnostic_patterns: Vec<String>,
     url_encoded_patterns: Vec<String>,
     diagnostic_url_encoded_patterns: Vec<String>,
-    registered_values: HashSet<String>,
 }
 
 struct Matcher {
@@ -57,24 +56,22 @@ impl SecretMasker {
 
         // Parse comma-separated base64 values
         let engine = base64::engine::general_purpose::STANDARD;
-        let secrets: Vec<String> = raw
-            .split(',')
-            .filter_map(|part| {
-                let trimmed = part.trim();
-                if trimmed.is_empty() {
-                    return None;
-                }
-                engine
-                    .decode(trimmed)
-                    .ok()
-                    .and_then(|bytes| String::from_utf8(bytes).ok())
-            })
-            .filter(|s| !s.is_empty())
-            .collect();
-
         let mut state = MaskerState::empty();
-        for secret in &secrets {
-            state.add_secret_value_patterns(secret);
+        let mut seen_secrets = HashSet::new();
+        for secret in raw.split(',').filter_map(|part| {
+            let trimmed = part.trim();
+            if trimmed.is_empty() {
+                return None;
+            }
+            engine
+                .decode(trimmed)
+                .ok()
+                .and_then(|bytes| String::from_utf8(bytes).ok())
+                .filter(|value| !value.is_empty())
+        }) {
+            if seen_secrets.insert(secret.clone()) {
+                state.add_secret_value_patterns(&secret);
+            }
         }
         state.rebuild_matchers();
         Self::from_state(state)
@@ -178,7 +175,6 @@ impl MaskerState {
             diagnostic_patterns: Vec::new(),
             url_encoded_patterns: Vec::new(),
             diagnostic_url_encoded_patterns: Vec::new(),
-            registered_values: HashSet::new(),
         }
     }
 
@@ -198,15 +194,14 @@ impl MaskerState {
             diagnostic_patterns,
             url_encoded_patterns,
             diagnostic_url_encoded_patterns,
-            registered_values: HashSet::new(),
         };
         state.rebuild_matchers();
         state
     }
 
-    fn add_secret_value_patterns(&mut self, value: &str) -> bool {
-        if value.len() < MIN_SECRET_LEN || !self.registered_values.insert(value.to_string()) {
-            return false;
+    fn add_secret_value_patterns(&mut self, value: &str) {
+        if value.len() < MIN_SECRET_LEN {
+            return;
         }
 
         push_secret_patterns(value, &mut self.patterns);
@@ -214,7 +209,6 @@ impl MaskerState {
         push_url_encoded_secret_pattern(value, &mut self.url_encoded_patterns);
         push_url_encoded_secret_pattern(value, &mut self.diagnostic_url_encoded_patterns);
         push_diagnostic_multiline_patterns(value, &mut self.diagnostic_patterns);
-        true
     }
 
     fn rebuild_matchers(&mut self) {

--- a/crates/guest-agent/src/masker.rs
+++ b/crates/guest-agent/src/masker.rs
@@ -1,31 +1,25 @@
-//! Sensitive value masking for event payloads and CLI diagnostics.
+//! Secret value masking for event payloads and CLI diagnostics.
 //!
 //! Reads `VM0_SECRET_VALUES` (comma-separated base64 values), pre-computes
 //! plain / base64 / URL-encoded variants for normal payload masking, and derives
-//! diagnostic-only multiline variants for bounded CLI stderr tails. Runtime
-//! metadata such as CLI session identifiers can be registered after startup and
-//! uses the same matcher set.
+//! diagnostic-only multiline variants for bounded CLI stderr tails.
 
 use crate::env;
 use aho_corasick::{AhoCorasick, MatchKind};
 use base64::Engine;
 use serde_json::Value;
-use std::{
-    collections::HashSet,
-    ops::Range,
-    sync::{RwLock, RwLockReadGuard, RwLockWriteGuard},
-};
+use std::{collections::HashSet, ops::Range};
 
 /// Minimum secret length to avoid false-positive masking.
 const MIN_SECRET_LEN: usize = 5;
 
-/// Holds pre-computed sensitive value patterns for efficient masking.
+/// Holds pre-computed secret value patterns for efficient masking.
 ///
 /// Uses Aho-Corasick with leftmost-longest match semantics so that when one
 /// configured value is a substring of another, the longer match wins and no
 /// partial sensitive value survives. See issue #9778.
 pub struct SecretMasker {
-    state: RwLock<MaskerState>,
+    state: MaskerState,
 }
 
 struct MaskerState {
@@ -48,9 +42,7 @@ struct Matcher {
 impl SecretMasker {
     /// Build a masker from an owned guest-agent config.
     pub fn from_config(config: &env::GuestConfig) -> Self {
-        let masker = Self::from_raw(&config.secret_values);
-        masker.add_sensitive_value(&config.resume_session_id);
-        masker
+        Self::from_raw(&config.secret_values)
     }
 
     /// Build a masker from a raw comma-separated base64-encoded secret string.
@@ -82,17 +74,10 @@ impl SecretMasker {
 
         let mut state = MaskerState::empty();
         for secret in &secrets {
-            state.add_sensitive_value_patterns(secret);
+            state.add_secret_value_patterns(secret);
         }
         state.rebuild_matchers();
         Self::from_state(state)
-    }
-
-    pub(crate) fn add_sensitive_value(&self, value: &str) {
-        let mut state = self.write_state();
-        if state.add_sensitive_value_patterns(value) {
-            state.rebuild_matchers();
-        }
     }
 
     fn empty() -> Self {
@@ -146,22 +131,12 @@ impl SecretMasker {
     }
 
     fn from_state(state: MaskerState) -> Self {
-        Self {
-            state: RwLock::new(state),
-        }
-    }
-
-    fn read_state(&self) -> RwLockReadGuard<'_, MaskerState> {
-        self.state.read().unwrap_or_else(|e| e.into_inner())
-    }
-
-    fn write_state(&self) -> RwLockWriteGuard<'_, MaskerState> {
-        self.state.write().unwrap_or_else(|e| e.into_inner())
+        Self { state }
     }
 
     /// Recursively mask secrets in a JSON value tree (in-place).
     pub fn mask_value(&self, val: &mut Value) {
-        self.read_state().mask_value(val);
+        self.state.mask_value(val);
     }
 
     /// Replace all secret patterns in a string with `***`.
@@ -179,16 +154,16 @@ impl SecretMasker {
 
     /// Mask diagnostic text while preserving the caller's line boundaries.
     pub(crate) fn mask_diagnostic_lines(&self, lines: Vec<String>) -> Vec<String> {
-        self.read_state().mask_diagnostic_lines(lines)
+        self.state.mask_diagnostic_lines(lines)
     }
 
     #[cfg(test)]
     fn mask_string_in_place(&self, s: &mut String) -> bool {
-        self.read_state().mask_string_in_place(s)
+        self.state.mask_string_in_place(s)
     }
 
     fn masked_string(&self, s: &str) -> Option<String> {
-        self.read_state().masked_string(s)
+        self.state.masked_string(s)
     }
 }
 
@@ -229,7 +204,7 @@ impl MaskerState {
         state
     }
 
-    fn add_sensitive_value_patterns(&mut self, value: &str) -> bool {
+    fn add_secret_value_patterns(&mut self, value: &str) -> bool {
         if value.len() < MIN_SECRET_LEN || !self.registered_values.insert(value.to_string()) {
             return false;
         }
@@ -631,43 +606,6 @@ mod tests {
         masker.mask_value(&mut val);
         assert_eq!(val["outer"]["inner"], "has *** inside");
         assert_eq!(val["list"][1], "***");
-    }
-
-    #[test]
-    fn runtime_sensitive_value_masks_existing_paths() {
-        let masker = SecretMasker::from_raw("");
-        let value = "session/value";
-        let encoded = base64::engine::general_purpose::STANDARD.encode(value);
-
-        masker.add_sensitive_value(value);
-
-        let mut val = json!({
-            "plain": "contains session/value",
-            "encoded": encoded,
-            "url": "contains session%2fvalue",
-        });
-        masker.mask_value(&mut val);
-        assert_eq!(val["plain"], "contains ***");
-        assert_eq!(val["encoded"], "***");
-        assert_eq!(val["url"], "contains ***");
-        assert_eq!(masker.mask_string("session/value"), "***");
-        assert_eq!(
-            masker.mask_owned_string("system log session/value".to_string()),
-            "system log ***"
-        );
-        assert_eq!(
-            masker.mask_diagnostic_lines(vec!["stderr session/value".to_string()]),
-            vec!["stderr ***".to_string()]
-        );
-    }
-
-    #[test]
-    fn runtime_sensitive_value_skips_short_values() {
-        let masker = SecretMasker::from_raw("");
-
-        masker.add_sensitive_value("abcd");
-
-        assert_eq!(masker.mask_string("abcd"), "abcd");
     }
 
     #[test]

--- a/crates/guest-agent/tests/cli_failure_diagnostic_session_id_visibility.rs
+++ b/crates/guest-agent/tests/cli_failure_diagnostic_session_id_visibility.rs
@@ -1,21 +1,23 @@
-//! Failure diagnostics must mask a session ID carried by the same JSONL event.
+//! Failure diagnostics keep session IDs visible while still masking secrets.
 //!
 //! This test lives in its own binary to isolate process env, working directory,
 //! and guest runtime path overrides used during setup.
 
 mod common;
 
+use base64::Engine;
 use common::SystemLogOverrideGuard;
 use guest_agent::masker::SecretMasker;
 use serde_json::json;
 use std::time::Duration;
 
 #[tokio::test]
-async fn cli_failure_diagnostic_masks_session_id_from_same_event()
+async fn cli_failure_diagnostic_preserves_session_id_from_same_event()
 -> Result<(), Box<dyn std::error::Error>> {
     let mock = common::build_and_locate_mock()?;
     let tmp = tempfile::tempdir()?;
-    let session_id = "result-session-secret-123";
+    let session_id = "result-session-id-123";
+    let secret = "actual-secret-token-123";
     let prompt = format!(
         "@ECHO@\n{}",
         json!({
@@ -25,7 +27,7 @@ async fn cli_failure_diagnostic_masks_session_id_from_same_event()
             "is_error": true,
             "duration_ms": 100,
             "num_turns": 1,
-            "result": format!("failed for {session_id}"),
+            "result": format!("failed for {session_id} with {secret}"),
             "total_cost_usd": 0,
             "usage": {"input_tokens": 0, "output_tokens": 0},
         })
@@ -39,7 +41,8 @@ async fn cli_failure_diagnostic_masks_session_id_from_same_event()
 
     let system_log_path = tmp.path().join("system.log");
     let _system_log_guard = SystemLogOverrideGuard::set(&system_log_path);
-    let masker = SecretMasker::from_raw("");
+    let secret_values = base64::engine::general_purpose::STANDARD.encode(secret);
+    let masker = SecretMasker::from_raw(&secret_values);
     let cli_result = tokio::time::timeout(
         Duration::from_secs(5),
         common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
@@ -51,10 +54,18 @@ async fn cli_failure_diagnostic_masks_session_id_from_same_event()
         .failure_diagnostic
         .as_ref()
         .expect("result event should produce a failure diagnostic");
-    assert_eq!(failure_diagnostic.message, "failed for ***");
+    assert_eq!(
+        failure_diagnostic.message,
+        format!("failed for {session_id} with ***")
+    );
     assert!(
-        !failure_diagnostic.message.contains(session_id),
-        "failure diagnostic leaked session id: {}",
+        failure_diagnostic.message.contains(session_id),
+        "failure diagnostic should include session id: {}",
+        failure_diagnostic.message
+    );
+    assert!(
+        !failure_diagnostic.message.contains(secret),
+        "failure diagnostic leaked secret: {}",
         failure_diagnostic.message
     );
 
@@ -64,12 +75,12 @@ async fn cli_failure_diagnostic_masks_session_id_from_same_event()
         "system log should include the failure diagnostic log, got: {system_log}"
     );
     assert!(
-        system_log.contains("failed for ***"),
-        "system log should mask the same-event session id, got: {system_log}"
+        system_log.contains(&format!("failed for {session_id} with ***")),
+        "system log should keep session id and mask secret, got: {system_log}"
     );
     assert!(
-        !system_log.contains(session_id),
-        "system log leaked session id: {system_log}"
+        !system_log.contains(secret),
+        "system log leaked secret: {system_log}"
     );
 
     Ok(())

--- a/crates/guest-agent/tests/cli_resume_id_stderr_visibility.rs
+++ b/crates/guest-agent/tests/cli_resume_id_stderr_visibility.rs
@@ -1,24 +1,27 @@
-//! Resume session IDs must be masked even when the CLI fails before emitting JSONL.
+//! Resume session IDs stay visible even when the CLI fails before emitting JSONL.
 //!
 //! This test lives in its own binary to isolate process env, working directory,
 //! and guest runtime path overrides used during setup.
 
 mod common;
 
+use base64::Engine;
 use guest_agent::masker::SecretMasker;
 use std::time::Duration;
 
 #[tokio::test]
-async fn cli_failure_masks_resume_session_id_in_stderr() -> Result<(), Box<dyn std::error::Error>> {
+async fn cli_failure_preserves_resume_session_id_in_stderr()
+-> Result<(), Box<dyn std::error::Error>> {
     let mock = common::build_and_locate_mock()?;
     let tmp = tempfile::tempdir()?;
-    let resume_id = "resume-secret-123";
+    let resume_id = "resume-session-id-123";
+    let secret = "actual-stderr-secret-123";
 
     unsafe {
         common::setup_env(
             &mock,
             tmp.path(),
-            &format!("@fail-no-newline:resume failed for {resume_id}"),
+            &format!("@fail-no-newline:resume failed for {resume_id} with {secret}"),
             3,
             1,
         )?;
@@ -27,7 +30,8 @@ async fn cli_failure_masks_resume_session_id_in_stderr() -> Result<(), Box<dyn s
 
     let runtime = common::guest_runtime_from_process_env()?;
 
-    let masker = SecretMasker::from_raw("");
+    let secret_values = base64::engine::general_purpose::STANDARD.encode(secret);
+    let masker = SecretMasker::from_raw(&secret_values);
     let cli_result = tokio::time::timeout(
         Duration::from_secs(5),
         common::execute_cli_for_runtime(&runtime, &masker, common::spawn_dummy_heartbeat()),
@@ -38,13 +42,10 @@ async fn cli_failure_masks_resume_session_id_in_stderr() -> Result<(), Box<dyn s
     assert_eq!(cli_result.exit_code, 1);
     let stderr = cli_result.stderr_lines.join("\n");
     assert!(
-        stderr.contains("resume failed for ***"),
-        "stderr should mask resume session id, got: {stderr}"
+        stderr.contains(&format!("resume failed for {resume_id} with ***")),
+        "stderr should preserve resume session id and mask secret, got: {stderr}"
     );
-    assert!(
-        !stderr.contains(resume_id),
-        "stderr leaked resume session id: {stderr}"
-    );
+    assert!(!stderr.contains(secret), "stderr leaked secret: {stderr}");
 
     Ok(())
 }

--- a/crates/guest-agent/tests/codex_app_server_backend.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend.rs
@@ -62,7 +62,7 @@ async fn codex_app_server_backend_runs_initial_turn_and_synthesizes_thread_start
     let marker = std::fs::read_to_string(runtime.paths.session_history_path_file())?;
     assert!(marker.starts_with("CODEX_SEARCH:"));
     assert!(marker.ends_with(&format!(":{thread_id}")));
-    assert_eq!(masker.mask_string(thread_id), "***");
+    assert_eq!(masker.mask_string(thread_id), thread_id);
 
     let session_events = read_codex_session_history_events(&runtime.paths)?;
     let input_event = session_events

--- a/crates/guest-agent/tests/codex_app_server_backend_error_masking.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_error_masking.rs
@@ -9,7 +9,7 @@ use guest_agent::masker::SecretMasker;
 use std::time::Duration;
 
 #[tokio::test]
-async fn codex_app_server_backend_masks_resume_id_in_rpc_errors()
+async fn codex_app_server_backend_preserves_resume_id_in_rpc_errors()
 -> Result<(), Box<dyn std::error::Error>> {
     let mock = common::build_and_locate_mock_codex()?;
     let tmp = tempfile::tempdir()?;
@@ -42,16 +42,8 @@ async fn codex_app_server_backend_masks_resume_id_in_rpc_errors()
     let error = result.expect_err("resume RPC error should fail the app-server backend");
     let message = error.to_string();
     assert!(
-        message.contains("resume failed for ***"),
-        "unexpected masked error: {message}"
-    );
-    assert!(
-        !message.contains(resume_thread_id),
-        "raw resume id leaked in app-server RPC error: {message}"
-    );
-    assert!(
-        !message.contains(canonical_resume_thread_id),
-        "canonical resume id leaked in app-server RPC error: {message}"
+        message.contains(&format!("resume failed for {canonical_resume_thread_id}")),
+        "unexpected error: {message}"
     );
 
     Ok(())

--- a/crates/guest-agent/tests/codex_app_server_backend_error_visibility.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend_error_visibility.rs
@@ -1,4 +1,4 @@
-//! Error masking coverage for the experimental Codex app-server backend.
+//! Error visibility coverage for the experimental Codex app-server backend.
 //!
 //! This test lives in its own binary to isolate process env, working directory,
 //! and guest runtime path overrides used during setup.

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -199,7 +199,7 @@ fn send_event_extracts_codex_thread_id_and_writes_marker() {
         marker.ends_with(&format!(":{thread_id}")),
         "marker should end with the thread id, got: {marker}"
     );
-    assert_eq!(masker.mask_string(thread_id), "***");
+    assert_eq!(masker.mask_string(thread_id), thread_id);
 
     let system_log = std::fs::read_to_string(&system_log_path).expect("system log written");
     assert!(
@@ -251,7 +251,7 @@ fn send_event_canonicalizes_codex_thread_id_before_writing_marker() {
 }
 
 #[test]
-fn send_event_seeds_existing_codex_thread_id_without_repairing_history_marker() {
+fn send_event_keeps_existing_codex_thread_id_without_repairing_history_marker() {
     let _guard = TEST_MUTEX.lock().unwrap();
     let _files_guard = CodexResumeFilesGuard::new();
 
@@ -291,7 +291,7 @@ fn send_event_seeds_existing_codex_thread_id_without_repairing_history_marker() 
                 "ordinary events must not create missing history markers"
             );
         }
-        assert_eq!(masker.mask_string(thread_id), "***");
+        assert_eq!(masker.mask_string(thread_id), thread_id);
     }
 }
 
@@ -412,10 +412,6 @@ fn send_event_codex_ignores_malformed_thread_id() {
             !Path::new(&session_id_file).exists(),
             "malformed thread_id must not be persisted: {thread_id}"
         );
-        if thread_id.len() >= 5 {
-            assert_eq!(masker.mask_string(thread_id), "***");
-        } else {
-            assert_eq!(masker.mask_string(thread_id), thread_id);
-        }
+        assert_eq!(masker.mask_string(thread_id), thread_id);
     }
 }

--- a/crates/guest-agent/tests/execute_cli_api_mode.rs
+++ b/crates/guest-agent/tests/execute_cli_api_mode.rs
@@ -76,7 +76,7 @@ async fn api_mode_execute_cli_captures_session_metadata_and_sends_events()
             .path("/api/webhooks/agent/events")
             .body_includes(format!(r#""runId":"{expected_run_id}""#))
             .body_includes(r#""subtype":"init""#)
-            .body_includes(r#""session_id":"***"#);
+            .body_includes(format!(r#""session_id":"{session_id}""#));
         then.status(200);
     });
     let result_event = server.mock(|when, then| {

--- a/crates/guest-agent/tests/integration/events.rs
+++ b/crates/guest-agent/tests/integration/events.rs
@@ -108,7 +108,7 @@ async fn send_event_captures_session_metadata_before_masking() {
     let mock = server.mock(|when, then| {
         when.method(POST)
             .path("/api/webhooks/agent/events")
-            .body_includes(r#""session_id":"***""#);
+            .body_includes(r#""session_id":"ses-secret-123""#);
         then.status(200);
     });
 
@@ -187,7 +187,7 @@ async fn prepare_event_does_not_capture_session_metadata() {
 }
 
 #[tokio::test]
-async fn send_event_masks_invalid_session_id_without_checkpoint_metadata() {
+async fn send_event_preserves_invalid_session_id_without_checkpoint_metadata() {
     let api = SharedApiMock::new().await;
     let server = api.server();
     let _session_files = SessionCheckpointFilesGuard::new();
@@ -197,11 +197,11 @@ async fn send_event_masks_invalid_session_id_without_checkpoint_metadata() {
     let mock = server.mock(|when, then| {
         when.method(POST)
             .path("/api/webhooks/agent/events")
-            .body_includes(r#""session_id":"***""#);
+            .body_includes(r#""session_id":"bad/session-id""#);
         then.status(200);
     });
 
-    let session_id = "bad/session-secret";
+    let session_id = "bad/session-id";
     let masker = SecretMasker::from_raw("");
     let event = json!({
         "type": "system",
@@ -212,7 +212,7 @@ async fn send_event_masks_invalid_session_id_without_checkpoint_metadata() {
 
     assert!(result.is_ok());
     mock.assert_calls_async(1).await;
-    assert_eq!(masker.mask_string(session_id), "***");
+    assert_eq!(masker.mask_string(session_id), session_id);
     assert!(
         !std::path::Path::new(&sid_file).exists(),
         "invalid session id must not be persisted"
@@ -236,7 +236,7 @@ async fn send_event_keeps_existing_session_metadata() {
     let mock = server.mock(|when, then| {
         when.method(POST)
             .path("/api/webhooks/agent/events")
-            .body_includes(r#""session_id":"***""#);
+            .body_includes(r#""session_id":"second-session""#);
         then.status(200);
     });
 
@@ -260,12 +260,12 @@ async fn send_event_keeps_existing_session_metadata() {
         "/tmp/first-session.jsonl",
         "later id-bearing events must not replace checkpoint history metadata"
     );
-    assert_eq!(masker.mask_string("first-session"), "***");
-    assert_eq!(masker.mask_string("second-session"), "***");
+    assert_eq!(masker.mask_string("first-session"), "first-session");
+    assert_eq!(masker.mask_string("second-session"), "second-session");
 }
 
 #[tokio::test]
-async fn send_event_seeds_existing_claude_session_id_without_repairing_history_marker() {
+async fn send_event_keeps_existing_claude_session_id_without_repairing_history_marker() {
     let api = SharedApiMock::new().await;
     let server = api.server();
     let _session_files = SessionCheckpointFilesGuard::new();
@@ -313,7 +313,7 @@ async fn send_event_seeds_existing_claude_session_id_without_repairing_history_m
                 "ordinary events must not create missing history markers"
             );
         }
-        assert_eq!(masker.mask_string(session_id), "***");
+        assert_eq!(masker.mask_string(session_id), session_id);
     }
 
     mock.assert_calls_async(2).await;

--- a/crates/guest-agent/tests/integration/events.rs
+++ b/crates/guest-agent/tests/integration/events.rs
@@ -108,11 +108,11 @@ async fn send_event_captures_session_metadata_before_masking() {
     let mock = server.mock(|when, then| {
         when.method(POST)
             .path("/api/webhooks/agent/events")
-            .body_includes(r#""session_id":"ses-secret-123""#);
+            .body_includes(r#""session_id":"ses-session-id-123""#);
         then.status(200);
     });
 
-    let session_id = "ses-secret-123";
+    let session_id = "ses-session-id-123";
     let masker = SecretMasker::from_raw("");
     let event = json!({
         "type": "system",

--- a/crates/guest-agent/tests/integration/telemetry.rs
+++ b/crates/guest-agent/tests/integration/telemetry.rs
@@ -1,4 +1,5 @@
 use crate::support::*;
+use base64::Engine;
 use guest_agent::masker::SecretMasker;
 use httpmock::prelude::*;
 use std::time::Duration;
@@ -202,7 +203,7 @@ async fn final_flush_and_shutdown_uploads_log_emitted_immediately_before_it() {
 }
 
 #[tokio::test]
-async fn telemetry_masks_runtime_session_id_registered_after_spawn() {
+async fn telemetry_preserves_runtime_session_id_and_masks_secrets() {
     let api = SharedApiMock::new().await;
     let server = api.server();
     let files = ExplicitTelemetryFiles::new("runtime-session-mask").unwrap();
@@ -212,27 +213,29 @@ async fn telemetry_masks_runtime_session_id_registered_after_spawn() {
     let system_log = paths.system_log_file();
     ensure_parent_dir(system_log);
 
-    let session_id = "telemetry-session-secret";
+    let session_id = "telemetry-session-id";
+    let secret = "actual-telemetry-secret-123";
     let event_mock = server.mock(|when, then| {
         when.method(POST)
             .path("/api/webhooks/agent/events")
-            .body_includes(r#""session_id":"***""#);
+            .body_includes(format!(r#""session_id":"{session_id}""#));
         then.status(200);
     });
     let raw_telemetry_mock = server.mock(|when, then| {
         when.method(POST)
             .path("/api/webhooks/agent/telemetry")
-            .body_includes(session_id);
+            .body_includes(secret);
         then.status(500);
     });
     let masked_telemetry_mock = server.mock(|when, then| {
         when.method(POST)
             .path("/api/webhooks/agent/telemetry")
-            .body_includes("system log ***");
+            .body_includes(format!("system log {session_id} ***"));
         then.status(200);
     });
 
-    let masker = std::sync::Arc::new(SecretMasker::from_raw(""));
+    let secret_values = base64::engine::general_purpose::STANDARD.encode(secret);
+    let masker = std::sync::Arc::new(SecretMasker::from_raw(&secret_values));
     let telemetry = guest_agent::telemetry::Telemetry::spawn_for_paths(
         "test-run-001".to_string(),
         paths,
@@ -249,7 +252,7 @@ async fn telemetry_masks_runtime_session_id_registered_after_spawn() {
         .await
         .expect("session event should be sent");
 
-    std::fs::write(system_log, format!("system log {session_id}\n"))
+    std::fs::write(system_log, format!("system log {session_id} {secret}\n"))
         .expect("system log should be written");
     telemetry
         .flush(guest_agent::telemetry::UploadMode::Final)

--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use crate::config::RunnerConfig;
 use crate::error::RunnerResult;
 use crate::live_runner_instances::LiveRunnerInstance;
-use crate::paths::{HomePaths, diagnostic_session_fingerprint};
+use crate::paths::HomePaths;
 use crate::process;
 use chrono::{DateTime, Utc};
 use clap::Args;
@@ -1343,9 +1343,8 @@ fn print_report(
 
 fn format_idle_vm_diagnostic_line(vm: &IdleVm) -> String {
     format!(
-        "      - session fingerprint {} -> sandbox {}",
-        diagnostic_session_fingerprint(&vm.session_id),
-        vm.sandbox_id
+        "      - session id {} -> sandbox {}",
+        vm.session_id, vm.sandbox_id
     )
 }
 
@@ -2350,21 +2349,14 @@ mod tests {
     }
 
     #[test]
-    fn idle_vm_diagnostic_line_redacts_session_id() {
+    fn idle_vm_diagnostic_line_includes_session_id() {
         let raw_session_id = "sess-sensitive-doctor-17975";
         let line = format_idle_vm_diagnostic_line(&IdleVm {
             session_id: raw_session_id.into(),
             sandbox_id: "sandbox-123".into(),
         });
 
-        assert!(
-            !line.contains(raw_session_id),
-            "doctor idle VM output must not expose raw session id: {line}"
-        );
-        assert!(
-            line.contains(&diagnostic_session_fingerprint(raw_session_id)),
-            "doctor idle VM output should retain session-level correlation: {line}"
-        );
+        assert!(line.contains(raw_session_id));
         assert!(line.contains("sandbox-123"));
     }
 

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -28,7 +28,6 @@ use crate::executor::{
 use crate::http::HttpClient;
 use crate::idle_pool::{IdlePoolSnapshot, IdleUnparkResult, ReusableIdleSandbox};
 use crate::ids::RunId;
-use crate::paths::diagnostic_session_fingerprint;
 use crate::provider::{ClaimedJob, JobCandidate};
 use crate::resource_budget::{BudgetLease, ResourceBudget};
 use crate::restored_session_identity::{
@@ -421,8 +420,6 @@ async fn try_reuse_from_pool(
             false,
         );
     };
-    let session_fingerprint = diagnostic_session_fingerprint(cli_agent_session_id);
-
     // Take the entry under the pool lock, then drop the lock before any awaits
     // so unpark does not block other take/park operations.
     let (taken, snapshot, held_session_states) = {
@@ -476,7 +473,7 @@ async fn try_reuse_from_pool(
                 if let Err(mismatch) = validation {
                     warn!(
                         run_id = %run_id,
-                        session_fingerprint = %session_fingerprint,
+                        session_id = %cli_agent_session_id,
                         profile = %profile_name,
                         mismatch = mismatch.as_str(),
                         "workspace promotion identity mismatch, destroying idle VM and falling through to fresh create"
@@ -505,7 +502,7 @@ async fn try_reuse_from_pool(
                 } => {
                     info!(
                         run_id = %run_id,
-                        session_fingerprint = %session_fingerprint,
+                        session_id = %cli_agent_session_id,
                         "reusing idle VM for session"
                     );
                     // Idle entry already holds budget. Drop the speculative
@@ -523,7 +520,7 @@ async fn try_reuse_from_pool(
                 IdleUnparkResult::Failed { destroy_job, error } => {
                     warn!(
                         run_id = %run_id,
-                        session_fingerprint = %session_fingerprint,
+                        session_id = %cli_agent_session_id,
                         error = %error,
                         "unpark failed, destroying idle VM and falling through to fresh create"
                     );
@@ -541,7 +538,7 @@ async fn try_reuse_from_pool(
         Some(stale) if stale.profile_name() == profile_name => {
             info!(
                 run_id = %run_id,
-                session_fingerprint = %session_fingerprint,
+                session_id = %cli_agent_session_id,
                 profile = %profile_name,
                 "idle VM device rate limiter mismatch, destroying"
             );
@@ -561,7 +558,7 @@ async fn try_reuse_from_pool(
         Some(stale) => {
             info!(
                 run_id = %run_id,
-                session_fingerprint = %session_fingerprint,
+                session_id = %cli_agent_session_id,
                 old_profile = %stale.profile_name(),
                 new_profile = %profile_name,
                 "idle VM profile mismatch, destroying"
@@ -582,7 +579,7 @@ async fn try_reuse_from_pool(
         None => {
             info!(
                 run_id = %run_id,
-                session_fingerprint = %session_fingerprint,
+                session_id = %cli_agent_session_id,
                 "no idle VM found for session"
             );
             (

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -54,7 +54,7 @@ use crate::kmsg_log;
 use crate::lock;
 use crate::network_log_drain::NetworkLogDrainCoordinator;
 use crate::network_log_manager::NetworkLogManager;
-use crate::paths::{HomePaths, LogPaths, RunnerPaths, diagnostic_session_fingerprint, touch_mtime};
+use crate::paths::{HomePaths, LogPaths, RunnerPaths, touch_mtime};
 use crate::prefetch;
 use crate::provider::{ApiProvider, JobProvider, LocalProvider};
 use crate::proxy;
@@ -819,16 +819,9 @@ enum SignalSource {
 #[derive(Debug, PartialEq, Eq)]
 enum StartLoopEvent {
     BudgetExhaustedReactorEntered,
-    IdleCleanupProcessed {
-        expired_count: usize,
-    },
-    BeforeIdlePoolOwnershipTransfer {
-        run_id: RunId,
-    },
-    VmParkedForReuse {
-        run_id: RunId,
-        session_fingerprint: String,
-    },
+    IdleCleanupProcessed { expired_count: usize },
+    BeforeIdlePoolOwnershipTransfer { run_id: RunId },
+    VmParkedForReuse { run_id: RunId, session_id: String },
     UsageFlushRequested,
 }
 
@@ -934,11 +927,8 @@ impl StartLoopTestObserver {
         self.record(StartLoopEvent::BeforeIdlePoolOwnershipTransfer { run_id });
     }
 
-    fn notify_vm_parked_for_reuse(&self, run_id: RunId, session_fingerprint: String) {
-        self.record(StartLoopEvent::VmParkedForReuse {
-            run_id,
-            session_fingerprint,
-        });
+    fn notify_vm_parked_for_reuse(&self, run_id: RunId, session_id: String) {
+        self.record(StartLoopEvent::VmParkedForReuse { run_id, session_id });
     }
 
     fn notify_usage_flush_requested(&self) {
@@ -984,8 +974,8 @@ impl StartLoopTestObserver {
         self.wait_for(timeout, "VM parked for reuse", |event| match event {
             StartLoopEvent::VmParkedForReuse {
                 run_id: observed_run_id,
-                session_fingerprint,
-            } if *observed_run_id == run_id => Some(session_fingerprint.clone()),
+                session_id,
+            } if *observed_run_id == run_id => Some(session_id.clone()),
             _ => None,
         })
         .await
@@ -1356,10 +1346,8 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                 if let Some(evicted) =
                     evict_oldest_idle_entry(&shared.idle_pool, &shared.status).await
                 {
-                    let session_fingerprint =
-                        diagnostic_session_fingerprint(evicted.cli_agent_session_id());
                     info!(
-                        session_fingerprint = %session_fingerprint,
+                        session_id = %evicted.cli_agent_session_id(),
                         profile = %evicted.profile_name(),
                         vcpu = evicted.budget_vcpu(),
                         memory_mb = evicted.budget_memory_mb(),

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -28,7 +28,6 @@ use crate::idle_pool::{
 use crate::ids::RunId;
 use crate::network_log_drain::NetworkLogDrainCoordinator;
 use crate::network_log_manager::NetworkLogSession;
-use crate::paths::diagnostic_session_fingerprint;
 #[cfg(test)]
 use crate::provider::CompletionAuth;
 use crate::resource_budget::BudgetLease;
@@ -157,7 +156,6 @@ pub(super) async fn finalize_sandbox_for_completion(
     let mut session_affinity_changed = false;
     let mut session_affinity_refresh_sent = false;
     let budget = if let Some(cli_agent_session_id) = parkable_cli_agent_session_id {
-        let session_fingerprint = diagnostic_session_fingerprint(&cli_agent_session_id);
         // Inflate the guest balloon BEFORE acquiring the pool lock —
         // the HTTP call to Firecracker can take milliseconds, and we
         // must not block other take/park operations on it.
@@ -187,7 +185,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                 } = failure.active;
                 warn!(
                     run_id = %run_id,
-                    session_fingerprint = %session_fingerprint,
+                    session_id = %cli_agent_session_id,
                     error = %failure.error,
                     "sandbox park failed, destroying instead of parking"
                 );
@@ -229,7 +227,7 @@ pub(super) async fn finalize_sandbox_for_completion(
             close_network_log_session(run_id, network_log_session.take(), &network_log_drain).await;
             info!(
                 run_id = %run_id,
-                session_fingerprint = %session_fingerprint,
+                session_id = %cli_agent_session_id,
                 "job cancelled while parking, destroying VM"
             );
             let destroy_result = destroy_active_owned_idle_payload(
@@ -257,7 +255,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                     if cancel.is_cancelled() {
                         info!(
                             run_id = %run_id,
-                            session_fingerprint = %session_fingerprint,
+                            session_id = %cli_agent_session_id,
                             "job cancelled before idle pool ownership transfer, destroying VM"
                         );
                         drop(transfer_guard);
@@ -281,7 +279,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                 if cancel.is_cancelled() {
                     info!(
                         run_id = %run_id,
-                        session_fingerprint = %session_fingerprint,
+                        session_id = %cli_agent_session_id,
                         "job cancelled before idle pool ownership transfer, destroying VM"
                     );
                     drop(transfer_guard);
@@ -303,10 +301,10 @@ pub(super) async fn finalize_sandbox_for_completion(
                 let candidate = candidate.with_last_completed_at(completed_at.clone());
                 break match pool.park(candidate) {
                     ParkResult::Parked => {
-                        info!(run_id = %run_id, session_fingerprint = %session_fingerprint, "VM parked for reuse");
+                        info!(run_id = %run_id, session_id = %cli_agent_session_id, "VM parked for reuse");
                         #[cfg(test)]
                         test_observer
-                            .notify_vm_parked_for_reuse(run_id, session_fingerprint.clone());
+                            .notify_vm_parked_for_reuse(run_id, cli_agent_session_id.clone());
                         cleanup_state.mark_idle_pool_owned();
                         #[cfg(test)]
                         maybe_panic_outer_job(
@@ -334,7 +332,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                         BudgetOwnership::idle_owned()
                     }
                     ParkResult::Replaced(evicted) => {
-                        info!(run_id = %run_id, session_fingerprint = %session_fingerprint, "VM parked, evicting previous");
+                        info!(run_id = %run_id, session_id = %cli_agent_session_id, "VM parked, evicting previous");
                         cleanup_state.mark_idle_pool_owned();
                         #[cfg(test)]
                         maybe_panic_outer_job(
@@ -362,7 +360,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                         BudgetOwnership::idle_owned()
                     }
                     ParkResult::Rejected(rejected) => {
-                        info!(run_id = %run_id, session_fingerprint = %session_fingerprint, "idle parking rejected, destroying VM");
+                        info!(run_id = %run_id, session_id = %cli_agent_session_id, "idle parking rejected, destroying VM");
                         drop(transfer_guard);
                         drop(pool);
                         // Pool unchanged (park rejected) — no status
@@ -523,16 +521,14 @@ async fn stop_and_destroy_sandbox(
     mut context: ActiveCleanupContext<'_>,
 ) -> DestroyOutcome {
     let mut uncertain = false;
-    let session_fingerprint = context
-        .cli_agent_session_id
-        .map(diagnostic_session_fingerprint);
+    let session_id = context.cli_agent_session_id;
     match AssertUnwindSafe(sandbox.stop()).catch_unwind().await {
         Ok(Ok(())) => {}
         Ok(Err(e)) => warn!(
             run_id = %context.run_id,
             sandbox_id = %context.sandbox_id,
             profile_name = context.profile_name,
-            session_fingerprint = ?session_fingerprint,
+            session_id = ?session_id,
             reason = context.reason,
             error = %e,
             "sandbox stop failed during active cleanup"
@@ -542,7 +538,7 @@ async fn stop_and_destroy_sandbox(
                 run_id = %context.run_id,
                 sandbox_id = %context.sandbox_id,
                 profile_name = context.profile_name,
-                session_fingerprint = ?session_fingerprint,
+                session_id = ?session_id,
                 reason = context.reason,
                 "sandbox stop panicked during active cleanup"
             );
@@ -564,7 +560,7 @@ async fn stop_and_destroy_sandbox(
             run_id = %context.run_id,
             sandbox_id = %context.sandbox_id,
             profile_name = context.profile_name,
-            session_fingerprint = ?session_fingerprint,
+            session_id = ?session_id,
             reason = context.reason,
             "sandbox destroy panicked during active cleanup"
         );
@@ -811,7 +807,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn finalizer_parking_log_uses_session_fingerprint() {
+    async fn finalizer_parking_log_uses_session_id() {
         let (_budget, lease) = test_budget_lease();
         let fixture = FinalizeTestFixture::new().await;
         let network_log_session = fixture.network_log_session().await;
@@ -842,15 +838,11 @@ mod tests {
             context,
         )
         .await;
-        let field = observer
+        let session_id = observer
             .wait_vm_parked_for_reuse(run_id, Duration::from_secs(1))
             .await;
 
-        assert_eq!(field, diagnostic_session_fingerprint(raw_session_id));
-        assert!(
-            !field.contains(raw_session_id),
-            "parking diagnostic field must not include raw session id: {field}"
-        );
+        assert_eq!(session_id, raw_session_id);
     }
 
     #[tokio::test]

--- a/crates/runner/src/executor/diagnostics.rs
+++ b/crates/runner/src/executor/diagnostics.rs
@@ -46,7 +46,7 @@ use super::{
 };
 use crate::helper_exec::{helper_exec_succeeded, helper_exec_termination_label};
 use crate::ids::RunId;
-use crate::paths::{LogPaths, diagnostic_session_fingerprint};
+use crate::paths::LogPaths;
 use crate::types::ExecutionContext;
 
 const AGENT_ENV_VALUE_SIZE_DIAGNOSTIC_LIMIT: usize = 5;
@@ -410,9 +410,9 @@ pub(super) fn log_agent_bootstrap_abnormal_exit_diagnostics(
         .session_restore_diagnostics
         .map(|diagnostics| diagnostics.framework)
         .unwrap_or("none");
-    let resume_session_fingerprint = context
+    let resume_session_id = context
         .session_restore_diagnostics
-        .map(|diagnostics| diagnostics.session_fingerprint.as_str())
+        .map(|diagnostics| diagnostics.session_id.as_str())
         .unwrap_or("");
     let resume_session_bytes_in = context
         .session_restore_diagnostics
@@ -442,7 +442,7 @@ pub(super) fn log_agent_bootstrap_abnormal_exit_diagnostics(
         env_keys = %context.env_key_diagnostics.logged_keys_csv(),
         omitted_env_key_count = context.env_key_diagnostics.omitted_key_count,
         resume_session_framework = %resume_session_framework,
-        resume_session_fingerprint = %resume_session_fingerprint,
+        resume_session_id = %resume_session_id,
         resume_session_bytes_in = ?resume_session_bytes_in,
         "agent bootstrap abnormal exit diagnostics"
     );
@@ -619,7 +619,7 @@ pub(super) async fn read_guest_cli_agent_session_id(
             if !is_valid_session_id(&id) {
                 warn!(
                     run_id = %run_id,
-                    session_fingerprint = %diagnostic_session_fingerprint(&id),
+                    session_id = %id,
                     "ignoring invalid guest session ID"
                 );
                 return None;

--- a/crates/runner/src/executor/diagnostics.rs
+++ b/crates/runner/src/executor/diagnostics.rs
@@ -35,7 +35,7 @@ use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use tracing::{info, warn};
 
 use super::env::is_runner_owned_env_key;
-use super::session_id::is_valid_session_id;
+use super::session_id::{invalid_session_id_diagnostic_preview, is_valid_session_id};
 use super::session_restore::SessionRestoreDiagnostics;
 use super::{
     AGENT_ABNORMAL_EXIT_DIAGNOSTIC_SCRIPT, AGENT_ABNORMAL_EXIT_DIAGNOSTIC_TIMEOUT,
@@ -619,7 +619,7 @@ pub(super) async fn read_guest_cli_agent_session_id(
             if !is_valid_session_id(&id) {
                 warn!(
                     run_id = %run_id,
-                    session_id = %id,
+                    session_id = %invalid_session_id_diagnostic_preview(&id),
                     "ignoring invalid guest session ID"
                 );
                 return None;

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -24,7 +24,6 @@ use super::{
 use crate::duration::duration_ms;
 use crate::ids::RunId;
 use crate::network_log_manager::NetworkLogSession;
-use crate::paths::diagnostic_session_fingerprint;
 use crate::proxy;
 use crate::telemetry::JobTelemetry;
 use crate::types::ExecutionContext;
@@ -570,7 +569,7 @@ pub(super) async fn execute_prepared_sandbox_run(
             if let Some(ref sid) = id {
                 info!(
                     run_id = %context.run_id,
-                    session_fingerprint = %diagnostic_session_fingerprint(sid),
+                    session_id = %sid,
                     "read guest session ID for parking"
                 );
             }
@@ -599,7 +598,7 @@ fn normalize_guest_cli_agent_session_id_for_parking(
             warn!(
                 run_id = %context.run_id,
                 framework = "codex",
-                session_fingerprint = %diagnostic_session_fingerprint(&session_id),
+                session_id = %session_id,
                 "ignoring invalid guest session ID for framework"
             );
             None
@@ -611,7 +610,7 @@ fn normalize_guest_cli_agent_session_id_for_parking(
                 warn!(
                     run_id = %context.run_id,
                     framework = "claude-code",
-                    session_fingerprint = %diagnostic_session_fingerprint(&session_id),
+                    session_id = %session_id,
                     "ignoring invalid guest session ID for framework"
                 );
                 None

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -15,7 +15,9 @@ use super::diagnostics::{
     AgentStdoutStreamDiagnostics, append_stdout_stream_diagnostics_to_stream_log, copy_guest_logs,
     read_guest_cli_agent_session_id,
 };
-use super::session_id::{canonical_codex_thread_id, is_valid_session_id};
+use super::session_id::{
+    canonical_codex_thread_id, invalid_session_id_diagnostic_preview, is_valid_session_id,
+};
 use super::telemetry::record_workspace_cache_result;
 use super::{
     ExecuteOutcome, ExecutionFailure, ExecutorConfig, JobParams, NewSandboxDispatch, RunnerError,
@@ -598,7 +600,7 @@ fn normalize_guest_cli_agent_session_id_for_parking(
             warn!(
                 run_id = %context.run_id,
                 framework = "codex",
-                session_id = %session_id,
+                session_id = %invalid_session_id_diagnostic_preview(&session_id),
                 "ignoring invalid guest session ID for framework"
             );
             None
@@ -610,7 +612,7 @@ fn normalize_guest_cli_agent_session_id_for_parking(
                 warn!(
                     run_id = %context.run_id,
                     framework = "claude-code",
-                    session_id = %session_id,
+                    session_id = %invalid_session_id_diagnostic_preview(&session_id),
                     "ignoring invalid guest session ID for framework"
                 );
                 None

--- a/crates/runner/src/executor/session_id.rs
+++ b/crates/runner/src/executor/session_id.rs
@@ -1,4 +1,5 @@
 const MAX_SESSION_ID_LEN: usize = 128;
+const INVALID_SESSION_ID_DIAGNOSTIC_PREVIEW_BYTES: usize = MAX_SESSION_ID_LEN;
 
 /// Returns true if the session ID is short enough for guest filenames and
 /// contains only safe characters (alphanumeric, dash, underscore).
@@ -10,6 +11,50 @@ pub(super) fn is_valid_session_id(id: &str) -> bool {
             .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
 }
 
+pub(super) fn invalid_session_id_diagnostic_preview(id: &str) -> String {
+    let mut end = id.len().min(INVALID_SESSION_ID_DIAGNOSTIC_PREVIEW_BYTES);
+    while !id.is_char_boundary(end) {
+        end -= 1;
+    }
+    let preview: String = id[..end].chars().flat_map(char::escape_default).collect();
+    if end == id.len() {
+        preview
+    } else {
+        format!("{preview}...[truncated {} bytes]", id.len() - end)
+    }
+}
+
 pub(super) fn canonical_codex_thread_id(id: &str) -> Option<String> {
     guest_contracts::codex_thread_id::canonical_codex_thread_id(id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_session_id_preview_keeps_short_safe_text() {
+        assert_eq!(
+            invalid_session_id_diagnostic_preview("../session"),
+            "../session"
+        );
+    }
+
+    #[test]
+    fn invalid_session_id_preview_escapes_control_characters() {
+        assert_eq!(
+            invalid_session_id_diagnostic_preview("bad\nsession"),
+            "bad\\nsession"
+        );
+    }
+
+    #[test]
+    fn invalid_session_id_preview_truncates_overlong_values() {
+        let id = "a".repeat(MAX_SESSION_ID_LEN + 2);
+
+        assert_eq!(
+            invalid_session_id_diagnostic_preview(&id),
+            format!("{}...[truncated 2 bytes]", "a".repeat(MAX_SESSION_ID_LEN))
+        );
+    }
 }

--- a/crates/runner/src/executor/session_restore.rs
+++ b/crates/runner/src/executor/session_restore.rs
@@ -4,23 +4,16 @@ mod codex;
 
 use std::borrow::Cow;
 
-use sandbox::{Sandbox, SandboxError};
+use sandbox::Sandbox;
 use tracing::{info, warn};
 
 use super::cli_framework::{EffectiveCliFramework, effective_cli_framework};
 use super::env::validate_resume_session_id;
 use super::session_id::{canonical_codex_thread_id, is_valid_session_id};
 use super::{RunnerError, RunnerResult};
-use crate::paths::diagnostic_session_fingerprint;
 use crate::restored_session_identity::{RestoredSessionFramework, RestoredSessionIdentity};
 use crate::types::{ExecutionContext, ResumeSession};
 use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
-
-const SESSION_PATH_SENTINEL: &str = "\u{0}\u{1}";
-const SESSION_ID_SENTINEL: &str = "\u{0}\u{2}";
-const REDACTED_SESSION_PATH: &str = "[redacted-session-path]";
-const REDACTED_SESSION_ID: &str = "[redacted-session-id]";
-const SUBSTRING_SESSION_ID_REDACTION_MIN_LEN: usize = 8;
 
 impl RestoredSessionIdentity {
     pub(crate) fn from_context(context: &ExecutionContext) -> Option<Self> {
@@ -120,7 +113,7 @@ impl<'a> MaterializedResumeSession<'a> {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(super) struct SessionRestoreDiagnostics {
     pub(super) framework: &'static str,
-    pub(super) session_fingerprint: String,
+    pub(super) session_id: String,
     pub(super) bytes_in: usize,
 }
 
@@ -168,16 +161,16 @@ pub(super) async fn restore_claude_session(
     let session_id = session.cli_agent_session_id();
     let session_path = format!("{session_dir}/{session_id}.jsonl");
 
-    write_session_history_file(sandbox, &session_path, &[session_id], session_history).await?;
+    write_session_history_file(sandbox, &session_path, session_history).await?;
     let diagnostics = SessionRestoreDiagnostics {
         framework: "claude-code",
-        session_fingerprint: diagnostic_session_fingerprint(session_id),
+        session_id: session_id.to_string(),
         bytes_in: session_history.len(),
     };
     info!(
         run_id = %context.run_id,
         framework = diagnostics.framework,
-        session_fingerprint = %diagnostics.session_fingerprint,
+        session_id = %diagnostics.session_id,
         bytes_in = diagnostics.bytes_in,
         "restored session history"
     );
@@ -187,122 +180,10 @@ pub(super) async fn restore_claude_session(
 async fn write_session_history_file(
     sandbox: &dyn Sandbox,
     session_path: &str,
-    session_ids: &[&str],
     session_history: &[u8],
 ) -> RunnerResult<()> {
     sandbox
         .write_file(session_path, session_history)
         .await
-        .map_err(|error| redact_session_restore_sandbox_error(error, session_ids, session_path))
-}
-
-fn redact_session_restore_sandbox_error(
-    error: SandboxError,
-    session_ids: &[&str],
-    session_path: &str,
-) -> RunnerError {
-    RunnerError::Sandbox(match error {
-        SandboxError::BackendUnavailable { message } => SandboxError::BackendUnavailable {
-            message: redact_session_restore_diagnostic(message, session_ids, session_path),
-        },
-        SandboxError::Configuration { message } => SandboxError::Configuration {
-            message: redact_session_restore_diagnostic(message, session_ids, session_path),
-        },
-        SandboxError::Initialization { phase, message } => SandboxError::Initialization {
-            phase,
-            message: redact_session_restore_diagnostic(message, session_ids, session_path),
-        },
-        SandboxError::Start { message } => SandboxError::Start {
-            message: redact_session_restore_diagnostic(message, session_ids, session_path),
-        },
-        SandboxError::InvalidState {
-            context,
-            state,
-            message,
-        } => SandboxError::InvalidState {
-            context,
-            state: redact_session_restore_diagnostic(state, session_ids, session_path),
-            message: redact_session_restore_diagnostic(message, session_ids, session_path),
-        },
-        SandboxError::Operation {
-            operation,
-            reason,
-            message,
-        } => SandboxError::Operation {
-            operation,
-            reason,
-            message: redact_session_restore_diagnostic(message, session_ids, session_path),
-        },
-        SandboxError::IdleTransition {
-            transition,
-            message,
-        } => SandboxError::IdleTransition {
-            transition,
-            message: redact_session_restore_diagnostic(message, session_ids, session_path),
-        },
-        SandboxError::Io(error) => SandboxError::Io(std::io::Error::new(
-            error.kind(),
-            redact_session_restore_diagnostic(error.to_string(), session_ids, session_path),
-        )),
-    })
-}
-
-fn redact_session_restore_diagnostic(
-    message: String,
-    session_ids: &[&str],
-    session_path: &str,
-) -> String {
-    let mut redacted = message.replace(session_path, SESSION_PATH_SENTINEL);
-    for session_id in session_ids {
-        for sensitive in session_redaction_variants(session_id) {
-            redacted = redact_session_id_variant(redacted, &sensitive);
-        }
-    }
-    redacted
-        .replace(SESSION_PATH_SENTINEL, REDACTED_SESSION_PATH)
-        .replace(SESSION_ID_SENTINEL, REDACTED_SESSION_ID)
-}
-
-fn redact_session_id_variant(message: String, sensitive: &str) -> String {
-    if sensitive.len() >= SUBSTRING_SESSION_ID_REDACTION_MIN_LEN {
-        return message.replace(sensitive, SESSION_ID_SENTINEL);
-    }
-
-    let mut redacted = String::with_capacity(message.len());
-    let mut last = 0;
-    for (start, _) in message.match_indices(sensitive) {
-        let end = start + sensitive.len();
-        let previous = message[..start].chars().next_back();
-        let next = message[end..].chars().next();
-        if is_session_token_boundary(previous) && is_session_token_boundary(next) {
-            redacted.push_str(&message[last..start]);
-            redacted.push_str(SESSION_ID_SENTINEL);
-            last = end;
-        }
-    }
-    if last == 0 {
-        message
-    } else {
-        redacted.push_str(&message[last..]);
-        redacted
-    }
-}
-
-fn is_session_token_boundary(ch: Option<char>) -> bool {
-    !ch.is_some_and(|ch| ch.is_ascii_alphanumeric() || ch == '_')
-}
-
-fn session_redaction_variants(session_id: &str) -> Vec<String> {
-    let no_dashes = session_id.replace('-', "");
-    [
-        session_id.to_string(),
-        session_id.to_ascii_lowercase(),
-        session_id.to_ascii_uppercase(),
-        no_dashes.clone(),
-        no_dashes.to_ascii_lowercase(),
-        no_dashes.to_ascii_uppercase(),
-    ]
-    .into_iter()
-    .filter(|variant| !variant.is_empty())
-    .collect()
+        .map_err(RunnerError::Sandbox)
 }

--- a/crates/runner/src/executor/session_restore/codex.rs
+++ b/crates/runner/src/executor/session_restore/codex.rs
@@ -2,12 +2,8 @@ use sandbox::{EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, Sandbox};
 use shell_quote::quote_shell_arg;
 use tracing::info;
 
-use super::{
-    MaterializedResumeSession, SessionRestoreDiagnostics, redact_session_restore_diagnostic,
-    write_session_history_file,
-};
+use super::{MaterializedResumeSession, SessionRestoreDiagnostics, write_session_history_file};
 use crate::helper_exec::{format_helper_exec_failure, helper_exec_succeeded};
-use crate::paths::diagnostic_session_fingerprint;
 use crate::types::ExecutionContext;
 
 use super::super::{DEFAULT_EXEC_TIMEOUT, RunnerError, RunnerResult};
@@ -114,23 +110,17 @@ pub(super) async fn restore_codex_session(
     )
     .await?;
 
-    write_session_history_file(
-        sandbox,
-        &session_path,
-        &[session_id, original_session_id],
-        session_history,
-    )
-    .await?;
+    write_session_history_file(sandbox, &session_path, session_history).await?;
 
     let diagnostics = SessionRestoreDiagnostics {
         framework: "codex",
-        session_fingerprint: diagnostic_session_fingerprint(session_id),
+        session_id: session_id.to_string(),
         bytes_in: session_history.len(),
     };
     info!(
         run_id = %context.run_id,
         framework = diagnostics.framework,
-        session_fingerprint = %diagnostics.session_fingerprint,
+        session_id = %diagnostics.session_id,
         bytes_in = diagnostics.bytes_in,
         "restored session history",
     );
@@ -167,15 +157,14 @@ async fn cleanup_existing_codex_session_files(
         )
         .await?;
     if !helper_exec_succeeded(&result) {
-        return Err(RunnerError::Internal(redact_session_restore_diagnostic(
-            format_helper_exec_failure("codex session cleanup", &result),
-            &[session_id],
-            session_path,
+        return Err(RunnerError::Internal(format_helper_exec_failure(
+            "codex session cleanup",
+            &result,
         )));
     }
     info!(
         run_id = %context.run_id,
-        session_fingerprint = %diagnostic_session_fingerprint(session_id),
+        session_id = %session_id,
         "cleaned up existing codex session files before restore",
     );
     Ok(())

--- a/crates/runner/src/executor/tests/diagnostics_tests.rs
+++ b/crates/runner/src/executor/tests/diagnostics_tests.rs
@@ -25,9 +25,15 @@ use super::super::{
     ResourceFailureKind, SMALL_GUEST_FILE_MAX_BYTES, STDOUT_STREAM_LIMIT_MARKER,
     STDOUT_STREAM_OVERFLOW_MARKER, guest_runtime_path,
 };
-use super::support::{minimal_context, sandbox_exec_error, test_executor_config};
+use super::support::{
+    CapturedEvent, CapturedEvents, minimal_context, sandbox_exec_error, test_executor_config,
+};
 use crate::ids::RunId;
 use crate::paths::LogPaths;
+use tokio::sync::Mutex;
+use tracing_subscriber::prelude::*;
+
+static DIAGNOSTICS_LOG_CALLSITE_LOCK: Mutex<()> = Mutex::const_new(());
 
 fn mode(path: &Path) -> u32 {
     std::fs::metadata(path).unwrap().permissions().mode() & 0o777
@@ -417,6 +423,29 @@ async fn read_guest_cli_agent_session_id_rejects_overlong_content() {
     let session_id = read_guest_cli_agent_session_id(&sandbox, RunId::nil()).await;
 
     assert!(session_id.is_none());
+}
+
+#[tokio::test]
+async fn read_guest_cli_agent_session_id_bounds_invalid_diagnostic_field() {
+    let raw_id = format!("bad\n{}", "a".repeat(200));
+    let sandbox = MockSandbox::new("test");
+    sandbox.push_read_file_result(Ok(Some(raw_id.as_bytes().to_vec())));
+
+    let (session_id, events) =
+        capture_diagnostics_events(read_guest_cli_agent_session_id(&sandbox, RunId::nil())).await;
+
+    assert!(session_id.is_none());
+    let event = captured_event(&events, "ignoring invalid guest session ID");
+    let field = event
+        .fields
+        .get("session_id")
+        .expect("invalid session id diagnostic field should be present");
+    assert!(field.contains("bad\\n"), "got: {field}");
+    assert!(field.contains("[truncated 76 bytes]"), "got: {field}");
+    assert!(
+        !field.contains(&raw_id),
+        "diagnostic field should not contain the full invalid id: {field}"
+    );
 }
 
 #[tokio::test]
@@ -850,4 +879,30 @@ async fn append_stdout_stream_diagnostics_writes_markers() {
     expected.extend_from_slice(STDOUT_STREAM_OVERFLOW_MARKER);
     assert_eq!(content, expected);
     assert_eq!(mode(&path), 0o600);
+}
+
+async fn capture_diagnostics_events<F>(future: F) -> (F::Output, Vec<CapturedEvent>)
+where
+    F: std::future::Future,
+{
+    let _capture_guard = DIAGNOSTICS_LOG_CALLSITE_LOCK.lock().await;
+    let captured = CapturedEvents::default();
+    let subscriber = tracing_subscriber::registry().with(captured.clone());
+    let guard = tracing::subscriber::set_default(subscriber);
+    tracing::callsite::rebuild_interest_cache();
+    let output = future.await;
+    drop(guard);
+    (output, captured.entries())
+}
+
+fn captured_event<'a>(events: &'a [CapturedEvent], message: &str) -> &'a CapturedEvent {
+    events
+        .iter()
+        .find(|event| {
+            event
+                .fields
+                .get("message")
+                .is_some_and(|actual| actual == message)
+        })
+        .unwrap_or_else(|| panic!("missing event {message:?}; captured={events:#?}"))
 }

--- a/crates/runner/src/executor/tests/diagnostics_tests.rs
+++ b/crates/runner/src/executor/tests/diagnostics_tests.rs
@@ -449,6 +449,29 @@ async fn read_guest_cli_agent_session_id_bounds_invalid_diagnostic_field() {
 }
 
 #[tokio::test]
+async fn read_guest_cli_agent_session_id_truncates_invalid_diagnostic_at_char_boundary() {
+    let raw_id = "€".repeat(50);
+    let sandbox = MockSandbox::new("test");
+    sandbox.push_read_file_result(Ok(Some(raw_id.as_bytes().to_vec())));
+
+    let (session_id, events) =
+        capture_diagnostics_events(read_guest_cli_agent_session_id(&sandbox, RunId::nil())).await;
+
+    assert!(session_id.is_none());
+    let event = captured_event(&events, "ignoring invalid guest session ID");
+    let field = event
+        .fields
+        .get("session_id")
+        .expect("invalid session id diagnostic field should be present");
+    assert!(field.contains("\\u{20ac}"), "got: {field}");
+    assert!(field.ends_with("...[truncated 24 bytes]"), "got: {field}");
+    assert!(
+        !field.contains(&raw_id),
+        "diagnostic field should not contain the full invalid id: {field}"
+    );
+}
+
+#[tokio::test]
 async fn read_guest_failure_diagnostic_file_returns_valid_diagnostic() {
     let sandbox = MockSandbox::new("test");
     let diagnostic = FailureDiagnostic::new(

--- a/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
@@ -175,7 +175,7 @@ async fn execute_inner_preserves_system_stream_log_after_nonzero_exit_guest_copy
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn execute_prepared_sandbox_run_logs_guest_session_fingerprint_without_raw_id() {
+async fn execute_prepared_sandbox_run_logs_guest_session_id() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
     let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
@@ -212,15 +212,10 @@ async fn execute_prepared_sandbox_run_logs_guest_session_fingerprint_without_raw
         outcome.discovered_cli_agent_session_id.as_deref(),
         Some(raw_session_id)
     );
-    assert_captured_events_do_not_contain(&events, raw_session_id);
     let event = captured_event(&events, "read guest session ID for parking");
     assert_eq!(
-        event.fields.get("session_fingerprint").map(String::as_str),
-        Some(crate::paths::diagnostic_session_fingerprint(raw_session_id).as_str())
-    );
-    assert!(
-        !event.fields.contains_key("session_id"),
-        "guest session read diagnostic must not include raw session_id field: {event:#?}"
+        event.fields.get("session_id").map(String::as_str),
+        Some(raw_session_id)
     );
 }
 
@@ -265,11 +260,10 @@ async fn execute_prepared_sandbox_run_canonicalizes_codex_discovered_cli_agent_s
         outcome.discovered_cli_agent_session_id.as_deref(),
         Some(canonical_session_id)
     );
-    assert_captured_events_do_not_contain(&events, raw_session_id);
     let event = captured_event(&events, "read guest session ID for parking");
     assert_eq!(
-        event.fields.get("session_fingerprint").map(String::as_str),
-        Some(crate::paths::diagnostic_session_fingerprint(canonical_session_id).as_str())
+        event.fields.get("session_id").map(String::as_str),
+        Some(canonical_session_id)
     );
 }
 
@@ -309,15 +303,14 @@ async fn execute_prepared_sandbox_run_ignores_non_uuid_codex_discovered_cli_agen
 
     assert_eq!(outcome.exit_code(), 0);
     assert!(outcome.discovered_cli_agent_session_id.is_none());
-    assert_captured_events_do_not_contain(&events, raw_session_id);
     let event = captured_event(&events, "ignoring invalid guest session ID for framework");
     assert_eq!(
         event.fields.get("framework").map(String::as_str),
         Some("codex")
     );
     assert_eq!(
-        event.fields.get("session_fingerprint").map(String::as_str),
-        Some(crate::paths::diagnostic_session_fingerprint(raw_session_id).as_str())
+        event.fields.get("session_id").map(String::as_str),
+        Some(raw_session_id)
     );
 }
 
@@ -387,17 +380,6 @@ fn captured_event<'a>(events: &'a [CapturedEvent], message: &str) -> &'a Capture
                 .is_some_and(|actual| actual == message)
         })
         .unwrap_or_else(|| panic!("missing event {message:?}; captured={events:#?}"))
-}
-
-fn assert_captured_events_do_not_contain(events: &[CapturedEvent], raw: &str) {
-    for event in events {
-        for (field, value) in &event.fields {
-            assert!(
-                !value.contains(raw),
-                "captured field {field} leaked raw session id {raw:?}: {event:#?}"
-            );
-        }
-    }
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor/tests/session_restore_tests.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests.rs
@@ -11,7 +11,6 @@ use super::super::DEFAULT_EXEC_TIMEOUT;
 use super::super::session_id::{canonical_codex_thread_id, is_valid_session_id};
 use super::super::session_restore::{MaterializedResumeSession, restore_session};
 use super::support::{CapturedEvent, CapturedEvents, minimal_context, sandbox_write_file_error};
-use crate::paths::diagnostic_session_fingerprint;
 use crate::restored_session_identity::RestoredSessionIdentity;
 use crate::types::{
     ResumeSession, ResumeSessionHistory, ResumeSessionHistoryRef, ResumeSessionHistoryRefKind,
@@ -236,7 +235,7 @@ async fn restore_session_rejects_invalid_session_id() {
 }
 
 #[test]
-fn restore_session_logs_fingerprint_without_raw_claude_session_id() {
+fn restore_session_logs_claude_session_id() {
     let sandbox = MockSandbox::new("test");
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "claude-code".into();
@@ -247,20 +246,16 @@ fn restore_session_logs_fingerprint_without_raw_claude_session_id() {
 
     let diagnostics = result.unwrap();
     assert_eq!(diagnostics.framework, "claude-code");
-    assert_eq!(
-        diagnostics.session_fingerprint,
-        diagnostic_session_fingerprint(raw_session_id)
-    );
+    assert_eq!(diagnostics.session_id, raw_session_id);
     assert_eq!(diagnostics.bytes_in, session.history_bytes().len());
-    assert_captured_events_do_not_contain(&events, raw_session_id);
     let event = captured_event(&events, "restored session history");
     assert_eq!(
         event.fields.get("framework").map(String::as_str),
         Some("claude-code")
     );
     assert_eq!(
-        event.fields.get("session_fingerprint").map(String::as_str),
-        Some(diagnostic_session_fingerprint(raw_session_id).as_str())
+        event.fields.get("session_id").map(String::as_str),
+        Some(raw_session_id)
     );
     assert!(
         !event.fields.contains_key("path"),
@@ -349,7 +344,7 @@ fn restore_session_writes_codex_session() {
 }
 
 #[test]
-fn restore_session_logs_fingerprint_without_raw_codex_session_id() {
+fn restore_session_logs_codex_session_id() {
     let sandbox = MockSandbox::new("test");
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "codex".into();
@@ -360,23 +355,16 @@ fn restore_session_logs_fingerprint_without_raw_codex_session_id() {
 
     let diagnostics = result.unwrap();
     assert_eq!(diagnostics.framework, "codex");
-    assert_eq!(
-        diagnostics.session_fingerprint,
-        diagnostic_session_fingerprint(raw_session_id)
-    );
+    assert_eq!(diagnostics.session_id, raw_session_id);
     assert_eq!(diagnostics.bytes_in, session.history_bytes().len());
-    assert_captured_events_do_not_contain(&events, raw_session_id);
     let restore_event = captured_event(&events, "restored session history");
     assert_eq!(
         restore_event.fields.get("framework").map(String::as_str),
         Some("codex")
     );
     assert_eq!(
-        restore_event
-            .fields
-            .get("session_fingerprint")
-            .map(String::as_str),
-        Some(diagnostic_session_fingerprint(raw_session_id).as_str())
+        restore_event.fields.get("session_id").map(String::as_str),
+        Some(raw_session_id)
     );
     assert!(
         !restore_event.fields.contains_key("path"),
@@ -602,7 +590,7 @@ async fn restore_session_fails_when_codex_cleanup_exceeds_scan_budget() {
 }
 
 #[tokio::test]
-async fn restore_session_redacts_codex_cleanup_failure_output() {
+async fn restore_session_preserves_codex_cleanup_failure_output() {
     let sandbox = MockSandbox::new("test");
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "codex".into();
@@ -633,25 +621,14 @@ async fn restore_session_redacts_codex_cleanup_failure_output() {
 
     let message = err.to_string();
     assert!(message.contains("codex session cleanup failed"));
-    assert!(message.contains("[redacted-session-path]"));
-    assert!(message.contains("[redacted-session-id]"));
-    assert!(
-        !message.contains(session_id),
-        "cleanup failure must not echo raw session id: {message}"
-    );
-    assert!(
-        !message.contains(&session_id_no_dashes),
-        "cleanup failure must not echo no-dash session id: {message}"
-    );
-    assert!(
-        !message.contains(session_path),
-        "cleanup failure must not echo raw session path: {message}"
-    );
+    assert!(message.contains(session_id), "got: {message}");
+    assert!(message.contains(&session_id_no_dashes), "got: {message}");
+    assert!(message.contains(session_path), "got: {message}");
     assert!(sandbox.write_file_calls().is_empty());
 }
 
 #[tokio::test]
-async fn restore_session_redacts_non_exited_codex_cleanup_failure_output() {
+async fn restore_session_preserves_non_exited_codex_cleanup_failure_output() {
     let sandbox = MockSandbox::new("test");
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "codex".into();
@@ -685,15 +662,14 @@ async fn restore_session_redacts_non_exited_codex_cleanup_failure_output() {
 
     let message = err.to_string();
     assert!(message.contains("codex session cleanup failed (wait failed)"));
-    assert!(message.contains("[redacted-session-path]"));
-    assert!(message.contains("[redacted-session-id]"));
-    assert!(!message.contains(session_id));
-    assert!(!message.contains(&session_id_no_dashes));
+    assert!(message.contains(session_id), "got: {message}");
+    assert!(message.contains(&session_id_no_dashes), "got: {message}");
+    assert!(message.contains(session_path), "got: {message}");
     assert!(sandbox.write_file_calls().is_empty());
 }
 
 #[tokio::test]
-async fn restore_session_redacts_claude_write_file_error() {
+async fn restore_session_preserves_claude_write_file_error() {
     let sandbox = MockSandbox::new("test");
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "claude-code".into();
@@ -708,20 +684,12 @@ async fn restore_session_redacts_claude_write_file_error() {
     let err = restore_session(&sandbox, &ctx, &session).await.unwrap_err();
 
     let message = err.to_string();
-    assert!(message.contains("[redacted-session-path]"));
-    assert!(message.contains("[redacted-session-id]"));
-    assert!(
-        !message.contains(session_id),
-        "write failure must not echo raw session id: {message}"
-    );
-    assert!(
-        !message.contains(session_path),
-        "write failure must not echo raw session path: {message}"
-    );
+    assert!(message.contains(session_id), "got: {message}");
+    assert!(message.contains(session_path), "got: {message}");
 }
 
 #[tokio::test]
-async fn restore_session_redacts_codex_write_file_error() {
+async fn restore_session_preserves_codex_write_file_error() {
     let sandbox = MockSandbox::new("test");
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "codex".into();
@@ -749,24 +717,13 @@ async fn restore_session_redacts_codex_write_file_error() {
     let err = restore_session(&sandbox, &ctx, &session).await.unwrap_err();
 
     let message = err.to_string();
-    assert!(message.contains("[redacted-session-path]"));
-    assert!(message.contains("[redacted-session-id]"));
-    assert!(
-        !message.contains(session_id),
-        "write failure must not echo raw session id: {message}"
-    );
-    assert!(
-        !message.contains(&session_id_no_dashes),
-        "write failure must not echo no-dash session id: {message}"
-    );
-    assert!(
-        !message.contains(session_path),
-        "write failure must not echo raw session path: {message}"
-    );
+    assert!(message.contains(session_id), "got: {message}");
+    assert!(message.contains(&session_id_no_dashes), "got: {message}");
+    assert!(message.contains(session_path), "got: {message}");
 }
 
 #[tokio::test]
-async fn restore_session_redacts_codex_original_no_dash_write_file_error() {
+async fn restore_session_preserves_codex_original_no_dash_write_file_error() {
     let sandbox = MockSandbox::new("test");
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "codex".into();
@@ -794,24 +751,13 @@ async fn restore_session_redacts_codex_original_no_dash_write_file_error() {
     let err = restore_session(&sandbox, &ctx, &session).await.unwrap_err();
 
     let message = err.to_string();
-    assert!(message.contains("[redacted-session-path]"));
-    assert!(message.contains("[redacted-session-id]"));
-    assert!(
-        !message.contains(raw_session_id),
-        "write failure must not echo raw no-dash session id: {message}"
-    );
-    assert!(
-        !message.contains(canonical_session_id),
-        "write failure must not echo canonical session id: {message}"
-    );
-    assert!(
-        !message.contains(session_path),
-        "write failure must not echo raw session path: {message}"
-    );
+    assert!(message.contains(raw_session_id), "got: {message}");
+    assert!(message.contains(canonical_session_id), "got: {message}");
+    assert!(message.contains(session_path), "got: {message}");
 }
 
 #[tokio::test]
-async fn restore_session_redacts_codex_mixed_case_original_write_file_error() {
+async fn restore_session_preserves_codex_mixed_case_original_write_file_error() {
     let sandbox = MockSandbox::new("test");
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "codex".into();
@@ -838,19 +784,12 @@ async fn restore_session_redacts_codex_mixed_case_original_write_file_error() {
     let err = restore_session(&sandbox, &ctx, &session).await.unwrap_err();
 
     let message = err.to_string();
-    assert!(message.contains("[redacted-session-id]"));
-    assert!(
-        !message.contains(raw_session_id),
-        "write failure must not echo mixed-case raw session id: {message}"
-    );
-    assert!(
-        !message.contains(canonical_session_id),
-        "write failure must not echo canonical session id: {message}"
-    );
+    assert!(message.contains(raw_session_id), "got: {message}");
+    assert!(message.contains(canonical_session_id), "got: {message}");
 }
 
 #[tokio::test]
-async fn restore_session_redacts_write_file_invalid_state() {
+async fn restore_session_preserves_write_file_invalid_state() {
     let sandbox = MockSandbox::new("test");
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "claude-code".into();
@@ -867,20 +806,12 @@ async fn restore_session_redacts_write_file_invalid_state() {
     let err = restore_session(&sandbox, &ctx, &session).await.unwrap_err();
 
     let message = err.to_string();
-    assert!(message.contains("[redacted-session-path]"));
-    assert!(message.contains("[redacted-session-id]"));
-    assert!(
-        !message.contains(session_id),
-        "invalid-state failure must not echo raw session id: {message}"
-    );
-    assert!(
-        !message.contains(session_path),
-        "invalid-state failure must not echo raw session path: {message}"
-    );
+    assert!(message.contains(session_id), "got: {message}");
+    assert!(message.contains(session_path), "got: {message}");
 }
 
 #[tokio::test]
-async fn restore_session_redaction_does_not_rewrite_markers() {
+async fn restore_session_preserves_session_path_and_id_words() {
     let sandbox = MockSandbox::new("test");
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "claude-code".into();
@@ -895,21 +826,13 @@ async fn restore_session_redaction_does_not_rewrite_markers() {
 
     let message = err.to_string();
     assert!(
-        message.contains("failed to write [redacted-session-path] for [redacted-session-id]"),
-        "redaction markers should stay readable: {message}"
-    );
-    assert!(
-        !message.contains("[redacted-[redacted-session-id]"),
-        "redaction markers must not be recursively rewritten: {message}"
-    );
-    assert!(
-        !message.contains(session_path),
-        "write failure must not echo raw session path: {message}"
+        message.contains(&format!("failed to write {session_path} for {session_id}")),
+        "got: {message}"
     );
 }
 
 #[tokio::test]
-async fn restore_session_redaction_preserves_words_for_short_ids() {
+async fn restore_session_preserves_short_session_id() {
     let sandbox = MockSandbox::new("test");
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "claude-code".into();
@@ -924,16 +847,8 @@ async fn restore_session_redaction_preserves_words_for_short_ids() {
 
     let message = err.to_string();
     assert!(
-        message.contains("failed to write [redacted-session-path] for [redacted-session-id]"),
-        "short session id redaction should preserve surrounding words: {message}"
-    );
-    assert!(
-        !message.contains("f[redacted-session-id]iled"),
-        "short session id redaction must not rewrite ordinary words: {message}"
-    );
-    assert!(
-        !message.contains(session_path),
-        "write failure must not echo raw session path: {message}"
+        message.contains(&format!("failed to write {session_path} for {session_id}")),
+        "got: {message}"
     );
 }
 
@@ -1052,15 +967,4 @@ fn captured_event<'a>(events: &'a [CapturedEvent], message: &str) -> &'a Capture
                 .is_some_and(|actual| actual == message)
         })
         .unwrap_or_else(|| panic!("missing event {message:?}; captured={events:#?}"))
-}
-
-fn assert_captured_events_do_not_contain(events: &[CapturedEvent], raw: &str) {
-    for event in events {
-        for (field, value) in &event.fields {
-            assert!(
-                !value.contains(raw),
-                "captured field {field} leaked raw session id {raw:?}: {event:#?}"
-            );
-        }
-    }
 }

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -53,15 +53,6 @@ pub(crate) fn base_dir_lock_name(base_dir: &Path) -> String {
     format!("base-dir-{hash}.lock")
 }
 
-/// Stable non-reversible label for diagnostics that need to correlate one CLI
-/// session across logs without exposing the resumable session ID.
-///
-/// Do not use this value for resume, parking, cache metadata, or API payloads;
-/// it is diagnostic-only.
-pub(crate) fn diagnostic_session_fingerprint(session_id: &str) -> String {
-    short_digest(session_id)
-}
-
 /// Versioned digest key for host-shared session workspace image baselines.
 ///
 /// The raw CLI session id is untrusted and must not be embedded directly in
@@ -574,20 +565,6 @@ mod tests {
         assert_eq!(home.ca_dir(), PathBuf::from("/test/ca"));
         assert_eq!(home.debootstrap_dir(), PathBuf::from("/test/debootstrap"));
         assert_eq!(home.locks_dir(), PathBuf::from("/test/locks"));
-    }
-
-    #[test]
-    fn diagnostic_session_fingerprint_is_stable_short_hex() {
-        let raw_session_id = "sess-sensitive-paths-17975";
-        let fingerprint = diagnostic_session_fingerprint(raw_session_id);
-
-        assert_eq!(fingerprint, diagnostic_session_fingerprint(raw_session_id));
-        assert_ne!(fingerprint, raw_session_id);
-        assert_eq!(fingerprint.len(), 16);
-        assert!(
-            fingerprint.bytes().all(|byte| byte.is_ascii_hexdigit()),
-            "fingerprint should be hex: {fingerprint}"
-        );
     }
 
     #[test]

--- a/crates/runner/src/workspace_image_cache/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/lifecycle.rs
@@ -9,7 +9,6 @@ use tracing::{info, warn};
 
 use crate::error::{RunnerError, RunnerResult};
 use crate::ids::RunId;
-use crate::paths::diagnostic_session_fingerprint;
 use crate::storage_fingerprints::StorageFingerprints;
 use crate::types::{HeldSessionState, MAX_HELD_SESSION_STATES};
 
@@ -1162,12 +1161,11 @@ impl WorkspaceImagePromotionContext {
             ..
         } = self;
         let Some(_entry_lock) = entry_lock else {
-            let session_fingerprint = diagnostic_session_fingerprint(&cli_agent_session_id);
             info!(
                 run_id = %run_id,
                 sandbox_id = %sandbox_id,
                 profile_name,
-                session_fingerprint = %session_fingerprint,
+                session_id = %cli_agent_session_id,
                 cache_key,
                 reason,
                 "workspace image cache promotion context abandoned without entry lock"

--- a/crates/runner/src/workspace_promotion.rs
+++ b/crates/runner/src/workspace_promotion.rs
@@ -4,7 +4,6 @@ use futures_util::FutureExt;
 use sandbox::Sandbox;
 use tracing::warn;
 
-use crate::paths::diagnostic_session_fingerprint;
 use crate::workspace_image_cache::{
     WorkspaceImagePromotionContext, WorkspaceImagePromotionOutcome,
 };
@@ -38,13 +37,11 @@ pub(crate) async fn promote_workspace_image_from_active_sandbox(
             false
         }
         Err(_) => {
-            let session_fingerprint =
-                diagnostic_session_fingerprint(promotion.cli_agent_session_id());
             warn!(
                 run_id = %promotion.run_id(),
                 sandbox_id = %promotion.sandbox_id(),
                 profile_name = promotion.profile_name(),
-                session_fingerprint = %session_fingerprint,
+                session_id = %promotion.cli_agent_session_id(),
                 reason,
                 "workspace image cache promotion panicked"
             );
@@ -62,13 +59,11 @@ async fn promote_workspace_image_from_active_sandbox_inner(
     match flush_and_unmount_workspace_drive(sandbox, promotion.run_id()).await {
         Ok(()) => {}
         Err(e) => {
-            let session_fingerprint =
-                diagnostic_session_fingerprint(promotion.cli_agent_session_id());
             warn!(
                 run_id = %promotion.run_id(),
                 sandbox_id = %promotion.sandbox_id(),
                 profile_name = promotion.profile_name(),
-                session_fingerprint = %session_fingerprint,
+                session_id = %promotion.cli_agent_session_id(),
                 reason,
                 error = %e,
                 "workspace image cache promotion skipped because guest unmount failed"
@@ -86,13 +81,11 @@ async fn promote_workspace_image_from_active_sandbox_inner(
             WorkspacePromotionAction::AbandonUnpublished
         }
         Err(e) => {
-            let session_fingerprint =
-                diagnostic_session_fingerprint(promotion.cli_agent_session_id());
             warn!(
                 run_id = %promotion.run_id(),
                 sandbox_id = %promotion.sandbox_id(),
                 profile_name = promotion.profile_name(),
-                session_fingerprint = %session_fingerprint,
+                session_id = %promotion.cli_agent_session_id(),
                 reason,
                 error = %e,
                 "workspace image cache promotion failed"
@@ -114,13 +107,11 @@ pub(crate) async fn promote_workspace_image_from_parked_sandbox(
     match AssertUnwindSafe(sandbox.unpark()).catch_unwind().await {
         Ok(Ok(())) => {}
         Ok(Err(e)) => {
-            let session_fingerprint =
-                diagnostic_session_fingerprint(promotion.cli_agent_session_id());
             warn!(
                 run_id = %promotion.run_id(),
                 sandbox_id = %promotion.sandbox_id(),
                 profile_name = promotion.profile_name(),
-                session_fingerprint = %session_fingerprint,
+                session_id = %promotion.cli_agent_session_id(),
                 reason,
                 error = %e,
                 "workspace image cache promotion skipped because idle sandbox unpark failed"
@@ -129,13 +120,11 @@ pub(crate) async fn promote_workspace_image_from_parked_sandbox(
             return false;
         }
         Err(_) => {
-            let session_fingerprint =
-                diagnostic_session_fingerprint(promotion.cli_agent_session_id());
             warn!(
                 run_id = %promotion.run_id(),
                 sandbox_id = %promotion.sandbox_id(),
                 profile_name = promotion.profile_name(),
-                session_fingerprint = %session_fingerprint,
+                session_id = %promotion.cli_agent_session_id(),
                 reason,
                 "workspace image cache promotion skipped because idle sandbox unpark panicked"
             );
@@ -157,7 +146,7 @@ pub(crate) async fn abandon_unpublished_workspace_promotion(
     let run_id = promotion.run_id();
     let sandbox_id = promotion.sandbox_id();
     let profile_name = promotion.profile_name().to_owned();
-    let session_fingerprint = diagnostic_session_fingerprint(promotion.cli_agent_session_id());
+    let cli_agent_session_id = promotion.cli_agent_session_id().to_owned();
     match promotion.abandon_unpublished(reason).await {
         Ok(abandoned) => abandoned,
         Err(e) => {
@@ -165,7 +154,7 @@ pub(crate) async fn abandon_unpublished_workspace_promotion(
                 run_id = %run_id,
                 sandbox_id = %sandbox_id,
                 profile_name,
-                session_fingerprint = %session_fingerprint,
+                session_id = %cli_agent_session_id,
                 reason,
                 error = %e,
                 "workspace image cache promotion context abandonment failed"

--- a/crates/runner/src/workspace_promotion/tests.rs
+++ b/crates/runner/src/workspace_promotion/tests.rs
@@ -190,7 +190,7 @@ async fn parked_workspace_promotion_unpark_error_abandons_consumed_cache_hit() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn parked_workspace_promotion_warning_uses_session_fingerprint() {
+async fn parked_workspace_promotion_warning_uses_session_id() {
     let raw_session_id = "sess-sensitive-promotion-17975";
     let fixture = WorkspacePromotionFixture::new(raw_session_id).await;
     let overrides = Arc::new(MockSandboxOverrides::new());
@@ -208,18 +208,13 @@ async fn parked_workspace_promotion_warning_uses_session_fingerprint() {
     .await;
 
     assert!(!promoted);
-    assert_captured_events_do_not_contain(&events, raw_session_id);
     let event = captured_event(
         &events,
         "workspace image cache promotion skipped because idle sandbox unpark failed",
     );
     assert_eq!(
-        event.fields.get("session_fingerprint").map(String::as_str),
-        Some(crate::paths::diagnostic_session_fingerprint(raw_session_id).as_str())
-    );
-    assert!(
-        !event.fields.contains_key("session_id"),
-        "promotion diagnostic must not include raw session_id field: {event:#?}"
+        event.fields.get("session_id").map(String::as_str),
+        Some(raw_session_id)
     );
 }
 
@@ -304,15 +299,4 @@ fn captured_event<'a>(events: &'a [CapturedEvent], message: &str) -> &'a Capture
                 .is_some_and(|actual| actual == message)
         })
         .unwrap_or_else(|| panic!("missing event {message:?}; captured={events:#?}"))
-}
-
-fn assert_captured_events_do_not_contain(events: &[CapturedEvent], raw: &str) {
-    for event in events {
-        for (field, value) in &event.fields {
-            assert!(
-                !value.contains(raw),
-                "captured field {field} leaked raw session id {raw:?}: {event:#?}"
-            );
-        }
-    }
 }


### PR DESCRIPTION
## Summary

- expose raw CLI session/thread IDs in runner diagnostics instead of logging session fingerprints
- stop registering session, resume, and thread IDs as runtime secrets in guest-agent masking
- simplify `SecretMasker` to immutable secret-value masking from `VM0_SECRET_VALUES`
- update tests to assert session IDs stay visible while actual secrets remain masked

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml --all`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent mask -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p runner session_restore -- --nocapture`
- pre-commit: cargo fmt, cargo doc, cargo clippy
