### PR TITLE
fix: refresh agent connector authorization reads

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/artifact-google-drive-sync.ts
+++ b/turbo/apps/platform/src/signals/chat-page/artifact-google-drive-sync.ts
@@ -192,8 +192,8 @@ export const waitForGoogleDriveAndSyncArtifacts$ = command(
           createClient,
           signal: sig,
         });
-        sig.throwIfAborted();
         set(reloadAgentConnectorAuthorizations$);
+        sig.throwIfAborted();
 
         await syncArtifactFilesToGoogleDrive({
           createClient,

--- a/turbo/apps/platform/src/signals/chat-page/artifact-google-drive-sync.ts
+++ b/turbo/apps/platform/src/signals/chat-page/artifact-google-drive-sync.ts
@@ -187,12 +187,16 @@ export const waitForGoogleDriveAndSyncArtifacts$ = command(
         }
 
         const createClient = get(zeroClient$);
-        await authorizeGoogleDriveForAgent({
-          agentId: params.agentId,
-          createClient,
-          signal: sig,
-        });
-        set(reloadAgentConnectorAuthorizations$);
+        await withCleanup(
+          authorizeGoogleDriveForAgent({
+            agentId: params.agentId,
+            createClient,
+            signal: sig,
+          }),
+          () => {
+            set(reloadAgentConnectorAuthorizations$);
+          },
+        );
         sig.throwIfAborted();
 
         await syncArtifactFilesToGoogleDrive({

--- a/turbo/apps/platform/src/signals/chat-page/artifact-google-drive-sync.ts
+++ b/turbo/apps/platform/src/signals/chat-page/artifact-google-drive-sync.ts
@@ -6,6 +6,7 @@ import { accept } from "../../lib/accept.ts";
 import { zeroClient$, type ZeroClientFactory } from "../api-client.ts";
 import { connectors$, reloadConnectors$ } from "../external/connectors.ts";
 import { setAblyLoop$ } from "../realtime.ts";
+import { reloadAgentConnectorAuthorizations$ } from "../zero-page/agent-connector-authorizations.ts";
 import { settle, withCleanup } from "../utils.ts";
 
 type ArtifactGoogleDriveSyncParams = {
@@ -192,6 +193,7 @@ export const waitForGoogleDriveAndSyncArtifacts$ = command(
           signal: sig,
         });
         sig.throwIfAborted();
+        set(reloadAgentConnectorAuthorizations$);
 
         await syncArtifactFilesToGoogleDrive({
           createClient,

--- a/turbo/apps/platform/src/signals/chat-page/connector-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/connector-action-block.ts
@@ -4,9 +4,6 @@ import {
   type ConnectorType,
 } from "@vm0/connectors/connectors";
 import { customConnectorProposalSchema } from "@vm0/api-contracts/contracts/zero-custom-connectors";
-import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
-import { accept } from "../../lib/accept.ts";
-import { zeroClient$ } from "../api-client.ts";
 import { connectors$ } from "../external/connectors.ts";
 import {
   allConnectorTypes$,
@@ -14,7 +11,7 @@ import {
   setSelectedConnectorType$,
 } from "../zero-page/settings/connectors.ts";
 import { authorizeConnector$ as authorizeDirectedConnector$ } from "../connectors-page/directed-authorize-type.ts";
-import { agentConnectorAuthorizationsReload$ } from "../zero-page/agent-connector-authorizations.ts";
+import { isAgentConnectorAuthorized } from "../zero-page/agent-connector-authorizations.ts";
 import { jsonParseBase64UrlOr } from "../utils.ts";
 
 export interface ConnectorActionDescriptor {
@@ -192,14 +189,12 @@ export function createConnectorActionBlock(
     if (get(authorizedOverride$)) {
       return true;
     }
-    get(agentConnectorAuthorizationsReload$);
-    const createClient = get(zeroClient$);
-    const client = createClient(zeroUserConnectorsContract);
-    const result = await accept(
-      client.get({ params: { id: descriptor.agentId } }),
-      [200],
+    return await get(
+      isAgentConnectorAuthorized({
+        agentId: descriptor.agentId,
+        connectorType: descriptor.connectorType,
+      }),
     );
-    return result.body.enabledTypes.includes(descriptor.connectorType);
   });
 
   const complete$ = computed(async (get): Promise<boolean> => {

--- a/turbo/apps/platform/src/signals/chat-page/github-pr-tracking.ts
+++ b/turbo/apps/platform/src/signals/chat-page/github-pr-tracking.ts
@@ -4,7 +4,6 @@ import {
   chatThreadGithubPrsContract,
   type ChatThreadGithubPr,
 } from "@vm0/api-contracts/contracts/chat-threads";
-import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
@@ -12,7 +11,7 @@ import {
   allConnectorTypes$,
   connectorCurrentConnectionStatus,
 } from "../zero-page/settings/connectors.ts";
-import { agentConnectorAuthorizationsReload$ } from "../zero-page/agent-connector-authorizations.ts";
+import { isAgentConnectorAuthorized } from "../zero-page/agent-connector-authorizations.ts";
 import { detach, Reason, resetSignal } from "../utils.ts";
 
 const GITHUB_PR_TRACKING_POLL_INTERVAL_MS = 15_000;
@@ -86,13 +85,9 @@ function createAgentGithubPrTrackingAvailableFactory(): (
         return false;
       }
 
-      get(agentConnectorAuthorizationsReload$);
-      const client = get(zeroClient$)(zeroUserConnectorsContract);
-      const result = await accept(
-        client.get({ params: { id: agentId } }),
-        [200],
+      return await get(
+        isAgentConnectorAuthorized({ agentId, connectorType: "github" }),
       );
-      return result.body.enabledTypes.includes("github");
     });
 
     cache.set(agentId, atom$);

--- a/turbo/apps/platform/src/signals/connectors-page/directed-authorize-type.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/directed-authorize-type.ts
@@ -5,7 +5,10 @@ import { accept } from "../../lib/accept.ts";
 import { pathParams$, searchParams$ } from "../route.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { agents$ } from "../agent.ts";
-import { reloadAgentConnectorAuthorizations$ } from "../zero-page/agent-connector-authorizations.ts";
+import {
+  agentConnectorAuthorizations,
+  reloadAgentConnectorAuthorizations$,
+} from "../zero-page/agent-connector-authorizations.ts";
 
 /**
  * Connector type extracted from `/connectors/:type/authorize` route params.
@@ -42,10 +45,8 @@ export const agentEnabledTypes$ = computed(async (get) => {
   if (!agentId) {
     return { agentId: null, enabledTypes: [] };
   }
-  const createClient = get(zeroClient$);
-  const client = createClient(zeroUserConnectorsContract);
-  const result = await accept(client.get({ params: { id: agentId } }), [200]);
-  return { agentId, enabledTypes: result.body.enabledTypes };
+  const authorizations = await get(agentConnectorAuthorizations({ agentId }));
+  return { agentId, enabledTypes: [...authorizations.enabledTypes] };
 });
 
 export type DirectedAuthorizeConnectModalKey = {

--- a/turbo/apps/platform/src/signals/connectors-page/directed-authorize-type.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/directed-authorize-type.ts
@@ -5,6 +5,7 @@ import { accept } from "../../lib/accept.ts";
 import { pathParams$, searchParams$ } from "../route.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { agents$ } from "../agent.ts";
+import { withCleanup } from "../utils.ts";
 import {
   agentConnectorAuthorizations,
   reloadAgentConnectorAuthorizations$,
@@ -91,13 +92,18 @@ export const authorizeConnector$ = command(
     const createClient = get(zeroClient$);
     const client = createClient(zeroUserConnectorsContract);
 
-    await accept(
-      client.update({
-        params: { id: agentId },
-        body: { enabledTypes: [connectorType], operation: "add" },
-        fetchOptions: { signal },
-      }),
-      [200],
+    await withCleanup(
+      accept(
+        client.update({
+          params: { id: agentId },
+          body: { enabledTypes: [connectorType], operation: "add" },
+          fetchOptions: { signal },
+        }),
+        [200],
+      ),
+      () => {
+        set(reloadAgentConnectorAuthorizations$);
+      },
     );
     signal.throwIfAborted();
 
@@ -108,7 +114,6 @@ export const authorizeConnector$ = command(
         connectorAgentAuthorizationKey({ connectorType, agentId }),
       ]);
     });
-    set(reloadAgentConnectorAuthorizations$);
   },
 );
 

--- a/turbo/apps/platform/src/signals/zero-page/agent-connector-authorizations.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-connector-authorizations.ts
@@ -1,4 +1,13 @@
-import { command, computed, state } from "ccstate";
+import { command, computed, state, type Computed } from "ccstate";
+import type { ConnectorType } from "@vm0/connectors/connectors";
+import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
+import { accept } from "../../lib/accept.ts";
+import { zeroClient$ } from "../api-client.ts";
+
+export interface AgentConnectorAuthorizations {
+  readonly agentId: string;
+  readonly enabledTypes: readonly string[];
+}
 
 const internalAgentConnectorAuthorizationsReload$ = state(0);
 
@@ -11,3 +20,126 @@ export const reloadAgentConnectorAuthorizations$ = command(({ set }) => {
     return x + 1;
   });
 });
+
+interface AgentConnectorAuthorizationsFactory {
+  (params: {
+    readonly agentId: string;
+    readonly missing: "null";
+  }): Computed<Promise<AgentConnectorAuthorizations | null>>;
+  (params: {
+    readonly agentId: string;
+    readonly missing?: "throw";
+  }): Computed<Promise<AgentConnectorAuthorizations>>;
+}
+
+function createAuthorizationsAtom(
+  agentId: string,
+  options: { readonly missing: "throw" },
+): Computed<Promise<AgentConnectorAuthorizations>>;
+function createAuthorizationsAtom(
+  agentId: string,
+  options: { readonly missing: "null" },
+): Computed<Promise<AgentConnectorAuthorizations | null>>;
+function createAuthorizationsAtom(
+  agentId: string,
+  options: { readonly missing: "throw" | "null" },
+): Computed<Promise<AgentConnectorAuthorizations | null>> {
+  return computed(async (get): Promise<AgentConnectorAuthorizations | null> => {
+    get(agentConnectorAuthorizationsReload$);
+    const client = get(zeroClient$)(zeroUserConnectorsContract);
+    const request = client.get({ params: { id: agentId } });
+    const result =
+      options.missing === "null"
+        ? await accept(request, [200, 404], {
+            toast: false,
+          })
+        : await accept(request, [200]);
+    if (result.status === 404) {
+      return null;
+    }
+    return { agentId, enabledTypes: result.body.enabledTypes };
+  });
+}
+
+function createAgentConnectorAuthorizationsFactory(): AgentConnectorAuthorizationsFactory {
+  const authorizationsCache = new Map<
+    string,
+    Computed<Promise<AgentConnectorAuthorizations>>
+  >();
+  const nullableAuthorizationsCache = new Map<
+    string,
+    Computed<Promise<AgentConnectorAuthorizations | null>>
+  >();
+
+  const createAuthorizations = (
+    agentId: string,
+  ): Computed<Promise<AgentConnectorAuthorizations>> => {
+    const existing = authorizationsCache.get(agentId);
+    if (existing) {
+      return existing;
+    }
+    const atom$ = createAuthorizationsAtom(agentId, { missing: "throw" });
+    authorizationsCache.set(agentId, atom$);
+    return atom$;
+  };
+
+  const createNullableAuthorizations = (
+    agentId: string,
+  ): Computed<Promise<AgentConnectorAuthorizations | null>> => {
+    const existing = nullableAuthorizationsCache.get(agentId);
+    if (existing) {
+      return existing;
+    }
+    const atom$ = createAuthorizationsAtom(agentId, { missing: "null" });
+    nullableAuthorizationsCache.set(agentId, atom$);
+    return atom$;
+  };
+
+  function authorizations(params: {
+    readonly agentId: string;
+    readonly missing: "null";
+  }): Computed<Promise<AgentConnectorAuthorizations | null>>;
+  function authorizations(params: {
+    readonly agentId: string;
+    readonly missing?: "throw";
+  }): Computed<Promise<AgentConnectorAuthorizations>>;
+  function authorizations(params: {
+    readonly agentId: string;
+    readonly missing?: "throw" | "null";
+  }): Computed<Promise<AgentConnectorAuthorizations | null>> {
+    if (params.missing === "null") {
+      return createNullableAuthorizations(params.agentId);
+    }
+    return createAuthorizations(params.agentId);
+  }
+
+  return authorizations;
+}
+
+function createAgentConnectorAuthorizedFactory(): (params: {
+  readonly agentId: string;
+  readonly connectorType: ConnectorType;
+}) => Computed<Promise<boolean>> {
+  const cache = new Map<string, Computed<Promise<boolean>>>();
+  return (params) => {
+    const key = `${params.agentId}:${params.connectorType}`;
+    const existing = cache.get(key);
+    if (existing) {
+      return existing;
+    }
+    const atom$ = computed(async (get): Promise<boolean> => {
+      const authorizations = await get(
+        agentConnectorAuthorizations({ agentId: params.agentId }),
+      );
+      return authorizations.enabledTypes.includes(params.connectorType);
+    });
+    cache.set(key, atom$);
+    return atom$;
+  };
+}
+
+export const agentConnectorAuthorizations =
+  createAgentConnectorAuthorizationsFactory();
+
+export const isAgentConnectorAuthorized =
+  createAgentConnectorAuthorizedFactory();

--- a/turbo/apps/platform/src/signals/zero-page/job-detail/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/job-detail/connectors.ts
@@ -3,6 +3,10 @@ import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-co
 import { zeroClient$ } from "../../api-client.ts";
 import { withCleanup } from "../../utils.ts";
 import { accept } from "../../../lib/accept.ts";
+import {
+  agentConnectorAuthorizations,
+  reloadAgentConnectorAuthorizations$,
+} from "../agent-connector-authorizations.ts";
 import { agentDetail$ } from "./detail.ts";
 
 // ---------------------------------------------------------------------------
@@ -12,26 +16,15 @@ import { agentDetail$ } from "./detail.ts";
 //    for this agent
 // ---------------------------------------------------------------------------
 
-const authorizedConnectorsReload$ = state(0);
-
-const reloadAgentConnectors$ = command(({ set }) => {
-  set(authorizedConnectorsReload$, (prev) => {
-    return prev + 1;
-  });
-});
-
 const authorizedConnectors$ = computed(async (get): Promise<string[]> => {
-  get(authorizedConnectorsReload$);
   const detail = await get(agentDetail$);
   if (!detail?.agentId) {
     return [];
   }
-  const client = get(zeroClient$)(zeroUserConnectorsContract);
-  const result = await accept(
-    client.get({ params: { id: detail.agentId } }),
-    [200],
+  const authorizations = await get(
+    agentConnectorAuthorizations({ agentId: detail.agentId }),
   );
-  return result.body.enabledTypes;
+  return [...authorizations.enabledTypes];
 });
 
 type AuthorizedConnectorsDraft = {
@@ -140,7 +133,7 @@ export const saveAgentConnectors$ = command(
       })(),
       () => {
         set(clearAgentConnectorDraft$, detail.agentId);
-        set(reloadAgentConnectors$);
+        set(reloadAgentConnectorAuthorizations$);
       },
     );
   },

--- a/turbo/apps/platform/src/signals/zero-page/settings/connector-access-management.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connector-access-management.ts
@@ -11,7 +11,7 @@ import {
   agentConnectorAuthorizations,
   reloadAgentConnectorAuthorizations$,
 } from "../agent-connector-authorizations.ts";
-import { settle } from "../../utils.ts";
+import { settle, withCleanup } from "../../utils.ts";
 
 export interface ConnectorAgentAccessRow {
   readonly agent: TeamComposeItem;
@@ -211,19 +211,22 @@ export const setConnectorAgentAuthorization$ = command(
     signal: AbortSignal,
   ): Promise<void> => {
     const client = get(zeroClient$)(zeroUserConnectorsContract);
-    await accept(
-      client.update({
-        params: { id: params.agentId },
-        body: {
-          enabledTypes: [params.connectorType],
-          operation: params.authorized ? "add" : "remove",
-        },
-        fetchOptions: { signal },
-      }),
-      [200],
+    await withCleanup(
+      accept(
+        client.update({
+          params: { id: params.agentId },
+          body: {
+            enabledTypes: [params.connectorType],
+            operation: params.authorized ? "add" : "remove",
+          },
+          fetchOptions: { signal },
+        }),
+        [200],
+      ),
+      () => {
+        set(reloadAgentConnectorAuthorizations$);
+      },
     );
     signal.throwIfAborted();
-
-    set(reloadAgentConnectorAuthorizations$);
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/settings/connector-access-management.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connector-access-management.ts
@@ -7,7 +7,10 @@ import { zeroClient$ } from "../../api-client.ts";
 import { agents$ } from "../../agent.ts";
 import { ApiError, accept } from "../../../lib/accept.ts";
 import { userPermissionGrantsByAgent } from "../../permission-allow/permission-allow-signals.ts";
-import { reloadAgentConnectorAuthorizations$ } from "../agent-connector-authorizations.ts";
+import {
+  agentConnectorAuthorizations,
+  reloadAgentConnectorAuthorizations$,
+} from "../agent-connector-authorizations.ts";
 import { settle } from "../../utils.ts";
 
 export interface ConnectorAgentAccessRow {
@@ -31,7 +34,6 @@ interface SetConnectorAgentAuthorizationParams {
   readonly authorized: boolean;
 }
 
-const internalConnectorAccessManagementReload$ = state(0);
 const managedConnectorAccessTypeState$ = state<ConnectorType | null>(null);
 const connectorAccessManagementSearchState$ = state("");
 const connectorAccessManagementSavingAgentIdState$ = state<string | null>(null);
@@ -53,12 +55,6 @@ export const connectorAccessManagementSavingAgentId$ = computed((get) => {
 
 export const connectorAccessManagementPermissionAgentId$ = computed((get) => {
   return get(connectorAccessManagementPermissionAgentIdState$);
-});
-
-const reloadConnectorAccessManagement$ = command(({ set }) => {
-  set(internalConnectorAccessManagementReload$, (value) => {
-    return value + 1;
-  });
 });
 
 export const setManagedConnectorAccessType$ = command(
@@ -94,23 +90,22 @@ export const setConnectorAccessManagementPermissionAgentId$ = command(
 
 export const connectorAgentAuthorizations$ = computed(
   async (get): Promise<readonly ConnectorAgentAuthorizationRow[]> => {
-    get(internalConnectorAccessManagementReload$);
     const allAgents = await get(agents$);
-    const client = get(zeroClient$)(zeroUserConnectorsContract);
     const rows = await Promise.all(
       allAgents.map(
         async (agent): Promise<ConnectorAgentAuthorizationRow | null> => {
-          const result = await accept(
-            client.get({ params: { id: agent.id } }),
-            [200, 404],
-            { toast: false },
+          const authorizations = await get(
+            agentConnectorAuthorizations({
+              agentId: agent.id,
+              missing: "null",
+            }),
           );
-          if (result.status === 404) {
+          if (!authorizations) {
             return null;
           }
           return {
             agent,
-            enabledTypes: result.body.enabledTypes,
+            enabledTypes: authorizations.enabledTypes,
           };
         },
       ),
@@ -229,7 +224,6 @@ export const setConnectorAgentAuthorization$ = command(
     );
     signal.throwIfAborted();
 
-    set(reloadConnectorAccessManagement$);
     set(reloadAgentConnectorAuthorizations$);
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/settings/permission-dialog.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/permission-dialog.ts
@@ -5,6 +5,7 @@ import { zeroClient$ } from "../../api-client.ts";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { accept } from "../../../lib/accept.ts";
 import { reloadAgentConnectorAuthorizations$ } from "../agent-connector-authorizations.ts";
+import { withCleanup } from "../../utils.ts";
 
 // ---------------------------------------------------------------------------
 // Agent selection
@@ -58,36 +59,40 @@ export const confirmPermissionDialog$ = command(
     }
     const createClient = get(zeroClient$);
     const client = createClient(zeroUserConnectorsContract);
-    const results = await Promise.allSettled(
-      [...selected].map(async (agentId) => {
-        signal.throwIfAborted();
-        const result = await accept(
-          client.update({
-            params: { id: agentId },
-            body: { enabledTypes: [connectorType], operation: "add" },
-            fetchOptions: { signal },
-          }),
-          [200, 404],
-        );
-        return result.status === 200;
-      }),
+    const results = await withCleanup(
+      Promise.allSettled(
+        [...selected].map(async (agentId) => {
+          signal.throwIfAborted();
+          const result = await accept(
+            client.update({
+              params: { id: agentId },
+              body: { enabledTypes: [connectorType], operation: "add" },
+              fetchOptions: { signal },
+            }),
+            [200, 404],
+          );
+          return result.status === 200;
+        }),
+      ),
+      () => {
+        set(reloadAgentConnectorAuthorizations$);
+      },
     );
     signal.throwIfAborted();
+    const enabledCount = results.filter((result) => {
+      return result.status === "fulfilled" && result.value;
+    }).length;
     const failed = results.find((result): result is PromiseRejectedResult => {
       return result.status === "rejected";
     });
     if (failed) {
       throw failed.reason;
     }
-    const enabledCount = results.filter((result) => {
-      return result.status === "fulfilled" && result.value;
-    }).length;
     if (enabledCount > 0) {
       toast.success(
         `${connectorLabel} enabled for ${enabledCount} agent${enabledCount > 1 ? "s" : ""}`,
       );
     }
-    set(reloadAgentConnectorAuthorizations$);
     onClose();
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/zero-connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-connectors.ts
@@ -3,6 +3,7 @@ import { reloadOnboardingStatus$ } from "./zero-onboarding.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { currentChatAgentRecordId$ } from "../agent-chat.ts";
 import { accept } from "../../lib/accept.ts";
+import { withCleanup } from "../utils.ts";
 import {
   agentConnectorAuthorizations,
   reloadAgentConnectorAuthorizations$,
@@ -59,18 +60,22 @@ const updateAuthorizedConnectors$ = command(
     }
 
     const client = get(zeroClient$)(zeroUserConnectorsContract);
-    await accept(
-      client.update({
-        params: { id: agentId },
-        body: { enabledTypes: [connectorValue], operation },
-        fetchOptions: { signal },
-      }),
-      [200],
+    await withCleanup(
+      accept(
+        client.update({
+          params: { id: agentId },
+          body: { enabledTypes: [connectorValue], operation },
+          fetchOptions: { signal },
+        }),
+        [200],
+      ),
+      () => {
+        set(reloadAgentConnectorAuthorizations$);
+      },
     );
     signal.throwIfAborted();
 
     await set(reloadOnboardingStatus$);
     signal.throwIfAborted();
-    set(reloadAgentConnectorAuthorizations$);
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/zero-connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-connectors.ts
@@ -1,13 +1,13 @@
 import { command, computed } from "ccstate";
-import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import { reloadOnboardingStatus$ } from "./zero-onboarding.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { currentChatAgentRecordId$ } from "../agent-chat.ts";
 import { accept } from "../../lib/accept.ts";
 import {
-  agentConnectorAuthorizationsReload$,
+  agentConnectorAuthorizations,
   reloadAgentConnectorAuthorizations$,
 } from "./agent-connector-authorizations.ts";
+import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 
 // ---------------------------------------------------------------------------
 // Authorized connectors: User↔Agent↔Connector (per-agent grant)
@@ -18,14 +18,12 @@ import {
 
 /** Connectors the current user has authorized for the current agent. */
 const authorizedConnectors$ = computed(async (get) => {
-  get(agentConnectorAuthorizationsReload$);
   const agentId = await get(currentChatAgentRecordId$);
   if (!agentId) {
     return [];
   }
-  const client = get(zeroClient$)(zeroUserConnectorsContract);
-  const result = await accept(client.get({ params: { id: agentId } }), [200]);
-  return result.body.enabledTypes;
+  const authorizations = await get(agentConnectorAuthorizations({ agentId }));
+  return [...authorizations.enabledTypes];
 });
 
 export const zeroAuthorizedConnectors$ = computed(async (get) => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -38,6 +38,7 @@ import { setFeatureSwitch$ } from "../../../signals/external/feature-switch.ts";
 import { detachedNavigateTo$ } from "../../../signals/route.ts";
 import { ROUTES } from "../../../signals/route-paths.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { reloadAgentConnectorAuthorizations$ } from "../../../signals/zero-page/agent-connector-authorizations.ts";
 
 const context = testContext();
 
@@ -675,6 +676,36 @@ describe("connectors page", () => {
     });
     expect(search()).toContain("connection=agent");
     expect(search()).toContain(agentId);
+  });
+
+  it("refreshes agent-filtered connectors when authorizations reload", async () => {
+    const agentId = "c0000000-0000-4000-a000-000000000010";
+    let enabledTypes = ["github"];
+    mockConnectors([{ type: "github", externalUsername: "octocat" }]);
+    context.mocks.data.team([teamAgent(agentId, "Research Agent", "preset:0")]);
+    context.mocks.api(zeroUserConnectorsContract.get, ({ params, respond }) => {
+      return respond(200, {
+        enabledTypes: params.id === agentId ? enabledTypes : [],
+      });
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/connectors?connection=agent:${agentId}`,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("GitHub")).toBeInTheDocument();
+      expect(screen.queryByText("Asana")).not.toBeInTheDocument();
+    });
+
+    enabledTypes = ["github", "asana"];
+    await context.store.set(reloadAgentConnectorAuthorizations$);
+
+    await waitFor(() => {
+      expect(screen.getByText("GitHub")).toBeInTheDocument();
+      expect(screen.getByText("Asana")).toBeInTheDocument();
+    });
   });
 
   it("hydrates connector search from URL keywords", async () => {


### PR DESCRIPTION
## Summary
- centralize agent connector authorization reads behind shared signals
- refresh all agent connector UI paths from the same reload source after writes
- add regression coverage for agent-filtered connector pages refreshing after authorization reload

## Tests
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-connectors-page.test.tsx
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx src/views/team-page/__tests__/team-navigation.test.tsx src/views/zero-page/__tests__/chat-message-action-cards.test.tsx src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx src/views/zero-page/__tests__/chat-lifecycle.test.tsx
- git diff --check