### PR TITLE
feat: support darwin x64 desktop builds

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -30,12 +30,22 @@ permissions:
 
 jobs:
   build-macos:
-    name: build-macos-arm64
-    runs-on: macos-latest
+    name: build-macos-${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: arm64
+            runner: macos-latest
+          - arch: x64
+            runner: macos-15-intel
     defaults:
       run:
         working-directory: turbo
+    env:
+      DESKTOP_ARCH: ${{ matrix.arch }}
     steps:
       - uses: actions/checkout@v7
 
@@ -94,13 +104,13 @@ jobs:
           pnpm -F @vm0/desktop upload:sentry
           node apps/desktop/scripts/run-forge-make-with-retry.js \
             --platform darwin \
-            --arch arm64 \
+            --arch "$DESKTOP_ARCH" \
             --targets @electron-forge/maker-zip
 
           desktop_dir="$PWD/apps/desktop"
           version=$(node -p "require('./apps/desktop/package.json').version")
-          forge_zip="$desktop_dir/out/make/zip/darwin/arm64/Zero Computer Use-darwin-arm64-$version.zip"
-          artifact_path="apps/desktop/out/Zero-darwin-arm64.zip"
+          forge_zip="$desktop_dir/out/make/zip/darwin/$DESKTOP_ARCH/Zero Computer Use-darwin-$DESKTOP_ARCH-$version.zip"
+          artifact_path="apps/desktop/out/Zero-darwin-$DESKTOP_ARCH.zip"
 
           if [ ! -f "$forge_zip" ]; then
             echo "No Forge zip artifact found: $forge_zip"
@@ -113,9 +123,14 @@ jobs:
 
       - name: Verify production artifact
         run: |
-          artifact_path=apps/desktop/out/Zero-darwin-arm64.zip
-          app_dir="apps/desktop/out/Zero Computer Use-darwin-arm64/Zero Computer Use.app"
+          artifact_path="apps/desktop/out/Zero-darwin-$DESKTOP_ARCH.zip"
+          app_dir="apps/desktop/out/Zero Computer Use-darwin-$DESKTOP_ARCH/Zero Computer Use.app"
           plist="$app_dir/Contents/Info.plist"
+          case "$DESKTOP_ARCH" in
+            arm64) expected_mach_arch="arm64" ;;
+            x64) expected_mach_arch="x86_64" ;;
+            *) echo "Unsupported desktop architecture: $DESKTOP_ARCH"; exit 1 ;;
+          esac
           if [ ! -f "$artifact_path" ]; then
             echo "No desktop zip artifact found"
             find apps/desktop/out -maxdepth 5 -type f -print || true
@@ -158,6 +173,8 @@ jobs:
           /usr/libexec/PlistBuddy -c "Print :CFBundleIconFile" "$plist" | grep -qx "icon.icns"
           /usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes:0:CFBundleURLName" "$plist" | grep -qx "Zero Desktop Auth"
           /usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes:0:CFBundleURLSchemes:0" "$plist" | grep -qx "ai.vm0.zero.desktop"
+          file "$app_dir/Contents/MacOS/Zero Computer Use" | grep -q "$expected_mach_arch"
+          file "$app_dir/Contents/Resources/native/computer-use-helper" | grep -q "$expected_mach_arch"
           cmp -s apps/desktop/assets/icon.icns "$app_dir/Contents/Resources/icon.icns"
           cmp -s apps/desktop/assets/icon.png "$app_dir/Contents/Resources/app/assets/icon.png"
 
@@ -170,7 +187,7 @@ jobs:
       - name: Upload unsigned macOS artifact
         uses: actions/upload-artifact@v7
         with:
-          name: zero-desktop-macos-arm64-unsigned
+          name: zero-desktop-macos-${{ matrix.arch }}-unsigned
           path: turbo/${{ steps.build-prod.outputs.path }}
           if-no-files-found: error
           retention-days: 14
@@ -209,13 +226,13 @@ jobs:
           pnpm -F @vm0/desktop upload:sentry
           node apps/desktop/scripts/run-forge-make-with-retry.js \
             --platform darwin \
-            --arch arm64 \
+            --arch "$DESKTOP_ARCH" \
             --targets @electron-forge/maker-zip
 
           desktop_dir="$PWD/apps/desktop"
           version=$(node -p "require('./apps/desktop/package.json').version")
-          forge_zip="$desktop_dir/out/make/zip/darwin/arm64/Zero CU Dev-darwin-arm64-$version.zip"
-          artifact_path="apps/desktop/out/ZeroCUDev-darwin-arm64-preview.zip"
+          forge_zip="$desktop_dir/out/make/zip/darwin/$DESKTOP_ARCH/Zero CU Dev-darwin-$DESKTOP_ARCH-$version.zip"
+          artifact_path="apps/desktop/out/ZeroCUDev-darwin-$DESKTOP_ARCH-preview.zip"
 
           if [ ! -f "$forge_zip" ]; then
             echo "No Forge preview zip artifact found: $forge_zip"
@@ -231,10 +248,15 @@ jobs:
         env:
           EXPECTED_PLATFORM_URL: ${{ steps.preview.outputs.platform-url }}
         run: |
-          artifact_path=apps/desktop/out/ZeroCUDev-darwin-arm64-preview.zip
-          app_dir="apps/desktop/out/Zero CU Dev-darwin-arm64/Zero CU Dev.app"
+          artifact_path="apps/desktop/out/ZeroCUDev-darwin-$DESKTOP_ARCH-preview.zip"
+          app_dir="apps/desktop/out/Zero CU Dev-darwin-$DESKTOP_ARCH/Zero CU Dev.app"
           plist="$app_dir/Contents/Info.plist"
           runtime_config="$app_dir/Contents/Resources/app/desktop-runtime-config.json"
