### PR TITLE
test: bound concurrent mock codex resume waits

### DIFF
--- a/crates/guest-mock-codex/tests/integration.rs
+++ b/crates/guest-mock-codex/tests/integration.rs
@@ -1910,16 +1910,46 @@ fn concurrent_resume_writes_preserve_all_turns() -> std::io::Result<()> {
         ));
     }
 
+    let mut io_failures = Vec::new();
+    let mut status_failures = Vec::new();
+    let mut error_kind = None;
     for (prompt, handle) in handles {
-        let out = handle
-            .join()
-            .map_err(|_| std::io::Error::other(format!("resume thread panicked: {prompt}")))??;
-        assert_eq!(
-            out.status, 0,
-            "resume child failed for {prompt}: status={}; stderr={:?}",
-            out.status, out.stderr
-        );
+        match handle.join() {
+            Ok(Ok(out)) if out.status == 0 => {}
+            Ok(Ok(out)) => {
+                status_failures.push(format!(
+                    "{prompt}: status={}; stderr={:?}",
+                    out.status, out.stderr
+                ));
+            }
+            Ok(Err(err)) => {
+                error_kind.get_or_insert(err.kind());
+                io_failures.push(format!("{prompt}: {err}"));
+            }
+            Err(_) => {
+                error_kind.get_or_insert(std::io::ErrorKind::Other);
+                io_failures.push(format!("{prompt}: resume thread panicked"));
+            }
+        }
     }
+    if !io_failures.is_empty() {
+        let mut message = format!("resume child errors: {}", io_failures.join("; "));
+        if !status_failures.is_empty() {
+            message.push_str(&format!(
+                "; resume child non-zero statuses: {}",
+                status_failures.join("; ")
+            ));
+        }
+        return Err(std::io::Error::new(
+            error_kind.unwrap_or(std::io::ErrorKind::Other),
+            message,
+        ));
+    }
+    assert!(
+        status_failures.is_empty(),
+        "resume child non-zero statuses: {}",
+        status_failures.join("; ")
+    );
 
     let session_path = require_session_file(dir.path())?;
     let events = read_session_file(&session_path)?;

--- a/crates/guest-mock-codex/tests/integration.rs
+++ b/crates/guest-mock-codex/tests/integration.rs
@@ -162,14 +162,6 @@ fn cli_run_timeout_error_after_kill(args: &[&str]) -> std::io::Error {
     )
 }
 
-fn spawn(codex_home: &Path, args: &[&str]) -> std::io::Result<Child> {
-    let mut cmd = Command::new(BIN);
-    cmd.env("CODEX_HOME", codex_home).args(args);
-    cmd.env_remove("MOCK_CODEX_FIXTURE");
-    cmd.stdout(Stdio::null()).stderr(Stdio::null());
-    cmd.spawn()
-}
-
 struct AppServerProcess {
     child: Option<Child>,
     stdin: Option<ChildStdin>,
@@ -1906,17 +1898,27 @@ fn concurrent_resume_writes_preserve_all_turns() -> std::io::Result<()> {
     assert_eq!(first.status, 0);
     let thread_id = first.events[0]["thread_id"].as_str().unwrap();
 
-    let mut children = Vec::new();
+    let mut handles = Vec::new();
     for prompt in ["turn-1", "turn-2", "turn-3", "turn-4", "turn-5"] {
-        children.push(spawn(
-            dir.path(),
-            &["exec", "resume", thread_id, "--", prompt],
-        )?);
+        let codex_home = dir.path().to_path_buf();
+        let thread_id = thread_id.to_string();
+        handles.push((
+            prompt,
+            std::thread::spawn(move || {
+                run(&codex_home, &["exec", "resume", &thread_id, "--", prompt])
+            }),
+        ));
     }
 
-    for mut child in children {
-        let status = child.wait()?;
-        assert!(status.success(), "resume child failed with {status}");
+    for (prompt, handle) in handles {
+        let out = handle
+            .join()
+            .map_err(|_| std::io::Error::other(format!("resume thread panicked: {prompt}")))??;
+        assert_eq!(
+            out.status, 0,
+            "resume child failed for {prompt}: status={}; stderr={:?}",
+            out.status, out.stderr
+        );
     }
 
     let session_path = require_session_file(dir.path())?;

--- a/crates/guest-mock-codex/tests/integration.rs
+++ b/crates/guest-mock-codex/tests/integration.rs
@@ -1923,7 +1923,11 @@ fn concurrent_resume_writes_preserve_all_turns() -> std::io::Result<()> {
                 ));
             }
             Ok(Err(err)) => {
-                error_kind.get_or_insert(err.kind());
+                if err.kind() == std::io::ErrorKind::TimedOut {
+                    error_kind = Some(std::io::ErrorKind::TimedOut);
+                } else {
+                    error_kind.get_or_insert(err.kind());
+                }
                 io_failures.push(format!("{prompt}: {err}"));
             }
             Err(_) => {


### PR DESCRIPTION
## Summary

- route concurrent `guest-mock-codex exec resume` runs through the existing bounded `run()` helper
- preserve concurrent child-process coverage by starting each resume run from a Rust thread before joining
- remove the unused raw `spawn()` helper and keep the existing session assertions

## Tests

- `cargo fmt --manifest-path crates/guest-mock-codex/Cargo.toml -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p guest-mock-codex concurrent_resume_writes_preserve_all_turns`
- `cargo test --manifest-path crates/Cargo.toml -p guest-mock-codex`
- `git diff --check`

Closes #19735