### PR TITLE
fix(guest-agent): compress non-utf8 session history uploads

### DIFF
--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -96,16 +96,6 @@ fn build_session_history_upload(
         });
     }
 
-    // TODO: Remove the non-UTF-8 identity fallback after compressed session
-    // history refs are guaranteed everywhere. It only exists so old inline
-    // resume paths do not need to stringify binary history.
-    if std::str::from_utf8(&history_bytes).is_err() {
-        return Ok(SessionHistoryUpload {
-            raw_size,
-            body: SessionHistoryUploadBody::Identity(history_bytes),
-        });
-    }
-
     let gzip_bytes = gzip_session_history(&history_bytes)?;
     if gzip_bytes.len() >= history_bytes.len() {
         return Ok(SessionHistoryUpload {

--- a/crates/guest-agent/tests/integration/checkpoint.rs
+++ b/crates/guest-agent/tests/integration/checkpoint.rs
@@ -305,7 +305,7 @@ async fn success_checkpoint_uploads_gzip_session_history_when_acknowledged() {
 }
 
 #[tokio::test]
-async fn success_checkpoint_keeps_large_non_utf8_session_history_identity_encoded() {
+async fn success_checkpoint_uploads_large_non_utf8_session_history_as_gzip_when_acknowledged() {
     let api = SharedApiMock::new().await;
     let server = api.server();
 
@@ -323,22 +323,33 @@ async fn success_checkpoint_keeps_large_non_utf8_session_history_identity_encode
             .json_body_includes(r#"{"runId":"test-run-001"}"#)
             .json_body_includes(format!(r#"{{"hash":"{history_hash}"}}"#))
             .json_body_includes(format!(r#"{{"rawSize":{history_size}}}"#))
-            .json_body_includes(format!(r#"{{"encodedSize":{history_size}}}"#))
-            .json_body_includes(r#"{"encoding":"identity"}"#);
+            .json_body_includes(r#"{"encoding":"gzip"}"#);
         then.status(200)
             .header("Content-Type", "application/json")
             .json_body(json!({
                 "presignedUrl": server.url("/test/large-non-utf8-history-upload"),
-                "existing": false
+                "existing": false,
+                "encoding": "gzip"
             }));
     });
-    let upload_len = history_size.to_string();
     let upload_body = history.clone();
     let upload_mock = server.mock(|when, then| {
         when.method(PUT)
             .path("/test/large-non-utf8-history-upload")
             .header("Content-Type", "application/octet-stream");
-        then.respond_with(move |req| upload_validation_response(req, &upload_body, &upload_len));
+        then.respond_with(move |req| {
+            if request_header_absent(req, "authorization")
+                && request_header_absent(req, "x-vercel-protection-bypass")
+                && req.body_ref() != upload_body.as_slice()
+            {
+                let mut decoded = Vec::new();
+                let decode_result = GzDecoder::new(req.body_ref()).read_to_end(&mut decoded);
+                if decode_result.is_ok() && decoded == upload_body {
+                    return http_status(200);
+                }
+            }
+            http_status(400)
+        });
     });
     let checkpoint_mock = server.mock(|when, then| {
         when.method(POST)


### PR DESCRIPTION
## Summary
- remove the rollout-only non-UTF-8 identity fallback from guest session history upload selection
- update the large non-UTF-8 checkpoint test to assert gzip upload when the API acknowledges gzip
- keep small-history identity behavior and existing persisted blob compatibility untouched

Closes #19718

## Tests
- cargo fmt --all --check
- cargo test -p guest-agent --test integration success_checkpoint_uploads_large_non_utf8_session_history_as_gzip_when_acknowledged --quiet
- cargo test -p guest-agent --test integration checkpoint --quiet
- git diff --check

## Production check
- verified prod-3 runs runner 0.131.14
- verified prod-4 runs runner 0.131.13 and 0.131.14
- verified resumeSessionHistoryCompressedRef landed in runner-rs-v0.131.13 and v0.131.14