### PR TITLE
fix: fire Google Ads signup conversion

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -2244,6 +2244,7 @@ describe("CHAT-02: push notification gating", () => {
     expect(
       lifecycleMarkers(messages.messages, first.runId, "completed"),
     ).toHaveLength(1);
+    await flushWaitUntilForTest();
     expect(context.mocks.webpush.sendNotification).not.toHaveBeenCalled();
 
     chatCallbacks.enableVapid();
@@ -2270,6 +2271,7 @@ describe("CHAT-02: push notification gating", () => {
       body: "Your task is complete",
       url: `/chats/${first.threadId}`,
     });
+    await flushWaitUntilForTest();
 
     const third = await startChatRun(actor, {
       agentId,

--- a/turbo/apps/platform/src/signals/__tests__/signup-attribution-conversion.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/signup-attribution-conversion.test.ts
@@ -10,6 +10,9 @@ import { recordSignupAttribution$ } from "../bootstrap/signup-attribution.ts";
 import { testContext } from "./test-helpers.ts";
 
 const context = testContext();
+const STORED_AD_ATTRIBUTION_KEY = "vm0.adAttribution";
+const SIGNUP_ATTRIBUTION_RECORDED_KEY = "vm0.signupAttributionRecorded";
+const SIGNUP_CONVERSION_RECORDED_KEY = "vm0.googleAdsSignupConversionRecorded";
 const SIGNUP_SEND_TO = "AW-18144854014/OlLBCNXGgqwcEP7_kcxD";
 
 type WindowWithGtag = Window & {
@@ -63,7 +66,7 @@ function installGtagMock() {
 
 function storePaidSignupAttribution(): void {
   window.sessionStorage.setItem(
-    "vm0.adAttribution",
+    STORED_AD_ATTRIBUTION_KEY,
     new URLSearchParams({
       source_type: "paid",
       gclid: "click-123",
@@ -77,7 +80,9 @@ function storePaidSignupAttribution(): void {
 
 describe("signup attribution Google Ads conversion", () => {
   afterEach(() => {
-    window.sessionStorage.clear();
+    window.sessionStorage.removeItem(STORED_AD_ATTRIBUTION_KEY);
+    window.sessionStorage.removeItem(SIGNUP_ATTRIBUTION_RECORDED_KEY);
+    window.sessionStorage.removeItem(SIGNUP_CONVERSION_RECORDED_KEY);
   });
 
   it("fires the Signup conversion after first-time signup attribution is recorded", async () => {

--- a/turbo/apps/platform/src/signals/__tests__/signup-attribution-conversion.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/signup-attribution-conversion.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { zeroAttributionContract } from "@vm0/api-contracts/contracts/zero-attribution";
+
+import {
+  clearMockedAuth,
+  mockOrganization,
+  mockUser,
+} from "../../__tests__/mock-auth.ts";
+import { recordSignupAttribution$ } from "../bootstrap/signup-attribution.ts";
+import { testContext } from "./test-helpers.ts";
+
+const context = testContext();
+const SIGNUP_SEND_TO = "AW-18144854014/OlLBCNXGgqwcEP7_kcxD";
+
+type WindowWithGtag = Window & {
+  gtag?: (...args: unknown[]) => void;
+};
+
+function mockSignedInUser(): void {
+  mockUser(
+    {
+      id: "test-user-123",
+      fullName: "Test User",
+      email: "test@example.com",
+    },
+    {
+      token: "test-token",
+    },
+  );
+  mockOrganization({
+    activeOrg: { id: "org_default", name: "Default Org" },
+    memberships: [{ id: "org_default" }],
+  });
+  context.signal.addEventListener("abort", () => {
+    clearMockedAuth();
+  });
+}
+
+function installGtagMock() {
+  const windowWithGtag = window as WindowWithGtag;
+  const originalGtag = windowWithGtag.gtag;
+  const gtag = vi.fn();
+
+  Object.defineProperty(windowWithGtag, "gtag", {
+    configurable: true,
+    value: gtag,
+    writable: true,
+  });
+  context.signal.addEventListener("abort", () => {
+    if (originalGtag !== undefined) {
+      Object.defineProperty(windowWithGtag, "gtag", {
+        configurable: true,
+        value: originalGtag,
+        writable: true,
+      });
+      return;
+    }
+    Reflect.deleteProperty(windowWithGtag, "gtag");
+  });
+
+  return gtag;
+}
+
+function storePaidSignupAttribution(): void {
+  window.sessionStorage.setItem(
+    "vm0.adAttribution",
+    new URLSearchParams({
+      source_type: "paid",
+      gclid: "click-123",
+      utm_source: "google",
+      utm_medium: "cpc",
+      utm_campaign: "signup-campaign",
+      vm0_source: "homepage",
+    }).toString(),
+  );
+}
+
+describe("signup attribution Google Ads conversion", () => {
+  afterEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it("fires the Signup conversion after first-time signup attribution is recorded", async () => {
+    const gtag = installGtagMock();
+    mockSignedInUser();
+    storePaidSignupAttribution();
+
+    await context.store.set(recordSignupAttribution$, context.signal);
+
+    expect(gtag).toHaveBeenCalledWith(
+      "event",
+      "conversion",
+      expect.objectContaining({
+        send_to: SIGNUP_SEND_TO,
+        value: 1,
+        currency: "USD",
+      }),
+    );
+
+    await context.store.set(recordSignupAttribution$, context.signal);
+
+    expect(gtag).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire the Signup conversion when attribution was already recorded server-side", async () => {
+    const gtag = installGtagMock();
+    mockSignedInUser();
+    storePaidSignupAttribution();
+    context.mocks.api(zeroAttributionContract.recordSignup, ({ respond }) => {
+      return respond(200, { recorded: false });
+    });
+
+    await context.store.set(recordSignupAttribution$, context.signal);
+
+    expect(gtag).not.toHaveBeenCalled();
+  });
+});

--- a/turbo/apps/platform/src/signals/bootstrap/signup-attribution.ts
+++ b/turbo/apps/platform/src/signals/bootstrap/signup-attribution.ts
@@ -7,6 +7,23 @@ import { user$ } from "../auth.ts";
 import { getStoredAdAttributionMetadata } from "./ad-attribution.ts";
 
 const SIGNUP_ATTRIBUTION_RECORDED_KEY = "vm0.signupAttributionRecorded";
+const SIGNUP_CONVERSION_RECORDED_KEY = "vm0.googleAdsSignupConversionRecorded";
+const GOOGLE_ADS_SIGNUP_SEND_TO = "AW-18144854014/OlLBCNXGgqwcEP7_kcxD";
+const SIGNUP_CONVERSION_VALUE_USD = 1;
+
+type GoogleTag = (
+  command: "event",
+  eventName: "conversion",
+  params: {
+    readonly send_to: string;
+    readonly value: number;
+    readonly currency: "USD";
+  },
+) => void;
+
+type WindowWithGoogleTag = Window & {
+  readonly gtag?: GoogleTag;
+};
 
 function getSessionStorage(): Storage | null {
   if (typeof window === "undefined") {
@@ -14,6 +31,34 @@ function getSessionStorage(): Storage | null {
   }
 
   return window.sessionStorage;
+}
+
+function trackGoogleAdsSignupConversion(
+  storage: Storage | null,
+  fingerprint: string,
+): void {
+  if (storage?.getItem(SIGNUP_CONVERSION_RECORDED_KEY) === fingerprint) {
+    return;
+  }
+
+  const gtag =
+    typeof window === "undefined"
+      ? undefined
+      : (window as WindowWithGoogleTag).gtag;
+  if (typeof gtag !== "function") {
+    return;
+  }
+
+  try {
+    gtag("event", "conversion", {
+      send_to: GOOGLE_ADS_SIGNUP_SEND_TO,
+      value: SIGNUP_CONVERSION_VALUE_USD,
+      currency: "USD",
+    });
+    storage?.setItem(SIGNUP_CONVERSION_RECORDED_KEY, fingerprint);
+  } catch {
+    // Conversion tracking should never block sign-up attribution persistence.
+  }
 }
 
 export const recordSignupAttribution$ = command(
@@ -37,7 +82,7 @@ export const recordSignupAttribution$ = command(
 
     const createClient = get(zeroClient$);
     const client = createClient(zeroAttributionContract);
-    await accept(
+    const result = await accept(
       client.recordSignup({
         body: { attribution },
         fetchOptions: { signal },
@@ -45,6 +90,9 @@ export const recordSignupAttribution$ = command(
       [200],
     );
     signal.throwIfAborted();
+    if (result.body.recorded) {
+      trackGoogleAdsSignupConversion(storage, fingerprint);
+    }
     storage?.setItem(SIGNUP_ATTRIBUTION_RECORDED_KEY, fingerprint);
   },
 );

--- a/turbo/apps/platform/src/signals/bootstrap/signup-attribution.ts
+++ b/turbo/apps/platform/src/signals/bootstrap/signup-attribution.ts
@@ -49,16 +49,12 @@ function trackGoogleAdsSignupConversion(
     return;
   }
 
-  try {
-    gtag("event", "conversion", {
-      send_to: GOOGLE_ADS_SIGNUP_SEND_TO,
-      value: SIGNUP_CONVERSION_VALUE_USD,
-      currency: "USD",
-    });
-    storage?.setItem(SIGNUP_CONVERSION_RECORDED_KEY, fingerprint);
-  } catch {
-    // Conversion tracking should never block sign-up attribution persistence.
-  }
+  gtag("event", "conversion", {
+    send_to: GOOGLE_ADS_SIGNUP_SEND_TO,
+    value: SIGNUP_CONVERSION_VALUE_USD,
+    currency: "USD",
+  });
+  storage?.setItem(SIGNUP_CONVERSION_RECORDED_KEY, fingerprint);
 }
 
 export const recordSignupAttribution$ = command(


### PR DESCRIPTION
## Summary
- Fire the Google Ads Signup conversion after first-time signup attribution is recorded
- Use the existing Signup action label: `AW-18144854014/OlLBCNXGgqwcEP7_kcxD`
- Avoid duplicates by only firing when the API returns `recorded: true` and by storing a per-attribution conversion marker in sessionStorage
- Add targeted tests for first-time and already-recorded signup attribution paths

## Verification
- `pnpm --dir apps/platform exec vitest run src/signals/__tests__/signup-attribution-conversion.test.ts`
- `pnpm exec prettier --check apps/platform/src/signals/bootstrap/signup-attribution.ts apps/platform/src/signals/__tests__/signup-attribution-conversion.test.ts`

## Notes
- Per vm0 PR practice, I did not run full local vitest or start a dev server.