### PR TITLE
fix: accept 200 draft autosave responses

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/remote-chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/remote-chat-thread-data-source.ts
@@ -71,7 +71,7 @@ const patchDraft$ = command(
         body: { draftContent: content, draftAttachments: attachments },
         fetchOptions: { signal },
       }),
-      [204],
+      [200, 204],
     );
     signal.throwIfAborted();
     set(reloadSidebarDraftThreads$);

--- a/turbo/apps/platform/src/signals/zero-page/agent-draft.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-draft.ts
@@ -58,7 +58,7 @@ function createAgentDraftSync(agentId: string, draft: DraftSignals) {
           },
           fetchOptions: { signal },
         }),
-        [204],
+        [200, 204],
       );
     },
   );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
@@ -1,7 +1,8 @@
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { toast } from "@vm0/ui/components/ui/sonner";
 import { HttpResponse } from "msw";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   chatThreadByIdContract,
   chatThreadsContract,
@@ -192,6 +193,7 @@ describe("chat drafts", () => {
   it("persists typed agent drafts through the agent draft endpoint", async () => {
     const agentId = "c0000000-0000-4000-a000-000000000102";
     const draftPatches: Record<string, unknown>[] = [];
+    const toastError = vi.spyOn(toast, "error");
     mockAgentChatPage(agentId);
     context.mocks.api(zeroAgentDraftContract.get, ({ respond }) => {
       return respond(200, {
@@ -199,27 +201,37 @@ describe("chat drafts", () => {
         draftAttachments: null,
       });
     });
-    context.mocks.api(zeroAgentDraftContract.patch, ({ body, respond }) => {
-      draftPatches.push(body as Record<string, unknown>);
-      return respond(204);
-    });
+    context.mocks.http.patch(
+      "*/api/zero/agents/:id/draft",
+      async ({ request }) => {
+        draftPatches.push((await request.json()) as Record<string, unknown>);
+        return new Response(null, { status: 200 });
+      },
+    );
 
-    detachedSetupPage({
-      context,
-      path: `/agents/${agentId}/chat`,
-    });
-
-    await waitFor(() => {
-      expect(textarea()).toBeInTheDocument();
-    });
-    await fill(textarea(), "agent-level draft");
-
-    await waitFor(() => {
-      expect(draftPatches).toContainEqual({
-        draftContent: "agent-level draft",
-        draftAttachments: null,
+    try {
+      detachedSetupPage({
+        context,
+        path: `/agents/${agentId}/chat`,
       });
-    });
+
+      await waitFor(() => {
+        expect(textarea()).toBeInTheDocument();
+      });
+      await fill(textarea(), "agent-level draft");
+
+      await waitFor(() => {
+        expect(draftPatches).toContainEqual({
+          draftContent: "agent-level draft",
+          draftAttachments: null,
+        });
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(toastError).not.toHaveBeenCalledWith("HTTP 200");
+    } finally {
+      toastError.mockRestore();
+    }
   });
 
   it("preserves per-thread text drafts while navigating", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { toast } from "@vm0/ui/components/ui/sonner";
 import { describe, expect, it, vi } from "vitest";
 import {
   chatThreadByIdContract,
@@ -6376,31 +6377,53 @@ describe("chat lifecycle", () => {
   it("transcribes voice input into the composer", async () => {
     const user = userEvent.setup({ delay: null });
     const threadId = "voice-input-thread";
+    const draftPatches: unknown[] = [];
+    const toastError = vi.spyOn(toast, "error");
     context.mocks.browser.voiceInput({ rms: 0.1 });
     mockChatLifecycle(context, { threadId });
+    context.mocks.http.patch(
+      "*/api/zero/chat-threads/:id",
+      async ({ request }) => {
+        draftPatches.push(await request.json());
+        return new Response(null, { status: 200 });
+      },
+    );
     context.mocks.http.post("*/api/zero/voice-io/stt", () => {
       return new Response(JSON.stringify({ text: "Summarize the standup" }), {
         headers: { "Content-Type": "application/json" },
       });
     });
 
-    detachedSetupPage({ context, path: `/chats/${threadId}` });
+    try {
+      detachedSetupPage({ context, path: `/chats/${threadId}` });
 
-    const textarea = await waitFor(() => {
-      return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
-    });
+      const textarea = await waitFor(() => {
+        return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
+      });
 
-    await user.click(await screen.findByLabelText("Voice input"));
+      await user.click(await screen.findByLabelText("Voice input"));
 
-    await waitFor(() => {
-      expect(screen.getByLabelText("Stop recording")).toBeInTheDocument();
-    });
+      await waitFor(() => {
+        expect(screen.getByLabelText("Stop recording")).toBeInTheDocument();
+      });
 
-    await user.click(screen.getByLabelText("Stop recording"));
+      await user.click(screen.getByLabelText("Stop recording"));
 
-    await waitFor(() => {
-      expect(textarea).toHaveValue("Summarize the standup");
-    });
+      await waitFor(() => {
+        expect(textarea).toHaveValue("Summarize the standup");
+      });
+      await waitFor(() => {
+        expect(draftPatches).toContainEqual({
+          draftContent: "Summarize the standup",
+          draftAttachments: null,
+        });
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(toastError).not.toHaveBeenCalledWith("HTTP 200");
+    } finally {
+      toastError.mockRestore();
+    }
   });
 
   it("shows voice input starting state while the browser opens the microphone", async () => {


### PR DESCRIPTION
Summary:
- Treat 200 as a successful draft autosave response for chat-thread and agent-level drafts.
- Cover voice input and agent draft autosave flows when the draft PATCH returns 200.

Tests:
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx src/views/zero-page/__tests__/chat-draft.test.tsx -t "transcribes voice input|persists typed agent drafts"
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types