### PR TITLE
refactor(mitm-addon): separate body decode policies

### DIFF
--- a/crates/runner/mitm-addon/src/body_decoding.py
+++ b/crates/runner/mitm-addon/src/body_decoding.py
@@ -371,29 +371,6 @@ def _decode_body_bounded(
     return _BodyDecodeResult(data, False)
 
 
-def decode_request_body_for_network_log_capture(
-    data: bytes,
-    headers: http.Headers,
-    *,
-    max_output: int = DEFAULT_BODY_DECODE_LIMIT,
-) -> bytes | None:
-    """Decode a request body for persistent network-log capture.
-
-    Request capture hides unsupported encodings and supported-codec decode
-    failures instead of keeping best-effort fallback bytes. This helper is
-    intentionally separate from billing inspection, which has a stricter
-    fail-closed policy.
-    """
-    encoding = headers.get("content-encoding", "").strip().lower()
-    if encoding and encoding != "identity" and encoding not in _SUPPORTED_ONE_SHOT_BODY_ENCODINGS:
-        return None
-
-    result = _decode_body_bounded(data, headers, max_output=max_output)
-    if result.failed:
-        return None
-    return result.body
-
-
 def _decompress_brotli_bounded_with_status(
     data: bytes, max_output: int
 ) -> tuple[bytes, bool, bool]:
@@ -506,18 +483,9 @@ def _decompress_zstd_json_usage_body(data: bytes, max_output: int) -> tuple[byte
     return body, _validate_complete_zstd_frames(data)
 
 
-def decompress_json_usage_body(
-    data: bytes, headers: http.Headers, max_output: int = LARGE_RESPONSE_DECOMPRESS_LIMIT
+def _decode_supported_body_with_complete_status(
+    data: bytes, encoding: str, max_output: int
 ) -> tuple[bytes, str | None]:
-    """Decompress a JSON usage response body with an observable empty-prefix error.
-
-    ``decompress_body`` intentionally treats truncated compressed prefixes as an
-    empty body because body capture can still mark those responses truncated
-    from stream metadata. JSON usage fallback only has the final buffer, so it
-    needs to distinguish a valid compressed empty response from an incomplete
-    compressed frame that produced no JSON bytes.
-    """
-    encoding = headers.get("content-encoding", "").strip().lower()
     if encoding in ("gzip", "deflate"):
         return _decompress_zlib_json_usage_body(data, encoding, max_output)
     if encoding == "br":
@@ -535,6 +503,48 @@ def decompress_json_usage_body(
         return body, None
     if encoding == "zstd":
         return _decompress_zstd_json_usage_body(data, max_output)
+    raise ValueError(f"unsupported content encoding: {encoding}")
+
+
+def decode_request_body_for_network_log_capture(
+    data: bytes,
+    headers: http.Headers,
+    *,
+    max_output: int = DEFAULT_BODY_DECODE_LIMIT,
+) -> bytes | None:
+    """Decode a request body for persistent network-log capture.
+
+    Request capture hides unsupported encodings and supported-codec decode
+    failures instead of keeping best-effort fallback bytes. This helper is
+    intentionally separate from billing inspection, which has a stricter
+    fail-closed policy.
+    """
+    encoding = headers.get("content-encoding", "").strip().lower()
+    if not encoding or encoding == "identity":
+        return data
+    if encoding not in _SUPPORTED_ONE_SHOT_BODY_ENCODINGS:
+        return None
+
+    body, error = _decode_supported_body_with_complete_status(data, encoding, max_output)
+    if error is not None and error != DECODED_BODY_LIMIT_EXCEEDED:
+        return None
+    return body
+
+
+def decompress_json_usage_body(
+    data: bytes, headers: http.Headers, max_output: int = LARGE_RESPONSE_DECOMPRESS_LIMIT
+) -> tuple[bytes, str | None]:
+    """Decompress a JSON usage response body with an observable empty-prefix error.
+
+    ``decompress_body`` intentionally treats truncated compressed prefixes as an
+    empty body because body capture can still mark those responses truncated
+    from stream metadata. JSON usage fallback only has the final buffer, so it
+    needs to distinguish a valid compressed empty response from an incomplete
+    compressed frame that produced no JSON bytes.
+    """
+    encoding = headers.get("content-encoding", "").strip().lower()
+    if encoding in _SUPPORTED_ONE_SHOT_BODY_ENCODINGS:
+        return _decode_supported_body_with_complete_status(data, encoding, max_output)
     if encoding and encoding != "identity" and data:
         return b"", "unsupported content encoding"
     return decompress_body(data, headers, max_output=max_output), None

--- a/crates/runner/mitm-addon/src/body_decoding.py
+++ b/crates/runner/mitm-addon/src/body_decoding.py
@@ -4,8 +4,7 @@ Exports:
 
 - Bounded streaming usage decoding for gzip, deflate, zstd; one-shot
   decompression for gzip, deflate, br, zstd.
-- Request network-log capture decoding that suppresses unsupported or failed
-  encoded request bodies.
+- Request network-log capture decoding that hides opaque encoded bodies.
 - JSON usage decompression with diagnostic error classification.
 """
 
@@ -380,9 +379,10 @@ def decode_request_body_for_network_log_capture(
 ) -> bytes | None:
     """Decode a request body for persistent network-log capture.
 
-    Request capture hides unsupported or invalid encoded bodies instead of
-    keeping best-effort fallback bytes. This helper is intentionally separate
-    from billing inspection, which has a stricter fail-closed policy.
+    Request capture hides unsupported encodings and supported-codec decode
+    failures instead of keeping best-effort fallback bytes. This helper is
+    intentionally separate from billing inspection, which has a stricter
+    fail-closed policy.
     """
     encoding = headers.get("content-encoding", "").strip().lower()
     if encoding and encoding != "identity" and encoding not in _SUPPORTED_ONE_SHOT_BODY_ENCODINGS:

--- a/crates/runner/mitm-addon/src/body_decoding.py
+++ b/crates/runner/mitm-addon/src/body_decoding.py
@@ -36,20 +36,16 @@ _ZSTD_STREAM_DECODE_INPUT_CHUNK_SIZE = 4
 INVALID_COMPRESSED_BODY = "invalid compressed body"
 INCOMPLETE_COMPRESSED_BODY = "incomplete compressed body"
 DECODED_BODY_LIMIT_EXCEEDED = "decoded body limit exceeded"
+_SUPPORTED_ONE_SHOT_BODY_ENCODINGS = frozenset({"gzip", "deflate", "br", "zstd"})
 
 
 class _BodyDecodeResult(NamedTuple):
-    """Internal bounded decode result before a caller policy is applied.
+    """Internal low-level bounded decode result.
 
-    ``body`` is the bytes produced by the primitive. Depending on codec state
-    and caller policy, it may be fully decoded output, partial decoded output,
-    the original wire bytes, or ``b""`` from a valid empty compressed frame.
-
-    ``failed`` means the primitive could not safely satisfy the requested
-    policy. It is not a universal "body is unusable" verdict: best-effort
-    response capture may still keep ``body``, while request capture suppresses
-    body text on failure. ``error`` is populated only when a codec raised while
-    decoding; unsupported encodings can fail without an exception.
+    ``body`` may be original wire bytes, decoded bytes, partial decoded bytes,
+    or ``b""`` depending on codec state and output limits. ``failed`` is only a
+    primitive decode signal, not a general "body unusable" policy verdict.
+    ``error`` is populated when a supported codec raises while decoding.
     """
 
     body: bytes
@@ -345,24 +341,17 @@ def _decode_body_bounded(
     headers: http.Headers,
     *,
     max_output: int,
-    fail_on_unsupported_encoding: bool = False,
 ) -> _BodyDecodeResult:
-    """Decode a body with bounded output before applying public caller policy.
+    """Decode supported content encodings with a bounded best-effort contract.
 
-    Missing or ``identity`` encodings return the input unchanged. Supported
-    encodings decode up to ``max_output`` bytes; hitting that cap returns the
-    decoded prefix and does not set ``failed``. Valid compressed empty frames
-    return ``b""``.
-
-    For gzip and deflate, an invalid first member returns the original bytes
-    with ``failed=True``. Once at least one member completes, invalid trailing
-    garbage is ignored and the decoded prefix is returned with ``failed=False``.
-    Truncated gzip/deflate input may return partial decoded output without
-    failure if zlib emitted bytes before the stream ended.
-
-    Unsupported encodings pass through by default for best-effort callers. Set
-    ``fail_on_unsupported_encoding`` only for policies that must suppress
-    opaque encoded bodies, such as request network-log capture.
+    Missing and ``identity`` encodings return original bytes. Unsupported
+    encodings also pass through original bytes because unsupported encoding is a
+    caller policy decision, not a codec failure. Supported invalid compressed
+    bodies return ``failed=True`` with original bytes when no compressed member
+    completed. Gzip/deflate trailing garbage after a completed member keeps the
+    decoded prefix. Truncated gzip/deflate may return partial decoded output.
+    Valid empty compressed frames return ``b""``. ``max_output`` caps decoded
+    output and may return a truncated decoded prefix without marking failure.
     """
     encoding = headers.get("content-encoding", "").strip().lower()
     if not encoding or encoding == "identity":
@@ -380,8 +369,6 @@ def _decode_body_bounded(
                 return _BodyDecodeResult(reader.read(max_output), False)
     except (zlib.error, brotli.error, zstandard.ZstdError) as exc:
         return _BodyDecodeResult(data, True, exc)
-    if fail_on_unsupported_encoding:
-        return _BodyDecodeResult(b"", True)
     return _BodyDecodeResult(data, False)
 
 
@@ -391,25 +378,17 @@ def decode_request_body_for_network_log_capture(
     *,
     max_output: int = DEFAULT_BODY_DECODE_LIMIT,
 ) -> bytes | None:
-    """Decode a request body for network-log capture.
+    """Decode a request body for persistent network-log capture.
 
-    Request capture hides unsupported encodings and bodies that the bounded
-    primitive reports as decode failures instead of preserving opaque request
-    bytes in logs. Gzip/deflate input that yields partial decoded output still
-    follows the primitive's best-effort success semantics. Returns ``None`` when
-    callers should omit request body text and mark the body as binary. Returns
-    decoded bytes on success, including ``b""`` for a valid empty compressed
-    body.
-
-    This is distinct from ``billing_body.decode_request_body_for_billing``,
-    which has stricter billing-inspection policy.
+    Request capture hides unsupported or invalid encoded bodies instead of
+    keeping best-effort fallback bytes. This helper is intentionally separate
+    from billing inspection, which has a stricter fail-closed policy.
     """
-    result = _decode_body_bounded(
-        data,
-        headers,
-        max_output=max_output,
-        fail_on_unsupported_encoding=True,
-    )
+    encoding = headers.get("content-encoding", "").strip().lower()
+    if encoding and encoding != "identity" and encoding not in _SUPPORTED_ONE_SHOT_BODY_ENCODINGS:
+        return None
+
+    result = _decode_body_bounded(data, headers, max_output=max_output)
     if result.failed:
         return None
     return result.body

--- a/crates/runner/mitm-addon/tests/test_body_capture_fields.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture_fields.py
@@ -277,6 +277,23 @@ class TestAddCaptureFields:
         assert "request_body" not in entry
         assert entry["request_body_encoding"] == "binary"
 
+    def test_request_body_incomplete_gzip_is_hidden_as_binary(self, real_flow):
+        body = b"hello request body" * 100
+        compressed = gzip.compress(body)
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="text/plain",
+            request_encoding="gzip",
+            request_body=compressed[:-1],
+            response_content_type="application/json",
+            response_body=b'{"ok": true}',
+        )
+        entry = {}
+        add_capture_fields(flow, entry)
+        assert "request_body" not in entry
+        assert entry["request_body_encoding"] == "binary"
+
     def test_request_body_unknown_content_encoding_is_hidden_as_binary(self, real_flow):
         flow = real_flow(
             method="POST",

--- a/crates/runner/mitm-addon/tests/test_body_decoding.py
+++ b/crates/runner/mitm-addon/tests/test_body_decoding.py
@@ -17,6 +17,18 @@ from body_limits import DEFAULT_BODY_DECODE_LIMIT, STREAM_DECODE_CHUNK_LIMIT
 from tests.body_decode_helpers import pseudo_random_ascii, track_brotli_decompressor
 
 
+def _compress_one_shot_body(encoding: str, body: bytes) -> bytes:
+    if encoding == "gzip":
+        return gzip.compress(body)
+    if encoding == "deflate":
+        return zlib.compress(body)
+    if encoding == "br":
+        return brotli.compress(body)
+    if encoding == "zstd":
+        return zstandard.ZstdCompressor().compress(body)
+    raise AssertionError(f"unsupported test encoding: {encoding}")
+
+
 class TestStreamDecodeFeed:
     """Direct tests for the bounded push-style streaming decoder."""
 
@@ -279,6 +291,58 @@ class TestStreamDecodeFeed:
         assert len(proxies) == 1
         assert proxies[0].count == 1
         assert chunks == []
+
+
+class TestDecodeRequestBodyForNetworkLogCapture:
+    def test_unsupported_encoding_returns_none(self, headers):
+        assert (
+            decode_request_body_for_network_log_capture(
+                b"opaque",
+                headers(("Content-Encoding", "x-custom")),
+            )
+            is None
+        )
+
+    @pytest.mark.parametrize("encoding", ["gzip", "deflate", "br", "zstd"])
+    def test_invalid_compressed_body_returns_none(self, headers, encoding):
+        assert (
+            decode_request_body_for_network_log_capture(
+                b"not a compressed body",
+                headers(("Content-Encoding", encoding)),
+            )
+            is None
+        )
+
+    def test_identity_and_missing_encoding_return_original_bytes(self, headers):
+        data = b'{"hello":"world"}'
+
+        assert (
+            decode_request_body_for_network_log_capture(
+                data,
+                headers(("Content-Encoding", "identity")),
+            )
+            == data
+        )
+        assert decode_request_body_for_network_log_capture(data, headers()) == data
+
+    @pytest.mark.parametrize("encoding", ["gzip", "deflate", "br", "zstd"])
+    def test_valid_empty_compressed_body_returns_empty_bytes(self, headers, encoding):
+        body = decode_request_body_for_network_log_capture(
+            _compress_one_shot_body(encoding, b""),
+            headers(("Content-Encoding", encoding)),
+        )
+
+        assert body is not None
+        assert body == b""
+
+    @pytest.mark.parametrize("encoding", ["gzip", "deflate", "br", "zstd"])
+    def test_valid_compressed_body_returns_decoded_bytes(self, headers, encoding):
+        body = decode_request_body_for_network_log_capture(
+            _compress_one_shot_body(encoding, b"hello request"),
+            headers(("Content-Encoding", encoding)),
+        )
+
+        assert body == b"hello request"
 
 
 class TestDecompressBody:

--- a/crates/runner/mitm-addon/tests/test_body_decoding.py
+++ b/crates/runner/mitm-addon/tests/test_body_decoding.py
@@ -293,82 +293,6 @@ class TestStreamDecodeFeed:
         assert chunks == []
 
 
-class TestDecodeRequestBodyForNetworkLogCapture:
-    def test_unsupported_encoding_returns_none(self, headers):
-        assert (
-            decode_request_body_for_network_log_capture(
-                b"opaque",
-                headers(("Content-Encoding", "x-custom")),
-            )
-            is None
-        )
-
-    @pytest.mark.parametrize("encoding", ["gzip", "deflate", "br", "zstd"])
-    def test_invalid_compressed_body_returns_none(self, headers, encoding):
-        assert (
-            decode_request_body_for_network_log_capture(
-                b"not a compressed body",
-                headers(("Content-Encoding", encoding)),
-            )
-            is None
-        )
-
-    @pytest.mark.parametrize("encoding", ["gzip", "deflate", "br", "zstd"])
-    def test_incomplete_compressed_body_returns_none_before_decode_limit(self, headers, encoding):
-        compressed = _compress_one_shot_body(encoding, b"hello request body" * 100)
-
-        assert (
-            decode_request_body_for_network_log_capture(
-                compressed[:-1],
-                headers(("Content-Encoding", encoding)),
-            )
-            is None
-        )
-
-    @pytest.mark.parametrize("encoding", ["gzip", "deflate", "br", "zstd"])
-    def test_decode_limit_exceeded_returns_truncated_prefix(self, headers, encoding):
-        body = b"x" * 1024
-
-        decoded = decode_request_body_for_network_log_capture(
-            _compress_one_shot_body(encoding, body),
-            headers(("Content-Encoding", encoding)),
-            max_output=128,
-        )
-
-        assert decoded == body[:128]
-
-    def test_identity_and_missing_encoding_return_original_bytes(self, headers):
-        data = b'{"hello":"world"}'
-
-        assert (
-            decode_request_body_for_network_log_capture(
-                data,
-                headers(("Content-Encoding", "identity")),
-            )
-            == data
-        )
-        assert decode_request_body_for_network_log_capture(data, headers()) == data
-
-    @pytest.mark.parametrize("encoding", ["gzip", "deflate", "br", "zstd"])
-    def test_valid_empty_compressed_body_returns_empty_bytes(self, headers, encoding):
-        body = decode_request_body_for_network_log_capture(
-            _compress_one_shot_body(encoding, b""),
-            headers(("Content-Encoding", encoding)),
-        )
-
-        assert body is not None
-        assert body == b""
-
-    @pytest.mark.parametrize("encoding", ["gzip", "deflate", "br", "zstd"])
-    def test_valid_compressed_body_returns_decoded_bytes(self, headers, encoding):
-        body = decode_request_body_for_network_log_capture(
-            _compress_one_shot_body(encoding, b"hello request"),
-            headers(("Content-Encoding", encoding)),
-        )
-
-        assert body == b"hello request"
-
-
 class TestDecompressBody:
     """Direct tests for ``decompress_body`` — the non-streaming one-shot
     path used by ``extract_anthropic_messages_usage_from_json`` and ``log_connector_usage``
@@ -549,23 +473,16 @@ class TestDecodeRequestBodyForNetworkLogCapture:
         hdrs = headers(("Content-Encoding", "identity"))
         assert decode_request_body_for_network_log_capture(data, hdrs) == data
 
-    @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
-    def test_zlib_valid_body_returns_decoded_bytes(self, headers, encoding):
+    @pytest.mark.parametrize("encoding", ["gzip", "deflate", "br", "zstd"])
+    def test_valid_body_returns_decoded_bytes(self, headers, encoding):
         data = b'{"hello":"world"}'
-        compressed = gzip.compress(data) if encoding == "gzip" else zlib.compress(data)
+        compressed = _compress_one_shot_body(encoding, data)
         hdrs = headers(("Content-Encoding", encoding))
         assert decode_request_body_for_network_log_capture(compressed, hdrs) == data
 
-    @pytest.mark.parametrize(
-        ("encoding", "compressed"),
-        [
-            ("gzip", gzip.compress(b"")),
-            ("deflate", zlib.compress(b"")),
-            ("br", brotli.compress(b"")),
-            ("zstd", zstandard.ZstdCompressor().compress(b"")),
-        ],
-    )
-    def test_valid_empty_compressed_body_returns_empty_bytes(self, headers, encoding, compressed):
+    @pytest.mark.parametrize("encoding", ["gzip", "deflate", "br", "zstd"])
+    def test_valid_empty_compressed_body_returns_empty_bytes(self, headers, encoding):
+        compressed = _compress_one_shot_body(encoding, b"")
         hdrs = headers(("Content-Encoding", encoding))
         assert decode_request_body_for_network_log_capture(compressed, hdrs) == b""
 
@@ -573,18 +490,28 @@ class TestDecodeRequestBodyForNetworkLogCapture:
         hdrs = headers(("Content-Encoding", "x-custom"))
         assert decode_request_body_for_network_log_capture(b"opaque", hdrs) is None
 
-    def test_invalid_compressed_body_returns_none(self, headers):
-        hdrs = headers(("Content-Encoding", "gzip"))
+    @pytest.mark.parametrize("encoding", ["gzip", "deflate", "br", "zstd"])
+    def test_invalid_compressed_body_returns_none(self, headers, encoding):
+        hdrs = headers(("Content-Encoding", encoding))
         assert decode_request_body_for_network_log_capture(b"not gzip", hdrs) is None
 
-    def test_truncated_gzip_partial_decode_returns_decoded_bytes(self, headers):
-        data = b"x" * 100_000
-        compressed = gzip.compress(data)
-        truncated = compressed[: len(compressed) // 2]
-        hdrs = headers(("Content-Encoding", "gzip"))
+    @pytest.mark.parametrize("encoding", ["gzip", "deflate", "br", "zstd"])
+    def test_incomplete_compressed_body_returns_none_before_decode_limit(self, headers, encoding):
+        compressed = _compress_one_shot_body(encoding, b"hello request body" * 100)
+        hdrs = headers(("Content-Encoding", encoding))
 
-        result = decode_request_body_for_network_log_capture(truncated, hdrs)
+        assert decode_request_body_for_network_log_capture(compressed[:-1], hdrs) is None
 
-        assert result is not None
-        assert len(result) > 1024
-        assert set(result) == {ord("x")}
+    @pytest.mark.parametrize("encoding", ["gzip", "deflate", "br", "zstd"])
+    def test_decode_limit_exceeded_returns_truncated_prefix(self, headers, encoding):
+        body = b"x" * 1024
+        compressed = _compress_one_shot_body(encoding, body)
+        hdrs = headers(("Content-Encoding", encoding))
+
+        decoded = decode_request_body_for_network_log_capture(
+            compressed,
+            hdrs,
+            max_output=128,
+        )
+
+        assert decoded == body[:128]

--- a/crates/runner/mitm-addon/tests/test_body_decoding.py
+++ b/crates/runner/mitm-addon/tests/test_body_decoding.py
@@ -313,6 +313,30 @@ class TestDecodeRequestBodyForNetworkLogCapture:
             is None
         )
 
+    @pytest.mark.parametrize("encoding", ["gzip", "deflate", "br", "zstd"])
+    def test_incomplete_compressed_body_returns_none_before_decode_limit(self, headers, encoding):
+        compressed = _compress_one_shot_body(encoding, b"hello request body" * 100)
+
+        assert (
+            decode_request_body_for_network_log_capture(
+                compressed[:-1],
+                headers(("Content-Encoding", encoding)),
+            )
+            is None
+        )
+
+    @pytest.mark.parametrize("encoding", ["gzip", "deflate", "br", "zstd"])
+    def test_decode_limit_exceeded_returns_truncated_prefix(self, headers, encoding):
+        body = b"x" * 1024
+
+        decoded = decode_request_body_for_network_log_capture(
+            _compress_one_shot_body(encoding, body),
+            headers(("Content-Encoding", encoding)),
+            max_output=128,
+        )
+
+        assert decoded == body[:128]
+
     def test_identity_and_missing_encoding_return_original_bytes(self, headers):
         data = b'{"hello":"world"}'
 


### PR DESCRIPTION
## Summary

- Make the bounded one-shot body decoder an internal primitive with a private result type.
- Remove the `fail_on_unsupported_encoding` policy boolean from the primitive.
- Add `decode_request_body_for_network_log_capture()` so request capture owns unsupported/decode-failed body suppression.
- Share a complete-status decode helper between request capture and JSON usage so incomplete supported compressed request bodies are hidden before the capture limit, while oversized valid bodies still return a truncated prefix.
- Update request capture to branch on `bytes | None` and reconcile the request decode tests from `main` with the new incomplete-body policy.
- Cover the body-capture entry point for incomplete gzip requests so partial decoded text cannot be logged as complete request body text.

Refs #19731

## Testing

- `./.venv/bin/ruff check src/body_decoding.py src/body_capture.py tests/test_body_decoding.py tests/test_body_capture_fields.py`
- `./.venv/bin/basedpyright src/body_decoding.py src/body_capture.py tests/test_body_decoding.py tests/test_body_capture_fields.py`
- `./.venv/bin/pytest tests/test_body_decoding.py tests/test_body_capture_fields.py tests/test_body_capture_stream_buffer.py` (`123 passed`)
- `./.venv/bin/ruff check .`
- `./.venv/bin/basedpyright`
- `./.venv/bin/pytest tests/` (`3406 passed`)
