### PR TITLE
fix: show chat thread icon shortcut hints

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -3273,7 +3273,7 @@ describe("chat lifecycle", () => {
       expect(screen.getByText("Previous thread")).toBeInTheDocument();
       expect(screen.getByText("Next thread")).toBeInTheDocument();
       expect(screen.getByText("Rename chat")).toBeInTheDocument();
-      expect(screen.getByText("Change emoji")).toBeInTheDocument();
+      expect(screen.getByText("Change icon")).toBeInTheDocument();
       expect(screen.getAllByText("F2")).toHaveLength(2);
       expect(screen.getAllByText("Shift").length).toBeGreaterThan(0);
     });
@@ -3365,7 +3365,7 @@ describe("chat lifecycle", () => {
       ).toBeGreaterThan(0);
     });
 
-    expect(screen.queryByLabelText("Change emoji")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Change icon")).not.toBeInTheDocument();
 
     const threadRegion = screen.getByLabelText("Chat thread");
     threadRegion.focus();
@@ -3394,7 +3394,7 @@ describe("chat lifecycle", () => {
         screen.getAllByText("Current keyboard thread").length,
       ).toBeGreaterThan(0);
     });
-    const emojiButton = screen.getByLabelText("Change emoji");
+    const emojiButton = screen.getByLabelText("Change icon");
     expect(emojiButton).toHaveTextContent("");
     expect(emojiButton.querySelector("svg")).not.toBeInTheDocument();
     expect(emojiButton).toHaveClass("h-7", "w-7");
