### PR TITLE
fix: preserve agent connector add semantics

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/user-config.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/user-config.bdd.test.ts
@@ -259,6 +259,20 @@ describe("AUTH-03 agent user connectors", () => {
       new Set(["github", "slack"]),
     );
 
+    const added = await cfg.updateUserConnectors(
+      admin,
+      agent.agentId,
+      ["linear"],
+      "add",
+    );
+    expect(new Set(added.enabledTypes)).toStrictEqual(
+      new Set(["github", "slack", "linear"]),
+    );
+    const readAfterAdd = await cfg.readUserConnectors(admin, agent.agentId);
+    expect(new Set(readAfterAdd.enabledTypes)).toStrictEqual(
+      new Set(["github", "slack", "linear"]),
+    );
+
     const replaced = await cfg.updateUserConnectors(admin, agent.agentId, [
       "linear",
     ]);

--- a/turbo/apps/platform/src/mocks/handlers/__tests__/api-agents.test.ts
+++ b/turbo/apps/platform/src/mocks/handlers/__tests__/api-agents.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
+
+import { accept } from "../../../lib/accept.ts";
+import { zeroClient$ } from "../../../signals/api-client.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+
+const context = testContext();
+
+describe("api agents mock handlers", () => {
+  it("preserves existing user connectors when adding another connector", async () => {
+    const agentId = "c0000000-0000-4000-a000-000000000001";
+    const client = context.store.get(zeroClient$)(zeroUserConnectorsContract);
+
+    await accept(
+      client.update({
+        params: { id: agentId },
+        body: { enabledTypes: ["github"], operation: "add" },
+      }),
+      [200],
+    );
+
+    const updated = await accept(
+      client.update({
+        params: { id: agentId },
+        body: { enabledTypes: ["slack"], operation: "add" },
+      }),
+      [200],
+    );
+    expect(new Set(updated.body.enabledTypes)).toStrictEqual(
+      new Set(["github", "slack"]),
+    );
+
+    const readBack = await accept(
+      client.get({ params: { id: agentId } }),
+      [200],
+    );
+    expect(new Set(readBack.body.enabledTypes)).toStrictEqual(
+      new Set(["github", "slack"]),
+    );
+  });
+});

--- a/turbo/apps/platform/src/mocks/handlers/api-agents.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-agents.ts
@@ -61,6 +61,7 @@ const DEFAULT_COMPOSES_LIST: ComposeListItem[] = [
 ];
 
 let mockComposesList: ComposeListItem[] = [...DEFAULT_COMPOSES_LIST];
+const mockEnabledConnectorTypesByAgent = new Map<string, string[]>();
 
 export function setMockComposesList(composes: ComposeListItem[]): void {
   mockComposesList = composes;
@@ -70,12 +71,24 @@ export function resetMockComposesList(): void {
   mockComposesList = [...DEFAULT_COMPOSES_LIST];
 }
 
-function mockUserConnectorUpdateResponse(body: {
-  readonly enabledTypes: readonly string[];
-  readonly operation?: "replace" | "add" | "remove";
-}): string[] {
+export function resetMockUserConnectors(): void {
+  mockEnabledConnectorTypesByAgent.clear();
+}
+
+function mockUserConnectorUpdateResponse(
+  current: readonly string[],
+  body: {
+    readonly enabledTypes: readonly string[];
+    readonly operation?: "replace" | "add" | "remove";
+  },
+): string[] {
+  if (body.operation === "add") {
+    return Array.from(new Set([...current, ...body.enabledTypes]));
+  }
   if (body.operation === "remove") {
-    return [];
+    return current.filter((type) => {
+      return !body.enabledTypes.includes(type);
+    });
   }
   return [...body.enabledTypes];
 }
@@ -107,14 +120,21 @@ export const apiAgentsHandlers = [
   }),
 
   // GET /api/zero/agents/:id/user-connectors
-  mockApi(zeroUserConnectorsContract.get, ({ respond }) => {
-    return respond(200, { enabledTypes: [] });
+  mockApi(zeroUserConnectorsContract.get, ({ params, respond }) => {
+    return respond(200, {
+      enabledTypes: mockEnabledConnectorTypesByAgent.get(params.id) ?? [],
+    });
   }),
 
   // PUT /api/zero/agents/:id/user-connectors
-  mockApi(zeroUserConnectorsContract.update, ({ body, respond }) => {
+  mockApi(zeroUserConnectorsContract.update, ({ body, params, respond }) => {
+    const enabledTypes = mockUserConnectorUpdateResponse(
+      mockEnabledConnectorTypesByAgent.get(params.id) ?? [],
+      body,
+    );
+    mockEnabledConnectorTypesByAgent.set(params.id, enabledTypes);
     return respond(200, {
-      enabledTypes: mockUserConnectorUpdateResponse(body),
+      enabledTypes,
     });
   }),
 

--- a/turbo/apps/platform/src/mocks/handlers/index.ts
+++ b/turbo/apps/platform/src/mocks/handlers/index.ts
@@ -63,6 +63,7 @@ import {
   apiAgentsHandlers,
   resetMockComposesList,
   resetMockTeam,
+  resetMockUserConnectors,
 } from "./api-agents.ts";
 import { apiWorkflowsHandlers, resetMockWorkflows } from "./api-workflows.ts";
 import { apiMemoryHandlers, resetMockMemory } from "./api-memory.ts";
@@ -172,6 +173,7 @@ export function resetAllMockHandlers(): void {
   resetMockAutomations();
   resetMockAutomationTriggers();
   resetMockTeam();
+  resetMockUserConnectors();
   resetMockWorkflows();
   resetMockMemory();
   resetMockMemoryActivity();


### PR DESCRIPTION
## Summary
- make the platform agent connector mock preserve per-agent connector state across add/remove/replace updates
- reset mocked user connector state between tests
- add platform mock and API regression coverage for sequential agent connector adds preserving existing grants

## Verification
- pnpm format
- pnpm -F @vm0/app lint
- pnpm -F api lint
- pnpm -F @vm0/app check-types
- pnpm -F api check-types
- pnpm -F @vm0/app exec vitest run src/mocks/handlers/__tests__/api-agents.test.ts src/views/zero-page/__tests__/zero-connectors-page.test.tsx src/views/team-page/__tests__/team-navigation.test.tsx src/views/zero-page/__tests__/chat-message-action-cards.test.tsx src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
- pnpm -F api exec vitest run src/signals/routes/__tests__/user-config.bdd.test.ts
- pre-commit: prettier, knip, turbo run check-types --concurrency=1
