### PR TITLE
fix: keep chat draft until local send starts

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-signals.ts
@@ -1,7 +1,6 @@
 import type { Command, Computed } from "ccstate";
 import type {
   ChatThreadArtifactRun,
-  GenerationTemplateRequest,
   ModelSelectionRequest,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import type { ModelProviderSelection } from "../../views/zero-page/components/model-provider-picker.tsx";
@@ -26,7 +25,6 @@ export interface ActiveGoalState {
 export interface SendMessageOptions {
   readonly revokesMessageId?: string;
   readonly includeDraftAttachments?: boolean;
-  readonly generationTemplate?: GenerationTemplateRequest;
   readonly computerUseHostId?: string | null;
 }
 
@@ -60,12 +58,7 @@ export interface ChatThreadSignals {
   >;
   queueMessage$: Command<
     Promise<void>,
-    [
-      string,
-      GenerationTemplateRequest | undefined,
-      string | null | undefined,
-      AbortSignal,
-    ]
+    [string, string | null | undefined, AbortSignal]
   >;
   recallMessage$: Command<Promise<void>, [EnrichedChatMessage, AbortSignal]>;
   cancelRun$: Command<Promise<void>, [AbortSignal]>;

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -2454,11 +2454,13 @@ function createSendOptimisticMessageEntry({
   threadId,
   clientMessageId,
   result,
+  generationTemplate,
   options,
 }: {
   threadId: string;
   clientMessageId: string;
   result: PreparedSendMessageResult;
+  generationTemplate: GenerationTemplateRequest | undefined;
   options: SendMessageOptions | undefined;
 }): OptimisticChatMessageEntry {
   return {
@@ -2469,7 +2471,7 @@ function createSendOptimisticMessageEntry({
       role: "user",
       content: result.prompt,
       attachFiles: result.attachments,
-      generationTemplate: options?.generationTemplate,
+      generationTemplate,
       ...sendMessageRevocationPatch(options),
       createdAt: nowDate().toISOString(),
     },
@@ -2530,6 +2532,7 @@ function createSendMessage(deps: SendMessageDeps) {
         L.debug("sendMessage$ no agentId, abort", { threadId });
         return;
       }
+      const generationTemplate = get(draft.generationTemplate$);
       const hasVisualAttachments = hasVisualDraftAttachments(
         get(draft.attachments$),
       );
@@ -2574,6 +2577,7 @@ function createSendMessage(deps: SendMessageDeps) {
           threadId,
           clientMessageId,
           result,
+          generationTemplate,
           options,
         }),
       );
@@ -2598,7 +2602,7 @@ function createSendMessage(deps: SendMessageDeps) {
               hasTextContent: result.hasTextContent,
               clientMessageId,
               modelSelection,
-              generationTemplate: options?.generationTemplate,
+              generationTemplate,
               ...(options && "computerUseHostId" in options
                 ? { computerUseHostId: options.computerUseHostId ?? null }
                 : {}),
@@ -2662,7 +2666,6 @@ function createQueueMessage(deps: QueueMessageDeps) {
     async (
       { get, set },
       prompt: string,
-      generationTemplate: GenerationTemplateRequest | undefined,
       computerUseHostId: string | null | undefined,
       signal: AbortSignal,
     ) => {
@@ -2673,6 +2676,7 @@ function createQueueMessage(deps: QueueMessageDeps) {
         L.debug("queueMessage$ no thread data, abort", { threadId });
         return;
       }
+      const generationTemplate = get(draft.generationTemplate$);
 
       const modelSelection = await get(modelSelection$);
       signal.throwIfAborted();

--- a/turbo/apps/platform/src/signals/zero-page/chat-draft.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-draft.ts
@@ -3,7 +3,10 @@ import { resetSignal, tapError } from "../utils.ts";
 import { currentChatThreadId$ } from "../agent-chat.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { accept } from "../../lib/accept.ts";
-import type { PersistedAttachment } from "@vm0/api-contracts/contracts/chat-threads";
+import type {
+  GenerationTemplateRequest,
+  PersistedAttachment,
+} from "@vm0/api-contracts/contracts/chat-threads";
 import { zeroUploadsContract } from "@vm0/api-contracts/contracts/zero-uploads";
 import { toast } from "@vm0/ui/components/ui/sonner";
 
@@ -204,6 +207,11 @@ function createChatAttachment(file: File): ZeroChatAttachment {
 export interface DraftSignals {
   input$: Computed<string>;
   setInput$: Command<void, [string]>;
+  generationTemplate$: Computed<GenerationTemplateRequest | undefined>;
+  setGenerationTemplate$: Command<
+    void,
+    [GenerationTemplateRequest | undefined]
+  >;
   attachments$: Computed<ZeroChatAttachment[]>;
   attachmentUploadSummary$: Computed<Promise<AttachmentUploadSummary>>;
   uploadAttachment$: Command<Promise<void>, [File, AbortSignal]>;
@@ -211,7 +219,7 @@ export interface DraftSignals {
   removeAttachment$: Command<void, [ZeroChatAttachment]>;
   dragOver$: Computed<boolean>;
   setDragOver$: Command<void, [boolean]>;
-  /** Reset all draft state (input, attachments). Called after send. */
+  /** Reset all draft state (input, template, attachments). Called after send. */
   clear$: Command<void, []>;
   /** Seed draft from persisted server data. Only called when local cache was empty. */
   seed$: Command<void, [content: string, attachments: ZeroChatAttachment[]]>;
@@ -252,6 +260,9 @@ export function createRestoredAttachment(
 
 export function createDraftSignals(): DraftSignals {
   const internalInput$ = state("");
+  const internalGenerationTemplate$ = state<
+    GenerationTemplateRequest | undefined
+  >(undefined);
   const internalAttachments$ = state<ZeroChatAttachment[]>([]);
   const internalDragOver$ = state(false);
 
@@ -261,6 +272,15 @@ export function createDraftSignals(): DraftSignals {
   const setInput$ = command(({ set }, value: string) => {
     set(internalInput$, value);
   });
+
+  const generationTemplate$ = computed((get) => {
+    return get(internalGenerationTemplate$);
+  });
+  const setGenerationTemplate$ = command(
+    ({ set }, value: GenerationTemplateRequest | undefined) => {
+      set(internalGenerationTemplate$, value);
+    },
+  );
 
   const attachments$ = computed((get) => {
     return get(internalAttachments$);
@@ -333,6 +353,7 @@ export function createDraftSignals(): DraftSignals {
 
   const clear$ = command(({ get, set }) => {
     set(internalInput$, "");
+    set(internalGenerationTemplate$, undefined);
     // Cancel all pending uploads before clearing
     for (const attachment of get(internalAttachments$)) {
       set(attachment.cancel$);
@@ -351,6 +372,8 @@ export function createDraftSignals(): DraftSignals {
   return {
     input$,
     setInput$,
+    generationTemplate$,
+    setGenerationTemplate$,
     attachments$,
     attachmentUploadSummary$,
     uploadAttachment$,

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
@@ -374,19 +374,3 @@ export const setNewThreadGenerationTemplate$ = command(
     set(internalNewThreadGenerationTemplate$, value);
   },
 );
-
-interface ThreadGenerationTemplateState {
-  readonly threadId: string;
-  readonly value: GenerationTemplateRequest | undefined;
-}
-
-const internalThreadGenerationTemplate$ =
-  state<ThreadGenerationTemplateState | null>(null);
-export const threadGenerationTemplate$ = computed((get) => {
-  return get(internalThreadGenerationTemplate$);
-});
-export const setThreadGenerationTemplate$ = command(
-  ({ set }, threadId: string, value: GenerationTemplateRequest | undefined) => {
-    set(internalThreadGenerationTemplate$, { threadId, value });
-  },
-);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -1981,6 +1981,53 @@ describe("chat composer templates", () => {
     });
   });
 
+  it("keeps the draft visible while send waits for draft attachments", async () => {
+    const user = userEvent.setup({ delay: null });
+    const template = PRESENTATION_TEMPLATE_PICKER_ITEMS[0]!;
+    mockChatLifecycle(context, { threadId: THREAD_ID });
+    context.mocks.upload.pending({
+      id: "upload-send-pending",
+      filename: "launch-notes.txt",
+      contentType: "text/plain",
+      size: 16,
+      url: "https://example.com/launch-notes.txt",
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+    });
+
+    await selectTemplate(user, template);
+    const fileInput =
+      document.querySelector<HTMLInputElement>('input[type="file"]');
+    if (!fileInput) {
+      throw new Error("file input not found");
+    }
+    await user.upload(
+      fileInput,
+      new File(["pending notes"], "launch-notes.txt", {
+        type: "text/plain",
+      }),
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Cancel upload launch-notes.txt"),
+      ).toBeInTheDocument();
+    });
+
+    const textarea = await screen.findByPlaceholderText(PLACEHOLDER);
+    await sendMessageInUI(user, textarea as HTMLTextAreaElement, "Use this");
+
+    expect(textarea).toHaveValue("Use this");
+    expect(
+      screen.getByLabelText("Cancel upload launch-notes.txt"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(`Remove template ${template.title}`),
+    ).toBeInTheDocument();
+  });
+
   it("renders presentation template card hover previews from HTML when available", async () => {
     const template = PRESENTATION_TEMPLATE_PICKER_ITEMS[0]!;
     const prismTemplate = PRESENTATION_TEMPLATE_PICKER_ITEMS.find((item) => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -300,10 +300,6 @@ import {
   dismissFeedback$,
 } from "../../signals/zero-page/chat-feedback.ts";
 import {
-  setThreadGenerationTemplate$,
-  threadGenerationTemplate$,
-} from "../../signals/zero-page/zero-chat-composer.ts";
-import {
   computerUseHosts$,
   selectedComputerUseHostId as resolveSelectedComputerUseHostId,
   visibleComputerUseHosts,
@@ -4900,33 +4896,19 @@ function useChatThreadComposerSendState({
   modelSelection,
   computerUseHostIdForSend,
   clearComputerUseHostOverride,
-  setInput,
 }: {
   thread: ChatThreadSignals;
   modelSelection: ModelProviderSelection | null;
   computerUseHostIdForSend: string | null | undefined;
   clearComputerUseHostOverride: () => void;
-  setInput: (text: string) => void;
 }) {
   const [sendLoadable, send] = useLoadableSet(thread.sendMessage$);
   const [, queueMessage] = useLoadableSet(thread.queueMessage$);
   const rootSignal = useGet(rootSignal$);
-  const generationTemplateState = useGet(threadGenerationTemplate$);
-  const generationTemplate =
-    generationTemplateState?.threadId === thread.threadId
-      ? generationTemplateState.value
-      : undefined;
-  const setGenerationTemplate = useSet(setThreadGenerationTemplate$);
-  const clearGenerationTemplate = () => {
-    setGenerationTemplate(thread.threadId, undefined);
-  };
+  const generationTemplate = useGet(thread.draft.generationTemplate$);
+  const setGenerationTemplate = useSet(thread.draft.setGenerationTemplate$);
 
-  const handleSend = (
-    text: string,
-    selectedGenerationTemplate: GenerationTemplateRequest | undefined,
-  ) => {
-    setInput("");
-    clearGenerationTemplate();
+  const handleSend = (text: string) => {
     detach(
       (async () => {
         const computerUsePatch =
@@ -4937,9 +4919,6 @@ function useChatThreadComposerSendState({
           text,
           modelSelection,
           {
-            ...(selectedGenerationTemplate
-              ? { generationTemplate: selectedGenerationTemplate }
-              : {}),
             ...computerUsePatch,
           },
           rootSignal,
@@ -4950,21 +4929,11 @@ function useChatThreadComposerSendState({
     );
   };
 
-  const handleQueue = (
-    text: string,
-    selectedGenerationTemplate: GenerationTemplateRequest | undefined,
-  ) => {
-    setInput("");
-    clearGenerationTemplate();
+  const handleQueue = (text: string) => {
     detach(
       (async () => {
         const computerUseHostId = computerUseHostIdForSend;
-        await queueMessage(
-          text,
-          selectedGenerationTemplate,
-          computerUseHostId,
-          rootSignal,
-        );
+        await queueMessage(text, computerUseHostId, rootSignal);
         clearComputerUseHostOverride();
       })(),
       Reason.DomCallback,
@@ -4978,7 +4947,7 @@ function useChatThreadComposerSendState({
     templatePicker: {
       value: generationTemplate,
       onChange: (value: GenerationTemplateRequest | undefined) => {
-        setGenerationTemplate(thread.threadId, value);
+        setGenerationTemplate(value);
       },
     },
   };
@@ -5050,14 +5019,6 @@ function useChatThreadComposerFeedback(
   const dismiss = useSet(dismissFeedback$);
   const [, sendMessage] = useLoadableSet(thread.sendMessage$);
   const rootSignal = useGet(rootSignal$);
-  // A feedback turn can also carry the composer's template + attachments, so
-  // read the same per-thread template selection the normal send path uses.
-  const generationTemplateState = useGet(threadGenerationTemplate$);
-  const generationTemplate =
-    generationTemplateState?.threadId === thread.threadId
-      ? generationTemplateState.value
-      : undefined;
-  const setGenerationTemplate = useSet(setThreadGenerationTemplate$);
 
   // Feedback is owned by the thread it was drafted in; other threads keep their
   // own composer textarea so a draft never bleeds across chats.
@@ -5084,13 +5045,11 @@ function useChatThreadComposerFeedback(
           modelSelection,
           {
             includeDraftAttachments: true,
-            ...(generationTemplate ? { generationTemplate } : {}),
           },
           rootSignal,
         ),
         Reason.DomCallback,
       );
-      setGenerationTemplate(thread.threadId, undefined);
       dismiss();
     },
     onDismiss: () => {
@@ -5151,7 +5110,6 @@ function ChatThreadComposer({
       modelSelection,
       computerUseHostIdForSend,
       clearComputerUseHostOverride,
-      setInput,
     });
   const sending = (allFinishedResolved && !allFinished) || sendLoading;
   const skeletonVisible = useGet(thread.skeletonVisible$);


### PR DESCRIPTION
## Summary
- move existing-thread generation template selection into the chat draft signals
- let send/queue read and clear the selected template through `draft.clear$` when local send actually starts
- remove pre-send input/template clearing from the thread composer and inline feedback path
- add a regression test that keeps input, attachment, and template visible while send is still waiting on draft preparation

## Tests
- `pnpm --dir apps/platform exec vitest run src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx -t "keeps the draft visible while send waits for draft attachments|queues a selected template during an active run and clears the picker state|keeps newer template selections visible after a queued template is sent|selects and sends a workflow template from the picker" --reporter=verbose --testTimeout=20000 --hookTimeout=20000`
- `pnpm --dir apps/platform exec vitest run src/views/zero-page/__tests__/chat-inline-feedback.test.tsx -t "sends inline feedback with selected template and draft attachments" --reporter=verbose --testTimeout=20000 --hookTimeout=20000`
- `pnpm --dir apps/platform run check-types`
- `pnpm exec prettier --check apps/platform/src/signals/zero-page/chat-draft.ts apps/platform/src/signals/chat-page/chat-thread-signals.ts apps/platform/src/signals/chat-page/create-chat-thread.ts apps/platform/src/views/zero-page/zero-chat-thread-page.tsx apps/platform/src/signals/zero-page/zero-chat-composer.ts apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx`
- `git diff --check`