### PR TITLE
refactor(mitm-addon): separate body decode policies

### DIFF
--- a/crates/runner/mitm-addon/src/body_capture.py
+++ b/crates/runner/mitm-addon/src/body_capture.py
@@ -313,13 +313,12 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
                 flow.metadata.get(metadata_keys.REQUEST_STREAM_COMPLETE) is not True
             )
             req_ct = flow.request.headers.get("content-type", "")
-            request_body = body_decoding.decode_body_bounded(
+            request_body = body_decoding.decode_request_body_for_network_log_capture(
                 bytes(request_stream_body.buffer),
                 flow.request.headers,
                 max_output=BODY_CAPTURE_LIMIT + 1,
-                fail_on_unsupported_encoding=True,
             )
-            if request_body.failed:
+            if request_body is None:
                 if request_stream_body.truncated or request_stream_incomplete:
                     log_entry["request_body_truncated"] = True
                 log_entry["request_body_encoding"] = "binary"
@@ -327,22 +326,21 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
                 _set_body_fields(
                     log_entry,
                     "request",
-                    request_body.body,
+                    request_body,
                     req_ct,
                     already_truncated=request_stream_body.truncated or request_stream_incomplete,
                 )
         elif flow.request.raw_content:
             req_ct = flow.request.headers.get("content-type", "")
-            request_body = body_decoding.decode_body_bounded(
+            request_body = body_decoding.decode_request_body_for_network_log_capture(
                 flow.request.raw_content,
                 flow.request.headers,
                 max_output=BODY_CAPTURE_LIMIT + 1,
-                fail_on_unsupported_encoding=True,
             )
-            if request_body.failed:
+            if request_body is None:
                 log_entry["request_body_encoding"] = "binary"
             else:
-                _set_body_fields(log_entry, "request", request_body.body, req_ct)
+                _set_body_fields(log_entry, "request", request_body, req_ct)
 
     # Response headers
     if flow.response:

--- a/crates/runner/mitm-addon/src/body_decoding.py
+++ b/crates/runner/mitm-addon/src/body_decoding.py
@@ -4,6 +4,8 @@ Exports:
 
 - Bounded streaming usage decoding for gzip, deflate, zstd; one-shot
   decompression for gzip, deflate, br, zstd.
+- Request network-log capture decoding that suppresses unsupported or failed
+  encoded request bodies.
 - JSON usage decompression with diagnostic error classification.
 """
 

--- a/crates/runner/mitm-addon/src/body_decoding.py
+++ b/crates/runner/mitm-addon/src/body_decoding.py
@@ -36,7 +36,20 @@ INCOMPLETE_COMPRESSED_BODY = "incomplete compressed body"
 DECODED_BODY_LIMIT_EXCEEDED = "decoded body limit exceeded"
 
 
-class BodyDecodeResult(NamedTuple):
+class _BodyDecodeResult(NamedTuple):
+    """Internal bounded decode result before a caller policy is applied.
+
+    ``body`` is the bytes produced by the primitive. Depending on codec state
+    and caller policy, it may be fully decoded output, partial decoded output,
+    the original wire bytes, or ``b""`` from a valid empty compressed frame.
+
+    ``failed`` means the primitive could not safely satisfy the requested
+    policy. It is not a universal "body is unusable" verdict: best-effort
+    response capture may still keep ``body``, while request capture suppresses
+    body text on failure. ``error`` is populated only when a codec raised while
+    decoding; unsupported encodings can fail without an exception.
+    """
+
     body: bytes
     failed: bool
     error: Exception | None = None
@@ -272,7 +285,7 @@ def decompress_body(
     body returns ``b""`` — callers that short-circuit via ``if not body`` rely
     on that (see #10287).
     """
-    result = decode_body_bounded(data, headers, max_output=max_output)
+    result = _decode_body_bounded(data, headers, max_output=max_output)
     if result.failed and result.error is not None:
         with contextlib.suppress(AttributeError):
             # ctx.log unavailable outside mitmproxy runtime
@@ -285,9 +298,9 @@ def decompress_body(
 
 def _decompress_zlib_best_effort_bounded(
     data: bytes, encoding: Literal["gzip", "deflate"], max_output: int
-) -> BodyDecodeResult:
+) -> _BodyDecodeResult:
     if max_output <= 0:
-        return BodyDecodeResult(b"", False)
+        return _BodyDecodeResult(b"", False)
 
     wbits = 16 + zlib.MAX_WBITS if encoding == "gzip" else zlib.MAX_WBITS
     remaining_data = data
@@ -303,8 +316,8 @@ def _decompress_zlib_best_effort_bounded(
                 decoded = obj.decompress(member_data, max_length=max_output - len(out))
             except zlib.error as exc:
                 if completed_member:
-                    return BodyDecodeResult(bytes(out), False)
-                return BodyDecodeResult(data, True, exc)
+                    return _BodyDecodeResult(bytes(out), False)
+                return _BodyDecodeResult(data, True, exc)
 
             out.extend(decoded)
             if obj.unconsumed_tail:
@@ -313,44 +326,88 @@ def _decompress_zlib_best_effort_bounded(
             break
 
         if len(out) >= max_output:
-            return BodyDecodeResult(bytes(out), False)
+            return _BodyDecodeResult(bytes(out), False)
         if obj.eof:
             completed_member = True
             if obj.unused_data:
                 remaining_data = obj.unused_data
                 continue
-            return BodyDecodeResult(bytes(out), False)
-        return BodyDecodeResult(bytes(out), False)
+            return _BodyDecodeResult(bytes(out), False)
+        return _BodyDecodeResult(bytes(out), False)
 
-    return BodyDecodeResult(bytes(out), False)
+    return _BodyDecodeResult(bytes(out), False)
 
 
-def decode_body_bounded(
+def _decode_body_bounded(
     data: bytes,
     headers: http.Headers,
     *,
     max_output: int,
     fail_on_unsupported_encoding: bool = False,
-) -> BodyDecodeResult:
+) -> _BodyDecodeResult:
+    """Decode a body with bounded output before applying public caller policy.
+
+    Missing or ``identity`` encodings return the input unchanged. Supported
+    encodings decode up to ``max_output`` bytes; hitting that cap returns the
+    decoded prefix and does not set ``failed``. Valid compressed empty frames
+    return ``b""``.
+
+    For gzip and deflate, an invalid first member returns the original bytes
+    with ``failed=True``. Once at least one member completes, invalid trailing
+    garbage is ignored and the decoded prefix is returned with ``failed=False``.
+    Truncated gzip/deflate input may return partial decoded output without
+    failure if zlib emitted bytes before the stream ended.
+
+    Unsupported encodings pass through by default for best-effort callers. Set
+    ``fail_on_unsupported_encoding`` only for policies that must suppress
+    opaque encoded bodies, such as request network-log capture.
+    """
     encoding = headers.get("content-encoding", "").strip().lower()
     if not encoding or encoding == "identity":
-        return BodyDecodeResult(data, False)
+        return _BodyDecodeResult(data, False)
     try:
         if encoding in ("gzip", "deflate"):
             return _decompress_zlib_best_effort_bounded(data, encoding, max_output)
         if encoding == "br":
-            return BodyDecodeResult(_decompress_brotli_bounded(data, max_output), False)
+            return _BodyDecodeResult(_decompress_brotli_bounded(data, max_output), False)
         if encoding == "zstd":
             # stream_reader.read(n) reads *up to* n bytes: the full frame if
             # smaller than n, exactly n if larger — so total memory is bounded
             # by n plus ZSTD_DStream{In,Out}Size (~128 KB library buffers).
             with zstandard.ZstdDecompressor().stream_reader(data) as reader:
-                return BodyDecodeResult(reader.read(max_output), False)
+                return _BodyDecodeResult(reader.read(max_output), False)
     except (zlib.error, brotli.error, zstandard.ZstdError) as exc:
-        return BodyDecodeResult(data, True, exc)
+        return _BodyDecodeResult(data, True, exc)
     if fail_on_unsupported_encoding:
-        return BodyDecodeResult(b"", True)
-    return BodyDecodeResult(data, False)
+        return _BodyDecodeResult(b"", True)
+    return _BodyDecodeResult(data, False)
+
+
+def decode_request_body_for_network_log_capture(
+    data: bytes,
+    headers: http.Headers,
+    *,
+    max_output: int = DEFAULT_BODY_DECODE_LIMIT,
+) -> bytes | None:
+    """Decode a request body for network-log capture.
+
+    Request capture hides unsupported or invalid encoded bodies instead of
+    preserving opaque request bytes in logs. Returns ``None`` when callers
+    should omit request body text and mark the body as binary. Returns decoded
+    bytes on success, including ``b""`` for a valid empty compressed body.
+
+    This is distinct from ``billing_body.decode_request_body_for_billing``,
+    which has stricter billing-inspection policy.
+    """
+    result = _decode_body_bounded(
+        data,
+        headers,
+        max_output=max_output,
+        fail_on_unsupported_encoding=True,
+    )
+    if result.failed:
+        return None
+    return result.body
 
 
 def _decompress_brotli_bounded_with_status(

--- a/crates/runner/mitm-addon/src/body_decoding.py
+++ b/crates/runner/mitm-addon/src/body_decoding.py
@@ -391,10 +391,13 @@ def decode_request_body_for_network_log_capture(
 ) -> bytes | None:
     """Decode a request body for network-log capture.
 
-    Request capture hides unsupported or invalid encoded bodies instead of
-    preserving opaque request bytes in logs. Returns ``None`` when callers
-    should omit request body text and mark the body as binary. Returns decoded
-    bytes on success, including ``b""`` for a valid empty compressed body.
+    Request capture hides unsupported encodings and bodies that the bounded
+    primitive reports as decode failures instead of preserving opaque request
+    bytes in logs. Gzip/deflate input that yields partial decoded output still
+    follows the primitive's best-effort success semantics. Returns ``None`` when
+    callers should omit request body text and mark the body as binary. Returns
+    decoded bytes on success, including ``b""`` for a valid empty compressed
+    body.
 
     This is distinct from ``billing_body.decode_request_body_for_billing``,
     which has stricter billing-inspection policy.

--- a/crates/runner/mitm-addon/tests/test_body_capture_fields.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture_fields.py
@@ -262,6 +262,36 @@ class TestAddCaptureFields:
         assert entry["response_body"] == '{"ok": true}'
         assert entry["response_body_encoding"] == "utf-8"
 
+    def test_request_body_invalid_gzip_is_hidden_as_binary(self, real_flow):
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="text/plain",
+            request_encoding="gzip",
+            request_body=b"not gzip at all",
+            response_content_type="application/json",
+            response_body=b'{"ok": true}',
+        )
+        entry = {}
+        add_capture_fields(flow, entry)
+        assert "request_body" not in entry
+        assert entry["request_body_encoding"] == "binary"
+
+    def test_request_body_unknown_content_encoding_is_hidden_as_binary(self, real_flow):
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="text/plain",
+            request_encoding="x-custom",
+            request_body=b"opaque request body",
+            response_content_type="application/json",
+            response_body=b'{"ok": true}',
+        )
+        entry = {}
+        add_capture_fields(flow, entry)
+        assert "request_body" not in entry
+        assert entry["request_body_encoding"] == "binary"
+
     def test_response_decompression_error_skips_body(self, real_flow):
         # Content-Encoding: gzip + non-gzip bytes makes flow.response.content
         # raise ValueError, which add_capture_fields is expected to catch.

--- a/crates/runner/mitm-addon/tests/test_body_decoding.py
+++ b/crates/runner/mitm-addon/tests/test_body_decoding.py
@@ -10,6 +10,7 @@ import zstandard
 from body_decoding import (
     create_stream_decode_feed,
     create_stream_decode_session,
+    decode_request_body_for_network_log_capture,
     decompress_body,
 )
 from body_limits import DEFAULT_BODY_DECODE_LIMIT, STREAM_DECODE_CHUNK_LIMIT
@@ -446,3 +447,44 @@ class TestDecompressBody:
         compressed = zstandard.ZstdCompressor().compress(b"")
         hdrs = headers(("Content-Encoding", "zstd"))
         assert decompress_body(compressed, hdrs, max_output=64 * 1024) == b""
+
+
+class TestDecodeRequestBodyForNetworkLogCapture:
+    """Direct tests for request network-log capture decode policy."""
+
+    def test_no_encoding_returns_original_bytes(self, headers):
+        data = b'{"hello":"world"}'
+        assert decode_request_body_for_network_log_capture(data, headers()) == data
+
+    def test_identity_returns_original_bytes(self, headers):
+        data = b'{"hello":"world"}'
+        hdrs = headers(("Content-Encoding", "identity"))
+        assert decode_request_body_for_network_log_capture(data, hdrs) == data
+
+    @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
+    def test_zlib_valid_body_returns_decoded_bytes(self, headers, encoding):
+        data = b'{"hello":"world"}'
+        compressed = gzip.compress(data) if encoding == "gzip" else zlib.compress(data)
+        hdrs = headers(("Content-Encoding", encoding))
+        assert decode_request_body_for_network_log_capture(compressed, hdrs) == data
+
+    @pytest.mark.parametrize(
+        ("encoding", "compressed"),
+        [
+            ("gzip", gzip.compress(b"")),
+            ("deflate", zlib.compress(b"")),
+            ("br", brotli.compress(b"")),
+            ("zstd", zstandard.ZstdCompressor().compress(b"")),
+        ],
+    )
+    def test_valid_empty_compressed_body_returns_empty_bytes(self, headers, encoding, compressed):
+        hdrs = headers(("Content-Encoding", encoding))
+        assert decode_request_body_for_network_log_capture(compressed, hdrs) == b""
+
+    def test_unsupported_encoding_returns_none(self, headers):
+        hdrs = headers(("Content-Encoding", "x-custom"))
+        assert decode_request_body_for_network_log_capture(b"opaque", hdrs) is None
+
+    def test_invalid_compressed_body_returns_none(self, headers):
+        hdrs = headers(("Content-Encoding", "gzip"))
+        assert decode_request_body_for_network_log_capture(b"not gzip", hdrs) is None

--- a/crates/runner/mitm-addon/tests/test_body_decoding.py
+++ b/crates/runner/mitm-addon/tests/test_body_decoding.py
@@ -488,3 +488,15 @@ class TestDecodeRequestBodyForNetworkLogCapture:
     def test_invalid_compressed_body_returns_none(self, headers):
         hdrs = headers(("Content-Encoding", "gzip"))
         assert decode_request_body_for_network_log_capture(b"not gzip", hdrs) is None
+
+    def test_truncated_gzip_partial_decode_returns_decoded_bytes(self, headers):
+        data = b"x" * 100_000
+        compressed = gzip.compress(data)
+        truncated = compressed[: len(compressed) // 2]
+        hdrs = headers(("Content-Encoding", "gzip"))
+
+        result = decode_request_body_for_network_log_capture(truncated, hdrs)
+
+        assert result is not None
+        assert len(result) > 1024
+        assert set(result) == {ord("x")}


### PR DESCRIPTION
## Summary

- make the bounded body decode primitive and result type private implementation details
- add `decode_request_body_for_network_log_capture(...) -> bytes | None` so request capture no longer interprets low-level decode failures directly
- keep best-effort response decoding and diagnostic usage decoding on their existing public APIs
- add request network-log capture helper tests for pass-through, decoded, empty, unsupported, and invalid bodies

## Behavior

This is intended to preserve existing decompression behavior. The change only makes caller policy explicit at the API boundary.

## Tests

- `/tmp/mitm-addon-venv/bin/ruff format src/body_decoding.py src/body_capture.py tests/test_body_decoding.py`
- `/tmp/mitm-addon-venv/bin/ruff check --fix src/body_decoding.py src/body_capture.py tests/test_body_decoding.py`
- `/tmp/mitm-addon-venv/bin/pytest tests/test_body_decoding.py tests/test_body_capture_fields.py tests/test_body_capture_decompression.py`
- `/tmp/mitm-addon-venv/bin/basedpyright --pythonpath /tmp/mitm-addon-venv/bin/python src/body_decoding.py src/body_capture.py tests/test_body_decoding.py`
- `/tmp/mitm-addon-venv/bin/pytest tests/`

Closes #19731
