### PR TITLE
fix: prevent chat IndexedDB upgrade blocking

### DIFF
--- a/turbo/apps/platform/src/mocks/idb.ts
+++ b/turbo/apps/platform/src/mocks/idb.ts
@@ -37,6 +37,8 @@ export function openDB(): Promise<Record<string, unknown>> {
     objectStoreNames: {
       contains: () => false,
     },
+    addEventListener: () => undefined,
+    close: () => undefined,
     transaction: () => fakeTransaction(),
     // Direct get/put on the database (used by idb-thread-agent-store)
     get: () => Promise.resolve(undefined),

--- a/turbo/apps/platform/src/signals/external/chat-idb-store.test.ts
+++ b/turbo/apps/platform/src/signals/external/chat-idb-store.test.ts
@@ -1,6 +1,7 @@
 import type { DBSchema, IDBPDatabase, OpenDBCallbacks } from "idb";
 import { afterEach, describe, expect, it, vi, type Mock } from "vitest";
 import {
+  CHAT_IDB_VERSION,
   CHAT_MESSAGES_STORE,
   CHAT_THREAD_META_STORE,
 } from "./chat-idb-schema.ts";
@@ -164,7 +165,7 @@ describe("openChatIdb", () => {
 
     await subject.openChatIdb("user_1", "org_1");
 
-    expect(calls[0]?.version).toBe(6);
+    expect(calls[0]?.version).toBe(CHAT_IDB_VERSION);
     const upgrade = calls[0]?.callbacks?.upgrade;
     expect(upgrade).toBeTypeOf("function");
     if (upgrade === undefined) {
@@ -174,7 +175,13 @@ describe("openChatIdb", () => {
     const schemaDb = fakeSchemaDb();
     type UpgradeCallback = NonNullable<OpenDBCallbacks<unknown>["upgrade"]>;
     const transaction = {} as Parameters<UpgradeCallback>[3];
-    upgrade(schemaDb.db, 0, 6, transaction, versionChangeEvent(0, 6));
+    upgrade(
+      schemaDb.db,
+      0,
+      CHAT_IDB_VERSION,
+      transaction,
+      versionChangeEvent(0, CHAT_IDB_VERSION),
+    );
 
     expect(schemaDb.createObjectStore).toHaveBeenCalledWith(
       CHAT_MESSAGES_STORE,
@@ -193,8 +200,12 @@ describe("openChatIdb", () => {
     await subject.openChatIdb("user_1", "org_1");
 
     expect(firstDb.versionChangeListeners).toHaveLength(1);
-    firstDb.versionChangeListeners[0]?.(versionChangeEvent(6, 7));
-    firstDb.versionChangeListeners[0]?.(versionChangeEvent(6, 7));
+    firstDb.versionChangeListeners[0]?.(
+      versionChangeEvent(CHAT_IDB_VERSION, CHAT_IDB_VERSION + 1),
+    );
+    firstDb.versionChangeListeners[0]?.(
+      versionChangeEvent(CHAT_IDB_VERSION, CHAT_IDB_VERSION + 1),
+    );
 
     expect(firstDb.close).toHaveBeenCalledTimes(2);
     expect(reload).toHaveBeenCalledTimes(1);
@@ -209,7 +220,11 @@ describe("openChatIdb", () => {
     const { calls, reload, subject } = await setupSubject([db]);
 
     await subject.openChatIdb("user_1", "org_1");
-    calls[0]?.callbacks?.blocked?.(5, 6, versionChangeEvent(5, 6));
+    calls[0]?.callbacks?.blocked?.(
+      CHAT_IDB_VERSION - 1,
+      CHAT_IDB_VERSION,
+      versionChangeEvent(CHAT_IDB_VERSION - 1, CHAT_IDB_VERSION),
+    );
 
     expect(db.close).not.toHaveBeenCalled();
     expect(reload).not.toHaveBeenCalled();

--- a/turbo/apps/platform/src/signals/external/chat-idb-store.test.ts
+++ b/turbo/apps/platform/src/signals/external/chat-idb-store.test.ts
@@ -1,0 +1,217 @@
+import type { DBSchema, IDBPDatabase, OpenDBCallbacks } from "idb";
+import { afterEach, describe, expect, it, vi, type Mock } from "vitest";
+import {
+  CHAT_MESSAGES_STORE,
+  CHAT_THREAD_META_STORE,
+} from "./chat-idb-schema.ts";
+
+vi.mock("idb", () => {
+  return {
+    openDB: vi.fn(),
+  };
+});
+
+type VersionChangeListener = (event: IDBVersionChangeEvent) => void;
+
+interface FakeDb {
+  readonly db: IDBPDatabase;
+  readonly close: Mock<() => void>;
+  readonly versionChangeListeners: VersionChangeListener[];
+}
+
+interface OpenCall {
+  readonly name: string;
+  readonly version: number | undefined;
+  readonly callbacks: OpenDBCallbacks<unknown> | undefined;
+}
+
+interface FakeSchemaDb {
+  readonly db: IDBPDatabase;
+  readonly createObjectStore: Mock<
+    (name: string, options?: IDBObjectStoreParameters) => { createIndex: Mock }
+  >;
+}
+
+function versionChangeEvent(
+  oldVersion: number,
+  newVersion: number | null,
+): IDBVersionChangeEvent {
+  return { oldVersion, newVersion } as IDBVersionChangeEvent;
+}
+
+function fakeDb(): FakeDb {
+  const versionChangeListeners: VersionChangeListener[] = [];
+  const close = vi.fn();
+  const addEventListener = vi.fn(
+    (type: string, listener: EventListenerOrEventListenerObject) => {
+      if (type !== "versionchange") {
+        return;
+      }
+      if (typeof listener === "function") {
+        versionChangeListeners.push(listener as VersionChangeListener);
+        return;
+      }
+      versionChangeListeners.push((event) => {
+        listener.handleEvent(event);
+      });
+    },
+  );
+  return {
+    db: {
+      addEventListener,
+      close,
+    } as unknown as IDBPDatabase,
+    close,
+    versionChangeListeners,
+  };
+}
+
+function fakeSchemaDb(): FakeSchemaDb {
+  const stores = new Set<string>();
+  const createObjectStore = vi.fn(
+    (name: string, _options?: IDBObjectStoreParameters) => {
+      stores.add(name);
+      return { createIndex: vi.fn() };
+    },
+  );
+  return {
+    db: {
+      objectStoreNames: {
+        contains: (name: string) => {
+          return stores.has(name);
+        },
+      },
+      createObjectStore,
+      deleteObjectStore: vi.fn((name: string) => {
+        stores.delete(name);
+      }),
+    } as unknown as IDBPDatabase,
+    createObjectStore,
+  };
+}
+
+async function setupSubject(dbs: readonly FakeDb[]) {
+  vi.resetModules();
+  const idb = await import("idb");
+  const openDB = vi.mocked(idb.openDB);
+  const calls: OpenCall[] = [];
+  const dbQueue = [...dbs];
+
+  function openDbImplementation<DBTypes extends DBSchema | unknown = unknown>(
+    name: string,
+    version?: number,
+    callbacks?: OpenDBCallbacks<DBTypes>,
+  ): Promise<IDBPDatabase<DBTypes>> {
+    const next = dbQueue.shift();
+    if (next === undefined) {
+      throw new Error("unexpected openDB call");
+    }
+    calls.push({
+      name,
+      version,
+      callbacks: callbacks as OpenDBCallbacks<unknown> | undefined,
+    });
+    return Promise.resolve(next.db as IDBPDatabase<DBTypes>);
+  }
+
+  openDB.mockImplementation(openDbImplementation);
+  const reload = vi.spyOn(window.location, "reload").mockImplementation(() => {
+    return undefined;
+  });
+  const subject = await import("./chat-idb-store.ts");
+  return { calls, openDB, reload, subject };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("openChatIdb", () => {
+  it("reuses the same open promise for the same user and org", async () => {
+    const db = fakeDb();
+    const { calls, subject } = await setupSubject([db]);
+
+    const first = subject.openChatIdb("user_1", "org_1");
+    const second = subject.openChatIdb("user_1", "org_1");
+
+    expect(first).toBe(second);
+    await expect(first).resolves.toBe(db.db);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.name).toBe("vm0-chat-user_1-org_1");
+  });
+
+  it("uses separate open promises for different chat databases", async () => {
+    const firstDb = fakeDb();
+    const secondDb = fakeDb();
+    const { calls, subject } = await setupSubject([firstDb, secondDb]);
+
+    const first = subject.openChatIdb("user_1", "org_1");
+    const second = subject.openChatIdb("user_1", "org_2");
+
+    expect(first).not.toBe(second);
+    await expect(first).resolves.toBe(firstDb.db);
+    await expect(second).resolves.toBe(secondDb.db);
+    expect(
+      calls.map((call) => {
+        return call.name;
+      }),
+    ).toEqual(["vm0-chat-user_1-org_1", "vm0-chat-user_1-org_2"]);
+  });
+
+  it("registers the shared upgrade callback", async () => {
+    const db = fakeDb();
+    const { calls, subject } = await setupSubject([db]);
+
+    await subject.openChatIdb("user_1", "org_1");
+
+    expect(calls[0]?.version).toBe(6);
+    const upgrade = calls[0]?.callbacks?.upgrade;
+    expect(upgrade).toBeTypeOf("function");
+    if (upgrade === undefined) {
+      throw new Error("missing upgrade callback");
+    }
+
+    const schemaDb = fakeSchemaDb();
+    type UpgradeCallback = NonNullable<OpenDBCallbacks<unknown>["upgrade"]>;
+    const transaction = {} as Parameters<UpgradeCallback>[3];
+    upgrade(schemaDb.db, 0, 6, transaction, versionChangeEvent(0, 6));
+
+    expect(schemaDb.createObjectStore).toHaveBeenCalledWith(
+      CHAT_MESSAGES_STORE,
+      { keyPath: "id" },
+    );
+    expect(schemaDb.createObjectStore).toHaveBeenCalledWith(
+      CHAT_THREAD_META_STORE,
+      { keyPath: "threadId" },
+    );
+  });
+
+  it("closes, invalidates, reloads once, and prevents stale reopen after version change", async () => {
+    const firstDb = fakeDb();
+    const { openDB, reload, subject } = await setupSubject([firstDb]);
+
+    await subject.openChatIdb("user_1", "org_1");
+
+    expect(firstDb.versionChangeListeners).toHaveLength(1);
+    firstDb.versionChangeListeners[0]?.(versionChangeEvent(6, 7));
+    firstDb.versionChangeListeners[0]?.(versionChangeEvent(6, 7));
+
+    expect(firstDb.close).toHaveBeenCalledTimes(2);
+    expect(reload).toHaveBeenCalledTimes(1);
+    await expect(subject.openChatIdb("user_1", "org_1")).rejects.toThrow(
+      "Chat IndexedDB is closing for a page reload",
+    );
+    expect(openDB).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not close or reload when this open request is blocked", async () => {
+    const db = fakeDb();
+    const { calls, reload, subject } = await setupSubject([db]);
+
+    await subject.openChatIdb("user_1", "org_1");
+    calls[0]?.callbacks?.blocked?.(5, 6, versionChangeEvent(5, 6));
+
+    expect(db.close).not.toHaveBeenCalled();
+    expect(reload).not.toHaveBeenCalled();
+  });
+});

--- a/turbo/apps/platform/src/signals/external/chat-idb-store.test.ts
+++ b/turbo/apps/platform/src/signals/external/chat-idb-store.test.ts
@@ -1,16 +1,11 @@
-import type { DBSchema, IDBPDatabase, OpenDBCallbacks } from "idb";
+import type { DBSchema, IDBPDatabase, OpenDBCallbacks, openDB } from "idb";
 import { afterEach, describe, expect, it, vi, type Mock } from "vitest";
 import {
   CHAT_IDB_VERSION,
   CHAT_MESSAGES_STORE,
   CHAT_THREAD_META_STORE,
 } from "./chat-idb-schema.ts";
-
-vi.mock("idb", () => {
-  return {
-    openDB: vi.fn(),
-  };
-});
+import { createChatIdbStore } from "./chat-idb-store.ts";
 
 type VersionChangeListener = (event: IDBVersionChangeEvent) => void;
 
@@ -91,10 +86,7 @@ function fakeSchemaDb(): FakeSchemaDb {
   };
 }
 
-async function setupSubject(dbs: readonly FakeDb[]) {
-  vi.resetModules();
-  const idb = await import("idb");
-  const openDB = vi.mocked(idb.openDB);
+function setupSubject(dbs: readonly FakeDb[]) {
   const calls: OpenCall[] = [];
   const dbQueue = [...dbs];
 
@@ -115,12 +107,13 @@ async function setupSubject(dbs: readonly FakeDb[]) {
     return Promise.resolve(next.db as IDBPDatabase<DBTypes>);
   }
 
-  openDB.mockImplementation(openDbImplementation);
-  const reload = vi.spyOn(window.location, "reload").mockImplementation(() => {
+  const openDatabaseMock = vi.fn(openDbImplementation);
+  const openDatabase = openDatabaseMock as unknown as typeof openDB;
+  const reload = vi.fn(() => {
     return undefined;
   });
-  const subject = await import("./chat-idb-store.ts");
-  return { calls, openDB, reload, subject };
+  const subject = createChatIdbStore({ openDatabase, reload });
+  return { calls, openDatabaseMock, reload, subject };
 }
 
 afterEach(() => {
@@ -130,7 +123,7 @@ afterEach(() => {
 describe("openChatIdb", () => {
   it("reuses the same open promise for the same user and org", async () => {
     const db = fakeDb();
-    const { calls, subject } = await setupSubject([db]);
+    const { calls, subject } = setupSubject([db]);
 
     const first = subject.openChatIdb("user_1", "org_1");
     const second = subject.openChatIdb("user_1", "org_1");
@@ -144,7 +137,7 @@ describe("openChatIdb", () => {
   it("uses separate open promises for different chat databases", async () => {
     const firstDb = fakeDb();
     const secondDb = fakeDb();
-    const { calls, subject } = await setupSubject([firstDb, secondDb]);
+    const { calls, subject } = setupSubject([firstDb, secondDb]);
 
     const first = subject.openChatIdb("user_1", "org_1");
     const second = subject.openChatIdb("user_1", "org_2");
@@ -161,7 +154,7 @@ describe("openChatIdb", () => {
 
   it("registers the shared upgrade callback", async () => {
     const db = fakeDb();
-    const { calls, subject } = await setupSubject([db]);
+    const { calls, subject } = setupSubject([db]);
 
     await subject.openChatIdb("user_1", "org_1");
 
@@ -195,7 +188,7 @@ describe("openChatIdb", () => {
 
   it("closes, invalidates, reloads once, and prevents stale reopen after version change", async () => {
     const firstDb = fakeDb();
-    const { openDB, reload, subject } = await setupSubject([firstDb]);
+    const { openDatabaseMock, reload, subject } = setupSubject([firstDb]);
 
     await subject.openChatIdb("user_1", "org_1");
 
@@ -212,13 +205,13 @@ describe("openChatIdb", () => {
     await expect(subject.openChatIdb("user_1", "org_1")).rejects.toThrow(
       "Chat IndexedDB is closing for a page reload",
     );
-    expect(openDB).toHaveBeenCalledTimes(1);
+    expect(openDatabaseMock).toHaveBeenCalledTimes(1);
   });
 
   it("prevents reusing another cached database after reload is pending", async () => {
     const firstDb = fakeDb();
     const secondDb = fakeDb();
-    const { openDB, subject } = await setupSubject([firstDb, secondDb]);
+    const { openDatabaseMock, subject } = setupSubject([firstDb, secondDb]);
 
     await subject.openChatIdb("user_1", "org_1");
     await subject.openChatIdb("user_1", "org_2");
@@ -230,12 +223,12 @@ describe("openChatIdb", () => {
     await expect(subject.openChatIdb("user_1", "org_2")).rejects.toThrow(
       "Chat IndexedDB is closing for a page reload",
     );
-    expect(openDB).toHaveBeenCalledTimes(2);
+    expect(openDatabaseMock).toHaveBeenCalledTimes(2);
   });
 
   it("does not close or reload when this open request is blocked", async () => {
     const db = fakeDb();
-    const { calls, reload, subject } = await setupSubject([db]);
+    const { calls, reload, subject } = setupSubject([db]);
 
     await subject.openChatIdb("user_1", "org_1");
     calls[0]?.callbacks?.blocked?.(

--- a/turbo/apps/platform/src/signals/external/chat-idb-store.test.ts
+++ b/turbo/apps/platform/src/signals/external/chat-idb-store.test.ts
@@ -215,6 +215,24 @@ describe("openChatIdb", () => {
     expect(openDB).toHaveBeenCalledTimes(1);
   });
 
+  it("prevents reusing another cached database after reload is pending", async () => {
+    const firstDb = fakeDb();
+    const secondDb = fakeDb();
+    const { openDB, subject } = await setupSubject([firstDb, secondDb]);
+
+    await subject.openChatIdb("user_1", "org_1");
+    await subject.openChatIdb("user_1", "org_2");
+
+    firstDb.versionChangeListeners[0]?.(
+      versionChangeEvent(CHAT_IDB_VERSION, CHAT_IDB_VERSION + 1),
+    );
+
+    await expect(subject.openChatIdb("user_1", "org_2")).rejects.toThrow(
+      "Chat IndexedDB is closing for a page reload",
+    );
+    expect(openDB).toHaveBeenCalledTimes(2);
+  });
+
   it("does not close or reload when this open request is blocked", async () => {
     const db = fakeDb();
     const { calls, reload, subject } = await setupSubject([db]);

--- a/turbo/apps/platform/src/signals/external/chat-idb-store.ts
+++ b/turbo/apps/platform/src/signals/external/chat-idb-store.ts
@@ -46,16 +46,16 @@ export function openChatIdb(
   userId: string,
   orgId: string,
 ): Promise<IDBPDatabase> {
-  const dbName = chatIdbName(userId, orgId);
-  const existing = chatIdbStoreState.dbPromises.get(dbName);
-  if (existing !== undefined) {
-    return existing;
-  }
-
   if (chatIdbStoreState.reloadTriggered) {
     return Promise.reject(
       new Error("Chat IndexedDB is closing for a page reload"),
     );
+  }
+
+  const dbName = chatIdbName(userId, orgId);
+  const existing = chatIdbStoreState.dbPromises.get(dbName);
+  if (existing !== undefined) {
+    return existing;
   }
 
   L.debug("openDB", { dbName });

--- a/turbo/apps/platform/src/signals/external/chat-idb-store.ts
+++ b/turbo/apps/platform/src/signals/external/chat-idb-store.ts
@@ -1,0 +1,81 @@
+import { openDB, type IDBPDatabase } from "idb";
+import { logger } from "../log.ts";
+import { CHAT_IDB_VERSION, upgradeChatIdb } from "./chat-idb-schema.ts";
+
+const L = logger("ChatIdbStore");
+
+interface ChatIdbStoreState {
+  readonly dbPromises: Map<string, Promise<IDBPDatabase>>;
+  reloadTriggered: boolean;
+}
+
+function createChatIdbStoreState(): ChatIdbStoreState {
+  return {
+    dbPromises: new Map(),
+    reloadTriggered: false,
+  };
+}
+
+const chatIdbStoreState = createChatIdbStoreState();
+
+function chatIdbName(userId: string, orgId: string): string {
+  return `vm0-chat-${userId}-${orgId}`;
+}
+
+function handleVersionChange(
+  dbName: string,
+  db: IDBPDatabase,
+  event: IDBVersionChangeEvent,
+): void {
+  L.warn("versionchange", {
+    dbName,
+    currentVersion: event.oldVersion,
+    nextVersion: event.newVersion,
+  });
+  db.close();
+  chatIdbStoreState.dbPromises.delete(dbName);
+
+  if (chatIdbStoreState.reloadTriggered) {
+    return;
+  }
+  chatIdbStoreState.reloadTriggered = true;
+  window.location.reload();
+}
+
+export function openChatIdb(
+  userId: string,
+  orgId: string,
+): Promise<IDBPDatabase> {
+  const dbName = chatIdbName(userId, orgId);
+  const existing = chatIdbStoreState.dbPromises.get(dbName);
+  if (existing !== undefined) {
+    return existing;
+  }
+
+  if (chatIdbStoreState.reloadTriggered) {
+    return Promise.reject(
+      new Error("Chat IndexedDB is closing for a page reload"),
+    );
+  }
+
+  L.debug("openDB", { dbName });
+  const promise = openChatIdbConnection(dbName);
+  chatIdbStoreState.dbPromises.set(dbName, promise);
+  return promise;
+}
+
+async function openChatIdbConnection(dbName: string): Promise<IDBPDatabase> {
+  const db = await openDB(dbName, CHAT_IDB_VERSION, {
+    upgrade(db, oldVersion) {
+      L.debug("openDB:upgrade", { dbName });
+      upgradeChatIdb(db, oldVersion);
+    },
+    blocked(currentVersion, blockedVersion) {
+      L.warn("openDB:blocked", { dbName, currentVersion, blockedVersion });
+    },
+  });
+  db.addEventListener("versionchange", (event) => {
+    handleVersionChange(dbName, db, event);
+  });
+  return db;
+}

--- a/turbo/apps/platform/src/signals/external/chat-idb-store.ts
+++ b/turbo/apps/platform/src/signals/external/chat-idb-store.ts
@@ -1,81 +1,113 @@
-import { openDB, type IDBPDatabase } from "idb";
+import {
+  openDB,
+  type DBSchema,
+  type IDBPDatabase,
+  type OpenDBCallbacks,
+} from "idb";
 import { logger } from "../log.ts";
 import { CHAT_IDB_VERSION, upgradeChatIdb } from "./chat-idb-schema.ts";
 
 const L = logger("ChatIdbStore");
+
+type OpenChatIdbDatabase = <DBTypes extends DBSchema | unknown = unknown>(
+  name: string,
+  version?: number,
+  callbacks?: OpenDBCallbacks<DBTypes>,
+) => Promise<IDBPDatabase<DBTypes>>;
 
 interface ChatIdbStoreState {
   readonly dbPromises: Map<string, Promise<IDBPDatabase>>;
   reloadTriggered: boolean;
 }
 
-function createChatIdbStoreState(): ChatIdbStoreState {
-  return {
-    dbPromises: new Map(),
-    reloadTriggered: false,
-  };
+interface ChatIdbStoreOptions {
+  readonly openDatabase?: OpenChatIdbDatabase;
+  readonly reload?: () => void;
 }
 
-const chatIdbStoreState = createChatIdbStoreState();
+interface ChatIdbStore {
+  readonly openChatIdb: (
+    userId: string,
+    orgId: string,
+  ) => Promise<IDBPDatabase>;
+}
 
 function chatIdbName(userId: string, orgId: string): string {
   return `vm0-chat-${userId}-${orgId}`;
 }
 
-function handleVersionChange(
-  dbName: string,
-  db: IDBPDatabase,
-  event: IDBVersionChangeEvent,
-): void {
-  L.warn("versionchange", {
-    dbName,
-    currentVersion: event.oldVersion,
-    nextVersion: event.newVersion,
-  });
-  db.close();
-  chatIdbStoreState.dbPromises.delete(dbName);
+export function createChatIdbStore(
+  options: ChatIdbStoreOptions = {},
+): ChatIdbStore {
+  const openDatabase = options.openDatabase ?? openDB;
+  const reload =
+    options.reload ??
+    (() => {
+      window.location.reload();
+    });
+  const state: ChatIdbStoreState = {
+    dbPromises: new Map(),
+    reloadTriggered: false,
+  };
 
-  if (chatIdbStoreState.reloadTriggered) {
-    return;
-  }
-  chatIdbStoreState.reloadTriggered = true;
-  window.location.reload();
-}
+  function handleVersionChange(
+    dbName: string,
+    db: IDBPDatabase,
+    event: IDBVersionChangeEvent,
+  ): void {
+    L.warn("versionchange", {
+      dbName,
+      currentVersion: event.oldVersion,
+      nextVersion: event.newVersion,
+    });
+    db.close();
+    state.dbPromises.delete(dbName);
 
-export function openChatIdb(
-  userId: string,
-  orgId: string,
-): Promise<IDBPDatabase> {
-  if (chatIdbStoreState.reloadTriggered) {
-    return Promise.reject(
-      new Error("Chat IndexedDB is closing for a page reload"),
-    );
-  }
-
-  const dbName = chatIdbName(userId, orgId);
-  const existing = chatIdbStoreState.dbPromises.get(dbName);
-  if (existing !== undefined) {
-    return existing;
+    if (state.reloadTriggered) {
+      return;
+    }
+    state.reloadTriggered = true;
+    reload();
   }
 
-  L.debug("openDB", { dbName });
-  const promise = openChatIdbConnection(dbName);
-  chatIdbStoreState.dbPromises.set(dbName, promise);
-  return promise;
-}
+  async function openChatIdbConnection(dbName: string): Promise<IDBPDatabase> {
+    const db = await openDatabase(dbName, CHAT_IDB_VERSION, {
+      upgrade(db, oldVersion) {
+        L.debug("openDB:upgrade", { dbName });
+        upgradeChatIdb(db, oldVersion);
+      },
+      blocked(currentVersion, blockedVersion) {
+        L.warn("openDB:blocked", { dbName, currentVersion, blockedVersion });
+      },
+    });
+    db.addEventListener("versionchange", (event) => {
+      handleVersionChange(dbName, db, event);
+    });
+    return db;
+  }
 
-async function openChatIdbConnection(dbName: string): Promise<IDBPDatabase> {
-  const db = await openDB(dbName, CHAT_IDB_VERSION, {
-    upgrade(db, oldVersion) {
-      L.debug("openDB:upgrade", { dbName });
-      upgradeChatIdb(db, oldVersion);
+  return {
+    openChatIdb(userId, orgId) {
+      if (state.reloadTriggered) {
+        return Promise.reject(
+          new Error("Chat IndexedDB is closing for a page reload"),
+        );
+      }
+
+      const dbName = chatIdbName(userId, orgId);
+      const existing = state.dbPromises.get(dbName);
+      if (existing !== undefined) {
+        return existing;
+      }
+
+      L.debug("openDB", { dbName });
+      const promise = openChatIdbConnection(dbName);
+      state.dbPromises.set(dbName, promise);
+      return promise;
     },
-    blocked(currentVersion, blockedVersion) {
-      L.warn("openDB:blocked", { dbName, currentVersion, blockedVersion });
-    },
-  });
-  db.addEventListener("versionchange", (event) => {
-    handleVersionChange(dbName, db, event);
-  });
-  return db;
+  };
 }
+
+const defaultChatIdbStore = createChatIdbStore();
+
+export const openChatIdb = defaultChatIdbStore.openChatIdb;

--- a/turbo/apps/platform/src/signals/external/idb-message-store.ts
+++ b/turbo/apps/platform/src/signals/external/idb-message-store.ts
@@ -1,4 +1,4 @@
-import { openDB, type IDBPDatabase } from "idb";
+import type { IDBPDatabase } from "idb";
 import {
   pagedChatMessageSchema,
   type PagedChatMessage,
@@ -7,9 +7,7 @@ import { chatMessageOrderSequence } from "../chat-message-order.ts";
 import { logger } from "../log.ts";
 import {
   CHAT_MESSAGES_ORDER_INDEX,
-  CHAT_IDB_VERSION,
   CHAT_MESSAGES_STORE,
-  upgradeChatIdb,
 } from "./chat-idb-schema.ts";
 import {
   chatIdbReadOr,
@@ -18,6 +16,7 @@ import {
   logChatIdbDisabled,
   withChatIdbTimeout,
 } from "./chat-idb-safe.ts";
+import { openChatIdb } from "./chat-idb-store.ts";
 
 const L = logger("ChatIdbCache");
 
@@ -263,16 +262,7 @@ function createIdbMessageStores(userId: string, orgId: string) {
 
     if (!dbPromise) {
       L.debug("openDB", { dbName, storeName });
-      // Schema is shared with idb-thread-meta-store.ts: both modules open
-      // the same DB at the same version. The upgrade callback creates every store
-      // the schema currently defines, idempotently, so whichever module
-      // triggers the version bump leaves a complete schema for the other.
-      const openPromise = openDB(dbName, CHAT_IDB_VERSION, {
-        upgrade(db, oldVersion) {
-          L.debug("openDB:upgrade", { dbName, storeName });
-          upgradeChatIdb(db, oldVersion);
-        },
-      });
+      const openPromise = openChatIdb(userId, orgId);
       dbPromise = openPromise;
     }
 

--- a/turbo/apps/platform/src/signals/external/idb-thread-meta-store.ts
+++ b/turbo/apps/platform/src/signals/external/idb-thread-meta-store.ts
@@ -1,11 +1,7 @@
-import { openDB, type IDBPDatabase } from "idb";
+import type { IDBPDatabase } from "idb";
 import { nowDate } from "../../lib/time.ts";
 import { logger } from "../log.ts";
-import {
-  CHAT_IDB_VERSION,
-  CHAT_THREAD_META_STORE,
-  upgradeChatIdb,
-} from "./chat-idb-schema.ts";
+import { CHAT_THREAD_META_STORE } from "./chat-idb-schema.ts";
 import {
   chatIdbReadOr,
   chatIdbWriteBestEffort,
@@ -13,6 +9,7 @@ import {
   logChatIdbDisabled,
   withChatIdbTimeout,
 } from "./chat-idb-safe.ts";
+import { openChatIdb } from "./chat-idb-store.ts";
 
 const L = logger("ChatIdbThreadMeta");
 
@@ -88,12 +85,7 @@ const getDb = (() => {
       }
     }
     L.debug("openDB", { dbName });
-    const promise = openDB(dbName, CHAT_IDB_VERSION, {
-      upgrade(db, oldVersion) {
-        L.debug("openDB:upgrade", { dbName });
-        upgradeChatIdb(db, oldVersion);
-      },
-    });
+    const promise = openChatIdb(userId, orgId);
     cache[dbName] = promise;
 
     // IDB open is a cache fast path; timeout/rejection disables it for this tab.


### PR DESCRIPTION
## Summary

- Add a shared chat IndexedDB open helper for message and thread metadata stores.
- Close and invalidate chat IDB connections on future version-change events, then trigger one guarded page reload.
- Keep same-version read/write behavior unchanged and update the app IDB test mock for the new listener/close surface.

Fixes #19770

## Tests

- pnpm -F @vm0/app exec vitest src/signals/external/chat-idb-schema.test.ts src/signals/external/chat-idb-store.test.ts --run
- pnpm -F @vm0/app exec vitest src/views/zero-page/__tests__/chat-lifecycle.test.tsx --run
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm exec prettier --check apps/platform/src/signals/external/chat-idb-store.ts apps/platform/src/signals/external/chat-idb-store.test.ts apps/platform/src/signals/external/idb-message-store.ts apps/platform/src/signals/external/idb-thread-meta-store.ts apps/platform/src/mocks/idb.ts
- git diff --check
- pre-commit hook: prettier, knip, turbo check-types