### PR TITLE
fix: restart full thinking typewriter lines

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -7,7 +7,6 @@ import {
   VIDEO_TEMPLATE_ITEMS,
   WORKFLOW_TEMPLATE_ITEMS,
 } from "@vm0/core";
-import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import {
   chatMessagesContract,
   type AttachFile,
@@ -44,7 +43,6 @@ import { createComputerUseBddApi } from "./helpers/api-bdd-computer-use";
 import { createFirewallApi, secretTemplate } from "./helpers/api-bdd-firewall";
 import { createRunsAutomationsApi } from "./helpers/api-bdd-runs-automations";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
-import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 import { createZeroRouteMocks } from "./helpers/zero-route-test";
 import { testChatMessagesStateRoutes } from "../test-chat-messages-state";
 
@@ -2119,19 +2117,6 @@ describe("CHAT-02: initial thinking indicator", () => {
     const { actor, agentId } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
     mockOptionalEnv("OPENROUTER_API_KEY", "thinking-key");
-    if (!actor.orgId) {
-      throw new Error("Expected entitled chat actor to belong to an org");
-    }
-    await updateFeatureSwitchesForUser(
-      context,
-      {
-        userId: actor.userId,
-        orgId: actor.orgId,
-      },
-      {
-        [FeatureSwitchKey.ChatInitialThinkingIndicator]: true,
-      },
-    );
 
     let upstreamAuthorization: string | null = null;
     let promptPayload = "";

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -2975,14 +2975,31 @@ function createCancelRunWithQueuedRecall({
 // ---------------------------------------------------------------------------
 
 const THINKING_TYPEWRITER_INTERVAL_MS = 28;
+const THINKING_TYPEWRITER_LINE_PAUSE_MS = 1000;
+const THINKING_TYPEWRITER_LINE_PAUSE_TICKS = IN_VITEST
+  ? 1
+  : Math.ceil(
+      THINKING_TYPEWRITER_LINE_PAUSE_MS / THINKING_TYPEWRITER_INTERVAL_MS,
+    );
 const THINKING_TYPEWRITER_WIDTH_GUARD_PX = 8;
 const THINKING_TYPEWRITER_OVERFLOW_PREFIX = "...";
+// Short tails should roll from the previous line instead of restarting alone.
+const THINKING_TYPEWRITER_FULL_LINE_RATIO = 0.8;
+
+interface ThinkingTypewriterLine {
+  readonly startIndex: number;
+  readonly endIndex: number;
+  readonly text: string;
+  readonly fillsWidth: boolean;
+}
 
 interface ThinkingTypewriterFrame {
   readonly messageId: string | undefined;
   readonly text: string;
   readonly width: number;
+  readonly lineIndex: number;
   readonly charIndex: number;
+  readonly pauseTicksRemaining: number;
   readonly displayedText: string;
   readonly complete: boolean;
 }
@@ -2992,7 +3009,9 @@ function emptyThinkingTypewriterFrame(): ThinkingTypewriterFrame {
     messageId: undefined,
     text: "",
     width: 0,
+    lineIndex: 0,
     charIndex: 0,
+    pauseTicksRemaining: 0,
     displayedText: "",
     complete: false,
   };
@@ -3118,13 +3137,96 @@ function thinkingLabelWidth(el: HTMLElement): number {
   );
 }
 
+function fullThinkingLineThreshold(width: number): number {
+  return Math.max(
+    1,
+    (width - THINKING_TYPEWRITER_WIDTH_GUARD_PX) *
+      THINKING_TYPEWRITER_FULL_LINE_RATIO,
+  );
+}
+
+function wrapThinkingTextForWidth(args: {
+  readonly graphemes: readonly string[];
+  readonly width: number;
+  readonly measureText: (value: string) => number | undefined;
+}): ThinkingTypewriterLine[] {
+  if (args.graphemes.length === 0) {
+    return [];
+  }
+  if (!Number.isFinite(args.width) || args.width <= 0) {
+    return [
+      {
+        startIndex: 0,
+        endIndex: args.graphemes.length,
+        text: args.graphemes.join(""),
+        fillsWidth: false,
+      },
+    ];
+  }
+
+  const maxWidth = Math.max(1, args.width - THINKING_TYPEWRITER_WIDTH_GUARD_PX);
+  const fullLineThreshold = fullThinkingLineThreshold(args.width);
+  const lines: ThinkingTypewriterLine[] = [];
+  let startIndex = 0;
+  let current: string[] = [];
+  let currentWidth = 0;
+
+  for (let index = 0; index < args.graphemes.length; index++) {
+    const grapheme = args.graphemes[index]!;
+    const candidate = [...current, grapheme];
+    const candidateText = candidate.join("");
+    const measured = args.measureText(candidateText);
+    if (measured === undefined) {
+      return [
+        {
+          startIndex: 0,
+          endIndex: args.graphemes.length,
+          text: args.graphemes.join(""),
+          fillsWidth: false,
+        },
+      ];
+    }
+
+    if (measured <= maxWidth || current.length === 0) {
+      current = candidate;
+      currentWidth = measured;
+      continue;
+    }
+
+    lines.push({
+      startIndex,
+      endIndex: index,
+      text: current.join(""),
+      fillsWidth: true,
+    });
+    startIndex = index;
+    current = [grapheme];
+    currentWidth = args.measureText(grapheme) ?? measured;
+  }
+
+  if (current.length > 0) {
+    lines.push({
+      startIndex,
+      endIndex: args.graphemes.length,
+      text: current.join(""),
+      fillsWidth: currentWidth >= fullLineThreshold,
+    });
+  }
+
+  return lines;
+}
+
 function displayedSlidingThinkingText(args: {
   readonly graphemes: readonly string[];
+  readonly startIndex: number;
   readonly charIndex: number;
   readonly width: number;
   readonly measureText: (value: string) => number | undefined;
 }): string {
-  const visibleGraphemes = args.graphemes.slice(0, args.charIndex);
+  const visibleGraphemes = args.graphemes.slice(
+    args.startIndex,
+    args.charIndex,
+  );
   const visibleText = visibleGraphemes.join("");
   if (visibleText.length === 0) {
     return "";
@@ -3172,6 +3274,14 @@ function nextThinkingTypewriterFrame(args: {
   if (graphemes.length === 0) {
     return emptyThinkingTypewriterFrame();
   }
+  const lines = wrapThinkingTextForWidth({
+    graphemes,
+    width,
+    measureText: args.measureText,
+  });
+  if (lines.length === 0) {
+    return emptyThinkingTypewriterFrame();
+  }
 
   const currentFrame =
     args.currentFrame.messageId === args.messageId &&
@@ -3184,16 +3294,80 @@ function nextThinkingTypewriterFrame(args: {
           text: args.text,
           width,
         };
+  const lineIndex = Math.min(currentFrame.lineIndex, lines.length - 1);
+  const currentLine = lines[lineIndex]!;
+  const nextLine = lines[lineIndex + 1];
+
+  if (currentFrame.pauseTicksRemaining > 0) {
+    return {
+      ...currentFrame,
+      lineIndex,
+      pauseTicksRemaining: currentFrame.pauseTicksRemaining - 1,
+      displayedText: currentLine.text,
+      complete: false,
+    };
+  }
+
+  if (currentFrame.charIndex >= currentLine.endIndex) {
+    if (nextLine?.fillsWidth) {
+      const nextCharIndex = Math.min(
+        nextLine.endIndex,
+        nextLine.startIndex + thinkingTypewriterStep(width),
+      );
+      return {
+        ...currentFrame,
+        lineIndex: lineIndex + 1,
+        charIndex: nextCharIndex,
+        pauseTicksRemaining: 0,
+        displayedText: displayedSlidingThinkingText({
+          graphemes,
+          startIndex: nextLine.startIndex,
+          charIndex: nextCharIndex,
+          width,
+          measureText: args.measureText,
+        }),
+        complete:
+          lineIndex + 1 >= lines.length - 1 &&
+          nextCharIndex >= graphemes.length,
+      };
+    }
+
+    const nextCharIndex = Math.min(
+      graphemes.length,
+      currentFrame.charIndex + thinkingTypewriterStep(width),
+    );
+    return {
+      ...currentFrame,
+      lineIndex,
+      charIndex: nextCharIndex,
+      pauseTicksRemaining: 0,
+      displayedText: displayedSlidingThinkingText({
+        graphemes,
+        startIndex: currentLine.startIndex,
+        charIndex: nextCharIndex,
+        width,
+        measureText: args.measureText,
+      }),
+      complete: nextCharIndex >= graphemes.length,
+    };
+  }
+
   const nextCharIndex = Math.min(
-    graphemes.length,
+    currentLine.endIndex,
     currentFrame.charIndex + thinkingTypewriterStep(width),
   );
 
   return {
     ...currentFrame,
+    lineIndex,
     charIndex: nextCharIndex,
+    pauseTicksRemaining:
+      nextCharIndex >= currentLine.endIndex && nextLine?.fillsWidth
+        ? THINKING_TYPEWRITER_LINE_PAUSE_TICKS
+        : 0,
     displayedText: displayedSlidingThinkingText({
       graphemes,
+      startIndex: currentLine.startIndex,
       charIndex: nextCharIndex,
       width,
       measureText: args.measureText,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -924,11 +924,15 @@ function mockThinkingTypewriterLayout({
   labelWidth,
   parentWidth,
   graphemeWidth,
+  measureTextWidth = (value) => {
+    return Array.from(value).length * graphemeWidth;
+  },
 }: {
   readonly text: string;
   readonly labelWidth: number;
   readonly parentWidth: number;
   readonly graphemeWidth: number;
+  readonly measureTextWidth?: (value: string) => number;
 }): void {
   const getContextDescriptor = Object.getOwnPropertyDescriptor(
     HTMLCanvasElement.prototype,
@@ -981,7 +985,7 @@ function mockThinkingTypewriterLayout({
       return {
         measureText: (value: string) => {
           return {
-            width: Array.from(value).length * graphemeWidth,
+            width: measureTextWidth(value),
           } as TextMetrics;
         },
       } as CanvasRenderingContext2D;
@@ -6769,9 +6773,6 @@ describe("initial thinking indicator", () => {
     detachedSetupPage({
       context,
       path: `/chats/${threadId}`,
-      featureSwitches: {
-        [FeatureSwitchKey.ChatInitialThinkingIndicator]: true,
-      },
     });
 
     await waitFor(() => {
@@ -6781,27 +6782,53 @@ describe("initial thinking indicator", () => {
     expect(label.closest("[data-thinking-indicator]")).not.toBeNull();
   });
 
-  it("slides the thinking marker after it exceeds the label width", async () => {
-    const threadId = "thread-initial-thinking-sliding";
+  it("restarts on full follow-up lines before sliding a short tail", async () => {
+    const threadId = "thread-initial-thinking-rollover";
     const thinking = "ABCDEFG";
     mockThinkingTypewriterLayout({
       text: thinking,
-      labelWidth: 68,
+      labelWidth: 38,
       parentWidth: 160,
       graphemeWidth: 10,
+      measureTextWidth: (value) => {
+        return (
+          Array.from(value).filter((grapheme) => {
+            return grapheme !== ".";
+          }).length * 10
+        );
+      },
     });
+    const displayedLabels = new Set<string>();
+    const labelObserver = new MutationObserver(() => {
+      const label = document.querySelector(`[aria-label="${thinking}"]`);
+      if (label?.textContent) {
+        displayedLabels.add(label.textContent);
+      }
+    });
+    labelObserver.observe(document.body, {
+      childList: true,
+      characterData: true,
+      subtree: true,
+    });
+    context.signal.addEventListener(
+      "abort",
+      () => {
+        labelObserver.disconnect();
+      },
+      { once: true },
+    );
     mockChatLifecycle(context, {
       threadId,
       chatMessages: [
         {
-          id: "msg-thinking-sliding-user",
+          id: "msg-thinking-rollover-user",
           role: "user",
           content: "Draft a launch checklist",
           runId: "run-active",
           createdAt: "2026-03-10T00:00:00Z",
         },
         {
-          id: "msg-thinking-sliding-marker",
+          id: "msg-thinking-rollover-marker",
           role: "assistant",
           content: null,
           thinking,
@@ -6824,6 +6851,11 @@ describe("initial thinking indicator", () => {
     await waitFor(() => {
       expect(label).toHaveTextContent("...EFG");
     });
+    expect(
+      Array.from(displayedLabels).some((value) => {
+        return value === "D" || value === "DE" || value === "DEF";
+      }),
+    ).toBeTruthy();
     expect(label).not.toHaveTextContent(thinking);
     expect(label.closest("[data-thinking-indicator]")).not.toBeNull();
   });

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -9,6 +9,9 @@ import {
 describe("isFeatureEnabled", () => {
   it("should return true for globally enabled switch", () => {
     expect(isFeatureEnabled(FeatureSwitchKey.Dummy, {})).toBe(true);
+    expect(
+      isFeatureEnabled(FeatureSwitchKey.ChatInitialThinkingIndicator, {}),
+    ).toBe(true);
   });
 
   it("should return true for globally enabled switch even with context", () => {
@@ -87,6 +90,7 @@ describe("getAllFeatureStates", () => {
     const states = getAllFeatureStates();
     // Globally enabled switches should be true
     expect(states[FeatureSwitchKey.Dummy]).toBe(true);
+    expect(states[FeatureSwitchKey.ChatInitialThinkingIndicator]).toBe(true);
   });
 
   it("should enable switches when orgId matches enabledOrgIdHashes", () => {
@@ -124,6 +128,9 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.HtmlArtifactCommentEditing]).toBe(
       false,
     );
+    expect(staffOrgStates[FeatureSwitchKey.ChatInitialThinkingIndicator]).toBe(
+      true,
+    );
 
     const otherOrgStates = getAllFeatureStates({
       orgId: "org_nonexistent",
@@ -139,6 +146,9 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.AgentUnreadIndicators]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.HtmlArtifactCommentEditing]).toBe(
       false,
+    );
+    expect(otherOrgStates[FeatureSwitchKey.ChatInitialThinkingIndicator]).toBe(
+      true,
     );
   });
 

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -321,8 +321,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "ethan@vm0.ai",
     description:
       "Show fast generated status text in the web chat thinking indicator.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
   [FeatureSwitchKey.TeamsIntegration]: {
     maintainer: "linghan@vm0.ai",


### PR DESCRIPTION
## Summary
- restart the server thinking typewriter from the next segment when that segment is wide enough to fill the label
- keep short tails attached to the previous segment and roll them with the measured `...` suffix behavior
- enable `ChatInitialThinkingIndicator` globally instead of limiting it to staff orgs
- update the thinking indicator regression test to cover the `ABC` pause, `D/DE/DEF` restart, and final `...EFG` tail
- update API/platform tests so the thinking marker works without an explicit feature-switch override

## Verification
- pnpm exec prettier --check apps/platform/src/signals/chat-page/create-chat-thread.ts apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
- pnpm exec prettier --check packages/core/src/feature-switch.ts packages/core/src/__tests__/feature-switch.test.ts apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
- pnpm -F @vm0/app exec oxlint src/signals/chat-page/create-chat-thread.ts src/views/zero-page/__tests__/chat-lifecycle.test.tsx
- pnpm -F @vm0/core exec oxlint src/feature-switch.ts src/__tests__/feature-switch.test.ts
- pnpm -F api exec oxlint src/signals/routes/__tests__/chat-messages.bdd.test.ts
- pnpm -F @vm0/app exec oxlint src/views/zero-page/__tests__/chat-lifecycle.test.tsx
- pnpm -F @vm0/app exec eslint src/signals/chat-page/create-chat-thread.ts src/views/zero-page/__tests__/chat-lifecycle.test.tsx --max-warnings 0
- pnpm -F @vm0/core exec eslint src/feature-switch.ts src/__tests__/feature-switch.test.ts --max-warnings 0
- pnpm -F api exec eslint src/signals/routes/__tests__/chat-messages.bdd.test.ts --max-warnings 0
- pnpm -F @vm0/app exec eslint src/views/zero-page/__tests__/chat-lifecycle.test.tsx --max-warnings 0
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx -t "initial thinking indicator"
- pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts
- DATABASE_URL="postgresql://postgres@localhost:5432/vm0_test" pnpm -F api exec vitest run src/signals/routes/__tests__/chat-messages.bdd.test.ts -t "initial thinking indicator"
- pnpm -F @vm0/app exec tsc -p tsconfig.production.json --noEmit --pretty false
- pnpm -F @vm0/app exec tsc -p tsconfig.tests.json --noEmit --pretty false
- pnpm -F @vm0/core run check-types
- git diff --check

Note: full `api` check-types was attempted after starting and migrating local Postgres, but this runtime killed it with SIGKILL even when rerun alone with `NODE_OPTIONS=--max-old-space-size=6144`. Targeted API lint and regression test passed locally; full API typecheck will run in CI.
