### PR TITLE
fix: preserve onboarding domain override

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/auth-url.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/auth-url.test.ts
@@ -33,11 +33,14 @@ async function withoutConfiguredOnboarding<T>(
 async function withProductionDeployment<T>(
   callback: () => T | Promise<T>,
 ): Promise<T> {
+  const previousVercelEnv = import.meta.env.VITE_VERCEL_ENV as
+    | string
+    | undefined;
   vi.stubEnv("VITE_VERCEL_ENV", "production");
   try {
     return await callback();
   } finally {
-    vi.stubEnv("VITE_VERCEL_ENV", "");
+    vi.stubEnv("VITE_VERCEL_ENV", previousVercelEnv);
   }
 }
 

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -386,14 +386,23 @@ function setCurrentLandingContext(params: URLSearchParams): void {
   }
 }
 
+function appendDomainOverrideParam(url: URL): void {
+  const domainOverride = resolveDomainOverride();
+  if (domainOverride && !url.searchParams.has("domain")) {
+    url.searchParams.set("domain", domainOverride);
+  }
+}
+
 function buildVm0OnboardingEntryUrl(paramsInit?: URLSearchParams): string {
   const params = new URLSearchParams(paramsInit);
   if (!params.has("vm0_experiment")) {
     params.set("vm0_experiment", VM0_ONBOARDING_EXPERIMENT);
   }
   setCurrentLandingContext(params);
-  const query = params.toString();
-  return `${onboardingBaseUrl()}${VM0_ONBOARDING_PATH}${query ? `?${query}` : ""}`;
+  const url = new URL(VM0_ONBOARDING_PATH, onboardingBaseUrl());
+  url.search = params.toString();
+  appendDomainOverrideParam(url);
+  return url.toString();
 }
 
 function isKnownStagingOnboardingRedirect(redirectUrl: URL): boolean {
@@ -431,6 +440,7 @@ function normalizeOnboardingRedirectUrl(
   const normalized = new URL(redirectUrl.toString());
   normalized.protocol = paidUrl.protocol;
   normalized.host = paidUrl.host;
+  appendDomainOverrideParam(normalized);
   return normalized;
 }
 

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -399,7 +399,7 @@ function buildVm0OnboardingEntryUrl(paramsInit?: URLSearchParams): string {
     params.set("vm0_experiment", VM0_ONBOARDING_EXPERIMENT);
   }
   setCurrentLandingContext(params);
-  const url = new URL(VM0_ONBOARDING_PATH, onboardingBaseUrl());
+  const url = new URL(`${onboardingBaseUrl()}${VM0_ONBOARDING_PATH}`);
   url.search = params.toString();
   appendDomainOverrideParam(url);
   return url.toString();

--- a/turbo/apps/platform/src/views/auth/__tests__/auth-page.test.tsx
+++ b/turbo/apps/platform/src/views/auth/__tests__/auth-page.test.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
@@ -8,6 +8,17 @@ const context = testContext();
 
 function setBrowserUrl(url: string): void {
   window.location.href = url;
+}
+
+async function withProductionDeployment<T>(
+  callback: () => T | Promise<T>,
+): Promise<T> {
+  vi.stubEnv("VITE_VERCEL_ENV", "production");
+  try {
+    return await callback();
+  } finally {
+    vi.stubEnv("VITE_VERCEL_ENV", "");
+  }
 }
 
 describe("app auth pages", () => {
@@ -111,6 +122,27 @@ describe("app auth pages", () => {
     expect(redirectUrl.searchParams.get("utm_campaign")).toBe("summer");
     expect(redirectUrl.searchParams.get("vm0_source")).toBe("homepage");
     expect(redirectUrl.searchParams.get("vm0_experiment")).toBe("491858");
+    expect(redirectUrl.searchParams.get("domain")).toBe("api.vm7.ai:8443");
+  });
+
+  it("does not add the configured API domain to production onboarding redirects", async () => {
+    await withProductionDeployment(async () => {
+      const path = "/sign-up?gclid=click-123&utm_campaign=summer";
+      setBrowserUrl(`https://app.vm0.ai${path}`);
+
+      detachedSetupPage({ context, path });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("clerk-sign-up")).toBeInTheDocument();
+      });
+
+      const redirectUrl = new URL(
+        screen.getByTestId("clerk-sign-up").dataset.clerkForceRedirectUrl ?? "",
+      );
+      expect(redirectUrl.pathname).toBe("/onboarding/491858");
+      expect(redirectUrl.searchParams.get("gclid")).toBe("click-123");
+      expect(redirectUrl.searchParams.has("domain")).toBeFalsy();
+    });
   });
 
   it.each([
@@ -141,4 +173,27 @@ describe("app auth pages", () => {
       );
     },
   );
+
+  it("adds the configured API domain to normalized staging onboarding redirects", async () => {
+    const redirectUrl =
+      "https://staging-www.vm6.ai/onboarding/2afcf6?vm0_theme=light";
+    const path = `/sign-up?redirect_url=${encodeURIComponent(redirectUrl)}`;
+    setBrowserUrl(`https://app.vm0.ai${path}`);
+
+    detachedSetupPage({ context, path });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("clerk-sign-up")).toBeInTheDocument();
+    });
+
+    const normalizedRedirectUrl = new URL(
+      screen.getByTestId("clerk-sign-up").dataset.clerkForceRedirectUrl ?? "",
+    );
+    expect(normalizedRedirectUrl.origin).toBe("https://www.vm7.ai:8443");
+    expect(normalizedRedirectUrl.pathname).toBe("/onboarding/2afcf6");
+    expect(normalizedRedirectUrl.searchParams.get("vm0_theme")).toBe("light");
+    expect(normalizedRedirectUrl.searchParams.get("domain")).toBe(
+      "api.vm7.ai:8443",
+    );
+  });
 });

--- a/turbo/apps/platform/src/views/auth/__tests__/auth-page.test.tsx
+++ b/turbo/apps/platform/src/views/auth/__tests__/auth-page.test.tsx
@@ -13,11 +13,14 @@ function setBrowserUrl(url: string): void {
 async function withProductionDeployment<T>(
   callback: () => T | Promise<T>,
 ): Promise<T> {
+  const previousVercelEnv = import.meta.env.VITE_VERCEL_ENV as
+    | string
+    | undefined;
   vi.stubEnv("VITE_VERCEL_ENV", "production");
   try {
     return await callback();
   } finally {
-    vi.stubEnv("VITE_VERCEL_ENV", "");
+    vi.stubEnv("VITE_VERCEL_ENV", previousVercelEnv);
   }
 }
 


### PR DESCRIPTION
## Summary
- append the resolved API domain override when building onboarding entry URLs
- preserve existing `domain` query params while normalizing staging onboarding redirects to the configured onboarding origin
- cover local/preview domain propagation and production no-domain behavior in auth page tests

## Verification
- pnpm format
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app exec vitest run src/views/auth/__tests__/auth-page.test.tsx src/signals/__tests__/auth-url.test.ts
- pre-commit: prettier, knip, turbo run check-types --concurrency=1
