### PR TITLE
fix: show edit action for hosted site root URLs

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
@@ -368,8 +368,10 @@ function setupPresentationArtifactThread(
 function setupHostedSiteArtifactThread(
   siteUrl: string,
   html = "<!doctype html><html><body><h1>Original site</h1></body></html>",
+  artifactUrl = siteUrl,
 ): void {
-  const filename = new URL(siteUrl).pathname.split("/").pop() || "site.html";
+  const filename =
+    new URL(artifactUrl).pathname.split("/").pop() || "site.html";
   context.mocks.http.get(siteUrl, () => {
     return new Response(html, {
       headers: { "Content-Type": "text/html" },
@@ -377,7 +379,7 @@ function setupHostedSiteArtifactThread(
   });
   setupChatThread({
     artifactFiles: [
-      artifactFile(siteUrl, {
+      artifactFile(artifactUrl, {
         id: "artifact-hosted-site",
         filename,
         contentType: "text/html",
@@ -609,6 +611,18 @@ describe("zero artifact sidebar", () => {
     await user.click(screen.getByLabelText("Close artifact"));
     await waitFor(() => {
       expect(screen.queryByTestId("artifact-sidebar")).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows hosted-site edit action when the sidebar URL has a root trailing slash", async () => {
+    const artifactUrl = "https://root-launch-site.sites.vm7.io";
+    const siteUrl = `${artifactUrl}/`;
+    setupHostedSiteArtifactThread(siteUrl, undefined, artifactUrl);
+
+    const sidebar = await screen.findByTestId("artifact-sidebar");
+    await waitFor(() => {
+      expect(within(sidebar).getByLabelText("Edit page")).toBeInTheDocument();
+      expect(within(sidebar).queryByLabelText("Edit presentation")).toBeNull();
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -75,6 +75,7 @@ function presentationHtml(): string {
 }
 
 function setupHostedSiteArtifactPreview({
+  artifactUrl,
   featureSwitches = {
     [FeatureSwitchKey.HtmlArtifactCommentEditing]: true,
   },
@@ -85,6 +86,7 @@ function setupHostedSiteArtifactPreview({
   path = `/chats/${THREAD_ID}`,
   runId,
 }: {
+  artifactUrl?: string;
   featureSwitches?: Parameters<typeof detachedSetupPage>[0]["featureSwitches"];
   filename: string;
   html?: string;
@@ -93,6 +95,7 @@ function setupHostedSiteArtifactPreview({
   path?: string;
   runId: string;
 }): void {
+  const artifactMetadataUrl = artifactUrl ?? htmlUrl;
   context.mocks.http.get("*/__vm0-dev-artifact-fetch", ({ request }) => {
     expect(new URL(request.url).searchParams.get("url")).toBe(htmlUrl);
     return new Response(
@@ -116,7 +119,7 @@ function setupHostedSiteArtifactPreview({
         {
           runId,
           files: [
-            artifactFile(htmlUrl, {
+            artifactFile(artifactMetadataUrl, {
               artifactKind: "hosted-site",
               filename,
             }),
@@ -2276,6 +2279,31 @@ describe("zero attachment chips", () => {
       expect(restoredEditFrame.contentDocument?.body.textContent).not.toContain(
         "Launch sooner",
       );
+    });
+  });
+
+  it("shows hosted-site HTML edit action when the preview URL has a root trailing slash", async () => {
+    const artifactUrl = "https://launch-site-root.sites.vm7.io";
+    const previewUrl = `${artifactUrl}/`;
+    setupHostedSiteArtifactPreview({
+      artifactUrl,
+      filename: "launch-site-root.html",
+      htmlUrl: previewUrl,
+      label: "Launch site",
+      runId: "run-hosted-site-root",
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Open html preview for Launch site"),
+      ).toBeInTheDocument();
+    });
+
+    click(screen.getByLabelText("Open html preview for Launch site"));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Edit page")).toBeInTheDocument();
+      expect(screen.queryByLabelText("Edit presentation")).toBeNull();
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -66,6 +66,7 @@ import {
   publicAttachmentUrl,
   TextPreviewLoader,
 } from "./zero-attachment-chips.tsx";
+import { artifactPreviewUrlsMatch } from "./zero-attachment-url.ts";
 import { lightboxDialogVisible$ } from "../../signals/zero-page/zero-attachment-chips.ts";
 import { Markdown } from "../components/markdown.tsx";
 import { pageSignal$ } from "../../signals/page-signal.ts";
@@ -938,7 +939,7 @@ function findArtifactItemForUrl(
 ): ArtifactSidebarItem | undefined {
   for (const run of runs) {
     const file = run.files.find((candidate) => {
-      return candidate.url === url;
+      return artifactPreviewUrlsMatch(candidate.url, url);
     });
     if (file) {
       return { runId: run.runId, file };

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -69,6 +69,7 @@ import {
 } from "../../signals/zero-page/presentation-html-cache-bust.ts";
 import { FilePreviewIcon } from "./zero-file-preview-icon.tsx";
 import {
+  artifactPreviewUrlsMatch,
   attachmentFilenameFromUrl,
   downloadAttachmentUrl,
   publicAttachmentUrl,
@@ -398,7 +399,7 @@ function findArtifactDialogItemForUrl(
 ): ArtifactDialogItem | undefined {
   for (const run of runs) {
     const file = run.files.find((candidate) => {
-      return candidate.url === url;
+      return artifactPreviewUrlsMatch(candidate.url, url);
     });
     if (file) {
       return { runId: run.runId, file };

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-url.ts
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-url.ts
@@ -163,6 +163,30 @@ export function publicAttachmentUrl(url: string): string {
   return normalizedLegacyFileUrl(url) ?? normalizedArtifactFileUrl(url) ?? url;
 }
 
+function comparableArtifactPreviewUrl(value: string): string | null {
+  if (!URL.canParse(value)) {
+    return null;
+  }
+  const url = new URL(value);
+  const pathname = url.pathname === "/" ? "" : url.pathname;
+  return `${url.protocol}//${url.host}${pathname}${url.search}${url.hash}`;
+}
+
+export function artifactPreviewUrlsMatch(
+  artifactUrl: string,
+  previewUrl: string,
+): boolean {
+  if (artifactUrl === previewUrl) {
+    return true;
+  }
+  const comparableArtifactUrl = comparableArtifactPreviewUrl(artifactUrl);
+  const comparablePreviewUrl = comparableArtifactPreviewUrl(previewUrl);
+  return (
+    comparableArtifactUrl !== null &&
+    comparableArtifactUrl === comparablePreviewUrl
+  );
+}
+
 function canUseDevArtifactFetchProxy(): boolean {
   if (!import.meta.env.DEV) {
     return false;


### PR DESCRIPTION
Summary:
- Normalize artifact URL comparisons so root hosted-site URLs match with or without a trailing slash.
- Apply the matching to both lightbox previews and the artifact sidebar.
- Add page-level coverage for hosted-site edit actions when preview URLs include a root trailing slash.

Verification:
- pnpm exec prettier --check apps/platform/src/views/zero-page/zero-attachment-url.ts apps/platform/src/views/zero-page/zero-attachment-chips.tsx apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-attachment-chips.test.tsx src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types