+          case "$DESKTOP_ARCH" in
+            arm64) expected_mach_arch="arm64" ;;
+            x64) expected_mach_arch="x86_64" ;;
+            *) echo "Unsupported desktop architecture: $DESKTOP_ARCH"; exit 1 ;;
+          esac
           if [ ! -f "$artifact_path" ]; then
             echo "No desktop preview zip artifact found"
             find apps/desktop/out -maxdepth 5 -type f -print || true
@@ -291,6 +313,8 @@ jobs:
           /usr/libexec/PlistBuddy -c "Print :CFBundleIconFile" "$plist" | grep -qx "icon.icns"
           /usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes:0:CFBundleURLName" "$plist" | grep -qx "Zero CU Dev Desktop Auth"
           /usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes:0:CFBundleURLSchemes:0" "$plist" | grep -qx "ai.vm0.zero.desktop.dev"
+          file "$app_dir/Contents/MacOS/Zero CU Dev" | grep -q "$expected_mach_arch"
+          file "$app_dir/Contents/Resources/native/computer-use-helper" | grep -q "$expected_mach_arch"
           cmp -s apps/desktop/assets/icon.icns "$app_dir/Contents/Resources/icon.icns"
           cmp -s apps/desktop/assets/icon.png "$app_dir/Contents/Resources/app/assets/icon.png"
 
@@ -305,7 +329,7 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v7
         with:
-          name: zero-desktop-macos-arm64-preview-unsigned
+          name: zero-desktop-macos-${{ matrix.arch }}-preview-unsigned
           path: turbo/${{ steps.build-preview.outputs.path }}
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -129,18 +129,27 @@ jobs:
           echo "DB/API release coupling validated."
 
   build-desktop-release:
-    name: build-desktop-release
+    name: build-desktop-release-${{ matrix.arch }}
     needs: release-please
     if: ${{ needs.release-please.outputs.desktop_release_created == 'true' }}
-    runs-on: macos-latest
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
     environment: production
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: arm64
+            runner: macos-latest
+          - arch: x64
+            runner: macos-15-intel
     defaults:
       run:
         working-directory: turbo
     permissions:
       contents: write
     env:
+      DESKTOP_ARCH: ${{ matrix.arch }}
       DESKTOP_VERSION: ${{ needs.release-please.outputs.desktop_version }}
       RELEASE_TAG: desktop-v${{ needs.release-please.outputs.desktop_version }}
       VM0_DESKTOP_SIGNING_IDENTITY: "Developer ID Application: Max & Zoe, Inc. (C5UWSXYB67)"
@@ -179,7 +188,7 @@ jobs:
               - type: section
                 text:
                   type: mrkdwn
-                  text: "*Desktop App* building signed macOS release...\n📦 Version: `${{ needs.release-please.outputs.desktop_version }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/desktop-v${{ needs.release-please.outputs.desktop_version }}|View Release>"
+                  text: "*Desktop App* building signed macOS `${{ matrix.arch }}` release...\n📦 Version: `${{ needs.release-please.outputs.desktop_version }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/desktop-v${{ needs.release-please.outputs.desktop_version }}|View Release>"
 
       - name: Record start time
         id: timer
@@ -283,14 +292,14 @@ jobs:
           pnpm -F @vm0/desktop upload:sentry
           node apps/desktop/scripts/run-forge-make-with-retry.js \
             --platform darwin \
-            --arch arm64 \
+            --arch "$DESKTOP_ARCH" \
             --targets @electron-forge/maker-zip
 
           desktop_dir="$PWD/apps/desktop"
-          app_dir="$desktop_dir/out/Zero Computer Use-darwin-arm64/Zero Computer Use.app"
-          forge_zip="$desktop_dir/out/make/zip/darwin/arm64/Zero Computer Use-darwin-arm64-$DESKTOP_VERSION.zip"
-          zip_artifact_path="apps/desktop/out/Zero-darwin-arm64-$DESKTOP_VERSION.zip"
-          dmg_artifact_path="apps/desktop/out/Zero-darwin-arm64-$DESKTOP_VERSION.dmg"
+          app_dir="$desktop_dir/out/Zero Computer Use-darwin-$DESKTOP_ARCH/Zero Computer Use.app"
+          forge_zip="$desktop_dir/out/make/zip/darwin/$DESKTOP_ARCH/Zero Computer Use-darwin-$DESKTOP_ARCH-$DESKTOP_VERSION.zip"
+          zip_artifact_path="apps/desktop/out/Zero-darwin-$DESKTOP_ARCH-$DESKTOP_VERSION.zip"
+          dmg_artifact_path="apps/desktop/out/Zero-darwin-$DESKTOP_ARCH-$DESKTOP_VERSION.dmg"
 
           if [ ! -f "$forge_zip" ]; then
             echo "No Forge zip artifact found: $forge_zip"
@@ -321,11 +330,16 @@ jobs:
 
       - name: Verify signed and notarized macOS artifacts
         run: |
-          zip_artifact_path="apps/desktop/out/Zero-darwin-arm64-$DESKTOP_VERSION.zip"
-          dmg_artifact_path="apps/desktop/out/Zero-darwin-arm64-$DESKTOP_VERSION.dmg"
-          app_dir="apps/desktop/out/Zero Computer Use-darwin-arm64/Zero Computer Use.app"
+          zip_artifact_path="apps/desktop/out/Zero-darwin-$DESKTOP_ARCH-$DESKTOP_VERSION.zip"
+          dmg_artifact_path="apps/desktop/out/Zero-darwin-$DESKTOP_ARCH-$DESKTOP_VERSION.dmg"
+          app_dir="apps/desktop/out/Zero Computer Use-darwin-$DESKTOP_ARCH/Zero Computer Use.app"
           plist="$app_dir/Contents/Info.plist"
           dmg_mount="$RUNNER_TEMP/zero-desktop-dmg"
