### PR TITLE
fix: simplify computer use download buttons to one CTA

### DIFF
--- a/turbo/apps/platform/src/views/computer-use-authorization/computer-use-authorization-page.tsx
+++ b/turbo/apps/platform/src/views/computer-use-authorization/computer-use-authorization-page.tsx
@@ -122,37 +122,29 @@ function EmptyHosts() {
         </p>
       </div>
       {showIntelDownload ? (
-        <div className="flex w-full max-w-sm flex-col gap-2">
+        <div className="flex w-full max-w-sm flex-col items-center gap-3">
           <a
             href={ZERO_DESKTOP_DOWNLOAD_URL}
             aria-label="Download for Mac Apple Silicon"
             target="_blank"
             rel="noreferrer"
-            className="inline-flex min-h-11 items-center justify-center gap-2 rounded-lg border border-border bg-background px-3 py-2 text-sm font-medium text-foreground transition-colors hover:bg-accent"
+            className="inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-lg border border-border bg-background px-3 py-2 text-sm font-medium text-foreground transition-colors hover:bg-accent"
           >
             <IconDownload size={16} />
-            <span className="flex flex-col items-start gap-0.5">
-              <span>Download for Mac</span>
-              <span className="text-xs font-normal text-muted-foreground">
-                Apple Silicon
-              </span>
-            </span>
+            Download for Mac (Apple Silicon)
           </a>
-          <a
-            href={ZERO_DESKTOP_INTEL_DOWNLOAD_URL}
-            aria-label="Download for Mac Intel"
-            target="_blank"
-            rel="noreferrer"
-            className="inline-flex min-h-11 items-center justify-center gap-2 rounded-lg border border-border bg-background px-3 py-2 text-sm font-medium text-foreground transition-colors hover:bg-accent"
-          >
-            <IconDownload size={16} />
-            <span className="flex flex-col items-start gap-0.5">
-              <span>Download for Mac</span>
-              <span className="text-xs font-normal text-muted-foreground">
-                Intel
-              </span>
-            </span>
-          </a>
+          <p className="text-sm text-muted-foreground">
+            On an Intel Mac?{" "}
+            <a
+              href={ZERO_DESKTOP_INTEL_DOWNLOAD_URL}
+              aria-label="Download for Mac Intel"
+              target="_blank"
+              rel="noreferrer"
+              className="font-medium text-primary hover:underline"
+            >
+              Download here
+            </a>
+          </p>
         </div>
       ) : downloadSupportStatus === "unsupported-intel-mac" ? (
         <Button type="button" variant="outline" disabled className="h-9">

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -5861,12 +5861,8 @@ function ComputerUseDownloadDialog({
         </DialogHeader>
         <div className="px-6 pb-6 pt-4">
           {showIntelDownload ? (
-            <div className="flex flex-col gap-2">
-              <Button
-                asChild
-                size="lg"
-                className="h-auto min-h-11 w-full justify-start px-4 py-2"
-              >
+            <div className="flex flex-col items-center gap-3">
+              <Button asChild size="lg" className="w-full">
                 <a
                   href={downloadUrl}
                   aria-label="Download for Mac Apple Silicon"
@@ -5877,20 +5873,11 @@ function ComputerUseDownloadDialog({
                   }}
                 >
                   <IconDownload size={16} stroke={1.5} />
-                  <span className="flex flex-col items-start gap-0.5">
-                    <span>Download for Mac</span>
-                    <span className="text-xs font-normal text-primary-foreground/80">
-                      Apple Silicon
-                    </span>
-                  </span>
+                  Download for Mac (Apple Silicon)
                 </a>
               </Button>
-              <Button
-                asChild
-                size="lg"
-                variant="outline"
-                className="h-auto min-h-11 w-full justify-start px-4 py-2"
-              >
+              <p className="text-sm text-muted-foreground">
+                On an Intel Mac?{" "}
                 <a
                   href={ZERO_DESKTOP_INTEL_DOWNLOAD_URL}
                   aria-label="Download for Mac Intel"
@@ -5899,16 +5886,11 @@ function ComputerUseDownloadDialog({
                   onClick={() => {
                     onOpenChange(false);
                   }}
+                  className="font-medium text-primary hover:underline"
                 >
-                  <IconDownload size={16} stroke={1.5} />
-                  <span className="flex flex-col items-start gap-0.5">
-                    <span>Download for Mac</span>
-                    <span className="text-xs font-normal text-muted-foreground">
-                      Intel
-                    </span>
-                  </span>
+                  Download here
                 </a>
-              </Button>
+              </p>
             </div>
           ) : downloadSupportStatus === "unsupported-intel-mac" ? (
             <Button type="button" size="lg" className="w-full" disabled>


### PR DESCRIPTION
## What

Redesign the two download buttons in the **"Let Zero use your computer"** modal (and the matching computer-use authorization page).

**Before:** two stacked full-width buttons that both said *Download for Mac*, differing only by a small chip line (`Apple Silicon` / `Intel`). The label repeated, the modal read heavy, and there was no clear default.

**After:** one primary **Download for Mac (Apple Silicon)** CTA, with Intel demoted to a quiet **"On an Intel Mac? Download here"** text link below.

This is direction #2 from the mockup set Ming reviewed.

## Changes

- `zero-chat-composer.tsx` — `ComputerUseDownloadDialog` `showIntelDownload` branch
- `computer-use-authorization-page.tsx` — same treatment for consistency
- `aria-label`s (`Download for Mac Apple Silicon` / `Download for Mac Intel`) preserved, so existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)