### PR TITLE
feat: support safe script patches for html edits

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/host-maps.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/host-maps.bdd.test.ts
@@ -575,11 +575,9 @@ describe("FILE-01: hosted-site deployments through host APIs", () => {
     });
     expect(upstreamAuthorization).toBe("Bearer bdd-html-edit-key");
     expect(upstreamPrompt).toContain("vm0-node-1");
+    expect(upstreamPrompt).toContain("HTML may be a full snapshot");
     expect(upstreamPrompt).toContain(
-      "The HTML section contains either the current DOM snapshot or focused target context",
-    );
-    expect(upstreamPrompt).toContain(
-      "Do not assume the selected DOM node is the source of truth",
+      "do not assume selected DOM is the source of truth",
     );
     expect(upstreamPrompt).toContain("html-dom-edit-patch");
     expect(upstreamPrompt).toContain('"operation":"update"');

--- a/turbo/apps/api/src/signals/routes/__tests__/host-maps.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/host-maps.bdd.test.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 
 import { HttpResponse, http } from "msw";
 import { describe, expect, it } from "vitest";
@@ -42,6 +42,10 @@ const GOOGLE_PLACE_DETAILS_URL =
 const OPENSTREETMAP_OVERPASS_URL = "https://overpass-api.de/api/interpreter";
 const OPENROUTER_CHAT_COMPLETIONS_URL =
   "https://openrouter.ai/api/v1/chat/completions";
