### PR TITLE
fix: bump chat idb schema version

### DIFF
--- a/turbo/apps/platform/src/signals/external/chat-idb-schema.ts
+++ b/turbo/apps/platform/src/signals/external/chat-idb-schema.ts
@@ -2,8 +2,9 @@ import type { IDBPDatabase } from "idb";
 
 const CHAT_IDB_FULL_CACHE_RESET_VERSION = 4;
 const CHAT_IDB_MESSAGES_ORDER_RESET_VERSION = 6;
+const CHAT_IDB_SCHEMA_VERSION = 7;
 
-export const CHAT_IDB_VERSION = CHAT_IDB_MESSAGES_ORDER_RESET_VERSION;
+export const CHAT_IDB_VERSION = CHAT_IDB_SCHEMA_VERSION;
 export const CHAT_MESSAGES_STORE = "chat_messages";
 export const CHAT_THREAD_META_STORE = "chat_thread_agents";
 export const CHAT_MESSAGES_ORDER_INDEX = "byThreadAndOrder";


### PR DESCRIPTION
## Summary
- Bump the chat IndexedDB schema version from 6 to 7.
- Keep the existing v4/v6 reset thresholds unchanged so v6 databases upgrade without clearing stores.

## Tests
- Not run (fresh checkout has no node_modules; relying on the PR pipeline per repo preference).