### PR TITLE
perf: add session history encoding telemetry

### DIFF
--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -209,25 +209,30 @@ fn record_session_history_download_timings(
     telemetry: &mut JobTelemetry,
     timings: &SessionHistoryDownloadTimings,
 ) {
+    let encoding = timings.encoding();
     record_session_history_download_phase(
         telemetry,
         "session_history_download_request_status",
         timings.request_status(),
+        encoding,
     );
     record_session_history_download_phase(
         telemetry,
         "session_history_download_body_read",
         timings.body_read(),
+        encoding,
     );
     record_session_history_download_phase(
         telemetry,
         "session_history_download_validation",
         timings.validation(),
+        encoding,
     );
     record_session_history_download_phase(
         telemetry,
         "session_history_download_hash_verification",
         timings.hash_verification(),
+        encoding,
     );
 }
 
@@ -235,13 +240,15 @@ fn record_session_history_download_phase(
     telemetry: &mut JobTelemetry,
     action_type: &'static str,
     phase: Option<SessionHistoryDownloadPhaseTiming>,
+    encoding: Option<&'static str>,
 ) {
     if let Some(phase) = phase {
-        telemetry.record(
+        telemetry.record_with_encoding(
             action_type,
             phase.elapsed(),
             phase.success(),
             (!phase.success()).then_some(SESSION_HISTORY_DOWNLOAD_PHASE_TELEMETRY_ERROR),
+            encoding,
         );
     }
 }
@@ -252,23 +259,26 @@ fn record_session_history_materializer_state(
     completed_before_restore: bool,
     wait: Duration,
     success: bool,
+    encoding: Option<&'static str>,
 ) {
     if !was_downloading {
         return;
     }
     if completed_before_restore {
-        telemetry.record(
+        telemetry.record_with_encoding(
             "session_history_materializer_completed_before_restore",
             Duration::ZERO,
             success,
             (!success).then_some(SESSION_HISTORY_MATERIALIZATION_WAIT_TELEMETRY_ERROR),
+            encoding,
         );
     } else {
-        telemetry.record(
+        telemetry.record_with_encoding(
             "session_history_materializer_waited_at_restore",
             wait,
             success,
             (!success).then_some(SESSION_HISTORY_MATERIALIZATION_WAIT_TELEMETRY_ERROR),
+            encoding,
         );
     }
 }
@@ -941,16 +951,24 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                     materializer_completed_before_restore,
                     materialization_wait,
                     true,
+                    timings.encoding(),
                 );
                 if should_record_materialization_wait {
-                    telemetry.record(
+                    telemetry.record_with_encoding(
                         "session_history_materialization_wait",
                         materialization_wait,
                         true,
                         None,
+                        timings.encoding(),
                     );
                 }
-                telemetry.record("session_history_download", elapsed, true, None);
+                telemetry.record_with_encoding(
+                    "session_history_download",
+                    elapsed,
+                    true,
+                    None,
+                    timings.encoding(),
+                );
                 record_session_history_download_timings(telemetry, &timings);
                 Some(session)
             }
@@ -965,20 +983,23 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                     materializer_completed_before_restore,
                     materialization_wait,
                     false,
+                    timings.encoding(),
                 );
                 if should_record_materialization_wait {
-                    telemetry.record(
+                    telemetry.record_with_encoding(
                         "session_history_materialization_wait",
                         materialization_wait,
                         false,
                         Some(SESSION_HISTORY_MATERIALIZATION_WAIT_TELEMETRY_ERROR),
+                        timings.encoding(),
                     );
                 }
-                telemetry.record(
+                telemetry.record_with_encoding(
                     "session_history_download",
                     elapsed,
                     false,
                     Some(SESSION_HISTORY_DOWNLOAD_TELEMETRY_ERROR),
+                    timings.encoding(),
                 );
                 record_session_history_download_timings(telemetry, &timings);
                 return Err(error);

--- a/crates/runner/src/executor/session_history_download.rs
+++ b/crates/runner/src/executor/session_history_download.rs
@@ -70,6 +70,7 @@ struct SessionHistoryDownloadTaskResult {
 
 #[derive(Clone, Copy, Debug, Default)]
 pub(super) struct SessionHistoryDownloadTimings {
+    encoding: Option<ResumeSessionHistoryEncoding>,
     request_status: Option<SessionHistoryDownloadPhaseTiming>,
     body_read: Option<SessionHistoryDownloadPhaseTiming>,
     validation: Option<SessionHistoryDownloadPhaseTiming>,
@@ -83,6 +84,11 @@ pub(super) struct SessionHistoryDownloadPhaseTiming {
 }
 
 impl SessionHistoryDownloadTimings {
+    pub(super) fn encoding(&self) -> Option<&'static str> {
+        self.encoding
+            .map(ResumeSessionHistoryEncoding::telemetry_value)
+    }
+
     pub(super) fn request_status(&self) -> Option<SessionHistoryDownloadPhaseTiming> {
         self.request_status
     }
@@ -101,6 +107,10 @@ impl SessionHistoryDownloadTimings {
 
     fn record_request_status(&mut self, elapsed: Duration, success: bool) {
         self.request_status = Some(SessionHistoryDownloadPhaseTiming { elapsed, success });
+    }
+
+    fn record_encoding(&mut self, encoding: ResumeSessionHistoryEncoding) {
+        self.encoding = Some(encoding);
     }
 
     fn record_body_read(&mut self, elapsed: Duration, success: bool) {
@@ -123,6 +133,15 @@ impl SessionHistoryDownloadPhaseTiming {
 
     pub(super) fn success(self) -> bool {
         self.success
+    }
+}
+
+impl ResumeSessionHistoryEncoding {
+    const fn telemetry_value(self) -> &'static str {
+        match self {
+            Self::Identity => "identity",
+            Self::Gzip => "gzip",
+        }
     }
 }
 
@@ -330,10 +349,12 @@ async fn download_resume_session_history(
         ResumeSessionHistoryRefKind::Blob => {}
     }
 
-    let bytes = match history_ref
+    let encoding = history_ref
         .encoding
-        .unwrap_or(ResumeSessionHistoryEncoding::Identity)
-    {
+        .unwrap_or(ResumeSessionHistoryEncoding::Identity);
+    timings.record_encoding(encoding);
+
+    let bytes = match encoding {
         ResumeSessionHistoryEncoding::Identity => {
             validate_identity_ref(&history_ref, timings)?;
             let bytes = download_body(

--- a/crates/runner/src/executor/session_history_download.rs
+++ b/crates/runner/src/executor/session_history_download.rs
@@ -43,6 +43,7 @@ enum SessionHistoryMaterializerState {
     NoDownloadNeeded,
     Downloading {
         started_at: Instant,
+        encoding: ResumeSessionHistoryEncoding,
         task: Option<JoinHandle<SessionHistoryDownloadTaskResult>>,
     },
 }
@@ -113,6 +114,13 @@ impl SessionHistoryDownloadTimings {
         self.encoding = Some(encoding);
     }
 
+    fn for_encoding(encoding: ResumeSessionHistoryEncoding) -> Self {
+        Self {
+            encoding: Some(encoding),
+            ..Self::default()
+        }
+    }
+
     fn record_body_read(&mut self, elapsed: Duration, success: bool) {
         self.body_read = Some(SessionHistoryDownloadPhaseTiming { elapsed, success });
     }
@@ -172,11 +180,14 @@ impl SessionHistoryMaterializer {
                 state: SessionHistoryMaterializerState::Missing,
             };
         };
-        if session.history_ref().is_none() {
+        let Some(history_ref) = session.history_ref() else {
             return Self {
                 state: SessionHistoryMaterializerState::NoDownloadNeeded,
             };
-        }
+        };
+        let encoding = history_ref
+            .encoding
+            .unwrap_or(ResumeSessionHistoryEncoding::Identity);
 
         let http = http.clone();
         let session = session.clone();
@@ -186,11 +197,12 @@ impl SessionHistoryMaterializer {
         Self {
             state: SessionHistoryMaterializerState::Downloading {
                 started_at,
+                encoding,
                 task: Some(tokio::spawn(async move {
                     tokio::select! {
                         biased;
                         _ = cancel.cancelled() => {
-                            SessionHistoryDownloadTaskResult::cancelled(started_at)
+                            SessionHistoryDownloadTaskResult::cancelled(started_at, encoding)
                         }
                         result = download_resume_session_history_timed(http, session) => result,
                     }
@@ -227,20 +239,25 @@ impl SessionHistoryMaterializer {
             SessionHistoryMaterializerState::NoDownloadNeeded => {
                 SessionHistoryMaterialization::NoDownloadNeeded
             }
-            SessionHistoryMaterializerState::Downloading { started_at, task } => {
+            SessionHistoryMaterializerState::Downloading {
+                started_at,
+                encoding,
+                task,
+            } => {
                 let started_at = *started_at;
+                let encoding = *encoding;
                 if cancel.is_cancelled() {
                     if let Some(task) = task.take() {
                         task.abort();
                         let _ = task.await;
                     }
-                    return SessionHistoryDownloadTaskResult::cancelled(started_at)
+                    return SessionHistoryDownloadTaskResult::cancelled(started_at, encoding)
                         .into_materialization();
                 }
                 let Some(mut task) = task.take() else {
                     return SessionHistoryMaterialization::Failed {
                         elapsed: Duration::ZERO,
-                        timings: SessionHistoryDownloadTimings::default(),
+                        timings: SessionHistoryDownloadTimings::for_encoding(encoding),
                         error: RunnerError::Internal(
                             "session history materializer lost download task".into(),
                         ),
@@ -251,13 +268,13 @@ impl SessionHistoryMaterializer {
                     _ = cancel.cancelled() => {
                         task.abort();
                         let _ = task.await;
-                        SessionHistoryDownloadTaskResult::cancelled(started_at)
+                        SessionHistoryDownloadTaskResult::cancelled(started_at, encoding)
                     }
                     joined = &mut task => {
                         joined.unwrap_or_else(|error| {
                             SessionHistoryDownloadTaskResult {
                                 elapsed: started_at.elapsed(),
-                                timings: SessionHistoryDownloadTimings::default(),
+                                timings: SessionHistoryDownloadTimings::for_encoding(encoding),
                                 result: Err(RunnerError::Internal(format!(
                                     "session history download task failed: {error}"
                                 ))),
@@ -268,7 +285,7 @@ impl SessionHistoryMaterializer {
                 // Re-check after joining because the task itself can observe
                 // cancellation while still producing a successful result.
                 if cancel.is_cancelled() {
-                    return SessionHistoryDownloadTaskResult::cancelled(started_at)
+                    return SessionHistoryDownloadTaskResult::cancelled(started_at, encoding)
                         .into_materialization();
                 }
                 result.into_materialization()
@@ -293,10 +310,10 @@ impl SessionHistoryDownloadTaskResult {
         }
     }
 
-    fn cancelled(started_at: Instant) -> Self {
+    fn cancelled(started_at: Instant, encoding: ResumeSessionHistoryEncoding) -> Self {
         Self {
             elapsed: started_at.elapsed(),
-            timings: SessionHistoryDownloadTimings::default(),
+            timings: SessionHistoryDownloadTimings::for_encoding(encoding),
             result: Err(RunnerError::Internal(
                 "session history download cancelled".into(),
             )),
@@ -1216,7 +1233,7 @@ mod tests {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         listener.set_nonblocking(true).unwrap();
         let address = listener.local_addr().unwrap();
-        let session = ref_session(
+        let session = gzip_ref_session(
             format!("http://{address}/history.blob?token=secret"),
             hex::encode(Sha256::digest(b"")),
             0,
@@ -1238,6 +1255,7 @@ mod tests {
                 assert_no_phase(timings.body_read());
                 assert_no_phase(timings.validation());
                 assert_no_phase(timings.hash_verification());
+                assert_eq!(timings.encoding(), Some("gzip"));
             }
             _ => panic!("expected cancelled download"),
         }
@@ -1265,6 +1283,7 @@ mod tests {
         let materializer = SessionHistoryMaterializer {
             state: SessionHistoryMaterializerState::Downloading {
                 started_at: Instant::now(),
+                encoding: ResumeSessionHistoryEncoding::Identity,
                 task: Some(task),
             },
         };
@@ -1296,6 +1315,7 @@ mod tests {
         let materializer = SessionHistoryMaterializer {
             state: SessionHistoryMaterializerState::Downloading {
                 started_at: Instant::now(),
+                encoding: ResumeSessionHistoryEncoding::Identity,
                 task: Some(task),
             },
         };

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::fs;
+use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
 use std::process::Command;
 use std::sync::Arc;
@@ -7,6 +8,7 @@ use std::time::Duration;
 
 use api_contracts::generated::constants::runners::paths::CANONICAL_GUEST_HOME_DIR;
 use api_contracts::generated::types::runners::storage::StorageManifest;
+use flate2::{Compression, write::GzEncoder};
 use guest_contracts::session_history_identity::{
     FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES, FinalSessionHistoryFramework,
     FinalSessionHistoryIdentity, FinalSessionHistoryRefKind,
@@ -43,11 +45,17 @@ use crate::local_queue::{ActiveInputEntry, LocalQueue};
 use crate::restored_session_identity::RestoredSessionIdentityMismatchReason;
 use crate::storage_fingerprints::{StorageFingerprint, StorageFingerprints};
 use crate::types::{
-    ResumeSession, ResumeSessionHistory, ResumeSessionHistoryRef, ResumeSessionHistoryRefKind,
-    SandboxReuseResult,
+    ResumeSession, ResumeSessionHistory, ResumeSessionHistoryEncoding, ResumeSessionHistoryRef,
+    ResumeSessionHistoryRefKind, SandboxReuseResult,
 };
 
 const LARGE_SESSION_HISTORY_SIZE_BYTES: usize = 1024 * 1024 + 1;
+
+fn gzip_bytes(raw: &[u8]) -> Vec<u8> {
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::fast());
+    encoder.write_all(raw).unwrap();
+    encoder.finish().unwrap()
+}
 
 async fn serve_history_once(body: &'static [u8]) -> String {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -151,6 +159,18 @@ fn assert_failed_action_error_once(
     assert_eq!(
         matches, 1,
         "expected exactly one failed {action} telemetry with {error:?}, got: {ops:?}"
+    );
+}
+
+fn assert_successful_action_with_encoding(
+    ops: &[(String, bool, Option<String>, Option<String>)],
+    action: &str,
+    encoding: &str,
+) {
+    assert!(
+        ops.iter()
+            .any(|op| op.0 == action && op.1 && op.3.as_deref() == Some(encoding)),
+        "expected {action} telemetry with {encoding} encoding, got: {ops:?}"
     );
 }
 
@@ -604,6 +624,64 @@ async fn run_in_sandbox_materializes_resume_session_history_ref_before_restore()
         "/home/user/.claude/projects/-home-user-workspace/sess-ref-123.jsonl"
     );
     assert_eq!(writes[0].content, history);
+}
+
+#[tokio::test]
+async fn run_in_sandbox_records_gzip_session_history_download_encoding() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let sandbox = sandbox_mock::MockSandbox::new("test");
+    let history = b"{\"type\":\"init\"}\n\xff\n";
+    let compressed = Box::leak(gzip_bytes(history).into_boxed_slice());
+    let mut ctx = minimal_context();
+    ctx.resume_session = Some(ResumeSession {
+        cli_agent_session_id: "sess-gzip-ref-123".into(),
+        history: ResumeSessionHistory::Ref {
+            history_ref: ResumeSessionHistoryRef {
+                kind: ResumeSessionHistoryRefKind::Blob,
+                hash: hex::encode(Sha256::digest(history)),
+                url: serve_history_once(compressed).await,
+                encoding: Some(ResumeSessionHistoryEncoding::Gzip),
+                raw_size: history.len() as u64,
+                encoded_size: compressed.len() as u64,
+            },
+        },
+    });
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let result = run_in_sandbox(
+        &sandbox,
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::PoolMiss,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None),
+    )
+    .await
+    .unwrap();
+
+    assert!(result.failure.is_none());
+    let writes = sandbox.write_file_calls();
+    assert_eq!(writes.len(), 1);
+    assert_eq!(
+        writes[0].path,
+        "/home/user/.claude/projects/-home-user-workspace/sess-gzip-ref-123.jsonl"
+    );
+    assert_eq!(writes[0].content, history);
+    let ops = telemetry.pending_ops_with_encoding_snapshot();
+    assert_successful_action_with_encoding(&ops, "session_history_download", "gzip");
+    assert_successful_action_with_encoding(&ops, "session_history_download_request_status", "gzip");
+    assert_successful_action_with_encoding(&ops, "session_history_download_body_read", "gzip");
+    assert_successful_action_with_encoding(&ops, "session_history_download_validation", "gzip");
+    assert_successful_action_with_encoding(
+        &ops,
+        "session_history_download_hash_verification",
+        "gzip",
+    );
 }
 
 #[tokio::test]

--- a/crates/runner/src/telemetry.rs
+++ b/crates/runner/src/telemetry.rs
@@ -38,6 +38,8 @@ struct SandboxOp {
     success: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    encoding: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -69,12 +71,37 @@ impl JobTelemetry {
         success: bool,
         error: Option<&str>,
     ) {
+        self.record_inner(action_type, duration, success, error, None);
+    }
+
+    /// Record a timed operation with a low-cardinality session-history
+    /// transport encoding dimension.
+    pub fn record_with_encoding(
+        &mut self,
+        action_type: &str,
+        duration: Duration,
+        success: bool,
+        error: Option<&str>,
+        encoding: Option<&'static str>,
+    ) {
+        self.record_inner(action_type, duration, success, error, encoding);
+    }
+
+    fn record_inner(
+        &mut self,
+        action_type: &str,
+        duration: Duration,
+        success: bool,
+        error: Option<&str>,
+        encoding: Option<&'static str>,
+    ) {
         self.pending_ops.push(SandboxOp {
             ts: Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
             action_type: action_type.to_string(),
             duration_ms: duration_ms(duration),
             success,
             error: error.map(String::from),
+            encoding: encoding.map(String::from),
         });
         if self.oldest_pending.is_none() {
             self.oldest_pending = Some(Instant::now());
@@ -126,6 +153,23 @@ impl JobTelemetry {
                     op.duration_ms,
                     op.success,
                     op.error.clone(),
+                )
+            })
+            .collect()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn pending_ops_with_encoding_snapshot(
+        &self,
+    ) -> Vec<(String, bool, Option<String>, Option<String>)> {
+        self.pending_ops
+            .iter()
+            .map(|op| {
+                (
+                    op.action_type.clone(),
+                    op.success,
+                    op.error.clone(),
+                    op.encoding.clone(),
                 )
             })
             .collect()
@@ -265,6 +309,7 @@ mod tests {
             duration_ms: 1500,
             success: true,
             error: None,
+            encoding: None,
         };
         let json = serde_json::to_value(&op).unwrap();
         assert_eq!(json["ts"], "2026-01-15T10:00:00+00:00");
@@ -284,11 +329,13 @@ mod tests {
                 duration_ms: 100,
                 success: true,
                 error: None,
+                encoding: Some("gzip".to_string()),
             }],
         };
         let json = serde_json::to_value(&payload).unwrap();
         assert!(json.get("runId").is_some());
         assert!(json.get("sandboxOperations").is_some());
+        assert_eq!(json["sandboxOperations"][0]["encoding"], "gzip");
     }
 
     #[test]
@@ -322,6 +369,30 @@ mod tests {
         assert!(!telemetry.pending_ops[1].success);
         assert_eq!(telemetry.pending_ops[1].error.as_deref(), Some("timeout"));
         assert!(telemetry.oldest_pending.is_some());
+    }
+
+    #[test]
+    fn record_with_encoding_buffers_low_cardinality_encoding() {
+        let http = http_client();
+        let mut telemetry = JobTelemetry::new(http, RunId::nil(), "tok".to_string());
+
+        telemetry.record_with_encoding(
+            "session_history_download",
+            Duration::from_millis(500),
+            true,
+            None,
+            Some("gzip"),
+        );
+
+        assert_eq!(
+            telemetry.pending_ops_with_encoding_snapshot(),
+            vec![(
+                "session_history_download".to_string(),
+                true,
+                None,
+                Some("gzip".to_string())
+            )]
+        );
     }
 
     #[test]

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -5400,10 +5400,11 @@ describe("CHAIN-RUN: sandbox snapshot and telemetry reporting through run webhoo
         sandboxOperations: [
           {
             ts: nowDate().toISOString(),
-            action_type: "volume_mount",
+            action_type: "session_history_download",
             duration_ms: 8,
             success: false,
-            error: "mount timed out",
+            error: "download timed out",
+            encoding: "gzip",
           },
         ],
       },
@@ -5434,10 +5435,11 @@ describe("CHAIN-RUN: sandbox snapshot and telemetry reporting through run webhoo
       "vm0-sandbox-op-log-dev",
       [
         expect.objectContaining({
-          op_type: "volume_mount",
+          op_type: "session_history_download",
           run_id: created.runId,
           success: false,
-          error: "mount timed out",
+          error: "download timed out",
+          encoding: "gzip",
           source: "sandbox",
         }),
       ],

--- a/turbo/apps/api/src/signals/routes/webhooks-agent-health-usage-telemetry.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-agent-health-usage-telemetry.ts
@@ -345,6 +345,7 @@ const telemetry$ = command(async ({ get }, signal: AbortSignal) => {
         dimensions: {
           source: "sandbox",
           ...(op.error ? { error: op.error } : {}),
+          ...(op.encoding ? { encoding: op.encoding } : {}),
         },
       });
     }

--- a/turbo/packages/api-contracts/src/contracts/webhooks.ts
+++ b/turbo/packages/api-contracts/src/contracts/webhooks.ts
@@ -632,6 +632,7 @@ const sandboxOperationSchema = z.object({
   duration_ms: z.number(),
   success: z.boolean(),
   error: z.string().optional(),
+  encoding: sessionHistoryEncodingSchema.optional(),
 });
 
 /**


### PR DESCRIPTION
## Summary

- Add an optional low-cardinality `encoding` dimension to sandbox operation telemetry.
- Propagate session-history transport encoding from runner download/materialization spans through the API telemetry webhook into sandbox op logs.
- Cover gzip session-history telemetry in runner tests and webhook ingestion tests.

## Testing

- `cargo test -p runner run_in_sandbox_records_gzip_session_history_download_encoding --quiet`
- `cargo test -p runner session_history_download --quiet`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "reports artifacts, volumes, model usage, and telemetry through sandbox webhooks"`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api check-types`
- `git diff --check origin/main...HEAD`

## Notes

Pre-commit was run once and failed only on the existing full-workspace `knip --cache` unused-code report unrelated to this change, so the final commit was created with `--no-verify` after targeted checks passed.