### PR TITLE
test(runner): verify ffmpeg in rootfs images

### DIFF
--- a/crates/runner/scripts/verify-rootfs.sh
+++ b/crates/runner/scripts/verify-rootfs.sh
@@ -304,6 +304,9 @@ check_required_executable "/usr/bin/wc" "wc"
 check_required_executable "/usr/bin/kill" "kill"
 check_required_executable "/usr/bin/sleep" "sleep"
 
+# Media workflows rely on ffmpeg being available in fresh agent runtimes.
+check_required_executable "/usr/bin/ffmpeg" "ffmpeg"
+
 # Check CLIs
 if [[ -f "${MOUNT_DIR}/usr/bin/gh" ]]; then
   echo "  gh CLI: found"

--- a/crates/runner/src/cmd/build/scripts.rs
+++ b/crates/runner/src/cmd/build/scripts.rs
@@ -491,6 +491,18 @@ exit 1
     }
 
     #[test]
+    fn template_installs_and_verifies_ffmpeg() {
+        assert!(
+            TEMPLATE_BUILD_SCRIPT.contains("sudo ffmpeg \\"),
+            "build-template.sh should install ffmpeg into sandbox templates"
+        );
+        assert!(
+            VERIFY_SCRIPT.contains(r#"check_required_executable "/usr/bin/ffmpeg" "ffmpeg""#),
+            "verify-rootfs.sh should verify ffmpeg is present in sandbox images"
+        );
+    }
+
+    #[test]
     fn verify_script_checks_sandbox_helper_runtime_commands() {
         assert!(
             VERIFY_SCRIPT.contains("resolve_rootfs_path()"),

--- a/crates/runner/src/cmd/build/scripts.rs
+++ b/crates/runner/src/cmd/build/scripts.rs
@@ -134,6 +134,33 @@ mod tests {
                 .all(|part| matches!(part.parse::<u32>(), Ok(value) if *part == value.to_string()))
     }
 
+    fn template_build_installs_apt_package(package: &str) -> bool {
+        let mut in_apt_install = false;
+        for raw_line in TEMPLATE_BUILD_SCRIPT.lines() {
+            let line = raw_line.trim();
+            if line == r#"apt-get install -y \"# {
+                in_apt_install = true;
+                continue;
+            }
+
+            if !in_apt_install {
+                continue;
+            }
+
+            let package_line = line.strip_suffix('\\').unwrap_or(line).trim();
+            if package_line
+                .split_whitespace()
+                .any(|token| token == package)
+            {
+                return true;
+            }
+            if !line.ends_with('\\') {
+                in_apt_install = false;
+            }
+        }
+        false
+    }
+
     struct ProcessGroupCleanup {
         pgid_file: PathBuf,
     }
@@ -493,7 +520,7 @@ exit 1
     #[test]
     fn template_installs_and_verifies_ffmpeg() {
         assert!(
-            TEMPLATE_BUILD_SCRIPT.contains("sudo ffmpeg \\"),
+            template_build_installs_apt_package("ffmpeg"),
             "build-template.sh should install ffmpeg into sandbox templates"
         );
         assert!(


### PR DESCRIPTION
## Summary

- require `/usr/bin/ffmpeg` during runner rootfs/template verification
- add a runner script contract test that pins both template installation and verifier coverage for ffmpeg

## Notes

`ffmpeg` was already installed by `build-template.sh`; this PR makes that runtime expectation explicit in `verify-rootfs.sh` so future image regressions fail during verification instead of surfacing in user media workflows.

Closes #19754

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p runner template_installs_and_verifies_ffmpeg`
- `cargo test --manifest-path crates/Cargo.toml -p runner verify_script_checks_sandbox_helper_runtime_commands`
- `cargo fmt --manifest-path crates/runner/Cargo.toml -- --check`
- `bash -n crates/runner/scripts/verify-rootfs.sh`
- `git diff --check`
- pre-commit hook: `cargo-fmt`, `cargo-clippy`, `cargo-doc`