+
+function sha256Hex(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
 
 function expectPublicSlugSegment(value: string): void {
   expect(value).toMatch(/^[a-f0-9]{8}$/);
@@ -571,11 +575,20 @@ describe("FILE-01: hosted-site deployments through host APIs", () => {
     });
     expect(upstreamAuthorization).toBe("Bearer bdd-html-edit-key");
     expect(upstreamPrompt).toContain("vm0-node-1");
+    expect(upstreamPrompt).toContain(
+      "The HTML section contains either the current DOM snapshot or focused target context",
+    );
+    expect(upstreamPrompt).toContain(
+      "Do not assume the selected DOM node is the source of truth",
+    );
     expect(upstreamPrompt).toContain("html-dom-edit-patch");
     expect(upstreamPrompt).toContain('"operation":"update"');
     expect(upstreamPrompt).toContain("color, background, icon");
     expect(upstreamPrompt).toContain("Do not add comment markers");
     expect(upstreamPrompt).toContain("Do not return the complete HTML");
+    expect(upstreamPrompt).not.toContain(
+      "No target-related script context was found.",
+    );
     expect(upstreamPrompt).not.toContain("zero host");
 
     const snapshotUrl =
@@ -663,6 +676,648 @@ describe("FILE-01: hosted-site deployments through host APIs", () => {
     expect(invalid.body.error.message).toBe(
       "HTML edit generation returned invalid patch JSON",
     );
+  });
+
+  it("applies HTML edit script update, delete, and add patches [HOST-G]", async () => {
+    const bdd = createBddApi(context);
+    const api = createHostMapsBddApi(context);
+    const actor = bdd.user();
+    mockOptionalEnv("OPENROUTER_API_KEY", "bdd-html-edit-key");
+
+    const oldScriptContent = [
+      'const state = { title: "Draft headline" };',
+      'document.getElementById("title").textContent = state.title;',
+    ].join("\n");
+    const newScriptContent = [
+      'const state = { title: "Published headline" };',
+      'document.getElementById("title").textContent = state.title;',
+    ].join("\n");
+    const removableScriptContent = 'console.log("remove me");';
+    const oldScriptSha = sha256Hex(
+      `<script data-vm0-script-id="vm0-script-1">${oldScriptContent}</script>`,
+    );
+    const removableScriptSha = sha256Hex(
+      `<script data-vm0-script-id="vm0-script-2">${removableScriptContent}</script>`,
+    );
+    let upstreamPrompt: string | null = null;
+
+    server.use(
+      http.post(OPENROUTER_CHAT_COMPLETIONS_URL, async ({ request }) => {
+        const requestBody = (await request.json()) as {
+          readonly messages?: readonly { readonly content?: string }[];
+        };
+        upstreamPrompt = requestBody.messages?.at(-1)?.content ?? null;
+        return HttpResponse.json({
+          choices: [
+            {
+              finish_reason: "stop",
+              message: {
+                content: JSON.stringify({
+                  kind: "html-dom-edit-patch",
+                  version: 1,
+                  patches: [
+                    {
+                      commentId: "comment-1",
+                      targetNodeId: "vm0-node-1",
+                      operation: "update",
+                      outerHTML: '<h1 id="title">Published headline</h1>',
+                    },
+                    {
+                      commentId: "comment-1",
+                      scriptId: "vm0-script-1",
+                      oldSha256: oldScriptSha,
+                      operation: "script_update",
+                      content: newScriptContent,
+                    },
+                    {
+                      commentId: "comment-2",
+                      scriptId: "vm0-script-2",
+                      oldSha256: removableScriptSha,
+                      operation: "script_delete",
+                    },
+                    {
+                      commentId: "comment-3",
+                      operation: "script_add",
+                      placement: "end_of_body",
+                      content:
+                        'document.documentElement.dataset.edited = "true";',
+                    },
+                  ],
+                }),
+              },
+            },
+          ],
+        });
+      }),
+    );
+
+    const generated = await api.requestCreateHtmlEditDraft(
+      actor,
+      {
+        html: `<!doctype html><html><body><h1 id="title" data-vm0-node-id="vm0-node-1">Draft headline</h1><script>${oldScriptContent}</script><script>${removableScriptContent}</script></body></html>`,
+        comments: [
+          {
+            id: "comment-1",
+            targetNodeIds: ["vm0-node-1"],
+            comment: "Update the title and keep runtime state in sync",
+          },
+          {
+            id: "comment-2",
+            targetNodeIds: ["vm0-node-1"],
+            comment: "Remove the obsolete console logging behavior",
+          },
+          {
+            id: "comment-3",
+            targetNodeIds: ["vm0-node-1"],
+            comment: "Mark the document as edited at runtime",
+          },
+        ],
+      },
+      [200],
+    );
+
+    expect(generated.body).toStrictEqual({
+      kind: "html-edit-draft",
+      version: 1,
+      html: `<!doctype html><html><body><h1 id="title">Published headline</h1><script>${newScriptContent}</script><script>document.documentElement.dataset.edited = "true";</script></body></html>`,
+    });
+    expect(upstreamPrompt).toContain("scriptId: vm0-script-1");
+    expect(upstreamPrompt).toContain(`oldSha256: ${oldScriptSha}`);
+    expect(upstreamPrompt).toContain("Target-script context");
+    expect(upstreamPrompt).toContain("Target search terms: title");
+    expect(upstreamPrompt).toContain('document.getElementById("title")');
+    expect(upstreamPrompt).toContain(
+      'const state = { title: "Draft headline" };',
+    );
+    expect(upstreamPrompt).toContain('"operation":"script_update"');
+    expect(upstreamPrompt).toContain('"operation":"script_text_replace"');
+    expect(upstreamPrompt).toContain('"operation":"script_delete"');
+    expect(upstreamPrompt).toContain('"operation":"script_add"');
+    expect(upstreamPrompt).not.toContain("script_replace");
+  });
+
+  it("uses focused HTML edit context for large documents [HOST-H]", async () => {
+    const bdd = createBddApi(context);
+    const api = createHostMapsBddApi(context);
+    const actor = bdd.user();
+    mockOptionalEnv("OPENROUTER_API_KEY", "bdd-html-edit-key");
+
+    const oldScriptContent = [
+      'const state = { title: "Draft headline" };',
+      'document.getElementById("title").textContent = state.title;',
+    ].join("\n");
+    const oldScriptSha = sha256Hex(
+      `<script data-vm0-script-id="vm0-script-1">${oldScriptContent}</script>`,
+    );
+    const largeFiller = `<section>${"large-filler ".repeat(6000)}</section>`;
+    let upstreamPrompt: string | null = null;
+
+    server.use(
+      http.post(OPENROUTER_CHAT_COMPLETIONS_URL, async ({ request }) => {
+        const requestBody = (await request.json()) as {
+          readonly messages?: readonly { readonly content?: string }[];
+        };
+        upstreamPrompt = requestBody.messages?.at(-1)?.content ?? null;
+        return HttpResponse.json({
+          choices: [
+            {
+              finish_reason: "stop",
+              message: {
+                content: JSON.stringify({
+                  kind: "html-dom-edit-patch",
+                  version: 1,
+                  patches: [
+                    {
+                      commentId: "comment-1",
+                      targetNodeId: "vm0-node-1",
+                      operation: "update",
+                      outerHTML: '<h1 id="title">Published headline</h1>',
+                    },
+                    {
+                      commentId: "comment-1",
+                      scriptId: "vm0-script-1",
+                      oldSha256: oldScriptSha,
+                      operation: "script_text_replace",
+                      oldText: '"Draft headline"',
+                      newText: '"Published headline"',
+                    },
+                  ],
+                }),
+              },
+            },
+          ],
+        });
+      }),
+    );
+
+    const generated = await api.requestCreateHtmlEditDraft(
+      actor,
+      {
+        html: `<!doctype html><html><body><h1 id="title" data-vm0-node-id="vm0-node-1">Draft headline</h1>${largeFiller}<script>${oldScriptContent}</script></body></html>`,
+        comments: [
+          {
+            id: "comment-1",
+            targetNodeIds: ["vm0-node-1"],
+            comment: "Update the title and runtime state",
+          },
+        ],
+      },
+      [200],
+    );
+
+    if ("error" in generated.body) {
+      throw new Error(generated.body.error.message);
+    }
+    expect(generated.body.html).toContain(
+      '<h1 id="title">Published headline</h1>',
+    );
+    expect(generated.body.html).toContain(
+      'const state = { title: "Published headline" };',
+    );
+    expect(upstreamPrompt).toContain("Focused HTML context");
+    expect(upstreamPrompt).toContain(
+      '<h1 id="title" data-vm0-node-id="vm0-node-1">Draft headline</h1>',
+    );
+    expect(upstreamPrompt).toContain('"operation":"script_text_replace"');
+    expect(upstreamPrompt).not.toContain(largeFiller);
+  });
+
+  it("applies HTML edit script add patches that use browser APIs [HOST-I]", async () => {
+    const bdd = createBddApi(context);
+    const api = createHostMapsBddApi(context);
+    const actor = bdd.user();
+    mockOptionalEnv("OPENROUTER_API_KEY", "bdd-html-edit-key");
+
+    server.use(
+      http.post(OPENROUTER_CHAT_COMPLETIONS_URL, () => {
+        return HttpResponse.json({
+          choices: [
+            {
+              finish_reason: "stop",
+              message: {
+                content: JSON.stringify({
+                  kind: "html-dom-edit-patch",
+                  version: 1,
+                  patches: [
+                    {
+                      commentId: "comment-1",
+                      operation: "script_add",
+                      placement: "end_of_body",
+                      content: 'fetch("/collect");',
+                    },
+                  ],
+                }),
+              },
+            },
+          ],
+        });
+      }),
+    );
+
+    const generated = await api.requestCreateHtmlEditDraft(
+      actor,
+      {
+        html: '<!doctype html><html><body><h1 data-vm0-node-id="vm0-node-1">Launch</h1></body></html>',
+        comments: [
+          {
+            id: "comment-1",
+            targetNodeIds: ["vm0-node-1"],
+            comment: "Add a runtime marker",
+          },
+        ],
+      },
+      [200],
+    );
+
+    expect(generated.body).toStrictEqual({
+      kind: "html-edit-draft",
+      version: 1,
+      html: '<!doctype html><html><body><h1>Launch</h1><script>fetch("/collect");</script></body></html>',
+    });
+  });
+
+  it("applies HTML edit script updates that mutate browser API calls [HOST-J]", async () => {
+    const bdd = createBddApi(context);
+    const api = createHostMapsBddApi(context);
+    const actor = bdd.user();
+    mockOptionalEnv("OPENROUTER_API_KEY", "bdd-html-edit-key");
+
+    const oldScriptContent =
+      'fetch("/old-endpoint");\nconst title = "Draft headline";';
+    const oldScriptSha = sha256Hex(
+      `<script data-vm0-script-id="vm0-script-1">${oldScriptContent}</script>`,
+    );
+
+    server.use(
+      http.post(OPENROUTER_CHAT_COMPLETIONS_URL, () => {
+        return HttpResponse.json({
+          choices: [
+            {
+              finish_reason: "stop",
+              message: {
+                content: JSON.stringify({
+                  kind: "html-dom-edit-patch",
+                  version: 1,
+                  patches: [
+                    {
+                      commentId: "comment-1",
+                      scriptId: "vm0-script-1",
+                      oldSha256: oldScriptSha,
+                      operation: "script_update",
+                      content:
+                        'fetch("/collect");\nconst title = "Published headline";',
+                    },
+                  ],
+                }),
+              },
+            },
+          ],
+        });
+      }),
+    );
+
+    const generated = await api.requestCreateHtmlEditDraft(
+      actor,
+      {
+        html: `<!doctype html><html><body><h1 data-vm0-node-id="vm0-node-1">Draft headline</h1><script>${oldScriptContent}</script></body></html>`,
+        comments: [
+          {
+            id: "comment-1",
+            targetNodeIds: ["vm0-node-1"],
+            comment: "Update the title",
+          },
+        ],
+      },
+      [200],
+    );
+
+    expect(generated.body).toStrictEqual({
+      kind: "html-edit-draft",
+      version: 1,
+      html: '<!doctype html><html><body><h1>Draft headline</h1><script>fetch("/collect");\nconst title = "Published headline";</script></body></html>',
+    });
+  });
+
+  it("applies HTML edit script updates that add imports or parameterized JavaScript fetches [HOST-K]", async () => {
+    const bdd = createBddApi(context);
+    const api = createHostMapsBddApi(context);
+    const actor = bdd.user();
+    mockOptionalEnv("OPENROUTER_API_KEY", "bdd-html-edit-key");
+
+    const importScriptContent = 'const title = "Draft headline";';
+    const importScriptSha = sha256Hex(
+      `<script type="module" data-vm0-script-id="vm0-script-1">${importScriptContent}</script>`,
+    );
+
+    server.use(
+      http.post(OPENROUTER_CHAT_COMPLETIONS_URL, () => {
+        return HttpResponse.json({
+          choices: [
+            {
+              finish_reason: "stop",
+              message: {
+                content: JSON.stringify({
+                  kind: "html-dom-edit-patch",
+                  version: 1,
+                  patches: [
+                    {
+                      commentId: "comment-1",
+                      scriptId: "vm0-script-1",
+                      oldSha256: importScriptSha,
+                      operation: "script_update",
+                      content:
+                        'import tracker from "/tracker.js";\nconst title = "Published headline";\ntracker();',
+                    },
+                  ],
+                }),
+              },
+            },
+          ],
+        });
+      }),
+    );
+
+    const importGenerated = await api.requestCreateHtmlEditDraft(
+      actor,
+      {
+        html: `<!doctype html><html><body><h1 data-vm0-node-id="vm0-node-1">Draft headline</h1><script type="module">${importScriptContent}</script></body></html>`,
+        comments: [
+          {
+            id: "comment-1",
+            targetNodeIds: ["vm0-node-1"],
+            comment: "Update the title",
+          },
+        ],
+      },
+      [200],
+    );
+
+    expect(importGenerated.body).toStrictEqual({
+      kind: "html-edit-draft",
+      version: 1,
+      html: '<!doctype html><html><body><h1>Draft headline</h1><script type="module">import tracker from "/tracker.js";\nconst title = "Published headline";\ntracker();</script></body></html>',
+    });
+
+    const fetchScriptContent = 'const title = "Draft headline";';
+    const fetchScriptSha = sha256Hex(
+      `<script type="text/javascript; charset=utf-8" data-vm0-script-id="vm0-script-1">${fetchScriptContent}</script>`,
+    );
+
+    server.use(
+      http.post(OPENROUTER_CHAT_COMPLETIONS_URL, () => {
+        return HttpResponse.json({
+          choices: [
+            {
+              finish_reason: "stop",
+              message: {
+                content: JSON.stringify({
+                  kind: "html-dom-edit-patch",
+                  version: 1,
+                  patches: [
+                    {
+                      commentId: "comment-1",
+                      scriptId: "vm0-script-1",
+                      oldSha256: fetchScriptSha,
+                      operation: "script_update",
+                      content:
+                        'const title = "Published headline";\nfetch("/collect");',
+                    },
+                  ],
+                }),
+              },
+            },
+          ],
+        });
+      }),
+    );
+
+    const fetchGenerated = await api.requestCreateHtmlEditDraft(
+      actor,
+      {
+        html: `<!doctype html><html><body><h1 data-vm0-node-id="vm0-node-1">Draft headline</h1><script type="text/javascript; charset=utf-8">${fetchScriptContent}</script></body></html>`,
+        comments: [
+          {
+            id: "comment-1",
+            targetNodeIds: ["vm0-node-1"],
+            comment: "Update the title",
+          },
+        ],
+      },
+      [200],
+    );
+
+    expect(fetchGenerated.body).toStrictEqual({
+      kind: "html-edit-draft",
+      version: 1,
+      html: '<!doctype html><html><body><h1>Draft headline</h1><script type="text/javascript; charset=utf-8">const title = "Published headline";\nfetch("/collect");</script></body></html>',
+    });
+  });
+
+  it("rejects HTML edit script patches that break out of script tags [HOST-L]", async () => {
+    const bdd = createBddApi(context);
+    const api = createHostMapsBddApi(context);
+    const actor = bdd.user();
+    mockOptionalEnv("OPENROUTER_API_KEY", "bdd-html-edit-key");
+
+    server.use(
+      http.post(OPENROUTER_CHAT_COMPLETIONS_URL, () => {
+        return HttpResponse.json({
+          choices: [
+            {
+              finish_reason: "stop",
+              message: {
+                content: JSON.stringify({
+                  kind: "html-dom-edit-patch",
+                  version: 1,
+                  patches: [
+                    {
+                      commentId: "comment-1",
+                      operation: "script_add",
+                      placement: "end_of_body",
+                      content: '</script><img src=x alt="">',
+                    },
+                  ],
+                }),
+              },
+            },
+          ],
+        });
+      }),
+    );
+
+    const rejected = await api.requestCreateHtmlEditDraft(
+      actor,
+      {
+        html: '<!doctype html><html><body><h1 data-vm0-node-id="vm0-node-1">Launch</h1></body></html>',
+        comments: [
+          {
+            id: "comment-1",
+            targetNodeIds: ["vm0-node-1"],
+            comment: "Add a runtime marker",
+          },
+        ],
+      },
+      [400],
+    );
+
+    expectApiError(rejected.body);
+    expect(rejected.body.error.message).toBe(
+      "HTML DOM edit script patches cannot contain closing script tags",
+    );
+  });
+
+  it("updates HTML edit scripts that contain script-like text [HOST-M]", async () => {
+    const bdd = createBddApi(context);
+    const api = createHostMapsBddApi(context);
+    const actor = bdd.user();
+    mockOptionalEnv("OPENROUTER_API_KEY", "bdd-html-edit-key");
+
+    const oldScriptContent = [
+      String.raw`const template = "<script data-demo=\"x\">";`,
+      'const priority = "important draft";',
+      'const state = { title: "Draft headline" };',
+      'document.getElementById("title").textContent = state.title;',
+    ].join("\n");
+    const newScriptContent = [
+      String.raw`const template = "<script data-demo=\"x\">";`,
+      'const priority = "important published";',
+      'const state = { title: "Published headline" };',
+      'document.getElementById("title").textContent = state.title;',
+    ].join("\n");
+    const oldScriptSha = sha256Hex(
+      `<script data-vm0-script-id="vm0-script-1">${oldScriptContent}</script>`,
+    );
+
+    server.use(
+      http.post(OPENROUTER_CHAT_COMPLETIONS_URL, () => {
+        return HttpResponse.json({
+          choices: [
+            {
+              finish_reason: "stop",
+              message: {
+                content: JSON.stringify({
+                  kind: "html-dom-edit-patch",
+                  version: 1,
+                  patches: [
+                    {
+                      commentId: "comment-1",
+                      targetNodeId: "vm0-node-1",
+                      operation: "update",
+                      outerHTML: '<h1 id="title">Published headline</h1>',
+                    },
+                    {
+                      commentId: "comment-1",
+                      scriptId: "vm0-script-1",
+                      oldSha256: oldScriptSha,
+                      operation: "script_update",
+                      content: newScriptContent,
+                    },
+                  ],
+                }),
+              },
+            },
+          ],
+        });
+      }),
+    );
+
+    const generated = await api.requestCreateHtmlEditDraft(
+      actor,
+      {
+        html: `<!doctype html><html><body><h1 id="title" data-vm0-node-id="vm0-node-1">Draft headline</h1><script>${oldScriptContent}</script></body></html>`,
+        comments: [
+          {
+            id: "comment-1",
+            targetNodeIds: ["vm0-node-1"],
+            comment: "Update the title and runtime state",
+          },
+        ],
+      },
+      [200],
+    );
+
+    expect(generated.body).toStrictEqual({
+      kind: "html-edit-draft",
+      version: 1,
+      html: `<!doctype html><html><body><h1 id="title">Published headline</h1><script>${newScriptContent}</script></body></html>`,
+    });
+  });
+
+  it("updates HTML edit scripts with unchanged existing imports [HOST-N]", async () => {
+    const bdd = createBddApi(context);
+    const api = createHostMapsBddApi(context);
+    const actor = bdd.user();
+    mockOptionalEnv("OPENROUTER_API_KEY", "bdd-html-edit-key");
+
+    const oldScriptContent = [
+      'import tracker from "/tracker.js";',
+      'const state = { title: "Draft headline" };',
+      'document.getElementById("title").textContent = state.title;',
+      "tracker.ready();",
+    ].join("\n");
+    const newScriptContent = [
+      'import tracker from "/tracker.js";',
+      'const state = { title: "Published headline" };',
+      'document.getElementById("title").textContent = state.title;',
+      "tracker.ready();",
+    ].join("\n");
+    const oldScriptSha = sha256Hex(
+      `<script type="module" data-vm0-script-id="vm0-script-1">${oldScriptContent}</script>`,
+    );
+
+    server.use(
+      http.post(OPENROUTER_CHAT_COMPLETIONS_URL, () => {
+        return HttpResponse.json({
+          choices: [
+            {
+              finish_reason: "stop",
+              message: {
+                content: JSON.stringify({
+                  kind: "html-dom-edit-patch",
+                  version: 1,
+                  patches: [
+                    {
+                      commentId: "comment-1",
+                      targetNodeId: "vm0-node-1",
+                      operation: "update",
+                      outerHTML: '<h1 id="title">Published headline</h1>',
+                    },
+                    {
+                      commentId: "comment-1",
+                      scriptId: "vm0-script-1",
+                      oldSha256: oldScriptSha,
+                      operation: "script_update",
+                      content: newScriptContent,
+                    },
+                  ],
+                }),
+              },
+            },
+          ],
+        });
+      }),
+    );
+
+    const generated = await api.requestCreateHtmlEditDraft(
+      actor,
+      {
+        html: `<!doctype html><html><body><h1 id="title" data-vm0-node-id="vm0-node-1">Draft headline</h1><script type="module">${oldScriptContent}</script></body></html>`,
+        comments: [
+          {
+            id: "comment-1",
+            targetNodeIds: ["vm0-node-1"],
+            comment: "Update the title and runtime state",
+          },
+        ],
+      },
+      [200],
+    );
+
+    expect(generated.body).toStrictEqual({
+      kind: "html-edit-draft",
+      version: 1,
+      html: `<!doctype html><html><body><h1 id="title">Published headline</h1><script type="module">${newScriptContent}</script></body></html>`,
+    });
   });
 });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/host-maps.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/host-maps.bdd.test.ts
