### PR TITLE
fix: clarify Mac desktop download labels

### DIFF
--- a/turbo/apps/platform/src/views/computer-use-authorization/__tests__/computer-use-authorization-page.test.tsx
+++ b/turbo/apps/platform/src/views/computer-use-authorization/__tests__/computer-use-authorization-page.test.tsx
@@ -50,6 +50,16 @@ function linkByText(text: string): HTMLElement {
   return link;
 }
 
+function linkByLabel(label: string): HTMLElement {
+  const link = queryAllByRoleFast("link").find((candidate) => {
+    return candidate.getAttribute("aria-label") === label;
+  });
+  if (!link) {
+    throw new Error(`${label} link not found`);
+  }
+  return link;
+}
+
 function queryLinkByText(text: string): HTMLElement | null {
   return (
     queryAllByRoleFast("link").find((candidate) => {
@@ -291,7 +301,7 @@ describe("computer use authorization page", () => {
     ).resolves.toBeInTheDocument();
 
     const appleSiliconDownload = await waitFor(() => {
-      return linkByText("Download for Apple Silicon");
+      return linkByLabel("Download for Mac Apple Silicon");
     });
     expect(appleSiliconDownload).toHaveAttribute(
       "href",
@@ -299,7 +309,7 @@ describe("computer use authorization page", () => {
         "/api/zero/desktop/updates/stable/darwin/arm64/dmg",
       ),
     );
-    expect(linkByText("Download for Intel Mac")).toHaveAttribute(
+    expect(linkByLabel("Download for Mac Intel")).toHaveAttribute(
       "href",
       expect.stringContaining(
         "/api/zero/desktop/updates/stable/darwin/x64/dmg",

--- a/turbo/apps/platform/src/views/computer-use-authorization/computer-use-authorization-page.tsx
+++ b/turbo/apps/platform/src/views/computer-use-authorization/computer-use-authorization-page.tsx
@@ -121,21 +121,33 @@ function EmptyHosts() {
         <div className="flex w-full max-w-sm flex-col gap-2">
           <a
             href={ZERO_DESKTOP_DOWNLOAD_URL}
+            aria-label="Download for Mac Apple Silicon"
             target="_blank"
             rel="noreferrer"
-            className="inline-flex h-9 items-center justify-center gap-2 rounded-lg border border-border bg-background px-3 text-sm font-medium text-foreground transition-colors hover:bg-accent"
+            className="inline-flex min-h-11 items-center justify-center gap-2 rounded-lg border border-border bg-background px-3 py-2 text-sm font-medium text-foreground transition-colors hover:bg-accent"
           >
             <IconDownload size={16} />
-            Download for Apple Silicon
+            <span className="flex flex-col items-start gap-0.5">
+              <span>Download for Mac</span>
+              <span className="text-xs font-normal text-muted-foreground">
+                Apple Silicon
+              </span>
+            </span>
           </a>
           <a
             href={ZERO_DESKTOP_INTEL_DOWNLOAD_URL}
+            aria-label="Download for Mac Intel"
             target="_blank"
             rel="noreferrer"
-            className="inline-flex h-9 items-center justify-center gap-2 rounded-lg border border-border bg-background px-3 text-sm font-medium text-foreground transition-colors hover:bg-accent"
+            className="inline-flex min-h-11 items-center justify-center gap-2 rounded-lg border border-border bg-background px-3 py-2 text-sm font-medium text-foreground transition-colors hover:bg-accent"
           >
             <IconDownload size={16} />
-            Download for Intel Mac
+            <span className="flex flex-col items-start gap-0.5">
+              <span>Download for Mac</span>
+              <span className="text-xs font-normal text-muted-foreground">
+                Intel
+              </span>
+            </span>
           </a>
         </div>
       ) : downloadSupportStatus === "unsupported-intel-mac" ? (

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -869,6 +869,16 @@ function linkByText(text: string): HTMLElement {
   return link;
 }
 
+function linkByLabel(label: string): HTMLElement {
+  const link = queryAllByRoleFast("link").find((candidate) => {
+    return candidate.getAttribute("aria-label") === label;
+  });
+  if (!link) {
+    throw new Error(`${label} link not found`);
+  }
+  return link;
+}
+
 function queryLinkByText(text: string): HTMLElement | null {
   return (
     queryAllByRoleFast("link").find((candidate) => {
@@ -5848,7 +5858,7 @@ describe("chat lifecycle", () => {
     await user.click(await screen.findByText("Connect my computer"));
 
     const appleSiliconDownload = await waitFor(() => {
-      return linkByText("Download for Apple Silicon");
+      return linkByLabel("Download for Mac Apple Silicon");
     });
     expect(appleSiliconDownload).toHaveAttribute(
       "href",
@@ -5856,7 +5866,7 @@ describe("chat lifecycle", () => {
         "/api/zero/desktop/updates/stable/darwin/arm64/dmg",
       ),
     );
-    expect(linkByText("Download for Intel Mac")).toHaveAttribute(
+    expect(linkByLabel("Download for Mac Intel")).toHaveAttribute(
       "href",
       expect.stringContaining(
         "/api/zero/desktop/updates/stable/darwin/x64/dmg",

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -5856,9 +5856,14 @@ function ComputerUseDownloadDialog({
         <div className="px-6 pb-6 pt-4">
           {showIntelDownload ? (
             <div className="flex flex-col gap-2">
-              <Button asChild size="lg" className="w-full justify-start">
+              <Button
+                asChild
+                size="lg"
+                className="h-auto min-h-11 w-full justify-start px-4 py-2"
+              >
                 <a
                   href={downloadUrl}
+                  aria-label="Download for Mac Apple Silicon"
                   target="_blank"
                   rel="noreferrer"
                   onClick={() => {
@@ -5866,17 +5871,23 @@ function ComputerUseDownloadDialog({
                   }}
                 >
                   <IconDownload size={16} stroke={1.5} />
-                  Download for Apple Silicon
+                  <span className="flex flex-col items-start gap-0.5">
+                    <span>Download for Mac</span>
+                    <span className="text-xs font-normal text-primary-foreground/80">
+                      Apple Silicon
+                    </span>
+                  </span>
                 </a>
               </Button>
               <Button
                 asChild
                 size="lg"
                 variant="outline"
-                className="w-full justify-start"
+                className="h-auto min-h-11 w-full justify-start px-4 py-2"
               >
                 <a
                   href={ZERO_DESKTOP_INTEL_DOWNLOAD_URL}
+                  aria-label="Download for Mac Intel"
                   target="_blank"
                   rel="noreferrer"
                   onClick={() => {
@@ -5884,7 +5895,12 @@ function ComputerUseDownloadDialog({
                   }}
                 >
                   <IconDownload size={16} stroke={1.5} />
-                  Download for Intel Mac
+                  <span className="flex flex-col items-start gap-0.5">
+                    <span>Download for Mac</span>
+                    <span className="text-xs font-normal text-muted-foreground">
+                      Intel
+                    </span>
+                  </span>
                 </a>
               </Button>
             </div>


### PR DESCRIPTION
## Summary
- keep the primary desktop download label as `Download for Mac`
- move architecture details into secondary copy: `Apple Silicon` and `Intel`
- add explicit accessible names for the two architecture-specific Mac download links

Follow-up to #19766.

## Verification
- `pnpm --dir turbo/apps/platform exec vitest run src/views/computer-use-authorization/__tests__/computer-use-authorization-page.test.tsx`
- `pnpm --dir turbo/apps/platform exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx -t "Computer Use download"`
- `pnpm --dir turbo -F @vm0/app check-types`