### PR TITLE
feat: rename agent detail Info tab to Settings

### DIFF
--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -1120,7 +1120,7 @@ describe("workflow detail page", () => {
     expect(screen.getAllByText("Last run").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Next run").length).toBeGreaterThan(0);
     expect(buttonByText("Run now")).toBeInTheDocument();
-    click(buttonByText("Info"));
+    click(buttonByText("Settings"));
     await waitFor(() => {
       expect(screen.getAllByText("Visibility").length).toBeGreaterThan(0);
     });
@@ -1529,7 +1529,7 @@ describe("workflow detail page", () => {
     await waitFor(() => {
       expect(screen.getByText("Every weekday at 9:00 AM")).toBeInTheDocument();
     });
-    click(buttonByText("Info"));
+    click(buttonByText("Settings"));
 
     await waitFor(() => {
       expect(screen.getAllByText("Visibility").length).toBeGreaterThan(0);

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -466,7 +466,7 @@ function WorkflowTabNav({
           <SelectContent>
             <SelectItem value="automations">Automations</SelectItem>
             <SelectItem value="instructions">Instructions</SelectItem>
-            <SelectItem value="info">Info</SelectItem>
+            <SelectItem value="info">Settings</SelectItem>
           </SelectContent>
         </Select>
       </div>
@@ -484,7 +484,7 @@ function WorkflowTabNav({
         </TabsTrigger>
         <TabsTrigger value="info" className={WORKFLOW_TAB_TRIGGER_CLASS}>
           <IconInfoCircle size={14} stroke={1.5} />
-          Info
+          Settings
         </TabsTrigger>
       </TabsList>
     </Tabs>


### PR DESCRIPTION
## What

Renames the third tab on the agent (workflow) detail page from **Info** to **Settings** — the visible label only.

Applies to both the desktop `TabsTrigger` and the mobile `Select` dropdown item.

## Why

Requested UI copy change (see screenshot). "Settings" better reflects the tab's contents than "Info".

## Scope / notes

- Only the user-facing label text changes. Internal tab id (`value="info"`), route path (`/workflows/:id/info`), route constant (`workflowDetailInfo`), and the `WorkflowDetailTab` union all keep `info` — no routing/state churn.
- Updated the two `workflows-page` tests that click the tab by its label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)