+          case "$DESKTOP_ARCH" in
+            arm64) expected_mach_arch="arm64" ;;
+            x64) expected_mach_arch="x86_64" ;;
+            *) echo "Unsupported desktop architecture: $DESKTOP_ARCH"; exit 1 ;;
+          esac
 
           if [ ! -f "$zip_artifact_path" ]; then
             echo "No desktop zip artifact found"
@@ -351,6 +365,8 @@ jobs:
           /usr/libexec/PlistBuddy -c "Print :CFBundleName" "$plist" | grep -qx "Zero Computer Use"
           /usr/libexec/PlistBuddy -c "Print :CFBundleDisplayName" "$plist" | grep -qx "Zero Computer Use"
           /usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "$plist" | grep -qx "ai.vm0.zero.desktop"
+          file "$app_dir/Contents/MacOS/Zero Computer Use" | grep -q "$expected_mach_arch"
+          file "$app_dir/Contents/Resources/native/computer-use-helper" | grep -q "$expected_mach_arch"
           codesign --verify --deep --strict --verbose=2 "$app_dir"
           codesign --display --verbose=4 "$app_dir" 2>&1 | grep -F "Authority=$VM0_DESKTOP_SIGNING_IDENTITY"
           xcrun stapler validate "$app_dir"
@@ -407,47 +423,6 @@ jobs:
             --repo "${{ github.repository }}" \
             --clobber
 
-      - name: Publish Desktop update manifest
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MANIFEST_TAG: desktop-updates
-        run: |
-          manifest_dir="apps/desktop/out/update-manifest"
-          manifest_path="$manifest_dir/desktop-update-manifest.json"
-          zip_url="https://github.com/${{ github.repository }}/releases/download/$RELEASE_TAG/Zero-darwin-arm64-$DESKTOP_VERSION.zip"
-
-          mkdir -p "$manifest_dir"
-          if gh release view "$MANIFEST_TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
-            if gh release view "$MANIFEST_TAG" \
-              --repo "${{ github.repository }}" \
-              --json assets \
-              --jq '.assets[].name' | grep -qx desktop-update-manifest.json; then
-              gh release download "$MANIFEST_TAG" \
-                --repo "${{ github.repository }}" \
-                --pattern desktop-update-manifest.json \
-                --dir "$manifest_dir" \
-                --clobber
-            fi
-          else
-            gh release create "$MANIFEST_TAG" \
-              --repo "${{ github.repository }}" \
-              --title "Desktop Updates" \
-              --notes "Mutable manifest used by the Desktop auto-update feed." \
-              --latest=false
-          fi
-
-          node apps/desktop/scripts/update-desktop-release-manifest.mjs \
-            --manifest "$manifest_path" \
-            --version "$DESKTOP_VERSION" \
-            --zip-url "$zip_url" \
-            --channel stable \
-            --platform darwin \
-            --arch arm64
-
-          gh release upload "$MANIFEST_TAG" "$manifest_path" \
-            --repo "${{ github.repository }}" \
-            --clobber
-
       - name: Calculate duration
         id: duration
         if: ${{ always() && steps.timer.outputs.start }}
@@ -473,7 +448,7 @@ jobs:
               - type: section
                 text:
                   type: mrkdwn
-                  text: "*Desktop App* ✅ Published signed macOS release\n📦 Version: `${{ needs.release-please.outputs.desktop_version }}`\n⏱️ `${{ steps.duration.outputs.text }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/desktop-v${{ needs.release-please.outputs.desktop_version }}|View Release>\n⬇️ <${{ github.server_url }}/${{ github.repository }}/releases/download/desktop-v${{ needs.release-please.outputs.desktop_version }}/Zero-darwin-arm64-${{ needs.release-please.outputs.desktop_version }}.dmg|Download macOS DMG>\n🔄 <${{ github.server_url }}/${{ github.repository }}/releases/download/desktop-v${{ needs.release-please.outputs.desktop_version }}/Zero-darwin-arm64-${{ needs.release-please.outputs.desktop_version }}.zip|Auto-update ZIP>"
+                  text: "*Desktop App* ✅ Published signed macOS `${{ matrix.arch }}` artifacts\n📦 Version: `${{ needs.release-please.outputs.desktop_version }}`\n⏱️ `${{ steps.duration.outputs.text }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/desktop-v${{ needs.release-please.outputs.desktop_version }}|View Release>\n⬇️ <${{ github.server_url }}/${{ github.repository }}/releases/download/desktop-v${{ needs.release-please.outputs.desktop_version }}/Zero-darwin-${{ matrix.arch }}-${{ needs.release-please.outputs.desktop_version }}.dmg|Download macOS DMG>\n🔄 <${{ github.server_url }}/${{ github.repository }}/releases/download/desktop-v${{ needs.release-please.outputs.desktop_version }}/Zero-darwin-${{ matrix.arch }}-${{ needs.release-please.outputs.desktop_version }}.zip|Auto-update ZIP>"
 
       - name: Notify Slack - Failure
         if: ${{ failure() && steps.slack-start.outputs.ts }}
@@ -494,6 +469,88 @@ jobs:
       - name: Delete temporary keychain
         if: ${{ always() && steps.signing-certificate.outputs.keychain_path != '' }}
         run: security delete-keychain "${{ steps.signing-certificate.outputs.keychain_path }}" || true
