### PR TITLE
fix: animate initial thinking lines independently

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -2991,7 +2991,7 @@ function createCancelRunWithQueuedRecall({
 // ---------------------------------------------------------------------------
 
 const THINKING_TYPEWRITER_INTERVAL_MS = 28;
-const THINKING_TYPEWRITER_LINE_PAUSE_MS = 1000;
+const THINKING_TYPEWRITER_LINE_PAUSE_MS = 3000;
 const THINKING_TYPEWRITER_LINE_PAUSE_TICKS = IN_VITEST
   ? 1
   : Math.ceil(
@@ -2999,14 +2999,11 @@ const THINKING_TYPEWRITER_LINE_PAUSE_TICKS = IN_VITEST
     );
 const THINKING_TYPEWRITER_WIDTH_GUARD_PX = 8;
 const THINKING_TYPEWRITER_OVERFLOW_PREFIX = "...";
-// Short tails should roll from the previous line instead of restarting alone.
-const THINKING_TYPEWRITER_FULL_LINE_RATIO = 0.8;
 
 interface ThinkingTypewriterLine {
   readonly startIndex: number;
   readonly endIndex: number;
   readonly text: string;
-  readonly fillsWidth: boolean;
 }
 
 interface ThinkingTypewriterFrame {
@@ -3153,14 +3150,6 @@ function thinkingLabelWidth(el: HTMLElement): number {
   );
 }
 
-function fullThinkingLineThreshold(width: number): number {
-  return Math.max(
-    1,
-    (width - THINKING_TYPEWRITER_WIDTH_GUARD_PX) *
-      THINKING_TYPEWRITER_FULL_LINE_RATIO,
-  );
-}
-
 function wrapThinkingTextForWidth(args: {
   readonly graphemes: readonly string[];
   readonly width: number;
@@ -3175,17 +3164,14 @@ function wrapThinkingTextForWidth(args: {
         startIndex: 0,
         endIndex: args.graphemes.length,
         text: args.graphemes.join(""),
-        fillsWidth: false,
       },
     ];
   }
 
   const maxWidth = Math.max(1, args.width - THINKING_TYPEWRITER_WIDTH_GUARD_PX);
-  const fullLineThreshold = fullThinkingLineThreshold(args.width);
   const lines: ThinkingTypewriterLine[] = [];
   let startIndex = 0;
   let current: string[] = [];
-  let currentWidth = 0;
 
   for (let index = 0; index < args.graphemes.length; index++) {
     const grapheme = args.graphemes[index]!;
@@ -3198,14 +3184,12 @@ function wrapThinkingTextForWidth(args: {
           startIndex: 0,
           endIndex: args.graphemes.length,
           text: args.graphemes.join(""),
-          fillsWidth: false,
         },
       ];
     }
 
     if (measured <= maxWidth || current.length === 0) {
       current = candidate;
-      currentWidth = measured;
       continue;
     }
 
@@ -3213,11 +3197,9 @@ function wrapThinkingTextForWidth(args: {
       startIndex,
       endIndex: index,
       text: current.join(""),
-      fillsWidth: true,
     });
     startIndex = index;
     current = [grapheme];
-    currentWidth = args.measureText(grapheme) ?? measured;
   }
 
   if (current.length > 0) {
@@ -3225,7 +3207,6 @@ function wrapThinkingTextForWidth(args: {
       startIndex,
       endIndex: args.graphemes.length,
       text: current.join(""),
-      fillsWidth: currentWidth >= fullLineThreshold,
     });
   }
 
@@ -3325,46 +3306,33 @@ function nextThinkingTypewriterFrame(args: {
   }
 
   if (currentFrame.charIndex >= currentLine.endIndex) {
-    if (nextLine?.fillsWidth) {
-      const nextCharIndex = Math.min(
-        nextLine.endIndex,
-        nextLine.startIndex + thinkingTypewriterStep(width),
-      );
+    if (!nextLine) {
       return {
         ...currentFrame,
-        lineIndex: lineIndex + 1,
-        charIndex: nextCharIndex,
-        pauseTicksRemaining: 0,
-        displayedText: displayedSlidingThinkingText({
-          graphemes,
-          startIndex: nextLine.startIndex,
-          charIndex: nextCharIndex,
-          width,
-          measureText: args.measureText,
-        }),
-        complete:
-          lineIndex + 1 >= lines.length - 1 &&
-          nextCharIndex >= graphemes.length,
+        lineIndex,
+        displayedText: currentLine.text,
+        complete: true,
       };
     }
 
     const nextCharIndex = Math.min(
-      graphemes.length,
-      currentFrame.charIndex + thinkingTypewriterStep(width),
+      nextLine.endIndex,
+      nextLine.startIndex + thinkingTypewriterStep(width),
     );
     return {
       ...currentFrame,
-      lineIndex,
+      lineIndex: lineIndex + 1,
       charIndex: nextCharIndex,
       pauseTicksRemaining: 0,
       displayedText: displayedSlidingThinkingText({
         graphemes,
-        startIndex: currentLine.startIndex,
+        startIndex: nextLine.startIndex,
         charIndex: nextCharIndex,
         width,
         measureText: args.measureText,
       }),
-      complete: nextCharIndex >= graphemes.length,
+      complete:
+        lineIndex + 1 >= lines.length - 1 && nextCharIndex >= graphemes.length,
     };
   }
 
@@ -3378,7 +3346,7 @@ function nextThinkingTypewriterFrame(args: {
     lineIndex,
     charIndex: nextCharIndex,
     pauseTicksRemaining:
-      nextCharIndex >= currentLine.endIndex && nextLine?.fillsWidth
+      nextCharIndex >= currentLine.endIndex && nextLine !== undefined
         ? THINKING_TYPEWRITER_LINE_PAUSE_TICKS
         : 0,
     displayedText: displayedSlidingThinkingText({

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -7066,7 +7066,7 @@ describe("initial thinking indicator", () => {
     expect(label.closest("[data-thinking-indicator]")).not.toBeNull();
   });
 
-  it("restarts on full follow-up lines before sliding a short tail", async () => {
+  it("restarts on every follow-up line instead of sliding a short tail", async () => {
     const threadId = "thread-initial-thinking-rollover";
     const thinking = "ABCDEFG";
     mockThinkingTypewriterLayout({
@@ -7133,13 +7133,14 @@ describe("initial thinking indicator", () => {
 
     const label = await screen.findByLabelText(thinking);
     await waitFor(() => {
-      expect(label).toHaveTextContent("...EFG");
+      expect(label).toHaveTextContent(/^G$/);
     });
     expect(
       Array.from(displayedLabels).some((value) => {
         return value === "D" || value === "DE" || value === "DEF";
       }),
     ).toBeTruthy();
+    expect(displayedLabels.has("...EFG")).toBeFalsy();
     expect(label).not.toHaveTextContent(thinking);
     expect(label.closest("[data-thinking-indicator]")).not.toBeNull();
   });


### PR DESCRIPTION
## Summary
- Remove the initial thinking typewriter short-tail line merge strategy so every wrapped line starts its own animation.
- Increase the inter-line pause from 1s to 3s.
- Update the rollover coverage to assert the short tail renders as its own line instead of a merged sliding label.

## Verification
- pnpm exec prettier --write apps/platform/src/signals/chat-page/create-chat-thread.ts apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
- pnpm exec oxlint src/signals/chat-page/create-chat-thread.ts src/views/zero-page/__tests__/chat-lifecycle.test.tsx
- pnpm exec oxlint --type-aware -c ../../.oxlintrc.typeaware.json src/signals/chat-page/create-chat-thread.ts src/views/zero-page/__tests__/chat-lifecycle.test.tsx
- pnpm exec eslint src/signals/chat-page/create-chat-thread.ts src/views/zero-page/__tests__/chat-lifecycle.test.tsx --max-warnings 0

## Notes
- Attempted targeted Vitest locally with `timeout 180s pnpm -F @vm0/app test -- src/views/zero-page/__tests__/chat-lifecycle.test.tsx:7067`; it timed out before producing a result. Full PR checks should cover the test suite.