### PR TITLE
fix: fire Signup Google Ads conversion for recent signups

### DIFF
--- a/turbo/apps/platform/src/__tests__/mock-auth.ts
+++ b/turbo/apps/platform/src/__tests__/mock-auth.ts
@@ -35,6 +35,7 @@ interface MockedUser {
   fullName: string;
   firstName?: string;
   imageUrl?: string;
+  createdAt?: Date;
   primaryEmailAddress: { emailAddress: string } | null;
   unsafeMetadata: Record<string, unknown>;
   createOrganizationEnabled: boolean;
@@ -68,6 +69,7 @@ export function mockUser(
     email?: string;
     firstName?: string;
     imageUrl?: string;
+    createdAt?: Date;
     createOrganizationEnabled?: boolean;
     clientSessions?: MockedClientSession[];
   } | null,

--- a/turbo/apps/platform/src/signals/__tests__/signup-attribution-conversion.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/signup-attribution-conversion.test.ts
@@ -6,6 +6,12 @@ import {
   mockOrganization,
   mockUser,
 } from "../../__tests__/mock-auth.ts";
+import {
+  dateFromIso,
+  isoFromNowMs,
+  mockNow,
+  nowDate,
+} from "../../__tests__/time.ts";
 import { recordSignupAttribution$ } from "../bootstrap/signup-attribution.ts";
 import { testContext } from "./test-helpers.ts";
 
@@ -20,12 +26,13 @@ type WindowWithGtag = Window & {
 };
 
 function mockSignedInUser(options: { readonly createdAt?: Date } = {}): void {
+  mockNow();
   mockUser(
     {
       id: "test-user-123",
       fullName: "Test User",
       email: "test@example.com",
-      createdAt: options.createdAt ?? new Date(),
+      createdAt: options.createdAt ?? nowDate(),
     },
     {
       token: "test-token",
@@ -127,7 +134,7 @@ describe("signup attribution Google Ads conversion", () => {
 
   it("records attribution without firing the Signup conversion for older users", async () => {
     const gtag = installGtagMock();
-    mockSignedInUser({ createdAt: new Date(Date.now() - 31 * 60 * 1000) });
+    mockSignedInUser({ createdAt: dateFromIso(isoFromNowMs(-31 * 60 * 1000)) });
     storePaidSignupAttribution();
 
     await context.store.set(recordSignupAttribution$, context.signal);

--- a/turbo/apps/platform/src/signals/__tests__/signup-attribution-conversion.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/signup-attribution-conversion.test.ts
@@ -19,12 +19,13 @@ type WindowWithGtag = Window & {
   gtag?: (...args: unknown[]) => void;
 };
 
-function mockSignedInUser(): void {
+function mockSignedInUser(options: { readonly createdAt?: Date } = {}): void {
   mockUser(
     {
       id: "test-user-123",
       fullName: "Test User",
       email: "test@example.com",
+      createdAt: options.createdAt ?? new Date(),
     },
     {
       token: "test-token",
@@ -105,6 +106,33 @@ describe("signup attribution Google Ads conversion", () => {
     await context.store.set(recordSignupAttribution$, context.signal);
 
     expect(gtag).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires the Signup conversion for a recent signup without stored ad attribution", async () => {
+    const gtag = installGtagMock();
+    mockSignedInUser();
+
+    await context.store.set(recordSignupAttribution$, context.signal);
+
+    expect(gtag).toHaveBeenCalledWith(
+      "event",
+      "conversion",
+      expect.objectContaining({
+        send_to: SIGNUP_SEND_TO,
+        value: 1,
+        currency: "USD",
+      }),
+    );
+  });
+
+  it("records attribution without firing the Signup conversion for older users", async () => {
+    const gtag = installGtagMock();
+    mockSignedInUser({ createdAt: new Date(Date.now() - 31 * 60 * 1000) });
+    storePaidSignupAttribution();
+
+    await context.store.set(recordSignupAttribution$, context.signal);
+
+    expect(gtag).not.toHaveBeenCalled();
   });
 
   it("does not fire the Signup conversion when attribution was already recorded server-side", async () => {

--- a/turbo/apps/platform/src/signals/bootstrap/signup-attribution.ts
+++ b/turbo/apps/platform/src/signals/bootstrap/signup-attribution.ts
@@ -5,6 +5,7 @@ import {
 } from "@vm0/api-contracts/contracts/zero-attribution";
 
 import { accept } from "../../lib/accept.ts";
+import { now } from "../../lib/time.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { user$ } from "../auth.ts";
 import { getStoredAdAttributionMetadata } from "./ad-attribution.ts";
@@ -83,7 +84,7 @@ function isRecentlyCreatedUser(user: {
   if (createdAtMs === null) {
     return false;
   }
-  const ageMs = Date.now() - createdAtMs;
+  const ageMs = now() - createdAtMs;
   return ageMs >= 0 && ageMs <= SIGNUP_CONVERSION_MAX_USER_AGE_MS;
 }
 

--- a/turbo/apps/platform/src/signals/bootstrap/signup-attribution.ts
+++ b/turbo/apps/platform/src/signals/bootstrap/signup-attribution.ts
@@ -1,5 +1,8 @@
 import { command } from "ccstate";
-import { zeroAttributionContract } from "@vm0/api-contracts/contracts/zero-attribution";
+import {
+  zeroAttributionContract,
+  type AdAttributionMetadata,
+} from "@vm0/api-contracts/contracts/zero-attribution";
 
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
@@ -10,6 +13,7 @@ const SIGNUP_ATTRIBUTION_RECORDED_KEY = "vm0.signupAttributionRecorded";
 const SIGNUP_CONVERSION_RECORDED_KEY = "vm0.googleAdsSignupConversionRecorded";
 const GOOGLE_ADS_SIGNUP_SEND_TO = "AW-18144854014/OlLBCNXGgqwcEP7_kcxD";
 const SIGNUP_CONVERSION_VALUE_USD = 1;
+const SIGNUP_CONVERSION_MAX_USER_AGE_MS = 30 * 60 * 1000;
 
 type GoogleTag = (
   command: "event",
@@ -57,38 +61,77 @@ function trackGoogleAdsSignupConversion(
   storage?.setItem(SIGNUP_CONVERSION_RECORDED_KEY, fingerprint);
 }
 
+function timestampMs(value: unknown): number | null {
+  if (value instanceof Date) {
+    const time = value.getTime();
+    return Number.isFinite(time) ? time : null;
+  }
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value === "string") {
+    const time = Date.parse(value);
+    return Number.isFinite(time) ? time : null;
+  }
+  return null;
+}
+
+function isRecentlyCreatedUser(user: {
+  readonly createdAt?: unknown;
+}): boolean {
+  const createdAtMs = timestampMs(user.createdAt);
+  if (createdAtMs === null) {
+    return false;
+  }
+  const ageMs = Date.now() - createdAtMs;
+  return ageMs >= 0 && ageMs <= SIGNUP_CONVERSION_MAX_USER_AGE_MS;
+}
+
 export const recordSignupAttribution$ = command(
   async ({ get }, signal: AbortSignal): Promise<void> => {
-    const attribution = getStoredAdAttributionMetadata();
-    if (!attribution) {
-      return;
-    }
-
     const user = await get(user$);
     signal.throwIfAborted();
     if (!user) {
       return;
     }
 
-    const storage = getSessionStorage();
-    const fingerprint = JSON.stringify(attribution);
-    if (storage?.getItem(SIGNUP_ATTRIBUTION_RECORDED_KEY) === fingerprint) {
+    const storedAttribution = getStoredAdAttributionMetadata();
+    const recentlyCreatedUser = isRecentlyCreatedUser(user);
+    const attribution: AdAttributionMetadata | undefined =
+      storedAttribution ??
+      (recentlyCreatedUser ? { source_type: "unknown" } : undefined);
+    if (!attribution) {
       return;
     }
 
-    const createClient = get(zeroClient$);
-    const client = createClient(zeroAttributionContract);
-    const result = await accept(
-      client.recordSignup({
-        body: { attribution },
-        fetchOptions: { signal },
-      }),
-      [200],
-    );
-    signal.throwIfAborted();
-    if (result.body.recorded) {
-      trackGoogleAdsSignupConversion(storage, fingerprint);
+    const storage = getSessionStorage();
+    const attributionFingerprint = `${user.id}:${JSON.stringify(attribution)}`;
+    let recorded =
+      storage?.getItem(SIGNUP_ATTRIBUTION_RECORDED_KEY) ===
+      attributionFingerprint;
+
+    if (!recorded) {
+      const createClient = get(zeroClient$);
+      const client = createClient(zeroAttributionContract);
+      const result = await accept(
+        client.recordSignup({
+          body: { attribution },
+          fetchOptions: { signal },
+        }),
+        [200],
+      );
+      signal.throwIfAborted();
+      recorded = result.body.recorded;
+      if (recorded) {
+        storage?.setItem(
+          SIGNUP_ATTRIBUTION_RECORDED_KEY,
+          attributionFingerprint,
+        );
+      }
     }
-    storage?.setItem(SIGNUP_ATTRIBUTION_RECORDED_KEY, fingerprint);
+
+    if (recorded && recentlyCreatedUser) {
+      trackGoogleAdsSignupConversion(storage, user.id);
+    }
   },
 );


### PR DESCRIPTION
Summary
- Let the Signup webpage gtag conversion fire for recently created users without requiring stored Google Ads attribution.
- Keep the Signup event scoped to recent users and first successful signup attribution recording so old route loads are not counted as new signups.
- Preserve session dedupe for the Google Ads Signup conversion and add coverage for no-attribution recent signups and older users.

Validation
- Passed: pnpm --dir apps/platform exec vitest run src/signals/__tests__/signup-attribution-conversion.test.ts
- Passed: pnpm exec prettier --check apps/platform/src/signals/bootstrap/signup-attribution.ts apps/platform/src/signals/__tests__/signup-attribution-conversion.test.ts apps/platform/src/__tests__/mock-auth.ts
- Passed: git diff --check