+
+  publish-desktop-update-manifest:
+    name: publish-desktop-update-manifest
+    needs: [release-please, build-desktop-release]
+    if: ${{ needs.release-please.outputs.desktop_release_created == 'true' && needs.build-desktop-release.result == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: turbo
+    permissions:
+      contents: write
+    env:
+      DESKTOP_VERSION: ${{ needs.release-please.outputs.desktop_version }}
+      RELEASE_TAG: desktop-v${{ needs.release-please.outputs.desktop_version }}
+      MANIFEST_TAG: desktop-updates
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          ref: desktop-v${{ needs.release-please.outputs.desktop_version }}
+
+      - name: Verify Desktop release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          release_assets="$(gh release view "$RELEASE_TAG" \
+            --repo "${{ github.repository }}" \
+            --json assets \
+            --jq '.assets[].name')"
+
+          for arch in arm64 x64; do
+            for extension in zip dmg; do
+              asset_name="Zero-darwin-$arch-$DESKTOP_VERSION.$extension"
+              if ! printf '%s\n' "$release_assets" | grep -qx "$asset_name"; then
+                echo "::error::Missing Desktop release asset: $asset_name"
+                printf '%s\n' "$release_assets"
+                exit 1
+              fi
+            done
+          done
+
+      - name: Publish Desktop update manifest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          manifest_dir="apps/desktop/out/update-manifest"
+          manifest_path="$manifest_dir/desktop-update-manifest.json"
+
+          mkdir -p "$manifest_dir"
+          if gh release view "$MANIFEST_TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            if gh release view "$MANIFEST_TAG" \
+              --repo "${{ github.repository }}" \
+              --json assets \
+              --jq '.assets[].name' | grep -qx desktop-update-manifest.json; then
+              gh release download "$MANIFEST_TAG" \
+                --repo "${{ github.repository }}" \
+                --pattern desktop-update-manifest.json \
+                --dir "$manifest_dir" \
+                --clobber
+            fi
+          else
+            gh release create "$MANIFEST_TAG" \
+              --repo "${{ github.repository }}" \
+              --title "Desktop Updates" \
+              --notes "Mutable manifest used by the Desktop auto-update feed." \
+              --latest=false
+          fi
+
+          for arch in arm64 x64; do
+            zip_url="https://github.com/${{ github.repository }}/releases/download/$RELEASE_TAG/Zero-darwin-$arch-$DESKTOP_VERSION.zip"
+            node apps/desktop/scripts/update-desktop-release-manifest.mjs \
+              --manifest "$manifest_path" \
+              --version "$DESKTOP_VERSION" \
+              --zip-url "$zip_url" \
+              --channel stable \
+              --platform darwin \
+              --arch "$arch"
+          done
+
+          gh release upload "$MANIFEST_TAG" "$manifest_path" \
+            --repo "${{ github.repository }}" \
+            --clobber
 
   # Run database migrations in production for API releases only. The API staged
   # deployment is built first, then migrations run, then API traffic is promoted.

--- a/turbo/apps/api/src/signals/routes/__tests__/desktop-updates.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/desktop-updates.test.ts
@@ -60,7 +60,7 @@ function stableManifest(
   };
 }
 
-function darwinArm64Release(version: string, url: string) {
+function darwinRelease(version: string, arch: "arm64" | "x64", url: string) {
   return {
     version,
     name: `Zero Computer Use ${version}`,
@@ -68,10 +68,14 @@ function darwinArm64Release(version: string, url: string) {
     pubDate: "2026-06-08T00:00:00.000Z",
     platforms: {
       darwin: {
-        arm64: { url },
+        [arch]: { url },
       },
     },
   };
+}
+
+function darwinArm64Release(version: string, url: string) {
+  return darwinRelease(version, "arm64", url);
 }
 
 describe("desktop update routes", () => {
@@ -159,6 +163,46 @@ describe("desktop update routes", () => {
         },
       ],
     });
+  });
+
+  it("serves the current stable macOS x64 update from the manifest", async () => {
+    const zipUrl =
+      "https://github.com/vm0-ai/vm0/releases/download/desktop-v0.2.1/Zero-darwin-x64-0.2.1.zip";
+    mockDesktopUpdateManifest(
+      stableManifest("0.2.1", {
+        "0.2.1": darwinRelease("0.2.1", "x64", zipUrl),
+      }),
+    );
+
+    const response = await accept(
+      client().feed({
+        params: { channel: "stable", platform: "darwin", arch: "x64" },
+      }),
+      [200],
+    );
+
+    expect(response.body.releases[0]?.updateTo.url).toBe(zipUrl);
+  });
+
+  it("redirects the x64 dmg route to the current stable desktop dmg asset", async () => {
+    mockDesktopUpdateManifest(
+      stableManifest("0.12.0", {
+        "0.12.0": darwinRelease(
+          "0.12.0",
+          "x64",
+          "https://github.com/vm0-ai/vm0/releases/download/desktop-v0.12.0/Zero-darwin-x64-0.12.0.zip",
+        ),
+      }),
+    );
+
+    const response = await appRequest(
+      "http://api.test/api/zero/desktop/updates/stable/darwin/x64/dmg",
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe(
+      "https://github.com/vm0-ai/vm0/releases/download/desktop-v0.12.0/Zero-darwin-x64-0.12.0.dmg",
+    );
   });
 
   it("does not return a blocked latest release", async () => {

--- a/turbo/apps/desktop/README.md
+++ b/turbo/apps/desktop/README.md
@@ -122,9 +122,12 @@ oracle independent from `vm0-computer` output.
 
 The `Desktop` GitHub Actions workflow builds macOS artifacts for internal
 testing. Run the workflow manually from GitHub Actions, then download the
-`zero-desktop-macos-arm64-unsigned` artifact.
+artifact that matches the target Mac:
 
-The downloaded GitHub artifact contains `Zero-darwin-arm64.zip`. Unzip both
+- `zero-desktop-macos-arm64-unsigned` for Apple Silicon Macs
+- `zero-desktop-macos-x64-unsigned` for Intel Macs
+
+The downloaded GitHub artifact contains `Zero-darwin-<arch>.zip`. Unzip both
 layers, then open `Zero Computer Use.app`.
 
 These artifacts are ad-hoc signed, not Developer ID signed, and not notarized.
@@ -143,12 +146,14 @@ Desktop releases are versioned by release-please. Changes under
 `desktop-vX.Y.Z` GitHub Release.
 
 When release-please creates the `desktop-vX.Y.Z` GitHub Release, the
-`build-desktop-release` job in the release-please workflow checks out the
-matching tag, builds the production `Zero Computer Use.app`, signs it with the
-Developer ID Application certificate, notarizes it for direct distribution
-outside the Mac App Store, validates the stapled ticket, uploads
-`Zero-darwin-arm64-X.Y.Z.zip` and `Zero-darwin-arm64-X.Y.Z.dmg` to the matching
-GitHub Release, and updates the Desktop update manifest.
+`build-desktop-release` jobs in the release-please workflow check out the
+matching tag, build the production `Zero Computer Use.app` for Apple Silicon
+and Intel Macs, sign each app with the Developer ID Application certificate,
+notarize them for direct distribution outside the Mac App Store, validate the
+stapled tickets, and upload `Zero-darwin-arm64-X.Y.Z.zip`,
+`Zero-darwin-arm64-X.Y.Z.dmg`, `Zero-darwin-x64-X.Y.Z.zip`, and
+`Zero-darwin-x64-X.Y.Z.dmg` to the matching GitHub Release. After both
+architectures finish, the release workflow updates the Desktop update manifest.
 
 Use the DMG for manual installation. It opens with a styled Finder background,
 `Zero Computer Use.app` on the left, and an `/Applications` symlink on the right

--- a/turbo/apps/desktop/src/desktop-auto-updates.test.ts
+++ b/turbo/apps/desktop/src/desktop-auto-updates.test.ts
@@ -78,19 +78,22 @@ interface CapturedUpdateOptions {
   readonly onNotifyUser: (info: { readonly releaseName: string }) => void;
 }
 
-function stubDesktopAutoUpdatePlatform(): void {
+function stubDesktopAutoUpdatePlatform(
+  arch: NodeJS.Architecture = "arm64",
+): void {
   Object.defineProperty(process, "platform", {
     configurable: true,
     value: "darwin",
   });
   Object.defineProperty(process, "arch", {
     configurable: true,
-    value: "arm64",
+    value: arch,
   });
 }
 
 function installAndCaptureUpdateOptions(
   getComputerUseHostState: () => ComputerUseHostRuntimeState,
+  expectedFeedArch: "arm64" | "x64" = "arm64",
 ): {
   readonly updateOptions: CapturedUpdateOptions;
   readonly prepareForQuitAndInstall: ReturnType<typeof vi.fn>;
@@ -113,7 +116,7 @@ function installAndCaptureUpdateOptions(
       notifyUser: true,
       updateInterval: "30 minutes",
       updateSource: expect.objectContaining({
-        baseUrl: "https://api.vm0.ai/api/desktop/updates/stable/darwin/arm64",
+        baseUrl: `https://api.vm0.ai/api/desktop/updates/stable/darwin/${expectedFeedArch}`,
       }),
     }),
   );
@@ -171,6 +174,24 @@ describe("desktop auto-updates", () => {
       expect(mocks.autoUpdater.quitAndInstall).toHaveBeenCalledTimes(1);
     });
     expect(mocks.dialog.showMessageBox).not.toHaveBeenCalled();
+  });
+
+  it("uses the x64 update feed on Intel Macs", () => {
+    stubDesktopAutoUpdatePlatform("x64");
+
+    installAndCaptureUpdateOptions(
+      () => OFFLINE_COMPUTER_USE_HOST_STATE,
+      "x64",
+    );
+
+    const [updateOptions] = mocks.updateElectronApp.mock.calls[0] ?? [];
+    expect(updateOptions).toEqual(
+      expect.objectContaining({
+        updateSource: expect.objectContaining({
+          baseUrl: "https://api.vm0.ai/api/desktop/updates/stable/darwin/x64",
+        }),
+      }),
+    );
   });
 
   it("checks for updates on request", () => {

--- a/turbo/apps/desktop/src/desktop-auto-updates.ts
+++ b/turbo/apps/desktop/src/desktop-auto-updates.ts
@@ -8,6 +8,7 @@ import {
 import type { DesktopConfig } from "./config";
 import { shouldNotifyUserForDesktopUpdate } from "./desktop-auto-update-policy";
 import {
+  desktopUpdateArchitecture,
   desktopUpdateFeedBaseUrl,
   shouldInstallDesktopAutoUpdates,
 } from "./desktop-update-feed";
@@ -97,7 +98,9 @@ async function handleDownloadedUpdate(
 export function installDesktopAutoUpdates(
   options: DesktopAutoUpdateOptions,
 ): boolean {
+  const updateArch = desktopUpdateArchitecture(process.arch);
   if (
+    !updateArch ||
     !shouldInstallDesktopAutoUpdates({
       environment: options.config.environment,
       isPackaged: app.isPackaged,
@@ -108,7 +111,7 @@ export function installDesktopAutoUpdates(
     return false;
   }
 
-  const baseUrl = desktopUpdateFeedBaseUrl(options.apiBaseUrl);
+  const baseUrl = desktopUpdateFeedBaseUrl(options.apiBaseUrl, updateArch);
   if (new URL(baseUrl).protocol !== "https:") {
     console.warn("Desktop auto-updates require an HTTPS feed URL");
     return false;

--- a/turbo/apps/desktop/src/desktop-update-feed.test.ts
+++ b/turbo/apps/desktop/src/desktop-update-feed.test.ts
@@ -6,13 +6,21 @@ import {
 } from "./desktop-update-feed";
 
 describe("desktop update feed", () => {
-  it("enables updates only for packaged production macOS arm64 builds", () => {
+  it("enables updates only for packaged production macOS arm64 and x64 builds", () => {
     expect(
       shouldInstallDesktopAutoUpdates({
         environment: "production",
         isPackaged: true,
         platform: "darwin",
         arch: "arm64",
+      }),
+    ).toBe(true);
+    expect(
+      shouldInstallDesktopAutoUpdates({
+        environment: "production",
+        isPackaged: true,
+        platform: "darwin",
+        arch: "x64",
       }),
     ).toBe(true);
 
@@ -40,11 +48,22 @@ describe("desktop update feed", () => {
         arch: "arm64",
       }),
     ).toBe(false);
+    expect(
+      shouldInstallDesktopAutoUpdates({
+        environment: "production",
+        isPackaged: true,
+        platform: "darwin",
+        arch: "ia32",
+      }),
+    ).toBe(false);
   });
 
   it("builds the static feed base URL used by update-electron-app", () => {
-    expect(desktopUpdateFeedBaseUrl("https://api.vm0.ai")).toBe(
+    expect(desktopUpdateFeedBaseUrl("https://api.vm0.ai", "arm64")).toBe(
       "https://api.vm0.ai/api/desktop/updates/stable/darwin/arm64",
+    );
+    expect(desktopUpdateFeedBaseUrl("https://api.vm0.ai", "x64")).toBe(
+      "https://api.vm0.ai/api/desktop/updates/stable/darwin/x64",
     );
   });
 });

--- a/turbo/apps/desktop/src/desktop-update-feed.ts
+++ b/turbo/apps/desktop/src/desktop-update-feed.ts
@@ -2,7 +2,8 @@ import type { DesktopConfig } from "./config";
 
 const DESKTOP_UPDATE_CHANNEL = "stable";
 const DESKTOP_UPDATE_PLATFORM = "darwin";
-const DESKTOP_UPDATE_ARCH = "arm64";
+
+type DesktopUpdateArchitecture = "arm64" | "x64";
 
 interface DesktopAutoUpdateEligibility {
   readonly environment: DesktopConfig["environment"];
@@ -18,13 +19,22 @@ export function shouldInstallDesktopAutoUpdates(
     eligibility.environment === "production" &&
     eligibility.isPackaged &&
     eligibility.platform === DESKTOP_UPDATE_PLATFORM &&
-    eligibility.arch === DESKTOP_UPDATE_ARCH
+    desktopUpdateArchitecture(eligibility.arch) !== null
   );
 }
 
-export function desktopUpdateFeedBaseUrl(apiBaseUrl: string): string {
+export function desktopUpdateArchitecture(
+  arch: NodeJS.Architecture,
+): DesktopUpdateArchitecture | null {
+  return arch === "arm64" || arch === "x64" ? arch : null;
+}
+
+export function desktopUpdateFeedBaseUrl(
+  apiBaseUrl: string,
+  arch: DesktopUpdateArchitecture,
+): string {
   const url = new URL(apiBaseUrl);
-  url.pathname = `/api/desktop/updates/${DESKTOP_UPDATE_CHANNEL}/${DESKTOP_UPDATE_PLATFORM}/${DESKTOP_UPDATE_ARCH}`;
+  url.pathname = `/api/desktop/updates/${DESKTOP_UPDATE_CHANNEL}/${DESKTOP_UPDATE_PLATFORM}/${arch}`;
   url.search = "";
   url.hash = "";
   return url.toString().replace(/\/$/, "");

--- a/turbo/apps/platform/src/signals/zero-page/computer-use-hosts.ts
+++ b/turbo/apps/platform/src/signals/zero-page/computer-use-hosts.ts
@@ -11,9 +11,16 @@ import { onRef, settle } from "../utils.ts";
 
 const ZERO_DESKTOP_DMG_DOWNLOAD_PATH =
   "/api/zero/desktop/updates/stable/darwin/arm64/dmg";
+const ZERO_DESKTOP_INTEL_DMG_DOWNLOAD_PATH =
+  "/api/zero/desktop/updates/stable/darwin/x64/dmg";
 
 export const ZERO_DESKTOP_DOWNLOAD_URL = new URL(
   ZERO_DESKTOP_DMG_DOWNLOAD_PATH,
+  resolveApiBaseForNavigation("api"),
+).toString();
+
+export const ZERO_DESKTOP_INTEL_DOWNLOAD_URL = new URL(
+  ZERO_DESKTOP_INTEL_DMG_DOWNLOAD_PATH,
   resolveApiBaseForNavigation("api"),
 ).toString();
 

--- a/turbo/apps/platform/src/views/computer-use-authorization/__tests__/computer-use-authorization-page.test.tsx
+++ b/turbo/apps/platform/src/views/computer-use-authorization/__tests__/computer-use-authorization-page.test.tsx
@@ -2,6 +2,7 @@ import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 import { zeroComputerUseAuthorizationRequestsContract } from "@vm0/api-contracts/contracts/zero-computer-use";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 
 import {
   detachedSetupPage,
@@ -262,5 +263,51 @@ describe("computer use authorization page", () => {
     });
     expect(requiredButton).toBeDisabled();
     expect(queryLinkByText("Download for macOS")).not.toBeInTheDocument();
+  });
+
+  it("shows Apple Silicon and Intel downloads when x64 downloads are enabled", async () => {
+    mockMacUserAgentData("x86");
+    context.mocks.api(
+      zeroComputerUseAuthorizationRequestsContract.get,
+      ({ respond }) => {
+        return respond(200, {
+          source: "slack",
+          expiresAt: "2026-06-25T12:00:00Z",
+          completedAt: null,
+          computerUseHostId: null,
+          hosts: [],
+        });
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/computer-use/authorize/vm0_computer_use_authorization_request_x64",
+      featureSwitches: { [FeatureSwitchKey.DesktopX64Download]: true },
+    });
+
+    await expect(
+      screen.findByText("No online computers"),
+    ).resolves.toBeInTheDocument();
+
+    const appleSiliconDownload = await waitFor(() => {
+      return linkByText("Download for Apple Silicon");
+    });
+    expect(appleSiliconDownload).toHaveAttribute(
+      "href",
+      expect.stringContaining(
+        "/api/zero/desktop/updates/stable/darwin/arm64/dmg",
+      ),
+    );
+    expect(linkByText("Download for Intel Mac")).toHaveAttribute(
+      "href",
+      expect.stringContaining(
+        "/api/zero/desktop/updates/stable/darwin/x64/dmg",
+      ),
+    );
+    expect(queryLinkByText("Download for macOS")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Requires Apple Silicon Mac"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/turbo/apps/platform/src/views/computer-use-authorization/computer-use-authorization-page.tsx
+++ b/turbo/apps/platform/src/views/computer-use-authorization/computer-use-authorization-page.tsx
@@ -8,6 +8,7 @@ import {
   IconLoader2,
 } from "@tabler/icons-react";
 import type { ComputerUseHost } from "@vm0/api-contracts/contracts/zero-computer-use";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { Button } from "@vm0/ui/components/ui/button";
 import {
   applyComputerUseAuthorizationRequest$,
@@ -17,9 +18,11 @@ import {
   zeroDesktopDownloadSupportStatus$,
   visibleComputerUseHosts,
   ZERO_DESKTOP_DOWNLOAD_URL,
+  ZERO_DESKTOP_INTEL_DOWNLOAD_URL,
   ZERO_DESKTOP_UNSUPPORTED_INTEL_MAC_LABEL,
 } from "../../signals/zero-page/computer-use-hosts.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
+import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import computerUseIllustration from "../zero-page/assets/computer-use-illustration.png";
 import { Vm0LogoLink } from "../zero-page/zero-directed-shared.tsx";
@@ -85,6 +88,9 @@ function HostOption({
 }
 
 function EmptyHosts() {
+  const features = useGet(featureSwitch$);
+  const showIntelDownload =
+    features[FeatureSwitchKey.DesktopX64Download] ?? false;
   const downloadSupportLoadable = useLoadable(
     zeroDesktopDownloadSupportStatus$,
   );
@@ -111,7 +117,28 @@ function EmptyHosts() {
           online.
         </p>
       </div>
-      {downloadSupportStatus === "unsupported-intel-mac" ? (
+      {showIntelDownload ? (
+        <div className="flex w-full max-w-sm flex-col gap-2">
+          <a
+            href={ZERO_DESKTOP_DOWNLOAD_URL}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex h-9 items-center justify-center gap-2 rounded-lg border border-border bg-background px-3 text-sm font-medium text-foreground transition-colors hover:bg-accent"
+          >
+            <IconDownload size={16} />
+            Download for Apple Silicon
+          </a>
+          <a
+            href={ZERO_DESKTOP_INTEL_DOWNLOAD_URL}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex h-9 items-center justify-center gap-2 rounded-lg border border-border bg-background px-3 text-sm font-medium text-foreground transition-colors hover:bg-accent"
+          >
+            <IconDownload size={16} />
+            Download for Intel Mac
+          </a>
+        </div>
+      ) : downloadSupportStatus === "unsupported-intel-mac" ? (
         <Button type="button" variant="outline" disabled className="h-9">
           <IconAlertTriangle size={16} />
           {ZERO_DESKTOP_UNSUPPORTED_INTEL_MAC_LABEL}

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -5829,6 +5829,45 @@ describe("chat lifecycle", () => {
     expect(queryLinkByText("Download for macOS")).not.toBeInTheDocument();
   });
 
+  it("shows Apple Silicon and Intel download links when x64 downloads are enabled", async () => {
+    mockMacUserAgentData("x86");
+    const user = userEvent.setup({ delay: null });
+    const threadId = "computer-use-download-x64";
+    mockChatLifecycle(context, { threadId });
+    context.mocks.api(zeroComputerUseHostsContract.list, ({ respond }) => {
+      return respond(200, { hosts: [] });
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${threadId}`,
+      featureSwitches: { [FeatureSwitchKey.DesktopX64Download]: true },
+    });
+
+    await user.click(await screen.findByLabelText("Connectors"));
+    await user.click(await screen.findByText("Connect my computer"));
+
+    const appleSiliconDownload = await waitFor(() => {
+      return linkByText("Download for Apple Silicon");
+    });
+    expect(appleSiliconDownload).toHaveAttribute(
+      "href",
+      expect.stringContaining(
+        "/api/zero/desktop/updates/stable/darwin/arm64/dmg",
+      ),
+    );
+    expect(linkByText("Download for Intel Mac")).toHaveAttribute(
+      "href",
+      expect.stringContaining(
+        "/api/zero/desktop/updates/stable/darwin/x64/dmg",
+      ),
+    );
+    expect(queryLinkByText("Download for macOS")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Requires Apple Silicon Mac"),
+    ).not.toBeInTheDocument();
+  });
+
   it("does not auto-select the only online Computer Use host", async () => {
     const user = userEvent.setup({ delay: null });
     const threadId = "computer-use-manual-selection";

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -155,6 +155,7 @@ import { rootSignal$ } from "../../signals/root-signal.ts";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import {
   zeroDesktopDownloadSupportStatus$,
+  ZERO_DESKTOP_INTEL_DOWNLOAD_URL,
   ZERO_DESKTOP_UNSUPPORTED_INTEL_MAC_LABEL,
 } from "../../signals/zero-page/computer-use-hosts.ts";
 import {
@@ -5829,6 +5830,9 @@ function ComputerUseDownloadDialog({
     downloadSupportLoadable.state === "hasData"
       ? downloadSupportLoadable.data
       : "checking";
+  const features = useGet(featureSwitch$);
+  const showIntelDownload =
+    features[FeatureSwitchKey.DesktopX64Download] ?? false;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -5850,7 +5854,41 @@ function ComputerUseDownloadDialog({
           </DialogDescription>
         </DialogHeader>
         <div className="px-6 pb-6 pt-4">
-          {downloadSupportStatus === "unsupported-intel-mac" ? (
+          {showIntelDownload ? (
+            <div className="flex flex-col gap-2">
+              <Button asChild size="lg" className="w-full justify-start">
+                <a
+                  href={downloadUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  onClick={() => {
+                    onOpenChange(false);
+                  }}
+                >
+                  <IconDownload size={16} stroke={1.5} />
+                  Download for Apple Silicon
+                </a>
+              </Button>
+              <Button
+                asChild
+                size="lg"
+                variant="outline"
+                className="w-full justify-start"
+              >
+                <a
+                  href={ZERO_DESKTOP_INTEL_DOWNLOAD_URL}
+                  target="_blank"
+                  rel="noreferrer"
+                  onClick={() => {
+                    onOpenChange(false);
+                  }}
+                >
+                  <IconDownload size={16} stroke={1.5} />
+                  Download for Intel Mac
+                </a>
+              </Button>
+            </div>
+          ) : downloadSupportStatus === "unsupported-intel-mac" ? (
             <Button type="button" size="lg" className="w-full" disabled>
               <IconAlertTriangle size={16} stroke={1.5} />
               {ZERO_DESKTOP_UNSUPPORTED_INTEL_MAC_LABEL}

--- a/turbo/packages/api-contracts/src/contracts/desktop-updates.ts
+++ b/turbo/packages/api-contracts/src/contracts/desktop-updates.ts
@@ -6,7 +6,7 @@ const c = initContract();
 
 const desktopUpdateChannelSchema = z.enum(["stable"]);
 const desktopUpdatePlatformSchema = z.enum(["darwin"]);
-const desktopUpdateArchitectureSchema = z.enum(["arm64"]);
+const desktopUpdateArchitectureSchema = z.enum(["arm64", "x64"]);
 
 export type DesktopUpdateChannel = z.infer<typeof desktopUpdateChannelSchema>;
 export type DesktopUpdatePlatform = z.infer<typeof desktopUpdatePlatformSchema>;

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -49,6 +49,7 @@ export enum FeatureSwitchKey {
   MemoryViewer = "memoryViewer",
   HtmlArtifactCommentEditing = "htmlArtifactCommentEditing",
   ComputerUseDelegatedAuthorization = "computerUseDelegatedAuthorization",
+  DesktopX64Download = "desktopX64Download",
   PresentationTemplateRunbook = "presentationTemplateRunbook",
   AgentUnreadIndicators = "agentUnreadIndicators",
   ImageArtifactKeyboardNavigation = "imageArtifactKeyboardNavigation",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -277,6 +277,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.DesktopX64Download]: {
+    maintainer: "lancy@vm0.ai",
+    description:
+      "Show Intel Mac download links for Zero Computer Use after darwin-x64 release artifacts are available.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.PresentationTemplateRunbook]: {
     maintainer: "bingjie@vm0.ai",
     description:


### PR DESCRIPTION
## Summary
- add darwin x64 to the desktop update contract, API tests, and auto-update feed selection
- build and verify arm64/x64 Desktop artifacts separately in CI/release, then publish the update manifest only after both architectures exist
- gate Intel Mac download links behind `DesktopX64Download` while preserving the current Apple Silicon-only fallback

Closes #19749
Related #19742

## Verification
- `pnpm exec vitest run src/desktop-update-feed.test.ts src/desktop-auto-updates.test.ts` in `turbo/apps/desktop`
- `pnpm exec vitest run src/signals/routes/__tests__/desktop-updates.test.ts` in `turbo/apps/api`
- `pnpm exec vitest run src/views/computer-use-authorization/__tests__/computer-use-authorization-page.test.tsx` in `turbo/apps/platform`
- `pnpm exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx -t "Computer Use download"` in `turbo/apps/platform`
- `pnpm --dir turbo -F @vm0/desktop check-types`
- `pnpm --dir turbo -F @vm0/app check-types`
- `pnpm --dir turbo -F @vm0/api-contracts check-types && pnpm --dir turbo -F @vm0/connectors check-types && pnpm --dir turbo -F @vm0/core check-types`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --dir turbo -F api check-types`
- `pnpm --dir turbo -F @vm0/desktop lint`
- `pnpm --dir turbo -F @vm0/api-contracts lint`
- `pnpm --dir turbo -F @vm0/connectors lint`
- `pnpm --dir turbo -F @vm0/core lint`
- `pnpm --dir turbo -F @vm0/app lint`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --dir turbo -F api lint`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/desktop.yml'); YAML.load_file('.github/workflows/release-please.yml'); puts 'workflow yaml parsed'"`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/desktop.yml .github/workflows/release-please.yml`

## Notes
- The first package-script test attempts accidentally ran whole suites and were interrupted or failed on unrelated local DB/timeout issues; the exact-file commands above passed.
- `api` type check needed a larger local Node heap and passed with `NODE_OPTIONS=--max-old-space-size=4096`.
- `pnpm --dir turbo knip`
- after knip fix: `pnpm exec vitest run src/desktop-update-feed.test.ts src/desktop-auto-updates.test.ts` in `turbo/apps/desktop`
- after knip fix: `pnpm --dir turbo -F @vm0/desktop check-types`