### PR TITLE
feat: explain agent creator and role in a white card on name hover

### DIFF
--- a/turbo/apps/platform/src/views/agents-page/__tests__/agents-page-tabs.test.tsx
+++ b/turbo/apps/platform/src/views/agents-page/__tests__/agents-page-tabs.test.tsx
@@ -63,6 +63,19 @@ function tab(label: "Public" | "Private"): HTMLElement {
   return found;
 }
 
+async function expectVisibleTooltip(text: string): Promise<void> {
+  const matches = await screen.findAllByText(text);
+  const visibleMatch = matches.find((element) => {
+    try {
+      expect(element).toBeVisible();
+      return true;
+    } catch {
+      return false;
+    }
+  });
+  expect(visibleMatch).toBeDefined();
+}
+
 describe("agents page (redesign)", () => {
   it("filters agents by tab and shows creator only on public cards", async () => {
     const user = userEvent.setup();
@@ -100,7 +113,7 @@ describe("agents page (redesign)", () => {
       expect(tab("Private")).toBeInTheDocument();
     });
 
-    // Private tab: only private agents, no creator footer.
+    // Private tab: only private agents, no creator tooltip.
     await user.click(tab("Private"));
     await waitFor(() => {
       expect(agentCard("Private Ops")).toBeInTheDocument();
@@ -110,15 +123,20 @@ describe("agents page (redesign)", () => {
       within(agentCard("Private Ops")).queryByText("Created by Bob Builder"),
     ).not.toBeInTheDocument();
 
-    // Public tab: only public agents, each with a creator footer.
+    // Public tab: only public agents, each surfacing the creator on hover.
     await user.click(tab("Public"));
     await waitFor(() => {
       expect(agentCard("Research Agent")).toBeInTheDocument();
     });
     expect(findAgentCard("Private Ops")).toBeNull();
     expect(
-      within(agentCard("Research Agent")).getByText("Created by Alice Admin"),
-    ).toBeInTheDocument();
+      screen.queryByText("Created by Alice Admin"),
+    ).not.toBeInTheDocument();
+
+    await user.hover(
+      within(agentCard("Research Agent")).getByText("Research Agent"),
+    );
+    await expectVisibleTooltip("Created by Alice Admin");
   });
 
   it("shows the private empty state when there are no private agents", async () => {

--- a/turbo/apps/platform/src/views/agents-page/agents-page-tabs.tsx
+++ b/turbo/apps/platform/src/views/agents-page/agents-page-tabs.tsx
@@ -671,24 +671,35 @@ function AgentCard({ agent, creator, hasUnread, showCreator }: AgentProps) {
             {hasUnread && <AgentUnreadIndicator />}
           </span>
           <div className="flex-1 min-w-0">
-            <span className="block truncate text-sm font-medium text-foreground">
-              {displayName}
-            </span>
+            {showCreator ? (
+              <TooltipProvider delayDuration={200}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="block w-fit max-w-full truncate text-sm font-medium text-foreground">
+                      {displayName}
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent
+                    side="top"
+                    className="flex items-center gap-2"
+                  >
+                    <span className="flex h-5 w-5 shrink-0 items-center justify-center overflow-hidden rounded-full">
+                      <CreatorAvatar creator={creator} />
+                    </span>
+                    <span className="text-xs">Created by {creator.name}</span>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            ) : (
+              <span className="block truncate text-sm font-medium text-foreground">
+                {displayName}
+              </span>
+            )}
             <p className="text-xs text-muted-foreground mt-0.5 line-clamp-1">
               {description}
             </p>
           </div>
         </div>
-        {showCreator && (
-          <div className="mt-auto flex items-center gap-2 border-t border-border/60 pt-3">
-            <span className="flex h-5 w-5 shrink-0 items-center justify-center overflow-hidden rounded-full">
-              <CreatorAvatar creator={creator} />
-            </span>
-            <span className="truncate text-xs text-muted-foreground">
-              Created by {creator.name}
-            </span>
-          </div>
-        )}
       </CardContent>
     </Card>
   );

--- a/turbo/apps/platform/src/views/agents-page/agents-page-tabs.tsx
+++ b/turbo/apps/platform/src/views/agents-page/agents-page-tabs.tsx
@@ -680,30 +680,6 @@ function AgentCard({ agent, creator, hasUnread, showCreator }: AgentProps) {
                     </span>
                   </TooltipTrigger>
                   <TooltipContent
-                    side="top"
-                    className="flex items-center gap-2"
-                  >
-                    <span className="flex h-5 w-5 shrink-0 items-center justify-center overflow-hidden rounded-full">
-                      <CreatorAvatar creator={creator} />
-                    </span>
-                    <span className="text-xs">Created by {creator.name}</span>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            ) : (
-              <span className="block truncate text-sm font-medium text-foreground">
-                {displayName}
-              </span>
-            )}
-            {description ? (
-              <TooltipProvider delayDuration={200}>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <p className="text-xs text-muted-foreground mt-0.5 line-clamp-1 w-fit max-w-full">
-                      {description}
-                    </p>
-                  </TooltipTrigger>
-                  <TooltipContent
                     side="bottom"
                     align="start"
                     className="w-64 rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] p-3 text-left font-normal"
@@ -713,20 +689,30 @@ function AgentCard({ agent, creator, hasUnread, showCreator }: AgentProps) {
                       whiteSpace: "normal",
                     }}
                   >
-                    <span className="block text-xs font-medium text-foreground">
-                      {displayName}
+                    <span className="flex items-center gap-2">
+                      <span className="flex h-5 w-5 shrink-0 items-center justify-center overflow-hidden rounded-full">
+                        <CreatorAvatar creator={creator} />
+                      </span>
+                      <span className="text-xs font-medium text-foreground">
+                        Created by {creator.name}
+                      </span>
                     </span>
-                    <span className="mt-1 block text-xs leading-relaxed text-muted-foreground">
-                      {description}
-                    </span>
+                    {description && (
+                      <span className="mt-2 block text-xs leading-relaxed text-muted-foreground">
+                        {description}
+                      </span>
+                    )}
                   </TooltipContent>
                 </Tooltip>
               </TooltipProvider>
             ) : (
-              <p className="text-xs text-muted-foreground mt-0.5 line-clamp-1">
-                {description}
-              </p>
+              <span className="block truncate text-sm font-medium text-foreground">
+                {displayName}
+              </span>
             )}
+            <p className="text-xs text-muted-foreground mt-0.5 line-clamp-1">
+              {description}
+            </p>
           </div>
         </div>
       </CardContent>

--- a/turbo/apps/platform/src/views/agents-page/agents-page-tabs.tsx
+++ b/turbo/apps/platform/src/views/agents-page/agents-page-tabs.tsx
@@ -695,9 +695,38 @@ function AgentCard({ agent, creator, hasUnread, showCreator }: AgentProps) {
                 {displayName}
               </span>
             )}
-            <p className="text-xs text-muted-foreground mt-0.5 line-clamp-1">
-              {description}
-            </p>
+            {description ? (
+              <TooltipProvider delayDuration={200}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <p className="text-xs text-muted-foreground mt-0.5 line-clamp-1 w-fit max-w-full">
+                      {description}
+                    </p>
+                  </TooltipTrigger>
+                  <TooltipContent
+                    side="bottom"
+                    align="start"
+                    className="w-64 rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] p-3 text-left font-normal"
+                    style={{
+                      backgroundColor: "hsl(var(--popover))",
+                      color: "hsl(var(--popover-foreground))",
+                      whiteSpace: "normal",
+                    }}
+                  >
+                    <span className="block text-xs font-medium text-foreground">
+                      {displayName}
+                    </span>
+                    <span className="mt-1 block text-xs leading-relaxed text-muted-foreground">
+                      {description}
+                    </span>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            ) : (
+              <p className="text-xs text-muted-foreground mt-0.5 line-clamp-1">
+                {description}
+              </p>
+            )}
           </div>
         </div>
       </CardContent>


### PR DESCRIPTION
## What

On the redesigned Agents page cards, the creator used to sit in its own footer row (`Created by X` with a divider). This folds it into the agent **name**: hovering the name opens a single elegant white card that explains **who created the agent** and **what it does**.

## The card (name hover, public cards)

- Header: creator avatar + `Created by X`
- Body: the agent's full description / role (wraps in the card, no longer truncated to `…`)
- Surface mirrors the Popover primitive — white `bg`, `rounded-lg`, hairline `border-[0.7px] border-[hsl(var(--gray-400))]`, no harsh shadow

## Changes

- `agents-page-tabs.tsx`: remove the `showCreator` footer row; attach a white explanation tooltip card to the name on public cards. Private cards keep a plain, non-interactive name.
- Test: hover the name and assert the card surfaces `Created by …`; assert it is not visible before hover.

## Notes

- Reuses the existing `Tooltip` primitive, `CreatorAvatar`, and the Popover surface style.
- Targeted test passes (4/4); format + oxlint clean. Relying on the PR pipeline for full checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)