@@ -579,6 +579,7 @@ describe("FILE-01: hosted-site deployments through host APIs", () => {
     expect(upstreamPrompt).toContain(
       "do not assume selected DOM is the source of truth",
     );
+    expect(upstreamPrompt).toContain("a DOM-only response is invalid");
     expect(upstreamPrompt).toContain("html-dom-edit-patch");
     expect(upstreamPrompt).toContain('"operation":"update"');
     expect(upstreamPrompt).toContain("color, background, icon");

--- a/turbo/apps/api/src/signals/routes/__tests__/host-maps.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/host-maps.bdd.test.ts
@@ -47,6 +47,13 @@ function sha256Hex(value: string): string {
   return createHash("sha256").update(value).digest("hex");
 }
 
+const HTML_SCRIPT_TAG_NAME = "script";
+
+function scriptTag(content: string, attributes?: string): string {
+  const attributeText = attributes ? ` ${attributes}` : "";
+  return `<${HTML_SCRIPT_TAG_NAME}${attributeText}>${content}</${HTML_SCRIPT_TAG_NAME}>`;
+}
+
 function expectPublicSlugSegment(value: string): void {
   expect(value).toMatch(/^[a-f0-9]{8}$/);
 }
@@ -583,7 +590,7 @@ describe("FILE-01: hosted-site deployments through host APIs", () => {
     expect(upstreamPrompt).toContain("html-dom-edit-patch");
     expect(upstreamPrompt).toContain('"operation":"update"');
     expect(upstreamPrompt).toContain("color, background, icon");
-    expect(upstreamPrompt).toContain("Do not add comment markers");
+    expect(upstreamPrompt).toContain("comment markers");
     expect(upstreamPrompt).toContain("Do not return the complete HTML");
     expect(upstreamPrompt).not.toContain(
       "No target-related script context was found.",
@@ -693,10 +700,10 @@ describe("FILE-01: hosted-site deployments through host APIs", () => {
     ].join("\n");
     const removableScriptContent = 'console.log("remove me");';
     const oldScriptSha = sha256Hex(
-      `<script data-vm0-script-id="vm0-script-1">${oldScriptContent}</script>`,
+      scriptTag(oldScriptContent, 'data-vm0-script-id="vm0-script-1"'),
     );
     const removableScriptSha = sha256Hex(
-      `<script data-vm0-script-id="vm0-script-2">${removableScriptContent}</script>`,
+      scriptTag(removableScriptContent, 'data-vm0-script-id="vm0-script-2"'),
     );
     let upstreamPrompt: string | null = null;
 
@@ -753,7 +760,7 @@ describe("FILE-01: hosted-site deployments through host APIs", () => {
     const generated = await api.requestCreateHtmlEditDraft(
       actor,
       {
-        html: `<!doctype html><html><body><h1 id="title" data-vm0-node-id="vm0-node-1">Draft headline</h1><script>${oldScriptContent}</script><script>${removableScriptContent}</script></body></html>`,
+        html: `<!doctype html><html><body><h1 id="title" data-vm0-node-id="vm0-node-1">Draft headline</h1>${scriptTag(oldScriptContent)}${scriptTag(removableScriptContent)}</body></html>`,
         comments: [
           {
             id: "comment-1",
@@ -778,7 +785,7 @@ describe("FILE-01: hosted-site deployments through host APIs", () => {
     expect(generated.body).toStrictEqual({
       kind: "html-edit-draft",
       version: 1,
-      html: `<!doctype html><html><body><h1 id="title">Published headline</h1><script>${newScriptContent}</script><script>document.documentElement.dataset.edited = "true";</script></body></html>`,
+      html: `<!doctype html><html><body><h1 id="title">Published headline</h1>${scriptTag(newScriptContent)}${scriptTag('document.documentElement.dataset.edited = "true";')}</body></html>`,
     });
     expect(upstreamPrompt).toContain("scriptId: vm0-script-1");
     expect(upstreamPrompt).toContain(`oldSha256: ${oldScriptSha}`);
@@ -806,7 +813,7 @@ describe("FILE-01: hosted-site deployments through host APIs", () => {
       'document.getElementById("title").textContent = state.title;',
     ].join("\n");
     const oldScriptSha = sha256Hex(
-      `<script data-vm0-script-id="vm0-script-1">${oldScriptContent}</script>`,
+      scriptTag(oldScriptContent, 'data-vm0-script-id="vm0-script-1"'),
     );
     const largeFiller = `<section>${"large-filler ".repeat(6000)}</section>`;
     let upstreamPrompt: string | null = null;
@@ -852,7 +859,7 @@ describe("FILE-01: hosted-site deployments through host APIs", () => {
     const generated = await api.requestCreateHtmlEditDraft(
       actor,
       {
-        html: `<!doctype html><html><body><h1 id="title" data-vm0-node-id="vm0-node-1">Draft headline</h1>${largeFiller}<script>${oldScriptContent}</script></body></html>`,
+        html: `<!doctype html><html><body><h1 id="title" data-vm0-node-id="vm0-node-1">Draft headline</h1>${largeFiller}${scriptTag(oldScriptContent)}</body></html>`,
         comments: [
           {
             id: "comment-1",
@@ -931,7 +938,7 @@ describe("FILE-01: hosted-site deployments through host APIs", () => {
     expect(generated.body).toStrictEqual({
       kind: "html-edit-draft",
       version: 1,
-      html: '<!doctype html><html><body><h1>Launch</h1><script>fetch("/collect");</script></body></html>',
+      html: `<!doctype html><html><body><h1>Launch</h1>${scriptTag('fetch("/collect");')}</body></html>`,
     });
   });
 
@@ -944,7 +951,7 @@ describe("FILE-01: hosted-site deployments through host APIs", () => {
     const oldScriptContent =
       'fetch("/old-endpoint");\nconst title = "Draft headline";';
     const oldScriptSha = sha256Hex(
-      `<script data-vm0-script-id="vm0-script-1">${oldScriptContent}</script>`,
+      scriptTag(oldScriptContent, 'data-vm0-script-id="vm0-script-1"'),
     );
 
     server.use(
@@ -978,7 +985,7 @@ describe("FILE-01: hosted-site deployments through host APIs", () => {
     const generated = await api.requestCreateHtmlEditDraft(
       actor,
       {
-        html: `<!doctype html><html><body><h1 data-vm0-node-id="vm0-node-1">Draft headline</h1><script>${oldScriptContent}</script></body></html>`,
+        html: `<!doctype html><html><body><h1 data-vm0-node-id="vm0-node-1">Draft headline</h1>${scriptTag(oldScriptContent)}</body></html>`,
         comments: [
           {
             id: "comment-1",
@@ -993,7 +1000,7 @@ describe("FILE-01: hosted-site deployments through host APIs", () => {
     expect(generated.body).toStrictEqual({
       kind: "html-edit-draft",
       version: 1,
-      html: '<!doctype html><html><body><h1>Draft headline</h1><script>fetch("/collect");\nconst title = "Published headline";</script></body></html>',
+      html: `<!doctype html><html><body><h1>Draft headline</h1>${scriptTag('fetch("/collect");\nconst title = "Published headline";')}</body></html>`,
     });
   });
 
@@ -1005,7 +1012,10 @@ describe("FILE-01: hosted-site deployments through host APIs", () => {
 
     const importScriptContent = 'const title = "Draft headline";';
     const importScriptSha = sha256Hex(
-      `<script type="module" data-vm0-script-id="vm0-script-1">${importScriptContent}</script>`,
+      scriptTag(
+        importScriptContent,
+        'type="module" data-vm0-script-id="vm0-script-1"',
+      ),
     );
 
     server.use(
@@ -1039,7 +1049,7 @@ describe("FILE-01: hosted-site deployments through host APIs", () => {
     const importGenerated = await api.requestCreateHtmlEditDraft(
       actor,
       {
-        html: `<!doctype html><html><body><h1 data-vm0-node-id="vm0-node-1">Draft headline</h1><script type="module">${importScriptContent}</script></body></html>`,
+        html: `<!doctype html><html><body><h1 data-vm0-node-id="vm0-node-1">Draft headline</h1>${scriptTag(importScriptContent, 'type="module"')}</body></html>`,
         comments: [
           {
             id: "comment-1",
@@ -1054,12 +1064,15 @@ describe("FILE-01: hosted-site deployments through host APIs", () => {
     expect(importGenerated.body).toStrictEqual({
       kind: "html-edit-draft",
       version: 1,
-      html: '<!doctype html><html><body><h1>Draft headline</h1><script type="module">import tracker from "/tracker.js";\nconst title = "Published headline";\ntracker();</script></body></html>',
+      html: `<!doctype html><html><body><h1>Draft headline</h1>${scriptTag('import tracker from "/tracker.js";\nconst title = "Published headline";\ntracker();', 'type="module"')}</body></html>`,
     });
 
     const fetchScriptContent = 'const title = "Draft headline";';
     const fetchScriptSha = sha256Hex(
-      `<script type="text/javascript; charset=utf-8" data-vm0-script-id="vm0-script-1">${fetchScriptContent}</script>`,
+      scriptTag(
+        fetchScriptContent,
+        'type="text/javascript; charset=utf-8" data-vm0-script-id="vm0-script-1"',
+      ),
     );
 
     server.use(
@@ -1093,7 +1106,7 @@ describe("FILE-01: hosted-site deployments through host APIs", () => {
     const fetchGenerated = await api.requestCreateHtmlEditDraft(
       actor,
       {
-        html: `<!doctype html><html><body><h1 data-vm0-node-id="vm0-node-1">Draft headline</h1><script type="text/javascript; charset=utf-8">${fetchScriptContent}</script></body></html>`,
+        html: `<!doctype html><html><body><h1 data-vm0-node-id="vm0-node-1">Draft headline</h1>${scriptTag(fetchScriptContent, 'type="text/javascript; charset=utf-8"')}</body></html>`,
         comments: [
           {
             id: "comment-1",
@@ -1108,7 +1121,7 @@ describe("FILE-01: hosted-site deployments through host APIs", () => {
     expect(fetchGenerated.body).toStrictEqual({
       kind: "html-edit-draft",
       version: 1,
-      html: '<!doctype html><html><body><h1>Draft headline</h1><script type="text/javascript; charset=utf-8">const title = "Published headline";\nfetch("/collect");</script></body></html>',
+      html: `<!doctype html><html><body><h1>Draft headline</h1>${scriptTag('const title = "Published headline";\nfetch("/collect");', 'type="text/javascript; charset=utf-8"')}</body></html>`,
     });
   });
 
@@ -1133,7 +1146,7 @@ describe("FILE-01: hosted-site deployments through host APIs", () => {
                       commentId: "comment-1",
                       operation: "script_add",
                       placement: "end_of_body",
-                      content: '</script><img src=x alt="">',
+                      content: `</${HTML_SCRIPT_TAG_NAME}><img src=x alt="">`,
                     },
                   ],
                 }),
@@ -1171,20 +1184,21 @@ describe("FILE-01: hosted-site deployments through host APIs", () => {
     const actor = bdd.user();
     mockOptionalEnv("OPENROUTER_API_KEY", "bdd-html-edit-key");
 
+    const scriptLikeTemplate = `const template = "<${HTML_SCRIPT_TAG_NAME} data-demo=\\"x\\">";`;
     const oldScriptContent = [
-      String.raw`const template = "<script data-demo=\"x\">";`,
+      scriptLikeTemplate,
       'const priority = "important draft";',
       'const state = { title: "Draft headline" };',
       'document.getElementById("title").textContent = state.title;',
     ].join("\n");
     const newScriptContent = [
-      String.raw`const template = "<script data-demo=\"x\">";`,
+      scriptLikeTemplate,
       'const priority = "important published";',
       'const state = { title: "Published headline" };',
       'document.getElementById("title").textContent = state.title;',
     ].join("\n");
     const oldScriptSha = sha256Hex(
-      `<script data-vm0-script-id="vm0-script-1">${oldScriptContent}</script>`,
+      scriptTag(oldScriptContent, 'data-vm0-script-id="vm0-script-1"'),
     );
 
     server.use(
@@ -1223,7 +1237,7 @@ describe("FILE-01: hosted-site deployments through host APIs", () => {
     const generated = await api.requestCreateHtmlEditDraft(
       actor,
       {
-        html: `<!doctype html><html><body><h1 id="title" data-vm0-node-id="vm0-node-1">Draft headline</h1><script>${oldScriptContent}</script></body></html>`,
+        html: `<!doctype html><html><body><h1 id="title" data-vm0-node-id="vm0-node-1">Draft headline</h1>${scriptTag(oldScriptContent)}</body></html>`,
         comments: [
           {
             id: "comment-1",
@@ -1238,7 +1252,7 @@ describe("FILE-01: hosted-site deployments through host APIs", () => {
     expect(generated.body).toStrictEqual({
       kind: "html-edit-draft",
       version: 1,
-      html: `<!doctype html><html><body><h1 id="title">Published headline</h1><script>${newScriptContent}</script></body></html>`,
+      html: `<!doctype html><html><body><h1 id="title">Published headline</h1>${scriptTag(newScriptContent)}</body></html>`,
     });
   });
 
@@ -1261,7 +1275,10 @@ describe("FILE-01: hosted-site deployments through host APIs", () => {
       "tracker.ready();",
     ].join("\n");
     const oldScriptSha = sha256Hex(
-      `<script type="module" data-vm0-script-id="vm0-script-1">${oldScriptContent}</script>`,
+      scriptTag(
+        oldScriptContent,
+        'type="module" data-vm0-script-id="vm0-script-1"',
+      ),
     );
 
     server.use(
@@ -1300,7 +1317,7 @@ describe("FILE-01: hosted-site deployments through host APIs", () => {
     const generated = await api.requestCreateHtmlEditDraft(
       actor,
       {
-        html: `<!doctype html><html><body><h1 id="title" data-vm0-node-id="vm0-node-1">Draft headline</h1><script type="module">${oldScriptContent}</script></body></html>`,
+        html: `<!doctype html><html><body><h1 id="title" data-vm0-node-id="vm0-node-1">Draft headline</h1>${scriptTag(oldScriptContent, 'type="module"')}</body></html>`,
         comments: [
           {
             id: "comment-1",
@@ -1315,7 +1332,7 @@ describe("FILE-01: hosted-site deployments through host APIs", () => {
     expect(generated.body).toStrictEqual({
       kind: "html-edit-draft",
       version: 1,
-      html: `<!doctype html><html><body><h1 id="title">Published headline</h1><script type="module">${newScriptContent}</script></body></html>`,
+      html: `<!doctype html><html><body><h1 id="title">Published headline</h1>${scriptTag(newScriptContent, 'type="module"')}</body></html>`,
     });
   });
 });

--- a/turbo/apps/api/src/signals/services/zero-host.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-host.service.ts
@@ -45,7 +45,17 @@ const MAX_PUBLIC_SLUG_ATTEMPTS = 5;
 const PRESENTATION_SPEAKER_NOTES_MODEL = "openai/gpt-4.1-mini";
 const HTML_DOM_EDIT_MODEL = "openai/gpt-4.1-mini";
 const HTML_DOM_NODE_ID_ATTR = "data-vm0-node-id";
+const HTML_DOM_SCRIPT_ID_ATTR = "data-vm0-script-id";
+const DEFAULT_SCRIPT_ID_PREFIX = "vm0-script";
 const MAX_HTML_EDIT_SNAPSHOT_BYTES = 5 * 1024 * 1024;
+const MAX_HTML_DOM_EDIT_PROMPT_HTML_CHARS = 60_000;
+const MAX_HTML_DOM_EDIT_TARGET_CONTEXTS = 10;
+const MAX_HTML_DOM_EDIT_TARGET_OUTER_HTML_CHARS = 1500;
+const MAX_HTML_DOM_EDIT_TARGET_TEXT_CHARS = 400;
+const MAX_HTML_DOM_EDIT_SCRIPT_CONTEXTS_PER_TARGET = 2;
+const MAX_HTML_DOM_EDIT_SCRIPT_SNIPPETS_PER_TARGET = 2;
+const MAX_HTML_DOM_EDIT_SCRIPT_SNIPPET_CHARS = 500;
+const SHA256_HEX_PATTERN = /^[a-f0-9]{64}$/;
 
 const htmlDomEditPatchSchema = z.discriminatedUnion("operation", [
   z.object({
@@ -66,6 +76,33 @@ const htmlDomEditPatchSchema = z.discriminatedUnion("operation", [
     targetNodeId: z.string().min(1),
     operation: z.literal("remove"),
   }),
+  z.object({
+    commentId: z.string().min(1),
+    scriptId: z.string().min(1),
+    oldSha256: z.string().regex(SHA256_HEX_PATTERN),
+    operation: z.literal("script_update"),
+    content: z.string(),
+  }),
+  z.object({
+    commentId: z.string().min(1),
+    scriptId: z.string().min(1),
+    oldSha256: z.string().regex(SHA256_HEX_PATTERN),
+    operation: z.literal("script_text_replace"),
+    oldText: z.string().min(1),
+    newText: z.string(),
+  }),
+  z.object({
+    commentId: z.string().min(1),
+    placement: z.literal("end_of_body"),
+    operation: z.literal("script_add"),
+    content: z.string().min(1),
+  }),
+  z.object({
+    commentId: z.string().min(1),
+    scriptId: z.string().min(1),
+    oldSha256: z.string().regex(SHA256_HEX_PATTERN),
+    operation: z.literal("script_delete"),
+  }),
 ]);
 
 const htmlDomEditPatchResultSchema = z.object({
@@ -76,6 +113,20 @@ const htmlDomEditPatchResultSchema = z.object({
 
 type HtmlDomEditPatch = z.infer<typeof htmlDomEditPatchSchema>;
 type HtmlDomEditPatchResult = z.infer<typeof htmlDomEditPatchResultSchema>;
+type HtmlDomEditDomPatch = Extract<
+  HtmlDomEditPatch,
+  { readonly operation: "insert" | "remove" | "update" }
+>;
+type HtmlDomEditScriptPatch = Extract<
+  HtmlDomEditPatch,
+  {
+    readonly operation:
+      | "script_add"
+      | "script_delete"
+      | "script_text_replace"
+      | "script_update";
+  }
+>;
 
 interface HtmlElementSpan {
   readonly start: number;
@@ -83,6 +134,34 @@ interface HtmlElementSpan {
   readonly closeTagStart: number | null;
   readonly end: number;
   readonly tagName: string;
+}
+
+interface HtmlDomEditScriptInfo {
+  readonly hasSrc: boolean;
+  readonly inline: boolean;
+  readonly oldSha256: string;
+  readonly scriptId: string;
+}
+
+interface HtmlDomEditRelatedScriptContext {
+  readonly matchedTerms: readonly string[];
+  readonly oldSha256: string;
+  readonly scriptId: string;
+  readonly snippets: readonly string[];
+}
+
+interface HtmlDomEditTargetContext {
+  readonly commentId: string;
+  readonly relatedScripts: readonly HtmlDomEditRelatedScriptContext[];
+  readonly searchTerms: readonly string[];
+  readonly targetNodeId: string;
+  readonly targetOuterHTML: string;
+  readonly targetTextContent?: string;
+}
+
+interface HtmlDomEditPromptHtmlContext {
+  readonly focused: boolean;
+  readonly html: string;
 }
 
 interface PrepareDeploymentArgs {
@@ -127,6 +206,10 @@ interface CreateHtmlEditDraftArgs {
 interface HtmlEditDraftDocument {
   readonly comments: CreateHtmlEditDraftRequest["comments"];
   readonly html: string;
+  readonly promptHtml?: string;
+  readonly promptHtmlIsFocused?: boolean;
+  readonly scripts?: readonly HtmlDomEditScriptInfo[];
+  readonly targetContexts?: readonly HtmlDomEditTargetContext[];
 }
 
 interface GetHostedSiteFilesArgs {
@@ -299,11 +382,10 @@ ${html}`,
   ];
 }
 
-function htmlDomEditPrompt(body: HtmlEditDraftDocument): readonly {
-  readonly role: "system" | "user";
-  readonly content: string;
-}[] {
-  const comments = body.comments
+function htmlDomEditPromptComments(
+  comments: CreateHtmlEditDraftRequest["comments"],
+): string {
+  return comments
     .map((comment, index) => {
       return [
         `${index + 1}. Comment ID: ${comment.id}`,
@@ -312,21 +394,162 @@ function htmlDomEditPrompt(body: HtmlEditDraftDocument): readonly {
       ].join("\n");
     })
     .join("\n\n");
+}
+
+function htmlDomEditPromptScripts(
+  scripts: readonly HtmlDomEditScriptInfo[] | undefined,
+): string {
+  return scripts && scripts.length > 0
+    ? scripts
+        .map((script, index) => {
+          return [
+            `${index + 1}. scriptId: ${script.scriptId}`,
+            `   oldSha256: ${script.oldSha256}`,
+            `   inline: ${script.inline ? "true" : "false"}`,
+            `   hasSrc: ${script.hasSrc ? "true" : "false"}`,
+          ].join("\n");
+        })
+        .join("\n\n")
+    : "No editable inline scripts were found.";
+}
+
+function htmlDomEditPromptRelatedScripts(
+  scripts: readonly HtmlDomEditRelatedScriptContext[],
+): string {
+  return scripts
+    .map((script) => {
+      return [
+        `   - scriptId: ${script.scriptId}`,
+        `     oldSha256: ${script.oldSha256}`,
+        `     matchedTerms: ${script.matchedTerms.join(", ")}`,
+        "     snippets:",
+        ...script.snippets.map((snippet) => {
+          return `       ${snippet}`;
+        }),
+      ].join("\n");
+    })
+    .join("\n");
+}
+
+function htmlDomEditPromptTargetContexts(
+  contexts: readonly HtmlDomEditTargetContext[] | undefined,
+): string | null {
+  const scriptContexts = contexts?.filter((context) => {
+    return context.relatedScripts.length > 0;
+  });
+  if (!scriptContexts || scriptContexts.length === 0) {
+    return null;
+  }
+  return scriptContexts
+    .map((context, index) => {
+      return [
+        `${index + 1}. Comment ID: ${context.commentId}`,
+        `   Target node ID: ${context.targetNodeId}`,
+        `   Target outerHTML: ${context.targetOuterHTML}`,
+        context.targetTextContent
+          ? `   Target textContent: ${context.targetTextContent}`
+          : null,
+        context.searchTerms.length > 0
+          ? `   Target search terms: ${context.searchTerms.join(", ")}`
+          : null,
+        "   Related script snippets:",
+        htmlDomEditPromptRelatedScripts(context.relatedScripts),
+      ]
+        .filter((line) => {
+          return line !== null;
+        })
+        .join("\n");
+    })
+    .join("\n\n");
+}
+
+function htmlDomEditPromptFocusedContext(
+  contexts: readonly HtmlDomEditTargetContext[] | undefined,
+): string | null {
+  if (!contexts || contexts.length === 0) {
+    return null;
+  }
+  return contexts
+    .map((context, index) => {
+      return [
+        `${index + 1}. Comment ID: ${context.commentId}`,
+        `   Target node ID: ${context.targetNodeId}`,
+        `   Target outerHTML: ${context.targetOuterHTML}`,
+        context.targetTextContent
+          ? `   Target textContent: ${context.targetTextContent}`
+          : null,
+        context.searchTerms.length > 0
+          ? `   Target search terms: ${context.searchTerms.join(", ")}`
+          : null,
+        context.relatedScripts.length > 0
+          ? [
+              "   Related script snippets:",
+              htmlDomEditPromptRelatedScripts(context.relatedScripts),
+            ].join("\n")
+          : null,
+      ]
+        .filter((line) => {
+          return line !== null;
+        })
+        .join("\n");
+    })
+    .join("\n\n");
+}
+
+function htmlDomEditPromptHtml(body: HtmlEditDraftDocument): string {
+  if (!body.promptHtmlIsFocused) {
+    return body.promptHtml ?? body.html;
+  }
+  return [
+    "Focused HTML context for the selected targets. This is not the complete document.",
+    "Use targetNodeId and scriptId values from this context; patches will be applied to the complete document.",
+    "",
+    body.promptHtml ?? "",
+  ].join("\n");
+}
+
+function htmlDomEditPromptHtmlContext(params: {
+  readonly html: string;
+  readonly targetContexts: readonly HtmlDomEditTargetContext[];
+}): HtmlDomEditPromptHtmlContext {
+  if (params.html.length <= MAX_HTML_DOM_EDIT_PROMPT_HTML_CHARS) {
+    return { focused: false, html: params.html };
+  }
+  const focusedContext = htmlDomEditPromptFocusedContext(params.targetContexts);
+  if (!focusedContext) {
+    return { focused: false, html: params.html };
+  }
+  return { focused: true, html: focusedContext };
+}
+
+function htmlDomEditPrompt(body: HtmlEditDraftDocument): readonly {
+  readonly role: "system" | "user";
+  readonly content: string;
+}[] {
+  const comments = htmlDomEditPromptComments(body.comments);
+  const scripts = htmlDomEditPromptScripts(body.scripts);
+  const targetContexts = htmlDomEditPromptTargetContexts(body.targetContexts);
+  const targetContextSection = targetContexts
+    ? `\n\nTarget-script context:\n${targetContexts}`
+    : "";
+  const html = htmlDomEditPromptHtml(body);
 
   return [
     {
       role: "system",
       content:
-        "You edit the user's own HTML document by returning compact DOM patches. Return valid JSON matching the requested schema. Do not deploy, publish, host, upload, or describe commands. Preserve existing scripts, styles, assets, layout, and language unless a comment asks for a change.",
+        "You edit the user's own HTML document by returning compact DOM and inline script patches. Return valid JSON matching the requested schema. Do not deploy, publish, host, upload, or describe commands. Preserve existing scripts, styles, assets, layout, and language unless a comment asks for a change.",
     },
     {
       role: "user",
-      content: `Create DOM patches for these comments on the existing HTML document.
+      content: `Create patches for these comments on the existing HTML document.
 
 Output:
 - Return only JSON.
 - Output shape: {"kind":"html-dom-edit-patch","version":1,"patches":[...]}.
-- Each patch must include commentId, targetNodeId, operation, and the operation-specific field.
+- Each patch must include commentId, operation, and the operation-specific fields.
+- DOM patch operations must include targetNodeId.
+- Script patch operations must include scriptId and oldSha256 except script_add.
 - Supported operations:
   - {"operation":"update","outerHTML":"<tag>...</tag>"} replaces the target DOM node with the updated DOM node.
   - {"operation":"insert","position":"before","html":"..."} inserts HTML before the target element.
@@ -334,16 +557,40 @@ Output:
   - {"operation":"insert","position":"append_child","html":"..."} appends HTML inside the target element.
   - {"operation":"insert","position":"prepend_child","html":"..."} prepends HTML inside the target element.
   - {"operation":"remove"} removes the target element.
-- Use update for any change to an existing DOM node, including text, color, background, icon, attributes, classes, or nested markup.
+  - {"operation":"script_update","scriptId":"...","oldSha256":"...","content":"..."} replaces the complete body of an existing inline script.
+  - {"operation":"script_text_replace","scriptId":"...","oldSha256":"...","oldText":"...","newText":"..."} replaces one exact text occurrence inside an existing inline script.
+  - {"operation":"script_delete","scriptId":"...","oldSha256":"..."} removes an existing script.
+  - {"operation":"script_add","placement":"end_of_body","content":"..."} inserts a new inline script immediately before </body>.
+- Treat target node IDs as intent anchors, not edit boundaries.
+- Before choosing patches, inspect the HTML section and the Scripts section to determine the source of truth for each requested change.
+- Use DOM update for static DOM changes, including text, color, background, icon, attributes, classes, or nested markup.
 - For update, keep the same tag when possible and include all attributes and children that should remain.
-- Prefer the smallest target node that satisfies the comment.
+- Prefer the smallest DOM target that satisfies the comment when the change belongs in DOM.
+- Return DOM-only patches only when page scripts do not control, derive, render, or overwrite the requested visible change.
+- If an inline script controls, derives, renders, or overwrites the targeted content or behavior, a DOM-only patch is incomplete; update the script's backing data or source so the requested change survives script execution.
+- When script data/source is the source of truth for selected visible content, keep any corresponding static DOM fallback synchronized with the same final user-facing value. Do not leave the fallback in the old language or a different paraphrase.
+- If the same requested user-facing text appears in both DOM fallback and script backing data, update both to the same final text unless the comment explicitly asks for different values.
+- Check whether scripts reference target ids, classes, data attributes, selectors, rendered data objects, render functions, reset handlers, or event handlers related to the selected nodes.
+- Use script_update when an existing inline script is the backing source for the requested change.
+- Prefer script_text_replace for small script text or data changes, especially when the HTML section is focused context instead of the complete document.
+- Use script_delete only when a comment asks to remove script behavior.
+- Use script_add only when the requested behavior cannot be represented by updating existing DOM or inline script.
+- For script_update, preserve the existing script structure and behavior. Make the smallest data, text, or configuration change needed for the comment, and do not rewrite unrelated functions, control flow, event handlers, timers, or state.
+- For script_text_replace, oldText must be copied exactly from the HTML section or Target-script context, and it must uniquely identify the intended script text.
+- For script_update and script_add, content must be the script body only. Do not include <script> tags.
+- For script_update, script_text_replace, and script_delete, copy the exact scriptId and oldSha256 from the Scripts section.
+- Do not introduce unrelated side effects, network calls, imports, globals, timers, or script element creation unless the requested change specifically requires them.
 - Do not return the complete HTML document.
-- Do not include vm0-only editing attributes such as data-vm0-node-id or data-vm0-html-edit-* in returned HTML fragments.
+- Do not include vm0-only editing attributes such as data-vm0-node-id, data-vm0-script-id, or data-vm0-html-edit-* in returned HTML fragments.
 - Do not add comment markers, overlays, annotations, explanations, or deployment commands.
 - Do not add script tags in new HTML fragments.
 
 Editing rules:
 - Use the target node IDs to locate the intended elements in the HTML.
+- The HTML section contains either the current DOM snapshot or focused target context, and the Scripts section lists the document's scripts. Do not assume the selected DOM node is the source of truth.
+- Before choosing patches, inspect the HTML section, Scripts section, and any Target-script context to determine whether the requested change belongs in static DOM, script data, or script behavior.
+- Target-script context, when present, is derived from the same HTML by matching selected target ids, classes, attributes, and text against inline scripts. Use it as a navigation aid for source-of-truth analysis.
+- If Target-script context shows script snippets that reference the selected target or its visible text, inspect those scripts carefully. If a script renders, derives, resets, or overwrites the selected visible content, update the script or backing data that produces that content. A DOM-only patch is incomplete in that case.
 - Apply every requested change exactly once.
 - Keep unrelated content and formatting as stable as practical.
 - Preserve relative and absolute asset URLs.
@@ -352,8 +599,11 @@ Editing rules:
 Comments:
 ${comments}
 
+Scripts:
+${scripts}${targetContextSection}
+
 HTML:
-${body.html}`,
+${html}`,
     },
   ];
 }
@@ -632,6 +882,31 @@ function startTagAttributeValue(
   return null;
 }
 
+function escapeHtmlAttribute(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function insertStartTagAttribute(
+  tagSource: string,
+  attributeName: string,
+  attributeValue: string,
+): string {
+  const insertionIndex = tagSource.endsWith("/>")
+    ? tagSource.length - 2
+    : tagSource.length - 1;
+  return `${tagSource.slice(0, insertionIndex)} ${attributeName}="${escapeHtmlAttribute(
+    attributeValue,
+  )}"${tagSource.slice(insertionIndex)}`;
+}
+
+function sha256Hex(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
 function findStartTagWithAttributeValue(
   html: string,
   attributeName: string,
@@ -699,18 +974,10 @@ function findNextTagByName(
   return null;
 }
 
-function findHtmlElementSpan(
+function htmlElementSpanFromStartTag(
   html: string,
-  targetNodeId: string,
+  startTag: HtmlTagMatch,
 ): HtmlElementSpan | null {
-  const startTag = findStartTagWithAttributeValue(
-    html,
-    HTML_DOM_NODE_ID_ATTR,
-    targetNodeId,
-  );
-  if (!startTag) {
-    return null;
-  }
   if (
     isVoidElement(startTag.tagName) ||
     isSelfClosingStartTag(startTag.source)
@@ -750,6 +1017,334 @@ function findHtmlElementSpan(
   return null;
 }
 
+function htmlScriptRawTextElementSpanFromStartTag(
+  html: string,
+  startTag: HtmlTagMatch,
+): HtmlElementSpan | null {
+  if (isSelfClosingStartTag(startTag.source)) {
+    return {
+      start: startTag.start,
+      startTagEnd: startTag.end,
+      closeTagStart: null,
+      end: startTag.end + 1,
+      tagName: startTag.tagName,
+    };
+  }
+
+  const closeTagPattern = /<\/\s*script\s*>/gi;
+  closeTagPattern.lastIndex = startTag.end + 1;
+  const closeTagMatch = closeTagPattern.exec(html);
+  if (!closeTagMatch) {
+    return null;
+  }
+  return {
+    start: startTag.start,
+    startTagEnd: startTag.end,
+    closeTagStart: closeTagMatch.index,
+    end: closeTagMatch.index + closeTagMatch[0].length,
+    tagName: startTag.tagName,
+  };
+}
+
+function htmlScriptElementSpanFromStartTag(
+  html: string,
+  startTag: HtmlTagMatch,
+): HtmlElementSpan | null {
+  return htmlScriptRawTextElementSpanFromStartTag(html, startTag);
+}
+
+function findHtmlElementSpanByAttribute(
+  html: string,
+  params: {
+    readonly attributeName: string;
+    readonly attributeValue: string;
+    readonly tagName?: string;
+  },
+): HtmlElementSpan | null {
+  const startTag = findStartTagWithAttributeValue(
+    html,
+    params.attributeName,
+    params.attributeValue,
+  );
+  if (!startTag) {
+    return null;
+  }
+  if (params.tagName && startTag.tagName.toLowerCase() !== params.tagName) {
+    return null;
+  }
+  if (startTag.tagName.toLowerCase() === "script") {
+    return htmlScriptElementSpanFromStartTag(html, startTag);
+  }
+  return htmlElementSpanFromStartTag(html, startTag);
+}
+
+function findHtmlElementSpan(
+  html: string,
+  targetNodeId: string,
+): HtmlElementSpan | null {
+  return findHtmlElementSpanByAttribute(html, {
+    attributeName: HTML_DOM_NODE_ID_ATTR,
+    attributeValue: targetNodeId,
+  });
+}
+
+function findScriptElementSpan(
+  html: string,
+  scriptId: string,
+): HtmlElementSpan | null {
+  return findHtmlElementSpanByAttribute(html, {
+    attributeName: HTML_DOM_SCRIPT_ID_ATTR,
+    attributeValue: scriptId,
+    tagName: "script",
+  });
+}
+
+function stripHtmlDomEditScriptAttributes(html: string): string {
+  return html.replace(
+    /\s+data-vm0-script-id(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+))?/g,
+    "",
+  );
+}
+
+function clipped(value: string, maxLength: number): string {
+  return value.length > maxLength ? value.slice(0, maxLength) : value;
+}
+
+function decodeBasicHtmlEntities(value: string): string {
+  return value
+    .replaceAll("&nbsp;", " ")
+    .replaceAll("&amp;", "&")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&quot;", '"')
+    .replaceAll("&#39;", "'");
+}
+
+function normalizedHtmlText(html: string): string {
+  return decodeBasicHtmlEntities(
+    html
+      .replace(/<\s*(script|style)\b[\s\S]*?<\s*\/\s*\1\s*>/gi, " ")
+      .replace(/<[^>]*>/g, " "),
+  )
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function attributeValuesFromStartTag(
+  startTagSource: string,
+): readonly string[] {
+  const values: string[] = [];
+  const attributePattern =
+    /\s([^\s"'<>/=]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+)))?/g;
+  let match: RegExpExecArray | null;
+  while ((match = attributePattern.exec(startTagSource))) {
+    const name = match[1]?.toLowerCase();
+    const value = match[2] ?? match[3] ?? match[4];
+    if (!name || !value || name.startsWith("data-vm0-") || name === "style") {
+      continue;
+    }
+    if (name === "class") {
+      values.push(...value.split(/\s+/));
+      continue;
+    }
+    values.push(value);
+  }
+  return values;
+}
+
+function addUniqueSearchTerm(terms: string[], value: string): void {
+  const normalized = value.trim();
+  if (normalized.length < 2 || normalized.length > 180) {
+    return;
+  }
+  if (!terms.includes(normalized)) {
+    terms.push(normalized);
+  }
+}
+
+function targetSearchTerms(params: {
+  readonly startTagSource: string;
+  readonly targetTextContent?: string;
+}): readonly string[] {
+  const terms: string[] = [];
+  for (const value of attributeValuesFromStartTag(params.startTagSource)) {
+    addUniqueSearchTerm(terms, value);
+  }
+  if (params.targetTextContent) {
+    addUniqueSearchTerm(terms, params.targetTextContent);
+  }
+  return terms;
+}
+
+function scriptBodyFromSpan(
+  html: string,
+  span: HtmlElementSpan,
+): string | null {
+  if (span.closeTagStart === null) {
+    return null;
+  }
+  return html.slice(span.startTagEnd + 1, span.closeTagStart);
+}
+
+function scriptSnippetAround(content: string, index: number): string {
+  const halfLength = Math.floor(MAX_HTML_DOM_EDIT_SCRIPT_SNIPPET_CHARS / 2);
+  const start = Math.max(0, index - halfLength);
+  const end = Math.min(content.length, index + halfLength);
+  const prefix = start > 0 ? "..." : "";
+  const suffix = end < content.length ? "..." : "";
+  return `${prefix}${content.slice(start, end)}${suffix}`;
+}
+
+function relatedScriptContextForTerms(params: {
+  readonly html: string;
+  readonly script: HtmlDomEditScriptInfo;
+  readonly searchTerms: readonly string[];
+}): HtmlDomEditRelatedScriptContext | null {
+  if (!params.script.inline || params.script.hasSrc) {
+    return null;
+  }
+  const span = findScriptElementSpan(params.html, params.script.scriptId);
+  if (!span) {
+    return null;
+  }
+  const content = scriptBodyFromSpan(params.html, span);
+  if (content === null) {
+    return null;
+  }
+
+  const matchedTerms: string[] = [];
+  const snippets: string[] = [];
+  for (const term of params.searchTerms) {
+    const index = content.indexOf(term);
+    if (index === -1) {
+      continue;
+    }
+    matchedTerms.push(term);
+    if (snippets.length < MAX_HTML_DOM_EDIT_SCRIPT_SNIPPETS_PER_TARGET) {
+      snippets.push(scriptSnippetAround(content, index));
+    }
+  }
+  if (matchedTerms.length === 0) {
+    return null;
+  }
+  return {
+    matchedTerms,
+    oldSha256: params.script.oldSha256,
+    scriptId: params.script.scriptId,
+    snippets,
+  };
+}
+
+function htmlDomEditTargetContexts(params: {
+  readonly comments: CreateHtmlEditDraftRequest["comments"];
+  readonly html: string;
+  readonly scripts: readonly HtmlDomEditScriptInfo[];
+}): readonly HtmlDomEditTargetContext[] {
+  const contexts: HtmlDomEditTargetContext[] = [];
+  for (const comment of params.comments) {
+    for (const targetNodeId of comment.targetNodeIds) {
+      if (contexts.length >= MAX_HTML_DOM_EDIT_TARGET_CONTEXTS) {
+        return contexts;
+      }
+      const span = findHtmlElementSpan(params.html, targetNodeId);
+      if (!span) {
+        continue;
+      }
+      const targetOuterHTML = htmlSpanSource(params.html, span);
+      const targetTextContent = normalizedHtmlText(targetOuterHTML);
+      const searchTerms = targetSearchTerms({
+        startTagSource: params.html.slice(span.start, span.startTagEnd + 1),
+        targetTextContent,
+      });
+      const relatedScripts = params.scripts
+        .map((script) => {
+          return relatedScriptContextForTerms({
+            html: params.html,
+            script,
+            searchTerms,
+          });
+        })
+        .filter((script): script is HtmlDomEditRelatedScriptContext => {
+          return script !== null;
+        })
+        .slice(0, MAX_HTML_DOM_EDIT_SCRIPT_CONTEXTS_PER_TARGET);
+
+      contexts.push({
+        commentId: comment.id,
+        relatedScripts,
+        searchTerms,
+        targetNodeId,
+        targetOuterHTML: clipped(
+          targetOuterHTML,
+          MAX_HTML_DOM_EDIT_TARGET_OUTER_HTML_CHARS,
+        ),
+        ...(targetTextContent
+          ? {
+              targetTextContent: clipped(
+                targetTextContent,
+                MAX_HTML_DOM_EDIT_TARGET_TEXT_CHARS,
+              ),
+            }
+          : {}),
+      });
+    }
+  }
+  return contexts;
+}
+
+function instrumentHtmlDomEditScripts(html: string): {
+  readonly html: string;
+  readonly scripts: readonly HtmlDomEditScriptInfo[];
+} {
+  const source = stripHtmlDomEditScriptAttributes(html);
+  const scripts: HtmlDomEditScriptInfo[] = [];
+  let nextId = 1;
+  let output = "";
+  let cursor = 0;
+  let searchStart = 0;
+
+  while (searchStart < source.length) {
+    const startTag = findNextTagByName(source, "script", searchStart);
+    if (!startTag) {
+      break;
+    }
+    if (startTag.isClosing) {
+      searchStart = startTag.end + 1;
+      continue;
+    }
+
+    const span = htmlScriptElementSpanFromStartTag(source, startTag);
+    if (!span) {
+      break;
+    }
+
+    const scriptId = `${DEFAULT_SCRIPT_ID_PREFIX}-${nextId}`;
+    nextId += 1;
+    const startTagWithId = insertStartTagAttribute(
+      startTag.source,
+      HTML_DOM_SCRIPT_ID_ATTR,
+      scriptId,
+    );
+    const restOfScript = source.slice(startTag.end + 1, span.end);
+    const scriptSource = `${startTagWithId}${restOfScript}`;
+
+    output += source.slice(cursor, startTag.start);
+    output += scriptSource;
+    scripts.push({
+      hasSrc: startTagAttributeValue(startTag.source, "src") !== null,
+      inline: startTagAttributeValue(startTag.source, "src") === null,
+      oldSha256: sha256Hex(scriptSource),
+      scriptId,
+    });
+
+    cursor = span.end;
+    searchStart = span.end;
+  }
+
+  output += source.slice(cursor);
+  return { html: output, scripts };
+}
+
 function assertSafeHtmlFragment(html: string): string | null {
   if (/<\s*script\b/i.test(html)) {
     return "HTML DOM edit patches cannot add script tags";
@@ -757,9 +1352,16 @@ function assertSafeHtmlFragment(html: string): string | null {
   return null;
 }
 
+function assertScriptPatchContentCanBeEmbedded(content: string): string | null {
+  if (/<\/\s*script/i.test(content)) {
+    return "HTML DOM edit script patches cannot contain closing script tags";
+  }
+  return null;
+}
+
 function applyHtmlDomEditPatch(
   html: string,
-  patch: HtmlDomEditPatch,
+  patch: HtmlDomEditDomPatch,
 ): { readonly html: string } | { readonly message: string } {
   const span = findHtmlElementSpan(html, patch.targetNodeId);
   if (!span) {
@@ -820,9 +1422,164 @@ function applyHtmlDomEditPatch(
   };
 }
 
+function htmlSpanSource(html: string, span: HtmlElementSpan): string {
+  return html.slice(span.start, span.end);
+}
+
+function scriptElementHtml(content: string): string {
+  return `<script>${content}</script>`;
+}
+
+function insertScriptAtEndOfBody(html: string, content: string): string {
+  const script = scriptElementHtml(content);
+  const bodyClose = /<\/\s*body\s*>/i.exec(html);
+  if (!bodyClose) {
+    return `${html}${script}`;
+  }
+  return `${html.slice(0, bodyClose.index)}${script}${html.slice(
+    bodyClose.index,
+  )}`;
+}
+
+function applyHtmlDomEditScriptUpdatePatch(
+  html: string,
+  patch: Extract<HtmlDomEditPatch, { readonly operation: "script_update" }>,
+): { readonly html: string } | { readonly message: string } {
+  const span = findScriptElementSpan(html, patch.scriptId);
+  if (!span) {
+    return { message: `HTML edit script was not found: ${patch.scriptId}` };
+  }
+
+  if (sha256Hex(htmlSpanSource(html, span)) !== patch.oldSha256) {
+    return { message: `HTML edit script was stale: ${patch.scriptId}` };
+  }
+
+  const startTagSource = html.slice(span.start, span.startTagEnd + 1);
+  if (startTagAttributeValue(startTagSource, "src") !== null) {
+    return {
+      message: `HTML edit script cannot update external scripts: ${patch.scriptId}`,
+    };
+  }
+
+  if (span.closeTagStart === null) {
+    return { message: `HTML edit script cannot be updated: ${patch.scriptId}` };
+  }
+  const unsafe = assertScriptPatchContentCanBeEmbedded(patch.content);
+  if (unsafe) {
+    return { message: unsafe };
+  }
+
+  return {
+    html: `${html.slice(0, span.startTagEnd + 1)}${patch.content}${html.slice(
+      span.closeTagStart,
+    )}`,
+  };
+}
+
+function applyHtmlDomEditScriptTextReplacePatch(
+  html: string,
+  patch: Extract<
+    HtmlDomEditPatch,
+    { readonly operation: "script_text_replace" }
+  >,
+): { readonly html: string } | { readonly message: string } {
+  const span = findScriptElementSpan(html, patch.scriptId);
+  if (!span) {
+    return { message: `HTML edit script was not found: ${patch.scriptId}` };
+  }
+
+  if (sha256Hex(htmlSpanSource(html, span)) !== patch.oldSha256) {
+    return { message: `HTML edit script was stale: ${patch.scriptId}` };
+  }
+
+  const startTagSource = html.slice(span.start, span.startTagEnd + 1);
+  if (startTagAttributeValue(startTagSource, "src") !== null) {
+    return {
+      message: `HTML edit script cannot update external scripts: ${patch.scriptId}`,
+    };
+  }
+
+  if (span.closeTagStart === null) {
+    return { message: `HTML edit script cannot be updated: ${patch.scriptId}` };
+  }
+  const unsafe = assertScriptPatchContentCanBeEmbedded(patch.newText);
+  if (unsafe) {
+    return { message: unsafe };
+  }
+
+  const content = html.slice(span.startTagEnd + 1, span.closeTagStart);
+  const firstIndex = content.indexOf(patch.oldText);
+  if (firstIndex === -1) {
+    return {
+      message: `HTML edit script text was not found: ${patch.scriptId}`,
+    };
+  }
+  if (
+    content.indexOf(patch.oldText, firstIndex + patch.oldText.length) !== -1
+  ) {
+    return {
+      message: `HTML edit script text was not unique: ${patch.scriptId}`,
+    };
+  }
+
+  return {
+    html: `${html.slice(0, span.startTagEnd + 1)}${content.slice(
+      0,
+      firstIndex,
+    )}${patch.newText}${content.slice(firstIndex + patch.oldText.length)}${html.slice(
+      span.closeTagStart,
+    )}`,
+  };
+}
+
+function applyHtmlDomEditScriptAddPatch(
+  html: string,
+  patch: Extract<HtmlDomEditPatch, { readonly operation: "script_add" }>,
+): { readonly html: string } | { readonly message: string } {
+  const unsafe = assertScriptPatchContentCanBeEmbedded(patch.content);
+  if (unsafe) {
+    return { message: unsafe };
+  }
+  return { html: insertScriptAtEndOfBody(html, patch.content) };
+}
+
+function applyHtmlDomEditScriptDeletePatch(
+  html: string,
+  patch: Extract<HtmlDomEditPatch, { readonly operation: "script_delete" }>,
+): { readonly html: string } | { readonly message: string } {
+  const span = findScriptElementSpan(html, patch.scriptId);
+  if (!span) {
+    return { message: `HTML edit script was not found: ${patch.scriptId}` };
+  }
+
+  if (sha256Hex(htmlSpanSource(html, span)) !== patch.oldSha256) {
+    return { message: `HTML edit script was stale: ${patch.scriptId}` };
+  }
+
+  return {
+    html: `${html.slice(0, span.start)}${html.slice(span.end)}`,
+  };
+}
+
+function applyHtmlDomEditScriptPatch(
+  html: string,
+  patch: HtmlDomEditScriptPatch,
+): { readonly html: string } | { readonly message: string } {
+  if (patch.operation === "script_update") {
+    return applyHtmlDomEditScriptUpdatePatch(html, patch);
+  }
+  if (patch.operation === "script_text_replace") {
+    return applyHtmlDomEditScriptTextReplacePatch(html, patch);
+  }
+  if (patch.operation === "script_add") {
+    return applyHtmlDomEditScriptAddPatch(html, patch);
+  }
+  return applyHtmlDomEditScriptDeletePatch(html, patch);
+}
+
 function stripHtmlDomEditAttributes(html: string): string {
   return html.replace(
-    /\s+data-vm0-(?:node-id|html-edit-[\w-]+)(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+))?/g,
+    /\s+data-vm0-(?:node-id|script-id|html-edit-[\w-]+)(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+))?/g,
     "",
   );
 }
@@ -832,13 +1589,44 @@ function applyHtmlDomEditPatches(params: {
   readonly patchResult: HtmlDomEditPatchResult;
 }): { readonly html: string } | { readonly message: string } {
   let html = params.html;
+  const scriptPatchInputs: HtmlDomEditScriptPatch[] = [];
+
   for (const patch of params.patchResult.patches) {
+    if (
+      patch.operation === "script_update" ||
+      patch.operation === "script_text_replace" ||
+      patch.operation === "script_add" ||
+      patch.operation === "script_delete"
+    ) {
+      scriptPatchInputs.push(patch);
+      continue;
+    }
+
     const result = applyHtmlDomEditPatch(html, patch);
     if ("message" in result) {
       return result;
     }
     html = result.html;
   }
+
+  const touchedScriptIds = new Set<string>();
+  for (const patch of scriptPatchInputs) {
+    if (patch.operation !== "script_add") {
+      if (touchedScriptIds.has(patch.scriptId)) {
+        return {
+          message: `HTML edit script received multiple patches: ${patch.scriptId}`,
+        };
+      }
+      touchedScriptIds.add(patch.scriptId);
+    }
+
+    const result = applyHtmlDomEditScriptPatch(html, patch);
+    if ("message" in result) {
+      return result;
+    }
+    html = result.html;
+  }
+
   return { html: stripHtmlDomEditAttributes(html) };
 }
 
@@ -1686,10 +2474,30 @@ export const createHtmlEditDraft$ = command(
         message: document.message,
       };
     }
+    const scriptInstrumentedDocument = instrumentHtmlDomEditScripts(
+      document.html,
+    );
+    const targetContexts = htmlDomEditTargetContexts({
+      comments: document.comments,
+      html: scriptInstrumentedDocument.html,
+      scripts: scriptInstrumentedDocument.scripts,
+    });
+    const promptHtmlContext = htmlDomEditPromptHtmlContext({
+      html: scriptInstrumentedDocument.html,
+      targetContexts,
+    });
+    const editDocument: HtmlEditDraftDocument = {
+      comments: document.comments,
+      html: scriptInstrumentedDocument.html,
+      promptHtml: promptHtmlContext.html,
+      promptHtmlIsFocused: promptHtmlContext.focused,
+      scripts: scriptInstrumentedDocument.scripts,
+      targetContexts,
+    };
 
     const generated = await generateText(
       HTML_DOM_EDIT_MODEL,
-      htmlDomEditPrompt(document),
+      htmlDomEditPrompt(editDocument),
       8192,
     );
     signal.throwIfAborted();
@@ -1707,7 +2515,7 @@ export const createHtmlEditDraft$ = command(
       };
     }
     const applied = applyHtmlDomEditPatches({
-      html: document.html,
+      html: editDocument.html,
       patchResult,
     });
     if ("message" in applied) {

--- a/turbo/apps/api/src/signals/services/zero-host.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-host.service.ts
@@ -560,7 +560,7 @@ Output:
 Rules:
 - HTML may be a full snapshot or focused target context. Use target node IDs as intent anchors; do not assume selected DOM is the source of truth.
 - Inspect HTML, Scripts, and Target-script context. Use DOM patches for static markup, including text, color, background, icon, attributes, classes, and nested markup.
-- If inline script data/source renders, derives, resets, or overwrites selected content or behavior, patch that script or backing data too.
+- Source-of-truth rule: when Target-script context or inline scripts reference the selected node, its selectors, or its visible text, check whether that script renders, derives, resets, or overwrites the requested content or behavior. If yes, a DOM-only response is invalid; include script_text_replace or script_update for the script/backing data.
 - Keep DOM fallback and script value synchronized when they represent the same user-facing text.
 - Prefer the smallest patch: script_text_replace for exact small script text/data changes, script_update for larger inline script edits, script_delete only when requested, and script_add only when existing DOM/script cannot satisfy the requested behavior.
 - For script_update/script_add, content is script body only, without <script> tags. For script_text_replace, oldText must be exact and unique. For script_update/script_text_replace/script_delete, copy exact scriptId and oldSha256.

--- a/turbo/apps/api/src/signals/services/zero-host.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-host.service.ts
@@ -56,6 +56,9 @@ const MAX_HTML_DOM_EDIT_SCRIPT_CONTEXTS_PER_TARGET = 2;
 const MAX_HTML_DOM_EDIT_SCRIPT_SNIPPETS_PER_TARGET = 2;
 const MAX_HTML_DOM_EDIT_SCRIPT_SNIPPET_CHARS = 500;
 const SHA256_HEX_PATTERN = /^[a-f0-9]{64}$/;
+const HTML_SCRIPT_TAG_NAME = "script";
+const HTML_SCRIPT_OPEN_TAG = `<${HTML_SCRIPT_TAG_NAME}>`;
+const HTML_SCRIPT_CLOSE_TAG = `</${HTML_SCRIPT_TAG_NAME}>`;
 
 const htmlDomEditPatchSchema = z.discriminatedUnion("operation", [
   z.object({
@@ -563,9 +566,9 @@ Rules:
 - Source-of-truth rule: when Target-script context or inline scripts reference the selected node, its selectors, or its visible text, check whether that script renders, derives, resets, or overwrites the requested content or behavior. If yes, a DOM-only response is invalid; include script_text_replace or script_update for the script/backing data.
 - Keep DOM fallback and script value synchronized when they represent the same user-facing text.
 - Prefer the smallest patch: script_text_replace for exact small script text/data changes, script_update for larger inline script edits, script_delete only when requested, and script_add only when existing DOM/script cannot satisfy the requested behavior.
-- For script_update/script_add, content is script body only, without <script> tags. For script_text_replace, oldText must be exact and unique. For script_update/script_text_replace/script_delete, copy exact scriptId and oldSha256.
+- For script_update/script_add, content is script body only, without opening or closing script tags. For script_text_replace, oldText must be exact and unique. For script_update/script_text_replace/script_delete, copy exact scriptId and oldSha256.
 - Keep unrelated content, formatting, assets, language, and behavior stable. Do not introduce unrelated side effects, network calls, imports, globals, timers, or script element creation.
-- Do not return the complete HTML document, explanations, deployment commands, overlays, annotations, comment markers, vm0-only editing attributes, or <script> tags in DOM fragments.
+- Do not return the complete HTML document, explanations, deployment commands, overlays, annotations, comment markers, vm0-only editing attributes, or script tags in DOM fragments.
 - Apply every requested change exactly once.
 
 Comments:
@@ -855,11 +858,18 @@ function startTagAttributeValue(
 }
 
 function escapeHtmlAttribute(value: string): string {
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;");
+  return value.replace(/[&"<>]/g, (char) => {
+    if (char === "&") {
+      return "&amp;";
+    }
+    if (char === '"') {
+      return "&quot;";
+    }
+    if (char === "<") {
+      return "&lt;";
+    }
+    return "&gt;";
+  });
 }
 
 function insertStartTagAttribute(
@@ -1083,13 +1093,18 @@ function clipped(value: string, maxLength: number): string {
 }
 
 function decodeBasicHtmlEntities(value: string): string {
-  return value
-    .replaceAll("&nbsp;", " ")
-    .replaceAll("&amp;", "&")
-    .replaceAll("&lt;", "<")
-    .replaceAll("&gt;", ">")
-    .replaceAll("&quot;", '"')
-    .replaceAll("&#39;", "'");
+  return value.replace(/&(nbsp|amp|lt|gt|quot|#39);/g, (entity) => {
+    return (
+      {
+        "&#39;": "'",
+        "&amp;": "&",
+        "&gt;": ">",
+        "&lt;": "<",
+        "&nbsp;": " ",
+        "&quot;": '"',
+      }[entity] ?? entity
+    );
+  });
 }
 
 function normalizedHtmlText(html: string): string {
@@ -1399,7 +1414,7 @@ function htmlSpanSource(html: string, span: HtmlElementSpan): string {
 }
 
 function scriptElementHtml(content: string): string {
-  return `<script>${content}</script>`;
+  return `${HTML_SCRIPT_OPEN_TAG}${content}${HTML_SCRIPT_CLOSE_TAG}`;
 }
 
 function insertScriptAtEndOfBody(html: string, content: string): string {

--- a/turbo/apps/api/src/signals/services/zero-host.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-host.service.ts
@@ -545,56 +545,28 @@ function htmlDomEditPrompt(body: HtmlEditDraftDocument): readonly {
       content: `Create patches for these comments on the existing HTML document.
 
 Output:
-- Return only JSON.
-- Output shape: {"kind":"html-dom-edit-patch","version":1,"patches":[...]}.
-- Each patch must include commentId, operation, and the operation-specific fields.
-- DOM patch operations must include targetNodeId.
-- Script patch operations must include scriptId and oldSha256 except script_add.
-- Supported operations:
-  - {"operation":"update","outerHTML":"<tag>...</tag>"} replaces the target DOM node with the updated DOM node.
-  - {"operation":"insert","position":"before","html":"..."} inserts HTML before the target element.
-  - {"operation":"insert","position":"after","html":"..."} inserts HTML after the target element.
-  - {"operation":"insert","position":"append_child","html":"..."} appends HTML inside the target element.
-  - {"operation":"insert","position":"prepend_child","html":"..."} prepends HTML inside the target element.
-  - {"operation":"remove"} removes the target element.
-  - {"operation":"script_update","scriptId":"...","oldSha256":"...","content":"..."} replaces the complete body of an existing inline script.
-  - {"operation":"script_text_replace","scriptId":"...","oldSha256":"...","oldText":"...","newText":"..."} replaces one exact text occurrence inside an existing inline script.
-  - {"operation":"script_delete","scriptId":"...","oldSha256":"..."} removes an existing script.
-  - {"operation":"script_add","placement":"end_of_body","content":"..."} inserts a new inline script immediately before </body>.
-- Treat target node IDs as intent anchors, not edit boundaries.
-- Before choosing patches, inspect the HTML section and the Scripts section to determine the source of truth for each requested change.
-- Use DOM update for static DOM changes, including text, color, background, icon, attributes, classes, or nested markup.
-- For update, keep the same tag when possible and include all attributes and children that should remain.
-- Prefer the smallest DOM target that satisfies the comment when the change belongs in DOM.
-- Return DOM-only patches only when page scripts do not control, derive, render, or overwrite the requested visible change.
-- If an inline script controls, derives, renders, or overwrites the targeted content or behavior, a DOM-only patch is incomplete; update the script's backing data or source so the requested change survives script execution.
-- When script data/source is the source of truth for selected visible content, keep any corresponding static DOM fallback synchronized with the same final user-facing value. Do not leave the fallback in the old language or a different paraphrase.
-- If the same requested user-facing text appears in both DOM fallback and script backing data, update both to the same final text unless the comment explicitly asks for different values.
-- Check whether scripts reference target ids, classes, data attributes, selectors, rendered data objects, render functions, reset handlers, or event handlers related to the selected nodes.
-- Use script_update when an existing inline script is the backing source for the requested change.
-- Prefer script_text_replace for small script text or data changes, especially when the HTML section is focused context instead of the complete document.
-- Use script_delete only when a comment asks to remove script behavior.
-- Use script_add only when the requested behavior cannot be represented by updating existing DOM or inline script.
-- For script_update, preserve the existing script structure and behavior. Make the smallest data, text, or configuration change needed for the comment, and do not rewrite unrelated functions, control flow, event handlers, timers, or state.
-- For script_text_replace, oldText must be copied exactly from the HTML section or Target-script context, and it must uniquely identify the intended script text.
-- For script_update and script_add, content must be the script body only. Do not include <script> tags.
-- For script_update, script_text_replace, and script_delete, copy the exact scriptId and oldSha256 from the Scripts section.
-- Do not introduce unrelated side effects, network calls, imports, globals, timers, or script element creation unless the requested change specifically requires them.
-- Do not return the complete HTML document.
-- Do not include vm0-only editing attributes such as data-vm0-node-id, data-vm0-script-id, or data-vm0-html-edit-* in returned HTML fragments.
-- Do not add comment markers, overlays, annotations, explanations, or deployment commands.
-- Do not add script tags in new HTML fragments.
+- Return only JSON: {"kind":"html-dom-edit-patch","version":1,"patches":[...]}.
+- Every patch includes commentId and operation.
+- DOM operations require targetNodeId:
+  - {"operation":"update","outerHTML":"<tag>...</tag>"}
+  - {"operation":"insert","position":"before|after|append_child|prepend_child","html":"..."}
+  - {"operation":"remove"}
+- Script operations:
+  - {"operation":"script_update","scriptId":"...","oldSha256":"...","content":"..."}
+  - {"operation":"script_text_replace","scriptId":"...","oldSha256":"...","oldText":"...","newText":"..."}
+  - {"operation":"script_delete","scriptId":"...","oldSha256":"..."}
+  - {"operation":"script_add","placement":"end_of_body","content":"..."}
 
-Editing rules:
-- Use the target node IDs to locate the intended elements in the HTML.
-- The HTML section contains either the current DOM snapshot or focused target context, and the Scripts section lists the document's scripts. Do not assume the selected DOM node is the source of truth.
-- Before choosing patches, inspect the HTML section, Scripts section, and any Target-script context to determine whether the requested change belongs in static DOM, script data, or script behavior.
-- Target-script context, when present, is derived from the same HTML by matching selected target ids, classes, attributes, and text against inline scripts. Use it as a navigation aid for source-of-truth analysis.
-- If Target-script context shows script snippets that reference the selected target or its visible text, inspect those scripts carefully. If a script renders, derives, resets, or overwrites the selected visible content, update the script or backing data that produces that content. A DOM-only patch is incomplete in that case.
+Rules:
+- HTML may be a full snapshot or focused target context. Use target node IDs as intent anchors; do not assume selected DOM is the source of truth.
+- Inspect HTML, Scripts, and Target-script context. Use DOM patches for static markup, including text, color, background, icon, attributes, classes, and nested markup.
+- If inline script data/source renders, derives, resets, or overwrites selected content or behavior, patch that script or backing data too.
+- Keep DOM fallback and script value synchronized when they represent the same user-facing text.
+- Prefer the smallest patch: script_text_replace for exact small script text/data changes, script_update for larger inline script edits, script_delete only when requested, and script_add only when existing DOM/script cannot satisfy the requested behavior.
+- For script_update/script_add, content is script body only, without <script> tags. For script_text_replace, oldText must be exact and unique. For script_update/script_text_replace/script_delete, copy exact scriptId and oldSha256.
+- Keep unrelated content, formatting, assets, language, and behavior stable. Do not introduce unrelated side effects, network calls, imports, globals, timers, or script element creation.
+- Do not return the complete HTML document, explanations, deployment commands, overlays, annotations, comment markers, vm0-only editing attributes, or <script> tags in DOM fragments.
 - Apply every requested change exactly once.
-- Keep unrelated content and formatting as stable as practical.
-- Preserve relative and absolute asset URLs.
-- Preserve the page's primary language and tone.
 
 Comments:
 ${comments}


### PR DESCRIPTION
## Summary
- Add controlled script_update, script_insert, and script_remove operations for hosted HTML edit drafts.
- Move HTML edit draft generation, prompt construction, patch apply, and script safety out of zero-host.service into zero-host-html-edit.service.
- Inject stable script ids and SHA handles before prompting so script updates/removals can be matched safely.
- Apply checked script operations on the backend and return a final html draft payload, keeping the response contract stable as `{ html }`.
- Simplify script safety to validate the final HTML script surface: reject invalid JS, new dangerous capability counts, and newly introduced external scripts after all DOM/script patches are applied.

## Tests
- pnpm exec prettier --write apps/api/src/signals/services/zero-host-html-edit.service.ts apps/api/src/signals/services/zero-host.service.ts apps/api/src/signals/routes/zero-host.ts apps/api/src/signals/routes/__tests__/host-maps.bdd.test.ts
- pnpm -F api exec oxlint src/signals/services/zero-host-html-edit.service.ts src/signals/services/zero-host.service.ts src/signals/routes/zero-host.ts src/signals/routes/__tests__/host-maps.bdd.test.ts
- NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types
- git diff --check

## Notes
- Plain `pnpm -F api check-types` hit the local Node heap limit; rerunning with `NODE_OPTIONS=--max-old-space-size=4096` passed.