### PR TITLE
fix: fail open chat IndexedDB cache

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/idb-cached-chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/idb-cached-chat-thread-data-source.ts
@@ -6,6 +6,10 @@ import {
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { clerk$ } from "../auth.ts";
+import {
+  chatIdbReadOr,
+  chatIdbWriteBestEffort,
+} from "../external/chat-idb-safe.ts";
 import { createIdbMessageStores } from "../external/idb-message-store.ts";
 import {
   patchThreadMeta$,
@@ -92,10 +96,17 @@ export async function readCachedMessagesBeforeUntilMiss(
   const seenIds = new Set<string>([beforeId]);
 
   while (true) {
-    const page = await readStore.readBefore(
-      threadId,
-      cursorId,
-      MESSAGE_PAGE_SIZE,
+    const page = await chatIdbReadOr(
+      "cachedDataSource:readBefore",
+      () => {
+        return readStore.readBefore(
+          threadId,
+          cursorId,
+          MESSAGE_PAGE_SIZE,
+          signal,
+        );
+      },
+      [],
       signal,
     );
     signal.throwIfAborted();
@@ -156,7 +167,14 @@ function createListMessagesBefore(
 
       const stores = getStores(userId, orgId);
       const readStore = stores.readStore;
-      const meta = await readThreadMeta$(userId, orgId, tid, signal);
+      const meta = await chatIdbReadOr(
+        "cachedDataSource:readThreadMetaBefore",
+        () => {
+          return readThreadMeta$(userId, orgId, tid, signal);
+        },
+        null,
+        signal,
+      );
       const cached = await readCachedMessagesBeforeUntilMiss(
         readStore,
         tid,
@@ -184,7 +202,13 @@ function createListMessagesBefore(
       );
 
       const writeStore = stores.writeStore;
-      await writeStore.upsertMessages(tid, result.messages, signal);
+      await chatIdbWriteBestEffort(
+        "cachedDataSource:upsertBefore",
+        () => {
+          return writeStore.upsertMessages(tid, result.messages, signal);
+        },
+        signal,
+      );
       L.debug("listBefore:cacheFilled", {
         threadId: tid,
         beforeId,
@@ -193,7 +217,19 @@ function createListMessagesBefore(
 
       if (!result.hasMore) {
         const startMessageId = result.messages[0]?.id ?? beforeId;
-        await patchThreadMeta$(userId, orgId, tid, { startMessageId }, signal);
+        await chatIdbWriteBestEffort(
+          "cachedDataSource:patchThreadMetaBefore",
+          () => {
+            return patchThreadMeta$(
+              userId,
+              orgId,
+              tid,
+              { startMessageId },
+              signal,
+            );
+          },
+          signal,
+        );
       }
 
       return result;
@@ -228,9 +264,12 @@ function createListMessagesAfter(
         // If it doesn't, local state has diverged and writing would create
         // a permanent gap between the last cached message and the new batch.
         if (sinceId) {
-          const anchorExists = await stores.readStore.messageExists(
-            tid,
-            sinceId,
+          const anchorExists = await chatIdbReadOr(
+            "cachedDataSource:messageExists",
+            () => {
+              return stores.readStore.messageExists(tid, sinceId, signal);
+            },
+            false,
             signal,
           );
           if (!anchorExists) {
@@ -238,7 +277,17 @@ function createListMessagesAfter(
             return result;
           }
         }
-        await stores.writeStore.upsertMessages(tid, result.messages, signal);
+        await chatIdbWriteBestEffort(
+          "cachedDataSource:upsertAfter",
+          () => {
+            return stores.writeStore.upsertMessages(
+              tid,
+              result.messages,
+              signal,
+            );
+          },
+          signal,
+        );
         L.debug("listAfter:cacheFilled", {
           threadId: tid,
           sinceId,
@@ -285,7 +334,13 @@ function createGetMessage(
       }
 
       const stores = getStores(userId, orgId);
-      await stores.writeStore.upsertMessages(tid, [message], signal);
+      await chatIdbWriteBestEffort(
+        "cachedDataSource:upsertMessage",
+        () => {
+          return stores.writeStore.upsertMessages(tid, [message], signal);
+        },
+        signal,
+      );
       L.debug("getMessage:cacheFilled", { threadId: tid, messageId });
       return message;
     },
@@ -305,7 +360,14 @@ export const warmLatestChatThreadMessages$ = command(
     }
 
     const stores = createIdbMessageStores(userId, orgId);
-    const latest = await stores.readStore.readLatest(threadId, 1, signal);
+    const latest = await chatIdbReadOr(
+      "cachedDataSource:warmReadLatest",
+      () => {
+        return stores.readStore.readLatest(threadId, 1, signal);
+      },
+      [],
+      signal,
+    );
     signal.throwIfAborted();
 
     let sinceId = latest[0]?.id;
@@ -331,9 +393,15 @@ export const warmLatestChatThreadMessages$ = command(
       });
 
       if (result.messages.length > 0) {
-        await stores.writeStore.upsertMessages(
-          threadId,
-          result.messages,
+        await chatIdbWriteBestEffort(
+          "cachedDataSource:warmUpsert",
+          () => {
+            return stores.writeStore.upsertMessages(
+              threadId,
+              result.messages,
+              signal,
+            );
+          },
           signal,
         );
         signal.throwIfAborted();
@@ -395,10 +463,22 @@ export function createIdbCachedDataSource(
 
     const stores = getStores(userId, orgId);
     const readStore = stores.readStore;
-    const cached = await readStore.readLatest(threadId);
+    const cached = await chatIdbReadOr(
+      "cachedDataSource:initialReadLatest",
+      () => {
+        return readStore.readLatest(threadId);
+      },
+      [],
+    );
 
     if (cached.length > 0) {
-      const meta = await readThreadMeta$(userId, orgId, threadId);
+      const meta = await chatIdbReadOr(
+        "cachedDataSource:initialReadThreadMeta",
+        () => {
+          return readThreadMeta$(userId, orgId, threadId);
+        },
+        null,
+      );
       const startMessageId = meta?.startMessageId ?? null;
       const hasReachedStart = reachedStart(cached, startMessageId);
       const needsHistoryBackfill = !hasReachedStart && startMessageId === null;
@@ -416,16 +496,23 @@ export function createIdbCachedDataSource(
     onInitialPageCacheMiss?.();
     const page = await get(remote.initialPage$);
     const writeStore = stores.writeStore;
-    await writeStore.upsertMessages(threadId, page.messages);
+    await chatIdbWriteBestEffort("cachedDataSource:initialUpsert", () => {
+      return writeStore.upsertMessages(threadId, page.messages);
+    });
     L.debug("initialPage:cacheFilled", {
       threadId,
       count: page.messages.length,
     });
 
     if (!page.hasHistoryBefore && page.messages.length > 0) {
-      await patchThreadMeta$(userId, orgId, threadId, {
-        startMessageId: page.messages[0].id,
-      });
+      await chatIdbWriteBestEffort(
+        "cachedDataSource:initialPatchThreadMeta",
+        () => {
+          return patchThreadMeta$(userId, orgId, threadId, {
+            startMessageId: page.messages[0].id,
+          });
+        },
+      );
     }
 
     return page;

--- a/turbo/apps/platform/src/signals/external/chat-idb-safe.ts
+++ b/turbo/apps/platform/src/signals/external/chat-idb-safe.ts
@@ -1,0 +1,82 @@
+import { delay } from "signal-timers";
+import { throwIfAbort } from "../utils.ts";
+import { logger } from "../log.ts";
+
+const L = logger("ChatIdbCache");
+
+const CHAT_IDB_OPERATION_TIMEOUT_MS = 200;
+
+class ChatIdbTimeoutError extends Error {
+  constructor(label: string) {
+    super(`IndexedDB operation timed out: ${label}`);
+    this.name = "ChatIdbTimeoutError";
+  }
+}
+
+class ChatIdbDisabledError extends Error {
+  constructor(dbName: string) {
+    super(`IndexedDB disabled for this session: ${dbName}`);
+    this.name = "ChatIdbDisabledError";
+  }
+}
+
+export function disabledChatIdbError(dbName: string): Error {
+  return new ChatIdbDisabledError(dbName);
+}
+
+export function logChatIdbDisabled(dbName: string, reason: unknown): void {
+  L.warn("disableForSession", { dbName, reason });
+}
+
+export async function withChatIdbTimeout<T>(
+  label: string,
+  operation: () => Promise<T>,
+  signal?: AbortSignal,
+): Promise<T> {
+  signal?.throwIfAborted();
+  const timeoutSignal = signal ?? AbortSignal.any([]);
+
+  const timeoutPromise = (async (): Promise<never> => {
+    await delay(CHAT_IDB_OPERATION_TIMEOUT_MS, { signal: timeoutSignal });
+    throw new ChatIdbTimeoutError(label);
+  })();
+  const operationPromise = (async (): Promise<T> => {
+    return await operation();
+  })();
+
+  return await Promise.race([operationPromise, timeoutPromise]);
+}
+
+export async function chatIdbReadOr<T>(
+  label: string,
+  operation: () => Promise<T>,
+  fallback: T,
+  signal?: AbortSignal,
+): Promise<T> {
+  // IDB is an untrusted local cache, so non-abort failures degrade to miss.
+  // eslint-disable-next-line no-restricted-syntax
+  try {
+    return await withChatIdbTimeout(label, operation, signal);
+  } catch (error) {
+    throwIfAbort(error);
+    signal?.throwIfAborted();
+    L.debug("read:fallback", { label, error });
+    return fallback;
+  }
+}
+
+export async function chatIdbWriteBestEffort(
+  label: string,
+  operation: () => Promise<void>,
+  signal?: AbortSignal,
+): Promise<void> {
+  // Writes should never block the server-backed chat flow.
+  // eslint-disable-next-line no-restricted-syntax
+  try {
+    await withChatIdbTimeout(label, operation, signal);
+  } catch (error) {
+    throwIfAbort(error);
+    signal?.throwIfAborted();
+    L.debug("write:ignored", { label, error });
+  }
+}

--- a/turbo/apps/platform/src/signals/external/idb-message-store.ts
+++ b/turbo/apps/platform/src/signals/external/idb-message-store.ts
@@ -11,6 +11,13 @@ import {
   CHAT_MESSAGES_STORE,
   upgradeChatIdb,
 } from "./chat-idb-schema.ts";
+import {
+  chatIdbReadOr,
+  chatIdbWriteBestEffort,
+  disabledChatIdbError,
+  logChatIdbDisabled,
+  withChatIdbTimeout,
+} from "./chat-idb-safe.ts";
 
 const L = logger("ChatIdbCache");
 
@@ -99,128 +106,195 @@ function storedOrderSequence(raw: unknown, message: PagedChatMessage): number {
   return chatMessageOrderSequence(message);
 }
 
+type GetDb = () => Promise<IDBPDatabase>;
+
+function createMessageReadStore(
+  storeName: string,
+  getDb: GetDb,
+): ChatMessageReadStore {
+  return {
+    async readLatest(threadId, limit, signal) {
+      return await chatIdbReadOr(
+        "messages:readLatest",
+        async () => {
+          L.debug("readLatest:start", { threadId, limit });
+          const db = await getDb();
+          signal?.throwIfAborted();
+          const tx = db.transaction(storeName, "readonly");
+          const index = tx.store.index(CHAT_MESSAGES_ORDER_INDEX);
+          const range = threadOrderRange(threadId);
+          const messages: PagedChatMessage[] = [];
+          let cursor = await index.openCursor(range, "prev");
+          while (cursor && (limit === undefined || messages.length < limit)) {
+            signal?.throwIfAborted();
+            messages.push(validateMessage(cursor.value));
+            cursor = await cursor.continue();
+          }
+          L.debug("readLatest:done", { threadId, count: messages.length });
+          return messages.reverse();
+        },
+        [],
+        signal,
+      );
+    },
+
+    async messageExists(threadId, messageId, signal) {
+      return await chatIdbReadOr(
+        "messages:messageExists",
+        async () => {
+          const db = await getDb();
+          signal?.throwIfAborted();
+          const tx = db.transaction(storeName, "readonly");
+          const msg = await tx.store.get(messageId);
+          return (
+            msg !== undefined &&
+            (msg as { threadId?: string }).threadId === threadId
+          );
+        },
+        false,
+        signal,
+      );
+    },
+
+    async readBefore(threadId, beforeId, limit, signal) {
+      return await chatIdbReadOr(
+        "messages:readBefore",
+        async () => {
+          L.debug("readBefore:start", { threadId, beforeId, limit });
+          const db = await getDb();
+          signal?.throwIfAborted();
+          const tx = db.transaction(storeName, "readonly");
+          const anchor = await tx.store.get(beforeId);
+          if (!anchor) {
+            L.debug("readBefore:anchorMiss", { threadId, beforeId });
+            return [];
+          }
+          if ((anchor as { threadId?: string }).threadId !== threadId) {
+            L.debug("readBefore:anchorThreadMismatch", { threadId, beforeId });
+            return [];
+          }
+          const anchorMsg = validateMessage(anchor);
+          signal?.throwIfAborted();
+
+          const index = tx.store.index(CHAT_MESSAGES_ORDER_INDEX);
+          const range = IDBKeyRange.bound(
+            [threadId],
+            [
+              threadId,
+              anchorMsg.createdAt,
+              storedOrderSequence(anchor, anchorMsg),
+              beforeId,
+            ],
+          );
+          const messages: PagedChatMessage[] = [];
+          let cursor = await index.openCursor(range, "prev");
+          if (cursor?.primaryKey === beforeId) {
+            cursor = await cursor.continue();
+          }
+          while (cursor && messages.length < limit) {
+            signal?.throwIfAborted();
+            messages.push(validateMessage(cursor.value));
+            cursor = await cursor.continue();
+          }
+          L.debug("readBefore:done", {
+            threadId,
+            beforeId,
+            count: messages.length,
+          });
+          return messages.reverse();
+        },
+        [],
+        signal,
+      );
+    },
+  };
+}
+
+function createMessageWriteStore(
+  storeName: string,
+  getDb: GetDb,
+): ChatMessageWriteStore {
+  return {
+    async upsertMessages(threadId, messages, signal) {
+      await chatIdbWriteBestEffort(
+        "messages:upsertMessages",
+        async () => {
+          L.debug("upsertMessages:start", {
+            threadId,
+            count: messages.length,
+          });
+          const db = await getDb();
+          signal?.throwIfAborted();
+          const tx = db.transaction(storeName, "readwrite");
+          for (const msg of messages) {
+            signal?.throwIfAborted();
+            // Stitch local ordering fields onto the stored value. PagedChatMessage
+            // from the API has no threadId and keeps sequenceNumber optional.
+            await tx.store.put(storedMessage(threadId, msg));
+          }
+          await tx.done;
+          L.debug("upsertMessages:done", { threadId, count: messages.length });
+        },
+        signal,
+      );
+    },
+  };
+}
+
 function createIdbMessageStores(userId: string, orgId: string) {
   const dbName = `vm0-chat-${userId}-${orgId}`;
   const storeName = CHAT_MESSAGES_STORE;
 
   let dbPromise: Promise<IDBPDatabase> | null = null;
+  let disabled = false;
 
-  function getDb(): Promise<IDBPDatabase> {
+  function disableForSession(reason: unknown): void {
+    if (disabled) {
+      return;
+    }
+    disabled = true;
+    logChatIdbDisabled(dbName, reason);
+  }
+
+  async function getDb(): Promise<IDBPDatabase> {
+    if (disabled) {
+      throw disabledChatIdbError(dbName);
+    }
+
     if (!dbPromise) {
       L.debug("openDB", { dbName, storeName });
       // Schema is shared with idb-thread-meta-store.ts: both modules open
       // the same DB at the same version. The upgrade callback creates every store
       // the schema currently defines, idempotently, so whichever module
       // triggers the version bump leaves a complete schema for the other.
-      dbPromise = openDB(dbName, CHAT_IDB_VERSION, {
+      const openPromise = openDB(dbName, CHAT_IDB_VERSION, {
         upgrade(db, oldVersion) {
           L.debug("openDB:upgrade", { dbName, storeName });
           upgradeChatIdb(db, oldVersion);
         },
       });
+      dbPromise = openPromise;
     }
-    return dbPromise;
+
+    const pending = dbPromise;
+    // IDB open is a cache fast path; timeout/rejection disables it for this tab.
+    // eslint-disable-next-line no-restricted-syntax
+    try {
+      return await withChatIdbTimeout("messages:openDB", () => {
+        return pending;
+      });
+    } catch (error) {
+      if (dbPromise === pending) {
+        dbPromise = null;
+      }
+      disableForSession(error);
+      throw error;
+    }
   }
 
-  const readStore: ChatMessageReadStore = {
-    async readLatest(threadId, limit, signal) {
-      L.debug("readLatest:start", { threadId, limit });
-      const db = await getDb();
-      signal?.throwIfAborted();
-      const tx = db.transaction(storeName, "readonly");
-      const index = tx.store.index(CHAT_MESSAGES_ORDER_INDEX);
-      const range = threadOrderRange(threadId);
-      const messages: PagedChatMessage[] = [];
-      let cursor = await index.openCursor(range, "prev");
-      while (cursor && (limit === undefined || messages.length < limit)) {
-        signal?.throwIfAborted();
-        messages.push(validateMessage(cursor.value));
-        cursor = await cursor.continue();
-      }
-      L.debug("readLatest:done", { threadId, count: messages.length });
-      return messages.reverse();
-    },
-
-    async messageExists(threadId, messageId, signal) {
-      const db = await getDb();
-      signal?.throwIfAborted();
-      const tx = db.transaction(storeName, "readonly");
-      const msg = await tx.store.get(messageId);
-      return (
-        msg !== undefined &&
-        (msg as { threadId?: string }).threadId === threadId
-      );
-    },
-
-    async readBefore(threadId, beforeId, limit, signal) {
-      L.debug("readBefore:start", { threadId, beforeId, limit });
-      const db = await getDb();
-      signal?.throwIfAborted();
-      const tx = db.transaction(storeName, "readonly");
-      const anchor = await tx.store.get(beforeId);
-      if (!anchor) {
-        L.debug("readBefore:anchorMiss", { threadId, beforeId });
-        return [];
-      }
-      if ((anchor as { threadId?: string }).threadId !== threadId) {
-        L.debug("readBefore:anchorThreadMismatch", { threadId, beforeId });
-        return [];
-      }
-      const anchorMsg = validateMessage(anchor);
-      signal?.throwIfAborted();
-
-      const index = tx.store.index(CHAT_MESSAGES_ORDER_INDEX);
-      const range = IDBKeyRange.bound(
-        [threadId],
-        [
-          threadId,
-          anchorMsg.createdAt,
-          storedOrderSequence(anchor, anchorMsg),
-          beforeId,
-        ],
-      );
-      const messages: PagedChatMessage[] = [];
-      let cursor = await index.openCursor(range, "prev");
-      if (cursor?.primaryKey === beforeId) {
-        cursor = await cursor.continue();
-      }
-      while (cursor && messages.length < limit) {
-        signal?.throwIfAborted();
-        messages.push(validateMessage(cursor.value));
-        cursor = await cursor.continue();
-      }
-      L.debug("readBefore:done", {
-        threadId,
-        beforeId,
-        count: messages.length,
-      });
-      return messages.reverse();
-    },
-  };
-
-  const writeStore: ChatMessageWriteStore = {
-    async upsertMessages(threadId, messages, signal) {
-      L.debug("upsertMessages:start", {
-        threadId,
-        count: messages.length,
-      });
-      const db = await getDb();
-      signal?.throwIfAborted();
-      const tx = db.transaction(storeName, "readwrite");
-      for (const msg of messages) {
-        signal?.throwIfAborted();
-        // Stitch local ordering fields onto the stored value. PagedChatMessage
-        // from the API has no threadId and keeps sequenceNumber optional.
-        await tx.store.put(storedMessage(threadId, msg));
-      }
-      await tx.done;
-      L.debug("upsertMessages:done", { threadId, count: messages.length });
-    },
-  };
-
   return Object.freeze({
-    readStore,
-    writeStore,
+    readStore: createMessageReadStore(storeName, getDb),
+    writeStore: createMessageWriteStore(storeName, getDb),
   });
 }
 

--- a/turbo/apps/platform/src/signals/external/idb-thread-meta-store.ts
+++ b/turbo/apps/platform/src/signals/external/idb-thread-meta-store.ts
@@ -6,6 +6,13 @@ import {
   CHAT_THREAD_META_STORE,
   upgradeChatIdb,
 } from "./chat-idb-schema.ts";
+import {
+  chatIdbReadOr,
+  chatIdbWriteBestEffort,
+  disabledChatIdbError,
+  logChatIdbDisabled,
+  withChatIdbTimeout,
+} from "./chat-idb-safe.ts";
 
 const L = logger("ChatIdbThreadMeta");
 
@@ -50,11 +57,35 @@ const STORE = CHAT_THREAD_META_STORE;
 
 const getDb = (() => {
   const cache: Record<string, Promise<IDBPDatabase>> = {};
-  return (userId: string, orgId: string): Promise<IDBPDatabase> => {
+  const disabled: Record<string, true> = {};
+
+  function disableForSession(dbName: string, reason: unknown): void {
+    if (disabled[dbName]) {
+      return;
+    }
+    disabled[dbName] = true;
+    logChatIdbDisabled(dbName, reason);
+  }
+
+  return async (userId: string, orgId: string): Promise<IDBPDatabase> => {
     const dbName = `vm0-chat-${userId}-${orgId}`;
+    if (disabled[dbName]) {
+      throw disabledChatIdbError(dbName);
+    }
+
     const existing = cache[dbName];
     if (existing !== undefined) {
-      return existing;
+      // IDB open is a cache fast path; timeout/rejection disables it for this tab.
+      // eslint-disable-next-line no-restricted-syntax
+      try {
+        return await withChatIdbTimeout("threadMeta:openDB", () => {
+          return existing;
+        });
+      } catch (error) {
+        delete cache[dbName];
+        disableForSession(dbName, error);
+        throw error;
+      }
     }
     L.debug("openDB", { dbName });
     const promise = openDB(dbName, CHAT_IDB_VERSION, {
@@ -64,7 +95,20 @@ const getDb = (() => {
       },
     });
     cache[dbName] = promise;
-    return promise;
+
+    // IDB open is a cache fast path; timeout/rejection disables it for this tab.
+    // eslint-disable-next-line no-restricted-syntax
+    try {
+      return await withChatIdbTimeout("threadMeta:openDB", () => {
+        return promise;
+      });
+    } catch (error) {
+      if (cache[dbName] === promise) {
+        delete cache[dbName];
+      }
+      disableForSession(dbName, error);
+      throw error;
+    }
   };
 })();
 
@@ -74,22 +118,29 @@ export async function readThreadMeta$(
   threadId: string,
   signal?: AbortSignal,
 ): Promise<ThreadMeta | null> {
-  const db = await getDb(userId, orgId);
-  signal?.throwIfAborted();
-  const raw = await db.get(STORE, threadId);
-  if (!raw) {
-    return null;
-  }
-  if (!isThreadMetaRow(raw)) {
-    L.debug("read:corruptRow", { threadId });
-    return null;
-  }
-  return {
-    threadId: raw.threadId,
-    agentId: raw.agentId ?? null,
-    startMessageId: raw.startMessageId ?? null,
-    updatedAt: raw.updatedAt,
-  };
+  return await chatIdbReadOr(
+    "threadMeta:read",
+    async () => {
+      const db = await getDb(userId, orgId);
+      signal?.throwIfAborted();
+      const raw = await db.get(STORE, threadId);
+      if (!raw) {
+        return null;
+      }
+      if (!isThreadMetaRow(raw)) {
+        L.debug("read:corruptRow", { threadId });
+        return null;
+      }
+      return {
+        threadId: raw.threadId,
+        agentId: raw.agentId ?? null,
+        startMessageId: raw.startMessageId ?? null,
+        updatedAt: raw.updatedAt,
+      };
+    },
+    null,
+    signal,
+  );
 }
 
 interface ThreadMetaPatch {
@@ -109,19 +160,25 @@ export async function patchThreadMeta$(
   patch: ThreadMetaPatch,
   signal?: AbortSignal,
 ): Promise<void> {
-  const db = await getDb(userId, orgId);
-  signal?.throwIfAborted();
-  const tx = db.transaction(STORE, "readwrite");
-  const existing = await tx.store.get(threadId);
-  signal?.throwIfAborted();
-  const current = isThreadMetaRow(existing) ? existing : null;
-  const next: ThreadMetaRow = {
-    threadId,
-    agentId: patch.agentId ?? current?.agentId,
-    startMessageId: patch.startMessageId ?? current?.startMessageId,
-    updatedAt: nowDate().toISOString(),
-  };
-  await tx.store.put(next);
-  await tx.done;
-  L.debug("patch:done", { threadId, patch });
+  await chatIdbWriteBestEffort(
+    "threadMeta:patch",
+    async () => {
+      const db = await getDb(userId, orgId);
+      signal?.throwIfAborted();
+      const tx = db.transaction(STORE, "readwrite");
+      const existing = await tx.store.get(threadId);
+      signal?.throwIfAborted();
+      const current = isThreadMetaRow(existing) ? existing : null;
+      const next: ThreadMetaRow = {
+        threadId,
+        agentId: patch.agentId ?? current?.agentId,
+        startMessageId: patch.startMessageId ?? current?.startMessageId,
+        updatedAt: nowDate().toISOString(),
+      };
+      await tx.store.put(next);
+      await tx.done;
+      L.debug("patch:done", { threadId, patch });
+    },
+    signal,
+  );
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx
@@ -1,0 +1,177 @@
+import { screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  chatThreadByIdContract,
+  chatThreadMessagesContract,
+  chatThreadsContract,
+} from "@vm0/api-contracts/contracts/chat-threads";
+
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { PLACEHOLDER } from "./chat-test-helpers.ts";
+
+const idbMessageStoreMock = vi.hoisted(() => {
+  const readLatest = vi.fn(() => {
+    return Promise.resolve([]);
+  });
+  const readBefore = vi.fn(() => {
+    return Promise.resolve([]);
+  });
+  const messageExists = vi.fn(() => {
+    return Promise.resolve(false);
+  });
+  const upsertMessages = vi.fn(() => {
+    return Promise.resolve();
+  });
+
+  return {
+    readLatest,
+    readBefore,
+    messageExists,
+    upsertMessages,
+    reset() {
+      readLatest.mockReset();
+      readLatest.mockResolvedValue([]);
+      readBefore.mockReset();
+      readBefore.mockResolvedValue([]);
+      messageExists.mockReset();
+      messageExists.mockResolvedValue(false);
+      upsertMessages.mockReset();
+      upsertMessages.mockResolvedValue(undefined);
+    },
+  };
+});
+
+vi.mock("../../../signals/external/idb-message-store.ts", () => {
+  return {
+    createIdbMessageStores: () => {
+      return {
+        readStore: {
+          readLatest: idbMessageStoreMock.readLatest,
+          readBefore: idbMessageStoreMock.readBefore,
+          messageExists: idbMessageStoreMock.messageExists,
+        },
+        writeStore: {
+          upsertMessages: idbMessageStoreMock.upsertMessages,
+        },
+      };
+    },
+  };
+});
+
+const context = testContext();
+
+const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
+const THREAD_ID = "b0000000-0000-4000-a000-000000000001";
+const THREAD_TITLE = "GEO pricing research";
+const USER_MESSAGE = "Summarize the launch plan";
+const ASSISTANT_MESSAGE = "Here is the result";
+
+function prepareDefaultAgent(): void {
+  context.mocks.data.team([
+    {
+      id: AGENT_ID,
+      ownerId: "test-user-123",
+      displayName: "Zero",
+      description: null,
+      sound: null,
+      avatarUrl: null,
+      visibility: "public",
+      headVersionId: "version_1",
+      updatedAt: "2024-01-01T00:00:00Z",
+    },
+  ]);
+}
+
+function mockCurrentThreadDetail(): void {
+  context.mocks.api(chatThreadByIdContract.get, ({ params, respond }) => {
+    return respond(200, {
+      id: params.id,
+      title: THREAD_TITLE,
+      agentId: AGENT_ID,
+      activeRunIds: [],
+      lastReadAt: "2026-03-10T00:00:00Z",
+      lastMessageAt: "2026-03-10T00:00:02Z",
+      createdAt: "2026-03-10T00:00:00Z",
+      updatedAt: "2026-03-10T00:00:02Z",
+      draftContent: null,
+      draftAttachments: null,
+    });
+  });
+}
+
+function mockSidebarThread(): void {
+  context.mocks.api(chatThreadsContract.list, ({ respond }) => {
+    return respond(200, {
+      pinned: [],
+      threads: [
+        {
+          id: THREAD_ID,
+          title: THREAD_TITLE,
+          agent: { id: AGENT_ID, avatarUrl: null },
+          createdAt: "2026-03-10T00:00:00Z",
+          updatedAt: "2026-03-10T00:00:02Z",
+          running: false,
+          pinnedAt: null,
+        },
+      ],
+      hasMore: false,
+      nextCursor: null,
+    });
+  });
+}
+
+describe("zero chat thread IndexedDB fallback", () => {
+  afterEach(() => {
+    idbMessageStoreMock.reset();
+  });
+
+  it("falls back to remote messages when IndexedDB message read never settles", async () => {
+    const pendingRead = context.mocks.deferred<never[]>();
+    idbMessageStoreMock.readLatest.mockImplementation(() => {
+      return pendingRead.promise;
+    });
+    prepareDefaultAgent();
+    mockCurrentThreadDetail();
+    mockSidebarThread();
+
+    let messageListRequests = 0;
+    context.mocks.api(chatThreadMessagesContract.list, ({ respond }) => {
+      messageListRequests += 1;
+      return respond(200, {
+        messages: [
+          {
+            id: "00000000-0000-4000-8000-000000000101",
+            role: "user",
+            content: USER_MESSAGE,
+            createdAt: "2026-03-10T00:00:01Z",
+          },
+          {
+            id: "00000000-0000-4000-8000-000000000102",
+            role: "assistant",
+            content: ASSISTANT_MESSAGE,
+            createdAt: "2026-03-10T00:00:02Z",
+          },
+        ],
+      });
+    });
+
+    detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+
+    await waitFor(() => {
+      expect(screen.getByText(THREAD_TITLE)).toBeInTheDocument();
+      expect(screen.getByPlaceholderText(PLACEHOLDER)).toBeInTheDocument();
+    });
+
+    const messageContainer = document.querySelector("[data-message-container]");
+    expect(messageContainer).toBeInstanceOf(HTMLElement);
+    await expect(screen.findByText(USER_MESSAGE)).resolves.toBeInTheDocument();
+    await expect(
+      screen.findByText(ASSISTANT_MESSAGE),
+    ).resolves.toBeInTheDocument();
+    expect(
+      screen.queryByText("Send a message to start the conversation"),
+    ).not.toBeInTheDocument();
+    expect(messageListRequests).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Impact
为聊天缓存实现IndexedDB超时降级加载机制

## Summary
- add a shared chat IndexedDB timeout/fail-open helper
- make chat message and thread metadata IDB reads degrade to cache misses, while writes stay best-effort
- add a page-level regression test for the blank chat body when message IndexedDB reads never settle

## Testing
- pnpm --dir /home/user/workspace/vm0/turbo exec vitest run apps/platform/src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx
- pnpm --dir /home/user/workspace/vm0/turbo exec vitest run apps/platform/src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx apps/platform/src/signals/chat-page/__tests__/idb-cached-chat-thread-initial-page.test.ts apps/platform/src/signals/chat-page/__tests__/idb-cached-chat-thread-data-source.test.ts apps/platform/src/signals/external/chat-idb-schema.test.ts
- pnpm --dir /home/user/workspace/vm0/turbo --filter @vm0/app lint
- pnpm --dir /home/user/workspace/vm0/turbo --filter @vm0/app check-types
- git diff --check