### PR TITLE
fix: keep account menu subscriptions stable during refresh

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/account-menu-subscriptions.ts
+++ b/turbo/apps/platform/src/signals/zero-page/account-menu-subscriptions.ts
@@ -1,0 +1,161 @@
+import { command, computed, state } from "ccstate";
+import type {
+  ModelProviderResponse,
+  ModelProviderType,
+} from "@vm0/api-contracts/contracts/model-providers";
+import { reloadPersonalModelProviders$ } from "../external/personal-model-providers.ts";
+import { personalConfiguredProviders$ } from "./settings/personal-model-providers.ts";
+
+export type AccountMenuSubscriptionUsage = NonNullable<
+  ModelProviderResponse["subscriptionUsage"]
+>;
+export type AccountMenuSubscriptionUsageWindow = NonNullable<
+  AccountMenuSubscriptionUsage["fiveHour"]
+>;
+
+export interface AccountMenuSubscriptionUsageRow {
+  readonly type: ModelProviderType;
+  readonly label: string;
+  readonly usage: AccountMenuSubscriptionUsage;
+}
+
+export type AccountMenuSubscriptionUsageRowsCacheKey = string | null;
+
+export const ACCOUNT_MENU_SUBSCRIPTION_PROVIDERS = [
+  { type: "codex-oauth-token", label: "Codex" },
+  { type: "claude-code-oauth-token", label: "Claude Code" },
+] as const satisfies readonly {
+  readonly type: ModelProviderType;
+  readonly label: string;
+}[];
+
+interface AccountMenuSubscriptionUsageRowsCache {
+  readonly key: AccountMenuSubscriptionUsageRowsCacheKey;
+  readonly rows: readonly AccountMenuSubscriptionUsageRow[] | null;
+}
+
+const internalAccountMenuSubscriptionUsageRowsRequestId$ = state(0);
+const internalAccountMenuSubscriptionUsageRowsRefreshPromise$ =
+  state<Promise<void> | null>(null);
+const internalAccountMenuSubscriptionUsageRowsCache$ =
+  state<AccountMenuSubscriptionUsageRowsCache>({
+    key: null,
+    rows: null,
+  });
+
+export const accountMenuSubscriptionUsageRowsCache$ = computed((get) => {
+  return get(internalAccountMenuSubscriptionUsageRowsCache$);
+});
+
+export const accountMenuSubscriptionUsageRowsRefreshPromise$ = computed(
+  (get) => {
+    return get(internalAccountMenuSubscriptionUsageRowsRefreshPromise$);
+  },
+);
+
+export const reloadAccountMenuSubscriptionUsageRows$ = command(
+  (
+    { get, set },
+    key: AccountMenuSubscriptionUsageRowsCacheKey,
+    signal: AbortSignal,
+  ) => {
+    signal.throwIfAborted();
+    const requestId =
+      get(internalAccountMenuSubscriptionUsageRowsRequestId$) + 1;
+    set(internalAccountMenuSubscriptionUsageRowsRequestId$, requestId);
+
+    const promise = (async () => {
+      set(reloadPersonalModelProviders$);
+      const providers = await get(personalConfiguredProviders$);
+      signal.throwIfAborted();
+      if (
+        get(internalAccountMenuSubscriptionUsageRowsRequestId$) !== requestId
+      ) {
+        return;
+      }
+      const rows = accountMenuSubscriptionUsageRows(providers);
+      set(internalAccountMenuSubscriptionUsageRowsCache$, { key, rows });
+    })();
+
+    set(internalAccountMenuSubscriptionUsageRowsRefreshPromise$, promise);
+
+    return promise;
+  },
+);
+
+function accountMenuSubscriptionUsageRows(
+  providers: readonly ModelProviderResponse[],
+): readonly AccountMenuSubscriptionUsageRow[] {
+  return ACCOUNT_MENU_SUBSCRIPTION_PROVIDERS.flatMap((definition) => {
+    const provider = providers.find((candidate) => {
+      return candidate.type === definition.type;
+    });
+    if (!provider) {
+      return [];
+    }
+    const usage = fallbackSubscriptionUsage(provider);
+    if (!usage || accountMenuSubscriptionUsageWindows(usage).length === 0) {
+      return [];
+    }
+    return [{ ...definition, usage }];
+  });
+}
+
+export function accountMenuSubscriptionUsageWindows(
+  usage: AccountMenuSubscriptionUsage | null | undefined,
+): readonly {
+  readonly label: string;
+  readonly window: AccountMenuSubscriptionUsageWindow;
+}[] {
+  return [
+    { label: "5h", window: usage?.fiveHour ?? null },
+    { label: "week", window: usage?.weekly ?? null },
+  ].filter(
+    (
+      item,
+    ): item is {
+      label: string;
+      window: AccountMenuSubscriptionUsageWindow;
+    } => {
+      return hasUsageWindow(item.window);
+    },
+  );
+}
+
+function fallbackSubscriptionUsage(
+  provider: ModelProviderResponse,
+): AccountMenuSubscriptionUsage | null {
+  if (
+    accountMenuSubscriptionUsageWindows(provider.subscriptionUsage).length > 0
+  ) {
+    return provider.subscriptionUsage ?? null;
+  }
+
+  const resetAt = provider.subscriptionNextResetAt?.trim();
+  if (!resetAt) {
+    return null;
+  }
+
+  const resetPeriod = provider.subscriptionResetPeriod?.trim().toLowerCase();
+  const window = {
+    usedPercent: null,
+    remainingPercent: null,
+    resetAt,
+    windowSeconds: resetPeriod?.includes("5") ? 18_000 : 604_800,
+  };
+
+  return resetPeriod?.includes("5")
+    ? { fiveHour: window, weekly: null }
+    : { fiveHour: null, weekly: window };
+}
+
+function hasUsageWindow(
+  window: AccountMenuSubscriptionUsage["fiveHour"],
+): window is AccountMenuSubscriptionUsageWindow {
+  return (
+    window !== null &&
+    (window.remainingPercent !== null ||
+      window.usedPercent !== null ||
+      window.resetAt !== null)
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import { chatThreadsContract } from "@vm0/api-contracts/contracts/chat-threads";
 import type { ModelProviderResponse } from "@vm0/api-contracts/contracts/model-providers";
 import { zeroBillingStatusContract } from "@vm0/api-contracts/contracts/zero-billing";
+import { zeroPersonalModelProvidersMainContract } from "@vm0/api-contracts/contracts/zero-personal-model-providers";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 
 import {
@@ -356,6 +357,72 @@ describe("zero sidebar account menu", () => {
     await waitFor(() => {
       expect(within(panel).getByText("64%")).toBeInTheDocument();
       expect(within(panel).getByText("30%")).toBeInTheDocument();
+    });
+  });
+
+  it("keeps loaded subscription usage visible while a menu refresh is pending", async () => {
+    mockAdminAccountSidebar();
+    context.mocks.data.personalModelProviders([
+      connectedPersonalCodexProvider(),
+    ]);
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      user: {
+        id: "test-user-123",
+        fullName: "Alex Rivera",
+        email: "alex.rivera@example.test",
+      },
+      featureSwitches: { [FeatureSwitchKey.SidebarSubscriptionUsage]: true },
+    });
+
+    let menu = await openAccountMenu();
+    let panel = await within(menu).findByTestId("account-menu-subscriptions");
+    expect(
+      within(panel).getByRole("heading", { name: "Codex" }),
+    ).toBeInTheDocument();
+    expect(within(panel).getByText("82%")).toBeInTheDocument();
+    expect(
+      within(panel).queryByRole("heading", { name: "Claude Code" }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.keyDown(document.body, { key: "Escape" });
+    await waitFor(() => {
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    });
+
+    const refreshReady = context.mocks.deferred<void>();
+    let refreshRequested = false;
+    context.mocks.api(
+      zeroPersonalModelProvidersMainContract.list,
+      async ({ respond }) => {
+        refreshRequested = true;
+        await refreshReady.promise;
+        return respond(200, { modelProviders: [] });
+      },
+    );
+
+    menu = await openAccountMenu();
+    panel = await within(menu).findByTestId("account-menu-subscriptions");
+
+    await waitFor(() => {
+      expect(refreshRequested).toBeTruthy();
+    });
+    expect(
+      within(panel).getByRole("heading", { name: "Codex" }),
+    ).toBeInTheDocument();
+    expect(within(panel).getByText("82%")).toBeInTheDocument();
+    expect(
+      within(panel).queryByRole("heading", { name: "Claude Code" }),
+    ).not.toBeInTheDocument();
+
+    refreshReady.resolve();
+
+    await waitFor(() => {
+      expect(
+        within(menu).queryByTestId("account-menu-subscriptions"),
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx
@@ -17,7 +17,6 @@ import {
   IconLink,
   IconMail,
   IconMessageCircle,
-  IconPlus,
   IconRepeat,
   IconTag,
 } from "@tabler/icons-react";
@@ -47,7 +46,6 @@ import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detachedNavigateTo$ } from "../../signals/route.ts";
 import { ROUTES } from "../../signals/route-paths.ts";
 import {
-  allWorkflowTriggerEntries$,
   allVisibleWorkflows$,
   setWorkflowTriggerEnabled$,
   type WorkflowTriggerAutomationEntry,
@@ -56,10 +54,8 @@ import {
   atTimeInTimezone,
   cronWallTimeInTimezone,
 } from "../../signals/zero-page/cron.ts";
-import { userPreferences$ } from "../../signals/zero-page/settings/user-preferences.ts";
 import { pinnedAgentIds$ } from "../../signals/zero-page/zero-pinned-agents.ts";
 import { detach, Reason } from "../../signals/utils.ts";
-import { Link } from "../router/link.tsx";
 import {
   AgentDialogAgentButton,
   agentDialogMatchesQuery,
@@ -214,32 +210,6 @@ export function triggerTypeLabel(trigger: ZeroWorkflowTriggerSummary): string {
   return "Trigger";
 }
 
-function TriggerListSkeleton() {
-  return (
-    <div
-      className="flex flex-col gap-2.5"
-      data-testid="workflow-trigger-list-skeleton"
-    >
-      {["a", "b", "c"].map((key) => {
-        return (
-          <div
-            key={key}
-            className="zero-card grid min-h-[5.5rem] grid-cols-[2.75rem_minmax(0,1fr)_auto] items-center gap-x-4 px-5 py-4"
-          >
-            <Skeleton className="row-span-2 h-11 w-11 rounded-xl" />
-            <Skeleton className="h-4 w-48 max-w-full rounded-md" />
-            <Skeleton className="row-span-2 h-5 w-9 rounded-full" />
-            <div className="flex min-w-0 items-center gap-2">
-              <Skeleton className="h-5 w-5 rounded-full" />
-              <Skeleton className="h-3 w-64 max-w-full rounded-md" />
-            </div>
-          </div>
-        );
-      })}
-    </div>
-  );
-}
-
 function agentInitials(label: string): string {
   const words = label.trim().split(/\s+/).filter(Boolean);
   if (words.length >= 2) {
@@ -345,82 +315,6 @@ export function WorkflowTriggerEnabledSwitch({
         );
       }}
     />
-  );
-}
-
-function WorkflowTriggerIndexCard({
-  entry,
-  displayTimezone,
-  agents,
-}: {
-  readonly entry: WorkflowTriggerAutomationEntry;
-  readonly displayTimezone: string;
-  readonly agents: readonly TeamComposeItem[];
-}) {
-  const title = workflowTitle(entry.workflow);
-  const label = agentLabel(entry.workflow);
-  const agent = agents.find((item) => {
-    return item.id === entry.workflow.agentId;
-  });
-
-  return (
-    <article
-      className={cn(
-        "zero-card relative flex min-w-0 items-center gap-4 px-5 py-5 transition-colors hover:bg-gray-50",
-        !entry.trigger.enabled && "opacity-75",
-      )}
-    >
-      <Link
-        pathname={ROUTES.workflowDetailAutomations}
-        options={{ pathParams: { workflowId: entry.workflow.id } }}
-        aria-label={`Open ${title} automations`}
-        className="absolute inset-0 z-0 rounded-[inherit] focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring"
-      >
-        <span className="sr-only">{title}</span>
-      </Link>
-      <div className="pointer-events-none relative z-10 shrink-0">
-        <TriggerListIcon trigger={entry.trigger} />
-      </div>
-      <div className="pointer-events-none relative z-10 min-w-0 flex-1">
-        <p className="min-w-0 truncate text-base font-semibold leading-6 text-foreground">
-          {title}
-        </p>
-        <div className="mt-1 flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-1 text-sm leading-5 text-muted-foreground">
-          <WorkflowAgentAvatar agent={agent} label={label} />
-          <span className="max-w-[10rem] truncate">{label}</span>
-          <span className="select-none text-muted-foreground/50">·</span>
-          <span>{triggerTypeLabel(entry.trigger)}</span>
-          <span className="select-none text-muted-foreground/50">·</span>
-          <span className="min-w-0 font-medium text-foreground/85">
-            {humanReadableTriggerRuleLabel(entry.trigger, displayTimezone)}
-          </span>
-        </div>
-      </div>
-      <div className="relative z-20 ml-auto shrink-0 pl-3">
-        <WorkflowTriggerEnabledSwitch entry={entry} />
-      </div>
-    </article>
-  );
-}
-
-function EmptyTriggers({ onAdd }: { readonly onAdd: () => void }) {
-  return (
-    <div className="zero-card flex min-h-56 flex-col items-center justify-center px-6 py-10 text-center">
-      <p className="text-sm font-medium text-foreground">No triggers yet</p>
-      <p className="mt-1 max-w-sm text-sm text-muted-foreground">
-        Create a triggered workflow and it will show up here.
-      </p>
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        className="zero-btn-morandi mt-4 h-9 gap-2 rounded-lg border"
-        onClick={onAdd}
-      >
-        <IconPlus size={14} stroke={2} />
-        Add automation
-      </Button>
-    </div>
   );
 }
 
@@ -739,102 +633,5 @@ export function CreateWorkflowAutomationDialog() {
         />
       </DialogContent>
     </Dialog>
-  );
-}
-
-function WorkflowTriggerAutomationIndexList({
-  entries,
-  displayTimezone,
-  agents,
-  loading,
-  onAdd,
-}: {
-  readonly entries: readonly WorkflowTriggerAutomationEntry[];
-  readonly displayTimezone: string;
-  readonly agents: readonly TeamComposeItem[];
-  readonly loading: boolean;
-  readonly onAdd: () => void;
-}) {
-  if (loading) {
-    return <TriggerListSkeleton />;
-  }
-
-  if (entries.length === 0) {
-    return <EmptyTriggers onAdd={onAdd} />;
-  }
-
-  return (
-    <div className="flex flex-col gap-2.5">
-      {entries.map((entry) => {
-        return (
-          <WorkflowTriggerIndexCard
-            key={entry.trigger.id}
-            entry={entry}
-            displayTimezone={displayTimezone}
-            agents={agents}
-          />
-        );
-      })}
-    </div>
-  );
-}
-
-export function WorkflowTriggerAutomationsPage() {
-  const entriesLoadable = useLastLoadable(allWorkflowTriggerEntries$);
-  const prefsLoadable = useLastLoadable(userPreferences$);
-  const agentsLoadable = useLastLoadable(agents$);
-  const setCreateOpen = useSet(setWorkflowAutomationDialogOpen$);
-  const entries =
-    entriesLoadable.state === "hasData" ? entriesLoadable.data : [];
-  const agents = agentsLoadable.state === "hasData" ? agentsLoadable.data : [];
-  const displayTimezone =
-    prefsLoadable.state === "hasData" && prefsLoadable.data?.timezone
-      ? prefsLoadable.data.timezone
-      : new Intl.DateTimeFormat().resolvedOptions().timeZone;
-  const loading = entriesLoadable.state === "loading";
-
-  return (
-    <div className="flex min-h-0 flex-1 flex-col">
-      <header className="shrink-0 bg-transparent px-4 pb-0 pt-3 sm:px-6 md:pb-3 md:pt-10">
-        <div className="mx-auto flex max-w-[900px] flex-wrap items-end justify-between gap-4">
-          <div className="hidden min-w-0 md:block">
-            <h1 className="text-lg font-semibold tracking-tight text-foreground">
-              Automations
-            </h1>
-            <p className="mt-0.5 text-sm text-muted-foreground">
-              Workflow triggers running across your workspace.
-            </p>
-          </div>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className="zero-btn-morandi h-9 shrink-0 gap-2 rounded-lg border"
-            onClick={() => {
-              setCreateOpen(true);
-            }}
-          >
-            <IconPlus size={14} stroke={2} />
-            Add automation
-          </Button>
-        </div>
-      </header>
-
-      <main className="flex-1 overflow-auto px-4 pb-8 pt-3 sm:px-6">
-        <div className="mx-auto max-w-[900px]">
-          <WorkflowTriggerAutomationIndexList
-            entries={entries}
-            displayTimezone={displayTimezone}
-            agents={agents}
-            loading={loading}
-            onAdd={() => {
-              setCreateOpen(true);
-            }}
-          />
-        </div>
-      </main>
-
-      <CreateWorkflowAutomationDialog />
-    </div>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
@@ -124,6 +124,18 @@ interface AccountDisplay {
   imageUrl: string | undefined;
 }
 
+function subscriptionRowsCacheKeyFrom({
+  clerk,
+  current,
+  user,
+}: {
+  clerk: { session?: { id?: string } | null } | null;
+  current: SessionAccount | undefined;
+  user: { id: string } | undefined;
+}): AccountMenuSubscriptionUsageRowsCacheKey {
+  return clerk?.session?.id ?? current?.sessionId ?? user?.id ?? null;
+}
+
 function accountDisplayFrom(
   user:
     | {
@@ -555,7 +567,11 @@ export function AccountDropdown({
   const current = accounts.find((a) => {
     return a.isActive;
   });
-  const subscriptionRowsCacheKey = user?.id ?? current?.sessionId ?? null;
+  const subscriptionRowsCacheKey = subscriptionRowsCacheKeyFrom({
+    clerk,
+    current,
+    user,
+  });
   const accountDisplay = accountDisplayFrom(user, current);
   const others = accounts.filter((a) => {
     return !a.isActive;

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
@@ -34,6 +34,10 @@ import {
   currentUserInfo$,
   resolveAppAuthUrl,
 } from "../../signals/auth.ts";
+import {
+  reloadAccountMenuSubscriptionUsageRows$,
+  type AccountMenuSubscriptionUsageRowsCacheKey,
+} from "../../signals/zero-page/account-menu-subscriptions.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import {
   handleZeroNavSelect$,
@@ -41,7 +45,6 @@ import {
   type ZeroAccountAction,
 } from "../../signals/zero-page/zero-nav.ts";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
-import { reloadPersonalModelProviders$ } from "../../signals/external/personal-model-providers.ts";
 import { openSettingsDialogAt$ } from "../../signals/zero-page/settings/settings-dialog.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { isOrgAdmin$ } from "../../signals/org.ts";
@@ -206,9 +209,11 @@ function CurrentAccountHeader({
 
 function AccountUsageGroup({
   onOpenCreditBalance,
+  subscriptionRowsCacheKey,
   subscriptionsEnabled,
 }: {
   onOpenCreditBalance: () => void;
+  subscriptionRowsCacheKey: AccountMenuSubscriptionUsageRowsCacheKey;
   subscriptionsEnabled: boolean;
 }) {
   const isAdminLoadable = useLastLoadable(isOrgAdmin$);
@@ -217,9 +222,14 @@ function AccountUsageGroup({
 
   if (subscriptionsEnabled) {
     return isAdmin ? (
-      <AccountUsageGroupWithCredit onOpenCreditBalance={onOpenCreditBalance} />
+      <AccountUsageGroupWithCredit
+        onOpenCreditBalance={onOpenCreditBalance}
+        subscriptionRowsCacheKey={subscriptionRowsCacheKey}
+      />
     ) : (
-      <AccountSubscriptionsGroup />
+      <AccountSubscriptionsGroup
+        subscriptionRowsCacheKey={subscriptionRowsCacheKey}
+      />
     );
   }
 
@@ -261,11 +271,15 @@ function AccountCreditBalanceGroup({
 
 function AccountUsageGroupWithCredit({
   onOpenCreditBalance,
+  subscriptionRowsCacheKey,
 }: {
   onOpenCreditBalance: () => void;
+  subscriptionRowsCacheKey: AccountMenuSubscriptionUsageRowsCacheKey;
 }) {
   const billingLoadable = useLastLoadable(billingStatusAsync$);
-  const { loading: subscriptionsLoading, rows } = useSubscriptionUsageRows();
+  const { loading: subscriptionsLoading, rows } = useSubscriptionUsageRows({
+    cacheKey: subscriptionRowsCacheKey,
+  });
   const credits =
     billingLoadable.state === "hasData" ? billingLoadable.data.credits : null;
   const creditLoading = billingLoadable.state === "loading" && credits === null;
@@ -301,8 +315,14 @@ function AccountUsageGroupWithCredit({
   );
 }
 
-function AccountSubscriptionsGroup() {
-  const { loading, rows } = useSubscriptionUsageRows();
+function AccountSubscriptionsGroup({
+  subscriptionRowsCacheKey,
+}: {
+  subscriptionRowsCacheKey: AccountMenuSubscriptionUsageRowsCacheKey;
+}) {
+  const { loading, rows } = useSubscriptionUsageRows({
+    cacheKey: subscriptionRowsCacheKey,
+  });
   const showSubscriptions = loading || rows.length > 0;
 
   if (!showSubscriptions) {
@@ -528,13 +548,14 @@ export function AccountDropdown({
     features?.[FeatureSwitchKey.SidebarSubscriptionUsage] ?? false;
   const selectNav = useSet(handleZeroNavSelect$);
   const openSettings = useSet(openSettingsDialogAt$);
-  const reloadSubscriptions = useSet(reloadPersonalModelProviders$);
+  const reloadSubscriptions = useSet(reloadAccountMenuSubscriptionUsageRows$);
   const setSidebarExpanded = useSet(setSidebarExpanded$);
   const pageSignal = useGet(pageSignal$);
 
   const current = accounts.find((a) => {
     return a.isActive;
   });
+  const subscriptionRowsCacheKey = user?.id ?? current?.sessionId ?? null;
   const accountDisplay = accountDisplayFrom(user, current);
   const others = accounts.filter((a) => {
     return !a.isActive;
@@ -593,13 +614,11 @@ export function AccountDropdown({
       return;
     }
 
-    queueMicrotask(() => {
-      detach(
-        reloadSubscriptions(),
-        Reason.DomCallback,
-        "reload account menu subscriptions",
-      );
-    });
+    detach(
+      reloadSubscriptions(subscriptionRowsCacheKey, pageSignal),
+      Reason.DomCallback,
+      "reload account menu subscriptions",
+    );
   };
 
   return (
@@ -621,6 +640,7 @@ export function AccountDropdown({
         {!hidePreferences && (
           <AccountUsageGroup
             onOpenCreditBalance={handleOpenCreditBalance}
+            subscriptionRowsCacheKey={subscriptionRowsCacheKey}
             subscriptionsEnabled={subscriptionsEnabled}
           />
         )}

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-subscriptions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-subscriptions.tsx
@@ -1,8 +1,4 @@
-import { useLastLoadable } from "ccstate-react";
-import type {
-  ModelProviderResponse,
-  ModelProviderType,
-} from "@vm0/api-contracts/contracts/model-providers";
+import { useGet, useLoadable } from "ccstate-react";
 import {
   Tooltip,
   TooltipContent,
@@ -10,33 +6,34 @@ import {
   TooltipTrigger,
 } from "@vm0/ui";
 
-import { personalConfiguredProviders$ } from "../../signals/zero-page/settings/personal-model-providers.ts";
+import {
+  ACCOUNT_MENU_SUBSCRIPTION_PROVIDERS,
+  accountMenuSubscriptionUsageRowsRefreshPromise$,
+  accountMenuSubscriptionUsageRowsCache$,
+  accountMenuSubscriptionUsageWindows,
+  type AccountMenuSubscriptionUsage,
+  type AccountMenuSubscriptionUsageRow,
+  type AccountMenuSubscriptionUsageWindow,
+  type AccountMenuSubscriptionUsageRowsCacheKey,
+} from "../../signals/zero-page/account-menu-subscriptions.ts";
 
-type SubscriptionUsage = NonNullable<
-  ModelProviderResponse["subscriptionUsage"]
->;
-type SubscriptionUsageWindow = NonNullable<SubscriptionUsage["fiveHour"]>;
+type SubscriptionUsage = AccountMenuSubscriptionUsage;
+type SubscriptionUsageWindow = AccountMenuSubscriptionUsageWindow;
 
-const SUBSCRIPTION_PROVIDERS = [
-  { type: "codex-oauth-token", label: "Codex" },
-  { type: "claude-code-oauth-token", label: "Claude Code" },
-] as const satisfies readonly {
-  readonly type: ModelProviderType;
-  readonly label: string;
-}[];
-
-interface SubscriptionUsageRow {
-  readonly type: ModelProviderType;
-  readonly label: string;
-  readonly usage: SubscriptionUsage;
-}
-
-export function useSubscriptionUsageRows() {
-  const providersLoadable = useLastLoadable(personalConfiguredProviders$);
-  const providers =
-    providersLoadable.state === "hasData" ? providersLoadable.data : [];
-  const rows = subscriptionUsageRows(providers);
-  const loading = providersLoadable.state === "loading";
+export function useSubscriptionUsageRows({
+  cacheKey,
+}: {
+  readonly cacheKey: AccountMenuSubscriptionUsageRowsCacheKey;
+}) {
+  const rowsCache = useGet(accountMenuSubscriptionUsageRowsCache$);
+  const refreshLoadable = useLoadable(
+    accountMenuSubscriptionUsageRowsRefreshPromise$,
+  );
+  const cachedRows =
+    cacheKey !== null && rowsCache.key === cacheKey ? rowsCache.rows : null;
+  const hasCachedRows = cachedRows !== null;
+  const loading = refreshLoadable.state === "loading" && !hasCachedRows;
+  const rows = cachedRows ?? [];
 
   return { loading, rows };
 }
@@ -46,7 +43,7 @@ export function AccountMenuSubscriptionsPanel({
   rows,
 }: {
   readonly loading: boolean;
-  readonly rows: readonly SubscriptionUsageRow[];
+  readonly rows: readonly AccountMenuSubscriptionUsageRow[];
 }) {
   return (
     <div data-testid="account-menu-subscriptions" className="px-3 py-2.5">
@@ -75,7 +72,7 @@ export function AccountMenuSubscriptionsPanel({
 function AccountMenuSubscriptionsSkeleton() {
   return (
     <div className="flex flex-col gap-2.5" aria-hidden="true">
-      {SUBSCRIPTION_PROVIDERS.map((provider, index) => {
+      {ACCOUNT_MENU_SUBSCRIPTION_PROVIDERS.map((provider, index) => {
         return (
           <div key={provider.type} className="flex flex-col gap-1.5">
             {index > 0 && <div className="-mx-3 h-px bg-border" />}
@@ -108,7 +105,7 @@ function AccountMenuSubscriptionProviderSection({
   readonly label: string;
   readonly usage: SubscriptionUsage;
 }) {
-  const windows = usageWindows(usage);
+  const windows = accountMenuSubscriptionUsageWindows(usage);
 
   return (
     <section className="flex flex-col gap-1.5" aria-label={`${label} usage`}>
@@ -191,35 +188,6 @@ function AccountMenuSubscriptionUsageBar({
   );
 }
 
-function subscriptionUsageRows(
-  providers: readonly ModelProviderResponse[],
-): readonly SubscriptionUsageRow[] {
-  return SUBSCRIPTION_PROVIDERS.flatMap((definition) => {
-    const provider = providers.find((candidate) => {
-      return candidate.type === definition.type;
-    });
-    if (!provider) {
-      return [];
-    }
-    const usage = fallbackSubscriptionUsage(provider);
-    if (!usage || usageWindows(usage).length === 0) {
-      return [];
-    }
-    return [{ ...definition, usage }];
-  });
-}
-
-function hasUsageWindow(
-  window: SubscriptionUsage["fiveHour"],
-): window is SubscriptionUsageWindow {
-  return (
-    window !== null &&
-    (window.remainingPercent !== null ||
-      window.usedPercent !== null ||
-      window.resetAt !== null)
-  );
-}
-
 function formatUsagePercent(value: number | null): string | null {
   if (value === null || !Number.isFinite(value)) {
     return null;
@@ -250,45 +218,6 @@ function formatUsageReset(resetAt: string | null): string | null {
     options.timeZone = browserTimeZone;
   }
   return `resets ${date.toLocaleDateString("en-US", options)}`;
-}
-
-function fallbackSubscriptionUsage(
-  provider: ModelProviderResponse,
-): SubscriptionUsage | null {
-  if (usageWindows(provider.subscriptionUsage).length > 0) {
-    return provider.subscriptionUsage ?? null;
-  }
-
-  const resetAt = provider.subscriptionNextResetAt?.trim();
-  if (!resetAt) {
-    return null;
-  }
-
-  const resetPeriod = provider.subscriptionResetPeriod?.trim().toLowerCase();
-  const window = {
-    usedPercent: null,
-    remainingPercent: null,
-    resetAt,
-    windowSeconds: resetPeriod?.includes("5") ? 18_000 : 604_800,
-  };
-
-  return resetPeriod?.includes("5")
-    ? { fiveHour: window, weekly: null }
-    : { fiveHour: null, weekly: window };
-}
-
-function usageWindows(usage: SubscriptionUsage | null | undefined): readonly {
-  readonly label: string;
-  readonly window: SubscriptionUsageWindow;
-}[] {
-  return [
-    { label: "5h", window: usage?.fiveHour ?? null },
-    { label: "week", window: usage?.weekly ?? null },
-  ].filter(
-    (item): item is { label: string; window: SubscriptionUsageWindow } => {
-      return hasUsageWindow(item.window);
-    },
-  );
 }
 
 function usageTone(remainingPercent: number | null): {


### PR DESCRIPTION
## Summary
- add a ccstate-backed account menu subscription usage cache keyed by the current user/session
- refresh subscription rows through the existing personal model-provider signal on menu open while keeping cached rows visible during pending refreshes
- add regression coverage for pending refresh and successful empty response clearing
- remove an unused legacy workflow trigger page entry surfaced by knip while keeping the shared workflow dialog exports

## Tests
- pnpm format
- pnpm -F @vm0/app lint
- pnpm check-types
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
- pnpm knip --cache

Closes #19776