@@ -3646,7 +3646,12 @@ describe("chat lifecycle", () => {
 
     const menu = await screen.findByRole("menu");
     expect(queryAllByRoleFast("menuitem", menu)).toHaveLength(10);
-    click(menuItemByLabel("Done ✅", menu));
+    expect(within(menu).queryByText("Done")).not.toBeInTheDocument();
+    expect(within(menu).getByText("Clear icon")).toBeInTheDocument();
+    expect(within(menu).getAllByText("Shift").length).toBeGreaterThan(0);
+    expect(within(menu).getByText("1")).toBeInTheDocument();
+    expect(within(menu).getByText("0")).toBeInTheDocument();
+    click(menuItemByLabel("Done icon Shift 1", menu));
 
     await waitFor(() => {
       expect(renameRequest).toHaveBeenCalledWith(
@@ -3747,10 +3752,10 @@ describe("chat lifecycle", () => {
       expect(
         screen.getByText("Current thread launch note"),
       ).toBeInTheDocument();
-      expect(screen.getByLabelText("Change emoji")).toHaveTextContent("🔥");
+      expect(screen.getByLabelText("Change icon")).toHaveTextContent("🔥");
     });
 
-    const emojiButton = screen.getByLabelText("Change emoji");
+    const emojiButton = screen.getByLabelText("Change icon");
     function visibleChatThreadIconTooltip(): HTMLElement | undefined {
       return screen.queryAllByText("Chat thread icon").find((element) => {
         try {
@@ -3808,7 +3813,7 @@ describe("chat lifecycle", () => {
         screen.getByText("Current thread launch note"),
       ).toBeInTheDocument();
       expect(document.title).toBe("🔥   Current keyboard thread | VM0");
-      expect(screen.getByLabelText("Change emoji")).toHaveTextContent("🔥");
+      expect(screen.getByLabelText("Change icon")).toHaveTextContent("🔥");
       expect(screen.getByText("Current keyboard thread")).toBeInTheDocument();
     });
 
@@ -3823,10 +3828,10 @@ describe("chat lifecycle", () => {
       }),
     ).toBeFalsy();
     const doneItem = queryAllByRoleFast("menuitem", menu).find((item) => {
-      return item.getAttribute("aria-label") === "Done ✅";
+      return item.getAttribute("aria-label") === "Done icon Shift 1";
     });
     if (!doneItem) {
-      throw new Error("Done emoji menu item not found");
+      throw new Error("Done icon menu item not found");
     }
     click(doneItem);
 
@@ -3859,7 +3864,7 @@ describe("chat lifecycle", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Change emoji")).toHaveTextContent("🔥");
+      expect(screen.getByLabelText("Change icon")).toHaveTextContent("🔥");
     });
 
     const threadRegion = screen.getByLabelText("Chat thread");
@@ -3897,7 +3902,7 @@ describe("chat lifecycle", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Change emoji")).toHaveTextContent("🔥");
+      expect(screen.getByLabelText("Change icon")).toHaveTextContent("🔥");
     });
 
     const threadRegion = screen.getByLabelText("Chat thread");

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -1269,7 +1269,7 @@ function ChatThreadEmojiMenuButton({
         </Tooltip>
         <UiDropdownMenuContent
           align="start"
-          className="w-40"
+          className="w-48"
           onCloseAutoFocus={(event) => {
             event.preventDefault();
           }}
@@ -1280,7 +1280,7 @@ function ChatThreadEmojiMenuButton({
               <UiDropdownMenuItem
                 key={option.emoji}
                 aria-label={`${option.label} icon Shift ${index + 1}`}
-                className="justify-between gap-6"
+                className="justify-between gap-4"
                 onSelect={() => {
                   selectEmoji(option.emoji);
                 }}
@@ -1295,12 +1295,12 @@ function ChatThreadEmojiMenuButton({
           <UiDropdownMenuSeparator />
           <UiDropdownMenuItem
             aria-label="Clear icon Shift 0"
-            className="justify-between gap-6"
+            className="justify-between gap-4"
             onSelect={() => {
               clearEmoji();
             }}
           >
-            <span>Clear icon</span>
+            <span className="whitespace-nowrap">Clear icon</span>
             <ChatThreadIconShortcutHint shortcut="shift+0" />
           </UiDropdownMenuItem>
         </UiDropdownMenuContent>
@@ -1311,15 +1311,12 @@ function ChatThreadEmojiMenuButton({
 
 function ChatThreadIconShortcutHint({ shortcut }: { shortcut: string }) {
   return (
-    <span
-      aria-hidden="true"
-      className="ml-auto flex shrink-0 items-center gap-1 text-muted-foreground"
-    >
+    <span aria-hidden="true" className="ml-4 flex shrink-0 items-center gap-1">
       {getShortcutParts(shortcut).map((part) => {
         return (
           <kbd
             key={part}
-            className='inline-flex h-5 min-w-5 items-center justify-center rounded-md bg-background px-1 text-[10px] font-medium leading-none text-muted-foreground shadow-[inset_0_-1px_0_hsl(var(--border)),0_0_0_1px_hsl(var(--border))] font-["-apple-system",BlinkMacSystemFont,"Segoe_UI",system-ui,sans-serif]'
+            className='inline-flex h-6 min-w-[1.5rem] items-center justify-center rounded-md bg-background px-1.5 text-[11px] font-medium text-foreground shadow-[inset_0_-1px_0_hsl(var(--border)),0_0_0_1px_hsl(var(--border))] font-["-apple-system",BlinkMacSystemFont,"Segoe_UI",system-ui,sans-serif]'
           >
             {part}
           </kbd>

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -58,6 +58,7 @@ import {
   cn,
   Button,
   Skeleton,
+  getShortcutParts,
   DropdownMenu as UiDropdownMenu,
   DropdownMenuContent as UiDropdownMenuContent,
   DropdownMenuItem as UiDropdownMenuItem,
@@ -354,9 +355,9 @@ const CHAT_SHORTCUT_SECTIONS = [
       { key: "mod+shift+o", label: "New chat" },
       { key: "mod+shift+a", label: "Open agent list" },
       { key: "f2", label: "Rename chat" },
-      { key: "shift+f2", label: "Change emoji" },
-      { key: "shift+1", label: "Set emoji (shift+1-9)" },
-      { key: "shift+0", label: "Clear emoji" },
+      { key: "shift+f2", label: "Change icon" },
+      { key: "shift+1", label: "Set icon (shift+1-9)" },
+      { key: "shift+0", label: "Clear icon" },
     ],
   },
   {
@@ -1253,7 +1254,7 @@ function ChatThreadEmojiMenuButton({
             <UiDropdownMenuTrigger asChild>
               <button
                 type="button"
-                aria-label="Change emoji"
+                aria-label="Change icon"
                 className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
               >
                 {emoji && (
@@ -1273,34 +1274,58 @@ function ChatThreadEmojiMenuButton({
             event.preventDefault();
           }}
         >
-          {CHAT_THREAD_EMOJI_OPTIONS.map((option) => {
+          {CHAT_THREAD_EMOJI_OPTIONS.map((option, index) => {
+            const shortcut = `shift+${index + 1}`;
             return (
               <UiDropdownMenuItem
                 key={option.emoji}
-                aria-label={`${option.label} ${option.emoji}`}
+                aria-label={`${option.label} icon Shift ${index + 1}`}
+                className="justify-between gap-6"
                 onSelect={() => {
                   selectEmoji(option.emoji);
                 }}
               >
-                <span className="mr-2 text-base leading-none" aria-hidden>
+                <span className="text-base leading-none" aria-hidden>
                   {option.emoji}
                 </span>
-                <span>{option.label}</span>
+                <ChatThreadIconShortcutHint shortcut={shortcut} />
               </UiDropdownMenuItem>
             );
           })}
           <UiDropdownMenuSeparator />
           <UiDropdownMenuItem
-            aria-label="Clear emoji"
+            aria-label="Clear icon Shift 0"
+            className="justify-between gap-6"
             onSelect={() => {
               clearEmoji();
             }}
           >
-            <span>Clear emoji</span>
+            <span>Clear icon</span>
+            <ChatThreadIconShortcutHint shortcut="shift+0" />
           </UiDropdownMenuItem>
         </UiDropdownMenuContent>
       </UiDropdownMenu>
     </TooltipProvider>
+  );
+}
+
+function ChatThreadIconShortcutHint({ shortcut }: { shortcut: string }) {
+  return (
+    <span
+      aria-hidden="true"
+      className="ml-auto flex shrink-0 items-center gap-1 text-muted-foreground"
+    >
+      {getShortcutParts(shortcut).map((part) => {
+        return (
+          <kbd
+            key={part}
+            className='inline-flex h-5 min-w-5 items-center justify-center rounded-md bg-background px-1 text-[10px] font-medium leading-none text-muted-foreground shadow-[inset_0_-1px_0_hsl(var(--border)),0_0_0_1px_hsl(var(--border))] font-["-apple-system",BlinkMacSystemFont,"Segoe_UI",system-ui,sans-serif]'
+          >
+            {part}
+          </kbd>
+        );
+      })}
+    </span>
   );
 }
 


### PR DESCRIPTION
## Summary
- Replace chat thread icon menu labels with shortcut hints for Shift+1 through Shift+9
- Rename visible shortcut copy to use icon wording and show Clear icon with Shift+0
- Update chat lifecycle coverage for the menu text and shortcut labels

## Verification
- pnpm exec prettier --check apps/platform/src/views/zero-page/zero-chat-thread-page.tsx apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx -t "keyboard shortcuts|Shift\\+F2|feature switch|does not refocus|clears the current chat|does not clear"
- pnpm -F @vm0/app exec oxlint src/views/zero-page/zero-chat-thread-page.tsx src/views/zero-page/__tests__/chat-lifecycle.test.tsx
- pnpm -F @vm0/app check-types
