### PR TITLE
fix: refine html artifact edit controls

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/html-dom-comment-editor.ts
+++ b/turbo/apps/platform/src/signals/zero-page/html-dom-comment-editor.ts
@@ -165,6 +165,8 @@ const FRAME_COMMENT_LABEL_MAX_LINES = 2;
 const FRAME_COMMENT_LABEL_HEIGHT =
   FRAME_COMMENT_LABEL_MAX_LINES * FRAME_COMMENT_LABEL_LINE_HEIGHT +
   FRAME_COMMENT_LABEL_VERTICAL_PADDING;
+const FRAME_COMMENT_DELETE_BUTTON_SIZE = 24;
+const FRAME_COMMENT_DELETE_BUTTON_INSET = 8;
 const FRAME_COMMENT_CONNECTOR_GAP = 36;
 const FRAME_COMMENT_DOT_SIZE = 8;
 const FRAME_COMMENT_VIEWPORT_PADDING = 8;
@@ -1721,13 +1723,11 @@ function styleCommentMarkerDeleteButton(params: {
   params.button.setAttribute(HTML_DOM_COMMENT_DELETE_ATTR, params.commentId);
   params.button.setAttribute("aria-label", "Delete comment");
   params.button.style.position = "absolute";
-  params.button.style.right = "8px";
-  params.button.style.top = "50%";
   params.button.style.display = "inline-flex";
   params.button.style.alignItems = "center";
   params.button.style.justifyContent = "center";
-  params.button.style.width = "24px";
-  params.button.style.height = "24px";
+  params.button.style.width = `${FRAME_COMMENT_DELETE_BUTTON_SIZE}px`;
+  params.button.style.height = `${FRAME_COMMENT_DELETE_BUTTON_SIZE}px`;
   params.button.style.border = "0";
   params.button.style.borderRadius = "999px";
   params.button.style.background = "rgba(255, 255, 255, 0.18)";
@@ -1764,7 +1764,27 @@ function createCommentMarkerDeleteIcon(doc: Document): SVGSVGElement {
   return icon;
 }
 
+function positionCommentMarkerLabel(params: {
+  readonly deleteButton: HTMLElement;
+  readonly label: HTMLElement;
+  readonly left: number;
+  readonly top: number;
+}): void {
+  params.label.style.left = `${params.left}px`;
+  params.label.style.top = `${params.top}px`;
+  params.deleteButton.style.left = `${
+    params.left +
+    FRAME_COMMENT_LABEL_MAX_WIDTH -
+    FRAME_COMMENT_DELETE_BUTTON_INSET -
+    FRAME_COMMENT_DELETE_BUTTON_SIZE
+  }px`;
+  params.deleteButton.style.top = `${
+    params.top + FRAME_COMMENT_LABEL_HEIGHT / 2
+  }px`;
+}
+
 function positionCommentMarkerParts(params: {
+  readonly deleteButton: HTMLElement;
   readonly dot: HTMLElement;
   readonly label: HTMLElement;
   readonly leader: HTMLElement;
@@ -1794,8 +1814,12 @@ function positionCommentMarkerParts(params: {
       params.leader.style.top = `${markerCenterY - 1}px`;
       params.leader.style.width = `${horizontalLeaderWidth}px`;
       params.leader.style.borderTop = "2px dashed rgb(37, 99, 235)";
-      params.label.style.left = `${FRAME_COMMENT_CONNECTOR_GAP}px`;
-      params.label.style.top = `${markerCenterY - labelCenterOffset}px`;
+      positionCommentMarkerLabel({
+        deleteButton: params.deleteButton,
+        label: params.label,
+        left: FRAME_COMMENT_CONNECTOR_GAP,
+        top: markerCenterY - labelCenterOffset,
+      });
       break;
     }
     case "bottom": {
@@ -1805,13 +1829,21 @@ function positionCommentMarkerParts(params: {
       params.leader.style.top = `${verticalLeaderTop}px`;
       params.leader.style.height = `${verticalLeaderHeight}px`;
       params.leader.style.borderLeft = "2px dashed rgb(37, 99, 235)";
-      params.label.style.left = "0";
-      params.label.style.top = `${FRAME_COMMENT_CONNECTOR_GAP}px`;
+      positionCommentMarkerLabel({
+        deleteButton: params.deleteButton,
+        label: params.label,
+        left: 0,
+        top: FRAME_COMMENT_CONNECTOR_GAP,
+      });
       break;
     }
     case "left": {
-      params.label.style.left = "0";
-      params.label.style.top = `${markerCenterY - labelCenterOffset}px`;
+      positionCommentMarkerLabel({
+        deleteButton: params.deleteButton,
+        label: params.label,
+        left: 0,
+        top: markerCenterY - labelCenterOffset,
+      });
       params.leader.style.left = `${FRAME_COMMENT_LABEL_MAX_WIDTH + 4}px`;
       params.leader.style.top = `${markerCenterY - 1}px`;
       params.leader.style.width = `${horizontalLeaderWidth}px`;
@@ -1821,8 +1853,12 @@ function positionCommentMarkerParts(params: {
       break;
     }
     case "top": {
-      params.label.style.left = "0";
-      params.label.style.top = "0";
+      positionCommentMarkerLabel({
+        deleteButton: params.deleteButton,
+        label: params.label,
+        left: 0,
+        top: 0,
+      });
       params.leader.style.left = `${markerCenterX - 1}px`;
       params.leader.style.top = `${labelHeight + 4}px`;
       params.leader.style.height = `${verticalLeaderHeight}px`;
@@ -1883,15 +1919,16 @@ function createFrameCommentMarker(params: {
     commentId: params.comment.id,
   });
   deleteButton.append(deleteIcon);
-  label.append(labelText, deleteButton);
+  label.append(labelText);
   positionCommentMarkerParts({
+    deleteButton,
     dot,
     label,
     leader,
     placement: params.position.placement,
     rect: params.position.rect,
   });
-  marker.append(dot, leader, label);
+  marker.append(dot, leader, label, deleteButton);
   return marker;
 }
 

--- a/turbo/apps/platform/src/signals/zero-page/html-dom-comment-editor.ts
+++ b/turbo/apps/platform/src/signals/zero-page/html-dom-comment-editor.ts
@@ -871,6 +871,9 @@ function installFrameStyles(doc: Document): void {
       opacity: 1 !important;
       pointer-events: auto !important;
     }
+    [${HTML_DOM_COMMENT_DELETE_ATTR}]:hover {
+      background: rgba(255, 255, 255, 0.28) !important;
+    }
     [${HTML_DOM_COMMENT_FLASH_ATTR}="true"] {
       animation: vm0-html-comment-flash 900ms ease-out both !important;
     }
@@ -1654,6 +1657,7 @@ function styleCommentMarkerLabel(label: HTMLElement): void {
   label.style.position = "absolute";
   label.style.display = "flex";
   label.style.alignItems = "center";
+  label.style.justifyContent = "center";
   label.style.boxSizing = "border-box";
   label.style.maxWidth = `${FRAME_COMMENT_LABEL_MAX_WIDTH}px`;
   label.style.width = `${FRAME_COMMENT_LABEL_MAX_WIDTH}px`;
@@ -1670,6 +1674,7 @@ function styleCommentMarkerLabel(label: HTMLElement): void {
   label.style.fontWeight = "600";
   label.style.lineHeight = `${FRAME_COMMENT_LABEL_LINE_HEIGHT}px`;
   label.style.overflow = "hidden";
+  label.style.textAlign = "center";
   label.style.boxShadow = "0 6px 16px rgba(15, 23, 42, 0.18)";
   label.style.pointerEvents = "auto";
 }
@@ -1678,10 +1683,13 @@ function styleCommentMarkerLabelText(labelText: HTMLElement): void {
   labelText.dataset.testid = "html-dom-comment-tag-text";
   labelText.style.display = "-webkit-box";
   labelText.style.width = "100%";
+  labelText.style.boxSizing = "border-box";
   labelText.style.lineHeight = `${FRAME_COMMENT_LABEL_LINE_HEIGHT}px`;
   labelText.style.whiteSpace = "normal";
   labelText.style.overflow = "hidden";
   labelText.style.overflowWrap = "anywhere";
+  labelText.style.padding = "0 18px";
+  labelText.style.textAlign = "center";
   labelText.style.setProperty("-webkit-box-orient", "vertical");
   labelText.style.setProperty(
     "-webkit-line-clamp",
@@ -1714,15 +1722,17 @@ function styleCommentMarkerDeleteButton(params: {
   params.button.setAttribute("aria-label", "Delete comment");
   params.button.textContent = "x";
   params.button.style.position = "absolute";
+  params.button.style.right = "8px";
+  params.button.style.top = "50%";
   params.button.style.display = "inline-flex";
   params.button.style.alignItems = "center";
   params.button.style.justifyContent = "center";
-  params.button.style.width = "18px";
-  params.button.style.height = "18px";
-  params.button.style.border = "1px solid rgb(37, 99, 235)";
+  params.button.style.width = "20px";
+  params.button.style.height = "20px";
+  params.button.style.border = "0";
   params.button.style.borderRadius = "999px";
-  params.button.style.background = "white";
-  params.button.style.color = "rgb(37, 99, 235)";
+  params.button.style.background = "rgba(255, 255, 255, 0.18)";
+  params.button.style.color = "white";
   params.button.style.cursor = "pointer";
   params.button.style.fontFamily =
     "Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif";
@@ -1732,12 +1742,11 @@ function styleCommentMarkerDeleteButton(params: {
   params.button.style.opacity = "0";
   params.button.style.padding = "0";
   params.button.style.pointerEvents = "none";
-  params.button.style.boxShadow = "0 2px 6px rgba(15, 23, 42, 0.18)";
-  params.button.style.transition = "opacity 120ms ease, box-shadow 120ms ease";
+  params.button.style.transform = "translateY(-50%)";
+  params.button.style.transition = "opacity 120ms ease, background 120ms ease";
 }
 
 function positionCommentMarkerParts(params: {
-  readonly deleteButton: HTMLElement;
   readonly dot: HTMLElement;
   readonly label: HTMLElement;
   readonly leader: HTMLElement;
@@ -1769,12 +1778,6 @@ function positionCommentMarkerParts(params: {
       params.leader.style.borderTop = "2px dashed rgb(37, 99, 235)";
       params.label.style.left = `${FRAME_COMMENT_CONNECTOR_GAP}px`;
       params.label.style.top = `${markerCenterY - labelCenterOffset}px`;
-      params.deleteButton.style.left = `${
-        FRAME_COMMENT_CONNECTOR_GAP + FRAME_COMMENT_LABEL_MAX_WIDTH - 10
-      }px`;
-      params.deleteButton.style.top = `${
-        markerCenterY - labelCenterOffset - 8
-      }px`;
       break;
     }
     case "bottom": {
@@ -1786,10 +1789,6 @@ function positionCommentMarkerParts(params: {
       params.leader.style.borderLeft = "2px dashed rgb(37, 99, 235)";
       params.label.style.left = "0";
       params.label.style.top = `${FRAME_COMMENT_CONNECTOR_GAP}px`;
-      params.deleteButton.style.left = `${
-        FRAME_COMMENT_LABEL_MAX_WIDTH - 10
-      }px`;
-      params.deleteButton.style.top = `${FRAME_COMMENT_CONNECTOR_GAP - 8}px`;
       break;
     }
     case "left": {
@@ -1801,12 +1800,6 @@ function positionCommentMarkerParts(params: {
       params.leader.style.borderTop = "2px dashed rgb(37, 99, 235)";
       params.dot.style.left = `${params.rect.width - FRAME_COMMENT_DOT_SIZE}px`;
       params.dot.style.top = `${markerCenterY - dotCenterOffset}px`;
-      params.deleteButton.style.left = `${
-        FRAME_COMMENT_LABEL_MAX_WIDTH - 10
-      }px`;
-      params.deleteButton.style.top = `${
-        markerCenterY - labelCenterOffset - 8
-      }px`;
       break;
     }
     case "top": {
@@ -1818,10 +1811,6 @@ function positionCommentMarkerParts(params: {
       params.leader.style.borderLeft = "2px dashed rgb(37, 99, 235)";
       params.dot.style.left = `${markerCenterX - dotCenterOffset}px`;
       params.dot.style.top = `${params.rect.height - FRAME_COMMENT_DOT_SIZE}px`;
-      params.deleteButton.style.left = `${
-        FRAME_COMMENT_LABEL_MAX_WIDTH - 10
-      }px`;
-      params.deleteButton.style.top = "-8px";
       break;
     }
   }
@@ -1874,16 +1863,15 @@ function createFrameCommentMarker(params: {
     button: deleteButton,
     commentId: params.comment.id,
   });
-  label.append(labelText);
+  label.append(labelText, deleteButton);
   positionCommentMarkerParts({
-    deleteButton,
     dot,
     label,
     leader,
     placement: params.position.placement,
     rect: params.position.rect,
   });
-  marker.append(dot, leader, label, deleteButton);
+  marker.append(dot, leader, label);
   return marker;
 }
 

--- a/turbo/apps/platform/src/signals/zero-page/html-dom-comment-editor.ts
+++ b/turbo/apps/platform/src/signals/zero-page/html-dom-comment-editor.ts
@@ -1688,7 +1688,7 @@ function styleCommentMarkerLabelText(labelText: HTMLElement): void {
   labelText.style.whiteSpace = "normal";
   labelText.style.overflow = "hidden";
   labelText.style.overflowWrap = "anywhere";
-  labelText.style.padding = "0 18px";
+  labelText.style.padding = "0 22px";
   labelText.style.textAlign = "center";
   labelText.style.setProperty("-webkit-box-orient", "vertical");
   labelText.style.setProperty(
@@ -1720,30 +1720,48 @@ function styleCommentMarkerDeleteButton(params: {
   params.button.dataset.testid = "html-dom-comment-delete";
   params.button.setAttribute(HTML_DOM_COMMENT_DELETE_ATTR, params.commentId);
   params.button.setAttribute("aria-label", "Delete comment");
-  params.button.textContent = "x";
   params.button.style.position = "absolute";
   params.button.style.right = "8px";
   params.button.style.top = "50%";
   params.button.style.display = "inline-flex";
   params.button.style.alignItems = "center";
   params.button.style.justifyContent = "center";
-  params.button.style.width = "20px";
-  params.button.style.height = "20px";
+  params.button.style.width = "24px";
+  params.button.style.height = "24px";
   params.button.style.border = "0";
   params.button.style.borderRadius = "999px";
   params.button.style.background = "rgba(255, 255, 255, 0.18)";
   params.button.style.color = "white";
   params.button.style.cursor = "pointer";
-  params.button.style.fontFamily =
-    "Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif";
-  params.button.style.fontSize = "13px";
-  params.button.style.fontWeight = "700";
   params.button.style.lineHeight = "1";
   params.button.style.opacity = "0";
   params.button.style.padding = "0";
   params.button.style.pointerEvents = "none";
   params.button.style.transform = "translateY(-50%)";
   params.button.style.transition = "opacity 120ms ease, background 120ms ease";
+}
+
+function createCommentMarkerDeleteIcon(doc: Document): SVGSVGElement {
+  const icon = doc.createElementNS("http://www.w3.org/2000/svg", "svg");
+  icon.setAttribute("viewBox", "0 0 24 24");
+  icon.setAttribute("fill", "none");
+  icon.setAttribute("stroke", "currentColor");
+  icon.setAttribute("stroke-width", "2.25");
+  icon.setAttribute("stroke-linecap", "round");
+  icon.setAttribute("stroke-linejoin", "round");
+  icon.setAttribute("aria-hidden", "true");
+  icon.style.display = "block";
+  icon.style.width = "14px";
+  icon.style.height = "14px";
+
+  const firstLine = doc.createElementNS("http://www.w3.org/2000/svg", "path");
+  firstLine.setAttribute("d", "M18 6 6 18");
+
+  const secondLine = doc.createElementNS("http://www.w3.org/2000/svg", "path");
+  secondLine.setAttribute("d", "m6 6 12 12");
+
+  icon.append(firstLine, secondLine);
+  return icon;
 }
 
 function positionCommentMarkerParts(params: {
@@ -1850,6 +1868,7 @@ function createFrameCommentMarker(params: {
   const label = params.doc.createElement("button");
   const labelText = params.doc.createElement("span");
   const deleteButton = params.doc.createElement("button");
+  const deleteIcon = createCommentMarkerDeleteIcon(params.doc);
   label.type = "button";
   deleteButton.type = "button";
   dot.dataset.testid = "html-dom-comment-anchor";
@@ -1863,6 +1882,7 @@ function createFrameCommentMarker(params: {
     button: deleteButton,
     commentId: params.comment.id,
   });
+  deleteButton.append(deleteIcon);
   label.append(labelText, deleteButton);
   positionCommentMarkerParts({
     dot,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -1819,6 +1819,7 @@ describe("zero attachment chips", () => {
     const deleteButton = marker.querySelector<HTMLElement>(
       "[data-testid='html-dom-comment-delete']",
     )!;
+    const deleteIcon = deleteButton.querySelector<SVGSVGElement>("svg")!;
     expect(marker).toHaveAttribute(HTML_DOM_EDIT_OVERLAY_ATTR);
     expect(marker).not.toHaveAttribute("title");
     expect(marker).toHaveAttribute("data-vm0-html-comment-placement", "right");
@@ -1831,9 +1832,17 @@ describe("zero attachment chips", () => {
     expect(deleteButton.parentElement).toBe(tag);
     expect(deleteButton.style.right).toBe("8px");
     expect(deleteButton.style.top).toBe("50%");
+    expect(deleteButton.style.width).toBe("24px");
+    expect(deleteButton.style.height).toBe("24px");
+    expect(deleteButton.style.alignItems).toBe("center");
+    expect(deleteButton.style.justifyContent).toBe("center");
     expect(deleteButton.style.transform).toBe("translateY(-50%)");
     expect(deleteButton.style.opacity).toBe("0");
     expect(deleteButton.style.pointerEvents).toBe("none");
+    expect(deleteIcon).not.toBeNull();
+    expect(deleteIcon.getAttribute("viewBox")).toBe("0 0 24 24");
+    expect(deleteIcon.style.width).toBe("14px");
+    expect(deleteIcon.style.height).toBe("14px");
     expect(frame.contentDocument?.head.textContent).toContain(
       "[data-vm0-html-comment-target-node-id]:hover [data-vm0-html-comment-delete-id]",
     );
@@ -1847,6 +1856,7 @@ describe("zero attachment chips", () => {
     expect(tag.style.textAlign).toBe("center");
     expect(tagText.style.whiteSpace).toBe("normal");
     expect(tagText.style.overflowWrap).toBe("anywhere");
+    expect(tagText.style.padding).toBe("0px 22px");
     expect(tagText.style.textAlign).toBe("center");
     expect(tagText.style.getPropertyValue("-webkit-line-clamp")).toBe("2");
     expect(screen.getByTestId("html-dom-comment-toolbar")).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -155,20 +155,19 @@ function expectHostedSiteEditingHeader({
   expect(
     within(sidebar).getByTestId("artifact-sidebar-html-edit-status"),
   ).toHaveTextContent("Editing");
-  expect(
-    within(sidebar).getByTestId("artifact-sidebar-exit-html-edit"),
-  ).toHaveTextContent("Exit");
+  const exitEdit = within(sidebar).getByTestId(
+    "artifact-sidebar-exit-html-edit",
+  );
+  expect(exitEdit).toHaveAttribute("aria-label", "Exit editing");
   expect(
     within(sidebar)
       .getByTestId("artifact-sidebar-html-edit-status")
-      .compareDocumentPosition(
-        within(sidebar).getByTestId("artifact-sidebar-exit-html-edit"),
-      ),
+      .compareDocumentPosition(within(sidebar).getByLabelText(fullscreenLabel)),
   ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
   expect(
     within(sidebar)
-      .getByTestId("artifact-sidebar-exit-html-edit")
-      .compareDocumentPosition(within(sidebar).getByLabelText(fullscreenLabel)),
+      .getByLabelText(fullscreenLabel)
+      .compareDocumentPosition(exitEdit),
   ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
   expect(within(sidebar).queryByLabelText("Edit page")).toBeNull();
   expect(within(sidebar).queryByLabelText("Open in new tab")).toBeNull();
@@ -1733,25 +1732,21 @@ describe("zero attachment chips", () => {
       expect(
         within(sidebar).getByTestId("artifact-sidebar-html-edit-status"),
       ).toHaveTextContent("Editing");
-      expect(
-        within(sidebar).getByTestId("artifact-sidebar-exit-html-edit"),
-      ).toHaveTextContent("Exit");
-      expect(
-        within(sidebar).getByTestId("artifact-sidebar-exit-html-edit"),
-      ).toHaveClass("border");
+      const exitEdit = within(sidebar).getByTestId(
+        "artifact-sidebar-exit-html-edit",
+      );
+      expect(exitEdit).toHaveAttribute("aria-label", "Exit editing");
       expect(
         within(sidebar)
           .getByTestId("artifact-sidebar-html-edit-status")
           .compareDocumentPosition(
-            within(sidebar).getByTestId("artifact-sidebar-exit-html-edit"),
+            within(sidebar).getByLabelText("Enter fullscreen"),
           ),
       ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
       expect(
         within(sidebar)
-          .getByTestId("artifact-sidebar-exit-html-edit")
-          .compareDocumentPosition(
-            within(sidebar).getByLabelText("Enter fullscreen"),
-          ),
+          .getByLabelText("Enter fullscreen")
+          .compareDocumentPosition(exitEdit),
       ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
       expect(within(sidebar).queryByLabelText("Edit page")).toBeNull();
       expect(within(sidebar).queryByLabelText("Open in new tab")).toBeNull();
@@ -1806,47 +1801,54 @@ describe("zero attachment chips", () => {
     });
 
     await waitFor(() => {
-      const marker = frame.contentDocument?.querySelector<HTMLElement>(
-        "[data-testid='html-dom-comment-marker']",
-      );
-      const tag = marker?.querySelector<HTMLElement>(
-        "[data-testid='html-dom-comment-tag']",
-      );
-      const tagText = tag?.querySelector<HTMLElement>(
-        "[data-testid='html-dom-comment-tag-text']",
-      );
-      const deleteButton = marker?.querySelector<HTMLElement>(
-        "[data-testid='html-dom-comment-delete']",
-      );
-      expect(marker).not.toBeNull();
-      expect(marker).toHaveAttribute(HTML_DOM_EDIT_OVERLAY_ATTR);
-      expect(marker).not.toHaveAttribute("title");
-      expect(marker).toHaveAttribute(
-        "data-vm0-html-comment-placement",
-        "right",
-      );
       expect(
-        marker?.querySelector("[data-testid='html-dom-comment-anchor']"),
+        frame.contentDocument?.querySelector(
+          "[data-testid='html-dom-comment-marker']",
+        ),
       ).not.toBeNull();
-      expect(
-        marker?.querySelector("[data-testid='html-dom-comment-leader']"),
-      ).not.toBeNull();
-      expect(deleteButton).not.toBeNull();
-      expect(deleteButton?.style.opacity).toBe("0");
-      expect(deleteButton?.style.pointerEvents).toBe("none");
-      expect(frame.contentDocument?.head.textContent).toContain(
-        "[data-vm0-html-comment-target-node-id]:hover [data-vm0-html-comment-delete-id]",
-      );
-      expect(frame.contentDocument?.head.textContent).toContain(":hover");
-      expect(tag).toHaveTextContent("Make the headline shorter");
-      expect(tagText).toHaveTextContent("Make the headline shorter");
-      expect(tag?.style.maxWidth).toBe("136px");
-      expect(tag?.style.height).toBe("56px");
-      expect(tag?.style.overflow).toBe("hidden");
-      expect(tagText?.style.whiteSpace).toBe("normal");
-      expect(tagText?.style.overflowWrap).toBe("anywhere");
-      expect(tagText?.style.getPropertyValue("-webkit-line-clamp")).toBe("2");
     });
+    const marker = frame.contentDocument!.querySelector<HTMLElement>(
+      "[data-testid='html-dom-comment-marker']",
+    )!;
+    const tag = marker.querySelector<HTMLElement>(
+      "[data-testid='html-dom-comment-tag']",
+    )!;
+    const tagText = tag.querySelector<HTMLElement>(
+      "[data-testid='html-dom-comment-tag-text']",
+    )!;
+    const deleteButton = marker.querySelector<HTMLElement>(
+      "[data-testid='html-dom-comment-delete']",
+    )!;
+    expect(marker).toHaveAttribute(HTML_DOM_EDIT_OVERLAY_ATTR);
+    expect(marker).not.toHaveAttribute("title");
+    expect(marker).toHaveAttribute("data-vm0-html-comment-placement", "right");
+    expect(
+      marker.querySelector("[data-testid='html-dom-comment-anchor']"),
+    ).not.toBeNull();
+    expect(
+      marker.querySelector("[data-testid='html-dom-comment-leader']"),
+    ).not.toBeNull();
+    expect(deleteButton.parentElement).toBe(tag);
+    expect(deleteButton.style.right).toBe("8px");
+    expect(deleteButton.style.top).toBe("50%");
+    expect(deleteButton.style.transform).toBe("translateY(-50%)");
+    expect(deleteButton.style.opacity).toBe("0");
+    expect(deleteButton.style.pointerEvents).toBe("none");
+    expect(frame.contentDocument?.head.textContent).toContain(
+      "[data-vm0-html-comment-target-node-id]:hover [data-vm0-html-comment-delete-id]",
+    );
+    expect(frame.contentDocument?.head.textContent).toContain(":hover");
+    expect(tag).toHaveTextContent("Make the headline shorter");
+    expect(tagText).toHaveTextContent("Make the headline shorter");
+    expect(tag.style.maxWidth).toBe("136px");
+    expect(tag.style.height).toBe("56px");
+    expect(tag.style.overflow).toBe("hidden");
+    expect(tag.style.justifyContent).toBe("center");
+    expect(tag.style.textAlign).toBe("center");
+    expect(tagText.style.whiteSpace).toBe("normal");
+    expect(tagText.style.overflowWrap).toBe("anywhere");
+    expect(tagText.style.textAlign).toBe("center");
+    expect(tagText.style.getPropertyValue("-webkit-line-clamp")).toBe("2");
     expect(screen.getByTestId("html-dom-comment-toolbar")).toBeInTheDocument();
     expect(screen.getByTestId("html-dom-toolbar-send")).toBeEnabled();
     expect(
@@ -2260,7 +2262,7 @@ describe("zero attachment chips", () => {
       ).toHaveTextContent("Editing");
       expect(
         within(sidebar).getByTestId("artifact-sidebar-exit-html-edit"),
-      ).toHaveTextContent("Exit");
+      ).toHaveAttribute("aria-label", "Exit editing");
       expect(within(sidebar).queryByLabelText("Open in new tab")).toBeNull();
       expect(within(sidebar).queryByLabelText("Share artifact")).toBeNull();
       expect(within(sidebar).queryByLabelText("Download artifact")).toBeNull();
@@ -3456,7 +3458,9 @@ describe("zero attachment chips", () => {
       expect(within(sidebar).queryByLabelText("Open in new tab")).toBeNull();
       expect(within(sidebar).queryByLabelText("Share artifact")).toBeNull();
       expect(within(sidebar).queryByLabelText("Download artifact")).toBeNull();
-      expect(within(sidebar).queryByLabelText("Close artifact")).toBeNull();
+      expect(
+        within(sidebar).getByLabelText("Close artifact"),
+      ).toBeInTheDocument();
       expect(
         within(sidebar).queryByTestId("artifact-sidebar-exit-html-edit"),
       ).toBeNull();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -1829,9 +1829,9 @@ describe("zero attachment chips", () => {
     expect(
       marker.querySelector("[data-testid='html-dom-comment-leader']"),
     ).not.toBeNull();
-    expect(deleteButton.parentElement).toBe(tag);
-    expect(deleteButton.style.right).toBe("8px");
-    expect(deleteButton.style.top).toBe("50%");
+    expect(deleteButton.parentElement).toBe(marker);
+    expect(deleteButton.style.left).toBe("140px");
+    expect(deleteButton.style.top).toBe("28px");
     expect(deleteButton.style.width).toBe("24px");
     expect(deleteButton.style.height).toBe("24px");
     expect(deleteButton.style.alignItems).toBe("center");

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -1020,55 +1020,41 @@ function ArtifactSidebarHeader({
   onClose: () => void;
 }) {
   const compactActions = onBack !== undefined;
-  const features = useLastResolved(featureSwitch$);
-  const showHtmlControls =
-    kind === "html" &&
-    artifactKind === "hosted-site" &&
-    Boolean(features?.[FeatureSwitchKey.HtmlArtifactCommentEditing]) &&
-    htmlState !== undefined;
-  const htmlEditActive = showHtmlControls && htmlState !== "idle";
 
   return (
-    <div className="grid min-h-14 shrink-0 grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-3 border-b border-border/60 px-4 py-2">
-      <div className="flex min-w-0 items-center gap-3">
-        {onBack && (
-          <ArtifactActionTooltip label="Back to all artifacts">
-            <button
-              type="button"
-              onClick={onBack}
-              aria-label="Back to all artifacts"
-              className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
-            >
-              <IconArrowLeft size={16} />
-            </button>
-          </ArtifactActionTooltip>
-        )}
-        <div className="min-w-0 flex-1">
-          <div className="truncate text-sm font-medium text-foreground">
-            {title}
-          </div>
-          {subtitle && (
-            <div className="mt-0.5 truncate text-xs text-muted-foreground">
-              {subtitle}
-            </div>
-          )}
+    <div className="flex min-h-14 shrink-0 items-center gap-3 border-b border-border/60 px-4 py-2">
+      {onBack && (
+        <ArtifactActionTooltip label="Back to all artifacts">
+          <button
+            type="button"
+            onClick={onBack}
+            aria-label="Back to all artifacts"
+            className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+          >
+            <IconArrowLeft size={16} />
+          </button>
+        </ArtifactActionTooltip>
+      )}
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-sm font-medium text-foreground">
+          {title}
         </div>
-      </div>
-      <div className="justify-self-center">
-        {showHtmlControls && <ArtifactHtmlEditStatus state={htmlState} />}
+        {subtitle && (
+          <div className="mt-0.5 truncate text-xs text-muted-foreground">
+            {subtitle}
+          </div>
+        )}
       </div>
       <ArtifactSidebarActions
         compactActions={compactActions}
         artifactKind={artifactKind}
         fullscreen={fullscreen}
-        htmlEditActive={htmlEditActive}
         htmlState={htmlState}
         kind={kind}
         onClose={onClose}
         onEditHtml={onEditHtml}
         onEditPresentation={onEditPresentation}
         onExitHtmlEdit={onExitHtmlEdit}
-        showHtmlControls={showHtmlControls}
         onToggleFullscreen={onToggleFullscreen}
         syncTarget={syncTarget}
         title={title}
@@ -1082,14 +1068,12 @@ function ArtifactSidebarActions({
   artifactKind,
   compactActions,
   fullscreen,
-  htmlEditActive,
   htmlState,
   kind,
   onClose,
   onEditHtml,
   onEditPresentation,
   onExitHtmlEdit,
-  showHtmlControls,
   onToggleFullscreen,
   syncTarget,
   title,
@@ -1098,26 +1082,31 @@ function ArtifactSidebarActions({
   artifactKind?: ChatThreadArtifactFile["artifactKind"];
   compactActions: boolean;
   fullscreen: boolean;
-  htmlEditActive: boolean;
   htmlState?: HtmlArtifactHeaderState;
   kind?: ArtifactKindForBody;
   onClose: () => void;
   onEditHtml?: () => void;
   onEditPresentation?: () => void;
   onExitHtmlEdit?: () => void;
-  showHtmlControls: boolean;
   onToggleFullscreen: () => void;
   syncTarget?: ArtifactDownloadSyncTarget;
   title: string;
   url?: string;
 }) {
+  const features = useLastResolved(featureSwitch$);
   const showPresentationEdit =
     artifactKind === "presentation-html" && onEditPresentation !== undefined;
+  const showHtmlControls =
+    kind === "html" &&
+    artifactKind === "hosted-site" &&
+    Boolean(features?.[FeatureSwitchKey.HtmlArtifactCommentEditing]) &&
+    htmlState !== undefined;
+  const htmlEditActive = showHtmlControls && htmlState !== "idle";
   const htmlExitAction =
     htmlState === "editing" && onExitHtmlEdit ? onExitHtmlEdit : undefined;
 
   return (
-    <div className="flex shrink-0 items-center gap-1 justify-self-end">
+    <div className="flex shrink-0 items-center gap-1">
       {url && (
         <>
           {!htmlEditActive && (
@@ -1144,6 +1133,7 @@ function ArtifactSidebarActions({
           )}
           {showHtmlControls && (
             <>
+              <ArtifactHtmlEditStatus state={htmlState} />
               {onEditHtml && <ArtifactEditHtmlAction onClick={onEditHtml} />}
               <ArtifactActionSeparator />
             </>
@@ -1204,7 +1194,7 @@ function ArtifactExitHtmlEditAction({ onClick }: { onClick: () => void }) {
         onClick={onClick}
         aria-label="Exit editing"
         data-testid="artifact-sidebar-exit-html-edit"
-        className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+        className="inline-flex h-8 w-8 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
       >
         <IconX size={16} />
       </button>
@@ -1334,7 +1324,7 @@ function ArtifactCloseAction({ onClose }: { onClose: () => void }) {
         onClick={onClose}
         aria-label="Close artifact"
         data-testid="artifact-sidebar-close"
-        className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+        className="inline-flex h-8 w-8 items-center justify-center rounded-full text-muted-foreground hover:bg-muted/60 hover:text-foreground"
       >
         <IconX size={16} />
       </button>

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -1020,41 +1020,55 @@ function ArtifactSidebarHeader({
   onClose: () => void;
 }) {
   const compactActions = onBack !== undefined;
+  const features = useLastResolved(featureSwitch$);
+  const showHtmlControls =
+    kind === "html" &&
+    artifactKind === "hosted-site" &&
+    Boolean(features?.[FeatureSwitchKey.HtmlArtifactCommentEditing]) &&
+    htmlState !== undefined;
+  const htmlEditActive = showHtmlControls && htmlState !== "idle";
 
   return (
-    <div className="flex min-h-14 shrink-0 items-center gap-3 border-b border-border/60 px-4 py-2">
-      {onBack && (
-        <ArtifactActionTooltip label="Back to all artifacts">
-          <button
-            type="button"
-            onClick={onBack}
-            aria-label="Back to all artifacts"
-            className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
-          >
-            <IconArrowLeft size={16} />
-          </button>
-        </ArtifactActionTooltip>
-      )}
-      <div className="min-w-0 flex-1">
-        <div className="truncate text-sm font-medium text-foreground">
-          {title}
-        </div>
-        {subtitle && (
-          <div className="mt-0.5 truncate text-xs text-muted-foreground">
-            {subtitle}
-          </div>
+    <div className="grid min-h-14 shrink-0 grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-3 border-b border-border/60 px-4 py-2">
+      <div className="flex min-w-0 items-center gap-3">
+        {onBack && (
+          <ArtifactActionTooltip label="Back to all artifacts">
+            <button
+              type="button"
+              onClick={onBack}
+              aria-label="Back to all artifacts"
+              className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+            >
+              <IconArrowLeft size={16} />
+            </button>
+          </ArtifactActionTooltip>
         )}
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-sm font-medium text-foreground">
+            {title}
+          </div>
+          {subtitle && (
+            <div className="mt-0.5 truncate text-xs text-muted-foreground">
+              {subtitle}
+            </div>
+          )}
+        </div>
+      </div>
+      <div className="justify-self-center">
+        {showHtmlControls && <ArtifactHtmlEditStatus state={htmlState} />}
       </div>
       <ArtifactSidebarActions
         compactActions={compactActions}
         artifactKind={artifactKind}
         fullscreen={fullscreen}
+        htmlEditActive={htmlEditActive}
         htmlState={htmlState}
         kind={kind}
         onClose={onClose}
         onEditHtml={onEditHtml}
         onEditPresentation={onEditPresentation}
         onExitHtmlEdit={onExitHtmlEdit}
+        showHtmlControls={showHtmlControls}
         onToggleFullscreen={onToggleFullscreen}
         syncTarget={syncTarget}
         title={title}
@@ -1068,12 +1082,14 @@ function ArtifactSidebarActions({
   artifactKind,
   compactActions,
   fullscreen,
+  htmlEditActive,
   htmlState,
   kind,
   onClose,
   onEditHtml,
   onEditPresentation,
   onExitHtmlEdit,
+  showHtmlControls,
   onToggleFullscreen,
   syncTarget,
   title,
@@ -1082,29 +1098,26 @@ function ArtifactSidebarActions({
   artifactKind?: ChatThreadArtifactFile["artifactKind"];
   compactActions: boolean;
   fullscreen: boolean;
+  htmlEditActive: boolean;
   htmlState?: HtmlArtifactHeaderState;
   kind?: ArtifactKindForBody;
   onClose: () => void;
   onEditHtml?: () => void;
   onEditPresentation?: () => void;
   onExitHtmlEdit?: () => void;
+  showHtmlControls: boolean;
   onToggleFullscreen: () => void;
   syncTarget?: ArtifactDownloadSyncTarget;
   title: string;
   url?: string;
 }) {
-  const features = useLastResolved(featureSwitch$);
   const showPresentationEdit =
     artifactKind === "presentation-html" && onEditPresentation !== undefined;
-  const showHtmlControls =
-    kind === "html" &&
-    artifactKind === "hosted-site" &&
-    Boolean(features?.[FeatureSwitchKey.HtmlArtifactCommentEditing]) &&
-    htmlState !== undefined;
-  const htmlEditActive = showHtmlControls && htmlState !== "idle";
+  const htmlExitAction =
+    htmlState === "editing" && onExitHtmlEdit ? onExitHtmlEdit : undefined;
 
   return (
-    <div className="flex shrink-0 items-center gap-1">
+    <div className="flex shrink-0 items-center gap-1 justify-self-end">
       {url && (
         <>
           {!htmlEditActive && (
@@ -1131,10 +1144,6 @@ function ArtifactSidebarActions({
           )}
           {showHtmlControls && (
             <>
-              <ArtifactHtmlEditStatus state={htmlState} />
-              {htmlState === "editing" && onExitHtmlEdit && (
-                <ArtifactExitHtmlEditAction onClick={onExitHtmlEdit} />
-              )}
               {onEditHtml && <ArtifactEditHtmlAction onClick={onEditHtml} />}
               <ArtifactActionSeparator />
             </>
@@ -1145,12 +1154,13 @@ function ArtifactSidebarActions({
         fullscreen={fullscreen}
         onToggleFullscreen={onToggleFullscreen}
       />
-      {!htmlEditActive &&
-        (compactActions ? (
-          <ArtifactMoreActions onClose={onClose} />
-        ) : (
-          <ArtifactCloseAction onClose={onClose} />
-        ))}
+      {htmlExitAction ? (
+        <ArtifactExitHtmlEditAction onClick={htmlExitAction} />
+      ) : compactActions ? (
+        <ArtifactMoreActions onClose={onClose} />
+      ) : (
+        <ArtifactCloseAction onClose={onClose} />
+      )}
     </div>
   );
 }
@@ -1188,15 +1198,15 @@ function ArtifactEditHtmlAction({ onClick }: { onClick: () => void }) {
 
 function ArtifactExitHtmlEditAction({ onClick }: { onClick: () => void }) {
   return (
-    <ArtifactActionTooltip label="Exit editing and keep preview open">
+    <ArtifactActionTooltip label="Exit editing">
       <button
         type="button"
         onClick={onClick}
-        aria-label="Exit editing and keep preview open"
+        aria-label="Exit editing"
         data-testid="artifact-sidebar-exit-html-edit"
-        className="inline-flex h-8 items-center rounded-full border border-border/80 bg-background px-3 text-sm font-medium text-foreground shadow-sm transition-colors hover:bg-muted/60"
+        className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
       >
-        Exit
+        <IconX size={16} />
       </button>
     </ArtifactActionTooltip>
   );


### PR DESCRIPTION
## Summary
- Keep hosted-site HTML edit states (`Editing`, `Working`, `Preview draft`) as pills in the right action group, immediately before the separator.
- Move the old editing exit affordance into the right-side icon action group as a circular `IconX` button.
- Keep HTML comment marker delete controls inside the blue marker button, using a larger centered SVG `x` revealed on hover/focus.

## Screenshot
- Preview: https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/deb28205-fc07-457e-8358-0c9658104c29/preview-v3.png

## Verification
- `pnpm prettier --write apps/platform/src/signals/zero-page/html-dom-comment-editor.ts apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm exec vitest run apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx`

## Notes
- Tried browser verification against the local dev server, but the available Chromium build is blocked by the app's "Update Chrome to continue" browser-version gate. The screenshot is from a temporary visual harness matching the implemented layout and hover state.